### PR TITLE
Fix progress calculation in Content tab. Closes #2639 Closes #2752

### DIFF
--- a/src/gui/torrentcontentmodelfolder.cpp
+++ b/src/gui/torrentcontentmodelfolder.cpp
@@ -136,19 +136,19 @@ void TorrentContentModelFolder::setPriority(int new_prio, bool update_parent)
 
 void TorrentContentModelFolder::recalculateProgress()
 {
-  qreal progress = 0;
-  int count = 0;
+  qreal tProgress = 0;
+  qulonglong tSize = 0;
   foreach (TorrentContentModelItem* child, m_childItems) {
     if (child->priority() != prio::IGNORED) {
       if (child->itemType() == FolderType)
         static_cast<TorrentContentModelFolder*>(child)->recalculateProgress();
-      progress += child->progress();
-      ++count;
+      tProgress += child->progress() * child->size();
+      tSize += child->size();
     }
   }
 
-  if (!isRootItem() && (count > 0)) {
-    m_progress = progress / count;
+  if (!isRootItem() && tSize > 0) {
+    m_progress = tProgress / tSize;
     Q_ASSERT(m_progress <= 1.);
   }
 }


### PR DESCRIPTION
**With the old code:**
![](http://i.imgur.com/OtSmkAN.png)
The old code was completely wrong because it's calculating the average value of progress without weighting the size.  In the screenshot the real total progress it's around 33.7 % but as you can see the result is 83.4 % The code reach this number doing:
100 + 33.7 + 100 + 100 = 333.7
333.7 / 4 = 83.4 %

**With the new code:**
33.7 * size2 gives you the downloaded size of these file.
total_size = size1 + size2 + size3 + size4
(100 * size1 + 33.7 * size2 + 100 * size3 + 100 * size4) / total_size = 33.7 %
