### PR TITLE
Save fastresume data only when needed. Improves shutdown when there are ...

### DIFF
--- a/src/qtlibtorrent/qbtsession.cpp
+++ b/src/qtlibtorrent/qbtsession.cpp
@@ -1643,8 +1643,10 @@ void QBtSession::saveFastResumeData() {
       // Actually with should save fast resume data for paused files too
       //if (h.is_paused()) continue;
       if (h.state() == torrent_status::checking_files || h.state() == torrent_status::queued_for_checking) continue;
-      h.save_resume_data();
-      ++num_resume_data;
+      if (h.need_save_resume_data()) {
+        h.save_resume_data(torrent_handle::flush_disk_cache);
+        ++num_resume_data;
+      }
     } catch(libtorrent::invalid_handle&) {}
   }
   while (num_resume_data > 0) {
@@ -2194,7 +2196,8 @@ void QBtSession::readAlerts() {
           const bool was_already_seeded = TorrentPersistentData::isSeed(hash);
           qDebug("Was already seeded: %d", was_already_seeded);
           if (!was_already_seeded) {
-            h.save_resume_data();
+            if (h.need_save_resume_data())
+              h.save_resume_data();
             qDebug("Checking if the torrent contains torrent files to download");
             // Check if there are torrent files inside
             for (int i=0; i<h.num_files(); ++i) {
@@ -2434,8 +2437,8 @@ void QBtSession::readAlerts() {
       else if (torrent_paused_alert* p = dynamic_cast<torrent_paused_alert*>(a.get())) {
         if (p->handle.is_valid()) {
           QTorrentHandle h(p->handle);
-          if (!h.has_error())
-            h.save_resume_data();
+          if (!h.has_error() && h.need_save_resume_data())
+            h.save_resume_data(torrent_handle::flush_disk_cache);
           emit pausedTorrent(h);
         }
       }

--- a/src/qtlibtorrent/qtorrenthandle.cpp
+++ b/src/qtlibtorrent/qtorrenthandle.cpp
@@ -620,7 +620,6 @@ void QTorrentHandle::file_progress(std::vector<size_type>& fp) const {
 void QTorrentHandle::pause() const {
   torrent_handle::auto_managed(false);
   torrent_handle::pause();
-  torrent_handle::save_resume_data();
 }
 
 void QTorrentHandle::resume() const {


### PR DESCRIPTION
...many torrents in the session. Also eliminates unnecessary disk writing.
