### PR TITLE
Fix MSVC2013 complains on Unicode characters

### DIFF
--- a/src/core/unicodestrings.h
+++ b/src/core/unicodestrings.h
@@ -26,10 +26,14 @@
  * exception statement from your version.
  */
 
+// This file must be encoded in "UTF-8 with BOM"
 #ifdef _MSC_VER
 #pragma execution_character_set("utf-8")
 #endif
 
+// Because of the poor handling of UTF-8 characters in MSVC (emits warning C4819),
+// we put all problematic UTF-8 chars/strings in this file.
+// See issue #3059 for more details (https://github.com/qbittorrent/qBittorrent/issues/3059).
 const char C_INFINITY[] = "∞";
 const char C_UP[] = "▲";
 const char C_DOWN[] = "▼";
@@ -76,48 +80,3 @@ const char C_LOCALE_VIETNAMESE[] = "tiếng Việt";
 const char C_LOCALE_CHINESE_TRADITIONAL[] = "中文 (繁體)";
 const char C_LOCALE_CHINESE_SIMPLIFIED[] = "中文 (简体)";
 const char C_LOCALE_KOREAN[] = "한글";
-const char C_THANKS[] =
-    "<p>I would first like to thank sourceforge.net for hosting qBittorrent project and for their support.</p>\
-    <p>I am pleased that people from all over the world are contributing to qBittorrent: Ishan Arora (India), Arnaud Demaizière (France) and Stephanos Antaris (Greece). Their help is greatly appreciated</p>\
-    <p>I also want to thank Στέφανος Αντάρης (santaris@csd.auth.gr) and Mirco Chinelli (infinity89@fastwebmail.it) for working on Mac OS X packaging.</p>\
-	<p>I am grateful to Peter Koeleman (peter@qbittorrent.org) and Mohammad Dib (mdib@qbittorrent.org) for working on qBittorrent port to Windows.</p>\
-	<p>Thanks a lot to our graphist Mateusz Toboła (tobejodok@qbittorrent.org) for his great work.</p>";
-const char C_TRANSLATORS[] =
-    "<ul><li><u>Arabic:</u> SDERAWI (abz8868@msn.com), sn51234 (nesseyan@gmail.com) and  Ibrahim Saed ibraheem_alex(Transifex)</li>\
-    <li><u>Armenian:</u> Hrant Ohanyan (hrantohanyan@mail.am)</li>\
-    <li><u>Basque:</u> Xabier Aramendi (azpidatziak@gmail.com)</li>\
-    <li><u>Belarusian:</u> Mihas Varantsou (meequz@gmail.com)</li>\
-    <li><u>Bulgarian:</u> Tsvetan & Boyko Bankoff (emerge_life@users.sourceforge.net)</li>\
-    <li><u>Catalan:</u> Francisco Luque Contreras (frannoe@ya.com)</li>\
-    <li><u>Chinese (Simplified):</u> Guo Yue (yue.guo0418@gmail.com)</li>\
-    <li><u>Chinese (Traditional):</u> Yi-Shun Wang (dnextstep@gmail.com) and 冥王歐西里斯 s8321414(Transifex)</li>\
-    <li><u>Croatian:</u> Oliver Mucafir (oliver.untwist@gmail.com)</li>\
-    <li><u>Czech:</u> Jirka Vilim (web@tets.cz) and Petr Cernobila abr(Transifex)</li>\
-    <li><u>Danish:</u> Mathias Nielsen (comoneo@gmail.com)</li>\
-    <li><u>Dutch:</u> Pieter Heyvaert (pieter_heyvaert@hotmail.com)</li>\
-    <li><u>English(Australia):</u> Robert Readman readmanr(Transifex)</li>\
-    <li><u>English(United Kingdom):</u> Robert Readman readmanr(Transifex)</li>\
-    <li><u>Finnish:</u> Niklas Laxström (nikerabbit@users.sourceforge.net), Pekka Niemi (pekka.niemi@iki.fi) and Jiri Grönroos artnay(Transifex)</li>\
-    <li><u>Galician:</u> Marcos Lans (marcoslansgarza@gmail.com) and antiparvos(Transifex)</li>\
-    <li><u>Georgian:</u> Beqa Arabuli (arabulibeqa@yahoo.com)</li>\
-    <li><u>German:</u> Niels Hoffmann (zentralmaschine@users.sourceforge.net), schnurlos (schnurlos@gmail.com)</li>\
-    <li><u>Greek:</u> Tsvetan Bankov (emerge_life@users.sourceforge.net), Stephanos Antaris (santaris@csd.auth.gr), sledgehammer999(hammered999@gmail.com), Γιάννης Ανθυμίδης Evropi(Transifex) and Panagiotis Tabakis(tabakisp@gmail.com)</li>\
-    <li><u>Hebrew:</u> David Deutsch (d.deffo@gmail.com)</li>\
-    <li><u>Hungarian:</u> Majoros Péter (majoros.peterj@gmail.com)</li>\
-    <li><u>Italian:</u> bovirus (bovirus@live.it) and Matteo Sechi (bu17714@gmail.com)</li>\
-    <li><u>Japanese:</u> Masato Hashimoto (cabezon.hashimoto@gmail.com)</li>\
-    <li><u>Korean:</u> Jin Woo Sin (jin828sin@users.sourceforge.net)</li>\
-    <li><u>Lithuanian:</u> Naglis Jonaitis (njonaitis@gmail.com)</li>\
-    <li><u>Norwegian:</u> Tomaso</li>\
-    <li><u>Polish:</u> Mariusz Fik (fisiu@opensuse.org)</li>\
-    <li><u>Portuguese:</u> Sérgio Marques smarquespt(Transifex)</li>\
-    <li><u>Portuguese(Brazil):</u> Nick Marinho (nickmarinho@gmail.com)</li>\
-    <li><u>Romanian:</u> Obada Denis (obadadenis@users.sourceforge.net), Adrian Gabor Adriannho(Transifex) and Mihai Coman z0id(Transifex)</li>\
-    <li><u>Russian:</u> Nick Khazov (m2k3d0n at users.sourceforge.net), Alexey Morsov (samurai@ricom.ru), Nick Tiskov Dayman(daymansmail (at) gmail (dot) com), Dmitry DmitryKX(Transifex) and kraleksandr kraleksandr(Transifex)</li>\
-    <li><u>Serbian:</u> Anaximandar Milet (anaximandar@operamail.com)</li>\
-    <li><u>Slovak:</u>  helix84</li>\
-    <li><u>Spanish:</u> Alfredo Monclús (alfrix), Francisco Luque Contreras (frannoe@ya.com), José Antonio Moray moray33(Transifex) and Diego de las Heras(Transifex)</li>\
-    <li><u>Swedish:</u> Daniel Nylander (po@danielnylander.se) and Emil Hammarberg Ooglogput(Transifex)</li>\
-    <li><u>Turkish:</u> Hasan YILMAZ (iletisim@hedefturkce.com) and Erdem Bingöl (erdem84@gmail.com)</li>\
-    <li><u>Ukrainian:</u> Oleh Prypin (blaxpirit@gmail.com)</li>\
-    <li><u>Vietnamese:</u> Anh Phan ppanhh(Transifex)</li></ul>";

--- a/src/core/unicodestrings.h
+++ b/src/core/unicodestrings.h
@@ -1,0 +1,123 @@
+﻿/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2015  Mike Tzou
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#ifdef _MSC_VER
+#pragma execution_character_set("utf-8")
+#endif
+
+const char C_INFINITY[] = "∞";
+const char C_UP[] = "▲";
+const char C_DOWN[] = "▼";
+const char C_COPYRIGHT[] = "©";
+const char C_LOCALE_ENGLISH[] = "English";
+const char C_LOCALE_ENGLISH_AUSTRALIA[] = "English(Australia)";
+const char C_LOCALE_ENGLISH_UNITEDKINGDOM[] = "English(United Kingdom)";
+const char C_LOCALE_FRENCH[] = "Français";
+const char C_LOCALE_GERMAN[] = "Deutsch";
+const char C_LOCALE_HUNGARIAN[] = "Magyar";
+const char C_LOCALE_INDONESIAN[] = "Bahasa Indonesia";
+const char C_LOCALE_ITALIAN[] = "Italiano";
+const char C_LOCALE_DUTCH[] = "Nederlands";
+const char C_LOCALE_SPANISH[] = "Español";
+const char C_LOCALE_CATALAN[] = "Català";
+const char C_LOCALE_GALICIAN[] = "Galego";
+const char C_LOCALE_PORTUGUESE[] = "Português";
+const char C_LOCALE_PORTUGUESE_BRAZIL[] = "Português brasileiro";
+const char C_LOCALE_POLISH[] = "Polski";
+const char C_LOCALE_LITHUANIAN[] = "Lietuvių";
+const char C_LOCALE_CZECH[] = "Čeština";
+const char C_LOCALE_SLOVAK[] = "Slovenčina";
+const char C_LOCALE_SERBIAN[] = "Српски";
+const char C_LOCALE_CROATIAN[] = "Hrvatski";
+const char C_LOCALE_ARMENIAN[] = "Հայերեն";
+const char C_LOCALE_ROMANIAN[] = "Română";
+const char C_LOCALE_TURKISH[] = "Türkçe";
+const char C_LOCALE_GREEK[] = "Ελληνικά";
+const char C_LOCALE_SWEDISH[] = "Svenska";
+const char C_LOCALE_FINNISH[] = "Suomi";
+const char C_LOCALE_NORWEGIAN[] = "Norsk";
+const char C_LOCALE_DANISH[] = "Dansk";
+const char C_LOCALE_BULGARIAN[] = "Български";
+const char C_LOCALE_UKRAINIAN[] = "Українська";
+const char C_LOCALE_RUSSIAN[] = "Русский";
+const char C_LOCALE_JAPANESE[] = "日本語";
+const char C_LOCALE_HEBREW[] = "עברית";
+const char C_LOCALE_HINDI[] = "हिन्दी, हिंदी";
+const char C_LOCALE_ARABIC[] = "عربي";
+const char C_LOCALE_GEORGIAN[] = "ქართული";
+const char C_LOCALE_BYELORUSSIAN[] = "Беларуская";
+const char C_LOCALE_BASQUE[] = "Euskara";
+const char C_LOCALE_VIETNAMESE[] = "tiếng Việt";
+const char C_LOCALE_CHINESE_TRADITIONAL[] = "中文 (繁體)";
+const char C_LOCALE_CHINESE_SIMPLIFIED[] = "中文 (简体)";
+const char C_LOCALE_KOREAN[] = "한글";
+const char C_THANKS[] =
+    "<p>I would first like to thank sourceforge.net for hosting qBittorrent project and for their support.</p>\
+    <p>I am pleased that people from all over the world are contributing to qBittorrent: Ishan Arora (India), Arnaud Demaizière (France) and Stephanos Antaris (Greece). Their help is greatly appreciated</p>\
+    <p>I also want to thank Στέφανος Αντάρης (santaris@csd.auth.gr) and Mirco Chinelli (infinity89@fastwebmail.it) for working on Mac OS X packaging.</p>\
+	<p>I am grateful to Peter Koeleman (peter@qbittorrent.org) and Mohammad Dib (mdib@qbittorrent.org) for working on qBittorrent port to Windows.</p>\
+	<p>Thanks a lot to our graphist Mateusz Toboła (tobejodok@qbittorrent.org) for his great work.</p>";
+const char C_TRANSLATORS[] =
+    "<ul><li><u>Arabic:</u> SDERAWI (abz8868@msn.com), sn51234 (nesseyan@gmail.com) and  Ibrahim Saed ibraheem_alex(Transifex)</li>\
+    <li><u>Armenian:</u> Hrant Ohanyan (hrantohanyan@mail.am)</li>\
+    <li><u>Basque:</u> Xabier Aramendi (azpidatziak@gmail.com)</li>\
+    <li><u>Belarusian:</u> Mihas Varantsou (meequz@gmail.com)</li>\
+    <li><u>Bulgarian:</u> Tsvetan & Boyko Bankoff (emerge_life@users.sourceforge.net)</li>\
+    <li><u>Catalan:</u> Francisco Luque Contreras (frannoe@ya.com)</li>\
+    <li><u>Chinese (Simplified):</u> Guo Yue (yue.guo0418@gmail.com)</li>\
+    <li><u>Chinese (Traditional):</u> Yi-Shun Wang (dnextstep@gmail.com) and 冥王歐西里斯 s8321414(Transifex)</li>\
+    <li><u>Croatian:</u> Oliver Mucafir (oliver.untwist@gmail.com)</li>\
+    <li><u>Czech:</u> Jirka Vilim (web@tets.cz) and Petr Cernobila abr(Transifex)</li>\
+    <li><u>Danish:</u> Mathias Nielsen (comoneo@gmail.com)</li>\
+    <li><u>Dutch:</u> Pieter Heyvaert (pieter_heyvaert@hotmail.com)</li>\
+    <li><u>English(Australia):</u> Robert Readman readmanr(Transifex)</li>\
+    <li><u>English(United Kingdom):</u> Robert Readman readmanr(Transifex)</li>\
+    <li><u>Finnish:</u> Niklas Laxström (nikerabbit@users.sourceforge.net), Pekka Niemi (pekka.niemi@iki.fi) and Jiri Grönroos artnay(Transifex)</li>\
+    <li><u>Galician:</u> Marcos Lans (marcoslansgarza@gmail.com) and antiparvos(Transifex)</li>\
+    <li><u>Georgian:</u> Beqa Arabuli (arabulibeqa@yahoo.com)</li>\
+    <li><u>German:</u> Niels Hoffmann (zentralmaschine@users.sourceforge.net), schnurlos (schnurlos@gmail.com)</li>\
+    <li><u>Greek:</u> Tsvetan Bankov (emerge_life@users.sourceforge.net), Stephanos Antaris (santaris@csd.auth.gr), sledgehammer999(hammered999@gmail.com), Γιάννης Ανθυμίδης Evropi(Transifex) and Panagiotis Tabakis(tabakisp@gmail.com)</li>\
+    <li><u>Hebrew:</u> David Deutsch (d.deffo@gmail.com)</li>\
+    <li><u>Hungarian:</u> Majoros Péter (majoros.peterj@gmail.com)</li>\
+    <li><u>Italian:</u> bovirus (bovirus@live.it) and Matteo Sechi (bu17714@gmail.com)</li>\
+    <li><u>Japanese:</u> Masato Hashimoto (cabezon.hashimoto@gmail.com)</li>\
+    <li><u>Korean:</u> Jin Woo Sin (jin828sin@users.sourceforge.net)</li>\
+    <li><u>Lithuanian:</u> Naglis Jonaitis (njonaitis@gmail.com)</li>\
+    <li><u>Norwegian:</u> Tomaso</li>\
+    <li><u>Polish:</u> Mariusz Fik (fisiu@opensuse.org)</li>\
+    <li><u>Portuguese:</u> Sérgio Marques smarquespt(Transifex)</li>\
+    <li><u>Portuguese(Brazil):</u> Nick Marinho (nickmarinho@gmail.com)</li>\
+    <li><u>Romanian:</u> Obada Denis (obadadenis@users.sourceforge.net), Adrian Gabor Adriannho(Transifex) and Mihai Coman z0id(Transifex)</li>\
+    <li><u>Russian:</u> Nick Khazov (m2k3d0n at users.sourceforge.net), Alexey Morsov (samurai@ricom.ru), Nick Tiskov Dayman(daymansmail (at) gmail (dot) com), Dmitry DmitryKX(Transifex) and kraleksandr kraleksandr(Transifex)</li>\
+    <li><u>Serbian:</u> Anaximandar Milet (anaximandar@operamail.com)</li>\
+    <li><u>Slovak:</u>  helix84</li>\
+    <li><u>Spanish:</u> Alfredo Monclús (alfrix), Francisco Luque Contreras (frannoe@ya.com), José Antonio Moray moray33(Transifex) and Diego de las Heras(Transifex)</li>\
+    <li><u>Swedish:</u> Daniel Nylander (po@danielnylander.se) and Emil Hammarberg Ooglogput(Transifex)</li>\
+    <li><u>Turkish:</u> Hasan YILMAZ (iletisim@hedefturkce.com) and Erdem Bingöl (erdem84@gmail.com)</li>\
+    <li><u>Ukrainian:</u> Oleh Prypin (blaxpirit@gmail.com)</li>\
+    <li><u>Vietnamese:</u> Anh Phan ppanhh(Transifex)</li></ul>";

--- a/src/core/utils/misc.cpp
+++ b/src/core/utils/misc.cpp
@@ -67,6 +67,7 @@ const int UNLEN = 256;
 #endif // DISABLE_GUI
 
 #include "core/utils/string.h"
+#include "core/unicodestrings.h"
 #include "misc.h"
 
 static struct { const char *source; const char *comment; } units[] = {
@@ -345,7 +346,7 @@ QString Utils::Misc::bcLinkToMagnet(QString bc_link)
 QString Utils::Misc::userFriendlyDuration(qlonglong seconds)
 {
     if (seconds < 0 || seconds >= MAX_ETA)
-        return QString::fromUtf8("∞");
+        return QString::fromUtf8(C_INFINITY);
     if (seconds == 0)
         return "0";
     if (seconds < 60)
@@ -361,7 +362,7 @@ QString Utils::Misc::userFriendlyDuration(qlonglong seconds)
     hours = hours - days * 24;
     if (days < 100)
         return QCoreApplication::translate("misc", "%1d %2h", "e.g: 2days 10hours").arg(QString::number(days)).arg(QString::number(hours));
-    return QString::fromUtf8("∞");
+    return QString::fromUtf8(C_INFINITY);
 }
 
 QString Utils::Misc::getUserIDString()

--- a/src/gui/about.qrc
+++ b/src/gui/about.qrc
@@ -1,6 +1,8 @@
 <!DOCTYPE RCC><RCC version="1.0">
 <qresource>
   <file>gpl.html</file>
+  <file>thanks.html</file>
+  <file>translators.html</file>
 </qresource>
 </RCC>
 

--- a/src/gui/about.ui
+++ b/src/gui/about.ui
@@ -369,7 +369,11 @@
         <number>6</number>
        </property>
        <item>
-        <widget class="QTextBrowser" name="te_thanks"/>
+        <widget class="QTextBrowser" name="te_thanks">
+         <property name="openExternalLinks">
+          <bool>true</bool>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/src/gui/about_imp.h
+++ b/src/gui/about_imp.h
@@ -36,6 +36,7 @@
 #include <QtGlobal>
 #include <libtorrent/version.hpp>
 #include <boost/version.hpp>
+#include "core/unicodestrings.h"
 
 class about : public QDialog, private Ui::AboutDlg{
   Q_OBJECT
@@ -53,7 +54,7 @@ class about : public QDialog, private Ui::AboutDlg{
           QString::fromUtf8("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/REC-html40/strict.dtd\"><html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/css\">p, li { white-space: pre-wrap; }</style></head><body style=\" font-size:11pt; font-weight:400; font-style:normal;\"><p style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">") +
           tr("An advanced BitTorrent client programmed in C++, based on Qt toolkit and libtorrent-rasterbar.") +
           QString::fromUtf8(" <br /><br />") +
-          trUtf8("Copyright ©2006-2015 The qBittorrent project") +
+          trUtf8("Copyright %1 2006-2015 The qBittorrent project").arg(C_COPYRIGHT) +
           QString::fromUtf8("<br /><br />") +
           tr("Home Page: ") +
           QString::fromUtf8("<a href=\"http://www.qbittorrent.org\"><span style=\" text-decoration: underline; color:#0000ff;\">http://www.qbittorrent.org</span></a></p><p style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">") +
@@ -71,53 +72,10 @@ class about : public QDialog, private Ui::AboutDlg{
       //Title
       lb_name->setText(QString::fromUtf8("<b><h1>qBittorrent")+QString::fromUtf8(" " VERSION"</h1></b>"));
       // Thanks
-      QString thanks_txt;
-      thanks_txt += QString::fromUtf8("<p>I would first like to thank sourceforge.net for hosting qBittorrent project and for their support.</p>");
-      thanks_txt += QString::fromUtf8("<p>I am pleased that people from all over the world are contributing to qBittorrent: Ishan Arora (India), Arnaud Demaizière (France) and Stephanos Antaris (Greece). Their help is greatly appreciated</p>");
-      thanks_txt += QString::fromUtf8("<p>I also want to thank Στέφανος Αντάρης (santaris@csd.auth.gr) and Mirco Chinelli (infinity89@fastwebmail.it) for working on Mac OS X packaging.</p>");
-      thanks_txt += QString::fromUtf8("<p>I am grateful to Peter Koeleman (peter@qbittorrent.org) and Mohammad Dib (mdib@qbittorrent.org) for working on qBittorrent port to Windows.</p>");
-      thanks_txt += QString::fromUtf8("<p>Thanks a lot to our graphist Mateusz Toboła (tobejodok@qbittorrent.org) for his great work.</p>");
-      te_thanks->setHtml(thanks_txt);
+      te_thanks->setHtml(QString::fromUtf8(C_THANKS));
       // Translation
       QString trans_txt = "<p>"+tr("I would like to thank the following people who volunteered to translate qBittorrent:")+"</p>";
-      trans_txt += QString::fromUtf8("<ul><li><u>Arabic:</u> SDERAWI (abz8868@msn.com), sn51234 (nesseyan@gmail.com) and  Ibrahim Saed ibraheem_alex(Transifex)</li>\
-          <li><u>Armenian:</u> Hrant Ohanyan (hrantohanyan@mail.am)</li>\
-          <li><u>Basque:</u> Xabier Aramendi (azpidatziak@gmail.com)</li>\
-          <li><u>Belarusian:</u> Mihas Varantsou (meequz@gmail.com)</li>\
-          <li><u>Bulgarian:</u> Tsvetan & Boyko Bankoff (emerge_life@users.sourceforge.net)</li>\
-          <li><u>Catalan:</u> Francisco Luque Contreras (frannoe@ya.com)</li>\
-          <li><u>Chinese (Simplified):</u> Guo Yue (yue.guo0418@gmail.com)</li>\
-          <li><u>Chinese (Traditional):</u> Yi-Shun Wang (dnextstep@gmail.com) and 冥王歐西里斯 s8321414(Transifex)</li>\
-          <li><u>Croatian:</u> Oliver Mucafir (oliver.untwist@gmail.com)</li>\
-          <li><u>Czech:</u> Jirka Vilim (web@tets.cz) and Petr Cernobila abr(Transifex)</li>\
-          <li><u>Danish:</u> Mathias Nielsen (comoneo@gmail.com)</li>\
-          <li><u>Dutch:</u> Pieter Heyvaert (pieter_heyvaert@hotmail.com)</li>\
-          <li><u>English(Australia):</u> Robert Readman readmanr(Transifex)</li>\
-          <li><u>English(United Kingdom):</u> Robert Readman readmanr(Transifex)</li>\
-          <li><u>Finnish:</u> Niklas Laxström (nikerabbit@users.sourceforge.net), Pekka Niemi (pekka.niemi@iki.fi) and Jiri Grönroos artnay(Transifex)</li>\
-          <li><u>Galician:</u> Marcos Lans (marcoslansgarza@gmail.com) and antiparvos(Transifex)</li>\
-          <li><u>Georgian:</u> Beqa Arabuli (arabulibeqa@yahoo.com)</li>\
-          <li><u>German:</u> Niels Hoffmann (zentralmaschine@users.sourceforge.net), schnurlos (schnurlos@gmail.com)</li>\
-          <li><u>Greek:</u> Tsvetan Bankov (emerge_life@users.sourceforge.net), Stephanos Antaris (santaris@csd.auth.gr), sledgehammer999(hammered999@gmail.com), Γιάννης Ανθυμίδης Evropi(Transifex) and Panagiotis Tabakis(tabakisp@gmail.com)</li>\
-          <li><u>Hebrew:</u> David Deutsch (d.deffo@gmail.com)</li>\
-          <li><u>Hungarian:</u> Majoros Péter (majoros.peterj@gmail.com)</li>\
-          <li><u>Italian:</u> bovirus (bovirus@live.it) and Matteo Sechi (bu17714@gmail.com)</li>\
-          <li><u>Japanese:</u> Masato Hashimoto (cabezon.hashimoto@gmail.com)</li>\
-          <li><u>Korean:</u> Jin Woo Sin (jin828sin@users.sourceforge.net)</li>\
-          <li><u>Lithuanian:</u> Naglis Jonaitis (njonaitis@gmail.com)</li>\
-          <li><u>Norwegian:</u> Tomaso</li>\
-          <li><u>Polish:</u> Mariusz Fik (fisiu@opensuse.org)</li>\
-          <li><u>Portuguese:</u> Sérgio Marques smarquespt(Transifex)</li>\
-          <li><u>Portuguese(Brazil):</u> Nick Marinho (nickmarinho@gmail.com)</li>\
-          <li><u>Romanian:</u> Obada Denis (obadadenis@users.sourceforge.net), Adrian Gabor Adriannho(Transifex) and Mihai Coman z0id(Transifex)</li>\
-          <li><u>Russian:</u> Nick Khazov (m2k3d0n at users.sourceforge.net), Alexey Morsov (samurai@ricom.ru), Nick Tiskov Dayman(daymansmail (at) gmail (dot) com), Dmitry DmitryKX(Transifex) and kraleksandr kraleksandr(Transifex)</li>\
-          <li><u>Serbian:</u> Anaximandar Milet (anaximandar@operamail.com)</li>\
-          <li><u>Slovak:</u>  helix84</li>\
-          <li><u>Spanish:</u> Alfredo Monclús (alfrix), Francisco Luque Contreras (frannoe@ya.com), José Antonio Moray moray33(Transifex) and Diego de las Heras(Transifex)</li>\
-          <li><u>Swedish:</u> Daniel Nylander (po@danielnylander.se) and Emil Hammarberg Ooglogput(Transifex)</li>\
-          <li><u>Turkish:</u> Hasan YILMAZ (iletisim@hedefturkce.com) and Erdem Bingöl (erdem84@gmail.com)</li>\
-          <li><u>Ukrainian:</u> Oleh Prypin (blaxpirit@gmail.com)</li>\
-          <li><u>Vietnamese:</u> Anh Phan ppanhh(Transifex)</li></ul>");
+      trans_txt += QString::fromUtf8(C_TRANSLATORS);
       trans_txt += "<p>"+tr("Please contact me if you would like to translate qBittorrent into your own language.")+"</p>";
       te_translation->setHtml(trans_txt);
       // License

--- a/src/gui/about_imp.h
+++ b/src/gui/about_imp.h
@@ -72,17 +72,21 @@ class about : public QDialog, private Ui::AboutDlg{
       //Title
       lb_name->setText(QString::fromUtf8("<b><h1>qBittorrent")+QString::fromUtf8(" " VERSION"</h1></b>"));
       // Thanks
-      te_thanks->setHtml(QString::fromUtf8(C_THANKS));
+      QFile thanksfile(":/thanks.html");
+      if (thanksfile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        te_thanks->setHtml(QString::fromUtf8(thanksfile.readAll().constData()));
+        thanksfile.close();
+      }
       // Translation
-      QString trans_txt = "<p>"+tr("I would like to thank the following people who volunteered to translate qBittorrent:")+"</p>";
-      trans_txt += QString::fromUtf8(C_TRANSLATORS);
-      trans_txt += "<p>"+tr("Please contact me if you would like to translate qBittorrent into your own language.")+"</p>";
-      te_translation->setHtml(trans_txt);
+      QFile translatorsfile(":/translators.html");
+      if (translatorsfile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        te_translation->setHtml(QString::fromUtf8(translatorsfile.readAll().constData()));
+        translatorsfile.close();
+      }
       // License
-      te_license->append(QString::fromUtf8("<a name='top'></a>"));
       QFile licensefile(":/gpl.html");
-      if (licensefile.open(QIODevice::ReadOnly|QIODevice::Text)) {
-        te_license->setHtml(licensefile.readAll());
+      if (licensefile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        te_license->setHtml(QString::fromUtf8(licensefile.readAll().constData()));
         licensefile.close();
       }
       // Libraries

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -44,6 +44,7 @@
 #include "core/bittorrent/torrenthandle.h"
 #include "core/utils/fs.h"
 #include "core/utils/misc.h"
+#include "core/unicodestrings.h"
 #include "guiiconprovider.h"
 #include "autoexpandabledialog.h"
 #include "messageboxraised.h"
@@ -248,7 +249,7 @@ void AddNewTorrentDialog::showEvent(QShowEvent *event)
 void AddNewTorrentDialog::showAdvancedSettings(bool show)
 {
     if (show) {
-        ui->adv_button->setText(QString::fromUtf8("▲"));
+        ui->adv_button->setText(QString::fromUtf8(C_UP));
         ui->settings_group->setVisible(true);
         ui->info_group->setVisible(true);
         if (m_hasMetadata && (m_torrentInfo.filesCount() > 1)) {
@@ -262,7 +263,7 @@ void AddNewTorrentDialog::showAdvancedSettings(bool show)
         static_cast<QVBoxLayout*>(layout())->insertWidget(layout()->indexOf(ui->never_show_cb) + 1, ui->adv_button);
     }
     else {
-        ui->adv_button->setText(QString::fromUtf8("▼"));
+        ui->adv_button->setText(QString::fromUtf8(C_DOWN));
         ui->settings_group->setVisible(false);
         ui->info_group->setVisible(false);
         ui->buttonsHLayout->insertWidget(0, layout()->takeAt(layout()->indexOf(ui->never_show_cb) + 1)->widget());

--- a/src/gui/gpl.html
+++ b/src/gui/gpl.html
@@ -1,3 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>License</title>
+</head>
+<body>
 <p>qBittorrent is licensed under the GNU General Public License version 2 with the
 addition of the following special exception:</p>
 <p>
@@ -505,4 +512,6 @@ consider it more useful to permit linking proprietary applications with the
 library.  If this is what you want to do, use the 
 <a href="http://www.gnu.org/licenses/lgpl.html">GNU Lesser General Public License</a> 
 instead of this License.
-</p> 
+</p>
+</body>
+</html>

--- a/src/gui/options_imp.cpp
+++ b/src/gui/options_imp.cpp
@@ -27,6 +27,7 @@
  *
  * Contact : chris@qbittorrent.org
  */
+
 #include <QTextStream>
 #include <QFileDialog>
 #include <QMessageBox>
@@ -50,6 +51,7 @@
 #include "core/bittorrent/session.h"
 #include "guiiconprovider.h"
 #include "core/net/dnsupdater.h"
+#include "core/unicodestrings.h"
 
 #ifndef QT_NO_OPENSSL
 #include <QSslKey>
@@ -1327,56 +1329,56 @@ QString options_imp::languageToLocalizedString(const QLocale &locale)
   switch(locale.language()) {
   case QLocale::English: {
     if (locale.country() == QLocale::Australia)
-      return "English(Australia)";
+      return QString::fromUtf8(C_LOCALE_ENGLISH_AUSTRALIA);
     else if (locale.country() == QLocale::UnitedKingdom)
-      return "English(United Kingdom)";
-    return "English";
+      return QString::fromUtf8(C_LOCALE_ENGLISH_UNITEDKINGDOM);
+    return QString::fromUtf8(C_LOCALE_ENGLISH);
   }
-  case QLocale::French: return QString::fromUtf8("Français");
-  case QLocale::German: return QString::fromUtf8("Deutsch");
-  case QLocale::Hungarian: return QString::fromUtf8("Magyar");
-  case QLocale::Indonesian: return QString::fromUtf8("Bahasa Indonesia");
-  case QLocale::Italian: return QString::fromUtf8("Italiano");
-  case QLocale::Dutch: return QString::fromUtf8("Nederlands");
-  case QLocale::Spanish: return QString::fromUtf8("Español");
-  case QLocale::Catalan: return QString::fromUtf8("Català");
-  case QLocale::Galician: return QString::fromUtf8("Galego");
+  case QLocale::French: return QString::fromUtf8(C_LOCALE_FRENCH);
+  case QLocale::German: return QString::fromUtf8(C_LOCALE_GERMAN);
+  case QLocale::Hungarian: return QString::fromUtf8(C_LOCALE_HUNGARIAN);
+  case QLocale::Indonesian: return QString::fromUtf8(C_LOCALE_INDONESIAN);
+  case QLocale::Italian: return QString::fromUtf8(C_LOCALE_ITALIAN);
+  case QLocale::Dutch: return QString::fromUtf8(C_LOCALE_DUTCH);
+  case QLocale::Spanish: return QString::fromUtf8(C_LOCALE_SPANISH);
+  case QLocale::Catalan: return QString::fromUtf8(C_LOCALE_CATALAN);
+  case QLocale::Galician: return QString::fromUtf8(C_LOCALE_GALICIAN);
   case QLocale::Portuguese: {
     if (locale.country() == QLocale::Brazil)
-      return QString::fromUtf8("Português brasileiro");
-    return QString::fromUtf8("Português");
+      return QString::fromUtf8(C_LOCALE_PORTUGUESE_BRAZIL);
+    return QString::fromUtf8(C_LOCALE_PORTUGUESE);
   }
-  case QLocale::Polish: return QString::fromUtf8("Polski");
-  case QLocale::Lithuanian: return QString::fromUtf8("Lietuvių");
-  case QLocale::Czech: return QString::fromUtf8("Čeština");
-  case QLocale::Slovak: return QString::fromUtf8("Slovenčina");
-  case QLocale::Serbian: return QString::fromUtf8("Српски");
-  case QLocale::Croatian: return QString::fromUtf8("Hrvatski");
-  case QLocale::Armenian: return QString::fromUtf8("Հայերեն");
-  case QLocale::Romanian: return QString::fromUtf8("Română");
-  case QLocale::Turkish: return QString::fromUtf8("Türkçe");
-  case QLocale::Greek: return QString::fromUtf8("Ελληνικά");
-  case QLocale::Swedish: return QString::fromUtf8("Svenska");
-  case QLocale::Finnish: return QString::fromUtf8("Suomi");
-  case QLocale::Norwegian: return QString::fromUtf8("Norsk");
-  case QLocale::Danish: return QString::fromUtf8("Dansk");
-  case QLocale::Bulgarian: return QString::fromUtf8("Български");
-  case QLocale::Ukrainian: return QString::fromUtf8("Українська");
-  case QLocale::Russian: return QString::fromUtf8("Русский");
-  case QLocale::Japanese: return QString::fromUtf8("日本語");
-  case QLocale::Hebrew: return QString::fromUtf8("עברית");
-  case QLocale::Hindi: return QString::fromUtf8("हिन्दी, हिंदी");
-  case QLocale::Arabic: return QString::fromUtf8("عربي");
-  case QLocale::Georgian: return QString::fromUtf8("ქართული");
-  case QLocale::Byelorussian: return QString::fromUtf8("Беларуская");
-  case QLocale::Basque: return QString::fromUtf8("Euskara");
-  case QLocale::Vietnamese: return QString::fromUtf8("tiếng Việt");
+  case QLocale::Polish: return QString::fromUtf8(C_LOCALE_POLISH);
+  case QLocale::Lithuanian: return QString::fromUtf8(C_LOCALE_LITHUANIAN);
+  case QLocale::Czech: return QString::fromUtf8(C_LOCALE_CZECH);
+  case QLocale::Slovak: return QString::fromUtf8(C_LOCALE_SLOVAK);
+  case QLocale::Serbian: return QString::fromUtf8(C_LOCALE_SERBIAN);
+  case QLocale::Croatian: return QString::fromUtf8(C_LOCALE_CROATIAN);
+  case QLocale::Armenian: return QString::fromUtf8(C_LOCALE_ARMENIAN);
+  case QLocale::Romanian: return QString::fromUtf8(C_LOCALE_ROMANIAN);
+  case QLocale::Turkish: return QString::fromUtf8(C_LOCALE_TURKISH);
+  case QLocale::Greek: return QString::fromUtf8(C_LOCALE_GREEK);
+  case QLocale::Swedish: return QString::fromUtf8(C_LOCALE_SWEDISH);
+  case QLocale::Finnish: return QString::fromUtf8(C_LOCALE_FINNISH);
+  case QLocale::Norwegian: return QString::fromUtf8(C_LOCALE_NORWEGIAN);
+  case QLocale::Danish: return QString::fromUtf8(C_LOCALE_DANISH);
+  case QLocale::Bulgarian: return QString::fromUtf8(C_LOCALE_BULGARIAN);
+  case QLocale::Ukrainian: return QString::fromUtf8(C_LOCALE_UKRAINIAN);
+  case QLocale::Russian: return QString::fromUtf8(C_LOCALE_RUSSIAN);
+  case QLocale::Japanese: return QString::fromUtf8(C_LOCALE_JAPANESE);
+  case QLocale::Hebrew: return QString::fromUtf8(C_LOCALE_HEBREW);
+  case QLocale::Hindi: return QString::fromUtf8(C_LOCALE_HINDI);
+  case QLocale::Arabic: return QString::fromUtf8(C_LOCALE_ARABIC);
+  case QLocale::Georgian: return QString::fromUtf8(C_LOCALE_GEORGIAN);
+  case QLocale::Byelorussian: return QString::fromUtf8(C_LOCALE_BYELORUSSIAN);
+  case QLocale::Basque: return QString::fromUtf8(C_LOCALE_BASQUE);
+  case QLocale::Vietnamese: return QString::fromUtf8(C_LOCALE_VIETNAMESE);
   case QLocale::Chinese: {
     if (locale.script() == QLocale::SimplifiedHanScript)
-      return QString::fromUtf8("中文 (简体)");
-    return QString::fromUtf8("中文 (繁體)");
+      return QString::fromUtf8(C_LOCALE_CHINESE_SIMPLIFIED);
+    return QString::fromUtf8(C_LOCALE_CHINESE_TRADITIONAL);
   }
-  case QLocale::Korean: return QString::fromUtf8("한글");
+  case QLocale::Korean: return QString::fromUtf8(C_LOCALE_KOREAN);
   default: {
     // Fallback to English
     const QString eng_lang = QLocale::languageToString(locale.language());

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -47,6 +47,7 @@
 #include "core/utils/fs.h"
 #include "core/utils/misc.h"
 #include "core/utils/string.h"
+#include "core/unicodestrings.h"
 #include "proplistdelegate.h"
 #include "torrentcontentfiltermodel.h"
 #include "torrentcontentmodel.h"
@@ -355,8 +356,8 @@ void PropertiesWidget::loadDynamicData() {
         wasted->setText(Utils::Misc::friendlyUnit(m_torrent->wastedSize()));
         upTotal->setText(Utils::Misc::friendlyUnit(m_torrent->totalUpload()) + " ("+Utils::Misc::friendlyUnit(m_torrent->totalPayloadUpload())+" "+tr("this session")+")");
         dlTotal->setText(Utils::Misc::friendlyUnit(m_torrent->totalDownload()) + " ("+Utils::Misc::friendlyUnit(m_torrent->totalPayloadDownload())+" "+tr("this session")+")");
-        lbl_uplimit->setText(m_torrent->uploadLimit() <= 0 ? QString::fromUtf8("∞") : Utils::Misc::friendlyUnit(m_torrent->uploadLimit())+tr("/s", "/second (i.e. per second)"));
-        lbl_dllimit->setText(m_torrent->downloadLimit() <= 0 ? QString::fromUtf8("∞") : Utils::Misc::friendlyUnit(m_torrent->downloadLimit())+tr("/s", "/second (i.e. per second)"));
+        lbl_uplimit->setText(m_torrent->uploadLimit() <= 0 ? QString::fromUtf8(C_INFINITY) : Utils::Misc::friendlyUnit(m_torrent->uploadLimit())+tr("/s", "/second (i.e. per second)"));
+        lbl_dllimit->setText(m_torrent->downloadLimit() <= 0 ? QString::fromUtf8(C_INFINITY) : Utils::Misc::friendlyUnit(m_torrent->downloadLimit())+tr("/s", "/second (i.e. per second)"));
         QString elapsed_txt = Utils::Misc::userFriendlyDuration(m_torrent->activeTime());
         if (m_torrent->isSeed())
             elapsed_txt += " ("+tr("Seeded for %1", "e.g. Seeded for 3m10s").arg(Utils::Misc::userFriendlyDuration(m_torrent->seedingTime()))+")";
@@ -371,7 +372,7 @@ void PropertiesWidget::loadDynamicData() {
 
         // Update ratio info
         const qreal ratio = m_torrent->realRatio();
-        shareRatio->setText(ratio > BitTorrent::TorrentHandle::MAX_RATIO ? QString::fromUtf8("∞") : Utils::String::fromDouble(ratio, 2));
+        shareRatio->setText(ratio > BitTorrent::TorrentHandle::MAX_RATIO ? QString::fromUtf8(C_INFINITY) : Utils::String::fromDouble(ratio, 2));
 
         label_seeds_val->setText(QString::number(m_torrent->seedsCount()) + " " + tr("(%1 total)","e.g. (10 total)").arg(QString::number(m_torrent->totalSeedsCount())));
         label_peers_val->setText(QString::number(m_torrent->leechsCount()) + " " + tr("(%1 total)","e.g. (10 total)").arg(QString::number(m_torrent->totalLeechersCount())));

--- a/src/gui/speedlimitdlg.cpp
+++ b/src/gui/speedlimitdlg.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "speedlimitdlg.h"
+#include "core/unicodestrings.h"
 
 SpeedLimitDialog::SpeedLimitDialog(QWidget *parent): QDialog(parent)
 {
@@ -69,7 +70,7 @@ void SpeedLimitDialog::updateSpinValue(int val) const
     qDebug("Called updateSpinValue with %d", val);
     if (val <= 0) {
         spinBandwidth->setValue(0);
-        spinBandwidth->setSpecialValueText(QString::fromUtf8("∞"));
+        spinBandwidth->setSpecialValueText(QString::fromUtf8(C_INFINITY));
         spinBandwidth->setSuffix(QString::fromUtf8(""));
     }
     else {
@@ -82,7 +83,7 @@ void SpeedLimitDialog::updateSliderValue(int val) const
 {
     if (val <= 0) {
         spinBandwidth->setValue(0);
-        spinBandwidth->setSpecialValueText(QString::fromUtf8("∞"));
+        spinBandwidth->setSpecialValueText(QString::fromUtf8(C_INFINITY));
         spinBandwidth->setSuffix(QString::fromUtf8(""));
     }
     if (val > bandwidthSlider->maximum())

--- a/src/gui/thanks.html
+++ b/src/gui/thanks.html
@@ -10,5 +10,6 @@
     <p>I also want to thank Στέφανος Αντάρης (santaris@csd.auth.gr) and Mirco Chinelli (infinity89@fastwebmail.it) for working on Mac OS X packaging.</p>
     <p>I am grateful to Peter Koeleman (peter@qbittorrent.org) and Mohammad Dib (mdib@qbittorrent.org) for working on qBittorrent port to Windows.</p>
     <p>Thanks a lot to our graphist Mateusz Toboła (tobejodok@qbittorrent.org) for his great work.</p>
+    <p>Thanks to all contributors on <a href="https://github.com/qbittorrent/qBittorrent/graphs/contributors">GitHub</a>.</p>
 </body>
 </html>

--- a/src/gui/thanks.html
+++ b/src/gui/thanks.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Thanks</title>
+</head>
+<body>
+    <p>I would first like to thank sourceforge.net for hosting qBittorrent project and for their support.</p>
+    <p>I am pleased that people from all over the world are contributing to qBittorrent: Ishan Arora (India), Arnaud Demaizière (France) and Stephanos Antaris (Greece). Their help is greatly appreciated</p>
+    <p>I also want to thank Στέφανος Αντάρης (santaris@csd.auth.gr) and Mirco Chinelli (infinity89@fastwebmail.it) for working on Mac OS X packaging.</p>
+    <p>I am grateful to Peter Koeleman (peter@qbittorrent.org) and Mohammad Dib (mdib@qbittorrent.org) for working on qBittorrent port to Windows.</p>
+    <p>Thanks a lot to our graphist Mateusz Toboła (tobejodok@qbittorrent.org) for his great work.</p>
+</body>
+</html>

--- a/src/gui/transferlistdelegate.cpp
+++ b/src/gui/transferlistdelegate.cpp
@@ -39,6 +39,7 @@
 #include "torrentmodel.h"
 #include "core/bittorrent/session.h"
 #include "core/bittorrent/torrenthandle.h"
+#include "core/unicodestrings.h"
 
 #ifdef Q_OS_WIN
 #if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
@@ -151,7 +152,7 @@ void TransferListDelegate::paint(QPainter * painter, const QStyleOptionViewItem 
     QItemDelegate::drawBackground(painter, opt, index);
     const qlonglong limit = index.data().toLongLong();
     opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
-    QItemDelegate::drawDisplay(painter, opt, opt.rect, limit > 0 ? Utils::String::fromDouble(limit/1024., 1) + " " + tr("KiB/s", "KiB/second (.i.e per second)") : QString::fromUtf8("∞"));
+    QItemDelegate::drawDisplay(painter, opt, opt.rect, limit > 0 ? Utils::String::fromDouble(limit/1024., 1) + " " + tr("KiB/s", "KiB/second (.i.e per second)") : QString::fromUtf8(C_INFINITY));
     break;
   }
   case TorrentModel::TR_TIME_ELAPSED: {
@@ -174,7 +175,7 @@ void TransferListDelegate::paint(QPainter * painter, const QStyleOptionViewItem 
       opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
       const qreal ratio = index.data().toDouble();
       QItemDelegate::drawDisplay(painter, opt, opt.rect,
-                                 ((ratio == -1) || (ratio > BitTorrent::TorrentHandle::MAX_RATIO)) ? QString::fromUtf8("∞") : Utils::String::fromDouble(ratio, 2));
+                                 ((ratio == -1) || (ratio > BitTorrent::TorrentHandle::MAX_RATIO)) ? QString::fromUtf8(C_INFINITY) : Utils::String::fromDouble(ratio, 2));
       break;
     }
   case TorrentModel::TR_PRIORITY: {

--- a/src/gui/translators.html
+++ b/src/gui/translators.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Translators</title>
+</head>
+<body>
+    <p>I would like to thank the following people who volunteered to translate qBittorrent:</p>
+    <ul>
+        <li><u>Arabic:</u> SDERAWI (abz8868@msn.com), sn51234 (nesseyan@gmail.com) and Ibrahim Saed ibraheem_alex(Transifex)</li>
+        <li><u>Armenian:</u> Hrant Ohanyan (hrantohanyan@mail.am)</li>
+        <li><u>Basque:</u> Xabier Aramendi (azpidatziak@gmail.com)</li>
+        <li><u>Belarusian:</u> Mihas Varantsou (meequz@gmail.com)</li>
+        <li><u>Bulgarian:</u> Tsvetan & Boyko Bankoff (emerge_life@users.sourceforge.net)</li>
+        <li><u>Catalan:</u> Francisco Luque Contreras (frannoe@ya.com)</li>
+        <li><u>Chinese (Simplified):</u> Guo Yue (yue.guo0418@gmail.com)</li>
+        <li><u>Chinese (Traditional):</u> Yi-Shun Wang (dnextstep@gmail.com) and 冥王歐西里斯 s8321414(Transifex)</li>
+        <li><u>Croatian:</u> Oliver Mucafir (oliver.untwist@gmail.com)</li>
+        <li><u>Czech:</u> Jirka Vilim (web@tets.cz) and Petr Cernobila abr(Transifex)</li>
+        <li><u>Danish:</u> Mathias Nielsen (comoneo@gmail.com)</li>
+        <li><u>Dutch:</u> Pieter Heyvaert (pieter_heyvaert@hotmail.com)</li>
+        <li><u>English(Australia):</u> Robert Readman readmanr(Transifex)</li>
+        <li><u>English(United Kingdom):</u> Robert Readman readmanr(Transifex)</li>
+        <li><u>Finnish:</u> Niklas Laxström (nikerabbit@users.sourceforge.net), Pekka Niemi (pekka.niemi@iki.fi) and Jiri Grönroos artnay(Transifex)</li>
+        <li><u>Galician:</u> Marcos Lans (marcoslansgarza@gmail.com) and antiparvos(Transifex)</li>
+        <li><u>Georgian:</u> Beqa Arabuli (arabulibeqa@yahoo.com)</li>
+        <li><u>German:</u> Niels Hoffmann (zentralmaschine@users.sourceforge.net), schnurlos (schnurlos@gmail.com)</li>
+        <li><u>Greek:</u> Tsvetan Bankov (emerge_life@users.sourceforge.net), Stephanos Antaris (santaris@csd.auth.gr), sledgehammer999(hammered999@gmail.com), Γιάννης Ανθυμίδης Evropi(Transifex) and Panagiotis Tabakis(tabakisp@gmail.com)</li>
+        <li><u>Hebrew:</u> David Deutsch (d.deffo@gmail.com)</li>
+        <li><u>Hungarian:</u> Majoros Péter (majoros.peterj@gmail.com)</li>
+        <li><u>Italian:</u> bovirus (bovirus@live.it) and Matteo Sechi (bu17714@gmail.com)</li>
+        <li><u>Japanese:</u> Masato Hashimoto (cabezon.hashimoto@gmail.com)</li>
+        <li><u>Korean:</u> Jin Woo Sin (jin828sin@users.sourceforge.net)</li>
+        <li><u>Lithuanian:</u> Naglis Jonaitis (njonaitis@gmail.com)</li>
+        <li><u>Norwegian:</u> Tomaso</li>
+        <li><u>Polish:</u> Mariusz Fik (fisiu@opensuse.org)</li>
+        <li><u>Portuguese:</u> Sérgio Marques smarquespt(Transifex)</li>
+        <li><u>Portuguese(Brazil):</u> Nick Marinho (nickmarinho@gmail.com)</li>
+        <li><u>Romanian:</u> Obada Denis (obadadenis@users.sourceforge.net), Adrian Gabor Adriannho(Transifex) and Mihai Coman z0id(Transifex)</li>
+        <li><u>Russian:</u> Nick Khazov (m2k3d0n at users.sourceforge.net), Alexey Morsov (samurai@ricom.ru), Nick Tiskov Dayman(daymansmail (at) gmail (dot) com), Dmitry DmitryKX(Transifex) and kraleksandr kraleksandr(Transifex)</li>
+        <li><u>Serbian:</u> Anaximandar Milet (anaximandar@operamail.com)</li>
+        <li><u>Slovak:</u> helix84</li>
+        <li><u>Spanish:</u> Alfredo Monclús (alfrix), Francisco Luque Contreras (frannoe@ya.com), José Antonio Moray moray33(Transifex) and Diego de las Heras(Transifex)</li>
+        <li><u>Swedish:</u> Daniel Nylander (po@danielnylander.se) and Emil Hammarberg Ooglogput(Transifex)</li>
+        <li><u>Turkish:</u> Hasan YILMAZ (iletisim@hedefturkce.com) and Erdem Bingöl (erdem84@gmail.com)</li>
+        <li><u>Ukrainian:</u> Oleh Prypin (blaxpirit@gmail.com)</li>
+        <li><u>Vietnamese:</u> Anh Phan ppanhh(Transifex)</li>
+    </ul>
+    <p>Please contact me if you would like to translate qBittorrent into your own language.</p>
+</body>
+</html>


### PR DESCRIPTION
Still one warning remains, but there isn't any unicode character at there:
```
gui\options_imp.cpp(621) : warning C4819: The file contains a character that cannot be represented in the current code page (950). Save the file in Unicode format to prevent data loss
```
I have no idea how to fix it...