### PR TITLE
Keep a list of individual trackers for each (host,hash) pair. Closes #4267.

### DIFF
--- a/src/gui/transferlistfilterswidget.h
+++ b/src/gui/transferlistfilterswidget.h
@@ -127,7 +127,7 @@ private:
     void downloadFavicon(const QString &url);
 
 private:
-    QHash<QString, QStringList> m_trackers;
+    QHash<QString, QHash<QString, QStringList>> m_trackers;
     QHash<QString, QStringList> m_errors;
     QHash<QString, QStringList> m_warnings;
     QStringList m_iconPaths;


### PR DESCRIPTION
If the tracker list for a torrent includes several entries pointing to
the same host, removing a single entry should not immediately cause the
(host,torrent) item to disappear from the tracker filters list.

By keeping a list of all actual tracker URLs for each (host,hash) pair,
we can determine whether or not a removed entry was the last one
remaining.

### Additional notes for this pull request

- I have used `operator[]` instead of `value()` in new code to alleviate things a little bit.  I've seen this done in other files, but it wasn't present in this particular one before.  Let me know if this was a bad choice.

- It could be argued that simply keeping count of trackers would do the job more efficiently than maintaining a whole list.  I opted for what seemed to be the safest choice, given how a single number could more easily derail at the slightest hiccup.  I defer to your judgement on the performance impact of this.

- Is it possible for a torrent's tracker list to contain duplicate entries?  Could `TrackerFiltersList::addItem()` ever be called twice with the same (tracker,hash) arguments?  If so, this patch expects `TrackerFiltersList::removeItem()` to be called twice as well.  If this is wrong, I'll need to replace `removeOne()` with `removeAll()`.

I've tested this and it appears to work fine for me.  However, given my lack of familiarity with the qBittorrent codebase, I rely on you to let me know if I've screwed up something.  :smile: