### PR TITLE
Add libtorrent v1.1 basic support

### DIFF
--- a/src/base/bittorrent/cachestatus.cpp
+++ b/src/base/bittorrent/cachestatus.cpp
@@ -26,6 +26,7 @@
  * exception statement from your version.
  */
 
+#include <libtorrent/version.hpp>
 #include "cachestatus.h"
 
 using namespace BitTorrent;
@@ -50,7 +51,11 @@ qreal CacheStatus::readRatio() const
 
 int CacheStatus::jobQueueLength() const
 {
+#if LIBTORRENT_VERSION_NUM < 10100
     return m_nativeStatus.job_queue_length;
+#else
+    return m_nativeStatus.queued_jobs;
+#endif
 }
 
 int CacheStatus::averageJobTime() const

--- a/src/base/bittorrent/cachestatus.h
+++ b/src/base/bittorrent/cachestatus.h
@@ -29,8 +29,8 @@
 #ifndef BITTORRENT_CACHESTATUS_H
 #define BITTORRENT_CACHESTATUS_H
 
-#include <libtorrent/disk_io_thread.hpp>
 #include <QtGlobal>
+#include <libtorrent/disk_io_thread.hpp>
 
 namespace BitTorrent
 {

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -38,6 +38,8 @@
 #include <QWaitCondition>
 #include <QNetworkConfigurationManager>
 
+#include <libtorrent/version.hpp>
+
 #include "base/tristatebool.h"
 #include "base/types.h"
 #include "torrentinfo.h"
@@ -52,7 +54,16 @@ namespace libtorrent
     struct session_settings;
     struct session_status;
 
+#if LIBTORRENT_VERSION_NUM < 10100
     struct proxy_settings;
+#else
+    namespace aux
+    {
+        struct proxy_settings;
+    }
+
+    typedef aux::proxy_settings proxy_settings;
+#endif
 
     class alert;
     struct torrent_alert;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -45,12 +45,14 @@
 namespace libtorrent
 {
     class session;
+    struct torrent_handle;
     class entry;
     struct add_torrent_params;
     struct pe_settings;
-    struct proxy_settings;
     struct session_settings;
     struct session_status;
+
+    struct proxy_settings;
 
     class alert;
     struct torrent_alert;
@@ -312,6 +314,8 @@ namespace BitTorrent
         void handleListenSucceededAlert(libtorrent::listen_succeeded_alert *p);
         void handleListenFailedAlert(libtorrent::listen_failed_alert *p);
         void handleExternalIPAlert(libtorrent::external_ip_alert *p);
+
+        void createTorrentHandle(const libtorrent::torrent_handle &nativeHandle);
 
         void saveResumeData();
         bool writeResumeDataFile(TorrentHandle *const torrent, const libtorrent::entry &data);

--- a/src/base/bittorrent/torrentcreatorthread.cpp
+++ b/src/base/bittorrent/torrentcreatorthread.cpp
@@ -55,7 +55,7 @@ using namespace BitTorrent;
 // name starts with a .
 bool fileFilter(const std::string &f)
 {
-    return (libt::filename(f)[0] != '.');
+    return !Utils::Fs::fileName(Utils::String::fromStdString(f)).startsWith('.');
 }
 
 TorrentCreatorThread::TorrentCreatorThread(QObject *parent)

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -40,6 +40,9 @@
 #include <libtorrent/alert_types.hpp>
 #include <libtorrent/create_torrent.hpp>
 #include <libtorrent/magnet_uri.hpp>
+#if LIBTORRENT_VERSION_NUM >= 10100
+#include <libtorrent/time.hpp>
+#endif
 
 #include <boost/bind.hpp>
 
@@ -1067,7 +1070,11 @@ int TorrentHandle::connectionsLimit() const
 
 qlonglong TorrentHandle::nextAnnounce() const
 {
+#if LIBTORRENT_VERSION_NUM < 10100
     return m_nativeStatus.next_announce.total_seconds();
+#else
+    return libt::duration_cast<libt::seconds>(m_nativeStatus.next_announce).count();
+#endif
 }
 
 void TorrentHandle::setName(const QString &name)
@@ -1690,7 +1697,11 @@ libtorrent::torrent_handle TorrentHandle::nativeHandle() const
 void TorrentHandle::updateTorrentInfo()
 {
     if (!hasMetadata()) return;
+#if LIBTORRENT_VERSION_NUM < 10100
     m_torrentInfo = TorrentInfo(m_nativeStatus.torrent_file);
+#else
+    m_torrentInfo = TorrentInfo(m_nativeStatus.torrent_file.lock());
+#endif
 }
 
 void TorrentHandle::initialize()

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -40,6 +40,7 @@
 #include <libtorrent/alert_types.hpp>
 #include <libtorrent/create_torrent.hpp>
 #include <libtorrent/magnet_uri.hpp>
+
 #include <boost/bind.hpp>
 
 #ifdef Q_OS_WIN
@@ -433,7 +434,7 @@ bool TorrentHandle::connectPeer(const PeerAddress &peerAddress)
     libt::address addr = libt::address::from_string(Utils::String::toStdString(peerAddress.ip.toString()), ec);
     if (ec) return false;
 
-    libt::asio::ip::tcp::endpoint ep(addr, peerAddress.port);
+    boost::asio::ip::tcp::endpoint ep(addr, peerAddress.port);
     SAFE_CALL_BOOL(connect_peer, ep);
 }
 
@@ -847,7 +848,7 @@ qulonglong TorrentHandle::eta() const
 
 QVector<qreal> TorrentHandle::filesProgress() const
 {
-    std::vector<libt::size_type> fp;
+    std::vector<boost::int64_t> fp;
     QVector<qreal> result;
     SAFE_CALL(file_progress, fp, libt::torrent_handle::piece_granularity);
 
@@ -1022,9 +1023,9 @@ qreal TorrentHandle::maxRatio(bool *usesGlobalRatio) const
 
 qreal TorrentHandle::realRatio() const
 {
-    libt::size_type upload = m_nativeStatus.all_time_upload;
+    boost::int64_t upload = m_nativeStatus.all_time_upload;
     // special case for a seeder who lost its stats, also assume nobody will import a 99% done torrent
-    libt::size_type download = (m_nativeStatus.all_time_download < m_nativeStatus.total_done * 0.01) ? m_nativeStatus.total_done : m_nativeStatus.all_time_download;
+    boost::int64_t download = (m_nativeStatus.all_time_download < m_nativeStatus.total_done * 0.01) ? m_nativeStatus.total_done : m_nativeStatus.all_time_download;
 
     if (download == 0)
         return (upload == 0) ? 0.0 : MAX_RATIO;
@@ -1689,7 +1690,6 @@ libtorrent::torrent_handle TorrentHandle::nativeHandle() const
 void TorrentHandle::updateTorrentInfo()
 {
     if (!hasMetadata()) return;
-
     m_torrentInfo = TorrentInfo(m_nativeStatus.torrent_file);
 }
 

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -38,6 +38,11 @@
 #include <QHash>
 
 #include <libtorrent/torrent_handle.hpp>
+#include <libtorrent/version.hpp>
+#if LIBTORRENT_VERSION_NUM >= 10100
+#include <libtorrent/torrent_status.hpp>
+#endif
+
 #include <boost/function.hpp>
 
 #include "base/tristatebool.h"

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -43,8 +43,8 @@
 namespace libt = libtorrent;
 using namespace BitTorrent;
 
-TorrentInfo::TorrentInfo(boost::intrusive_ptr<const libt::torrent_info> nativeInfo)
-    : m_nativeInfo(const_cast<libt::torrent_info *>(nativeInfo.get()))
+TorrentInfo::TorrentInfo(NativeConstPtr nativeInfo)
+    : m_nativeInfo(nativeInfo)
 {
 }
 
@@ -63,7 +63,7 @@ TorrentInfo TorrentInfo::loadFromFile(const QString &path, QString &error)
 {
     error.clear();
     libt::error_code ec;
-    TorrentInfo info(new libt::torrent_info(Utils::String::toStdString(Utils::Fs::toNativePath(path)), ec));
+    TorrentInfo info(NativePtr(new libt::torrent_info(Utils::String::toStdString(Utils::Fs::toNativePath(path)), ec)));
     if (ec) {
         error = QString::fromUtf8(ec.message().c_str());
         qDebug("Cannot load .torrent file: %s", qPrintable(error));
@@ -214,10 +214,10 @@ QByteArray TorrentInfo::metadata() const
 void TorrentInfo::renameFile(uint index, const QString &newPath)
 {
     if (!isValid()) return;
-    m_nativeInfo->rename_file(index, Utils::String::toStdString(newPath));
+    nativeInfo()->rename_file(index, Utils::String::toStdString(newPath));
 }
 
-boost::intrusive_ptr<libtorrent::torrent_info> TorrentInfo::nativeInfo() const
+TorrentInfo::NativePtr TorrentInfo::nativeInfo() const
 {
-    return m_nativeInfo;
+    return *reinterpret_cast<const NativePtr *>(&m_nativeInfo);
 }

--- a/src/base/bittorrent/torrentinfo.h
+++ b/src/base/bittorrent/torrentinfo.h
@@ -30,6 +30,7 @@
 #define BITTORRENT_TORRENTINFO_H
 
 #include <QtGlobal>
+
 #include <libtorrent/torrent_info.hpp>
 
 class QString;
@@ -47,7 +48,10 @@ namespace BitTorrent
     class TorrentInfo
     {
     public:
-        explicit TorrentInfo(boost::intrusive_ptr<const libtorrent::torrent_info> nativeInfo = boost::intrusive_ptr<const libtorrent::torrent_info>());
+        typedef boost::intrusive_ptr<const libtorrent::torrent_info> NativeConstPtr;
+        typedef boost::intrusive_ptr<libtorrent::torrent_info> NativePtr;
+
+        explicit TorrentInfo(NativeConstPtr nativeInfo = NativeConstPtr());
         TorrentInfo(const TorrentInfo &other);
 
         static TorrentInfo loadFromFile(const QString &path, QString &error);
@@ -77,10 +81,11 @@ namespace BitTorrent
         QByteArray metadata() const;
 
         void renameFile(uint index, const QString &newPath);
-        boost::intrusive_ptr<libtorrent::torrent_info> nativeInfo() const;
+
+        NativePtr nativeInfo() const;
 
     private:
-        boost::intrusive_ptr<libtorrent::torrent_info> m_nativeInfo;
+        NativeConstPtr m_nativeInfo;
     };
 }
 

--- a/src/base/bittorrent/torrentinfo.h
+++ b/src/base/bittorrent/torrentinfo.h
@@ -32,6 +32,7 @@
 #include <QtGlobal>
 
 #include <libtorrent/torrent_info.hpp>
+#include <libtorrent/version.hpp>
 
 class QString;
 class QUrl;
@@ -48,8 +49,13 @@ namespace BitTorrent
     class TorrentInfo
     {
     public:
+#if LIBTORRENT_VERSION_NUM < 10100
         typedef boost::intrusive_ptr<const libtorrent::torrent_info> NativeConstPtr;
         typedef boost::intrusive_ptr<libtorrent::torrent_info> NativePtr;
+#else
+        typedef boost::shared_ptr<const libtorrent::torrent_info> NativeConstPtr;
+        typedef boost::shared_ptr<libtorrent::torrent_info> NativePtr;
+#endif
 
         explicit TorrentInfo(NativeConstPtr nativeInfo = NativeConstPtr());
         TorrentInfo(const TorrentInfo &other);

--- a/src/base/bittorrent/trackerentry.h
+++ b/src/base/bittorrent/trackerentry.h
@@ -30,6 +30,10 @@
 #define BITTORRENT_TRACKERENTRY_H
 
 #include <libtorrent/torrent_info.hpp>
+#include <libtorrent/version.hpp>
+#if LIBTORRENT_VERSION_NUM >= 10100
+#include <libtorrent/announce_entry.hpp>
+#endif
 
 class QString;
 

--- a/winconf-msvc.pri
+++ b/winconf-msvc.pri
@@ -15,9 +15,6 @@ QMAKE_LFLAGS += "/OPT:REF /OPT:ICF"
 
 RC_FILE = qbittorrent.rc
 
-# Enable Wide characters
-DEFINES += TORRENT_USE_WPATH
-
 # Adapt the lib names/versions accordingly
 CONFIG(debug, debug|release) {
   LIBS += libtorrentd.lib \


### PR DESCRIPTION
This is a minimal set of changes that adds support for libtorrent v1.1. 
Its advantages are not used.

@sledgehammer999, The first two commits are improvements for current code and they are important in themselves. Next, I want to implement support for some innovations (in particular, a new way to get alerts you suggested) and get rid of the use of deprecated functions. This PR can (and, IMO, should) be merged without waiting for the rest.