### PR TITLE
Free space on disk label in status bar (Closes #6764)

### DIFF
--- a/src/gui/statusbar.cpp
+++ b/src/gui/statusbar.cpp
@@ -43,6 +43,7 @@
 #include "base/bittorrent/sessionstatus.h"
 #include "speedlimitdlg.h"
 #include "guiiconprovider.h"
+#include "base/utils/fs.h"
 #include "base/utils/misc.h"
 #include "base/logger.h"
 
@@ -86,6 +87,10 @@ StatusBar::StatusBar(QStatusBar *bar)
     m_DHTLbl = new QLabel(tr("DHT: %1 nodes").arg(0), bar);
     m_DHTLbl->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
 
+    m_freeSpaceOnDiskLbl = new QLabel(tr("Free space: %1").arg(0), bar);
+    m_freeSpaceOnDiskLbl->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
+    m_freeSpaceOnDiskLbl->setToolTip(QString("<b>%1</b><br>%2").arg(tr("Default save path:"), BitTorrent::Session::instance()->defaultSavePath()));
+
     m_altSpeedsBtn = new QPushButton(bar);
     m_altSpeedsBtn->setFlat(true);
     m_altSpeedsBtn->setFocusPolicy(Qt::NoFocus);
@@ -118,14 +123,20 @@ StatusBar::StatusBar(QStatusBar *bar)
     m_statusSep4 = new QFrame(bar);
     m_statusSep4->setFrameStyle(QFrame::VLine);
     m_statusSep4->setFrameShadow(QFrame::Raised);
-    m_layout->addWidget(m_DHTLbl);
+    m_statusSep5 = new QFrame(bar);
+    m_statusSep5->setFrameStyle(QFrame::VLine);
+    m_statusSep5->setFrameShadow(QFrame::Raised);
+
+    m_layout->addWidget(m_freeSpaceOnDiskLbl);
     m_layout->addWidget(m_statusSep1);
-    m_layout->addWidget(m_connecStatusLblIcon);
+    m_layout->addWidget(m_DHTLbl);
     m_layout->addWidget(m_statusSep2);
+    m_layout->addWidget(m_connecStatusLblIcon);
+    m_layout->addWidget(m_statusSep3);
     m_layout->addWidget(m_altSpeedsBtn);
     m_layout->addWidget(m_statusSep4);
     m_layout->addWidget(m_dlSpeedLbl);
-    m_layout->addWidget(m_statusSep3);
+    m_layout->addWidget(m_statusSep5);
     m_layout->addWidget(m_upSpeedLbl);
 
     bar->addPermanentWidget(m_container);
@@ -221,6 +232,14 @@ void StatusBar::refreshStatusBar()
     updateConnectionStatus();
     updateDHTNodesNumber();
     updateSpeedLabels();
+    updateFreeSpaceOnDisk();
+}
+
+void StatusBar::updateFreeSpaceOnDisk()
+{
+    QString defaultPath = BitTorrent::Session::instance()->defaultSavePath();
+    m_freeSpaceOnDiskLbl->setText(tr("Free space: %1").arg(Utils::Misc::friendlyUnit(Utils::Fs::freeDiskSpaceOnPath(defaultPath))));
+    m_freeSpaceOnDiskLbl->setToolTip(QString("<b>%1</b><br>%2").arg(tr("Default save path:"), defaultPath));
 }
 
 void StatusBar::updateAltSpeedsBtn(bool alternative)

--- a/src/gui/statusbar.h
+++ b/src/gui/statusbar.h
@@ -64,15 +64,18 @@ private:
     void updateConnectionStatus();
     void updateDHTNodesNumber();
     void updateSpeedLabels();
+    void updateFreeSpaceOnDisk();
 
     QStatusBar *m_bar;
     QPushButton *m_dlSpeedLbl;
     QPushButton *m_upSpeedLbl;
     QLabel *m_DHTLbl;
+    QLabel *m_freeSpaceOnDiskLbl;
     QFrame *m_statusSep1;
     QFrame *m_statusSep2;
     QFrame *m_statusSep3;
     QFrame *m_statusSep4;
+    QFrame *m_statusSep5;
     QPushButton *m_connecStatusLblIcon;
     QPushButton *m_altSpeedsBtn;
     QWidget *m_container;


### PR DESCRIPTION
Currently, this PR gives "Free space: 0B". Works after PR #6785.
Free space calculation done against default save path with a tooltip shows the default save path.

Result:
![](https://cloud.githubusercontent.com/assets/17493070/26030678/9663bd82-3859-11e7-8a9a-231a24a94820.png)