### PR TITLE
Improve the "Watch folders" UI. Closes #4300.

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -475,46 +475,15 @@ void Preferences::addTorrentsInPause(bool b)
     setValue("Preferences/Downloads/StartInPause", b);
 }
 
-QStringList Preferences::getScanDirs() const
+QVariantHash Preferences::getScanDirs() const
 {
-    QStringList originalList = value("Preferences/Downloads/ScanDirs").toStringList();
-    if (originalList.isEmpty())
-        return originalList;
-
-    QStringList newList;
-    foreach (const QString& s, originalList)
-        newList << Utils::Fs::fromNativePath(s);
-    return newList;
+    return value("Preferences/Downloads/ScanDirsV2").toHash();
 }
 
 // This must be called somewhere with data from the model
-void Preferences::setScanDirs(const QStringList &dirs)
+void Preferences::setScanDirs(const QVariantHash &dirs)
 {
-    QStringList newList;
-    if (!dirs.isEmpty())
-        foreach (const QString& s, dirs)
-            newList << Utils::Fs::fromNativePath(s);
-    setValue("Preferences/Downloads/ScanDirs", newList);
-}
-
-QList<bool> Preferences::getDownloadInScanDirs() const
-{
-    return Utils::Misc::boolListfromStringList(value("Preferences/Downloads/DownloadInScanDirs").toStringList());
-}
-
-void Preferences::setDownloadInScanDirs(const QList<bool> &list)
-{
-    setValue("Preferences/Downloads/DownloadInScanDirs", Utils::Misc::toStringList(list));
-}
-
-void Preferences::setScanDirsDownloadPaths(const QStringList &downloadpaths)
-{
-    setValue("Preferences/Downloads/ScanDirsDownloadPaths", downloadpaths);
-}
-
-QStringList Preferences::getScanDirsDownloadPaths() const
-{
-    return value("Preferences/Downloads/ScanDirsDownloadPaths").toStringList();
+    setValue("Preferences/Downloads/ScanDirsV2", dirs);
 }
 
 QString Preferences::getScanDirsLastPath() const

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -176,13 +176,9 @@ public:
     void additionDialogFront(bool b);
     bool addTorrentsInPause() const;
     void addTorrentsInPause(bool b);
-    QStringList getScanDirs() const;
-    void setScanDirs(const QStringList &dirs);
-    QList<bool> getDownloadInScanDirs() const;
-    void setDownloadInScanDirs(const QList<bool> &list);
+    QVariantHash getScanDirs() const;
+    void setScanDirs(const QVariantHash &dirs);
     QString getScanDirsLastPath() const;
-    void setScanDirsDownloadPaths(const QStringList &downloadpaths);
-    QStringList getScanDirsDownloadPaths() const;
     void setScanDirsLastPath(const QString &path);
     bool isTorrentExportEnabled() const;
     QString getTorrentExportDir() const;

--- a/src/base/scanfoldersmodel.cpp
+++ b/src/base/scanfoldersmodel.cpp
@@ -122,11 +122,21 @@ QVariant ScanFoldersModel::data(const QModelIndex &index, int role) const
             value = Utils::Fs::toNativePath(pathData->watchPath);
         break;
     case DOWNLOAD:
-        if (role == Qt::DisplayRole) {
+        if (role == Qt::UserRole) {
             value = pathData->downloadType;
         }
-        else if ((role == Qt::UserRole) && (pathData->downloadType == CUSTOM_LOCATION)) {
-            value = pathData->downloadPath;
+        else if (role == Qt::DisplayRole) {
+            switch (pathData->downloadType) {
+            case DOWNLOAD_IN_WATCH_FOLDER:
+                value = tr("Watch Folder");
+                break;
+            case DEFAULT_LOCATION:
+                value = tr("Default Folder");
+                break;
+            case CUSTOM_LOCATION:
+                value = pathData->downloadPath;
+                break;
+            }
         }
         break;
     }
@@ -178,7 +188,7 @@ bool ScanFoldersModel::setData(const QModelIndex &index, const QVariant &value, 
         || (index.column() != DOWNLOAD))
         return false;
 
-    if (role == Qt::DisplayRole) {
+    if (role == Qt::UserRole) {
         PathType type = static_cast<PathType>(value.toInt());
         if (type == CUSTOM_LOCATION)
             return false;
@@ -187,7 +197,7 @@ bool ScanFoldersModel::setData(const QModelIndex &index, const QVariant &value, 
         m_pathList[index.row()]->downloadPath.clear();
         emit dataChanged(index, index);
     }
-    else if (role == Qt::UserRole) {
+    else if (role == Qt::DisplayRole) {
         QString path = value.toString();
         if (path.isEmpty()) // means we didn't pass CUSTOM_LOCATION type
             return false;

--- a/src/base/scanfoldersmodel.cpp
+++ b/src/base/scanfoldersmodel.cpp
@@ -203,7 +203,7 @@ bool ScanFoldersModel::setData(const QModelIndex &index, const QVariant &value, 
     return true;
 }
 
-ScanFoldersModel::PathStatus ScanFoldersModel::addPath(const QString &watchPath, const PathType &downloadType, const QString &downloadPath)
+ScanFoldersModel::PathStatus ScanFoldersModel::addPath(const QString &watchPath, const PathType &downloadType, const QString &downloadPath, bool addToFSWatcher)
 {
     QDir watchDir(watchPath);
     if (!watchDir.exists()) return DoesNotExist;
@@ -225,8 +225,21 @@ ScanFoldersModel::PathStatus ScanFoldersModel::addPath(const QString &watchPath,
     endInsertRows();
 
     // Start scanning
-    m_fsWatcher->addPath(canonicalWatchPath);
+    if (addToFSWatcher)
+        m_fsWatcher->addPath(canonicalWatchPath);
     return Ok;
+}
+
+void ScanFoldersModel::addToFSWatcher(const QStringList &watchPaths)
+{
+    if (!m_fsWatcher)
+        return; // addPath() wasn't called before this
+
+    foreach (const QString &path, watchPaths) {
+        QDir watchDir(path);
+        const QString &canonicalWatchPath = watchDir.canonicalPath();
+        m_fsWatcher->addPath(canonicalWatchPath);
+    }
 }
 
 void ScanFoldersModel::removePath(int row)

--- a/src/base/scanfoldersmodel.cpp
+++ b/src/base/scanfoldersmodel.cpp
@@ -268,22 +268,29 @@ void ScanFoldersModel::addToFSWatcher(const QStringList &watchPaths)
     }
 }
 
-void ScanFoldersModel::removePath(int row)
+void ScanFoldersModel::removePath(int row, bool removeFromFSWatcher)
 {
     Q_ASSERT((row >= 0) && (row < rowCount()));
     beginRemoveRows(QModelIndex(), row, row);
-    m_fsWatcher->removePath(m_pathList.at(row)->watchPath);
+    if (removeFromFSWatcher)
+        m_fsWatcher->removePath(m_pathList.at(row)->watchPath);
     m_pathList.removeAt(row);
     endRemoveRows();
 }
 
-bool ScanFoldersModel::removePath(const QString &path)
+bool ScanFoldersModel::removePath(const QString &path, bool removeFromFSWatcher)
 {
     const int row = findPathData(path);
     if (row == -1) return false;
 
-    removePath(row);
+    removePath(row, removeFromFSWatcher);
     return true;
+}
+
+void ScanFoldersModel::removeFromFSWatcher(const QStringList &watchPaths)
+{
+    foreach (const QString &path, watchPaths)
+        m_fsWatcher->removePath(path);
 }
 
 bool ScanFoldersModel::downloadInWatchFolder(const QString &filePath) const

--- a/src/base/scanfoldersmodel.cpp
+++ b/src/base/scanfoldersmodel.cpp
@@ -230,6 +230,22 @@ ScanFoldersModel::PathStatus ScanFoldersModel::addPath(const QString &watchPath,
     return Ok;
 }
 
+ScanFoldersModel::PathStatus ScanFoldersModel::updatePath(const QString &watchPath, const PathType& downloadType, const QString &downloadPath)
+{
+    QDir watchDir(watchPath);
+    const QString &canonicalWatchPath = watchDir.canonicalPath();
+    int row = findPathData(canonicalWatchPath);
+    if (row == -1) return DoesNotExist;
+
+    QDir downloadDir(downloadPath);
+    const QString &canonicalDownloadPath = downloadDir.canonicalPath();
+
+    m_pathList.at(row)->downloadType = downloadType;
+    m_pathList.at(row)->downloadPath = Utils::Fs::toNativePath(canonicalDownloadPath);
+
+    return Ok;
+}
+
 void ScanFoldersModel::addToFSWatcher(const QStringList &watchPaths)
 {
     if (!m_fsWatcher)

--- a/src/base/scanfoldersmodel.cpp
+++ b/src/base/scanfoldersmodel.cpp
@@ -37,37 +37,25 @@
 #include "utils/misc.h"
 #include "utils/fs.h"
 #include "preferences.h"
+#include "logger.h"
 #include "filesystemwatcher.h"
 #include "bittorrent/session.h"
 #include "scanfoldersmodel.h"
 
-namespace
+struct ScanFoldersModel::PathData
 {
-    const int PathColumn = 0;
-    const int DownloadAtTorrentColumn = 1;
-    const int DownloadPath = 2;
-}
-
-class ScanFoldersModel::PathData
-{
-public:
-    PathData(const QString &path)
-        : path(path)
-        , downloadAtPath(false)
-        , downloadPath(path)
-    {
-    }
-
-    PathData(const QString &path, bool downloadAtPath, const QString &downloadPath)
-        : path(path)
-        , downloadAtPath(downloadAtPath)
+    PathData(const QString &watchPath, const PathType &type, const QString &downloadPath)
+        : watchPath(watchPath)
+        , downloadType(type)
         , downloadPath(downloadPath)
     {
+        if (this->downloadPath.isEmpty() && downloadType == CUSTOM_LOCATION)
+            downloadType = DEFAULT_LOCATION;
     }
 
-    const QString path; //watching directory
-    bool downloadAtPath; //if TRUE save data to watching directory
-    QString downloadPath; //if 'downloadAtPath' FALSE use this path for save data
+    QString watchPath;
+    PathType downloadType;
+    QString downloadPath; // valid for CUSTOM_LOCATION
 };
 
 ScanFoldersModel *ScanFoldersModel::m_instance = 0;
@@ -96,7 +84,7 @@ ScanFoldersModel *ScanFoldersModel::instance()
 }
 
 ScanFoldersModel::ScanFoldersModel(QObject *parent)
-    : QAbstractTableModel(parent)
+    : QAbstractListModel(parent)
     , m_fsWatcher(0)
 {
     configure();
@@ -116,7 +104,7 @@ int ScanFoldersModel::rowCount(const QModelIndex &parent) const
 int ScanFoldersModel::columnCount(const QModelIndex &parent) const
 {
     Q_UNUSED(parent);
-    return 3;
+    return NB_COLUMNS;
 }
 
 QVariant ScanFoldersModel::data(const QModelIndex &index, int role) const
@@ -128,17 +116,17 @@ QVariant ScanFoldersModel::data(const QModelIndex &index, int role) const
     QVariant value;
 
     switch (index.column()) {
-    case PathColumn:
+    case WATCH:
         if (role == Qt::DisplayRole)
-            value = Utils::Fs::toNativePath(pathData->path);
+            value = Utils::Fs::toNativePath(pathData->watchPath);
         break;
-    case DownloadAtTorrentColumn:
-        if (role == Qt::CheckStateRole)
-            value = pathData->downloadAtPath ? Qt::Checked : Qt::Unchecked;
-        break;
-    case DownloadPath:
-        if (role == Qt::DisplayRole || role == Qt::EditRole || role == Qt::ToolTipRole)
-            value = Utils::Fs::toNativePath(pathData->downloadPath);
+    case DOWNLOAD:
+        if (role == Qt::DisplayRole) {
+            value = pathData->downloadType;
+        }
+        else if ((role == Qt::UserRole) && (pathData->downloadType == CUSTOM_LOCATION)) {
+            value = pathData->downloadPath;
+        }
         break;
     }
 
@@ -153,14 +141,11 @@ QVariant ScanFoldersModel::headerData(int section, Qt::Orientation orientation, 
     QVariant title;
 
     switch (section) {
-    case PathColumn:
+    case WATCH:
         title = tr("Watched Folder");
         break;
-    case DownloadAtTorrentColumn:
-        title = tr("Download here");
-        break;
-    case DownloadPath:
-        title = tr("Download path");
+    case DOWNLOAD:
+        title = tr("Save Files to");
         break;
     }
 
@@ -170,23 +155,16 @@ QVariant ScanFoldersModel::headerData(int section, Qt::Orientation orientation, 
 Qt::ItemFlags ScanFoldersModel::flags(const QModelIndex &index) const
 {
     if (!index.isValid() || (index.row() >= rowCount()))
-        return QAbstractTableModel::flags(index);
+        return QAbstractListModel::flags(index);
 
-    const PathData *pathData = m_pathList.at(index.row());
     Qt::ItemFlags flags;
 
     switch (index.column()) {
-    case PathColumn:
-        flags = QAbstractTableModel::flags(index);
+    case WATCH:
+        flags = QAbstractListModel::flags(index);
         break;
-    case DownloadAtTorrentColumn:
-        flags = QAbstractTableModel::flags(index) | Qt::ItemIsUserCheckable;
-        break;
-    case DownloadPath:
-        if (pathData->downloadAtPath == false)
-            flags = QAbstractTableModel::flags(index) | Qt::ItemIsEditable | Qt::ItemIsEnabled;
-        else
-            flags = QAbstractTableModel::flags(index) ^ Qt::ItemIsEnabled; //dont edit DownloadPath if checked 'downloadAtPath'
+    case DOWNLOAD:
+        flags = QAbstractListModel::flags(index) | Qt::ItemIsEditable;
         break;
     }
 
@@ -195,42 +173,46 @@ Qt::ItemFlags ScanFoldersModel::flags(const QModelIndex &index) const
 
 bool ScanFoldersModel::setData(const QModelIndex &index, const QVariant &value, int role)
 {
-    if (!index.isValid() || (index.row() >= rowCount()) || (index.column() > DownloadPath))
+    if (!index.isValid() || (index.row() >= rowCount()) || (index.column() >= columnCount())
+        || (index.column() != DOWNLOAD))
         return false;
 
-    bool success = true;
+    if (role == Qt::DisplayRole) {
+        PathType type = static_cast<PathType>(value.toInt());
+        if (type == CUSTOM_LOCATION)
+            return false;
 
-    switch (index.column()) {
-    case PathColumn:
-        success = false;
-        break;
-    case DownloadAtTorrentColumn:
-        if (role == Qt::CheckStateRole) {
-            Q_ASSERT(index.column() == DownloadAtTorrentColumn);
-            m_pathList[index.row()]->downloadAtPath = (value.toInt() == Qt::Checked);
-            emit dataChanged(index, index);
-            success = true;
-        }
-        break;
-    case DownloadPath:
-        Q_ASSERT(index.column() == DownloadPath);
-        m_pathList[index.row()]->downloadPath = value.toString();
+        m_pathList[index.row()]->downloadType = type;
+        m_pathList[index.row()]->downloadPath.clear();
         emit dataChanged(index, index);
-        success = true;
-        break;
+    }
+    else if (role == Qt::UserRole) {
+        QString path = value.toString();
+        if (path.isEmpty()) // means we didn't pass CUSTOM_LOCATION type
+            return false;
+
+        m_pathList[index.row()]->downloadType = CUSTOM_LOCATION;
+        m_pathList[index.row()]->downloadPath = Utils::Fs::toNativePath(path);
+        emit dataChanged(index, index);
+    }
+    else {
+        return false;
     }
 
-    return success;
+    return true;
 }
 
-ScanFoldersModel::PathStatus ScanFoldersModel::addPath(const QString &path, bool downloadAtPath, const QString &downloadPath)
+ScanFoldersModel::PathStatus ScanFoldersModel::addPath(const QString &watchPath, const PathType &downloadType, const QString &downloadPath)
 {
-    QDir dir(path);
-    if (!dir.exists()) return DoesNotExist;
-    if (!dir.isReadable()) return CannotRead;
+    QDir watchDir(watchPath);
+    if (!watchDir.exists()) return DoesNotExist;
+    if (!watchDir.isReadable()) return CannotRead;
 
-    const QString &canonicalPath = dir.canonicalPath();
-    if (findPathData(canonicalPath) != -1) return AlreadyInList;
+    const QString &canonicalWatchPath = watchDir.canonicalPath();
+    if (findPathData(canonicalWatchPath) != -1) return AlreadyInList;
+
+    QDir downloadDir(downloadPath);
+    const QString &canonicalDownloadPath = downloadDir.canonicalPath();
 
     if (!m_fsWatcher) {
         m_fsWatcher = new FileSystemWatcher(this);
@@ -238,12 +220,11 @@ ScanFoldersModel::PathStatus ScanFoldersModel::addPath(const QString &path, bool
     }
 
     beginInsertRows(QModelIndex(), rowCount(), rowCount());
-    QString downloadToPath = downloadPath.isEmpty() ? path : downloadPath;
-    m_pathList << new PathData(canonicalPath, downloadAtPath, downloadToPath);
+    m_pathList << new PathData(Utils::Fs::toNativePath(canonicalWatchPath), downloadType, Utils::Fs::toNativePath(canonicalDownloadPath));
     endInsertRows();
 
     // Start scanning
-    m_fsWatcher->addPath(canonicalPath);
+    m_fsWatcher->addPath(canonicalWatchPath);
     return Ok;
 }
 
@@ -251,7 +232,7 @@ void ScanFoldersModel::removePath(int row)
 {
     Q_ASSERT((row >= 0) && (row < rowCount()));
     beginRemoveRows(QModelIndex(), row, row);
-    m_fsWatcher->removePath(m_pathList.at(row)->path);
+    m_fsWatcher->removePath(m_pathList.at(row)->watchPath);
     m_pathList.removeAt(row);
     endRemoveRows();
 }
@@ -265,43 +246,37 @@ bool ScanFoldersModel::removePath(const QString &path)
     return true;
 }
 
-ScanFoldersModel::PathStatus ScanFoldersModel::setDownloadAtPath(int row, bool downloadAtPath)
-{
-    Q_ASSERT((row >= 0) && (row < rowCount()));
-
-    bool &oldValue = m_pathList[row]->downloadAtPath;
-    if (oldValue != downloadAtPath) {
-        if (downloadAtPath) {
-            QTemporaryFile testFile(m_pathList[row]->path + "/tmpFile");
-            if (!testFile.open()) return CannotWrite;
-        }
-
-        oldValue = downloadAtPath;
-        const QModelIndex changedIndex = index(row, DownloadAtTorrentColumn);
-        emit dataChanged(changedIndex, changedIndex);
-    }
-
-    return Ok;
-}
-
-bool ScanFoldersModel::downloadInTorrentFolder(const QString &filePath) const
+bool ScanFoldersModel::downloadInWatchFolder(const QString &filePath) const
 {
     const int row = findPathData(QFileInfo(filePath).dir().path());
     Q_ASSERT(row != -1);
-    return m_pathList.at(row)->downloadAtPath;
+    PathData *data = m_pathList.at(row);
+    return (data->downloadType == DOWNLOAD_IN_WATCH_FOLDER);
+}
+
+bool ScanFoldersModel::downloadInDefaultFolder(const QString &filePath) const
+{
+    const int row = findPathData(QFileInfo(filePath).dir().path());
+    Q_ASSERT(row != -1);
+    PathData *data = m_pathList.at(row);
+    return (data->downloadType == DEFAULT_LOCATION);
 }
 
 QString ScanFoldersModel::downloadPathTorrentFolder(const QString &filePath) const
 {
     const int row = findPathData(QFileInfo(filePath).dir().path());
     Q_ASSERT(row != -1);
-    return  m_pathList.at(row)->downloadPath;
+    PathData *data = m_pathList.at(row);
+    if (data->downloadType == CUSTOM_LOCATION)
+        return data->downloadPath;
+
+    return  QString();
 }
 
 int ScanFoldersModel::findPathData(const QString &path) const
 {
     for (int i = 0; i < m_pathList.count(); ++i)
-        if (m_pathList.at(i)->path == Utils::Fs::fromNativePath(path))
+        if (m_pathList.at(i)->watchPath == Utils::Fs::toNativePath(path))
             return i;
 
     return -1;
@@ -309,33 +284,27 @@ int ScanFoldersModel::findPathData(const QString &path) const
 
 void ScanFoldersModel::makePersistent()
 {
-    Preferences *const pref = Preferences::instance();
-    QStringList paths;
-    QList<bool> downloadInFolderInfo;
-    QStringList downloadPaths;
+    QVariantHash dirs;
+
     foreach (const PathData *pathData, m_pathList) {
-        paths << pathData->path;
-        downloadInFolderInfo << pathData->downloadAtPath;
-        downloadPaths << pathData->downloadPath;
+        if (pathData->downloadType == CUSTOM_LOCATION)
+            dirs.insert(Utils::Fs::fromNativePath(pathData->watchPath), Utils::Fs::fromNativePath(pathData->downloadPath));
+        else
+            dirs.insert(Utils::Fs::fromNativePath(pathData->watchPath), pathData->downloadType);
     }
 
-    pref->setScanDirs(paths);
-    pref->setDownloadInScanDirs(downloadInFolderInfo);
-    pref->setScanDirsDownloadPaths(downloadPaths);
+    Preferences::instance()->setScanDirs(dirs);
 }
 
 void ScanFoldersModel::configure()
 {
-    Preferences *const pref = Preferences::instance();
+    QVariantHash dirs = Preferences::instance()->getScanDirs();
 
-    int i = 0;
-    QStringList downloadPaths = pref->getScanDirsDownloadPaths();
-    QList<bool> downloadInDirList = pref->getDownloadInScanDirs();
-    foreach (const QString &dir, pref->getScanDirs()) {
-        bool downloadInDir = downloadInDirList.value(i, true);
-        QString downloadPath = downloadPaths.value(i); //empty string if out-of-bounds
-        addPath(dir, downloadInDir, downloadPath);
-        ++i;
+    for (QVariantHash::const_iterator i = dirs.begin(), e = dirs.end(); i != e; ++i) {
+        if (i.value().type() == QVariant::Int)
+            addPath(i.key(), static_cast<PathType>(i.value().toInt()), QString());
+        else
+            addPath(i.key(), CUSTOM_LOCATION, i.value().toString());
     }
 }
 
@@ -343,10 +312,17 @@ void ScanFoldersModel::addTorrentsToSession(const QStringList &pathList)
 {
     foreach (const QString &file, pathList) {
         qDebug("File %s added", qPrintable(file));
+
+        BitTorrent::AddTorrentParams params;
+        if (downloadInWatchFolder(file))
+            params.savePath = QFileInfo(file).dir().path();
+        else if (!downloadInDefaultFolder(file))
+            params.savePath = downloadPathTorrentFolder(file);
+
         if (file.endsWith(".magnet")) {
             QFile f(file);
             if (f.open(QIODevice::ReadOnly)) {
-                BitTorrent::Session::instance()->addTorrent(QString::fromLocal8Bit(f.readAll()));
+                BitTorrent::Session::instance()->addTorrent(QString::fromLocal8Bit(f.readAll()), params);
                 f.remove();
             }
             else {
@@ -354,12 +330,6 @@ void ScanFoldersModel::addTorrentsToSession(const QStringList &pathList)
             }
         }
         else {
-            BitTorrent::AddTorrentParams params;
-            if (downloadInTorrentFolder(file))
-                params.savePath = QFileInfo(file).dir().path();
-            else
-                params.savePath = downloadPathTorrentFolder(file); //if empty it will use the default savePath
-
             BitTorrent::TorrentInfo torrentInfo = BitTorrent::TorrentInfo::loadFromFile(file);
             if (torrentInfo.isValid()) {
                 BitTorrent::Session::instance()->addTorrent(torrentInfo, params);

--- a/src/base/scanfoldersmodel.h
+++ b/src/base/scanfoldersmodel.h
@@ -85,13 +85,16 @@ public:
     PathStatus updatePath(const QString &watchPath, const PathType& downloadType, const QString &downloadPath);
     // PRECONDITION: The paths must have been added with addPath() first.
     void addToFSWatcher(const QStringList &watchPaths);
-    void removePath(int row);
-    bool removePath(const QString &path);
+    void removePath(int row, bool removeFromFSWatcher = true);
+    bool removePath(const QString &path, bool removeFromFSWatcher = true);
+    void removeFromFSWatcher(const QStringList &watchPaths);
 
     void makePersistent();
 
-private slots:
+public slots:
     void configure();
+
+private slots:
     void addTorrentsToSession(const QStringList &pathList);
 
 private:

--- a/src/base/scanfoldersmodel.h
+++ b/src/base/scanfoldersmodel.h
@@ -82,6 +82,7 @@ public:
     // TODO: removePaths(); singular version becomes private helper functions;
     // also: remove functions should take modelindexes
     PathStatus addPath(const QString &watchPath, const PathType& downloadType, const QString &downloadPath, bool addToFSWatcher = true);
+    PathStatus updatePath(const QString &watchPath, const PathType& downloadType, const QString &downloadPath);
     // PRECONDITION: The paths must have been added with addPath() first.
     void addToFSWatcher(const QStringList &watchPaths);
     void removePath(int row);

--- a/src/base/scanfoldersmodel.h
+++ b/src/base/scanfoldersmodel.h
@@ -81,7 +81,9 @@ public:
 
     // TODO: removePaths(); singular version becomes private helper functions;
     // also: remove functions should take modelindexes
-    PathStatus addPath(const QString &watchPath, const PathType& downloadType, const QString &downloadPath);
+    PathStatus addPath(const QString &watchPath, const PathType& downloadType, const QString &downloadPath, bool addToFSWatcher = true);
+    // PRECONDITION: The paths must have been added with addPath() first.
+    void addToFSWatcher(const QStringList &watchPaths);
     void removePath(int row);
     bool removePath(const QString &path);
 

--- a/src/base/scanfoldersmodel.h
+++ b/src/base/scanfoldersmodel.h
@@ -31,7 +31,7 @@
 #ifndef SCANFOLDERSMODEL_H
 #define SCANFOLDERSMODEL_H
 
-#include <QAbstractTableModel>
+#include <QAbstractListModel>
 #include <QList>
 
 QT_BEGIN_NAMESPACE
@@ -40,7 +40,7 @@ QT_END_NAMESPACE
 
 class FileSystemWatcher;
 
-class ScanFoldersModel : public QAbstractTableModel
+class ScanFoldersModel : public QAbstractListModel
 {
     Q_OBJECT
     Q_DISABLE_COPY(ScanFoldersModel)
@@ -55,6 +55,20 @@ public:
         AlreadyInList
     };
 
+    enum Column
+    {
+        WATCH,
+        DOWNLOAD,
+        NB_COLUMNS
+    };
+
+    enum PathType
+    {
+        DOWNLOAD_IN_WATCH_FOLDER,
+        DEFAULT_LOCATION,
+        CUSTOM_LOCATION
+    };
+
     static bool initInstance(QObject *parent = 0);
     static void freeInstance();
     static ScanFoldersModel *instance();
@@ -67,13 +81,10 @@ public:
 
     // TODO: removePaths(); singular version becomes private helper functions;
     // also: remove functions should take modelindexes
-    PathStatus addPath(const QString &path, bool downloadAtPath, const QString &downloadPath);
+    PathStatus addPath(const QString &watchPath, const PathType& downloadType, const QString &downloadPath);
     void removePath(int row);
     bool removePath(const QString &path);
-    PathStatus setDownloadAtPath(int row, bool downloadAtPath);
 
-    bool downloadInTorrentFolder(const QString &filePath) const;
-    QString downloadPathTorrentFolder(const QString &filePath) const;
     void makePersistent();
 
 private slots:
@@ -85,9 +96,14 @@ private:
     ~ScanFoldersModel();
 
     virtual bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
-    static ScanFoldersModel *m_instance;
-    class PathData;
+    bool downloadInWatchFolder(const QString &filePath) const;
+    bool downloadInDefaultFolder(const QString &filePath) const;
+    QString downloadPathTorrentFolder(const QString &filePath) const;
     int findPathData(const QString &path) const;
+
+private:
+    static ScanFoldersModel *m_instance;
+    struct PathData;
 
     QList<PathData*> m_pathList;
     FileSystemWatcher *m_fsWatcher;

--- a/src/gui/gui.pri
+++ b/src/gui/gui.pri
@@ -42,6 +42,7 @@ HEADERS += \
     $$PWD/shutdownconfirm.h \
     $$PWD/torrentmodel.h \
     $$PWD/torrentcreatordlg.h \
+    $$PWD/scanfoldersdelegate.h \
     $$PWD/search/searchwidget.h \
     $$PWD/search/searchtab.h \
     $$PWD/search/pluginselectdlg.h \
@@ -79,6 +80,7 @@ SOURCES += \
     $$PWD/shutdownconfirm.cpp \
     $$PWD/torrentmodel.cpp \
     $$PWD/torrentcreatordlg.cpp \
+    $$PWD/scanfoldersdelegate.cpp \
     $$PWD/search/searchwidget.cpp \
     $$PWD/search/searchtab.cpp \
     $$PWD/search/pluginselectdlg.cpp \

--- a/src/gui/options.ui
+++ b/src/gui/options.ui
@@ -745,6 +745,9 @@
                       <attribute name="headerDefaultSectionSize">
                        <number>80</number>
                       </attribute>
+                      <attribute name="headerStretchLastSection">
+                       <bool>false</bool>
+                      </attribute>
                      </widget>
                     </item>
                     <item>
@@ -2724,7 +2727,7 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>89</width>
+             <width>98</width>
              <height>28</height>
             </rect>
            </property>

--- a/src/gui/options.ui
+++ b/src/gui/options.ui
@@ -714,7 +714,7 @@
                   <item>
                    <layout class="QHBoxLayout" name="horizontalLayout_16">
                     <item>
-                     <widget class="QTableView" name="scanFoldersView">
+                     <widget class="QTreeView" name="scanFoldersView">
                       <property name="sizePolicy">
                        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
                         <horstretch>0</horstretch>
@@ -727,29 +727,23 @@
                         <height>150</height>
                        </size>
                       </property>
+                      <property name="editTriggers">
+                       <set>QAbstractItemView::AllEditTriggers</set>
+                      </property>
                       <property name="selectionMode">
                        <enum>QAbstractItemView::SingleSelection</enum>
                       </property>
                       <property name="selectionBehavior">
                        <enum>QAbstractItemView::SelectRows</enum>
                       </property>
-                      <property name="showGrid">
+                      <property name="textElideMode">
+                       <enum>Qt::ElideNone</enum>
+                      </property>
+                      <property name="rootIsDecorated">
                        <bool>false</bool>
                       </property>
-                      <property name="sortingEnabled">
-                       <bool>true</bool>
-                      </property>
-                      <attribute name="horizontalHeaderDefaultSectionSize">
+                      <attribute name="headerDefaultSectionSize">
                        <number>80</number>
-                      </attribute>
-                      <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
-                       <bool>false</bool>
-                      </attribute>
-                      <attribute name="horizontalHeaderStretchLastSection">
-                       <bool>true</bool>
-                      </attribute>
-                      <attribute name="verticalHeaderVisible">
-                       <bool>false</bool>
                       </attribute>
                      </widget>
                     </item>

--- a/src/gui/options_imp.cpp
+++ b/src/gui/options_imp.cpp
@@ -419,6 +419,7 @@ void options_imp::saveOptions()
     pref->useAdditionDialog(useAdditionDialog());
     pref->additionDialogFront(checkAdditionDialogFront->isChecked());
     pref->addTorrentsInPause(addTorrentsInPause());
+    ScanFoldersModel::instance()->addToFSWatcher(addedScanDirs);
     ScanFoldersModel::instance()->makePersistent();
     addedScanDirs.clear();
     pref->setTorrentExportDir(getTorrentExportDir());
@@ -1204,7 +1205,7 @@ void options_imp::on_addScanFolderButton_clicked()
     const QString dir = QFileDialog::getExistingDirectory(this, tr("Add directory to scan"),
                                                           Utils::Fs::toNativePath(Utils::Fs::folderName(pref->getScanDirsLastPath())));
     if (!dir.isEmpty()) {
-        const ScanFoldersModel::PathStatus status = ScanFoldersModel::instance()->addPath(dir, ScanFoldersModel::DOWNLOAD_IN_WATCH_FOLDER, QString());
+        const ScanFoldersModel::PathStatus status = ScanFoldersModel::instance()->addPath(dir, ScanFoldersModel::DOWNLOAD_IN_WATCH_FOLDER, QString(), false);
         QString error;
         switch (status) {
         case ScanFoldersModel::AlreadyInList:

--- a/src/gui/options_imp.cpp
+++ b/src/gui/options_imp.cpp
@@ -1209,7 +1209,7 @@ void options_imp::on_addScanFolderButton_clicked()
         QString error;
         switch (status) {
         case ScanFoldersModel::AlreadyInList:
-            error = tr("Folder is already being watched.").arg(dir);
+            error = tr("Folder is already being watched.");
             break;
         case ScanFoldersModel::DoesNotExist:
             error = tr("Folder does not exist.");

--- a/src/gui/options_imp.h
+++ b/src/gui/options_imp.h
@@ -42,6 +42,7 @@ enum DoubleClickAction
 };
 
 class AdvancedSettings;
+class ScanFoldersDelegate;
 
 QT_BEGIN_NAMESPACE
 class QCloseEvent;
@@ -172,6 +173,7 @@ private:
     QAbstractButton *applyButton;
     AdvancedSettings *advancedSettings;
     QList<QString> addedScanDirs;
+    ScanFoldersDelegate *m_scanDelegate;
     // SSL Cert / key
     QByteArray m_sslCert, m_sslKey;
 };

--- a/src/gui/options_imp.h
+++ b/src/gui/options_imp.h
@@ -173,6 +173,7 @@ private:
     QAbstractButton *applyButton;
     AdvancedSettings *advancedSettings;
     QList<QString> addedScanDirs;
+    QList<QString> removedScanDirs;
     ScanFoldersDelegate *m_scanDelegate;
     // SSL Cert / key
     QByteArray m_sslCert, m_sslKey;

--- a/src/gui/scanfoldersdelegate.cpp
+++ b/src/gui/scanfoldersdelegate.cpp
@@ -1,0 +1,183 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2015  sledgehammer999
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ *
+ * Contact : hammered999@gmail.com
+ */
+
+#include <QPainter>
+#include <QComboBox>
+#include <QFileDialog>
+#include <QTreeView>
+#include <QItemSelectionModel>
+
+#include "base/scanfoldersmodel.h"
+#include "base/preferences.h"
+#include "scanfoldersdelegate.h"
+
+
+ScanFoldersDelegate::ScanFoldersDelegate(QObject *parent, QTreeView *foldersView)
+    : QItemDelegate(parent)
+    , m_folderView(foldersView)
+{
+}
+
+ScanFoldersDelegate::~ScanFoldersDelegate() {}
+
+void ScanFoldersDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
+{
+    painter->save();
+
+    switch(index.column()) {
+    case ScanFoldersModel::WATCH:
+        QItemDelegate::paint(painter, option, index);
+        break;
+
+    case ScanFoldersModel::DOWNLOAD: {
+        QStyleOptionViewItemV2 opt = QItemDelegate::setOptions(index, option);
+        QItemDelegate::drawBackground(painter, opt, index);
+        QString text;
+
+        switch (index.data().toInt()) {
+        case ScanFoldersModel::DOWNLOAD_IN_WATCH_FOLDER:
+            text = tr("Watch Folder");
+            break;
+        case ScanFoldersModel::DEFAULT_LOCATION:
+            text = tr("Default Folder");
+            break;
+        case ScanFoldersModel::CUSTOM_LOCATION:
+            text = index.data(Qt::UserRole).toString();
+            break;
+        }
+        QItemDelegate::drawDisplay(painter, opt, option.rect, text);
+        break;
+    }
+
+    default:
+        break;
+    }
+
+    painter->restore();
+}
+
+void ScanFoldersDelegate::setEditorData(QWidget *editor, const QModelIndex &index) const
+{
+    QComboBox *combobox = static_cast<QComboBox*>(editor);
+    // Set combobox index
+    if (index.data().toInt() == ScanFoldersModel::CUSTOM_LOCATION)
+        combobox->setCurrentIndex(4); // '4' is the index of the item after the separator in the QComboBox menu
+    else
+        combobox->setCurrentIndex(index.data().toInt());
+}
+
+QWidget *ScanFoldersDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &, const QModelIndex &index) const
+{
+    if (index.column() != ScanFoldersModel::DOWNLOAD) return 0;
+
+    QComboBox* editor = new QComboBox(parent);
+    editor->setFocusPolicy(Qt::StrongFocus);
+    editor->addItem(tr("Watch Folder"));
+    editor->addItem(tr("Default Folder"));
+    editor->addItem(tr("Browse..."));
+    if (index.data().toInt() == ScanFoldersModel::CUSTOM_LOCATION) {
+        editor->insertSeparator(3);
+        editor->addItem(index.data(Qt::UserRole).toString());
+    }
+
+    connect(editor, SIGNAL(currentIndexChanged(int)), this, SLOT(comboboxIndexChanged(int)));
+    return editor;
+}
+
+void ScanFoldersDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const
+{
+    QComboBox *combobox = static_cast<QComboBox*>(editor);
+    int value = combobox->currentIndex();
+
+    switch(value)  {
+    case ScanFoldersModel::DOWNLOAD_IN_WATCH_FOLDER:
+    case ScanFoldersModel::DEFAULT_LOCATION:
+        model->setData(index, value, Qt::DisplayRole);
+        break;
+
+    case 4: // '4' is the index of the item after the separator in the QComboBox menu
+        model->setData(index, combobox->currentText(), Qt::UserRole);
+        break;
+
+    default:
+        break;
+    }
+}
+
+void ScanFoldersDelegate::updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &) const
+{
+    qDebug("UpdateEditor Geometry called");
+    editor->setGeometry(option.rect);
+}
+
+void ScanFoldersDelegate::comboboxIndexChanged(int index)
+{
+    if (index < 2)
+        return;
+
+    if (index == 2) {
+        QString path;
+        QString newPath;
+        QModelIndexList selIndex = m_folderView->selectionModel()->selectedRows(1);
+
+        if (selIndex.isEmpty())
+            return;
+
+        ScanFoldersModel::PathType type = static_cast<ScanFoldersModel::PathType>(selIndex.at(0).data().toInt());
+
+        if (type == ScanFoldersModel::CUSTOM_LOCATION)
+            path = selIndex.at(0).data(Qt::UserRole).toString();
+        else
+            path = Preferences::instance()->getSavePath();
+
+        newPath = QFileDialog::getExistingDirectory(0, tr("Choose save path"), path);
+        QComboBox *combobox = static_cast<QComboBox*>(sender());
+        disconnect(combobox, SIGNAL(currentIndexChanged(int)), this, SLOT(comboboxIndexChanged(int)));
+
+        if (!newPath.isEmpty()) {
+            if (combobox->count() != 5) {
+                combobox->insertSeparator(3);
+                combobox->addItem(newPath);
+            }
+            else {
+                combobox->setItemText(4, newPath);
+            }
+            combobox->setCurrentIndex(4);
+        }
+        else {
+            if (type == ScanFoldersModel::CUSTOM_LOCATION)
+                combobox->setCurrentIndex(4);
+            else
+                combobox->setCurrentIndex(type);
+        }
+
+        connect(combobox, SIGNAL(currentIndexChanged(int)), this, SLOT(comboboxIndexChanged(int)));
+    }
+}

--- a/src/gui/scanfoldersdelegate.cpp
+++ b/src/gui/scanfoldersdelegate.cpp
@@ -46,50 +46,14 @@ ScanFoldersDelegate::ScanFoldersDelegate(QObject *parent, QTreeView *foldersView
 {
 }
 
-void ScanFoldersDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
-{
-    painter->save();
-
-    switch(index.column()) {
-    case ScanFoldersModel::WATCH:
-        QItemDelegate::paint(painter, option, index);
-        break;
-
-    case ScanFoldersModel::DOWNLOAD: {
-        QStyleOptionViewItemV2 opt = QItemDelegate::setOptions(index, option);
-        QItemDelegate::drawBackground(painter, opt, index);
-        QString text;
-
-        switch (index.data().toInt()) {
-        case ScanFoldersModel::DOWNLOAD_IN_WATCH_FOLDER:
-            text = tr("Watch Folder");
-            break;
-        case ScanFoldersModel::DEFAULT_LOCATION:
-            text = tr("Default Folder");
-            break;
-        case ScanFoldersModel::CUSTOM_LOCATION:
-            text = index.data(Qt::UserRole).toString();
-            break;
-        }
-        QItemDelegate::drawDisplay(painter, opt, option.rect, text);
-        break;
-    }
-
-    default:
-        break;
-    }
-
-    painter->restore();
-}
-
 void ScanFoldersDelegate::setEditorData(QWidget *editor, const QModelIndex &index) const
 {
     QComboBox *combobox = static_cast<QComboBox*>(editor);
     // Set combobox index
-    if (index.data().toInt() == ScanFoldersModel::CUSTOM_LOCATION)
+    if (index.data(Qt::UserRole).toInt() == ScanFoldersModel::CUSTOM_LOCATION)
         combobox->setCurrentIndex(4); // '4' is the index of the item after the separator in the QComboBox menu
     else
-        combobox->setCurrentIndex(index.data().toInt());
+        combobox->setCurrentIndex(index.data(Qt::UserRole).toInt());
 }
 
 QWidget *ScanFoldersDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &, const QModelIndex &index) const
@@ -102,9 +66,9 @@ QWidget *ScanFoldersDelegate::createEditor(QWidget *parent, const QStyleOptionVi
     editor->addItem(tr("Watch Folder"));
     editor->addItem(tr("Default Folder"));
     editor->addItem(tr("Browse..."));
-    if (index.data().toInt() == ScanFoldersModel::CUSTOM_LOCATION) {
+    if (index.data(Qt::UserRole).toInt() == ScanFoldersModel::CUSTOM_LOCATION) {
         editor->insertSeparator(3);
-        editor->addItem(index.data(Qt::UserRole).toString());
+        editor->addItem(index.data().toString());
     }
 
     connect(editor, SIGNAL(currentIndexChanged(int)), this, SLOT(comboboxIndexChanged(int)));
@@ -128,7 +92,7 @@ void ScanFoldersDelegate::setModelData(QWidget *editor, QAbstractItemModel *mode
     switch (value) {
     case ScanFoldersModel::DOWNLOAD_IN_WATCH_FOLDER:
     case ScanFoldersModel::DEFAULT_LOCATION:
-        model->setData(index, value, Qt::DisplayRole);
+        model->setData(index, value, Qt::UserRole);
         break;
 
     case ScanFoldersModel::CUSTOM_LOCATION:
@@ -136,10 +100,10 @@ void ScanFoldersDelegate::setModelData(QWidget *editor, QAbstractItemModel *mode
                     index,
                     QFileDialog::getExistingDirectory(
                         0, tr("Choose save path"),
-                        index.data().toInt() == ScanFoldersModel::CUSTOM_LOCATION ?
-                            index.data(Qt::UserRole).toString() :
+                        index.data(Qt::UserRole).toInt() == ScanFoldersModel::CUSTOM_LOCATION ?
+                            index.data().toString() :
                             Preferences::instance()->getSavePath()),
-                    Qt::UserRole);
+                    Qt::DisplayRole);
         break;
 
     default:

--- a/src/gui/scanfoldersdelegate.h
+++ b/src/gui/scanfoldersdelegate.h
@@ -1,0 +1,65 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2015  sledgehammer999
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ *
+ * Contact : hammered999@gmail.com
+ */
+
+#ifndef SCANFOLDERSDELEGATE_H
+#define SCANFOLDERSDELEGATE_H
+
+#include <QItemDelegate>
+
+class QPainter;
+class QModelIndex;
+class QStyleOptionViewItem;
+class QAbstractItemModel;
+class PropertiesWidget;
+class QTreeView;
+
+class ScanFoldersDelegate : public QItemDelegate
+{
+    Q_OBJECT
+
+public:
+    ScanFoldersDelegate(QObject *parent, QTreeView *foldersView);
+    ~ScanFoldersDelegate();
+
+    void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+    void setEditorData(QWidget *editor, const QModelIndex &index) const;
+    QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &, const QModelIndex &index) const;
+
+public slots:
+    void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
+    void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &) const;
+    void comboboxIndexChanged(int index);
+
+private:
+    QTreeView *m_folderView;
+};
+
+#endif // SCANFOLDERSDELEGATE_H
+

--- a/src/gui/scanfoldersdelegate.h
+++ b/src/gui/scanfoldersdelegate.h
@@ -46,18 +46,17 @@ class ScanFoldersDelegate : public QItemDelegate
 
 public:
     ScanFoldersDelegate(QObject *parent, QTreeView *foldersView);
-    ~ScanFoldersDelegate();
 
+private slots:
+    void comboboxIndexChanged(int index);
+
+private:
+    void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
+    void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &) const;
     void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
     void setEditorData(QWidget *editor, const QModelIndex &index) const;
     QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &, const QModelIndex &index) const;
 
-public slots:
-    void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
-    void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &) const;
-    void comboboxIndexChanged(int index);
-
-private:
     QTreeView *m_folderView;
 };
 

--- a/src/gui/scanfoldersdelegate.h
+++ b/src/gui/scanfoldersdelegate.h
@@ -53,7 +53,6 @@ private slots:
 private:
     void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
     void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &) const;
-    void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
     void setEditorData(QWidget *editor, const QModelIndex &index) const;
     QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &, const QModelIndex &index) const;
 

--- a/src/webui/extra_translations.h
+++ b/src/webui/extra_translations.h
@@ -87,6 +87,8 @@ static const char *__TRANSLATIONS__[] = {
     QT_TRANSLATE_NOOP("HttpServer", "Save files to location:")
     QT_TRANSLATE_NOOP("HttpServer", "Label:")
     QT_TRANSLATE_NOOP("HttpServer", "Cookie:")
+    QT_TRANSLATE_NOOP("HttpServer", "Type folder here")
+    QT_TRANSLATE_NOOP("HttpServer", "Other...")
 };
 
 static const struct { const char *source; const char *comment; } __COMMENTED_TRANSLATIONS__[] = {

--- a/src/webui/prefjson.cpp
+++ b/src/webui/prefjson.cpp
@@ -58,7 +58,7 @@ QByteArray prefjson::getPreferences()
     data["temp_path"] = Utils::Fs::toNativePath(pref->getTempPath());
     data["preallocate_all"] = pref->preAllocateAllFiles();
     data["incomplete_files_ext"] = pref->useIncompleteFilesExtension();
-    QVariantList scanDirs;
+    /*QVariantList scanDirs;
     foreach (const QString& s, pref->getScanDirs()) {
         scanDirs << Utils::Fs::toNativePath(s);
     }
@@ -72,7 +72,7 @@ QByteArray prefjson::getPreferences()
     foreach (bool b, pref->getDownloadInScanDirs()) {
         var_list << b;
     }
-    data["download_in_scan_dirs"] = var_list;
+    data["download_in_scan_dirs"] = var_list;*/
     data["export_dir"] = Utils::Fs::toNativePath(pref->getTorrentExportDir());
     data["export_dir_fin"] = Utils::Fs::toNativePath(pref->getFinishedTorrentExportDir());
     // Email notification upon download completion
@@ -188,7 +188,7 @@ void prefjson::setPreferences(const QString& json)
         pref->preAllocateAllFiles(m["preallocate_all"].toBool());
     if (m.contains("incomplete_files_ext"))
         pref->useIncompleteFilesExtension(m["incomplete_files_ext"].toBool());
-    if (m.contains("scan_dirs") && m.contains("download_in_scan_dirs") && m.contains("scan_dirs_download_paths")) {
+    /*if (m.contains("scan_dirs") && m.contains("download_in_scan_dirs") && m.contains("scan_dirs_download_paths")) {
         QVariantList download_at_path_tmp = m["download_in_scan_dirs"].toList();
         QList<bool> download_at_path;
         foreach (QVariant var, download_at_path_tmp) {
@@ -217,7 +217,7 @@ void prefjson::setPreferences(const QString& json)
                 ++i;
             }
         }
-    }
+    }*/
     if (m.contains("export_dir"))
         pref->setTorrentExportDir(m["export_dir"].toString());
     if (m.contains("export_dir_fin"))

--- a/src/webui/prefjson.cpp
+++ b/src/webui/prefjson.cpp
@@ -58,21 +58,15 @@ QByteArray prefjson::getPreferences()
     data["temp_path"] = Utils::Fs::toNativePath(pref->getTempPath());
     data["preallocate_all"] = pref->preAllocateAllFiles();
     data["incomplete_files_ext"] = pref->useIncompleteFilesExtension();
-    /*QVariantList scanDirs;
-    foreach (const QString& s, pref->getScanDirs()) {
-        scanDirs << Utils::Fs::toNativePath(s);
+    QVariantHash dirs = pref->getScanDirs();
+    QVariantHash nativeDirs;
+    for (QVariantHash::const_iterator i = dirs.begin(), e = dirs.end(); i != e; ++i) {
+        if (i.value().type() == QVariant::Int)
+            nativeDirs.insert(Utils::Fs::toNativePath(i.key()), i.value().toInt());
+        else
+            nativeDirs.insert(Utils::Fs::toNativePath(i.key()), Utils::Fs::toNativePath(i.value().toString()));
     }
-    data["scan_dirs"] = scanDirs;
-    QVariantList ScanDirsDownloadPaths;
-    foreach (const QString& s, pref->getScanDirsDownloadPaths()) {
-        ScanDirsDownloadPaths << Utils::Fs::toNativePath(s);
-    }
-    data["scan_dirs_download_paths"] = ScanDirsDownloadPaths;
-    QVariantList var_list;
-    foreach (bool b, pref->getDownloadInScanDirs()) {
-        var_list << b;
-    }
-    data["download_in_scan_dirs"] = var_list;*/
+    data["scan_dirs"] = nativeDirs;
     data["export_dir"] = Utils::Fs::toNativePath(pref->getTorrentExportDir());
     data["export_dir_fin"] = Utils::Fs::toNativePath(pref->getFinishedTorrentExportDir());
     // Email notification upon download completion
@@ -188,36 +182,51 @@ void prefjson::setPreferences(const QString& json)
         pref->preAllocateAllFiles(m["preallocate_all"].toBool());
     if (m.contains("incomplete_files_ext"))
         pref->useIncompleteFilesExtension(m["incomplete_files_ext"].toBool());
-    /*if (m.contains("scan_dirs") && m.contains("download_in_scan_dirs") && m.contains("scan_dirs_download_paths")) {
-        QVariantList download_at_path_tmp = m["download_in_scan_dirs"].toList();
-        QList<bool> download_at_path;
-        foreach (QVariant var, download_at_path_tmp) {
-            download_at_path << var.toBool();
-        }
-        QStringList old_folders = pref->getScanDirs();
-        QStringList new_folders = m["scan_dirs"].toStringList();
-        QStringList download_paths = m["scan_dirs_download_paths"].toStringList();
-        if (download_at_path.size() == new_folders.size()) {
-            pref->setScanDirs(new_folders);
-            pref->setDownloadInScanDirs(download_at_path);
-            pref->setScanDirsDownloadPaths(download_paths);
-            foreach (const QString &old_folder, old_folders) {
-                // Update deleted folders
-                if (!new_folders.contains(old_folder)) {
-                    ScanFoldersModel::instance()->removePath(old_folder);
-                }
+    if (m.contains("scan_dirs")) {
+        QVariantMap nativeDirs = m["scan_dirs"].toMap();
+        QVariantHash oldScanDirs = pref->getScanDirs();
+        QVariantHash scanDirs;
+        ScanFoldersModel *model = ScanFoldersModel::instance();
+        for (QVariantMap::const_iterator i = nativeDirs.begin(), e = nativeDirs.end(); i != e; ++i) {
+            QString folder = Utils::Fs::fromNativePath(i.key());
+            QString downloadPath;
+            ScanFoldersModel::PathStatus ec;
+            if (i.value().type() == QVariant::String) {
+                downloadPath = Utils::Fs::fromNativePath(i.value().toString());
+                if (!oldScanDirs.contains(folder))
+                    ec = model->addPath(folder, ScanFoldersModel::CUSTOM_LOCATION, downloadPath);
+                else
+                    ec = model->updatePath(folder, ScanFoldersModel::CUSTOM_LOCATION, downloadPath);
+                if (ec == ScanFoldersModel::Ok)
+                    scanDirs.insert(folder, downloadPath);
+            } else {
+                int downloadType = i.value().toInt();
+                if (!oldScanDirs.contains(folder))
+                    ec = model->addPath(folder, static_cast<ScanFoldersModel::PathType>(downloadType), QString());
+                else
+                    ec = model->updatePath(folder, static_cast<ScanFoldersModel::PathType>(downloadType), QString());
+                if (ec == ScanFoldersModel::Ok)
+                    scanDirs.insert(folder, downloadType);
+                // Just for a more readable debug later
+                downloadPath = (downloadType == 0) ? "Watch folder" : "Default folder";
             }
-            int i = 0;
-            foreach (const QString &new_folder, new_folders) {
-                qDebug("New watched folder: %s", qPrintable(new_folder));
-                // Update new folders
-                if (!old_folders.contains(Utils::Fs::fromNativePath(new_folder))) {
-                    ScanFoldersModel::instance()->addPath(new_folder, download_at_path.at(i), download_paths.at(i));
-                }
-                ++i;
+            // Debug
+            if (ec == ScanFoldersModel::Ok)
+                qDebug("New watched folder: %s to %s", qPrintable(folder), qPrintable(downloadPath));
+            else
+                qDebug("Watched folder %s failed with error %d", qPrintable(folder), (int) ec);
+        }
+
+        // Update deleted folders
+        foreach (QVariant folderVariant, oldScanDirs.keys()) {
+            QString folder = folderVariant.toString();
+            if (!scanDirs.contains(folder)) {
+                model->removePath(folder);
+                qDebug("Removed watched folder %s", qPrintable(folder));
             }
         }
-    }*/
+        pref->setScanDirs(scanDirs);
+    }
     if (m.contains("export_dir"))
         pref->setTorrentExportDir(m["export_dir"].toString());
     if (m.contains("export_dir_fin"))

--- a/src/webui/www/public/css/style.css
+++ b/src/webui/www/public/css/style.css
@@ -408,6 +408,37 @@ td.generalLabel {
     border: 1px solid black;
 }
 
+.select-watched-folder-editable {
+    position:relative;
+    background-color: white;
+    border: solid grey 1px;
+    width: 160px;
+    height: 20px;
+}
+
+.select-watched-folder-editable select {
+    position: absolute;
+    top: 0px;
+    bottom: 0px;
+    left: 0px;
+    border: none;
+    width: 160px;
+    margin: 0;
+}
+
+.select-watched-folder-editable input {
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    width: 140px;
+    padding: 1px;
+    border: none;
+}
+
+.select-watched-folder-editable select:focus, .select-editable input:focus {
+    outline: none;
+}
+
 /*
  * Workaround to prevent the transfer list from
  * disappearing when zooming in the browser.

--- a/src/webui/www/public/preferences_content.html
+++ b/src/webui/www/public/preferences_content.html
@@ -18,9 +18,22 @@
   </span><br/><br/>
   QBT_TR(Automatically add torrents from:)QBT_TR<br/>
     <table border="1" id="watched_folders_tab">
-    <thead><tr><th>QBT_TR(Watched Folder)QBT_TR</th><th>QBT_TR(Download here)QBT_TR</th></tr></thead>
+    <thead><tr><th>QBT_TR(Watched Folder)QBT_TR</th><th>QBT_TR(Save Files to)QBT_TR</th></tr></thead>
     <tbody></tbody>
-    <tfoot><tr><td style="padding-top:4px;"><input type="text" id="new_watch_folder_txt"/></td><td style="padding-top:4px;"><input type="checkbox" id="new_watch_folder_dl" style="padding-left:18px;"/><img src="theme/list-add" alt="Add" style="padding-left:2px;width:16px;cursor:pointer;margin-right:-18px;" onclick="addWatchFolder();"/></td></tr></tfoot>
+    <tfoot><tr>
+    <td style="padding-top:4px;"><input type="text" id="new_watch_folder_txt"/></td>
+    <td style="padding-top:4px;">
+    <div class="select-watched-folder-editable">
+      <select id="new_watch_folder_select" onchange="changeWatchFolderSelect(this)">
+        <option selected value="watch_folder">QBT_TR(Watch Folder)QBT_TR</option>
+        <option value="default_folder">QBT_TR(Default Folder)QBT_TR</option>
+        <option value="other">QBT_TR(Other...)QBT_TR</option>
+      </select>
+      <input id="new_watch_folder_other_txt" type="text" value="QBT_TR(Watch Folder)QBT_TR" onchange="changeWatchFolderText(this)" />
+      <img src="theme/list-add" alt="Add" style="padding-left:170px;width:16px;cursor:pointer;" onclick="addWatchFolder();"/>
+    </div>
+    </td>
+    </tr></tfoot>
     </table><br/>
   <input type="checkbox" id="exportdir_checkbox" onclick="updateExportDirEnabled();"/>
   <label for="exportdir_checkbox">QBT_TR(Copy .torrent files to:)QBT_TR</label>&nbsp;&nbsp;
@@ -412,38 +425,75 @@ updateTempDirEnabled = function() {
 
 addWatchFolder = function() {
   var new_folder = $('new_watch_folder_txt').getProperty('value').trim();
-  if(new_folder.length <= 0) return;
+  if (new_folder.length <= 0) return;
 
-  var checked = "";
-  if ($('new_watch_folder_dl').getProperty('checked') == true)
-      checked = "checked";
+  var new_other = $('new_watch_folder_other_txt').getProperty('value').trim();
+  if (new_other.length <= 0) return;
+
+  var new_select = $('new_watch_folder_select').getProperty('value').trim();
+
   var i = $('watched_folders_tab').getChildren('tbody')[0].getChildren('tr').length;
-
-  var myinput = "<input id='text_watch_"+ i +"' type='text' value='" + new_folder + "'>";
-  var mycb = "<input id='cb_watch_"+ i +"' type='checkbox' " + checked + ">";
-  WatchedFoldersTable.push([myinput, mycb]);
+  pushWatchFolder(i, new_folder, new_select, new_other);
 
   // Clear fields
   $('new_watch_folder_txt').setProperty('value', '');
-  $('new_watch_folder_dl').setProperty('checked', false);
+  var elt = $('new_watch_folder_select');
+  elt.setProperty('value', 'watch_folder');
+  var text = elt.options[elt.selectedIndex].innerHTML;
+  $('new_watch_folder_other_txt').setProperty('value', text);
+}
+
+changeWatchFolderSelect = function(item) {
+  if (item.value == "other") {
+    item.nextElementSibling.value = 'QBT_TR(Type folder here)QBT_TR';
+    item.nextElementSibling.select();
+  } else {
+    var text = item.options[item.selectedIndex].innerHTML;
+    item.nextElementSibling.value = text;
+  }
+}
+
+changeWatchFolderText = function(item) {
+  item.previousElementSibling.value = 'other';
+}
+
+pushWatchFolder = function(pos, folder, sel, other) {
+  var myinput = "<input id='text_watch_"+ pos +"' type='text' value='" + folder + "'>";
+  var mycb = "<div class='select-watched-folder-editable'>" +
+             "<select id ='cb_watch_" + pos + "' onchange='changeWatchFolderSelect(this)'>" +
+             "<option value='watch_folder'>QBT_TR(Watch Folder)QBT_TR</option>" +
+             "<option value='default_folder'>QBT_TR(Default Folder)QBT_TR</option>" +
+             "<option value='other'>QBT_TR(Other...)QBT_TR</option>" +
+             "</select>" +
+             "<input id='cb_watch_txt_" + pos + "' type='text' " +
+             "onchange='changeWatchFolderText(this)' /></div>";
+
+  WatchedFoldersTable.push([myinput, mycb]);
+  $('cb_watch_' + pos).setProperty('value', sel);
+  if (sel != "other") {
+    var elt = $('cb_watch_' + pos);
+    other = elt.options[elt.selectedIndex].innerHTML;
+  }
+  $('cb_watch_txt_'+ pos).setProperty('value', other);
 }
 
 getWatchedFolders = function() {
   var nb_folders = $("watched_folders_tab").getChildren("tbody")[0].getChildren("tr").length;
-  var folders = Array();
-  var download_in_place = Array();
-  for(var i=0; i<nb_folders; i+=1) {
-    var folder_path = $('text_watch_'+i).getProperty('value').trim();
-    if(folder_path.length > 0) {
-      folders[folders.length] = folder_path;
-      if($("cb_watch_"+i).getProperty('checked')) {
-        download_in_place[download_in_place.length] = 1;
+  var folders = new Hash();
+  for(var i = 0; i < nb_folders; i++) {
+    var fpath = $('text_watch_' + i).getProperty('value').trim();
+    if (fpath.length > 0) {
+      var other;
+      var sel = $('cb_watch_' + i).getProperty('value').trim();
+      if (sel == "other") {
+        other = $('cb_watch_txt_' + i).getProperty('value').trim();
       } else {
-        download_in_place[download_in_place.length] = 0;
+        other = (sel == "watch_folder") ? 0 : 1;
       }
+      folders.set(fpath, other);
     }
   }
-  return [folders, download_in_place];
+  return folders;
 }
 
 updateExportDirEnabled = function() {
@@ -714,14 +764,17 @@ loadPreferences = function() {
                     updateTempDirEnabled();
                     $('preallocateall_checkbox').setProperty('checked', pref.preallocate_all);
                     $('appendext_checkbox').setProperty('checked', pref.incomplete_files_ext);
-                    var i;
-                    for(i=0; i<pref.scan_dirs.length; i+=1) {
-                      var myinput = "<input id='text_watch_"+ i +"' type='text' value='" + pref.scan_dirs[i] + "'>";
-                      var checked = "";
-                      if (pref.download_in_scan_dirs[i])
-                          checked = "checked";
-                      var mycb = "<input id='cb_watch_"+ i +"' type='checkbox' " + checked + ">";
-                      WatchedFoldersTable.push([myinput, mycb]);
+                    var i = 0;
+                    for (var folder in pref.scan_dirs) {
+                      var sel;
+                      var other = "";
+                      if (typeof pref.scan_dirs[folder] == "string") {
+                         other = pref.scan_dirs[folder];
+                         sel = "other";
+                      } else {
+                         sel = (pref.scan_dirs[folder] == 0) ? "watch_folder" : "default_folder";
+                      }
+                      pushWatchFolder(i++, folder, sel, other);
                     }
                     if(pref.export_dir != '') {
                       $('exportdir_checkbox').setProperty('checked', true);
@@ -950,9 +1003,7 @@ applyPreferences = function() {
   settings.set('temp_path', $('temppath_text').getProperty('value'));
   settings.set('preallocate_all', $('preallocateall_checkbox').getProperty('checked'));
   settings.set('incomplete_files_ext', $('appendext_checkbox').getProperty('checked'));
-  var watched_folders = getWatchedFolders();
-  settings.set('scan_dirs', watched_folders[0]);
-  settings.set('download_in_scan_dirs', watched_folders[1]);
+  settings.set('scan_dirs', getWatchedFolders());
   if($('exportdir_checkbox').getProperty('checked'))
     settings.set('export_dir', $('exportdir_text').getProperty('value'));
   else


### PR DESCRIPTION
The old behavior for watch folders was to download to "default path" if the "Download Here" wasn't checked. It never asked the user for a path.

I have disabled the WebUI code. I can't code it. Help is very welcome.

This works fine with Qt4. For some reason Qt5 crashes when the "Choose a directory" dialog is closed. I cannot understand why. I hope someone can find the reason.

The preferences are saved in a "weird" way now. It saves the watch folders as stringlist.
Then it saves the download preferences as stringlist too. However, the first 2 options are of type int and the 3rd is a string(ie the download path). When saving the integers (enum values) are converted to string and when restoring they are read as strings but converted back to enum values.
If you can propose a better way, I'm all ears.

Plan for future: Now any path added via the options window is being watched by the fs_watcher even if the options window isn't accepted by the user yet. I plan to change this after this commit is finalized.

And finally here is a screenshot(updated):
![untitled](https://cloud.githubusercontent.com/assets/273315/12011505/c0bb82ee-acd8-11e5-955a-c759ab142e3f.jpg)

