### PR TITLE
Enabling IPv6 should not disable IPv4

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1448,7 +1448,7 @@ const QStringList Session::getListeningIPs()
         protocol = ip.protocol();
         Q_ASSERT(protocol == QAbstractSocket::IPv4Protocol || protocol == QAbstractSocket::IPv6Protocol);
         if (!listenIPv6 && (protocol == QAbstractSocket::IPv6Protocol))
-          continue;
+            continue;
         IPs.append(ipString);
     }
 

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1447,9 +1447,8 @@ const QStringList Session::getListeningIPs()
         ipString = ip.toString();
         protocol = ip.protocol();
         Q_ASSERT(protocol == QAbstractSocket::IPv4Protocol || protocol == QAbstractSocket::IPv6Protocol);
-        if ((!listenIPv6 && (protocol == QAbstractSocket::IPv6Protocol))
-            || (listenIPv6 && (protocol == QAbstractSocket::IPv4Protocol)))
-            continue;
+        if (!listenIPv6 && (protocol == QAbstractSocket::IPv6Protocol))
+          continue;
         IPs.append(ipString);
     }
 

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1454,7 +1454,7 @@ const QStringList Session::getListeningIPs()
 
     // Make sure there is at least one IP
     // At this point there was a valid network interface, with no suitable IP.
-    if (IPs.size() == 0) {
+    if (IPs.isEmpty()) {
         logger->addMessage(tr("qBittorrent didn't find an %1 local address to listen on", "qBittorrent didn't find an IPv4 local address to listen on").arg(listenIPv6 ? "IPv6" : "IPv4"), Log::CRITICAL);
         IPs.append("127.0.0.1"); // Force listening to localhost and avoid accidental connection that will expose user data.
         return IPs;


### PR DESCRIPTION
The option to enable IPv6 should not disable operation on IPv4. Having an IPv6-only BitTorrent client is not useful today, the practical scenario for the foreseeable future is to utilize both protocols simultaneously (dual-stack).