### PR TITLE
WebUI: Allow to retrieve web API version and qBT version

### DIFF
--- a/src/webui/requesthandler.cpp
+++ b/src/webui/requesthandler.cpp
@@ -108,6 +108,7 @@ QMap<QString, QMap<QString, RequestHandler::Action> > RequestHandler::initialize
     ADD_ACTION(command, recheck);
     ADD_ACTION(version, api);
     ADD_ACTION(version, api_min);
+    ADD_ACTION(version, qbittorrent);
 
     return actions;
 }
@@ -223,6 +224,11 @@ void RequestHandler::action_version_api()
 void RequestHandler::action_version_api_min()
 {
     print(QString::number(API_VERSION_MIN), CONTENT_TYPE_TXT);
+}
+
+void RequestHandler::action_version_qbittorrent()
+{
+    print(QString(VERSION), CONTENT_TYPE_TXT);
 }
 
 void RequestHandler::action_command_shutdown()

--- a/src/webui/requesthandler.h
+++ b/src/webui/requesthandler.h
@@ -83,6 +83,7 @@ private:
     void action_command_recheck();
     void action_version_api();
     void action_version_api_min();
+    void action_version_qbittorrent();
 
     typedef void (RequestHandler::*Action)();
 


### PR DESCRIPTION
- Assign a version to the current web API.
- Add a new GET method to retrieve the current API version and the minium API version supported.
- Allow to retrieve the version of qBittorrent
