### PR TITLE
Add option to automatically remove .torrent files upon adding

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -52,6 +52,7 @@ qinisettings.h
 scanfoldersmodel.h
 searchengine.h
 settingsstorage.h
+torrentfileguard.h
 torrentfilter.h
 tristatebool.h
 types.h
@@ -107,6 +108,7 @@ preferences.cpp
 scanfoldersmodel.cpp
 searchengine.cpp
 settingsstorage.cpp
+torrentfileguard.cpp
 torrentfilter.cpp
 tristatebool.cpp
 )

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -51,6 +51,7 @@ HEADERS += \
     $$PWD/utils/misc.h \
     $$PWD/utils/string.h \
     $$PWD/unicodestrings.h \
+    $$PWD/torrentfileguard.h \
     $$PWD/torrentfilter.h \
     $$PWD/scanfoldersmodel.h \
     $$PWD/searchengine.h
@@ -103,6 +104,7 @@ SOURCES += \
     $$PWD/utils/gzip.cpp \
     $$PWD/utils/misc.cpp \
     $$PWD/utils/string.cpp \
+    $$PWD/torrentfileguard.cpp \
     $$PWD/torrentfilter.cpp \
     $$PWD/scanfoldersmodel.cpp \
     $$PWD/searchengine.cpp

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -70,6 +70,7 @@
 #include "base/net/portforwarder.h"
 #include "base/preferences.h"
 #include "base/settingsstorage.h"
+#include "base/torrentfileguard.h"
 #include "base/torrentfilter.h"
 #include "base/unicodestrings.h"
 #include "base/utils/misc.h"
@@ -1229,6 +1230,8 @@ bool Session::addTorrent(QString source, const AddTorrentParams &params)
         m_downloadedTorrents[handler->url()] = params;
     }
     else {
+        TorrentFileGuard guard(source);
+        guard.markAsAddedToSession();
         return addTorrent_impl(params, MagnetUri(), TorrentInfo::loadFromFile(source));
     }
 

--- a/src/base/torrentfileguard.cpp
+++ b/src/base/torrentfileguard.cpp
@@ -1,0 +1,100 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2016  Eugene Shalygin <eugene.shalygin@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "torrentfileguard.h"
+
+#include <QMetaEnum>
+#include "settingsstorage.h"
+#include "utils/fs.h"
+
+namespace
+{
+    const QLatin1String KEY_AUTO_DELETE_ENABLED ("Core/AutoDeleteAddedTorrentFile");
+}
+
+FileGuard::FileGuard(const QString &path)
+    : m_path {path}
+    , m_remove {true}
+{
+}
+
+void FileGuard::setAutoRemove(bool remove) noexcept
+{
+    m_remove = remove;
+}
+
+FileGuard::~FileGuard()
+{
+    if (m_remove && !m_path.isEmpty())
+        Utils::Fs::forceRemove(m_path); // forceRemove() checks for file existence
+}
+
+TorrentFileGuard::TorrentFileGuard(const QString &path)
+    : m_mode {autoDeleteMode()}
+    , m_wasAdded {false}
+    , m_guard {m_mode != Never ? path : QString()}
+{
+}
+
+TorrentFileGuard::~TorrentFileGuard()
+{
+    if (!m_wasAdded && (m_mode != Always))
+        m_guard.setAutoRemove(false);
+}
+
+void TorrentFileGuard::markAsAddedToSession()
+{
+    m_wasAdded = true;
+}
+
+void TorrentFileGuard::setAutoRemove(bool remove)
+{
+    m_guard.setAutoRemove(remove);
+}
+
+TorrentFileGuard::AutoDeleteMode TorrentFileGuard::autoDeleteMode()
+{
+    QMetaEnum meta {modeMetaEnum()};
+    return static_cast<AutoDeleteMode>(meta.keyToValue(SettingsStorage::instance()->loadValue(
+                                                           KEY_AUTO_DELETE_ENABLED, meta.valueToKey(Never)).toByteArray()));
+}
+
+void TorrentFileGuard::setautoDeleteMode(TorrentFileGuard::AutoDeleteMode mode)
+{
+    QMetaEnum meta {modeMetaEnum()};
+    SettingsStorage::instance()->storeValue(KEY_AUTO_DELETE_ENABLED, meta.valueToKey(mode));
+}
+
+QMetaEnum TorrentFileGuard::modeMetaEnum()
+{
+#if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
+    return QMetaEnum::fromType<AutoDeleteMode>();
+#else
+    return staticMetaObject.enumerator(staticMetaObject.indexOfEnumerator("AutoDeleteMode"));
+#endif
+}

--- a/src/base/torrentfileguard.h
+++ b/src/base/torrentfileguard.h
@@ -1,0 +1,95 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2016  Eugene Shalygin <eugene.shalygin@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include <QString>
+#include <QMetaType>
+
+class QMetaEnum;
+/// Utility class to defer file deletion
+class FileGuard
+{
+public:
+    FileGuard(const QString &path = QString());
+    ~FileGuard();
+
+    /// Cancels or re-enables deferred file deletion
+    void setAutoRemove(bool remove) noexcept;
+
+private:
+    QString m_path;
+    bool m_remove;
+};
+
+/// Reads settings for .torrent files from preferences
+/// and sets the file guard up accordingly
+class TorrentFileGuard
+{
+    Q_GADGET
+
+public:
+    TorrentFileGuard(const QString &path = QString());
+    ~TorrentFileGuard();
+
+    /// marks the torrent file as loaded (added) into the BitTorrent::Session
+    void markAsAddedToSession();
+    void setAutoRemove(bool remove);
+
+    enum AutoDeleteMode     // do not change these names: they are stored in config file
+    {
+        Never,
+        IfAdded,
+        Always
+    };
+
+    // static interface to get/set preferences
+    static AutoDeleteMode autoDeleteMode();
+    static void setautoDeleteMode(AutoDeleteMode mode);
+
+private:
+    static QMetaEnum modeMetaEnum();
+#if QT_VERSION < QT_VERSION_CHECK(5, 5, 0)
+    Q_ENUMS(AutoDeleteMode)
+#else
+    Q_ENUM(AutoDeleteMode)
+#endif
+    AutoDeleteMode m_mode;
+    bool m_wasAdded;
+    // Qt 4 moc has troubles with Q_GADGET: if Q_GADGET is present in a class, moc unconditionally
+    // references in the generated code the statiMetaObject from the class ancestor.
+    // Moreover, if the ancestor class has Q_GADGET but does not have other
+    // Q_ declarations, moc does not generate staticMetaObject for it. These results
+    // in referencing the non existent staticMetaObject and such code fails to compile.
+    // This problem is NOT present in Qt 5.7.0 and maybe in some older Qt 5 versions too
+    // Qt 4.8.7 has it.
+    // Therefore, we can't inherit FileGuard :(
+    FileGuard m_guard;
+};
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 5, 0)
+Q_DECLARE_METATYPE(TorrentFileGuard::AutoDeleteMode)
+#endif

--- a/src/gui/addnewtorrentdialog.h
+++ b/src/gui/addnewtorrentdialog.h
@@ -31,8 +31,9 @@
 #ifndef ADDNEWTORRENTDIALOG_H
 #define ADDNEWTORRENTDIALOG_H
 
-#include <QShortcut>
 #include <QDialog>
+#include <QScopedPointer>
+#include <QShortcut>
 #include <QUrl>
 
 #include "base/bittorrent/infohash.h"
@@ -49,6 +50,7 @@ namespace Ui
 }
 
 class TorrentContentFilterModel;
+class TorrentFileGuard;
 class PropListDelegate;
 
 class AddNewTorrentDialog: public QDialog
@@ -79,6 +81,7 @@ private slots:
     void handleDownloadFinished(const QString &url, const QString &filePath);
     void savingModeChanged(bool enabled);
     void categoryChanged(int index);
+    void doNotDeleteTorrentClicked(bool checked);
 
     void accept() override;
     void reject() override;
@@ -109,6 +112,7 @@ private:
     QShortcut *editHotkey;
     QByteArray m_headerState;
     int m_oldIndex;
+    QScopedPointer<TorrentFileGuard> m_torrentGuard;
 };
 
 #endif // ADDNEWTORRENTDIALOG_H

--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>414</width>
-    <height>590</height>
+    <height>661</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="AddNewTorrentDialogLayout">
@@ -93,6 +93,16 @@
        </widget>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="doNotDeleteTorrentCheckBox">
+     <property name="toolTip">
+      <string>When checked, the .torrent file will not be deleted despite the settings at the &quot;Download&quot; page of the options dialog</string>
+     </property>
+     <property name="text">
+      <string>Do not delete .torrent file</string>
+     </property>
     </widget>
    </item>
    <item>
@@ -278,8 +288,8 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>301</width>
-           <height>73</height>
+           <width>308</width>
+           <height>74</height>
           </rect>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout">

--- a/src/gui/options.ui
+++ b/src/gui/options.ui
@@ -113,9 +113,9 @@
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>-190</y>
-             <width>486</width>
-             <height>732</height>
+             <y>0</y>
+             <width>514</width>
+             <height>968</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -670,8 +670,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>487</width>
-             <height>1334</height>
+             <width>514</width>
+             <height>1537</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout">
@@ -715,6 +715,64 @@
                      <bool>true</bool>
                     </property>
                    </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QGroupBox" name="deleteTorrentBox">
+                 <property name="toolTip">
+                  <string>Should the .torrent file be deleted after adding it</string>
+                 </property>
+                 <property name="title">
+                  <string>Delete .torrent files afterwards </string>
+                 </property>
+                 <property name="checkable">
+                  <bool>true</bool>
+                 </property>
+                 <property name="checked">
+                  <bool>false</bool>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_17">
+                  <item>
+                   <widget class="QCheckBox" name="deleteCancelledTorrentBox">
+                    <property name="toolTip">
+                     <string>Also delete .torrent files whose addition was cancelled</string>
+                    </property>
+                    <property name="text">
+                     <string>Also when addition is cancelled</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_11">
+                    <item>
+                     <widget class="QLabel" name="deleteTorrentWarningIcon">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="text">
+                       <string notr="true">&lt;&gt;</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QLabel" name="deleteTorrentWarningLabel">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="text">
+                       <string>Warning! Data loss possible!</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
                   </item>
                  </layout>
                 </widget>
@@ -1364,8 +1422,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>450</width>
-             <height>658</height>
+             <width>457</width>
+             <height>713</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -1894,8 +1952,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>376</width>
-             <height>444</height>
+             <width>362</width>
+             <height>484</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -2281,8 +2339,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>555</width>
-             <height>527</height>
+             <width>587</width>
+             <height>578</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -2678,8 +2736,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>419</width>
-             <height>537</height>
+             <width>460</width>
+             <height>562</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -3130,12 +3188,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>544</x>
-     <y>172</y>
+     <x>604</x>
+     <y>205</y>
     </hint>
     <hint type="destinationlabel">
-     <x>603</x>
-     <y>171</y>
+     <x>677</x>
+     <y>206</y>
     </hint>
    </hints>
   </connection>
@@ -3146,12 +3204,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>544</x>
-     <y>198</y>
+     <x>604</x>
+     <y>238</y>
     </hint>
     <hint type="destinationlabel">
-     <x>603</x>
-     <y>197</y>
+     <x>677</x>
+     <y>239</y>
     </hint>
    </hints>
   </connection>
@@ -3162,12 +3220,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>544</x>
-     <y>250</y>
+     <x>604</x>
+     <y>304</y>
     </hint>
     <hint type="destinationlabel">
-     <x>603</x>
-     <y>249</y>
+     <x>677</x>
+     <y>305</y>
     </hint>
    </hints>
   </connection>
@@ -3178,12 +3236,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>509</x>
-     <y>372</y>
+     <x>547</x>
+     <y>415</y>
     </hint>
     <hint type="destinationlabel">
-     <x>584</x>
-     <y>373</y>
+     <x>642</x>
+     <y>414</y>
     </hint>
    </hints>
   </connection>
@@ -3194,12 +3252,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>509</x>
-     <y>372</y>
+     <x>547</x>
+     <y>415</y>
     </hint>
     <hint type="destinationlabel">
-     <x>721</x>
-     <y>373</y>
+     <x>815</x>
+     <y>413</y>
     </hint>
    </hints>
   </connection>
@@ -3210,12 +3268,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>423</x>
-     <y>224</y>
+     <x>604</x>
+     <y>271</y>
     </hint>
     <hint type="destinationlabel">
-     <x>571</x>
-     <y>224</y>
+     <x>677</x>
+     <y>272</y>
     </hint>
    </hints>
   </connection>
@@ -3226,12 +3284,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>398</x>
-     <y>292</y>
+     <x>395</x>
+     <y>203</y>
     </hint>
     <hint type="destinationlabel">
-     <x>477</x>
-     <y>292</y>
+     <x>496</x>
+     <y>204</y>
     </hint>
    </hints>
   </connection>
@@ -3242,12 +3300,44 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>398</x>
-     <y>263</y>
+     <x>395</x>
+     <y>170</y>
     </hint>
     <hint type="destinationlabel">
-     <x>477</x>
-     <y>263</y>
+     <x>496</x>
+     <y>171</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>deleteTorrentBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>deleteTorrentWarningIcon</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>554</x>
+     <y>153</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>324</x>
+     <y>214</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>deleteTorrentBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>deleteTorrentWarningLabel</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>646</x>
+     <y>158</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>629</x>
+     <y>207</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
Re-implementation of #2700 

Some browsers do not download files, intended for an immediate opening, into a temporary directory, and the regular downloads directory accumulates those unneeded files.

The option allows qBittorrent to clean after itself and delete those files whether they were successfully added or not (user selects the policy).

The identifiers names (the option name, the preferences class members names, and the helper class name) are more than debatable and I will be thankful for better ones.

Options tab screenshot:
![qbt-options-auto-remove-torrent](https://cloud.githubusercontent.com/assets/394621/14433331/2fb4493c-000e-11e6-8ed1-5d1334dc1e6b.png)

The warning label appears when any of the two options gets checked.