### PR TITLE
Fix build with GCC 4.6

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -141,25 +141,43 @@ namespace BitTorrent
         QString name;
         QString category;
         QString savePath;
-        bool disableTempPath = false; // e.g. for imported torrents
-        bool sequential = false;
+        bool disableTempPath;
+        bool sequential;
         TriStateBool addForced;
         TriStateBool addPaused;
         QVector<int> filePriorities; // used if TorrentInfo is set
-        bool ignoreShareRatio = false;
-        bool skipChecking = false;
+        bool ignoreShareRatio;
+        bool skipChecking;
+        AddTorrentParams()
+        {
+            disableTempPath = false; // e.g. for imported torrents
+            sequential = false;
+            ignoreShareRatio = false;
+            skipChecking = false;
+        }
     };
 
     struct TorrentStatusReport
     {
-        uint nbDownloading = 0;
-        uint nbSeeding = 0;
-        uint nbCompleted = 0;
-        uint nbActive = 0;
-        uint nbInactive = 0;
-        uint nbPaused = 0;
-        uint nbResumed = 0;
-        uint nbErrored = 0;
+        uint nbDownloading;
+        uint nbSeeding;
+        uint nbCompleted;
+        uint nbActive;
+        uint nbInactive;
+        uint nbPaused;
+        uint nbResumed;
+        uint nbErrored;
+        TorrentStatusReport()
+        {
+            nbDownloading = 0;
+            nbSeeding = 0;
+            nbCompleted = 0;
+            nbActive = 0;
+            nbInactive = 0;
+            nbPaused = 0;
+            nbResumed = 0;
+            nbErrored = 0;
+        }
     };
 
     class Session : public QObject

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -110,7 +110,11 @@ namespace BitTorrent
     struct TrackerInfo
     {
         QString lastMessage;
-        quint32 numPeers = 0;
+        quint32 numPeers;
+        TrackerInfo()
+        {
+            numPeers = 0;
+        }
     };
 
     class TorrentState

--- a/src/base/net/downloadmanager.cpp
+++ b/src/base/net/downloadmanager.cpp
@@ -98,7 +98,7 @@ namespace
         }
 #endif
 
-        QList<QNetworkCookie> cookiesForUrl(const QUrl &url) const override
+        QList<QNetworkCookie> cookiesForUrl(const QUrl &url) const
         {
             QDateTime now = QDateTime::currentDateTime();
             QList<QNetworkCookie> cookies = QNetworkCookieJar::cookiesForUrl(url);
@@ -110,7 +110,7 @@ namespace
             return cookies;
         }
 
-        bool setCookiesFromUrl(const QList<QNetworkCookie> &cookieList, const QUrl &url) override
+        bool setCookiesFromUrl(const QList<QNetworkCookie> &cookieList, const QUrl &url)
         {
             QDateTime now = QDateTime::currentDateTime();
             QList<QNetworkCookie> cookies = cookieList;

--- a/src/base/rss/rssfile.h
+++ b/src/base/rss/rssfile.h
@@ -75,7 +75,11 @@ namespace Rss
     protected:
         friend class Folder;
 
-        Folder *m_parent = nullptr;
+        Folder *m_parent;
+        File()
+        {
+            m_parent = nullptr;
+        }
     };
 }
 


### PR DESCRIPTION
Non-static data member initializers and Explicit virtual overrides C++11
features have both been introduced in GCC 4.7:
https://gcc.gnu.org/projects/cxx-status.html#cxx11
https://gcc.gnu.org/gcc-4.7/changes.html

Several embedded systems like NAS are running qbittorrent-nox and are
built with an older GCC version. Fix the build failures using GCC 4.6.

Signed-off-by: Fathi Boudra <fabo@debian.org>