### PR TITLE
Open destination folder on download completion notification balloon click

### DIFF
--- a/src/core/preferences.cpp
+++ b/src/core/preferences.cpp
@@ -348,6 +348,16 @@ void Preferences::setPreventFromSuspend(bool b)
     setValue("Preferences/General/PreventFromSuspend", b);
 }
 
+bool Preferences::openDestinationFolderOnBalloonClick() const
+{
+    return value("Preferences/General/OpenDestinationFolderOnBalloonClick", false).toBool();
+}
+
+void Preferences::setOpenDestinationFolderOnBalloonClick(bool b)
+{
+    setValue("Preferences/General/OpenDestinationFolderOnBalloonClick", b);
+}
+
 #ifdef Q_OS_WIN
 bool Preferences::WinStartup() const
 {

--- a/src/core/preferences.h
+++ b/src/core/preferences.h
@@ -148,6 +148,8 @@ public:
     void setSplashScreenDisabled(bool b);
     bool preventFromSuspend() const;
     void setPreventFromSuspend(bool b);
+    bool openDestinationFolderOnBalloonClick() const;
+    void setOpenDestinationFolderOnBalloonClick(bool b);
 #ifdef Q_OS_WIN
     bool WinStartup() const;
     void setWinStartup(bool b);

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -80,11 +80,12 @@ public:
     TransferListWidget* getTransferList() const { return transferList; }
     QMenu* getTrayIconMenu();
     PropertiesWidget *getProperties() const { return properties; }
+    enum TrayIconBalloonShowReason {BALLOON_REASON_UNKNOWN, BALLOON_REASON_TORRENT_FINISHED};
 
 public slots:
     void trackerAuthenticationRequired(BitTorrent::TorrentHandle *const torrent);
     void setTabText(int index, QString text) const;
-    void showNotificationBaloon(QString title, QString msg) const;
+    void showNotificationBaloon(QString title, QString msg, TrayIconBalloonShowReason reason = BALLOON_REASON_UNKNOWN);
     void downloadFromURLList(const QStringList& urls);
     void updateAltSpeedsBtn(bool alternative);
     void updateNbTorrents();
@@ -98,12 +99,13 @@ protected slots:
     void on_actionStatistics_triggered();
     void on_actionCreate_torrent_triggered();
     void balloonClicked();
+    void finishedTorrentBalloonClicked();
     void writeSettings();
     void readSettings();
     void on_actionExit_triggered();
     void createTrayIcon();
-    void fullDiskError(BitTorrent::TorrentHandle *const torrent, QString msg) const;
-    void handleDownloadFromUrlFailure(QString, QString) const;
+    void fullDiskError(BitTorrent::TorrentHandle *const torrent, QString msg);
+    void handleDownloadFromUrlFailure(QString, QString);
     void createSystrayDelayed();
     void tab_changed(int);
     void on_actionLock_qBittorrent_triggered();
@@ -127,8 +129,8 @@ protected slots:
     void updateGUI();
     void loadPreferences(bool configure_session = true);
     void addUnauthenticatedTracker(const QPair<BitTorrent::TorrentHandle*, QString> &tracker);
-    void addTorrentFailed(const QString &error) const;
-    void finishedTorrent(BitTorrent::TorrentHandle *const torrent) const;
+    void addTorrentFailed(const QString &error);
+    void finishedTorrent(BitTorrent::TorrentHandle *const torrent);
     void askRecursiveTorrentDownloadConfirmation(BitTorrent::TorrentHandle *const torrent);
     // Options slots
     void on_actionOptions_triggered();
@@ -205,6 +207,9 @@ private:
 #endif
     bool has_python;
     QMenu* toolbarMenu;
+    TrayIconBalloonShowReason baloonShowReason;
+    QString balloonClickDestinationPath;
+    bool balloonClickDestinationSingleFile;
 
 private slots:
     void on_actionSearch_engine_triggered();

--- a/src/gui/options.ui
+++ b/src/gui/options.ui
@@ -406,6 +406,13 @@
                    </widget>
                   </item>
                   <item>
+                   <widget class="QCheckBox" name="checkOpenDestinationFolderOnBalloonClick">
+                    <property name="text">
+                     <string>Open folder on torrent completion notification balloon click</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
                    <layout class="QFormLayout" name="formLayout_4">
                     <item row="0" column="0">
                      <widget class="QLabel" name="label_trayIconStyle">

--- a/src/gui/options_imp.cpp
+++ b/src/gui/options_imp.cpp
@@ -153,6 +153,7 @@ options_imp::options_imp(QWidget *parent)
     connect(checkAssociateTorrents, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
     connect(checkAssociateMagnetLinks, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
 #endif
+    connect(checkOpenDestinationFolderOnBalloonClick, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
     // Downloads tab
     connect(textSavePath, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
     connect(textTempPath, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
@@ -392,6 +393,7 @@ void options_imp::saveOptions()
     pref->setCloseToTray(closeToTray());
     pref->setMinimizeToTray(minimizeToTray());
     pref->setStartMinimized(startMinimized());
+    pref->setOpenDestinationFolderOnBalloonClick(openDestinationFolderOnBalloonClick());
     pref->setSplashScreenDisabled(isSlashScreenDisabled());
     pref->setConfirmOnExit(checkProgramExitConfirm->isChecked());
     pref->setPreventFromSuspend(preventFromSuspend());
@@ -561,6 +563,7 @@ void options_imp::loadOptions()
         checkMinimizeToSysTray->setChecked(pref->minimizeToTray());
         checkCloseToSystray->setChecked(pref->closeToTray());
         comboTrayIcon->setCurrentIndex(pref->trayIconStyle());
+        checkOpenDestinationFolderOnBalloonClick->setChecked(pref->openDestinationFolderOnBalloonClick());
     }
 
     checkPreventFromSuspend->setChecked(pref->preventFromSuspend());
@@ -869,6 +872,13 @@ bool options_imp::closeToTray() const
 {
     if (!checkShowSystray->isChecked()) return false;
     return checkCloseToSystray->isChecked();
+}
+
+bool options_imp::openDestinationFolderOnBalloonClick() const
+{
+    if (!checkShowSystray->isChecked())
+        return false;
+    return checkOpenDestinationFolderOnBalloonClick->isChecked();
 }
 
 bool options_imp::isQueueingSystemEnabled() const

--- a/src/gui/options_imp.h
+++ b/src/gui/options_imp.h
@@ -112,6 +112,7 @@ private:
     bool minimizeToTray() const;
     bool closeToTray() const;
     bool startMinimized() const;
+    bool openDestinationFolderOnBalloonClick() const;
     bool isSlashScreenDisabled() const;
     bool preventFromSuspend() const;
 #ifdef Q_OS_WIN


### PR DESCRIPTION
Hi everyone. I migrated to qBittorrent from μTorrent a few months ago. 
μTorrent has a nice feature, when you click on tray icon baloon notification about torrent finished downloading, μTorrent opens the destination folder of a torrent.
This is my attempt to implement this feature (#1529) in qBittorent.
Tried to run **lupdate** but it always crashes or hangs.

![screenshot 2015-10-17 001.png](https://lh3.googleusercontent.com/-gN-VjlneSoI/ViKxQkTWoHI/AAAAAAAAGOY/sTm0GHe4Qe0/s0/screenshot%2525202015-10-17%252520001.png)

![screenshot 2015-10-17 001.png](https://lh3.googleusercontent.com/-Qd5k7RIqrfM/ViKsip-eCzI/AAAAAAAAGOM/0YSju3xuL_c/s0/screenshot%2525202015-10-17%252520001.png)
