### PR TITLE
Elimination of incorrect singletons. Step 1: QBtSession (Issue #2433).

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -56,7 +56,6 @@
 #include "application.h"
 #include "logger.h"
 #include "preferences.h"
-#include "qbtsession.h"
 #include "torrentpersistentdata.h"
 
 static const char PARAMS_SEPARATOR[] = "|";
@@ -117,7 +116,7 @@ void Application::processParams(const QStringList &params)
     foreach (QString param, params) {
         param = param.trimmed();
         if (misc::isUrl(param)) {
-            QBtSession::instance()->downloadFromUrl(param);
+            m_btSession->downloadFromUrl(param);
         }
         else {
             if (param.startsWith("bc://bt/", Qt::CaseInsensitive)) {
@@ -131,7 +130,7 @@ void Application::processParams(const QStringList &params)
                     AddNewTorrentDialog::showMagnet(param, m_window);
                 else
 #endif
-                    QBtSession::instance()->addMagnetUri(param);
+                    m_btSession->addMagnetUri(param);
             }
             else {
 #ifndef DISABLE_GUI
@@ -139,7 +138,7 @@ void Application::processParams(const QStringList &params)
                     AddNewTorrentDialog::showTorrent(param, QString(), m_window);
                 else
 #endif
-                    QBtSession::instance()->addTorrent(param);
+                    m_btSession->addTorrent(param);
             }
         }
     }
@@ -147,8 +146,9 @@ void Application::processParams(const QStringList &params)
 
 int Application::exec(const QStringList &params)
 {
+    m_btSession = new QBtSession(this);
     // Resume unfinished torrents
-    QBtSession::instance()->startUpTorrents();
+    m_btSession->startUpTorrents();
 
 #ifndef DISABLE_WEBUI
     m_webui = new WebUI;
@@ -296,7 +296,7 @@ void Application::cleanup()
 #ifndef DISABLE_WEBUI
     delete m_webui;
 #endif
-    QBtSession::drop();
+    delete m_btSession;
     TorrentPersistentData::drop();
     Preferences::drop();
     Logger::drop();

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -47,6 +47,11 @@ typedef QtSingleCoreApplication BaseApplication;
 class WebUI;
 #endif
 
+class Application;
+#define App (static_cast<Application *>(QCoreApplication::instance()))
+// Application component includes (for easy access)
+#include "qbtsession.h"
+
 class Application : public BaseApplication
 {
     Q_OBJECT
@@ -59,6 +64,8 @@ public:
 #endif
     int exec(const QStringList &params);
     bool sendParams(const QStringList &params);
+
+    inline QBtSession *BtSession() { return m_btSession; }
 
 protected:
 #ifndef DISABLE_GUI
@@ -86,6 +93,8 @@ private:
     QTranslator m_qtTranslator;
     QTranslator m_translator;
     QStringList m_paramsQueue;
+
+    QBtSession *m_btSession;
 
     void initializeTranslation();
     void processParams(const QStringList &params);

--- a/src/core/qtlibtorrent/qbtsession.cpp
+++ b/src/core/qtlibtorrent/qbtsession.cpp
@@ -86,7 +86,6 @@
 
 using namespace libtorrent;
 
-QBtSession* QBtSession::m_instance = 0;
 const qreal QBtSession::MAX_RATIO = 9999.;
 
 const int MAX_TRACKER_ERRORS = 2;
@@ -101,8 +100,9 @@ static libtorrent::sha1_hash QStringToSha1(const QString& s) {
 }
 
 // Main constructor
-QBtSession::QBtSession()
-    : m_scanFolders(ScanFoldersModel::instance(this)),
+QBtSession::QBtSession(QObject *parent)
+    : QObject(parent),
+      m_scanFolders(ScanFoldersModel::instance(this)),
       preAllocateAll(false), global_ratio_limit(-1),
       LSDEnabled(false),
       DHTEnabled(false), queueingEnabled(false),
@@ -2995,22 +2995,6 @@ void QBtSession::startUpTorrents() {
         }
     }
     qDebug("Unfinished torrents resumed");
-}
-
-QBtSession * QBtSession::instance()
-{
-    if (!m_instance) {
-        m_instance = new QBtSession;
-    }
-    return m_instance;
-}
-
-void QBtSession::drop()
-{
-    if (m_instance) {
-        delete m_instance;
-        m_instance = 0;
-    }
 }
 
 qlonglong QBtSession::getETA(const QString &hash, const libtorrent::torrent_status &status) const

--- a/src/core/qtlibtorrent/qbtsession.h
+++ b/src/core/qtlibtorrent/qbtsession.h
@@ -110,14 +110,9 @@ class QBtSession : public QObject {
 public:
     static const qreal MAX_RATIO;
 
-private:
-    explicit QBtSession();
-    static QBtSession* m_instance;
-
-public:
-    static QBtSession* instance();
-    static void drop();
+    explicit QBtSession(QObject *parent = 0);
     ~QBtSession();
+
     QTorrentHandle getTorrentHandle(const QString &hash) const;
     std::vector<libtorrent::torrent_handle> getTorrents() const;
     bool isFilePreviewPossible(const QString& hash) const;

--- a/src/core/qtlibtorrent/qtorrenthandle.cpp
+++ b/src/core/qtlibtorrent/qtorrenthandle.cpp
@@ -40,6 +40,7 @@
 #include "preferences.h"
 #include "qtorrenthandle.h"
 #include "torrentpersistentdata.h"
+#include "application.h"
 #include "qbtsession.h"
 #include <libtorrent/version.hpp>
 #include <libtorrent/magnet_uri.hpp>
@@ -453,7 +454,7 @@ QTorrentState QTorrentHandle::torrentState() const
             state = is_seed(s) ? QTorrentState::PausedUploading : QTorrentState::PausedDownloading;
     }
     else {
-        if (QBtSession::instance()->isQueueingEnabled() && is_queued(s)) {
+        if (App->BtSession()->isQueueingEnabled() && is_queued(s)) {
             state = is_seed(s) ? QTorrentState::QueuedUploading : QTorrentState::QueuedDownloading;
         }
         else {
@@ -484,7 +485,7 @@ QTorrentState QTorrentHandle::torrentState() const
 qulonglong QTorrentHandle::eta() const
 {
     libtorrent::torrent_status s = status(torrent_handle::query_accurate_download_counters);
-    return QBtSession::instance()->getETA(hash(), s);
+    return App->BtSession()->getETA(hash(), s);
 }
 
 void QTorrentHandle::toggleSequentialDownload()

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -35,7 +35,7 @@
 #include "torrentcontentfiltermodel.h"
 #include "preferences.h"
 #include "torrentpersistentdata.h"
-#include "qbtsession.h"
+#include "application.h"
 #include "iconprovider.h"
 #include "fs_utils.h"
 #include "autoexpandabledialog.h"
@@ -206,9 +206,9 @@ bool AddNewTorrentDialog::loadTorrent(const QString& torrent_path, const QString
     }
 
     // Prevent showing the dialog if download is already present
-    if (QBtSession::instance()->getTorrentHandle(m_hash).is_valid()) {
+    if (App->BtSession()->getTorrentHandle(m_hash).is_valid()) {
         MessageBoxRaised::information(0, tr("Already in download list"), tr("Torrent is already in download list. Merging trackers."), QMessageBox::Ok);
-        QBtSession::instance()->addTorrent(m_filePath, false, m_url);;
+        App->BtSession()->addTorrent(m_filePath, false, m_url);;
         return false;
     }
 
@@ -219,7 +219,7 @@ bool AddNewTorrentDialog::loadTorrent(const QString& torrent_path, const QString
 
 bool AddNewTorrentDialog::loadMagnet(const QString &magnet_uri)
 {
-    connect(QBtSession::instance(), SIGNAL(metadataReceivedHidden(const QTorrentHandle &)), SLOT(updateMetadata(const QTorrentHandle &)));
+    connect(App->BtSession(), SIGNAL(metadataReceivedHidden(const QTorrentHandle &)), SLOT(updateMetadata(const QTorrentHandle &)));
     m_isMagnet = true;
     m_url = magnet_uri;
     m_hash = misc::magnetUriToHash(m_url);
@@ -229,9 +229,9 @@ bool AddNewTorrentDialog::loadMagnet(const QString &magnet_uri)
     }
 
     // Prevent showing the dialog if download is already present
-    if (QBtSession::instance()->getTorrentHandle(m_hash).is_valid()) {
+    if (App->BtSession()->getTorrentHandle(m_hash).is_valid()) {
         MessageBoxRaised::information(0, tr("Already in download list"), tr("Magnet link is already in download list. Merging trackers."), QMessageBox::Ok);
-        QBtSession::instance()->addMagnetUri(m_url, false);
+        App->BtSession()->addMagnetUri(m_url, false);
         return false;
     }
 
@@ -246,7 +246,7 @@ bool AddNewTorrentDialog::loadMagnet(const QString &magnet_uri)
     // Override save path
     TorrentTempData::setSavePath(m_hash, QString(QDir::tempPath() + "/" + m_hash));
     HiddenData::addData(m_hash);
-    QBtSession::instance()->addMagnetUri(m_url, false);
+    App->BtSession()->addMagnetUri(m_url, false);
     setMetadataProgressIndicator(true, tr("Retrieving metadata..."));
     ui->lblhash->setText(m_hash);
 
@@ -590,16 +590,16 @@ void AddNewTorrentDialog::accept()
 
     // Add torrent
     if (m_isMagnet)
-        QBtSession::instance()->unhideMagnet(m_hash);
+        App->BtSession()->unhideMagnet(m_hash);
     else
-        QBtSession::instance()->addTorrent(m_filePath, false, m_url);
+        App->BtSession()->addTorrent(m_filePath, false, m_url);
 
     saveSavePathHistory();
     // Save settings
     pref->useAdditionDialog(!ui->never_show_cb->isChecked());
     if (ui->default_save_path_cb->isChecked()) {
         pref->setSavePath(ui->save_path_combo->itemData(ui->save_path_combo->currentIndex()).toString());
-        QBtSession::instance()->setDefaultSavePath(pref->getSavePath());
+        App->BtSession()->setDefaultSavePath(pref->getSavePath());
     }
     QDialog::accept();
 }
@@ -609,7 +609,7 @@ void AddNewTorrentDialog::reject()
     if (m_isMagnet) {
         disconnect(this, SLOT(updateMetadata(const QTorrentHandle &)));
         setMetadataProgressIndicator(false);
-        QBtSession::instance()->deleteTorrent(m_hash, true);
+        App->BtSession()->deleteTorrent(m_hash, true);
     }
     QDialog::reject();
 }

--- a/src/gui/options_imp.cpp
+++ b/src/gui/options_imp.cpp
@@ -46,7 +46,7 @@
 #include "fs_utils.h"
 #include "advancedsettings.h"
 #include "scannedfoldersmodel.h"
-#include "qbtsession.h"
+#include "application.h"
 #include "iconprovider.h"
 #include "dnsupdater.h"
 
@@ -1250,9 +1250,9 @@ void options_imp::on_IpFilterRefreshBtn_clicked() {
   pref->setFilteringEnabled(true);
   pref->setFilter(getFilter());
   // Force refresh
-  connect(QBtSession::instance(), SIGNAL(ipFilterParsed(bool, int)), SLOT(handleIPFilterParsed(bool, int)));
+  connect(App->BtSession(), SIGNAL(ipFilterParsed(bool, int)), SLOT(handleIPFilterParsed(bool, int)));
   setCursor(QCursor(Qt::WaitCursor));
-  QBtSession::instance()->enableIPFilter(getFilter(), true);
+  App->BtSession()->enableIPFilter(getFilter(), true);
 }
 
 void options_imp::handleIPFilterParsed(bool error, int ruleCount)
@@ -1264,7 +1264,7 @@ void options_imp::handleIPFilterParsed(bool error, int ruleCount)
     QMessageBox::information(this, tr("Successfully refreshed"), tr("Successfully parsed the provided IP filter: %1 rules were applied.", "%1 is a number").arg(ruleCount));
   }
   m_refreshingIpFilter = false;
-  disconnect(QBtSession::instance(), SIGNAL(ipFilterParsed(bool, int)), this, SLOT(handleIPFilterParsed(bool, int)));
+  disconnect(App->BtSession(), SIGNAL(ipFilterParsed(bool, int)), this, SLOT(handleIPFilterParsed(bool, int)));
 }
 
 QString options_imp::languageToLocalizedString(const QLocale &locale)

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -237,7 +237,7 @@ void PeerListWidget::banSelectedPeers(const QStringList& peer_ips)
   foreach (const QString &ip, peer_ips) {
     qDebug("Banning peer %s...", ip.toLocal8Bit().data());
     Logger::instance()->addMessage(tr("Manually banning peer %1...").arg(ip));
-    QBtSession::instance()->banIP(ip);
+    App->BtSession()->banIP(ip);
   }
   // Refresh list
   loadPeers(m_properties->getCurrentTorrent());

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -44,7 +44,7 @@
 #include "propertieswidget.h"
 #include "transferlistwidget.h"
 #include "torrentpersistentdata.h"
-#include "qbtsession.h"
+#include "application.h"
 #include "proplistdelegate.h"
 #include "torrentcontentfiltermodel.h"
 #include "torrentcontentmodel.h"
@@ -95,8 +95,8 @@ PropertiesWidget::PropertiesWidget(QWidget *parent, MainWindow* main_window, Tra
   connect(transferList, SIGNAL(currentTorrentChanged(QTorrentHandle)), this, SLOT(loadTorrentInfos(QTorrentHandle)));
   connect(PropDelegate, SIGNAL(filteredFilesChanged()), this, SLOT(filteredFilesChanged()));
   connect(stackedProperties, SIGNAL(currentChanged(int)), this, SLOT(loadDynamicData()));
-  connect(QBtSession::instance(), SIGNAL(savePathChanged(QTorrentHandle)), this, SLOT(updateSavePath(QTorrentHandle)));
-  connect(QBtSession::instance(), SIGNAL(metadataReceived(QTorrentHandle)), this, SLOT(updateTorrentInfos(QTorrentHandle)));
+  connect(App->BtSession(), SIGNAL(savePathChanged(QTorrentHandle)), this, SLOT(updateSavePath(QTorrentHandle)));
+  connect(App->BtSession(), SIGNAL(metadataReceived(QTorrentHandle)), this, SLOT(updateTorrentInfos(QTorrentHandle)));
   connect(filesList->header(), SIGNAL(sectionMoved(int, int, int)), this, SLOT(saveSettings()));
   connect(filesList->header(), SIGNAL(sectionResized(int, int, int)), this, SLOT(saveSettings()));
   connect(filesList->header(), SIGNAL(sortIndicatorChanged(int, Qt::SortOrder)), this, SLOT(saveSettings()));
@@ -354,7 +354,7 @@ void PropertiesWidget::loadDynamicData() {
       // Update next announce time
       reannounce_lbl->setText(misc::userFriendlyDuration(status.next_announce.total_seconds()));
       // Update ratio info
-      const qreal ratio = QBtSession::instance()->getRealRatio(status);
+      const qreal ratio = App->BtSession()->getRealRatio(status);
       shareRatio->setText(ratio > QBtSession::MAX_RATIO ? QString::fromUtf8("∞") : misc::accurateDoubleToString(ratio, 2));
       if (!h.is_seed(status) && status.has_metadata) {
         showPiecesDownloaded(true);

--- a/src/gui/properties/trackerlist.cpp
+++ b/src/gui/properties/trackerlist.cpp
@@ -42,7 +42,7 @@
 #include "propertieswidget.h"
 #include "trackersadditiondlg.h"
 #include "iconprovider.h"
-#include "qbtsession.h"
+#include "application.h"
 #include "preferences.h"
 #include "misc.h"
 #include "autoexpandabledialog.h"
@@ -202,19 +202,19 @@ void TrackerList::loadStickyItems(const QTorrentHandle &h) {
   QString disabled = tr("Disabled");
 
   // load DHT information
-  if (QBtSession::instance()->isDHTEnabled() && !h.priv())
+  if (App->BtSession()->isDHTEnabled() && !h.priv())
     dht_item->setText(COL_STATUS, working);
   else
     dht_item->setText(COL_STATUS, disabled);
 
   // Load PeX Information
-  if (QBtSession::instance()->isPexEnabled() && !h.priv())
+  if (App->BtSession()->isPexEnabled() && !h.priv())
     pex_item->setText(COL_STATUS, working);
   else
     pex_item->setText(COL_STATUS, disabled);
 
   // Load LSD Information
-  if (QBtSession::instance()->isLSDEnabled() && !h.priv())
+  if (App->BtSession()->isLSDEnabled() && !h.priv())
     lsd_item->setText(COL_STATUS, working);
   else
     lsd_item->setText(COL_STATUS, disabled);
@@ -252,7 +252,7 @@ void TrackerList::loadTrackers() {
   if (!h.is_valid()) return;
   loadStickyItems(h);
   // Load actual trackers information
-  QHash<QString, TrackerInfos> trackers_data = QBtSession::instance()->getTrackersInfo(h.hash());
+  QHash<QString, TrackerInfos> trackers_data = App->BtSession()->getTrackersInfo(h.hash());
   QStringList old_trackers_urls = tracker_items.keys();
   const std::vector<announce_entry> trackers = h.trackers();
   std::vector<announce_entry>::const_iterator it = trackers.begin();

--- a/src/gui/rss/rss_imp.cpp
+++ b/src/gui/rss/rss_imp.cpp
@@ -39,7 +39,7 @@
 
 #include "rss_imp.h"
 #include "feedlistwidget.h"
-#include "qbtsession.h"
+#include "application.h"
 #include "cookiesdlg.h"
 #include "preferences.h"
 #include "rsssettingsdlg.h"
@@ -344,7 +344,7 @@ void RSSImp::downloadSelectedTorrents()
         QString torrentLink = article->torrentUrl();
         // Check if it is a magnet link
         if (torrentLink.startsWith("magnet:", Qt::CaseInsensitive)) {
-            QBtSession::instance()->addMagnetInteractive(torrentLink);
+            App->BtSession()->addMagnetInteractive(torrentLink);
         }
         else {
             // Load possible cookies
@@ -352,7 +352,7 @@ void RSSImp::downloadSelectedTorrents()
             QString feed_hostname = QUrl::fromEncoded(feed_url.toUtf8()).host();
             QList<QNetworkCookie> cookies = Preferences::instance()->getHostNameQNetworkCookies(feed_hostname);
             qDebug("Loaded %d cookies for RSS item\n", cookies.size());
-            QBtSession::instance()->downloadFromUrl(torrentLink, cookies);
+            App->BtSession()->downloadFromUrl(torrentLink, cookies);
         }
     }
 }

--- a/src/gui/rss/rssfeed.cpp
+++ b/src/gui/rss/rssfeed.cpp
@@ -31,7 +31,7 @@
 #include <QDebug>
 #include "rssfeed.h"
 #include "rssmanager.h"
-#include "qbtsession.h"
+#include "application.h"
 #include "rssfolder.h"
 #include "preferences.h"
 #include "qinisettings.h"
@@ -369,12 +369,12 @@ void RssFeed::downloadArticleTorrentIfMatching(RssDownloadRuleList* rules, const
   // Download the torrent
   const QString& torrent_url = article->torrentUrl();
   Logger::instance()->addMessage(tr("Automatically downloading %1 torrent from %2 RSS feed...").arg(article->title()).arg(displayName()));
-  connect(QBtSession::instance(), SIGNAL(newDownloadedTorrentFromRss(QString)), article.data(), SLOT(handleTorrentDownloadSuccess(const QString&)), Qt::UniqueConnection);
+  connect(App->BtSession(), SIGNAL(newDownloadedTorrentFromRss(QString)), article.data(), SLOT(handleTorrentDownloadSuccess(const QString&)), Qt::UniqueConnection);
   connect(article.data(), SIGNAL(articleWasRead()), SLOT(handleArticleStateChanged()), Qt::UniqueConnection);
   if (torrent_url.startsWith("magnet:", Qt::CaseInsensitive))
-    QBtSession::instance()->addMagnetSkipAddDlg(torrent_url, matching_rule->savePath(), matching_rule->label(), matching_rule->addPaused());
+    App->BtSession()->addMagnetSkipAddDlg(torrent_url, matching_rule->savePath(), matching_rule->label(), matching_rule->addPaused());
   else
-    QBtSession::instance()->downloadUrlAndSkipDialog(torrent_url, matching_rule->savePath(), matching_rule->label(), feedCookies(), matching_rule->addPaused());
+    App->BtSession()->downloadUrlAndSkipDialog(torrent_url, matching_rule->savePath(), matching_rule->label(), feedCookies(), matching_rule->addPaused());
 }
 
 void RssFeed::recheckRssItemsForDownload()

--- a/src/gui/rss/rssfolder.cpp
+++ b/src/gui/rss/rssfolder.cpp
@@ -33,7 +33,7 @@
 #include "iconprovider.h"
 #include "rssfolder.h"
 #include "rssarticle.h"
-#include "qbtsession.h"
+#include "application.h"
 #include "rssmanager.h"
 #include "rssfeed.h"
 

--- a/src/gui/rss/rssmanager.cpp
+++ b/src/gui/rss/rssmanager.cpp
@@ -31,7 +31,7 @@
 #include <QDebug>
 #include "rssmanager.h"
 #include "preferences.h"
-#include "qbtsession.h"
+#include "application.h"
 #include "rssfeed.h"
 #include "rssarticle.h"
 #include "rssdownloadrulelist.h"

--- a/src/gui/speedlimitdlg.h
+++ b/src/gui/speedlimitdlg.h
@@ -35,7 +35,7 @@
 #include <QList>
 #include "ui_bandwidth_limit.h"
 #include "misc.h"
-#include "qbtsession.h"
+#include "application.h"
 
 class SpeedLimitDialog : public QDialog, private Ui_bandwidth_dlg {
     Q_OBJECT

--- a/src/gui/statsdialog.cpp
+++ b/src/gui/statsdialog.cpp
@@ -39,7 +39,7 @@ StatsDialog::StatsDialog(QWidget *parent) :   QDialog(parent), ui(new Ui::StatsD
   ui->setupUi(this);
   setAttribute(Qt::WA_DeleteOnClose);
   connect(ui->buttonOK, SIGNAL(clicked()), SLOT(close()));
-  session = QBtSession::instance();
+  session = App->BtSession();
   updateUI();
   t = new QTimer(this);
   t->setInterval(1500);

--- a/src/gui/statsdialog.h
+++ b/src/gui/statsdialog.h
@@ -33,7 +33,7 @@
 
 #include <QDialog>
 #include <QTimer>
-#include "qbtsession.h"
+#include "application.h"
 
 namespace Ui {
   class StatsDialog;

--- a/src/gui/torrentcreator/torrentcreatordlg.cpp
+++ b/src/gui/torrentcreator/torrentcreatordlg.cpp
@@ -39,7 +39,7 @@
 #include "preferences.h"
 #include "torrentcreatorthread.h"
 #include "iconprovider.h"
-#include "qbtsession.h"
+#include "application.h"
 
 const uint NB_PIECES_MIN = 1200;
 const uint NB_PIECES_MAX = 2200;
@@ -166,7 +166,7 @@ void TorrentCreatorDlg::handleCreationSuccess(QString path, QString branch_path)
     TorrentTempData::setSeedingMode(hash, true);
     emit torrent_to_seed(path);
     if (checkIgnoreShareLimits->isChecked())
-      QBtSession::instance()->setMaxRatioPerTorrent(hash, -1);
+      App->BtSession()->setMaxRatioPerTorrent(hash, -1);
   }
   QMessageBox::information(0, tr("Torrent creation"), tr("Torrent was created successfully:")+" "+fsutils::toNativePath(path));
   close();

--- a/src/gui/torrentimportdlg.cpp
+++ b/src/gui/torrentimportdlg.cpp
@@ -35,7 +35,7 @@
 #include "torrentimportdlg.h"
 #include "ui_torrentimportdlg.h"
 #include "preferences.h"
-#include "qbtsession.h"
+#include "application.h"
 #include "torrentpersistentdata.h"
 #include "iconprovider.h"
 #include "fs_utils.h"
@@ -199,7 +199,7 @@ void TorrentImportDlg::importTorrent()
         TorrentTempData::setSavePath(hash, content_path);
         TorrentTempData::setSeedingMode(hash, dlg.skipFileChecking());
         qDebug("Adding the torrent to the session...");
-        QBtSession::instance()->addTorrent(torrent_path, false, QString(), false, true);
+        App->BtSession()->addTorrent(torrent_path, false, QString(), false, true);
         // Remember the last opened folder
         Preferences* const pref = Preferences::instance();
         pref->setMainLastDir(fsutils::fromNativePath(torrent_path));

--- a/src/gui/transferlistdelegate.cpp
+++ b/src/gui/transferlistdelegate.cpp
@@ -36,7 +36,7 @@
 #include <QPainter>
 #include "misc.h"
 #include "torrentmodel.h"
-#include "qbtsession.h"
+#include "application.h"
 
 #ifdef Q_OS_WIN
 #if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -48,7 +48,7 @@
 #include <queue>
 
 #include "transferlistwidget.h"
-#include "qbtsession.h"
+#include "application.h"
 #include "torrentpersistentdata.h"
 #include "transferlistdelegate.h"
 #include "previewselect.h"

--- a/src/searchengine/searchengine.cpp
+++ b/src/searchengine/searchengine.cpp
@@ -48,7 +48,7 @@
 #endif
 
 #include "searchengine.h"
-#include "qbtsession.h"
+#include "application.h"
 #include "fs_utils.h"
 #include "misc.h"
 #include "preferences.h"
@@ -330,7 +330,7 @@ void SearchEngine::downloadFinished(int exitcode, QProcess::ExitStatus) {
         if (parts.size() == 2) {
             QString path = parts[0];
             QString url = parts[1];
-            QBtSession::instance()->processDownloadedFile(url, path);
+            App->BtSession()->processDownloadedFile(url, path);
         }
     }
     qDebug("Deleting downloadProcess");

--- a/src/webui/prefjson.cpp
+++ b/src/webui/prefjson.cpp
@@ -30,7 +30,7 @@
 
 #include "prefjson.h"
 #include "preferences.h"
-#include "qbtsession.h"
+#include "application.h"
 #include "scannedfoldersmodel.h"
 #include "fs_utils.h"
 
@@ -182,7 +182,7 @@ void prefjson::setPreferences(const QString& json)
       foreach (const QString &old_folder, old_folders) {
         // Update deleted folders
         if (!new_folders.contains(old_folder)) {
-          QBtSession::instance()->getScanFoldersModel()->removePath(old_folder);
+          App->BtSession()->getScanFoldersModel()->removePath(old_folder);
         }
       }
       int i = 0;
@@ -190,7 +190,7 @@ void prefjson::setPreferences(const QString& json)
         qDebug("New watched folder: %s", qPrintable(new_folder));
         // Update new folders
         if (!old_folders.contains(fsutils::fromNativePath(new_folder))) {
-          QBtSession::instance()->getScanFoldersModel()->addPath(new_folder, download_at_path.at(i));
+          App->BtSession()->getScanFoldersModel()->addPath(new_folder, download_at_path.at(i));
         }
         ++i;
       }


### PR DESCRIPTION
Make QBtSession not to use Singleton pattern.
Now its instance is accessible as App->BtSession().

Elimination of incorrect Singletons is one of my goals for the redesign. The main reason to do this is to get rid of using this pattern where it is inappropriate (for example, there are dependencies between singletons or we need to create and delete objects in certain places in a certain order).

This is one of soft mergable PR related to #2433, so it can be targeted to 3.2.
My first major #2433-related PR will be quite large (because I can't divide it into many small commits), so I will post some more preliminary PRs, to reduce it a little.