### PR TITLE
Add the stats from tracker scrape response. Closes #5048.

### DIFF
--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -910,31 +910,33 @@ int TorrentHandle::peersCount() const
 
 int TorrentHandle::leechsCount() const
 {
-    return (m_nativeStatus.num_peers - m_nativeStatus.num_seeds);
+    return (peersCount() - seedsCount());
 }
 
 int TorrentHandle::totalSeedsCount() const
 {
-    return m_nativeStatus.list_seeds;
+    return m_nativeStatus.list_seeds + std::max(m_nativeStatus.num_complete, 0);
 }
 
 int TorrentHandle::totalPeersCount() const
 {
-    return m_nativeStatus.list_peers;
+    return m_nativeStatus.list_peers + std::max(m_nativeStatus.num_complete, 0) + std::max(m_nativeStatus.num_incomplete, 0);
 }
 
 int TorrentHandle::totalLeechersCount() const
 {
-    return (m_nativeStatus.list_peers - m_nativeStatus.list_seeds);
+    return (totalPeersCount() - totalSeedsCount());
 }
 
 int TorrentHandle::completeCount() const
 {
+    // additional info: https://github.com/qbittorrent/qBittorrent/pull/5300#issuecomment-267783646
     return m_nativeStatus.num_complete;
 }
 
 int TorrentHandle::incompleteCount() const
 {
+    // additional info: https://github.com/qbittorrent/qBittorrent/pull/5300#issuecomment-267783646
     return m_nativeStatus.num_incomplete;
 }
 

--- a/src/webui/btjson.cpp
+++ b/src/webui/btjson.cpp
@@ -707,9 +707,9 @@ QVariantMap toMap(BitTorrent::TorrentHandle *const torrent)
     ret[KEY_TORRENT_UPSPEED] = torrent->uploadPayloadRate();
     ret[KEY_TORRENT_PRIORITY] = torrent->queuePosition();
     ret[KEY_TORRENT_SEEDS] = torrent->seedsCount();
-    ret[KEY_TORRENT_NUM_COMPLETE] = torrent->completeCount();
+    ret[KEY_TORRENT_NUM_COMPLETE] = torrent->totalSeedsCount();
     ret[KEY_TORRENT_LEECHS] = torrent->leechsCount();
-    ret[KEY_TORRENT_NUM_INCOMPLETE] = torrent->incompleteCount();
+    ret[KEY_TORRENT_NUM_INCOMPLETE] = torrent->totalLeechersCount();
     const qreal ratio = torrent->realRatio();
     ret[KEY_TORRENT_RATIO] = (ratio > BitTorrent::TorrentHandle::MAX_RATIO) ? -1 : ratio;
     ret[KEY_TORRENT_STATE] = torrent->state().toString();


### PR DESCRIPTION
Thanks to the report in #5299, it shows `torrent_status::list_peers` & `torrent_status::list_seeds` doesn't count the stats from tracker scrape.

Please verify this fix.
