### PR TITLE
Improve .fastresume saving and torrents starting up. Closes #4315.

### DIFF
--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -36,6 +36,7 @@ HEADERS += \
     $$PWD/bittorrent/private/bandwidthscheduler.h \
     $$PWD/bittorrent/private/filterparserthread.h \
     $$PWD/bittorrent/private/statistics.h \
+    $$PWD/bittorrent/private/resumedatasavingmanager.h \
     $$PWD/rss/rssmanager.h \
     $$PWD/rss/rssfeed.h \
     $$PWD/rss/rssfolder.h \
@@ -87,6 +88,7 @@ SOURCES += \
     $$PWD/bittorrent/private/bandwidthscheduler.cpp \
     $$PWD/bittorrent/private/filterparserthread.cpp \
     $$PWD/bittorrent/private/statistics.cpp \
+    $$PWD/bittorrent/private/resumedatasavingmanager.cpp \
     $$PWD/rss/rssmanager.cpp \
     $$PWD/rss/rssfeed.cpp \
     $$PWD/rss/rssfolder.cpp \

--- a/src/base/bittorrent/private/resumedatasavingmanager.cpp
+++ b/src/base/bittorrent/private/resumedatasavingmanager.cpp
@@ -1,0 +1,54 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2015  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include <QDebug>
+#include <QFile>
+
+#include "base/utils/fs.h"
+#include "resumedatasavingmanager.h"
+
+ResumeDataSavingManager::ResumeDataSavingManager(const QString &resumeFolderPath)
+    : m_resumeDataDir(resumeFolderPath)
+{
+}
+
+void ResumeDataSavingManager::saveResumeData(QString infoHash, QByteArray data, int priority) const
+{
+    QStringList filters(QString("%1.fastresume.*").arg(infoHash));
+    const QStringList files = m_resumeDataDir.entryList(filters, QDir::Files, QDir::Unsorted);
+    foreach (const QString &file, files)
+        Utils::Fs::forceRemove(m_resumeDataDir.absoluteFilePath(file));
+
+    QString filename = QString("%1.fastresume.%2").arg(infoHash).arg(priority);
+    QString filepath = m_resumeDataDir.absoluteFilePath(filename);
+
+    qDebug() << "Saving resume data in" << filepath;
+    QFile resumeFile(filepath);
+    if (resumeFile.open(QIODevice::WriteOnly))
+        resumeFile.write(data);
+}

--- a/src/base/bittorrent/private/resumedatasavingmanager.cpp
+++ b/src/base/bittorrent/private/resumedatasavingmanager.cpp
@@ -37,14 +37,9 @@ ResumeDataSavingManager::ResumeDataSavingManager(const QString &resumeFolderPath
 {
 }
 
-void ResumeDataSavingManager::saveResumeData(QString infoHash, QByteArray data, int priority) const
+void ResumeDataSavingManager::saveResumeData(QString infoHash, QByteArray data) const
 {
-    QStringList filters(QString("%1.fastresume.*").arg(infoHash));
-    const QStringList files = m_resumeDataDir.entryList(filters, QDir::Files, QDir::Unsorted);
-    foreach (const QString &file, files)
-        Utils::Fs::forceRemove(m_resumeDataDir.absoluteFilePath(file));
-
-    QString filename = QString("%1.fastresume.%2").arg(infoHash).arg(priority);
+    QString filename = QString("%1.fastresume").arg(infoHash);
     QString filepath = m_resumeDataDir.absoluteFilePath(filename);
 
     qDebug() << "Saving resume data in" << filepath;

--- a/src/base/bittorrent/private/resumedatasavingmanager.cpp
+++ b/src/base/bittorrent/private/resumedatasavingmanager.cpp
@@ -27,8 +27,13 @@
  */
 
 #include <QDebug>
+#ifdef QBT_USES_QT5
+#include <QSaveFile>
+#else
 #include <QFile>
+#endif
 
+#include "base/logger.h"
 #include "base/utils/fs.h"
 #include "resumedatasavingmanager.h"
 
@@ -43,7 +48,18 @@ void ResumeDataSavingManager::saveResumeData(QString infoHash, QByteArray data) 
     QString filepath = m_resumeDataDir.absoluteFilePath(filename);
 
     qDebug() << "Saving resume data in" << filepath;
+#ifdef QBT_USES_QT5
+    QSaveFile resumeFile(filepath);
+#else
     QFile resumeFile(filepath);
-    if (resumeFile.open(QIODevice::WriteOnly))
+#endif
+    if (resumeFile.open(QIODevice::WriteOnly)) {
         resumeFile.write(data);
+#ifdef QBT_USES_QT5
+        if (!resumeFile.commit()) {
+            Logger::instance()->addMessage(QString("Couldn't save resume data in %1. Error: %2")
+                                           .arg(filepath).arg(resumeFile.errorString()), Log::WARNING);
+        }
+#endif
+    }
 }

--- a/src/base/bittorrent/private/resumedatasavingmanager.h
+++ b/src/base/bittorrent/private/resumedatasavingmanager.h
@@ -41,7 +41,7 @@ public:
     explicit ResumeDataSavingManager(const QString &resumeFolderPath);
 
 public slots:
-    void saveResumeData(QString infoHash, QByteArray data, int priority) const;
+    void saveResumeData(QString infoHash, QByteArray data) const;
 
 private:
     QDir m_resumeDataDir;

--- a/src/base/bittorrent/private/resumedatasavingmanager.h
+++ b/src/base/bittorrent/private/resumedatasavingmanager.h
@@ -1,0 +1,50 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2015  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#ifndef RESUMEDATASAVINGMANAGER_H
+#define RESUMEDATASAVINGMANAGER_H
+
+#include <QObject>
+#include <QByteArray>
+#include <QDir>
+
+class ResumeDataSavingManager: public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit ResumeDataSavingManager(const QString &resumeFolderPath);
+
+public slots:
+    void saveResumeData(QString infoHash, QByteArray data, int priority) const;
+
+private:
+    QDir m_resumeDataDir;
+};
+
+#endif // RESUMEDATASAVINGMANAGER_H

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1898,7 +1898,6 @@ void Session::startUpTorrents()
     QStringList fastresumes = resumeDataDir.entryList(
                 QStringList(QLatin1String("*.fastresume")), QDir::Files, QDir::Unsorted);
 
-    QString filePath;
     Logger *const logger = Logger::instance();
 
     typedef struct
@@ -1909,28 +1908,41 @@ void Session::startUpTorrents()
         QByteArray data;
     } TorrentResumeData;
 
+    auto startupTorrent = [this, logger, resumeDataDir](const TorrentResumeData &params)
+    {
+        QString filePath = resumeDataDir.filePath(QString("%1.torrent").arg(params.hash));
+        qDebug() << "Starting up torrent" << params.hash << "...";
+        if (!addTorrent_impl(params.addTorrentData, params.magnetUri, TorrentInfo::loadFromFile(filePath), params.data))
+            logger->addMessage(tr("Unable to resume torrent '%1'.", "e.g: Unable to resume torrent 'hash'.")
+                               .arg(params.hash), Log::CRITICAL);
+    };
+
     qDebug("Starting up torrents");
     qDebug("Queue size: %d", fastresumes.size());
     // Resume downloads
     QMap<int, TorrentResumeData> queuedResumeData;
+    int nextQueuePosition = 1;
     QRegExp rx(QLatin1String("^([A-Fa-f0-9]{40})\\.fastresume$"));
     foreach (const QString &fastresumeName, fastresumes) {
         if (rx.indexIn(fastresumeName) == -1) continue;
 
         QString hash = rx.cap(1);
-        QString fastresumePath =
-                resumeDataDir.absoluteFilePath(fastresumeName);
+        QString fastresumePath = resumeDataDir.absoluteFilePath(fastresumeName);
         QByteArray data;
         AddTorrentData resumeData;
         MagnetUri magnetUri;
         int queuePosition;
         if (readFile(fastresumePath, data) && loadTorrentResumeData(data, resumeData, queuePosition, magnetUri)) {
-            if (queuePosition == 0) {
-                filePath = resumeDataDir.filePath(QString("%1.torrent").arg(hash));
-                qDebug("Starting up torrent %s ...", qPrintable(hash));
-                if (!addTorrent_impl(resumeData, magnetUri, TorrentInfo::loadFromFile(filePath), data))
-                    logger->addMessage(tr("Unable to resume torrent '%1'.", "e.g: Unable to resume torrent 'hash'.")
-                                       .arg(hash), Log::CRITICAL);
+            if (queuePosition <= nextQueuePosition) {
+                startupTorrent({ hash, magnetUri, resumeData, data });
+
+                if (queuePosition == nextQueuePosition) {
+                    ++nextQueuePosition;
+                    while (queuedResumeData.contains(nextQueuePosition)) {
+                        startupTorrent(queuedResumeData.take(nextQueuePosition));
+                        ++nextQueuePosition;
+                    }
+                }
             }
             else {
                 queuedResumeData[queuePosition] = { hash, magnetUri, resumeData, data };
@@ -1939,13 +1951,8 @@ void Session::startUpTorrents()
     }
 
     // starting up downloading torrents (queue position > 0)
-    foreach (const TorrentResumeData &torrentResumeData, queuedResumeData) {
-        filePath = resumeDataDir.filePath(QString("%1.torrent").arg(torrentResumeData.hash));
-        qDebug("Starting up torrent %s ...", qPrintable(torrentResumeData.hash));
-        if (!addTorrent_impl(torrentResumeData.addTorrentData, torrentResumeData.magnetUri, TorrentInfo::loadFromFile(filePath), torrentResumeData.data))
-            logger->addMessage(tr("Unable to resume torrent '%1'.", "e.g: Unable to resume torrent 'hash'.")
-                               .arg(torrentResumeData.hash), Log::CRITICAL);
-    }
+    foreach (const TorrentResumeData &torrentResumeData, queuedResumeData)
+        startupTorrent(torrentResumeData);
 }
 
 quint64 Session::getAlltimeDL() const

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -86,6 +86,7 @@ namespace libtorrent
     struct external_ip_alert;
 }
 
+class QThread;
 class QTimer;
 class QStringList;
 class QString;
@@ -95,6 +96,7 @@ template<typename T> class QList;
 class FilterParserThread;
 class BandwidthScheduler;
 class Statistics;
+class ResumeDataSavingManager;
 
 typedef QPair<QString, QString> QStringPair;
 
@@ -314,7 +316,6 @@ namespace BitTorrent
         void handleExternalIPAlert(libtorrent::external_ip_alert *p);
 
         void saveResumeData();
-        bool writeResumeDataFile(TorrentHandle *const torrent, const libtorrent::entry &data);
 
         void dispatchAlerts(std::auto_ptr<libtorrent::alert> alertPtr);
         void getPendingAlerts(QVector<libtorrent::alert *> &out, ulong time = 0);
@@ -355,6 +356,9 @@ namespace BitTorrent
         QPointer<BandwidthScheduler> m_bwScheduler;
         // Tracker
         QPointer<Tracker> m_tracker;
+        // fastresume data writing thread
+        QThread *m_ioThread;
+        ResumeDataSavingManager *m_resumeDataSavingManager;
 
         QHash<InfoHash, TorrentInfo> m_loadedMetadata;
         QHash<InfoHash, TorrentHandle *> m_torrents;

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -1432,6 +1432,7 @@ void TorrentHandle::handleSaveResumeDataAlert(libtorrent::save_resume_data_alert
     resumeData["qBt-name"] = Utils::String::toStdString(m_name);
     resumeData["qBt-seedStatus"] = m_hasSeedStatus;
     resumeData["qBt-tempPathDisabled"] = m_tempPathDisabled;
+    resumeData["qBt-queuePosition"] = queuePosition();
 
     m_session->handleTorrentResumeDataReady(this, resumeData);
 }


### PR DESCRIPTION
WARNING!
This patch swith .fastresume file naming to pre-v3.3 form: \<torrent-hash\>.fastresume.
qBittorrent silently converts all v3.3.0-v3.3.1 fastresume files to new names.
Don't worry about this! If you downgrade qBittorrent will be able to load these files (as old format fastresumes).