### PR TITLE
Use `rootPath()` in save path field

### DIFF
--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -252,7 +252,7 @@ BitTorrent::TorrentHandle *PropertiesWidget::getCurrentTorrent() const
 void PropertiesWidget::updateSavePath(BitTorrent::TorrentHandle *const torrent)
 {
   if (m_torrent == torrent) {
-    save_path->setText(m_torrent->savePathParsed());
+    save_path->setText(m_torrent->rootPath());
   }
 }
 

--- a/src/gui/torrentmodel.cpp
+++ b/src/gui/torrentmodel.cpp
@@ -221,7 +221,7 @@ QVariant TorrentModel::data(const QModelIndex &index, int role) const
     case TR_TIME_ELAPSED:
         return (role == Qt::DisplayRole) ? torrent->activeTime() : torrent->seedingTime();
     case TR_SAVE_PATH:
-        return torrent->savePathParsed();
+        return torrent->rootPath();
     case TR_COMPLETED:
         return torrent->completedSize();
     case TR_RATIO_LIMIT:


### PR DESCRIPTION
IMHO, this is more correct.

Example:
```
Single-file torrent
Before: /home/asdf/Desktop/torrent_test/ubuntu-14.04.2-desktop-amd64.iso
After:  /home/asdf/Desktop/torrent_test/

Multi-file torrent
Before: /home/asdf/Desktop/torrent_test
After:  /home/asdf/Desktop/torrent_test/Wallpapers_HQ    <--this is the root folder of the downloaded data
```