### PR TITLE
Fix potential out-of-bound access in misc::friendlyUnit()

### DIFF
--- a/src/core/utils/misc.cpp
+++ b/src/core/utils/misc.cpp
@@ -258,8 +258,10 @@ QString Utils::Misc::friendlyUnit(qreal val, bool is_speed)
     if (val < 0)
         return QCoreApplication::translate("misc", "Unknown", "Unknown (size)");
     int i = 0;
-    while(val >= 1024. && i++<6)
+    while(val >= 1024. && i < 4) {
         val /= 1024.;
+        ++i;
+    }
     QString ret;
     if (i == 0)
         ret = QString::number((long)val) + " " + QCoreApplication::translate("misc", units[0].source, units[0].comment);


### PR DESCRIPTION
The old code could allow `i = 6`, while `units[]` only has a size of 5. And also simplify the code a bit.
