### PR TITLE
Fix dialogs didn't position on the correct screen

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -366,7 +366,7 @@ void Application::allTorrentsFinished()
         // do nothing & skip confirm
     }
     else {
-        if (!ShutdownConfirmDlg::askForConfirmation(action)) return;
+        if (!ShutdownConfirmDlg::askForConfirmation(m_window, action)) return;
     }
 #endif // DISABLE_GUI
 

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -409,7 +409,7 @@ void Application::processParams(const QStringList &params)
         param = param.trimmed();
 
         // Process strings indicating options specified by the user.
-        
+
         if (param.startsWith(QLatin1String("@savePath="))) {
             torrentParams.savePath = param.mid(10);
             continue;

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -1127,7 +1127,6 @@ void Preferences::setMainLastDir(const QString &path)
     setValue("MainWindowLastDir", path);
 }
 
-#ifndef DISABLE_GUI
 QSize Preferences::getPrefSize(const QSize& defaultSize) const
 {
     return value("Preferences/State/size", defaultSize).toSize();
@@ -1137,7 +1136,6 @@ void Preferences::setPrefSize(const QSize &size)
 {
     setValue("Preferences/State/size", size);
 }
-#endif
 
 QStringList Preferences::getPrefHSplitterSizes() const
 {
@@ -1209,14 +1207,14 @@ void Preferences::setPropTrackerListState(const QByteArray &state)
     setValue("TorrentProperties/Trackers/qt5/TrackerListState", state);
 }
 
-QByteArray Preferences::getRssGeometry() const
+QSize Preferences::getRssGeometrySize(const QSize &defaultSize) const
 {
-    return value("RssFeedDownloader/geometry").toByteArray();
+    return value("RssFeedDownloader/geometrySize", defaultSize).toSize();
 }
 
-void Preferences::setRssGeometry(const QByteArray &geometry)
+void Preferences::setRssGeometrySize(const QSize &geometry)
 {
-    setValue("RssFeedDownloader/geometry", geometry);
+    setValue("RssFeedDownloader/geometrySize", geometry);
 }
 
 QByteArray Preferences::getRssHSplitterSizes() const

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -1139,16 +1139,6 @@ void Preferences::setPrefSize(const QSize &size)
 }
 #endif
 
-QPoint Preferences::getPrefPos() const
-{
-    return value("Preferences/State/pos").toPoint();
-}
-
-void Preferences::setPrefPos(const QPoint &pos)
-{
-    setValue("Preferences/State/pos", pos);
-}
-
 QStringList Preferences::getPrefHSplitterSizes() const
 {
     return value("Preferences/State/hSplitterSizes").toStringList();

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -36,6 +36,7 @@
 #include <QTime>
 #include <QDateTime>
 #include <QList>
+#include <QSize>
 #include <QTimer>
 #include <QReadWriteLock>
 #include <QNetworkCookie>
@@ -274,10 +275,8 @@ public:
     void setMainVSplitterState(const QByteArray &state);
     QString getMainLastDir() const;
     void setMainLastDir(const QString &path);
-#ifndef DISABLE_GUI
     QSize getPrefSize(const QSize &defaultSize) const;
     void setPrefSize(const QSize &size);
-#endif
     QStringList getPrefHSplitterSizes() const;
     void setPrefHSplitterSizes(const QStringList &sizes);
     QByteArray getPeerListState() const;
@@ -292,8 +291,8 @@ public:
     void setPropVisible(const bool visible);
     QByteArray getPropTrackerListState() const;
     void setPropTrackerListState(const QByteArray &state);
-    QByteArray getRssGeometry() const;
-    void setRssGeometry(const QByteArray &geometry);
+    QSize getRssGeometrySize(const QSize &defaultSize) const;
+    void setRssGeometrySize(const QSize &geometry);
     QByteArray getRssHSplitterSizes() const;
     void setRssHSplitterSizes(const QByteArray &sizes);
     QStringList getRssOpenFolders() const;

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -278,8 +278,6 @@ public:
     QSize getPrefSize(const QSize &defaultSize) const;
     void setPrefSize(const QSize &size);
 #endif
-    QPoint getPrefPos() const;
-    void setPrefPos(const QPoint &pos);
     QStringList getPrefHSplitterSizes() const;
     void setPrefHSplitterSizes(const QStringList &sizes);
     QByteArray getPeerListState() const;

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -219,21 +219,15 @@ void Utils::Misc::shutdownComputer(const ShutdownDialogAction &action)
 }
 
 #ifndef DISABLE_GUI
-// Get screen center
-QPoint Utils::Misc::screenCenter(QWidget *win)
+QPoint Utils::Misc::screenCenter(const QWidget *w)
 {
-    int scrn = 0;
-    const QWidget *w = win->window();
+    // Returns the QPoint which the widget will be placed center on screen (where parent resides)
 
-    if (w)
-        scrn = QApplication::desktop()->screenNumber(w);
-    else if (QApplication::desktop()->isVirtualDesktop())
-        scrn = QApplication::desktop()->screenNumber(QCursor::pos());
-    else
-        scrn = QApplication::desktop()->screenNumber(win);
-
-    QRect desk(QApplication::desktop()->availableGeometry(scrn));
-    return QPoint((desk.width() - win->frameGeometry().width()) / 2, (desk.height() - win->frameGeometry().height()) / 2);
+    QWidget *parent = w->parentWidget();
+    QDesktopWidget *desktop = QApplication::desktop();
+    int scrn = desktop->screenNumber(parent);  // fallback to `primaryScreen` when parent is invalid
+    QRect r = desktop->availableGeometry(scrn);
+    return QPoint(r.x() + (r.width() - w->frameSize().width()) / 2, r.y() + (r.height() - w->frameSize().height()) / 2);
 }
 
 #endif

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -102,7 +102,7 @@ namespace Utils
         void openPath(const QString& absolutePath);
         void openFolderSelect(const QString& absolutePath);
 
-        QPoint screenCenter(QWidget *win);
+        QPoint screenCenter(const QWidget *w);
         QSize smallIconSize();
         QSize largeIconSize();
 #endif

--- a/src/gui/addnewtorrentdialog.h
+++ b/src/gui/addnewtorrentdialog.h
@@ -75,7 +75,6 @@ private slots:
     void updateDiskSpaceLabel();
     void onSavePathChanged(int);
     void renameSelectedFile();
-    void setdialogPosition();
     void updateMetadata(const BitTorrent::TorrentInfo &info);
     void browseButton_clicked();
     void handleDownloadFailed(const QString &url, const QString &reason);

--- a/src/gui/autoexpandabledialog.cpp
+++ b/src/gui/autoexpandabledialog.cpp
@@ -72,7 +72,6 @@ void AutoExpandableDialog::showEvent(QShowEvent *e) {
   // NOTE: For some strange reason QFontMetrics gets more accurate
   // when called from showEvent. Only 6 symbols off instead of 11 symbols off.
   int textW = ui->textEdit->fontMetrics().width(ui->textEdit->text()) + 4;
-  int screenW = QApplication::desktop()->width() / 4;
   int wd = textW;
 
   if (!windowTitle().isEmpty()) {
@@ -87,35 +86,9 @@ void AutoExpandableDialog::showEvent(QShowEvent *e) {
       wd = _w;
   }
 
-
   // Now resize the dialog to fit the contents
-  // Maximum value is whichever is smaller:
-  // 1. screen width / 4
-  // 2. max width of text from either of: label, title, textedit
+  // max width of text from either of: label, title, textedit
   // If the value is less than dialog default size default size is used
-  wd = textW < screenW ? textW : screenW;
   if (wd > width())
-    resize(width() - ui->horizontalLayout->sizeHint().width() + wd, height());
-
-  // Use old dialog behavior: prohibit resizing the dialog
-  setFixedHeight(height());
-
-  // Update geometry: center on screen
-  QDesktopWidget *desk = QApplication::desktop();
-  MainWindow *wnd = qobject_cast<MainWindow*>(QApplication::activeWindow());
-  QPoint p = QCursor::pos();
-
-  int screenNum = 0;
-  if (wnd == 0)
-    screenNum = desk->screenNumber(p);
-  else if (!wnd->isHidden())
-    screenNum = desk->screenNumber(wnd);
-  else
-    screenNum = desk->screenNumber(p);
-
-  QRect screenRes = desk->screenGeometry(screenNum);
-
-  QRect geom = geometry();
-  geom.moveCenter(QPoint(screenRes.width() / 2, screenRes.height() / 2));
-  setGeometry(geom);
+    resize(width() - ui->verticalLayout->sizeHint().width() + wd, height());
 }

--- a/src/gui/autoexpandabledialog.h
+++ b/src/gui/autoexpandabledialog.h
@@ -41,9 +41,9 @@ class AutoExpandableDialog;
 
 class AutoExpandableDialog : public QDialog {
   Q_OBJECT
-  
+
 public:
-  explicit AutoExpandableDialog(QWidget *parent = 0);
+  explicit AutoExpandableDialog(QWidget *parent);
   ~AutoExpandableDialog();
 
   static QString getText(QWidget *parent, const QString& title,  const QString& label,
@@ -52,7 +52,7 @@ public:
 
 protected:
   void showEvent(QShowEvent *e);
-  
+
 private:
   Ui::AutoExpandableDialog *ui;
 };

--- a/src/gui/autoexpandabledialog.ui
+++ b/src/gui/autoexpandabledialog.ui
@@ -7,78 +7,22 @@
     <x>0</x>
     <y>0</y>
     <width>222</width>
-    <height>94</height>
+    <height>105</height>
    </rect>
-  </property>
-  <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-    <horstretch>0</horstretch>
-    <verstretch>0</verstretch>
-   </sizepolicy>
-  </property>
-  <property name="windowTitle">
-   <string notr="true">Dialog</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
+    <widget class="QLabel" name="textLabel"/>
    </item>
    <item>
-    <widget class="QLabel" name="textLabel">
-     <property name="toolTip">
-      <string notr="true"/>
-     </property>
-     <property name="text">
-      <string notr="true"/>
+    <widget class="QLineEdit" name="textEdit"/>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
-   </item>
-   <item>
-    <widget class="QLineEdit" name="textEdit">
-     <property name="toolTip">
-      <string notr="true"/>
-     </property>
-     <property name="text">
-      <string notr="true"/>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QDialogButtonBox" name="buttonBox">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
   </layout>
  </widget>

--- a/src/gui/bandwidth_limit.ui
+++ b/src/gui/bandwidth_limit.ui
@@ -10,9 +10,6 @@
     <height>83</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string notr="true">Bandwidth allocation</string>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
@@ -25,9 +22,6 @@
      </item>
      <item>
       <widget class="QSpinBox" name="spinBandwidth">
-       <property name="suffix">
-        <string/>
-       </property>
        <property name="maximum">
         <number>65535</number>
        </property>
@@ -40,9 +34,6 @@
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>

--- a/src/gui/cookiesdialog.cpp
+++ b/src/gui/cookiesdialog.cpp
@@ -35,7 +35,7 @@
 #include "ui_cookiesdialog.h"
 
 #define SETTINGS_KEY(name) "CookiesDialog/" name
-const QString KEY_GEOMETRY = SETTINGS_KEY("Geometry");
+const QString KEY_SIZE = SETTINGS_KEY("Size");
 const QString KEY_COOKIESVIEWSTATE = SETTINGS_KEY("CookiesViewState");
 
 CookiesDialog::CookiesDialog(QWidget *parent)
@@ -55,14 +55,14 @@ CookiesDialog::CookiesDialog(QWidget *parent)
                     m_cookiesModel->index(0, 0),
                     QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
 
-    restoreGeometry(SettingsStorage::instance()->loadValue(KEY_GEOMETRY).toByteArray());
+    resize(SettingsStorage::instance()->loadValue(KEY_SIZE, size()).toSize());
     m_ui->treeView->header()->restoreState(
                 SettingsStorage::instance()->loadValue(KEY_COOKIESVIEWSTATE).toByteArray());
 }
 
 CookiesDialog::~CookiesDialog()
 {
-    SettingsStorage::instance()->storeValue(KEY_GEOMETRY, saveGeometry());
+    SettingsStorage::instance()->storeValue(KEY_SIZE, size());
     SettingsStorage::instance()->storeValue(
                 KEY_COOKIESVIEWSTATE, m_ui->treeView->header()->saveState());
     delete m_ui;

--- a/src/gui/deletionconfirmationdlg.h
+++ b/src/gui/deletionconfirmationdlg.h
@@ -54,7 +54,6 @@ class DeletionConfirmationDlg : public QDialog, private Ui::confirmDeletionDlg {
     lbl_warn->setFixedWidth(lbl_warn->height());
     rememberBtn->setIcon(GuiIconProvider::instance()->getIcon("object-locked"));
 
-    move(Utils::Misc::screenCenter(this));
     checkPermDelete->setChecked(defaultDeleteFiles || Preferences::instance()->deleteTorrentFilesAsDefault());
     connect(checkPermDelete, SIGNAL(clicked()), this, SLOT(updateRememberButtonState()));
     buttonBox->button(QDialogButtonBox::Cancel)->setFocus();
@@ -64,8 +63,8 @@ class DeletionConfirmationDlg : public QDialog, private Ui::confirmDeletionDlg {
     return checkPermDelete->isChecked();
   }
 
-  static bool askForDeletionConfirmation(bool& deleteLocalFiles, const int& size, const QString& name) {
-    DeletionConfirmationDlg dlg(NULL, size, name, deleteLocalFiles);
+  static bool askForDeletionConfirmation(QWidget *parent, bool& deleteLocalFiles, const int& size, const QString& name) {
+    DeletionConfirmationDlg dlg(parent, size, name, deleteLocalFiles);
     if (dlg.exec() == QDialog::Accepted) {
       deleteLocalFiles = dlg.shouldDeleteLocalFiles();
       return true;

--- a/src/gui/downloadfromurldlg.h
+++ b/src/gui/downloadfromurldlg.h
@@ -47,7 +47,7 @@ class downloadFromURL : public QDialog, private Ui::downloadFromURL{
       setupUi(this);
       setAttribute(Qt::WA_DeleteOnClose);
       setModal(true);
-      show();
+
       // Paste clipboard if there is an URL in it
       QString clip_txt = qApp->clipboard()->text();
       QStringList clip_txt_list = clip_txt.split(QString::fromUtf8("\n"));
@@ -71,6 +71,8 @@ class downloadFromURL : public QDialog, private Ui::downloadFromURL{
       }
       if (clip_txt_list_cleaned.size() > 0)
         textUrls->setText(clip_txt_list_cleaned.join("\n"));
+
+      show();
     }
 
     ~downloadFromURL() {}
@@ -93,7 +95,7 @@ class downloadFromURL : public QDialog, private Ui::downloadFromURL{
         }
       }
       if (!url_list_cleaned.size()) {
-        QMessageBox::warning(0, tr("No URL entered"), tr("Please type at least one URL."));
+        QMessageBox::warning(this, tr("No URL entered"), tr("Please type at least one URL."));
         return;
       }
       emit urlsReadyToBeDownloaded(url_list_cleaned);

--- a/src/gui/downloadfromurldlg.ui
+++ b/src/gui/downloadfromurldlg.ui
@@ -11,51 +11,41 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Download from urls</string>
+   <string>Download from URLs</string>
   </property>
   <layout class="QVBoxLayout">
    <item>
-    <layout class="QHBoxLayout">
-     <item>
-      <widget class="QLabel" name="downloadURL_lbl">
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>Add torrent links</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QLabel" name="downloadURL_lbl">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Add torrent links</string>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QTextEdit" name="textUrls">
-     <property name="acceptRichText">
-      <bool>false</bool>
-     </property>
      <property name="tabChangesFocus">
       <bool>true</bool>
+     </property>
+     <property name="acceptRichText">
+      <bool>false</bool>
      </property>
     </widget>
    </item>
    <item>
     <widget class="QLabel" name="label_infos">
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>17</height>
-      </size>
-     </property>
      <property name="font">
       <font>
        <italic>true</italic>
       </font>
      </property>
      <property name="text">
-      <string>One per line (HTTP links, Magnet links and info-hashes are supported)</string>
+      <string>One link per line (HTTP links, Magnet links and info-hashes are supported)</string>
      </property>
     </widget>
    </item>

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -385,7 +385,7 @@ MainWindow::MainWindow(QWidget *parent)
     qDebug("GUI Built");
 #ifdef Q_OS_WIN
     if (!pref->neverCheckFileAssoc() && (!Preferences::isTorrentFileAssocSet() || !Preferences::isMagnetLinkAssocSet())) {
-        if (QMessageBox::question(0, tr("Torrent file association"),
+        if (QMessageBox::question(this, tr("Torrent file association"),
                                   tr("qBittorrent is not the default application to open torrent files or Magnet links.\nDo you want to associate qBittorrent to torrent files and Magnet links?"),
                                   QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes) == QMessageBox::Yes) {
             Preferences::setTorrentFileAssoc(true);
@@ -841,7 +841,7 @@ void MainWindow::askRecursiveTorrentDownloadConfirmation(BitTorrent::TorrentHand
     if (pref->recursiveDownloadDisabled()) return;
     // Get Torrent name
     QString torrentName = torrent->name();
-    QMessageBox confirmBox(QMessageBox::Question, tr("Recursive download confirmation"), tr("The torrent '%1' contains torrent files, do you want to proceed with their download?").arg(torrentName));
+    QMessageBox confirmBox(QMessageBox::Question, tr("Recursive download confirmation"), tr("The torrent '%1' contains torrent files, do you want to proceed with their download?").arg(torrentName), QMessageBox::NoButton, this);
     QPushButton *yes = confirmBox.addButton(tr("Yes"), QMessageBox::YesRole);
     /*QPushButton *no = */ confirmBox.addButton(tr("No"), QMessageBox::NoRole);
     QPushButton *never = confirmBox.addButton(tr("Never"), QMessageBox::NoRole);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -862,10 +862,12 @@ void MainWindow::handleDownloadFromUrlFailure(QString url, QString reason) const
 void MainWindow::on_actionSetGlobalUploadLimit_triggered()
 {
     qDebug() << Q_FUNC_INFO;
+
     BitTorrent::Session *const session = BitTorrent::Session::instance();
     bool ok = false;
     const long newLimit = SpeedLimitDialog::askSpeedLimit(
-        &ok, tr("Global Upload Speed Limit"), session->uploadSpeedLimit());
+        this, &ok, tr("Global Upload Speed Limit"), session->uploadSpeedLimit());
+
     if (ok) {
         qDebug("Setting global upload rate limit to %.1fKb/s", newLimit / 1024.);
         session->setUploadSpeedLimit(newLimit);
@@ -875,10 +877,12 @@ void MainWindow::on_actionSetGlobalUploadLimit_triggered()
 void MainWindow::on_actionSetGlobalDownloadLimit_triggered()
 {
     qDebug() << Q_FUNC_INFO;
+
     BitTorrent::Session *const session = BitTorrent::Session::instance();
     bool ok = false;
     const long newLimit = SpeedLimitDialog::askSpeedLimit(
-        &ok, tr("Global Download Speed Limit"), session->downloadSpeedLimit());
+        this, &ok, tr("Global Download Speed Limit"), session->downloadSpeedLimit());
+
     if (ok) {
         qDebug("Setting global download rate limit to %.1fKb/s", newLimit / 1024.);
         session->setDownloadSpeedLimit(newLimit);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1163,8 +1163,9 @@ void MainWindow::on_actionOpen_triggered()
     // Open File Open Dialog
     // Note: it is possible to select more than one file
     const QStringList pathsList =
-        QFileDialog::getOpenFileNames(0, tr("Open Torrent Files"), pref->getMainLastDir(),
+        QFileDialog::getOpenFileNames(this, tr("Open Torrent Files"), pref->getMainLastDir(),
                                       tr("Torrent Files") + " (*.torrent)");
+
     const bool useTorrentAdditionDialog = AddNewTorrentDialog::isEnabled();
     if (!pathsList.isEmpty()) {
         foreach (QString file, pathsList) {

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -52,7 +52,6 @@ class TransferListFiltersWidget;
 class PropertiesWidget;
 class StatusBar;
 class TorrentCreatorDlg;
-class downloadFromURL;
 class LineEdit;
 class ExecutionLog;
 class PowerManagement;

--- a/src/gui/optionsdlg.cpp
+++ b/src/gui/optionsdlg.cpp
@@ -357,7 +357,6 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     m_ui->advPageLayout->addWidget(advancedSettings);
     connect(advancedSettings, SIGNAL(settingsChanged()), this, SLOT(enableApplyButton()));
 
-    // Adapt size
     show();
     loadWindowState();
 }
@@ -404,14 +403,9 @@ void OptionsDialog::changePage(QListWidgetItem *current, QListWidgetItem *previo
 void OptionsDialog::loadWindowState()
 {
     const Preferences* const pref = Preferences::instance();
-    resize(pref->getPrefSize(sizeFittingScreen()));
-    QPoint p = pref->getPrefPos();
-    QRect scr_rect = qApp->desktop()->screenGeometry();
-    if (!p.isNull() && scr_rect.contains(p))
-        move(p);
-    // Load slider size
+
+    resize(pref->getPrefSize(this->size()));
     const QStringList sizes_str = pref->getPrefHSplitterSizes();
-    // Splitter size
     QList<int> sizes;
     if (sizes_str.size() == 2) {
         sizes << sizes_str.first().toInt();
@@ -427,32 +421,15 @@ void OptionsDialog::loadWindowState()
 void OptionsDialog::saveWindowState() const
 {
     Preferences* const pref = Preferences::instance();
+
+    // window size
     pref->setPrefSize(size());
-    pref->setPrefPos(pos());
+
     // Splitter size
     QStringList sizes_str;
     sizes_str << QString::number(m_ui->hsplitter->sizes().first());
     sizes_str << QString::number(m_ui->hsplitter->sizes().last());
     pref->setPrefHSplitterSizes(sizes_str);
-}
-
-QSize OptionsDialog::sizeFittingScreen() const
-{
-    int scrn = 0;
-    QWidget *w = this->topLevelWidget();
-
-    if (w)
-        scrn = QApplication::desktop()->screenNumber(w);
-    else if (QApplication::desktop()->isVirtualDesktop())
-        scrn = QApplication::desktop()->screenNumber(QCursor::pos());
-    else
-        scrn = QApplication::desktop()->screenNumber(this);
-
-    QRect desk(QApplication::desktop()->availableGeometry(scrn));
-    if (width() > desk.width() || height() > desk.height())
-        if (desk.width() > 0 && desk.height() > 0)
-            return QSize(desk.width(), desk.height());
-    return size();
 }
 
 void OptionsDialog::saveOptions()

--- a/src/gui/optionsdlg.h
+++ b/src/gui/optionsdlg.h
@@ -170,7 +170,6 @@ private:
     quint16 webUiPort() const;
     QString webUiUsername() const;
     QString webUiPassword() const;
-    QSize sizeFittingScreen() const;
 
 private:
     bool setSslKey(const QByteArray &key);

--- a/src/gui/preview.ui
+++ b/src/gui/preview.ui
@@ -16,17 +16,8 @@
   <layout class="QVBoxLayout">
    <item>
     <widget class="QLabel" name="label">
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>42</height>
-      </size>
-     </property>
      <property name="text">
       <string>The following files support previewing, please select one of them:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/src/gui/previewselect.cpp
+++ b/src/gui/previewselect.cpp
@@ -83,7 +83,7 @@ PreviewSelect::PreviewSelect(QWidget* parent, BitTorrent::TorrentHandle *const t
   }
 
   if (!previewListModel->rowCount()) {
-    QMessageBox::critical(0, tr("Preview impossible"), tr("Sorry, we can't preview this file"));
+    QMessageBox::critical(this->parentWidget(), tr("Preview impossible"), tr("Sorry, we can't preview this file"));
     close();
   }
   connect(this, SIGNAL(readyToPreviewFile(QString)), parent, SLOT(previewFile(QString)));
@@ -120,7 +120,7 @@ void PreviewSelect::on_previewButton_clicked() {
   if (QFile::exists(path))
     emit readyToPreviewFile(path);
   else
-    QMessageBox::critical(0, tr("Preview impossible"), tr("Sorry, we can't preview this file"));
+    QMessageBox::critical(this->parentWidget(), tr("Preview impossible"), tr("Sorry, we can't preview this file"));
   close();
 }
 

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -245,7 +245,7 @@ void PeerListWidget::showPeerListMenu(const QPoint &)
     QAction *act = menu.exec(QCursor::pos());
     if (act == 0) return;
     if (act == addPeerAct) {
-        QList<BitTorrent::PeerAddress> peersList = PeersAdditionDlg::askForPeers();
+        QList<BitTorrent::PeerAddress> peersList = PeersAdditionDlg::askForPeers(this);
         int peerCount = 0;
         foreach (const BitTorrent::PeerAddress &addr, peersList) {
             if (torrent->connectPeer(addr)) {

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -258,9 +258,9 @@ void PeerListWidget::showPeerListMenu(const QPoint &)
             }
         }
         if (peerCount < peersList.length())
-            QMessageBox::information(0, tr("Peer addition"), tr("Some peers could not be added. Check the Log for details."));
+            QMessageBox::information(this, tr("Peer addition"), tr("Some peers could not be added. Check the Log for details."));
         else if (peerCount > 0)
-            QMessageBox::information(0, tr("Peer addition"), tr("The peers were added to this torrent."));
+            QMessageBox::information(this, tr("Peer addition"), tr("The peers were added to this torrent."));
         return;
     }
     if (act == banAct) {

--- a/src/gui/properties/peersadditiondlg.cpp
+++ b/src/gui/properties/peersadditiondlg.cpp
@@ -51,9 +51,9 @@ PeersAdditionDlg::~PeersAdditionDlg()
     delete m_ui;
 }
 
-QList<BitTorrent::PeerAddress> PeersAdditionDlg::askForPeers()
+QList<BitTorrent::PeerAddress> PeersAdditionDlg::askForPeers(QWidget *parent)
 {
-    PeersAdditionDlg dlg;
+    PeersAdditionDlg dlg(parent);
     dlg.exec();
     return dlg.m_peersList;
 }

--- a/src/gui/properties/peersadditiondlg.h
+++ b/src/gui/properties/peersadditiondlg.h
@@ -47,10 +47,10 @@ class PeersAdditionDlg: public QDialog
     Q_OBJECT
 
 public:
-    PeersAdditionDlg(QWidget *parent = 0);
+    PeersAdditionDlg(QWidget *parent);
     ~PeersAdditionDlg();
 
-    static QList<BitTorrent::PeerAddress> askForPeers();
+    static QList<BitTorrent::PeerAddress> askForPeers(QWidget *parent);
 
 protected slots:
     void validateInput();

--- a/src/gui/properties/peersadditiondlg.ui
+++ b/src/gui/properties/peersadditiondlg.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>List of peers to add (one per line):</string>
+      <string>List of peers to add (one IP per line):</string>
      </property>
     </widget>
    </item>
@@ -40,9 +40,6 @@
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>

--- a/src/gui/properties/trackerlist.cpp
+++ b/src/gui/properties/trackerlist.cpp
@@ -347,7 +347,7 @@ void TrackerList::askForTrackers() {
   if (!torrent) return;
 
   QList<BitTorrent::TrackerEntry> trackers;
-  foreach (const QString &tracker, TrackersAdditionDlg::askForTrackers(torrent))
+  foreach (const QString &tracker, TrackersAdditionDlg::askForTrackers(this, torrent))
       trackers << tracker;
   torrent->addTrackers(trackers);
 }

--- a/src/gui/properties/trackersadditiondlg.cpp
+++ b/src/gui/properties/trackersadditiondlg.cpp
@@ -43,7 +43,7 @@
 #include "guiiconprovider.h"
 #include "ui_trackersadditiondlg.h"
 
-TrackersAdditionDlg::TrackersAdditionDlg(BitTorrent::TorrentHandle *const torrent, QWidget *parent)
+TrackersAdditionDlg::TrackersAdditionDlg(QWidget *parent, BitTorrent::TorrentHandle *const torrent)
     : QDialog(parent)
     , m_ui(new Ui::TrackersAdditionDlg())
     , m_torrent(torrent)
@@ -132,10 +132,10 @@ void TrackersAdditionDlg::getTrackerError(const QString &, const QString &error)
     QMessageBox::warning(this, tr("Download error"), tr("The trackers list could not be downloaded, reason: %1").arg(error), QMessageBox::Ok);
 }
 
-QStringList TrackersAdditionDlg::askForTrackers(BitTorrent::TorrentHandle *const torrent)
+QStringList TrackersAdditionDlg::askForTrackers(QWidget *parent, BitTorrent::TorrentHandle *const torrent)
 {
     QStringList trackers;
-    TrackersAdditionDlg dlg(torrent);
+    TrackersAdditionDlg dlg(parent, torrent);
     if (dlg.exec() == QDialog::Accepted)
         return dlg.newTrackers();
 

--- a/src/gui/properties/trackersadditiondlg.h
+++ b/src/gui/properties/trackersadditiondlg.h
@@ -51,11 +51,11 @@ class TrackersAdditionDlg : public QDialog
     Q_OBJECT
 
 public:
-    TrackersAdditionDlg(BitTorrent::TorrentHandle *const torrent, QWidget *parent = 0);
+    TrackersAdditionDlg(QWidget *parent, BitTorrent::TorrentHandle *const torrent);
     ~TrackersAdditionDlg();
 
     QStringList newTrackers() const;
-    static QStringList askForTrackers(BitTorrent::TorrentHandle *const torrent);
+    static QStringList askForTrackers(QWidget *parent, BitTorrent::TorrentHandle *const torrent);
 
 public slots:
     void on_uTorrentListButton_clicked();

--- a/src/gui/properties/trackersadditiondlg.ui
+++ b/src/gui/properties/trackersadditiondlg.ui
@@ -26,13 +26,6 @@
      <property name="lineWrapMode">
       <enum>QTextEdit::NoWrap</enum>
      </property>
-     <property name="html">
-      <string notr="true">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Sans'; font-size:10pt;&quot;&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
      <property name="acceptRichText">
       <bool>false</bool>
      </property>
@@ -51,23 +44,7 @@ p, li { white-space: pre-wrap; }
       <widget class="QLineEdit" name="list_url"/>
      </item>
      <item>
-      <widget class="QPushButton" name="uTorrentListButton">
-       <property name="minimumSize">
-        <size>
-         <width>31</width>
-         <height>31</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>31</width>
-         <height>31</height>
-        </size>
-       </property>
-       <property name="text">
-        <string notr="true"/>
-       </property>
-      </widget>
+      <widget class="QPushButton" name="uTorrentListButton"/>
      </item>
     </layout>
    </item>

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -149,17 +149,15 @@ AutomatedRssDownloader::~AutomatedRssDownloader()
 
 void AutomatedRssDownloader::loadSettings()
 {
-    // load dialog geometry
     const Preferences *const pref = Preferences::instance();
-    restoreGeometry(pref->getRssGeometry());
+    resize(pref->getRssGeometrySize(this->size()));
     m_ui->hsplitter->restoreState(pref->getRssHSplitterSizes());
 }
 
 void AutomatedRssDownloader::saveSettings()
 {
-    // Save dialog geometry
     Preferences *const pref = Preferences::instance();
-    pref->setRssGeometry(saveGeometry());
+    pref->setRssGeometrySize(this->size());
     pref->setRssHSplitterSizes(m_ui->hsplitter->saveState());
 }
 

--- a/src/gui/search/pluginselectdlg.cpp
+++ b/src/gui/search/pluginselectdlg.cpp
@@ -208,9 +208,9 @@ void PluginSelectDlg::on_actionUninstall_triggered()
     }
 
     if (error)
-        QMessageBox::warning(0, tr("Uninstall warning"), tr("Some plugins could not be uninstalled because they are included in qBittorrent. Only the ones you added yourself can be uninstalled.\nThose plugins were disabled."));
+        QMessageBox::warning(this, tr("Uninstall warning"), tr("Some plugins could not be uninstalled because they are included in qBittorrent. Only the ones you added yourself can be uninstalled.\nThose plugins were disabled."));
     else
-        QMessageBox::information(0, tr("Uninstall success"), tr("All selected plugins were uninstalled successfully"));
+        QMessageBox::information(this, tr("Uninstall success"), tr("All selected plugins were uninstalled successfully"));
 }
 
 void PluginSelectDlg::enableSelection(bool enable)

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -265,7 +265,7 @@ void SearchWidget::on_searchButton_clicked()
     const QString pattern = m_ui->m_searchPattern->text().trimmed();
     // No search pattern entered
     if (pattern.isEmpty()) {
-        QMessageBox::critical(0, tr("Empty search pattern"), tr("Please type a search pattern first"));
+        QMessageBox::critical(this, tr("Empty search pattern"), tr("Please type a search pattern first"));
         return;
     }
 

--- a/src/gui/shutdownconfirmdlg.cpp
+++ b/src/gui/shutdownconfirmdlg.cpp
@@ -42,8 +42,9 @@
 #include "base/utils/misc.h"
 
 
-ShutdownConfirmDlg::ShutdownConfirmDlg(const ShutdownDialogAction &action)
-    : ui(new Ui::confirmShutdownDlg)
+ShutdownConfirmDlg::ShutdownConfirmDlg(QWidget *parent, const ShutdownDialogAction &action)
+    : QDialog(parent)
+    , ui(new Ui::confirmShutdownDlg)
     , m_timeout(15)
     , m_action(action)
 {
@@ -82,9 +83,9 @@ void ShutdownConfirmDlg::showEvent(QShowEvent *event)
     m_timer.start();
 }
 
-bool ShutdownConfirmDlg::askForConfirmation(const ShutdownDialogAction &action)
+bool ShutdownConfirmDlg::askForConfirmation(QWidget *parent, const ShutdownDialogAction &action)
 {
-    ShutdownConfirmDlg dlg(action);
+    ShutdownConfirmDlg dlg(parent, action);
     return (dlg.exec() == QDialog::Accepted);
 }
 

--- a/src/gui/shutdownconfirmdlg.h
+++ b/src/gui/shutdownconfirmdlg.h
@@ -45,10 +45,10 @@ class ShutdownConfirmDlg: public QDialog
     Q_OBJECT
 
 public:
-    ShutdownConfirmDlg(const ShutdownDialogAction &action);
+    ShutdownConfirmDlg(QWidget *parent, const ShutdownDialogAction &action);
     ~ShutdownConfirmDlg();
 
-    static bool askForConfirmation(const ShutdownDialogAction &action);
+    static bool askForConfirmation(QWidget *parent, const ShutdownDialogAction &action);
 
 protected:
     void showEvent(QShowEvent *event) override;

--- a/src/gui/speedlimitdlg.cpp
+++ b/src/gui/speedlimitdlg.cpp
@@ -39,10 +39,10 @@ SpeedLimitDialog::SpeedLimitDialog(QWidget *parent)
 {
     m_ui->setupUi(this);
     qDebug("Bandwidth allocation dialog creation");
+
     // Connect to slots
     connect(m_ui->bandwidthSlider, SIGNAL(valueChanged(int)), this, SLOT(updateSpinValue(int)));
     connect(m_ui->spinBandwidth, SIGNAL(valueChanged(int)), this, SLOT(updateSliderValue(int)));
-    move(Utils::Misc::screenCenter(this));
 }
 
 SpeedLimitDialog::~SpeedLimitDialog()
@@ -52,9 +52,9 @@ SpeedLimitDialog::~SpeedLimitDialog()
 }
 
 // -2: if cancel
-long SpeedLimitDialog::askSpeedLimit(bool *ok, QString title, long default_value, long max_value)
+long SpeedLimitDialog::askSpeedLimit(QWidget *parent, bool *ok, QString title, long default_value, long max_value)
 {
-    SpeedLimitDialog dlg;
+    SpeedLimitDialog dlg(parent);
     dlg.setWindowTitle(title);
     dlg.setupDialog(max_value / 1024., default_value / 1024.);
     if (dlg.exec() == QDialog::Accepted) {

--- a/src/gui/speedlimitdlg.h
+++ b/src/gui/speedlimitdlg.h
@@ -44,9 +44,9 @@ namespace Ui
 class SpeedLimitDialog : public QDialog {
     Q_OBJECT
 public:
-    explicit SpeedLimitDialog(QWidget *parent=0);
+    explicit SpeedLimitDialog(QWidget *parent);
     ~SpeedLimitDialog();
-    static long askSpeedLimit(bool *ok, QString title, long default_value, long max_value=10240000);
+    static long askSpeedLimit(QWidget *parent, bool *ok, QString title, long default_value, long max_value=10240000);
 
 protected slots:
     void updateSpinValue(int val) const;

--- a/src/gui/statsdialog.cpp
+++ b/src/gui/statsdialog.cpp
@@ -44,12 +44,13 @@ StatsDialog::StatsDialog(QWidget *parent)
 {
   ui->setupUi(this);
   setAttribute(Qt::WA_DeleteOnClose);
-  connect(ui->buttonOK, SIGNAL(clicked()), SLOT(close()));
+  connect(ui->buttonBox, SIGNAL(accepted()), SLOT(close()));
   updateUI();
   t = new QTimer(this);
   t->setInterval(1500);
   connect(t, SIGNAL(timeout()), SLOT(updateUI()));
   t->start();
+
   show();
 }
 

--- a/src/gui/statsdialog.h
+++ b/src/gui/statsdialog.h
@@ -42,7 +42,7 @@ class StatsDialog : public QDialog {
   Q_OBJECT
 
 public:
-  explicit StatsDialog(QWidget *parent = 0);
+  explicit StatsDialog(QWidget *parent);
   ~StatsDialog();
 
 private slots:

--- a/src/gui/statsdialog.ui
+++ b/src/gui/statsdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>273</width>
-    <height>395</height>
+    <width>286</width>
+    <height>401</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -223,28 +223,11 @@
     </spacer>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="buttonOK">
-       <property name="text">
-        <string>OK</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/gui/statusbar.cpp
+++ b/src/gui/statusbar.cpp
@@ -252,9 +252,10 @@ void StatusBar::toggleAlternativeSpeeds()
 void StatusBar::capDownloadSpeed()
 {
     BitTorrent::Session *const session = BitTorrent::Session::instance();
+
     bool ok = false;
     const long newLimit = SpeedLimitDialog::askSpeedLimit(
-                &ok, tr("Global Download Speed Limit"), session->downloadSpeedLimit());
+                m_bar->parentWidget(), &ok, tr("Global Download Speed Limit"), session->downloadSpeedLimit());
     if (ok) {
         qDebug("Setting global download rate limit to %.1fKb/s", newLimit / 1024.);
         session->setDownloadSpeedLimit(newLimit);
@@ -265,9 +266,10 @@ void StatusBar::capDownloadSpeed()
 void StatusBar::capUploadSpeed()
 {
     BitTorrent::Session *const session = BitTorrent::Session::instance();
+
     bool ok = false;
     const long newLimit = SpeedLimitDialog::askSpeedLimit(
-                &ok, tr("Global Upload Speed Limit"), session->uploadSpeedLimit());
+                m_bar->parentWidget(), &ok, tr("Global Upload Speed Limit"), session->uploadSpeedLimit());
     if (ok) {
         qDebug("Setting global upload rate limit to %.1fKb/s", newLimit / 1024.);
         session->setUploadSpeedLimit(newLimit);

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -328,7 +328,7 @@ void TransferListWidget::deleteSelectedTorrents(bool deleteLocalFiles)
     if (torrents.empty()) return;
 
     if (Preferences::instance()->confirmTorrentDeletion()
-        && !DeletionConfirmationDlg::askForDeletionConfirmation(deleteLocalFiles, torrents.size(), torrents[0]->name()))
+        && !DeletionConfirmationDlg::askForDeletionConfirmation(this, deleteLocalFiles, torrents.size(), torrents[0]->name()))
         return;
     foreach (BitTorrent::TorrentHandle *const torrent, torrents)
         BitTorrent::Session::instance()->deleteTorrent(torrent->hash(), deleteLocalFiles);
@@ -344,8 +344,9 @@ void TransferListWidget::deleteVisibleTorrents()
 
     bool deleteLocalFiles = false;
     if (Preferences::instance()->confirmTorrentDeletion()
-        && !DeletionConfirmationDlg::askForDeletionConfirmation(deleteLocalFiles, torrents.size(), torrents[0]->name()))
+        && !DeletionConfirmationDlg::askForDeletionConfirmation(this, deleteLocalFiles, torrents.size(), torrents[0]->name()))
         return;
+
     foreach (BitTorrent::TorrentHandle *const torrent, torrents)
         BitTorrent::Session::instance()->deleteTorrent(torrent->hash(), deleteLocalFiles);
 }

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -445,7 +445,7 @@ void TransferListWidget::setDlLimitSelectedTorrents()
 
     bool ok = false;
     const long newLimit = SpeedLimitDialog::askSpeedLimit(
-                &ok, tr("Torrent Download Speed Limiting"), oldLimit
+                this, &ok, tr("Torrent Download Speed Limiting"), oldLimit
                 , BitTorrent::Session::instance()->globalDownloadSpeedLimit());
     if (!ok) return;
 
@@ -470,7 +470,7 @@ void TransferListWidget::setUpLimitSelectedTorrents()
 
     bool ok = false;
     const long newLimit = SpeedLimitDialog::askSpeedLimit(
-                &ok, tr("Torrent Upload Speed Limiting"), oldLimit
+                this, &ok, tr("Torrent Upload Speed Limiting"), oldLimit
                 , BitTorrent::Session::instance()->globalUploadSpeedLimit());
     if (!ok) return;
 


### PR DESCRIPTION
See issue #3538.

This PR made child dialogs/windows pop up directly on top of it's parent.

I removed `isVirtualDesktop()` check.
It's possible to have mouse cursor & qbt main window on different screens and (while qbt window have focus) use keyboard shortcuts to open a dialog, this way, `screenNumber(QCursor::pos())` would not get the correct screen number.

---

~~# Don't merge yet.~~
It' ready now.
