### PR TITLE
add option to middle elide column text in the torrents list

### DIFF
--- a/src/gui/properties/peerlistdelegate.h
+++ b/src/gui/properties/peerlistdelegate.h
@@ -106,6 +106,10 @@ public:
             QItemDelegate::drawDisplay(painter, opt, opt.rect, Utils::String::fromDouble(progress*100.0, 1)+"%");
             }
             break;
+        case DOWNLOADING_PIECE:
+            opt.textElideMode = Qt::ElideMiddle;
+            QItemDelegate::paint(painter, opt, index);
+            break;
         default:
             QItemDelegate::paint(painter, option, index);
         }

--- a/src/gui/torrentmodel.h
+++ b/src/gui/torrentmodel.h
@@ -90,6 +90,7 @@ public:
     bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::DisplayRole);
     QVariant headerData(int section, Qt::Orientation orientation, int role) const;
     Qt::ItemFlags flags(const QModelIndex &index) const;
+    QVariant getTooltip(const QModelIndex& idx, const BitTorrent::TorrentHandle *torrent) const;
 
     BitTorrent::TorrentHandle *torrentHandle(const QModelIndex &index) const;
 
@@ -101,6 +102,7 @@ private slots:
 
 private:
     QList<BitTorrent::TorrentHandle *> m_torrents;
+    QObject *m_parent;
 };
 
 #endif // TORRENTMODEL_H

--- a/src/gui/torrentmodel.h
+++ b/src/gui/torrentmodel.h
@@ -40,6 +40,7 @@ namespace BitTorrent
     class InfoHash;
     class TorrentHandle;
 }
+class TransferListWidget;
 
 class TorrentModel : public QAbstractListModel
 {
@@ -82,7 +83,7 @@ public:
         NB_COLUMNS
     };
 
-    explicit TorrentModel(QObject *parent = 0);
+    explicit TorrentModel(TransferListWidget *parent = 0);
 
     int rowCount(const QModelIndex& index = QModelIndex()) const;
     int columnCount(const QModelIndex &parent=QModelIndex()) const;
@@ -102,7 +103,7 @@ private slots:
 
 private:
     QList<BitTorrent::TorrentHandle *> m_torrents;
-    QObject *m_parent;
+    const TransferListWidget *m_transferListWidget;
 };
 
 #endif // TORRENTMODEL_H

--- a/src/gui/transferlistdelegate.cpp
+++ b/src/gui/transferlistdelegate.cpp
@@ -70,6 +70,11 @@ void TransferListDelegate::paint(QPainter * painter, const QStyleOptionViewItem 
     QStyleOptionViewItem opt = QItemDelegate::setOptions(index, option);
     QItemDelegate::drawBackground(painter, opt, index);
     switch (index.column()) {
+    case TorrentModel::TR_NAME:
+    case TorrentModel::TR_SAVE_PATH:
+        opt.textElideMode = Qt::ElideMiddle;
+        QItemDelegate::paint(painter, opt, index);
+        break;
     case TorrentModel::TR_AMOUNT_DOWNLOADED:
     case TorrentModel::TR_AMOUNT_UPLOADED:
     case TorrentModel::TR_AMOUNT_DOWNLOADED_SESSION:
@@ -231,7 +236,7 @@ QSize TransferListDelegate::sizeHint(const QStyleOptionViewItem & option, const 
     return size;
 }
 
-QString TransferListDelegate::getStatusString(const int state) const
+QString TransferListDelegate::getStatusString(const int state)
 {
     QString str;
 

--- a/src/gui/transferlistdelegate.h
+++ b/src/gui/transferlistdelegate.h
@@ -51,8 +51,7 @@ public:
     QWidget* createEditor(QWidget*, const QStyleOptionViewItem &, const QModelIndex &) const;
     QSize sizeHint(const QStyleOptionViewItem & option, const QModelIndex & index) const;
 
-private:
-    QString getStatusString(const int state) const;
+    static QString getStatusString(const int state);
 };
 
 #endif // TRANSFERLISTDELEGATE_H


### PR DESCRIPTION
This commit adds option to middle elide text columns. This is handy when there are similar save paths that can be only distinguished by the final folder name e.g:

**/path/to/areally/really/loooong/long/folder/software
/path/to/areally/really/loooong/long/folder/books**

becomes

**/path/to/ ... folder/software
/path/to/ ... folder/books**

instead of something like this:

![textelision](https://cloud.githubusercontent.com/assets/9851506/22751981/62c7bbb8-ee3f-11e6-9454-842e8967ac60.png)

where it is impossible to tell what the final folder would be by just having a looking at the list.

In case anything should be adjusted in this commit please feel free to contact me and I'll update it as required.
