### PR TITLE
Fix peers and seeds sorting in transfer list.

### DIFF
--- a/src/transferlistsortmodel.h
+++ b/src/transferlistsortmodel.h
@@ -66,6 +66,16 @@ protected:
       if (!vR.isValid()) return true;
 
       return vL < vR;
+    } else if (sortColumn() == TorrentModelItem::TR_PEERS || sortColumn() == TorrentModelItem::TR_SEEDS) {
+        int left_active = sourceModel()->data(left).toInt();
+        int left_total = sourceModel()->data(left, Qt::UserRole).toInt();
+        int right_active = sourceModel()->data(right).toInt();
+        int right_total = sourceModel()->data(right, Qt::UserRole).toInt();
+
+        // Active peers/seeds take precedence over total peers/seeds.
+        if (left_active == right_active)
+            return (left_total < right_total);
+        else return (left_active < right_active);
     }
     return QSortFilterProxyModel::lessThan(left, right);
   }


### PR DESCRIPTION
An image explains it better. Before:
![2014-01-18-113453_97x127_scrot](https://f.cloud.github.com/assets/236201/1946883/4da723b2-802f-11e3-8a40-4e1bd5f2b104.png)

After this patch:
![2014-01-18-115613_89x151_scrot](https://f.cloud.github.com/assets/236201/1946885/536d094c-802f-11e3-920c-7dc1e1aeb465.png)

When active peers (or seeds) of two torrents are the same we sort by total peers
(or seeds).
