### PR TITLE
Changes and additions in search, peerlist, transferlist

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -1320,14 +1320,22 @@ void Preferences::setRssMainSplitterState(const QByteArray &state)
 #endif
 }
 
-QString Preferences::getSearchColsWidth() const
+QByteArray Preferences::getSearchTabHeaderState() const
 {
-    return value("SearchResultsColsWidth").toString();
+#ifdef QBT_USES_QT5
+    return value("SearchTab/qt5/SearchTabHeaderState").toByteArray();
+#else
+    return value("SearchTab/SearchTabHeaderState").toByteArray();
+#endif
 }
 
-void Preferences::setSearchColsWidth(const QString &width)
+void Preferences::setSearchTabHeaderState(const QByteArray &state)
 {
-    setValue("SearchResultsColsWidth", width);
+#ifdef QBT_USES_QT5
+    setValue("SearchTab/qt5/SearchTabHeaderState", state);
+#else
+    setValue("SearchTab/SearchTabHeaderState", state);
+#endif
 }
 
 QStringList Preferences::getSearchEngDisabled() const

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -304,8 +304,8 @@ public:
     void setRssSideSplitterState(const QByteArray &state);
     QByteArray getRssMainSplitterState() const;
     void setRssMainSplitterState(const QByteArray &state);
-    QString getSearchColsWidth() const;
-    void setSearchColsWidth(const QString &width);
+    QByteArray getSearchTabHeaderState() const;
+    void setSearchTabHeaderState(const QByteArray &state);
     QStringList getSearchEngDisabled() const;
     void setSearchEngDisabled(const QStringList &engines);
     QString getCreateTorLastAddPath() const;

--- a/src/gui/properties/peerlistdelegate.h
+++ b/src/gui/properties/peerlistdelegate.h
@@ -33,69 +33,89 @@
 
 #include <QItemDelegate>
 #include <QPainter>
+
+#include "base/preferences.h"
 #include "base/utils/misc.h"
 #include "base/utils/string.h"
-#include "base/preferences.h"
 
 class PeerListDelegate: public QItemDelegate {
-  Q_OBJECT
+    Q_OBJECT
 
 public:
-  enum PeerListColumns {COUNTRY, IP, PORT, CONNECTION, FLAGS, CLIENT, PROGRESS, DOWN_SPEED, UP_SPEED,
-                        TOT_DOWN, TOT_UP, RELEVANCE, DOWNLOADING_PIECE, IP_HIDDEN, COL_COUNT};
+    enum PeerListColumns
+    {
+        COUNTRY,
+        IP,
+        PORT,
+        CONNECTION,
+        FLAGS,
+        CLIENT,
+        PROGRESS,
+        DOWN_SPEED,
+        UP_SPEED,
+        TOT_DOWN,
+        TOT_UP, RELEVANCE,
+        DOWNLOADING_PIECE,
+        IP_HIDDEN,
+
+        COL_COUNT
+    };
 
 public:
-  PeerListDelegate(QObject *parent) : QItemDelegate(parent) {}
+    PeerListDelegate(QObject *parent) : QItemDelegate(parent) {}
 
-  ~PeerListDelegate() {}
+    ~PeerListDelegate() {}
 
-  void paint(QPainter * painter, const QStyleOptionViewItem & option, const QModelIndex & index) const {
-    painter->save();
-    const bool hideValues = Preferences::instance()->getHideZeroValues();
-    QStyleOptionViewItem opt = QItemDelegate::setOptions(index, option);
-    switch(index.column()) {
-    case PORT:
-        QItemDelegate::drawBackground(painter, opt, index);
-        opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
-        QItemDelegate::drawDisplay(painter, opt, option.rect, index.data().toString());
-        break;
-    case TOT_DOWN:
-    case TOT_UP: {
-        qlonglong size = index.data().toLongLong();
-        if (hideValues && (size <= 0))
+    void paint(QPainter * painter, const QStyleOptionViewItem & option, const QModelIndex & index) const
+    {
+        painter->save();
+        const bool hideValues = Preferences::instance()->getHideZeroValues();
+        QStyleOptionViewItem opt = QItemDelegate::setOptions(index, option);
+        switch(index.column()) {
+        case PORT: {
+            QItemDelegate::drawBackground(painter, opt, index);
+            opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
+            QItemDelegate::drawDisplay(painter, opt, option.rect, index.data().toString());
+            }
             break;
-      QItemDelegate::drawBackground(painter, opt, index);
-      opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
-      QItemDelegate::drawDisplay(painter, opt, option.rect, Utils::Misc::friendlyUnit(size));
-      }
-      break;
-    case DOWN_SPEED:
-    case UP_SPEED:{
-      QItemDelegate::drawBackground(painter, opt, index);
-      qreal speed = index.data().toDouble();
-      opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
-      if (speed > 0.0)
-        QItemDelegate::drawDisplay(painter, opt, opt.rect, Utils::Misc::friendlyUnit(speed, true));
-      break;
+        case TOT_DOWN:
+        case TOT_UP: {
+            qlonglong size = index.data().toLongLong();
+            if (hideValues && (size <= 0))
+                break;
+            QItemDelegate::drawBackground(painter, opt, index);
+            opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
+            QItemDelegate::drawDisplay(painter, opt, option.rect, Utils::Misc::friendlyUnit(size));
+            }
+            break;
+        case DOWN_SPEED:
+        case UP_SPEED:{
+            QItemDelegate::drawBackground(painter, opt, index);
+            qreal speed = index.data().toDouble();
+            opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
+            if (speed > 0.0)
+                QItemDelegate::drawDisplay(painter, opt, opt.rect, Utils::Misc::friendlyUnit(speed, true));
+            }
+            break;
+        case PROGRESS:
+        case RELEVANCE: {
+            QItemDelegate::drawBackground(painter, opt, index);
+            qreal progress = index.data().toDouble();
+            opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
+            QItemDelegate::drawDisplay(painter, opt, opt.rect, Utils::String::fromDouble(progress*100.0, 1)+"%");
+            }
+            break;
+        default:
+            QItemDelegate::paint(painter, option, index);
+        }
+        painter->restore();
     }
-    case PROGRESS:
-    case RELEVANCE:{
-      QItemDelegate::drawBackground(painter, opt, index);
-      qreal progress = index.data().toDouble();
-      opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
-      QItemDelegate::drawDisplay(painter, opt, opt.rect, Utils::String::fromDouble(progress*100.0, 1)+"%");
-      break;
-    }
-    default:
-      QItemDelegate::paint(painter, option, index);
-    }
-    painter->restore();
-  }
 
-  QWidget* createEditor(QWidget*, const QStyleOptionViewItem &, const QModelIndex &) const {
-    // No editor here
-    return 0;
-  }
+    QWidget* createEditor(QWidget*, const QStyleOptionViewItem &, const QModelIndex &) const
+    {
+        // No editor here
+        return 0;
+    }
 
 };
 

--- a/src/gui/properties/peerlistdelegate.h
+++ b/src/gui/properties/peerlistdelegate.h
@@ -52,15 +52,22 @@ public:
     painter->save();
     QStyleOptionViewItem opt = QItemDelegate::setOptions(index, option);
     switch(index.column()) {
+    case PORT:
+        QItemDelegate::drawBackground(painter, opt, index);
+        opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
+        QItemDelegate::drawDisplay(painter, opt, option.rect, index.data().toString());
+        break;
     case TOT_DOWN:
     case TOT_UP:
       QItemDelegate::drawBackground(painter, opt, index);
+      opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
       QItemDelegate::drawDisplay(painter, opt, option.rect, Utils::Misc::friendlyUnit(index.data().toLongLong()));
       break;
     case DOWN_SPEED:
     case UP_SPEED:{
       QItemDelegate::drawBackground(painter, opt, index);
       qreal speed = index.data().toDouble();
+      opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
       if (speed > 0.0)
         QItemDelegate::drawDisplay(painter, opt, opt.rect, Utils::Misc::friendlyUnit(speed, true));
       break;
@@ -69,6 +76,7 @@ public:
     case RELEVANCE:{
       QItemDelegate::drawBackground(painter, opt, index);
       qreal progress = index.data().toDouble();
+      opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
       QItemDelegate::drawDisplay(painter, opt, opt.rect, Utils::String::fromDouble(progress*100.0, 1)+"%");
       break;
     }

--- a/src/gui/properties/peerlistdelegate.h
+++ b/src/gui/properties/peerlistdelegate.h
@@ -35,6 +35,7 @@
 #include <QPainter>
 #include "base/utils/misc.h"
 #include "base/utils/string.h"
+#include "base/preferences.h"
 
 class PeerListDelegate: public QItemDelegate {
   Q_OBJECT
@@ -50,6 +51,7 @@ public:
 
   void paint(QPainter * painter, const QStyleOptionViewItem & option, const QModelIndex & index) const {
     painter->save();
+    const bool hideValues = Preferences::instance()->getHideZeroValues();
     QStyleOptionViewItem opt = QItemDelegate::setOptions(index, option);
     switch(index.column()) {
     case PORT:
@@ -58,10 +60,14 @@ public:
         QItemDelegate::drawDisplay(painter, opt, option.rect, index.data().toString());
         break;
     case TOT_DOWN:
-    case TOT_UP:
+    case TOT_UP: {
+        qlonglong size = index.data().toLongLong();
+        if (hideValues && (size <= 0))
+            break;
       QItemDelegate::drawBackground(painter, opt, index);
       opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
-      QItemDelegate::drawDisplay(painter, opt, option.rect, Utils::Misc::friendlyUnit(index.data().toLongLong()));
+      QItemDelegate::drawDisplay(painter, opt, option.rect, Utils::Misc::friendlyUnit(size));
+      }
       break;
     case DOWN_SPEED:
     case UP_SPEED:{

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -83,6 +83,14 @@ PeerListWidget::PeerListWidget(PropertiesWidget *parent)
     m_listModel->setHeaderData(PeerListDelegate::TOT_UP, Qt::Horizontal, tr("Uploaded", "i.e: total data uploaded"));
     m_listModel->setHeaderData(PeerListDelegate::RELEVANCE, Qt::Horizontal, tr("Relevance", "i.e: How relevant this peer is to us. How many pieces it has that we don't."));
     m_listModel->setHeaderData(PeerListDelegate::DOWNLOADING_PIECE, Qt::Horizontal, tr("Files", "i.e. files that are being downloaded right now"));
+    // Set header text alignment
+    m_listModel->setHeaderData(PeerListDelegate::PORT, Qt::Horizontal, QVariant(Qt::AlignRight | Qt::AlignVCenter), Qt::TextAlignmentRole);
+    m_listModel->setHeaderData(PeerListDelegate::PROGRESS, Qt::Horizontal, QVariant(Qt::AlignRight | Qt::AlignVCenter), Qt::TextAlignmentRole);
+    m_listModel->setHeaderData(PeerListDelegate::DOWN_SPEED, Qt::Horizontal, QVariant(Qt::AlignRight | Qt::AlignVCenter), Qt::TextAlignmentRole);
+    m_listModel->setHeaderData(PeerListDelegate::UP_SPEED, Qt::Horizontal, QVariant(Qt::AlignRight | Qt::AlignVCenter), Qt::TextAlignmentRole);
+    m_listModel->setHeaderData(PeerListDelegate::TOT_DOWN, Qt::Horizontal, QVariant(Qt::AlignRight | Qt::AlignVCenter), Qt::TextAlignmentRole);
+    m_listModel->setHeaderData(PeerListDelegate::TOT_UP, Qt::Horizontal, QVariant(Qt::AlignRight | Qt::AlignVCenter), Qt::TextAlignmentRole);
+    m_listModel->setHeaderData(PeerListDelegate::RELEVANCE, Qt::Horizontal, QVariant(Qt::AlignRight | Qt::AlignVCenter), Qt::TextAlignmentRole);
     // Proxy model to support sorting without actually altering the underlying model
     m_proxyModel = new PeerListSortModel();
     m_proxyModel->setDynamicSortFilter(true);

--- a/src/gui/search/searchlistdelegate.cpp
+++ b/src/gui/search/searchlistdelegate.cpp
@@ -50,14 +50,17 @@ void SearchListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
     switch(index.column()) {
     case SearchSortModel::SIZE:
         QItemDelegate::drawBackground(painter, opt, index);
+        opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
         QItemDelegate::drawDisplay(painter, opt, option.rect, Utils::Misc::friendlyUnit(index.data().toLongLong()));
         break;
     case SearchSortModel::SEEDS:
         QItemDelegate::drawBackground(painter, opt, index);
+        opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
         QItemDelegate::drawDisplay(painter, opt, option.rect, (index.data().toLongLong() >= 0) ? index.data().toString() : tr("Unknown"));
         break;
     case SearchSortModel::LEECHES:
         QItemDelegate::drawBackground(painter, opt, index);
+        opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
         QItemDelegate::drawDisplay(painter, opt, option.rect, (index.data().toLongLong() >= 0) ? index.data().toString() : tr("Unknown"));
         break;
     default:

--- a/src/gui/search/searchtab.cpp
+++ b/src/gui/search/searchtab.cpp
@@ -130,9 +130,7 @@ SearchTab::SearchTab(SearchWidget *parent)
     connect(header(), SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(displayToggleColumnsMenu(const QPoint &)));
     connect(header(), SIGNAL(sectionResized(int, int, int)), this, SLOT(saveSettings()));
     connect(header(), SIGNAL(sectionMoved(int, int, int)), this, SLOT(saveSettings()));
-
-    // Sort by Seeds
-    m_ui->resultsBrowser->sortByColumn(SearchSortModel::SEEDS, Qt::DescendingOrder);
+    connect(header(), SIGNAL(sortIndicatorChanged(int, Qt::SortOrder)), this, SLOT(saveSettings()));
 
     fillFilterComboBoxes();
 

--- a/src/gui/search/searchtab.cpp
+++ b/src/gui/search/searchtab.cpp
@@ -83,6 +83,10 @@ SearchTab::SearchTab(SearchWidget *parent)
     m_searchListModel->setHeaderData(SearchSortModel::SEEDS, Qt::Horizontal, tr("Seeders", "i.e: Number of full sources"));
     m_searchListModel->setHeaderData(SearchSortModel::LEECHES, Qt::Horizontal, tr("Leechers", "i.e: Number of partial sources"));
     m_searchListModel->setHeaderData(SearchSortModel::ENGINE_URL, Qt::Horizontal, tr("Search engine"));
+    // Set columns text alignment
+    m_searchListModel->setHeaderData(SearchSortModel::SIZE, Qt::Horizontal, QVariant(Qt::AlignRight | Qt::AlignVCenter), Qt::TextAlignmentRole);
+    m_searchListModel->setHeaderData(SearchSortModel::SEEDS, Qt::Horizontal, QVariant(Qt::AlignRight | Qt::AlignVCenter), Qt::TextAlignmentRole);
+    m_searchListModel->setHeaderData(SearchSortModel::LEECHES, Qt::Horizontal, QVariant(Qt::AlignRight | Qt::AlignVCenter), Qt::TextAlignmentRole);
 
     m_proxyModel = new SearchSortModel(this);
     m_proxyModel->setDynamicSortFilter(true);

--- a/src/gui/search/searchtab.h
+++ b/src/gui/search/searchtab.h
@@ -98,6 +98,7 @@ private slots:
     void loadSettings();
     void saveSettings() const;
     void updateFilter();
+    void displayToggleColumnsMenu(const QPoint&);
 
 private:
     void fillFilterComboBoxes();

--- a/src/gui/search/searchtab.h
+++ b/src/gui/search/searchtab.h
@@ -75,7 +75,6 @@ public:
     QTreeView* getCurrentTreeView() const;
     QHeaderView* header() const;
 
-    bool loadColWidthResultsList();
     void setRowColor(int row, const QColor &color);
 
     enum class Status
@@ -96,6 +95,8 @@ public slots:
     void downloadItem(const QModelIndex &index);
 
 private slots:
+    void loadSettings();
+    void saveSettings() const;
     void updateFilter();
 
 private:

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -267,7 +267,6 @@ void SearchWidget::on_searchButton_clicked()
     // Tab Addition
     m_currentSearchTab = new SearchTab(this);
     m_activeSearchTab = m_currentSearchTab;
-    connect(m_currentSearchTab->header(), SIGNAL(sectionResized(int, int, int)), this, SLOT(saveResultsColumnsWidth()));
     m_allTabs.append(m_currentSearchTab);
     QString tabName = pattern;
     tabName.replace(QRegExp("&{1}"), "&&");
@@ -291,21 +290,6 @@ void SearchWidget::on_searchButton_clicked()
 
     // Launch search
     m_searchEngine->startSearch(pattern, selectedCategory(), plugins);
-}
-
-void SearchWidget::saveResultsColumnsWidth()
-{
-    if (m_allTabs.isEmpty()) return;
-
-    QTreeView *treeview = m_allTabs.first()->getCurrentTreeView();
-    QStringList newWidthList;
-    short nbColumns = m_allTabs.first()->getCurrentSearchListModel()->columnCount();
-    for (short i = 0; i < nbColumns; ++i)
-        if (treeview->columnWidth(i) > 0)
-            newWidthList << QString::number(treeview->columnWidth(i));
-    // Don't save the width of the last column (auto column width)
-    newWidthList.removeLast();
-    Preferences::instance()->setSearchColsWidth(newWidthList.join(" "));
 }
 
 void SearchWidget::searchStarted()

--- a/src/gui/search/searchwidget.h
+++ b/src/gui/search/searchwidget.h
@@ -74,7 +74,6 @@ private slots:
 
     void addTorrentToSession(const QString &source);
 
-    void saveResultsColumnsWidth();
     void fillCatCombobox();
     void fillPluginComboBox();
     void searchTextEdited(QString);

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -141,7 +141,7 @@ TransferListWidget::TransferListWidget(QWidget *parent, MainWindow *main_window)
     //end up being size 0 when the new version is launched with
     //a conf file from the previous version.
     for (unsigned int i = 0; i<TorrentModel::NB_COLUMNS; i++)
-        if (!columnWidth(i))
+        if ((columnWidth(i) <= 0) && (!isColumnHidden(i)))
             resizeColumnToContents(i);
 
     setContextMenuPolicy(Qt::CustomContextMenu);


### PR DESCRIPTION
- Aligned text to the right in columns that handle numbers in PeerList and SearchTab. I wanted to do it for Content and Trackers too but i don't know how, actually i could do it in data() and headerData() for Content but i don't know how to unstretch the last column because IMO it's unacceptable to have even 1 column that aligns to the right in combination with a stretched last column.
- Make columns in Search tabs toggleable.
- Keep columns width in TransferList even if they are hidden on qBittorrent startup (unless something goes wrong) like we did in PeerList in another PR.
- Allow to hide zero values for the "uploaded" and "downloaded" columns in PeerList via "Hide zero and infinity values" (or maybe do it like the [cases below](https://github.com/qbittorrent/qBittorrent/blob/master/src/gui/properties/peerlistdelegate.h#L60) , hardcoded and no option?)
- Fix coding style in whole peerlistdelegate.h
- Experimental*: Use saveSettings() and loadSettings() to handle header state of search tabs like almost all other widgets. This saves the position of columns as well as resizes from any tab, not just from the first.
- SearchTab: Can now save sorting column changes (if the usage of saveSettings() is accepted).

*"Experimental" as in i was gonna make an issue asking why search tabs don't save columns position but i suppose it is the way it is for a reason. Then i tested saveSettings() and loadSettings() and i figured i may as well put it in the PR and see what happens.

Edit: forgot the pics:
Search
![searchtab](https://cloud.githubusercontent.com/assets/6451685/16295266/769674ca-392e-11e6-9ebf-66d10debbba4.PNG)
Peerlist
![alignright](https://cloud.githubusercontent.com/assets/6451685/16295280/90cae4c0-392e-11e6-97bf-84e969f24c5d.PNG)
