### PR TITLE
Fix missing header

### DIFF
--- a/src/base/http/server.cpp
+++ b/src/base/http/server.cpp
@@ -30,9 +30,8 @@
 
 #ifndef QT_NO_OPENSSL
 #include <QSslSocket>
-#else
-#include <QTcpSocket>
 #endif
+#include <QTcpSocket>
 #include "connection.h"
 #include "server.h"
 


### PR DESCRIPTION
Was compiling with Qt 4.8.7.

That header should be included anyway, see line 76 & 82.