### PR TITLE
Fix torrents pausing due to ratio conditions. Closes #6048,  Closes #6039

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1292,7 +1292,7 @@ void Session::processBigRatios()
     qreal globalMaxRatio = this->globalMaxRatio();
     foreach (TorrentHandle *const torrent, m_torrents) {
         if (torrent->isSeed()
-            && ((torrent->ratioLimit() != TorrentHandle::NO_RATIO_LIMIT) || !torrent->isForced())) {
+            && ((torrent->ratioLimit() != TorrentHandle::NO_RATIO_LIMIT) && !torrent->isForced())) {
             const qreal ratio = torrent->realRatio();
             qreal ratioLimit = torrent->ratioLimit();
             if (ratioLimit == TorrentHandle::USE_GLOBAL_RATIO) {


### PR DESCRIPTION
From https://github.com/qbittorrent/qBittorrent/commit/259b5e51c49b74455183d734932a3c67dba51af8