### PR TITLE
Update matching RSS articles while editing rules

### DIFF
--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -523,6 +523,7 @@ void AutomatedRssDownloader::updateMatchingArticles()
     return;
   const QHash<QString, RssFeedPtr> all_feeds = manager->getAllFeedsAsHash();
 
+  saveEditedRule();
   foreach (const QListWidgetItem *rule_item, ui->listRules->selectedItems()) {
     RssDownloadRulePtr rule = m_editableRuleList->getRule(rule_item->text());
     if (!rule) continue;


### PR DESCRIPTION
Save the rules as soon as they are edited so that the matching
articles tree is immediately updated.

Closes #2829.