### PR TITLE
Fix status string for errored torrents.

### DIFF
--- a/src/core/bittorrent/session.cpp
+++ b/src/core/bittorrent/session.cpp
@@ -122,6 +122,7 @@ TorrentStatusReport::TorrentStatusReport()
     , nbInactive(0)
     , nbPaused(0)
     , nbResumed(0)
+    , nbErrored(0)
 {
 }
 
@@ -2397,6 +2398,8 @@ void Session::handleStateUpdateAlert(libt::state_update_alert *p)
             ++torrentStatusReport.nbActive;
         if (torrent->isInactive())
             ++torrentStatusReport.nbInactive;
+        if (torrent->isErrored())
+            ++torrentStatusReport.nbErrored;
     }
 
     emit torrentsUpdated(torrentStatusReport);

--- a/src/core/bittorrent/session.h
+++ b/src/core/bittorrent/session.h
@@ -134,6 +134,7 @@ namespace BitTorrent
         uint nbInactive;
         uint nbPaused;
         uint nbResumed;
+        uint nbErrored;
 
         TorrentStatusReport();
     };

--- a/src/core/bittorrent/torrenthandle.cpp
+++ b/src/core/bittorrent/torrenthandle.cpp
@@ -80,6 +80,8 @@ QString TorrentState::toString() const
     switch (m_value) {
     case Error:
         return QLatin1String("error");
+    case MissingFiles:
+        return QLatin1String("missingFiles");
     case Uploading:
         return QLatin1String("uploading");
     case PausedUploading:
@@ -625,6 +627,7 @@ bool TorrentHandle::isDownloading() const
             || m_state == TorrentState::PausedDownloading
             || m_state == TorrentState::QueuedDownloading
             || m_state == TorrentState::ForcedDownloading
+            || m_state == TorrentState::MissingFiles
             || m_state == TorrentState::Error;
 }
 
@@ -723,7 +726,9 @@ TorrentState TorrentHandle::state() const
 void TorrentHandle::updateState()
 {
     if (isPaused()) {
-        if (hasError() || hasMissingFiles())
+        if (hasMissingFiles())
+            m_state = TorrentState::MissingFiles;
+        else if (hasError())
             m_state = TorrentState::Error;
         else
             m_state = isSeed() ? TorrentState::PausedUploading : TorrentState::PausedDownloading;

--- a/src/core/bittorrent/torrenthandle.cpp
+++ b/src/core/bittorrent/torrenthandle.cpp
@@ -626,9 +626,7 @@ bool TorrentHandle::isDownloading() const
             || m_state == TorrentState::CheckingDownloading
             || m_state == TorrentState::PausedDownloading
             || m_state == TorrentState::QueuedDownloading
-            || m_state == TorrentState::ForcedDownloading
-            || m_state == TorrentState::MissingFiles
-            || m_state == TorrentState::Error;
+            || m_state == TorrentState::ForcedDownloading;
 }
 
 bool TorrentHandle::isUploading() const
@@ -665,6 +663,12 @@ bool TorrentHandle::isActive() const
 bool TorrentHandle::isInactive() const
 {
     return !isActive();
+}
+
+bool TorrentHandle::isErrored() const
+{
+    return m_state == TorrentState::MissingFiles
+            || m_state == TorrentState::Error;
 }
 
 bool TorrentHandle::isSeed() const

--- a/src/core/bittorrent/torrenthandle.h
+++ b/src/core/bittorrent/torrenthandle.h
@@ -139,6 +139,7 @@ namespace BitTorrent
             PausedDownloading,
             PausedUploading,
 
+            MissingFiles,
             Error
         };
 

--- a/src/core/bittorrent/torrenthandle.h
+++ b/src/core/bittorrent/torrenthandle.h
@@ -252,6 +252,7 @@ namespace BitTorrent
         bool isCompleted() const;
         bool isActive() const;
         bool isInactive() const;
+        bool isErrored() const;
         bool isSequentialDownload() const;
         bool hasFirstLastPiecePriority() const;
         TorrentState state() const;

--- a/src/core/torrentfilter.cpp
+++ b/src/core/torrentfilter.cpp
@@ -39,6 +39,7 @@ const TorrentFilter TorrentFilter::PausedTorrent(TorrentFilter::Paused);
 const TorrentFilter TorrentFilter::ResumedTorrent(TorrentFilter::Resumed);
 const TorrentFilter TorrentFilter::ActiveTorrent(TorrentFilter::Active);
 const TorrentFilter TorrentFilter::InactiveTorrent(TorrentFilter::Inactive);
+const TorrentFilter TorrentFilter::ErroredTorrent(TorrentFilter::Errored);
 
 using BitTorrent::TorrentHandle;
 using BitTorrent::TorrentState;
@@ -91,6 +92,8 @@ bool TorrentFilter::setTypeByName(const QString &filter)
         type = Active;
     else if (filter == "inactive")
         type = Inactive;
+    else if (filter == "errored")
+        type = Errored;
 
     return setType(type);
 }
@@ -144,6 +147,8 @@ bool TorrentFilter::matchState(BitTorrent::TorrentHandle *const torrent) const
         return torrent->isActive();
     case Inactive:
         return torrent->isInactive();
+    case Errored:
+        return torrent->isErrored();
     default: // All
         return true;
     }

--- a/src/core/torrentfilter.h
+++ b/src/core/torrentfilter.h
@@ -54,7 +54,8 @@ public:
         Resumed,
         Paused,
         Active,
-        Inactive
+        Inactive,
+        Errored
     };
 
     static const QString AnyLabel;
@@ -67,6 +68,7 @@ public:
     static const TorrentFilter ResumedTorrent;
     static const TorrentFilter ActiveTorrent;
     static const TorrentFilter InactiveTorrent;
+    static const TorrentFilter ErroredTorrent;
 
     TorrentFilter();
     // label: pass empty string for "no label" or null string (QString()) for "any label"

--- a/src/gui/torrentmodel.cpp
+++ b/src/gui/torrentmodel.cpp
@@ -337,6 +337,7 @@ QIcon getIconByState(BitTorrent::TorrentState state)
     case BitTorrent::TorrentState::CheckingResumeData:
         return getCheckingIcon();
     case BitTorrent::TorrentState::Unknown:
+    case BitTorrent::TorrentState::MissingFiles:
     case BitTorrent::TorrentState::Error:
         return getErrorIcon();
     default:
@@ -379,6 +380,7 @@ QColor getColorByState(BitTorrent::TorrentState state)
         else
             return QColor(79, 148, 205); // Steel Blue 3
     case BitTorrent::TorrentState::Error:
+    case BitTorrent::TorrentState::MissingFiles:
         return QColor(255, 0, 0); // red
     case BitTorrent::TorrentState::QueuedDownloading:
     case BitTorrent::TorrentState::QueuedUploading:

--- a/src/gui/transferlistdelegate.cpp
+++ b/src/gui/transferlistdelegate.cpp
@@ -135,8 +135,11 @@ void TransferListDelegate::paint(QPainter * painter, const QStyleOptionViewItem 
       case BitTorrent::TorrentState::PausedUploading:
         display = tr("Completed");
         break;
+      case BitTorrent::TorrentState::MissingFiles:
+          display = tr("Missing Files");
+          break;
       case BitTorrent::TorrentState::Error:
-        display = tr("Missing Files");
+        display = tr("Errored", "torrent status, the torrent has an error");
         break;
       default:
          display = "";

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -137,6 +137,9 @@ StatusFiltersWidget::StatusFiltersWidget(QWidget *parent, TransferListWidget *tr
     QListWidgetItem *inactive = new QListWidgetItem(this);
     inactive->setData(Qt::DisplayRole, QVariant(tr("Inactive (0)")));
     inactive->setData(Qt::DecorationRole, QIcon(":/icons/skin/filterinactive.png"));
+    QListWidgetItem *errored = new QListWidgetItem(this);
+    errored->setData(Qt::DisplayRole, QVariant(tr("Errored (0)")));
+    errored->setData(Qt::DecorationRole, QIcon(":/icons/skin/error.png"));
 
     const Preferences* const pref = Preferences::instance();
     setCurrentRow(pref->getTransSelFilter(), QItemSelectionModel::SelectCurrent);
@@ -158,6 +161,7 @@ void StatusFiltersWidget::updateTorrentNumbers(const BitTorrent::TorrentStatusRe
     item(TorrentFilter::Resumed)->setData(Qt::DisplayRole, QVariant(tr("Resumed (%1)").arg(report.nbResumed)));
     item(TorrentFilter::Active)->setData(Qt::DisplayRole, QVariant(tr("Active (%1)").arg(report.nbActive)));
     item(TorrentFilter::Inactive)->setData(Qt::DisplayRole, QVariant(tr("Inactive (%1)").arg(report.nbInactive)));
+    item(TorrentFilter::Errored)->setData(Qt::DisplayRole, QVariant(tr("Errored (%1)").arg(report.nbErrored)));
 }
 
 void StatusFiltersWidget::showMenu(QPoint) {}


### PR DESCRIPTION
The first commit is important. The 2nd one, it can be postponed if @glassez absolutely doesn't want me to break his PR.

Will someone be able to mirror the changes in the WebUI? @Chocobo1 @ngosang @pmzqla 