### PR TITLE
First try on improving metadata loading.

### DIFF
--- a/src/addnewtorrentdialog.h
+++ b/src/addnewtorrentdialog.h
@@ -91,7 +91,6 @@ private:
   PropListDelegate *m_contentDelegate;
   bool m_isMagnet;
   bool m_hasMetadata;
-  bool m_convertingMagnet;
   QString m_filePath;
   QString m_url;
   QString m_hash;

--- a/src/qtlibtorrent/qbtsession.h
+++ b/src/qtlibtorrent/qbtsession.h
@@ -175,6 +175,7 @@ public slots:
   void configureSession();
   void banIP(QString ip);
   void recursiveTorrentDownload(const QTorrentHandle &h);
+  void unhideMagnet(const QString &hash);
 
 private:
   QString getSavePath(const QString &hash, bool fromScanDir = false, QString filePath = QString::null);
@@ -224,6 +225,7 @@ signals:
   void alternativeSpeedsModeChanged(bool alternative);
   void recursiveTorrentDownloadPossible(const QTorrentHandle &h);
   void ipFilterParsed(bool error, int ruleCount);
+  void metadataReceivedHidden(const QTorrentHandle &h);
 
 private:
   // Bittorrent

--- a/src/torrentpersistentdata.h
+++ b/src/torrentpersistentdata.h
@@ -114,6 +114,37 @@ private:
   static QHash<QString, TorrentData> data;
 };
 
+class HiddenData {
+public:
+  static bool hasData(const QString &hash) {
+    return data.contains(hash);
+  }
+
+  static void deleteData(const QString &hash) {
+    data.remove(hash);
+  }
+
+  static void setAddInPause(const QString &hash, bool AddInPause) {
+    data[hash].AddInPause = AddInPause;
+  }
+
+  static bool getAddInPause(const QString &hash) {
+    return data.value(hash).AddInPause;
+  }
+
+  static int getSize() {
+    return data.size();
+  }
+
+private:
+  struct TorrentData {
+    TorrentData(): AddInPause(false) {}
+    bool AddInPause;
+  };
+
+  static QHash<QString, TorrentData> data;
+};
+
 class TorrentPersistentData {
 public:
   enum RatioLimit {


### PR DESCRIPTION
This is a "staging" branch. It will not be merged "as is"

I was trying to improve the magnet metadata loading in the AddNewTorrent Dialogm, but I have hit a hard wall. The ui freezes either on the "retrieving metadata..." stage or in the "metadata retrieval complete" stage. I tried to debug this but I cannot find where the freeze happens. I need more eyes on this.

Basically this patch should resolve most of #894 issues. This is the **ONLY** thing left for 3.1.0. It is a blocking bug. (all others will be moved for 3.1.1).
