### PR TITLE
Download-from-URL textbox change focus on tab key

### DIFF
--- a/src/gui/downloadfromurldlg.ui
+++ b/src/gui/downloadfromurldlg.ui
@@ -36,6 +36,9 @@
      <property name="acceptRichText">
       <bool>false</bool>
      </property>
+     <property name="tabChangesFocus">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
"Download from urls" dialog can be opened by a keyboard shortcut. But, after the text box opens, the tab key doesn't work to change focus to the "Download" button and nor does the return key, so we need to use the mouse.

Understandably, the return key is needed to make the links one per line, but I did not find a reason for the use of tab in the textbox, so we can use tab to change the focus. 

This allows tab key to change focus. A new torrent from magnet link can be now added completely with the keyboard without needing to even touch the mouse. 