### PR TITLE
Revamp Torrent creator

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -52,6 +52,7 @@ utils/string.h
 utils/version.h
 asyncfilestorage.h
 filesystemwatcher.h
+global.h
 iconprovider.h
 indexrange.h
 logger.h

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -63,7 +63,8 @@ HEADERS += \
     $$PWD/torrentfileguard.h \
     $$PWD/torrentfilter.h \
     $$PWD/scanfoldersmodel.h \
-    $$PWD/searchengine.h
+    $$PWD/searchengine.h \
+    $$PWD/global.h
 
 SOURCES += \
     $$PWD/asyncfilestorage.cpp \

--- a/src/base/bittorrent/torrentcreatorthread.cpp
+++ b/src/base/bittorrent/torrentcreatorthread.cpp
@@ -28,25 +28,21 @@
  * Contact : chris@qbittorrent.org
  */
 
-#include <libtorrent/entry.hpp>
-#include <libtorrent/bencode.hpp>
-#include <libtorrent/torrent_info.hpp>
-#include <libtorrent/file.hpp>
-#include <libtorrent/storage.hpp>
-#include <libtorrent/hasher.hpp>
-#include <libtorrent/file_pool.hpp>
-#include <libtorrent/create_torrent.hpp>
-#include <QFile>
-#include <QDir>
+#include "torrentcreatorthread.h"
+
+#include <fstream>
 
 #include <boost/bind.hpp>
-#include <iostream>
-#include <fstream>
+#include <libtorrent/bencode.hpp>
+#include <libtorrent/create_torrent.hpp>
+#include <libtorrent/torrent_info.hpp>
+#include <libtorrent/storage.hpp>
+
+#include <QFile>
 
 #include "base/utils/fs.h"
 #include "base/utils/misc.h"
 #include "base/utils/string.h"
-#include "torrentcreatorthread.h"
 
 namespace libt = libtorrent;
 using namespace BitTorrent;

--- a/src/base/bittorrent/torrentcreatorthread.h
+++ b/src/base/bittorrent/torrentcreatorthread.h
@@ -46,7 +46,6 @@ namespace BitTorrent
 
         void create(const QString &inputPath, const QString &savePath, const QStringList &trackers,
                     const QStringList &urlSeeds, const QString &comment, bool isPrivate, int pieceSize);
-        void abortCreation();
 
     protected:
         void run();
@@ -66,7 +65,6 @@ namespace BitTorrent
         QString m_comment;
         bool m_private;
         int m_pieceSize;
-        bool m_abort;
     };
 }
 

--- a/src/base/bittorrent/torrentcreatorthread.h
+++ b/src/base/bittorrent/torrentcreatorthread.h
@@ -31,8 +31,8 @@
 #ifndef BITTORRENT_TORRENTCREATORTHREAD_H
 #define BITTORRENT_TORRENTCREATORTHREAD_H
 
-#include <QThread>
 #include <QStringList>
+#include <QThread>
 
 namespace BitTorrent
 {

--- a/src/base/global.h
+++ b/src/base/global.h
@@ -1,0 +1,30 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2016  Mike Tzou
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+const char C_TORRENT_FILE_EXTENSION[] = ".torrent";
+

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -1277,56 +1277,6 @@ void Preferences::setSearchEngDisabled(const QStringList &engines)
     setValue("SearchEngines/disabledEngines", engines);
 }
 
-QString Preferences::getCreateTorLastAddPath() const
-{
-    return value("CreateTorrent/last_add_path", QDir::homePath()).toString();
-}
-
-void Preferences::setCreateTorLastAddPath(const QString &path)
-{
-    setValue("CreateTorrent/last_add_path", path);
-}
-
-QString Preferences::getCreateTorLastSavePath() const
-{
-    return value("CreateTorrent/last_save_path", QDir::homePath()).toString();
-}
-
-void Preferences::setCreateTorLastSavePath(const QString &path)
-{
-    setValue("CreateTorrent/last_save_path", path);
-}
-
-QString Preferences::getCreateTorTrackers() const
-{
-    return value("CreateTorrent/TrackerList").toString();
-}
-
-void Preferences::setCreateTorTrackers(const QString &path)
-{
-    setValue("CreateTorrent/TrackerList", path);
-}
-
-QByteArray Preferences::getCreateTorGeometry() const
-{
-    return value("CreateTorrent/dimensions").toByteArray();
-}
-
-void Preferences::setCreateTorGeometry(const QByteArray &geometry)
-{
-    setValue("CreateTorrent/dimensions", geometry);
-}
-
-bool Preferences::getCreateTorIgnoreRatio() const
-{
-    return value("CreateTorrent/IgnoreRatio").toBool();
-}
-
-void Preferences::setCreateTorIgnoreRatio(const bool ignore)
-{
-    setValue("CreateTorrent/IgnoreRatio", ignore);
-}
-
 QString Preferences::getTorImportLastContentDir() const
 {
     return value("TorrentImport/LastContentDir", QDir::homePath()).toString();

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -305,16 +305,6 @@ public:
     void setSearchTabHeaderState(const QByteArray &state);
     QStringList getSearchEngDisabled() const;
     void setSearchEngDisabled(const QStringList &engines);
-    QString getCreateTorLastAddPath() const;
-    void setCreateTorLastAddPath(const QString &path);
-    QString getCreateTorLastSavePath() const;
-    void setCreateTorLastSavePath(const QString &path);
-    QString getCreateTorTrackers() const;
-    void setCreateTorTrackers(const QString &path);
-    QByteArray getCreateTorGeometry() const;
-    void setCreateTorGeometry(const QByteArray &geometry);
-    bool getCreateTorIgnoreRatio() const;
-    void setCreateTorIgnoreRatio(const bool ignore);
     QString getTorImportLastContentDir() const;
     void setTorImportLastContentDir(const QString &path);
     QByteArray getTorImportGeometry() const;

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1075,8 +1075,10 @@ void MainWindow::on_actionCreateTorrent_triggered()
 
 void MainWindow::createTorrentTriggered(const QString &path)
 {
-    if (m_createTorrentDlg)
+    if (m_createTorrentDlg) {
+        m_createTorrentDlg->updateInputPath(path);
         m_createTorrentDlg->setFocus();
+    }
     else
         m_createTorrentDlg = new TorrentCreatorDlg(this, path);
 }

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -64,6 +64,7 @@
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/sessionstatus.h"
 #include "base/bittorrent/torrenthandle.h"
+#include "base/global.h"
 #include "base/rss/rss_folder.h"
 #include "base/rss/rss_session.h"
 
@@ -1152,7 +1153,7 @@ void MainWindow::dropEvent(QDropEvent *event)
     // differentiate ".torrent" files and others
     QStringList torrentFiles, otherFiles;
     foreach (const QString &file, files) {
-        if (file.endsWith(".torrent", Qt::CaseInsensitive))
+        if (file.endsWith(C_TORRENT_FILE_EXTENSION, Qt::CaseInsensitive))
             torrentFiles << file;
         else
             otherFiles << file;
@@ -1203,7 +1204,7 @@ void MainWindow::on_actionOpen_triggered()
     // Note: it is possible to select more than one file
     const QStringList pathsList =
         QFileDialog::getOpenFileNames(this, tr("Open Torrent Files"), pref->getMainLastDir(),
-                                      tr("Torrent Files") + " (*.torrent)");
+                                      tr("Torrent Files") + " (*" + C_TORRENT_FILE_EXTENSION + ')');
 
     const bool useTorrentAdditionDialog = AddNewTorrentDialog::isEnabled();
     if (!pathsList.isEmpty()) {

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -202,6 +202,7 @@ private:
     bool event(QEvent *e) override;
     void displayRSSTab(bool enable);
     void displaySearchTab(bool enable);
+    void createTorrentTriggered(const QString &path = QString());
 
     Ui::MainWindow *m_ui;
 

--- a/src/gui/torrentcreatordlg.cpp
+++ b/src/gui/torrentcreatordlg.cpp
@@ -41,32 +41,26 @@
 #include "base/bittorrent/torrentcreatorthread.h"
 #include "base/bittorrent/torrentinfo.h"
 #include "base/global.h"
-#include "base/settingsstorage.h"
 #include "base/utils/fs.h"
 
 #include "ui_torrentcreatordlg.h"
 
-namespace
-{
 #define SETTINGS_KEY(name) "TorrentCreator/" name
-    CachedSettingValue<QSize> storeDialogSize(SETTINGS_KEY("Dimension"));
-
-    CachedSettingValue<int> storePieceSize(SETTINGS_KEY("PieceSize"));
-    CachedSettingValue<bool> storePrivateTorrent(SETTINGS_KEY("PrivateTorrent"));
-    CachedSettingValue<bool> storeStartSeeding(SETTINGS_KEY("StartSeeding"));
-    CachedSettingValue<bool> storeIgnoreRatio(SETTINGS_KEY("IgnoreRatio"));
-
-    CachedSettingValue<QString> storeLastAddPath(SETTINGS_KEY("LastAddPath"), QDir::homePath());
-    CachedSettingValue<QString> storeTrackerList(SETTINGS_KEY("TrackerList"));
-    CachedSettingValue<QString> storeWebSeedList(SETTINGS_KEY("WebSeedList"));
-    CachedSettingValue<QString> storeComments(SETTINGS_KEY("Comments"));
-    CachedSettingValue<QString> storeLastSavePath(SETTINGS_KEY("LastSavePath"), QDir::homePath());
-}
 
 TorrentCreatorDlg::TorrentCreatorDlg(QWidget *parent, const QString &defaultPath)
     : QDialog(parent)
     , m_ui(new Ui::TorrentCreatorDlg)
     , m_creatorThread(new BitTorrent::TorrentCreatorThread(this))
+    , m_storeDialogSize(SETTINGS_KEY("Dimension"))
+    , m_storePieceSize(SETTINGS_KEY("PieceSize"))
+    , m_storePrivateTorrent(SETTINGS_KEY("PrivateTorrent"))
+    , m_storeStartSeeding(SETTINGS_KEY("StartSeeding"))
+    , m_storeIgnoreRatio(SETTINGS_KEY("IgnoreRatio"))
+    , m_storeLastAddPath(SETTINGS_KEY("LastAddPath"), QDir::homePath())
+    , m_storeTrackerList(SETTINGS_KEY("TrackerList"))
+    , m_storeWebSeedList(SETTINGS_KEY("WebSeedList"))
+    , m_storeComments(SETTINGS_KEY("Comments"))
+    , m_storeLastSavePath(SETTINGS_KEY("LastSavePath"), QDir::homePath())
 {
     m_ui->setupUi(this);
     setAttribute(Qt::WA_DeleteOnClose);
@@ -166,13 +160,13 @@ void TorrentCreatorDlg::onCreateButtonClicked()
     input = fi.canonicalFilePath();
 
     // get save path
-    QString lastPath = storeLastSavePath;
+    QString lastPath = m_storeLastSavePath;
     QString destination = QFileDialog::getSaveFileName(this, tr("Select where to save the new torrent"), lastPath, tr("Torrent Files (*.torrent)"));
     if (destination.isEmpty())
         return;
     if (!destination.endsWith(C_TORRENT_FILE_EXTENSION, Qt::CaseInsensitive))
         destination += C_TORRENT_FILE_EXTENSION;
-    storeLastSavePath = Utils::Fs::branchPath(destination);
+    m_storeLastSavePath = Utils::Fs::branchPath(destination);
 
     // Disable dialog & set busy cursor
     setInteractionEnabled(false);
@@ -239,34 +233,34 @@ void TorrentCreatorDlg::setInteractionEnabled(bool enabled)
 
 void TorrentCreatorDlg::saveSettings()
 {
-    storeLastAddPath = m_ui->textInputPath->text().trimmed();
+    m_storeLastAddPath = m_ui->textInputPath->text().trimmed();
 
-    storePieceSize = m_ui->comboPieceSize->currentIndex();
-    storePrivateTorrent = m_ui->check_private->isChecked();
-    storeStartSeeding = m_ui->checkStartSeeding->isChecked();
-    storeIgnoreRatio = m_ui->checkIgnoreShareLimits->isChecked();
+    m_storePieceSize = m_ui->comboPieceSize->currentIndex();
+    m_storePrivateTorrent = m_ui->check_private->isChecked();
+    m_storeStartSeeding = m_ui->checkStartSeeding->isChecked();
+    m_storeIgnoreRatio = m_ui->checkIgnoreShareLimits->isChecked();
 
-    storeTrackerList = m_ui->trackers_list->toPlainText();
-    storeWebSeedList = m_ui->URLSeeds_list->toPlainText();
-    storeComments = m_ui->txt_comment->toPlainText();
+    m_storeTrackerList = m_ui->trackers_list->toPlainText();
+    m_storeWebSeedList = m_ui->URLSeeds_list->toPlainText();
+    m_storeComments = m_ui->txt_comment->toPlainText();
 
-    storeDialogSize = size();
+    m_storeDialogSize = size();
 }
 
 void TorrentCreatorDlg::loadSettings()
 {
-    m_ui->textInputPath->setText(storeLastAddPath);
+    m_ui->textInputPath->setText(m_storeLastAddPath);
 
-    m_ui->comboPieceSize->setCurrentIndex(storePieceSize);
-    m_ui->check_private->setChecked(storePrivateTorrent);
-    m_ui->checkStartSeeding->setChecked(storeStartSeeding);
-    m_ui->checkIgnoreShareLimits->setChecked(storeIgnoreRatio);
+    m_ui->comboPieceSize->setCurrentIndex(m_storePieceSize);
+    m_ui->check_private->setChecked(m_storePrivateTorrent);
+    m_ui->checkStartSeeding->setChecked(m_storeStartSeeding);
+    m_ui->checkIgnoreShareLimits->setChecked(m_storeIgnoreRatio);
     m_ui->checkIgnoreShareLimits->setEnabled(m_ui->checkStartSeeding->isChecked());
 
-    m_ui->trackers_list->setPlainText(storeTrackerList);
-    m_ui->URLSeeds_list->setPlainText(storeWebSeedList);
-    m_ui->txt_comment->setPlainText(storeComments);
+    m_ui->trackers_list->setPlainText(m_storeTrackerList);
+    m_ui->URLSeeds_list->setPlainText(m_storeWebSeedList);
+    m_ui->txt_comment->setPlainText(m_storeComments);
 
-    if (storeDialogSize.value().isValid())
-        resize(storeDialogSize);
+    if (m_storeDialogSize.value().isValid())
+        resize(m_storeDialogSize);
 }

--- a/src/gui/torrentcreatordlg.cpp
+++ b/src/gui/torrentcreatordlg.cpp
@@ -38,11 +38,11 @@
 #include <QUrl>
 
 #include "base/bittorrent/session.h"
-#include "base/bittorrent/torrentinfo.h"
 #include "base/bittorrent/torrentcreatorthread.h"
+#include "base/bittorrent/torrentinfo.h"
+#include "base/global.h"
 #include "base/settingsstorage.h"
 #include "base/utils/fs.h"
-#include "guiiconprovider.h"
 
 #include "ui_torrentcreatordlg.h"
 
@@ -161,8 +161,8 @@ void TorrentCreatorDlg::onCreateButtonClicked()
     QString destination = QFileDialog::getSaveFileName(this, tr("Select where to save the new torrent"), lastPath, tr("Torrent Files (*.torrent)"));
     if (destination.isEmpty())
         return;
-    if (!destination.endsWith(".torrent", Qt::CaseInsensitive))
-        destination += ".torrent";
+    if (!destination.endsWith(C_TORRENT_FILE_EXTENSION, Qt::CaseInsensitive))
+        destination += C_TORRENT_FILE_EXTENSION;
     storeLastSavePath = Utils::Fs::branchPath(destination);
 
     // Disable dialog & set busy cursor

--- a/src/gui/torrentcreatordlg.cpp
+++ b/src/gui/torrentcreatordlg.cpp
@@ -28,254 +28,350 @@
  * Contact : chris@qbittorrent.org
  */
 
+#include "torrentcreatordlg.h"
+
+#include <QCloseEvent>
 #include <QDebug>
 #include <QFileDialog>
 #include <QMessageBox>
+#include <QMimeData>
+#include <QUrl>
 
-#include "torrentcreatordlg.h"
-#include "base/utils/fs.h"
-#include "base/utils/misc.h"
-#include "base/preferences.h"
-#include "guiiconprovider.h"
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/torrentinfo.h"
 #include "base/bittorrent/torrentcreatorthread.h"
+#include "base/settingsstorage.h"
+#include "base/utils/fs.h"
+#include "guiiconprovider.h"
 
-const uint NB_PIECES_MIN = 1200;
-const uint NB_PIECES_MAX = 2200;
+#include "ui_torrentcreatordlg.h"
 
-TorrentCreatorDlg::TorrentCreatorDlg(QWidget *parent)
-    : QDialog(parent)
-    , m_creatorThread(0)
+namespace
 {
-    setupUi(this);
-    // Icons
-    addFile_button->setIcon(GuiIconProvider::instance()->getIcon("document-new"));
-    addFolder_button->setIcon(GuiIconProvider::instance()->getIcon("folder-new"));
-    createButton->setIcon(GuiIconProvider::instance()->getIcon("document-save"));
-    cancelButton->setIcon(GuiIconProvider::instance()->getIcon("dialog-cancel"));
+#define SETTINGS_KEY(name) "TorrentCreator/" name
+    const QString KEY_DIALOG_SIZE = SETTINGS_KEY("Dimension");
 
+    const QString KEY_PIECE_SIZE = SETTINGS_KEY("PieceSize");
+    const QString KEY_PRIVATE_TORRENT = SETTINGS_KEY("PrivateTorrent");
+    const QString KEY_START_SEEDING = SETTINGS_KEY("StartSeeding");
+    const QString KEY_SETTING_IGNORE_RATIO = SETTINGS_KEY("IgnoreRatio");
+
+    const QString KEY_LAST_ADD_PATH = SETTINGS_KEY("LastAddPath");
+    const QString KEY_TRACKER_LIST = SETTINGS_KEY("TrackerList");
+    const QString KEY_WEB_SEED_LIST = SETTINGS_KEY("WebSeedList");
+    const QString KEY_COMMENTS = SETTINGS_KEY("Comments");
+    const QString KEY_LAST_SAVE_PATH = SETTINGS_KEY("LastSavePath");
+
+    SettingsStorage *settings() { return  SettingsStorage::instance(); }
+}
+
+TorrentCreatorDlg::TorrentCreatorDlg(QWidget *parent, const QString &defaultPath)
+    : QDialog(parent)
+    , m_ui(new Ui::TorrentCreatorDlg)
+    , m_creatorThread(nullptr)
+    , m_defaultPath(Utils::Fs::toNativePath(defaultPath))
+{
+    m_ui->setupUi(this);
     setAttribute(Qt::WA_DeleteOnClose);
     setModal(true);
+
     showProgressBar(false);
-    loadTrackerList();
-    // Piece sizes
-    m_pieceSizes << 16 << 32 << 64 << 128 << 256 << 512 << 1024 << 2048 << 4096 << 8192 << 16384;
+    m_ui->buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Create Torrent"));
+
+    connect(m_ui->addFile_button, SIGNAL(clicked(bool)), SLOT(onAddFileButtonClicked()));
+    connect(m_ui->addFolder_button, SIGNAL(clicked(bool)), SLOT(onAddFolderButtonClicked()));
+    connect(m_ui->buttonBox, SIGNAL(accepted()), SLOT(onCreateButtonClicked()));
+
     loadSettings();
     show();
 }
 
 TorrentCreatorDlg::~TorrentCreatorDlg()
 {
-    if (m_creatorThread)
+    saveSettings();
+
+    // End torrent creation thread
+    if (m_creatorThread) {
+        if (m_creatorThread->isRunning()) {
+            m_creatorThread->abortCreation();
+            m_creatorThread->terminate();
+            // Wait for termination
+            m_creatorThread->wait();
+        }
         delete m_creatorThread;
+    }
+
+    delete m_ui;
 }
 
-void TorrentCreatorDlg::on_addFolder_button_clicked()
+void TorrentCreatorDlg::onAddFolderButtonClicked()
 {
-    Preferences* const pref = Preferences::instance();
-    QString lastPath = pref->getCreateTorLastAddPath();
-    QString dir = QFileDialog::getExistingDirectory(this, tr("Select a folder to add to the torrent"), lastPath, QFileDialog::ShowDirsOnly);
-    if (!dir.isEmpty()) {
-        pref->setCreateTorLastAddPath(dir);
-        textInputPath->setText(Utils::Fs::toNativePath(dir));
-        // Update piece size
-        if (checkAutoPieceSize->isChecked())
-            updateOptimalPieceSize();
-    }
+    QString oldPath = m_ui->textInputPath->text();
+    QString path = QFileDialog::getExistingDirectory(this, tr("Select folder"), oldPath);
+    if (!path.isEmpty())
+        m_ui->textInputPath->setText(Utils::Fs::toNativePath(path));
 }
 
-void TorrentCreatorDlg::on_addFile_button_clicked()
+void TorrentCreatorDlg::onAddFileButtonClicked()
 {
-    Preferences* const pref = Preferences::instance();
-    QString lastPath = pref->getCreateTorLastAddPath();
-    QString file = QFileDialog::getOpenFileName(this, tr("Select a file to add to the torrent"), lastPath);
-    if (!file.isEmpty()) {
-        pref->setCreateTorLastAddPath(Utils::Fs::branchPath(file));
-        textInputPath->setText(Utils::Fs::toNativePath(file));
-        // Update piece size
-        if (checkAutoPieceSize->isChecked())
-            updateOptimalPieceSize();
-    }
+    QString oldPath = m_ui->textInputPath->text();
+    QString path = QFileDialog::getOpenFileName(this, tr("Select file"), oldPath);
+    if (!path.isEmpty())
+        m_ui->textInputPath->setText(Utils::Fs::toNativePath(path));
 }
 
 int TorrentCreatorDlg::getPieceSize() const
 {
-    return m_pieceSizes.at(comboPieceSize->currentIndex()) * 1024;
+    const int pieceSizes[] = {0, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384};  // base unit in KiB
+    return pieceSizes[m_ui->comboPieceSize->currentIndex()] * 1024;
+}
+
+void TorrentCreatorDlg::dropEvent(QDropEvent *event)
+{
+    event->acceptProposedAction();
+
+    if (event->mimeData()->hasUrls()) {
+        // only take the first one
+        QUrl firstItem = event->mimeData()->urls().first();
+        QString path = (firstItem.scheme().compare("file", Qt::CaseInsensitive) == 0)
+                       ? firstItem.toLocalFile() : firstItem.toString();
+        m_ui->textInputPath->setText(Utils::Fs::toNativePath(path));
+    }
+}
+
+void TorrentCreatorDlg::dragEnterEvent(QDragEnterEvent *event)
+{
+    if (event->mimeData()->hasFormat("text/plain") || event->mimeData()->hasFormat("text/uri-list"))
+        event->acceptProposedAction();
 }
 
 // Main function that create a .torrent file
-void TorrentCreatorDlg::on_createButton_clicked()
+void TorrentCreatorDlg::onCreateButtonClicked()
 {
-    QString input = Utils::Fs::fromNativePath(textInputPath->text()).trimmed();
-    if (input.endsWith("/"))
-        input.chop(1);
-    if (input.isEmpty()) {
-        QMessageBox::critical(0, tr("No input path set"), tr("Please type an input path first"));
+    QString input = Utils::Fs::fromNativePath(m_ui->textInputPath->text()).trimmed();
+
+    // test if readable
+    QFileInfo fi(input);
+    if (!fi.isReadable()) {
+        QMessageBox::critical(this, tr("Torrent creator failed"), tr("Reason: Path to file/folder is not readable."));
         return;
     }
-    QStringList trackers = trackers_list->toPlainText().split("\n");
-    if (!trackers_list->toPlainText().trimmed().isEmpty())
-        saveTrackerList();
+    input = fi.canonicalFilePath();
 
-    Preferences* const pref = Preferences::instance();
-    QString lastPath = pref->getCreateTorLastSavePath();
-
-    QString destination = QFileDialog::getSaveFileName(this, tr("Select destination torrent file"), lastPath, tr("Torrent Files (*.torrent)"));
+    // get save path
+    QString lastPath = getLastSavePath();
+    QString destination = QFileDialog::getSaveFileName(this, tr("Select where to save the new torrent"), lastPath, tr("Torrent Files (*.torrent)"));
     if (destination.isEmpty())
         return;
+    if (!destination.endsWith(".torrent", Qt::CaseInsensitive))
+        destination += ".torrent";
+    setLastSavePath(Utils::Fs::branchPath(destination));
 
-    pref->setCreateTorLastSavePath(Utils::Fs::branchPath(destination));
-    if (!destination.toUpper().endsWith(".TORRENT"))
-        destination += QString::fromUtf8(".torrent");
-
-    // Disable dialog
+    // Disable dialog & set busy cursor
     setInteractionEnabled(false);
     showProgressBar(true);
-    // Set busy cursor
     setCursor(QCursor(Qt::WaitCursor));
-    // Actually create the torrent
-    QStringList urlSeeds = URLSeeds_list->toPlainText().split("\n");
-    QString comment = txt_comment->toPlainText();
+
+    QStringList trackers = m_ui->trackers_list->toPlainText().split("\n");
+    QStringList urlSeeds = m_ui->URLSeeds_list->toPlainText().split("\n");
+    QString comment = m_ui->txt_comment->toPlainText();
+
     // Create the creator thread
     m_creatorThread = new BitTorrent::TorrentCreatorThread(this);
     connect(m_creatorThread, SIGNAL(creationSuccess(QString, QString)), this, SLOT(handleCreationSuccess(QString, QString)));
     connect(m_creatorThread, SIGNAL(creationFailure(QString)), this, SLOT(handleCreationFailure(QString)));
     connect(m_creatorThread, SIGNAL(updateProgress(int)), this, SLOT(updateProgressBar(int)));
-    m_creatorThread->create(input, destination, trackers, urlSeeds, comment, check_private->isChecked(), getPieceSize());
+    m_creatorThread->create(input, destination, trackers, urlSeeds, comment, m_ui->check_private->isChecked(), getPieceSize());
 }
 
-void TorrentCreatorDlg::handleCreationFailure(QString msg)
+void TorrentCreatorDlg::handleCreationFailure(const QString &msg)
 {
     // Remove busy cursor
     setCursor(QCursor(Qt::ArrowCursor));
-    QMessageBox::information(0, tr("Torrent creation"), tr("Torrent creation was unsuccessful, reason: %1").arg(msg));
+    QMessageBox::information(this, tr("Torrent creator failed"), tr("Reason: %1").arg(msg));
     setInteractionEnabled(true);
     showProgressBar(false);
 }
 
-void TorrentCreatorDlg::handleCreationSuccess(QString path, QString branch_path)
+void TorrentCreatorDlg::handleCreationSuccess(const QString &path, const QString &branchPath)
 {
     // Remove busy cursor
     setCursor(QCursor(Qt::ArrowCursor));
-    if (checkStartSeeding->isChecked()) {
+    if (m_ui->checkStartSeeding->isChecked()) {
         // Create save path temp data
         BitTorrent::TorrentInfo t = BitTorrent::TorrentInfo::loadFromFile(Utils::Fs::toNativePath(path));
         if (!t.isValid()) {
-            QMessageBox::critical(0, tr("Torrent creation"), tr("Created torrent file is invalid. It won't be added to download list."));
+            QMessageBox::critical(this, tr("Torrent creator failed"), tr("Reason: Created torrent is invalid. It won't be added to download list."));
             return;
         }
 
         BitTorrent::AddTorrentParams params;
-        params.savePath = branch_path;
+        params.savePath = branchPath;
         params.skipChecking = true;
-        params.ignoreShareLimits = checkIgnoreShareLimits->isChecked();
+        params.ignoreShareLimits = m_ui->checkIgnoreShareLimits->isChecked();
 
         BitTorrent::Session::instance()->addTorrent(t, params);
     }
-    QMessageBox::information(0, tr("Torrent creation"), tr("Torrent was created successfully: %1", "%1 is the path of the torrent").arg(Utils::Fs::toNativePath(path)));
-    close();
-}
+    QMessageBox::information(this, tr("Torrent creator"), QString("%1\n%2").arg(tr("Create torrent success:")).arg(Utils::Fs::toNativePath(path)));
 
-void TorrentCreatorDlg::on_cancelButton_clicked()
-{
-    // End torrent creation thread
-    if (m_creatorThread && m_creatorThread->isRunning()) {
-        m_creatorThread->abortCreation();
-        m_creatorThread->terminate();
-        // Wait for termination
-        m_creatorThread->wait();
-    }
-    // Close the dialog
     close();
 }
 
 void TorrentCreatorDlg::updateProgressBar(int progress)
 {
-    progressBar->setValue(progress);
+    m_ui->progressBar->setValue(progress);
 }
 
 void TorrentCreatorDlg::setInteractionEnabled(bool enabled)
 {
-    textInputPath->setEnabled(enabled);
-    addFile_button->setEnabled(enabled);
-    addFolder_button->setEnabled(enabled);
-    trackers_list->setEnabled(enabled);
-    URLSeeds_list->setEnabled(enabled);
-    txt_comment->setEnabled(enabled);
-    comboPieceSize->setEnabled(enabled);
-    checkAutoPieceSize->setEnabled(enabled);
-    check_private->setEnabled(enabled);
-    checkStartSeeding->setEnabled(enabled);
-    createButton->setEnabled(enabled);
-    checkIgnoreShareLimits->setEnabled(enabled && checkStartSeeding->isChecked());
+    m_ui->textInputPath->setEnabled(enabled);
+    m_ui->addFile_button->setEnabled(enabled);
+    m_ui->addFolder_button->setEnabled(enabled);
+    m_ui->trackers_list->setEnabled(enabled);
+    m_ui->URLSeeds_list->setEnabled(enabled);
+    m_ui->txt_comment->setEnabled(enabled);
+    m_ui->comboPieceSize->setEnabled(enabled);
+    m_ui->check_private->setEnabled(enabled);
+    m_ui->checkStartSeeding->setEnabled(enabled);
+    m_ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(enabled);
+    m_ui->checkIgnoreShareLimits->setEnabled(enabled && m_ui->checkStartSeeding->isChecked());
 }
 
 void TorrentCreatorDlg::showProgressBar(bool show)
 {
-    progressLbl->setVisible(show);
-    progressBar->setVisible(show);
-}
-
-void TorrentCreatorDlg::on_checkAutoPieceSize_clicked(bool checked)
-{
-    comboPieceSize->setEnabled(!checked);
-    if (checked)
-        updateOptimalPieceSize();
-}
-
-void TorrentCreatorDlg::updateOptimalPieceSize()
-{
-    qint64 torrentSize = Utils::Fs::computePathSize(textInputPath->text());
-    qDebug("Torrent size is %lld", torrentSize);
-    if (torrentSize < 0)
-        return;
-    int i = 0;
-    qulonglong nb_pieces = 0;
-    do {
-        nb_pieces = (double)torrentSize/(m_pieceSizes.at(i) * 1024.);
-        qDebug("nb_pieces=%lld with piece_size=%s", nb_pieces, qPrintable(comboPieceSize->itemText(i)));
-        if (nb_pieces <= NB_PIECES_MIN) {
-            if (i > 1)
-                --i;
-            break;
-        }
-        else if (nb_pieces < NB_PIECES_MAX) {
-            qDebug("Good, nb_pieces=%lld < %d", nb_pieces + 1, NB_PIECES_MAX);
-            break;
-        }
-        ++i;
-    } while (i < (m_pieceSizes.size() - 1));
-    comboPieceSize->setCurrentIndex(i);
-}
-
-void TorrentCreatorDlg::saveTrackerList()
-{
-    Preferences::instance()->setCreateTorTrackers(trackers_list->toPlainText());
-}
-
-void TorrentCreatorDlg::loadTrackerList()
-{
-    trackers_list->setPlainText(Preferences::instance()->getCreateTorTrackers());
+    m_ui->progressLbl->setVisible(show);
+    m_ui->progressBar->setVisible(show);
 }
 
 void TorrentCreatorDlg::saveSettings()
 {
-    Preferences* const pref = Preferences::instance();
-    pref->setCreateTorGeometry(saveGeometry());
-    pref->setCreateTorIgnoreRatio(checkIgnoreShareLimits->isChecked());
+    setLastAddPath(m_ui->textInputPath->text().trimmed());
+
+    setSettingPieceSize(m_ui->comboPieceSize->currentIndex());
+    setSettingPrivateTorrent(m_ui->check_private->isChecked());
+    setSettingStartSeeding(m_ui->checkStartSeeding->isChecked());
+    setSettingIgnoreRatio(m_ui->checkIgnoreShareLimits->isChecked());
+
+    setTrackerList(m_ui->trackers_list->toPlainText());
+    setWebSeedList(m_ui->URLSeeds_list->toPlainText());
+    setComments(m_ui->txt_comment->toPlainText());
+
+    setDialogSize(size());
 }
 
 void TorrentCreatorDlg::loadSettings()
 {
-    const Preferences* const pref = Preferences::instance();
-    restoreGeometry(pref->getCreateTorGeometry());
-    checkIgnoreShareLimits->setChecked(pref->getCreateTorIgnoreRatio());
+    m_ui->textInputPath->setText(!m_defaultPath.isEmpty() ? m_defaultPath : getLastAddPath());
+
+    m_ui->comboPieceSize->setCurrentIndex(getSettingPieceSize());
+    m_ui->check_private->setChecked(getSettingPrivateTorrent());
+    m_ui->checkStartSeeding->setChecked(getSettingStartSeeding());
+    m_ui->checkIgnoreShareLimits->setChecked(getSettingIgnoreRatio());
+    m_ui->checkIgnoreShareLimits->setEnabled(m_ui->checkStartSeeding->isChecked());
+
+    m_ui->trackers_list->setPlainText(getTrackerList());
+    m_ui->URLSeeds_list->setPlainText(getWebSeedList());
+    m_ui->txt_comment->setPlainText(getComments());
+
+    resize(getDialogSize());
 }
 
-void TorrentCreatorDlg::closeEvent(QCloseEvent *event)
+QSize TorrentCreatorDlg::getDialogSize() const
 {
-    qDebug() << Q_FUNC_INFO;
-    saveSettings();
-    QDialog::closeEvent(event);
+    return settings()->loadValue(KEY_DIALOG_SIZE, size()).toSize();
+}
+
+void TorrentCreatorDlg::setDialogSize(const QSize &size)
+{
+    settings()->storeValue(KEY_DIALOG_SIZE, size);
+}
+
+int TorrentCreatorDlg::getSettingPieceSize() const
+{
+    return settings()->loadValue(KEY_PIECE_SIZE).toInt();
+}
+
+void TorrentCreatorDlg::setSettingPieceSize(const int size)
+{
+    settings()->storeValue(KEY_PIECE_SIZE, size);
+}
+
+bool TorrentCreatorDlg::getSettingPrivateTorrent() const
+{
+    return settings()->loadValue(KEY_PRIVATE_TORRENT).toBool();
+}
+
+void TorrentCreatorDlg::setSettingPrivateTorrent(const bool b)
+{
+    settings()->storeValue(KEY_PRIVATE_TORRENT, b);
+}
+
+bool TorrentCreatorDlg::getSettingStartSeeding() const
+{
+    return settings()->loadValue(KEY_START_SEEDING).toBool();
+}
+
+void TorrentCreatorDlg::setSettingStartSeeding(const bool b)
+{
+    settings()->storeValue(KEY_START_SEEDING, b);
+}
+
+bool TorrentCreatorDlg::getSettingIgnoreRatio() const
+{
+    return settings()->loadValue(KEY_SETTING_IGNORE_RATIO).toBool();
+}
+
+void TorrentCreatorDlg::setSettingIgnoreRatio(const bool ignore)
+{
+    settings()->storeValue(KEY_SETTING_IGNORE_RATIO, ignore);
+}
+
+QString TorrentCreatorDlg::getLastAddPath() const
+{
+    return settings()->loadValue(KEY_LAST_ADD_PATH, QDir::homePath()).toString();
+}
+
+void TorrentCreatorDlg::setLastAddPath(const QString &path)
+{
+    settings()->storeValue(KEY_LAST_ADD_PATH, path);
+}
+
+QString TorrentCreatorDlg::getTrackerList() const
+{
+    return settings()->loadValue(KEY_TRACKER_LIST).toString();
+}
+
+void TorrentCreatorDlg::setTrackerList(const QString &list)
+{
+    settings()->storeValue(KEY_TRACKER_LIST, list);
+}
+
+QString TorrentCreatorDlg::getWebSeedList() const
+{
+    return settings()->loadValue(KEY_WEB_SEED_LIST).toString();
+}
+
+void TorrentCreatorDlg::setWebSeedList(const QString &list)
+{
+    settings()->storeValue(KEY_WEB_SEED_LIST, list);
+}
+
+QString TorrentCreatorDlg::getComments() const
+{
+    return settings()->loadValue(KEY_COMMENTS).toString();
+}
+
+void TorrentCreatorDlg::setComments(const QString &str)
+{
+    settings()->storeValue(KEY_COMMENTS, str);
+}
+
+QString TorrentCreatorDlg::getLastSavePath() const
+{
+    return settings()->loadValue(KEY_LAST_SAVE_PATH, QDir::homePath()).toString();
+}
+
+void TorrentCreatorDlg::setLastSavePath(const QString &path)
+{
+    settings()->storeValue(KEY_LAST_SAVE_PATH, path);
 }

--- a/src/gui/torrentcreatordlg.cpp
+++ b/src/gui/torrentcreatordlg.cpp
@@ -86,16 +86,8 @@ TorrentCreatorDlg::~TorrentCreatorDlg()
 {
     saveSettings();
 
-    // End torrent creation thread
-    if (m_creatorThread) {
-        if (m_creatorThread->isRunning()) {
-            m_creatorThread->abortCreation();
-            m_creatorThread->terminate();
-            // Wait for termination
-            m_creatorThread->wait();
-        }
+    if (m_creatorThread)
         delete m_creatorThread;
-    }
 
     delete m_ui;
 }

--- a/src/gui/torrentcreatordlg.cpp
+++ b/src/gui/torrentcreatordlg.cpp
@@ -1,6 +1,7 @@
 /*
- * Bittorrent Client using Qt4 and libtorrent.
- * Copyright (C) 2010  Christophe Dumez
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2017  Mike Tzou (Chocobo1)
+ * Copyright (C) 2010  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,8 +25,6 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : chris@qbittorrent.org
  */
 
 #include "torrentcreatordlg.h"
@@ -68,8 +67,8 @@ TorrentCreatorDlg::TorrentCreatorDlg(QWidget *parent, const QString &defaultPath
 
     m_ui->buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Create Torrent"));
 
-    connect(m_ui->addFile_button, SIGNAL(clicked(bool)), SLOT(onAddFileButtonClicked()));
-    connect(m_ui->addFolder_button, SIGNAL(clicked(bool)), SLOT(onAddFolderButtonClicked()));
+    connect(m_ui->addFileButton, SIGNAL(clicked(bool)), SLOT(onAddFileButtonClicked()));
+    connect(m_ui->addFolderButton, SIGNAL(clicked(bool)), SLOT(onAddFolderButtonClicked()));
     connect(m_ui->buttonBox, SIGNAL(accepted()), SLOT(onCreateButtonClicked()));
 
     connect(m_creatorThread, SIGNAL(creationSuccess(QString, QString)), this, SLOT(handleCreationSuccess(QString, QString)));
@@ -164,12 +163,12 @@ void TorrentCreatorDlg::onCreateButtonClicked()
     setInteractionEnabled(false);
     setCursor(QCursor(Qt::WaitCursor));
 
-    QStringList trackers = m_ui->trackers_list->toPlainText().split("\n");
-    QStringList urlSeeds = m_ui->URLSeeds_list->toPlainText().split("\n");
-    QString comment = m_ui->txt_comment->toPlainText();
+    QStringList trackers = m_ui->trackersList->toPlainText().split("\n");
+    QStringList urlSeeds = m_ui->URLSeedsList->toPlainText().split("\n");
+    QString comment = m_ui->txtComment->toPlainText();
 
     // run the creator thread
-    m_creatorThread->create(input, destination, trackers, urlSeeds, comment, m_ui->check_private->isChecked(), getPieceSize());
+    m_creatorThread->create(input, destination, trackers, urlSeeds, comment, m_ui->checkPrivate->isChecked(), getPieceSize());
 }
 
 void TorrentCreatorDlg::handleCreationFailure(const QString &msg)
@@ -211,13 +210,13 @@ void TorrentCreatorDlg::updateProgressBar(int progress)
 void TorrentCreatorDlg::setInteractionEnabled(bool enabled)
 {
     m_ui->textInputPath->setEnabled(enabled);
-    m_ui->addFile_button->setEnabled(enabled);
-    m_ui->addFolder_button->setEnabled(enabled);
-    m_ui->trackers_list->setEnabled(enabled);
-    m_ui->URLSeeds_list->setEnabled(enabled);
-    m_ui->txt_comment->setEnabled(enabled);
+    m_ui->addFileButton->setEnabled(enabled);
+    m_ui->addFolderButton->setEnabled(enabled);
+    m_ui->trackersList->setEnabled(enabled);
+    m_ui->URLSeedsList->setEnabled(enabled);
+    m_ui->txtComment->setEnabled(enabled);
     m_ui->comboPieceSize->setEnabled(enabled);
-    m_ui->check_private->setEnabled(enabled);
+    m_ui->checkPrivate->setEnabled(enabled);
     m_ui->checkStartSeeding->setEnabled(enabled);
     m_ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(enabled);
     m_ui->checkIgnoreShareLimits->setEnabled(enabled && m_ui->checkStartSeeding->isChecked());
@@ -228,13 +227,13 @@ void TorrentCreatorDlg::saveSettings()
     m_storeLastAddPath = m_ui->textInputPath->text().trimmed();
 
     m_storePieceSize = m_ui->comboPieceSize->currentIndex();
-    m_storePrivateTorrent = m_ui->check_private->isChecked();
+    m_storePrivateTorrent = m_ui->checkPrivate->isChecked();
     m_storeStartSeeding = m_ui->checkStartSeeding->isChecked();
     m_storeIgnoreRatio = m_ui->checkIgnoreShareLimits->isChecked();
 
-    m_storeTrackerList = m_ui->trackers_list->toPlainText();
-    m_storeWebSeedList = m_ui->URLSeeds_list->toPlainText();
-    m_storeComments = m_ui->txt_comment->toPlainText();
+    m_storeTrackerList = m_ui->trackersList->toPlainText();
+    m_storeWebSeedList = m_ui->URLSeedsList->toPlainText();
+    m_storeComments = m_ui->txtComment->toPlainText();
 
     m_storeDialogSize = size();
 }
@@ -244,14 +243,14 @@ void TorrentCreatorDlg::loadSettings()
     m_ui->textInputPath->setText(m_storeLastAddPath);
 
     m_ui->comboPieceSize->setCurrentIndex(m_storePieceSize);
-    m_ui->check_private->setChecked(m_storePrivateTorrent);
+    m_ui->checkPrivate->setChecked(m_storePrivateTorrent);
     m_ui->checkStartSeeding->setChecked(m_storeStartSeeding);
     m_ui->checkIgnoreShareLimits->setChecked(m_storeIgnoreRatio);
     m_ui->checkIgnoreShareLimits->setEnabled(m_ui->checkStartSeeding->isChecked());
 
-    m_ui->trackers_list->setPlainText(m_storeTrackerList);
-    m_ui->URLSeeds_list->setPlainText(m_storeWebSeedList);
-    m_ui->txt_comment->setPlainText(m_storeComments);
+    m_ui->trackersList->setPlainText(m_storeTrackerList);
+    m_ui->URLSeedsList->setPlainText(m_storeWebSeedList);
+    m_ui->txtComment->setPlainText(m_storeComments);
 
     if (m_storeDialogSize.value().isValid())
         resize(m_storeDialogSize);

--- a/src/gui/torrentcreatordlg.h
+++ b/src/gui/torrentcreatordlg.h
@@ -1,6 +1,7 @@
 /*
- * Bittorrent Client using Qt4 and libtorrent.
- * Copyright (C) 2010  Christophe Dumez
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2017  Mike Tzou (Chocobo1)
+ * Copyright (C) 2010  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,8 +25,6 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : chris@qbittorrent.org
  */
 
 #ifndef TORRENTCREATORDLG_H

--- a/src/gui/torrentcreatordlg.h
+++ b/src/gui/torrentcreatordlg.h
@@ -50,6 +50,7 @@ class TorrentCreatorDlg: public QDialog
 public:
     TorrentCreatorDlg(QWidget *parent = 0, const QString &defaultPath = QString());
     ~TorrentCreatorDlg();
+    void updateInputPath(const QString &path);
 
 private slots:
     void updateProgressBar(int progress);
@@ -66,12 +67,10 @@ private:
     void saveSettings();
     void loadSettings();
     int getPieceSize() const;
-    void showProgressBar(bool show);
     void setInteractionEnabled(bool enabled);
 
     Ui::TorrentCreatorDlg *m_ui;
     BitTorrent::TorrentCreatorThread *m_creatorThread;
-    QString m_defaultPath;
 };
 
 #endif

--- a/src/gui/torrentcreatordlg.h
+++ b/src/gui/torrentcreatordlg.h
@@ -33,6 +33,8 @@
 
 #include <QDialog>
 
+#include "base/settingvalue.h"
+
 namespace Ui
 {
     class TorrentCreatorDlg;
@@ -71,6 +73,18 @@ private:
 
     Ui::TorrentCreatorDlg *m_ui;
     BitTorrent::TorrentCreatorThread *m_creatorThread;
+
+    // settings
+    CachedSettingValue<QSize> m_storeDialogSize;
+    CachedSettingValue<int> m_storePieceSize;
+    CachedSettingValue<bool> m_storePrivateTorrent;
+    CachedSettingValue<bool> m_storeStartSeeding;
+    CachedSettingValue<bool> m_storeIgnoreRatio;
+    CachedSettingValue<QString> m_storeLastAddPath;
+    CachedSettingValue<QString> m_storeTrackerList;
+    CachedSettingValue<QString> m_storeWebSeedList;
+    CachedSettingValue<QString> m_storeComments;
+    CachedSettingValue<QString> m_storeLastSavePath;
 };
 
 #endif

--- a/src/gui/torrentcreatordlg.h
+++ b/src/gui/torrentcreatordlg.h
@@ -28,52 +28,72 @@
  * Contact : chris@qbittorrent.org
  */
 
-#ifndef CREATE_TORRENT_IMP_H
-#define CREATE_TORRENT_IMP_H
+#ifndef TORRENTCREATORDLG_H
+#define TORRENTCREATORDLG_H
 
-#include "ui_torrentcreatordlg.h"
+#include <QDialog>
+
+namespace Ui
+{
+    class TorrentCreatorDlg;
+}
 
 namespace BitTorrent
 {
     class TorrentCreatorThread;
 }
 
-class TorrentCreatorDlg : public QDialog, private Ui::createTorrentDialog
+class TorrentCreatorDlg: public QDialog
 {
     Q_OBJECT
 
 public:
-    TorrentCreatorDlg(QWidget *parent = 0);
+    TorrentCreatorDlg(QWidget *parent = 0, const QString &defaultPath = QString());
     ~TorrentCreatorDlg();
-    int getPieceSize() const;
 
-public slots:
+private slots:
     void updateProgressBar(int progress);
-    void on_cancelButton_clicked();
-
-protected slots:
-    void on_createButton_clicked();
-    void on_addFile_button_clicked();
-    void on_addFolder_button_clicked();
-    void handleCreationFailure(QString msg);
-    void handleCreationSuccess(QString path, QString branch_path);
-    void setInteractionEnabled(bool enabled);
-    void showProgressBar(bool show);
-    void on_checkAutoPieceSize_clicked(bool checked);
-    void updateOptimalPieceSize();
-    void saveTrackerList();
-    void loadTrackerList();
-
-protected:
-    void closeEvent(QCloseEvent *event);
+    void onCreateButtonClicked();
+    void onAddFileButtonClicked();
+    void onAddFolderButtonClicked();
+    void handleCreationFailure(const QString &msg);
+    void handleCreationSuccess(const QString &path, const QString &branchPath);
 
 private:
+    void dropEvent(QDropEvent *event) override;
+    void dragEnterEvent(QDragEnterEvent *event) override;
+
     void saveSettings();
     void loadSettings();
+    int getPieceSize() const;
+    void showProgressBar(bool show);
+    void setInteractionEnabled(bool enabled);
 
-private:
+    // settings storage
+    QSize getDialogSize() const;
+    void setDialogSize(const QSize &size);
+    int getSettingPieceSize() const;
+    void setSettingPieceSize(const int size);
+    bool getSettingPrivateTorrent() const;
+    void setSettingPrivateTorrent(const bool b);
+    bool getSettingStartSeeding() const;
+    void setSettingStartSeeding(const bool b);
+    bool getSettingIgnoreRatio() const;
+    void setSettingIgnoreRatio(const bool ignore);
+    QString getLastAddPath() const;
+    void setLastAddPath(const QString &path);
+    QString getTrackerList() const;
+    void setTrackerList(const QString &list);
+    QString getWebSeedList() const;
+    void setWebSeedList(const QString &list);
+    QString getComments() const;
+    void setComments(const QString &str);
+    QString getLastSavePath() const;
+    void setLastSavePath(const QString &path);
+
+    Ui::TorrentCreatorDlg *m_ui;
     BitTorrent::TorrentCreatorThread *m_creatorThread;
-    QList<int> m_pieceSizes;
+    QString m_defaultPath;
 };
 
 #endif

--- a/src/gui/torrentcreatordlg.h
+++ b/src/gui/torrentcreatordlg.h
@@ -69,28 +69,6 @@ private:
     void showProgressBar(bool show);
     void setInteractionEnabled(bool enabled);
 
-    // settings storage
-    QSize getDialogSize() const;
-    void setDialogSize(const QSize &size);
-    int getSettingPieceSize() const;
-    void setSettingPieceSize(const int size);
-    bool getSettingPrivateTorrent() const;
-    void setSettingPrivateTorrent(const bool b);
-    bool getSettingStartSeeding() const;
-    void setSettingStartSeeding(const bool b);
-    bool getSettingIgnoreRatio() const;
-    void setSettingIgnoreRatio(const bool ignore);
-    QString getLastAddPath() const;
-    void setLastAddPath(const QString &path);
-    QString getTrackerList() const;
-    void setTrackerList(const QString &list);
-    QString getWebSeedList() const;
-    void setWebSeedList(const QString &list);
-    QString getComments() const;
-    void setComments(const QString &str);
-    QString getLastSavePath() const;
-    void setLastSavePath(const QString &path);
-
     Ui::TorrentCreatorDlg *m_ui;
     BitTorrent::TorrentCreatorThread *m_creatorThread;
     QString m_defaultPath;

--- a/src/gui/torrentcreatordlg.ui
+++ b/src/gui/torrentcreatordlg.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>createTorrentDialog</class>
- <widget class="QDialog" name="createTorrentDialog">
+ <class>TorrentCreatorDlg</class>
+ <widget class="QDialog" name="TorrentCreatorDlg">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -10,322 +10,293 @@
     <height>658</height>
    </rect>
   </property>
+  <property name="acceptDrops">
+   <bool>true</bool>
+  </property>
   <property name="windowTitle">
-   <string>Torrent Creation Tool</string>
+   <string>Torrent Creator</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QLabel" name="createTorrent_title">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>27</height>
-      </size>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Select file/folder to share</string>
      </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>27</height>
-      </size>
-     </property>
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Torrent file creation</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Path:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="textInputPath">
+          <property name="acceptDrops">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QLabel" name="label_2">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>[Drag and drop area]</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="addFile_button">
+          <property name="text">
+           <string>Select file</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="addFolder_button">
+          <property name="text">
+           <string>Select folder</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
-    <widget class="QLabel" name="lbl_input">
-     <property name="text">
-      <string>File or folder to add to the torrent:</string>
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Settings</string>
      </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <layout class="QHBoxLayout" name="pieceSizeLayout">
+        <item>
+         <widget class="QLabel" name="txtPieceSize">
+          <property name="text">
+           <string>Piece size:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="comboPieceSize">
+          <property name="currentIndex">
+           <number>0</number>
+          </property>
+          <item>
+           <property name="text">
+            <string>Auto</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>16 KiB</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>32 KiB</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>64 KiB</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>128 KiB</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>256 KiB</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>512 KiB</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>1 MiB</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>2 MiB</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>4 MiB</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>8 MiB</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>16 MiB</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item>
+         <spacer name="spacer1">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="check_private">
+        <property name="text">
+         <string>Private torrent (Won't distribute on DHT network)</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="checkStartSeeding">
+        <property name="text">
+         <string>Start seeding immediately</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="checkIgnoreShareLimits">
+        <property name="text">
+         <string>Ignore share ratio limits for this torrent</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
-    <widget class="QLineEdit" name="textInputPath"/>
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Fields</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="1">
+       <widget class="QTextEdit" name="trackers_list">
+        <property name="toolTip">
+         <string comment="A tracker tier is a group of trackers, consisting of a main tracker and its mirrors.">You can separate tracker tiers / groups with an empty line.</string>
+        </property>
+        <property name="acceptRichText">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="urlSeeds_lbl">
+        <property name="text">
+         <string>Web seed URLs:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QTextEdit" name="URLSeeds_list">
+        <property name="acceptRichText">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QTextEdit" name="txt_comment">
+        <property name="acceptRichText">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="lbl_announce_url">
+        <property name="text">
+         <string>Tracker URLs:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="lbl_comment">
+        <property name="text">
+         <string>Comments:</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
-      <widget class="QPushButton" name="addFile_button">
+      <widget class="QLabel" name="progressLbl">
        <property name="text">
-        <string>Add file</string>
+        <string>Progress:</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="addFolder_button">
-       <property name="text">
-        <string>Add folder</string>
-       </property>
-      </widget>
+      <widget class="QProgressBar" name="progressBar"/>
      </item>
     </layout>
    </item>
    <item>
-    <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="lbl_announce_url">
-       <property name="text">
-        <string>Tracker URLs:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="urlSeeds_lbl">
-       <property name="text">
-        <string>Web seeds urls:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="lbl_comment">
-       <property name="text">
-        <string>Comment:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QTextEdit" name="txt_comment">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="acceptRichText">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QTextEdit" name="trackers_list">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string comment="A tracker tier is a group of trackers, consisting of a main tracker and its mirrors.">You can separate tracker tiers / groups with an empty line.</string>
-       </property>
-       <property name="acceptRichText">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QTextEdit" name="URLSeeds_list">
-       <property name="acceptRichText">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout">
-     <item>
-      <widget class="QLabel" name="txtPieceSize">
-       <property name="text">
-        <string>Piece size:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="comboPieceSize">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="editable">
-        <bool>false</bool>
-       </property>
-       <property name="currentIndex">
-        <number>4</number>
-       </property>
-       <item>
-        <property name="text">
-         <string>16 KiB</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>32 KiB</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>64 KiB</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>128 KiB</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>256 KiB</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>512 KiB</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>1 MiB</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>2 MiB</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>4 MiB</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>8 MiB</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>16 MiB</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="checkAutoPieceSize">
-       <property name="text">
-        <string>Auto</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="check_private">
-     <property name="text">
-      <string>Private (won't be distributed on DHT network if enabled)</string>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="checkStartSeeding">
-     <property name="text">
-      <string>Start seeding after creation</string>
-     </property>
-     <property name="checked">
+     <property name="centerButtons">
       <bool>true</bool>
      </property>
     </widget>
    </item>
-   <item>
-    <widget class="QCheckBox" name="checkIgnoreShareLimits">
-     <property name="text">
-      <string>Ignore share ratio limits for this torrent</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="progressLbl">
-     <property name="text">
-      <string>Progress:</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QProgressBar" name="progressBar">
-     <property name="value">
-      <number>0</number>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout">
-     <item>
-      <spacer>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>131</width>
-         <height>31</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="createButton">
-       <property name="text">
-        <string>Create and save...</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="cancelButton">
-       <property name="text">
-        <string>Cancel</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>textInputPath</tabstop>
+  <tabstop>addFile_button</tabstop>
+  <tabstop>addFolder_button</tabstop>
+  <tabstop>comboPieceSize</tabstop>
+  <tabstop>check_private</tabstop>
+  <tabstop>checkStartSeeding</tabstop>
+  <tabstop>checkIgnoreShareLimits</tabstop>
+  <tabstop>trackers_list</tabstop>
+  <tabstop>URLSeeds_list</tabstop>
+  <tabstop>txt_comment</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>
@@ -341,6 +312,22 @@
     <hint type="destinationlabel">
      <x>295</x>
      <y>555</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>TorrentCreatorDlg</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>295</x>
+     <y>635</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>295</x>
+     <y>328</y>
     </hint>
    </hints>
   </connection>

--- a/src/gui/torrentcreatordlg.ui
+++ b/src/gui/torrentcreatordlg.ui
@@ -101,6 +101,9 @@
           <property name="currentIndex">
            <number>0</number>
           </property>
+          <property name="minimumContentsLength">
+           <number>7</number>
+          </property>
           <item>
            <property name="text">
             <string>Auto</string>

--- a/src/gui/torrentcreatordlg.ui
+++ b/src/gui/torrentcreatordlg.ui
@@ -63,14 +63,14 @@
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="addFile_button">
+         <widget class="QPushButton" name="addFileButton">
           <property name="text">
            <string>Select file</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="addFolder_button">
+         <widget class="QPushButton" name="addFolderButton">
           <property name="text">
            <string>Select folder</string>
           </property>
@@ -182,7 +182,7 @@
        </layout>
       </item>
       <item>
-       <widget class="QCheckBox" name="check_private">
+       <widget class="QCheckBox" name="checkPrivate">
         <property name="text">
          <string>Private torrent (Won't distribute on DHT network)</string>
         </property>
@@ -215,7 +215,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="1">
-       <widget class="QTextEdit" name="trackers_list">
+       <widget class="QTextEdit" name="trackersList">
         <property name="toolTip">
          <string comment="A tracker tier is a group of trackers, consisting of a main tracker and its mirrors.">You can separate tracker tiers / groups with an empty line.</string>
         </property>
@@ -232,14 +232,14 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QTextEdit" name="URLSeeds_list">
+       <widget class="QTextEdit" name="URLSeedsList">
         <property name="acceptRichText">
          <bool>false</bool>
         </property>
        </widget>
       </item>
       <item row="2" column="1">
-       <widget class="QTextEdit" name="txt_comment">
+       <widget class="QTextEdit" name="txtComment">
         <property name="acceptRichText">
          <bool>false</bool>
         </property>
@@ -294,15 +294,15 @@
  </widget>
  <tabstops>
   <tabstop>textInputPath</tabstop>
-  <tabstop>addFile_button</tabstop>
-  <tabstop>addFolder_button</tabstop>
+  <tabstop>addFileButton</tabstop>
+  <tabstop>addFolderButton</tabstop>
   <tabstop>comboPieceSize</tabstop>
-  <tabstop>check_private</tabstop>
+  <tabstop>checkPrivate</tabstop>
   <tabstop>checkStartSeeding</tabstop>
   <tabstop>checkIgnoreShareLimits</tabstop>
-  <tabstop>trackers_list</tabstop>
-  <tabstop>URLSeeds_list</tabstop>
-  <tabstop>txt_comment</tabstop>
+  <tabstop>trackersList</tabstop>
+  <tabstop>URLSeedsList</tabstop>
+  <tabstop>txtComment</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/gui/torrentcreatordlg.ui
+++ b/src/gui/torrentcreatordlg.ui
@@ -269,7 +269,11 @@
       </widget>
      </item>
      <item>
-      <widget class="QProgressBar" name="progressBar"/>
+      <widget class="QProgressBar" name="progressBar">
+       <property name="value">
+        <number>0</number>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
- All settings/text field in Torrent creator & dialog size are now remembered.
- Support drag and drop in Torrent creator.
- Support drag and drop to open Torrent creator in mainwindow.
- Revised popup messages.
- Switch to modeless dialog.

scrnshot: [old](https://cloud.githubusercontent.com/assets/9395168/14884053/ea122c40-0d74-11e6-9790-7915a2d24973.png), [new](https://cloud.githubusercontent.com/assets/9395168/14935452/b0c953fa-0f04-11e6-9482-84c6a788827b.png)
