### PR TITLE
Share torrents until seeding time reaches an specific amount of minutes

### DIFF
--- a/src/base/bittorrent/addtorrentparams.h
+++ b/src/base/bittorrent/addtorrentparams.h
@@ -46,7 +46,7 @@ namespace BitTorrent
         TriStateBool addForced;
         TriStateBool addPaused;
         QVector<int> filePriorities; // used if TorrentInfo is set
-        bool ignoreShareRatio = false;
+        bool ignoreShareLimits = false;
         bool skipChecking = false;
         TriStateBool createSubfolder;
     };

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -245,6 +245,8 @@ namespace BitTorrent
 
         qreal globalMaxRatio() const;
         void setGlobalMaxRatio(qreal ratio);
+        int globalMaxSeedingMinutes() const;
+        void setGlobalMaxSeedingMinutes(int minutes);
         bool isDHTEnabled() const;
         void setDHTEnabled(bool enabled);
         bool isLSDEnabled() const;
@@ -395,7 +397,7 @@ namespace BitTorrent
         void bottomTorrentsPriority(const QStringList &hashes);
 
         // TorrentHandle interface
-        void handleTorrentRatioLimitChanged(TorrentHandle *const torrent);
+        void handleTorrentShareLimitChanged(TorrentHandle *const torrent);
         void handleTorrentSavePathChanged(TorrentHandle *const torrent);
         void handleTorrentCategoryChanged(TorrentHandle *const torrent, const QString &oldCategory);
         void handleTorrentSavingModeChanged(TorrentHandle *const torrent);
@@ -455,7 +457,7 @@ namespace BitTorrent
         void configureDeferred();
         void readAlerts();
         void refresh();
-        void processBigRatios();
+        void processShareLimits();
         void generateResumeData(bool final = false);
         void handleIPFilterParsed(int ruleCount);
         void handleIPFilterError();
@@ -473,6 +475,7 @@ namespace BitTorrent
         ~Session();
 
         bool hasPerTorrentRatioLimit() const;
+        bool hasPerTorrentSeedingTimeLimit() const;
 
         void initResumeFolder();
 
@@ -503,7 +506,7 @@ namespace BitTorrent
                              const QByteArray &fastresumeData = QByteArray());
         bool findIncompleteFiles(TorrentInfo &torrentInfo, QString &savePath) const;
 
-        void updateRatioTimer();
+        void updateSeedingLimitTimer();
         void exportTorrentFile(TorrentHandle *const torrent, TorrentExportFolder folder = TorrentExportFolder::Regular);
         void saveTorrentResumeData(TorrentHandle *const torrent, bool finalSave = false);
 
@@ -578,6 +581,7 @@ namespace BitTorrent
         CachedSettingValue<bool> m_isAddTrackersEnabled;
         CachedSettingValue<QString> m_additionalTrackers;
         CachedSettingValue<qreal> m_globalMaxRatio;
+        CachedSettingValue<int> m_globalMaxSeedingMinutes;
         CachedSettingValue<bool> m_isAddTorrentPaused;
         CachedSettingValue<bool> m_isCreateTorrentSubfolder;
         CachedSettingValue<bool> m_isAppendExtensionEnabled;
@@ -628,7 +632,7 @@ namespace BitTorrent
         bool m_useProxy;
 
         QTimer *m_refreshTimer;
-        QTimer *m_bigRatioTimer;
+        QTimer *m_seedingLimitTimer;
         QTimer *m_resumeDataTimer;
         Statistics *m_statistics;
         // IP filtering

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -106,6 +106,7 @@ namespace BitTorrent
         QVector<int> filePriorities;
         // for resumed torrents
         qreal ratioLimit;
+        int seedingTimeLimit;
 
         AddTorrentData();
         AddTorrentData(const AddTorrentParams &params);
@@ -169,7 +170,11 @@ namespace BitTorrent
         static const qreal USE_GLOBAL_RATIO;
         static const qreal NO_RATIO_LIMIT;
 
+        static const int USE_GLOBAL_SEEDING_TIME;
+        static const int NO_SEEDING_TIME_LIMIT;
+
         static const qreal MAX_RATIO;
+        static const int MAX_SEEDING_TIME;
 
         TorrentHandle(Session *session, const libtorrent::torrent_handle &nativeHandle,
                           const AddTorrentData &data);
@@ -251,6 +256,7 @@ namespace BitTorrent
         qreal progress() const;
         QDateTime addedTime() const;
         qreal ratioLimit() const;
+        int seedingTimeLimit() const;
 
         QString filePath(int index) const;
         QString fileName(int index) const;
@@ -313,6 +319,7 @@ namespace BitTorrent
         QVector<int> pieceAvailability() const;
         qreal distributedCopies() const;
         qreal maxRatio(bool *usesGlobalRatio = 0) const;
+        int maxSeedingTime(bool *usesGlobalSeedingTime = 0) const;
         qreal realRatio() const;
         int uploadPayloadRate() const;
         int downloadPayloadRate() const;
@@ -341,6 +348,7 @@ namespace BitTorrent
         void prioritizeFiles(const QVector<int> &priorities);
         void setFilePriority(int index, int priority);
         void setRatioLimit(qreal limit);
+        void setSeedingTimeLimit(int limit);
         void setUploadLimit(int limit);
         void setDownloadLimit(int limit);
         void setSuperSeeding(bool enable);
@@ -439,6 +447,7 @@ namespace BitTorrent
         QString m_category;
         bool m_hasSeedStatus;
         qreal m_ratioLimit;
+        int m_seedingTimeLimit;
         bool m_tempPathDisabled;
         bool m_hasMissingFiles;
         bool m_hasRootFolder;

--- a/src/gui/optionsdlg.h
+++ b/src/gui/optionsdlg.h
@@ -90,6 +90,7 @@ private slots:
     void on_buttonBox_rejected();
     void applySettings(QAbstractButton* button);
     void enableApplyButton();
+    void toggleComboRatioLimitAct();
     void changePage(QListWidgetItem*, QListWidgetItem*);
     void loadWindowState();
     void saveWindowState() const;
@@ -145,6 +146,7 @@ private:
     bool isLSDEnabled() const;
     int getEncryptionSetting() const;
     qreal getMaxRatio() const;
+    int getMaxSeedingMinutes() const;
     // Proxy options
     bool isProxyEnabled() const;
     bool isProxyAuthEnabled() const;

--- a/src/gui/optionsdlg.ui
+++ b/src/gui/optionsdlg.ui
@@ -1852,15 +1852,15 @@
                     <property name="wrapping">
                      <bool>true</bool>
                     </property>
-                    <property name="displayFormat">
-                     <string notr="true">hh:mm</string>
-                    </property>
                     <property name="time">
                      <time>
                       <hour>20</hour>
                       <minute>0</minute>
                       <second>0</second>
                      </time>
+                    </property>
+                    <property name="displayFormat">
+                     <string notr="true">hh:mm</string>
                     </property>
                    </widget>
                   </item>
@@ -1876,18 +1876,18 @@
                     <property name="wrapping">
                      <bool>true</bool>
                     </property>
-                    <property name="displayFormat">
-                     <string notr="true">hh:mm</string>
-                    </property>
-                    <property name="calendarPopup">
-                     <bool>false</bool>
-                    </property>
                     <property name="time">
                      <time>
                       <hour>8</hour>
                       <minute>0</minute>
                       <second>0</second>
                      </time>
+                    </property>
+                    <property name="displayFormat">
+                     <string notr="true">hh:mm</string>
+                    </property>
+                    <property name="calendarPopup">
+                     <bool>false</bool>
                     </property>
                    </widget>
                   </item>
@@ -2374,66 +2374,144 @@
               <property name="title">
                <string>Share Ratio Limiting</string>
               </property>
-              <layout class="QVBoxLayout">
-               <property name="bottomMargin">
-                <number>9</number>
-               </property>
-               <item>
-                <layout class="QHBoxLayout">
+              <layout class="QGridLayout" name="gridLayout_91">
+               <item row="0" column="0" rowspan="3" colspan="3">
+                <widget class="QCheckBox" name="checkMaxRatio">
+                 <property name="text">
+                  <string>Seed torrents until their ratio reaches</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="6" rowspan="2">
+                <spacer name="horizontalSpacer_161">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>109</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="5" column="2">
+                <widget class="QLabel" name="label">
+                 <property name="text">
+                  <string>then</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="4" colspan="2">
+                <widget class="QComboBox" name="comboRatioLimitAct">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
                  <item>
-                  <widget class="QCheckBox" name="checkMaxRatio">
-                   <property name="text">
-                    <string>Seed torrents until their ratio reaches</string>
-                   </property>
-                  </widget>
+                  <property name="text">
+                   <string>Pause them</string>
+                  </property>
                  </item>
                  <item>
-                  <widget class="QDoubleSpinBox" name="spinMaxRatio">
-                   <property name="enabled">
-                    <bool>false</bool>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignHCenter</set>
-                   </property>
-                   <property name="minimum">
-                    <double>0.000000000000000</double>
-                   </property>
-                   <property name="maximum">
-                    <double>9998.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.050000000000000</double>
-                   </property>
-                   <property name="value">
-                    <double>1.000000000000000</double>
-                   </property>
-                  </widget>
+                  <property name="text">
+                   <string>Remove them</string>
+                  </property>
                  </item>
-                 <item>
-                  <widget class="QLabel" name="label">
-                   <property name="text">
-                    <string>then</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QComboBox" name="comboRatioLimitAct">
-                   <property name="enabled">
-                    <bool>false</bool>
-                   </property>
-                   <item>
-                    <property name="text">
-                     <string>Pause them</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>Remove them</string>
-                    </property>
-                   </item>
-                  </widget>
-                 </item>
-                </layout>
+                </widget>
+               </item>
+               <item row="5" column="6">
+                <spacer name="horizontalSpacer_20">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>121</width>
+                   <height>28</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="5" column="1">
+                <spacer name="horizontalSpacer_171">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>100</width>
+                   <height>42</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="3" column="6">
+                <spacer name="horizontalSpacer_191">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="3" column="4">
+                <widget class="QSpinBox" name="spinMaxSeedingMinutes">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                 <property name="maximum">
+                  <number>9999999</number>
+                 </property>
+                 <property name="value">
+                  <number>1440</number>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="4">
+                <widget class="QDoubleSpinBox" name="spinMaxRatio">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignHCenter</set>
+                 </property>
+                 <property name="minimum">
+                  <double>0.000000000000000</double>
+                 </property>
+                 <property name="maximum">
+                  <double>9998.000000000000000</double>
+                 </property>
+                 <property name="singleStep">
+                  <double>0.050000000000000</double>
+                 </property>
+                 <property name="value">
+                  <double>1.000000000000000</double>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="5">
+                <widget class="QLabel" name="label_11">
+                 <property name="text">
+                  <string>minutes</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0" colspan="4">
+                <widget class="QCheckBox" name="checkMaxSeedingMinutes">
+                 <property name="text">
+                  <string>Seed torrents until their seeding time reaches</string>
+                 </property>
+                </widget>
                </item>
               </layout>
              </widget>
@@ -2506,7 +2584,7 @@
            <item>
             <layout class="QGridLayout" name="gridLayout_5">
              <item row="0" column="0">
-              <widget class="QLabel" name="label_11">
+              <widget class="QLabel" name="label_111">
                <property name="text">
                 <string>Feeds refresh interval:</string>
                </property>
@@ -3035,16 +3113,129 @@
  <tabstops>
   <tabstop>tabOption</tabstop>
   <tabstop>comboI18n</tabstop>
+  <tabstop>browseSaveDirButton</tabstop>
   <tabstop>checkStartPaused</tabstop>
   <tabstop>spinPort</tabstop>
   <tabstop>checkUPnP</tabstop>
+  <tabstop>textWebUiUsername</tabstop>
+  <tabstop>checkWebUi</tabstop>
+  <tabstop>textSavePath</tabstop>
+  <tabstop>scrollArea_7</tabstop>
+  <tabstop>scrollArea_2</tabstop>
+  <tabstop>spinWebUiPort</tabstop>
+  <tabstop>textWebUiPassword</tabstop>
+  <tabstop>buttonBox</tabstop>
+  <tabstop>tabSelection</tabstop>
+  <tabstop>scrollArea</tabstop>
+  <tabstop>confirmDeletion</tabstop>
+  <tabstop>checkAltRowColors</tabstop>
+  <tabstop>actionTorrentDlOnDblClBox</tabstop>
+  <tabstop>actionTorrentFnOnDblClBox</tabstop>
+  <tabstop>checkStartup</tabstop>
+  <tabstop>checkShowSplash</tabstop>
+  <tabstop>checkStartMinimized</tabstop>
+  <tabstop>checkProgramExitConfirm</tabstop>
+  <tabstop>checkShowSystray</tabstop>
+  <tabstop>checkMinimizeToSysTray</tabstop>
+  <tabstop>checkCloseToSystray</tabstop>
+  <tabstop>comboTrayIcon</tabstop>
+  <tabstop>checkAssociateTorrents</tabstop>
+  <tabstop>checkAssociateMagnetLinks</tabstop>
+  <tabstop>checkPreventFromSuspend</tabstop>
+  <tabstop>checkAdditionDialog</tabstop>
+  <tabstop>checkAdditionDialogFront</tabstop>
+  <tabstop>checkPreallocateAll</tabstop>
+  <tabstop>checkTempFolder</tabstop>
+  <tabstop>textTempPath</tabstop>
+  <tabstop>browseTempDirButton</tabstop>
+  <tabstop>checkAppendqB</tabstop>
+  <tabstop>scanFoldersView</tabstop>
+  <tabstop>addScanFolderButton</tabstop>
+  <tabstop>removeScanFolderButton</tabstop>
+  <tabstop>checkExportDir</tabstop>
+  <tabstop>textExportDir</tabstop>
+  <tabstop>browseExportDirButton</tabstop>
+  <tabstop>checkExportDirFin</tabstop>
+  <tabstop>textExportDirFin</tabstop>
+  <tabstop>browseExportDirFinButton</tabstop>
+  <tabstop>groupMailNotification</tabstop>
+  <tabstop>dest_email_txt</tabstop>
+  <tabstop>smtp_server_txt</tabstop>
+  <tabstop>groupMailNotifAuth</tabstop>
+  <tabstop>mailNotifUsername</tabstop>
+  <tabstop>mailNotifPassword</tabstop>
+  <tabstop>checkSmtpSSL</tabstop>
+  <tabstop>autoRunBox</tabstop>
+  <tabstop>autoRun_txt</tabstop>
+  <tabstop>scrollArea_3</tabstop>
+  <tabstop>randomButton</tabstop>
+  <tabstop>checkRandomPort</tabstop>
+  <tabstop>checkMaxConnecs</tabstop>
+  <tabstop>spinMaxConnec</tabstop>
+  <tabstop>checkMaxConnecsPerTorrent</tabstop>
+  <tabstop>spinMaxConnecPerTorrent</tabstop>
+  <tabstop>checkMaxUploadsPerTorrent</tabstop>
+  <tabstop>spinMaxUploadsPerTorrent</tabstop>
+  <tabstop>checkMaxUploads</tabstop>
+  <tabstop>spinMaxUploads</tabstop>
+  <tabstop>comboProxyType</tabstop>
+  <tabstop>textProxyIP</tabstop>
+  <tabstop>spinProxyPort</tabstop>
+  <tabstop>checkProxyPeerConnecs</tabstop>
+  <tabstop>checkForceProxy</tabstop>
+  <tabstop>isProxyOnlyForTorrents</tabstop>
+  <tabstop>checkProxyAuth</tabstop>
+  <tabstop>textProxyUsername</tabstop>
+  <tabstop>textProxyPassword</tabstop>
+  <tabstop>checkIPFilter</tabstop>
+  <tabstop>textFilterPath</tabstop>
+  <tabstop>browseFilterButton</tabstop>
+  <tabstop>IpFilterRefreshBtn</tabstop>
+  <tabstop>checkIpFilterTrackers</tabstop>
+  <tabstop>scrollArea_9</tabstop>
+  <tabstop>spinUploadLimit</tabstop>
+  <tabstop>checkUploadLimit</tabstop>
+  <tabstop>spinDownloadLimit</tabstop>
+  <tabstop>checkDownloadLimit</tabstop>
+  <tabstop>check_schedule</tabstop>
+  <tabstop>schedule_to</tabstop>
+  <tabstop>schedule_from</tabstop>
+  <tabstop>schedule_days</tabstop>
+  <tabstop>checkUploadLimitAlt</tabstop>
+  <tabstop>checkDownloadLimitAlt</tabstop>
+  <tabstop>spinUploadLimitAlt</tabstop>
+  <tabstop>spinDownloadLimitAlt</tabstop>
+  <tabstop>checkLimitLocalPeerRate</tabstop>
+  <tabstop>checkLimitTransportOverhead</tabstop>
+  <tabstop>checkuTP</tabstop>
+  <tabstop>checkLimituTPConnections</tabstop>
+  <tabstop>scrollArea_4</tabstop>
+  <tabstop>checkDHT</tabstop>
+  <tabstop>checkPeX</tabstop>
   <tabstop>checkLSD</tabstop>
   <tabstop>comboEncryption</tabstop>
+  <tabstop>checkAnonymousMode</tabstop>
+  <tabstop>checkEnableQueueing</tabstop>
+  <tabstop>spinMaxActiveDownloads</tabstop>
+  <tabstop>spinMaxActiveUploads</tabstop>
+  <tabstop>spinMaxActiveTorrents</tabstop>
+  <tabstop>checkIgnoreSlowTorrentsForQueueing</tabstop>
   <tabstop>checkMaxRatio</tabstop>
   <tabstop>spinMaxRatio</tabstop>
-  <tabstop>spinWebUiPort</tabstop>
-  <tabstop>textWebUiUsername</tabstop>
-  <tabstop>textWebUiPassword</tabstop>
+  <tabstop>checkMaxSeedingMinutes</tabstop>
+  <tabstop>spinMaxSeedingMinutes</tabstop>
+  <tabstop>comboRatioLimitAct</tabstop>
+  <tabstop>checkWebUIUPnP</tabstop>
+  <tabstop>checkWebUiHttps</tabstop>
+  <tabstop>btnWebUiCrt</tabstop>
+  <tabstop>btnWebUiKey</tabstop>
+  <tabstop>checkBypassLocalAuth</tabstop>
+  <tabstop>checkDynDNS</tabstop>
+  <tabstop>comboDNSService</tabstop>
+  <tabstop>registerDNSBtn</tabstop>
+  <tabstop>domainNameTxt</tabstop>
+  <tabstop>DNSUsernameTxt</tabstop>
+  <tabstop>DNSPasswordTxt</tabstop>
  </tabstops>
  <resources>
   <include location="../icons.qrc"/>
@@ -3131,9 +3322,9 @@
    </hints>
   </connection>
   <connection>
-   <sender>checkMaxRatio</sender>
+   <sender>checkMaxUploads</sender>
    <signal>toggled(bool)</signal>
-   <receiver>spinMaxRatio</receiver>
+   <receiver>spinMaxUploads</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -3147,9 +3338,9 @@
    </hints>
   </connection>
   <connection>
-   <sender>checkMaxRatio</sender>
+   <sender>checkDownloadLimitAlt</sender>
    <signal>toggled(bool)</signal>
-   <receiver>comboRatioLimitAct</receiver>
+   <receiver>spinDownloadLimitAlt</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -3163,9 +3354,9 @@
    </hints>
   </connection>
   <connection>
-   <sender>checkMaxUploads</sender>
+   <sender>checkUploadLimitAlt</sender>
    <signal>toggled(bool)</signal>
-   <receiver>spinMaxUploads</receiver>
+   <receiver>spinUploadLimitAlt</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -3179,9 +3370,9 @@
    </hints>
   </connection>
   <connection>
-   <sender>checkDownloadLimitAlt</sender>
+   <sender>checkMaxRatio</sender>
    <signal>toggled(bool)</signal>
-   <receiver>spinDownloadLimitAlt</receiver>
+   <receiver>spinMaxRatio</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -3195,9 +3386,9 @@
    </hints>
   </connection>
   <connection>
-   <sender>checkUploadLimitAlt</sender>
+   <sender>checkMaxSeedingMinutes</sender>
    <signal>toggled(bool)</signal>
-   <receiver>spinUploadLimitAlt</receiver>
+   <receiver>spinMaxSeedingMinutes</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">

--- a/src/gui/torrentcreatordlg.cpp
+++ b/src/gui/torrentcreatordlg.cpp
@@ -169,7 +169,7 @@ void TorrentCreatorDlg::handleCreationSuccess(QString path, QString branch_path)
         BitTorrent::AddTorrentParams params;
         params.savePath = branch_path;
         params.skipChecking = true;
-        params.ignoreShareRatio = checkIgnoreShareLimits->isChecked();
+        params.ignoreShareLimits = checkIgnoreShareLimits->isChecked();
 
         BitTorrent::Session::instance()->addTorrent(t, params);
     }

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -487,16 +487,24 @@ void TransferListWidget::setMaxRatioSelectedTorrents()
     if (torrents.isEmpty()) return;
 
     bool useGlobalValue = true;
-    qreal currentMaxRatio = BitTorrent::Session::instance()->globalMaxRatio();;
+    qreal currentMaxRatio = BitTorrent::Session::instance()->globalMaxRatio();
     if (torrents.count() == 1)
         currentMaxRatio = torrents[0]->maxRatio(&useGlobalValue);
 
-    UpDownRatioDlg dlg(useGlobalValue, currentMaxRatio, BitTorrent::TorrentHandle::MAX_RATIO, this);
+    int currentMaxSeedingTime = BitTorrent::Session::instance()->globalMaxSeedingMinutes();
+    if (torrents.count() == 1)
+        currentMaxSeedingTime = torrents[0]->maxSeedingTime(&useGlobalValue);
+
+    UpDownRatioDlg dlg(useGlobalValue, currentMaxRatio, BitTorrent::TorrentHandle::MAX_RATIO,
+                       currentMaxSeedingTime, BitTorrent::TorrentHandle::MAX_SEEDING_TIME, this);
     if (dlg.exec() != QDialog::Accepted) return;
 
     foreach (BitTorrent::TorrentHandle *const torrent, torrents) {
         qreal ratio = (dlg.useDefault() ? BitTorrent::TorrentHandle::USE_GLOBAL_RATIO : dlg.ratio());
         torrent->setRatioLimit(ratio);
+
+        int seedingTime = (dlg.useDefault() ? BitTorrent::TorrentHandle::USE_GLOBAL_SEEDING_TIME : dlg.seedingTime());
+        torrent->setSeedingTimeLimit(seedingTime);
     }
 }
 

--- a/src/gui/updownratiodlg.h
+++ b/src/gui/updownratiodlg.h
@@ -45,14 +45,21 @@ class UpDownRatioDlg : public QDialog
 
 public:
     explicit UpDownRatioDlg(bool useDefault, qreal initialValue, qreal maxValue,
+        int initialTimeValue, int maxTimeValue,
         QWidget *parent = 0);
     ~UpDownRatioDlg();
 
     bool useDefault() const;
     qreal ratio() const;
+    int seedingTime() const;
+
+public slots:
+    void accept();
 
 private slots:
     void handleRatioTypeChanged();
+    void enableRatioSpin();
+    void enableTimeSpin();
 
 private:
     Ui::UpDownRatioDlg *ui;

--- a/src/gui/updownratiodlg.ui
+++ b/src/gui/updownratiodlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>317</width>
-    <height>152</height>
+    <width>399</width>
+    <height>195</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,7 @@
    <item>
     <widget class="QRadioButton" name="useDefaultButton">
      <property name="text">
-      <string>Use global ratio limit</string>
+      <string>Use global share limit</string>
      </property>
      <attribute name="buttonGroup">
       <string>buttonGroup</string>
@@ -27,7 +27,7 @@
    <item>
     <widget class="QRadioButton" name="noLimitButton">
      <property name="text">
-      <string>Set no ratio limit</string>
+      <string>Set no share limit</string>
      </property>
      <attribute name="buttonGroup">
       <string>buttonGroup</string>
@@ -35,18 +35,18 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
       <widget class="QRadioButton" name="torrentLimitButton">
        <property name="text">
-        <string>Set ratio limit to</string>
+        <string>Set share limit to</string>
        </property>
        <attribute name="buttonGroup">
         <string>buttonGroup</string>
        </attribute>
       </widget>
      </item>
-     <item>
+     <item row="0" column="2">
       <widget class="QDoubleSpinBox" name="ratioSpinBox">
        <property name="maximum">
         <double>9998.000000000000000</double>
@@ -59,7 +59,29 @@
        </property>
       </widget>
      </item>
-     <item>
+     <item row="2" column="2">
+      <widget class="QDoubleSpinBox" name="timeSpinBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="decimals">
+        <number>0</number>
+       </property>
+       <property name="maximum">
+        <double>525600.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>1.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>1440.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="3">
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -71,6 +93,20 @@
         </size>
        </property>
       </spacer>
+     </item>
+     <item row="0" column="1">
+      <widget class="QCheckBox" name="checkMaxRatio">
+       <property name="text">
+        <string>ratio</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QCheckBox" name="checkMaxTime">
+       <property name="text">
+        <string>minutes</string>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
@@ -135,6 +171,7 @@
   </connection>
  </connections>
  <buttongroups>
+  <buttongroup name="shareButtonGroup"/>
   <buttongroup name="buttonGroup"/>
  </buttongroups>
 </ui>

--- a/src/webui/extra_translations.h
+++ b/src/webui/extra_translations.h
@@ -74,6 +74,7 @@ static const char *__TRANSLATIONS__[] = {
     QT_TRANSLATE_NOOP("HttpServer", "Unknown"),
     QT_TRANSLATE_NOOP("HttpServer", "Hard Disk"),
     QT_TRANSLATE_NOOP("HttpServer", "Share ratio limit must be between 0 and 9998.")
+    QT_TRANSLATE_NOOP("HttpServer", "Seeding time limit must be between 0 and 525600 minutes.")
 };
 
 static const struct { const char *source; const char *comment; } __COMMENTED_TRANSLATIONS__[] = {

--- a/src/webui/prefjson.cpp
+++ b/src/webui/prefjson.cpp
@@ -151,6 +151,8 @@ QByteArray prefjson::getPreferences()
     // Share Ratio Limiting
     data["max_ratio_enabled"] = (session->globalMaxRatio() >= 0.);
     data["max_ratio"] = session->globalMaxRatio();
+    data["max_seeding_time_enabled"] = (session->globalMaxSeedingMinutes() >= 0.);
+    data["max_seeding_time"] = session->globalMaxSeedingMinutes();
     data["max_ratio_act"] = session->maxRatioAction();
     // Add trackers
     data["add_trackers_enabled"] = session->isAddTrackersEnabled();
@@ -367,6 +369,10 @@ void prefjson::setPreferences(const QString& json)
         session->setGlobalMaxRatio(m["max_ratio"].toReal());
     else
         session->setGlobalMaxRatio(-1);
+    if (m.contains("max_seeding_time_enabled"))
+        session->setGlobalMaxSeedingMinutes(m["max_seeding_time"].toInt());
+    else
+        session->setGlobalMaxSeedingMinutes(-1);
     if (m.contains("max_ratio_act"))
         session->setMaxRatioAction(static_cast<MaxRatioAction>(m["max_ratio_act"].toInt()));
     // Add trackers

--- a/src/webui/www/public/preferences_content.html
+++ b/src/webui/www/public/preferences_content.html
@@ -307,14 +307,36 @@
 
 <fieldset class="settings">
   <legend>QBT_TR(Share Ratio Limiting)QBT_TR[CONTEXT=OptionsDialog]</legend>
-  <input type="checkbox" id="max_ratio_checkbox" onClick="updateMaxRatioEnabled();"/>
+  <table>
+  <tr>
+  <td> 
+  <input type="checkbox" id="max_ratio_checkbox" onClick="updateMaxRatioTimeEnabled();"/>
   <label for="max_ratio_checkbox">QBT_TR(Seed torrents until their ratio reaches)QBT_TR[CONTEXT=OptionsDialog]</label>
+  </td>
+  <td>
   <input type="text" id="max_ratio_value" style="width: 4em;"/>
+  </td>
+  <tr>
+  <td> 
+  <input type="checkbox" id="max_seeding_time_checkbox" onClick="updateMaxRatioTimeEnabled();"/>
+  <label for="max_seeding_time_checkbox">QBT_TR(Seed torrents until their seeding time reaches)QBT_TR[CONTEXT=OptionsDialog]</label>
+  </td>
+  <td>
+  <input type="text" id="max_seeding_time_value" style="width: 4em;"/> QBT_TR(minutes)QBT_TR[CONTEXT=OptionsDialog]
+  </td>
+  </tr>
+  <tr>
+  <td style="text-align: right;">
   QBT_TR(then)QBT_TR[CONTEXT=OptionsDialog]
+  </td>
+  <td>
   <select id="max_ratio_act">
     <option value="0">QBT_TR(Pause them)QBT_TR[CONTEXT=OptionsDialog]</option>
     <option value="1">QBT_TR(Remove them)QBT_TR[CONTEXT=OptionsDialog]</option>
   </select>
+  </td>
+  </tr>
+  </table>
 </fieldset>
 
 <fieldset class="settings">
@@ -724,12 +746,20 @@ updateQueueingSystem = function() {
   }
 }
 
-updateMaxRatioEnabled = function() {
+updateMaxRatioTimeEnabled = function() {
   if($('max_ratio_checkbox').getProperty('checked')) {
     $('max_ratio_value').setProperty('disabled', false);
-    $('max_ratio_act').setProperty('disabled', false);
   } else {
     $('max_ratio_value').setProperty('disabled', true);
+  }
+  if($('max_seeding_time_checkbox').getProperty('checked')) {
+    $('max_seeding_time_value').setProperty('disabled', false);
+  } else {
+    $('max_seeding_time_value').setProperty('disabled', true);
+  }
+  if($('max_ratio_checkbox').getProperty('checked') || $('max_seeding_time_checkbox').getProperty('checked')) {
+    $('max_ratio_act').setProperty('disabled', false);
+  } else {
     $('max_ratio_act').setProperty('disabled', true);
   }
 }
@@ -992,7 +1022,7 @@ loadPreferences = function() {
                     $('dont_count_slow_torrents_checkbox').setProperty('checked', pref.dont_count_slow_torrents);
                     updateQueueingSystem();
 
-                    // Share Ratio Limiting
+                    // Share Limiting
                     $('max_ratio_checkbox').setProperty('checked', pref.max_ratio_enabled);
                     if (pref.max_ratio_enabled)
                         $('max_ratio_value').setProperty('value', pref.max_ratio);
@@ -1000,7 +1030,14 @@ loadPreferences = function() {
                         $('max_ratio_value').setProperty('value', 1);
                     var max_ratio_act = pref.max_ratio_act.toInt();
                     $('max_ratio_act').getChildren('option')[max_ratio_act].setAttribute('selected', '');
-                    updateMaxRatioEnabled();
+                    $('max_seeding_time_checkbox').setProperty('checked', pref.max_seeding_time_enabled);
+                    if (pref.max_seeding_time_enabled)
+                        $('max_seeding_time_value').setProperty('value', pref.max_seeding_time.toInt());
+                    else
+                        $('max_seeding_time_value').setProperty('value', 1440);
+                    var max_ratio_act = pref.max_ratio_act.toInt();
+                    $('max_ratio_act').getChildren('option')[max_ratio_act].setAttribute('selected', '');
+                    updateMaxRatioTimeEnabled();
 
                     // Add trackers
                     $('add_trackers_checkbox').setProperty('checked', pref.add_trackers_enabled);
@@ -1256,6 +1293,18 @@ applyPreferences = function() {
   }
   settings.set('max_ratio_enabled', $('max_ratio_checkbox').getProperty('checked'));
   settings.set('max_ratio', max_ratio);
+  settings.set('max_ratio_act', $('max_ratio_act').getProperty('value').toInt());
+
+  var max_seeding_time = -1;
+  if($('max_seeding_time_checkbox').getProperty('checked')) {
+    max_seeding_time = $('max_seeding_time_value').getProperty('value').toInt();
+    if(isNaN(max_seeding_time) || max_seeding_time < 0 || max_seeding_time > 525600) {
+      alert("QBT_TR(Seeding time limit must be between 0 and 525600 minutes.)QBT_TR[CONTEXT=HttpServer]");
+      return;
+    }
+  }
+  settings.set('max_seeding_time_enabled', $('max_seeding_time_checkbox').getProperty('checked'));
+  settings.set('max_seeding_time', max_seeding_time);
   settings.set('max_ratio_act', $('max_ratio_act').getProperty('value').toInt());
 
   // Add trackers


### PR DESCRIPTION
This feature appears from time to time in the Issues section as a [Wishlist].  I use it heavily.

This allows to specify seeding a torrent for up to X minutes.  You can also mix it with the max share ratio option and the torrent will stop seeding if any of both rules applies first.

This PR has several changes:

1.- The method processBigRatios() was renamed to processShareLimits().  That's because the name was misleading in the first place since most people set "1" or "2" as a share ratio limit and those are not big numbers, and also because this method now also process seeding time limits.

2.- Sadly I couldn't change the name of max_ratio_act for the action to apply to the torrent when it's completed in the WebUI because that would break backward compatibility.

3.- The ETA method now returns qMin(ratio_eta,seeding_time_eta), that is the lowest time between reaching the ratio or reaching the time limit.

4.- The option dialog was changed to this:

![qBittorrent Options](http://i.imgur.com/IoiKlgj.png)

5.- The WebUI was changed to this:

![WebUI Options](http://i.imgur.com/pEFPhi3.png)

6.- And finally the torrent share settings to:

![WebUI Torrent Setting](http://i.imgur.com/u0yPXaH.png)

It works great!  I've been using it for months.

Hope you like it.
