### PR TITLE
Fix a typo in TorrentFileGuard and a crash when adding torrent via magnet link

### DIFF
--- a/src/base/torrentfileguard.cpp
+++ b/src/base/torrentfileguard.cpp
@@ -84,7 +84,7 @@ TorrentFileGuard::AutoDeleteMode TorrentFileGuard::autoDeleteMode()
                                                            KEY_AUTO_DELETE_ENABLED, meta.valueToKey(Never)).toByteArray()));
 }
 
-void TorrentFileGuard::setautoDeleteMode(TorrentFileGuard::AutoDeleteMode mode)
+void TorrentFileGuard::setAutoDeleteMode(TorrentFileGuard::AutoDeleteMode mode)
 {
     QMetaEnum meta {modeMetaEnum()};
     SettingsStorage::instance()->storeValue(KEY_AUTO_DELETE_ENABLED, meta.valueToKey(mode));

--- a/src/base/torrentfileguard.h
+++ b/src/base/torrentfileguard.h
@@ -68,7 +68,7 @@ public:
 
     // static interface to get/set preferences
     static AutoDeleteMode autoDeleteMode();
-    static void setautoDeleteMode(AutoDeleteMode mode);
+    static void setAutoDeleteMode(AutoDeleteMode mode);
 
 private:
     static QMetaEnum modeMetaEnum();

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -259,6 +259,7 @@ bool AddNewTorrentDialog::loadMagnet(const BitTorrent::MagnetUri &magnetUri)
         return false;
     }
 
+    m_torrentGuard.reset(new TorrentFileGuard(QString()));
     m_hash = magnetUri.hash();
     // Prevent showing the dialog if download is already present
     if (BitTorrent::Session::instance()->isKnownTorrent(m_hash)) {

--- a/src/gui/options_imp.cpp
+++ b/src/gui/options_imp.cpp
@@ -519,7 +519,7 @@ void options_imp::saveOptions()
     pref->setAutoRunProgram(autoRun_txt->text().trimmed());
     pref->setActionOnDblClOnTorrentDl(getActionOnDblClOnTorrentDl());
     pref->setActionOnDblClOnTorrentFn(getActionOnDblClOnTorrentFn());
-    TorrentFileGuard::setautoDeleteMode(!deleteTorrentBox->isChecked() ? TorrentFileGuard::Never
+    TorrentFileGuard::setAutoDeleteMode(!deleteTorrentBox->isChecked() ? TorrentFileGuard::Never
                              : !deleteCancelledTorrentBox->isChecked() ? TorrentFileGuard::IfAdded
                              : TorrentFileGuard::Always);
     // End Downloads preferences


### PR DESCRIPTION
Sorry, committed the incorrectly cased identifier.