### PR TITLE
Default/native look for the search filter

### DIFF
--- a/src/lineedit/src/lineedit.cpp
+++ b/src/lineedit/src/lineedit.cpp
@@ -20,22 +20,19 @@ LineEdit::LineEdit(QWidget *parent)
   searchButton->setIcon(QIcon(pixmap1));
   searchButton->setIconSize(pixmap1.size());
   searchButton->setCursor(Qt::ArrowCursor);
-  searchButton->setStyleSheet("QToolButton { border: none; padding: 0px; }");
+  searchButton->setStyleSheet("QToolButton { border: none; padding: 2px; }");
   clearButton = new QToolButton(this);
   QPixmap pixmap2(":/lineeditimages/clear_left.png");
   clearButton->setIcon(QIcon(pixmap2));
   clearButton->setIconSize(pixmap2.size());
   clearButton->setCursor(Qt::ArrowCursor);
-  clearButton->setStyleSheet("QToolButton { border: none; padding: 0px; }");
+  clearButton->setStyleSheet("QToolButton { border: none; padding: 2px; }");
   clearButton->setToolTip(tr("Clear the text"));
   clearButton->hide();
   connect(clearButton, SIGNAL(clicked()), this, SLOT(clear()));
   connect(this, SIGNAL(textChanged(const QString&)), this, SLOT(updateCloseButton(const QString&)));
   int frameWidth = style()->pixelMetric(QStyle::PM_DefaultFrameWidth);
-  setStyleSheet(QString("QLineEdit { padding-right: %1px; padding-left: %2px; border-radius: 10px; }").arg(clearButton->sizeHint().width() + frameWidth + 1).arg(clearButton->sizeHint().width() + frameWidth + 1));
-#ifdef Q_WS_MAC
-  setAttribute(Qt::WA_MacShowFocusRect, 0);
-#endif
+  setStyleSheet(QString("QLineEdit { padding-right: %1px; padding-left: %2px; }").arg(clearButton->sizeHint().width() + frameWidth + 1).arg(clearButton->sizeHint().width() + frameWidth + 1));
   QSize msz = minimumSizeHint();
   setMinimumSize(qMax(msz.width(), clearButton->sizeHint().width() + searchButton->sizeHint().width() + frameWidth * 2 + 2),
                  qMax(msz.height(), clearButton->sizeHint().height() + frameWidth * 2 + 2));


### PR DESCRIPTION
A minor annoyance I've had with the search filter text box in the toolbar is that it looks rather ugly and out of place with its 0px rounded borders. IMHO, I think it should have a native look&feel like the rest of the GUI.
