### PR TITLE
Add toggle columns menu for peerlist. Closes #3301

### DIFF
--- a/src/gui/properties/peerlistwidget.h
+++ b/src/gui/properties/peerlistwidget.h
@@ -77,6 +77,7 @@ public:
 private slots:
     void loadSettings();
     void saveSettings() const;
+    void displayToggleColumnsMenu(const QPoint&);
     void showPeerListMenu(const QPoint&);
     void banSelectedPeers();
     void copySelectedPeers();


### PR DESCRIPTION
Copy-paste-adjusted from transferlistwidget. The only problem i've seen with this is "Resolve peer countries". If disabled in options and then the column is re-enabled via the menu it'll just be blank and i was thinking whether it's functionality can/should be attached to this menu. I tried to do it and i partially succeeded=failed. I guess it's not good to copy paste especially if it's to be done again and again for trackerlist and contents. I tried to make some kind of template and i failed (again) so i put this here in hopes that it can inspire someone to do it better.
![qbit_peer_columns_menu](https://cloud.githubusercontent.com/assets/6451685/12874094/ad8ad45e-cdd5-11e5-9777-38f916c12539.png)