### PR TITLE
Don't remove torrent contents parent folder, even it is empty.

### DIFF
--- a/src/core/bittorrent/session.h
+++ b/src/core/bittorrent/session.h
@@ -61,6 +61,7 @@ namespace libtorrent
     struct torrent_finished_alert;
     struct torrent_removed_alert;
     struct torrent_deleted_alert;
+    struct torrent_delete_failed_alert;
     struct torrent_paused_alert;
     struct torrent_resumed_alert;
     struct save_resume_data_alert;
@@ -305,6 +306,7 @@ namespace BitTorrent
         void handleFileErrorAlert(libtorrent::file_error_alert *p);
         void handleTorrentRemovedAlert(libtorrent::torrent_removed_alert *p);
         void handleTorrentDeletedAlert(libtorrent::torrent_deleted_alert *p);
+        void handleTorrentDeleteFailedAlert(libtorrent::torrent_delete_failed_alert *p);
         void handlePortmapWarningAlert(libtorrent::portmap_error_alert *p);
         void handlePortmapAlert(libtorrent::portmap_alert *p);
         void handlePeerBlockedAlert(libtorrent::peer_blocked_alert *p);

--- a/src/core/utils/fs.h
+++ b/src/core/utils/fs.h
@@ -55,7 +55,8 @@ namespace Utils
         bool sameFileNames(const QString& first, const QString& second);
         QString expandPath(const QString& path);
         QString expandPathAbs(const QString& path);
-        bool smartRemoveEmptyFolderTree(const QString& dir_path);
+
+        bool smartRemoveEmptyFolderTree(const QString& path);
         bool forceRemove(const QString& file_path);
         void removeDirRecursive(const QString& dirName);
 


### PR DESCRIPTION
IMO, it makes no sense to delete torrent contents **parent** folder, no matter it is created by user or qbt.
Just deleting the folder containing the contents is enough.

#3144,  #3619 is probably related.

Should I remove `Utils::Fs::smartRemoveEmptyFolderTree()`? It's not being called anymore after this PR.