### PR TITLE
Add Support for Logging in via Authentication Tokens

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -54,6 +54,7 @@
 
 #include "utils/fs.h"
 #include "utils/misc.h"
+#include "utils/string.h"
 #include "settingsstorage.h"
 #include "logger.h"
 #include "preferences.h"
@@ -970,6 +971,32 @@ bool Preferences::useUPnPForWebUIPort() const
 void Preferences::setUPnPForWebUIPort(bool enabled)
 {
     setValue("Preferences/WebUI/UseUPnP", enabled);
+}
+
+QStringList Preferences::getWebUiAuthenticationTokens() const
+{
+    return value("Preferences/WebUI/AuthenticationTokens").toStringList();
+}
+
+void Preferences::setWebUiAuthenticationTokens(const QStringList &tokens)
+{
+    setValue("Preferences/WebUI/AuthenticationTokens", tokens);
+}
+
+bool Preferences::isAuthenticationTokenValid(const QString& token) const
+{
+    bool tokenAuthenticated = false;
+
+    if (!token.isNull()) {
+        foreach (QString storedToken, getWebUiAuthenticationTokens()) {
+            if (Utils::String::slowEquals(token.toUtf8(), storedToken.toUtf8())) {
+                tokenAuthenticated = true;
+                break;
+            }
+        }
+    }
+
+    return tokenAuthenticated;
 }
 
 QString Preferences::getWebUiUsername() const

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -296,6 +296,9 @@ public:
     void setWebUiPort(quint16 port);
     bool useUPnPForWebUIPort() const;
     void setUPnPForWebUIPort(bool enabled);
+    QStringList getWebUiAuthenticationTokens() const;
+    void setWebUiAuthenticationTokens(const QStringList &tokens);
+    bool isAuthenticationTokenValid(const QString& token) const;
     QString getWebUiUsername() const;
     void setWebUiUsername(const QString &username);
     QString getWebUiPassword() const;

--- a/src/gui/options.ui
+++ b/src/gui/options.ui
@@ -2928,6 +2928,13 @@
                                            </property>
                                        </widget>
                                    </item>
+                                   <item>
+                                       <widget class="QPushButton" name="copyAuthTokenClipboardButton">
+                                           <property name="text">
+                                               <string>Copy to Clipboard</string>
+                                           </property>
+                                       </widget>
+                                   </item>
 
                                    <item>
                                        <spacer name="verticalSpacer_6">

--- a/src/gui/options.ui
+++ b/src/gui/options.ui
@@ -2887,101 +2887,69 @@
                  </layout>
                 </widget>
                </item>
-
                <item>
-                   <widget class="QGroupBox" name="groupWebUiAuth">
-                       <property name="title">
-                           <string>Authentication Tokens</string>
-                       </property>
-
-
-                       <layout class="QHBoxLayout" name="horizontalLayout_16">
-                           <item>
-                               <widget class="QListWidget" name="authTokensView">
-                                   <property name="sizePolicy">
-                                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                                           <horstretch>0</horstretch>
-                                           <verstretch>1</verstretch>
-                                       </sizepolicy>
-                                   </property>
-                                   <property name="minimumSize">
-                                       <size>
-                                           <width>250</width>
-                                           <height>150</height>
-                                       </size>
-                                   </property>
-                               </widget>
-                           </item>
-                           <item>
-                               <layout class="QVBoxLayout" name="verticalLayout_37">
-                                   <item>
-                                       <widget class="QPushButton" name="addAuthTokenButton">
-                                           <property name="text">
-                                               <string>Add</string>
-                                           </property>
-                                       </widget>
-                                   </item>
-                                   <item>
-                                       <widget class="QPushButton" name="removeAuthTokenButton">
-                                           <property name="text">
-                                               <string>Remove</string>
-                                           </property>
-                                       </widget>
-                                   </item>
-                                   <item>
-                                       <widget class="QPushButton" name="copyAuthTokenClipboardButton">
-                                           <property name="text">
-                                               <string>Copy to Clipboard</string>
-                                           </property>
-                                       </widget>
-                                   </item>
-
-                                   <item>
-                                       <spacer name="verticalSpacer_6">
-                                           <property name="orientation">
-                                               <enum>Qt::Vertical</enum>
-                                           </property>
-                                           <property name="sizeHint" stdset="0">
-                                               <size>
-                                                   <width>20</width>
-                                                   <height>40</height>
-                                               </size>
-                                           </property>
-                                       </spacer>
-                                   </item>
-                               </layout>
-                           </item>
-                       </layout>
-
-
-
-
-                       <!-- <layout class="QGridLayout" name="gridLayout_10">
-                           <item row="3" column="1">
-                               <widget class="QLineEdit" name="textWebUiAuthenticationTokens">
-                                   <property name="text">
-                                       <string/>
-                                   </property>
-                                   <property name="maxLength">
-                                       <number>1000</number>
-                                   </property>
-                                   <property name="echoMode">
-                                       <enum>QLineEdit::Normal</enum>
-                                   </property>
-                               </widget>
-                           </item>
-                           <item row="0" column="0" rowspan="3">
-                               <widget class="QLabel" name="lblWebUiAuthenticationTokens">
-                                   <property name="text">
-                                       <string>Tokens:</string>
-                                   </property>
-                               </widget>
-                           </item>
-                       </layout> -->
+                <widget class="QGroupBox" name="groupWebUiTokenAuth">
+                 <property name="title">
+                  <string>Authentication Tokens</string>
+                 </property>
+                 <layout class="QHBoxLayout" name="horizontalLayout_16">
+                  <item>
+                   <widget class="QListWidget" name="authTokensView">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                      <horstretch>0</horstretch>
+                      <verstretch>1</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="minimumSize">
+                     <size>
+                      <width>250</width>
+                      <height>150</height>
+                     </size>
+                    </property>
                    </widget>
+                  </item>
+                  <item>
+                   <layout class="QVBoxLayout" name="verticalLayout_37">
+                    <item>
+                     <widget class="QPushButton" name="addAuthTokenButton">
+                      <property name="text">
+                       <string>Add</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="removeAuthTokenButton">
+                      <property name="text">
+                       <string>Remove</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="copyAuthTokenClipboardButton">
+                      <property name="text">
+                       <string>Copy to Clipboard</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <spacer name="verticalSpacer_6">
+                      <property name="orientation">
+                       <enum>Qt::Vertical</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>20</width>
+                        <height>40</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                   </layout>
+                  </item>
+                 </layout>
+                </widget>
                </item>
-
-
               </layout>
              </widget>
             </item>

--- a/src/gui/options.ui
+++ b/src/gui/options.ui
@@ -2887,6 +2887,94 @@
                  </layout>
                 </widget>
                </item>
+
+               <item>
+                   <widget class="QGroupBox" name="groupWebUiAuth">
+                       <property name="title">
+                           <string>Authentication Tokens</string>
+                       </property>
+
+
+                       <layout class="QHBoxLayout" name="horizontalLayout_16">
+                           <item>
+                               <widget class="QListWidget" name="authTokensView">
+                                   <property name="sizePolicy">
+                                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                                           <horstretch>0</horstretch>
+                                           <verstretch>1</verstretch>
+                                       </sizepolicy>
+                                   </property>
+                                   <property name="minimumSize">
+                                       <size>
+                                           <width>250</width>
+                                           <height>150</height>
+                                       </size>
+                                   </property>
+                               </widget>
+                           </item>
+                           <item>
+                               <layout class="QVBoxLayout" name="verticalLayout_37">
+                                   <item>
+                                       <widget class="QPushButton" name="addAuthTokenButton">
+                                           <property name="text">
+                                               <string>Add</string>
+                                           </property>
+                                       </widget>
+                                   </item>
+                                   <item>
+                                       <widget class="QPushButton" name="removeAuthTokenButton">
+                                           <property name="text">
+                                               <string>Remove</string>
+                                           </property>
+                                       </widget>
+                                   </item>
+
+                                   <item>
+                                       <spacer name="verticalSpacer_6">
+                                           <property name="orientation">
+                                               <enum>Qt::Vertical</enum>
+                                           </property>
+                                           <property name="sizeHint" stdset="0">
+                                               <size>
+                                                   <width>20</width>
+                                                   <height>40</height>
+                                               </size>
+                                           </property>
+                                       </spacer>
+                                   </item>
+                               </layout>
+                           </item>
+                       </layout>
+
+
+
+
+                       <!-- <layout class="QGridLayout" name="gridLayout_10">
+                           <item row="3" column="1">
+                               <widget class="QLineEdit" name="textWebUiAuthenticationTokens">
+                                   <property name="text">
+                                       <string/>
+                                   </property>
+                                   <property name="maxLength">
+                                       <number>1000</number>
+                                   </property>
+                                   <property name="echoMode">
+                                       <enum>QLineEdit::Normal</enum>
+                                   </property>
+                               </widget>
+                           </item>
+                           <item row="0" column="0" rowspan="3">
+                               <widget class="QLabel" name="lblWebUiAuthenticationTokens">
+                                   <property name="text">
+                                       <string>Tokens:</string>
+                                   </property>
+                               </widget>
+                           </item>
+                       </layout> -->
+                   </widget>
+               </item>
+
+
               </layout>
              </widget>
             </item>

--- a/src/gui/options_imp.cpp
+++ b/src/gui/options_imp.cpp
@@ -39,6 +39,7 @@
 #include <QTranslator>
 #include <QDesktopServices>
 #include <QDebug>
+#include <QClipboard>
 
 #include <cstdlib>
 
@@ -203,6 +204,7 @@ options_imp::options_imp(QWidget *parent)
 
     connect(addAuthTokenButton, SIGNAL(clicked()), this, SLOT(enableApplyButton()));
     connect(removeAuthTokenButton, SIGNAL(clicked()), this, SLOT(enableApplyButton()));
+    // connect(copyAuthTokenClipboardButton, SIGNAL(clicked()), this, SLOT(enableApplyButton()));
 
     const QString autoRunStr = QString::fromUtf8("%1\n    %2\n    %3\n    %4\n    %5\n    %6\n    %7\n    %8\n    %9\n    %10\n%11")
                                .arg(tr("Supported parameters (case sensitive):"))
@@ -1272,9 +1274,19 @@ void options_imp::on_removeAuthTokenButton_clicked()
     handleAuthTokensCurrentItemChanged();
 }
 
+void options_imp::on_copyAuthTokenClipboardButton_clicked()
+{
+    QString selectedAuthToken = authTokensView->selectedItems().first()->text();
+
+    QApplication::clipboard()->setText(selectedAuthToken);
+}
+
 void options_imp::handleAuthTokensCurrentItemChanged()
 {
-    removeAuthTokenButton->setEnabled(!authTokensView->selectedItems().isEmpty());
+    bool enabled = !authTokensView->selectedItems().isEmpty();
+
+    removeAuthTokenButton->setEnabled(enabled);
+    copyAuthTokenClipboardButton->setEnabled(enabled);
 }
 
 void options_imp::on_addScanFolderButton_clicked()

--- a/src/gui/options_imp.cpp
+++ b/src/gui/options_imp.cpp
@@ -201,10 +201,8 @@ options_imp::options_imp(QWidget *parent)
     connect(mailNotifPassword, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
     connect(autoRunBox, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
     connect(autoRun_txt, SIGNAL(textChanged(QString)), this, SLOT(enableApplyButton()));
-
     connect(addAuthTokenButton, SIGNAL(clicked()), this, SLOT(enableApplyButton()));
     connect(removeAuthTokenButton, SIGNAL(clicked()), this, SLOT(enableApplyButton()));
-    // connect(copyAuthTokenClipboardButton, SIGNAL(clicked()), this, SLOT(enableApplyButton()));
 
     const QString autoRunStr = QString::fromUtf8("%1\n    %2\n    %3\n    %4\n    %5\n    %6\n    %7\n    %8\n    %9\n    %10\n%11")
                                .arg(tr("Supported parameters (case sensitive):"))
@@ -310,7 +308,6 @@ options_imp::options_imp(QWidget *parent)
 
     // initialize rand for authentication tokens
     srand(time(0));
-
 }
 
 void options_imp::initializeLanguageCombo()

--- a/src/gui/options_imp.cpp
+++ b/src/gui/options_imp.cpp
@@ -40,6 +40,7 @@
 #include <QDesktopServices>
 #include <QDebug>
 #include <QClipboard>
+#include <QCryptographicHash>
 
 #include <cstdlib>
 

--- a/src/gui/options_imp.h
+++ b/src/gui/options_imp.h
@@ -98,6 +98,7 @@ private slots:
 
     void on_addAuthTokenButton_clicked();
     void on_removeAuthTokenButton_clicked();
+    void on_copyAuthTokenClipboardButton_clicked();
     void handleAuthTokensCurrentItemChanged();
 
 private:

--- a/src/gui/options_imp.h
+++ b/src/gui/options_imp.h
@@ -96,6 +96,10 @@ private slots:
     void on_registerDNSBtn_clicked();
     void setLocale(const QString &locale);
 
+    void on_addAuthTokenButton_clicked();
+    void on_removeAuthTokenButton_clicked();
+    void handleAuthTokensCurrentItemChanged();
+
 private:
     // Methods
     void saveOptions();
@@ -155,6 +159,7 @@ private:
     int getMaxActiveTorrents() const;
     bool isWebUiEnabled() const;
     quint16 webUiPort() const;
+    QStringList webUiAuthenticationTokens() const;
     QString webUiUsername() const;
     QString webUiPassword() const;
     QSize sizeFittingScreen() const;

--- a/src/webui/abstractwebapplication.h
+++ b/src/webui/abstractwebapplication.h
@@ -67,7 +67,7 @@ protected:
 
     // Session management
     bool sessionActive() const { return session_ != 0; }
-    bool sessionStart();
+    bool sessionStart(const QString& token = QString());
     bool sessionEnd();
 
     bool isAuthNeeded();

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -172,11 +172,17 @@ void WebApplication::action_public_login()
     md5.addData(request().posts["password"].toLocal8Bit());
     QString pass = md5.result().toHex();
 
+    QString token = request().posts["token"];
+
     bool equalUser = Utils::String::slowEquals(request().posts["username"].toUtf8(), pref->getWebUiUsername().toUtf8());
     bool equalPass = Utils::String::slowEquals(pass.toUtf8(), pref->getWebUiPassword().toUtf8());
+    bool userAuthenticated = equalUser && equalPass;
 
-    if (equalUser && equalPass) {
-        sessionStart();
+    // check if the provided token matches one of our authentication tokens
+    bool tokenAuthenticated = pref->isAuthenticationTokenValid(token);
+
+    if (tokenAuthenticated || userAuthenticated) {
+        sessionStart(token);
         print(QByteArray("Ok."), Http::CONTENT_TYPE_TXT);
     }
     else {


### PR DESCRIPTION
## General:

I was using qbittorrent in such a way that I wanted to remotely log into my client. Initially I was just using my username and password, but I didn't like the idea of my username and password floating around in a script that could be exposed to the internet. So I had the idea of extending qbittorrent to accept logging in via "authentication tokens", which you can create in the UI. When you create a new token, it will be randomly generated and you will immediately be able to log in using it. However, I also wanted to support "revoking" access for tokens, so I added checks to ensure the token you logged in using is still currently valid. If it isn't valid anymore (ie. it's been revoked/removed), your session is destroyed.

Please let me know if anyone else would find this useful, or if you have any suggestions/comments.
## Example Login via Authentication Token:

```
POST /login HTTP/1.1
Host: 192.168.0.15:8090
Content-Type: application/x-www-form-urlencoded
Content-Length: 38

token=5cc2832f4830a89199dd921025c4d374

HTTP/1.1 200 OK
Content-Length: 3
Content-Type: text/plain; charset=UTF-8
Set-Cookie: SID=7rWsLgJto2E7ReEdO/LpS6rtxDG4bzl2; path=/

Ok.
```
## GUI Changes:

![GUI Changes](http://puu.sh/nDp4f/1a942c6031.png)
