### PR TITLE
Use libtorrent::session_handle::set_alert_notify() instead of set_alert_dispatch(). WIP

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -387,9 +387,13 @@ namespace BitTorrent
         void createTorrentHandle(const libtorrent::torrent_handle &nativeHandle);
 
         void saveResumeData();
-
+#if LIBTORRENT_VERSION_NUM >= 10100
+        void handleAlerts();
+        void waitForAlerts(ulong time = 0);
+#else
         void dispatchAlerts(std::auto_ptr<libtorrent::alert> alertPtr);
         void getPendingAlerts(QVector<libtorrent::alert *> &out, ulong time = 0);
+#endif
 
         SettingsStorage *m_settings;
 


### PR DESCRIPTION
[This commit](https://github.com/arvidn/libtorrent/pull/721/commits/19defdc47c5d81760428be0830254372a2939c7a)  removed `session_handle::set_alert_dispatch()`. 

`set_alerts_notify()` seems to be around for quite a long time.