### PR TITLE
Fix: using files/folder in disk root for torrent creation fails

### DIFF
--- a/src/torrentcreator/torrentcreatorthread.cpp
+++ b/src/torrentcreator/torrentcreatorthread.cpp
@@ -38,6 +38,7 @@
 #include <libtorrent/file_pool.hpp>
 #include <libtorrent/create_torrent.hpp>
 #include <QFile>
+#include <QDir>
 
 #include "torrentcreatorthread.h"
 #include "fs_utils.h"
@@ -128,7 +129,7 @@ void TorrentCreatorThread::run() {
     }
     if (abort) return;
     // calculate the hash for all pieces
-    const QString parent_path = fsutils::branchPath(input_path);
+    const QString parent_path = fsutils::branchPath(input_path) + QDir::separator();
     set_piece_hashes(t, parent_path.toUtf8().constData(), boost::bind<void>(&sendProgressUpdateSignal, _1, t.num_pieces(), this));
     // Set qBittorrent as creator and add user comment to
     // torrent_info structure


### PR DESCRIPTION
Mostly affects Windows, but still valid on Linux.

<hr>

Wanted to fix the issue in `fsutils::branchPath` but I'm not sure if other code, using `branchPath` is gonna be okay with that.
