### PR TITLE
CMake 3.8 compatibility and refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -150,9 +150,8 @@ install:
       if [ "$build_system" = "cmake" ]; then
         brew install qt5 ;
         brew link --force qt5 ;
-        export HOMEBREW_QT5_VERSION=$(brew list --versions qt5 | rev | cut -d' ' -f1 | rev)
-        ln -s /usr/local/Cellar/qt5/$HOMEBREW_QT5_VERSION/mkspecs /usr/local/mkspecs
-        ln -s /usr/local/Cellar/qt5/$HOMEBREW_QT5_VERSION/plugins /usr/local/plugins
+        ln -s /usr/local/opt/qt/mkspecs /usr/local/mkspecs
+        ln -s /usr/local/opt/qt/plugins /usr/local/plugins
       else
         # Qt
         # Copy custom qt5 bottle to homebrew's cache so it can find and install it

--- a/.travis.yml
+++ b/.travis.yml
@@ -177,7 +177,6 @@ script:
   - |
     cd "$TRAVIS_BUILD_DIR"
     if [ "$build_system" = "cmake" ]; then
-      cd "$TRAVIS_BUILD_DIR"
       mkdir build
       cd build
       cmake -DGUI=${gui} -DCMAKE_INSTALL_PREFIX="$qbt_path" "$MY_CMAKE_OPENSSL_HINT" \

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -135,7 +135,7 @@ shutdownconfirmdlg.ui
 
 qbt_target_sources(about.qrc)
 
-add_library(qbt_gui STATIC ${QBT_GUI_HEADERS} ${QBT_GUI_SOURCES})
+add_library(qbt_gui STATIC ${QBT_GUI_HEADERS} ${QBT_GUI_SOURCES} ${QBT_GUI_FORMS})
 target_link_libraries(qbt_gui qbt_lineedit qbt_powermanagement qbt_rss qbt_properties qbt_searchengine
     ${QBT_GUI_OPTIONAL_LINK_LIBRARIES} qbt_base
     QtSingleApplication::QtSingleApplication

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -28,6 +28,8 @@
  * Contact : chris@qbittorrent.org
  */
 
+#include "mainwindow.h"
+
 #include <QtGlobal>
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC)) && defined(QT_DBUS_LIB)
 #include <QDBusConnection>
@@ -44,6 +46,7 @@
 #include <QCloseEvent>
 #include <QShortcut>
 #include <QScrollBar>
+#include <QSplitter>
 #include <QSysInfo>
 #include <QMimeData>
 #include <QCryptographicHash>
@@ -91,7 +94,6 @@
 #include "executionlog.h"
 #include "hidabletabwidget.h"
 #include "ui_mainwindow.h"
-#include "mainwindow.h"
 
 #ifdef Q_OS_MAC
 void qt_mac_set_dock_menu(QMenu *menu);

--- a/src/gui/properties/CMakeLists.txt
+++ b/src/gui/properties/CMakeLists.txt
@@ -42,6 +42,6 @@ speedwidget.cpp
 speedplotview.cpp
 )
 
-add_library(qbt_properties STATIC ${QBT_PROPERTIES_HEADERS} ${QBT_PROPERTIES_SOURCES})
+add_library(qbt_properties STATIC ${QBT_PROPERTIES_HEADERS} ${QBT_PROPERTIES_SOURCES} ${QBT_PROPERTIES_FORMS})
 target_link_libraries(qbt_properties qbt_base)
 target_link_libraries(qbt_properties Qt5::Widgets Qt5::Concurrent)

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -28,6 +28,9 @@
  * Contact : chris@qbittorrent.org
  */
 
+#include "peerlistwidget.h"
+
+#include <QApplication>
 #include <QStandardItemModel>
 #include <QSortFilterProxyModel>
 #include <QSet>
@@ -51,7 +54,6 @@
 #include "guiiconprovider.h"
 #include "peerlistdelegate.h"
 #include "peerlistsortmodel.h"
-#include "peerlistwidget.h"
 
 PeerListWidget::PeerListWidget(PropertiesWidget *parent)
     : QTreeView(parent)

--- a/src/gui/properties/peersadditiondlg.cpp
+++ b/src/gui/properties/peersadditiondlg.cpp
@@ -28,19 +28,27 @@
  * Contact : chris@qbittorrent.org
  */
 
+#include "peersadditiondlg.h"
+
 #include <QMessageBox>
 #include <QHostAddress>
 
-#include "peersadditiondlg.h"
+#include "ui_peersadditiondlg.h"
 
 PeersAdditionDlg::PeersAdditionDlg(QWidget *parent)
     : QDialog(parent)
+    , m_ui(new Ui::addPeersDialog())
 {
-    setupUi(this);
-    connect(buttonBox, SIGNAL(accepted()), this, SLOT(validateInput()));
+    m_ui->setupUi(this);
+    connect(m_ui->buttonBox, SIGNAL(accepted()), this, SLOT(validateInput()));
 
-    label_format->hide();
-    peers_txt->setPlaceholderText("Format: IPv4:port / [IPv6]:port");
+    m_ui->label_format->hide();
+    m_ui->peers_txt->setPlaceholderText("Format: IPv4:port / [IPv6]:port");
+}
+
+PeersAdditionDlg::~PeersAdditionDlg()
+{
+    delete m_ui;
 }
 
 QList<BitTorrent::PeerAddress> PeersAdditionDlg::askForPeers()
@@ -52,13 +60,13 @@ QList<BitTorrent::PeerAddress> PeersAdditionDlg::askForPeers()
 
 void PeersAdditionDlg::validateInput()
 {
-    if (peers_txt->toPlainText().trimmed().isEmpty()) {
+    if (m_ui->peers_txt->toPlainText().trimmed().isEmpty()) {
         QMessageBox::warning(this, tr("No peer entered"),
                     tr("Please type at least one peer."),
                     QMessageBox::Ok);
         return;
     }
-    foreach (const QString &peer, peers_txt->toPlainText().trimmed().split("\n")) {
+    foreach (const QString &peer, m_ui->peers_txt->toPlainText().trimmed().split("\n")) {
         BitTorrent::PeerAddress addr = parsePeer(peer);
         if (!addr.ip.isNull()) {
             m_peersList.append(addr);

--- a/src/gui/properties/peersadditiondlg.h
+++ b/src/gui/properties/peersadditiondlg.h
@@ -34,14 +34,21 @@
 #include <QDialog>
 
 #include "base/bittorrent/peerinfo.h"
-#include "ui_peersadditiondlg.h"
 
-class PeersAdditionDlg: public QDialog, private Ui::addPeersDialog
+template <class T> class QList;
+
+namespace Ui
+{
+    class addPeersDialog;
+}
+
+class PeersAdditionDlg: public QDialog
 {
     Q_OBJECT
 
 public:
     PeersAdditionDlg(QWidget *parent = 0);
+    ~PeersAdditionDlg();
 
     static QList<BitTorrent::PeerAddress> askForPeers();
 
@@ -50,6 +57,8 @@ protected slots:
 
 private:
     BitTorrent::PeerAddress parsePeer(QString peer);
+
+    Ui::addPeersDialog *m_ui;
     QList<BitTorrent::PeerAddress> m_peersList;
 
 };

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -64,87 +64,93 @@
 #include "transferlistwidget.h"
 #include "autoexpandabledialog.h"
 
+#include "ui_propertieswidget.h"
+
 PropertiesWidget::PropertiesWidget(QWidget *parent, MainWindow *main_window, TransferListWidget *transferList)
-    : QWidget(parent), transferList(transferList), main_window(main_window), m_torrent(0)
+    : QWidget(parent)
+    , m_ui(new Ui::PropertiesWidget())
+    , transferList(transferList)
+    , main_window(main_window)
+    , m_torrent(0)
 {
-    setupUi(this);
+    m_ui->setupUi(this);
     setAutoFillBackground(true);
 
     state = VISIBLE;
 
     // Set Properties list model
     PropListModel = new TorrentContentFilterModel();
-    filesList->setModel(PropListModel);
+    m_ui->filesList->setModel(PropListModel);
     PropDelegate = new PropListDelegate(this);
-    filesList->setItemDelegate(PropDelegate);
-    filesList->setSortingEnabled(true);
+    m_ui->filesList->setItemDelegate(PropDelegate);
+    m_ui->filesList->setSortingEnabled(true);
     // Torrent content filtering
     m_contentFilterLine = new LineEdit(this);
     m_contentFilterLine->setPlaceholderText(tr("Filter files..."));
     m_contentFilterLine->setMaximumSize(300, m_contentFilterLine->size().height());
     connect(m_contentFilterLine, SIGNAL(textChanged(QString)), this, SLOT(filterText(QString)));
-    contentFilterLayout->insertWidget(3, m_contentFilterLine);
+    m_ui->contentFilterLayout->insertWidget(3, m_contentFilterLine);
 
     // SIGNAL/SLOTS
-    connect(filesList, SIGNAL(clicked(const QModelIndex&)), filesList, SLOT(edit(const QModelIndex&)));
-    connect(selectAllButton, SIGNAL(clicked()), PropListModel, SLOT(selectAll()));
-    connect(selectNoneButton, SIGNAL(clicked()), PropListModel, SLOT(selectNone()));
-    connect(filesList, SIGNAL(customContextMenuRequested(const QPoint&)), this, SLOT(displayFilesListMenu(const QPoint&)));
-    connect(filesList, SIGNAL(doubleClicked(const QModelIndex&)), this, SLOT(openDoubleClickedFile(const QModelIndex&)));
+    connect(m_ui->filesList, SIGNAL(clicked(const QModelIndex&)), m_ui->filesList, SLOT(edit(const QModelIndex&)));
+    connect(m_ui->selectAllButton, SIGNAL(clicked()), PropListModel, SLOT(selectAll()));
+    connect(m_ui->selectNoneButton, SIGNAL(clicked()), PropListModel, SLOT(selectNone()));
+    connect(m_ui->filesList, SIGNAL(customContextMenuRequested(const QPoint&)), this, SLOT(displayFilesListMenu(const QPoint&)));
+    connect(m_ui->filesList, SIGNAL(doubleClicked(const QModelIndex&)), this, SLOT(openDoubleClickedFile(const QModelIndex&)));
     connect(PropListModel, SIGNAL(filteredFilesChanged()), this, SLOT(filteredFilesChanged()));
-    connect(listWebSeeds, SIGNAL(customContextMenuRequested(const QPoint&)), this, SLOT(displayWebSeedListMenu(const QPoint&)));
+    connect(m_ui->listWebSeeds, SIGNAL(customContextMenuRequested(const QPoint&)), this, SLOT(displayWebSeedListMenu(const QPoint&)));
     connect(transferList, SIGNAL(currentTorrentChanged(BitTorrent::TorrentHandle * const)), this, SLOT(loadTorrentInfos(BitTorrent::TorrentHandle * const)));
     connect(PropDelegate, SIGNAL(filteredFilesChanged()), this, SLOT(filteredFilesChanged()));
-    connect(stackedProperties, SIGNAL(currentChanged(int)), this, SLOT(loadDynamicData()));
+    connect(m_ui->stackedProperties, SIGNAL(currentChanged(int)), this, SLOT(loadDynamicData()));
     connect(BitTorrent::Session::instance(), SIGNAL(torrentSavePathChanged(BitTorrent::TorrentHandle * const)), this, SLOT(updateSavePath(BitTorrent::TorrentHandle * const)));
     connect(BitTorrent::Session::instance(), SIGNAL(torrentMetadataLoaded(BitTorrent::TorrentHandle * const)), this, SLOT(updateTorrentInfos(BitTorrent::TorrentHandle * const)));
-    connect(filesList->header(), SIGNAL(sectionMoved(int,int,int)), this, SLOT(saveSettings()));
-    connect(filesList->header(), SIGNAL(sectionResized(int,int,int)), this, SLOT(saveSettings()));
-    connect(filesList->header(), SIGNAL(sortIndicatorChanged(int,Qt::SortOrder)), this, SLOT(saveSettings()));
+    connect(m_ui->filesList->header(), SIGNAL(sectionMoved(int,int,int)), this, SLOT(saveSettings()));
+    connect(m_ui->filesList->header(), SIGNAL(sectionResized(int,int,int)), this, SLOT(saveSettings()));
+    connect(m_ui->filesList->header(), SIGNAL(sortIndicatorChanged(int,Qt::SortOrder)), this, SLOT(saveSettings()));
 
     // set bar height relative to screen dpi
     int barHeight = devicePixelRatio() * 18;
 
     // Downloaded pieces progress bar
-    tempProgressBarArea->setVisible(false);
+    m_ui->tempProgressBarArea->setVisible(false);
     downloaded_pieces = new DownloadedPiecesBar(this);
-    groupBarLayout->addWidget(downloaded_pieces, 0, 1);
+    m_ui->groupBarLayout->addWidget(downloaded_pieces, 0, 1);
     downloaded_pieces->setFixedHeight(barHeight);
     downloaded_pieces->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
     // Pieces availability bar
-    tempAvailabilityBarArea->setVisible(false);
+    m_ui->tempAvailabilityBarArea->setVisible(false);
     pieces_availability = new PieceAvailabilityBar(this);
-    groupBarLayout->addWidget(pieces_availability, 1, 1);
+    m_ui->groupBarLayout->addWidget(pieces_availability, 1, 1);
     pieces_availability->setFixedHeight(barHeight);
     pieces_availability->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
     // Tracker list
     trackerList = new TrackerList(this);
-    trackerUpButton->setIcon(GuiIconProvider::instance()->getIcon("go-up"));
-    trackerUpButton->setIconSize(Utils::Misc::smallIconSize());
-    trackerDownButton->setIcon(GuiIconProvider::instance()->getIcon("go-down"));
-    trackerDownButton->setIconSize(Utils::Misc::smallIconSize());
-    connect(trackerUpButton, SIGNAL(clicked()), trackerList, SLOT(moveSelectionUp()));
-    connect(trackerDownButton, SIGNAL(clicked()), trackerList, SLOT(moveSelectionDown()));
-    horizontalLayout_trackers->insertWidget(0, trackerList);
+    m_ui->trackerUpButton->setIcon(GuiIconProvider::instance()->getIcon("go-up"));
+    m_ui->trackerUpButton->setIconSize(Utils::Misc::smallIconSize());
+    m_ui->trackerDownButton->setIcon(GuiIconProvider::instance()->getIcon("go-down"));
+    m_ui->trackerDownButton->setIconSize(Utils::Misc::smallIconSize());
+    connect(m_ui->trackerUpButton, SIGNAL(clicked()), trackerList, SLOT(moveSelectionUp()));
+    connect(m_ui->trackerDownButton, SIGNAL(clicked()), trackerList, SLOT(moveSelectionDown()));
+    m_ui->horizontalLayout_trackers->insertWidget(0, trackerList);
     connect(trackerList->header(), SIGNAL(sectionMoved(int,int,int)), trackerList, SLOT(saveSettings()));
     connect(trackerList->header(), SIGNAL(sectionResized(int,int,int)), trackerList, SLOT(saveSettings()));
     connect(trackerList->header(), SIGNAL(sortIndicatorChanged(int,Qt::SortOrder)), trackerList, SLOT(saveSettings()));
     // Peers list
     peersList = new PeerListWidget(this);
-    peerpage_layout->addWidget(peersList);
+    m_ui->peerpage_layout->addWidget(peersList);
     connect(peersList->header(), SIGNAL(sectionMoved(int,int,int)), peersList, SLOT(saveSettings()));
     connect(peersList->header(), SIGNAL(sectionResized(int,int,int)), peersList, SLOT(saveSettings()));
     connect(peersList->header(), SIGNAL(sortIndicatorChanged(int,Qt::SortOrder)), peersList, SLOT(saveSettings()));
     // Speed widget
     speedWidget = new SpeedWidget(this);
-    speed_layout->addWidget(speedWidget);
+    m_ui->speed_layout->addWidget(speedWidget);
     // Tab bar
     m_tabBar = new PropTabBar();
     m_tabBar->setContentsMargins(0, 5, 0, 0);
-    verticalLayout->addLayout(m_tabBar);
-    connect(m_tabBar, SIGNAL(tabChanged(int)), stackedProperties, SLOT(setCurrentIndex(int)));
+    m_ui->verticalLayout->addLayout(m_tabBar);
+    connect(m_tabBar, SIGNAL(tabChanged(int)), m_ui->stackedProperties, SLOT(setCurrentIndex(int)));
     connect(m_tabBar, SIGNAL(tabChanged(int)), this, SLOT(saveSettings()));
     connect(m_tabBar, SIGNAL(visibilityToggled(bool)), SLOT(setVisibility(bool)));
     connect(m_tabBar, SIGNAL(visibilityToggled(bool)), this, SLOT(saveSettings()));
@@ -152,14 +158,14 @@ PropertiesWidget::PropertiesWidget(QWidget *parent, MainWindow *main_window, Tra
     refreshTimer = new QTimer(this);
     connect(refreshTimer, SIGNAL(timeout()), this, SLOT(loadDynamicData()));
     refreshTimer->start(3000); // 3sec
-    editHotkeyFile = new QShortcut(Qt::Key_F2, filesList, 0, 0, Qt::WidgetShortcut);
+    editHotkeyFile = new QShortcut(Qt::Key_F2, m_ui->filesList, 0, 0, Qt::WidgetShortcut);
     connect(editHotkeyFile, SIGNAL(activated()), SLOT(renameSelectedFile()));
-    editHotkeyWeb = new QShortcut(Qt::Key_F2, listWebSeeds, 0, 0, Qt::WidgetShortcut);
+    editHotkeyWeb = new QShortcut(Qt::Key_F2, m_ui->listWebSeeds, 0, 0, Qt::WidgetShortcut);
     connect(editHotkeyWeb, SIGNAL(activated()), SLOT(editWebSeed()));
-    connect(listWebSeeds, SIGNAL(doubleClicked(QModelIndex)), SLOT(editWebSeed()));
-    deleteHotkeyWeb = new QShortcut(QKeySequence::Delete, listWebSeeds, 0, 0, Qt::WidgetShortcut);
+    connect(m_ui->listWebSeeds, SIGNAL(doubleClicked(QModelIndex)), SLOT(editWebSeed()));
+    deleteHotkeyWeb = new QShortcut(QKeySequence::Delete, m_ui->listWebSeeds, 0, 0, Qt::WidgetShortcut);
     connect(deleteHotkeyWeb, SIGNAL(activated()), SLOT(deleteSelectedUrlSeeds()));
-    openHotkeyFile = new QShortcut(Qt::Key_Return, filesList, 0, 0, Qt::WidgetShortcut);
+    openHotkeyFile = new QShortcut(Qt::Key_Return, m_ui->filesList, 0, 0, Qt::WidgetShortcut);
     connect(openHotkeyFile, SIGNAL(activated()), SLOT(openSelectedFile()));
 }
 
@@ -179,32 +185,33 @@ PropertiesWidget::~PropertiesWidget()
     delete editHotkeyWeb;
     delete deleteHotkeyWeb;
     delete openHotkeyFile;
+    delete m_ui;
     qDebug() << Q_FUNC_INFO << "EXIT";
 }
 
 void PropertiesWidget::showPiecesAvailability(bool show)
 {
-    avail_pieces_lbl->setVisible(show);
+    m_ui->avail_pieces_lbl->setVisible(show);
     pieces_availability->setVisible(show);
-    avail_average_lbl->setVisible(show);
+    m_ui->avail_average_lbl->setVisible(show);
     if (show || !downloaded_pieces->isVisible())
-        line_2->setVisible(show);
+        m_ui->line_2->setVisible(show);
 }
 
 void PropertiesWidget::showPiecesDownloaded(bool show)
 {
-    downloaded_pieces_lbl->setVisible(show);
+    m_ui->downloaded_pieces_lbl->setVisible(show);
     downloaded_pieces->setVisible(show);
-    progress_lbl->setVisible(show);
+    m_ui->progress_lbl->setVisible(show);
     if (show || !pieces_availability->isVisible())
-        line_2->setVisible(show);
+        m_ui->line_2->setVisible(show);
 }
 
 void PropertiesWidget::setVisibility(bool visible)
 {
     if (!visible && ( state == VISIBLE) ) {
         QSplitter *hSplitter = static_cast<QSplitter *>(parentWidget());
-        stackedProperties->setVisible(false);
+        m_ui->stackedProperties->setVisible(false);
         slideSizes = hSplitter->sizes();
         hSplitter->handle(1)->setVisible(false);
         hSplitter->handle(1)->setDisabled(true);
@@ -215,7 +222,7 @@ void PropertiesWidget::setVisibility(bool visible)
     }
 
     if (visible && ( state == REDUCED) ) {
-        stackedProperties->setVisible(true);
+        m_ui->stackedProperties->setVisible(true);
         QSplitter *hSplitter = static_cast<QSplitter *>(parentWidget());
         hSplitter->handle(1)->setDisabled(false);
         hSplitter->handle(1)->setVisible(true);
@@ -229,39 +236,39 @@ void PropertiesWidget::setVisibility(bool visible)
 void PropertiesWidget::clear()
 {
     qDebug("Clearing torrent properties");
-    save_path->clear();
-    lbl_creationDate->clear();
-    label_total_pieces_val->clear();
-    hash_lbl->clear();
-    comment_text->clear();
-    progress_lbl->clear();
+    m_ui->save_path->clear();
+    m_ui->lbl_creationDate->clear();
+    m_ui->label_total_pieces_val->clear();
+    m_ui->hash_lbl->clear();
+    m_ui->comment_text->clear();
+    m_ui->progress_lbl->clear();
     trackerList->clear();
     downloaded_pieces->clear();
     pieces_availability->clear();
-    avail_average_lbl->clear();
-    wasted->clear();
-    upTotal->clear();
-    dlTotal->clear();
+    m_ui->avail_average_lbl->clear();
+    m_ui->wasted->clear();
+    m_ui->upTotal->clear();
+    m_ui->dlTotal->clear();
     peersList->clear();
-    lbl_uplimit->clear();
-    lbl_dllimit->clear();
-    lbl_elapsed->clear();
-    lbl_connections->clear();
-    reannounce_lbl->clear();
-    shareRatio->clear();
-    listWebSeeds->clear();
+    m_ui->lbl_uplimit->clear();
+    m_ui->lbl_dllimit->clear();
+    m_ui->lbl_elapsed->clear();
+    m_ui->lbl_connections->clear();
+    m_ui->reannounce_lbl->clear();
+    m_ui->shareRatio->clear();
+    m_ui->listWebSeeds->clear();
     m_contentFilterLine->clear();
     PropListModel->model()->clear();
-    label_eta_val->clear();
-    label_seeds_val->clear();
-    label_peers_val->clear();
-    label_dl_speed_val->clear();
-    label_upload_speed_val->clear();
-    label_total_size_val->clear();
-    label_completed_on_val->clear();
-    label_last_complete_val->clear();
-    label_created_by_val->clear();
-    label_added_on_val->clear();
+    m_ui->label_eta_val->clear();
+    m_ui->label_seeds_val->clear();
+    m_ui->label_peers_val->clear();
+    m_ui->label_dl_speed_val->clear();
+    m_ui->label_upload_speed_val->clear();
+    m_ui->label_total_size_val->clear();
+    m_ui->label_completed_on_val->clear();
+    m_ui->label_last_complete_val->clear();
+    m_ui->label_created_by_val->clear();
+    m_ui->label_added_on_val->clear();
 }
 
 BitTorrent::TorrentHandle *PropertiesWidget::getCurrentTorrent() const
@@ -269,10 +276,15 @@ BitTorrent::TorrentHandle *PropertiesWidget::getCurrentTorrent() const
     return m_torrent;
 }
 
+QTreeView *PropertiesWidget::getFilesList() const
+{
+    return m_ui->filesList;
+}
+
 void PropertiesWidget::updateSavePath(BitTorrent::TorrentHandle *const torrent)
 {
     if (m_torrent == torrent)
-        save_path->setText(Utils::Fs::toNativePath(m_torrent->savePath()));
+        m_ui->save_path->setText(Utils::Fs::toNativePath(m_torrent->savePath()));
 }
 
 void PropertiesWidget::loadTrackers(BitTorrent::TorrentHandle *const torrent)
@@ -298,26 +310,26 @@ void PropertiesWidget::loadTorrentInfos(BitTorrent::TorrentHandle *const torrent
     // Save path
     updateSavePath(m_torrent);
     // Hash
-    hash_lbl->setText(m_torrent->hash());
+    m_ui->hash_lbl->setText(m_torrent->hash());
     PropListModel->model()->clear();
     if (m_torrent->hasMetadata()) {
         // Creation date
-        lbl_creationDate->setText(m_torrent->creationDate().toString(Qt::DefaultLocaleShortDate));
+        m_ui->lbl_creationDate->setText(m_torrent->creationDate().toString(Qt::DefaultLocaleShortDate));
 
-        label_total_size_val->setText(Utils::Misc::friendlyUnit(m_torrent->totalSize()));
+        m_ui->label_total_size_val->setText(Utils::Misc::friendlyUnit(m_torrent->totalSize()));
 
         // Comment
-        comment_text->setText(Utils::Misc::parseHtmlLinks(m_torrent->comment().toHtmlEscaped()));
+        m_ui->comment_text->setText(Utils::Misc::parseHtmlLinks(m_torrent->comment().toHtmlEscaped()));
 
         // URL seeds
         loadUrlSeeds();
 
-        label_created_by_val->setText(m_torrent->creator().toHtmlEscaped());
+        m_ui->label_created_by_val->setText(m_torrent->creator().toHtmlEscaped());
 
         // List files in torrent
         PropListModel->model()->setupModelData(m_torrent->info());
         if ((m_torrent->filesCount() > 1) && (PropListModel->model()->rowCount() == 1))
-            filesList->setExpanded(PropListModel->index(0, 0), true);
+            m_ui->filesList->setExpanded(PropListModel->index(0, 0), true);
 
         // Load file priorities
         PropListModel->model()->updateFilesPriorities(m_torrent->filePriorities());
@@ -340,8 +352,8 @@ void PropertiesWidget::readSettings()
     const int current_tab = pref->getPropCurTab();
     const bool visible = pref->getPropVisible();
     // the following will call saveSettings but shouldn't change any state
-    if (!filesList->header()->restoreState(pref->getPropFileListState()))
-        filesList->header()->resizeSection(0, 400); // Default
+    if (!m_ui->filesList->header()->restoreState(pref->getPropFileListState()))
+        m_ui->filesList->header()->resizeSection(0, 400); // Default
     m_tabBar->setCurrentIndex(current_tab);
     if (!visible)
         setVisibility(false);
@@ -361,7 +373,7 @@ void PropertiesWidget::saveSettings()
     qDebug("Sizes: %d", sizes.size());
     if (sizes.size() == 2)
         pref->setPropSplitterSizes(QString::number(sizes.first()) + ',' + QString::number(sizes.last()));
-    pref->setPropFileListState(filesList->header()->saveState());
+    pref->setPropFileListState(m_ui->filesList->header()->saveState());
     // Remember current tab
     pref->setPropCurTab(m_tabBar->currentIndex());
 }
@@ -379,19 +391,19 @@ void PropertiesWidget::loadDynamicData()
     if (!m_torrent || (main_window->currentTabWidget() != transferList) || (state != VISIBLE)) return;
 
     // Transfer infos
-    switch (stackedProperties->currentIndex()) {
+    switch (m_ui->stackedProperties->currentIndex()) {
     case PropTabBar::MAIN_TAB: {
-        wasted->setText(Utils::Misc::friendlyUnit(m_torrent->wastedSize()));
+        m_ui->wasted->setText(Utils::Misc::friendlyUnit(m_torrent->wastedSize()));
 
-        upTotal->setText(tr("%1 (%2 this session)").arg(Utils::Misc::friendlyUnit(m_torrent->totalUpload()))
+        m_ui->upTotal->setText(tr("%1 (%2 this session)").arg(Utils::Misc::friendlyUnit(m_torrent->totalUpload()))
                          .arg(Utils::Misc::friendlyUnit(m_torrent->totalPayloadUpload())));
 
-        dlTotal->setText(tr("%1 (%2 this session)").arg(Utils::Misc::friendlyUnit(m_torrent->totalDownload()))
+        m_ui->dlTotal->setText(tr("%1 (%2 this session)").arg(Utils::Misc::friendlyUnit(m_torrent->totalDownload()))
                          .arg(Utils::Misc::friendlyUnit(m_torrent->totalPayloadDownload())));
 
-        lbl_uplimit->setText(m_torrent->uploadLimit() <= 0 ? QString::fromUtf8(C_INFINITY) : Utils::Misc::friendlyUnit(m_torrent->uploadLimit(), true));
+        m_ui->lbl_uplimit->setText(m_torrent->uploadLimit() <= 0 ? QString::fromUtf8(C_INFINITY) : Utils::Misc::friendlyUnit(m_torrent->uploadLimit(), true));
 
-        lbl_dllimit->setText(m_torrent->downloadLimit() <= 0 ? QString::fromUtf8(C_INFINITY) : Utils::Misc::friendlyUnit(m_torrent->downloadLimit(), true));
+        m_ui->lbl_dllimit->setText(m_torrent->downloadLimit() <= 0 ? QString::fromUtf8(C_INFINITY) : Utils::Misc::friendlyUnit(m_torrent->downloadLimit(), true));
 
         QString elapsed_txt;
         if (m_torrent->isSeed())
@@ -400,51 +412,51 @@ void PropertiesWidget::loadDynamicData()
                           .arg(Utils::Misc::userFriendlyDuration(m_torrent->seedingTime()));
         else
             elapsed_txt = Utils::Misc::userFriendlyDuration(m_torrent->activeTime());
-        lbl_elapsed->setText(elapsed_txt);
+        m_ui->lbl_elapsed->setText(elapsed_txt);
 
-        lbl_connections->setText(tr("%1 (%2 max)", "%1 and %2 are numbers, e.g. 3 (10 max)")
+        m_ui->lbl_connections->setText(tr("%1 (%2 max)", "%1 and %2 are numbers, e.g. 3 (10 max)")
                                  .arg(m_torrent->connectionsCount())
                                  .arg(m_torrent->connectionsLimit() < 0 ? QString::fromUtf8(C_INFINITY) : QString::number(m_torrent->connectionsLimit())));
 
-        label_eta_val->setText(Utils::Misc::userFriendlyDuration(m_torrent->eta()));
+        m_ui->label_eta_val->setText(Utils::Misc::userFriendlyDuration(m_torrent->eta()));
 
         // Update next announce time
-        reannounce_lbl->setText(Utils::Misc::userFriendlyDuration(m_torrent->nextAnnounce()));
+        m_ui->reannounce_lbl->setText(Utils::Misc::userFriendlyDuration(m_torrent->nextAnnounce()));
 
         // Update ratio info
         const qreal ratio = m_torrent->realRatio();
-        shareRatio->setText(ratio > BitTorrent::TorrentHandle::MAX_RATIO ? QString::fromUtf8(C_INFINITY) : Utils::String::fromDouble(ratio, 2));
+        m_ui->shareRatio->setText(ratio > BitTorrent::TorrentHandle::MAX_RATIO ? QString::fromUtf8(C_INFINITY) : Utils::String::fromDouble(ratio, 2));
 
-        label_seeds_val->setText(tr("%1 (%2 total)", "%1 and %2 are numbers, e.g. 3 (10 total)")
+        m_ui->label_seeds_val->setText(tr("%1 (%2 total)", "%1 and %2 are numbers, e.g. 3 (10 total)")
                                  .arg(QString::number(m_torrent->seedsCount()))
                                  .arg(QString::number(m_torrent->totalSeedsCount())));
 
-        label_peers_val->setText(tr("%1 (%2 total)", "%1 and %2 are numbers, e.g. 3 (10 total)")
+        m_ui->label_peers_val->setText(tr("%1 (%2 total)", "%1 and %2 are numbers, e.g. 3 (10 total)")
                                  .arg(QString::number(m_torrent->leechsCount()))
                                  .arg(QString::number(m_torrent->totalLeechersCount())));
 
-        label_dl_speed_val->setText(tr("%1 (%2 avg.)", "%1 and %2 are speed rates, e.g. 200KiB/s (100KiB/s avg.)")
+        m_ui->label_dl_speed_val->setText(tr("%1 (%2 avg.)", "%1 and %2 are speed rates, e.g. 200KiB/s (100KiB/s avg.)")
                                     .arg(Utils::Misc::friendlyUnit(m_torrent->downloadPayloadRate(), true))
                                     .arg(Utils::Misc::friendlyUnit(m_torrent->totalDownload() / (1 + m_torrent->activeTime() - m_torrent->finishedTime()), true)));
 
-        label_upload_speed_val->setText(tr("%1 (%2 avg.)", "%1 and %2 are speed rates, e.g. 200KiB/s (100KiB/s avg.)")
+        m_ui->label_upload_speed_val->setText(tr("%1 (%2 avg.)", "%1 and %2 are speed rates, e.g. 200KiB/s (100KiB/s avg.)")
                                         .arg(Utils::Misc::friendlyUnit(m_torrent->uploadPayloadRate(), true))
                                         .arg(Utils::Misc::friendlyUnit(m_torrent->totalUpload() / (1 + m_torrent->activeTime()), true)));
 
-        label_last_complete_val->setText(m_torrent->lastSeenComplete().isValid() ? m_torrent->lastSeenComplete().toString(Qt::DefaultLocaleShortDate) : tr("Never"));
+        m_ui->label_last_complete_val->setText(m_torrent->lastSeenComplete().isValid() ? m_torrent->lastSeenComplete().toString(Qt::DefaultLocaleShortDate) : tr("Never"));
 
-        label_completed_on_val->setText(m_torrent->completedTime().isValid() ? m_torrent->completedTime().toString(Qt::DefaultLocaleShortDate) : "");
+        m_ui->label_completed_on_val->setText(m_torrent->completedTime().isValid() ? m_torrent->completedTime().toString(Qt::DefaultLocaleShortDate) : "");
 
-        label_added_on_val->setText(m_torrent->addedTime().toString(Qt::DefaultLocaleShortDate));
+        m_ui->label_added_on_val->setText(m_torrent->addedTime().toString(Qt::DefaultLocaleShortDate));
 
         if (m_torrent->hasMetadata()) {
-            label_total_pieces_val->setText(tr("%1 x %2 (have %3)", "(torrent pieces) eg 152 x 4MB (have 25)").arg(m_torrent->piecesCount()).arg(Utils::Misc::friendlyUnit(m_torrent->pieceLength())).arg(m_torrent->piecesHave()));
+            m_ui->label_total_pieces_val->setText(tr("%1 x %2 (have %3)", "(torrent pieces) eg 152 x 4MB (have 25)").arg(m_torrent->piecesCount()).arg(Utils::Misc::friendlyUnit(m_torrent->pieceLength())).arg(m_torrent->piecesHave()));
 
             if (!m_torrent->isSeed() && !m_torrent->isPaused() && !m_torrent->isQueued() && !m_torrent->isChecking()) {
                 // Pieces availability
                 showPiecesAvailability(true);
                 pieces_availability->setAvailability(m_torrent->pieceAvailability());
-                avail_average_lbl->setText(Utils::String::fromDouble(m_torrent->distributedCopies(), 3));
+                m_ui->avail_average_lbl->setText(Utils::String::fromDouble(m_torrent->distributedCopies(), 3));
             }
             else {
                 showPiecesAvailability(false);
@@ -452,7 +464,7 @@ void PropertiesWidget::loadDynamicData()
 
             // Progress
             qreal progress = m_torrent->progress() * 100.;
-            progress_lbl->setText(Utils::String::fromDouble(progress, 1) + "%");
+            m_ui->progress_lbl->setText(Utils::String::fromDouble(progress, 1) + "%");
             downloaded_pieces->setProgress(m_torrent->pieces(), m_torrent->downloadingPieces());
         }
         else {
@@ -478,13 +490,13 @@ void PropertiesWidget::loadDynamicData()
         // Files progress
         if (m_torrent->hasMetadata()) {
             qDebug("Updating priorities in files tab");
-            filesList->setUpdatesEnabled(false);
+            m_ui->filesList->setUpdatesEnabled(false);
             PropListModel->model()->updateFilesProgress(m_torrent->filesProgress());
             // XXX: We don't update file priorities regularly for performance
             // reasons. This means that priorities will not be updated if
             // set from the Web UI.
             // PropListModel->model()->updateFilesPriorities(h.file_priorities());
-            filesList->setUpdatesEnabled(true);
+            m_ui->filesList->setUpdatesEnabled(true);
         }
         break;
     }
@@ -495,13 +507,13 @@ void PropertiesWidget::loadDynamicData()
 
 void PropertiesWidget::loadUrlSeeds()
 {
-    listWebSeeds->clear();
+    m_ui->listWebSeeds->clear();
     qDebug("Loading URL seeds");
     const QList<QUrl> hc_seeds = m_torrent->urlSeeds();
     // Add url seeds
     foreach (const QUrl &hc_seed, hc_seeds) {
         qDebug("Loading URL seed: %s", qPrintable(hc_seed.toString()));
-        new QListWidgetItem(hc_seed.toString(), listWebSeeds);
+        new QListWidgetItem(hc_seed.toString(), m_ui->listWebSeeds);
     }
 }
 
@@ -565,7 +577,7 @@ void PropertiesWidget::displayFilesListMenu(const QPoint &)
 {
     if (!m_torrent) return;
 
-    QModelIndexList selectedRows = filesList->selectionModel()->selectedRows(0);
+    QModelIndexList selectedRows = m_ui->filesList->selectionModel()->selectedRows(0);
     if (selectedRows.empty())
         return;
     QMenu myFilesLlistMenu;
@@ -581,10 +593,10 @@ void PropertiesWidget::displayFilesListMenu(const QPoint &)
     QMenu subMenu;
     if (!m_torrent->isSeed()) {
         subMenu.setTitle(tr("Priority"));
-        subMenu.addAction(actionNot_downloaded);
-        subMenu.addAction(actionNormal);
-        subMenu.addAction(actionHigh);
-        subMenu.addAction(actionMaximum);
+        subMenu.addAction(m_ui->actionNot_downloaded);
+        subMenu.addAction(m_ui->actionNormal);
+        subMenu.addAction(m_ui->actionHigh);
+        subMenu.addAction(m_ui->actionMaximum);
         myFilesLlistMenu.addMenu(&subMenu);
     }
     // Call menu
@@ -606,11 +618,11 @@ void PropertiesWidget::displayFilesListMenu(const QPoint &)
         }
         else {
             int prio = prio::NORMAL;
-            if (act == actionHigh)
+            if (act == m_ui->actionHigh)
                 prio = prio::HIGH;
-            else if (act == actionMaximum)
+            else if (act == m_ui->actionMaximum)
                 prio = prio::MAXIMUM;
-            else if (act == actionNot_downloaded)
+            else if (act == m_ui->actionNot_downloaded)
                 prio = prio::IGNORED;
 
             qDebug("Setting files priority");
@@ -629,7 +641,7 @@ void PropertiesWidget::displayWebSeedListMenu(const QPoint &)
     if (!m_torrent) return;
 
     QMenu seedMenu;
-    QModelIndexList rows = listWebSeeds->selectionModel()->selectedRows();
+    QModelIndexList rows = m_ui->listWebSeeds->selectionModel()->selectedRows();
     QAction *actAdd = seedMenu.addAction(GuiIconProvider::instance()->getIcon("list-add"), tr("New Web seed"));
     QAction *actDel = 0;
     QAction *actCpy = 0;
@@ -657,7 +669,7 @@ void PropertiesWidget::displayWebSeedListMenu(const QPoint &)
 
 void PropertiesWidget::renameSelectedFile()
 {
-    const QModelIndexList selectedIndexes = filesList->selectionModel()->selectedRows(0);
+    const QModelIndexList selectedIndexes = m_ui->filesList->selectionModel()->selectedRows(0);
     if (selectedIndexes.size() != 1)
         return;
     const QModelIndex index = selectedIndexes.first();
@@ -777,7 +789,7 @@ void PropertiesWidget::renameSelectedFile()
 
 void PropertiesWidget::openSelectedFile()
 {
-    const QModelIndexList selectedIndexes = filesList->selectionModel()->selectedRows(0);
+    const QModelIndexList selectedIndexes = m_ui->filesList->selectionModel()->selectedRows(0);
     if (selectedIndexes.size() != 1)
         return;
     openDoubleClickedFile(selectedIndexes.first());
@@ -792,7 +804,7 @@ void PropertiesWidget::askWebSeed()
                                                            QString::fromUtf8("http://www."), &ok);
     if (!ok) return;
     qDebug("Adding %s web seed", qPrintable(url_seed));
-    if (!listWebSeeds->findItems(url_seed, Qt::MatchFixedString).empty()) {
+    if (!m_ui->listWebSeeds->findItems(url_seed, Qt::MatchFixedString).empty()) {
         QMessageBox::warning(this, "qBittorrent",
                              tr("This URL seed is already in the list."),
                              QMessageBox::Ok);
@@ -806,7 +818,7 @@ void PropertiesWidget::askWebSeed()
 
 void PropertiesWidget::deleteSelectedUrlSeeds()
 {
-    const QList<QListWidgetItem *> selectedItems = listWebSeeds->selectedItems();
+    const QList<QListWidgetItem *> selectedItems = m_ui->listWebSeeds->selectedItems();
     if (selectedItems.isEmpty()) return;
 
     QList<QUrl> urlSeeds;
@@ -820,7 +832,7 @@ void PropertiesWidget::deleteSelectedUrlSeeds()
 
 void PropertiesWidget::copySelectedWebSeedsToClipboard() const
 {
-    const QList<QListWidgetItem *> selected_items = listWebSeeds->selectedItems();
+    const QList<QListWidgetItem *> selected_items = m_ui->listWebSeeds->selectedItems();
     if (selected_items.isEmpty())
         return;
 
@@ -833,7 +845,7 @@ void PropertiesWidget::copySelectedWebSeedsToClipboard() const
 
 void PropertiesWidget::editWebSeed()
 {
-    const QList<QListWidgetItem *> selected_items = listWebSeeds->selectedItems();
+    const QList<QListWidgetItem *> selected_items = m_ui->listWebSeeds->selectedItems();
     if (selected_items.size() != 1)
         return;
 
@@ -846,7 +858,7 @@ void PropertiesWidget::editWebSeed()
     if (!result)
         return;
 
-    if (!listWebSeeds->findItems(new_seed, Qt::MatchFixedString).empty()) {
+    if (!m_ui->listWebSeeds->findItems(new_seed, Qt::MatchFixedString).empty()) {
         QMessageBox::warning(this, tr("qBittorrent"),
                              tr("This URL seed is already in the list."),
                              QMessageBox::Ok);
@@ -878,10 +890,10 @@ void PropertiesWidget::filterText(const QString &filter)
 {
     PropListModel->setFilterRegExp(QRegExp(filter, Qt::CaseInsensitive, QRegExp::WildcardUnix));
     if (filter.isEmpty()) {
-        filesList->collapseAll();
-        filesList->expand(PropListModel->index(0, 0));
+        m_ui->filesList->collapseAll();
+        m_ui->filesList->expand(PropListModel->index(0, 0));
     }
     else {
-        filesList->expandAll();
+        m_ui->filesList->expandAll();
     }
 }

--- a/src/gui/properties/propertieswidget.h
+++ b/src/gui/properties/propertieswidget.h
@@ -33,7 +33,6 @@
 
 #include <QShortcut>
 #include <QWidget>
-#include "ui_propertieswidget.h"
 #include "base/bittorrent/torrenthandle.h"
 
 
@@ -52,10 +51,17 @@ class LineEdit;
 
 QT_BEGIN_NAMESPACE
 class QAction;
+class QPushButton;
 class QTimer;
+class QTreeView;
 QT_END_NAMESPACE
 
-class PropertiesWidget: public QWidget, private Ui::PropertiesWidget
+namespace Ui
+{
+    class PropertiesWidget;
+}
+
+class PropertiesWidget: public QWidget
 {
     Q_OBJECT
     Q_DISABLE_COPY(PropertiesWidget)
@@ -69,7 +75,7 @@ public:
     BitTorrent::TorrentHandle *getCurrentTorrent() const;
     TrackerList *getTrackerList() const { return trackerList; }
     PeerListWidget *getPeerList() const { return peersList; }
-    QTreeView *getFilesList() const { return filesList; }
+    QTreeView *getFilesList() const;
     SpeedWidget *getSpeedWidget() const { return speedWidget; }
 
 protected:
@@ -107,6 +113,7 @@ private:
     void openFolder(const QModelIndex &index, bool containing_folder);
 
 private:
+    Ui::PropertiesWidget *m_ui;
     TransferListWidget *transferList;
     MainWindow *main_window;
     BitTorrent::TorrentHandle *m_torrent;

--- a/src/gui/properties/proplistdelegate.cpp
+++ b/src/gui/properties/proplistdelegate.cpp
@@ -28,6 +28,9 @@
  * Contact : chris@qbittorrent.org
  */
 
+#include "proplistdelegate.h"
+
+#include <QApplication>
 #include <QComboBox>
 #include <QModelIndex>
 #include <QPainter>
@@ -42,7 +45,6 @@
 #include "base/utils/misc.h"
 #include "base/utils/string.h"
 #include "propertieswidget.h"
-#include "proplistdelegate.h"
 #include "torrentcontentmodelitem.h"
 
 namespace {

--- a/src/gui/properties/trackerlist.cpp
+++ b/src/gui/properties/trackerlist.cpp
@@ -28,6 +28,9 @@
  * Contact : chris@qbittorrent.org
  */
 
+#include "trackerlist.h"
+
+#include <QApplication>
 #include <QTreeWidgetItem>
 #include <QStringList>
 #include <QMenu>
@@ -50,7 +53,6 @@
 #include "trackersadditiondlg.h"
 #include "guiiconprovider.h"
 #include "autoexpandabledialog.h"
-#include "trackerlist.h"
 
 TrackerList::TrackerList(PropertiesWidget *properties): QTreeWidget(), properties(properties) {
   // Graphical settings

--- a/src/gui/properties/trackersadditiondlg.h
+++ b/src/gui/properties/trackersadditiondlg.h
@@ -32,7 +32,6 @@
 #define TRACKERSADDITION_H
 
 #include <QDialog>
-#include "ui_trackersadditiondlg.h"
 
 class QString;
 class QStringList;
@@ -42,12 +41,18 @@ namespace BitTorrent
     class TorrentHandle;
 }
 
-class TrackersAdditionDlg : public QDialog, private Ui::TrackersAdditionDlg
+namespace Ui
+{
+    class TrackersAdditionDlg;
+}
+
+class TrackersAdditionDlg : public QDialog
 {
     Q_OBJECT
 
 public:
     TrackersAdditionDlg(BitTorrent::TorrentHandle *const torrent, QWidget *parent = 0);
+    ~TrackersAdditionDlg();
 
     QStringList newTrackers() const;
     static QStringList askForTrackers(BitTorrent::TorrentHandle *const torrent);
@@ -58,6 +63,7 @@ public slots:
     void getTrackerError(const QString &, const QString &error);
 
 private:
+    Ui::TrackersAdditionDlg *m_ui;
     BitTorrent::TorrentHandle *const m_torrent;
 };
 

--- a/src/gui/rss/rss_imp.cpp
+++ b/src/gui/rss/rss_imp.cpp
@@ -28,6 +28,8 @@
  * Contact : chris@qbittorrent.org arnaud@qbittorrent.org
  */
 
+#include "rss_imp.h"
+
 #include <QDesktopServices>
 #include <QMenu>
 #include <QStandardItemModel>
@@ -37,7 +39,6 @@
 #include <QDragMoveEvent>
 #include <QDebug>
 
-#include "rss_imp.h"
 #include "feedlistwidget.h"
 #include "base/bittorrent/session.h"
 #include "base/net/downloadmanager.h"
@@ -51,6 +52,8 @@
 #include "guiiconprovider.h"
 #include "autoexpandabledialog.h"
 #include "addnewtorrentdialog.h"
+
+#include "ui_rss.h"
 
 namespace Article
 {
@@ -73,33 +76,33 @@ void RSSImp::displayRSSListMenu(const QPoint &pos)
     QMenu myRSSListMenu(this);
     QList<QTreeWidgetItem * > selectedItems = m_feedList->selectedItems();
     if (selectedItems.size() > 0) {
-        myRSSListMenu.addAction(actionUpdate);
-        myRSSListMenu.addAction(actionMark_items_read);
+        myRSSListMenu.addAction(m_ui->actionUpdate);
+        myRSSListMenu.addAction(m_ui->actionMark_items_read);
         myRSSListMenu.addSeparator();
         if (selectedItems.size() == 1) {
             if (m_feedList->getRSSItem(selectedItems.first()) != m_rssManager->rootFolder()) {
-                myRSSListMenu.addAction(actionRename);
-                myRSSListMenu.addAction(actionDelete);
+                myRSSListMenu.addAction(m_ui->actionRename);
+                myRSSListMenu.addAction(m_ui->actionDelete);
                 myRSSListMenu.addSeparator();
                 if (m_feedList->isFolder(selectedItems.first()))
-                    myRSSListMenu.addAction(actionNew_folder);
+                    myRSSListMenu.addAction(m_ui->actionNew_folder);
             }
         }
         else {
-            myRSSListMenu.addAction(actionDelete);
+            myRSSListMenu.addAction(m_ui->actionDelete);
             myRSSListMenu.addSeparator();
         }
-        myRSSListMenu.addAction(actionNew_subscription);
+        myRSSListMenu.addAction(m_ui->actionNew_subscription);
         if (m_feedList->isFeed(selectedItems.first())) {
             myRSSListMenu.addSeparator();
-            myRSSListMenu.addAction(actionCopy_feed_URL);
+            myRSSListMenu.addAction(m_ui->actionCopy_feed_URL);
         }
     }
     else {
-        myRSSListMenu.addAction(actionNew_subscription);
-        myRSSListMenu.addAction(actionNew_folder);
+        myRSSListMenu.addAction(m_ui->actionNew_subscription);
+        myRSSListMenu.addAction(m_ui->actionNew_folder);
         myRSSListMenu.addSeparator();
-        myRSSListMenu.addAction(actionUpdate_all_feeds);
+        myRSSListMenu.addAction(m_ui->actionUpdate_all_feeds);
     }
     myRSSListMenu.exec(QCursor::pos());
 }
@@ -107,7 +110,7 @@ void RSSImp::displayRSSListMenu(const QPoint &pos)
 void RSSImp::displayItemsListMenu(const QPoint &)
 {
     QMenu myItemListMenu(this);
-    QList<QListWidgetItem * > selectedItems = listArticles->selectedItems();
+    QList<QListWidgetItem * > selectedItems = m_ui->listArticles->selectedItems();
     if (selectedItems.size() <= 0)
         return;
 
@@ -128,9 +131,9 @@ void RSSImp::displayItemsListMenu(const QPoint &)
             break;
     }
     if (hasTorrent)
-        myItemListMenu.addAction(actionDownload_torrent);
+        myItemListMenu.addAction(m_ui->actionDownload_torrent);
     if (hasLink)
-        myItemListMenu.addAction(actionOpen_news_URL);
+        myItemListMenu.addAction(m_ui->actionOpen_news_URL);
     if (hasTorrent || hasLink)
         myItemListMenu.exec(QCursor::pos());
 }
@@ -323,7 +326,7 @@ void RSSImp::refreshAllFeeds()
 
 void RSSImp::downloadSelectedTorrents()
 {
-    QList<QListWidgetItem * > selected_items = listArticles->selectedItems();
+    QList<QListWidgetItem * > selected_items = m_ui->listArticles->selectedItems();
     if (selected_items.size() <= 0)
         return;
     foreach (QListWidgetItem *item, selected_items) {
@@ -353,7 +356,7 @@ void RSSImp::downloadSelectedTorrents()
 // open the url of the selected RSS articles in the Web browser
 void RSSImp::openSelectedArticlesUrls()
 {
-    QList<QListWidgetItem * > selected_items = listArticles->selectedItems();
+    QList<QListWidgetItem * > selected_items = m_ui->listArticles->selectedItems();
     if (selected_items.size() <= 0)
         return;
     foreach (QListWidgetItem *item, selected_items) {
@@ -519,7 +522,7 @@ QListWidgetItem *RSSImp::createArticleListItem(const Rss::ArticlePtr &article)
 void RSSImp::populateArticleList(QTreeWidgetItem *item)
 {
     if (!item) {
-        listArticles->clear();
+        m_ui->listArticles->clear();
         return;
     }
 
@@ -528,9 +531,9 @@ void RSSImp::populateArticleList(QTreeWidgetItem *item)
         return;
 
     // Clear the list first
-    textBrowser->clear();
+    m_ui->textBrowser->clear();
     m_currentArticle = 0;
-    listArticles->clear();
+    m_ui->listArticles->clear();
 
     qDebug("Getting the list of news");
     Rss::ArticleList articles;
@@ -542,7 +545,7 @@ void RSSImp::populateArticleList(QTreeWidgetItem *item)
     qDebug("Got the list of news");
     foreach (const Rss::ArticlePtr &article, articles) {
         QListWidgetItem *articleItem = createArticleListItem(article);
-        listArticles->addItem(articleItem);
+        m_ui->listArticles->addItem(articleItem);
     }
     qDebug("Added all news to the GUI");
 }
@@ -550,7 +553,7 @@ void RSSImp::populateArticleList(QTreeWidgetItem *item)
 // display a news
 void RSSImp::refreshTextBrowser()
 {
-    QList<QListWidgetItem * > selection = listArticles->selectedItems();
+    QList<QListWidgetItem * > selection = m_ui->listArticles->selectedItems();
     if (selection.empty()) return;
     QListWidgetItem *item = selection.first();
     Q_ASSERT(item);
@@ -601,7 +604,7 @@ void RSSImp::refreshTextBrowser()
         html += "<pre>" + description + "</pre>";
     }
     html += "</div>";
-    textBrowser->setHtml(html);
+    m_ui->textBrowser->setHtml(html);
     article->markAsRead();
     item->setData(Article::ColorRole, QVariant(QColor("grey")));
     item->setData(Article::IconRole, QVariant(QIcon(":/icons/sphere.png")));
@@ -614,8 +617,8 @@ void RSSImp::saveSlidersPosition()
 {
     // Remember sliders positions
     Preferences *const pref = Preferences::instance();
-    pref->setRssSideSplitterState(splitterSide->saveState());
-    pref->setRssMainSplitterState(splitterMain->saveState());
+    pref->setRssSideSplitterState(m_ui->splitterSide->saveState());
+    pref->setRssMainSplitterState(m_ui->splitterMain->saveState());
     qDebug("Splitters position saved");
 }
 
@@ -624,10 +627,10 @@ void RSSImp::restoreSlidersPosition()
     const Preferences *const pref = Preferences::instance();
     const QByteArray stateSide = pref->getRssSideSplitterState();
     if (!stateSide.isEmpty())
-        splitterSide->restoreState(stateSide);
+        m_ui->splitterSide->restoreState(stateSide);
     const QByteArray stateMain = pref->getRssMainSplitterState();
     if (!stateMain.isEmpty())
-        splitterMain->restoreState(stateMain);
+        m_ui->splitterMain->restoreState(stateMain);
 }
 
 void RSSImp::updateItemsInfos(const QList<QTreeWidgetItem *> &items)
@@ -701,29 +704,30 @@ void RSSImp::updateRefreshInterval(uint val)
 }
 
 RSSImp::RSSImp(QWidget *parent)
-    : QWidget(parent),
-    m_rssManager(new Rss::Manager)
+    : QWidget(parent)
+    , m_ui(new Ui::RSS())
+    , m_rssManager(new Rss::Manager)
 {
-    setupUi(this);
+    m_ui->setupUi(this);
     // Icons
-    actionCopy_feed_URL->setIcon(GuiIconProvider::instance()->getIcon("edit-copy"));
-    actionDelete->setIcon(GuiIconProvider::instance()->getIcon("edit-delete"));
-    actionDownload_torrent->setIcon(GuiIconProvider::instance()->getIcon("download"));
-    actionMark_items_read->setIcon(GuiIconProvider::instance()->getIcon("mail-mark-read"));
-    actionNew_folder->setIcon(GuiIconProvider::instance()->getIcon("folder-new"));
-    actionNew_subscription->setIcon(GuiIconProvider::instance()->getIcon("list-add"));
-    actionOpen_news_URL->setIcon(GuiIconProvider::instance()->getIcon("application-x-mswinurl"));
-    actionRename->setIcon(GuiIconProvider::instance()->getIcon("edit-rename"));
-    actionUpdate->setIcon(GuiIconProvider::instance()->getIcon("view-refresh"));
-    actionUpdate_all_feeds->setIcon(GuiIconProvider::instance()->getIcon("view-refresh"));
-    newFeedButton->setIcon(GuiIconProvider::instance()->getIcon("list-add"));
-    markReadButton->setIcon(GuiIconProvider::instance()->getIcon("mail-mark-read"));
-    updateAllButton->setIcon(GuiIconProvider::instance()->getIcon("view-refresh"));
-    rssDownloaderBtn->setIcon(GuiIconProvider::instance()->getIcon("download"));
-    settingsButton->setIcon(GuiIconProvider::instance()->getIcon("configure", "preferences-system"));
+    m_ui->actionCopy_feed_URL->setIcon(GuiIconProvider::instance()->getIcon("edit-copy"));
+    m_ui->actionDelete->setIcon(GuiIconProvider::instance()->getIcon("edit-delete"));
+    m_ui->actionDownload_torrent->setIcon(GuiIconProvider::instance()->getIcon("download"));
+    m_ui->actionMark_items_read->setIcon(GuiIconProvider::instance()->getIcon("mail-mark-read"));
+    m_ui->actionNew_folder->setIcon(GuiIconProvider::instance()->getIcon("folder-new"));
+    m_ui->actionNew_subscription->setIcon(GuiIconProvider::instance()->getIcon("list-add"));
+    m_ui->actionOpen_news_URL->setIcon(GuiIconProvider::instance()->getIcon("application-x-mswinurl"));
+    m_ui->actionRename->setIcon(GuiIconProvider::instance()->getIcon("edit-rename"));
+    m_ui->actionUpdate->setIcon(GuiIconProvider::instance()->getIcon("view-refresh"));
+    m_ui->actionUpdate_all_feeds->setIcon(GuiIconProvider::instance()->getIcon("view-refresh"));
+    m_ui->newFeedButton->setIcon(GuiIconProvider::instance()->getIcon("list-add"));
+    m_ui->markReadButton->setIcon(GuiIconProvider::instance()->getIcon("mail-mark-read"));
+    m_ui->updateAllButton->setIcon(GuiIconProvider::instance()->getIcon("view-refresh"));
+    m_ui->rssDownloaderBtn->setIcon(GuiIconProvider::instance()->getIcon("download"));
+    m_ui->settingsButton->setIcon(GuiIconProvider::instance()->getIcon("configure", "preferences-system"));
 
-    m_feedList = new FeedListWidget(splitterSide, m_rssManager);
-    splitterSide->insertWidget(0, m_feedList);
+    m_feedList = new FeedListWidget(m_ui->splitterSide, m_rssManager);
+    m_ui->splitterSide->insertWidget(0, m_feedList);
     editHotkey = new QShortcut(Qt::Key_F2, m_feedList, 0, 0, Qt::WidgetShortcut);
     connect(editHotkey, SIGNAL(activated()), SLOT(renameSelectedRssFile()));
     connect(m_feedList, SIGNAL(doubleClicked(QModelIndex)), SLOT(renameSelectedRssFile()));
@@ -742,33 +746,33 @@ RSSImp::RSSImp(QWidget *parent)
     connect(m_rssManager.data(), SIGNAL(feedIconChanged(QString,QString)), SLOT(updateFeedIcon(QString,QString)));
 
     connect(m_feedList, SIGNAL(customContextMenuRequested(const QPoint&)), SLOT(displayRSSListMenu(const QPoint&)));
-    connect(listArticles, SIGNAL(customContextMenuRequested(const QPoint&)), SLOT(displayItemsListMenu(const QPoint&)));
+    connect(m_ui->listArticles, SIGNAL(customContextMenuRequested(const QPoint&)), SLOT(displayItemsListMenu(const QPoint&)));
 
     // Feeds list actions
-    connect(actionDelete, SIGNAL(triggered()), this, SLOT(deleteSelectedItems()));
-    connect(actionRename, SIGNAL(triggered()), this, SLOT(renameSelectedRssFile()));
-    connect(actionUpdate, SIGNAL(triggered()), this, SLOT(refreshSelectedItems()));
-    connect(actionNew_folder, SIGNAL(triggered()), this, SLOT(askNewFolder()));
-    connect(actionNew_subscription, SIGNAL(triggered()), this, SLOT(on_newFeedButton_clicked()));
-    connect(actionUpdate_all_feeds, SIGNAL(triggered()), this, SLOT(refreshAllFeeds()));
-    connect(updateAllButton, SIGNAL(clicked()), SLOT(refreshAllFeeds()));
-    connect(actionCopy_feed_URL, SIGNAL(triggered()), this, SLOT(copySelectedFeedsURL()));
-    connect(actionMark_items_read, SIGNAL(triggered()), this, SLOT(on_markReadButton_clicked()));
+    connect(m_ui->actionDelete, SIGNAL(triggered()), this, SLOT(deleteSelectedItems()));
+    connect(m_ui->actionRename, SIGNAL(triggered()), this, SLOT(renameSelectedRssFile()));
+    connect(m_ui->actionUpdate, SIGNAL(triggered()), this, SLOT(refreshSelectedItems()));
+    connect(m_ui->actionNew_folder, SIGNAL(triggered()), this, SLOT(askNewFolder()));
+    connect(m_ui->actionNew_subscription, SIGNAL(triggered()), this, SLOT(on_newFeedButton_clicked()));
+    connect(m_ui->actionUpdate_all_feeds, SIGNAL(triggered()), this, SLOT(refreshAllFeeds()));
+    connect(m_ui->updateAllButton, SIGNAL(clicked()), SLOT(refreshAllFeeds()));
+    connect(m_ui->actionCopy_feed_URL, SIGNAL(triggered()), this, SLOT(copySelectedFeedsURL()));
+    connect(m_ui->actionMark_items_read, SIGNAL(triggered()), this, SLOT(on_markReadButton_clicked()));
     // News list actions
-    connect(actionOpen_news_URL, SIGNAL(triggered()), this, SLOT(openSelectedArticlesUrls()));
-    connect(actionDownload_torrent, SIGNAL(triggered()), this, SLOT(downloadSelectedTorrents()));
+    connect(m_ui->actionOpen_news_URL, SIGNAL(triggered()), this, SLOT(openSelectedArticlesUrls()));
+    connect(m_ui->actionDownload_torrent, SIGNAL(triggered()), this, SLOT(downloadSelectedTorrents()));
 
     connect(m_feedList, SIGNAL(currentItemChanged(QTreeWidgetItem *,QTreeWidgetItem *)), this, SLOT(populateArticleList(QTreeWidgetItem *)));
     connect(m_feedList, SIGNAL(foldersAltered(QList<QTreeWidgetItem * >)), this, SLOT(updateItemsInfos(QList<QTreeWidgetItem * >)));
 
-    connect(listArticles, SIGNAL(itemSelectionChanged()), this, SLOT(refreshTextBrowser()));
-    connect(listArticles, SIGNAL(itemDoubleClicked(QListWidgetItem *)), this, SLOT(downloadSelectedTorrents()));
+    connect(m_ui->listArticles, SIGNAL(itemSelectionChanged()), this, SLOT(refreshTextBrowser()));
+    connect(m_ui->listArticles, SIGNAL(itemDoubleClicked(QListWidgetItem *)), this, SLOT(downloadSelectedTorrents()));
 
     // Restore sliders position
     restoreSlidersPosition();
     // Bind saveSliders slots
-    connect(splitterMain, SIGNAL(splitterMoved(int,int)), this, SLOT(saveSlidersPosition()));
-    connect(splitterSide, SIGNAL(splitterMoved(int,int)), this, SLOT(saveSlidersPosition()));
+    connect(m_ui->splitterMain, SIGNAL(splitterMoved(int,int)), this, SLOT(saveSlidersPosition()));
+    connect(m_ui->splitterSide, SIGNAL(splitterMoved(int,int)), this, SLOT(saveSlidersPosition()));
 
     qDebug("RSSImp constructed");
 }
@@ -780,6 +784,7 @@ RSSImp::~RSSImp()
     delete editHotkey;
     delete deleteHotkey;
     delete m_feedList;
+    delete m_ui;
     qDebug("RSSImp deleted");
 }
 

--- a/src/gui/rss/rss_imp.h
+++ b/src/gui/rss/rss_imp.h
@@ -37,15 +37,20 @@
 
 #include "base/rss/rssfolder.h"
 #include "base/rss/rssmanager.h"
-#include "ui_rss.h"
 
 class FeedListWidget;
 
 QT_BEGIN_NAMESPACE
+class QListWidgetItem;
 class QTreeWidgetItem;
 QT_END_NAMESPACE
 
-class RSSImp: public QWidget, public Ui::RSS
+namespace Ui
+{
+    class RSS;
+}
+
+class RSSImp: public QWidget
 {
     Q_OBJECT
 
@@ -92,6 +97,7 @@ private:
     static QTreeWidgetItem *createFolderListItem(const Rss::FilePtr &rssFile);
 
 private:
+    Ui::RSS *m_ui;
     Rss::ManagerPtr m_rssManager;
     FeedListWidget *m_feedList;
     QListWidgetItem *m_currentArticle;

--- a/src/gui/search/pluginselectdlg.cpp
+++ b/src/gui/search/pluginselectdlg.cpp
@@ -29,6 +29,8 @@
  * Contact : chris@qbittorrent.org
  */
 
+#include "pluginselectdlg.h"
+
 #include <QHeaderView>
 #include <QMenu>
 #include <QMessageBox>
@@ -48,7 +50,7 @@
 #include "pluginsourcedlg.h"
 #include "guiiconprovider.h"
 #include "autoexpandabledialog.h"
-#include "pluginselectdlg.h"
+#include "ui_pluginselectdlg.h"
 
 enum PluginColumns
 {
@@ -61,30 +63,31 @@ enum PluginColumns
 
 PluginSelectDlg::PluginSelectDlg(SearchEngine *pluginManager, QWidget *parent)
     : QDialog(parent)
+    , m_ui(new Ui::PluginSelectDlg())
     , m_pluginManager(pluginManager)
     , m_asyncOps(0)
 {
-    setupUi(this);
+    m_ui->setupUi(this);
     setAttribute(Qt::WA_DeleteOnClose);
 
     // This hack fixes reordering of first column with Qt5.
     // https://github.com/qtproject/qtbase/commit/e0fc088c0c8bc61dbcaf5928b24986cd61a22777
     QTableView unused;
-    unused.setVerticalHeader(pluginsTree->header());
-    pluginsTree->header()->setParent(pluginsTree);
+    unused.setVerticalHeader(m_ui->pluginsTree->header());
+    m_ui->pluginsTree->header()->setParent(m_ui->pluginsTree);
     unused.setVerticalHeader(new QHeaderView(Qt::Horizontal));
 
-    pluginsTree->setRootIsDecorated(false);
-    pluginsTree->header()->resizeSection(0, 160);
-    pluginsTree->header()->resizeSection(1, 80);
-    pluginsTree->header()->resizeSection(2, 200);
-    pluginsTree->hideColumn(PLUGIN_ID);
+    m_ui->pluginsTree->setRootIsDecorated(false);
+    m_ui->pluginsTree->header()->resizeSection(0, 160);
+    m_ui->pluginsTree->header()->resizeSection(1, 80);
+    m_ui->pluginsTree->header()->resizeSection(2, 200);
+    m_ui->pluginsTree->hideColumn(PLUGIN_ID);
 
-    actionUninstall->setIcon(GuiIconProvider::instance()->getIcon("list-remove"));
+    m_ui->actionUninstall->setIcon(GuiIconProvider::instance()->getIcon("list-remove"));
 
-    connect(actionEnable, SIGNAL(toggled(bool)), this, SLOT(enableSelection(bool)));
-    connect(pluginsTree, SIGNAL(customContextMenuRequested(const QPoint&)), this, SLOT(displayContextMenu(const QPoint&)));
-    connect(pluginsTree, SIGNAL(itemDoubleClicked(QTreeWidgetItem*, int)), this, SLOT(togglePluginState(QTreeWidgetItem*, int)));
+    connect(m_ui->actionEnable, SIGNAL(toggled(bool)), this, SLOT(enableSelection(bool)));
+    connect(m_ui->pluginsTree, SIGNAL(customContextMenuRequested(const QPoint&)), this, SLOT(displayContextMenu(const QPoint&)));
+    connect(m_ui->pluginsTree, SIGNAL(itemDoubleClicked(QTreeWidgetItem*, int)), this, SLOT(togglePluginState(QTreeWidgetItem*, int)));
 
     loadSupportedSearchPlugins();
 
@@ -101,6 +104,7 @@ PluginSelectDlg::PluginSelectDlg(SearchEngine *pluginManager, QWidget *parent)
 PluginSelectDlg::~PluginSelectDlg()
 {
     emit pluginsChanged();
+    delete m_ui;
 }
 
 void PluginSelectDlg::dropEvent(QDropEvent *event)
@@ -156,11 +160,11 @@ void PluginSelectDlg::togglePluginState(QTreeWidgetItem *item, int)
     m_pluginManager->enablePlugin(plugin->name, !plugin->enabled);
     if (plugin->enabled) {
         item->setText(PLUGIN_STATE, tr("Yes"));
-        setRowColor(pluginsTree->indexOfTopLevelItem(item), "green");
+        setRowColor(m_ui->pluginsTree->indexOfTopLevelItem(item), "green");
     }
     else {
         item->setText(PLUGIN_STATE, tr("No"));
-        setRowColor(pluginsTree->indexOfTopLevelItem(item), "red");
+        setRowColor(m_ui->pluginsTree->indexOfTopLevelItem(item), "red");
     }
 }
 
@@ -168,14 +172,14 @@ void PluginSelectDlg::displayContextMenu(const QPoint&)
 {
     QMenu myContextMenu(this);
     // Enable/disable pause/start action given the DL state
-    QList<QTreeWidgetItem *> items = pluginsTree->selectedItems();
+    QList<QTreeWidgetItem *> items = m_ui->pluginsTree->selectedItems();
     if (items.isEmpty()) return;
 
     QString first_id = items.first()->text(PLUGIN_ID);
-    actionEnable->setChecked(m_pluginManager->pluginInfo(first_id)->enabled);
-    myContextMenu.addAction(actionEnable);
+    m_ui->actionEnable->setChecked(m_pluginManager->pluginInfo(first_id)->enabled);
+    myContextMenu.addAction(m_ui->actionEnable);
     myContextMenu.addSeparator();
-    myContextMenu.addAction(actionUninstall);
+    myContextMenu.addAction(m_ui->actionUninstall);
     myContextMenu.exec(QCursor::pos());
 }
 
@@ -187,8 +191,8 @@ void PluginSelectDlg::on_closeButton_clicked()
 void PluginSelectDlg::on_actionUninstall_triggered()
 {
     bool error = false;
-    foreach (QTreeWidgetItem *item, pluginsTree->selectedItems()) {
-        int index = pluginsTree->indexOfTopLevelItem(item);
+    foreach (QTreeWidgetItem *item, m_ui->pluginsTree->selectedItems()) {
+        int index = m_ui->pluginsTree->indexOfTopLevelItem(item);
         Q_ASSERT(index != -1);
         QString id = item->text(PLUGIN_ID);
         if (m_pluginManager->uninstallPlugin(id)) {
@@ -211,8 +215,8 @@ void PluginSelectDlg::on_actionUninstall_triggered()
 
 void PluginSelectDlg::enableSelection(bool enable)
 {
-    foreach (QTreeWidgetItem *item, pluginsTree->selectedItems()) {
-        int index = pluginsTree->indexOfTopLevelItem(item);
+    foreach (QTreeWidgetItem *item, m_ui->pluginsTree->selectedItems()) {
+        int index = m_ui->pluginsTree->indexOfTopLevelItem(item);
         Q_ASSERT(index != -1);
         QString id = item->text(PLUGIN_ID);
         m_pluginManager->enablePlugin(id, enable);
@@ -230,8 +234,8 @@ void PluginSelectDlg::enableSelection(bool enable)
 // Set the color of a row in data model
 void PluginSelectDlg::setRowColor(int row, QString color)
 {
-    QTreeWidgetItem *item = pluginsTree->topLevelItem(row);
-    for (int i = 0; i < pluginsTree->columnCount(); ++i) {
+    QTreeWidgetItem *item = m_ui->pluginsTree->topLevelItem(row);
+    for (int i = 0; i < m_ui->pluginsTree->columnCount(); ++i) {
         item->setData(i, Qt::ForegroundRole, QVariant(QColor(color)));
     }
 }
@@ -240,8 +244,8 @@ QList<QTreeWidgetItem*> PluginSelectDlg::findItemsWithUrl(QString url)
 {
     QList<QTreeWidgetItem*> res;
 
-    for (int i = 0; i < pluginsTree->topLevelItemCount(); ++i) {
-        QTreeWidgetItem *item = pluginsTree->topLevelItem(i);
+    for (int i = 0; i < m_ui->pluginsTree->topLevelItemCount(); ++i) {
+        QTreeWidgetItem *item = m_ui->pluginsTree->topLevelItem(i);
         if (url.startsWith(item->text(PLUGIN_URL), Qt::CaseInsensitive))
             res << item;
     }
@@ -251,8 +255,8 @@ QList<QTreeWidgetItem*> PluginSelectDlg::findItemsWithUrl(QString url)
 
 QTreeWidgetItem* PluginSelectDlg::findItemWithID(QString id)
 {
-    for (int i = 0; i < pluginsTree->topLevelItemCount(); ++i) {
-        QTreeWidgetItem *item = pluginsTree->topLevelItem(i);
+    for (int i = 0; i < m_ui->pluginsTree->topLevelItemCount(); ++i) {
+        QTreeWidgetItem *item = m_ui->pluginsTree->topLevelItem(i);
         if (id == item->text(PLUGIN_ID))
             return item;
     }
@@ -263,25 +267,25 @@ QTreeWidgetItem* PluginSelectDlg::findItemWithID(QString id)
 void PluginSelectDlg::loadSupportedSearchPlugins()
 {
     // Some clean up first
-    pluginsTree->clear();
+    m_ui->pluginsTree->clear();
     foreach (QString name, m_pluginManager->allPlugins())
         addNewPlugin(name);
 }
 
 void PluginSelectDlg::addNewPlugin(QString pluginName)
 {
-    QTreeWidgetItem *item = new QTreeWidgetItem(pluginsTree);
+    QTreeWidgetItem *item = new QTreeWidgetItem(m_ui->pluginsTree);
     PluginInfo *plugin = m_pluginManager->pluginInfo(pluginName);
     item->setText(PLUGIN_NAME, plugin->fullName);
     item->setText(PLUGIN_URL, plugin->url);
     item->setText(PLUGIN_ID, plugin->name);
     if (plugin->enabled) {
         item->setText(PLUGIN_STATE, tr("Yes"));
-        setRowColor(pluginsTree->indexOfTopLevelItem(item), "green");
+        setRowColor(m_ui->pluginsTree->indexOfTopLevelItem(item), "green");
     }
     else {
         item->setText(PLUGIN_STATE, tr("No"));
-        setRowColor(pluginsTree->indexOfTopLevelItem(item), "red");
+        setRowColor(m_ui->pluginsTree->indexOfTopLevelItem(item), "red");
     }
     // Handle icon
     if (QFile::exists(plugin->iconPath)) {

--- a/src/gui/search/pluginselectdlg.h
+++ b/src/gui/search/pluginselectdlg.h
@@ -32,12 +32,19 @@
 #ifndef PLUGINSELECTDLG_H
 #define PLUGINSELECTDLG_H
 
-#include "ui_pluginselectdlg.h"
+#include <QDialog>
 
 class QDropEvent;
+class QTreeWidgetItem;
+
 class SearchEngine;
 
-class PluginSelectDlg: public QDialog, private Ui::PluginSelectDlg
+namespace Ui
+{
+    class PluginSelectDlg;
+}
+
+class PluginSelectDlg: public QDialog
 {
     Q_OBJECT
 
@@ -82,6 +89,7 @@ private:
     void startAsyncOp();
     void finishAsyncOp();
 
+    Ui::PluginSelectDlg *m_ui;
     SearchEngine *m_pluginManager;
     int m_asyncOps;
 };

--- a/src/gui/search/pluginsourcedlg.cpp
+++ b/src/gui/search/pluginsourcedlg.cpp
@@ -30,12 +30,20 @@
 
 #include "pluginsourcedlg.h"
 
+#include "ui_pluginsourcedlg.h"
+
 PluginSourceDlg::PluginSourceDlg(QWidget *parent)
     : QDialog(parent)
+    , m_ui(new Ui::PluginSourceDlg())
 {
-    setupUi(this);
+    m_ui->setupUi(this);
     setAttribute(Qt::WA_DeleteOnClose);
     show();
+}
+
+PluginSourceDlg::~PluginSourceDlg()
+{
+    delete m_ui;
 }
 
 void PluginSourceDlg::on_localButton_clicked()

--- a/src/gui/search/pluginsourcedlg.h
+++ b/src/gui/search/pluginsourcedlg.h
@@ -32,14 +32,19 @@
 #define PLUGINSOURCEDLG_H
 
 #include <QDialog>
-#include "ui_pluginsourcedlg.h"
 
-class PluginSourceDlg: public QDialog, private Ui::PluginSourceDlg
+namespace Ui
+{
+    class PluginSourceDlg;
+}
+
+class PluginSourceDlg: public QDialog
 {
     Q_OBJECT
 
 public:
     explicit PluginSourceDlg(QWidget *parent = 0);
+    ~PluginSourceDlg();
 
 signals:
     void askForUrl();
@@ -48,6 +53,9 @@ signals:
 private slots:
     void on_localButton_clicked();
     void on_urlButton_clicked();
+
+private:
+    Ui::PluginSourceDlg *m_ui;
 };
 
 #endif // PLUGINSOURCEDLG_H

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -29,6 +29,8 @@
  * Contact : chris@qbittorrent.org
  */
 
+#include "searchwidget.h"
+
 #include <QHeaderView>
 #include <QMessageBox>
 #include <QSystemTrayIcon>
@@ -45,6 +47,7 @@
 #include <QProcess>
 #include <QDebug>
 #include <QTextStream>
+#include <QTreeView>
 
 #include <iostream>
 #ifdef Q_OS_WIN
@@ -63,18 +66,20 @@
 #include "pluginselectdlg.h"
 #include "searchsortmodel.h"
 #include "searchtab.h"
-#include "searchwidget.h"
+
+#include "ui_searchwidget.h"
 
 #define SEARCHHISTORY_MAXSIZE 50
 #define URL_COLUMN 5
 
 SearchWidget::SearchWidget(MainWindow *mainWindow)
     : QWidget(mainWindow)
+    , m_ui(new Ui::SearchWidget())
     , m_mainWindow(mainWindow)
     , m_isNewQueryString(false)
     , m_noSearchResults(true)
 {
-    setupUi(this);
+    m_ui->setupUi(this);
 
     QString searchPatternHint;
     QTextStream stream(&searchPatternHint, QIODevice::WriteOnly);
@@ -92,15 +97,15 @@ SearchWidget::SearchWidget(MainWindow *mainWindow)
                  "Search phrase example, illustrates quotes usage, double quoted"
                  "pair of space delimited words, the whole pair is highlighted")
            << "</p></body></html>" << flush;
-    m_searchPattern->setToolTip(searchPatternHint);
+    m_ui->m_searchPattern->setToolTip(searchPatternHint);
 
     // Icons
-    searchButton->setIcon(GuiIconProvider::instance()->getIcon("edit-find"));
-    downloadButton->setIcon(GuiIconProvider::instance()->getIcon("download"));
-    goToDescBtn->setIcon(GuiIconProvider::instance()->getIcon("application-x-mswinurl"));
-    pluginsButton->setIcon(GuiIconProvider::instance()->getIcon("preferences-system-network"));
-    copyURLBtn->setIcon(GuiIconProvider::instance()->getIcon("edit-copy"));
-    connect(tabWidget, SIGNAL(tabCloseRequested(int)), this, SLOT(closeTab(int)));
+    m_ui->searchButton->setIcon(GuiIconProvider::instance()->getIcon("edit-find"));
+    m_ui->downloadButton->setIcon(GuiIconProvider::instance()->getIcon("download"));
+    m_ui->goToDescBtn->setIcon(GuiIconProvider::instance()->getIcon("application-x-mswinurl"));
+    m_ui->pluginsButton->setIcon(GuiIconProvider::instance()->getIcon("preferences-system-network"));
+    m_ui->copyURLBtn->setIcon(GuiIconProvider::instance()->getIcon("edit-copy"));
+    connect(m_ui->tabWidget, SIGNAL(tabCloseRequested(int)), this, SLOT(closeTab(int)));
 
     m_searchEngine = new SearchEngine;
     connect(m_searchEngine, SIGNAL(searchStarted()), SLOT(searchStarted()));
@@ -113,16 +118,16 @@ SearchWidget::SearchWidget(MainWindow *mainWindow)
     fillCatCombobox();
     fillPluginComboBox();
 
-    connect(m_searchPattern, SIGNAL(returnPressed()), searchButton, SLOT(click()));
-    connect(m_searchPattern, SIGNAL(textEdited(QString)), this, SLOT(searchTextEdited(QString)));
-    connect(selectPlugin, SIGNAL(currentIndexChanged(int)), this, SLOT(selectMultipleBox(int)));
+    connect(m_ui->m_searchPattern, SIGNAL(returnPressed()), m_ui->searchButton, SLOT(click()));
+    connect(m_ui->m_searchPattern, SIGNAL(textEdited(QString)), this, SLOT(searchTextEdited(QString)));
+    connect(m_ui->selectPlugin, SIGNAL(currentIndexChanged(int)), this, SLOT(selectMultipleBox(int)));
 }
 
 void SearchWidget::fillCatCombobox()
 {
-    comboCategory->clear();
-    comboCategory->addItem(SearchEngine::categoryFullName("all"), QVariant("all"));
-    comboCategory->insertSeparator(1);
+    m_ui->comboCategory->clear();
+    m_ui->comboCategory->addItem(SearchEngine::categoryFullName("all"), QVariant("all"));
+    m_ui->comboCategory->insertSeparator(1);
 
     using QStrPair = QPair<QString, QString>;
     QList<QStrPair> tmpList;
@@ -132,17 +137,17 @@ void SearchWidget::fillCatCombobox()
 
     foreach (const QStrPair &p, tmpList) {
         qDebug("Supported category: %s", qPrintable(p.second));
-        comboCategory->addItem(p.first, QVariant(p.second));
+        m_ui->comboCategory->addItem(p.first, QVariant(p.second));
     }
 }
 
 void SearchWidget::fillPluginComboBox()
 {
-    selectPlugin->clear();
-    selectPlugin->addItem(tr("Only enabled"), QVariant("enabled"));
-    selectPlugin->addItem(tr("All plugins"), QVariant("all"));
-    selectPlugin->addItem(tr("Select..."), QVariant("multi"));
-    selectPlugin->insertSeparator(3);
+    m_ui->selectPlugin->clear();
+    m_ui->selectPlugin->addItem(tr("Only enabled"), QVariant("enabled"));
+    m_ui->selectPlugin->addItem(tr("All plugins"), QVariant("all"));
+    m_ui->selectPlugin->addItem(tr("Select..."), QVariant("multi"));
+    m_ui->selectPlugin->insertSeparator(3);
 
     using QStrPair = QPair<QString, QString>;
     QList<QStrPair> tmpList;
@@ -151,23 +156,24 @@ void SearchWidget::fillPluginComboBox()
     std::sort(tmpList.begin(), tmpList.end(), [](const QStrPair &l, const QStrPair &r) { return (l.first < r.first); } );
 
     foreach (const QStrPair &p, tmpList)
-        selectPlugin->addItem(p.first, QVariant(p.second));
+        m_ui->selectPlugin->addItem(p.first, QVariant(p.second));
 }
 
 QString SearchWidget::selectedCategory() const
 {
-    return comboCategory->itemData(comboCategory->currentIndex()).toString();
+    return m_ui->comboCategory->itemData(m_ui->comboCategory->currentIndex()).toString();
 }
 
 QString SearchWidget::selectedPlugin() const
 {
-    return selectPlugin->itemData(selectPlugin->currentIndex()).toString();
+    return m_ui->selectPlugin->itemData(m_ui->selectPlugin->currentIndex()).toString();
 }
 
 SearchWidget::~SearchWidget()
 {
     qDebug("Search destruction");
     delete m_searchEngine;
+    delete m_ui;
 }
 
 void SearchWidget::downloadTorrent(const QString &siteUrl, const QString &url)
@@ -184,16 +190,16 @@ void SearchWidget::tab_changed(int t)
     //doesn't have to be available
     if (t > -1) {
         //-1 = no more tab
-        m_currentSearchTab = m_allTabs.at(tabWidget->currentIndex());
+        m_currentSearchTab = m_allTabs.at(m_ui->tabWidget->currentIndex());
         if (m_currentSearchTab->getCurrentSearchListModel()->rowCount()) {
-            downloadButton->setEnabled(true);
-            goToDescBtn->setEnabled(true);
-            copyURLBtn->setEnabled(true);
+            m_ui->downloadButton->setEnabled(true);
+            m_ui->goToDescBtn->setEnabled(true);
+            m_ui->copyURLBtn->setEnabled(true);
         }
         else {
-            downloadButton->setEnabled(false);
-            goToDescBtn->setEnabled(false);
-            copyURLBtn->setEnabled(false);
+            m_ui->downloadButton->setEnabled(false);
+            m_ui->goToDescBtn->setEnabled(false);
+            m_ui->copyURLBtn->setEnabled(false);
         }
     }
 }
@@ -223,18 +229,18 @@ void SearchWidget::on_pluginsButton_clicked()
 void SearchWidget::searchTextEdited(QString)
 {
     // Enable search button
-    searchButton->setText(tr("Search"));
+    m_ui->searchButton->setText(tr("Search"));
     m_isNewQueryString = true;
 }
 
 void SearchWidget::giveFocusToSearchInput()
 {
-    m_searchPattern->setFocus();
+    m_ui->m_searchPattern->setFocus();
 }
 
 QTabWidget *SearchWidget::searchTabs() const
 {
-    return tabWidget;
+    return m_ui->tabWidget;
 }
 
 // Function called when we click on search button
@@ -249,14 +255,14 @@ void SearchWidget::on_searchButton_clicked()
         m_searchEngine->cancelSearch();
 
         if (!m_isNewQueryString) {
-            searchButton->setText(tr("Search"));
+            m_ui->searchButton->setText(tr("Search"));
             return;
         }
     }
 
     m_isNewQueryString = false;
 
-    const QString pattern = m_searchPattern->text().trimmed();
+    const QString pattern = m_ui->m_searchPattern->text().trimmed();
     // No search pattern entered
     if (pattern.isEmpty()) {
         QMessageBox::critical(0, tr("Empty search pattern"), tr("Please type a search pattern first"));
@@ -269,8 +275,8 @@ void SearchWidget::on_searchButton_clicked()
     m_allTabs.append(m_currentSearchTab);
     QString tabName = pattern;
     tabName.replace(QRegExp("&{1}"), "&&");
-    tabWidget->addTab(m_currentSearchTab, tabName);
-    tabWidget->setCurrentWidget(m_currentSearchTab);
+    m_ui->tabWidget->addTab(m_currentSearchTab, tabName);
+    m_ui->tabWidget->setCurrentWidget(m_currentSearchTab);
     m_currentSearchTab->getCurrentSearchListProxy()->setNameFilter(pattern);
 
     QStringList plugins;
@@ -295,7 +301,7 @@ void SearchWidget::searchStarted()
 {
     // Update SearchEngine widgets
     m_activeSearchTab->setStatus(SearchTab::Status::Ongoing);
-    searchButton->setText(tr("Stop"));
+    m_ui->searchButton->setText(tr("Stop"));
 }
 
 // Slot called when search is Finished
@@ -316,7 +322,7 @@ void SearchWidget::searchFinished(bool cancelled)
         m_activeSearchTab->setStatus(SearchTab::Status::Finished);
 
     m_activeSearchTab = 0;
-    searchButton->setText(tr("Search"));
+    m_ui->searchButton->setText(tr("Search"));
 }
 
 void SearchWidget::searchFailed()
@@ -363,15 +369,15 @@ void SearchWidget::appendSearchResults(const QList<SearchResult> &results)
     m_activeSearchTab->updateResultsCount();
 
     // Enable clear & download buttons
-    downloadButton->setEnabled(true);
-    goToDescBtn->setEnabled(true);
-    copyURLBtn->setEnabled(true);
+    m_ui->downloadButton->setEnabled(true);
+    m_ui->goToDescBtn->setEnabled(true);
+    m_ui->copyURLBtn->setEnabled(true);
 }
 
 void SearchWidget::closeTab(int index)
 {
     // Search is run for active tab so if user decided to close it, then stop search
-    if (!m_activeSearchTab.isNull() && index == tabWidget->indexOf(m_activeSearchTab)) {
+    if (!m_activeSearchTab.isNull() && index == m_ui->tabWidget->indexOf(m_activeSearchTab)) {
         qDebug("Closed active search Tab");
         if (m_searchEngine->isActive())
             m_searchEngine->cancelSearch();
@@ -381,9 +387,9 @@ void SearchWidget::closeTab(int index)
     delete m_allTabs.takeAt(index);
 
     if (!m_allTabs.size()) {
-        downloadButton->setEnabled(false);
-        goToDescBtn->setEnabled(false);
-        copyURLBtn->setEnabled(false);
+        m_ui->downloadButton->setEnabled(false);
+        m_ui->goToDescBtn->setEnabled(false);
+        m_ui->copyURLBtn->setEnabled(false);
     }
 }
 
@@ -391,19 +397,21 @@ void SearchWidget::closeTab(int index)
 void SearchWidget::on_downloadButton_clicked()
 {
     //QModelIndexList selectedIndexes = currentSearchTab->getCurrentTreeView()->selectionModel()->selectedIndexes();
-    QModelIndexList selectedIndexes = m_allTabs.at(tabWidget->currentIndex())->getCurrentTreeView()->selectionModel()->selectedIndexes();
+    QModelIndexList selectedIndexes =
+        m_allTabs.at(m_ui->tabWidget->currentIndex())->getCurrentTreeView()->selectionModel()->selectedIndexes();
     foreach (const QModelIndex &index, selectedIndexes) {
         if (index.column() == SearchSortModel::NAME)
-            m_allTabs.at(tabWidget->currentIndex())->downloadItem(index);
+            m_allTabs.at(m_ui->tabWidget->currentIndex())->downloadItem(index);
     }
 }
 
 void SearchWidget::on_goToDescBtn_clicked()
 {
-    QModelIndexList selectedIndexes = m_allTabs.at(tabWidget->currentIndex())->getCurrentTreeView()->selectionModel()->selectedIndexes();
+    QModelIndexList selectedIndexes =
+        m_allTabs.at(m_ui->tabWidget->currentIndex())->getCurrentTreeView()->selectionModel()->selectedIndexes();
     foreach (const QModelIndex &index, selectedIndexes) {
         if (index.column() == SearchSortModel::NAME) {
-            QSortFilterProxyModel *model = m_allTabs.at(tabWidget->currentIndex())->getCurrentSearchListProxy();
+            QSortFilterProxyModel *model = m_allTabs.at(m_ui->tabWidget->currentIndex())->getCurrentSearchListProxy();
             const QString descUrl = model->data(model->index(index.row(), SearchSortModel::DESC_LINK)).toString();
             if (!descUrl.isEmpty())
                 QDesktopServices::openUrl(QUrl::fromEncoded(descUrl.toUtf8()));
@@ -414,11 +422,12 @@ void SearchWidget::on_goToDescBtn_clicked()
 void SearchWidget::on_copyURLBtn_clicked()
 {
     QStringList urls;
-    QModelIndexList selectedIndexes = m_allTabs.at(tabWidget->currentIndex())->getCurrentTreeView()->selectionModel()->selectedIndexes();
+    QModelIndexList selectedIndexes =
+        m_allTabs.at(m_ui->tabWidget->currentIndex())->getCurrentTreeView()->selectionModel()->selectedIndexes();
 
     foreach (const QModelIndex &index, selectedIndexes) {
         if (index.column() == SearchSortModel::NAME) {
-            QSortFilterProxyModel *model = m_allTabs.at(tabWidget->currentIndex())->getCurrentSearchListProxy();
+            QSortFilterProxyModel *model = m_allTabs.at(m_ui->tabWidget->currentIndex())->getCurrentSearchListProxy();
             const QString descUrl = model->data(model->index(index.row(), SearchSortModel::DESC_LINK)).toString();
             if (!descUrl.isEmpty())
                 urls << descUrl.toUtf8();

--- a/src/gui/search/searchwidget.h
+++ b/src/gui/search/searchwidget.h
@@ -34,15 +34,21 @@
 
 #include <QList>
 #include <QPointer>
+#include <QWidget>
 
-#include "ui_searchwidget.h"
+class QTabWidget;
 
 class MainWindow;
 class SearchEngine;
 struct SearchResult;
 class SearchTab;
 
-class SearchWidget: public QWidget, private Ui::SearchWidget
+namespace Ui
+{
+    class SearchWidget;
+}
+
+class SearchWidget: public QWidget
 {
     Q_OBJECT
     Q_DISABLE_COPY(SearchWidget)
@@ -82,6 +88,7 @@ private:
     QString selectedCategory() const;
     QString selectedPlugin() const;
 
+    Ui::SearchWidget *m_ui;
     SearchEngine *m_searchEngine;
     QPointer<SearchTab> m_currentSearchTab; // Selected tab
     QPointer<SearchTab> m_activeSearchTab; // Tab with running search

--- a/src/gui/speedlimitdlg.cpp
+++ b/src/gui/speedlimitdlg.cpp
@@ -29,21 +29,26 @@
  */
 
 #include "speedlimitdlg.h"
+
+#include "ui_bandwidth_limit.h"
 #include "base/unicodestrings.h"
 
-SpeedLimitDialog::SpeedLimitDialog(QWidget *parent): QDialog(parent)
+SpeedLimitDialog::SpeedLimitDialog(QWidget *parent)
+    : QDialog(parent)
+    , m_ui(new Ui::bandwidth_dlg())
 {
-    setupUi(this);
+    m_ui->setupUi(this);
     qDebug("Bandwidth allocation dialog creation");
     // Connect to slots
-    connect(bandwidthSlider, SIGNAL(valueChanged(int)), this, SLOT(updateSpinValue(int)));
-    connect(spinBandwidth, SIGNAL(valueChanged(int)), this, SLOT(updateSliderValue(int)));
+    connect(m_ui->bandwidthSlider, SIGNAL(valueChanged(int)), this, SLOT(updateSpinValue(int)));
+    connect(m_ui->spinBandwidth, SIGNAL(valueChanged(int)), this, SLOT(updateSliderValue(int)));
     move(Utils::Misc::screenCenter(this));
 }
 
 SpeedLimitDialog::~SpeedLimitDialog()
 {
     qDebug("Deleting bandwidth allocation dialog");
+    delete m_ui;
 }
 
 // -2: if cancel
@@ -69,31 +74,31 @@ void SpeedLimitDialog::updateSpinValue(int val) const
 {
     qDebug("Called updateSpinValue with %d", val);
     if (val <= 0) {
-        spinBandwidth->setValue(0);
-        spinBandwidth->setSpecialValueText(QString::fromUtf8(C_INFINITY));
-        spinBandwidth->setSuffix(QString::fromUtf8(""));
+        m_ui->spinBandwidth->setValue(0);
+        m_ui->spinBandwidth->setSpecialValueText(QString::fromUtf8(C_INFINITY));
+        m_ui->spinBandwidth->setSuffix(QString::fromUtf8(""));
     }
     else {
-        spinBandwidth->setValue(val);
-        spinBandwidth->setSuffix(" " + tr("KiB/s"));
+        m_ui->spinBandwidth->setValue(val);
+        m_ui->spinBandwidth->setSuffix(" " + tr("KiB/s"));
     }
 }
 
 void SpeedLimitDialog::updateSliderValue(int val) const
 {
     if (val <= 0) {
-        spinBandwidth->setValue(0);
-        spinBandwidth->setSpecialValueText(QString::fromUtf8(C_INFINITY));
-        spinBandwidth->setSuffix(QString::fromUtf8(""));
+        m_ui->spinBandwidth->setValue(0);
+        m_ui->spinBandwidth->setSpecialValueText(QString::fromUtf8(C_INFINITY));
+        m_ui->spinBandwidth->setSuffix(QString::fromUtf8(""));
     }
-    if (val > bandwidthSlider->maximum())
-        bandwidthSlider->setMaximum(val);
-    bandwidthSlider->setValue(val);
+    if (val > m_ui->bandwidthSlider->maximum())
+        m_ui->bandwidthSlider->setMaximum(val);
+    m_ui->bandwidthSlider->setValue(val);
 }
 
 long SpeedLimitDialog::getSpeedLimit() const
 {
-    long val = bandwidthSlider->value();
+    long val = m_ui->bandwidthSlider->value();
     if (val > 0)
         return val;
     return -1;
@@ -109,7 +114,7 @@ void SpeedLimitDialog::setupDialog(long max_slider, long val) const
     // than torrent rate limit.
     if (val > max_slider)
         max_slider = val;
-    bandwidthSlider->setMaximum(max_slider);
-    bandwidthSlider->setValue(val);
+    m_ui->bandwidthSlider->setMaximum(max_slider);
+    m_ui->bandwidthSlider->setValue(val);
     updateSpinValue(val);
 }

--- a/src/gui/speedlimitdlg.h
+++ b/src/gui/speedlimitdlg.h
@@ -33,11 +33,15 @@
 
 #include <QDialog>
 #include <QList>
-#include "ui_bandwidth_limit.h"
 #include "base/utils/misc.h"
 #include "base/bittorrent/session.h"
 
-class SpeedLimitDialog : public QDialog, private Ui_bandwidth_dlg {
+namespace Ui
+{
+    class bandwidth_dlg;
+}
+
+class SpeedLimitDialog : public QDialog {
     Q_OBJECT
 public:
     explicit SpeedLimitDialog(QWidget *parent=0);
@@ -49,6 +53,9 @@ protected slots:
     void updateSliderValue(int val) const;
     long getSpeedLimit() const;
     void setupDialog(long max_slider, long val) const;
+
+private:
+    Ui::bandwidth_dlg *m_ui;
 };
 
 #endif

--- a/src/gui/statusbar.cpp
+++ b/src/gui/statusbar.cpp
@@ -30,6 +30,7 @@
 
 #include "statusbar.h"
 
+#include <QApplication>
 #include <QStatusBar>
 #include <QFrame>
 #include <QLabel>


### PR DESCRIPTION
With version 3.8 CMake became stricter with include directories and instead of messing up with them, here we remove generated includes (actually, only uic products) from header files in `src/gui/` subdirs to make it compile, introducing `m_ui` pointers.

Additionally, Homebrew updated its Qt formula and now Qt installs into a different prefix, which has to be reflected in our workaround (the second commit).