### PR TITLE
Removes several warnings related with RSS

### DIFF
--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -107,7 +107,7 @@ AutomatedRssDownloader::AutomatedRssDownloader(const QWeakPointer<RssManager>& m
   Q_ASSERT(ok);
   ok = connect(ui->checkRegex, SIGNAL(stateChanged(int)), SLOT(updateMustNotLineValidity()));
   Q_ASSERT(ok);
-  ok = connect(this, SIGNAL(finished(int)), SLOT(on_finished(int)));
+  ok = connect(this, SIGNAL(finished(int)), SLOT(onFinished(int)));
   Q_ASSERT(ok);
   ok = connect(ui->lineEFilter, SIGNAL(textEdited(QString)), SLOT(updateMatchingArticles()));
   Q_ASSERT(ok);
@@ -635,7 +635,7 @@ void AutomatedRssDownloader::updateMustNotLineValidity()
   }
 }
 
-void AutomatedRssDownloader::on_finished(int result) {
+void AutomatedRssDownloader::onFinished(int result) {
   Q_UNUSED(result);
   // Save current item on exit
   saveEditedRule();

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -82,7 +82,7 @@ private slots:
   void updateFieldsToolTips(bool regex);
   void updateMustLineValidity();
   void updateMustNotLineValidity();
-  void on_finished(int result);
+  void onFinished(int result);
 
 private:
   RssDownloadRulePtr getCurrentRule() const;

--- a/src/gui/rss/rss_imp.cpp
+++ b/src/gui/rss/rss_imp.cpp
@@ -759,8 +759,6 @@ RSSImp::RSSImp(QWidget *parent):
     connect(listArticles, SIGNAL(itemSelectionChanged()), this, SLOT(refreshTextBrowser()));
     connect(listArticles, SIGNAL(itemDoubleClicked(QListWidgetItem *)), this, SLOT(downloadSelectedTorrents()));
 
-    // Refresh all feeds
-    m_rssManager->refresh();
     // Restore sliders position
     restoreSlidersPosition();
     // Bind saveSliders slots


### PR DESCRIPTION
With on_finished shows a warning in the console when RSS Downloader is opened.
The RSS feeds are updated when the function RssFolder::addStream is called.