### PR TITLE
Sort labels in RSS Downloader dialog

### DIFF
--- a/src/core/utils/string.h
+++ b/src/core/utils/string.h
@@ -31,6 +31,10 @@
 #define UTILS_STRING_H
 
 #include <string>
+#include <QtGlobal>
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 2, 0))
+#include <QCollator>
+#endif
 
 class QString;
 class QByteArray;
@@ -41,12 +45,25 @@ namespace Utils
     {
         QString fromStdString(const std::string &str);
         std::string toStdString(const QString &str);
-        bool naturalSort(QString left, QString right, bool &result);
         QString fromDouble(double n, int precision);
 
         // Implements constant-time comparison to protect against timing attacks
         // Taken from https://crackstation.net/hashing-security.htm
         bool slowEquals(const QByteArray &a, const QByteArray &b);
+
+        bool naturalSort(const QString &left, const QString &right, bool &result);
+
+        class NaturalCompare
+        {
+        public:
+            NaturalCompare();
+            bool operator()(const QString &l, const QString &r);
+            bool lessThan(const QString &left, const QString &right);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 2, 0))
+        private:
+            QCollator m_collator;
+#endif
+        };
     }
 }
 

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -260,9 +260,9 @@ void AutomatedRssDownloader::updateRuleDefinitionBox()
       QDateTime dateTime = rule->lastMatch();
       QString lMatch;
       if (dateTime.isValid())
-        lMatch = tr("Last match: %1 days ago").arg(dateTime.daysTo(QDateTime::currentDateTime()));
+        lMatch = tr("Last Match: %1 days ago").arg(dateTime.daysTo(QDateTime::currentDateTime()));
       else
-        lMatch = tr("Last match: Unknown");
+        lMatch = tr("Last Match: Unknown");
       ui->lblLastMatch->setText(lMatch);
       updateMustLineValidity();
       updateMustNotLineValidity();

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -43,6 +43,7 @@
 #include "guiiconprovider.h"
 #include "autoexpandabledialog.h"
 #include "core/utils/fs.h"
+#include "core/utils/string.h"
 
 AutomatedRssDownloader::AutomatedRssDownloader(const QWeakPointer<RssManager>& manager, QWidget *parent) :
   QDialog(parent),
@@ -308,10 +309,10 @@ RssDownloadRulePtr AutomatedRssDownloader::getCurrentRule() const
 void AutomatedRssDownloader::initLabelCombobox()
 {
   // Load custom labels
-  const QStringList customLabels = Preferences::instance()->getTorrentLabels();
-  foreach (const QString& label, customLabels) {
-    ui->comboLabel->addItem(label);
-  }
+  QStringList customLabels = Preferences::instance()->getTorrentLabels();
+  std::sort(customLabels.begin(), customLabels.end(), Utils::String::NaturalCompare());
+  foreach (const QString& l, customLabels)
+    ui->comboLabel->addItem(l);
 }
 
 void AutomatedRssDownloader::saveEditedRule()

--- a/src/gui/rss/automatedrssdownloader.ui
+++ b/src/gui/rss/automatedrssdownloader.ui
@@ -7,11 +7,11 @@
     <x>0</x>
     <y>0</y>
     <width>816</width>
-    <height>494</height>
+    <height>537</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Automated RSS Downloader</string>
+   <string>RSS Downloader</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_5">
    <item>
@@ -50,26 +50,7 @@
           </widget>
          </item>
          <item>
-          <spacer name="horizontalSpacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Expanding</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
           <widget class="QToolButton" name="removeRuleBtn">
-           <property name="text">
-            <string/>
-           </property>
            <property name="iconSize">
             <size>
              <width>24</width>
@@ -80,9 +61,6 @@
          </item>
          <item>
           <widget class="QToolButton" name="addRuleBtn">
-           <property name="text">
-            <string/>
-           </property>
            <property name="iconSize">
             <size>
              <width>24</width>
@@ -90,19 +68,6 @@
             </size>
            </property>
           </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
          </item>
         </layout>
        </item>
@@ -131,129 +96,66 @@
            </widget>
           </item>
           <item>
-           <layout class="QFormLayout" name="formLayout">
+           <layout class="QGridLayout" name="gridLayout">
             <item row="0" column="0">
              <widget class="QLabel" name="label_4">
               <property name="text">
                <string>Must contain:</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
              </widget>
-            </item>
-            <item row="0" column="1">
-             <layout class="QHBoxLayout" name="horizontalLayout_3">
-              <item>
-               <widget class="QLineEdit" name="lineContains"/>
-              </item>
-              <item>
-               <widget class="QLabel" name="lbl_must_stat">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>18</width>
-                  <height>18</height>
-                 </size>
-                </property>
-                <property name="maximumSize">
-                 <size>
-                  <width>18</width>
-                  <height>18</height>
-                 </size>
-                </property>
-                <property name="text">
-                 <string notr="true"/>
-                </property>
-               </widget>
-              </item>
-             </layout>
             </item>
             <item row="1" column="0">
              <widget class="QLabel" name="label_5">
               <property name="text">
                <string>Must not contain:</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
              </widget>
-            </item>
-            <item row="1" column="1">
-             <layout class="QHBoxLayout" name="horizontalLayout_5">
-              <item>
-               <widget class="QLineEdit" name="lineNotContains"/>
-              </item>
-              <item>
-               <widget class="QLabel" name="lbl_mustnot_stat">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>18</width>
-                  <height>18</height>
-                 </size>
-                </property>
-                <property name="maximumSize">
-                 <size>
-                  <width>18</width>
-                  <height>18</height>
-                 </size>
-                </property>
-                <property name="text">
-                 <string notr="true"/>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item row="2" column="1">
-             <layout class="QHBoxLayout" name="horizontalLayout_6">
-              <item>
-               <widget class="QLineEdit" name="lineEFilter"/>
-              </item>
-              <item>
-               <widget class="QLabel" name="lblEFilterStat">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>18</width>
-                  <height>18</height>
-                 </size>
-                </property>
-                <property name="maximumSize">
-                 <size>
-                  <width>18</width>
-                  <height>18</height>
-                 </size>
-                </property>
-                <property name="text">
-                 <string notr="true"/>
-                </property>
-               </widget>
-              </item>
-             </layout>
             </item>
             <item row="2" column="0">
              <widget class="QLabel" name="lblEFilter">
               <property name="text">
-               <string>Episode filter:</string>
+               <string>Episode Filter:</string>
               </property>
              </widget>
+            </item>
+            <item row="2" column="2">
+             <widget class="QLabel" name="lblEFilterStat">
+              <property name="maximumSize">
+               <size>
+                <width>18</width>
+                <height>18</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="2">
+             <widget class="QLabel" name="lbl_mustnot_stat">
+              <property name="maximumSize">
+               <size>
+                <width>18</width>
+                <height>18</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLineEdit" name="lineContains"/>
+            </item>
+            <item row="2" column="1">
+             <widget class="QLineEdit" name="lineEFilter"/>
+            </item>
+            <item row="0" column="2">
+             <widget class="QLabel" name="lbl_must_stat">
+              <property name="maximumSize">
+               <size>
+                <width>18</width>
+                <height>18</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QLineEdit" name="lineNotContains"/>
             </item>
            </layout>
           </item>
@@ -265,18 +167,21 @@
            </widget>
           </item>
           <item>
-           <layout class="QFormLayout" name="formLayout_2">
-            <item row="0" column="0">
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <item>
              <widget class="QLabel" name="label_7">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="text">
                <string>Assign label:</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
              </widget>
             </item>
-            <item row="0" column="1">
+            <item>
              <widget class="QComboBox" name="comboLabel">
               <property name="editable">
                <bool>true</bool>
@@ -293,8 +198,8 @@
            </widget>
           </item>
           <item>
-           <layout class="QFormLayout" name="formLayout_3">
-            <item row="0" column="0">
+           <layout class="QHBoxLayout" name="horizontalLayout_5">
+            <item>
              <widget class="QLabel" name="label_6">
               <property name="enabled">
                <bool>false</bool>
@@ -302,31 +207,24 @@
               <property name="text">
                <string>Save to:</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="lineSavePath">
+              <property name="enabled">
+               <bool>false</bool>
               </property>
              </widget>
             </item>
-            <item row="0" column="1">
-             <layout class="QHBoxLayout" name="horizontalLayout">
-              <item>
-               <widget class="QLineEdit" name="lineSavePath">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QToolButton" name="browseSP">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="text">
-                 <string notr="true">...</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
+            <item>
+             <widget class="QToolButton" name="browseSP">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string notr="true">...</string>
+              </property>
+             </widget>
             </item>
            </layout>
           </item>
@@ -338,19 +236,6 @@
                <string comment="... X days">Ignore subsequent matches for (0 to disable)</string>
               </property>
              </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_4">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
             </item>
             <item>
              <widget class="QSpinBox" name="spinIgnorePeriod">
@@ -368,36 +253,25 @@
            </layout>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_7">
-            <item>
-             <spacer name="horizontalSpacer_5">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QLabel" name="lblLastMatch">
-              <property name="enabled">
-               <bool>true</bool>
-              </property>
-              <property name="text">
-               <string notr="true"/>
-              </property>
-             </widget>
-            </item>
-           </layout>
+           <widget class="QLabel" name="lblLastMatch">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
           </item>
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_9">
             <item>
              <widget class="QLabel" name="lblAddPaused">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="text">
                <string>Add Paused:</string>
               </property>
@@ -405,12 +279,6 @@
             </item>
             <item>
              <widget class="QComboBox" name="comboAddPaused">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
               <item>
                <property name="text">
                 <string>Use global setting</string>
@@ -491,35 +359,19 @@
      <item>
       <widget class="QPushButton" name="importBtn">
        <property name="text">
-        <string>Import...</string>
+        <string>&amp;Import...</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QPushButton" name="exportBtn">
        <property name="text">
-        <string>Export...</string>
+        <string>&amp;Export...</string>
        </property>
       </widget>
      </item>
      <item>
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
       <widget class="QDialogButtonBox" name="buttonBox">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
        <property name="standardButtons">
         <set>QDialogButtonBox::Close</set>
        </property>

--- a/src/gui/rss/automatedrssdownloader.ui
+++ b/src/gui/rss/automatedrssdownloader.ui
@@ -23,7 +23,7 @@
       </font>
      </property>
      <property name="text">
-      <string>Enable the automated RSS downloader</string>
+      <string>Enable Automated RSS Downloader</string>
      </property>
     </widget>
    </item>
@@ -45,7 +45,7 @@
             </font>
            </property>
            <property name="text">
-            <string>Download rules</string>
+            <string>Download Rules</string>
            </property>
           </widget>
          </item>
@@ -85,13 +85,13 @@
        <item>
         <widget class="QGroupBox" name="ruleDefBox">
          <property name="title">
-          <string>Rule definition</string>
+          <string>Rule Definition</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_6">
           <item>
            <widget class="QCheckBox" name="checkRegex">
             <property name="text">
-             <string>Use regular expressions</string>
+             <string>Use Regular Expressions</string>
             </property>
            </widget>
           </item>
@@ -100,14 +100,14 @@
             <item row="0" column="0">
              <widget class="QLabel" name="label_4">
               <property name="text">
-               <string>Must contain:</string>
+               <string>Must Contain:</string>
               </property>
              </widget>
             </item>
             <item row="1" column="0">
              <widget class="QLabel" name="label_5">
               <property name="text">
-               <string>Must not contain:</string>
+               <string>Must Not Contain:</string>
               </property>
              </widget>
             </item>
@@ -177,7 +177,7 @@
                </sizepolicy>
               </property>
               <property name="text">
-               <string>Assign label:</string>
+               <string>Assign Label:</string>
               </property>
              </widget>
             </item>
@@ -193,7 +193,7 @@
           <item>
            <widget class="QCheckBox" name="saveDiffDir_check">
             <property name="text">
-             <string>Save to a different directory</string>
+             <string>Save to a Different Directory</string>
             </property>
            </widget>
           </item>
@@ -233,7 +233,7 @@
             <item>
              <widget class="QLabel" name="lblIgnoreDays">
               <property name="text">
-               <string comment="... X days">Ignore subsequent matches for (0 to disable)</string>
+               <string comment="... X days">Ignore Subsequent Matches for (0 to Disable)</string>
               </property>
              </widget>
             </item>
@@ -246,7 +246,7 @@
                <string> days</string>
               </property>
               <property name="maximum">
-               <number>360</number>
+               <number>365</number>
               </property>
              </widget>
             </item>
@@ -281,17 +281,17 @@
              <widget class="QComboBox" name="comboAddPaused">
               <item>
                <property name="text">
-                <string>Use global setting</string>
+                <string>Use global settings</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Always add paused</string>
+                <string>Always</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Never add paused</string>
+                <string>Never</string>
                </property>
               </item>
              </widget>
@@ -312,7 +312,7 @@
             </font>
            </property>
            <property name="text">
-            <string>Apply rule to feeds:</string>
+            <string>Apply Rule to Feeds:</string>
            </property>
           </widget>
          </item>
@@ -334,7 +334,7 @@
           </font>
          </property>
          <property name="text">
-          <string>Matching RSS articles</string>
+          <string>Matching RSS Articles</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
**~~WIP, don't merge yet!!~~**
-----

And also clean up the layout, capitalize strings...

I added a modified version of `naturalSort()` which IMO works better in some cases.
If possible the new version should be able to replace the old one.

BTW `naturalSort()` should be renamed to `naturalCmp()`, because it doesn't really sort, it just compare  inputs.

[old_ver1](https://cloud.githubusercontent.com/assets/9395168/8058682/a8648490-0eed-11e5-93b2-5d72cc984fd8.png)
[old_ver2](https://cloud.githubusercontent.com/assets/9395168/9930570/39d3d3be-5d67-11e5-9008-8f6199f39c9a.png)
Latest version:
![latest](https://cloud.githubusercontent.com/assets/9395168/9955054/634eaffc-5e20-11e5-88f8-2ce6dca900c6.png)

Original naturalSort():
[old1](https://cloud.githubusercontent.com/assets/9395168/8058684/a9fd6556-0eed-11e5-8e31-fd4cb6629588.png)
![original](https://cloud.githubusercontent.com/assets/9395168/9955062/70783e82-5e20-11e5-88ea-d4ee88b89727.png)

