### PR TITLE
Group settings in advanced settings table

### DIFF
--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -150,42 +150,6 @@ void AdvancedSettings::saveAdvancedSettings()
     pref->setAnnounceToAllTrackers(cb_announce_all_trackers.isChecked());
 }
 
-void AdvancedSettings::setRow(int row, const QString &property, QSpinBox* editor)
-{
-    setItem(row, PROPERTY, new QTableWidgetItem(property));
-    bool ok; Q_UNUSED(ok);
-    ok = connect(editor, SIGNAL(valueChanged(int)), SIGNAL(settingsChanged()));
-    Q_ASSERT(ok);
-    setCellWidget(row, VALUE, editor);
-}
-
-void AdvancedSettings::setRow(int row, const QString &property, QComboBox* editor)
-{
-    setItem(row, PROPERTY, new QTableWidgetItem(property));
-    bool ok; Q_UNUSED(ok);
-    ok = connect(editor, SIGNAL(currentIndexChanged(int)), SIGNAL(settingsChanged()));
-    Q_ASSERT(ok);
-    setCellWidget(row, VALUE, editor);
-}
-
-void AdvancedSettings::setRow(int row, const QString &property, QCheckBox* editor)
-{
-    setItem(row, PROPERTY, new QTableWidgetItem(property));
-    bool ok; Q_UNUSED(ok);
-    ok = connect(editor, SIGNAL(stateChanged(int)), SIGNAL(settingsChanged()));
-    Q_ASSERT(ok);
-    setCellWidget(row, VALUE, editor);
-}
-
-void AdvancedSettings::setRow(int row, const QString &property, QLineEdit* editor)
-{
-    setItem(row, PROPERTY, new QTableWidgetItem(property));
-    bool ok; Q_UNUSED(ok);
-    ok = connect(editor, SIGNAL(textChanged(QString)), SIGNAL(settingsChanged()));
-    Q_ASSERT(ok);
-    setCellWidget(row, VALUE, editor);
-}
-
 void AdvancedSettings::updateCacheSpinSuffix(int value)
 {
     if (value <= 0)
@@ -209,55 +173,55 @@ void AdvancedSettings::loadAdvancedSettings()
 #endif
     spin_cache.setValue(pref->diskCacheSize());
     updateCacheSpinSuffix(spin_cache.value());
-    setRow(DISK_CACHE, tr("Disk write cache size"), &spin_cache);
+    addRow(DISK_CACHE, tr("Disk write cache size"), &spin_cache);
     // Disk cache expiry
     spin_cache_ttl.setMinimum(15);
     spin_cache_ttl.setMaximum(600);
     spin_cache_ttl.setValue(pref->diskCacheTTL());
     spin_cache_ttl.setSuffix(tr(" s", " seconds"));
-    setRow(DISK_CACHE_TTL, tr("Disk cache expiry interval"), &spin_cache_ttl);
+    addRow(DISK_CACHE_TTL, tr("Disk cache expiry interval"), &spin_cache_ttl);
     // Enable OS cache
     cb_os_cache.setChecked(pref->osCache());
-    setRow(OS_CACHE, tr("Enable OS cache"), &cb_os_cache);
+    addRow(OS_CACHE, tr("Enable OS cache"), &cb_os_cache);
     // Save resume data interval
     spin_save_resume_data_interval.setMinimum(1);
     spin_save_resume_data_interval.setMaximum(1440);
     spin_save_resume_data_interval.setValue(pref->saveResumeDataInterval());
     spin_save_resume_data_interval.setSuffix(tr(" m", " minutes"));
-    setRow(SAVE_RESUME_DATA_INTERVAL, tr("Save resume data interval", "How often the fastresume file is saved."), &spin_save_resume_data_interval);
+    addRow(SAVE_RESUME_DATA_INTERVAL, tr("Save resume data interval", "How often the fastresume file is saved."), &spin_save_resume_data_interval);
     // Outgoing port Min
     outgoing_ports_min.setMinimum(0);
     outgoing_ports_min.setMaximum(65535);
     outgoing_ports_min.setValue(pref->outgoingPortsMin());
-    setRow(OUTGOING_PORT_MIN, tr("Outgoing ports (Min) [0: Disabled]"), &outgoing_ports_min);
+    addRow(OUTGOING_PORT_MIN, tr("Outgoing ports (Min) [0: Disabled]"), &outgoing_ports_min);
     // Outgoing port Min
     outgoing_ports_max.setMinimum(0);
     outgoing_ports_max.setMaximum(65535);
     outgoing_ports_max.setValue(pref->outgoingPortsMax());
-    setRow(OUTGOING_PORT_MAX, tr("Outgoing ports (Max) [0: Disabled]"), &outgoing_ports_max);
+    addRow(OUTGOING_PORT_MAX, tr("Outgoing ports (Max) [0: Disabled]"), &outgoing_ports_max);
     // Recheck completed torrents
     cb_recheck_completed.setChecked(pref->recheckTorrentsOnCompletion());
-    setRow(RECHECK_COMPLETED, tr("Recheck torrents on completion"), &cb_recheck_completed);
+    addRow(RECHECK_COMPLETED, tr("Recheck torrents on completion"), &cb_recheck_completed);
     // Transfer list refresh interval
     spin_list_refresh.setMinimum(30);
     spin_list_refresh.setMaximum(99999);
     spin_list_refresh.setValue(pref->getRefreshInterval());
     spin_list_refresh.setSuffix(tr(" ms", " milliseconds"));
-    setRow(LIST_REFRESH, tr("Transfer list refresh interval"), &spin_list_refresh);
+    addRow(LIST_REFRESH, tr("Transfer list refresh interval"), &spin_list_refresh);
     // Resolve Peer countries
     cb_resolve_countries.setChecked(pref->resolvePeerCountries());
-    setRow(RESOLVE_COUNTRIES, tr("Resolve peer countries (GeoIP)"), &cb_resolve_countries);
+    addRow(RESOLVE_COUNTRIES, tr("Resolve peer countries (GeoIP)"), &cb_resolve_countries);
     // Resolve peer hosts
     cb_resolve_hosts.setChecked(pref->resolvePeerHostNames());
-    setRow(RESOLVE_HOSTS, tr("Resolve peer host names"), &cb_resolve_hosts);
+    addRow(RESOLVE_HOSTS, tr("Resolve peer host names"), &cb_resolve_hosts);
     // Max Half Open connections
     spin_maxhalfopen.setMinimum(0);
     spin_maxhalfopen.setMaximum(99999);
     spin_maxhalfopen.setValue(pref->getMaxHalfOpenConnections());
-    setRow(MAX_HALF_OPEN, tr("Maximum number of half-open connections [0: Unlimited]"), &spin_maxhalfopen);
+    addRow(MAX_HALF_OPEN, tr("Maximum number of half-open connections [0: Unlimited]"), &spin_maxhalfopen);
     // Super seeding
     cb_super_seeding.setChecked(pref->isSuperSeedingEnabled());
-    setRow(SUPER_SEEDING, tr("Strict super seeding"), &cb_super_seeding);
+    addRow(SUPER_SEEDING, tr("Strict super seeding"), &cb_super_seeding);
     // Network interface
     combo_iface.addItem(tr("Any interface", "i.e. Any network interface"));
     const QString current_iface = pref->getNetworkInterface();
@@ -277,39 +241,57 @@ void AdvancedSettings::loadAdvancedSettings()
         combo_iface.addItem(pref->getNetworkInterfaceName(), current_iface);
         combo_iface.setCurrentIndex(i);
     }
-    setRow(NETWORK_IFACE, tr("Network Interface (requires restart)"), &combo_iface);
+    addRow(NETWORK_IFACE, tr("Network Interface (requires restart)"), &combo_iface);
     // Listen on IPv6 address
     cb_listen_ipv6.setChecked(pref->getListenIPv6());
-    setRow(NETWORK_LISTEN_IPV6, tr("Listen on IPv6 address (requires restart)"), &cb_listen_ipv6);
+    addRow(NETWORK_LISTEN_IPV6, tr("Listen on IPv6 address (requires restart)"), &cb_listen_ipv6);
     // Network address
     txt_network_address.setText(pref->getNetworkAddress());
-    setRow(NETWORK_ADDRESS, tr("IP Address to report to trackers (requires restart)"), &txt_network_address);
+    addRow(NETWORK_ADDRESS, tr("IP Address to report to trackers (requires restart)"), &txt_network_address);
     // Program notifications
     cb_program_notifications.setChecked(pref->useProgramNotification());
-    setRow(PROGRAM_NOTIFICATIONS, tr("Display program on-screen notifications"), &cb_program_notifications);
+    addRow(PROGRAM_NOTIFICATIONS, tr("Display program on-screen notifications"), &cb_program_notifications);
     // Tracker State
     cb_tracker_status.setChecked(pref->isTrackerEnabled());
-    setRow(TRACKER_STATUS, tr("Enable embedded tracker"), &cb_tracker_status);
+    addRow(TRACKER_STATUS, tr("Enable embedded tracker"), &cb_tracker_status);
     // Tracker port
     spin_tracker_port.setMinimum(1);
     spin_tracker_port.setMaximum(65535);
     spin_tracker_port.setValue(pref->getTrackerPort());
-    setRow(TRACKER_PORT, tr("Embedded tracker port"), &spin_tracker_port);
+    addRow(TRACKER_PORT, tr("Embedded tracker port"), &spin_tracker_port);
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     cb_update_check.setChecked(pref->isUpdateCheckEnabled());
-    setRow(UPDATE_CHECK, tr("Check for software updates"), &cb_update_check);
+    addRow(UPDATE_CHECK, tr("Check for software updates"), &cb_update_check);
 #endif
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
     cb_use_icon_theme.setChecked(pref->useSystemIconTheme());
-    setRow(USE_ICON_THEME, tr("Use system icon theme"), &cb_use_icon_theme);
+    addRow(USE_ICON_THEME, tr("Use system icon theme"), &cb_use_icon_theme);
 #endif
     // Torrent recheck confirmation
     cb_confirm_torrent_recheck.setChecked(pref->confirmTorrentRecheck());
-    setRow(CONFIRM_RECHECK_TORRENT, tr("Confirm torrent recheck"), &cb_confirm_torrent_recheck);
+    addRow(CONFIRM_RECHECK_TORRENT, tr("Confirm torrent recheck"), &cb_confirm_torrent_recheck);
     // Tracker exchange
     cb_enable_tracker_ext.setChecked(pref->trackerExchangeEnabled());
-    setRow(TRACKER_EXCHANGE, tr("Exchange trackers with other peers"), &cb_enable_tracker_ext);
+    addRow(TRACKER_EXCHANGE, tr("Exchange trackers with other peers"), &cb_enable_tracker_ext);
     // Announce to all trackers
     cb_announce_all_trackers.setChecked(pref->announceToAllTrackers());
-    setRow(ANNOUNCE_ALL_TRACKERS, tr("Always announce to all trackers"), &cb_announce_all_trackers);
+    addRow(ANNOUNCE_ALL_TRACKERS, tr("Always announce to all trackers"), &cb_announce_all_trackers);
+}
+
+template <typename T>
+void AdvancedSettings::addRow(int row, const QString &rowText, T* widget)
+{
+    setItem(row, PROPERTY, new QTableWidgetItem(rowText));
+    setCellWidget(row, VALUE, widget);
+
+    bool ok;
+    if (std::is_same<T, QCheckBox>::value)
+        ok = connect(widget, SIGNAL(stateChanged(int)), SIGNAL(settingsChanged()));
+    else if (std::is_same<T, QSpinBox>::value)
+        ok = connect(widget, SIGNAL(valueChanged(int)), SIGNAL(settingsChanged()));
+    else if (std::is_same<T, QComboBox>::value)
+        ok = connect(widget, SIGNAL(currentIndexChanged(int)), SIGNAL(settingsChanged()));
+    else if (std::is_same<T, QLineEdit>::value)
+        ok = connect(widget, SIGNAL(textChanged(QString)), SIGNAL(settingsChanged()));
+    Q_ASSERT(ok);
 }

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -72,21 +72,22 @@ enum AdvSettingsRows
 AdvancedSettings::AdvancedSettings(QWidget *parent)
     : QTableWidget(parent)
 {
-    // Set visual appearance
-    setEditTriggers(QAbstractItemView::NoEditTriggers);
-    setAlternatingRowColors(true);
+    // column
     setColumnCount(2);
-    QStringList header;
-    header << tr("Setting") << tr("Value", "Value set for this setting");
+    QStringList header = { tr("Setting"), tr("Value", "Value set for this setting") };
     setHorizontalHeaderLabels(header);
-    setColumnWidth(0, width() / 2);
-    horizontalHeader()->setStretchLastSection(true);
-    verticalHeader()->setVisible(false);
+    // row
     setRowCount(ROW_COUNT);
+    verticalHeader()->setVisible(false);
+    // etc.
+    setAlternatingRowColors(true);
+    setEditTriggers(QAbstractItemView::NoEditTriggers);
     // Signals
     connect(&spin_cache, SIGNAL(valueChanged(int)), SLOT(updateCacheSpinSuffix(int)));
     // Load settings
     loadAdvancedSettings();
+    resizeColumnToContents(0);
+    horizontalHeader()->setStretchLastSection(true);
 }
 
 void AdvancedSettings::saveAdvancedSettings()

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -27,6 +27,7 @@
  */
 
 #include "advancedsettings.h"
+#include <QFont>
 #include <QHeaderView>
 #include <QHostAddress>
 #include <QNetworkInterface>
@@ -35,37 +36,52 @@
 enum AdvSettingsCols
 {
     PROPERTY,
-    VALUE
+    VALUE,
+    COL_COUNT
 };
 enum AdvSettingsRows
 {
-    DISK_CACHE,
-    DISK_CACHE_TTL,
-    OS_CACHE,
-    SAVE_RESUME_DATA_INTERVAL,
-    OUTGOING_PORT_MIN,
-    OUTGOING_PORT_MAX,
-    RECHECK_COMPLETED,
-    LIST_REFRESH,
-    RESOLVE_COUNTRIES,
-    RESOLVE_HOSTS,
-    MAX_HALF_OPEN,
-    SUPER_SEEDING,
+    // qBittorrent section
+    QBITTORRENT_HEADER,
+    // network interface
     NETWORK_IFACE,
     NETWORK_LISTEN_IPV6,
-    NETWORK_ADDRESS,
-    PROGRAM_NOTIFICATIONS,
-    TRACKER_STATUS,
-    TRACKER_PORT,
+    // behavior
+    SAVE_RESUME_DATA_INTERVAL,
+    CONFIRM_RECHECK_TORRENT,
+    RECHECK_COMPLETED,
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     UPDATE_CHECK,
 #endif
+    // UI related
+    LIST_REFRESH,
+    RESOLVE_HOSTS,
+    RESOLVE_COUNTRIES,
+    PROGRAM_NOTIFICATIONS,
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
     USE_ICON_THEME,
 #endif
-    CONFIRM_RECHECK_TORRENT,
+
+    // libtorrent section
+    LIBTORRENT_HEADER,
+    // cache
+    DISK_CACHE,
+    DISK_CACHE_TTL,
+    OS_CACHE,
+    // ports
+    MAX_HALF_OPEN,
+    OUTGOING_PORT_MIN,
+    OUTGOING_PORT_MAX,
+    // embedded tracker
+    TRACKER_STATUS,
+    TRACKER_PORT,
+    // seeding
+    SUPER_SEEDING,
+    // tracker
     TRACKER_EXCHANGE,
     ANNOUNCE_ALL_TRACKERS,
+    NETWORK_ADDRESS,
+
     ROW_COUNT
 };
 
@@ -73,7 +89,7 @@ AdvancedSettings::AdvancedSettings(QWidget *parent)
     : QTableWidget(parent)
 {
     // column
-    setColumnCount(2);
+    setColumnCount(COL_COUNT);
     QStringList header = { tr("Setting"), tr("Value", "Value set for this setting") };
     setHorizontalHeaderLabels(header);
     // row
@@ -161,6 +177,18 @@ void AdvancedSettings::updateCacheSpinSuffix(int value)
 void AdvancedSettings::loadAdvancedSettings()
 {
     const Preferences* const pref = Preferences::instance();
+    // add section headers
+    QFont boldFont;
+    boldFont.setBold(true);
+    addRow(QBITTORRENT_HEADER, tr("qBittorrent Section"), &labelQbtLink);
+    item(QBITTORRENT_HEADER, PROPERTY)->setFont(boldFont);
+    labelQbtLink.setText(QString("<a href=\"%1\">%2</a>").arg("https://github.com/qbittorrent/qBittorrent/wiki/Explanation-of-Options-in-qBittorrent#Advanced").arg(tr("Open documentation")));
+    labelQbtLink.setOpenExternalLinks(true);
+
+    addRow(LIBTORRENT_HEADER, tr("libtorrent Section"), &labelLibtorrentLink);
+    item(LIBTORRENT_HEADER, PROPERTY)->setFont(boldFont);
+    labelLibtorrentLink.setText(QString("<a href=\"%1\">%2</a>").arg("http://www.libtorrent.org/reference.html").arg(tr("Open documentation")));
+    labelLibtorrentLink.setOpenExternalLinks(true);
     // Disk write cache
     spin_cache.setMinimum(0);
     // When build as 32bit binary, set the maximum at less than 2GB to prevent crashes.

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -1,0 +1,314 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2016 qBittorrent project
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "advancedsettings.h"
+#include <QHeaderView>
+#include <QHostAddress>
+#include <QNetworkInterface>
+#include "base/preferences.h"
+
+enum AdvSettingsCols
+{
+    PROPERTY,
+    VALUE
+};
+enum AdvSettingsRows
+{
+    DISK_CACHE,
+    DISK_CACHE_TTL,
+    OS_CACHE,
+    SAVE_RESUME_DATA_INTERVAL,
+    OUTGOING_PORT_MIN,
+    OUTGOING_PORT_MAX,
+    RECHECK_COMPLETED,
+    LIST_REFRESH,
+    RESOLVE_COUNTRIES,
+    RESOLVE_HOSTS,
+    MAX_HALF_OPEN,
+    SUPER_SEEDING,
+    NETWORK_IFACE,
+    NETWORK_LISTEN_IPV6,
+    NETWORK_ADDRESS,
+    PROGRAM_NOTIFICATIONS,
+    TRACKER_STATUS,
+    TRACKER_PORT,
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+    UPDATE_CHECK,
+#endif
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+    USE_ICON_THEME,
+#endif
+    CONFIRM_RECHECK_TORRENT,
+    TRACKER_EXCHANGE,
+    ANNOUNCE_ALL_TRACKERS,
+    ROW_COUNT
+};
+
+AdvancedSettings::AdvancedSettings(QWidget *parent)
+    : QTableWidget(parent)
+{
+    // Set visual appearance
+    setEditTriggers(QAbstractItemView::NoEditTriggers);
+    setAlternatingRowColors(true);
+    setColumnCount(2);
+    QStringList header;
+    header << tr("Setting") << tr("Value", "Value set for this setting");
+    setHorizontalHeaderLabels(header);
+    setColumnWidth(0, width() / 2);
+    horizontalHeader()->setStretchLastSection(true);
+    verticalHeader()->setVisible(false);
+    setRowCount(ROW_COUNT);
+    // Signals
+    connect(&spin_cache, SIGNAL(valueChanged(int)), SLOT(updateCacheSpinSuffix(int)));
+    // Load settings
+    loadAdvancedSettings();
+}
+
+void AdvancedSettings::saveAdvancedSettings()
+{
+    Preferences* const pref = Preferences::instance();
+    // Disk write cache
+    pref->setDiskCacheSize(spin_cache.value());
+    pref->setDiskCacheTTL(spin_cache_ttl.value());
+    // Enable OS cache
+    pref->setOsCache(cb_os_cache.isChecked());
+    // Save resume data interval
+    pref->setSaveResumeDataInterval(spin_save_resume_data_interval.value());
+    // Outgoing ports
+    pref->setOutgoingPortsMin(outgoing_ports_min.value());
+    pref->setOutgoingPortsMax(outgoing_ports_max.value());
+    // Recheck torrents on completion
+    pref->recheckTorrentsOnCompletion(cb_recheck_completed.isChecked());
+    // Transfer list refresh interval
+    pref->setRefreshInterval(spin_list_refresh.value());
+    // Peer resolution
+    pref->resolvePeerCountries(cb_resolve_countries.isChecked());
+    pref->resolvePeerHostNames(cb_resolve_hosts.isChecked());
+    // Max Half-Open connections
+    pref->setMaxHalfOpenConnections(spin_maxhalfopen.value());
+    // Super seeding
+    pref->enableSuperSeeding(cb_super_seeding.isChecked());
+    // Network interface
+    if (combo_iface.currentIndex() == 0) {
+        // All interfaces (default)
+        pref->setNetworkInterface(QString::null);
+        pref->setNetworkInterfaceName(QString::null);
+    }
+    else {
+        pref->setNetworkInterface(combo_iface.itemData(combo_iface.currentIndex()).toString());
+        pref->setNetworkInterfaceName(combo_iface.currentText());
+    }
+    // Listen on IPv6 address
+    pref->setListenIPv6(cb_listen_ipv6.isChecked());
+    // Network address
+    QHostAddress addr(txt_network_address.text().trimmed());
+    if (addr.isNull())
+        pref->setNetworkAddress("");
+    else
+        pref->setNetworkAddress(addr.toString());
+    // Program notification
+    pref->useProgramNotification(cb_program_notifications.isChecked());
+    // Tracker
+    pref->setTrackerEnabled(cb_tracker_status.isChecked());
+    pref->setTrackerPort(spin_tracker_port.value());
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+    pref->setUpdateCheckEnabled(cb_update_check.isChecked());
+#endif
+    // Icon theme
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+    pref->useSystemIconTheme(cb_use_icon_theme.isChecked());
+#endif
+    pref->setConfirmTorrentRecheck(cb_confirm_torrent_recheck.isChecked());
+    // Tracker exchange
+    pref->setTrackerExchangeEnabled(cb_enable_tracker_ext.isChecked());
+    pref->setAnnounceToAllTrackers(cb_announce_all_trackers.isChecked());
+}
+
+void AdvancedSettings::setRow(int row, const QString &property, QSpinBox* editor)
+{
+    setItem(row, PROPERTY, new QTableWidgetItem(property));
+    bool ok; Q_UNUSED(ok);
+    ok = connect(editor, SIGNAL(valueChanged(int)), SIGNAL(settingsChanged()));
+    Q_ASSERT(ok);
+    setCellWidget(row, VALUE, editor);
+}
+
+void AdvancedSettings::setRow(int row, const QString &property, QComboBox* editor)
+{
+    setItem(row, PROPERTY, new QTableWidgetItem(property));
+    bool ok; Q_UNUSED(ok);
+    ok = connect(editor, SIGNAL(currentIndexChanged(int)), SIGNAL(settingsChanged()));
+    Q_ASSERT(ok);
+    setCellWidget(row, VALUE, editor);
+}
+
+void AdvancedSettings::setRow(int row, const QString &property, QCheckBox* editor)
+{
+    setItem(row, PROPERTY, new QTableWidgetItem(property));
+    bool ok; Q_UNUSED(ok);
+    ok = connect(editor, SIGNAL(stateChanged(int)), SIGNAL(settingsChanged()));
+    Q_ASSERT(ok);
+    setCellWidget(row, VALUE, editor);
+}
+
+void AdvancedSettings::setRow(int row, const QString &property, QLineEdit* editor)
+{
+    setItem(row, PROPERTY, new QTableWidgetItem(property));
+    bool ok; Q_UNUSED(ok);
+    ok = connect(editor, SIGNAL(textChanged(QString)), SIGNAL(settingsChanged()));
+    Q_ASSERT(ok);
+    setCellWidget(row, VALUE, editor);
+}
+
+void AdvancedSettings::updateCacheSpinSuffix(int value)
+{
+    if (value <= 0)
+        spin_cache.setSuffix(tr(" (auto)"));
+    else
+        spin_cache.setSuffix(tr(" MiB"));
+}
+
+void AdvancedSettings::loadAdvancedSettings()
+{
+    const Preferences* const pref = Preferences::instance();
+    // Disk write cache
+    spin_cache.setMinimum(0);
+    // When build as 32bit binary, set the maximum at less than 2GB to prevent crashes.
+    // These macros may not be available on compilers other than MSVC and GCC
+#if defined(__x86_64__) || defined(_M_X64)
+    spin_cache.setMaximum(4096);
+#else
+    // allocate 1536MiB and leave 512MiB to the rest of program data in RAM
+    spin_cache.setMaximum(1536);
+#endif
+    spin_cache.setValue(pref->diskCacheSize());
+    updateCacheSpinSuffix(spin_cache.value());
+    setRow(DISK_CACHE, tr("Disk write cache size"), &spin_cache);
+    // Disk cache expiry
+    spin_cache_ttl.setMinimum(15);
+    spin_cache_ttl.setMaximum(600);
+    spin_cache_ttl.setValue(pref->diskCacheTTL());
+    spin_cache_ttl.setSuffix(tr(" s", " seconds"));
+    setRow(DISK_CACHE_TTL, tr("Disk cache expiry interval"), &spin_cache_ttl);
+    // Enable OS cache
+    cb_os_cache.setChecked(pref->osCache());
+    setRow(OS_CACHE, tr("Enable OS cache"), &cb_os_cache);
+    // Save resume data interval
+    spin_save_resume_data_interval.setMinimum(1);
+    spin_save_resume_data_interval.setMaximum(1440);
+    spin_save_resume_data_interval.setValue(pref->saveResumeDataInterval());
+    spin_save_resume_data_interval.setSuffix(tr(" m", " minutes"));
+    setRow(SAVE_RESUME_DATA_INTERVAL, tr("Save resume data interval", "How often the fastresume file is saved."), &spin_save_resume_data_interval);
+    // Outgoing port Min
+    outgoing_ports_min.setMinimum(0);
+    outgoing_ports_min.setMaximum(65535);
+    outgoing_ports_min.setValue(pref->outgoingPortsMin());
+    setRow(OUTGOING_PORT_MIN, tr("Outgoing ports (Min) [0: Disabled]"), &outgoing_ports_min);
+    // Outgoing port Min
+    outgoing_ports_max.setMinimum(0);
+    outgoing_ports_max.setMaximum(65535);
+    outgoing_ports_max.setValue(pref->outgoingPortsMax());
+    setRow(OUTGOING_PORT_MAX, tr("Outgoing ports (Max) [0: Disabled]"), &outgoing_ports_max);
+    // Recheck completed torrents
+    cb_recheck_completed.setChecked(pref->recheckTorrentsOnCompletion());
+    setRow(RECHECK_COMPLETED, tr("Recheck torrents on completion"), &cb_recheck_completed);
+    // Transfer list refresh interval
+    spin_list_refresh.setMinimum(30);
+    spin_list_refresh.setMaximum(99999);
+    spin_list_refresh.setValue(pref->getRefreshInterval());
+    spin_list_refresh.setSuffix(tr(" ms", " milliseconds"));
+    setRow(LIST_REFRESH, tr("Transfer list refresh interval"), &spin_list_refresh);
+    // Resolve Peer countries
+    cb_resolve_countries.setChecked(pref->resolvePeerCountries());
+    setRow(RESOLVE_COUNTRIES, tr("Resolve peer countries (GeoIP)"), &cb_resolve_countries);
+    // Resolve peer hosts
+    cb_resolve_hosts.setChecked(pref->resolvePeerHostNames());
+    setRow(RESOLVE_HOSTS, tr("Resolve peer host names"), &cb_resolve_hosts);
+    // Max Half Open connections
+    spin_maxhalfopen.setMinimum(0);
+    spin_maxhalfopen.setMaximum(99999);
+    spin_maxhalfopen.setValue(pref->getMaxHalfOpenConnections());
+    setRow(MAX_HALF_OPEN, tr("Maximum number of half-open connections [0: Unlimited]"), &spin_maxhalfopen);
+    // Super seeding
+    cb_super_seeding.setChecked(pref->isSuperSeedingEnabled());
+    setRow(SUPER_SEEDING, tr("Strict super seeding"), &cb_super_seeding);
+    // Network interface
+    combo_iface.addItem(tr("Any interface", "i.e. Any network interface"));
+    const QString current_iface = pref->getNetworkInterface();
+    bool interface_exists = current_iface.isEmpty();
+    int i = 1;
+    foreach (const QNetworkInterface& iface, QNetworkInterface::allInterfaces()) {
+        if (iface.flags() & QNetworkInterface::IsLoopBack) continue;
+        combo_iface.addItem(iface.humanReadableName(), iface.name());
+        if (!current_iface.isEmpty() && (iface.name() == current_iface)) {
+            combo_iface.setCurrentIndex(i);
+            interface_exists = true;
+        }
+        ++i;
+    }
+    // Saved interface does not exist, show it anyway
+    if (!interface_exists) {
+        combo_iface.addItem(pref->getNetworkInterfaceName(), current_iface);
+        combo_iface.setCurrentIndex(i);
+    }
+    setRow(NETWORK_IFACE, tr("Network Interface (requires restart)"), &combo_iface);
+    // Listen on IPv6 address
+    cb_listen_ipv6.setChecked(pref->getListenIPv6());
+    setRow(NETWORK_LISTEN_IPV6, tr("Listen on IPv6 address (requires restart)"), &cb_listen_ipv6);
+    // Network address
+    txt_network_address.setText(pref->getNetworkAddress());
+    setRow(NETWORK_ADDRESS, tr("IP Address to report to trackers (requires restart)"), &txt_network_address);
+    // Program notifications
+    cb_program_notifications.setChecked(pref->useProgramNotification());
+    setRow(PROGRAM_NOTIFICATIONS, tr("Display program on-screen notifications"), &cb_program_notifications);
+    // Tracker State
+    cb_tracker_status.setChecked(pref->isTrackerEnabled());
+    setRow(TRACKER_STATUS, tr("Enable embedded tracker"), &cb_tracker_status);
+    // Tracker port
+    spin_tracker_port.setMinimum(1);
+    spin_tracker_port.setMaximum(65535);
+    spin_tracker_port.setValue(pref->getTrackerPort());
+    setRow(TRACKER_PORT, tr("Embedded tracker port"), &spin_tracker_port);
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+    cb_update_check.setChecked(pref->isUpdateCheckEnabled());
+    setRow(UPDATE_CHECK, tr("Check for software updates"), &cb_update_check);
+#endif
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+    cb_use_icon_theme.setChecked(pref->useSystemIconTheme());
+    setRow(USE_ICON_THEME, tr("Use system icon theme"), &cb_use_icon_theme);
+#endif
+    // Torrent recheck confirmation
+    cb_confirm_torrent_recheck.setChecked(pref->confirmTorrentRecheck());
+    setRow(CONFIRM_RECHECK_TORRENT, tr("Confirm torrent recheck"), &cb_confirm_torrent_recheck);
+    // Tracker exchange
+    cb_enable_tracker_ext.setChecked(pref->trackerExchangeEnabled());
+    setRow(TRACKER_EXCHANGE, tr("Exchange trackers with other peers"), &cb_enable_tracker_ext);
+    // Announce to all trackers
+    cb_announce_all_trackers.setChecked(pref->announceToAllTrackers());
+    setRow(ANNOUNCE_ALL_TRACKERS, tr("Always announce to all trackers"), &cb_announce_all_trackers);
+}

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -29,6 +29,7 @@
 #ifndef ADVANCEDSETTINGS_H
 #define ADVANCEDSETTINGS_H
 
+#include <QLabel>
 #include <QSpinBox>
 #include <QCheckBox>
 #include <QLineEdit>
@@ -56,6 +57,7 @@ private:
     void loadAdvancedSettings();
     template <typename T> void addRow(int row, const QString &rowText, T* widget);
 
+    QLabel labelQbtLink, labelLibtorrentLink;
     QSpinBox spin_cache, spin_save_resume_data_interval, outgoing_ports_min, outgoing_ports_max, spin_list_refresh, spin_maxhalfopen, spin_tracker_port, spin_cache_ttl;
     QCheckBox cb_os_cache, cb_recheck_completed, cb_resolve_countries, cb_resolve_hosts,
               cb_super_seeding, cb_program_notifications, cb_tracker_status,

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -1,3 +1,31 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2015
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
 #ifndef ADVANCEDSETTINGS_H
 #define ADVANCEDSETTINGS_H
 

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -54,10 +54,7 @@ private slots:
 
 private:
     void loadAdvancedSettings();
-    void setRow(int row, const QString &property, QSpinBox* editor);
-    void setRow(int row, const QString &property, QComboBox* editor);
-    void setRow(int row, const QString &property, QCheckBox* editor);
-    void setRow(int row, const QString &property, QLineEdit* editor);
+    template <typename T> void addRow(int row, const QString &rowText, T* widget);
 
     QSpinBox spin_cache, spin_save_resume_data_interval, outgoing_ports_min, outgoing_ports_max, spin_list_refresh, spin_maxhalfopen, spin_tracker_port, spin_cache_ttl;
     QCheckBox cb_os_cache, cb_recheck_completed, cb_resolve_countries, cb_resolve_hosts,

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -29,325 +29,51 @@
 #ifndef ADVANCEDSETTINGS_H
 #define ADVANCEDSETTINGS_H
 
-#include <QTableWidget>
-#include <QHeaderView>
 #include <QSpinBox>
-#include <QHostAddress>
 #include <QCheckBox>
 #include <QLineEdit>
 #include <QComboBox>
-#include <QNetworkInterface>
+#include <QTableWidget>
 
-#include "base/preferences.h"
-
-enum AdvSettingsCols
-{
-    PROPERTY,
-    VALUE
-};
-enum AdvSettingsRows
-{
-    DISK_CACHE,
-    DISK_CACHE_TTL,
-    OS_CACHE,
-    SAVE_RESUME_DATA_INTERVAL,
-    OUTGOING_PORT_MIN,
-    OUTGOING_PORT_MAX,
-    RECHECK_COMPLETED,
-    LIST_REFRESH,
-    RESOLVE_COUNTRIES,
-    RESOLVE_HOSTS,
-    MAX_HALF_OPEN,
-    SUPER_SEEDING,
-    NETWORK_IFACE,
-    NETWORK_LISTEN_IPV6,
-    NETWORK_ADDRESS,
-    PROGRAM_NOTIFICATIONS,
-    TRACKER_STATUS,
-    TRACKER_PORT,
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
-    UPDATE_CHECK,
-#endif
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
-    USE_ICON_THEME,
-#endif
-    CONFIRM_RECHECK_TORRENT,
-    TRACKER_EXCHANGE,
-    ANNOUNCE_ALL_TRACKERS,
-    ROW_COUNT
-};
 
 class AdvancedSettings: public QTableWidget
 {
     Q_OBJECT
 
-private:
-    QSpinBox spin_cache, spin_save_resume_data_interval, outgoing_ports_min, outgoing_ports_max, spin_list_refresh, spin_maxhalfopen, spin_tracker_port;
-    QCheckBox cb_os_cache, cb_recheck_completed, cb_resolve_countries, cb_resolve_hosts,
-              cb_super_seeding, cb_program_notifications, cb_tracker_status,
-              cb_confirm_torrent_recheck, cb_enable_tracker_ext, cb_listen_ipv6;
-    QComboBox combo_iface;
-    QSpinBox spin_cache_ttl;
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
-    QCheckBox cb_update_check;
-#endif
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
-    QCheckBox cb_use_icon_theme;
-#endif
-    QCheckBox cb_announce_all_trackers;
-    QLineEdit txt_network_address;
-
 public:
-    AdvancedSettings(QWidget *parent=0): QTableWidget(parent)
-    {
-        // Set visual appearance
-        setEditTriggers(QAbstractItemView::NoEditTriggers);
-        setAlternatingRowColors(true);
-        setColumnCount(2);
-        QStringList header;
-        header << tr("Setting") << tr("Value", "Value set for this setting");
-        setHorizontalHeaderLabels(header);
-        setColumnWidth(0, width()/2);
-        horizontalHeader()->setStretchLastSection(true);
-        verticalHeader()->setVisible(false);
-        setRowCount(ROW_COUNT);
-        // Signals
-        connect(&spin_cache, SIGNAL(valueChanged(int)), SLOT(updateCacheSpinSuffix(int)));
-        // Load settings
-        loadAdvancedSettings();
-    }
-
-    ~AdvancedSettings() {}
+    AdvancedSettings(QWidget *parent = 0);
 
 public slots:
-    void saveAdvancedSettings()
-    {
-        Preferences* const pref = Preferences::instance();
-        // Disk write cache
-        pref->setDiskCacheSize(spin_cache.value());
-        pref->setDiskCacheTTL(spin_cache_ttl.value());
-        // Enable OS cache
-        pref->setOsCache(cb_os_cache.isChecked());
-        // Save resume data interval
-        pref->setSaveResumeDataInterval(spin_save_resume_data_interval.value());
-        // Outgoing ports
-        pref->setOutgoingPortsMin(outgoing_ports_min.value());
-        pref->setOutgoingPortsMax(outgoing_ports_max.value());
-        // Recheck torrents on completion
-        pref->recheckTorrentsOnCompletion(cb_recheck_completed.isChecked());
-        // Transfer list refresh interval
-        pref->setRefreshInterval(spin_list_refresh.value());
-        // Peer resolution
-        pref->resolvePeerCountries(cb_resolve_countries.isChecked());
-        pref->resolvePeerHostNames(cb_resolve_hosts.isChecked());
-        // Max Half-Open connections
-        pref->setMaxHalfOpenConnections(spin_maxhalfopen.value());
-        // Super seeding
-        pref->enableSuperSeeding(cb_super_seeding.isChecked());
-        // Network interface
-        if (combo_iface.currentIndex() == 0) {
-            // All interfaces (default)
-            pref->setNetworkInterface(QString::null);
-            pref->setNetworkInterfaceName(QString::null);
-        }
-        else {
-            pref->setNetworkInterface(combo_iface.itemData(combo_iface.currentIndex()).toString());
-            pref->setNetworkInterfaceName(combo_iface.currentText());
-        }
-        // Listen on IPv6 address
-        pref->setListenIPv6(cb_listen_ipv6.isChecked());
-        // Network address
-        QHostAddress addr(txt_network_address.text().trimmed());
-        if (addr.isNull())
-            pref->setNetworkAddress("");
-        else
-            pref->setNetworkAddress(addr.toString());
-        // Program notification
-        pref->useProgramNotification(cb_program_notifications.isChecked());
-        // Tracker
-        pref->setTrackerEnabled(cb_tracker_status.isChecked());
-        pref->setTrackerPort(spin_tracker_port.value());
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
-        pref->setUpdateCheckEnabled(cb_update_check.isChecked());
-#endif
-        // Icon theme
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
-        pref->useSystemIconTheme(cb_use_icon_theme.isChecked());
-#endif
-        pref->setConfirmTorrentRecheck(cb_confirm_torrent_recheck.isChecked());
-        // Tracker exchange
-        pref->setTrackerExchangeEnabled(cb_enable_tracker_ext.isChecked());
-        pref->setAnnounceToAllTrackers(cb_announce_all_trackers.isChecked());
-    }
+    void saveAdvancedSettings();
 
 signals:
     void settingsChanged();
 
-private:
-    void setRow(int row, const QString &property, QSpinBox* editor)
-    {
-        setItem(row, PROPERTY, new QTableWidgetItem(property));
-        bool ok; Q_UNUSED(ok);
-        ok = connect(editor, SIGNAL(valueChanged(int)), SIGNAL(settingsChanged()));
-        Q_ASSERT(ok);
-        setCellWidget(row, VALUE, editor);
-    }
-
-    void setRow(int row, const QString &property, QComboBox* editor)
-    {
-        setItem(row, PROPERTY, new QTableWidgetItem(property));
-        bool ok; Q_UNUSED(ok);
-        ok = connect(editor, SIGNAL(currentIndexChanged(int)), SIGNAL(settingsChanged()));
-        Q_ASSERT(ok);
-        setCellWidget(row, VALUE, editor);
-    }
-
-    void setRow(int row, const QString &property, QCheckBox* editor)
-    {
-        setItem(row, PROPERTY, new QTableWidgetItem(property));
-        bool ok; Q_UNUSED(ok);
-        ok = connect(editor, SIGNAL(stateChanged(int)), SIGNAL(settingsChanged()));
-        Q_ASSERT(ok);
-        setCellWidget(row, VALUE, editor);
-    }
-
-    void setRow(int row, const QString &property, QLineEdit* editor)
-    {
-        setItem(row, PROPERTY, new QTableWidgetItem(property));
-        bool ok; Q_UNUSED(ok);
-        ok = connect(editor, SIGNAL(textChanged(QString)), SIGNAL(settingsChanged()));
-        Q_ASSERT(ok);
-        setCellWidget(row, VALUE, editor);
-    }
-
 private slots:
-    void updateCacheSpinSuffix(int value)
-    {
-        if (value <= 0)
-            spin_cache.setSuffix(tr(" (auto)"));
-        else
-            spin_cache.setSuffix(tr(" MiB"));
-    }
+    void updateCacheSpinSuffix(int value);
 
-    void loadAdvancedSettings()
-    {
-        const Preferences* const pref = Preferences::instance();
-        // Disk write cache
-        spin_cache.setMinimum(0);
-        // When build as 32bit binary, set the maximum at less than 2GB to prevent crashes.
-        // These macros may not be available on compilers other than MSVC and GCC
-#if defined(__x86_64__) || defined(_M_X64)
-        spin_cache.setMaximum(4096);
-#else
-        // allocate 1536MiB and leave 512MiB to the rest of program data in RAM
-        spin_cache.setMaximum(1536);
-#endif
-        spin_cache.setValue(pref->diskCacheSize());
-        updateCacheSpinSuffix(spin_cache.value());
-        setRow(DISK_CACHE, tr("Disk write cache size"), &spin_cache);
-        // Disk cache expiry
-        spin_cache_ttl.setMinimum(15);
-        spin_cache_ttl.setMaximum(600);
-        spin_cache_ttl.setValue(pref->diskCacheTTL());
-        spin_cache_ttl.setSuffix(tr(" s", " seconds"));
-        setRow(DISK_CACHE_TTL, tr("Disk cache expiry interval"), &spin_cache_ttl);
-        // Enable OS cache
-        cb_os_cache.setChecked(pref->osCache());
-        setRow(OS_CACHE, tr("Enable OS cache"), &cb_os_cache);
-        // Save resume data interval
-        spin_save_resume_data_interval.setMinimum(1);
-        spin_save_resume_data_interval.setMaximum(1440);
-        spin_save_resume_data_interval.setValue(pref->saveResumeDataInterval());
-        spin_save_resume_data_interval.setSuffix(tr(" m", " minutes"));
-        setRow(SAVE_RESUME_DATA_INTERVAL, tr("Save resume data interval", "How often the fastresume file is saved."), &spin_save_resume_data_interval);
-        // Outgoing port Min
-        outgoing_ports_min.setMinimum(0);
-        outgoing_ports_min.setMaximum(65535);
-        outgoing_ports_min.setValue(pref->outgoingPortsMin());
-        setRow(OUTGOING_PORT_MIN, tr("Outgoing ports (Min) [0: Disabled]"), &outgoing_ports_min);
-        // Outgoing port Min
-        outgoing_ports_max.setMinimum(0);
-        outgoing_ports_max.setMaximum(65535);
-        outgoing_ports_max.setValue(pref->outgoingPortsMax());
-        setRow(OUTGOING_PORT_MAX, tr("Outgoing ports (Max) [0: Disabled]"), &outgoing_ports_max);
-        // Recheck completed torrents
-        cb_recheck_completed.setChecked(pref->recheckTorrentsOnCompletion());
-        setRow(RECHECK_COMPLETED, tr("Recheck torrents on completion"), &cb_recheck_completed);
-        // Transfer list refresh interval
-        spin_list_refresh.setMinimum(30);
-        spin_list_refresh.setMaximum(99999);
-        spin_list_refresh.setValue(pref->getRefreshInterval());
-        spin_list_refresh.setSuffix(tr(" ms", " milliseconds"));
-        setRow(LIST_REFRESH, tr("Transfer list refresh interval"), &spin_list_refresh);
-        // Resolve Peer countries
-        cb_resolve_countries.setChecked(pref->resolvePeerCountries());
-        setRow(RESOLVE_COUNTRIES, tr("Resolve peer countries (GeoIP)"), &cb_resolve_countries);
-        // Resolve peer hosts
-        cb_resolve_hosts.setChecked(pref->resolvePeerHostNames());
-        setRow(RESOLVE_HOSTS, tr("Resolve peer host names"), &cb_resolve_hosts);
-        // Max Half Open connections
-        spin_maxhalfopen.setMinimum(0);
-        spin_maxhalfopen.setMaximum(99999);
-        spin_maxhalfopen.setValue(pref->getMaxHalfOpenConnections());
-        setRow(MAX_HALF_OPEN, tr("Maximum number of half-open connections [0: Unlimited]"), &spin_maxhalfopen);
-        // Super seeding
-        cb_super_seeding.setChecked(pref->isSuperSeedingEnabled());
-        setRow(SUPER_SEEDING, tr("Strict super seeding"), &cb_super_seeding);
-        // Network interface
-        combo_iface.addItem(tr("Any interface", "i.e. Any network interface"));
-        const QString current_iface = pref->getNetworkInterface();
-        bool interface_exists = current_iface.isEmpty();
-        int i = 1;
-        foreach (const QNetworkInterface& iface, QNetworkInterface::allInterfaces()) {
-            if (iface.flags() & QNetworkInterface::IsLoopBack) continue;
-            combo_iface.addItem(iface.humanReadableName(),iface.name());
-            if (!current_iface.isEmpty() && iface.name() == current_iface) {
-                combo_iface.setCurrentIndex(i);
-                interface_exists = true;
-            }
-            ++i;
-        }
-        // Saved interface does not exist, show it anyway
-        if (!interface_exists) {
-            combo_iface.addItem(pref->getNetworkInterfaceName(),current_iface);
-            combo_iface.setCurrentIndex(i);
-        }
-        setRow(NETWORK_IFACE, tr("Network Interface (requires restart)"), &combo_iface);
-        // Listen on IPv6 address
-        cb_listen_ipv6.setChecked(pref->getListenIPv6());
-        setRow(NETWORK_LISTEN_IPV6, tr("Listen on IPv6 address (requires restart)"), &cb_listen_ipv6);
-        // Network address
-        txt_network_address.setText(pref->getNetworkAddress());
-        setRow(NETWORK_ADDRESS, tr("IP Address to report to trackers (requires restart)"), &txt_network_address);
-        // Program notifications
-        cb_program_notifications.setChecked(pref->useProgramNotification());
-        setRow(PROGRAM_NOTIFICATIONS, tr("Display program on-screen notifications"), &cb_program_notifications);
-        // Tracker State
-        cb_tracker_status.setChecked(pref->isTrackerEnabled());
-        setRow(TRACKER_STATUS, tr("Enable embedded tracker"), &cb_tracker_status);
-        // Tracker port
-        spin_tracker_port.setMinimum(1);
-        spin_tracker_port.setMaximum(65535);
-        spin_tracker_port.setValue(pref->getTrackerPort());
-        setRow(TRACKER_PORT, tr("Embedded tracker port"), &spin_tracker_port);
+private:
+    void loadAdvancedSettings();
+    void setRow(int row, const QString &property, QSpinBox* editor);
+    void setRow(int row, const QString &property, QComboBox* editor);
+    void setRow(int row, const QString &property, QCheckBox* editor);
+    void setRow(int row, const QString &property, QLineEdit* editor);
+
+    QSpinBox spin_cache, spin_save_resume_data_interval, outgoing_ports_min, outgoing_ports_max, spin_list_refresh, spin_maxhalfopen, spin_tracker_port, spin_cache_ttl;
+    QCheckBox cb_os_cache, cb_recheck_completed, cb_resolve_countries, cb_resolve_hosts,
+              cb_super_seeding, cb_program_notifications, cb_tracker_status,
+              cb_confirm_torrent_recheck, cb_enable_tracker_ext, cb_listen_ipv6, cb_announce_all_trackers;
+    QComboBox combo_iface;
+    QLineEdit txt_network_address;
+
+    // OS dependent settings
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
-        cb_update_check.setChecked(pref->isUpdateCheckEnabled());
-        setRow(UPDATE_CHECK, tr("Check for software updates"), &cb_update_check);
+    QCheckBox cb_update_check;
 #endif
+
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
-        cb_use_icon_theme.setChecked(pref->useSystemIconTheme());
-        setRow(USE_ICON_THEME, tr("Use system icon theme"), &cb_use_icon_theme);
+    QCheckBox cb_use_icon_theme;
 #endif
-        // Torrent recheck confirmation
-        cb_confirm_torrent_recheck.setChecked(pref->confirmTorrentRecheck());
-        setRow(CONFIRM_RECHECK_TORRENT, tr("Confirm torrent recheck"), &cb_confirm_torrent_recheck);
-        // Tracker exchange
-        cb_enable_tracker_ext.setChecked(pref->trackerExchangeEnabled());
-        setRow(TRACKER_EXCHANGE, tr("Exchange trackers with other peers"), &cb_enable_tracker_ext);
-        // Announce to all trackers
-        cb_announce_all_trackers.setChecked(pref->announceToAllTrackers());
-        setRow(ANNOUNCE_ALL_TRACKERS, tr("Always announce to all trackers"), &cb_announce_all_trackers);
-    }
 };
 
 #endif // ADVANCEDSETTINGS_H

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -41,7 +41,7 @@ class AdvancedSettings: public QTableWidget
     Q_OBJECT
 
 public:
-    AdvancedSettings(QWidget *parent = 0);
+    AdvancedSettings(QWidget *parent);
 
 public slots:
     void saveAdvancedSettings();

--- a/src/gui/gui.pri
+++ b/src/gui/gui.pri
@@ -75,6 +75,7 @@ SOURCES += \
     $$PWD/statsdialog.cpp \
     $$PWD/messageboxraised.cpp \
     $$PWD/statusbar.cpp \
+    $$PWD/advancedsettings.cpp \
     $$PWD/trackerlogin.cpp \
     $$PWD/options_imp.cpp \
     $$PWD/shutdownconfirm.cpp \

--- a/src/gui/options.ui
+++ b/src/gui/options.ui
@@ -162,8 +162,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>454</width>
-             <height>610</height>
+             <width>480</width>
+             <height>672</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -520,8 +520,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>454</width>
-             <height>942</height>
+             <width>487</width>
+             <height>1040</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout">
@@ -1033,8 +1033,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>361</width>
-             <height>586</height>
+             <width>450</width>
+             <height>658</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -1563,8 +1563,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>275</width>
-             <height>401</height>
+             <width>376</width>
+             <height>444</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -1947,8 +1947,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>440</width>
-             <height>481</height>
+             <width>555</width>
+             <height>527</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -2341,8 +2341,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>332</width>
-             <height>480</height>
+             <width>419</width>
+             <height>537</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -2707,47 +2707,19 @@
        </layout>
       </widget>
       <widget class="QWidget" name="tabAdvancedPage">
-       <layout class="QVBoxLayout" name="verticalLayout_35">
+       <layout class="QVBoxLayout" name="advPageLayout">
         <property name="leftMargin">
          <number>0</number>
         </property>
         <property name="topMargin">
          <number>0</number>
         </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
         <property name="bottomMargin">
          <number>0</number>
         </property>
-        <item>
-         <widget class="QScrollArea" name="scrollArea_advanced">
-          <property name="widgetResizable">
-           <bool>true</bool>
-          </property>
-          <widget class="QWidget" name="scrollAreaWidgetContents_10">
-           <property name="geometry">
-            <rect>
-             <x>0</x>
-             <y>0</y>
-             <width>98</width>
-             <height>28</height>
-            </rect>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_36">
-            <property name="leftMargin">
-             <number>0</number>
-            </property>
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <property name="rightMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>0</number>
-            </property>
-           </layout>
-          </widget>
-         </widget>
-        </item>
        </layout>
       </widget>
      </widget>

--- a/src/gui/options_imp.cpp
+++ b/src/gui/options_imp.cpp
@@ -279,10 +279,8 @@ options_imp::options_imp(QWidget *parent)
     // Tab selection mechanism
     connect(tabSelection, SIGNAL(currentItemChanged(QListWidgetItem *, QListWidgetItem *)), this, SLOT(changePage(QListWidgetItem *, QListWidgetItem*)));
     // Load Advanced settings
-    QVBoxLayout *adv_layout = new QVBoxLayout();
-    advancedSettings = new AdvancedSettings();
-    adv_layout->addWidget(advancedSettings);
-    scrollArea_advanced->setLayout(adv_layout);
+    advancedSettings = new AdvancedSettings(tabAdvancedPage);
+    advPageLayout->addWidget(advancedSettings);
     connect(advancedSettings, SIGNAL(settingsChanged()), this, SLOT(enableApplyButton()));
 
     // Adapt size
@@ -312,8 +310,6 @@ options_imp::~options_imp()
     foreach (const QString &path, addedScanDirs)
         ScanFoldersModel::instance()->removePath(path);
     ScanFoldersModel::instance()->configure(); // reloads "removed" paths
-    delete scrollArea_advanced->layout();
-    delete advancedSettings;
 }
 
 void options_imp::changePage(QListWidgetItem *current, QListWidgetItem *previous)


### PR DESCRIPTION
IMO, it's better to divide the settings into `qBittorrent` group and `libtorrent` group, so that "power users" can know what kind of settings they are tweaking.

Before:
![old](https://cloud.githubusercontent.com/assets/9395168/11167941/564262c4-8bb4-11e5-83b7-73a1517b826e.png)


After:
![new](https://cloud.githubusercontent.com/assets/9395168/11167939/543e17fc-8bb4-11e5-8069-7f09709b536d.png)
