### PR TITLE
WebUI: Fix negative offsets when requesting torrent list

### DIFF
--- a/src/webui/btjson.cpp
+++ b/src/webui/btjson.cpp
@@ -250,7 +250,7 @@ QByteArray btjson::getTorrents(QString filter, QString label,
     int size = torrent_list.size();
     // normalize offset
     if (offset < 0)
-        offset = size - offset;
+        offset = size + offset;
     if ((offset >= size) || (offset < 0))
         offset = 0;
     // normalize limit


### PR DESCRIPTION
If the offset is negative, it must be added to the current list size.