### PR TITLE
cross-platform free space on disk (Closes #6780)

### DIFF
--- a/src/base/utils/fs.h
+++ b/src/base/utils/fs.h
@@ -51,7 +51,7 @@ namespace Utils
         QString toValidFileSystemName(const QString &name, bool allowSeparators = false
                 , const QString &pad = QLatin1String(" "));
         bool isValidFileSystemName(const QString& name, bool allowSeparators = false);
-        qulonglong freeDiskSpaceOnPath(const QString &path);
+        qint64 freeDiskSpaceOnPath(const QString &path);
         QString branchPath(const QString& file_path, QString* removed = 0);
         bool sameFileNames(const QString& first, const QString& second);
         QString expandPath(const QString& path);


### PR DESCRIPTION
Uses [QStorageInfo](https://doc.qt.io/qt-5/qstorageinfo.html) Instead of using native APIs/#if for each platform.