### PR TITLE
searchengine: Update KickassTorrents url

### DIFF
--- a/src/searchengine/nova/engines/kickasstorrents.py
+++ b/src/searchengine/nova/engines/kickasstorrents.py
@@ -1,4 +1,4 @@
-#VERSION: 1.24
+#VERSION: 1.25
 #AUTHORS: Christophe Dumez (chris@qbittorrent.org)
 
 # Redistribution and use in source and binary forms, with or without
@@ -31,7 +31,7 @@ from helpers import retrieve_url, download_file
 import json
 
 class kickasstorrents(object):
-  url = 'https://kickass.to'
+  url = 'https://kickass.so'
   name = 'kickasstorrents'
   supported_categories = {'all': '', 'movies': 'Movies', 'tv': 'TV', 'music': 'Music', 'games': 'Games', 'software': 'Applications'}
 

--- a/src/searchengine/nova/engines/versions.txt
+++ b/src/searchengine/nova/engines/versions.txt
@@ -3,6 +3,6 @@ mininova: 1.50
 piratebay: 2.01
 vertor: 1.3
 extratorrent: 1.2
-kickasstorrents: 1.24
+kickasstorrents: 1.25
 btdigg: 1.23
 legittorrents: 1.02

--- a/src/searchengine/nova3/engines/kickasstorrents.py
+++ b/src/searchengine/nova3/engines/kickasstorrents.py
@@ -1,4 +1,4 @@
-#VERSION: 1.24
+#VERSION: 1.25
 #AUTHORS: Christophe Dumez (chris@qbittorrent.org)
 
 # Redistribution and use in source and binary forms, with or without
@@ -31,7 +31,7 @@ from helpers import retrieve_url, download_file
 import json
 
 class kickasstorrents(object):
-  url = 'https://kickass.to'
+  url = 'https://kickass.so'
   name = 'kickasstorrents'
   supported_categories = {'all': '', 'movies': 'Movies', 'tv': 'TV', 'music': 'Music', 'games': 'Games', 'software': 'Applications'}
 

--- a/src/searchengine/nova3/engines/versions.txt
+++ b/src/searchengine/nova3/engines/versions.txt
@@ -3,6 +3,6 @@ mininova: 1.50
 piratebay: 2.01
 vertor: 1.3
 extratorrent: 1.2
-kickasstorrents: 1.24
+kickasstorrents: 1.25
 btdigg: 1.23
 legittorrents: 1.02


### PR DESCRIPTION
Even if the old domain is still working, this is the new official one.

Closes #2228.
