### PR TITLE
Fix slow startup by adding torrents in the background

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -66,6 +66,8 @@ class QTabWidget;
 class QTimer;
 QT_END_NAMESPACE
 
+Q_DECLARE_METATYPE(QTorrentHandle);
+
 class MainWindow : public QMainWindow, private Ui::MainWindow{
   Q_OBJECT
 

--- a/src/qtlibtorrent/qbtsession.cpp
+++ b/src/qtlibtorrent/qbtsession.cpp
@@ -114,6 +114,7 @@ QBtSession::QBtSession()
   , m_upnp(0), m_natpmp(0)
   #endif
   , m_dynDNSUpdater(0)
+  , startupCount(0)
 {
   BigRatioTimer = new QTimer(this);
   BigRatioTimer->setInterval(10000);
@@ -2726,12 +2727,17 @@ void QBtSession::startUpTorrents() {
   QStringList filters;
   filters << "*.torrent";
   const QStringList torrents_on_hd = torrentBackup.entryList(filters, QDir::Files, QDir::Unsorted);
+  startupCount = torrents_on_hd.size();
   foreach (QString hash, torrents_on_hd) {
+    if (!startupCount)
+      break;
     hash.chop(8); // remove trailing .torrent
     if (!known_torrents.contains(hash)) {
       qDebug("found torrent with hash: %s on hard disk", qPrintable(hash));
       std::cerr << "ERROR Detected!!! Adding back torrent " << qPrintable(hash) << " which got lost for some reason." << std::endl;
       addTorrent(torrentBackup.path()+"/"+hash+".torrent", false, QString(), true);
+      //make the gui responsive while torrents are added
+      SleeperThread::msleep(1000);
     }
   }
   // End of safety measure
@@ -2745,7 +2751,10 @@ void QBtSession::startUpTorrents() {
     }
     qDebug("Priority_queue size: %ld", (long)torrent_queue.size());
     // Resume downloads
+    startupCount = torrent_queue.size();
     while(!torrent_queue.empty()) {
+      if (!startupCount)
+        break;
       const QString hash = torrent_queue.top().second;
       torrent_queue.pop();
       qDebug("Starting up torrent %s", qPrintable(hash));
@@ -2754,17 +2763,24 @@ void QBtSession::startUpTorrents() {
       } else {
         addTorrent(torrentBackup.path()+"/"+hash+".torrent", false, QString(), true);
       }
+      SleeperThread::msleep(1000);
     }
   } else {
     // Resume downloads
+    startupCount = known_torrents.size();
     foreach (const QString &hash, known_torrents) {
+      if (!startupCount)
+        break;
       qDebug("Starting up torrent %s", qPrintable(hash));
       if (TorrentPersistentData::isMagnet(hash))
         addMagnetUri(TorrentPersistentData::getMagnetUri(hash), true);
       else
         addTorrent(torrentBackup.path()+"/"+hash+".torrent", false, QString(), true);
+      SleeperThread::msleep(1000);
     }
   }
+  startupCount = 0;
+  emit updateNbTorrents();
   QIniSettings settings;
   settings.setValue("ported_to_new_savepath_system", true);
   qDebug("Unfinished torrents resumed");

--- a/src/qtlibtorrent/qbtsession.h
+++ b/src/qtlibtorrent/qbtsession.h
@@ -109,6 +109,7 @@ public:
   inline bool isQueueingEnabled() const { return queueingEnabled; }
   quint64 getAlltimeDL() const;
   quint64 getAlltimeUL() const;
+  int startupCount;
 
 public slots:
   QTorrentHandle addTorrent(QString path, bool fromScanDir = false, QString from_url = QString(), bool resumed = false);
@@ -229,6 +230,7 @@ signals:
   void recursiveTorrentDownloadPossible(const QTorrentHandle &h);
   void ipFilterParsed(bool error, int ruleCount);
   void metadataReceivedHidden(const QTorrentHandle &h);
+  void updateNbTorrents();
 
 private:
   // Bittorrent


### PR DESCRIPTION
because it allow using the program instantly (f.e. downloading new torrents) after its started
## adding my torrents hang the gui for 1 h without this patch

i have 7k torrents in my list (6k paused) because i use my torrent list as my library and backup (if i lose or delete a file i can download it again by starting the torrent)

adding my 7k torrents takes 1 h during which the qbittorrent.exe gui thread is hanged so I have to wait 1 h after i start qbittorrent before i can download new files
## gui should never hang

a gui should never **hang or semi-hang** because
- it prevent the user from using the gui for other tasks while the slow task complete

a gui should never **hang** because
- the user don't know if the user should wait for the program to respond or restart it
## patch

the latest patch is in https://github.com/john-peterson/qBittorrent/commits/start if u have > 1k torrents and qt start slowly
