### PR TITLE
Cleanup torrent model item

### DIFF
--- a/src/qtlibtorrent/torrentmodel.cpp
+++ b/src/qtlibtorrent/torrentmodel.cpp
@@ -504,7 +504,7 @@ TorrentStatusReport TorrentModel::getTorrentStatusReport() const
   QList<TorrentModelItem*>::const_iterator it = m_torrents.constBegin();
   QList<TorrentModelItem*>::const_iterator itend = m_torrents.constEnd();
   for ( ; it != itend; ++it) {
-    switch((*it)->data(TorrentModelItem::TR_STATUS).toInt()) {
+    switch((*it)->state()) {
     case TorrentModelItem::STATE_DOWNLOADING:
       ++report.nb_active;
       ++report.nb_downloading;

--- a/src/qtlibtorrent/torrentmodel.h
+++ b/src/qtlibtorrent/torrentmodel.h
@@ -58,6 +58,7 @@ public:
   QVariant data(int column, int role = Qt::DisplayRole) const;
   bool setData(int column, const QVariant &value, int role = Qt::DisplayRole);
   inline QString hash() const { return m_hash; }
+  State state() const;
 
 signals:
   void labelChanged(QString previous, QString current);
@@ -65,7 +66,6 @@ signals:
 private:
   static QIcon getIconByState(State state);
   static QColor getColorByState(State state);
-  State state() const;
 
 private:
   QTorrentHandle m_torrent;


### PR DESCRIPTION
This patch is doing 2 things.

First. Currently torrent model item has two mutable members: icon and color. They are changed when status() is queried. If status() is not queried they are not changed. This is bad that content of one column depends on querying of other column.

Second. QColor was created by string. This is not very slow, but slower than creating it by Qt::GlobalColor. I used Qt::GlobalColor. The only problem is that orange is not present in GlobalColor, so I just used it's RGB values.
