### PR TITLE
TravisCI: only allow coverity build job when `build_system=qmake`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ addons:
       - qt55tools
 before_install:
   # only allow specific build for coverity scan, others will stop
-  - if [ "$TRAVIS_BRANCH" = "$coverity_branch" ] && ! [ "$TRAVIS_OS_NAME" = "linux" -a "$lt_branch" = "RC_1_0" -a "$gui" = true ]; then exit ; fi
+  - if [ "$TRAVIS_BRANCH" = "$coverity_branch" ] && ! [ "$TRAVIS_OS_NAME" = "linux" -a "$lt_branch" = "RC_1_0" -a "$gui" = true -a "$build_system" = "qmake" ]; then exit ; fi
 
   - shopt -s expand_aliases
   - alias make="colormake -j3" # Using nprocs/2 sometimes may fail (gcc is killed by system)


### PR DESCRIPTION
The coverity build job actually builds when `build_system=cmake`, this PR allows only `build_system=qmake` to build.

https://travis-ci.org/qbittorrent/qBittorrent/builds/225280424