### PR TITLE
Cosmetic fixes for WebUI upload and download windows

### DIFF
--- a/src/webui/www/public/download.html
+++ b/src/webui/www/public/download.html
@@ -31,12 +31,12 @@
 </div>
 <div class="formRow">
     <label for="start_torrent" class="leftLabelLarge">QBT_TR(Start torrent)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
-    <input type="checkbox" id="start_torrent" checked="checked" style="width: 16em;"/>
+    <input type="checkbox" id="start_torrent" checked="checked"/>
     <input type="hidden" id="add_paused" name="paused" value="true" disabled="disabled"/>
 </div>
 <div class="formRow">
     <label for="skip_checking" class="leftLabelLarge">QBT_TR(Skip hash check)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
-    <input type="checkbox" name="skip_checking" value="true" style="width: 16em;"/>
+    <input type="checkbox" name="skip_checking" value="true"/>
 </div>
 <div id="submitbutton" style="margin-top: 12px; text-align: center;">
     <button type="submit" id="submitButton">QBT_TR(Download)QBT_TR[CONTEXT=downloadFromURL]</button>

--- a/src/webui/www/public/scripts/mocha-init.js
+++ b/src/webui/www/public/scripts/mocha-init.js
@@ -57,7 +57,7 @@ initializeWindows = function() {
             paddingVertical: 0,
             paddingHorizontal: 0,
             width: 500,
-            height: 360
+            height: 400
         });
         updateMainData();
     });
@@ -97,7 +97,7 @@ initializeWindows = function() {
             paddingVertical: 0,
             paddingHorizontal: 0,
             width: 500,
-            height: 220
+            height: 240
         });
         updateMainData();
     });

--- a/src/webui/www/public/upload.html
+++ b/src/webui/www/public/upload.html
@@ -27,12 +27,12 @@
 </div>
 <div class="formRow">
     <label for="start_torrent" class="leftLabelLarge">QBT_TR(Start torrent)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
-    <input type="checkbox" id="start_torrent" checked="checked" style="width: 16em;"/>
+    <input type="checkbox" id="start_torrent" checked="checked"/>
     <input type="hidden" id="add_paused" name="paused" value="true" disabled="disabled"/>
 </div>
 <div class="formRow">
     <label for="skip_checking" class="leftLabelLarge">QBT_TR(Skip hash check)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
-    <input type="checkbox" name="skip_checking" value="true" style="width: 16em;"/>
+    <input type="checkbox" name="skip_checking" value="true"/>
 </div>
 <div id="submitbutton" style="margin-top: 30px; text-align: center;">
         <button type="submit" style="font-size: 1em;">QBT_TR(Upload Torrents)QBT_TR[CONTEXT=HttpServer]</button>


### PR DESCRIPTION
These are cosmetic fixes for the pull request #6475 that was merged like 3 months ago but I think it doesn't look good.

Here's how it looks right now:

![upload](http://i.imgur.com/XcNqTZL.png)

Here's what I'm proposing:

![upload](http://i.imgur.com/y3zHw96.png)

No unnecessary scrollbar and no centering of the checkmark, it's so far way is hard to see what it is for.

Same for download, here's how it looks right now:

![download](http://i.imgur.com/y2yGq2E.png)

And here's what I'm proposing:

![download](http://i.imgur.com/HUk2tuU.png)