### PR TITLE
Remove exception suppressing from torrenthandle.cpp

### DIFF
--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -153,42 +153,6 @@ TorrentState::operator int() const
 
 // TorrentHandle
 
-#define SAFE_CALL(func, ...) \
-    try { \
-        m_nativeHandle.func(__VA_ARGS__); \
-    } \
-    catch (std::exception &exc) { \
-        qDebug() << Q_FUNC_INFO << " throws exception: " << exc.what(); \
-    }
-
-#define SAFE_CALL_BOOL(func, ...) \
-    try { \
-        m_nativeHandle.func(__VA_ARGS__); \
-        return true; \
-    } \
-    catch (std::exception &exc) { \
-        qDebug() << Q_FUNC_INFO << " throws exception: " << exc.what(); \
-        return false; \
-    }
-
-#define SAFE_RETURN(type, func, val) \
-    type result = val; \
-    try { \
-        result = m_nativeHandle.func(); \
-    } \
-    catch (std::exception &exc) { \
-        qDebug() << Q_FUNC_INFO << " throws exception: " << exc.what(); \
-    } \
-    return result;
-
-#define SAFE_GET(var, func, ...) \
-    try { \
-        var = m_nativeHandle.func(__VA_ARGS__); \
-    } \
-    catch (std::exception &exc) { \
-        qDebug() << Q_FUNC_INFO << " throws exception: " << exc.what(); \
-    }
-
 const qreal TorrentHandle::USE_GLOBAL_RATIO = -2.;
 const qreal TorrentHandle::NO_RATIO_LIMIT = -1.;
 
@@ -378,8 +342,8 @@ QList<TrackerEntry> TorrentHandle::trackers() const
 {
     QList<TrackerEntry> entries;
     std::vector<libt::announce_entry> announces;
-    SAFE_GET(announces, trackers);
 
+    announces = m_nativeHandle.trackers();
     foreach (const libt::announce_entry &tracker, announces)
         entries << tracker;
 
@@ -417,21 +381,15 @@ void TorrentHandle::replaceTrackers(QList<TrackerEntry> trackers)
             existingTrackers.removeOne(tracker);
     }
 
-    try {
-        m_nativeHandle.replace_trackers(announces);
-        if (addedTrackers.isEmpty() && existingTrackers.isEmpty()) {
-            m_session->handleTorrentTrackersChanged(this);
-        }
-        else {
-            if (!existingTrackers.isEmpty())
-                m_session->handleTorrentTrackersRemoved(this, existingTrackers);
-            if (!addedTrackers.isEmpty())
-                m_session->handleTorrentTrackersAdded(this, addedTrackers);
-        }
-
+    m_nativeHandle.replace_trackers(announces);
+    if (addedTrackers.isEmpty() && existingTrackers.isEmpty()) {
+        m_session->handleTorrentTrackersChanged(this);
     }
-    catch (std::exception &exc) {
-        qDebug("torrent_handle::replace_trackers() throws exception: %s", exc.what());
+    else {
+        if (!existingTrackers.isEmpty())
+            m_session->handleTorrentTrackersRemoved(this, existingTrackers);
+        if (!addedTrackers.isEmpty())
+            m_session->handleTorrentTrackersAdded(this, addedTrackers);
     }
 }
 
@@ -440,14 +398,14 @@ bool TorrentHandle::addTracker(const TrackerEntry &tracker)
     if (trackers().contains(tracker))
         return false;
 
-    SAFE_CALL_BOOL(add_tracker, tracker.nativeEntry());
+    m_nativeHandle.add_tracker(tracker.nativeEntry());
+    return true;
 }
 
 QList<QUrl> TorrentHandle::urlSeeds() const
 {
     QList<QUrl> urlSeeds;
-    std::set<std::string> seeds;
-    SAFE_GET(seeds, url_seeds);
+    std::set<std::string> seeds = m_nativeHandle.url_seeds();
 
     foreach (const std::string &urlSeed, seeds)
         urlSeeds.append(QUrl(urlSeed.c_str()));
@@ -484,7 +442,8 @@ bool TorrentHandle::addUrlSeed(const QUrl &urlSeed)
     QList<QUrl> seeds = urlSeeds();
     if (seeds.contains(urlSeed)) return false;
 
-    SAFE_CALL_BOOL(add_url_seed, Utils::String::toStdString(urlSeed.toString()));
+    m_nativeHandle.add_url_seed(Utils::String::toStdString(urlSeed.toString()));
+    return true;
 }
 
 bool TorrentHandle::removeUrlSeed(const QUrl &urlSeed)
@@ -492,7 +451,8 @@ bool TorrentHandle::removeUrlSeed(const QUrl &urlSeed)
     QList<QUrl> seeds = urlSeeds();
     if (!seeds.contains(urlSeed)) return false;
 
-    SAFE_CALL_BOOL(remove_url_seed, Utils::String::toStdString(urlSeed.toString()));
+    m_nativeHandle.remove_url_seed(Utils::String::toStdString(urlSeed.toString()));
+    return true;
 }
 
 bool TorrentHandle::connectPeer(const PeerAddress &peerAddress)
@@ -502,14 +462,15 @@ bool TorrentHandle::connectPeer(const PeerAddress &peerAddress)
     if (ec) return false;
 
     boost::asio::ip::tcp::endpoint ep(addr, peerAddress.port);
-    SAFE_CALL_BOOL(connect_peer, ep);
+    m_nativeHandle.connect_peer(ep);
+    return true;
 }
 
 bool TorrentHandle::needSaveResumeData() const
 {
     if (m_needSaveResumeData) return true;
 
-    SAFE_RETURN(bool, need_save_resume_data, false);
+    return m_nativeHandle.need_save_resume_data();
 }
 
 void TorrentHandle::saveResumeData(bool updateStatus)
@@ -517,7 +478,7 @@ void TorrentHandle::saveResumeData(bool updateStatus)
     if (updateStatus) // to update queue_position, see discussion in PR #6154
         this->updateStatus();
 
-    SAFE_CALL(save_resume_data);
+    m_nativeHandle.save_resume_data();
     m_needSaveResumeData = false;
 }
 
@@ -613,7 +574,7 @@ QStringList TorrentHandle::absoluteFilePathsUnwanted() const
     QDir saveDir(savePath(true));
     QStringList res;
     std::vector<int> fp;
-    SAFE_GET(fp, file_priorities);
+    fp = m_nativeHandle.file_priorities();
 
     int count = static_cast<int>(fp.size());
     for (int i = 0; i < count; ++i) {
@@ -630,7 +591,7 @@ QStringList TorrentHandle::absoluteFilePathsUnwanted() const
 QVector<int> TorrentHandle::filePriorities() const
 {
     std::vector<int> fp;
-    SAFE_GET(fp, file_priorities);
+    fp = m_nativeHandle.file_priorities();
 
     return QVector<int>::fromStdVector(fp);
 }
@@ -718,7 +679,9 @@ bool TorrentHandle::isErrored() const
 bool TorrentHandle::isSeed() const
 {
     // Affected by bug http://code.rasterbar.com/libtorrent/ticket/402
-    //SAFE_RETURN(bool, is_seed, false);
+    //bool result;
+    //result = m_nativeHandle.is_seed());
+    //return result;
     // May suffer from approximation problems
     //return (progress() == 1.);
     // This looks safe
@@ -742,7 +705,7 @@ bool TorrentHandle::hasFirstLastPiecePriority() const
 
     // Get int first media file
     std::vector<int> fp;
-    SAFE_GET(fp, file_priorities);
+    fp = m_nativeHandle.file_priorities();
 
     TorrentInfo::PieceRange extremities;
     bool found = false;
@@ -758,10 +721,8 @@ bool TorrentHandle::hasFirstLastPiecePriority() const
 
     if (!found) return false; // No media file
 
-    int first = 0;
-    int last = 0;
-    SAFE_GET(first, piece_priority, extremities.first());
-    SAFE_GET(last, piece_priority, extremities.last());
+    int first = m_nativeHandle.piece_priority(extremities.first());
+    int last = m_nativeHandle.piece_priority(extremities.last());
 
     return ((first == 7) && (last == 7));
 }
@@ -840,8 +801,7 @@ bool TorrentHandle::hasError() const
 
 bool TorrentHandle::hasFilteredPieces() const
 {
-    std::vector<int> pp;
-    SAFE_GET(pp, piece_priorities);
+    std::vector<int> pp = m_nativeHandle.piece_priorities();
 
     foreach (const int priority, pp)
         if (priority == 0) return true;
@@ -914,7 +874,7 @@ QVector<qreal> TorrentHandle::filesProgress() const
 {
     std::vector<boost::int64_t> fp;
     QVector<qreal> result;
-    SAFE_CALL(file_progress, fp, libt::torrent_handle::piece_granularity);
+    m_nativeHandle.file_progress(fp, libt::torrent_handle::piece_granularity);
 
     int count = static_cast<int>(fp.size());
     for (int i = 0; i < count; ++i) {
@@ -1007,12 +967,12 @@ int TorrentHandle::timeSinceActivity() const
 
 int TorrentHandle::downloadLimit() const
 {
-    SAFE_RETURN(int, download_limit, -1)
+    return m_nativeHandle.download_limit();
 }
 
 int TorrentHandle::uploadLimit() const
 {
-    SAFE_RETURN(int, upload_limit, -1)
+    return m_nativeHandle.upload_limit();
 }
 
 bool TorrentHandle::superSeeding() const
@@ -1025,7 +985,7 @@ QList<PeerInfo> TorrentHandle::peers() const
     QList<PeerInfo> peers;
     std::vector<libt::peer_info> nativePeers;
 
-    SAFE_CALL(get_peer_info, nativePeers);
+    m_nativeHandle.get_peer_info(nativePeers);
 
     foreach (const libt::peer_info &peer, nativePeers)
         peers << PeerInfo(this, peer);
@@ -1048,7 +1008,7 @@ QBitArray TorrentHandle::downloadingPieces() const
     QBitArray result(piecesCount());
 
     std::vector<libt::partial_piece_info> queue;
-    SAFE_CALL(get_download_queue, queue);
+    m_nativeHandle.get_download_queue(queue);
 
     std::vector<libt::partial_piece_info>::const_iterator it = queue.begin();
     std::vector<libt::partial_piece_info>::const_iterator itend = queue.end();
@@ -1061,7 +1021,7 @@ QBitArray TorrentHandle::downloadingPieces() const
 QVector<int> TorrentHandle::pieceAvailability() const
 {
     std::vector<int> avail;
-    SAFE_CALL(piece_availability, avail);
+    m_nativeHandle.piece_availability(avail);
 
     return QVector<int>::fromStdVector(avail);
 }
@@ -1206,12 +1166,12 @@ void TorrentHandle::move_impl(QString path)
 
 void TorrentHandle::forceReannounce(int index)
 {
-    SAFE_CALL(force_reannounce, 0, index);
+    m_nativeHandle.force_reannounce(0, index);
 }
 
 void TorrentHandle::forceDHTAnnounce()
 {
-    SAFE_CALL(force_dht_announce);
+    m_nativeHandle.force_dht_announce();
 }
 
 void TorrentHandle::forceRecheck()
@@ -1223,13 +1183,13 @@ void TorrentHandle::forceRecheck()
         resume();
     }
 
-    SAFE_CALL(force_recheck);
+    m_nativeHandle.force_recheck();
 }
 
 void TorrentHandle::setSequentialDownload(bool b)
 {
     if (b != isSequentialDownload()) {
-        SAFE_CALL(set_sequential_download, b);
+        m_nativeHandle.set_sequential_download(b);
         m_nativeStatus.sequential_download = b; // prevent return cached value
     }
 }
@@ -1243,10 +1203,8 @@ void TorrentHandle::setFirstLastPiecePriority(bool b)
 {
     if (!hasMetadata()) return;
 
-    std::vector<int> fp;
-    SAFE_GET(fp, file_priorities);
-    std::vector<int> pp;
-    SAFE_GET(pp, piece_priorities);
+    std::vector<int> fp = m_nativeHandle.file_priorities();
+    std::vector<int> pp = m_nativeHandle.piece_priorities();
 
     // Download first and last pieces first for all media files in the torrent
     int nbfiles = static_cast<int>(fp.size());
@@ -1270,7 +1228,7 @@ void TorrentHandle::setFirstLastPiecePriority(bool b)
         }
     }
 
-    SAFE_CALL(prioritize_pieces, pp);
+    m_nativeHandle.prioritize_pieces(pp);
 }
 
 void TorrentHandle::toggleFirstLastPiecePriority()
@@ -1282,28 +1240,18 @@ void TorrentHandle::pause()
 {
     if (isPaused()) return;
 
-    try {
-        m_nativeHandle.auto_managed(false);
-        m_nativeHandle.pause();
-    }
-    catch (std::exception &exc) {
-        qDebug() << Q_FUNC_INFO << " throws exception: " << exc.what();
-    }
+    m_nativeHandle.auto_managed(false);
+    m_nativeHandle.pause();
 }
 
 void TorrentHandle::resume(bool forced)
 {
-    try {
-        if (hasError())
-            m_nativeHandle.clear_error();
-        m_hasMissingFiles = false;
-        m_nativeHandle.set_upload_mode(false);
-        m_nativeHandle.auto_managed(!forced);
-        m_nativeHandle.resume();
-    }
-    catch (std::exception &exc) {
-        qDebug() << Q_FUNC_INFO << " throws exception: " << exc.what();
-    }
+    if (hasError())
+        m_nativeHandle.clear_error();
+    m_hasMissingFiles = false;
+    m_nativeHandle.set_upload_mode(false);
+    m_nativeHandle.auto_managed(!forced);
+    m_nativeHandle.resume();
 }
 
 void TorrentHandle::moveStorage(const QString &newPath)
@@ -1317,28 +1265,24 @@ void TorrentHandle::moveStorage(const QString &newPath)
         if (QDir(oldPath) == QDir(newPath)) return;
 
         qDebug("move storage: %s to %s", qPrintable(oldPath), qPrintable(newPath));
-        try {
-            // Actually move the storage
-            m_nativeHandle.move_storage(newPath.toUtf8().constData());
-            m_oldPath = oldPath;
-            m_newPath = newPath;
-        }
-        catch (std::exception &exc) {
-            qDebug("torrent_handle::move_storage() throws exception: %s", exc.what());
-        }
+        // Actually move the storage
+        m_nativeHandle.move_storage(newPath.toUtf8().constData());
+        m_oldPath = oldPath;
+        m_newPath = newPath;
     }
 }
 
 void TorrentHandle::setTrackerLogin(const QString &username, const QString &password)
 {
-    SAFE_CALL(set_tracker_login, std::string(username.toLocal8Bit().constData()), std::string(password.toLocal8Bit().constData()));
+    m_nativeHandle.set_tracker_login(std::string(username.toLocal8Bit().constData())
+                                     , std::string(password.toLocal8Bit().constData()));
 }
 
 void TorrentHandle::renameFile(int index, const QString &name)
 {
     ++m_renameCount;
     qDebug() << Q_FUNC_INFO << index << name;
-    SAFE_CALL(rename_file, index, Utils::String::toStdString(Utils::Fs::toNativePath(name)));
+    m_nativeHandle.rename_file(index, Utils::String::toStdString(Utils::Fs::toNativePath(name)));
 }
 
 bool TorrentHandle::saveTorrentFile(const QString &path)
@@ -1359,8 +1303,7 @@ bool TorrentHandle::saveTorrentFile(const QString &path)
 
 void TorrentHandle::setFilePriority(int index, int priority)
 {
-    std::vector<int> priorities;
-    SAFE_GET(priorities, file_priorities);
+    std::vector<int> priorities = m_nativeHandle.file_priorities();
 
     if ((priorities.size() > static_cast<quint64>(index)) && (priorities[index] != priority)) {
         priorities[index] = priority;
@@ -1805,10 +1748,7 @@ bool TorrentHandle::useTempPath() const
 
 void TorrentHandle::updateStatus()
 {
-    libt::torrent_status status;
-    SAFE_GET(status, status);
-
-    updateStatus(status);
+    updateStatus(m_nativeHandle.status());
 }
 
 void TorrentHandle::updateStatus(const libtorrent::torrent_status &nativeStatus)
@@ -1835,24 +1775,24 @@ void TorrentHandle::setRatioLimit(qreal limit)
 
 void TorrentHandle::setUploadLimit(int limit)
 {
-    SAFE_CALL(set_upload_limit, limit)
+    m_nativeHandle.set_upload_limit(limit);
 }
 
 void TorrentHandle::setDownloadLimit(int limit)
 {
-    SAFE_CALL(set_download_limit, limit)
+    m_nativeHandle.set_download_limit(limit);
 }
 
 void TorrentHandle::setSuperSeeding(bool enable)
 {
-    SAFE_CALL(super_seeding, enable)
+    m_nativeHandle.super_seeding(enable);
     if (superSeeding() != enable)
         updateStatus();
 }
 
 void TorrentHandle::flushCache()
 {
-    SAFE_CALL(flush_cache)
+    m_nativeHandle.flush_cache();
 }
 
 QString TorrentHandle::toMagnetUri() const
@@ -1880,7 +1820,7 @@ void TorrentHandle::prioritizeFiles(const QVector<int> &priorities)
     }
 
     qDebug() << Q_FUNC_INFO << "Changing files priorities...";
-    SAFE_CALL(prioritize_files, priorities.toStdVector());
+    m_nativeHandle.prioritize_files(priorities.toStdVector());
 
     qDebug() << Q_FUNC_INFO << "Moving unwanted files to .unwanted folder and conversely...";
     QString spath = savePath(true);


### PR DESCRIPTION
<del>Now we need to write the libtorrent::torrent_handle method calls in the correct form, which should improve code maintainability and allow to use advanced code navigation features of QtCreator (and of other IDEs).</del>

Remove SAFE_* macros from TorrentHandle class.
Using these macros don't seem necessary.