### PR TITLE
Appearance tab. Issue #6363.

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -57,9 +57,11 @@
 #include "logger.h"
 #include "preferences.h"
 
-Preferences* Preferences::m_instance = 0;
+Preferences *Preferences::m_instance = 0;
 
-Preferences::Preferences() {}
+Preferences::Preferences()
+{
+}
 
 Preferences *Preferences::instance()
 {
@@ -250,6 +252,7 @@ void Preferences::setWinStartup(bool b)
         settings.remove("qBittorrent");
     }
 }
+
 #endif
 
 // Downloads
@@ -712,6 +715,7 @@ void Preferences::useSystemIconTheme(bool enabled)
 {
     setValue("Preferences/Advanced/useSystemIconTheme", enabled);
 }
+
 #endif
 
 bool Preferences::recursiveDownloadDisabled() const
@@ -725,7 +729,8 @@ void Preferences::disableRecursiveDownload(bool disable)
 }
 
 #ifdef Q_OS_WIN
-namespace {
+namespace
+{
     enum REG_SEARCH_TYPE
     {
         USER,
@@ -814,7 +819,7 @@ namespace {
             versions.sort();
 
             bool found = false;
-            while(!found && !versions.empty()) {
+            while (!found && !versions.empty()) {
                 const QString version = versions.takeLast() + "\\InstallPath";
                 LPWSTR lpSubkey = new WCHAR[version.size() + 1];
                 version.toWCharArray(lpSubkey);
@@ -844,7 +849,6 @@ namespace {
 
         return path;
     }
-
 }
 
 QString Preferences::getPythonPath()
@@ -950,6 +954,7 @@ void Preferences::setMagnetLinkAssoc(bool set)
 
     SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, 0, 0);
 }
+
 #endif
 
 #ifdef Q_OS_MAC
@@ -1006,6 +1011,7 @@ void Preferences::setMagnetLinkAssoc()
     CFStringRef myBundleId = CFBundleGetIdentifier(CFBundleGetMainBundle());
     LSSetDefaultHandlerForURLScheme(magnetUrlScheme, myBundleId);
 }
+
 #endif
 
 int Preferences::getTrackerPort() const
@@ -1028,6 +1034,7 @@ void Preferences::setUpdateCheckEnabled(bool enabled)
 {
     setValue("Preferences/Advanced/updateCheck", enabled);
 }
+
 #endif
 
 bool Preferences::confirmTorrentDeletion() const
@@ -1132,7 +1139,7 @@ void Preferences::setMainLastDir(const QString &path)
 }
 
 #ifndef DISABLE_GUI
-QSize Preferences::getPrefSize(const QSize& defaultSize) const
+QSize Preferences::getPrefSize(const QSize &defaultSize) const
 {
     return value("Preferences/State/size", defaultSize).toSize();
 }
@@ -1141,6 +1148,7 @@ void Preferences::setPrefSize(const QSize &size)
 {
     setValue("Preferences/State/size", size);
 }
+
 #endif
 
 QPoint Preferences::getPrefPos() const
@@ -1477,7 +1485,7 @@ void Preferences::setTransHeaderState(const QByteArray &state)
 #endif
 }
 
-//From old RssSettings class
+// From old RssSettings class
 bool Preferences::isRSSEnabled() const
 {
     return value("Preferences/RSS/RSSEnabled", false).toBool();
@@ -1611,10 +1619,9 @@ void Preferences::upgrade()
     QStringList labels = value("TransferListFilters/customLabels").toStringList();
     if (!labels.isEmpty()) {
         QVariantMap categories = value("BitTorrent/Session/Categories").toMap();
-        foreach (const QString &label, labels) {
+        foreach (const QString &label, labels)
             if (!categories.contains(label))
                 categories[label] = "";
-        }
         setValue("BitTorrent/Session/Categories", categories);
         SettingsStorage::instance()->removeValue("TransferListFilters/customLabels");
     }

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -89,7 +89,7 @@ class Preferences: public QObject
     const QVariant value(const QString &key, const QVariant &defaultValue = QVariant()) const;
     void setValue(const QString &key, const QVariant &value);
 
-    static Preferences* m_instance;
+    static Preferences *m_instance;
 
 signals:
     void changed();
@@ -97,7 +97,7 @@ signals:
 public:
     static void initInstance();
     static void freeInstance();
-    static Preferences* instance();
+    static Preferences *instance();
 
     // General options
     QString getLocale() const;
@@ -332,7 +332,7 @@ public:
     int getToolbarTextPosition() const;
     void setToolbarTextPosition(const int position);
 
-    //From old RssSettings class
+    // From old RssSettings class
     bool isRSSEnabled() const;
     void setRSSEnabled(const bool enabled);
     uint getRSSRefreshInterval() const;

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -99,17 +99,23 @@ public:
     static void freeInstance();
     static Preferences *instance();
 
-    // General options
+    // Appearance options
     QString getLocale() const;
     void setLocale(const QString &locale);
+    bool useAlternatingRowColors() const;
+    void setAlternatingRowColors(bool b);
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+    bool useSystemIconTheme() const;
+    void setSystemIconTheme(bool enabled);
+#endif
+
+    // General options
     bool deleteTorrentFilesAsDefault() const;
     void setDeleteTorrentFilesAsDefault(bool del);
     bool confirmOnExit() const;
     void setConfirmOnExit(bool confirm);
     bool speedInTitleBar() const;
     void showSpeedInTitleBar(bool show);
-    bool useAlternatingRowColors() const;
-    void setAlternatingRowColors(bool b);
     bool getHideZeroValues() const;
     void setHideZeroValues(bool b);
     int getHideZeroComboValues() const;
@@ -226,10 +232,6 @@ public:
     void resolvePeerCountries(bool resolve);
     bool resolvePeerHostNames() const;
     void resolvePeerHostNames(bool resolve);
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
-    bool useSystemIconTheme() const;
-    void useSystemIconTheme(bool enabled);
-#endif
     bool recursiveDownloadDisabled() const;
     void disableRecursiveDownload(bool disable = true);
 #ifdef Q_OS_WIN

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -67,9 +67,6 @@ enum AdvSettingsRows
     PROGRAM_NOTIFICATIONS,
     TORRENT_ADDED_NOTIFICATIONS,
     DOWNLOAD_TRACKER_FAVICON,
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
-    USE_ICON_THEME,
-#endif
 
     // libtorrent section
     LIBTORRENT_HEADER,
@@ -179,10 +176,6 @@ void AdvancedSettings::saveAdvancedSettings()
     pref->setTrackerPort(spin_tracker_port.value());
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     pref->setUpdateCheckEnabled(cb_update_check.isChecked());
-#endif
-    // Icon theme
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
-    pref->useSystemIconTheme(cb_use_icon_theme.isChecked());
 #endif
     pref->setConfirmTorrentRecheck(cb_confirm_torrent_recheck.isChecked());
     session->setAnnounceToAllTrackers(cb_announce_all_trackers.isChecked());
@@ -369,10 +362,6 @@ void AdvancedSettings::loadAdvancedSettings()
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     cb_update_check.setChecked(pref->isUpdateCheckEnabled());
     addRow(UPDATE_CHECK, tr("Check for software updates"), &cb_update_check);
-#endif
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
-    cb_use_icon_theme.setChecked(pref->useSystemIconTheme());
-    addRow(USE_ICON_THEME, tr("Use system icon theme"), &cb_use_icon_theme);
 #endif
     // Torrent recheck confirmation
     cb_confirm_torrent_recheck.setChecked(pref->confirmTorrentRecheck());

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -87,10 +87,6 @@ private:
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     QCheckBox cb_update_check;
 #endif
-
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
-    QCheckBox cb_use_icon_theme;
-#endif
 };
 
 #endif // ADVANCEDSETTINGS_H

--- a/src/gui/guiiconprovider.cpp
+++ b/src/gui/guiiconprovider.cpp
@@ -43,7 +43,9 @@ GuiIconProvider::GuiIconProvider(QObject *parent)
     connect(Preferences::instance(), SIGNAL(changed()), SLOT(configure()));
 }
 
-GuiIconProvider::~GuiIconProvider() {}
+GuiIconProvider::~GuiIconProvider()
+{
+}
 
 void GuiIconProvider::initInstance()
 {
@@ -117,6 +119,7 @@ QIcon GuiIconProvider::generateDifferentSizes(const QIcon &icon)
 
     return newIcon;
 }
+
 #endif
 
 QString GuiIconProvider::getIconPath(const QString &iconId)
@@ -137,7 +140,6 @@ QString GuiIconProvider::getIconPath(const QString &iconId)
 #endif
     return IconProvider::getIconPath(iconId);
 }
-
 
 void GuiIconProvider::configure()
 {

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -776,7 +776,7 @@ void MainWindow::createKeyboardShortcuts()
     m_ui->actionDocumentation->setShortcut(QKeySequence::HelpContents);
     m_ui->actionOptions->setShortcut(Qt::ALT + Qt::Key_O);
     m_ui->actionStart->setShortcut(Qt::CTRL + Qt::Key_S);
-    m_ui->actionStartAll->setShortcut(Qt::CTRL + Qt::SHIFT +Qt::Key_S);
+    m_ui->actionStartAll->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_S);
     m_ui->actionPause->setShortcut(Qt::CTRL + Qt::Key_P);
     m_ui->actionPauseAll->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_P);
     m_ui->actionBottomPriority->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_Minus);

--- a/src/gui/optionsdlg.cpp
+++ b/src/gui/optionsdlg.cpp
@@ -77,7 +77,9 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     setModal(true);
 
     // Icons
-    m_ui->tabSelection->item(TAB_UI)->setIcon(GuiIconProvider::instance()->getIcon("preferences-desktop"));
+    // TODO fix up icons
+    m_ui->tabSelection->item(TAB_APPEARANCE)->setIcon(QIcon());
+    m_ui->tabSelection->item(TAB_BEHAVIOUR)->setIcon(GuiIconProvider::instance()->getIcon("preferences-desktop"));
     m_ui->tabSelection->item(TAB_BITTORRENT)->setIcon(GuiIconProvider::instance()->getIcon("preferences-system-network"));
     m_ui->tabSelection->item(TAB_CONNECTION)->setIcon(GuiIconProvider::instance()->getIcon("network-wired"));
     m_ui->tabSelection->item(TAB_DOWNLOADS)->setIcon(GuiIconProvider::instance()->getIcon("folder-download"));
@@ -120,6 +122,13 @@ OptionsDialog::OptionsDialog(QWidget *parent)
             break;
         }
     }
+
+#if !((defined(Q_OS_UNIX) && !defined(Q_OS_MAC)))
+    m_ui->checkUseSystemTheme->setHidden(true);
+#endif
+
+    // Hide the Appearance/Desktop section if it doesn't contain any visible children.
+    m_ui->groupBoxAppearanceDesktop->setHidden(m_ui->groupBoxAppearanceDesktop->childrenRect().isEmpty());
 
 #ifndef QBT_USES_QT5
     m_ui->scanFoldersView->header()->setResizeMode(QHeaderView::ResizeToContents);
@@ -170,6 +179,9 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     // General tab
     connect(m_ui->comboI18n, SIGNAL(currentIndexChanged(int)), this, SLOT(enableApplyButton()));
     connect(m_ui->confirmDeletion, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+    connect(m_ui->checkUseSystemTheme, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
+#endif
     connect(m_ui->checkAltRowColors, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
     connect(m_ui->checkHideZero, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
     connect(m_ui->checkHideZero, SIGNAL(toggled(bool)), m_ui->comboHideZero, SLOT(setEnabled(bool)));
@@ -459,6 +471,9 @@ void OptionsDialog::saveOptions()
     pref->setLocale(locale);
     pref->setConfirmTorrentDeletion(m_ui->confirmDeletion->isChecked());
     pref->setAlternatingRowColors(m_ui->checkAltRowColors->isChecked());
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+    pref->setSystemIconTheme(m_ui->checkUseSystemTheme->isChecked());
+#endif
     pref->setHideZeroValues(m_ui->checkHideZero->isChecked());
     pref->setHideZeroComboValues(m_ui->comboHideZero->currentIndex());
     pref->setSystrayIntegration(systrayIntegration());
@@ -664,6 +679,9 @@ void OptionsDialog::loadOptions()
     setLocale(pref->getLocale());
     m_ui->confirmDeletion->setChecked(pref->confirmTorrentDeletion());
     m_ui->checkAltRowColors->setChecked(pref->useAlternatingRowColors());
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+    m_ui->checkUseSystemTheme->setChecked(pref->useSystemIconTheme());
+#endif
     m_ui->checkHideZero->setChecked(pref->getHideZeroValues());
     m_ui->comboHideZero->setEnabled(m_ui->checkHideZero->isChecked());
     m_ui->comboHideZero->setCurrentIndex(pref->getHideZeroComboValues());

--- a/src/gui/optionsdlg.h
+++ b/src/gui/optionsdlg.h
@@ -64,7 +64,8 @@ class OptionsDialog: public QDialog
 private:
     enum Tabs
     {
-        TAB_UI,
+        TAB_APPEARANCE,
+        TAB_BEHAVIOUR,
         TAB_DOWNLOADS,
         TAB_CONNECTION,
         TAB_SPEED,

--- a/src/gui/optionsdlg.h
+++ b/src/gui/optionsdlg.h
@@ -60,6 +60,7 @@ namespace Ui
 class OptionsDialog: public QDialog
 {
     Q_OBJECT
+
 private:
     enum Tabs
     {
@@ -85,9 +86,9 @@ private slots:
     void on_buttonBox_accepted();
     void closeEvent(QCloseEvent *e);
     void on_buttonBox_rejected();
-    void applySettings(QAbstractButton* button);
+    void applySettings(QAbstractButton *button);
     void enableApplyButton();
-    void changePage(QListWidgetItem*, QListWidgetItem*);
+    void changePage(QListWidgetItem *, QListWidgetItem *);
     void loadWindowState();
     void saveWindowState() const;
     void handleScanFolderViewSelectionChanged();
@@ -130,7 +131,7 @@ private:
     bool addTorrentsInPause() const;
     QString getTorrentExportDir() const;
     QString getFinishedTorrentExportDir() const;
-    QString askForExportDir(const QString& currentExportPath);
+    QString askForExportDir(const QString &currentExportPath);
     int getActionOnDblClOnTorrentDl() const;
     int getActionOnDblClOnTorrentFn() const;
     // Connection options

--- a/src/gui/optionsdlg.ui
+++ b/src/gui/optionsdlg.ui
@@ -49,6 +49,11 @@
       </property>
       <item>
        <property name="text">
+        <string>Appearance</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
         <string>Behavior</string>
        </property>
       </item>
@@ -87,8 +92,8 @@
       <property name="currentIndex">
        <number>0</number>
       </property>
-      <widget class="QWidget" name="tabBehaviorPage">
-       <layout class="QVBoxLayout" name="verticalLayout_10">
+      <widget class="QWidget" name="tabAppearancePage">
+       <layout class="QVBoxLayout" name="verticalLayout_21">
         <property name="leftMargin">
          <number>0</number>
         </property>
@@ -102,7 +107,7 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QScrollArea" name="scrollArea">
+         <widget class="QScrollArea" name="scrollArea_5">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -112,16 +117,16 @@
           <property name="widgetResizable">
            <bool>true</bool>
           </property>
-          <widget class="QWidget" name="scrollAreaWidgetContents">
+          <widget class="QWidget" name="scrollAreaWidgetContents_5">
            <property name="geometry">
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>497</width>
-             <height>880</height>
+             <width>518</width>
+             <height>538</height>
             </rect>
            </property>
-           <layout class="QVBoxLayout" name="verticalLayout_9">
+           <layout class="QVBoxLayout" name="verticalLayout_25">
             <item>
              <widget class="QGroupBox" name="UISettingsBox">
               <property name="title">
@@ -187,6 +192,95 @@
              </widget>
             </item>
             <item>
+             <widget class="QGroupBox" name="groupBoxAppearanceDesktop">
+              <property name="title">
+               <string>Desktop</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_27">
+               <item>
+                <widget class="QCheckBox" name="checkUseSystemTheme">
+                 <property name="text">
+                  <string>Use system icon theme</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupBox_5">
+              <property name="title">
+               <string>Transfer List</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_26">
+               <item>
+                <widget class="QCheckBox" name="checkAltRowColors">
+                 <property name="text">
+                  <string extracomment="In transfer list, one every two rows will have grey background.">Use alternating row colors</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_5">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="tabBehaviorPage">
+       <layout class="QVBoxLayout" name="verticalLayout_10">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QScrollArea" name="scrollArea">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <widget class="QWidget" name="scrollAreaWidgetContents">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>0</y>
+             <width>504</width>
+             <height>849</height>
+            </rect>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_9">
+            <item>
              <widget class="QGroupBox" name="groupBox_4">
               <property name="title">
                <string>Transfer List</string>
@@ -196,16 +290,6 @@
                 <widget class="QCheckBox" name="confirmDeletion">
                  <property name="text">
                   <string>Confirm when deleting torrents</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="checkAltRowColors">
-                 <property name="text">
-                  <string extracomment="In transfer list, one every two rows will have grey background.">Use alternating row colors</string>
                  </property>
                  <property name="checked">
                   <bool>true</bool>
@@ -673,8 +757,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>586</width>
-             <height>1118</height>
+             <width>524</width>
+             <height>1167</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout">
@@ -1348,8 +1432,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>457</width>
-             <height>672</height>
+             <width>418</width>
+             <height>700</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -1821,8 +1905,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>388</width>
-             <height>452</height>
+             <width>328</width>
+             <height>478</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -2208,8 +2292,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>574</width>
-             <height>534</height>
+             <width>515</width>
+             <height>569</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -2605,8 +2689,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>438</width>
-             <height>543</height>
+             <width>393</width>
+             <height>555</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -3000,7 +3084,6 @@
  </widget>
  <tabstops>
   <tabstop>tabOption</tabstop>
-  <tabstop>comboI18n</tabstop>
   <tabstop>textSavePath</tabstop>
   <tabstop>browseSaveDirButton</tabstop>
   <tabstop>checkStartPaused</tabstop>


### PR DESCRIPTION
Moves existing options to a new "Appearance tab" as discussed in issue #6363.

![appearance_prefs](https://cloud.githubusercontent.com/assets/1728015/22773570/fa0babf8-eef6-11e6-9314-e6bc458e6f67.png)

Changed preferences icons:

Existing _Behaviour_ icon moved to _Appearance_.
_Behaviour_ now has the gear icon. 
WebUI icon changed to `qbt-theme/webui.png` (which I think it was probably intended to be).

2 new signals emitted from `Preferences` when theme-related options are changed or dark/light theme change detected:

- `Preferences::configureThemeProvider()` emitted first, theme providers (e.g. `GuiIconProvider`) need to connect directly to ensure they are configured before being used;

- `Preferences::themeChanged()` for components that need to update themselves when a theme change occurs.

Both of these signals are emitted before `Preferences::changed()`.