### PR TITLE
cmake: set warning and error compiler options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,6 @@ add_definitions(-DQBT_VERSION="v${PROJECT_VERSION}")
 add_definitions(-DQBT_VERSION_2="${PROJECT_VERSION}")
 # }
 
-# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Og")
 if (UNIX AND NOT APPLE)
     include(GNUInstallDirs)
 endif (UNIX AND NOT APPLE)

--- a/cmake/Modules/MacroGlibcDetect.cmake
+++ b/cmake/Modules/MacroGlibcDetect.cmake
@@ -1,0 +1,49 @@
+ ###############################################################
+ #
+ # Copyright 2011 Red Hat, Inc.
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License"); you
+ # may not use this file except in compliance with the License.  You may
+ # obtain a copy of the License at
+ #
+ #    http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ #
+ ###############################################################
+
+MACRO (GLIBC_DETECT _VERSION)
+
+# there are multiple ways to detect glibc, but given nmi's
+# cons'd up paths I will trust only gcc.  I guess I could also use
+# ldd --version to detect.
+
+    set(_GLIB_SOURCE_DETECT "
+#include <limits.h>
+#include <stdio.h>
+int main()
+{
+  printf(\"%d%d\",__GLIBC__, __GLIBC_MINOR__);
+  return 0;
+}
+")
+
+file (WRITE ${CMAKE_CURRENT_BINARY_DIR}/build/cmake/glibc.cpp "${_GLIB_SOURCE_DETECT}\n")
+
+try_run(POST26_GLIBC_DETECTED
+        POST26_GLIBC_COMPILE
+        ${CMAKE_CURRENT_BINARY_DIR}/build/cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/build/cmake/glibc.cpp
+        RUN_OUTPUT_VARIABLE GLIBC_VERSION )
+
+if (GLIBC_VERSION AND POST26_GLIBC_COMPILE )
+    set(${_VERSION} ${GLIBC_VERSION})
+else()
+    message(STATUS "NOTE: Could not detect GLIBC_VERSION from compiler")
+endif()
+
+ENDMACRO (GLIBC_DETECT)

--- a/cmake/Modules/MacroQbtCompilerSettings.cmake
+++ b/cmake/Modules/MacroQbtCompilerSettings.cmake
@@ -1,0 +1,89 @@
+# Sets cache variable QBT_ADDITONAL_FLAGS and QBT_ADDITONAL_CXX_FLAGS to list of additional
+# compiler flags for C and C++ (QBT_ADDITONAL_FLAGS) and for C++ only (QBT_ADDITONAL_CXX_FLAGS)
+# and appends them to CMAKE_XXX_FLAGS variables.
+
+# It could use add_compile_options(), but then it is needed to use generator expressions,
+# and most interesting of them are not compatible with Visual Studio :(
+
+macro(qbt_set_compiler_options)
+# if (NOT QBT_ADDITONAL_FLAGS)
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+        #-Wshadow -Wconversion ?
+        set(_GCC_COMMON_C_AND_CXX_FLAGS "-Wall -Wextra"
+            "-Wfloat-equal -Wcast-qual -Wcast-align"
+            "-Wsign-conversion -Winvalid-pch -Werror=return-type -Wno-long-long"
+#			-fstack-protector-all
+            "-Werror -Wno-error=deprecated-declarations"
+        )
+        set (_GCC_COMMON_CXX_FLAGS  "-fexceptions -frtti"
+            "-Woverloaded-virtual -Wold-style-cast -Wstrict-null-sentinel"
+            "-Wnon-virtual-dtor -Wfloat-equal -Wcast-qual -Wcast-align"
+            "-Werror=overloaded-virtual"
+    # 		"-Weffc++"
+            "-Werror -Wno-error=cpp"
+            # we should modify code to make these ones obsolete
+            "-Wno-error=old-style-cast -Wno-error=sign-conversion -Wno-error=float-equal"
+        )
+
+        if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
+            # GCC 4.8 has problems with std::array and its initialization
+            list(APPEND _GCC_COMMON_CXX_FLAGS "-Wno-error=missing-field-initializers")
+        endif()
+
+        include(CheckCXXCompilerFlag)
+        # check for -pedantic
+        check_cxx_compiler_flag(-pedantic _PEDANTIC_IS_SUPPORTED)
+        if (_PEDANTIC_IS_SUPPORTED)
+            list(APPEND _GCC_COMMON_CXX_FLAGS "-pedantic -pedantic-errors")
+        else (_PEDANTIC_IS_SUPPORTED)
+            list(APPEND _GCC_COMMON_CXX_FLAGS "-Wpedantic")
+        endif (_PEDANTIC_IS_SUPPORTED)
+
+        if (CMAKE_SYSTEM_NAME MATCHES Linux)
+            # if Glibc version is 2.20 or higher, set -D_DEFAULT_SOURCE
+            include(MacroGlibcDetect)
+            message(STATUS "Detecting Glibc version...")
+            glibc_detect(GLIBC_VERSION)
+            if(${GLIBC_VERSION})
+                if(GLIBC_VERSION LESS "220")
+                    message(STATUS "Glibc version is ${GLIBC_VERSION}")
+                else(GLIBC_VERSION LESS "220")
+                    message(STATUS "Glibc version is ${GLIBC_VERSION}, adding -D_DEFAULT_SOURCE")
+                    add_definitions(-D_DEFAULT_SOURCE)
+                endif(GLIBC_VERSION LESS "220")
+            endif(${GLIBC_VERSION})
+        endif (CMAKE_SYSTEM_NAME MATCHES Linux)
+
+        string(REPLACE ";" " " _GCC_COMMON_C_AND_CXX_FLAGS_STRING "${_GCC_COMMON_C_AND_CXX_FLAGS}")
+        string(REPLACE ";" " " _GCC_COMMON_CXX_FLAGS_STRING "${_GCC_COMMON_CXX_FLAGS}")
+
+        string(APPEND CMAKE_C_FLAGS " ${_GCC_COMMON_C_AND_CXX_FLAGS_STRING}")
+        string(APPEND CMAKE_CXX_FLAGS " ${_GCC_COMMON_C_AND_CXX_FLAGS_STRING} ${_GCC_COMMON_CXX_FLAGS_STRING}")
+
+        set(QBT_ADDITONAL_FLAGS "${_GCC_COMMON_C_AND_CXX_FLAGS_STRING}" CACHE STRING
+            "Additional qBittorent compile flags" FORCE)
+        set(QBT_ADDITONAL_CXX_FLAGS "${_GCC_COMMON_CXX_FLAGS_STRING}" CACHE STRING
+            "Additional qBittorent C++ compile flags" FORCE)
+
+        # check whether we can enable -Og optimization for debug build
+        # also let's enable -march=native for debug builds
+        check_cxx_compiler_flag(-Og _DEBUG_OPTIMIZATION_LEVEL_IS_SUPPORTED)
+
+        if (_DEBUG_OPTIMIZATION_LEVEL_IS_SUPPORTED)
+            string(APPEND CMAKE_C_FLAGS_DEBUG " -Og -g3 -march=native -pipe" )
+            string(APPEND CMAKE_CXX_FLAGS_DEBUG " -Og -g3 -march=native -pipe" )
+        else(_DEBUG_OPTIMIZATION_LEVEL_IS_SUPPORTED)
+            string(APPEND CMAKE_C_FLAGS_DEBUG " -O0 -g3 -march=native -pipe" )
+            string(APPEND CMAKE_CXX_FLAGS_DEBUG " -O0 -g3 -march=native -pipe" )
+        endif (_DEBUG_OPTIMIZATION_LEVEL_IS_SUPPORTED)
+    endif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+        set(QBT_ADDITONAL_FLAGS "-wd4290 -wd4275 -wd4251 /W4" CACHE STRING "Additional qBittorent compile flags")
+        string(APPEND CMAKE_C_FLAGS " ${QBT_ADDITONAL_FLAGS}")
+        string(APPEND CMAKE_CXX_FLAGS " ${QBT_ADDITONAL_FLAGS}")
+    endif ()
+
+# endif (NOT QBT_ADDITONAL_FLAGS)
+endmacro(qbt_set_compiler_options)
+

--- a/cmake/Modules/winconf.cmake
+++ b/cmake/Modules/winconf.cmake
@@ -1,5 +1,7 @@
 # Settings for compiling qBittorrent on Windows
 
+list(APPEND CMAKE_LIBRARY_PATH "$ENV{LIB}")
+
 # We want to link with static version of
 # libtorrent
 set(LibtorrentRasterbar_USE_STATIC_LIBS True)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_STANDARD "11")
 add_definitions(-DBOOST_NO_CXX11_RVALUE_REFERENCES)
 
+include(MacroQbtCompilerSettings)
+qbt_set_compiler_options()
+
 include(MacroLinkQtComponents)
 include(QbtTargetSources)
 

--- a/src/app/stacktrace.h
+++ b/src/app/stacktrace.h
@@ -9,16 +9,18 @@
 #include <execinfo.h>
 #include <cxxabi.h>
 
+#include <vector>
+
 /** Print a demangled stack backtrace of the caller function to FILE* out. */
 static inline void print_stacktrace(FILE *out = stderr, unsigned int max_frames = 63)
 {
     fprintf(out, "stack trace:\n");
 
     // storage array for stack trace address data
-    void *addrlist[max_frames + 1];
+    std::vector<void *> addrlist(max_frames + 1);
 
     // retrieve current stack addresses
-    int addrlen = backtrace(addrlist, sizeof(addrlist) / sizeof(void *));
+    int addrlen = backtrace(addrlist.data(), addrlist.size());
 
     if (addrlen == 0) {
         fprintf(out, "  <empty, possibly corrupt>\n");
@@ -27,7 +29,7 @@ static inline void print_stacktrace(FILE *out = stderr, unsigned int max_frames 
 
     // resolve addresses into strings containing "filename(function+address)",
     // this array must be free()-ed
-    char * *symbollist = backtrace_symbols(addrlist, addrlen);
+    char * *symbollist = backtrace_symbols(addrlist.data(), addrlen);
 
     // allocate string which will be filled with the demangled function name
     size_t funcnamesize = 256;

--- a/src/base/net/private/geoipdatabase.h
+++ b/src/base/net/private/geoipdatabase.h
@@ -96,7 +96,7 @@ private:
     // Search data
     mutable QHash<quint32, QString> m_countries;
     quint32 m_size;
-    const uchar *m_data;
+    uchar *m_data;
 };
 
 #endif // GEOIPDATABASE_H

--- a/src/webui/abstractwebapplication.cpp
+++ b/src/webui/abstractwebapplication.cpp
@@ -121,7 +121,7 @@ Http::Response AbstractWebApplication::processRequest(const Http::Request &reque
         print(QObject::tr("Your IP address has been banned after too many failed authentication attempts."), Http::CONTENT_TYPE_TXT);
     }
     else {
-        processRequest();
+        doProcessRequest();
     }
 
     return response();

--- a/src/webui/abstractwebapplication.h
+++ b/src/webui/abstractwebapplication.h
@@ -54,10 +54,10 @@ public:
     explicit AbstractWebApplication(QObject *parent = 0);
     virtual ~AbstractWebApplication();
 
-    Http::Response processRequest(const Http::Request &request, const Http::Environment &env);
+    Http::Response processRequest(const Http::Request &request, const Http::Environment &env) final;
 
 protected:
-    virtual void processRequest() = 0;
+    virtual void doProcessRequest() = 0;
 
     bool isBanned() const;
     int failedAttempts() const;

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -814,7 +814,7 @@ bool WebApplication::isPublicScope()
     return (scope_ == DEFAULT_SCOPE || scope_ == VERSION_INFO);
 }
 
-void WebApplication::processRequest()
+void WebApplication::doProcessRequest()
 {
     scope_ = DEFAULT_SCOPE;
     action_ = DEFAULT_ACTION;

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -103,7 +103,7 @@ private:
     QString action_;
     QStringList args_;
 
-    void processRequest();
+    void doProcessRequest() override;
 
     bool isPublicScope();
     void parsePath();


### PR DESCRIPTION
The set is far from perfect, but guards against common errors with GCC.