### PR TITLE
Don't close downloadFromURL dialog when showing empty url warning.

### DIFF
--- a/src/gui/downloadfromurldlg.h
+++ b/src/gui/downloadfromurldlg.h
@@ -80,7 +80,6 @@ class downloadFromURL : public QDialog, private Ui::downloadFromURL{
 
   public slots:
     void on_downloadButton_clicked() {
-      close();
       QString urls = textUrls->toPlainText();
       QStringList url_list = urls.split(QString::fromUtf8("\n"));
       QString url;
@@ -97,6 +96,7 @@ class downloadFromURL : public QDialog, private Ui::downloadFromURL{
         QMessageBox::critical(0, tr("No URL entered"), tr("Please type at least one URL."));
         return;
       }
+      close();
       emit urlsReadyToBeDownloaded(url_list_cleaned);
       qDebug("Emitted urlsReadytobedownloaded signal");
     }

--- a/src/gui/downloadfromurldlg.h
+++ b/src/gui/downloadfromurldlg.h
@@ -93,7 +93,7 @@ class downloadFromURL : public QDialog, private Ui::downloadFromURL{
         }
       }
       if (!url_list_cleaned.size()) {
-        QMessageBox::critical(0, tr("No URL entered"), tr("Please type at least one URL."));
+        QMessageBox::warning(0, tr("No URL entered"), tr("Please type at least one URL."));
         return;
       }
       close();


### PR DESCRIPTION
As title. I personally think downloadFromURL dialog should be kept open instead of closing it.
