### PR TITLE
Fix Windows file associations creation (old way)

### DIFF
--- a/src/preferences/preferences.h
+++ b/src/preferences/preferences.h
@@ -45,6 +45,10 @@
 #include <QCoreApplication>
 #endif
 
+#ifdef Q_OS_WIN
+#include <ShlObj.h>
+#endif
+
 #include "misc.h"
 #include "fs_utils.h"
 #include "qinisettings.h"
@@ -1204,91 +1208,66 @@ public:
   }
 
   static bool isTorrentFileAssocSet() {
-    QSettings settings("HKEY_CLASSES_ROOT", QIniSettings::NativeFormat);
-    if (settings.value(".torrent/Default").toString() != "qBittorrent") {
-      qDebug(".torrent != qBittorrent");
-      return false;
+      QSettings settings("HKEY_CURRENT_USER\\Software\\Classes", QSettings::NativeFormat);
+      if (settings.value(".torrent/Default").toString() != "qBittorrent") {
+        qDebug(".torrent != qBittorrent");
+        return false;
+      }
+
+      return true;
     }
-    qDebug("Checking shell command");
-    QString shell_command = fsutils::toNativePath(settings.value("qBittorrent/shell/open/command/Default", "").toString());
-    qDebug("Shell command is: %s", qPrintable(shell_command));
-    QRegExp exe_reg("\"([^\"]+)\".*");
-    if (exe_reg.indexIn(shell_command) < 0)
-      return false;
-    QString assoc_exe = exe_reg.cap(1);
-    qDebug("exe: %s", qPrintable(assoc_exe));
-    if (assoc_exe.compare(fsutils::toNativePath(qApp->applicationFilePath()), Qt::CaseInsensitive) != 0)
-      return false;
-    // Icon
-    const QString icon_str = "\""+fsutils::toNativePath(qApp->applicationFilePath())+"\",1";
-    if (settings.value("qBittorrent/DefaultIcon/Default", icon_str).toString().compare(icon_str, Qt::CaseInsensitive) != 0)
-      return false;
 
-    return true;
-  }
+    static bool isMagnetLinkAssocSet() {
+      QSettings settings("HKEY_CURRENT_USER\\Software\\Classes", QSettings::NativeFormat);
 
-  static bool isMagnetLinkAssocSet() {
-    QSettings settings("HKEY_CLASSES_ROOT", QIniSettings::NativeFormat);
-
-    // Check magnet link assoc
-    QRegExp exe_reg("\"([^\"]+)\".*");
-    QString shell_command = fsutils::toNativePath(settings.value("Magnet/shell/open/command/Default", "").toString());
-    if (exe_reg.indexIn(shell_command) < 0)
-      return false;
-    QString assoc_exe = exe_reg.cap(1);
-    qDebug("exe: %s", qPrintable(assoc_exe));
-    if (assoc_exe.compare(fsutils::toNativePath(qApp->applicationFilePath()), Qt::CaseInsensitive) != 0)
-      return false;
-    return true;
-  }
-
-  static void setTorrentFileAssoc(bool set) {
-    QSettings settings("HKEY_CLASSES_ROOT", QSettings::NativeFormat);
-
-    // .Torrent association
-    if (set) {
-      const QString command_str = "\""+qApp->applicationFilePath()+"\" \"%1\"";
-      const QString icon_str = "\""+qApp->applicationFilePath()+"\",1";
-
-      settings.setValue(".torrent/Default", "qBittorrent");
-      settings.setValue(".torrent/Content Type", "application/x-bittorrent");
-      settings.setValue("qBittorrent/shell/Default", "open");
-      settings.setValue("qBittorrent/shell/open/command/Default", fsutils::toNativePath(command_str));
-      settings.setValue("qBittorrent/Content Type/Default", "application/x-bittorrent");
-      settings.setValue("qBittorrent/DefaultIcon/Default", fsutils::toNativePath(icon_str));
-    } else if (isTorrentFileAssocSet()) {
-      settings.remove(".torrent/Default");
-      settings.remove(".torrent/Content Type");
-      settings.remove("qBittorrent/shell/Default");
-      settings.remove("qBittorrent/shell/open/command/Default");
-      settings.remove("qBittorrent/Content Type/Default");
-      settings.remove("qBittorrent/DefaultIcon/Default");
+      // Check magnet link assoc
+      QRegExp exe_reg("\"([^\"]+)\".*");
+      QString shell_command = fsutils::toNativePath(settings.value("magnet/shell/open/command/Default", "").toString());
+      if (exe_reg.indexIn(shell_command) < 0)
+        return false;
+      QString assoc_exe = exe_reg.cap(1);
+      qDebug("exe: %s", qPrintable(assoc_exe));
+      if (assoc_exe.compare(fsutils::toNativePath(qApp->applicationFilePath()), Qt::CaseInsensitive) != 0)
+        return false;
+      return true;
     }
-  }
 
-  static void setMagnetLinkAssoc(bool set) {
-    QSettings settings("HKEY_CLASSES_ROOT", QSettings::NativeFormat);
+    static void setTorrentFileAssoc(bool set) {
+      QSettings settings("HKEY_CURRENT_USER\\Software\\Classes", QSettings::NativeFormat);
 
-    // Magnet association
-    if (set) {
-      const QString command_str = "\""+qApp->applicationFilePath()+"\" \"%1\"";
-      const QString icon_str = "\""+qApp->applicationFilePath()+"\",1";
+      // .Torrent association
+      if (set) {
+        QString old_progid = settings.value(".torrent/Default").toString();
+        if (!old_progid.isEmpty() && (old_progid != "qBittorrent"))
+          settings.setValue(".torrent/OpenWithProgids/" + old_progid, "");
+        settings.setValue(".torrent/Default", "qBittorrent");
+      } else if (isTorrentFileAssocSet()) {
+        settings.setValue(".torrent/Default", "");
+      }
 
-      settings.setValue("Magnet/Default", "Magnet URI");
-      settings.setValue("Magnet/Content Type", "application/x-magnet");
-      settings.setValue("Magnet/URL Protocol", "");
-      settings.setValue("Magnet/DefaultIcon/Default", fsutils::toNativePath(icon_str));
-      settings.setValue("Magnet/shell/Default", "open");
-      settings.setValue("Magnet/shell/open/command/Default", fsutils::toNativePath(command_str));
-    } else if (isMagnetLinkAssocSet()) {
-      settings.remove("Magnet/Default");
-      settings.remove("Magnet/Content Type");
-      settings.remove("Magnet/URL Protocol");
-      settings.remove("Magnet/DefaultIcon/Default");
-      settings.remove("Magnet/shell/Default");
-      settings.remove("Magnet/shell/open/command/Default");
+      SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, 0, 0);
     }
-  }
+
+    static void setMagnetLinkAssoc(bool set) {
+      QSettings settings("HKEY_CURRENT_USER\\Software\\Classes", QSettings::NativeFormat);
+
+      // Magnet association
+      if (set) {
+        const QString command_str = "\""+qApp->applicationFilePath()+"\" \"%1\"";
+        const QString icon_str = "\""+qApp->applicationFilePath()+"\",1";
+
+        settings.setValue("magnet/Default", "URL:Magnet link");
+        settings.setValue("magnet/Content Type", "application/x-magnet");
+        settings.setValue("magnet/URL Protocol", "");
+        settings.setValue("magnet/DefaultIcon/Default", fsutils::toNativePath(icon_str));
+        settings.setValue("magnet/shell/Default", "open");
+        settings.setValue("magnet/shell/open/command/Default", fsutils::toNativePath(command_str));
+      } else if (isMagnetLinkAssocSet()) {
+        settings.remove("magnet");
+      }
+
+      SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, 0, 0);
+    }
 #endif
 
   bool isTrackerEnabled() const {

--- a/src/windows/installer.nsi
+++ b/src/windows/installer.nsi
@@ -60,21 +60,28 @@ Section $(inst_qbt_req) ;"qBittorrent (required)"
   File /oname=translations\qt_zh_TW.qm "translations\qt_zh_TW.qm" 
   
   ; Write the installation path into the registry  
-  WriteRegStr HKLM "Software\qbittorrent" "InstallLocation" "$INSTDIR"
+  WriteRegStr HKLM "Software\qBittorrent" "InstallLocation" "$INSTDIR"
   
   ; Write the uninstall keys for Windows
-  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qbittorrent" "DisplayName" "qBittorrent ${PROG_VERSION}"
-  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qbittorrent" "UninstallString" '"$INSTDIR\uninst.exe"'
-  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qbittorrent" "DisplayIcon" '"$INSTDIR\qbittorrent.exe",0'
-  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qbittorrent" "Publisher" "The qBittorrent project"
-  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qbittorrent" "URLInfoAbout" "http://www.qbittorrent.org"
-  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qbittorrent" "DisplayVersion" "${PROG_VERSION}"
-  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qbittorrent" "NoModify" 1
-  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qbittorrent" "NoRepair" 1
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qBittorrent" "DisplayName" "qBittorrent ${PROG_VERSION}"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qBittorrent" "UninstallString" '"$INSTDIR\uninst.exe"'
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qBittorrent" "DisplayIcon" '"$INSTDIR\qbittorrent.exe",0'
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qBittorrent" "Publisher" "The qBittorrent project"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qBittorrent" "URLInfoAbout" "http://www.qbittorrent.org"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qBittorrent" "DisplayVersion" "${PROG_VERSION}"
+  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qBittorrent" "NoModify" 1
+  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qBittorrent" "NoRepair" 1
   WriteUninstaller "uninst.exe"  
   ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
   IntFmt $0 "0x%08X" $0
-  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qbittorrent" "EstimatedSize" "$0"
+  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qBittorrent" "EstimatedSize" "$0"
+  
+  ; qBittorrent ProgID
+  WriteRegStr HKLM "Software\Classes\qBittorrent" "" "qBittorrent Torrent File"
+  WriteRegStr HKLM "Software\Classes\qBittorrent" "FriendlyTypeName" "qBittorrent Torrent File"
+  WriteRegStr HKLM "Software\Classes\qBittorrent\shell" "" "open"
+  WriteRegStr HKLM "Software\Classes\qBittorrent\shell\open\command" "" '"$INSTDIR\qbittorrent.exe" "%1"'
+  WriteRegStr HKLM "Software\Classes\qBittorrent\DefaultIcon" "" '"$INSTDIR\qbittorrent.exe",1'
   
 SectionEnd
 
@@ -90,32 +97,6 @@ Section $(inst_startmenu) ;"Create Start Menu Shortcut"
   CreateDirectory "$SMPROGRAMS\qBittorrent"  
   CreateShortCut "$SMPROGRAMS\qBittorrent\qBittorrent.lnk" "$INSTDIR\qbittorrent.exe"
   CreateShortCut "$SMPROGRAMS\qBittorrent\Uninstall.lnk" "$INSTDIR\uninst.exe"
-  
-SectionEnd
-
-Section $(inst_torrent) ;"Open .torrent files with qBittorrent"
-
-  WriteRegStr HKEY_CLASSES_ROOT ".torrent" "" "qBittorrent"
-  WriteRegStr HKEY_CLASSES_ROOT ".torrent" "Content Type" "application/x-bittorrent"
-  WriteRegStr HKEY_CLASSES_ROOT "qBittorrent\shell" "" "open"
-  WriteRegStr HKEY_CLASSES_ROOT "qBittorrent\shell\open\command" "" '"$INSTDIR\qbittorrent.exe" "%1"'
-  WriteRegStr HKEY_CLASSES_ROOT "qBittorrent\Content Type" "" "application/x-bittorrent"
-  WriteRegStr HKEY_CLASSES_ROOT "qBittorrent\DefaultIcon" "" '"$INSTDIR\qbittorrent.exe",1'
-  
-  System::Call 'Shell32::SHChangeNotify(i ${SHCNE_ASSOCCHANGED}, i ${SHCNF_IDLIST}, i 0, i 0)'
-  
-SectionEnd
-
-Section $(inst_magnet) ;"Open magnet links with qBittorrent"
-
-  WriteRegStr HKEY_CLASSES_ROOT "Magnet" "" "Magnet URI"
-  WriteRegStr HKEY_CLASSES_ROOT "Magnet" "Content Type" "application/x-magnet"
-  WriteRegStr HKEY_CLASSES_ROOT "Magnet" "URL Protocol" ""
-  WriteRegStr HKEY_CLASSES_ROOT "Magnet\DefaultIcon" "" '"$INSTDIR\qbittorrent.exe",1'
-  WriteRegStr HKEY_CLASSES_ROOT "Magnet\shell" "" "open"
-  WriteRegStr HKEY_CLASSES_ROOT "Magnet\shell\open\command" "" '"$INSTDIR\qbittorrent.exe" "%1"'
-  
-  System::Call 'Shell32::SHChangeNotify(i ${SHCNE_ASSOCCHANGED}, i ${SHCNF_IDLIST}, i 0, i 0)'
   
 SectionEnd
 

--- a/src/windows/uninstaller.nsi
+++ b/src/windows/uninstaller.nsi
@@ -49,35 +49,14 @@ Section "un.$(remove_shortcuts)" ;"un.Remove shortcuts"
   Delete "$DESKTOP\qBittorrent.lnk"
 SectionEnd
 
-Section "un.$(remove_associations)" ;"un.Remove file associations"
-  SectionIn RO
-  ReadRegStr $0 HKEY_CLASSES_ROOT ".torrent" ""
-  StrCmp $0 "qBittorrent" torrent 0
-  DetailPrint "$(uninst_tor_warn) $0"
-  Goto qbt
-  torrent:
-  DeleteRegKey HKEY_CLASSES_ROOT ".torrent"
-  
-  qbt:
-  DeleteRegKey HKEY_CLASSES_ROOT "qBittorrent"  
-  
-  ReadRegStr $0 HKEY_CLASSES_ROOT "Magnet\shell\open\command" ""
-  StrCmp $0 '"$INSTDIR\qbittorrent.exe" "%1"' magnet 0
-  DetailPrint "$(uninst_mag_warn) $0"
-  Goto done
-  
-  magnet:
-  DeleteRegKey HKEY_CLASSES_ROOT "Magnet"
-  
-  done:
-  System::Call 'Shell32::SHChangeNotify(i ${SHCNE_ASSOCCHANGED}, i ${SHCNF_IDLIST}, i 0, i 0)'
-SectionEnd
-
 Section "un.$(remove_registry)" ;"un.Remove registry keys" 
   SectionIn RO 
   ; Remove registry keys
-  DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qbittorrent"
-  DeleteRegKey HKLM "Software\qbittorrent"
+  DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qBittorrent"
+  DeleteRegKey HKLM "Software\qBittorrent"
+  DeleteRegKey HKLM "Software\Classes\qBittorrent"
+  
+  System::Call 'Shell32::SHChangeNotify(i ${SHCNE_ASSOCCHANGED}, i ${SHCNF_IDLIST}, i 0, i 0)'
 SectionEnd
 
 Section "un.$(remove_firewall)" ;


### PR DESCRIPTION
Now qBittorrent create global ProgId during installation (using HKLM hive)
and allow to associate .torrent files with it (using HKCU).
