### PR TITLE
cmake: fix build and add build configurations for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,18 @@ env:
     # Uncomment when Travis upgraded "Ubuntu 12.04 LTS" to a newer version whose repo will have a more up-to-date libtorrent package
     #- lt_branch=dist gui=true
     #- lt_branch=dist gui=false
-    - lt_branch=RC_1_0 gui=true
-    - lt_branch=RC_1_0 gui=false
+    - lt_branch=RC_1_0 gui=true build_system=cmake
+    - lt_branch=RC_1_0 gui=false build_system=cmake
+    - lt_branch=RC_1_0 gui=true build_system=qmake
+    - lt_branch=RC_1_0 gui=false build_system=qmake
   global:
     - secure: "OI9CUjj4lTb0HwwIZU5PbECU3hLlAL6KC8KsbwohG8/O3j5fLcnmDsK4Ad9us5cC39sS11Jcd1kDP2qRcCuST/glVNhLkcjKkiQerOfd5nQ/qL4JYfz/1mfP5mdpz9jHKzpLUIG+TXkbSTjP6VVmsb5KPT+3pKEdRFZB+Pu9+J8="
     - coverity_branch: coverity_scan
+
+matrix:
+  allow_failures:
+    - env: lt_branch=RC_1_0 gui=true build_system=cmake
+    - env: lt_branch=RC_1_0 gui=false build_system=cmake
 
 branches:
   except:
@@ -53,10 +60,12 @@ addons:
       #- boost-latest
       - sourceline: 'ppa:qbittorrent-team/qbittorrent-stable'
       - sourceline: 'ppa:beineri/opt-qt551-trusty'
+      - sourceline: 'ppa:adrozdoff/cmake'
     packages:
     # packages list: https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise
       - autoconf
       - automake
+      - cmake
       - colormake
       - libssl-dev
       - libboost-dev
@@ -90,9 +99,9 @@ before_install:
   # print settings
   - echo $lt_branch
   - echo $gui
+  - echo $build_system
   - echo $ltconf
   - echo $qbtconf
-
 install:
   - |
     if [ "$TRAVIS_OS_NAME" = "linux" ]; then
@@ -127,6 +136,10 @@ install:
       # dependencies
       brew update > /dev/null ;
       brew install colormake ccache ;
+      if [ "$build_system" = "cmake" ]; then
+        brew unlink cmake
+        brew install cmake;
+      fi
       brew outdated "pkg-config" || brew upgrade "pkg-config" ;
       # Copy custom libtorrent bottle to homebrew's cache so it can find and install it
       # Also install our custom libtorrent formula by passing the local path to it
@@ -134,13 +147,23 @@ install:
       cp "$HOME/hombebrew_cache/libtorrent-rasterbar-1.0.10.el_capitan.bottle.tar.gz" "$(brew --cache)" ;
       brew install "$HOME/hombebrew_cache/libtorrent-rasterbar.rb" ;
 
-      # Qt
-      # Copy custom qt5 bottle to homebrew's cache so it can find and install it
-      # Also install our custom qt5 formula by passing the local path to it
-      # These 2 files are restored from Travis' cache.
-      cp "$HOME/hombebrew_cache/qt5-5.7.1_1.el_capitan.bottle.tar.gz" "$(brew --cache)" ;
-      brew install "$HOME/hombebrew_cache/qt5.rb" ;
-      brew link --force qt5 ;
+      if [ "$build_system" = "cmake" ]; then
+        brew install qt5 ;
+        brew link --force qt5 ;
+        export HOMEBREW_QT5_VERSION=$(brew list --versions qt5 | rev | cut -d' ' -f1 | rev)
+        ln -s /usr/local/Cellar/qt5/$HOMEBREW_QT5_VERSION/mkspecs /usr/local/mkspecs
+        ln -s /usr/local/Cellar/qt5/$HOMEBREW_QT5_VERSION/plugins /usr/local/plugins
+      else
+        # Qt
+        # Copy custom qt5 bottle to homebrew's cache so it can find and install it
+        # Also install our custom qt5 formula by passing the local path to it
+        # These 2 files are restored from Travis' cache.
+        cp "$HOME/hombebrew_cache/qt5-5.7.1_1.el_capitan.bottle.tar.gz" "$(brew --cache)" ;
+        brew install "$HOME/hombebrew_cache/qt5.rb" ;
+        brew link --force qt5 ;
+      fi
+
+      MY_CMAKE_OPENSSL_HINT="-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl/"
 
       # ccache
       if [ "$TRAVIS_BRANCH" != "$coverity_branch" ]; then
@@ -151,12 +174,22 @@ install:
 
 script:
   - if [ "$TRAVIS_BRANCH" = "$coverity_branch" ]; then exit ; fi # skip usual build when running coverity scan
-  - cd "$TRAVIS_BUILD_DIR" && ./bootstrap.sh && ./configure $qbtconf
   - |
-    if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-      sed -i "" -e "s/^\(CC.*&&\).*$/\1 $CC/" src/Makefile ;  # workaround for Qt & ccache: https://bugreports.qt.io/browse/QTBUG-31034
-      sed -i "" -e "s/^\(CXX.*&&\).*$/\1 $CXX/" src/Makefile ;
-      sed -i "" -e 's/^\(CXXFLAGS.*\)$/\1 -Wno-unused-local-typedefs -Wno-inconsistent-missing-override/' src/Makefile ;
+    cd "$TRAVIS_BUILD_DIR"
+    if [ "$build_system" = "cmake" ]; then
+      cd "$TRAVIS_BUILD_DIR"
+      mkdir build
+      cd build
+      cmake -DGUI=${gui} -DCMAKE_INSTALL_PREFIX="$qbt_path" "$MY_CMAKE_OPENSSL_HINT" \
+        -G "Unix Makefiles" -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE ..
+    fi
+    if [ "$build_system" = "qmake" ]; then
+      ./bootstrap.sh && ./configure $qbtconf
+      if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+        sed -i "" -e "s/^\(CC.*&&\).*$/\1 $CC/" src/Makefile ;  # workaround for Qt & ccache: https://bugreports.qt.io/browse/QTBUG-31034
+        sed -i "" -e "s/^\(CXX.*&&\).*$/\1 $CXX/" src/Makefile ;
+        sed -i "" -e 's/^\(CXXFLAGS.*\)$/\1 -Wno-unused-local-typedefs -Wno-inconsistent-missing-override/' src/Makefile ;
+      fi
     fi
   - make && make install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,21 +47,24 @@ addons:
     branch_pattern: $coverity_branch
     notification_email: sledgehammer999@qbittorrent.org
   apt:
-    #sources:
-    # sources list: https://github.com/travis-ci/apt-source-whitelist/blob/master/ubuntu.json
-    #- ubuntu-toolchain-r-test
-    #- boost-latest
+    sources:
+      # sources list: https://github.com/travis-ci/apt-source-whitelist/blob/master/ubuntu.json
+      #- ubuntu-toolchain-r-test
+      #- boost-latest
+      - sourceline: 'ppa:qbittorrent-team/qbittorrent-stable'
+      - sourceline: 'ppa:beineri/opt-qt551-trusty'
     packages:
     # packages list: https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise
-    - autoconf
-    - automake
-    - colormake
-    - libssl-dev
-    - libboost-dev
-    - libboost-system-dev
-    # uncomment when Travis upgraded "Ubuntu 12.04 LTS" to a newer version whose repo will have a more up-to-date libtorrent package
-    #- libtorrent-rasterbar6
-
+      - autoconf
+      - automake
+      - colormake
+      - libssl-dev
+      - libboost-dev
+      - libboost-system-dev
+      - libtorrent-rasterbar-dev
+      # Qt 5.5.1
+      - qt55base
+      - qt55tools
 before_install:
   # only allow specific build for coverity scan, others will stop
   - if [ "$TRAVIS_BRANCH" = "$coverity_branch" ] && ! [ "$TRAVIS_OS_NAME" = "linux" -a "$lt_branch" = "RC_1_0" -a "$gui" = true ]; then exit ; fi
@@ -94,17 +97,6 @@ before_install:
 install:
   - |
     if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-      # repositories
-      sudo add-apt-repository --yes ppa:qbittorrent-team/qbittorrent-stable ;
-      sudo add-apt-repository --yes ppa:beineri/opt-qt551-trusty ;
-      sudo apt-get update -qq ;
-
-      # libtorrent
-      sudo apt-get install -qq libtorrent-rasterbar-dev ;
-
-      # Qt 5.5.1
-      sudo apt-get install -qq qt55base qt55tools ;
-
       # build libtorrent from source
       #if [ "$lt_branch" != "dist" ]; then
         #cd "$HOME" && pwd && git clone --depth 1 https://github.com/arvidn/libtorrent.git --branch $lt_branch ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ env:
     # Uncomment when Travis upgraded "Ubuntu 12.04 LTS" to a newer version whose repo will have a more up-to-date libtorrent package
     #- lt_branch=dist gui=true
     #- lt_branch=dist gui=false
-    - lt_branch=RC_1_0 qt=5 gui=true
-    - lt_branch=RC_1_0 qt=5 gui=false
+    - lt_branch=RC_1_0 gui=true
+    - lt_branch=RC_1_0 gui=false
   global:
     - secure: "OI9CUjj4lTb0HwwIZU5PbECU3hLlAL6KC8KsbwohG8/O3j5fLcnmDsK4Ad9us5cC39sS11Jcd1kDP2qRcCuST/glVNhLkcjKkiQerOfd5nQ/qL4JYfz/1mfP5mdpz9jHKzpLUIG+TXkbSTjP6VVmsb5KPT+3pKEdRFZB+Pu9+J8="
     - coverity_branch: coverity_scan
@@ -77,7 +77,6 @@ before_install:
   - qbtconf="$qbtconf --prefix="$qbt_path" PKG_CONFIG_PATH="$libt_path/lib/pkgconfig":/opt/qt55/lib/pkgconfig:$PKG_CONFIG_PATH"
 
   # options for specific branches
-  - if [ "$qt" = 4 ]; then qbtconf="$qbtconf --with-qt4" ; fi
   - if [ "$gui" = false ]; then qbtconf="$qbtconf --disable-gui" ; fi
   - |
     if [ "$TRAVIS_OS_NAME" = "linux" ]; then

--- a/dist/mac/bundle.cmake
+++ b/dist/mac/bundle.cmake
@@ -1,2 +1,3 @@
+set(BU_CHMOD_BUNDLE_ITEMS ON)
 include(BundleUtilities)
 fixup_bundle("$ENV{DESTDIR}/${CMAKE_INSTALL_PREFIX}/qbittorrent.app" "" "")

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -39,11 +39,7 @@ set(QBT_APP_RESOURCES
 
 # With AUTORCC rcc is ran by cmake before language files are generated,
 # and thus we call rcc explicitly
-if (QT5)
-    qt5_add_resources(QBT_APP_RESOURCE_SOURCE ${QBT_APP_RESOURCES})
-else (QT5)
-    qt4_add_resources(QBT_APP_RESOURCE_SOURCE ${QBT_APP_RESOURCES})
-endif (QT5)
+qt5_add_resources(QBT_APP_RESOURCE_SOURCE ${QBT_APP_RESOURCES})
 
 if (WIN32)
     if (MINGW)

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -172,6 +172,6 @@ install(TARGETS ${QBT_TARGET_NAME}
     BUNDLE  DESTINATION .
     COMPONENT runtime)
 
-if (APPLE)
+if (APPLE AND GUI)
     install(SCRIPT ${OSX_RES_SRC_DIR}/bundle.cmake)
-endif (APPLE)
+endif (APPLE AND GUI)


### PR DESCRIPTION
1. Remove Qt4 leftover from CMake build files.
1. Fix cmake build and bundle creation on OSX
1. Add CMake builds to Travis (with fails allowed).
