### PR TITLE
Cleanup in options_imp

### DIFF
--- a/src/gui/options.ui
+++ b/src/gui/options.ui
@@ -10,12 +10,6 @@
     <height>591</height>
    </rect>
   </property>
-  <property name="sizePolicy">
-   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-    <horstretch>0</horstretch>
-    <verstretch>0</verstretch>
-   </sizepolicy>
-  </property>
   <property name="windowTitle">
    <string>Options</string>
   </property>
@@ -25,22 +19,10 @@
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
+     <property name="childrenCollapsible">
+      <bool>false</bool>
+     </property>
      <widget class="QListWidget" name="tabSelection">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>116</width>
-        <height>0</height>
-       </size>
-      </property>
-      <property name="frameShape">
-       <enum>QFrame::StyledPanel</enum>
-      </property>
       <property name="autoScroll">
        <bool>false</bool>
       </property>
@@ -49,9 +31,6 @@
         <width>32</width>
         <height>32</height>
        </size>
-      </property>
-      <property name="flow">
-       <enum>QListView::LeftToRight</enum>
       </property>
       <property name="isWrapping" stdset="0">
        <bool>true</bool>
@@ -70,12 +49,6 @@
       </property>
       <property name="viewMode">
        <enum>QListView::IconMode</enum>
-      </property>
-      <property name="wordWrap">
-       <bool>false</bool>
-      </property>
-      <property name="selectionRectVisible">
-       <bool>false</bool>
       </property>
       <property name="currentRow">
        <number>0</number>
@@ -164,6 +137,15 @@
       </property>
       <widget class="QWidget" name="tabOptionPage1">
        <layout class="QVBoxLayout" name="verticalLayout_10">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
         <item>
          <widget class="QScrollArea" name="scrollArea">
           <property name="sizePolicy">
@@ -180,8 +162,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>474</width>
-             <height>646</height>
+             <width>480</width>
+             <height>672</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -519,6 +501,15 @@
       </widget>
       <widget class="QWidget" name="tabOptionPage2">
        <layout class="QVBoxLayout" name="verticalLayout_13">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
         <item>
          <widget class="QScrollArea" name="scrollArea_2">
           <property name="widgetResizable">
@@ -1026,6 +1017,15 @@
       </widget>
       <widget class="QWidget" name="tabOptionPage3">
        <layout class="QVBoxLayout" name="verticalLayout_6">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
         <item>
          <widget class="QScrollArea" name="scrollArea_3">
           <property name="widgetResizable">
@@ -1036,8 +1036,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>450</width>
-             <height>632</height>
+             <width>480</width>
+             <height>658</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -1386,11 +1386,11 @@
                </item>
                <item>
                 <widget class="QCheckBox" name="isProxyOnlyForTorrents">
-                 <property name="text">
-                  <string>Use proxy only for torrents</string>
-                 </property>
                  <property name="toolTip">
                   <string>RSS feeds, search engine, software updates or anything else other than torrent transfers and related operations (such as peer exchanges) will use a direct connection</string>
+                 </property>
+                 <property name="text">
+                  <string>Use proxy only for torrents</string>
                  </property>
                  <property name="checked">
                   <bool>false</bool>
@@ -1540,13 +1540,22 @@
           </widget>
          </widget>
         </item>
-        <item>
-         <layout class="QVBoxLayout"/>
-        </item>
        </layout>
       </widget>
-      <widget class="QWidget" name="page_2">
+      <widget class="QWidget" name="tabSpeedPage">
        <layout class="QVBoxLayout" name="verticalLayout_34">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
         <item>
          <widget class="QScrollArea" name="scrollArea_9">
           <property name="widgetResizable">
@@ -1557,266 +1566,107 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>376</width>
-             <height>431</height>
+             <width>502</width>
+             <height>538</height>
             </rect>
            </property>
-           <layout class="QVBoxLayout" name="verticalLayout_33">
+           <layout class="QVBoxLayout" name="verticalLayout_5">
             <item>
-             <widget class="QGroupBox" name="bandwidthBox">
+             <widget class="QGroupBox" name="rateLimitBox">
               <property name="title">
                <string>Global Rate Limits</string>
               </property>
-              <layout class="QGridLayout" name="gridLayout_7">
-               <item row="0" column="0">
-                <widget class="QLabel" name="label_5">
-                 <property name="text">
-                  <string notr="true"/>
+              <layout class="QGridLayout" name="rateLimitBoxLayout">
+               <item row="0" column="2">
+                <widget class="QSpinBox" name="spinUploadLimit">
+                 <property name="enabled">
+                  <bool>false</bool>
                  </property>
+                 <property name="minimum">
+                  <number>1</number>
+                 </property>
+                 <property name="maximum">
+                  <number>1000000</number>
+                 </property>
+                 <property name="value">
+                  <number>100</number>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QCheckBox" name="checkUploadLimit">
+                 <property name="text">
+                  <string>Upload:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="3">
+                <widget class="QLabel" name="label_10">
+                 <property name="text">
+                  <string>KiB/s</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="2">
+                <widget class="QSpinBox" name="spinDownloadLimit">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="minimum">
+                  <number>1</number>
+                 </property>
+                 <property name="maximum">
+                  <number>1000000</number>
+                 </property>
+                 <property name="value">
+                  <number>100</number>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="3">
+                <widget class="QLabel" name="label_13">
+                 <property name="text">
+                  <string>KiB/s</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0" rowspan="2">
+                <widget class="QLabel" name="label_5">
                  <property name="pixmap">
                   <pixmap resource="../icons.qrc">:/icons/slow_off.png</pixmap>
                  </property>
                 </widget>
                </item>
-               <item row="0" column="1">
-                <layout class="QGridLayout" name="gridLayout_6">
-                 <item row="0" column="0">
-                  <widget class="QCheckBox" name="checkUploadLimit">
-                   <property name="text">
-                    <string>Upload:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1">
-                  <widget class="QSpinBox" name="spinUploadLimit">
-                   <property name="enabled">
-                    <bool>false</bool>
-                   </property>
-                   <property name="suffix">
-                    <string/>
-                   </property>
-                   <property name="minimum">
-                    <number>1</number>
-                   </property>
-                   <property name="maximum">
-                    <number>1000000</number>
-                   </property>
-                   <property name="value">
-                    <number>100</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="2">
-                  <widget class="QLabel" name="label_10">
-                   <property name="text">
-                    <string>KiB/s</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="0">
-                  <widget class="QCheckBox" name="checkDownloadLimit">
-                   <property name="text">
-                    <string>Download:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="1">
-                  <widget class="QSpinBox" name="spinDownloadLimit">
-                   <property name="enabled">
-                    <bool>false</bool>
-                   </property>
-                   <property name="suffix">
-                    <string/>
-                   </property>
-                   <property name="minimum">
-                    <number>1</number>
-                   </property>
-                   <property name="maximum">
-                    <number>1000000</number>
-                   </property>
-                   <property name="value">
-                    <number>100</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="2">
-                  <widget class="QLabel" name="label_13">
-                   <property name="text">
-                    <string>KiB/s</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
+               <item row="1" column="1">
+                <widget class="QCheckBox" name="checkDownloadLimit">
+                 <property name="text">
+                  <string>Download:</string>
+                 </property>
+                </widget>
                </item>
-               <item row="0" column="2">
-                <spacer>
+               <item row="0" column="4">
+                <spacer name="horizontalSpacer">
                  <property name="orientation">
                   <enum>Qt::Horizontal</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
-                   <width>200</width>
+                   <width>40</width>
                    <height>20</height>
                   </size>
                  </property>
                 </spacer>
                </item>
-               <item row="1" column="1" colspan="2">
-                <widget class="QGroupBox" name="groupBox_5">
-                 <property name="title">
-                  <string>Options</string>
-                 </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_27">
-                  <item>
-                   <widget class="QCheckBox" name="checkuTP">
-                    <property name="text">
-                     <string>Enable bandwidth management (uTP)</string>
-                    </property>
-                    <property name="checked">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QCheckBox" name="checkLimituTPConnections">
-                    <property name="text">
-                     <string>Apply rate limit to uTP connections</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QCheckBox" name="checkLimitTransportOverhead">
-                    <property name="text">
-                     <string>Apply rate limit to transport overhead</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QCheckBox" name="checkLimitLocalPeerRate">
-                    <property name="text">
-                     <string>Apply rate limit to peers on LAN</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
               </layout>
              </widget>
             </item>
             <item>
-             <widget class="QGroupBox" name="groupBox_6">
+             <widget class="QGroupBox" name="altRateLimitBox">
               <property name="title">
-               <string>Alternative Global Rate Limits</string>
+               <string>Alternative Rate Limits</string>
               </property>
-              <layout class="QVBoxLayout" name="verticalLayout_11">
-               <item>
-                <layout class="QGridLayout" name="gridLayout_9">
-                 <item row="0" column="0">
-                  <widget class="QLabel" name="label_16">
-                   <property name="minimumSize">
-                    <size>
-                     <width>48</width>
-                     <height>48</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>48</width>
-                     <height>48</height>
-                    </size>
-                   </property>
-                   <property name="text">
-                    <string/>
-                   </property>
-                   <property name="pixmap">
-                    <pixmap resource="../icons.qrc">:/icons/slow.png</pixmap>
-                   </property>
-                   <property name="scaledContents">
-                    <bool>false</bool>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1">
-                  <layout class="QGridLayout" name="gridLayout_8">
-                   <item row="0" column="1">
-                    <widget class="QSpinBox" name="spinUploadLimitAlt">
-                     <property name="minimum">
-                      <number>1</number>
-                     </property>
-                     <property name="maximum">
-                      <number>1000000</number>
-                     </property>
-                     <property name="value">
-                      <number>10</number>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="2">
-                    <widget class="QLabel" name="label_14">
-                     <property name="text">
-                      <string>KiB/s</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="1">
-                    <widget class="QSpinBox" name="spinDownloadLimitAlt">
-                     <property name="enabled">
-                      <bool>false</bool>
-                     </property>
-                     <property name="minimum">
-                      <number>1</number>
-                     </property>
-                     <property name="maximum">
-                      <number>1000000</number>
-                     </property>
-                     <property name="value">
-                      <number>10</number>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="2">
-                    <widget class="QLabel" name="label_15">
-                     <property name="text">
-                      <string>KiB/s</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="0">
-                    <widget class="QCheckBox" name="checkUploadLimitAlt">
-                     <property name="text">
-                      <string>Upload:</string>
-                     </property>
-                     <property name="checked">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="0">
-                    <widget class="QCheckBox" name="checkDownloadLimitAlt">
-                     <property name="text">
-                      <string>Download:</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </item>
-                 <item row="0" column="2">
-                  <spacer name="horizontalSpacer_8">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>222</width>
-                     <height>59</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </item>
-               <item>
+              <layout class="QGridLayout" name="gridLayout_6">
+               <item row="2" column="0" colspan="5">
                 <widget class="QGroupBox" name="check_schedule">
                  <property name="title">
                   <string>Schedule the use of alternative rate limits</string>
@@ -1827,129 +1677,235 @@
                  <property name="checked">
                   <bool>false</bool>
                  </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_5">
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_13">
-                    <property name="leftMargin">
-                     <number>5</number>
+                 <layout class="QGridLayout" name="gridLayout_7">
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="label_6">
+                    <property name="text">
+                     <string extracomment="from (time1 to time2)">From:</string>
                     </property>
-                    <item>
-                     <widget class="QLabel" name="label_6">
-                      <property name="text">
-                       <string extracomment="from (time1 to time2)">from</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QTimeEdit" name="schedule_from">
-                      <property name="wrapping">
-                       <bool>true</bool>
-                      </property>
-                      <property name="displayFormat">
-                       <string notr="true">hh:mm</string>
-                      </property>
-                      <property name="calendarPopup">
-                       <bool>false</bool>
-                      </property>
-                      <property name="time">
-                       <time>
-                        <hour>8</hour>
-                        <minute>0</minute>
-                        <second>0</second>
-                       </time>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QLabel" name="label_17">
-                      <property name="text">
-                       <string extracomment="time1 to time2">to</string>
-                      </property>
-                      <property name="alignment">
-                       <set>Qt::AlignCenter</set>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QTimeEdit" name="schedule_to">
-                      <property name="wrapping">
-                       <bool>true</bool>
-                      </property>
-                      <property name="displayFormat">
-                       <string notr="true">hh:mm</string>
-                      </property>
-                      <property name="time">
-                       <time>
-                        <hour>20</hour>
-                        <minute>0</minute>
-                        <second>0</second>
-                       </time>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <spacer name="horizontalSpacer_9">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>40</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                   </layout>
+                   </widget>
                   </item>
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_14">
-                    <property name="leftMargin">
-                     <number>5</number>
+                  <item row="0" column="3">
+                   <widget class="QTimeEdit" name="schedule_to">
+                    <property name="wrapping">
+                     <bool>true</bool>
+                    </property>
+                    <property name="displayFormat">
+                     <string notr="true">hh:mm</string>
+                    </property>
+                    <property name="time">
+                     <time>
+                      <hour>20</hour>
+                      <minute>0</minute>
+                      <second>0</second>
+                     </time>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="2">
+                   <widget class="QLabel" name="label_17">
+                    <property name="text">
+                     <string extracomment="time1 to time2">To:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QTimeEdit" name="schedule_from">
+                    <property name="wrapping">
+                     <bool>true</bool>
+                    </property>
+                    <property name="displayFormat">
+                     <string notr="true">hh:mm</string>
+                    </property>
+                    <property name="calendarPopup">
+                     <bool>false</bool>
+                    </property>
+                    <property name="time">
+                     <time>
+                      <hour>8</hour>
+                      <minute>0</minute>
+                      <second>0</second>
+                     </time>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_18">
+                    <property name="text">
+                     <string>When:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1" colspan="3">
+                   <widget class="QComboBox" name="schedule_days">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
                     </property>
                     <item>
-                     <widget class="QLabel" name="label_18">
-                      <property name="text">
-                       <string>When:</string>
-                      </property>
-                     </widget>
+                     <property name="text">
+                      <string>Every day</string>
+                     </property>
                     </item>
                     <item>
-                     <widget class="QComboBox" name="schedule_days">
-                      <item>
-                       <property name="text">
-                        <string>Every day</string>
-                       </property>
-                      </item>
-                      <item>
-                       <property name="text">
-                        <string>Week days</string>
-                       </property>
-                      </item>
-                      <item>
-                       <property name="text">
-                        <string>Week ends</string>
-                       </property>
-                      </item>
-                     </widget>
+                     <property name="text">
+                      <string>Weekdays</string>
+                     </property>
                     </item>
                     <item>
-                     <spacer name="horizontalSpacer_10">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>40</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
+                     <property name="text">
+                      <string>Weekends</string>
+                     </property>
                     </item>
-                   </layout>
+                   </widget>
+                  </item>
+                  <item row="0" column="4">
+                   <spacer name="horizontalSpacer_8">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
                   </item>
                  </layout>
                 </widget>
+               </item>
+               <item row="0" column="0" rowspan="2">
+                <widget class="QLabel" name="label_16">
+                 <property name="pixmap">
+                  <pixmap resource="../icons.qrc">:/icons/slow.png</pixmap>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QCheckBox" name="checkUploadLimitAlt">
+                 <property name="text">
+                  <string>Upload:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QCheckBox" name="checkDownloadLimitAlt">
+                 <property name="text">
+                  <string>Download:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="2">
+                <widget class="QSpinBox" name="spinUploadLimitAlt">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="minimum">
+                  <number>1</number>
+                 </property>
+                 <property name="maximum">
+                  <number>1000000</number>
+                 </property>
+                 <property name="value">
+                  <number>10</number>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="2">
+                <widget class="QSpinBox" name="spinDownloadLimitAlt">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="minimum">
+                  <number>1</number>
+                 </property>
+                 <property name="maximum">
+                  <number>1000000</number>
+                 </property>
+                 <property name="value">
+                  <number>10</number>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="3">
+                <widget class="QLabel" name="label_14">
+                 <property name="text">
+                  <string>KiB/s</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="3">
+                <widget class="QLabel" name="label_15">
+                 <property name="text">
+                  <string>KiB/s</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="4">
+                <spacer name="horizontalSpacer_5">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="rateLimitsGroupBox">
+              <property name="title">
+               <string>Rate Limits Settings</string>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_8">
+               <item row="4" column="0" colspan="3">
+                <widget class="QCheckBox" name="checkLimitLocalPeerRate">
+                 <property name="text">
+                  <string>Apply rate limit to peers on LAN</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0" colspan="3">
+                <widget class="QCheckBox" name="checkLimitTransportOverhead">
+                 <property name="text">
+                  <string>Apply rate limit to transport overhead</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0" colspan="3">
+                <widget class="QCheckBox" name="checkuTP">
+                 <property name="text">
+                  <string>Enable µTP protocol</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QCheckBox" name="checkLimituTPConnections">
+                 <property name="text">
+                  <string>Apply rate limit to µTP protocol</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="2">
+                <spacer name="horizontalSpacer_9">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
                </item>
               </layout>
              </widget>
@@ -1975,6 +1931,15 @@
       </widget>
       <widget class="QWidget" name="tabOptionPage4">
        <layout class="QVBoxLayout" name="verticalLayout_15">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
         <item>
          <widget class="QScrollArea" name="scrollArea_4">
           <property name="widgetResizable">
@@ -2329,6 +2294,15 @@
       </widget>
       <widget class="QWidget" name="tabOptionPage7">
        <layout class="QVBoxLayout">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
         <item>
          <widget class="QScrollArea" name="scrollArea_7">
           <property name="widgetResizable">
@@ -2704,8 +2678,17 @@
         </item>
        </layout>
       </widget>
-      <widget class="QWidget" name="page_3">
+      <widget class="QWidget" name="tabAdvancedPage">
        <layout class="QVBoxLayout" name="verticalLayout_35">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
         <item>
          <widget class="QScrollArea" name="scrollArea_advanced">
           <property name="widgetResizable">
@@ -2720,7 +2703,20 @@
              <height>28</height>
             </rect>
            </property>
-           <layout class="QVBoxLayout" name="verticalLayout_36"/>
+           <layout class="QVBoxLayout" name="verticalLayout_36">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+           </layout>
           </widget>
          </widget>
         </item>
@@ -2730,34 +2726,11 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>208</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QDialogButtonBox" name="buttonBox">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-       </property>
-       <property name="centerButtons">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
@@ -2890,22 +2863,6 @@
     <hint type="destinationlabel">
      <x>721</x>
      <y>373</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>checkuTP</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>checkLimituTPConnections</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>421</x>
-     <y>147</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>711</x>
-     <y>172</y>
     </hint>
    </hints>
   </connection>

--- a/src/gui/options_imp.cpp
+++ b/src/gui/options_imp.cpp
@@ -423,6 +423,7 @@ void options_imp::saveOptions() {
   pref->setActionOnDblClOnTorrentDl(getActionOnDblClOnTorrentDl());
   pref->setActionOnDblClOnTorrentFn(getActionOnDblClOnTorrentFn());
   // End Downloads preferences
+
   // Connection preferences
   pref->setSessionPort(getPort());
   pref->setRandomPort(checkRandomPort->isChecked());
@@ -539,8 +540,9 @@ void options_imp::loadOptions() {
   int intValue;
   qreal floatValue;
   QString strValue;
-  // General preferences
   const Preferences* const pref = Preferences::instance();
+
+  // General preferences
   setLocale(pref->getLocale());
   confirmDeletion->setChecked(pref->confirmTorrentDeletion());
   checkAltRowColors->setChecked(pref->useAlternatingRowColors());
@@ -560,15 +562,18 @@ void options_imp::loadOptions() {
 
 #ifdef Q_OS_WIN
   checkStartup->setChecked(pref->WinStartup());
-  // Windows: file association settings
   checkAssociateTorrents->setChecked(Preferences::isTorrentFileAssocSet());
   checkAssociateMagnetLinks->setChecked(Preferences::isMagnetLinkAssocSet());
 #endif
   // End General preferences
+
   // Downloads preferences
+  checkAdditionDialog->setChecked(pref->useAdditionDialog());
+  checkAdditionDialogFront->setChecked(pref->additionDialogFront());
+  checkStartPaused->setChecked(pref->addTorrentsInPause());
+
   textSavePath->setText(Utils::Fs::toNativePath(pref->getSavePath()));
   if (pref->isTempPathEnabled()) {
-    // enable
     checkTempFolder->setChecked(true);
   } else {
     checkTempFolder->setChecked(false);
@@ -577,16 +582,13 @@ void options_imp::loadOptions() {
   checkAppendLabel->setChecked(pref->appendTorrentLabel());
   checkAppendqB->setChecked(pref->useIncompleteFilesExtension());
   checkPreallocateAll->setChecked(pref->preAllocateAllFiles());
-  checkAdditionDialog->setChecked(pref->useAdditionDialog());
-  checkAdditionDialogFront->setChecked(pref->additionDialogFront());
-  checkStartPaused->setChecked(pref->addTorrentsInPause());
 
   strValue = Utils::Fs::toNativePath(pref->getTorrentExportDir());
   if (strValue.isEmpty()) {
     // Disable
     checkExportDir->setChecked(false);
   } else {
-    // enable
+    // Enable
     checkExportDir->setChecked(true);
     textExportDir->setText(strValue);
   }
@@ -596,10 +598,11 @@ void options_imp::loadOptions() {
     // Disable
     checkExportDirFin->setChecked(false);
   } else {
-    // enable
+    // Enable
     checkExportDirFin->setChecked(true);
     textExportDirFin->setText(strValue);
   }
+
   groupMailNotification->setChecked(pref->isMailNotificationEnabled());
   dest_email_txt->setText(pref->getMailNotificationEmail());
   smtp_server_txt->setText(pref->getMailNotificationSMTP());
@@ -607,6 +610,7 @@ void options_imp::loadOptions() {
   groupMailNotifAuth->setChecked(pref->getMailNotificationSMTPAuth());
   mailNotifUsername->setText(pref->getMailNotificationSMTPUsername());
   mailNotifPassword->setText(pref->getMailNotificationSMTPPassword());
+
   autoRunBox->setChecked(pref->isAutoRunEnabled());
   autoRun_txt->setText(pref->getAutoRunProgram());
   intValue = pref->getActionOnDblClOnTorrentDl();
@@ -618,11 +622,90 @@ void options_imp::loadOptions() {
     intValue = 1;
   actionTorrentFnOnDblClBox->setCurrentIndex(intValue);
   // End Downloads preferences
+
   // Connection preferences
-  spinPort->setValue(pref->getSessionPort());
   checkUPnP->setChecked(pref->isUPnPEnabled());
   checkRandomPort->setChecked(pref->useRandomPort());
+  spinPort->setValue(pref->getSessionPort());
   spinPort->setDisabled(checkRandomPort->isChecked());
+
+  intValue = pref->getMaxConnecs();
+  if (intValue > 0) {
+    // enable
+    checkMaxConnecs->setChecked(true);
+    spinMaxConnec->setEnabled(true);
+    spinMaxConnec->setValue(intValue);
+  } else {
+    // disable
+    checkMaxConnecs->setChecked(false);
+    spinMaxConnec->setEnabled(false);
+  }
+  intValue = pref->getMaxConnecsPerTorrent();
+  if (intValue > 0) {
+    // enable
+    checkMaxConnecsPerTorrent->setChecked(true);
+    spinMaxConnecPerTorrent->setEnabled(true);
+    spinMaxConnecPerTorrent->setValue(intValue);
+  } else {
+    // disable
+    checkMaxConnecsPerTorrent->setChecked(false);
+    spinMaxConnecPerTorrent->setEnabled(false);
+  }
+  intValue = pref->getMaxUploads();
+  if (intValue > 0) {
+    // enable
+    checkMaxUploads->setChecked(true);
+    spinMaxUploads->setEnabled(true);
+    spinMaxUploads->setValue(intValue);
+  } else {
+    // disable
+    checkMaxUploads->setChecked(false);
+    spinMaxUploads->setEnabled(false);
+  }
+  intValue = pref->getMaxUploadsPerTorrent();
+  if (intValue > 0) {
+    // enable
+    checkMaxUploadsPerTorrent->setChecked(true);
+    spinMaxUploadsPerTorrent->setEnabled(true);
+    spinMaxUploadsPerTorrent->setValue(intValue);
+  } else {
+    // disable
+    checkMaxUploadsPerTorrent->setChecked(false);
+    spinMaxUploadsPerTorrent->setEnabled(false);
+  }
+
+  intValue = pref->getProxyType();
+  switch(intValue) {
+  case Proxy::SOCKS4:
+    comboProxyType->setCurrentIndex(1);
+    break;
+  case Proxy::SOCKS5:
+  case Proxy::SOCKS5_PW:
+    comboProxyType->setCurrentIndex(2);
+    break;
+  case Proxy::HTTP:
+  case Proxy::HTTP_PW:
+    comboProxyType->setCurrentIndex(3);
+    break;
+  default:
+    comboProxyType->setCurrentIndex(0);
+  }
+  enableProxy(comboProxyType->currentIndex());
+  textProxyIP->setText(pref->getProxyIp());
+  spinProxyPort->setValue(pref->getProxyPort());
+  checkProxyPeerConnecs->setChecked(pref->proxyPeerConnections());
+  checkForceProxy->setChecked(pref->getForceProxy());
+  isProxyOnlyForTorrents->setChecked(pref->isProxyOnlyForTorrents());
+  checkProxyAuth->setChecked(pref->isProxyAuthEnabled());
+  textProxyUsername->setText(pref->getProxyUsername());
+  textProxyPassword->setText(pref->getProxyPassword());
+
+  checkIPFilter->setChecked(pref->isFilteringEnabled());
+  checkIpFilterTrackers->setChecked(pref->isFilteringTrackerEnabled());
+  textFilterPath->setText(Utils::Fs::toNativePath(pref->getFilter()));
+  // End Connection preferences
+
+  // Speed preferences
   intValue = pref->getGlobalDownloadLimit();
   if (intValue > 0) {
     // Enabled
@@ -668,97 +751,31 @@ void options_imp::loadOptions() {
     checkUploadLimitAlt->setChecked(false);
     spinUploadLimitAlt->setEnabled(false);
   }
-  // Options
+
   checkuTP->setChecked(pref->isuTPEnabled());
   checkLimituTPConnections->setChecked(pref->isuTPRateLimited());
   checkLimitTransportOverhead->setChecked(pref->includeOverheadInLimits());
   checkLimitLocalPeerRate->setChecked(!pref->getIgnoreLimitsOnLAN());
-  // Scheduler
+
   check_schedule->setChecked(pref->isSchedulerEnabled());
   schedule_from->setTime(pref->getSchedulerStartTime());
   schedule_to->setTime(pref->getSchedulerEndTime());
   schedule_days->setCurrentIndex((int)pref->getSchedulerDays());
+  // End Speed preferences
 
-  intValue = pref->getProxyType();
-  switch(intValue) {
-  case Proxy::SOCKS4:
-    comboProxyType->setCurrentIndex(1);
-    break;
-  case Proxy::SOCKS5:
-  case Proxy::SOCKS5_PW:
-    comboProxyType->setCurrentIndex(2);
-    break;
-  case Proxy::HTTP:
-  case Proxy::HTTP_PW:
-    comboProxyType->setCurrentIndex(3);
-    break;
-  default:
-    comboProxyType->setCurrentIndex(0);
-  }
-  enableProxy(comboProxyType->currentIndex());
-  //if (isProxyEnabled()) {
-  // Proxy is enabled, save settings
-  textProxyIP->setText(pref->getProxyIp());
-  spinProxyPort->setValue(pref->getProxyPort());
-  checkProxyPeerConnecs->setChecked(pref->proxyPeerConnections());
-  checkForceProxy->setChecked(pref->getForceProxy());
-  isProxyOnlyForTorrents->setChecked(pref->isProxyOnlyForTorrents());
-  checkProxyAuth->setChecked(pref->isProxyAuthEnabled());
-  textProxyUsername->setText(pref->getProxyUsername());
-  textProxyPassword->setText(pref->getProxyPassword());
-  //}
-  // End Connection preferences
   // Bittorrent preferences
-  intValue = pref->getMaxConnecs();
-  if (intValue > 0) {
-    // enable
-    checkMaxConnecs->setChecked(true);
-    spinMaxConnec->setEnabled(true);
-    spinMaxConnec->setValue(intValue);
-  } else {
-    // disable
-    checkMaxConnecs->setChecked(false);
-    spinMaxConnec->setEnabled(false);
-  }
-  intValue = pref->getMaxConnecsPerTorrent();
-  if (intValue > 0) {
-    // enable
-    checkMaxConnecsPerTorrent->setChecked(true);
-    spinMaxConnecPerTorrent->setEnabled(true);
-    spinMaxConnecPerTorrent->setValue(intValue);
-  } else {
-    // disable
-    checkMaxConnecsPerTorrent->setChecked(false);
-    spinMaxConnecPerTorrent->setEnabled(false);
-  }
-  intValue = pref->getMaxUploads();
-  if (intValue > 0) {
-    // enable
-    checkMaxUploads->setChecked(true);
-    spinMaxUploads->setEnabled(true);
-    spinMaxUploads->setValue(intValue);
-  } else {
-    // disable
-    checkMaxUploads->setChecked(false);
-    spinMaxUploads->setEnabled(false);
-  }
-  intValue = pref->getMaxUploadsPerTorrent();
-  if (intValue > 0) {
-    // enable
-    checkMaxUploadsPerTorrent->setChecked(true);
-    spinMaxUploadsPerTorrent->setEnabled(true);
-    spinMaxUploadsPerTorrent->setValue(intValue);
-  } else {
-    // disable
-    checkMaxUploadsPerTorrent->setChecked(false);
-    spinMaxUploadsPerTorrent->setEnabled(false);
-  }
   checkDHT->setChecked(pref->isDHTEnabled());
   checkPeX->setChecked(pref->isPeXEnabled());
   checkLSD->setChecked(pref->isLSDEnabled());
   comboEncryption->setCurrentIndex(pref->getEncryptionSetting());
   checkAnonymousMode->setChecked(pref->isAnonymousModeEnabled());
-  // Ratio limit
+
+  checkEnableQueueing->setChecked(pref->isQueueingSystemEnabled());
+  spinMaxActiveDownloads->setValue(pref->getMaxActiveDownloads());
+  spinMaxActiveUploads->setValue(pref->getMaxActiveUploads());
+  spinMaxActiveTorrents->setValue(pref->getMaxActiveTorrents());
+  checkIgnoreSlowTorrentsForQueueing->setChecked(pref->ignoreSlowTorrentsForQueueing());
+
   floatValue = pref->getGlobalMaxRatio();
   if (floatValue >= 0.) {
     // Enable
@@ -774,20 +791,8 @@ void options_imp::loadOptions() {
   }
   comboRatioLimitAct->setCurrentIndex(pref->getMaxRatioAction());
   // End Bittorrent preferences
-  // Misc preferences
-  // * IP Filter
-  checkIPFilter->setChecked(pref->isFilteringEnabled());
-  checkIpFilterTrackers->setChecked(pref->isFilteringTrackerEnabled());
-  textFilterPath->setText(Utils::Fs::toNativePath(pref->getFilter()));
-  // End IP Filter
-  // Queueing system preferences
-  checkEnableQueueing->setChecked(pref->isQueueingSystemEnabled());
-  spinMaxActiveDownloads->setValue(pref->getMaxActiveDownloads());
-  spinMaxActiveUploads->setValue(pref->getMaxActiveUploads());
-  spinMaxActiveTorrents->setValue(pref->getMaxActiveTorrents());
-  checkIgnoreSlowTorrentsForQueueing->setChecked(pref->ignoreSlowTorrentsForQueueing());
-  // End Queueing system preferences
-  // Web UI
+
+  // Web UI preferences
   checkWebUi->setChecked(pref->isWebUiEnabled());
   spinWebUiPort->setValue(pref->getWebUiPort());
   checkWebUIUPnP->setChecked(pref->useUPnPForWebUIPort());
@@ -797,13 +802,13 @@ void options_imp::loadOptions() {
   textWebUiUsername->setText(pref->getWebUiUsername());
   textWebUiPassword->setText(pref->getWebUiPassword());
   checkBypassLocalAuth->setChecked(!pref->isWebUiLocalAuthEnabled());
-  // Dynamic DNS
+
   checkDynDNS->setChecked(pref->isDynDNSEnabled());
   comboDNSService->setCurrentIndex((int)pref->getDynDNSService());
   domainNameTxt->setText(pref->getDynDomainName());
   DNSUsernameTxt->setText(pref->getDynDNSUsername());
   DNSPasswordTxt->setText(pref->getDynDNSPassword());
-  // End Web UI
+  // End Web UI preferences
 }
 
 // return min & max ports

--- a/src/gui/options_imp.cpp
+++ b/src/gui/options_imp.cpp
@@ -57,1384 +57,1450 @@
 #endif
 
 // Constructor
-options_imp::options_imp(QWidget *parent):
-  QDialog(parent), m_refreshingIpFilter(false) {
-  qDebug("-> Constructing Options");
-  setupUi(this);
-  setAttribute(Qt::WA_DeleteOnClose);
-  setModal(true);
-  // Icons
-  tabSelection->item(TAB_UI)->setIcon(GuiIconProvider::instance()->getIcon("preferences-desktop"));
-  tabSelection->item(TAB_BITTORRENT)->setIcon(GuiIconProvider::instance()->getIcon("preferences-system-network"));
-  tabSelection->item(TAB_CONNECTION)->setIcon(GuiIconProvider::instance()->getIcon("network-wired"));
-  tabSelection->item(TAB_DOWNLOADS)->setIcon(GuiIconProvider::instance()->getIcon("download"));
-  tabSelection->item(TAB_SPEED)->setIcon(GuiIconProvider::instance()->getIcon("chronometer"));
+options_imp::options_imp(QWidget *parent)
+    : QDialog(parent),
+    m_refreshingIpFilter(false)
+{
+    qDebug("-> Constructing Options");
+    setupUi(this);
+    setAttribute(Qt::WA_DeleteOnClose);
+    setModal(true);
+    // Icons
+    tabSelection->item(TAB_UI)->setIcon(GuiIconProvider::instance()->getIcon("preferences-desktop"));
+    tabSelection->item(TAB_BITTORRENT)->setIcon(GuiIconProvider::instance()->getIcon("preferences-system-network"));
+    tabSelection->item(TAB_CONNECTION)->setIcon(GuiIconProvider::instance()->getIcon("network-wired"));
+    tabSelection->item(TAB_DOWNLOADS)->setIcon(GuiIconProvider::instance()->getIcon("download"));
+    tabSelection->item(TAB_SPEED)->setIcon(GuiIconProvider::instance()->getIcon("chronometer"));
 #ifndef DISABLE_WEBUI
-  tabSelection->item(TAB_WEBUI)->setIcon(GuiIconProvider::instance()->getIcon("network-server"));
+    tabSelection->item(TAB_WEBUI)->setIcon(GuiIconProvider::instance()->getIcon("network-server"));
 #else
-  tabSelection->item(TAB_WEBUI)->setHidden(true);
+    tabSelection->item(TAB_WEBUI)->setHidden(true);
 #endif
-  tabSelection->item(TAB_ADVANCED)->setIcon(GuiIconProvider::instance()->getIcon("preferences-other"));
-  IpFilterRefreshBtn->setIcon(GuiIconProvider::instance()->getIcon("view-refresh"));
+    tabSelection->item(TAB_ADVANCED)->setIcon(GuiIconProvider::instance()->getIcon("preferences-other"));
+    IpFilterRefreshBtn->setIcon(GuiIconProvider::instance()->getIcon("view-refresh"));
 
-  hsplitter->setCollapsible(0, false);
-  hsplitter->setCollapsible(1, false);
-  // Get apply button in button box
-  QList<QAbstractButton *> buttons = buttonBox->buttons();
-  foreach (QAbstractButton *button, buttons) {
-    if (buttonBox->buttonRole(button) == QDialogButtonBox::ApplyRole) {
-      applyButton = button;
-      break;
+    hsplitter->setCollapsible(0, false);
+    hsplitter->setCollapsible(1, false);
+    // Get apply button in button box
+    QList<QAbstractButton *> buttons = buttonBox->buttons();
+    foreach (QAbstractButton *button, buttons) {
+        if (buttonBox->buttonRole(button) == QDialogButtonBox::ApplyRole) {
+            applyButton = button;
+            break;
+        }
     }
-  }
 
 #if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
-  scanFoldersView->horizontalHeader()->setResizeMode(QHeaderView::ResizeToContents);
+    scanFoldersView->horizontalHeader()->setResizeMode(QHeaderView::ResizeToContents);
 #else
-  scanFoldersView->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+    scanFoldersView->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
 #endif
-  scanFoldersView->setModel(ScanFoldersModel::instance());
-  connect(ScanFoldersModel::instance(), SIGNAL(dataChanged(QModelIndex,QModelIndex)), this, SLOT(enableApplyButton()));
-  connect(scanFoldersView->selectionModel(), SIGNAL(selectionChanged(QItemSelection,QItemSelection)), this, SLOT(handleScanFolderViewSelectionChanged()));
+    scanFoldersView->setModel(ScanFoldersModel::instance());
+    connect(ScanFoldersModel::instance(), SIGNAL(dataChanged(QModelIndex, QModelIndex)), this, SLOT(enableApplyButton()));
+    connect(scanFoldersView->selectionModel(), SIGNAL(selectionChanged(QItemSelection, QItemSelection)), this, SLOT(handleScanFolderViewSelectionChanged()));
 
-  connect(buttonBox, SIGNAL(clicked(QAbstractButton*)), this, SLOT(applySettings(QAbstractButton*)));
-  // Languages supported
-  initializeLanguageCombo();
+    connect(buttonBox, SIGNAL(clicked(QAbstractButton*)), this, SLOT(applySettings(QAbstractButton*)));
+    // Languages supported
+    initializeLanguageCombo();
 
-  // Load week days (scheduler)
-  for (uint i=1; i<=7; ++i) {
-    schedule_days->addItem(QDate::longDayName(i, QDate::StandaloneFormat));
-  }
+    // Load week days (scheduler)
+    for (uint i = 1; i <= 7; ++i)
+        schedule_days->addItem(QDate::longDayName(i, QDate::StandaloneFormat));
 
-  // Load options
-  loadOptions();
-  // Disable systray integration if it is not supported by the system
-  if (!QSystemTrayIcon::isSystemTrayAvailable()) {
-    checkShowSystray->setChecked(false);
-    checkShowSystray->setEnabled(false);
-    label_trayIconStyle->setVisible(false);
-    comboTrayIcon->setVisible(false);
-  }
+    // Load options
+    loadOptions();
+    // Disable systray integration if it is not supported by the system
+    if (!QSystemTrayIcon::isSystemTrayAvailable()) {
+        checkShowSystray->setChecked(false);
+        checkShowSystray->setEnabled(false);
+        label_trayIconStyle->setVisible(false);
+        comboTrayIcon->setVisible(false);
+    }
 
 #if defined(QT_NO_OPENSSL)
-  checkWebUiHttps->setVisible(false);
+    checkWebUiHttps->setVisible(false);
 #endif
 
 #ifndef Q_OS_WIN
-  checkStartup->setVisible(false);
-  groupFileAssociation->setVisible(false);
+    checkStartup->setVisible(false);
+    groupFileAssociation->setVisible(false);
 #endif
 
-  // Connect signals / slots
-  connect(comboProxyType, SIGNAL(currentIndexChanged(int)),this, SLOT(enableProxy(int)));
-  connect(checkRandomPort, SIGNAL(toggled(bool)), spinPort, SLOT(setDisabled(bool)));
+    // Connect signals / slots
+    connect(comboProxyType, SIGNAL(currentIndexChanged(int)), this, SLOT(enableProxy(int)));
+    connect(checkRandomPort, SIGNAL(toggled(bool)), spinPort, SLOT(setDisabled(bool)));
 
-  // Apply button is activated when a value is changed
-  // General tab
-  connect(comboI18n, SIGNAL(currentIndexChanged(int)), this, SLOT(enableApplyButton()));
-  connect(confirmDeletion, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkAltRowColors, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkShowSystray, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkCloseToSystray, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkMinimizeToSysTray, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkStartMinimized, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    // Apply button is activated when a value is changed
+    // General tab
+    connect(comboI18n, SIGNAL(currentIndexChanged(int)), this, SLOT(enableApplyButton()));
+    connect(confirmDeletion, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkAltRowColors, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkShowSystray, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkCloseToSystray, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkMinimizeToSysTray, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkStartMinimized, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
 #ifdef Q_OS_WIN
-  connect(checkStartup, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkStartup, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
 #endif
-  connect(checkShowSplash, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkProgramExitConfirm, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkPreventFromSuspend, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(comboTrayIcon, SIGNAL(currentIndexChanged(int)), this, SLOT(enableApplyButton()));
+    connect(checkShowSplash, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkProgramExitConfirm, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkPreventFromSuspend, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(comboTrayIcon, SIGNAL(currentIndexChanged(int)), this, SLOT(enableApplyButton()));
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC)) && !defined(QT_DBUS_LIB)
-  checkPreventFromSuspend->setDisabled(true);
+    checkPreventFromSuspend->setDisabled(true);
 #endif
 #ifdef Q_OS_WIN
-  connect(checkAssociateTorrents, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkAssociateMagnetLinks, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkAssociateTorrents, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkAssociateMagnetLinks, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
 #endif
-  // Downloads tab
-  connect(textSavePath, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(textTempPath, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(checkAppendLabel, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkAppendqB, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkPreallocateAll, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkAdditionDialog, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkAdditionDialogFront, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkStartPaused, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkExportDir, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkExportDirFin, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(textExportDir, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(textExportDirFin, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(actionTorrentDlOnDblClBox, SIGNAL(currentIndexChanged(int)), this, SLOT(enableApplyButton()));
-  connect(actionTorrentFnOnDblClBox, SIGNAL(currentIndexChanged(int)), this, SLOT(enableApplyButton()));
-  connect(checkTempFolder, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(addScanFolderButton, SIGNAL(clicked()), this, SLOT(enableApplyButton()));
-  connect(removeScanFolderButton, SIGNAL(clicked()), this, SLOT(enableApplyButton()));
-  connect(groupMailNotification, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(dest_email_txt, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(smtp_server_txt, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(checkSmtpSSL, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(groupMailNotifAuth, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(mailNotifUsername, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(mailNotifPassword, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(autoRunBox, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(autoRun_txt, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
+    // Downloads tab
+    connect(textSavePath, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(textTempPath, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(checkAppendLabel, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkAppendqB, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkPreallocateAll, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkAdditionDialog, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkAdditionDialogFront, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkStartPaused, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkExportDir, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkExportDirFin, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(textExportDir, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(textExportDirFin, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(actionTorrentDlOnDblClBox, SIGNAL(currentIndexChanged(int)), this, SLOT(enableApplyButton()));
+    connect(actionTorrentFnOnDblClBox, SIGNAL(currentIndexChanged(int)), this, SLOT(enableApplyButton()));
+    connect(checkTempFolder, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(addScanFolderButton, SIGNAL(clicked()), this, SLOT(enableApplyButton()));
+    connect(removeScanFolderButton, SIGNAL(clicked()), this, SLOT(enableApplyButton()));
+    connect(groupMailNotification, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(dest_email_txt, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(smtp_server_txt, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(checkSmtpSSL, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(groupMailNotifAuth, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(mailNotifUsername, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(mailNotifPassword, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(autoRunBox, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(autoRun_txt, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
 
-  autoRun_param->setText(QString::fromUtf8("%1\n    %2\n    %3\n    %4\n    %5\n    %6\n    %7\n    %8\n    %9\n    %10")
-                         .arg(tr("Supported parameters (case sensitive):"))
-                         .arg(tr("%N: Torrent name"))
-                         .arg(tr("%F: Downloaded file name (single-file torrent only)"))
-                         .arg(tr("%L: Label"))
-                         .arg(tr("%D: Save path"))
-                         .arg(tr("%K: \"single\"|\"multi\" file(s)"))
-                         .arg(tr("%C: Number of files"))
-                         .arg(tr("%Z: Torrent size (bytes)"))
-                         .arg(tr("%T: Current tracker"))
-                         .arg(tr("%I: Info hash")));
+    autoRun_param->setText(QString::fromUtf8("%1\n    %2\n    %3\n    %4\n    %5\n    %6\n    %7\n    %8\n    %9\n    %10")
+                           .arg(tr("Supported parameters (case sensitive):"))
+                           .arg(tr("%N: Torrent name"))
+                           .arg(tr("%F: Downloaded file name (single-file torrent only)"))
+                           .arg(tr("%L: Label"))
+                           .arg(tr("%D: Save path"))
+                           .arg(tr("%K: \"single\"|\"multi\" file(s)"))
+                           .arg(tr("%C: Number of files"))
+                           .arg(tr("%Z: Torrent size (bytes)"))
+                           .arg(tr("%T: Current tracker"))
+                           .arg(tr("%I: Info hash")));
 
-  // Connection tab
-  connect(spinPort, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(checkRandomPort, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkUPnP, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkUploadLimit, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkDownloadLimit, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkUploadLimitAlt, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkDownloadLimitAlt, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(spinUploadLimit, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(spinDownloadLimit, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(spinUploadLimitAlt, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(spinDownloadLimitAlt, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(check_schedule, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(schedule_from, SIGNAL(timeChanged(QTime)), this, SLOT(enableApplyButton()));
-  connect(schedule_to, SIGNAL(timeChanged(QTime)), this, SLOT(enableApplyButton()));
-  connect(schedule_days, SIGNAL(currentIndexChanged(int)), this, SLOT(enableApplyButton()));
-  connect(checkuTP, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
-  connect(checkLimituTPConnections, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
-  connect(checkLimitTransportOverhead, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
-  connect(checkLimitLocalPeerRate, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
-  // Bittorrent tab
-  connect(checkMaxConnecs, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkMaxConnecsPerTorrent, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkMaxUploads, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkMaxUploadsPerTorrent, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(spinMaxConnec, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(spinMaxConnecPerTorrent, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(spinMaxUploads, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(spinMaxUploadsPerTorrent, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(checkDHT, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkAnonymousMode, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkPeX, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkLSD, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(comboEncryption, SIGNAL(currentIndexChanged(int)), this, SLOT(enableApplyButton()));
-  connect(checkMaxRatio, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(spinMaxRatio, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(comboRatioLimitAct, SIGNAL(currentIndexChanged(int)), this, SLOT(enableApplyButton()));
-  // Proxy tab
-  connect(comboProxyType, SIGNAL(currentIndexChanged(int)), this, SLOT(enableApplyButton()));
-  connect(textProxyIP, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(spinProxyPort, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(checkProxyPeerConnecs, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
-  connect(checkForceProxy, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
-  connect(isProxyOnlyForTorrents, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
-  connect(checkProxyAuth, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(textProxyUsername, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(textProxyPassword, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
-  // Misc tab
-  connect(checkIPFilter, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkIpFilterTrackers, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
-  connect(textFilterPath, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(checkEnableQueueing, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(spinMaxActiveDownloads, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(spinMaxActiveUploads, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(spinMaxActiveTorrents, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(checkIgnoreSlowTorrentsForQueueing, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    // Connection tab
+    connect(spinPort, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(checkRandomPort, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkUPnP, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkUploadLimit, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkDownloadLimit, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkUploadLimitAlt, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkDownloadLimitAlt, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(spinUploadLimit, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(spinDownloadLimit, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(spinUploadLimitAlt, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(spinDownloadLimitAlt, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(check_schedule, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(schedule_from, SIGNAL(timeChanged(QTime)), this, SLOT(enableApplyButton()));
+    connect(schedule_to, SIGNAL(timeChanged(QTime)), this, SLOT(enableApplyButton()));
+    connect(schedule_days, SIGNAL(currentIndexChanged(int)), this, SLOT(enableApplyButton()));
+    connect(checkuTP, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
+    connect(checkLimituTPConnections, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
+    connect(checkLimitTransportOverhead, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
+    connect(checkLimitLocalPeerRate, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
+    // Bittorrent tab
+    connect(checkMaxConnecs, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkMaxConnecsPerTorrent, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkMaxUploads, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkMaxUploadsPerTorrent, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(spinMaxConnec, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(spinMaxConnecPerTorrent, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(spinMaxUploads, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(spinMaxUploadsPerTorrent, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(checkDHT, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkAnonymousMode, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkPeX, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkLSD, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(comboEncryption, SIGNAL(currentIndexChanged(int)), this, SLOT(enableApplyButton()));
+    connect(checkMaxRatio, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(spinMaxRatio, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(comboRatioLimitAct, SIGNAL(currentIndexChanged(int)), this, SLOT(enableApplyButton()));
+    // Proxy tab
+    connect(comboProxyType, SIGNAL(currentIndexChanged(int)), this, SLOT(enableApplyButton()));
+    connect(textProxyIP, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(spinProxyPort, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(checkProxyPeerConnecs, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
+    connect(checkForceProxy, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
+    connect(isProxyOnlyForTorrents, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
+    connect(checkProxyAuth, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(textProxyUsername, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(textProxyPassword, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
+    // Misc tab
+    connect(checkIPFilter, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkIpFilterTrackers, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
+    connect(textFilterPath, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(checkEnableQueueing, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(spinMaxActiveDownloads, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(spinMaxActiveUploads, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(spinMaxActiveTorrents, SIGNAL(valueChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(checkIgnoreSlowTorrentsForQueueing, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
 #ifndef DISABLE_WEBUI
-  // Web UI tab
-  connect(checkWebUi, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(spinWebUiPort, SIGNAL(valueChanged(int)), this, SLOT(enableApplyButton()));
-  connect(checkWebUIUPnP, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
-  connect(checkWebUiHttps, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
-  connect(btnWebUiKey, SIGNAL(clicked()), SLOT(enableApplyButton()));
-  connect(btnWebUiCrt, SIGNAL(clicked()), SLOT(enableApplyButton()));
-  connect(textWebUiUsername, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(textWebUiPassword, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
-  connect(checkBypassLocalAuth, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
-  connect(checkDynDNS, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
-  connect(comboDNSService, SIGNAL(currentIndexChanged(int)), SLOT(enableApplyButton()));
-  connect(domainNameTxt, SIGNAL(textChanged(QString)), SLOT(enableApplyButton()));
-  connect(DNSUsernameTxt, SIGNAL(textChanged(QString)), SLOT(enableApplyButton()));
-  connect(DNSPasswordTxt, SIGNAL(textChanged(QString)), SLOT(enableApplyButton()));
+    // Web UI tab
+    connect(checkWebUi, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(spinWebUiPort, SIGNAL(valueChanged(int)), this, SLOT(enableApplyButton()));
+    connect(checkWebUIUPnP, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
+    connect(checkWebUiHttps, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
+    connect(btnWebUiKey, SIGNAL(clicked()), SLOT(enableApplyButton()));
+    connect(btnWebUiCrt, SIGNAL(clicked()), SLOT(enableApplyButton()));
+    connect(textWebUiUsername, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(textWebUiPassword, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
+    connect(checkBypassLocalAuth, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkDynDNS, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
+    connect(comboDNSService, SIGNAL(currentIndexChanged(int)), SLOT(enableApplyButton()));
+    connect(domainNameTxt, SIGNAL(textChanged(QString)), SLOT(enableApplyButton()));
+    connect(DNSUsernameTxt, SIGNAL(textChanged(QString)), SLOT(enableApplyButton()));
+    connect(DNSPasswordTxt, SIGNAL(textChanged(QString)), SLOT(enableApplyButton()));
 #endif
-  // Disable apply Button
-  applyButton->setEnabled(false);
-  // Tab selection mechanism
-  connect(tabSelection, SIGNAL(currentItemChanged(QListWidgetItem *, QListWidgetItem *)), this, SLOT(changePage(QListWidgetItem *, QListWidgetItem*)));
-  // Load Advanced settings
-  QVBoxLayout *adv_layout = new QVBoxLayout();
-  advancedSettings = new AdvancedSettings();
-  adv_layout->addWidget(advancedSettings);
-  scrollArea_advanced->setLayout(adv_layout);
-  connect(advancedSettings, SIGNAL(settingsChanged()), this, SLOT(enableApplyButton()));
+    // Disable apply Button
+    applyButton->setEnabled(false);
+    // Tab selection mechanism
+    connect(tabSelection, SIGNAL(currentItemChanged(QListWidgetItem *, QListWidgetItem *)), this, SLOT(changePage(QListWidgetItem *, QListWidgetItem*)));
+    // Load Advanced settings
+    QVBoxLayout *adv_layout = new QVBoxLayout();
+    advancedSettings = new AdvancedSettings();
+    adv_layout->addWidget(advancedSettings);
+    scrollArea_advanced->setLayout(adv_layout);
+    connect(advancedSettings, SIGNAL(settingsChanged()), this, SLOT(enableApplyButton()));
 
-  // Adapt size
-  show();
-  loadWindowState();
+    // Adapt size
+    show();
+    loadWindowState();
 }
 
 void options_imp::initializeLanguageCombo()
 {
-  // List language files
-  const QDir lang_dir(":/lang");
-  const QStringList lang_files = lang_dir.entryList(QStringList() << "qbittorrent_*.qm", QDir::Files);
-  foreach (QString lang_file, lang_files) {
-    QString localeStr = lang_file.mid(12); // remove "qbittorrent_"
-    localeStr.chop(3); // Remove ".qm"
-    QLocale locale(localeStr);
-    QString language_name = languageToLocalizedString(locale);
-    comboI18n->addItem(/*QIcon(":/icons/flags/"+country+".png"), */language_name, localeStr);
-    qDebug() << "Supported locale:" << localeStr;
-  }
+    // List language files
+    const QDir lang_dir(":/lang");
+    const QStringList lang_files = lang_dir.entryList(QStringList() << "qbittorrent_*.qm", QDir::Files);
+    foreach (QString lang_file, lang_files) {
+        QString localeStr = lang_file.mid(12); // remove "qbittorrent_"
+        localeStr.chop(3); // Remove ".qm"
+        QLocale locale(localeStr);
+        QString language_name = languageToLocalizedString(locale);
+        comboI18n->addItem(/*QIcon(":/icons/flags/"+country+".png"), */ language_name, localeStr);
+        qDebug() << "Supported locale:" << localeStr;
+    }
 }
 
 // Main destructor
-options_imp::~options_imp() {
-  qDebug("-> destructing Options");
-  foreach (const QString &path, addedScanDirs)
-    ScanFoldersModel::instance()->removePath(path);
-  delete scrollArea_advanced->layout();
-  delete advancedSettings;
+options_imp::~options_imp()
+{
+    qDebug("-> destructing Options");
+    foreach (const QString &path, addedScanDirs)
+        ScanFoldersModel::instance()->removePath(path);
+    delete scrollArea_advanced->layout();
+    delete advancedSettings;
 }
 
-void options_imp::changePage(QListWidgetItem *current, QListWidgetItem *previous) {
-  if (!current)
-    current = previous;
-  tabOption->setCurrentIndex(tabSelection->row(current));
+void options_imp::changePage(QListWidgetItem *current, QListWidgetItem *previous)
+{
+    if (!current)
+        current = previous;
+    tabOption->setCurrentIndex(tabSelection->row(current));
 }
 
-void options_imp::loadWindowState() {
-  const Preferences* const pref = Preferences::instance();
-  resize(pref->getPrefSize(sizeFittingScreen()));
-  QPoint p = pref->getPrefPos();
-  QRect scr_rect = qApp->desktop()->screenGeometry();
-  if (!p.isNull() && scr_rect.contains(p))
-    move(p);
-  // Load slider size
-  const QStringList sizes_str = pref->getPrefHSplitterSizes();
-  // Splitter size
-  QList<int> sizes;
-  if (sizes_str.size() == 2) {
-    sizes << sizes_str.first().toInt();
-    sizes << sizes_str.last().toInt();
-  } else {
-    sizes << 116;
-    sizes << hsplitter->width()-116;
-  }
-  hsplitter->setSizes(sizes);
-}
-
-void options_imp::saveWindowState() const {
-  Preferences* const pref = Preferences::instance();
-  pref->setPrefSize(size());
-  pref->setPrefPos(pos());
-  // Splitter size
-  QStringList sizes_str;
-  sizes_str << QString::number(hsplitter->sizes().first());
-  sizes_str << QString::number(hsplitter->sizes().last());
-  pref->setPrefHSplitterSizes(sizes_str);
-}
-
-QSize options_imp::sizeFittingScreen() const {
-  int scrn = 0;
-  QWidget *w = this->topLevelWidget();
-
-  if (w)
-    scrn = QApplication::desktop()->screenNumber(w);
-  else if (QApplication::desktop()->isVirtualDesktop())
-    scrn = QApplication::desktop()->screenNumber(QCursor::pos());
-  else
-    scrn = QApplication::desktop()->screenNumber(this);
-
-  QRect desk(QApplication::desktop()->availableGeometry(scrn));
-  if (width() > desk.width() || height() > desk.height()) {
-    if (desk.width() > 0 && desk.height() > 0)
-      return QSize(desk.width(), desk.height());
-  }
-  return size();
-}
-
-void options_imp::saveOptions() {
-  applyButton->setEnabled(false);
-  Preferences* const pref = Preferences::instance();
-  // Load the translation
-  QString locale = getLocale();
-  if (pref->getLocale() != locale) {
-    QTranslator *translator = new QTranslator;
-    if (translator->load(QString::fromUtf8(":/lang/qbittorrent_") + locale)) {
-      qDebug("%s locale recognized, using translation.", qPrintable(locale));
-    }else{
-      qDebug("%s locale unrecognized, using default (en).", qPrintable(locale));
+void options_imp::loadWindowState()
+{
+    const Preferences* const pref = Preferences::instance();
+    resize(pref->getPrefSize(sizeFittingScreen()));
+    QPoint p = pref->getPrefPos();
+    QRect scr_rect = qApp->desktop()->screenGeometry();
+    if (!p.isNull() && scr_rect.contains(p))
+        move(p);
+    // Load slider size
+    const QStringList sizes_str = pref->getPrefHSplitterSizes();
+    // Splitter size
+    QList<int> sizes;
+    if (sizes_str.size() == 2) {
+        sizes << sizes_str.first().toInt();
+        sizes << sizes_str.last().toInt();
     }
-    qApp->installTranslator(translator);
-  }
+    else {
+        sizes << 116;
+        sizes << hsplitter->width() - 116;
+    }
+    hsplitter->setSizes(sizes);
+}
 
-  // General preferences
-  pref->setLocale(locale);
-  pref->setConfirmTorrentDeletion(confirmDeletion->isChecked());
-  pref->setAlternatingRowColors(checkAltRowColors->isChecked());
-  pref->setSystrayIntegration(systrayIntegration());
-  pref->setTrayIconStyle(TrayIcon::Style(comboTrayIcon->currentIndex()));
-  pref->setCloseToTray(closeToTray());
-  pref->setMinimizeToTray(minimizeToTray());
-  pref->setStartMinimized(startMinimized());
-  pref->setSplashScreenDisabled(isSlashScreenDisabled());
-  pref->setConfirmOnExit(checkProgramExitConfirm->isChecked());
-  pref->setPreventFromSuspend(preventFromSuspend());
+void options_imp::saveWindowState() const
+{
+    Preferences* const pref = Preferences::instance();
+    pref->setPrefSize(size());
+    pref->setPrefPos(pos());
+    // Splitter size
+    QStringList sizes_str;
+    sizes_str << QString::number(hsplitter->sizes().first());
+    sizes_str << QString::number(hsplitter->sizes().last());
+    pref->setPrefHSplitterSizes(sizes_str);
+}
+
+QSize options_imp::sizeFittingScreen() const
+{
+    int scrn = 0;
+    QWidget *w = this->topLevelWidget();
+
+    if (w)
+        scrn = QApplication::desktop()->screenNumber(w);
+    else if (QApplication::desktop()->isVirtualDesktop())
+        scrn = QApplication::desktop()->screenNumber(QCursor::pos());
+    else
+        scrn = QApplication::desktop()->screenNumber(this);
+
+    QRect desk(QApplication::desktop()->availableGeometry(scrn));
+    if (width() > desk.width() || height() > desk.height())
+        if (desk.width() > 0 && desk.height() > 0)
+            return QSize(desk.width(), desk.height());
+    return size();
+}
+
+void options_imp::saveOptions()
+{
+    applyButton->setEnabled(false);
+    Preferences* const pref = Preferences::instance();
+    // Load the translation
+    QString locale = getLocale();
+    if (pref->getLocale() != locale) {
+        QTranslator *translator = new QTranslator;
+        if (translator->load(QString::fromUtf8(":/lang/qbittorrent_") + locale))
+            qDebug("%s locale recognized, using translation.", qPrintable(locale));
+        else
+            qDebug("%s locale unrecognized, using default (en).", qPrintable(locale));
+        qApp->installTranslator(translator);
+    }
+
+    // General preferences
+    pref->setLocale(locale);
+    pref->setConfirmTorrentDeletion(confirmDeletion->isChecked());
+    pref->setAlternatingRowColors(checkAltRowColors->isChecked());
+    pref->setSystrayIntegration(systrayIntegration());
+    pref->setTrayIconStyle(TrayIcon::Style(comboTrayIcon->currentIndex()));
+    pref->setCloseToTray(closeToTray());
+    pref->setMinimizeToTray(minimizeToTray());
+    pref->setStartMinimized(startMinimized());
+    pref->setSplashScreenDisabled(isSlashScreenDisabled());
+    pref->setConfirmOnExit(checkProgramExitConfirm->isChecked());
+    pref->setPreventFromSuspend(preventFromSuspend());
 #ifdef Q_OS_WIN
-  pref->setWinStartup(WinStartup());
-  // Windows: file association settings
-  Preferences::setTorrentFileAssoc(checkAssociateTorrents->isChecked());
-  Preferences::setMagnetLinkAssoc(checkAssociateMagnetLinks->isChecked());
+    pref->setWinStartup(WinStartup());
+    // Windows: file association settings
+    Preferences::setTorrentFileAssoc(checkAssociateTorrents->isChecked());
+    Preferences::setMagnetLinkAssoc(checkAssociateMagnetLinks->isChecked());
 #endif
-  // End General preferences
+    // End General preferences
 
-  // Downloads preferences
-  pref->setSavePath(getSavePath());
-  pref->setTempPathEnabled(isTempPathEnabled());
-  pref->setTempPath(getTempPath());
-  pref->setAppendTorrentLabel(checkAppendLabel->isChecked());
-  pref->useIncompleteFilesExtension(checkAppendqB->isChecked());
-  pref->preAllocateAllFiles(preAllocateAllFiles());
-  pref->useAdditionDialog(useAdditionDialog());
-  pref->additionDialogFront(checkAdditionDialogFront->isChecked());
-  pref->addTorrentsInPause(addTorrentsInPause());
-  ScanFoldersModel::instance()->makePersistent();
-  addedScanDirs.clear();
-  pref->setTorrentExportDir(getTorrentExportDir());
-  pref->setFinishedTorrentExportDir(getFinishedTorrentExportDir());
-  pref->setMailNotificationEnabled(groupMailNotification->isChecked());
-  pref->setMailNotificationEmail(dest_email_txt->text());
-  pref->setMailNotificationSMTP(smtp_server_txt->text());
-  pref->setMailNotificationSMTPSSL(checkSmtpSSL->isChecked());
-  pref->setMailNotificationSMTPAuth(groupMailNotifAuth->isChecked());
-  pref->setMailNotificationSMTPUsername(mailNotifUsername->text());
-  pref->setMailNotificationSMTPPassword(mailNotifPassword->text());
-  pref->setAutoRunEnabled(autoRunBox->isChecked());
-  pref->setAutoRunProgram(autoRun_txt->text().trimmed());
-  pref->setActionOnDblClOnTorrentDl(getActionOnDblClOnTorrentDl());
-  pref->setActionOnDblClOnTorrentFn(getActionOnDblClOnTorrentFn());
-  // End Downloads preferences
+    // Downloads preferences
+    pref->setSavePath(getSavePath());
+    pref->setTempPathEnabled(isTempPathEnabled());
+    pref->setTempPath(getTempPath());
+    pref->setAppendTorrentLabel(checkAppendLabel->isChecked());
+    pref->useIncompleteFilesExtension(checkAppendqB->isChecked());
+    pref->preAllocateAllFiles(preAllocateAllFiles());
+    pref->useAdditionDialog(useAdditionDialog());
+    pref->additionDialogFront(checkAdditionDialogFront->isChecked());
+    pref->addTorrentsInPause(addTorrentsInPause());
+    ScanFoldersModel::instance()->makePersistent();
+    addedScanDirs.clear();
+    pref->setTorrentExportDir(getTorrentExportDir());
+    pref->setFinishedTorrentExportDir(getFinishedTorrentExportDir());
+    pref->setMailNotificationEnabled(groupMailNotification->isChecked());
+    pref->setMailNotificationEmail(dest_email_txt->text());
+    pref->setMailNotificationSMTP(smtp_server_txt->text());
+    pref->setMailNotificationSMTPSSL(checkSmtpSSL->isChecked());
+    pref->setMailNotificationSMTPAuth(groupMailNotifAuth->isChecked());
+    pref->setMailNotificationSMTPUsername(mailNotifUsername->text());
+    pref->setMailNotificationSMTPPassword(mailNotifPassword->text());
+    pref->setAutoRunEnabled(autoRunBox->isChecked());
+    pref->setAutoRunProgram(autoRun_txt->text().trimmed());
+    pref->setActionOnDblClOnTorrentDl(getActionOnDblClOnTorrentDl());
+    pref->setActionOnDblClOnTorrentFn(getActionOnDblClOnTorrentFn());
+    // End Downloads preferences
 
-  // Connection preferences
-  pref->setSessionPort(getPort());
-  pref->setRandomPort(checkRandomPort->isChecked());
-  pref->setUPnPEnabled(isUPnPEnabled());
-  const QPair<int, int> down_up_limit = getGlobalBandwidthLimits();
-  pref->setGlobalDownloadLimit(down_up_limit.first);
-  pref->setGlobalUploadLimit(down_up_limit.second);
-  pref->setuTPEnabled(checkuTP->isChecked());
-  pref->setuTPRateLimited(checkLimituTPConnections->isChecked());
-  pref->includeOverheadInLimits(checkLimitTransportOverhead->isChecked());
-  pref->setIgnoreLimitsOnLAN(!checkLimitLocalPeerRate->isChecked());
-  const QPair<int, int> alt_down_up_limit = getAltGlobalBandwidthLimits();
-  pref->setAltGlobalDownloadLimit(alt_down_up_limit.first);
-  pref->setAltGlobalUploadLimit(alt_down_up_limit.second);
-  pref->setSchedulerEnabled(check_schedule->isChecked());
-  pref->setSchedulerStartTime(schedule_from->time());
-  pref->setSchedulerEndTime(schedule_to->time());
-  pref->setSchedulerDays((scheduler_days)schedule_days->currentIndex());
-  pref->setProxyType(getProxyType());
-  pref->setProxyIp(getProxyIp());
-  pref->setProxyPort(getProxyPort());
-  pref->setProxyPeerConnections(checkProxyPeerConnecs->isChecked());
-  pref->setForceProxy(checkForceProxy->isChecked());
-  pref->setProxyOnlyForTorrents(isProxyOnlyForTorrents->isChecked());
-  pref->setProxyAuthEnabled(isProxyAuthEnabled());
-  pref->setProxyUsername(getProxyUsername());
-  pref->setProxyPassword(getProxyPassword());
-  // End Connection preferences
-  // Bittorrent preferences
-  pref->setMaxConnecs(getMaxConnecs());
-  pref->setMaxConnecsPerTorrent(getMaxConnecsPerTorrent());
-  pref->setMaxUploads(getMaxUploads());
-  pref->setMaxUploadsPerTorrent(getMaxUploadsPerTorrent());
-  pref->setDHTEnabled(isDHTEnabled());
-  pref->setPeXEnabled(checkPeX->isChecked());
-  pref->setLSDEnabled(isLSDEnabled());
-  pref->setEncryptionSetting(getEncryptionSetting());
-  pref->enableAnonymousMode(checkAnonymousMode->isChecked());
-  pref->setGlobalMaxRatio(getMaxRatio());
-  pref->setMaxRatioAction(comboRatioLimitAct->currentIndex());
-  // End Bittorrent preferences
-  // Misc preferences
-  // * IPFilter
-  pref->setFilteringEnabled(isFilteringEnabled());
-  if (isFilteringEnabled()) {
-    pref->setFilteringTrackerEnabled(checkIpFilterTrackers->isChecked());
-    pref->setFilter(textFilterPath->text());
-  }
-  // End IPFilter preferences
-  // Queueing system
-  pref->setQueueingSystemEnabled(isQueueingSystemEnabled());
-  pref->setMaxActiveDownloads(spinMaxActiveDownloads->value());
-  pref->setMaxActiveUploads(spinMaxActiveUploads->value());
-  pref->setMaxActiveTorrents(spinMaxActiveTorrents->value());
-  pref->setIgnoreSlowTorrentsForQueueing(checkIgnoreSlowTorrentsForQueueing->isChecked());
-  // End Queueing system preferences
-  // Web UI
-  pref->setWebUiEnabled(isWebUiEnabled());
-  if (isWebUiEnabled())
-  {
-    pref->setWebUiPort(webUiPort());
-    pref->setUPnPForWebUIPort(checkWebUIUPnP->isChecked());
-    pref->setWebUiHttpsEnabled(checkWebUiHttps->isChecked());
-    if (checkWebUiHttps->isChecked())
-    {
-      pref->setWebUiHttpsCertificate(m_sslCert);
-      pref->setWebUiHttpsKey(m_sslKey);
+    // Connection preferences
+    pref->setSessionPort(getPort());
+    pref->setRandomPort(checkRandomPort->isChecked());
+    pref->setUPnPEnabled(isUPnPEnabled());
+    const QPair<int, int> down_up_limit = getGlobalBandwidthLimits();
+    pref->setGlobalDownloadLimit(down_up_limit.first);
+    pref->setGlobalUploadLimit(down_up_limit.second);
+    pref->setuTPEnabled(checkuTP->isChecked());
+    pref->setuTPRateLimited(checkLimituTPConnections->isChecked());
+    pref->includeOverheadInLimits(checkLimitTransportOverhead->isChecked());
+    pref->setIgnoreLimitsOnLAN(!checkLimitLocalPeerRate->isChecked());
+    const QPair<int, int> alt_down_up_limit = getAltGlobalBandwidthLimits();
+    pref->setAltGlobalDownloadLimit(alt_down_up_limit.first);
+    pref->setAltGlobalUploadLimit(alt_down_up_limit.second);
+    pref->setSchedulerEnabled(check_schedule->isChecked());
+    pref->setSchedulerStartTime(schedule_from->time());
+    pref->setSchedulerEndTime(schedule_to->time());
+    pref->setSchedulerDays((scheduler_days)schedule_days->currentIndex());
+    pref->setProxyType(getProxyType());
+    pref->setProxyIp(getProxyIp());
+    pref->setProxyPort(getProxyPort());
+    pref->setProxyPeerConnections(checkProxyPeerConnecs->isChecked());
+    pref->setForceProxy(checkForceProxy->isChecked());
+    pref->setProxyOnlyForTorrents(isProxyOnlyForTorrents->isChecked());
+    pref->setProxyAuthEnabled(isProxyAuthEnabled());
+    pref->setProxyUsername(getProxyUsername());
+    pref->setProxyPassword(getProxyPassword());
+    // End Connection preferences
+    // Bittorrent preferences
+    pref->setMaxConnecs(getMaxConnecs());
+    pref->setMaxConnecsPerTorrent(getMaxConnecsPerTorrent());
+    pref->setMaxUploads(getMaxUploads());
+    pref->setMaxUploadsPerTorrent(getMaxUploadsPerTorrent());
+    pref->setDHTEnabled(isDHTEnabled());
+    pref->setPeXEnabled(checkPeX->isChecked());
+    pref->setLSDEnabled(isLSDEnabled());
+    pref->setEncryptionSetting(getEncryptionSetting());
+    pref->enableAnonymousMode(checkAnonymousMode->isChecked());
+    pref->setGlobalMaxRatio(getMaxRatio());
+    pref->setMaxRatioAction(comboRatioLimitAct->currentIndex());
+    // End Bittorrent preferences
+    // Misc preferences
+    // * IPFilter
+    pref->setFilteringEnabled(isFilteringEnabled());
+    if (isFilteringEnabled()) {
+        pref->setFilteringTrackerEnabled(checkIpFilterTrackers->isChecked());
+        pref->setFilter(textFilterPath->text());
     }
-    pref->setWebUiUsername(webUiUsername());
-    // FIXME: Check that the password is valid (not empty at least)
-    pref->setWebUiPassword(webUiPassword());
-    pref->setWebUiLocalAuthEnabled(!checkBypassLocalAuth->isChecked());
-    // DynDNS
-    pref->setDynDNSEnabled(checkDynDNS->isChecked());
-    pref->setDynDNSService(comboDNSService->currentIndex());
-    pref->setDynDomainName(domainNameTxt->text());
-    pref->setDynDNSUsername(DNSUsernameTxt->text());
-    pref->setDynDNSPassword(DNSPasswordTxt->text());
-  }
-  // End Web UI
-  // End preferences
-  // Save advanced settings
-  advancedSettings->saveAdvancedSettings();
-  // Assume that user changed multiple settings
-  // so it's best to save immediately
-  pref->apply();
+    // End IPFilter preferences
+    // Queueing system
+    pref->setQueueingSystemEnabled(isQueueingSystemEnabled());
+    pref->setMaxActiveDownloads(spinMaxActiveDownloads->value());
+    pref->setMaxActiveUploads(spinMaxActiveUploads->value());
+    pref->setMaxActiveTorrents(spinMaxActiveTorrents->value());
+    pref->setIgnoreSlowTorrentsForQueueing(checkIgnoreSlowTorrentsForQueueing->isChecked());
+    // End Queueing system preferences
+    // Web UI
+    pref->setWebUiEnabled(isWebUiEnabled());
+    if (isWebUiEnabled()) {
+        pref->setWebUiPort(webUiPort());
+        pref->setUPnPForWebUIPort(checkWebUIUPnP->isChecked());
+        pref->setWebUiHttpsEnabled(checkWebUiHttps->isChecked());
+        if (checkWebUiHttps->isChecked()) {
+            pref->setWebUiHttpsCertificate(m_sslCert);
+            pref->setWebUiHttpsKey(m_sslKey);
+        }
+        pref->setWebUiUsername(webUiUsername());
+        // FIXME: Check that the password is valid (not empty at least)
+        pref->setWebUiPassword(webUiPassword());
+        pref->setWebUiLocalAuthEnabled(!checkBypassLocalAuth->isChecked());
+        // DynDNS
+        pref->setDynDNSEnabled(checkDynDNS->isChecked());
+        pref->setDynDNSService(comboDNSService->currentIndex());
+        pref->setDynDomainName(domainNameTxt->text());
+        pref->setDynDNSUsername(DNSUsernameTxt->text());
+        pref->setDynDNSPassword(DNSPasswordTxt->text());
+    }
+    // End Web UI
+    // End preferences
+    // Save advanced settings
+    advancedSettings->saveAdvancedSettings();
+    // Assume that user changed multiple settings
+    // so it's best to save immediately
+    pref->apply();
 }
 
-bool options_imp::isFilteringEnabled() const {
-  return checkIPFilter->isChecked();
+bool options_imp::isFilteringEnabled() const
+{
+    return checkIPFilter->isChecked();
 }
 
-int options_imp::getProxyType() const {
-  switch(comboProxyType->currentIndex()) {
-  case 1:
-    return Proxy::SOCKS4;
-    break;
-  case 2:
-    if (isProxyAuthEnabled()) {
-      return Proxy::SOCKS5_PW;
+int options_imp::getProxyType() const
+{
+    switch (comboProxyType->currentIndex()) {
+    case 1:
+        return Proxy::SOCKS4;
+        break;
+    case 2:
+        if (isProxyAuthEnabled())
+            return Proxy::SOCKS5_PW;
+        return Proxy::SOCKS5;
+    case 3:
+        if (isProxyAuthEnabled())
+            return Proxy::HTTP_PW;
+        return Proxy::HTTP;
+    default:
+        return -1;
     }
-    return Proxy::SOCKS5;
-  case 3:
-    if (isProxyAuthEnabled()) {
-      return Proxy::HTTP_PW;
-    }
-    return Proxy::HTTP;
-  default:
-    return -1;
-  }
 }
 
-void options_imp::loadOptions() {
-  int intValue;
-  qreal floatValue;
-  QString strValue;
-  const Preferences* const pref = Preferences::instance();
+void options_imp::loadOptions()
+{
+    int intValue;
+    qreal floatValue;
+    QString strValue;
+    const Preferences* const pref = Preferences::instance();
 
-  // General preferences
-  setLocale(pref->getLocale());
-  confirmDeletion->setChecked(pref->confirmTorrentDeletion());
-  checkAltRowColors->setChecked(pref->useAlternatingRowColors());
+    // General preferences
+    setLocale(pref->getLocale());
+    confirmDeletion->setChecked(pref->confirmTorrentDeletion());
+    checkAltRowColors->setChecked(pref->useAlternatingRowColors());
 
-  checkShowSplash->setChecked(!pref->isSplashScreenDisabled());
-  checkStartMinimized->setChecked(pref->startMinimized());
-  checkProgramExitConfirm->setChecked(pref->confirmOnExit());
+    checkShowSplash->setChecked(!pref->isSplashScreenDisabled());
+    checkStartMinimized->setChecked(pref->startMinimized());
+    checkProgramExitConfirm->setChecked(pref->confirmOnExit());
 
-  checkShowSystray->setChecked(pref->systrayIntegration());
-  if (checkShowSystray->isChecked()) {
-    checkMinimizeToSysTray->setChecked(pref->minimizeToTray());
-    checkCloseToSystray->setChecked(pref->closeToTray());
-    comboTrayIcon->setCurrentIndex(pref->trayIconStyle());
-  }
+    checkShowSystray->setChecked(pref->systrayIntegration());
+    if (checkShowSystray->isChecked()) {
+        checkMinimizeToSysTray->setChecked(pref->minimizeToTray());
+        checkCloseToSystray->setChecked(pref->closeToTray());
+        comboTrayIcon->setCurrentIndex(pref->trayIconStyle());
+    }
 
-  checkPreventFromSuspend->setChecked(pref->preventFromSuspend());
+    checkPreventFromSuspend->setChecked(pref->preventFromSuspend());
 
 #ifdef Q_OS_WIN
-  checkStartup->setChecked(pref->WinStartup());
-  checkAssociateTorrents->setChecked(Preferences::isTorrentFileAssocSet());
-  checkAssociateMagnetLinks->setChecked(Preferences::isMagnetLinkAssocSet());
+    checkStartup->setChecked(pref->WinStartup());
+    checkAssociateTorrents->setChecked(Preferences::isTorrentFileAssocSet());
+    checkAssociateMagnetLinks->setChecked(Preferences::isMagnetLinkAssocSet());
 #endif
-  // End General preferences
+    // End General preferences
 
-  // Downloads preferences
-  checkAdditionDialog->setChecked(pref->useAdditionDialog());
-  checkAdditionDialogFront->setChecked(pref->additionDialogFront());
-  checkStartPaused->setChecked(pref->addTorrentsInPause());
+    // Downloads preferences
+    checkAdditionDialog->setChecked(pref->useAdditionDialog());
+    checkAdditionDialogFront->setChecked(pref->additionDialogFront());
+    checkStartPaused->setChecked(pref->addTorrentsInPause());
 
-  textSavePath->setText(Utils::Fs::toNativePath(pref->getSavePath()));
-  if (pref->isTempPathEnabled()) {
-    checkTempFolder->setChecked(true);
-  } else {
-    checkTempFolder->setChecked(false);
-  }
-  textTempPath->setText(Utils::Fs::toNativePath(pref->getTempPath()));
-  checkAppendLabel->setChecked(pref->appendTorrentLabel());
-  checkAppendqB->setChecked(pref->useIncompleteFilesExtension());
-  checkPreallocateAll->setChecked(pref->preAllocateAllFiles());
+    textSavePath->setText(Utils::Fs::toNativePath(pref->getSavePath()));
+    if (pref->isTempPathEnabled())
+        checkTempFolder->setChecked(true);
+    else
+        checkTempFolder->setChecked(false);
+    textTempPath->setText(Utils::Fs::toNativePath(pref->getTempPath()));
+    checkAppendLabel->setChecked(pref->appendTorrentLabel());
+    checkAppendqB->setChecked(pref->useIncompleteFilesExtension());
+    checkPreallocateAll->setChecked(pref->preAllocateAllFiles());
 
-  strValue = Utils::Fs::toNativePath(pref->getTorrentExportDir());
-  if (strValue.isEmpty()) {
-    // Disable
-    checkExportDir->setChecked(false);
-  } else {
-    // Enable
-    checkExportDir->setChecked(true);
-    textExportDir->setText(strValue);
-  }
+    strValue = Utils::Fs::toNativePath(pref->getTorrentExportDir());
+    if (strValue.isEmpty()) {
+        // Disable
+        checkExportDir->setChecked(false);
+    }
+    else {
+        // Enable
+        checkExportDir->setChecked(true);
+        textExportDir->setText(strValue);
+    }
 
-  strValue = Utils::Fs::toNativePath(pref->getFinishedTorrentExportDir());
-  if (strValue.isEmpty()) {
-    // Disable
-    checkExportDirFin->setChecked(false);
-  } else {
-    // Enable
-    checkExportDirFin->setChecked(true);
-    textExportDirFin->setText(strValue);
-  }
+    strValue = Utils::Fs::toNativePath(pref->getFinishedTorrentExportDir());
+    if (strValue.isEmpty()) {
+        // Disable
+        checkExportDirFin->setChecked(false);
+    }
+    else {
+        // Enable
+        checkExportDirFin->setChecked(true);
+        textExportDirFin->setText(strValue);
+    }
 
-  groupMailNotification->setChecked(pref->isMailNotificationEnabled());
-  dest_email_txt->setText(pref->getMailNotificationEmail());
-  smtp_server_txt->setText(pref->getMailNotificationSMTP());
-  checkSmtpSSL->setChecked(pref->getMailNotificationSMTPSSL());
-  groupMailNotifAuth->setChecked(pref->getMailNotificationSMTPAuth());
-  mailNotifUsername->setText(pref->getMailNotificationSMTPUsername());
-  mailNotifPassword->setText(pref->getMailNotificationSMTPPassword());
+    groupMailNotification->setChecked(pref->isMailNotificationEnabled());
+    dest_email_txt->setText(pref->getMailNotificationEmail());
+    smtp_server_txt->setText(pref->getMailNotificationSMTP());
+    checkSmtpSSL->setChecked(pref->getMailNotificationSMTPSSL());
+    groupMailNotifAuth->setChecked(pref->getMailNotificationSMTPAuth());
+    mailNotifUsername->setText(pref->getMailNotificationSMTPUsername());
+    mailNotifPassword->setText(pref->getMailNotificationSMTPPassword());
 
-  autoRunBox->setChecked(pref->isAutoRunEnabled());
-  autoRun_txt->setText(pref->getAutoRunProgram());
-  intValue = pref->getActionOnDblClOnTorrentDl();
-  if (intValue >= actionTorrentDlOnDblClBox->count())
-    intValue = 0;
-  actionTorrentDlOnDblClBox->setCurrentIndex(intValue);
-  intValue = pref->getActionOnDblClOnTorrentFn();
-  if (intValue >= actionTorrentFnOnDblClBox->count())
-    intValue = 1;
-  actionTorrentFnOnDblClBox->setCurrentIndex(intValue);
-  // End Downloads preferences
+    autoRunBox->setChecked(pref->isAutoRunEnabled());
+    autoRun_txt->setText(pref->getAutoRunProgram());
+    intValue = pref->getActionOnDblClOnTorrentDl();
+    if (intValue >= actionTorrentDlOnDblClBox->count())
+        intValue = 0;
+    actionTorrentDlOnDblClBox->setCurrentIndex(intValue);
+    intValue = pref->getActionOnDblClOnTorrentFn();
+    if (intValue >= actionTorrentFnOnDblClBox->count())
+        intValue = 1;
+    actionTorrentFnOnDblClBox->setCurrentIndex(intValue);
+    // End Downloads preferences
 
-  // Connection preferences
-  checkUPnP->setChecked(pref->isUPnPEnabled());
-  checkRandomPort->setChecked(pref->useRandomPort());
-  spinPort->setValue(pref->getSessionPort());
-  spinPort->setDisabled(checkRandomPort->isChecked());
+    // Connection preferences
+    checkUPnP->setChecked(pref->isUPnPEnabled());
+    checkRandomPort->setChecked(pref->useRandomPort());
+    spinPort->setValue(pref->getSessionPort());
+    spinPort->setDisabled(checkRandomPort->isChecked());
 
-  intValue = pref->getMaxConnecs();
-  if (intValue > 0) {
-    // enable
-    checkMaxConnecs->setChecked(true);
-    spinMaxConnec->setEnabled(true);
-    spinMaxConnec->setValue(intValue);
-  } else {
-    // disable
-    checkMaxConnecs->setChecked(false);
-    spinMaxConnec->setEnabled(false);
-  }
-  intValue = pref->getMaxConnecsPerTorrent();
-  if (intValue > 0) {
-    // enable
-    checkMaxConnecsPerTorrent->setChecked(true);
-    spinMaxConnecPerTorrent->setEnabled(true);
-    spinMaxConnecPerTorrent->setValue(intValue);
-  } else {
-    // disable
-    checkMaxConnecsPerTorrent->setChecked(false);
-    spinMaxConnecPerTorrent->setEnabled(false);
-  }
-  intValue = pref->getMaxUploads();
-  if (intValue > 0) {
-    // enable
-    checkMaxUploads->setChecked(true);
-    spinMaxUploads->setEnabled(true);
-    spinMaxUploads->setValue(intValue);
-  } else {
-    // disable
-    checkMaxUploads->setChecked(false);
-    spinMaxUploads->setEnabled(false);
-  }
-  intValue = pref->getMaxUploadsPerTorrent();
-  if (intValue > 0) {
-    // enable
-    checkMaxUploadsPerTorrent->setChecked(true);
-    spinMaxUploadsPerTorrent->setEnabled(true);
-    spinMaxUploadsPerTorrent->setValue(intValue);
-  } else {
-    // disable
-    checkMaxUploadsPerTorrent->setChecked(false);
-    spinMaxUploadsPerTorrent->setEnabled(false);
-  }
+    intValue = pref->getMaxConnecs();
+    if (intValue > 0) {
+        // enable
+        checkMaxConnecs->setChecked(true);
+        spinMaxConnec->setEnabled(true);
+        spinMaxConnec->setValue(intValue);
+    }
+    else {
+        // disable
+        checkMaxConnecs->setChecked(false);
+        spinMaxConnec->setEnabled(false);
+    }
+    intValue = pref->getMaxConnecsPerTorrent();
+    if (intValue > 0) {
+        // enable
+        checkMaxConnecsPerTorrent->setChecked(true);
+        spinMaxConnecPerTorrent->setEnabled(true);
+        spinMaxConnecPerTorrent->setValue(intValue);
+    }
+    else {
+        // disable
+        checkMaxConnecsPerTorrent->setChecked(false);
+        spinMaxConnecPerTorrent->setEnabled(false);
+    }
+    intValue = pref->getMaxUploads();
+    if (intValue > 0) {
+        // enable
+        checkMaxUploads->setChecked(true);
+        spinMaxUploads->setEnabled(true);
+        spinMaxUploads->setValue(intValue);
+    }
+    else {
+        // disable
+        checkMaxUploads->setChecked(false);
+        spinMaxUploads->setEnabled(false);
+    }
+    intValue = pref->getMaxUploadsPerTorrent();
+    if (intValue > 0) {
+        // enable
+        checkMaxUploadsPerTorrent->setChecked(true);
+        spinMaxUploadsPerTorrent->setEnabled(true);
+        spinMaxUploadsPerTorrent->setValue(intValue);
+    }
+    else {
+        // disable
+        checkMaxUploadsPerTorrent->setChecked(false);
+        spinMaxUploadsPerTorrent->setEnabled(false);
+    }
 
-  intValue = pref->getProxyType();
-  switch(intValue) {
-  case Proxy::SOCKS4:
-    comboProxyType->setCurrentIndex(1);
-    break;
-  case Proxy::SOCKS5:
-  case Proxy::SOCKS5_PW:
-    comboProxyType->setCurrentIndex(2);
-    break;
-  case Proxy::HTTP:
-  case Proxy::HTTP_PW:
-    comboProxyType->setCurrentIndex(3);
-    break;
-  default:
-    comboProxyType->setCurrentIndex(0);
-  }
-  enableProxy(comboProxyType->currentIndex());
-  textProxyIP->setText(pref->getProxyIp());
-  spinProxyPort->setValue(pref->getProxyPort());
-  checkProxyPeerConnecs->setChecked(pref->proxyPeerConnections());
-  checkForceProxy->setChecked(pref->getForceProxy());
-  isProxyOnlyForTorrents->setChecked(pref->isProxyOnlyForTorrents());
-  checkProxyAuth->setChecked(pref->isProxyAuthEnabled());
-  textProxyUsername->setText(pref->getProxyUsername());
-  textProxyPassword->setText(pref->getProxyPassword());
+    intValue = pref->getProxyType();
+    switch (intValue) {
+    case Proxy::SOCKS4:
+        comboProxyType->setCurrentIndex(1);
+        break;
+    case Proxy::SOCKS5:
+    case Proxy::SOCKS5_PW:
+        comboProxyType->setCurrentIndex(2);
+        break;
+    case Proxy::HTTP:
+    case Proxy::HTTP_PW:
+        comboProxyType->setCurrentIndex(3);
+        break;
+    default:
+        comboProxyType->setCurrentIndex(0);
+    }
+    enableProxy(comboProxyType->currentIndex());
+    textProxyIP->setText(pref->getProxyIp());
+    spinProxyPort->setValue(pref->getProxyPort());
+    checkProxyPeerConnecs->setChecked(pref->proxyPeerConnections());
+    checkForceProxy->setChecked(pref->getForceProxy());
+    isProxyOnlyForTorrents->setChecked(pref->isProxyOnlyForTorrents());
+    checkProxyAuth->setChecked(pref->isProxyAuthEnabled());
+    textProxyUsername->setText(pref->getProxyUsername());
+    textProxyPassword->setText(pref->getProxyPassword());
 
-  checkIPFilter->setChecked(pref->isFilteringEnabled());
-  checkIpFilterTrackers->setChecked(pref->isFilteringTrackerEnabled());
-  textFilterPath->setText(Utils::Fs::toNativePath(pref->getFilter()));
-  // End Connection preferences
+    checkIPFilter->setChecked(pref->isFilteringEnabled());
+    checkIpFilterTrackers->setChecked(pref->isFilteringTrackerEnabled());
+    textFilterPath->setText(Utils::Fs::toNativePath(pref->getFilter()));
+    // End Connection preferences
 
-  // Speed preferences
-  intValue = pref->getGlobalDownloadLimit();
-  if (intValue > 0) {
-    // Enabled
-    checkDownloadLimit->setChecked(true);
-    spinDownloadLimit->setEnabled(true);
-    spinDownloadLimit->setValue(intValue);
-  } else {
-    // Disabled
-    checkDownloadLimit->setChecked(false);
-    spinDownloadLimit->setEnabled(false);
-  }
-  intValue = pref->getGlobalUploadLimit();
-  if (intValue != -1) {
-    // Enabled
-    checkUploadLimit->setChecked(true);
-    spinUploadLimit->setEnabled(true);
-    spinUploadLimit->setValue(intValue);
-  } else {
-    // Disabled
-    checkUploadLimit->setChecked(false);
-    spinUploadLimit->setEnabled(false);
-  }
+    // Speed preferences
+    intValue = pref->getGlobalDownloadLimit();
+    if (intValue > 0) {
+        // Enabled
+        checkDownloadLimit->setChecked(true);
+        spinDownloadLimit->setEnabled(true);
+        spinDownloadLimit->setValue(intValue);
+    }
+    else {
+        // Disabled
+        checkDownloadLimit->setChecked(false);
+        spinDownloadLimit->setEnabled(false);
+    }
+    intValue = pref->getGlobalUploadLimit();
+    if (intValue != -1) {
+        // Enabled
+        checkUploadLimit->setChecked(true);
+        spinUploadLimit->setEnabled(true);
+        spinUploadLimit->setValue(intValue);
+    }
+    else {
+        // Disabled
+        checkUploadLimit->setChecked(false);
+        spinUploadLimit->setEnabled(false);
+    }
 
-  intValue = pref->getAltGlobalDownloadLimit();
-  if (intValue > 0) {
-    // Enabled
-    checkDownloadLimitAlt->setChecked(true);
-    spinDownloadLimitAlt->setEnabled(true);
-    spinDownloadLimitAlt->setValue(intValue);
-  } else {
-    // Disabled
-    checkDownloadLimitAlt->setChecked(false);
-    spinDownloadLimitAlt->setEnabled(false);
-  }
-  intValue = pref->getAltGlobalUploadLimit();
-  if (intValue != -1) {
-    // Enabled
-    checkUploadLimitAlt->setChecked(true);
-    spinUploadLimitAlt->setEnabled(true);
-    spinUploadLimitAlt->setValue(intValue);
-  } else {
-    // Disabled
-    checkUploadLimitAlt->setChecked(false);
-    spinUploadLimitAlt->setEnabled(false);
-  }
+    intValue = pref->getAltGlobalDownloadLimit();
+    if (intValue > 0) {
+        // Enabled
+        checkDownloadLimitAlt->setChecked(true);
+        spinDownloadLimitAlt->setEnabled(true);
+        spinDownloadLimitAlt->setValue(intValue);
+    }
+    else {
+        // Disabled
+        checkDownloadLimitAlt->setChecked(false);
+        spinDownloadLimitAlt->setEnabled(false);
+    }
+    intValue = pref->getAltGlobalUploadLimit();
+    if (intValue != -1) {
+        // Enabled
+        checkUploadLimitAlt->setChecked(true);
+        spinUploadLimitAlt->setEnabled(true);
+        spinUploadLimitAlt->setValue(intValue);
+    }
+    else {
+        // Disabled
+        checkUploadLimitAlt->setChecked(false);
+        spinUploadLimitAlt->setEnabled(false);
+    }
 
-  checkuTP->setChecked(pref->isuTPEnabled());
-  checkLimituTPConnections->setChecked(pref->isuTPRateLimited());
-  checkLimitTransportOverhead->setChecked(pref->includeOverheadInLimits());
-  checkLimitLocalPeerRate->setChecked(!pref->getIgnoreLimitsOnLAN());
+    checkuTP->setChecked(pref->isuTPEnabled());
+    checkLimituTPConnections->setChecked(pref->isuTPRateLimited());
+    checkLimitTransportOverhead->setChecked(pref->includeOverheadInLimits());
+    checkLimitLocalPeerRate->setChecked(!pref->getIgnoreLimitsOnLAN());
 
-  check_schedule->setChecked(pref->isSchedulerEnabled());
-  schedule_from->setTime(pref->getSchedulerStartTime());
-  schedule_to->setTime(pref->getSchedulerEndTime());
-  schedule_days->setCurrentIndex((int)pref->getSchedulerDays());
-  // End Speed preferences
+    check_schedule->setChecked(pref->isSchedulerEnabled());
+    schedule_from->setTime(pref->getSchedulerStartTime());
+    schedule_to->setTime(pref->getSchedulerEndTime());
+    schedule_days->setCurrentIndex((int)pref->getSchedulerDays());
+    // End Speed preferences
 
-  // Bittorrent preferences
-  checkDHT->setChecked(pref->isDHTEnabled());
-  checkPeX->setChecked(pref->isPeXEnabled());
-  checkLSD->setChecked(pref->isLSDEnabled());
-  comboEncryption->setCurrentIndex(pref->getEncryptionSetting());
-  checkAnonymousMode->setChecked(pref->isAnonymousModeEnabled());
+    // Bittorrent preferences
+    checkDHT->setChecked(pref->isDHTEnabled());
+    checkPeX->setChecked(pref->isPeXEnabled());
+    checkLSD->setChecked(pref->isLSDEnabled());
+    comboEncryption->setCurrentIndex(pref->getEncryptionSetting());
+    checkAnonymousMode->setChecked(pref->isAnonymousModeEnabled());
 
-  checkEnableQueueing->setChecked(pref->isQueueingSystemEnabled());
-  spinMaxActiveDownloads->setValue(pref->getMaxActiveDownloads());
-  spinMaxActiveUploads->setValue(pref->getMaxActiveUploads());
-  spinMaxActiveTorrents->setValue(pref->getMaxActiveTorrents());
-  checkIgnoreSlowTorrentsForQueueing->setChecked(pref->ignoreSlowTorrentsForQueueing());
+    checkEnableQueueing->setChecked(pref->isQueueingSystemEnabled());
+    spinMaxActiveDownloads->setValue(pref->getMaxActiveDownloads());
+    spinMaxActiveUploads->setValue(pref->getMaxActiveUploads());
+    spinMaxActiveTorrents->setValue(pref->getMaxActiveTorrents());
+    checkIgnoreSlowTorrentsForQueueing->setChecked(pref->ignoreSlowTorrentsForQueueing());
 
-  floatValue = pref->getGlobalMaxRatio();
-  if (floatValue >= 0.) {
-    // Enable
-    checkMaxRatio->setChecked(true);
-    spinMaxRatio->setEnabled(true);
-    comboRatioLimitAct->setEnabled(true);
-    spinMaxRatio->setValue(floatValue);
-  } else {
-    // Disable
-    checkMaxRatio->setChecked(false);
-    spinMaxRatio->setEnabled(false);
-    comboRatioLimitAct->setEnabled(false);
-  }
-  comboRatioLimitAct->setCurrentIndex(pref->getMaxRatioAction());
-  // End Bittorrent preferences
+    floatValue = pref->getGlobalMaxRatio();
+    if (floatValue >= 0.) {
+        // Enable
+        checkMaxRatio->setChecked(true);
+        spinMaxRatio->setEnabled(true);
+        comboRatioLimitAct->setEnabled(true);
+        spinMaxRatio->setValue(floatValue);
+    }
+    else {
+        // Disable
+        checkMaxRatio->setChecked(false);
+        spinMaxRatio->setEnabled(false);
+        comboRatioLimitAct->setEnabled(false);
+    }
+    comboRatioLimitAct->setCurrentIndex(pref->getMaxRatioAction());
+    // End Bittorrent preferences
 
-  // Web UI preferences
-  checkWebUi->setChecked(pref->isWebUiEnabled());
-  spinWebUiPort->setValue(pref->getWebUiPort());
-  checkWebUIUPnP->setChecked(pref->useUPnPForWebUIPort());
-  checkWebUiHttps->setChecked(pref->isWebUiHttpsEnabled());
-  setSslCertificate(pref->getWebUiHttpsCertificate(), false);
-  setSslKey(pref->getWebUiHttpsKey(), false);
-  textWebUiUsername->setText(pref->getWebUiUsername());
-  textWebUiPassword->setText(pref->getWebUiPassword());
-  checkBypassLocalAuth->setChecked(!pref->isWebUiLocalAuthEnabled());
+    // Web UI preferences
+    checkWebUi->setChecked(pref->isWebUiEnabled());
+    spinWebUiPort->setValue(pref->getWebUiPort());
+    checkWebUIUPnP->setChecked(pref->useUPnPForWebUIPort());
+    checkWebUiHttps->setChecked(pref->isWebUiHttpsEnabled());
+    setSslCertificate(pref->getWebUiHttpsCertificate(), false);
+    setSslKey(pref->getWebUiHttpsKey(), false);
+    textWebUiUsername->setText(pref->getWebUiUsername());
+    textWebUiPassword->setText(pref->getWebUiPassword());
+    checkBypassLocalAuth->setChecked(!pref->isWebUiLocalAuthEnabled());
 
-  checkDynDNS->setChecked(pref->isDynDNSEnabled());
-  comboDNSService->setCurrentIndex((int)pref->getDynDNSService());
-  domainNameTxt->setText(pref->getDynDomainName());
-  DNSUsernameTxt->setText(pref->getDynDNSUsername());
-  DNSPasswordTxt->setText(pref->getDynDNSPassword());
-  // End Web UI preferences
+    checkDynDNS->setChecked(pref->isDynDNSEnabled());
+    comboDNSService->setCurrentIndex((int)pref->getDynDNSService());
+    domainNameTxt->setText(pref->getDynDomainName());
+    DNSUsernameTxt->setText(pref->getDynDNSUsername());
+    DNSPasswordTxt->setText(pref->getDynDNSPassword());
+    // End Web UI preferences
 }
 
 // return min & max ports
 // [min, max]
-int options_imp::getPort() const {
-  return spinPort->value();
+int options_imp::getPort() const
+{
+    return spinPort->value();
 }
 
-void options_imp::on_randomButton_clicked() {
-  // Range [1024: 65535]
-  spinPort->setValue(rand() % 64512 + 1024);
+void options_imp::on_randomButton_clicked()
+{
+    // Range [1024: 65535]
+    spinPort->setValue(rand() % 64512 + 1024);
 }
 
-int options_imp::getEncryptionSetting() const {
-  return comboEncryption->currentIndex();
+int options_imp::getEncryptionSetting() const
+{
+    return comboEncryption->currentIndex();
 }
 
-int options_imp::getMaxActiveDownloads() const {
-  return spinMaxActiveDownloads->value();
+int options_imp::getMaxActiveDownloads() const
+{
+    return spinMaxActiveDownloads->value();
 }
 
-int options_imp::getMaxActiveUploads() const {
-  return spinMaxActiveUploads->value();
+int options_imp::getMaxActiveUploads() const
+{
+    return spinMaxActiveUploads->value();
 }
 
-int options_imp::getMaxActiveTorrents() const {
-  return spinMaxActiveTorrents->value();
+int options_imp::getMaxActiveTorrents() const
+{
+    return spinMaxActiveTorrents->value();
 }
 
-bool options_imp::minimizeToTray() const {
-  if (!checkShowSystray->isChecked()) return false;
-  return checkMinimizeToSysTray->isChecked();
+bool options_imp::minimizeToTray() const
+{
+    if (!checkShowSystray->isChecked()) return false;
+    return checkMinimizeToSysTray->isChecked();
 }
 
-bool options_imp::closeToTray() const {
-  if (!checkShowSystray->isChecked()) return false;
-  return checkCloseToSystray->isChecked();
+bool options_imp::closeToTray() const
+{
+    if (!checkShowSystray->isChecked()) return false;
+    return checkCloseToSystray->isChecked();
 }
 
-bool options_imp::isQueueingSystemEnabled() const {
-  return checkEnableQueueing->isChecked();
+bool options_imp::isQueueingSystemEnabled() const
+{
+    return checkEnableQueueing->isChecked();
 }
 
-bool options_imp::isDHTEnabled() const {
-  return checkDHT->isChecked();
+bool options_imp::isDHTEnabled() const
+{
+    return checkDHT->isChecked();
 }
 
-bool options_imp::isLSDEnabled() const {
-  return checkLSD->isChecked();
+bool options_imp::isLSDEnabled() const
+{
+    return checkLSD->isChecked();
 }
 
-bool options_imp::isUPnPEnabled() const {
-  return checkUPnP->isChecked();
+bool options_imp::isUPnPEnabled() const
+{
+    return checkUPnP->isChecked();
 }
 
 // Return Download & Upload limits in kbps
 // [download,upload]
-QPair<int,int> options_imp::getGlobalBandwidthLimits() const {
-  int DL = -1, UP = -1;
-  if (checkDownloadLimit->isChecked()) {
-    DL = spinDownloadLimit->value();
-  }
-  if (checkUploadLimit->isChecked()) {
-    UP = spinUploadLimit->value();
-  }
-  return qMakePair(DL, UP);
+QPair<int, int> options_imp::getGlobalBandwidthLimits() const
+{
+    int DL = -1, UP = -1;
+    if (checkDownloadLimit->isChecked())
+        DL = spinDownloadLimit->value();
+    if (checkUploadLimit->isChecked())
+        UP = spinUploadLimit->value();
+    return qMakePair(DL, UP);
 }
 
 // Return alternate Download & Upload limits in kbps
 // [download,upload]
-QPair<int,int> options_imp::getAltGlobalBandwidthLimits() const {
-  int DL = -1, UP = -1;
-  if (checkDownloadLimitAlt->isChecked()) {
-    DL = spinDownloadLimitAlt->value();
-  }
-  if (checkUploadLimitAlt->isChecked()) {
-    UP = spinUploadLimitAlt->value();
-  }
-  return qMakePair(DL, UP);
+QPair<int, int> options_imp::getAltGlobalBandwidthLimits() const
+{
+    int DL = -1, UP = -1;
+    if (checkDownloadLimitAlt->isChecked())
+        DL = spinDownloadLimitAlt->value();
+    if (checkUploadLimitAlt->isChecked())
+        UP = spinUploadLimitAlt->value();
+    return qMakePair(DL, UP);
 }
 
-bool options_imp::startMinimized() const {
-  return checkStartMinimized->isChecked();
+bool options_imp::startMinimized() const
+{
+    return checkStartMinimized->isChecked();
 }
 
-bool options_imp::systrayIntegration() const {
-  if (!QSystemTrayIcon::isSystemTrayAvailable()) return false;
-  return checkShowSystray->isChecked();
+bool options_imp::systrayIntegration() const
+{
+    if (!QSystemTrayIcon::isSystemTrayAvailable()) return false;
+    return checkShowSystray->isChecked();
 }
 
 // Return Share ratio
-qreal options_imp::getMaxRatio() const {
-  if (checkMaxRatio->isChecked()) {
-    return spinMaxRatio->value();
-  }
-  return -1;
+qreal options_imp::getMaxRatio() const
+{
+    if (checkMaxRatio->isChecked())
+        return spinMaxRatio->value();
+    return -1;
 }
 
 // Return Save Path
-QString options_imp::getSavePath() const {
-  if (textSavePath->text().trimmed().isEmpty()) {
-    QString save_path = Preferences::instance()->getSavePath();
-    textSavePath->setText(Utils::Fs::toNativePath(save_path));
-  }
-  return Utils::Fs::expandPathAbs(textSavePath->text());
+QString options_imp::getSavePath() const
+{
+    if (textSavePath->text().trimmed().isEmpty()) {
+        QString save_path = Preferences::instance()->getSavePath();
+        textSavePath->setText(Utils::Fs::toNativePath(save_path));
+    }
+    return Utils::Fs::expandPathAbs(textSavePath->text());
 }
 
-QString options_imp::getTempPath() const {
-  return Utils::Fs::expandPathAbs(textTempPath->text());
+QString options_imp::getTempPath() const
+{
+    return Utils::Fs::expandPathAbs(textTempPath->text());
 }
 
-bool options_imp::isTempPathEnabled() const {
-  return checkTempFolder->isChecked();
+bool options_imp::isTempPathEnabled() const
+{
+    return checkTempFolder->isChecked();
 }
 
 // Return max connections number
-int options_imp::getMaxConnecs() const {
-  if (!checkMaxConnecs->isChecked()) {
-    return -1;
-  }else{
-    return spinMaxConnec->value();
-  }
+int options_imp::getMaxConnecs() const
+{
+    if (!checkMaxConnecs->isChecked())
+        return -1;
+    else
+        return spinMaxConnec->value();
 }
 
-int options_imp::getMaxConnecsPerTorrent() const {
-  if (!checkMaxConnecsPerTorrent->isChecked()) {
-    return -1;
-  }else{
-    return spinMaxConnecPerTorrent->value();
-  }
+int options_imp::getMaxConnecsPerTorrent() const
+{
+    if (!checkMaxConnecsPerTorrent->isChecked())
+        return -1;
+    else
+        return spinMaxConnecPerTorrent->value();
 }
 
-int options_imp::getMaxUploads() const {
-  if (!checkMaxUploads->isChecked()) {
-    return -1;
-  }else{
-    return spinMaxUploads->value();
-  }
+int options_imp::getMaxUploads() const
+{
+    if (!checkMaxUploads->isChecked())
+        return -1;
+    else
+        return spinMaxUploads->value();
 }
 
-int options_imp::getMaxUploadsPerTorrent() const {
-  if (!checkMaxUploadsPerTorrent->isChecked()) {
-    return -1;
-  }else{
-    return spinMaxUploadsPerTorrent->value();
-  }
+int options_imp::getMaxUploadsPerTorrent() const
+{
+    if (!checkMaxUploadsPerTorrent->isChecked())
+        return -1;
+    else
+        return spinMaxUploadsPerTorrent->value();
 }
 
-void options_imp::on_buttonBox_accepted() {
-  if (applyButton->isEnabled()) {
-    if (!schedTimesOk()) {
-      tabSelection->setCurrentRow(TAB_SPEED);
-      return;
+void options_imp::on_buttonBox_accepted()
+{
+    if (applyButton->isEnabled()) {
+        if (!schedTimesOk()) {
+            tabSelection->setCurrentRow(TAB_SPEED);
+            return;
+        }
+        saveOptions();
+        applyButton->setEnabled(false);
+        this->hide();
+        emit status_changed();
     }
-    saveOptions();
-    applyButton->setEnabled(false);
-    this->hide();
-    emit status_changed();
-  }
-  saveWindowState();
-  accept();
+    saveWindowState();
+    accept();
 }
 
-void options_imp::applySettings(QAbstractButton* button) {
-  if (button == applyButton) {
-    if (!schedTimesOk()) {
-      tabSelection->setCurrentRow(TAB_SPEED);
-      return;
+void options_imp::applySettings(QAbstractButton* button)
+{
+    if (button == applyButton) {
+        if (!schedTimesOk()) {
+            tabSelection->setCurrentRow(TAB_SPEED);
+            return;
+        }
+        saveOptions();
+        emit status_changed();
     }
-    saveOptions();
-    emit status_changed();
-  }
 }
 
-void options_imp::closeEvent(QCloseEvent *e) {
-  setAttribute(Qt::WA_DeleteOnClose);
-  e->accept();
+void options_imp::closeEvent(QCloseEvent *e)
+{
+    setAttribute(Qt::WA_DeleteOnClose);
+    e->accept();
 }
 
-void options_imp::on_buttonBox_rejected() {
-  setAttribute(Qt::WA_DeleteOnClose);
-  reject();
+void options_imp::on_buttonBox_rejected()
+{
+    setAttribute(Qt::WA_DeleteOnClose);
+    reject();
 }
 
-bool options_imp::useAdditionDialog() const {
-  return checkAdditionDialog->isChecked();
+bool options_imp::useAdditionDialog() const
+{
+    return checkAdditionDialog->isChecked();
 }
 
-void options_imp::enableApplyButton() {
-  applyButton->setEnabled(true);
+void options_imp::enableApplyButton()
+{
+    applyButton->setEnabled(true);
 }
 
-void options_imp::enableProxy(int index) {
-  if (index) {
-    //enable
-    lblProxyIP->setEnabled(true);
-    textProxyIP->setEnabled(true);
-    lblProxyPort->setEnabled(true);
-    spinProxyPort->setEnabled(true);
-    checkProxyPeerConnecs->setEnabled(true);
-    checkForceProxy->setEnabled(true);
-    isProxyOnlyForTorrents->setEnabled(true);
-    if (index > 1) {
-      checkProxyAuth->setEnabled(true);
-    } else {
-      checkProxyAuth->setEnabled(false);
-      checkProxyAuth->setChecked(false);
+void options_imp::enableProxy(int index)
+{
+    if (index) {
+        //enable
+        lblProxyIP->setEnabled(true);
+        textProxyIP->setEnabled(true);
+        lblProxyPort->setEnabled(true);
+        spinProxyPort->setEnabled(true);
+        checkProxyPeerConnecs->setEnabled(true);
+        checkForceProxy->setEnabled(true);
+        isProxyOnlyForTorrents->setEnabled(true);
+        if (index > 1) {
+            checkProxyAuth->setEnabled(true);
+        }
+        else {
+            checkProxyAuth->setEnabled(false);
+            checkProxyAuth->setChecked(false);
+        }
     }
-  }else{
-    //disable
-    lblProxyIP->setEnabled(false);
-    textProxyIP->setEnabled(false);
-    lblProxyPort->setEnabled(false);
-    spinProxyPort->setEnabled(false);
-    checkProxyPeerConnecs->setEnabled(false);
-    checkForceProxy->setEnabled(false);
-    isProxyOnlyForTorrents->setEnabled(false);
-    checkProxyAuth->setEnabled(false);
-    checkProxyAuth->setChecked(false);
-  }
+    else {
+        //disable
+        lblProxyIP->setEnabled(false);
+        textProxyIP->setEnabled(false);
+        lblProxyPort->setEnabled(false);
+        spinProxyPort->setEnabled(false);
+        checkProxyPeerConnecs->setEnabled(false);
+        checkForceProxy->setEnabled(false);
+        isProxyOnlyForTorrents->setEnabled(false);
+        checkProxyAuth->setEnabled(false);
+        checkProxyAuth->setChecked(false);
+    }
 }
 
-bool options_imp::isSlashScreenDisabled() const {
-  return !checkShowSplash->isChecked();
+bool options_imp::isSlashScreenDisabled() const
+{
+    return !checkShowSplash->isChecked();
 }
 
 #ifdef Q_OS_WIN
-bool options_imp::WinStartup() const {
-  return checkStartup->isChecked();
+bool options_imp::WinStartup() const
+{
+    return checkStartup->isChecked();
 }
 #endif
 
-bool options_imp::preventFromSuspend() const {
-  return checkPreventFromSuspend->isChecked();
+bool options_imp::preventFromSuspend() const
+{
+    return checkPreventFromSuspend->isChecked();
 }
 
-bool options_imp::preAllocateAllFiles() const {
-  return checkPreallocateAll->isChecked();
+bool options_imp::preAllocateAllFiles() const
+{
+    return checkPreallocateAll->isChecked();
 }
 
-bool options_imp::addTorrentsInPause() const {
-  return checkStartPaused->isChecked();
+bool options_imp::addTorrentsInPause() const
+{
+    return checkStartPaused->isChecked();
 }
 
 // Proxy settings
-bool options_imp::isProxyEnabled() const {
-  return comboProxyType->currentIndex();
+bool options_imp::isProxyEnabled() const
+{
+    return comboProxyType->currentIndex();
 }
 
-bool options_imp::isProxyAuthEnabled() const {
-  return checkProxyAuth->isChecked();
+bool options_imp::isProxyAuthEnabled() const
+{
+    return checkProxyAuth->isChecked();
 }
 
-QString options_imp::getProxyIp() const {
-  return textProxyIP->text().trimmed();
+QString options_imp::getProxyIp() const
+{
+    return textProxyIP->text().trimmed();
 }
 
-unsigned short options_imp::getProxyPort() const {
-  return spinProxyPort->value();
+unsigned short options_imp::getProxyPort() const
+{
+    return spinProxyPort->value();
 }
 
-QString options_imp::getProxyUsername() const {
-  QString username = textProxyUsername->text();
-  username = username.trimmed();
-  return username;
+QString options_imp::getProxyUsername() const
+{
+    QString username = textProxyUsername->text();
+    username = username.trimmed();
+    return username;
 }
 
-QString options_imp::getProxyPassword() const {
-  QString password = textProxyPassword->text();
-  password = password.trimmed();
-  return password;
+QString options_imp::getProxyPassword() const
+{
+    QString password = textProxyPassword->text();
+    password = password.trimmed();
+    return password;
 }
 
 // Locale Settings
-QString options_imp::getLocale() const {
-  return comboI18n->itemData(comboI18n->currentIndex(), Qt::UserRole).toString();
+QString options_imp::getLocale() const
+{
+    return comboI18n->itemData(comboI18n->currentIndex(), Qt::UserRole).toString();
 }
 
-void options_imp::setLocale(const QString &localeStr) {
-  QLocale locale(localeStr);
-  QString name = locale.name();
-  // Attempt to find exact match
-  int index = comboI18n->findData(name, Qt::UserRole);
-  if (index < 0 ) {
-      //Attempt to find a language match without a country
-      int pos = name.indexOf('_');
-      if (pos > -1) {
-          QString lang = name.left(pos);
-          index = comboI18n->findData(lang, Qt::UserRole);
-      }
-  }
-  if (index < 0) {
-    // Unrecognized, use US English
-    index = comboI18n->findData(QLocale("en").name(), Qt::UserRole);
-    Q_ASSERT(index >= 0);
-  }
-  comboI18n->setCurrentIndex(index);
+void options_imp::setLocale(const QString &localeStr)
+{
+    QLocale locale(localeStr);
+    QString name = locale.name();
+    // Attempt to find exact match
+    int index = comboI18n->findData(name, Qt::UserRole);
+    if (index < 0) {
+        //Attempt to find a language match without a country
+        int pos = name.indexOf('_');
+        if (pos > -1) {
+            QString lang = name.left(pos);
+            index = comboI18n->findData(lang, Qt::UserRole);
+        }
+    }
+    if (index < 0) {
+        // Unrecognized, use US English
+        index = comboI18n->findData(QLocale("en").name(), Qt::UserRole);
+        Q_ASSERT(index >= 0);
+    }
+    comboI18n->setCurrentIndex(index);
 }
 
-QString options_imp::getTorrentExportDir() const {
-  if (checkExportDir->isChecked())
-    return Utils::Fs::expandPathAbs(textExportDir->text());
-  return QString();
+QString options_imp::getTorrentExportDir() const
+{
+    if (checkExportDir->isChecked())
+        return Utils::Fs::expandPathAbs(textExportDir->text());
+    return QString();
 }
 
-QString options_imp::getFinishedTorrentExportDir() const {
-  if (checkExportDirFin->isChecked())
-    return Utils::Fs::expandPathAbs(textExportDirFin->text());
-  return QString();
+QString options_imp::getFinishedTorrentExportDir() const
+{
+    if (checkExportDirFin->isChecked())
+        return Utils::Fs::expandPathAbs(textExportDirFin->text());
+    return QString();
 }
 
 // Return action on double-click on a downloading torrent set in options
-int options_imp::getActionOnDblClOnTorrentDl() const {
-  if (actionTorrentDlOnDblClBox->currentIndex() < 1)
-    return 0;
-  return actionTorrentDlOnDblClBox->currentIndex();
+int options_imp::getActionOnDblClOnTorrentDl() const
+{
+    if (actionTorrentDlOnDblClBox->currentIndex() < 1)
+        return 0;
+    return actionTorrentDlOnDblClBox->currentIndex();
 }
 
 // Return action on double-click on a finished torrent set in options
-int options_imp::getActionOnDblClOnTorrentFn() const {
-  if (actionTorrentFnOnDblClBox->currentIndex() < 1)
-    return 0;
-  return actionTorrentFnOnDblClBox->currentIndex();
+int options_imp::getActionOnDblClOnTorrentFn() const
+{
+    if (actionTorrentFnOnDblClBox->currentIndex() < 1)
+        return 0;
+    return actionTorrentFnOnDblClBox->currentIndex();
 }
 
-void options_imp::on_addScanFolderButton_clicked() {
-  Preferences* const pref = Preferences::instance();
-  const QString dir = QFileDialog::getExistingDirectory(this, tr("Add directory to scan"),
-                                                        Utils::Fs::toNativePath(Utils::Fs::folderName(pref->getScanDirsLastPath())));
-  if (!dir.isEmpty()) {
-    const ScanFoldersModel::PathStatus status = ScanFoldersModel::instance()->addPath(dir, false);
-    QString error;
-    switch (status) {
-    case ScanFoldersModel::AlreadyInList:
-      error = tr("Folder is already being watched.").arg(dir);
-      break;
-    case ScanFoldersModel::DoesNotExist:
-      error = tr("Folder does not exist.");
-      break;
-    case ScanFoldersModel::CannotRead:
-      error = tr("Folder is not readable.");
-      break;
-    default:
-      pref->setScanDirsLastPath(dir);
-      addedScanDirs << dir;
-      scanFoldersView->resizeColumnsToContents();
-      enableApplyButton();
+void options_imp::on_addScanFolderButton_clicked()
+{
+    Preferences* const pref = Preferences::instance();
+    const QString dir = QFileDialog::getExistingDirectory(this, tr("Add directory to scan"),
+                                                          Utils::Fs::toNativePath(Utils::Fs::folderName(pref->getScanDirsLastPath())));
+    if (!dir.isEmpty()) {
+        const ScanFoldersModel::PathStatus status = ScanFoldersModel::instance()->addPath(dir, false);
+        QString error;
+        switch (status) {
+        case ScanFoldersModel::AlreadyInList:
+            error = tr("Folder is already being watched.").arg(dir);
+            break;
+        case ScanFoldersModel::DoesNotExist:
+            error = tr("Folder does not exist.");
+            break;
+        case ScanFoldersModel::CannotRead:
+            error = tr("Folder is not readable.");
+            break;
+        default:
+            pref->setScanDirsLastPath(dir);
+            addedScanDirs << dir;
+            scanFoldersView->resizeColumnsToContents();
+            enableApplyButton();
+        }
+
+        if (!error.isEmpty())
+            QMessageBox::warning(this, tr("Failure"), tr("Failed to add Scan Folder '%1': %2").arg(dir).arg(error));
     }
-
-    if (!error.isEmpty()) {
-      QMessageBox::warning(this, tr("Failure"), tr("Failed to add Scan Folder '%1': %2").arg(dir).arg(error));
-    }
-  }
 }
 
-void options_imp::on_removeScanFolderButton_clicked() {
-  const QModelIndexList selected
-      = scanFoldersView->selectionModel()->selectedIndexes();
-  if (selected.isEmpty())
-    return;
-  Q_ASSERT(selected.count() == ScanFoldersModel::instance()->columnCount());
-  ScanFoldersModel::instance()->removePath(selected.first().row());
+void options_imp::on_removeScanFolderButton_clicked()
+{
+    const QModelIndexList selected
+        = scanFoldersView->selectionModel()->selectedIndexes();
+    if (selected.isEmpty())
+        return;
+    Q_ASSERT(selected.count() == ScanFoldersModel::instance()->columnCount());
+    ScanFoldersModel::instance()->removePath(selected.first().row());
 }
 
-void options_imp::handleScanFolderViewSelectionChanged() {
-  removeScanFolderButton->setEnabled(!scanFoldersView->selectionModel()->selectedIndexes().isEmpty());
+void options_imp::handleScanFolderViewSelectionChanged()
+{
+    removeScanFolderButton->setEnabled(!scanFoldersView->selectionModel()->selectedIndexes().isEmpty());
 }
 
 QString options_imp::askForExportDir(const QString& currentExportPath)
 {
-  QDir currentExportDir(Utils::Fs::expandPathAbs(currentExportPath));
-  QString dir;
-  if (!currentExportPath.isEmpty() && currentExportDir.exists()) {
-    dir = QFileDialog::getExistingDirectory(this, tr("Choose export directory"), currentExportDir.absolutePath());
-  } else {
-    dir = QFileDialog::getExistingDirectory(this, tr("Choose export directory"), QDir::homePath());
-  }
-  return dir;
+    QDir currentExportDir(Utils::Fs::expandPathAbs(currentExportPath));
+    QString dir;
+    if (!currentExportPath.isEmpty() && currentExportDir.exists())
+        dir = QFileDialog::getExistingDirectory(this, tr("Choose export directory"), currentExportDir.absolutePath());
+    else
+        dir = QFileDialog::getExistingDirectory(this, tr("Choose export directory"), QDir::homePath());
+    return dir;
 }
 
-void options_imp::on_browseExportDirButton_clicked() {
-  const QString newExportDir = askForExportDir(textExportDir->text());
-  if (!newExportDir.isNull())
-    textExportDir->setText(Utils::Fs::toNativePath(newExportDir));
+void options_imp::on_browseExportDirButton_clicked()
+{
+    const QString newExportDir = askForExportDir(textExportDir->text());
+    if (!newExportDir.isNull())
+        textExportDir->setText(Utils::Fs::toNativePath(newExportDir));
 }
 
-void options_imp::on_browseExportDirFinButton_clicked() {
-  const QString newExportDir = askForExportDir(textExportDirFin->text());
-  if (!newExportDir.isNull())
-    textExportDirFin->setText(Utils::Fs::toNativePath(newExportDir));
+void options_imp::on_browseExportDirFinButton_clicked()
+{
+    const QString newExportDir = askForExportDir(textExportDirFin->text());
+    if (!newExportDir.isNull())
+        textExportDirFin->setText(Utils::Fs::toNativePath(newExportDir));
 }
 
-void options_imp::on_browseFilterButton_clicked() {
-  const QString filter_path = Utils::Fs::expandPathAbs(textFilterPath->text());
-  QDir filterDir(filter_path);
-  QString ipfilter;
-  if (!filter_path.isEmpty() && filterDir.exists()) {
-    ipfilter = QFileDialog::getOpenFileName(this, tr("Choose an IP filter file"), filterDir.absolutePath(), tr("Filters")+QString(" (*.dat *.p2p *.p2b)"));
-  } else {
-    ipfilter = QFileDialog::getOpenFileName(this, tr("Choose an IP filter file"), QDir::homePath(), tr("Filters")+QString(" (*.dat *.p2p *.p2b)"));
-  }
-  if (!ipfilter.isNull())
-    textFilterPath->setText(Utils::Fs::toNativePath(ipfilter));
+void options_imp::on_browseFilterButton_clicked()
+{
+    const QString filter_path = Utils::Fs::expandPathAbs(textFilterPath->text());
+    QDir filterDir(filter_path);
+    QString ipfilter;
+    if (!filter_path.isEmpty() && filterDir.exists())
+        ipfilter = QFileDialog::getOpenFileName(this, tr("Choose an IP filter file"), filterDir.absolutePath(), tr("Filters") + QString(" (*.dat *.p2p *.p2b)"));
+    else
+        ipfilter = QFileDialog::getOpenFileName(this, tr("Choose an IP filter file"), QDir::homePath(), tr("Filters") + QString(" (*.dat *.p2p *.p2b)"));
+    if (!ipfilter.isNull())
+        textFilterPath->setText(Utils::Fs::toNativePath(ipfilter));
 }
 
 // Display dialog to choose save dir
-void options_imp::on_browseSaveDirButton_clicked() {
-  const QString save_path = Utils::Fs::expandPathAbs(textSavePath->text());
-  QDir saveDir(save_path);
-  QString dir;
-  if (!save_path.isEmpty() && saveDir.exists()) {
-    dir = QFileDialog::getExistingDirectory(this, tr("Choose a save directory"), saveDir.absolutePath());
-  } else {
-    dir = QFileDialog::getExistingDirectory(this, tr("Choose a save directory"), QDir::homePath());
-  }
-  if (!dir.isNull())
-    textSavePath->setText(Utils::Fs::toNativePath(dir));
+void options_imp::on_browseSaveDirButton_clicked()
+{
+    const QString save_path = Utils::Fs::expandPathAbs(textSavePath->text());
+    QDir saveDir(save_path);
+    QString dir;
+    if (!save_path.isEmpty() && saveDir.exists())
+        dir = QFileDialog::getExistingDirectory(this, tr("Choose a save directory"), saveDir.absolutePath());
+    else
+        dir = QFileDialog::getExistingDirectory(this, tr("Choose a save directory"), QDir::homePath());
+    if (!dir.isNull())
+        textSavePath->setText(Utils::Fs::toNativePath(dir));
 }
 
-void options_imp::on_browseTempDirButton_clicked() {
-  const QString temp_path = Utils::Fs::expandPathAbs(textTempPath->text());
-  QDir tempDir(temp_path);
-  QString dir;
-  if (!temp_path.isEmpty() && tempDir.exists()) {
-    dir = QFileDialog::getExistingDirectory(this, tr("Choose a save directory"), tempDir.absolutePath());
-  } else {
-    dir = QFileDialog::getExistingDirectory(this, tr("Choose a save directory"), QDir::homePath());
-  }
-  if (!dir.isNull())
-    textTempPath->setText(Utils::Fs::toNativePath(dir));
+void options_imp::on_browseTempDirButton_clicked()
+{
+    const QString temp_path = Utils::Fs::expandPathAbs(textTempPath->text());
+    QDir tempDir(temp_path);
+    QString dir;
+    if (!temp_path.isEmpty() && tempDir.exists())
+        dir = QFileDialog::getExistingDirectory(this, tr("Choose a save directory"), tempDir.absolutePath());
+    else
+        dir = QFileDialog::getExistingDirectory(this, tr("Choose a save directory"), QDir::homePath());
+    if (!dir.isNull())
+        textTempPath->setText(Utils::Fs::toNativePath(dir));
 }
 
 // Return Filter object to apply to BT session
-QString options_imp::getFilter() const {
-  return Utils::Fs::fromNativePath(textFilterPath->text());
+QString options_imp::getFilter() const
+{
+    return Utils::Fs::fromNativePath(textFilterPath->text());
 }
 
 // Web UI
 
 bool options_imp::isWebUiEnabled() const
 {
-  return checkWebUi->isChecked();
+    return checkWebUi->isChecked();
 }
 
 quint16 options_imp::webUiPort() const
 {
-  return spinWebUiPort->value();
+    return spinWebUiPort->value();
 }
 
 QString options_imp::webUiUsername() const
 {
-  return textWebUiUsername->text();
+    return textWebUiUsername->text();
 }
 
 QString options_imp::webUiPassword() const
 {
-  return textWebUiPassword->text();
+    return textWebUiPassword->text();
 }
 
 void options_imp::showConnectionTab()
 {
-  tabSelection->setCurrentRow(TAB_CONNECTION);
+    tabSelection->setCurrentRow(TAB_CONNECTION);
 }
 
-void options_imp::on_btnWebUiCrt_clicked() {
-  QString filename = QFileDialog::getOpenFileName(this, QString(), QString(), tr("SSL Certificate")+QString(" (*.crt *.pem)"));
-  if (filename.isNull())
-    return;
-  QFile file(filename);
-  if (file.open(QIODevice::ReadOnly)) {
-    setSslCertificate(file.readAll());
-    file.close();
-  }
+void options_imp::on_btnWebUiCrt_clicked()
+{
+    QString filename = QFileDialog::getOpenFileName(this, QString(), QString(), tr("SSL Certificate") + QString(" (*.crt *.pem)"));
+    if (filename.isNull())
+        return;
+    QFile file(filename);
+    if (file.open(QIODevice::ReadOnly)) {
+        setSslCertificate(file.readAll());
+        file.close();
+    }
 }
 
-void options_imp::on_btnWebUiKey_clicked() {
-  QString filename = QFileDialog::getOpenFileName(this, QString(), QString(), tr("SSL Key")+QString(" (*.key *.pem)"));
-  if (filename.isNull())
-    return;
-  QFile file(filename);
-  if (file.open(QIODevice::ReadOnly)) {
-    setSslKey(file.readAll());
-    file.close();
-  }
+void options_imp::on_btnWebUiKey_clicked()
+{
+    QString filename = QFileDialog::getOpenFileName(this, QString(), QString(), tr("SSL Key") + QString(" (*.key *.pem)"));
+    if (filename.isNull())
+        return;
+    QFile file(filename);
+    if (file.open(QIODevice::ReadOnly)) {
+        setSslKey(file.readAll());
+        file.close();
+    }
 }
 
-void options_imp::on_registerDNSBtn_clicked() {
-  QDesktopServices::openUrl(Net::DNSUpdater::getRegistrationUrl(comboDNSService->currentIndex()));
+void options_imp::on_registerDNSBtn_clicked()
+{
+    QDesktopServices::openUrl(Net::DNSUpdater::getRegistrationUrl(comboDNSService->currentIndex()));
 }
 
-void options_imp::on_IpFilterRefreshBtn_clicked() {
-  if (m_refreshingIpFilter) return;
-  m_refreshingIpFilter = true;
-  // Updating program preferences
-  Preferences* const pref = Preferences::instance();
-  pref->setFilteringEnabled(true);
-  pref->setFilter(getFilter());
-  // Force refresh
-  connect(BitTorrent::Session::instance(), SIGNAL(ipFilterParsed(bool, int)), SLOT(handleIPFilterParsed(bool, int)));
-  setCursor(QCursor(Qt::WaitCursor));
-  BitTorrent::Session::instance()->enableIPFilter(getFilter(), true);
+void options_imp::on_IpFilterRefreshBtn_clicked()
+{
+    if (m_refreshingIpFilter) return;
+    m_refreshingIpFilter = true;
+    // Updating program preferences
+    Preferences* const pref = Preferences::instance();
+    pref->setFilteringEnabled(true);
+    pref->setFilter(getFilter());
+    // Force refresh
+    connect(BitTorrent::Session::instance(), SIGNAL(ipFilterParsed(bool, int)), SLOT(handleIPFilterParsed(bool, int)));
+    setCursor(QCursor(Qt::WaitCursor));
+    BitTorrent::Session::instance()->enableIPFilter(getFilter(), true);
 }
 
 void options_imp::handleIPFilterParsed(bool error, int ruleCount)
 {
-  setCursor(QCursor(Qt::ArrowCursor));
-  if (error) {
-    QMessageBox::warning(this, tr("Parsing error"), tr("Failed to parse the provided IP filter"));
-  } else {
-    QMessageBox::information(this, tr("Successfully refreshed"), tr("Successfully parsed the provided IP filter: %1 rules were applied.", "%1 is a number").arg(ruleCount));
-  }
-  m_refreshingIpFilter = false;
-  disconnect(BitTorrent::Session::instance(), SIGNAL(ipFilterParsed(bool, int)), this, SLOT(handleIPFilterParsed(bool, int)));
+    setCursor(QCursor(Qt::ArrowCursor));
+    if (error)
+        QMessageBox::warning(this, tr("Parsing error"), tr("Failed to parse the provided IP filter"));
+    else
+        QMessageBox::information(this, tr("Successfully refreshed"), tr("Successfully parsed the provided IP filter: %1 rules were applied.", "%1 is a number").arg(ruleCount));
+    m_refreshingIpFilter = false;
+    disconnect(BitTorrent::Session::instance(), SIGNAL(ipFilterParsed(bool, int)), this, SLOT(handleIPFilterParsed(bool, int)));
 }
 
 QString options_imp::languageToLocalizedString(const QLocale &locale)
 {
-  switch(locale.language()) {
-  case QLocale::English: {
-    if (locale.country() == QLocale::Australia)
-      return QString::fromUtf8(C_LOCALE_ENGLISH_AUSTRALIA);
-    else if (locale.country() == QLocale::UnitedKingdom)
-      return QString::fromUtf8(C_LOCALE_ENGLISH_UNITEDKINGDOM);
-    return QString::fromUtf8(C_LOCALE_ENGLISH);
-  }
-  case QLocale::French: return QString::fromUtf8(C_LOCALE_FRENCH);
-  case QLocale::German: return QString::fromUtf8(C_LOCALE_GERMAN);
-  case QLocale::Hungarian: return QString::fromUtf8(C_LOCALE_HUNGARIAN);
-  case QLocale::Indonesian: return QString::fromUtf8(C_LOCALE_INDONESIAN);
-  case QLocale::Italian: return QString::fromUtf8(C_LOCALE_ITALIAN);
-  case QLocale::Dutch: return QString::fromUtf8(C_LOCALE_DUTCH);
-  case QLocale::Spanish: return QString::fromUtf8(C_LOCALE_SPANISH);
-  case QLocale::Catalan: return QString::fromUtf8(C_LOCALE_CATALAN);
-  case QLocale::Galician: return QString::fromUtf8(C_LOCALE_GALICIAN);
-  case QLocale::Portuguese: {
-    if (locale.country() == QLocale::Brazil)
-      return QString::fromUtf8(C_LOCALE_PORTUGUESE_BRAZIL);
-    return QString::fromUtf8(C_LOCALE_PORTUGUESE);
-  }
-  case QLocale::Polish: return QString::fromUtf8(C_LOCALE_POLISH);
-  case QLocale::Lithuanian: return QString::fromUtf8(C_LOCALE_LITHUANIAN);
-  case QLocale::Czech: return QString::fromUtf8(C_LOCALE_CZECH);
-  case QLocale::Slovak: return QString::fromUtf8(C_LOCALE_SLOVAK);
-  case QLocale::Slovenian: return QString::fromUtf8(C_LOCALE_SLOVENIAN);
-  case QLocale::Serbian: return QString::fromUtf8(C_LOCALE_SERBIAN);
-  case QLocale::Croatian: return QString::fromUtf8(C_LOCALE_CROATIAN);
-  case QLocale::Armenian: return QString::fromUtf8(C_LOCALE_ARMENIAN);
-  case QLocale::Romanian: return QString::fromUtf8(C_LOCALE_ROMANIAN);
-  case QLocale::Turkish: return QString::fromUtf8(C_LOCALE_TURKISH);
-  case QLocale::Greek: return QString::fromUtf8(C_LOCALE_GREEK);
-  case QLocale::Swedish: return QString::fromUtf8(C_LOCALE_SWEDISH);
-  case QLocale::Finnish: return QString::fromUtf8(C_LOCALE_FINNISH);
-  case QLocale::Norwegian: return QString::fromUtf8(C_LOCALE_NORWEGIAN);
-  case QLocale::Danish: return QString::fromUtf8(C_LOCALE_DANISH);
-  case QLocale::Bulgarian: return QString::fromUtf8(C_LOCALE_BULGARIAN);
-  case QLocale::Ukrainian: return QString::fromUtf8(C_LOCALE_UKRAINIAN);
-  case QLocale::Russian: return QString::fromUtf8(C_LOCALE_RUSSIAN);
-  case QLocale::Japanese: return QString::fromUtf8(C_LOCALE_JAPANESE);
-  case QLocale::Hebrew: return QString::fromUtf8(C_LOCALE_HEBREW);
-  case QLocale::Hindi: return QString::fromUtf8(C_LOCALE_HINDI);
-  case QLocale::Arabic: return QString::fromUtf8(C_LOCALE_ARABIC);
-  case QLocale::Georgian: return QString::fromUtf8(C_LOCALE_GEORGIAN);
-  case QLocale::Byelorussian: return QString::fromUtf8(C_LOCALE_BYELORUSSIAN);
-  case QLocale::Basque: return QString::fromUtf8(C_LOCALE_BASQUE);
-  case QLocale::Vietnamese: return QString::fromUtf8(C_LOCALE_VIETNAMESE);
-  case QLocale::Chinese: {
-      switch(locale.country()) {
-      case QLocale::China:
-          return QString::fromUtf8(C_LOCALE_CHINESE_SIMPLIFIED);
-      case QLocale::HongKong:
-          return QString::fromUtf8(C_LOCALE_CHINESE_TRADITIONAL_HK);
-      default:
-          return QString::fromUtf8(C_LOCALE_CHINESE_TRADITIONAL_TW);
+    switch (locale.language()) {
+    case QLocale::English: {
+        if (locale.country() == QLocale::Australia)
+            return QString::fromUtf8(C_LOCALE_ENGLISH_AUSTRALIA);
+        else if (locale.country() == QLocale::UnitedKingdom)
+            return QString::fromUtf8(C_LOCALE_ENGLISH_UNITEDKINGDOM);
+        return QString::fromUtf8(C_LOCALE_ENGLISH);
+    }
+    case QLocale::French: return QString::fromUtf8(C_LOCALE_FRENCH);
+    case QLocale::German: return QString::fromUtf8(C_LOCALE_GERMAN);
+    case QLocale::Hungarian: return QString::fromUtf8(C_LOCALE_HUNGARIAN);
+    case QLocale::Indonesian: return QString::fromUtf8(C_LOCALE_INDONESIAN);
+    case QLocale::Italian: return QString::fromUtf8(C_LOCALE_ITALIAN);
+    case QLocale::Dutch: return QString::fromUtf8(C_LOCALE_DUTCH);
+    case QLocale::Spanish: return QString::fromUtf8(C_LOCALE_SPANISH);
+    case QLocale::Catalan: return QString::fromUtf8(C_LOCALE_CATALAN);
+    case QLocale::Galician: return QString::fromUtf8(C_LOCALE_GALICIAN);
+    case QLocale::Portuguese: {
+        if (locale.country() == QLocale::Brazil)
+            return QString::fromUtf8(C_LOCALE_PORTUGUESE_BRAZIL);
+        return QString::fromUtf8(C_LOCALE_PORTUGUESE);
+    }
+    case QLocale::Polish: return QString::fromUtf8(C_LOCALE_POLISH);
+    case QLocale::Lithuanian: return QString::fromUtf8(C_LOCALE_LITHUANIAN);
+    case QLocale::Czech: return QString::fromUtf8(C_LOCALE_CZECH);
+    case QLocale::Slovak: return QString::fromUtf8(C_LOCALE_SLOVAK);
+    case QLocale::Slovenian: return QString::fromUtf8(C_LOCALE_SLOVENIAN);
+    case QLocale::Serbian: return QString::fromUtf8(C_LOCALE_SERBIAN);
+    case QLocale::Croatian: return QString::fromUtf8(C_LOCALE_CROATIAN);
+    case QLocale::Armenian: return QString::fromUtf8(C_LOCALE_ARMENIAN);
+    case QLocale::Romanian: return QString::fromUtf8(C_LOCALE_ROMANIAN);
+    case QLocale::Turkish: return QString::fromUtf8(C_LOCALE_TURKISH);
+    case QLocale::Greek: return QString::fromUtf8(C_LOCALE_GREEK);
+    case QLocale::Swedish: return QString::fromUtf8(C_LOCALE_SWEDISH);
+    case QLocale::Finnish: return QString::fromUtf8(C_LOCALE_FINNISH);
+    case QLocale::Norwegian: return QString::fromUtf8(C_LOCALE_NORWEGIAN);
+    case QLocale::Danish: return QString::fromUtf8(C_LOCALE_DANISH);
+    case QLocale::Bulgarian: return QString::fromUtf8(C_LOCALE_BULGARIAN);
+    case QLocale::Ukrainian: return QString::fromUtf8(C_LOCALE_UKRAINIAN);
+    case QLocale::Russian: return QString::fromUtf8(C_LOCALE_RUSSIAN);
+    case QLocale::Japanese: return QString::fromUtf8(C_LOCALE_JAPANESE);
+    case QLocale::Hebrew: return QString::fromUtf8(C_LOCALE_HEBREW);
+    case QLocale::Hindi: return QString::fromUtf8(C_LOCALE_HINDI);
+    case QLocale::Arabic: return QString::fromUtf8(C_LOCALE_ARABIC);
+    case QLocale::Georgian: return QString::fromUtf8(C_LOCALE_GEORGIAN);
+    case QLocale::Byelorussian: return QString::fromUtf8(C_LOCALE_BYELORUSSIAN);
+    case QLocale::Basque: return QString::fromUtf8(C_LOCALE_BASQUE);
+    case QLocale::Vietnamese: return QString::fromUtf8(C_LOCALE_VIETNAMESE);
+    case QLocale::Chinese: {
+        switch (locale.country()) {
+        case QLocale::China:
+            return QString::fromUtf8(C_LOCALE_CHINESE_SIMPLIFIED);
+        case QLocale::HongKong:
+            return QString::fromUtf8(C_LOCALE_CHINESE_TRADITIONAL_HK);
+        default:
+            return QString::fromUtf8(C_LOCALE_CHINESE_TRADITIONAL_TW);
 
-      }
-  }
-  case QLocale::Korean: return QString::fromUtf8(C_LOCALE_KOREAN);
-  default: {
-    // Fallback to English
-    const QString eng_lang = QLocale::languageToString(locale.language());
-    qWarning() << "Unrecognized language name: " << eng_lang;
-    return eng_lang;
-  }
-  }
+        }
+    }
+    case QLocale::Korean: return QString::fromUtf8(C_LOCALE_KOREAN);
+    default: {
+        // Fallback to English
+        const QString eng_lang = QLocale::languageToString(locale.language());
+        qWarning() << "Unrecognized language name: " << eng_lang;
+        return eng_lang;
+    }
+    }
 }
 
 void options_imp::setSslKey(const QByteArray &key, bool interactive)
 {
 #ifndef QT_NO_OPENSSL
-  if (!key.isEmpty() && !QSslKey(key, QSsl::Rsa).isNull()) {
-    lblSslKeyStatus->setPixmap(QPixmap(":/icons/oxygen/security-high.png").scaledToHeight(20, Qt::SmoothTransformation));
-    m_sslKey = key;
-  } else {
-    lblSslKeyStatus->setPixmap(QPixmap(":/icons/oxygen/security-low.png").scaledToHeight(20, Qt::SmoothTransformation));
-    m_sslKey.clear();
-    if (interactive)
-      QMessageBox::warning(this, tr("Invalid key"), tr("This is not a valid SSL key."));
-  }
+    if (!key.isEmpty() && !QSslKey(key, QSsl::Rsa).isNull()) {
+        lblSslKeyStatus->setPixmap(QPixmap(":/icons/oxygen/security-high.png").scaledToHeight(20, Qt::SmoothTransformation));
+        m_sslKey = key;
+    }
+    else {
+        lblSslKeyStatus->setPixmap(QPixmap(":/icons/oxygen/security-low.png").scaledToHeight(20, Qt::SmoothTransformation));
+        m_sslKey.clear();
+        if (interactive)
+            QMessageBox::warning(this, tr("Invalid key"), tr("This is not a valid SSL key."));
+    }
 #endif
 }
 
 void options_imp::setSslCertificate(const QByteArray &cert, bool interactive)
 {
 #ifndef QT_NO_OPENSSL
-  if (!cert.isEmpty() && !QSslCertificate(cert).isNull()) {
-    lblSslCertStatus->setPixmap(QPixmap(":/icons/oxygen/security-high.png").scaledToHeight(20, Qt::SmoothTransformation));
-    m_sslCert = cert;
-  } else {
-    lblSslCertStatus->setPixmap(QPixmap(":/icons/oxygen/security-low.png").scaledToHeight(20, Qt::SmoothTransformation));
-    m_sslCert.clear();
-    if (interactive)
-      QMessageBox::warning(this, tr("Invalid certificate"), tr("This is not a valid SSL certificate."));
-  }
+    if (!cert.isEmpty() && !QSslCertificate(cert).isNull()) {
+        lblSslCertStatus->setPixmap(QPixmap(":/icons/oxygen/security-high.png").scaledToHeight(20, Qt::SmoothTransformation));
+        m_sslCert = cert;
+    }
+    else {
+        lblSslCertStatus->setPixmap(QPixmap(":/icons/oxygen/security-low.png").scaledToHeight(20, Qt::SmoothTransformation));
+        m_sslCert.clear();
+        if (interactive)
+            QMessageBox::warning(this, tr("Invalid certificate"), tr("This is not a valid SSL certificate."));
+    }
 #endif
 }
 
-bool options_imp::schedTimesOk() {
-  QString msg;
+bool options_imp::schedTimesOk()
+{
+    QString msg;
 
-  if (schedule_from->time() == schedule_to->time())
-    msg = tr("The start time and the end time can't be the same.");
+    if (schedule_from->time() == schedule_to->time())
+        msg = tr("The start time and the end time can't be the same.");
 
-  if (!msg.isEmpty()) {
-    QMessageBox::critical(this, tr("Time Error"), msg);
-    return false;
-  }
+    if (!msg.isEmpty()) {
+        QMessageBox::critical(this, tr("Time Error"), msg);
+        return false;
+    }
 
-  return true;
+    return true;
 }

--- a/src/gui/options_imp.h
+++ b/src/gui/options_imp.h
@@ -34,7 +34,12 @@
 #include "ui_options.h"
 
 // actions on double-click on torrents
-enum DoubleClickAction {TOGGLE_PAUSE, OPEN_DEST, NO_ACTION};
+enum DoubleClickAction
+{
+    TOGGLE_PAUSE,
+    OPEN_DEST,
+    NO_ACTION
+};
 
 class AdvancedSettings;
 
@@ -42,128 +47,137 @@ QT_BEGIN_NAMESPACE
 class QCloseEvent;
 QT_END_NAMESPACE
 
-class options_imp : public QDialog, private Ui_Preferences {
-  Q_OBJECT
+class options_imp: public QDialog, private Ui_Preferences
+{
+    Q_OBJECT
 private:
-  enum Tabs {TAB_UI, TAB_DOWNLOADS, TAB_CONNECTION, TAB_SPEED, TAB_BITTORRENT, TAB_WEBUI, TAB_ADVANCED};
+    enum Tabs
+    {
+        TAB_UI,
+        TAB_DOWNLOADS,
+        TAB_CONNECTION,
+        TAB_SPEED,
+        TAB_BITTORRENT,
+        TAB_WEBUI,
+        TAB_ADVANCED
+    };
 
 public:
-  // Constructor / Destructor
-  options_imp(QWidget *parent=0);
-  ~options_imp();
+    // Constructor / Destructor
+    options_imp(QWidget *parent = 0);
+    ~options_imp();
 
 public slots:
-  void showConnectionTab();
+    void showConnectionTab();
 
 signals:
-  void status_changed() const;
-  void exitWithCancel();
+    void status_changed() const;
+    void exitWithCancel();
 
 private slots:
-  void enableProxy(int comboIndex);
-  void on_buttonBox_accepted();
-  void closeEvent(QCloseEvent *e);
-  void on_buttonBox_rejected();
-  void applySettings(QAbstractButton* button);
-  void enableApplyButton();
-  void changePage(QListWidgetItem*, QListWidgetItem*);
-  void loadWindowState();
-  void saveWindowState() const;
-  void handleScanFolderViewSelectionChanged();
-  void on_IpFilterRefreshBtn_clicked();
-  void handleIPFilterParsed(bool error, int ruleCount);
-  void on_browseExportDirButton_clicked();
-  void on_browseExportDirFinButton_clicked();
-  void on_browseFilterButton_clicked();
-  void on_browseSaveDirButton_clicked();
-  void on_browseTempDirButton_clicked();
-  void on_randomButton_clicked();
-  void on_addScanFolderButton_clicked();
-  void on_removeScanFolderButton_clicked();
-  void on_btnWebUiCrt_clicked();
-  void on_btnWebUiKey_clicked();
-  void on_registerDNSBtn_clicked();
-  void setLocale(const QString &locale);
+    void enableProxy(int comboIndex);
+    void on_buttonBox_accepted();
+    void closeEvent(QCloseEvent *e);
+    void on_buttonBox_rejected();
+    void applySettings(QAbstractButton* button);
+    void enableApplyButton();
+    void changePage(QListWidgetItem*, QListWidgetItem*);
+    void loadWindowState();
+    void saveWindowState() const;
+    void handleScanFolderViewSelectionChanged();
+    void on_IpFilterRefreshBtn_clicked();
+    void handleIPFilterParsed(bool error, int ruleCount);
+    void on_browseExportDirButton_clicked();
+    void on_browseExportDirFinButton_clicked();
+    void on_browseFilterButton_clicked();
+    void on_browseSaveDirButton_clicked();
+    void on_browseTempDirButton_clicked();
+    void on_randomButton_clicked();
+    void on_addScanFolderButton_clicked();
+    void on_removeScanFolderButton_clicked();
+    void on_btnWebUiCrt_clicked();
+    void on_btnWebUiKey_clicked();
+    void on_registerDNSBtn_clicked();
+    void setLocale(const QString &locale);
 
 private:
-  // Methods
-  void saveOptions();
-  void loadOptions();
-  void initializeLanguageCombo();
-  static QString languageToLocalizedString(const QLocale &locale);
-  // General options
-  QString getLocale() const;
-  bool systrayIntegration() const;
-  bool minimizeToTray() const;
-  bool closeToTray() const;
-  bool startMinimized() const;
-  bool isSlashScreenDisabled() const;
-  bool preventFromSuspend() const;
+    // Methods
+    void saveOptions();
+    void loadOptions();
+    void initializeLanguageCombo();
+    static QString languageToLocalizedString(const QLocale &locale);
+    // General options
+    QString getLocale() const;
+    bool systrayIntegration() const;
+    bool minimizeToTray() const;
+    bool closeToTray() const;
+    bool startMinimized() const;
+    bool isSlashScreenDisabled() const;
+    bool preventFromSuspend() const;
 #ifdef Q_OS_WIN
-  bool WinStartup() const;
+    bool WinStartup() const;
 #endif
-  // Downloads
-  QString getSavePath() const;
-  bool isTempPathEnabled() const;
-  QString getTempPath() const;
-  bool preAllocateAllFiles() const;
-  bool useAdditionDialog() const;
-  bool addTorrentsInPause() const;
-  QString getTorrentExportDir() const;
-  QString getFinishedTorrentExportDir() const;
-  QString askForExportDir(const QString& currentExportPath);
-  int getActionOnDblClOnTorrentDl() const;
-  int getActionOnDblClOnTorrentFn() const;
-  // Connection options
-  int getPort() const;
-  bool isUPnPEnabled() const;
-  QPair<int,int> getGlobalBandwidthLimits() const;
-  QPair<int,int> getAltGlobalBandwidthLimits() const;
-  // Bittorrent options
-  int getMaxConnecs() const;
-  int getMaxConnecsPerTorrent() const;
-  int getMaxUploads() const;
-  int getMaxUploadsPerTorrent() const;
-  bool isDHTEnabled() const;
-  bool isLSDEnabled() const;
-  int getEncryptionSetting() const;
-  qreal getMaxRatio() const;
-  // Proxy options
-  bool isProxyEnabled() const;
-  bool isProxyAuthEnabled() const;
-  QString getProxyIp() const;
-  unsigned short getProxyPort() const;
-  QString getProxyUsername() const;
-  QString getProxyPassword() const;
-  int getProxyType() const;
-  // IP Filter
-  bool isFilteringEnabled() const;
-  QString getFilter() const;
-  bool m_refreshingIpFilter;
-  // Queueing system
-  bool isQueueingSystemEnabled() const;
-  int getMaxActiveDownloads() const;
-  int getMaxActiveUploads() const;
-  int getMaxActiveTorrents() const;
-  bool isWebUiEnabled() const;
-  quint16 webUiPort() const;
-  QString webUiUsername() const;
-  QString webUiPassword() const;
-  QSize sizeFittingScreen() const;
+    // Downloads
+    QString getSavePath() const;
+    bool isTempPathEnabled() const;
+    QString getTempPath() const;
+    bool preAllocateAllFiles() const;
+    bool useAdditionDialog() const;
+    bool addTorrentsInPause() const;
+    QString getTorrentExportDir() const;
+    QString getFinishedTorrentExportDir() const;
+    QString askForExportDir(const QString& currentExportPath);
+    int getActionOnDblClOnTorrentDl() const;
+    int getActionOnDblClOnTorrentFn() const;
+    // Connection options
+    int getPort() const;
+    bool isUPnPEnabled() const;
+    QPair<int, int> getGlobalBandwidthLimits() const;
+    QPair<int, int> getAltGlobalBandwidthLimits() const;
+    // Bittorrent options
+    int getMaxConnecs() const;
+    int getMaxConnecsPerTorrent() const;
+    int getMaxUploads() const;
+    int getMaxUploadsPerTorrent() const;
+    bool isDHTEnabled() const;
+    bool isLSDEnabled() const;
+    int getEncryptionSetting() const;
+    qreal getMaxRatio() const;
+    // Proxy options
+    bool isProxyEnabled() const;
+    bool isProxyAuthEnabled() const;
+    QString getProxyIp() const;
+    unsigned short getProxyPort() const;
+    QString getProxyUsername() const;
+    QString getProxyPassword() const;
+    int getProxyType() const;
+    // IP Filter
+    bool isFilteringEnabled() const;
+    QString getFilter() const;
+    bool m_refreshingIpFilter;
+    // Queueing system
+    bool isQueueingSystemEnabled() const;
+    int getMaxActiveDownloads() const;
+    int getMaxActiveUploads() const;
+    int getMaxActiveTorrents() const;
+    bool isWebUiEnabled() const;
+    quint16 webUiPort() const;
+    QString webUiUsername() const;
+    QString webUiPassword() const;
+    QSize sizeFittingScreen() const;
 
 private:
-  void setSslKey(const QByteArray &key, bool interactive = true);
-  void setSslCertificate(const QByteArray &cert, bool interactive = true);
-  bool schedTimesOk();
+    void setSslKey(const QByteArray &key, bool interactive = true);
+    void setSslCertificate(const QByteArray &cert, bool interactive = true);
+    bool schedTimesOk();
 
 private:
-  QButtonGroup choiceLanguage;
-  QAbstractButton *applyButton;
-  AdvancedSettings *advancedSettings;
-  QList<QString> addedScanDirs;
-  // SSL Cert / key
-  QByteArray m_sslCert, m_sslKey;
-
+    QButtonGroup choiceLanguage;
+    QAbstractButton *applyButton;
+    AdvancedSettings *advancedSettings;
+    QList<QString> addedScanDirs;
+    // SSL Cert / key
+    QByteArray m_sslCert, m_sslKey;
 };
 
 #endif


### PR DESCRIPTION
The GUI layout cleanups are done mostly to the Speed page and it's parents widgets, other pages are not touched.
It's hard to commit each small step since one small change leads to another change and so on...
I plan to cleanup each page... this is the first step.

I applied "Follow project coding style" by running my script. I already skimmed through, a pair of fresh eyes would help catching some leftovers.

Before:
![old](https://cloud.githubusercontent.com/assets/9395168/9659880/634d4d16-5285-11e5-9c44-b159a52d4729.png)

After:
[new_ver1](https://cloud.githubusercontent.com/assets/9395168/9698540/ac09dc04-53ed-11e5-95b1-91a2ba8df14e.png)
![latest_ver](https://cloud.githubusercontent.com/assets/9395168/9782533/6b98d03a-57d0-11e5-814f-d40aff56baef.png)



@ngosang 
You might want to try it out.
