### PR TITLE
Fix file associations creation on Windows.

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -305,7 +305,9 @@ MainWindow::MainWindow(QWidget *parent, const QStringList& torrentCmdLine) : QMa
 
   qDebug("GUI Built");
 #ifdef Q_WS_WIN
-  if (!pref.neverCheckFileAssoc() && (!Preferences::isTorrentFileAssocSet() || !Preferences::isMagnetLinkAssocSet())) {
+  if (!pref.neverCheckFileAssoc() &&
+      (!(Preferences::isTorrentFileAssocSet(false) || Preferences::isTorrentFileAssocSet()) ||
+       !(Preferences::isMagnetLinkAssocSet(false) || Preferences::isMagnetLinkAssocSet()))) {
     if (QMessageBox::question(0, tr("Torrent file association"),
                              tr("qBittorrent is not the default application to open torrent files or Magnet links.\nDo you want to associate qBittorrent to torrent files and Magnet links?"),
                              QMessageBox::Yes|QMessageBox::No, QMessageBox::Yes) == QMessageBox::Yes) {

--- a/src/preferences/options_imp.cpp
+++ b/src/preferences/options_imp.cpp
@@ -527,8 +527,26 @@ void options_imp::loadOptions() {
 #ifdef Q_WS_WIN
   checkStartup->setChecked(pref.Startup());
   // Windows: file association settings
-  checkAssociateTorrents->setChecked(Preferences::isTorrentFileAssocSet());
-  checkAssociateMagnetLinks->setChecked(Preferences::isMagnetLinkAssocSet());
+  // Check system settings, then user settings.
+  // We can edit only user settings.
+  if (Preferences::isTorrentFileAssocSet(false))
+  {
+    checkAssociateTorrents->setChecked(true);
+    checkAssociateTorrents->setEnabled(false);
+  }
+  else
+  {
+    checkAssociateTorrents->setChecked(Preferences::isTorrentFileAssocSet());
+  }
+  if (Preferences::isMagnetLinkAssocSet(false))
+  {
+    checkAssociateMagnetLinks->setChecked(true);
+    checkAssociateMagnetLinks->setEnabled(false);
+  }
+  else
+  {
+    checkAssociateMagnetLinks->setChecked(Preferences::isMagnetLinkAssocSet());
+  }
 #endif
   // End General preferences
   // Downloads preferences

--- a/src/preferences/preferences.h
+++ b/src/preferences/preferences.h
@@ -1207,8 +1207,12 @@ public:
     setValue(QString::fromUtf8("Preferences/Win32/NeverCheckFileAssocation"), check);
   }
 
-  static bool isTorrentFileAssocSet() {
-    QSettings settings("HKEY_CLASSES_ROOT", QIniSettings::NativeFormat);
+  static bool isTorrentFileAssocSet(bool userLevel = true) {
+    QString hive;
+    if (userLevel) hive = "HKEY_CURRENT_USER\\Software\\Classes";
+    else hive = "HKEY_CLASSES_ROOT";
+
+    QSettings settings(hive, QSettings::NativeFormat);
     if (settings.value(".torrent/Default").toString() != "qBittorrent") {
       qDebug(".torrent != qBittorrent");
       return false;
@@ -1231,8 +1235,12 @@ public:
     return true;
   }
 
-  static bool isMagnetLinkAssocSet() {
-    QSettings settings("HKEY_CLASSES_ROOT", QIniSettings::NativeFormat);
+  static bool isMagnetLinkAssocSet(bool userLevel = true) {
+    QString hive;
+    if (userLevel) hive = "HKEY_CURRENT_USER\\Software\\Classes";
+    else hive = "HKEY_CLASSES_ROOT";
+
+    QSettings settings(hive, QSettings::NativeFormat);
 
     // Check magnet link assoc
     QRegExp exe_reg("\"([^\"]+)\".*");
@@ -1247,7 +1255,7 @@ public:
   }
 
   static void setTorrentFileAssoc(bool set) {
-    QSettings settings("HKEY_CLASSES_ROOT", QSettings::NativeFormat);
+    QSettings settings("HKEY_CURRENT_USER\\Software\\Classes", QSettings::NativeFormat);
 
     // .Torrent association
     if (set) {
@@ -1271,7 +1279,7 @@ public:
   }
 
   static void setMagnetLinkAssoc(bool set) {
-    QSettings settings("HKEY_CLASSES_ROOT", QSettings::NativeFormat);
+    QSettings settings("HKEY_CURRENT_USER\\Software\\Classes", QSettings::NativeFormat);
 
     // Magnet association
     if (set) {


### PR DESCRIPTION
Now qBittorrent create file associations at user level (we cannot edit
system level settings in common case).
