### PR TITLE
[WIP] Implement open & select file in file manager

### DIFF
--- a/src/properties/propertieswidget.cpp
+++ b/src/properties/propertieswidget.cpp
@@ -429,9 +429,10 @@ void PropertiesWidget::openFile(const QModelIndex &index) {
   // Flush data
   h.flush_cache();
   if (QFile::exists(file_path)) {
-    // Hack to access samba shares with QDesktopServices::openUrl
-    const QString p = file_path.startsWith("//") ? QString("file:") + file_path : file_path;
-    QDesktopServices::openUrl(QUrl::fromLocalFile(p));
+    if (file_path.startsWith("//"))
+      QDesktopServices::openUrl(fsutils::toNativePath("file:" + file_path));
+    else
+      QDesktopServices::openUrl(QUrl::fromLocalFile(file_path));
   }
   else {
     QMessageBox::warning(this, tr("I/O Error"), tr("This file does not exist yet."));
@@ -471,8 +472,10 @@ void PropertiesWidget::openFolder(const QModelIndex &index, bool containing_fold
 #endif
     if (QFile::exists(file_path)) {
       // Hack to access samba shares with QDesktopServices::openUrl
-      const QString p = file_path.startsWith("//") ? QString("file:") + file_path : file_path;
-      QDesktopServices::openUrl(QUrl::fromLocalFile(p));
+      if (file_path.startsWith("//"))
+        QDesktopServices::openUrl(fsutils::toNativePath("file:" + file_path));
+      else
+        QDesktopServices::openUrl(QUrl::fromLocalFile(file_path));
     } else {
       QMessageBox::warning(this, tr("I/O Error"), tr("This folder does not exist yet."));
     }

--- a/src/transferlistwidget.cpp
+++ b/src/transferlistwidget.cpp
@@ -633,8 +633,10 @@ void TransferListWidget::askNewLabelForSelection() {
 bool TransferListWidget::openUrl(const QString &_path) const {
   const QString path = fsutils::fromNativePath(_path);
   // Hack to access samba shares with QDesktopServices::openUrl
-  const QString p = path.startsWith("//") ? QString("file:") + path : path;
-  return QDesktopServices::openUrl(QUrl::fromLocalFile(p));
+  if (path.startsWith("//"))
+    return QDesktopServices::openUrl(fsutils::toNativePath("file:" + path));
+  else
+    return QDesktopServices::openUrl(QUrl::fromLocalFile(path));
 }
 
 void TransferListWidget::renameSelectedTorrent() {


### PR DESCRIPTION
Should close #218 when ready for merge.
**[WIP] Not ready for merging. Putting it here for a discussion**

As you can see, implementing this will introduce three platform-specific code branches, which is not very convenient.

**[DONE]** On Windows: using explorer.exe command line switch
On Linux we'll need to use DBUS: http://www.freedesktop.org/wiki/Specifications/file-manager-interface/
On Mac: whatever this is (looks like obj-c thought :-/) https://developer.apple.com/library/mac/#documentation/Cocoa/Reference/ApplicationKit/Classes/NSWorkspace_Class/Reference/Reference.html#//apple_ref/occ/instm/NSWorkspace/selectFile:inFileViewerRootedAtPath:
