### PR TITLE
Workaround sections state loading bug

### DIFF
--- a/src/gui/gui.pri
+++ b/src/gui/gui.pri
@@ -41,7 +41,8 @@ HEADERS += \
     $$PWD/messageboxraised.h \
     $$PWD/torrentfilterenum.h \
     $$PWD/options_imp.h \
-    $$PWD/advancedsettings.h
+    $$PWD/advancedsettings.h \
+    $$PWD/signalblocker.h
 
 SOURCES += \
     $$PWD/mainwindow.cpp \
@@ -69,7 +70,8 @@ SOURCES += \
     $$PWD/messageboxraised.cpp \
     $$PWD/statusbar.cpp \
     $$PWD/trackerlogin.cpp \
-    $$PWD/options_imp.cpp
+    $$PWD/options_imp.cpp \
+    $$PWD/signalblocker.cpp
 
 win32|macx {
     HEADERS += $$PWD/programupdater.h

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -59,6 +59,7 @@
 #include "lineedit.h"
 #include "fs_utils.h"
 #include "autoexpandabledialog.h"
+#include "signalblocker.h"
 
 using namespace libtorrent;
 
@@ -292,7 +293,7 @@ void PropertiesWidget::readSettings() {
   }
   const int current_tab = pref->getPropCurTab();
   const bool visible = pref->getPropVisible();
-  // the following will call saveSettings but shouldn't change any state
+  SignalBlocker blocker(filesList->header());
   if (!filesList->header()->restoreState(pref->getPropFileListState())) {
     filesList->header()->resizeSection(0, 400); //Default
   }

--- a/src/gui/signalblocker.cpp
+++ b/src/gui/signalblocker.cpp
@@ -1,0 +1,18 @@
+#include "signalblocker.h"
+
+SignalBlocker::SignalBlocker(QObject *p, bool block)
+    :m_object(p), m_previousState(m_object->blockSignals(block))
+{
+
+}
+
+SignalBlocker::SignalBlocker(QObject &p, bool block)
+    :m_object(&p), m_previousState(m_object->blockSignals(block))
+{
+
+}
+
+SignalBlocker::~SignalBlocker()
+{
+    m_object->blockSignals(m_previousState);
+}

--- a/src/gui/signalblocker.h
+++ b/src/gui/signalblocker.h
@@ -1,0 +1,56 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#ifndef SIGNALBLOCKER_HXX
+#define SIGNALBLOCKER_HXX
+
+#include <QObject>
+
+/*! Simple guard object that blocks signals from a QObject.
+
+This class calls @see QObject::blockSignals(block) in its constructor, blocking singals from
+the given QObject until the instance of SignalsBlocker is destroyed. Previous state of signals
+blocking is restored in destructor, thus allowing for hierarchical blocking/unblocking.
+*/
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+class Q_DECL_UNUSED SignalBlocker
+#else
+class SignalBlocker
+#endif
+{
+public:
+    SignalBlocker(QObject* p, bool block = true);
+    SignalBlocker(QObject& p, bool block = true);
+    ~SignalBlocker();
+private:
+    Q_DISABLE_COPY(SignalBlocker)
+    QObject* m_object;
+    bool m_previousState;
+};
+
+#endif // SIGNALBLOCKER_HXX

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -64,6 +64,7 @@
 #include "fs_utils.h"
 #include "autoexpandabledialog.h"
 #include "transferlistsortmodel.h"
+#include "signalblocker.h"
 
 using namespace libtorrent;
 
@@ -960,6 +961,7 @@ void TransferListWidget::saveSettings()
 
 bool TransferListWidget::loadSettings()
 {
+    SignalBlocker blocker(header());
     bool ok = header()->restoreState(Preferences::instance()->getTransHeaderState());
     if (!ok)
         header()->resizeSection(0, 200); // Default


### PR DESCRIPTION
For some reason sometimes (I saw this twice) header state on disk gets
corrupted, and when this corrupted one is read by readSettings(),
it must be saved immidiately back to the disk. Then this wrong state
is loaded next time and leads to unusabe tree or list: Qt uses
incorrect width of columns and it is impossible to click on their
headers.

Blocking signals (and thus call to saveSettings()) while loading a
header state we interrupt this circle.

At least it should not make things worse.