### PR TITLE
Minor refactor in PeerListWidget

### DIFF
--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -57,7 +57,6 @@
 PeerListWidget::PeerListWidget(PropertiesWidget *parent)
     : QTreeView(parent)
     , m_properties(parent)
-    , m_resolveCountries(false)
 {
     // Load settings
     loadSettings();
@@ -91,9 +90,9 @@ PeerListWidget::PeerListWidget(PropertiesWidget *parent)
     setModel(m_proxyModel);
     hideColumn(PeerListDelegate::IP_HIDDEN);
     hideColumn(PeerListDelegate::COL_COUNT);
-    if (!Preferences::instance()->resolvePeerCountries())
+    m_resolveCountries = Preferences::instance()->resolvePeerCountries();
+    if (!m_resolveCountries)
         hideColumn(PeerListDelegate::COUNTRY);
-    m_wasCountryColHidden = isColumnHidden(PeerListDelegate::COUNTRY);
     //Ensure that at least one column is visible at all times
     bool atLeastOne = false;
     for (unsigned int i = 0; i < PeerListDelegate::IP_HIDDEN; i++) {
@@ -108,7 +107,7 @@ PeerListWidget::PeerListWidget(PropertiesWidget *parent)
     //its size is 0, because explicitly 'showing' the column isn't enough
     //in the above scenario.
     for (unsigned int i = 0; i < PeerListDelegate::IP_HIDDEN; i++)
-        if (!columnWidth(i))
+        if ((columnWidth(i) <= 0) && !isColumnHidden(i))
             resizeColumnToContents(i);
     // Context menu
     setContextMenuPolicy(Qt::CustomContextMenu);
@@ -208,14 +207,12 @@ void PeerListWidget::updatePeerCountryResolutionState()
         m_resolveCountries = !m_resolveCountries;
         if (m_resolveCountries) {
             loadPeers(m_properties->getCurrentTorrent());
-            if (!m_wasCountryColHidden) {
-                showColumn(PeerListDelegate::COUNTRY);
+            showColumn(PeerListDelegate::COUNTRY);
+            if (columnWidth(PeerListDelegate::COUNTRY) <= 0)
                 resizeColumnToContents(PeerListDelegate::COUNTRY);
-            }
         }
         else {
             hideColumn(PeerListDelegate::COUNTRY);
-            m_wasCountryColHidden = false; // to forcefully enable that column if the user decides to resolve countries again
         }
     }
 }

--- a/src/gui/properties/peerlistwidget.h
+++ b/src/gui/properties/peerlistwidget.h
@@ -94,7 +94,6 @@ private:
     QPointer<Net::ReverseResolution> m_resolver;
     PropertiesWidget *m_properties;
     bool m_resolveCountries;
-    bool m_wasCountryColHidden;
     QShortcut *m_copyHotkey;
 };
 


### PR DESCRIPTION
- ~~Removed `m_resolveCountries` as we can use `Preferences::instance()->resolvePeerCountries()` directly, i guess there was a reason for using `m_resolveCountries` so i'm waiting to be corrected.~~
- Check if a column is visible before resizing it to be able to keep the column's saved width even when we restart qbit with that column disabled. If there are no objections with this one we should do the same in `transferlistwidget` as it suffers the same problem.
- Now it doesn't resize Country column to contents on every restart (fixes part of #5236)
- Now country column is automatically shown when you enable Resolve peer countries" after a qbit restart with it disabled (had to manually show the country column from the column menu).
