### PR TITLE
Fix text misalignment in propertieswidget.

### DIFF
--- a/src/gui/properties/propertieswidget.ui
+++ b/src/gui/properties/propertieswidget.ui
@@ -801,6 +801,9 @@
                 <property name="text">
                  <string>Torrent Hash:</string>
                 </property>
+                <property name="textFormat">
+                 <enum>Qt::RichText</enum>
+                </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
@@ -832,6 +835,9 @@
                 </property>
                 <property name="text">
                  <string>Save Path:</string>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::RichText</enum>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
@@ -867,6 +873,9 @@
                 </property>
                 <property name="text">
                  <string>Comment:</string>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::RichText</enum>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>


### PR DESCRIPTION
Weird problem...
When "Qt:TextSelectableByMouse" is selected, QLabel will drop lower by about 2px.
This effect is also observed when using "Qt::RichText". So I change the affected text fields' header to use "Qt::RichText" to make it align properly.


Before:
![old](https://cloud.githubusercontent.com/assets/9395168/10714300/33f86a10-7b24-11e5-8fd9-fbb7383f23b6.png)

After:
![new](https://cloud.githubusercontent.com/assets/9395168/10714299/30263584-7b24-11e5-84f6-26d6be0b3e8e.png)
