### PR TITLE
Stack trace for windows now contains source filenames and line numbers

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -33,7 +33,11 @@ nogui {
     TARGET = qbittorrent
 }
 nowebui: DEFINES += DISABLE_WEBUI
-strace_win: DEFINES += STACKTRACE_WIN
+strace_win {
+    DEFINES += STACKTRACE_WIN
+    DEFINES += STACKTRACE_WIN_PROJECT_PATH=$$PWD
+    DEFINES += STACKTRACE_WIN_MAKEFILE_PATH=$$OUT_PWD
+}
 QT += network xml
 
 # Vars


### PR DESCRIPTION
Example:
![trace](https://cloud.githubusercontent.com/assets/17599485/13475499/5a984daa-e0d4-11e5-9cbe-2497ab63c91c.png)