### PR TITLE
WebUI: Don't empty transfer list before updating it

### DIFF
--- a/src/webui/www/public/scripts/dynamicTable.js
+++ b/src/webui/www/public/scripts/dynamicTable.js
@@ -126,7 +126,6 @@ var dynamicTable = new Class	({
 	updateSort: function() {
 		var trs = this.table.getChildren('tr');
 		trs.sort(this.sortfunction);
-		this.table.set('html', '');
 		this.table.adopt(trs);
 	},
 	


### PR DESCRIPTION
This causes the list from disappearing in IE 10.
No longer needed table rows are deleted anyway.
