### PR TITLE
uncrustify: honour pointer and reference symbols alignment rules

### DIFF
--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -12,7 +12,7 @@ indent_col1_comment     	= true
 indent_access_spec      	= -4
 
 nl_after_func_body		= 2
-nl_collapse_empty_body	= true
+nl_collapse_empty_body	= false
 nl_enum_brace			= add
 nl_union_brace			= add
 nl_struct_brace			= add
@@ -60,3 +60,16 @@ sp_cmt_cpp_start			= add
 sp_cmt_cpp_doxygen			= true
 sp_angle_shift				= remove
 sp_permit_cpp11_shift		= true
+
+sp_before_ptr_star			= add
+sp_before_byref				= add
+sp_after_ptr_star			= remove
+sp_after_byref				= remove
+sp_before_unnamed_ptr_star	= remove
+sp_before_unnamed_byref		= remove
+sp_after_ptr_star_func		= add
+sp_after_byref_func			= add
+sp_before_ptr_star_func		= remove
+sp_before_byref_func		= remove
+
+eat_blanks_before_close_brace	= true


### PR DESCRIPTION
Stick the '*' and '&' symbols to the variable name if there is one.
Also fix empty function bodies collapse option: replace it with the
eat_blanks_before_close_brace setting.