### PR TITLE
Fix OS X compilation and packaging

### DIFF
--- a/macxconf.pri
+++ b/macxconf.pri
@@ -21,7 +21,7 @@ qt_conf.path = Contents/Resources
 qt_conf.files = mac/qt.conf
 QMAKE_BUNDLE_DATA += qt_conf
 
-qt_translations.path = Contents/MacOS/translations
+qt_translations.path = Contents/translations
 qt_translations.files = qt-translations/qt_ar.qm \
                         qt-translations/qt_bg.qm \
                         qt-translations/qt_ca.qm \

--- a/macxconf.pri
+++ b/macxconf.pri
@@ -10,8 +10,7 @@ exists($$OUT_PWD/../conf.pri) {
 }
 
 LIBS += -framework Carbon -framework IOKit
-QMAKE_CXXFLAGS += -stdlib=libc++
-QMAKE_LFLAGS += -stdlib=libc++
+CONFIG += c++11
 
 document_icon.path = Contents/Resources
 document_icon.files = mac/qBitTorrentDocument.icns

--- a/macxconf.pri
+++ b/macxconf.pri
@@ -10,6 +10,8 @@ exists($$OUT_PWD/../conf.pri) {
 }
 
 LIBS += -framework Carbon -framework IOKit
+QMAKE_CXXFLAGS += -stdlib=libc++
+QMAKE_LFLAGS += -stdlib=libc++
 
 document_icon.path = Contents/Resources
 document_icon.files = mac/qBitTorrentDocument.icns

--- a/src/about_imp.h
+++ b/src/about_imp.h
@@ -69,7 +69,7 @@ class about : public QDialog, private Ui::AboutDlg{
       // Set icons
       logo->setPixmap(QPixmap(QString::fromUtf8(":/Icons/skin/qbittorrent22.png")));
       //Title
-      lb_name->setText(QString::fromUtf8("<b><h1>qBittorrent")+QString::fromUtf8(" "VERSION"</h1></b>"));
+      lb_name->setText(QString::fromUtf8("<b><h1>qBittorrent")+QString::fromUtf8(" " VERSION"</h1></b>"));
       // Thanks
       QString thanks_txt;
       thanks_txt += QString::fromUtf8("<p>I would first like to thank sourceforge.net for hosting qBittorrent project and for their support.</p>");

--- a/src/dnsupdater.cpp
+++ b/src/dnsupdater.cpp
@@ -76,7 +76,7 @@ void DNSUpdater::checkPublicIP()
   m_lastIPCheckTime = QDateTime::currentDateTime();
   QNetworkRequest request;
   request.setUrl(QUrl("http://checkip.dyndns.org"));
-  request.setRawHeader("User-Agent", "qBittorrent/"VERSION" chris@qbittorrent.org");
+  request.setRawHeader("User-Agent", "qBittorrent/" VERSION" chris@qbittorrent.org");
   manager->get(request);
 }
 
@@ -123,7 +123,7 @@ void DNSUpdater::updateDNSService()
   m_lastIPCheckTime = QDateTime::currentDateTime();
   QNetworkRequest request;
   request.setUrl(getUpdateUrl());
-  request.setRawHeader("User-Agent", "qBittorrent/"VERSION" chris@qbittorrent.org");
+  request.setRawHeader("User-Agent", "qBittorrent/" VERSION" chris@qbittorrent.org");
   manager->get(request);
 }
 

--- a/src/mac/qt.conf
+++ b/src/mac/qt.conf
@@ -1,4 +1,3 @@
 [Paths]
- Prefix = MacOS
  Translations = translations
  Plugins = PlugIns

--- a/src/qtlibtorrent/qbtsession.cpp
+++ b/src/qtlibtorrent/qbtsession.cpp
@@ -421,7 +421,7 @@ void QBtSession::configureSession() {
   }
   // * Session settings
   session_settings sessionSettings = s->settings();
-  sessionSettings.user_agent = "qBittorrent "VERSION;
+  sessionSettings.user_agent = "qBittorrent " VERSION;
   //std::cout << "HTTP user agent is " << sessionSettings.user_agent << std::endl;
   logger->addMessage(tr("HTTP user agent is %1").arg(misc::toQString(sessionSettings.user_agent)));
 

--- a/src/torrentcreator/torrentcreatorthread.cpp
+++ b/src/torrentcreator/torrentcreatorthread.cpp
@@ -83,7 +83,7 @@ void TorrentCreatorThread::sendProgressSignal(int progress) {
 
 void TorrentCreatorThread::run() {
   emit updateProgress(0);
-  QString creator_str("qBittorrent "VERSION);
+  QString creator_str("qBittorrent " VERSION);
   try {
     file_storage fs;
     // Adding files to the torrent


### PR DESCRIPTION
Qt5 on OS X apparently does not add ```-stdlib=libc++``` to *CXXFLAGS* or *LFLAGS*, so they must be added by us for compilation to succeed. Fix packaging by removing erroneous ```Prefix``` entry from the Mac *qt.conf*, change translation install location.

Fixes #2133