### PR TITLE
Removing the confusion caused by moving GeoIP code/.dat

### DIFF
--- a/configure
+++ b/configure
@@ -1390,7 +1390,7 @@ Optional Packages:
   --with-geoip-database-embedded
                           Embed the GeoIP database in the qBittorrent
                           executable (please follow instructions in
-                          src/geoip/README) (default=no)
+                          src/gui/geoip/README) (default=no)
   --with-qtsingleapplication=[system|shipped]
                           Use the shipped qtsingleapplication library or the
                           system one (default=shipped)

--- a/configure.ac
+++ b/configure.ac
@@ -26,7 +26,7 @@ AC_ARG_WITH(libtorrent-rasterbar0.16,
 
 AC_ARG_WITH(geoip-database-embedded,
             [AS_HELP_STRING([--with-geoip-database-embedded],
-                            [Embed the GeoIP database in the qBittorrent executable (please follow instructions in src/geoip/README) (default=no)])],
+                            [Embed the GeoIP database in the qBittorrent executable (please follow instructions in src/gui/geoip/README) (default=no)])],
             [],
             [with_geoip_database_embedded=no])
 

--- a/src/gui/geoip/geoip.pri
+++ b/src/gui/geoip/geoip.pri
@@ -8,11 +8,11 @@ SOURCES += $$PWD/geoipmanager.cpp
 # should be embedded in qBittorrent executable
 contains(DEFINES, WITH_GEOIP_EMBEDDED) {
   exists("GeoIP.dat") {
-    message("GeoIP.dat was found in src/geoip/.")
+    message("GeoIP.dat was found in src/gui/geoip/.")
     RESOURCES += $$PWD/geoip.qrc
   } else {
     DEFINES -= WITH_GEOIP_EMBEDDED
-    error("GeoIP.dat was not found in src/geoip/ folder, please follow instructions in src/geoip/README.")
+    error("GeoIP.dat was not found in src/gui/geoip/ folder, please follow instructions in src/gui/geoip/README.")
   }
 } else {
   message("GeoIP database will not be embedded in qBittorrent executable.")


### PR DESCRIPTION
Somebody shuffled this stuff around but forgot to update the supporting references. I was confused for a while until I figured it out. Would've been much more obvious to me if these references had been updated as well.