### PR TITLE
Include "Missing Files" torrents in double-click action for Completed to...

### DIFF
--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -219,7 +219,7 @@ void TransferListWidget::torrentDoubleClicked(const QModelIndex& index)
     QTorrentHandle h = BTSession->getTorrentHandle(hash);
     if (!h.is_valid()) return;
     int action;
-    if (h.is_seed())
+    if (h.is_seed() || (TorrentPersistentData::instance()->getHasMissingFiles(hash) && !h.has_missing_files()))
         action = Preferences::instance()->getActionOnDblClOnTorrentFn();
     else
         action = Preferences::instance()->getActionOnDblClOnTorrentDl();


### PR DESCRIPTION
...rrents

because it's consistent with the Completed filter where it's included

and all my torrents with "Missing Files" had all their files on disk. even though the fastresume file say it doesn't