### PR TITLE
Replace QProgress::startDetached with std::detatch.

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -264,6 +264,7 @@ void Application::sendNotificationEmail(BitTorrent::TorrentHandle *const torrent
 void Application::torrentFinished(BitTorrent::TorrentHandle *const torrent)
 {
     Preferences *const pref = Preferences::instance();
+    Logger *logger = Logger::instance();
 
     // AutoRun program
     if (pref->isAutoRunEnabled()) {
@@ -279,12 +280,15 @@ void Application::torrentFinished(BitTorrent::TorrentHandle *const torrent)
         program.replace("%T", torrent->currentTracker());
         program.replace("%I", torrent->hash());
 
+        logger->addMessage(tr("Torrent: %1, running external program: %2").arg(torrent->name()).arg(program));
         QProcess::startDetached(program);
     }
 
     // Mail notification
-    if (pref->isMailNotificationEnabled())
+    if (pref->isMailNotificationEnabled()) {
+        logger->addMessage(tr("Torrent: %1, sending mail notification").arg(torrent->name()));
         sendNotificationEmail(torrent);
+    }
 }
 
 void Application::allTorrentsFinished()

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -134,6 +134,7 @@ private:
 
     void initializeTranslation();
     void processParams(const QStringList &params);
+    void runExternalProgram(BitTorrent::TorrentHandle *const torrent) const;
     void sendNotificationEmail(BitTorrent::TorrentHandle *const torrent);
 };
 


### PR DESCRIPTION
Users can write (platform dependent) shell scripts now.
A dead simple script like the following isn't possible before
```shell
echo "%F" >> /tmp/txt
```

Update: some info:
[std::thread::detach](http://en.cppreference.com/w/cpp/thread/thread/detach)
[What happens to a detached thread when main() exits?](http://stackoverflow.com/questions/19744250/what-happens-to-a-detached-thread-when-main-exits)

