### PR TITLE
Build qbittorrent-nox for macOS

### DIFF
--- a/dist/mac/Info.plist
+++ b/dist/mac/Info.plist
@@ -37,7 +37,7 @@
 		</dict>
 	</array>
 	<key>CFBundleName</key>
-	<string>qBittorrent</string>
+	<string>@EXECUTABLE@</string>
 	<key>CFBundleIconFile</key>
 	<string>qbittorrent_mac.icns</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -49,7 +49,7 @@
 	<key>CFBundleSignature</key>
 	<string>qBit</string>
 	<key>CFBundleExecutable</key>
-	<string>qbittorrent</string>
+	<string>@EXECUTABLE@</string>
 	<key>CFBundleIdentifier</key>
 	<string>org.qbittorrent</string>
 	<key>NSPrincipalClass</key>

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -161,10 +161,15 @@ endif (GUI AND WIN32)
 target_link_libraries(${QBT_TARGET_NAME} ${QBT_TARGET_LIBRARIES} QtSingleApplication::QtSingleApplication)
 
 if (APPLE)
-    set(qbt_BUNDLE_NAME "${CMAKE_PROJECT_NAME}")
+    set(qbt_BUNDLE_NAME "${QBT_TARGET_NAME}")
+
+# substitute @EXECUTABLE@ in dist/mac/Info.plist
+    set(EXECUTABLE ${qbt_BUNDLE_NAME})
+    configure_file(${qBittorrent_SOURCE_DIR}/dist/mac/Info.plist ${qBittorrent_BINARY_DIR}/dist/mac/Info.plist @ONLY)
+
     set_target_properties(${QBT_TARGET_NAME} PROPERTIES
         MACOSX_BUNDLE_BUNDLE_NAME "${qbt_BUNDLE_NAME}"
-        MACOSX_BUNDLE_INFO_PLIST ${qBittorrent_SOURCE_DIR}/dist/mac/Info.plist
+        MACOSX_BUNDLE_INFO_PLIST ${qBittorrent_BINARY_DIR}/dist/mac/Info.plist
     )
 endif (APPLE)
 


### PR DESCRIPTION
Fixed the error when you do `macdeployqt` after `./configure --disable-gui` or `cmake -DGUI=OFF`

I doubt there are needs for qbittorrent-nox for macOS though.
