### PR TITLE
WebUI: Use QJson JSON parser/serializer if Qt < 5.5

### DIFF
--- a/src/webui/jsonutils.h
+++ b/src/webui/jsonutils.h
@@ -30,7 +30,7 @@
 #define JSONUTILS_H
 
 #include <QVariant>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
@@ -44,7 +44,7 @@ namespace json {
 
     inline QByteArray toJson(const QVariant& var)
     {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
         return QJsonDocument::fromVariant(var).toJson(QJsonDocument::Compact);
 #else
         QJson::Serializer serializer;
@@ -55,7 +55,7 @@ namespace json {
 
     inline QVariant fromJson(const QString& json)
     {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
         return QJsonDocument::fromJson(json.toUtf8()).toVariant();
 #else
         return QJson::Parser().parse(json.toUtf8());

--- a/src/webui/webui.pri
+++ b/src/webui/webui.pri
@@ -19,7 +19,9 @@ SOURCES += \
     $$PWD/qtorrentfilter.cpp \
     $$PWD/abstractwebapplication.cpp
 
-# QJson JSON parser/serializer for using with Qt4
-lessThan(QT_MAJOR_VERSION, 5): include(qjson/qjson.pri)
+# QJson JSON parser/serializer for using with Qt < 5.5
+lessThan(QT_MAJOR_VERSION, 6) {
+    lessThan(QT_MAJOR_VERSION, 5)|lessThan(QT_MINOR_VERSION, 5): include(qjson/qjson.pri)
+}
 
 RESOURCES += $$PWD/webui.qrc


### PR DESCRIPTION
QJsonDocument::fromVariant() supports QVariantHash since Qt 5.5, so
use the old QJson JSON parser/serializer since QVariantHash is used
to generate the list of torrents.

Closes #2849.