### PR TITLE
Fix "Run External Program Launches too Early" issue

### DIFF
--- a/src/core/bittorrent/torrenthandle.cpp
+++ b/src/core/bittorrent/torrenthandle.cpp
@@ -191,6 +191,7 @@ TorrentHandle::TorrentHandle(Session *session, const libtorrent::torrent_handle 
     , m_session(session)
     , m_nativeHandle(nativeHandle)
     , m_state(TorrentState::Unknown)
+    , m_renameCount(0)
     , m_name(data.name)
     , m_addedTime(data.resumed ? data.addedTime : QDateTime::currentDateTime())
     , m_savePath(Utils::Fs::toNativePath(data.savePath))
@@ -1297,6 +1298,7 @@ void TorrentHandle::setTrackerLogin(const QString &username, const QString &pass
 
 void TorrentHandle::renameFile(int index, const QString &name)
 {
+    ++m_renameCount;
     qDebug() << Q_FUNC_INFO << index << name;
     SAFE_CALL(rename_file, index, Utils::String::toStdString(Utils::Fs::toNativePath(name)));
 }
@@ -1367,10 +1369,8 @@ void TorrentHandle::handleStorageMovedAlert(libtorrent::storage_moved_alert *p)
         QDir().rmpath(m_oldPath);
     }
 
-    if (!isMoveInProgress()) {
-        while (!m_moveStorageTriggers.isEmpty())
-            m_moveStorageTriggers.takeFirst()();
-    }
+    while (!isMoveInProgress() && (m_renameCount == 0) && !m_moveFinishedTriggers.isEmpty())
+        m_moveFinishedTriggers.takeFirst()();
 }
 
 void TorrentHandle::handleStorageMovedFailedAlert(libtorrent::storage_moved_failed_alert *p)
@@ -1389,10 +1389,8 @@ void TorrentHandle::handleStorageMovedFailedAlert(libtorrent::storage_moved_fail
         m_queuedPath.clear();
     }
 
-    if (!isMoveInProgress()) {
-        while (!m_moveStorageTriggers.isEmpty())
-            m_moveStorageTriggers.takeFirst()();
-    }
+    while (!isMoveInProgress() && (m_renameCount == 0) && !m_moveFinishedTriggers.isEmpty())
+        m_moveFinishedTriggers.takeFirst()();
 }
 
 void TorrentHandle::handleTrackerReplyAlert(libtorrent::tracker_reply_alert *p)
@@ -1461,10 +1459,10 @@ void TorrentHandle::handleTorrentFinishedAlert(libtorrent::torrent_finished_aler
     if (Preferences::instance()->recheckTorrentsOnCompletion())
         forceRecheck();
 
-    if (!isMoveInProgress())
-        m_session->handleTorrentFinished(this);
+    if (isMoveInProgress() || m_renameCount > 0)
+        m_moveFinishedTriggers.append(boost::bind(&SessionPrivate::handleTorrentFinished, m_session, this));
     else
-        m_moveStorageTriggers.append(boost::bind(&SessionPrivate::handleTorrentFinished, m_session, this));
+        m_session->handleTorrentFinished(this);
 }
 
 void TorrentHandle::handleTorrentPausedAlert(libtorrent::torrent_paused_alert *p)
@@ -1560,6 +1558,19 @@ void TorrentHandle::handleFileRenamedAlert(libtorrent::file_renamed_alert *p)
         // Renaming a file corresponds to changing the save path
         m_session->handleTorrentSavePathChanged(this);
     }
+
+    --m_renameCount;
+    while (!isMoveInProgress() && (m_renameCount == 0) && !m_moveFinishedTriggers.isEmpty())
+        m_moveFinishedTriggers.takeFirst()();
+}
+
+void TorrentHandle::handleFileRenameFailedAlert(libtorrent::file_rename_failed_alert *p)
+{
+    Q_UNUSED(p);
+
+    --m_renameCount;
+    while (!isMoveInProgress() && (m_renameCount == 0) && !m_moveFinishedTriggers.isEmpty())
+        m_moveFinishedTriggers.takeFirst()();
 }
 
 void TorrentHandle::handleFileCompletedAlert(libtorrent::file_completed_alert *p)
@@ -1660,6 +1671,9 @@ void TorrentHandle::handleAlert(libtorrent::alert *a)
     case libt::file_renamed_alert::alert_type:
         handleFileRenamedAlert(static_cast<libt::file_renamed_alert*>(a));
         break;
+    case libt::file_rename_failed_alert::alert_type:
+        handleFileRenameFailedAlert(static_cast<libt::file_rename_failed_alert*>(a));
+        break;
     case libt::file_completed_alert::alert_type:
         handleFileCompletedAlert(static_cast<libt::file_completed_alert*>(a));
         break;
@@ -1735,7 +1749,7 @@ void TorrentHandle::adjustActualSavePath()
     if (!isMoveInProgress())
         adjustActualSavePath_impl();
     else
-        m_moveStorageTriggers.append(boost::bind(&TorrentHandle::adjustActualSavePath_impl, this));
+        m_moveFinishedTriggers.append(boost::bind(&TorrentHandle::adjustActualSavePath_impl, this));
 }
 
 void TorrentHandle::adjustActualSavePath_impl()

--- a/src/core/bittorrent/torrenthandle.h
+++ b/src/core/bittorrent/torrenthandle.h
@@ -61,6 +61,7 @@ namespace libtorrent
     struct save_resume_data_alert;
     struct save_resume_data_failed_alert;
     struct file_renamed_alert;
+    struct file_rename_failed_alert;
     struct storage_moved_alert;
     struct storage_moved_failed_alert;
     struct metadata_received_alert;
@@ -303,7 +304,7 @@ namespace BitTorrent
         libtorrent::torrent_handle nativeHandle() const;
 
     private:
-        typedef boost::function<void ()> MoveStorageTrigger;
+        typedef boost::function<void ()> EventTrigger;
 
         void initialize();
         void updateStatus();
@@ -333,6 +334,7 @@ namespace BitTorrent
         void handleSaveResumeDataFailedAlert(libtorrent::save_resume_data_failed_alert *p);
         void handleFastResumeRejectedAlert(libtorrent::fastresume_rejected_alert *p);
         void handleFileRenamedAlert(libtorrent::file_renamed_alert *p);
+        void handleFileRenameFailedAlert(libtorrent::file_rename_failed_alert *p);
         void handleFileCompletedAlert(libtorrent::file_completed_alert *p);
         void handleMetadataReceivedAlert(libtorrent::metadata_received_alert *p);
         void handleStatsAlert(libtorrent::stats_alert *p);
@@ -370,7 +372,10 @@ namespace BitTorrent
         // m_queuedPath is where files should be moved to,
         // when current moving is completed
         QString m_queuedPath;
-        QQueue<MoveStorageTrigger> m_moveStorageTriggers;
+        // m_moveFinishedTriggers is activated only when the following conditions are met:
+        // all file rename jobs complete, all file move jobs complete
+        QQueue<EventTrigger> m_moveFinishedTriggers;
+        int m_renameCount;
 
         // Persistent data
         QString m_name;


### PR DESCRIPTION
To fix issue #2107.

I was thinking it could be fixed by counting rename events at [torrenthandle.cpp#L1298 ](https://github.com/qbittorrent/qBittorrent/blob/de84bb98245365425eb8e6d8ff471e92456908f2/src/core/bittorrent/torrenthandle.cpp#L1298) and [torrenthandle.cpp#L1535](https://github.com/qbittorrent/qBittorrent/blob/de84bb98245365425eb8e6d8ff471e92456908f2/src/core/bittorrent/torrenthandle.cpp#L1535).

Unfortunately I cannot reproduce that issue, even before my commit, so I have no clue if that problem really existed or not (or it's fixed in my commit).
However I can see my code is working.