### PR TITLE
Add notifications when new torrent file/magnet link is added to the download list

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1163,15 +1163,17 @@ void MainWindow::showNotificationBaloon(QString title, QString msg) const {
   org::freedesktop::Notifications notifications("org.freedesktop.Notifications",
                                                 "/org/freedesktop/Notifications",
                                                 QDBusConnection::sessionBus());
-  if (notifications.isValid()) {
+  //Not sure why but this always seems to return false on my Linux Mint 14 Machine, works fine with the check disabled
+//  if (notifications.isValid()) {
     QVariantMap hints;
     hints["desktop-entry"] = "qBittorrent";
     QDBusPendingReply<uint> reply = notifications.Notify("qBittorrent", 0, "qbittorrent", title,
                                                          msg, QStringList(), hints, -1);
     reply.waitForFinished();
+    
     if (!reply.isError())
       return;
-  }
+//  }
 #endif
   if (systrayIcon && QSystemTrayIcon::supportsMessages())
     systrayIcon->showMessage(title, msg, QSystemTrayIcon::Information, TIME_TRAY_BALLOON);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -891,11 +891,8 @@ void MainWindow::dropEvent(QDropEvent *event) {
     if (file.startsWith("magnet:", Qt::CaseInsensitive)) {
       if (useTorrentAdditionDialog)
         AddNewTorrentDialog::showMagnet(file);
-      else{
+      else
         QBtSession::instance()->addMagnetUri(file);
-        showNotificationBaloon("Magnet Link added","");
-        std::cout<<"Torrent Added - "<<qPrintable(file)<<std::endl;
-      }
     } else {
       // Local file
       if (useTorrentAdditionDialog)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -891,8 +891,11 @@ void MainWindow::dropEvent(QDropEvent *event) {
     if (file.startsWith("magnet:", Qt::CaseInsensitive)) {
       if (useTorrentAdditionDialog)
         AddNewTorrentDialog::showMagnet(file);
-      else
+      else{
         QBtSession::instance()->addMagnetUri(file);
+        showNotificationBaloon("Magnet Link added","");
+        std::cout<<"Torrent Added - "<<qPrintable(file)<<std::endl;
+      }
     } else {
       // Local file
       if (useTorrentAdditionDialog)
@@ -978,13 +981,21 @@ void MainWindow::processParams(const QStringList& params) {
       if (param.startsWith("magnet:", Qt::CaseInsensitive)) {
         if (useTorrentAdditionDialog)
           AddNewTorrentDialog::showMagnet(param);
-        else
-          QBtSession::instance()->addMagnetUri(param);
+        else{
+          QTorrentHandle torrent =  QBtSession::instance()->addMagnetUri(param);
+          //TODO TRANSLATE AND DETAILS
+          showNotificationBaloon("Magnet Link has been added", "A Magnet Link has been added to the list of downloads");
+          std::cout<<"Magnet added"<<torrent.name().toStdString()<<std::endl<<torrent.is_queued()<<std::endl<<torrent.active_time()<<std::endl<<torrent.creation_date().toStdString()<<std::endl;
+        }
       } else {
         if (useTorrentAdditionDialog)
           AddNewTorrentDialog::showTorrent(param);
-        else
+        else{
           QBtSession::instance()->addTorrent(param);
+          //TODO TRanslate and DETAILS
+          showNotificationBaloon("Torrent file has been added", "A Torrent File has been added to the list of downloads");
+          std::cout<<"Torrent added"<<std::endl;
+        }
       }
     }
   }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -980,18 +980,22 @@ void MainWindow::processParams(const QStringList& params) {
           AddNewTorrentDialog::showMagnet(param);
         else{
           QTorrentHandle torrent =  QBtSession::instance()->addMagnetUri(param);
-          //TODO TRANSLATE AND DETAILS
-          showNotificationBaloon("Magnet Link has been added", "A Magnet Link has been added to the list of downloads");
-          std::cout<<"Magnet added"<<torrent.name().toStdString()<<std::endl<<torrent.is_queued()<<std::endl<<torrent.active_time()<<std::endl<<torrent.creation_date().toStdString()<<std::endl;
+          
+          //TODO TRANSLATE          
+          // to check for a new torrent I use name non empty, as explained below, active_time can also be used.
+          //Ideally it should be done from within the add function, but I dont know QT customs
+          if (torrent.name().toStdString() != "") //it appears to be non empty only the time it is properly added for some reason
+          	showNotificationBaloon("Magnet Link has been added", ("A Magnet File titled \"" +torrent.name().toStdString() + "\" has been added to the list of downloads").c_str());
         }
       } else {
         if (useTorrentAdditionDialog)
           AddNewTorrentDialog::showTorrent(param);
         else{
-          QBtSession::instance()->addTorrent(param);
-          //TODO TRanslate and DETAILS
-          showNotificationBaloon("Torrent file has been added", "A Torrent File has been added to the list of downloads");
-          std::cout<<"Torrent added"<<std::endl;
+          QTorrentHandle torrent =  QBtSession::instance()->addTorrent(param);
+          
+          //TODO Translate     
+          if (torrent.name().toStdString() != "") //it appears to be non empty only the time it is properly added for some reason
+          	showNotificationBaloon("Torrent File has been added", ("A Torrent File titled \"" +torrent.name().toStdString() + "\" has been added to the list of downloads").c_str());
         }
       }
     }


### PR DESCRIPTION
Related to https://github.com/qbittorrent/qBittorrent/issues/334

It is not a very clean implementation, but I have no experience with QT, so I hope you might clean it up when applying these changes, otherwise these commits achieve two things

1. Add notifications when torrents/magnet links are added by clicking in a browser and the add torrent dialog is disabled. This is not ready for translation yet, it uses hard coded strings, something else to clean up..
2. "Fix" notifications on Linux Mint 14. 
  A check was being done, which seems to fail on my distro atleast, which led to me getting ugly qt notifications instead of the system ones, I have commented the check, since I cant find any documentation pointing towards that function or the need for it.