### PR TITLE
Cast MaxRatioAction to int when store as JSON. Closes #3939.

### DIFF
--- a/src/webui/prefjson.cpp
+++ b/src/webui/prefjson.cpp
@@ -141,7 +141,7 @@ QByteArray prefjson::getPreferences()
     // Share Ratio Limiting
     data["max_ratio_enabled"] = (pref->getGlobalMaxRatio() >= 0.);
     data["max_ratio"] = pref->getGlobalMaxRatio();
-    data["max_ratio_act"] = QVariant::fromValue(pref->getMaxRatioAction());
+    data["max_ratio_act"] = static_cast<int>(pref->getMaxRatioAction());
 
     // Web UI
     // Language
@@ -337,7 +337,7 @@ void prefjson::setPreferences(const QString& json)
     else
         pref->setGlobalMaxRatio(-1);
     if (m.contains("max_ratio_act"))
-        pref->setMaxRatioAction(m["max_ratio_act"].value<MaxRatioAction>());
+        pref->setMaxRatioAction(static_cast<MaxRatioAction>(m["max_ratio_act"].toInt()));
 
     // Web UI
     // Language


### PR DESCRIPTION
I not tested it with Qt4, but I'm sure it works.