### PR TITLE
Fixes bug where sending email could silently fail

### DIFF
--- a/src/base/net/smtp.cpp
+++ b/src/base/net/smtp.cpp
@@ -97,6 +97,13 @@ Smtp::Smtp(QObject *parent)
     , m_useSsl(false)
     , m_authType(AuthPlain)
 {
+    static bool needToRegisterMetaType = true;
+    
+    if (needToRegisterMetaType) {
+        qRegisterMetaType<QAbstractSocket::SocketError>();
+        needToRegisterMetaType = false;
+    }
+    
 #ifndef QT_NO_OPENSSL
     m_socket = new QSslSocket(this);
 #else
@@ -105,6 +112,7 @@ Smtp::Smtp(QObject *parent)
 
     connect(m_socket, SIGNAL(readyRead()), SLOT(readyRead()));
     connect(m_socket, SIGNAL(disconnected()), SLOT(deleteLater()));
+    connect(m_socket, SIGNAL(error(QAbstractSocket::SocketError)), SLOT(error(QAbstractSocket::SocketError)));
 
     // Test hmacMD5 function (http://www.faqs.org/rfcs/rfc2202.html)
     Q_ASSERT(hmacMD5("Jefe", "what do ya want for nothing?").toHex()
@@ -524,4 +532,12 @@ QString Smtp::getCurrentDateTime() const
 
     QString ret = weekDayStr + ", " + dayStr + " " + monthStr + " " + yearStr + " " + timeStr + " " + timeOffsetStr;
     return ret;
+}
+
+void Smtp::error(QAbstractSocket::SocketError socketError)
+{
+    // Getting a remote host closed error is apparently normal, even when successfully sending
+    // an email
+    if (socketError != QAbstractSocket::RemoteHostClosedError)
+        logError(m_socket->errorString());
 }

--- a/src/base/net/smtp.h
+++ b/src/base/net/smtp.h
@@ -39,6 +39,8 @@
 #include <QObject>
 #include <QByteArray>
 #include <QHash>
+#include <QAbstractSocket>
+#include <QMetaType>
 
 QT_BEGIN_NAMESPACE
 class QTextStream;
@@ -64,6 +66,7 @@ namespace Net
 
     private slots:
         void readyRead();
+        void error(QAbstractSocket::SocketError socketError);
 
     private:
         enum States
@@ -122,5 +125,9 @@ namespace Net
         QString m_password;
     };
 }
+
+#ifndef QBT_USES_QT5
+Q_DECLARE_METATYPE(QAbstractSocket::SocketError)
+#endif
 
 #endif

--- a/src/gui/optionsdlg.cpp
+++ b/src/gui/optionsdlg.cpp
@@ -149,6 +149,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
 
 #if defined(QT_NO_OPENSSL)
     m_ui->checkWebUiHttps->setVisible(false);
+    m_ui->checkSmtpSSL->setVisible(false);
 #endif
 
 #ifndef Q_OS_WIN


### PR DESCRIPTION
This pull request includes two relatively minor fixes:

1. Fixes a bug with the smtp client where in certain cases sending an email when a torrent completes would silently fail. Cases where it could happen includes but is not limited to: trying to connect to an SMTP server without encryption when it requires SSL, the connecting timing out, or the connection being refused.

2. Hides the "This server requires a secure connection (SSL)" checkbox in the settings when qBittorrent is built without SSL support, as all emails will be unencrypted anyway. This is consistent with the SSL aspects of the Web UI settings being hidden when the build does not include SSL.