### PR TITLE
Adds a label parameter to the autoexecute command.

### DIFF
--- a/src/preferences/options.ui
+++ b/src/preferences/options.ui
@@ -157,7 +157,7 @@
      </widget>
      <widget class="QStackedWidget" name="tabOption">
       <property name="currentIndex">
-       <number>0</number>
+       <number>1</number>
       </property>
       <widget class="QWidget" name="tabOptionPage1">
        <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -176,9 +176,9 @@
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>0</y>
-             <width>458</width>
-             <height>587</height>
+             <y>-302</y>
+             <width>486</width>
+             <height>668</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -515,9 +515,9 @@
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>0</y>
-             <width>458</width>
-             <height>905</height>
+             <y>-651</y>
+             <width>495</width>
+             <height>1020</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout">
@@ -1006,6 +1006,7 @@
 &lt;ul&gt;
 &lt;li&gt;%f: Torrent path&lt;/li&gt;
 &lt;li&gt;%n: Torrent name&lt;/li&gt;
+&lt;li&gt;%l: Torrent label&lt;/li&gt;
 &lt;/ul&gt;</string>
                  </property>
                  <property name="textFormat">
@@ -1033,9 +1034,9 @@
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>0</y>
-             <width>357</width>
-             <height>498</height>
+             <y>-205</y>
+             <width>486</width>
+             <height>563</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -1518,8 +1519,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>275</width>
-             <height>396</height>
+             <width>486</width>
+             <height>440</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_33">
@@ -1936,8 +1937,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>418</width>
-             <height>442</height>
+             <width>538</width>
+             <height>500</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -2350,8 +2351,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>330</width>
-             <height>480</height>
+             <width>486</width>
+             <height>533</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -2727,8 +2728,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>98</width>
-             <height>28</height>
+             <width>68</width>
+             <height>18</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_36"/>

--- a/src/qtlibtorrent/qbtsession.cpp
+++ b/src/qtlibtorrent/qbtsession.cpp
@@ -2098,15 +2098,20 @@ void QBtSession::autoRunExternalProgram(const QTorrentHandle &h, bool async) {
   if (!h.is_valid()) return;
   QString program = Preferences().getAutoRunProgram().trimmed();
   if (program.isEmpty()) return;
-  // Replace %f by torrent path
+
+  // Replace %f by torrent path.
   QString torrent_path;
   if (h.num_files() == 1)
     torrent_path = h.firstFileSavePath();
   else
     torrent_path = h.save_path();
   program.replace("%f", torrent_path);
-  // Replace %n by torrent name
+  // Replace %n by torrent name.
   program.replace("%n", h.name());
+  // Replace %l by torrent label.
+  program.replace("%l", TorrentPersistentData::getLabel(h.hash()));
+
+  // Spawn or start the process.
   QProcess *process = new QProcess;
   if (async) {
     connect(process, SIGNAL(finished(int)), this, SLOT(cleanUpAutoRunProcess(int)));


### PR DESCRIPTION
Screenshot:
![2014-01-19-135604_590x142_scrot](https://f.cloud.github.com/assets/236201/1949470/1a0500a8-8109-11e3-8179-1e3a81603dd7.png)

Inspired by https://github.com/qbittorrent/qBittorrent/issues/1291.
"%l" will be replaced by the torrent label.