### PR TITLE
Fix eye-gouging green in TorrentModel

### DIFF
--- a/src/qtlibtorrent/torrentmodel.cpp
+++ b/src/qtlibtorrent/torrentmodel.cpp
@@ -169,7 +169,7 @@ QColor TorrentModelItem::getColorByState(State state) {
   switch (state) {
   case STATE_DOWNLOADING:
   case STATE_DOWNLOADING_META:
-    return QColor(Qt::green);
+    return QColor(Qt::darkGreen);
   case STATE_ALLOCATING:
   case STATE_STALLED_DL:
   case STATE_STALLED_UP:


### PR DESCRIPTION
Commit ad116edac74587ccca88cb64afa445b8ce87f6d7 introduced a unintendent
change. The active torrents are shown with color (0, 255, 0) now,
instead of (0, 128, 0).

QColor("green")        is (0, 128, 0)
QColor(Qt::green)      is (0, 255, 0)
QColor(Qt::darkGreen)  is (0, 128, 0)

This commit replaces Qt::green with Qt::darkGreen.

For references see qcolor.cpp and qcolor_p.cpp.
