### PR TITLE
Set minimum width of the left panel in the preferences

### DIFF
--- a/src/preferences/options.ui
+++ b/src/preferences/options.ui
@@ -32,6 +32,12 @@
         <verstretch>0</verstretch>
        </sizepolicy>
       </property>
+      <property name="minimumSize">
+       <size>
+        <width>116</width>
+        <height>0</height>
+       </size>
+      </property>
       <property name="frameShape">
        <enum>QFrame::StyledPanel</enum>
       </property>

--- a/src/preferences/options_imp.cpp
+++ b/src/preferences/options_imp.cpp
@@ -310,8 +310,8 @@ void options_imp::loadWindowState() {
     sizes << sizes_str.first().toInt();
     sizes << sizes_str.last().toInt();
   } else {
-    sizes << 130;
-    sizes << hsplitter->width()-130;
+    sizes << 116;
+    sizes << hsplitter->width()-116;
   }
   hsplitter->setSizes(sizes);
 }


### PR DESCRIPTION
Change also the default width and set it to the minimum.
This minimum width prevents the horizontal scrollbar from appearing.

The size of the items in the list depends on the Qt style, so the
left panel could be few pixels larger than required with some of them.
