### PR TITLE
Fix for macOS-specific bug in AddNewTorrentDialog

### DIFF
--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -553,6 +553,10 @@ void AddNewTorrentDialog::renameSelectedFile()
 
 void AddNewTorrentDialog::setdialogPosition()
 {
+    // In macOS, AddNewTorrentDialog is a sheet, not a window. Moving it
+    // causes very bad things to happen, especially if AddNewTorrentDialog is
+    // on a secondary monitor.
+#ifndef Q_OS_MAC
     qApp->processEvents();
     QPoint center(Utils::Misc::screenCenter(this));
     // Adjust y
@@ -566,6 +570,7 @@ void AddNewTorrentDialog::setdialogPosition()
             center.setY(0);
     }
     move(center);
+#endif
 }
 
 void AddNewTorrentDialog::populateSavePathComboBox()


### PR DESCRIPTION
Found a macOS specific bug in `AddNewTorrentDialog` while working on my other PR. The gist of it is that since `AddNewTorrentDialog` is a sheet in macOS, it should not be repositioned. This is especially true if the main qBittorrent window is on a secondary monitor, because it causes the sheet to leap off screen in a manner that makes it invisible and totally inaccessible.