### PR TITLE
Migrate from platform-specific code in Private::DefaultProfile to QStandardPaths

### DIFF
--- a/src/base/private/profile_p.h
+++ b/src/base/private/profile_p.h
@@ -32,6 +32,7 @@
 #define QBT_PROFILE_P_H
 
 #include <QDir>
+#include <QStandardPaths>
 #include "base/profile.h"
 
 namespace Private
@@ -48,13 +49,17 @@ namespace Private
 
         virtual ~Profile() = default;
 
-        QString configurationName() const;
+        /**
+         * @brief QCoreApplication::applicationName() with optional configuration name appended
+         */
+        QString profileName() const;
 
     protected:
         Profile(const QString &configurationName);
 
+        QString configurationSuffix() const;
     private:
-        QString m_configurationName;
+        QString m_configurationSuffix;
     };
 
     /// Default implementation. Takes paths from system
@@ -69,6 +74,15 @@ namespace Private
         QString dataLocation() const override;
         QString downloadLocation() const override;
         SettingsPtr applicationSettings(const QString &name) const override;
+
+    private:
+        /**
+         * @brief Standard path writable location for profile files
+         *
+         * @param location location kind
+         * @return QStandardPaths::writableLocation(location) / configurationName()
+         */
+        QString locationWithConfigurationName(QStandardPaths::StandardLocation location) const;
     };
 
     /// Custom tree: creates directories under the specified root directory

--- a/src/base/profile.cpp
+++ b/src/base/profile.cpp
@@ -90,9 +90,9 @@ QString Profile::location(SpecialFolder folder) const
     return result;
 }
 
-QString Profile::configurationName() const
+QString Profile::profileName() const
 {
-    return m_profileImpl->configurationName();
+    return m_profileImpl->profileName();
 }
 
 SettingsPtr Profile::applicationSettings(const QString &name) const

--- a/src/base/profile.h
+++ b/src/base/profile.h
@@ -63,7 +63,7 @@ public:
 
     /// Returns either default name for configuration file (QCoreApplication::applicationName())
     /// or the value, supplied via parameters
-    QString configurationName() const;
+    QString profileName() const;
 
     QString toPortablePath(const QString &absolutePath) const;
     QString fromPortablePath(const QString &portablePath) const;


### PR DESCRIPTION
Do not append '/config/' to data location on Windows to maintain backward compatibility.

Thanks @glassez  for spotting this and sorry for the inconvenience.

Additionally, Windows sub-path was ignoring configuration name.

PR updated: now it should work, but I did test on Linux only so far. And there is a little ugliness in the case of UNIX and non-MacOS: instead of using `~/.local/share/qBittorrent` directory,  qBt creates `~/.local/share/qBittorrent/data/` and writes files there. I don't understand why does it do so. To me, it would be a good idea to migrate these files out of the 'data' subdir. But for now  `Private::DefaultProfile::dataLocation()` contains an `#ifdef`.

And I went ahead and renamed `Profile::configurationName()` and `Private::Profile::configurationName()` into `profileName()` and store only optional suffix in the `Private::Profile`.

Tested on:

- [x] Linux
- [x] Window
- [ ] MacOS