### PR TITLE
Call system msiexec.exe directly

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -261,13 +261,8 @@ void Application::runExternalProgram(BitTorrent::TorrentHandle *const torrent) c
 #if defined(Q_OS_UNIX)
     QProcess::startDetached(QLatin1String("/bin/sh"), {QLatin1String("-c"), program});
 #elif defined(Q_OS_WIN)  // test cmd: `echo "%F" > "c:\ab ba.txt"`
-    static const QString cmdPath = []() -> QString {
-        WCHAR systemPath[64] = {0};
-        GetSystemDirectoryW(systemPath, sizeof(systemPath) / sizeof(WCHAR));
-        return QString::fromWCharArray(systemPath) + QLatin1String("\\cmd.exe /C ");
-    }();
     program.prepend(QLatin1String("\"")).append(QLatin1String("\""));
-    program.prepend(cmdPath);
+    program.prepend(Utils::Misc::windowsSystemPath() + QLatin1String("\\cmd.exe /C "));
     const uint cmdMaxLength = 32768;  // max length (incl. terminate char) for `lpCommandLine` in `CreateProcessW()`
     if ((program.size() + 1) > cmdMaxLength) {
         logger->addMessage(tr("Torrent: %1, run external program command too long (length > %2), execution failed.").arg(torrent->name()).arg(cmdMaxLength), Log::CRITICAL);

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -696,3 +696,15 @@ QString Utils::Misc::libtorrentVersionString()
     static const QString ver = LIBTORRENT_VERSION;
     return ver;
 }
+
+#ifdef Q_OS_WIN
+QString Utils::Misc::windowsSystemPath()
+{
+    static const QString path = []() -> QString {
+        WCHAR systemPath[64] = {0};
+        GetSystemDirectoryW(systemPath, sizeof(systemPath) / sizeof(WCHAR));
+        return QString::fromWCharArray(systemPath);
+    }();
+    return path;
+}
+#endif

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -102,12 +102,16 @@ namespace Utils
         QList<int> intListfromStringList(const QStringList &l);
         QList<bool> boolListfromStringList(const QStringList &l);
 
+        void msleep(unsigned long msecs);
+
 #ifndef DISABLE_GUI
         void openPath(const QString& absolutePath);
         void openFolderSelect(const QString& absolutePath);
 #endif
 
-        void msleep(unsigned long msecs);
+#ifdef Q_OS_WIN
+        QString windowsSystemPath();
+#endif
     }
 }
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1772,7 +1772,7 @@ void MainWindow::pythonDownloadSuccess(const QString &url, const QString &filePa
     QProcess installer;
     qDebug("Launching Python installer in passive mode...");
 
-    installer.start("msiexec.exe /passive /i " + Utils::Fs::toNativePath(filePath) + ".msi");
+    installer.start(Utils::Misc::windowsSystemPath() + "\\msiexec.exe /passive /i " + Utils::Fs::toNativePath(filePath) + ".msi");
     // Wait for setup to complete
     installer.waitForFinished();
 


### PR DESCRIPTION
Searching through various directories for a system program is not a good practice.