### PR TITLE
Fix downloadFromURL bug. Closes #5844

### DIFF
--- a/src/gui/downloadfromurldlg.h
+++ b/src/gui/downloadfromurldlg.h
@@ -96,9 +96,9 @@ class downloadFromURL : public QDialog, private Ui::downloadFromURL{
         QMessageBox::warning(0, tr("No URL entered"), tr("Please type at least one URL."));
         return;
       }
-      close();
       emit urlsReadyToBeDownloaded(url_list_cleaned);
       qDebug("Emitted urlsReadytobedownloaded signal");
+      close();
     }
 
     void on_cancelButton_clicked() {


### PR DESCRIPTION
I am actually not very much sure why this fixes the problem.
But my guess is as soon as close() is called url_list_cleaned is destroyed by setAttribute(Qt::WA_DeleteOnClose)
resulting MainWindow::downloadFromURLList() gets invalid memory area.
I tested on Ubuntu 16.04 and Windows 10 to make sure this change does not break.
