### PR TITLE
make the gui responsive while moving torrents

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -346,6 +346,14 @@ void MainWindow::shutdownCleanUp() {
   setUnifiedTitleAndToolBarOnMac(false);
 #endif
   disconnect(tabs, SIGNAL(currentChanged(int)), this, SLOT(tab_changed(int)));
+
+  // Delete classes that can contain threads here
+  if (rssWidget)
+    delete rssWidget;
+  getTransferList()->m_running = false;
+  if (QThreadPool::globalInstance()->activeThreadCount())
+    QThreadPool::globalInstance()->waitForDone();
+
   // Delete other GUI objects
   if (executable_watcher)
     delete executable_watcher;
@@ -365,8 +373,6 @@ void MainWindow::shutdownCleanUp() {
     delete options;
   if (downloadFromURLDialog)
     delete downloadFromURLDialog;
-  if (rssWidget)
-    delete rssWidget;
   if (searchEngine)
     delete searchEngine;
   delete transferListFilters;

--- a/src/transferlistwidget.h
+++ b/src/transferlistwidget.h
@@ -33,6 +33,7 @@
 
 #include <QShortcut>
 #include <QTreeView>
+#include <QMutex>
 #include <libtorrent/version.hpp>
 #include "qtorrenthandle.h"
 #include "transferlistsortmodel.h"
@@ -56,6 +57,7 @@ public:
   TransferListWidget(QWidget *parent, MainWindow *main_window, QBtSession* BTSession);
   ~TransferListWidget();
   TorrentModel* getSourceModel() const;
+  bool m_running;
 
 public slots:
   void setSelectionLabel(QString label);
@@ -96,6 +98,7 @@ protected:
   void saveSettings();
   bool loadSettings();
   QStringList getSelectedTorrentsHashes() const;
+  void setSelectedTorrentsLocationDo(QStringList hashes, QDir savePath);
 
 protected slots:
   void torrentDoubleClicked(const QModelIndex& index);
@@ -122,6 +125,7 @@ private:
   MainWindow *main_window;
   QShortcut *editHotkey;
   QShortcut *deleteHotkey;
+  QMutex sstl_mutex;
 };
 
 #endif // TRANSFERLISTWIDGET_H


### PR DESCRIPTION
## because moving torrents freeze the GUI for a long time

make the gui responsive while moving torrents because
- moving many (1000) torrents freeze the GUI for a long time (around 1 h)
## test
### my test

i moved 5000 of 10000 torrents in 1 operation and after the GUI and WUI hanged for 1 h (qbittorrent.exe CPU load around 14% on a 8 thread 3770) i killed qbittorrent.exe and created this patch

the 5000 torrents are only non-existing files (they don't schedule a HDD move operation)
### moving existing files should also be tested

a move operation that move many torrents with existing files (that schedule a HDD move operation) should also be tested to make sure it doesn't lock the GUI
