### PR TITLE
Add option to start qbt with Windows startup.

### DIFF
--- a/src/preferences/options.ui
+++ b/src/preferences/options.ui
@@ -351,6 +351,13 @@
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12">
                <item>
+                <widget class="QCheckBox" name="checkStartup">
+                 <property name="text">
+                  <string>Start qBittorrent on Windows start up</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <widget class="QCheckBox" name="checkShowSplash">
                  <property name="text">
                   <string>Show splash screen on start up</string>

--- a/src/preferences/options_imp.cpp
+++ b/src/preferences/options_imp.cpp
@@ -122,6 +122,7 @@ options_imp::options_imp(QWidget *parent):
 #endif
 
 #ifndef Q_WS_WIN
+  checkStartup->setVisible(false);
   groupFileAssociation->setVisible(false);
 #endif
 #if LIBTORRENT_VERSION_MINOR < 16
@@ -141,6 +142,9 @@ options_imp::options_imp(QWidget *parent):
   connect(checkCloseToSystray, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
   connect(checkMinimizeToSysTray, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
   connect(checkStartMinimized, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+#ifdef Q_WS_WIN
+  connect(checkStartup, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+#endif
   connect(checkShowSplash, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
   connect(checkProgramExitConfirm, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
   connect(checkPreventFromSuspend, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
@@ -372,6 +376,7 @@ void options_imp::saveOptions() {
   pref.setConfirmOnExit(checkProgramExitConfirm->isChecked());
   pref.setPreventFromSuspend(preventFromSuspend());
 #ifdef Q_WS_WIN
+  pref.setStartup(Startup());
   // Windows: file association settings
   Preferences::setTorrentFileAssoc(checkAssociateTorrents->isChecked());
   Preferences::setMagnetLinkAssoc(checkAssociateMagnetLinks->isChecked());
@@ -546,6 +551,7 @@ void options_imp::loadOptions() {
   checkProgramExitConfirm->setChecked(pref.confirmOnExit());
   checkPreventFromSuspend->setChecked(pref.preventFromSuspend());
 #ifdef Q_WS_WIN
+  checkStartup->setChecked(pref.Startup());
   // Windows: file association settings
   checkAssociateTorrents->setChecked(Preferences::isTorrentFileAssocSet());
   checkAssociateMagnetLinks->setChecked(Preferences::isMagnetLinkAssocSet());
@@ -973,6 +979,12 @@ void options_imp::enableProxy(int index) {
 bool options_imp::isSlashScreenDisabled() const {
   return !checkShowSplash->isChecked();
 }
+
+#ifdef Q_WS_WIN
+bool options_imp::Startup() const {
+  return checkStartup->isChecked();
+}
+#endif
 
 bool options_imp::preventFromSuspend() const {
   return checkPreventFromSuspend->isChecked();

--- a/src/preferences/options_imp.h
+++ b/src/preferences/options_imp.h
@@ -101,6 +101,9 @@ private:
   bool startMinimized() const;
   bool isSlashScreenDisabled() const;
   bool preventFromSuspend() const;
+#ifdef Q_WS_WIN
+  bool Startup() const;
+#endif
   // Downloads
   QString getSavePath() const;
   bool isTempPathEnabled() const;

--- a/src/preferences/preferences.h
+++ b/src/preferences/preferences.h
@@ -181,6 +181,24 @@ public:
     setValue("Preferences/General/PreventFromSuspend", b);
   }
 
+#ifdef Q_WS_WIN
+  bool Startup() const {
+    QSettings settings("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Run", QSettings::NativeFormat);
+    return settings.contains("qBittorrent");
+  }
+
+  void setStartup(bool b) {
+    QSettings settings("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Run", QSettings::NativeFormat);
+    if (b) {
+        const QString bin_path = "\""+qApp->applicationFilePath().replace("/", "\\")+"\"";
+        settings.setValue("qBittorrent", bin_path);
+    }
+    else {
+        settings.remove("qBittorrent");
+    }
+  }
+#endif
+
   // Downloads
   QString getSavePath() const {
     QString save_path = value(QString::fromUtf8("Preferences/Downloads/SavePath")).toString();


### PR DESCRIPTION
I haven't tested if the checkbox is actually disabled under Linux/MacOSX.
