### PR TITLE
Set /usr/local/bin before default PATH on macOS. Closes #5639 #5571

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -230,6 +230,17 @@ int main(int argc, char *argv[])
     qputenv("QT_BEARER_POLL_TIMEOUT", QByteArray::number(-1));
 #endif
 
+#if defined(Q_OS_MAC)
+{
+    // Since Apple made difficult for users to set PATH, we set here for convenience.
+    // Users are supposed to install Homebrew Python for search function.
+    // For more info see issue #5571.
+    QByteArray path = "/usr/local/bin:";
+    path += qgetenv("PATH");
+    qputenv("PATH", path.constData());
+}
+#endif
+
 #ifndef DISABLE_GUI
     if (!upgrade()) return EXIT_FAILURE;
 #else

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1476,7 +1476,8 @@ void MainWindow::on_actionSearchWidget_triggered()
 
         // Check if python is already in PATH
         if (pythonVersion > 0)
-            Logger::instance()->addMessage(tr("Python found in %1").arg("PATH"), Log::INFO); // Prevent translators from messing with PATH
+            // Prevent translators from messing with PATH
+            Logger::instance()->addMessage(tr("Python found in %1: %2", "Python found in PATH: /usr/local/bin:/usr/bin:/etc/bin").arg("PATH").arg(qgetenv("PATH").constData()), Log::INFO);
 #ifdef Q_OS_WIN
         else if (addPythonPathToEnv())
             pythonVersion = Utils::Misc::pythonVersion();


### PR DESCRIPTION
Since Apple made difficult for users to set PATH and /usr/bin/python
is almost unusable, I simply add /usr/local/bin before default PATH
to pick up Homebrew Python.
