### PR TITLE
Fix signaling to checkForUpdatesFinished() failed

### DIFF
--- a/src/gui/search/pluginselectdlg.cpp
+++ b/src/gui/search/pluginselectdlg.cpp
@@ -44,7 +44,6 @@
 #include "base/utils/misc.h"
 #include "base/net/downloadmanager.h"
 #include "base/net/downloadhandler.h"
-#include "base/searchengine.h"
 #include "ico.h"
 #include "searchwidget.h"
 #include "pluginsourcedlg.h"
@@ -95,7 +94,7 @@ PluginSelectDlg::PluginSelectDlg(SearchEngine *pluginManager, QWidget *parent)
     connect(m_pluginManager, SIGNAL(pluginInstallationFailed(QString, QString)), SLOT(pluginInstallationFailed(QString, QString)));
     connect(m_pluginManager, SIGNAL(pluginUpdated(QString)), SLOT(pluginUpdated(QString)));
     connect(m_pluginManager, SIGNAL(pluginUpdateFailed(QString, QString)), SLOT(pluginUpdateFailed(QString, QString)));
-    connect(m_pluginManager, SIGNAL(checkForUpdatesFinished(QHash<QString, qreal>)), SLOT(checkForUpdatesFinished(QHash<QString, qreal>)));
+    connect(m_pluginManager, &SearchEngine::checkForUpdatesFinished, this, &PluginSelectDlg::checkForUpdatesFinished);
     connect(m_pluginManager, SIGNAL(checkForUpdatesFailed(QString)), SLOT(checkForUpdatesFailed(QString)));
 
     show();
@@ -388,7 +387,7 @@ void PluginSelectDlg::iconDownloadFailed(const QString &url, const QString &reas
     qDebug("Could not download favicon: %s, reason: %s", qPrintable(url), qPrintable(reason));
 }
 
-void PluginSelectDlg::checkForUpdatesFinished(const QHash<QString, qreal> &updateInfo)
+void PluginSelectDlg::checkForUpdatesFinished(const QHash<QString, PluginVersion> &updateInfo)
 {
     finishAsyncOp();
     if (updateInfo.isEmpty()) {

--- a/src/gui/search/pluginselectdlg.h
+++ b/src/gui/search/pluginselectdlg.h
@@ -34,10 +34,10 @@
 
 #include <QDialog>
 
+#include "base/searchengine.h"
+
 class QDropEvent;
 class QTreeWidgetItem;
-
-class SearchEngine;
 
 namespace Ui
 {
@@ -76,7 +76,7 @@ private slots:
     void iconDownloaded(const QString &url, QString filePath);
     void iconDownloadFailed(const QString &url, const QString &reason);
 
-    void checkForUpdatesFinished(const QHash<QString, qreal> &updateInfo);
+    void checkForUpdatesFinished(const QHash<QString, PluginVersion> &updateInfo);
     void checkForUpdatesFailed(const QString &reason);
     void pluginInstalled(const QString &name);
     void pluginInstallationFailed(const QString &name, const QString &reason);


### PR DESCRIPTION
Fixup of 14e168039cae8e7b241c206754fe6d6f8a7f919e.

Error msg in console when you click "Search Plugins ..." button:
```
QObject::connect: No such signal SearchEngine::checkForUpdatesFinished(QHash<QString, qreal>)
QObject::connect:  (receiver name: 'PluginSelectDlg')
```