### PR TITLE
WebUI: Set correct HTTP Content-Type in case of forbidden access

### DIFF
--- a/src/webui/httpconnection.cpp
+++ b/src/webui/httpconnection.cpp
@@ -193,6 +193,7 @@ void HttpConnection::respond() {
     if (nb_fail >= MAX_AUTH_FAILED_ATTEMPTS) {
       m_generator.setStatusLine(403, "Forbidden");
       m_generator.setMessage(tr("Your IP address has been banned after too many failed authentication attempts."));
+      m_generator.setContentType("text/plain; charset=utf-8");
       m_generator.setContentEncoding(m_parser.acceptsEncoding());
       write();
       return;


### PR DESCRIPTION
The error message is an utf-8 string. With no charset specified,
web browsers will likely use the wrong one making reading the message
in some languages impossibile.
