### PR TITLE
Enable editing of save path when adding new torrents. Also checks if path is valid

### DIFF
--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -39,6 +39,9 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="editable">
+           <bool>true</bool>
+          </property>
          </widget>
         </item>
         <item>


### PR DESCRIPTION
I implemented editing of save paths in the addNewTorrent dialog. Checks for valid paths are included. Also paths autocomplete with existing directories.