### PR TITLE
Check invalid tracker favicon

### DIFF
--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -617,7 +617,7 @@ void TrackerFiltersList::handleFavicoDownload(const QString& url, const QString&
     QListWidgetItem *trackerItem = item(rowFromTracker(host));
     QIcon icon(filePath);
     //Detect a non-decodable icon
-    bool invalid = icon.pixmap(icon.availableSizes().first()).isNull();
+    bool invalid = icon.availableSizes().isEmpty() || icon.pixmap(icon.availableSizes().first()).isNull();
     if (invalid) {
         if (url.endsWith(".ico", Qt::CaseInsensitive)) {
             Logger::instance()->addMessage(tr("Couldn't decode favico for url `%1`. Trying to download favico in PNG format.").arg(url),


### PR DESCRIPTION
If the icon is invalid the list is empty. Tested with:
http://istole.it/favicon.ico <= Not found
http://openbittorrent.com/favicon.ico <= Invalid
Debug log:
```
Download finished: http://openbittorrent.com/favicon.ico
Temporary filename is: /tmp/qBittorrent.jd5366
ASSERT: "!isEmpty()" in file /usr/include/qt/QtCore/qlist.h, line 292

*************************************************************
Catching SIGABRT, please report a bug at http://bug.qbittorrent.org
and provide the following backtrace:
qBittorrent version: v3.3.0alpha
stack trace:
  linux-gate.so.1 : __kernel_vsyscall()+0x10  [0xb77dabc8]
  /usr/lib/libc.so.6 : gsignal()+0x47  [0xb5c5bca7]
  /usr/lib/libc.so.6 : abort()+0x149  [0xb5c5d2e9]
  /usr/lib/libQt5Core.so.5 : QMessageLogger::fatal(char const*, ...) const+0x111  [0xb60888a1]
  /usr/lib/libQt5Core.so.5 : ()+0x6ff02  [0xb6083f02]
  ./src/qbittorrent : TrackerFiltersList::handleFavicoDownload(QString const&, QString const&)+0x559  [0x8242c89]
  ./src/qbittorrent() [0x82bb6bf]
  /usr/lib/libQt5Core.so.5 : QMetaObject::activate(QObject*, int, int, void**)+0x5d1  [0xb62a3211]
  /usr/lib/libQt5Core.so.5 : QMetaObject::activate(QObject*, QMetaObject const*, int, void**)+0x2d  [0xb62a385d]
  ./src/qbittorrent : DownloadThread::downloadFinished(QString const&, QString const&)+0x3d  [0x82acc5d]
  ./src/qbittorrent : DownloadThread::processDlFinished(QNetworkReply*)+0xba3  [0x8106a63]
  ./src/qbittorrent() [0x82ace70]
  /usr/lib/libQt5Core.so.5 : QMetaObject::activate(QObject*, int, int, void**)+0x5d1  [0xb62a3211]
  /usr/lib/libQt5Core.so.5 : QMetaObject::activate(QObject*, QMetaObject const*, int, void**)+0x2d  [0xb62a385d]
  /usr/lib/libQt5Network.so.5 : QNetworkAccessManager::finished(QNetworkReply*)+0x49  [0xb6523839]
  /usr/lib/libQt5Network.so.5 : ()+0x5229d  [0xb652429d]
  /usr/lib/libQt5Network.so.5 : ()+0x5408b  [0xb652608b]
  /usr/lib/libQt5Core.so.5 : QMetaObject::activate(QObject*, int, int, void**)+0x5d1  [0xb62a3211]
  /usr/lib/libQt5Core.so.5 : QMetaObject::activate(QObject*, QMetaObject const*, int, void**)+0x2d  [0xb62a385d]
  /usr/lib/libQt5Network.so.5 : QNetworkReply::finished()+0x22  [0xb65d6252]
  /usr/lib/libQt5Network.so.5 : ()+0x7bba8  [0xb654dba8]
  /usr/lib/libQt5Network.so.5 : ()+0x105373  [0xb65d7373]
  /usr/lib/libQt5Core.so.5 : QMetaCallEvent::placeMetaCall(QObject*)+0x70  [0xb62a0980]
  /usr/lib/libQt5Core.so.5 : QObject::event(QEvent*)+0xe3  [0xb62a3f63]
  /usr/lib/libQt5Widgets.so.5 : QApplicationPrivate::notify_helper(QObject*, QEvent*)+0x9a  [0xb6da539a]
  /usr/lib/libQt5Widgets.so.5 : QApplication::notify(QObject*, QEvent*)+0x3a1  [0xb6daab71]
  ./src/qbittorrent : Application::notify(QObject*, QEvent*)+0x22  [0x80c46d2]
  /usr/lib/libQt5Core.so.5 : QCoreApplication::notifyInternal(QObject*, QEvent*)+0xda  [0xb627096a]
  /usr/lib/libQt5Core.so.5 : QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*)+0x1ac  [0xb6272c2c]
  /usr/lib/libQt5Core.so.5 : QCoreApplication::sendPostedEvents(QObject*, int)+0x27  [0xb6273347]
  /usr/lib/libQt5Core.so.5 : ()+0x2b72f3  [0xb62cb2f3]
  /usr/lib/libglib-2.0.so.0 : g_main_context_dispatch()+0x244  [0xb5827b14]
  /usr/lib/libglib-2.0.so.0 : ()+0x46e39  [0xb5827e39]
  /usr/lib/libglib-2.0.so.0 : g_main_context_iteration()+0x36  [0xb5827f06]
  /usr/lib/libQt5Core.so.5 : QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>)+0x64  [0xb62cb6e4]
  /usr/lib/qt/plugins/platforms/libqxcb.so : ()+0x50fb1  [0xb28f8fb1]
  /usr/lib/libQt5Core.so.5 : QEventLoop::processEvents(QFlags<QEventLoop::ProcessEventsFlag>)+0x23  [0xb626de53]
  /usr/lib/libQt5Core.so.5 : QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>)+0x12a  [0xb626e2ba]
  /usr/lib/libQt5Core.so.5 : QCoreApplication::exec()+0x95  [0xb62761b5]
  /usr/lib/libQt5Gui.so.5 : QGuiApplication::exec()+0x21  [0xb67e61b1]
  /usr/lib/libQt5Widgets.so.5 : QApplication::exec()+0x14  [0xb6da0954]
  ./src/qbittorrent : Application::exec(QStringList const&)+0x228  [0x80c6578]
  ./src/qbittorrent : main()+0x56f  [0x80bd9bf]
  /usr/lib/libc.so.6 : __libc_start_main()+0xde  [0xb5c4864e]
  ./src/qbittorrent() [0x80c24f6]
```