### PR TITLE
Fix renaming files is not case sensitive on Windows platform

### DIFF
--- a/src/base/utils/fs.cpp
+++ b/src/base/utils/fs.cpp
@@ -37,8 +37,9 @@
 #include <QDirIterator>
 #include <QCoreApplication>
 
-#ifndef Q_OS_WIN
-#if defined(Q_OS_MAC) || defined(Q_OS_FREEBSD)
+#if defined(Q_OS_WIN)
+#include <Windows.h>
+#elif defined(Q_OS_MAC) || defined(Q_OS_FREEBSD)
 #include <sys/param.h>
 #include <sys/mount.h>
 #elif defined(Q_OS_HAIKU)
@@ -46,9 +47,8 @@
 #else
 #include <sys/vfs.h>
 #endif
-#else
-#include <Windows.h>
-#endif
+
+#include "base/bittorrent/torrenthandle.h"
 
 /**
  * Converts a path to a string suitable for display.
@@ -70,7 +70,7 @@ QString Utils::Fs::fromNativePath(const QString &path)
  */
 QString Utils::Fs::fileExtension(const QString &filename)
 {
-    QString ext = QString(filename).remove(".!qB");
+    QString ext = QString(filename).remove(QB_EXT);
     const int point_index = ext.lastIndexOf(".");
     return (point_index >= 0) ? ext.mid(point_index + 1) : QString();
 }

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -471,101 +471,101 @@ void AddNewTorrentDialog::browseButton_clicked()
 void AddNewTorrentDialog::renameSelectedFile()
 {
     const QModelIndexList selectedIndexes = ui->contentTreeView->selectionModel()->selectedRows(0);
-    if (selectedIndexes.size() != 1)
-        return;
-    const QModelIndex &index = selectedIndexes.first();
-    if (!index.isValid())
-        return;
+    if (selectedIndexes.size() != 1) return;
+
+    const QModelIndex modelIndex = selectedIndexes.first();
+    if (!modelIndex.isValid()) return;
+
     // Ask for new name
-    bool ok;
-    const QString new_name_last = AutoExpandableDialog::getText(this, tr("Rename the file"),
-                                                                tr("New name:"), QLineEdit::Normal,
-                                                                index.data().toString(), &ok).trimmed();
-    if (ok && !new_name_last.isEmpty()) {
-        if (!Utils::Fs::isValidFileSystemName(new_name_last)) {
-            MessageBoxRaised::warning(this, tr("The file could not be renamed"),
-                                      tr("This file name contains forbidden characters, please choose a different one."),
-                                      QMessageBox::Ok);
+    bool ok = false;
+    QString newName = AutoExpandableDialog::getText(this, tr("Renaming"), tr("New name:"), QLineEdit::Normal, modelIndex.data().toString(), &ok)
+                            .trimmed();
+    if (!ok) return;
+
+    if (newName.isEmpty() || !Utils::Fs::isValidFileSystemName(newName)) {
+        MessageBoxRaised::warning(this, tr("Rename error"),
+                                  tr("The name is empty or contains forbidden characters, please choose a different one."),
+                                  QMessageBox::Ok);
+        return;
+    }
+
+    if (m_contentModel->itemType(modelIndex) == TorrentContentModelItem::FileType) {
+        // renaming a file
+        const int fileIndex = m_contentModel->getFileIndex(modelIndex);
+
+        if (newName.endsWith(QB_EXT))
+            newName.chop(QB_EXT.size());
+        const QString oldFileName = m_torrentInfo.fileName(fileIndex);
+        const QString oldFilePath = m_torrentInfo.filePath(fileIndex);
+        const QString newFilePath = oldFilePath.leftRef(oldFilePath.size() - oldFileName.size()) + newName;
+
+        if (oldFileName == newName) {
+            qDebug("Name did not change: %s", qPrintable(oldFileName));
             return;
         }
-        if (m_contentModel->itemType(index) == TorrentContentModelItem::FileType) {
-            // File renaming
-            const int file_index = m_contentModel->getFileIndex(index);
-            QString old_name = Utils::Fs::fromNativePath(m_torrentInfo.filePath(file_index));
-            qDebug("Old name: %s", qPrintable(old_name));
-            QStringList path_items = old_name.split("/");
-            path_items.removeLast();
-            path_items << new_name_last;
-            QString new_name = path_items.join("/");
-            if (Utils::Fs::sameFileNames(old_name, new_name)) {
-                qDebug("Name did not change");
-                return;
-            }
-            new_name = Utils::Fs::expandPath(new_name);
-            qDebug("New name: %s", qPrintable(new_name));
-            // Check if that name is already used
-            for (int i = 0; i < m_torrentInfo.filesCount(); ++i) {
-                if (i == file_index) continue;
-                if (Utils::Fs::sameFileNames(m_torrentInfo.filePath(i), new_name)) {
-                    // Display error message
-                    MessageBoxRaised::warning(this, tr("The file could not be renamed"),
-                                              tr("This name is already in use in this folder. Please use a different name."),
-                                              QMessageBox::Ok);
-                    return;
-                }
-            }
-            qDebug("Renaming %s to %s", qPrintable(old_name), qPrintable(new_name));
-            m_torrentInfo.renameFile(file_index, new_name);
-            // Rename in torrent files model too
-            m_contentModel->setData(index, new_name_last);
-        }
-        else {
-            // Folder renaming
-            QStringList path_items;
-            path_items << index.data().toString();
-            QModelIndex parent = m_contentModel->parent(index);
-            while (parent.isValid()) {
-                path_items.prepend(parent.data().toString());
-                parent = m_contentModel->parent(parent);
-            }
-            const QString old_path = path_items.join("/");
-            path_items.removeLast();
-            path_items << new_name_last;
-            QString new_path = path_items.join("/");
-            if (Utils::Fs::sameFileNames(old_path, new_path)) {
-                qDebug("Name did not change");
-                return;
-            }
-            if (!new_path.endsWith("/")) new_path += "/";
-            // Check for overwriting
-            for (int i = 0; i < m_torrentInfo.filesCount(); ++i) {
-                const QString &current_name = m_torrentInfo.filePath(i);
-#if defined(Q_OS_UNIX) || defined(Q_WS_QWS)
-                if (current_name.startsWith(new_path, Qt::CaseSensitive)) {
-#else
-                if (current_name.startsWith(new_path, Qt::CaseInsensitive)) {
-#endif
-                    MessageBoxRaised::warning(this, tr("The folder could not be renamed"),
-                                              tr("This name is already in use in this folder. Please use a different name."),
-                                              QMessageBox::Ok);
-                    return;
-                }
-            }
-            // Replace path in all files
-            for (int i = 0; i < m_torrentInfo.filesCount(); ++i) {
-                const QString &current_name = m_torrentInfo.filePath(i);
-                if (current_name.startsWith(old_path)) {
-                    QString new_name = current_name;
-                    new_name.replace(0, old_path.length(), new_path);
-                    new_name = Utils::Fs::expandPath(new_name);
-                    qDebug("Rename %s to %s", qPrintable(current_name), qPrintable(new_name));
-                    m_torrentInfo.renameFile(i, new_name);
-                }
-            }
 
-            // Rename folder in torrent files model too
-            m_contentModel->setData(index, new_name_last);
+        // check if that name is already used
+        for (int i = 0; i < m_torrentInfo.filesCount(); ++i) {
+            if (i == fileIndex) continue;
+            if (Utils::Fs::sameFileNames(m_torrentInfo.filePath(i), newFilePath)) {
+                MessageBoxRaised::warning(this, tr("Rename error"),
+                                          tr("This name is already in use in this folder. Please use a different name."),
+                                          QMessageBox::Ok);
+                return;
+            }
         }
+
+        qDebug("Renaming %s to %s", qPrintable(oldFilePath), qPrintable(newFilePath));
+        m_torrentInfo.renameFile(fileIndex, newFilePath);
+
+        m_contentModel->setData(modelIndex, newName);
+    }
+    else {
+        // renaming a folder
+        QStringList pathItems;
+        pathItems << modelIndex.data().toString();
+        QModelIndex parent = m_contentModel->parent(modelIndex);
+        while (parent.isValid()) {
+            pathItems.prepend(parent.data().toString());
+            parent = m_contentModel->parent(parent);
+        }
+        const QString oldPath = pathItems.join("/");
+        pathItems.removeLast();
+        pathItems << newName;
+        QString newPath = pathItems.join("/");
+        if (Utils::Fs::sameFileNames(oldPath, newPath)) {
+            qDebug("Name did not change");
+            return;
+        }
+        if (!newPath.endsWith("/")) newPath += "/";
+        // Check for overwriting
+        for (int i = 0; i < m_torrentInfo.filesCount(); ++i) {
+            const QString &currentName = m_torrentInfo.filePath(i);
+#if defined(Q_OS_UNIX) || defined(Q_WS_QWS)
+            if (currentName.startsWith(newPath, Qt::CaseSensitive)) {
+#else
+            if (currentName.startsWith(newPath, Qt::CaseInsensitive)) {
+#endif
+                MessageBoxRaised::warning(this, tr("The folder could not be renamed"),
+                                          tr("This name is already in use in this folder. Please use a different name."),
+                                          QMessageBox::Ok);
+                return;
+            }
+        }
+        // Replace path in all files
+        for (int i = 0; i < m_torrentInfo.filesCount(); ++i) {
+            const QString &currentName = m_torrentInfo.filePath(i);
+            if (currentName.startsWith(oldPath)) {
+                QString newName = currentName;
+                newName.replace(0, oldPath.length(), newPath);
+                newName = Utils::Fs::expandPath(newName);
+                qDebug("Rename %s to %s", qPrintable(currentName), qPrintable(newName));
+                m_torrentInfo.renameFile(i, newName);
+            }
+        }
+
+        // Rename folder in torrent files model too
+        m_contentModel->setData(modelIndex, newName);
     }
 }
 

--- a/src/gui/addnewtorrentdialog.h
+++ b/src/gui/addnewtorrentdialog.h
@@ -71,7 +71,7 @@ public:
 
 private slots:
     void showAdvancedSettings(bool show);
-    void displayContentTreeMenu(const QPoint&);
+    void displayContentTreeMenu(const QPoint &);
     void updateDiskSpaceLabel();
     void onSavePathChanged(int);
     void renameSelectedFile();
@@ -93,7 +93,7 @@ private:
     bool loadMagnet(const BitTorrent::MagnetUri &magnetUri);
     void populateSavePathComboBox();
     void saveSavePathHistory() const;
-    int indexOfSavePath(const QString& save_path);
+    int indexOfSavePath(const QString &save_path);
     void loadState();
     void saveState();
     void setMetadataProgressIndicator(bool visibleIndicator, const QString &labelText = QString());

--- a/src/gui/previewselect.cpp
+++ b/src/gui/previewselect.cpp
@@ -69,7 +69,7 @@ PreviewSelect::PreviewSelect(QWidget* parent, BitTorrent::TorrentHandle *const t
   int nbFiles = torrent->filesCount();
   for (int i = 0; i < nbFiles; ++i) {
     QString fileName = torrent->fileName(i);
-    if (fileName.endsWith(".!qB"))
+    if (fileName.endsWith(QB_EXT))
       fileName.chop(4);
     QString extension = Utils::Fs::fileExtension(fileName).toUpper();
     if (Utils::Misc::isPreviewable(extension)) {

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -210,7 +210,7 @@ void PropertiesWidget::showPiecesDownloaded(bool show)
 
 void PropertiesWidget::setVisibility(bool visible)
 {
-    if (!visible && ( state == VISIBLE) ) {
+    if (!visible && (state == VISIBLE)) {
         QSplitter *hSplitter = static_cast<QSplitter *>(parentWidget());
         m_ui->stackedProperties->setVisible(false);
         slideSizes = hSplitter->sizes();
@@ -222,7 +222,7 @@ void PropertiesWidget::setVisibility(bool visible)
         return;
     }
 
-    if (visible && ( state == REDUCED) ) {
+    if (visible && (state == REDUCED)) {
         m_ui->stackedProperties->setVisible(true);
         QSplitter *hSplitter = static_cast<QSplitter *>(parentWidget());
         hSplitter->handle(1)->setDisabled(false);
@@ -363,7 +363,7 @@ void PropertiesWidget::readSettings()
 void PropertiesWidget::saveSettings()
 {
     Preferences *const pref = Preferences::instance();
-    pref->setPropVisible(state==VISIBLE);
+    pref->setPropVisible(state == VISIBLE);
     // Splitter sizes
     QSplitter *hSplitter = static_cast<QSplitter *>(parentWidget());
     QList<int> sizes;
@@ -397,10 +397,10 @@ void PropertiesWidget::loadDynamicData()
         m_ui->wasted->setText(Utils::Misc::friendlyUnit(m_torrent->wastedSize()));
 
         m_ui->upTotal->setText(tr("%1 (%2 this session)").arg(Utils::Misc::friendlyUnit(m_torrent->totalUpload()))
-                         .arg(Utils::Misc::friendlyUnit(m_torrent->totalPayloadUpload())));
+                               .arg(Utils::Misc::friendlyUnit(m_torrent->totalPayloadUpload())));
 
         m_ui->dlTotal->setText(tr("%1 (%2 this session)").arg(Utils::Misc::friendlyUnit(m_torrent->totalDownload()))
-                         .arg(Utils::Misc::friendlyUnit(m_torrent->totalPayloadDownload())));
+                               .arg(Utils::Misc::friendlyUnit(m_torrent->totalPayloadDownload())));
 
         m_ui->lbl_uplimit->setText(m_torrent->uploadLimit() <= 0 ? QString::fromUtf8(C_INFINITY) : Utils::Misc::friendlyUnit(m_torrent->uploadLimit(), true));
 
@@ -416,8 +416,8 @@ void PropertiesWidget::loadDynamicData()
         m_ui->lbl_elapsed->setText(elapsed_txt);
 
         m_ui->lbl_connections->setText(tr("%1 (%2 max)", "%1 and %2 are numbers, e.g. 3 (10 max)")
-                                 .arg(m_torrent->connectionsCount())
-                                 .arg(m_torrent->connectionsLimit() < 0 ? QString::fromUtf8(C_INFINITY) : QString::number(m_torrent->connectionsLimit())));
+                                       .arg(m_torrent->connectionsCount())
+                                       .arg(m_torrent->connectionsLimit() < 0 ? QString::fromUtf8(C_INFINITY) : QString::number(m_torrent->connectionsLimit())));
 
         m_ui->label_eta_val->setText(Utils::Misc::userFriendlyDuration(m_torrent->eta()));
 
@@ -429,20 +429,20 @@ void PropertiesWidget::loadDynamicData()
         m_ui->shareRatio->setText(ratio > BitTorrent::TorrentHandle::MAX_RATIO ? QString::fromUtf8(C_INFINITY) : Utils::String::fromDouble(ratio, 2));
 
         m_ui->label_seeds_val->setText(tr("%1 (%2 total)", "%1 and %2 are numbers, e.g. 3 (10 total)")
-                                 .arg(QString::number(m_torrent->seedsCount()))
-                                 .arg(QString::number(m_torrent->totalSeedsCount())));
+                                       .arg(QString::number(m_torrent->seedsCount()))
+                                       .arg(QString::number(m_torrent->totalSeedsCount())));
 
         m_ui->label_peers_val->setText(tr("%1 (%2 total)", "%1 and %2 are numbers, e.g. 3 (10 total)")
-                                 .arg(QString::number(m_torrent->leechsCount()))
-                                 .arg(QString::number(m_torrent->totalLeechersCount())));
+                                       .arg(QString::number(m_torrent->leechsCount()))
+                                       .arg(QString::number(m_torrent->totalLeechersCount())));
 
         m_ui->label_dl_speed_val->setText(tr("%1 (%2 avg.)", "%1 and %2 are speed rates, e.g. 200KiB/s (100KiB/s avg.)")
-                                    .arg(Utils::Misc::friendlyUnit(m_torrent->downloadPayloadRate(), true))
-                                    .arg(Utils::Misc::friendlyUnit(m_torrent->totalDownload() / (1 + m_torrent->activeTime() - m_torrent->finishedTime()), true)));
+                                          .arg(Utils::Misc::friendlyUnit(m_torrent->downloadPayloadRate(), true))
+                                          .arg(Utils::Misc::friendlyUnit(m_torrent->totalDownload() / (1 + m_torrent->activeTime() - m_torrent->finishedTime()), true)));
 
         m_ui->label_upload_speed_val->setText(tr("%1 (%2 avg.)", "%1 and %2 are speed rates, e.g. 200KiB/s (100KiB/s avg.)")
-                                        .arg(Utils::Misc::friendlyUnit(m_torrent->uploadPayloadRate(), true))
-                                        .arg(Utils::Misc::friendlyUnit(m_torrent->totalUpload() / (1 + m_torrent->activeTime()), true)));
+                                              .arg(Utils::Misc::friendlyUnit(m_torrent->uploadPayloadRate(), true))
+                                              .arg(Utils::Misc::friendlyUnit(m_torrent->totalUpload() / (1 + m_torrent->activeTime()), true)));
 
         m_ui->label_last_complete_val->setText(m_torrent->lastSeenComplete().isValid() ? m_torrent->lastSeenComplete().toString(Qt::DefaultLocaleShortDate) : tr("Never"));
 
@@ -674,117 +674,120 @@ void PropertiesWidget::renameSelectedFile()
     const QModelIndexList selectedIndexes = m_ui->filesList->selectionModel()->selectedRows(0);
     if (selectedIndexes.size() != 1)
         return;
+
     const QModelIndex index = selectedIndexes.first();
     if (!index.isValid())
         return;
+
     // Ask for new name
-    bool ok;
+    bool ok = false;
     QString new_name_last = AutoExpandableDialog::getText(this, tr("Rename the file"),
                                                           tr("New name:"), QLineEdit::Normal,
                                                           index.data().toString(), &ok).trimmed();
-    if (ok && !new_name_last.isEmpty()) {
-        if (!Utils::Fs::isValidFileSystemName(new_name_last)) {
-            MessageBoxRaised::warning(this, tr("The file could not be renamed"),
-                                      tr("This file name contains forbidden characters, please choose a different one."),
-                                      QMessageBox::Ok);
+    if (!ok || new_name_last.isEmpty())
+        return;
+
+    if (!Utils::Fs::isValidFileSystemName(new_name_last)) {
+        MessageBoxRaised::warning(this, tr("The file could not be renamed"),
+                                  tr("This file name contains forbidden characters, please choose a different one."),
+                                  QMessageBox::Ok);
+        return;
+    }
+    if (PropListModel->itemType(index) == TorrentContentModelItem::FileType) {
+        // File renaming
+        const int file_index = PropListModel->getFileIndex(index);
+        if (!m_torrent || !m_torrent->hasMetadata()) return;
+        QString old_name = m_torrent->filePath(file_index);
+        if (old_name.endsWith(".!qB") && !new_name_last.endsWith(".!qB"))
+            new_name_last += ".!qB";
+        QStringList path_items = old_name.split("/");
+        path_items.removeLast();
+        path_items << new_name_last;
+        QString new_name = path_items.join("/");
+        if (old_name == new_name) {
+            qDebug("Name did not change");
             return;
         }
-        if (PropListModel->itemType(index) == TorrentContentModelItem::FileType) {
-            // File renaming
-            const int file_index = PropListModel->getFileIndex(index);
-            if (!m_torrent || !m_torrent->hasMetadata()) return;
-            QString old_name = m_torrent->filePath(file_index);
-            if (old_name.endsWith(".!qB") && !new_name_last.endsWith(".!qB"))
-                new_name_last += ".!qB";
-            QStringList path_items = old_name.split("/");
-            path_items.removeLast();
-            path_items << new_name_last;
-            QString new_name = path_items.join("/");
-            if (old_name == new_name) {
-                qDebug("Name did not change");
+        new_name = Utils::Fs::expandPath(new_name);
+        qDebug("New name: %s", qPrintable(new_name));
+        // Check if that name is already used
+        for (int i = 0; i < m_torrent->filesCount(); ++i) {
+            if (i == file_index) continue;
+            if (Utils::Fs::sameFileNames(m_torrent->filePath(i), new_name)) {
+                // Display error message
+                MessageBoxRaised::warning(this, tr("The file could not be renamed"),
+                                          tr("This name is already in use in this folder. Please use a different name."),
+                                          QMessageBox::Ok);
                 return;
             }
-            new_name = Utils::Fs::expandPath(new_name);
-            qDebug("New name: %s", qPrintable(new_name));
-            // Check if that name is already used
-            for (int i = 0; i < m_torrent->filesCount(); ++i) {
-                if (i == file_index) continue;
-                if (Utils::Fs::sameFileNames(m_torrent->filePath(i), new_name)) {
-                    // Display error message
-                    MessageBoxRaised::warning(this, tr("The file could not be renamed"),
-                                              tr("This name is already in use in this folder. Please use a different name."),
-                                              QMessageBox::Ok);
-                    return;
-                }
-            }
-            const bool force_recheck = QFile::exists(m_torrent->savePath(true) + "/" + new_name);
-            qDebug("Renaming %s to %s", qPrintable(old_name), qPrintable(new_name));
-            m_torrent->renameFile(file_index, new_name);
-            // Force recheck
-            if (force_recheck) m_torrent->forceRecheck();
-            // Rename if torrent files model too
-            if (new_name_last.endsWith(".!qB"))
-                new_name_last.chop(4);
-            PropListModel->setData(index, new_name_last);
         }
-        else {
-            // Folder renaming
-            QStringList path_items;
-            path_items << index.data().toString();
-            QModelIndex parent = PropListModel->parent(index);
-            while (parent.isValid()) {
-                path_items.prepend(parent.data().toString());
-                parent = PropListModel->parent(parent);
-            }
-            const QString old_path = path_items.join("/");
-            path_items.removeLast();
-            path_items << new_name_last;
-            QString new_path = path_items.join("/");
-            if (Utils::Fs::sameFileNames(old_path, new_path)) {
-                qDebug("Name did not change");
+        const bool force_recheck = QFile::exists(m_torrent->savePath(true) + "/" + new_name);
+        qDebug("Renaming %s to %s", qPrintable(old_name), qPrintable(new_name));
+        m_torrent->renameFile(file_index, new_name);
+        // Force recheck
+        if (force_recheck) m_torrent->forceRecheck();
+        // Rename if torrent files model too
+        if (new_name_last.endsWith(".!qB"))
+            new_name_last.chop(4);
+        PropListModel->setData(index, new_name_last);
+    }
+    else {
+        // Folder renaming
+        QStringList path_items;
+        path_items << index.data().toString();
+        QModelIndex parent = PropListModel->parent(index);
+        while (parent.isValid()) {
+            path_items.prepend(parent.data().toString());
+            parent = PropListModel->parent(parent);
+        }
+        const QString old_path = path_items.join("/");
+        path_items.removeLast();
+        path_items << new_name_last;
+        QString new_path = path_items.join("/");
+        if (Utils::Fs::sameFileNames(old_path, new_path)) {
+            qDebug("Name did not change");
+            return;
+        }
+        if (!new_path.endsWith("/")) new_path += "/";
+        // Check for overwriting
+        for (int i = 0; i < m_torrent->filesCount(); ++i) {
+            const QString &current_name = m_torrent->filePath(i);
+#if defined(Q_OS_UNIX) || defined(Q_WS_QWS)
+            if (current_name.startsWith(new_path, Qt::CaseSensitive)) {
+#else
+            if (current_name.startsWith(new_path, Qt::CaseInsensitive)) {
+#endif
+                QMessageBox::warning(this, tr("The folder could not be renamed"),
+                                     tr("This name is already in use in this folder. Please use a different name."),
+                                     QMessageBox::Ok);
                 return;
             }
-            if (!new_path.endsWith("/")) new_path += "/";
-            // Check for overwriting
-            for (int i = 0; i < m_torrent->filesCount(); ++i) {
-                const QString &current_name = m_torrent->filePath(i);
-#if defined(Q_OS_UNIX) || defined(Q_WS_QWS)
-                if (current_name.startsWith(new_path, Qt::CaseSensitive)) {
-#else
-                if (current_name.startsWith(new_path, Qt::CaseInsensitive)) {
-#endif
-                    QMessageBox::warning(this, tr("The folder could not be renamed"),
-                                         tr("This name is already in use in this folder. Please use a different name."),
-                                         QMessageBox::Ok);
-                    return;
-                }
+        }
+        bool force_recheck = false;
+        // Replace path in all files
+        for (int i = 0; i < m_torrent->filesCount(); ++i) {
+            const QString current_name = m_torrent->filePath(i);
+            if (current_name.startsWith(old_path)) {
+                QString new_name = current_name;
+                new_name.replace(0, old_path.length(), new_path);
+                if (!force_recheck && QDir(m_torrent->savePath(true)).exists(new_name))
+                    force_recheck = true;
+                new_name = Utils::Fs::expandPath(new_name);
+                qDebug("Rename %s to %s", qPrintable(current_name), qPrintable(new_name));
+                m_torrent->renameFile(i, new_name);
             }
-            bool force_recheck = false;
-            // Replace path in all files
-            for (int i = 0; i < m_torrent->filesCount(); ++i) {
-                const QString current_name = m_torrent->filePath(i);
-                if (current_name.startsWith(old_path)) {
-                    QString new_name = current_name;
-                    new_name.replace(0, old_path.length(), new_path);
-                    if (!force_recheck && QDir(m_torrent->savePath(true)).exists(new_name))
-                        force_recheck = true;
-                    new_name = Utils::Fs::expandPath(new_name);
-                    qDebug("Rename %s to %s", qPrintable(current_name), qPrintable(new_name));
-                    m_torrent->renameFile(i, new_name);
-                }
-            }
-            // Force recheck
-            if (force_recheck) m_torrent->forceRecheck();
-            // Rename folder in torrent files model too
-            PropListModel->setData(index, new_name_last);
-            // Remove old folder
-            const QDir old_folder(m_torrent->savePath(true) + "/" + old_path);
-            int timeout = 10;
-            while (!QDir().rmpath(old_folder.absolutePath()) && timeout > 0) {
-                // FIXME: We should not sleep here (freezes the UI for 1 second)
-                QThread::msleep(100);
-                --timeout;
-            }
+        }
+        // Force recheck
+        if (force_recheck) m_torrent->forceRecheck();
+        // Rename folder in torrent files model too
+        PropListModel->setData(index, new_name_last);
+        // Remove old folder
+        const QDir old_folder(m_torrent->savePath(true) + "/" + old_path);
+        int timeout = 10;
+        while (!QDir().rmpath(old_folder.absolutePath()) && timeout > 0) {
+            // FIXME: We should not sleep here (freezes the UI for 1 second)
+            QThread::msleep(100);
+            --timeout;
         }
     }
 }

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -700,7 +700,7 @@ void PropertiesWidget::renameSelectedFile()
             path_items.removeLast();
             path_items << new_name_last;
             QString new_name = path_items.join("/");
-            if (Utils::Fs::sameFileNames(old_name, new_name)) {
+            if (old_name == new_name) {
                 qDebug("Name did not change");
                 return;
             }

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -681,18 +681,18 @@ void PropertiesWidget::renameSelectedFile()
 
     // Ask for new name
     bool ok = false;
-    QString new_name_last = AutoExpandableDialog::getText(this, tr("Rename the file"),
+    QString new_name_last = AutoExpandableDialog::getText(this, tr("Renaming"),
                                                           tr("New name:"), QLineEdit::Normal,
                                                           index.data().toString(), &ok).trimmed();
-    if (!ok || new_name_last.isEmpty())
+    if (!ok)
         return;
-
-    if (!Utils::Fs::isValidFileSystemName(new_name_last)) {
-        MessageBoxRaised::warning(this, tr("The file could not be renamed"),
-                                  tr("This file name contains forbidden characters, please choose a different one."),
+    if (new_name_last.isEmpty() || !Utils::Fs::isValidFileSystemName(new_name_last)) {
+        MessageBoxRaised::warning(this, tr("Rename error"),
+                                  tr("The name is empty or contains forbidden characters, please choose a different one."),
                                   QMessageBox::Ok);
         return;
     }
+
     if (PropListModel->itemType(index) == TorrentContentModelItem::FileType) {
         // File renaming
         const int file_index = PropListModel->getFileIndex(index);

--- a/src/gui/torrentcontentmodelfile.cpp
+++ b/src/gui/torrentcontentmodelfile.cpp
@@ -29,6 +29,8 @@
  */
 
 #include "torrentcontentmodelfile.h"
+
+#include "base/bittorrent/torrenthandle.h"
 #include "torrentcontentmodelfolder.h"
 
 TorrentContentModelFile::TorrentContentModelFile(const QString &fileName, qulonglong fileSize,
@@ -41,7 +43,7 @@ TorrentContentModelFile::TorrentContentModelFile(const QString &fileName, qulong
     m_name = fileName;
 
     // Do not display incomplete extensions
-    if (m_name.endsWith(".!qB"))
+    if (m_name.endsWith(QB_EXT))
         m_name.chop(4);
 
     m_size = fileSize;

--- a/src/gui/torrentcontentmodelfolder.cpp
+++ b/src/gui/torrentcontentmodelfolder.cpp
@@ -28,8 +28,9 @@
  * Contact : chris@qbittorrent.org
  */
 
-#include <QDebug>
 #include "torrentcontentmodelfolder.h"
+
+#include "base/bittorrent/torrenthandle.h"
 
 TorrentContentModelFolder::TorrentContentModelFolder(const QString &name, TorrentContentModelFolder *parent)
     : TorrentContentModelItem(parent)
@@ -37,7 +38,7 @@ TorrentContentModelFolder::TorrentContentModelFolder(const QString &name, Torren
     Q_ASSERT(parent);
     m_name = name;
     // Do not display incomplete extensions
-    if (m_name.endsWith(".!qB"))
+    if (m_name.endsWith(QB_EXT))
         m_name.chop(4);
 }
 


### PR DESCRIPTION
*  Fix renaming files is not case sensitive on Windows platform
*  Code formatting 
*  Improve error message reported to user
  Should not contain "file" or "folder", because it's not clear which type is selected