### PR TITLE
Load magnet metadata inside AddNewTorrentDialog

### DIFF
--- a/src/addnewtorrentdialog.h
+++ b/src/addnewtorrentdialog.h
@@ -36,6 +36,7 @@
 #include <QUrl>
 #include <libtorrent/torrent_info.hpp>
 #include "qtorrenthandle.h"
+#include <QProgressBar>
 
 QT_BEGIN_NAMESPACE
 namespace Ui {
@@ -80,6 +81,7 @@ private:
   void updateFileNameInSavePaths(const QString& new_filename);
   void loadState();
   void saveState();
+  void setMetadataProgressIndicator(bool enabled, const QString &labelText = QString());
 
 private:
   Ui::AddNewTorrentDialog *ui;
@@ -95,6 +97,7 @@ private:
   QStringList m_filesPath;
   bool m_hasRenamedFile;
   QShortcut *editHotkey;
+  QProgressBar *m_progress;
 };
 
 #endif // ADDNEWTORRENTDIALOG_H

--- a/src/addnewtorrentdialog.ui
+++ b/src/addnewtorrentdialog.ui
@@ -187,6 +187,16 @@
    <item>
     <layout class="QHBoxLayout" name="buttonsHLayout">
      <item>
+      <widget class="QLabel" name="lblMetaLoading">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string notr="true"/>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
Closes: #326

Obsoletes: #422
1. Has a colored progress indicator for metadata retrieval
2. Supports:
   - Adding magnets after retrieving metadata - file list is available
   - Adding magnets before metadata is retrieved (old behavior) - file list is unavailable
