### PR TITLE
fix filemanager tests

### DIFF
--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -521,8 +521,14 @@ void PropertiesWidget::openFolder(const QModelIndex &index, bool containing_fold
     output = proc.readLine().simplified();
     if (output == "dolphin.desktop")
       proc.startDetached("dolphin", QStringList() << "--select" << fsutils::toNativePath(absolute_path));
-    else if (output == "nautilus-folder-handler.desktop")
+    else if (output == "caja-folder-handler.desktop")
+      proc.startDetached("caja", QStringList() << "--no-desktop" << fsutils::toNativePath(absolute_path));
+    else if (output == "nautilus.desktop")
       proc.startDetached("nautilus", QStringList() << "--no-desktop" << fsutils::toNativePath(absolute_path));
+    else if (output == "org.gnome.Nautilus.desktop")
+      proc.startDetached("nautilus", QStringList() << "--no-desktop" << fsutils::toNativePath(absolute_path));
+    else if (output == "nemo.desktop")
+      proc.startDetached("nemo", QStringList() << "--no-desktop" << fsutils::toNativePath(absolute_path));
     else if (output == "kfmclient_dir.desktop")
       proc.startDetached("konqueror", QStringList() << "--select" << fsutils::toNativePath(absolute_path));
     else


### PR DESCRIPTION
nautilus-folder-handler.desktop is the wrong name for nautilus-3.x.x, it should be nautilus.desktop till nautilus-3.14 then it's name changes to org.gnome.Nautilus.desktop
I have also added nemo and caja support.

Should fix https://github.com/qbittorrent/qBittorrent/issues/2895