### PR TITLE
Fix TorrentFileGuard::setAutoRemove() recursion problem. Closes #6488.

### DIFF
--- a/src/base/torrentfileguard.cpp
+++ b/src/base/torrentfileguard.cpp
@@ -77,11 +77,6 @@ void TorrentFileGuard::markAsAddedToSession()
     m_wasAdded = true;
 }
 
-void TorrentFileGuard::setAutoRemove(bool remove)
-{
-    setAutoRemove(remove);
-}
-
 TorrentFileGuard::AutoDeleteMode TorrentFileGuard::autoDeleteMode()
 {
     QMetaEnum meta {modeMetaEnum()};

--- a/src/base/torrentfileguard.h
+++ b/src/base/torrentfileguard.h
@@ -60,7 +60,7 @@ public:
 
     /// marks the torrent file as loaded (added) into the BitTorrent::Session
     void markAsAddedToSession();
-    void setAutoRemove(bool remove);
+    using FileGuard::setAutoRemove;
 
     enum AutoDeleteMode     // do not change these names: they are stored in config file
     {


### PR DESCRIPTION
The problem was created during Qt 4 drop, when FileGuard was promoted
from a member to a base class. The function was blindly changed.