### PR TITLE
Add ip subnet whitelist for bypassing webui auth

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -30,6 +30,8 @@
  * Contact : hammered999@gmail.com
  */
 
+#include "preferences.h"
+
 #include <QCryptographicHash>
 #include <QDir>
 #include <QLocale>
@@ -51,11 +53,10 @@
 #include <CoreServices/CoreServices.h>
 #endif
 
+#include "logger.h"
+#include "settingsstorage.h"
 #include "utils/fs.h"
 #include "utils/misc.h"
-#include "settingsstorage.h"
-#include "logger.h"
-#include "preferences.h"
 
 Preferences *Preferences::m_instance = 0;
 
@@ -461,6 +462,38 @@ bool Preferences::isWebUiLocalAuthEnabled() const
 void Preferences::setWebUiLocalAuthEnabled(bool enabled)
 {
     setValue("Preferences/WebUI/LocalHostAuth", enabled);
+}
+
+bool Preferences::isWebUiAuthSubnetWhitelistEnabled() const
+{
+    return value("Preferences/WebUI/AuthSubnetWhitelistEnabled", false).toBool();
+}
+
+void Preferences::setWebUiAuthSubnetWhitelistEnabled(bool enabled)
+{
+    setValue("Preferences/WebUI/AuthSubnetWhitelistEnabled", enabled);
+}
+
+QList<Utils::Net::Subnet> Preferences::getWebUiAuthSubnetWhitelist() const
+{
+    QList<Utils::Net::Subnet> subnets;
+    foreach (const QString &rawSubnet, value("Preferences/WebUI/AuthSubnetWhitelist").toStringList()) {
+        bool ok = false;
+        const Utils::Net::Subnet subnet = Utils::Net::parseSubnet(rawSubnet.trimmed(), &ok);
+        if (ok)
+            subnets.append(subnet);
+    }
+
+    return subnets;
+}
+
+void Preferences::setWebUiAuthSubnetWhitelist(const QList<Utils::Net::Subnet> &subnets)
+{
+    QStringList subnetsStringList;
+    for (const Utils::Net::Subnet &subnet : subnets)
+        subnetsStringList.append(Utils::Net::subnetToString(subnet));
+
+    setValue("Preferences/WebUI/AuthSubnetWhitelist", subnetsStringList);
 }
 
 QString Preferences::getServerDomains() const

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -33,15 +33,18 @@
 #ifndef PREFERENCES_H
 #define PREFERENCES_H
 
-#include <QTime>
 #include <QDateTime>
+#include <QHostAddress>
 #include <QList>
-#include <QSize>
-#include <QTimer>
-#include <QReadWriteLock>
 #include <QNetworkCookie>
+#include <QReadWriteLock>
+#include <QSize>
+#include <QStringList>
+#include <QTime>
+#include <QTimer>
 #include <QVariant>
 
+#include "base/utils/net.h"
 #include "types.h"
 
 enum scheduler_days
@@ -170,10 +173,9 @@ public:
     bool isSearchEnabled() const;
     void setSearchEnabled(bool enabled);
 
+    // HTTP Server
     bool isWebUiEnabled() const;
     void setWebUiEnabled(bool enabled);
-    bool isWebUiLocalAuthEnabled() const;
-    void setWebUiLocalAuthEnabled(bool enabled);
     QString getServerDomains() const;
     void setServerDomains(const QString &str);
     QString getWebUiAddress() const;
@@ -182,16 +184,28 @@ public:
     void setWebUiPort(quint16 port);
     bool useUPnPForWebUIPort() const;
     void setUPnPForWebUIPort(bool enabled);
+
+    // Authentication
+    bool isWebUiLocalAuthEnabled() const;
+    void setWebUiLocalAuthEnabled(bool enabled);
+    bool isWebUiAuthSubnetWhitelistEnabled() const;
+    void setWebUiAuthSubnetWhitelistEnabled(bool enabled);
+    QList<Utils::Net::Subnet> getWebUiAuthSubnetWhitelist() const;
+    void setWebUiAuthSubnetWhitelist(const QList<Utils::Net::Subnet> &subnets);
     QString getWebUiUsername() const;
     void setWebUiUsername(const QString &username);
     QString getWebUiPassword() const;
     void setWebUiPassword(const QString &new_password);
+
+    // HTTPS
     bool isWebUiHttpsEnabled() const;
     void setWebUiHttpsEnabled(bool enabled);
     QByteArray getWebUiHttpsCertificate() const;
     void setWebUiHttpsCertificate(const QByteArray &data);
     QByteArray getWebUiHttpsKey() const;
     void setWebUiHttpsKey(const QByteArray &data);
+
+    // Dynamic DNS
     bool isDynDNSEnabled() const;
     void setDynDNSEnabled(bool enabled);
     DNS::Service getDynDNSService() const;

--- a/src/base/utils/net.cpp
+++ b/src/base/utils/net.cpp
@@ -29,6 +29,7 @@
 #include "net.h"
 #include <QHostAddress>
 #include <QString>
+#include <QStringList>
 
 namespace Utils
 {
@@ -37,6 +38,56 @@ namespace Utils
         bool isValidIP(const QString &ip)
         {
             return !QHostAddress(ip).isNull();
+        }
+
+        Subnet parseSubnet(const QString &subnetStr, bool *ok)
+        {
+            const Subnet invalid = qMakePair(QHostAddress(), -1);
+            const Subnet subnet = QHostAddress::parseSubnet(subnetStr);
+            if (ok)
+                *ok = (subnet != invalid);
+            return subnet;
+        }
+
+        bool canParseSubnet(const QString &subnetStr)
+        {
+            bool ok = false;
+            parseSubnet(subnetStr, &ok);
+            return ok;
+        }
+
+        bool isLoopbackAddress(const QHostAddress &addr)
+        {
+            return (addr == QHostAddress::LocalHost)
+                    || (addr == QHostAddress::LocalHostIPv6)
+                    || (addr == QHostAddress(QLatin1String("::ffff:127.0.0.1")));
+        }
+
+        bool isIPInRange(const QHostAddress &addr, const QList<Subnet> &subnets)
+        {
+            QHostAddress protocolEquivalentAddress;
+            bool addrConversionOk = false;
+
+            if (addr.protocol() == QAbstractSocket::IPv4Protocol) {
+                // always succeeds
+                protocolEquivalentAddress = QHostAddress(addr.toIPv6Address());
+                addrConversionOk = true;
+            }
+            else {
+                // only succeeds when addr is an ipv4-mapped ipv6 address
+                protocolEquivalentAddress = QHostAddress(addr.toIPv4Address(&addrConversionOk));
+            }
+
+            for (const Subnet &subnet : subnets)
+                if (addr.isInSubnet(subnet) || (addrConversionOk && protocolEquivalentAddress.isInSubnet(subnet)))
+                    return true;
+
+            return false;
+        }
+
+        QString subnetToString(const Subnet &subnet)
+        {
+            return subnet.first.toString() + '/' + QString::number(subnet.second);
         }
     }
 }

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -45,6 +45,7 @@ fspathedit.h
 fspathedit_p.h
 guiiconprovider.h
 hidabletabwidget.h
+ipsubnetwhitelistoptionsdialog.h
 loglistwidget.h
 mainwindow.h
 messageboxraised.h
@@ -90,6 +91,7 @@ executionlog.cpp
 fspathedit.cpp
 fspathedit_p.cpp
 guiiconprovider.cpp
+ipsubnetwhitelistoptionsdialog.cpp
 loglistwidget.cpp
 mainwindow.cpp
 messageboxraised.cpp
@@ -135,6 +137,7 @@ mainwindow.ui
 about.ui
 banlistoptions.ui
 cookiesdialog.ui
+ipsubnetwhitelistoptionsdialog.ui
 previewselectdialog.ui
 login.ui
 downloadfromurldlg.ui

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -30,7 +30,6 @@ set(QBT_GUI_HEADERS
 about_imp.h
 addnewtorrentdialog.h
 advancedsettings.h
-advancedsettings.h
 autoexpandabledialog.h
 banlistoptions.h
 categoryfiltermodel.h

--- a/src/gui/banlistoptions.cpp
+++ b/src/gui/banlistoptions.cpp
@@ -70,8 +70,11 @@ void BanListOptions::on_buttonBox_accepted()
             IPList << index.data().toString();
         }
         BitTorrent::Session::instance()->setBannedIPs(IPList);
+        QDialog::accept();
     }
-    QDialog::accept();
+    else {
+        QDialog::reject();
+    }
 }
 
 void BanListOptions::on_buttonBanIP_clicked()

--- a/src/gui/gui.pri
+++ b/src/gui/gui.pri
@@ -55,6 +55,7 @@ HEADERS += \
     $$PWD/tagfilterproxymodel.h \
     $$PWD/tagfilterwidget.h \
     $$PWD/banlistoptions.h \
+    $$PWD/ipsubnetwhitelistoptionsdialog.h \
     $$PWD/rss/rsswidget.h \
     $$PWD/rss/articlelistwidget.h \
     $$PWD/rss/feedlistwidget.h \
@@ -109,6 +110,7 @@ SOURCES += \
     $$PWD/tagfilterproxymodel.cpp \
     $$PWD/tagfilterwidget.cpp \
     $$PWD/banlistoptions.cpp \
+    $$PWD/ipsubnetwhitelistoptionsdialog.cpp \
     $$PWD/rss/rsswidget.cpp \
     $$PWD/rss/articlelistwidget.cpp \
     $$PWD/rss/feedlistwidget.cpp \
@@ -150,6 +152,7 @@ FORMS += \
     $$PWD/search/searchtab.ui \
     $$PWD/cookiesdialog.ui \
     $$PWD/banlistoptions.ui \
+    $$PWD/ipsubnetwhitelistoptionsdialog.ui \
     $$PWD/rss/rsswidget.ui \
     $$PWD/rss/automatedrssdownloader.ui \
     $$PWD/torrentcategorydialog.ui

--- a/src/gui/ipsubnetwhitelistoptionsdialog.cpp
+++ b/src/gui/ipsubnetwhitelistoptionsdialog.cpp
@@ -1,0 +1,111 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2017  Thomas Piccirello <thomas@piccirello.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "ipsubnetwhitelistoptionsdialog.h"
+
+#include <QHostAddress>
+#include <QMessageBox>
+#include <QPair>
+#include <QSortFilterProxyModel>
+#include <QStringListModel>
+
+#include "base/preferences.h"
+#include "base/utils/net.h"
+#include "ui_ipsubnetwhitelistoptionsdialog.h"
+
+IPSubnetWhitelistOptionsDialog::IPSubnetWhitelistOptionsDialog(QWidget *parent)
+    : QDialog(parent)
+    , m_ui(new Ui::IPSubnetWhitelistOptionsDialog)
+    , m_modified(false)
+{
+    m_ui->setupUi(this);
+
+    QStringList authSubnetWhitelistStringList;
+    for (const Utils::Net::Subnet &subnet : Preferences::instance()->getWebUiAuthSubnetWhitelist())
+        authSubnetWhitelistStringList << Utils::Net::subnetToString(subnet);
+    m_model = new QStringListModel(authSubnetWhitelistStringList, this);
+
+    m_sortFilter = new QSortFilterProxyModel(this);
+    m_sortFilter->setDynamicSortFilter(true);
+    m_sortFilter->setSourceModel(m_model);
+
+    m_ui->whitelistedIPSubnetList->setModel(m_sortFilter);
+    m_ui->whitelistedIPSubnetList->sortByColumn(0, Qt::AscendingOrder);
+    m_ui->buttonWhitelistIPSubnet->setEnabled(false);
+}
+
+IPSubnetWhitelistOptionsDialog::~IPSubnetWhitelistOptionsDialog()
+{
+    delete m_ui;
+}
+
+void IPSubnetWhitelistOptionsDialog::on_buttonBox_accepted()
+{
+    if (m_modified) {
+        // save to session
+        QList<Utils::Net::Subnet> subnets;
+        // Operate on the m_sortFilter to grab the strings in sorted order
+        for (int i = 0; i < m_sortFilter->rowCount(); ++i) {
+            const QString subnet = m_sortFilter->index(i, 0).data().toString();
+            subnets.append(QHostAddress::parseSubnet(subnet));
+        }
+        Preferences::instance()->setWebUiAuthSubnetWhitelist(subnets);
+        QDialog::accept();
+    }
+    else {
+        QDialog::reject();
+    }
+}
+
+void IPSubnetWhitelistOptionsDialog::on_buttonWhitelistIPSubnet_clicked()
+{
+    bool ok = false;
+    const Utils::Net::Subnet subnet = Utils::Net::parseSubnet(m_ui->txtIPSubnet->text(), &ok);
+    if (!ok) {
+        QMessageBox::critical(this, tr("Error"), tr("The entered subnet is invalid."));
+        return;
+    }
+
+    m_model->insertRow(m_model->rowCount());
+    m_model->setData(m_model->index(m_model->rowCount() - 1, 0), Utils::Net::subnetToString(subnet));
+    m_ui->txtIPSubnet->clear();
+    m_modified = true;
+}
+
+void IPSubnetWhitelistOptionsDialog::on_buttonDeleteIPSubnet_clicked()
+{
+    for (const auto &i : m_ui->whitelistedIPSubnetList->selectionModel()->selectedIndexes())
+        m_sortFilter->removeRow(i.row());
+
+    m_modified = true;
+}
+
+void IPSubnetWhitelistOptionsDialog::on_txtIPSubnet_textChanged(const QString &subnetStr)
+{
+    m_ui->buttonWhitelistIPSubnet->setEnabled(Utils::Net::canParseSubnet(subnetStr));
+}

--- a/src/gui/ipsubnetwhitelistoptionsdialog.h
+++ b/src/gui/ipsubnetwhitelistoptionsdialog.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2016  Alexandr Milovantsev <dzmat@yandex.ru>
+ * Copyright (C) 2017  Thomas Piccirello <thomas@piccirello.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -26,29 +26,39 @@
  * exception statement from your version.
  */
 
-#ifndef BASE_UTILS_NET_H
-#define BASE_UTILS_NET_H
+#ifndef OPTIONS_IPSUBNETWHITELIST_H
+#define OPTIONS_IPSUBNETWHITELIST_H
 
-#include <QList>
-#include <QPair>
+#include <QDialog>
 
-class QHostAddress;
-class QString;
-class QStringList;
+class QSortFilterProxyModel;
+class QStringListModel;
 
-namespace Utils
+namespace Ui
 {
-    namespace Net
-    {
-        using Subnet = QPair<QHostAddress, int>;
-
-        bool isValidIP(const QString &ip);
-        Subnet parseSubnet(const QString &subnetStr, bool *ok = nullptr);
-        bool canParseSubnet(const QString &subnetStr);
-        bool isLoopbackAddress(const QHostAddress &addr);
-        bool isIPInRange(const QHostAddress &addr, const QList<Subnet> &subnets);
-        QString subnetToString(const Subnet &subnet);
-    }
+    class IPSubnetWhitelistOptionsDialog;
 }
 
-#endif // BASE_UTILS_NET_H
+class IPSubnetWhitelistOptionsDialog : public QDialog
+{
+    Q_OBJECT
+    Q_DISABLE_COPY(IPSubnetWhitelistOptionsDialog)
+
+public:
+    explicit IPSubnetWhitelistOptionsDialog(QWidget *parent = nullptr);
+    ~IPSubnetWhitelistOptionsDialog();
+
+private slots:
+    void on_buttonBox_accepted();
+    void on_buttonWhitelistIPSubnet_clicked();
+    void on_buttonDeleteIPSubnet_clicked();
+    void on_txtIPSubnet_textChanged(const QString &subnetStr);
+
+private:
+    Ui::IPSubnetWhitelistOptionsDialog *m_ui;
+    QStringListModel *m_model;
+    QSortFilterProxyModel *m_sortFilter;
+    bool m_modified;
+};
+
+#endif // OPTIONS_IPSUBNETWHITELIST_H

--- a/src/gui/ipsubnetwhitelistoptionsdialog.ui
+++ b/src/gui/ipsubnetwhitelistoptionsdialog.ui
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>IPSubnetWhitelistOptionsDialog</class>
+ <widget class="QDialog" name="IPSubnetWhitelistOptionsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>360</width>
+    <height>450</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>List of whitelisted IP subnets</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QFrame" name="whitelistedIPSubnetBox">
+     <property name="autoFillBackground">
+      <bool>true</bool>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Panel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_21">
+      <item>
+       <widget class="QTreeView" name="whitelistedIPSubnetList">
+        <property name="rootIsDecorated">
+         <bool>false</bool>
+        </property>
+        <property name="uniformRowHeights">
+         <bool>true</bool>
+        </property>
+        <property name="itemsExpandable">
+         <bool>false</bool>
+        </property>
+        <property name="sortingEnabled">
+         <bool>true</bool>
+        </property>
+        <attribute name="headerVisible">
+         <bool>false</bool>
+        </attribute>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_18">
+        <item>
+         <widget class="QLineEdit" name="txtIPSubnet">
+          <property name="placeholderText">
+            <string>Example: 172.17.32.0/24, fdff:ffff:c8::/40</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="buttonWhitelistIPSubnet">
+          <property name="text">
+           <string>Add subnet</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="buttonDeleteIPSubnet">
+          <property name="text">
+           <string>Delete</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>whitelistedIPSubnetList</tabstop>
+  <tabstop>txtIPSubnet</tabstop>
+  <tabstop>buttonWhitelistIPSubnet</tabstop>
+  <tabstop>buttonDeleteIPSubnet</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>IPSubnetWhitelistOptionsDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>179</x>
+     <y>427</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>179</x>
+     <y>224</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/gui/optionsdlg.cpp
+++ b/src/gui/optionsdlg.cpp
@@ -65,6 +65,7 @@
 #include "advancedsettings.h"
 #include "rss/automatedrssdownloader.h"
 #include "banlistoptions.h"
+#include "ipsubnetwhitelistoptionsdialog.h"
 #include "guiiconprovider.h"
 #include "scanfoldersdelegate.h"
 
@@ -350,6 +351,8 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     connect(m_ui->textWebUiUsername, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->textWebUiPassword, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->checkBypassLocalAuth, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->checkBypassAuthSubnetWhitelist, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->checkBypassAuthSubnetWhitelist, &QAbstractButton::toggled, m_ui->IPSubnetWhitelistButton, &QPushButton::setEnabled);
     connect(m_ui->checkDynDNS, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->comboDNSService, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->domainNameTxt, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
@@ -655,13 +658,16 @@ void OptionsDialog::saveOptions()
         pref->setWebUiPort(m_ui->spinWebUiPort->value());
         pref->setUPnPForWebUIPort(m_ui->checkWebUIUPnP->isChecked());
         pref->setWebUiHttpsEnabled(m_ui->checkWebUiHttps->isChecked());
+        // HTTPS
         if (m_ui->checkWebUiHttps->isChecked()) {
             pref->setWebUiHttpsCertificate(m_sslCert);
             pref->setWebUiHttpsKey(m_sslKey);
         }
+        // Authentication
         pref->setWebUiUsername(webUiUsername());
         pref->setWebUiPassword(webUiPassword());
         pref->setWebUiLocalAuthEnabled(!m_ui->checkBypassLocalAuth->isChecked());
+        pref->setWebUiAuthSubnetWhitelistEnabled(m_ui->checkBypassAuthSubnetWhitelist->isChecked());
         // DynDNS
         pref->setDynDNSEnabled(m_ui->checkDynDNS->isChecked());
         pref->setDynDNSService(m_ui->comboDNSService->currentIndex());
@@ -1052,6 +1058,8 @@ void OptionsDialog::loadOptions()
     m_ui->textWebUiUsername->setText(pref->getWebUiUsername());
     m_ui->textWebUiPassword->setText(pref->getWebUiPassword());
     m_ui->checkBypassLocalAuth->setChecked(!pref->isWebUiLocalAuthEnabled());
+    m_ui->checkBypassAuthSubnetWhitelist->setChecked(pref->isWebUiAuthSubnetWhitelistEnabled());
+    m_ui->IPSubnetWhitelistButton->setEnabled(m_ui->checkBypassAuthSubnetWhitelist->isChecked());
 
     m_ui->checkDynDNS->setChecked(pref->isDynDNSEnabled());
     m_ui->comboDNSService->setCurrentIndex(static_cast<int>(pref->getDynDNSService()));
@@ -1724,7 +1732,13 @@ bool OptionsDialog::webUIAuthenticationOk()
 
 void OptionsDialog::on_banListButton_clicked()
 {
-    //have to call dialog window
-    BanListOptions bl(this);
-    bl.exec();
+    // have to call dialog window
+    BanListOptions(this).exec();
+}
+
+void OptionsDialog::on_IPSubnetWhitelistButton_clicked()
+{
+    // call dialog window
+    if (IPSubnetWhitelistOptionsDialog(this).exec() == QDialog::Accepted)
+        enableApplyButton();
 }

--- a/src/gui/optionsdlg.cpp
+++ b/src/gui/optionsdlg.cpp
@@ -1732,8 +1732,9 @@ bool OptionsDialog::webUIAuthenticationOk()
 
 void OptionsDialog::on_banListButton_clicked()
 {
-    // have to call dialog window
-    BanListOptions(this).exec();
+    // call dialog window
+    if (BanListOptions(this).exec() == QDialog::Accepted)
+        enableApplyButton();
 }
 
 void OptionsDialog::on_IPSubnetWhitelistButton_clicked()

--- a/src/gui/optionsdlg.h
+++ b/src/gui/optionsdlg.h
@@ -99,6 +99,7 @@ private slots:
     void on_IpFilterRefreshBtn_clicked();
     void handleIPFilterParsed(bool error, int ruleCount);
     void on_banListButton_clicked();
+    void on_IPSubnetWhitelistButton_clicked();
     void on_randomButton_clicked();
     void on_addScanFolderButton_clicked();
     void on_removeScanFolderButton_clicked();

--- a/src/gui/optionsdlg.ui
+++ b/src/gui/optionsdlg.ui
@@ -3005,7 +3005,27 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
                   <item row="4" column="0" colspan="2">
                    <widget class="QCheckBox" name="checkBypassLocalAuth">
                     <property name="text">
-                     <string>Bypass authentication for localhost</string>
+                     <string>Bypass authentication for clients on localhost</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="5" column="0" colspan="2">
+                   <widget class="QCheckBox" name="checkBypassAuthSubnetWhitelist">
+                    <property name="text">
+                     <string>Bypass authentication for clients in whitelisted IP subnets</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="6" column="1" colspan="1">
+                   <widget class="QPushButton" name="IPSubnetWhitelistButton">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string>IP subnet whitelist...</string>
                     </property>
                    </widget>
                   </item>
@@ -3289,6 +3309,8 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
   <tabstop>btnWebUiCrt</tabstop>
   <tabstop>btnWebUiKey</tabstop>
   <tabstop>checkBypassLocalAuth</tabstop>
+  <tabstop>checkBypassAuthSubnetWhitelist</tabstop>
+  <tabstop>IPSubnetWhitelistButton</tabstop>
   <tabstop>checkDynDNS</tabstop>
   <tabstop>comboDNSService</tabstop>
   <tabstop>registerDNSBtn</tabstop>

--- a/src/webui/www/public/preferences_content.html
+++ b/src/webui/www/public/preferences_content.html
@@ -438,9 +438,17 @@
   <div class="formRow">
   <label for="webui_password_text" class="leftLabelSmall">QBT_TR(Password:)QBT_TR[CONTEXT=OptionsDialog]</label><input type="password" id="webui_password_text" />
   </div>
-
-  <input type="checkbox" id="bypass_local_auth_checkbox" />
-  <label for="bypass_local_auth_checkbox">QBT_TR(Bypass authentication for localhost)QBT_TR[CONTEXT=OptionsDialog]</label>
+  <div class="formRow">
+    <input type="checkbox" id="bypass_local_auth_checkbox" />
+    <label for="bypass_local_auth_checkbox">QBT_TR(Bypass authentication for clients on localhost)QBT_TR[CONTEXT=OptionsDialog]</label>
+  </div>
+  <div class="formRow">
+    <input type="checkbox" id="bypass_auth_subnet_whitelist_checkbox" onclick="updateBypasssAuthSettings();" />
+    <label for="bypass_auth_subnet_whitelist_checkbox">QBT_TR(Bypass authentication for clients in these IP subnets (CIDR notation))QBT_TR[CONTEXT=OptionsDialog]</label>
+  </div>
+  <div class="formRow" style="padding-left: 30px; padding-top: 5px;">
+    <textarea id="bypass_auth_subnet_whitelist_textarea" rows="5" cols="48" placeholder="Example: 172.17.32.0/24, fdff:ffff:c8::/40"></textarea>
+  </div>
 </fieldset>
 
 <fieldset class="settings">
@@ -781,6 +789,13 @@ updateHttpsSettings = function() {
   }
 }
 
+updateBypasssAuthSettings = function() {
+  if ($('bypass_auth_subnet_whitelist_checkbox').getProperty('checked'))
+    $('bypass_auth_subnet_whitelist_textarea').setProperty('disabled', false);
+  else
+    $('bypass_auth_subnet_whitelist_textarea').setProperty('disabled', true);
+};
+
 updateDynDnsSettings = function() {
   if($('use_dyndns_checkbox').getProperty('checked')) {
     $('dyndns_select').setProperty('disabled', false);
@@ -1059,6 +1074,9 @@ loadPreferences = function() {
                     $('webui_username_text').setProperty('value', pref.web_ui_username);
                     $('webui_password_text').setProperty('value', pref.web_ui_password);
                     $('bypass_local_auth_checkbox').setProperty('checked', pref.bypass_local_auth);
+                    $('bypass_auth_subnet_whitelist_checkbox').setProperty('checked', pref.bypass_auth_subnet_whitelist_enabled);
+                    $('bypass_auth_subnet_whitelist_textarea').setProperty('value', pref.bypass_auth_subnet_whitelist);
+                    updateBypasssAuthSettings();
 
                     // Update my dynamic domain name
                     $('use_dyndns_checkbox').setProperty('checked', pref.dyndns_enabled);
@@ -1343,6 +1361,8 @@ applyPreferences = function() {
   settings.set('web_ui_username', web_ui_username);
   settings.set('web_ui_password', web_ui_password);
   settings.set('bypass_local_auth', $('bypass_local_auth_checkbox').getProperty('checked'));
+  settings.set('bypass_auth_subnet_whitelist_enabled', $('bypass_auth_subnet_whitelist_checkbox').getProperty('checked'));
+  settings.set('bypass_auth_subnet_whitelist', $('bypass_auth_subnet_whitelist_textarea').getProperty('value'));
 
   // Update my dynamic domain name
   settings.set('dyndns_enabled', $('use_dyndns_checkbox').getProperty('checked'));


### PR DESCRIPTION
Requested in #924.
Provides a more permanent solution than this [wiki page](https://github.com/qbittorrent/qBittorrent/wiki/Disable-authentification-of-webGUI) while also allowing the web API auth to be disabled

This feature is useful when qBitttorrent is used behind a reverse proxy with its own authentication scheme, or when it's running on a local network.