### PR TITLE
Allow controling cache expiry timer

### DIFF
--- a/src/preferences/advancedsettings.h
+++ b/src/preferences/advancedsettings.h
@@ -13,7 +13,11 @@
 #include "preferences.h"
 
 enum AdvSettingsCols {PROPERTY, VALUE};
-enum AdvSettingsRows {DISK_CACHE, OUTGOING_PORT_MIN, OUTGOING_PORT_MAX, IGNORE_LIMIT_LAN, RECHECK_COMPLETED, LIST_REFRESH, RESOLVE_COUNTRIES, RESOLVE_HOSTS, MAX_HALF_OPEN, SUPER_SEEDING, NETWORK_IFACE, NETWORK_ADDRESS, PROGRAM_NOTIFICATIONS, TRACKER_STATUS, TRACKER_PORT,
+enum AdvSettingsRows {DISK_CACHE,
+                    #if LIBTORRENT_VERSION_NUM >= 001610
+                      DISK_CACHE_TTL,
+                    #endif
+                      OUTGOING_PORT_MIN, OUTGOING_PORT_MAX, IGNORE_LIMIT_LAN, RECHECK_COMPLETED, LIST_REFRESH, RESOLVE_COUNTRIES, RESOLVE_HOSTS, MAX_HALF_OPEN, SUPER_SEEDING, NETWORK_IFACE, NETWORK_ADDRESS, PROGRAM_NOTIFICATIONS, TRACKER_STATUS, TRACKER_PORT,
                     #if defined(Q_WS_WIN) || defined(Q_WS_MAC)
                       UPDATE_CHECK,
                     #endif
@@ -33,6 +37,9 @@ private:
   cb_super_seeding, cb_program_notifications, cb_tracker_status, cb_confirm_torrent_deletion,
   cb_enable_tracker_ext;
   QComboBox combo_iface;
+#if LIBTORRENT_VERSION_NUM >= 001610
+  QSpinBox spin_cache_ttl;
+#endif
 #if defined(Q_WS_WIN) || defined(Q_WS_MAC)
   QCheckBox cb_update_check;
 #endif
@@ -69,6 +76,9 @@ public slots:
     Preferences pref;
     // Disk write cache
     pref.setDiskCacheSize(spin_cache.value());
+#if LIBTORRENT_VERSION_NUM >= 001610
+    pref.setDiskCacheTTL(spin_cache_ttl.value());
+#endif
     // Outgoing ports
     pref.setOutgoingPortsMin(outgoing_ports_min.value());
     pref.setOutgoingPortsMax(outgoing_ports_max.value());
@@ -172,6 +182,14 @@ private slots:
     spin_cache.setValue(pref.diskCacheSize());
     updateCacheSpinSuffix(spin_cache.value());
     setRow(DISK_CACHE, tr("Disk write cache size"), &spin_cache);
+#if LIBTORRENT_VERSION_NUM >= 001610
+    // Disk cache expiry
+    spin_cache_ttl.setMinimum(15);
+    spin_cache_ttl.setMaximum(600);
+    spin_cache_ttl.setValue(pref.diskCacheTTL());
+    spin_cache_ttl.setSuffix(tr(" s", " seconds"));
+    setRow(DISK_CACHE_TTL, tr("Disk cache expiry interval"), &spin_cache_ttl);
+#endif
     // Outgoing port Min
     outgoing_ports_min.setMinimum(0);
     outgoing_ports_min.setMaximum(65535);

--- a/src/preferences/preferences.h
+++ b/src/preferences/preferences.h
@@ -959,12 +959,26 @@ public:
   }
 
   uint diskCacheSize() const {
+#if LIBTORRENT_VERSION_NUM >= 001610
     return value(QString::fromUtf8("Preferences/Downloads/DiskWriteCacheSize"), 0).toUInt();
+#else
+    return value(QString::fromUtf8("Preferences/Downloads/DiskWriteCacheSize"), 128).toUInt();
+#endif
   }
 
   void setDiskCacheSize(uint size) {
     setValue(QString::fromUtf8("Preferences/Downloads/DiskWriteCacheSize"), size);
   }
+
+#if LIBTORRENT_VERSION_NUM >= 001610
+  uint diskCacheTTL() const {
+    return value(QString::fromUtf8("Preferences/Downloads/DiskWriteCacheTTL"), 60).toUInt();
+  }
+
+  void setDiskCacheTTL(uint ttl) {
+    setValue(QString::fromUtf8("Preferences/Downloads/DiskWriteCacheTTL"), ttl);
+  }
+#endif
 
   uint outgoingPortsMin() const {
     return value(QString::fromUtf8("Preferences/Advanced/OutgoingPortsMin"), 0).toUInt();

--- a/src/qtlibtorrent/qbtsession.cpp
+++ b/src/qtlibtorrent/qbtsession.cpp
@@ -422,6 +422,9 @@ void QBtSession::configureSession() {
   sessionSettings.auto_scrape_min_interval = 900; // 15 minutes
   int cache_size = pref.diskCacheSize();
   sessionSettings.cache_size = cache_size ? cache_size * 64 : -1;
+#if LIBTORRENT_VERSION_NUM >= 001610
+  sessionSettings.cache_expiry = pref.diskCacheTTL();
+#endif
   qDebug() << "Using a disk cache size of" << cache_size << "MiB";
 #if LIBTORRENT_VERSION_NUM >= 001600
   sessionSettings.anonymous_mode = pref.isAnonymousModeEnabled();


### PR DESCRIPTION
This change is aimed for libtorrent 0.16.10 release (and Windows platform mostly). 0.16.10 now properly returns expired cache entries to kernel, so memory used will now vary depending on the load instead of always growing to max cache as before. 'Auto' value for cache size can now be used w/o problems.

I'm not sure that 60s expiry is ok or too small: author states that default value is 300s, while the manual states it's 60s. (Anyway Deluge uses 60s by default)

Closes: #258
