### PR TITLE
saving torrent list view when changed

### DIFF
--- a/src/transferlistwidget.cpp
+++ b/src/transferlistwidget.cpp
@@ -149,6 +149,8 @@ TransferListWidget::TransferListWidget(QWidget *parent, MainWindow *main_window,
     connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(displayListMenu(const QPoint &)));
     header()->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(header(), SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(displayDLHoSMenu(const QPoint &)));
+    connect(header(), SIGNAL(sectionMoved(int, int, int)), this, SLOT(saveSettings()));
+    connect(header(), SIGNAL(sectionResized(int, int, int)), this, SLOT(saveSettings()));
 
     editHotkey = new QShortcut(QKeySequence("F2"), this, SLOT(renameSelectedTorrent()), 0, Qt::WidgetShortcut);
     deleteHotkey = new QShortcut(QKeySequence::Delete, this, SLOT(deleteSelectedTorrents()), 0, Qt::WidgetShortcut);
@@ -594,6 +596,7 @@ void TransferListWidget::displayDLHoSMenu(const QPoint&)
         setColumnHidden(col, !isColumnHidden(col));
         if (!isColumnHidden(col) && columnWidth(col) <= 5)
             setColumnWidth(col, 100);
+        saveSettings();
     }
 }
 

--- a/src/transferlistwidget.h
+++ b/src/transferlistwidget.h
@@ -92,7 +92,6 @@ protected:
     QString getHashFromRow(int row) const;
     QModelIndex mapToSource(const QModelIndex &index) const;
     QModelIndex mapFromSource(const QModelIndex &index) const;
-    void saveSettings();
     bool loadSettings();
     QStringList getSelectedTorrentsHashes() const;
 
@@ -104,6 +103,7 @@ protected slots:
     void toggleSelectedTorrentsSequentialDownload() const;
     void toggleSelectedFirstLastPiecePrio() const;
     void askNewLabelForSelection();
+    void saveSettings();
 
 private:
     bool openUrl(const QString& _path) const;


### PR DESCRIPTION
saving torrent list view when changed

bc its otherwise forgotten by an unclean exit
## no clean exit, slow to restart, scrambled by app changes

the reason for the change is that

saving the view by restarting the app is slow. it takes around 30 min with 16k torrents bc
- starting the app is slow. it takes 1 min / 1k torrents #1541
- ending the app is slow. it takes around 10 min in total. around 0.5 min / 1k torrents to write the resume data. and then another around 5 min with 0 disk and cpu activity and 0.1 Mpbs net activity

even if i dont change the columns i sometimes have to fix them after columns are added or removed to the app. when i ran master with my around 6 months old [TransferList] settings the columns were wrong (selected, visible and widths)

i have to restart to save the view bc i never close the app cleanly. it ends bc of a memory leak, gui hang, crash or windows kernel fail after a few weeks
