### PR TITLE
RSS rules and feed UI bugfixes. Closes #3782, #6281.

### DIFF
--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -28,14 +28,14 @@
  * Contact : chris@qbittorrent.org
  */
 
-#include <QMessageBox>
-#include <QFileDialog>
-#include <QDebug>
-#include <QMenu>
 #include <QCursor>
+#include <QDebug>
+#include <QFileDialog>
+#include <QMessageBox>
+#include <QMenu>
 
-#include "base/preferences.h"
 #include "base/bittorrent/session.h"
+#include "base/preferences.h"
 #include "base/rss/rssdownloadrulelist.h"
 #include "base/rss/rssmanager.h"
 #include "base/rss/rssfolder.h"
@@ -48,9 +48,10 @@
 #include "automatedrssdownloader.h"
 
 AutomatedRssDownloader::AutomatedRssDownloader(const QWeakPointer<Rss::Manager> &manager, QWidget *parent)
-    : QDialog(parent),
-    ui(new Ui::AutomatedRssDownloader),
-    m_manager(manager), m_editedRule(0)
+    : QDialog(parent)
+    , ui(new Ui::AutomatedRssDownloader)
+    , m_manager(manager)
+    , m_editedRule(0)
 {
     ui->setupUi(this);
     // Icons

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -32,8 +32,13 @@
 #define AUTOMATEDRSSDOWNLOADER_H
 
 #include <QDialog>
+#include <QHideEvent>
+#include <QPair>
 #include <QRegExpValidator>
+#include <QSet>
 #include <QShortcut>
+#include <QShowEvent>
+#include <QString>
 #include <QWeakPointer>
 
 #include "base/rss/rssdownloadrule.h"
@@ -64,17 +69,21 @@ public:
     ~AutomatedRssDownloader();
     bool isRssDownloaderEnabled() const;
 
+protected:
+    virtual void showEvent(QShowEvent *event) override;
+    virtual void hideEvent(QHideEvent *event) override;
+
 protected slots:
     void loadSettings();
     void saveSettings();
     void loadRulesList();
     void handleRuleCheckStateChange(QListWidgetItem *rule_item);
     void handleFeedCheckStateChange(QListWidgetItem *feed_item);
-    void updateRuleDefinitionBox();
+    void updateRuleDefinitionBox(QListWidgetItem *selected = 0);
     void clearRuleDefinitionBox();
     void saveEditedRule();
     void loadFeedList();
-    void updateFeedList();
+    void updateFeedList(QListWidgetItem *selected = 0);
 
 private slots:
     void displayRulesListMenu(const QPoint &pos);
@@ -95,6 +104,8 @@ private:
     Rss::DownloadRulePtr getCurrentRule() const;
     void initCategoryCombobox();
     void addFeedArticlesToTree(const Rss::FeedPtr &feed, const QStringList &articles);
+    void disconnectRuleFeedSlots();
+    void connectRuleFeedSlots();
 
 private:
     Ui::AutomatedRssDownloader *ui;
@@ -105,6 +116,7 @@ private:
     QRegExp *m_episodeRegex;
     QShortcut *editHotkey;
     QShortcut *deleteHotkey;
+    QSet<QPair<QString, QString >> m_treeListEntries;
 };
 
 #endif // AUTOMATEDRSSDOWNLOADER_H

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -32,14 +32,15 @@
 #define AUTOMATEDRSSDOWNLOADER_H
 
 #include <QDialog>
-#include <QWeakPointer>
-#include <QShortcut>
 #include <QRegExpValidator>
+#include <QShortcut>
+#include <QWeakPointer>
 
 #include "base/rss/rssdownloadrule.h"
 
 QT_BEGIN_NAMESPACE
-namespace Ui {
+namespace Ui
+{
     class AutomatedRssDownloader;
 }
 QT_END_NAMESPACE

--- a/src/gui/rss/automatedrssdownloader.ui
+++ b/src/gui/rss/automatedrssdownloader.ui
@@ -249,11 +249,17 @@
             </item>
             <item>
              <widget class="QSpinBox" name="spinIgnorePeriod">
+              <property name="specialValueText">
+               <string>Disabled</string>
+              </property>
               <property name="enabled">
                <bool>true</bool>
               </property>
               <property name="suffix">
                <string> days</string>
+              </property>
+              <property name="minimum">
+               <number>0</number>
               </property>
               <property name="maximum">
                <number>365</number>
@@ -314,7 +320,7 @@
        <item>
         <layout class="QVBoxLayout" name="verticalLayout">
          <item>
-          <widget class="QLabel" name="label_2">
+          <widget class="QLabel" name="lblListFeeds">
            <property name="font">
             <font>
              <weight>50</weight>

--- a/src/gui/rss/rss_imp.cpp
+++ b/src/gui/rss/rss_imp.cpp
@@ -164,6 +164,7 @@ void RSSImp::askNewFolder()
     // Expand parent folder to display new folder
     if (parent_item)
         parent_item->setExpanded(true);
+    m_feedList->setCurrentItem(folderItem);
     m_rssManager->saveStreamList();
 }
 
@@ -219,7 +220,10 @@ void RSSImp::on_newFeedButton_clicked()
         m_feedList->addTopLevelItem(item);
     // Notify TreeWidget
     m_feedList->itemAdded(item, stream);
-
+    // Expand parent folder to display new feed
+    if (parent_item)
+        parent_item->setExpanded(true);
+    m_feedList->setCurrentItem(item);
     m_rssManager->saveStreamList();
 }
 
@@ -238,6 +242,8 @@ void RSSImp::deleteSelectedItems()
     if (answer == QMessageBox::No)
         return;
 
+    QList<QString> deleted;
+
     foreach (QTreeWidgetItem *item, selectedItems) {
         if (item == m_feedList->stickyUnreadItem())
             continue;
@@ -247,6 +253,7 @@ void RSSImp::deleteSelectedItems()
         m_feedList->itemAboutToBeRemoved(item);
         // Actually delete the item
         rss_item->parentFolder()->removeChild(rss_item->id());
+        deleted << rss_item->id();
         delete item;
         // Update parents count
         while (parent && (parent != m_feedList->invisibleRootItem())) {
@@ -255,6 +262,10 @@ void RSSImp::deleteSelectedItems()
         }
     }
     m_rssManager->saveStreamList();
+
+    foreach (const QString &feed_id, deleted)
+        m_rssManager->forwardFeedInfosChanged(feed_id, "", 0);
+
     // Update Unread items
     updateItemInfos(m_feedList->stickyUnreadItem());
     if (m_feedList->currentItem() == m_feedList->stickyUnreadItem())
@@ -393,6 +404,7 @@ void RSSImp::renameSelectedRssFile()
     } while (!ok);
     // Rename item
     rss_item->rename(newName);
+    m_rssManager->saveStreamList();
     // Update TreeWidget
     updateItemInfos(item);
 }
@@ -647,20 +659,26 @@ void RSSImp::updateItemInfos(QTreeWidgetItem *item)
 void RSSImp::updateFeedIcon(const QString &url, const QString &iconPath)
 {
     QTreeWidgetItem *item = m_feedList->getTreeItemFromUrl(url);
-    item->setData(0, Qt::DecorationRole, QVariant(QIcon(iconPath)));
+
+    if (item)
+        item->setData(0, Qt::DecorationRole, QVariant(QIcon(iconPath)));
 }
 
 void RSSImp::updateFeedInfos(const QString &url, const QString &display_name, uint nbUnread)
 {
     qDebug() << Q_FUNC_INFO << display_name;
     QTreeWidgetItem *item = m_feedList->getTreeItemFromUrl(url);
-    Rss::FeedPtr stream = qSharedPointerCast<Rss::Feed>(m_feedList->getRSSItem(item));
-    item->setText(0, display_name + QString::fromUtf8("  (") + QString::number(nbUnread) + QString(")"));
-    if (!stream->isLoading())
-        item->setData(0, Qt::DecorationRole, QIcon(stream->iconPath()));
-    // Update parent
-    if (item->parent())
-        updateItemInfos(item->parent());
+
+    if (item) {
+        Rss::FeedPtr stream = qSharedPointerCast<Rss::Feed>(m_feedList->getRSSItem(item));
+        item->setText(0, display_name + QString::fromUtf8("  (") + QString::number(nbUnread) + QString(")"));
+        if (!stream->isLoading())
+            item->setData(0, Qt::DecorationRole, QIcon(stream->iconPath()));
+        // Update parent
+        if (item->parent())
+            updateItemInfos(item->parent());
+    }
+
     // Update Unread item
     updateItemInfos(m_feedList->stickyUnreadItem());
 }
@@ -713,7 +731,9 @@ RSSImp::RSSImp(QWidget *parent)
     connect(deleteHotkey, SIGNAL(activated()), SLOT(deleteSelectedItems()));
 
     m_rssManager->loadStreamList();
+    m_feedList->setSortingEnabled(false);
     fillFeedsList();
+    m_feedList->setSortingEnabled(true);
     populateArticleList(m_feedList->currentItem());
 
     loadFoldersOpenState();


### PR DESCRIPTION
A collection of bugfixes for the RSS rules downloader UI and RSS tab feed list.

1. Issue #3782: Save feed aliases when renaming.

2. Issue #6281: Sort the feed list (but see PR #6345 for further enhancement).

3. Show "Disabled" in Subsequent Matches spinner when 0 days.

4. Clear all fields when no rule selected.

5. Clear all fields when creating a new rule.

6. When multiple rules are selected, use tri-state partially-selected checkbox for feeds that are used by some but not all of the selected rules.

7. Fix the episode validator so an empty string is considered valid.

8. Fix a case where a rule could be saved with the criteria from a different rule:
    1. Select a rule.
    2. Ctrl-click a second rule - now have 2 rules selected)
    3. Ctrl-click the second rule - now have 1 rule selected, but populated with criteria from second rule
