### PR TITLE
Remove logging of fast resumes.

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -2088,9 +2088,6 @@ void Session::handleAddTorrentAlert(libtorrent::add_torrent_alert *p)
     if (data.resumed) {
         if (fromMagnetUri && !data.addPaused)
             torrent->resume(data.addForced);
-
-        logger->addMessage(tr("'%1' resumed. (fast resume)", "'torrent name' was resumed. (fast resume)")
-                           .arg(torrent->name()));
     }
     else {
         qDebug("This is a NEW torrent (first time)...");


### PR DESCRIPTION
When qBittorrent is seeding 1000+ torrents, the logging of fast resumes on every single one is very noisy, and crowds all of the actually useful startup info out of the Execution Log (where there seems to be no way to increase buffer size). 
Fast resumes without complication are not interesting enough to be logged at what is effectively 'info' level, anyways - might as well just not log them at all, imo.