### PR TITLE
Move option "Confirm torrent deletion" to Behavior page

### DIFF
--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -43,7 +43,6 @@ enum AdvSettingsRows
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
     USE_ICON_THEME,
 #endif
-    CONFIRM_DELETE_TORRENT,
     CONFIRM_RECHECK_TORRENT,
     TRACKER_EXCHANGE,
     ANNOUNCE_ALL_TRACKERS,
@@ -57,7 +56,7 @@ class AdvancedSettings: public QTableWidget
 private:
     QSpinBox spin_cache, spin_save_resume_data_interval, outgoing_ports_min, outgoing_ports_max, spin_list_refresh, spin_maxhalfopen, spin_tracker_port;
     QCheckBox cb_os_cache, cb_recheck_completed, cb_resolve_countries, cb_resolve_hosts,
-              cb_super_seeding, cb_program_notifications, cb_tracker_status, cb_confirm_torrent_deletion,
+              cb_super_seeding, cb_program_notifications, cb_tracker_status,
               cb_confirm_torrent_recheck, cb_enable_tracker_ext, cb_listen_ipv6;
     QComboBox combo_iface;
     QSpinBox spin_cache_ttl;
@@ -147,7 +146,6 @@ public slots:
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
         pref->useSystemIconTheme(cb_use_icon_theme.isChecked());
 #endif
-        pref->setConfirmTorrentDeletion(cb_confirm_torrent_deletion.isChecked());
         pref->setConfirmTorrentRecheck(cb_confirm_torrent_recheck.isChecked());
         // Tracker exchange
         pref->setTrackerExchangeEnabled(cb_enable_tracker_ext.isChecked());
@@ -313,9 +311,6 @@ private slots:
         cb_use_icon_theme.setChecked(pref->useSystemIconTheme());
         setRow(USE_ICON_THEME, tr("Use system icon theme"), &cb_use_icon_theme);
 #endif
-        // Torrent deletion confirmation
-        cb_confirm_torrent_deletion.setChecked(pref->confirmTorrentDeletion());
-        setRow(CONFIRM_DELETE_TORRENT, tr("Confirm torrent deletion"), &cb_confirm_torrent_deletion);
         // Torrent recheck confirmation
         cb_confirm_torrent_recheck.setChecked(pref->confirmTorrentRecheck());
         setRow(CONFIRM_RECHECK_TORRENT, tr("Confirm torrent recheck"), &cb_confirm_torrent_recheck);

--- a/src/gui/options.ui
+++ b/src/gui/options.ui
@@ -256,6 +256,16 @@
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_4">
                <item>
+                <widget class="QCheckBox" name="confirmDeletion">
+                 <property name="text">
+                  <string>Confirm when deleting torrents</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <widget class="QCheckBox" name="checkAltRowColors">
                  <property name="text">
                   <string extracomment="In transfer list, one every two rows will have grey background.">Use alternating row colors</string>

--- a/src/gui/options_imp.cpp
+++ b/src/gui/options_imp.cpp
@@ -132,6 +132,7 @@ options_imp::options_imp(QWidget *parent):
   // Apply button is activated when a value is changed
   // General tab
   connect(comboI18n, SIGNAL(currentIndexChanged(int)), this, SLOT(enableApplyButton()));
+  connect(confirmDeletion, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
   connect(checkAltRowColors, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
   connect(checkShowSystray, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
   connect(checkCloseToSystray, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
@@ -377,6 +378,7 @@ void options_imp::saveOptions() {
 
   // General preferences
   pref->setLocale(locale);
+  pref->setConfirmTorrentDeletion(confirmDeletion->isChecked());
   pref->setAlternatingRowColors(checkAltRowColors->isChecked());
   pref->setSystrayIntegration(systrayIntegration());
   pref->setTrayIconStyle(TrayIcon::Style(comboTrayIcon->currentIndex()));
@@ -538,6 +540,7 @@ void options_imp::loadOptions() {
   // General preferences
   const Preferences* const pref = Preferences::instance();
   setLocale(pref->getLocale());
+  confirmDeletion->setChecked(pref->confirmTorrentDeletion());
   checkAltRowColors->setChecked(pref->useAlternatingRowColors());
 
   checkShowSplash->setChecked(!pref->isSplashScreenDisabled());


### PR DESCRIPTION
Due to users complaining about the OK/cancel default in torrent delete confirmation dialog, I think it's a good idea to expose this option:
![1](https://cloud.githubusercontent.com/assets/9395168/9278398/1dabd5c2-42e3-11e5-8a6f-f434ea3872bf.png)


This PR is based on #3481 (because it contains a cleanup), so please merge that before this, then I will rebase if needed.