### PR TITLE
Fix translated localhost address (::ffff:127.0.0.1) is not recognized

### DIFF
--- a/src/webui/abstractwebapplication.cpp
+++ b/src/webui/abstractwebapplication.cpp
@@ -316,7 +316,8 @@ void AbstractWebApplication::increaseFailedAttempts()
 bool AbstractWebApplication::isAuthNeeded()
 {
     return (env_.clientAddress != QHostAddress::LocalHost
-            && env_.clientAddress != QHostAddress::LocalHostIPv6)
+            && env_.clientAddress != QHostAddress::LocalHostIPv6
+            && env_.clientAddress != QHostAddress("::ffff:127.0.0.1"))
             || Preferences::instance()->isWebUiLocalAuthEnabled();
 }
 


### PR DESCRIPTION
Environment:
Firefox 39.0 & qbtorrent running in ArchLinux.

When I use Firefox 39.0 to connect to `127.0.0.1:8080` (webUI), log from qbtorrent says the source IP is from `::ffff:127.0.0.1`.

This could be a QT issue, but we can also fix it locally.

See: https://en.wikipedia.org/wiki/IPv6_transition_mechanism#Stateless_IP.2FICMP_Translation
