### PR TITLE
Add torrent and files deletion with Shift+Delete hotkey

### DIFF
--- a/src/gui/deletionconfirmationdlg.h
+++ b/src/gui/deletionconfirmationdlg.h
@@ -42,7 +42,7 @@ class DeletionConfirmationDlg : public QDialog, private Ui::confirmDeletionDlg {
   Q_OBJECT
 
   public:
-  DeletionConfirmationDlg(QWidget *parent, const int &size, const QString &name): QDialog(parent) {
+  DeletionConfirmationDlg(QWidget *parent, const int &size, const QString &name, bool defaultDeleteFiles): QDialog(parent) {
     setupUi(this);
     if (size == 1)
       label->setText(tr("Are you sure you want to delete '%1' from the transfer list?", "Are you sure you want to delete 'ubuntu-linux-iso' from the transfer list?").arg(name));
@@ -54,7 +54,7 @@ class DeletionConfirmationDlg : public QDialog, private Ui::confirmDeletionDlg {
     rememberBtn->setIcon(GuiIconProvider::instance()->getIcon("object-locked"));
 
     move(Utils::Misc::screenCenter(this));
-    checkPermDelete->setChecked(Preferences::instance()->deleteTorrentFilesAsDefault());
+    checkPermDelete->setChecked(defaultDeleteFiles || Preferences::instance()->deleteTorrentFilesAsDefault());
     connect(checkPermDelete, SIGNAL(clicked()), this, SLOT(updateRememberButtonState()));
     buttonBox->button(QDialogButtonBox::Cancel)->setFocus();
   }
@@ -63,10 +63,10 @@ class DeletionConfirmationDlg : public QDialog, private Ui::confirmDeletionDlg {
     return checkPermDelete->isChecked();
   }
 
-  static bool askForDeletionConfirmation(bool& delete_local_files, const int& size, const QString& name) {
-    DeletionConfirmationDlg dlg(NULL, size, name);
+  static bool askForDeletionConfirmation(bool& deleteLocalFiles, const int& size, const QString& name) {
+    DeletionConfirmationDlg dlg(NULL, size, name, deleteLocalFiles);
     if (dlg.exec() == QDialog::Accepted) {
-      delete_local_files = dlg.shouldDeleteLocalFiles();
+      deleteLocalFiles = dlg.shouldDeleteLocalFiles();
       return true;
     }
     return false;

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -248,7 +248,7 @@ MainWindow::MainWindow(QWidget *parent)
     connect(m_ui->actionStartAll, SIGNAL(triggered()), m_transferListWidget, SLOT(resumeAllTorrents()));
     connect(m_ui->actionPause, SIGNAL(triggered()), m_transferListWidget, SLOT(pauseSelectedTorrents()));
     connect(m_ui->actionPauseAll, SIGNAL(triggered()), m_transferListWidget, SLOT(pauseAllTorrents()));
-    connect(m_ui->actionDelete, SIGNAL(triggered()), m_transferListWidget, SLOT(deleteSelectedTorrents()));
+    connect(m_ui->actionDelete, SIGNAL(triggered()), m_transferListWidget, SLOT(softDeleteSelectedTorrents()));
     connect(m_ui->actionTopPriority, SIGNAL(triggered()), m_transferListWidget, SLOT(topPrioSelectedTorrents()));
     connect(m_ui->actionIncreasePriority, SIGNAL(triggered()), m_transferListWidget, SLOT(increasePrioSelectedTorrents()));
     connect(m_ui->actionDecreasePriority, SIGNAL(triggered()), m_transferListWidget, SLOT(decreasePrioSelectedTorrents()));

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -68,7 +68,9 @@ public slots:
     void startVisibleTorrents();
     void pauseSelectedTorrents();
     void pauseVisibleTorrents();
-    void deleteSelectedTorrents();
+    void softDeleteSelectedTorrents();
+    void permDeleteSelectedTorrents();
+    void deleteSelectedTorrents(bool deleteLocalFiles);
     void deleteVisibleTorrents();
     void increasePrioSelectedTorrents();
     void decreasePrioSelectedTorrents();
@@ -119,6 +121,7 @@ private:
     MainWindow *main_window;
     QShortcut *editHotkey;
     QShortcut *deleteHotkey;
+    QShortcut *permDeleteHotkey;
 };
 
 #endif // TRANSFERLISTWIDGET_H


### PR DESCRIPTION
Added new shortcut (shift+delete) to open delete torrent dialog with checkbox to remove files checked.
Old behaviour with just delete key or toolbar button unchanged.