### PR TITLE
Fix potential negative loop bound.

### DIFF
--- a/src/core/qtlibtorrent/qtorrenthandle.cpp
+++ b/src/core/qtlibtorrent/qtorrenthandle.cpp
@@ -732,8 +732,8 @@ void QTorrentHandle::prioritize_first_last_piece(bool b) const
 {
     if (!has_metadata()) return;
     // Download first and last pieces first for all media files in the torrent
-    const uint nbfiles = num_files();
-    for (uint index = 0; index < nbfiles; ++index) {
+    const int nbfiles = num_files();
+    for (int index = 0; index < nbfiles; ++index) {
         const QString path = filepath_at(index);
         const QString ext = fsutils::fileExtension(path);
         if (misc::isPreviewable(ext) && torrent_handle::file_priority(index) > 0) {

--- a/src/gui/previewselect.cpp
+++ b/src/gui/previewselect.cpp
@@ -60,8 +60,8 @@ PreviewSelect::PreviewSelect(QWidget* parent, QTorrentHandle h): QDialog(parent)
   // Fill list in
   std::vector<libtorrent::size_type> fp;
   h.file_progress(fp);
-  unsigned int nbFiles = h.num_files();
-  for (unsigned int i=0; i<nbFiles; ++i) {
+  int nbFiles = h.num_files();
+  for (int i=0; i<nbFiles; ++i) {
     QString fileName = h.filename_at(i);
     if (fileName.endsWith(".!qB"))
       fileName.chop(4);


### PR DESCRIPTION
QTorrentHandle::num_files() could return -1 in these cases.