### PR TITLE
Fix "IP Filtering - Apply to trackers" wasn't being applied

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -675,6 +675,8 @@ void Session::setSessionSettings()
         sessionSettings.force_proxy = false;
     sessionSettings.no_connect_privileged_ports = false;
     sessionSettings.seed_choking_algorithm = libt::session_settings::fastest_upload;
+
+    sessionSettings.apply_ip_filter_to_trackers = pref->isFilteringTrackerEnabled();
     qDebug() << "Set session settings";
     m_nativeSession->set_settings(sessionSettings);
 }

--- a/src/gui/options_imp.cpp
+++ b/src/gui/options_imp.cpp
@@ -545,13 +545,12 @@ void options_imp::saveOptions()
     pref->setGlobalMaxRatio(getMaxRatio());
     session->setMaxRatioAction(static_cast<MaxRatioAction>(comboRatioLimitAct->currentIndex()));
     // End Bittorrent preferences
+
     // Misc preferences
     // * IPFilter
     pref->setFilteringEnabled(isFilteringEnabled());
-    if (isFilteringEnabled()) {
-        pref->setFilteringTrackerEnabled(checkIpFilterTrackers->isChecked());
-        pref->setFilter(textFilterPath->text());
-    }
+    pref->setFilteringTrackerEnabled(checkIpFilterTrackers->isChecked());
+    pref->setFilter(textFilterPath->text());
     // End IPFilter preferences
     // Queueing system
     pref->setQueueingSystemEnabled(isQueueingSystemEnabled());


### PR DESCRIPTION
The session setting got lost during refactor.