### PR TITLE
Simplify signal handler

### DIFF
--- a/src/app/stacktrace_win.h
+++ b/src/app/stacktrace_win.h
@@ -18,6 +18,9 @@
 *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
 ***************************************************************************/
 
+#ifndef STACKTRACE_WIN_H
+#define STACKTRACE_WIN_H
+
 #include <windows.h>
 #include <dbghelp.h>
 #include <stdio.h>
@@ -266,3 +269,5 @@ const QString straceWin::getBacktrace()
 #pragma warning(pop)
 #pragma optimize("g", on)
 #endif
+
+#endif // STACKTRACE_WIN_H

--- a/src/app/stacktrace_win_dlg.h
+++ b/src/app/stacktrace_win_dlg.h
@@ -1,51 +1,80 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2015 The qBittorrent project
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ *
+ */
+
 #ifndef STACKTRACE_WIN_DLG_H
 #define STACKTRACE_WIN_DLG_H
 
-#include <QTextStream>
-#include <QClipboard>
+#include <QString>
+#include <QDialog>
 #include "boost/version.hpp"
 #include "libtorrent/version.hpp"
 #include "ui_stacktrace_win_dlg.h"
 
-class StraceDlg: public QDialog, private Ui::errorDialog
+class StraceDlg : public QDialog, private Ui::errorDialog
 {
     Q_OBJECT
 
 public:
-    StraceDlg(QWidget* parent = 0): QDialog(parent)
+    StraceDlg(QWidget* parent = 0)
+        : QDialog(parent)
     {
         setupUi(this);
     }
 
-    ~StraceDlg()
-    {
-    }
-
     void setStacktraceString(const QString& trace)
     {
-        QString htmlStr;
-        QTextStream outStream(&htmlStr);
-        outStream << "<p align=center><b><font size=7 color=red>" <<
-            "qBittorrent has crashed" <<
-            "</font></b></p>" <<
-            "<font size=4>" <<
-            "<p>" <<
-            "Please report a bug at <a href=\"http://bugs.qbittorrent.org\">" <<
-            "http://bugs.qbittorrent.org</a>" <<
-            " and provide the following backtrace." <<
-            "</p>" <<
-            "</font>" <<
-            "<br/><hr><br/>" <<
-            "<p align=center><font size=4>qBittorrent version: " << VERSION <<
-            "<br/>Libtorrent version: " << LIBTORRENT_VERSION <<
-            "<br/>Qt version: " << QT_VERSION_STR <<
-            "<br/>Boost version: " << QString::number(BOOST_VERSION / 100000) << '.' <<
-            QString::number((BOOST_VERSION / 100) % 1000) << '.' <<
-            QString::number(BOOST_VERSION % 100) << "</font></p><br/>"
-            "<pre><code>" <<
-            trace <<
-            "</code></pre>" <<
-            "<br/><hr><br/><br/>";
+        // try to call Qt function as less as possible
+        const int boostVerMajor = BOOST_VERSION / 100000;
+        const int boostVerMinor = ((BOOST_VERSION / 100) % 1000);
+        const int boostVerSubMin = BOOST_VERSION % 100;
+        QString htmlStr = QString(
+            "<p align=center><b><font size=7 color=red>"
+            "qBittorrent has crashed"
+            "</font></b></p>"
+            "<font size=4><p>"
+            "Please file a bug report at "
+            "<a href=\"http://bugs.qbittorrent.org\">http://bugs.qbittorrent.org</a> "
+            "and provide the following information:"
+            "</p></font>"
+            "<br/><hr><br/>"
+            "<p align=center><font size=4>"
+            "qBittorrent version: " VERSION "<br/>"
+            "Libtorrent version: " LIBTORRENT_VERSION "<br/>"
+            "Qt version: " QT_VERSION_STR "<br/>"
+            "Boost version: %1.%2.%3"
+            "</font></p><br/>"
+            "<pre><code>%4</code></pre>"
+            "<br/><hr><br/><br/>")
+            .arg(boostVerMajor)
+            .arg(boostVerMinor)
+            .arg(boostVerSubMin)
+            .arg(trace);
 
         errorText->setHtml(htmlStr);
     }


### PR DESCRIPTION
It's not possible to make signal handler perfectly safe, but at least non-safe function calls is much less than before; still, that shouldn't matter, since our signal handler is for program termination :p.
In the end, it's just some cleanup.

Was trying to print more useful infos (when crashed) on windows, like exception description, but later realized that is only possible in a `try()... catch()` block.

Tested on windows & linux.
