### PR TITLE
Fix the downloadbar for libtorrent > 0.16.7

### DIFF
--- a/src/qtlibtorrent/qtorrenthandle.cpp
+++ b/src/qtlibtorrent/qtorrenthandle.cpp
@@ -135,7 +135,7 @@ float QTorrentHandle::progress() const {
 
 bitfield QTorrentHandle::pieces() const {
 #if LIBTORRENT_VERSION_MINOR > 15
-  return torrent_handle::status(0x0).pieces;
+  return torrent_handle::status(torrent_handle::query_pieces).pieces;
 #else
   return torrent_handle::status().pieces;
 #endif


### PR DESCRIPTION
Libtorrent 0.16.8 now correctly takes into account query_pieces flag in the torrent_handle::status and we passed the wrong flag. It worked by coincidence up until now, since libtorrent had this bug.
