### PR TITLE
Enable to choose dark/light tray icons on all platforms.

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1588,6 +1588,10 @@ void MainWindow::checkForActiveTorrents()
 QIcon MainWindow::getSystrayIcon() const
 {
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+    if (Preferences::instance()->useSystemIconTheme())
+        return QIcon::fromTheme("qbittorrent");
+#endif
+
     TrayIcon::Style style = Preferences::instance()->trayIconStyle();
     switch(style) {
     case TrayIcon::MONO_DARK:
@@ -1597,18 +1601,11 @@ QIcon MainWindow::getSystrayIcon() const
     default:
         break;
     }
-#endif
-    QIcon icon;
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
-    if (Preferences::instance()->useSystemIconTheme())
-        icon = QIcon::fromTheme("qbittorrent");
 
-#endif
-    if (icon.isNull()) {
-        icon.addFile(":/icons/skin/qbittorrent22.png", QSize(22, 22));
-        icon.addFile(":/icons/skin/qbittorrent16.png", QSize(16, 16));
-        icon.addFile(":/icons/skin/qbittorrent32.png", QSize(32, 32));
-    }
+    QIcon icon;
+    icon.addFile(":/icons/skin/qbittorrent16.png");
+    icon.addFile(":/icons/skin/qbittorrent22.png");
+    icon.addFile(":/icons/skin/qbittorrent32.png");
     return icon;
 }
 

--- a/src/gui/options_imp.cpp
+++ b/src/gui/options_imp.cpp
@@ -113,11 +113,10 @@ options_imp::options_imp(QWidget *parent):
   if (!QSystemTrayIcon::isSystemTrayAvailable()) {
     checkShowSystray->setChecked(false);
     checkShowSystray->setEnabled(false);
+    label_trayIconStyle->setVisible(false);
+    comboTrayIcon->setVisible(false);
   }
-#if (!defined(Q_OS_UNIX) || defined(Q_OS_MAC))
-  label_trayIconStyle->setVisible(false);
-  comboTrayIcon->setVisible(false);
-#endif
+
 #if defined(QT_NO_OPENSSL)
   checkWebUiHttps->setVisible(false);
 #endif
@@ -268,7 +267,7 @@ options_imp::options_imp(QWidget *parent):
 
   // Adapt size
   show();
-  loadWindowState();  
+  loadWindowState();
 }
 
 void options_imp::initializeLanguageCombo()
@@ -279,7 +278,7 @@ void options_imp::initializeLanguageCombo()
   foreach (QString lang_file, lang_files) {
     QString localeStr = lang_file.mid(12); // remove "qbittorrent_"
     localeStr.chop(3); // Remove ".qm"
-    QLocale locale(localeStr);    
+    QLocale locale(localeStr);
     QString language_name = languageToLocalizedString(locale);
     comboI18n->addItem(/*QIcon(":/icons/flags/"+country+".png"), */language_name, localeStr);
     qDebug() << "Supported locale:" << localeStr;
@@ -762,7 +761,7 @@ void options_imp::loadOptions() {
   domainNameTxt->setText(pref->getDynDomainName());
   DNSUsernameTxt->setText(pref->getDynDNSUsername());
   DNSPasswordTxt->setText(pref->getDynDNSPassword());
-  // End Web UI  
+  // End Web UI
 }
 
 // return min & max ports


### PR DESCRIPTION
On windows (not sure about OSX), theme color can be changed too. So why not let users have more choices?
