### PR TITLE
Don't overwrite WebUI password when changing preferences

### DIFF
--- a/src/preferences/preferences.cpp
+++ b/src/preferences/preferences.cpp
@@ -958,6 +958,10 @@ QString Preferences::getWebUiPassword() const {
 }
 
 void Preferences::setWebUiPassword(const QString &new_password) {
+  // Do not overwrite current password with its hash
+  if (new_password == getWebUiPassword())
+      return;
+
   // Encode to md5 and save
   QCryptographicHash md5(QCryptographicHash::Md5);
   md5.addData(new_password.toLocal8Bit());


### PR DESCRIPTION
The input field to change password does not contain the actual
password, but its hash. When the preferences are saved, the hashed
password is considered as a new password.
Prevent this by comparing the new password with the hash of the
previous password.

Closes #2241.
