### PR TITLE
Backporting #3765 to v3_2_x branch

### DIFF
--- a/src/core/downloadthread.cpp
+++ b/src/core/downloadthread.cpp
@@ -193,6 +193,8 @@ QNetworkReply* DownloadThread::downloadUrl(const QString &url, const QList<QNetw
   QNetworkRequest request(qurl);
   // Spoof Firefox 38 user agent to avoid web server banning
   request.setRawHeader("User-Agent", "Mozilla/5.0 (X11; Linux i686; rv:38.0) Gecko/20100101 Firefox/38.0");
+  // Spoof HTTP Referer to allow adding torrent link from Torcache/KickAssTorrents
+  request.setRawHeader("Referer", request.url().toEncoded().data());
   qDebug("Downloading %s...", request.url().toEncoded().data());
   qDebug("%d cookies for this URL", m_networkManager.cookieJar()->cookiesForUrl(url).size());
   for (int i=0; i<m_networkManager.cookieJar()->cookiesForUrl(url).size(); ++i) {


### PR DESCRIPTION
Allow adding torrent link from Torcache.
Recent changes in Torcache prevent adding (or drag-and-dropping) a torrent link into qBittorrent. Modifying DownloadManager to always spoof the HTTP Referer header to the file itself being downloaded solves this.