### PR TITLE
Change update URL to FossHub. Closes #4188

### DIFF
--- a/src/gui/programupdater.cpp
+++ b/src/gui/programupdater.cpp
@@ -50,149 +50,157 @@ const QUrl RSS_URL("http://sourceforge.net/projects/qbittorrent/rss?path=/qbitto
 const QString FILE_EXT = "EXE";
 #endif
 
-ProgramUpdater::ProgramUpdater(QObject *parent, bool invokedByUser) :
-  QObject(parent), m_invokedByUser(invokedByUser)
+ProgramUpdater::ProgramUpdater(QObject *parent, bool invokedByUser)
+    : QObject(parent)
+    , m_invokedByUser(invokedByUser)
 {
-  mp_manager = new QNetworkAccessManager(this);
-  Preferences* const pref = Preferences::instance();
-  // Proxy support
-  if (pref->isProxyEnabled()) {
-    QNetworkProxy proxy;
-    switch(pref->getProxyType()) {
-    case Proxy::SOCKS4:
-    case Proxy::SOCKS5:
-    case Proxy::SOCKS5_PW:
-      proxy.setType(QNetworkProxy::Socks5Proxy);
-    default:
-      proxy.setType(QNetworkProxy::HttpProxy);
-      break;
+    m_networkManager = new QNetworkAccessManager(this);
+    Preferences* const pref = Preferences::instance();
+    // Proxy support
+    if (pref->isProxyEnabled()) {
+        QNetworkProxy proxy;
+        switch(pref->getProxyType()) {
+        case Proxy::SOCKS4:
+        case Proxy::SOCKS5:
+        case Proxy::SOCKS5_PW:
+            proxy.setType(QNetworkProxy::Socks5Proxy);
+        default:
+            proxy.setType(QNetworkProxy::HttpProxy);
+            break;
+        }
+        proxy.setHostName(pref->getProxyIp());
+        proxy.setPort(pref->getProxyPort());
+        // Proxy authentication
+        if (pref->isProxyAuthEnabled()) {
+            proxy.setUser(pref->getProxyUsername());
+            proxy.setPassword(pref->getProxyPassword());
+        }
+        m_networkManager->setProxy(proxy);
     }
-    proxy.setHostName(pref->getProxyIp());
-    proxy.setPort(pref->getProxyPort());
-    // Proxy authentication
-    if (pref->isProxyAuthEnabled()) {
-      proxy.setUser(pref->getProxyUsername());
-      proxy.setPassword(pref->getProxyPassword());
-    }
-    mp_manager->setProxy(proxy);
-  }
 }
 
-ProgramUpdater::~ProgramUpdater() {
-  delete mp_manager;
+ProgramUpdater::~ProgramUpdater()
+{
+    delete m_networkManager;
 }
 
 void ProgramUpdater::checkForUpdates()
 {
-  // SIGNAL/SLOT
-  connect(mp_manager, SIGNAL(finished(QNetworkReply*)),
-          this, SLOT(rssDownloadFinished(QNetworkReply*)));
-  // Send the request
-  QNetworkRequest request(RSS_URL);
-  request.setRawHeader("User-Agent", QString("qBittorrent/%1 ProgramUpdater (www.qbittorrent.org)").arg(VERSION).toLocal8Bit());
-  mp_manager->get(request);
+    // SIGNAL/SLOT
+    connect(m_networkManager, SIGNAL(finished(QNetworkReply*)),
+            this, SLOT(rssDownloadFinished(QNetworkReply*)));
+    // Send the request
+    QNetworkRequest request(RSS_URL);
+    request.setRawHeader("User-Agent", QString("qBittorrent/%1 ProgramUpdater (www.qbittorrent.org)").arg(VERSION).toLocal8Bit());
+    m_networkManager->get(request);
 }
 
-void ProgramUpdater::setUpdateUrl(QString title) {
-  m_updateUrl = "http://downloads.sourceforge.net/project/qbittorrent"+title;
-  qDebug("The Update URL is %s", qPrintable(m_updateUrl));
+void ProgramUpdater::setUpdateUrl(QString title)
+{
+    m_updateUrl = "http://downloads.sourceforge.net/project/qbittorrent" + title;
+    qDebug("The Update URL is %s", qPrintable(m_updateUrl));
 }
 
 void ProgramUpdater::rssDownloadFinished(QNetworkReply *reply)
 {
-  // Disconnect SIGNAL/SLOT
-  disconnect(mp_manager, 0, this, 0);
-  qDebug("Finished downloading the new qBittorrent updates RSS");
-  QString new_version;
-  if (!reply->error()) {
-    qDebug("No download error, good.");
-    QXmlStreamReader xml(reply);
-    QString item_title;
-    bool in_title = false;
-    bool in_item = false;
-    while (!xml.atEnd()) {
-      xml.readNext();
-      if (xml.isStartElement()) {
-        if (in_item && xml.name() == "title") {
-          in_title = true;
-          item_title = "";
-        } else if (xml.name() == "item") {
-          in_item = true;
-        }
-      } else if (xml.isEndElement()) {
-        if (in_item && xml.name() == "title") {
-          in_title = false;
-          const QString ext = Utils::Fs::fileExtension(item_title).toUpper();
-          qDebug("Found an update with file extension: %s", qPrintable(ext));
-          if (ext == FILE_EXT) {
-            qDebug("The last update available is %s", qPrintable(item_title));
-            new_version = extractVersionNumber(item_title);
-            if (!new_version.isEmpty()) {
-              qDebug("Detected version is %s", qPrintable(new_version));
-              if (isVersionMoreRecent(new_version))
-                setUpdateUrl(item_title);
+    // Disconnect SIGNAL/SLOT
+    disconnect(m_networkManager, 0, this, 0);
+    qDebug("Finished downloading the new qBittorrent updates RSS");
+    QString new_version;
+    if (!reply->error()) {
+        qDebug("No download error, good.");
+        QXmlStreamReader xml(reply);
+        QString item_title;
+        bool in_title = false;
+        bool in_item = false;
+        while (!xml.atEnd()) {
+            xml.readNext();
+            if (xml.isStartElement()) {
+                if (in_item && xml.name() == "title") {
+                    in_title = true;
+                    item_title = "";
+                }
+                else if (xml.name() == "item") {
+                    in_item = true;
+                }
             }
-            break;
-          }
-        } else if (xml.name() == "item") {
-          in_item = false;
+            else if (xml.isEndElement()) {
+                if (in_item && xml.name() == "title") {
+                    in_title = false;
+                    const QString ext = Utils::Fs::fileExtension(item_title).toUpper();
+                    qDebug("Found an update with file extension: %s", qPrintable(ext));
+                    if (ext == FILE_EXT) {
+                        qDebug("The last update available is %s", qPrintable(item_title));
+                        new_version = extractVersionNumber(item_title);
+                        if (!new_version.isEmpty()) {
+                            qDebug("Detected version is %s", qPrintable(new_version));
+                            if (isVersionMoreRecent(new_version))
+                                setUpdateUrl(item_title);
+                        }
+                        break;
+                    }
+                }
+                else if (xml.name() == "item") {
+                    in_item = false;
+                }
+            }
+            else if (xml.isCharacters() && !xml.isWhitespace()) {
+                if (in_item && in_title)
+                    item_title += xml.text().toString();
+            }
         }
-      } else if (xml.isCharacters() && !xml.isWhitespace()) {
-        if (in_item && in_title)
-          item_title += xml.text().toString();
-      }
     }
-  }
-  emit updateCheckFinished(!m_updateUrl.isEmpty(), new_version, m_invokedByUser);
-  // Clean up
-  reply->deleteLater();
+    emit updateCheckFinished(!m_updateUrl.isEmpty(), new_version, m_invokedByUser);
+    // Clean up
+    reply->deleteLater();
 }
 
 void ProgramUpdater::updateProgram()
 {
-  Q_ASSERT(!m_updateUrl.isEmpty());
-  QDesktopServices::openUrl(m_updateUrl);
-  return;
+    Q_ASSERT(!m_updateUrl.isEmpty());
+    QDesktopServices::openUrl(m_updateUrl);
+    return;
 }
 
 // title on Windows: /qbittorrent-win32/qbittorrent-2.4.7/qbittorrent_2.4.7_setup.exe
 // title on Mac: /qbittorrent-mac/qbittorrent-2.4.4/qbittorrent-2.4.4.dmg
 QString ProgramUpdater::extractVersionNumber(const QString& title) const
 {
-  qDebug() << Q_FUNC_INFO << title;
-  QRegExp regVer("qbittorrent[_-]([0-9.]+)(_setup)?(\\.exe|\\.dmg)");
-  if (regVer.indexIn(title)  < 0) {
-    qWarning() << Q_FUNC_INFO << "Failed to extract version from file name:" << title;
-    return QString::null;
-  } else {
-    QString version = regVer.cap(1);
-    qDebug() << Q_FUNC_INFO << "Extracted version:" << version;
-    return version;
-  }
+    qDebug() << Q_FUNC_INFO << title;
+    QRegExp regVer("qbittorrent[_-]([0-9.]+)(_setup)?(\\.exe|\\.dmg)");
+    if (regVer.indexIn(title)  < 0) {
+        qWarning() << Q_FUNC_INFO << "Failed to extract version from file name:" << title;
+        return QString::null;
+    }
+    else {
+        QString version = regVer.cap(1);
+        qDebug() << Q_FUNC_INFO << "Extracted version:" << version;
+        return version;
+    }
 }
 
-bool ProgramUpdater::isVersionMoreRecent(const QString& remote_version) const
+bool ProgramUpdater::isVersionMoreRecent(const QString &remoteVersion) const
 {
-  QRegExp regVer("([0-9.]+)");
-  if (regVer.indexIn(QString(VERSION)) >= 0) {
-    QString local_version = regVer.cap(1);
-    qDebug() << Q_FUNC_INFO << "local version:" << local_version << "/" << VERSION;
-    QStringList remote_parts = remote_version.split('.');
-    QStringList local_parts = local_version.split('.');
-    for (int i=0; i<qMin(remote_parts.size(), local_parts.size()); ++i) {
-      if (remote_parts[i].toInt() > local_parts[i].toInt())
-        return true;
-      if (remote_parts[i].toInt() < local_parts[i].toInt())
-        return false;
+    QRegExp regVer("([0-9.]+)");
+    if (regVer.indexIn(QString(VERSION)) >= 0) {
+        QString localVersion = regVer.cap(1);
+        qDebug() << Q_FUNC_INFO << "local version:" << localVersion << "/" << VERSION;
+        QStringList remoteParts = remoteVersion.split('.');
+        QStringList localParts = localVersion.split('.');
+        for (int i = 0; i<qMin(remoteParts.size(), localParts.size()); ++i) {
+            if (remoteParts[i].toInt() > localParts[i].toInt())
+                return true;
+            if (remoteParts[i].toInt() < localParts[i].toInt())
+                return false;
+        }
+        // Compared parts were equal, if remote version is longer, then it's more recent (2.9.2.1 > 2.9.2)
+        if (remoteParts.size() > localParts.size())
+            return true;
+        // versions are equal, check if the local version is a development release, in which case it is older (2.9.2beta < 2.9.2)
+        QRegExp regDevel("(alpha|beta|rc)");
+        if (regDevel.indexIn(VERSION) >= 0)
+            return true;
     }
-    // Compared parts were equal, if remote version is longer, then it's more recent (2.9.2.1 > 2.9.2)
-    if (remote_parts.size() > local_parts.size())
-      return true;
-    // versions are equal, check if the local version is a development release, in which case it is older (2.9.2beta < 2.9.2)
-    QRegExp regDevel("(alpha|beta|rc)");
-    if (regDevel.indexIn(VERSION) >= 0)
-      return true;
-  }
-  return false;
+    return false;
 }
 

--- a/src/gui/programupdater.h
+++ b/src/gui/programupdater.h
@@ -47,12 +47,10 @@ public:
     void updateProgram();
 
 protected:
-    QString extractVersionNumber(const QString& title) const;
     bool isVersionMoreRecent(const QString &remoteVersion) const;
 
 protected slots:
     void rssDownloadFinished(QNetworkReply* reply);
-    void setUpdateUrl(QString title);
 
 signals:
     void updateCheckFinished(bool updateAvailable, QString version, bool invokedByUser);

--- a/src/gui/programupdater.h
+++ b/src/gui/programupdater.h
@@ -37,7 +37,7 @@
 class QNetworkReply;
 class QNetworkAccessManager;
 
-class ProgramUpdater : public QObject
+class ProgramUpdater: public QObject
 {
     Q_OBJECT
 public:
@@ -48,18 +48,18 @@ public:
 
 protected:
     QString extractVersionNumber(const QString& title) const;
-    bool isVersionMoreRecent(const QString& new_version) const;
+    bool isVersionMoreRecent(const QString &remoteVersion) const;
 
 protected slots:
     void rssDownloadFinished(QNetworkReply* reply);
     void setUpdateUrl(QString title);
 
 signals:
-    void updateCheckFinished(bool update_available, QString version, bool invokedByUser);
+    void updateCheckFinished(bool updateAvailable, QString version, bool invokedByUser);
 
 private:
     QString m_updateUrl;
-    QNetworkAccessManager *mp_manager;
+    QNetworkAccessManager *m_networkManager;
     bool m_invokedByUser;
 };
 


### PR DESCRIPTION
After communication with FossHub, they created a feed containing the latest versions. That feed will autoupdate with the latest versions.

Any comments on the code?
Or at the feed/update notification from FossHub's part? They could implement something else if we ask.

@qbittorrent/qbittorrent-frequent-contributors 