### PR TITLE
Wait until session is paused when saving resume data

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1853,6 +1853,9 @@ void Session::saveResumeData()
 
     // Pause session
     m_nativeSession->pause();
+    while (!m_nativeSession->is_paused()) {
+        readAlerts(10);
+    }
 
     generateResumeData(true);
 
@@ -3168,10 +3171,10 @@ void Session::getPendingAlerts(std::vector<libt::alert *> &out, ulong time)
 }
 
 // Read alerts sent by the BitTorrent session
-void Session::readAlerts()
+void Session::readAlerts(ulong time)
 {
     std::vector<libt::alert *> alerts;
-    getPendingAlerts(alerts);
+    getPendingAlerts(alerts, time);
 
     for (const auto a: alerts) {
         handleAlert(a);

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -414,7 +414,7 @@ namespace BitTorrent
 
     private slots:
         void configureDeferred();
-        void readAlerts();
+        void readAlerts(ulong time = 0);
         void refresh();
         void processBigRatios();
         void generateResumeData(bool final = false);


### PR DESCRIPTION
libtorrent::session(?:_handler)::pause() is asynchronous, thus after
making the call we wait until the session is actually paused.

Many users noticed that the longer the torrents number grows, the more frequently torrents disappear after qBt restart. @nxd4 in issue #6113 provided [patch](https://gist.github.com/anonymous/5e839beeea27dbd13a59cb6ccf820607) to workaround the problem. 

The patch makes me think that we deal with a multi-threading issue. The only possible thing I was able to find is the asynchronous call for pausing the libtorrent session, and then immediate resume data generation without waiting for session to turn into paused state. So I added the code to wait until `m_nativeSession->is_paused()` returns `true` and torrents seems to stop disappearing.

The fix from @nxd4 is needed to fix already corrupted .fastresume files.