### PR TITLE
Download more pieces in "Download first and last pieces first" feature

### DIFF
--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -668,7 +668,7 @@ void TransferListWidget::displayListMenu(const QPoint&)
     QAction actionSequential_download(tr("Download in sequential order"), 0);
     actionSequential_download.setCheckable(true);
     connect(&actionSequential_download, SIGNAL(triggered()), this, SLOT(toggleSelectedTorrentsSequentialDownload()));
-    QAction actionFirstLastPiece_prio(tr("Download first and last piece first"), 0);
+    QAction actionFirstLastPiece_prio(tr("Download first and last pieces first"), 0);
     actionFirstLastPiece_prio.setCheckable(true);
     connect(&actionFirstLastPiece_prio, SIGNAL(triggered()), this, SLOT(toggleSelectedFirstLastPiecePrio()));
     // End of actions

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -122,7 +122,7 @@
         <li><a href="#UploadLimit"><img src="images/skin/uploadLimit.png" alt="QBT_TR(Limit upload rate...)QBT_TR"/> QBT_TR(Limit upload rate...)QBT_TR</a></li>
         <li><a href="#SuperSeeding"><img src="theme/checked" alt="QBT_TR(Super seeding mode)QBT_TR"/> QBT_TR(Super seeding mode)QBT_TR</a></li>
         <li class="separator"><a href="#SequentialDownload"><img src="theme/checked" alt="QBT_TR(Download in sequential order)QBT_TR"/> QBT_TR(Download in sequential order)QBT_TR</a></li>
-        <li><a href="#FirstLastPiecePrio"><img src="theme/checked" alt="QBT_TR(Download first and last piece first)QBT_TR"/> QBT_TR(Download first and last piece first)QBT_TR</a></li>
+        <li><a href="#FirstLastPiecePrio"><img src="theme/checked" alt="QBT_TR(Download first and last pieces first)QBT_TR"/> QBT_TR(Download first and last pieces first)QBT_TR</a></li>
         <li class="separator"><a href="#ForceRecheck"><img src="theme/document-edit-verify" alt="QBT_TR(Force recheck)QBT_TR"/>  QBT_TR(Force recheck)QBT_TR</a></li>
     </ul>
     <div id="desktopFooterWrapper">


### PR DESCRIPTION
Closes #189,  #2331 and #1813. Maybe #3743.

I did a lot of tests (more than 50 different movies) and the index length is proportional to the file length. It depends on many things as the codec, framerate... but I get a fix for that.
* The AVI format has the biggest index at the end of the file.
* In most AVI files the index length is 0.25% of the total file size.
* In the worst AVI file I have found the index length is almost 1% of the total file size.

This fix always downloads the last 1% of the file.

Example: Movie 1.3 GB (5612 pieces x 256 KB)
* In the current implementation you will download 1 piece (1 x 256 KB = 256 KB)
* With this PR you will download 52 pieces (52 * 256 KB = 13 MB)

The index length will be between 2MB and 13MB but we can't know. With this fix maybe we are downloading more than necessary but you can preview all the files.