### PR TITLE
Fix crash in download piece bar

### DIFF
--- a/src/gui/properties/piecesbar.cpp
+++ b/src/gui/properties/piecesbar.cpp
@@ -50,7 +50,8 @@ namespace
     {
     public:
         PieceIndexToImagePos(const BitTorrent::TorrentInfo &torrentInfo, const QImage &image)
-            : m_bytesPerPixel {image.width() > 0 ? torrentInfo.totalSize() / image.width() : -1}
+            : m_bytesPerPixel {(image.width() > 0 && torrentInfo.totalSize() >= image.width())
+                ? torrentInfo.totalSize() / image.width() : -1}
             , m_torrentInfo {torrentInfo}
         {
             if ((m_bytesPerPixel > 0) && (m_bytesPerPixel < 10))


### PR DESCRIPTION
When torrent size is smaller than the image width, bytes per pixel was
set to zero and code was crashing. Set it to -1 instead, as we do when
image is empty. This will disable highliting, but our algorithm does not
work in this case anyway.