### PR TITLE
Update src/torrentcontentmodelitem.cpp

### DIFF
--- a/src/torrentcontentmodelitem.cpp
+++ b/src/torrentcontentmodelitem.cpp
@@ -43,7 +43,6 @@ TorrentContentModelItem::TorrentContentModelItem(const libtorrent::file_entry &f
 #if LIBTORRENT_VERSION_MINOR >= 16
   QString name = fsutils::fileName(misc::toQStringU(f.path.c_str()));
 #else
-  Q_UNUSED(t);
   QString name = misc::toQStringU(f.path.filename());
 #endif
   // Do not display incomplete extensions


### PR DESCRIPTION
removed macro for not existing variable t

was mist in edcfa4df12f8d9cdc705f312daa8477e5e85c9a8 (TorrentContentModel code clean up)
