### PR TITLE
Use the numbers from tracker scrape response

### DIFF
--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -915,26 +915,29 @@ int TorrentHandle::leechsCount() const
 
 int TorrentHandle::totalSeedsCount() const
 {
-    return m_nativeStatus.list_seeds;
+    return (m_nativeStatus.num_complete > 0) ? m_nativeStatus.num_complete : m_nativeStatus.list_seeds;
 }
 
 int TorrentHandle::totalPeersCount() const
 {
-    return m_nativeStatus.list_peers;
+    int peers = m_nativeStatus.num_complete + m_nativeStatus.num_incomplete;
+    return (peers > 0) ? peers : m_nativeStatus.list_peers;
 }
 
 int TorrentHandle::totalLeechersCount() const
 {
-    return (m_nativeStatus.list_peers - m_nativeStatus.list_seeds);
+    return (m_nativeStatus.num_incomplete > 0) ? m_nativeStatus.num_incomplete : (m_nativeStatus.list_peers - m_nativeStatus.list_seeds);
 }
 
 int TorrentHandle::completeCount() const
 {
+    // additional info: https://github.com/qbittorrent/qBittorrent/pull/5300#issuecomment-267783646
     return m_nativeStatus.num_complete;
 }
 
 int TorrentHandle::incompleteCount() const
 {
+    // additional info: https://github.com/qbittorrent/qBittorrent/pull/5300#issuecomment-267783646
     return m_nativeStatus.num_incomplete;
 }
 

--- a/src/webui/btjson.cpp
+++ b/src/webui/btjson.cpp
@@ -707,9 +707,9 @@ QVariantMap toMap(BitTorrent::TorrentHandle *const torrent)
     ret[KEY_TORRENT_UPSPEED] = torrent->uploadPayloadRate();
     ret[KEY_TORRENT_PRIORITY] = torrent->queuePosition();
     ret[KEY_TORRENT_SEEDS] = torrent->seedsCount();
-    ret[KEY_TORRENT_NUM_COMPLETE] = torrent->completeCount();
+    ret[KEY_TORRENT_NUM_COMPLETE] = torrent->totalSeedsCount();
     ret[KEY_TORRENT_LEECHS] = torrent->leechsCount();
-    ret[KEY_TORRENT_NUM_INCOMPLETE] = torrent->incompleteCount();
+    ret[KEY_TORRENT_NUM_INCOMPLETE] = torrent->totalLeechersCount();
     const qreal ratio = torrent->realRatio();
     ret[KEY_TORRENT_RATIO] = (ratio > BitTorrent::TorrentHandle::MAX_RATIO) ? -1 : ratio;
     ret[KEY_TORRENT_STATE] = torrent->state().toString();


### PR DESCRIPTION
Closing PR #5300 in favor of this one.

* Fix webUI used the wrong value. Closes #5048.
* Use the numbers from tracker scrape response. Closes #6117.
   also see: https://github.com/qbittorrent/qBittorrent/issues/6117#issuecomment-269104117