### PR TITLE
fixing "Save path" column sorting so that it doesnt hang the gui

### DIFF
--- a/src/qtlibtorrent/torrentmodel.cpp
+++ b/src/qtlibtorrent/torrentmodel.cpp
@@ -257,7 +257,7 @@ QVariant TorrentModelItem::data(int column, int role) const
   case TR_TIME_ELAPSED:
     return (role == Qt::DisplayRole) ? m_lastStatus.active_time : m_lastStatus.seeding_time;
   case TR_SAVE_PATH:
-    return fsutils::toNativePath(m_torrent.save_path_parsed());
+    return fsutils::toNativePath(m_torrent.save_path());
   case TR_COMPLETED:
     return static_cast<qlonglong>(m_lastStatus.total_wanted_done);
   case TR_RATIO_LIMIT: {


### PR DESCRIPTION
## save_path_parsed is 100 times slower than save_path

### problem

the gui is unusable when sorted by save path (with my 7k torrents) because it decrease the gui input processing rate to around 1 time/minute (windows is "not responding" for 1 min)

### reason

the problem is probably that save_path_parsed is reading (what?) from disk or using an enormous amount of cpu

### result

the result is that i cant easily sort by path (to find files or move torrents)