### PR TITLE
cmake: read version numbers from the version.pri file. Closes #6350.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,14 @@
 cmake_minimum_required(VERSION 3.5)
 cmake_policy(VERSION 3.5)
 
-project(qBittorrent VERSION 3.4.0.0)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
+include(FunctionReadVersion)
 
-set(VER_MAJOR ${qBittorrent_VERSION_MAJOR})
-set(VER_MINOR ${qBittorrent_VERSION_MINOR})
-set(VER_BUGFIX ${qBittorrent_VERSION_PATCH})
-set(VER_BUILD ${qBittorrent_VERSION_TWEAK})
-set(VER_STATUS "alpha") # Should be empty for stable releases!
+read_version("${CMAKE_CURRENT_SOURCE_DIR}/version.pri" VER_MAJOR VER_MINOR VER_BUGFIX VER_BUILD VER_STATUS)
+# message(STATUS "Project version is: ${VER_MAJOR}.${VER_MINOR}.${VER_BUGFIX}.${VER_BUILD} (${VER_STATUS})")
 
-# Don't touch the rest part
+project(qBittorrent VERSION ${VER_MAJOR}.${VER_MINOR}.${VER_BUGFIX}.${VER_BUILD})
+
 set(PROJECT_VERSION "${VER_MAJOR}.${VER_MINOR}.${VER_BUGFIX}")
 
 if (NOT VER_BUILD EQUAL 0)
@@ -28,7 +27,6 @@ add_definitions(-DVERSION_BUILD=${VER_BUILD})
 # } else {
 add_definitions(-DVERSION="v${PROJECT_VERSION}")
 # }
-list(APPEND CMAKE_MODULE_PATH ${qBittorrent_SOURCE_DIR}/cmake/Modules)
 
 # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Og")
 if (UNIX AND NOT APPLE)

--- a/cmake/Modules/FunctionReadVersion.cmake
+++ b/cmake/Modules/FunctionReadVersion.cmake
@@ -1,0 +1,28 @@
+# function for parsing version variables that are set in version.pri file
+# the version identifiers there are defined as follows:
+# VER_MAJOR = 3
+# VER_MINOR = 4
+# VER_BUGFIX = 0
+# VER_BUILD = 0
+# VER_STATUS = alpha
+
+function(read_version priFile outMajor outMinor outBugfix outBuild outStatus)
+    file(STRINGS ${priFile} _priFileContents REGEX "^VER_.+")
+    # message(STATUS "version.pri version contents: ${_priFileContents}")
+    # the _priFileContents variable contains something like the following:
+    # VER_MAJOR = 3;VER_MINOR = 4;VER_BUGFIX = 0;VER_BUILD = 0;VER_STATUS = alpha # Should be empty for stable releases!
+    set(_regex "VER_MAJOR += +([0-9]+);VER_MINOR += +([0-9]+);VER_BUGFIX += +([0-9]+);VER_BUILD += +([0-9]+);VER_STATUS += +([0-9A-Za-z]+)?")
+     # note quotes around _regex, they are needed because the variable contains semicolons
+    string(REGEX MATCH "${_regex}" _tmp "${_priFileContents}")
+    if (NOT _tmp)
+        message(FATAL_ERROR "Could not detect project version number from ${priFile}")
+    endif()
+
+    # message(STATUS "Matched version string: ${_tmp}")
+
+    set(${outMajor} ${CMAKE_MATCH_1} PARENT_SCOPE)
+    set(${outMinor} ${CMAKE_MATCH_2} PARENT_SCOPE)
+    set(${outBugfix} ${CMAKE_MATCH_3} PARENT_SCOPE)
+    set(${outBuild} ${CMAKE_MATCH_4} PARENT_SCOPE)
+    set(${outStatus} ${CMAKE_MATCH_5} PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
The title says it. 

An assumption was made that VER_STATUS is any of 0-9 and a-z or empty (see the regex in `cmake/Modules/FunctionReadVersion.cmake`.  I do not know whether the assumption is correct.