### PR TITLE
Fix heap-buffer-overrun in PropertiesWidget::displayFilesListMenu

### DIFF
--- a/src/properties/propertieswidget.cpp
+++ b/src/properties/propertieswidget.cpp
@@ -468,8 +468,10 @@ void PropertiesWidget::openFolder(const QModelIndex &index, bool containing_fold
 void PropertiesWidget::displayFilesListMenu(const QPoint&) {
   if (!h.is_valid())
     return;
-  QMenu myFilesLlistMenu;
   QModelIndexList selectedRows = filesList->selectionModel()->selectedRows(0);
+  if (selectedRows.empty())
+    return;
+  QMenu myFilesLlistMenu;
   QAction *actOpen = 0;
   QAction *actOpenContainingFolder = 0;
   QAction *actRename = 0;


### PR DESCRIPTION
This is a fix for #1978.
