### PR TITLE
[WebUI] Add New API: "/command/blockPeer", "/command/unblockPeer" and "/command/resetIPFilter"

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1418,7 +1418,8 @@ void Session::removeBannedIP(const QString &ip)
 void Session::EraseIPFilter()
 {
     m_nativeSession->set_ip_filter(libt::ip_filter());
-    processBannedIPs();
+	libt::ip_filter filter;
+    processBannedIPs(filter);
 }
 
 // Delete a torrent from the session, given its hash

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1392,6 +1392,35 @@ void Session::banIP(const QString &ip)
     }
 }
 
+bool Session::checkAccessFlags(const QString &ip)
+{
+    libt::ip_filter filter = m_nativeSession->get_ip_filter();
+    libt::address addr = libt::address::from_string(ip.toLatin1().constData());
+    return filter.access(addr);
+}
+
+void Session::blockIP(const QString &ip)
+{
+    libt::ip_filter filter = m_nativeSession->get_ip_filter();
+    libt::address addr = libt::address::from_string(ip.toLatin1().constData());
+    filter.add_rule(addr, addr, libt::ip_filter::blocked);
+    m_nativeSession->set_ip_filter(filter);
+}
+
+void Session::removeBannedIP(const QString &ip)
+{
+    libt::ip_filter filter = m_nativeSession->get_ip_filter();
+    libt::address addr = libt::address::from_string(ip.toLatin1().constData());
+    filter.add_rule(addr, addr, 0);
+    m_nativeSession->set_ip_filter(filter);
+}
+
+void Session::EraseIPFilter()
+{
+    m_nativeSession->set_ip_filter(libt::ip_filter());
+    processBannedIPs();
+}
+
 // Delete a torrent from the session, given its hash
 // deleteLocalFiles = true means that the torrent will be removed from the hard-drive too
 bool Session::deleteTorrent(const QString &hash, bool deleteLocalFiles)

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1417,9 +1417,8 @@ void Session::removeBannedIP(const QString &ip)
 
 void Session::EraseIPFilter()
 {
-    m_nativeSession->set_ip_filter(libt::ip_filter());
-	libt::ip_filter filter;
-    processBannedIPs(filter);
+    disableIPFilter();
+    enableIPFilter();
 }
 
 // Delete a torrent from the session, given its hash

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -344,7 +344,10 @@ namespace BitTorrent
         MaxRatioAction maxRatioAction() const;
         void setMaxRatioAction(MaxRatioAction act);
 
-        void banIP(const QString &ip);
+        bool checkAccessFlags(const QString &ip);
+        void blockIP(const QString &ip);
+        void removeBannedIP(const QString &ip);
+        void EraseIPFilter();
 
         bool isKnownTorrent(const InfoHash &hash) const;
         bool addTorrent(QString source, const AddTorrentParams &params = AddTorrentParams());

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -344,6 +344,7 @@ namespace BitTorrent
         MaxRatioAction maxRatioAction() const;
         void setMaxRatioAction(MaxRatioAction act);
 
+        void banIP(const QString &ip);
         bool checkAccessFlags(const QString &ip);
         void blockIP(const QString &ip);
         void removeBannedIP(const QString &ip);

--- a/src/webui/abstractwebapplication.cpp
+++ b/src/webui/abstractwebapplication.cpp
@@ -37,6 +37,7 @@
 #include <QTemporaryFile>
 #include <QTimer>
 
+#include "base/bittorrent/session.h"
 #include "base/preferences.h"
 #include "base/utils/fs.h"
 #include "base/utils/random.h"
@@ -87,7 +88,10 @@ AbstractWebApplication::AbstractWebApplication(QObject *parent)
     , session_(0)
 {
     QTimer *timer = new QTimer(this);
+    m_UnbanTimer = new QTimer(this);
+    m_UnbanTimer->setInterval(500);
     connect(timer, SIGNAL(timeout()), SLOT(removeInactiveSessions()));
+    connect(m_UnbanTimer, SIGNAL(timeout()), SLOT(processUnbanRequest()));
     timer->start(60 * 1000);  // 1 min.
 }
 
@@ -323,6 +327,29 @@ void AbstractWebApplication::increaseFailedAttempts()
         UnbanTimer* ubantimer = new UnbanTimer(env_.clientAddress, this);
         connect(ubantimer, SIGNAL(timeout()), SLOT(UnbanTimerEvent()));
         ubantimer->start();
+    }
+}
+
+void AbstractWebApplication::processUnbanRequest()
+{
+    if (bannedIPs.isEmpty() && UnbanTime.isEmpty()) {
+        m_UnbanTimer->stop();
+    }
+    else if (m_isActive) {
+        return;
+    }
+    else {
+        m_isActive = true;
+        int64_t currentTime = QDateTime::currentMSecsSinceEpoch();
+        int64_t nextTime = UnbanTime.dequeue();
+        int delayTime = int(nextTime - currentTime);
+        QString nextIP = bannedIPs.dequeue();
+        if (delayTime < 0) {
+            QTimer::singleShot(0, [=] { BitTorrent::Session::instance()->removeBannedIP(nextIP); m_isActive = false; });
+        }
+        else {
+            QTimer::singleShot(delayTime, [=] { BitTorrent::Session::instance()->removeBannedIP(nextIP); m_isActive = false; });
+        }
     }
 }
 

--- a/src/webui/abstractwebapplication.h
+++ b/src/webui/abstractwebapplication.h
@@ -32,6 +32,8 @@
 #include <QHash>
 #include <QMap>
 #include <QObject>
+#include <QQueue>
+#include <QTimer>
 
 #include "base/http/irequesthandler.h"
 #include "base/http/responsebuilder.h"
@@ -55,6 +57,14 @@ public:
     virtual ~AbstractWebApplication();
 
     Http::Response processRequest(const Http::Request &request, const Http::Environment &env);
+
+    bool m_isActive = false;
+    QQueue<QString> bannedIPs;
+    QQueue<int64_t> UnbanTime;
+    QTimer *m_UnbanTimer;
+
+public slots:
+    void processUnbanRequest();
 
 protected:
     virtual void processRequest() = 0;

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -93,6 +93,9 @@ private:
     void action_command_addCategory();
     void action_command_removeCategories();
     void action_command_getSavePath();
+    void action_command_blockPeer();
+    void action_command_unblockPeer();
+    void action_command_resetIPFilter();
     void action_version_api();
     void action_version_api_min();
     void action_version_qbittorrent();


### PR DESCRIPTION
Idea from [#2489](https://github.com/qbittorrent/qBittorrent/issues/2489)

We cannot block any BT client right now since Libtorrent only support blocking IP manually.
In this API, it is able to block a specific peer's IP temporarily by tracking their BT Client.
I think it will be useful for the users who want to block the specific peers with the specified criteria.

## Example
I want to block client contains "Xunlei". Do the infinite loop in ```GET /query/torrents``` for the torrent hash

### Response
```
[{
	"added_on": 1489712222,
	"category": "",
	"completed": 123456,
	"completion_on": 1489712453,
	"dl_limit": 0,
	"dlspeed": 0,
	"downloaded": 123456,
	"downloaded_session": 0,
	"eta": 8640000,
	"f_l_piece_prio": false,
	"force_start": false,
	"hash": "abcdefghijklmnopqrstuvwxyz12345678900000",
	"last_activity": 0,
	"name": "Example.7z",
	"num_complete": 10,
	"num_incomplete": 5,
	"num_leechs": 0,
	"num_seeds": 0,
	"priority": 0,
	"progress": 1,
	"ratio": 1,
	"ratio_limit": 10,
	"remaining": 0,
	"save_path": "F:\\Downloads\\",
	"seen_complete": 4294967295,
	"seq_dl": false,
	"size": 123456,
	"state": "pausedUP",
	"super_seeding": false,
	"total_size": 123456,
	"tracker": "",
	"up_limit": 0,
	"uploaded": 123456,
	"uploaded_session": 0,
	"upspeed": 0
}]
```

Next, fetch ```GET /sync/torrent_peers?hash=:hash```
### Response
```
{
	"full_update": true,
	"peers": {
		"1.2.3.4:1234": {
			"client": "Xunlei 7.9.5.4480",
			"connection": "μTP",
			"country": "China",
			"country_code": "cn",
			"dl_speed": 0,
			"downloaded": 0,
			"files": "",
			"flags": "U X E P",
			"flags_desc": "interested(peer) and unchoked(local), peer from PEX, encrypted traffic, μTP",
			"ip": "1.2.3.4:1234",
			"port": 1234,
			"progress": 0.00000001,
			"relevance": 0,
			"up_speed": 47175,
			"uploaded": 33603584
		}
	},
	"rid": 1,
	"show_flags": true
}
```

## Block Peer
If the peer's client contains "Xunlei", just send a request to ```Post /command/blockPeer```

### Parameters
| Name | Required? | Type | Description |
| ---- | --------- | ---- | ----------- |
| ```ip``` | Required | String | IP address that you want to block |

### Example Request
```
curl -X POST -F 'ip=1.2.3.4' http://hostname:port/command/blockPeer
```

## Unblock Peer
If you want to unblock Peer, just send a request to ```Post /command/unblockPeer```

### Parameters
| Name | Required? | Type | Description |
| ---- | --------- | ---- | ----------- |
| ```ip``` | Required | String | IP address that you want to block |

### Example Request
```
curl -X POST -F 'ip=1.2.3.4' http://hostname:port/command/unblockPeer
```

## Reset IP Filter
If you want to reset whole IP Filter after block Peer and you don't want to unblock Peer one by one, just send a request to ```Post /command/resetIPFilter```

### It's no additional parameters are needed.

### Example Request
```
curl -X POST http://hostname:port/command/resetIPFilter
```