### PR TITLE
Move AddTorrentParams to its own header

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -1,6 +1,7 @@
 find_package(ZLIB REQUIRED)
 
 set(QBT_BASE_HEADERS
+bittorrent/addtorrentparams.h
 bittorrent/cachestatus.h
 bittorrent/infohash.h
 bittorrent/magneturi.h

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -25,6 +25,7 @@ HEADERS += \
     $$PWD/net/reverseresolution.h \
     $$PWD/net/smtp.h \
     $$PWD/net/private/geoipdatabase.h \
+    $$PWD/bittorrent/addtorrentparams.h  \
     $$PWD/bittorrent/infohash.h \
     $$PWD/bittorrent/session.h \
     $$PWD/bittorrent/sessionstatus.h \

--- a/src/base/bittorrent/addtorrentparams.h
+++ b/src/base/bittorrent/addtorrentparams.h
@@ -1,0 +1,52 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2015  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+#include <QString>
+#include <QVector>
+
+#include "../tristatebool.h"
+
+namespace BitTorrent
+{
+    struct AddTorrentParams
+    {
+        QString name;
+        QString category;
+        QString savePath;
+        bool disableTempPath = false; // e.g. for imported torrents
+        bool sequential = false;
+        TriStateBool addForced;
+        TriStateBool addPaused;
+        QVector<int> filePriorities; // used if TorrentInfo is set
+        bool ignoreShareRatio = false;
+        bool skipChecking = false;
+        TriStateBool createSubfolder;
+    };
+}

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -49,6 +49,7 @@
 #include "base/settingvalue.h"
 #include "base/tristatebool.h"
 #include "base/types.h"
+#include "addtorrentparams.h"
 #include "torrentinfo.h"
 
 namespace libtorrent
@@ -134,21 +135,6 @@ namespace BitTorrent
     class MagnetUri;
     class TrackerEntry;
     struct AddTorrentData;
-
-    struct AddTorrentParams
-    {
-        QString name;
-        QString category;
-        QString savePath;
-        bool disableTempPath = false; // e.g. for imported torrents
-        bool sequential = false;
-        TriStateBool addForced;
-        TriStateBool addPaused;
-        QVector<int> filePriorities; // used if TorrentInfo is set
-        bool ignoreShareRatio = false;
-        bool skipChecking = false;
-        TriStateBool createSubfolder;
-    };
 
     struct TorrentStatusReport
     {


### PR DESCRIPTION
Prevent inclusion of big "session.h" into other header when we want to create some class field of type AddTorrentParams.