### PR TITLE
Fix 6-hour speedplot point push rate #5545

### DIFF
--- a/src/gui/properties/speedplotview.cpp
+++ b/src/gui/properties/speedplotview.cpp
@@ -81,7 +81,7 @@ void SpeedPlotView::setGraphEnable(GraphID id, bool enable)
 void SpeedPlotView::pushPoint(SpeedPlotView::PointData point)
 {
     m_counter30Min = (m_counter30Min + 1) % 3;
-    m_counter6Hour = (m_counter6Hour + 1) % 6;
+    m_counter6Hour = (m_counter6Hour + 1) % 18;
 
     m_data5Min.push_back(point);
 
@@ -131,7 +131,7 @@ void SpeedPlotView::replot()
     if ((m_period == MIN1)
         || (m_period == MIN5)
         || ((m_period == MIN30) && (m_counter30Min == 2))
-        || ((m_period == HOUR6) && (m_counter6Hour == 5)))
+        || ((m_period == HOUR6) && (m_counter6Hour == 17)))
         viewport()->update();
 }
 


### PR DESCRIPTION
I've briefly looked into the code, and i think [this causes the bug](https://github.com/onto/qBittorrent/blob/cdab0bb140b76083dbc77dea3caaeba445d08a37/src/gui/properties/speedplotview.cpp#L84).
It should be `m_counter6Hour = (m_counter6Hour + 1) % 18;` instead of the `% 6` (and not 36, since [it has a double-sized buffer](https://github.com/onto/qBittorrent/blob/cdab0bb140b76083dbc77dea3caaeba445d08a37/src/gui/properties/speedplotview.h#L98) compared to the 30 min plot)