### PR TITLE
Forbid newlines in rename torrent dialog.

### DIFF
--- a/src/transferlistwidget.cpp
+++ b/src/transferlistwidget.cpp
@@ -624,8 +624,9 @@ void TransferListWidget::renameSelectedTorrent() {
   if (!h.is_valid()) return;
   // Ask for a new Name
   bool ok;
-  const QString name = QInputDialog::getText(this, tr("Rename"), tr("New name:"), QLineEdit::Normal, h.name(), &ok);
+  QString name = QInputDialog::getText(this, tr("Rename"), tr("New name:"), QLineEdit::Normal, h.name(), &ok);
   if (ok && !name.isEmpty()) {
+    name.replace(QRegExp("\r?\n|\r"), " ");
     // Rename the torrent
     listModel->setData(mi, name, Qt::DisplayRole);
   }


### PR DESCRIPTION
Unfortunately it is not possible (or I didn't dig deep enough) to fix existing torrents with newlines - users will need to rename them manually. I wanted to fix this in `TorrentPersistantData` but fastresume isn't saved all the time after 5425653681bb04038ed240b68fbe1fa5c05d3f9d.
