### PR TITLE
Add sequential downloading to web API

### DIFF
--- a/src/webui/httpconnection.cpp
+++ b/src/webui/httpconnection.cpp
@@ -541,6 +541,22 @@ void HttpConnection::respondCommand(const QString& command) {
     }
     return;
   }
+  if (command == "setTorrentSequentialDownload") {
+    QString hash = m_parser.post("hash");
+    QTorrentHandle h = QBtSession::instance()->getTorrentHandle(hash);
+    if (h.is_valid()) {
+      h.set_sequential_download(true);
+    }
+    return;
+  }
+  if (command == "setTorrentNonSequentialDownload") {
+    QString hash = m_parser.post("hash");
+    QTorrentHandle h = QBtSession::instance()->getTorrentHandle(hash);
+    if (h.is_valid()) {
+      h.set_sequential_download(false);
+    }
+    return;
+  }
   if (command == "setTorrentDlLimit") {
     QString hash = m_parser.post("hash");
     qlonglong limit = m_parser.post("limit").toLongLong();


### PR DESCRIPTION
Adds two methods to the web API:
setTorrentSequentialDownload and setTorrentNotSequentialDownload

I've not added this to the webui because I don't use that. But it should be simple for anyone to add this functionality now it exists in the API
