### PR TITLE
Fix issue with SSL under Win32

### DIFF
--- a/src/searchengine/nova/engines/btdigg.py
+++ b/src/searchengine/nova/engines/btdigg.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 
-#VERSION: 1.21
+#VERSION: 1.22
 #AUTHORS: BTDigg team (research@btdigg.org)
 #
 #                    GNU GENERAL PUBLIC LICENSE
@@ -23,6 +23,36 @@
 import urllib
 import urllib2
 import sys
+
+if sys.platform == 'win32':
+    import httplib
+    import socket
+    import ssl
+
+    class HTTPSConnection(httplib.HTTPConnection):
+        "This class allows communication via SSL."
+
+        default_port = httplib.HTTPS_PORT
+
+        def __init__(self, host, port=None, key_file=None, cert_file=None,
+                     strict=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
+                     source_address=None):
+            httplib.HTTPConnection.__init__(self, host, port, strict, timeout,
+                                    source_address)
+            self.key_file = key_file
+            self.cert_file = cert_file
+
+        def connect(self):
+            "Connect to a host on a given (SSL) port."
+
+            sock = socket.create_connection((self.host, self.port),
+                                            self.timeout, self.source_address)
+            if self._tunnel_host:
+                self.sock = sock
+                self._tunnel()
+            self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file, ssl_version=ssl.PROTOCOL_TLSv1)
+
+    httplib.HTTPSConnection =  HTTPSConnection
 
 from novaprinter import prettyPrinter
 


### PR DESCRIPTION
Python under Win32 seems to have issues with SSL/TLS versions.
Also need to add same fix for nova3 plugin (python 3.x)
