### PR TITLE
Fix building with Qt5 (missing QObject decl).

### DIFF
--- a/src/qtlibtorrent/torrentspeedmonitor.h
+++ b/src/qtlibtorrent/torrentspeedmonitor.h
@@ -31,6 +31,7 @@
 #ifndef TORRENTSPEEDMONITOR_H
 #define TORRENTSPEEDMONITOR_H
 
+#include <QObject>
 #include <QString>
 #include <QHash>
 #include "qtorrenthandle.h"


### PR DESCRIPTION
Since qBittorrent now compatible with Qt5, ask to check for newer commits such compatibility.
