### PR TITLE
Speedup and fix a bug in torrent moving.

### DIFF
--- a/src/qtlibtorrent/qbtsession.h
+++ b/src/qtlibtorrent/qbtsession.h
@@ -200,6 +200,7 @@ private:
   void handleFileRenamedAlert(libtorrent::file_renamed_alert* p);
   void handleTorrentDeletedAlert(libtorrent::torrent_deleted_alert* p);
   void handleStorageMovedAlert(libtorrent::storage_moved_alert* p);
+  void handleStorageMovedFailedAlert(libtorrent::storage_moved_failed_alert* p);
   void handleMetadataReceivedAlert(libtorrent::metadata_received_alert* p);
   void handleFileErrorAlert(libtorrent::file_error_alert* p);
   void handleFileCompletedAlert(libtorrent::file_completed_alert* p);


### PR DESCRIPTION
This commit implements a map where qbittorrent store a state of
current torrent movings. This commit speed up
torrents moving a bit and also fix a bug when qbittorrent doesn't do
cleanup action when a single torrent is moved several times without
waiting for a previous move to complete.

How it worked before.

Libtorrent has a function torrent_handle::move_storage() that allows to move a
torrent to a specific directory. This function is asynchorous. It means that
this function quits instantaneously and when the actual operation
completes the alert 'storage_moved_alert' or
'storage_moved_failed_alert' will be sent. The storage_moved_alert contains a
torrent_handle and a new path to where the torrent is moved.

During handling of storage_moved_alert, qbittorrent needs not only new path,
but also an old path to perform some of cleanup actions (like removing an old
folder if it is empty). This was achieved by storing a value named
'previous save path' in TorrentPersistentData. A previous save path is
written when move_storage() is issued and is read when
storage_moved_alert is received.

Problems.

This mechanism has two negative aspects:
1. TorrentPersistentData is very slow. As torrent_handle::move_storage() is asynchoronous,
   TorrentPersistentData is responsible for more that 99.8% of time
   QTorrentHandle::move_storage(). This percent could be higher when there
   are lots of torrents and lower when there are few of them.
2. TorrentPersistentData stores only one previous path. But many
   move_storage()'s could be issued without waiting for previous to
   complete. Subsequent move_storage()'s overwrites previous save path of a
   previous move.

A fix.

The fix is simple. Before issueing move_storage() the oldPath is stored in
a special map called 'torrentMoveStates'. When a storage_moved_alert
is received the map is consulted and an alert is handled.

When user moves torrent when previous moving have not yet finished, the
new location is saved in a field 'latchedPath' the same map. When
torrent moving is completed (or failed) qbittorrent attemps to perform
move again to the latched location.

Future direction.

This fix removes one slow read and one slow write to
TorrentPersistentData on torrent moving, but there is still exists
TorrentPersistentData::saveSavePath in handleStorageMovedAlert(), so
overall time for UI hang should be reduced only threefold. A speeding up
TorrentPersistentData should be addressed in a separate commit.
