### PR TITLE
Use out of range value when the number of files can't be determined

### DIFF
--- a/src/core/qtlibtorrent/qtorrenthandle.cpp
+++ b/src/core/qtlibtorrent/qtorrenthandle.cpp
@@ -243,6 +243,8 @@ bool QTorrentHandle::has_filtered_pieces() const
 
 int QTorrentHandle::num_files() const
 {
+    if (!has_metadata())
+        return -1;
 #if LIBTORRENT_VERSION_NUM < 10000
     return torrent_handle::get_torrent_info().num_files();
 #else


### PR DESCRIPTION
Trying to get the number of files of a torrent with no metadata causes
a crash. Prevent this by first checking if the metadata is available.
If the number of files can't be determined, -1 will be returned.

Closes #2522.