### PR TITLE
Fix variable names

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -220,10 +220,10 @@ bool Application::event(QEvent *ev)
             // Get the url instead
             path = static_cast<QFileOpenEvent *>(ev)->url().toString();
         qDebug("Received a mac file open event: %s", qPrintable(path));
-        if (running_)
+        if (m_running)
             processParams(QStringList(path));
         else
-            paramsQueue_.append(path);
+            m_paramsQueue.append(path);
         return true;
     }
     else {


### PR DESCRIPTION
I've had this fixed locally for months and just realized that I never submitted it. Anyways, compilation of `src/app/application.cpp` on 3.2.0 has failed on OS X ever since 0c50a8b.
```
app/application.cpp:223:13: error: use of undeclared identifier 'running_'
        if (running_)
            ^
app/application.cpp:226:13: error: use of undeclared identifier
      'paramsQueue_'; did you mean 'm_paramsQueue'?
            paramsQueue_.append(path);
            ^~~~~~~~~~~~
            m_paramsQueue
app/application.h:88:17: note: 'm_paramsQueue' declared here
    QStringList m_paramsQueue;
                ^
2 errors generated.
Makefile:36238: recipe for target 'application.o' failed
```
It seems that `running_` and `paramsQueue_` were used mistakenly, as they don't appear anywhere else. So I have switched those identifiers to `m_running` and `m_paramsQueue`, which are properly initialized.