### PR TITLE
Changes in typography

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -376,7 +376,7 @@ QString makeUsage(const QString &prg_name)
 #endif
     text += QLatin1String("\t-h | --help\t\t") + QObject::tr("Displays this help message") + QLatin1Char('\n');
     text += QLatin1String("\t--webui-port=<port>\t")
-            + QObject::tr("Changes the webui port (current: %1)").arg(QString::number(Preferences::instance()->getWebUiPort()))
+            + QObject::tr("Changes the Web UI port (current: %1)").arg(QString::number(Preferences::instance()->getWebUiPort()))
             + QLatin1Char('\n');
 #ifndef DISABLE_GUI
     text += QLatin1String("\t--no-splash\t\t") + QObject::tr("Disable splash screen") + QLatin1Char('\n');

--- a/src/core/bittorrent/session.cpp
+++ b/src/core/bittorrent/session.cpp
@@ -163,7 +163,7 @@ Session::Session(QObject *parent)
     // Construct session
     libt::fingerprint fingerprint(PEER_ID, VERSION_MAJOR, VERSION_MINOR, VERSION_BUGFIX, VERSION_BUILD);
     m_nativeSession = new libt::session(fingerprint, 0);
-    Logger::instance()->addMessage("Peer ID: " + Utils::String::fromStdString(fingerprint.to_string()));
+    Logger::instance()->addMessage(tr("Peer ID: ") + Utils::String::fromStdString(fingerprint.to_string()));
 
     m_nativeSession->set_alert_dispatch(boost::bind(&Session::dispatchAlerts, this, _1));
 
@@ -363,8 +363,8 @@ void Session::setSessionSettings()
 
     libt::session_settings sessionSettings = m_nativeSession->settings();
     sessionSettings.user_agent = "qBittorrent " VERSION;
-    //std::cout << "HTTP user agent is " << sessionSettings.user_agent << std::endl;
-    logger->addMessage(tr("HTTP user agent is %1").arg(Utils::String::fromStdString(sessionSettings.user_agent)));
+    //std::cout << "HTTP User-Agent is " << sessionSettings.user_agent << std::endl;
+    logger->addMessage(tr("HTTP User-Agent is %1").arg(Utils::String::fromStdString(sessionSettings.user_agent)));
 
     sessionSettings.upnp_ignore_nonrouters = true;
     sessionSettings.use_dht_as_fallback = false;
@@ -2257,7 +2257,7 @@ void Session::handlePeerBanAlert(libt::peer_ban_alert *p)
 
 void Session::handleUrlSeedAlert(libt::url_seed_alert *p)
 {
-    Logger::instance()->addMessage(tr("Url seed lookup failed for url: %1, message: %2").arg(Utils::String::fromStdString(p->url)).arg(Utils::String::fromStdString(p->message())), Log::CRITICAL);
+    Logger::instance()->addMessage(tr("URL seed lookup failed for url: %1, message: %2").arg(Utils::String::fromStdString(p->url)).arg(Utils::String::fromStdString(p->message())), Log::CRITICAL);
 }
 
 void Session::handleListenSucceededAlert(libt::listen_succeeded_alert *p)

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -723,7 +723,7 @@ void MainWindow::askRecursiveTorrentDownloadConfirmation(BitTorrent::TorrentHand
 void MainWindow::handleDownloadFromUrlFailure(QString url, QString reason) const
 {
     // Display a message box
-    showNotificationBaloon(tr("Url download error"), tr("Couldn't download file at url: %1, reason: %2.").arg(url).arg(reason));
+    showNotificationBaloon(tr("URL download error"), tr("Couldn't download file at URL: %1, reason: %2.").arg(url).arg(reason));
 }
 
 void MainWindow::on_actionSet_global_upload_limit_triggered()

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -143,7 +143,7 @@
   <widget class="QStatusBar" name="statusBar"/>
   <action name="actionOpen">
    <property name="text">
-    <string>&amp;Add torrent file...</string>
+    <string>&amp;Add Torrent File...</string>
    </property>
    <property name="iconText">
     <string>Open</string>
@@ -205,7 +205,7 @@
   </action>
   <action name="actionDownload_from_URL">
    <property name="text">
-    <string>Add &amp;link to torrent...</string>
+    <string>Add Torrent &amp;Link...</string>
    </property>
    <property name="iconText">
     <string>Open URL</string>

--- a/src/gui/options_imp.cpp
+++ b/src/gui/options_imp.cpp
@@ -1187,9 +1187,9 @@ void options_imp::on_browseFilterButton_clicked() {
   QDir filterDir(filter_path);
   QString ipfilter;
   if (!filter_path.isEmpty() && filterDir.exists()) {
-    ipfilter = QFileDialog::getOpenFileName(this, tr("Choose an ip filter file"), filterDir.absolutePath(), tr("Filters")+QString(" (*.dat *.p2p *.p2b)"));
+    ipfilter = QFileDialog::getOpenFileName(this, tr("Choose an IP filter file"), filterDir.absolutePath(), tr("Filters")+QString(" (*.dat *.p2p *.p2b)"));
   } else {
-    ipfilter = QFileDialog::getOpenFileName(this, tr("Choose an ip filter file"), QDir::homePath(), tr("Filters")+QString(" (*.dat *.p2p *.p2b)"));
+    ipfilter = QFileDialog::getOpenFileName(this, tr("Choose an IP filter file"), QDir::homePath(), tr("Filters")+QString(" (*.dat *.p2p *.p2b)"));
   }
   if (!ipfilter.isNull())
     textFilterPath->setText(Utils::Fs::toNativePath(ipfilter));

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -737,14 +737,14 @@ void PropertiesWidget::openSelectedFile() {
 void PropertiesWidget::askWebSeed() {
   bool ok;
   // Ask user for a new url seed
-  const QString url_seed = AutoExpandableDialog::getText(this, tr("New url seed", "New HTTP source"),
-                                                 tr("New url seed:"), QLineEdit::Normal,
+  const QString url_seed = AutoExpandableDialog::getText(this, tr("New URL seed", "New HTTP source"),
+                                                 tr("New URL seed:"), QLineEdit::Normal,
                                                  QString::fromUtf8("http://www."), &ok);
   if (!ok) return;
   qDebug("Adding %s web seed", qPrintable(url_seed));
   if (!listWebSeeds->findItems(url_seed, Qt::MatchFixedString).empty()) {
     QMessageBox::warning(this, "qBittorrent",
-                         tr("This url seed is already in the list."),
+                         tr("This URL seed is already in the list."),
                          QMessageBox::Ok);
     return;
   }
@@ -795,7 +795,7 @@ void PropertiesWidget::editWebSeed() {
 
   if (!listWebSeeds->findItems(new_seed, Qt::MatchFixedString).empty()) {
     QMessageBox::warning(this, tr("qBittorrent"),
-                         tr("This url seed is already in the list."),
+                         tr("This URL seed is already in the list."),
                          QMessageBox::Ok);
     return;
   }

--- a/src/gui/properties/trackerlist.cpp
+++ b/src/gui/properties/trackerlist.cpp
@@ -433,7 +433,7 @@ void TrackerList::showTrackerListMenu(QPoint) {
   QAction *editAct = 0;
   if (!getSelectedTrackerItems().isEmpty()) {
     delAct = menu.addAction(GuiIconProvider::instance()->getIcon("list-remove"), tr("Remove tracker"));
-    copyAct = menu.addAction(GuiIconProvider::instance()->getIcon("edit-copy"), tr("Copy tracker url"));
+    copyAct = menu.addAction(GuiIconProvider::instance()->getIcon("edit-copy"), tr("Copy tracker URL"));
     editAct = menu.addAction(GuiIconProvider::instance()->getIcon("edit-rename"),tr("Edit selected tracker URL"));
   }
 #if LIBTORRENT_VERSION_NUM >= 10000

--- a/src/gui/rss/cookiesdlg.cpp
+++ b/src/gui/rss/cookiesdlg.cpp
@@ -45,7 +45,7 @@ CookiesDlg::CookiesDlg(QWidget *parent, const QList<QByteArray> &raw_cookies) :
   ui->add_btn->setIcon(GuiIconProvider::instance()->getIcon("list-add"));
   ui->del_btn->setIcon(GuiIconProvider::instance()->getIcon("list-remove"));
 
-  ui->infos_lbl->setText(tr("Common keys for cookies are : '%1', '%2'.\nYou should get this information from your Web browser preferences.").arg("uid").arg("pass"));
+  ui->infos_lbl->setText(tr("Common keys for cookies are: '%1', '%2'.\nYou should get this information from your Web browser preferences.").arg("uid").arg("pass"));
   foreach (const QByteArray &raw_cookie, raw_cookies) {
     QList<QByteArray> cookie_parts = raw_cookie.split('=');
     if (cookie_parts.size() != 2) continue;

--- a/src/gui/rss/rss_imp.cpp
+++ b/src/gui/rss/rss_imp.cpp
@@ -204,7 +204,7 @@ void RSSImp::on_newFeedButton_clicked()
     if (clip_txt.startsWith("http://", Qt::CaseInsensitive) || clip_txt.startsWith("https://", Qt::CaseInsensitive) || clip_txt.startsWith("ftp://", Qt::CaseInsensitive))
         default_url = clip_txt;
 
-    QString newUrl = AutoExpandableDialog::getText(this, tr("Please type a rss stream url"), tr("Stream URL:"), QLineEdit::Normal, default_url, &ok);
+    QString newUrl = AutoExpandableDialog::getText(this, tr("Please type a RSS stream URL"), tr("Stream URL:"), QLineEdit::Normal, default_url, &ok);
     if (!ok)
         return;
 
@@ -214,7 +214,7 @@ void RSSImp::on_newFeedButton_clicked()
 
     if (m_feedList->hasFeed(newUrl)) {
         QMessageBox::warning(this, "qBittorrent",
-                             tr("This rss feed is already in the list."),
+                             tr("This RSS feed is already in the list."),
                              QMessageBox::Ok);
         return;
     }

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -625,14 +625,14 @@ void TrackerFiltersList::handleFavicoDownload(const QString& url, const QString&
     bool invalid = (sizes.size() > 0 ? icon.pixmap(sizes.first()).isNull() : true);
     if (invalid) {
         if (url.endsWith(".ico", Qt::CaseInsensitive)) {
-            Logger::instance()->addMessage(tr("Couldn't decode favico for url `%1`. Trying to download favico in PNG format.").arg(url),
+            Logger::instance()->addMessage(tr("Couldn't decode favicon for URL `%1`. Trying to download favicon in PNG format.").arg(url),
                                            Log::WARNING);
             Net::DownloadHandler *h = Net::DownloadManager::instance()->downloadUrl(url.left(url.size() - 4) + ".png");
             connect(h, SIGNAL(downloadFinished(QString, QString)), this, SLOT(handleFavicoDownload(QString, QString)));
             connect(h, SIGNAL(downloadFailed(QString, QString)), this, SLOT(handleFavicoFailure(QString, QString)));
         }
         else {
-            Logger::instance()->addMessage(tr("Couldn't decode favico for url `%1`.").arg(url), Log::WARNING);
+            Logger::instance()->addMessage(tr("Couldn't decode favicon for URL `%1`.").arg(url), Log::WARNING);
         }
         Utils::Fs::forceRemove(filePath);
     }
@@ -646,7 +646,7 @@ void TrackerFiltersList::handleFavicoFailure(const QString& url, const QString& 
 {
     // Don't use getHost() on the url here. Print the full url. The error might relate to
     // that.
-    Logger::instance()->addMessage(tr("Couldn't download favico for url `%1`. Reason: `%2`").arg(url).arg(error),
+    Logger::instance()->addMessage(tr("Couldn't download favicon for URL `%1`. Reason: `%2`").arg(url).arg(error),
                                    Log::WARNING);
 }
 

--- a/src/webui/webui.cpp
+++ b/src/webui/webui.cpp
@@ -83,7 +83,7 @@ void WebUI::init()
             if (success)
                 logger->addMessage(tr("The Web UI is listening on port %1").arg(m_port));
             else
-                logger->addMessage(tr("Web User Interface Error - Unable to bind Web UI to port %1").arg(m_port), Log::CRITICAL);
+                logger->addMessage(tr("Web UI Error - Unable to bind Web UI to port %1").arg(m_port), Log::CRITICAL);
         }
 
         // DynDNS

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -35,8 +35,8 @@
                     <li>
                         <a class="returnFalse">QBT_TR(File)QBT_TR</a>
                         <ul>
-                            <li><a id="uploadLink"><img class="MyMenuIcon" alt="QBT_TR(&Add torrent file...)QBT_TR" src="theme/list-add" width="16" height="16" onload="fixPNG(this)"/>QBT_TR(&Add torrent file...)QBT_TR</a></li>
-                            <li><a id="downloadLink"><img class="MyMenuIcon" alt="QBT_TR(Add &link to torrent...)QBT_TR" src="theme/insert-link" width="16" height="16" onload="fixPNG(this)"/>QBT_TR(Add &link to torrent...)QBT_TR</a></li>
+                            <li><a id="uploadLink"><img class="MyMenuIcon" alt="QBT_TR(&Add Torrent File...)QBT_TR" src="theme/list-add" width="16" height="16" onload="fixPNG(this)"/>QBT_TR(&Add Torrent File...)QBT_TR</a></li>
+                            <li><a id="downloadLink"><img class="MyMenuIcon" alt="QBT_TR(Add Torrent &Link...)QBT_TR" src="theme/insert-link" width="16" height="16" onload="fixPNG(this)"/>QBT_TR(Add Torrent &Link...)QBT_TR</a></li>
                             <li class="divider"><a id="logoutLink"><img class="MyMenuIcon" alt="QBT_TR(Logout)QBT_TR" src="theme/system-log-out" width="16" height="16" onload="fixPNG(this)"/>QBT_TR(Logout)QBT_TR</a></li>
                             <li><a id="shutdownLink"><img class="MyMenuIcon" alt="QBT_TR(Exit qBittorrent)QBT_TR" src="theme/application-exit" width="16" height="16" onload="fixPNG(this)"/>QBT_TR(Exit qBittorrent)QBT_TR</a></li>
                         </ul>
@@ -77,8 +77,8 @@
             </div>
             <div id="mochaToolbar">
                 &nbsp;&nbsp;
-                <a id="uploadButton"><img class="mochaToolButton" title="QBT_TR(&Add torrent file...)QBT_TR" src="theme/list-add" alt="QBT_TR(&Add torrent file...)QBT_TR" width="24" height="24" onload="fixPNG(this)"/></a>
-                <a id="downloadButton"><img class="mochaToolButton" title="QBT_TR(Add &link to torrent...)QBT_TR" src="theme/insert-link" alt="QBT_TR(Add &link to torrent...)QBT_TR" width="24" height="24" onload="fixPNG(this)"/></a>
+                <a id="uploadButton"><img class="mochaToolButton" title="QBT_TR(&Add Torrent File...)QBT_TR" src="theme/list-add" alt="QBT_TR(&Add Torrent File...)QBT_TR" width="24" height="24" onload="fixPNG(this)"/></a>
+                <a id="downloadButton"><img class="mochaToolButton" title="QBT_TR(Add Torrent &Link...)QBT_TR" src="theme/insert-link" alt="QBT_TR(Add Torrent &Link...)QBT_TR" width="24" height="24" onload="fixPNG(this)"/></a>
                 <a id="deleteButton" class="divider"><img class="mochaToolButton" title="QBT_TR(Delete)QBT_TR" src="theme/list-remove" alt="QBT_TR(Delete)QBT_TR" width="24" height="24" onload="fixPNG(this)"/></a>
                 <a id="resumeButton" class="divider"><img class="mochaToolButton" title="QBT_TR(Resume)QBT_TR" src="theme/media-playback-start" alt="QBT_TR(Resume)QBT_TR" width="24" height="24" onload="fixPNG(this)"/></a>
                 <a id="pauseButton"><img class="mochaToolButton" title="QBT_TR(Pause)QBT_TR" src="theme/media-playback-pause" alt="QBT_TR(Pause)QBT_TR" width="24" height="24" onload="fixPNG(this)"/></a>

--- a/src/webui/www/public/download.html
+++ b/src/webui/www/public/download.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" dir="ltr">
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-	<title>QBT_TR(Add &link to torrent...)QBT_TR</title>
+	<title>QBT_TR(Add Torrent Link)QBT_TR</title>
 	<link rel="stylesheet" href="css/style.css" type="text/css" />
 	<script type="text/javascript" src="scripts/mootools-1.2-core-yc.js" charset="utf-8"></script>
 	<script type="text/javascript" src="scripts/download.js" charset="utf-8"></script>
@@ -10,7 +10,7 @@
 <body>
 <center>
 	<br/>
-	<h2 class="vcenter">QBT_TR(Download Torrents from their URL or Magnet link)QBT_TR</h2>
+	<h2 class="vcenter">QBT_TR(Download Torrents from their URLs or Magnet links)QBT_TR</h2>
 	<textarea id="urls" rows="10"></textarea>
 <p>QBT_TR(Only one link per line)QBT_TR</p>
 <input type="button" value="QBT_TR(Download)QBT_TR" id="downButton"/>

--- a/src/webui/www/public/scripts/mocha-init.js
+++ b/src/webui/www/public/scripts/mocha-init.js
@@ -47,7 +47,7 @@ initializeWindows = function() {
         new Event(e).stop();
         new MochaUI.Window({
             id: 'downloadPage',
-            title: "QBT_TR(Download from urls)QBT_TR",
+            title: "QBT_TR(Download from URLs)QBT_TR",
             loadMethod: 'iframe',
             contentURL: 'download.html',
             scrollbars: true,


### PR DESCRIPTION
Most of them are minor changes. I want to discuss about other changes:
* "Add &link to torrent..." in menu "File" => "Add torrent &link..."
* "Options" in menu "Tools" => "Preferences" (maybe move to "Edit" menu)
* "Transfers" / "Transfers list" => "Downloads" / "Downloads list" (in some places it is called in one way and others another)

I don't know why but the first two messages in the log window are not translated:
* 30/03/15 16:10 - qBittorrent v3.2.0beta started => The traslated string exists but it's not used.
* 30/03/15 16:10 - Peer ID: -qB3200- => It's in src/core/qtlibtorrent/qbtsession.cpp:134 but I don't know how to mark it for translation.

I think there is an Issue related to rename priority buttons but can't find.