### PR TITLE
Remove duplicated code from search tab and widget

### DIFF
--- a/src/gui/search/searchtab.cpp
+++ b/src/gui/search/searchtab.cpp
@@ -98,7 +98,7 @@ SearchTab::SearchTab(SearchWidget *parent)
     m_ui->resultsBrowser->setSortingEnabled(true);
 
     // Connect signals to slots (search part)
-    connect(m_ui->resultsBrowser, SIGNAL(doubleClicked(const QModelIndex&)), this, SLOT(downloadSelectedItem(const QModelIndex&)));
+    connect(m_ui->resultsBrowser, SIGNAL(doubleClicked(const QModelIndex&)), this, SLOT(downloadItem(const QModelIndex&)));
 
     // Load last columns width for search results list
     if (!loadColWidthResultsList())
@@ -129,7 +129,7 @@ SearchTab::~SearchTab()
     delete m_ui;
 }
 
-void SearchTab::downloadSelectedItem(const QModelIndex &index)
+void SearchTab::downloadItem(const QModelIndex &index)
 {
     QString torrentUrl = m_proxyModel->data(m_proxyModel->index(index.row(), SearchSortModel::DL_LINK)).toString();
     setRowColor(index.row(), "blue");

--- a/src/gui/search/searchtab.h
+++ b/src/gui/search/searchtab.h
@@ -92,8 +92,10 @@ public:
 
     void updateResultsCount();
 
+public slots:
+    void downloadItem(const QModelIndex &index);
+
 private slots:
-    void downloadSelectedItem(const QModelIndex &index);
     void updateFilter();
 
 private:

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -392,11 +392,7 @@ void SearchWidget::on_downloadButton_clicked()
     QModelIndexList selectedIndexes = m_allTabs.at(tabWidget->currentIndex())->getCurrentTreeView()->selectionModel()->selectedIndexes();
     foreach (const QModelIndex &index, selectedIndexes) {
         if (index.column() == SearchSortModel::NAME) {
-            // Get Item url
-            QSortFilterProxyModel *model = m_allTabs.at(tabWidget->currentIndex())->getCurrentSearchListProxy();
-            QString torrentUrl = model->data(model->index(index.row(), URL_COLUMN)).toString();
-            downloadTorrent(torrentUrl);
-            m_allTabs.at(tabWidget->currentIndex())->setRowColor(index.row(), "blue");
+            m_allTabs.at(tabWidget->currentIndex())->downloadItem(index);
         }
     }
 }


### PR DESCRIPTION
Both download handlers (in the tab and widget classes) convert model
index into an URL, set row color, and call download function.
Make the download button handler (in the SearchWidget class) call the
slot of the SearchTab class.