### PR TITLE
Don't stretch the last section in the transfer list

### DIFF
--- a/src/transferlistwidget.cpp
+++ b/src/transferlistwidget.cpp
@@ -111,6 +111,7 @@ TransferListWidget::TransferListWidget(QWidget *parent, MainWindow *main_window,
 #if defined(Q_OS_MAC)
   setAttribute(Qt::WA_MacShowFocusRect, false);
 #endif
+  header()->setStretchLastSection(false);
 
   // Default hidden columns
   if (!column_loaded) {


### PR DESCRIPTION
Since the content of some sections is right aligned, automatically
resizing the width of the last one to fill the header could be
sometimes undesired.

Let the user choose the width of each section and never change his
preference.

Issue #2032
