### PR TITLE
NSIS ManifestDPIAware

### DIFF
--- a/dist/windows/options.nsi
+++ b/dist/windows/options.nsi
@@ -1,4 +1,5 @@
 ﻿Unicode true
+ManifestDPIAware true
 ;Compress the header too
 !packhdr "$%TEMP%\exehead.tmp" 'upx.exe -9 --best --ultra-brute "$%TEMP%\exehead.tmp"'
 


### PR DESCRIPTION
dpi-aware installer

ManifestDPIAware is supported from nsis 3.0 