### PR TITLE
Remove leading and trailing whitespace when choosing filenames. Fixes is...

### DIFF
--- a/src/addnewtorrentdialog.cpp
+++ b/src/addnewtorrentdialog.cpp
@@ -394,7 +394,7 @@ void AddNewTorrentDialog::renameSelectedFile()
   bool ok;
   const QString new_name_last = QInputDialog::getText(this, tr("Rename the file"),
                                                       tr("New name:"), QLineEdit::Normal,
-                                                      index.data().toString(), &ok);
+                                                      index.data().toString(), &ok).trimmed();
   if (ok && !new_name_last.isEmpty()) {
     if (!fsutils::isValidFileSystemName(new_name_last)) {
       QMessageBox::warning(this, tr("The file could not be renamed"),

--- a/src/properties/propertieswidget.cpp
+++ b/src/properties/propertieswidget.cpp
@@ -511,7 +511,7 @@ void PropertiesWidget::renameSelectedFile() {
   bool ok;
   QString new_name_last = QInputDialog::getText(this, tr("Rename the file"),
                                                 tr("New name:"), QLineEdit::Normal,
-                                                index.data().toString(), &ok);
+                                                index.data().toString(), &ok).trimmed();
   if (ok && !new_name_last.isEmpty()) {
     if (!fsutils::isValidFileSystemName(new_name_last)) {
       QMessageBox::warning(this, tr("The file could not be renamed"),

--- a/src/transferlistwidget.cpp
+++ b/src/transferlistwidget.cpp
@@ -593,7 +593,7 @@ void TransferListWidget::askNewLabelForSelection() {
   bool invalid;
   do {
     invalid = false;
-    const QString label = QInputDialog::getText(this, tr("New Label"), tr("Label:"), QLineEdit::Normal, "", &ok);
+    const QString label = QInputDialog::getText(this, tr("New Label"), tr("Label:"), QLineEdit::Normal, "", &ok).trimmed();
     if (ok && !label.isEmpty()) {
       if (fsutils::isValidFileSystemName(label)) {
         setSelectionLabel(label);


### PR DESCRIPTION
...sue #401.

In Windows this enabled users to create folders/files with leading/trailing space in the filename. These folders/files cannot be removed through the GUI nor qbt can delete them. Special cmd commands are needed for these files to be removed from the filesystem.

On a side-note: This check could happen inside fsutils::isValidFileSystemName() to universally prohibit such use in the future too. But it has one flaw. Normally the user won't understand why "_The file could not be renamed_" when the illegal character is leading/trailing whitespace. Furthermore, I think we can safely assume that whitespace should be removed automatically.
