### PR TITLE
[WebUI] Add save path, cookies and labels when adding torrents

### DIFF
--- a/src/webui/extra_translations.h
+++ b/src/webui/extra_translations.h
@@ -39,7 +39,7 @@ static const char *__TRANSLATIONS__[] = {
     QT_TRANSLATE_NOOP("HttpServer", "Logout"),
     QT_TRANSLATE_NOOP("HttpServer", "Download Torrents from their URL or Magnet link"),
     QT_TRANSLATE_NOOP("HttpServer", "Only one link per line"),
-    QT_TRANSLATE_NOOP("HttpServer", "Download local torrent"),
+    QT_TRANSLATE_NOOP("HttpServer", "Upload local torrent"),
     QT_TRANSLATE_NOOP("HttpServer", "Download"),
     QT_TRANSLATE_NOOP("HttpServer", "Are you sure you want to delete the selected torrents from the transfer list?"),
     QT_TRANSLATE_NOOP("HttpServer", "Global upload rate limit must be greater than 0 or disabled."),
@@ -84,6 +84,9 @@ static const char *__TRANSLATIONS__[] = {
     QT_TRANSLATE_NOOP("HttpServer", "Paused"),
     QT_TRANSLATE_NOOP("HttpServer", "Active"),
     QT_TRANSLATE_NOOP("HttpServer", "Inactive")
+    QT_TRANSLATE_NOOP("HttpServer", "Save files to location:")
+    QT_TRANSLATE_NOOP("HttpServer", "Label:")
+    QT_TRANSLATE_NOOP("HttpServer", "Cookie:")
 };
 
 static const struct { const char *source; const char *comment; } __COMMENTED_TRANSLATIONS__[] = {

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -87,6 +87,7 @@ private:
     void action_command_bottomPrio();
     void action_command_recheck();
     void action_command_setLabel();
+    void action_command_getSavePath();
     void action_version_api();
     void action_version_api_min();
     void action_version_qbittorrent();

--- a/src/webui/www/public/download.html
+++ b/src/webui/www/public/download.html
@@ -4,16 +4,50 @@
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 	<title>QBT_TR(Add Torrent Link)QBT_TR</title>
 	<link rel="stylesheet" href="css/style.css" type="text/css" />
+        <link rel="stylesheet" href="css/Window.css" type="text/css" />
 	<script type="text/javascript" src="scripts/mootools-1.2-core-yc.js" charset="utf-8"></script>
 	<script type="text/javascript" src="scripts/download.js" charset="utf-8"></script>
 </head>
 <body>
+<iframe id="download_frame" name="download_frame" class="invisible" src="javascript:false;"></iframe>
+<form action="command/download" enctype="multipart/form-data" method="post" id="downloadForm" style="text-align: center;" target="download_frame">
 <center>
 	<br/>
 	<h2 class="vcenter">QBT_TR(Download Torrents from their URLs or Magnet links)QBT_TR</h2>
-	<textarea id="urls" rows="10"></textarea>
+	<textarea id="urls" rows="10" name="urls"></textarea>
 <p>QBT_TR(Only one link per line)QBT_TR</p>
-<input type="button" value="QBT_TR(Download)QBT_TR" id="downButton"/>
-	</center>
+<fieldset class="settings" style="border: 0; text-align: left;">
+<div class="formRow" style="margin-top: 6px;">
+	<label for="savepath" class="leftLabelLarge">QBT_TR(Save files to location:)QBT_TR</label>
+	<input type="text" id="savepath" name="savepath" style="width: 16em;"/>
+</div>
+<div class="formRow">
+	<label for="cookie" class="leftLabelLarge">QBT_TR(Cookie:)QBT_TR</label>
+	<input type="text" id="cookie" name="cookie" style="width: 16em;"/>
+</div>
+<div class="formRow">
+	<label for="label" class="leftLabelLarge">QBT_TR(Label:)QBT_TR</label>
+	<input type="text" id="label" name="label" style="width: 16em;"/>
+</div>
+<div id="submitbutton" style="margin-top: 12px; text-align: center;">
+    <button type="submit" id="submitButton">QBT_TR(Download)QBT_TR</button>
+</div>
+</center>
+</form>
+<script type="text/javascript">
+
+var submitted = false;
+
+$('downloadForm').addEventListener("submit", function() {
+	$('download_spinner').style.display = "block";
+        submitted = true;
+});
+
+$('download_frame').addEventListener("load", function() {
+	if (submitted)
+	        window.parent.closeWindows();
+});
+</script>
+<div id="download_spinner" class="mochaSpinner"></div>
 </body>
 </html>

--- a/src/webui/www/public/scripts/download.js
+++ b/src/webui/www/public/scripts/download.js
@@ -20,19 +20,23 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-window.addEvent('domready', function() {
-    $('urls').focus();
-    $('downButton').addEvent('click', function(e) {
-        new Event(e).stop();
-        new Request({
-            url: 'command/download',
-            method: 'post',
-            data: {
-                urls: $('urls').value
-            },
-            onComplete: function() {
-                window.parent.document.getElementById('downloadPage').parentNode.removeChild(window.parent.document.getElementById('downloadPage'));
-            }
+
+getSavePath = function() {
+        var req = new Request({
+                url: 'command/getSavePath',
+                method: 'get',
+                noCache: true,
+                onFailure: function() {
+                        alert("Could not contact qBittorrent");
+                },
+                onSuccess: function(data) {
+                        if (data) {
+                                $('savepath').setProperty('value', data);
+                        }
+                }
         }).send();
-    });
+}
+
+$(window).addEventListener("load", function() {
+	getSavePath();
 });

--- a/src/webui/www/public/scripts/mocha-init.js
+++ b/src/webui/www/public/scripts/mocha-init.js
@@ -57,7 +57,7 @@ initializeWindows = function() {
             paddingVertical: 0,
             paddingHorizontal: 0,
             width: 500,
-            height: 300
+            height: 360
         });
         updateMainData();
     });
@@ -88,7 +88,7 @@ initializeWindows = function() {
         new Event(e).stop();
         new MochaUI.Window({
             id: 'uploadPage',
-            title: "QBT_TR(Download local torrent)QBT_TR",
+            title: "QBT_TR(Upload local torrent)QBT_TR",
             loadMethod: 'iframe',
             contentURL: 'upload.html',
             scrollbars: true,
@@ -96,8 +96,8 @@ initializeWindows = function() {
             maximizable: false,
             paddingVertical: 0,
             paddingHorizontal: 0,
-            width: 600,
-            height: 130
+            width: 500,
+            height: 200
         });
         updateMainData();
     });

--- a/src/webui/www/public/upload.html
+++ b/src/webui/www/public/upload.html
@@ -2,73 +2,48 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" dir="ltr">
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-	<title>QBT_TR(Download local torrent)QBT_TR</title>
+	<title>QBT_TR(Upload local torrent)QBT_TR</title>
 	<link rel="stylesheet" href="css/style.css" type="text/css" />
 	<link rel="stylesheet" href="css/Window.css" type="text/css" />
 	<script type="text/javascript" src="scripts/mootools-1.2-core-yc.js" charset="utf-8"></script>
-<script type="text/javascript">
-
-function stateChangeHandler() {
-	if (this.readyState == this.DONE) {
-		if (this.status == 200) {
-			window.parent.closeWindows();
-		} else {
-			if (this.responseText != "") {
-				alert(this.responseText);
-			} else {
-				alert("QBT_TR(Upload Failed!)QBT_TR");
-			}
-		}
-		$('upload_spinner').style.display = "none";
-	}
-}
-
-function uploadFiles(files) {
-	var xhr = new XMLHttpRequest();
-	if (xhr.upload) {
-		// start upload
-		var formData = new FormData();
-		for (var i = 0, file; file = files[i]; ++i)
-			formData.append(file.name, file);
-		xhr.onreadystatechange = stateChangeHandler;
-		xhr.open("POST", "command/upload");
-		// Bypass cache
-		xhr.setRequestHeader("Cache-Control", "no-cache");
-		xhr.send(formData);
-	}
-}
-
-function fileHandler(e) {
-	e.preventDefault();
-	$('upload_spinner').style.display = "block";
-	// fetch FileList object
-	var files = $('fileselect').files
-	// process all File objects
-	uploadFiles(files);
-}
-
-window.addEvent('load', function() {
-	// is XHR2 available?
-	var xhr = new XMLHttpRequest();
-	if (xhr.upload) {
-		$('uploadForm').addEvent('submit', fileHandler);
-	} else {
-		$('upload_frame').addEvent('load', function() { window.parent.closeWindows(); });
-		$('uploadForm').addEvent('submit', function() { $('upload_spinner').style.display = "block"; });
-	}
-});
-</script>
+	<script type="text/javascript" src="scripts/download.js" charset="utf-8"></script>
 </head>
 <body>
 <iframe id="upload_frame" name="upload_frame" class="invisible" src="javascript:false;"></iframe>
-<form action="command/upload" enctype="multipart/form-data" method="post" id="uploadForm" target="upload_frame" style="text-align: center;">
-<div style="margin-top: 25px; display: inline-block; border: 1px solid lightgrey; border-radius: 4px;">
-	<input type="file" id="fileselect" name="fileselect[]" multiple="multiple" />
+<form action="command/upload" enctype="multipart/form-data" method="post" id="uploadForm" style="text-align: center;" target="upload_frame">
+<p>
+	<div style="margin-top: 25px; display: inline-block; border: 1px solid lightgrey; border-radius: 4px;">
+		<input type="file" id="fileselect" name="fileselect[]" multiple="multiple"/>
+	</div>
+</p>
+<fieldset class="settings" style="border: 0; text-align: left;">
+<div class="formRow" style="margin-top: 12px;">
+	<label for="savepath" class="leftLabelLarge">QBT_TR(Save files to location:)QBT_TR</label>
+	<input type="text" id="savepath" name="savepath" style="width: 16em;"/>
 </div>
-<div id="submitbutton" style="margin-top: 30px;">
+<div class="formRow">
+	<label for="label" class="leftLabelLarge">QBT_TR(Label:)QBT_TR</label>
+	<input type="text" id="label" name="label"/ style="width: 16em;"/>
+</div>
+<div id="submitbutton" style="margin-top: 30px; text-align: center;">
 	<button type="submit" style="font-size: 1em;">QBT_TR(Upload Torrents)QBT_TR</button>
 </div>
+</fieldset>
 </form>
+<script type="text/javascript">
+
+var submitted = false;
+
+$('uploadForm').addEventListener("submit", function() {
+	$('upload_spinner').style.display = "block";
+	submitted = true;
+});
+
+$('upload_frame').addEventListener("load", function() {
+	if (submitted)
+		window.parent.closeWindows();
+});
+</script>
 <div id="upload_spinner" class="mochaSpinner"></div>
 </body>
 </html>


### PR DESCRIPTION
This patch allows people to configure save path, cookies and labels when adding torrents using the WebUI, either downloading from an URL or uploading it from the local filesystem.

This is a feature that is pretty popular in other bittorrents clients so I think qBittorrent being as great as it is should have them.

This consist in expanding the AddTorrentParams to allow passing cookies from the WebUI to the main program.

Also the webpages upload.html and download.html were changed a little bit to allow browsers to autocomplete.  The way they were designed doesn't allow browsers to autocomplete fields.  Nobody is going to paste cookies all the time in the WebUI they would want their browser to remember them.  This fix includes that as well.