### PR TITLE
Anonymous mode link is not opened in default browser.

### DIFF
--- a/src/preferences/options.ui
+++ b/src/preferences/options.ui
@@ -2042,6 +2042,9 @@
                    <property name="text">
                     <string> (&lt;a href=&quot;http://github.com/qbittorrent/qBittorrent/wiki/Anonymous-Mode&quot;&gt;More information&lt;/a&gt;)</string>
                    </property>
+                   <property name="openExternalLinks">
+                    <bool>true</bool>
+                   </property>
                   </widget>
                  </item>
                  <item>


### PR DESCRIPTION
Small fix, partially referenced by #26
