### PR TITLE
Changed payload functions from int to qlonglong in TorrentHandle class

### DIFF
--- a/src/core/bittorrent/torrenthandle.cpp
+++ b/src/core/bittorrent/torrenthandle.cpp
@@ -1055,12 +1055,12 @@ int TorrentHandle::downloadPayloadRate() const
     return m_nativeStatus.download_payload_rate;
 }
 
-int TorrentHandle::totalPayloadUpload() const
+qlonglong TorrentHandle::totalPayloadUpload() const
 {
     return m_nativeStatus.total_payload_upload;
 }
 
-int TorrentHandle::totalPayloadDownload() const
+qlonglong TorrentHandle::totalPayloadDownload() const
 {
     return m_nativeStatus.total_payload_download;
 }

--- a/src/core/bittorrent/torrenthandle.h
+++ b/src/core/bittorrent/torrenthandle.h
@@ -254,8 +254,8 @@ namespace BitTorrent
         qreal realRatio() const;
         int uploadPayloadRate() const;
         int downloadPayloadRate() const;
-        int totalPayloadUpload() const;
-        int totalPayloadDownload() const;
+        qlonglong totalPayloadUpload() const;
+        qlonglong totalPayloadDownload() const;
         int connectionsCount() const;
         int connectionsLimit() const;
         qlonglong nextAnnounce() const;


### PR DESCRIPTION
This fixes #3895.

Functions totalPayloadUpload() and totalPayloadDownload() must be qlonglong since total_payload_upload and total_payload_download are defined as boost::int64_t size in libtorrent.