### PR TITLE
Fix copy tracker build failure

### DIFF
--- a/src/properties/trackerlist.cpp
+++ b/src/properties/trackerlist.cpp
@@ -34,6 +34,7 @@
 #include <QHash>
 #include <QAction>
 #include <QColor>
+#include <QDebug>
 #include <libtorrent/version.hpp>
 #include <libtorrent/peer_info.hpp>
 #include "trackerlist.h"


### PR DESCRIPTION
#206 doesn't build for me otherwise. Should have checked beforehand; my version had no qDebug.

```
..\..\src\properties\trackerlist.cpp(306) : error C2027: use of undefined type 'QNoDebug'
        T:\_outdir\Qt\Qt64\include\QtCore/qglobal.h(1786) : see declaration of 'QNoDebug'
..\..\src\properties\trackerlist.cpp(306) : error C2678: binary '<<' : no operator found which takes a left-hand operand of type 'QNoDebug' (or there is no acceptable conversion)
        T:\_outdir\libtorrent\libtorrent64\include\libtorrent/peer_id.hpp(258):could be 'std::ostream &libtorrent::operator <<(std::ostream &,const libtorrent::big_number &)'
        T:\_outdir\libtorrent\libtorrent64\include\libtorrent/lazy_entry.hpp(288): or       'std::ostream &libtorrent::operator <<(std::ostream &,const libtorrent::lazy_entry &)'
```
