### PR TITLE
Change "Select Graphs" from QToolButton to QComboBox

### DIFF
--- a/src/gui/properties/speedwidget.cpp
+++ b/src/gui/properties/speedwidget.cpp
@@ -31,8 +31,6 @@
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QLabel>
-#include <QComboBox>
-#include <QToolButton>
 #include <QMenu>
 #include <QSignalMapper>
 
@@ -43,6 +41,20 @@
 #include "core/bittorrent/sessionstatus.h"
 #include "core/preferences.h"
 #include "core/utils/misc.h"
+
+ComboBoxMenuButton::ComboBoxMenuButton(QWidget *parent, QMenu *menu)
+    : QComboBox(parent)
+    , m_menu(menu)
+{
+}
+
+void ComboBoxMenuButton::showPopup()
+{
+    QPoint p = mapToGlobal(QPoint(0, height()));
+    m_menu->exec(p);
+    QComboBox::hidePopup();
+}
+
 
 SpeedWidget::SpeedWidget(PropertiesWidget *parent)
     : QWidget(parent)
@@ -62,11 +74,6 @@ SpeedWidget::SpeedWidget(PropertiesWidget *parent)
     m_periodCombobox->addItem(tr("6 Hours"));
 
     connect(m_periodCombobox, SIGNAL(currentIndexChanged(int)), this, SLOT(onPeriodChange(int)));
-
-    m_graphsButton = new QToolButton();
-    m_graphsButton->setText(tr("Select Graphs"));
-    m_graphsButton->setPopupMode(QToolButton::InstantPopup);
-    m_graphsButton->setAutoExclusive(true);
 
     m_graphsMenu = new QMenu();
     m_graphsMenu->addAction(tr("Total Upload"));
@@ -92,7 +99,8 @@ SpeedWidget::SpeedWidget(PropertiesWidget *parent)
     }
     connect(m_graphsSignalMapper, SIGNAL(mapped(int)), this, SLOT(onGraphChange(int)));
 
-    m_graphsButton->setMenu(m_graphsMenu);
+    m_graphsButton = new ComboBoxMenuButton(this, m_graphsMenu);
+    m_graphsButton->addItem(tr("Select Graphs"));
 
     m_hlayout->addWidget(m_periodLabel);
     m_hlayout->addWidget(m_periodCombobox);

--- a/src/gui/properties/speedwidget.h
+++ b/src/gui/properties/speedwidget.h
@@ -30,6 +30,7 @@
 #define SPEEDWIDGET_H
 
 #include <QWidget>
+#include <QComboBox>
 #include <QtConcurrentRun>
 
 #include "speedplotview.h"
@@ -37,11 +38,21 @@
 class QVBoxLayout;
 class QHBoxLayout;
 class QLabel;
-class QComboBox;
-class QToolButton;
 class QMenu;
 class QSignalMapper;
 class PropertiesWidget;
+
+class ComboBoxMenuButton : public QComboBox
+{
+    Q_OBJECT
+public:
+    ComboBoxMenuButton(QWidget *parent, QMenu *menu);
+    virtual void showPopup();
+
+private:
+    QMenu *m_menu;
+};
+
 
 class SpeedWidget : public QWidget
 {
@@ -66,7 +77,7 @@ private:
     QComboBox *m_periodCombobox;
     SpeedPlotView *m_plot;
 
-    QToolButton *m_graphsButton;
+    ComboBoxMenuButton *m_graphsButton;
     QMenu *m_graphsMenu;
     QList<QAction *> m_graphsMenuActions;
     QSignalMapper *m_graphsSignalMapper;


### PR DESCRIPTION
In windows, using QToolButton in this case seems a little bit weird, e.g. the height is smaller, the down arrow is near to bottom. It doesn't give a consistent UI feel, maybe switching it to QComboBox is better.

Below screenshot is using QT5.
Old:
![old](https://cloud.githubusercontent.com/assets/9395168/9292353/0aff2d72-4426-11e5-8e66-a54c45f20708.png)

New:
![new](https://cloud.githubusercontent.com/assets/9395168/9292357/32e84684-4426-11e5-888a-216c36ab9f62.png)
