### PR TITLE
Support wildcards for filtering torrent list and torrent content

### DIFF
--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -857,7 +857,7 @@ void PropertiesWidget::filteredFilesChanged() {
 }
 
 void PropertiesWidget::filterText(const QString& filter) {
-  PropListModel->setFilterFixedString(filter);
+  PropListModel->setFilterRegExp(QRegExp(filter, Qt::CaseInsensitive, QRegExp::WildcardUnix));
   if (filter.isEmpty()) {
     filesList->collapseAll();
     filesList->expand(PropListModel->index(0, 0));

--- a/src/gui/torrentcontentfiltermodel.cpp
+++ b/src/gui/torrentcontentfiltermodel.cpp
@@ -38,7 +38,6 @@ TorrentContentFilterModel::TorrentContentFilterModel(QObject *parent):
   connect(m_model, SIGNAL(filteredFilesChanged()), this, SIGNAL(filteredFilesChanged()));
   setSourceModel(m_model);
   // Filter settings
-  setFilterCaseSensitivity(Qt::CaseInsensitive);
   setFilterKeyColumn(TorrentContentModelItem::COL_NAME);
   setFilterRole(Qt::DisplayRole);
   setDynamicSortFilter(true);

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -874,7 +874,7 @@ void TransferListWidget::applyTrackerFilter(const QStringList &hashes)
 
 void TransferListWidget::applyNameFilter(const QString& name)
 {
-    nameFilterModel->setFilterRegExp(QRegExp(QRegExp::escape(name), Qt::CaseInsensitive));
+    nameFilterModel->setFilterRegExp(QRegExp(name, Qt::CaseInsensitive, QRegExp::WildcardUnix));
 }
 
 void TransferListWidget::applyStatusFilter(int f)


### PR DESCRIPTION
Supersedes #4164.

Uses the [WildcardUnix](http://doc.qt.io/qt-4.8/qregexp.html#PatternSyntax-enum) mode.