### PR TITLE
Fix compilation error on Qt<5.4. Closes #6170.

### DIFF
--- a/src/base/rss/rssdownloadrule.cpp
+++ b/src/base/rss/rssdownloadrule.cpp
@@ -31,8 +31,8 @@
 #include <QRegExp>
 #include <QDebug>
 #include <QDir>
-#include <QStringRef>
-#include <QVector>
+#include <QString>
+#include <QStringList>
 
 #include "base/preferences.h"
 #include "base/utils/fs.h"
@@ -155,11 +155,9 @@ bool DownloadRule::matches(const QString &articleTitle) const
         QStringList eps = f.cap(2).split(";");
         int sOurs = s.toInt();
 
-        foreach (const QString &epStr, eps) {
-            if (epStr.isEmpty())
+        foreach (QString ep, eps) {
+            if (ep.isEmpty())
                 continue;
-
-            QStringRef ep( &epStr);
 
             // We need to trim leading zeroes, but if it's all zeros then we want episode zero.
             while (ep.size() > 1 && ep.startsWith("0"))
@@ -192,7 +190,7 @@ bool DownloadRule::matches(const QString &articleTitle) const
                     }
                 }
                 else { // Normal range
-                    QVector<QStringRef> range = ep.split('-');
+                    QStringList range = ep.split('-');
                     Q_ASSERT(range.size() == 2);
                     if (range.first().toInt() > range.last().toInt())
                         continue; // Ignore this subrule completely


### PR DESCRIPTION
PR #6181 introduced code which required Qt 5.4 or later - `QStringRef::split()`. This PR reverts to using `QString.split()`.

There is currently discussion about making Qt 5.5.1 the minimum supported version, and if that happens this PR should probably be backed out. However, currently this error will mask other errors on builders using Qt <5.4.