### PR TITLE
 Fix WEBUI port overflow

### DIFF
--- a/src/base/net/portforwarder.cpp
+++ b/src/base/net/portforwarder.cpp
@@ -70,7 +70,7 @@ PortForwarder *PortForwarder::instance()
     return m_instance;
 }
 
-void PortForwarder::addPort(qint16 port)
+void PortForwarder::addPort(quint16 port)
 {
     if (!m_mappedPorts.contains(port)) {
         m_mappedPorts.insert(port, 0);
@@ -79,7 +79,7 @@ void PortForwarder::addPort(qint16 port)
     }
 }
 
-void PortForwarder::deletePort(qint16 port)
+void PortForwarder::deletePort(quint16 port)
 {
     if (m_mappedPorts.contains(port)) {
         if (m_active)
@@ -104,7 +104,7 @@ void PortForwarder::start()
     qDebug("Enabling UPnP / NAT-PMP");
     m_provider->start_upnp();
     m_provider->start_natpmp();
-    foreach (qint16 port, m_mappedPorts.keys())
+    foreach (quint16 port, m_mappedPorts.keys())
         m_mappedPorts[port] = m_provider->add_port_mapping(libt::session::tcp, port, port);
     m_active = true;
     Logger::instance()->addMessage(tr("UPnP / NAT-PMP support [ON]"), Log::INFO);

--- a/src/base/net/portforwarder.h
+++ b/src/base/net/portforwarder.h
@@ -49,8 +49,8 @@ namespace Net
         static void freeInstance();
         static PortForwarder *instance();
 
-        void addPort(qint16 port);
-        void deletePort(qint16 port);
+        void addPort(quint16 port);
+        void deletePort(quint16 port);
 
     private slots:
         void configure();
@@ -64,7 +64,7 @@ namespace Net
 
         bool m_active;
         libtorrent::session *m_provider;
-        QHash<qint16, int> m_mappedPorts;
+        QHash<quint16, int> m_mappedPorts;
 
         static PortForwarder *m_instance;
     };

--- a/src/webui/webui.h
+++ b/src/webui/webui.h
@@ -58,7 +58,7 @@ private:
     QPointer<Http::Server> httpServer_;
     QPointer<Net::DNSUpdater> dynDNSUpdater_;
     QPointer<AbstractWebApplication> webapp_;
-    qint16 m_port;
+    quint16 m_port;
 };
 
 #endif // WEBUI_H


### PR DESCRIPTION
Can now use WEBUI port bigger than 32766. Don't know if this causes any other problems.
Also changed the remaining `qint16` to `quint16` in `portforwarder` (other than `addPort()` `deletePort()`) as it makes no sense to use `signed type` for ports.

Although i tested it and didn't get any new problems, i get all sorts of UPnP errors (`unknown UPnP error (-1)`, `500 Internal Server Error`, `400 Bad Request`) when i try to change port or disable UPnP from the options, with or without these changes so testing for side effects is limited. 

/Offtopic
The problem i mention in #5673 about being able to change port only once per qbit session remains. To circumvent it you can change port, apply, disable UPnP and re-enable it and it'll open the port.