### PR TITLE
Small fix of import in legittorrents engine

### DIFF
--- a/src/searchengine/nova3/engines/legittorrents.py
+++ b/src/searchengine/nova3/engines/legittorrents.py
@@ -1,4 +1,4 @@
-#VERSION: 1.02
+#VERSION: 1.03
 #AUTHORS: Christophe Dumez (chris@qbittorrent.org)
 
 # Redistribution and use in source and binary forms, with or without
@@ -28,7 +28,7 @@
 
 from novaprinter import prettyPrinter
 from helpers import retrieve_url, download_file
-import sgmllib
+import sgmllib3 as sgmllib
 import re
 
 class legittorrents(object):

--- a/src/searchengine/nova3/engines/versions.txt
+++ b/src/searchengine/nova3/engines/versions.txt
@@ -4,4 +4,4 @@ piratebay: 2.01
 extratorrent: 1.2
 kickasstorrents: 1.25
 btdigg: 1.23
-legittorrents: 1.02
+legittorrents: 1.03


### PR DESCRIPTION
Not sure why i haven't noticed it earlier...
For py3 version legittorents could not import sgmllib so it wasn't working at all.
