### PR TITLE
Move old RSS items to separate config file. Closes #6167.

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -141,6 +141,10 @@ int main(int argc, char *argv[])
     macMigratePlists();
 #endif
 
+#ifndef DISABLE_GUI
+    migrateRSS();
+#endif
+
     // Create Application
     QString appId = QLatin1String("qBittorrent-") + Utils::Misc::getUserIDString();
     QScopedPointer<Application> app(new Application(appId, argc, argv));

--- a/src/app/upgrade.h
+++ b/src/app/upgrade.h
@@ -228,7 +228,6 @@ bool upgrade(bool ask = true)
     return true;
 }
 
-
 #ifdef Q_OS_MAC
 void migratePlistToIni(const QString &application)
 {
@@ -257,5 +256,22 @@ void macMigratePlists()
 }
 #endif  // Q_OS_MAC
 
+#ifndef DISABLE_GUI
+void migrateRSS()
+{
+    // Copy old feed items to new file if needed
+    QIniSettings qBTRSS("qBittorrent", "qBittorrent-rss-feeds");
+    if (!qBTRSS.allKeys().isEmpty()) return; // We move the contents of RSS old_items only if inifile does not exist (is empty).
+
+    QIniSettings qBTRSSLegacy("qBittorrent", "qBittorrent-rss");
+    QHash<QString, QVariant> allOldItems = qBTRSSLegacy.value("old_items", QHash<QString, QVariant>()).toHash();
+
+    if (!allOldItems.empty()) {
+        qDebug("Moving %d old items for feeds to qBittorrent-rss-feeds", allOldItems.size());
+        qBTRSS.setValue("old_items", allOldItems);
+        qBTRSSLegacy.remove("old_items");
+    }
+}
+#endif
 
 #endif // UPGRADE_H

--- a/src/base/rss/rssfeed.cpp
+++ b/src/base/rss/rssfeed.cpp
@@ -99,7 +99,7 @@ void Feed::saveItemsToDisk()
 
     m_dirty = false;
 
-    QIniSettings qBTRSS("qBittorrent", "qBittorrent-rss");
+    QIniSettings qBTRSSFeeds("qBittorrent", "qBittorrent-rss-feeds");
     QVariantList oldItems;
 
     ArticleHash::ConstIterator it = m_articles.begin();
@@ -107,15 +107,16 @@ void Feed::saveItemsToDisk()
     for (; it != itend; ++it)
         oldItems << it.value()->toHash();
     qDebug("Saving %d old items for feed %s", oldItems.size(), qPrintable(displayName()));
-    QHash<QString, QVariant> allOldItems = qBTRSS.value("old_items", QHash<QString, QVariant>()).toHash();
+    QHash<QString, QVariant> allOldItems = qBTRSSFeeds.value("old_items", QHash<QString, QVariant>()).toHash();
     allOldItems[m_url] = oldItems;
-    qBTRSS.setValue("old_items", allOldItems);
+    qBTRSSFeeds.setValue("old_items", allOldItems);
 }
 
 void Feed::loadItemsFromDisk()
 {
-    QIniSettings qBTRSS("qBittorrent", "qBittorrent-rss");
-    QHash<QString, QVariant> allOldItems = qBTRSS.value("old_items", QHash<QString, QVariant>()).toHash();
+    QIniSettings qBTRSSFeeds("qBittorrent", "qBittorrent-rss-feeds");
+    QHash<QString, QVariant> allOldItems = qBTRSSFeeds.value("old_items", QHash<QString, QVariant>()).toHash();
+
     const QVariantList oldItems = allOldItems.value(m_url, QVariantList()).toList();
     qDebug("Loading %d old items for feed %s", oldItems.size(), qPrintable(displayName()));
 
@@ -203,10 +204,11 @@ void Feed::removeAllSettings()
         allFeedsFilters.remove(m_url);
         qBTRSS.setValue("feed_filters", allFeedsFilters);
     }
-    QVariantHash allOldItems = qBTRSS.value("old_items", QVariantHash()).toHash();
+    QIniSettings qBTRSSFeeds("qBittorrent", "qBittorrent-rss-feeds");
+    QVariantHash allOldItems = qBTRSSFeeds.value("old_items", QVariantHash()).toHash();
     if (allOldItems.contains(m_url)) {
         allOldItems.remove(m_url);
-        qBTRSS.setValue("old_items", allOldItems);
+        qBTRSSFeeds.setValue("old_items", allOldItems);
     }
 }
 


### PR DESCRIPTION
This is one of a series of pull requests designed to improve the responsiveness of the UI. This pull request addresses #6167.

When editing RSS downloader rules, each edit results in persisting the rules to disk. Since the `old_items` are in the same file, this also means persisting the `old_items` to disk each time a rule is edited. I have ~100 rules which use <1MB on disk, but the `old_items` use ~70MB, so persisting them each edit affected responsiveness.

This change moves the RSS `old_items` from `qBittorrent-rss.conf` to a new `qBittorrent-rss-items.conf`. Existing entries are migrated on first run.