### PR TITLE
libtorrent session options

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -284,6 +284,7 @@ Session::Session(QObject *parent)
     , m_isUTPEnabled(BITTORRENT_SESSION_KEY("uTPEnabled"), true)
     , m_isUTPRateLimited(BITTORRENT_SESSION_KEY("uTPRateLimited"), true)
     , m_utpMixedMode(BITTORRENT_SESSION_KEY("uTPMixedMode"), m_isUTPEnabled)
+    , m_multiConnectionsPerIpEnabled(BITTORRENT_SESSION_KEY("MultiConnectionsPerIp"), false)
     , m_isAddTrackersEnabled(BITTORRENT_SESSION_KEY("AddTrackersEnabled"), false)
     , m_additionalTrackers(BITTORRENT_SESSION_KEY("AdditionalTrackers"))
     , m_globalMaxRatio(BITTORRENT_SESSION_KEY("GlobalMaxRatio"), -1, [](qreal r) { return r < 0 ? -1. : r;})
@@ -1310,6 +1311,8 @@ void Session::configure(libtorrent::settings_pack &settingsPack)
         break;
     }
 
+    settingsPack.set_bool(libt::settings_pack::allow_multiple_connections_per_ip, multiConnectionsPerIpEnabled());
+
     settingsPack.set_bool(libt::settings_pack::apply_ip_filter_to_trackers, isTrackerFilteringEnabled());
 
     settingsPack.set_bool(libt::settings_pack::enable_dht, isDHTEnabled());
@@ -1537,6 +1540,8 @@ void Session::configure(libtorrent::session_settings &sessionSettings)
         sessionSettings.mixed_mode_algorithm = libt::session_settings::peer_proportional;
         break;
     }
+
+    sessionSettings.allow_multiple_connections_per_ip = multiConnectionsPerIpEnabled();
 
     sessionSettings.apply_ip_filter_to_trackers = isTrackerFilteringEnabled();
 
@@ -3113,6 +3118,19 @@ void Session::setUtpMixedMode(int mode)
     if (mode == m_utpMixedMode) return;
 
     m_utpMixedMode = mode;
+    configureDeferred();
+}
+
+bool Session::multiConnectionsPerIpEnabled() const
+{
+    return m_multiConnectionsPerIpEnabled;
+}
+
+void Session::setMultiConnectionsPerIpEnabled(bool enabled)
+{
+    if (enabled == m_multiConnectionsPerIpEnabled) return;
+
+    m_multiConnectionsPerIpEnabled = enabled;
     configureDeferred();
 }
 

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -237,6 +237,20 @@ namespace
 
     template <typename T>
     LowerLimited<T> lowerLimited(T limit, T ret) { return LowerLimited<T>(limit, ret); }
+
+    template <typename T>
+    std::function<T (const T&)> clampValue(const T lower, const T upper)
+    {
+        // TODO: change return type to `auto` when using C++14
+        return [lower, upper](const T value) -> T
+        {
+            if (value < lower)
+                return lower;
+            if (value > upper)
+                return upper;
+            return value;
+        };
+    }
 }
 
 // Session
@@ -287,7 +301,7 @@ Session::Session(QObject *parent)
     , m_maxUploadsPerTorrent(BITTORRENT_SESSION_KEY("MaxUploadsPerTorrent"), -1, lowerLimited(0, -1))
     , m_isUTPEnabled(BITTORRENT_SESSION_KEY("uTPEnabled"), true)
     , m_isUTPRateLimited(BITTORRENT_SESSION_KEY("uTPRateLimited"), true)
-    , m_utpMixedMode(BITTORRENT_SESSION_KEY("uTPMixedMode"), m_isUTPEnabled)
+    , m_utpMixedMode(BITTORRENT_SESSION_KEY("uTPMixedMode"), m_isUTPEnabled, clampValue(0, 1))
     , m_multiConnectionsPerIpEnabled(BITTORRENT_SESSION_KEY("MultiConnectionsPerIp"), false)
     , m_isAddTrackersEnabled(BITTORRENT_SESSION_KEY("AddTrackersEnabled"), false)
     , m_additionalTrackers(BITTORRENT_SESSION_KEY("AdditionalTrackers"))
@@ -316,8 +330,8 @@ Session::Session(QObject *parent)
     , m_encryption(BITTORRENT_SESSION_KEY("Encryption"), 0)
     , m_isForceProxyEnabled(BITTORRENT_SESSION_KEY("ForceProxy"), true)
     , m_isProxyPeerConnectionsEnabled(BITTORRENT_SESSION_KEY("ProxyPeerConnections"), false)
-    , m_chokingAlgorithm(BITTORRENT_SESSION_KEY("ChokingAlgorithm"), 0)
-    , m_seedChokingAlgorithm(BITTORRENT_SESSION_KEY("SeedChokingAlgorithm"), 1)
+    , m_chokingAlgorithm(BITTORRENT_SESSION_KEY("ChokingAlgorithm"), 0, clampValue(0, 2))
+    , m_seedChokingAlgorithm(BITTORRENT_SESSION_KEY("SeedChokingAlgorithm"), 1, clampValue(0, 2))
     , m_storedCategories(BITTORRENT_SESSION_KEY("Categories"))
     , m_storedTags(BITTORRENT_SESSION_KEY("Tags"))
     , m_maxRatioAction(BITTORRENT_SESSION_KEY("MaxRatioAction"), Pause)
@@ -1310,15 +1324,7 @@ void Session::configure(libtorrent::settings_pack &settingsPack)
     // uTP
     settingsPack.set_bool(libt::settings_pack::enable_incoming_utp, isUTPEnabled());
     settingsPack.set_bool(libt::settings_pack::enable_outgoing_utp, isUTPEnabled());
-    switch (utpMixedMode()) {
-    case 0:
-    default:
-        settingsPack.set_int(libt::settings_pack::mixed_mode_algorithm, libt::settings_pack::prefer_tcp);
-        break;
-    case 1:
-        settingsPack.set_int(libt::settings_pack::mixed_mode_algorithm, libt::settings_pack::peer_proportional);
-        break;
-    }
+    settingsPack.set_int(libt::settings_pack::mixed_mode_algorithm, utpMixedMode());
 
     settingsPack.set_bool(libt::settings_pack::allow_multiple_connections_per_ip, multiConnectionsPerIpEnabled());
 
@@ -1556,15 +1562,7 @@ void Session::configure(libtorrent::session_settings &sessionSettings)
     sessionSettings.enable_outgoing_utp = isUTPEnabled();
     // uTP rate limiting
     sessionSettings.rate_limit_utp = isUTPRateLimited();
-    switch (utpMixedMode()) {
-    case 0:
-    default:
-        sessionSettings.mixed_mode_algorithm = libt::session_settings::prefer_tcp;
-        break;
-    case 1:
-        sessionSettings.mixed_mode_algorithm = libt::session_settings::peer_proportional;
-        break;
-    }
+    sessionSettings.mixed_mode_algorithm = utpMixedMode();
 
     sessionSettings.allow_multiple_connections_per_ip = multiConnectionsPerIpEnabled();
 

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -312,6 +312,8 @@ Session::Session(QObject *parent)
     , m_encryption(BITTORRENT_SESSION_KEY("Encryption"), 0)
     , m_isForceProxyEnabled(BITTORRENT_SESSION_KEY("ForceProxy"), true)
     , m_isProxyPeerConnectionsEnabled(BITTORRENT_SESSION_KEY("ProxyPeerConnections"), false)
+    , m_chokingAlgorithm(BITTORRENT_SESSION_KEY("ChokingAlgorithm"), 0)
+    , m_seedChokingAlgorithm(BITTORRENT_SESSION_KEY("SeedChokingAlgorithm"), 1)
     , m_storedCategories(BITTORRENT_SESSION_KEY("Categories"))
     , m_storedTags(BITTORRENT_SESSION_KEY("Tags"))
     , m_maxRatioAction(BITTORRENT_SESSION_KEY("MaxRatioAction"), Pause)
@@ -380,7 +382,6 @@ Session::Session(QObject *parent)
     sessionSettings.auto_scrape_min_interval = 900; // 15 minutes
     sessionSettings.connection_speed = 20; // default is 10
     sessionSettings.no_connect_privileged_ports = false;
-    sessionSettings.seed_choking_algorithm = libt::session_settings::fastest_upload;
     // Disk cache pool is rarely tested in libtorrent and doesn't free buffers
     // Soon to be deprecated there
     // More info: https://github.com/arvidn/libtorrent/issues/2251
@@ -411,7 +412,6 @@ Session::Session(QObject *parent)
     pack.set_int(libt::settings_pack::auto_scrape_min_interval, 900); // 15 minutes
     pack.set_int(libt::settings_pack::connection_speed, 20); // default is 10
     pack.set_bool(libt::settings_pack::no_connect_privileged_ports, false);
-    pack.set_int(libt::settings_pack::seed_choking_algorithm, libt::settings_pack::fastest_upload);
     // Disk cache pool is rarely tested in libtorrent and doesn't free buffers
     // Soon to be deprecated there
     // More info: https://github.com/arvidn/libtorrent/issues/2251
@@ -1319,6 +1319,17 @@ void Session::configure(libtorrent::settings_pack &settingsPack)
     if (isDHTEnabled())
         settingsPack.set_str(libt::settings_pack::dht_bootstrap_nodes, "dht.libtorrent.org:25401,router.bittorrent.com:6881,router.utorrent.com:6881,dht.transmissionbt.com:6881,dht.aelitis.com:6881");
     settingsPack.set_bool(libt::settings_pack::enable_lsd, isLSDEnabled());
+
+    switch (chokingAlgorithm()) {
+    case 0:
+    default:
+        settingsPack.set_int(libt::settings_pack::choking_algorithm, libt::settings_pack::fixed_slots_choker);
+        break;
+    case 1:
+        settingsPack.set_int(libt::settings_pack::choking_algorithm, libt::settings_pack::rate_based_choker);
+        break;
+    }
+    settingsPack.set_int(libt::settings_pack::seed_choking_algorithm, seedChokingAlgorithm());
 }
 
 void Session::configurePeerClasses()
@@ -1562,6 +1573,17 @@ void Session::configure(libtorrent::session_settings &sessionSettings)
         m_nativeSession->start_lsd();
     else
         m_nativeSession->stop_lsd();
+
+    switch (chokingAlgorithm()) {
+    case 0:
+    default:
+        sessionSettings.choking_algorithm = libt::session_settings::fixed_slots_choker;
+        break;
+    case 1:
+        sessionSettings.choking_algorithm = libt::session_settings::rate_based_choker;
+        break;
+    }
+    sessionSettings.seed_choking_algorithm = seedChokingAlgorithm();
 }
 #endif
 
@@ -2661,6 +2683,32 @@ void Session::setProxyPeerConnectionsEnabled(bool enabled)
         m_isProxyPeerConnectionsEnabled = enabled;
         configureDeferred();
     }
+}
+
+int Session::chokingAlgorithm() const
+{
+    return m_chokingAlgorithm;
+}
+
+void Session::setChokingAlgorithm(int mode)
+{
+    if (mode == m_chokingAlgorithm) return;
+
+    m_chokingAlgorithm = mode;
+    configureDeferred();
+}
+
+int Session::seedChokingAlgorithm() const
+{
+    return m_seedChokingAlgorithm;
+}
+
+void Session::setSeedChokingAlgorithm(int mode)
+{
+    if (mode == m_seedChokingAlgorithm) return;
+
+    m_seedChokingAlgorithm = mode;
+    configureDeferred();
 }
 
 bool Session::isAddTrackersEnabled() const

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -264,6 +264,7 @@ Session::Session(QObject *parent)
     , m_diskCacheTTL(BITTORRENT_SESSION_KEY("DiskCacheTTL"), 60)
     , m_useOSCache(BITTORRENT_SESSION_KEY("UseOSCache"), true)
     , m_guidedReadCacheEnabled(BITTORRENT_SESSION_KEY("GuidedReadCache"), true)
+    , m_isSuggestMode(BITTORRENT_SESSION_KEY("SuggestMode"), false)
     , m_isAnonymousModeEnabled(BITTORRENT_SESSION_KEY("AnonymousModeEnabled"), false)
     , m_isQueueingEnabled(BITTORRENT_SESSION_KEY("QueueingSystemEnabled"), true)
     , m_maxActiveDownloads(BITTORRENT_SESSION_KEY("MaxActiveDownloads"), 3, lowerLimited(-1))
@@ -1260,6 +1261,7 @@ void Session::configure(libtorrent::settings_pack &settingsPack)
     settingsPack.set_int(libt::settings_pack::disk_io_read_mode, mode);
     settingsPack.set_int(libt::settings_pack::disk_io_write_mode, mode);
     settingsPack.set_bool(libt::settings_pack::guided_read_cache, isGuidedReadCacheEnabled());
+    settingsPack.set_bool(libt::settings_pack::suggest_mode, isSuggestModeEnabled());
 
     settingsPack.set_bool(libt::settings_pack::anonymous_mode, isAnonymousModeEnabled());
 
@@ -1496,6 +1498,7 @@ void Session::configure(libtorrent::session_settings &sessionSettings)
     sessionSettings.disk_io_read_mode = mode;
     sessionSettings.disk_io_write_mode = mode;
     sessionSettings.guided_read_cache = isGuidedReadCacheEnabled();
+    sessionSettings.suggest_mode = isSuggestModeEnabled();
 
     sessionSettings.anonymous_mode = isAnonymousModeEnabled();
 
@@ -2923,6 +2926,19 @@ void Session::setGuidedReadCacheEnabled(bool enabled)
     if (enabled == m_guidedReadCacheEnabled) return;
 
     m_guidedReadCacheEnabled = enabled;
+    configureDeferred();
+}
+
+bool Session::isSuggestModeEnabled() const
+{
+    return m_isSuggestMode;
+}
+
+void Session::setSuggestMode(bool mode)
+{
+    if (mode == m_isSuggestMode) return;
+
+    m_isSuggestMode = mode;
     configureDeferred();
 }
 

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -265,6 +265,9 @@ Session::Session(QObject *parent)
     , m_useOSCache(BITTORRENT_SESSION_KEY("UseOSCache"), true)
     , m_guidedReadCacheEnabled(BITTORRENT_SESSION_KEY("GuidedReadCache"), true)
     , m_isSuggestMode(BITTORRENT_SESSION_KEY("SuggestMode"), false)
+    , m_sendBufferWatermark(BITTORRENT_SESSION_KEY("SendBufferWatermark"), 500)
+    , m_sendBufferLowWatermark(BITTORRENT_SESSION_KEY("SendBufferLowWatermark"), 10)
+    , m_sendBufferWatermarkFactor(BITTORRENT_SESSION_KEY("SendBufferWatermarkFactor"), 50)
     , m_isAnonymousModeEnabled(BITTORRENT_SESSION_KEY("AnonymousModeEnabled"), false)
     , m_isQueueingEnabled(BITTORRENT_SESSION_KEY("QueueingSystemEnabled"), true)
     , m_maxActiveDownloads(BITTORRENT_SESSION_KEY("MaxActiveDownloads"), 3, lowerLimited(-1))
@@ -1263,6 +1266,10 @@ void Session::configure(libtorrent::settings_pack &settingsPack)
     settingsPack.set_bool(libt::settings_pack::guided_read_cache, isGuidedReadCacheEnabled());
     settingsPack.set_bool(libt::settings_pack::suggest_mode, isSuggestModeEnabled());
 
+    settingsPack.set_int(libt::settings_pack::send_buffer_watermark, sendBufferWatermark() * 1024);
+    settingsPack.set_int(libt::settings_pack::send_buffer_low_watermark, sendBufferLowWatermark() * 1024);
+    settingsPack.set_int(libt::settings_pack::send_buffer_watermark_factor, sendBufferWatermarkFactor());
+
     settingsPack.set_bool(libt::settings_pack::anonymous_mode, isAnonymousModeEnabled());
 
     // Queueing System
@@ -1499,6 +1506,10 @@ void Session::configure(libtorrent::session_settings &sessionSettings)
     sessionSettings.disk_io_write_mode = mode;
     sessionSettings.guided_read_cache = isGuidedReadCacheEnabled();
     sessionSettings.suggest_mode = isSuggestModeEnabled();
+
+    sessionSettings.send_buffer_watermark = sendBufferWatermark() * 1024;
+    sessionSettings.send_buffer_low_watermark = sendBufferLowWatermark() * 1024;
+    sessionSettings.send_buffer_watermark_factor = sendBufferWatermarkFactor();
 
     sessionSettings.anonymous_mode = isAnonymousModeEnabled();
 
@@ -2939,6 +2950,45 @@ void Session::setSuggestMode(bool mode)
     if (mode == m_isSuggestMode) return;
 
     m_isSuggestMode = mode;
+    configureDeferred();
+}
+
+int Session::sendBufferWatermark() const
+{
+    return m_sendBufferWatermark;
+}
+
+void Session::setSendBufferWatermark(int value)
+{
+    if (value == m_sendBufferWatermark) return;
+
+    m_sendBufferWatermark = value;
+    configureDeferred();
+}
+
+int Session::sendBufferLowWatermark() const
+{
+    return m_sendBufferLowWatermark;
+}
+
+void Session::setSendBufferLowWatermark(int value)
+{
+    if (value == m_sendBufferLowWatermark) return;
+
+    m_sendBufferLowWatermark = value;
+    configureDeferred();
+}
+
+int Session::sendBufferWatermarkFactor() const
+{
+    return m_sendBufferWatermarkFactor;
+}
+
+void Session::setSendBufferWatermarkFactor(int value)
+{
+    if (value == m_sendBufferWatermarkFactor) return;
+
+    m_sendBufferWatermarkFactor = value;
     configureDeferred();
 }
 

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -263,6 +263,7 @@ Session::Session(QObject *parent)
     , m_diskCacheSize(BITTORRENT_SESSION_KEY("DiskCacheSize"), 0)
     , m_diskCacheTTL(BITTORRENT_SESSION_KEY("DiskCacheTTL"), 60)
     , m_useOSCache(BITTORRENT_SESSION_KEY("UseOSCache"), true)
+    , m_guidedReadCacheEnabled(BITTORRENT_SESSION_KEY("GuidedReadCache"), true)
     , m_isAnonymousModeEnabled(BITTORRENT_SESSION_KEY("AnonymousModeEnabled"), false)
     , m_isQueueingEnabled(BITTORRENT_SESSION_KEY("QueueingSystemEnabled"), true)
     , m_maxActiveDownloads(BITTORRENT_SESSION_KEY("MaxActiveDownloads"), 3, lowerLimited(-1))
@@ -1256,6 +1257,7 @@ void Session::configure(libtorrent::settings_pack &settingsPack)
                                                               : libt::settings_pack::disable_os_cache;
     settingsPack.set_int(libt::settings_pack::disk_io_read_mode, mode);
     settingsPack.set_int(libt::settings_pack::disk_io_write_mode, mode);
+    settingsPack.set_bool(libt::settings_pack::guided_read_cache, isGuidedReadCacheEnabled());
 
     settingsPack.set_bool(libt::settings_pack::anonymous_mode, isAnonymousModeEnabled());
 
@@ -1472,6 +1474,7 @@ void Session::configure(libtorrent::session_settings &sessionSettings)
                                                                  : libt::session_settings::disable_os_cache;
     sessionSettings.disk_io_read_mode = mode;
     sessionSettings.disk_io_write_mode = mode;
+    sessionSettings.guided_read_cache = isGuidedReadCacheEnabled();
 
     sessionSettings.anonymous_mode = isAnonymousModeEnabled();
 
@@ -2842,6 +2845,19 @@ void Session::setUseOSCache(bool use)
         m_useOSCache = use;
         configureDeferred();
     }
+}
+
+bool Session::isGuidedReadCacheEnabled() const
+{
+    return m_guidedReadCacheEnabled;
+}
+
+void Session::setGuidedReadCacheEnabled(bool enabled)
+{
+    if (enabled == m_guidedReadCacheEnabled) return;
+
+    m_guidedReadCacheEnabled = enabled;
+    configureDeferred();
 }
 
 bool Session::isAnonymousModeEnabled() const

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -317,6 +317,10 @@ namespace BitTorrent
         void setForceProxyEnabled(bool enabled);
         bool isProxyPeerConnectionsEnabled() const;
         void setProxyPeerConnectionsEnabled(bool enabled);
+        int chokingAlgorithm() const;
+        void setChokingAlgorithm(int mode);
+        int seedChokingAlgorithm() const;
+        void setSeedChokingAlgorithm(int mode);
         bool isAddTrackersEnabled() const;
         void setAddTrackersEnabled(bool enabled);
         QString additionalTrackers() const;
@@ -630,6 +634,8 @@ namespace BitTorrent
         CachedSettingValue<int> m_encryption;
         CachedSettingValue<bool> m_isForceProxyEnabled;
         CachedSettingValue<bool> m_isProxyPeerConnectionsEnabled;
+        CachedSettingValue<int> m_chokingAlgorithm;
+        CachedSettingValue<int> m_seedChokingAlgorithm;
         CachedSettingValue<QVariantMap> m_storedCategories;
         CachedSettingValue<QStringList> m_storedTags;
         CachedSettingValue<int> m_maxRatioAction;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -375,6 +375,8 @@ namespace BitTorrent
         void setUTPRateLimited(bool limited);
         int utpMixedMode() const;
         void setUtpMixedMode(int mode);
+        bool multiConnectionsPerIpEnabled() const;
+        void setMultiConnectionsPerIpEnabled(bool enabled);
         bool isTrackerFilteringEnabled() const;
         void setTrackerFilteringEnabled(bool enabled);
         QStringList bannedIPs() const;
@@ -600,6 +602,7 @@ namespace BitTorrent
         CachedSettingValue<bool> m_isUTPEnabled;
         CachedSettingValue<bool> m_isUTPRateLimited;
         CachedSettingValue<int> m_utpMixedMode;
+        CachedSettingValue<bool> m_multiConnectionsPerIpEnabled;
         CachedSettingValue<bool> m_isAddTrackersEnabled;
         CachedSettingValue<QString> m_additionalTrackers;
         CachedSettingValue<qreal> m_globalMaxRatio;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -333,6 +333,8 @@ namespace BitTorrent
         void setDiskCacheTTL(int ttl);
         bool useOSCache() const;
         void setUseOSCache(bool use);
+        bool isGuidedReadCacheEnabled() const;
+        void setGuidedReadCacheEnabled(bool enabled);
         bool isAnonymousModeEnabled() const;
         void setAnonymousModeEnabled(bool enabled);
         bool isQueueingSystemEnabled() const;
@@ -575,6 +577,7 @@ namespace BitTorrent
         CachedSettingValue<int> m_diskCacheSize;
         CachedSettingValue<int> m_diskCacheTTL;
         CachedSettingValue<bool> m_useOSCache;
+        CachedSettingValue<bool> m_guidedReadCacheEnabled;
         CachedSettingValue<bool> m_isAnonymousModeEnabled;
         CachedSettingValue<bool> m_isQueueingEnabled;
         CachedSettingValue<int> m_maxActiveDownloads;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -341,6 +341,12 @@ namespace BitTorrent
         void setGuidedReadCacheEnabled(bool enabled);
         bool isSuggestModeEnabled() const;
         void setSuggestMode(bool mode);
+        int sendBufferWatermark() const;
+        void setSendBufferWatermark(int value);
+        int sendBufferLowWatermark() const;
+        void setSendBufferLowWatermark(int value);
+        int sendBufferWatermarkFactor() const;
+        void setSendBufferWatermarkFactor(int value);
         bool isAnonymousModeEnabled() const;
         void setAnonymousModeEnabled(bool enabled);
         bool isQueueingSystemEnabled() const;
@@ -589,6 +595,9 @@ namespace BitTorrent
         CachedSettingValue<bool> m_useOSCache;
         CachedSettingValue<bool> m_guidedReadCacheEnabled;
         CachedSettingValue<bool> m_isSuggestMode;
+        CachedSettingValue<int> m_sendBufferWatermark;
+        CachedSettingValue<int> m_sendBufferLowWatermark;
+        CachedSettingValue<int> m_sendBufferWatermarkFactor;
         CachedSettingValue<bool> m_isAnonymousModeEnabled;
         CachedSettingValue<bool> m_isQueueingEnabled;
         CachedSettingValue<int> m_maxActiveDownloads;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -373,6 +373,8 @@ namespace BitTorrent
         void setUTPEnabled(bool enabled);
         bool isUTPRateLimited() const;
         void setUTPRateLimited(bool limited);
+        int utpMixedMode() const;
+        void setUtpMixedMode(int mode);
         bool isTrackerFilteringEnabled() const;
         void setTrackerFilteringEnabled(bool enabled);
         QStringList bannedIPs() const;
@@ -597,6 +599,7 @@ namespace BitTorrent
         CachedSettingValue<int> m_maxUploadsPerTorrent;
         CachedSettingValue<bool> m_isUTPEnabled;
         CachedSettingValue<bool> m_isUTPRateLimited;
+        CachedSettingValue<int> m_utpMixedMode;
         CachedSettingValue<bool> m_isAddTrackersEnabled;
         CachedSettingValue<QString> m_additionalTrackers;
         CachedSettingValue<qreal> m_globalMaxRatio;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -151,6 +151,38 @@ namespace BitTorrent
         uint nbErrored = 0;
     };
 
+    class SessionSettingsEnums
+    {
+        Q_GADGET
+
+    public:
+        // TODO: remove `SessionSettingsEnums` wrapper when we can use `Q_ENUM_NS` directly (QT >= 5.8 only)
+        enum class ChokingAlgorithm : int
+        {
+            FixedSlots = 0,
+            RateBased = 1
+        };
+        Q_ENUM(ChokingAlgorithm)
+
+        enum class SeedChokingAlgorithm : int
+        {
+            RoundRobin = 0,
+            FastestUpload = 1,
+            AntiLeech = 2
+        };
+        Q_ENUM(SeedChokingAlgorithm)
+
+        enum class MixedModeAlgorithm : int
+        {
+            TCP = 0,
+            Proportional = 1
+        };
+        Q_ENUM(MixedModeAlgorithm)
+    };
+    using ChokingAlgorithm = SessionSettingsEnums::ChokingAlgorithm;
+    using SeedChokingAlgorithm = SessionSettingsEnums::SeedChokingAlgorithm;
+    using MixedModeAlgorithm = SessionSettingsEnums::MixedModeAlgorithm;
+
 #if LIBTORRENT_VERSION_NUM >= 10100
     struct SessionMetricIndices
     {
@@ -317,10 +349,10 @@ namespace BitTorrent
         void setForceProxyEnabled(bool enabled);
         bool isProxyPeerConnectionsEnabled() const;
         void setProxyPeerConnectionsEnabled(bool enabled);
-        int chokingAlgorithm() const;
-        void setChokingAlgorithm(int mode);
-        int seedChokingAlgorithm() const;
-        void setSeedChokingAlgorithm(int mode);
+        ChokingAlgorithm chokingAlgorithm() const;
+        void setChokingAlgorithm(ChokingAlgorithm mode);
+        SeedChokingAlgorithm seedChokingAlgorithm() const;
+        void setSeedChokingAlgorithm(SeedChokingAlgorithm mode);
         bool isAddTrackersEnabled() const;
         void setAddTrackersEnabled(bool enabled);
         QString additionalTrackers() const;
@@ -385,8 +417,8 @@ namespace BitTorrent
         void setUTPEnabled(bool enabled);
         bool isUTPRateLimited() const;
         void setUTPRateLimited(bool limited);
-        int utpMixedMode() const;
-        void setUtpMixedMode(int mode);
+        MixedModeAlgorithm utpMixedMode() const;
+        void setUtpMixedMode(MixedModeAlgorithm mode);
         bool multiConnectionsPerIpEnabled() const;
         void setMultiConnectionsPerIpEnabled(bool enabled);
         bool isTrackerFilteringEnabled() const;
@@ -617,7 +649,7 @@ namespace BitTorrent
         CachedSettingValue<int> m_maxUploadsPerTorrent;
         CachedSettingValue<bool> m_isUTPEnabled;
         CachedSettingValue<bool> m_isUTPRateLimited;
-        CachedSettingValue<int> m_utpMixedMode;
+        CachedSettingValue<MixedModeAlgorithm> m_utpMixedMode;
         CachedSettingValue<bool> m_multiConnectionsPerIpEnabled;
         CachedSettingValue<bool> m_isAddTrackersEnabled;
         CachedSettingValue<QString> m_additionalTrackers;
@@ -646,8 +678,8 @@ namespace BitTorrent
         CachedSettingValue<int> m_encryption;
         CachedSettingValue<bool> m_isForceProxyEnabled;
         CachedSettingValue<bool> m_isProxyPeerConnectionsEnabled;
-        CachedSettingValue<int> m_chokingAlgorithm;
-        CachedSettingValue<int> m_seedChokingAlgorithm;
+        CachedSettingValue<ChokingAlgorithm> m_chokingAlgorithm;
+        CachedSettingValue<SeedChokingAlgorithm> m_seedChokingAlgorithm;
         CachedSettingValue<QVariantMap> m_storedCategories;
         CachedSettingValue<QStringList> m_storedTags;
         CachedSettingValue<int> m_maxRatioAction;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -339,6 +339,8 @@ namespace BitTorrent
         void setUseOSCache(bool use);
         bool isGuidedReadCacheEnabled() const;
         void setGuidedReadCacheEnabled(bool enabled);
+        bool isSuggestModeEnabled() const;
+        void setSuggestMode(bool mode);
         bool isAnonymousModeEnabled() const;
         void setAnonymousModeEnabled(bool enabled);
         bool isQueueingSystemEnabled() const;
@@ -586,6 +588,7 @@ namespace BitTorrent
         CachedSettingValue<int> m_diskCacheTTL;
         CachedSettingValue<bool> m_useOSCache;
         CachedSettingValue<bool> m_guidedReadCacheEnabled;
+        CachedSettingValue<bool> m_isSuggestMode;
         CachedSettingValue<bool> m_isAnonymousModeEnabled;
         CachedSettingValue<bool> m_isQueueingEnabled;
         CachedSettingValue<int> m_maxActiveDownloads;

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -80,6 +80,9 @@ enum AdvSettingsRows
     OS_CACHE,
     GUIDED_READ_CACHE,
     SUGGEST_MODE,
+    SEND_BUF_WATERMARK,
+    SEND_BUF_LOW_WATERMARK,
+    SEND_BUF_WATERMARK_FACTOR,
     // ports
     MAX_HALF_OPEN,
     OUTGOING_PORT_MIN,
@@ -137,6 +140,10 @@ void AdvancedSettings::saveAdvancedSettings()
     session->setGuidedReadCacheEnabled(cbGuidedReadCache.isChecked());
     // Suggest mode
     session->setSuggestMode(cbSuggestMode.isChecked());
+    // Send buffer watermark
+    session->setSendBufferWatermark(spinSendBufferWatermark.value());
+    session->setSendBufferLowWatermark(spinSendBufferLowWatermark.value());
+    session->setSendBufferWatermarkFactor(spinSendBufferWatermarkFactor.value());
     // Save resume data interval
     session->setSaveResumeDataInterval(spin_save_resume_data_interval.value());
     // Outgoing ports
@@ -303,6 +310,22 @@ void AdvancedSettings::loadAdvancedSettings()
     // Suggest mode
     cbSuggestMode.setChecked(session->isSuggestModeEnabled());
     addRow(SUGGEST_MODE, tr("Send upload piece suggestions"), &cbSuggestMode);
+    // Send buffer watermark
+    spinSendBufferWatermark.setMinimum(1);
+    spinSendBufferWatermark.setMaximum(INT_MAX);
+    spinSendBufferWatermark.setSuffix(tr(" KiB"));
+    spinSendBufferWatermark.setValue(session->sendBufferWatermark());
+    addRow(SEND_BUF_WATERMARK, tr("Send buffer watermark"), &spinSendBufferWatermark);
+    spinSendBufferLowWatermark.setMinimum(1);
+    spinSendBufferLowWatermark.setMaximum(INT_MAX);
+    spinSendBufferLowWatermark.setSuffix(tr(" KiB"));
+    spinSendBufferLowWatermark.setValue(session->sendBufferLowWatermark());
+    addRow(SEND_BUF_LOW_WATERMARK, tr("Send buffer low watermark"), &spinSendBufferLowWatermark);
+    spinSendBufferWatermarkFactor.setMinimum(1);
+    spinSendBufferWatermarkFactor.setMaximum(INT_MAX);
+    spinSendBufferWatermarkFactor.setSuffix(" %");
+    spinSendBufferWatermarkFactor.setValue(session->sendBufferWatermarkFactor());
+    addRow(SEND_BUF_WATERMARK_FACTOR, tr("Send buffer watermark factor"), &spinSendBufferWatermarkFactor);
     // Save resume data interval
     spin_save_resume_data_interval.setMinimum(1);
     spin_save_resume_data_interval.setMaximum(1440);

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -83,6 +83,7 @@ enum AdvSettingsRows
     MAX_HALF_OPEN,
     OUTGOING_PORT_MIN,
     OUTGOING_PORT_MAX,
+    UTP_MIX_MODE,
     // embedded tracker
     TRACKER_STATUS,
     TRACKER_PORT,
@@ -135,6 +136,8 @@ void AdvancedSettings::saveAdvancedSettings()
     // Outgoing ports
     session->setOutgoingPortsMin(outgoing_ports_min.value());
     session->setOutgoingPortsMax(outgoing_ports_max.value());
+    // uTP-TCP mixed mode
+    session->setUtpMixedMode(comboUtpMixedMode.currentIndex());
     // Recheck torrents on completion
     pref->recheckTorrentsOnCompletion(cb_recheck_completed.isChecked());
     // Transfer list refresh interval
@@ -300,6 +303,10 @@ void AdvancedSettings::loadAdvancedSettings()
     outgoing_ports_max.setMaximum(65535);
     outgoing_ports_max.setValue(session->outgoingPortsMax());
     addRow(OUTGOING_PORT_MAX, tr("Outgoing ports (Max) [0: Disabled]"), &outgoing_ports_max);
+    // uTP-TCP mixed mode
+    comboUtpMixedMode.addItems({"Prefer TCP", "Peer proportional (throttles TCP)"});
+    comboUtpMixedMode.setCurrentIndex(session->utpMixedMode());
+    addRow(UTP_MIX_MODE, tr("uTP-TCP mixed mode algorithm"), &comboUtpMixedMode);
     // Recheck completed torrents
     cb_recheck_completed.setChecked(pref->recheckTorrentsOnCompletion());
     addRow(RECHECK_COMPLETED, tr("Recheck torrents on completion"), &cb_recheck_completed);

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -78,6 +78,7 @@ enum AdvSettingsRows
     DISK_CACHE,
     DISK_CACHE_TTL,
     OS_CACHE,
+    GUIDED_READ_CACHE,
     // ports
     MAX_HALF_OPEN,
     OUTGOING_PORT_MIN,
@@ -127,6 +128,8 @@ void AdvancedSettings::saveAdvancedSettings()
     session->setDiskCacheTTL(spin_cache_ttl.value());
     // Enable OS cache
     session->setUseOSCache(cb_os_cache.isChecked());
+    // Guided read cache
+    session->setGuidedReadCacheEnabled(cbGuidedReadCache.isChecked());
     // Save resume data interval
     session->setSaveResumeDataInterval(spin_save_resume_data_interval.value());
     // Outgoing ports
@@ -278,6 +281,9 @@ void AdvancedSettings::loadAdvancedSettings()
     // Enable OS cache
     cb_os_cache.setChecked(session->useOSCache());
     addRow(OS_CACHE, tr("Enable OS cache"), &cb_os_cache);
+    // Guided read cache
+    cbGuidedReadCache.setChecked(session->isGuidedReadCacheEnabled());
+    addRow(GUIDED_READ_CACHE, tr("Guided read cache"), &cbGuidedReadCache);
     // Save resume data interval
     spin_save_resume_data_interval.setMinimum(1);
     spin_save_resume_data_interval.setMaximum(1440);

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -89,6 +89,8 @@ enum AdvSettingsRows
     TRACKER_STATUS,
     TRACKER_PORT,
     // seeding
+    CHOKING_ALGORITHM,
+    SEED_CHOKING_ALGORITHM,
     SUPER_SEEDING,
     // tracker
     ANNOUNCE_ALL_TRACKERS,
@@ -187,6 +189,11 @@ void AdvancedSettings::saveAdvancedSettings()
     // Tracker
     session->setTrackerEnabled(cb_tracker_status.isChecked());
     pref->setTrackerPort(spin_tracker_port.value());
+    // Choking algorithm
+    session->setChokingAlgorithm(comboChokingAlgorithm.currentIndex());
+    // Seed choking algorithm
+    session->setSeedChokingAlgorithm(comboSeedChokingAlgorithm.currentIndex());
+
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     pref->setUpdateCheckEnabled(cb_update_check.isChecked());
 #endif
@@ -391,6 +398,15 @@ void AdvancedSettings::loadAdvancedSettings()
     spin_tracker_port.setMaximum(65535);
     spin_tracker_port.setValue(pref->getTrackerPort());
     addRow(TRACKER_PORT, tr("Embedded tracker port"), &spin_tracker_port);
+    // Choking algorithm
+    comboChokingAlgorithm.addItems({"Fixed slots", "Upload rate based"});
+    comboChokingAlgorithm.setCurrentIndex(session->chokingAlgorithm());
+    addRow(CHOKING_ALGORITHM, tr("Upload slots behavior"), &comboChokingAlgorithm);
+    // Seed choking algorithm
+    comboSeedChokingAlgorithm.addItems({"Round-robin", "Fastest upload", "Anti-leech"});
+    comboSeedChokingAlgorithm.setCurrentIndex(session->seedChokingAlgorithm());
+    addRow(SEED_CHOKING_ALGORITHM, tr("Upload choking algorithm"), &comboSeedChokingAlgorithm);
+
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     cb_update_check.setChecked(pref->isUpdateCheckEnabled());
     addRow(UPDATE_CHECK, tr("Check for software updates"), &cb_update_check);

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -150,7 +150,7 @@ void AdvancedSettings::saveAdvancedSettings()
     session->setOutgoingPortsMin(outgoing_ports_min.value());
     session->setOutgoingPortsMax(outgoing_ports_max.value());
     // uTP-TCP mixed mode
-    session->setUtpMixedMode(comboUtpMixedMode.currentIndex());
+    session->setUtpMixedMode(static_cast<BitTorrent::MixedModeAlgorithm>(comboUtpMixedMode.currentIndex()));
     // multiple connections per IP
     session->setMultiConnectionsPerIpEnabled(cbMultiConnectionsPerIp.isChecked());
     // Recheck torrents on completion
@@ -200,9 +200,9 @@ void AdvancedSettings::saveAdvancedSettings()
     session->setTrackerEnabled(cb_tracker_status.isChecked());
     pref->setTrackerPort(spin_tracker_port.value());
     // Choking algorithm
-    session->setChokingAlgorithm(comboChokingAlgorithm.currentIndex());
+    session->setChokingAlgorithm(static_cast<BitTorrent::ChokingAlgorithm>(comboChokingAlgorithm.currentIndex()));
     // Seed choking algorithm
-    session->setSeedChokingAlgorithm(comboSeedChokingAlgorithm.currentIndex());
+    session->setSeedChokingAlgorithm(static_cast<BitTorrent::SeedChokingAlgorithm>(comboSeedChokingAlgorithm.currentIndex()));
 
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     pref->setUpdateCheckEnabled(cb_update_check.isChecked());
@@ -344,7 +344,7 @@ void AdvancedSettings::loadAdvancedSettings()
     addRow(OUTGOING_PORT_MAX, tr("Outgoing ports (Max) [0: Disabled]"), &outgoing_ports_max);
     // uTP-TCP mixed mode
     comboUtpMixedMode.addItems({"Prefer TCP", "Peer proportional (throttles TCP)"});
-    comboUtpMixedMode.setCurrentIndex(session->utpMixedMode());
+    comboUtpMixedMode.setCurrentIndex(static_cast<int>(session->utpMixedMode()));
     addRow(UTP_MIX_MODE, tr("uTP-TCP mixed mode algorithm"), &comboUtpMixedMode);
     // multiple connections per IP
     cbMultiConnectionsPerIp.setChecked(session->multiConnectionsPerIpEnabled());
@@ -429,11 +429,11 @@ void AdvancedSettings::loadAdvancedSettings()
     addRow(TRACKER_PORT, tr("Embedded tracker port"), &spin_tracker_port);
     // Choking algorithm
     comboChokingAlgorithm.addItems({"Fixed slots", "Upload rate based"});
-    comboChokingAlgorithm.setCurrentIndex(session->chokingAlgorithm());
+    comboChokingAlgorithm.setCurrentIndex(static_cast<int>(session->chokingAlgorithm()));
     addRow(CHOKING_ALGORITHM, tr("Upload slots behavior"), &comboChokingAlgorithm);
     // Seed choking algorithm
     comboSeedChokingAlgorithm.addItems({"Round-robin", "Fastest upload", "Anti-leech"});
-    comboSeedChokingAlgorithm.setCurrentIndex(session->seedChokingAlgorithm());
+    comboSeedChokingAlgorithm.setCurrentIndex(static_cast<int>(session->seedChokingAlgorithm()));
     addRow(SEED_CHOKING_ALGORITHM, tr("Upload choking algorithm"), &comboSeedChokingAlgorithm);
 
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -84,6 +84,7 @@ enum AdvSettingsRows
     OUTGOING_PORT_MIN,
     OUTGOING_PORT_MAX,
     UTP_MIX_MODE,
+    MULTI_CONNECTIONS_PER_IP,
     // embedded tracker
     TRACKER_STATUS,
     TRACKER_PORT,
@@ -138,6 +139,8 @@ void AdvancedSettings::saveAdvancedSettings()
     session->setOutgoingPortsMax(outgoing_ports_max.value());
     // uTP-TCP mixed mode
     session->setUtpMixedMode(comboUtpMixedMode.currentIndex());
+    // multiple connections per IP
+    session->setMultiConnectionsPerIpEnabled(cbMultiConnectionsPerIp.isChecked());
     // Recheck torrents on completion
     pref->recheckTorrentsOnCompletion(cb_recheck_completed.isChecked());
     // Transfer list refresh interval
@@ -307,6 +310,9 @@ void AdvancedSettings::loadAdvancedSettings()
     comboUtpMixedMode.addItems({"Prefer TCP", "Peer proportional (throttles TCP)"});
     comboUtpMixedMode.setCurrentIndex(session->utpMixedMode());
     addRow(UTP_MIX_MODE, tr("uTP-TCP mixed mode algorithm"), &comboUtpMixedMode);
+    // multiple connections per IP
+    cbMultiConnectionsPerIp.setChecked(session->multiConnectionsPerIpEnabled());
+    addRow(MULTI_CONNECTIONS_PER_IP, tr("Allow multiple connections from the same IP address"), &cbMultiConnectionsPerIp);
     // Recheck completed torrents
     cb_recheck_completed.setChecked(pref->recheckTorrentsOnCompletion());
     addRow(RECHECK_COMPLETED, tr("Recheck torrents on completion"), &cb_recheck_completed);

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -79,6 +79,7 @@ enum AdvSettingsRows
     DISK_CACHE_TTL,
     OS_CACHE,
     GUIDED_READ_CACHE,
+    SUGGEST_MODE,
     // ports
     MAX_HALF_OPEN,
     OUTGOING_PORT_MIN,
@@ -134,6 +135,8 @@ void AdvancedSettings::saveAdvancedSettings()
     session->setUseOSCache(cb_os_cache.isChecked());
     // Guided read cache
     session->setGuidedReadCacheEnabled(cbGuidedReadCache.isChecked());
+    // Suggest mode
+    session->setSuggestMode(cbSuggestMode.isChecked());
     // Save resume data interval
     session->setSaveResumeDataInterval(spin_save_resume_data_interval.value());
     // Outgoing ports
@@ -297,6 +300,9 @@ void AdvancedSettings::loadAdvancedSettings()
     // Guided read cache
     cbGuidedReadCache.setChecked(session->isGuidedReadCacheEnabled());
     addRow(GUIDED_READ_CACHE, tr("Guided read cache"), &cbGuidedReadCache);
+    // Suggest mode
+    cbSuggestMode.setChecked(session->isSuggestModeEnabled());
+    addRow(SUGGEST_MODE, tr("Send upload piece suggestions"), &cbSuggestMode);
     // Save resume data interval
     spin_save_resume_data_interval.setMinimum(1);
     spin_save_resume_data_interval.setMaximum(1440);

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -79,7 +79,7 @@ private:
     QCheckBox cb_os_cache, cb_recheck_completed, cb_resolve_countries, cb_resolve_hosts, cb_super_seeding,
               cb_program_notifications, cb_torrent_added_notifications, cb_tracker_favicon, cb_tracker_status,
               cb_confirm_torrent_recheck, cb_confirm_remove_all_tags, cb_listen_ipv6, cb_announce_all_trackers, cbGuidedReadCache, cbMultiConnectionsPerIp;
-    QComboBox combo_iface, combo_iface_address, comboUtpMixedMode;
+    QComboBox combo_iface, combo_iface_address, comboUtpMixedMode, comboChokingAlgorithm, comboSeedChokingAlgorithm;
     QLineEdit txtAnnounceIP;
 
     // OS dependent settings

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -78,7 +78,8 @@ private:
     QSpinBox spin_cache, spin_save_resume_data_interval, outgoing_ports_min, outgoing_ports_max, spin_list_refresh, spin_maxhalfopen, spin_tracker_port, spin_cache_ttl;
     QCheckBox cb_os_cache, cb_recheck_completed, cb_resolve_countries, cb_resolve_hosts, cb_super_seeding,
               cb_program_notifications, cb_torrent_added_notifications, cb_tracker_favicon, cb_tracker_status,
-              cb_confirm_torrent_recheck, cb_confirm_remove_all_tags, cb_listen_ipv6, cb_announce_all_trackers, cbGuidedReadCache, cbMultiConnectionsPerIp;
+              cb_confirm_torrent_recheck, cb_confirm_remove_all_tags, cb_listen_ipv6, cb_announce_all_trackers, cbGuidedReadCache, cbMultiConnectionsPerIp,
+              cbSuggestMode;
     QComboBox combo_iface, combo_iface_address, comboUtpMixedMode, comboChokingAlgorithm, comboSeedChokingAlgorithm;
     QLineEdit txtAnnounceIP;
 

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -29,14 +29,13 @@
 #ifndef ADVANCEDSETTINGS_H
 #define ADVANCEDSETTINGS_H
 
+#include <QCheckBox>
+#include <QComboBox>
 #include <QEvent>
 #include <QLabel>
-#include <QSpinBox>
-#include <QCheckBox>
 #include <QLineEdit>
-#include <QComboBox>
+#include <QSpinBox>
 #include <QTableWidget>
-
 
 class WheelEventEater: public QObject
 {
@@ -79,7 +78,7 @@ private:
     QSpinBox spin_cache, spin_save_resume_data_interval, outgoing_ports_min, outgoing_ports_max, spin_list_refresh, spin_maxhalfopen, spin_tracker_port, spin_cache_ttl;
     QCheckBox cb_os_cache, cb_recheck_completed, cb_resolve_countries, cb_resolve_hosts, cb_super_seeding,
               cb_program_notifications, cb_torrent_added_notifications, cb_tracker_favicon, cb_tracker_status,
-              cb_confirm_torrent_recheck, cb_confirm_remove_all_tags, cb_listen_ipv6, cb_announce_all_trackers;
+              cb_confirm_torrent_recheck, cb_confirm_remove_all_tags, cb_listen_ipv6, cb_announce_all_trackers, cbGuidedReadCache;
     QComboBox combo_iface, combo_iface_address;
     QLineEdit txtAnnounceIP;
 

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -79,7 +79,7 @@ private:
     QCheckBox cb_os_cache, cb_recheck_completed, cb_resolve_countries, cb_resolve_hosts, cb_super_seeding,
               cb_program_notifications, cb_torrent_added_notifications, cb_tracker_favicon, cb_tracker_status,
               cb_confirm_torrent_recheck, cb_confirm_remove_all_tags, cb_listen_ipv6, cb_announce_all_trackers, cbGuidedReadCache;
-    QComboBox combo_iface, combo_iface_address;
+    QComboBox combo_iface, combo_iface_address, comboUtpMixedMode;
     QLineEdit txtAnnounceIP;
 
     // OS dependent settings

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -78,7 +78,7 @@ private:
     QSpinBox spin_cache, spin_save_resume_data_interval, outgoing_ports_min, outgoing_ports_max, spin_list_refresh, spin_maxhalfopen, spin_tracker_port, spin_cache_ttl;
     QCheckBox cb_os_cache, cb_recheck_completed, cb_resolve_countries, cb_resolve_hosts, cb_super_seeding,
               cb_program_notifications, cb_torrent_added_notifications, cb_tracker_favicon, cb_tracker_status,
-              cb_confirm_torrent_recheck, cb_confirm_remove_all_tags, cb_listen_ipv6, cb_announce_all_trackers, cbGuidedReadCache;
+              cb_confirm_torrent_recheck, cb_confirm_remove_all_tags, cb_listen_ipv6, cb_announce_all_trackers, cbGuidedReadCache, cbMultiConnectionsPerIp;
     QComboBox combo_iface, combo_iface_address, comboUtpMixedMode;
     QLineEdit txtAnnounceIP;
 

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -75,7 +75,8 @@ private:
     template <typename T> void addRow(int row, const QString &rowText, T* widget);
 
     QLabel labelQbtLink, labelLibtorrentLink;
-    QSpinBox spin_cache, spin_save_resume_data_interval, outgoing_ports_min, outgoing_ports_max, spin_list_refresh, spin_maxhalfopen, spin_tracker_port, spin_cache_ttl;
+    QSpinBox spin_cache, spin_save_resume_data_interval, outgoing_ports_min, outgoing_ports_max, spin_list_refresh, spin_maxhalfopen, spin_tracker_port, spin_cache_ttl,
+             spinSendBufferWatermark, spinSendBufferLowWatermark, spinSendBufferWatermarkFactor;
     QCheckBox cb_os_cache, cb_recheck_completed, cb_resolve_countries, cb_resolve_hosts, cb_super_seeding,
               cb_program_notifications, cb_torrent_added_notifications, cb_tracker_favicon, cb_tracker_status,
               cb_confirm_torrent_recheck, cb_confirm_remove_all_tags, cb_listen_ipv6, cb_announce_all_trackers, cbGuidedReadCache, cbMultiConnectionsPerIp,


### PR DESCRIPTION
# >>First post outdated, see https://github.com/qbittorrent/qBittorrent/pull/3235#issuecomment-321976399 <<

I found some interesting options when reading libtorrent's document:
- [guided_read_cache](http://www.libtorrent.org/reference-Settings.html#guided_read_cache): [default off]
  Also see: [tuning#disk-cache](http://www.libtorrent.org/tuning.html#disk-cache)
  
  > The idea being that slow peers don't use up a disproportional amount of space in the cache
  
  This looks promising. 
-  [prefer_tcp](http://www.libtorrent.org/reference-Settings.html#bandwidth_mixed_algo_t): [default off]
  Also see: [tuning#utp-tcp-mixed-mode](http://www.libtorrent.org/tuning.html#utp-tcp-mixed-mode)
  Since there are issues with `peer_proportional` in the past, then just use `prefer_tcp` in all cases.
  I can't see why this should be depending on `rate_limit_utp`.
- [use_parole_mode](http://www.libtorrent.org/reference-Settings.html#use_parole_mode): [default off]
  Maybe give a hashcheck-failed peer another chance before banning.

![new](https://cloud.githubusercontent.com/assets/9395168/12743539/83fefc24-c9c9-11e5-897d-60210c93f2c4.png)
