### PR TITLE
cmake: fix systemd unit install path

### DIFF
--- a/dist/unix/CMakeLists.txt
+++ b/dist/unix/CMakeLists.txt
@@ -4,7 +4,7 @@ if (SYSTEMD)
         set(EXPAND_BINDIR ${CMAKE_INSTALL_FULL_BINDIR})
         configure_file(systemd/qbittorrent-nox.service.in ${CMAKE_CURRENT_BINARY_DIR}/qbittorrent-nox.service @ONLY)
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/qbittorrent-nox.service
-            DESTINATION ${CMAKE_INSTALL_PREFIX}/${SYSTEMD_SERVICES_INSTALL_DIR}
+            DESTINATION ${SYSTEMD_SERVICES_INSTALL_DIR}
             COMPONENT data)
     endif(SYSTEMD_FOUND)
 endif(SYSTEMD)


### PR DESCRIPTION
SYSTEMD_SERVICES_INSTALL_DIR includes systemd installation prefix already