### PR TITLE
reduce methods accessibility from public to private

### DIFF
--- a/src/base/bittorrent/private/filterparserthread.h
+++ b/src/base/bittorrent/private/filterparserthread.h
@@ -49,11 +49,6 @@ class FilterParserThread : public QThread
 public:
     FilterParserThread(libtorrent::session *s, QObject *parent = 0);
     ~FilterParserThread();
-
-    int parseDATFilterFile(QString filePath, libtorrent::ip_filter &filter);
-    int parseP2PFilterFile(QString filePath, libtorrent::ip_filter &filter);
-    int getlineInStream(QDataStream &stream, std::string &name, char delim);
-    int parseP2BFilterFile(QString filePath, libtorrent::ip_filter &filter);
     void processFilterFile(QString filePath);
 
 signals:
@@ -65,6 +60,11 @@ protected:
     void run();
 
 private:
+    int parseDATFilterFile(QString filePath, libtorrent::ip_filter &filter);
+    int parseP2PFilterFile(QString filePath, libtorrent::ip_filter &filter);
+    int getlineInStream(QDataStream &stream, std::string &name, char delim);
+    int parseP2BFilterFile(QString filePath, libtorrent::ip_filter &filter);
+
     libtorrent::session *m_session;
     bool m_abort;
     QString m_filePath;


### PR DESCRIPTION
A little correction to distinguish inner used  methods from outer API methods.