### PR TITLE
Allow to Open files from the properties pane by pressing "Enter"

### DIFF
--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -142,6 +142,8 @@ PropertiesWidget::PropertiesWidget(QWidget *parent, MainWindow* main_window, Tra
   connect(listWebSeeds, SIGNAL(doubleClicked(QModelIndex)), SLOT(editWebSeed()));
   deleteHotkeyWeb = new QShortcut(QKeySequence(QKeySequence::Delete), listWebSeeds, 0, 0, Qt::WidgetShortcut);
   connect(deleteHotkeyWeb, SIGNAL(activated()), SLOT(deleteSelectedUrlSeeds()));
+  openHotkeyFile = new QShortcut(QKeySequence("Return"), filesList, 0, 0, Qt::WidgetShortcut);
+  connect(openHotkeyFile, SIGNAL(activated()), SLOT(openSelectedFile()));
 }
 
 PropertiesWidget::~PropertiesWidget() {
@@ -157,6 +159,7 @@ PropertiesWidget::~PropertiesWidget() {
   delete editHotkeyFile;
   delete editHotkeyWeb;
   delete deleteHotkeyWeb;
+  delete openHotkeyFile;
   qDebug() << Q_FUNC_INFO << "EXIT";
 }
 
@@ -749,6 +752,13 @@ void PropertiesWidget::renameSelectedFile() {
       }
     }
   }
+}
+
+void PropertiesWidget::openSelectedFile() {
+  const QModelIndexList selectedIndexes = filesList->selectionModel()->selectedRows(0);
+  if (selectedIndexes.size() != 1)
+    return;
+  openDoubleClickedFile(selectedIndexes.first());
 }
 
 void PropertiesWidget::askWebSeed() {

--- a/src/gui/properties/propertieswidget.h
+++ b/src/gui/properties/propertieswidget.h
@@ -92,6 +92,7 @@ protected slots:
   void showPiecesDownloaded(bool show);
   void showPiecesAvailability(bool show);
   void renameSelectedFile();
+  void openSelectedFile();
 
 public slots:
   void setVisibility(bool visible);
@@ -126,6 +127,7 @@ private:
   QShortcut *editHotkeyFile;
   QShortcut *editHotkeyWeb;
   QShortcut *deleteHotkeyWeb;
+  QShortcut *openHotkeyFile;
 
 private slots:
   void filterText(const QString& filter);


### PR DESCRIPTION
Allow to open only one file at a time and ignore keypresses when multiple items are selected.