### PR TITLE
Add an option to copy a torrent file.

### DIFF
--- a/src/transferlistwidget.h
+++ b/src/transferlistwidget.h
@@ -72,6 +72,7 @@ public slots:
   void topPrioSelectedTorrents();
   void bottomPrioSelectedTorrents();
   void copySelectedMagnetURIs() const;
+  void copySelectedTorrentFiles() const;
   void openSelectedTorrentsFolder() const;
   void recheckSelectedTorrents();
   void setDlLimitSelectedTorrents();


### PR DESCRIPTION
Add an action to the context menu of a torrent to copy its associated torrent
file (if exists) to a user-specified directory. Inspired by issue #1231.
