### PR TITLE
Manage save path in one place

### DIFF
--- a/src/base/bittorrent/magneturi.h
+++ b/src/base/bittorrent/magneturi.h
@@ -43,7 +43,7 @@ namespace BitTorrent
     class MagnetUri
     {
     public:
-        explicit MagnetUri(const QString &url = QString());
+        explicit MagnetUri(const QString &source = QString());
 
         bool isValid() const;
         InfoHash hash() const;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -127,15 +127,13 @@ namespace BitTorrent
         QString name;
         QString label;
         QString savePath;
-        bool disableTempPath; // e.g. for imported torrents
-        bool sequential;
+        bool disableTempPath = false; // e.g. for imported torrents
+        bool sequential = false;
         TriStateBool addForced;
         TriStateBool addPaused;
         QVector<int> filePriorities; // used if TorrentInfo is set
-        bool ignoreShareRatio;
-        bool skipChecking;
-
-        AddTorrentParams();
+        bool ignoreShareRatio = false;
+        bool skipChecking = false;
     };
 
     struct TorrentStatusReport
@@ -333,8 +331,6 @@ namespace BitTorrent
 
         void dispatchAlerts(std::auto_ptr<libtorrent::alert> alertPtr);
         void getPendingAlerts(QVector<libtorrent::alert *> &out, ulong time = 0);
-
-        AddTorrentData addDataFromParams(const AddTorrentParams &params);
 
         // BitTorrent
         libtorrent::session *m_nativeSession;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -196,7 +196,7 @@ namespace BitTorrent
         bool addTorrent(QString source, const AddTorrentParams &params = AddTorrentParams());
         bool addTorrent(const TorrentInfo &torrentInfo, const AddTorrentParams &params = AddTorrentParams());
         bool deleteTorrent(const QString &hash, bool deleteLocalFiles = false);
-        bool loadMetadata(const QString &magnetUri);
+        bool loadMetadata(const MagnetUri &magnetUri);
         bool cancelLoadMetadata(const InfoHash &hash);
 
         void recursiveTorrentDownload(const InfoHash &hash);

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -102,14 +102,15 @@ namespace BitTorrent
         QVector<int> filePriorities;
         // for resumed torrents
         qreal ratioLimit;
+
+        AddTorrentData();
+        AddTorrentData(const AddTorrentParams &params);
     };
 
     struct TrackerInfo
     {
         QString lastMessage;
-        quint32 numPeers;
-
-        TrackerInfo();
+        quint32 numPeers = 0;
     };
 
     class TorrentState
@@ -349,7 +350,6 @@ namespace BitTorrent
     private:
         typedef boost::function<void ()> EventTrigger;
 
-        void initialize();
         void updateStatus();
         void updateStatus(const libtorrent::torrent_status &nativeStatus);
         void updateState();

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -392,21 +392,6 @@ bool Utils::Misc::isPreviewable(const QString& extension)
     return multimedia_extensions.contains(extension.toUpper());
 }
 
-QString Utils::Misc::bcLinkToMagnet(QString bc_link)
-{
-    QByteArray raw_bc = bc_link.toUtf8();
-    raw_bc = raw_bc.mid(8); // skip bc://bt/
-    raw_bc = QByteArray::fromBase64(raw_bc); // Decode base64
-    // Format is now AA/url_encoded_filename/size_bytes/info_hash/ZZ
-    QStringList parts = QString(raw_bc).split("/");
-    if (parts.size() != 5) return QString::null;
-    QString filename = parts.at(1);
-    QString hash = parts.at(3);
-    QString magnet = "magnet:?xt=urn:btih:" + hash;
-    magnet += "&dn=" + filename;
-    return magnet;
-}
-
 // Take a number of seconds and return an user-friendly
 // time duration like "1d 2h 10m".
 QString Utils::Misc::userFriendlyDuration(qlonglong seconds)

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -66,7 +66,6 @@ namespace Utils
         QString friendlyUnit(qreal val, bool is_speed = false);
         bool isPreviewable(const QString& extension);
 
-        QString bcLinkToMagnet(QString bc_link);
         // Take a number of seconds and return an user-friendly
         // time duration like "1d 2h 10m".
         QString userFriendlyDuration(qlonglong seconds);

--- a/src/gui/addnewtorrentdialog.h
+++ b/src/gui/addnewtorrentdialog.h
@@ -38,11 +38,15 @@
 #include "base/bittorrent/infohash.h"
 #include "base/bittorrent/torrentinfo.h"
 
-QT_BEGIN_NAMESPACE
-namespace Ui {
+namespace BitTorrent
+{
+    class MagnetUri;
+}
+
+namespace Ui
+{
     class AddNewTorrentDialog;
 }
-QT_END_NAMESPACE
 
 class TorrentContentFilterModel;
 class PropListDelegate;
@@ -79,8 +83,8 @@ protected slots:
 
 private:
     explicit AddNewTorrentDialog(QWidget *parent = 0);
-    bool loadTorrent(const QString& torrent_path);
-    bool loadMagnet(const QString& magnet_uri);
+    bool loadTorrent(const QString &torrentPath);
+    bool loadMagnet(const BitTorrent::MagnetUri &magnetUri);
     void loadSavePathHistory();
     void saveSavePathHistory() const;
     int indexOfSavePath(const QString& save_path);

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -354,14 +354,6 @@ void WebApplication::action_command_download()
     foreach (QString url, list) {
         url = url.trimmed();
         if (!url.isEmpty()) {
-            if (url.startsWith("bc://bt/", Qt::CaseInsensitive)) {
-                qDebug("Converting bc link to magnet link");
-                url = Utils::Misc::bcLinkToMagnet(url);
-            }
-            if ((url.size() == 40 && !url.contains(QRegExp("[^0-9A-Fa-f]")))
-                || (url.size() == 32 && !url.contains(QRegExp("[^2-7A-Za-z]"))))
-                url = "magnet:?xt=urn:btih:" + url;
-
             Net::DownloadManager::instance()->setCookiesFromUrl(cookies, QUrl::fromEncoded(url.toUtf8()));
             BitTorrent::Session::instance()->addTorrent(url, params);
         }


### PR DESCRIPTION
Fix saving torrent to **current directory** (when empty save path passed to libtorrent).
Fix loading corrupted .fastresume file. Related to #4454.
Manage torrent save path in TorrentHandle constructor. This is the last point where we can do it, so we can be sure that we remembered to do it. (Don't worry about the fact that we now do not set the save path in the add_torrent_params before calling the async_add_torrent() function: because we run the torrent in a paused state, the actual file operations will not begin to run until the call to the TorrentHandle constructor since we call TorrentHandle::resume after it.)