### PR TITLE
[searchengine] Update Torrentz trackers

### DIFF
--- a/src/searchengine/nova/engines/torrentz.py
+++ b/src/searchengine/nova/engines/torrentz.py
@@ -1,4 +1,4 @@
-#VERSION: 2.16
+#VERSION: 2.17
 #AUTHORS: Diego de las Heras (ngosang@hotmail.es)
 
 # Redistribution and use in source and binary forms, with or without
@@ -36,11 +36,11 @@ class torrentz(object):
     name = 'Torrentz'
     supported_categories = {'all': ''}
 
-    trackers_list = ['udp://open.demonii.com:1337/announce',
-                    'udp://tracker.openbittorrent.com:80/announce',
+    trackers_list = ['udp://tracker.openbittorrent.com:80/announce',
+                    'udp://glotorrents.pw:6969/announce',
                     'udp://tracker.leechers-paradise.org:6969',
-                    'udp://tracker.coppersurfer.tk:6969',
-                    'udp://9.rarbg.com:2710/announce']
+                    'udp://9.rarbg.com:2710/announce',
+                    'udp://tracker.coppersurfer.tk:6969']
 
     class MyHtmlParser(HTMLParser):
         def __init__(self, results, url, trackers):

--- a/src/searchengine/nova/engines/versions.txt
+++ b/src/searchengine/nova/engines/versions.txt
@@ -6,4 +6,4 @@ legittorrents: 2.00
 mininova: 2.00
 piratebay: 2.11
 torrentreactor: 1.40
-torrentz: 2.16
+torrentz: 2.17

--- a/src/searchengine/nova3/engines/torrentz.py
+++ b/src/searchengine/nova3/engines/torrentz.py
@@ -1,4 +1,4 @@
-#VERSION: 2.16
+#VERSION: 2.17
 #AUTHORS: Diego de las Heras (ngosang@hotmail.es)
 
 # Redistribution and use in source and binary forms, with or without
@@ -36,11 +36,11 @@ class torrentz(object):
     name = 'Torrentz'
     supported_categories = {'all': ''}
 
-    trackers_list = ['udp://open.demonii.com:1337/announce',
-                    'udp://tracker.openbittorrent.com:80/announce',
+    trackers_list = ['udp://tracker.openbittorrent.com:80/announce',
+                    'udp://glotorrents.pw:6969/announce',
                     'udp://tracker.leechers-paradise.org:6969',
-                    'udp://tracker.coppersurfer.tk:6969',
-                    'udp://9.rarbg.com:2710/announce']
+                    'udp://9.rarbg.com:2710/announce',
+                    'udp://tracker.coppersurfer.tk:6969']
 
     class MyHtmlParser(HTMLParser):
         def __init__(self, results, url, trackers):

--- a/src/searchengine/nova3/engines/versions.txt
+++ b/src/searchengine/nova3/engines/versions.txt
@@ -6,4 +6,4 @@ legittorrents: 2.00
 mininova: 2.00
 piratebay: 2.11
 torrentreactor: 1.40
-torrentz: 2.16
+torrentz: 2.17


### PR DESCRIPTION
Removed demonii. Reason => https://torrentfreak.com/demonii-torrent-tracker-shuts-down-for-good-151116/