### PR TITLE
Use AllUppercase for label text

### DIFF
--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -760,7 +760,7 @@ TransferListFiltersWidget::TransferListFiltersWidget(QWidget *parent, TransferLi
     QVBoxLayout *frameLayout = new QVBoxLayout(frame);
     QFont font;
     font.setBold(true);
-    font.setCapitalization(QFont::SmallCaps);
+    font.setCapitalization(QFont::AllUppercase);
 
     frame->setFrameShadow(QFrame::Plain);
     frame->setFrameShape(QFrame::NoFrame);


### PR DESCRIPTION
The current label text is hard to read (which is using `SmallCaps`).
I suggest changing it to `AllUppercase`.


Comparison:
Old:
![old](https://cloud.githubusercontent.com/assets/9395168/7174957/96b2952e-e441-11e4-807b-7139e5aebf67.png)

New:
![new](https://cloud.githubusercontent.com/assets/9395168/7174964/a579bcd6-e441-11e4-9df8-47f3d9b88019.png)
