### PR TITLE
Fix build error.

### DIFF
--- a/src/gui/categoryfilterproxymodel.h
+++ b/src/gui/categoryfilterproxymodel.h
@@ -43,6 +43,10 @@ public:
 
 protected:
     bool lessThan(const QModelIndex &left, const QModelIndex &right) const override;
+
+private:
+    // we added another overload of index(), hence this using directive:
+    using QSortFilterProxyModel::index;
 };
 
 #endif // CATEGORYFILTERPROXYMODEL_H


### PR DESCRIPTION
```
[ 56%] Building CXX object src/gui/CMakeFiles/qbt_gui.dir/categoryfilterproxymodel.cpp.o
In file included from /opt/qt55/include/QtCore/QSortFilterProxyModel:1:0,
                 from /home/travis/build/evsh/qBittorrent/src/gui/categoryfilterproxymodel.h:32,
                 from /home/travis/build/evsh/qBittorrent/src/gui/categoryfilterproxymodel.cpp:29:
/opt/qt55/include/QtCore/qsortfilterproxymodel.h:122:17: error: ‘virtual QModelIndex QSortFilterProxyModel::index(int, int, const QModelIndex&) const’ was hidden [-Werror=overloaded-virtual]
     QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const Q_DECL_OVERRIDE;
                 ^
In file included from /home/travis/build/evsh/qBittorrent/src/gui/categoryfilterproxymodel.cpp:29:0:
/home/travis/build/evsh/qBittorrent/src/gui/categoryfilterproxymodel.h:41:17: error:   by ‘QModelIndex CategoryFilterProxyModel::index(const QString&) const’ [-Werror=overloaded-virtual]
     QModelIndex index(const QString &categoryName) const;
```