### PR TITLE
Fix icons are missing when using RTL languages in Options dialog

### DIFF
--- a/src/gui/optionsdlg.ui
+++ b/src/gui/optionsdlg.ui
@@ -23,6 +23,9 @@
       <bool>false</bool>
      </property>
      <widget class="QListWidget" name="tabSelection">
+      <property name="layoutDirection">
+       <enum>Qt::LeftToRight</enum>
+      </property>
       <property name="horizontalScrollBarPolicy">
        <enum>Qt::ScrollBarAlwaysOff</enum>
       </property>


### PR DESCRIPTION
The icons for selecting different pages in Options dialog were missing when using RTL languages.
It's fixed now:
![pic](https://cloud.githubusercontent.com/assets/9395168/16222446/9aaf1480-37ca-11e6-8019-536fc56c1cb6.png)

Please verify in Windows.