### PR TITLE
Partially revert 14310f9b0503d3dffa48bdb1bf9bdd5c754fa9d4

### DIFF
--- a/src/addnewtorrentdialog.cpp
+++ b/src/addnewtorrentdialog.cpp
@@ -560,7 +560,6 @@ void AddNewTorrentDialog::accept()
     // TODO: Check if destination actually exists
     TorrentTempData::setSeedingMode(m_hash, true);
   }
-  pref->addTorrentsInPause(!ui->start_torrent_cb->isChecked());
 
   // Label
   const QString label = ui->label_combo->currentText();
@@ -574,6 +573,8 @@ void AddNewTorrentDialog::accept()
   // Rename files if necessary
   if (m_hasRenamedFile)
     TorrentTempData::setFilesPath(m_hash, m_filesPath);
+
+  TorrentTempData::setAddPaused(m_hash, !ui->start_torrent_cb->isChecked());
 
   // Add torrent
   if (m_isMagnet)

--- a/src/torrentpersistentdata.cpp
+++ b/src/torrentpersistentdata.cpp
@@ -160,6 +160,14 @@ QString TorrentTempData::getQueuedPath(const QString &hash) {
   return i->queuedPath;
 }
 
+void TorrentTempData::setAddPaused(const QString &hash, const bool &paused) {
+  data[hash].add_paused = paused;
+}
+
+bool TorrentTempData::isAddPaused(const QString &hash) {
+  return data.value(hash).add_paused;
+}
+
 void HiddenData::addData(const QString &hash) {
   data[hash] = false;
 }

--- a/src/torrentpersistentdata.h
+++ b/src/torrentpersistentdata.h
@@ -34,6 +34,7 @@
 #include <QHash>
 #include <QStringList>
 #include <vector>
+#include "preferences.h"
 
 QT_BEGIN_NAMESPACE
 class QDateTime;
@@ -65,16 +66,19 @@ public:
   static QString getOldPath(const QString &hash);
   static QString getNewPath(const QString &hash);
   static QString getQueuedPath(const QString &hash);
+  static void setAddPaused(const QString &hash, const bool &paused);
+  static bool isAddPaused(const QString &hash);
 
 private:
   struct TorrentData {
-    TorrentData(): sequential(false), seed(false) {}
+    TorrentData(): sequential(false), seed(false), add_paused(Preferences::instance()->addTorrentsInPause()) {}
     std::vector<int> files_priority;
     QStringList path_list;
     QString save_path;
     QString label;
     bool sequential;
     bool seed;
+    bool add_paused;
   };
 
   struct TorrentMoveState {


### PR DESCRIPTION
Closes: #1315 - using "Start torrent" in Add torrent dialog overrides "Start paused" global option forever.
