### PR TITLE
Fix crash when entering daemon mode. Closes #6759.

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -134,7 +134,7 @@ int main(int argc, char *argv[])
         migrateRSS();
 #endif
 
-        const QBtCommandLineParameters &params = app->commandLineArgs();
+        const QBtCommandLineParameters params = app->commandLineArgs();
 
         if (!params.unknownParameter.isEmpty()) {
             throw CommandLineParameterError(QObject::tr("%1 is an unknown command line parameter.",


### PR DESCRIPTION
We stored reference to parameters object in main(), but that object gets
deleted when we reset Application object upon entering daemon mode.
Change reference to copy to fix that.