### PR TITLE
Fix default save path for magnet. Closes #4105.

### DIFF
--- a/src/core/bittorrent/session.h
+++ b/src/core/bittorrent/session.h
@@ -321,6 +321,8 @@ namespace BitTorrent
         void dispatchAlerts(std::auto_ptr<libtorrent::alert> alertPtr);
         void getPendingAlerts(QVector<libtorrent::alert *> &out, ulong time = 0);
 
+        AddTorrentData addDataFromParams(const AddTorrentParams &params);
+
         // BitTorrent
         libtorrent::session *m_nativeSession;
 

--- a/src/core/bittorrent/torrenthandle.cpp
+++ b/src/core/bittorrent/torrenthandle.cpp
@@ -122,26 +122,6 @@ TorrentState::operator int() const
     return m_value;
 }
 
-// AddTorrentData
-
-AddTorrentData::AddTorrentData() {}
-
-AddTorrentData::AddTorrentData(const AddTorrentParams &in)
-    : resumed(false)
-    , name(in.name)
-    , label(in.label)
-    , savePath(in.savePath)
-    , disableTempPath(in.disableTempPath)
-    , sequential(in.sequential)
-    , hasSeedStatus(in.skipChecking) // do not react on 'torrent_finished_alert' when skipping
-    , skipChecking(in.skipChecking)
-    , addForced(in.addForced)
-    , addPaused(in.addPaused)
-    , filePriorities(in.filePriorities)
-    , ratioLimit(in.ignoreShareRatio ? TorrentHandle::NO_RATIO_LIMIT : TorrentHandle::USE_GLOBAL_RATIO)
-{
-}
-
 // TorrentHandle
 
 #define SAFE_CALL(func, ...) \
@@ -892,12 +872,12 @@ int TorrentHandle::leechsCount() const
 
 int TorrentHandle::totalSeedsCount() const
 {
-	return m_nativeStatus.list_seeds;
+    return m_nativeStatus.list_seeds;
 }
 
 int TorrentHandle::totalPeersCount() const
 {
-	return m_nativeStatus.list_peers;
+    return m_nativeStatus.list_peers;
 }
 
 int TorrentHandle::totalLeechersCount() const

--- a/src/core/bittorrent/torrenthandle.h
+++ b/src/core/bittorrent/torrenthandle.h
@@ -97,9 +97,6 @@ namespace BitTorrent
         QVector<int> filePriorities;
         // for resumed torrents
         qreal ratioLimit;
-
-        AddTorrentData();
-        AddTorrentData(const AddTorrentParams &in);
     };
 
     struct TrackerInfo


### PR DESCRIPTION
Hopefully this will be the last **torrent save path** fix.