### PR TITLE
Change options dialog to non-modal. Closes #2687.

### DIFF
--- a/src/gui/options_imp.cpp
+++ b/src/gui/options_imp.cpp
@@ -63,7 +63,7 @@ options_imp::options_imp(QWidget *parent):
   qDebug("-> Constructing Options");
   setupUi(this);
   setAttribute(Qt::WA_DeleteOnClose);
-  setModal(true);
+  setModal(false);
   // Icons
   tabSelection->item(TAB_UI)->setIcon(IconProvider::instance()->getIcon("preferences-desktop"));
   tabSelection->item(TAB_BITTORRENT)->setIcon(IconProvider::instance()->getIcon("preferences-system-network"));

--- a/src/gui/torrentcreator/torrentcreatordlg.cpp
+++ b/src/gui/torrentcreator/torrentcreatordlg.cpp
@@ -55,7 +55,7 @@ TorrentCreatorDlg::TorrentCreatorDlg(QWidget *parent): QDialog(parent), creatorT
   cancelButton->setIcon(IconProvider::instance()->getIcon("dialog-cancel"));
 
   setAttribute(Qt::WA_DeleteOnClose);
-  setModal(true);
+  setModal(false);
   showProgressBar(false);
   loadTrackerList();
   // Piece sizes


### PR DESCRIPTION
For issue #2687.
I think its good for functionality, and there seems to have no side effects according to my *basic test.
Torrent creator dialog can also benefit from this.
More inputs are welcome.
