### PR TITLE
cmake: fix man installation

### DIFF
--- a/dist/unix/CMakeLists.txt
+++ b/dist/unix/CMakeLists.txt
@@ -13,7 +13,7 @@ endif(SYSTEMD)
 if (GUI)
     list(APPEND MAN_FILES ${qBittorrent_SOURCE_DIR}/doc/qbittorrent.1)
 else (GUI)
-    list(APPEND MAN_FILES ${qBittorrent_SOURCE_DIR}/doc/qbittorrent.1)
+    list(APPEND MAN_FILES ${qBittorrent_SOURCE_DIR}/doc/qbittorrent-nox.1)
 endif (GUI)
 
 install(FILES ${MAN_FILES}


### PR DESCRIPTION
Fix copy-n-paste error: for non-GUI build we have to install
qbittorrent-nox.1, but not qbittorrent.1.