### PR TITLE
Use unique temp directories. Closes #5154.

### DIFF
--- a/src/base/bittorrent/infohash.cpp
+++ b/src/base/bittorrent/infohash.cpp
@@ -68,7 +68,6 @@ bool InfoHash::isValid() const
     return m_valid;
 }
 
-
 InfoHash::operator libtorrent::sha1_hash() const
 {
     return m_nativeHash;

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -333,7 +333,9 @@ QString Session::tempPath() const
 
 QString Session::torrentTempPath(const InfoHash &hash) const
 {
-    return m_tempPath + QString(hash) + "/";
+    return m_tempPath
+            + static_cast<QString>(hash).left(7)
+            + "/";
 }
 
 bool Session::isValidCategoryName(const QString &name)

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -331,6 +331,11 @@ QString Session::tempPath() const
     return m_tempPath;
 }
 
+QString Session::torrentTempPath(const InfoHash &hash) const
+{
+    return m_tempPath + QString(hash) + "/";
+}
+
 bool Session::isValidCategoryName(const QString &name)
 {
     QRegExp re(R"(^([^\\\/]|[^\\\/]([^\\\/]|\/(?=[^\/]))*[^\\\/])$)");
@@ -1398,7 +1403,7 @@ bool Session::findIncompleteFiles(TorrentInfo &torrentInfo, QString &savePath) c
 
     bool found = findInDir(savePath, torrentInfo);
     if (!found && isTempPathEnabled()) {
-        savePath = m_tempPath;
+        savePath = torrentTempPath(torrentInfo.hash());
         found = findInDir(savePath, torrentInfo);
     }
 

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -185,6 +185,7 @@ namespace BitTorrent
         void setTempPath(QString path);
         bool isTempPathEnabled() const;
         void setTempPathEnabled(bool enabled);
+        QString torrentTempPath(const InfoHash &hash) const;
 
         static bool isValidCategoryName(const QString &name);
         // returns category itself and all top level categories

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -1392,7 +1392,7 @@ void TorrentHandle::handleStorageMovedAlert(libtorrent::storage_moved_alert *p)
 
     // Attempt to remove old folder if empty
     QDir oldSaveDir(Utils::Fs::fromNativePath(m_oldPath));
-    if ((oldSaveDir != QDir(m_session->defaultSavePath())) && (oldSaveDir != QDir(m_session->tempPath()))) {
+    if (oldSaveDir != QDir(m_session->defaultSavePath())) {
         qDebug("Attempting to remove %s", qPrintable(m_oldPath));
         QDir().rmpath(m_oldPath);
     }
@@ -1778,7 +1778,7 @@ void TorrentHandle::adjustActualSavePath_impl()
     }
     else {
         // Moving all downloading torrents to temporary save path
-        path = m_session->tempPath();
+        path = m_session->torrentTempPath(hash());
         qDebug() << "Moving torrent to its temp save path:" << path;
     }
 


### PR DESCRIPTION
Save torrent in `temp_path/<truncated_torrent_hash>` directory.
Closes #5154.
This is also the required prerequisite to #4081.