### PR TITLE
Do not use hardcoded colors in RSS feed view

### DIFF
--- a/src/gui/rss/articlelistwidget.cpp
+++ b/src/gui/rss/articlelistwidget.cpp
@@ -94,7 +94,7 @@ void ArticleListWidget::handleArticleAdded(RSS::Article *rssArticle)
 void ArticleListWidget::handleArticleRead(RSS::Article *rssArticle)
 {
     auto item = mapRSSArticle(rssArticle);
-    item->setData(Qt::ForegroundRole, QColor("grey"));
+    item->setData(Qt::ForegroundRole, QPalette().color(QPalette::Inactive, QPalette::WindowText));
     item->setData(Qt::DecorationRole, QIcon(":/icons/sphere.png"));
 
     checkInvariant();
@@ -119,11 +119,11 @@ QListWidgetItem *ArticleListWidget::createItem(RSS::Article *article) const
     item->setData(Qt::DisplayRole, article->title());
     item->setData(Qt::UserRole, reinterpret_cast<quintptr>(article));
     if (article->isRead()) {
-        item->setData(Qt::ForegroundRole, QColor("grey"));
+        item->setData(Qt::ForegroundRole, QPalette().color(QPalette::Inactive, QPalette::WindowText));
         item->setData(Qt::DecorationRole, QIcon(":/icons/sphere.png"));
     }
     else {
-        item->setData(Qt::ForegroundRole, QColor("blue"));
+        item->setData(Qt::ForegroundRole, QPalette().color(QPalette::Active, QPalette::Link));
         item->setData(Qt::DecorationRole, QIcon(":/icons/sphere2.png"));
     }
 


### PR DESCRIPTION
One of the commits from PR #6698. This commit does not really belong to that PR. It replaces hardcoded colours in RSS list widget with colours from app palette.