### PR TITLE
Change options for OSX

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -117,6 +117,7 @@ MainWindow::MainWindow(QWidget *parent)
     ui_locked = pref->isUILocked();
     setWindowTitle(QString("qBittorrent %1").arg(QString::fromUtf8(VERSION)));
     displaySpeedInTitle = pref->speedInTitleBar();
+
     // Setting icons
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
     if (Preferences::instance()->useSystemIconTheme())
@@ -124,6 +125,10 @@ MainWindow::MainWindow(QWidget *parent)
     else
 #endif
     setWindowIcon(QIcon(QString::fromUtf8(":/icons/skin/qbittorrent32.png")));
+
+#if (defined(Q_OS_UNIX))
+    actionOptions->setText(tr("Preferences"));
+#endif
 
     addToolbarContextMenu();
 

--- a/src/gui/options_imp.cpp
+++ b/src/gui/options_imp.cpp
@@ -120,6 +120,11 @@ options_imp::options_imp(QWidget *parent)
         comboTrayIcon->setVisible(false);
     }
 
+#ifdef Q_OS_MAC
+    checkMinimizeToSysTray->setVisible(false);
+    checkCloseToSystray->setVisible(false);
+#endif
+
 #if defined(QT_NO_OPENSSL)
     checkWebUiHttps->setVisible(false);
 #endif

--- a/src/gui/options_imp.cpp
+++ b/src/gui/options_imp.cpp
@@ -67,6 +67,11 @@ options_imp::options_imp(QWidget *parent)
     setupUi(this);
     setAttribute(Qt::WA_DeleteOnClose);
     setModal(true);
+
+#if (defined(Q_OS_UNIX))
+    setWindowTitle(tr("Preferences"));
+#endif
+
     // Icons
     tabSelection->item(TAB_UI)->setIcon(GuiIconProvider::instance()->getIcon("preferences-desktop"));
     tabSelection->item(TAB_BITTORRENT)->setIcon(GuiIconProvider::instance()->getIcon("preferences-system-network"));

--- a/src/gui/options_imp.cpp
+++ b/src/gui/options_imp.cpp
@@ -121,6 +121,7 @@ options_imp::options_imp(QWidget *parent)
     }
 
 #ifdef Q_OS_MAC
+    checkShowSystray->setTitle(tr("Show qBittorrent in menu bar"));
     checkMinimizeToSysTray->setVisible(false);
     checkCloseToSystray->setVisible(false);
 #endif


### PR DESCRIPTION
Created for issue #951:
* Close to tray option defaults to true on OSX
* Hide options on OSX: minimize to tray & close to tray 

ainstushar suggest changing the name "Show qBittorrent in notification area" to "Show qBittorrent in menu bar" on OSX, however I'm not sure how to change this and whether should follow this.
