### PR TITLE
Add visual feedback for wrong paths in FileSystemPathEdit

### DIFF
--- a/src/gui/fspathedit.cpp
+++ b/src/gui/fspathedit.cpp
@@ -80,6 +80,7 @@ class FileSystemPathEdit::FileSystemPathEditPrivate
     Mode m_mode;
     QString m_lastSignaledPath;
     QString m_dialogCaption;
+    Private::FileSystemPathValidator *m_validator;
 };
 
 FileSystemPathEdit::FileSystemPathEditPrivate::FileSystemPathEditPrivate(
@@ -89,6 +90,7 @@ FileSystemPathEdit::FileSystemPathEditPrivate::FileSystemPathEditPrivate(
     , m_browseAction {new QAction(q)}
     , m_browseBtn {new QToolButton(q)}
     , m_mode {FileSystemPathEdit::Mode::FileOpen}
+    , m_validator {new Private::FileSystemPathValidator(q)}
 {
     m_browseAction->setIconText(browseButtonBriefText.tr());
     m_browseAction->setText(browseButtonFullText.tr());
@@ -97,6 +99,8 @@ FileSystemPathEdit::FileSystemPathEditPrivate::FileSystemPathEditPrivate(
     m_browseBtn->setDefaultAction(m_browseAction);
     m_fileNameFilter = tr("Any file") + QLatin1String(" (*)");
     m_editor->setBrowseAction(m_browseAction);
+    m_validator->setStrictMode(false);
+    m_editor->setValidator(m_validator);
     modeChanged();
 }
 
@@ -163,6 +167,11 @@ void FileSystemPathEdit::FileSystemPathEditPrivate::modeChanged()
     }
     m_browseAction->setIcon(QApplication::style()->standardIcon(pixmap));
     m_editor->completeDirectoriesOnly(showDirsOnly);
+
+    m_validator->setExistingOnly(m_mode != FileSystemPathEdit::Mode::FileSave);
+    m_validator->setDirectoriesOnly((m_mode == FileSystemPathEdit::Mode::DirectoryOpen) || (m_mode == FileSystemPathEdit::Mode::DirectorySave));
+    m_validator->setCheckReadPermission((m_mode == FileSystemPathEdit::Mode::FileOpen) || (m_mode == FileSystemPathEdit::Mode::DirectoryOpen));
+    m_validator->setCheckWritePermission((m_mode == FileSystemPathEdit::Mode::FileSave) || (m_mode == FileSystemPathEdit::Mode::DirectorySave));
 }
 
 FileSystemPathEdit::FileSystemPathEdit(Private::FileEditorWithCompletion *editor, QWidget *parent)

--- a/src/gui/fspathedit_p.h
+++ b/src/gui/fspathedit_p.h
@@ -39,9 +39,69 @@
 #include <QKeyEvent>
 #include <QLineEdit>
 #include <QMenu>
+#include <QStringRef>
+#include <QValidator>
+#include <QVector>
+
+class QStringList;
 
 namespace Private
 {
+    class FileSystemPathValidator: public QValidator
+    {
+        Q_OBJECT
+
+    public:
+        FileSystemPathValidator(QObject *parent = nullptr);
+
+        bool strictMode() const;
+        void setStrictMode(bool v);
+
+        bool existingOnly() const;
+        void setExistingOnly(bool v);
+
+        bool directoriesOnly() const;
+        void setDirectoriesOnly(bool v);
+
+        bool checkReadPermission() const;
+        void setCheckReadPermission(bool v);
+
+        bool checkWritePermission() const;
+        void setCheckWritePermission(bool v);
+
+        QValidator::State validate(QString &input, int &pos) const override;
+
+        enum class TestResult
+        {
+            OK,
+            DoesNotExist,
+            NotADir,
+            NotAFile,
+            CantRead,
+            CantWrite
+        };
+
+        TestResult lastTestResult() const;
+        QValidator::State lastValidationState() const;
+        QString lastTestedPath() const;
+
+    private:
+        QValidator::State validate(const QString &path, const QVector<QStringRef> &pathComponents, bool strict,
+                                   int firstComponentToTest, int lastComponentToTest) const;
+
+        TestResult testPath(const QStringRef &path, bool pathIsComplete) const;
+
+        bool m_strictMode;
+        bool m_existingOnly;
+        bool m_directoriesOnly;
+        bool m_checkReadPermission;
+        bool m_checkWritePermission;
+
+        mutable TestResult m_lastTestResult;
+        mutable QValidator::State m_lastValidationState;
+        mutable QString m_lastTestedPath;
+    };
+
     class FileEditorWithCompletion
     {
     public:
@@ -49,6 +109,7 @@ namespace Private
         virtual void completeDirectoriesOnly(bool completeDirsOnly) = 0;
         virtual void setFilenameFilters(const QStringList &filters) = 0;
         virtual void setBrowseAction(QAction *action) = 0;
+        virtual void setValidator(QValidator *validator) = 0;
         virtual QWidget *widget() = 0;
     };
 
@@ -64,6 +125,7 @@ namespace Private
         void completeDirectoriesOnly(bool completeDirsOnly) override;
         void setFilenameFilters(const QStringList &filters) override;
         void setBrowseAction(QAction *action) override;
+        void setValidator(QValidator *validator) override;
         QWidget *widget() override;
 
     protected:
@@ -74,12 +136,14 @@ namespace Private
         void showCompletionPopup();
 
     private:
+        static QString warningText(FileSystemPathValidator::TestResult r);
+
         QFileSystemModel *m_completerModel;
         QCompleter *m_completer;
         QAction *m_browseAction;
         QFileIconProvider m_iconProvider;
+        QAction *m_warningAction;
     };
-
 
     class FileComboEdit: public QComboBox, public FileEditorWithCompletion
     {
@@ -91,6 +155,7 @@ namespace Private
         void completeDirectoriesOnly(bool completeDirsOnly) override;
         void setFilenameFilters(const QStringList &filters) override;
         void setBrowseAction(QAction *action) override;
+        void setValidator(QValidator *validator) override;
         QWidget *widget() override;
 
     protected:


### PR DESCRIPTION
Not a code I can be proud of. Any suggestions are very welcome.

This PR adds a QValidator implementation for filesystem paths and uses validation result in the file line edit to show a warning action with explanation tooltip when validation was not successful.

The following situations are handled:
1. File or directory does not exist.
2. Expected a file (directory), but path points to a directory (file).
3. User has no read permission for the object, pointed by path.
4. User has no write permission for the object, pointed by path.

Tests are selected basing on the widget mode (file or directory open or save).

![qbt-fspatedit-warning](https://user-images.githubusercontent.com/394621/26887047-46896f76-4ba7-11e7-96e5-603157070a36.png)
