### PR TITLE
Read and use KDE 4/5 colours for torrents list, torrent progress bars, and log window

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -712,6 +712,16 @@ void Preferences::useSystemIconTheme(bool enabled)
 {
     setValue("Preferences/Advanced/useSystemIconTheme", enabled);
 }
+
+bool Preferences::useSystemColorTheme() const
+{
+    return value("Preferences/Advanced/SystemColors", true).toBool();
+}
+
+void Preferences::useSystemColorTheme(bool b)
+{
+    setValue("Preferences/Advanced/SystemColors", b);
+}
 #endif
 
 bool Preferences::recursiveDownloadDisabled() const

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -229,6 +229,8 @@ public:
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
     bool useSystemIconTheme() const;
     void useSystemIconTheme(bool enabled);
+    bool useSystemColorTheme() const;
+    void useSystemColorTheme(bool b);
 #endif
     bool recursiveDownloadDisabled() const;
     void disableRecursiveDownload(bool disable = true);

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -61,6 +61,7 @@ torrentcontentmodelitem.h
 torrentcontenttreeview.h
 torrentcreatordlg.h
 torrentmodel.h
+torrentmodel_p.h
 trackerlogin.h
 transferlistdelegate.h
 transferlistfilterswidget.h
@@ -98,6 +99,7 @@ torrentcontentmodelitem.cpp
 torrentcontenttreeview.cpp
 torrentcreatordlg.cpp
 torrentmodel.cpp
+torrentmodel_p.cpp
 trackerlogin.cpp
 transferlistdelegate.cpp
 transferlistfilterswidget.cpp
@@ -110,6 +112,17 @@ if (WIN32 OR APPLE)
     list(APPEND QBT_GUI_HEADERS programupdater.h)
     list(APPEND QBT_GUI_SOURCES programupdater.cpp)
 endif (WIN32 OR APPLE)
+
+if (UNIX AND NOT APPLE)
+    list(APPEND QBT_GUI_HEADERS
+        utils/colorutils.h
+        utils/kdecolorscheme.h
+    )
+    list(APPEND QBT_GUI_SOURCES
+        utils/colorutils.cpp
+        utils/kdecolorscheme.cpp
+    )
+endif (UNIX AND NOT APPLE)
 
 set(QBT_GUI_FORMS
 mainwindow.ui

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -69,6 +69,7 @@ enum AdvSettingsRows
     DOWNLOAD_TRACKER_FAVICON,
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
     USE_ICON_THEME,
+    USE_COLOR_THEME,
 #endif
 
     // libtorrent section
@@ -183,6 +184,7 @@ void AdvancedSettings::saveAdvancedSettings()
     // Icon theme
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
     pref->useSystemIconTheme(cb_use_icon_theme.isChecked());
+    pref->useSystemColorTheme(cb_use_color_theme.isChecked());
 #endif
     pref->setConfirmTorrentRecheck(cb_confirm_torrent_recheck.isChecked());
     session->setAnnounceToAllTrackers(cb_announce_all_trackers.isChecked());
@@ -373,6 +375,8 @@ void AdvancedSettings::loadAdvancedSettings()
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
     cb_use_icon_theme.setChecked(pref->useSystemIconTheme());
     addRow(USE_ICON_THEME, tr("Use system icon theme"), &cb_use_icon_theme);
+    cb_use_color_theme.setChecked(pref->useSystemColorTheme());
+    addRow(USE_COLOR_THEME, tr("Use system color theme"), &cb_use_color_theme);
 #endif
     // Torrent recheck confirmation
     cb_confirm_torrent_recheck.setChecked(pref->confirmTorrentRecheck());

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -37,7 +37,6 @@
 #include <QComboBox>
 #include <QTableWidget>
 
-
 class WheelEventEater: public QObject
 {
     Q_OBJECT
@@ -90,6 +89,7 @@ private:
 
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
     QCheckBox cb_use_icon_theme;
+    QCheckBox cb_use_color_theme;
 #endif
 };
 

--- a/src/gui/executionlog.cpp
+++ b/src/gui/executionlog.cpp
@@ -37,6 +37,9 @@
 #include "ui_executionlog.h"
 #include "guiiconprovider.h"
 #include "loglistwidget.h"
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+#include "utils/kdecolorscheme.h"
+#endif
 
 ExecutionLog::ExecutionLog(QWidget *parent, const Log::MsgTypes &types)
     : QWidget(parent)
@@ -77,7 +80,28 @@ void ExecutionLog::addLogMessage(const Log::Msg &msg)
 {
     QString text;
     QDateTime time = QDateTime::fromMSecsSinceEpoch(msg.timestamp);
+    QColor neutralColor;
     QColor color;
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+    if (KDEColorScheme::instance()->wasLoadedSuccesfuly()) {
+        neutralColor = KDEColorScheme::instance()->color(KDEColorScheme::ForegroundNormal);
+        switch (msg.type) {
+        case Log::INFO:
+            color = KDEColorScheme::instance()->color(KDEColorScheme::ForegroundActive);
+            break;
+        case Log::WARNING:
+            color = KDEColorScheme::instance()->color(KDEColorScheme::ForegroundNeutral);
+            break;
+        case Log::CRITICAL:
+            color = KDEColorScheme::instance()->color(KDEColorScheme::ForegroundNegative);
+            break;
+        default:
+            color = QApplication::palette().color(QPalette::WindowText);
+        }
+    }
+    else {
+#endif
+    neutralColor.setNamedColor("grey");
 
     switch (msg.type) {
     case Log::INFO:
@@ -92,8 +116,12 @@ void ExecutionLog::addLogMessage(const Log::Msg &msg)
     default:
         color = QApplication::palette().color(QPalette::WindowText);
     }
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+    }
+#endif
 
-    text = "<font color='grey'>" + time.toString(Qt::SystemLocaleShortDate) + "</font> - <font color='" + color.name() + "'>" + msg.message + "</font>";
+    text = "<font color='" + neutralColor.name() + "'>" + time.toString(Qt::SystemLocaleShortDate)
+           + "</font> - <font color='" + color.name() + "'>" + msg.message + "</font>";
     m_msgList->appendLine(text, msg.type);
 }
 

--- a/src/gui/gui.pri
+++ b/src/gui/gui.pri
@@ -51,7 +51,8 @@ HEADERS += \
     $$PWD/cookiesmodel.h \
     $$PWD/cookiesdialog.h \
     $$PWD/categoryfiltermodel.h \
-    $$PWD/categoryfilterwidget.h
+    $$PWD/categoryfilterwidget.h \
+    $$PWD/torrentmodel_p.h
 
 SOURCES += \
     $$PWD/mainwindow.cpp \
@@ -93,11 +94,19 @@ SOURCES += \
     $$PWD/cookiesmodel.cpp \
     $$PWD/cookiesdialog.cpp \
     $$PWD/categoryfiltermodel.cpp \
-    $$PWD/categoryfilterwidget.cpp
+    $$PWD/categoryfilterwidget.cpp \
+    $$PWD/torrentmodel_p.cpp
 
 win32|macx {
     HEADERS += $$PWD/programupdater.h
     SOURCES += $$PWD/programupdater.cpp
+}
+
+unix:!macx {
+    HEADERS += $$PWD/utils/colorutils.h \
+               $$PWD/utils/kdecolorscheme.h
+    SOURCES += $$PWD/utils/colorutils.cpp \
+               $$PWD/utils/kdecolorscheme.cpp
 }
 
 FORMS += \

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -64,6 +64,10 @@
 #include "transferlistwidget.h"
 #include "autoexpandabledialog.h"
 
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+#include "utils/kdecolorscheme.h"
+#endif
+
 PropertiesWidget::PropertiesWidget(QWidget *parent, MainWindow *main_window, TransferListWidget *transferList)
     : QWidget(parent), transferList(transferList), main_window(main_window), m_torrent(0)
 {
@@ -125,6 +129,20 @@ PropertiesWidget::PropertiesWidget(QWidget *parent, MainWindow *main_window, Tra
     groupBarLayout->addWidget(pieces_availability, 1, 1);
     pieces_availability->setFixedHeight(barHeight);
     pieces_availability->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+    if (KDEColorScheme::instance()->wasLoadedSuccesfuly()) {
+        downloaded_pieces->setColors(
+            KDEColorScheme::instance()->color(KDEColorScheme::BackgroundNormal).rgb(),
+            KDEColorScheme::instance()->color(KDEColorScheme::DecorationFocus).rgb(),
+            KDEColorScheme::instance()->color(KDEColorScheme::ForegroundActive).rgb(),
+            KDEColorScheme::instance()->color(KDEColorScheme::ForegroundPositive).rgb());
+        pieces_availability->setColors(
+            KDEColorScheme::instance()->color(KDEColorScheme::BackgroundNormal).rgb(),
+            KDEColorScheme::instance()->color(KDEColorScheme::DecorationFocus).rgb(),
+            KDEColorScheme::instance()->color(KDEColorScheme::ForegroundActive).rgb());
+    }
+#endif
 
     // Tracker list
     trackerList = new TrackerList(this);

--- a/src/gui/torrentmodel.cpp
+++ b/src/gui/torrentmodel.cpp
@@ -29,16 +29,17 @@
  * Contact : chris@qbittorrent.org
  */
 
-#include <QDebug>
 #include <QApplication>
-#include <QPalette>
+#include <QDebug>
 #include <QIcon>
+#include <QProcessEnvironment>
 
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/torrenthandle.h"
 #include "base/torrentfilter.h"
 #include "base/utils/fs.h"
 #include "torrentmodel.h"
+#include "torrentmodel_p.h"
 
 static QIcon getIconByState(BitTorrent::TorrentState state);
 static QColor getColorByState(BitTorrent::TorrentState state);
@@ -52,8 +53,6 @@ static QIcon getStalledUploadingIcon();
 static QIcon getCompletedIcon();
 static QIcon getCheckingIcon();
 static QIcon getErrorIcon();
-
-static bool isDarkTheme();
 
 // TorrentModel
 
@@ -353,56 +352,7 @@ QIcon getIconByState(BitTorrent::TorrentState state)
 
 QColor getColorByState(BitTorrent::TorrentState state)
 {
-    // Color names taken from http://cloford.com/resources/colours/500col.htm
-    bool dark = isDarkTheme();
-
-    switch (state) {
-    case BitTorrent::TorrentState::Downloading:
-    case BitTorrent::TorrentState::ForcedDownloading:
-    case BitTorrent::TorrentState::DownloadingMetadata:
-        if (!dark)
-            return QColor(34, 139, 34); // Forest Green
-        else
-            return QColor(50, 205, 50); // Lime Green
-    case BitTorrent::TorrentState::Allocating:
-    case BitTorrent::TorrentState::StalledDownloading:
-    case BitTorrent::TorrentState::StalledUploading:
-        if (!dark)
-            return QColor(0, 0, 0); // Black
-        else
-            return QColor(204, 204, 204); // Gray 80
-    case BitTorrent::TorrentState::Uploading:
-    case BitTorrent::TorrentState::ForcedUploading:
-        if (!dark)
-            return QColor(65, 105, 225); // Royal Blue
-        else
-            return QColor(99, 184, 255); // Steel Blue 1
-    case BitTorrent::TorrentState::PausedDownloading:
-        return QColor(250, 128, 114); // Salmon
-    case BitTorrent::TorrentState::PausedUploading:
-        if (!dark)
-            return QColor(0, 0, 139); // Dark Blue
-        else
-            return QColor(79, 148, 205); // Steel Blue 3
-    case BitTorrent::TorrentState::Error:
-    case BitTorrent::TorrentState::MissingFiles:
-        return QColor(255, 0, 0); // red
-    case BitTorrent::TorrentState::QueuedDownloading:
-    case BitTorrent::TorrentState::QueuedUploading:
-    case BitTorrent::TorrentState::CheckingDownloading:
-    case BitTorrent::TorrentState::CheckingUploading:
-    case BitTorrent::TorrentState::QueuedForChecking:
-    case BitTorrent::TorrentState::CheckingResumeData:
-        if (!dark)
-            return QColor(0, 128, 128); // Teal
-        else
-            return QColor(0, 205, 205); // Cyan 3
-    case BitTorrent::TorrentState::Unknown:
-        return QColor(255, 0, 0); // red
-    default:
-        Q_ASSERT(false);
-        return QColor(255, 0, 0); // red
-    }
+   return TorrentStateColors::instance()->color(state);
 }
 
 QIcon getPausedIcon()
@@ -457,12 +407,4 @@ QIcon getErrorIcon()
 {
     static QIcon cached = QIcon(":/icons/skin/error.png");
     return cached;
-}
-
-bool isDarkTheme()
-{
-    QPalette pal = QApplication::palette();
-    // QPalette::Base is used for the background of the Treeview
-    QColor color = pal.color(QPalette::Active, QPalette::Base);
-    return (color.lightness() < 127);
 }

--- a/src/gui/torrentmodel_p.cpp
+++ b/src/gui/torrentmodel_p.cpp
@@ -1,0 +1,204 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2015 Eugene Shalygin
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "torrentmodel_p.h"
+
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+#include "base/preferences.h"
+#include "utils/kdecolorscheme.h"
+#include "utils/colorutils.h"
+#endif
+
+#include <QApplication>
+#include <QPalette>
+#include <QProcessEnvironment>
+
+Q_GLOBAL_STATIC(TorrentStateColors, torrentStateColors)
+
+TorrentStateColors * TorrentStateColors::instance(){
+#if QT_VERSION >= 0x050000
+    return torrentStateColors;
+#else
+    return torrentStateColors();
+#endif
+}
+
+TorrentStateColors::TorrentStateColors()
+{
+    setupColors();
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC)) // there is no need to reload colors if we do not support it
+    connect(Preferences::instance(), SIGNAL(changed()), this, SLOT(setupColors()));
+#endif
+}
+
+void TorrentStateColors::setupColors()
+{
+    QScopedPointer<StateColorsProvider> provider;
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+    if (Preferences::instance()->useSystemColorTheme()) {
+        QProcessEnvironment env(QProcessEnvironment::systemEnvironment());
+        if (env.contains(QLatin1String("XDG_CURRENT_DESKTOP"))) {
+            QString desktop = env.value(QLatin1String("XDG_CURRENT_DESKTOP"));
+            if (desktop == QLatin1String("KDE"))
+                provider.reset(new KDEColorsProvider());
+        }
+    }
+#endif
+    if (!provider)
+        provider.reset(new DefaultColorsProvider());
+    provider->setColors(stateColors);
+}
+
+bool StateColorsProvider::isDarkTheme()
+{
+    QPalette pal = QApplication::palette();
+    // QPalette::Base is used for the background of the Treeview
+    QColor color = pal.color(QPalette::Active, QPalette::Base);
+    return (color.lightnessF() < 0.5);
+}
+
+void DefaultColorsProvider::setColors(TorrentStateColorsMap &m)
+{
+    using BitTorrent::TorrentState;
+    // Color names taken from http://cloford.com/resources/colours/500col.htm
+    bool dark = isDarkTheme();
+
+    m[TorrentState::Downloading] =
+    m[TorrentState::ForcedDownloading] =
+    m[TorrentState::DownloadingMetadata] =
+        !dark ? QColor(34, 139, 34) : // Forest Green
+                QColor(50, 205, 50);  // Lime Green
+
+    m[TorrentState::Allocating] =
+    m[TorrentState::StalledDownloading] =
+    m[TorrentState::StalledUploading] =
+        !dark ? QColor(0, 0, 0) :      // Black
+                QColor(204, 204, 204); // Gray 80
+
+    m[TorrentState::Uploading] =
+    m[TorrentState::ForcedUploading] =
+        !dark ? QColor(65, 105, 225) : // Royal Blue
+                QColor(99, 184, 255);  // Steel Blue 1
+
+    m[TorrentState::PausedDownloading] =
+        QColor(250, 128, 114); // Salmon
+
+    m[TorrentState::PausedUploading] =
+        !dark ? QColor(0, 0, 139) :   // Dark Blue
+                QColor(79, 148, 205); // Steel Blue 3
+
+    m[TorrentState::Error] =
+    m[TorrentState::MissingFiles] =
+        QColor(255, 0, 0); // red
+
+    m[TorrentState::QueuedDownloading] =
+    m[TorrentState::QueuedUploading] =
+    m[TorrentState::CheckingDownloading] =
+    m[TorrentState::CheckingUploading] =
+    m[TorrentState::QueuedForChecking] =
+    m[TorrentState::CheckingResumeData] =
+        !dark ? QColor(0, 128, 128) : // Teal
+                QColor(0, 205, 205);  // Cyan 3
+
+    m[TorrentState::Unknown] =
+        QColor(255, 0, 0); // red
+}
+
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+namespace
+{
+    QColor lighten(const QColor &c)
+    {
+        return Utils::Color::lighten(c, 0.25);
+    }
+
+    QColor darken(const QColor &c)
+    {
+        return Utils::Color::darken(c, 0.25);
+    }
+
+    typedef QColor (*ColorCorrectionFunc)(const QColor&);
+}
+
+void KDEColorsProvider::setColors(TorrentStateColorsMap &m)
+{
+    using BitTorrent::TorrentState;
+
+    const KDEColorScheme* const scheme = KDEColorScheme::instance();
+    bool dark = isDarkTheme();
+
+    ColorCorrectionFunc towardsBackground  = dark ? &darken  : &lighten;
+    ColorCorrectionFunc awayFromBackground = dark ? &lighten : &darken;
+
+    m[TorrentState::Downloading] =
+        scheme->color(KDEColorScheme::ForegroundPositive);
+    m[TorrentState::ForcedDownloading] =
+        awayFromBackground(scheme->color(KDEColorScheme::ForegroundPositive));
+
+    m[TorrentState::DownloadingMetadata] =
+         towardsBackground(scheme->color(KDEColorScheme::ForegroundActive));
+
+    m[TorrentState::Allocating] =
+         scheme->color(KDEColorScheme::ForegroundInactive);
+
+    m[TorrentState::StalledDownloading] =
+    m[TorrentState::StalledUploading] =
+        scheme->color(KDEColorScheme::ForegroundInactive);
+
+    m[TorrentState::Uploading] =
+        scheme->color(KDEColorScheme::ForegroundNeutral);
+    m[TorrentState::ForcedUploading] =
+        awayFromBackground(scheme->color(KDEColorScheme::ForegroundNeutral));
+
+    m[TorrentState::PausedDownloading] =
+        scheme->color(KDEColorScheme::ForegroundPositive, QPalette::Disabled);
+
+    m[TorrentState::PausedUploading] =
+        scheme->color(KDEColorScheme::ForegroundNeutral, QPalette::Disabled);
+
+    m[TorrentState::Error] =
+    m[TorrentState::MissingFiles] =
+        scheme->color(KDEColorScheme::ForegroundNegative);
+
+    m[TorrentState::QueuedDownloading] =
+        scheme->color(KDEColorScheme::ForegroundPositive, QPalette::Inactive);
+
+    m[TorrentState::QueuedUploading] =
+        scheme->color(KDEColorScheme::ForegroundNeutral, QPalette::Inactive);
+
+    m[TorrentState::CheckingDownloading] =
+    m[TorrentState::CheckingUploading] =
+    m[TorrentState::QueuedForChecking] =
+    m[TorrentState::CheckingResumeData] =
+        scheme->color(KDEColorScheme::ForegroundActive, QPalette::Inactive);
+
+    m[TorrentState::Unknown] =
+        scheme->color(KDEColorScheme::ForegroundNegative, QPalette::Disabled);
+}
+
+#endif

--- a/src/gui/torrentmodel_p.h
+++ b/src/gui/torrentmodel_p.h
@@ -1,0 +1,124 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2015 Eugene Shalygin
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#ifndef TORRENTMODEL_P_H
+#define TORRENTMODEL_P_H
+
+#include <QObject>
+#include <QColor>
+#include <QMap>
+
+#include "base/bittorrent/torrenthandle.h"
+
+class QProcessEnvironment;
+class QSettings;
+
+typedef QMap<BitTorrent::TorrentState, QColor> TorrentStateColorsMap;
+
+class StateColorsProvider
+{
+public:
+    virtual ~StateColorsProvider(){}
+    virtual void setColors(TorrentStateColorsMap& m) = 0;
+protected:
+    static bool isDarkTheme();
+};
+
+class DefaultColorsProvider: public StateColorsProvider
+{
+    // StateColorsProvider interface
+
+public:
+    virtual void setColors(TorrentStateColorsMap &m);
+};
+
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+struct KDEColorEffect
+{
+    enum ColorEfffect
+    {
+        ColorEfffectNone = 0,
+        ColorEfffectDesaturate,
+        ColorEfffectFade,
+        ColorEfffectTint
+    };
+    enum IntensityEffect
+    {
+        IntensityEffectNone = 0,
+        IntensityEffectShade,
+        IntensityEffectDarken,
+        IntensityEffectLighten
+    };
+    enum ContrastEffect
+    {
+        ContrastEffectNone = 0,
+        ContrastEffectFade,
+        ContrastEffectTint
+    };
+    bool changeSelectionColor;
+    QColor color;
+    qreal colorAmount; // [-1:1]
+    ColorEfffect colorEffect;
+    qreal contrastAmount; // [-1:1]
+    ContrastEffect contrastEffect;
+    bool enable;
+    qreal intensityAmount; // [-1:1]
+    IntensityEffect intensityEffect;
+};
+
+
+class KDEColorsProvider: public StateColorsProvider
+{
+public:
+    // StateColorsProvider interface
+    virtual void setColors(TorrentStateColorsMap &m);
+};
+
+#endif
+
+class TorrentStateColors: public QObject
+{
+    Q_OBJECT
+
+public:
+    static TorrentStateColors* instance();
+    TorrentStateColors();
+    QColor color(BitTorrent::TorrentState state) const
+    {
+        return stateColors.value(state, Qt::red);
+    }
+
+private slots:
+    void setupColors();
+
+private:
+    QMap<BitTorrent::TorrentState, QColor> stateColors;
+};
+
+#endif // TORRENTMODEL_P_H
+

--- a/src/gui/utils/colorutils.cpp
+++ b/src/gui/utils/colorutils.cpp
@@ -1,0 +1,329 @@
+/* This file is composed from stripped versions of
+ * kcolorutils.cpp, kguiaddons_colorhelpers_p.h,
+ * kcolorspaces_p.h, and kcolorspaces.cpp
+ *
+ * This file is part of the KDE project
+ * Copyright (C) 2007 Matthew Woehlke <mw_triad@users.sourceforge.net>
+ * Copyright (C) 2007 Thomas Zander <zander@kde.org>
+ * Copyright (C) 2007 Zack Rusin <zack@kde.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+#include "colorutils.h"
+
+#include <QColor>
+#include <QImage>
+
+#if QT_VERSION >= 0x050000
+    #include <QtNumeric> // qIsNaN
+#else
+    #include <Qt/qnumeric.h> // qIsNaN
+#endif
+
+#include <math.h>
+
+// BEGIN internal helper functions
+namespace {
+    // normalize: like qBound(a, 0.0, 1.0) but without needing the args and with
+    // "safer" behavior on NaN (isnan(a) -> return 0.0)
+    inline qreal normalize(qreal a)
+    {
+        return (a < 1.0 ? (a > 0.0 ? a : 0.0) : 1.0);
+    }
+
+    inline qreal mixQreal(qreal a, qreal b, qreal bias)
+    {
+        return a + (b - a) * bias;
+    }
+
+    inline qreal wrap(qreal a, qreal d = 1.0)
+    {
+        qreal r = fmod(a, d);
+        return (r < 0.0 ? d + r : (r > 0.0 ? r : 0.0));
+    }
+
+    // END internal helper functions
+
+    class HCY
+    {
+    public:
+        explicit HCY(const QColor &);
+        explicit HCY(qreal h_, qreal c_, qreal y_, qreal a_ = 1.0);
+        QColor qColor() const;
+        qreal h, c, y, a;
+        static qreal luma(const QColor &);
+    private:
+        static qreal gamma(qreal);
+        static qreal igamma(qreal);
+        static qreal lumag(qreal, qreal, qreal);
+    };
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // HCY color space
+
+#define HCY_REC 709 // use 709 for now
+#if   HCY_REC == 601
+    static const qreal yc[3] = { 0.299, 0.587, 0.114 };
+#elif HCY_REC == 709
+    static const qreal yc[3] = {0.2126, 0.7152, 0.0722};
+#else // use Qt values
+    static const qreal yc[3] = { 0.34375, 0.5, 0.15625 };
+#endif
+
+    qreal HCY::gamma(qreal n)
+    {
+        return pow(normalize(n), 2.2);
+    }
+
+    qreal HCY::igamma(qreal n)
+    {
+        return pow(normalize(n), 1.0 / 2.2);
+    }
+
+    qreal HCY::lumag(qreal r, qreal g, qreal b)
+    {
+        return r * yc[0] + g * yc[1] + b * yc[2];
+    }
+
+    HCY::HCY(qreal h_, qreal c_, qreal y_, qreal a_)
+    {
+        h = h_;
+        c = c_;
+        y = y_;
+        a = a_;
+    }
+
+    HCY::HCY(const QColor &color)
+    {
+        qreal r = gamma(color.redF());
+        qreal g = gamma(color.greenF());
+        qreal b = gamma(color.blueF());
+        a = color.alphaF();
+
+        // luma component
+        y = lumag(r, g, b);
+
+        // hue component
+        qreal p = qMax(qMax(r, g), b);
+        qreal n = qMin(qMin(r, g), b);
+        qreal d = 6.0 * (p - n);
+        if (n == p)
+            h = 0.0;
+        else if (r == p)
+            h = ((g - b) / d);
+        else if (g == p)
+            h = ((b - r) / d) + (1.0 / 3.0);
+        else
+            h = ((r - g) / d) + (2.0 / 3.0);
+
+        // chroma component
+        if (( r == g) && ( g == b) )
+            c = 0.0;
+        else
+            c = qMax((y - n) / y, (p - y) / (1 - y));
+    }
+
+    QColor HCY::qColor() const
+    {
+        // start with sane component values
+        qreal _h = wrap(h);
+        qreal _c = normalize(c);
+        qreal _y = normalize(y);
+
+        // calculate some needed variables
+        qreal _hs = _h * 6.0, th, tm;
+        if (_hs < 1.0) {
+            th = _hs;
+            tm = yc[0] + yc[1] * th;
+        }
+        else if (_hs < 2.0) {
+            th = 2.0 - _hs;
+            tm = yc[1] + yc[0] * th;
+        }
+        else if (_hs < 3.0) {
+            th = _hs - 2.0;
+            tm = yc[1] + yc[2] * th;
+        }
+        else if (_hs < 4.0) {
+            th = 4.0 - _hs;
+            tm = yc[2] + yc[1] * th;
+        }
+        else if (_hs < 5.0) {
+            th = _hs - 4.0;
+            tm = yc[2] + yc[0] * th;
+        }
+        else {
+            th = 6.0 - _hs;
+            tm = yc[0] + yc[2] * th;
+        }
+
+        // calculate RGB channels in sorted order
+        qreal tn, to, tp;
+        if (tm >= _y) {
+            tp = _y + _y * _c * (1.0 - tm) / tm;
+            to = _y + _y * _c * (th - tm) / tm;
+            tn = _y - (_y * _c);
+        }
+        else {
+            tp = _y + (1.0 - _y) * _c;
+            to = _y + (1.0 - _y) * _c * (th - tm) / (1.0 - tm);
+            tn = _y - (1.0 - _y) * _c * tm / (1.0 - tm);
+        }
+
+        // return RGB channels in appropriate order
+        if (_hs < 1.0)
+            return QColor::fromRgbF(igamma(tp), igamma(to), igamma(tn), a);
+        else if (_hs < 2.0)
+            return QColor::fromRgbF(igamma(to), igamma(tp), igamma(tn), a);
+        else if (_hs < 3.0)
+            return QColor::fromRgbF(igamma(tn), igamma(tp), igamma(to), a);
+        else if (_hs < 4.0)
+            return QColor::fromRgbF(igamma(tn), igamma(to), igamma(tp), a);
+        else if (_hs < 5.0)
+            return QColor::fromRgbF(igamma(to), igamma(tn), igamma(tp), a);
+        else
+            return QColor::fromRgbF(igamma(tp), igamma(tn), igamma(to), a);
+    }
+
+    qreal HCY::luma(const QColor &color)
+    {
+        return lumag(gamma(color.redF()),
+                     gamma(color.greenF()),
+                     gamma(color.blueF()));
+    }
+
+}
+
+qreal Utils::Color::luma(const QColor &color)
+{
+    return HCY::luma(color);
+}
+
+void Utils::Color::getHcy(const QColor &color, qreal *h, qreal *c, qreal *y, qreal *a)
+{
+    if (!c || !h || !y)
+        return;
+    HCY khcy(color);
+    *c = khcy.c;
+    *h = khcy.h;
+    *y = khcy.y;
+    if (a)
+        *a = khcy.a;
+}
+
+static qreal contrastRatioForLuma(qreal y1, qreal y2)
+{
+    if (y1 > y2)
+        return (y1 + 0.05) / (y2 + 0.05);
+    else
+        return (y2 + 0.05) / (y1 + 0.05);
+}
+
+qreal Utils::Color::contrastRatio(const QColor &c1, const QColor &c2)
+{
+    return contrastRatioForLuma(luma(c1), luma(c2));
+}
+
+QColor Utils::Color::lighten(const QColor &color, qreal ky, qreal kc)
+{
+    HCY c(color);
+    c.y = 1.0 - normalize((1.0 - c.y) * (1.0 - ky));
+    c.c = 1.0 - normalize((1.0 - c.c) * kc);
+    return c.qColor();
+}
+
+QColor Utils::Color::darken(const QColor &color, qreal ky, qreal kc)
+{
+    HCY c(color);
+    c.y = normalize(c.y * (1.0 - ky));
+    c.c = normalize(c.c * kc);
+    return c.qColor();
+}
+
+QColor Utils::Color::shade(const QColor &color, qreal ky, qreal kc)
+{
+    HCY c(color);
+    c.y = normalize(c.y + ky);
+    c.c = normalize(c.c + kc);
+    return c.qColor();
+}
+
+static QColor tintHelper(const QColor &base, qreal baseLuma, const QColor &color, qreal amount)
+{
+    HCY result(Utils::Color::mix(base, color, pow(amount, 0.3)));
+    result.y = mixQreal(baseLuma, result.y, amount);
+
+    return result.qColor();
+}
+
+QColor Utils::Color::tint(const QColor &base, const QColor &color, qreal amount)
+{
+    if (amount <= 0.0)
+        return base;
+    if (amount >= 1.0)
+        return color;
+    if (qIsNaN(amount))
+        return base;
+
+    qreal baseLuma = luma(base); //cache value because luma call is expensive
+    double ri = contrastRatioForLuma(baseLuma, luma(color));
+    double rg = 1.0 + ((ri + 1.0) * amount * amount * amount);
+    double u = 1.0, l = 0.0;
+    QColor result;
+    for (int i = 12; i; --i) {
+        double a = 0.5 * (l + u);
+        result = tintHelper(base, baseLuma, color, a);
+        double ra = contrastRatioForLuma(baseLuma, luma(result));
+        if (ra > rg)
+            u = a;
+        else
+            l = a;
+    }
+    return result;
+}
+
+QColor Utils::Color::mix(const QColor &c1, const QColor &c2, qreal bias)
+{
+    if (bias <= 0.0)
+        return c1;
+    if (bias >= 1.0)
+        return c2;
+    if (qIsNaN(bias))
+        return c1;
+
+    qreal r = mixQreal(c1.redF(),   c2.redF(),   bias);
+    qreal g = mixQreal(c1.greenF(), c2.greenF(), bias);
+    qreal b = mixQreal(c1.blueF(),  c2.blueF(),  bias);
+    qreal a = mixQreal(c1.alphaF(), c2.alphaF(), bias);
+
+    return QColor::fromRgbF(r, g, b, a);
+}
+
+QColor Utils::Color::overlayColors(const QColor &base, const QColor &paint,
+                                   QPainter::CompositionMode comp)
+{
+    // This isn't the fastest way, but should be "fast enough".
+    // It's also the only safe way to use QPainter::CompositionMode
+    QImage img(1, 1, QImage::Format_ARGB32_Premultiplied);
+    QPainter p(&img);
+    QColor start = base;
+    start.setAlpha(255); // opaque
+    p.fillRect(0, 0, 1, 1, start);
+    p.setCompositionMode(comp);
+    p.fillRect(0, 0, 1, 1, paint);
+    p.end();
+    return img.pixel(0, 0);
+}

--- a/src/gui/utils/colorutils.h
+++ b/src/gui/utils/colorutils.h
@@ -1,0 +1,164 @@
+/* This is the stripped version of the file kcolorutils.h
+ * from KDE framework KGuiAddons.
+ *
+ * This file is part of the KDE project
+ * Copyright (C) 2007 Matthew Woehlke <mw_triad@users.sourceforge.net>
+ * Copyright (C) 2007 Thomas Zander <zander@kde.org>
+ * Copyright (C) 2007 Zack Rusin <zack@kde.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef COLORUTILS_H
+#define COLORUTILS_H
+
+#include <QPainter>
+
+class QColor;
+
+/**
+ * A set of methods used to work with colors.
+ */
+namespace Utils
+{
+    namespace Color
+    {
+        /**
+         * Calculate the luma of a color. Luma is weighted sum of gamma-adjusted
+         * R'G'B' components of a color. The result is similar to qGray. The range
+         * is from 0.0 (black) to 1.0 (white).
+         *
+         * Utils::Color::darken(), Utils::Color::lighten() and Utils::Color::shade()
+         * operate on the luma of a color.
+         *
+         * @see http://en.wikipedia.org/wiki/Luma_(video)
+         */
+        qreal luma(const QColor &);
+
+        /**
+         * Calculate hue, chroma and luma of a color in one call.
+         */
+        void getHcy(const QColor &, qreal *hue, qreal *chroma, qreal *luma, qreal *alpha = 0);
+
+        /**
+         * Calculate the contrast ratio between two colors, according to the
+         * W3C/WCAG2.0 algorithm, (Lmax + 0.05)/(Lmin + 0.05), where Lmax and Lmin
+         * are the luma values of the lighter color and the darker color,
+         * respectively.
+         *
+         * A contrast ration of 5:1 (result == 5.0) is the minimum for "normal"
+         * text to be considered readable (large text can go as low as 3:1). The
+         * ratio ranges from 1:1 (result == 1.0) to 21:1 (result == 21.0).
+         *
+         * @see Utils::Color::luma
+         */
+        qreal contrastRatio(const QColor &, const QColor &);
+
+        /**
+         * Adjust the luma of a color by changing its distance from white.
+         *
+         * @li amount == 1.0 gives white
+         * @li amount == 0.5 results in a color whose luma is halfway between 1.0
+         * and that of the original color
+         * @li amount == 0.0 gives the original color
+         * @li amount == -1.0 gives a color that is 'twice as far from white' as
+         * the original color, that is luma(result) == 1.0 - 2*(1.0 - luma(color))
+         *
+         * @param amount factor by which to adjust the luma component of the color
+         * @param chromaInverseGain (optional) factor by which to adjust the chroma
+         * component of the color; 1.0 means no change, 0.0 maximizes chroma
+         * @see Utils::Color::shade
+         */
+        QColor lighten(const QColor &, qreal amount = 0.5, qreal chromaInverseGain = 1.0);
+
+        /**
+         * Adjust the luma of a color by changing its distance from black.
+         *
+         * @li amount == 1.0 gives black
+         * @li amount == 0.5 results in a color whose luma is halfway between 0.0
+         * and that of the original color
+         * @li amount == 0.0 gives the original color
+         * @li amount == -1.0 gives a color that is 'twice as far from black' as
+         * the original color, that is luma(result) == 2*luma(color)
+         *
+         * @param amount factor by which to adjust the luma component of the color
+         * @param chromaGain (optional) factor by which to adjust the chroma
+         * component of the color; 1.0 means no change, 0.0 minimizes chroma
+         * @see Utils::Color::shade
+         */
+        QColor darken(const QColor &, qreal amount = 0.5, qreal chromaGain = 1.0);
+
+        /**
+         * Adjust the luma and chroma components of a color. The amount is added
+         * to the corresponding component.
+         *
+         * @param lumaAmount amount by which to adjust the luma component of the
+         * color; 0.0 results in no change, -1.0 turns anything black, 1.0 turns
+         * anything white
+         * @param chromaAmount (optional) amount by which to adjust the chroma
+         * component of the color; 0.0 results in no change, -1.0 minimizes chroma,
+         * 1.0 maximizes chroma
+         * @see Utils::Color::luma
+         */
+        QColor shade(const QColor &, qreal lumaAmount, qreal chromaAmount = 0.0);
+
+        /**
+         * Create a new color by tinting one color with another. This function is
+         * meant for creating additional colors withings the same class (background,
+         * foreground) from colors in a different class. Therefore when @p amount
+         * is low, the luma of @p base is mostly preserved, while the hue and
+         * chroma of @p color is mostly inherited.
+         *
+         * @param base color to be tinted
+         * @param color color with which to tint
+         * @param amount how strongly to tint the base; 0.0 gives @p base,
+         * 1.0 gives @p color
+         */
+        QColor tint(const QColor &base, const QColor &color, qreal amount = 0.3);
+
+        /**
+         * Blend two colors into a new color by linear combination.
+         * @code
+            QColor lighter = Utils::Color::mix(myColor, Qt::white)
+         * @endcode
+         * @param c1 first color.
+         * @param c2 second color.
+         * @param bias weight to be used for the mix. @p bias <= 0 gives @p c1,
+         * @p bias >= 1 gives @p c2. @p bias == 0.5 gives a 50% blend of @p c1
+         * and @p c2.
+         */
+        QColor mix(const QColor &c1, const QColor &c2,
+                   qreal bias = 0.5);
+
+        /**
+         * Blend two colors into a new color by painting the second color over the
+         * first using the specified composition mode.
+         * @code
+            QColor white(Qt::white);
+            white.setAlphaF(0.5);
+            QColor lighter = Utils::Color::overlayColors(myColor, white);
+           @endcode
+         * @param base the base color (alpha channel is ignored).
+         * @param paint the color to be overlayed onto the base color.
+         * @param comp the CompositionMode used to do the blending.
+         */
+        QColor overlayColors(const QColor &base, const QColor &paint,
+                             QPainter::CompositionMode comp = QPainter::CompositionMode_SourceOver);
+
+    }
+}
+
+#endif // COLORUTILS_H

--- a/src/gui/utils/kdecolorscheme.cpp
+++ b/src/gui/utils/kdecolorscheme.cpp
@@ -1,0 +1,355 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2016 Eugene Shalygin
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "kdecolorscheme.h"
+#include "colorutils.h"
+#include <QDir>
+#include <QApplication>
+#include <QSettings>
+
+namespace {
+    static QString settingsGroupName(KDEColorScheme::ColorSet set)
+    {
+        switch(set) {
+        case KDEColorScheme::View:
+            return QLatin1String("Colors:View");
+        case KDEColorScheme::Window:
+            return QLatin1String("Colors:Window");
+        case KDEColorScheme::Button:
+            return QLatin1String("Colors:Button");
+        case KDEColorScheme::Selection:
+            return QLatin1String("Colors:Selection");
+        case KDEColorScheme::Tooltip:
+            return QLatin1String("Colors:Tooltip");
+        }
+    }
+
+    QRgb decodeKDEColor(const QVariant &v, bool &ok)
+    {
+        QVariantList components(v.toList());
+        if (components.size() == 3) {
+            bool rOk, gOk, bOk;
+            const int r = components[0].toString().toInt(&rOk);
+            const int g = components[1].toString().toInt(&gOk);
+            const int b = components[2].toString().toInt(&bOk);
+            if (rOk && gOk && bOk) {
+                ok = true;
+                return qRgb(r, g, b);
+            }
+        }
+        ok = false;
+        return qRgb(0, 0, 0);
+    }
+
+    KDEColorScheme::Effect readColorEffect(QSettings &settings, const QString &name, bool &ok)
+    {
+        using Effect = KDEColorScheme::Effect;
+        Effect res;
+        bool allReadsOK = true;
+        bool singleReadOK = false;
+        settings.beginGroup(QLatin1String("ColorEffects:") + name);
+
+        res.changeSelectionColor = settings.value(QLatin1String("ChangeSelectionColor"), false).toBool();
+
+        res.color = decodeKDEColor(settings.value(QLatin1String("Color")), singleReadOK);
+        allReadsOK &= singleReadOK;
+
+        res.colorAmount = settings.value(QLatin1String("ColorAmount"), 0.).toDouble(&ok);
+        allReadsOK &= singleReadOK;
+
+        res.colorEffect = static_cast<Effect::ColorEfffect>(
+            settings.value(QLatin1String("ColorEffect"), 0).toInt(&singleReadOK));
+        allReadsOK &= singleReadOK;
+
+        res.contrastAmount = settings.value(QLatin1String("ContrastAmount"), 0.).toDouble(&singleReadOK);
+        allReadsOK &= singleReadOK;
+
+        res.contrastEffect = static_cast<Effect::ContrastEffect>(
+            settings.value(QLatin1String("ContrastEffect"), 0).toInt(&singleReadOK));
+        allReadsOK &= singleReadOK;
+
+        res.enable = settings.value(QLatin1String("Enable"), false).toBool();
+
+        res.intensityAmount = settings.value(QLatin1String("IntensityAmount"), 0.).toDouble(&singleReadOK);
+        allReadsOK &= singleReadOK;
+
+        res.intensityEffect = static_cast<Effect::IntensityEffect>(
+            settings.value(QLatin1String("IntensityEffect"), 0).toInt(&singleReadOK));
+        allReadsOK &= singleReadOK;
+
+        settings.endGroup();
+        ok = allReadsOK;
+        return res;
+    }
+
+    QColor applyColorEffect(const QColor &color, const KDEColorScheme::Effect &effect)
+    {
+        using Effect = KDEColorScheme::Effect;
+        QColor res(color);
+
+        switch (effect.intensityEffect) {
+        case Effect::IntensityEffectNone:
+            break;
+        case Effect::IntensityEffectShade:
+            res = Utils::Color::shade(res, effect.intensityAmount);
+            break;
+        case Effect::IntensityEffectDarken:
+            res = Utils::Color::darken(res, effect.intensityAmount);
+            break;
+        case Effect::IntensityEffectLighten:
+            res = Utils::Color::lighten(res, effect.intensityAmount);
+            break;
+        }
+
+        switch (effect.colorEffect) {
+        case Effect::ColorEfffectNone:
+            break;
+        case Effect::ColorEfffectDesaturate:
+            res = Utils::Color::darken(res, 0., 1.0 - effect.colorAmount);
+            break;
+        case Effect::ColorEfffectFade:
+            res = Utils::Color::mix(res, effect.color, effect.colorAmount);
+            break;
+        case Effect::ColorEfffectTint:
+            res = Utils::Color::tint(res, effect.color, effect.colorAmount);
+            break;
+        }
+
+#if 0
+        // shall we worry about contrast with background at all?
+        switch (effect.contrastEffect) {
+        case KDEColorEffect::ContrastEffectNone:
+            break;
+        case KDEColorEffect::ContrastEffectFade:
+            res = Utils::Color::mix(res, bgColor, effect.contrastAmount);
+            break;
+        case KDEColorEffect::ContrastEffectTint:
+            res = Utils::Color::tint(res, bgColor, effect.contrastAmount);
+            break;
+        }
+#endif
+        return res;
+    }
+
+    class ColorLoadingError: public std::runtime_error
+    {
+    public:
+        ColorLoadingError() : std::runtime_error(""){}
+    };
+}
+
+Q_GLOBAL_STATIC(KDEColorScheme, kdeColorScheme)
+
+const KDEColorScheme * KDEColorScheme::instance(){
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    return kdeColorScheme;
+#else
+    return kdeColorScheme();
+#endif
+}
+
+KDEColorScheme::KDEColorScheme(const QProcessEnvironment& env)
+{
+    reload(env);
+}
+
+void KDEColorScheme::reload(const QProcessEnvironment& env)
+{
+    try {
+        load(env);
+        m_loadedSuccesfully = true;
+    }
+    catch (ColorLoadingError&) {
+        m_loadedSuccesfully = false;
+        setFallbackColors();
+    }
+}
+
+QColor KDEColorScheme::color(KDEColorScheme::ColorRole role, QPalette::ColorGroup group, KDEColorScheme::ColorSet set) const
+{
+    if (group > QPalette::Inactive)
+        return Qt::black;
+
+    return m_colors[group][set][role];
+}
+
+QColor KDEColorScheme::inactiveColor(const QColor& color) const
+{
+    return applyColorEffect(color, m_inactiveEffect);
+}
+
+QColor KDEColorScheme::disabledColor(const QColor& color) const
+{
+    return applyColorEffect(color, m_disabledEffect);
+}
+
+bool KDEColorScheme::wasLoadedSuccesfuly() const
+{
+    return m_loadedSuccesfully;
+}
+
+void KDEColorScheme::load(const QProcessEnvironment& env)
+{
+    bool versionDecodedOk = false;
+    int kdeVersion = env.value(QLatin1String("KDE_SESSION_VERSION"), QLatin1String("4"))
+                     .toInt(&versionDecodedOk);
+    if (!versionDecodedOk)
+        throw ColorLoadingError();
+    QString kdeCfgFile;
+    switch (kdeVersion) {
+    case 4:
+        kdeCfgFile = QLatin1String(".kde4/share/config/kdeglobals");
+        break;
+    case 5:
+        kdeCfgFile = QLatin1String(".config/kdeglobals");
+        break;
+    default:
+        throw ColorLoadingError();
+    }
+    QString configPath = QDir(QDir::homePath()).absoluteFilePath(kdeCfgFile);
+    if (!QFileInfo(configPath).exists())
+        throw ColorLoadingError();
+
+    QSettings kdeGlobals(configPath, QSettings::IniFormat);
+    ColorsSet activeColors;
+    activeColors[View] = readSet(kdeGlobals, View);
+    activeColors[Window] = readSet(kdeGlobals, Window);
+    activeColors[Button] = readSet(kdeGlobals, Button);
+    activeColors[Selection] = readSet(kdeGlobals, Selection);
+    activeColors[Tooltip] = readSet(kdeGlobals, Tooltip);
+
+    m_colors[QPalette::Active] = activeColors;
+
+    bool inactiveEffectReadOK, disabledEffectReadOK;
+    m_inactiveEffect = readColorEffect(kdeGlobals, QLatin1String("Inactive"), inactiveEffectReadOK);
+    m_disabledEffect = readColorEffect(kdeGlobals, QLatin1String("Disabled"), disabledEffectReadOK);
+    if(!inactiveEffectReadOK || !disabledEffectReadOK)
+        throw ColorLoadingError();
+
+    m_colors[QPalette::Inactive] = applyEffect(activeColors, m_inactiveEffect);
+    m_colors[QPalette::Disabled] = applyEffect(activeColors, m_disabledEffect);
+}
+
+
+KDEColorScheme::ColorsMap KDEColorScheme::readSet(QSettings& settings, KDEColorScheme::ColorSet set)
+{
+    ColorsMap colors;
+
+    settings.beginGroup(settingsGroupName(set));
+    bool allColorsWereReadOk = true;
+    bool colorReadOk = false;
+    colors[BackgroundAlternate] = decodeKDEColor(settings.value(QLatin1String("BackgroundAlternate")), colorReadOk);
+    allColorsWereReadOk &= colorReadOk;
+    colors[BackgroundNormal] = decodeKDEColor(settings.value(QLatin1String("BackgroundNormal")), colorReadOk);
+    allColorsWereReadOk &= colorReadOk;
+    colors[DecorationFocus] = decodeKDEColor(settings.value(QLatin1String("DecorationFocus")), colorReadOk);
+    allColorsWereReadOk &= colorReadOk;
+    colors[ForegroundVisited] = decodeKDEColor(settings.value(QLatin1String("ForegroundVisited")), colorReadOk);
+    allColorsWereReadOk &= colorReadOk;
+    colors[ForegroundNormal] = decodeKDEColor(settings.value(QLatin1String("ForegroundNormal")), colorReadOk);
+    allColorsWereReadOk &= colorReadOk;
+    colors[DecorationHover] = decodeKDEColor(settings.value(QLatin1String("DecorationHover")), colorReadOk);
+    allColorsWereReadOk &= colorReadOk;
+    colors[ForegroundActive] = decodeKDEColor(settings.value(QLatin1String("ForegroundActive")), colorReadOk);
+    allColorsWereReadOk &= colorReadOk;
+    colors[ForegroundInactive] = decodeKDEColor(settings.value(QLatin1String("ForegroundInactive")), colorReadOk);
+    allColorsWereReadOk &= colorReadOk;
+    colors[ForegroundLink] = decodeKDEColor(settings.value(QLatin1String("ForegroundLink")), colorReadOk);
+    allColorsWereReadOk &= colorReadOk;
+    colors[ForegroundNegative] = decodeKDEColor(settings.value(QLatin1String("ForegroundNegative")), colorReadOk);
+    allColorsWereReadOk &= colorReadOk;
+    colors[ForegroundNeutral] = decodeKDEColor(settings.value(QLatin1String("ForegroundNeutral")), colorReadOk);
+    allColorsWereReadOk &= colorReadOk;
+    colors[ForegroundPositive] = decodeKDEColor(settings.value(QLatin1String("ForegroundPositive")), colorReadOk);
+    allColorsWereReadOk &= colorReadOk;
+    settings.endGroup();
+
+    return colors;
+}
+
+void KDEColorScheme::setFallbackColors()
+{
+    m_colors[QPalette::Active] = fallbackColorSet(QPalette::Active);
+    m_colors[QPalette::Disabled] = fallbackColorSet(QPalette::Disabled);
+    m_colors[QPalette::Inactive] = fallbackColorSet(QPalette::Inactive);
+}
+
+KDEColorScheme::ColorsSet KDEColorScheme::fallbackColorSet(QPalette::ColorGroup group)
+{
+    QPalette palette = QApplication::palette();
+    ColorsMap view;
+    view[BackgroundAlternate] = palette.color(group, QPalette::AlternateBase);
+    view[BackgroundNormal] = palette.color(group, QPalette::Background);
+    view[DecorationFocus] = palette.color(group, QPalette::HighlightedText);
+    view[DecorationHover] = palette.color(group, QPalette::Highlight);
+    view[ForegroundActive] = palette.color(group, QPalette::Text);
+    view[ForegroundInactive] = palette.color(group, QPalette::Text);
+    view[ForegroundLink] = palette.color(group, QPalette::Link);
+    view[ForegroundNegative] = palette.color(group, QPalette::Text);
+    view[ForegroundNeutral] = palette.color(group, QPalette::Text);
+    view[ForegroundNormal] = palette.color(group, QPalette::Text);
+    view[ForegroundPositive] = palette.color(group, QPalette::Text);
+    view[ForegroundVisited] = palette.color(group, QPalette::LinkVisited);
+
+    ColorsMap window = {view};
+    window[BackgroundNormal] = window[BackgroundAlternate] = palette.color(group, QPalette::Window);
+
+    ColorsMap button = {view};
+    button[BackgroundNormal] = button[BackgroundAlternate] = palette.color(group, QPalette::Button);
+    button[ForegroundActive] = palette.color(group, QPalette::ButtonText);
+    button[ForegroundInactive] = palette.color(group, QPalette::ButtonText);
+
+    ColorsMap tooltip = {view};
+    tooltip[BackgroundNormal] = tooltip[BackgroundAlternate] = palette.color(group, QPalette::ToolTipBase);
+    tooltip[ForegroundActive] = tooltip[ForegroundInactive] = palette.color(group, QPalette::ToolTipText);
+    tooltip[ForegroundNegative] = tooltip[ForegroundNeutral] = palette.color(group, QPalette::ToolTipText);
+    tooltip[ForegroundNormal] = tooltip[ForegroundPositive] = palette.color(group, QPalette::ToolTipText);
+
+    ColorsSet res;
+    res.insert(View, view);
+    res.insert(Window, window);
+    res.insert(Button, button);
+    res.insert(Tooltip, tooltip);
+    res.insert(Selection, view);
+
+    return res;
+}
+
+KDEColorScheme::ColorsSet KDEColorScheme::applyEffect(const KDEColorScheme::ColorsSet& set, const KDEColorScheme::Effect& effect)
+{
+    ColorsSet res;
+    for (auto i = set.begin(); i != set.end(); ++i) {
+        ColorsMap resMap;
+        const ColorsMap &srcMap = i.value();
+        for (auto j = srcMap.begin(); j != srcMap.end(); ++j)
+            resMap[j.key()] = applyColorEffect(j.value(), effect);
+        res.insert(i.key(), resMap);
+    }
+
+    return res;
+}

--- a/src/gui/utils/kdecolorscheme.h
+++ b/src/gui/utils/kdecolorscheme.h
@@ -1,0 +1,161 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2016 Eugene Shalygin
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#ifndef KDECOLORSCHEME_H
+#define KDECOLORSCHEME_H
+
+#include <QColor>
+#include <QPalette>
+#include <QMap>
+#include <QProcessEnvironment>
+
+class QSettings;
+
+class KDEColorScheme
+{
+public:
+    struct Effect
+    {
+        enum ColorEfffect
+        {
+            ColorEfffectNone = 0,
+            ColorEfffectDesaturate,
+            ColorEfffectFade,
+            ColorEfffectTint
+        };
+        enum IntensityEffect
+        {
+            IntensityEffectNone = 0,
+            IntensityEffectShade,
+            IntensityEffectDarken,
+            IntensityEffectLighten
+        };
+        enum ContrastEffect
+        {
+            ContrastEffectNone = 0,
+            ContrastEffectFade,
+            ContrastEffectTint
+        };
+        bool changeSelectionColor;
+        QColor color;
+        qreal colorAmount; // [-1:1]
+        ColorEfffect colorEffect;
+        qreal contrastAmount; // [-1:1]
+        ContrastEffect contrastEffect;
+        bool enable;
+        qreal intensityAmount; // [-1:1]
+        IntensityEffect intensityEffect;
+    };
+
+    enum ColorRole
+    {
+        BackgroundAlternate,
+        BackgroundNormal,
+        DecorationFocus,
+        DecorationHover,
+        ForegroundActive,
+        ForegroundInactive,
+        ForegroundLink,
+        ForegroundNegative,
+        ForegroundNeutral,
+        ForegroundNormal,
+        ForegroundPositive,
+        ForegroundVisited
+    };
+
+    enum ColorSet
+    {
+        /**
+         * Views; for example, frames, input fields, etc.
+         *
+         * If it contains things that can be selected, it is probably a View.
+         */
+        View,
+        /**
+         * Non-editable window elements; for example, menus.
+         *
+         * If it isn't a Button, View, or Tooltip, it is probably a Window.
+         */
+        Window,
+        /**
+         * Buttons and button-like controls.
+         *
+         * In addition to buttons, "button-like" controls such as non-editable
+         * dropdowns, scrollbar sliders, slider handles, etc. should also use
+         * this role.
+         */
+        Button,
+        /**
+         * Selected items in views.
+         *
+         * Note that unfocused or disabled selections should use the Window
+         * role. This makes it more obvious to the user that the view
+         * containing the selection does not have input focus.
+         */
+        Selection,
+        /**
+         * Tooltips.
+         *
+         * The tooltip set can often be substituted for the view
+         * set when editing is not possible, but the Window set is deemed
+         * inappropriate. "What's This" help is an excellent example, another
+         * might be pop-up notifications (depending on taste).
+         */
+        Tooltip
+    };
+
+    KDEColorScheme(const QProcessEnvironment& env = QProcessEnvironment::systemEnvironment());
+    void reload(const QProcessEnvironment& env = QProcessEnvironment::systemEnvironment());
+
+    static const KDEColorScheme* instance();
+
+    QColor color(ColorRole role, QPalette::ColorGroup group = QPalette::Active, ColorSet set = View) const;
+    QColor disabledColor(const QColor& color) const;
+    QColor inactiveColor(const QColor& color) const;
+
+    bool wasLoadedSuccesfuly() const;
+
+private:
+    using ColorsMap = QMap<ColorRole, QColor>;
+    using ColorsSet = QMap<ColorSet, ColorsMap>;
+    using Colors = QMap<QPalette::ColorGroup, ColorsSet>;
+
+    void load(const QProcessEnvironment& env = QProcessEnvironment::systemEnvironment());
+    void setFallbackColors();
+    static ColorsSet fallbackColorSet(QPalette::ColorGroup group);
+
+    static ColorsMap readSet(QSettings& settings, ColorSet set);
+    static ColorsSet applyEffect(const ColorsSet &set, const Effect& effect);
+
+    Colors m_colors;
+    Effect m_disabledEffect;
+    Effect m_inactiveEffect;
+    bool m_loadedSuccesfully;
+};
+
+#endif


### PR DESCRIPTION
Resurrection of pull request #3819. But now with an option to enable/disable (disabled by default) usage of the system colour theme, and of course without build or run-time dependencies on KF5/KDE4.

The used KDE colours are strongly connected with the torrent states (neutral/negative/positive), shows KDE colour effects (disabled and inactive) and therefore, I believe, are understandable and pleasant for KDE users. However, to implement the effects, colorutils .h + .cpp files from KF5 are directly included. But they are small files. 

If XDG_CURRENT_DESKTOP environment variable suggests KDE session, read kdeglobals config file and use defined there colours for torrent list. Otherwise hard-coded default values are used.
