### PR TITLE
fix default save path bug

### DIFF
--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -645,8 +645,10 @@ void AddNewTorrentDialog::accept()
     if (ui->comboTTM->currentIndex() != 1) { // 0 is Manual mode and 1 is Automatic mode. Handle all non 1 values as manual mode.
         params.savePath = savePath;
         saveSavePathHistory();
-        if (ui->defaultSavePathCheckBox->isChecked())
+        if (ui->defaultSavePathCheckBox->isChecked()) {
             settings()->storeValue(KEY_DEFAULTSAVEPATH, savePath);
+            BitTorrent::Session::instance()->setDefaultSavePath(savePath);
+        }
     }
 
     setEnabled(!ui->never_show_cb->isChecked());


### PR DESCRIPTION
This commit fixes the default save path bug (v3.3.7) which can be reproduced by changing the default save path in new torrent dialog and checking "do not show again" checkbox followed by "OK" button. Now if a new torrent file is opened it is saved automatically to previous default directory rather than to the new save path.