### PR TITLE
Allow paused status to be applied to added torrents based on config setting

### DIFF
--- a/src/base/scanfoldersmodel.cpp
+++ b/src/base/scanfoldersmodel.cpp
@@ -361,6 +361,8 @@ void ScanFoldersModel::addTorrentsToSession(const QStringList &pathList)
         else if (!downloadInDefaultFolder(file))
             params.savePath = downloadPathTorrentFolder(file);
 
+        params.addPaused = BitTorrent::Session::instance()->isAddTorrentPaused();
+
         if (file.endsWith(".magnet")) {
             QFile f(file);
             if (f.open(QIODevice::ReadOnly | QIODevice::Text)) {

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -392,6 +392,7 @@ void WebApplication::action_command_download()
     BitTorrent::AddTorrentParams params;
     params.savePath = savepath;
     params.category = category;
+    params.addPaused = BitTorrent::Session::instance()->isAddTorrentPaused();
 
     foreach (QString url, list) {
         url = url.trimmed();
@@ -425,6 +426,7 @@ void WebApplication::action_command_upload()
                 BitTorrent::AddTorrentParams params;
                 params.savePath = savepath;
                 params.category = category;
+                params.addPaused = BitTorrent::Session::instance()->isAddTorrentPaused();
                 if (!BitTorrent::Session::instance()->addTorrent(torrentInfo, params)) {
                     status(500, "Internal Server Error");
                     print(QObject::tr("Error: Could not add torrent to session."), Http::CONTENT_TYPE_TXT);


### PR DESCRIPTION
This will allow torrents to be added with a default state of "Paused" based on the config setting of: Downloads\StartInPause=true.

This applies to both watched directories AND torrents added via the webui (download [file url fetch] or upload payload).
