### PR TITLE
Fix a memleak in torrentmodel.

### DIFF
--- a/src/qtlibtorrent/torrentmodel.cpp
+++ b/src/qtlibtorrent/torrentmodel.cpp
@@ -408,6 +408,7 @@ void TorrentModel::removeTorrent(const QString &hash)
   qDebug() << Q_FUNC_INFO << hash << row;
   if (row >= 0) {
     beginRemoveTorrent(row);
+    delete m_torrents[row];
     m_torrents.removeAt(row);
     endRemoveTorrent();
   }


### PR DESCRIPTION
Perhaps we should finally move to C++11 and std::unique_ptr?
