### PR TITLE
Don't hide tray icon immediately on exit

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -290,13 +290,13 @@ void Application::initializeTranslation()
 
 void Application::cleanup()
 {
-#ifndef DISABLE_GUI
-    delete m_window;
-#endif
 #ifndef DISABLE_WEBUI
     delete m_webui;
 #endif
     QBtSession::drop();
+#ifndef DISABLE_GUI
+    delete m_window;
+#endif
     TorrentPersistentData::drop();
     Preferences::drop();
     Logger::drop();

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -899,9 +899,6 @@ void MainWindow::closeEvent(QCloseEvent *e)
         }
     }
     hide();
-    if (systrayIcon)
-        // Hide tray icon
-        systrayIcon->hide();
     // Save window size, columns size
     writeSettings();
     // Accept exit

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -899,8 +899,6 @@ void MainWindow::closeEvent(QCloseEvent *e)
         }
     }
     hide();
-    // Save window size, columns size
-    writeSettings();
     // Accept exit
     e->accept();
     qApp->exit();


### PR DESCRIPTION
Dropping the current session might take a while. If the tray icon is
hidden as soon as the application is closed, there's no easy way to
know whether qBittorrent is still closing or not. If qBittorrent is
still closing and a new session is started, nothing will happen.
Keep the tray icon visible to give some feedback.