### PR TITLE
add host address parameter to helo smtp request

### DIFF
--- a/src/smtp.h
+++ b/src/smtp.h
@@ -64,6 +64,7 @@ private slots:
 private:
   QByteArray encode_mime_header(const QString& key, const QString& value, QTextCodec* latin1, const QByteArray& prefix=QByteArray());
   void ehlo();
+  void helo();
   void parseEhloResponse(const QByteArray& code, bool continued, const QString& line);
   void authenticate();
   void startTLS();


### PR DESCRIPTION
I added the address of the host to helo request. It should help i think. But in my opinion problem is deeper in smtp state machine. Should not we use the results of the ehlo request?
