### PR TITLE
Fix to Issue #395: Preview feature absent when .!qB extensions added

### DIFF
--- a/src/fs_utils.cpp
+++ b/src/fs_utils.cpp
@@ -81,18 +81,8 @@ QString fsutils::toDisplayPath(const QString& path)
  */
 QString fsutils::fileExtension(const QString &filename)
 {
-  QString holder;
-  int point_index = filename.lastIndexOf(".");
-  if (point_index >= 0) {
-    holder = filename.mid(point_index + 1);
-    if (holder == "!qB") {
-      holder = filename.mid(0, point_index);
-      point_index = holder.lastIndexOf(".");
-      holder = (point_index >= 0) ? holder.mid(point_index + 1) : QString();
-    }
-    return holder;
-  }
-  return QString();
+  const int point_index = filename.lastIndexOf(".");
+  return (point_index >= 0) ? filename.mid(point_index + 1) : QString();
 }
 
 QString fsutils::fileName(const QString& file_path)

--- a/src/previewselect.cpp
+++ b/src/previewselect.cpp
@@ -59,6 +59,8 @@ PreviewSelect::PreviewSelect(QWidget* parent, QTorrentHandle h): QDialog(parent)
   unsigned int nbFiles = h.num_files();
   for (unsigned int i=0; i<nbFiles; ++i) {
     QString fileName = h.filename_at(i);
+    if (fileName.endsWith(".!qB"))
+      fileName.chop(4);
     QString extension = fsutils::fileExtension(fileName).toUpper();
     if (misc::isPreviewable(extension)) {
       int row = previewListModel->rowCount();

--- a/src/qtlibtorrent/qbtsession.cpp
+++ b/src/qtlibtorrent/qbtsession.cpp
@@ -1731,7 +1731,10 @@ bool QBtSession::isFilePreviewPossible(const QString &hash) const {
   }
   const unsigned int nbFiles = h.num_files();
   for (unsigned int i=0; i<nbFiles; ++i) {
-    const QString extension = fsutils::fileExtension(h.filename_at(i));
+    QString filename = h.filename_at(i);
+    if (filename.endsWith(".!qB"))
+      filename.chop(4);
+    const QString extension = fsutils::fileExtension(filename);
     if (misc::isPreviewable(extension))
       return true;
   }


### PR DESCRIPTION
Previous code failed to detect .!qB files for preview. The function related to extract the extension from a filename was fixed.
