### PR TITLE
[WebAPI] Get piece information/state 

### DIFF
--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -246,6 +246,21 @@ QVector<int> TorrentInfo::fileIndicesForPiece(int pieceIndex) const
     return res;
 }
 
+QVector<QByteArray> TorrentInfo::pieceHashes() const
+{
+    if (!isValid())
+        return {};
+
+    const int count = piecesCount();
+    QVector<QByteArray> hashes;
+    hashes.reserve(count);
+
+    for (int i = 0; i < count; ++i)
+        hashes += { m_nativeInfo->hash_for_piece_ptr(i), libtorrent::sha1_hash::size };
+
+    return hashes;
+}
+
 TorrentInfo::PieceRange TorrentInfo::filePieces(const QString& file) const
 {
     if (!isValid()) // if we do not check here the debug message will be printed, which would be not correct

--- a/src/base/bittorrent/torrentinfo.h
+++ b/src/base/bittorrent/torrentinfo.h
@@ -91,6 +91,7 @@ namespace BitTorrent
         QByteArray metadata() const;
         QStringList filesForPiece(int pieceIndex) const;
         QVector<int> fileIndicesForPiece(int pieceIndex) const;
+        QVector<QByteArray> pieceHashes() const;
 
         using PieceRange = IndexRange<int>;
         // returns pair of the first and the last pieces into which

--- a/src/webui/btjson.h
+++ b/src/webui/btjson.h
@@ -51,6 +51,8 @@ public:
     static QByteArray getWebSeedsForTorrent(const QString& hash);
     static QByteArray getPropertiesForTorrent(const QString& hash);
     static QByteArray getFilesForTorrent(const QString& hash);
+    static QByteArray getPieceHashesForTorrent(const QString &hash);
+    static QByteArray getPieceStatesForTorrent(const QString &hash);
     static QByteArray getTransferInfo();
     static QByteArray getTorrentsRatesLimits(QStringList& hashes, bool downloadLimits);
     static QByteArray getLog(bool normal, bool info, bool warning, bool critical, int lastKnownId);

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -49,7 +49,7 @@
 #include "websessiondata.h"
 #include "webapplication.h"
 
-static const int API_VERSION = 13;
+static const int API_VERSION = 14;
 static const int API_VERSION_MIN = 13;
 
 const QString WWW_FOLDER = ":/www/public/";
@@ -83,6 +83,8 @@ QMap<QString, QMap<QString, WebApplication::Action> > WebApplication::initialize
     ADD_ACTION(query, propertiesFiles);
     ADD_ACTION(query, getLog);
     ADD_ACTION(query, getPeerLog);
+    ADD_ACTION(query, getPieceHashes);
+    ADD_ACTION(query, getPieceStates);
     ADD_ACTION(sync, maindata);
     ADD_ACTION(sync, torrent_peers);
     ADD_ACTION(command, shutdown);
@@ -308,6 +310,18 @@ void WebApplication::action_query_getPeerLog()
         lastKnownId = -1;
 
     print(btjson::getPeerLog(lastKnownId), Http::CONTENT_TYPE_JSON);
+}
+
+void WebApplication::action_query_getPieceHashes()
+{
+    CHECK_URI(1);
+    print(btjson::getPieceHashesForTorrent(args_.front()), Http::CONTENT_TYPE_JSON);
+}
+
+void WebApplication::action_query_getPieceStates()
+{
+    CHECK_URI(1);
+    print(btjson::getPieceStatesForTorrent(args_.front()), Http::CONTENT_TYPE_JSON);
 }
 
 // GET param:

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -56,6 +56,8 @@ private:
     void action_query_propertiesFiles();
     void action_query_getLog();
     void action_query_getPeerLog();
+    void action_query_getPieceHashes();
+    void action_query_getPieceStates();
     void action_sync_maindata();
     void action_sync_torrent_peers();
     void action_command_shutdown();


### PR DESCRIPTION
Now getting pieces information for a specific torrent is possible via:
* returns a list of states (integers) of pieces in order. defined:
"0=not downloaded", "1=downloading", "2=downloaded".
`GET /query/getPieceStates/<torrent_hash>`

* returns a list of hashes (hex strings) of pieces in order:
`GET /query/getPieceHashes/<torrent_hash>`

-------

UPDATE1: updated API names