### PR TITLE
fix index overflow for torrents with invalid meta data or empty progress

### DIFF
--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -1701,6 +1701,11 @@ void TorrentHandle::manageIncompleteFiles()
 {
     const bool isAppendExtensionEnabled = m_session->isAppendExtensionEnabled();
     QVector<qreal> fp = filesProgress();
+    if( fp.size() != filesCount() ) {
+        qDebug() << "skip manageIncompleteFiles because of invalid torrent meta-data or empty file-progress";
+        return;
+    }
+
     for (int i = 0; i < filesCount(); ++i) {
         QString name = filePath(i);
         if (isAppendExtensionEnabled && (fileSize(i) > 0) && (fp[i] < 1)) {


### PR DESCRIPTION
I'm not sure if this error should be more verbose then debug.

here cases where we could get a missmatch beteen known files and file progress resonse, there are 2 empty return cases:
https://github.com/arvidn/libtorrent/blob/master/src/torrent.cpp#L10205-L10228