### PR TITLE
memleak fix

### DIFF
--- a/src/gui/properties/speedwidget.cpp
+++ b/src/gui/properties/speedwidget.cpp
@@ -73,7 +73,7 @@ SpeedWidget::SpeedWidget(PropertiesWidget *parent)
 
     connect(m_periodCombobox, SIGNAL(currentIndexChanged(int)), this, SLOT(onPeriodChange(int)));
 
-    m_graphsMenu = new QMenu();
+    m_graphsMenu = new QMenu(this);
     m_graphsMenu->addAction(tr("Total Upload"));
     m_graphsMenu->addAction(tr("Total Download"));
     m_graphsMenu->addAction(tr("Payload Upload"));


### PR DESCRIPTION
Fix QMenu left orphaned when speedwidget is destructed. 