### PR TITLE
Actually show the tray notification when a torrent finishes downloading.

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -528,7 +528,7 @@ void MainWindow::balloonClicked() {
 
 // called when a torrent has finished
 void MainWindow::finishedTorrent(const QTorrentHandle& h) const {
-  if (!TorrentPersistentData::isSeed(h.hash()))
+  if (TorrentPersistentData::isSeed(h.hash()))
     showNotificationBaloon(tr("Download completion"), tr("%1 has finished downloading.", "e.g: xxx.avi has finished downloading.").arg(h.name()));
 }
 


### PR DESCRIPTION
Up until now I never knew that such a notification existed. It popped up out of nowhere when I was messing around with my torrents. It is supposed to pop up whenever a torrent finished downloading, but it never did. With my change the notification is always displayed when a torrent finishes downloading.
