### PR TITLE
Use default save path if save path is not set.

### DIFF
--- a/src/core/bittorrent/torrenthandle.cpp
+++ b/src/core/bittorrent/torrenthandle.cpp
@@ -201,6 +201,9 @@ TorrentHandle::TorrentHandle(Session *session, const libtorrent::torrent_handle 
     , m_pauseAfterRecheck(false)
     , m_needSaveResumeData(false)
 {
+    if (m_savePath.isEmpty())
+        m_savePath = Utils::Fs::toNativePath(m_session->defaultSavePath());
+
     initialize();
 
     if (!data.resumed) {


### PR DESCRIPTION
This patch must fix #3649-related issues.