### PR TITLE
Set about tab font-size to default

### DIFF
--- a/src/gui/about.ui
+++ b/src/gui/about.ui
@@ -71,11 +71,6 @@
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="font">
-          <font>
-           <pointsize>11</pointsize>
-          </font>
-         </property>
          <property name="textFormat">
           <enum>Qt::RichText</enum>
          </property>


### PR DESCRIPTION
Adjust about tab font-size to match other tabs of about dialog.

Before:

![old](https://cloud.githubusercontent.com/assets/4026304/15068356/9263f082-136e-11e6-92d7-5eabdc5b0d24.png) 

After:

![new](https://cloud.githubusercontent.com/assets/4026304/15068365/abedde0a-136e-11e6-98e3-b90228dd27ac.png)

