### PR TITLE
Remove remainings of Qt4

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,7 +66,6 @@ endif (CMAKE_BUILD_TYPE STREQUAL "Debug")
 
 set(QBT_USE_GUI ${GUI})
 set(QBT_USE_WEBUI ${WEBUI})
-set(QBT_USES_QT5 ${QT5})
 
 configure_file(config.h.cmakein ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 

--- a/src/app/upgrade.h
+++ b/src/app/upgrade.h
@@ -119,7 +119,7 @@ bool upgradeResumeFile(const QString &filepath, const QVariantHash &oldTorrent =
     }
     else {
         queuePosition = fastOld.dict_find_int_value("qBt-queuePosition", 0);
-        fastNew["qBt-name"] = Utils::String::toStdString(oldTorrent.value("name").toString());
+        fastNew["qBt-name"] = oldTorrent.value("name").toString().toStdString();
         fastNew["qBt-tempPathDisabled"] = false;
     }
 
@@ -192,14 +192,14 @@ bool upgrade(bool ask = true)
         QVariantHash oldTorrent = oldResumeData[hash].toHash();
         if (oldTorrent.value("is_magnet", false).toBool()) {
             libtorrent::entry resumeData;
-            resumeData["qBt-magnetUri"] = Utils::String::toStdString(oldTorrent.value("magnet_uri").toString());
+            resumeData["qBt-magnetUri"] = oldTorrent.value("magnet_uri").toString().toStdString();
             resumeData["qBt-paused"] = false;
             resumeData["qBt-forced"] = false;
 
-            resumeData["qBt-savePath"] = Utils::String::toStdString(oldTorrent.value("save_path").toString());
-            resumeData["qBt-ratioLimit"] = Utils::String::toStdString(QString::number(oldTorrent.value("max_ratio", -2).toReal()));
-            resumeData["qBt-label"] = Utils::String::toStdString(oldTorrent.value("label").toString());
-            resumeData["qBt-name"] = Utils::String::toStdString(oldTorrent.value("name").toString());
+            resumeData["qBt-savePath"] = oldTorrent.value("save_path").toString().toStdString();
+            resumeData["qBt-ratioLimit"] = QString::number(oldTorrent.value("max_ratio", -2).toReal()).toStdString();
+            resumeData["qBt-label"] = oldTorrent.value("label").toString().toStdString();
+            resumeData["qBt-name"] = oldTorrent.value("name").toString().toStdString();
             resumeData["qBt-seedStatus"] = oldTorrent.value("seed").toBool();
             resumeData["qBt-tempPathDisabled"] = false;
 

--- a/src/base/bittorrent/magneturi.cpp
+++ b/src/base/bittorrent/magneturi.cpp
@@ -80,10 +80,10 @@ MagnetUri::MagnetUri(const QString &source)
 
     m_valid = true;
     m_hash = m_addTorrentParams.info_hash;
-    m_name = Utils::String::fromStdString(m_addTorrentParams.name);
+    m_name = QString::fromStdString(m_addTorrentParams.name);
 
     foreach (const std::string &tracker, m_addTorrentParams.trackers)
-        m_trackers.append(Utils::String::fromStdString(tracker));
+        m_trackers.append(QString::fromStdString(tracker));
 
     foreach (const std::string &urlSeed, m_addTorrentParams.url_seeds)
         m_urlSeeds.append(QUrl(urlSeed.c_str()));

--- a/src/base/bittorrent/peerinfo.cpp
+++ b/src/base/bittorrent/peerinfo.cpp
@@ -198,7 +198,7 @@ PeerAddress PeerInfo::address() const
 
 QString PeerInfo::client() const
 {
-    return Utils::String::fromStdString(m_nativeInfo.client);
+    return QString::fromStdString(m_nativeInfo.client);
 }
 
 

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -367,7 +367,7 @@ Session::Session(QObject *parent)
         m_nativeSession->add_extension(&libt::create_ut_pex_plugin);
     m_nativeSession->add_extension(&libt::create_smart_ban_plugin);
 
-    logger->addMessage(tr("Peer ID: ") + Utils::String::fromStdString(peerId));
+    logger->addMessage(tr("Peer ID: ") + QString::fromStdString(peerId));
     logger->addMessage(tr("HTTP User-Agent is '%1'").arg(USER_AGENT));
     logger->addMessage(tr("DHT support [%1]").arg(isDHTEnabled() ? tr("ON") : tr("OFF")), Log::INFO);
     logger->addMessage(tr("Local Peer Discovery support [%1]").arg(isLSDEnabled() ? tr("ON") : tr("OFF")), Log::INFO);
@@ -3265,7 +3265,7 @@ void Session::handleAlert(libt::alert *a)
         }
     }
     catch (std::exception &exc) {
-        qWarning() << "Caught exception in " << Q_FUNC_INFO << ": " << Utils::String::fromStdString(exc.what());
+        qWarning() << "Caught exception in " << Q_FUNC_INFO << ": " << QString::fromStdString(exc.what());
     }
 }
 
@@ -3347,7 +3347,7 @@ void Session::handleAddTorrentAlert(libt::add_torrent_alert *p)
 {
     if (p->error) {
         qDebug("/!\\ Error: Failed to add torrent!");
-        QString msg = Utils::String::fromStdString(p->message());
+        QString msg = QString::fromStdString(p->message());
         Logger::instance()->addMessage(tr("Couldn't add torrent. Reason: %1").arg(msg), Log::WARNING);
         emit addTorrentFailed(msg);
     }
@@ -3395,7 +3395,7 @@ void Session::handleFileErrorAlert(libt::file_error_alert *p)
     // NOTE: Check this function!
     TorrentHandle *const torrent = m_torrents.value(p->handle.info_hash());
     if (torrent) {
-        QString msg = Utils::String::fromStdString(p->message());
+        QString msg = QString::fromStdString(p->message());
         Logger::instance()->addMessage(tr("An I/O error occurred, '%1' paused. %2")
                            .arg(torrent->name()).arg(msg));
         emit fullDiskError(torrent, msg);
@@ -3404,13 +3404,13 @@ void Session::handleFileErrorAlert(libt::file_error_alert *p)
 
 void Session::handlePortmapWarningAlert(libt::portmap_error_alert *p)
 {
-    Logger::instance()->addMessage(tr("UPnP/NAT-PMP: Port mapping failure, message: %1").arg(Utils::String::fromStdString(p->message())), Log::CRITICAL);
+    Logger::instance()->addMessage(tr("UPnP/NAT-PMP: Port mapping failure, message: %1").arg(QString::fromStdString(p->message())), Log::CRITICAL);
 }
 
 void Session::handlePortmapAlert(libt::portmap_alert *p)
 {
     qDebug("UPnP Success, msg: %s", p->message().c_str());
-    Logger::instance()->addMessage(tr("UPnP/NAT-PMP: Port mapping successful, message: %1").arg(Utils::String::fromStdString(p->message())), Log::INFO);
+    Logger::instance()->addMessage(tr("UPnP/NAT-PMP: Port mapping successful, message: %1").arg(QString::fromStdString(p->message())), Log::INFO);
 }
 
 void Session::handlePeerBlockedAlert(libt::peer_blocked_alert *p)
@@ -3453,7 +3453,7 @@ void Session::handlePeerBanAlert(libt::peer_ban_alert *p)
 
 void Session::handleUrlSeedAlert(libt::url_seed_alert *p)
 {
-    Logger::instance()->addMessage(tr("URL seed lookup failed for URL: '%1', message: %2").arg(Utils::String::fromStdString(p->url)).arg(Utils::String::fromStdString(p->message())), Log::CRITICAL);
+    Logger::instance()->addMessage(tr("URL seed lookup failed for URL: '%1', message: %2").arg(QString::fromStdString(p->url)).arg(QString::fromStdString(p->message())), Log::CRITICAL);
 }
 
 void Session::handleListenSucceededAlert(libt::listen_succeeded_alert *p)
@@ -3567,20 +3567,20 @@ namespace
         if (ec || (fast.type() != libt::bdecode_node::dict_t)) return false;
 #endif
 
-        torrentData.savePath = Utils::Fs::fromNativePath(Utils::String::fromStdString(fast.dict_find_string_value("qBt-savePath")));
-        torrentData.ratioLimit = Utils::String::fromStdString(fast.dict_find_string_value("qBt-ratioLimit")).toDouble();
+        torrentData.savePath = Utils::Fs::fromNativePath(QString::fromStdString(fast.dict_find_string_value("qBt-savePath")));
+        torrentData.ratioLimit = QString::fromStdString(fast.dict_find_string_value("qBt-ratioLimit")).toDouble();
         // **************************************************************************************
         // Workaround to convert legacy label to category
         // TODO: Should be removed in future
-        torrentData.category = Utils::String::fromStdString(fast.dict_find_string_value("qBt-label"));
+        torrentData.category = QString::fromStdString(fast.dict_find_string_value("qBt-label"));
         if (torrentData.category.isEmpty())
         // **************************************************************************************
-            torrentData.category = Utils::String::fromStdString(fast.dict_find_string_value("qBt-category"));
-        torrentData.name = Utils::String::fromStdString(fast.dict_find_string_value("qBt-name"));
+            torrentData.category = QString::fromStdString(fast.dict_find_string_value("qBt-category"));
+        torrentData.name = QString::fromStdString(fast.dict_find_string_value("qBt-name"));
         torrentData.hasSeedStatus = fast.dict_find_int_value("qBt-seedStatus");
         torrentData.disableTempPath = fast.dict_find_int_value("qBt-tempPathDisabled");
 
-        magnetUri = MagnetUri(Utils::String::fromStdString(fast.dict_find_string_value("qBt-magnetUri")));
+        magnetUri = MagnetUri(QString::fromStdString(fast.dict_find_string_value("qBt-magnetUri")));
         torrentData.addPaused = fast.dict_find_int_value("qBt-paused");
         torrentData.addForced = fast.dict_find_int_value("qBt-forced");
 

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -976,11 +976,11 @@ void Session::configure(libtorrent::settings_pack &settingsPack)
     Net::ProxyConfiguration proxyConfig = proxyManager->proxyConfiguration();
     if (m_useProxy || (proxyConfig.type != Net::ProxyType::None)) {
         if (proxyConfig.type != Net::ProxyType::None) {
-            settingsPack.set_str(libt::settings_pack::proxy_hostname, Utils::String::toStdString(proxyConfig.ip));
+            settingsPack.set_str(libt::settings_pack::proxy_hostname, proxyConfig.ip.toStdString());
             settingsPack.set_int(libt::settings_pack::proxy_port, proxyConfig.port);
             if (proxyManager->isAuthenticationRequired()) {
-                settingsPack.set_str(libt::settings_pack::proxy_username, Utils::String::toStdString(proxyConfig.username));
-                settingsPack.set_str(libt::settings_pack::proxy_password, Utils::String::toStdString(proxyConfig.password));
+                settingsPack.set_str(libt::settings_pack::proxy_username, proxyConfig.username.toStdString());
+                settingsPack.set_str(libt::settings_pack::proxy_password, proxyConfig.password.toStdString());
             }
             settingsPack.set_bool(libt::settings_pack::proxy_peer_connections, isProxyPeerConnectionsEnabled());
         }
@@ -1055,7 +1055,7 @@ void Session::configure(libtorrent::settings_pack &settingsPack)
     // Include overhead in transfer limits
     settingsPack.set_bool(libt::settings_pack::rate_limit_ip_overhead, includeOverheadInLimits());
     // IP address to announce to trackers
-    settingsPack.set_str(libt::settings_pack::announce_ip, Utils::String::toStdString(announceIP()));
+    settingsPack.set_str(libt::settings_pack::announce_ip, announceIP().toStdString());
     // Super seeding
     settingsPack.set_bool(libt::settings_pack::strict_super_seeding, isSuperSeedingEnabled());
     // * Max Half-open connections
@@ -1123,11 +1123,11 @@ void Session::configure(libtorrent::session_settings &sessionSettings)
     if (m_useProxy || (proxyConfig.type != Net::ProxyType::None)) {
         libt::proxy_settings proxySettings;
         if (proxyConfig.type != Net::ProxyType::None) {
-            proxySettings.hostname = Utils::String::toStdString(proxyConfig.ip);
+            proxySettings.hostname = proxyConfig.ip.toStdString();
             proxySettings.port = proxyConfig.port;
             if (proxyManager->isAuthenticationRequired()) {
-                proxySettings.username = Utils::String::toStdString(proxyConfig.username);
-                proxySettings.password = Utils::String::toStdString(proxyConfig.password);
+                proxySettings.username = proxyConfig.username.toStdString();
+                proxySettings.password = proxyConfig.password.toStdString();
             }
             proxySettings.proxy_peer_connections = isProxyPeerConnectionsEnabled();
         }
@@ -1200,7 +1200,7 @@ void Session::configure(libtorrent::session_settings &sessionSettings)
     // Include overhead in transfer limits
     sessionSettings.rate_limit_ip_overhead = includeOverheadInLimits();
     // IP address to announce to trackers
-    sessionSettings.announce_ip = Utils::String::toStdString(announceIP());
+    sessionSettings.announce_ip = announceIP().toStdString();
     // Super seeding
     sessionSettings.strict_super_seeding = isSuperSeedingEnabled();
     // * Max Half-open connections
@@ -1699,7 +1699,7 @@ bool Session::addTorrent_impl(AddTorrentData addData, const MagnetUri &magnetUri
     // Limits
     p.max_connections = maxConnectionsPerTorrent();
     p.max_uploads = maxUploadsPerTorrent();
-    p.save_path = Utils::String::toStdString(Utils::Fs::toNativePath(savePath));
+    p.save_path = Utils::Fs::toNativePath(savePath).toStdString();
 
     m_addingTorrents.insert(hash, addData);
     // Adding torrent to BitTorrent session
@@ -1787,7 +1787,7 @@ bool Session::loadMetadata(const MagnetUri &magnetUri)
     p.max_uploads = maxUploadsPerTorrent();
 
     QString savePath = QString("%1/%2").arg(QDir::tempPath()).arg(hash);
-    p.save_path = Utils::String::toStdString(Utils::Fs::toNativePath(savePath));
+    p.save_path = Utils::Fs::toNativePath(savePath).toStdString();
 
     // Forced start
     p.flags &= ~libt::add_torrent_params::flag_paused;

--- a/src/base/bittorrent/torrentcreatorthread.cpp
+++ b/src/base/bittorrent/torrentcreatorthread.cpp
@@ -107,14 +107,14 @@ void TorrentCreatorThread::run()
     try {
         libt::file_storage fs;
         // Adding files to the torrent
-        libt::add_files(fs, Utils::String::toStdString(Utils::Fs::toNativePath(m_inputPath)), fileFilter);
+        libt::add_files(fs, Utils::Fs::toNativePath(m_inputPath).toStdString(), fileFilter);
         if (m_abort) return;
 
         libt::create_torrent t(fs, m_pieceSize);
 
         // Add url seeds
         foreach (const QString &seed, m_urlSeeds)
-            t.add_url_seed(Utils::String::toStdString(seed.trimmed()));
+            t.add_url_seed(seed.trimmed().toStdString());
 
         int tier = 0;
         bool newline = false;
@@ -126,14 +126,14 @@ void TorrentCreatorThread::run()
                 newline = true;
                 continue;
             }
-            t.add_tracker(Utils::String::toStdString(tracker.trimmed()), tier);
+            t.add_tracker(tracker.trimmed().toStdString(), tier);
             newline = false;
         }
         if (m_abort) return;
 
         // calculate the hash for all pieces
         const QString parentPath = Utils::Fs::branchPath(m_inputPath) + "/";
-        libt::set_piece_hashes(t, Utils::String::toStdString(Utils::Fs::toNativePath(parentPath)), boost::bind(&TorrentCreatorThread::sendProgressSignal, this, _1, t.num_pieces()));
+        libt::set_piece_hashes(t, Utils::Fs::toNativePath(parentPath).toStdString(), boost::bind(&TorrentCreatorThread::sendProgressSignal, this, _1, t.num_pieces()));
         // Set qBittorrent as creator and add user comment to
         // torrent_info structure
         t.set_creator(creator_str.toUtf8().constData());

--- a/src/base/bittorrent/torrentcreatorthread.cpp
+++ b/src/base/bittorrent/torrentcreatorthread.cpp
@@ -55,7 +55,7 @@ using namespace BitTorrent;
 // name starts with a .
 bool fileFilter(const std::string &f)
 {
-    return !Utils::Fs::fileName(Utils::String::fromStdString(f)).startsWith('.');
+    return !Utils::Fs::fileName(QString::fromStdString(f)).startsWith('.');
 }
 
 TorrentCreatorThread::TorrentCreatorThread(QObject *parent)
@@ -163,6 +163,6 @@ void TorrentCreatorThread::run()
         emit creationSuccess(m_savePath, parentPath);
     }
     catch (std::exception& e) {
-        emit creationFailure(Utils::String::fromStdString(e.what()));
+        emit creationFailure(QString::fromStdString(e.what()));
     }
 }

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -484,7 +484,7 @@ bool TorrentHandle::addUrlSeed(const QUrl &urlSeed)
     QList<QUrl> seeds = urlSeeds();
     if (seeds.contains(urlSeed)) return false;
 
-    SAFE_CALL_BOOL(add_url_seed, Utils::String::toStdString(urlSeed.toString()));
+    SAFE_CALL_BOOL(add_url_seed, urlSeed.toString().toStdString());
 }
 
 bool TorrentHandle::removeUrlSeed(const QUrl &urlSeed)
@@ -492,13 +492,13 @@ bool TorrentHandle::removeUrlSeed(const QUrl &urlSeed)
     QList<QUrl> seeds = urlSeeds();
     if (!seeds.contains(urlSeed)) return false;
 
-    SAFE_CALL_BOOL(remove_url_seed, Utils::String::toStdString(urlSeed.toString()));
+    SAFE_CALL_BOOL(remove_url_seed, urlSeed.toString().toStdString());
 }
 
 bool TorrentHandle::connectPeer(const PeerAddress &peerAddress)
 {
     libt::error_code ec;
-    libt::address addr = libt::address::from_string(Utils::String::toStdString(peerAddress.ip.toString()), ec);
+    libt::address addr = libt::address::from_string(peerAddress.ip.toString().toStdString(), ec);
     if (ec) return false;
 
     boost::asio::ip::tcp::endpoint ep(addr, peerAddress.port);
@@ -1338,7 +1338,7 @@ void TorrentHandle::renameFile(int index, const QString &name)
 {
     ++m_renameCount;
     qDebug() << Q_FUNC_INFO << index << name;
-    SAFE_CALL(rename_file, index, Utils::String::toStdString(Utils::Fs::toNativePath(name)));
+    SAFE_CALL(rename_file, index, Utils::Fs::toNativePath(name).toStdString());
 }
 
 bool TorrentHandle::saveTorrentFile(const QString &path)
@@ -1530,14 +1530,14 @@ void TorrentHandle::handleSaveResumeDataAlert(libtorrent::save_resume_data_alert
 
     libtorrent::entry &resumeData = useDummyResumeData ? dummyEntry : *(p->resume_data);
     if (useDummyResumeData) {
-        resumeData["qBt-magnetUri"] = Utils::String::toStdString(toMagnetUri());
+        resumeData["qBt-magnetUri"] = toMagnetUri().toStdString();
         resumeData["qBt-paused"] = isPaused();
         resumeData["qBt-forced"] = isForced();
     }
-    resumeData["qBt-savePath"] = m_useAutoTMM ? "" : Utils::String::toStdString(m_savePath);
-    resumeData["qBt-ratioLimit"] = Utils::String::toStdString(QString::number(m_ratioLimit));
-    resumeData["qBt-category"] = Utils::String::toStdString(m_category);
-    resumeData["qBt-name"] = Utils::String::toStdString(m_name);
+    resumeData["qBt-savePath"] = m_useAutoTMM ? "" : m_savePath.toStdString();
+    resumeData["qBt-ratioLimit"] = QString::number(m_ratioLimit).toStdString();
+    resumeData["qBt-category"] = m_category.toStdString();
+    resumeData["qBt-name"] = m_name.toStdString();
     resumeData["qBt-seedStatus"] = m_hasSeedStatus;
     resumeData["qBt-tempPathDisabled"] = m_tempPathDisabled;
     resumeData["qBt-queuePosition"] = queuePosition();

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -263,7 +263,7 @@ QString TorrentHandle::name() const
 {
     QString name = m_name;
     if (name.isEmpty())
-        name = Utils::String::fromStdString(m_nativeStatus.name);
+        name = QString::fromStdString(m_nativeStatus.name);
 
     if (name.isEmpty())
         name = m_hash;
@@ -324,7 +324,7 @@ qlonglong TorrentHandle::wastedSize() const
 
 QString TorrentHandle::currentTracker() const
 {
-    return Utils::String::fromStdString(m_nativeStatus.current_tracker);
+    return QString::fromStdString(m_nativeStatus.current_tracker);
 }
 
 QString TorrentHandle::savePath(bool actual) const
@@ -371,7 +371,7 @@ void TorrentHandle::setAutoTMMEnabled(bool enabled)
 
 QString TorrentHandle::nativeActualSavePath() const
 {
-    return Utils::String::fromStdString(m_nativeStatus.save_path);
+    return QString::fromStdString(m_nativeStatus.save_path);
 }
 
 QList<TrackerEntry> TorrentHandle::trackers() const
@@ -858,7 +858,7 @@ int TorrentHandle::queuePosition() const
 
 QString TorrentHandle::error() const
 {
-    return Utils::String::fromStdString(m_nativeStatus.error);
+    return QString::fromStdString(m_nativeStatus.error);
 }
 
 qlonglong TorrentHandle::totalDownload() const
@@ -1380,7 +1380,7 @@ void TorrentHandle::handleStorageMovedAlert(libtorrent::storage_moved_alert *p)
         return;
     }
 
-    const QString newPath = Utils::String::fromStdString(p->path);
+    const QString newPath = QString::fromStdString(p->path);
     if (newPath != m_newPath) {
         qWarning() << Q_FUNC_INFO << ": New path doesn't match a path in a queue.";
         return;
@@ -1412,7 +1412,7 @@ void TorrentHandle::handleStorageMovedFailedAlert(libtorrent::storage_moved_fail
     }
 
     Logger::instance()->addMessage(tr("Could not move torrent: '%1'. Reason: %2")
-                                   .arg(name()).arg(Utils::String::fromStdString(p->message())), Log::CRITICAL);
+                                   .arg(name()).arg(QString::fromStdString(p->message())), Log::CRITICAL);
 
     m_newPath.clear();
     if (!m_queuedPath.isEmpty()) {
@@ -1426,7 +1426,7 @@ void TorrentHandle::handleStorageMovedFailedAlert(libtorrent::storage_moved_fail
 
 void TorrentHandle::handleTrackerReplyAlert(libtorrent::tracker_reply_alert *p)
 {
-    QString trackerUrl = Utils::String::fromStdString(p->url);
+    QString trackerUrl = QString::fromStdString(p->url);
     qDebug("Received a tracker reply from %s (Num_peers = %d)", qPrintable(trackerUrl), p->num_peers);
     // Connection was successful now. Remove possible old errors
     m_trackerInfos[trackerUrl].lastMessage.clear(); // Reset error/warning message
@@ -1437,8 +1437,8 @@ void TorrentHandle::handleTrackerReplyAlert(libtorrent::tracker_reply_alert *p)
 
 void TorrentHandle::handleTrackerWarningAlert(libtorrent::tracker_warning_alert *p)
 {
-    QString trackerUrl = Utils::String::fromStdString(p->url);
-    QString message = Utils::String::fromStdString(p->msg);
+    QString trackerUrl = QString::fromStdString(p->url);
+    QString message = QString::fromStdString(p->msg);
     qDebug("Received a tracker warning for %s: %s", qPrintable(trackerUrl), qPrintable(message));
     // Connection was successful now but there is a warning message
     m_trackerInfos[trackerUrl].lastMessage = message; // Store warning message
@@ -1448,8 +1448,8 @@ void TorrentHandle::handleTrackerWarningAlert(libtorrent::tracker_warning_alert 
 
 void TorrentHandle::handleTrackerErrorAlert(libtorrent::tracker_error_alert *p)
 {
-    QString trackerUrl = Utils::String::fromStdString(p->url);
-    QString message = Utils::String::fromStdString(p->msg);
+    QString trackerUrl = QString::fromStdString(p->url);
+    QString message = QString::fromStdString(p->msg);
     qDebug("Received a tracker error for %s: %s", qPrintable(trackerUrl), qPrintable(message));
     m_trackerInfos[trackerUrl].lastMessage = message;
 
@@ -1570,13 +1570,13 @@ void TorrentHandle::handleFastResumeRejectedAlert(libtorrent::fastresume_rejecte
     }
     else {
         logger->addMessage(tr("Fast resume data was rejected for torrent '%1'. Reason: %2. Checking again...")
-                           .arg(name()).arg(Utils::String::fromStdString(p->message())), Log::CRITICAL);
+                           .arg(name()).arg(QString::fromStdString(p->message())), Log::CRITICAL);
     }
 }
 
 void TorrentHandle::handleFileRenamedAlert(libtorrent::file_renamed_alert *p)
 {
-    QString newName = Utils::Fs::fromNativePath(Utils::String::fromStdString(p->name));
+    QString newName = Utils::Fs::fromNativePath(QString::fromStdString(p->name));
 
     // TODO: Check this!
     if (filesCount() > 1) {
@@ -1857,7 +1857,7 @@ void TorrentHandle::flushCache()
 
 QString TorrentHandle::toMagnetUri() const
 {
-    return Utils::String::fromStdString(libt::make_magnet_uri(m_nativeHandle));
+    return QString::fromStdString(libt::make_magnet_uri(m_nativeHandle));
 }
 
 void TorrentHandle::prioritizeFiles(const QVector<int> &priorities)

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -93,7 +93,7 @@ InfoHash TorrentInfo::hash() const
 QString TorrentInfo::name() const
 {
     if (!isValid()) return QString();
-    return Utils::String::fromStdString(m_nativeInfo->name());
+    return QString::fromStdString(m_nativeInfo->name());
 }
 
 QDateTime TorrentInfo::creationDate() const
@@ -106,13 +106,13 @@ QDateTime TorrentInfo::creationDate() const
 QString TorrentInfo::creator() const
 {
     if (!isValid()) return QString();
-    return Utils::String::fromStdString(m_nativeInfo->creator());
+    return QString::fromStdString(m_nativeInfo->creator());
 }
 
 QString TorrentInfo::comment() const
 {
     if (!isValid()) return QString();
-    return Utils::String::fromStdString(m_nativeInfo->comment());
+    return QString::fromStdString(m_nativeInfo->comment());
 }
 
 bool TorrentInfo::isPrivate() const
@@ -154,7 +154,7 @@ int TorrentInfo::piecesCount() const
 QString TorrentInfo::filePath(int index) const
 {
     if (!isValid()) return QString();
-    return Utils::Fs::fromNativePath(Utils::String::fromStdString(m_nativeInfo->files().file_path(index)));
+    return Utils::Fs::fromNativePath(QString::fromStdString(m_nativeInfo->files().file_path(index)));
 }
 
 QStringList TorrentInfo::filePaths() const
@@ -174,7 +174,7 @@ QString TorrentInfo::fileName(int index) const
 QString TorrentInfo::origFilePath(int index) const
 {
     if (!isValid()) return QString();
-    return Utils::Fs::fromNativePath(Utils::String::fromStdString(m_nativeInfo->orig_files().file_path(index)));
+    return Utils::Fs::fromNativePath(QString::fromStdString(m_nativeInfo->orig_files().file_path(index)));
 }
 
 qlonglong TorrentInfo::fileSize(int index) const

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -64,7 +64,7 @@ TorrentInfo TorrentInfo::loadFromFile(const QString &path, QString &error)
 {
     error.clear();
     libt::error_code ec;
-    TorrentInfo info(NativePtr(new libt::torrent_info(Utils::String::toStdString(Utils::Fs::toNativePath(path)), ec)));
+    TorrentInfo info(NativePtr(new libt::torrent_info(Utils::Fs::toNativePath(path).toStdString(), ec)));
     if (ec) {
         error = QString::fromUtf8(ec.message().c_str());
         qDebug("Cannot load .torrent file: %s", qPrintable(error));
@@ -279,7 +279,7 @@ TorrentInfo::PieceRange TorrentInfo::filePieces(int fileIndex) const
 void TorrentInfo::renameFile(uint index, const QString &newPath)
 {
     if (!isValid()) return;
-    nativeInfo()->rename_file(index, Utils::String::toStdString(newPath));
+    nativeInfo()->rename_file(index, newPath.toStdString());
 }
 
 int BitTorrent::TorrentInfo::fileIndex(const QString& fileName) const

--- a/src/base/bittorrent/tracker.cpp
+++ b/src/base/bittorrent/tracker.cpp
@@ -65,8 +65,8 @@ libtorrent::entry Peer::toEntry(bool noPeerId) const
 {
     libtorrent::entry::dictionary_type peerMap;
     if (!noPeerId)
-        peerMap["id"] = libtorrent::entry(Utils::String::toStdString(peerId));
-    peerMap["ip"] = libtorrent::entry(Utils::String::toStdString(ip));
+        peerMap["id"] = libtorrent::entry(peerId.toStdString());
+    peerMap["ip"] = libtorrent::entry(ip.toStdString());
     peerMap["port"] = libtorrent::entry(port);
 
     return libtorrent::entry(peerMap);

--- a/src/base/bittorrent/trackerentry.cpp
+++ b/src/base/bittorrent/trackerentry.cpp
@@ -35,7 +35,7 @@
 using namespace BitTorrent;
 
 TrackerEntry::TrackerEntry(const QString &url)
-    : m_nativeEntry(libtorrent::announce_entry(Utils::String::toStdString(url)))
+    : m_nativeEntry(libtorrent::announce_entry(url.toStdString()))
 {
 }
 

--- a/src/base/bittorrent/trackerentry.cpp
+++ b/src/base/bittorrent/trackerentry.cpp
@@ -51,7 +51,7 @@ TrackerEntry::TrackerEntry(const TrackerEntry &other)
 
 QString TrackerEntry::url() const
 {
-    return Utils::String::fromStdString(m_nativeEntry.url);
+    return QString::fromStdString(m_nativeEntry.url);
 }
 
 int TrackerEntry::tier() const

--- a/src/base/logger.cpp
+++ b/src/base/logger.cpp
@@ -37,7 +37,7 @@ void Logger::addMessage(const QString &message, const Log::MsgType &type)
 {
     QWriteLocker locker(&lock);
 
-    Log::Msg temp = { msgCounter++, QDateTime::currentMSecsSinceEpoch(), type, Utils::String::toHtmlEscaped(message) };
+    Log::Msg temp = { msgCounter++, QDateTime::currentMSecsSinceEpoch(), type, message.toHtmlEscaped() };
     m_messages.push_back(temp);
 
     if (m_messages.size() >= MAX_LOG_MESSAGES)
@@ -50,7 +50,7 @@ void Logger::addPeer(const QString &ip, bool blocked, const QString &reason)
 {
     QWriteLocker locker(&lock);
 
-    Log::Peer temp = { peerCounter++, QDateTime::currentMSecsSinceEpoch(), Utils::String::toHtmlEscaped(ip), blocked, Utils::String::toHtmlEscaped(reason) };
+    Log::Peer temp = { peerCounter++, QDateTime::currentMSecsSinceEpoch(), ip.toHtmlEscaped(), blocked, reason.toHtmlEscaped() };
     m_peers.push_back(temp);
 
     if (m_peers.size() >= MAX_LOG_MESSAGES)

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -1271,20 +1271,12 @@ void Preferences::setRssMainSplitterState(const QByteArray &state)
 
 QByteArray Preferences::getSearchTabHeaderState() const
 {
-#ifdef QBT_USES_QT5
     return value("SearchTab/qt5/HeaderState").toByteArray();
-#else
-    return value("SearchTab/HeaderState").toByteArray();
-#endif
 }
 
 void Preferences::setSearchTabHeaderState(const QByteArray &state)
 {
-#ifdef QBT_USES_QT5
     setValue("SearchTab/qt5/HeaderState", state);
-#else
-    setValue("SearchTab/HeaderState", state);
-#endif
 }
 
 QStringList Preferences::getSearchEngDisabled() const

--- a/src/base/utils/string.cpp
+++ b/src/base/utils/string.cpp
@@ -157,11 +157,6 @@ QString Utils::String::fromStdString(const std::string &str)
     return QString::fromUtf8(str.c_str());
 }
 
-std::string Utils::String::toStdString(const QString &str)
-{
-    return str.toStdString();
-}
-
 // to send numbers instead of strings with suffixes
 QString Utils::String::fromDouble(double n, int precision)
 {

--- a/src/base/utils/string.cpp
+++ b/src/base/utils/string.cpp
@@ -152,11 +152,6 @@ bool Utils::String::naturalCompareCaseInsensitive(const QString &left, const QSt
 #endif
 }
 
-QString Utils::String::fromStdString(const std::string &str)
-{
-    return QString::fromUtf8(str.c_str());
-}
-
 // to send numbers instead of strings with suffixes
 QString Utils::String::fromDouble(double n, int precision)
 {

--- a/src/base/utils/string.cpp
+++ b/src/base/utils/string.cpp
@@ -183,8 +183,3 @@ bool Utils::String::slowEquals(const QByteArray &a, const QByteArray &b)
 
     return (diff == 0);
 }
-
-QString Utils::String::toHtmlEscaped(const QString &str)
-{
-    return str.toHtmlEscaped();
-}

--- a/src/base/utils/string.cpp
+++ b/src/base/utils/string.cpp
@@ -159,12 +159,7 @@ QString Utils::String::fromStdString(const std::string &str)
 
 std::string Utils::String::toStdString(const QString &str)
 {
-#ifdef QBT_USES_QT5
     return str.toStdString();
-#else
-    QByteArray utf8 = str.toUtf8();
-    return std::string(utf8.constData(), utf8.length());
-#endif
 }
 
 // to send numbers instead of strings with suffixes
@@ -196,26 +191,5 @@ bool Utils::String::slowEquals(const QByteArray &a, const QByteArray &b)
 
 QString Utils::String::toHtmlEscaped(const QString &str)
 {
-#ifdef QBT_USES_QT5
     return str.toHtmlEscaped();
-#else
-    // code from Qt
-    QString rich;
-    const int len = str.length();
-    rich.reserve(int(len * 1.1));
-    for (int i = 0; i < len; ++i) {
-        if (str.at(i) == QLatin1Char('<'))
-            rich += QLatin1String("&lt;");
-        else if (str.at(i) == QLatin1Char('>'))
-            rich += QLatin1String("&gt;");
-        else if (str.at(i) == QLatin1Char('&'))
-            rich += QLatin1String("&amp;");
-        else if (str.at(i) == QLatin1Char('"'))
-            rich += QLatin1String("&quot;");
-        else
-            rich += str.at(i);
-    }
-    rich.squeeze();
-    return rich;
-#endif
 }

--- a/src/base/utils/string.h
+++ b/src/base/utils/string.h
@@ -39,7 +39,6 @@ namespace Utils
 {
     namespace String
     {
-        QString fromStdString(const std::string &str);
         QString fromDouble(double n, int precision);
 
         // Implements constant-time comparison to protect against timing attacks

--- a/src/base/utils/string.h
+++ b/src/base/utils/string.h
@@ -40,7 +40,6 @@ namespace Utils
     namespace String
     {
         QString fromStdString(const std::string &str);
-        std::string toStdString(const QString &str);
         QString fromDouble(double n, int precision);
 
         // Implements constant-time comparison to protect against timing attacks

--- a/src/base/utils/string.h
+++ b/src/base/utils/string.h
@@ -46,8 +46,6 @@ namespace Utils
         // Taken from https://crackstation.net/hashing-security.htm
         bool slowEquals(const QByteArray &a, const QByteArray &b);
 
-        QString toHtmlEscaped(const QString &str);
-
         bool naturalCompareCaseSensitive(const QString &left, const QString &right);
         bool naturalCompareCaseInsensitive(const QString &left, const QString &right);
     }

--- a/src/gui/categoryfilterwidget.cpp
+++ b/src/gui/categoryfilterwidget.cpp
@@ -161,22 +161,7 @@ void CategoryFilterWidget::callUpdateGeometry()
 
 QSize CategoryFilterWidget::sizeHint() const
 {
-#ifdef QBT_USES_QT5
     return viewportSizeHint();
-#else
-    int lastRow = model()->rowCount() - 1;
-    QModelIndex last = model()->index(lastRow, 0);
-    while ((lastRow >= 0) && isExpanded(last)) {
-        lastRow = model()->rowCount(last) - 1;
-        last = model()->index(lastRow, 0, last);
-    }
-    const QRect deepestRect = visualRect(last);
-
-    if (!deepestRect.isValid())
-        return viewport()->sizeHint();
-
-    return QSize(header()->length(), deepestRect.bottom() + 1);
-#endif
 }
 
 QSize CategoryFilterWidget::minimumSizeHint() const

--- a/src/gui/deletionconfirmationdlg.h
+++ b/src/gui/deletionconfirmationdlg.h
@@ -46,7 +46,7 @@ class DeletionConfirmationDlg : public QDialog, private Ui::confirmDeletionDlg {
   DeletionConfirmationDlg(QWidget *parent, const int &size, const QString &name, bool defaultDeleteFiles): QDialog(parent) {
     setupUi(this);
     if (size == 1)
-      label->setText(tr("Are you sure you want to delete '%1' from the transfer list?", "Are you sure you want to delete 'ubuntu-linux-iso' from the transfer list?").arg(Utils::String::toHtmlEscaped(name)));
+      label->setText(tr("Are you sure you want to delete '%1' from the transfer list?", "Are you sure you want to delete 'ubuntu-linux-iso' from the transfer list?").arg(name.toHtmlEscaped()));
     else
       label->setText(tr("Are you sure you want to delete these %1 torrents from the transfer list?", "Are you sure you want to delete these 5 torrents from the transfer list?").arg(QString::number(size)));
     // Icons

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -397,7 +397,7 @@ QStandardItem* PeerListWidget::addPeer(const QString& ip, BitTorrent::TorrentHan
     m_listModel->setData(m_listModel->index(row, PeerListDelegate::CONNECTION), peer.connectionType());
     m_listModel->setData(m_listModel->index(row, PeerListDelegate::FLAGS), peer.flags());
     m_listModel->setData(m_listModel->index(row, PeerListDelegate::FLAGS), peer.flagsDescription(), Qt::ToolTipRole);
-    m_listModel->setData(m_listModel->index(row, PeerListDelegate::CLIENT), Utils::String::toHtmlEscaped(peer.client()));
+    m_listModel->setData(m_listModel->index(row, PeerListDelegate::CLIENT), peer.client().toHtmlEscaped());
     m_listModel->setData(m_listModel->index(row, PeerListDelegate::PROGRESS), peer.progress());
     m_listModel->setData(m_listModel->index(row, PeerListDelegate::DOWN_SPEED), peer.payloadDownSpeed());
     m_listModel->setData(m_listModel->index(row, PeerListDelegate::UP_SPEED), peer.payloadUpSpeed());
@@ -428,7 +428,7 @@ void PeerListWidget::updatePeer(const QString &ip, BitTorrent::TorrentHandle *co
     m_listModel->setData(m_listModel->index(row, PeerListDelegate::PORT), peer.address().port);
     m_listModel->setData(m_listModel->index(row, PeerListDelegate::FLAGS), peer.flags());
     m_listModel->setData(m_listModel->index(row, PeerListDelegate::FLAGS), peer.flagsDescription(), Qt::ToolTipRole);
-    m_listModel->setData(m_listModel->index(row, PeerListDelegate::CLIENT), Utils::String::toHtmlEscaped(peer.client()));
+    m_listModel->setData(m_listModel->index(row, PeerListDelegate::CLIENT), peer.client().toHtmlEscaped());
     m_listModel->setData(m_listModel->index(row, PeerListDelegate::PROGRESS), peer.progress());
     m_listModel->setData(m_listModel->index(row, PeerListDelegate::DOWN_SPEED), peer.payloadDownSpeed());
     m_listModel->setData(m_listModel->index(row, PeerListDelegate::UP_SPEED), peer.payloadUpSpeed());

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -307,12 +307,12 @@ void PropertiesWidget::loadTorrentInfos(BitTorrent::TorrentHandle *const torrent
         label_total_size_val->setText(Utils::Misc::friendlyUnit(m_torrent->totalSize()));
 
         // Comment
-        comment_text->setText(Utils::Misc::parseHtmlLinks(Utils::String::toHtmlEscaped(m_torrent->comment())));
+        comment_text->setText(Utils::Misc::parseHtmlLinks(m_torrent->comment().toHtmlEscaped()));
 
         // URL seeds
         loadUrlSeeds();
 
-        label_created_by_val->setText(Utils::String::toHtmlEscaped(m_torrent->creator()));
+        label_created_by_val->setText(m_torrent->creator().toHtmlEscaped());
 
         // List files in torrent
         PropListModel->model()->setupModelData(m_torrent->info());


### PR DESCRIPTION
* Remove remaining QBT_USES_QT5 defines.
  Fixup of e64bb1d.
* Replace Utils::String::toStdString() by QString::toStdString()
* Replace Utils::String::toHtmlEscaped() by QString::.toHtmlEscaped()

UPDATE:
* Replace Utils::String::fromStdString() by QString::fromStdString()