### PR TITLE
Fix file error notification flood. Closes #2592, #2610, #3352.

### DIFF
--- a/src/core/bittorrent/session.cpp
+++ b/src/core/bittorrent/session.cpp
@@ -2199,7 +2199,7 @@ void Session::handleFileErrorAlert(libt::file_error_alert *p)
     qDebug() << Q_FUNC_INFO;
     // NOTE: Check this function!
     TorrentHandle *const torrent = m_torrents.value(p->handle.info_hash());
-    if (torrent) {
+    if (torrent && !torrent->nativeHandle().status().paused) {
         QString msg = Utils::String::fromStdString(p->message());
         Logger::instance()->addMessage(tr("An I/O error occurred, '%1' paused. %2")
                            .arg(torrent->name()).arg(msg));


### PR DESCRIPTION
From http://www.libtorrent.org/reference-Core.html#pause%28%29:
>Torrents may be paused automatically if there is a file error (e.g. disk full) or something similar. 

Also see: https://github.com/arvidn/libtorrent/blob/d1670c72c27e4516cb3b38faaff7312313131d38/src/torrent.cpp#L1204 to #L1235

Now the error notification emits at most once.