### PR TITLE
Let's check if the torrent file can actually be opened before passing it...

### DIFF
--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -190,6 +190,12 @@ bool AddNewTorrentDialog::loadTorrent(const QString& torrent_path, const QString
         return false;
     }
 
+    QFileInfo fileinfo(m_filePath);
+    if (!fileinfo.isReadable()) {
+        MessageBoxRaised::critical(0, tr("I/O Error"), tr("The torrent file cannot be read from the disk. Probably you don't have enough permissions."));
+        return false;
+    }
+
     m_hasMetadata = true;
 
     try {


### PR DESCRIPTION
... to libtorrent

If we don't have enough permissions, libtorrent will spew a pretty useless, irrelevant and almost wrong message: "Failed to load the torrent: torrent file is not a dictionary"