### PR TITLE
Fix aboutToQuit signal is not emitted on Windows.

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -316,6 +316,20 @@ MainWindow::MainWindow(QWidget *parent)
             activateWindow();
             raise();
         }
+        else {
+            create();
+        }
+    }
+    else {
+        // Make sure the Window is visible if we don't have a tray icon
+        if (pref->startMinimized()) {
+            showMinimized();
+        }
+        else {
+            show();
+            activateWindow();
+            raise();
+        }
     }
 
     properties->readSettings();
@@ -351,18 +365,6 @@ MainWindow::MainWindow(QWidget *parent)
 #ifdef Q_OS_MAC
     qt_mac_set_dock_menu(getTrayIconMenu());
 #endif
-
-    // Make sure the Window is visible if we don't have a tray icon
-    if (!systrayIcon) {
-        if (pref->startMinimized()) {
-            showMinimized();
-        }
-        else {
-            show();
-            activateWindow();
-            raise();
-        }
-    }
 }
 
 MainWindow::~MainWindow()
@@ -882,6 +884,7 @@ void MainWindow::closeEvent(QCloseEvent *e)
         e->accept();
         return;
     }
+
     if (pref->confirmOnExit() && QBtSession::instance()->hasActiveTorrents()) {
         if (e->spontaneous() || force_exit) {
             if (!isVisible())
@@ -905,12 +908,11 @@ void MainWindow::closeEvent(QCloseEvent *e)
                 Preferences::instance()->setConfirmOnExit(false);
         }
     }
+
     hide();
+    // Hide tray icon
     if (systrayIcon)
-        // Hide tray icon
         systrayIcon->hide();
-    // Save window size, columns size
-    writeSettings();
     // Accept exit
     e->accept();
     qApp->exit();


### PR DESCRIPTION
In some cases QApplication::aboutToQuit() signal not emitted on
Windows. This happened when qBittorrent is started with both "Show
minimized" and "Minimize to system tray" enabled.

Also fix MainWindow::writeSettings() called twice on application exit.