### PR TITLE
minimizing the number of warnings about deprecated auto_ptr

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -331,7 +331,7 @@ Session::Session(QObject *parent)
     configureListeningInterface();
     m_nativeSession->set_alert_dispatch([this](std::auto_ptr<libt::alert> alertPtr)
     {
-        dispatchAlerts(alertPtr);
+        dispatchAlerts(alertPtr.release());
     });
 #else
     std::string peerId = libt::generate_fingerprint(PEER_ID, VERSION_MAJOR, VERSION_MINOR, VERSION_BUGFIX, VERSION_BUILD);
@@ -3125,13 +3125,13 @@ void Session::handleIPFilterError()
 }
 
 #if LIBTORRENT_VERSION_NUM < 10100
-void Session::dispatchAlerts(std::auto_ptr<libt::alert> alertPtr)
+void Session::dispatchAlerts(libt::alert *alertPtr)
 {
     QMutexLocker lock(&m_alertsMutex);
 
     bool wasEmpty = m_alerts.empty();
 
-    m_alerts.push_back(alertPtr.release());
+    m_alerts.push_back(alertPtr);
 
     if (wasEmpty) {
         m_alertsWaitCondition.wakeAll();

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -492,7 +492,7 @@ namespace BitTorrent
         void saveResumeData();
 
 #if LIBTORRENT_VERSION_NUM < 10100
-        void dispatchAlerts(std::auto_ptr<libtorrent::alert> alertPtr);
+        void dispatchAlerts(libtorrent::alert *alertPtr);
 #endif
         void getPendingAlerts(std::vector<libtorrent::alert *> &out, ulong time = 0);
 


### PR DESCRIPTION
Minimized number of warnings about deprecated auto_ptr from some dozens to just 1 warning. The last warning caused by libtorrent API call, can't fix it.