### PR TITLE
Disable Qt embedding manifest automatically

### DIFF
--- a/winconf-msvc.pri
+++ b/winconf-msvc.pri
@@ -11,6 +11,7 @@ strace_win {
   LIBS += dbghelp.lib
 }
 
+CONFIG -= embed_manifest_exe
 QMAKE_LFLAGS += "/OPT:REF /OPT:ICF /MANIFEST:EMBED /MANIFESTINPUT:$$quote($${PWD}/src/qbittorrent.exe.manifest)"
 
 RC_FILE = qbittorrent.rc


### PR DESCRIPTION
Embedding manifest fails for me after upgrading to VS2017, this fixes it.
Qt: 5.7.1

Qt doc: https://doc.qt.io/qt-5/windows-deployment.html#manifest-files

Compile log:
```bat
qrc_lang.cpp
linking release\qbittorrent.exe
LINK : warning LNK4075: ignoring '/MANIFESTFILE' due to '/MANIFEST:EMBED' specif
ication
   Creating library release\qbittorrent.lib and object release\qbittorrent.exp
        mt.exe /nologo /manifest release\qbittorrent.exe.embed.manifest /outputr
esource:release\qbittorrent.exe;1

release\qbittorrent.exe.embed.manifest : general error c1010070: Failed to load
and parse the manifest. ???????????
```