### PR TITLE
Allow editing RSS feed URLs. Closes #5489

### DIFF
--- a/src/base/rss/rssdownloadrule.cpp
+++ b/src/base/rss/rssdownloadrule.cpp
@@ -147,7 +147,7 @@ bool DownloadRule::matches(const QString &articleTitle) const
 
     if (!m_episodeFilter.isEmpty()) {
         qDebug() << "Checking episode filter:" << m_episodeFilter;
-        QRegularExpression f(cachedRegex("(^\\d{1,4})x(.*;$)"));
+        QRegularExpression f(cachedRegex("(^\\d{1,4})x(.+;$)"));
         QRegularExpressionMatch matcher = f.match(m_episodeFilter);
         bool matched = matcher.hasMatch();
 
@@ -188,7 +188,9 @@ bool DownloadRule::matches(const QString &articleTitle) const
                         int sTheirs = matcher.captured(1).toInt();
                         int epTheirs = matcher.captured(2).toInt();
                         if (((sTheirs == sOurs) && (epTheirs >= epOurs)) || (sTheirs > sOurs)) {
-                            qDebug() << "Matched episode:" << ep;
+                            qDebug() << "Matched episode:";
+                            qDebug() << "    Filter: " << s << "x" << ep;
+                            qDebug() << "    Article:" << sTheirs << "x" << epTheirs;
                             qDebug() << "Matched article:" << articleTitle;
                             return true;
                         }
@@ -217,7 +219,9 @@ bool DownloadRule::matches(const QString &articleTitle) const
                         int sTheirs = matcher.captured(1).toInt();
                         int epTheirs = matcher.captured(2).toInt();
                         if ((sTheirs == sOurs) && ((epOursFirst <= epTheirs) && (epOursLast >= epTheirs))) {
-                            qDebug() << "Matched episode:" << ep;
+                            qDebug() << "Matched episode:";
+                            qDebug() << "    Filter: " << s << "x" << ep;
+                            qDebug() << "    Article:" << sTheirs << "x" << epTheirs;
                             qDebug() << "Matched article:" << articleTitle;
                             return true;
                         }
@@ -228,7 +232,7 @@ bool DownloadRule::matches(const QString &articleTitle) const
                 QString expStr("\\b(?:s0?" + s + "[ -_\\.]?" + "e0?" + ep + "|" + s + "x" + "0?" + ep + ")(?:\\D|\\b)");
                 QRegularExpression reg(cachedRegex(expStr));
                 if (reg.match(articleTitle).hasMatch()) {
-                    qDebug() << "Matched episode:" << ep;
+                    qDebug() << "Matched episode:" << s << "x" << ep;
                     qDebug() << "Matched article:" << articleTitle;
                     return true;
                 }

--- a/src/base/rss/rssdownloadrulelist.cpp
+++ b/src/base/rss/rssdownloadrulelist.cpp
@@ -136,6 +136,19 @@ void DownloadRuleList::renameRule(const QString &oldName, const QString &newName
     }
 }
 
+void DownloadRuleList::updateFeedURL(const QString &oldUrl, const QString &newUrl)
+{
+    if (m_feedRules.contains(oldUrl)) {
+        QStringList feedRules = m_feedRules.take(oldUrl);
+        m_feedRules.insert(newUrl, feedRules);
+        foreach (const QString &ruleName, feedRules) {
+            QStringList ruleFeeds = m_rules[ruleName]->rssFeeds();
+            ruleFeeds.replace(ruleFeeds.indexOf(oldUrl), newUrl);
+            m_rules[ruleName]->setRssFeeds(ruleFeeds);
+        }
+    }
+}
+
 DownloadRulePtr DownloadRuleList::getRule(const QString &name) const
 {
     return m_rules.value(name);

--- a/src/base/rss/rssdownloadrulelist.h
+++ b/src/base/rss/rssdownloadrulelist.h
@@ -58,6 +58,7 @@ namespace Rss
         bool serialize(const QString &path);
         bool unserialize(const QString &path);
         void replace(DownloadRuleList *other);
+        void updateFeedURL(const QString &oldUrl, const QString &newUrl);
 
     private:
         void loadRulesFromStorage();

--- a/src/base/rss/rssfeed.cpp
+++ b/src/base/rss/rssfeed.cpp
@@ -77,8 +77,7 @@ Feed::Feed(const QString &url, Manager *manager)
     connect(m_parser, SIGNAL(finished(QString)), SLOT(handleParsingFinished(QString)));
 
     // Download the RSS Feed icon
-    Net::DownloadHandler *handler = Net::DownloadManager::instance()->downloadUrl(iconUrl(), true);
-    connect(handler, SIGNAL(downloadFinished(QString,QString)), this, SLOT(handleIconDownloadFinished(QString,QString)));
+    downloadIcon();
 
     // Load old RSS articles
     loadItemsFromDisk();
@@ -126,6 +125,12 @@ void Feed::loadItemsFromDisk()
         if (rssItem)
             addArticle(rssItem);
     }
+}
+
+void Feed::downloadIcon()
+{
+    Net::DownloadHandler *handler = Net::DownloadManager::instance()->downloadUrl(iconUrl(), true);
+    connect(handler, SIGNAL(downloadFinished(QString,QString)), this, SLOT(handleIconDownloadFinished(QString,QString)));
 }
 
 void Feed::addArticle(const ArticlePtr &article)
@@ -243,6 +248,21 @@ QString Feed::url() const
     return m_url;
 }
 
+void Feed::setURL(const QString &url)
+{
+    // Clear old articles
+    m_articles.clear();
+    m_articlesByDate.clear();
+    m_unreadCount = 0;
+    saveItemsToDisk();
+
+    m_url = url;
+    downloadIcon();
+
+    // FIXME: Cancel current refresh if in progress
+    refresh();
+}
+
 QString Feed::iconPath() const
 {
     if (m_inErrorState)
@@ -318,7 +338,8 @@ ArticleList Feed::unreadArticleListByDateDesc() const
 QString Feed::iconUrl() const
 {
     // XXX: This works for most sites but it is not perfect
-    return QString("http://%1/favicon.ico").arg(QUrl(m_url).host());
+    const QUrl url(m_url);
+    return QString("%1://%2/favicon.ico").arg(url.scheme()).arg(url.host());
 }
 
 void Feed::handleIconDownloadFinished(const QString &url, const QString &filePath)

--- a/src/base/rss/rssfeed.h
+++ b/src/base/rss/rssfeed.h
@@ -76,6 +76,7 @@ namespace Rss
         void rename(const QString &newName);
         QString displayName() const;
         QString url() const;
+        void setURL(const QString &url);
         QString iconPath() const;
         bool hasCustomIcon() const;
         void setIconPath(const QString &pathHierarchy);
@@ -105,6 +106,7 @@ namespace Rss
         void addArticle(const ArticlePtr &article);
         void downloadArticleTorrentIfMatching(const ArticlePtr &article);
         void deferredDownloadArticleTorrentIfMatching(const ArticlePtr &article);
+        void downloadIcon();
 
     private:
         Manager *m_manager;

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -588,7 +588,7 @@ void AutomatedRssDownloader::handleFeedCheckStateChange(QListWidgetItem *feed_it
     updateMatchingArticles();
 }
 
-// FIXME: This should return early if any of the filters are invalid
+// FIXME: This should skip rules with any invalid filters
 void AutomatedRssDownloader::updateMatchingArticles()
 {
     ui->treeMatchingArticles->clear();

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -57,7 +57,6 @@ namespace Rss
 
 QT_BEGIN_NAMESPACE
 class QListWidgetItem;
-class QRegularExpression;
 QT_END_NAMESPACE
 
 class AutomatedRssDownloader: public QDialog
@@ -113,7 +112,6 @@ private:
     QListWidgetItem *m_editedRule;
     Rss::DownloadRuleList *m_ruleList;
     Rss::DownloadRuleList *m_editableRuleList;
-    QRegularExpression *m_episodeRegex;
     QShortcut *editHotkey;
     QShortcut *deleteHotkey;
     QSet<QPair<QString, QString >> m_treeListEntries;

--- a/src/gui/rss/rss.ui
+++ b/src/gui/rss/rss.ui
@@ -194,6 +194,11 @@
     <string>New folder...</string>
    </property>
   </action>
+  <action name="actionChange_Feed_URL">
+   <property name="text">
+    <string>Change Feed URL</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>
@@ -203,5 +208,25 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>actionChange_Feed_URL</sender>
+   <signal>triggered()</signal>
+   <receiver>RSS</receiver>
+   <slot>changeSelectedFeedURL()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>809</x>
+     <y>457</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <slots>
+  <slot>changeSelectedFeedURL()</slot>
+ </slots>
 </ui>

--- a/src/gui/rss/rss_imp.cpp
+++ b/src/gui/rss/rss_imp.cpp
@@ -43,6 +43,7 @@
 #include "base/net/downloadmanager.h"
 #include "base/preferences.h"
 #include "rsssettingsdlg.h"
+#include "base/rss/rssdownloadrulelist.h"
 #include "base/rss/rssmanager.h"
 #include "base/rss/rssfolder.h"
 #include "base/rss/rssarticle.h"
@@ -480,9 +481,13 @@ void RSSImp::changeSelectedFeedURL()
         }
     } while (!ok);
 
+    m_rssManager->downloadRules()->updateFeedURL(feed->url(), newUrl);
+    m_rssManager->downloadRules()->saveRulesToStorage();
+
     m_feedList->itemAboutToBeRemoved(item);
     feed->setURL(newUrl);
     m_feedList->itemAdded(item, feed);
+
     m_rssManager->saveStreamList();
     updateItemInfos(item);
 }

--- a/src/gui/rss/rss_imp.h
+++ b/src/gui/rss/rss_imp.h
@@ -69,6 +69,7 @@ private slots:
     void renameSelectedRssFile();
     void refreshSelectedItems();
     void copySelectedFeedsURL();
+    void changeSelectedFeedURL();
     void populateArticleList(QTreeWidgetItem *item);
     void refreshTextBrowser();
     void updateFeedIcon(const QString &url, const QString &icon_path);


### PR DESCRIPTION
Add ability to update feed URLs: #5489 

Update to download rules episode filter pattern to not require trailing semi-colon and add an input validator to disallow bad manual entries. This is a small bit of prep for #5195 