### PR TITLE
Multiple Torrents Uploads Fix.  Closes #4428

### DIFF
--- a/src/base/http/requestparser.cpp
+++ b/src/base/http/requestparser.cpp
@@ -319,7 +319,7 @@ bool RequestParser::parseFormData(const QByteArray& data)
         ufile.type = disposition["content-type"];
         ufile.data = data.mid(header_end + EOH.length());
 
-        m_request.files[disposition["name"]] = ufile;
+        m_request.files.append(ufile);
     }
     else {
         m_request.posts[disposition["name"]] = QString::fromUtf8(data.mid(header_end + EOH.length()));

--- a/src/base/http/types.h
+++ b/src/base/http/types.h
@@ -32,6 +32,7 @@
 #include <QString>
 #include <QMap>
 #include <QHostAddress>
+#include <QVector>
 
 typedef QMap<QString, QString> QStringMap;
 
@@ -70,7 +71,7 @@ namespace Http
         QStringMap headers;
         QStringMap gets;
         QStringMap posts;
-        QMap<QString, UploadedFile> files;
+        QVector<UploadedFile> files;
     };
 
     struct ResponseStatus


### PR DESCRIPTION
This is a fix for #4428

Basically the problem is that when several torrents are uploaded via the WebUI, a QMap is filled with this data.  The QMap m_request.files uses disposition["name"] as a key and all the files have the same HTML name attribute value ("fileselect[]").   It was changed to disposition["filename"] which has way more sense.  If you look at the code you'll see that even validates disposition["filename"] but somehow used disposition["name"] for the key:

```
    if (disposition.contains("filename")) {
        UploadedFile ufile;
        ufile.filename = disposition["filename"];
        ufile.type = disposition["content-type"];
        ufile.data = data.mid(header_end + EOH.length());

        m_request.files[disposition["name"]] = ufile;
    }
```

That last line was changed to:
```
m_request.files[disposition["filename"]] = ufile;
```

Anyway the key is not used in the code.  It's just used to differentiate torrents in the QMap.  The UploadedFile class has all the data it needs (filename, type and data).