### PR TITLE
Shorten crash report on windows

### DIFF
--- a/src/app/stacktrace_win.h
+++ b/src/app/stacktrace_win.h
@@ -259,9 +259,9 @@ const QString straceWin::getBacktrace()
         }
     }
 
-    logStream << "\n\nList of linked Modules:\n";
-    EnumModulesContext modulesContext(hProcess, logStream);
-    SymEnumerateModules64(hProcess, EnumModulesCB, (PVOID)&modulesContext);
+    //logStream << "\n\nList of linked Modules:\n";
+    //EnumModulesContext modulesContext(hProcess, logStream);
+    //SymEnumerateModules64(hProcess, EnumModulesCB, (PVOID)&modulesContext);
     logStream << "```";
     return log;
 }

--- a/src/app/stacktrace_win_dlg.h
+++ b/src/app/stacktrace_win_dlg.h
@@ -32,7 +32,6 @@
 
 #include <QString>
 #include <QDialog>
-#include "boost/version.hpp"
 #include "libtorrent/version.hpp"
 #include "base/utils/misc.h"
 #include "ui_stacktrace_win_dlg.h"
@@ -51,9 +50,6 @@ public:
     void setStacktraceString(const QString& trace)
     {
         // try to call Qt function as less as possible
-        const int boostVerMajor = BOOST_VERSION / 100000;
-        const int boostVerMinor = ((BOOST_VERSION / 100) % 1000);
-        const int boostVerSubMin = BOOST_VERSION % 100;
         QString htmlStr = QString(
             "<p align=center><b><font size=7 color=red>"
             "qBittorrent has crashed"
@@ -68,14 +64,12 @@ public:
             "qBittorrent version: " VERSION "<br/>"
             "Libtorrent version: " LIBTORRENT_VERSION "<br/>"
             "Qt version: " QT_VERSION_STR "<br/>"
-            "Boost version: %1.%2.%3<br/>"
-            "OS version: %4"
+            "Boost version: %1<br/>"
+            "OS version: %2"
             "</font></p><br/>"
-            "<pre><code>%5</code></pre>"
+            "<pre><code>%3</code></pre>"
             "<br/><hr><br/><br/>")
-            .arg(boostVerMajor)
-            .arg(boostVerMinor)
-            .arg(boostVerSubMin)
+            .arg(Utils::Misc::boostVersionString())
             .arg(Utils::Misc::osName())
             .arg(trace);
 

--- a/src/app/stacktrace_win_dlg.h
+++ b/src/app/stacktrace_win_dlg.h
@@ -34,6 +34,7 @@
 #include <QDialog>
 #include "boost/version.hpp"
 #include "libtorrent/version.hpp"
+#include "base/utils/misc.h"
 #include "ui_stacktrace_win_dlg.h"
 
 class StraceDlg : public QDialog, private Ui::errorDialog
@@ -67,13 +68,15 @@ public:
             "qBittorrent version: " VERSION "<br/>"
             "Libtorrent version: " LIBTORRENT_VERSION "<br/>"
             "Qt version: " QT_VERSION_STR "<br/>"
-            "Boost version: %1.%2.%3"
+            "Boost version: %1.%2.%3<br/>"
+            "OS version: %4"
             "</font></p><br/>"
-            "<pre><code>%4</code></pre>"
+            "<pre><code>%5</code></pre>"
             "<br/><hr><br/><br/>")
             .arg(boostVerMajor)
             .arg(boostVerMinor)
             .arg(boostVerSubMin)
+            .arg(Utils::Misc::osName())
             .arg(trace);
 
         errorText->setHtml(htmlStr);

--- a/src/app/stacktrace_win_dlg.h
+++ b/src/app/stacktrace_win_dlg.h
@@ -32,7 +32,6 @@
 
 #include <QString>
 #include <QDialog>
-#include "libtorrent/version.hpp"
 #include "base/utils/misc.h"
 #include "ui_stacktrace_win_dlg.h"
 
@@ -62,13 +61,14 @@ public:
             "<br/><hr><br/>"
             "<p align=center><font size=4>"
             "qBittorrent version: " VERSION "<br/>"
-            "Libtorrent version: " LIBTORRENT_VERSION "<br/>"
+            "Libtorrent version: %1<br/>"
             "Qt version: " QT_VERSION_STR "<br/>"
-            "Boost version: %1<br/>"
-            "OS version: %2"
+            "Boost version: %2<br/>"
+            "OS version: %3"
             "</font></p><br/>"
-            "<pre><code>%3</code></pre>"
+            "<pre><code>%4</code></pre>"
             "<br/><hr><br/><br/>")
+            .arg(Utils::Misc::libtorrentVersionString())
             .arg(Utils::Misc::boostVersionString())
             .arg(Utils::Misc::osName())
             .arg(trace);

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -37,6 +37,7 @@
 #include <QProcess>
 #include <QSettings>
 #include <QThread>
+#include <QSysInfo>
 
 #ifdef DISABLE_GUI
 #include <QCoreApplication>
@@ -634,3 +635,18 @@ QSize Utils::Misc::smallIconSize()
     return QSize(s, s);
 }
 #endif
+
+QString Utils::Misc::osName()
+{
+    // static initialization for usage in signal handler
+    static const QString name =
+#ifdef QBT_USES_QT5
+    QString("%1 %2 %3")
+    .arg(QSysInfo::prettyProductName())
+    .arg(QSysInfo::kernelVersion())
+    .arg(QSysInfo::currentCpuArchitecture());
+#else
+    "<Input OS name here>";
+#endif
+    return name;
+}

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -39,6 +39,7 @@
 #include <QThread>
 #include <QSysInfo>
 #include <boost/version.hpp>
+#include <libtorrent/version.hpp>
 
 #ifdef DISABLE_GUI
 #include <QCoreApplication>
@@ -659,5 +660,12 @@ QString Utils::Misc::boostVersionString()
                  .arg(BOOST_VERSION / 100000)
                  .arg((BOOST_VERSION / 100) % 1000)
                  .arg(BOOST_VERSION % 100);
+    return ver;
+}
+
+QString Utils::Misc::libtorrentVersionString()
+{
+    // static initialization for usage in signal handler
+    static const QString ver = LIBTORRENT_VERSION;
     return ver;
 }

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -38,6 +38,7 @@
 #include <QSettings>
 #include <QThread>
 #include <QSysInfo>
+#include <boost/version.hpp>
 
 #ifdef DISABLE_GUI
 #include <QCoreApplication>
@@ -649,4 +650,14 @@ QString Utils::Misc::osName()
     "<Input OS name here>";
 #endif
     return name;
+}
+
+QString Utils::Misc::boostVersionString()
+{
+    // static initialization for usage in signal handler
+    static const QString ver = QString("%1.%2.%3")
+                 .arg(BOOST_VERSION / 100000)
+                 .arg((BOOST_VERSION / 100) % 1000)
+                 .arg(BOOST_VERSION % 100);
+    return ver;
 }

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -57,6 +57,7 @@ namespace Utils
         QSize smallIconSize();
 #endif
         QString osName();
+        QString boostVersionString();
 
         int pythonVersion();
         QString pythonExecutable();

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -56,6 +56,8 @@ namespace Utils
         QPoint screenCenter(QWidget *win);
         QSize smallIconSize();
 #endif
+        QString osName();
+
         int pythonVersion();
         QString pythonExecutable();
         QString pythonVersionComplete();

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -58,6 +58,7 @@ namespace Utils
 #endif
         QString osName();
         QString boostVersionString();
+        QString libtorrentVersionString();
 
         int pythonVersion();
         QString pythonExecutable();

--- a/src/gui/about_imp.h
+++ b/src/gui/about_imp.h
@@ -34,7 +34,7 @@
 #include "ui_about.h"
 #include <QFile>
 #include <libtorrent/version.hpp>
-#include <boost/version.hpp>
+#include "base/utils/misc.h"
 #include "base/unicodestrings.h"
 
 class about: public QDialog, private Ui::AboutDlg
@@ -92,7 +92,7 @@ public:
         // Libraries
         label_11->setText(QT_VERSION_STR);
         label_12->setText(LIBTORRENT_VERSION);
-        label_13->setText(QString::number(BOOST_VERSION / 100000) + "." + QString::number((BOOST_VERSION / 100) % 1000) + "." + QString::number(BOOST_VERSION % 100));
+        label_13->setText(Utils::Misc::boostVersionString());
 
         show();
     }

--- a/src/gui/about_imp.h
+++ b/src/gui/about_imp.h
@@ -33,7 +33,6 @@
 
 #include "ui_about.h"
 #include <QFile>
-#include <libtorrent/version.hpp>
 #include "base/utils/misc.h"
 #include "base/unicodestrings.h"
 
@@ -91,7 +90,7 @@ public:
 
         // Libraries
         label_11->setText(QT_VERSION_STR);
-        label_12->setText(LIBTORRENT_VERSION);
+        label_12->setText(Utils::Misc::libtorrentVersionString());
         label_13->setText(Utils::Misc::boostVersionString());
 
         show();


### PR DESCRIPTION
* Shorten crash report on windows: Comment out "List of linked Modules" section.
* Also created some helper functions to get version strings.
* `Utils::Misc::osName()` output on Win8.1: `Windows 8.1 6.3.9600 x86_64`
* output on archLinux: `Arch Linux 4.4.1-2-ARCH x86_64`
