### PR TITLE
First attempt at bringing the AddNewTorrentDialog to the front.

### DIFF
--- a/src/addnewtorrentdialog.cpp
+++ b/src/addnewtorrentdialog.cpp
@@ -122,6 +122,17 @@ void AddNewTorrentDialog::saveState()
   settings.setValue("expanded", ui->adv_button->isChecked());
 }
 
+void AddNewTorrentDialog::showEvent(QShowEvent *event)
+{
+  QDialog::showEvent(event);
+#ifdef Q_OS_WIN
+  SetWindowPos(effectiveWinId(), HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+  SetWindowPos(effectiveWinId(), HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+#endif
+  activateWindow();
+  raise();
+}
+
 void AddNewTorrentDialog::showTorrent(const QString &torrent_path, const QString& from_url)
 {
   AddNewTorrentDialog dlg;

--- a/src/addnewtorrentdialog.h
+++ b/src/addnewtorrentdialog.h
@@ -55,6 +55,9 @@ public:
   static void showTorrent(const QString& torrent_path, const QString& from_url = QString());
   static void showMagnet(const QString& torrent_link);
 
+protected:
+  virtual void showEvent(QShowEvent *event);
+
 private slots:
   void showAdvancedSettings(bool show);
   void displayContentTreeMenu(const QPoint&);


### PR DESCRIPTION
This should close:  #166 #327 #443 #698

On platforms other than Windows this should work with the patch.
On Windows we need some hack where our dialog becomes momentarily ALWAYSONTOP and immediately loses that attribute. It works but in eg firefox which displays an animation when a download is complete(.torrent is downloaded) it hides the dialog again. At least now with activateWindow() the taskbar entry is flashing.

Any ideas?
