### PR TITLE
Fix 3 compiler warnings

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -163,9 +163,9 @@ void Application::torrentFinished(BitTorrent::TorrentHandle *const torrent)
 
 void Application::allTorrentsFinished()
 {
+#ifndef DISABLE_GUI
     Preferences *const pref = Preferences::instance();
 
-#ifndef DISABLE_GUI
     bool will_shutdown = (pref->shutdownWhenDownloadsComplete()
                           || pref->shutdownqBTWhenDownloadsComplete()
                           || pref->suspendWhenDownloadsComplete()

--- a/src/core/bittorrent/session.cpp
+++ b/src/core/bittorrent/session.cpp
@@ -88,7 +88,6 @@ using namespace BitTorrent;
 
 static const char PEER_ID[] = "qB";
 static const char RESUME_FOLDER[] = "BT_backup";
-static const int MAX_TRACKER_ERRORS = 2;
 
 namespace libt = libtorrent;
 using namespace BitTorrent;

--- a/src/gui/rss/rssparser.cpp
+++ b/src/gui/rss/rssparser.cpp
@@ -58,12 +58,6 @@ static const char shortMonth[][4] = {
   "May", "Jun", "Jul", "Aug",
   "Sep", "Oct", "Nov", "Dec"
 };
-static const char longMonth[][10] = {
-  "January", "February", "March",
-  "April", "May", "June",
-  "July", "August", "September",
-  "October", "November", "December"
-};
 
 // Ported to Qt4 from KDElibs4
 QDateTime RssParser::parseDate(const QString &string) {


### PR DESCRIPTION
* `MAX_TRACKER_ERRORS` and `longMonth` are unused vars.
* `pref = Preferences::instance()` unused var in nox build.

**Finally not included:**
* `QMetaType::Float` I tested it and seems that everything is working but please review it carefully. I found the fix here https://stackoverflow.com/questions/31290606/qmetatypefloat-not-in-qvarianttype