### PR TITLE
Add appveyor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 qBittorrent - A BitTorrent client in Qt
 ------------------------------------------
 
-[![Build Status](https://travis-ci.org/qbittorrent/qBittorrent.svg?branch=master)](https://travis-ci.org/qbittorrent/qBittorrent)
+[![TravisCI Status](https://travis-ci.org/qbittorrent/qBittorrent.svg?branch=master)](https://travis-ci.org/qbittorrent/qBittorrent)
+[![AppVeyor Status](https://ci.appveyor.com/api/projects/status/github/qbittorrent/qBittorrent?branch=master&svg=true)](https://ci.appveyor.com/project/qbittorrent/qBittorrent)
 [![Coverity Status](https://scan.coverity.com/projects/5494/badge.svg)](https://scan.coverity.com/projects/5494)
 ********************************
 ### Description:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,52 @@
+version: '{branch}-{build}'
+
+# Do not build on tags (GitHub only)
+skip_tags: true
+
+os: Visual Studio 2015
+
+environment:
+  REPO_DIR: &REPO_DIR c:\qbittorrent
+  CACHE_DIR: &CACHE_DIR c:\qbt_cache
+
+  QBT_VER_URL: http://builds.shiki.hu/appveyor/version
+  QBT_LIB_URL: http://builds.shiki.hu/appveyor/qbt_libraries.7z
+
+# project directory
+clone_folder: *REPO_DIR
+
+# cache size should < 100MB (after compressing with fastest option):
+# see: https://www.appveyor.com/docs/build-cache#save-update-cache-before-build-finishes
+cache:
+  - *CACHE_DIR
+
+install:
+  # check if library needs update
+  - appveyor DownloadFile "%QBT_VER_URL%" -FileName "c:\version_new" && SET /P newVersion=<"c:\version_new"
+  - IF EXIST "%CACHE_DIR%\version" (SET /P oldVersion=<"%CACHE_DIR%\version")
+  - IF NOT EXIST "%CACHE_DIR%\version" (SET updateCache=1)
+  - IF NOT "%oldVersion%" == "%newVersion%" (SET updateCache=1)
+  # update library
+  - IF "%updateCache%" == "1" (ECHO "--- Will redownload libraries ---" &&
+      RMDIR /S /Q "%CACHE_DIR%" & MKDIR "%CACHE_DIR%" &&
+      appveyor DownloadFile "%QBT_LIB_URL%" -FileName "c:\qbt_lib.7z" && 7z x "c:\qbt_lib.7z" -o"%CACHE_DIR%" > nul &&
+      COPY "c:\version_new" "%CACHE_DIR%\version")
+  # Qt stay compressed in cache
+  - 7z x "%CACHE_DIR%\qt5_32.7z" -o"c:\qbt" > nul
+
+before_build:
+  # setup env
+  - CALL "c:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\vcvars32.bat"
+  - SET PATH=%PATH%;c:\qbt\qt5_32\bin;%CACHE_DIR%\jom;
+  # setup project
+  - COPY /Y "%CACHE_DIR%\winconf.pri" "%REPO_DIR%"
+  - COPY /Y "%CACHE_DIR%\winconf-msvc.pri" "%REPO_DIR%"
+  # workarounds
+  - MKLINK /J "c:\qbt\base" "%CACHE_DIR%\base"
+
+build_script:
+  - cd "%REPO_DIR%"
+  - qmake qbittorrent.pro && cd src && qmake src.pro
+  - jom -j2 -f Makefile.Release
+
+test: off


### PR DESCRIPTION
Mine attempt of adding appveyor support.
In `QBT_LIB_URL` boost dir, I've striped some unused dirs to make file smaller.

Compile process here: https://ci.appveyor.com/project/Chocobo1/qbittorrent/build/appveyor-2

@sledgehammer999 
You can copy the files at `QBT_VER_URL` & `QBT_LIB_URL` to your server and give me the new URLs.
If you want to use secret variables, see: http://www.appveyor.com/docs/build-configuration#secure-variables
