### PR TITLE
Initial implementation of category options

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -162,7 +162,7 @@ namespace BitTorrent
         uint nbErrored = 0;
     };
 
-    class Session : public QObject
+    class Session: public QObject
     {
         Q_OBJECT
         Q_DISABLE_COPY(Session)
@@ -190,11 +190,12 @@ namespace BitTorrent
         static bool isValidCategoryName(const QString &name);
         // returns category itself and all top level categories
         static QStringList expandCategory(const QString &category);
+        static QString getParentCategory(const QString &category);
 
         QStringList categories() const;
-        QString categorySavePath(const QString &categoryName) const;
-        bool addCategory(const QString &name, const QString &savePath = "");
-        bool editCategory(const QString &name, const QString &savePath);
+        QString getCategorySavePath(const QString &categoryName) const;
+        bool addCategory(const QString &name);
+        void saveCategory(const QString &name);
         bool removeCategory(const QString &name);
         bool isSubcategoriesEnabled() const;
         void setSubcategoriesEnabled(bool value);
@@ -219,6 +220,25 @@ namespace BitTorrent
         bool isDisableASMWhenCategorySavePathChanged() const;
         void setDisableASMWhenCategorySavePathChanged(bool value);
 
+        void setCategorySavePath(const QString &categoryName, const QString &value);
+        bool isCategoryDownloadsSettingsEnabled(const QString &categoryName) const;
+        void setCategoryDownloadsSettingsEnabled(const QString &categoryName, bool value);
+        bool hasCategoryDownloadFirstLastPiecePriority(const QString &categoryName) const;
+        void setCategoryDownloadFirstAndLastPieceFirstEnabled(const QString &categoryName, bool value);
+        bool isCategoryDownloadSequential(const QString &categoryName) const;
+        void setCategoryDownloadSequential(const QString &categoryName, bool value);
+        bool isCategoryBandwidthSettingsEnabled(const QString &categoryName) const;
+        void setCategoryBandwidthSettingsEnabled(const QString &categoryName, bool value);
+        int getCategoryDownloadLimit(const QString &categoryName) const;
+        void setCategoryDownloadLimit(const QString &categoryName, int value);
+        int getCategoryUploadLimit(const QString &categoryName) const;
+        void setCategoryUploadLimit(const QString &categoryName, int value);
+        bool isCategoryRatioSettingsEnabled(const QString &categoryName) const;
+        void setCategoryRatioSettingsEnabled(const QString &categoryName, bool value);
+        int getCategoryRatioLimitType(const QString &categoryName) const;
+        void setCategoryRatioLimitType(const QString &categoryName, int value);
+        qreal getCategoryRatioLimit(const QString &categoryName) const;
+        void setCategoryRatioLimit(const QString &categoryName, qreal value);
         bool isAddTorrentPaused() const;
         void setAddTorrentPaused(bool value);
 
@@ -391,6 +411,9 @@ namespace BitTorrent
         void dispatchAlerts(std::auto_ptr<libtorrent::alert> alertPtr);
         void getPendingAlerts(QVector<libtorrent::alert *> &out, ulong time = 0);
 
+        QVariant getCategoryProperty(const QString &categoryName, const QString &propertyName) const;
+        void setCategoryProperty(const QString &categoryName, const QString &propertyName, const QVariant &value);
+
         SettingsStorage *m_settings;
 
         // BitTorrent
@@ -435,7 +458,7 @@ namespace BitTorrent
         QHash<InfoHash, AddTorrentData> m_addingTorrents;
         QHash<QString, AddTorrentParams> m_downloadedTorrents;
         TorrentStatusReport m_torrentStatusReport;
-        QStringMap m_categories;
+        QVariantMap m_categories;
 
         QMutex m_alertsMutex;
         QWaitCondition m_alertsWaitCondition;

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -74,8 +74,7 @@ AddTorrentData::AddTorrentData()
     , hasSeedStatus(false)
     , skipChecking(false)
     , ratioLimit(TorrentHandle::USE_GLOBAL_RATIO)
-{
-}
+{}
 
 AddTorrentData::AddTorrentData(const AddTorrentParams &params)
     : resumed(false)
@@ -90,15 +89,13 @@ AddTorrentData::AddTorrentData(const AddTorrentParams &params)
     , addPaused(params.addPaused)
     , filePriorities(params.filePriorities)
     , ratioLimit(params.ignoreShareRatio ? TorrentHandle::NO_RATIO_LIMIT : TorrentHandle::USE_GLOBAL_RATIO)
-{
-}
+{}
 
 // TorrentState
 
 TorrentState::TorrentState(int value)
     : m_value(value)
-{
-}
+{}
 
 QString TorrentState::toString() const
 {
@@ -193,7 +190,7 @@ const qreal TorrentHandle::NO_RATIO_LIMIT = -1.;
 const qreal TorrentHandle::MAX_RATIO = 9999.;
 
 TorrentHandle::TorrentHandle(Session *session, const libtorrent::torrent_handle &nativeHandle,
-                                     const AddTorrentData &data)
+                             const AddTorrentData &data)
     : QObject(session)
     , m_session(session)
     , m_nativeHandle(nativeHandle)
@@ -211,7 +208,7 @@ TorrentHandle::TorrentHandle(Session *session, const libtorrent::torrent_handle 
     , m_needSaveResumeData(false)
 {
     if (m_useASM)
-        m_savePath = Utils::Fs::toNativePath(m_session->categorySavePath(m_category));
+        m_savePath = Utils::Fs::toNativePath(m_session->getCategorySavePath(m_category));
 
     updateStatus();
     m_hash = InfoHash(m_nativeStatus.info_hash);
@@ -339,7 +336,7 @@ void TorrentHandle::setASMEnabled(bool enabled)
     m_session->handleTorrentSavingModeChanged(this);
 
     if (m_useASM)
-        move_impl(m_session->categorySavePath(m_category));
+        move_impl(m_session->getCategorySavePath(m_category));
 }
 
 QString TorrentHandle::nativeActualSavePath() const
@@ -367,10 +364,9 @@ QHash<QString, TrackerInfo> TorrentHandle::trackerInfos() const
 void TorrentHandle::addTrackers(const QList<TrackerEntry> &trackers)
 {
     QList<TrackerEntry> addedTrackers;
-    foreach (const TrackerEntry &tracker, trackers) {
+    foreach (const TrackerEntry &tracker, trackers)
         if (addTracker(tracker))
             addedTrackers << tracker;
-    }
 
     if (!addedTrackers.isEmpty())
         m_session->handleTorrentTrackersAdded(this, addedTrackers);
@@ -431,10 +427,9 @@ QList<QUrl> TorrentHandle::urlSeeds() const
 void TorrentHandle::addUrlSeeds(const QList<QUrl> &urlSeeds)
 {
     QList<QUrl> addedUrlSeeds;
-    foreach (const QUrl &urlSeed, urlSeeds) {
+    foreach (const QUrl &urlSeed, urlSeeds)
         if (addUrlSeed(urlSeed))
             addedUrlSeeds << urlSeed;
-    }
 
     if (!addedUrlSeeds.isEmpty())
         m_session->handleTorrentUrlSeedsAdded(this, addedUrlSeeds);
@@ -443,10 +438,9 @@ void TorrentHandle::addUrlSeeds(const QList<QUrl> &urlSeeds)
 void TorrentHandle::removeUrlSeeds(const QList<QUrl> &urlSeeds)
 {
     QList<QUrl> removedUrlSeeds;
-    foreach (const QUrl &urlSeed, urlSeeds) {
+    foreach (const QUrl &urlSeed, urlSeeds)
         if (removeUrlSeed(urlSeed))
             removedUrlSeeds << urlSeed;
-    }
 
     if (!removedUrlSeeds.isEmpty())
         m_session->handleTorrentUrlSeedsRemoved(this, removedUrlSeeds);
@@ -554,7 +548,7 @@ QString TorrentHandle::filePath(int index) const
 
 QString TorrentHandle::fileName(int index) const
 {
-    if (!hasMetadata()) return  QString();
+    if (!hasMetadata()) return QString();
     return Utils::Fs::fileName(filePath(index));
 }
 
@@ -567,7 +561,7 @@ qlonglong TorrentHandle::fileSize(int index) const
 // to all files in a torrent
 QStringList TorrentHandle::absoluteFilePaths() const
 {
-    if (!hasMetadata()) return  QStringList();
+    if (!hasMetadata()) return QStringList();
 
     QDir saveDir(savePath(true));
     QStringList res;
@@ -578,7 +572,7 @@ QStringList TorrentHandle::absoluteFilePaths() const
 
 QStringList TorrentHandle::absoluteFilePathsUnwanted() const
 {
-    if (!hasMetadata()) return  QStringList();
+    if (!hasMetadata()) return QStringList();
 
     QDir saveDir(savePath(true));
     QStringList res;
@@ -654,31 +648,31 @@ bool TorrentHandle::isChecking() const
 bool TorrentHandle::isDownloading() const
 {
     return m_state == TorrentState::Downloading
-            || m_state == TorrentState::DownloadingMetadata
-            || m_state == TorrentState::StalledDownloading
-            || m_state == TorrentState::CheckingDownloading
-            || m_state == TorrentState::PausedDownloading
-            || m_state == TorrentState::QueuedDownloading
-            || m_state == TorrentState::ForcedDownloading;
+           || m_state == TorrentState::DownloadingMetadata
+           || m_state == TorrentState::StalledDownloading
+           || m_state == TorrentState::CheckingDownloading
+           || m_state == TorrentState::PausedDownloading
+           || m_state == TorrentState::QueuedDownloading
+           || m_state == TorrentState::ForcedDownloading;
 }
 
 bool TorrentHandle::isUploading() const
 {
     return m_state == TorrentState::Uploading
-            || m_state == TorrentState::StalledUploading
-            || m_state == TorrentState::CheckingUploading
-            || m_state == TorrentState::QueuedUploading
-            || m_state == TorrentState::ForcedUploading;
+           || m_state == TorrentState::StalledUploading
+           || m_state == TorrentState::CheckingUploading
+           || m_state == TorrentState::QueuedUploading
+           || m_state == TorrentState::ForcedUploading;
 }
 
 bool TorrentHandle::isCompleted() const
 {
     return m_state == TorrentState::Uploading
-            || m_state == TorrentState::StalledUploading
-            || m_state == TorrentState::CheckingUploading
-            || m_state == TorrentState::PausedUploading
-            || m_state == TorrentState::QueuedUploading
-            || m_state == TorrentState::ForcedUploading;
+           || m_state == TorrentState::StalledUploading
+           || m_state == TorrentState::CheckingUploading
+           || m_state == TorrentState::PausedUploading
+           || m_state == TorrentState::QueuedUploading
+           || m_state == TorrentState::ForcedUploading;
 }
 
 bool TorrentHandle::isActive() const
@@ -687,10 +681,10 @@ bool TorrentHandle::isActive() const
         return (uploadPayloadRate() > 0);
 
     return m_state == TorrentState::DownloadingMetadata
-            || m_state == TorrentState::Downloading
-            || m_state == TorrentState::ForcedDownloading
-            || m_state == TorrentState::Uploading
-            || m_state == TorrentState::ForcedUploading;
+           || m_state == TorrentState::Downloading
+           || m_state == TorrentState::ForcedDownloading
+           || m_state == TorrentState::Uploading
+           || m_state == TorrentState::ForcedUploading;
 }
 
 bool TorrentHandle::isInactive() const
@@ -701,15 +695,15 @@ bool TorrentHandle::isInactive() const
 bool TorrentHandle::isErrored() const
 {
     return m_state == TorrentState::MissingFiles
-            || m_state == TorrentState::Error;
+           || m_state == TorrentState::Error;
 }
 
 bool TorrentHandle::isSeed() const
 {
     // Affected by bug http://code.rasterbar.com/libtorrent/ticket/402
-    //SAFE_RETURN(bool, is_seed, false);
+    // SAFE_RETURN(bool, is_seed, false);
     // May suffer from approximation problems
-    //return (progress() == 1.);
+    // return (progress() == 1.);
     // This looks safe
     return ((m_nativeStatus.state == libt::torrent_status::finished)
             || (m_nativeStatus.state == libt::torrent_status::seeding));
@@ -1066,10 +1060,8 @@ qreal TorrentHandle::maxRatio(bool *usesGlobalRatio) const
         if (usesGlobalRatio)
             *usesGlobalRatio = true;
     }
-    else {
-        if (usesGlobalRatio)
-            *usesGlobalRatio = false;
-    }
+    else if (usesGlobalRatio)
+        *usesGlobalRatio = false;
 
     return ratioLimit;
 }
@@ -1151,10 +1143,17 @@ bool TorrentHandle::setCategory(const QString &category)
         m_session->handleTorrentCategoryChanged(this, oldCategory);
 
         if (m_useASM) {
-            if (!m_session->isDisableASMWhenCategoryChanged())
-                move_impl(m_session->categorySavePath(m_category));
-            else
+            if (!m_session->isDisableASMWhenCategoryChanged()) {
+                move_impl(m_session->getCategorySavePath(m_category));
+                setFirstLastPiecePriority(m_session->hasCategoryDownloadFirstLastPiecePriority(category));
+                setSequentialDownload(m_session->isCategoryDownloadSequential(category));
+                setDownloadLimit(m_session->getCategoryDownloadLimit(category));
+                setUploadLimit(m_session->getCategoryUploadLimit(category));
+                setRatioLimit(m_session->getCategoryRatioLimit(category));
+            }
+            else {
                 setASMEnabled(false);
+            }
         }
     }
 
@@ -1494,7 +1493,7 @@ void TorrentHandle::handleTorrentFinishedAlert(libtorrent::torrent_finished_aler
     manageIncompleteFiles();
 
     const bool recheckTorrentsOnCompletion = Preferences::instance()->recheckTorrentsOnCompletion();
-    if (isMoveInProgress() || m_renameCount > 0) {
+    if (isMoveInProgress() || (m_renameCount > 0)) {
         if (recheckTorrentsOnCompletion)
             m_moveFinishedTriggers.append(boost::bind(&TorrentHandle::forceRecheck, this));
         m_moveFinishedTriggers.append(boost::bind(&Session::handleTorrentFinished, m_session, this));
@@ -1628,7 +1627,7 @@ void TorrentHandle::handleStatsAlert(libtorrent::stats_alert *p)
 {
     Q_ASSERT(p->interval >= 1000);
     SpeedSample transferred(p->transferred[libt::stats_alert::download_payload] * 1000LL / p->interval,
-            p->transferred[libt::stats_alert::upload_payload] * 1000LL / p->interval);
+                            p->transferred[libt::stats_alert::upload_payload] * 1000LL / p->interval);
     m_speedMonitor.addSample(transferred);
 }
 
@@ -1657,7 +1656,7 @@ void TorrentHandle::handleTempPathChanged()
 void TorrentHandle::handleCategorySavePathChanged()
 {
     if (m_useASM)
-        move_impl(m_session->categorySavePath(m_category));
+        move_impl(m_session->getCategorySavePath(m_category));
 }
 
 void TorrentHandle::handleAppendExtensionToggled()

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -65,6 +65,7 @@ transferlistfilterswidget.h
 transferlistsortmodel.h
 transferlistwidget.h
 updownratiodlg.h
+categoryoptionsdialog.h
 )
 
 set(QBT_GUI_SOURCES
@@ -100,6 +101,7 @@ transferlistfilterswidget.cpp
 transferlistsortmodel.cpp
 transferlistwidget.cpp
 updownratiodlg.cpp
+categoryoptionsdialog.cpp
 )
 
 if (WIN32 OR APPLE)
@@ -124,6 +126,7 @@ statsdialog.ui
 options.ui
 torrentcreatordlg.ui
 shutdownconfirmdlg.ui
+categoryoptionsdialog.ui
 )
 
 qbt_target_sources(about.qrc)

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -397,7 +397,7 @@ void AddNewTorrentDialog::categoryChanged(int index)
     Q_UNUSED(index);
 
     if (ui->advancedModeRadioButton->isChecked()) {
-        QString savePath = BitTorrent::Session::instance()->categorySavePath(ui->categoryComboBox->currentText());
+        QString savePath = BitTorrent::Session::instance()->getCategorySavePath(ui->categoryComboBox->currentText());
         ui->savePathComboBox->setItemText(0, Utils::Fs::toNativePath(savePath));
         ui->savePathComboBox->setItemData(0, savePath);
     }
@@ -777,7 +777,7 @@ void AddNewTorrentDialog::savingModeChanged(bool enabled)
     else {
         ui->savePathComboBox->blockSignals(true);
         ui->savePathComboBox->clear();
-        QString savePath = BitTorrent::Session::instance()->categorySavePath(ui->categoryComboBox->currentText());
+        QString savePath = BitTorrent::Session::instance()->getCategorySavePath(ui->categoryComboBox->currentText());
         ui->savePathComboBox->addItem(Utils::Fs::toNativePath(savePath), savePath);
         ui->savePathComboBox->setEnabled(false);
         ui->browseButton->setEnabled(false);

--- a/src/gui/categoryoptionsdialog.cpp
+++ b/src/gui/categoryoptionsdialog.cpp
@@ -1,0 +1,158 @@
+#include <QFileDialog>
+#include <QMessageBox>
+
+#include "base/bittorrent/session.h"
+#include "base/preferences.h"
+#include "base/bittorrent/torrenthandle.h"
+#include "base/unicodestrings.h"
+#include "base/utils/fs.h"
+#include "categoryoptionsdialog.h"
+#include "ui_categoryoptionsdialog.h"
+
+CategoryOptionsDialog::CategoryOptionsDialog(QString category, QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::CategoryOptionsDialog),
+    m_category(category)
+{
+    ui->setupUi(this);
+    m_path = BitTorrent::Session::instance()->getCategorySavePath(category);
+    m_ratioLimitType = BitTorrent::Session::instance()->getCategoryRatioLimitType(m_category);
+    setWindowTitle(category + " Category Options");
+    ui->downloadPath->setText(Utils::Fs::toNativePath(m_path));
+    ui->downloadsBox->setChecked(BitTorrent::Session::instance()->isCategoryDownloadsSettingsEnabled(m_category));
+    ui->firstLastPiecePriorityBox->setChecked(
+        BitTorrent::Session::instance()->hasCategoryDownloadFirstLastPiecePriority(m_category));
+    ui->sequentialOrderBox->setChecked(BitTorrent::Session::instance()->isCategoryDownloadSequential(m_category));
+    ui->bandwidthBox->setChecked(BitTorrent::Session::instance()->isCategoryBandwidthSettingsEnabled(m_category));
+
+    int maxDownloadSlider = Preferences::instance()->getGlobalDownloadLimit() / 1024;
+    int downloadLimitInKb = BitTorrent::Session::instance()->getCategoryDownloadLimit(m_category) / 1024;
+    int upload_limit_in_kb = BitTorrent::Session::instance()->getCategoryUploadLimit(m_category) / 1024;
+    if (maxDownloadSlider < 1000)
+        maxDownloadSlider = 1000;
+    if (maxDownloadSlider < downloadLimitInKb)
+        maxDownloadSlider = downloadLimitInKb;
+
+    int maxUploadSlider = Preferences::instance()->getGlobalUploadLimit() / 1024;
+    if (maxUploadSlider < 1000)
+        maxUploadSlider = 1000;
+    if (maxUploadSlider < upload_limit_in_kb)
+        maxUploadSlider = upload_limit_in_kb;
+
+    ui->downloadSlider->setMaximum(maxDownloadSlider);
+    ui->uploadSlider->setMaximum(maxUploadSlider);
+    ui->downloadSlider->setValue(downloadLimitInKb);
+    ui->uploadSlider->setValue(upload_limit_in_kb);
+    CategoryOptionsDialog::updateSpinValue(ui->spinDownload, downloadLimitInKb);
+    CategoryOptionsDialog::updateSpinValue(ui->spinUpload, upload_limit_in_kb);
+
+    ui->ratioBox->setChecked(BitTorrent::Session::instance()->isCategoryRatioSettingsEnabled(m_category));
+    ui->ratioSpin->setEnabled(BitTorrent::Session::instance()->getCategoryRatioLimitType(m_category) == 3);
+    ui->ratioSpin->setMinimum(0);
+    ui->ratioSpin->setMaximum(BitTorrent::TorrentHandle::MAX_RATIO);
+    ui->ratioSpin->setValue(BitTorrent::Session::instance()->getCategoryRatioLimit(m_category));
+    ui->ratioButtonGroup->setId(ui->globalRatioLimitRadio, 0);
+    ui->ratioButtonGroup->setId(ui->noRatioLimitRadio, 1);
+    ui->ratioButtonGroup->setId(ui->specificRatioLimitRadio, 2);
+    ui->ratioButtonGroup->button(m_ratioLimitType)->setChecked(true);
+
+    connect(ui->downloadSlider, SIGNAL(valueChanged(int)), this, SLOT(updateDownloadSpinValue(int)));
+    connect(ui->spinDownload, SIGNAL(valueChanged(int)), this, SLOT(updateDownloadSliderValue(int)));
+    connect(ui->uploadSlider, SIGNAL(valueChanged(int)), this, SLOT(updateUploadSpinValue(int)));
+    connect(ui->spinUpload, SIGNAL(valueChanged(int)), this, SLOT(updateUploadSliderValue(int)));
+    connect(ui->ratioButtonGroup, SIGNAL(buttonClicked(int)), this, SLOT(ratioLimitTypeChanged(int)));
+}
+
+CategoryOptionsDialog::~CategoryOptionsDialog()
+{
+    delete ui;
+}
+
+void CategoryOptionsDialog::on_browseButton_clicked()
+{
+    QDir pathDir(m_path);
+    QString dir;
+    if (!m_path.isEmpty() && pathDir.exists())
+        dir = QFileDialog::getExistingDirectory(this, tr("Choose a download directory"), pathDir.absolutePath());
+    else
+        dir = QFileDialog::getExistingDirectory(this, tr("Choose a download directory"), QDir::homePath());
+    if (dir.isEmpty()) return;
+    m_path = dir;
+    ui->downloadPath->setText(Utils::Fs::toNativePath(dir));
+}
+
+void CategoryOptionsDialog::on_buttonBox_accepted()
+{
+    if (!BitTorrent::Session::instance()->categories().contains(m_category)) return;
+    BitTorrent::Session::instance()->setCategoryDownloadsSettingsEnabled(m_category, ui->downloadsBox->isChecked());
+    if (ui->downloadsBox->isChecked()) {
+        BitTorrent::Session::instance()->setCategorySavePath(m_category, m_path);
+        BitTorrent::Session::instance()->setCategoryDownloadFirstAndLastPieceFirstEnabled(m_category,
+                                                                                          ui->firstLastPiecePriorityBox->isChecked());
+        BitTorrent::Session::instance()->setCategoryDownloadSequential(m_category, ui->sequentialOrderBox->isChecked());
+    }
+    BitTorrent::Session::instance()->setCategoryBandwidthSettingsEnabled(m_category, ui->bandwidthBox->isChecked());
+    if (ui->bandwidthBox->isChecked()) {
+        BitTorrent::Session::instance()->setCategoryDownloadLimit(m_category, (ui->downloadSlider->value() > 0) ?
+                                                                  ui->downloadSlider->value() * 1024 : -1);
+        BitTorrent::Session::instance()->setCategoryUploadLimit(m_category, (ui->uploadSlider->value() > 0) ?
+                                                                ui->uploadSlider->value() * 1024 : -1);
+    }
+    BitTorrent::Session::instance()->setCategoryRatioSettingsEnabled(m_category, ui->ratioBox->isChecked());
+    if (ui->ratioBox->isChecked()) {
+        BitTorrent::Session::instance()->setCategoryRatioLimitType(m_category, m_ratioLimitType);
+        BitTorrent::Session::instance()->setCategoryRatioLimit(m_category, ui->ratioSpin->value());
+    }
+    BitTorrent::Session::instance()->saveCategory(m_category);
+}
+
+void CategoryOptionsDialog::updateSpinValue(QSpinBox *box, int val) const
+{
+    if (val <= 0) {
+        box->setValue(0);
+        box->setSpecialValueText(QString::fromUtf8(C_INFINITY));
+        box->setSuffix(QString::fromUtf8(""));
+    }
+    else {
+        box->setValue(val);
+        box->setSuffix(" " + tr("KiB/s"));
+    }
+}
+
+void CategoryOptionsDialog::updateSliderValue(QSpinBox *box, QSlider *slider, int val) const
+{
+    if (val <= 0) {
+        box->setValue(0);
+        box->setSpecialValueText(QString::fromUtf8(C_INFINITY));
+        box->setSuffix(QString::fromUtf8(""));
+    }
+    if (val > slider->maximum())
+        slider->setMaximum(val);
+    slider->setValue(val);
+}
+
+void CategoryOptionsDialog::updateDownloadSpinValue(int val) const
+{
+    CategoryOptionsDialog::updateSpinValue(ui->spinDownload, val);
+}
+
+void CategoryOptionsDialog::updateDownloadSliderValue(int val) const
+{
+    CategoryOptionsDialog::updateSliderValue(ui->spinDownload, ui->downloadSlider, val);
+}
+
+void CategoryOptionsDialog::updateUploadSpinValue(int val) const
+{
+    CategoryOptionsDialog::updateSpinValue(ui->spinUpload, val);
+}
+
+void CategoryOptionsDialog::updateUploadSliderValue(int val) const
+{
+    CategoryOptionsDialog::updateSliderValue(ui->spinUpload, ui->uploadSlider, val);
+}
+
+void CategoryOptionsDialog::ratioLimitTypeChanged(int id)
+{
+    ui->ratioSpin->setEnabled(ui->ratioButtonGroup->id(ui->specificRatioLimitRadio) == id);
+    m_ratioLimitType = id;
+}

--- a/src/gui/categoryoptionsdialog.h
+++ b/src/gui/categoryoptionsdialog.h
@@ -1,0 +1,41 @@
+#ifndef CATEGORYOPTIONSDIALOG_H
+#define CATEGORYOPTIONSDIALOG_H
+
+#include <QDialog>
+#include <QtWidgets/QSpinBox>
+#include <QtWidgets/QSlider>
+
+QT_BEGIN_NAMESPACE
+namespace Ui
+{
+    class CategoryOptionsDialog;
+}
+QT_END_NAMESPACE
+
+class CategoryOptionsDialog: public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit CategoryOptionsDialog(QString category, QWidget *parent = 0);
+    ~CategoryOptionsDialog();
+
+protected slots:
+    void on_browseButton_clicked();
+    void on_buttonBox_accepted();
+    void updateSpinValue(QSpinBox *box, int val) const; // consider making a util method to share with speed dialog
+    void updateSliderValue(QSpinBox *box, QSlider *slider, int val) const; // consider making a util method to share with speed dialog
+    void updateDownloadSpinValue(int val) const;
+    void updateDownloadSliderValue(int val) const;
+    void updateUploadSpinValue(int val) const;
+    void updateUploadSliderValue(int val) const;
+    void ratioLimitTypeChanged(int id);
+
+private:
+    Ui::CategoryOptionsDialog *ui;
+    QString m_path;
+    QString m_category;
+    int m_ratioLimitType;
+};
+
+#endif // CATEGORYOPTIONSDIALOG_H

--- a/src/gui/categoryoptionsdialog.ui
+++ b/src/gui/categoryoptionsdialog.ui
@@ -1,0 +1,360 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CategoryOptionsDialog</class>
+ <widget class="QDialog" name="CategoryOptionsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="downloadsTab">
+      <attribute name="title">
+       <string>Downloads</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <widget class="QGroupBox" name="downloadsBox">
+         <property name="title">
+          <string>Enable downloads settings</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <item>
+           <widget class="QCheckBox" name="sequentialOrderBox">
+            <property name="text">
+             <string>Download in sequential order</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="firstLastPiecePriorityBox">
+            <property name="text">
+             <string>Download first and last pieces first</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+             <widget class="QLabel" name="label">
+              <property name="text">
+               <string>Download to:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="downloadPath">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>1</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QToolButton" name="browseButton">
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>25</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>...</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <spacer name="verticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="bandwidthTab">
+      <attribute name="title">
+       <string>Bandwidth</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_7">
+       <item>
+        <widget class="QGroupBox" name="bandwidthBox">
+         <property name="title">
+          <string>Enable bandwidth settings</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_6">
+          <item>
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Max download speed:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <item>
+             <widget class="QSlider" name="downloadSlider">
+              <property name="minimum">
+               <number>0</number>
+              </property>
+              <property name="maximum">
+               <number>1000</number>
+              </property>
+              <property name="sliderPosition">
+               <number>0</number>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="spinDownload">
+              <property name="suffix">
+               <string/>
+              </property>
+              <property name="maximum">
+               <number>65535</number>
+              </property>
+              <property name="value">
+               <number>0</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>Max upload speed:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <item>
+             <widget class="QSlider" name="uploadSlider">
+              <property name="minimum">
+               <number>0</number>
+              </property>
+              <property name="maximum">
+               <number>1000</number>
+              </property>
+              <property name="sliderPosition">
+               <number>0</number>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="spinUpload">
+              <property name="suffix">
+               <string/>
+              </property>
+              <property name="maximum">
+               <number>65535</number>
+              </property>
+              <property name="value">
+               <number>0</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="ratioTab">
+      <attribute name="title">
+       <string>Ratio</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QGroupBox" name="ratioBox">
+         <property name="title">
+          <string>Enable ratio settings</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_5">
+          <item>
+           <widget class="QRadioButton" name="globalRatioLimitRadio">
+            <property name="text">
+             <string>Use global ratio limit</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+            <attribute name="buttonGroup">
+             <string notr="true">ratioButtonGroup</string>
+            </attribute>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="noRatioLimitRadio">
+            <property name="text">
+             <string>Set no ratio limit</string>
+            </property>
+            <attribute name="buttonGroup">
+             <string notr="true">ratioButtonGroup</string>
+            </attribute>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
+            <item>
+             <widget class="QRadioButton" name="specificRatioLimitRadio">
+              <property name="text">
+               <string>Set ratio limit to:</string>
+              </property>
+              <attribute name="buttonGroup">
+               <string notr="true">ratioButtonGroup</string>
+              </attribute>
+             </widget>
+            </item>
+            <item>
+             <widget class="QDoubleSpinBox" name="ratioSpin"/>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>CategoryOptionsDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>CategoryOptionsDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <buttongroups>
+  <buttongroup name="ratioButtonGroup"/>
+ </buttongroups>
+</ui>

--- a/src/gui/gui.pri
+++ b/src/gui/gui.pri
@@ -49,7 +49,8 @@ HEADERS += \
     $$PWD/search/searchlistdelegate.h \
     $$PWD/search/searchsortmodel.h \
     $$PWD/cookiesmodel.h \
-    $$PWD/cookiesdialog.h
+    $$PWD/cookiesdialog.h \
+    $$PWD/categoryoptionsdialog.h
 
 SOURCES += \
     $$PWD/mainwindow.cpp \
@@ -89,7 +90,8 @@ SOURCES += \
     $$PWD/search/searchlistdelegate.cpp \
     $$PWD/search/searchsortmodel.cpp \
     $$PWD/cookiesmodel.cpp \
-    $$PWD/cookiesdialog.cpp
+    $$PWD/cookiesdialog.cpp \
+    $$PWD/categoryoptionsdialog.cpp
 
 win32|macx {
     HEADERS += $$PWD/programupdater.h
@@ -116,6 +118,7 @@ FORMS += \
     $$PWD/search/pluginselectdlg.ui \
     $$PWD/search/pluginsourcedlg.ui \
     $$PWD/search/searchtab.ui \
-    $$PWD/cookiesdialog.ui
+    $$PWD/cookiesdialog.ui \
+    $$PWD/categoryoptionsdialog.ui
 
 RESOURCES += $$PWD/about.qrc

--- a/src/gui/transferlistfilterswidget.h
+++ b/src/gui/transferlistfilterswidget.h
@@ -102,6 +102,7 @@ private slots:
     void addItem(const QString &category, bool hasTorrent = false);
     void removeItem(const QString &category);
     void removeSelectedCategory();
+    void editSelectedCategoryOptions();
     void removeUnusedCategories();
     void torrentCategoryChanged(BitTorrent::TorrentHandle *const torrent, const QString &oldCategory);
     void categoryRemoved(const QString &category);


### PR DESCRIPTION
As discussed in #5201, this is the first PR with the initial implementation of the category options.
Things done:
- download tab:
  - setting download path explicitly
  - setting download in sequential order
  - setting download first and last piece first
- bandwidth tab:
  - setting maximum upload and download speeds to every torrent in category
- ratio tab:
  - setting ratio limit to global, none, or specified one to every torrent in category

All files have been uncrustified with the provided cfg file and includes follow the guidelines (to the best of my knowledge).
