### PR TITLE
Fix emule dat parsing

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -106,6 +106,8 @@ Application::Application(const QString &id, int &argc, char **argv)
     , m_shutdownAct(ShutdownDialogAction::Exit)
     , m_commandLineArgs(parseCommandLine(this->arguments()))
 {
+    qRegisterMetaType<Log::Msg>("Log::Msg");
+
     setApplicationName("qBittorrent");
     validateCommandLineParameters();
 

--- a/src/base/bittorrent/private/filterparserthread.cpp
+++ b/src/base/bittorrent/private/filterparserthread.cpp
@@ -124,7 +124,7 @@ int FilterParserThread::parseDATFilterFile()
     if (!file.exists()) return ruleCount;
 
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        Logger::instance()->addMessage(tr("I/O Error: Could not open ip filter file in read mode."), Log::CRITICAL);
+        LogMsg(tr("I/O Error: Could not open ip filter file in read mode."), Log::CRITICAL);
         return ruleCount;
     }
 
@@ -203,7 +203,7 @@ int FilterParserThread::parseDATFilterFile()
             int endOfIPRange = ((firstComma == -1) ? (endOfLine - 1) : (firstComma - 1));
             int delimIP = findAndNullDelimiter(buffer.data(), '-', start, endOfIPRange);
             if (delimIP == -1) {
-                Logger::instance()->addMessage(tr("IP filter line %1 is malformed.").arg(nbLine), Log::CRITICAL);
+                LogMsg(tr("IP filter line %1 is malformed.").arg(nbLine), Log::CRITICAL);
                 start = endOfLine;
                 continue;
             }
@@ -211,7 +211,7 @@ int FilterParserThread::parseDATFilterFile()
             libt::address startAddr;
             int newStart = trim(buffer.data(), start, delimIP - 1);
             if (!parseIPAddress(buffer.data() + newStart, startAddr)) {
-                Logger::instance()->addMessage(tr("IP filter line %1 is malformed. Start IP of the range is malformed.").arg(nbLine), Log::CRITICAL);
+                LogMsg(tr("IP filter line %1 is malformed. Start IP of the range is malformed.").arg(nbLine), Log::CRITICAL);
                 start = endOfLine;
                 continue;
             }
@@ -219,14 +219,14 @@ int FilterParserThread::parseDATFilterFile()
             libt::address endAddr;
             newStart = trim(buffer.data(), delimIP + 1, endOfIPRange);
             if (!parseIPAddress(buffer.data() + newStart, endAddr)) {
-                Logger::instance()->addMessage(tr("IP filter line %1 is malformed. End IP of the range is malformed.").arg(nbLine), Log::CRITICAL);
+                LogMsg(tr("IP filter line %1 is malformed. End IP of the range is malformed.").arg(nbLine), Log::CRITICAL);
                 start = endOfLine;
                 continue;
             }
 
             if ((startAddr.is_v4() != endAddr.is_v4())
                 || (startAddr.is_v6() != endAddr.is_v6())) {
-                Logger::instance()->addMessage(tr("IP filter line %1 is malformed. One IP is IPv4 and the other is IPv6!").arg(nbLine), Log::CRITICAL);
+                LogMsg(tr("IP filter line %1 is malformed. One IP is IPv4 and the other is IPv6!").arg(nbLine), Log::CRITICAL);
                 start = endOfLine;
                 continue;
             }
@@ -239,7 +239,7 @@ int FilterParserThread::parseDATFilterFile()
                 ++ruleCount;
             }
             catch (std::exception &e) {
-                Logger::instance()->addMessage(tr("IP filter exception thrown for line %1. Exception is: %2").arg(nbLine)
+                LogMsg(tr("IP filter exception thrown for line %1. Exception is: %2").arg(nbLine)
                                                .arg(QString::fromLocal8Bit(e.what())), Log::CRITICAL);
             }
         }
@@ -259,7 +259,7 @@ int FilterParserThread::parseP2PFilterFile()
     if (!file.exists()) return ruleCount;
 
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        Logger::instance()->addMessage(tr("I/O Error: Could not open ip filter file in read mode."), Log::CRITICAL);
+        LogMsg(tr("I/O Error: Could not open ip filter file in read mode."), Log::CRITICAL);
         return ruleCount;
     }
 
@@ -274,32 +274,32 @@ int FilterParserThread::parseP2PFilterFile()
         // Line is split by :
         QList<QByteArray> partsList = line.split(':');
         if (partsList.size() < 2) {
-            Logger::instance()->addMessage(tr("IP filter line %1 is malformed.").arg(nbLine), Log::CRITICAL);
+            LogMsg(tr("IP filter line %1 is malformed.").arg(nbLine), Log::CRITICAL);
             continue;
         }
 
         // Get IP range
         QList<QByteArray> IPs = partsList.last().split('-');
         if (IPs.size() != 2) {
-            Logger::instance()->addMessage(tr("IP filter line %1 is malformed.").arg(nbLine), Log::CRITICAL);
+            LogMsg(tr("IP filter line %1 is malformed.").arg(nbLine), Log::CRITICAL);
             continue;
         }
 
         libt::address startAddr;
         if (!parseIPAddress(IPs.at(0), startAddr)) {
-            Logger::instance()->addMessage(tr("IP filter line %1 is malformed. Start IP of the range is malformed.").arg(nbLine), Log::CRITICAL);
+            LogMsg(tr("IP filter line %1 is malformed. Start IP of the range is malformed.").arg(nbLine), Log::CRITICAL);
             continue;
         }
 
         libt::address endAddr;
         if (!parseIPAddress(IPs.at(1), endAddr)) {
-            Logger::instance()->addMessage(tr("IP filter line %1 is malformed. End IP of the range is malformed.").arg(nbLine), Log::CRITICAL);
+            LogMsg(tr("IP filter line %1 is malformed. End IP of the range is malformed.").arg(nbLine), Log::CRITICAL);
             continue;
         }
 
         if ((startAddr.is_v4() != endAddr.is_v4())
             || (startAddr.is_v6() != endAddr.is_v6())) {
-            Logger::instance()->addMessage(tr("IP filter line %1 is malformed. One IP is IPv4 and the other is IPv6!").arg(nbLine), Log::CRITICAL);
+            LogMsg(tr("IP filter line %1 is malformed. One IP is IPv4 and the other is IPv6!").arg(nbLine), Log::CRITICAL);
             continue;
         }
 
@@ -308,7 +308,7 @@ int FilterParserThread::parseP2PFilterFile()
             ++ruleCount;
         }
         catch (std::exception &e) {
-            Logger::instance()->addMessage(tr("IP filter exception thrown for line %1. Exception is: %2").arg(nbLine)
+            LogMsg(tr("IP filter exception thrown for line %1. Exception is: %2").arg(nbLine)
                                            .arg(QString::fromLocal8Bit(e.what())), Log::CRITICAL);
         }
     }
@@ -347,7 +347,7 @@ int FilterParserThread::parseP2BFilterFile()
     if (!file.exists()) return ruleCount;
 
     if (!file.open(QIODevice::ReadOnly)) {
-        Logger::instance()->addMessage(tr("I/O Error: Could not open ip filter file in read mode."), Log::CRITICAL);
+        LogMsg(tr("I/O Error: Could not open ip filter file in read mode."), Log::CRITICAL);
         return ruleCount;
     }
 
@@ -358,7 +358,7 @@ int FilterParserThread::parseP2BFilterFile()
     if (!stream.readRawData(buf, sizeof(buf))
         || memcmp(buf, "\xFF\xFF\xFF\xFFP2B", 7)
         || !stream.readRawData((char*)&version, sizeof(version))) {
-        Logger::instance()->addMessage(tr("Parsing Error: The filter file is not a valid PeerGuardian P2B file."), Log::CRITICAL);
+        LogMsg(tr("Parsing Error: The filter file is not a valid PeerGuardian P2B file."), Log::CRITICAL);
         return ruleCount;
     }
 
@@ -370,7 +370,7 @@ int FilterParserThread::parseP2BFilterFile()
         while(getlineInStream(stream, name, '\0') && !m_abort) {
             if (!stream.readRawData((char*)&start, sizeof(start))
                 || !stream.readRawData((char*)&end, sizeof(end))) {
-                Logger::instance()->addMessage(tr("Parsing Error: The filter file is not a valid PeerGuardian P2B file."), Log::CRITICAL);
+                LogMsg(tr("Parsing Error: The filter file is not a valid PeerGuardian P2B file."), Log::CRITICAL);
                 return ruleCount;
             }
 
@@ -391,7 +391,7 @@ int FilterParserThread::parseP2BFilterFile()
         qDebug ("p2b version 3");
         unsigned int namecount;
         if (!stream.readRawData((char*)&namecount, sizeof(namecount))) {
-            Logger::instance()->addMessage(tr("Parsing Error: The filter file is not a valid PeerGuardian P2B file."), Log::CRITICAL);
+            LogMsg(tr("Parsing Error: The filter file is not a valid PeerGuardian P2B file."), Log::CRITICAL);
             return ruleCount;
         }
 
@@ -400,7 +400,7 @@ int FilterParserThread::parseP2BFilterFile()
         for (unsigned int i = 0; i < namecount; ++i) {
             std::string name;
             if (!getlineInStream(stream, name, '\0')) {
-                Logger::instance()->addMessage(tr("Parsing Error: The filter file is not a valid PeerGuardian P2B file."), Log::CRITICAL);
+                LogMsg(tr("Parsing Error: The filter file is not a valid PeerGuardian P2B file."), Log::CRITICAL);
                 return ruleCount;
             }
 
@@ -410,7 +410,7 @@ int FilterParserThread::parseP2BFilterFile()
         // Reading the ranges
         unsigned int rangecount;
         if (!stream.readRawData((char*)&rangecount, sizeof(rangecount))) {
-            Logger::instance()->addMessage(tr("Parsing Error: The filter file is not a valid PeerGuardian P2B file."), Log::CRITICAL);
+            LogMsg(tr("Parsing Error: The filter file is not a valid PeerGuardian P2B file."), Log::CRITICAL);
             return ruleCount;
         }
 
@@ -420,7 +420,7 @@ int FilterParserThread::parseP2BFilterFile()
             if (!stream.readRawData((char*)&name, sizeof(name))
                 || !stream.readRawData((char*)&start, sizeof(start))
                 || !stream.readRawData((char*)&end, sizeof(end))) {
-                Logger::instance()->addMessage(tr("Parsing Error: The filter file is not a valid PeerGuardian P2B file."), Log::CRITICAL);
+                LogMsg(tr("Parsing Error: The filter file is not a valid PeerGuardian P2B file."), Log::CRITICAL);
                 return ruleCount;
             }
 
@@ -440,7 +440,7 @@ int FilterParserThread::parseP2BFilterFile()
         }
     }
     else {
-        Logger::instance()->addMessage(tr("Parsing Error: The filter file is not a valid PeerGuardian P2B file."), Log::CRITICAL);
+        LogMsg(tr("Parsing Error: The filter file is not a valid PeerGuardian P2B file."), Log::CRITICAL);
     }
 
     return ruleCount;

--- a/src/base/bittorrent/private/filterparserthread.cpp
+++ b/src/base/bittorrent/private/filterparserthread.cpp
@@ -125,34 +125,25 @@ int FilterParserThread::parseDATFilterFile()
         // IP Range should be split by a dash
         QList<QByteArray> IPs = partsList.first().split('-');
         if (IPs.size() != 2) {
-            qDebug("Ipfilter.dat: line %d is malformed.", nbLine);
-            qDebug("Line was %s", line.constData());
+            Logger::instance()->addMessage(tr("IP filter line %1 is malformed. Line is: %2").arg(nbLine).arg(QString(line)), Log::CRITICAL);
             continue;
         }
 
         libt::address startAddr;
         if (!parseIPAddress(IPs.at(0), startAddr)) {
-            qDebug("Ipfilter.dat: line %d is malformed.", nbLine);
-            qDebug("Start IP of the range is malformated: %s", qPrintable(IPs.at(0)));
+            Logger::instance()->addMessage(tr("IP filter line %1 is malformed. Start IP of the range is malformed: %2").arg(nbLine).arg(QString(IPs.at(0))), Log::CRITICAL);
             continue;
         }
 
         libt::address endAddr;
         if (!parseIPAddress(IPs.at(1), endAddr)) {
-            qDebug("Ipfilter.dat: line %d is malformed.", nbLine);
-            qDebug("End IP of the range is malformated: %s", qPrintable(IPs.at(1)));
+            Logger::instance()->addMessage(tr("IP filter line %1 is malformed. End IP of the range is malformed: %2").arg(nbLine).arg(QString(IPs.at(1))), Log::CRITICAL);
             continue;
         }
 
-        if (startAddr.is_v4() != endAddr.is_v4()) {
-            qDebug("Ipfilter.dat: line %d is malformed.", nbLine);
-            qDebug("One IP is IPv4 and the other is IPv6!");
-            continue;
-        }
-
-        if (startAddr.is_v6() != endAddr.is_v6()) {
-            qDebug("Ipfilter.dat: line %d is malformed.", nbLine);
-            qDebug("One IP is IPv6 and the other is IPv4!");
+        if (startAddr.is_v4() != endAddr.is_v4()
+            || startAddr.is_v6() != endAddr.is_v6()) {
+            Logger::instance()->addMessage(tr("IP filter line %1 is malformed. One IP is IPv4 and the other is IPv6!").arg(nbLine), Log::CRITICAL);
             continue;
         }
 
@@ -162,11 +153,10 @@ int FilterParserThread::parseDATFilterFile()
             ++ruleCount;
         }
         catch(std::exception &) {
-            qDebug("Bad line in filter file, avoided crash...");
+            Logger::instance()->addMessage(tr("IP filter exception thrown for line %1. Line is: %2").arg(nbLine).arg(QString(line)), Log::CRITICAL);
         }
     }
 
-    file.close();
     return ruleCount;
 }
 
@@ -193,41 +183,32 @@ int FilterParserThread::parseP2PFilterFile()
         // Line is split by :
         QList<QByteArray> partsList = line.split(':');
         if (partsList.size() < 2) {
-            qDebug("p2p file: line %d is malformed.", nbLine);
+            Logger::instance()->addMessage(tr("IP filter line %1 is malformed. Line is: %2").arg(nbLine).arg(QString(line)), Log::CRITICAL);
             continue;
         }
 
         // Get IP range
         QList<QByteArray> IPs = partsList.last().split('-');
         if (IPs.size() != 2) {
-            qDebug("p2p file: line %d is malformed.", nbLine);
-            qDebug("line was: %s", line.constData());
+            Logger::instance()->addMessage(tr("IP filter line %1 is malformed. Line is: %2").arg(nbLine).arg(QString(line)), Log::CRITICAL);
             continue;
         }
 
         libt::address startAddr;
         if (!parseIPAddress(IPs.at(0), startAddr)) {
-            qDebug("p2p file: line %d is malformed.", nbLine);
-            qDebug("Start IP is invalid: %s", qPrintable(IPs.at(0)));
+            Logger::instance()->addMessage(tr("IP filter line %1 is malformed. Start IP of the range is malformed: %2").arg(nbLine).arg(QString(IPs.at(0))), Log::CRITICAL);
             continue;
         }
 
         libt::address endAddr;
         if (!parseIPAddress(IPs.at(1), endAddr)) {
-            qDebug("p2p file: line %d is malformed.", nbLine);
-            qDebug("End IP is invalid: %s", qPrintable(IPs.at(1)));
+            Logger::instance()->addMessage(tr("IP filter line %1 is malformed. End IP of the range is malformed: %2").arg(nbLine).arg(QString(IPs.at(1))), Log::CRITICAL);
             continue;
         }
 
-        if (startAddr.is_v4() != endAddr.is_v4()) {
-            qDebug("p2p file: line %d is malformed.", nbLine);
-            qDebug("One IP is IPv4 and the other is IPv6!");
-            continue;
-        }
-
-        if (startAddr.is_v6() != endAddr.is_v6()) {
-            qDebug("p2p file: line %d is malformed.", nbLine);
-            qDebug("One IP is IPv6 and the other is IPv4!");
+        if (startAddr.is_v4() != endAddr.is_v4()
+            || startAddr.is_v6() != endAddr.is_v6()) {
+            Logger::instance()->addMessage(tr("IP filter line %1 is malformed. One IP is IPv4 and the other is IPv6!").arg(nbLine), Log::CRITICAL);
             continue;
         }
 
@@ -236,13 +217,10 @@ int FilterParserThread::parseP2PFilterFile()
             ++ruleCount;
         }
         catch(std::exception &) {
-            qDebug("p2p file: line %d is malformed.", nbLine);
-            qDebug("Line was: %s", line.constData());
-            continue;
+            Logger::instance()->addMessage(tr("IP filter exception thrown for line %1. Line is: %2").arg(nbLine).arg(QString(line)), Log::CRITICAL);
         }
     }
 
-    file.close();
     return ruleCount;
 }
 
@@ -373,7 +351,6 @@ int FilterParserThread::parseP2BFilterFile()
         Logger::instance()->addMessage(tr("Parsing Error: The filter file is not a valid PeerGuardian P2B file."), Log::CRITICAL);
     }
 
-    file.close();
     return ruleCount;
 }
 

--- a/src/base/bittorrent/private/filterparserthread.h
+++ b/src/base/bittorrent/private/filterparserthread.h
@@ -37,6 +37,8 @@
 
 class QDataStream;
 class QStringList;
+class QByteArray;
+template<typename T> class QVector;
 
 class FilterParserThread : public QThread
 {
@@ -56,6 +58,8 @@ protected:
     void run();
 
 private:
+    QVector<int> indicesOfDelimiters(const QByteArray &data, const char delimiter, const int start, const int end);
+    QByteArray trim(const QByteArray &data, const int start, const int end);
     int parseDATFilterFile();
     int parseP2PFilterFile();
     int getlineInStream(QDataStream &stream, std::string &name, char delim);

--- a/src/base/bittorrent/private/filterparserthread.h
+++ b/src/base/bittorrent/private/filterparserthread.h
@@ -37,7 +37,6 @@
 
 class QDataStream;
 class QStringList;
-class QByteArray;
 template<typename T> class QVector;
 
 class FilterParserThread : public QThread
@@ -58,8 +57,8 @@ protected:
     void run();
 
 private:
-    QVector<int> indicesOfDelimiters(const QByteArray &data, const char delimiter, const int start, const int end);
-    QByteArray trim(const QByteArray &data, const int start, const int end);
+    QVector<int> indicesOfDelimiters(const char * const data, const char delimiter, const int start, const int end) const;
+    QByteArray trim(const char * const data, const int start, const int end) const;
     int parseDATFilterFile();
     int parseP2PFilterFile();
     int getlineInStream(QDataStream &stream, std::string &name, char delim);

--- a/src/base/bittorrent/private/filterparserthread.h
+++ b/src/base/bittorrent/private/filterparserthread.h
@@ -53,7 +53,6 @@ signals:
     void IPFilterError();
 
 protected:
-    QString cleanupIPAddress(QString _ip);
     void run();
 
 private:

--- a/src/base/bittorrent/private/filterparserthread.h
+++ b/src/base/bittorrent/private/filterparserthread.h
@@ -36,8 +36,6 @@
 #include <libtorrent/ip_filter.hpp>
 
 class QDataStream;
-class QStringList;
-template<typename T> class QVector;
 
 class FilterParserThread : public QThread
 {
@@ -57,8 +55,8 @@ protected:
     void run();
 
 private:
-    QVector<int> indicesOfDelimiters(const char * const data, const char delimiter, const int start, const int end) const;
-    QByteArray trim(const char * const data, const int start, const int end) const;
+    int findAndNullDelimiter(char *const data, char delimiter, int start, int end);
+    int trim(char *const data, int start, int end);
     int parseDATFilterFile();
     int parseP2PFilterFile();
     int getlineInStream(QDataStream &stream, std::string &name, char delim);

--- a/src/base/logger.cpp
+++ b/src/base/logger.cpp
@@ -90,3 +90,8 @@ QVector<Log::Peer> Logger::getPeers(int lastKnownId) const
 
     return m_peers.mid(size - diff);
 }
+
+void LogMsg(const QString &message, const Log::MsgType &type)
+{
+    Logger::instance()->addMessage(message, type);
+}

--- a/src/base/logger.h
+++ b/src/base/logger.h
@@ -71,4 +71,7 @@ private:
     int peerCounter;
 };
 
+// Helper function
+void LogMsg(const QString &message, const Log::MsgType &type = Log::NORMAL);
+
 #endif // LOGGER_H


### PR DESCRIPTION
As you can see from #5281 eMule .DAT files contain ip ranges with leading zeroes in each octet. Both Boost.Asio and QHostAddress fail to parse them as is. So we need to clean them up.

I tested various implementations from that issue and benchmarked how long it took `FilterParserThread::parseDATFilterFile()` to finish. I post my findings below:

1st attempt:

``` c++
QString FilterParserThread::cleanupIPAddress(QString _ip)
{
    _ip = _ip.trimmed();
    _ip.remove(QRegExp("^0{1,2}(?!\\.)"));
    _ip.replace(QRegExp("\\.0{1,2}(?!\\.|$)"), ".");
    QHostAddress ip(_ip);
    if (ip.isNull()) return QString();

    return ip.toString();
}
```

Results:

```
Duration(ms): 6088
Duration(ms): 5978
Duration(ms): 6095
```

2nd attempt:

``` c++
QString FilterParserThread::cleanupIPAddress(QString _ip)
{
    _ip = _ip.trimmed();

    // Truncate leading zeros
    QStringList octets = _ip.split('.');
    QString ipOctet;
    for (int i = 0; i < 4; i++) {
        ipOctet = octets[i];
        if ((ipOctet[0] == QChar('0')) && (ipOctet.count() > 1)) {
            if ((ipOctet[1] == QChar('0')) && (ipOctet.count() > 2)) {
                ipOctet.remove(0, 2);
                octets[i] = ipOctet;
                continue;
            }
            ipOctet.remove(0, 1);
            octets[i] = ipOctet;
        }
    }

    _ip = octets.join(".");
    QHostAddress ip(_ip);
    if (ip.isNull()) return QString();

    return ip.toString();
}
```

Results:

```
Duration(ms): 4294
Duration(ms): 4322
Duration(ms): 4287
```

3rd attempt:

``` c++
QString FilterParserThread::cleanupIPAddress(QString _ip)
{
    // Truncate leading zeros
    if (_ip.contains('.')) {
        QStringList octets = _ip.trimmed().split('.');
        if (octets.size() == 4) {
            int firstOctet = octets[0].toInt();
            int secondOctet = octets[1].toInt();
            int thirdOctet = octets[2].toInt();
            int fourthOctet = octets[3].toInt();
            _ip = QString("%1.%2.%3.%4").arg(firstOctet).arg(secondOctet).arg(thirdOctet).arg(fourthOctet);
        }
    }

    QHostAddress ip(_ip);
    if (ip.isNull()) return QString();

    return ip.toString();
}
```

Results:

```
Duration(ms): 4851
Duration(ms): 4862
Duration(ms): 4863
```

4th attempt:

``` c++
QString FilterParserThread::cleanupIPAddress(QString _ip)
{
    _ip = _ip.trimmed();
    _ip.remove(QRegExp("\\b0+\\B"));
    QHostAddress ip(_ip);
    if (ip.isNull()) return QString();

    return ip.toString();
}
```

Resutls:

```
Duration(ms): 4637
Duration(ms): 4598
Duration(ms): 4617
```

So I chose the 2nd attempt, put some checks in it and with my next commit I optimized other places in the code so now the parsing results are:

```
Duration(ms): 2977
Duration(ms): 2992
Duration(ms): 2994
```

If you have faster proposals for `FilterParserThread::cleanupIPAddress()`, please share them.
