### PR TITLE
.gitignore: ignore moc_*.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ Makefile*
 
 # Generated MOC, resource and UI files
 moc_*.cpp
+moc_*.h
 qrc_*.cpp
 ui_*.h
 *.moc


### PR DESCRIPTION
To exclude the offending file `_build_dir/src/moc_predefs.h`.