### PR TITLE
WebUI: add delay in shutdown command in order to send out response msg

### DIFF
--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -289,12 +289,12 @@ void WebApplication::action_version_qbittorrent()
 void WebApplication::action_command_shutdown()
 {
     qDebug() << "Shutdown request from Web UI";
+    CHECK_URI(0);
+
     // Special case handling for shutdown, we
     // need to reply to the Web UI before
     // actually shutting down.
-
-    CHECK_URI(0);
-    QTimer::singleShot(0, qApp, SLOT(quit()));
+    QTimer::singleShot(100, qApp, SLOT(quit()));
 }
 
 void WebApplication::action_command_download()


### PR DESCRIPTION
Problem:
After selecting "exit qbittorrent" in webui, the browser doesn't change to the "qBittorrent has been shutdown." page.

I hooked up wireshark, and confirmed that qB didn't response `200 OK` after receiving shutdown command.
The immediate  `singleShot(0,,)` doesn't give qB enough time to send out response.

Only observable on windows builds; linux builds behave correctly...and browser version/os doesn't matter.
