### PR TITLE
Enable CI cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,7 +131,7 @@ install:
 script:
   - if [ "$TRAVIS_BRANCH" = "$coverity_branch" ]; then exit ; fi # skip usual build when running coverity scan
   - cd "$TRAVIS_BUILD_DIR" && ./bootstrap.sh && ./configure $qbtconf
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sed -i "" -e 's/^\(CXXFLAGS.*\)$/\1 -Wno-unused-local-typedefs/' src/Makefile ; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sed -i "" -e 's/^\(CXXFLAGS.*\)$/\1 -Wno-unused-local-typedefs -Wno-inconsistent-missing-override/' src/Makefile ; fi
   - make && make install
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,7 @@ notifications:
 
 # container-based builds
 #sudo: false
-# TODO: osx builder does not enable cache yet, see: https://github.com/travis-ci/travis-ci/issues/4011
-#cache:
-  #directories:
-    #- $HOME/.ccache
+cache: ccache
 
 # opt-in Ubuntu Trusty
 sudo: required
@@ -80,12 +77,6 @@ before_install:
   - if [ "$gui" = false ]; then qbtconf="$qbtconf --disable-gui" ; fi
   - |
     if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-      # ccache
-      #if [ "$TRAVIS_BRANCH" != "$coverity_branch" ]; then
-        #dpkg-query -L ccache && export PATH="/usr/lib/ccache/:$PATH" && export use_ccache=true ;
-        #ccache -V && ccache --show-stats && ccache --zero-stats ;
-      #fi ;
-
       # setup virtual display for after_success target
       if [ "$gui" = true ]; then export "DISPLAY=:99.0" && /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16 ; fi ;
     fi
@@ -117,21 +108,38 @@ install:
       # Qt
       if [ "$qt" = 4 ]; then sudo apt-get -qq install qt4-default libqt4-dev ; fi ;
       if [ "$qt" = 5 ]; then sudo apt-get -qq install qt5-default qtbase5-dev qttools5-dev-tools ; fi ;
+
+      # ccache
+      if [ "$TRAVIS_BRANCH" != "$coverity_branch" ]; then
+        dpkg-query -L ccache && export use_ccache=true ;
+        ccache -V && ccache --show-stats && ccache --zero-stats ;
+      fi ;
     fi
   - |
     if [ "$TRAVIS_OS_NAME" = "osx" ]; then
       # dependencies
-      brew update > /dev/null && brew install colormake libtorrent-rasterbar ;
+      brew update > /dev/null && brew install colormake ccache libtorrent-rasterbar ;
 
       # Qt
       if [ "$qt" = 4 ]; then brew install qt && ln -s /usr/local/Cellar/qt/4.8.7_2/plugins /usr/local ; fi ;
       if [ "$qt" = 5 ]; then brew install qt5 && brew link --force qt5 && ln -s /usr/local/Cellar/qt5/5.6.0/plugins /usr/local ; fi ;
+
+      # ccache
+      if [ "$TRAVIS_BRANCH" != "$coverity_branch" ]; then
+        export PATH="/usr/local/opt/ccache/libexec:$PATH" && export use_ccache=true ;
+        ccache -V && ccache --show-stats && ccache --zero-stats ;
+      fi ;
     fi
 
 script:
   - if [ "$TRAVIS_BRANCH" = "$coverity_branch" ]; then exit ; fi # skip usual build when running coverity scan
   - cd "$TRAVIS_BUILD_DIR" && ./bootstrap.sh && ./configure $qbtconf
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sed -i "" -e 's/^\(CXXFLAGS.*\)$/\1 -Wno-unused-local-typedefs -Wno-inconsistent-missing-override/' src/Makefile ; fi
+  - |
+    if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+      sed -i "" -e "s/^\(CC.*&&\).*$/\1 $CC/" src/Makefile ;  # workaround for Qt & ccache: https://bugreports.qt.io/browse/QTBUG-31034
+      sed -i "" -e "s/^\(CXX.*&&\).*$/\1 $CXX/" src/Makefile ;
+      sed -i "" -e 's/^\(CXXFLAGS.*\)$/\1 -Wno-unused-local-typedefs -Wno-inconsistent-missing-override/' src/Makefile ;
+    fi
   - make && make install
 
 after_success:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 aclocal -I m4
 autoconf

--- a/src/src.pro
+++ b/src/src.pro
@@ -36,8 +36,6 @@ nowebui: DEFINES += DISABLE_WEBUI
 strace_win: DEFINES += STACKTRACE_WIN
 QT += network xml
 
-# Vars
-LANG_PATH = lang
 
 CONFIG(debug, debug|release): message(Project is built in DEBUG mode.)
 CONFIG(release, debug|release): message(Project is built in RELEASE mode.)
@@ -72,51 +70,6 @@ RESOURCES += \
     searchengine.qrc
 
 # Translations
-TRANSLATIONS = \
-    $$LANG_PATH/qbittorrent_fr.ts \
-    $$LANG_PATH/qbittorrent_zh.ts \
-    $$LANG_PATH/qbittorrent_zh_TW.ts \
-    $$LANG_PATH/qbittorrent_zh_HK.ts \
-    $$LANG_PATH/qbittorrent_en.ts \
-    $$LANG_PATH/qbittorrent_en_AU.ts \
-    $$LANG_PATH/qbittorrent_en_GB.ts \
-    $$LANG_PATH/qbittorrent_ca.ts \
-    $$LANG_PATH/qbittorrent_es.ts \
-    $$LANG_PATH/qbittorrent_eo.ts \
-    $$LANG_PATH/qbittorrent_pl.ts \
-    $$LANG_PATH/qbittorrent_ko.ts \
-    $$LANG_PATH/qbittorrent_de.ts \
-    $$LANG_PATH/qbittorrent_nl.ts \
-    $$LANG_PATH/qbittorrent_tr.ts \
-    $$LANG_PATH/qbittorrent_sv.ts \
-    $$LANG_PATH/qbittorrent_el.ts \
-    $$LANG_PATH/qbittorrent_ru.ts \
-    $$LANG_PATH/qbittorrent_uk.ts \
-    $$LANG_PATH/qbittorrent_bg.ts \
-    $$LANG_PATH/qbittorrent_id.ts \
-    $$LANG_PATH/qbittorrent_it.ts \
-    $$LANG_PATH/qbittorrent_sk.ts \
-    $$LANG_PATH/qbittorrent_sl.ts \
-    $$LANG_PATH/qbittorrent_ro.ts \
-    $$LANG_PATH/qbittorrent_pt_PT.ts \
-    $$LANG_PATH/qbittorrent_nb.ts \
-    $$LANG_PATH/qbittorrent_fi.ts \
-    $$LANG_PATH/qbittorrent_da.ts \
-    $$LANG_PATH/qbittorrent_ja.ts \
-    $$LANG_PATH/qbittorrent_hu.ts \
-    $$LANG_PATH/qbittorrent_pt_BR.ts \
-    $$LANG_PATH/qbittorrent_cs.ts \
-    $$LANG_PATH/qbittorrent_sr.ts \
-    $$LANG_PATH/qbittorrent_ar.ts \
-    $$LANG_PATH/qbittorrent_hr.ts \
-    $$LANG_PATH/qbittorrent_gl.ts \
-    $$LANG_PATH/qbittorrent_hy.ts \
-    $$LANG_PATH/qbittorrent_lt.ts \
-    $$LANG_PATH/qbittorrent_ka.ts \
-    $$LANG_PATH/qbittorrent_be.ts \
-    $$LANG_PATH/qbittorrent_eu.ts \
-    $$LANG_PATH/qbittorrent_he.ts \
-    $$LANG_PATH/qbittorrent_vi.ts \
-    $$LANG_PATH/qbittorrent_hi_IN.ts
+TRANSLATIONS += $$files(lang/qbittorrent_*.ts)
 
 DESTDIR = .


### PR DESCRIPTION
See: https://blog.travis-ci.com/2016-05-03-caches-are-coming-to-everyone

* Suppress warning on OSX builds: only Qt4 builds are affected: https://travis-ci.org/qbittorrent/qBittorrent/jobs/127618787#L331
* Use POSIX shell since the script doesn't require bash-specific functions.
* Enable CI cache: linux builds are working as expected. ~~For OSX builds, Qt4 builds are working, *Qt5 builds doesn't seem to fully utilize ccache*, not sure why.~~  Update: OSX builds are also working now.
* Use qmake built-in test function `files` to locate translation files