### PR TITLE
Show human readable interface names

### DIFF
--- a/src/preferences/advancedsettings.h
+++ b/src/preferences/advancedsettings.h
@@ -89,16 +89,10 @@ public slots:
     if (combo_iface.currentIndex() == 0) {
       // All interfaces (default)
       pref.setNetworkInterface(QString::null);
-#if QT_VERSION >= QT_VERSION_CHECK(4,5,0)
       pref.setNetworkInterfaceName(QString::null);
-#endif
     } else {
-#if QT_VERSION < QT_VERSION_CHECK(4,5,0)
-      pref.setNetworkInterface(combo_iface.currentText());
-#else
       pref.setNetworkInterface(combo_iface.itemData(combo_iface.currentIndex()).toString());
       pref.setNetworkInterfaceName(combo_iface.currentText());
-#endif
     }
     // Network address
     QHostAddress addr(txt_network_address.text().trimmed());
@@ -221,11 +215,7 @@ private slots:
     int i = 1;
     foreach (const QNetworkInterface& iface, QNetworkInterface::allInterfaces()) {
       if (iface.flags() & QNetworkInterface::IsLoopBack) continue;
-#if QT_VERSION >= QT_VERSION_CHECK(4,5,0)
       combo_iface.addItem(iface.humanReadableName(),iface.name());
-#else
-      combo_iface.addItem(iface.name());
-#endif
       if (!current_iface.isEmpty() && iface.name() == current_iface) {
         combo_iface.setCurrentIndex(i);
         interface_exists = true;
@@ -234,11 +224,7 @@ private slots:
     }
     // Saved interface does not exist, show it anyway
     if (!interface_exists) {
-#if QT_VERSION >= QT_VERSION_CHECK(4,5,0)
       combo_iface.addItem(pref.getNetworkInterfaceName(),current_iface);
-#else
-      combo_iface.addItem(current_iface);
-#endif
       combo_iface.setCurrentIndex(i);
     }
     setRow(NETWORK_IFACE, tr("Network Interface (requires restart)"), &combo_iface);

--- a/src/preferences/preferences.h
+++ b/src/preferences/preferences.h
@@ -1043,7 +1043,6 @@ public:
     return value(QString::fromUtf8("Preferences/Connection/Interface"), QString()).toString();
   }
   
-#if QT_VERSION >= QT_VERSION_CHECK(4,5,0)
   void setNetworkInterfaceName(const QString& iface) {
     setValue(QString::fromUtf8("Preferences/Connection/InterfaceName"), iface);
   }
@@ -1051,7 +1050,6 @@ public:
   QString getNetworkInterfaceName() const {
     return value(QString::fromUtf8("Preferences/Connection/InterfaceName"), QString()).toString();
   }
-#endif
 
   void setNetworkAddress(const QString& addr) {
     setValue(QString::fromUtf8("Preferences/Connection/InetAddress"), addr);


### PR DESCRIPTION
Requested on forums (http://qbforums.shiki.hu/index.php?topic=1662.0)

Mostly intended for Windows users, shouldn't have any effect on Unix (http://doc.qt.digia.com/qt/qnetworkinterface.html#humanReadableName)

Looks like this:
![iface_names](https://f.cloud.github.com/assets/1910559/62855/2c2f3690-5d88-11e2-85da-d55b6bd58c10.png)

If anybody is wondering whats wrong with interface names on Windows, here's an example:
![iface_names_old](https://f.cloud.github.com/assets/1910559/62875/f81aac68-5d8c-11e2-9f57-ad03e439f30a.png)
