### PR TITLE
[WIP]Fix reordering of first column with Qt5. Closes #2835.

### DIFF
--- a/src/gui/properties/peerlistdelegate.h
+++ b/src/gui/properties/peerlistdelegate.h
@@ -36,12 +36,31 @@
 #include "core/utils/misc.h"
 #include "core/utils/string.h"
 
-class PeerListDelegate: public QItemDelegate {
+class PeerListDelegate: public QItemDelegate
+{
   Q_OBJECT
 
 public:
-  enum PeerListColumns {COUNTRY, IP, PORT, CONNECTION, FLAGS, CLIENT, PROGRESS, DOWN_SPEED, UP_SPEED,
-                        TOT_DOWN, TOT_UP, RELEVANCE, IP_HIDDEN, COL_COUNT};
+  enum PeerListColumns
+  {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+    DUMMY,
+#endif
+    COUNTRY,
+    IP,
+    PORT,
+    CONNECTION,
+    FLAGS,
+    CLIENT,
+    PROGRESS,
+    DOWN_SPEED,
+    UP_SPEED,
+    TOT_DOWN,
+    TOT_UP,
+    RELEVANCE,
+    IP_HIDDEN,
+    COL_COUNT
+  };
 
 public:
   PeerListDelegate(QObject *parent) : QItemDelegate(parent) {}

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -86,6 +86,11 @@ PeerListWidget::PeerListWidget(PropertiesWidget *parent):
   //incorrect restoreState() being used.
   for (unsigned int i=0; i<PeerListDelegate::IP_HIDDEN; i++)
     showColumn(i);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+  // On Qt5 the first column can be reordered by the user.
+  // So we use a dummy column that is always hidden.
+  setColumnHidden(PeerListDelegate::DUMMY, true);
+#endif
   hideColumn(PeerListDelegate::IP_HIDDEN);
   hideColumn(PeerListDelegate::COL_COUNT);
   if (!Preferences::instance()->resolvePeerCountries())

--- a/src/gui/torrentmodel.h
+++ b/src/gui/torrentmodel.h
@@ -49,6 +49,9 @@ class TorrentModel : public QAbstractListModel
 public:
     enum Column
     {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+        TR_DUMMY,
+#endif
         TR_PRIORITY,
         TR_NAME,
         TR_SIZE,

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -100,6 +100,12 @@ TransferListWidget::TransferListWidget(QWidget *parent, MainWindow *main_window)
 #endif
     header()->setStretchLastSection(false);
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+    // On Qt5 the first column can be reordered by the user.
+    // So we use a dummy column that is always hidden.
+    setColumnHidden(TorrentModel::TR_DUMMY, true);
+#endif
+
     // Default hidden columns
     if (!column_loaded) {
         setColumnHidden(TorrentModel::TR_ADD_DATE, true);
@@ -503,7 +509,11 @@ void TransferListWidget::displayDLHoSMenu(const QPoint&)
     hideshowColumn.setTitle(tr("Column visibility"));
     QList<QAction*> actions;
     for (int i = 0; i < listModel->columnCount(); ++i) {
-        if (!BitTorrent::Session::instance()->isQueueingEnabled() && i == TorrentModel::TR_PRIORITY) {
+        if ((!BitTorrent::Session::instance()->isQueueingEnabled() && i == TorrentModel::TR_PRIORITY)
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+            || (i == TorrentModel::TR_DUMMY)
+#endif
+            ) {
             actions.append(0);
             continue;
         }


### PR DESCRIPTION
This is work in progress.

I cannot figure out how to fix:
1. The columns in the "Content" button
2. The columns in the treeview widget of "Add New Torrent" dialog (multifile torrents)
3. The columns in the "Trackers"

1 + 2 are probably related.

PS: I just remembered that the columns in the Preview dialog also need fixing.

**EDITED**
List of unfinished Views:
1. Content button
2. Content in "Add New Torrent" dialog (multifile torrents)
3. Trackers button
4. Preview dialog
5. Search tabs
6. Search engine selection dialog