### PR TITLE
Fix RSS isn't automarking articles as read. Closes #4260.

### DIFF
--- a/src/gui/rss/rssfeed.cpp
+++ b/src/gui/rss/rssfeed.cpp
@@ -32,6 +32,7 @@
 #include "rssfeed.h"
 #include "rssmanager.h"
 #include "core/bittorrent/session.h"
+#include "core/bittorrent/magneturi.h"
 #include "rssfolder.h"
 #include "core/preferences.h"
 #include "core/qinisettings.h"
@@ -371,8 +372,11 @@ void RssFeed::downloadArticleTorrentIfMatching(RssDownloadRuleList* rules, const
   }
 
   Logger::instance()->addMessage(tr("Automatically downloading '%1' torrent from '%2' RSS feed...").arg(article->title()).arg(displayName()));
-  connect(BitTorrent::Session::instance(), SIGNAL(downloadFromUrlFinished(QString)), article.data(), SLOT(handleTorrentDownloadSuccess(const QString&)), Qt::UniqueConnection);
   connect(article.data(), SIGNAL(articleWasRead()), SLOT(handleArticleStateChanged()), Qt::UniqueConnection);
+  if (BitTorrent::MagnetUri(torrent_url).isValid())
+      article->markAsRead();
+  else
+      connect(BitTorrent::Session::instance(), SIGNAL(downloadFromUrlFinished(QString)), article.data(), SLOT(handleTorrentDownloadSuccess(const QString&)), Qt::UniqueConnection);
 
   BitTorrent::AddTorrentParams params;
   params.savePath = matching_rule->savePath();


### PR DESCRIPTION
@sledgehammer999 this is yet another v3.3 hotfix so merge it before 3.3.1 release.