### PR TITLE
RSS use red text to indicate invalid filter. Closes #6165.

### DIFF
--- a/src/base/rss/rssdownloadrulelist.cpp
+++ b/src/base/rss/rssdownloadrulelist.cpp
@@ -46,6 +46,7 @@ DownloadRuleList::DownloadRuleList()
 DownloadRulePtr DownloadRuleList::findMatchingRule(const QString &feedUrl, const QString &articleTitle) const
 {
     Q_ASSERT(Preferences::instance()->isRssDownloadingEnabled());
+    qDebug() << "Matching article:" << articleTitle;
     QStringList ruleNames = m_feedRules.value(feedUrl);
     foreach (const QString &rule_name, ruleNames) {
         DownloadRulePtr rule = m_rules[rule_name];

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -73,8 +73,6 @@ AutomatedRssDownloader::AutomatedRssDownloader(const QWeakPointer<Rss::Manager> 
     m_editableRuleList = new Rss::DownloadRuleList; // Read rule list from disk
     m_episodeRegex = new QRegExp("^(^[1-9]{1,1}\\d{0,3}x([1-9]{1,1}\\d{0,3}(-([1-9]{1,1}\\d{0,3})?)?;){1,}){1,1}",
                                  Qt::CaseInsensitive);
-    m_episodeValidator = new QRegExpValidator(*m_episodeRegex, ui->lineEFilter);
-    ui->lineEFilter->setValidator(m_episodeValidator);
     QString tip = "<p>" + tr("Matches articles based on episode filter.") + "</p><p><b>" + tr("Example: ")
                   + "1x2;8-15;5;30-;</b>" + tr(" will match 2, 5, 8 through 15, 30 and onward episodes of season one", "example X will match") + "</p>";
     tip += "<p>" + tr("Episode filter rules: ") + "</p><ul><li>" + tr("Season number is a mandatory non-zero value") + "</li>"
@@ -102,6 +100,8 @@ AutomatedRssDownloader::AutomatedRssDownloader(const QWeakPointer<Rss::Manager> 
     ok = connect(ui->lineNotContains, SIGNAL(textEdited(QString)), SLOT(updateMatchingArticles()));
     Q_ASSERT(ok);
     ok = connect(ui->lineNotContains, SIGNAL(textEdited(QString)), SLOT(updateMustNotLineValidity()));
+    Q_ASSERT(ok);
+    ok = connect(ui->lineEFilter, SIGNAL(textEdited(QString)), SLOT(updateEpisodeFilterValidity()));
     Q_ASSERT(ok);
     ok = connect(ui->checkRegex, SIGNAL(stateChanged(int)), SLOT(updateMatchingArticles()));
     Q_ASSERT(ok);
@@ -132,7 +132,6 @@ AutomatedRssDownloader::~AutomatedRssDownloader()
     delete deleteHotkey;
     delete ui;
     delete m_editableRuleList;
-    delete m_episodeValidator;
     delete m_episodeRegex;
 }
 
@@ -639,6 +638,20 @@ void AutomatedRssDownloader::updateMustNotLineValidity()
     else {
         ui->lineNotContains->setStyleSheet("QLineEdit { color: #ff0000; }");
         ui->lbl_mustnot_stat->setPixmap(GuiIconProvider::instance()->getIcon("task-attention").pixmap(16, 16));
+    }
+}
+
+void AutomatedRssDownloader::updateEpisodeFilterValidity()
+{
+    const QString text = ui->lineEFilter->text();
+    bool valid = m_episodeRegex->indexIn(text) != -1;
+    if (valid) {
+        ui->lineEFilter->setStyleSheet("");
+        ui->lbl_epfilter_stat->setPixmap(QPixmap());
+    }
+    else {
+        ui->lineEFilter->setStyleSheet("QLineEdit { color: #ff0000; }");
+        ui->lbl_epfilter_stat->setPixmap(GuiIconProvider::instance()->getIcon("task-attention").pixmap(16, 16));
     }
 }
 

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -71,10 +71,9 @@ AutomatedRssDownloader::AutomatedRssDownloader(const QWeakPointer<Rss::Manager> 
     Q_ASSERT(ok);
     m_ruleList = manager.toStrongRef()->downloadRules();
     m_editableRuleList = new Rss::DownloadRuleList; // Read rule list from disk
-    m_episodeValidator = new QRegExpValidator(
-        QRegExp("^(^[1-9]{1,1}\\d{0,3}x([1-9]{1,1}\\d{0,3}(-([1-9]{1,1}\\d{0,3})?)?;){1,}){1,1}",
-                Qt::CaseInsensitive),
-        ui->lineEFilter);
+    m_episodeRegex = new QRegExp("^(^[1-9]{1,1}\\d{0,3}x([1-9]{1,1}\\d{0,3}(-([1-9]{1,1}\\d{0,3})?)?;){1,}){1,1}",
+                                 Qt::CaseInsensitive);
+    m_episodeValidator = new QRegExpValidator(*m_episodeRegex, ui->lineEFilter);
     ui->lineEFilter->setValidator(m_episodeValidator);
     QString tip = "<p>" + tr("Matches articles based on episode filter.") + "</p><p><b>" + tr("Example: ")
                   + "1x2;8-15;5;30-;</b>" + tr(" will match 2, 5, 8 through 15, 30 and onward episodes of season one", "example X will match") + "</p>";
@@ -134,6 +133,7 @@ AutomatedRssDownloader::~AutomatedRssDownloader()
     delete ui;
     delete m_editableRuleList;
     delete m_episodeValidator;
+    delete m_episodeRegex;
 }
 
 void AutomatedRssDownloader::loadSettings()

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -99,6 +99,7 @@ private:
     QListWidgetItem *m_editedRule;
     Rss::DownloadRuleList *m_ruleList;
     Rss::DownloadRuleList *m_editableRuleList;
+    QRegExp *m_episodeRegex;
     QRegExpValidator *m_episodeValidator;
     QShortcut *editHotkey;
     QShortcut *deleteHotkey;

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -86,6 +86,7 @@ private slots:
     void updateFieldsToolTips(bool regex);
     void updateMustLineValidity();
     void updateMustNotLineValidity();
+    void updateEpisodeFilterValidity();
     void onFinished(int result);
 
 private:
@@ -100,7 +101,6 @@ private:
     Rss::DownloadRuleList *m_ruleList;
     Rss::DownloadRuleList *m_editableRuleList;
     QRegExp *m_episodeRegex;
-    QRegExpValidator *m_episodeValidator;
     QShortcut *editHotkey;
     QShortcut *deleteHotkey;
 };

--- a/src/gui/rss/automatedrssdownloader.ui
+++ b/src/gui/rss/automatedrssdownloader.ui
@@ -151,6 +151,16 @@
               </property>
              </widget>
             </item>
+            <item row="2" column="2">
+             <widget class="QLabel" name="lbl_epfilter_stat">
+              <property name="maximumSize">
+               <size>
+                <width>18</width>
+                <height>18</height>
+               </size>
+              </property>
+             </widget>
+            </item>
             <item row="1" column="1">
              <widget class="QLineEdit" name="lineNotContains"/>
             </item>


### PR DESCRIPTION
This pull request addresses issue #6165.

This pull request changes the RSS episode filter validation to be consistent with the must and must not contain fields - red text + warning icon if invalid.

![ep_filter](https://cloud.githubusercontent.com/assets/1728015/21580026/cc5c7f18-d027-11e6-951b-f2c16f08cb10.png)

The existing behaviour has some undesirable characteristics - in particular, not allowing intermediate states e.g. if you have a valid filter "1x2-" and you want to change it to "1x3-", it is not currently possible to delete the "2" and then type "3". It is instead necessary to have "1x23-" before deleting the "2".

Note: this pull request includes a commit (ee0359c) which has been factored out to allow all the pull requests I am submitting to merge without conflicts.