### PR TITLE
Fix Help menu links in WebUI

### DIFF
--- a/src/webui/html/index.html
+++ b/src/webui/html/index.html
@@ -61,7 +61,7 @@
 						<a class="returnFalse">_(&Help)</a>
 						<ul>
 							<li><a id="bugLink" target="_blank" href="http://bugs.qbittorrent.org/"><img class="MyMenuIcon" src="theme/tools-report-bug" width="16" height="16" onload="fixPNG(this)"/>_(Report a &bug)</a></li>
-							<li><a id="siteLink"><img class="MyMenuIcon" src="images/skin/qbittorrent16.png" width="16" height="16" onload="fixPNG(this)"/>_(Visit &Website)</a></li>
+							<li><a id="siteLink" target="_blank" href="http://www.qbittorrent.org/"><img class="MyMenuIcon" src="images/skin/qbittorrent16.png" width="16" height="16" onload="fixPNG(this)"/>_(Visit &Website)</a></li>
 							<li><a id="docsLink" target="_blank" href="http://wiki.qbittorrent.org/"><img class="MyMenuIcon" src="theme/help-contents" width="16" height="16" onload="fixPNG(this)"/>_(&Documentation)</a></li>
 							<li><a id="aboutLink"><img class="MyMenuIcon" src="theme/help-about" width="16" height="16" onload="fixPNG(this)"/>_(&About)</a></li>
 						</ul>

--- a/src/webui/scripts/mocha-init.js
+++ b/src/webui/scripts/mocha-init.js
@@ -234,18 +234,6 @@ initializeWindows = function(){
 		}
 	}
 
-	addClickEvent('site', function(e){
-		new Event(e).stop();
-		new MochaUI.Window({
-			id: 'sitePage',
-			title: 'qBittorrent Website',
-			loadMethod: 'iframe',
-			contentURL: 'http://www.qbittorrent.org/',
-			width: 650,
-			height: 400
-		});
-	});
-
 	addClickEvent('about', function(e){
 		new Event(e).stop();
 		new MochaUI.Window({


### PR DESCRIPTION
Safer commits that shouldn't pose risk to the release of qBt 3.1.10. Simply cleans up the `Help` menu links in the webui, fixing qBittorrent/qBittorrent#1343
