### PR TITLE
#2928 Improvements #1

### DIFF
--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -193,9 +193,15 @@ bool AddNewTorrentDialog::loadTorrent(const QString &torrentPath)
                 MessageBoxRaised::critical(0, tr("Already in download list"), tr("Torrent is already in download list. Trackers weren't merged because it is a private torrent."), QMessageBox::Ok);
             }
             else {
-                torrent->addTrackers(m_torrentInfo.trackers());
-                torrent->addUrlSeeds(m_torrentInfo.urlSeeds());
-                MessageBoxRaised::information(0, tr("Already in download list"), tr("Torrent is already in download list. Trackers were merged."), QMessageBox::Ok);
+                QMessageBox::StandardButton mergeTrackersReply;
+                mergeTrackersReply = QMessageBox::question(0, tr("Already in download list"), tr("Torrent is already in download list. Do you want to merge trackers?"), QMessageBox::Yes|QMessageBox::No);
+                if (mergeTrackersReply == QMessageBox::Yes) {
+                    torrent->addTrackers(m_torrentInfo.trackers());
+                    torrent->addUrlSeeds(m_torrentInfo.urlSeeds());
+                    MessageBoxRaised::information(0, tr("Already in download list"), tr("Torrent is already in download list. Trackers were merged."), QMessageBox::Ok);
+                } else {
+                    MessageBoxRaised::information(0, tr("Already in download list"), tr("Torrent is already in download list. Trackers were not merged."), QMessageBox::Ok);
+                }
             }
         }
         else {

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -198,10 +198,7 @@ bool AddNewTorrentDialog::loadTorrent(const QString &torrentPath)
                 if (mergeTrackersReply == QMessageBox::Yes) {
                     torrent->addTrackers(m_torrentInfo.trackers());
                     torrent->addUrlSeeds(m_torrentInfo.urlSeeds());
-                    MessageBoxRaised::information(0, tr("Already in download list"), tr("Torrent is already in download list. Trackers were merged."), QMessageBox::Ok);
-                } else {
-                    MessageBoxRaised::information(0, tr("Already in download list"), tr("Torrent is already in download list. Trackers were not merged."), QMessageBox::Ok);
-                }
+                } 
             }
         }
         else {
@@ -231,9 +228,12 @@ bool AddNewTorrentDialog::loadMagnet(const BitTorrent::MagnetUri &magnetUri)
                 MessageBoxRaised::critical(0, tr("Already in download list"), tr("Torrent is already in download list. Trackers weren't merged because it is a private torrent."), QMessageBox::Ok);
             }
             else {
-                torrent->addTrackers(magnetUri.trackers());
-                torrent->addUrlSeeds(magnetUri.urlSeeds());
-                MessageBoxRaised::information(0, tr("Already in download list"), tr("Magnet link is already in download list. Trackers were merged."), QMessageBox::Ok);
+                QMessageBox::StandardButton mergeTrackersReply;
+                mergeTrackersReply = QMessageBox::question(0, tr("Already in download list"), tr("Magnet link is already in download list. Do you want to merge trackers?"), QMessageBox::Yes|QMessageBox::No);
+                if (mergeTrackersReply == QMessageBox::Yes) {
+                    torrent->addTrackers(magnetUri.trackers());
+                    torrent->addUrlSeeds(magnetUri.urlSeeds());
+                }
             }
         }
         else {


### PR DESCRIPTION
Possible to change logic in this way?

if it's private torrent - display message that it was not possible to merge trackers.
if it's not private one - ask user "Do you want to merge trackers?" Yes / No 
If yes - merge trackers, no - don't to anything

Have no idea how to patch src/base/bittorrent/session.cpp. It's logic is not related to GUI, right?