### PR TITLE
Add 16 KiB, 8 MiB and 16 MiB piece sizes in Torrent Creator

### DIFF
--- a/src/gui/torrentcreator/createtorrent.ui
+++ b/src/gui/torrentcreator/createtorrent.ui
@@ -158,8 +158,13 @@
         <bool>false</bool>
        </property>
        <property name="currentIndex">
-        <number>3</number>
+        <number>4</number>
        </property>
+       <item>
+        <property name="text">
+         <string>16 KiB</string>
+        </property>
+       </item>
        <item>
         <property name="text">
          <string>32 KiB</string>
@@ -198,6 +203,16 @@
        <item>
         <property name="text">
          <string>4 MiB</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>8 MiB</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>16 MiB</string>
         </property>
        </item>
       </widget>

--- a/src/gui/torrentcreator/torrentcreatordlg.cpp
+++ b/src/gui/torrentcreator/torrentcreatordlg.cpp
@@ -59,7 +59,7 @@ TorrentCreatorDlg::TorrentCreatorDlg(QWidget *parent): QDialog(parent), creatorT
   showProgressBar(false);
   loadTrackerList();
   // Piece sizes
-  m_piece_sizes << 32 << 64 << 128 << 256 << 512 << 1024 << 2048 << 4096;
+  m_piece_sizes << 16 << 32 << 64 << 128 << 256 << 512 << 1024 << 2048 << 4096 << 8192 << 16384;
   loadSettings();
   show();
 }


### PR DESCRIPTION
Backport of #3291 for v3.2.0.