### PR TITLE
Set placeholder text to torrent content filter.

### DIFF
--- a/src/properties/propertieswidget.cpp
+++ b/src/properties/propertieswidget.cpp
@@ -80,6 +80,7 @@ PropertiesWidget::PropertiesWidget(QWidget *parent, MainWindow* main_window, Tra
   filesList->setSortingEnabled(true);
   // Torrent content filtering
   m_contentFilerLine = new LineEdit(this);
+  m_contentFilerLine->setPlaceholderText(tr("Filter files..."));
   connect(m_contentFilerLine, SIGNAL(textChanged(QString)), this, SLOT(filterText(QString)));
   contentFilterLayout->insertWidget(1, m_contentFilerLine);
 


### PR DESCRIPTION
In commit afb03725ad8fcf6eb1db305bdc89391a573f5968 it was implemented
for torrent list filter. Now it is here for files filter.
