### PR TITLE
Fix lack of separator at the end of xdgDataHome on Linux.

### DIFF
--- a/src/fs_utils.cpp
+++ b/src/fs_utils.cpp
@@ -391,6 +391,10 @@ QString fsutils::QDesktopServicesDataLocation() {
     xdgDataHome = QDir::homePath() + QLatin1String("/.local/share");
   xdgDataHome += QLatin1String("/data/")
       + qApp->applicationName();
+
+  // Other functions expect this string to end with "/".
+  xdgDataHome += "/";
+
   return xdgDataHome;
 #endif
 #endif


### PR DESCRIPTION
Fixes #1095 support for Linux.
