### PR TITLE
Libtorrent: 1.1.2 - add method to set queue prio by position

### DIFF
--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -1828,6 +1828,16 @@ void TorrentHandle::flushCache()
     SAFE_CALL(flush_cache)
 }
 
+void TorrentHandle::setQueuePosition(int pos)
+{
+#if LIBTORRENT_VERSION_NUM >= 10102
+    SAFE_CALL(queue_position_set, pos < 0 ? 0 : pos);
+#else
+    qWarning("%s queue_position_set(%d) is not implemented in libtorrent < 1.1.2",
+		qPrintable(name()), pos);
+#endif
+}
+
 QString TorrentHandle::toMagnetUri() const
 {
     return Utils::String::fromStdString(libt::make_magnet_uri(m_nativeHandle));

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -338,6 +338,7 @@ namespace BitTorrent
         void addUrlSeeds(const QList<QUrl> &urlSeeds);
         void removeUrlSeeds(const QList<QUrl> &urlSeeds);
         bool connectPeer(const PeerAddress &peerAddress);
+        void setQueuePosition(int pos);
 
         QString toMagnetUri() const;
 

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -88,6 +88,7 @@ private:
     void action_command_decreasePrio();
     void action_command_topPrio();
     void action_command_bottomPrio();
+    void action_command_setPrioPos();
     void action_command_recheck();
     void action_command_setCategory();
     void action_command_addCategory();


### PR DESCRIPTION
This is needed to sort over api, because if you sort by using top or button you would kick your aktive torrents from the first place. Libtorrent is very aggressive at queue management to give the user a nice feedback. It disconnect all users on the pause action forced by reordering the queue.

If you could tell me how to execute the tests in qbittorent, I would write one for it.
When and Who does update the webui wiki? On merge or on release? By me or by maintainer?

If you want to know when you could merge it to master and maybe to 3.3. you could track the change here:
https://github.com/arvidn/libtorrent/pull/1617