### PR TITLE
Create translations at compile time

### DIFF
--- a/qbittorrent.pro
+++ b/qbittorrent.pro
@@ -3,6 +3,7 @@ TEMPLATE = subdirs
 SUBDIRS += src
 
 include(version.pri)
+include(qm_gen.pri)
 
 # Dist
 dist.commands += rm -fR ../$${PROJECT_NAME}-$${PROJECT_VERSION}/ &&

--- a/qm_gen.pri
+++ b/qm_gen.pri
@@ -1,0 +1,36 @@
+TS_IN = $$fromfile(src/src.pro,TRANSLATIONS)
+TS_IN_NOEXT = $$replace(TS_IN,".ts","")
+             
+isEmpty(QMAKE_LUPDATE) {
+    win32|os2:QMAKE_LUPDATE = $$[QT_INSTALL_BINS]\\lupdate.exe
+    else:QMAKE_LUPDATE = $$[QT_INSTALL_BINS]/lupdate
+    unix {
+        !exists($$QMAKE_LUPDATE) { QMAKE_LUPDATE = lupdate-qt4 }
+    } else {
+        !exists($$QMAKE_LUPDATE) { QMAKE_LUPDATE = lupdate }
+    }
+}
+
+isEmpty(QMAKE_LRELEASE) {
+    win32|os2:QMAKE_LRELEASE = $$[QT_INSTALL_BINS]\\lrelease.exe
+    else:QMAKE_LRELEASE = $$[QT_INSTALL_BINS]/lrelease
+    unix {
+        !exists($$QMAKE_LRELEASE) { QMAKE_LRELEASE = lrelease-qt4 }
+    } else {
+        !exists($$QMAKE_LRELEASE) { QMAKE_LRELEASE = lrelease }
+    }
+}
+
+message("Updating translations")
+win32|os2 {
+    system("$$QMAKE_LUPDATE -silent -no-obsolete src/src.pro > NUL 2>&1")
+} else {
+    system("$$QMAKE_LUPDATE -silent -no-obsolete src/src.pro > /dev/null 2>&1")
+}
+
+message("Building translations")
+for(L,TS_IN_NOEXT) {
+    message("Processing $${L}")
+    system("$$QMAKE_LRELEASE -silent src/$${L}.ts -qm src/$${L}.qm")
+    !exists("src/$${L}.qm"):error("Building translations failed, cannot continue")
+}


### PR DESCRIPTION
This allows updating .qm translations during build time, before rcc is run.

<hr>

**Side note**
It is possible to remove .qm files completely from source tree. It will still build fine with this patch.
The only side-effect would be multiple `RCC: Error in '..\..\src\lang.qrc': Cannot find file 'lang/qbittorrent_{lang}.qm'` when qmake is run. Obviously qmake doesn't know that those files will be generated during build time, but still generates valid makefiles despite this message.
I've tested this on Windows and Xubuntu 12.04.
**Side note End**

<hr>
