### PR TITLE
Move some URLs overs to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ out there. qBittorrent is fast, stable and provides unicode
 support as well as many features.
 
 This product includes GeoLite data created by MaxMind, available from
-http://maxmind.com/
+https://www.maxmind.com/
 
 ### Installation:
 For installation, follow the instructions from INSTALL file, but simple:

--- a/src/base/net/dnsupdater.cpp
+++ b/src/base/net/dnsupdater.cpp
@@ -300,7 +300,7 @@ QUrl DNSUpdater::getRegistrationUrl(int service)
     case DNS::DYNDNS:
         return QUrl("https://www.dyndns.com/account/services/hosts/add.html");
     case DNS::NOIP:
-        return QUrl("http://www.no-ip.com/services/managed_dns/free_dynamic_dns.html");
+        return QUrl("https://www.noip.com/remote-access");
     default:
         Q_ASSERT(0);
     }

--- a/src/base/net/geoipmanager.cpp
+++ b/src/base/net/geoipmanager.cpp
@@ -42,7 +42,7 @@
 #include "private/geoipdatabase.h"
 #include "geoipmanager.h"
 
-static const char DATABASE_URL[] = "http://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.mmdb.gz";
+static const char DATABASE_URL[] = "https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.mmdb.gz";
 static const char GEOIP_FOLDER[] = "GeoIP";
 static const char GEOIP_FILENAME[] = "GeoLite2-Country.mmdb";
 static const int CACHE_SIZE = 1000;

--- a/src/gui/gpl.html
+++ b/src/gui/gpl.html
@@ -510,7 +510,7 @@ This General Public License does not permit incorporating your program into
 proprietary programs.  If your program is a subroutine library, you may
 consider it more useful to permit linking proprietary applications with the
 library.  If this is what you want to do, use the 
-<a href="http://www.gnu.org/licenses/lgpl.html">GNU Lesser General Public License</a> 
+<a href="https://www.gnu.org/licenses/lgpl.html">GNU Lesser General Public License</a> 
 instead of this License.
 </p>
 </body>

--- a/src/gui/options.ui
+++ b/src/gui/options.ui
@@ -2252,7 +2252,7 @@
                  <item>
                   <widget class="QLabel" name="label_anonymous">
                    <property name="text">
-                    <string> (&lt;a href=&quot;http://github.com/qbittorrent/qBittorrent/wiki/Anonymous-Mode&quot;&gt;More information&lt;/a&gt;)</string>
+                    <string> (&lt;a href=&quot;https://github.com/qbittorrent/qBittorrent/wiki/Anonymous-Mode&quot;&gt;More information&lt;/a&gt;)</string>
                    </property>
                    <property name="openExternalLinks">
                     <bool>true</bool>
@@ -2729,7 +2729,7 @@
                   <item row="2" column="0" colspan="3">
                    <widget class="QLabel" name="lblWebUIInfo">
                     <property name="text">
-                     <string>&lt;a href=http://httpd.apache.org/docs/2.2/ssl/ssl_faq.html#aboutcerts&gt;Information about certificates&lt;/a&gt;</string>
+                     <string>&lt;a href=https://httpd.apache.org/docs/current/ssl/ssl_faq.html#aboutcerts&gt;Information about certificates&lt;/a&gt;</string>
                     </property>
                     <property name="openExternalLinks">
                      <bool>true</bool>

--- a/src/gui/programupdater.cpp
+++ b/src/gui/programupdater.cpp
@@ -41,7 +41,7 @@
 
 namespace
 {
-    const QString RSS_URL("http://www.fosshub.com/software/feedqBittorent");
+    const QString RSS_URL("https://www.fosshub.com/software/feedqBittorent");
 
 #ifdef Q_OS_MAC
     const QString OS_TYPE("Mac OS X");

--- a/src/gui/properties/trackersadditiondlg.cpp
+++ b/src/gui/properties/trackersadditiondlg.cpp
@@ -59,7 +59,7 @@ QStringList TrackersAdditionDlg::newTrackers() const
 void TrackersAdditionDlg::on_uTorrentListButton_clicked()
 {
     uTorrentListButton->setEnabled(false);
-    Net::DownloadHandler *handler = Net::DownloadManager::instance()->downloadUrl(QString("http://www.torrentz.com/announce_%1").arg(m_torrent->hash()), true);
+    Net::DownloadHandler *handler = Net::DownloadManager::instance()->downloadUrl(QString("https://www.torrentz.com/announce_%1").arg(m_torrent->hash()), true);
     connect(handler, SIGNAL(downloadFinished(QString, QString)), this, SLOT(parseUTorrentList(QString, QString)));
     connect(handler, SIGNAL(downloadFailed(QString, QString)), this, SLOT(getTrackerError(QString, QString)));
     //Just to show that it takes times

--- a/src/searchengine/nova/engines/extratorrent.py
+++ b/src/searchengine/nova/engines/extratorrent.py
@@ -1,4 +1,4 @@
-#VERSION: 2.03
+#VERSION: 2.04
 #AUTHORS: Christophe Dumez (chris@qbittorrent.org)
 #CONTRIBUTORS: Diego de las Heras (ngosang@hotmail.es)
 
@@ -33,7 +33,7 @@ from helpers import download_file, retrieve_url
 
 class extratorrent(object):
     """ Search engine class """
-    url = 'http://extratorrent.cc'
+    url = 'https://extratorrent.cc'
     name = 'ExtraTorrent'
     supported_categories = {'all'       : '0',
                             'movies'    : '4',

--- a/src/searchengine/nova/engines/torrentreactor.py
+++ b/src/searchengine/nova/engines/torrentreactor.py
@@ -1,4 +1,4 @@
-#VERSION: 1.40
+#VERSION: 1.41
 #AUTHORS: Gekko Dam Beer (gekko04@users.sourceforge.net)
 #CONTRIBUTORS: Christophe Dumez (chris@qbittorrent.org)
 #              Bruno Barbieri (brunorex@gmail.com)
@@ -34,7 +34,7 @@ from HTMLParser import HTMLParser
 from re import compile as re_compile
 
 class torrentreactor(object):
-    url = 'http://torrentreactor.com'
+    url = 'https://torrentreactor.com'
     name = 'TorrentReactor'
     supported_categories = {'all': '', 'movies': '5', 'tv': '8', 'music': '6', 'games': '3', 'anime': '1', 'software': '2'}
 

--- a/src/searchengine/nova/engines/versions.txt
+++ b/src/searchengine/nova/engines/versions.txt
@@ -1,9 +1,9 @@
 btdigg: 1.30
 demonoid: 1.2
-extratorrent: 2.03
+extratorrent: 2.04
 kickasstorrents: 1.28
 legittorrents: 2.00
 mininova: 2.01
 piratebay: 2.14
-torrentreactor: 1.40
+torrentreactor: 1.41
 torrentz: 2.17

--- a/src/searchengine/nova3/engines/extratorrent.py
+++ b/src/searchengine/nova3/engines/extratorrent.py
@@ -1,4 +1,4 @@
-#VERSION: 2.03
+#VERSION: 2.04
 #AUTHORS: Christophe Dumez (chris@qbittorrent.org)
 #CONTRIBUTORS: Diego de las Heras (ngosang@hotmail.es)
 
@@ -33,7 +33,7 @@ from helpers import download_file, retrieve_url
 
 class extratorrent(object):
     """ Search engine class """
-    url = 'http://extratorrent.cc'
+    url = 'https://extratorrent.cc'
     name = 'ExtraTorrent'
     supported_categories = {'all'       : '0',
                             'movies'    : '4',

--- a/src/searchengine/nova3/engines/torrentreactor.py
+++ b/src/searchengine/nova3/engines/torrentreactor.py
@@ -1,4 +1,4 @@
-#VERSION: 1.40
+#VERSION: 1.41
 #AUTHORS: Gekko Dam Beer (gekko04@users.sourceforge.net)
 #CONTRIBUTORS: Christophe Dumez (chris@qbittorrent.org)
 #              Bruno Barbieri (brunorex@gmail.com)
@@ -34,7 +34,7 @@ from html.parser import HTMLParser
 from re import compile as re_compile
 
 class torrentreactor(object):
-    url = 'http://torrentreactor.com'
+    url = 'https://torrentreactor.com'
     name = 'TorrentReactor'
     supported_categories = {'all': '', 'movies': '5', 'tv': '8', 'music': '6', 'games': '3', 'anime': '1', 'software': '2'}
 

--- a/src/searchengine/nova3/engines/versions.txt
+++ b/src/searchengine/nova3/engines/versions.txt
@@ -1,9 +1,9 @@
 btdigg: 1.30
 demonoid: 1.2
-extratorrent: 2.03
+extratorrent: 2.04
 kickasstorrents: 1.28
 legittorrents: 2.00
 mininova: 2.01
 piratebay: 2.14
-torrentreactor: 1.40
+torrentreactor: 1.41
 torrentz: 2.17

--- a/src/webui/www/public/preferences_content.html
+++ b/src/webui/www/public/preferences_content.html
@@ -378,7 +378,7 @@
     <label for="ssl_cert_textarea" style="margin-left: 20px;">QBT_TR(Certificate:)QBT_TR</label>
     <textarea id="ssl_cert_textarea" rows="5" cols="70"></textarea>
     </div>
-    <div style="padding-left: 10px;"><a target="_blank" href="http://httpd.apache.org/docs/2.2/ssl/ssl_faq.html#aboutcerts">QBT_TR(Information about certificates)QBT_TR</a></div>
+    <div style="padding-left: 10px;"><a target="_blank" href="https://httpd.apache.org/docs/current/ssl/ssl_faq.html#aboutcerts">QBT_TR(Information about certificates)QBT_TR</a></div>
   </fieldset>
 </fieldset>
 


### PR DESCRIPTION
The main goal of this was to move some search engines over to HTTPS to avoid censorship on (some) ISPs. However, this may warrant discussion of moving all the URLs over to https://unblocked.red/ which would prevent all types of censorship and provide HTTPS protection for the engines that don't support it.

I took the opportunity to fix a few other URLs on top of that.

I also tried to verify if the update checker was done over HTTPS and I assume it to be this URL: http://www.fosshub.com/software/feedqBittorent in which case I'd strongly recommend moving this over to GitHub and having qBt download the raw XML file from GitHub over HTTPS. As it stands anyone can MitM the XML file feeding custom versions pointing to any malicious URL. A less malicious user could use this to gather statistics on qBt usage.