### PR TITLE
Treating Alt Global Rate Limits Like Regular Global Rate Limits

### DIFF
--- a/src/gui/options.ui
+++ b/src/gui/options.ui
@@ -181,7 +181,7 @@
              <x>0</x>
              <y>0</y>
              <width>458</width>
-             <height>587</height>
+             <height>611</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -520,7 +520,7 @@
              <x>0</x>
              <y>0</y>
              <width>458</width>
-             <height>905</height>
+             <height>933</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout">
@@ -1037,8 +1037,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>357</width>
-             <height>498</height>
+             <width>458</width>
+             <height>556</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -1538,8 +1538,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>275</width>
-             <height>396</height>
+             <width>458</width>
+             <height>407</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_33">
@@ -1716,13 +1716,6 @@
                  </item>
                  <item row="0" column="1">
                   <layout class="QGridLayout" name="gridLayout_8">
-                   <item row="0" column="0">
-                    <widget class="QLabel" name="label_11">
-                     <property name="text">
-                      <string>Upload:</string>
-                     </property>
-                    </widget>
-                   </item>
                    <item row="0" column="1">
                     <widget class="QSpinBox" name="spinUploadLimitAlt">
                      <property name="minimum">
@@ -1743,15 +1736,11 @@
                      </property>
                     </widget>
                    </item>
-                   <item row="1" column="0">
-                    <widget class="QLabel" name="label_12">
-                     <property name="text">
-                      <string>Download:</string>
-                     </property>
-                    </widget>
-                   </item>
                    <item row="1" column="1">
                     <widget class="QSpinBox" name="spinDownloadLimitAlt">
+                     <property name="enabled">
+                      <bool>false</bool>
+                     </property>
                      <property name="minimum">
                       <number>1</number>
                      </property>
@@ -1767,6 +1756,23 @@
                     <widget class="QLabel" name="label_15">
                      <property name="text">
                       <string>KiB/s</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="0" column="0">
+                    <widget class="QCheckBox" name="checkUploadLimitAlt">
+                     <property name="text">
+                      <string>Upload:</string>
+                     </property>
+                     <property name="checked">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="0">
+                    <widget class="QCheckBox" name="checkDownloadLimitAlt">
+                     <property name="text">
+                      <string>Download:</string>
                      </property>
                     </widget>
                    </item>
@@ -1816,18 +1822,18 @@
                       <property name="wrapping">
                        <bool>true</bool>
                       </property>
+                      <property name="displayFormat">
+                       <string notr="true">hh:mm</string>
+                      </property>
+                      <property name="calendarPopup">
+                       <bool>false</bool>
+                      </property>
                       <property name="time">
                        <time>
                         <hour>8</hour>
                         <minute>0</minute>
                         <second>0</second>
                        </time>
-                      </property>
-                      <property name="displayFormat">
-                       <string notr="true">hh:mm</string>
-                      </property>
-                      <property name="calendarPopup">
-                       <bool>false</bool>
                       </property>
                      </widget>
                     </item>
@@ -1846,15 +1852,15 @@
                       <property name="wrapping">
                        <bool>true</bool>
                       </property>
+                      <property name="displayFormat">
+                       <string notr="true">hh:mm</string>
+                      </property>
                       <property name="time">
                        <time>
                         <hour>20</hour>
                         <minute>0</minute>
                         <second>0</second>
                        </time>
-                      </property>
-                      <property name="displayFormat">
-                       <string notr="true">hh:mm</string>
                       </property>
                      </widget>
                     </item>
@@ -1956,8 +1962,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>418</width>
-             <height>442</height>
+             <width>458</width>
+             <height>381</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -2310,8 +2316,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>330</width>
-             <height>480</height>
+             <width>458</width>
+             <height>494</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -2687,8 +2693,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>98</width>
-             <height>28</height>
+             <width>474</width>
+             <height>316</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_36"/>
@@ -2791,12 +2797,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>496</x>
-     <y>66</y>
+     <x>544</x>
+     <y>172</y>
     </hint>
     <hint type="destinationlabel">
-     <x>643</x>
-     <y>74</y>
+     <x>603</x>
+     <y>171</y>
     </hint>
    </hints>
   </connection>
@@ -2807,12 +2813,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>494</x>
-     <y>97</y>
+     <x>544</x>
+     <y>198</y>
     </hint>
     <hint type="destinationlabel">
-     <x>611</x>
-     <y>99</y>
+     <x>603</x>
+     <y>197</y>
     </hint>
    </hints>
   </connection>
@@ -2823,12 +2829,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>510</x>
-     <y>123</y>
+     <x>544</x>
+     <y>250</y>
     </hint>
     <hint type="destinationlabel">
-     <x>616</x>
-     <y>126</y>
+     <x>603</x>
+     <y>249</y>
     </hint>
    </hints>
   </connection>
@@ -2839,12 +2845,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>552</x>
-     <y>441</y>
+     <x>509</x>
+     <y>372</y>
     </hint>
     <hint type="destinationlabel">
-     <x>612</x>
-     <y>443</y>
+     <x>584</x>
+     <y>373</y>
     </hint>
    </hints>
   </connection>
@@ -2855,12 +2861,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>552</x>
-     <y>441</y>
+     <x>509</x>
+     <y>372</y>
     </hint>
     <hint type="destinationlabel">
-     <x>788</x>
-     <y>444</y>
+     <x>721</x>
+     <y>373</y>
     </hint>
    </hints>
   </connection>
@@ -2875,8 +2881,8 @@
      <y>147</y>
     </hint>
     <hint type="destinationlabel">
-     <x>430</x>
-     <y>176</y>
+     <x>711</x>
+     <y>172</y>
     </hint>
    </hints>
   </connection>
@@ -2893,6 +2899,38 @@
     <hint type="destinationlabel">
      <x>571</x>
      <y>224</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>checkDownloadLimitAlt</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>spinDownloadLimitAlt</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>398</x>
+     <y>292</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>477</x>
+     <y>292</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>checkUploadLimitAlt</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>spinUploadLimitAlt</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>398</x>
+     <y>263</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>477</x>
+     <y>263</y>
     </hint>
    </hints>
   </connection>

--- a/src/gui/options_imp.cpp
+++ b/src/gui/options_imp.cpp
@@ -186,6 +186,8 @@ options_imp::options_imp(QWidget *parent):
   connect(checkUPnP, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
   connect(checkUploadLimit, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
   connect(checkDownloadLimit, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+  connect(checkUploadLimitAlt, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+  connect(checkDownloadLimitAlt, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
   connect(spinUploadLimit, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
   connect(spinDownloadLimit, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
   connect(spinUploadLimitAlt, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
@@ -422,8 +424,9 @@ void options_imp::saveOptions() {
   pref->setuTPEnabled(checkuTP->isChecked());
   pref->setuTPRateLimited(checkLimituTPConnections->isChecked());
   pref->includeOverheadInLimits(checkLimitTransportOverhead->isChecked());
-  pref->setAltGlobalDownloadLimit(spinDownloadLimitAlt->value());
-  pref->setAltGlobalUploadLimit(spinUploadLimitAlt->value());
+  const QPair<int, int> alt_down_up_limit = getAltGlobalBandwidthLimits();
+  pref->setAltGlobalDownloadLimit(alt_down_up_limit.first);
+  pref->setAltGlobalUploadLimit(alt_down_up_limit.second);
   pref->setSchedulerEnabled(check_schedule->isChecked());
   pref->setSchedulerStartTime(schedule_from->time());
   pref->setSchedulerEndTime(schedule_to->time());
@@ -626,8 +629,29 @@ void options_imp::loadOptions() {
     checkUploadLimit->setChecked(false);
     spinUploadLimit->setEnabled(false);
   }
-  spinUploadLimitAlt->setValue(pref->getAltGlobalUploadLimit());
-  spinDownloadLimitAlt->setValue(pref->getAltGlobalDownloadLimit());
+
+  intValue = pref->getAltGlobalDownloadLimit();
+  if (intValue > 0) {
+    // Enabled
+    checkDownloadLimitAlt->setChecked(true);
+    spinDownloadLimitAlt->setEnabled(true);
+    spinDownloadLimitAlt->setValue(intValue);
+  } else {
+    // Disabled
+    checkDownloadLimitAlt->setChecked(false);
+    spinDownloadLimitAlt->setEnabled(false);
+  }
+  intValue = pref->getAltGlobalUploadLimit();
+  if (intValue != -1) {
+    // Enabled
+    checkUploadLimitAlt->setChecked(true);
+    spinUploadLimitAlt->setEnabled(true);
+    spinUploadLimitAlt->setValue(intValue);
+  } else {
+    // Disabled
+    checkUploadLimitAlt->setChecked(false);
+    spinUploadLimitAlt->setEnabled(false);
+  }
   // Options
   checkuTP->setChecked(pref->isuTPEnabled());
   checkLimituTPConnections->setChecked(pref->isuTPRateLimited());
@@ -827,6 +851,19 @@ QPair<int,int> options_imp::getGlobalBandwidthLimits() const {
   }
   if (checkUploadLimit->isChecked()) {
     UP = spinUploadLimit->value();
+  }
+  return qMakePair(DL, UP);
+}
+
+// Return alternate Download & Upload limits in kbps
+// [download,upload]
+QPair<int,int> options_imp::getAltGlobalBandwidthLimits() const {
+  int DL = -1, UP = -1;
+  if (checkDownloadLimitAlt->isChecked()) {
+    DL = spinDownloadLimitAlt->value();
+  }
+  if (checkUploadLimitAlt->isChecked()) {
+    UP = spinUploadLimitAlt->value();
   }
   return qMakePair(DL, UP);
 }

--- a/src/gui/options_imp.h
+++ b/src/gui/options_imp.h
@@ -118,6 +118,7 @@ private:
   int getPort() const;
   bool isUPnPEnabled() const;
   QPair<int,int> getGlobalBandwidthLimits() const;
+  QPair<int,int> getAltGlobalBandwidthLimits() const;
   // Bittorrent options
   int getMaxConnecs() const;
   int getMaxConnecsPerTorrent() const;


### PR DESCRIPTION
The UI did not allow users to set unbounded up/down limits for alt global rate limits, but did allow it for regular global rate limits. The rest of the code treats everything appropriately, it was purely a UI limitation. It seemed silly to me that I would have unbounded down for regular limits and then have to set 99999 KB/s on my alt download limit to alter just my upload rate.