### PR TITLE
Minor style change in transfer list & filters

### DIFF
--- a/src/core/utils/misc.cpp
+++ b/src/core/utils/misc.cpp
@@ -43,6 +43,7 @@
 #else
 #include <QApplication>
 #include <QDesktopWidget>
+#include <QStyle>
 #endif
 
 #ifdef Q_OS_WIN
@@ -543,3 +544,12 @@ void Utils::Misc::msleep(unsigned long msecs)
 {
     SleeperThread::msleep(msecs);
 }
+
+#ifndef DISABLE_GUI
+QSize Utils::Misc::smallIconSize()
+{
+    // Get DPI scaled icon size (device-dependent), see QT source
+    int s = QApplication::style()->pixelMetric(QStyle::PM_SmallIconSize);
+    return QSize(s, s);
+}
+#endif

--- a/src/core/utils/misc.h
+++ b/src/core/utils/misc.h
@@ -54,6 +54,7 @@ namespace Utils
         void shutdownComputer(ShutdownAction action);
         // Get screen center
         QPoint screenCenter(QWidget *win);
+        QSize smallIconSize();
 #endif
         int pythonVersion();
         QString pythonExecutable();

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -179,7 +179,7 @@ MainWindow::MainWindow(QWidget *parent)
 
     hSplitter = new QSplitter(Qt::Vertical, this);
     hSplitter->setChildrenCollapsible(false);
-    hSplitter->setContentsMargins(0, 4, 0, 0);
+    hSplitter->setFrameShape(QFrame::NoFrame);
 
     // Name filter
     search_filter = new LineEdit(this);
@@ -193,6 +193,7 @@ MainWindow::MainWindow(QWidget *parent)
 
     // Transfer List tab
     transferList = new TransferListWidget(hSplitter, this);
+    //transferList->setStyleSheet("QTreeView {border: none;}");  // borderless
     properties = new PropertiesWidget(hSplitter, this, transferList);
     transferListFilters = new TransferListFiltersWidget(vSplitter, transferList);
     hSplitter->addWidget(transferList);

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -81,7 +81,7 @@ QSize FiltersBase::sizeHint() const
     QSize size;
     // Height should be exactly the height of the content
     size.setHeight((sizeHintForRow(0) * count()) + (2 * frameWidth()) + 6);
-    // Width should be exactly the height of the content
+    // Width should be exactly the width of the content
     size.setWidth(sizeHintForColumn(0) + (2 * frameWidth()));
     return size;
 }
@@ -108,7 +108,7 @@ StatusFiltersWidget::StatusFiltersWidget(QWidget *parent, TransferListWidget *tr
     setUniformItemSizes(true);
     setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     // Height is fixed (sizeHint().height() is used)
-    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
     setSpacing(0);
     connect(BitTorrent::Session::instance(), SIGNAL(torrentsUpdated(const BitTorrent::TorrentStatusReport &)), SLOT(updateTorrentNumbers(const BitTorrent::TorrentStatusReport &)));
 
@@ -176,7 +176,7 @@ LabelFiltersList::LabelFiltersList(QWidget *parent, TransferListWidget *transfer
     , m_totalTorrents(0)
     , m_totalLabeled(0)
 {
-    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
     connect(BitTorrent::Session::instance(), SIGNAL(torrentLabelChanged(BitTorrent::TorrentHandle *const, QString)), SLOT(torrentChangedLabel(BitTorrent::TorrentHandle *const, QString)));
 
@@ -420,7 +420,7 @@ TrackerFiltersList::TrackerFiltersList(QWidget *parent, TransferListWidget *tran
     : FiltersBase(parent, transferList)
     , m_totalTorrents(0)
 {
-    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
     QListWidgetItem *allTrackers = new QListWidgetItem(this);
     allTrackers->setData(Qt::DisplayRole, QVariant(tr("All (0)", "this is for the label filter")));
@@ -778,6 +778,7 @@ TransferListFiltersWidget::TransferListFiltersWidget(QWidget *parent, TransferLi
     vLayout->setContentsMargins(0, 4, 0, 0);
     frameLayout->setContentsMargins(0, 4, 0, 0);
     frameLayout->setSpacing(2);
+    frameLayout->setAlignment(Qt::AlignLeft | Qt::AlignTop);
 
     frame->setLayout(frameLayout);
     scroll->setWidget(frame);
@@ -808,8 +809,6 @@ TransferListFiltersWidget::TransferListFiltersWidget(QWidget *parent, TransferLi
 
     trackerFilters = new TrackerFiltersList(this, transferList);
     frameLayout->addWidget(trackerFilters);
-
-    frameLayout->addStretch();
 
     connect(statusLabel, SIGNAL(toggled(bool)), statusFilters, SLOT(toggleFilter(bool)));
     connect(statusLabel, SIGNAL(toggled(bool)), pref, SLOT(setStatusFilterState(const bool)));

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -67,7 +67,7 @@ FiltersBase::FiltersBase(QWidget *parent, TransferListWidget *transferList)
     setUniformItemSizes(true);
     setSpacing(0);
 
-    setIconSize(QSize(16, 16));
+    setIconSize(Utils::Misc::smallIconSize());
 
 #if defined(Q_OS_MAC)
     setAttribute(Qt::WA_MacShowFocusRect, false);

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -767,16 +767,13 @@ TransferListFiltersWidget::TransferListFiltersWidget(QWidget *parent, TransferLi
     font.setBold(true);
     font.setCapitalization(QFont::AllUppercase);
 
-    frame->setFrameShadow(QFrame::Plain);
-    frame->setFrameShape(QFrame::NoFrame);
-    scroll->setFrameShadow(QFrame::Plain);
-    scroll->setFrameShape(QFrame::NoFrame);
-    scroll->setStyleSheet("QFrame { background: transparent; }");
     scroll->setWidgetResizable(true);
     scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
-    vLayout->setContentsMargins(0, 4, 0, 0);
-    frameLayout->setContentsMargins(0, 4, 0, 0);
+    setStyleSheet("QFrame {background: transparent;}");
+    scroll->setStyleSheet("QFrame {border: none;}");
+    vLayout->setContentsMargins(0, 0, 0, 0);
+    frameLayout->setContentsMargins(0, 2, 0, 0);
     frameLayout->setSpacing(2);
     frameLayout->setAlignment(Qt::AlignLeft | Qt::AlignTop);
 
@@ -784,7 +781,6 @@ TransferListFiltersWidget::TransferListFiltersWidget(QWidget *parent, TransferLi
     scroll->setWidget(frame);
     vLayout->addWidget(scroll);
     setLayout(vLayout);
-    setContentsMargins(0,0,0,0);
 
     QCheckBox * statusLabel = new QCheckBox(tr("Status"), this);
     statusLabel->setChecked(pref->getStatusFilterState());

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -60,15 +60,20 @@ FiltersBase::FiltersBase(QWidget *parent, TransferListWidget *transferList)
     : QListWidget(parent)
     , transferList(transferList)
 {
-    setStyleSheet("QListWidget { background: transparent; border: 0 }");
-#if defined(Q_OS_MAC)
-    setAttribute(Qt::WA_MacShowFocusRect, false);
-#endif
+    setFrameShape(QFrame::NoFrame);
     setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    setContextMenuPolicy(Qt::CustomContextMenu);
+    setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    setUniformItemSizes(true);
+    setSpacing(0);
 
     setIconSize(QSize(16, 16));
 
+#if defined(Q_OS_MAC)
+    setAttribute(Qt::WA_MacShowFocusRect, false);
+#endif
+
+    setContextMenuPolicy(Qt::CustomContextMenu);
     connect(this, SIGNAL(customContextMenuRequested(QPoint)), SLOT(showMenu(QPoint)));
     connect(this, SIGNAL(currentRowChanged(int)), SLOT(applyFilter(int)));
 
@@ -80,9 +85,9 @@ QSize FiltersBase::sizeHint() const
 {
     QSize size;
     // Height should be exactly the height of the content
-    size.setHeight((sizeHintForRow(0) * count()) + (2 * frameWidth()) + 6);
+    size.setHeight(((sizeHintForRow(0) + 2 * spacing()) * (count() + 0.5)));
     // Width should be exactly the width of the content
-    size.setWidth(sizeHintForColumn(0) + (2 * frameWidth()));
+    size.setWidth(sizeHintForColumn(0));
     return size;
 }
 
@@ -105,11 +110,6 @@ void FiltersBase::toggleFilter(bool checked)
 StatusFiltersWidget::StatusFiltersWidget(QWidget *parent, TransferListWidget *transferList)
     : FiltersBase(parent, transferList)
 {
-    setUniformItemSizes(true);
-    setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    // Height is fixed (sizeHint().height() is used)
-    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-    setSpacing(0);
     connect(BitTorrent::Session::instance(), SIGNAL(torrentsUpdated(const BitTorrent::TorrentStatusReport &)), SLOT(updateTorrentNumbers(const BitTorrent::TorrentStatusReport &)));
 
     // Add status filters
@@ -176,8 +176,6 @@ LabelFiltersList::LabelFiltersList(QWidget *parent, TransferListWidget *transfer
     , m_totalTorrents(0)
     , m_totalLabeled(0)
 {
-    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-
     connect(BitTorrent::Session::instance(), SIGNAL(torrentLabelChanged(BitTorrent::TorrentHandle *const, QString)), SLOT(torrentChangedLabel(BitTorrent::TorrentHandle *const, QString)));
 
     // Add Label filters
@@ -420,8 +418,6 @@ TrackerFiltersList::TrackerFiltersList(QWidget *parent, TransferListWidget *tran
     : FiltersBase(parent, transferList)
     , m_totalTorrents(0)
 {
-    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-
     QListWidgetItem *allTrackers = new QListWidgetItem(this);
     allTrackers->setData(Qt::DisplayRole, QVariant(tr("All (0)", "this is for the label filter")));
     allTrackers->setData(Qt::DecorationRole, GuiIconProvider::instance()->getIcon("network-server"));


### PR DESCRIPTION
Removed borders around transfer list & filter list.
The spacing between different set of filters is a bit larger, IMO, it was too tight before.

If any change is not preferable, it can be reverted.

Old:
![old](https://cloud.githubusercontent.com/assets/9395168/8716542/f0b62278-2bc4-11e5-8ab5-d862ae7e5cb5.png)

New:
![new](https://cloud.githubusercontent.com/assets/9395168/8716543/f43a1d00-2bc4-11e5-8942-b45854860b72.png)

-----

UPDATE:

After commit `Move "Lock qBittorrent" button to the right of "Options..." buttion`:
![1](https://cloud.githubusercontent.com/assets/9395168/8702190/dfe55f76-2b48-11e5-81a2-16910ae9b0df.png)

-----