### PR TITLE
Minor refactor

### DIFF
--- a/src/base/bittorrent/private/speedmonitor.cpp
+++ b/src/base/bittorrent/private/speedmonitor.cpp
@@ -27,17 +27,21 @@
  * exception statement from your version.
  */
 
-#include <QList>
 #include "speedmonitor.h"
+
+SpeedMonitor::SpeedMonitor()
+    : m_speedSamples(MAX_SAMPLES)
+{
+}
 
 void SpeedMonitor::addSample(const SpeedSample &sample)
 {
+    if (m_speedSamples.size() >= MAX_SAMPLES) {
+        m_sum -= m_speedSamples.front();
+    }
+
     m_speedSamples.push_back(sample);
     m_sum += sample;
-    if (m_speedSamples.size() > MAX_SAMPLES) {
-        m_sum -= m_speedSamples.front();
-        m_speedSamples.pop_front();
-    }
 }
 
 SpeedSampleAvg SpeedMonitor::average() const

--- a/src/base/bittorrent/private/speedmonitor.h
+++ b/src/base/bittorrent/private/speedmonitor.h
@@ -30,7 +30,11 @@
 #ifndef SPEEDMONITOR_H
 #define SPEEDMONITOR_H
 
-template<typename T> class QList;
+#ifndef Q_MOC_RUN
+#include <boost/circular_buffer.hpp>
+#endif
+
+#include <QtGlobal>
 
 template<typename T>
 struct Sample
@@ -71,13 +75,15 @@ typedef Sample<qreal> SpeedSampleAvg;
 class SpeedMonitor
 {
 public:
+    SpeedMonitor();
+
     void addSample(const SpeedSample &sample);
     SpeedSampleAvg average() const;
     void reset();
 
 private:
     static const int MAX_SAMPLES = 30;
-    QList<SpeedSample> m_speedSamples;
+    boost::circular_buffer<SpeedSample> m_speedSamples;
     SpeedSample m_sum;
 };
 

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -129,7 +129,7 @@ void SearchWidget::fillCatCombobox()
     QList<QStrPair> tmpList;
     foreach (const QString &cat, m_searchEngine->supportedCategories())
         tmpList << qMakePair(SearchEngine::categoryFullName(cat), cat);
-    std::sort(tmpList.begin(), tmpList.end(), [](const QStrPair &l, const QStrPair &r) { return (l.first < r.first); } );
+    std::sort(tmpList.begin(), tmpList.end(), [](const QStrPair &l, const QStrPair &r) { return (QString::localeAwareCompare(l.first, r.first) < 0); });
 
     foreach (const QStrPair &p, tmpList) {
         qDebug("Supported category: %s", qPrintable(p.second));


### PR DESCRIPTION
* Use std::vector instead of QList: QList has to store an additional pointer for each element which leads to bad space efficiency.
* Use QString::localeAwareCompare for comparsion: because the categories strings are translated to each locale.
* Rename buttons on Content tab: [pic](https://cloud.githubusercontent.com/assets/9395168/15446923/659580bc-1f61-11e6-9210-35ea8a1b2ad0.png)
