### PR TITLE
Add "Copy name" option in right-click menu of torrent list

### DIFF
--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -755,7 +755,7 @@ void TransferListWidget::displayListMenu(const QPoint&)
     QAction actionCopy_magnet_link(QIcon(":/icons/magnet.png"), tr("Copy magnet link"), 0);
     connect(&actionCopy_magnet_link, SIGNAL(triggered()), this, SLOT(copySelectedMagnetURIs()));
 
-    QAction actionCopy_caption_list(tr("Copy name"), 0);
+    QAction actionCopy_caption_list(IconProvider::instance()->getIcon("edit-copy"), tr("Copy name"), 0);
     connect(&actionCopy_caption_list, SIGNAL(triggered()), this, SLOT(copySelectedCaptions()));
 
     QAction actionSuper_seeding_mode(tr("Super seeding mode"), 0);
@@ -890,8 +890,8 @@ void TransferListWidget::displayListMenu(const QPoint&)
         prioMenu->addAction(&actionBottomPriority);
     }
     listMenu.addSeparator();
-    listMenu.addAction(&actionCopy_magnet_link);
     listMenu.addAction(&actionCopy_caption_list);
+    listMenu.addAction(&actionCopy_magnet_link);
     // Call menu
     QAction *act = 0;
     act = listMenu.exec(QCursor::pos());

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -424,17 +424,16 @@ void TransferListWidget::copySelectedMagnetURIs() const
     qApp->clipboard()->setText(magnet_uris.join("\n"));
 }
 
-// create list of captions from tasklist.
-void TransferListWidget::copySelectedCaptions() const
+void TransferListWidget::copySelectedNames() const
 {
-    QStringList captions;
+    QStringList torrent_names;
     const QStringList hashes = getSelectedTorrentsHashes();
     foreach (const QString &hash, hashes) {
         const QTorrentHandle h = BTSession->getTorrentHandle(hash);
         if (h.is_valid())
-            captions << h.name();
+            torrent_names << h.name();
     }
-    qApp->clipboard()->setText(captions.join("\n"));
+    qApp->clipboard()->setText(torrent_names.join("\n"));
 }
 
 void TransferListWidget::hidePriorityColumn(bool hide)
@@ -755,8 +754,8 @@ void TransferListWidget::displayListMenu(const QPoint&)
     QAction actionCopy_magnet_link(QIcon(":/icons/magnet.png"), tr("Copy magnet link"), 0);
     connect(&actionCopy_magnet_link, SIGNAL(triggered()), this, SLOT(copySelectedMagnetURIs()));
 
-    QAction actionCopy_caption_list(IconProvider::instance()->getIcon("edit-copy"), tr("Copy name"), 0);
-    connect(&actionCopy_caption_list, SIGNAL(triggered()), this, SLOT(copySelectedCaptions()));
+    QAction actionCopy_name(IconProvider::instance()->getIcon("edit-copy"), tr("Copy name"), 0);
+    connect(&actionCopy_name, SIGNAL(triggered()), this, SLOT(copySelectedNames()));
 
     QAction actionSuper_seeding_mode(tr("Super seeding mode"), 0);
     actionSuper_seeding_mode.setCheckable(true);
@@ -890,7 +889,7 @@ void TransferListWidget::displayListMenu(const QPoint&)
         prioMenu->addAction(&actionBottomPriority);
     }
     listMenu.addSeparator();
-    listMenu.addAction(&actionCopy_caption_list);
+    listMenu.addAction(&actionCopy_name);
     listMenu.addAction(&actionCopy_magnet_link);
     // Call menu
     QAction *act = 0;

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -424,6 +424,19 @@ void TransferListWidget::copySelectedMagnetURIs() const
     qApp->clipboard()->setText(magnet_uris.join("\n"));
 }
 
+// create list of captions from tasklist.
+void TransferListWidget::copySelectedCaptions() const
+{
+    QStringList captions;
+    const QStringList hashes = getSelectedTorrentsHashes();
+    foreach (const QString &hash, hashes) {
+        const QTorrentHandle h = BTSession->getTorrentHandle(hash);
+        if (h.is_valid())
+            captions << h.name();
+    }
+    qApp->clipboard()->setText(captions.join("\n"));
+}
+
 void TransferListWidget::hidePriorityColumn(bool hide)
 {
     qDebug("hidePriorityColumn(%d)", hide);
@@ -741,6 +754,10 @@ void TransferListWidget::displayListMenu(const QPoint&)
     connect(&actionForce_recheck, SIGNAL(triggered()), this, SLOT(recheckSelectedTorrents()));
     QAction actionCopy_magnet_link(QIcon(":/icons/magnet.png"), tr("Copy magnet link"), 0);
     connect(&actionCopy_magnet_link, SIGNAL(triggered()), this, SLOT(copySelectedMagnetURIs()));
+
+    QAction actionCopy_caption_list(tr("Copy name"), 0);
+    connect(&actionCopy_caption_list, SIGNAL(triggered()), this, SLOT(copySelectedCaptions()));
+
     QAction actionSuper_seeding_mode(tr("Super seeding mode"), 0);
     actionSuper_seeding_mode.setCheckable(true);
     connect(&actionSuper_seeding_mode, SIGNAL(triggered()), this, SLOT(toggleSelectedTorrentsSuperSeeding()));
@@ -874,6 +891,7 @@ void TransferListWidget::displayListMenu(const QPoint&)
     }
     listMenu.addSeparator();
     listMenu.addAction(&actionCopy_magnet_link);
+    listMenu.addAction(&actionCopy_caption_list);
     // Call menu
     QAction *act = 0;
     act = listMenu.exec(QCursor::pos());

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -71,7 +71,7 @@ public slots:
     void topPrioSelectedTorrents();
     void bottomPrioSelectedTorrents();
     void copySelectedMagnetURIs() const;
-    void copySelectedCaptions() const;
+    void copySelectedNames() const;
     void openSelectedTorrentsFolder() const;
     void recheckSelectedTorrents();
     void setDlLimitSelectedTorrents();

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -71,6 +71,7 @@ public slots:
     void topPrioSelectedTorrents();
     void bottomPrioSelectedTorrents();
     void copySelectedMagnetURIs() const;
+    void copySelectedCaptions() const;
     void openSelectedTorrentsFolder() const;
     void recheckSelectedTorrents();
     void setDlLimitSelectedTorrents();


### PR DESCRIPTION
Implementation of feature request #2452 

Adds a new option in the right-click menu of the torrent list to copy the name(s) of selected torrent(s) to the clipboard. This is similar to the existing option to copy the magnet links to the clipboard.

This patch was originally authored by Chris Hirst (ciaobaby, @chrishirst ). I changed the item name from "Copy caption" to "Copy name" (the torrent list column header says "Name"), and I added the missing line in the header file.

Note: Translations are not updated for the English menu item "Copy name".