### PR TITLE
convert includes like <Windows.h> to lowercase

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -37,7 +37,7 @@
 #ifndef DISABLE_GUI
 #include "gui/guiiconprovider.h"
 #ifdef Q_OS_WIN
-#include <Windows.h>
+#include <windows.h>
 #include <QSharedMemory>
 #include <QSessionManager>
 #endif // Q_OS_WIN

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -43,7 +43,7 @@
 #include <boost/bind.hpp>
 
 #ifdef Q_OS_WIN
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #include "base/logger.h"

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -47,7 +47,7 @@
 #endif
 
 #ifdef Q_OS_WIN
-#include <ShlObj.h>
+#include <shlobj.h>
 #include <winreg.h>
 #endif
 

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -48,7 +48,7 @@
 
 #ifdef Q_OS_WIN
 #include <windows.h>
-#include <PowrProf.h>
+#include <powrprof.h>
 const int UNLEN = 256;
 #else
 #include <unistd.h>

--- a/src/gui/powermanagement/powermanagement.cpp
+++ b/src/gui/powermanagement/powermanagement.cpp
@@ -40,7 +40,7 @@
 #endif
 
 #ifdef Q_OS_WIN
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 PowerManagement::PowerManagement(QObject *parent) : QObject(parent), m_busy(false)


### PR DESCRIPTION
There is header file windows.h, not Windows.h.
MinGW on Linux build machine is filename case-sensitive.