### PR TITLE
Fix regex RSS matching. Closes #6337.

### DIFF
--- a/src/base/rss/rssdownloadrule.h
+++ b/src/base/rss/rssdownloadrule.h
@@ -88,6 +88,8 @@ namespace Rss
         bool operator==(const DownloadRule &other) const;
 
     private:
+        bool matches(const QString &articleTitle, const QString &expression) const;
+
         QString m_name;
         QStringList m_mustContain;
         QStringList m_mustNotContain;

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -673,8 +673,6 @@ void AutomatedRssDownloader::updateFieldsToolTips(bool regex)
     QString tip;
     if (regex) {
         tip = "<p>" + tr("Regex mode: use Perl-like regular expressions") + "</p>";
-        ui->lineContains->setToolTip(tip);
-        ui->lineNotContains->setToolTip(tip);
     }
     else {
         tip = "<p>" + tr("Wildcard mode: you can use") + "<ul>"
@@ -683,9 +681,18 @@ void AutomatedRssDownloader::updateFieldsToolTips(bool regex)
               + "<li>" + tr("Whitespaces count as AND operators (all words, any order)") + "</li>"
               + "<li>" + tr("| is used as OR operator") + "</li></ul></p>"
               + "<p>" + tr("If word order is important use * instead of whitespace.") + "</p>";
-        ui->lineContains->setToolTip(tip);
-        ui->lineNotContains->setToolTip(tip);
     }
+
+    // Whether regex or wildcard, warn about a potential gotcha for users.
+    // Explanatory string broken over multiple lines for readability (and multiple
+    // statements to prevent uncrustify indenting excessively.
+    tip += "<p>";
+    tip += tr("An expression with an empty %1 clause (e.g. %2)",
+              "We talk about regex/wildcards in the RSS filters section here."
+              " So a valid sentence would be: An expression with an empty | clause (e.g. expr|)"
+              ).arg("<tt>|</tt>").arg("<tt>expr|</tt>");
+    ui->lineContains->setToolTip(tip + tr(" will match all articles.") + "</p>");
+    ui->lineNotContains->setToolTip(tip + tr(" will exclude all articles.") + "</p>");
 }
 
 void AutomatedRssDownloader::updateMustLineValidity()


### PR DESCRIPTION
Fixes an error introduced in PR #6181 that resulted in regex always matching (unless prevented by must not match or episode).

The rules are as follows:

1. An empty must contain field matches all articles.
2. An empty must not contain field does not exclude any articles.
3. An empty `|` clause e.g. `expr|` in the  must contain field matches all articles (this was already the behaviour of regex, so make wildcard work the same).
4. An empty `|` clause e.g. `expr|` in the must not contain field excludes all articles (this was already the behaviour of regex, so make wildcard work the same).

Updated the tooltips to make the behaviour with an empty `|` clause explicit.