### PR TITLE
Add a workaround for QTBUG-52633, qBt issue #5073

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1935,7 +1935,17 @@ void Session::networkConfigurationChange(const QNetworkConfiguration& cfg)
     if (configuredInterfaceName.isEmpty()) return;
 
     const QString changedInterface = cfg.name();
+
+    // workaround for QTBUG-52633: check interface IPs, react only if the IPs have changed
+    // seems to be present only with NetworkManager, hence Q_OS_LINUX
+#if defined Q_OS_LINUX && QT_VERSION >= QT_VERSION_CHECK(5, 0, 0) // && QT_VERSION <= QT_VERSION_CHECK(5, ?, ?)
+    static QStringList boundIPs = getListeningIPs();
+    const QStringList newBoundIPs = getListeningIPs();
+    if ((configuredInterfaceName == changedInterface) && (boundIPs != newBoundIPs)) {
+        boundIPs = newBoundIPs;
+#else
     if (configuredInterfaceName == changedInterface) {
+#endif
         Logger::instance()->addMessage(tr("Network configuration of %1 has changed, refreshing session binding", "e.g: Network configuration of tun0 has changed, refreshing session binding").arg(changedInterface), Log::INFO);
         configureListeningInterface();
     }


### PR DESCRIPTION
The QTBUG-52633 results in flood of network interface changed events, libtorrent IP
rebind calls and flood in the qBt log. The work around is the check not only for
interface name, but for IP address on that interface before triggering the libtorrent rebind.

I don't know yet the project policy on maintaining workarounds.
