### PR TITLE
Fix tab order in RSS downloader. Closes #6164.

### DIFF
--- a/src/gui/rss/automatedrssdownloader.ui
+++ b/src/gui/rss/automatedrssdownloader.ui
@@ -141,9 +141,6 @@
             <item row="0" column="1">
              <widget class="QLineEdit" name="lineContains"/>
             </item>
-            <item row="2" column="1">
-             <widget class="QLineEdit" name="lineEFilter"/>
-            </item>
             <item row="0" column="2">
              <widget class="QLabel" name="lbl_must_stat">
               <property name="maximumSize">
@@ -156,6 +153,9 @@
             </item>
             <item row="1" column="1">
              <widget class="QLineEdit" name="lineNotContains"/>
+            </item>
+            <item row="2" column="1">
+             <widget class="QLineEdit" name="lineEFilter"/>
             </item>
            </layout>
           </item>


### PR DESCRIPTION
This pull request addresses issue #6164.

Fixes the tabbing order in the RSS download rules dialog so it goes "Must Contain" -> "Must Not Contain" -> "Episode Filter".

Note: this pull request includes a commit (ee0359c) which has been factored out to allow all the pull requests I am submitting to merge without conflicts.