### PR TITLE
Support tracker mirrors in torrent creator

### DIFF
--- a/src/torrentcreator/createtorrent.ui
+++ b/src/torrentcreator/createtorrent.ui
@@ -124,7 +124,7 @@
         </sizepolicy>
        </property>
        <property name="toolTip">
-        <string comment="Tracker tier is a list of trackers, consisting of a main tracker and it's mirrors">You can separate tracker tiers with newlines</string>
+        <string comment="A tracker tier is a group of trackers, consisting of a main tracker and its mirrors.">You can separate tracker tiers / groups with an empty line.</string>
        </property>
        <property name="acceptRichText">
         <bool>false</bool>

--- a/src/torrentcreator/torrentcreatorthread.cpp
+++ b/src/torrentcreator/torrentcreatorthread.cpp
@@ -113,7 +113,7 @@ void TorrentCreatorThread::run() {
     foreach (const QString &seed, url_seeds) {
       t.add_url_seed(seed.trimmed().toStdString());
     }
-    qint32 tier = 0;
+    int tier = 0;
     bool newline = false;
     foreach (const QString &tracker, trackers) {
       if (tracker.isEmpty()) {


### PR DESCRIPTION
Closes: #479

Multiple tiers must be separated by a newline in creator dialog.
