### PR TITLE
Fix sorting in peerlistwidget after #3908. Closes #5238.

### DIFF
--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -87,7 +87,6 @@ PeerListWidget::PeerListWidget(PropertiesWidget *parent)
     m_proxyModel = new PeerListSortModel();
     m_proxyModel->setDynamicSortFilter(true);
     m_proxyModel->setSourceModel(m_listModel);
-    m_proxyModel->setSortCaseSensitivity(Qt::CaseInsensitive);
     setModel(m_proxyModel);
     hideColumn(PeerListDelegate::IP_HIDDEN);
     hideColumn(PeerListDelegate::COL_COUNT);
@@ -126,7 +125,7 @@ PeerListWidget::PeerListWidget(PropertiesWidget *parent)
     connect(header(), SIGNAL(sectionClicked(int)), SLOT(handleSortColumnChanged(int)));
     handleSortColumnChanged(header()->sortIndicatorSection());
     m_copyHotkey = new QShortcut(QKeySequence(Qt::ControlModifier + Qt::Key_C), this, SLOT(copySelectedPeers()), 0, Qt::WidgetShortcut);
-	
+
 #ifdef QBT_USES_QT5
     // This hack fixes reordering of first column with Qt5.
     // https://github.com/qtproject/qtbase/commit/e0fc088c0c8bc61dbcaf5928b24986cd61a22777


### PR DESCRIPTION
Aside from fixing #5238, also put list entries with empty field at the bottom of the list (no matter the sort order).

for example, download speed old:
![old](https://cloud.githubusercontent.com/assets/9395168/15135702/f64b7a44-16ab-11e6-907a-f2a920eacd9a.png)
new:
![new](https://cloud.githubusercontent.com/assets/9395168/15135703/f64bbe00-16ab-11e6-8ad6-7823779a4d27.png)
