### PR TITLE
Use native path separators

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -60,6 +60,7 @@
 #include "application.h"
 #include "core/logger.h"
 #include "core/preferences.h"
+#include "core/utils/fs.h"
 #include "core/utils/misc.h"
 #include "core/iconprovider.h"
 #include "core/scanfoldersmodel.h"
@@ -146,7 +147,7 @@ void Application::torrentFinished(BitTorrent::TorrentHandle *const torrent)
         program.replace("%N", torrent->name());
         program.replace("%F", (file_count > 1) ? "" : torrent->fileName(0));
         program.replace("%L", torrent->label());
-        program.replace("%D", torrent->rootPath());
+        program.replace("%D", Utils::Fs::toNativePath(torrent->rootPath()));
         program.replace("%K", (file_count > 1) ? "multi" : "single");
         program.replace("%C", QString::number(torrent->filesCount()));
         program.replace("%Z", QString::number(torrent->totalSize()));

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -252,7 +252,7 @@ BitTorrent::TorrentHandle *PropertiesWidget::getCurrentTorrent() const
 void PropertiesWidget::updateSavePath(BitTorrent::TorrentHandle *const torrent)
 {
   if (m_torrent == torrent) {
-    save_path->setText(m_torrent->rootPath());
+    save_path->setText(Utils::Fs::toNativePath(m_torrent->rootPath()));
   }
 }
 

--- a/src/gui/torrentmodel.cpp
+++ b/src/gui/torrentmodel.cpp
@@ -221,7 +221,7 @@ QVariant TorrentModel::data(const QModelIndex &index, int role) const
     case TR_TIME_ELAPSED:
         return (role == Qt::DisplayRole) ? torrent->activeTime() : torrent->seedingTime();
     case TR_SAVE_PATH:
-        return torrent->rootPath();
+        return Utils::Fs::toNativePath(torrent->rootPath());
     case TR_COMPLETED:
         return torrent->completedSize();
     case TR_RATIO_LIMIT:

--- a/src/webui/btjson.cpp
+++ b/src/webui/btjson.cpp
@@ -509,7 +509,7 @@ QByteArray btjson::getPropertiesForTorrent(const QString& hash)
         dataDict[KEY_PROP_COMPLETION_DATE] = -1;
         dataDict[KEY_PROP_CREATION_DATE] = -1;
     }
-    dataDict[KEY_PROP_SAVE_PATH] = torrent->savePathParsed();
+    dataDict[KEY_PROP_SAVE_PATH] = Utils::Fs::toNativePath(torrent->rootPath());
     dataDict[KEY_PROP_COMMENT] = torrent->comment();
 
     return json::toJson(dataDict);


### PR DESCRIPTION
Before:
`C:/a/b/`
After: 
`C:\a\b\`

~~It's probably a copy-paste error in `savePath()` & `actualSavePath()`, not sure about it.~~