### PR TITLE
Fix Shutdown confirmation

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -363,7 +363,7 @@ int Application::exec(const QStringList &params)
 
     BitTorrent::Session::initInstance();
     connect(BitTorrent::Session::instance(), SIGNAL(torrentFinished(BitTorrent::TorrentHandle *const)), SLOT(torrentFinished(BitTorrent::TorrentHandle *const)));
-    connect(BitTorrent::Session::instance(), SIGNAL(allTorrentsFinished()), SLOT(allTorrentsFinished()));
+    connect(BitTorrent::Session::instance(), SIGNAL(allTorrentsFinished()), SLOT(allTorrentsFinished()), Qt::QueuedConnection);
 
 #ifndef DISABLE_COUNTRIES_RESOLUTION
     Net::GeoIPManager::initInstance();

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -96,9 +96,7 @@ namespace
 Application::Application(const QString &id, int &argc, char **argv)
     : BaseApplication(id, argc, argv)
     , m_running(false)
-#ifndef DISABLE_GUI
     , m_shutdownAct(ShutdownDialogAction::Exit)
-#endif
 {
     Logger::initInstance();
     SettingsStorage::initInstance();
@@ -283,7 +281,6 @@ void Application::torrentFinished(BitTorrent::TorrentHandle *const torrent)
 
 void Application::allTorrentsFinished()
 {
-#ifndef DISABLE_GUI
     Preferences *const pref = Preferences::instance();
     bool isExit = pref->shutdownqBTWhenDownloadsComplete();
     bool isShutdown = pref->shutdownWhenDownloadsComplete();
@@ -301,6 +298,7 @@ void Application::allTorrentsFinished()
     else if (isShutdown)
         action = ShutdownDialogAction::Shutdown;
 
+#ifndef DISABLE_GUI
     // ask confirm
     if ((action == ShutdownDialogAction::Exit) && (pref->dontConfirmAutoExit())) {
         // do nothing & skip confirm
@@ -308,6 +306,7 @@ void Application::allTorrentsFinished()
     else {
         if (!ShutdownConfirmDlg::askForConfirmation(action)) return;
     }
+#endif // DISABLE_GUI
 
     // Actually shut down
     if (action != ShutdownDialogAction::Exit) {
@@ -322,7 +321,6 @@ void Application::allTorrentsFinished()
 
     qDebug("Exiting the application");
     exit();
-#endif // DISABLE_GUI
 }
 
 bool Application::sendParams(const QStringList &params)
@@ -589,6 +587,7 @@ void Application::cleanup()
     delete m_fileLogger;
     Logger::freeInstance();
     IconProvider::freeInstance();
+
 #ifndef DISABLE_GUI
 #ifdef Q_OS_WIN
     typedef BOOL (WINAPI *PSHUTDOWNBRDESTROY)(HWND);
@@ -598,9 +597,10 @@ void Application::cleanup()
         shutdownBRDestroy((HWND)m_window->effectiveWinId());
 #endif // Q_OS_WIN
     delete m_window;
+#endif // DISABLE_GUI
+
     if (m_shutdownAct != ShutdownDialogAction::Exit) {
         qDebug() << "Sending computer shutdown/suspend/hibernate signal...";
         Utils::Misc::shutdownComputer(m_shutdownAct);
     }
-#endif
 }

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -111,10 +111,10 @@ private slots:
 
 private:
     bool m_running;
+    ShutdownDialogAction m_shutdownAct;
 
 #ifndef DISABLE_GUI
     QPointer<MainWindow> m_window;
-    ShutdownDialogAction m_shutdownAct;
 #endif
 
 #ifndef DISABLE_WEBUI

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -91,7 +91,6 @@ static struct { const char *source; const char *comment; } units[] = {
     QT_TRANSLATE_NOOP3("misc", "EiB", "exbibytes (1024 pebibytes)")
 };
 
-#ifndef DISABLE_GUI
 void Utils::Misc::shutdownComputer(const ShutdownDialogAction &action)
 {
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC)) && defined(QT_DBUS_LIB)
@@ -216,7 +215,6 @@ void Utils::Misc::shutdownComputer(const ShutdownDialogAction &action)
                           (PTOKEN_PRIVILEGES) NULL, 0);
 #endif
 }
-#endif // DISABLE_GUI
 
 #ifndef DISABLE_GUI
 // Get screen center

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -67,8 +67,9 @@ namespace Utils
         QString parseHtmlLinks(const QString &raw_text);
         bool isUrl(const QString &s);
 
-#ifndef DISABLE_GUI
         void shutdownComputer(const ShutdownDialogAction &action);
+
+#ifndef DISABLE_GUI
         // Get screen center
         QPoint screenCenter(QWidget *win);
         QSize smallIconSize();


### PR DESCRIPTION
* Fix Coverity Scan 143909
* Enable access to shutdown functions when configured with `--disable-gui` option

-
Don't merge yet, qbt tray icon hangs on quit when `Confirmation on auto-exit when downloads finish` is enabled.
gdb backtrace:
```
#0  0x00007ffff723b3e8 in pthread_cond_timedwait@@GLIBC_2.3.2 ()
   from /usr/lib/libpthread.so.0
#1  0x00007ffff53e2bc6 in QWaitCondition::wait(QMutex*, unsigned long) ()
   from /usr/lib/libQt5Core.so.5
#2  0x000000000051d4aa in BitTorrent::Session::getPendingAlerts (this=0xe07d50, out=...,
    time=30000) at base/bittorrent/session.cpp:2239
#3  0x0000000000521ed2 in BitTorrent::Session::saveResumeData (this=this@entry=0xe07d50)
    at base/bittorrent/session.cpp:1575
#4  0x000000000052b4dc in BitTorrent::Session::~Session (this=0xe07d50,
    __in_chrg=<optimized out>) at base/bittorrent/session.cpp:527
#5  0x000000000052b6d9 in BitTorrent::Session::~Session (this=0xe07d50,
    __in_chrg=<optimized out>) at base/bittorrent/session.cpp:546
#6  0x000000000051b0d6 in BitTorrent::Session::freeInstance ()
    at base/bittorrent/session.cpp:557
#7  0x00000000004c6233 in Application::cleanup (this=0xbfac00) at app/application.cpp:580
#8  0x00007ffff55e1870 in QMetaObject::activate(QObject*, int, int, void**) ()
   from /usr/lib/libQt5Core.so.5
#9  0x00007ffff55bbbf3 in QCoreApplication::exec() () from /usr/lib/libQt5Core.so.5
#10 0x00000000004c7ed0 in Application::exec (this=this@entry=0xbfac00, params=...)
    at app/application.cpp:401
#11 0x00000000004be6a0 in main (argc=2, argv=<optimized out>) at app/main.cpp:269
```