### PR TITLE
RSS defer matching articles for rules until idle. Closes #6166.

### DIFF
--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -48,9 +48,10 @@
 #include "automatedrssdownloader.h"
 
 AutomatedRssDownloader::AutomatedRssDownloader(const QWeakPointer<Rss::Manager> &manager, QWidget *parent)
-    : QDialog(parent),
-    ui(new Ui::AutomatedRssDownloader),
-    m_manager(manager), m_editedRule(0)
+    : QDialog(parent)
+    , ui(new Ui::AutomatedRssDownloader)
+    , m_manager(manager)
+    , m_editedRule(0)
 {
     ui->setupUi(this);
     // Icons
@@ -516,8 +517,9 @@ void AutomatedRssDownloader::handleFeedCheckStateChange(QListWidgetItem *feed_it
             if (!affected_feeds.contains(feed_url))
                 affected_feeds << feed_url;
         }
-        else if (affected_feeds.contains(feed_url))
+        else if (affected_feeds.contains(feed_url)) {
             affected_feeds.removeOne(feed_url);
+        }
         // Save the updated rule
         if (affected_feeds.size() != rule->rssFeeds().size()) {
             rule->setRssFeeds(affected_feeds);

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -62,6 +62,7 @@ AutomatedRssDownloader::AutomatedRssDownloader(const QWeakPointer<Rss::Manager> 
     ui->listRules->setSortingEnabled(true);
     ui->listRules->setSelectionMode(QAbstractItemView::ExtendedSelection);
     ui->treeMatchingArticles->setSortingEnabled(true);
+    ui->treeMatchingArticles->sortByColumn(0, Qt::AscendingOrder);
     ui->hsplitter->setCollapsible(0, false);
     ui->hsplitter->setCollapsible(1, false);
     ui->hsplitter->setCollapsible(2, true); // Only the preview list is collapsible

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -172,8 +172,6 @@ void AutomatedRssDownloader::loadRulesList()
         else
             item->setCheckState(Qt::Unchecked);
     }
-    if (( ui->listRules->count() > 0) && !ui->listRules->currentItem())
-        ui->listRules->setCurrentRow(0);
 }
 
 void AutomatedRssDownloader::loadFeedList()

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -84,6 +84,7 @@ private slots:
     void on_importBtn_clicked();
     void renameSelectedRule();
     void updateMatchingArticles();
+    void deferredUpdateMatchingArticles();
     void updateFieldsToolTips(bool regex);
     void updateMustLineValidity();
     void updateMustNotLineValidity();

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -96,6 +96,8 @@ private:
     void addFeedArticlesToTree(const Rss::FeedPtr &feed, const QStringList &articles);
 
 private:
+    class DownloadRuleListMatchState;
+
     Ui::AutomatedRssDownloader *ui;
     QWeakPointer<Rss::Manager> m_manager;
     QListWidgetItem *m_editedRule;
@@ -104,6 +106,7 @@ private:
     QRegExp *m_episodeRegex;
     QShortcut *editHotkey;
     QShortcut *deleteHotkey;
+    DownloadRuleListMatchState *m_ruleMatcher;
 };
 
 #endif // AUTOMATEDRSSDOWNLOADER_H

--- a/src/gui/rss/automatedrssdownloader.ui
+++ b/src/gui/rss/automatedrssdownloader.ui
@@ -336,17 +336,31 @@
      <widget class="QWidget" name="layoutWidget2">
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
-        <widget class="QLabel" name="label_3">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Matching RSS Articles</string>
-         </property>
-        </widget>
+        <layout class="QHBoxLayout" name="horizontalLayout_10">
+         <item>
+            <widget class="QLabel" name="label_3">
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Matching RSS Articles</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="treeMatchingLoading">
+             <property name="maximumSize">
+              <size>
+               <width>18</width>
+               <height>18</height>
+              </size>
+             </property>
+            </widget>
+         </item>
+	    </layout>
        </item>
        <item>
         <widget class="QTreeWidget" name="treeMatchingArticles">


### PR DESCRIPTION
This is one of a series of pull requests designed to improve the responsiveness of the UI. This pull request addresses #6166.

Currently when editing an RSS rule each modification (e.g. each keypress in "Must Contain") results in immediately matching articles to populate the tree. This matching can take a long time - seconds is not uncommon, and can be a lot longer (one of my filters takes ~1 minute) - during which no further input is accepted.

This pull requests delays the article matching until there has been at least 1 second without any changes to the rule. This allows typing, etc without delay and makes for a much more responsive UI.

This pull request also adds a processing indicator while the articles are being matched:

![rss_matching](https://cloud.githubusercontent.com/assets/1728015/21579991/deef69da-d025-11e6-8437-1237c251b2f4.png)

Note: this pull request includes a commit (ee0359c) which has been factored out to allow all the pull requests I am submitting to merge without conflicts.