### PR TITLE
Dynamically adapt step size for rate limit boxes

### DIFF
--- a/src/gui/optionsdlg.h
+++ b/src/gui/optionsdlg.h
@@ -33,6 +33,7 @@
 
 #include <QButtonGroup>
 #include <QDialog>
+#include <QSpinBox>
 
 class QAbstractButton;
 class QCloseEvent;
@@ -101,10 +102,14 @@ private slots:
     void on_btnWebUiKey_clicked();
     void on_registerDNSBtn_clicked();
     void setLocale(const QString &locale);
+    void adaptLimitStep(int value);
+    void adaptLimitStep(QSpinBox* limitBox);
 
 private:
     // Methods
     void saveOptions();
+    int limitStep(int value);
+    void adaptLimitStep(QSpinBox* limitBox, int value);
     void loadOptions();
     void initializeLanguageCombo();
     static QString languageToLocalizedString(const QLocale &locale);


### PR DESCRIPTION
This will dynamically adapt the step size of each of the four Rate Limit spinboxes to one order of magnitude below the value. When the rate limit is to 320 KiB/s, the step size will be 10, so that increasing it one step changes the value to 330 instead of 321. Increasing 1200 KiB/s will give 1300, and so on. Values 1-99 will still have step size 1.

The step size is calculated by taking `log10` of the value every time it changes, rounding it down, subtracting by one, and inflating it again with `pow`. Special care is taken for single-digit values.
