### PR TITLE
Fix memory leak

### DIFF
--- a/src/base/utils/fs.cpp
+++ b/src/base/utils/fs.cpp
@@ -372,7 +372,6 @@ QString Utils::Fs::QDesktopServicesDataLocation()
     OSErr err = FSFindFolder(kUserDomain, kApplicationSupportFolderType, false, &ref);
     if (err)
         return QString();
-    QString path;
     QByteArray ba(2048, 0);
     if (FSRefMakePath(&ref, reinterpret_cast<UInt8 *>(ba.data()), ba.size()) == noErr)
         result = QString::fromUtf8(ba).normalized(QString::NormalizationForm_C);

--- a/src/base/utils/fs.cpp
+++ b/src/base/utils/fs.cpp
@@ -363,8 +363,8 @@ QString Utils::Fs::QDesktopServicesDataLocation()
 {
     QString result;
 #ifdef Q_OS_WIN
-    LPWSTR path=new WCHAR[256];
-    if (SHGetSpecialFolderPath(0, path, CSIDL_LOCAL_APPDATA, FALSE))
+    wchar_t path[MAX_PATH + 1] = {L'\0'};
+    if (SHGetSpecialFolderPathW(0, path, CSIDL_LOCAL_APPDATA, FALSE))
         result = fromNativePath(QString::fromWCharArray(path));
     if (!QCoreApplication::applicationName().isEmpty())
         result += QLatin1String("/") + qApp->applicationName();

--- a/src/base/utils/fs.cpp
+++ b/src/base/utils/fs.cpp
@@ -310,26 +310,10 @@ qlonglong Utils::Fs::freeDiskSpaceOnPath(QString path)
     }
 #endif
 #else
-    typedef BOOL (WINAPI *GetDiskFreeSpaceEx_t)(LPCTSTR,
-                                                PULARGE_INTEGER,
-                                                PULARGE_INTEGER,
-                                                PULARGE_INTEGER);
-    GetDiskFreeSpaceEx_t pGetDiskFreeSpaceEx =
-            (GetDiskFreeSpaceEx_t)::GetProcAddress(::GetModuleHandleW(L"kernel32.dll"), "GetDiskFreeSpaceExW");
-    if (pGetDiskFreeSpaceEx) {
-        ULARGE_INTEGER bytesFree, bytesTotal;
-        unsigned long long *ret;
-        if (pGetDiskFreeSpaceEx((LPCTSTR)(toNativePath(dir_path.path())).utf16(), &bytesFree, &bytesTotal, NULL)) {
-            ret = (unsigned long long*)&bytesFree;
-            return *ret;
-        }
-        else {
-            return -1;
-        }
-    }
-    else {
+    ULARGE_INTEGER bytesFree;
+    if (GetDiskFreeSpaceExW((LPCTSTR)(toNativePath(dir_path.path())).utf16(), &bytesFree, NULL, NULL) == 0)
         return -1;
-    }
+    return qlonglong(bytesFree.QuadPart);
 #endif
 }
 

--- a/src/base/utils/fs.h
+++ b/src/base/utils/fs.h
@@ -50,7 +50,7 @@ namespace Utils
         bool sameFiles(const QString& path1, const QString& path2);
         QString toValidFileSystemName(const QString &name, bool allowSeparators = false);
         bool isValidFileSystemName(const QString& name, bool allowSeparators = false);
-        qlonglong freeDiskSpaceOnPath(QString path);
+        qulonglong freeDiskSpaceOnPath(const QString &path);
         QString branchPath(const QString& file_path, QString* removed = 0);
         bool sameFileNames(const QString& first, const QString& second);
         QString expandPath(const QString& path);


### PR DESCRIPTION
* Simplify function call
  `GetDiskFreeSpaceExW` is supported on win XP, so there is no need for the `GetProcAddress` loading method.
* Fix memory leak
  `path` variable was not freed after use.
* refactor
* Remove unused variable