### PR TITLE
Disable proxy in WebUI HTTP server. Closes #6349.

### DIFF
--- a/src/base/http/server.cpp
+++ b/src/base/http/server.cpp
@@ -33,6 +33,7 @@
 #else
 #include <QTcpSocket>
 #endif
+#include <QNetworkProxy>
 #include "connection.h"
 #include "server.h"
 
@@ -45,6 +46,7 @@ Server::Server(IRequestHandler *requestHandler, QObject *parent)
     , m_https(false)
 #endif
 {
+    setProxy(QNetworkProxy::NoProxy);
 }
 
 Server::~Server()


### PR DESCRIPTION
Due to a bug in Qt 5.8 (QTBUG-58706) QTcpServer tries to use HTTP proxy
when it is set as default app proxy (for instance via "http_prxy"
environment variable) and this breaks the server. So we disable any proxy
in it.