### PR TITLE
Add ability to import uTorrent RSS feeds and download rules

### DIFF
--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -48,6 +48,7 @@ HEADERS += \
     $$PWD/rss/rssarticle.h \
     $$PWD/rss/rssdownloadrule.h \
     $$PWD/rss/rssdownloadrulelist.h \
+    $$PWD/rss/utorrentrssdata.h \
     $$PWD/rss/private/rssparser.h \
     $$PWD/utils/fs.h \
     $$PWD/utils/gzip.h \
@@ -103,6 +104,7 @@ SOURCES += \
     $$PWD/rss/rssdownloadrule.cpp \
     $$PWD/rss/rssdownloadrulelist.cpp \
     $$PWD/rss/rssfile.cpp \
+    $$PWD/rss/utorrentrssdata.cpp \
     $$PWD/rss/private/rssparser.cpp \
     $$PWD/utils/fs.cpp \
     $$PWD/utils/gzip.cpp \

--- a/src/base/rss/private/rssparser.cpp
+++ b/src/base/rss/private/rssparser.cpp
@@ -465,3 +465,9 @@ void Parser::parseAtomChannel(QXmlStreamReader &xml)
         }
     }
 }
+
+// Just delegate to parent.
+void Parser::moveToThread(QThread *thread)
+{
+    QObject::moveToThread(thread);
+}

--- a/src/base/rss/rssdownloadrule.h
+++ b/src/base/rss/rssdownloadrule.h
@@ -33,7 +33,7 @@
 
 #include <QStringList>
 #include <QVariantHash>
-#include <QSharedPointer>
+#include <QSharedDataPointer>
 #include <QDateTime>
 
 namespace Rss
@@ -42,9 +42,9 @@ namespace Rss
     typedef QSharedPointer<Feed> FeedPtr;
 
     class DownloadRule;
-    typedef QSharedPointer<DownloadRule> DownloadRulePtr;
+    typedef QSharedDataPointer<DownloadRule> DownloadRulePtr;
 
-    class DownloadRule
+    class DownloadRule : public QSharedData
     {
     public:
         enum AddPausedState

--- a/src/base/rss/rssdownloadrulelist.cpp
+++ b/src/base/rss/rssdownloadrulelist.cpp
@@ -38,11 +38,6 @@
 
 using namespace Rss;
 
-DownloadRuleList::DownloadRuleList()
-{
-    loadRulesFromStorage();
-}
-
 DownloadRulePtr DownloadRuleList::findMatchingRule(const QString &feedUrl, const QString &articleTitle) const
 {
     Q_ASSERT(Preferences::instance()->isRssDownloadingEnabled());
@@ -54,13 +49,17 @@ DownloadRulePtr DownloadRuleList::findMatchingRule(const QString &feedUrl, const
     return DownloadRulePtr();
 }
 
-void DownloadRuleList::replace(DownloadRuleList *other)
+void DownloadRuleList::replace(const DownloadRuleList &other)
 {
     m_rules.clear();
     m_feedRules.clear();
-    foreach (const QString &name, other->ruleNames()) {
-        saveRule(other->getRule(name));
-    }
+    merge(other);
+}
+
+void DownloadRuleList::merge(const DownloadRuleList &other)
+{
+    foreach (const QString &name, other.ruleNames())
+        saveRule(other.getRule(name));
 }
 
 void DownloadRuleList::saveRulesToStorage()

--- a/src/base/rss/rssdownloadrulelist.h
+++ b/src/base/rss/rssdownloadrulelist.h
@@ -41,12 +41,10 @@ namespace Rss
 {
     class DownloadRuleList
     {
-        Q_DISABLE_COPY(DownloadRuleList)
-
     public:
-        DownloadRuleList();
-
         DownloadRulePtr findMatchingRule(const QString &feedUrl, const QString &articleTitle) const;
+        void loadRulesFromStorage();
+
         // Operators
         void saveRule(const DownloadRulePtr &rule);
         void removeRule(const QString &name);
@@ -57,10 +55,10 @@ namespace Rss
         void saveRulesToStorage();
         bool serialize(const QString &path);
         bool unserialize(const QString &path);
-        void replace(DownloadRuleList *other);
+        void replace(const DownloadRuleList& other);
+        void merge(const DownloadRuleList& other);
 
     private:
-        void loadRulesFromStorage();
         void loadRulesFromVariantHash(const QVariantHash &l);
         QVariantHash toVariantHash() const;
 

--- a/src/base/rss/rssfeed.h
+++ b/src/base/rss/rssfeed.h
@@ -64,7 +64,7 @@ namespace Rss
         Q_OBJECT
 
     public:
-        Feed(const QString &url, Manager *manager);
+        explicit Feed(const QString &url, Manager *manager = nullptr);
         ~Feed();
 
         bool refresh();
@@ -87,6 +87,7 @@ namespace Rss
         const ArticleHash &articleHash() const;
         ArticleList unreadArticleListByDateDesc() const;
         void recheckRssItemsForDownload();
+        void setManager(Manager *manager);
 
     private slots:
         void handleIconDownloadFinished(const QString &url, const QString &filePath);

--- a/src/base/rss/rssfolder.cpp
+++ b/src/base/rss/rssfolder.cpp
@@ -189,7 +189,6 @@ QHash<QString, FeedPtr> Folder::getAllFeedsAsHash() const
 
 bool Folder::addFile(const FilePtr &item)
 {
-    Q_ASSERT(!m_children.contains(item->id()));
     if (!m_children.contains(item->id())) {
         m_children[item->id()] = item;
         // Update parent

--- a/src/base/rss/rssmanager.cpp
+++ b/src/base/rss/rssmanager.cpp
@@ -50,6 +50,7 @@ Manager::Manager(QObject *parent)
     , m_rootFolder(new Folder)
     , m_workingThread(new QThread(this))
 {
+    m_downloadRules->loadRulesFromStorage();
     m_workingThread->start();
     connect(&m_refreshTimer, SIGNAL(timeout()), SLOT(refresh()));
     m_refreshInterval = Preferences::instance()->getRSSRefreshInterval();

--- a/src/base/rss/utorrentrssdata.cpp
+++ b/src/base/rss/utorrentrssdata.cpp
@@ -1,0 +1,220 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2016  Michael Ziminsky <mgziminsky@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "utorrentrssdata.h"
+
+#include <libtorrent/lazy_entry.hpp>
+
+#include <QDebug>
+#include <QFile>
+#include <QStringList>
+
+#ifdef QBT_USES_QT5
+#include <QRegularExpression>
+#else
+#include <QRegExp>
+#endif
+
+#include "rssfeed.h"
+#include "rssdownloadrule.h"
+#include "rssdownloadrulelist.h"
+#include "base/utils/string.h"
+
+using namespace Rss;
+using namespace libtorrent;
+using namespace Utils::String;
+
+namespace
+{
+    int POSTPONE_OPTS[] = {0, 0, 0, 1, 2, 3, 4, 7, 14, 21, 30};
+
+    enum EnabledFlags
+    {
+        ENABLED      = 1,
+        RAW_NAME     = 2,
+        MAX_PRIORITY = 4,
+        SMART_FILTER = 8,
+        PAUSED       = 16
+    };
+
+    enum Quality
+    {
+        QUALITY_ALL   = -1,
+        QUALITY_480p  = 0x10000,
+        QUALITY_720p  = 0x00800,
+        QUALITY_1080i = 0x01000,
+        QUALITY_1080p = 0x02000
+    };
+
+    void applyFilter(Rss::DownloadRule *rule, const libtorrent::lazy_entry &filter)
+    {
+#ifdef QBT_USES_QT5
+        // Leading/Trailing *'s and *'s before/after '|'
+        const QRegularExpression STRIP_PATTERN(R"((?<=^|\|)\*+|\*+(?=$|\|))");
+#else
+        // Leading/Trailing *'s and *'s before '|'
+        // No lookbehind, so as close as it'll get without complicating things
+        const QRegExp STRIP_PATTERN(R"(^\*+|\*+(?=$|\|))");
+#endif
+
+        rule->setUseRegex(true);
+        rule->setMustNotContain(fromStdString(filter.dict_find_string_value("not_filter")).remove(STRIP_PATTERN).replace('*', ".*").replace('?', "."));
+
+        QString mustContain = fromStdString(filter.dict_find_string_value("filter")).remove(STRIP_PATTERN).replace('*', ".*").replace('?', ".");
+
+        QStringList qualityList;
+        int quality = filter.dict_find_int_value("quality");
+        if (quality != QUALITY_ALL) {
+            if (quality & QUALITY_480p)
+                qualityList << "480p";
+            if (quality & QUALITY_720p)
+                qualityList << "720p";
+            if (quality & QUALITY_1080i)
+                qualityList << "1080i";
+            if (quality & QUALITY_1080p)
+                qualityList << "1080p";
+        }
+
+        if (qualityList.empty())
+            rule->setMustContain(mustContain);
+        else
+            rule->setMustContain("(" % mustContain % ").*(" % qualityList.join("|") % ")");
+    }
+}
+
+UTorrentRssData::UTorrentRssData()
+    : m_rules(new DownloadRuleList)
+{
+}
+
+UTorrentRssData::~UTorrentRssData()
+{
+    delete m_rules;
+}
+
+const QList<FeedPtr>& UTorrentRssData::getFeeds() const
+{
+    return m_feeds;
+}
+
+const DownloadRuleList& UTorrentRssData::getRules() const
+{
+    return *m_rules;
+}
+
+bool UTorrentRssData::load(const QString &path)
+{
+    bool success = false;
+
+    QFile file(path);
+    if (file.open(QFile::ReadOnly)) {
+        QByteArray contents = file.readAll();
+        file.close();
+
+        lazy_entry e;
+        boost::system::error_code ec;
+        lazy_bdecode(contents.constData(), contents.constData() + contents.size(), e, ec);
+
+        if (!ec) {
+            const lazy_entry *feeds = e.dict_find_list("feeds");
+            const lazy_entry *filters = e.dict_find_list("filters");
+            if (success = (feeds && filters))
+                loadRules(*filters, loadFeeds(*feeds));
+        }
+    }
+
+    return success;
+}
+
+QHash<int, QString> UTorrentRssData::loadFeeds(const libtorrent::lazy_entry &feeds)
+{
+    QHash<int, QString> feedUrls;
+
+    for (int i = 0; i < feeds.list_size(); ++i) {
+        const lazy_entry *feed = feeds.list_at(i);
+
+        // Don't import disabled feeds
+        if (feed->dict_find_int_value("enabled") != 1)
+            continue;
+
+        Rss::FeedPtr newFeed;
+        QString url = fromStdString(feed->dict_find_string_value("url"));
+        qDebug() << "Importing uTorrent Feed: " << url;
+
+        if (url.contains('|')) {
+            newFeed = Rss::FeedPtr(new Rss::Feed(url.section('|', 1)));
+            if (feed->dict_find_int_value("usefeedtitle") != 1)
+                newFeed->rename(url.section('|', 0, 0));
+        }
+        else {
+            newFeed = Rss::FeedPtr(new Rss::Feed(url));
+        }
+
+        m_feeds.append(newFeed);
+        feedUrls.insert(feed->dict_find_int_value("ident"), newFeed->url());
+    }
+
+    return feedUrls;
+}
+
+void UTorrentRssData::loadRules(const libtorrent::lazy_entry &filters, const QHash<int, QString> &feedUrls)
+{
+    for (int i = 0; i < filters.list_size(); ++i) {
+        const lazy_entry *filter = filters.list_at(i);
+        Rss::DownloadRule *rule = new Rss::DownloadRule();
+
+        QString name = fromStdString(filter->dict_find_string_value("name")).trimmed();
+        if (name.isEmpty())
+            continue;
+
+        rule->setName(name);
+        qDebug() << "Importing uTorrent Rule: " << rule->name();
+
+        rule->setSavePath(fromStdString(filter->dict_find_string_value("directory")));
+        rule->setLastMatch(QDateTime::fromTime_t(filter->dict_find_int_value("last_match")));
+        rule->setIgnoreDays(POSTPONE_OPTS[filter->dict_find_int_value("postpone_mode")]);
+        rule->setCategory(fromStdString(filter->dict_find_string_value("label")));
+
+        if (filter->dict_find_int_value("episode_filter") == 1)
+            rule->setEpisodeFilter(fromStdString(filter->dict_find_string_value("episode_filter2")));
+
+        int enabledState = filter->dict_find_int_value("enabled");
+        rule->setEnabled(enabledState & EnabledFlags::ENABLED);
+        if (enabledState & EnabledFlags::PAUSED)
+            rule->setAddPaused(Rss::DownloadRule::AddPausedState::ALWAYS_PAUSED);
+
+        int feedId = filter->dict_find_int_value("feed");
+        if (feedId == -1)
+            rule->setRssFeeds(QStringList(feedUrls.values()));
+        else
+            rule->setRssFeeds(QStringList(feedUrls[feedId]));
+
+        applyFilter(rule, *filter);
+        m_rules->saveRule(Rss::DownloadRulePtr(rule));
+    }
+}

--- a/src/base/rss/utorrentrssdata.h
+++ b/src/base/rss/utorrentrssdata.h
@@ -1,7 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015  Vladimir Golovnev <glassez@yandex.ru>
- * Copyright (C) 2012  Christophe Dumez <chris@qbittorrent.org>
+ * Copyright (C) 2016  Michael Ziminsky <mgziminsky@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -25,48 +24,45 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : chris@qbittorrent.org
  */
 
-#ifndef RSSPARSER_H
-#define RSSPARSER_H
+#ifndef UTORRENTRSSDATA_H
+#define UTORRENTRSSDATA_H
 
-#include <QObject>
-#include <QString>
-#include <QVariantHash>
+#include <QHash>
+#include <QList>
+#include <QSharedPointer>
 
-class QXmlStreamReader;
+namespace libtorrent
+{
+    class lazy_entry;
+}
 
 namespace Rss
 {
-    namespace Private
+    class Feed;
+    class DownloadRuleList;
+    class Manager;
+
+    typedef QSharedPointer<Feed> FeedPtr;
+    typedef QList<FeedPtr> FeedList;
+
+    class UTorrentRssData
     {
-        class Parser: public QObject
-        {
-            Q_OBJECT
+    public:
+        UTorrentRssData();
+        ~UTorrentRssData();
 
-        public slots:
-            void parse(const QByteArray &feedData);
+        const QList<FeedPtr>& getFeeds() const;
+        const DownloadRuleList& getRules() const;
+        bool load(const QString &path);
 
-            // Redefine as a slot so it can be invoked on the owning thread
-            void moveToThread(QThread *thread);
+    private:
+        QHash<int, QString> loadFeeds(const libtorrent::lazy_entry &feeds);
+        void loadRules(const libtorrent::lazy_entry &filters, const QHash<int, QString> &feedUrls);
 
-        signals:
-            void newArticle(const QVariantHash &rssArticle);
-            void feedTitle(const QString &title);
-            void finished(const QString &error);
-
-        private:
-            void parseRssArticle(QXmlStreamReader &xml);
-            void parseRSSChannel(QXmlStreamReader &xml);
-            void parseAtomArticle(QXmlStreamReader &xml);
-            void parseAtomChannel(QXmlStreamReader &xml);
-
-            QString m_lastBuildDate; // Optimization
-            QString m_baseUrl;
-        };
-    }
+        QList<FeedPtr> m_feeds;
+        DownloadRuleList *m_rules;
+    };
 }
-
-#endif // RSSPARSER_H
+#endif // UTORRENTRSSDATA_H

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -176,6 +176,7 @@ private slots:
     void on_actionDownloadFromURL_triggered();
     void on_actionExit_triggered();
     void on_actionLock_triggered();
+    void on_actionImportUTorrentRss_triggered();
     // Check for active torrents and set preventing from suspend state
     void checkForActiveTorrents();
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -35,7 +35,7 @@
      <x>0</x>
      <y>0</y>
      <width>914</width>
-     <height>21</height>
+     <height>20</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuEdit">
@@ -88,6 +88,7 @@
     </property>
     <addaction name="actionOpen"/>
     <addaction name="actionDownloadFromURL"/>
+    <addaction name="actionImportUTorrentRss"/>
     <addaction name="separator"/>
     <addaction name="actionExit"/>
    </widget>
@@ -455,7 +456,29 @@
     <string>Critical Messages</string>
    </property>
   </action>
+  <action name="actionImportUTorrentRss">
+   <property name="text">
+    <string>&amp;Import RSS data from uTorrent</string>
+   </property>
+  </action>
  </widget>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>actionRSSReader</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>actionImportUTorrentRss</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/src/gui/rss/rss_imp.cpp
+++ b/src/gui/rss/rss_imp.cpp
@@ -47,6 +47,7 @@
 #include "base/rss/rssfolder.h"
 #include "base/rss/rssarticle.h"
 #include "base/rss/rssfeed.h"
+#include "base/rss/rssdownloadrulelist.h"
 #include "automatedrssdownloader.h"
 #include "guiiconprovider.h"
 #include "autoexpandabledialog.h"
@@ -152,18 +153,12 @@ void RSSImp::askNewFolder()
     if (!ok || rss_parent->hasChild(new_name))
         return;
 
-    Rss::FolderPtr newFolder(new Rss::Folder(new_name));
-    rss_parent->addFile(newFolder);
-    QTreeWidgetItem* folderItem = createFolderListItem(newFolder);
-    if (parent_item)
-        parent_item->addChild(folderItem);
-    else
-        m_feedList->addTopLevelItem(folderItem);
-    // Notify TreeWidget
-    m_feedList->itemAdded(folderItem, newFolder);
+    addItem(Rss::FolderPtr(new Rss::Folder(new_name)), parent_item);
+
     // Expand parent folder to display new folder
     if (parent_item)
         parent_item->setExpanded(true);
+
     m_rssManager->saveStreamList();
 }
 
@@ -182,11 +177,7 @@ void RSSImp::on_newFeedButton_clicked()
         if (!m_feedList->isFolder(parent_item))
             parent_item = parent_item->parent();
     }
-    Rss::FolderPtr rss_parent;
-    if (parent_item)
-        rss_parent = qSharedPointerCast<Rss::Folder>(m_feedList->getRSSItem(parent_item));
-    else
-        rss_parent = m_rssManager->rootFolder();
+
     // Ask for feed URL
     bool ok;
     QString clip_txt = qApp->clipboard()->text();
@@ -210,15 +201,7 @@ void RSSImp::on_newFeedButton_clicked()
     }
 
     Rss::FeedPtr stream(new Rss::Feed(newUrl, m_rssManager.data()));
-    rss_parent->addFile(stream);
-    // Create TreeWidget item
-    QTreeWidgetItem* item = createFolderListItem(stream);
-    if (parent_item)
-        parent_item->addChild(item);
-    else
-        m_feedList->addTopLevelItem(item);
-    // Notify TreeWidget
-    m_feedList->itemAdded(item, stream);
+    addItem(stream, parent_item);
 
     m_rssManager->saveStreamList();
 }
@@ -380,9 +363,9 @@ void RSSImp::renameSelectedRssFile()
     bool ok;
     QString newName;
     do {
-        newName = AutoExpandableDialog::getText(this, tr("Please choose a new name for this RSS feed"), tr("New feed name:"), QLineEdit::Normal, m_feedList->getRSSItem(item)->displayName(), &ok);
+        newName = AutoExpandableDialog::getText(this, tr("Please choose a new name for this RSS feed"), tr("New feed name:"), QLineEdit::Normal, rss_item->displayName(), &ok);
         // Check if name is already taken
-        if (ok) {
+        if (ok && rss_item->displayName() != newName) {
             if (rss_item->parentFolder()->hasChild(newName)) {
                 QMessageBox::warning(0, tr("Name already in use"), tr("This name is already used by another item, please choose another one."));
                 ok = false;
@@ -468,18 +451,11 @@ void RSSImp::fillFeedsList(QTreeWidgetItem* parent, const Rss::FolderPtr& rss_pa
     else
         children = m_rssManager->rootFolder()->getContent();
     foreach (const Rss::FilePtr& rssFile, children) {
-        QTreeWidgetItem* item = createFolderListItem(rssFile);
-        Q_ASSERT(item);
-        if (parent)
-            parent->addChild(item);
-        else
-            m_feedList->addTopLevelItem(item);
-
-        // Notify TreeWidget of item addition
-        m_feedList->itemAdded(item, rssFile);
+        QTreeWidgetItem *item = addItem(rssFile, parent);
 
         // Recursive call if this is a folder.
-        if (Rss::FolderPtr folder = qSharedPointerDynamicCast<Rss::Folder>(rssFile))
+        Rss::FolderPtr folder = qSharedPointerDynamicCast<Rss::Folder>(rssFile);
+        if (item && folder)
             fillFeedsList(item, folder);
     }
 }
@@ -682,6 +658,21 @@ void RSSImp::updateRefreshInterval(uint val)
     m_rssManager->updateRefreshInterval(val);
 }
 
+void RSSImp::addFeeds(const QList<Rss::FeedPtr> &feeds)
+{
+    for (const Rss::FeedPtr &feed : feeds) {
+        feed->setManager(m_rssManager.data());
+        addItem(feed.staticCast<Rss::File>());
+        feed->refresh();
+    }
+    m_rssManager->saveStreamList();
+}
+
+void RSSImp::addRules(const Rss::DownloadRuleList &newRules)
+{
+    m_rssManager->downloadRules()->merge(newRules);
+}
+
 RSSImp::RSSImp(QWidget *parent):
     QWidget(parent),
     m_rssManager(new Rss::Manager)
@@ -711,6 +702,7 @@ RSSImp::RSSImp(QWidget *parent):
     connect(m_feedList, SIGNAL(doubleClicked(QModelIndex)), SLOT(renameSelectedRssFile()));
     deleteHotkey = new QShortcut(QKeySequence::Delete, m_feedList, 0, 0, Qt::WidgetShortcut);
     connect(deleteHotkey, SIGNAL(activated()), SLOT(deleteSelectedItems()));
+    connect(rssDownloaderBtn, SIGNAL(clicked()), SLOT(showDownloadRulesDialog()));
 
     m_rssManager->loadStreamList();
     fillFeedsList();
@@ -770,7 +762,7 @@ void RSSImp::on_settingsButton_clicked()
         updateRefreshInterval(Preferences::instance()->getRSSRefreshInterval());
 }
 
-void RSSImp::on_rssDownloaderBtn_clicked()
+void RSSImp::showDownloadRulesDialog()
 {
     AutomatedRssDownloader dlg(m_rssManager, this);
     dlg.exec();
@@ -778,4 +770,30 @@ void RSSImp::on_rssDownloaderBtn_clicked()
         m_rssManager->rootFolder()->recheckRssItemsForDownload();
         refreshAllFeeds();
     }
+}
+
+QTreeWidgetItem* RSSImp::addItem(const Rss::FilePtr &file, QTreeWidgetItem *parent)
+{
+    qDebug() << Q_FUNC_INFO << file->id();
+
+    QTreeWidgetItem *item = nullptr;
+    if (!m_feedList->hasFeed(file->id())) {
+        item = createFolderListItem(file);
+        Q_ASSERT(item);
+
+        Rss::FolderPtr rssParent = qSharedPointerDynamicCast<Rss::Folder>(m_feedList->getRSSItem(parent));
+        if (!rssParent)
+            rssParent = m_rssManager->rootFolder();
+        rssParent->addFile(file);
+
+        if (parent)
+            parent->addChild(item);
+        else
+            m_feedList->addTopLevelItem(item);
+
+        // Notify TreeWidget of item addition
+        m_feedList->itemAdded(item, file);
+    }
+
+    return item;
 }

--- a/src/gui/rss/rss_imp.h
+++ b/src/gui/rss/rss_imp.h
@@ -53,9 +53,13 @@ public:
     RSSImp(QWidget *parent);
     ~RSSImp();
 
+    void addFeeds(const QList<Rss::FeedPtr> &feeds);
+    void addRules(const Rss::DownloadRuleList &newRules);
+
 public slots:
     void deleteSelectedItems();
     void updateRefreshInterval(uint val);
+    void showDownloadRulesDialog();
 
 signals:
     void updateRSSCount(int);
@@ -85,11 +89,11 @@ private slots:
     void saveFoldersOpenState();
     void loadFoldersOpenState();
     void on_settingsButton_clicked();
-    void on_rssDownloaderBtn_clicked();
 
 private:
     static QListWidgetItem* createArticleListItem(const Rss::ArticlePtr& article);
     static QTreeWidgetItem* createFolderListItem(const Rss::FilePtr& rssFile);
+    QTreeWidgetItem* addItem(const Rss::FilePtr& file, QTreeWidgetItem *parent = nullptr);
 
 private:
     Rss::ManagerPtr m_rssManager;


### PR DESCRIPTION
Adds the ability to import all download rules and feeds from a uTorrent `rss.dat` file.

The file dialog opened by clicking the "Import..." button in the "RSS Downloader" window now contains an additional file "uTorrent" filter for `*.dat` files.

Both the feeds and the download rules will be imported and merged with the current lists. I tried to make it so the imported rules filters behave as closely as possible to how they did in uTorrent, but due to fundamental differences with how the matching is handled, it isn't perfect.
