### PR TITLE
Small fix for for RSS regexp, should fix #210

### DIFF
--- a/src/rss/rssdownloadrule.cpp
+++ b/src/rss/rssdownloadrule.cpp
@@ -82,13 +82,13 @@ RssDownloadRulePtr RssDownloadRule::fromVariantHash(const QVariantHash &rule_has
 {
   RssDownloadRulePtr rule(new RssDownloadRule);
   rule->setName(rule_hash.value("name").toString());
+  rule->setUseRegex(rule_hash.value("use_regex", false).toBool());
   rule->setMustContain(rule_hash.value("must_contain").toString());
   rule->setMustNotContain(rule_hash.value("must_not_contain").toString());
   rule->setRssFeeds(rule_hash.value("affected_feeds").toStringList());
   rule->setEnabled(rule_hash.value("enabled", false).toBool());
   rule->setSavePath(rule_hash.value("save_path").toString());
   rule->setLabel(rule_hash.value("label_assigned").toString());
-  rule->setUseRegex(rule_hash.value("use_regex", false).toBool());
   return rule;
 }
 


### PR DESCRIPTION
Checking if we are using regexp was done in setMustContain and
setMustNotContain before m_useRegex  was even read, corrupting the
value.
Only m_mustNotContain is affected because of how
RssDownloadRule::setMustNotContain handles read string when m_useRegex
is false.

Ref: https://github.com/qbittorrent/qBittorrent/issues/210
