### PR TITLE
Use tree for feeds in RSS downloader dialog. Closes #6281.

### DIFF
--- a/src/base/utils/string.h
+++ b/src/base/utils/string.h
@@ -32,6 +32,8 @@
 
 #include <string>
 
+#include <Qt>
+
 class QByteArray;
 class QString;
 
@@ -47,8 +49,17 @@ namespace Utils
         // Taken from https://crackstation.net/hashing-security.htm
         bool slowEquals(const QByteArray &a, const QByteArray &b);
 
+        enum CaseSensitivity
+        {
+            CaseInsensitive = Qt::CaseInsensitive,  // 0
+            CaseSensitive = Qt::CaseSensitive,      // 1
+            CaseSemiSensitive = 2
+        };
+
         bool naturalCompareCaseSensitive(const QString &left, const QString &right);
         bool naturalCompareCaseInsensitive(const QString &left, const QString &right);
+        bool naturalCompareCaseSemiSensitive(const QString &left, const QString &right);
+        bool naturalCompare(const QString &left, const QString &right, CaseSensitivity cs);
     }
 }
 

--- a/src/gui/gui.pri
+++ b/src/gui/gui.pri
@@ -51,7 +51,8 @@ HEADERS += \
     $$PWD/cookiesmodel.h \
     $$PWD/cookiesdialog.h \
     $$PWD/categoryfiltermodel.h \
-    $$PWD/categoryfilterwidget.h
+    $$PWD/categoryfilterwidget.h \
+    $$PWD/sortablewidgetitems.h
 
 SOURCES += \
     $$PWD/mainwindow.cpp \
@@ -93,7 +94,8 @@ SOURCES += \
     $$PWD/cookiesmodel.cpp \
     $$PWD/cookiesdialog.cpp \
     $$PWD/categoryfiltermodel.cpp \
-    $$PWD/categoryfilterwidget.cpp
+    $$PWD/categoryfilterwidget.cpp \
+    $$PWD/sortablewidgetitems.cpp
 
 win32|macx {
     HEADERS += $$PWD/programupdater.h

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -28,14 +28,14 @@
  * Contact : chris@qbittorrent.org
  */
 
-#include <QMessageBox>
-#include <QFileDialog>
-#include <QDebug>
-#include <QMenu>
 #include <QCursor>
+#include <QDebug>
+#include <QFileDialog>
+#include <QMessageBox>
+#include <QMenu>
 
-#include "base/preferences.h"
 #include "base/bittorrent/session.h"
+#include "base/preferences.h"
 #include "base/rss/rssdownloadrulelist.h"
 #include "base/rss/rssmanager.h"
 #include "base/rss/rssfolder.h"
@@ -48,9 +48,10 @@
 #include "automatedrssdownloader.h"
 
 AutomatedRssDownloader::AutomatedRssDownloader(const QWeakPointer<Rss::Manager> &manager, QWidget *parent)
-    : QDialog(parent),
-    ui(new Ui::AutomatedRssDownloader),
-    m_manager(manager), m_editedRule(0)
+    : QDialog(parent)
+    , ui(new Ui::AutomatedRssDownloader)
+    , m_manager(manager)
+    , m_editedRule(0)
 {
     ui->setupUi(this);
     // Icons

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -42,6 +42,7 @@
 #include "base/rss/rssfeed.h"
 #include "base/utils/fs.h"
 #include "base/utils/string.h"
+#include "gui/sortablewidgetitems.h"
 #include "guiiconprovider.h"
 #include "autoexpandabledialog.h"
 #include "ui_automatedrssdownloader.h"
@@ -173,7 +174,7 @@ void AutomatedRssDownloader::loadRulesList()
     ui->listRules->clear();
 
     foreach (const QString &rule_name, m_editableRuleList->ruleNames()) {
-        QListWidgetItem *item = new QListWidgetItem(rule_name, ui->listRules);
+        QListWidgetItem *item = new SortableListWidgetItem(rule_name, ui->listRules);
         item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
         if (m_editableRuleList->getRule(rule_name)->isEnabled())
             item->setCheckState(Qt::Checked);
@@ -428,7 +429,7 @@ void AutomatedRssDownloader::on_addRuleBtn_clicked()
     disconnectRuleFeedSlots();
 
     // Add the new rule to the list
-    QListWidgetItem *item = new QListWidgetItem(rule_name, ui->listRules);
+    QListWidgetItem *item = new SortableListWidgetItem(rule_name, ui->listRules);
     item->setFlags(item->flags() | Qt::ItemIsUserCheckable | Qt::ItemIsTristate);
     item->setCheckState(Qt::Checked); // Enable as a default
     m_editedRule = 0;
@@ -641,7 +642,7 @@ void AutomatedRssDownloader::addFeedArticlesToTree(const Rss::FeedPtr &feed, con
 
     // If there is none, create it
     if (!treeFeedItem) {
-        treeFeedItem = new QTreeWidgetItem(QStringList() << feed->displayName());
+        treeFeedItem = new SortableTreeWidgetItem(QStringList() << feed->displayName());
         treeFeedItem->setToolTip(0, feed->displayName());
         QFont f = treeFeedItem->font(0);
         f.setBold(true);
@@ -657,7 +658,7 @@ void AutomatedRssDownloader::addFeedArticlesToTree(const Rss::FeedPtr &feed, con
 
         if (!m_treeListEntries.contains(key)) {
             m_treeListEntries << key;
-            QTreeWidgetItem *item = new QTreeWidgetItem(QStringList() << art);
+            QTreeWidgetItem *item = new SortableTreeWidgetItem(QStringList() << art);
             item->setToolTip(0, art);
             treeFeedItem->addChild(item);
         }

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -42,6 +42,7 @@
 #include <QWeakPointer>
 
 #include "base/rss/rssdownloadrule.h"
+#include "base/rss/rssfolder.h"
 
 QT_BEGIN_NAMESPACE
 namespace Ui
@@ -104,6 +105,7 @@ private:
     Rss::DownloadRulePtr getCurrentRule() const;
     void initCategoryCombobox();
     void addFeedArticlesToTree(const Rss::FeedPtr &feed, const QStringList &articles);
+    void fillFeedList(const Rss::FolderPtr &rss_parent = Rss::FolderPtr());
     void disconnectRuleFeedSlots();
     void connectRuleFeedSlots();
 

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -32,8 +32,13 @@
 #define AUTOMATEDRSSDOWNLOADER_H
 
 #include <QDialog>
+#include <QHideEvent>
+#include <QPair>
 #include <QRegExpValidator>
+#include <QSet>
 #include <QShortcut>
+#include <QShowEvent>
+#include <QString>
 #include <QWeakPointer>
 
 #include "base/rss/rssdownloadrule.h"
@@ -64,17 +69,21 @@ public:
     ~AutomatedRssDownloader();
     bool isRssDownloaderEnabled() const;
 
+protected:
+    virtual void showEvent(QShowEvent *event);
+    virtual void hideEvent(QHideEvent *event);
+
 protected slots:
     void loadSettings();
     void saveSettings();
     void loadRulesList();
     void handleRuleCheckStateChange(QListWidgetItem *rule_item);
     void handleFeedCheckStateChange(QListWidgetItem *feed_item);
-    void updateRuleDefinitionBox();
+    void updateRuleDefinitionBox(QListWidgetItem *selected = 0);
     void clearRuleDefinitionBox();
     void saveEditedRule();
     void loadFeedList();
-    void updateFeedList();
+    void updateFeedList(QListWidgetItem *selected = 0);
 
 private slots:
     void displayRulesListMenu(const QPoint &pos);
@@ -95,6 +104,8 @@ private:
     Rss::DownloadRulePtr getCurrentRule() const;
     void initCategoryCombobox();
     void addFeedArticlesToTree(const Rss::FeedPtr &feed, const QStringList &articles);
+    void disconnectRuleFeedSlots();
+    void connectRuleFeedSlots();
 
 private:
     Ui::AutomatedRssDownloader *ui;
@@ -105,6 +116,7 @@ private:
     QRegExp *m_episodeRegex;
     QShortcut *editHotkey;
     QShortcut *deleteHotkey;
+    QSet<QPair<QString, QString >> m_treeListEntries;
 };
 
 #endif // AUTOMATEDRSSDOWNLOADER_H

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -32,14 +32,15 @@
 #define AUTOMATEDRSSDOWNLOADER_H
 
 #include <QDialog>
-#include <QWeakPointer>
-#include <QShortcut>
 #include <QRegExpValidator>
+#include <QShortcut>
+#include <QWeakPointer>
 
 #include "base/rss/rssdownloadrule.h"
 
 QT_BEGIN_NAMESPACE
-namespace Ui {
+namespace Ui
+{
     class AutomatedRssDownloader;
 }
 QT_END_NAMESPACE

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -59,6 +59,7 @@ namespace Rss
 
 QT_BEGIN_NAMESPACE
 class QListWidgetItem;
+class QTreeWidgetItem;
 QT_END_NAMESPACE
 
 class AutomatedRssDownloader: public QDialog
@@ -79,7 +80,7 @@ protected slots:
     void saveSettings();
     void loadRulesList();
     void handleRuleCheckStateChange(QListWidgetItem *rule_item);
-    void handleFeedCheckStateChange(QListWidgetItem *feed_item);
+    void handleFeedCheckStateChange(QTreeWidgetItem *feed_item, int column);
     void updateRuleDefinitionBox(QListWidgetItem *selected = 0);
     void clearRuleDefinitionBox();
     void saveEditedRule();
@@ -105,11 +106,14 @@ private:
     Rss::DownloadRulePtr getCurrentRule() const;
     void initCategoryCombobox();
     void addFeedArticlesToTree(const Rss::FeedPtr &feed, const QStringList &articles);
-    void fillFeedList(const Rss::FolderPtr &rss_parent = Rss::FolderPtr());
+    void fillFeedList(QTreeWidgetItem *parent = 0, const Rss::FolderPtr &rss_parent = Rss::FolderPtr());
     void disconnectRuleFeedSlots();
     void connectRuleFeedSlots();
 
 private:
+    class FeedListWidgetItem;
+    friend class FeedListWidgetItem;
+
     Ui::AutomatedRssDownloader *ui;
     QWeakPointer<Rss::Manager> m_manager;
     QListWidgetItem *m_editedRule;

--- a/src/gui/rss/automatedrssdownloader.ui
+++ b/src/gui/rss/automatedrssdownloader.ui
@@ -249,11 +249,17 @@
             </item>
             <item>
              <widget class="QSpinBox" name="spinIgnorePeriod">
+              <property name="specialValueText">
+               <string>Disabled</string>
+              </property>
               <property name="enabled">
                <bool>true</bool>
               </property>
               <property name="suffix">
                <string> days</string>
+              </property>
+              <property name="minimum">
+               <number>0</number>
               </property>
               <property name="maximum">
                <number>365</number>
@@ -314,7 +320,7 @@
        <item>
         <layout class="QVBoxLayout" name="verticalLayout">
          <item>
-          <widget class="QLabel" name="label_2">
+          <widget class="QLabel" name="lblListFeeds">
            <property name="font">
             <font>
              <weight>50</weight>

--- a/src/gui/rss/automatedrssdownloader.ui
+++ b/src/gui/rss/automatedrssdownloader.ui
@@ -333,7 +333,16 @@
           </widget>
          </item>
          <item>
-          <widget class="QListWidget" name="listFeeds"/>
+          <widget class="QTreeWidget" name="listFeeds">
+           <attribute name="headerVisible">
+            <bool>false</bool>
+           </attribute>
+           <column>
+            <property name="text">
+             <string notr="true">1</string>
+            </property>
+           </column>
+          </widget>
          </item>
         </layout>
        </item>

--- a/src/gui/rss/feedlistwidget.cpp
+++ b/src/gui/rss/feedlistwidget.cpp
@@ -34,203 +34,219 @@
 #include "guiiconprovider.h"
 #include "feedlistwidget.h"
 
-FeedListWidget::FeedListWidget(QWidget *parent, const Rss::ManagerPtr& rssmanager)
+FeedListWidget::FeedListWidget(QWidget *parent, const Rss::ManagerPtr &rssmanager)
     : QTreeWidget(parent)
     , m_rssManager(rssmanager)
     , m_currentFeed(nullptr)
 {
-  setContextMenuPolicy(Qt::CustomContextMenu);
-  setDragDropMode(QAbstractItemView::InternalMove);
-  setSelectionMode(QAbstractItemView::ExtendedSelection);
-  setColumnCount(1);
-  headerItem()->setText(0, tr("RSS feeds"));
-  m_unreadStickyItem = new QTreeWidgetItem(this);
-  m_unreadStickyItem->setText(0, tr("Unread") + QString::fromUtf8("  (") + QString::number(rssmanager->rootFolder()->unreadCount()) + QString(")"));
-  m_unreadStickyItem->setData(0,Qt::DecorationRole, GuiIconProvider::instance()->getIcon("mail-folder-inbox"));
-  itemAdded(m_unreadStickyItem, rssmanager->rootFolder());
-  connect(this, SIGNAL(currentItemChanged(QTreeWidgetItem*,QTreeWidgetItem*)), SLOT(updateCurrentFeed(QTreeWidgetItem*)));
-  setCurrentItem(m_unreadStickyItem);
+    setContextMenuPolicy(Qt::CustomContextMenu);
+    setDragDropMode(QAbstractItemView::InternalMove);
+    setSelectionMode(QAbstractItemView::ExtendedSelection);
+    setColumnCount(1);
+    headerItem()->setText(0, tr("RSS feeds"));
+    m_unreadStickyItem = new QTreeWidgetItem(this);
+    m_unreadStickyItem->setText(0, tr("Unread") + QString::fromUtf8("  (") + QString::number(rssmanager->rootFolder()->unreadCount()) + QString(")"));
+    m_unreadStickyItem->setData(0,Qt::DecorationRole, GuiIconProvider::instance()->getIcon("mail-folder-inbox"));
+    itemAdded(m_unreadStickyItem, rssmanager->rootFolder());
+    connect(this, SIGNAL(currentItemChanged(QTreeWidgetItem *,QTreeWidgetItem *)), SLOT(updateCurrentFeed(QTreeWidgetItem *)));
+    setCurrentItem(m_unreadStickyItem);
 }
 
-FeedListWidget::~FeedListWidget() {
-  delete m_unreadStickyItem;
+FeedListWidget::~FeedListWidget()
+{
+    delete m_unreadStickyItem;
 }
 
-void FeedListWidget::itemAdded(QTreeWidgetItem *item, const Rss::FilePtr& file) {
-  m_rssMapping[item] = file;
-  if (Rss::FeedPtr feed = qSharedPointerDynamicCast<Rss::Feed>(file)) {
-    m_feedsItems[feed->id()] = item;
-  }
+void FeedListWidget::itemAdded(QTreeWidgetItem *item, const Rss::FilePtr &file)
+{
+    m_rssMapping[item] = file;
+    if (Rss::FeedPtr feed = qSharedPointerDynamicCast<Rss::Feed>(file))
+        m_feedsItems[feed->id()] = item;
 }
 
-void FeedListWidget::itemAboutToBeRemoved(QTreeWidgetItem *item) {
-  Rss::FilePtr file = m_rssMapping.take(item);
-  if (Rss::FeedPtr feed = qSharedPointerDynamicCast<Rss::Feed>(file)) {
-    m_feedsItems.remove(feed->id());
-  } else if (Rss::FolderPtr folder = qSharedPointerDynamicCast<Rss::Folder>(file)) {
-    Rss::FeedList feeds = folder->getAllFeeds();
-    foreach (const Rss::FeedPtr& feed, feeds) {
-      m_feedsItems.remove(feed->id());
+void FeedListWidget::itemAboutToBeRemoved(QTreeWidgetItem *item)
+{
+    Rss::FilePtr file = m_rssMapping.take(item);
+    if (Rss::FeedPtr feed = qSharedPointerDynamicCast<Rss::Feed>(file)) {
+        m_feedsItems.remove(feed->id());
     }
-  }
+    else if (Rss::FolderPtr folder = qSharedPointerDynamicCast<Rss::Folder>(file)) {
+        Rss::FeedList feeds = folder->getAllFeeds();
+        foreach (const Rss::FeedPtr &feed, feeds)
+            m_feedsItems.remove(feed->id());
+    }
 }
 
-bool FeedListWidget::hasFeed(const QString &url) const {
-  return m_feedsItems.contains(QUrl(url).toString());
+bool FeedListWidget::hasFeed(const QString &url) const
+{
+    return m_feedsItems.contains(QUrl(url).toString());
 }
 
-QList<QTreeWidgetItem*> FeedListWidget::getAllFeedItems() const {
-  return m_feedsItems.values();
+QList<QTreeWidgetItem *> FeedListWidget::getAllFeedItems() const
+{
+    return m_feedsItems.values();
 }
 
-QTreeWidgetItem* FeedListWidget::stickyUnreadItem() const {
-  return m_unreadStickyItem;
+QTreeWidgetItem *FeedListWidget::stickyUnreadItem() const
+{
+    return m_unreadStickyItem;
 }
 
-QStringList FeedListWidget::getItemPath(QTreeWidgetItem* item) const {
-  QStringList path;
-  if (item) {
-    if (item->parent())
-      path << getItemPath(item->parent());
-    path.append(getRSSItem(item)->id());
-  }
-  return path;
+QStringList FeedListWidget::getItemPath(QTreeWidgetItem *item) const
+{
+    QStringList path;
+    if (item) {
+        if (item->parent())
+            path << getItemPath(item->parent());
+        path.append(getRSSItem(item)->id());
+    }
+    return path;
 }
 
-QList<QTreeWidgetItem*> FeedListWidget::getAllOpenFolders(QTreeWidgetItem *parent) const {
-  QList<QTreeWidgetItem*> open_folders;
-  int nbChildren;
-  if (parent)
-    nbChildren = parent->childCount();
-  else
-    nbChildren = topLevelItemCount();
-  for (int i=0; i<nbChildren; ++i) {
-    QTreeWidgetItem *item;
+QList<QTreeWidgetItem *> FeedListWidget::getAllOpenFolders(QTreeWidgetItem *parent) const
+{
+    QList<QTreeWidgetItem *> open_folders;
+    int nbChildren;
     if (parent)
-      item = parent->child(i);
+        nbChildren = parent->childCount();
     else
-      item = topLevelItem(i);
-    if (isFolder(item) && item->isExpanded()) {
-      QList<QTreeWidgetItem*> open_subfolders = getAllOpenFolders(item);
-      if (!open_subfolders.empty()) {
-        open_folders << open_subfolders;
-      } else {
-        open_folders << item;
-      }
+        nbChildren = topLevelItemCount();
+    for (int i = 0; i<nbChildren; ++i) {
+        QTreeWidgetItem *item;
+        if (parent)
+            item = parent->child(i);
+        else
+            item = topLevelItem(i);
+        if (isFolder(item) && item->isExpanded()) {
+            QList<QTreeWidgetItem *> open_subfolders = getAllOpenFolders(item);
+            if (!open_subfolders.empty())
+                open_folders << open_subfolders;
+            else
+                open_folders << item;
+        }
     }
-  }
-  return open_folders;
+    return open_folders;
 }
 
-QList<QTreeWidgetItem*> FeedListWidget::getAllFeedItems(QTreeWidgetItem* folder) {
-  QList<QTreeWidgetItem*> feeds;
-  const int nbChildren = folder->childCount();
-  for (int i=0; i<nbChildren; ++i) {
-    QTreeWidgetItem *item = folder->child(i);
-    if (isFeed(item)) {
-      feeds << item;
-    } else {
-      feeds << getAllFeedItems(item);
+QList<QTreeWidgetItem *> FeedListWidget::getAllFeedItems(QTreeWidgetItem *folder)
+{
+    QList<QTreeWidgetItem *> feeds;
+    const int nbChildren = folder->childCount();
+    for (int i = 0; i<nbChildren; ++i) {
+        QTreeWidgetItem *item = folder->child(i);
+        if (isFeed(item))
+            feeds << item;
+        else
+            feeds << getAllFeedItems(item);
     }
-  }
-  return feeds;
+    return feeds;
 }
 
-Rss::FilePtr FeedListWidget::getRSSItem(QTreeWidgetItem *item) const {
-  return m_rssMapping.value(item, Rss::FilePtr());
+Rss::FilePtr FeedListWidget::getRSSItem(QTreeWidgetItem *item) const
+{
+    return m_rssMapping.value(item, Rss::FilePtr());
 }
 
 bool FeedListWidget::isFeed(QTreeWidgetItem *item) const
 {
-  return (qSharedPointerDynamicCast<Rss::Feed>(m_rssMapping.value(item)) != NULL);
+    return (qSharedPointerDynamicCast<Rss::Feed>(m_rssMapping.value(item)) != NULL);
 }
 
 bool FeedListWidget::isFolder(QTreeWidgetItem *item) const
 {
-  return (qSharedPointerDynamicCast<Rss::Folder>(m_rssMapping.value(item)) != NULL);
+    return (qSharedPointerDynamicCast<Rss::Folder>(m_rssMapping.value(item)) != NULL);
 }
 
-QString FeedListWidget::getItemID(QTreeWidgetItem *item) const {
-  return m_rssMapping.value(item)->id();
+QString FeedListWidget::getItemID(QTreeWidgetItem *item) const
+{
+    return m_rssMapping.value(item)->id();
 }
 
-QTreeWidgetItem* FeedListWidget::getTreeItemFromUrl(const QString &url) const {
-  return m_feedsItems.value(url, 0);
+QTreeWidgetItem *FeedListWidget::getTreeItemFromUrl(const QString &url) const
+{
+    return m_feedsItems.value(url, 0);
 }
 
-Rss::FeedPtr FeedListWidget::getRSSItemFromUrl(const QString &url) const {
-  return qSharedPointerDynamicCast<Rss::Feed>(getRSSItem(getTreeItemFromUrl(url)));
+Rss::FeedPtr FeedListWidget::getRSSItemFromUrl(const QString &url) const
+{
+    return qSharedPointerDynamicCast<Rss::Feed>(getRSSItem(getTreeItemFromUrl(url)));
 }
 
-QTreeWidgetItem* FeedListWidget::currentItem() const {
-  return m_currentFeed;
+QTreeWidgetItem *FeedListWidget::currentItem() const
+{
+    return m_currentFeed;
 }
 
-QTreeWidgetItem* FeedListWidget::currentFeed() const {
-  return m_currentFeed;
+QTreeWidgetItem *FeedListWidget::currentFeed() const
+{
+    return m_currentFeed;
 }
 
-void FeedListWidget::updateCurrentFeed(QTreeWidgetItem* new_item) {
-  if (!new_item) return;
-  if (!m_rssMapping.contains(new_item)) return;
-  if (isFeed(new_item) || new_item == m_unreadStickyItem)
-    m_currentFeed = new_item;
+void FeedListWidget::updateCurrentFeed(QTreeWidgetItem *new_item)
+{
+    if (!new_item) return;
+    if (!m_rssMapping.contains(new_item)) return;
+    if (isFeed(new_item) || ( new_item == m_unreadStickyItem) )
+        m_currentFeed = new_item;
 }
 
-void FeedListWidget::dragMoveEvent(QDragMoveEvent * event) {
-  QTreeWidget::dragMoveEvent(event);
+void FeedListWidget::dragMoveEvent(QDragMoveEvent *event)
+{
+    QTreeWidget::dragMoveEvent(event);
 
-  QTreeWidgetItem *item = itemAt(event->pos());
-  // Prohibit dropping onto global unread counter
-  if (item == m_unreadStickyItem) {
-    event->ignore();
-    return;
-  }
-  // Prohibit dragging of global unread counter
-  if (selectedItems().contains(m_unreadStickyItem)) {
-    event->ignore();
-    return;
-  }
-  // Prohibit dropping onto feeds
-  if (item && isFeed(item)) {
-    event->ignore();
-    return;
-  }
-}
-
-void FeedListWidget::dropEvent(QDropEvent *event) {
-  qDebug("dropEvent");
-  QList<QTreeWidgetItem*> folders_altered;
-  QTreeWidgetItem *dest_folder_item =  itemAt(event->pos());
-  Rss::FolderPtr dest_folder;
-  if (dest_folder_item) {
-    dest_folder = qSharedPointerCast<Rss::Folder>(getRSSItem(dest_folder_item));
-    folders_altered << dest_folder_item;
-  } else {
-    dest_folder = m_rssManager->rootFolder();
-  }
-  QList<QTreeWidgetItem *> src_items = selectedItems();
-  // Check if there is not going to overwrite another file
-  foreach (QTreeWidgetItem *src_item, src_items) {
-    Rss::FilePtr file = getRSSItem(src_item);
-    if (dest_folder->hasChild(file->id())) {
-      QTreeWidget::dropEvent(event);
-      return;
+    QTreeWidgetItem *item = itemAt(event->pos());
+    // Prohibit dropping onto global unread counter
+    if (item == m_unreadStickyItem) {
+        event->ignore();
+        return;
     }
-  }
-  // Proceed with the move
-  foreach (QTreeWidgetItem *src_item, src_items) {
-    QTreeWidgetItem *parent_folder = src_item->parent();
-    if (parent_folder && !folders_altered.contains(parent_folder))
-      folders_altered << parent_folder;
-    // Actually move the file
-    Rss::FilePtr file = getRSSItem(src_item);
-    m_rssManager->moveFile(file, dest_folder);
-  }
-  QTreeWidget::dropEvent(event);
-  if (dest_folder_item)
-    dest_folder_item->setExpanded(true);
-  // Emit signal for update
-  if (!folders_altered.empty())
-    emit foldersAltered(folders_altered);
+    // Prohibit dragging of global unread counter
+    if (selectedItems().contains(m_unreadStickyItem)) {
+        event->ignore();
+        return;
+    }
+    // Prohibit dropping onto feeds
+    if (item && isFeed(item)) {
+        event->ignore();
+        return;
+    }
+}
+
+void FeedListWidget::dropEvent(QDropEvent *event)
+{
+    qDebug("dropEvent");
+    QList<QTreeWidgetItem *> folders_altered;
+    QTreeWidgetItem *dest_folder_item = itemAt(event->pos());
+    Rss::FolderPtr dest_folder;
+    if (dest_folder_item) {
+        dest_folder = qSharedPointerCast<Rss::Folder>(getRSSItem(dest_folder_item));
+        folders_altered << dest_folder_item;
+    }
+    else {
+        dest_folder = m_rssManager->rootFolder();
+    }
+    QList<QTreeWidgetItem *> src_items = selectedItems();
+    // Check if there is not going to overwrite another file
+    foreach (QTreeWidgetItem *src_item, src_items) {
+        Rss::FilePtr file = getRSSItem(src_item);
+        if (dest_folder->hasChild(file->id())) {
+            QTreeWidget::dropEvent(event);
+            return;
+        }
+    }
+    // Proceed with the move
+    foreach (QTreeWidgetItem *src_item, src_items) {
+        QTreeWidgetItem *parent_folder = src_item->parent();
+        if (parent_folder && !folders_altered.contains(parent_folder))
+            folders_altered << parent_folder;
+        // Actually move the file
+        Rss::FilePtr file = getRSSItem(src_item);
+        m_rssManager->moveFile(file, dest_folder);
+    }
+    QTreeWidget::dropEvent(event);
+    if (dest_folder_item)
+        dest_folder_item->setExpanded(true);
+    // Emit signal for update
+    if (!folders_altered.empty())
+        emit foldersAltered(folders_altered);
 }

--- a/src/gui/rss/feedlistwidget.h
+++ b/src/gui/rss/feedlistwidget.h
@@ -43,48 +43,49 @@
 #include "base/rss/rssfeed.h"
 #include "base/rss/rssmanager.h"
 
-class FeedListWidget: public QTreeWidget {
-  Q_OBJECT
+class FeedListWidget: public QTreeWidget
+{
+    Q_OBJECT
 
 public:
-  FeedListWidget(QWidget *parent, const Rss::ManagerPtr& rssManager);
-  ~FeedListWidget();
+    FeedListWidget(QWidget *parent, const Rss::ManagerPtr &rssManager);
+    ~FeedListWidget();
 
-  bool hasFeed(const QString &url) const;
-  QList<QTreeWidgetItem*> getAllFeedItems() const;
-  QTreeWidgetItem* stickyUnreadItem() const;
-  QStringList getItemPath(QTreeWidgetItem* item) const;
-  QList<QTreeWidgetItem*> getAllOpenFolders(QTreeWidgetItem *parent=0) const;
-  QList<QTreeWidgetItem*> getAllFeedItems(QTreeWidgetItem* folder);
-  Rss::FilePtr getRSSItem(QTreeWidgetItem *item) const;
-  bool isFeed(QTreeWidgetItem *item) const;
-  bool isFolder(QTreeWidgetItem *item) const;
-  QString getItemID(QTreeWidgetItem *item) const;
-  QTreeWidgetItem* getTreeItemFromUrl(const QString &url) const;
-  Rss::FeedPtr getRSSItemFromUrl(const QString &url) const;
-  QTreeWidgetItem* currentItem() const;
-  QTreeWidgetItem* currentFeed() const;
+    bool hasFeed(const QString &url) const;
+    QList<QTreeWidgetItem *> getAllFeedItems() const;
+    QTreeWidgetItem *stickyUnreadItem() const;
+    QStringList getItemPath(QTreeWidgetItem *item) const;
+    QList<QTreeWidgetItem *> getAllOpenFolders(QTreeWidgetItem *parent = 0) const;
+    QList<QTreeWidgetItem *> getAllFeedItems(QTreeWidgetItem *folder);
+    Rss::FilePtr getRSSItem(QTreeWidgetItem *item) const;
+    bool isFeed(QTreeWidgetItem *item) const;
+    bool isFolder(QTreeWidgetItem *item) const;
+    QString getItemID(QTreeWidgetItem *item) const;
+    QTreeWidgetItem *getTreeItemFromUrl(const QString &url) const;
+    Rss::FeedPtr getRSSItemFromUrl(const QString &url) const;
+    QTreeWidgetItem *currentItem() const;
+    QTreeWidgetItem *currentFeed() const;
 
 public slots:
-  void itemAdded(QTreeWidgetItem *item, const Rss::FilePtr& file);
-  void itemAboutToBeRemoved(QTreeWidgetItem *item);
+    void itemAdded(QTreeWidgetItem *item, const Rss::FilePtr &file);
+    void itemAboutToBeRemoved(QTreeWidgetItem *item);
 
 signals:
-  void foldersAltered(const QList<QTreeWidgetItem*> &folders);
+    void foldersAltered(const QList<QTreeWidgetItem *> &folders);
 
 private slots:
-  void updateCurrentFeed(QTreeWidgetItem* new_item);
+    void updateCurrentFeed(QTreeWidgetItem *new_item);
 
 protected:
-  void dragMoveEvent(QDragMoveEvent * event);
-  void dropEvent(QDropEvent *event);
+    void dragMoveEvent(QDragMoveEvent *event);
+    void dropEvent(QDropEvent *event);
 
 private:
-  Rss::ManagerPtr m_rssManager;
-  QHash<QTreeWidgetItem*, Rss::FilePtr> m_rssMapping;
-  QHash<QString, QTreeWidgetItem*> m_feedsItems;
-  QTreeWidgetItem* m_currentFeed;
-  QTreeWidgetItem *m_unreadStickyItem;
+    Rss::ManagerPtr m_rssManager;
+    QHash<QTreeWidgetItem *, Rss::FilePtr> m_rssMapping;
+    QHash<QString, QTreeWidgetItem *> m_feedsItems;
+    QTreeWidgetItem *m_currentFeed;
+    QTreeWidgetItem *m_unreadStickyItem;
 };
 
 #endif // FEEDLIST_H

--- a/src/gui/rss/feedlistwidget.h
+++ b/src/gui/rss/feedlistwidget.h
@@ -54,13 +54,14 @@ public:
     bool hasFeed(const QString &url) const;
     QList<QTreeWidgetItem *> getAllFeedItems() const;
     QTreeWidgetItem *stickyUnreadItem() const;
-    QStringList getItemPath(QTreeWidgetItem *item) const;
+    QStringList getItemPath(const QTreeWidgetItem *item) const;
     QList<QTreeWidgetItem *> getAllOpenFolders(QTreeWidgetItem *parent = 0) const;
     QList<QTreeWidgetItem *> getAllFeedItems(QTreeWidgetItem *folder);
-    Rss::FilePtr getRSSItem(QTreeWidgetItem *item) const;
-    bool isFeed(QTreeWidgetItem *item) const;
-    bool isFolder(QTreeWidgetItem *item) const;
-    QString getItemID(QTreeWidgetItem *item) const;
+    QTreeWidgetItem *createListItem(const Rss::FilePtr &rssFile);
+    Rss::FilePtr getRSSItem(const QTreeWidgetItem *item) const;
+    bool isFeed(const QTreeWidgetItem *item) const;
+    bool isFolder(const QTreeWidgetItem *item) const;
+    QString getItemID(const QTreeWidgetItem *item) const;
     QTreeWidgetItem *getTreeItemFromUrl(const QString &url) const;
     Rss::FeedPtr getRSSItemFromUrl(const QString &url) const;
     QTreeWidgetItem *currentItem() const;
@@ -81,8 +82,11 @@ protected:
     void dropEvent(QDropEvent *event);
 
 private:
+    class FeedListWidgetItem;
+    friend class FeedListWidgetItem;
+
     Rss::ManagerPtr m_rssManager;
-    QHash<QTreeWidgetItem *, Rss::FilePtr> m_rssMapping;
+    QHash<const QTreeWidgetItem *, Rss::FilePtr> m_rssMapping;
     QHash<QString, QTreeWidgetItem *> m_feedsItems;
     QTreeWidgetItem *m_currentFeed;
     QTreeWidgetItem *m_unreadStickyItem;

--- a/src/gui/rss/rss_imp.cpp
+++ b/src/gui/rss/rss_imp.cpp
@@ -154,7 +154,7 @@ void RSSImp::askNewFolder()
 
     Rss::FolderPtr newFolder(new Rss::Folder(new_name));
     rss_parent->addFile(newFolder);
-    QTreeWidgetItem *folderItem = createFolderListItem(newFolder);
+    QTreeWidgetItem *folderItem = m_feedList->createListItem(newFolder);
     if (parent_item)
         parent_item->addChild(folderItem);
     else
@@ -213,7 +213,7 @@ void RSSImp::on_newFeedButton_clicked()
     Rss::FeedPtr stream(new Rss::Feed(newUrl, m_rssManager.data()));
     rss_parent->addFile(stream);
     // Create TreeWidget item
-    QTreeWidgetItem *item = createFolderListItem(stream);
+    QTreeWidgetItem *item = m_feedList->createListItem(stream);
     if (parent_item)
         parent_item->addChild(item);
     else
@@ -461,16 +461,6 @@ void RSSImp::on_markReadButton_clicked()
         populateArticleList(m_feedList->currentItem());
 }
 
-QTreeWidgetItem *RSSImp::createFolderListItem(const Rss::FilePtr &rssFile)
-{
-    Q_ASSERT(rssFile);
-    QTreeWidgetItem *item = new QTreeWidgetItem;
-    item->setData(0, Qt::DisplayRole, QVariant(rssFile->displayName() + QString::fromUtf8("  (") + QString::number(rssFile->unreadCount()) + QString(")")));
-    item->setData(0, Qt::DecorationRole, QIcon(rssFile->iconPath()));
-
-    return item;
-}
-
 void RSSImp::fillFeedsList(QTreeWidgetItem *parent, const Rss::FolderPtr &rss_parent)
 {
     QList<Rss::FilePtr> children;
@@ -479,7 +469,7 @@ void RSSImp::fillFeedsList(QTreeWidgetItem *parent, const Rss::FolderPtr &rss_pa
     else
         children = m_rssManager->rootFolder()->getContent();
     foreach (const Rss::FilePtr &rssFile, children) {
-        QTreeWidgetItem *item = createFolderListItem(rssFile);
+        QTreeWidgetItem *item = m_feedList->createListItem(rssFile);
         Q_ASSERT(item);
         if (parent)
             parent->addChild(item);

--- a/src/gui/rss/rss_imp.h
+++ b/src/gui/rss/rss_imp.h
@@ -89,7 +89,6 @@ private slots:
 
 private:
     static QListWidgetItem *createArticleListItem(const Rss::ArticlePtr &article);
-    static QTreeWidgetItem *createFolderListItem(const Rss::FilePtr &rssFile);
 
 private:
     Rss::ManagerPtr m_rssManager;

--- a/src/gui/rss/rss_imp.h
+++ b/src/gui/rss/rss_imp.h
@@ -50,7 +50,7 @@ class RSSImp: public QWidget, public Ui::RSS
     Q_OBJECT
 
 public:
-    RSSImp(QWidget * parent);
+    RSSImp(QWidget *parent);
     ~RSSImp();
 
 public slots:

--- a/src/gui/sortablewidgetitems.cpp
+++ b/src/gui/sortablewidgetitems.cpp
@@ -1,0 +1,129 @@
+/*
+ * Bittorrent Client using Qt4 and libtorrent.
+ * Copyright (C) 2017  Christophe Dumez
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ *
+ * Contact : chris@qbittorrent.org
+ */
+
+#include "base/utils/string.h"
+#include "sortablewidgetitems.h"
+
+SortableListWidgetItem::SortableListWidgetItem(QListWidget *parent, Utils::String::CaseSensitivity cs, int type)
+    : QListWidgetItem(parent, type)
+    , m_caseSensitivity(cs)
+{
+}
+
+SortableListWidgetItem::SortableListWidgetItem(const QString &text, QListWidget *parent, Utils::String::CaseSensitivity cs, int type)
+    : QListWidgetItem(text, parent, type)
+    , m_caseSensitivity(cs)
+{
+}
+
+SortableListWidgetItem::SortableListWidgetItem(const QIcon &icon, const QString &text, QListWidget *parent, Utils::String::CaseSensitivity cs, int type)
+    : QListWidgetItem(icon, text, parent, type)
+    , m_caseSensitivity(cs)
+{
+}
+
+SortableListWidgetItem::SortableListWidgetItem(const SortableListWidgetItem &other)
+    : QListWidgetItem(other)
+    , m_caseSensitivity(other.m_caseSensitivity)
+{
+}
+
+SortableListWidgetItem::~SortableListWidgetItem()
+{
+}
+
+bool SortableListWidgetItem::operator<(const QListWidgetItem &other) const
+{
+    return Utils::String::naturalCompare(text(), other.text(), m_caseSensitivity);
+}
+
+SortableTreeWidgetItem::SortableTreeWidgetItem(Utils::String::CaseSensitivity cs, int type)
+    : QTreeWidgetItem(type)
+    , m_caseSensitivity(cs)
+{
+}
+
+SortableTreeWidgetItem::SortableTreeWidgetItem(const QStringList &strings, Utils::String::CaseSensitivity cs, int type)
+    : QTreeWidgetItem(strings, type)
+    , m_caseSensitivity(cs)
+{
+}
+
+SortableTreeWidgetItem::SortableTreeWidgetItem(QTreeWidget *parent, Utils::String::CaseSensitivity cs, int type)
+    : QTreeWidgetItem(parent, type)
+    , m_caseSensitivity(cs)
+{
+}
+
+SortableTreeWidgetItem::SortableTreeWidgetItem(QTreeWidget *parent, const QStringList &strings, Utils::String::CaseSensitivity cs, int type)
+    : QTreeWidgetItem(parent, strings, type)
+    , m_caseSensitivity(cs)
+{
+}
+
+SortableTreeWidgetItem::SortableTreeWidgetItem(QTreeWidget *parent, QTreeWidgetItem *preceding, Utils::String::CaseSensitivity cs, int type)
+    : QTreeWidgetItem(parent, preceding, type)
+    , m_caseSensitivity(cs)
+{
+}
+
+SortableTreeWidgetItem::SortableTreeWidgetItem(QTreeWidgetItem *parent, Utils::String::CaseSensitivity cs, int type)
+    : QTreeWidgetItem(parent, type)
+    , m_caseSensitivity(cs)
+{
+}
+
+SortableTreeWidgetItem::SortableTreeWidgetItem(QTreeWidgetItem *parent, const QStringList &strings, Utils::String::CaseSensitivity cs, int type)
+    : QTreeWidgetItem(parent, strings, type)
+    , m_caseSensitivity(cs)
+{
+}
+
+SortableTreeWidgetItem::SortableTreeWidgetItem(QTreeWidgetItem *parent, QTreeWidgetItem *preceding, Utils::String::CaseSensitivity cs, int type)
+    : QTreeWidgetItem(parent, preceding, type)
+    , m_caseSensitivity(cs)
+{
+}
+
+SortableTreeWidgetItem::SortableTreeWidgetItem(const SortableTreeWidgetItem &other)
+    : QTreeWidgetItem(other)
+    , m_caseSensitivity(other.m_caseSensitivity)
+{
+}
+
+SortableTreeWidgetItem::~SortableTreeWidgetItem()
+{
+}
+
+bool SortableTreeWidgetItem::operator<(const QTreeWidgetItem &other) const
+{
+    int column = treeWidget()->sortColumn();
+    return Utils::String::naturalCompare(text(column), other.text(column), m_caseSensitivity);
+}

--- a/src/gui/sortablewidgetitems.h
+++ b/src/gui/sortablewidgetitems.h
@@ -1,0 +1,77 @@
+/*
+ * Bittorrent Client using Qt4 and libtorrent.
+ * Copyright (C) 2017  Christophe Dumez
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ *
+ * Contact : chris@qbittorrent.org
+ */
+
+#ifndef SORTABLEWIDGETITEMS_H
+#define SORTABLEWIDGETITEMS_H
+
+#include <QListWidget>
+#include <QListWidgetItem>
+#include <QStringList>
+#include <QTreeWidget>
+#include <QTreeWidgetItem>
+
+#include "base/utils/string.h"
+
+class SortableListWidgetItem: public QListWidgetItem
+{
+public:
+    SortableListWidgetItem(QListWidget *parent = 0, Utils::String::CaseSensitivity cs = Utils::String::CaseSensitivity::CaseSemiSensitive, int type = Type);
+    SortableListWidgetItem(const QString &text, QListWidget *parent = 0, Utils::String::CaseSensitivity cs = Utils::String::CaseSensitivity::CaseSemiSensitive, int type = Type);
+    SortableListWidgetItem(const QIcon &icon, const QString &text, QListWidget *parent = 0, Utils::String::CaseSensitivity cs = Utils::String::CaseSensitivity::CaseSemiSensitive, int type = Type);
+    SortableListWidgetItem(const SortableListWidgetItem &other);
+    virtual ~SortableListWidgetItem();
+    virtual bool operator<(const QListWidgetItem &other) const;
+
+private:
+
+    Utils::String::CaseSensitivity m_caseSensitivity;
+};
+
+class SortableTreeWidgetItem: public QTreeWidgetItem
+{
+public:
+    SortableTreeWidgetItem(Utils::String::CaseSensitivity cs = Utils::String::CaseSensitivity::CaseSemiSensitive, int type = Type);
+    SortableTreeWidgetItem(const QStringList &strings, Utils::String::CaseSensitivity cs = Utils::String::CaseSensitivity::CaseSemiSensitive, int type = Type);
+    SortableTreeWidgetItem(QTreeWidget *parent, Utils::String::CaseSensitivity cs = Utils::String::CaseSensitivity::CaseSemiSensitive, int type = Type);
+    SortableTreeWidgetItem(QTreeWidget *parent, const QStringList &strings, Utils::String::CaseSensitivity cs = Utils::String::CaseSensitivity::CaseSemiSensitive, int type = Type);
+    SortableTreeWidgetItem(QTreeWidget *parent, QTreeWidgetItem *preceding, Utils::String::CaseSensitivity cs = Utils::String::CaseSensitivity::CaseSemiSensitive, int type = Type);
+    SortableTreeWidgetItem(QTreeWidgetItem *parent, Utils::String::CaseSensitivity cs = Utils::String::CaseSensitivity::CaseSemiSensitive, int type = Type);
+    SortableTreeWidgetItem(QTreeWidgetItem *parent, const QStringList &strings, Utils::String::CaseSensitivity cs = Utils::String::CaseSensitivity::CaseSemiSensitive, int type = Type);
+    SortableTreeWidgetItem(QTreeWidgetItem *parent, QTreeWidgetItem *preceding, Utils::String::CaseSensitivity cs = Utils::String::CaseSensitivity::CaseSemiSensitive, int type = Type);
+    SortableTreeWidgetItem(const SortableTreeWidgetItem &other);
+    virtual ~SortableTreeWidgetItem();
+    virtual bool operator<(const QTreeWidgetItem &other) const;
+
+private:
+
+    Utils::String::CaseSensitivity m_caseSensitivity;
+};
+
+#endif // SORTABLEWIDGETITEMS_H


### PR DESCRIPTION
This PR builds on PR #6326. It changes the RSS downloader dialog to use a tree for its feed list, as discussed in issue #6281.

This PR also introduces a new form of Natural Sort - the "case semi-sensitive" sort. This is a case insensitive sort, except where 2 strings compare equal ignoring case, in which case the strings are compared using a case-sensitive sort. This ensures a consistent ordering.

This PR also introduces subclasses of QListWidgetItem and QTreeWidgetItem that sort via natural sort (defaults to case semi-sensitive, but can be specified as case-sensitive or case-insensitive).

The RSS tab and downloader dialogs use these classes to sort, with a further enhancement that folders sort first (and for the RSS tab, the Unread item sorts before all others).

![feed_tree](https://cloud.githubusercontent.com/assets/1728015/22623926/859dc3e4-ebbf-11e6-8b7b-2fd409225ace.png)

If there are no visible folders then the expander decorations are hidden, resulting in effectively the same UI as current.