### PR TITLE
changes in mootools breaks the context menu 

### DIFF
--- a/src/webui/scripts/contextmenu.js
+++ b/src/webui/scripts/contextmenu.js
@@ -27,7 +27,17 @@ var ContextMenu = new Class({
 		this.targets = $$(this.options.targets);
 		
 		//fx
-		this.fx = new Fx.Tween(this.menu, { property: 'opacity', duration:this.options.fadeSpeed });
+		this.fx = new Fx.Tween(this.menu, { 
+			property: 'opacity', 
+			duration:this.options.fadeSpeed,
+			onComplete: function() {
+				if(this.getStyle('opacity')){
+					this.setStyle('visibility','visible');
+				}else{
+					this.setStyle('visibility','hidden');
+				}
+			}.bind(this.menu)
+		});
 		
 		//hide and begin the listener
 		this.hide().startListener();


### PR DESCRIPTION
Fx.Tween in mootols 1.4.5  no longer sets visibility to hidden, so when the context menu dissapear, if you put the mouse in the space where the menu were showed is still there but with opacity to 0 and cannot click to nothing below that area

So i emulated the old behaviour with OnComplete event.

Additionally i changed the use of deprecated $empty
