### PR TITLE
Add --disable-qt-dbus to configure if $host_os is macOS

### DIFF
--- a/configure
+++ b/configure
@@ -4257,6 +4257,17 @@ else
 $as_echo "no" >&6; }
 fi
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OS is macOS" >&5
+$as_echo_n "checking whether OS is macOS... " >&6; }
+if expr "$host_os" : ".*darwin.*" > /dev/null; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+      enable_qt_dbus=no
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
 # Require 0.23 pkg-config
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,12 @@ AS_IF([expr "$host_os" : ".*freebsd.*" > /dev/null],
       LIBS="-lexecinfo $LIBS"],
       [AC_MSG_RESULT([no])])
 
+AC_MSG_CHECKING([whether OS is macOS])
+AS_IF([expr "$host_os" : ".*darwin.*" > /dev/null],
+      [AC_MSG_RESULT([yes])
+      enable_qt_dbus=no],
+      [AC_MSG_RESULT([no])])
+
 # Require 0.23 pkg-config
 PKG_PROG_PKG_CONFIG([0.23])
 AS_IF([test "x$PKG_CONFIG" = "x"],


### PR DESCRIPTION
I am tired of typing ./configure --disable-qt-dbus
