### PR TITLE
WebUI: Update browser title even with no transfer going on

### DIFF
--- a/src/webui/www/public/scripts/client.js
+++ b/src/webui/www/public/scripts/client.js
@@ -271,7 +271,7 @@ window.addEvent('load', function () {
             $('speedInBrowserTitleBarLink').firstChild.style.opacity = '1';
         else
             $('speedInBrowserTitleBarLink').firstChild.style.opacity = '0';
-        updateMainData();
+        processServerState();
     });
 
     new MochaUI.Panel({


### PR DESCRIPTION
Because of the recent changes the browser title is updated only when the server state changes, so the browser title is not always immediately updated (basically when there's no transfer going on).