### PR TITLE
Fix: error in mininova search engine

### DIFF
--- a/src/gui/searchengine/nova/engines/mininova.py
+++ b/src/gui/searchengine/nova/engines/mininova.py
@@ -1,5 +1,6 @@
-#VERSION: 1.50
+#VERSION: 1.51
 #AUTHORS: Christophe Dumez (chris@qbittorrent.org)
+#CONTRIBUTORS: Diego de las Heras (diegodelasheras@gmail.com)
 
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -59,7 +60,7 @@ class mininova(object):
           self.current_item = {}
           self.td_counter = 0
           self.current_item['link']=self.url+params['href'].strip()
-        elif params['href'].startswith("/tor/"):
+        elif params['href'].startswith("/tor/") and self.current_item is not None:
           self.current_item['desc_link']=self.url+params['href'].strip()
     
     def handle_data(self, data):

--- a/src/gui/searchengine/nova/engines/versions.txt
+++ b/src/gui/searchengine/nova/engines/versions.txt
@@ -1,5 +1,5 @@
 torrentreactor: 1.33
-mininova: 1.50
+mininova: 1.51
 piratebay: 2.01
 extratorrent: 1.2
 kickasstorrents: 1.25

--- a/src/gui/searchengine/nova3/engines/mininova.py
+++ b/src/gui/searchengine/nova3/engines/mininova.py
@@ -1,5 +1,6 @@
-#VERSION: 1.50
+#VERSION: 1.51
 #AUTHORS: Christophe Dumez (chris@qbittorrent.org)
+#CONTRIBUTORS: Diego de las Heras (diegodelasheras@gmail.com)
 
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -59,7 +60,7 @@ class mininova(object):
           self.current_item = {}
           self.td_counter = 0
           self.current_item['link']=self.url+params['href'].strip()
-        elif params['href'].startswith("/tor/"):
+        elif params['href'].startswith("/tor/") and self.current_item is not None:
           self.current_item['desc_link']=self.url+params['href'].strip()
     
     def handle_data(self, data):

--- a/src/gui/searchengine/nova3/engines/versions.txt
+++ b/src/gui/searchengine/nova3/engines/versions.txt
@@ -1,5 +1,5 @@
 torrentreactor: 1.33
-mininova: 1.50
+mininova: 1.51
 piratebay: 2.01
 extratorrent: 1.2
 kickasstorrents: 1.25


### PR DESCRIPTION
This error only happens with some search terms.
Test:
```
[ngosang@ngo qBittorrent]$ python nova2.py mininova all x264
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.4/threading.py", line 921, in _bootstrap_inner
    self.run()
  File "src/searchengine/nova3/nova2.py", line 110, in run
    self.engine.search(self.what, self.cat)
  File "/home/ngosang/qBittorrent/src/searchengine/nova3/engines/mininova.py", line 108, in search
    parser.feed(res_tab)
  File "/home/ngosang/qBittorrent/src/searchengine/nova3/sgmllib3.py", line 98, in feed
    self.goahead(0)
  File "/home/ngosang/qBittorrent/src/searchengine/nova3/sgmllib3.py", line 132, in goahead
    k = self.parse_starttag(i)
  File "/home/ngosang/qBittorrent/src/searchengine/nova3/sgmllib3.py", line 290, in parse_starttag
    self.finish_starttag(tag, attrs)
  File "/home/ngosang/qBittorrent/src/searchengine/nova3/sgmllib3.py", line 339, in finish_starttag
    self.handle_starttag(tag, method, attrs)
  File "/home/ngosang/qBittorrent/src/searchengine/nova3/sgmllib3.py", line 375, in handle_starttag
    method(attrs)
  File "/home/ngosang/qBittorrent/src/searchengine/nova3/engines/mininova.py", line 63, in start_a
    self.current_item['desc_link']=self.url+params['href'].strip()
TypeError: 'NoneType' object does not support item assignment
```