### PR TITLE
Web API: Implement sync/maindata request

### DIFF
--- a/src/webui/abstractrequesthandler.h
+++ b/src/webui/abstractrequesthandler.h
@@ -37,53 +37,53 @@ struct WebSession;
 
 class AbstractRequestHandler
 {
-  friend class WebApplication;
+    friend class WebApplication;
 
 public:
-  AbstractRequestHandler(
-      const HttpRequest& request, const HttpEnvironment& env,
-      WebApplication* app);
+    AbstractRequestHandler(
+        const HttpRequest& request, const HttpEnvironment& env,
+        WebApplication* app);
 
-  HttpResponse run();
+    HttpResponse run();
 
 protected:
-  virtual void processRequest() = 0;
+    virtual void processRequest() = 0;
 
-  void status(uint code, const QString& text);
-  void header(const QString& name, const QString& value);
-  void print(const QString& text, const QString& type = CONTENT_TYPE_HTML);
-  void print(const QByteArray& data, const QString& type = CONTENT_TYPE_HTML);
-  void printFile(const QString& path);
+    void status(uint code, const QString& text);
+    void header(const QString& name, const QString& value);
+    void print(const QString& text, const QString& type = CONTENT_TYPE_HTML);
+    void print(const QByteArray& data, const QString& type = CONTENT_TYPE_HTML);
+    void printFile(const QString& path);
 
-  // Session management
-  bool sessionActive() const { return session_ != 0; }
-  void sessionInitialize();
-  void sessionStart();
-  void sessionEnd();
+    // Session management
+    bool sessionActive() const { return session_ != 0; }
+    void sessionInitialize();
+    void sessionStart();
+    void sessionEnd();
 
-  // Ban management
-  bool isBanned() const;
-  int failedAttempts() const;
-  void resetFailedAttempts();
-  void increaseFailedAttempts();
+    // Ban management
+    bool isBanned() const;
+    int failedAttempts() const;
+    void resetFailedAttempts();
+    void increaseFailedAttempts();
 
-  bool isAuthNeeded();
+    bool isAuthNeeded();
 
-  // save data to temporary file on disk and return its name (or empty string if fails)
-  static QString saveTmpFile(const QByteArray& data);
+    // save data to temporary file on disk and return its name (or empty string if fails)
+    static QString saveTmpFile(const QByteArray& data);
 
-  inline WebSession* session() { return session_; }
-  inline HttpRequest request() const { return request_; }
-  inline HttpEnvironment env() const { return env_; }
+    inline WebSession* session() { return session_; }
+    inline HttpRequest request() const { return request_; }
+    inline HttpEnvironment env() const { return env_; }
 
 private:
-  WebApplication* app_;
-  WebSession* session_;
-  const HttpRequest request_;
-  const HttpEnvironment env_;
-  HttpResponse response_;
+    WebApplication* app_;
+    WebSession* session_;
+    const HttpRequest request_;
+    const HttpEnvironment env_;
+    HttpResponse response_;
 
-  void print_impl(const QByteArray& data, const QString& type);
+    void print_impl(const QByteArray& data, const QString& type);
 };
 
 #endif // ABSTRACTREQUESTHANDLER_H

--- a/src/webui/btjson.cpp
+++ b/src/webui/btjson.cpp
@@ -101,6 +101,7 @@ static const char KEY_TORRENT_ETA[] = "eta";
 static const char KEY_TORRENT_STATE[] = "state";
 static const char KEY_TORRENT_SEQUENTIAL_DOWNLOAD[] = "seq_dl";
 static const char KEY_TORRENT_FIRST_LAST_PIECE_PRIO[] = "f_l_piece_prio";
+static const char KEY_TORRENT_LABEL[] = "label";
 
 // Tracker keys
 static const char KEY_TRACKER_URL[] = "url";
@@ -147,6 +148,8 @@ static const char KEY_FULL_UPDATE[] = "full_update";
 static const char KEY_RESPONSE_ID[] = "rid";
 static const char KEY_SUFFIX_REMOVED[] = "_removed";
 
+QVariantMap getTranserInfoMap();
+QVariantMap toMap(const QTorrentHandle& h);
 void processMap(QVariantMap prevData, QVariantMap data, QVariantMap &syncData);
 void processHash(QVariantHash prevData, QVariantHash data, QVariantHash &syncData, QVariantList &removedItems);
 void processList(QVariantList prevData, QVariantList data, QVariantList &syncData, QVariantList &removedItems);
@@ -204,36 +207,6 @@ private:
 #endif
 };
 
-static QVariantMap toMap(const QTorrentHandle& h)
-{
-    libtorrent::torrent_status status = h.status(torrent_handle::query_accurate_download_counters);
-
-    QVariantMap ret;
-    ret[KEY_TORRENT_HASH] =  h.hash();
-    ret[KEY_TORRENT_NAME] =  h.name();
-    ret[KEY_TORRENT_SIZE] =  static_cast<qlonglong>(status.total_wanted);
-    ret[KEY_TORRENT_PROGRESS] = h.progress(status);
-    ret[KEY_TORRENT_DLSPEED] = status.download_payload_rate;
-    ret[KEY_TORRENT_UPSPEED] = status.upload_payload_rate;
-    if (QBtSession::instance()->isQueueingEnabled() && h.queue_position(status) >= 0)
-        ret[KEY_TORRENT_PRIORITY] = h.queue_position(status);
-    else
-        ret[KEY_TORRENT_PRIORITY] = -1;
-    ret[KEY_TORRENT_SEEDS] = status.num_seeds;
-    ret[KEY_TORRENT_NUM_COMPLETE] = status.num_complete;
-    ret[KEY_TORRENT_LEECHS] = status.num_peers - status.num_seeds;
-    ret[KEY_TORRENT_NUM_INCOMPLETE] = status.num_incomplete;
-    const qreal ratio = QBtSession::instance()->getRealRatio(status);
-    ret[KEY_TORRENT_RATIO] = (ratio > QBtSession::MAX_RATIO) ? -1 : ratio;
-    ret[KEY_TORRENT_STATE] = h.torrentState().toString();
-    ret[KEY_TORRENT_ETA] = h.eta();
-    ret[KEY_TORRENT_SEQUENTIAL_DOWNLOAD] = status.sequential_download;
-    if (h.has_metadata())
-        ret[KEY_TORRENT_FIRST_LAST_PIECE_PRIO] = h.first_last_piece_first();
-
-    return ret;
-}
-
 /**
  * Returns all the torrents in JSON format.
  *
@@ -266,7 +239,7 @@ QByteArray btjson::getTorrents(QString filter, QString label,
     std::vector<torrent_handle>::const_iterator end = torrents.end();
 
     QTorrentFilter torrentFilter(filter, label);
-    for(; it != end; ++it) {
+    for (; it != end; ++it) {
         QTorrentHandle torrent = QTorrentHandle(*it);
 
         if (torrentFilter.apply(torrent))
@@ -288,6 +261,76 @@ QByteArray btjson::getTorrents(QString filter, QString label,
         return json::toJson(torrent_list.mid(offset, limit));
     else
         return json::toJson(torrent_list);
+}
+
+/**
+ * The function returns the changed data from the server to synchronize with the web client.
+ * Return value is map in JSON format.
+ * Map contain the key:
+ *  - "Rid": ID response
+ * Map can contain the keys:
+ *  - "full_update": full data update flag
+ *  - "torrents": dictionary contains information about torrents.
+ *  - "torrents_removed": a list of hashes of removed torrents
+ *  - "labels": list of labels
+ *  - "labels_removed": list of removed labels
+ *  - "queueing": priority system usage flag
+ *  - "server_state": map contains information about the status of the server
+ * The keys of the 'torrents' dictionary are hashes of torrents.
+ * Each value of the 'torrents' dictionary contains map. The map can contain following keys:
+ *  - "name": Torrent name
+ *  - "size": Torrent size
+ *  - "progress: Torrent progress
+ *  - "dlspeed": Torrent download speed
+ *  - "upspeed": Torrent upload speed
+ *  - "priority": Torrent priority (-1 if queuing is disabled)
+ *  - "num_seeds": Torrent seeds connected to
+ *  - "num_complete": Torrent seeds in the swarm
+ *  - "num_leechs": Torrent leechers connected to
+ *  - "num_incomplete": Torrent leechers in the swarm
+ *  - "ratio": Torrent share ratio
+ *  - "eta": Torrent ETA
+ *  - "state": Torrent state
+ *  - "seq_dl": Torrent sequential download state
+ *  - "f_l_piece_prio": Torrent first last piece priority state
+ * Server state map may contain the following keys:
+ *  - "connection_status": conection status
+ *  - "dht_nodes": DHT nodes count
+ *  - "dl_info_data": bytes downloaded
+ *  - "dl_info_speed": download speed
+ *  - "dl_rate_limit: downlaod rate limit
+ *  - "up_info_data: bytes uploaded
+ *  - "up_info_speed: upload speed
+ *  - "up_rate_limit: upload speed limit
+ */
+QByteArray btjson::getSyncMainData(int acceptedResponseId, QVariantMap &lastData, QVariantMap &lastAcceptedData)
+{
+    QVariantMap data;
+
+    QVariantHash torrents;
+
+    std::vector<torrent_handle> torrentsList = QBtSession::instance()->getTorrents();
+    std::vector<torrent_handle>::const_iterator it = torrentsList.begin();
+    std::vector<torrent_handle>::const_iterator end = torrentsList.end();
+
+    for (; it != end; ++it) {
+        QTorrentHandle torrent = QTorrentHandle(*it);
+        QVariantMap map = toMap(torrent);
+        map.remove(KEY_TORRENT_HASH);
+        torrents[torrent.hash()] = map;
+    }
+
+    data["torrents"] = torrents;
+    data["queueing"] = QBtSession::instance()->isQueueingEnabled();
+
+    QVariantList labels;
+    foreach (QString s, Preferences::instance()->getTorrentLabels())
+        labels << s;
+
+    data["labels"] = labels;
+    data["server_state"] = getTranserInfoMap();
+
+    return json::toJson(generateSyncData(acceptedResponseId, data, lastAcceptedData, lastData));
 }
 
 /**
@@ -331,7 +374,7 @@ QByteArray btjson::getTrackersForTorrent(const QString& hash)
             tracker_list.append(tracker_dict);
         }
     }
-    catch(const std::exception& e) {
+    catch (const std::exception& e) {
         qWarning() << Q_FUNC_INFO << "Invalid torrent: " << misc::toQStringU(e.what());
         return QByteArray();
     }
@@ -393,7 +436,7 @@ QByteArray btjson::getPropertiesForTorrent(const QString& hash)
         const qreal ratio = QBtSession::instance()->getRealRatio(status);
         data[KEY_PROP_RATIO] = ratio > QBtSession::MAX_RATIO ? -1 : ratio;
     }
-    catch(const std::exception& e) {
+    catch (const std::exception& e) {
         qWarning() << Q_FUNC_INFO << "Invalid torrent: " << misc::toQStringU(e.what());
         return QByteArray();
     }
@@ -463,23 +506,57 @@ QByteArray btjson::getFilesForTorrent(const QString& hash)
  */
 QByteArray btjson::getTransferInfo()
 {
-    QVariantMap info;
+    return json::toJson(getTranserInfoMap());
+}
+
+QVariantMap getTranserInfoMap()
+{
+    QVariantMap map;
     session_status sessionStatus = QBtSession::instance()->getSessionStatus();
     session_settings sessionSettings = QBtSession::instance()->getSession()->settings();
-    info[KEY_TRANSFER_DLSPEED] = sessionStatus.payload_download_rate;
-    info[KEY_TRANSFER_DLDATA] = static_cast<qlonglong>(sessionStatus.total_payload_download);
-    info[KEY_TRANSFER_UPSPEED] = sessionStatus.payload_upload_rate;
-    info[KEY_TRANSFER_UPDATA] = static_cast<qlonglong>(sessionStatus.total_payload_upload);
-    if (sessionSettings.download_rate_limit)
-        info[KEY_TRANSFER_DLRATELIMIT] = sessionSettings.download_rate_limit;
-    if (sessionSettings.upload_rate_limit)
-        info[KEY_TRANSFER_UPRATELIMIT] = sessionSettings.upload_rate_limit;
-    info[KEY_TRANSFER_DHT_NODES] = sessionStatus.dht_nodes;
+    map[KEY_TRANSFER_DLSPEED] = sessionStatus.payload_download_rate;
+    map[KEY_TRANSFER_DLDATA] = static_cast<qlonglong>(sessionStatus.total_payload_download);
+    map[KEY_TRANSFER_UPSPEED] = sessionStatus.payload_upload_rate;
+    map[KEY_TRANSFER_UPDATA] = static_cast<qlonglong>(sessionStatus.total_payload_upload);
+    map[KEY_TRANSFER_DLRATELIMIT] = sessionSettings.download_rate_limit;
+    map[KEY_TRANSFER_UPRATELIMIT] = sessionSettings.upload_rate_limit;
+    map[KEY_TRANSFER_DHT_NODES] = sessionStatus.dht_nodes;
     if (!QBtSession::instance()->getSession()->is_listening())
-        info[KEY_TRANSFER_CONNECTION_STATUS] = "disconnected";
+        map[KEY_TRANSFER_CONNECTION_STATUS] = "disconnected";
     else
-        info[KEY_TRANSFER_CONNECTION_STATUS] = sessionStatus.has_incoming_connections ? "connected" : "firewalled";
-    return json::toJson(info);
+        map[KEY_TRANSFER_CONNECTION_STATUS] = sessionStatus.has_incoming_connections ? "connected" : "firewalled";
+    return map;
+}
+
+QVariantMap toMap(const QTorrentHandle& h)
+{
+    libtorrent::torrent_status status = h.status(torrent_handle::query_accurate_download_counters);
+
+    QVariantMap ret;
+    ret[KEY_TORRENT_HASH] =  h.hash();
+    ret[KEY_TORRENT_NAME] =  h.name();
+    ret[KEY_TORRENT_SIZE] =  static_cast<qlonglong>(status.total_wanted);
+    ret[KEY_TORRENT_PROGRESS] = h.progress(status);
+    ret[KEY_TORRENT_DLSPEED] = status.download_payload_rate;
+    ret[KEY_TORRENT_UPSPEED] = status.upload_payload_rate;
+    if (QBtSession::instance()->isQueueingEnabled() && h.queue_position(status) >= 0)
+        ret[KEY_TORRENT_PRIORITY] = h.queue_position(status);
+    else
+        ret[KEY_TORRENT_PRIORITY] = -1;
+    ret[KEY_TORRENT_SEEDS] = status.num_seeds;
+    ret[KEY_TORRENT_NUM_COMPLETE] = status.num_complete;
+    ret[KEY_TORRENT_LEECHS] = status.num_peers - status.num_seeds;
+    ret[KEY_TORRENT_NUM_INCOMPLETE] = status.num_incomplete;
+    const qreal ratio = QBtSession::instance()->getRealRatio(status);
+    ret[KEY_TORRENT_RATIO] = (ratio > QBtSession::MAX_RATIO) ? -1 : ratio;
+    ret[KEY_TORRENT_STATE] = h.torrentState().toString();
+    ret[KEY_TORRENT_ETA] = h.eta();
+    ret[KEY_TORRENT_SEQUENTIAL_DOWNLOAD] = status.sequential_download;
+    if (h.has_metadata())
+        ret[KEY_TORRENT_FIRST_LAST_PIECE_PRIO] = h.first_last_piece_first();
+    ret[KEY_TORRENT_LABEL] = TorrentPersistentData::getLabel(h.hash());
+
+    return ret;
 }
 
 // Compare two structures (prevData, data) and calculate difference (syncData).

--- a/src/webui/btjson.h
+++ b/src/webui/btjson.h
@@ -33,6 +33,7 @@
 
 #include <QCoreApplication>
 #include <QString>
+#include <QVariant>
 
 class QTorrentHandle;
 
@@ -46,6 +47,7 @@ private:
 public:
     static QByteArray getTorrents(QString filter = "all", QString label = QString(),
         QString sortedColumn = "name", bool reverse = false, int limit = 0, int offset = 0);
+    static QByteArray getSyncMainData(int acceptedResponseId, QVariantMap &lastData, QVariantMap &lastAcceptedData);
     static QByteArray getTrackersForTorrent(const QString& hash);
     static QByteArray getPropertiesForTorrent(const QString& hash);
     static QByteArray getFilesForTorrent(const QString& hash);

--- a/src/webui/requesthandler.cpp
+++ b/src/webui/requesthandler.cpp
@@ -48,6 +48,7 @@
 #include "prefjson.h"
 #include "qbtsession.h"
 #include "requesthandler.h"
+#include "webapplication.h"
 
 using namespace libtorrent;
 
@@ -82,6 +83,7 @@ QMap<QString, QMap<QString, RequestHandler::Action> > RequestHandler::initialize
     ADD_ACTION(json, propertiesGeneral);
     ADD_ACTION(json, propertiesTrackers);
     ADD_ACTION(json, propertiesFiles);
+    ADD_ACTION(sync, maindata);
     ADD_ACTION(command, shutdown);
     ADD_ACTION(command, download);
     ADD_ACTION(command, upload);
@@ -259,6 +261,14 @@ void RequestHandler::action_json_propertiesFiles()
 {
     CHECK_URI(1);
     print(btjson::getFilesForTorrent(args_.front()), CONTENT_TYPE_JS);
+}
+
+// GET param:
+//   - rid (int): last response id
+void RequestHandler::action_sync_maindata()
+{
+    CHECK_URI(0);
+    print(btjson::getSyncMainData(request().gets["rid"].toInt(), session()->syncMainDataLastResponse, session()->syncMainDataLastAcceptedResponse));
 }
 
 void RequestHandler::action_version_api()

--- a/src/webui/requesthandler.h
+++ b/src/webui/requesthandler.h
@@ -56,6 +56,7 @@ private:
     void action_json_propertiesGeneral();
     void action_json_propertiesTrackers();
     void action_json_propertiesFiles();
+    void action_sync_maindata();
     void action_command_shutdown();
     void action_command_download();
     void action_command_upload();

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -36,9 +36,9 @@
 
 struct WebSession
 {
-  const QString id;
+    const QString id;
 
-  WebSession(const QString& id): id(id) {}
+    WebSession(const QString& id): id(id) {}
 };
 
 const QString C_SID = "SID"; // name of session id cookie
@@ -49,39 +49,39 @@ class AbstractRequestHandler;
 
 class WebApplication: public QObject
 {
-  Q_OBJECT
-  Q_DISABLE_COPY(WebApplication)
+    Q_OBJECT
+    Q_DISABLE_COPY(WebApplication)
 
 public:
-  WebApplication(QObject* parent = 0);
-  virtual ~WebApplication();
+    WebApplication(QObject* parent = 0);
+    virtual ~WebApplication();
 
-  static WebApplication* instance();
+    static WebApplication* instance();
 
-  bool isBanned(const AbstractRequestHandler* _this) const;
-  int failedAttempts(const AbstractRequestHandler *_this) const;
-  void resetFailedAttempts(AbstractRequestHandler* _this);
-  void increaseFailedAttempts(AbstractRequestHandler* _this);
+    bool isBanned(const AbstractRequestHandler* _this) const;
+    int failedAttempts(const AbstractRequestHandler *_this) const;
+    void resetFailedAttempts(AbstractRequestHandler* _this);
+    void increaseFailedAttempts(AbstractRequestHandler* _this);
 
-  bool sessionStart(AbstractRequestHandler* _this);
-  bool sessionEnd(AbstractRequestHandler* _this);
-  bool sessionInitialize(AbstractRequestHandler* _this);
+    bool sessionStart(AbstractRequestHandler* _this);
+    bool sessionEnd(AbstractRequestHandler* _this);
+    bool sessionInitialize(AbstractRequestHandler* _this);
 
-  bool readFile(const QString &path, QByteArray& data, QString& type);
+    bool readFile(const QString &path, QByteArray& data, QString& type);
 
 private slots:
-  void UnbanTimerEvent();
+    void UnbanTimerEvent();
 
 private:
-  QMap<QString, WebSession*> sessions_;
-  QHash<QHostAddress, int> clientFailedAttempts_;
-  QMap<QString, QByteArray> translatedFiles_;
+    QMap<QString, WebSession*> sessions_;
+    QHash<QHostAddress, int> clientFailedAttempts_;
+    QMap<QString, QByteArray> translatedFiles_;
 
-  QString generateSid();
-  static void translateDocument(QString& data);
+    QString generateSid();
+    static void translateDocument(QString& data);
 
-  static const QStringMap CONTENT_TYPE_BY_EXT;
-  static QStringMap initializeContentTypeByExtMap();
+    static const QStringMap CONTENT_TYPE_BY_EXT;
+    static QStringMap initializeContentTypeByExtMap();
 };
 
 #endif // WEBAPPLICATION_H

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -33,11 +33,13 @@
 #include <QMap>
 #include <QHash>
 #include "httptypes.h"
+#include <QVariant>
 
 struct WebSession
 {
     const QString id;
-
+    QVariantMap syncMainDataLastResponse;
+    QVariantMap syncMainDataLastAcceptedResponse;
     WebSession(const QString& id): id(id) {}
 };
 

--- a/src/webui/www/public/downloadlimit.html
+++ b/src/webui/www/public/downloadlimit.html
@@ -31,7 +31,7 @@
                     'limit': limit
                 },
                 onComplete: function() {
-                    window.parent.updateTransferInfo();
+                    window.parent.updateMainData();
                     window.parent.closeWindows();
                 }
             }).send();

--- a/src/webui/www/public/scripts/mocha-init.js
+++ b/src/webui/www/public/scripts/mocha-init.js
@@ -55,7 +55,7 @@ initializeWindows = function() {
             width: 500,
             height: 300
         });
-        updateTransferList();
+        updateMainData();
     });
 
     addClickEvent('preferences', function(e) {
@@ -95,7 +95,7 @@ initializeWindows = function() {
             width: 600,
             height: 130
         });
-        updateTransferList();
+        updateMainData();
     });
 
     globalUploadLimitFN = function() {
@@ -144,7 +144,7 @@ initializeWindows = function() {
                     hashes: h.join("|")
                 }
             }).send();
-            updateTransferList();
+            updateMainData();
         }
     };
 
@@ -158,7 +158,7 @@ initializeWindows = function() {
                     hashes: h.join("|")
                 }
             }).send();
-            updateTransferList();
+            updateMainData();
         }
     };
 
@@ -218,7 +218,7 @@ initializeWindows = function() {
                 width: 424,
                 height: 140
             });
-            updateTransferList();
+            updateMainData();
         }
     };
 
@@ -239,7 +239,7 @@ initializeWindows = function() {
                     }
                 }).send();
             });
-            updateTransferList();
+            updateMainData();
         }
     };
 
@@ -255,7 +255,7 @@ initializeWindows = function() {
                     }
                 }).send();
             });
-            updateTransferList();
+            updateMainData();
         }
     };
 
@@ -288,7 +288,7 @@ initializeWindows = function() {
                         }
                     }).send();
                 });
-                updateTransferList();
+                updateMainData();
             }
         });
 
@@ -317,7 +317,7 @@ initializeWindows = function() {
                     hashes: h.join("|")
                 }
             }).send();
-            updateTransferList();
+            updateMainData();
         }
     }
 

--- a/src/webui/www/public/uploadlimit.html
+++ b/src/webui/www/public/uploadlimit.html
@@ -31,7 +31,7 @@
                     'limit': limit
                 },
                 onComplete: function() {
-                    window.parent.updateTransferInfo();
+                    window.parent.updateMainData();
                     window.parent.closeWindows();
                 }
             }).send();


### PR DESCRIPTION
```sync/maindata``` request is used to synchronize torrents data, labels, server state (transfer speed, transfer speed limit, connection state, etc.) with web client. Response of ```sync/maindata``` request will contain only the changed data from the previous request if ID of previous request ( ```rid``` ) was passed to the request.