### PR TITLE
Put unselected files into unwanted folder when adding torrent through…

### DIFF
--- a/src/gui/addnewtorrentdialog.h
+++ b/src/gui/addnewtorrentdialog.h
@@ -72,6 +72,7 @@ private slots:
     void handleDownloadFailed(const QString &url, const QString &reason);
     void handleRedirectedToMagnet(const QString &url, const QString &magnetUri);
     void handleDownloadFinished(const QString &url, const QString &filePath);
+    void prioritizeFiles();
 
 protected slots:
     virtual void accept();


### PR DESCRIPTION
… the dialog.

This was discovered while toying with #3559 

**Situation:**

Before doing the core code refactor we applied any file priorities(unselected files) AFTER the torrent was added to the session.
Now we just tell libtorrent the file priorities while adding the torrent to the session with add_torrent_params.
Unexpected side-effect is that the paths of the unselected files don't get adjusted and they get dropped into the main folder.

As I say in my code comment I basically copied and adjusted the `TorrentHandle::prioritizeFiles()` code. It seems to work for me. Do you have any better idea on how to solve this instead?

Caveat: The .unwanted folder created this way isn't hidden on Windows. Did I miss something in the libtorrent API that lets you set file attributes?
