### PR TITLE
Change Queue buttons order in the Toolbar (GUI & Web UI)

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -218,7 +218,7 @@ MainWindow::MainWindow(QWidget *parent)
 
     vboxLayout->addWidget(tabs);
 
-    prioSeparator = toolBar->insertSeparator(actionBottomPriority);
+    prioSeparator = toolBar->insertSeparator(actionTopPriority);
     prioSeparatorMenu = menu_Edit->insertSeparator(actionTopPriority);
 
     // Transfer list slots

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -131,10 +131,10 @@
    <addaction name="separator"/>
    <addaction name="actionStart"/>
    <addaction name="actionPause"/>
-   <addaction name="actionBottomPriority"/>
-   <addaction name="actionDecreasePriority"/>
-   <addaction name="actionIncreasePriority"/>
    <addaction name="actionTopPriority"/>
+   <addaction name="actionIncreasePriority"/>
+   <addaction name="actionDecreasePriority"/>
+   <addaction name="actionBottomPriority"/>
    <addaction name="separator"/>
    <addaction name="actionOptions"/>
    <addaction name="actionLock_qBittorrent"/>

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -89,10 +89,10 @@
                 <a id="resumeButton" class="divider"><img class="mochaToolButton" title="QBT_TR(Resume)QBT_TR" src="theme/media-playback-start" alt="QBT_TR(Resume)QBT_TR" width="24" height="24" onload="fixPNG(this)"/></a>
                 <a id="pauseButton"><img class="mochaToolButton" title="QBT_TR(Pause)QBT_TR" src="theme/media-playback-pause" alt="QBT_TR(Pause)QBT_TR" width="24" height="24" onload="fixPNG(this)"/></a>
                 <span id="queueingButtons">
-                    <a id="bottomPrioButton" class="divider"><img class="mochaToolButton" title="QBT_TR(Move to bottom)QBT_TR" src="theme/go-bottom" alt="QBT_TR(Move to bottom)QBT_TR" width="24" height="24" onload="fixPNG(this)"/></a>
-                    <a id="decreasePrioButton"><img class="mochaToolButton" title="QBT_TR(Decrease priority)QBT_TR" src="theme/go-down" alt="QBT_TR(Decrease priority)QBT_TR" width="24" height="24" onload="fixPNG(this)"/></a>
-                    <a id="increasePrioButton"><img class="mochaToolButton" title="QBT_TR(Increase priority)QBT_TR" src="theme/go-up" alt="QBT_TR(Increase priority)QBT_TR" width="24" height="24" onload="fixPNG(this)"/></a>
-                    <a id="topPrioButton"><img class="mochaToolButton" title="QBT_TR(Move to top)QBT_TR" src="theme/go-top" alt="QBT_TR(Move to top)QBT_TR" width="24" height="24" onload="fixPNG(this)"/></a>
+                    <a id="topPrioButton" class="divider"><img class="mochaToolButton" title="QBT_TR(Top Priority)QBT_TR" src="theme/go-top" alt="QBT_TR(Top Priority)QBT_TR" width="24" height="24" onload="fixPNG(this)"/></a>
+                    <a id="increasePrioButton"><img class="mochaToolButton" title="QBT_TR(Increase Priority)QBT_TR" src="theme/go-up" alt="QBT_TR(Increase Priority)QBT_TR" width="24" height="24" onload="fixPNG(this)"/></a>
+                    <a id="decreasePrioButton"><img class="mochaToolButton" title="QBT_TR(Decrease Priority)QBT_TR" src="theme/go-down" alt="QBT_TR(Decrease Priority)QBT_TR" width="24" height="24" onload="fixPNG(this)"/></a>
+                    <a id="bottomPrioButton"><img class="mochaToolButton" title="QBT_TR(Minimum Priority)QBT_TR" src="theme/go-bottom" alt="QBT_TR(Minimum Priority)QBT_TR" width="24" height="24" onload="fixPNG(this)"/></a>
                 </span>
                 <a id="preferencesButton" class="divider"><img class="mochaToolButton" title="QBT_TR(Options)QBT_TR" src="theme/preferences-system" alt="QBT_TR(Options)QBT_TR" width="24" height="24" onload="fixPNG(this)"/></a>
             </div>


### PR DESCRIPTION
The most used button is Top priority so must be the first.

**Previous order was:**
Lowest Decrease Increase Maximum (priority)
**Now:**
Maximum Increase Decrease Lowest (priority)

Other clients:
* http://i49.tinypic.com/2rzxduv.png
* http://imagenes.es.sftcdn.net/es/scrn/43000/43961/utorrent-21-700x386.png
* https://wiki.vuze.com/mediawiki/images/b/b9/Vuze43TorrentDetailsSources.png