### PR TITLE
[QuickFix] cmake: fix FindSystemd.cmake

### DIFF
--- a/cmake/Modules/FindSystemd.cmake
+++ b/cmake/Modules/FindSystemd.cmake
@@ -3,6 +3,9 @@
 # sets variables
 # SYSTEMD_FOUND
 # SYSTEMD_SERVICES_INSTALL_DIR
+
+find_package(PkgConfig QUIET REQUIRED)
+
 if (NOT SYSTEMD_FOUND)
     pkg_check_modules(SYSTEMD "systemd")
 endif(NOT SYSTEMD_FOUND)


### PR DESCRIPTION
Apparently, recent version of CMake made PkgConfig stuff scooped and we
need to call find_package(PkgConfig) in FindSystemd.cmake too, the call
in FindLibtorrentRasterbar.cmake, that is always used first, is not
enough now.