### PR TITLE
Allow/Fix special characters in json replies in WebUI

### DIFF
--- a/src/webui/json.cpp
+++ b/src/webui/json.cpp
@@ -76,9 +76,7 @@ QString json::toJson(const QVariant& v) {
         result += "\\t";
         break;
       case '\"':
-      case '\'':
       case '\\':
-      case '&':
         result += '\\';
       case '\0':
       default:


### PR DESCRIPTION
Closes: #455 #324 #460
Hopefully closes #389 too, it has apostrophe in file name.

Tested with FF 18, IE9 and Chromium 24.0.1312.56

For reference see http://www.json.org/

<hr>

![JSON Escapes](http://www.json.org/string.gif)
