### PR TITLE
Fix: default settings in "Create Torrent" dialog

### DIFF
--- a/src/core/preferences.cpp
+++ b/src/core/preferences.cpp
@@ -1840,7 +1840,7 @@ void Preferences::setCreateTorLastSavePath(const QString &path) {
 }
 
 QString Preferences::getCreateTorTrackers() const {
-  return value("CreateTorrent/TrackerList", QDir::homePath()).toString();
+  return value("CreateTorrent/TrackerList").toString();
 }
 
 void Preferences::setCreateTorTrackers(const QString &path) {


### PR DESCRIPTION
The first time you create a new torrent, in the TrackerList textbox appears your home dir.