### PR TITLE
Replace icon name "open-menu" with "preferences-system"

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -166,7 +166,7 @@ MainWindow::MainWindow(QWidget *parent)
     m_ui->actionIncreasePriority->setIcon(GuiIconProvider::instance()->getIcon("go-up"));
     m_ui->actionTopPriority->setIcon(GuiIconProvider::instance()->getIcon("go-top"));
     m_ui->actionLock->setIcon(GuiIconProvider::instance()->getIcon("object-locked"));
-    m_ui->actionOptions->setIcon(GuiIconProvider::instance()->getIcon("configure", "open-menu"));
+    m_ui->actionOptions->setIcon(GuiIconProvider::instance()->getIcon("configure", "preferences-system"));
     m_ui->actionPause->setIcon(GuiIconProvider::instance()->getIcon("media-playback-pause"));
     m_ui->actionPauseAll->setIcon(GuiIconProvider::instance()->getIcon("media-playback-pause"));
     m_ui->actionStart->setIcon(GuiIconProvider::instance()->getIcon("media-playback-start"));

--- a/src/gui/rss/rss_imp.cpp
+++ b/src/gui/rss/rss_imp.cpp
@@ -702,7 +702,7 @@ RSSImp::RSSImp(QWidget *parent):
     markReadButton->setIcon(GuiIconProvider::instance()->getIcon("mail-mark-read"));
     updateAllButton->setIcon(GuiIconProvider::instance()->getIcon("view-refresh"));
     rssDownloaderBtn->setIcon(GuiIconProvider::instance()->getIcon("download"));
-    settingsButton->setIcon(GuiIconProvider::instance()->getIcon("configure", "open-menu"));
+    settingsButton->setIcon(GuiIconProvider::instance()->getIcon("configure", "preferences-system"));
 
     m_feedList = new FeedListWidget(splitterSide, m_rssManager);
     splitterSide->insertWidget(0, m_feedList);


### PR DESCRIPTION
Apparently, we can not use symbolic icons transparently.

Uncovered in #6274