### PR TITLE
Include QFont headers for OS X

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -33,6 +33,10 @@
 #include <QLibraryInfo>
 #include <QSysInfo>
 
+#if (!defined(DISABLE_GUI) && defined(Q_OS_MAC))
+#include <QFont>
+#endif
+
 #include "application.h"
 #include "preferences.h"
 


### PR DESCRIPTION
Fix compilation on OS X >10.8 by including headers for QFont.

Without this, I get the following error during compilation on OS X 10.10 with both Qt4 and Qt5:
```
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++ -c -pipe -g -O2 -stdlib=libc++ -O2 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk -mmacosx-version-min=10.7 -Wall -W -fPIE -DWITH_GEOIP_EMBEDDED -DTORRENT_LINKING_SHARED -DBOOST_ASIO_DYN_LINK -DBOOST_ASIO_ENABLE_CANCELIO -DBOOST_EXCEPTION_DISABLE -DBOOST_ASIO_HASH_MAP_BUCKETS=1021 -DTORRENT_USE_OPENSSL -DWITH_GEOIP_EMBEDDED -DQT_NO_DEBUG_OUTPUT -DVERSION_MAJOR=3 -DVERSION_MINOR=2 -DVERSION_BUGFIX=0 -DVERSION_BUILD=0 -DVERSION=\"v3.2.0alpha\" -DQT_NO_CAST_TO_ASCII -DQT_USE_FAST_CONCATENATION -DQT_USE_FAST_OPERATOR_PLUS -DBOOST_FILESYSTEM_VERSION=2 -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_XML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -I/usr/local/Cellar/qt5/5.4.0/mkspecs/macx-clang -I. -I/usr/local/Cellar/boost/1.57.0/include -I/usr/local/Cellar/libtorrent-rasterbar/1.0.3/include/libtorrent -I/usr/local/Cellar/libtorrent-rasterbar/1.0.3/include -I. -Iqtsingleapp -Iqtlibtorrent -Iwebui -Itracker -Ipreferences -Ilineedit/src -Iproperties -Isearchengine -Irss -Itorrentcreator -Igeoip -Ipowermanagement -I/usr/local/Cellar/qt5/5.4.0/lib/QtWidgets.framework/Versions/5/Headers -I/usr/local/Cellar/qt5/5.4.0/lib/QtGui.framework/Versions/5/Headers -I/usr/local/Cellar/qt5/5.4.0/lib/QtXml.framework/Versions/5/Headers -I/usr/local/Cellar/qt5/5.4.0/lib/QtNetwork.framework/Versions/5/Headers -I/usr/local/Cellar/qt5/5.4.0/lib/QtCore.framework/Versions/5/Headers -I. -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/System/Library/Frameworks/OpenGL.framework/Versions/A/Headers -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/System/Library/Frameworks/AGL.framework/Headers -I. -F/usr/local/Cellar/qt5/5.4.0/lib -o application.o application.cpp
application.cpp:50:9: error: incomplete type 'QFont' named in nested name specifier
        QFont::insertSubstitution(".Lucida Grande UI", "Lucida Grande");
        ^~~~~~~
/usr/local/Cellar/qt5/5.4.0/lib/QtCore.framework/Headers/qmetatype.h:1749:1: note: forward declaration of 'QFont'
QT_FOR_EACH_STATIC_GUI_CLASS(QT_FORWARD_DECLARE_STATIC_TYPES_ITER)
^
/usr/local/Cellar/qt5/5.4.0/lib/QtCore.framework/Headers/qmetatype.h:125:18: note: expanded from macro 'QT_FOR_EACH_STATIC_GUI_CLASS'
    F(QFont, 64, QFont) \
                 ^
/usr/local/Cellar/qt5/5.4.0/lib/QtCore.framework/Headers/qmetatype.h:1746:11: note: expanded from macro 'QT_FORWARD_DECLARE_STATIC_TYPES_ITER'
    class Name;
          ^
1 error generated.
Makefile:64104: recipe for target 'application.o' failed
```