### PR TITLE
Schedule downloading via piece deadlines. WIP.

### DIFF
--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -43,6 +43,7 @@
 #include <libtorrent/torrent_status.hpp>
 #endif
 
+#include <chrono>
 #include <boost/function.hpp>
 
 #include "base/tristatebool.h"
@@ -315,6 +316,14 @@ namespace BitTorrent
         void setName(const QString &name);
         void setSequentialDownload(bool b);
         void toggleSequentialDownload();
+        // disables deadlines if completionTime < 0
+        void scheduleDownloading(std::chrono::milliseconds totalDeadline,
+                                 std::chrono::milliseconds delay = std::chrono::milliseconds(0),
+                                 bool onlyUncompletedPieces = false);
+        void scheduleFileDonwloading(int fileIndex,
+                                     std::chrono::milliseconds totalDeadline,
+                                     std::chrono::milliseconds delay = std::chrono::milliseconds(0),
+                                     bool onlyUncompletedPieces = false);
         void setFirstLastPiecePriority(bool b);
         void toggleFirstLastPiecePriority();
         void pause();
@@ -391,6 +400,12 @@ namespace BitTorrent
         bool addTracker(const TrackerEntry &tracker);
         bool addUrlSeed(const QUrl &urlSeed);
         bool removeUrlSeed(const QUrl &urlSeed);
+
+        // disables deadlines if totalDeadline < 0
+        void setSequentialUniformDeadlines(TorrentInfo::PieceRange range,
+                                           std::chrono::milliseconds totalDeadline,
+                                           std::chrono::milliseconds delay,
+                                           bool onlyUncompletedPieces = false);
 
         Session *const m_session;
         libtorrent::torrent_handle m_nativeHandle;

--- a/src/base/indexrange.h
+++ b/src/base/indexrange.h
@@ -122,6 +122,11 @@ public:
         return m_size == 0;
     }
 
+    constexpr IndexType operator[](IndexDiffType index) const
+    {
+        return m_first + index;
+    }
+
 private:
     IndexType m_first;
     IndexDiffType m_size;

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -35,6 +35,7 @@ autoexpandabledialog.h
 cookiesdialog.h
 cookiesmodel.h
 deletionconfirmationdlg.h
+downloadingdeadlinedialog.h
 downloadfromurldlg.h
 executionlog.h
 guiiconprovider.h
@@ -73,6 +74,7 @@ advancedsettings.cpp
 autoexpandabledialog.cpp
 cookiesdialog.cpp
 cookiesmodel.cpp
+downloadingdeadlinedialog.cpp
 executionlog.cpp
 guiiconprovider.cpp
 ico.cpp
@@ -111,6 +113,7 @@ set(QBT_GUI_FORMS
 mainwindow.ui
 about.ui
 cookiesdialog.ui
+downloadingdeadlinedialog.ui
 preview.ui
 login.ui
 downloadfromurldlg.ui

--- a/src/gui/downloadingdeadlinedialog.cpp
+++ b/src/gui/downloadingdeadlinedialog.cpp
@@ -1,0 +1,144 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2016 Eugene Shalygin
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "downloadingdeadlinedialog.h"
+
+#include <QTime>
+
+#include "base/settingsstorage.h"
+#include "base/utils/misc.h"
+
+#include "ui_downloadingdeadlinedialog.h"
+
+namespace
+{
+#define SETTINGS_KEY(name) "DownloadingDeadlineDialog/" name
+    constexpr const char KEY_SPEED[] = SETTINGS_KEY("speed");
+    constexpr const char KEY_ONLY_UNCOMPLETED[] = SETTINGS_KEY("onlyUncompleted");
+}
+
+DownloadingDeadlineDialog::DownloadingDeadlineDialog(const QString &fileOrTorrentName,
+                                                     qlonglong fileOrTorrentSize, qlonglong remainingSize,
+                                                     QWidget *parent)
+    : QDialog {parent}
+    , m_ui {new Ui::DownloadingDeadlineDialog()}
+    , m_size {fileOrTorrentSize}
+    , m_remainingSize {remainingSize}
+{
+    m_ui->setupUi(this);
+
+    m_ui->lblName->setText(fileOrTorrentName);
+    m_ui->lblSize->setText(Utils::Misc::friendlyUnit(m_size, false));
+    m_ui->lblRemainingSize->setText(Utils::Misc::friendlyUnit(m_remainingSize, false));
+    m_ui->sbSpeed->setValue(SettingsStorage::instance()->loadValue(QLatin1String(KEY_SPEED), 2000).toInt());
+    m_ui->chbxUncompletedOnly->setChecked(SettingsStorage::instance()->loadValue(QLatin1String(KEY_ONLY_UNCOMPLETED), true).toBool());
+
+    speedChanged(m_ui->sbSpeed->value());
+
+    setupSignals();
+}
+
+DownloadingDeadlineDialog::~DownloadingDeadlineDialog()
+{
+    delete m_ui;
+}
+
+std::chrono::milliseconds DownloadingDeadlineDialog::downloadingDeadline() const
+{
+#ifdef QBT_USES_QT5
+    return std::chrono::milliseconds {m_ui->teDeadline->time().msecsSinceStartOfDay()};
+#else
+    return std::chrono::milliseconds {QTime(0, 0, 0, 0).msecsTo(m_ui->teDeadline->time())};
+#endif
+}
+
+std::chrono::milliseconds DownloadingDeadlineDialog::downloadingDelay() const
+{
+#ifdef QBT_USES_QT5
+    return std::chrono::milliseconds {m_ui->teDealy->time().msecsSinceStartOfDay()};
+#else
+    return std::chrono::milliseconds {QTime(0, 0, 0, 0).msecsTo(m_ui->teDealy->time())};
+#endif
+}
+
+bool DownloadingDeadlineDialog::onlyUncompletedPieces() const
+{
+    return m_ui->chbxUncompletedOnly->isChecked();
+}
+
+void DownloadingDeadlineDialog::setupSignals()
+{
+    connect(m_ui->sbSpeed, SIGNAL(valueChanged(int)), this, SLOT(speedChanged(int)));
+    connect(m_ui->teDeadline, SIGNAL(timeChanged(const QTime&)), this, SLOT(deadlineChanged(const QTime&)));
+    connect(m_ui->chbxUncompletedOnly, SIGNAL(clicked(bool)), this, SLOT(uncompletedOnlyClicked()));
+}
+
+qlonglong DownloadingDeadlineDialog::sizeToDownload() const
+{
+    return onlyUncompletedPieces() ? m_remainingSize : m_size;
+}
+
+void DownloadingDeadlineDialog::speedChanged(int speed)
+{
+    // speed is in kb/s
+    int downloadingTime = static_cast<int>(sizeToDownload() / speed * 8 / 1024);     // seconds
+    constexpr int secondsInDay = 24 * 60 * 60;     // 86400
+    if (downloadingTime > secondsInDay)
+        downloadingTime = secondsInDay - 1;
+
+#ifdef QBT_USES_QT5
+    m_ui->teDeadline->setTime(QTime::fromMSecsSinceStartOfDay(downloadingTime * 1000));
+#else
+    m_ui->teDeadline->setTime(QTime(0, 0, 0 ,0).addMSecs(downloadingTime * 1000));
+#endif
+}
+
+void DownloadingDeadlineDialog::deadlineChanged(const QTime &deadline)
+{
+#ifdef QBT_USES_QT5
+    const int downloadingTime = deadline.msecsSinceStartOfDay() / 1000;
+#else
+    const int downloadingTime = QTime(0, 0, 0, 0).msecsTo(deadline) / 1000;
+#endif
+    const int speed = sizeToDownload() / downloadingTime * 8 / 1024;
+    m_ui->sbSpeed->setValue(speed);
+}
+
+void DownloadingDeadlineDialog::uncompletedOnlyClicked()
+{
+    // preserve speed, recompute deadline
+    speedChanged(m_ui->sbSpeed->value());
+}
+
+void DownloadingDeadlineDialog::accept()
+{
+    SettingsStorage::instance()->storeValue(QLatin1String(KEY_SPEED), m_ui->sbSpeed->value());
+    SettingsStorage::instance()->storeValue(QLatin1String(KEY_ONLY_UNCOMPLETED), m_ui->chbxUncompletedOnly->isChecked());
+
+    QDialog::accept();
+}

--- a/src/gui/downloadingdeadlinedialog.h
+++ b/src/gui/downloadingdeadlinedialog.h
@@ -1,0 +1,77 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2016 Eugene Shalygin
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#ifndef DOWNLOADINGDEADLINEDIALOG_H
+#define DOWNLOADINGDEADLINEDIALOG_H
+
+#include <chrono>
+#include <QDialog>
+
+class QTime;
+
+namespace Ui
+{
+    class DownloadingDeadlineDialog;
+}
+
+// This dialog allows user to compute appropriate downloading deadline for a torrent or file.
+// Give the size of that entity (torrent or file), the dialog shows correlated values of bitrate
+// and playtime, allowing to change both of them.
+class DownloadingDeadlineDialog: public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit DownloadingDeadlineDialog(const QString &fileOrTorrentName,
+                                       qlonglong fileOrTorrentSize, qlonglong remainingSize,
+                                       QWidget *parent = 0);
+    ~DownloadingDeadlineDialog();
+
+    std::chrono::milliseconds downloadingDeadline() const;
+    std::chrono::milliseconds downloadingDelay() const;
+    bool onlyUncompletedPieces() const;
+
+    void accept() override;
+
+private slots:
+    void speedChanged(int speed);
+    void deadlineChanged(const QTime &deadline);
+    void uncompletedOnlyClicked();
+
+private:
+    void setupSignals();
+
+    qlonglong sizeToDownload() const;
+    //  void set
+
+    Ui::DownloadingDeadlineDialog *m_ui;
+    qlonglong m_size;
+    qlonglong m_remainingSize;
+};
+
+#endif // DOWNLOADINGDEADLINEDIALOG_H

--- a/src/gui/downloadingdeadlinedialog.ui
+++ b/src/gui/downloadingdeadlinedialog.ui
@@ -1,0 +1,265 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DownloadingDeadlineDialog</class>
+ <widget class="QDialog" name="DownloadingDeadlineDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>483</width>
+    <height>176</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Schedule sequential downloading</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="lblName">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Torrent or file name</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_7">
+       <property name="text">
+        <string>of size</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="lblSize">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>XX GB</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>; remaining</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="lblRemainingSize">
+       <property name="text">
+        <string>XX GB</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <layout class="QFormLayout" name="formLayout_3">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_3">
+         <property name="text">
+          <string>Down&amp;load time</string>
+         </property>
+         <property name="buddy">
+          <cstring>teDeadline</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QTimeEdit" name="teDeadline">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Downloading of pieces will be scheduled monotonically with the deadline for the last piece equal to this value.</string>
+         </property>
+         <property name="currentSection">
+          <enum>QDateTimeEdit::HourSection</enum>
+         </property>
+         <property name="displayFormat">
+          <string>HH 'h' mm 'm'  ss 's'</string>
+         </property>
+         <property name="calendarPopup">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QFormLayout" name="formLayout">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>Wi&amp;th speed</string>
+         </property>
+         <property name="buddy">
+          <cstring>sbSpeed</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QSpinBox" name="sbSpeed">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="suffix">
+          <string> kb/s</string>
+         </property>
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>100000</number>
+         </property>
+         <property name="singleStep">
+          <number>1</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <layout class="QFormLayout" name="formLayout_2">
+       <property name="verticalSpacing">
+        <number>-1</number>
+       </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>Add a dela&amp;y</string>
+         </property>
+         <property name="buddy">
+          <cstring>teDealy</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QTimeEdit" name="teDealy">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Downlaoding deadlines will be delayed for this amount of time.</string>
+         </property>
+         <property name="displayFormat">
+          <string>HH 'h' mm 'm'  ss 's'</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="chbxUncompletedOnly">
+       <property name="text">
+        <string>Unfinished only</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>sbSpeed</tabstop>
+  <tabstop>teDeadline</tabstop>
+  <tabstop>teDealy</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>DownloadingDeadlineDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>224</x>
+     <y>188</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>208</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>DownloadingDeadlineDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>235</x>
+     <y>194</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>241</x>
+     <y>208</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/gui/gui.pri
+++ b/src/gui/gui.pri
@@ -49,7 +49,8 @@ HEADERS += \
     $$PWD/search/searchlistdelegate.h \
     $$PWD/search/searchsortmodel.h \
     $$PWD/cookiesmodel.h \
-    $$PWD/cookiesdialog.h
+    $$PWD/cookiesdialog.h \
+    $$PWD/downloadingdeadlinedialog.h
 
 SOURCES += \
     $$PWD/mainwindow.cpp \
@@ -89,7 +90,8 @@ SOURCES += \
     $$PWD/search/searchlistdelegate.cpp \
     $$PWD/search/searchsortmodel.cpp \
     $$PWD/cookiesmodel.cpp \
-    $$PWD/cookiesdialog.cpp
+    $$PWD/cookiesdialog.cpp \
+    $$PWD/downloadingdeadlinedialog.cpp
 
 win32|macx {
     HEADERS += $$PWD/programupdater.h
@@ -116,6 +118,7 @@ FORMS += \
     $$PWD/search/pluginselectdlg.ui \
     $$PWD/search/pluginsourcedlg.ui \
     $$PWD/search/searchtab.ui \
-    $$PWD/cookiesdialog.ui
+    $$PWD/cookiesdialog.ui \
+    $$PWD/downloadingdeadlinedialog.ui
 
 RESOURCES += $$PWD/about.qrc

--- a/src/gui/properties/propertieswidget.h
+++ b/src/gui/properties/propertieswidget.h
@@ -91,6 +91,7 @@ protected slots:
     void showPiecesAvailability(bool show);
     void renameSelectedFile();
     void openSelectedFile();
+    void scheduleFilesDownloading();
 
 public slots:
     void setVisibility(bool visible);

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -125,7 +125,7 @@ TransferListWidget::TransferListWidget(QWidget *parent, MainWindow *main_window)
         setColumnHidden(TorrentModel::TR_TOTAL_SIZE, true);
     }
 
-    //Ensure that at least one column is visible at all times
+    // Ensure that at least one column is visible at all times
     bool atLeastOne = false;
     for (unsigned int i = 0; i<TorrentModel::NB_COLUMNS; i++) {
         if (!isColumnHidden(i)) {
@@ -136,9 +136,9 @@ TransferListWidget::TransferListWidget(QWidget *parent, MainWindow *main_window)
     if (!atLeastOne)
         setColumnHidden(TorrentModel::TR_NAME, false);
 
-    //When adding/removing columns between versions some may
-    //end up being size 0 when the new version is launched with
-    //a conf file from the previous version.
+    // When adding/removing columns between versions some may
+    // end up being size 0 when the new version is launched with
+    // a conf file from the previous version.
     for (unsigned int i = 0; i<TorrentModel::NB_COLUMNS; i++)
         if (!columnWidth(i))
             resizeColumnToContents(i);
@@ -147,12 +147,12 @@ TransferListWidget::TransferListWidget(QWidget *parent, MainWindow *main_window)
 
     // Listen for list events
     connect(this, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(torrentDoubleClicked(QModelIndex)));
-    connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(displayListMenu(const QPoint &)));
+    connect(this, SIGNAL(customContextMenuRequested(const QPoint&)), this, SLOT(displayListMenu(const QPoint&)));
     header()->setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(header(), SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(displayDLHoSMenu(const QPoint &)));
-    connect(header(), SIGNAL(sectionMoved(int, int, int)), this, SLOT(saveSettings()));
-    connect(header(), SIGNAL(sectionResized(int, int, int)), this, SLOT(saveSettings()));
-    connect(header(), SIGNAL(sortIndicatorChanged(int, Qt::SortOrder)), this, SLOT(saveSettings()));
+    connect(header(), SIGNAL(customContextMenuRequested(const QPoint&)), this, SLOT(displayDLHoSMenu(const QPoint&)));
+    connect(header(), SIGNAL(sectionMoved(int,int,int)), this, SLOT(saveSettings()));
+    connect(header(), SIGNAL(sectionResized(int,int,int)), this, SLOT(saveSettings()));
+    connect(header(), SIGNAL(sortIndicatorChanged(int,Qt::SortOrder)), this, SLOT(saveSettings()));
 
     editHotkey = new QShortcut(QKeySequence("F2"), this, SLOT(renameSelectedTorrent()), 0, Qt::WidgetShortcut);
     deleteHotkey = new QShortcut(QKeySequence::Delete, this, SLOT(deleteSelectedTorrents()), 0, Qt::WidgetShortcut);
@@ -181,7 +181,7 @@ TransferListWidget::~TransferListWidget()
     qDebug() << Q_FUNC_INFO << "EXIT";
 }
 
-TorrentModel* TransferListWidget::getSourceModel() const
+TorrentModel *TransferListWidget::getSourceModel() const
 {
     return listModel;
 }
@@ -206,7 +206,7 @@ inline QModelIndex TransferListWidget::mapFromSource(const QModelIndex &index) c
     return nameFilterModel->mapFromSource(index);
 }
 
-void TransferListWidget::torrentDoubleClicked(const QModelIndex& index)
+void TransferListWidget::torrentDoubleClicked(const QModelIndex &index)
 {
     BitTorrent::TorrentHandle *const torrent = listModel->torrentHandle(mapToSource(index));
     if (!torrent) return;
@@ -217,7 +217,7 @@ void TransferListWidget::torrentDoubleClicked(const QModelIndex& index)
     else
         action = Preferences::instance()->getActionOnDblClOnTorrentDl();
 
-    switch(action) {
+    switch (action) {
     case TOGGLE_PAUSE:
         if (torrent->isPaused())
             torrent->resume();
@@ -254,10 +254,9 @@ void TransferListWidget::setSelectedTorrentsLocation()
                                             QFileDialog::DontConfirmOverwrite | QFileDialog::ShowDirsOnly | QFileDialog::HideNameFilterDetails);
     if (!dir.isNull()) {
         qDebug("New path is %s", qPrintable(dir));
-        foreach (BitTorrent::TorrentHandle *const torrent, torrents) {
+        foreach (BitTorrent::TorrentHandle *const torrent, torrents)
             // Actually move storage
             torrent->move(Utils::Fs::expandPathAbs(dir));
-        }
     }
 }
 
@@ -409,10 +408,9 @@ void TransferListWidget::openSelectedTorrentsFolder() const
 
 void TransferListWidget::previewSelectedTorrents()
 {
-    foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents()) {
+    foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents())
         if (torrent->hasMetadata())
             new PreviewSelect(this, torrent);
-    }
 }
 
 void TransferListWidget::setDlLimitSelectedTorrents()
@@ -506,13 +504,13 @@ void TransferListWidget::recheckSelectedTorrents()
 }
 
 // hide/show columns menu
-void TransferListWidget::displayDLHoSMenu(const QPoint&)
+void TransferListWidget::displayDLHoSMenu(const QPoint &)
 {
     QMenu hideshowColumn(this);
     hideshowColumn.setTitle(tr("Column visibility"));
-    QList<QAction*> actions;
+    QList<QAction *> actions;
     for (int i = 0; i < listModel->columnCount(); ++i) {
-        if (!BitTorrent::Session::instance()->isQueueingEnabled() && i == TorrentModel::TR_PRIORITY) {
+        if (!BitTorrent::Session::instance()->isQueueingEnabled() && (i == TorrentModel::TR_PRIORITY)) {
             actions.append(0);
             continue;
         }
@@ -536,11 +534,11 @@ void TransferListWidget::displayDLHoSMenu(const QPoint&)
         int col = actions.indexOf(act);
         Q_ASSERT(col >= 0);
         Q_ASSERT(visibleCols > 0);
-        if (!isColumnHidden(col) && visibleCols == 1)
+        if (!isColumnHidden(col) && (visibleCols == 1))
             return;
         qDebug("Toggling column %d visibility", col);
         setColumnHidden(col, !isColumnHidden(col));
-        if (!isColumnHidden(col) && columnWidth(col) <= 5)
+        if (!isColumnHidden(col) && (columnWidth(col) <= 5))
             setColumnWidth(col, 100);
         saveSettings();
     }
@@ -548,10 +546,9 @@ void TransferListWidget::displayDLHoSMenu(const QPoint&)
 
 void TransferListWidget::toggleSelectedTorrentsSuperSeeding() const
 {
-    foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents()) {
+    foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents())
         if (torrent->hasMetadata())
             torrent->setSuperSeeding(!torrent->superSeeding());
-    }
 }
 
 void TransferListWidget::toggleSelectedTorrentsSequentialDownload() const
@@ -592,7 +589,7 @@ void TransferListWidget::askNewCategoryForSelection()
                 setSelectionCategory(category);
             }
         }
-    } while(invalid);
+    } while (invalid);
 }
 
 void TransferListWidget::renameSelectedTorrent()
@@ -621,7 +618,7 @@ void TransferListWidget::setSelectionCategory(QString category)
         listModel->setData(listModel->index(mapToSource(index).row(), TorrentModel::TR_CATEGORY), category, Qt::DisplayRole);
 }
 
-void TransferListWidget::displayListMenu(const QPoint&)
+void TransferListWidget::displayListMenu(const QPoint &)
 {
     QModelIndexList selectedIndexes = selectionModel()->selectedRows();
     if (selectedIndexes.size() == 0)
@@ -728,12 +725,10 @@ void TransferListWidget::displayListMenu(const QPoint&)
         }
         else {
             if (!one_not_seed && all_same_super_seeding && torrent->hasMetadata()) {
-                if (first) {
+                if (first)
                     super_seeding_mode = torrent->superSeeding();
-                }
                 else if (super_seeding_mode != torrent->superSeeding())
                     all_same_super_seeding = false;
-
             }
         }
         if (!torrent->isForced())
@@ -751,9 +746,8 @@ void TransferListWidget::displayListMenu(const QPoint&)
 
         if (one_has_metadata && one_not_seed && !all_same_sequential_download_mode
             && !all_same_prio_firstlast && !all_same_super_seeding && !allSameCategory
-            && needs_start && needs_force && needs_pause && needs_preview && !allSameAutoTMM) {
+            && needs_start && needs_force && needs_pause && needs_preview && !allSameAutoTMM)
             break;
-        }
     }
     QMenu listMenu(this);
     if (needs_start)
@@ -771,7 +765,7 @@ void TransferListWidget::displayListMenu(const QPoint&)
     // Category Menu
     QStringList categories = BitTorrent::Session::instance()->categories();
     std::sort(categories.begin(), categories.end(), Utils::String::naturalCompareCaseInsensitive);
-    QList<QAction*> categoryActions;
+    QList<QAction *> categoryActions;
     QMenu *categoryMenu = listMenu.addMenu(GuiIconProvider::instance()->getIcon("view-categories"), tr("Category"));
     categoryActions << categoryMenu->addAction(GuiIconProvider::instance()->getIcon("list-add"), tr("New...", "New category..."));
     categoryActions << categoryMenu->addAction(GuiIconProvider::instance()->getIcon("edit-clear"), tr("Reset", "Reset category"));
@@ -861,7 +855,7 @@ void TransferListWidget::displayListMenu(const QPoint&)
     }
 }
 
-void TransferListWidget::currentChanged(const QModelIndex& current, const QModelIndex&)
+void TransferListWidget::currentChanged(const QModelIndex &current, const QModelIndex &)
 {
     qDebug("CURRENT CHANGED");
     BitTorrent::TorrentHandle *torrent = 0;
@@ -891,7 +885,7 @@ void TransferListWidget::applyTrackerFilter(const QStringList &hashes)
     nameFilterModel->setTrackerFilter(hashes);
 }
 
-void TransferListWidget::applyNameFilter(const QString& name)
+void TransferListWidget::applyNameFilter(const QString &name)
 {
     nameFilterModel->setFilterRegExp(QRegExp(name, Qt::CaseInsensitive, QRegExp::WildcardUnix));
 }
@@ -900,7 +894,7 @@ void TransferListWidget::applyStatusFilter(int f)
 {
     nameFilterModel->setStatusFilter(static_cast<TorrentFilter::Type>(f));
     // Select first item if nothing is selected
-    if (selectionModel()->selectedRows(0).empty() && nameFilterModel->rowCount() > 0) {
+    if (selectionModel()->selectedRows(0).empty() && (nameFilterModel->rowCount() > 0)) {
         qDebug("Nothing is selected, selecting first row: %s", qPrintable(nameFilterModel->index(0, TorrentModel::TR_NAME).data().toString()));
         selectionModel()->setCurrentIndex(nameFilterModel->index(0, TorrentModel::TR_NAME), QItemSelectionModel::SelectCurrent | QItemSelectionModel::Rows);
     }

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -104,6 +104,7 @@ protected slots:
     void currentChanged(const QModelIndex& current, const QModelIndex&);
     void toggleSelectedTorrentsSuperSeeding() const;
     void toggleSelectedTorrentsSequentialDownload() const;
+    void scheduleSequentialDownload();
     void toggleSelectedFirstLastPiecePrio() const;
     void setSelectedAutoTMMEnabled(bool enabled) const;
     void askNewCategoryForSelection();


### PR DESCRIPTION
The rationale is given in #182.

Implementation is based on the assumption what we set monotonically increasing deadlines for a range (which may be sparse, see below) of pieces. For that we add corresponding functions to the `TorrentHandle` class and context menu actions to the torrent list context menu and the torrent contents context menu:

![qbt-deadline-menu-torrentlist](https://cloud.githubusercontent.com/assets/394621/15623069/1814e1c0-2470-11e6-9055-d194fd4fdba6.png)

![qbt-deadline-menu-filelist](https://cloud.githubusercontent.com/assets/394621/15623071/1dadb4cc-2470-11e6-9678-41b0ae7afc82.png)

Selecting these actions we may schedule downloading for the whole torrent or for a particular file. The scheduling is based on two parameters and a flag: desired total download time, delay, and whether to apply the downloading time to all pieces or to uncompleted ones only. To help user correlate those timings with its connection speed or the file bit rate, upon selecting any of those actions the following dialogue appears:
![qbt-deadline-dialogue](https://cloud.githubusercontent.com/assets/394621/15623346/db856506-2472-11e6-923a-a39aaf43eb49.png)

The values in speed and deadline widgets are correlated via the item size. Specifying zero deadline disables this mode.

These changes are based on #4936 and thus the diff is pretty long.

Open questions:
- [ ] Item name in the dialog has to be ellipsised. Subcalss `QLabel`?
- [ ] Should we add an UI element to show current deadlines? Shall it show real time information? How could it look? A page in properties with a plot? Another kind of tooltip in the general tab?
- [ ] Should we save deadlines to fastresume? Or, maybe, submit a libtorrent patch for that? 
- [ ] Web UI
