### PR TITLE
Fix issues when compiling with Qt4 

### DIFF
--- a/src/base/http/server.cpp
+++ b/src/base/http/server.cpp
@@ -28,14 +28,18 @@
  * exception statement from your version.
  */
 
+#include "server.h"
+
+#include <QNetworkProxy>
+#include <QStringList>
+
 #ifndef QT_NO_OPENSSL
 #include <QSslSocket>
 #else
 #include <QTcpSocket>
 #endif
-#include <QNetworkProxy>
+
 #include "connection.h"
-#include "server.h"
 
 using namespace Http;
 

--- a/src/base/utils/string.cpp
+++ b/src/base/utils/string.cpp
@@ -34,6 +34,7 @@
 #include <QByteArray>
 #include <QtGlobal>
 #include <QLocale>
+
 #ifdef QBT_USES_QT5
 #include <QCollator>
 #endif
@@ -217,6 +218,23 @@ QString Utils::String::toHtmlEscaped(const QString &str)
 #ifdef QBT_USES_QT5
     return str.toHtmlEscaped();
 #else
-    return Qt::escape(str);
+    // code from Qt
+    QString rich;
+    const int len = str.length();
+    rich.reserve(int(len * 1.1));
+    for (int i = 0; i < len; ++i) {
+        if (str.at(i) == QLatin1Char('<'))
+            rich += QLatin1String("&lt;");
+        else if (str.at(i) == QLatin1Char('>'))
+            rich += QLatin1String("&gt;");
+        else if (str.at(i) == QLatin1Char('&'))
+            rich += QLatin1String("&amp;");
+        else if (str.at(i) == QLatin1Char('"'))
+            rich += QLatin1String("&quot;");
+        else
+            rich += str.at(i);
+    }
+    rich.squeeze();
+    return rich;
 #endif
 }


### PR DESCRIPTION
@sledgehammer999 
* 2 commits for Qt4 should also merged into 3.3.x branch.
  The Qt::escape() is defined in QTextDocument header which is available only when gui=true. So I just borrowed the code from upstream.
