### PR TITLE
[SYSTEMD]Make executable path absolute

### DIFF
--- a/dist/unix/systemd/qbittorrent-nox.service
+++ b/dist/unix/systemd/qbittorrent-nox.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=forking
 User=1000
-ExecStart=qbittorrent-nox -d
+ExecStart=/usr/bin/qbittorrent-nox -d
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The executable path must be absolute

```
Apr 26 21:19:05 srv-rhsoft systemd:
[/usr/lib/systemd/system/qbittorrent-nox.service:8] Executable path is not
absolute, ignoring: qbittorrent-nox -d
Apr 26 21:19:05 srv-rhsoft systemd: qbittorrent-nox.service lacks both
ExecStart= and ExecStop= setting. Refusing.
Apr 26 21:19:05 srv-rhsoft systemd:
[/usr/lib/systemd/system/qbittorrent-nox.service:8] Executable path is not
absolute, ignoring: qbittorrent-nox -d
Apr 26 21:19:05 srv-rhsoft systemd: qbittorrent-nox.service lacks both
ExecStart= and ExecStop= setting. Refusing.
```

https://bugzilla.redhat.com/show_bug.cgi?id=1215460