### PR TITLE
update uncrustify config

### DIFF
--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -28,6 +28,7 @@ nl_fdef_brace			= add
 nl_after_return			= false
 nl_brace_else			= add
 nl_class_leave_one_liners 	= true
+nl_before_access_spec	= 2
 
 mod_full_brace_if		= remove
 mod_full_brace_do		= remove
@@ -47,3 +48,7 @@ sp_pp_stringify			= ignore
 sp_bool				= add
 sp_after_class_colon    	= add
 sp_before_class_colon   	= remove
+sp_cmt_cpp_start			= add
+sp_cmt_cpp_doxygen			= true
+sp_angle_shift				= remove
+sp_permit_cpp11_shift		= true


### PR DESCRIPTION
The changes make uncrustify to 
1) add a space in the beginning of a comment ('// comment');
2) do not split '<<' and '>>' when used in template declarations;
3) add empty line before class access specifiers.
