### PR TITLE
Start up torrents after UI was created. Fixes #6454.

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -462,6 +462,9 @@ int Application::exec(const QStringList &params)
         m_paramsQueue.clear();
     }
 
+    // Now UI is ready to process signals from Session
+    BitTorrent::Session::instance()->startUpTorrents();
+
     return BaseApplication::exec();
 }
 

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -440,7 +440,6 @@ Session::Session(QObject *parent)
     Net::PortForwarder::initInstance(m_nativeSession);
 
     qDebug("* BitTorrent Session constructed");
-    startUpTorrents();
 }
 
 bool Session::isDHTEnabled() const

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -330,6 +330,7 @@ namespace BitTorrent
         QStringList bannedIPs() const;
         void setBannedIPs(const QStringList &list);
 
+        void startUpTorrents();
         TorrentHandle *findTorrent(const InfoHash &hash) const;
         QHash<InfoHash, TorrentHandle *> torrents() const;
         TorrentStatusReport torrentStatusReport() const;
@@ -460,7 +461,6 @@ namespace BitTorrent
         void enableIPFilter();
         void disableIPFilter();
 
-        void startUpTorrents();
         bool addTorrent_impl(AddTorrentData addData, const MagnetUri &magnetUri,
                              TorrentInfo torrentInfo = TorrentInfo(),
                              const QByteArray &fastresumeData = QByteArray());


### PR DESCRIPTION
Commit dd0537d changed torrents startup code adding alerts processing
into it. Therefore alerts were processing before UI code subscribed to
signals and therefore part of  alerts was not reflected in UI.

Thus here we do not start torrents in Session constructor but do this
from Application::exec() after UI was constructed and is ready to process
signals.