### PR TITLE
update uncrustify config

### DIFF
--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -60,19 +60,25 @@ sp_cmt_cpp_start			= add
 sp_cmt_cpp_doxygen			= true
 sp_angle_shift				= remove
 sp_permit_cpp11_shift		= true
+sp_before_sparen			= add
+sp_after_operator			= remove
+sp_after_operator_sym		= remove
 
 sp_before_ptr_star			= add
 sp_before_byref				= add
 sp_after_ptr_star			= remove
 sp_after_byref				= remove
-sp_before_unnamed_ptr_star	= remove
-sp_before_unnamed_byref		= remove
-sp_after_ptr_star_func		= add
-sp_after_byref_func			= add
-sp_before_ptr_star_func		= remove
-sp_before_byref_func		= remove
+sp_before_unnamed_ptr_star	= add
+sp_before_unnamed_byref		= add
+sp_after_ptr_star_func		= remove
+sp_after_byref_func			= remove
+sp_before_ptr_star_func		= add
+sp_before_byref_func		= add
 
 eat_blanks_before_close_brace	= true
 
+pos_arith					= lead
+pos_conditional				= lead
 pos_constr_comma			= lead_break
 pos_constr_colon			= lead_break
+


### PR DESCRIPTION
The second one: fix pointer and ref symbols placements
The first commit: "Add or remove space before '(' of 'if', 'for', 'switch', 'while', etc.". Remove spaces in operator names, add options to place arithmetic and conditional operators at the beginning of the line in wrapped expressions.
