### PR TITLE
Allow strip root folder using default settings

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -3372,8 +3372,8 @@ void Session::createTorrentHandle(const libt::torrent_handle &nativeHandle)
     bool fromMagnetUri = !torrent->hasMetadata();
 
     if (data.resumed) {
-        if (fromMagnetUri && (data.addPaused != TriStateBool::True))
-            torrent->resume(data.addForced == TriStateBool::True);
+        if (fromMagnetUri && !data.addPaused)
+            torrent->resume(data.addForced);
 
         logger->addMessage(tr("'%1' resumed. (fast resume)", "'torrent name' was resumed. (fast resume)")
                            .arg(torrent->name()));
@@ -3399,12 +3399,8 @@ void Session::createTorrentHandle(const libt::torrent_handle &nativeHandle)
         if (isAddTrackersEnabled() && !torrent->isPrivate())
             torrent->addTrackers(m_additionalTrackerList);
 
-        bool addPaused = (data.addPaused == TriStateBool::True);
-        if (data.addPaused == TriStateBool::Undefined)
-            addPaused = isAddTorrentPaused();
-
         // Start torrent because it was added in paused state
-        if (!addPaused)
+        if (!data.addPaused)
             torrent->resume();
         logger->addMessage(tr("'%1' added to download list.", "'torrent name' was added to download list.")
                            .arg(torrent->name()));
@@ -3664,8 +3660,8 @@ namespace
         torrentData.hasRootFolder = fast.dict_find_int_value("qBt-hasRootFolder");
 
         magnetUri = MagnetUri(QString::fromStdString(fast.dict_find_string_value("qBt-magnetUri")));
-        torrentData.addPaused = TriStateBool(fast.dict_find_int_value("qBt-paused"));
-        torrentData.addForced = TriStateBool(fast.dict_find_int_value("qBt-forced"));
+        torrentData.addPaused = fast.dict_find_int_value("qBt-paused");
+        torrentData.addForced = fast.dict_find_int_value("qBt-forced");
 
         prio = fast.dict_find_int_value("qBt-queuePosition");
 

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -147,7 +147,7 @@ namespace BitTorrent
         QVector<int> filePriorities; // used if TorrentInfo is set
         bool ignoreShareRatio = false;
         bool skipChecking = false;
-        bool createSubfolder = true;
+        TriStateBool createSubfolder;
     };
 
     struct TorrentStatusReport

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -92,7 +92,9 @@ AddTorrentData::AddTorrentData(const AddTorrentParams &params)
     , sequential(params.sequential)
     , hasSeedStatus(params.skipChecking) // do not react on 'torrent_finished_alert' when skipping
     , skipChecking(params.skipChecking)
-    , hasRootFolder(params.createSubfolder)
+    , hasRootFolder(params.createSubfolder == TriStateBool::Undefined
+                    ? Session::instance()->isCreateTorrentSubfolder()
+                    : params.createSubfolder == TriStateBool::True)
     , addForced(params.addForced == TriStateBool::True)
     , addPaused(params.addPaused == TriStateBool::Undefined
                 ? Session::instance()->isAddTorrentPaused()

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -76,6 +76,9 @@ AddTorrentData::AddTorrentData()
     , sequential(false)
     , hasSeedStatus(false)
     , skipChecking(false)
+    , hasRootFolder(true)
+    , addForced(false)
+    , addPaused(false)
     , ratioLimit(TorrentHandle::USE_GLOBAL_RATIO)
 {
 }
@@ -90,8 +93,10 @@ AddTorrentData::AddTorrentData(const AddTorrentParams &params)
     , hasSeedStatus(params.skipChecking) // do not react on 'torrent_finished_alert' when skipping
     , skipChecking(params.skipChecking)
     , hasRootFolder(params.createSubfolder)
-    , addForced(params.addForced)
-    , addPaused(params.addPaused)
+    , addForced(params.addForced == TriStateBool::True)
+    , addPaused(params.addPaused == TriStateBool::Undefined
+                ? Session::instance()->isAddTorrentPaused()
+                : params.addPaused == TriStateBool::True)
     , filePriorities(params.filePriorities)
     , ratioLimit(params.ignoreShareRatio ? TorrentHandle::NO_RATIO_LIMIT : TorrentHandle::USE_GLOBAL_RATIO)
 {

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -99,8 +99,8 @@ namespace BitTorrent
         bool hasSeedStatus;
         bool skipChecking;
         bool hasRootFolder;
-        TriStateBool addForced;
-        TriStateBool addPaused;
+        bool addForced;
+        bool addPaused;
         // for new torrents
         QVector<int> filePriorities;
         // for resumed torrents

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -642,7 +642,7 @@ void AddNewTorrentDialog::accept()
         params.filePriorities = m_contentModel->model()->getFilePriorities();
 
     params.addPaused = TriStateBool(!ui->startTorrentCheckBox->isChecked());
-    params.createSubfolder = ui->createSubfolderCheckBox->isChecked();
+    params.createSubfolder = TriStateBool(ui->createSubfolderCheckBox->isChecked());
 
     QString savePath = ui->savePathComboBox->itemData(ui->savePathComboBox->currentIndex()).toString();
     if (ui->comboTTM->currentIndex() != 1) { // 0 is Manual mode and 1 is Automatic mode. Handle all non 1 values as manual mode.


### PR DESCRIPTION
This allows qBittorrent to use the default settings for this option if the user does not specify it explicitly.
Also fixes AddTorrentData since it shouldn't use TriStateBool params.