### PR TITLE
Improve UI responsiveness during RSS downloading. Closes #873, #1089, #1235, #5423

### DIFF
--- a/src/base/rss/rssfeed.cpp
+++ b/src/base/rss/rssfeed.cpp
@@ -361,6 +361,14 @@ void Feed::handleFeedTitle(const QString &title)
 void Feed::downloadArticleTorrentIfMatching(const ArticlePtr &article)
 {
     Q_ASSERT(Preferences::instance()->isRssDownloadingEnabled());
+    qDebug().nospace() << Q_FUNC_INFO << " Deferring matching of " << article->title() << " from " << displayName() << " RSS feed";
+    m_manager->downloadArticleTorrentIfMatching(m_url, article);
+}
+
+void Feed::deferredDownloadArticleTorrentIfMatching(const ArticlePtr &article)
+{
+    qDebug().nospace() << Q_FUNC_INFO << " Matching of " << article->title() << " from " << displayName() << " RSS feed";
+
     DownloadRuleList *rules = m_manager->downloadRules();
     DownloadRulePtr matchingRule = rules->findMatchingRule(m_url, article->title());
     if (!matchingRule) return;

--- a/src/base/rss/rssfeed.h
+++ b/src/base/rss/rssfeed.h
@@ -98,10 +98,13 @@ namespace Rss
         void handleArticleRead();
 
     private:
+        friend class Manager;
+
         QString iconUrl() const;
         void loadItemsFromDisk();
         void addArticle(const ArticlePtr &article);
         void downloadArticleTorrentIfMatching(const ArticlePtr &article);
+        void deferredDownloadArticleTorrentIfMatching(const ArticlePtr &article);
 
     private:
         Manager *m_manager;

--- a/src/base/rss/rssmanager.h
+++ b/src/base/rss/rssmanager.h
@@ -32,19 +32,23 @@
 #ifndef RSSMANAGER_H
 #define RSSMANAGER_H
 
+#include <QList>
 #include <QObject>
+#include <QPair>
 #include <QTimer>
 #include <QSharedPointer>
 #include <QThread>
 
 namespace Rss
 {
+    class Article;
     class DownloadRuleList;
     class File;
     class Folder;
     class Feed;
     class Manager;
 
+    typedef QSharedPointer<Article> ArticlePtr;
     typedef QSharedPointer<File> FilePtr;
     typedef QSharedPointer<Folder> FolderPtr;
     typedef QSharedPointer<Feed> FeedPtr;
@@ -62,6 +66,7 @@ namespace Rss
         DownloadRuleList *downloadRules() const;
         FolderPtr rootFolder() const;
         QThread *workingThread() const;
+        void downloadArticleTorrentIfMatching(const QString &url, const ArticlePtr &article);
 
     public slots:
         void refresh();
@@ -78,12 +83,17 @@ namespace Rss
         void feedInfosChanged(const QString &url, const QString &displayName, uint unreadCount);
         void feedIconChanged(const QString &url, const QString &iconPath);
 
+    private slots:
+        void downloadNextArticleTorrentIfMatching();
+
     private:
         QTimer m_refreshTimer;
         uint m_refreshInterval;
         DownloadRuleList *m_downloadRules;
         FolderPtr m_rootFolder;
         QThread *m_workingThread;
+        QTimer m_deferredDownloadTimer;
+        QList<QPair<QString, ArticlePtr>> m_deferredDownloads;
     };
 }
 


### PR DESCRIPTION
This is one of a series of pull requests designed to improve the responsiveness of the UI. This pull request addresses #873, #1089, #1235, #5423 (which are all essentially the same issue reported multiple times).

The issues mentioned talk about using QThread, and my initial intention was to move the processing of the RSS articles fully to the thread currently being used for RSS parsing, but I wasn't able to work out how to get it to work. I have taken a different approach in this pull request - process a single article, then fire a timer to process the next article with a 1ms delay. This allows UI and input events to be processed almost immediately instead of the entire UI freezing until the feed is processed.

Note: Qt seems to do something special with a 0ms delay - I'm guessing adding it to the current events to be processed rather than actually going around the event loop - which resulted in a much less responsive UI than using 1ms.

This pull request also improves startup time, since the feeds were being processed before the UI was displayed. With this change qBittorrent is usable within a short period (~20 seconds in the VM on my QNAP) instead of having to wait for the feed processing (which took multiple minutes in my VM).