### PR TITLE
[TorrentCreator] Show total number of pieces. Closes #6774.

### DIFF
--- a/src/base/bittorrent/torrentcreatorthread.cpp
+++ b/src/base/bittorrent/torrentcreatorthread.cpp
@@ -160,3 +160,13 @@ void TorrentCreatorThread::run()
         emit creationFailure(QString::fromStdString(e.what()));
     }
 }
+
+int TorrentCreatorThread::calculateTotalPieces(const QString &inputPath, const int pieceSize)
+{
+    if (inputPath.isEmpty())
+        return 0;
+
+    libt::file_storage fs;
+    libt::add_files(fs, Utils::Fs::toNativePath(inputPath).toStdString(), fileFilter);
+    return libt::create_torrent(fs, pieceSize).num_pieces();
+}

--- a/src/base/bittorrent/torrentcreatorthread.h
+++ b/src/base/bittorrent/torrentcreatorthread.h
@@ -47,6 +47,8 @@ namespace BitTorrent
         void create(const QString &inputPath, const QString &savePath, const QStringList &trackers,
                     const QStringList &urlSeeds, const QString &comment, bool isPrivate, int pieceSize);
 
+        static int calculateTotalPieces(const QString &inputPath, const int pieceSize);
+
     protected:
         void run();
 

--- a/src/gui/torrentcreatordlg.cpp
+++ b/src/gui/torrentcreatordlg.cpp
@@ -70,6 +70,7 @@ TorrentCreatorDlg::TorrentCreatorDlg(QWidget *parent, const QString &defaultPath
     connect(m_ui->addFileButton, SIGNAL(clicked(bool)), SLOT(onAddFileButtonClicked()));
     connect(m_ui->addFolderButton, SIGNAL(clicked(bool)), SLOT(onAddFolderButtonClicked()));
     connect(m_ui->buttonBox, SIGNAL(accepted()), SLOT(onCreateButtonClicked()));
+    connect(m_ui->buttonCalcTotalPieces, &QAbstractButton::clicked, this, &TorrentCreatorDlg::updatePiecesCount);
 
     connect(m_creatorThread, SIGNAL(creationSuccess(QString, QString)), this, SLOT(handleCreationSuccess(QString, QString)));
     connect(m_creatorThread, SIGNAL(creationFailure(QString)), this, SLOT(handleCreationFailure(QString)));
@@ -205,6 +206,14 @@ void TorrentCreatorDlg::handleCreationSuccess(const QString &path, const QString
 void TorrentCreatorDlg::updateProgressBar(int progress)
 {
     m_ui->progressBar->setValue(progress);
+}
+
+void TorrentCreatorDlg::updatePiecesCount()
+{
+    const QString path = m_ui->textInputPath->text().trimmed();
+
+    const int count = BitTorrent::TorrentCreatorThread::calculateTotalPieces(path, getPieceSize());
+    m_ui->labelTotalPieces->setText(QString::number(count));
 }
 
 void TorrentCreatorDlg::setInteractionEnabled(bool enabled)

--- a/src/gui/torrentcreatordlg.h
+++ b/src/gui/torrentcreatordlg.h
@@ -55,6 +55,7 @@ public:
 
 private slots:
     void updateProgressBar(int progress);
+    void updatePiecesCount();
     void onCreateButtonClicked();
     void onAddFileButtonClicked();
     void onAddFolderButtonClicked();

--- a/src/gui/torrentcreatordlg.ui
+++ b/src/gui/torrentcreatordlg.ui
@@ -167,6 +167,20 @@
          </widget>
         </item>
         <item>
+         <widget class="QPushButton" name="buttonCalcTotalPieces">
+          <property name="text">
+           <string>Calculate total pieces:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelTotalPieces">
+          <property name="text">
+           <string notr="true">0</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <spacer name="spacer1">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
See: ~~[screenshot](https://cloud.githubusercontent.com/assets/9395168/26484280/c38960ea-4223-11e7-82f3-0a18d5c8973f.png)~~, [screenshot2](https://cloud.githubusercontent.com/assets/9395168/26518946/9fea7dbc-42ec-11e7-9377-729e3e6444f4.png)

~~The calculation `libt::create_torrent().num_pieces()` is quite fast.~~ But not fast enough to do so for every input event.
