### PR TITLE
Attempt to fix data loss during session end

### DIFF
--- a/src/sessionapplication.cpp
+++ b/src/sessionapplication.cpp
@@ -42,6 +42,7 @@ QtSingleApplication(id, argc, argv)
 void SessionApplication::commitData(QSessionManager & manager) {
   Q_UNUSED(manager);
   emit sessionIsShuttingDown();
+  manager.release();
 }
 
 bool SessionApplication::notify(QObject* receiver, QEvent* event) {


### PR DESCRIPTION
Rationale:
1. According to [docs](http://doc.qt.digia.com/stable/qapplication.html#commitData) we should not exit application in `commitData`, which we do, because `sessionIsShuttingDown` signal is blocking.
2. I'm also making `sessionIsShuttingDown` -> `deleteBTSession` direct, so the [slot is called immideatly](http://doc.qt.digia.com/stable/qt.html#ConnectionType-enum).

`ShutdownBlockReasonCreate` and `ShutdownBlockReasonDestroy` function calls are the last line of 'defense'. These functions only exist on vista and higher, so using dynamic loading through `LoadLibrary` is the only option to maintain compatibility without rebuilding. This way qBt will have all the time it needs to clean up.
