### PR TITLE
Add option for sending security headers

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -463,6 +463,16 @@ void Preferences::setUPnPForWebUIPort(bool enabled)
     setValue("Preferences/WebUI/UseUPnP", enabled);
 }
 
+bool Preferences::isWebUiSecurityHeadersEnabled() const
+{
+    return value("Preferences/WebUI/SecurityHeaders", true).toBool();
+}
+
+void Preferences::setWebUiSecurityHeadersEnabled(bool enabled)
+{
+    setValue("Preferences/WebUI/SecurityHeaders", enabled);
+}
+
 QString Preferences::getWebUiUsername() const
 {
     return value("Preferences/WebUI/Username", "admin").toString();

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -180,6 +180,8 @@ public:
     void setWebUiPort(quint16 port);
     bool useUPnPForWebUIPort() const;
     void setUPnPForWebUIPort(bool enabled);
+    bool isWebUiSecurityHeadersEnabled() const;
+    void setWebUiSecurityHeadersEnabled(bool enabled);
     QString getWebUiUsername() const;
     void setWebUiUsername(const QString &username);
     QString getWebUiPassword() const;

--- a/src/gui/optionsdlg.cpp
+++ b/src/gui/optionsdlg.cpp
@@ -327,6 +327,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     connect(m_ui->checkWebUi, SIGNAL(toggled(bool)), this, SLOT(enableApplyButton()));
     connect(m_ui->spinWebUiPort, SIGNAL(valueChanged(int)), this, SLOT(enableApplyButton()));
     connect(m_ui->checkWebUIUPnP, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
+    connect(m_ui->checkWebUISecurityHeaders, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
     connect(m_ui->checkWebUiHttps, SIGNAL(toggled(bool)), SLOT(enableApplyButton()));
     connect(m_ui->btnWebUiKey, SIGNAL(clicked()), SLOT(enableApplyButton()));
     connect(m_ui->btnWebUiCrt, SIGNAL(clicked()), SLOT(enableApplyButton()));
@@ -602,6 +603,7 @@ void OptionsDialog::saveOptions()
     if (isWebUiEnabled()) {
         pref->setWebUiPort(webUiPort());
         pref->setUPnPForWebUIPort(m_ui->checkWebUIUPnP->isChecked());
+        pref->setWebUiSecurityHeadersEnabled(m_ui->checkWebUISecurityHeaders->isChecked());
         pref->setWebUiHttpsEnabled(m_ui->checkWebUiHttps->isChecked());
         if (m_ui->checkWebUiHttps->isChecked()) {
             pref->setWebUiHttpsCertificate(m_sslCert);
@@ -984,6 +986,7 @@ void OptionsDialog::loadOptions()
     m_ui->checkWebUi->setChecked(pref->isWebUiEnabled());
     m_ui->spinWebUiPort->setValue(pref->getWebUiPort());
     m_ui->checkWebUIUPnP->setChecked(pref->useUPnPForWebUIPort());
+    m_ui->checkWebUISecurityHeaders->setChecked(pref->isWebUiSecurityHeadersEnabled());
     m_ui->checkWebUiHttps->setChecked(pref->isWebUiHttpsEnabled());
     setSslCertificate(pref->getWebUiHttpsCertificate());
     setSslKey(pref->getWebUiHttpsKey());

--- a/src/gui/optionsdlg.ui
+++ b/src/gui/optionsdlg.ui
@@ -2811,6 +2811,16 @@
                 </widget>
                </item>
                <item>
+                <widget class="QCheckBox" name="checkWebUISecurityHeaders">
+                 <property name="text">
+                  <string>Send security headers on all requests</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <widget class="QGroupBox" name="checkWebUiHttps">
                  <property name="title">
                   <string>Use HTTPS instead of HTTP</string>

--- a/src/webui/abstractwebapplication.cpp
+++ b/src/webui/abstractwebapplication.cpp
@@ -106,11 +106,13 @@ Http::Response AbstractWebApplication::processRequest(const Http::Request &reque
     // clear response
     clear();
 
-    // avoid clickjacking attacks
-    header(Http::HEADER_X_FRAME_OPTIONS, "SAMEORIGIN");
-    header(Http::HEADER_X_XSS_PROTECTION, "1; mode=block");
-    header(Http::HEADER_X_CONTENT_TYPE_OPTIONS, "nosniff");
-    header(Http::HEADER_CONTENT_SECURITY_POLICY, "default-src 'self' 'unsafe-inline' 'unsafe-eval';");
+    if (Preferences::instance()->isWebUiSecurityHeadersEnabled()) {
+        // avoid clickjacking attacks
+        header(Http::HEADER_X_FRAME_OPTIONS, "SAMEORIGIN");
+        header(Http::HEADER_X_XSS_PROTECTION, "1; mode=block");
+        header(Http::HEADER_X_CONTENT_TYPE_OPTIONS, "nosniff");
+        header(Http::HEADER_CONTENT_SECURITY_POLICY, "default-src 'self' 'unsafe-inline' 'unsafe-eval';");
+    }
 
     sessionInitialize();
     if (!sessionActive() && !isAuthNeeded())

--- a/src/webui/prefjson.cpp
+++ b/src/webui/prefjson.cpp
@@ -162,6 +162,7 @@ QByteArray prefjson::getPreferences()
     // HTTP Server
     data["web_ui_port"] = pref->getWebUiPort();
     data["web_ui_upnp"] = pref->useUPnPForWebUIPort();
+    data["use_security_headers"] = pref->isWebUiSecurityHeadersEnabled();
     data["use_https"] = pref->isWebUiHttpsEnabled();
     data["ssl_key"] = QString::fromLatin1(pref->getWebUiHttpsKey());
     data["ssl_cert"] = QString::fromLatin1(pref->getWebUiHttpsCertificate());
@@ -394,6 +395,8 @@ void prefjson::setPreferences(const QString& json)
         pref->setWebUiPort(m["web_ui_port"].toUInt());
     if (m.contains("web_ui_upnp"))
         pref->setUPnPForWebUIPort(m["web_ui_upnp"].toBool());
+    if (m.contains("use_security_headers"))
+        pref->setWebUiSecurityHeadersEnabled(m["use_security_headers"].toBool());
     if (m.contains("use_https"))
         pref->setWebUiHttpsEnabled(m["use_https"].toBool());
 #ifndef QT_NO_OPENSSL

--- a/src/webui/www/public/preferences_content.html
+++ b/src/webui/www/public/preferences_content.html
@@ -387,6 +387,8 @@
   <label for="webui_port_value">QBT_TR(Port:)QBT_TR[CONTEXT=OptionsDialog]</label><input type="text" id="webui_port_value" style="width: 4em;"/><br/>
   <input type="checkbox" id="webui_upnp_checkbox"/>
   <label for="webui_upnp_checkbox">QBT_TR(Use UPnP / NAT-PMP to forward the port from my router)QBT_TR[CONTEXT=OptionsDialog]</label><br/>
+  <input type="checkbox" id="webui_security_headers_checkbox"/>
+  <label for="webui_security_headers_checkbox">QBT_TR(Send security headers on all requests)QBT_TR</label><br/>
   <fieldset class="settings">
   <legend><input type="checkbox" id="use_https_checkbox" onclick="updateHttpsSettings();" />
   <label for="use_https_checkbox">QBT_TR(Use HTTPS instead of HTTP)QBT_TR[CONTEXT=OptionsDialog]</label></legend>
@@ -1014,6 +1016,7 @@ loadPreferences = function() {
                     // HTTP Server
                     $('webui_port_value').setProperty('value', pref.web_ui_port);
                     $('webui_upnp_checkbox').setProperty('checked', pref.web_ui_upnp);
+                    $('webui_security_headers_checkbox').setProperty('checked', pref.use_security_headers);
                     $('use_https_checkbox').setProperty('checked', pref.use_https);
                     $('ssl_key_textarea').setProperty('value', pref.ssl_key);
                     $('ssl_cert_textarea').setProperty('value', pref.ssl_cert);
@@ -1274,6 +1277,7 @@ applyPreferences = function() {
   }
   settings.set('web_ui_port', web_ui_port);
   settings.set('web_ui_upnp', $('webui_upnp_checkbox').getProperty('checked'));
+  settings.set('use_security_headers', $('webui_security_headers_checkbox').getProperty('checked'));
   settings.set('use_https', $('use_https_checkbox').getProperty('checked'));
   settings.set('ssl_key', $('ssl_key_textarea').getProperty('value'));
   settings.set('ssl_cert', $('ssl_cert_textarea').getProperty('value'));


### PR DESCRIPTION
Allowing the security headers to be disabled is useful when qBittorrent is behind a reverse proxy.

A wiki page denoting the specific headers could be useful. For future reference: X-Frame-Options, X-XSS-Protection, X-Content-Type-Options, Content-Security-Policy.