### PR TITLE
[WebUI] Make cookie parsing robust

### DIFF
--- a/src/base/utils/string.h
+++ b/src/base/utils/string.h
@@ -30,10 +30,10 @@
 #ifndef UTILS_STRING_H
 #define UTILS_STRING_H
 
-#include <string>
+#include <QString>
 
 class QByteArray;
-class QString;
+class QLatin1String;
 
 namespace Utils
 {
@@ -49,6 +49,19 @@ namespace Utils
         bool naturalCompareCaseInsensitive(const QString &left, const QString &right);
 
         QString wildcardToRegex(const QString &pattern);
+
+        template <typename T>
+        T unquote(const T &str, const QString &quotes = QLatin1String("\""))
+        {
+            if (str.length() < 2) return str;
+
+            for (auto const quote : quotes) {
+                if (str.startsWith(quote) && str.endsWith(quote))
+                    return str.mid(1, str.length() - 2);
+            }
+
+            return str;
+        }
     }
 }
 

--- a/src/webui/abstractwebapplication.cpp
+++ b/src/webui/abstractwebapplication.cpp
@@ -40,6 +40,7 @@
 #include "base/preferences.h"
 #include "base/utils/fs.h"
 #include "base/utils/random.h"
+#include "base/utils/string.h"
 #include "websessiondata.h"
 
 // UnbanTimer
@@ -147,24 +148,13 @@ void AbstractWebApplication::removeInactiveSessions()
 
 bool AbstractWebApplication::sessionInitialize()
 {
-    static const QString SID_START = QLatin1String(C_SID) + QLatin1String("=");
-
     if (session_ == 0)
     {
-        QString cookie = request_.headers.value("cookie");
-        //qDebug() << Q_FUNC_INFO << "cookie: " << cookie;
-
-        QString sessionId;
-        int pos = cookie.indexOf(SID_START);
-        if (pos >= 0) {
-            pos += SID_START.length();
-            int end = cookie.indexOf(QRegExp("[,;]"), pos);
-            sessionId = cookie.mid(pos, end >= 0 ? end - pos : end);
-        }
+        const QString sessionId = parseCookie(request_).value(C_SID);
 
         // TODO: Additional session check
 
-        if (!sessionId.isNull()) {
+        if (!sessionId.isEmpty()) {
             if (sessions_.contains(sessionId)) {
                 session_ = sessions_[sessionId];
                 session_->updateTimestamp();
@@ -386,3 +376,23 @@ const QStringMap AbstractWebApplication::CONTENT_TYPE_BY_EXT = {
     { "png", Http::CONTENT_TYPE_PNG },
     { "js", Http::CONTENT_TYPE_JS }
 };
+
+QStringMap AbstractWebApplication::parseCookie(const Http::Request &request) const
+{
+    // [rfc6265] 4.2.1. Syntax
+    QStringMap ret;
+    const QString cookieStr = request.headers.value(QLatin1String("cookie"));
+    const QVector<QStringRef> cookies = cookieStr.splitRef(';', QString::SkipEmptyParts);
+
+    for (const auto &cookie : cookies) {
+        const int idx = cookie.indexOf('=');
+        if (idx < 0)
+            continue;
+
+        const QString name = cookie.left(idx).trimmed().toString();
+        const QString value = Utils::String::unquote(cookie.mid(idx + 1).trimmed())
+                                  .toString();
+        ret.insert(name, value);
+    }
+    return ret;
+}

--- a/src/webui/abstractwebapplication.h
+++ b/src/webui/abstractwebapplication.h
@@ -100,6 +100,8 @@ private:
     QString generateSid();
     bool sessionInitialize();
 
+    QStringMap parseCookie(const Http::Request &request) const;
+
     static void translateDocument(QString &data);
 
     static const QStringMap CONTENT_TYPE_BY_EXT;


### PR DESCRIPTION
Previously cookie name such as `<any string>SID` will be mistakenly
accepted as `SID` session ID, this commit fixes it.
