### PR TITLE
default RSSRefreshInterval to 30 mins

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -2184,7 +2184,7 @@ void Preferences::setRSSEnabled(const bool enabled)
 
 uint Preferences::getRSSRefreshInterval() const
 {
-    return value("Preferences/RSS/RSSRefresh", 5).toUInt();
+    return value("Preferences/RSS/RSSRefresh", 30).toUInt();
 }
 
 void Preferences::setRSSRefreshInterval(const uint &interval)


### PR DESCRIPTION
closes issue #5235 (https://github.com/qbittorrent/qBittorrent/issues/5235).

As this is not a proper pull request, please feel free to make the change yourself (if you want to keep the number of contributors to real contributors)