### PR TITLE
Fix a bug with highlighting selected file on Windows. Closes #3185.

### DIFF
--- a/src/core/utils/misc.cpp
+++ b/src/core/utils/misc.cpp
@@ -592,7 +592,7 @@ void Utils::Misc::openFolderSelect(const QString& absolutePath)
         proc.start("xdg-mime", QStringList() << "query" << "default" << "inode/directory");
         proc.waitForFinished();
         output = proc.readLine().simplified();
-        if (output == "dolphin.desktop")
+        if (output == "dolphin.desktop" || output == "org.kde.dolphin.desktop")
             proc.startDetached("dolphin", QStringList() << "--select" << Utils::Fs::toNativePath(path));
         else if (output == "nautilus.desktop" || output == "org.gnome.Nautilus.desktop"
                  || output == "nautilus-folder-handler.desktop")


### PR DESCRIPTION
The comment in the code explains why this is needed.

@glassez can you take a look a tell if I am ok with the WINAPI usage? I am not too confident on my C skills.

@pmzqla @ngosang @Chocobo1 @glassez @Gelmir 

This isn't finished. While it fixes the problem stated in the commit, it is broken in another way.
If the file resides in folders that have letters explorer.exe still shows the default path. If the path has only folders with digit names it works. Example:
```
G:\myfolder\file.mkv  --> doesn't work
G:\12\file.mkv  --> works
```

Printing the `cmd` variable and using its contents via the terminal it works!!!
I cannot understand what the problem is here.
Any ideas?