### PR TITLE
After files relocate, don't remove the old folder even if it is empty

### DIFF
--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -1280,7 +1280,7 @@ void TorrentHandle::moveStorage(const QString &newPath)
         m_queuedPath = newPath;
     }
     else {
-        QString oldPath = nativeActualSavePath();
+        const QString oldPath = nativeActualSavePath();
         if (QDir(oldPath) == QDir(newPath)) return;
 
         qDebug("move storage: %s to %s", qPrintable(oldPath), qPrintable(newPath));
@@ -1347,7 +1347,7 @@ void TorrentHandle::handleStorageMovedAlert(libtorrent::storage_moved_alert *p)
         return;
     }
 
-    QString newPath = Utils::String::fromStdString(p->path);
+    const QString newPath = Utils::String::fromStdString(p->path);
     if (newPath != m_newPath) {
         qWarning() << Q_FUNC_INFO << ": New path doesn't match a path in a queue.";
         return;

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -1367,13 +1367,6 @@ void TorrentHandle::handleStorageMovedAlert(libtorrent::storage_moved_alert *p)
         m_session->handleTorrentSavePathChanged(this);
     }
 
-    // Attempt to remove old folder if empty
-    QDir oldSaveDir(Utils::Fs::fromNativePath(m_oldPath));
-    if (oldSaveDir != QDir(m_session->defaultSavePath())) {
-        qDebug("Attempting to remove %s", qPrintable(m_oldPath));
-        QDir().rmpath(m_oldPath);
-    }
-
     while (!isMoveInProgress() && (m_renameCount == 0) && !m_moveFinishedTriggers.isEmpty())
         m_moveFinishedTriggers.takeFirst()();
 }

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -249,18 +249,17 @@ void TransferListWidget::setSelectedTorrentsLocation()
     const QList<BitTorrent::TorrentHandle *> torrents = getSelectedTorrents();
     if (torrents.isEmpty()) return;
 
-    QString dir;
-    const QDir saveDir(torrents[0]->savePath());
-    qDebug("Old save path is %s", qPrintable(saveDir.absolutePath()));
-    dir = QFileDialog::getExistingDirectory(this, tr("Choose save path"), saveDir.absolutePath(),
+    const QString oldLocation = torrents[0]->savePath();
+    qDebug("Old location is %s", qPrintable(oldLocation));
+
+    const QString newLocation = QFileDialog::getExistingDirectory(this, tr("Choose save path"), oldLocation,
                                             QFileDialog::DontConfirmOverwrite | QFileDialog::ShowDirsOnly | QFileDialog::HideNameFilterDetails);
-    if (!dir.isNull()) {
-        qDebug("New path is %s", qPrintable(dir));
-        foreach (BitTorrent::TorrentHandle *const torrent, torrents) {
-            // Actually move storage
-            torrent->move(Utils::Fs::expandPathAbs(dir));
-        }
-    }
+    if (!QDir(newLocation).exists()) return;
+    qDebug("New location is %s", qPrintable(newLocation));
+
+    // Actually move storage
+    foreach (BitTorrent::TorrentHandle *const torrent, torrents)
+        torrent->move(Utils::Fs::expandPathAbs(newLocation));
 }
 
 void TransferListWidget::pauseAllTorrents()


### PR DESCRIPTION
This behavior could be troublesome in some situations, e.g., I download a torrent to some temp folder, now later I have a permanent folder for it, so I use "Set location" to relocate it but it deletes my temp folder.