### PR TITLE
uncrustify: add "slots" to WORDs keywords.

### DIFF
--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1,4 +1,5 @@
 set FOR foreach
+set WORD slots
 
 newlines			= LF
 


### PR DESCRIPTION
Uncrustify inserts line break between an access specifier and "slots".
However, it keeps these words combinations if "Q_SLOTS" is used.
Its built-in parser classifies "Q_SLOTS" as WORD token, thus let's add
"slots" to that class.