### PR TITLE
WebUI: Specify URI size

### DIFF
--- a/src/webui/requesthandler.cpp
+++ b/src/webui/requesthandler.cpp
@@ -118,8 +118,8 @@ QMap<QString, QMap<QString, RequestHandler::Action> > RequestHandler::initialize
     return actions;
 }
 
-#define CHECK_URI() \
-    if (!args_.isEmpty()) { \
+#define CHECK_URI(ARGS_NUM) \
+    if (args_.size() != ARGS_NUM) { \
         status(404, "Not Found"); \
         return; \
     }
@@ -184,7 +184,7 @@ void RequestHandler::action_public_login()
 
 void RequestHandler::action_public_logout()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     sessionEnd();
 }
 
@@ -222,7 +222,7 @@ void RequestHandler::action_public_images()
 //   - offset (int): set offset (if less than 0 - offset from end)
 void RequestHandler::action_json_torrents()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     const QStringMap& gets = request().gets;
 
     print(btjson::getTorrents(
@@ -233,49 +233,49 @@ void RequestHandler::action_json_torrents()
 
 void RequestHandler::action_json_preferences()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     print(prefjson::getPreferences(), CONTENT_TYPE_JS);
 }
 
 void RequestHandler::action_json_transferInfo()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     print(btjson::getTransferInfo(), CONTENT_TYPE_JS);
 }
 
 void RequestHandler::action_json_propertiesGeneral()
 {
-    CHECK_URI();
+    CHECK_URI(1);
     print(btjson::getPropertiesForTorrent(args_.front()), CONTENT_TYPE_JS);
 }
 
 void RequestHandler::action_json_propertiesTrackers()
 {
-    CHECK_URI();
+    CHECK_URI(1);
     print(btjson::getTrackersForTorrent(args_.front()), CONTENT_TYPE_JS);
 }
 
 void RequestHandler::action_json_propertiesFiles()
 {
-    CHECK_URI();
+    CHECK_URI(1);
     print(btjson::getFilesForTorrent(args_.front()), CONTENT_TYPE_JS);
 }
 
 void RequestHandler::action_version_api()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     print(QString::number(API_VERSION), CONTENT_TYPE_TXT);
 }
 
 void RequestHandler::action_version_api_min()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     print(QString::number(API_VERSION_MIN), CONTENT_TYPE_TXT);
 }
 
 void RequestHandler::action_version_qbittorrent()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     print(QString(VERSION), CONTENT_TYPE_TXT);
 }
 
@@ -286,13 +286,13 @@ void RequestHandler::action_command_shutdown()
     // need to reply to the Web UI before
     // actually shutting down.
 
-    CHECK_URI();
+    CHECK_URI(0);
     QTimer::singleShot(0, qApp, SLOT(quit()));
 }
 
 void RequestHandler::action_command_download()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     CHECK_PARAMETERS("urls");
     QString urls = request().posts["urls"];
     QStringList list = urls.split('\n');
@@ -318,7 +318,7 @@ void RequestHandler::action_command_download()
 void RequestHandler::action_command_upload()
 {
     qDebug() << Q_FUNC_INFO;
-    CHECK_URI();
+    CHECK_URI(0);
 
     foreach(const UploadedFile& torrent, request().files) {
         QString filePath = saveTmpFile(torrent.data);
@@ -342,7 +342,7 @@ void RequestHandler::action_command_upload()
 
 void RequestHandler::action_command_addTrackers()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     CHECK_PARAMETERS("hash" << "urls");
     QString hash = request().posts["hash"];
 
@@ -363,40 +363,40 @@ void RequestHandler::action_command_addTrackers()
 
 void RequestHandler::action_command_resumeAll()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     QBtSession::instance()->resumeAllTorrents();
 }
 
 void RequestHandler::action_command_pauseAll()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     QBtSession::instance()->pauseAllTorrents();
 }
 
 void RequestHandler::action_command_resume()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     CHECK_PARAMETERS("hash");
     QBtSession::instance()->resumeTorrent(request().posts["hash"]);
 }
 
 void RequestHandler::action_command_pause()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     CHECK_PARAMETERS("hash");
     QBtSession::instance()->pauseTorrent(request().posts["hash"]);
 }
 
 void RequestHandler::action_command_setPreferences()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     CHECK_PARAMETERS("json");
     prefjson::setPreferences(request().posts["json"]);
 }
 
 void RequestHandler::action_command_setFilePrio()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     CHECK_PARAMETERS("hash" << "id" << "priority");
     QString hash = request().posts["hash"];
     int file_id = request().posts["id"].toInt();
@@ -409,19 +409,19 @@ void RequestHandler::action_command_setFilePrio()
 
 void RequestHandler::action_command_getGlobalUpLimit()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     print(QByteArray::number(QBtSession::instance()->getSession()->settings().upload_rate_limit));
 }
 
 void RequestHandler::action_command_getGlobalDlLimit()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     print(QByteArray::number(QBtSession::instance()->getSession()->settings().download_rate_limit));
 }
 
 void RequestHandler::action_command_setGlobalUpLimit()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     CHECK_PARAMETERS("limit");
     qlonglong limit = request().posts["limit"].toLongLong();
     if (limit == 0) limit = -1;
@@ -435,7 +435,7 @@ void RequestHandler::action_command_setGlobalUpLimit()
 
 void RequestHandler::action_command_setGlobalDlLimit()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     CHECK_PARAMETERS("limit");
     qlonglong limit = request().posts["limit"].toLongLong();
     if (limit == 0) limit = -1;
@@ -449,7 +449,7 @@ void RequestHandler::action_command_setGlobalDlLimit()
 
 void RequestHandler::action_command_getTorrentUpLimit()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     CHECK_PARAMETERS("hash");
     QString hash = request().posts["hash"];
     QTorrentHandle h = QBtSession::instance()->getTorrentHandle(hash);
@@ -460,7 +460,7 @@ void RequestHandler::action_command_getTorrentUpLimit()
 
 void RequestHandler::action_command_getTorrentDlLimit()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     CHECK_PARAMETERS("hash");
     QString hash = request().posts["hash"];
     QTorrentHandle h = QBtSession::instance()->getTorrentHandle(hash);
@@ -471,7 +471,7 @@ void RequestHandler::action_command_getTorrentDlLimit()
 
 void RequestHandler::action_command_setTorrentUpLimit()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     CHECK_PARAMETERS("hash" << "limit");
     QString hash = request().posts["hash"];
     qlonglong limit = request().posts["limit"].toLongLong();
@@ -484,7 +484,7 @@ void RequestHandler::action_command_setTorrentUpLimit()
 
 void RequestHandler::action_command_setTorrentDlLimit()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     CHECK_PARAMETERS("hash" << "limit");
     QString hash = request().posts["hash"];
     qlonglong limit = request().posts["limit"].toLongLong();
@@ -497,19 +497,19 @@ void RequestHandler::action_command_setTorrentDlLimit()
 
 void RequestHandler::action_command_toggleAlternativeSpeedLimits()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     QBtSession::instance()->useAlternativeSpeedsLimit(!Preferences::instance()->isAltBandwidthEnabled());
 }
 
 void RequestHandler::action_command_alternativeSpeedLimitsEnabled()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     print(QByteArray::number(Preferences::instance()->isAltBandwidthEnabled()));
 }
 
 void RequestHandler::action_command_toggleSequentialDownload()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     CHECK_PARAMETERS("hashes");
     QStringList hashes = request().posts["hashes"].split("|");
     foreach (const QString &hash, hashes) {
@@ -523,7 +523,7 @@ void RequestHandler::action_command_toggleSequentialDownload()
 
 void RequestHandler::action_command_toggleFirstLastPiecePrio()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     CHECK_PARAMETERS("hashes");
     QStringList hashes = request().posts["hashes"].split("|");
     foreach (const QString &hash, hashes) {
@@ -537,7 +537,7 @@ void RequestHandler::action_command_toggleFirstLastPiecePrio()
 
 void RequestHandler::action_command_delete()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     CHECK_PARAMETERS("hashes");
     QStringList hashes = request().posts["hashes"].split("|");
     foreach (const QString &hash, hashes)
@@ -546,7 +546,7 @@ void RequestHandler::action_command_delete()
 
 void RequestHandler::action_command_deletePerm()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     CHECK_PARAMETERS("hashes");
     QStringList hashes = request().posts["hashes"].split("|");
     foreach (const QString &hash, hashes)
@@ -555,7 +555,7 @@ void RequestHandler::action_command_deletePerm()
 
 void RequestHandler::action_command_increasePrio()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     CHECK_PARAMETERS("hashes");
     QStringList hashes = request().posts["hashes"].split("|");
 
@@ -588,7 +588,7 @@ void RequestHandler::action_command_increasePrio()
 
 void RequestHandler::action_command_decreasePrio()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     CHECK_PARAMETERS("hashes");
     QStringList hashes = request().posts["hashes"].split("|");
 
@@ -622,7 +622,7 @@ void RequestHandler::action_command_decreasePrio()
 
 void RequestHandler::action_command_topPrio()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     CHECK_PARAMETERS("hashes");
     foreach (const QString &hash, request().posts["hashes"].split("|")) {
         QTorrentHandle h = QBtSession::instance()->getTorrentHandle(hash);
@@ -632,7 +632,7 @@ void RequestHandler::action_command_topPrio()
 
 void RequestHandler::action_command_bottomPrio()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     CHECK_PARAMETERS("hashes");
     foreach (const QString &hash, request().posts["hashes"].split("|")) {
         QTorrentHandle h = QBtSession::instance()->getTorrentHandle(hash);
@@ -642,7 +642,7 @@ void RequestHandler::action_command_bottomPrio()
 
 void RequestHandler::action_command_recheck()
 {
-    CHECK_URI();
+    CHECK_URI(0);
     CHECK_PARAMETERS("hash");
     QBtSession::instance()->recheckTorrent(request().posts["hash"]);
 }


### PR DESCRIPTION
In some cases, args_ can't be empty. Specify the expected size to
avoid issues.

Fix 2023ec043c03 ("WebUI: Check URI of GET and POST requests")
