### PR TITLE
Support SSL certificate bundles. Closes #4896.

### DIFF
--- a/src/base/http/server.cpp
+++ b/src/base/http/server.cpp
@@ -52,9 +52,9 @@ Server::~Server()
 }
 
 #ifndef QT_NO_OPENSSL
-void Server::enableHttps(const QSslCertificate &certificate, const QSslKey &key)
+void Server::enableHttps(const QList<QSslCertificate> &certificates, const QSslKey &key)
 {
-    m_certificate = certificate;
+    m_certificates = certificates;
     m_key = key;
     m_https = true;
 }
@@ -62,7 +62,7 @@ void Server::enableHttps(const QSslCertificate &certificate, const QSslKey &key)
 void Server::disableHttps()
 {
     m_https = false;
-    m_certificate.clear();
+    m_certificates.clear();
     m_key.clear();
 }
 #endif
@@ -84,9 +84,13 @@ void Server::incomingConnection(int socketDescriptor)
     if (serverSocket->setSocketDescriptor(socketDescriptor)) {
 #ifndef QT_NO_OPENSSL
         if (m_https) {
-            static_cast<QSslSocket*>(serverSocket)->setProtocol(QSsl::AnyProtocol);
+            static_cast<QSslSocket*>(serverSocket)->setProtocol(QSsl::SecureProtocols);
             static_cast<QSslSocket*>(serverSocket)->setPrivateKey(m_key);
-            static_cast<QSslSocket*>(serverSocket)->setLocalCertificate(m_certificate);
+#ifdef QBT_USES_QT5
+            static_cast<QSslSocket*>(serverSocket)->setLocalCertificateChain(m_certificates);
+#else
+            static_cast<QSslSocket*>(serverSocket)->setLocalCertificate(m_certificates.first());
+#endif
             static_cast<QSslSocket*>(serverSocket)->startServerEncryption();
         }
 #endif

--- a/src/base/http/server.h
+++ b/src/base/http/server.h
@@ -54,7 +54,7 @@ namespace Http
         ~Server();
 
     #ifndef QT_NO_OPENSSL
-        void enableHttps(const QSslCertificate &certificate, const QSslKey &key);
+        void enableHttps(const QList<QSslCertificate> &certificates, const QSslKey &key);
         void disableHttps();
     #endif
 
@@ -69,7 +69,7 @@ namespace Http
         IRequestHandler *m_requestHandler;
     #ifndef QT_NO_OPENSSL
         bool m_https;
-        QSslCertificate m_certificate;
+        QList<QSslCertificate> m_certificates;
         QSslKey m_key;
     #endif
     };

--- a/src/webui/webui.cpp
+++ b/src/webui/webui.cpp
@@ -65,11 +65,12 @@ void WebUI::init()
 
 #ifndef QT_NO_OPENSSL
         if (pref->isWebUiHttpsEnabled()) {
-            QSslCertificate cert(pref->getWebUiHttpsCertificate());
+            QList<QSslCertificate> certs = QSslCertificate::fromData(pref->getWebUiHttpsCertificate());
             QSslKey key;
             key = QSslKey(pref->getWebUiHttpsKey(), QSsl::Rsa);
-            if (!cert.isNull() && !key.isNull())
-                httpServer_->enableHttps(cert, key);
+            bool certsIsNull = std::any_of(certs.begin(), certs.end(), [](QSslCertificate c) { return c.isNull(); });
+            if (!certsIsNull && !certs.empty() && !key.isNull())
+                httpServer_->enableHttps(certs, key);
             else
                 httpServer_->disableHttps();
         }


### PR DESCRIPTION
This fixes issue #4896 when built with Qt5 and retains the original behavior with Qt4.