### PR TITLE
Properties widget cleanup

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -215,7 +215,7 @@ MainWindow::MainWindow(QWidget *parent)
     connect(BitTorrent::Session::instance(), SIGNAL(trackerError(BitTorrent::TorrentHandle *const, const QString &)), transferListFilters, SLOT(trackerError(BitTorrent::TorrentHandle *const, const QString &)));
     connect(BitTorrent::Session::instance(), SIGNAL(trackerWarning(BitTorrent::TorrentHandle *const, const QString &)), transferListFilters, SLOT(trackerWarning(BitTorrent::TorrentHandle *const, const QString &)));
 
-    vboxLayout->addWidget(tabs);
+    centralWidgetLayout->addWidget(tabs);
 
     prioSeparator = toolBar->insertSeparator(actionTopPriority);
     prioSeparatorMenu = menu_Edit->insertSeparator(actionTopPriority);

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -13,11 +13,17 @@
   <property name="contextMenuPolicy">
    <enum>Qt::CustomContextMenu</enum>
   </property>
-  <property name="windowTitle">
-   <string/>
-  </property>
-  <widget class="QWidget" name="centralwidget">
-   <layout class="QVBoxLayout">
+  <widget class="QWidget" name="centralWidget">
+   <layout class="QVBoxLayout" name="centralWidgetLayout">
+    <property name="leftMargin">
+     <number>7</number>
+    </property>
+    <property name="topMargin">
+     <number>3</number>
+    </property>
+    <property name="rightMargin">
+     <number>5</number>
+    </property>
     <property name="bottomMargin">
      <number>0</number>
     </property>
@@ -29,7 +35,7 @@
      <x>0</x>
      <y>0</y>
      <width>914</width>
-     <height>20</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_Edit">
@@ -152,16 +158,10 @@
    <property name="text">
     <string>E&amp;xit</string>
    </property>
-   <property name="toolTip">
-    <string>Exit</string>
-   </property>
   </action>
   <action name="actionOptions">
    <property name="text">
     <string>&amp;Options...</string>
-   </property>
-   <property name="iconText">
-    <string>Options</string>
    </property>
   </action>
   <action name="actionAbout">
@@ -173,24 +173,15 @@
    <property name="text">
     <string>&amp;Resume</string>
    </property>
-   <property name="iconText">
-    <string>Resume</string>
-   </property>
   </action>
   <action name="actionPause">
    <property name="text">
     <string>&amp;Pause</string>
    </property>
-   <property name="iconText">
-    <string>Pause</string>
-   </property>
   </action>
   <action name="actionDelete">
    <property name="text">
     <string>&amp;Delete</string>
-   </property>
-   <property name="iconText">
-    <string>Delete</string>
    </property>
   </action>
   <action name="actionDownload_from_URL">
@@ -318,9 +309,6 @@
    </property>
    <property name="iconText">
     <string>Lock</string>
-   </property>
-   <property name="toolTip">
-    <string>Lock qBittorrent</string>
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+L</string>

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -79,8 +79,9 @@ PropertiesWidget::PropertiesWidget(QWidget *parent, MainWindow* main_window, Tra
   // Torrent content filtering
   m_contentFilterLine = new LineEdit(this);
   m_contentFilterLine->setPlaceholderText(tr("Filter files..."));
+  m_contentFilterLine->setMaximumSize(300, m_contentFilterLine->size().height());
   connect(m_contentFilterLine, SIGNAL(textChanged(QString)), this, SLOT(filterText(QString)));
-  contentFilterLayout->insertWidget(4, m_contentFilterLine);
+  contentFilterLayout->insertWidget(3, m_contentFilterLine);
 
   // SIGNAL/SLOTS
   connect(filesList, SIGNAL(clicked(const QModelIndex&)), filesList, SLOT(edit(const QModelIndex&)));

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -126,7 +126,9 @@ PropertiesWidget::PropertiesWidget(QWidget *parent, MainWindow* main_window, Tra
   // Tracker list
   trackerList = new TrackerList(this);
   trackerUpButton->setIcon(GuiIconProvider::instance()->getIcon("go-up"));
+  trackerUpButton->setIconSize(Utils::Misc::smallIconSize());
   trackerDownButton->setIcon(GuiIconProvider::instance()->getIcon("go-down"));
+  trackerDownButton->setIconSize(Utils::Misc::smallIconSize());
   connect(trackerUpButton, SIGNAL(clicked()), trackerList, SLOT(moveSelectionUp()));
   connect(trackerDownButton, SIGNAL(clicked()), trackerList, SLOT(moveSelectionDown()));
   horizontalLayout_trackers->insertWidget(0, trackerList);

--- a/src/gui/properties/propertieswidget.ui
+++ b/src/gui/properties/propertieswidget.ui
@@ -998,8 +998,20 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="page_4">
+     <widget class="QWidget" name="pageContents">
       <layout class="QVBoxLayout" name="verticalLayout_3">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
        <item>
         <layout class="QHBoxLayout" name="contentFilterLayout">
          <item>
@@ -1028,22 +1040,6 @@
             </size>
            </property>
           </spacer>
-         </item>
-         <item>
-          <widget class="QLabel" name="label_11">
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>Torrent content:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignVCenter</set>
-           </property>
-          </widget>
          </item>
         </layout>
        </item>

--- a/src/gui/properties/propertieswidget.ui
+++ b/src/gui/properties/propertieswidget.ui
@@ -33,9 +33,6 @@
      </property>
      <widget class="QWidget" name="pageInfos">
       <layout class="QVBoxLayout" name="verticalLayout_7">
-       <property name="spacing">
-        <number>0</number>
-       </property>
        <property name="leftMargin">
         <number>0</number>
        </property>
@@ -912,6 +909,18 @@
      </widget>
      <widget class="QWidget" name="pageTrackers">
       <layout class="QHBoxLayout" name="horizontalLayout_trackers">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
        <item>
         <layout class="QVBoxLayout" name="verticalLayout_10">
          <item>
@@ -928,54 +937,10 @@
           </spacer>
          </item>
          <item>
-          <widget class="QPushButton" name="trackerUpButton">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-             <horstretch>31</horstretch>
-             <verstretch>27</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>31</width>
-             <height>27</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>31</width>
-             <height>27</height>
-            </size>
-           </property>
-           <property name="text">
-            <string notr="true"/>
-           </property>
-          </widget>
+          <widget class="QPushButton" name="trackerUpButton"/>
          </item>
          <item>
-          <widget class="QPushButton" name="trackerDownButton">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-             <horstretch>31</horstretch>
-             <verstretch>27</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>31</width>
-             <height>27</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>31</width>
-             <height>27</height>
-            </size>
-           </property>
-           <property name="text">
-            <string notr="true"/>
-           </property>
-          </widget>
+          <widget class="QPushButton" name="trackerDownButton"/>
          </item>
          <item>
           <spacer name="verticalSpacer_3">

--- a/src/gui/properties/propertieswidget.ui
+++ b/src/gui/properties/propertieswidget.ui
@@ -11,9 +11,6 @@
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="spacing">
-    <number>0</number>
-   </property>
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -31,7 +28,7 @@
      <property name="currentIndex">
       <number>0</number>
      </property>
-     <widget class="QWidget" name="pageInfos">
+     <widget class="QWidget" name="pageGeneral">
       <layout class="QVBoxLayout" name="verticalLayout_7">
        <property name="leftMargin">
         <number>0</number>
@@ -959,11 +956,36 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="page_5">
-      <layout class="QVBoxLayout" name="peerpage_layout"/>
+     <widget class="QWidget" name="pagePeers">
+      <layout class="QVBoxLayout" name="peerpage_layout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+      </layout>
      </widget>
-     <widget class="QWidget" name="page_3">
+     <widget class="QWidget" name="pageSources">
       <layout class="QVBoxLayout" name="verticalLayout_9">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
        <item>
         <widget class="QListWidget" name="listWebSeeds">
          <property name="contextMenuPolicy">
@@ -1043,8 +1065,21 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="speed_page">
-      <layout class="QVBoxLayout" name="speed_layout"/>
+     <widget class="QWidget" name="pageSpeed">
+      <layout class="QVBoxLayout" name="speed_layout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+      </layout>
      </widget>
     </widget>
    </item>


### PR DESCRIPTION
Border in various pages are removed, now it should align perfectly (with upper windows), see pic below.

~~I also changed the use of (our own) LineEdit to QLineEdit in Content page.~~

Old:
![old](https://cloud.githubusercontent.com/assets/9395168/10968808/e0ff8b98-83fe-11e5-988b-822a99eaee24.png)

New:
[new_1](https://cloud.githubusercontent.com/assets/9395168/10969027/a5be2c7c-8400-11e5-9353-815a7d225f46.png)
After reduce mainwindow border width: ![new2](https://cloud.githubusercontent.com/assets/9395168/11452838/cda2ea3e-962f-11e5-8df6-b9eef43cb00a.png)

