### PR TITLE
Adding Travis CI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,54 @@
+language:
+# linux
+- cpp
+
+# osx
+# - objective-c
+
+env:
+# linux
+- lt=APT debug=false gui=true
+- lt=repo debug=false gui=true
+- lt=repo debug=true gui=true
+- lt=repo debug=true gui=false
+
+install:
+# linux, osx
+- (cd src/geoip && wget http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz && gzip -d GeoIP.dat.gz)
+
+# linux
+- shopt -s expand_aliases
+- alias sudo="sudo "
+- alias make=colormake
+- export MAKEFLAGS="-j $((`nproc` / 2))"
+
+- if $debug; then qtc="--enable-debug"; ltc="--enable-debug"; fi
+- if ! $gui; then qtc="$qtc --disable-gui"; fi
+
+- echo settings
+- echo $lt
+- echo $debug
+- echo $gui
+- echo $qtc
+- echo $ltc
+
+- sudo apt-get -qq update
+- sudo apt-get -qq install debhelper libboost-dev libboost-filesystem-dev libboost-system-dev libqt4-dev qconf colormake
+- if [[ "$lt" == "APT" ]]; then sudo apt-get -qq install libtorrent-rasterbar-dev; fi
+- if [[ "$lt" == "repo" ]]; then sudo apt-get -qq build-dep libtorrent-rasterbar-dev && git clone git://github.com/mirror/libtorrent.git && (cd libtorrent && ./autotool.sh && ./configure $ltc && sudo make install); fi
+
+# osx
+# - export MAKEFLAGS="-j 4"
+# - brew update
+# - brew install libtorrent-rasterbar qt boost
+
+script:
+# linux, osx
+- mkdir -p build && cd build && mkdir -p install
+
+# linux
+- (cd .. && qt-qconf)
+- ../configure $qtc && sudo make install
+
+# osx
+# - qmake ../qbittorrent.pro && make


### PR DESCRIPTION
### Problem

A commit with build errors is sometimes pushed to origin because
- the build complete in one system (f.e. Windows) but not in all systems (f.e. Linux or OS X)
- a change that include a minor error (f.e. a typing error) is commited without a build test

This is a problem because
- the build fix require a separate commit because origin master commits can't be amended
- the build fix commit use space in the repo history
- it's better if every commit build on all systems than if some commits have build errors

Testing a change that's structurally correct because it might contain a minor errors (f.e. a typing error) use more time compared to
- push the code that's correct unless there's a typing error
- receiving a message from notifications@travis-ci.org if the build fail
- amend the commit if the build fail
### Solution

Adding a Travis CI script because
- that solve the problem in the topic "Problem"
### Configuration
#### Reference
- qbittorrent: [qt4.qcm](https://github.com/qbittorrent/qBittorrent/blob/master/qcm/qt4.qcm)
- libtorrent: [building.html](http://htmlpreview.github.io/?https://github.com/mirror/libtorrent/blob/master/docs/building.html), [configure.ac](https://github.com/mirror/libtorrent/blob/master/configure.ac)
#### Discussion

> I'd rather we build with predefined libtorrent versions instead of whatever stale one they've got in the repos.
> 2 builds are preferable: with libtorrent 0.15.10 and with current 0.16.X version
> 
> Judging by travis docs we could hook before_install, build and install two versions of libtorrent and then build two versions of qBt.
#### Qt

libqt4-dev is installed also with the configuration

```
../configure --disable-gui --disable-qt-dbus
```

because it still check for Qt

```
Verifying Qt 4 build environment ... fail
```
### Time
#### Linux
- qbittorrent: [9:00](https://travis-ci.org/john-peterson/qBittorrent/builds/8666734)
- qbittorrent, libtorrent: 17:00
#### OS X
- qbittorrent: [15:00](https://travis-ci.org/john-peterson/qBittorrent/builds/8678069)
### Platform
#### No multi-platform build

The build is on [either Linux or OS X](https://github.com/travis-ci/travis-ci/issues/216#issuecomment-19430107) rather than both

The reason to build in Linux is
- the build time is significantly lower because `nproc` is 32 instead of 1
#### Disabled build script commands

The OS X build commands are in `.travis.yml` but disabled rather than not included because
- that allow a user to easily enable the OS X build and test it by pushing to a GitHub branch
#### Information

The [output](https://www.dropbox.com/sh/2z5p162ovqtbn17/bQWX1aKTQK/note/travis) from

```
uname
nproc
lscpu
system_profiler
```
### OS X
#### Simultaneous make jobs

The simultaneous make jobs is 4 despite that `nproc` is 1 because
- `-j 4` is around 2 × the speed of `-j 1`
- `-j 4` is faster than `-j 2`
- `-j 8` isn't faster than `-j 4`
### Linux
#### Simultaneous make jobs

The make command is `make -j $((`nproc` / 2))` rather than `make -j `nproc`` because
- `nproc` is 32 which use much memory
- `make -j `nproc`` [return](https://travis-ci.org/john-peterson/dolphin-emu/builds/8127049) "Killed (program cc1plus)" because memory is inadequate
### Travis CI enabled for origin

> I don't want to grant such access

Describe the disadvantage with [allowing](https://github.com/github/github-services/blob/master/docs/travis) Travis CI write access to

> listen to push and pull request events to trigger new builds, member and public events to keep track of repository visibility and issue comment events to allow users to talk to @travisbot

for https://github.com/qbittorrent/qBittorrent
#### Change the repo

> 2a. There's a rogue process in their systems and destroys random repos in the process

If Travis CI change the repo
- it might affect many (rather than few) repos because [41 K](https://bluebox.net/landing/travis-ci) ([25 K](http://about.travis-ci.org/blog/2012-12-17-numbers/) at 2012-10) repos use Travis CI which makes it more likely that it's noticed
- GitHub is compelled to restore the repo from a backup because it's important for GitHub that a service hook doesn't do harm that isn't corrected

> How about git rm

`git rm` in the repo hosted at GitHub return

```
fatal: This operation must be run in a work tree
```

because it's a bare repo

If the repo is changed in a way that break it

it's noticed because `git clone` return an error

f.e. `rm HEAD` make `git clone` return this

```
fatal: repository '' does not exist
```

and the comment in the topic "Travis CI is hacked" apply
#### Is hacked

> 2b. A malicious attacker gains access to their systems and inserts malicous code into random/specific repos.

If a malicious agent change the repo

the same arguments as in the topic "Travis CI change the repo" apply that mitigate the potential harm

by rebasing
- it will be noticed from `git push` because it will fail because it can't fast forward

by adding a commit
- it's noticed in `git log`
