### PR TITLE
fix exception in PropertiesWidget

### DIFF
--- a/src/properties/propertieswidget.cpp
+++ b/src/properties/propertieswidget.cpp
@@ -337,7 +337,7 @@ void PropertiesWidget::loadDynamicData() {
       // Update ratio info
       const qreal ratio = QBtSession::instance()->getRealRatio(h.hash());
       shareRatio->setText(ratio > QBtSession::MAX_RATIO ? QString::fromUtf8("∞") : misc::accurateDoubleToString(ratio, 2));
-      if (!h.is_seed()) {
+      if (!h.is_seed() && h.has_metadata()) {
         showPiecesDownloaded(true);
         // Downloaded pieces
 #if LIBTORRENT_VERSION_NUM < 10000
@@ -348,7 +348,7 @@ void PropertiesWidget::loadDynamicData() {
         h.downloading_pieces(bf);
         downloaded_pieces->setProgress(h.pieces(), bf);
         // Pieces availability
-        if (h.has_metadata() && !h.is_paused() && !h.is_queued() && !h.is_checking()) {
+        if (!h.is_paused() && !h.is_queued() && !h.is_checking()) {
           showPiecesAvailability(true);
           std::vector<int> avail;
           h.piece_availability(avail);


### PR DESCRIPTION
Caught exception in PropertiesWidget::loadDynamicData():  invalid
torrent handle used

This exception occurs when an user clicks on torrent that doesn't have
metadata (when magnet link is not resolved yet).

One should not call torrent_handle::get_torrent_info when torrent
doesn't have a metadata.
