### PR TITLE
Small change in progress bar percentage

### DIFF
--- a/src/gui/previewlistdelegate.h
+++ b/src/gui/previewlistdelegate.h
@@ -69,7 +69,7 @@ class PreviewListDelegate: public QItemDelegate {
           QStyleOptionProgressBarV2 newopt;
           qreal progress = index.data().toDouble()*100.;
           newopt.rect = opt.rect;
-          newopt.text = misc::accurateDoubleToString(progress, 1) + "%";
+          newopt.text = ((progress == 100.0) ? QString("100%") : misc::accurateDoubleToString(progress, 1) + "%");
           newopt.progress = (int)progress;
           newopt.maximum = 100;
           newopt.minimum = 0;

--- a/src/gui/properties/proplistdelegate.h
+++ b/src/gui/properties/proplistdelegate.h
@@ -82,7 +82,7 @@ public:
         QStyleOptionProgressBarV2 newopt;
         qreal progress = index.data().toDouble()*100.;
         newopt.rect = opt.rect;
-        newopt.text = misc::accurateDoubleToString(progress, 1) + "%";
+        newopt.text = ((progress == 100.0) ? QString("100%") : misc::accurateDoubleToString(progress, 1) + "%");
         newopt.progress = (int)progress;
         newopt.maximum = 100;
         newopt.minimum = 0;

--- a/src/gui/transferlistdelegate.cpp
+++ b/src/gui/transferlistdelegate.cpp
@@ -186,7 +186,7 @@ void TransferListDelegate::paint(QPainter * painter, const QStyleOptionViewItem 
       QStyleOptionProgressBarV2 newopt;
       qreal progress = index.data().toDouble()*100.;
       newopt.rect = opt.rect;
-      newopt.text = misc::accurateDoubleToString(progress, 1) + "%";
+      newopt.text = ((progress == 100.0) ? QString("100%") : misc::accurateDoubleToString(progress, 1) + "%");
       newopt.progress = (int)progress;
       newopt.maximum = 100;
       newopt.minimum = 0;


### PR DESCRIPTION
I have removed the decimal when it is 100%. Doesn't have sense to have 100.0 when can't be greater than 100. Also because 100% occupies a similar size to xx,x% (100.0% is bigger).