### PR TITLE
Drop libtorrent 0.16.x support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ env:
     # Uncomment when Travis upgraded "Ubuntu 12.04 LTS" to a newer version whose repo will have a more up-to-date libtorrent package
     #- lt_branch=dist gui=true
     #- lt_branch=dist gui=false
-    - lt_branch=RC_0_16 gui=true
-    - lt_branch=RC_0_16 gui=false
     - lt_branch=RC_1_0 gui=true
     - lt_branch=RC_1_0 gui=false
   global:
@@ -37,9 +35,6 @@ before_install:
   - if ! $gui; then qbtconf="$qbtconf --disable-gui" ; else export "DISPLAY=:99.0" && /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16 ; fi
   - qbtconf="$qbtconf --with-qt4"
   - ltconf=" --with-libgeoip=system"
-
-  # Options for specific branches
-  - if [[ "$lt_branch" == "RC_0_16" ]]; then qbtconf="$qbtconf --with-libtorrent-rasterbar0.16" ; fi
 
   # Print settings
   - echo $lt_branch

--- a/INSTALL
+++ b/INSTALL
@@ -14,15 +14,11 @@ qBittorrent - A BitTorrent client in C++ / Qt4
 
     - pkg-config executable
 
-    - libtorrent-rasterbar by Arvid Norberg (>= 0.15.0)
+    - libtorrent-rasterbar by Arvid Norberg (>= 1.0.0)
         -> http://www.libtorrent.net
         Be careful: another library (the one used by rTorrent) uses a similar name.
 
-    - libboost 1.34.x (libboost-filesystem°) + libasio
-      or
-    - libboost >= 1.35.x (libboost-system, libboost-filesystem°)
-      
-    °libboost-filesystem is not needed if libtorrent-rasterbar >= v0.16.x is used
+    - libboost >= 1.35.x (libboost-system)
 
     - python >= 2.3 (needed by search engine)
         * Run time only dependency
@@ -44,7 +40,7 @@ qBittorrent - A BitTorrent client in C++ / Qt4
 
     - pkg-config executable
 
-    - libtorrent-rasterbar by Arvid Norberg (>= v0.15.0)
+    - libtorrent-rasterbar by Arvid Norberg (>= v1.0.0)
         -> http://www.libtorrent.net
         Be careful: another library (the one used by rTorrent) uses a similar name.
 

--- a/configure
+++ b/configure
@@ -601,10 +601,10 @@ EXPAND_BINDIR
 EXPAND_PREFIX
 zlib_LIBS
 zlib_CFLAGS
-qjson_LIBS
-qjson_CFLAGS
 libtorrent_LIBS
 libtorrent_CFLAGS
+qjson_LIBS
+qjson_CFLAGS
 BOOST_SYSTEM_LIB
 BOOST_LDFLAGS
 BOOST_CPPFLAGS
@@ -715,7 +715,6 @@ enable_option_checking
 enable_dependency_tracking
 enable_silent_rules
 with_qt5
-with_libtorrent_rasterbar0_16
 with_qtsingleapplication
 with_qjson
 enable_debug
@@ -742,10 +741,10 @@ PKG_CONFIG
 PKG_CONFIG_PATH
 PKG_CONFIG_LIBDIR
 QT_QMAKE
-libtorrent_CFLAGS
-libtorrent_LIBS
 qjson_CFLAGS
 qjson_LIBS
+libtorrent_CFLAGS
+libtorrent_LIBS
 zlib_CFLAGS
 zlib_LIBS'
 
@@ -1383,9 +1382,6 @@ Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --with-qt5              Compile using Qt5 (default=no)
-  --with-libtorrent-rasterbar0.16
-                          Compile using libtorrent-rasterbar 0.16.x series
-                          (default=no)
   --with-qtsingleapplication=[system|shipped]
                           Use the shipped qtsingleapplication library or the
                           system one (default=shipped)
@@ -1422,13 +1418,13 @@ Some influential environment variables:
   PKG_CONFIG_LIBDIR
               path overriding pkg-config's built-in search path
   QT_QMAKE    value of moc_location for QtCore >= 4.8.0, overriding pkg-config
+  qjson_CFLAGS
+              C compiler flags for qjson, overriding pkg-config
+  qjson_LIBS  linker flags for qjson, overriding pkg-config
   libtorrent_CFLAGS
               C compiler flags for libtorrent, overriding pkg-config
   libtorrent_LIBS
               linker flags for libtorrent, overriding pkg-config
-  qjson_CFLAGS
-              C compiler flags for qjson, overriding pkg-config
-  qjson_LIBS  linker flags for qjson, overriding pkg-config
   zlib_CFLAGS C compiler flags for zlib, overriding pkg-config
   zlib_LIBS   linker flags for zlib, overriding pkg-config
 
@@ -2805,8 +2801,8 @@ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
-# Expand $ac_aux_dir to an absolute path.
-am_aux_dir=`cd "$ac_aux_dir" && pwd`
+# expand $ac_aux_dir to an absolute path
+am_aux_dir=`cd $ac_aux_dir && pwd`
 
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
@@ -4167,7 +4163,6 @@ fi
 
 
 
-
 # Define --wth-* and --enable-* arguments
 
 
@@ -4176,15 +4171,6 @@ if test "${with_qt5+set}" = set; then :
   withval=$with_qt5;
 else
   with_qt5=no
-fi
-
-
-
-# Check whether --with-libtorrent-rasterbar0.16 was given.
-if test "${with_libtorrent_rasterbar0_16+set}" = set; then :
-  withval=$with_libtorrent_rasterbar0_16;
-else
-  with_libtorrent_rasterbar0_16=no
 fi
 
 
@@ -5279,205 +5265,6 @@ $as_echo "$as_me: Boost.System LIB: $BOOST_SYSTEM_LIB" >&6;}
       LIBS="$BOOST_SYSTEM_LIB $LIBS"
 fi
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to compile using libtorrent-rasterbar 0.16.x" >&5
-$as_echo_n "checking whether to compile using libtorrent-rasterbar 0.16.x... " >&6; }
-case "x$with_libtorrent_rasterbar0_16" in #(
-  "xno") :
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-pkg_failed=no
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for libtorrent" >&5
-$as_echo_n "checking for libtorrent... " >&6; }
-
-if test -n "$libtorrent_CFLAGS"; then
-    pkg_cv_libtorrent_CFLAGS="$libtorrent_CFLAGS"
- elif test -n "$PKG_CONFIG"; then
-    if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libtorrent-rasterbar >= 1.0.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libtorrent-rasterbar >= 1.0.0") 2>&5
-  ac_status=$?
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }; then
-  pkg_cv_libtorrent_CFLAGS=`$PKG_CONFIG --cflags "libtorrent-rasterbar >= 1.0.0" 2>/dev/null`
-		      test "x$?" != "x0" && pkg_failed=yes
-else
-  pkg_failed=yes
-fi
- else
-    pkg_failed=untried
-fi
-if test -n "$libtorrent_LIBS"; then
-    pkg_cv_libtorrent_LIBS="$libtorrent_LIBS"
- elif test -n "$PKG_CONFIG"; then
-    if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libtorrent-rasterbar >= 1.0.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libtorrent-rasterbar >= 1.0.0") 2>&5
-  ac_status=$?
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }; then
-  pkg_cv_libtorrent_LIBS=`$PKG_CONFIG --libs "libtorrent-rasterbar >= 1.0.0" 2>/dev/null`
-		      test "x$?" != "x0" && pkg_failed=yes
-else
-  pkg_failed=yes
-fi
- else
-    pkg_failed=untried
-fi
-
-
-
-if test $pkg_failed = yes; then
-   	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
-        _pkg_short_errors_supported=yes
-else
-        _pkg_short_errors_supported=no
-fi
-        if test $_pkg_short_errors_supported = yes; then
-	        libtorrent_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libtorrent-rasterbar >= 1.0.0" 2>&1`
-        else
-	        libtorrent_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libtorrent-rasterbar >= 1.0.0" 2>&1`
-        fi
-	# Put the nasty error message in config.log where it belongs
-	echo "$libtorrent_PKG_ERRORS" >&5
-
-	as_fn_error $? "Package requirements (libtorrent-rasterbar >= 1.0.0) were not met:
-
-$libtorrent_PKG_ERRORS
-
-Consider adjusting the PKG_CONFIG_PATH environment variable if you
-installed software in a non-standard prefix.
-
-Alternatively, you may set the environment variables libtorrent_CFLAGS
-and libtorrent_LIBS to avoid the need to call pkg-config.
-See the pkg-config man page for more details." "$LINENO" 5
-elif test $pkg_failed = untried; then
-     	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-	{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "The pkg-config script could not be found or is too old.  Make sure it
-is in your PATH or set the PKG_CONFIG environment variable to the full
-path to pkg-config.
-
-Alternatively, you may set the environment variables libtorrent_CFLAGS
-and libtorrent_LIBS to avoid the need to call pkg-config.
-See the pkg-config man page for more details.
-
-To get pkg-config, see <http://pkg-config.freedesktop.org/>.
-See \`config.log' for more details" "$LINENO" 5; }
-else
-	libtorrent_CFLAGS=$pkg_cv_libtorrent_CFLAGS
-	libtorrent_LIBS=$pkg_cv_libtorrent_LIBS
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-	CPPFLAGS="$libtorrent_CFLAGS $CPPFLAGS"
-                               LIBS="$libtorrent_LIBS $LIBS"
-fi ;; #(
-  "xyes") :
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-
-pkg_failed=no
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for libtorrent" >&5
-$as_echo_n "checking for libtorrent... " >&6; }
-
-if test -n "$libtorrent_CFLAGS"; then
-    pkg_cv_libtorrent_CFLAGS="$libtorrent_CFLAGS"
- elif test -n "$PKG_CONFIG"; then
-    if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libtorrent-rasterbar >= 0.16.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libtorrent-rasterbar >= 0.16.0") 2>&5
-  ac_status=$?
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }; then
-  pkg_cv_libtorrent_CFLAGS=`$PKG_CONFIG --cflags "libtorrent-rasterbar >= 0.16.0" 2>/dev/null`
-		      test "x$?" != "x0" && pkg_failed=yes
-else
-  pkg_failed=yes
-fi
- else
-    pkg_failed=untried
-fi
-if test -n "$libtorrent_LIBS"; then
-    pkg_cv_libtorrent_LIBS="$libtorrent_LIBS"
- elif test -n "$PKG_CONFIG"; then
-    if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libtorrent-rasterbar >= 0.16.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libtorrent-rasterbar >= 0.16.0") 2>&5
-  ac_status=$?
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }; then
-  pkg_cv_libtorrent_LIBS=`$PKG_CONFIG --libs "libtorrent-rasterbar >= 0.16.0" 2>/dev/null`
-		      test "x$?" != "x0" && pkg_failed=yes
-else
-  pkg_failed=yes
-fi
- else
-    pkg_failed=untried
-fi
-
-
-
-if test $pkg_failed = yes; then
-   	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
-        _pkg_short_errors_supported=yes
-else
-        _pkg_short_errors_supported=no
-fi
-        if test $_pkg_short_errors_supported = yes; then
-	        libtorrent_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libtorrent-rasterbar >= 0.16.0" 2>&1`
-        else
-	        libtorrent_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libtorrent-rasterbar >= 0.16.0" 2>&1`
-        fi
-	# Put the nasty error message in config.log where it belongs
-	echo "$libtorrent_PKG_ERRORS" >&5
-
-	as_fn_error $? "Package requirements (libtorrent-rasterbar >= 0.16.0) were not met:
-
-$libtorrent_PKG_ERRORS
-
-Consider adjusting the PKG_CONFIG_PATH environment variable if you
-installed software in a non-standard prefix.
-
-Alternatively, you may set the environment variables libtorrent_CFLAGS
-and libtorrent_LIBS to avoid the need to call pkg-config.
-See the pkg-config man page for more details." "$LINENO" 5
-elif test $pkg_failed = untried; then
-     	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-	{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "The pkg-config script could not be found or is too old.  Make sure it
-is in your PATH or set the PKG_CONFIG environment variable to the full
-path to pkg-config.
-
-Alternatively, you may set the environment variables libtorrent_CFLAGS
-and libtorrent_LIBS to avoid the need to call pkg-config.
-See the pkg-config man page for more details.
-
-To get pkg-config, see <http://pkg-config.freedesktop.org/>.
-See \`config.log' for more details" "$LINENO" 5; }
-else
-	libtorrent_CFLAGS=$pkg_cv_libtorrent_CFLAGS
-	libtorrent_LIBS=$pkg_cv_libtorrent_LIBS
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-	CPPFLAGS="$libtorrent_CFLAGS $CPPFLAGS"
-                                LIBS="$libtorrent_LIBS $LIBS"
-fi ;; #(
-  *) :
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_libtorrent_rasterbar0_16" >&5
-$as_echo "$with_libtorrent_rasterbar0_16" >&6; }
-        as_fn_error $? "Unknown option \"$with_libtorrent_rasterbar0_16\". Use either \"yes\" or \"no\"." "$LINENO" 5 ;;
-esac
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking which qtsingleapplication to use" >&5
 $as_echo_n "checking which qtsingleapplication to use... " >&6; }
 case "x$with_qtsingleapplication" in #(
@@ -5605,6 +5392,99 @@ $as_echo "$with_qjson" >&6; }
               as_fn_error $? "Unknown option \"$with_qjson\". Use either \"system\" or \"shipped\"." "$LINENO" 5 ;;
 esac
 
+fi
+
+
+pkg_failed=no
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for libtorrent" >&5
+$as_echo_n "checking for libtorrent... " >&6; }
+
+if test -n "$libtorrent_CFLAGS"; then
+    pkg_cv_libtorrent_CFLAGS="$libtorrent_CFLAGS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libtorrent-rasterbar >= 1.0.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libtorrent-rasterbar >= 1.0.0") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_libtorrent_CFLAGS=`$PKG_CONFIG --cflags "libtorrent-rasterbar >= 1.0.0" 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+if test -n "$libtorrent_LIBS"; then
+    pkg_cv_libtorrent_LIBS="$libtorrent_LIBS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libtorrent-rasterbar >= 1.0.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libtorrent-rasterbar >= 1.0.0") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_libtorrent_LIBS=`$PKG_CONFIG --libs "libtorrent-rasterbar >= 1.0.0" 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+
+
+
+if test $pkg_failed = yes; then
+   	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+        _pkg_short_errors_supported=yes
+else
+        _pkg_short_errors_supported=no
+fi
+        if test $_pkg_short_errors_supported = yes; then
+	        libtorrent_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libtorrent-rasterbar >= 1.0.0" 2>&1`
+        else
+	        libtorrent_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libtorrent-rasterbar >= 1.0.0" 2>&1`
+        fi
+	# Put the nasty error message in config.log where it belongs
+	echo "$libtorrent_PKG_ERRORS" >&5
+
+	as_fn_error $? "Package requirements (libtorrent-rasterbar >= 1.0.0) were not met:
+
+$libtorrent_PKG_ERRORS
+
+Consider adjusting the PKG_CONFIG_PATH environment variable if you
+installed software in a non-standard prefix.
+
+Alternatively, you may set the environment variables libtorrent_CFLAGS
+and libtorrent_LIBS to avoid the need to call pkg-config.
+See the pkg-config man page for more details." "$LINENO" 5
+elif test $pkg_failed = untried; then
+     	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+	{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "The pkg-config script could not be found or is too old.  Make sure it
+is in your PATH or set the PKG_CONFIG environment variable to the full
+path to pkg-config.
+
+Alternatively, you may set the environment variables libtorrent_CFLAGS
+and libtorrent_LIBS to avoid the need to call pkg-config.
+See the pkg-config man page for more details.
+
+To get pkg-config, see <http://pkg-config.freedesktop.org/>.
+See \`config.log' for more details" "$LINENO" 5; }
+else
+	libtorrent_CFLAGS=$pkg_cv_libtorrent_CFLAGS
+	libtorrent_LIBS=$pkg_cv_libtorrent_LIBS
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+	CPPFLAGS="$libtorrent_CFLAGS $CPPFLAGS"
+                  LIBS="$libtorrent_LIBS $LIBS"
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -18,12 +18,6 @@ AC_ARG_WITH(qt5,
             [],
             [with_qt5=no])
 
-AC_ARG_WITH(libtorrent-rasterbar0.16,
-            [AS_HELP_STRING([--with-libtorrent-rasterbar0.16],
-                            [Compile using libtorrent-rasterbar 0.16.x series (default=no)])],
-            [],
-            [with_libtorrent_rasterbar0_16=no])
-
 AC_ARG_WITH(qtsingleapplication,
             [AS_HELP_STRING([--with-qtsingleapplication=@<:@system|shipped@:>@],
                             [Use the shipped qtsingleapplication library or the system one (default=shipped)])],
@@ -101,7 +95,6 @@ AS_CASE(["x$enable_gui"],
         ["xno"],
               [AC_MSG_RESULT([no])
               enable_qt_dbus=[no]
-              enable_geoip_database=[no]
               QBT_ADD_CONFIG="$QBT_ADD_CONFIG nogui"],
         [AC_MSG_RESULT([$enable_gui])
         AC_MSG_ERROR([Unknown option "$enable_gui". Use either "yes" or "no".])])
@@ -175,23 +168,6 @@ AS_IF([test "x$BOOST_SYSTEM_LIB" = "x"],
       [AC_MSG_NOTICE([Boost.System LIB: $BOOST_SYSTEM_LIB])
       LIBS="$BOOST_SYSTEM_LIB $LIBS"])
 
-AC_MSG_CHECKING([whether to compile using libtorrent-rasterbar 0.16.x])
-AS_CASE(["x$with_libtorrent_rasterbar0_16"],
-        ["xno"],
-              [AC_MSG_RESULT([no])
-              PKG_CHECK_MODULES(libtorrent,
-                               [libtorrent-rasterbar >= 1.0.0],
-                               [CPPFLAGS="$libtorrent_CFLAGS $CPPFLAGS"
-                               LIBS="$libtorrent_LIBS $LIBS"])],
-        ["xyes"],
-               [AC_MSG_RESULT([yes])
-               PKG_CHECK_MODULES(libtorrent,
-                                [libtorrent-rasterbar >= 0.16.0],
-                                [CPPFLAGS="$libtorrent_CFLAGS $CPPFLAGS"
-                                LIBS="$libtorrent_LIBS $LIBS"])],
-        [AC_MSG_RESULT([$with_libtorrent_rasterbar0_16])
-        AC_MSG_ERROR([Unknown option "$with_libtorrent_rasterbar0_16". Use either "yes" or "no".])])
-
 AC_MSG_CHECKING([which qtsingleapplication to use])
 AS_CASE(["x$with_qtsingleapplication"],
         ["xshipped"],
@@ -219,6 +195,11 @@ AS_IF([test "x$with_qt5" = "xno"],
               [AC_MSG_RESULT([$with_qjson])
               AC_MSG_ERROR([Unknown option "$with_qjson". Use either "system" or "shipped".])])
      ])
+
+PKG_CHECK_MODULES(libtorrent,
+                  [libtorrent-rasterbar >= 1.0.0],
+                  [CPPFLAGS="$libtorrent_CFLAGS $CPPFLAGS"
+                  LIBS="$libtorrent_LIBS $LIBS"])
 
 PKG_CHECK_MODULES(zlib,
                  [zlib],

--- a/src/core/bittorrent/infohash.h
+++ b/src/core/bittorrent/infohash.h
@@ -29,13 +29,7 @@
 #ifndef BITTORRENT_INFOHASH_H
 #define BITTORRENT_INFOHASH_H
 
-#include <libtorrent/version.hpp>
-#if LIBTORRENT_VERSION_NUM < 10000
-#include <libtorrent/peer_id.hpp>
-#else
 #include <libtorrent/sha1_hash.hpp>
-#endif
-
 #include <QString>
 
 namespace BitTorrent

--- a/src/core/bittorrent/magneturi.cpp
+++ b/src/core/bittorrent/magneturi.cpp
@@ -53,10 +53,8 @@ MagnetUri::MagnetUri(const QString &url)
     foreach (const std::string &tracker, m_addTorrentParams.trackers)
         m_trackers.append(Utils::String::fromStdString(tracker));
 
-#if LIBTORRENT_VERSION_NUM >= 10000
     foreach (const std::string &urlSeed, m_addTorrentParams.url_seeds)
         m_urlSeeds.append(QUrl(urlSeed.c_str()));
-#endif
 }
 
 bool MagnetUri::isValid() const

--- a/src/core/bittorrent/peerinfo.cpp
+++ b/src/core/bittorrent/peerinfo.cpp
@@ -26,8 +26,6 @@
  * exception statement from your version.
  */
 
-#include <libtorrent/version.hpp>
-
 #include "core/net/geoipmanager.h"
 #include "core/utils/string.h"
 #include "peerinfo.h"
@@ -169,20 +167,12 @@ bool PeerInfo::useI2PSocket() const
 
 bool PeerInfo::useUTPSocket() const
 {
-#if LIBTORRENT_VERSION_NUM < 10000
-    return (m_nativeInfo.connection_type & libt::peer_info::bittorrent_utp);
-#else
     return (m_nativeInfo.flags & libt::peer_info::utp_socket);
-#endif
 }
 
 bool PeerInfo::useSSLSocket() const
 {
-#if LIBTORRENT_VERSION_NUM < 10000
-    return false;
-#else
     return (m_nativeInfo.flags & libt::peer_info::ssl_socket);
-#endif
 }
 
 bool PeerInfo::isRC4Encrypted() const
@@ -239,12 +229,7 @@ QBitArray PeerInfo::pieces() const
 {
     QBitArray result(m_nativeInfo.pieces.size());
 
-#if LIBTORRENT_VERSION_NUM < 10000
-    typedef size_t pieces_size_t;
-#else
-    typedef int pieces_size_t;
-#endif
-    for (pieces_size_t i = 0; i < m_nativeInfo.pieces.size(); ++i)
+    for (int i = 0; i < m_nativeInfo.pieces.size(); ++i)
         result.setBit(i, m_nativeInfo.pieces.get_bit(i));
 
     return result;
@@ -252,11 +237,7 @@ QBitArray PeerInfo::pieces() const
 
 QString PeerInfo::connectionType() const
 {
-#if LIBTORRENT_VERSION_NUM < 10000
-    if (m_nativeInfo.connection_type & libt::peer_info::bittorrent_utp)
-#else
     if (m_nativeInfo.flags & libt::peer_info::utp_socket)
-#endif
         return QString::fromUtf8("μTP");
 
     QString connection;

--- a/src/core/bittorrent/torrentcreatorthread.cpp
+++ b/src/core/bittorrent/torrentcreatorthread.cpp
@@ -28,7 +28,6 @@
  * Contact : chris@qbittorrent.org
  */
 
-#include <libtorrent/version.hpp>
 #include <libtorrent/entry.hpp>
 #include <libtorrent/bencode.hpp>
 #include <libtorrent/torrent_info.hpp>

--- a/src/core/bittorrent/torrenthandle.h
+++ b/src/core/bittorrent/torrenthandle.h
@@ -272,11 +272,7 @@ namespace BitTorrent
         void pause();
         void resume(bool forced = false);
         void move(QString path);
-    #if LIBTORRENT_VERSION_NUM < 10000
-        void forceReannounce();
-    #else
         void forceReannounce(int index = -1);
-    #endif
         void forceDHTAnnounce();
         void forceRecheck();
         void setTrackerLogin(const QString &username, const QString &password);
@@ -354,10 +350,6 @@ namespace BitTorrent
         TorrentState  m_state;
         TorrentInfo m_torrentInfo;
         SpeedMonitor m_speedMonitor;
-    #if LIBTORRENT_VERSION_NUM < 10000
-        QString m_nativeName;
-        QString m_nativeSavePath;
-    #endif
 
         InfoHash m_hash;
 

--- a/src/core/logger.cpp
+++ b/src/core/logger.cpp
@@ -16,18 +16,12 @@ namespace Log
 
     Peer::Peer() {}
 
-#if LIBTORRENT_VERSION_NUM < 10000
-    Peer::Peer(int id, const QString &ip, bool blocked)
-#else
     Peer::Peer(int id, const QString &ip, bool blocked, const QString &reason)
-#endif
         : id(id)
         , timestamp(QDateTime::currentMSecsSinceEpoch())
         , ip(ip)
         , blocked(blocked)
-#if LIBTORRENT_VERSION_NUM >= 10000
         , reason(reason)
-#endif
     {
     }
 
@@ -76,19 +70,11 @@ void Logger::addMessage(const QString &message, const Log::MsgType &type)
     emit newLogMessage(temp);
 }
 
-#if LIBTORRENT_VERSION_NUM < 10000
-void Logger::addPeer(const QString &ip, bool blocked)
-#else
 void Logger::addPeer(const QString &ip, bool blocked, const QString &reason)
-#endif
 {
     QWriteLocker locker(&lock);
 
-#if LIBTORRENT_VERSION_NUM < 10000
-    Log::Peer temp(peerCounter++, ip, blocked);
-#else
     Log::Peer temp(peerCounter++, ip, blocked, reason);
-#endif
     m_peers.push_back(temp);
 
     if (m_peers.size() >= MAX_LOG_MESSAGES)

--- a/src/core/logger.h
+++ b/src/core/logger.h
@@ -5,7 +5,6 @@
 #include <QVector>
 #include <QReadWriteLock>
 #include <QObject>
-#include <libtorrent/version.hpp>
 
 const int MAX_LOG_MESSAGES = 1000;
 
@@ -31,19 +30,13 @@ namespace Log
 
     struct Peer
     {
-#if LIBTORRENT_VERSION_NUM < 10000
-        Peer(int id, const QString &ip, bool blocked);
-#else
         Peer(int id, const QString &ip, bool blocked, const QString &reason);
-#endif
         Peer();
         int id;
         qint64 timestamp;
         QString ip;
         bool blocked;
-#if LIBTORRENT_VERSION_NUM >= 10000
         QString reason;
-#endif
     };
 }
 
@@ -58,11 +51,7 @@ public:
     static Logger *instance();
 
     void addMessage(const QString &message, const Log::MsgType &type = Log::NORMAL);
-#if LIBTORRENT_VERSION_NUM < 10000
-    void addPeer(const QString &ip, bool blocked);
-#else
     void addPeer(const QString &ip, bool blocked, const QString &reason = QString());
-#endif
     QVector<Log::Msg> getMessages(int lastKnownId = -1) const;
     QVector<Log::Peer> getPeers(int lastKnownId = -1) const;
 

--- a/src/core/net/portforwarder.h
+++ b/src/core/net/portforwarder.h
@@ -31,14 +31,9 @@
 
 #include <QObject>
 #include <QHash>
-#include <libtorrent/version.hpp>
 
 namespace libtorrent
 {
-#if LIBTORRENT_VERSION_NUM < 10000
-    class upnp;
-    class natpmp;
-#endif
     class session;
 }
 
@@ -69,13 +64,7 @@ namespace Net
 
         bool m_active;
         libtorrent::session *m_provider;
-#if LIBTORRENT_VERSION_NUM < 10000
-        libtorrent::upnp *m_upnp;
-        libtorrent::natpmp *m_natpmp;
-        QHash<qint16, QPair<int, int> > m_mappedPorts;
-#else
         QHash<qint16, int> m_mappedPorts;
-#endif
 
         static PortForwarder *m_instance;
     };

--- a/src/core/preferences.cpp
+++ b/src/core/preferences.cpp
@@ -822,7 +822,6 @@ void Preferences::setProxyPeerConnections(bool enabled)
     setValue("Preferences/Connection/ProxyPeerConnections", enabled);
 }
 
-#if LIBTORRENT_VERSION_NUM >= 10000
 bool Preferences::getForceProxy() const
 {
     return value("Preferences/Connection/ProxyForce", true).toBool();
@@ -832,7 +831,6 @@ void Preferences::setForceProxy(bool enabled)
 {
     setValue("Preferences/Connection/ProxyForce", enabled);
 }
-#endif
 
 // Bittorrent options
 int Preferences::getMaxConnecs() const

--- a/src/core/preferences.h
+++ b/src/core/preferences.h
@@ -41,8 +41,6 @@
 #include <QNetworkCookie>
 #include <QVariant>
 
-#include <libtorrent/version.hpp>
-
 #include "core/types.h"
 
 enum scheduler_days
@@ -246,10 +244,8 @@ public:
     void setProxyType(int type);
     bool proxyPeerConnections() const;
     void setProxyPeerConnections(bool enabled);
-#if LIBTORRENT_VERSION_NUM >= 10000
     bool getForceProxy() const;
     void setForceProxy(bool enabled);
-#endif
 
     // Bittorrent options
     int getMaxConnecs() const;

--- a/src/gui/executionlog.cpp
+++ b/src/gui/executionlog.cpp
@@ -98,11 +98,7 @@ void ExecutionLog::addPeerMessage(const Log::Peer& peer)
     QDateTime time = QDateTime::fromMSecsSinceEpoch(peer.timestamp);
 
     if (peer.blocked)
-#if LIBTORRENT_VERSION_NUM < 10000
-        text = "<font color='grey'>" + time.toString(Qt::SystemLocaleShortDate) + "</font> - " + tr("<font color='red'>%1</font> was blocked", "x.y.z.w was blocked").arg(peer.ip);
-#else
         text = "<font color='grey'>" + time.toString(Qt::SystemLocaleShortDate) + "</font> - " + tr("<font color='red'>%1</font> was blocked %2", "x.y.z.w was blocked").arg(peer.ip).arg(peer.reason);
-#endif
     else
         text = "<font color='grey'>" + time.toString(Qt::SystemLocaleShortDate) + "</font> - " + tr("<font color='red'>%1</font> was banned", "x.y.z.w was banned").arg(peer.ip);
 

--- a/src/gui/options_imp.cpp
+++ b/src/gui/options_imp.cpp
@@ -40,8 +40,6 @@
 #include <QDesktopServices>
 #include <QDebug>
 
-#include <libtorrent/version.hpp>
-
 #include <cstdlib>
 #include "options_imp.h"
 #include "core/preferences.h"
@@ -221,9 +219,7 @@ options_imp::options_imp(QWidget *parent):
   connect(textProxyIP, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
   connect(spinProxyPort, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
   connect(checkProxyPeerConnecs, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
-#if LIBTORRENT_VERSION_NUM >= 10000
   connect(checkForceProxy, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
-#endif
   connect(checkProxyAuth, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
   connect(textProxyUsername, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
   connect(textProxyPassword, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
@@ -263,11 +259,6 @@ options_imp::options_imp(QWidget *parent):
   adv_layout->addWidget(advancedSettings);
   scrollArea_advanced->setLayout(adv_layout);
   connect(advancedSettings, SIGNAL(settingsChanged()), this, SLOT(enableApplyButton()));
-
-  //Hide incompatible options
-#if LIBTORRENT_VERSION_NUM < 10000
-  checkForceProxy->setVisible(false);
-#endif
 
   // Adapt size
   show();
@@ -436,9 +427,7 @@ void options_imp::saveOptions() {
   pref->setProxyIp(getProxyIp());
   pref->setProxyPort(getProxyPort());
   pref->setProxyPeerConnections(checkProxyPeerConnecs->isChecked());
-#if LIBTORRENT_VERSION_NUM >= 10000
   pref->setForceProxy(checkForceProxy->isChecked());
-#endif
   pref->setProxyAuthEnabled(isProxyAuthEnabled());
   pref->setProxyUsername(getProxyUsername());
   pref->setProxyPassword(getProxyPassword());
@@ -691,9 +680,7 @@ void options_imp::loadOptions() {
   textProxyIP->setText(pref->getProxyIp());
   spinProxyPort->setValue(pref->getProxyPort());
   checkProxyPeerConnecs->setChecked(pref->proxyPeerConnections());
-#if LIBTORRENT_VERSION_NUM >= 10000
   checkForceProxy->setChecked(pref->getForceProxy());
-#endif
   checkProxyAuth->setChecked(pref->isProxyAuthEnabled());
   textProxyUsername->setText(pref->getProxyUsername());
   textProxyPassword->setText(pref->getProxyPassword());
@@ -995,9 +982,7 @@ void options_imp::enableProxy(int index) {
     lblProxyPort->setEnabled(true);
     spinProxyPort->setEnabled(true);
     checkProxyPeerConnecs->setEnabled(true);
-#if LIBTORRENT_VERSION_NUM >= 10000
     checkForceProxy->setEnabled(true);
-#endif
     if (index > 1) {
       checkProxyAuth->setEnabled(true);
     } else {
@@ -1011,9 +996,7 @@ void options_imp::enableProxy(int index) {
     lblProxyPort->setEnabled(false);
     spinProxyPort->setEnabled(false);
     checkProxyPeerConnecs->setEnabled(false);
-#if LIBTORRENT_VERSION_NUM >= 10000
     checkForceProxy->setEnabled(false);
-#endif
     checkProxyAuth->setEnabled(false);
     checkProxyAuth->setChecked(false);
   }

--- a/src/gui/properties/trackerlist.cpp
+++ b/src/gui/properties/trackerlist.cpp
@@ -399,7 +399,6 @@ void TrackerList::editSelectedTracker() {
     }
 }
 
-#if LIBTORRENT_VERSION_NUM >= 10000
 void TrackerList::reannounceSelected() {
     QList<QTreeWidgetItem *> selected_items = selectedItems();
     if (selected_items.isEmpty()) return;
@@ -427,8 +426,6 @@ void TrackerList::reannounceSelected() {
     loadTrackers();
 }
 
-#endif
-
 void TrackerList::showTrackerListMenu(QPoint) {
   BitTorrent::TorrentHandle *const torrent = properties->getCurrentTorrent();
   if (!torrent) return;
@@ -444,14 +441,10 @@ void TrackerList::showTrackerListMenu(QPoint) {
     copyAct = menu.addAction(GuiIconProvider::instance()->getIcon("edit-copy"), tr("Copy tracker URL"));
     editAct = menu.addAction(GuiIconProvider::instance()->getIcon("edit-rename"),tr("Edit selected tracker URL"));
   }
-#if LIBTORRENT_VERSION_NUM >= 10000
   QAction *reannounceSelAct = NULL;
-#endif
   QAction *reannounceAct = NULL;
   if (!torrent->isPaused()) {
-#if LIBTORRENT_VERSION_NUM >= 10000
     reannounceSelAct = menu.addAction(GuiIconProvider::instance()->getIcon("view-refresh"), tr("Force reannounce to selected trackers"));
-#endif
     menu.addSeparator();
     reannounceAct = menu.addAction(GuiIconProvider::instance()->getIcon("view-refresh"), tr("Force reannounce to all trackers"));
   }
@@ -469,12 +462,10 @@ void TrackerList::showTrackerListMenu(QPoint) {
     deleteSelectedTrackers();
     return;
   }
-#if LIBTORRENT_VERSION_NUM >= 10000
   if (act == reannounceSelAct) {
     reannounceSelected();
     return;
   }
-#endif
   if (act == reannounceAct) {
     BitTorrent::TorrentHandle *h = properties->getCurrentTorrent();
     h->forceReannounce();

--- a/src/gui/properties/trackerlist.h
+++ b/src/gui/properties/trackerlist.h
@@ -36,7 +36,6 @@
 #include <QList>
 #include <QClipboard>
 
-#include <libtorrent/version.hpp>
 #include "propertieswidget.h"
 
 enum TrackerListColumn {COL_TIER, COL_URL, COL_STATUS, COL_PEERS, COL_MSG};
@@ -79,9 +78,7 @@ public slots:
   void loadTrackers();
   void askForTrackers();
   void copyTrackerUrl();
-#if LIBTORRENT_VERSION_NUM >= 10000
   void reannounceSelected();
-#endif
   void deleteSelectedTrackers();
   void editSelectedTracker();
   void showTrackerListMenu(QPoint);

--- a/src/webui/prefjson.cpp
+++ b/src/webui/prefjson.cpp
@@ -97,9 +97,7 @@ QByteArray prefjson::getPreferences()
     data["proxy_ip"] = pref->getProxyIp();
     data["proxy_port"] = pref->getProxyPort();
     data["proxy_peer_connections"] = pref->proxyPeerConnections();
-#if LIBTORRENT_VERSION_NUM >= 10000
     data["force_proxy"] = pref->getForceProxy();
-#endif
     data["proxy_auth_enabled"] = pref->isProxyAuthEnabled();
     data["proxy_username"] = pref->getProxyUsername();
     data["proxy_password"] = pref->getProxyPassword();
@@ -264,10 +262,8 @@ void prefjson::setPreferences(const QString& json)
         pref->setProxyPort(m["proxy_port"].toUInt());
     if (m.contains("proxy_peer_connections"))
         pref->setProxyPeerConnections(m["proxy_peer_connections"].toBool());
-#if LIBTORRENT_VERSION_NUM >= 10000
     if (m.contains("force_proxy"))
         pref->setForceProxy(m["force_proxy"].toBool());
-#endif
     if (m.contains("proxy_auth_enabled"))
         pref->setProxyAuthEnabled(m["proxy_auth_enabled"].toBool());
     if (m.contains("proxy_username"))


### PR DESCRIPTION
@sledgehammer999 If you still decide to drop support for outdated libtorrent-0.16.x, you will simply merge this PR.