### PR TITLE
Change QSettings to IniFormat on macOS. Closes #5770 #5808

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -135,6 +135,12 @@ int main(int argc, char *argv[])
     // We must save it here because QApplication constructor may change it
     bool isOneArg = (argc == 2);
 
+#ifdef Q_OS_MAC
+    // On macOS 10.12 Sierra, Apple changed the behaviour of CFPreferencesSetValue() https://bugreports.qt.io/browse/QTBUG-56344
+    // Due to this, we have to move from native plist to IniFormat
+    macSalvagePlists();
+#endif
+
     // Create Application
     QString appId = QLatin1String("qBittorrent-") + Utils::Misc::getUserIDString();
     QScopedPointer<Application> app(new Application(appId, argc, argv));

--- a/src/app/upgrade.h
+++ b/src/app/upgrade.h
@@ -143,7 +143,12 @@ bool upgrade(bool ask = true)
         upgradeResumeFile(backupFolderDir.absoluteFilePath(backupFile));
     // ****************************************************************************************
 
+#ifdef Q_OS_MAC
+    // native .plist
+    QSettings *oldResumeSettings = new QSettings("qBittorrent", "qBittorrent-resume");
+#else
     QIniSettings *oldResumeSettings = new QIniSettings("qBittorrent", "qBittorrent-resume");
+#endif
     QString oldResumeFilename = oldResumeSettings->fileName();
     QVariantHash oldResumeData = oldResumeSettings->value("torrents").toHash();
     delete oldResumeSettings;
@@ -209,5 +214,30 @@ bool upgrade(bool ask = true)
 
     return true;
 }
+
+
+#ifdef Q_OS_MAC
+bool copyPlistToIni(const char *application)
+{
+    QSettings iniFile(QSettings::IniFormat, QSettings::UserScope, "qBittorrent", application);
+    if (QFile::exists(iniFile.fileName())) return false; // We copy the contents of plist, only if inifile does not exist.
+    QSettings plistFile("qBittorrent", application);
+    if (!QFile::exists(plistFile.fileName())) return false;
+    plistFile.setFallbacksEnabled(false);
+    const QStringList plist = plistFile.allKeys();
+    foreach (const QString &key, plist) {
+        iniFile.setValue(key, plistFile.value(key));
+    }
+    return true;
+}
+
+void macSalvagePlists()
+{
+    copyPlistToIni("qBittorrent-data");
+    copyPlistToIni("qBittorrent-rss");
+    copyPlistToIni("qBittorrent");
+}
+#endif  // Q_OS_MAC
+
 
 #endif // UPGRADE_H

--- a/src/base/qinisettings.h
+++ b/src/base/qinisettings.h
@@ -39,7 +39,7 @@ class QIniSettings : public QSettings {
 
 public:
   QIniSettings(const QString &organization = "qBittorrent", const QString &application = "qBittorrent", QObject *parent = 0 ):
-#ifdef Q_OS_WIN
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
       QSettings(QSettings::IniFormat, QSettings::UserScope, organization, application, parent)
 #else
       QSettings(organization, application, parent)

--- a/src/base/settingsstorage.cpp
+++ b/src/base/settingsstorage.cpp
@@ -39,7 +39,8 @@
 #include "utils/fs.h"
 
 #ifdef Q_OS_MAC
-#define QSETTINGS_SYNC_IS_SAVE // whether QSettings::sync() is "atomic"
+// now mac uses ini
+//#define QSETTINGS_SYNC_IS_SAVE // whether QSettings::sync() is "atomic"
 #endif
 
 namespace
@@ -69,7 +70,7 @@ namespace
         using SettingsPtr = std::unique_ptr<QSettings>;
         SettingsPtr createSettings(const QString &name)
         {
-#ifdef Q_OS_WIN
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
             return SettingsPtr(new QSettings(QSettings::IniFormat, QSettings::UserScope, "qBittorrent", name));
 #else
             return SettingsPtr(new QSettings("qBittorrent", name));


### PR DESCRIPTION
On macOS 10.12 Sierra, Apple changed the behaviour of CFPreferencesSetValue()
truncating data after a null character. https://bugreports.qt.io/browse/QTBUG-56344
Due to this, we have to move from native plist to IniFormat.
