### PR TITLE
RFC: [Web UI] add save_path to /query/torrents and /sync/maindata

### DIFF
--- a/src/webui/btjson.cpp
+++ b/src/webui/btjson.cpp
@@ -103,6 +103,7 @@ static const char KEY_TORRENT_FIRST_LAST_PIECE_PRIO[] = "f_l_piece_prio";
 static const char KEY_TORRENT_LABEL[] = "label";
 static const char KEY_TORRENT_SUPER_SEEDING[] = "super_seeding";
 static const char KEY_TORRENT_FORCE_START[] = "force_start";
+static const char KEY_TORRENT_SAVE_PATH[] = "save_path";
 
 // Tracker keys
 static const char KEY_TRACKER_URL[] = "url";
@@ -635,6 +636,7 @@ QVariantMap toMap(BitTorrent::TorrentHandle *const torrent)
     ret[KEY_TORRENT_LABEL] = torrent->label();
     ret[KEY_TORRENT_SUPER_SEEDING] = torrent->superSeeding();
     ret[KEY_TORRENT_FORCE_START] = torrent->isForced();
+    ret[KEY_TORRENT_SAVE_PATH] = Utils::Fs::toNativePath(torrent->rootPath());
 
     return ret;
 }


### PR DESCRIPTION
I'm working with the Sonarr devs to add a qBittorrent plugin (pull request at https://github.com/Sonarr/Sonarr/pull/779). There are two obstacles at the moment.

One is the inability to set a label on torrents added by Sonarr, which is resolved by the "[Web UI] Labels implementation pull" request, https://github.com/qbittorrent/qBittorrent/pull/3444. So +1 to that!

The second is that Sonarr needs to cache a download path for each torrent it sees. Because this isn't currently included in the api for /query/torrents, we need to make an extra request to /query/propertiesGeneral for every torrent in the list. Including the "save_path" field in the maps returned with /query/torrents and /sync/maindata allows us to avoid these extra requests.