### PR TITLE
Fix 'Append label to save path'. Closes #4031.

### DIFF
--- a/src/core/bittorrent/session.cpp
+++ b/src/core/bittorrent/session.cpp
@@ -1026,7 +1026,7 @@ bool Session::addTorrent(const TorrentInfo &torrentInfo, const AddTorrentParams 
 }
 
 // Add a torrent to the BitTorrent session
-bool Session::addTorrent_impl(const AddTorrentData &addData, const MagnetUri &magnetUri,
+bool Session::addTorrent_impl(AddTorrentData addData, const MagnetUri &magnetUri,
                               const TorrentInfo &torrentInfo, const QByteArray &fastresumeData)
 {
     libt::add_torrent_params p;
@@ -1098,21 +1098,21 @@ bool Session::addTorrent_impl(const AddTorrentData &addData, const MagnetUri &ma
     p.max_connections = pref->getMaxConnecsPerTorrent();
     p.max_uploads = pref->getMaxUploadsPerTorrent();
 
+    if (addData.savePath.isEmpty()) {
+        addData.savePath = m_defaultSavePath;
+        if (m_appendLabelToSavePath && !addData.label.isEmpty())
+            addData.savePath +=  QString("%1/").arg(addData.label);
+    }
+    else if (!addData.savePath.endsWith("/")) {
+        addData.savePath += "/";
+    }
+
     QString savePath;
     // Set actual save path (e.g. temporary folder)
-    if (isTempPathEnabled() && !addData.disableTempPath && !addData.hasSeedStatus) {
+    if (isTempPathEnabled() && !addData.disableTempPath && !addData.hasSeedStatus)
         savePath = m_tempPath;
-    }
-    else {
+    else
         savePath = addData.savePath;
-        if (savePath.isEmpty()) {
-            savePath = m_defaultSavePath;
-            if (m_appendLabelToSavePath && !addData.label.isEmpty())
-                savePath +=  QString("%1/").arg(addData.label);
-        }
-        else if (!savePath.endsWith("/"))
-            savePath += "/";
-    }
 
     p.save_path = Utils::String::toStdString(Utils::Fs::toNativePath(savePath));
     // Check if save path exists, creating it otherwise

--- a/src/core/bittorrent/session.h
+++ b/src/core/bittorrent/session.h
@@ -288,7 +288,7 @@ namespace BitTorrent
         void setAppendExtension(bool append);
 
         void startUpTorrents();
-        bool addTorrent_impl(const AddTorrentData &addData, const MagnetUri &magnetUri,
+        bool addTorrent_impl(AddTorrentData addData, const MagnetUri &magnetUri,
                              const TorrentInfo &torrentInfo = TorrentInfo(),
                              const QByteArray &fastresumeData = QByteArray());
 

--- a/src/core/bittorrent/torrenthandle.cpp
+++ b/src/core/bittorrent/torrenthandle.cpp
@@ -202,9 +202,6 @@ TorrentHandle::TorrentHandle(Session *session, const libtorrent::torrent_handle 
     , m_pauseAfterRecheck(false)
     , m_needSaveResumeData(false)
 {
-    if (m_savePath.isEmpty())
-        m_savePath = Utils::Fs::toNativePath(m_session->defaultSavePath());
-
     initialize();
 
     if (!data.resumed) {


### PR DESCRIPTION
<del>This fixes issue that may happen if you used one of the early pre-release builds of version 3.3 before.</del>
This patch is required for v3.3.