### PR TITLE
Potential fix for crash. Closes #4990, #4905, #4864, #4855, #4818, #4726,  #4648

### DIFF
--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -482,7 +482,6 @@ void TrackerFiltersList::addItem(const QString &tracker, const QString &hash)
 
         if (host != "") {
             trackerItem = item(rowFromTracker(host));
-            if (!trackerItem) return;
         }
         else {
             trackerItem = item(1);
@@ -494,6 +493,7 @@ void TrackerFiltersList::addItem(const QString &tracker, const QString &hash)
 
         downloadFavicon(QString("http://%1/favicon.ico").arg(host));
     }
+    if (!trackerItem) return;
 
     tmp.append(hash);
     m_trackers.insert(host, tmp);


### PR DESCRIPTION
It tries to fix #4990, #4905, #4864, #4855, #4818, #4726,  #4648. I know that `item(1)` should always exist but it's the only thing in that function that can be causing the crash...

Related 3067f82aea1a3c0ff0df5236db05d20334887722