### PR TITLE
Fixed sort order for datetime columns with empty values (closes #2988)

### DIFF
--- a/src/gui/transferlistsortmodel.h
+++ b/src/gui/transferlistsortmodel.h
@@ -51,6 +51,7 @@ public:
 private:
     bool lessThan(const QModelIndex &left, const QModelIndex &right) const;
     bool lowerPositionThan(const QModelIndex &left, const QModelIndex &right) const;
+    bool dateLessThan(const int dateColumn, const QModelIndex &left, const QModelIndex &right) const;
     bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const;
 
     bool matchStatusFilter(int sourceRow, const QModelIndex &sourceParent) const;


### PR DESCRIPTION
A small fix belonging to #2531.
During the sorting empty QDateTime values are shuffled around due to
unstable sort in QSortFilterProxyModel (see #2526 and #2158), causing
the transfer list items to constantly change order.

Fixed by using an already existing correct comparison (with a torrent
hash fallback).
