### PR TITLE
Make AddNewTorrentDialog modal on macOS. Closes #3022

### DIFF
--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -194,7 +194,11 @@ void AddNewTorrentDialog::show(QString source, QWidget *parent)
             ok = dlg->loadTorrent(source);
 
         if (ok)
+#ifdef Q_OS_MAC
+            dlg->exec();
+#else
             dlg->open();
+#endif
         else
             delete dlg;
     }


### PR DESCRIPTION
I don't know why, but a modeless dialog box does not work on macOS here.