### PR TITLE
Remove additional vertical spacer.

### DIFF
--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -247,19 +247,6 @@
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
     <layout class="QHBoxLayout" name="buttonsHLayout">
      <item>
       <widget class="QProgressBar" name="progMetaLoading">


### PR DESCRIPTION
I accidentally added a vertical spacer when doing #4251.

@sledgehammer999 
This is a quick fix, hope you can merge in soon.

Before:
![before](https://cloud.githubusercontent.com/assets/9395168/13113827/c5f7db56-d5cb-11e5-9302-efafebe48073.png)
After this PR:
![after_fix](https://cloud.githubusercontent.com/assets/9395168/13113826/c5a0ec6a-d5cb-11e5-9313-5d5b37b26efa.png)


BTW, I am looking at #4204. There is still anomaly when downloading via magnets. I think I will postpone fixing it until there are no overlapping PRs.