### PR TITLE
adding a save resume data interval option

### DIFF
--- a/src/preferences/advancedsettings.h
+++ b/src/preferences/advancedsettings.h
@@ -13,7 +13,7 @@
 #include "preferences.h"
 
 enum AdvSettingsCols {PROPERTY, VALUE};
-enum AdvSettingsRows {DISK_CACHE, DISK_CACHE_TTL, OS_CACHE, OUTGOING_PORT_MIN, OUTGOING_PORT_MAX, IGNORE_LIMIT_LAN, RECHECK_COMPLETED, LIST_REFRESH, RESOLVE_COUNTRIES, RESOLVE_HOSTS, MAX_HALF_OPEN, SUPER_SEEDING, NETWORK_IFACE, NETWORK_LISTEN_IPV6, NETWORK_ADDRESS, PROGRAM_NOTIFICATIONS, TRACKER_STATUS, TRACKER_PORT,
+enum AdvSettingsRows {DISK_CACHE, DISK_CACHE_TTL, OS_CACHE, SAVE_RESUME_DATA_INTERVAL, OUTGOING_PORT_MIN, OUTGOING_PORT_MAX, IGNORE_LIMIT_LAN, RECHECK_COMPLETED, LIST_REFRESH, RESOLVE_COUNTRIES, RESOLVE_HOSTS, MAX_HALF_OPEN, SUPER_SEEDING, NETWORK_IFACE, NETWORK_LISTEN_IPV6, NETWORK_ADDRESS, PROGRAM_NOTIFICATIONS, TRACKER_STATUS, TRACKER_PORT,
                     #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
                       UPDATE_CHECK,
                     #endif
@@ -28,7 +28,7 @@ class AdvancedSettings: public QTableWidget {
   Q_OBJECT
 
 private:
-  QSpinBox spin_cache, outgoing_ports_min, outgoing_ports_max, spin_list_refresh, spin_maxhalfopen, spin_tracker_port;
+  QSpinBox spin_cache, spin_save_resume_data_interval, outgoing_ports_min, outgoing_ports_max, spin_list_refresh, spin_maxhalfopen, spin_tracker_port;
   QCheckBox cb_os_cache, cb_ignore_limits_lan, cb_recheck_completed, cb_resolve_countries, cb_resolve_hosts,
   cb_super_seeding, cb_program_notifications, cb_tracker_status, cb_confirm_torrent_deletion,
   cb_enable_tracker_ext, cb_listen_ipv6;
@@ -73,6 +73,8 @@ public slots:
     pref->setDiskCacheTTL(spin_cache_ttl.value());
     // Enable OS cache
     pref->setOsCache(cb_os_cache.isChecked());
+    // Save resume data interval
+    pref->setSaveResumeDataInterval(spin_save_resume_data_interval.value());
     // Outgoing ports
     pref->setOutgoingPortsMin(outgoing_ports_min.value());
     pref->setOutgoingPortsMax(outgoing_ports_max.value());
@@ -195,6 +197,12 @@ private slots:
     // Enable OS cache
     cb_os_cache.setChecked(pref->osCache());
     setRow(OS_CACHE, tr("Enable OS cache"), &cb_os_cache);
+    // Save resume data interval
+    spin_save_resume_data_interval.setMinimum(1);
+    spin_save_resume_data_interval.setMaximum(1440);
+    spin_save_resume_data_interval.setValue(pref->saveResumeDataInterval());
+    spin_save_resume_data_interval.setSuffix(tr(" m", " minutes"));
+    setRow(SAVE_RESUME_DATA_INTERVAL, tr("Save resume data interval"), &spin_save_resume_data_interval);
     // Outgoing port Min
     outgoing_ports_min.setMinimum(0);
     outgoing_ports_min.setMaximum(65535);

--- a/src/preferences/preferences.cpp
+++ b/src/preferences/preferences.cpp
@@ -1157,6 +1157,14 @@ void Preferences::setOsCache(bool enable) {
   setValue("Preferences/Advanced/osCache", enable);
 }
 
+uint Preferences::saveResumeDataInterval() const {
+  return value("Preferences/Downloads/SaveResumeDataInterval", 3).toUInt();
+}
+
+void Preferences::setSaveResumeDataInterval(uint m) {
+  setValue("Preferences/Downloads/SaveResumeDataInterval", m);
+}
+
 uint Preferences::outgoingPortsMin() const {
   return value("Preferences/Advanced/OutgoingPortsMin", 0).toUInt();
 }

--- a/src/preferences/preferences.h
+++ b/src/preferences/preferences.h
@@ -316,6 +316,8 @@ public:
   void setDiskCacheTTL(uint ttl);
   bool osCache() const;
   void setOsCache(bool enable);
+  uint saveResumeDataInterval() const;
+  void setSaveResumeDataInterval(uint m);
   uint outgoingPortsMin() const;
   void setOutgoingPortsMin(uint val);
   uint outgoingPortsMax() const;

--- a/src/qtlibtorrent/qbtsession.cpp
+++ b/src/qtlibtorrent/qbtsession.cpp
@@ -166,7 +166,7 @@ QBtSession::QBtSession()
   connect(downloader, SIGNAL(magnetRedirect(QString, QString)), SLOT(handleMagnetRedirect(QString, QString)));
   // Regular saving of fastresume data
   connect(&resumeDataTimer, SIGNAL(timeout()), SLOT(saveTempFastResumeData()));
-  resumeDataTimer.start(170000); // 3min
+  resumeDataTimer.start(pref->saveResumeDataInterval() * 60 * 1000);
   qDebug("* BTSession constructed");
 }
 
@@ -429,6 +429,7 @@ void QBtSession::configureSession() {
   session_settings::io_buffer_mode_t mode = pref->osCache() ? session_settings::enable_os_cache : session_settings::disable_os_cache;
   sessionSettings.disk_io_read_mode = mode;
   sessionSettings.disk_io_write_mode = mode;
+  resumeDataTimer.setInterval(pref->saveResumeDataInterval() * 60 * 1000);
   sessionSettings.anonymous_mode = pref->isAnonymousModeEnabled();
   if (sessionSettings.anonymous_mode) {
     addConsoleMessage(tr("Anonymous mode [ON]"), "blue");


### PR DESCRIPTION
because some SSD users oppose frequent disk writes
## don't be evil to an SSD

saving a session f.e. every 60 minutes rather than every 3 minutes is a 20 times longer SSD life span

i leave the default at 3 minutes though because if someone wanna kill their MLC flash in 3 years they're free to do so
