### PR TITLE
RSS episode filter improvements. Closes #800, #2749, #3876, #6170.

### DIFF
--- a/src/base/rss/rssdownloadrule.cpp
+++ b/src/base/rss/rssdownloadrule.cpp
@@ -96,6 +96,7 @@ bool DownloadRule::matches(const QString &articleTitle) const
 
         QString s = f.cap(1);
         QStringList eps = f.cap(2).split(";");
+        int sOurs = s.toInt();
 
         foreach (const QString &epStr, eps) {
             if (epStr.isEmpty())
@@ -108,8 +109,8 @@ bool DownloadRule::matches(const QString &articleTitle) const
                 ep = ep.right(ep.size() - 1);
 
             if (ep.indexOf('-') != -1) { // Range detected
-                QString partialPattern1 = "\\bs0?" + s + "[ -_\\.]?" + "e(0?\\d{1,4})(?:\\D|\\b)";
-                QString partialPattern2 = "\\b" + s + "x" + "(0?\\d{1,4})(?:\\D|\\b)";
+                QString partialPattern1 = "\\bs0?(\\d{1,4})[ -_\\.]?e(0?\\d{1,4})(?:\\D|\\b)";
+                QString partialPattern2 = "\\b(\\d{1,4})x(0?\\d{1,4})(?:\\D|\\b)";
                 QRegExp reg(partialPattern1, Qt::CaseInsensitive);
 
                 if (ep.endsWith('-')) { // Infinite range
@@ -124,8 +125,9 @@ bool DownloadRule::matches(const QString &articleTitle) const
                     }
 
                     if (pos != -1) {
-                        int epTheirs = reg.cap(1).toInt();
-                        if (epTheirs >= epOurs) {
+                        int sTheirs = reg.cap(1).toInt();
+                        int epTheirs = reg.cap(2).toInt();
+                        if (((sTheirs == sOurs) && (epTheirs >= epOurs)) || (sTheirs > sOurs)) {
                             qDebug() << "Matched episode:" << ep;
                             qDebug() << "Matched article:" << articleTitle;
                             return true;
@@ -150,8 +152,9 @@ bool DownloadRule::matches(const QString &articleTitle) const
                     }
 
                     if (pos != -1) {
-                        int epTheirs = reg.cap(1).toInt();
-                        if ((epOursFirst <= epTheirs) && (epOursLast >= epTheirs)) {
+                        int sTheirs = reg.cap(1).toInt();
+                        int epTheirs = reg.cap(2).toInt();
+                        if ((sTheirs == sOurs) && ((epOursFirst <= epTheirs) && (epOursLast >= epTheirs))) {
                             qDebug() << "Matched episode:" << ep;
                             qDebug() << "Matched article:" << articleTitle;
                             return true;

--- a/src/base/rss/rssdownloadrule.cpp
+++ b/src/base/rss/rssdownloadrule.cpp
@@ -31,6 +31,8 @@
 #include <QRegExp>
 #include <QDebug>
 #include <QDir>
+#include <QStringRef>
+#include <QVector>
 
 #include "base/preferences.h"
 #include "base/utils/fs.h"
@@ -97,9 +99,15 @@ bool DownloadRule::matches(const QString &articleTitle) const
         QString expStr;
         expStr += "s0?" + s + "[ -_\\.]?" + "e0?";
 
-        foreach (const QString &ep, eps) {
-            if (ep.isEmpty())
+        foreach (const QString &epStr, eps) {
+            if (epStr.isEmpty())
                 continue;
+
+            QStringRef ep( &epStr);
+
+            // We need to trim leading zeroes, but if it's all zeros then we want episode zero.
+            while (ep.size() > 1 && ep.startsWith("0"))
+                ep = ep.right(ep.size() - 1);
 
             if (ep.indexOf('-') != -1) { // Range detected
                 QString partialPattern = "s0?" + s + "[ -_\\.]?" + "e(0?\\d{1,4})";
@@ -120,7 +128,7 @@ bool DownloadRule::matches(const QString &articleTitle) const
                     }
                 }
                 else { // Normal range
-                    QStringList range = ep.split('-');
+                    QVector<QStringRef> range = ep.split('-');
                     Q_ASSERT(range.size() == 2);
                     if (range.first().toInt() > range.last().toInt())
                         continue; // Ignore this subrule completely

--- a/src/base/rss/rssdownloadrule.cpp
+++ b/src/base/rss/rssdownloadrule.cpp
@@ -96,8 +96,6 @@ bool DownloadRule::matches(const QString &articleTitle) const
 
         QString s = f.cap(1);
         QStringList eps = f.cap(2).split(";");
-        QString expStr;
-        expStr += "s0?" + s + "[ -_\\.]?" + "e0?";
 
         foreach (const QString &epStr, eps) {
             if (epStr.isEmpty())
@@ -110,14 +108,21 @@ bool DownloadRule::matches(const QString &articleTitle) const
                 ep = ep.right(ep.size() - 1);
 
             if (ep.indexOf('-') != -1) { // Range detected
-                QString partialPattern = "s0?" + s + "[ -_\\.]?" + "e(0?\\d{1,4})";
-                QRegExp reg(partialPattern, Qt::CaseInsensitive);
+                QString partialPattern1 = "\\bs0?" + s + "[ -_\\.]?" + "e(0?\\d{1,4})(?:\\D|\\b)";
+                QString partialPattern2 = "\\b" + s + "x" + "(0?\\d{1,4})(?:\\D|\\b)";
+                QRegExp reg(partialPattern1, Qt::CaseInsensitive);
 
                 if (ep.endsWith('-')) { // Infinite range
                     int epOurs = ep.left(ep.size() - 1).toInt();
 
                     // Extract partial match from article and compare as digits
                     pos = reg.indexIn(articleTitle);
+
+                    if (pos == -1) {
+                        reg = QRegExp(partialPattern2, Qt::CaseInsensitive);
+                        pos = reg.indexIn(articleTitle);
+                    }
+
                     if (pos != -1) {
                         int epTheirs = reg.cap(1).toInt();
                         if (epTheirs >= epOurs) {
@@ -138,6 +143,12 @@ bool DownloadRule::matches(const QString &articleTitle) const
 
                     // Extract partial match from article and compare as digits
                     pos = reg.indexIn(articleTitle);
+
+                    if (pos == -1) {
+                        reg = QRegExp(partialPattern2, Qt::CaseInsensitive);
+                        pos = reg.indexIn(articleTitle);
+                    }
+
                     if (pos != -1) {
                         int epTheirs = reg.cap(1).toInt();
                         if ((epOursFirst <= epTheirs) && (epOursLast >= epTheirs)) {
@@ -149,7 +160,8 @@ bool DownloadRule::matches(const QString &articleTitle) const
                 }
             }
             else { // Single number
-                QRegExp reg(expStr + ep + "\\D", Qt::CaseInsensitive);
+                QString expStr("\\b(?:s0?" + s + "[ -_\\.]?" + "e0?" + ep + "|" + s + "x" + "0?" + ep + ")(?:\\D|\\b)");
+                QRegExp reg(expStr, Qt::CaseInsensitive);
                 if (reg.indexIn(articleTitle) != -1) {
                     qDebug() << "Matched episode:" << ep;
                     qDebug() << "Matched article:" << articleTitle;

--- a/src/base/rss/rssdownloadrulelist.cpp
+++ b/src/base/rss/rssdownloadrulelist.cpp
@@ -46,6 +46,7 @@ DownloadRuleList::DownloadRuleList()
 DownloadRulePtr DownloadRuleList::findMatchingRule(const QString &feedUrl, const QString &articleTitle) const
 {
     Q_ASSERT(Preferences::instance()->isRssDownloadingEnabled());
+    qDebug() << "Matching article:" << articleTitle;
     QStringList ruleNames = m_feedRules.value(feedUrl);
     foreach (const QString &rule_name, ruleNames) {
         DownloadRulePtr rule = m_rules[rule_name];

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -83,7 +83,7 @@ AutomatedRssDownloader::AutomatedRssDownloader(const QWeakPointer<Rss::Manager> 
            + "<li>" + tr("Three range types for episodes are supported: ") + "</li>" + "<li><ul>"
            "<li>" + tr("Single number: <b>1x25;</b> matches episode 25 of season one") + "</li>"
            + "<li>" + tr("Normal range: <b>1x25-40;</b> matches episodes 25 through 40 of season one") + "</li>"
-           + "<li>" + tr("Infinite range: <b>1x25-;</b> matches episodes 25 and upward of season one") + "</li>" + "</ul></li></ul>";
+           + "<li>" + tr("Infinite range: <b>1x25-;</b> matches episodes 25 and upward of season one, and all episodes of later seasons") + "</li>" + "</ul></li></ul>";
     ui->lineEFilter->setToolTip(tip);
     initCategoryCombobox();
     loadFeedList();

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -78,7 +78,7 @@ AutomatedRssDownloader::AutomatedRssDownloader(const QWeakPointer<Rss::Manager> 
     QString tip = "<p>" + tr("Matches articles based on episode filter.") + "</p><p><b>" + tr("Example: ")
                   + "1x2;8-15;5;30-;</b>" + tr(" will match 2, 5, 8 through 15, 30 and onward episodes of season one", "example X will match") + "</p>";
     tip += "<p>" + tr("Episode filter rules: ") + "</p><ul><li>" + tr("Season number is a mandatory non-zero value") + "</li>"
-           + "<li>" + tr("Episode number is a mandatory non-zero value") + "</li>"
+           + "<li>" + tr("Episode number is a mandatory positive value") + "</li>"
            + "<li>" + tr("Filter must end with semicolon") + "</li>"
            + "<li>" + tr("Three range types for episodes are supported: ") + "</li>" + "<li><ul>"
            "<li>" + tr("Single number: <b>1x25;</b> matches episode 25 of season one") + "</li>"

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -71,10 +71,9 @@ AutomatedRssDownloader::AutomatedRssDownloader(const QWeakPointer<Rss::Manager> 
     Q_ASSERT(ok);
     m_ruleList = manager.toStrongRef()->downloadRules();
     m_editableRuleList = new Rss::DownloadRuleList; // Read rule list from disk
-    m_episodeValidator = new QRegExpValidator(
-        QRegExp("^(^[1-9]{1,1}\\d{0,3}x([1-9]{1,1}\\d{0,3}(-([1-9]{1,1}\\d{0,3})?)?;){1,}){1,1}",
-                Qt::CaseInsensitive),
-        ui->lineEFilter);
+    m_episodeRegex = new QRegExp("^(^[1-9]{1,1}\\d{0,3}x([1-9]{1,1}\\d{0,3}(-([1-9]{1,1}\\d{0,3})?)?;){1,}){1,1}",
+                                 Qt::CaseInsensitive);
+    m_episodeValidator = new QRegExpValidator(*m_episodeRegex, ui->lineEFilter);
     ui->lineEFilter->setValidator(m_episodeValidator);
     QString tip = "<p>" + tr("Matches articles based on episode filter.") + "</p><p><b>" + tr("Example: ")
                   + "1x2;8-15;5;30-;</b>" + tr(" will match 2, 5, 8 through 15, 30 and onward episodes of season one", "example X will match") + "</p>";
@@ -134,6 +133,7 @@ AutomatedRssDownloader::~AutomatedRssDownloader()
     delete ui;
     delete m_editableRuleList;
     delete m_episodeValidator;
+    delete m_episodeRegex;
 }
 
 void AutomatedRssDownloader::loadSettings()

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -71,7 +71,7 @@ AutomatedRssDownloader::AutomatedRssDownloader(const QWeakPointer<Rss::Manager> 
     Q_ASSERT(ok);
     m_ruleList = manager.toStrongRef()->downloadRules();
     m_editableRuleList = new Rss::DownloadRuleList; // Read rule list from disk
-    m_episodeRegex = new QRegExp("^(^[1-9]{1,1}\\d{0,3}x([1-9]{1,1}\\d{0,3}(-([1-9]{1,1}\\d{0,3})?)?;){1,}){1,1}",
+    m_episodeRegex = new QRegExp("^(^\\d{1,4}x(\\d{1,4}(-(\\d{1,4})?)?;){1,}){1,1}",
                                  Qt::CaseInsensitive);
     m_episodeValidator = new QRegExpValidator(*m_episodeRegex, ui->lineEFilter);
     ui->lineEFilter->setValidator(m_episodeValidator);

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -99,6 +99,7 @@ private:
     QListWidgetItem *m_editedRule;
     Rss::DownloadRuleList *m_ruleList;
     Rss::DownloadRuleList *m_editableRuleList;
+    QRegExp *m_episodeRegex;
     QRegExpValidator *m_episodeValidator;
     QShortcut *editHotkey;
     QShortcut *deleteHotkey;


### PR DESCRIPTION
This pull request addresses issue #6170 (and the issues mentioned in there - #800 and #3876).

Adds support for the following:

- Zeroes in the episode portion of the filter, including episode #0 for specials e.g. `1x00;`.
- Open-ended filters now match future seasons e.g. `1x01-;` will match all episodes from season 2 and later. This is issue #3876 which had been closed.
- Matches episodes specified like `1x01` in the article title (this is an extension of issue #800).

It looks like this also fixes #2749 (although I'm not convinced there was an actual problem there, but the use case works with this pull request).

Note: this pull request includes a commit (ee0359c) which has been factored out to allow all the pull requests I am submitting to merge without conflicts.