### PR TITLE
Changes in User-Agents

### DIFF
--- a/src/core/net/dnsupdater.cpp
+++ b/src/core/net/dnsupdater.cpp
@@ -81,7 +81,7 @@ void DNSUpdater::checkPublicIP()
     m_lastIPCheckTime = QDateTime::currentDateTime();
     QNetworkRequest request;
     request.setUrl(QUrl("http://checkip.dyndns.org"));
-    request.setRawHeader("User-Agent", "qBittorrent/" VERSION" chris@qbittorrent.org");
+    request.setRawHeader("User-Agent", "qBittorrent/" VERSION);
     manager->get(request);
 }
 
@@ -130,7 +130,7 @@ void DNSUpdater::updateDNSService()
     m_lastIPCheckTime = QDateTime::currentDateTime();
     QNetworkRequest request;
     request.setUrl(getUpdateUrl());
-    request.setRawHeader("User-Agent", "qBittorrent/" VERSION" chris@qbittorrent.org");
+    request.setRawHeader("User-Agent", "qBittorrent/" VERSION);
     manager->get(request);
 }
 

--- a/src/core/net/downloadmanager.cpp
+++ b/src/core/net/downloadmanager.cpp
@@ -85,9 +85,8 @@ DownloadHandler *DownloadManager::downloadUrl(const QString &url, qint64 limit)
     const QUrl qurl = QUrl::fromEncoded(url.toUtf8());
     QNetworkRequest request(qurl);
 
-    // Spoof Firefox 3.5 user agent to avoid
-    // Web server banning
-    request.setRawHeader("User-Agent", "Mozilla/5.0 (X11; U; Linux i686 (x86_64); en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5");
+    // Spoof Firefox 38 user agent to avoid web server banning
+    request.setRawHeader("User-Agent", "Mozilla/5.0 (X11; Linux i686; rv:38.0) Gecko/20100101 Firefox/38.0");
 
     qDebug("Downloading %s...", request.url().toEncoded().data());
     // accept gzip

--- a/src/searchengine/nova/helpers.py
+++ b/src/searchengine/nova/helpers.py
@@ -36,7 +36,7 @@ import socks
 import re
 
 # Some sites blocks default python User-agent
-user_agent = 'Mozilla/5.0'
+user_agent = 'Mozilla/5.0 (X11; Linux i686; rv:38.0) Gecko/20100101 Firefox/38.0'
 headers    = {'User-Agent': user_agent}
 # SOCKS5 Proxy support
 if os.environ.has_key("sock_proxy") and len(os.environ["sock_proxy"].strip()) > 0:

--- a/src/searchengine/nova3/helpers.py
+++ b/src/searchengine/nova3/helpers.py
@@ -36,7 +36,7 @@ import socks
 import re
 
 # Some sites blocks default python User-agent
-user_agent = 'Mozilla/5.0'
+user_agent = 'Mozilla/5.0 (X11; Linux i686; rv:38.0) Gecko/20100101 Firefox/38.0'
 headers    = {'User-Agent': user_agent}
 # SOCKS5 Proxy support
 if "sock_proxy" in os.environ and len(os.environ["sock_proxy"].strip()) > 0:


### PR DESCRIPTION
This commit is to keep consistency.
qBittorrent User-Agent: qBittorrent/v3.3.0
Firefox User-Agent (to avoid bans): Mozilla/5.0 (X11; Linux i686; rv:38.0) Gecko/20100101 Firefox/38.0
This is the last Firefox version and an incomplete User-Agent can be suspicious.