### PR TITLE
Vertical align right-aligned header text

### DIFF
--- a/src/qtlibtorrent/torrentmodel.cpp
+++ b/src/qtlibtorrent/torrentmodel.cpp
@@ -402,7 +402,7 @@ QVariant TorrentModel::headerData(int section, Qt::Orientation orientation,
       case TorrentModelItem::TR_RATIO:
       case TorrentModelItem::TR_PRIORITY:
       case TorrentModelItem::TR_LAST_ACTIVITY:
-        return Qt::AlignRight;
+        return QVariant(Qt::AlignRight | Qt::AlignVCenter);
       default:
         return QAbstractListModel::headerData(section, orientation, role);
       }


### PR DESCRIPTION
Since e907306b411 ("Right align header text that also has right-aligned
row text"), right-aligned elements are no longer centered vertically.
This can be noticed with some Qt styles (e.g. Breeze).
