### PR TITLE
Usability improvements for unselected files

### DIFF
--- a/src/gui/properties/proplistdelegate.cpp
+++ b/src/gui/properties/proplistdelegate.cpp
@@ -85,8 +85,11 @@ void PropListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
             newopt.progress = (int)progress;
             newopt.maximum = 100;
             newopt.minimum = 0;
-            newopt.state |= QStyle::State_Enabled;
             newopt.textVisible = true;
+            if (index.sibling(index.row(), PRIORITY).data().toInt() == prio::IGNORED)
+                newopt.state &= ~QStyle::State_Enabled;
+            else
+                newopt.state |= QStyle::State_Enabled;
 #ifndef Q_OS_WIN
             QApplication::style()->drawControl(QStyle::CE_ProgressBar, &newopt, painter);
 #else

--- a/src/gui/properties/proplistdelegate.cpp
+++ b/src/gui/properties/proplistdelegate.cpp
@@ -69,12 +69,7 @@ void PropListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
         break;
     case REMAINING:
         QItemDelegate::drawBackground(painter, opt, index);
-        if (index.sibling(index.row(), PRIORITY).data().toInt() == prio::IGNORED) {
-            QItemDelegate::drawDisplay(painter, opt, option.rect, tr("N/A"));
-        }
-        else {
-            QItemDelegate::drawDisplay(painter, opt, option.rect, Utils::Misc::friendlyUnit(index.data().toLongLong()));
-        }
+        QItemDelegate::drawDisplay(painter, opt, option.rect, Utils::Misc::friendlyUnit(index.data().toLongLong()));
         break;
     case PROGRESS:
         if (index.data().toDouble() >= 0) {

--- a/src/gui/properties/proplistdelegate.cpp
+++ b/src/gui/properties/proplistdelegate.cpp
@@ -137,14 +137,17 @@ void PropListDelegate::setEditorData(QWidget *editor, const QModelIndex &index) 
     QComboBox *combobox = static_cast<QComboBox*>(editor);
     // Set combobox index
     switch(index.data().toInt()) {
-    case prio::HIGH:
-        combobox->setCurrentIndex(1);
+    case prio::IGNORED:
+        combobox->setCurrentIndex(0);
         break;
-    case prio::MAXIMUM:
+    case prio::HIGH:
         combobox->setCurrentIndex(2);
         break;
+    case prio::MAXIMUM:
+        combobox->setCurrentIndex(3);
+        break;
     default:
-        combobox->setCurrentIndex(0);
+        combobox->setCurrentIndex(1);
         break;
     }
 }
@@ -159,13 +162,12 @@ QWidget *PropListDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
             return 0;
     }
 
-    if (index.data().toInt() <= 0) {
-        // IGNORED or MIXED
+    if (index.data().toInt() == prio::MIXED)
         return 0;
-    }
 
     QComboBox* editor = new QComboBox(parent);
     editor->setFocusPolicy(Qt::StrongFocus);
+    editor->addItem(tr("Do not download", "Do not download (priority)"));
     editor->addItem(tr("Normal", "Normal (priority)"));
     editor->addItem(tr("High", "High (priority)"));
     editor->addItem(tr("Maximum", "Maximum (priority)"));
@@ -179,10 +181,13 @@ void PropListDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, 
     qDebug("PropListDelegate: setModelData(%d)", value);
 
     switch(value)  {
-    case 1:
-        model->setData(index, prio::HIGH); // HIGH
+    case 0:
+        model->setData(index, prio::IGNORED); // IGNORED
         break;
     case 2:
+        model->setData(index, prio::HIGH); // HIGH
+        break;
+    case 3:
         model->setData(index, prio::MAXIMUM); // MAX
         break;
     default:

--- a/src/gui/torrentcontentfiltermodel.cpp
+++ b/src/gui/torrentcontentfiltermodel.cpp
@@ -31,6 +31,7 @@
 #include "base/utils/string.h"
 #include "torrentcontentfiltermodel.h"
 #include "torrentcontentmodel.h"
+#include "proplistdelegate.h"
 
 TorrentContentFilterModel::TorrentContentFilterModel(QObject *parent):
   QSortFilterProxyModel(parent), m_model(new TorrentContentModel(this))

--- a/src/gui/torrentcontentfiltermodel.cpp
+++ b/src/gui/torrentcontentfiltermodel.cpp
@@ -31,7 +31,6 @@
 #include "base/utils/string.h"
 #include "torrentcontentfiltermodel.h"
 #include "torrentcontentmodel.h"
-#include "proplistdelegate.h"
 
 TorrentContentFilterModel::TorrentContentFilterModel(QObject *parent):
   QSortFilterProxyModel(parent), m_model(new TorrentContentModel(this))
@@ -84,7 +83,7 @@ bool TorrentContentFilterModel::filterAcceptsRow(int source_row, const QModelInd
 
 bool TorrentContentFilterModel::lessThan(const QModelIndex &left, const QModelIndex &right) const {
   switch (sortColumn()) {
-  case NAME: {  // PropColumn::NAME
+  case TorrentContentModelItem::COL_NAME: {
     QString vL = left.data().toString();
     QString vR = right.data().toString();
     TorrentContentModelItem::ItemType leftType = m_model->itemType(m_model->index(left.row(), 0, left.parent()));

--- a/src/gui/torrentcontentfiltermodel.h
+++ b/src/gui/torrentcontentfiltermodel.h
@@ -33,7 +33,6 @@
 
 #include <QSortFilterProxyModel>
 #include "torrentcontentmodelitem.h"
-#include "proplistdelegate.h"
 
 class TorrentContentModel;
 

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -199,7 +199,9 @@ QVariant TorrentContentModel::data(const QModelIndex& index, int role) const
         return Qt::Checked;
     }
 
-    if ((role == Qt::ForegroundRole) && (item->data(TorrentContentModelItem::COL_PRIO).toInt() == prio::IGNORED)) {
+    if ((index.column() != 3) // PRIORITY
+        && (role == Qt::ForegroundRole)
+        && (item->data(TorrentContentModelItem::COL_PRIO).toInt() == prio::IGNORED)) {
         QPalette pal = QApplication::palette();
         return pal.color(QPalette::Disabled, QPalette::Text);
     }

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -124,7 +124,7 @@ bool TorrentContentModel::setData(const QModelIndex& index, const QVariant& valu
     if (!index.isValid())
         return false;
 
-    if ((index.column() == 0) && (role == Qt::CheckStateRole)) {
+    if ((index.column() == TorrentContentModelItem::COL_NAME) && (role == Qt::CheckStateRole)) {
         TorrentContentModelItem *item = static_cast<TorrentContentModelItem*>(index.internalPointer());
         qDebug("setData(%s, %d", qPrintable(item->name()), value.toInt());
         if (item->priority() != value.toInt()) {
@@ -184,14 +184,14 @@ QVariant TorrentContentModel::data(const QModelIndex& index, int role) const
 
     TorrentContentModelItem* item = static_cast<TorrentContentModelItem*>(index.internalPointer());
 
-    if ((index.column() == 0) && (role == Qt::DecorationRole)) {
+    if ((index.column() == TorrentContentModelItem::COL_NAME) && (role == Qt::DecorationRole)) {
         if (item->itemType() == TorrentContentModelItem::FolderType)
             return getDirectoryIcon();
         else
             return getFileIcon();
     }
 
-    if ((index.column() == 0) && (role == Qt::CheckStateRole)) {
+    if ((index.column() == TorrentContentModelItem::COL_NAME) && (role == Qt::CheckStateRole)) {
         if (item->data(TorrentContentModelItem::COL_PRIO).toInt() == prio::IGNORED)
             return Qt::Unchecked;
         if (item->data(TorrentContentModelItem::COL_PRIO).toInt() == prio::MIXED)
@@ -199,7 +199,7 @@ QVariant TorrentContentModel::data(const QModelIndex& index, int role) const
         return Qt::Checked;
     }
 
-    if ((index.column() != 3) // PRIORITY
+    if ((index.column() != TorrentContentModelItem::COL_PRIO)
         && (role == Qt::ForegroundRole)
         && (item->data(TorrentContentModelItem::COL_PRIO).toInt() == prio::IGNORED)) {
         QPalette pal = QApplication::palette();

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -28,8 +28,10 @@
  * Contact : chris@qbittorrent.org
  */
 
+#include <QApplication>
 #include <QDir>
 #include <QIcon>
+#include <QPalette>
 
 #include "guiiconprovider.h"
 #include "base/utils/misc.h"
@@ -181,12 +183,14 @@ QVariant TorrentContentModel::data(const QModelIndex& index, int role) const
         return QVariant();
 
     TorrentContentModelItem* item = static_cast<TorrentContentModelItem*>(index.internalPointer());
+
     if ((index.column() == 0) && (role == Qt::DecorationRole)) {
         if (item->itemType() == TorrentContentModelItem::FolderType)
             return getDirectoryIcon();
         else
             return getFileIcon();
     }
+
     if ((index.column() == 0) && (role == Qt::CheckStateRole)) {
         if (item->data(TorrentContentModelItem::COL_PRIO).toInt() == prio::IGNORED)
             return Qt::Unchecked;
@@ -194,10 +198,16 @@ QVariant TorrentContentModel::data(const QModelIndex& index, int role) const
             return Qt::PartiallyChecked;
         return Qt::Checked;
     }
-    if (role != Qt::DisplayRole)
-        return QVariant();
 
-    return item->data(index.column());
+    if ((role == Qt::ForegroundRole) && (item->data(TorrentContentModelItem::COL_PRIO).toInt() == prio::IGNORED)) {
+        QPalette pal = QApplication::palette();
+        return pal.color(QPalette::Disabled, QPalette::Text);
+    }
+
+    if (role == Qt::DisplayRole)
+        return item->data(index.column());
+
+    return QVariant();
 }
 
 Qt::ItemFlags TorrentContentModel::flags(const QModelIndex& index) const

--- a/src/gui/torrentcontentmodelitem.cpp
+++ b/src/gui/torrentcontentmodelitem.cpp
@@ -69,7 +69,6 @@ qulonglong TorrentContentModelItem::size() const
 qreal TorrentContentModelItem::progress() const
 {
     Q_ASSERT(!isRootItem());
-    if (m_priority == prio::IGNORED) return 0;
 
     if (m_size > 0) return m_progress;
 
@@ -78,10 +77,8 @@ qreal TorrentContentModelItem::progress() const
 
 qulonglong TorrentContentModelItem::remaining() const
 {
-  Q_ASSERT(!isRootItem());
-  if (m_priority == prio::IGNORED) return 0;
-
-  return m_remaining;
+    Q_ASSERT(!isRootItem());
+    return m_remaining;
 }
 
 int TorrentContentModelItem::priority() const


### PR DESCRIPTION
Look at the commits messages. They are self-explanatory.

Reason: Let's say for whatever reason you unselected a file you had half-downloaded and continued downloading another one. Afterwards you might have lost track which one you were downloading previously, because all unselected files report 0% progress. I think showing the actual data and not masking them will be more beneficial in the end of the day.

Screenshot:
![untitled](https://cloud.githubusercontent.com/assets/273315/21469167/8d1c6e9a-ca45-11e6-99ed-2b13868e7131.png)


@qbittorrent/qbittorrent-frequent-contributors any serious objections to these changes?

PS: Can someone test with a dark theme?