### PR TITLE
cmake: fix powermanagement compilation

### DIFF
--- a/cmake/Modules/FindLibtorrentRasterbar.cmake
+++ b/cmake/Modules/FindLibtorrentRasterbar.cmake
@@ -99,6 +99,7 @@ if (LibtorrentRasterbar_FOUND AND NOT TARGET LibtorrentRasterbar::LibTorrent)
         IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
         IMPORTED_LOCATION "${LibtorrentRasterbar_LIBRARY}"
         INTERFACE_INCLUDE_DIRECTORIES "${LibtorrentRasterbar_INCLUDE_DIRS}"
+        INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${LibtorrentRasterbar_INCLUDE_DIRS}"
         INTERFACE_LINK_LIBRARIES "${LibtorrentRasterbar_LIBRARIES}"
         INTERFACE_COMPILE_OPTIONS "${LibtorrentRasterbar_DEFINITIONS}"
     )

--- a/cmake/Modules/FindQtSingleApplication.cmake
+++ b/cmake/Modules/FindQtSingleApplication.cmake
@@ -84,6 +84,7 @@ if(NOT TARGET QtSingleApplication::QtSingleApplication)
     add_library(QtSingleApplication::QtSingleApplication UNKNOWN IMPORTED)
     set_target_properties(QtSingleApplication::QtSingleApplication PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES "${QTSINGLEAPPLICATION_INCLUDE_DIR}"
+        INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${QTSINGLEAPPLICATION_INCLUDE_DIR}"
     )
     if(EXISTS "${QTSINGLEAPPLICATION_LIBRARY}")
     set_target_properties(QtSingleApplication::QtSingleApplication PROPERTIES

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -123,6 +123,11 @@ else (QT4_FOUND)
         target_link_libraries(qbt_base Qt5::Gui Qt5::Widgets)
     endif (GUI)
 endif (QT4_FOUND)
+
+if (DBUS)
+    target_link_qt_components(qbt_base DBus)
+endif ()
+
 if (APPLE)
     find_library(IOKit_LIBRARY IOKit)
     find_library(Carbon_LIBRARY Carbon)


### PR DESCRIPTION
base "module" needs -DQT_DBUS_LIB set to compile proper power management code. The appropriate library dependency was mistakenly forgotten.

Also mark libtorrent and qtsingleapplication include dirs as system.