### PR TITLE
Opt-in DPI scaling 

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -122,9 +122,8 @@ Application::Application(const QString &id, int &argc, char **argv)
     SettingsStorage::initInstance();
     Preferences::initInstance();
 
-    if (m_commandLineArgs.webUiPort > 0) { // it will be -1 when user did not set any value
+    if (m_commandLineArgs.webUiPort > 0) // it will be -1 when user did not set any value
         Preferences::instance()->setWebUiPort(m_commandLineArgs.webUiPort);
-    }
 
     setApplicationName("qBittorrent");
     initializeTranslation();

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -126,14 +126,6 @@ Application::Application(const QString &id, int &argc, char **argv)
         Preferences::instance()->setWebUiPort(m_commandLineArgs.webUiPort);
     }
 
-#if defined(Q_OS_MACX) && !defined(DISABLE_GUI)
-    if (QSysInfo::MacintoshVersion > QSysInfo::MV_10_8) {
-        // fix Mac OS X 10.9 (mavericks) font issue
-        // https://bugreports.qt-project.org/browse/QTBUG-32789
-        QFont::insertSubstitution(".Lucida Grande UI", "Lucida Grande");
-    }
-#endif
-
     setApplicationName("qBittorrent");
     initializeTranslation();
 

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -133,14 +133,18 @@ Application::Application(const QString &id, int &argc, char **argv)
         QFont::insertSubstitution(".Lucida Grande UI", "Lucida Grande");
     }
 #endif
+
+    setApplicationName("qBittorrent");
     initializeTranslation();
-#ifndef DISABLE_GUI
+
+#if !defined(DISABLE_GUI)
     setAttribute(Qt::AA_UseHighDpiPixmaps, true);  // opt-in to the high DPI pixmap support
     setQuitOnLastWindowClosed(false);
-#ifdef Q_OS_WIN
+#endif
+
+#if defined(Q_OS_WIN) && !defined(DISABLE_GUI)
     connect(this, SIGNAL(commitDataRequest(QSessionManager &)), this, SLOT(shutdownCleanup(QSessionManager &)), Qt::DirectConnection);
-#endif // Q_OS_WIN
-#endif // DISABLE_GUI
+#endif
 
     connect(this, SIGNAL(messageReceived(const QString &)), SLOT(processMessage(const QString &)));
     connect(this, SIGNAL(aboutToQuit()), SLOT(cleanup()));


### PR DESCRIPTION
Qt doc: https://doc.qt.io/qt-5/highdpi.html#high-dpi-support-in-qt

OS support summary:
* macOS: with `Info.plist` setup correctly, everything should be in place.
* linux: depends on environment variable `QT_AUTO_SCREEN_SCALE_FACTOR`.
  This PR sets `QT_AUTO_SCREEN_SCALE_FACTOR=1` by default.
* windows: still depends on `qt.conf`.
  Tried `QT_AUTO_SCREEN_SCALE_FACTOR` & `SetProcessDPIAware()` combinations, no use.

~~**[WIP] Don't merge yet**~~
PR is ready