### PR TITLE
cmake: make prefix variables cached

### DIFF
--- a/cmake/Modules/winconf.cmake
+++ b/cmake/Modules/winconf.cmake
@@ -29,16 +29,17 @@ set(Boost_USE_STATIC_LIBS  True)
 # with usual unix subdirectories (bin, lib, include)
 # if so, we just need to set CMAKE_SYSTEM_PREFIX_PATH
 # If it is not the case, individual paths need to be specified manually (see below)
-set(COMMON_INSTALL_PREFIX "c:/usr")
+set(COMMON_INSTALL_PREFIX "c:/usr" CACHE PATH "Prefix used to install all the required libraries")
 list(APPEND CMAKE_SYSTEM_PREFIX_PATH "${COMMON_INSTALL_PREFIX}")
 
 # If two version of Qt are installed, separate prefixes are needed most likely
-set(QT4_INSTALL_PREFIX "${COMMON_INSTALL_PREFIX}/lib/qt4")
-set(QT5_INSTALL_PREFIX "${COMMON_INSTALL_PREFIX}/lib/qt5")
+set(QT4_INSTALL_PREFIX "${COMMON_INSTALL_PREFIX}/lib/qt4" CACHE PATH "Prefix where Qt4 is installed")
+set(QT5_INSTALL_PREFIX "${COMMON_INSTALL_PREFIX}/lib/qt5" CACHE PATH "Prefix where Qt5 is installed")
 
 # it is safe to set Qt dirs even if their files are directly in the prefix
 # Qt4
 if(NOT QT5)
+    # for qt 4 we need qmake, Qt5 provides cmake config files
     LIST(APPEND CMAKE_PROGRAM_PATH  "${QT4_INSTALL_PREFIX}/bin/")
 endif(NOT QT5)
 


### PR DESCRIPTION
This allows user to override their default value via -D cmake switch