### PR TITLE
New logging interface

### DIFF
--- a/src/executionlog.cpp
+++ b/src/executionlog.cpp
@@ -39,11 +39,11 @@
 #include "iconprovider.h"
 #include "loglistwidget.h"
 
-ExecutionLog::ExecutionLog(QWidget *parent) :
-  QWidget(parent),
-  ui(new Ui::ExecutionLog),
-  m_msgList(new LogListWidget(MAX_LOG_MESSAGES)),
-  m_peerList(new LogListWidget(MAX_LOG_MESSAGES))
+ExecutionLog::ExecutionLog(QWidget *parent)
+    : QWidget(parent)
+    , ui(new Ui::ExecutionLog)
+    , m_msgList(new LogListWidget(MAX_LOG_MESSAGES))
+    , m_peerList(new LogListWidget(MAX_LOG_MESSAGES))
 {
     ui->setupUi(this);
 
@@ -54,57 +54,57 @@ ExecutionLog::ExecutionLog(QWidget *parent) :
 
     const Logger* const logger = Logger::instance();
     foreach (const Log::Msg& msg, logger->getMessages())
-      addLogMessage(msg);
+        addLogMessage(msg);
     foreach (const Log::Peer& peer, logger->getPeers())
-      addPeerMessage(peer);
-    connect(logger, SIGNAL(newLogMessage(const Log::Msg &)), SLOT(addLogMessage(const Logg:Msg &)));
+        addPeerMessage(peer);
+    connect(logger, SIGNAL(newLogMessage(const Log::Msg &)), SLOT(addLogMessage(const Log::Msg &)));
     connect(logger, SIGNAL(newLogPeer(const Log::Peer &)), SLOT(addPeerMessage(const Log::Peer &)));
 }
 
 ExecutionLog::~ExecutionLog()
 {
-  delete m_msgList;
-  delete m_peerList;
-  delete ui;
+    delete m_msgList;
+    delete m_peerList;
+    delete ui;
 }
 
 void ExecutionLog::addLogMessage(const Log::Msg &msg)
 {
-  QString text;
-  QDateTime time = QDateTime::fromMSecsSinceEpoch(msg.timestamp);
-  QColor color;
+    QString text;
+    QDateTime time = QDateTime::fromMSecsSinceEpoch(msg.timestamp);
+    QColor color;
 
-  switch (msg.type) {
-  case Log::INFO:
-    color.setNamedColor("blue");
-    break;
-  case Log::WARNING:
-    color.setNamedColor("orange");
-    break;
-  case Log::CRITICAL:
-    color.setNamedColor("red");
-    break;
-  default:
-    color = QApplication::palette().color(QPalette::WindowText);
-  }
+    switch (msg.type) {
+    case Log::INFO:
+        color.setNamedColor("blue");
+        break;
+    case Log::WARNING:
+        color.setNamedColor("orange");
+        break;
+    case Log::CRITICAL:
+        color.setNamedColor("red");
+        break;
+    default:
+        color = QApplication::palette().color(QPalette::WindowText);
+    }
 
-  text = "<font color='grey'>" + time.toString("dd/MM/yyyy hh:mm:ss") + "</font> - <font color='" + color.name() + "'>" + msg.message + "</font>";
-  m_msgList->appendLine(text);
+    text = "<font color='grey'>" + time.toString("dd/MM/yyyy hh:mm:ss") + "</font> - <font color='" + color.name() + "'>" + msg.message + "</font>";
+    m_msgList->appendLine(text);
 }
 
 void ExecutionLog::addPeerMessage(const Log::Peer& peer)
 {
-  QString text;
-  QDateTime time = QDateTime::fromMSecsSinceEpoch(peer.timestamp);
+    QString text;
+    QDateTime time = QDateTime::fromMSecsSinceEpoch(peer.timestamp);
 
-  if (peer.blocked)
+    if (peer.blocked)
 #if LIBTORRENT_VERSION_NUM < 10000
-    text = "<font color='grey'>" + time.toString("dd/MM/yyyy hh:mm:ss") + "</font> - " + tr("<font color='red'>%1</font> was blocked", "x.y.z.w was blocked").arg(peer.ip);
+        text = "<font color='grey'>" + time.toString("dd/MM/yyyy hh:mm:ss") + "</font> - " + tr("<font color='red'>%1</font> was blocked", "x.y.z.w was blocked").arg(peer.ip);
 #else
-    text = "<font color='grey'>" + time.toString("dd/MM/yyyy hh:mm:ss") + "</font> - " + tr("<font color='red'>%1</font> was blocked %2", "x.y.z.w was blocked").arg(peer.ip).arg(peer.reason);
+        text = "<font color='grey'>" + time.toString("dd/MM/yyyy hh:mm:ss") + "</font> - " + tr("<font color='red'>%1</font> was blocked %2", "x.y.z.w was blocked").arg(peer.ip).arg(peer.reason);
 #endif
-  else
-    text = "<font color='grey'>" + time.toString("dd/MM/yyyy hh:mm:ss") + "</font> - " + tr("<font color='red'>%1</font> was banned", "x.y.z.w was banned").arg(peer.ip);
+    else
+        text = "<font color='grey'>" + time.toString("dd/MM/yyyy hh:mm:ss") + "</font> - " + tr("<font color='red'>%1</font> was banned", "x.y.z.w was banned").arg(peer.ip);
 
-  m_peerList->appendLine(text);
+    m_peerList->appendLine(text);
 }

--- a/src/executionlog.h
+++ b/src/executionlog.h
@@ -43,11 +43,11 @@ class LogListWidget;
 
 namespace Log
 {
-  struct Msg;
-  struct Peer;
+    struct Msg;
+    struct Peer;
 }
 
-class ExecutionLog : public QWidget
+class ExecutionLog: public QWidget
 {
     Q_OBJECT
 
@@ -56,14 +56,14 @@ public:
     ~ExecutionLog();
 
 private slots:
-  void addLogMessage(const Log::Msg &msg);
-  void addPeerMessage(const Log::Peer &peer);
+    void addLogMessage(const Log::Msg &msg);
+    void addPeerMessage(const Log::Peer &peer);
 
 private:
-  Ui::ExecutionLog *ui;
+    Ui::ExecutionLog *ui;
 
-  LogListWidget *m_msgList;
-  LogListWidget *m_peerList;
+    LogListWidget *m_msgList;
+    LogListWidget *m_peerList;
 };
 
 #endif // EXECUTIONLOG_H

--- a/src/executionlog.h
+++ b/src/executionlog.h
@@ -38,7 +38,14 @@ namespace Ui {
     class ExecutionLog;
 }
 QT_END_NAMESPACE
+class Logger;
 class LogListWidget;
+
+namespace Log
+{
+  struct Msg;
+  struct Peer;
+}
 
 class ExecutionLog : public QWidget
 {
@@ -48,15 +55,15 @@ public:
     explicit ExecutionLog(QWidget *parent = 0);
     ~ExecutionLog();
 
-public slots:
-  void addLogMessage(const QString &msg);
-  void addBanMessage(const QString &msg);
+private slots:
+  void addLogMessage(const Log::Msg &msg);
+  void addPeerMessage(const Log::Peer &peer);
 
 private:
   Ui::ExecutionLog *ui;
 
-  LogListWidget *m_logList;
-  LogListWidget *m_banList;
+  LogListWidget *m_msgList;
+  LogListWidget *m_peerList;
 };
 
 #endif // EXECUTIONLOG_H

--- a/src/headlessloader.h
+++ b/src/headlessloader.h
@@ -38,6 +38,7 @@
 #include "qbtsession.h"
 #include "fs_utils.h"
 #include "misc.h"
+#include "logger.h"
 
 class HeadlessLoader: public QObject {
   Q_OBJECT
@@ -69,6 +70,7 @@ public slots:
   void shutdownCleanUp() {
     QBtSession::drop();
     Preferences::drop();
+    Logger::drop();
   }
 
   // Call this function to exit qBittorrent headless loader

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -1,0 +1,127 @@
+#include "logger.h"
+
+#include <QDateTime>
+
+namespace Log
+{
+    Msg::Msg() {}
+
+    Msg::Msg(int id, MsgType type, const QString &message)
+        : id(id)
+        , timestamp(QDateTime::currentMSecsSinceEpoch())
+        , type(type)
+        , message(message)
+    {
+    }
+
+    Peer::Peer() {}
+
+#if LIBTORRENT_VERSION_NUM < 10000
+    Peer::Peer(int id, const QString &ip, bool blocked)
+#else
+    Peer::Peer(int id, const QString &ip, bool blocked, const QString &reason)
+#endif
+        : id(id)
+        , timestamp(QDateTime::currentMSecsSinceEpoch())
+        , ip(ip)
+        , blocked(blocked)
+#if LIBTORRENT_VERSION_NUM >= 10000
+        , reason(reason)
+#endif
+    {
+    }
+
+}
+
+Logger* Logger::m_instance = 0;
+
+Logger::Logger()
+    : lock(QReadWriteLock::Recursive)
+    , msgCounter(0)
+    , peerCounter(0)
+{
+}
+
+Logger::~Logger() {}
+
+Logger * Logger::instance()
+{
+    if (!m_instance)
+        m_instance = new Logger;
+
+    return m_instance;
+}
+
+void Logger::drop()
+{
+    if (m_instance) {
+        delete m_instance;
+        m_instance = 0;
+    }
+}
+
+void Logger::addMessage(const QString &message, const Log::MsgType &type)
+{
+    QWriteLocker locker(&lock);
+
+    Log::Msg temp(msgCounter++, type, message);
+    m_messages.push_back(temp);
+
+    if (m_messages.size() >= MAX_LOG_MESSAGES)
+        m_messages.pop_front();
+
+    emit newLogMessage(temp);
+}
+
+#if LIBTORRENT_VERSION_NUM < 10000
+void Logger::addPeer(const QString &ip, bool blocked)
+#else
+void Logger::addPeer(const QString &ip, bool blocked, const QString &reason)
+#endif
+{
+    QWriteLocker locker(&lock);
+
+#if LIBTORRENT_VERSION_NUM < 10000
+    Log::Peer temp(peerCounter++, ip, blocked);
+#else
+    Log::Peer temp(peerCounter++, ip, blocked, reason);
+#endif
+    m_peers.push_back(temp);
+
+    if (m_peers.size() >= MAX_LOG_MESSAGES)
+        m_peers.pop_front();
+
+    emit newLogPeer(temp);
+}
+
+QVector<Log::Msg> Logger::getMessages(int lastKnownId) const
+{
+    QReadLocker locker(&lock);
+
+    int diff = msgCounter - lastKnownId - 1;
+    int size = m_messages.size();
+
+    if ((lastKnownId == -1) || (diff >= size))
+        return m_messages;
+
+    if (diff <= 0)
+        return QVector<Log::Msg>();
+
+    return m_messages.mid(size - diff);
+}
+
+QVector<Log::Peer> Logger::getPeers(int lastKnownId) const
+{
+    QReadLocker locker(&lock);
+
+    int diff = peerCounter - lastKnownId - 1;
+    int size = m_peers.size();
+
+    if ((lastKnownId == -1) || (diff >= size))
+        return m_peers;
+
+    if (diff <= 0)
+        return QVector<Log::Peer>();
+
+    return m_peers.mid(size - diff);
+}

--- a/src/logger.h
+++ b/src/logger.h
@@ -1,0 +1,83 @@
+#ifndef LOGGER_H
+#define LOGGER_H
+
+#include <QString>
+#include <QVector>
+#include <QReadWriteLock>
+#include <QObject>
+#include <libtorrent/version.hpp>
+
+const int MAX_LOG_MESSAGES = 1000;
+
+namespace Log
+{
+    enum MsgType
+    {
+        NORMAL,
+        INFO,
+        WARNING,
+        CRITICAL //ERROR is defined by libtorrent and results in compiler error
+    };
+
+    struct Msg
+    {
+        Msg();
+        Msg(int id, MsgType type, const QString &message);
+        int id;
+        qint64 timestamp;
+        MsgType type;
+        QString message;
+    };
+
+    struct Peer
+    {
+#if LIBTORRENT_VERSION_NUM < 10000
+        Peer(int id, const QString &ip, bool blocked);
+#else
+        Peer(int id, const QString &ip, bool blocked, const QString &reason);
+#endif
+        Peer();
+        int id;
+        qint64 timestamp;
+        QString ip;
+        bool blocked;
+#if LIBTORRENT_VERSION_NUM >= 10000
+        QString reason;
+#endif
+    };
+}
+
+class Logger : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY(Logger)
+
+public:
+    static Logger* instance();
+    static void drop();
+    ~Logger();
+
+    void addMessage(const QString &message, const Log::MsgType &type = Log::NORMAL);
+#if LIBTORRENT_VERSION_NUM < 10000
+    void addPeer(const QString &ip, bool blocked);
+#else
+    void addPeer(const QString &ip, bool blocked, const QString &reason = QString());
+#endif
+    QVector<Log::Msg> getMessages(int lastKnownId = -1) const;
+    QVector<Log::Peer> getPeers(int lastKnownId = -1) const;
+
+signals:
+    void newLogMessage(const Log::Msg &message);
+    void newLogPeer(const Log::Peer &peer);
+
+private:
+    Logger();
+    static Logger* m_instance;
+    QVector<Log::Msg> m_messages;
+    QVector<Log::Peer> m_peers;
+    mutable QReadWriteLock lock;
+    int msgCounter;
+    int peerCounter;
+};
+
+#endif // LOGGER_H

--- a/src/loglistwidget.cpp
+++ b/src/loglistwidget.cpp
@@ -93,5 +93,4 @@ void LogListWidget::copySelection()
 
 void LogListWidget::clearLog() {
   clear();
-  emit logCleared();
 }

--- a/src/loglistwidget.h
+++ b/src/loglistwidget.h
@@ -50,9 +50,6 @@ protected slots:
   void copySelection();
   void clearLog();
 
-signals:
-  void logCleared();
-
 protected:
   void keyPressEvent(QKeyEvent *event);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,6 +74,7 @@ Q_IMPORT_PLUGIN(qico)
 #include <stdlib.h>
 #include "misc.h"
 #include "preferences.h"
+#include "logger.h"
 
 class MessagesCollector : public QObject
 {
@@ -143,6 +144,8 @@ QBtCommandLineParameters parseCommandLine();
 // Main
 int main(int argc, char *argv[])
 {
+    //Initialize logger singleton here to avoid threading issues
+    Logger::instance()->addMessage(QObject::tr("qBittorrent %1 started", "qBittorrent v3.2.0alpha started").arg(VERSION));
     // We must save it here because QApplication constructor may change it
     bool isOneArg = (argc == 2);
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -72,6 +72,7 @@
 #include "torrentmodel.h"
 #include "executionlog.h"
 #include "iconprovider.h"
+#include "logger.h"
 #ifndef DISABLE_GUI
 #include "autoexpandabledialog.h"
 #endif
@@ -506,6 +507,7 @@ void MainWindow::shutdownCleanUp()
     delete toolbarMenu;
     IconProvider::drop();
     Preferences::drop();
+    Logger::drop();
     qDebug("Finished GUI destruction");
 }
 
@@ -1181,7 +1183,7 @@ void MainWindow::optionsSaved()
 // Load program preferences
 void MainWindow::loadPreferences(bool configure_session)
 {
-    QBtSession::instance()->addConsoleMessage(tr("Options were saved successfully."));
+    Logger::instance()->addMessage(tr("Options were saved successfully."));
     const Preferences* const pref = Preferences::instance();
     const bool newSystrayIntegration = pref->systrayIntegration();
     actionLock_qBittorrent->setVisible(newSystrayIntegration);

--- a/src/properties/peerlistwidget.cpp
+++ b/src/properties/peerlistwidget.cpp
@@ -39,6 +39,7 @@
 #include "speedlimitdlg.h"
 #include "iconprovider.h"
 #include "qtorrenthandle.h"
+#include "logger.h"
 #include <QStandardItemModel>
 #include <QSortFilterProxyModel>
 #include <QSet>
@@ -232,7 +233,7 @@ void PeerListWidget::banSelectedPeers(const QStringList& peer_ips)
 
   foreach (const QString &ip, peer_ips) {
     qDebug("Banning peer %s...", ip.toLocal8Bit().data());
-    QBtSession::instance()->addConsoleMessage(tr("Manually banning peer %1...").arg(ip));
+    Logger::instance()->addMessage(tr("Manually banning peer %1...").arg(ip));
     QBtSession::instance()->banIP(ip);
   }
   // Refresh list

--- a/src/qtlibtorrent/qbtsession.h
+++ b/src/qtlibtorrent/qbtsession.h
@@ -34,12 +34,6 @@
 #include <QHash>
 #include <QUrl>
 #include <QStringList>
-#ifdef DISABLE_GUI
-#include <QCoreApplication>
-#else
-#include <QApplication>
-#include <QPalette>
-#endif
 #include <QPointer>
 #include <QTimer>
 #include <QNetworkCookie>
@@ -104,8 +98,6 @@ class TorrentStatistics;
 class DNSUpdater;
 class QAlertDispatcher;
 
-const int MAX_LOG_MESSAGES = 1000;
-
 enum TorrentExportFolder {
   RegularTorrentExportFolder,
   FinishedTorrentExportFolder
@@ -141,8 +133,6 @@ public:
   bool hasDownloadingTorrents() const;
   //int getMaximumActiveDownloads() const;
   //int getMaximumActiveTorrents() const;
-  inline QStringList getConsoleMessages() const { return consoleMessages; }
-  inline QStringList getPeerBanMessages() const { return peerBanMessages; }
   inline libtorrent::session* getSession() const { return s; }
   inline bool useTemporaryFolder() const { return !defaultTempPath.isEmpty(); }
   inline QString getDefaultSavePath() const { return defaultSavePath; }
@@ -210,18 +200,6 @@ public slots:
   void enableUPnP(bool b);
   void enableLSD(bool b);
   void enableDHT(bool b);
-#ifdef DISABLE_GUI
-  void addConsoleMessage(QString msg, QString color=QString::null);
-#else
-  void addConsoleMessage(QString msg, QColor color=QApplication::palette().color(QPalette::WindowText));
-#endif
-#if LIBTORRENT_VERSION_NUM < 10000
-  void addPeerBanMessage(const QString &msg, bool blocked);
-#else
-  void addPeerBanMessage(const QString &msg, bool blocked, const QString &blockedReason = QString());
-#endif
-  void clearConsoleMessages() { consoleMessages.clear(); }
-  void clearPeerBanMessages() { peerBanMessages.clear(); }
   void processDownloadedFile(QString, QString);
 #ifndef DISABLE_GUI
   void addMagnetSkipAddDlg(const QString& uri, const QString& save_path = QString(), const QString& label = QString(),
@@ -307,8 +285,6 @@ signals:
   void torrentFinishedChecking(const QTorrentHandle& h);
   void metadataReceived(const QTorrentHandle &h);
   void savePathChanged(const QTorrentHandle &h);
-  void newConsoleMessage(const QString &msg);
-  void newBanMessage(const QString &msg);
   void alternativeSpeedsModeChanged(bool alternative);
   void recursiveTorrentDownloadPossible(const QTorrentHandle &h);
   void ipFilterParsed(bool error, int ruleCount);
@@ -334,9 +310,6 @@ private:
   DownloadThread* downloader;
   // File System
   ScanFoldersModel *m_scanFolders;
-  // Console / Log
-  QStringList consoleMessages;
-  QStringList peerBanMessages;
   // Settings
   bool preAllocateAll;
   qreal global_ratio_limit;

--- a/src/rss/rssfeed.cpp
+++ b/src/rss/rssfeed.cpp
@@ -41,6 +41,7 @@
 #include "rssdownloadrulelist.h"
 #include "downloadthread.h"
 #include "fs_utils.h"
+#include "logger.h"
 
 bool rssArticleDateRecentThan(const RssArticlePtr& left, const RssArticlePtr& right)
 {
@@ -367,7 +368,7 @@ void RssFeed::downloadArticleTorrentIfMatching(RssDownloadRuleList* rules, const
   rules->saveRulesToStorage();
   // Download the torrent
   const QString& torrent_url = article->torrentUrl();
-  QBtSession::instance()->addConsoleMessage(tr("Automatically downloading %1 torrent from %2 RSS feed...").arg(article->title()).arg(displayName()));
+  Logger::instance()->addMessage(tr("Automatically downloading %1 torrent from %2 RSS feed...").arg(article->title()).arg(displayName()));
   connect(QBtSession::instance(), SIGNAL(newDownloadedTorrentFromRss(QString)), article.data(), SLOT(handleTorrentDownloadSuccess(const QString&)), Qt::UniqueConnection);
   connect(article.data(), SIGNAL(articleWasRead()), SLOT(handleArticleStateChanged()), Qt::UniqueConnection);
   if (torrent_url.startsWith("magnet:", Qt::CaseInsensitive))

--- a/src/smtp.cpp
+++ b/src/smtp.cpp
@@ -34,7 +34,7 @@
 
 #include "smtp.h"
 #include "preferences.h"
-#include "qbtsession.h"
+#include "logger.h"
 
 #include <QTextStream>
 #ifndef QT_NO_OPENSSL
@@ -48,6 +48,7 @@
 #include <QHostInfo>
 #include <QNetworkInterface>
 #include <QCryptographicHash>
+#include <QStringList>
 
 namespace {
 const short DEFAULT_PORT = 25;
@@ -475,5 +476,5 @@ void Smtp::authLogin()
 void Smtp::logError(const QString &msg)
 {
   qDebug() << "Email Notification Error:" << msg;
-  QBtSession::instance()->addConsoleMessage("Email Notification Error: "+msg, "red");
+  Logger::instance()->addMessage(tr("Email Notification Error:") + " " + msg, Log::CRITICAL);
 }

--- a/src/src.pro
+++ b/src/src.pro
@@ -110,7 +110,8 @@ HEADERS += misc.h \
            qinisettings.h \
            smtp.h \
            dnsupdater.h \
-           application.h
+           application.h \
+           logger.h
 
 SOURCES += main.cpp \
            downloadthread.cpp \
@@ -120,7 +121,8 @@ SOURCES += main.cpp \
            fs_utils.cpp \
            smtp.cpp \
            dnsupdater.cpp \
-           application.cpp
+           application.cpp \
+           logger.cpp
 
 nox {
   HEADERS += headlessloader.h

--- a/src/statusbar.cpp
+++ b/src/statusbar.cpp
@@ -38,6 +38,7 @@
 #include "iconprovider.h"
 #include "preferences.h"
 #include "misc.h"
+#include "logger.h"
 
 #include <libtorrent/session.hpp>
 #include <libtorrent/session_status.hpp>
@@ -149,7 +150,7 @@ void StatusBar::showRestartRequired() {
   m_bar->insertWidget(1, restartLbl);
   QFontMetrics fm(restartLbl->font());
   restartLbl->setText(fm.elidedText(restart_text, Qt::ElideRight, restartLbl->width()));
-  QBtSession::instance()->addConsoleMessage(tr("qBittorrent was just updated and needs to be restarted for the changes to be effective."), "red");
+  Logger::instance()->addMessage(tr("qBittorrent was just updated and needs to be restarted for the changes to be effective."), Log::CRITICAL);
 }
 
 void StatusBar::stopTimer() {

--- a/src/webui/prefjson.cpp
+++ b/src/webui/prefjson.cpp
@@ -40,6 +40,7 @@
 #include <QSslKey>
 #endif
 #include <QTranslator>
+#include <QCoreApplication>
 #include "jsonutils.h"
 
 prefjson::prefjson()


### PR DESCRIPTION
I wanted to decouple QbtSession from managing the logging framework. That code was messed up too. It couldn't easily be used outside that class.
I tried to create a simple, light and abstract interface. I hope I did it with the Logger class.

The Logger class can be used two ways:
1. Every piece of code can use it to push log messages
2. There can be different backends created and attached to it, which will further process the messages. For now the only backend that uses it is the GUI log. One backend that I intend to introduce in the future is a "file" backend. That backend will write the messages to disk and format them accordingly. It will also manage things like max log file size. Rotating the logs etc. One other backend that could benefit is the WebUI.(I suppose you'll request the messages each time and not listen to signals of the logger class). Lastly, if someone is adventurous he could write an ncurses backend for output in the terminal for the nox build.

I want your input. If something can be made better I would like to hear. If the WEBUI API would benefit from additional functions in the logger interface I would like to know. Or maybe I maid a programming mistake or some code could be simplified.

Caveats:
* nox was not tested. Travis-ci will barf if it is broken
* building against libtorrent 0.16.x was not tested. Travis-ci will barf if it is broken
* qt5 was not tested. I don't really think it is broken. Will test before final commit
* Just before pushing I saw that I never `Logger::instance()->drop()`. I am too tired now, I'll fix it tomorrow. No big deal.

@qbittorrent/qbittorrent-frequent-contributors 