### PR TITLE
Some TransferListWidget speedup.

### DIFF
--- a/src/core/bittorrent/session.cpp
+++ b/src/core/bittorrent/session.cpp
@@ -112,19 +112,6 @@ AddTorrentParams::AddTorrentParams()
 {
 }
 
-// TorrentStatusReport
-
-TorrentStatusReport::TorrentStatusReport()
-    : nbDownloading(0)
-    , nbSeeding(0)
-    , nbCompleted(0)
-    , nbActive(0)
-    , nbInactive(0)
-    , nbPaused(0)
-    , nbResumed(0)
-{
-}
-
 // Session
 
 Session *Session::m_instance = 0;
@@ -980,6 +967,11 @@ void Session::bottomTorrentsPriority(const QStringList &hashes)
 QHash<InfoHash, TorrentHandle *> Session::torrents() const
 {
     return m_torrents;
+}
+
+TorrentStatusReport Session::torrentStatusReport() const
+{
+    return m_torrentStatusReport;
 }
 
 // source - .torrent file path/url or magnet uri (hash for preloaded torrent)
@@ -2342,31 +2334,29 @@ void Session::handleStateUpdateAlert(libt::state_update_alert *p)
 {
     foreach (const libt::torrent_status &status, p->status) {
         TorrentHandle *const torrent = m_torrents.value(status.info_hash);
-        if (torrent) {
+        if (torrent)
             torrent->handleStateUpdate(status);
-            emit torrentStatusUpdated(torrent);
-        }
     }
 
-    TorrentStatusReport torrentStatusReport;
+    m_torrentStatusReport = TorrentStatusReport();
     foreach (TorrentHandle *const torrent, m_torrents) {
         if (torrent->isDownloading())
-            ++torrentStatusReport.nbDownloading;
+            ++m_torrentStatusReport.nbDownloading;
         if (torrent->isUploading())
-            ++torrentStatusReport.nbSeeding;
+            ++m_torrentStatusReport.nbSeeding;
         if (torrent->isCompleted())
-            ++torrentStatusReport.nbCompleted;
+            ++m_torrentStatusReport.nbCompleted;
         if (torrent->isPaused())
-            ++torrentStatusReport.nbPaused;
+            ++m_torrentStatusReport.nbPaused;
         if (torrent->isResumed())
-            ++torrentStatusReport.nbResumed;
+            ++m_torrentStatusReport.nbResumed;
         if (torrent->isActive())
-            ++torrentStatusReport.nbActive;
+            ++m_torrentStatusReport.nbActive;
         if (torrent->isInactive())
-            ++torrentStatusReport.nbInactive;
+            ++m_torrentStatusReport.nbInactive;
     }
 
-    emit torrentsUpdated(torrentStatusReport);
+    emit torrentsUpdated();
 }
 
 bool readFile(const QString &path, QByteArray &buf)

--- a/src/core/bittorrent/session.h
+++ b/src/core/bittorrent/session.h
@@ -127,15 +127,13 @@ namespace BitTorrent
 
     struct TorrentStatusReport
     {
-        uint nbDownloading;
-        uint nbSeeding;
-        uint nbCompleted;
-        uint nbActive;
-        uint nbInactive;
-        uint nbPaused;
-        uint nbResumed;
-
-        TorrentStatusReport();
+        uint nbDownloading = 0;
+        uint nbSeeding = 0;
+        uint nbCompleted = 0;
+        uint nbActive = 0;
+        uint nbInactive = 0;
+        uint nbPaused = 0;
+        uint nbResumed = 0;
     };
 
     class Session : public QObject
@@ -161,6 +159,7 @@ namespace BitTorrent
 
         TorrentHandle *findTorrent(const InfoHash &hash) const;
         QHash<InfoHash, TorrentHandle *> torrents() const;
+        TorrentStatusReport torrentStatusReport() const;
         bool hasActiveTorrents() const;
         bool hasUnfinishedTorrents() const;
         SessionStatus status() const;
@@ -214,11 +213,10 @@ namespace BitTorrent
         void handleTorrentTrackerAuthenticationRequired(TorrentHandle *const torrent, const QString &trackerUrl);
 
     signals:
-        void torrentsUpdated(const BitTorrent::TorrentStatusReport &torrentStatusReport = BitTorrent::TorrentStatusReport());
+        void torrentsUpdated();
         void addTorrentFailed(const QString &error);
         void torrentAdded(BitTorrent::TorrentHandle *const torrent);
         void torrentAboutToBeRemoved(BitTorrent::TorrentHandle *const torrent);
-        void torrentStatusUpdated(BitTorrent::TorrentHandle *const torrent);
         void torrentPaused(BitTorrent::TorrentHandle *const torrent);
         void torrentResumed(BitTorrent::TorrentHandle *const torrent);
         void torrentFinished(BitTorrent::TorrentHandle *const torrent);
@@ -361,6 +359,7 @@ namespace BitTorrent
         QHash<InfoHash, TorrentHandle *> m_torrents;
         QHash<InfoHash, AddTorrentData> m_addingTorrents;
         QHash<QString, AddTorrentParams> m_downloadedTorrents;
+        TorrentStatusReport m_torrentStatusReport;
 
         QMutex m_alertsMutex;
         QWaitCondition m_alertsWaitCondition;

--- a/src/gui/torrentmodel.cpp
+++ b/src/gui/torrentmodel.cpp
@@ -67,7 +67,7 @@ TorrentModel::TorrentModel(QObject *parent)
     // Listen for torrent changes
     connect(BitTorrent::Session::instance(), SIGNAL(torrentAdded(BitTorrent::TorrentHandle *const)), SLOT(addTorrent(BitTorrent::TorrentHandle *const)));
     connect(BitTorrent::Session::instance(), SIGNAL(torrentAboutToBeRemoved(BitTorrent::TorrentHandle *const)), SLOT(handleTorrentAboutToBeRemoved(BitTorrent::TorrentHandle *const)));
-    connect(BitTorrent::Session::instance(), SIGNAL(torrentStatusUpdated(BitTorrent::TorrentHandle *const)), this, SLOT(handleTorrentStatusUpdated(BitTorrent::TorrentHandle *const)));
+    connect(BitTorrent::Session::instance(), SIGNAL(torrentsUpdated()), SLOT(handleTorrentsUpdated()));
 
     connect(BitTorrent::Session::instance(), SIGNAL(torrentFinished(BitTorrent::TorrentHandle *const)), SLOT(handleTorrentStatusUpdated(BitTorrent::TorrentHandle *const)));
     connect(BitTorrent::Session::instance(), SIGNAL(torrentMetadataLoaded(BitTorrent::TorrentHandle *const)), SLOT(handleTorrentStatusUpdated(BitTorrent::TorrentHandle *const)));
@@ -305,6 +305,11 @@ void TorrentModel::handleTorrentStatusUpdated(BitTorrent::TorrentHandle *const t
     const int row = m_torrents.indexOf(torrent);
     if (row >= 0)
         emit dataChanged(index(row, 0), index(row, columnCount() - 1));
+}
+
+void TorrentModel::handleTorrentsUpdated()
+{
+    emit dataChanged(index(0, 0), index(rowCount() - 1, columnCount() - 1));
 }
 
 // Static functions

--- a/src/gui/torrentmodel.h
+++ b/src/gui/torrentmodel.h
@@ -97,6 +97,7 @@ private slots:
     void addTorrent(BitTorrent::TorrentHandle *const torrent);
     void handleTorrentAboutToBeRemoved(BitTorrent::TorrentHandle *const torrent);
     void handleTorrentStatusUpdated(BitTorrent::TorrentHandle *const torrent);
+    void handleTorrentsUpdated();
 
 private:
     QList<BitTorrent::TorrentHandle *> m_torrents;

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -110,7 +110,7 @@ void FiltersBase::toggleFilter(bool checked)
 StatusFiltersWidget::StatusFiltersWidget(QWidget *parent, TransferListWidget *transferList)
     : FiltersBase(parent, transferList)
 {
-    connect(BitTorrent::Session::instance(), SIGNAL(torrentsUpdated(const BitTorrent::TorrentStatusReport &)), SLOT(updateTorrentNumbers(const BitTorrent::TorrentStatusReport &)));
+    connect(BitTorrent::Session::instance(), SIGNAL(torrentsUpdated()), SLOT(updateTorrentNumbers()));
 
     // Add status filters
     QListWidgetItem *all = new QListWidgetItem(this);
@@ -148,8 +148,10 @@ StatusFiltersWidget::~StatusFiltersWidget()
     Preferences::instance()->setTransSelFilter(currentRow());
 }
 
-void StatusFiltersWidget::updateTorrentNumbers(const BitTorrent::TorrentStatusReport &report)
+void StatusFiltersWidget::updateTorrentNumbers()
 {
+    auto report = BitTorrent::Session::instance()->torrentStatusReport();
+
     item(TorrentFilter::All)->setData(Qt::DisplayRole, QVariant(tr("All (%1)").arg(report.nbActive + report.nbInactive)));
     item(TorrentFilter::Downloading)->setData(Qt::DisplayRole, QVariant(tr("Downloading (%1)").arg(report.nbDownloading)));
     item(TorrentFilter::Seeding)->setData(Qt::DisplayRole, QVariant(tr("Seeding (%1)").arg(report.nbSeeding)));

--- a/src/gui/transferlistfilterswidget.h
+++ b/src/gui/transferlistfilterswidget.h
@@ -45,7 +45,6 @@ namespace BitTorrent
 {
     class TorrentHandle;
     class TrackerEntry;
-    struct TorrentStatusReport;
 }
 
 class FiltersBase: public QListWidget
@@ -80,7 +79,7 @@ public:
     ~StatusFiltersWidget();
 
 private slots:
-    void updateTorrentNumbers(const BitTorrent::TorrentStatusReport &report);
+    void updateTorrentNumbers();
 
 private:
     // These 4 methods are virtual slots in the base class.


### PR DESCRIPTION
Handle data changed event for all torrents at once.

Additional changes:
    Calculate TorrentStatusReport only once per update.