### PR TITLE
login.html escape quotes + add qbittorrent-nox to gitignore + bug with startup info with qbittorrent-nox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 src/geoip/GeoIP.dat
 src/geoip/GeoIP.dat.gz
 src/qbittorrent
+src/qbittorrent-nox
 qbittorrent.pro.user*
 conf.pri
 Makefile

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -157,16 +157,14 @@ int Application::exec(const QStringList &params)
 #ifdef DISABLE_GUI
 #ifndef DISABLE_WEBUI
     Preferences* const pref = Preferences::instance();
-    if (pref->isWebUiEnabled()) {
-        // Display some information to the user
-        std::cout << std::endl << "******** " << qPrintable(tr("Information")) << " ********" << std::endl;
-        std::cout << qPrintable(tr("To control qBittorrent, access the Web UI at http://localhost:%1").arg(QString::number(pref->getWebUiPort()))) << std::endl;
-        std::cout << qPrintable(tr("The Web UI administrator user name is: %1").arg(pref->getWebUiUsername())) << std::endl;
-        qDebug() << "Password:" << pref->getWebUiPassword();
-        if (pref->getWebUiPassword() == "f6fdffe48c908deb0f4c3bd36c032e72") {
-            std::cout << qPrintable(tr("The Web UI administrator password is still the default one: %1").arg("adminadmin")) << std::endl;
-            std::cout << qPrintable(tr("This is a security risk, please consider changing your password from program preferences.")) << std::endl;
-        }
+    // Display some information to the user
+    std::cout << std::endl << "******** " << qPrintable(tr("Information")) << " ********" << std::endl;
+    std::cout << qPrintable(tr("To control qBittorrent, access the Web UI at http://localhost:%1").arg(QString::number(pref->getWebUiPort()))) << std::endl;
+    std::cout << qPrintable(tr("The Web UI administrator user name is: %1").arg(pref->getWebUiUsername())) << std::endl;
+    qDebug() << "Password:" << pref->getWebUiPassword();
+    if (pref->getWebUiPassword() == "f6fdffe48c908deb0f4c3bd36c032e72") {
+        std::cout << qPrintable(tr("The Web UI administrator password is still the default one: %1").arg("adminadmin")) << std::endl;
+        std::cout << qPrintable(tr("This is a security risk, please consider changing your password from program preferences.")) << std::endl;
     }
 #endif // DISABLE_WEBUI
 #else

--- a/src/core/preferences.cpp
+++ b/src/core/preferences.cpp
@@ -1076,7 +1076,11 @@ void Preferences::setIgnoreSlowTorrentsForQueueing(bool ignore)
 
 bool Preferences::isWebUiEnabled() const
 {
+#ifdef DISABLE_GUI
+    return true;
+#else
     return value("Preferences/WebUI/Enabled", false).toBool();
+#endif
 }
 
 void Preferences::setWebUiEnabled(bool enabled)

--- a/src/webui/abstractwebapplication.cpp
+++ b/src/webui/abstractwebapplication.cpp
@@ -270,6 +270,10 @@ void AbstractWebApplication::translateDocument(QString& data)
             // Remove keyboard shortcuts
             translation.replace(mnemonic, "");
 
+            // Use HTML code for quotes to prevent issues with JS
+            translation.replace("'", "&#39;");
+            translation.replace("\"", "&#34;");
+
             data.replace(i, regex.matchedLength(), translation);
             i += translation.length();
         }


### PR DESCRIPTION
Three littles modifications:
* Add "qbittorrent-nox" to the gitignore like is brother "qbittorrent"
* Fix a bug that prevent webUI startup information to print in the console with qbittorrent-nox
* Fix login.html JavaScript bug. There is a quote in the French translation that is not escape. So all the JavaScript doesn't compile. I just replace quotes by double quotes for QBT_TR strings