### PR TITLE
Fix crash when delete RSS feed

### DIFF
--- a/src/gui/rss/feedlistwidget.cpp
+++ b/src/gui/rss/feedlistwidget.cpp
@@ -137,6 +137,7 @@ void FeedListWidget::handleItemPathChanged(RSS::Item *rssItem)
 
 void FeedListWidget::handleItemAboutToBeRemoved(RSS::Item *rssItem)
 {
+    rssItem->disconnect(this);
     delete m_rssToTreeItemMapping.take(rssItem);
 
     // RSS Item is still valid in this slot so if it is the last


### PR DESCRIPTION
How to reproduce:
click on RSS feed (not Unread feed) then click on any article then right click this feed then delete.

This PR has a solution if you want to keep unread count doesn't change till changing articles, we can change this behavior to make article read on click (I can work on it).

Crash report:
qBittorrent has crashed
Please file a bug report at http://bugs.qbittorrent.org and provide the following information:

qBittorrent version: v3.4.0alpha (64-bit)
Libtorrent version: 1.0.11.0
Qt version: 5.9.0
Boost version: 1.64.0
OS version: Windows 10 (10.0) 10.0.15063 x86_64

```
#  0 qbittorrent.exe      0x00007ff60e4cccd6 straceWin::getBacktrace()[ app\stacktrace_win.h : 213 ]
#  1 qbittorrent.exe      0x00007ff60e4d006b sigAbnormalHandler(signum)[ app\main.cpp : 303 ]
#  2 ucrtbased.dll        0x00007ff89cddfe21 raise()
#  3 ucrtbased.dll        0x00007ff89cde1979 abort()
#  4 Qt5Cored.dll         0x000000006a80b682 QtPrivate::QContainerImplHelper::mid()
#  5 Qt5Cored.dll         0x000000006a809ea2 QtPrivate::QContainerImplHelper::mid()
#  6 Qt5Cored.dll         0x000000006a7fc8cf QtPrivate::QContainerImplHelper::mid()
#  7 qbittorrent.exe      0x00007ff60e730f3f FeedListWidget::handleItemUnreadCountChanged(rssItem)[ gui\rss\feedlistwidget.cpp : 119 ]
#  8 qbittorrent.exe      0x00007ff60e72f833 QtPrivate::FunctorCall,QtPrivate::List,void,void (__cdecl ArticleListWidget::*)(RSS::Article * __ptr64) __ptr64>::call(f, o, arg)[ c:\qt\5.9\msvc2015_64\include\qtcore\qobjectdefs_impl.h : 136 ]
#  9 qbittorrent.exe      0x00007ff60e72f4dd QtPrivate::FunctionPointer::call,void>(f, o, arg)[ c:\qt\5.9\msvc2015_64\include\qtcore\qobjectdefs_impl.h : 169 ]
# 10 qbittorrent.exe      0x00007ff60e72bb36 QtPrivate::QSlotObject,void>::impl(which, this_, r, a, ret)[ c:\qt\5.9\msvc2015_64\include\qtcore\qobject_impl.h : 120 ]
# 11 Qt5Cored.dll         0x000000006ac4d598 QtPrivate::QContainerImplHelper::mid()
# 12 Qt5Cored.dll         0x000000006ac3c190 QtPrivate::QContainerImplHelper::mid()
# 13 Qt5Cored.dll         0x000000006ac3ba58 QtPrivate::QContainerImplHelper::mid()
# 14 qbittorrent.exe      0x00007ff60e75599e RSS::Item::unreadCountChanged(_t1)[ debug\moc_rss_item.cpp : 230 ]
# 15 qbittorrent.exe      0x00007ff60e580576 RSS::Feed::decreaseUnreadCount()[ base\rss\rss_feed.cpp : 366 ]
# 16 qbittorrent.exe      0x00007ff60e57f14b RSS::Feed::handleArticleRead(article)[ base\rss\rss_feed.cpp : 423 ]
# 17 qbittorrent.exe      0x00007ff60e588561 QtPrivate::FunctorCall,QtPrivate::List,void,void (__cdecl RSS::Item::*)(RSS::Article * __ptr64) __ptr64>::call(f, o, arg)[ c:\qt\5.9\msvc2015_64\include\qtcore\qobjectdefs_impl.h : 136 ]
# 18 qbittorrent.exe      0x00007ff60e587877 QtPrivate::FunctionPointer::call,void>(f, o, arg)[ c:\qt\5.9\msvc2015_64\include\qtcore\qobjectdefs_impl.h : 169 ]
# 19 qbittorrent.exe      0x00007ff60e5888be QtPrivate::QSlotObject,void>::impl(which, this_, r, a, ret)[ c:\qt\5.9\msvc2015_64\include\qtcore\qobject_impl.h : 120 ]
# 20 Qt5Cored.dll         0x000000006ac4d598 QtPrivate::QContainerImplHelper::mid()
# 21 Qt5Cored.dll         0x000000006ac3c190 QtPrivate::QContainerImplHelper::mid()
# 22 Qt5Cored.dll         0x000000006ac3ba58 QtPrivate::QContainerImplHelper::mid()
# 23 qbittorrent.exe      0x00007ff60e7553ab RSS::Article::read(_t1)[ debug\moc_rss_article.cpp : 143 ]
# 24 qbittorrent.exe      0x00007ff60e57bffe RSS::Article::markAsRead()[ base\rss\rss_article.cpp : 111 ]
# 25 qbittorrent.exe      0x00007ff60e7272c7 RSSWidget::handleCurrentArticleItemChanged(currentItem, previousItem)[ gui\rss\rsswidget.cpp : 441 ]
# 26 qbittorrent.exe      0x00007ff60e6c7a75 QtPrivate::FunctorCall,QtPrivate::List,void,void (__cdecl OptionsDialog::*)(QListWidgetItem * __ptr64,QListWidgetItem * __ptr64) __ptr64>::call(f, o, arg)[ c:\qt\5.9\msvc2015_64\include\qtcore\qobjectdefs_impl.h : 136 ]
# 27 qbittorrent.exe      0x00007ff60e6b138d QtPrivate::FunctionPointer::call,void>(f, o, arg)[ c:\qt\5.9\msvc2015_64\include\qtcore\qobjectdefs_impl.h : 169 ]
# 28 qbittorrent.exe      0x00007ff60e72ba06 QtPrivate::QSlotObject,void>::impl(which, this_, r, a, ret)[ c:\qt\5.9\msvc2015_64\include\qtcore\qobject_impl.h : 120 ]
# 29 Qt5Cored.dll         0x000000006ac4d598 QtPrivate::QContainerImplHelper::mid()
# 30 Qt5Cored.dll         0x000000006ac3c190 QtPrivate::QContainerImplHelper::mid()
# 31 Qt5Cored.dll         0x000000006ac3ba58 QtPrivate::QContainerImplHelper::mid()
# 32 Qt5Widgetsd.dll      0x000000006bc5aa8c QPixmapDropShadowFilter::setBlurRadius()
# 33 Qt5Widgetsd.dll      0x000000006bc5d9fe QPixmapDropShadowFilter::setBlurRadius()
# 34 Qt5Widgetsd.dll      0x000000006bc58ac1 QPixmapDropShadowFilter::setBlurRadius()
# 35 Qt5Cored.dll         0x000000006ac3c2ea QtPrivate::QContainerImplHelper::mid()
# 36 Qt5Cored.dll         0x000000006ac3ba58 QtPrivate::QContainerImplHelper::mid()
# 37 Qt5Cored.dll         0x000000006ab711eb QtPrivate::QContainerImplHelper::mid()
# 38 Qt5Cored.dll         0x000000006ab710b9 QtPrivate::QContainerImplHelper::mid()
# 39 Qt5Cored.dll         0x000000006ab70ef6 QtPrivate::QContainerImplHelper::mid()
# 40 Qt5Widgetsd.dll      0x000000006bc5a827 QPixmapDropShadowFilter::setBlurRadius()
# 41 qbittorrent.exe      0x00007ff60e72eab2 ArticleListWidget::setRSSItem(rssItem, unreadOnly)[ gui\rss\articlelistwidget.cpp : 59 ]
# 42 qbittorrent.exe      0x00007ff60e727209 RSSWidget::handleCurrentFeedItemChanged(currentItem)[ gui\rss\rsswidget.cpp : 419 ]
# 43 qbittorrent.exe      0x00007ff60e72f833 QtPrivate::FunctorCall,QtPrivate::List,void,void (__cdecl ArticleListWidget::*)(RSS::Article * __ptr64) __ptr64>::call(f, o, arg)[ c:\qt\5.9\msvc2015_64\include\qtcore\qobjectdefs_impl.h : 136 ]
# 44 qbittorrent.exe      0x00007ff60e72f4dd QtPrivate::FunctionPointer::call,void>(f, o, arg)[ c:\qt\5.9\msvc2015_64\include\qtcore\qobjectdefs_impl.h : 169 ]
# 45 qbittorrent.exe      0x00007ff60e72bb36 QtPrivate::QSlotObject,void>::impl(which, this_, r, a, ret)[ c:\qt\5.9\msvc2015_64\include\qtcore\qobject_impl.h : 120 ]
# 46 Qt5Cored.dll         0x000000006ac4d598 QtPrivate::QContainerImplHelper::mid()
# 47 Qt5Cored.dll         0x000000006ac3c190 QtPrivate::QContainerImplHelper::mid()
# 48 Qt5Cored.dll         0x000000006ac3ba58 QtPrivate::QContainerImplHelper::mid()
# 49 Qt5Widgetsd.dll      0x000000006bc874ec QPixmapDropShadowFilter::setBlurRadius()
# 50 Qt5Widgetsd.dll      0x000000006bc8ba1e QPixmapDropShadowFilter::setBlurRadius()
# 51 Qt5Widgetsd.dll      0x000000006bc84b1b QPixmapDropShadowFilter::setBlurRadius()
# 52 Qt5Cored.dll         0x000000006ac3c2ea QtPrivate::QContainerImplHelper::mid()
# 53 Qt5Cored.dll         0x000000006ac3ba58 QtPrivate::QContainerImplHelper::mid()
# 54 Qt5Cored.dll         0x000000006ab711eb QtPrivate::QContainerImplHelper::mid()
# 55 Qt5Cored.dll         0x000000006ab73386 QtPrivate::QContainerImplHelper::mid()
# 56 Qt5Cored.dll         0x000000006ab6da66 QtPrivate::QContainerImplHelper::mid()
# 57 Qt5Cored.dll         0x000000006ac3c2ea QtPrivate::QContainerImplHelper::mid()
# 58 Qt5Cored.dll         0x000000006ac3ba58 QtPrivate::QContainerImplHelper::mid()
# 59 Qt5Cored.dll         0x000000006ad4cbe7 QtPrivate::QContainerImplHelper::mid()
# 60 Qt5Cored.dll         0x000000006ab47905 QtPrivate::QContainerImplHelper::mid()
# 61 Qt5Widgetsd.dll      0x000000006bc8af28 QPixmapDropShadowFilter::setBlurRadius()
# 62 Qt5Widgetsd.dll      0x000000006bc82013 QPixmapDropShadowFilter::setBlurRadius()
# 63 qbittorrent.exe      0x00007ff60e614af8 QTreeWidgetItem::`scalar deleting destructor'()
# 64 qbittorrent.exe      0x00007ff60e73151f FeedListWidget::handleItemAboutToBeRemoved(rssItem)[ gui\rss\feedlistwidget.cpp : 140 ]
# 65 qbittorrent.exe      0x00007ff60e72f833 QtPrivate::FunctorCall,QtPrivate::List,void,void (__cdecl ArticleListWidget::*)(RSS::Article * __ptr64) __ptr64>::call(f, o, arg)[ c:\qt\5.9\msvc2015_64\include\qtcore\qobjectdefs_impl.h : 136 ]
# 66 qbittorrent.exe      0x00007ff60e72f4dd QtPrivate::FunctionPointer::call,void>(f, o, arg)[ c:\qt\5.9\msvc2015_64\include\qtcore\qobjectdefs_impl.h : 169 ]
# 67 qbittorrent.exe      0x00007ff60e72bb36 QtPrivate::QSlotObject,void>::impl(which, this_, r, a, ret)[ c:\qt\5.9\msvc2015_64\include\qtcore\qobject_impl.h : 120 ]
# 68 Qt5Cored.dll         0x000000006ac4d598 QtPrivate::QContainerImplHelper::mid()
# 69 Qt5Cored.dll         0x000000006ac3c190 QtPrivate::QContainerImplHelper::mid()
# 70 Qt5Cored.dll         0x000000006ac3ba58 QtPrivate::QContainerImplHelper::mid()
# 71 qbittorrent.exe      0x00007ff60e75695e RSS::Session::itemAboutToBeRemoved(_t1)[ debug\moc_rss_session.cpp : 249 ]
# 72 qbittorrent.exe      0x00007ff60e58a296 RSS::Session::removeItem(itemPath, error)[ base\rss\rss_session.cpp : 208 ]
# 73 qbittorrent.exe      0x00007ff60e725db9 RSSWidget::deleteSelectedItems()[ gui\rss\rsswidget.cpp : 300 ]
# 74 qbittorrent.exe      0x00007ff60e72b921 QtPrivate::FunctorCall,QtPrivate::List,void,void (__cdecl RSSWidget::*)(void) __ptr64>::call(f, o, arg)[ c:\qt\5.9\msvc2015_64\include\qtcore\qobjectdefs_impl.h : 136 ]
# 75 qbittorrent.exe      0x00007ff60e7290ed QtPrivate::FunctionPointer::call,void>(f, o, arg)[ c:\qt\5.9\msvc2015_64\include\qtcore\qobjectdefs_impl.h : 169 ]
# 76 qbittorrent.exe      0x00007ff60e68ff46 QtPrivate::QSlotObject,void>::impl(which, this_, r, a, ret)[ c:\qt\5.9\msvc2015_64\include\qtcore\qobject_impl.h : 120 ]
# 77 Qt5Cored.dll         0x000000006ac4d598 QtPrivate::QContainerImplHelper::mid()
# 78 Qt5Cored.dll         0x000000006ac3c190 QtPrivate::QContainerImplHelper::mid()
# 79 Qt5Cored.dll         0x000000006ac3ba58 QtPrivate::QContainerImplHelper::mid()
# 80 Qt5Widgetsd.dll      0x000000006b7096bd QPixmapDropShadowFilter::setBlurRadius()
# 81 Qt5Widgetsd.dll      0x000000006b708ba2 QPixmapDropShadowFilter::setBlurRadius()
# 82 Qt5Widgetsd.dll      0x000000006ba03e83 QPixmapDropShadowFilter::setBlurRadius()
# 83 Qt5Widgetsd.dll      0x000000006ba03d70 QPixmapDropShadowFilter::setBlurRadius()
# 84 Qt5Widgetsd.dll      0x000000006b9fb98f QPixmapDropShadowFilter::setBlurRadius()
# 85 Qt5Widgetsd.dll      0x000000006b79692d QPixmapDropShadowFilter::setBlurRadius()
# 86 Qt5Widgetsd.dll      0x000000006b9fe036 QPixmapDropShadowFilter::setBlurRadius()
# 87 Qt5Widgetsd.dll      0x000000006b736f0e QPixmapDropShadowFilter::setBlurRadius()
# 88 Qt5Widgetsd.dll      0x000000006b73214c QPixmapDropShadowFilter::setBlurRadius()
# 89 qbittorrent.exe      0x00007ff60e4be83d Application::notify(receiver, event)[ app\application.cpp : 573 ]
# 90 Qt5Cored.dll         0x000000006abe5f66 QtPrivate::QContainerImplHelper::mid()
# 91 Qt5Cored.dll         0x000000006ad5545b QtPrivate::QContainerImplHelper::mid()
# 92 Qt5Widgetsd.dll      0x000000006b739603 QPixmapDropShadowFilter::setBlurRadius()
# 93 Qt5Widgetsd.dll      0x000000006b7e0383 QPixmapDropShadowFilter::setBlurRadius()
# 94 Qt5Widgetsd.dll      0x000000006b7df54a QPixmapDropShadowFilter::setBlurRadius()
# 95 Qt5Widgetsd.dll      0x000000006b736f0e QPixmapDropShadowFilter::setBlurRadius()
# 96 Qt5Widgetsd.dll      0x000000006b731943 QPixmapDropShadowFilter::setBlurRadius()
# 97 qbittorrent.exe      0x00007ff60e4be83d Application::notify(receiver, event)[ app\application.cpp : 573 ]
# 98 Qt5Cored.dll         0x000000006abe5f66 QtPrivate::QContainerImplHelper::mid()
# 99 Qt5Cored.dll         0x000000006ad5545b QtPrivate::QContainerImplHelper::mid()
#100 Qt5Guid.dll          0x00007ff88f55be5a QDragManager::self()
#101 Qt5Guid.dll          0x00007ff88f55e9d3 QDragManager::self()
#102 Qt5Guid.dll          0x00007ff88f519a15 QDragManager::self()
#103 qwindowsd.dll        0x00007ff89c6dfd92 qt_plugin_query_metadata()
#104 Qt5Cored.dll         0x000000006ac9f6d1 QtPrivate::QContainerImplHelper::mid()
#105 USER32.dll           0x00007ff8baa7bc50 CallWindowProcW()
#106 USER32.dll           0x00007ff8baa7b5cf DispatchMessageW()
#107 Qt5Cored.dll         0x000000006aca00db QtPrivate::QContainerImplHelper::mid()
#108 qwindowsd.dll        0x00007ff89c6dfd44 qt_plugin_query_metadata()
#109 Qt5Cored.dll         0x000000006abe0a88 QtPrivate::QContainerImplHelper::mid()
#110 Qt5Cored.dll         0x000000006abe0cce QtPrivate::QContainerImplHelper::mid()
#111 Qt5Widgetsd.dll      0x000000006b9f919f QPixmapDropShadowFilter::setBlurRadius()
#112 qbittorrent.exe      0x00007ff60e726781 RSSWidget::displayRSSListMenu(pos)[ gui\rss\rsswidget.cpp : 179 ]
#113 qbittorrent.exe      0x00007ff60e714ef0 QtPrivate::FunctorCall,QtPrivate::List > const & __ptr64>,void,void (__cdecl PluginSelectDlg::*)(QHash > const & __ptr64) __ptr64>::call(f, o, arg)[ c:\qt\5.9\msvc2015_64\include\qtcore\qobjectdefs_impl.h : 136 ]
#114 qbittorrent.exe      0x00007ff60e71399d QtPrivate::FunctionPointer > const & __ptr64) __ptr64>::call > const & __ptr64>,void>(f, o, arg)[ c:\qt\5.9\msvc2015_64\include\qtcore\qobjectdefs_impl.h : 169 ]
#115 qbittorrent.exe      0x00007ff60e7150f6 QtPrivate::QSlotObject > const & __ptr64) __ptr64,QtPrivate::List > const & __ptr64>,void>::impl(which, this_, r, a, ret)[ c:\qt\5.9\msvc2015_64\include\qtcore\qobject_impl.h : 120 ]
#116 Qt5Cored.dll         0x000000006ac4d598 QtPrivate::QContainerImplHelper::mid()
#117 Qt5Cored.dll         0x000000006ac3c190 QtPrivate::QContainerImplHelper::mid()
#118 Qt5Cored.dll         0x000000006ac3ba58 QtPrivate::QContainerImplHelper::mid()
#119 Qt5Widgetsd.dll      0x000000006b7967de QPixmapDropShadowFilter::setBlurRadius()
#120 Qt5Widgetsd.dll      0x000000006b7972b6 QPixmapDropShadowFilter::setBlurRadius()
#121 Qt5Widgetsd.dll      0x000000006b98d79f QPixmapDropShadowFilter::setBlurRadius()
#122 Qt5Widgetsd.dll      0x000000006ba7836c QPixmapDropShadowFilter::setBlurRadius()
#123 Qt5Widgetsd.dll      0x000000006bbbeb26 QPixmapDropShadowFilter::setBlurRadius()
#124 Qt5Widgetsd.dll      0x000000006bc2be60 QPixmapDropShadowFilter::setBlurRadius()
#125 Qt5Widgetsd.dll      0x000000006b72af25 QPixmapDropShadowFilter::setBlurRadius()
#126 Qt5Widgetsd.dll      0x000000006ba7d2dd QPixmapDropShadowFilter::setBlurRadius()
#127 Qt5Cored.dll         0x000000006abe6d54 QtPrivate::QContainerImplHelper::mid()
```