### PR TITLE
Set qBittorrent as default torrent app in Mac OS

### DIFF
--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -422,6 +422,12 @@ public:
     static void setTorrentFileAssoc(bool set);
     static void setMagnetLinkAssoc(bool set);
 #endif
+#ifdef Q_OS_MAC
+    static bool isTorrentFileAssocSet();
+    static bool isMagnetLinkAssocSet();
+    static void setTorrentFileAssoc();
+    static void setMagnetLinkAssoc();
+#endif
     bool isTrackerEnabled() const;
     void setTrackerEnabled(bool enabled);
     int getTrackerPort() const;

--- a/src/gui/options_imp.cpp
+++ b/src/gui/options_imp.cpp
@@ -123,6 +123,9 @@ options_imp::options_imp(QWidget *parent)
 
 #ifndef Q_OS_WIN
     checkStartup->setVisible(false);
+#endif
+
+#if !(defined(Q_OS_WIN) || defined(Q_OS_MAC))
     groupFileAssociation->setVisible(false);
 #endif
 
@@ -149,7 +152,7 @@ options_imp::options_imp(QWidget *parent)
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC)) && !defined(QT_DBUS_LIB)
     checkPreventFromSuspend->setDisabled(true);
 #endif
-#ifdef Q_OS_WIN
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     connect(checkAssociateTorrents, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
     connect(checkAssociateMagnetLinks, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
 #endif
@@ -403,6 +406,18 @@ void options_imp::saveOptions()
     Preferences::setTorrentFileAssoc(checkAssociateTorrents->isChecked());
     Preferences::setMagnetLinkAssoc(checkAssociateMagnetLinks->isChecked());
 #endif
+#ifdef Q_OS_MAC
+    if (checkAssociateTorrents->isChecked()) {
+        Preferences::setTorrentFileAssoc();
+        checkAssociateTorrents->setChecked(Preferences::isTorrentFileAssocSet());
+        checkAssociateTorrents->setEnabled(!checkAssociateTorrents->isChecked());
+    }
+    if (checkAssociateMagnetLinks->isChecked()) {
+        Preferences::setMagnetLinkAssoc();
+        checkAssociateMagnetLinks->setChecked(Preferences::isMagnetLinkAssocSet());
+        checkAssociateMagnetLinks->setEnabled(!checkAssociateMagnetLinks->isChecked());
+    }
+#endif
     // End General preferences
 
     // Downloads preferences
@@ -573,6 +588,12 @@ void options_imp::loadOptions()
     checkStartup->setChecked(pref->WinStartup());
     checkAssociateTorrents->setChecked(Preferences::isTorrentFileAssocSet());
     checkAssociateMagnetLinks->setChecked(Preferences::isMagnetLinkAssocSet());
+#endif
+#ifdef Q_OS_MAC
+    checkAssociateTorrents->setChecked(Preferences::isTorrentFileAssocSet());
+    checkAssociateTorrents->setEnabled(!checkAssociateTorrents->isChecked());
+    checkAssociateMagnetLinks->setChecked(Preferences::isMagnetLinkAssocSet());
+    checkAssociateMagnetLinks->setEnabled(!checkAssociateMagnetLinks->isChecked());
 #endif
     // End General preferences
 


### PR DESCRIPTION
This commit adds combo box that allows user to choose default magnet links handler application in Mac OS X. It is implemented in mac way. I mean that mac applications usually have such combo boxes with list of apps that can handle some URLs or documents (windows apps usually have checkbox that says make me default).

I suggest to move qBittorrent.app to /Applications deleting it from build folder to test this feature. This is needed to exclude duplicates for the same bundle ID because LSSetDefaultHandlerForURLScheme() accepts bundle ID of the app, and Launch Services "likes" when application is installed in /Applications