### PR TITLE
Do not remove added files unconditionally. Closes #6248

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1576,8 +1576,10 @@ bool Session::addTorrent(QString source, const AddTorrentParams &params)
     }
     else {
         TorrentFileGuard guard(source);
-        guard.markAsAddedToSession();
-        return addTorrent_impl(params, MagnetUri(), TorrentInfo::loadFromFile(source));
+        if (addTorrent_impl(params, MagnetUri(), TorrentInfo::loadFromFile(source))) {
+            guard.markAsAddedToSession();
+            return true;
+        }
     }
 
     return false;


### PR DESCRIPTION
If removing of added torrents is enabled and dialog for adding torrents
is disabled, file guard was assuming that torrent is added successfully.
And that can be not the case if a user trying to add a broken torrent
file (or not a torrent file at all). Then this file gets deleted always.

Fix this by checking result of addTorrent_impl().