### PR TITLE
Fix filter and message for tracker with warning.

### DIFF
--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -1343,6 +1343,11 @@ void TorrentHandle::handleStorageMovedFailedAlert(libtorrent::storage_moved_fail
 
 void TorrentHandle::handleTrackerReplyAlert(libtorrent::tracker_reply_alert *p)
 {
+    if (m_previousWarningUrl == p->url) {
+        m_previousWarningUrl = "";
+        return;
+    }
+
     QString trackerUrl = Utils::String::fromStdString(p->url);
     qDebug("Received a tracker reply from %s (Num_peers = %d)", qPrintable(trackerUrl), p->num_peers);
     // Connection was successful now. Remove possible old errors
@@ -1359,6 +1364,7 @@ void TorrentHandle::handleTrackerWarningAlert(libtorrent::tracker_warning_alert 
     qDebug("Received a tracker warning for %s: %s", qPrintable(trackerUrl), qPrintable(message));
     // Connection was successful now but there is a warning message
     m_trackerInfos[trackerUrl].lastMessage = message; // Store warning message
+    m_previousWarningUrl = p->url;
 
     m_session->handleTorrentTrackerWarning(this, trackerUrl);
 }

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -38,6 +38,7 @@
 #include <QHash>
 
 #include <libtorrent/torrent_handle.hpp>
+#include <libtorrent/alert_types.hpp>
 #include <libtorrent/version.hpp>
 #if LIBTORRENT_VERSION_NUM >= 10100
 #include <libtorrent/torrent_status.hpp>
@@ -417,6 +418,7 @@ namespace BitTorrent
         bool m_pauseAfterRecheck;
         bool m_needSaveResumeData;
         QHash<QString, TrackerInfo> m_trackerInfos;
+        std::string m_previousWarningUrl = "";
     };
 }
 

--- a/src/gui/properties/trackerlist.cpp
+++ b/src/gui/properties/trackerlist.cpp
@@ -284,7 +284,7 @@ void TrackerList::loadTrackers() {
     switch (entry.status()) {
     case BitTorrent::TrackerEntry::Working:
         item->setText(COL_STATUS, tr("Working"));
-        item->setText(COL_MSG, "");
+        item->setText(COL_MSG, error_message);
         break;
     case BitTorrent::TrackerEntry::Updating:
         item->setText(COL_STATUS, tr("Updating..."));


### PR DESCRIPTION
Tracker with warning not included in relevant filter (Trackers -> Warning always show zero trackers).
After several days of exploring libtorrent and qBittorrent sources (this was a pain because I don't know c++) I have figured out something. Libtorrent [succesfully detects and posts tracker warning alert](https://github.com/arvidn/libtorrent/blob/libtorrent-1_0_7/src/http_tracker_connection.cpp#L404) and imediately after that [posts tracker success alert](https://github.com/arvidn/libtorrent/blob/libtorrent-1_0_7/src/http_tracker_connection.cpp#L540). A little bit later qBitorrent processes this warning alert and after that processes success alert, effectively cancelling previous warning alert.
This pull request offers a workaround. It is not so pretty but it's simple and working. Please take a look at it.
