### PR TITLE
[WebUI-API] Add "skip_checking" and "paused" to "/command/download" and "/command/upload"

### DIFF
--- a/src/base/http/requestparser.cpp
+++ b/src/base/http/requestparser.cpp
@@ -198,14 +198,14 @@ QList<QByteArray> RequestParser::splitMultipartData(const QByteArray& data, cons
         start = end + sepLength; // skip first boundary
 
         while ((end = data.indexOf(sep, start)) >= 0) {
-            ret << data.mid(start, end - start);
+            ret << data.mid(start, end - EOL.length() - start);
             start = end + sepLength;
         }
 
         // last or single part
         sep = boundary + "--" + EOL;
         if ((end = data.indexOf(sep, start)) >= 0)
-            ret << data.mid(start, end - start);
+            ret << data.mid(start, end - EOL.length() - start);
     }
 
     return ret;

--- a/src/webui/abstractwebapplication.cpp
+++ b/src/webui/abstractwebapplication.cpp
@@ -245,7 +245,7 @@ void AbstractWebApplication::translateDocument(QString& data)
         "options_imp", "Preferences", "TrackersAdditionDlg", "ScanFoldersModel",
         "PropTabBar", "TorrentModel", "downloadFromURL", "MainWindow", "misc",
         "StatusBar", "AboutDlg", "about", "PeerListWidget", "StatusFiltersWidget",
-        "CategoryFiltersList", "TransferListDelegate"
+        "CategoryFiltersList", "TransferListDelegate", "AddNewTorrentDialog"
     };
     const size_t context_count = sizeof(contexts) / sizeof(contexts[0]);
     int i = 0;

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -367,6 +367,8 @@ void WebApplication::action_command_download()
     CHECK_URI(0);
     QString urls = request().posts["urls"];
     QStringList list = urls.split('\n');
+    bool skipChecking = request().posts["skip_checking"] == "true";
+    bool addPaused = request().posts["paused"] == "true";
     QString savepath = request().posts["savepath"];
     QString category = request().posts["category"];
     QString cookie = request().posts["cookie"];
@@ -390,6 +392,11 @@ void WebApplication::action_command_download()
     category = category.trimmed();
 
     BitTorrent::AddTorrentParams params;
+
+    // TODO: Check if destination actually exists
+    params.skipChecking = skipChecking;
+
+    params.addPaused = addPaused;
     params.savePath = savepath;
     params.category = category;
 
@@ -406,6 +413,8 @@ void WebApplication::action_command_upload()
 {
     qDebug() << Q_FUNC_INFO;
     CHECK_URI(0);
+    bool skipChecking = request().posts["skip_checking"] == "true";
+    bool addPaused = request().posts["paused"] == "true";
     QString savepath = request().posts["savepath"];
     QString category = request().posts["category"];
 
@@ -423,6 +432,11 @@ void WebApplication::action_command_upload()
             }
             else {
                 BitTorrent::AddTorrentParams params;
+
+                 // TODO: Check if destination actually exists
+                params.skipChecking = skipChecking;
+
+                params.addPaused = addPaused;
                 params.savePath = savepath;
                 params.category = category;
                 if (!BitTorrent::Session::instance()->addTorrent(torrentInfo, params)) {

--- a/src/webui/www/public/download.html
+++ b/src/webui/www/public/download.html
@@ -29,6 +29,15 @@
     <label for="category" class="leftLabelLarge">QBT_TR(Category:)QBT_TR</label>
     <input type="text" id="category" name="category" style="width: 16em;"/>
 </div>
+<div class="formRow">
+    <label for="start_torrent" class="leftLabelLarge">QBT_TR(Start torrent)QBT_TR</label>
+    <input type="checkbox" id="start_torrent" checked="checked" style="width: 16em;"/>
+    <input type="hidden" id="add_paused" name="paused" value="true" disabled="disabled"/>
+</div>
+<div class="formRow">
+    <label for="skip_checking" class="leftLabelLarge">QBT_TR(Skip hash check)QBT_TR</label>
+    <input type="checkbox" name="skip_checking" value="true" style="width: 16em;"/>
+</div>
 <div id="submitbutton" style="margin-top: 12px; text-align: center;">
     <button type="submit" id="submitButton">QBT_TR(Download)QBT_TR</button>
 </div>
@@ -46,6 +55,10 @@ $('downloadForm').addEventListener("submit", function() {
 $('download_frame').addEventListener("load", function() {
     if (submitted)
             window.parent.closeWindows();
+});
+
+$('start_torrent').addEventListener('change', function() {
+    $('add_paused').disabled = $('start_torrent').checked;
 });
 </script>
 <div id="download_spinner" class="mochaSpinner"></div>

--- a/src/webui/www/public/scripts/mocha-init.js
+++ b/src/webui/www/public/scripts/mocha-init.js
@@ -97,7 +97,7 @@ initializeWindows = function() {
             paddingVertical: 0,
             paddingHorizontal: 0,
             width: 500,
-            height: 200
+            height: 220
         });
         updateMainData();
     });

--- a/src/webui/www/public/upload.html
+++ b/src/webui/www/public/upload.html
@@ -25,6 +25,15 @@
     <label for="category" class="leftLabelLarge">QBT_TR(Category:)QBT_TR</label>
 	<input type="text" id="category" name="category"/ style="width: 16em;"/>
 </div>
+<div class="formRow">
+    <label for="start_torrent" class="leftLabelLarge">QBT_TR(Start torrent)QBT_TR</label>
+    <input type="checkbox" id="start_torrent" checked="checked" style="width: 16em;"/>
+    <input type="hidden" id="add_paused" name="paused" value="true" disabled="disabled"/>
+</div>
+<div class="formRow">
+    <label for="skip_checking" class="leftLabelLarge">QBT_TR(Skip hash check)QBT_TR</label>
+    <input type="checkbox" name="skip_checking" value="true" style="width: 16em;"/>
+</div>
 <div id="submitbutton" style="margin-top: 30px; text-align: center;">
 	<button type="submit" style="font-size: 1em;">QBT_TR(Upload Torrents)QBT_TR</button>
 </div>
@@ -42,6 +51,10 @@ $('uploadForm').addEventListener("submit", function() {
 $('upload_frame').addEventListener("load", function() {
 	if (submitted)
 		window.parent.closeWindows();
+});
+
+$('start_torrent').addEventListener('change', function() {
+    $('add_paused').disabled = $('start_torrent').checked;
 });
 </script>
 <div id="upload_spinner" class="mochaSpinner"></div>


### PR DESCRIPTION
API design

Adding two post fields to `command/download` and `/command/upload`.

- `skip_checking`: Skip hash checking if `skip_checking` is presented and of string value `true`.
- `paused`: Add task as paused state, if `paused` is presented and of string value `true`.

### Download torrent from URL ###

```http
POST /command/download HTTP/1.1
User-Agent: Fiddler
Host: 127.0.0.1
Cookie: SID=your_sid
Content-Type: multipart/form-data; boundary=---------------------------6688794727912
Content-Length: length

-----------------------------6688794727912
Content-Disposition: form-data; name="urls"

https://torcache.net/torrent/3B1A1469C180F447B77021074DBBCCAEF62611E7.torrent
https://torcache.net/torrent/3B1A1469C180F447B77021074DBBCCAEF62611E8.torrent
-----------------------------6688794727912
Content-Disposition: form-data; name="savepath"

C:/Users/qBit/Downloads
-----------------------------6688794727912
Content-Disposition: form-data; name="cookie"

ui=28979218048197
-----------------------------6688794727912
Content-Disposition: form-data; name="category"

movies
-----------------------------6688794727912
Content-Disposition: form-data; name="skip_checking"

true
-----------------------------6688794727912
Content-Disposition: form-data; name="paused"

true
-----------------------------6688794727912--
```

Property                      | Type    | Description
------------------------------|---------|------------
`urls`                        | string  | URLs separated with newlines
`savepath`                    | string  | (optional) Download folder
`cookie`                      | string  | (optional) Cookie sent to download the .torrent file
`category`                    | string  | (optional) Category for the torrent
`skip_checking`                    | string  | (optional) Skip hash checking if `skip_checking` is presented and of string value `true`
`paused`                    | string  | (optional) Add task as paused state, if `paused` is presented and of string value `true`

### Upload torrent from disk ###

```http
POST /command/upload HTTP/1.1
Content-Type: multipart/form-data; boundary=-------------------------acebdf13572468
User-Agent: Fiddler
Host: 127.0.0.1
Cookie: SID=your_sid
Content-Length: length

---------------------------acebdf13572468
Content-Disposition: form-data; name="torrents"; filename="8f18036b7a205c9347cb84a253975e12f7adddf2.torrent"
Content-Type: application/x-bittorrent

file_binary_data_goes_here
---------------------------acebdf13572468
Content-Disposition: form-data; name="torrents"; filename="UFS.torrent"
Content-Type: application/x-bittorrent

file_binary_data_goes_here
---------------------------acebdf13572468
Content-Disposition: form-data; name="skip_checking"

true
---------------------------acebdf13572468
Content-Disposition: form-data; name="paused"

true
---------------------------acebdf13572468--

```


Related issues:
https://github.com/qbittorrent/qBittorrent/issues/6024
https://github.com/qbittorrent/qBittorrent/issues/3227
