### PR TITLE
Update qBittorrent.appdata.xml (invalid tag)

### DIFF
--- a/dist/unix/qBittorrent.appdata.xml
+++ b/dist/unix/qBittorrent.appdata.xml
@@ -57,5 +57,5 @@
   </screenshot>
  </screenshots>
  <url type="homepage">http://www.qbittorrent.org/</url>
- <updatecontact>sledgehammer999@qbittorrent.org</updatecontact>
+ <update_contact>sledgehammer999@qbittorrent.org</update_contact>
 </component>


### PR DESCRIPTION
Usage of the <updatecontact/> breaks validation. The correct tag is <update_contact/> as per info on this page:
http://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-update_contact