### PR TITLE
fix import torrent

### DIFF
--- a/src/qtlibtorrent/qbtsession.cpp
+++ b/src/qtlibtorrent/qbtsession.cpp
@@ -1032,7 +1032,7 @@ QTorrentHandle QBtSession::addMagnetUri(QString magnet_uri, bool resumed, bool f
 }
 
 // Add a torrent to the Bittorrent session
-QTorrentHandle QBtSession::addTorrent(QString path, bool fromScanDir, QString from_url, bool resumed) {
+QTorrentHandle QBtSession::addTorrent(QString path, bool fromScanDir, QString from_url, bool resumed, bool imported) {
   QTorrentHandle h;
   Preferences pref;
 
@@ -1166,9 +1166,9 @@ QTorrentHandle QBtSession::addTorrent(QString path, bool fromScanDir, QString fr
     // Remember label
     TorrentTempData::setLabel(hash, savePath_label.second);
   } else {
-    savePath = getSavePath(hash, fromScanDir, path);
+    savePath = getSavePath(hash, fromScanDir, path, imported);
   }
-  if (!defaultTempPath.isEmpty() && !TorrentPersistentData::isSeed(hash)) {
+  if (!imported && !defaultTempPath.isEmpty() && !TorrentPersistentData::isSeed(hash)) {
     qDebug("addTorrent::Temp folder is enabled.");
     QString torrent_tmp_path = defaultTempPath.replace("\\", "/");
     p.save_path = torrent_tmp_path.toUtf8().constData();
@@ -2668,14 +2668,14 @@ session_status QBtSession::getSessionStatus() const {
   return s->status();
 }
 
-QString QBtSession::getSavePath(const QString &hash, bool fromScanDir, QString filePath) {
+QString QBtSession::getSavePath(const QString &hash, bool fromScanDir, QString filePath, bool imported) {
   QString savePath;
   if (TorrentTempData::hasTempData(hash)) {
     savePath = TorrentTempData::getSavePath(hash);
     if (savePath.isEmpty()) {
       savePath = defaultSavePath;
     }
-    if (appendLabelToSavePath) {
+    if (!imported && appendLabelToSavePath) {
       qDebug("appendLabelToSavePath is true");
       const QString label = TorrentTempData::getLabel(hash);
       if (!label.isEmpty()) {

--- a/src/qtlibtorrent/qbtsession.h
+++ b/src/qtlibtorrent/qbtsession.h
@@ -111,7 +111,7 @@ public:
   quint64 getAlltimeUL() const;
 
 public slots:
-  QTorrentHandle addTorrent(QString path, bool fromScanDir = false, QString from_url = QString(), bool resumed = false);
+  QTorrentHandle addTorrent(QString path, bool fromScanDir = false, QString from_url = QString(), bool resumed = false, bool imported = false);
   QTorrentHandle addMagnetUri(QString magnet_uri, bool resumed=false, bool fromScanDir=false, const QString &filePath=QString());
   void loadSessionState();
   void saveSessionState();
@@ -180,7 +180,7 @@ public slots:
   void unhideMagnet(const QString &hash);
 
 private:
-  QString getSavePath(const QString &hash, bool fromScanDir = false, QString filePath = QString::null);
+  QString getSavePath(const QString &hash, bool fromScanDir = false, QString filePath = QString::null, bool imported = false);
   bool loadFastResumeData(const QString &hash, std::vector<char> &buf);
   void loadTorrentSettings(QTorrentHandle &h);
   void loadTorrentTempData(QTorrentHandle &h, QString savePath, bool magnet);


### PR DESCRIPTION
When using "File->Import existing torrent...", it will fail if you have "Options->Downloads->Keep incomplete torrents in:" selected and you do not select "Skip the data checking stage and start seeding immediately".

Also, even if you import the torrent successfully by selecting to skip the data check, if you later select for a "Force Recheck", the recheck will fail (because qBittorrent thinks the file is located somewhere else) and qBittorrent will attempt to download the file again.

This may not be the most correct way to implement this fix (I didn't dig to thoroughly into the code), but it _does_ work.  Tested and it's what I'm currently running on my computer until this or an equivalent fix gets implemented. 

This should also at least partially solve #804
