### PR TITLE
OS X improvements

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -251,6 +251,10 @@ int main(int argc, char *argv[])
     signal(SIGSEGV, sigAbnormalHandler);
 #endif
 
+#ifdef Q_OS_MAC
+    // On OS X the standard is to not show icons in the menus
+    app->setAttribute(Qt::AA_DontShowIconsInMenus);
+#endif
     return app->exec(params.torrents);
 }
 

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -303,6 +303,9 @@ void Preferences::setRandomPort(bool b)
     setValue("Preferences/General/UseRandomPort", b);
 }
 
+// In Mac OS X the dock is sufficient for our needs so we disable the sys tray functionality.
+// See extensive discussion in https://github.com/qbittorrent/qBittorrent/pull/3018
+#ifndef Q_OS_MAC
 bool Preferences::systrayIntegration() const
 {
     return value("Preferences/General/SystrayEnabled", true).toBool();
@@ -311,16 +314,6 @@ bool Preferences::systrayIntegration() const
 void Preferences::setSystrayIntegration(bool enabled)
 {
     setValue("Preferences/General/SystrayEnabled", enabled);
-}
-
-bool Preferences::isToolbarDisplayed() const
-{
-    return value("Preferences/General/ToolbarDisplayed", true).toBool();
-}
-
-void Preferences::setToolbarDisplayed(bool displayed)
-{
-    setValue("Preferences/General/ToolbarDisplayed", displayed);
 }
 
 bool Preferences::minimizeToTray() const
@@ -341,6 +334,17 @@ bool Preferences::closeToTray() const
 void Preferences::setCloseToTray(bool b)
 {
     setValue("Preferences/General/CloseToTray", b);
+}
+#endif
+
+bool Preferences::isToolbarDisplayed() const
+{
+    return value("Preferences/General/ToolbarDisplayed", true).toBool();
+}
+
+void Preferences::setToolbarDisplayed(bool displayed)
+{
+    setValue("Preferences/General/ToolbarDisplayed", displayed);
 }
 
 bool Preferences::startMinimized() const
@@ -2011,6 +2015,7 @@ void Preferences::setConfirmTorrentRecheck(bool enabled)
     setValue("Preferences/Advanced/confirmTorrentRecheck", enabled);
 }
 
+#ifndef Q_OS_MAC
 TrayIcon::Style Preferences::trayIconStyle() const
 {
     return TrayIcon::Style(value("Preferences/Advanced/TrayIconStyle", TrayIcon::NORMAL).toInt());
@@ -2020,6 +2025,7 @@ void Preferences::setTrayIconStyle(TrayIcon::Style style)
 {
     setValue("Preferences/Advanced/TrayIconStyle", style);
 }
+#endif
 
 // Stuff that don't appear in the Options GUI but are saved
 // in the same file.

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -138,14 +138,16 @@ public:
     void setHideZeroComboValues(int n);
     bool useRandomPort() const;
     void setRandomPort(bool b);
+#ifndef Q_OS_MAC
     bool systrayIntegration() const;
     void setSystrayIntegration(bool enabled);
-    bool isToolbarDisplayed() const;
-    void setToolbarDisplayed(bool displayed);
     bool minimizeToTray() const;
     void setMinimizeToTray(bool b);
     bool closeToTray() const;
     void setCloseToTray(bool b);
+#endif
+    bool isToolbarDisplayed() const;
+    void setToolbarDisplayed(bool displayed);
     bool startMinimized() const;
     void setStartMinimized(bool b);
     bool isSplashScreenDisabled() const;
@@ -440,8 +442,10 @@ public:
     void setConfirmTorrentDeletion(bool enabled);
     bool confirmTorrentRecheck() const;
     void setConfirmTorrentRecheck(bool enabled);
+#ifndef Q_OS_MAC
     TrayIcon::Style trayIconStyle() const;
     void setTrayIconStyle(TrayIcon::Style style);
+#endif
 
 
     // Stuff that don't appear in the Options GUI but are saved

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1374,9 +1374,11 @@ QMenu* MainWindow::getTrayIconMenu()
         return myTrayIconMenu;
     // Tray icon Menu
     myTrayIconMenu = new QMenu(this);
+#ifndef Q_OS_MAC
     connect(myTrayIconMenu, SIGNAL(aboutToShow()), SLOT(updateTrayIconMenu()));
     myTrayIconMenu->addAction(actionToggleVisibility);
     myTrayIconMenu->addSeparator();
+#endif
     myTrayIconMenu->addAction(actionOpen);
     myTrayIconMenu->addAction(actionDownload_from_URL);
     myTrayIconMenu->addSeparator();
@@ -1389,8 +1391,10 @@ QMenu* MainWindow::getTrayIconMenu()
     myTrayIconMenu->addSeparator();
     myTrayIconMenu->addAction(actionStart_All);
     myTrayIconMenu->addAction(actionPause_All);
+#ifndef Q_OS_MAC
     myTrayIconMenu->addSeparator();
     myTrayIconMenu->addAction(actionExit);
+#endif
     if (ui_locked)
         myTrayIconMenu->setEnabled(false);
     return myTrayIconMenu;

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -904,12 +904,20 @@ void MainWindow::closeEvent(QCloseEvent *e)
         }
     }
 
-    //abort search if any
-    if (searchEngine) delete searchEngine;
-
-    hide();
+#ifdef Q_OS_MAC
+    // This is for on_actionExit_triggered() to work
+    if (force_exit) {
+#endif
+        //abort search if any
+        if (searchEngine) delete searchEngine;
+#ifdef Q_OS_MAC
+    }
+#endif
 
 #ifndef Q_OS_MAC
+    hide();
+
+
     // Hide tray icon
     if (systrayIcon)
         systrayIcon->hide();
@@ -917,7 +925,11 @@ void MainWindow::closeEvent(QCloseEvent *e)
 
     // Accept exit
     e->accept();
-    qApp->exit();
+#ifdef Q_OS_MAC
+    // This is for on_actionExit_triggered() to work
+    if (force_exit)
+#endif
+        qApp->exit();
 }
 
 // Display window to create a torrent

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -32,8 +32,12 @@
 #define GUI_H
 
 #include <QProcess>
-#include <QSystemTrayIcon>
 #include <QPointer>
+
+#ifndef Q_OS_MAC
+#include <QSystemTrayIcon>
+#endif
+
 #include "ui_mainwindow.h"
 #include "statsdialog.h"
 
@@ -93,7 +97,6 @@ public slots:
 
 protected slots:
     // GUI related slots
-    void toggleVisibility(QSystemTrayIcon::ActivationReason e = QSystemTrayIcon::Trigger);
     void on_actionAbout_triggered();
     void on_actionStatistics_triggered();
     void on_actionCreate_torrent_triggered();
@@ -101,10 +104,14 @@ protected slots:
     void writeSettings();
     void readSettings();
     void on_actionExit_triggered();
+#ifndef Q_OS_MAC
+    void toggleVisibility(QSystemTrayIcon::ActivationReason e = QSystemTrayIcon::Trigger);
     void createTrayIcon();
+    void createSystrayDelayed();
+    void updateTrayIconMenu();
+#endif
     void fullDiskError(BitTorrent::TorrentHandle *const torrent, QString msg) const;
     void handleDownloadFromUrlFailure(QString, QString) const;
-    void createSystrayDelayed();
     void tab_changed(int);
     void on_actionLock_qBittorrent_triggered();
     void defineUILockPassword();
@@ -113,7 +120,6 @@ protected slots:
     void notifyOfUpdate(QString);
     void showConnectionSettings();
     void minimizeWindow();
-    void updateTrayIconMenu();
     // Keyboard shortcuts
     void createKeyboardShortcuts();
     void displayTransferTab() const;
@@ -150,7 +156,9 @@ protected:
     void displaySearchTab(bool enable);
 
 private:
+#ifndef Q_OS_MAC
     QIcon getSystrayIcon() const;
+#endif
 #ifdef Q_OS_WIN
     bool addPythonPathToEnv();
     void installPython();
@@ -174,8 +182,10 @@ private:
     QPointer<StatsDialog> statsDlg;
     QPointer<TorrentCreatorDlg> createTorrentDlg;
     QPointer<downloadFromURL> downloadFromURLDialog;
+#ifndef Q_OS_MAC
     QPointer<QSystemTrayIcon> systrayIcon;
     QPointer<QTimer> systrayCreator;
+#endif
     QPointer<QMenu> myTrayIconMenu;
     TransferListWidget *transferList;
     TransferListFiltersWidget *transferListFilters;

--- a/src/gui/options_imp.h
+++ b/src/gui/options_imp.h
@@ -104,9 +104,11 @@ private:
     static QString languageToLocalizedString(const QLocale &locale);
     // General options
     QString getLocale() const;
+#ifndef Q_OS_MAC
     bool systrayIntegration() const;
     bool minimizeToTray() const;
     bool closeToTray() const;
+#endif
     bool startMinimized() const;
     bool isSlashScreenDisabled() const;
     bool preventFromSuspend() const;


### PR DESCRIPTION
I have made changes to improve the OS X experience somewhat.

From the discussion on #3018 and by searching on google+stackoverflow I came to realize that the dock does most of the things we need. So I have disabled the system tray(icon in menu bar) on OS X.

Apps minimized can be restored from there. Actually I found out that if you programmatically hide a window, OS X cannot restore it by just clicking on the dock icon. That's why only the "Show" menu item from context menu worked. Because that called our code that unhides it.

Under OS X when you click the `X` button on the mainwindow it should just hide the window and not exit. Exit is done through the menus. That is what I am trying to do here. But it doesn't work. Normally when you click on the dock icon it should restore the window but in this case it doesn't.
**For devs:** I think we get a showEvent when the dock icon is clicked. Then a show() in there should work. I am tired now, I will test this tomorrow.

I also hide the menu icons as per the Apple standard.

**UPDATE:** Can you guys test this PR with this [build](http://builds.shiki.hu/temp/qbittorrent_3.4.0alpha_for_issue_4757.dmg) and report back?
