### PR TITLE
Fix crash in TrackerFiltersList::removeItem()

### DIFF
--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -523,7 +523,7 @@ void TrackerFiltersList::addItem(const QString &tracker, const QString &hash)
 void TrackerFiltersList::removeItem(const QString &tracker, const QString &hash)
 {
     QString host = getHost(tracker);
-    QListWidgetItem *trackerItem = 0;
+    QListWidgetItem *trackerItem = nullptr;
     QStringList tmp = m_trackers.value(host);
     int row = 0;
 
@@ -531,7 +531,7 @@ void TrackerFiltersList::removeItem(const QString &tracker, const QString &hash)
         return;
     tmp.removeAll(hash);
 
-    if (host != "") {
+    if (!host.isEmpty()) {
         // Remove from 'Error' and 'Warning' view
         trackerSuccess(hash, tracker);
         row = rowFromTracker(host);

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -544,7 +544,8 @@ void TrackerFiltersList::removeItem(const QString &tracker, const QString &hash)
             updateGeometry();
             return;
         }
-        trackerItem->setText(tr("%1 (%2)", "openbittorrent.com (10)").arg(host).arg(tmp.size()));
+        if (trackerItem != nullptr)
+            trackerItem->setText(tr("%1 (%2)", "openbittorrent.com (10)").arg(host).arg(tmp.size()));
     }
     else {
         row = 1;


### PR DESCRIPTION
At https://github.com/qbittorrent/qBittorrent/blob/master/src/gui/transferlistfilterswidget.cpp#L538, `item(row);` might return 0.
