### PR TITLE
Fix double click on system tray icon causing program to open and minimize immediately

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -949,17 +949,17 @@ void MainWindow::notifyOfUpdate(QString)
 }
 
 // Toggle Main window visibility
-void MainWindow::toggleVisibility(QSystemTrayIcon::ActivationReason e)
+void MainWindow::toggleVisibility(const QSystemTrayIcon::ActivationReason reason)
 {
-    if ((e == QSystemTrayIcon::Trigger) || (e == QSystemTrayIcon::DoubleClick)) {
+    switch (reason) {
+    case QSystemTrayIcon::Trigger: {
         if (isHidden()) {
-            if (m_uiLocked) {
-                // Ask for UI lock password
-                if (!unlockUI())
-                    return;
-            }
+            if (m_uiLocked && !unlockUI())  // Ask for UI lock password
+                return;
+
             // Make sure the window is not minimized
             setWindowState((windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
+
             // Then show it
             show();
             raise();
@@ -968,6 +968,12 @@ void MainWindow::toggleVisibility(QSystemTrayIcon::ActivationReason e)
         else {
             hide();
         }
+
+        break;
+    }
+
+    default:
+        break;
     }
 }
 

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -103,7 +103,7 @@ public:
     void showNotificationBaloon(QString title, QString msg) const;
 
 private slots:
-    void toggleVisibility(QSystemTrayIcon::ActivationReason e = QSystemTrayIcon::Trigger);
+    void toggleVisibility(const QSystemTrayIcon::ActivationReason reason = QSystemTrayIcon::Trigger);
 
     void balloonClicked();
     void writeSettings();


### PR DESCRIPTION
Simply ignore DoubleClick event, as it always come after Trigger event.