### PR TITLE
Make it compile with libtorrent 1.2.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -210,6 +210,8 @@ PKG_CHECK_MODULES(libtorrent,
                   [CPPFLAGS="$libtorrent_CFLAGS $CPPFLAGS"
                   LIBS="$libtorrent_LIBS $LIBS"])
 
+AC_CHECK_HEADERS([libtorrent/extensions/lt_trackers.hpp libtorrent/string_view.hpp], [], [], [])
+
 PKG_CHECK_MODULES(zlib,
                  [zlib],
                  [CPPFLAGS="$zlib_CFLAGS $CPPFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_LANG(C++)
 AC_CANONICAL_HOST
 AM_INIT_AUTOMAKE
 
-
+AC_CONFIG_HEADERS([src/config.h])
 
 # Define --wth-* and --enable-* arguments
 
@@ -97,6 +97,7 @@ AS_CASE(["x$enable_gui"],
         ["xyes"],
                [AC_MSG_RESULT([yes])
                enable_systemd=[no]
+               AC_DEFINE([QBT_USE_GUI])
                QBT_REMOVE_CONFIG="$QBT_REMOVE_CONFIG nogui"],
         ["xno"],
               [AC_MSG_RESULT([no])
@@ -120,6 +121,7 @@ AC_MSG_CHECKING([whether to enable the WebUI])
 AS_CASE(["x$enable_webui"],
         ["xyes"],
                [AC_MSG_RESULT([yes])
+               AC_DEFINE([QBT_USE_WEBUI])
                QBT_REMOVE_CONFIG="$QBT_REMOVE_CONFIG nowebui"],
         ["xno"],
               [AC_MSG_RESULT([no])
@@ -131,7 +133,8 @@ AC_MSG_CHECKING([whether Qt4 should be enabled])
 AS_CASE(["x$with_qt4"],
         ["xno"],
               [AC_MSG_RESULT([no])
-              FIND_QT5()],
+              FIND_QT5()
+              AC_DEFINE([QBT_USES_QT5])],
         ["xyes"],
                [AC_MSG_RESULT([yes])
                FIND_QT4()],
@@ -258,11 +261,12 @@ AC_SUBST(QBT_REMOVE_CONFIG)
 AC_SUBST(QBT_ADD_DEFINES)
 AC_SUBST(QBT_REMOVE_DEFINES)
 
-AC_OUTPUT(conf.pri)
 AS_IF([test "x$enable_systemd" = "xyes"],
-      [AC_OUTPUT(dist/unix/systemd/qbittorrent-nox.service)])
+      [AC_CONFIG_FILES(dist/unix/systemd/qbittorrent-nox.service)])
 
+AC_CONFIG_FILES([conf.pri])
 
+AC_OUTPUT()
 
 AC_MSG_NOTICE([Running qmake to generate the makefile...])
 CONFDIR="$( cd "$( dirname "$0" )" && pwd )"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,6 @@ find_package(LibtorrentRasterbar REQUIRED)
 
 # Qt
 if (QT5)
-    add_definitions(-DQBT_USES_QT5)
     list(APPEND QBT_QT_COMPONENTS Core Network Xml)
     if (GUI)
         list (APPEND QBT_QT_COMPONENTS Concurrent Gui Widgets)
@@ -42,14 +41,6 @@ add_definitions(-DQT_USE_FAST_CONCATENATION -DQT_USE_FAST_OPERATOR_PLUS)
 if (WIN32)
     add_definitions(-DNOMINMAX)
 endif (WIN32)
-
-if (NOT GUI)
-    add_definitions(-DDISABLE_GUI -DDISABLE_COUNTRIES_RESOLUTION)
-endif (NOT GUI)
-
-if (NOT WEBUI)
-    add_definitions(-DDISABLE_WEBUI)
-endif (NOT WEBUI)
 
 if (STACKTRACE_WIN)
     add_definitions(-DSTACKTRACE_WIN)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,10 +2,15 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_STANDARD "11")
 add_definitions(-DBOOST_NO_CXX11_RVALUE_REFERENCES)
 
+include(CheckIncludeFileCXX)
 include(MacroLinkQtComponents)
 include(QbtTargetSources)
 
 find_package(LibtorrentRasterbar REQUIRED)
+
+set(CMAKE_REQUIRED_INCLUDES ${LibtorrentRasterbar_INCLUDE_DIR})
+check_include_file_cxx(libtorrent/extensions/lt_trackers.hpp HAVE_LIBTORRENT_EXTENSIONS_LT_TRACKERS_HPP)
+check_include_file_cxx(libtorrent/string_view.hpp HAVE_LIBTORRENT_STRING_VIEW_HPP)
 
 # Qt
 if (QT5)

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -35,6 +35,8 @@
 #include <QProcess>
 #include <QAtomicInt>
 
+#include "config.h"
+
 #ifndef DISABLE_GUI
 #include "gui/guiiconprovider.h"
 #ifdef Q_OS_WIN

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -34,6 +34,8 @@
 #include <QStringList>
 #include <QTranslator>
 
+#include "config.h"
+
 #ifndef DISABLE_GUI
 #include "qtsingleapplication.h"
 typedef QtSingleApplication BaseApplication;

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -32,6 +32,8 @@
 #include <QDebug>
 #include <QScopedPointer>
 
+#include "config.h"
+
 #ifndef DISABLE_GUI
 // GUI-only includes
 #include <QFont>

--- a/src/app/upgrade.h
+++ b/src/app/upgrade.h
@@ -39,6 +39,7 @@
 #include <libtorrent/lazy_entry.hpp>
 #endif
 
+#include "config.h"
 
 #include <QDir>
 #include <QFile>

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -119,6 +119,8 @@ tristatebool.cpp
 add_library(qbt_base STATIC ${QBT_BASE_HEADERS} ${QBT_BASE_SOURCES})
 target_link_libraries(qbt_base ZLIB::ZLIB LibtorrentRasterbar::LibTorrent)
 target_link_qt_components(qbt_base Core Network Xml)
+target_include_directories(qbt_base PUBLIC "${qBittorrent_BINARY_DIR}/src") # for config.h
+
 if (QT4_FOUND)
     if (GUI)
         target_link_libraries(qbt_base Qt4::QtGui)

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -140,3 +140,5 @@ if (APPLE)
     find_library(Carbon_LIBRARY Carbon)
     target_link_libraries(qbt_base ${Carbon_LIBRARY} ${IOKit_LIBRARY})
 endif (APPLE)
+
+# target_compile_options(qbt_base PUBLIC "-Werror=deprecated-declarations")

--- a/src/base/bittorrent/peerinfo.h
+++ b/src/base/bittorrent/peerinfo.h
@@ -35,6 +35,8 @@
 #include <QBitArray>
 #include <QCoreApplication>
 
+#include "config.h"
+
 namespace BitTorrent
 {
     class TorrentHandle;

--- a/src/base/bittorrent/private/resumedatasavingmanager.cpp
+++ b/src/base/bittorrent/private/resumedatasavingmanager.cpp
@@ -27,6 +27,9 @@
  */
 
 #include <QDebug>
+
+#include "config.h"
+
 #ifdef QBT_USES_QT5
 #include <QSaveFile>
 #else

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -45,8 +45,11 @@
 #include <QTimer>
 
 #include <cstdlib>
+#include <iostream>
 #include <queue>
 #include <vector>
+
+#include <boost/lexical_cast.hpp>
 
 #include <libtorrent/alert_types.hpp>
 #if LIBTORRENT_VERSION_NUM >= 10100
@@ -55,7 +58,9 @@
 #include <libtorrent/bencode.hpp>
 #include <libtorrent/error_code.hpp>
 #include <libtorrent/extensions/ut_metadata.hpp>
+#ifdef HAVE_LIBTORRENT_EXTENSIONS_LT_TRACKERS_HPP
 #include <libtorrent/extensions/lt_trackers.hpp>
+#endif
 #include <libtorrent/extensions/ut_pex.hpp>
 #include <libtorrent/extensions/smart_ban.hpp>
 #include <libtorrent/identify_client.hpp>
@@ -194,6 +199,20 @@ namespace
 
     template <typename T>
     LowerLimited<T> lowerLimited(T limit, T ret) { return LowerLimited<T>(limit, ret); }
+
+    // we declare this shortcut here, because...
+    inline QString fromStdString(const std::string& str)
+    {
+        return Utils::String::fromStdString(str);
+    }
+#ifdef HAVE_LIBTORRENT_STRING_VIEW_HPP
+    // ... if libtorrent uses string_view, we need a second overload
+    // only in this file.
+    inline QString fromStdString(const libtorrent::string_view& str)
+    {
+        return QString::fromUtf8(str.data(), str.size());
+    }
+#endif
 }
 
 // Session
@@ -213,7 +232,9 @@ Session::Session(QObject *parent)
     , m_isDHTEnabled(BITTORRENT_SESSION_KEY("DHTEnabled"), true)
     , m_isLSDEnabled(BITTORRENT_SESSION_KEY("LSDEnabled"), true)
     , m_isPeXEnabled(BITTORRENT_SESSION_KEY("PeXEnabled"), true)
+#ifdef BACKEND_HAS_LT_TRACKERS_EXTENSION
     , m_isTrackerExchangeEnabled(BITTORRENT_SESSION_KEY("TrackerExchangeEnabled"), false)
+#endif
     , m_isIPFilteringEnabled(BITTORRENT_SESSION_KEY("IPFilteringEnabled"), false)
     , m_isTrackerFilteringEnabled(BITTORRENT_SESSION_KEY("TrackerFilteringEnabled"), false)
     , m_IPFilterFile(BITTORRENT_SESSION_KEY("IPFilter"))
@@ -278,7 +299,9 @@ Session::Session(QObject *parent)
     , m_isTrackerEnabled(BITTORRENT_KEY("TrackerEnabled"), false)
     , m_bannedIPs("State/BannedIPs")
     , m_wasPexEnabled(m_isPeXEnabled)
+#ifdef BACKEND_HAS_LT_TRACKERS_EXTENSION
     , m_wasTrackerExchangeEnabled(m_isTrackerExchangeEnabled)
+#endif
     , m_numResumeData(0)
     , m_extraLimit(0)
     , m_useProxy(false)
@@ -365,8 +388,10 @@ Session::Session(QObject *parent)
     // Enabling plugins
     //m_nativeSession->add_extension(&libt::create_metadata_plugin);
     m_nativeSession->add_extension(&libt::create_ut_metadata_plugin);
+#ifdef BACKEND_HAS_LT_TRACKERS_EXTENSION
     if (isTrackerExchangeEnabled())
         m_nativeSession->add_extension(&libt::create_lt_trackers_plugin);
+#endif
     if (isPeXEnabled())
         m_nativeSession->add_extension(&libt::create_ut_pex_plugin);
     m_nativeSession->add_extension(&libt::create_smart_ban_plugin);
@@ -475,6 +500,7 @@ void Session::setPeXEnabled(bool enabled)
         Logger::instance()->addMessage(tr("Restart is required to toggle PeX support"), Log::WARNING);
 }
 
+#ifdef BACKEND_HAS_LT_TRACKERS_EXTENSION
 bool Session::isTrackerExchangeEnabled() const
 {
     return m_isTrackerExchangeEnabled;
@@ -486,6 +512,7 @@ void Session::setTrackerExchangeEnabled(bool enabled)
     if (m_wasTrackerExchangeEnabled != enabled)
         Logger::instance()->addMessage(tr("Restart is required to toggle Tracker Exchange support"), Log::WARNING);
 }
+#endif
 
 bool Session::isTempPathEnabled() const
 {
@@ -3391,32 +3418,33 @@ void Session::handlePortmapAlert(libt::portmap_alert *p)
 
 void Session::handlePeerBlockedAlert(libt::peer_blocked_alert *p)
 {
-    boost::system::error_code ec;
-    std::string ip = p->ip.to_string(ec);
-    QString reason;
-    switch (p->reason) {
-    case libt::peer_blocked_alert::ip_filter:
-        reason = tr("due to IP filter.", "this peer was blocked due to ip filter.");
-        break;
-    case libt::peer_blocked_alert::port_filter:
-        reason = tr("due to port filter.", "this peer was blocked due to port filter.");
-        break;
-    case libt::peer_blocked_alert::i2p_mixed:
-        reason = tr("due to i2p mixed mode restrictions.", "this peer was blocked due to i2p mixed mode restrictions.");
-        break;
-    case libt::peer_blocked_alert::privileged_ports:
-        reason = tr("because it has a low port.", "this peer was blocked because it has a low port.");
-        break;
-    case libt::peer_blocked_alert::utp_disabled:
-        reason = trUtf8("because %1 is disabled.", "this peer was blocked because uTP is disabled.").arg(QString::fromUtf8(C_UTP)); // don't translate μTP
-        break;
-    case libt::peer_blocked_alert::tcp_disabled:
-        reason = tr("because %1 is disabled.", "this peer was blocked because TCP is disabled.").arg("TCP"); // don't translate TCP
-        break;
-    }
+    try {
+        std::string ip = boost::lexical_cast<std::string>(p->ip);
+        QString reason;
+        switch (p->reason) {
+        case libt::peer_blocked_alert::ip_filter:
+            reason = tr("due to IP filter.", "this peer was blocked due to ip filter.");
+            break;
+        case libt::peer_blocked_alert::port_filter:
+            reason = tr("due to port filter.", "this peer was blocked due to port filter.");
+            break;
+        case libt::peer_blocked_alert::i2p_mixed:
+            reason = tr("due to i2p mixed mode restrictions.", "this peer was blocked due to i2p mixed mode restrictions.");
+            break;
+        case libt::peer_blocked_alert::privileged_ports:
+            reason = tr("because it has a low port.", "this peer was blocked because it has a low port.");
+            break;
+        case libt::peer_blocked_alert::utp_disabled:
+            reason = trUtf8("because %1 is disabled.", "this peer was blocked because uTP is disabled.").arg(QString::fromUtf8(C_UTP)); // don't translate μTP
+            break;
+        case libt::peer_blocked_alert::tcp_disabled:
+            reason = tr("because %1 is disabled.", "this peer was blocked because TCP is disabled.").arg("TCP"); // don't translate TCP
+            break;
+        }
 
-    if (!ec)
         Logger::instance()->addPeer(QString::fromLatin1(ip.c_str()), true, reason);
+    }
+    catch (boost::bad_lexical_cast&){}
 }
 
 void Session::handlePeerBanAlert(libt::peer_ban_alert *p)
@@ -3543,20 +3571,20 @@ namespace
         if (ec || (fast.type() != libt::bdecode_node::dict_t)) return false;
 #endif
 
-        torrentData.savePath = Utils::Fs::fromNativePath(Utils::String::fromStdString(fast.dict_find_string_value("qBt-savePath")));
-        torrentData.ratioLimit = Utils::String::fromStdString(fast.dict_find_string_value("qBt-ratioLimit")).toDouble();
+        torrentData.savePath = Utils::Fs::fromNativePath(fromStdString(fast.dict_find_string_value("qBt-savePath")));
+        torrentData.ratioLimit = fromStdString(fast.dict_find_string_value("qBt-ratioLimit")).toDouble();
         // **************************************************************************************
         // Workaround to convert legacy label to category
         // TODO: Should be removed in future
-        torrentData.category = Utils::String::fromStdString(fast.dict_find_string_value("qBt-label"));
+        torrentData.category = fromStdString(fast.dict_find_string_value("qBt-label"));
         if (torrentData.category.isEmpty())
         // **************************************************************************************
-            torrentData.category = Utils::String::fromStdString(fast.dict_find_string_value("qBt-category"));
-        torrentData.name = Utils::String::fromStdString(fast.dict_find_string_value("qBt-name"));
+            torrentData.category = fromStdString(fast.dict_find_string_value("qBt-category"));
+        torrentData.name = fromStdString(fast.dict_find_string_value("qBt-name"));
         torrentData.hasSeedStatus = fast.dict_find_int_value("qBt-seedStatus");
         torrentData.disableTempPath = fast.dict_find_int_value("qBt-tempPathDisabled");
 
-        magnetUri = MagnetUri(Utils::String::fromStdString(fast.dict_find_string_value("qBt-magnetUri")));
+        magnetUri = MagnetUri(fromStdString(fast.dict_find_string_value("qBt-magnetUri")));
         torrentData.addPaused = fast.dict_find_int_value("qBt-paused");
         torrentData.addForced = fast.dict_find_int_value("qBt-forced");
 

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -51,6 +51,8 @@
 #include "base/types.h"
 #include "torrentinfo.h"
 
+#include "config.h"
+
 namespace libtorrent
 {
     class session;
@@ -218,8 +220,10 @@ namespace BitTorrent
         void setLSDEnabled(bool enabled);
         bool isPeXEnabled() const;
         void setPeXEnabled(bool enabled);
+#ifdef BACKEND_HAS_LT_TRACKERS_EXTENSION
         bool isTrackerExchangeEnabled() const;
         void setTrackerExchangeEnabled(bool enabled);
+#endif
         bool isAddTorrentPaused() const;
         void setAddTorrentPaused(bool value);
         bool isTrackerEnabled() const;
@@ -507,7 +511,9 @@ namespace BitTorrent
         CachedSettingValue<bool> m_isDHTEnabled;
         CachedSettingValue<bool> m_isLSDEnabled;
         CachedSettingValue<bool> m_isPeXEnabled;
+#ifdef BACKEND_HAS_LT_TRACKERS_EXTENSION
         CachedSettingValue<bool> m_isTrackerExchangeEnabled;
+#endif
         CachedSettingValue<bool> m_isIPFilteringEnabled;
         CachedSettingValue<bool> m_isTrackerFilteringEnabled;
         CachedSettingValue<QString> m_IPFilterFile;
@@ -576,7 +582,9 @@ namespace BitTorrent
         // counterparts, because they use them for initialization in the constructor
         // initialization list.
         const bool m_wasPexEnabled;
+#ifdef BACKEND_HAS_LT_TRACKERS_EXTENSION
         const bool m_wasTrackerExchangeEnabled;
+#endif
 
         int m_numResumeData;
         int m_extraLimit;

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -46,7 +46,11 @@ using namespace BitTorrent;
 
 TorrentInfo::TorrentInfo(NativeConstPtr nativeInfo)
 {
+#if LIBTORRENT_VERSION_NUM >= 10200
+    m_nativeInfo = std::const_pointer_cast<libt::torrent_info>(nativeInfo);
+#else
     m_nativeInfo = boost::const_pointer_cast<libt::torrent_info>(nativeInfo);
+#endif
 }
 
 TorrentInfo::TorrentInfo(const TorrentInfo &other)
@@ -99,8 +103,13 @@ QString TorrentInfo::name() const
 QDateTime TorrentInfo::creationDate() const
 {
     if (!isValid()) return QDateTime();
+#if LIBTORRENT_VERSION_NUM >= 10200
+    time_t t = m_nativeInfo->creation_date();
+    return t ? QDateTime::fromTime_t(t) : QDateTime();
+#else
     boost::optional<time_t> t = m_nativeInfo->creation_date();
     return t ? QDateTime::fromTime_t(*t) : QDateTime();
+#endif
 }
 
 QString TorrentInfo::creator() const
@@ -186,7 +195,11 @@ qlonglong TorrentInfo::fileSize(int index) const
 qlonglong TorrentInfo::fileOffset(int index) const
 {
     if (!isValid()) return -1;
+#if LIBTORRENT_VERSION_NUM < 10200
     return m_nativeInfo->file_at(index).offset;
+#else
+    return m_nativeInfo->files().file_offset(index);
+#endif
 }
 
 QList<TrackerEntry> TorrentInfo::trackers() const

--- a/src/base/bittorrent/torrentinfo.h
+++ b/src/base/bittorrent/torrentinfo.h
@@ -55,9 +55,12 @@ namespace BitTorrent
 #if LIBTORRENT_VERSION_NUM < 10100
         typedef boost::intrusive_ptr<const libtorrent::torrent_info> NativeConstPtr;
         typedef boost::intrusive_ptr<libtorrent::torrent_info> NativePtr;
-#else
+#elif LIBTORRENT_VERSION_NUM < 10200
         typedef boost::shared_ptr<const libtorrent::torrent_info> NativeConstPtr;
         typedef boost::shared_ptr<libtorrent::torrent_info> NativePtr;
+#else
+        typedef std::shared_ptr<const libtorrent::torrent_info> NativeConstPtr;
+        typedef std::shared_ptr<libtorrent::torrent_info> NativePtr;
 #endif
 
         explicit TorrentInfo(NativeConstPtr nativeInfo = NativeConstPtr());

--- a/src/base/http/requestparser.cpp
+++ b/src/base/http/requestparser.cpp
@@ -31,6 +31,9 @@
 
 #include <QStringList>
 #include <QUrl>
+
+#include "config.h"
+
 #ifdef QBT_USES_QT5
 #include <QUrlQuery>
 #endif

--- a/src/base/http/server.h
+++ b/src/base/http/server.h
@@ -39,6 +39,8 @@
 #include <QSslKey>
 #endif
 
+#include "config.h"
+
 namespace Http
 {
     class IRequestHandler;

--- a/src/base/net/dnsupdater.cpp
+++ b/src/base/net/dnsupdater.cpp
@@ -31,6 +31,9 @@
 #include <QDebug>
 #include <QRegExp>
 #include <QStringList>
+
+#include "config.h"
+
 #ifdef QBT_USES_QT5
 #include <QUrlQuery>
 #endif

--- a/src/base/net/downloadmanager.cpp
+++ b/src/base/net/downloadmanager.cpp
@@ -43,6 +43,8 @@
 #include "downloadhandler.h"
 #include "proxyconfigurationmanager.h"
 
+#include "config.h"
+
 // Spoof Firefox 38 user agent to avoid web server banning
 const char DEFAULT_USER_AGENT[] = "Mozilla/5.0 (X11; Linux i686; rv:38.0) Gecko/20100101 Firefox/38.0";
 

--- a/src/base/net/private/geoipdatabase.cpp
+++ b/src/base/net/private/geoipdatabase.cpp
@@ -36,6 +36,8 @@
 #include "base/types.h"
 #include "geoipdatabase.h"
 
+#include "config.h"
+
 namespace
 {
     const quint32 __ENDIAN_TEST__ = 0x00000001;

--- a/src/base/net/smtp.h
+++ b/src/base/net/smtp.h
@@ -42,6 +42,8 @@
 #include <QAbstractSocket>
 #include <QMetaType>
 
+#include "config.h"
+
 QT_BEGIN_NAMESPACE
 class QTextStream;
 #ifndef QT_NO_OPENSSL

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -35,6 +35,8 @@
 #include <QDir>
 #include <QSettings>
 
+#include "config.h"
+
 #ifndef DISABLE_GUI
 #include <QApplication>
 #else

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -43,6 +43,8 @@
 
 #include "types.h"
 
+#include "config.h"
+
 enum scheduler_days
 {
     EVERY_DAY,

--- a/src/base/settingsstorage.cpp
+++ b/src/base/settingsstorage.cpp
@@ -38,6 +38,8 @@
 #include "logger.h"
 #include "utils/fs.h"
 
+#include "config.h"
+
 namespace
 {
     // Encapsulates serialization of settings in "atomic" way.

--- a/src/base/utils/fs.cpp
+++ b/src/base/utils/fs.cpp
@@ -55,6 +55,8 @@
 #include <winbase.h>
 #endif
 
+#include "config.h"
+
 #ifndef QBT_USES_QT5
 
 #ifndef DISABLE_GUI

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -41,6 +41,8 @@
 #include <boost/version.hpp>
 #include <libtorrent/version.hpp>
 
+#include "config.h"
+
 #ifdef DISABLE_GUI
 #include <QCoreApplication>
 #else

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -42,6 +42,8 @@
 #include <QSize>
 #include "base/types.h"
 
+#include "config.h"
+
 /*  Miscellaneous functions that can be useful */
 
 namespace Utils

--- a/src/base/utils/string.cpp
+++ b/src/base/utils/string.cpp
@@ -175,7 +175,7 @@ bool Utils::String::naturalCompareCaseInsensitive(const QString &left, const QSt
 
 QString Utils::String::fromStdString(const std::string &str)
 {
-    return QString::fromUtf8(str.c_str());
+    return QString::fromUtf8(str.c_str(), str.size());
 }
 
 std::string Utils::String::toStdString(const QString &str)

--- a/src/base/utils/string.cpp
+++ b/src/base/utils/string.cpp
@@ -34,6 +34,9 @@
 #include <QByteArray>
 #include <QtGlobal>
 #include <QLocale>
+
+#include "config.h"
+
 #ifdef QBT_USES_QT5
 #include <QCollator>
 #endif

--- a/src/config.h.cmakein
+++ b/src/config.h.cmakein
@@ -13,3 +13,13 @@
 #endif
 
 #cmakedefine STACKTRACE_WIN
+
+/* Define as 1 if you have libtorrent/extensions/lt_trackers.hpp */
+#cmakedefine HAVE_LIBTORRENT_EXTENSIONS_LT_TRACKERS_HPP
+/* Define as 1 if you have libtorrent/string_view.hpp */
+#cmakedefine HAVE_LIBTORRENT_STRING_VIEW_HPP
+
+
+#if defined HAVE_LIBTORRENT_EXTENSIONS_LT_TRACKERS_HPP
+#define BACKEND_HAS_LT_TRACKERS_EXTENSION
+#endif

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -1,0 +1,15 @@
+#undef QBT_USES_QT5
+#undef QBT_USE_GUI
+
+#ifndef QBT_USE_GUI
+#define DISABLE_GUI
+#define DISABLE_COUNTRIES_RESOLUTION
+#endif
+
+#undef QBT_USE_WEBUI
+
+#ifndef QBT_USE_WEBUI
+#define DISABLE_WEBUI
+#endif
+
+#undef STACKTRACE_WIN

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -13,3 +13,13 @@
 #endif
 
 #undef STACKTRACE_WIN
+
+/* Define as 1 if you have libtorrent/extensions/lt_trackers.hpp */
+#undef HAVE_LIBTORRENT_EXTENSIONS_LT_TRACKERS_HPP
+
+/* Define as 1 if you have libtorrent/string_view.hpp */
+#undef HAVE_LIBTORRENT_STRING_VIEW_HPP
+
+#if defined HAVE_LIBTORRENT_EXTENSIONS_LT_TRACKERS_HPP
+#define BACKEND_HAS_LT_TRACKERS_EXTENSION
+#endif

--- a/src/config.h.win.in
+++ b/src/config.h.win.in
@@ -1,0 +1,50 @@
+/* these come from qmake */
+#define _QBT_USES_QT5 $$QBT_USES_QT5
+#define _QBT_NOGUI $$QBT_NOGUI
+#define _QBT_NOWEBUI $$QBT_NOWEBUI
+
+/* these we initialize to be on-pair with the other config methods */
+#if _QBT_USES_QT5
+#define QBT_USES_QT5
+#else
+#undef QBT_USES_QT5
+#endif
+
+#if _QBT_NOGUI
+#undef QBT_USE_GUI
+#else
+#define QBT_USE_GUI
+#endif
+
+#if _QBT_NOWEBUI
+#undef QBT_USE_WEBUI
+#else
+#define QBT_USE_WEBUI
+#endif
+
+
+#ifndef QBT_USE_GUI
+#define DISABLE_GUI
+#define DISABLE_COUNTRIES_RESOLUTION
+#endif
+
+#ifndef QBT_USE_WEBUI
+#define DISABLE_WEBUI
+#endif
+
+#define STACKTRACE_WIN
+
+// on Windows we don't have any configure script, and as such:
+#include <libtorrent/version.hpp>
+
+#if LIBTORRENT_VERSION_NUM < 10200
+/* Define as 1 if you have libtorrent/extensions/lt_trackers.hpp */
+#define HAVE_LIBTORRENT_EXTENSIONS_LT_TRACKERS_HPP
+#else
+/* Define as 1 if you have libtorrent/string_view.hpp */
+#define HAVE_LIBTORRENT_STRING_VIEW_HPP
+#endif
+
+#if defined HAVE_LIBTORRENT_EXTENSIONS_LT_TRACKERS_HPP
+#define BACKEND_HAS_LT_TRACKERS_EXTENSION
+#endif

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -186,8 +186,10 @@ void AdvancedSettings::saveAdvancedSettings()
     pref->useSystemIconTheme(cb_use_icon_theme.isChecked());
 #endif
     pref->setConfirmTorrentRecheck(cb_confirm_torrent_recheck.isChecked());
+#ifdef BACKEND_HAS_LT_TRACKERS_EXTENSION
     // Tracker exchange
     session->setTrackerExchangeEnabled(cb_enable_tracker_ext.isChecked());
+#endif
     session->setAnnounceToAllTrackers(cb_announce_all_trackers.isChecked());
 }
 
@@ -380,9 +382,11 @@ void AdvancedSettings::loadAdvancedSettings()
     // Torrent recheck confirmation
     cb_confirm_torrent_recheck.setChecked(pref->confirmTorrentRecheck());
     addRow(CONFIRM_RECHECK_TORRENT, tr("Confirm torrent recheck"), &cb_confirm_torrent_recheck);
+#ifdef BACKEND_HAS_LT_TRACKERS_EXTENSION
     // Tracker exchange
     cb_enable_tracker_ext.setChecked(session->isTrackerExchangeEnabled());
     addRow(TRACKER_EXCHANGE, tr("Exchange trackers with other peers"), &cb_enable_tracker_ext);
+#endif
     // Announce to all trackers
     cb_announce_all_trackers.setChecked(session->announceToAllTrackers());
     addRow(ANNOUNCE_ALL_TRACKERS, tr("Always announce to all trackers"), &cb_announce_all_trackers);

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -36,6 +36,7 @@
 #include <QComboBox>
 #include <QTableWidget>
 
+#include "config.h"
 
 class AdvancedSettings: public QTableWidget
 {
@@ -62,7 +63,10 @@ private:
     QSpinBox spin_cache, spin_save_resume_data_interval, outgoing_ports_min, outgoing_ports_max, spin_list_refresh, spin_maxhalfopen, spin_tracker_port, spin_cache_ttl;
     QCheckBox cb_os_cache, cb_recheck_completed, cb_resolve_countries, cb_resolve_hosts, cb_super_seeding,
               cb_program_notifications, cb_torrent_added_notifications, cb_tracker_favicon, cb_tracker_status,
-              cb_confirm_torrent_recheck, cb_enable_tracker_ext, cb_listen_ipv6, cb_announce_all_trackers;
+              cb_confirm_torrent_recheck, cb_listen_ipv6, cb_announce_all_trackers;
+#ifdef BACKEND_HAS_LT_TRACKERS_EXTENSION
+    QCheckBox cb_enable_tracker_ext;
+#endif
     QComboBox combo_iface, combo_iface_address;
     QLineEdit txtAnnounceIP;
 

--- a/src/gui/ico.cpp
+++ b/src/gui/ico.cpp
@@ -19,6 +19,8 @@
 #include <QVector>
 #include <QDesktopWidget>
 
+#include "config.h"
+
 namespace
 {
     // Global header (see http://www.daubnet.com/formats/ICO.html)

--- a/src/gui/lineedit/CMakeLists.txt
+++ b/src/gui/lineedit/CMakeLists.txt
@@ -10,6 +10,8 @@ set(QBT_LINEEDIT_RESOURCES
 resources/lineeditimages.qrc
 )
 
+include_directories(${qBittorrent_BINARY_DIR}/src)
+
 add_library(qbt_lineedit STATIC ${QBT_LINEEDIT_SOURCES} ${QBT_LINEEDIT_HEADERS})
 if (QT4_FOUND)
     target_link_libraries(qbt_lineedit Qt4::QtGui)

--- a/src/gui/lineedit/src/lineedit.h
+++ b/src/gui/lineedit/src/lineedit.h
@@ -12,6 +12,8 @@
 
 #include <QLineEdit>
 
+#include "config.h"
+
 class QToolButton;
 
 class LineEdit : public QLineEdit

--- a/src/gui/optionsdlg.cpp
+++ b/src/gui/optionsdlg.cpp
@@ -65,6 +65,8 @@
 
 #include "ui_optionsdlg.h"
 
+#include "config.h"
+
 // Constructor
 OptionsDialog::OptionsDialog(QWidget *parent)
     : QDialog(parent)

--- a/src/gui/previewlistdelegate.h
+++ b/src/gui/previewlistdelegate.h
@@ -41,6 +41,8 @@
 #include "base/utils/string.h"
 #include "previewselect.h"
 
+#include "config.h"
+
 #ifdef Q_OS_WIN
 #ifndef QBT_USES_QT5
 #include <QPlastiqueStyle>

--- a/src/gui/previewselect.cpp
+++ b/src/gui/previewselect.cpp
@@ -32,6 +32,9 @@
 #include <QHeaderView>
 #include <QMessageBox>
 #include <QFile>
+
+#include "config.h"
+
 #ifdef QBT_USES_QT5
 #include <QTableView>
 #endif

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -36,6 +36,9 @@
 #include <QClipboard>
 #include <QMessageBox>
 #include <QWheelEvent>
+
+#include "config.h"
+
 #ifdef QBT_USES_QT5
 #include <QTableView>
 #endif

--- a/src/gui/properties/peersadditiondlg.cpp
+++ b/src/gui/properties/peersadditiondlg.cpp
@@ -33,6 +33,8 @@
 
 #include "peersadditiondlg.h"
 
+#include "config.h"
+
 PeersAdditionDlg::PeersAdditionDlg(QWidget *parent)
     : QDialog(parent)
 {

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -64,6 +64,8 @@
 #include "transferlistwidget.h"
 #include "autoexpandabledialog.h"
 
+#include "config.h"
+
 PropertiesWidget::PropertiesWidget(QWidget *parent, MainWindow *main_window, TransferListWidget *transferList)
     : QWidget(parent), transferList(transferList), main_window(main_window), m_torrent(0)
 {

--- a/src/gui/properties/proplistdelegate.cpp
+++ b/src/gui/properties/proplistdelegate.cpp
@@ -37,6 +37,8 @@
 #include <QProgressBar>
 #include <QApplication>
 
+#include "config.h"
+
 #ifdef Q_OS_WIN
 #ifndef QBT_USES_QT5
 #include <QPlastiqueStyle>

--- a/src/gui/properties/trackerlist.cpp
+++ b/src/gui/properties/trackerlist.cpp
@@ -37,6 +37,9 @@
 #include <QDebug>
 #include <QUrl>
 #include <QMessageBox>
+
+#include "config.h"
+
 #ifdef QBT_USES_QT5
 #include <QTableView>
 #include <QHeaderView>

--- a/src/gui/rss/CMakeLists.txt
+++ b/src/gui/rss/CMakeLists.txt
@@ -23,6 +23,7 @@ rsssettingsdlg.ui
 )
 
 add_library(qbt_rss STATIC ${QBT_RSS_HEADERS} ${QBT_RSS_SOURCE} ${QBT_RSS_FORMS})
+target_link_libraries(qbt_rss qbt_base)
 if (QT4_FOUND)
     target_link_libraries(qbt_rss Qt4::QtGui Qt4::QtNetwork)
 else (QT4_FOUND)

--- a/src/gui/search/pluginselectdlg.cpp
+++ b/src/gui/search/pluginselectdlg.cpp
@@ -37,6 +37,9 @@
 #include <QTemporaryFile>
 #include <QMimeData>
 #include <QClipboard>
+
+#include "config.h"
+
 #ifdef QBT_USES_QT5
 #include <QTableView>
 #endif

--- a/src/gui/search/searchtab.cpp
+++ b/src/gui/search/searchtab.cpp
@@ -38,6 +38,9 @@
 #include <QLabel>
 #include <QPalette>
 #include <QVBoxLayout>
+
+#include "config.h"
+
 #ifdef QBT_USES_QT5
 #include <QTableView>
 #endif

--- a/src/gui/torrentcontenttreeview.cpp
+++ b/src/gui/torrentcontenttreeview.cpp
@@ -32,6 +32,9 @@
 
 #include <QKeyEvent>
 #include <QModelIndexList>
+
+#include "config.h"
+
 #ifdef QBT_USES_QT5
 #include <QTableView>
 #include <QHeaderView>

--- a/src/gui/transferlistdelegate.cpp
+++ b/src/gui/transferlistdelegate.cpp
@@ -43,6 +43,8 @@
 #include "base/preferences.h"
 #include "base/unicodestrings.h"
 
+#include "config.h"
+
 #ifdef Q_OS_WIN
 #ifndef QBT_USES_QT5
 #include <QPlastiqueStyle>

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -41,6 +41,9 @@
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QWheelEvent>
+
+#include "config.h"
+
 #ifdef QBT_USES_QT5
 #include <QTableView>
 #endif

--- a/src/src.pro
+++ b/src/src.pro
@@ -5,7 +5,6 @@ CONFIG += qt thread silent
 # C++11 support
 CONFIG += c++11
 DEFINES += BOOST_NO_CXX11_RVALUE_REFERENCES
-greaterThan(QT_MAJOR_VERSION, 4): greaterThan(QT_MINOR_VERSION, 1): DEFINES += QBT_USES_QT5
 
 # Windows specific configuration
 win32: include(../winconf.pri)
@@ -21,7 +20,6 @@ os2: include(../os2conf.pri)
 
 nogui {
     QT -= gui
-    DEFINES += DISABLE_GUI
     TARGET = qbittorrent-nox
 } else {
     QT += xml
@@ -32,7 +30,6 @@ nogui {
     }
     TARGET = qbittorrent
 }
-nowebui: DEFINES += DISABLE_WEBUI
 strace_win {
     DEFINES += STACKTRACE_WIN
     DEFINES += STACKTRACE_WIN_PROJECT_PATH=$$PWD

--- a/src/src.pro
+++ b/src/src.pro
@@ -54,7 +54,18 @@ DEFINES += QT_NO_CAST_TO_ASCII
 # Fast concatenation (Qt >= 4.6)
 DEFINES += QT_USE_FAST_CONCATENATION QT_USE_FAST_OPERATOR_PLUS
 
-win32: DEFINES += NOMINMAX
+win32 {
+    DEFINES += NOMINMAX
+    QBT_USES_QT5 = 0
+    QBT_NOGUI = 0
+    QBT_NOWEBUI = 0
+    greaterThan(QT_MAJOR_VERSION, 4): greaterThan(QT_MINOR_VERSION, 1): QBT_USES_QT5 = 1
+    nogui: QBT_NOGUI = 1
+    nowebui: QBT_NOWEBUI = 1
+    configh.input = config.h.win.in
+    configh.output = config.h
+    QMAKE_SUBSTITUTES += configh
+}
 
 INCLUDEPATH += $$PWD
 

--- a/src/webui/abstractwebapplication.cpp
+++ b/src/webui/abstractwebapplication.cpp
@@ -39,6 +39,8 @@
 #include "websessiondata.h"
 #include "abstractwebapplication.h"
 
+#include "config.h"
+
 // UnbanTimer
 
 class UnbanTimer: public QTimer

--- a/src/webui/btjson.cpp
+++ b/src/webui/btjson.cpp
@@ -44,6 +44,9 @@
 
 #include <QDebug>
 #include <QVariant>
+
+#include "config.h"
+
 #ifndef QBT_USES_QT5
 #include <QMetaType>
 #endif

--- a/src/webui/btjson.cpp
+++ b/src/webui/btjson.cpp
@@ -885,7 +885,7 @@ QVariantMap generateSyncData(int acceptedResponseId, QVariantMap data, QVariantM
         lastAcceptedData.clear();
         syncData = data;
 
-#if (QBT_USES_QT5 && QT_VERSION < QT_VERSION_CHECK(5, 5, 0))
+#if defined QBT_USES_QT5 && QT_VERSION < QT_VERSION_CHECK(5, 5, 0)
         // QJsonDocument::fromVariant() supports QVariantHash only
         // since Qt5.5, so manually convert data["torrents"]
         QVariantMap torrentsMap;

--- a/src/webui/jsonutils.h
+++ b/src/webui/jsonutils.h
@@ -29,6 +29,8 @@
 #ifndef JSONUTILS_H
 #define JSONUTILS_H
 
+#include "config.h"
+
 #include <QVariant>
 #ifdef QBT_USES_QT5
 #include <QJsonDocument>


### PR DESCRIPTION
My distribution offers me libtorrent 1.1.0 and git master. qBt master does not build for me with any of them. This is  quick and dirty fix for libtorrent 1.2.0 branch. 

PR updated. Now it is not that quick and even more dirty :) The problem: to me this is the first time when libtorrent removes significant part of its functionality, namely lt_trackers extension (support is merged into the ut_metadata AFAIK). As such, qBt has to remove parts of UI and corresponding support in the `Session` class.  There are two basic ways: compile time and run-time detection of lt_trackers extension. Since all the other adoption of libtorrent changes made in compile time, I took that way too. 

Added checks to `configure.ac` and `src/CMakeLists.txt` to probe for `libtorrent/extensions/lt_trackers.hpp` and `libtorrent/string_view.hpp` header files. Results of these checks are written into `config.h` (autogenerated by autotools and cmake) along with all other qBt configuration switches (`QBT_USES_QT5`, `DISABLE_GUI`, etc.). The latter are removed from command line and 
```C++
#include "config.h"
```
is added to every file which depends those options (which is good, as to me, because now it can be seen at the very beginning of a source file whether its behaviour changes or not). In this way we avoid direct inclusion of libtorrent headers in the GUI code, relying on configuration-time checks instead. 

But there is Windows where neither CMake nor autotools are run, and for this case I don't know how to avoid a direct dependency on libtorrent include or hard-coding parameters into a qmake config in the very same way as it is done with the other build settings. I choose the libtorrent include and as such use another `config.h` template for this case (`config.h.win.in`) and populate it via qmake with build configuration options only, while libtorrent-related options are deduced from its version in-place.