### PR TITLE
Ignore 'Torrent addition dialog' setting if the file doesn't exist:

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1003,7 +1003,7 @@ void MainWindow::processParams(const QStringList& params) {
         else
           QBtSession::instance()->addMagnetUri(param);
       } else {
-        if (useTorrentAdditionDialog)
+        if (useTorrentAdditionDialog && QFile(param).exists())
           AddNewTorrentDialog::showTorrent(param, QString(), this);
         else
           QBtSession::instance()->addTorrent(param);


### PR DESCRIPTION
Closes: #100