### PR TITLE
Add column with list of currently downloading files

### DIFF
--- a/src/base/bittorrent/peerinfo.cpp
+++ b/src/base/bittorrent/peerinfo.cpp
@@ -408,3 +408,8 @@ QString PeerInfo::flagsDescription() const
 {
     return m_flagsDescription;
 }
+
+int PeerInfo::downloadingPieceIndex() const
+{
+    return m_nativeInfo.downloading_piece_index;
+}

--- a/src/base/bittorrent/peerinfo.h
+++ b/src/base/bittorrent/peerinfo.h
@@ -100,6 +100,7 @@ namespace BitTorrent
 #ifndef DISABLE_COUNTRIES_RESOLUTION
         QString country() const;
 #endif
+        int downloadingPieceIndex() const;
 
     private:
         void calcRelevance(const TorrentHandle *torrent);

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -211,6 +211,20 @@ QByteArray TorrentInfo::metadata() const
     return QByteArray(m_nativeInfo->metadata().get(), m_nativeInfo->metadata_size());
 }
 
+QStringList TorrentInfo::filesForPiece(int pieceIndex) const
+{
+    if (pieceIndex < 0)
+        return QStringList();
+
+    std::vector<libtorrent::file_slice> files(
+        nativeInfo()->map_block(pieceIndex, 0, nativeInfo()->piece_length()));
+    QStringList res;
+    for (const libtorrent::file_slice& s: files) {
+        res.append(filePath(s.file_index));
+    }
+    return res;
+}
+
 void TorrentInfo::renameFile(uint index, const QString &newPath)
 {
     if (!isValid()) return;

--- a/src/base/bittorrent/torrentinfo.h
+++ b/src/base/bittorrent/torrentinfo.h
@@ -75,6 +75,7 @@ namespace BitTorrent
         QList<TrackerEntry> trackers() const;
         QList<QUrl> urlSeeds() const;
         QByteArray metadata() const;
+        QStringList filesForPiece(int pieceIndex) const;
 
         void renameFile(uint index, const QString &newPath);
         boost::intrusive_ptr<libtorrent::torrent_info> nativeInfo() const;

--- a/src/gui/properties/peerlistdelegate.h
+++ b/src/gui/properties/peerlistdelegate.h
@@ -41,7 +41,7 @@ class PeerListDelegate: public QItemDelegate {
 
 public:
   enum PeerListColumns {COUNTRY, IP, PORT, CONNECTION, FLAGS, CLIENT, PROGRESS, DOWN_SPEED, UP_SPEED,
-                        TOT_DOWN, TOT_UP, RELEVANCE, IP_HIDDEN, COL_COUNT};
+                        TOT_DOWN, TOT_UP, RELEVANCE, DOWNLOADING_PIECE, IP_HIDDEN, COL_COUNT};
 
 public:
   PeerListDelegate(QObject *parent) : QItemDelegate(parent) {}

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -282,14 +282,14 @@ void PeerListWidget::loadPeers(BitTorrent::TorrentHandle *const torrent, bool fo
         QString peerIp = addr.ip.toString();
         if (m_peerItems.contains(peerIp)) {
             // Update existing peer
-            updatePeer(peerIp, peer);
+            updatePeer(peerIp, torrent, peer);
             oldeersSet.remove(peerIp);
             if (forceHostnameResolution && m_resolver)
                 m_resolver->resolve(peerIp);
         }
         else {
             // Add new peer
-            m_peerItems[peerIp] = addPeer(peerIp, peer);
+            m_peerItems[peerIp] = addPeer(peerIp, torrent, peer);
             m_peerAddresses[peerIp] = addr;
             // Resolve peer host name is asked
             if (m_resolver)
@@ -307,7 +307,7 @@ void PeerListWidget::loadPeers(BitTorrent::TorrentHandle *const torrent, bool fo
     }
 }
 
-QStandardItem* PeerListWidget::addPeer(const QString &ip, const BitTorrent::PeerInfo &peer)
+QStandardItem* PeerListWidget::addPeer(const QString& ip, BitTorrent::TorrentHandle *const torrent, const BitTorrent::PeerInfo &peer)
 {
     int row = m_listModel->rowCount();
     // Adding Peer to peer list
@@ -340,7 +340,7 @@ QStandardItem* PeerListWidget::addPeer(const QString &ip, const BitTorrent::Peer
     return m_listModel->item(row, PeerListDelegate::IP);
 }
 
-void PeerListWidget::updatePeer(const QString &ip, const BitTorrent::PeerInfo &peer)
+void PeerListWidget::updatePeer(const QString &ip, BitTorrent::TorrentHandle *const torrent, const BitTorrent::PeerInfo &peer)
 {
     QStandardItem *item = m_peerItems.value(ip);
     int row = item->row();

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -78,6 +78,7 @@ PeerListWidget::PeerListWidget(PropertiesWidget *parent)
     m_listModel->setHeaderData(PeerListDelegate::TOT_DOWN, Qt::Horizontal, tr("Downloaded", "i.e: total data downloaded"));
     m_listModel->setHeaderData(PeerListDelegate::TOT_UP, Qt::Horizontal, tr("Uploaded", "i.e: total data uploaded"));
     m_listModel->setHeaderData(PeerListDelegate::RELEVANCE, Qt::Horizontal, tr("Relevance", "i.e: How relevant this peer is to us. How many pieces it has that we don't."));
+    m_listModel->setHeaderData(PeerListDelegate::DOWNLOADING_PIECE, Qt::Horizontal, tr("Files", "i.e. files that are being downloaded right now"));
     // Proxy model to support sorting without actually altering the underlying model
     m_proxyModel = new PeerListSortModel();
     m_proxyModel->setDynamicSortFilter(true);
@@ -337,6 +338,10 @@ QStandardItem* PeerListWidget::addPeer(const QString& ip, BitTorrent::TorrentHan
     m_listModel->setData(m_listModel->index(row, PeerListDelegate::TOT_DOWN), peer.totalDownload());
     m_listModel->setData(m_listModel->index(row, PeerListDelegate::TOT_UP), peer.totalUpload());
     m_listModel->setData(m_listModel->index(row, PeerListDelegate::RELEVANCE), peer.relevance());
+    QStringList downloadingFiles(torrent->info().filesForPiece(peer.downloadingPieceIndex()));
+    m_listModel->setData(m_listModel->index(row, PeerListDelegate::DOWNLOADING_PIECE), downloadingFiles.join(QLatin1String(";")));
+    m_listModel->setData(m_listModel->index(row, PeerListDelegate::DOWNLOADING_PIECE), downloadingFiles.join(QLatin1String("\n")), Qt::ToolTipRole);
+
     return m_listModel->item(row, PeerListDelegate::IP);
 }
 
@@ -364,6 +369,9 @@ void PeerListWidget::updatePeer(const QString &ip, BitTorrent::TorrentHandle *co
     m_listModel->setData(m_listModel->index(row, PeerListDelegate::TOT_DOWN), peer.totalDownload());
     m_listModel->setData(m_listModel->index(row, PeerListDelegate::TOT_UP), peer.totalUpload());
     m_listModel->setData(m_listModel->index(row, PeerListDelegate::RELEVANCE), peer.relevance());
+    QStringList downloadingFiles(torrent->info().filesForPiece(peer.downloadingPieceIndex()));
+    m_listModel->setData(m_listModel->index(row, PeerListDelegate::DOWNLOADING_PIECE), downloadingFiles.join(QLatin1String(";")));
+    m_listModel->setData(m_listModel->index(row, PeerListDelegate::DOWNLOADING_PIECE), downloadingFiles.join(QLatin1String("\n")), Qt::ToolTipRole);
 }
 
 void PeerListWidget::handleResolved(const QString &ip, const QString &hostname)

--- a/src/gui/properties/peerlistwidget.h
+++ b/src/gui/properties/peerlistwidget.h
@@ -68,8 +68,8 @@ public:
     ~PeerListWidget();
 
     void loadPeers(BitTorrent::TorrentHandle *const torrent, bool forceHostnameResolution = false);
-    QStandardItem *addPeer(const QString &ip, const BitTorrent::PeerInfo &peer);
-    void updatePeer(const QString &ip, const BitTorrent::PeerInfo &peer);
+    QStandardItem *addPeer(const QString &ip, BitTorrent::TorrentHandle *const torrent, const BitTorrent::PeerInfo &peer);
+    void updatePeer(const QString &ip, BitTorrent::TorrentHandle *const torrent, const BitTorrent::PeerInfo &peer);
     void updatePeerHostNameResolutionState();
     void updatePeerCountryResolutionState();
     void clear();


### PR DESCRIPTION
Add a new column to peers list that shows list of files which are
donwloaded right now from a peer. The column is empty if we do not
download anything from the given peer.