### PR TITLE
Show file tree in Add torrent dialog when there is single file inside folder

### DIFF
--- a/src/gui/addnewtorrentdialog.h
+++ b/src/gui/addnewtorrentdialog.h
@@ -92,6 +92,8 @@ private:
     void saveState();
     void setMetadataProgressIndicator(bool visibleIndicator, const QString &labelText = QString());
     void setupTreeview();
+    bool isFileInFolder(const QString &filePath);
+    bool hasSingleFileInFolder();
 
 private:
     Ui::AddNewTorrentDialog *ui;


### PR DESCRIPTION
Torrents containing a single file inside folder were considered as containing just a file and didn't let to rename folder. File tree didn't show because it doesn't make any sense for just a single file without any folders. Now it is fixed:
![loco_screen](https://cloud.githubusercontent.com/assets/3942904/13075181/640fdaa4-d4ba-11e5-91b0-8a4b96876935.png)
Previously, extra folder Loco_Roco_2_EUR was created in save path and couldn't be renamed in the dialog, only afterwards.