### PR TITLE
Add ppc64le support in m4/ax_boost_base.m4

### DIFF
--- a/m4/ax_boost_base.m4
+++ b/m4/ax_boost_base.m4
@@ -95,6 +95,9 @@ if test "x$want_boost" = "xyes"; then
       x86_64|ppc64|s390x|sparc64|aarch64)
         libsubdirs="lib64 lib lib64"
         ;;
+      ppc64le)
+        libsubdirs="lib64"
+        ;;
     esac
 
     dnl allow for real multi-arch paths e.g. /usr/lib/x86_64-linux-gnu. Give


### PR DESCRIPTION
required to avoid build error message like
===
[   29s] configure: Boost CPPFLGAS: -I/usr/include
[   29s] checking whether the Boost::System library is available... yes
[   29s] configure: error: Could not find a version of the library!
===