### PR TITLE
Drop unneeded QtXml module dependency.

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -27,7 +27,6 @@ nox {
   TARGET = qbittorrent-nox
   DEFINES += DISABLE_GUI
 } else {
-  QT += xml
   CONFIG(static) {
     DEFINES += QBT_STATIC_QT
     QTPLUGIN += qico


### PR DESCRIPTION
Removed unneeded QtXml module dependency (QT += xml) from qBittorrent project - it is not used really.
I tested for Qt5 only, but I reviewed the code and have not found it of use,
so I think it should work for Qt4 too. 
