### PR TITLE
Disable Auto piece size checkbox when creating a new torrent

### DIFF
--- a/src/gui/torrentcreator/torrentcreatordlg.cpp
+++ b/src/gui/torrentcreator/torrentcreatordlg.cpp
@@ -197,6 +197,7 @@ void TorrentCreatorDlg::setInteractionEnabled(bool enabled)
   URLSeeds_list->setEnabled(enabled);
   txt_comment->setEnabled(enabled);
   comboPieceSize->setEnabled(enabled);
+  checkAutoPieceSize->setEnabled(enabled);
   check_private->setEnabled(enabled);
   checkStartSeeding->setEnabled(enabled);
   createButton->setEnabled(enabled);


### PR DESCRIPTION
It's a little bug. :smile: