### PR TITLE
[RSS] Removes refresh message when adding a new feed

### DIFF
--- a/src/gui/rss/rss_imp.cpp
+++ b/src/gui/rss/rss_imp.cpp
@@ -239,7 +239,6 @@ void RSSImp::on_newFeedButton_clicked()
     // Notify TreeWidget
     m_feedList->itemAdded(item, stream);
 
-    stream->refresh();
     m_rssManager->saveStreamList();
 }
 


### PR DESCRIPTION
When you **add a new RSS feed** you get this message in the console:
```
virtual bool RssFeed::refresh() Feed "https://xxxxxxxxxxxxxx" is already being refreshed, ignoring request
```
This is caused because `stream->refresh();` is called two times. It's called inside `RssFeedPtr stream = rss_parent->addStream(m_rssManager.data(), newUrl);` few lines above the removed line.
