### PR TITLE
Increase number of digits after the decimal point. Closes #5053

### DIFF
--- a/src/base/unicodestrings.h
+++ b/src/base/unicodestrings.h
@@ -35,6 +35,7 @@
 // we put all problematic UTF-8 chars/strings in this file.
 // See issue #3059 for more details (https://github.com/qbittorrent/qBittorrent/issues/3059).
 const char C_INFINITY[] = "∞";
+const char C_NON_BREAKING_SPACE[] = " ";
 const char C_UP[] = "▲";
 const char C_DOWN[] = "▼";
 const char C_COPYRIGHT[] = "©";

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -356,9 +356,9 @@ QString Utils::Misc::friendlyUnit(qint64 bytesValue, bool isSpeed)
         return QCoreApplication::translate("misc", "Unknown", "Unknown (size)");
     QString ret;
     if (unit == SizeUnit::Byte)
-        ret = QString::number(bytesValue) + " " + unitString(unit);
+        ret = QString::number(bytesValue) + QString::fromUtf8(C_NON_BREAKING_SPACE) + unitString(unit);
     else
-        ret = Utils::String::fromDouble(friendlyVal, friendlyUnitPrecision(unit)) + " " + unitString(unit);
+        ret = Utils::String::fromDouble(friendlyVal, friendlyUnitPrecision(unit)) + QString::fromUtf8(C_NON_BREAKING_SPACE) + unitString(unit);
     if (isSpeed)
         ret += QCoreApplication::translate("misc", "/s", "per second");
     return ret;

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -358,10 +358,18 @@ QString Utils::Misc::friendlyUnit(qint64 bytesValue, bool isSpeed)
     if (unit == SizeUnit::Byte)
         ret = QString::number(bytesValue) + " " + unitString(unit);
     else
-        ret = Utils::String::fromDouble(friendlyVal, 1) + " " + unitString(unit);
+        ret = Utils::String::fromDouble(friendlyVal, friendlyUnitPrecision(unit)) + " " + unitString(unit);
     if (isSpeed)
         ret += QCoreApplication::translate("misc", "/s", "per second");
     return ret;
+}
+
+int Utils::Misc::friendlyUnitPrecision(SizeUnit unit)
+{
+    // friendlyUnit's number of digits after the decimal point
+    if (unit <= SizeUnit::MebiByte) return 1;
+    else if (unit == SizeUnit::GibiByte) return 2;
+    else return 3;
 }
 
 qlonglong Utils::Misc::sizeInBytes(qreal size, Utils::Misc::SizeUnit unit)

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -88,6 +88,7 @@ namespace Utils
         // value must be given in bytes
         bool friendlyUnit(qint64 sizeInBytes, qreal& val, SizeUnit& unit);
         QString friendlyUnit(qint64 bytesValue, bool isSpeed = false);
+        int friendlyUnitPrecision(SizeUnit unit);
         qint64 sizeInBytes(qreal size, SizeUnit unit);
 
         bool isPreviewable(const QString& extension);


### PR DESCRIPTION
KiB and MiB remain unaffected
GiB get 2, TiB and above get 3.
Thoughts on these numbers?

Maybe i should implement it like i originally intended directly in `friendlyUnit`?

```
else if (unit <= SizeUnit::MebiByte)
    return Utils::String::fromDouble(friendlyVal, 1) + " " + unitString(unit);
else if (unit == SizeUnit::GibiByte)
    return Utils::String::fromDouble(friendlyVal, 2) + " " + unitString(unit);
else
    return Utils::String::fromDouble(friendlyVal, 3) + " " + unitString(unit);
```

Or maybe move everything in the new method

```
diff --git a/src/base/utils/misc.cpp b/src/base/utils/misc.cpp
index 18f06d2..943a814 100644
--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -355,15 +355,30 @@ QString Utils::Misc::friendlyUnit(qint64 bytesValue, bool isSpeed)
     if (!friendlyUnit(bytesValue, friendlyVal, unit))
         return QCoreApplication::translate("misc", "Unknown", "Unknown (size)");
     QString ret;
-    if (unit == SizeUnit::Byte)
-        ret = QString::number(bytesValue) + " " + unitString(unit);
-    else
-        ret = Utils::String::fromDouble(friendlyVal, 1) + " " + unitString(unit);
+        ret = friendlyUnitPrecision(unit, friendlyVal, bytesValue);
     if (isSpeed)
         ret += QCoreApplication::translate("misc", "/s", "per second");
     return ret;
 }

+QString Utils::Misc::friendlyUnitPrecision(const SizeUnit &unit, const qreal &friendlyVal, const qint64 &bytesValue)
+{
+    if (unit == SizeUnit::Byte)
+        return QString::number(bytesValue) + " " + unitString(unit);
+    else if (unit <= SizeUnit::MebiByte)
+        return Utils::String::fromDouble(friendlyVal, 1) + " " + unitString(unit);
+    else if (unit == SizeUnit::GibiByte)
+        return Utils::String::fromDouble(friendlyVal, 2) + " " + unitString(unit);
+    else
+        return Utils::String::fromDouble(friendlyVal, 3) + " " + unitString(unit);
+}
+
 qlonglong Utils::Misc::sizeInBytes(qreal size, Utils::Misc::SizeUnit unit)
 {
     for (int i = 0; i < static_cast<int>(unit); ++i)
diff --git a/src/base/utils/misc.h b/src/base/utils/misc.h
index d0a1c39..0109e37 100644
--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -88,6 +88,7 @@ namespace Utils
         // value must be given in bytes
         bool friendlyUnit(qint64 sizeInBytes, qreal& val, SizeUnit& unit);
         QString friendlyUnit(qint64 bytesValue, bool isSpeed = false);
+        QString friendlyUnitPrecision(const SizeUnit& unit, const qreal& friendlyVal, const qint64& bytesValue);
         qint64 sizeInBytes(qreal size, SizeUnit unit);

         bool isPreviewable(const QString& extension);
```

In #5053 @evsh says 

> And should anyone touch `Utils::Misc::friendlyUnit()` code could he, please, replace the space with the thin one (unbreakable)?

Anyone knows what that means?
