### PR TITLE
[RSS] Several changes in RSSs. Closes #3560

### DIFF
--- a/src/gui/rss/rss.ui
+++ b/src/gui/rss/rss.ui
@@ -116,16 +116,12 @@
         <widget class="QLabel" name="news_lbl">
          <property name="font">
           <font>
-           <weight>50</weight>
-           <bold>false</bold>
+           <weight>75</weight>
+           <bold>true</bold>
           </font>
          </property>
          <property name="text">
-          <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans'; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Torrents:&lt;/span&gt; &lt;span style=&quot; font-style:italic;&quot;&gt;(double-click to download)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>Torrents: (double-click to download)</string>
          </property>
         </widget>
        </item>

--- a/src/gui/rss/rss.ui
+++ b/src/gui/rss/rss.ui
@@ -139,7 +139,7 @@ p, li { white-space: pre-wrap; }
            <enum>Qt::CustomContextMenu</enum>
           </property>
           <property name="selectionMode">
-           <enum>QAbstractItemView::SingleSelection</enum>
+           <enum>QAbstractItemView::ExtendedSelection</enum>
           </property>
           <property name="selectionBehavior">
            <enum>QAbstractItemView::SelectItems</enum>

--- a/src/gui/rss/rss_imp.cpp
+++ b/src/gui/rss/rss_imp.cpp
@@ -355,6 +355,8 @@ void RSSImp::downloadSelectedTorrents()
         RssArticlePtr article = feed->getItem(item->data(Article::IdRole).toString());
         if (!article) continue;
 
+        if (article->torrentUrl().isEmpty())
+            continue;
         if (Preferences::instance()->useAdditionDialog())
             AddNewTorrentDialog::show(article->torrentUrl());
         else

--- a/src/gui/rss/rss_imp.cpp
+++ b/src/gui/rss/rss_imp.cpp
@@ -249,21 +249,13 @@ void RSSImp::deleteSelectedItems()
     QList<QTreeWidgetItem*> selectedItems = m_feedList->selectedItems();
     if (selectedItems.isEmpty())
         return;
+    if ((selectedItems.size() == 1) && (selectedItems.first() == m_feedList->stickyUnreadItem()))
+        return;
 
-    int ret;
-    if (selectedItems.size() > 1) {
-        ret = QMessageBox::question(this, tr("Are you sure? -- qBittorrent"), tr("Are you sure you want to delete these elements from the list?"),
-                                    tr("&Yes"), tr("&No"),
-                                    QString(), 0, 1);
-    }
-    else {
-        if (selectedItems.first() == m_feedList->stickyUnreadItem())
-            return;
-        ret = QMessageBox::question(this, tr("Are you sure? -- qBittorrent"), tr("Are you sure you want to delete this element from the list?"),
-                                    tr("&Yes"), tr("&No"),
-                                    QString(), 0, 1);
-    }
-    if (ret)
+    QMessageBox::StandardButton answer = QMessageBox::question(this, tr("Deletion confirmation"),
+        tr("Are you sure you want to delete the selected RSS feeds?"),
+        QMessageBox::Yes|QMessageBox::No, QMessageBox::No);
+    if (answer == QMessageBox::No)
         return;
 
     foreach (QTreeWidgetItem* item, selectedItems) {

--- a/src/gui/rss/rss_imp.cpp
+++ b/src/gui/rss/rss_imp.cpp
@@ -112,20 +112,31 @@ void RSSImp::displayItemsListMenu(const QPoint&)
 {
     QMenu myItemListMenu(this);
     QList<QListWidgetItem*> selectedItems = listArticles->selectedItems();
-    if (selectedItems.size() > 0) {
-        bool has_attachment = false;
-        foreach (const QListWidgetItem* item, selectedItems) {
-            if (m_feedList->getRSSItemFromUrl(item->data(Article::FeedUrlRole).toString())
-                ->getItem(item->data(Article::IdRole).toString())->hasAttachment()) {
-                has_attachment = true;
-                break;
-            }
-        }
-        if (has_attachment)
-            myItemListMenu.addAction(actionDownload_torrent);
-        myItemListMenu.addAction(actionOpen_news_URL);
+    if (selectedItems.size() <= 0)
+        return;
+
+    bool hasTorrent = false;
+    bool hasLink = false;
+    foreach (const QListWidgetItem* item, selectedItems) {
+        if (!item) continue;
+        RssFeedPtr feed = m_feedList->getRSSItemFromUrl(item->data(Article::FeedUrlRole).toString());
+        if (!feed) continue;
+        RssArticlePtr article = feed->getItem(item->data(Article::IdRole).toString());
+        if (!article) continue;
+
+        if (!article->torrentUrl().isEmpty())
+            hasTorrent = true;
+        if (!article->link().isEmpty())
+            hasLink = true;
+        if (hasTorrent && hasLink)
+            break;
     }
-    myItemListMenu.exec(QCursor::pos());
+    if (hasTorrent)
+        myItemListMenu.addAction(actionDownload_torrent);
+    if (hasLink)
+        myItemListMenu.addAction(actionOpen_news_URL);
+    if (hasTorrent || hasLink)
+        myItemListMenu.exec(QCursor::pos());
 }
 
 void RSSImp::on_actionManage_cookies_triggered()

--- a/src/gui/rss/rss_imp.cpp
+++ b/src/gui/rss/rss_imp.cpp
@@ -547,17 +547,8 @@ void RSSImp::refreshTextBrowser()
     QListWidgetItem *item = selection.first();
     Q_ASSERT(item);
     if (item == m_currentArticle) return;
-    // Stop displaying previous news if necessary
-    if (m_feedList->currentFeed() == m_feedList->stickyUnreadItem()) {
-        if (m_currentArticle) {
-            disconnect(listArticles, SIGNAL(itemSelectionChanged()), this, SLOT(refreshTextBrowser()));
-            listArticles->removeItemWidget(m_currentArticle);
-            Q_ASSERT(m_currentArticle);
-            delete m_currentArticle;
-            connect(listArticles, SIGNAL(itemSelectionChanged()), this, SLOT(refreshTextBrowser()));
-        }
-        m_currentArticle = item;
-    }
+    m_currentArticle = item;
+
     RssFeedPtr stream = m_feedList->getRSSItemFromUrl(item->data(Article::FeedUrlRole).toString());
     RssArticlePtr article = stream->getItem(item->data(Article::IdRole).toString());
     QString html;
@@ -680,14 +671,11 @@ void RSSImp::onFeedContentChanged(const QString& url)
     qDebug() << Q_FUNC_INFO << url;
     QTreeWidgetItem *item = m_feedList->getTreeItemFromUrl(url);
     // If the feed is selected, update the displayed news
-    if (m_feedList->currentItem() == item ) {
+    if (m_feedList->currentItem() == item)
         populateArticleList(item);
-    }
-    else {
-        // Update unread items
-        if (m_feedList->currentItem() == m_feedList->stickyUnreadItem())
-            populateArticleList(m_feedList->stickyUnreadItem());
-    }
+    // Update unread items
+    else if (m_feedList->currentItem() == m_feedList->stickyUnreadItem())
+        populateArticleList(m_feedList->stickyUnreadItem());
 }
 
 void RSSImp::updateRefreshInterval(uint val)

--- a/src/gui/rss/rssarticle.cpp
+++ b/src/gui/rss/rssarticle.cpp
@@ -82,7 +82,7 @@ const QString& RssArticle::author() const {
 }
 
 const QString& RssArticle::torrentUrl() const {
-  return m_torrentUrl.isEmpty() ? m_link : m_torrentUrl;
+  return m_torrentUrl;
 }
 
 const QString& RssArticle::link() const {
@@ -123,6 +123,6 @@ const QString& RssArticle::title() const
 }
 
 void RssArticle::handleTorrentDownloadSuccess(const QString &url) {
-  if (url == m_torrentUrl || url == m_link)
+  if (url == m_torrentUrl)
     markAsRead();
 }

--- a/src/gui/rss/rssfeed.cpp
+++ b/src/gui/rss/rssfeed.cpp
@@ -364,6 +364,12 @@ void RssFeed::downloadArticleTorrentIfMatching(RssDownloadRuleList* rules, const
   rules->saveRulesToStorage();
   // Download the torrent
   const QString& torrent_url = article->torrentUrl();
+  if (torrent_url.isEmpty()) {
+    Logger::instance()->addMessage(tr("Automatic download %1 from %2 RSS feed failed because it doesn't contain a torrent or a magnet link...").arg(article->title()).arg(displayName()), Log::WARNING);
+    article->markAsRead();
+    return;
+  }
+
   Logger::instance()->addMessage(tr("Automatically downloading %1 torrent from %2 RSS feed...").arg(article->title()).arg(displayName()));
   connect(BitTorrent::Session::instance(), SIGNAL(downloadFromUrlFinished(QString)), article.data(), SLOT(handleTorrentDownloadSuccess(const QString&)), Qt::UniqueConnection);
   connect(article.data(), SIGNAL(articleWasRead()), SLOT(handleArticleStateChanged()), Qt::UniqueConnection);

--- a/src/gui/rss/rssparser.cpp
+++ b/src/gui/rss/rssparser.cpp
@@ -277,6 +277,9 @@ void RssParser::parseRssArticle(QXmlStreamReader& xml, const QString& feedUrl)
     }
   }
 
+  if (!article.contains("torrent_url") && article.contains("news_link"))
+    article["torrent_url"] = article["news_link"];
+
   if (!article.contains("id")) {
     // Item does not have a guid, fall back to some other identifier
     const QString link = article.value("news_link").toString();
@@ -396,6 +399,9 @@ void RssParser::parseAtomArticle(QXmlStreamReader& xml, const QString& feedUrl, 
         article["id"] = xml.readElementText().trimmed();
     }
   }
+
+  if (!article.contains("torrent_url") && article.contains("news_link"))
+    article["torrent_url"] = article["news_link"];
 
   if (!article.contains("id")) {
     // Item does not have a guid, fall back to some other identifier

--- a/src/gui/rss/rssparser.cpp
+++ b/src/gui/rss/rssparser.cpp
@@ -259,8 +259,13 @@ void RssParser::parseRssArticle(QXmlStreamReader& xml, const QString& feedUrl)
         if (xml.attributes().value("type") == "application/x-bittorrent")
           article["torrent_url"] = xml.attributes().value("url").toString();
       }
-      else if (xml.name() == "link")
-        article["news_link"] = xml.readElementText();
+      else if (xml.name() == "link") {
+        QString link = xml.readElementText().trimmed();
+        if (link.startsWith("magnet:", Qt::CaseInsensitive))
+          article["torrent_url"] = link; // magnet link instead of a news URL
+        else
+          article["news_link"] = link;
+      }
       else if (xml.name() == "description")
         article["description"] = xml.readElementText();
       else if (xml.name() == "pubDate")
@@ -341,17 +346,18 @@ void RssParser::parseAtomArticle(QXmlStreamReader& xml, const QString& feedUrl, 
         article["title"] = doc.toPlainText();
       }
       else if (xml.name() == "link") {
-        QString theLink = ( xml.attributes().isEmpty() ?
-                              xml.readElementText() :
-                              xml.attributes().value("href").toString() );
+        QString link = ( xml.attributes().isEmpty() ?
+                           xml.readElementText().trimmed() :
+                           xml.attributes().value("href").toString() );
 
-        // Atom feeds can have relative links, work around this and
-        // take the stress of figuring article full URI from UI
+        if (link.startsWith("magnet:", Qt::CaseInsensitive))
+          article["torrent_url"] = link; // magnet link instead of a news URL
+        else
+          // Atom feeds can have relative links, work around this and
+          // take the stress of figuring article full URI from UI
+          // Assemble full URI
+          article["news_link"] = ( baseUrl.isEmpty() ? link : baseUrl + link );
 
-        // Assemble full URI
-        article["news_link"] = ( baseUrl.isEmpty() ?
-                                   theLink :
-                                   baseUrl + theLink );
       }
       else if (xml.name() == "summary" || xml.name() == "content"){
         if(double_content) { // Duplicate content -> ignore

--- a/src/gui/rss/rssparser.cpp
+++ b/src/gui/rss/rssparser.cpp
@@ -254,7 +254,7 @@ void RssParser::parseRssArticle(QXmlStreamReader& xml, const QString& feedUrl)
 
     if (xml.isStartElement()) {
       if (xml.name() == "title")
-        article["title"] = xml.readElementText();
+        article["title"] = xml.readElementText().trimmed();
       else if (xml.name() == "enclosure") {
         if (xml.attributes().value("type") == "application/x-bittorrent")
           article["torrent_url"] = xml.attributes().value("url").toString();
@@ -267,13 +267,13 @@ void RssParser::parseRssArticle(QXmlStreamReader& xml, const QString& feedUrl)
           article["news_link"] = link;
       }
       else if (xml.name() == "description")
-        article["description"] = xml.readElementText();
+        article["description"] = xml.readElementText().trimmed();
       else if (xml.name() == "pubDate")
-        article["date"] = parseDate(xml.readElementText());
+        article["date"] = parseDate(xml.readElementText().trimmed());
       else if (xml.name() == "author")
-        article["author"] = xml.readElementText();
+        article["author"] = xml.readElementText().trimmed();
       else if (xml.name() == "guid")
-        article["id"] = xml.readElementText();
+        article["id"] = xml.readElementText().trimmed();
     }
   }
 
@@ -343,7 +343,7 @@ void RssParser::parseAtomArticle(QXmlStreamReader& xml, const QString& feedUrl, 
         // Workaround for CDATA (QString cannot parse html escapes on it's own)
         QTextDocument doc;
         doc.setHtml(xml.readElementText());
-        article["title"] = doc.toPlainText();
+        article["title"] = doc.toPlainText().trimmed();
       }
       else if (xml.name() == "link") {
         QString link = ( xml.attributes().isEmpty() ?
@@ -373,13 +373,13 @@ void RssParser::parseAtomArticle(QXmlStreamReader& xml, const QString& feedUrl, 
         // Actually works great for non-broken content too
         QString feedText = xml.readElementText(QXmlStreamReader::IncludeChildElements);
         if (!feedText.isEmpty())
-          article["description"] = feedText;
+          article["description"] = feedText.trimmed();
 
         double_content = true;
       }
       else if (xml.name() == "updated"){
         // ATOM uses standard compliant date, don't do fancy stuff
-        QDateTime articleDate = QDateTime::fromString(xml.readElementText(), Qt::ISODate);
+        QDateTime articleDate = QDateTime::fromString(xml.readElementText().trimmed(), Qt::ISODate);
         article["date"] = ( articleDate.isValid() ?
                               articleDate :
                               QDateTime::currentDateTime() );
@@ -388,12 +388,12 @@ void RssParser::parseAtomArticle(QXmlStreamReader& xml, const QString& feedUrl, 
         xml.readNext();
         while(xml.name() != "author") {
           if(xml.name() == "name")
-            article["author"] = xml.readElementText();
+            article["author"] = xml.readElementText().trimmed();
           xml.readNext();
         }
       }
       else if (xml.name() == "id")
-        article["id"] = xml.readElementText();
+        article["id"] = xml.readElementText().trimmed();
     }
   }
 


### PR DESCRIPTION
* **Handle magnet links as torrents instead of news URLs.**

Closes #3560. Some RSSs have magnet links in the URL instead of an attached torrent.
* **Trim elements text in RSS articles**

If some RSS has this format, the Articles list looks horrible because each element occupies 2 lines and the link doesn't work. Found in #3560 also.
```xml
<item>
<title>
Toco-mocho</title>
<link>
magnet:?xt=urn:btih:7YUK6RY4IPP2LTO..........</link>
....

```
* **Fix contextual menu in RSS torrents list**

Display the menu only if there are items selected and news URL is not always available (if url = magnet link)
* **Improve error handling when a RSS feed doesn't contain torrents**

There are RSS feeds without torrents or magnets which caused problems in the double click download and in the automatic download manager. Obviously we can't download that but we can explain a bit. i.e. https://torrentz.eu/feedA?q=debian%20jessie
* **More precise message and code simplification in RSS feeds deletion**

The title says it all.

* **Don't hide the elements in Unread list when clicked**

Now the elements are in the list marked as read until you change the selected feed (or reload the Unread list).

* **Allow multiple selection in RSS torrents list**

This allows to download several torrents at the same time. The same for opening the news URLs.