### PR TITLE
Fix Mac OS X Build (Closes #5763)

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -397,10 +397,6 @@ MainWindow::MainWindow(QWidget *parent)
 
 MainWindow::~MainWindow()
 {
-#ifdef Q_OS_MAC
-    // Workaround to avoid bug http://bugreports.qt.nokia.com/browse/QTBUG-7305
-    setUnifiedTitleAndToolBarOnMac(false);
-#endif
     delete m_ui;
 }
 


### PR DESCRIPTION
Deleted offending code

 ```
MainWindow::~MainWindow()
 {
-#ifdef Q_OS_MAC
-    // Workaround to avoid bug http://bugreports.qt.nokia.com/browse/QTBUG-7305
-    setUnifiedTitleAndToolBarOnMac(false);
-#endif
     delete m_ui;
 }
```
which was a workaround to avoid bug https://bugreports.qt.io/browse/QTBUG-7305
The bug was fixed at Qt 4.6.2 https://github.com/Blizzard/qt4/blob/master/dist/changes-4.6.2