### PR TITLE
[search engine] Remove python3 cache during updateNova()

### DIFF
--- a/src/core/utils/fs.cpp
+++ b/src/core/utils/fs.cpp
@@ -179,6 +179,27 @@ bool Utils::Fs::forceRemove(const QString& file_path)
 }
 
 /**
+ * Removes directory and its content recursively.
+ *
+ */
+void Utils::Fs::removeDirRecursive(const QString& dirName) {
+    QDir dir(dirName);
+
+    if (!dir.exists()) return;
+
+    Q_FOREACH(QFileInfo info, dir.entryInfoList(QDir::NoDotAndDotDot |
+                                                QDir::System |
+                                                QDir::Hidden |
+                                                QDir::AllDirs |
+                                                QDir::Files, QDir::DirsFirst)) {
+        if (info.isDir()) removeDirRecursive(info.absoluteFilePath());
+        else forceRemove(info.absoluteFilePath());
+    }
+
+    dir.rmdir(dirName);
+}
+
+/**
  * Returns the size of a file.
  * If the file is a folder, it will compute its size based on its content.
  *

--- a/src/core/utils/fs.h
+++ b/src/core/utils/fs.h
@@ -57,6 +57,7 @@ namespace Utils
         QString expandPathAbs(const QString& path);
         bool smartRemoveEmptyFolderTree(const QString& dir_path);
         bool forceRemove(const QString& file_path);
+        void removeDirRecursive(const QString& dirName);
 
         /* Ported from Qt4 to drop dependency on QtGui */
         QString QDesktopServicesDataLocation();

--- a/src/searchengine/searchengine.cpp
+++ b/src/searchengine/searchengine.cpp
@@ -321,7 +321,7 @@ void SearchEngine::downloadFinished(int exitcode, QProcess::ExitStatus) {
     delete downloadProcess;
 }
 
-static void removePythonScriptIfExists(const QString& script_path)
+static inline void removePythonScriptIfExists(const QString& script_path)
 {
     Utils::Fs::forceRemove(script_path);
     Utils::Fs::forceRemove(script_path + "c");
@@ -339,6 +339,8 @@ void SearchEngine::updateNova() {
     if (!search_dir.exists("engines")) {
         search_dir.mkdir("engines");
     }
+    Utils::Fs::removeDirRecursive(search_dir.absoluteFilePath("__pycache__"));
+
     QFile package_file2(search_dir.absolutePath() + "/engines/__init__.py");
     package_file2.open(QIODevice::WriteOnly | QIODevice::Text);
     package_file2.close();
@@ -376,13 +378,13 @@ void SearchEngine::updateNova() {
         removePythonScriptIfExists(filePath);
         QFile::copy(":/"+nova_folder+"/fix_encoding.py", filePath);
     }
-
-    if (nova_folder == "nova3") {
+    else if (nova_folder == "nova3") {
         filePath = search_dir.absoluteFilePath("sgmllib3.py");
         removePythonScriptIfExists(filePath);
         QFile::copy(":/"+nova_folder+"/sgmllib3.py", filePath);
     }
     QDir destDir(QDir(Utils::Fs::searchEngineLocation()).absoluteFilePath("engines"));
+    Utils::Fs::removeDirRecursive(destDir.absoluteFilePath("__pycache__"));
     QDir shipped_subDir(":/"+nova_folder+"/engines/");
     QStringList files = shipped_subDir.entryList();
     foreach (const QString &file, files) {


### PR DESCRIPTION
It came to me that for some reason qBittorent removes only python2 cache while python3 cache is stored into separated directory ```__pycache__```
So here is small commit to change that.

Found in google some idea for simple recursive dir removal hope it is fine :)