### PR TITLE
Fix configure script when running with dash

### DIFF
--- a/configure
+++ b/configure
@@ -4080,7 +4080,6 @@ fi
 
 
 
-
 # Define --wth-* and --enable-* arguments
 
 
@@ -4137,7 +4136,7 @@ fi
 # Detect OS
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OS is FreeBSD" >&5
 $as_echo_n "checking whether OS is FreeBSD... " >&6; }
-if test "x$host_os" == "x*freebsd*"; then :
+if test "x$host_os" = "x*freebsd*"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
       LIBS="-lexecinfo $LIBS"
@@ -4267,7 +4266,7 @@ $as_echo "no" >&6; }
 		PKG_CONFIG=""
 	fi
 fi
-if test "x$PKG_CONFIG" == "x"; then :
+if test "x$PKG_CONFIG" = "x"; then :
   as_fn_error $? "Could not find pkg-config" "$LINENO" 5
 fi
 
@@ -4484,7 +4483,7 @@ fi
 $as_echo "$with_qt5" >&6; }
         as_fn_error $? "Unknown option \"$with_qt5\". Use either \"yes\" or \"no\"." "$LINENO" 5 ;;
 esac
-if test "x$QT_QMAKE" == "x"; then :
+if test "x$QT_QMAKE" = "x"; then :
   as_fn_error $? "Could not find qmake" "$LINENO" 5
 
 fi
@@ -4533,7 +4532,7 @@ fi
 
 fi
 
-               if test "x$HAVE_QTDBUS" == "xfalse"; then :
+               if test "x$HAVE_QTDBUS" = "xfalse"; then :
   as_fn_error $? "Could not find QtDBus" "$LINENO" 5
 else
   QBT_ADD_CONFIG="$QBT_ADD_CONFIG dbus"
@@ -4829,13 +4828,13 @@ fi
 
 # HAVE_BOOST is set to an empty value when Boost is found. I don't know
 # how to test for a set vs unset variable.
-if test "x$BOOST_CPPFLAGS" == "x"; then :
+if test "x$BOOST_CPPFLAGS" = "x"; then :
   as_fn_error $? "Could not find Boost" "$LINENO" 5
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: Boost CPPFLGAS: $BOOST_CPPFLAGS" >&5
 $as_echo "$as_me: Boost CPPFLGAS: $BOOST_CPPFLAGS" >&6;}
-	  CPPFLAGS="$BOOST_CPPFLAGS $CPPFLAGS"
-	  LDFLAGS="$BOOST_LDFLAGS $LDFLAGS"
+      CPPFLAGS="$BOOST_CPPFLAGS $CPPFLAGS"
+      LDFLAGS="$BOOST_LDFLAGS $LDFLAGS"
 fi
 
 
@@ -5081,12 +5080,12 @@ fi
 
 # HAVE_BOOST_SYSTEM is set to an empty value when Boost.System is found.
 # I don't know how to test for a set vs unset variable.
-if test "x$BOOST_SYSTEM_LIB" == "x"; then :
+if test "x$BOOST_SYSTEM_LIB" = "x"; then :
   as_fn_error $? "Could not find Boost.System" "$LINENO" 5
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: Boost.System LIB: $BOOST_SYSTEM_LIB" >&5
 $as_echo "$as_me: Boost.System LIB: $BOOST_SYSTEM_LIB" >&6;}
-	  LIBS="$BOOST_SYSTEM_LIB $LIBS"
+      LIBS="$BOOST_SYSTEM_LIB $LIBS"
 fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to embed the GeoIP database" >&5
@@ -6704,7 +6703,7 @@ $QT_QMAKE $CONFDIR/qbittorrent.pro
 ret="$?"
 
 $as_echo
-if test "x$ret" == "x0"; then :
+if test "x$ret" = "x0"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: Good, your configure finished." >&5
 $as_echo "$as_me: Good, your configure finished." >&6;}
 else

--- a/configure.ac
+++ b/configure.ac
@@ -16,31 +16,31 @@ AC_ARG_WITH(qt5,
                             [Compile using Qt5 (default=no)])],
             [],
             [with_qt5=no])
-            
+
 AC_ARG_WITH(geoip-database-embedded,
             [AS_HELP_STRING([--with-geoip-database-embedded],
                             [Embed the GeoIP database in the qBittorrent executable (please follow instructions in src/geoip/README) (default=no)])],
             [],
             [with_geoip_database_embedded=no])
-            
+
 AC_ARG_WITH(qtsingleapplication,
             [AS_HELP_STRING([--with-qtsingleapplication=@<:@system|shipped@:>@],
                             [Use the shipped qtsingleapplication library or the system one (default=shipped)])],
             [],
             [with_qtsingleapplication=shipped])
-             
+
 AC_ARG_ENABLE(debug,
               [AS_HELP_STRING([--enable-debug],
                               [Enable debug build])],
               [],
               [enable_debug=no])
-              
+
 AC_ARG_ENABLE(gui,
               [AS_HELP_STRING([--disable-gui],
                               [Disable the GUI for headless running. Disables QtDBus and the GeoIP Database.])],
               [],
               [enable_gui=yes])
-              
+
 AC_ARG_ENABLE(qt-dbus,
               [AS_HELP_STRING([--disable-qt-dbus],
                               [Disable use of QtDBus (GUI only)])],
@@ -49,19 +49,19 @@ AC_ARG_ENABLE(qt-dbus,
 
 # Detect OS
 AC_MSG_CHECKING([whether OS is FreeBSD])
-AS_IF([test "x$host_os" == "x*freebsd*"],
+AS_IF([test "x$host_os" = "x*freebsd*"],
       [AC_MSG_RESULT([yes])
       LIBS="-lexecinfo $LIBS"],
       [AC_MSG_RESULT([no])])
 
 # Require 0.26 pkg-config
 PKG_PROG_PKG_CONFIG([0.26])
-AS_IF([test "x$PKG_CONFIG" == "x"],
+AS_IF([test "x$PKG_CONFIG" = "x"],
       [AC_MSG_ERROR([Could not find pkg-config])])
 
 # Check which arguments were set and act accordingly
 AC_MSG_CHECKING([whether to enable the Debug build])
-AS_CASE(["x$enable_debug"],        
+AS_CASE(["x$enable_debug"],
         ["xno"],
               [AC_MSG_RESULT([no])
               QBT_ADD_CONFIG="$QBT_ADD_CONFIG release"
@@ -72,7 +72,7 @@ AS_CASE(["x$enable_debug"],
                QBT_REMOVE_CONFIG="$QBT_REMOVE_CONFIG release"],
         [AC_MSG_RESULT([$enable_debug])
         AC_MSG_ERROR([Unknown option "$enable_debug". Use either "yes" or "no".])])
-      
+
 AC_MSG_CHECKING([whether to enable the GUI])
 AS_CASE(["x$enable_gui"],
         ["xyes"],
@@ -82,7 +82,7 @@ AS_CASE(["x$enable_gui"],
               [AC_MSG_RESULT([no])
               enable_qt_dbus=[no]
               enable_geoip_database=[no]
-              QBT_ADD_CONFIG="$QBT_ADD_CONFIG nox"],        
+              QBT_ADD_CONFIG="$QBT_ADD_CONFIG nox"],
         [AC_MSG_RESULT([$enable_gui])
         AC_MSG_ERROR([Unknown option "$enable_gui". Use either "yes" or "no".])])
 
@@ -96,16 +96,16 @@ AS_CASE(["x$with_qt5"],
                FIND_QT5()],
         [AC_MSG_RESULT([$with_qt5])
         AC_MSG_ERROR([Unknown option "$with_qt5". Use either "yes" or "no".])])
-AS_IF([test "x$QT_QMAKE" == "x"],
+AS_IF([test "x$QT_QMAKE" = "x"],
       [AC_MSG_ERROR([Could not find qmake])
       ])
-      
+
 AC_MSG_CHECKING([whether QtDBus should be enabled])
 AS_CASE(["x$enable_qt_dbus"],
         ["xyes"],
                [AC_MSG_RESULT([yes])
                FIND_QTDBUS()
-               AS_IF([test "x$HAVE_QTDBUS" == "xfalse"],
+               AS_IF([test "x$HAVE_QTDBUS" = "xfalse"],
                      [AC_MSG_ERROR([Could not find QtDBus])],
                      [QBT_ADD_CONFIG="$QBT_ADD_CONFIG dbus"]
                     )],
@@ -115,23 +115,23 @@ AS_CASE(["x$enable_qt_dbus"],
         [AC_MSG_RESULT([$enable_qt_dbus])
         AC_MSG_ERROR([Unknown option "$enable_qt_dbus". Use either "yes" or "no".])])
 
-      
+
 AX_BOOST_BASE([1.35])
 # HAVE_BOOST is set to an empty value when Boost is found. I don't know
 # how to test for a set vs unset variable.
-AS_IF([test "x$BOOST_CPPFLAGS" == "x"],
+AS_IF([test "x$BOOST_CPPFLAGS" = "x"],
       [AC_MSG_ERROR([Could not find Boost])],
-	  [AC_MSG_NOTICE([Boost CPPFLGAS: $BOOST_CPPFLAGS])
-	  CPPFLAGS="$BOOST_CPPFLAGS $CPPFLAGS"
-	  LDFLAGS="$BOOST_LDFLAGS $LDFLAGS"])
+      [AC_MSG_NOTICE([Boost CPPFLGAS: $BOOST_CPPFLAGS])
+      CPPFLAGS="$BOOST_CPPFLAGS $CPPFLAGS"
+      LDFLAGS="$BOOST_LDFLAGS $LDFLAGS"])
 
 AX_BOOST_SYSTEM()
 # HAVE_BOOST_SYSTEM is set to an empty value when Boost.System is found.
 # I don't know how to test for a set vs unset variable.
-AS_IF([test "x$BOOST_SYSTEM_LIB" == "x"],
+AS_IF([test "x$BOOST_SYSTEM_LIB" = "x"],
       [AC_MSG_ERROR([Could not find Boost.System])],
-	  [AC_MSG_NOTICE([Boost.System LIB: $BOOST_SYSTEM_LIB])
-	  LIBS="$BOOST_SYSTEM_LIB $LIBS"])
+      [AC_MSG_NOTICE([Boost.System LIB: $BOOST_SYSTEM_LIB])
+      LIBS="$BOOST_SYSTEM_LIB $LIBS"])
 
 AC_MSG_CHECKING([whether to embed the GeoIP database])
 AS_CASE(["x$with_geoip_database_embedded"],
@@ -143,7 +143,7 @@ AS_CASE(["x$with_geoip_database_embedded"],
                QBT_ADD_DEFINES="$QBT_ADD_DEFINES WITH_GEOIP_EMBEDDED"],
         [AC_MSG_RESULT([$with_geoip_database_embedded])
         AC_MSG_ERROR([Unknown option "$with_geoip_database_embedded". Use either "yes" or "no".])])
-       
+
 AC_MSG_CHECKING([which qtsingleapplication to use])
 AS_CASE(["x$with_qtsingleapplication"],
         ["xshipped"],
@@ -164,9 +164,9 @@ PKG_CHECK_MODULES(libtorrent,
                  [libtorrent-rasterbar >= 0.16.0],
                  [CPPFLAGS="$libtorrent_CFLAGS $CPPFLAGS"
                  LIBS="$libtorrent_LIBS $LIBS"])
-                 
+
 # These are required because autoconf doesn't expand these **particular**
-# vars automatically. And qmake cannot autoexpand them.                 
+# vars automatically. And qmake cannot autoexpand them.
 AX_DEFINE_DIR([EXPAND_PREFIX], [prefix])
 AX_DEFINE_DIR([EXPAND_BINDIR], [bindir])
 AX_DEFINE_DIR([EXPAND_DATADIR], [datadir])
@@ -190,7 +190,7 @@ $QT_QMAKE [$CONFDIR]/qbittorrent.pro
 ret="$?"
 
 AS_ECHO()
-AS_IF([test "x$ret" == "x0"],
+AS_IF([test "x$ret" = "x0"],
       [AC_MSG_NOTICE([Good, your configure finished.])],
       [AC_MSG_ERROR([Failed running $QT_QMAKE to generate the makefile])])
 AS_ECHO()


### PR DESCRIPTION
`test 1 == 1` will fail using dash as the default shell. The `test 1 = 1`
syntax works in both Bash and Dash.
