### PR TITLE
prioritize fist files in the torrent's list

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -46,6 +46,7 @@
 #include <QVector>
 #include <QWaitCondition>
 
+#include "base/bittorrent/torrenthandle.h"
 #include "base/settingvalue.h"
 #include "base/tristatebool.h"
 #include "base/types.h"
@@ -146,6 +147,7 @@ namespace BitTorrent
         QVector<int> filePriorities; // used if TorrentInfo is set
         bool ignoreShareRatio = false;
         bool skipChecking = false;
+        BitTorrent::FileAutoPriority autoPrioType;
     };
 
     struct TorrentStatusReport

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -1548,6 +1548,16 @@ void Preferences::setToolbarTextPosition(const int position)
     setValue("Toolbar/textPosition", position);
 }
 
+bool Preferences::getAutoFilePriorities() const
+{
+    return value("Preferences/autoFilePriorities", false).toBool();
+}
+
+void Preferences::setAutoFilePriorities(bool enable)
+{
+    setValue("Preferences/autoFilePriorities", enable);
+}
+
 QList<QNetworkCookie> Preferences::getNetworkCookies() const
 {
     QList<QNetworkCookie> cookies;

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -331,6 +331,8 @@ public:
     void setTransHeaderState(const QByteArray &state);
     int getToolbarTextPosition() const;
     void setToolbarTextPosition(const int position);
+    void setAutoFilePriorities(bool enable);
+    bool getAutoFilePriorities() const;
 
     //From old RssSettings class
     bool isRSSEnabled() const;

--- a/src/base/utils/prio.h
+++ b/src/base/utils/prio.h
@@ -28,51 +28,11 @@
  * Contact : chris@qbittorrent.org
  */
 
-#ifndef TORRENTCONTENTMODELITEM_H
-#define TORRENTCONTENTMODELITEM_H
+#ifndef PRIO_H
+#define PRIO_H
 
-#include <QList>
-#include <QVariant>
-#include "base/utils/prio.h"
+namespace prio {
+enum FilePriority {IGNORED=0, NORMAL=1, HIGH=6, MAXIMUM=7, MIXED=-1};
+}
 
-class TorrentContentModelFolder;
-
-class TorrentContentModelItem {
-public:
-  enum TreeItemColumns {COL_NAME, COL_SIZE, COL_PROGRESS, COL_PRIO, COL_REMAINING, NB_COL};
-  enum ItemType { FileType, FolderType };
-
-  TorrentContentModelItem(TorrentContentModelFolder* parent);
-  virtual ~TorrentContentModelItem();
-
-  inline bool isRootItem() const { return !m_parentItem; }
-  TorrentContentModelFolder* parent() const;
-  virtual ItemType itemType() const = 0;
-
-  QString name() const;
-  void setName(const QString& name);
-
-  qulonglong size() const;
-  qreal progress() const;
-  qulonglong remaining() const;
-
-  int priority() const;
-  virtual void setPriority(int new_prio, bool update_parent = true) = 0;
-
-  int columnCount() const;
-  QVariant data(int column) const;
-  int row() const;
-
-protected:
-  TorrentContentModelFolder* m_parentItem;
-  // Root item members
-  QList<QVariant> m_itemData;
-  // Non-root item members
-  QString m_name;
-  qulonglong m_size;
-  qulonglong m_remaining;
-  int m_priority;
-  qreal m_progress;
-};
-
-#endif // TORRENTCONTENTMODELITEM_H
+#endif

--- a/src/gui/addnewtorrentdialog.h
+++ b/src/gui/addnewtorrentdialog.h
@@ -38,6 +38,7 @@
 
 #include "base/bittorrent/infohash.h"
 #include "base/bittorrent/torrentinfo.h"
+#include "base/bittorrent/torrenthandle.h"
 
 namespace BitTorrent
 {
@@ -82,9 +83,12 @@ private slots:
     void TMMChanged(int index);
     void categoryChanged(int index);
     void doNotDeleteTorrentClicked(bool checked);
+    void handleSortColumnChanged();
 
     void accept() override;
     void reject() override;
+
+    void dataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight);
 
 private:
     explicit AddNewTorrentDialog(QWidget *parent = 0);
@@ -98,6 +102,7 @@ private:
     void setMetadataProgressIndicator(bool visibleIndicator, const QString &labelText = QString());
     void setupTreeview();
     void setCommentText(const QString &str) const;
+    BitTorrent::FileAutoPriority getAutoPrioType() const;
 
     void showEvent(QShowEvent *event) override;
 

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -64,6 +64,7 @@ enum AdvSettingsRows
     LIST_REFRESH,
     RESOLVE_HOSTS,
     RESOLVE_COUNTRIES,
+    AUTO_FILE_PRIORITY,
     PROGRAM_NOTIFICATIONS,
     TORRENT_ADDED_NOTIFICATIONS,
     DOWNLOAD_TRACKER_FAVICON,
@@ -166,6 +167,9 @@ void AdvancedSettings::saveAdvancedSettings()
     // Announce IP
     QHostAddress addr(txtAnnounceIP.text().trimmed());
     session->setAnnounceIP(addr.isNull() ? "" : addr.toString());
+
+    // Auto file priorities
+    pref->setAutoFilePriorities(cb_auto_file_priority.isChecked());
 
     // Program notification
     MainWindow * const mainWindow = static_cast<Application*>(QCoreApplication::instance())->mainWindow();
@@ -346,6 +350,9 @@ void AdvancedSettings::loadAdvancedSettings()
     // Announce IP
     txtAnnounceIP.setText(session->announceIP());
     addRow(ANNOUNCE_IP, tr("IP Address to report to trackers (requires restart)"), &txtAnnounceIP);
+    // Auto file priority
+    cb_auto_file_priority.setChecked(pref->getAutoFilePriorities());
+    addRow(AUTO_FILE_PRIORITY, tr("Auto prioritize first files in the torrent's list"), &cb_auto_file_priority);
 
     // Program notifications
     const MainWindow * const mainWindow = static_cast<Application*>(QCoreApplication::instance())->mainWindow();

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -79,7 +79,7 @@ private:
     QSpinBox spin_cache, spin_save_resume_data_interval, outgoing_ports_min, outgoing_ports_max, spin_list_refresh, spin_maxhalfopen, spin_tracker_port, spin_cache_ttl;
     QCheckBox cb_os_cache, cb_recheck_completed, cb_resolve_countries, cb_resolve_hosts, cb_super_seeding,
               cb_program_notifications, cb_torrent_added_notifications, cb_tracker_favicon, cb_tracker_status,
-              cb_confirm_torrent_recheck, cb_listen_ipv6, cb_announce_all_trackers;
+              cb_confirm_torrent_recheck, cb_listen_ipv6, cb_announce_all_trackers, cb_auto_file_priority;
     QComboBox combo_iface, combo_iface_address;
     QLineEdit txtAnnounceIP;
 

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -92,6 +92,7 @@ PropertiesWidget::PropertiesWidget(QWidget *parent, MainWindow *main_window, Tra
     connect(filesList, SIGNAL(customContextMenuRequested(const QPoint&)), this, SLOT(displayFilesListMenu(const QPoint&)));
     connect(filesList, SIGNAL(doubleClicked(const QModelIndex&)), this, SLOT(openDoubleClickedFile(const QModelIndex&)));
     connect(PropListModel, SIGNAL(filteredFilesChanged()), this, SLOT(filteredFilesChanged()));
+    connect(PropListModel->model(), SIGNAL(dataChanged(const QModelIndex&, const QModelIndex&)), SLOT(dataChanged(const QModelIndex&, const QModelIndex&)));
     connect(listWebSeeds, SIGNAL(customContextMenuRequested(const QPoint&)), this, SLOT(displayWebSeedListMenu(const QPoint&)));
     connect(transferList, SIGNAL(currentTorrentChanged(BitTorrent::TorrentHandle * const)), this, SLOT(loadTorrentInfos(BitTorrent::TorrentHandle * const)));
     connect(PropDelegate, SIGNAL(filteredFilesChanged()), this, SLOT(filteredFilesChanged()));
@@ -323,6 +324,7 @@ void PropertiesWidget::loadTorrentInfos(BitTorrent::TorrentHandle *const torrent
 
         // List files in torrent
         PropListModel->model()->setupModelData(m_torrent->info());
+        PropListModel->model()->setAutoPriorityType(m_torrent->getFileAutoPriority());
         filesList->setExpanded(PropListModel->index(0, 0), true);
 
         // Load file priorities
@@ -889,5 +891,15 @@ void PropertiesWidget::filterText(const QString &filter)
     }
     else {
         filesList->expandAll();
+    }
+}
+
+void PropertiesWidget::dataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight)
+{
+    if (3 == topLeft.column()) {
+        PropListModel->model()->setAutoPriorityType(BitTorrent::FileAutoPriority::None);
+
+        if (m_torrent)
+            m_torrent->setFileAutoPriority(BitTorrent::FileAutoPriority::None);
     }
 }

--- a/src/gui/properties/propertieswidget.h
+++ b/src/gui/properties/propertieswidget.h
@@ -130,6 +130,7 @@ private:
 private slots:
     void filterText(const QString &filter);
     void updateSavePath(BitTorrent::TorrentHandle *const torrent);
+    void dataChanged(const QModelIndex&, const QModelIndex&);
 };
 
 #endif // PROPERTIESWIDGET_H

--- a/src/gui/properties/proplistdelegate.cpp
+++ b/src/gui/properties/proplistdelegate.cpp
@@ -48,6 +48,8 @@
 #include "propertieswidget.h"
 #include "proplistdelegate.h"
 #include "torrentcontentmodelitem.h"
+#include "torrentcontentmodel.h"
+#include "torrentcontentfiltermodel.h"
 
 namespace {
 
@@ -120,25 +122,31 @@ void PropListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
         }
         break;
     case PRIORITY: {
+            QString postfix;
+            auto p = dynamic_cast<const TorrentContentFilterModel *>(index.model());
+            if (p && p->model()->getAutoPriorityType() != BitTorrent::FileAutoPriority::None)
+                postfix = tr(" (auto)");
+
             QItemDelegate::drawBackground(painter, opt, index);
             QString text = "";
             switch (index.data().toInt()) {
             case prio::MIXED:
-                text = tr("Mixed", "Mixed (priorities");
+                text = tr("Mixed", "Mixed (priorities") + postfix;
                 break;
             case prio::IGNORED:
                 text = tr("Not downloaded");
                 break;
             case prio::HIGH:
-                text = tr("High", "High (priority)");
+                text = tr("High", "High (priority)") + postfix;
                 break;
             case prio::MAXIMUM:
-                text = tr("Maximum", "Maximum (priority)");
+                text = tr("Maximum", "Maximum (priority)") + postfix;
                 break;
             default:
                 text = tr("Normal", "Normal (priority)");
                 break;
             }
+
             QItemDelegate::drawDisplay(painter, opt, option.rect, text);
         }
         break;

--- a/src/gui/torrentcontentmodel.h
+++ b/src/gui/torrentcontentmodel.h
@@ -36,6 +36,7 @@
 #include <QVector>
 #include <QVariant>
 
+#include "base/bittorrent/torrenthandle.h"
 #include "base/bittorrent/torrentinfo.h"
 #include "torrentcontentmodelitem.h"
 
@@ -63,10 +64,15 @@ public:
   virtual QModelIndex parent(const QModelIndex& index) const;
   virtual int rowCount(const QModelIndex& parent = QModelIndex()) const;
   void clear();
-  void setupModelData(const BitTorrent::TorrentInfo &info);
+  BitTorrent::FileAutoPriority getAutoPriorityType() const;
+  void setAutoPriorityType(BitTorrent::FileAutoPriority type);
+
+  using AutoPriorityType = BitTorrent::FileAutoPriority;
+  void setupModelData(const BitTorrent::TorrentInfo &info, AutoPriorityType sort = AutoPriorityType::NameAsc);
 
 signals:
   void filteredFilesChanged();
+  void dataChanged(const QModelIndex&, const QModelIndex&);
 
 public slots:
   void selectAll();
@@ -75,6 +81,7 @@ public slots:
 private:
   TorrentContentModelFolder* m_rootItem;
   QVector<TorrentContentModelFile*> m_filesIndex;
+  BitTorrent::FileAutoPriority m_fileAutoPrio;
 };
 
 #endif // TORRENTCONTENTMODEL_H


### PR DESCRIPTION
The explanation for this pull request is here: [Auto prioritize files (not pieces) #6402](https://github.com/qbittorrent/qBittorrent/issues/6402).
What do you think about this? If you also find this could be usefull maybe it should be enabled by default because now it's not.