### PR TITLE
Fix crash when qbt exits with options dialog opened

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -33,6 +33,7 @@
 #include <QLibraryInfo>
 #include <QSysInfo>
 #include <QProcess>
+#include <QAtomicInt>
 
 #ifndef DISABLE_GUI
 #include "gui/guiiconprovider.h"
@@ -548,11 +549,9 @@ void Application::cleanup()
 #ifndef DISABLE_GUI
 #ifdef Q_OS_WIN
     // cleanup() can be called multiple times during shutdown. We only need it once.
-    static bool alreadyDone = false;
-
-    if (alreadyDone)
+    static QAtomicInt alreadyDone;
+    if (!alreadyDone.testAndSetAcquire(0, 1))
         return;
-    alreadyDone = true;
 #endif // Q_OS_WIN
 
     // Hide the window and not leave it on screen as
@@ -595,6 +594,7 @@ void Application::cleanup()
     delete m_fileLogger;
     Logger::freeInstance();
     IconProvider::freeInstance();
+
 #ifndef DISABLE_GUI
 #ifdef Q_OS_WIN
     typedef BOOL (WINAPI *PSHUTDOWNBRDESTROY)(HWND);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -654,12 +654,12 @@ void MainWindow::cleanup()
 #if (defined(Q_OS_WIN) || defined(Q_OS_MAC))
     m_programUpdateTimer->stop();
 #endif
-    delete m_searchFilter;
+
     delete m_searchFilterAction;
-    delete m_tabs; // this seems enough to also delete all contained widgets
-    delete m_statusBar;
-    delete m_pwr;
-    delete m_toolbarMenu;
+
+    // remove all child widgets
+    while (QWidget *w = findChild<QWidget *>())
+        delete w;
 }
 
 void MainWindow::readSettings()


### PR DESCRIPTION
From #4871.
All starts at: https://github.com/qbittorrent/qBittorrent/blob/master/src/app/application.cpp#L482
`~options_imp()` is calling `ScanFoldersModel::configure()` which access `Preference` class.
But at the time, `Preference` has already become invalid so the crash pop up.

~~Dirty workaround, better ideas welcome.~~

------

BTW, in the first commit, is it a good idea to make `static QAtomicInt alreadyDone;` independent of `DISABLE_GUI` & `Q_OS_WIN`, so it can apply to all platforms?