### PR TITLE
Sort torrent names case insensitively

### DIFF
--- a/src/gui/transferlistsortmodel.cpp
+++ b/src/gui/transferlistsortmodel.cpp
@@ -80,7 +80,7 @@ bool TransferListSortModel::lessThan(const QModelIndex &left, const QModelIndex 
         if (!vL.isValid() || !vR.isValid() || (vL == vR))
             return lowerPositionThan(left, right);
 
-        return Utils::String::naturalCompareCaseSensitive(vL.toString(), vR.toString());
+        return Utils::String::naturalCompareCaseInsensitive(vL.toString(), vR.toString());
     }
 
     case TorrentModel::TR_ADD_DATE:


### PR DESCRIPTION
If you want to sort torrents by name, you expect they are sorted case insensitively.
Or current implementation is intentional?
