### PR TITLE
src/lang/qbittorrent_pt_BR.ts: Fix some serious translation errors.

### DIFF
--- a/src/lang/qbittorrent_pt_BR.ts
+++ b/src/lang/qbittorrent_pt_BR.ts
@@ -1236,7 +1236,7 @@ Erro: %2</translation>
         <location filename="../base/bittorrent/session.cpp" line="3064"/>
         <source>Unable to resume torrent &apos;%1&apos;.</source>
         <comment>e.g: Unable to resume torrent &apos;hash&apos;.</comment>
-        <translation>Não foi possível resumir o torrent &apos;%1&apos;.</translation>
+        <translation>Não foi possível continuar o torrent &apos;%1&apos;.</translation>
     </message>
     <message>
         <location filename="../base/bittorrent/session.cpp" line="3141"/>
@@ -1258,7 +1258,7 @@ Erro: %2</translation>
         <location filename="../base/bittorrent/session.cpp" line="3297"/>
         <source>&apos;%1&apos; resumed. (fast resume)</source>
         <comment>&apos;torrent name&apos; was resumed. (fast resume)</comment>
-        <translation>&apos;%1&apos; resumido. (resumir rápido)</translation>
+        <translation>&apos;%1&apos; continuado. (continuação rápida)</translation>
     </message>
     <message>
         <location filename="../base/bittorrent/session.cpp" line="3328"/>
@@ -1868,7 +1868,7 @@ O nome da categoria não pode conter a sequência &apos;//&apos;.</translation>
     <message>
         <location filename="../webui/extra_translations.h" line="82"/>
         <source>Resumed</source>
-        <translation>Resumido</translation>
+        <translation>Continuado</translation>
     </message>
     <message>
         <location filename="../webui/extra_translations.h" line="83"/>
@@ -2151,7 +2151,7 @@ O nome da categoria não pode conter a sequência &apos;//&apos;.</translation>
     <message>
         <location filename="../gui/mainwindow.ui" line="188"/>
         <source>&amp;Resume</source>
-        <translation>&amp;Resumir</translation>
+        <translation>&amp;Continuar</translation>
     </message>
     <message>
         <location filename="../gui/mainwindow.ui" line="221"/>
@@ -8212,7 +8212,7 @@ Não serão exibidos mais avisos.</translation>
         <location filename="../gui/transferlistwidget.cpp" line="640"/>
         <source>Resume</source>
         <comment>Resume/start the torrent</comment>
-        <translation>Resumir</translation>
+        <translation>Continuar</translation>
     </message>
     <message>
         <location filename="../gui/transferlistwidget.cpp" line="644"/>


### PR DESCRIPTION
This fixes some atrocious (really serious) errors in Brazilian Portuguese.

Please merge these. I will propose them as a fix for Debian (and, hopefully, Ubuntu will pick up) ASAP.

Thanks,

Rogério Brito.


Signed-off-by: Rogério Brito <rbrito@ime.usp.br>
