### PR TITLE
Show exit confirmation dialog on exit even when no torrents are active

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -904,12 +904,12 @@ void MainWindow::closeEvent(QCloseEvent *e)
         return;
     }
 
-    if (pref->confirmOnExit() && QBtSession::instance()->hasActiveTorrents()) {
+    if (pref->confirmOnExit()) {
         if (e->spontaneous() || force_exit) {
             if (!isVisible())
                 show();
-            QMessageBox confirmBox(QMessageBox::Question, tr("Exiting qBittorrent"),
-                                   tr("Some files are currently transferring.\nAre you sure you want to quit qBittorrent?"),
+            QMessageBox confirmBox(QMessageBox::Question, tr("qBittorrent"),
+                                   tr("Are you sure you want to exit qBittorrent?"),
                                    QMessageBox::NoButton, this);
             QPushButton *noBtn = confirmBox.addButton(tr("No"), QMessageBox::NoRole);
             QPushButton *yesBtn = confirmBox.addButton(tr("Yes"), QMessageBox::YesRole);

--- a/src/gui/options.ui
+++ b/src/gui/options.ui
@@ -380,7 +380,7 @@
                <item>
                 <widget class="QCheckBox" name="checkProgramExitConfirm">
                  <property name="text">
-                  <string>Ask for program exit confirmation</string>
+                  <string>Confirmation on exit</string>
                  </property>
                  <property name="checked">
                   <bool>true</bool>


### PR DESCRIPTION
I find the current behavior contracted with what it says in the option menu "Ask for program exit confirmation"...