### PR TITLE
Allow GeoIP in NoGUI builds

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -62,10 +62,6 @@ using namespace BitTorrent;
 #include <libtorrent/extensions/smart_ban.hpp>
 //#include <libtorrent/extensions/metadata_transfer.hpp>
 
-#ifndef DISABLE_COUNTRIES_RESOLUTION
-#include "base/net/geoipmanager.h"
-#endif
-
 #include "base/utils/misc.h"
 #include "base/utils/fs.h"
 #include "base/utils/string.h"

--- a/src/src.pro
+++ b/src/src.pro
@@ -21,7 +21,7 @@ os2: include(../os2conf.pri)
 
 nogui {
     QT -= gui
-    DEFINES += DISABLE_GUI DISABLE_COUNTRIES_RESOLUTION
+    DEFINES += DISABLE_GUI
     TARGET = qbittorrent-nox
 } else {
     QT += xml


### PR DESCRIPTION
Since we use it in the WebUI now. See #4574.