### PR TITLE
Auto-resume paused torrent on ignored files' priority change

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,3 +106,4 @@ if (WEBUI)
     add_subdirectory(webui)
 endif (WEBUI)
 
+qbt_target_sources(searchengine.qrc)

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -1842,6 +1842,8 @@ void TorrentHandle::prioritizeFiles(const QVector<int> &priorities)
     for (int i = 0; i < oldPriorities.size(); ++i) {
         if ((oldPriorities[i] == 0) && (priorities[i] > 0) && (progress[i] < 1.0)) {
             m_hasSeedStatus = false;
+            // Also auto-resume the torrent.
+            resume();
             break;
         }
     }

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -194,7 +194,7 @@ void AddNewTorrentDialog::show(QString source, QWidget *parent)
             ok = dlg->loadTorrent(source);
 
         if (ok)
-            dlg->open();
+            dlg->QWidget::show();
         else
             delete dlg;
     }

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -624,6 +624,8 @@ void AddNewTorrentDialog::accept()
 
     BitTorrent::AddTorrentParams params;
 
+    params.sequential = true;
+
     if (ui->skip_check_cb->isChecked())
         // TODO: Check if destination actually exists
         params.skipChecking = true;

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -866,11 +866,17 @@ void PropertiesWidget::editWebSeed()
 
 bool PropertiesWidget::applyPriorities()
 {
+    qreal previousProgress = m_torrent->progress();
     qDebug("Saving files priorities");
     const QVector<int> priorities = PropListModel->model()->getFilePriorities();
     // Prioritize the files
     qDebug("prioritize files: %d", priorities[0]);
     m_torrent->prioritizeFiles(priorities);
+    // Auto-resume paused torrent if previously unchecked/ignored files
+    // have now been marked for downloading.
+    if (m_torrent->progress() < previousProgress && m_torrent->isPaused()) {
+        m_torrent->resume();
+    }
     return true;
 }
 

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -866,17 +866,11 @@ void PropertiesWidget::editWebSeed()
 
 bool PropertiesWidget::applyPriorities()
 {
-    qreal previousProgress = m_torrent->progress();
     qDebug("Saving files priorities");
     const QVector<int> priorities = PropListModel->model()->getFilePriorities();
     // Prioritize the files
     qDebug("prioritize files: %d", priorities[0]);
     m_torrent->prioritizeFiles(priorities);
-    // Auto-resume paused torrent if previously unchecked/ignored files
-    // have now been marked for downloading.
-    if (m_torrent->progress() < previousProgress && m_torrent->isPaused()) {
-        m_torrent->resume();
-    }
     return true;
 }
 

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -265,6 +265,10 @@ void SearchWidget::on_searchButton_clicked()
     }
 
     // Tab Addition
+    if (m_allTabs.size() > 0) {
+        closeTab(0);
+    }
+
     m_currentSearchTab = new SearchTab(this);
     m_activeSearchTab = m_currentSearchTab;
     connect(m_currentSearchTab->header(), SIGNAL(sectionResized(int, int, int)), this, SLOT(saveResultsColumnsWidth()));

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -187,6 +187,7 @@ CategoryFiltersList::CategoryFiltersList(QWidget *parent, TransferListWidget *tr
 
     refresh();
     toggleFilter(Preferences::instance()->getCategoryFilterState());
+    setCurrentRow(1);
 }
 
 void CategoryFiltersList::refresh()

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -148,6 +148,7 @@ TransferListWidget::TransferListWidget(QWidget *parent, MainWindow *main_window)
 
     // Listen for list events
     connect(this, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(torrentDoubleClicked(QModelIndex)));
+    connect(this, SIGNAL(activated(QModelIndex)), this, SLOT(torrentDoubleClicked(QModelIndex)));
     connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(displayListMenu(const QPoint &)));
     header()->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(header(), SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(displayDLHoSMenu(const QPoint &)));

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -213,26 +213,8 @@ void TransferListWidget::torrentDoubleClicked(const QModelIndex& index)
     BitTorrent::TorrentHandle *const torrent = listModel->torrentHandle(mapToSource(index));
     if (!torrent) return;
 
-    int action;
-    if (torrent->isSeed())
-        action = Preferences::instance()->getActionOnDblClOnTorrentFn();
-    else
-        action = Preferences::instance()->getActionOnDblClOnTorrentDl();
-
-    switch(action) {
-    case TOGGLE_PAUSE:
-        if (torrent->isPaused())
-            torrent->resume();
-        else
-            torrent->pause();
-        break;
-    case OPEN_DEST:
-        if (torrent->filesCount() == 1)
-            Utils::Misc::openFolderSelect(torrent->contentPath(true));
-        else
-            Utils::Misc::openPath(torrent->contentPath(true));
-        break;
-    }
+    if (torrent->hasMetadata())
+        new PreviewSelect(this, torrent);
 }
 
 QList<BitTorrent::TorrentHandle *> TransferListWidget::getSelectedTorrents() const


### PR DESCRIPTION
Auto-resume paused torrent if previously ignored files have now been marked for downloading. It implies user intent to resume the torrent anyway.

Otherwise a user might check a new file for downloading without realizing that the torrent has been paused. 