### PR TITLE
remove offsetWidth call in loop to improve webui performance

### DIFF
--- a/src/webui/www/public/scripts/dynamicTable.js
+++ b/src/webui/www/public/scripts/dynamicTable.js
@@ -851,7 +851,7 @@ var TorrentsTable = new Class({
 
                 if (td.getChildren('div').length) {
                     var div = td.getChildren('div')[0];
-                    var newWidth = td.offsetWidth - 5;
+                    var newWidth = 80;
                     if (div.lastWidth !== newWidth) {
                         div.setWidth(newWidth);
                         div.lastWidth = newWidth;
@@ -861,7 +861,7 @@ var TorrentsTable = new Class({
                 }
                 else
                     td.adopt(new ProgressBar(progressFormated.toFloat(), {
-                        'width' : td.offsetWidth - 5
+                        'width' : 80
                     }));
             };
 


### PR DESCRIPTION
offsetWidth is way to expensive to call it for every processbar.

I would be fine with the old 80px processbar. Otherwise we could store the offsetWidth calculation result based on the processbar table header someware as var and use it during td adjustments.

Something about how extrem the performance impact is:

Table with 200 Lines in chrom:
8000ms of 10000ms execution time for "style calculation" at line 864.

Table with 3500 lines
can't profile it but removing offsetWidth reduce the time from 150s to under 10s

But performance during resizing is quite good compared to the performance at initailisation. It does just lag a little bit with offsetWidth during resizing.