### PR TITLE
Rename Chinese translation files. Closes #2936.

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -337,8 +337,20 @@ void Application::initializeTranslation()
     Preferences* const pref = Preferences::instance();
     // Load translation
     QString locale = pref->getLocale();
+
     if (locale.isEmpty()) {
-        locale = QLocale::system().name();
+        QLocale systemLocale = QLocale::system();
+        // Check if Chinese and act according to script instead of country
+        if (systemLocale.language() == QLocale::Chinese) {
+            if (systemLocale.script() == QLocale::SimplifiedHanScript)
+                locale = "zh_Hans";
+            else
+                locale = "zh_Hant";
+        }
+        else {
+            locale = systemLocale.name();
+        }
+
         pref->setLocale(locale);
     }
 

--- a/src/gui/options_imp.cpp
+++ b/src/gui/options_imp.cpp
@@ -1075,7 +1075,19 @@ QString options_imp::getLocale() const {
 
 void options_imp::setLocale(const QString &localeStr) {
   QLocale locale(localeStr);
-  QString name = locale.name();
+  QString name;
+
+  // Check if Chinese and act according to script instead of country
+  if (locale.language() == QLocale::Chinese) {
+      if (locale.script() == QLocale::SimplifiedHanScript)
+          name = "zh_Hans";
+      else
+          name = "zh_Hant";
+  }
+  else {
+      name = locale.name();
+  }
+
   // Attempt to find exact match
   int index = comboI18n->findData(name, Qt::UserRole);
   if (index < 0 ) {
@@ -1360,7 +1372,7 @@ QString options_imp::languageToLocalizedString(const QLocale &locale)
   case QLocale::Basque: return QString::fromUtf8("Euskara");
   case QLocale::Vietnamese: return QString::fromUtf8("tiếng Việt");
   case QLocale::Chinese: {
-    if (locale.country() == QLocale::China)
+    if (locale.script() == QLocale::SimplifiedHanScript)
       return QString::fromUtf8("中文 (简体)");
     return QString::fromUtf8("中文 (繁體)");
   }

--- a/src/lang.qrc
+++ b/src/lang.qrc
@@ -40,7 +40,7 @@
   <file>lang/qbittorrent_tr.qm</file>
   <file>lang/qbittorrent_uk.qm</file>
   <file>lang/qbittorrent_vi.qm</file>
-  <file>lang/qbittorrent_zh.qm</file>
-  <file>lang/qbittorrent_zh_TW.qm</file>
+  <file>lang/qbittorrent_zh_Hans.qm</file>
+  <file>lang/qbittorrent_zh_Hant.qm</file>
 </qresource>
 </RCC>

--- a/src/lang/qbittorrent_zh_Hans.ts
+++ b/src/lang/qbittorrent_zh_Hans.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="zh">
+<TS version="2.0" language="zh-Hans">
 <context>
     <name>AboutDlg</name>
     <message>

--- a/src/lang/qbittorrent_zh_Hant.ts
+++ b/src/lang/qbittorrent_zh_Hant.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="zh_TW">
+<TS version="2.0" language="zh-Hant">
 <context>
     <name>AboutDlg</name>
     <message>

--- a/src/src.pro
+++ b/src/src.pro
@@ -75,8 +75,8 @@ RESOURCES += \
 # Translations
 TRANSLATIONS = \
     $$LANG_PATH/qbittorrent_fr.ts \
-    $$LANG_PATH/qbittorrent_zh.ts \
-    $$LANG_PATH/qbittorrent_zh_TW.ts \
+    $$LANG_PATH/qbittorrent_zh_Hans.ts \
+    $$LANG_PATH/qbittorrent_zh_Hant.ts \
     $$LANG_PATH/qbittorrent_en.ts \
     $$LANG_PATH/qbittorrent_en_AU.ts \
     $$LANG_PATH/qbittorrent_en_GB.ts \

--- a/src/webui/www/public/preferences_content.html
+++ b/src/webui/www/public/preferences_content.html
@@ -316,8 +316,8 @@
       <option value="be_BY">Беларуская</option>
       <option value="eu_ES">Euskara</option>
       <option value="vi_VN">tiếng Việt</option>
-      <option value="zh_CN">中文 (简体)</option>
-      <option value="zh_TW">中文 (繁體)</option>
+      <option value="zh_Hans">中文 (简体)</option>
+      <option value="zh_Hant">中文 (繁體)</option>
       <option value="ko_KR">한글</option>
     </select>
 </fieldset>


### PR DESCRIPTION
@Chocobo1 can you test this?

Test if the language selection from the GUI works. (I forgot to do the webui).
Also test if from a new install the correct locale is selected. eg on a German computer a clean install results in the German locale to be select upon first start.

And try to do a more general testing.
Waiting your info.

PS: After this is merged I'll create the relevant locales on Transifex too.