### PR TITLE
Fix parallel build is broken when building with Qt jom.

### DIFF
--- a/winconf-msvc.pri
+++ b/winconf-msvc.pri
@@ -12,6 +12,10 @@ strace_win {
 }
 
 CONFIG -= embed_manifest_exe
+
+QMAKE_CFLAGS += "/FS"
+QMAKE_CXXFLAGS += "/FS"
+
 QMAKE_LFLAGS += "/OPT:REF /OPT:ICF /MANIFEST:EMBED /MANIFESTINPUT:$$quote($${PWD}/src/qbittorrent.exe.manifest)"
 
 RC_FILE = qbittorrent.rc


### PR DESCRIPTION
Add /FS flag to serialize writes to the program database (PDB) file.
This occurs after I upgraded to VS2017.
Qt: 5.7.1

MSDN doc: https://msdn.microsoft.com/en-us/library/dn502518.aspx
