### PR TITLE
Setting for creating subfolder on multifile torrents. Closes #588.

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -109,6 +109,7 @@ AddTorrentParams::AddTorrentParams()
     , sequential(false)
     , ignoreShareRatio(false)
     , skipChecking(false)
+    , createSubfolder(true)
 {
 }
 
@@ -1001,7 +1002,7 @@ bool Session::addTorrent(const TorrentInfo &torrentInfo, const AddTorrentParams 
 
 // Add a torrent to the BitTorrent session
 bool Session::addTorrent_impl(AddTorrentData addData, const MagnetUri &magnetUri,
-                              const TorrentInfo &torrentInfo, const QByteArray &fastresumeData)
+                              TorrentInfo torrentInfo, const QByteArray &fastresumeData)
 {
     libt::add_torrent_params p;
     InfoHash hash;
@@ -1014,6 +1015,11 @@ bool Session::addTorrent_impl(AddTorrentData addData, const MagnetUri &magnetUri
         hash = magnetUri.hash();
     }
     else if (torrentInfo.isValid()) {
+        if (!addData.resumed && !addData.createSubfolder && torrentInfo.filesCount() > 1) {
+            libtorrent::file_storage files = torrentInfo.files();
+            files.set_name("");
+            torrentInfo.remapFiles(files);
+        }
         // Metadata
         p.ti = torrentInfo.nativeInfo();
         hash = torrentInfo.hash();

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -121,6 +121,7 @@ namespace BitTorrent
         QVector<int> filePriorities; // used if TorrentInfo is set
         bool ignoreShareRatio;
         bool skipChecking;
+        bool createSubfolder;
 
         AddTorrentParams();
     };
@@ -288,7 +289,7 @@ namespace BitTorrent
 
         void startUpTorrents();
         bool addTorrent_impl(AddTorrentData addData, const MagnetUri &magnetUri,
-                             const TorrentInfo &torrentInfo = TorrentInfo(),
+                             TorrentInfo torrentInfo = TorrentInfo(),
                              const QByteArray &fastresumeData = QByteArray());
 
         void updateRatioTimer();

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -124,6 +124,7 @@ TorrentState::operator int() const
     return m_value;
 }
 
+    , createSubfolder(in.createSubfolder)
 // TorrentHandle
 
 #define SAFE_CALL(func, ...) \
@@ -212,6 +213,9 @@ QString TorrentHandle::name() const
     QString name = m_name;
     if (name.isEmpty())
         name = Utils::String::fromStdString(m_nativeStatus.name);
+
+    if (name.isEmpty())
+        name = Utils::String::fromStdString(m_torrentInfo.origFiles().name());
 
     if (name.isEmpty())
         name = m_hash;

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -91,6 +91,7 @@ namespace BitTorrent
         bool sequential;
         bool hasSeedStatus;
         bool skipChecking;
+        bool createSubfolder;
         TriStateBool addForced;
         TriStateBool addPaused;
         // for new torrents

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -225,10 +225,28 @@ QStringList TorrentInfo::filesForPiece(int pieceIndex) const
     return res;
 }
 
+libtorrent::file_storage TorrentInfo::files() const
+{
+    if (!isValid()) return libtorrent::file_storage();
+    return m_nativeInfo->files();
+}
+
+libtorrent::file_storage TorrentInfo::origFiles() const
+{
+    if (!isValid()) return libtorrent::file_storage();
+    return m_nativeInfo->orig_files();
+}
+
 void TorrentInfo::renameFile(uint index, const QString &newPath)
 {
     if (!isValid()) return;
     m_nativeInfo->rename_file(index, Utils::String::toStdString(newPath));
+}
+
+void TorrentInfo::remapFiles(libtorrent::file_storage const &fileStorage)
+{
+    if (!isValid()) return;
+    m_nativeInfo->remap_files(fileStorage);
 }
 
 boost::intrusive_ptr<libtorrent::torrent_info> TorrentInfo::nativeInfo() const

--- a/src/base/bittorrent/torrentinfo.h
+++ b/src/base/bittorrent/torrentinfo.h
@@ -76,8 +76,11 @@ namespace BitTorrent
         QList<QUrl> urlSeeds() const;
         QByteArray metadata() const;
         QStringList filesForPiece(int pieceIndex) const;
+        libtorrent::file_storage files() const;
+        libtorrent::file_storage origFiles() const;
 
         void renameFile(uint index, const QString &newPath);
+        void remapFiles(libtorrent::file_storage const &fileStorage);
         boost::intrusive_ptr<libtorrent::torrent_info> nativeInfo() const;
 
     private:

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -475,6 +475,16 @@ void Preferences::addTorrentsInPause(bool b)
     setValue("Preferences/Downloads/StartInPause", b);
 }
 
+bool Preferences::getTorrentCreateSubfolder() const
+{
+    return value("Preferences/Downloads/CreateSubfolder", true).toBool();
+}
+
+void Preferences::setTorrentCreateSubfolder(bool b)
+{
+    setValue("Preferences/Downloads/CreateSubfolder", b);
+}
+
 QVariantHash Preferences::getScanDirs() const
 {
     return value("Preferences/Downloads/ScanDirsV2").toHash();

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -178,6 +178,8 @@ public:
     void addTorrentsInPause(bool b);
     QVariantHash getScanDirs() const;
     void setScanDirs(const QVariantHash &dirs);
+    bool getTorrentCreateSubfolder() const;
+    void setTorrentCreateSubfolder(bool b);
     QString getScanDirsLastPath() const;
     void setScanDirsLastPath(const QString &path);
     bool isTorrentExportEnabled() const;

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -69,6 +69,7 @@ AddNewTorrentDialog::AddNewTorrentDialog(QWidget *parent)
 
     Preferences* const pref = Preferences::instance();
     ui->start_torrent_cb->setChecked(!pref->addTorrentsInPause());
+    ui->create_subfolder_cb->setChecked(pref->getTorrentCreateSubfolder());
     ui->save_path_combo->addItem(Utils::Fs::toNativePath(pref->getSavePath()), pref->getSavePath());
     loadSavePathHistory();
     connect(ui->save_path_combo, SIGNAL(currentIndexChanged(int)), SLOT(onSavePathChanged(int)));
@@ -591,9 +592,8 @@ void AddNewTorrentDialog::accept()
     Preferences *const pref = Preferences::instance();
     BitTorrent::AddTorrentParams params;
 
-    if (ui->skip_check_cb->isChecked())
-        // TODO: Check if destination actually exists
-        params.skipChecking = true;
+    // TODO: Check if destination actually exists
+    params.skipChecking = ui->skip_check_cb->isChecked();
 
     // Label
     params.label = ui->label_combo->currentText();
@@ -606,6 +606,7 @@ void AddNewTorrentDialog::accept()
         params.filePriorities = m_contentModel->model()->getFilePriorities();
 
     params.addPaused = !ui->start_torrent_cb->isChecked();
+    params.createSubfolder = ui->create_subfolder_cb->isChecked();
 
     saveSavePathHistory();
     pref->useAdditionDialog(!ui->never_show_cb->isChecked());

--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -89,16 +89,6 @@
       <string>Torrent settings</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3" columnstretch="1,1">
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="start_torrent_cb">
-        <property name="text">
-         <string>Start torrent</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="1">
        <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">
         <item row="0" column="0">
@@ -131,6 +121,26 @@
        <widget class="QCheckBox" name="defaultLabel">
         <property name="text">
          <string>Set as default label</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="start_torrent_cb">
+        <property name="text">
+         <string>Start torrent</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="create_subfolder_cb">
+        <property name="text">
+         <string>Create subfolder</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
         </property>
        </widget>
       </item>

--- a/src/gui/options.ui
+++ b/src/gui/options.ui
@@ -521,7 +521,7 @@
              <x>0</x>
              <y>0</y>
              <width>454</width>
-             <height>942</height>
+             <height>890</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout">
@@ -567,6 +567,16 @@
                    </widget>
                   </item>
                  </layout>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QCheckBox" name="checkCreateSubfolder">
+                 <property name="text">
+                  <string>Create subfolder for torrents with multiple files</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
                 </widget>
                </item>
               </layout>

--- a/src/gui/options_imp.cpp
+++ b/src/gui/options_imp.cpp
@@ -165,6 +165,7 @@ options_imp::options_imp(QWidget *parent)
     connect(checkAdditionDialog, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
     connect(checkAdditionDialogFront, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
     connect(checkStartPaused, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(checkCreateSubfolder, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
     connect(checkExportDir, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
     connect(checkExportDirFin, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
     connect(textExportDir, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
@@ -419,6 +420,7 @@ void options_imp::saveOptions()
     pref->useAdditionDialog(useAdditionDialog());
     pref->additionDialogFront(checkAdditionDialogFront->isChecked());
     pref->addTorrentsInPause(addTorrentsInPause());
+    pref->setTorrentCreateSubfolder(checkCreateSubfolder->isChecked());
     ScanFoldersModel::instance()->removeFromFSWatcher(removedScanDirs);
     ScanFoldersModel::instance()->addToFSWatcher(addedScanDirs);
     ScanFoldersModel::instance()->makePersistent();
@@ -587,6 +589,7 @@ void options_imp::loadOptions()
     checkAdditionDialog->setChecked(pref->useAdditionDialog());
     checkAdditionDialogFront->setChecked(pref->additionDialogFront());
     checkStartPaused->setChecked(pref->addTorrentsInPause());
+    checkCreateSubfolder->setChecked(pref->getTorrentCreateSubfolder());
 
     textSavePath->setText(Utils::Fs::toNativePath(pref->getSavePath()));
     if (pref->isTempPathEnabled())

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -314,8 +314,11 @@ void PropertiesWidget::loadTorrentInfos(BitTorrent::TorrentHandle *const torrent
       label_created_by_val->setText(m_torrent->creator());
 
       // List files in torrent
-      PropListModel->model()->setupModelData(m_torrent->info());
-      filesList->setExpanded(PropListModel->index(0, 0), true);
+      BitTorrent::TorrentInfo info = m_torrent->info();
+      libtorrent::file_storage files = info.files();
+      PropListModel->model()->setupModelData(info);
+      if (!(info.filesCount() > 1 && files.name().empty()))
+          filesList->setExpanded(PropListModel->index(0, 0), true);
 
       // Load file priorities
       PropListModel->model()->updateFilesPriorities(m_torrent->filePriorities());


### PR DESCRIPTION
I tried different implementations. It took me ~5 hours hacking this, so I may be tired and not be able to understand how to solved 2 remaining issues.
1. If you rename the "root item" in the "Add New Torrent" dialog and uncheck "Create subfolder", it will create the subfolder with the renamed name.
2. `propertieswidget.cpp`: that change works when you add the torrent and click on in the transferlist. However, if you restart qbt and click on it, the first folder will be expanded. This is because `files.name()` actually returns a name and more specifically, the original one. Maybe this is a libtorrent bug.

**UPDATE:**
Importing torrents need to handle this situation somehow.

Add New torrent dialog:
![add](https://cloud.githubusercontent.com/assets/273315/11020367/5c6c3654-8626-11e5-93f4-b54c945cea2c.png)

Preferences:
![pref](https://cloud.githubusercontent.com/assets/273315/11020368/651aad58-8626-11e5-9ed0-18134876be53.png)
