### PR TITLE
Reduce time to open the context menu in the transfer list

### DIFF
--- a/src/core/qtlibtorrent/qbtsession.cpp
+++ b/src/core/qtlibtorrent/qbtsession.cpp
@@ -1682,7 +1682,7 @@ bool QBtSession::isFilePreviewPossible(const QString &hash) const {
   }
   const unsigned int nbFiles = h.num_files();
   for (unsigned int i=0; i<nbFiles; ++i) {
-    const QString extension = fsutils::fileExtension(h.filename_at(i));
+    const QString extension = fsutils::fileExtension(h.filepath_at(i));
     if (misc::isPreviewable(extension))
       return true;
   }

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -809,8 +809,14 @@ void TransferListWidget::displayListMenu(const QPoint&)
                 has_pause = true;
             }
         }
-        if (h.has_metadata() && BTSession->isFilePreviewPossible(hash) && !has_preview)
-            has_preview = true;
+        if (!has_preview) {
+            // If the torrent contains many files, don't bother checking if any
+            // of them is previewable. qBittorrent might hang while doing so.
+            if (h.num_files() > 100)
+                has_preview = true;
+            else if (h.has_metadata() && BTSession->isFilePreviewPossible(hash))
+                has_preview = true;
+        }
         first = false;
         if (has_pause && has_start && has_preview && one_not_seed) break;
     }


### PR DESCRIPTION
Starting from libtorrent 1.0, QTorrentHandle::filepath_at() (and
hence isFilePreviewPossible()) became much slower, making qBittorrent
hangs when a right click is performed on torrents with many files.
Fix this by always showing the preview button when a torrent contains
many files (> 100), thus avoiding the use of isFilePreviewPossible().
qBittorrent will verify the presence of previewable files once the
option is clicked anyway.

In addition, avoid calling isFilePreviewPossible() if we already know
that there are previewable files and use QTorrentHandle::filepath_at()
instead of QTorrentHandle::filename_at() since it's a bit faster and it
makes no difference for what the extension of files is concerned.

Closes #2365.