### PR TITLE
Fix potential race condition in showSplashScreen()

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -354,8 +354,8 @@ void showSplashScreen()
     painter.setFont(QFont("Arial", 22, QFont::Black));
     painter.drawText(224 - painter.fontMetrics().width(version), 270, version);
     QSplashScreen *splash = new QSplashScreen(splash_img);
-    QTimer::singleShot(1500, splash, SLOT(deleteLater()));
     splash->show();
+    QTimer::singleShot(1500, splash, SLOT(deleteLater()));
     qApp->processEvents();
 }
 #endif

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -335,7 +335,7 @@ void Preferences::setStartMinimized(bool b)
 
 bool Preferences::isSplashScreenDisabled() const
 {
-    return value("Preferences/General/NoSplashScreen", false).toBool();
+    return value("Preferences/General/NoSplashScreen", true).toBool();
 }
 
 void Preferences::setSplashScreenDisabled(bool b)
@@ -1900,7 +1900,7 @@ bool Preferences::isTorrentFileAssocSet()
             CFStringRef myBundleId = CFBundleGetIdentifier(CFBundleGetMainBundle());
             isSet = CFStringCompare(myBundleId, defaultHandlerId, 0) == kCFCompareEqualTo;
             CFRelease(defaultHandlerId);
-        }    
+        }
         CFRelease(torrentId);
     }
     return isSet;


### PR DESCRIPTION
BTW when testing this, I found the splash-screen is hidden under mainwindow, due to 0d32b9a to fix #1391. Now the splash-screen is never visible to me (unless minimize the mainwindow) rendering this option useless (on linux).

Some thoughts here:
1. Make splash-screen default off, I don't think splash-screen is a trend anymore...
2. The issue in #1391, I guess is caused by sharing the same thread with libtorrent. Merely removing the `Qt::WindowStaysOnTopHint` flag won't help much, the mainwindow could still hang, so it still need a proper fix. (Not sure this is still the case in current git master)

I would prefer doing the 1st change so that making the proper fix could be a low prio task (or even postponed forever :p).
