### PR TITLE
Incremental/interruptible RSS article match tree updates. Closes #6169.

### DIFF
--- a/src/base/rss/rssdownloadrule.cpp
+++ b/src/base/rss/rssdownloadrule.cpp
@@ -403,19 +403,3 @@ void DownloadRule::setEpisodeFilter(const QString &e)
 {
     m_episodeFilter = e;
 }
-
-QStringList DownloadRule::findMatchingArticles(const FeedPtr &feed) const
-{
-    QStringList ret;
-    const ArticleHash &feedArticles = feed->articleHash();
-
-    ArticleHash::ConstIterator artIt = feedArticles.begin();
-    ArticleHash::ConstIterator artItend = feedArticles.end();
-    for (; artIt != artItend; ++artIt) {
-        const QString title = artIt.value()->title();
-        qDebug() << "Matching article:" << title;
-        if (matches(title))
-            ret << title;
-    }
-    return ret;
-}

--- a/src/base/rss/rssdownloadrule.h
+++ b/src/base/rss/rssdownloadrule.h
@@ -83,7 +83,6 @@ namespace Rss
         void setUseRegex(bool enabled);
         QString episodeFilter() const;
         void setEpisodeFilter(const QString &e);
-        QStringList findMatchingArticles(const FeedPtr &feed) const;
         // Operators
         bool operator==(const DownloadRule &other) const;
 

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -48,9 +48,10 @@
 #include "automatedrssdownloader.h"
 
 AutomatedRssDownloader::AutomatedRssDownloader(const QWeakPointer<Rss::Manager> &manager, QWidget *parent)
-    : QDialog(parent),
-    ui(new Ui::AutomatedRssDownloader),
-    m_manager(manager), m_editedRule(0)
+    : QDialog(parent)
+    , ui(new Ui::AutomatedRssDownloader)
+    , m_manager(manager)
+    , m_editedRule(0)
 {
     ui->setupUi(this);
     // Icons
@@ -516,8 +517,9 @@ void AutomatedRssDownloader::handleFeedCheckStateChange(QListWidgetItem *feed_it
             if (!affected_feeds.contains(feed_url))
                 affected_feeds << feed_url;
         }
-        else if (affected_feeds.contains(feed_url))
+        else if (affected_feeds.contains(feed_url)) {
             affected_feeds.removeOne(feed_url);
+        }
         // Save the updated rule
         if (affected_feeds.size() != rule->rssFeeds().size()) {
             rule->setRssFeeds(affected_feeds);

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -62,6 +62,7 @@ AutomatedRssDownloader::AutomatedRssDownloader(const QWeakPointer<Rss::Manager> 
     ui->listRules->setSortingEnabled(true);
     ui->listRules->setSelectionMode(QAbstractItemView::ExtendedSelection);
     ui->treeMatchingArticles->setSortingEnabled(true);
+    ui->treeMatchingArticles->sortByColumn(0, Qt::AscendingOrder);
     ui->hsplitter->setCollapsible(0, false);
     ui->hsplitter->setCollapsible(1, false);
     ui->hsplitter->setCollapsible(2, true); // Only the preview list is collapsible

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -172,8 +172,6 @@ void AutomatedRssDownloader::loadRulesList()
         else
             item->setCheckState(Qt::Unchecked);
     }
-    if (( ui->listRules->count() > 0) && !ui->listRules->currentItem())
-        ui->listRules->setCurrentRow(0);
 }
 
 void AutomatedRssDownloader::loadFeedList()

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -85,6 +85,7 @@ private slots:
     void renameSelectedRule();
     void updateMatchingArticles();
     void deferredUpdateMatchingArticles();
+    void updateNextMatchingArticles();
     void updateFieldsToolTips(bool regex);
     void updateMustLineValidity();
     void updateMustNotLineValidity();
@@ -94,7 +95,7 @@ private slots:
 private:
     Rss::DownloadRulePtr getCurrentRule() const;
     void initCategoryCombobox();
-    void addFeedArticlesToTree(const Rss::FeedPtr &feed, const QStringList &articles);
+    void addFeedArticlesToTree(const Rss::FeedPtr &feed, const QSet<QString> &articles);
 
 private:
     class DownloadRuleListMatchState;

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -84,6 +84,7 @@ private slots:
     void on_importBtn_clicked();
     void renameSelectedRule();
     void updateMatchingArticles();
+    void deferredUpdateMatchingArticles();
     void updateFieldsToolTips(bool regex);
     void updateMustLineValidity();
     void updateMustNotLineValidity();

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -96,6 +96,8 @@ private:
     void addFeedArticlesToTree(const Rss::FeedPtr &feed, const QStringList &articles);
 
 private:
+    class DownloadRuleListMatchState;
+
     Ui::AutomatedRssDownloader *ui;
     QWeakPointer<Rss::Manager> m_manager;
     QListWidgetItem *m_editedRule;
@@ -104,6 +106,7 @@ private:
     QRegExp *m_episodeRegex;
     QShortcut *editHotkey;
     QShortcut *deleteHotkey;
+    DownloadRuleListMatchState *m_ruleMatcher;
 };
 
 #endif // AUTOMATEDRSSDOWNLOADER_H

--- a/src/gui/rss/automatedrssdownloader.ui
+++ b/src/gui/rss/automatedrssdownloader.ui
@@ -336,17 +336,31 @@
      <widget class="QWidget" name="layoutWidget2">
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
-        <widget class="QLabel" name="label_3">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Matching RSS Articles</string>
-         </property>
-        </widget>
+        <layout class="QHBoxLayout" name="horizontalLayout_10">
+         <item>
+            <widget class="QLabel" name="label_3">
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Matching RSS Articles</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="treeMatchingLoading">
+             <property name="maximumSize">
+              <size>
+               <width>18</width>
+               <height>18</height>
+              </size>
+             </property>
+            </widget>
+         </item>
+	    </layout>
        </item>
        <item>
         <widget class="QTreeWidget" name="treeMatchingArticles">


### PR DESCRIPTION
This is one of a series of pull requests designed to improve the responsiveness of the UI. This pull request addresses #6169.

Currently when the RSS download rules dialog is matching, the UI freezes until the matching is complete. This pull request breaks the matching up into 250ms chunks, so that the UI remains responsive. Matching in progress will be interrupted if there are any changes, a different rule is selected or the dialog is closed.

I've implemented a state machine for this. The code is a little messy, but I couldn't really see a way to clean it up since most of the state changes are different. The state machine needs to track what rules need to be processed (since there can be more than one), where it's up to in the list of articles for each rule, etc. It also needs to be able to detect that there has been input (or the dialog closed) and stop processing.

Note: this pull request also includes the commits in pull request #6177.