### PR TITLE
A little bit ot KF5 integration

### DIFF
--- a/configure
+++ b/configure
@@ -719,6 +719,7 @@ enable_debug
 enable_gui
 enable_webui
 enable_qt_dbus
+with_kf5
 with_boost
 with_boost_libdir
 with_boost_system
@@ -1383,6 +1384,7 @@ Optional Packages:
   --with-qtsingleapplication=[system|shipped]
                           Use the shipped qtsingleapplication library or the
                           system one (default=shipped)
+  --with-kf5              Compile using KDE Frameworks 5 (default=no)
   --with-boost[=ARG]      use Boost library from a standard location
                           (ARG=yes), from the specified location (ARG=<path>),
                           or disable it (ARG=no) [ARG=yes]
@@ -3258,7 +3260,7 @@ IFS=$ac_save_IFS
 case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
 
 
-am__api_version='1.14'
+am__api_version='1.15'
 
 # Find a good install program.  We prefer a C program (faster),
 # so one script is as good as another.  But avoid the broken or
@@ -3447,7 +3449,7 @@ else
 $as_echo "$as_me: WARNING: 'missing' script is too old or missing" >&2;}
 fi
 
-if test x"${install_sh}" != xset; then
+if test x"${install_sh+set}" != xset; then
   case $am_aux_dir in
   *\ * | *\	*)
     install_sh="\${SHELL} '$am_aux_dir/install-sh'" ;;
@@ -3838,8 +3840,8 @@ MAKEINFO=${MAKEINFO-"${am_missing_run}makeinfo"}
 # <http://lists.gnu.org/archive/html/automake/2012-07/msg00014.html>
 mkdir_p='$(MKDIR_P)'
 
-# We need awk for the "check" target.  The system "awk" is bad on
-# some platforms.
+# We need awk for the "check" target (and possibly the TAP driver).  The
+# system "awk" is bad on some platforms.
 # Always define AMTAR for backward compatibility.  Yes, it's still used
 # in the wild :-(  We should find a proper way to deprecate it ...
 AMTAR='$${TAR-tar}'
@@ -4214,6 +4216,15 @@ if test "${enable_qt_dbus+set}" = set; then :
   enableval=$enable_qt_dbus;
 else
   enable_qt_dbus=yes
+fi
+
+
+
+# Check whether --with-kf5 was given.
+if test "${with_kf5+set}" = set; then :
+  withval=$with_kf5;
+else
+  with_kf5=no
 fi
 
 
@@ -4693,6 +4704,21 @@ $as_echo "$enable_qt_dbus" >&6; }
         as_fn_error $? "Unknown option \"$enable_qt_dbus\". Use either \"yes\" or \"no\"." "$LINENO" 5 ;;
 esac
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether KF55 should be enabled" >&5
+$as_echo_n "checking whether KF55 should be enabled... " >&6; }
+case "x$with_kf5" in #(
+  "xno") :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; } ;; #(
+  "xyes") :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+               QBT_ADD_CONFIG="$QBT_ADD_CONFIG kf5" ;; #(
+  *) :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_kf5" >&5
+$as_echo "$with_kf5" >&6; }
+        as_fn_error $? "Unknown option \"$with_kf5\". Use either \"yes\" or \"no\"." "$LINENO" 5 ;;
+esac
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,12 @@ AC_ARG_ENABLE(qt-dbus,
               [],
               [enable_qt_dbus=yes])
 
+AC_ARG_WITH(kf5,
+            [AS_HELP_STRING([--with-kf5],
+                              [Compile using KDE Frameworks 5 (default=no)])],
+            [],
+            [with_kf5=no])
+
 # Detect OS
 AC_MSG_CHECKING([whether OS is FreeBSD])
 AS_IF([test "x$host_os" = "x*FreeBSD*"],
@@ -133,6 +139,15 @@ AS_CASE(["x$enable_qt_dbus"],
         [AC_MSG_RESULT([$enable_qt_dbus])
         AC_MSG_ERROR([Unknown option "$enable_qt_dbus". Use either "yes" or "no".])])
 
+AC_MSG_CHECKING([whether KF55 should be enabled])
+AS_CASE(["x$with_kf5"],
+        ["xno"],
+              [AC_MSG_RESULT([no])],
+        ["xyes"],
+               [AC_MSG_RESULT([yes])
+               QBT_ADD_CONFIG="$QBT_ADD_CONFIG kf5"],
+        [AC_MSG_RESULT([$with_kf5])
+        AC_MSG_ERROR([Unknown option "$with_kf5". Use either "yes" or "no".])])
 
 AX_BOOST_BASE([1.35])
 # HAVE_BOOST is set to an empty value when Boost is found. I don't know

--- a/src/core/core.pri
+++ b/src/core/core.pri
@@ -1,6 +1,10 @@
 INCLUDEPATH += $$PWD
 
-unix:!macx:dbus: include(qtnotify/qtnotify.pri)
+kf5: {
+    include (knotify/knotify.pri)
+} else {
+    unix:!macx:dbus: include(qtnotify/qtnotify.pri)
+}
 
 include(qtlibtorrent/qtlibtorrent.pri)
 
@@ -23,7 +27,8 @@ HEADERS += \
     $$PWD/http/responsegenerator.h \
     $$PWD/http/server.h \
     $$PWD/http/types.h \
-    $$PWD/http/responsebuilder.h
+    $$PWD/http/responsebuilder.h \
+    $$PWD/notifier.h
 
 SOURCES += \
     $$PWD/downloadthread.cpp \
@@ -40,4 +45,5 @@ SOURCES += \
     $$PWD/http/requestparser.cpp \
     $$PWD/http/responsegenerator.cpp \
     $$PWD/http/server.cpp \
-    $$PWD/http/responsebuilder.cpp
+    $$PWD/http/responsebuilder.cpp \
+    $$PWD/notifier.cpp

--- a/src/core/knotify/knotify.cpp
+++ b/src/core/knotify/knotify.cpp
@@ -1,0 +1,75 @@
+#include "knotify.h"
+#include <KNotification>
+#include <QDesktopServices>
+#include <QDir>
+#include <QUrl>
+
+KNotify::KNotify(QWidget *mainWindow)
+    : Notifier(mainWindow),
+      m_mainWindow(mainWindow)
+{
+}
+
+void KNotify::showNotification(NotificationKind kind, const QString &title, const QString &message, const Context *context)
+{
+    QWidget* contextWidget = context && context->widget ? context->widget : m_mainWindow;
+    switch(kind)
+    {
+    case Notifier::TorrentFinished:
+        showTorrentFinishedNotification(title, message, context);
+        break;
+    case Notifier::TorrentIOError:
+        KNotification::event("ioerror", title, message,
+                             QString(), contextWidget, KNotification::Persistent);
+        break;
+    case Notifier::UrlDownloadError:
+        KNotification::event("urlerror", title, message,
+                             QString(), contextWidget, KNotification::Persistent);
+        break;
+    case Notifier::SearchFinished:
+         KNotification::event("searchfinished", title, message, QString(),
+                              contextWidget, contextWidget ? KNotification::CloseWhenWidgetActivated : KNotification::CloseOnTimeout);
+         break;
+    default:
+        KNotification::event(KNotification::Notification, title, message, QString(), contextWidget);
+        break;
+    }
+}
+
+void KNotify::showTorrentFinishedNotification(const QString &title, const QString &message, const Context *context)
+{
+    KNotification* notification = new KNotification("downloadfinished",
+                           KNotification::Persistent /*CloseOnTimeout?*/, this);
+    notification->setTitle(title);
+    notification->setText(message);
+
+    if(context) {
+        if(context->widget) {
+            notification->setWidget(context->widget);
+        }
+        m_activeNotifications.insert(notification, context->torrent);
+        connect(notification, SIGNAL(closed()), this, SLOT(notificationClosed()));
+        connect(notification, SIGNAL(activated(unsigned )), this, SLOT(torrentFinishedNotificationActivated(unsigned )));
+    }
+
+    notification->sendEvent();
+}
+
+void KNotify::notificationClosed()
+{
+    m_activeNotifications.remove(sender());
+}
+
+void KNotify::torrentFinishedNotificationActivated(unsigned int /*actionId*/)
+{
+    if(m_activeNotifications.contains(sender())) { // the map should not be long
+        QTorrentHandle h = m_activeNotifications.value(sender());
+        // if there is only a single file in the torrent, we open it
+        if(h.num_files() == 1) {
+            QDesktopServices::openUrl(QUrl::fromLocalFile(
+                         QDir(h.save_path()).absoluteFilePath(h.filepath_at(0))));
+        } else { // otherwise we open top directory
+            QDesktopServices::openUrl(QUrl::fromLocalFile(h.root_path()));
+        }
+    }
+}

--- a/src/core/knotify/knotify.h
+++ b/src/core/knotify/knotify.h
@@ -1,0 +1,26 @@
+#ifndef KNOTIFY_H
+#define KNOTIFY_H
+
+#include <QObject>
+#include <QMap>
+#include "notifier.h"
+
+class KNotify : public Notifier
+{
+	Q_OBJECT
+public:
+    explicit KNotify(QWidget *mainWindow = 0);
+    // Notifier interface
+protected:
+
+    virtual void showNotification(NotificationKind kind, const QString &title, const QString &message, const Context *context);
+private slots:
+    void notificationClosed();
+    void torrentFinishedNotificationActivated(unsigned int actionId);
+private:
+    void showTorrentFinishedNotification(const QString &title, const QString &message, const Context *context);
+    QWidget* m_mainWindow;
+    QMap<QObject*, QTorrentHandle> m_activeNotifications;
+};
+
+#endif // KNOTIFY_H

--- a/src/core/knotify/knotify.pri
+++ b/src/core/knotify/knotify.pri
@@ -1,0 +1,12 @@
+QT += KNotifications
+
+notificationschemes.path = $$PREFIX/share/knotifications5
+notificationschemes.files = $$PWD/*.notifyrc
+
+INSTALLS += notificationschemes
+
+HEADERS += \
+    $$PWD/knotify.h
+
+SOURCES += \
+    $$PWD/knotify.cpp

--- a/src/core/knotify/qBittorrent.notifyrc
+++ b/src/core/knotify/qBittorrent.notifyrc
@@ -1,0 +1,40 @@
+[Global]
+IconName=qbittorrent
+Name=qBitTorrent
+Comment=Torrent Client
+
+[Context/download]
+Name=Downloads
+Comment=Downloads notifications
+
+[Context/error]
+Name=Errors
+Comment=Errors notifications
+
+[Context/search]
+Name=Search
+Comment=Search notifications
+
+[Event/downloadfinished]
+Name=Download finished
+Comment=Your download has completed
+Contexts=download
+Action=Popup
+
+[Event/ioerror]
+Name=I/O error
+Comment=An I/O error occured for a torrent
+Contexts=error
+Action=Popup|Taskbar
+
+[Event/urlerror]
+Name=Url download error
+Comment=Couldn't download file
+Contexts=error
+Action=Popup|Taskbar
+
+[Event/searchfinished]
+Name=Search finished
+Comment=Search has finished
+Contexts=search
+Action=Popup

--- a/src/core/notifier.cpp
+++ b/src/core/notifier.cpp
@@ -1,0 +1,107 @@
+#include "notifier.h"
+#include <QWidget>
+
+#ifdef ENABLE_KF5
+    #include "knotify/knotify.h"
+#else
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC)) && defined(QT_DBUS_LIB)
+    #include <QDBusConnection>
+    #include "qtnotify/dbusnotifier.h"
+#else
+
+#define TIME_TRAY_BALLOON 5000
+class SystemTrayNotifier : public Notifier {
+public:
+    SystemTrayNotifier(QObject* parent, QSystemTrayIcon* systrayIcon)
+        :Notifier(parent),
+         m_systrayIcon(QSystemTrayIcon::supportsMessages() ? systrayIcon : 0) {
+    }
+
+    // Notifier interface
+protected:
+    void showNotification(NotificationKind kind, const QString& title, const QString& message, const Context* context);
+private:
+    QSystemTrayIcon* m_systrayIcon;
+};
+
+void SystemTrayNotifier::showNotification(NotificationKind kind, const QString& title, const QString& message, const Context* /*context*/)
+{
+    QSystemTrayIcon::MessageIcon icon;
+    switch(kind)
+    {
+    case Notifier::UrlDownloadError:
+        icon = QSystemTrayIcon::Warning;
+        break;
+    case Notifier::TorrentIOError:
+        icon = QSystemTrayIcon::Critical;
+        break;
+    default:
+        icon = QSystemTrayIcon::Information;
+        break;
+    }
+
+    if (m_systrayIcon) {
+        m_systrayIcon->showMessage(title, message, icon, TIME_TRAY_BALLOON);
+    }
+}
+
+#endif
+#endif
+
+
+
+Notifier::Notifier(QWidget *mainWindow)
+    : QObject(mainWindow)
+{
+
+}
+
+void Notifier::notifyTorrentFinished(const QTorrentHandle &h, QWidget *widget)
+{
+    Context ct(widget, h);
+    showNotification(Notifier::TorrentFinished, tr("Download completion"),
+                     tr("%1 has finished downloading.", "e.g: xxx.avi has finished downloading.").arg(h.name()), &ct);
+}
+
+void Notifier::notifyTorrentIOError(const QTorrentHandle &h, const QString &message, QWidget *widget)
+{
+    Context ct(widget);
+    showNotification(Notifier::TorrentIOError, tr("I/O Error", "i.e: Input/Output Error"),
+                     tr("An I/O error occurred for torrent %1.\n Reason: %2",
+                        "e.g: An error occurred for torrent xxx.avi.\n Reason: disk is full.").arg(h.name()).arg(message), &ct);
+}
+
+void Notifier::notifyUrlDownloadError(const QString &url, const QString &reason, QWidget *widget)
+{
+    Context ct(widget);
+    showNotification(Notifier::UrlDownloadError, tr("Url download error"),
+                     tr("Couldn't download file at url: %1, reason: %2.").arg(url).arg(reason), &ct);
+}
+
+void Notifier::notifySearchFinished(QWidget *widget)
+{
+    Context ct(widget);
+    showNotification(Notifier::SearchFinished, tr("Search Engine"), tr("Search has finished"), &ct);
+}
+
+void Notifier::showNotification(const QString &title, const QString &message, QWidget *widget)
+{
+    Context ct(widget);
+    showNotification(Notifier::NoType, title, message, &ct);
+}
+
+
+Notifier *createNotifier(QWidget *mainWindow, QSystemTrayIcon *systrayIcon)
+{
+#ifdef ENABLE_KF5
+    Q_UNUSED(systrayIcon)
+    return new KNotify(mainWindow);
+#else
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC)) && defined(QT_DBUS_LIB)
+    Q_UNUSED(systrayIcon)
+    return new DBusNotifier(parent);
+#else
+    return new SystemTrayNotifier(parent, systrayIcon);
+#endif
+#endif
+}

--- a/src/core/notifier.h
+++ b/src/core/notifier.h
@@ -1,0 +1,43 @@
+#ifndef NOTIFIER_H
+#define NOTIFIER_H
+
+#include <QObject>
+#include <QSystemTrayIcon>
+
+#include "qtorrenthandle.h"
+
+class Notifier : public QObject
+{
+public:
+    explicit Notifier(QWidget *mainWindow);
+
+    enum NotificationKind {
+        NoType = 0,
+        TorrentFinished = 1,
+        TorrentIOError = 2,
+        UrlDownloadError = 3,
+        SearchFinished = 4
+    };
+
+    struct Context {
+        Context(QWidget* w = 0L, const QTorrentHandle& t = QTorrentHandle())
+            :widget(w), torrent(t) {
+        }
+
+        QWidget* widget;
+        QTorrentHandle torrent;
+    };
+
+    virtual void showNotification(NotificationKind kind, const QString& title, const QString& message, const Context* context) = 0;
+
+    // These helpers follow specific events to the general showNotification()
+    void notifyTorrentFinished(const QTorrentHandle& h, QWidget* widget = 0L);
+    void notifyTorrentIOError(const QTorrentHandle& h, const QString& message, QWidget* widget = 0L);
+    void notifyUrlDownloadError(const QString& url, const QString& reason, QWidget* widget = 0L);
+    void notifySearchFinished(QWidget* widget);
+    void showNotification(const QString& title, const QString& message, QWidget* widget = 0L);
+};
+
+Notifier* createNotifier(QWidget* mainWindow, QSystemTrayIcon* systrayIcon);
+
+#endif // NOTIFIER_H

--- a/src/core/qtlibtorrent/torrentmodel.cpp
+++ b/src/core/qtlibtorrent/torrentmodel.cpp
@@ -37,6 +37,10 @@
 
 #include <libtorrent/session.hpp>
 
+#ifdef ENABLE_KF5
+	#include <KF5/KConfigWidgets/KColorScheme>
+#endif
+
 using namespace libtorrent;
 
 namespace {
@@ -171,32 +175,64 @@ QIcon TorrentModelItem::getIconByState(State state) {
 }
 
 QColor TorrentModelItem::getColorByState(State state) {
+#ifdef ENABLE_KF5
+	KColorScheme kActiveColors (QPalette::Active);
+	KColorScheme kInactiveColors (QPalette::Inactive);
+#endif
     switch (state) {
     case STATE_DOWNLOADING:
     case STATE_DOWNLOADING_META:
+#ifdef ENABLE_KF5
+		return kActiveColors.foreground(KColorScheme::PositiveText).color();
+#else
         return QColor(0, 128, 0); // green
+#endif
     case STATE_ALLOCATING:
     case STATE_STALLED_DL:
     case STATE_STALLED_UP:
+#ifdef ENABLE_KF5
+		return kInactiveColors.foreground(KColorScheme::InactiveText).color();
+#else
         return QColor(128, 128, 128); // grey
+#endif
     case STATE_SEEDING:
+#ifdef ENABLE_KF5
+		return kActiveColors.foreground(KColorScheme::NeutralText).color();
+#else
         return QColor(255, 165, 0); // orange
+#endif
     case STATE_PAUSED_DL:
     case STATE_PAUSED_UP:
     case STATE_PAUSED_MISSING:
+#ifdef ENABLE_KF5
+		return kActiveColors.foreground(KColorScheme::NegativeText).color();
+#else
         return QColor(255, 0, 0); // red
+#endif
     case STATE_QUEUED_DL:
     case STATE_QUEUED_UP:
     case STATE_CHECKING_UP:
     case STATE_CHECKING_DL:
     case STATE_QUEUED_CHECK:
     case STATE_QUEUED_FASTCHECK:
+#ifdef ENABLE_KF5
+		return kInactiveColors.foreground(KColorScheme::ActiveText).color();
+#else
         return QColor(128, 128, 128); // grey
+#endif
     case STATE_INVALID:
+#ifdef ENABLE_KF5
+		return kInactiveColors.foreground(KColorScheme::NegativeText).color();
+#else
         return QColor(255, 0, 0); // red
+#endif
     default:
         Q_ASSERT(false);
+#ifdef ENABLE_KF5
+		return kActiveColors.foreground(KColorScheme::NegativeText).color();
+#else
         return QColor(255, 0, 0); // red
+#endif
     }
 }
 

--- a/src/core/qtnotify/dbusnotifier.cpp
+++ b/src/core/qtnotify/dbusnotifier.cpp
@@ -1,0 +1,21 @@
+#include "dbusnotifier.h"
+#include "./notifications.h"
+
+DBusNotifier::DBusNotifier(QObject *parent): Notifier(parent)
+{
+
+}
+
+void DBusNotifier::showNotification(Notifier::NotificationKind /*kind*/, const QString &title, const QString &message,
+                                    const Notifier::Context */*context*/)
+{
+    org::freedesktop::Notifications notifications("org.freedesktop.Notifications",
+                                                  "/org/freedesktop/Notifications",
+                                                  QDBusConnection::sessionBus());
+    QVariantMap hints;
+    hints["desktop-entry"] = "qBittorrent";
+    QDBusPendingReply<uint> reply = notifications.Notify("qBittorrent", 0, "qbittorrent", title,
+                                                         message, QStringList(), hints, -1);
+    reply.waitForFinished();
+}
+

--- a/src/core/qtnotify/dbusnotifier.h
+++ b/src/core/qtnotify/dbusnotifier.h
@@ -1,0 +1,20 @@
+#ifndef DBUSNOTIFIER_H
+#define DBUSNOTIFIER_H
+
+#include "notifier.h"
+
+class DBusNotifier : public Notifier
+{
+public:
+    DBusNotifier(QObject* parent);
+
+    // Notifier interface
+public:
+
+
+    // Notifier interface
+public:
+    virtual void showNotification(NotificationKind kind, const QString &title, const QString &message, const Context *context);
+};
+
+#endif // DBUSNOTIFIER_H

--- a/src/core/qtnotify/qtnotify.pri
+++ b/src/core/qtnotify/qtnotify.pri
@@ -1,5 +1,7 @@
 INCLUDEPATH += $$PWD
 
-HEADERS += $$PWD/notifications.h
+HEADERS += $$PWD/notifications.h \
+    $$PWD/dbusnotifier.h
 
-SOURCES += $$PWD/notifications.cpp
+SOURCES += $$PWD/notifications.cpp \
+    $$PWD/dbusnotifier.cpp

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -29,10 +29,6 @@
  */
 
 #include <QtGlobal>
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC)) && defined(QT_DBUS_LIB)
-#include <QDBusConnection>
-#include "notifications.h"
-#endif
 
 #include <QFileDialog>
 #include <QFileSystemWatcher>
@@ -106,6 +102,7 @@ using namespace libtorrent;
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
     , m_posInitialized(false)
+    , m_notifier(0)
     , force_exit(false)
     , unlockDlgShowing(false)
 #ifdef Q_OS_WIN
@@ -618,15 +615,16 @@ void MainWindow::balloonClicked()
 // called when a torrent has finished
 void MainWindow::finishedTorrent(const QTorrentHandle& h) const
 {
-    if (TorrentPersistentData::instance()->isSeed(h.hash()))
-        showNotificationBaloon(tr("Download completion"), tr("%1 has finished downloading.", "e.g: xxx.avi has finished downloading.").arg(h.name()));
+    if (TorrentPersistentData::instance()->isSeed(h.hash())) {
+        m_notifier->notifyTorrentFinished(h);
+    }
 }
 
 // Notification when disk is full
 void MainWindow::fullDiskError(const QTorrentHandle& h, QString msg) const
 {
     if (!h.is_valid()) return;
-    showNotificationBaloon(tr("I/O Error", "i.e: Input/Output Error"), tr("An I/O error occurred for torrent %1.\n Reason: %2", "e.g: An error occurred for torrent xxx.avi.\n Reason: disk is full.").arg(h.name()).arg(msg));
+    m_notifier->notifyTorrentIOError(h, msg);
 }
 
 void MainWindow::createKeyboardShortcuts()
@@ -709,7 +707,7 @@ void MainWindow::askRecursiveTorrentDownloadConfirmation(const QTorrentHandle &h
 void MainWindow::handleDownloadFromUrlFailure(QString url, QString reason) const
 {
     // Display a message box
-    showNotificationBaloon(tr("Url download error"), tr("Couldn't download file at url: %1, reason: %2.").arg(url).arg(reason));
+    m_notifier->notifyUrlDownloadError(url, reason);
 }
 
 void MainWindow::on_actionSet_global_upload_limit_triggered()
@@ -1237,34 +1235,6 @@ void MainWindow::updateGUI()
         setWindowTitle(tr("[D: %1/s, U: %2/s] qBittorrent %3", "D = Download; U = Upload; %3 is qBittorrent version").arg(misc::friendlyUnit(QBtSession::instance()->getSessionStatus().payload_download_rate)).arg(misc::friendlyUnit(QBtSession::instance()->getSessionStatus().payload_upload_rate)).arg(QString::fromUtf8(VERSION)));
 }
 
-void MainWindow::showNotificationBaloon(QString title, QString msg) const
-{
-    if (!Preferences::instance()->useProgramNotification()) return;
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC)) && defined(QT_DBUS_LIB)
-    org::freedesktop::Notifications notifications("org.freedesktop.Notifications",
-                                                  "/org/freedesktop/Notifications",
-                                                  QDBusConnection::sessionBus());
-    // Testing for 'notifications.isValid()' isn't helpful here.
-    // If the notification daemon is configured to run 'as needed'
-    // the above check can be false if the daemon wasn't started
-    // by another application. In this case DBus will be able to
-    // start the notification daemon and complete our request. Such
-    // a daemon is xfce4-notifyd, DBus autostarts it and after
-    // some inactivity shuts it down. Other DEs, like GNOME, choose
-    // to start their daemons at the session startup and have it sit
-    // idling for the whole session.
-    QVariantMap hints;
-    hints["desktop-entry"] = "qBittorrent";
-    QDBusPendingReply<uint> reply = notifications.Notify("qBittorrent", 0, "qbittorrent", title,
-                                                         msg, QStringList(), hints, -1);
-    reply.waitForFinished();
-    if (!reply.isError())
-        return;
-#endif
-    if (systrayIcon && QSystemTrayIcon::supportsMessages())
-        systrayIcon->showMessage(title, msg, QSystemTrayIcon::Information, TIME_TRAY_BALLOON);
-}
-
 /*****************************************************
 *                                                   *
 *                      Utils                        *
@@ -1366,6 +1336,11 @@ QMenu* MainWindow::getTrayIconMenu()
     return myTrayIconMenu;
 }
 
+Notifier *MainWindow::notifier()
+{
+    return m_notifier;
+}
+
 void MainWindow::createTrayIcon()
 {
     // Tray icon
@@ -1376,6 +1351,10 @@ void MainWindow::createTrayIcon()
     // End of Icon Menu
     connect(systrayIcon, SIGNAL(activated(QSystemTrayIcon::ActivationReason)), this, SLOT(toggleVisibility(QSystemTrayIcon::ActivationReason)));
     systrayIcon->show();
+    if(m_notifier) {
+        delete m_notifier;
+    }
+    m_notifier = createNotifier(this, systrayIcon);
 }
 
 // Display Program Options

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -37,6 +37,7 @@
 #include "ui_mainwindow.h"
 #include "qtorrenthandle.h"
 #include "statsdialog.h"
+#include "notifier.h"
 
 class QBtSession;
 class downloadFromURL;
@@ -77,11 +78,11 @@ public:
     TransferListWidget* getTransferList() const { return transferList; }
     QMenu* getTrayIconMenu();
     PropertiesWidget *getProperties() const { return properties; }
+    Notifier* notifier();
 
 public slots:
     void trackerAuthenticationRequired(const QTorrentHandle& h);
     void setTabText(int index, QString text) const;
-    void showNotificationBaloon(QString title, QString msg) const;
     void downloadFromURLList(const QStringList& urls);
     void updateAltSpeedsBtn(bool alternative);
     void updateNbTorrents();
@@ -176,6 +177,7 @@ private:
     QPointer<downloadFromURL> downloadFromURLDialog;
     QPointer<QSystemTrayIcon> systrayIcon;
     QPointer<QTimer> systrayCreator;
+    Notifier* m_notifier;
     QPointer<QMenu> myTrayIconMenu;
     TransferListWidget *transferList;
     TransferListFiltersWidget *transferListFilters;

--- a/src/searchengine/searchengine.cpp
+++ b/src/searchengine/searchengine.cpp
@@ -433,7 +433,7 @@ void SearchEngine::searchFinished(int exitcode,QProcess::ExitStatus) {
     }
     bool useNotificationBalloons = Preferences::instance()->useProgramNotification();
     if (useNotificationBalloons && mp_mainWindow->getCurrentTabWidget() != this) {
-        mp_mainWindow->showNotificationBaloon(tr("Search Engine"), tr("Search has finished"));
+        mp_mainWindow->notifier()->notifySearchFinished(this);
     }
     if (exitcode) {
 #ifdef Q_OS_WIN

--- a/src/src.pro
+++ b/src/src.pro
@@ -24,6 +24,10 @@ nogui {
         DEFINES += QBT_STATIC_QT
         QTPLUGIN += qico
     }
+    CONFIG(kf5) {
+        QT += KConfigWidgets
+        DEFINES += ENABLE_KF5
+    }
     TARGET = qbittorrent
 }
 nowebui: DEFINES += DISABLE_WEBUI

--- a/src/src.pro
+++ b/src/src.pro
@@ -24,9 +24,8 @@ nogui {
         DEFINES += QBT_STATIC_QT
         QTPLUGIN += qico
     }
-    CONFIG(kf5) {
+    kf5: {
         QT += KConfigWidgets
-        DEFINES += ENABLE_KF5
     }
     TARGET = qbittorrent
 }
@@ -34,6 +33,10 @@ nowebui: DEFINES += DISABLE_WEBUI
 strace_win: DEFINES += STACKTRACE_WIN
 QT += network
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+
+kf5: {
+    DEFINES += ENABLE_KF5
+}
 
 # Vars
 LANG_PATH = lang

--- a/unixconf.pri
+++ b/unixconf.pri
@@ -14,6 +14,11 @@ exists($$OUT_PWD/../conf.pri) {
     QT += dbus
 }
 
+# /usr/include is used by default, explicit specifying
+# makes clashes between KF5 and KDE4 headers installed into
+# the same prefix /usr
+INCLUDEPATH -= "/usr/include"
+
 QMAKE_CXXFLAGS += -Wformat -Wformat-security
 !haiku {
     QMAKE_LFLAGS_APP += -rdynamic


### PR DESCRIPTION
Using qBitttorent in Plasma 5 I did have two displeasures: it does not follow KDE colour scheme and its notifications are not well integrated into the Plasma environment.

Since KF5 provide QMake modules it is easy to use them in qBittorrent. In principle, the code should be the same for KDE4 (maybe with very minor changes), but I do not know how to write configure code for it. Neither do not know how to check for KF5 presence in configure.ac, but qmake should fail nicely if KF5 is not present. 

Colours problem is especially annoying with dark colour scheme, that could make torrent list absolutely unreadable. Using KColorScheme we can get readable colours.

Notifications integration means 2 things:  that user can change event properties (like how to show notification) and that we can add callbacks for notifications. In principle, it is possible with pure DBus, but since I wanted to add a .notifyrc file, I added this via KF5 classes. So, there is button "Open" on download finished notification and do not disappear now.