### PR TITLE
Added 'Added on' column in Webui. Closes #5145,#1092,#738

### DIFF
--- a/src/webui/btjson.cpp
+++ b/src/webui/btjson.cpp
@@ -709,8 +709,8 @@ QVariantMap toMap(BitTorrent::TorrentHandle *const torrent)
     ret[KEY_TORRENT_SUPER_SEEDING] = torrent->superSeeding();
     ret[KEY_TORRENT_FORCE_START] = torrent->isForced();
     ret[KEY_TORRENT_SAVE_PATH] = Utils::Fs::toNativePath(torrent->savePath());
-    ret[KEY_TORRENT_ADDED_ON] = torrent->addedTime();
-    ret[KEY_TORRENT_COMPLETION_ON] = torrent->completedTime();
+    ret[KEY_TORRENT_ADDED_ON] = torrent->addedTime().toTime_t();
+    ret[KEY_TORRENT_COMPLETION_ON] = torrent->completedTime().toTime_t();
 
     return ret;
 }

--- a/src/webui/www/public/scripts/dynamicTable.js
+++ b/src/webui/www/public/scripts/dynamicTable.js
@@ -452,6 +452,7 @@ var TorrentsTable = new Class({
             this.newColumn('eta', 'width: 100px', 'QBT_TR(ETA)QBT_TR');
             this.newColumn('ratio', 'width: 100px', 'QBT_TR(Ratio)QBT_TR');
             this.newColumn('category', 'width: 100px', 'QBT_TR(Category)QBT_TR');
+            this.newColumn('added_on', 'width: 100px', 'QBT_TR(Added on)QBT_TR');
 
             this.columns['state_icon'].onclick = '';
             this.columns['state_icon'].dataProperties[0] = 'state';
@@ -617,6 +618,13 @@ var TorrentsTable = new Class({
                 else
                     html = (Math.floor(100 * ratio) / 100).toFixed(2); //Don't round up
                 td.set('html', html);
+            };
+
+            // added on
+
+            this.columns['added_on'].updateTd = function (td, row) {
+                var date = new Date(this.getRowValue(row) * 1000).toLocaleString();
+                td.set('html', date);
             };
         },
 


### PR DESCRIPTION
If you take a look at #5145 #1092 and #738 you can see that this has been requested a few times.

As far as I understand the reasoning behind this is that once you have a list of say hundreds of torrents there is no way to sort your torrents to see which ones are the 'latest ones'. To do this you either need an 'Added on' column or a 'Completed on'.

This PR adds that 'Added on Column'. I suggest closing down all old issues that deals with 'Added on' or 'Completed on'. 

I would like to stress that this might not be the most elegant way. We should in my opinion add many more columns (as many as the desktop client has) and then have a way to add/remove columns from the webui via a context menu (right clicking).

But for the time being, this gets the job done.