### PR TITLE
Bringing some message boxes to the front.

### DIFF
--- a/src/addnewtorrentdialog.cpp
+++ b/src/addnewtorrentdialog.cpp
@@ -40,12 +40,12 @@
 #include "iconprovider.h"
 #include "fs_utils.h"
 #include "autoexpandabledialog.h"
+#include "qmessageboxraisable.h"
 
 #include <QString>
 #include <QFile>
 #include <QUrl>
 #include <QMenu>
-#include <QMessageBox>
 #include <QTimer>
 #include <QFileDialog>
 #include <libtorrent/version.hpp>
@@ -181,7 +181,7 @@ bool AddNewTorrentDialog::loadTorrent(const QString& torrent_path, const QString
     m_filePath = torrent_path;
 
   if (!QFile::exists(m_filePath)) {
-    QMessageBox::critical(0, tr("I/O Error"), tr("The torrent file does not exist."));
+    QMessageBoxRaisable::critical(0, tr("I/O Error"), tr("The torrent file does not exist."));
     return false;
   }
 
@@ -191,13 +191,13 @@ bool AddNewTorrentDialog::loadTorrent(const QString& torrent_path, const QString
     m_torrentInfo = new torrent_info(m_filePath.toUtf8().data());
     m_hash = misc::toQString(m_torrentInfo->info_hash());
   } catch(const std::exception& e) {
-    QMessageBox::critical(0, tr("Invalid torrent"), tr("Failed to load the torrent: %1").arg(e.what()));
+    QMessageBoxRaisable::critical(0, tr("Invalid torrent"), tr("Failed to load the torrent: %1").arg(e.what()));
     return false;
   }
 
   // Prevent showing the dialog if download is already present
   if (QBtSession::instance()->getTorrentHandle(m_hash).is_valid()) {
-    QMessageBox::information(0, tr("Already in download list"), tr("Torrent is already in download list. Merging trackers."), QMessageBox::Ok);
+    QMessageBoxRaisable::information(0, tr("Already in download list"), tr("Torrent is already in download list. Merging trackers."), QMessageBox::Ok);
     QBtSession::instance()->addTorrent(m_filePath, false, m_url);;
     return false;
   }
@@ -268,13 +268,13 @@ bool AddNewTorrentDialog::loadMagnet(const QString &magnet_uri)
   m_url = magnet_uri;
   m_hash = misc::magnetUriToHash(m_url);
   if (m_hash.isEmpty()) {
-    QMessageBox::critical(0, tr("Invalid magnet link"), tr("This magnet link was not recognized"));
+    QMessageBoxRaisable::critical(0, tr("Invalid magnet link"), tr("This magnet link was not recognized"));
     return false;
   }
 
   // Prevent showing the dialog if download is already present
   if (QBtSession::instance()->getTorrentHandle(m_hash).is_valid()) {
-    QMessageBox::information(0, tr("Already in download list"), tr("Magnet link is already in download list. Merging trackers."), QMessageBox::Ok);
+    QMessageBoxRaisable::information(0, tr("Already in download list"), tr("Magnet link is already in download list. Merging trackers."), QMessageBox::Ok);
     QBtSession::instance()->addMagnetUri(m_url, false);
     return false;
   }

--- a/src/qmessageboxraisable.cpp
+++ b/src/qmessageboxraisable.cpp
@@ -1,0 +1,102 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2006  Christophe Dumez
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ *
+ * Contact : chris@qbittorrent.org
+ */
+
+#include <QDialogButtonBox>
+#include <QPushButton>
+#include "qmessageboxraisable.h"
+
+static QMessageBox::StandardButton showNewMessageBox(QWidget *parent, QMessageBox::Icon icon,
+                                                     const QString& title, const QString& text,
+                                                     QMessageBox::StandardButtons buttons,
+                                                     QMessageBox::StandardButton defaultButton)
+{
+    QMessageBoxRaisable msgBox(icon, title, text, QMessageBox::NoButton, parent);
+    QDialogButtonBox *buttonBox = msgBox.findChild<QDialogButtonBox*>();
+    Q_ASSERT(buttonBox != 0);
+
+    uint mask = QMessageBox::FirstButton;
+    while (mask <= QMessageBox::LastButton) {
+        uint sb = buttons & mask;
+        mask <<= 1;
+        if (!sb)
+            continue;
+        QPushButton *button = msgBox.addButton((QMessageBox::StandardButton)sb);
+        // Choose the first accept role as the default
+        if (msgBox.defaultButton())
+            continue;
+        if ((defaultButton == QMessageBox::NoButton && buttonBox->buttonRole(button) == QDialogButtonBox::AcceptRole)
+            || (defaultButton != QMessageBox::NoButton && sb == uint(defaultButton)))
+            msgBox.setDefaultButton(button);
+    }
+    if (msgBox.exec() == -1)
+        return QMessageBox::Cancel;
+    return msgBox.standardButton(msgBox.clickedButton());
+}
+
+QMessageBoxRaisable::QMessageBoxRaisable(QMessageBox::Icon icon, const QString &title, const QString &text,
+                       QMessageBox::StandardButtons buttons, QWidget *parent)
+    : QMessageBox(icon, title, text, buttons, parent)
+{
+}
+
+QMessageBox::StandardButton QMessageBoxRaisable::information(QWidget *parent, const QString &title,
+                                                    const QString &text, QMessageBox::StandardButtons buttons,
+                                                    QMessageBox::StandardButton defaultButton)
+{
+    return showNewMessageBox(parent, Information, title, text, buttons, defaultButton);
+}
+
+QMessageBox::StandardButton QMessageBoxRaisable::question(QWidget *parent, const QString &title,
+                                                 const QString &text, QMessageBox::StandardButtons buttons,
+                                                 QMessageBox::StandardButton defaultButton)
+{
+    return showNewMessageBox(parent, Question, title, text, buttons, defaultButton);
+}
+
+QMessageBox::StandardButton QMessageBoxRaisable::warning(QWidget *parent, const QString &title,
+                                                const QString &text, QMessageBox::StandardButtons buttons,
+                                                QMessageBox::StandardButton defaultButton)
+{
+    return showNewMessageBox(parent, Warning, title, text, buttons, defaultButton);
+}
+
+QMessageBox::StandardButton QMessageBoxRaisable::critical(QWidget *parent, const QString &title,
+                                                 const QString &text, QMessageBox::StandardButtons buttons,
+                                                 QMessageBox::StandardButton defaultButton)
+{
+    return showNewMessageBox(parent, Critical, title, text, buttons, defaultButton);
+}
+
+void QMessageBoxRaisable::showEvent(QShowEvent *event)
+{
+    QMessageBox::showEvent(event);
+    activateWindow();
+    raise();
+}

--- a/src/qmessageboxraisable.h
+++ b/src/qmessageboxraisable.h
@@ -1,0 +1,59 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2006  Christophe Dumez
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ *
+ * Contact : chris@qbittorrent.org
+ */
+
+#ifndef MESSAGEBOXRAISABLE_H
+#define MESSAGEBOXRAISABLE_H
+
+#include <QMessageBox>
+
+class QMessageBoxRaisable : public QMessageBox
+{
+public:
+    QMessageBoxRaisable(Icon icon, const QString & title, const QString & text,
+         StandardButtons buttons = NoButton, QWidget * parent = 0);
+
+    static StandardButton information(QWidget *parent, const QString &title,
+         const QString &text, StandardButtons buttons = Ok,
+         StandardButton defaultButton = NoButton);
+    static StandardButton question(QWidget *parent, const QString &title,
+         const QString &text, StandardButtons buttons = StandardButtons(Yes | No),
+         StandardButton defaultButton = NoButton);
+    static StandardButton warning(QWidget *parent, const QString &title,
+         const QString &text, StandardButtons buttons = Ok,
+         StandardButton defaultButton = NoButton);
+    static StandardButton critical(QWidget *parent, const QString &title,
+         const QString &text, StandardButtons buttons = Ok,
+         StandardButton defaultButton = NoButton);
+
+protected:
+    void showEvent(QShowEvent *event);
+};
+
+#endif // MESSAGEBOXRAISABLE_H

--- a/src/src.pro
+++ b/src/src.pro
@@ -149,7 +149,8 @@ nox {
               updownratiodlg.h \
               loglistwidget.h \
               addnewtorrentdialog.h \
-              autoexpandabledialog.h
+              autoexpandabledialog.h \
+              qmessageboxraisable.h
 
   SOURCES += mainwindow.cpp \
              ico.cpp \
@@ -167,7 +168,8 @@ nox {
              updownratiodlg.cpp \
              loglistwidget.cpp \
              addnewtorrentdialog.cpp \
-             autoexpandabledialog.cpp
+             autoexpandabledialog.cpp \
+             qmessageboxraisable.cpp
 
   win32 {
     HEADERS += programupdater.h


### PR DESCRIPTION
Message boxes that may be shown during torrent addition connot be brought to the front.
Solution - inherit a class QMessageBox, add the QShowEvent handling (as in AddNewTorrentDialog) and then use that subclass (also it need to implement appropriate static functions like information(), warning() etc.).
