### PR TITLE
Indicate 64bit on Windows. Closes #6110

### DIFF
--- a/version.pri
+++ b/version.pri
@@ -21,9 +21,13 @@ DEFINES += VERSION_MINOR=$${VER_MINOR}
 DEFINES += VERSION_BUGFIX=$${VER_BUGFIX}
 DEFINES += VERSION_BUILD=$${VER_BUILD}
 
-os2 {
-    DEFINES += VERSION=\'\"v$${PROJECT_VERSION}\"\'
+win32: contains(QMAKE_TARGET.arch, x86_64) {
+# append (64-bit) for Windows 64-bit version
+    DEFINES += VERSION=\\\"v$${PROJECT_VERSION}\040(64-bit)\\\"
 } else {
-    DEFINES += VERSION=\\\"v$${PROJECT_VERSION}\\\"
+    os2 {
+        DEFINES += VERSION=\'\"v$${PROJECT_VERSION}\"\'
+    } else {
+        DEFINES += VERSION=\\\"v$${PROJECT_VERSION}\\\"
+    }
 }
-


### PR DESCRIPTION
Indicate 64bit in the title bar and the crashed dialog box for convenience.

![titlebar](https://cloud.githubusercontent.com/assets/24397896/21576025/3ac5f794-cf66-11e6-8769-71a800e259a9.png)

![crashed](https://cloud.githubusercontent.com/assets/24397896/21576026/3fe618bc-cf66-11e6-8818-af8235dba658.png)
