### PR TITLE
saving splitter state on change

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -207,6 +207,8 @@ MainWindow::MainWindow(QWidget *parent, const QStringList& torrentCmdLine) : QMa
   tabs->addTab(vSplitter, IconProvider::instance()->getIcon("folder-remote"), tr("Transfers"));
 
   connect(search_filter, SIGNAL(textChanged(QString)), transferList, SLOT(applyNameFilter(QString)));
+  connect(hSplitter, SIGNAL(splitterMoved(int, int)), this, SLOT(writeSettings()));
+  connect(vSplitter, SIGNAL(splitterMoved(int, int)), this, SLOT(writeSettings()));
 
   vboxLayout->addWidget(tabs);
 


### PR DESCRIPTION
to not lose it on unclean exit
## test

i tested that the slot connection works by placing `QMessageBox::information(0, tr(""), tr(""));` at the top of MainWindow::writeSettings an resizing the splitter
