### PR TITLE
Move "Missing Files" torrents from Completed to Downloading

### DIFF
--- a/src/core/qtlibtorrent/torrentmodel.cpp
+++ b/src/core/qtlibtorrent/torrentmodel.cpp
@@ -542,6 +542,7 @@ TorrentStatusReport TorrentModel::getTorrentStatusReport() const
       break;
     case TorrentModelItem::STATE_DOWNLOADING_META:
       ++report.nb_downloading;
+      ++report.nb_inactive;
       break;
     case TorrentModelItem::STATE_PAUSED_DL:
       ++report.nb_paused;

--- a/src/core/qtlibtorrent/torrentmodel.cpp
+++ b/src/core/qtlibtorrent/torrentmodel.cpp
@@ -545,6 +545,7 @@ TorrentStatusReport TorrentModel::getTorrentStatusReport() const
       ++report.nb_inactive;
       break;
     case TorrentModelItem::STATE_PAUSED_DL:
+    case TorrentModelItem::STATE_PAUSED_MISSING:
       ++report.nb_paused;
     case TorrentModelItem::STATE_STALLED_DL:
     case TorrentModelItem::STATE_CHECKING_DL:
@@ -558,7 +559,6 @@ TorrentStatusReport TorrentModel::getTorrentStatusReport() const
       ++report.nb_seeding;
       break;
     case TorrentModelItem::STATE_PAUSED_UP:
-    case TorrentModelItem::STATE_PAUSED_MISSING:
       ++report.nb_paused;
     case TorrentModelItem::STATE_STALLED_UP:
     case TorrentModelItem::STATE_CHECKING_UP:

--- a/src/gui/transferlistsortmodel.cpp
+++ b/src/gui/transferlistsortmodel.cpp
@@ -212,12 +212,13 @@ bool TransferListSortModel::matchStatusFilter(int sourceRow, const QModelIndex &
   case TorrentFilter::DOWNLOADING:
     return (state == TorrentModelItem::STATE_DOWNLOADING || state == TorrentModelItem::STATE_STALLED_DL
             || state == TorrentModelItem::STATE_PAUSED_DL || state == TorrentModelItem::STATE_CHECKING_DL
-            || state == TorrentModelItem::STATE_QUEUED_DL || state == TorrentModelItem::STATE_DOWNLOADING_META);
+            || state == TorrentModelItem::STATE_QUEUED_DL || state == TorrentModelItem::STATE_DOWNLOADING_META
+            || state == TorrentModelItem::STATE_PAUSED_MISSING);
 
   case TorrentFilter::COMPLETED:
     return (state == TorrentModelItem::STATE_SEEDING || state == TorrentModelItem::STATE_STALLED_UP
             || state == TorrentModelItem::STATE_PAUSED_UP || state == TorrentModelItem::STATE_CHECKING_UP
-            || state == TorrentModelItem::STATE_PAUSED_MISSING || state == TorrentModelItem::STATE_QUEUED_UP);
+            || state == TorrentModelItem::STATE_QUEUED_UP);
 
   case TorrentFilter::PAUSED:
     return (state == TorrentModelItem::STATE_PAUSED_UP || state == TorrentModelItem::STATE_PAUSED_DL


### PR DESCRIPTION
because a file size mismatch with resume data doesn't mean it was previously completed. and it's not complete now. it has to be rechecked to qualify for being in Completed. Completed torrents should be ready for consumption