### PR TITLE
Increase maximum size of system icons

### DIFF
--- a/src/iconprovider.cpp
+++ b/src/iconprovider.cpp
@@ -86,7 +86,7 @@ QIcon IconProvider::generateDifferentSizes(const QIcon& icon)
 {
   QIcon new_icon;
   QList<QSize> required_sizes;
-  required_sizes << QSize(16, 16) << QSize(24, 24);
+  required_sizes << QSize(16, 16) << QSize(24, 24) << QSize(32, 32);
   QList<QIcon::Mode> modes;
   modes << QIcon::Normal << QIcon::Active << QIcon::Selected << QIcon::Disabled;
   foreach (const QSize& size, required_sizes) {


### PR DESCRIPTION
System icons were limited to a size 24x24 pixels, while the embedded
icons are 32x32 pixels big.
