### PR TITLE
Sanitize run external program. Closes #6096.

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -262,6 +262,7 @@ void Application::runExternalProgram(BitTorrent::TorrentHandle *const torrent) c
 #if defined(Q_OS_UNIX)
     QProcess::startDetached(QLatin1String("/bin/sh"), {QLatin1String("-c"), program});
 #elif defined(Q_OS_WIN)  // test cmd: `echo "%F" > "c:\ab ba.txt"`
+    program.replace(QRegExp("(?=[^\\\\]*)\\\\\""), QLatin1String("\\\\\""));  // prevent users accidentally escape the double quote
     program.prepend(QLatin1String("\"")).append(QLatin1String("\""));
     program.prepend(Utils::Misc::windowsSystemPath() + QLatin1String("\\cmd.exe /C "));
     const int cmdMaxLength = 32768;  // max length (incl. terminate char) for `lpCommandLine` in `CreateProcessW()`


### PR DESCRIPTION
By replacing `\"` to `\\"`, qbt can prevent users accidentally escape the double quote (as in https://github.com/qbittorrent/qBittorrent/issues/6096#issuecomment-269486252).