### PR TITLE
Don't touch torrents whose files are missing (like when their drive isn'...

### DIFF
--- a/src/qtlibtorrent/qtorrenthandle.cpp
+++ b/src/qtlibtorrent/qtorrenthandle.cpp
@@ -511,7 +511,8 @@ void QTorrentHandle::pause() const
 {
     torrent_handle::auto_managed(false);
     torrent_handle::pause();
-    torrent_handle::save_resume_data();
+    if (!TorrentPersistentData::getHasMissingFiles(*this))
+      torrent_handle::save_resume_data();
 }
 
 void QTorrentHandle::resume() const

--- a/src/torrentpersistentdata.cpp
+++ b/src/torrentpersistentdata.cpp
@@ -396,6 +396,16 @@ void TorrentPersistentData::saveSeedStatus(const QString &hash, const bool seedS
   settings.setValue("torrents", all_data);
 }
 
+void TorrentPersistentData::setHasMissingFiles(const QTorrentHandle &h, bool missing) {
+  QString hash = h.hash();
+  QIniSettings settings(QString::fromUtf8("qBittorrent"), QString::fromUtf8("qBittorrent-resume"));
+  QHash<QString, QVariant> all_data = settings.value("torrents").toHash();
+  QHash<QString, QVariant> data = all_data[hash].toHash();
+  data["has_missing_files"] = missing;
+  all_data[hash] = data;
+  settings.setValue("torrents", all_data);
+}
+
 QString TorrentPersistentData::getSavePath(const QString &hash) {
   QIniSettings settings(QString::fromUtf8("qBittorrent"), QString::fromUtf8("qBittorrent-resume"));
   const QHash<QString, QVariant> all_data = settings.value("torrents").toHash();
@@ -445,4 +455,11 @@ QString TorrentPersistentData::getMagnetUri(const QString &hash) {
   const QHash<QString, QVariant> data = all_data.value(hash).toHash();
   Q_ASSERT(data.value("is_magnet", false).toBool());
   return data.value("magnet_uri").toString();
+}
+
+bool TorrentPersistentData::getHasMissingFiles(const QTorrentHandle &h) {
+  QIniSettings settings(QString::fromUtf8("qBittorrent"), QString::fromUtf8("qBittorrent-resume"));
+  const QHash<QString, QVariant> all_data = settings.value("torrents").toHash();
+  const QHash<QString, QVariant> data = all_data.value(h.hash()).toHash();
+  return data.value("has_missing_files").toBool();
 }

--- a/src/torrentpersistentdata.h
+++ b/src/torrentpersistentdata.h
@@ -142,6 +142,7 @@ public:
   static void savePriority(const QString &hash, const int &queue_pos);
   static void saveSeedStatus(const QTorrentHandle &h);
   static void saveSeedStatus(const QString &hash, const bool seedStatus);
+  static void setHasMissingFiles(const QTorrentHandle &h, bool missing);
 
   // Getters
   static QString getSavePath(const QString &hash);
@@ -151,6 +152,7 @@ public:
   static bool isSeed(const QString &hash);
   static bool isMagnet(const QString &hash);
   static QString getMagnetUri(const QString &hash);
+  static bool getHasMissingFiles(const QTorrentHandle &h);
 };
 
 #endif // TORRENTPERSISTENTDATA_H


### PR DESCRIPTION
...t plugged in).

This is related to #2308 and #342
This needs more polishing IMO.
The transferlist delegate should test for TorrentPersistentData::getHasMissingFiles() and display the status as "Missing files" or "Error: Files not found".

Ideally this should be postponed until #2112 gets merged.
Soft dependency of v3.2.0
