### PR TITLE
Add editable save path option to "Add New Torrent" dialog

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -373,6 +373,16 @@ void Preferences::setActionOnDblClOnTorrentFn(int act)
     setValue("Preferences/Downloads/DblClOnTorFn", act);
 }
 
+bool Preferences::getEditableSavePath() const
+{
+    return value("Preferences/Downloads/EditableSavePath").toBool();
+}
+
+void Preferences::setEditableSavePath(bool enabled)
+{
+    setValue("Preferences/Downloads/EditableSavePath", enabled);
+}
+
 QTime Preferences::getSchedulerStartTime() const
 {
     return value("Preferences/Scheduler/start_time", QTime(8,0)).toTime();

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -158,6 +158,8 @@ public:
     void setActionOnDblClOnTorrentDl(int act);
     int getActionOnDblClOnTorrentFn() const;
     void setActionOnDblClOnTorrentFn(int act);
+    bool getEditableSavePath() const;
+    void setEditableSavePath(bool enabled);
 
     // Connection options
     QTime getSchedulerStartTime() const;

--- a/src/base/settingsstorage.cpp
+++ b/src/base/settingsstorage.cpp
@@ -177,9 +177,8 @@ namespace
             {"AddNewTorrentDialog/SavePathHistory", "TorrentAdditionDlg/save_path_history"},
             {"AddNewTorrentDialog/Enabled", "Preferences/Downloads/NewAdditionDialog"},
             {"AddNewTorrentDialog/TopLevel", "Preferences/Downloads/NewAdditionDialogFront"},
-
+            {"AddNewTorrentDialog/EditableSavePath", "Preferences/Downloads/EditableSavePath"},
             {"State/BannedIPs", "Preferences/IPFilter/BannedIPs"}
-
         };
 
         return keyMapping.value(key, key);

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -65,6 +65,7 @@ const QString KEY_EXPANDED = SETTINGS_KEY("Expanded");
 const QString KEY_POSITION = SETTINGS_KEY("Position");
 const QString KEY_TOPLEVEL = SETTINGS_KEY("TopLevel");
 const QString KEY_SAVEPATHHISTORY = SETTINGS_KEY("SavePathHistory");
+const QString KEY_EDITABLESAVEPATH = SETTINGS_KEY("EditableSavePath");
 
 namespace
 {
@@ -91,6 +92,12 @@ AddNewTorrentDialog::AddNewTorrentDialog(QWidget *parent)
     ui->comboTTM->blockSignals(true); //the TreeView size isn't correct if the slot does it job at this point
     ui->comboTTM->setCurrentIndex(!session->isAutoTMMDisabledByDefault());
     ui->comboTTM->blockSignals(false);
+    
+    if (settings()->loadValue(KEY_EDITABLESAVEPATH).toBool())
+    {
+	ui->savePathComboBox->setEditable(true);
+    }
+    
     populateSavePathComboBox();
     connect(ui->savePathComboBox, SIGNAL(currentIndexChanged(int)), SLOT(onSavePathChanged(int)));
     connect(ui->browseButton, SIGNAL(clicked()), SLOT(browseButton_clicked()));

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -430,7 +430,7 @@ void AddNewTorrentDialog::onSavePathTextEdited()
     const QString &path = ui->savePathComboBox->currentText();
 
     // Show "Default Save Path" check box
-    ui->defaultSavePathCheckBox->setVisible(QDir(path) != QDir(defaultSavePath()));
+    ui->defaultSavePathCheckBox->setVisible(QDir(path) != QDir(BitTorrent::Session::instance()->defaultSavePath())); 
     
     if (!isSavePathValid(path)) { 
 	// Red background indicating invalid save path

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -419,8 +419,10 @@ void AddNewTorrentDialog::onSavePathChanged(int index)
 
     updateDiskSpaceLabel();
 
-    // Clear red background in case onSavePathTextEdited modified it
-    ui->savePathComboBox->lineEdit()->setStyleSheet("");
+    if (ui->savePathComboBox->isEditable()) {
+	// Clear red background in case onSavePathTextEdited modified it
+	ui->savePathComboBox->lineEdit()->setStyleSheet("");
+    }
 }
 
 void AddNewTorrentDialog::onSavePathTextEdited()
@@ -435,8 +437,10 @@ void AddNewTorrentDialog::onSavePathTextEdited()
 	ui->savePathComboBox->lineEdit()->setStyleSheet("QLineEdit {background: #FF9090;}");
     }
     else {
-	// Clear red background
-	ui->savePathComboBox->lineEdit()->setStyleSheet("");
+	if (ui->savePathComboBox->isEditable()) {
+	    // Clear red background
+	    ui->savePathComboBox->lineEdit()->setStyleSheet("");    
+	}
 	updateDiskSpaceLabel();
     }
 }
@@ -466,7 +470,7 @@ void AddNewTorrentDialog::browseButton_clicked()
         newPath = QFileDialog::getExistingDirectory(this, tr("Choose save path"), QDir::homePath());
 
     if (!newPath.isEmpty()) {
-	ui->savePathComboBox->lineEdit()->setText(newPath);
+	addPathToHistory(newPath);
     }
 
     ui->savePathComboBox->blockSignals(false);

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -34,6 +34,8 @@
 #include <QUrl>
 #include <QMenu>
 #include <QFileDialog>
+#include <QCompleter>
+#include <QDirModel>
 
 #include "base/settingsstorage.h"
 #include "base/net/downloadmanager.h"
@@ -96,10 +98,23 @@ AddNewTorrentDialog::AddNewTorrentDialog(QWidget *parent)
     if (settings()->loadValue(KEY_EDITABLESAVEPATH).toBool())
     {
 	ui->savePathComboBox->setEditable(true);
+	
+	// Autocomplete folder names
+	QCompleter* completer = new QCompleter(this);
+	completer->setCaseSensitivity(Qt::CaseInsensitive);
+	
+	QDirModel *fileSystemModel = new QDirModel(completer);
+	fileSystemModel->setFilter(QDir::AllDirs | QDir::NoDotAndDotDot);
+        
+	completer->setModel(fileSystemModel);
+
+	ui->savePathComboBox->lineEdit()->setCompleter(completer);
+	
+        connect(ui->savePathComboBox->lineEdit(), SIGNAL(textEdited(const QString &)), SLOT(onSavePathTextEdited()));
     }
     
     populateSavePathComboBox();
-    connect(ui->savePathComboBox, SIGNAL(currentIndexChanged(int)), SLOT(onSavePathChanged(int)));
+    connect(ui->savePathComboBox, SIGNAL(activated(int)), SLOT(onSavePathChanged(int)));
     connect(ui->browseButton, SIGNAL(clicked()), SLOT(browseButton_clicked()));
     ui->defaultSavePathCheckBox->setVisible(false); // Default path is selected by default
 
@@ -340,7 +355,7 @@ void AddNewTorrentDialog::showAdvancedSettings(bool show)
 
 void AddNewTorrentDialog::saveSavePathHistory() const
 {
-    QDir selectedSavePath(ui->savePathComboBox->itemData(ui->savePathComboBox->currentIndex()).toString());
+    QDir selectedSavePath(ui->savePathComboBox->currentText());
     // Get current history
     QStringList history = settings()->loadValue(KEY_SAVEPATHHISTORY).toStringList();
     QList<QDir> historyDirs;
@@ -388,8 +403,7 @@ void AddNewTorrentDialog::updateDiskSpaceLabel()
     QString size_string = torrent_size ? Utils::Misc::friendlyUnit(torrent_size) : QString(tr("Not Available", "This size is unavailable."));
     size_string += " (";
     size_string += tr("Free space on disk: %1").arg(Utils::Misc::friendlyUnit(Utils::Fs::freeDiskSpaceOnPath(
-                                                                   ui->savePathComboBox->itemData(
-                                                                       ui->savePathComboBox->currentIndex()).toString())));
+                                                                   ui->savePathComboBox->currentText())));
     size_string += ")";
     ui->size_lbl->setText(size_string);
 }
@@ -398,14 +412,33 @@ void AddNewTorrentDialog::onSavePathChanged(int index)
 {
     // Toggle default save path setting checkbox visibility
     ui->defaultSavePathCheckBox->setChecked(false);
-    ui->defaultSavePathCheckBox->setVisible(
-                QDir(ui->savePathComboBox->itemData(ui->savePathComboBox->currentIndex()).toString())
-                != QDir(BitTorrent::Session::instance()->defaultSavePath()));
+    ui->defaultSavePathCheckBox->setVisible(QDir(ui->savePathComboBox->currentText()) != QDir(BitTorrent::Session::instance()->defaultSavePath()));
 
     // Remember index
     m_oldIndex = index;
 
     updateDiskSpaceLabel();
+
+    // Clear red background in case onSavePathTextEdited modified it
+    ui->savePathComboBox->lineEdit()->setStyleSheet("");
+}
+
+void AddNewTorrentDialog::onSavePathTextEdited()
+{
+    const QString &path = ui->savePathComboBox->currentText();
+
+    // Show "Default Save Path" check box
+    ui->defaultSavePathCheckBox->setVisible(QDir(path) != QDir(defaultSavePath()));
+    
+    if (!isSavePathValid(path)) { 
+	// Red background indicating invalid save path
+	ui->savePathComboBox->lineEdit()->setStyleSheet("QLineEdit {background: #FF9090;}");
+    }
+    else {
+	// Clear red background
+	ui->savePathComboBox->lineEdit()->setStyleSheet("");
+	updateDiskSpaceLabel();
+    }
 }
 
 void AddNewTorrentDialog::categoryChanged(int index)
@@ -421,7 +454,7 @@ void AddNewTorrentDialog::categoryChanged(int index)
 
 void AddNewTorrentDialog::browseButton_clicked()
 {
-    disconnect(ui->savePathComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(onSavePathChanged(int)));
+    ui->savePathComboBox->blockSignals(true);
 
     // User is asking for a new save path
     QString curSavePath = ui->savePathComboBox->itemText(m_oldIndex);
@@ -433,24 +466,34 @@ void AddNewTorrentDialog::browseButton_clicked()
         newPath = QFileDialog::getExistingDirectory(this, tr("Choose save path"), QDir::homePath());
 
     if (!newPath.isEmpty()) {
-        const int existingIndex = indexOfSavePath(newPath);
-        if (existingIndex >= 0) {
-            ui->savePathComboBox->setCurrentIndex(existingIndex);
-        }
-        else {
-            // New path, prepend to combo box
-            ui->savePathComboBox->insertItem(0, Utils::Fs::toNativePath(newPath), newPath);
-            ui->savePathComboBox->setCurrentIndex(0);
-        }
+	ui->savePathComboBox->lineEdit()->setText(newPath);
+    }
 
-        onSavePathChanged(0);
+    ui->savePathComboBox->blockSignals(false);
+}
+
+bool AddNewTorrentDialog::isSavePathValid(const QString& path) const
+{
+    return !path.isEmpty() &&
+	Utils::Fs::isValidFileSystemName(path, true) &&
+	QDir::isAbsolutePath(path);
+}
+
+void AddNewTorrentDialog::addPathToHistory(QString &path)
+{
+    int existingPathIndex = ui->savePathComboBox->findText(path);
+    
+    ui->savePathComboBox->blockSignals(true);
+    
+    if (existingPathIndex == -1) {	
+	ui->savePathComboBox->insertItem(0, Utils::Fs::toNativePath(path), path);
+	ui->savePathComboBox->setCurrentIndex(0);
     }
     else {
-        // Restore index
-        ui->savePathComboBox->setCurrentIndex(m_oldIndex);
+	ui->savePathComboBox->setCurrentIndex(existingPathIndex);
     }
-
-    connect(ui->savePathComboBox, SIGNAL(currentIndexChanged(int)), SLOT(onSavePathChanged(int)));
+    
+    ui->savePathComboBox->blockSignals(false);
 }
 
 void AddNewTorrentDialog::renameSelectedFile()
@@ -647,7 +690,21 @@ void AddNewTorrentDialog::accept()
 
     params.addPaused = !ui->startTorrentCheckBox->isChecked();
 
-    QString savePath = ui->savePathComboBox->itemData(ui->savePathComboBox->currentIndex()).toString();
+    QString savePath = ui->savePathComboBox->currentText();
+
+    // If save path is editable, check if is a valid path
+    if (settings()->loadValue(KEY_EDITABLESAVEPATH).toBool()) {
+	if (!isSavePathValid(savePath)) {
+	    ui->savePathComboBox->lineEdit()->setFocus();
+	    return;
+	}
+	else {
+	    savePath = QDir::cleanPath(savePath);
+	    QDir(savePath).mkpath(".");
+	    addPathToHistory(savePath);
+	}
+    }
+    
     if (ui->comboTTM->currentIndex() != 1) { // 0 is Manual mode and 1 is Automatic mode. Handle all non 1 values as manual mode.
         params.savePath = savePath;
         saveSavePathHistory();

--- a/src/gui/addnewtorrentdialog.h
+++ b/src/gui/addnewtorrentdialog.h
@@ -72,6 +72,7 @@ private slots:
     void displayContentTreeMenu(const QPoint&);
     void updateDiskSpaceLabel();
     void onSavePathChanged(int);
+    void onSavePathTextEdited();
     void renameSelectedFile();
     void setdialogPosition();
     void updateMetadata(const BitTorrent::TorrentInfo &info);
@@ -98,7 +99,9 @@ private:
     void setMetadataProgressIndicator(bool visibleIndicator, const QString &labelText = QString());
     void setupTreeview();
     void setCommentText(const QString &str) const;
-
+    bool isSavePathValid(const QString &path) const;
+    void addPathToHistory(QString &path);
+    
     void showEvent(QShowEvent *event) override;
 
     Ui::AddNewTorrentDialog *ui;

--- a/src/gui/optionsdlg.cpp
+++ b/src/gui/optionsdlg.cpp
@@ -216,6 +216,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     connect(m_ui->checkAdditionDialog, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
     connect(m_ui->checkAdditionDialogFront, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
     connect(m_ui->checkStartPaused, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+    connect(m_ui->checkEditableSavePath, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
     connect(m_ui->deleteTorrentBox, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
     connect(m_ui->deleteCancelledTorrentBox, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
     connect(m_ui->checkExportDir, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
@@ -514,6 +515,7 @@ void OptionsDialog::saveOptions()
     AddNewTorrentDialog::setEnabled(useAdditionDialog());
     AddNewTorrentDialog::setTopLevel(m_ui->checkAdditionDialogFront->isChecked());
     session->setAddTorrentPaused(addTorrentsInPause());
+    pref->setEditableSavePath(isEditableSavePath());
     ScanFoldersModel::instance()->removeFromFSWatcher(removedScanDirs);
     ScanFoldersModel::instance()->addToFSWatcher(addedScanDirs);
     ScanFoldersModel::instance()->makePersistent();
@@ -715,6 +717,7 @@ void OptionsDialog::loadOptions()
     m_ui->checkAdditionDialog->setChecked(AddNewTorrentDialog::isEnabled());
     m_ui->checkAdditionDialogFront->setChecked(AddNewTorrentDialog::isTopLevel());
     m_ui->checkStartPaused->setChecked(session->isAddTorrentPaused());
+    m_ui->checkEditableSavePath->setChecked(pref->getEditableSavePath());
     const TorrentFileGuard::AutoDeleteMode autoDeleteMode = TorrentFileGuard::autoDeleteMode();
     m_ui->deleteTorrentBox->setChecked(autoDeleteMode != TorrentFileGuard::Never);
     m_ui->deleteCancelledTorrentBox->setChecked(autoDeleteMode == TorrentFileGuard::Always);
@@ -1244,6 +1247,11 @@ bool OptionsDialog::preAllocateAllFiles() const
 bool OptionsDialog::addTorrentsInPause() const
 {
     return m_ui->checkStartPaused->isChecked();
+}
+
+bool OptionsDialog::isEditableSavePath() const
+{
+    return m_ui->checkEditableSavePath->isChecked();
 }
 
 // Proxy settings

--- a/src/gui/optionsdlg.h
+++ b/src/gui/optionsdlg.h
@@ -128,6 +128,7 @@ private:
     bool preAllocateAllFiles() const;
     bool useAdditionDialog() const;
     bool addTorrentsInPause() const;
+    bool isEditableSavePath() const;
     QString getTorrentExportDir() const;
     QString getFinishedTorrentExportDir() const;
     QString askForExportDir(const QString& currentExportPath);

--- a/src/gui/optionsdlg.ui
+++ b/src/gui/optionsdlg.ui
@@ -717,6 +717,13 @@
                 </widget>
                </item>
                <item>
+                <widget class="QCheckBox" name="checkEditableSavePath">
+                 <property name="text">
+                  <string comment="The save path in will be editable">Enable editable save paths in "Add New Torrent" dialog</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <widget class="QGroupBox" name="deleteTorrentBox">
                  <property name="toolTip">
                   <string>Should the .torrent file be deleted after adding it</string>


### PR DESCRIPTION
Added an option to the Options/Download tab to enable editable save path in "Add New Torrent" dialog.

![options](https://cloud.githubusercontent.com/assets/3407234/18530312/4a11e60c-7ad1-11e6-8245-7fe8c405febb.png)

When the option is enabled, the save path combo box in "Add New Torrent" dialog is editable. If the inputed path is invalid the background of the combo box turns red and it's impossible to confirm the dialog. 

![new_torrent](https://cloud.githubusercontent.com/assets/3407234/18530344/76695bcc-7ad1-11e6-8f20-cd27c7eb4ebe.png)

When the inputed path is valid the background turns to normal and the user can confirm the dialog.

![screenshot_20160914_220519](https://cloud.githubusercontent.com/assets/3407234/18530371/938a2b5a-7ad1-11e6-97af-782aeddaf0c7.png)
