### PR TITLE
macxconf: remove openssl

### DIFF
--- a/macxconf.pri
+++ b/macxconf.pri
@@ -8,11 +8,9 @@ PKGCONFIG += libtorrent-rasterbar
 DEFINES += BOOST_ASIO_DYN_LINK
 
 # Special include/libs paths (macports)
-INCLUDEPATH += /usr/include/openssl /usr/include /opt/local/include/boost /opt/local/include
+INCLUDEPATH += /usr/include /opt/local/include/boost /opt/local/include
 LIBS += -L/opt/local/lib
 
-# OpenSSL lib
-LIBS += -lssl -lcrypto
 # Boost system lib
 LIBS += -lboost_system-mt
 # Boost filesystem lib (Not needed for libtorrent >= 0.16.0)


### PR DESCRIPTION
OpenSSL isn't actually a dependency of QBT, as discussed [here](https://github.com/qbittorrent/qBittorrent/issues/2282#issuecomment-66970670), but rather of `libtorrent-rasterbar`. But this file containing directions to OpenSSL is resulting in a consistent situation where QBT ends up dragging in the defunct OS X default OpenSSL with every build and run. We can get rid of it safely, and solve the issue.

Long-term, I think Sledge wants to move to autotools everywhere, so that'd presumably eliminate this file altogether.
