### PR TITLE
Command line arguments for specifying options when adding torrents

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -170,7 +170,7 @@ int main(int argc, char *argv[])
             qDebug("qBittorrent is already running for this user.");
 
             QThread::msleep(300);
-            app->sendParams(params.torrents);
+            app->sendParams(params.paramList());
 
             return EXIT_SUCCESS;
         }
@@ -235,7 +235,7 @@ int main(int argc, char *argv[])
         signal(SIGSEGV, sigAbnormalHandler);
 #endif
 
-        return app->exec(params.torrents);
+        return app->exec(params.paramList());
     }
     catch (CommandLineParameterError &er) {
         displayBadArgMessage(er.messageForUser());

--- a/src/app/options.h
+++ b/src/app/options.h
@@ -38,11 +38,13 @@
 #include <QString>
 #include <QStringList>
 
+#include "base/tristatebool.h"
+
 class QProcessEnvironment;
 
 struct QBtCommandLineParameters
 {
-    bool showHelp;
+    bool showHelp, relativeFastresumePaths, portableMode, skipChecking, sequential, firstLastPiecePriority;
 #ifndef Q_OS_WIN
     bool showVersion;
 #endif
@@ -52,14 +54,12 @@ struct QBtCommandLineParameters
     bool shouldDaemonize;
 #endif
     int webUiPort;
-    QString profileDir;
-    bool relativeFastresumePaths;
-    bool portableMode;
-    QString configurationName;
+    TriStateBool addPaused, skipDialog;
     QStringList torrents;
-    QString unknownParameter;
+    QString profileDir, configurationName, savePath, category, unknownParameter;
 
     QBtCommandLineParameters(const QProcessEnvironment&);
+    QStringList paramList() const;
 };
 
 class CommandLineParameterError: public std::runtime_error

--- a/src/base/bittorrent/addtorrentparams.h
+++ b/src/base/bittorrent/addtorrentparams.h
@@ -42,6 +42,7 @@ namespace BitTorrent
         QString savePath;
         bool disableTempPath = false; // e.g. for imported torrents
         bool sequential = false;
+        bool firstLastPiecePriority = false;
         TriStateBool addForced;
         TriStateBool addPaused;
         QVector<int> filePriorities; // used if TorrentInfo is set

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -3666,6 +3666,8 @@ namespace
         magnetUri = MagnetUri(QString::fromStdString(fast.dict_find_string_value("qBt-magnetUri")));
         torrentData.addPaused = fast.dict_find_int_value("qBt-paused");
         torrentData.addForced = fast.dict_find_int_value("qBt-forced");
+        torrentData.firstLastPiecePriority = fast.dict_find_int_value("qBt-firstLastPiecePriority");
+        torrentData.sequential = fast.dict_find_int_value("qBt-sequential");
 
         prio = fast.dict_find_int_value("qBt-queuePosition");
 

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -90,6 +90,7 @@ AddTorrentData::AddTorrentData(const AddTorrentParams &params)
     , savePath(params.savePath)
     , disableTempPath(params.disableTempPath)
     , sequential(params.sequential)
+    , firstLastPiecePriority(params.firstLastPiecePriority)
     , hasSeedStatus(params.skipChecking) // do not react on 'torrent_finished_alert' when skipping
     , skipChecking(params.skipChecking)
     , hasRootFolder(params.createSubfolder == TriStateBool::Undefined
@@ -208,6 +209,7 @@ TorrentHandle::TorrentHandle(Session *session, const libtorrent::torrent_handle 
     , m_tempPathDisabled(data.disableTempPath)
     , m_hasMissingFiles(false)
     , m_hasRootFolder(data.hasRootFolder)
+    , m_needsToSetFirstLastPiecePriority(false)
     , m_pauseAfterRecheck(false)
     , m_needSaveResumeData(false)
 {
@@ -217,12 +219,22 @@ TorrentHandle::TorrentHandle(Session *session, const libtorrent::torrent_handle 
     updateStatus();
     m_hash = InfoHash(m_nativeStatus.info_hash);
 
-    if (!data.resumed) {
+    // NB: the following two if statements are present because we don't want
+    // to set either sequential download or first/last piece priority to false
+    // if their respective flags in data are false when a torrent is being
+    // resumed. This is because, in that circumstance, this constructor is
+    // called with those flags set to false, even if the torrent was set to
+    // download sequentially or have first/last piece priority enabled when
+    // its resume data was saved. These two settings are restored later. But
+    // if we set them to false now, both will erroneously not be restored.
+    if (!data.resumed || data.sequential)
         setSequentialDownload(data.sequential);
-        if (hasMetadata()) {
-            if (filesCount() == 1)
-                m_hasRootFolder = false;
-        }
+    if (!data.resumed || data.firstLastPiecePriority)
+        setFirstLastPiecePriority(data.firstLastPiecePriority);
+
+    if (!data.resumed && hasMetadata()) {
+        if (filesCount() == 1)
+            m_hasRootFolder = false;
     }
 }
 
@@ -729,7 +741,8 @@ bool TorrentHandle::isSequentialDownload() const
 
 bool TorrentHandle::hasFirstLastPiecePriority() const
 {
-    if (!hasMetadata()) return false;
+    if (!hasMetadata())
+        return m_needsToSetFirstLastPiecePriority;
 
     // Get int first media file
     std::vector<int> fp;
@@ -1229,7 +1242,10 @@ void TorrentHandle::toggleSequentialDownload()
 
 void TorrentHandle::setFirstLastPiecePriority(bool b)
 {
-    if (!hasMetadata()) return;
+    if (!hasMetadata()) {
+        m_needsToSetFirstLastPiecePriority = b;
+        return;
+    }
 
     std::vector<int> fp = m_nativeHandle.file_priorities();
     std::vector<int> pp = m_nativeHandle.piece_priorities();
@@ -1508,6 +1524,11 @@ void TorrentHandle::handleSaveResumeDataAlert(libtorrent::save_resume_data_alert
         resumeData["qBt-magnetUri"] = toMagnetUri().toStdString();
         resumeData["qBt-paused"] = isPaused();
         resumeData["qBt-forced"] = isForced();
+        // Both firstLastPiecePriority and sequential need to be stored in the
+        // resume data if there is no metadata, otherwise they won't be
+        // restored if qBittorrent quits before the metadata are retrieved:
+        resumeData["qBt-firstLastPiecePriority"] = hasFirstLastPiecePriority();
+        resumeData["qBt-sequential"] = isSequentialDownload();
     }
     else {
         auto savePath = resumeData.find_key("save_path")->string();
@@ -1633,6 +1654,13 @@ void TorrentHandle::handleMetadataReceivedAlert(libt::metadata_received_alert *p
         // and the torrent can be paused when metadata is received
         m_speedMonitor.reset();
         m_session->handleTorrentPaused(this);
+    }
+    
+    // If first/last piece priority was specified when adding this torrent, we can set it
+    // now that we have metadata:
+    if (m_needsToSetFirstLastPiecePriority) {
+        setFirstLastPiecePriority(true);
+        m_needsToSetFirstLastPiecePriority = false;
     }
 }
 

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -96,6 +96,7 @@ namespace BitTorrent
         QString savePath;
         bool disableTempPath;
         bool sequential;
+        bool firstLastPiecePriority;
         bool hasSeedStatus;
         bool skipChecking;
         bool hasRootFolder;
@@ -429,6 +430,7 @@ namespace BitTorrent
         bool m_tempPathDisabled;
         bool m_hasMissingFiles;
         bool m_hasRootFolder;
+        bool m_needsToSetFirstLastPiecePriority;
 
         bool m_pauseAfterRecheck;
         bool m_needSaveResumeData;

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -76,14 +76,16 @@ namespace
     }
 }
 
-AddNewTorrentDialog::AddNewTorrentDialog(QWidget *parent)
+AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::AddTorrentParams &inParams, QWidget *parent)
     : QDialog(parent)
     , ui(new Ui::AddNewTorrentDialog)
     , m_contentModel(0)
     , m_contentDelegate(0)
     , m_hasMetadata(false)
     , m_oldIndex(0)
+    , m_torrentParams(inParams)
 {
+    // TODO: set dialog file properties using m_torrentParams.filePriorities 
     ui->setupUi(this);
     setAttribute(Qt::WA_DeleteOnClose);
     ui->lblMetaLoading->setVisible(false);
@@ -91,7 +93,13 @@ AddNewTorrentDialog::AddNewTorrentDialog(QWidget *parent)
 
     auto session = BitTorrent::Session::instance();
 
-    ui->startTorrentCheckBox->setChecked(!session->isAddTorrentPaused());
+    if (m_torrentParams.addPaused == TriStateBool::True)
+        ui->startTorrentCheckBox->setChecked(false);
+    else if (m_torrentParams.addPaused == TriStateBool::False)
+        ui->startTorrentCheckBox->setChecked(true);
+    else
+        ui->startTorrentCheckBox->setChecked(!session->isAddTorrentPaused());
+    
     ui->comboTTM->blockSignals(true); // the TreeView size isn't correct if the slot does it job at this point
     ui->comboTTM->setCurrentIndex(!session->isAutoTMMDisabledByDefault());
     ui->comboTTM->blockSignals(false);
@@ -99,8 +107,15 @@ AddNewTorrentDialog::AddNewTorrentDialog(QWidget *parent)
     connect(ui->savePathComboBox, SIGNAL(currentIndexChanged(int)), SLOT(onSavePathChanged(int)));
     connect(ui->browseButton, SIGNAL(clicked()), SLOT(browseButton_clicked()));
     ui->defaultSavePathCheckBox->setVisible(false); // Default path is selected by default
-    ui->createSubfolderCheckBox->setChecked(session->isCreateTorrentSubfolder());
 
+    if (m_torrentParams.createSubfolder == TriStateBool::True)
+        ui->createSubfolderCheckBox->setChecked(true);
+    else if (m_torrentParams.createSubfolder == TriStateBool::False)
+        ui->createSubfolderCheckBox->setChecked(false);
+    else
+        ui->createSubfolderCheckBox->setChecked(session->isCreateTorrentSubfolder());
+    
+    ui->skipCheckingCheckBox->setChecked(m_torrentParams.skipChecking);
     ui->doNotDeleteTorrentCheckBox->setVisible(TorrentFileGuard::autoDeleteMode() != TorrentFileGuard::Never);
 
     // Load categories
@@ -108,12 +123,14 @@ AddNewTorrentDialog::AddNewTorrentDialog(QWidget *parent)
     std::sort(categories.begin(), categories.end(), Utils::String::naturalCompareCaseInsensitive);
     QString defaultCategory = settings()->loadValue(KEY_DEFAULTCATEGORY).toString();
 
+    if (!m_torrentParams.category.isEmpty())
+        ui->categoryComboBox->addItem(m_torrentParams.category);
     if (!defaultCategory.isEmpty())
         ui->categoryComboBox->addItem(defaultCategory);
     ui->categoryComboBox->addItem("");
 
     foreach (const QString &category, categories)
-        if (category != defaultCategory)
+        if (category != defaultCategory && category != m_torrentParams.category)
             ui->categoryComboBox->addItem(category);
 
     ui->categoryComboBox->model()->sort(0);
@@ -179,9 +196,9 @@ void AddNewTorrentDialog::saveState()
     settings()->storeValue(KEY_EXPANDED, ui->adv_button->isChecked());
 }
 
-void AddNewTorrentDialog::show(QString source, QWidget *parent)
+void AddNewTorrentDialog::show(QString source, const BitTorrent::AddTorrentParams &inParams, QWidget *parent)
 {
-    AddNewTorrentDialog *dlg = new AddNewTorrentDialog(parent);
+    AddNewTorrentDialog *dlg = new AddNewTorrentDialog(inParams, parent);
 
     if (Utils::Misc::isUrl(source)) {
         // Launch downloader
@@ -203,6 +220,11 @@ void AddNewTorrentDialog::show(QString source, QWidget *parent)
         else
             delete dlg;
     }
+}
+
+void AddNewTorrentDialog::show(QString source, QWidget *parent)
+{
+    show(source, BitTorrent::AddTorrentParams(), parent);
 }
 
 bool AddNewTorrentDialog::loadTorrent(const QString &torrentPath)
@@ -416,6 +438,18 @@ void AddNewTorrentDialog::categoryChanged(int index)
     }
 }
 
+void AddNewTorrentDialog::setSavePath(const QString &newPath)
+{
+    int existingIndex = indexOfSavePath(newPath);
+    if (existingIndex < 0) {
+        // New path, prepend to combo box
+        ui->savePathComboBox->insertItem(0, Utils::Fs::toNativePath(newPath), newPath);
+        existingIndex = 0;
+    }
+    ui->savePathComboBox->setCurrentIndex(existingIndex);
+    onSavePathChanged(existingIndex);
+}
+
 void AddNewTorrentDialog::browseButton_clicked()
 {
     disconnect(ui->savePathComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(onSavePathChanged(int)));
@@ -430,17 +464,7 @@ void AddNewTorrentDialog::browseButton_clicked()
         newPath = QFileDialog::getExistingDirectory(this, tr("Choose save path"), QDir::homePath());
 
     if (!newPath.isEmpty()) {
-        const int existingIndex = indexOfSavePath(newPath);
-        if (existingIndex >= 0) {
-            ui->savePathComboBox->setCurrentIndex(existingIndex);
-        }
-        else {
-            // New path, prepend to combo box
-            ui->savePathComboBox->insertItem(0, Utils::Fs::toNativePath(newPath), newPath);
-            ui->savePathComboBox->setCurrentIndex(0);
-        }
-
-        onSavePathChanged(0);
+        setSavePath(newPath);
     }
     else {
         // Restore index
@@ -579,6 +603,9 @@ void AddNewTorrentDialog::populateSavePathComboBox()
     foreach (const QString &savePath, settings()->loadValue(KEY_SAVEPATHHISTORY).toStringList())
         if (QDir(savePath) != defaultSaveDir)
             ui->savePathComboBox->addItem(Utils::Fs::toNativePath(savePath), savePath);
+    
+    if (!m_torrentParams.savePath.isEmpty())
+        setSavePath(m_torrentParams.savePath);
 }
 
 void AddNewTorrentDialog::displayContentTreeMenu(const QPoint &)
@@ -626,27 +653,25 @@ void AddNewTorrentDialog::accept()
     if (!m_hasMetadata)
         disconnect(this, SLOT(updateMetadata(const BitTorrent::TorrentInfo&)));
 
-    BitTorrent::AddTorrentParams params;
-
     // TODO: Check if destination actually exists
-    params.skipChecking = ui->skipCheckingCheckBox->isChecked();
+    m_torrentParams.skipChecking = ui->skipCheckingCheckBox->isChecked();
 
     // Category
-    params.category = ui->categoryComboBox->currentText();
+    m_torrentParams.category = ui->categoryComboBox->currentText();
 
     if (ui->defaultCategoryCheckbox->isChecked())
-        settings()->storeValue(KEY_DEFAULTCATEGORY, params.category);
+        settings()->storeValue(KEY_DEFAULTCATEGORY, m_torrentParams.category);
 
     // Save file priorities
     if (m_contentModel)
-        params.filePriorities = m_contentModel->model()->getFilePriorities();
+        m_torrentParams.filePriorities = m_contentModel->model()->getFilePriorities();
 
-    params.addPaused = TriStateBool(!ui->startTorrentCheckBox->isChecked());
-    params.createSubfolder = TriStateBool(ui->createSubfolderCheckBox->isChecked());
+    m_torrentParams.addPaused = TriStateBool(!ui->startTorrentCheckBox->isChecked());
+    m_torrentParams.createSubfolder = TriStateBool(ui->createSubfolderCheckBox->isChecked());
 
     QString savePath = ui->savePathComboBox->itemData(ui->savePathComboBox->currentIndex()).toString();
     if (ui->comboTTM->currentIndex() != 1) { // 0 is Manual mode and 1 is Automatic mode. Handle all non 1 values as manual mode.
-        params.savePath = savePath;
+        m_torrentParams.savePath = savePath;
         saveSavePathHistory();
         if (ui->defaultSavePathCheckBox->isChecked())
             BitTorrent::Session::instance()->setDefaultSavePath(savePath);
@@ -656,9 +681,9 @@ void AddNewTorrentDialog::accept()
 
     // Add torrent
     if (!m_hasMetadata)
-        BitTorrent::Session::instance()->addTorrent(m_hash, params);
+        BitTorrent::Session::instance()->addTorrent(m_hash, m_torrentParams);
     else
-        BitTorrent::Session::instance()->addTorrent(m_torrentInfo, params);
+        BitTorrent::Session::instance()->addTorrent(m_torrentInfo, m_torrentParams);
 
     m_torrentGuard->markAsAddedToSession();
     QDialog::accept();

--- a/src/gui/addnewtorrentdialog.h
+++ b/src/gui/addnewtorrentdialog.h
@@ -38,6 +38,7 @@
 
 #include "base/bittorrent/infohash.h"
 #include "base/bittorrent/torrentinfo.h"
+#include "base/bittorrent/addtorrentparams.h"
 
 namespace BitTorrent
 {
@@ -65,7 +66,8 @@ public:
     static bool isTopLevel();
     static void setTopLevel(bool value);
 
-    static void show(QString source, QWidget *parent = 0);
+    static void show(QString source, const BitTorrent::AddTorrentParams &inParams, QWidget *parent);
+    static void show(QString source, QWidget *parent);
 
 private slots:
     void showAdvancedSettings(bool show);
@@ -87,7 +89,7 @@ private slots:
     void reject() override;
 
 private:
-    explicit AddNewTorrentDialog(QWidget *parent = 0);
+    explicit AddNewTorrentDialog(const BitTorrent::AddTorrentParams &inParams, QWidget *parent);
     bool loadTorrent(const QString &torrentPath);
     bool loadMagnet(const BitTorrent::MagnetUri &magnetUri);
     void populateSavePathComboBox();
@@ -98,6 +100,7 @@ private:
     void setMetadataProgressIndicator(bool visibleIndicator, const QString &labelText = QString());
     void setupTreeview();
     void setCommentText(const QString &str) const;
+    void setSavePath(const QString &newPath);
 
     void showEvent(QShowEvent *event) override;
 
@@ -112,6 +115,7 @@ private:
     QByteArray m_headerState;
     int m_oldIndex;
     QScopedPointer<TorrentFileGuard> m_torrentGuard;
+    BitTorrent::AddTorrentParams m_torrentParams;
 };
 
 #endif // ADDNEWTORRENTDIALOG_H

--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -192,16 +192,6 @@
         </property>
        </spacer>
       </item>
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="startTorrentCheckBox_2">
-        <property name="text">
-         <string>Start torrent</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
       <item row="2" column="0">
        <widget class="QCheckBox" name="createSubfolderCheckBox">
         <property name="text">

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -343,7 +343,7 @@ void RSSWidget::downloadSelectedTorrents()
 
         if (!article->torrentUrl().isEmpty()) {
             if (AddNewTorrentDialog::isEnabled())
-                AddNewTorrentDialog::show(article->torrentUrl());
+                AddNewTorrentDialog::show(article->torrentUrl(), window());
             else
                 BitTorrent::Session::instance()->addTorrent(article->torrentUrl());
         }


### PR DESCRIPTION
This pull request adds the following command line arguments to qBittorrent that apply when specifying new torrents via the command line:

-p | --path <path>: Torrent save path
--add-started | --add-paused: Add torrents as started or paused
--skip-hash-check: Skip hash check
--category <category name>: Assign torrents to category
--sequential: Download torrents in sequential order

Using one or more of these arguments will make qBittorrent skip the "Add new torrent" dialog and simply add the torrent with the specified options, falling back on the application-wide settings for the options not specified. This fulfills many users' requests for a better method of adding torrents via scripts or some other method of automation, including the ability to specify options for those new torrents, and in particular being able to specify what path they will be downloaded to.
