### PR TITLE
Correctly detect python in PATH

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1331,7 +1331,7 @@ void MainWindow::on_actionSearch_engine_triggered() {
     bool res = false;
 
     // Check if python is already in PATH
-    if (misc::pythonVersion())
+    if (misc::pythonVersion() > 0)
       res = true;
     else
       res = addPythonPathToEnv();


### PR DESCRIPTION
misc::pythonVersion() was used in the UPDATE_URL string setup before the python path was correctly detected and this cause the URL to contain "nova" instead of "nova3" even if (only) python 3.x is installed in the system.
On top of this the check to see if python is already in PATH erroneously succeed if python is not found (misc::pythonVersion() returns -1 which is seen as true).
