### PR TITLE
Fix additional space in comment label

### DIFF
--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -689,7 +689,7 @@ void AddNewTorrentDialog::setMetadataProgressIndicator(bool visibleIndicator, co
 void AddNewTorrentDialog::setupTreeview()
 {
     if (!m_hasMetadata) {
-        ui->comment_lbl->setText(tr("Not Available", "This comment is unavailable"));
+        setCommentText(tr("Not Available", "This comment is unavailable"));
         ui->date_lbl->setText(tr("Not Available", "This date is unavailable"));
     }
     else {
@@ -697,7 +697,7 @@ void AddNewTorrentDialog::setupTreeview()
         setWindowTitle(m_torrentInfo.name());
 
         // Set torrent information
-        ui->comment_lbl->setText(Utils::Misc::parseHtmlLinks(m_torrentInfo.comment()));
+        setCommentText(Utils::Misc::parseHtmlLinks(m_torrentInfo.comment()));
         ui->date_lbl->setText(!m_torrentInfo.creationDate().isNull() ? m_torrentInfo.creationDate().toString(Qt::DefaultLocaleShortDate) : tr("Not available"));
 
         // Prepare content tree
@@ -776,4 +776,15 @@ void AddNewTorrentDialog::savingModeChanged(bool enabled)
         ui->browseButton->setEnabled(false);
         ui->defaultSavePathCheckBox->setVisible(false);
     }
+}
+
+void AddNewTorrentDialog::setCommentText(const QString &str) const
+{
+    ui->commentLabel->setText(str);
+
+    // workaround for the additional space introduced by QScrollArea
+    int lineHeight = ui->commentLabel->fontMetrics().lineSpacing();
+    int lines = 1 + str.count("\n");
+    int height = lineHeight * lines;
+    ui->scrollArea->setMaximumHeight(height);
 }

--- a/src/gui/addnewtorrentdialog.h
+++ b/src/gui/addnewtorrentdialog.h
@@ -95,6 +95,7 @@ private:
     void setMetadataProgressIndicator(bool visibleIndicator, const QString &labelText = QString());
     void setupTreeview();
     QString defaultSavePath() const;
+    void setCommentText(const QString &str) const;
 
     void showEvent(QShowEvent *event) override;
 

--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -287,7 +287,7 @@
              <number>0</number>
             </property>
             <item>
-             <widget class="QLabel" name="comment_lbl">
+             <widget class="QLabel" name="commentLabel">
               <property name="textFormat">
                <enum>Qt::RichText</enum>
               </property>


### PR DESCRIPTION
Lazy to describe, see screenshot below.

Before:
![before](https://cloud.githubusercontent.com/assets/9395168/13560963/5aef1c26-e461-11e5-9375-8bae2ea0c4ca.png)

After:
![after](https://cloud.githubusercontent.com/assets/9395168/13560962/5a4aaa7e-e461-11e5-946a-9b52429c373d.png)