### PR TITLE
Fix empty tooltips showed at the progress bar borders

### DIFF
--- a/src/gui/properties/piecesbar.cpp
+++ b/src/gui/properties/piecesbar.cpp
@@ -253,11 +253,11 @@ void PiecesBar::showToolTip(const QHelpEvent *e)
     QTextStream stream(&toolTipText, QIODevice::WriteOnly);
     bool showDetailedInformation = QApplication::keyboardModifiers().testFlag(Qt::ShiftModifier);
     if (showDetailedInformation) {
-        stream << "<html><body>";
         const int imagePos = e->pos().x() - borderWidth;
         if ((imagePos >=0) && (imagePos < m_image.width())) {
+            stream << "<html><body>";
             PieceIndexToImagePos transform {m_torrent->info(), m_image};
-            int pieceIndex = transform.pieceIndex(e->pos().x() - borderWidth);
+            int pieceIndex = transform.pieceIndex(imagePos);
             QVector<int> files {m_torrent->info().fileIndicesForPiece(pieceIndex)};
 
             QString tooltipTitle;
@@ -281,8 +281,8 @@ void PiecesBar::showToolTip(const QHelpEvent *e)
 
                 renderer(Utils::Misc::friendlyUnit(m_torrent->info().fileSize(f)), filePath);
             }
+            stream << "</body></html>";
         }
-        stream << "</body></html>";
     }
     else {
         stream << simpleToolTipText();


### PR DESCRIPTION
A hotfix for the detailed tooltips glitch, which appears if you request the detailed tooltip at the image border.

If tooltip text contains an empty HTML body, Qt still shows it as an
empty rectangle. Thus, output HTML tags only if we are within the
image region, and return true empty string if we are at the borders.

@Chocobo1, thank you for the test case!