### PR TITLE
Code cleanup and optimizations to download rules

### DIFF
--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -47,6 +47,7 @@ HEADERS += \
     $$PWD/rss/rssfile.h \
     $$PWD/rss/rssarticle.h \
     $$PWD/rss/rssdownloadrule.h \
+    $$PWD/rss/rssdownloadrule_p.h \
     $$PWD/rss/rssdownloadrulelist.h \
     $$PWD/rss/private/rssparser.h \
     $$PWD/utils/fs.h \
@@ -103,6 +104,7 @@ SOURCES += \
     $$PWD/rss/rssfolder.cpp \
     $$PWD/rss/rssarticle.cpp \
     $$PWD/rss/rssdownloadrule.cpp \
+    $$PWD/rss/rssdownloadrule_p.cpp \
     $$PWD/rss/rssdownloadrulelist.cpp \
     $$PWD/rss/rssfile.cpp \
     $$PWD/rss/private/rssparser.cpp \

--- a/src/base/rss/rssdownloadrule.cpp
+++ b/src/base/rss/rssdownloadrule.cpp
@@ -147,7 +147,7 @@ bool DownloadRule::matches(const QString &articleTitle) const
 
     if (!m_episodeFilter.isEmpty()) {
         qDebug() << "Checking episode filter:" << m_episodeFilter;
-        QRegularExpression f(cachedRegex("(^\\d{1,4})x(.*;$)"));
+        QRegularExpression f(cachedRegex("(^\\d{1,4})x(.+;$)"));
         QRegularExpressionMatch matcher = f.match(m_episodeFilter);
         bool matched = matcher.hasMatch();
 
@@ -188,7 +188,9 @@ bool DownloadRule::matches(const QString &articleTitle) const
                         int sTheirs = matcher.captured(1).toInt();
                         int epTheirs = matcher.captured(2).toInt();
                         if (((sTheirs == sOurs) && (epTheirs >= epOurs)) || (sTheirs > sOurs)) {
-                            qDebug() << "Matched episode:" << ep;
+                            qDebug() << "Matched episode:";
+                            qDebug() << "    Filter: " << s << "x" << ep;
+                            qDebug() << "    Article:" << sTheirs << "x" << epTheirs;
                             qDebug() << "Matched article:" << articleTitle;
                             return true;
                         }
@@ -217,7 +219,9 @@ bool DownloadRule::matches(const QString &articleTitle) const
                         int sTheirs = matcher.captured(1).toInt();
                         int epTheirs = matcher.captured(2).toInt();
                         if ((sTheirs == sOurs) && ((epOursFirst <= epTheirs) && (epOursLast >= epTheirs))) {
-                            qDebug() << "Matched episode:" << ep;
+                            qDebug() << "Matched episode:";
+                            qDebug() << "    Filter: " << s << "x" << ep;
+                            qDebug() << "    Article:" << sTheirs << "x" << epTheirs;
                             qDebug() << "Matched article:" << articleTitle;
                             return true;
                         }
@@ -228,7 +232,7 @@ bool DownloadRule::matches(const QString &articleTitle) const
                 QString expStr("\\b(?:s0?" + s + "[ -_\\.]?" + "e0?" + ep + "|" + s + "x" + "0?" + ep + ")(?:\\D|\\b)");
                 QRegularExpression reg(cachedRegex(expStr));
                 if (reg.match(articleTitle).hasMatch()) {
-                    qDebug() << "Matched episode:" << ep;
+                    qDebug() << "Matched episode:" << s << "x" << ep;
                     qDebug() << "Matched article:" << articleTitle;
                     return true;
                 }

--- a/src/base/rss/rssdownloadrule.cpp
+++ b/src/base/rss/rssdownloadrule.cpp
@@ -28,68 +28,55 @@
  * Contact : chris@qbittorrent.org
  */
 
+#include "rssdownloadrule.h"
+#include "rssdownloadrule_p.h"
+
 #include <QDebug>
 #include <QDir>
 #include <QHash>
-#include <QRegExp>
 #include <QRegularExpression>
 #include <QString>
 #include <QStringList>
+#include <QSharedData>
 
 #include "base/preferences.h"
 #include "base/utils/fs.h"
 #include "base/utils/string.h"
 #include "rssfeed.h"
 #include "rssarticle.h"
-#include "rssdownloadrule.h"
 
 using namespace Rss;
 
+DownloadRule::DownloadRule(const QString &name)
+    : d(new DownloadRuleData)
+{
+    setName(name);
+}
+
 DownloadRule::DownloadRule()
-    : m_enabled(false)
-    , m_useRegex(false)
-    , m_apstate(USE_GLOBAL)
-    , m_ignoreDays(0)
-    , m_cachedRegexes(new QHash<QString, QRegularExpression>)
+    : d(nullptr)
 {
 }
 
-DownloadRule::~DownloadRule()
-{
-    delete m_cachedRegexes;
-}
-
-QRegularExpression DownloadRule::cachedRegex(const QString &expression, bool isRegex) const
-{
-    // Use a cache of regexes so we don't have to continually recompile - big performance increase.
-    // The cache is cleared whenever the regex/wildcard, must or must not contain fields or
-    // episode filter are modified.
-    Q_ASSERT(!expression.isEmpty());
-    QRegularExpression regex((*m_cachedRegexes)[expression]);
-
-    if (!regex.pattern().isEmpty())
-        return regex;
-
-    return (*m_cachedRegexes)[expression] = QRegularExpression(isRegex ? expression : Utils::String::wildcardToRegex(expression), QRegularExpression::CaseInsensitiveOption);
-}
+DownloadRule::~DownloadRule() {}
 
 bool DownloadRule::matches(const QString &articleTitle, const QString &expression) const
 {
-    static QRegularExpression whitespace("\\s+");
+    static const QRegularExpression whitespace("\\s+");
 
     if (expression.isEmpty()) {
         // A regex of the form "expr|" will always match, so do the same for wildcards
         return true;
     }
-    else if (m_useRegex) {
-        QRegularExpression reg(cachedRegex(expression));
+    else if (d->useRegex()) {
+        QRegularExpression reg(d->cachedRegex(expression));
         return reg.match(articleTitle).hasMatch();
     }
     else {
         // Only match if every wildcard token (separated by spaces) is present in the article name.
         // Order of wildcard tokens is unimportant (if order is important, they should have used *).
         foreach (const QString &wildcard, expression.split(whitespace, QString::SplitBehavior::SkipEmptyParts)) {
-            QRegularExpression reg(cachedRegex(wildcard, false));
+            QRegularExpression reg(d->cachedRegex(wildcard, false));
 
             if (!reg.match(articleTitle).hasMatch())
                 return false;
@@ -101,15 +88,15 @@ bool DownloadRule::matches(const QString &articleTitle, const QString &expressio
 
 bool DownloadRule::matches(const QString &articleTitle) const
 {
-    if (!m_mustContain.empty()) {
+    if (!d->mustContain().empty()) {
         bool logged = false;
         bool foundMustContain = false;
 
         // Each expression is either a regex, or a set of wildcards separated by whitespace.
         // Accept if any complete expression matches.
-        foreach (const QString &expression, m_mustContain) {
+        foreach (const QString &expression, d->mustContain()) {
             if (!logged) {
-                qDebug() << "Checking matching" << (m_useRegex ? "regex:" : "wildcard expressions:") << m_mustContain.join("|");
+                qDebug() << "Checking matching" << (d->useRegex() ? "regex:" : "wildcard expressions:") << mustContain();
                 logged = true;
             }
 
@@ -117,7 +104,7 @@ bool DownloadRule::matches(const QString &articleTitle) const
             foundMustContain = matches(articleTitle, expression);
 
             if (foundMustContain) {
-                qDebug() << "Found matching" << (m_useRegex ? "regex:" : "wildcard expression:") << expression;
+                qDebug() << "Found matching" << (d->useRegex() ? "regex:" : "wildcard expression:") << expression;
                 break;
             }
         }
@@ -126,29 +113,29 @@ bool DownloadRule::matches(const QString &articleTitle) const
             return false;
     }
 
-    if (!m_mustNotContain.empty()) {
+    if (!d->mustNotContain().empty()) {
         bool logged = false;
 
         // Each expression is either a regex, or a set of wildcards separated by whitespace.
         // Reject if any complete expression matches.
-        foreach (const QString &expression, m_mustNotContain) {
+        foreach (const QString &expression, d->mustNotContain()) {
             if (!logged) {
-                qDebug() << "Checking not matching" << (m_useRegex ? "regex:" : "wildcard expressions:") << m_mustNotContain.join("|");
+                qDebug() << "Checking not matching" << (d->useRegex() ? "regex:" : "wildcard expressions:") << mustNotContain();
                 logged = true;
             }
 
             // A regex of the form "expr|" will always match, so do the same for wildcards
             if (matches(articleTitle, expression)) {
-                qDebug() << "Found not matching" << (m_useRegex ? "regex:" : "wildcard expression:") << expression;
+                qDebug() << "Found not matching" << (d->useRegex() ? "regex:" : "wildcard expression:") << expression;
                 return false;
             }
         }
     }
 
-    if (!m_episodeFilter.isEmpty()) {
-        qDebug() << "Checking episode filter:" << m_episodeFilter;
-        QRegularExpression f(cachedRegex("(^\\d{1,4})x(.+;$)"));
-        QRegularExpressionMatch matcher = f.match(m_episodeFilter);
+    if (!d->episodeFilter().isEmpty()) {
+        qDebug() << "Checking episode filter:" << d->episodeFilter();
+        QRegularExpression f(d->cachedRegex("(^\\d{1,4})x(.+;$)"));
+        QRegularExpressionMatch matcher = f.match(d->episodeFilter());
         bool matched = matcher.hasMatch();
 
         if (!matched)
@@ -169,7 +156,7 @@ bool DownloadRule::matches(const QString &articleTitle) const
             if (ep.indexOf('-') != -1) { // Range detected
                 QString partialPattern1 = "\\bs0?(\\d{1,4})[ -_\\.]?e(0?\\d{1,4})(?:\\D|\\b)";
                 QString partialPattern2 = "\\b(\\d{1,4})x(0?\\d{1,4})(?:\\D|\\b)";
-                QRegularExpression reg(cachedRegex(partialPattern1));
+                QRegularExpression reg(d->cachedRegex(partialPattern1));
 
                 if (ep.endsWith('-')) { // Infinite range
                     int epOurs = ep.left(ep.size() - 1).toInt();
@@ -179,7 +166,7 @@ bool DownloadRule::matches(const QString &articleTitle) const
                     matched = matcher.hasMatch();
 
                     if (!matched) {
-                        reg = QRegularExpression(cachedRegex(partialPattern2));
+                        reg = QRegularExpression(d->cachedRegex(partialPattern2));
                         matcher = reg.match(articleTitle);
                         matched = matcher.hasMatch();
                     }
@@ -210,7 +197,7 @@ bool DownloadRule::matches(const QString &articleTitle) const
                     matched = matcher.hasMatch();
 
                     if (!matched) {
-                        reg = QRegularExpression(cachedRegex(partialPattern2));
+                        reg = QRegularExpression(d->cachedRegex(partialPattern2));
                         matcher = reg.match(articleTitle);
                         matched = matcher.hasMatch();
                     }
@@ -230,7 +217,7 @@ bool DownloadRule::matches(const QString &articleTitle) const
             }
             else { // Single number
                 QString expStr("\\b(?:s0?" + s + "[ -_\\.]?" + "e0?" + ep + "|" + s + "x" + "0?" + ep + ")(?:\\D|\\b)");
-                QRegularExpression reg(cachedRegex(expStr));
+                QRegularExpression reg(d->cachedRegex(expStr));
                 if (reg.match(articleTitle).hasMatch()) {
                     qDebug() << "Matched episode:" << s << "x" << ep;
                     qDebug() << "Matched article:" << articleTitle;
@@ -248,183 +235,170 @@ bool DownloadRule::matches(const QString &articleTitle) const
 
 void DownloadRule::setMustContain(const QString &tokens)
 {
-    m_cachedRegexes->clear();
-
-    if (m_useRegex)
-        m_mustContain = QStringList() << tokens;
-    else
-        m_mustContain = tokens.split("|");
-
-    // Check for single empty string - if so, no condition
-    if ((m_mustContain.size() == 1) && m_mustContain[0].isEmpty())
-        m_mustContain.clear();
+    d->setMustContain(tokens);
 }
 
 void DownloadRule::setMustNotContain(const QString &tokens)
 {
-    m_cachedRegexes->clear();
-
-    if (m_useRegex)
-        m_mustNotContain = QStringList() << tokens;
-    else
-        m_mustNotContain = tokens.split("|");
-
-    // Check for single empty string - if so, no condition
-    if ((m_mustNotContain.size() == 1) && m_mustNotContain[0].isEmpty())
-        m_mustNotContain.clear();
+    d->setMustNotContain(tokens);
 }
 
 QStringList DownloadRule::rssFeeds() const
 {
-    return m_rssFeeds;
+    return d->rssFeeds;
 }
 
 void DownloadRule::setRssFeeds(const QStringList &rssFeeds)
 {
-    m_rssFeeds = rssFeeds;
+    d->rssFeeds = rssFeeds;
 }
 
 QString DownloadRule::name() const
 {
-    return m_name;
+    return d->name;
 }
 
 void DownloadRule::setName(const QString &name)
 {
-    m_name = name;
+    d->name = name;
 }
 
 QString DownloadRule::savePath() const
 {
-    return m_savePath;
+    return d->savePath;
 }
 
-DownloadRulePtr DownloadRule::fromVariantHash(const QVariantHash &ruleHash)
+DownloadRule DownloadRule::fromVariantHash(const QVariantHash &ruleHash)
 {
-    DownloadRulePtr rule(new DownloadRule);
-    rule->setName(ruleHash.value("name").toString());
-    rule->setUseRegex(ruleHash.value("use_regex", false).toBool());
-    rule->setMustContain(ruleHash.value("must_contain").toString());
-    rule->setMustNotContain(ruleHash.value("must_not_contain").toString());
-    rule->setEpisodeFilter(ruleHash.value("episode_filter").toString());
-    rule->setRssFeeds(ruleHash.value("affected_feeds").toStringList());
-    rule->setEnabled(ruleHash.value("enabled", false).toBool());
-    rule->setSavePath(ruleHash.value("save_path").toString());
-    rule->setCategory(ruleHash.value("category_assigned").toString());
-    rule->setAddPaused(AddPausedState(ruleHash.value("add_paused").toUInt()));
-    rule->setLastMatch(ruleHash.value("last_match").toDateTime());
-    rule->setIgnoreDays(ruleHash.value("ignore_days").toInt());
+    DownloadRule rule(ruleHash.value("name").toString());
+    rule.setUseRegex(ruleHash.value("use_regex", false).toBool());
+    rule.setMustContain(ruleHash.value("must_contain").toString());
+    rule.setMustNotContain(ruleHash.value("must_not_contain").toString());
+    rule.setEpisodeFilter(ruleHash.value("episode_filter").toString());
+    rule.setRssFeeds(ruleHash.value("affected_feeds").toStringList());
+    rule.setEnabled(ruleHash.value("enabled", false).toBool());
+    rule.setSavePath(ruleHash.value("save_path").toString());
+    rule.setCategory(ruleHash.value("category_assigned").toString());
+    rule.setAddPaused(AddPausedState(ruleHash.value("add_paused").toUInt()));
+    rule.setLastMatch(ruleHash.value("last_match").toDateTime());
+    rule.setIgnoreDays(ruleHash.value("ignore_days").toInt());
     return rule;
 }
 
 QVariantHash DownloadRule::toVariantHash() const
 {
     QVariantHash hash;
-    hash["name"] = m_name;
-    hash["must_contain"] = m_mustContain.join("|");
-    hash["must_not_contain"] = m_mustNotContain.join("|");
-    hash["save_path"] = m_savePath;
-    hash["affected_feeds"] = m_rssFeeds;
-    hash["enabled"] = m_enabled;
-    hash["category_assigned"] = m_category;
-    hash["use_regex"] = m_useRegex;
-    hash["add_paused"] = m_apstate;
-    hash["episode_filter"] = m_episodeFilter;
-    hash["last_match"] = m_lastMatch;
-    hash["ignore_days"] = m_ignoreDays;
+    hash["name"] = name();
+    hash["must_contain"] = mustContain();
+    hash["must_not_contain"] = mustNotContain();
+    hash["save_path"] = savePath();
+    hash["affected_feeds"] = rssFeeds();
+    hash["enabled"] = isEnabled();
+    hash["category_assigned"] = category();
+    hash["use_regex"] = useRegex();
+    hash["add_paused"] = addPaused();
+    hash["episode_filter"] = episodeFilter();
+    hash["last_match"] = lastMatch();
+    hash["ignore_days"] = ignoreDays();
     return hash;
 }
 
 bool DownloadRule::operator==(const DownloadRule &other) const
 {
-    return m_name == other.name();
+    if (d && !other)
+        return false;
+
+    return d && name() == other.name();
+}
+
+DownloadRule::operator bool() const
+{
+    return d;
 }
 
 void DownloadRule::setSavePath(const QString &savePath)
 {
-    m_savePath = Utils::Fs::fromNativePath(savePath);
+    d->savePath = Utils::Fs::fromNativePath(savePath);
 }
 
 DownloadRule::AddPausedState DownloadRule::addPaused() const
 {
-    return m_apstate;
+    return d->apstate;
 }
 
 void DownloadRule::setAddPaused(const DownloadRule::AddPausedState &aps)
 {
-    m_apstate = aps;
+    d->apstate = aps;
 }
 
 QString DownloadRule::category() const
 {
-    return m_category;
+    return d->category;
 }
 
 void DownloadRule::setCategory(const QString &category)
 {
-    m_category = category;
+    d->category = category;
 }
 
 bool DownloadRule::isEnabled() const
 {
-    return m_enabled;
+    return d->enabled;
 }
 
 void DownloadRule::setEnabled(bool enable)
 {
-    m_enabled = enable;
+    d->enabled = enable;
 }
 
-void DownloadRule::setLastMatch(const QDateTime &d)
+void DownloadRule::setLastMatch(const QDateTime &date)
 {
-    m_lastMatch = d;
+    d->lastMatch = date;
 }
 
 QDateTime DownloadRule::lastMatch() const
 {
-    return m_lastMatch;
+    return d->lastMatch;
 }
 
-void DownloadRule::setIgnoreDays(int d)
+void DownloadRule::setIgnoreDays(int days)
 {
-    m_ignoreDays = d;
+    d->ignoreDays = days;
 }
 
 int DownloadRule::ignoreDays() const
 {
-    return m_ignoreDays;
+    return d->ignoreDays;
 }
 
 QString DownloadRule::mustContain() const
 {
-    return m_mustContain.join("|");
+    return d->mustContain().join("|");
 }
 
 QString DownloadRule::mustNotContain() const
 {
-    return m_mustNotContain.join("|");
+    return d->mustNotContain().join("|");
 }
 
 bool DownloadRule::useRegex() const
 {
-    return m_useRegex;
+    return d->useRegex();
 }
 
 void DownloadRule::setUseRegex(bool enabled)
 {
-    m_useRegex = enabled;
-    m_cachedRegexes->clear();
+    d->setUseRegex(enabled);
 }
 
 QString DownloadRule::episodeFilter() const
 {
-    return m_episodeFilter;
+    return d->episodeFilter();
 }
 
 void DownloadRule::setEpisodeFilter(const QString &e)
 {
-    m_episodeFilter = e;
-    m_cachedRegexes->clear();
+    d->setEpisodeFilter(e);
 }
 
 QStringList DownloadRule::findMatchingArticles(const FeedPtr &feed) const
@@ -432,13 +406,16 @@ QStringList DownloadRule::findMatchingArticles(const FeedPtr &feed) const
     QStringList ret;
     const ArticleHash &feedArticles = feed->articleHash();
 
-    ArticleHash::ConstIterator artIt = feedArticles.begin();
-    ArticleHash::ConstIterator artItend = feedArticles.end();
-    for (; artIt != artItend; ++artIt) {
-        const QString title = artIt.value()->title();
+    foreach (const ArticlePtr &article, feedArticles) {
+        const QString title = article->title();
         qDebug() << "Matching article:" << title;
         if (matches(title))
             ret << title;
     }
     return ret;
+}
+
+bool DownloadRule::isSame(const DownloadRule &other) const
+{
+    return d == other.d;
 }

--- a/src/base/rss/rssdownloadrule.h
+++ b/src/base/rss/rssdownloadrule.h
@@ -33,7 +33,7 @@
 
 #include <QDateTime>
 #include <QVariantHash>
-#include <QSharedPointer>
+#include <QSharedDataPointer>
 #include <QStringList>
 
 template <class T, class U> class QHash;
@@ -45,9 +45,9 @@ namespace Rss
     typedef QSharedPointer<Feed> FeedPtr;
 
     class DownloadRule;
-    typedef QSharedPointer<DownloadRule> DownloadRulePtr;
+    typedef QSharedDataPointer<DownloadRule> DownloadRulePtr;
 
-    class DownloadRule
+    class DownloadRule : public QSharedData
     {
     public:
         enum AddPausedState

--- a/src/base/rss/rssdownloadrule.h
+++ b/src/base/rss/rssdownloadrule.h
@@ -36,18 +36,13 @@
 #include <QSharedDataPointer>
 #include <QStringList>
 
-template <class T, class U> class QHash;
-class QRegularExpression;
-
 namespace Rss
 {
     class Feed;
-    typedef QSharedPointer<Feed> FeedPtr;
+    using FeedPtr = QSharedPointer<Feed>;
+    class DownloadRuleData;
 
-    class DownloadRule;
-    typedef QSharedDataPointer<DownloadRule> DownloadRulePtr;
-
-    class DownloadRule : public QSharedData
+    class DownloadRule
     {
     public:
         enum AddPausedState
@@ -57,10 +52,15 @@ namespace Rss
             NEVER_PAUSED
         };
 
+        /*!
+         * Default constructor represents null
+         * Convenient when used in a collection
+         */
         DownloadRule();
+        DownloadRule(const QString &name);
         ~DownloadRule();
 
-        static DownloadRulePtr fromVariantHash(const QVariantHash &ruleHash);
+        static DownloadRule fromVariantHash(const QVariantHash &ruleHash);
         QVariantHash toVariantHash() const;
         bool matches(const QString &articleTitle) const;
         void setMustContain(const QString &tokens);
@@ -77,9 +77,9 @@ namespace Rss
         void setCategory(const QString &category);
         bool isEnabled() const;
         void setEnabled(bool enable);
-        void setLastMatch(const QDateTime &d);
+        void setLastMatch(const QDateTime &date);
         QDateTime lastMatch() const;
-        void setIgnoreDays(int d);
+        void setIgnoreDays(int days);
         int ignoreDays() const;
         QString mustContain() const;
         QString mustNotContain() const;
@@ -88,26 +88,17 @@ namespace Rss
         QString episodeFilter() const;
         void setEpisodeFilter(const QString &e);
         QStringList findMatchingArticles(const FeedPtr &feed) const;
+        bool isSame(const DownloadRule &other) const;
+
         // Operators
         bool operator==(const DownloadRule &other) const;
+        operator bool() const;
 
     private:
         bool matches(const QString &articleTitle, const QString &expression) const;
-        QRegularExpression cachedRegex(const QString &expression, bool isRegex = true) const;
 
-        QString m_name;
-        QStringList m_mustContain;
-        QStringList m_mustNotContain;
-        QString m_episodeFilter;
-        QString m_savePath;
-        QString m_category;
-        bool m_enabled;
-        QStringList m_rssFeeds;
-        bool m_useRegex;
-        AddPausedState m_apstate;
-        QDateTime m_lastMatch;
-        int m_ignoreDays;
-        mutable QHash<QString, QRegularExpression> *m_cachedRegexes;
+    private:
+        QSharedDataPointer<DownloadRuleData> d;
     };
 }
 

--- a/src/base/rss/rssdownloadrule_p.cpp
+++ b/src/base/rss/rssdownloadrule_p.cpp
@@ -1,0 +1,96 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2017  Michael Ziminsky
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+#include "rssdownloadrule_p.h"
+
+#include <QRegularExpression>
+
+#include "base/utils/string.h"
+
+using namespace Rss;
+
+void DownloadRuleData::setMustContain(const QString &tokens)
+{
+    if (m_useRegex)
+        m_mustContain = QStringList() << tokens;
+    else
+        m_mustContain = tokens.split("|");
+
+    // Check for single empty string - if so, no condition
+    if ((m_mustContain.size() == 1) && m_mustContain[0].isEmpty())
+        m_mustContain.clear();
+
+    m_cachedRegexes.clear();
+}
+
+void DownloadRuleData::setMustNotContain(const QString &tokens)
+{
+    if (m_useRegex)
+        m_mustNotContain = QStringList() << tokens;
+    else
+        m_mustNotContain = tokens.split("|");
+
+    // Check for single empty string - if so, no condition
+    if ((m_mustNotContain.size() == 1) && m_mustNotContain[0].isEmpty())
+        m_mustNotContain.clear();
+
+    m_cachedRegexes.clear();
+}
+
+void DownloadRuleData::setEpisodeFilter(const QString &episodeFilter)
+{
+    if (episodeFilter == m_episodeFilter)
+        return;
+
+    m_episodeFilter = episodeFilter;
+    m_cachedRegexes.clear();
+}
+
+QRegularExpression DownloadRuleData::cachedRegex(const QString &expression, bool isRegex) const
+{
+    // Use a cache of regexes so we don't have to continually recompile - big performance increase.
+    // The cache is cleared whenever the regex/wildcard, must or must not contain fields or
+    // episode filter are modified.
+    Q_ASSERT(!expression.isEmpty());
+    QRegularExpression regex(m_cachedRegexes[expression]);
+
+    if (!regex.pattern().isEmpty())
+        return regex;
+
+    return m_cachedRegexes[expression] = QRegularExpression(isRegex ? expression : Utils::String::wildcardToRegex(expression), QRegularExpression::CaseInsensitiveOption);
+}
+
+void DownloadRuleData::setUseRegex(bool useRegex)
+{
+    if (useRegex == m_useRegex)
+        return;
+
+    m_useRegex = useRegex;
+    m_cachedRegexes.clear();
+}
+
+DownloadRuleData::~DownloadRuleData() {}

--- a/src/base/rss/rssdownloadrule_p.h
+++ b/src/base/rss/rssdownloadrule_p.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2010  Christophe Dumez
+ * Copyright (C) 2017  Michael Ziminsky
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,50 +24,52 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : chris@qbittorrent.org
  */
-
-#ifndef RSSDOWNLOADRULELIST_H
-#define RSSDOWNLOADRULELIST_H
-
-#include <QList>
-#include <QHash>
-#include <QVariantHash>
+#ifndef RSSDOWNLOADRULE_P_H
+#define RSSDOWNLOADRULE_P_H
 
 #include "rssdownloadrule.h"
 
+#include <QHash>
+#include <QStringList>
+
 namespace Rss
 {
-    class DownloadRuleList
+    class DownloadRuleData : public QSharedData
     {
     public:
-        DownloadRuleList();
+        QString name;
+        QString savePath;
+        QString category;
+        QStringList rssFeeds;
+        bool enabled = false;
+        DownloadRule::AddPausedState apstate = DownloadRule::USE_GLOBAL;
+        QDateTime lastMatch;
+        int ignoreDays = 0;
 
-        DownloadRule findMatchingRule(const QString &feedUrl, const QString &articleTitle) const;
-        // Operators
-        void saveRule(const DownloadRule &rule);
-        void removeRule(const QString &name);
-        void renameRule(const QString &oldName, const QString &newName);
-        DownloadRule getRule(const QString &name) const;
-        QStringList ruleNames() const;
-        bool isEmpty() const;
-        void saveRulesToStorage();
-        bool serialize(const QString &path);
-        bool unserialize(const QString &path);
-        void replace(const DownloadRuleList& other);
-        void merge(const DownloadRuleList& other);
-        void updateFeedURL(const QString &oldUrl, const QString &newUrl);
+        QStringList mustContain() const { return m_mustContain; }
+        void setMustContain(const QString &tokens);
+
+        QStringList mustNotContain() const { return m_mustNotContain; }
+        void setMustNotContain(const QString &tokens);
+
+        QString episodeFilter() const { return m_episodeFilter; }
+        void setEpisodeFilter(const QString &episodeFilter);
+
+        bool useRegex() const { return m_useRegex; }
+        void setUseRegex(bool useRegex);
+
+        QRegularExpression cachedRegex(const QString &expression, bool isRegex = true) const;
+
+        ~DownloadRuleData();
 
     private:
-        void loadRulesFromStorage();
-        void loadRulesFromVariantHash(const QVariantHash &l);
-        QVariantHash toVariantHash() const;
-
-    private:
-        QHash<QString, DownloadRule> m_rules;
-        QHash<QString, QStringList> m_feedRules;
+        QStringList m_mustContain;
+        QStringList m_mustNotContain;
+        QString m_episodeFilter;
+        bool m_useRegex = false;
+        mutable QHash<QString, QRegularExpression> m_cachedRegexes;
     };
 }
 
-#endif // RSSDOWNLOADFILTERLIST_H
+#endif // RSSDOWNLOADRULE_P_H

--- a/src/base/rss/rssdownloadrulelist.cpp
+++ b/src/base/rss/rssdownloadrulelist.cpp
@@ -105,8 +105,7 @@ void DownloadRuleList::saveRule(const DownloadRulePtr &rule)
     qDebug() << Q_FUNC_INFO << rule->name();
     Q_ASSERT(rule);
     if (m_rules.contains(rule->name())) {
-        if (m_rules[rule->name()] == rule)
-        {
+        if (m_rules[rule->name()] == rule) {
             qDebug("Rule already exists, and is unchanged. Skipping");
             return;
         }

--- a/src/base/rss/rssdownloadrulelist.cpp
+++ b/src/base/rss/rssdownloadrulelist.cpp
@@ -136,6 +136,19 @@ void DownloadRuleList::renameRule(const QString &oldName, const QString &newName
     }
 }
 
+void DownloadRuleList::updateFeedURL(const QString &oldUrl, const QString &newUrl)
+{
+    if (m_feedRules.contains(oldUrl)) {
+        QStringList feedRules = m_feedRules.take(oldUrl);
+        m_feedRules.insert(newUrl, feedRules);
+        foreach (const QString &ruleName, feedRules) {
+            QStringList ruleFeeds = m_rules[ruleName]->rssFeeds();
+            ruleFeeds.replace(ruleFeeds.indexOf(oldUrl), newUrl);
+            m_rules[ruleName]->setRssFeeds(ruleFeeds);
+        }
+    }
+}
+
 DownloadRulePtr DownloadRuleList::getRule(const QString &name) const
 {
     return m_rules.value(name);

--- a/src/base/rss/rssdownloadrulelist.cpp
+++ b/src/base/rss/rssdownloadrulelist.cpp
@@ -55,13 +55,17 @@ DownloadRulePtr DownloadRuleList::findMatchingRule(const QString &feedUrl, const
     return DownloadRulePtr();
 }
 
-void DownloadRuleList::replace(DownloadRuleList *other)
+void DownloadRuleList::replace(const DownloadRuleList &other)
 {
     m_rules.clear();
     m_feedRules.clear();
-    foreach (const QString &name, other->ruleNames()) {
-        saveRule(other->getRule(name));
-    }
+    merge(other);
+}
+
+void DownloadRuleList::merge(const DownloadRuleList &other)
+{
+    foreach (const QString &name, other.ruleNames())
+        saveRule(other.getRule(name));
 }
 
 void DownloadRuleList::saveRulesToStorage()
@@ -101,6 +105,12 @@ void DownloadRuleList::saveRule(const DownloadRulePtr &rule)
     qDebug() << Q_FUNC_INFO << rule->name();
     Q_ASSERT(rule);
     if (m_rules.contains(rule->name())) {
+        if (m_rules[rule->name()] == rule)
+        {
+            qDebug("Rule already exists, and is unchanged. Skipping");
+            return;
+        }
+
         qDebug("This is an update, removing old rule first");
         removeRule(rule->name());
     }

--- a/src/base/rss/rssdownloadrulelist.h
+++ b/src/base/rss/rssdownloadrulelist.h
@@ -41,8 +41,6 @@ namespace Rss
 {
     class DownloadRuleList
     {
-        Q_DISABLE_COPY(DownloadRuleList)
-
     public:
         DownloadRuleList();
 
@@ -57,7 +55,8 @@ namespace Rss
         void saveRulesToStorage();
         bool serialize(const QString &path);
         bool unserialize(const QString &path);
-        void replace(DownloadRuleList *other);
+        void replace(const DownloadRuleList& other);
+        void merge(const DownloadRuleList& other);
         void updateFeedURL(const QString &oldUrl, const QString &newUrl);
 
     private:

--- a/src/base/rss/rssdownloadrulelist.h
+++ b/src/base/rss/rssdownloadrulelist.h
@@ -58,6 +58,7 @@ namespace Rss
         bool serialize(const QString &path);
         bool unserialize(const QString &path);
         void replace(DownloadRuleList *other);
+        void updateFeedURL(const QString &oldUrl, const QString &newUrl);
 
     private:
         void loadRulesFromStorage();

--- a/src/base/rss/rssfeed.cpp
+++ b/src/base/rss/rssfeed.cpp
@@ -77,8 +77,7 @@ Feed::Feed(const QString &url, Manager *manager)
     connect(m_parser, SIGNAL(finished(QString)), SLOT(handleParsingFinished(QString)));
 
     // Download the RSS Feed icon
-    Net::DownloadHandler *handler = Net::DownloadManager::instance()->downloadUrl(iconUrl(), true);
-    connect(handler, SIGNAL(downloadFinished(QString,QString)), this, SLOT(handleIconDownloadFinished(QString,QString)));
+    downloadIcon();
 
     // Load old RSS articles
     loadItemsFromDisk();
@@ -126,6 +125,12 @@ void Feed::loadItemsFromDisk()
         if (rssItem)
             addArticle(rssItem);
     }
+}
+
+void Feed::downloadIcon()
+{
+    Net::DownloadHandler *handler = Net::DownloadManager::instance()->downloadUrl(iconUrl(), true);
+    connect(handler, SIGNAL(downloadFinished(QString,QString)), this, SLOT(handleIconDownloadFinished(QString,QString)));
 }
 
 void Feed::addArticle(const ArticlePtr &article)
@@ -243,6 +248,21 @@ QString Feed::url() const
     return m_url;
 }
 
+void Feed::setURL(const QString &url)
+{
+    // Clear old articles
+    m_articles.clear();
+    m_articlesByDate.clear();
+    m_unreadCount = 0;
+    saveItemsToDisk();
+
+    m_url = url;
+    downloadIcon();
+
+    // FIXME: Cancel current refresh if in progress
+    refresh();
+}
+
 QString Feed::iconPath() const
 {
     if (m_inErrorState)
@@ -318,7 +338,8 @@ ArticleList Feed::unreadArticleListByDateDesc() const
 QString Feed::iconUrl() const
 {
     // XXX: This works for most sites but it is not perfect
-    return QString("http://%1/favicon.ico").arg(QUrl(m_url).host());
+    const QUrl url(m_url);
+    return QString("%1://%2/favicon.ico").arg(url.scheme()).arg(url.host());
 }
 
 void Feed::handleIconDownloadFinished(const QString &url, const QString &filePath)

--- a/src/base/rss/rssfeed.h
+++ b/src/base/rss/rssfeed.h
@@ -76,6 +76,7 @@ namespace Rss
         void rename(const QString &newName);
         QString displayName() const;
         QString url() const;
+        void setURL(const QString &url);
         QString iconPath() const;
         bool hasCustomIcon() const;
         void setIconPath(const QString &pathHierarchy);
@@ -105,6 +106,7 @@ namespace Rss
         void addArticle(const ArticlePtr &article);
         void downloadArticleTorrentIfMatching(const ArticlePtr &article);
         void deferredDownloadArticleTorrentIfMatching(const ArticlePtr &article);
+        void downloadIcon();
 
     private:
         Manager *m_manager;

--- a/src/base/rss/rssfolder.cpp
+++ b/src/base/rss/rssfolder.cpp
@@ -189,7 +189,6 @@ QHash<QString, FeedPtr> Folder::getAllFeedsAsHash() const
 
 bool Folder::addFile(const FilePtr &item)
 {
-    Q_ASSERT(!m_children.contains(item->id()));
     if (!m_children.contains(item->id())) {
         m_children[item->id()] = item;
         // Update parent

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -588,7 +588,7 @@ void AutomatedRssDownloader::handleFeedCheckStateChange(QListWidgetItem *feed_it
     updateMatchingArticles();
 }
 
-// FIXME: This should return early if any of the filters are invalid
+// FIXME: This should skip rules with any invalid filters
 void AutomatedRssDownloader::updateMatchingArticles()
 {
     ui->treeMatchingArticles->clear();

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -181,14 +181,16 @@ void AutomatedRssDownloader::loadRulesList()
 
 void AutomatedRssDownloader::loadFeedList()
 {
-    if (Rss::ManagerPtr manager = m_manager.toStrongRef()) {
-        for (const Rss::FeedPtr &feed : manager->rootFolder()->getAllFeeds()) {
-            QListWidgetItem *item = new QListWidgetItem(feed->displayName(), ui->listFeeds);
-            item->setData(Qt::UserRole, feed->url());
-            item->setFlags(item->flags() | Qt::ItemIsUserCheckable | Qt::ItemIsTristate);
-        }
-        ui->listFeeds->sortItems();
+    Rss::ManagerPtr manager = m_manager.toStrongRef();
+    if (!manager)
+        return;
+
+    for (const Rss::FeedPtr &feed : manager->rootFolder()->getAllFeeds()) {
+        QListWidgetItem *item = new QListWidgetItem(feed->displayName(), ui->listFeeds);
+        item->setData(Qt::UserRole, feed->url());
+        item->setFlags(item->flags() | Qt::ItemIsUserCheckable | Qt::ItemIsTristate);
     }
+    ui->listFeeds->sortItems();
 }
 
 void AutomatedRssDownloader::updateFeedList(QListWidgetItem *selected)

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -57,7 +57,6 @@ namespace Rss
 
 QT_BEGIN_NAMESPACE
 class QListWidgetItem;
-class QRegularExpression;
 QT_END_NAMESPACE
 
 class AutomatedRssDownloader: public QDialog
@@ -113,7 +112,6 @@ private:
     QListWidgetItem *m_editedRule;
     Rss::DownloadRuleList *m_ruleList;
     Rss::DownloadRuleList *m_editableRuleList;
-    QRegularExpression *m_episodeRegex;
     QShortcut *editHotkey;
     QShortcut *deleteHotkey;
     QSet<QPair<QString, QString >> m_treeListEntries;

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -100,7 +100,7 @@ private slots:
     void onFinished(int result);
 
 private:
-    Rss::DownloadRulePtr getCurrentRule() const;
+    Rss::DownloadRule getCurrentRule() const;
     void initCategoryCombobox();
     void addFeedArticlesToTree(const Rss::FeedPtr &feed, const QStringList &articles);
     void disconnectRuleFeedSlots();

--- a/src/gui/rss/rss.ui
+++ b/src/gui/rss/rss.ui
@@ -194,6 +194,11 @@
     <string>New folder...</string>
    </property>
   </action>
+  <action name="actionChange_Feed_URL">
+   <property name="text">
+    <string>Change Feed URL</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>
@@ -203,5 +208,25 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>actionChange_Feed_URL</sender>
+   <signal>triggered()</signal>
+   <receiver>RSS</receiver>
+   <slot>changeSelectedFeedURL()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>809</x>
+     <y>457</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <slots>
+  <slot>changeSelectedFeedURL()</slot>
+ </slots>
 </ui>

--- a/src/gui/rss/rss_imp.cpp
+++ b/src/gui/rss/rss_imp.cpp
@@ -43,6 +43,7 @@
 #include "base/net/downloadmanager.h"
 #include "base/preferences.h"
 #include "rsssettingsdlg.h"
+#include "base/rss/rssdownloadrulelist.h"
 #include "base/rss/rssmanager.h"
 #include "base/rss/rssfolder.h"
 #include "base/rss/rssarticle.h"
@@ -480,9 +481,13 @@ void RSSImp::changeSelectedFeedURL()
         }
     } while (!ok);
 
+    m_rssManager->downloadRules()->updateFeedURL(feed->url(), newUrl);
+    m_rssManager->downloadRules()->saveRulesToStorage();
+
     m_feedList->itemAboutToBeRemoved(item);
     feed->setURL(newUrl);
     m_feedList->itemAdded(item, feed);
+
     m_rssManager->saveStreamList();
     updateItemInfos(item);
 }

--- a/src/gui/rss/rss_imp.cpp
+++ b/src/gui/rss/rss_imp.cpp
@@ -815,29 +815,27 @@ void RSSImp::on_rssDownloaderBtn_clicked()
 QTreeWidgetItem* RSSImp::addItem(const Rss::FilePtr &file, QTreeWidgetItem *parent)
 {
     qDebug() << Q_FUNC_INFO << file->id();
+    if (m_feedList->hasFeed(file->id()))
+        return nullptr;
 
-    QTreeWidgetItem *item = nullptr;
-    if (!m_feedList->hasFeed(file->id())) {
-        item = createFolderListItem(file);
-        Q_ASSERT(item);
+    QTreeWidgetItem *item = createFolderListItem(file);
 
-        Rss::FolderPtr rssParent = qSharedPointerDynamicCast<Rss::Folder>(m_feedList->getRSSItem(parent));
-        if (!rssParent)
-            rssParent = m_rssManager->rootFolder();
-        rssParent->addFile(file);
+    Rss::FolderPtr rssParent = qSharedPointerDynamicCast<Rss::Folder>(m_feedList->getRSSItem(parent));
+    if (!rssParent)
+        rssParent = m_rssManager->rootFolder();
+    rssParent->addFile(file);
 
-        if (parent) {
-            parent->addChild(item);
-            parent->setExpanded(true);
-        }
-        else {
-            m_feedList->addTopLevelItem(item);
-        }
-
-        // Notify TreeWidget of item addition
-        m_feedList->itemAdded(item, file);
-        m_feedList->setCurrentItem(item);
+    if (parent) {
+        parent->addChild(item);
+        parent->setExpanded(true);
     }
+    else {
+        m_feedList->addTopLevelItem(item);
+    }
+
+    // Notify TreeWidget of item addition
+    m_feedList->itemAdded(item, file);
+    m_feedList->setCurrentItem(item);
 
     return item;
 }

--- a/src/gui/rss/rss_imp.h
+++ b/src/gui/rss/rss_imp.h
@@ -91,6 +91,7 @@ private slots:
 private:
     static QListWidgetItem *createArticleListItem(const Rss::ArticlePtr &article);
     static QTreeWidgetItem *createFolderListItem(const Rss::FilePtr &rssFile);
+    QTreeWidgetItem* addItem(const Rss::FilePtr& file, QTreeWidgetItem *parent = nullptr);
 
 private:
     Rss::ManagerPtr m_rssManager;

--- a/src/gui/rss/rss_imp.h
+++ b/src/gui/rss/rss_imp.h
@@ -69,6 +69,7 @@ private slots:
     void renameSelectedRssFile();
     void refreshSelectedItems();
     void copySelectedFeedsURL();
+    void changeSelectedFeedURL();
     void populateArticleList(QTreeWidgetItem *item);
     void refreshTextBrowser();
     void updateFeedIcon(const QString &url, const QString &icon_path);


### PR DESCRIPTION
- Make download rules implicitly shared
  - No more need to load rules from disk every time the edit rules dialog is opened
- Some code cleanup

This is based on top of #6368