### PR TITLE
Fix time_t 0 special meaning.

### DIFF
--- a/src/core/bittorrent/torrenthandle.cpp
+++ b/src/core/bittorrent/torrenthandle.cpp
@@ -916,12 +916,18 @@ int TorrentHandle::incompleteCount() const
 
 QDateTime TorrentHandle::lastSeenComplete() const
 {
-    return QDateTime::fromTime_t(m_nativeStatus.last_seen_complete);
+    if (m_nativeStatus.last_seen_complete > 0)
+        return QDateTime::fromTime_t(m_nativeStatus.last_seen_complete);
+    else
+        return QDateTime();
 }
 
 QDateTime TorrentHandle::completedTime() const
 {
-    return QDateTime::fromTime_t(m_nativeStatus.completed_time);
+    if (m_nativeStatus.completed_time > 0)
+        return QDateTime::fromTime_t(m_nativeStatus.completed_time);
+    else
+        return QDateTime();
 }
 
 int TorrentHandle::timeSinceUpload() const


### PR DESCRIPTION
Return null QDateTime object when converting from 0 time_t value.
According to libtorrent doc:
```c++
// the posix-time when this torrent was finished. If the torrent is not
// yet finished, this is 0.
time_t completed_time;
```
