### PR TITLE
compatibility with MXE

### DIFF
--- a/configure
+++ b/configure
@@ -8345,7 +8345,7 @@ fi
 $as_echo "$as_me: Running qmake to generate the makefile..." >&6;}
 CONFDIR="$( cd "$( dirname "$0" )" && pwd )"
 
-$QT_QMAKE -r $CONFDIR/qbittorrent.pro
+$QT_QMAKE -r $CONFDIR/qbittorrent.pro "QMAKE_LRELEASE=$QMAKE_LRELEASE"
 
 ret="$?"
 

--- a/configure.ac
+++ b/configure.ac
@@ -261,7 +261,7 @@ AS_IF([test "x$enable_systemd" = "xyes"],
 AC_MSG_NOTICE([Running qmake to generate the makefile...])
 CONFDIR="$( cd "$( dirname "$0" )" && pwd )"
 
-$QT_QMAKE -r [$CONFDIR]/qbittorrent.pro
+$QT_QMAKE -r [$CONFDIR]/qbittorrent.pro "QMAKE_LRELEASE=$QMAKE_LRELEASE"
 
 ret="$?"
 

--- a/winconf-mingw.pri
+++ b/winconf-mingw.pri
@@ -22,17 +22,17 @@ RC_FILE = qbittorrent_mingw.rc
 
 # Adapt the lib names/versions accordingly
 CONFIG(debug, debug|release) {
-  LIBS += libtorrent \
-          libboost_system-mgw45-mt-d-1_47 \
-          libboost_filesystem-mgw45-mt-d-1_47 \
-          libboost_thread-mgw45-mt-d-1_47
+  LIBS += libtorrent-rasterbar \
+          libboost_system-mt \
+          libboost_filesystem-mt \
+          libboost_thread_win32-mt
 } else {
-  LIBS += libtorrent \
-          libboost_system-mgw45-mt-1_47 \
-          libboost_filesystem-mgw45-mt-1_47 \
-          libboost_thread-mgw45-mt-1_47
+  LIBS += libtorrent-rasterbar \
+          libboost_system-mt \
+          libboost_filesystem-mt \
+          libboost_thread_win32-mt
 }
 
 LIBS += libadvapi32 libshell32 libuser32
-LIBS += libcrypto.dll libssl.dll libwsock32 libws2_32 libz libiconv.dll
+LIBS += libcrypto libssl libwsock32 libws2_32 libz libiconv
 LIBS += libpowrprof

--- a/winconf.pri
+++ b/winconf.pri
@@ -53,7 +53,7 @@ CONFIG(debug, debug|release) {
 # Enable backtrace support
 CONFIG += strace_win
 
-win32-g++ {
+win32-g++* {
     include(winconf-mingw.pri)
 }
 else {

--- a/winconf.pri
+++ b/winconf.pri
@@ -12,7 +12,7 @@ INCLUDEPATH += $$quote(C:/qBittorrent/openssl/include)
 # Point this to the boost lib folder
 LIBS += $$quote(-LC:/qBittorrent/boost_1_51_0/stage/lib)
 # Point this to the libtorrent lib folder
-LIBS += $$quote(-LC:/qBittorrent/RC_0_16/bin/<path-according-to-the-build-options-chosen>)
+LIBS += $$quote(-LC:/qBittorrent/RC_0_16/bin/path-according-to-the-build-options-chosen)
 # Point this to the zlib lib folder
 LIBS += $$quote(-LC:/qBittorrent/Zlib/lib)
 # Point this to the openssl lib folder


### PR DESCRIPTION
Source: https://github.com/mxe/mxe/blob/master/plugins/apps/qbittorrent-1-fixes.patch
(Change of winconf.pri was improved, commit "convert includes like <Windows.h> to lowercase" is not needed.)