### PR TITLE
Use less permissive CSP header

### DIFF
--- a/src/webui/abstractwebapplication.cpp
+++ b/src/webui/abstractwebapplication.cpp
@@ -110,7 +110,7 @@ Http::Response AbstractWebApplication::processRequest(const Http::Request &reque
     header(Http::HEADER_X_FRAME_OPTIONS, "SAMEORIGIN");
     header(Http::HEADER_X_XSS_PROTECTION, "1; mode=block");
     header(Http::HEADER_X_CONTENT_TYPE_OPTIONS, "nosniff");
-    header(Http::HEADER_CONTENT_SECURITY_POLICY, "default-src 'self' 'unsafe-inline' 'unsafe-eval';");
+    header(Http::HEADER_CONTENT_SECURITY_POLICY, "default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self'; child-src 'self'; object-src 'none';");
 
     sessionInitialize();
     if (!sessionActive() && !isAuthNeeded())


### PR DESCRIPTION
This updated header blocks all sources but those explicitly needed for qBittorrent to load its assets.