### PR TITLE
WebUI: Convert torrent list from QVariantHash to QVariantMap

### DIFF
--- a/src/webui/btjson.cpp
+++ b/src/webui/btjson.cpp
@@ -736,6 +736,17 @@ QVariantMap generateSyncData(int acceptedResponseId, QVariantMap data, QVariantM
     if (fullUpdate) {
         lastAcceptedData.clear();
         syncData = data;
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0) && QT_VERSION < QT_VERSION_CHECK(5, 5, 0))
+        // QJsonDocument::fromVariant() supports QVariantHash only
+        // since Qt5.5, so manually convert data["torrents"]
+        QVariantMap torrentsMap;
+        QVariantHash torrents = data["torrents"].toHash();
+        foreach (const QString &key, torrents.keys())
+            torrentsMap[key] = torrents[key];
+        syncData["torrents"] = torrentsMap;
+#endif
+
         syncData[KEY_FULL_UPDATE] = true;
     }
 


### PR DESCRIPTION
Currently QJsonDocument::fromVariant() does not support QVariantHash,
so convert the torrent list to QVariantMap.

Closes #2849.