### PR TITLE
Don't include '/usr/include' in INCLUDEPATH as it will break building with GCC-6

### DIFF
--- a/configure
+++ b/configure
@@ -5689,6 +5689,7 @@ extract() {
   SAVEIFS=$IFS
   IFS=$(printf "\n\b")
   for i in $string; do
+    test "$i" = I/usr/include && continue
     case "$(echo "$i" | cut -c1)" in
       '') ;;
       D) QBT_CONF_DEFINES="$(echo $i | cut -c2-) $QBT_CONF_DEFINES";;

--- a/configure.ac
+++ b/configure.ac
@@ -230,6 +230,7 @@ extract() {
   SAVEIFS=$IFS
   IFS=$(printf "\n\b")
   for i in $string; do
+    test "$i" = I/usr/include && continue
     case "$(echo "$i" | cut -c1)" in
       '') ;;
       D) QBT_CONF_DEFINES="$(echo $i | cut -c2-) $QBT_CONF_DEFINES";;


### PR DESCRIPTION
Building qbittorrent with GCC-6 fails with:

```
 In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/6.1.0/include/g++-v6/bits/stl_algo.h:59:0,
                 from /usr/lib/gcc/x86_64-pc-linux-gnu/6.1.0/include/g++-v6/algorithm:62,
                 from /usr/include/qt5/QtCore/qglobal.h:85,
                 from /usr/include/qt5/QtCore/qalgorithms.h:37,
                 from /usr/include/qt5/QtCore/qlist.h:37,
                 from /usr/include/qt5/QtCore/qstringlist.h:34,
                 from /usr/include/qt5/QtCore/QStringList:1,
                 from base/http/requestparser.cpp:32:
/usr/lib/gcc/x86_64-pc-linux-gnu/6.1.0/include/g++-v6/cstdlib:75:25: fatal error: stdlib.h: No such file or directory
 #include_next <stdlib.h>
```

According to [QTBUG-53367: -isystem /usr/include with cstdlib causes file not found in include_next using GCC 6.1.0](https://bugreports.qt.io/browse/QTBUG-53367) packages using qmake are responsible for ensuring '/usr/include' is not included in INCLUDEPATH:

> the problem are the broken qmake-based build systems of 3rd party applications, which somehow end up adding '/usr/include' to INCLUDEPATH. report bugs against these applications.

On my end, '/usr/include' gets added to BOOST_CPPFLAGS, which gets added to CPPFLAGS, which gets parsed and filtered to QBT_CONF_INCLUDES, which gets added to INCLUDEPATH.

This commit filters out '/usr/include' from within the extract() function.