### PR TITLE
Allow QSsl::Ec as private key format

### DIFF
--- a/src/gui/optionsdlg.cpp
+++ b/src/gui/optionsdlg.cpp
@@ -978,8 +978,8 @@ void OptionsDialog::loadOptions()
     m_ui->spinWebUiPort->setValue(pref->getWebUiPort());
     m_ui->checkWebUIUPnP->setChecked(pref->useUPnPForWebUIPort());
     m_ui->checkWebUiHttps->setChecked(pref->isWebUiHttpsEnabled());
-    setSslCertificate(pref->getWebUiHttpsCertificate(), false);
-    setSslKey(pref->getWebUiHttpsKey(), false);
+    setSslCertificate(pref->getWebUiHttpsCertificate());
+    setSslKey(pref->getWebUiHttpsKey());
     m_ui->textWebUiUsername->setText(pref->getWebUiUsername());
     m_ui->textWebUiPassword->setText(pref->getWebUiPassword());
     m_ui->checkBypassLocalAuth->setChecked(!pref->isWebUiLocalAuthEnabled());
@@ -1511,26 +1511,32 @@ void OptionsDialog::showConnectionTab()
 
 void OptionsDialog::on_btnWebUiCrt_clicked()
 {
-    QString filename = QFileDialog::getOpenFileName(this, QString(), QString(), tr("SSL Certificate") + QString(" (*.crt *.pem)"));
-    if (filename.isNull())
+    const QString filename = QFileDialog::getOpenFileName(this, tr("Import SSL certificate"), QString(), tr("SSL Certificate") + QLatin1String(" (*.crt *.pem)"));
+    if (filename.isEmpty())
         return;
-    QFile file(filename);
-    if (file.open(QIODevice::ReadOnly)) {
-        setSslCertificate(file.readAll());
-        file.close();
-    }
+
+    QFile cert(filename);
+    if (!cert.open(QIODevice::ReadOnly))
+        return;
+
+    bool success = setSslCertificate(cert.read(1024 * 1024));
+    if (!success)
+        QMessageBox::warning(this, tr("Invalid certificate"), tr("This is not a valid SSL certificate."));
 }
 
 void OptionsDialog::on_btnWebUiKey_clicked()
 {
-    QString filename = QFileDialog::getOpenFileName(this, QString(), QString(), tr("SSL Key") + QString(" (*.key *.pem)"));
-    if (filename.isNull())
+    const QString filename = QFileDialog::getOpenFileName(this, tr("Import SSL key"), QString(), tr("SSL key") + QLatin1String(" (*.key *.pem)"));
+    if (filename.isEmpty())
         return;
-    QFile file(filename);
-    if (file.open(QIODevice::ReadOnly)) {
-        setSslKey(file.readAll());
-        file.close();
-    }
+
+    QFile key(filename);
+    if (!key.open(QIODevice::ReadOnly))
+        return;
+
+    bool success = setSslKey(key.read(1024 * 1024));
+    if (!success)
+        QMessageBox::warning(this, tr("Invalid key"), tr("This is not a valid SSL key."));
 }
 
 void OptionsDialog::on_registerDNSBtn_clicked()
@@ -1638,41 +1644,42 @@ QString OptionsDialog::languageToLocalizedString(const QLocale &locale)
     }
 }
 
-void OptionsDialog::setSslKey(const QByteArray &key, bool interactive)
+bool OptionsDialog::setSslKey(const QByteArray &key)
 {
 #ifndef QT_NO_OPENSSL
-    if (!key.isEmpty() && !QSslKey(key, QSsl::Rsa).isNull()) {
+    // try different formats
+    const bool isKeyValid = (!QSslKey(key, QSsl::Rsa).isNull() || !QSslKey(key, QSsl::Ec).isNull());
+    if (isKeyValid) {
         m_ui->lblSslKeyStatus->setPixmap(QPixmap(":/icons/qbt-theme/security-high.png").scaledToHeight(20, Qt::SmoothTransformation));
         m_sslKey = key;
     }
     else {
         m_ui->lblSslKeyStatus->setPixmap(QPixmap(":/icons/qbt-theme/security-low.png").scaledToHeight(20, Qt::SmoothTransformation));
         m_sslKey.clear();
-        if (interactive)
-            QMessageBox::warning(this, tr("Invalid key"), tr("This is not a valid SSL key."));
     }
+    return isKeyValid;
 #else
     Q_UNUSED(key);
-    Q_UNUSED(interactive);
+    return false;
 #endif
 }
 
-void OptionsDialog::setSslCertificate(const QByteArray &cert, bool interactive)
+bool OptionsDialog::setSslCertificate(const QByteArray &cert)
 {
 #ifndef QT_NO_OPENSSL
-    if (!cert.isEmpty() && !QSslCertificate(cert).isNull()) {
+    const bool isCertValid = !QSslCertificate(cert).isNull();
+    if (isCertValid) {
         m_ui->lblSslCertStatus->setPixmap(QPixmap(":/icons/qbt-theme/security-high.png").scaledToHeight(20, Qt::SmoothTransformation));
         m_sslCert = cert;
     }
     else {
         m_ui->lblSslCertStatus->setPixmap(QPixmap(":/icons/qbt-theme/security-low.png").scaledToHeight(20, Qt::SmoothTransformation));
         m_sslCert.clear();
-        if (interactive)
-            QMessageBox::warning(this, tr("Invalid certificate"), tr("This is not a valid SSL certificate."));
     }
+    return isCertValid;
 #else
     Q_UNUSED(cert);
-    Q_UNUSED(interactive);
+    return false;
 #endif
 }
 

--- a/src/gui/optionsdlg.h
+++ b/src/gui/optionsdlg.h
@@ -171,8 +171,8 @@ private:
     QSize sizeFittingScreen() const;
 
 private:
-    void setSslKey(const QByteArray &key, bool interactive = true);
-    void setSslCertificate(const QByteArray &cert, bool interactive = true);
+    bool setSslKey(const QByteArray &key);
+    bool setSslCertificate(const QByteArray &cert);
     bool schedTimesOk();
     bool webUIAuthenticationOk();
 


### PR DESCRIPTION
* This allows qbt to load/use ECDSA certificate in webUI
  Limit max read size
  Improve messages in dialogs
  Refactor



**Merge this after Qt4 is dropped (PR #6266)**