### PR TITLE
Do not attempt to show detailed tooltips without torrent metadata. Cl…

### DIFF
--- a/src/gui/properties/piecesbar.cpp
+++ b/src/gui/properties/piecesbar.cpp
@@ -251,8 +251,8 @@ void PiecesBar::showToolTip(const QHelpEvent *e)
 
     QString toolTipText;
     QTextStream stream(&toolTipText, QIODevice::WriteOnly);
-    bool showDetailedInformation = QApplication::keyboardModifiers().testFlag(Qt::ShiftModifier);
-    if (showDetailedInformation) {
+    const bool showDetailedInformation = QApplication::keyboardModifiers().testFlag(Qt::ShiftModifier);
+    if (showDetailedInformation && m_torrent->hasMetadata()) {
         const int imagePos = e->pos().x() - borderWidth;
         if ((imagePos >=0) && (imagePos < m_image.width())) {
             stream << "<html><body>";
@@ -286,7 +286,10 @@ void PiecesBar::showToolTip(const QHelpEvent *e)
     }
     else {
         stream << simpleToolTipText();
-        stream << '\n' << tr("Hold Shift key for detailed information");
+        if (showDetailedInformation) // metadata are not available at this point
+            stream << '\n' << tr("Wait until metadata become available to see detailed information");
+        else
+            stream << '\n' << tr("Hold Shift key for detailed information");
     }
 
     stream.flush();
@@ -296,7 +299,7 @@ void PiecesBar::showToolTip(const QHelpEvent *e)
 
 void PiecesBar::highlightFile(int imagePos)
 {
-    if (!m_torrent || (imagePos < 0) || (imagePos >= m_image.width()))
+    if (!m_torrent || !m_torrent->hasMetadata() || (imagePos < 0) || (imagePos >= m_image.width()))
         return;
 
     PieceIndexToImagePos transform {m_torrent->info(), m_image};


### PR DESCRIPTION
…oses #6768.

Computations for detailed tooltips are not protected against unavailable
metadata, that leads to asserts or crashes. But since those tooltips are
useless in this case, do not show them at all. Inform user that detailed
tooltip becomes available once torrent metadata are fetched.