### PR TITLE
Reduce max value of "Disk cache size"

### DIFF
--- a/src/core/preferences.cpp
+++ b/src/core/preferences.cpp
@@ -1358,37 +1358,26 @@ void Preferences::setShutdownqBTWhenDownloadsComplete(bool shutdown)
 uint Preferences::diskCacheSize() const
 {
     uint size = value("Preferences/Downloads/DiskWriteCacheSize", 0).toUInt();
-
-    // When build as 32bit binary, set the maximum at less than 2GB to prevent crashes.
     // These macros may not be available on compilers other than MSVC and GCC
-#if !defined(_M_X64) && !defined(__amd64__)
-    //1800MiB to leave 248MiB room to the rest of program data in RAM
-    if (size > 1800)
-        size = 1800;
+#if defined(__x86_64__) || defined(_M_X64)
+    size = qMin(size, (uint) 4096);  // 4GiB
 #else
-    // 4GiB
-    if (size > 4 * 1024)
-        size = 4 * 1024;
+    // When build as 32bit binary, set the maximum at less than 2GB to prevent crashes
+    // allocate 1536MiB and leave 512MiB to the rest of program data in RAM
+    size = qMin(size, (uint) 1536);
 #endif
-
     return size;
 }
 
 void Preferences::setDiskCacheSize(uint size)
 {
-    uint size0 = size;
-
-#if !defined(_M_X64) && !defined(__amd64__)
-    //1800MiB to leave 248MiB room to the rest of program data in RAM
-    if (size0 > 1800)
-        size0 = 1800;
+#if defined(__x86_64__) || defined(_M_X64)
+    size = qMin(size, (uint) 4096);  // 4GiB
 #else
-    // 4GiB
-    if (size0 > 4 * 1024)
-        size0 = 4 * 1024;
+    // allocate 1536MiB and leave 512MiB to the rest of program data in RAM
+    size = qMin(size, (uint) 1536);
 #endif
-
-    setValue("Preferences/Downloads/DiskWriteCacheSize", size0);
+    setValue("Preferences/Downloads/DiskWriteCacheSize", size);
 }
 
 uint Preferences::diskCacheTTL() const

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -208,12 +208,11 @@ private slots:
         spin_cache.setMinimum(0);
         // When build as 32bit binary, set the maximum at less than 2GB to prevent crashes.
         // These macros may not be available on compilers other than MSVC and GCC
-#if !defined(_M_X64) && !defined(__amd64__)
-        //1800MiB to leave 248MiB room to the rest of program data in RAM
-        spin_cache.setMaximum(1800);
+#if defined(__x86_64__) || defined(_M_X64)
+        spin_cache.setMaximum(4096);
 #else
-        // 4GiB
-        spin_cache.setMaximum(4*1024);
+        // allocate 1536MiB and leave 512MiB to the rest of program data in RAM
+        spin_cache.setMaximum(1536);
 #endif
         spin_cache.setValue(pref->diskCacheSize());
         updateCacheSpinSuffix(spin_cache.value());


### PR DESCRIPTION
In #4028, the user have 16GB of system ram and running 32bit qBT. The cache size was set to 1800MB and the system throws "bad allocation" exception.
Maybe the allowed maximum should be reduced.

And a little bit refactor from the information here: http://nadeausoftware.com/articles/2012/02/c_c_tip_how_detect_processor_type_using_compiler_predefined_macros#x86andx8664