### PR TITLE
Remove PDB file from installer

### DIFF
--- a/dist/windows/installer.nsi
+++ b/dist/windows/installer.nsi
@@ -28,7 +28,6 @@ Section $(inst_qbt_req) ;"qBittorrent (required)"
   
   ; Put file there  
   File "qbittorrent.exe"
-  File "qbittorrent.pdb"
   File "qt.conf"
   File /oname=translations\qt_ar.qm "translations\qt_ar.qm"
   File /oname=translations\qt_bg.qm "translations\qt_bg.qm"


### PR DESCRIPTION
Just a proposal :)

It is very uncommon to include these files in release package, and they are huge. Saves roughly 80% installation size and 40% installer size.

Not removed from uninstaller.nsi, for existing installations.

Refs https://github.com/qbittorrent/qBittorrent/commit/c96eff2c155fcbe69cdd1a82faf688fda9b22b11