### PR TITLE
Allow | in RSS must contain. Closes #6171.

### DIFF
--- a/src/base/rss/rssdownloadrulelist.cpp
+++ b/src/base/rss/rssdownloadrulelist.cpp
@@ -46,6 +46,7 @@ DownloadRuleList::DownloadRuleList()
 DownloadRulePtr DownloadRuleList::findMatchingRule(const QString &feedUrl, const QString &articleTitle) const
 {
     Q_ASSERT(Preferences::instance()->isRssDownloadingEnabled());
+    qDebug() << "Matching article:" << articleTitle;
     QStringList ruleNames = m_feedRules.value(feedUrl);
     foreach (const QString &rule_name, ruleNames) {
         DownloadRulePtr rule = m_rules[rule_name];

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -578,14 +578,18 @@ void AutomatedRssDownloader::updateFieldsToolTips(bool regex)
 {
     QString tip;
     if (regex) {
-        tip = tr("Regex mode: use Perl-like regular expressions");
+        tip = "<p>" + tr("Regex mode: use Perl-like regular expressions") + "</p>";
         ui->lineContains->setToolTip(tip);
         ui->lineNotContains->setToolTip(tip);
     }
     else {
-        tip = tr("Wildcard mode: you can use<ul><li>? to match any single character</li><li>* to match zero or more of any characters</li><li>Whitespaces count as AND operators</li></ul>");
+        tip = "<p>" + tr("Wildcard mode: you can use") + "<ul>"
+              + "<li>" + tr("? to match any single character") + "</li>"
+              + "<li>" + tr("* to match zero or more of any characters") + "</li>"
+              + "<li>" + tr("Whitespaces count as AND operators (all words, any order)") + "</li>"
+              + "<li>" + tr("| is used as OR operator") + "</li></ul></p>"
+              + "<p>" + tr("If word order is important use * instead of whitespace.") + "</p>";
         ui->lineContains->setToolTip(tip);
-        tip = tr("Wildcard mode: you can use<ul><li>? to match any single character</li><li>* to match zero or more of any characters</li><li>| is used as OR operator</li></ul>");
         ui->lineNotContains->setToolTip(tip);
     }
 }

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -71,10 +71,9 @@ AutomatedRssDownloader::AutomatedRssDownloader(const QWeakPointer<Rss::Manager> 
     Q_ASSERT(ok);
     m_ruleList = manager.toStrongRef()->downloadRules();
     m_editableRuleList = new Rss::DownloadRuleList; // Read rule list from disk
-    m_episodeValidator = new QRegExpValidator(
-        QRegExp("^(^[1-9]{1,1}\\d{0,3}x([1-9]{1,1}\\d{0,3}(-([1-9]{1,1}\\d{0,3})?)?;){1,}){1,1}",
-                Qt::CaseInsensitive),
-        ui->lineEFilter);
+    m_episodeRegex = new QRegExp("^(^[1-9]{1,1}\\d{0,3}x([1-9]{1,1}\\d{0,3}(-([1-9]{1,1}\\d{0,3})?)?;){1,}){1,1}",
+                                 Qt::CaseInsensitive);
+    m_episodeValidator = new QRegExpValidator(*m_episodeRegex, ui->lineEFilter);
     ui->lineEFilter->setValidator(m_episodeValidator);
     QString tip = "<p>" + tr("Matches articles based on episode filter.") + "</p><p><b>" + tr("Example: ")
                   + "1x2;8-15;5;30-;</b>" + tr(" will match 2, 5, 8 through 15, 30 and onward episodes of season one", "example X will match") + "</p>";
@@ -134,6 +133,7 @@ AutomatedRssDownloader::~AutomatedRssDownloader()
     delete ui;
     delete m_editableRuleList;
     delete m_episodeValidator;
+    delete m_episodeRegex;
 }
 
 void AutomatedRssDownloader::loadSettings()

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -99,6 +99,7 @@ private:
     QListWidgetItem *m_editedRule;
     Rss::DownloadRuleList *m_ruleList;
     Rss::DownloadRuleList *m_editableRuleList;
+    QRegExp *m_episodeRegex;
     QRegExpValidator *m_episodeValidator;
     QShortcut *editHotkey;
     QShortcut *deleteHotkey;


### PR DESCRIPTION
This pull request addresses issue #6171.

Adds support for | in the "Must Contain" field for RSS rules. Also makes the difference between using whitespace and `*` explicit in the tooltip (tokens separated by whitespace can be in any order in the article title).