### PR TITLE
Use Perl-compatible regexes for RSS rules. Closes #6367.

### DIFF
--- a/src/base/rss/rssdownloadrule.h
+++ b/src/base/rss/rssdownloadrule.h
@@ -36,6 +36,7 @@
 #include <QSharedPointer>
 #include <QStringList>
 
+template <class T, class U> class QHash;
 class QRegularExpression;
 
 namespace Rss
@@ -57,6 +58,7 @@ namespace Rss
         };
 
         DownloadRule();
+        ~DownloadRule();
 
         static DownloadRulePtr fromVariantHash(const QVariantHash &ruleHash);
         QVariantHash toVariantHash() const;
@@ -91,6 +93,7 @@ namespace Rss
 
     private:
         bool matches(const QString &articleTitle, const QString &expression) const;
+        QRegularExpression getRegex(const QString &expression, bool isRegex = true) const;
 
         QString m_name;
         QStringList m_mustContain;
@@ -104,6 +107,7 @@ namespace Rss
         AddPausedState m_apstate;
         QDateTime m_lastMatch;
         int m_ignoreDays;
+        mutable QHash<QString, QRegularExpression> *m_cachedRegexes;
     };
 }
 

--- a/src/base/rss/rssdownloadrule.h
+++ b/src/base/rss/rssdownloadrule.h
@@ -31,10 +31,12 @@
 #ifndef RSSDOWNLOADRULE_H
 #define RSSDOWNLOADRULE_H
 
-#include <QStringList>
+#include <QDateTime>
 #include <QVariantHash>
 #include <QSharedPointer>
-#include <QDateTime>
+#include <QStringList>
+
+class QRegularExpression;
 
 namespace Rss
 {

--- a/src/base/utils/string.cpp
+++ b/src/base/utils/string.cpp
@@ -37,6 +37,7 @@
 #ifdef QBT_USES_QT5
 #include <QCollator>
 #endif
+#include <QRegExp>
 #ifdef Q_OS_MAC
 #include <QThreadStorage>
 #endif
@@ -211,3 +212,13 @@ bool Utils::String::slowEquals(const QByteArray &a, const QByteArray &b)
 
     return (diff == 0);
 }
+
+// This is marked as internal in QRegExp.cpp, but is exported. The alternative would be to
+// copy the code from QRegExp::wc2rx().
+QString qt_regexp_toCanonical(const QString &pattern, QRegExp::PatternSyntax patternSyntax);
+
+QString Utils::String::wildcardToRegex(const QString &pattern)
+{
+    return qt_regexp_toCanonical(pattern, QRegExp::Wildcard);
+}
+

--- a/src/base/utils/string.h
+++ b/src/base/utils/string.h
@@ -49,6 +49,8 @@ namespace Utils
 
         bool naturalCompareCaseSensitive(const QString &left, const QString &right);
         bool naturalCompareCaseInsensitive(const QString &left, const QString &right);
+
+        QString wildcardToRegex(const QString &pattern);
     }
 }
 

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -33,6 +33,7 @@
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QMenu>
+#include <QRegularExpression>
 
 #include "base/bittorrent/session.h"
 #include "base/preferences.h"
@@ -73,8 +74,8 @@ AutomatedRssDownloader::AutomatedRssDownloader(const QWeakPointer<Rss::Manager> 
     Q_ASSERT(ok);
     m_ruleList = manager.toStrongRef()->downloadRules();
     m_editableRuleList = new Rss::DownloadRuleList; // Read rule list from disk
-    m_episodeRegex = new QRegExp("^(^\\d{1,4}x(\\d{1,4}(-(\\d{1,4})?)?;){1,}){1,1}",
-                                 Qt::CaseInsensitive);
+    m_episodeRegex = new QRegularExpression("^(^\\d{1,4}x(\\d{1,4}(-(\\d{1,4})?)?;){1,}){1,1}",
+                                 QRegularExpression::CaseInsensitiveOption);
     QString tip = "<p>" + tr("Matches articles based on episode filter.") + "</p><p><b>" + tr("Example: ")
                   + "1x2;8-15;5;30-;</b>" + tr(" will match 2, 5, 8 through 15, 30 and onward episodes of season one", "example X will match") + "</p>";
     tip += "<p>" + tr("Episode filter rules: ") + "</p><ul><li>" + tr("Season number is a mandatory non-zero value") + "</li>"
@@ -672,7 +673,7 @@ void AutomatedRssDownloader::updateFieldsToolTips(bool regex)
 {
     QString tip;
     if (regex) {
-        tip = "<p>" + tr("Regex mode: use Perl-like regular expressions") + "</p>";
+        tip = "<p>" + tr("Regex mode: use Perl-compatible regular expressions") + "</p>";
     }
     else {
         tip = "<p>" + tr("Wildcard mode: you can use") + "<ul>"
@@ -698,17 +699,23 @@ void AutomatedRssDownloader::updateFieldsToolTips(bool regex)
 void AutomatedRssDownloader::updateMustLineValidity()
 {
     const QString text = ui->lineContains->text();
+    bool isRegex = ui->checkRegex->isChecked();
     bool valid = true;
+    QString error;
 
     if (!text.isEmpty()) {
         QStringList tokens;
-        if (ui->checkRegex->isChecked())
+        if (isRegex)
             tokens << text;
         else
-            tokens << text.split("|");
+            foreach (const QString &token, text.split("|"))
+                tokens << Utils::String::wildcardToRegex(token);
+
         foreach (const QString &token, tokens) {
-            QRegExp reg(token, Qt::CaseInsensitive, ui->checkRegex->isChecked() ? QRegExp::RegExp : QRegExp::Wildcard);
+            QRegularExpression reg(token, QRegularExpression::CaseInsensitiveOption);
             if (!reg.isValid()) {
+                if (isRegex)
+                    error = tr("Position %1: %2").arg(reg.patternErrorOffset()).arg(reg.errorString());
                 valid = false;
                 break;
             }
@@ -718,27 +725,35 @@ void AutomatedRssDownloader::updateMustLineValidity()
     if (valid) {
         ui->lineContains->setStyleSheet("");
         ui->lbl_must_stat->setPixmap(QPixmap());
+        ui->lbl_must_stat->setToolTip(QLatin1String(""));
     }
     else {
         ui->lineContains->setStyleSheet("QLineEdit { color: #ff0000; }");
         ui->lbl_must_stat->setPixmap(GuiIconProvider::instance()->getIcon("task-attention").pixmap(16, 16));
+        ui->lbl_must_stat->setToolTip(error);
     }
 }
 
 void AutomatedRssDownloader::updateMustNotLineValidity()
 {
     const QString text = ui->lineNotContains->text();
+    bool isRegex = ui->checkRegex->isChecked();
     bool valid = true;
+    QString error;
 
     if (!text.isEmpty()) {
         QStringList tokens;
-        if (ui->checkRegex->isChecked())
+        if (isRegex)
             tokens << text;
         else
-            tokens << text.split("|");
+            foreach (const QString &token, text.split("|"))
+                tokens << Utils::String::wildcardToRegex(token);
+
         foreach (const QString &token, tokens) {
-            QRegExp reg(token, Qt::CaseInsensitive, ui->checkRegex->isChecked() ? QRegExp::RegExp : QRegExp::Wildcard);
+            QRegularExpression reg(token, QRegularExpression::CaseInsensitiveOption);
             if (!reg.isValid()) {
+                if (isRegex)
+                    error = tr("Position %1: %2").arg(reg.patternErrorOffset()).arg(reg.errorString());
                 valid = false;
                 break;
             }
@@ -748,17 +763,19 @@ void AutomatedRssDownloader::updateMustNotLineValidity()
     if (valid) {
         ui->lineNotContains->setStyleSheet("");
         ui->lbl_mustnot_stat->setPixmap(QPixmap());
+        ui->lbl_mustnot_stat->setToolTip(QLatin1String(""));
     }
     else {
         ui->lineNotContains->setStyleSheet("QLineEdit { color: #ff0000; }");
         ui->lbl_mustnot_stat->setPixmap(GuiIconProvider::instance()->getIcon("task-attention").pixmap(16, 16));
+        ui->lbl_mustnot_stat->setToolTip(error);
     }
 }
 
 void AutomatedRssDownloader::updateEpisodeFilterValidity()
 {
     const QString text = ui->lineEFilter->text();
-    bool valid = text.isEmpty() || m_episodeRegex->indexIn(text) != -1;
+    bool valid = text.isEmpty() || m_episodeRegex->match(text).hasMatch();
 
     if (valid) {
         ui->lineEFilter->setStyleSheet("");

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -34,7 +34,6 @@
 #include <QDialog>
 #include <QHideEvent>
 #include <QPair>
-#include <QRegExpValidator>
 #include <QSet>
 #include <QShortcut>
 #include <QShowEvent>
@@ -58,6 +57,7 @@ namespace Rss
 
 QT_BEGIN_NAMESPACE
 class QListWidgetItem;
+class QRegularExpression;
 QT_END_NAMESPACE
 
 class AutomatedRssDownloader: public QDialog
@@ -113,7 +113,7 @@ private:
     QListWidgetItem *m_editedRule;
     Rss::DownloadRuleList *m_ruleList;
     Rss::DownloadRuleList *m_editableRuleList;
-    QRegExp *m_episodeRegex;
+    QRegularExpression *m_episodeRegex;
     QShortcut *editHotkey;
     QShortcut *deleteHotkey;
     QSet<QPair<QString, QString >> m_treeListEntries;


### PR DESCRIPTION
Change `rssdownloadrule` and `automatedrssdownloader` to use `QRegularExpression` instead of `QRegExp`.

_Note: `QRegularExpression` is only available since Qt 5.0 so this PR cannot be merged while Qt 4.8 is supported. Since `QRegularExpression` is not a strict superset of the functionality in `QRegExp` I do not want to use one engine for Qt 4.8 and a different one for Qt 5.0+._

When using regex for rules, add a tooltip to the invalid icon specifying the first error. Not done for wildcards as we can't get this info in a way that corresponds to the wildcard string.

![rss_regex](https://cloud.githubusercontent.com/assets/1728015/22852347/66505884-f08e-11e6-8cfe-0d7ddad48ac8.png)

The second commit in the PR adds caching of the rule regexes - this results in a significant performance improvement over creating the regexes every time.

To convert wildcards to regex, use an internal function in `QRegExp` which is exported but not in the header file - `qt_regexp_toCanonical`. `Utils::String::wildcardToRegex` provides a facade. Note that `QRegExp` includes the following comment with the function:

````
/*!
    \internal
    convert the pattern string to the RegExp syntax.

    This is also used by QScriptEngine::newRegExp to convert to a pattern that JavaScriptCore can understan
 */
Q_CORE_EXPORT QString qt_regexp_toCanonical(const QString &pattern, QRegExp::PatternSyntax patternSyntax)
````

so there is precedent for doing this. An alternative would be to copy the code, but then we wouldn't pick up bugfixes. We always have the option if a future version of Qt removes the function.

~~Note: waiting for Qt4 builds to complete to confirm that `qt_regexp_toCanonical` is present in QT 4.8.~~