### PR TITLE
Implement an option to disable confirmation of torrent recheck

### DIFF
--- a/src/core/preferences.cpp
+++ b/src/core/preferences.cpp
@@ -1894,6 +1894,16 @@ void Preferences::setConfirmTorrentDeletion(bool enabled)
     setValue("Preferences/Advanced/confirmTorrentDeletion", enabled);
 }
 
+bool Preferences::confirmTorrentRecheck() const
+{
+    return value("Preferences/Advanced/confirmTorrentRecheck", true).toBool();
+}
+
+void Preferences::setConfirmTorrentRecheck(bool enabled)
+{
+    setValue("Preferences/Advanced/confirmTorrentRecheck", enabled);
+}
+
 TrayIcon::Style Preferences::trayIconStyle() const
 {
     return TrayIcon::Style(value("Preferences/Advanced/TrayIconStyle", TrayIcon::NORMAL).toInt());

--- a/src/core/preferences.h
+++ b/src/core/preferences.h
@@ -424,6 +424,8 @@ public:
 #endif
     bool confirmTorrentDeletion() const;
     void setConfirmTorrentDeletion(bool enabled);
+    bool confirmTorrentRecheck() const;
+    void setConfirmTorrentRecheck(bool enabled);
     TrayIcon::Style trayIconStyle() const;
     void setTrayIconStyle(TrayIcon::Style style);
 

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -20,7 +20,7 @@ enum AdvSettingsRows {DISK_CACHE, DISK_CACHE_TTL, OS_CACHE, SAVE_RESUME_DATA_INT
                     #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
                       USE_ICON_THEME,
                     #endif
-                      CONFIRM_DELETE_TORRENT, TRACKER_EXCHANGE,
+                      CONFIRM_DELETE_TORRENT, CONFIRM_RECHECK_TORRENT, TRACKER_EXCHANGE,
                       ANNOUNCE_ALL_TRACKERS,
                       ROW_COUNT};
 
@@ -31,7 +31,7 @@ private:
   QSpinBox spin_cache, spin_save_resume_data_interval, outgoing_ports_min, outgoing_ports_max, spin_list_refresh, spin_maxhalfopen, spin_tracker_port;
   QCheckBox cb_os_cache, cb_ignore_limits_lan, cb_recheck_completed, cb_resolve_countries, cb_resolve_hosts,
   cb_super_seeding, cb_program_notifications, cb_tracker_status, cb_confirm_torrent_deletion,
-  cb_enable_tracker_ext, cb_listen_ipv6;
+  cb_confirm_torrent_recheck, cb_enable_tracker_ext, cb_listen_ipv6;
   QComboBox combo_iface;
   QSpinBox spin_cache_ttl;
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
@@ -121,6 +121,7 @@ public slots:
     pref->useSystemIconTheme(cb_use_icon_theme.isChecked());
 #endif
     pref->setConfirmTorrentDeletion(cb_confirm_torrent_deletion.isChecked());
+    pref->setConfirmTorrentRecheck(cb_confirm_torrent_recheck.isChecked());
     // Tracker exchange
     pref->setTrackerExchangeEnabled(cb_enable_tracker_ext.isChecked());
     pref->setAnnounceToAllTrackers(cb_announce_all_trackers.isChecked());
@@ -287,6 +288,9 @@ private slots:
     // Torrent deletion confirmation
     cb_confirm_torrent_deletion.setChecked(pref->confirmTorrentDeletion());
     setRow(CONFIRM_DELETE_TORRENT, tr("Confirm torrent deletion"), &cb_confirm_torrent_deletion);
+    // Torrent recheck confirmation
+    cb_confirm_torrent_recheck.setChecked(pref->confirmTorrentRecheck());
+    setRow(CONFIRM_RECHECK_TORRENT, tr("Confirm torrent recheck"), &cb_confirm_torrent_recheck);
     // Tracker exchange
     cb_enable_tracker_ext.setChecked(pref->trackerExchangeEnabled());
     setRow(TRACKER_EXCHANGE, tr("Exchange trackers with other peers"), &cb_enable_tracker_ext);

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -478,8 +478,10 @@ void TransferListWidget::setMaxRatioSelectedTorrents()
 
 void TransferListWidget::recheckSelectedTorrents()
 {
-    QMessageBox::StandardButton ret = QMessageBox::question(this, tr("Recheck confirmation"), tr("Are you sure you want to recheck the selected torrent(s)?"), QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
-    if (ret != QMessageBox::Yes) return;
+    if (Preferences::instance()->confirmTorrentRecheck()) {
+        QMessageBox::StandardButton ret = QMessageBox::question(this, tr("Recheck confirmation"), tr("Are you sure you want to recheck the selected torrent(s)?"), QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+        if (ret != QMessageBox::Yes) return;
+    }
 
     foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents())
         torrent->forceRecheck();


### PR DESCRIPTION
Adds this line in Advanced options

![Advanced options](https://cloud.githubusercontent.com/assets/371383/8581439/608c0894-25c9-11e5-93a7-7e93eded16bb.png)

to disable this dialog:

![Confirmation](http://i.imgur.com/ng1tlSS.png)

> MrKB: Is there a way to make qBittorrent stop asking me if I'm sure I want to perform a recheck? It's annoying: http://i.imgur.com/ng1tlSS.png
> Sc0rpius: I don't see why you need to recheck, since if you know your bittorrent protocol, you should know that every piece is checked after download
> Sc0rpius: recheck is only useful if: a.- you deleted a file externally from qBittorrent by mistake, b.- a fatal error happened (like full disk)
> MrKB: Because sometimes I need to verify that something I did didn't change the files I'm seeding.
> Sc0rpius: you shouldn't work in the files directly, you should seed copies that you're not gonna use
> MrKB: For example: fb2k not messing with ID3 tags of albums I'm still seeding.
> MrKB: Rechecking isn't anything bad in the first place, I don't see why it even needs to get confirmed