### PR TITLE
saving properties window state when changed

### DIFF
--- a/src/properties/propertieswidget.cpp
+++ b/src/properties/propertieswidget.cpp
@@ -97,6 +97,9 @@ PropertiesWidget::PropertiesWidget(QWidget *parent, MainWindow* main_window, Tra
   connect(stackedProperties, SIGNAL(currentChanged(int)), this, SLOT(loadDynamicData()));
   connect(QBtSession::instance(), SIGNAL(savePathChanged(QTorrentHandle)), this, SLOT(updateSavePath(QTorrentHandle)));
   connect(QBtSession::instance(), SIGNAL(metadataReceived(QTorrentHandle)), this, SLOT(updateTorrentInfos(QTorrentHandle)));
+  connect(filesList->header(), SIGNAL(sectionMoved(int, int, int)), this, SLOT(saveSettings()));
+  connect(filesList->header(), SIGNAL(sectionResized(int, int, int)), this, SLOT(saveSettings()));
+  connect(filesList->header(), SIGNAL(sortIndicatorChanged(int, Qt::SortOrder)), this, SLOT(saveSettings()));
 
   // Downloaded pieces progress bar
   downloaded_pieces = new DownloadedPiecesBar(this);
@@ -109,14 +112,22 @@ PropertiesWidget::PropertiesWidget(QWidget *parent, MainWindow* main_window, Tra
   connect(trackerUpButton, SIGNAL(clicked()), trackerList, SLOT(moveSelectionUp()));
   connect(trackerDownButton, SIGNAL(clicked()), trackerList, SLOT(moveSelectionDown()));
   horizontalLayout_trackers->insertWidget(0, trackerList);
+  connect(trackerList->header(), SIGNAL(sectionMoved(int, int, int)), this, SLOT(saveSettings()));
+  connect(trackerList->header(), SIGNAL(sectionResized(int, int, int)), this, SLOT(saveSettings()));
+  connect(trackerList->header(), SIGNAL(sortIndicatorChanged(int, Qt::SortOrder)), this, SLOT(saveSettings()));
   // Peers list
   peersList = new PeerListWidget(this);
   peerpage_layout->addWidget(peersList);
+  connect(peersList->header(), SIGNAL(sectionMoved(int, int, int)), this, SLOT(saveSettings()));
+  connect(peersList->header(), SIGNAL(sectionResized(int, int, int)), this, SLOT(saveSettings()));
+  connect(peersList->header(), SIGNAL(sortIndicatorChanged(int, Qt::SortOrder)), this, SLOT(saveSettings()));
   // Tab bar
   m_tabBar = new PropTabBar();
   verticalLayout->addLayout(m_tabBar);
   connect(m_tabBar, SIGNAL(tabChanged(int)), stackedProperties, SLOT(setCurrentIndex(int)));
+  connect(m_tabBar, SIGNAL(tabChanged(int)), this, SLOT(saveSettings()));
   connect(m_tabBar, SIGNAL(visibilityToggled(bool)), SLOT(setVisibility(bool)));
+  connect(m_tabBar, SIGNAL(visibilityToggled(bool)), this, SLOT(saveSettings()));
   // Dynamic data refresher
   refreshTimer = new QTimer(this);
   connect(refreshTimer, SIGNAL(timeout()), this, SLOT(loadDynamicData()));

--- a/src/transferlistwidget.cpp
+++ b/src/transferlistwidget.cpp
@@ -151,6 +151,7 @@ TransferListWidget::TransferListWidget(QWidget *parent, MainWindow *main_window,
     connect(header(), SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(displayDLHoSMenu(const QPoint &)));
     connect(header(), SIGNAL(sectionMoved(int, int, int)), this, SLOT(saveSettings()));
     connect(header(), SIGNAL(sectionResized(int, int, int)), this, SLOT(saveSettings()));
+    connect(header(), SIGNAL(sortIndicatorChanged(int, Qt::SortOrder)), this, SLOT(saveSettings()));
 
     editHotkey = new QShortcut(QKeySequence("F2"), this, SLOT(renameSelectedTorrent()), 0, Qt::WidgetShortcut);
     deleteHotkey = new QShortcut(QKeySequence::Delete, this, SLOT(deleteSelectedTorrents()), 0, Qt::WidgetShortcut);


### PR DESCRIPTION
to not lose it on an unclean exit
## select and sort signal

sortIndicatorChanged is enough to detect selected and sorted column. sectionClicked isnt needed

i tested the sortIndicatorChanged signal by printing the signal name at the top of TransferListWidget::saveSettings()

```
QMessageBox::information(0, tr(""), QObject::sender()->metaObject()->method(senderSignalIndex()).signature());
```

the result is that its sent both when a selected and non-selected column header is clicked
- signals from clicking a selected column header: sortIndicatorChanged then sectionClicked
- signals from clicking a non-selected column header: sortIndicatorChanged then sectionClicked
## signal to multiple slots

the setCurrentIndex and setVisibility state will always be saved after the state is changed bc the slots are called in the order theyre connected

> http://stackoverflow.com/questions/1246933/order-of-slots-called-on-qobject
> 
> If several slots are connected to one signal, the slots will be executed one after the other, in the order they have been connected, when the signal is emitted
