### PR TITLE
Reduce the number of torrent_handle::torrent_file() calls in QTorrentHandle::prioritize_files()

### DIFF
--- a/src/qtlibtorrent/qtorrenthandle.h
+++ b/src/qtlibtorrent/qtorrenthandle.h
@@ -121,6 +121,7 @@ public:
   static bool is_checking(const libtorrent::torrent_status &status);
   static bool has_error(const libtorrent::torrent_status &status);
   static float progress(const libtorrent::torrent_status &status);
+  static QString filepath_at(const libtorrent::torrent_info &info, unsigned int index);
 
 private:
   void prioritize_first_last_piece(int file_index, bool b) const;


### PR DESCRIPTION
It was reported (#2161) that enabling/disabling a downloading of a file
is considerably slow on libtorrent 1.0.3, but not on 0.16.x. The problem
is that a function torrent_file() in libttorrent 1.0.3 does a deep copy
of torrent_info, while get_torrent_info() in libtorrent 0.16.x only
returns a reference.

This is how is was on libtorrent 1.0.3 before this commit:
![prio-1](https://cloud.githubusercontent.com/assets/286877/5055024/0ea1e86a-6c6e-11e4-94dd-4fb5f7158cab.png)
![prio-2](https://cloud.githubusercontent.com/assets/286877/5055025/0ea6f9b8-6c6e-11e4-991f-cc4c23912cdf.png)

This is how it is now:
![prio-3](https://cloud.githubusercontent.com/assets/286877/5055028/1d57fffc-6c6e-11e4-85c8-416974fd026e.png)

Note, absolute time doesn't matter. Look only on ratio of time spend by different functions.
