### PR TITLE
Add option to disable downloading of tracker favicons. Closes #5286

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -235,6 +235,16 @@ void Preferences::setSplashScreenDisabled(bool b)
     setValue("Preferences/General/NoSplashScreen", b);
 }
 
+bool Preferences::isLoadFaviconsEnabled() const
+{
+    return value("Preferences/General/LoadTrackerFavicons", true).toBool();
+}
+
+void Preferences::setLoadFaviconsEnabled(bool b)
+{
+    setValue("Preferences/General/LoadTrackerFavicons", b);
+}
+
 // Preventing from system suspend while active torrents are presented.
 bool Preferences::preventFromSuspend() const
 {

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -235,12 +235,12 @@ void Preferences::setSplashScreenDisabled(bool b)
     setValue("Preferences/General/NoSplashScreen", b);
 }
 
-bool Preferences::isLoadFaviconsEnabled() const
+bool Preferences::isFaviconsLoadingEnabled() const
 {
     return value("Preferences/General/LoadTrackerFavicons", true).toBool();
 }
 
-void Preferences::setLoadFaviconsEnabled(bool b)
+void Preferences::setFaviconsLoadingEnabled(bool b)
 {
     setValue("Preferences/General/LoadTrackerFavicons", b);
 }

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -143,8 +143,8 @@ public:
     void setSplashScreenDisabled(bool b);
     bool preventFromSuspend() const;
     void setPreventFromSuspend(bool b);
-    bool isLoadFaviconsEnabled() const;
-    void setLoadFaviconsEnabled(bool b);
+    bool isFaviconsLoadingEnabled() const;
+    void setFaviconsLoadingEnabled(bool b);
 #ifdef Q_OS_WIN
     bool WinStartup() const;
     void setWinStartup(bool b);

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -143,6 +143,8 @@ public:
     void setSplashScreenDisabled(bool b);
     bool preventFromSuspend() const;
     void setPreventFromSuspend(bool b);
+    bool isLoadFaviconsEnabled() const;
+    void setLoadFaviconsEnabled(bool b);
 #ifdef Q_OS_WIN
     bool WinStartup() const;
     void setWinStartup(bool b);

--- a/src/gui/optionsdlg.cpp
+++ b/src/gui/optionsdlg.cpp
@@ -465,7 +465,7 @@ void OptionsDialog::saveOptions()
     pref->setMinimizeToTray(minimizeToTray());
     pref->setStartMinimized(startMinimized());
     pref->setSplashScreenDisabled(isSlashScreenDisabled());
-    pref->setLoadFaviconsEnabled(isLoadFaviconsEnabled());
+    pref->setFaviconsLoadingEnabled(isFaviconsLoadingEnabled());
     pref->setConfirmOnExit(m_ui->checkProgramExitConfirm->isChecked());
     pref->setDontConfirmAutoExit(!m_ui->checkProgramAutoExitConfirm->isChecked());
     pref->setPreventFromSuspend(preventFromSuspend());
@@ -664,7 +664,7 @@ void OptionsDialog::loadOptions()
     m_ui->comboHideZero->setCurrentIndex(pref->getHideZeroComboValues());
 
     m_ui->checkShowSplash->setChecked(!pref->isSplashScreenDisabled());
-    m_ui->checkLoadFavicons->setChecked(pref->isLoadFaviconsEnabled());
+    m_ui->checkLoadFavicons->setChecked(pref->isFaviconsLoadingEnabled());
     m_ui->checkStartMinimized->setChecked(pref->startMinimized());
     m_ui->checkProgramExitConfirm->setChecked(pref->confirmOnExit());
     m_ui->checkProgramAutoExitConfirm->setChecked(!pref->dontConfirmAutoExit());
@@ -1213,7 +1213,7 @@ bool OptionsDialog::isSlashScreenDisabled() const
     return !m_ui->checkShowSplash->isChecked();
 }
 
-bool OptionsDialog::isLoadFaviconsEnabled() const
+bool OptionsDialog::isFaviconsLoadingEnabled() const
 {
     return m_ui->checkLoadFavicons->isChecked();
 }

--- a/src/gui/optionsdlg.cpp
+++ b/src/gui/optionsdlg.cpp
@@ -179,6 +179,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     connect(m_ui->checkStartup, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
 #endif
     connect(m_ui->checkShowSplash, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(m_ui->checkLoadFavicons, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
     connect(m_ui->checkProgramExitConfirm, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
     connect(m_ui->checkProgramAutoExitConfirm, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
     connect(m_ui->checkPreventFromSuspend, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
@@ -464,6 +465,7 @@ void OptionsDialog::saveOptions()
     pref->setMinimizeToTray(minimizeToTray());
     pref->setStartMinimized(startMinimized());
     pref->setSplashScreenDisabled(isSlashScreenDisabled());
+    pref->setLoadFaviconsEnabled(isLoadFaviconsEnabled());
     pref->setConfirmOnExit(m_ui->checkProgramExitConfirm->isChecked());
     pref->setDontConfirmAutoExit(!m_ui->checkProgramAutoExitConfirm->isChecked());
     pref->setPreventFromSuspend(preventFromSuspend());
@@ -662,6 +664,7 @@ void OptionsDialog::loadOptions()
     m_ui->comboHideZero->setCurrentIndex(pref->getHideZeroComboValues());
 
     m_ui->checkShowSplash->setChecked(!pref->isSplashScreenDisabled());
+    m_ui->checkLoadFavicons->setChecked(pref->isLoadFaviconsEnabled());
     m_ui->checkStartMinimized->setChecked(pref->startMinimized());
     m_ui->checkProgramExitConfirm->setChecked(pref->confirmOnExit());
     m_ui->checkProgramAutoExitConfirm->setChecked(!pref->dontConfirmAutoExit());
@@ -1208,6 +1211,11 @@ void OptionsDialog::enableProxy(int index)
 bool OptionsDialog::isSlashScreenDisabled() const
 {
     return !m_ui->checkShowSplash->isChecked();
+}
+
+bool OptionsDialog::isLoadFaviconsEnabled() const
+{
+    return m_ui->checkLoadFavicons->isChecked();
 }
 
 #ifdef Q_OS_WIN

--- a/src/gui/optionsdlg.h
+++ b/src/gui/optionsdlg.h
@@ -115,6 +115,7 @@ private:
     bool closeToTray() const;
     bool startMinimized() const;
     bool isSlashScreenDisabled() const;
+    bool isLoadFaviconsEnabled() const;
     bool preventFromSuspend() const;
 #ifdef Q_OS_WIN
     bool WinStartup() const;

--- a/src/gui/optionsdlg.h
+++ b/src/gui/optionsdlg.h
@@ -115,7 +115,7 @@ private:
     bool closeToTray() const;
     bool startMinimized() const;
     bool isSlashScreenDisabled() const;
-    bool isLoadFaviconsEnabled() const;
+    bool isFaviconsLoadingEnabled() const;
     bool preventFromSuspend() const;
 #ifdef Q_OS_WIN
     bool WinStartup() const;

--- a/src/gui/optionsdlg.ui
+++ b/src/gui/optionsdlg.ui
@@ -353,6 +353,16 @@
                 </widget>
                </item>
                <item>
+                <widget class="QCheckBox" name="checkLoadFavicons">
+                 <property name="text">
+                  <string>Load tracker favicons</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <widget class="QCheckBox" name="checkStartMinimized">
                  <property name="text">
                   <string>Start qBittorrent minimized</string>

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -440,6 +440,7 @@ int CategoryFiltersList::rowFromCategory(const QString &category) const
 TrackerFiltersList::TrackerFiltersList(QWidget *parent, TransferListWidget *transferList)
     : FiltersBase(parent, transferList)
     , m_totalTorrents(0)
+    , m_isFaviconsLoadingEnabled(Preferences::instance()->isFaviconsLoadingEnabled())
 {
     QListWidgetItem *allTrackers = new QListWidgetItem(this);
     allTrackers->setData(Qt::DisplayRole, QVariant(tr("All (0)", "this is for the tracker filter")));
@@ -457,6 +458,8 @@ TrackerFiltersList::TrackerFiltersList(QWidget *parent, TransferListWidget *tran
 
     setCurrentRow(0, QItemSelectionModel::SelectCurrent);
     toggleFilter(Preferences::instance()->getTrackerFilterState());
+
+    connect(Preferences::instance(), SIGNAL(changed()), this, SLOT(handlePreferencesChange()));
 }
 
 TrackerFiltersList::~TrackerFiltersList()
@@ -488,7 +491,7 @@ void TrackerFiltersList::addItem(const QString &tracker, const QString &hash)
         trackerItem = new QListWidgetItem();
         trackerItem->setData(Qt::DecorationRole, GuiIconProvider::instance()->getIcon("network-server"));
 
-        if(Preferences::instance()->isLoadFaviconsEnabled())
+        if (m_isFaviconsLoadingEnabled)
             downloadFavicon(QString("http://%1/favicon.ico").arg(host));
     }
     if (!trackerItem) return;
@@ -675,6 +678,11 @@ void TrackerFiltersList::handleFavicoFailure(const QString& url, const QString& 
                                    Log::WARNING);
     if (url.endsWith(".ico", Qt::CaseInsensitive))
         downloadFavicon(url.left(url.size() - 4) + ".png");
+}
+
+void TrackerFiltersList::handlePreferencesChange()
+{
+    m_isFaviconsLoadingEnabled = Preferences::instance()->isFaviconsLoadingEnabled();
 }
 
 void TrackerFiltersList::showMenu(QPoint)

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -488,7 +488,8 @@ void TrackerFiltersList::addItem(const QString &tracker, const QString &hash)
         trackerItem = new QListWidgetItem();
         trackerItem->setData(Qt::DecorationRole, GuiIconProvider::instance()->getIcon("network-server"));
 
-        downloadFavicon(QString("http://%1/favicon.ico").arg(host));
+        if(Preferences::instance()->isLoadFaviconsEnabled())
+            downloadFavicon(QString("http://%1/favicon.ico").arg(host));
     }
     if (!trackerItem) return;
 

--- a/src/gui/transferlistfilterswidget.h
+++ b/src/gui/transferlistfilterswidget.h
@@ -145,6 +145,7 @@ public slots:
 private slots:
     void handleFavicoDownload(const QString &url, const QString &filePath);
     void handleFavicoFailure(const QString &url, const QString &reason);
+    void handlePreferencesChange();
 
 private:
     // These 4 methods are virtual slots in the base class.
@@ -165,6 +166,7 @@ private:
     QHash<QString, QStringList> m_warnings;
     QStringList m_iconPaths;
     int m_totalTorrents;
+    bool m_isFaviconsLoadingEnabled;
 };
 
 class TransferListFiltersWidget: public QFrame


### PR DESCRIPTION
This adds a feature that allows people to toggle if the tracker favicons are downloaded or if the default placeholder is used.
This closes #5286.
Here you can see the difference between loaded favicons and the placeholder:
![2016-06-12_03 19 25](https://cloud.githubusercontent.com/assets/8920528/15988354/38310cc0-304d-11e6-872d-e12992430411.png)

And the checkbox in the Options menu:
![2016-06-12_03 19 53](https://cloud.githubusercontent.com/assets/8920528/15988355/4d4e872c-304d-11e6-9b16-924aec4b3b6a.png)

This is my first pullrequest here, please let me know if there is anything I could do better.
