### PR TITLE
Check for localhost auth bypass before increasing failed auth counter

### DIFF
--- a/src/webui/abstractwebapplication.cpp
+++ b/src/webui/abstractwebapplication.cpp
@@ -322,7 +322,9 @@ void AbstractWebApplication::resetFailedAttempts()
 
 void AbstractWebApplication::increaseFailedAttempts()
 {
-    const int nb_fail = clientFailedAttempts_.value(env_.clientAddress, 0) + 1;
+    if (!isAuthNeeded()) {
+        const int nb_fail = clientFailedAttempts_.value(env_.clientAddress, 0) + 1;
+    }
 
     clientFailedAttempts_[env_.clientAddress] = nb_fail;
     if (nb_fail == MAX_AUTH_FAILED_ATTEMPTS) {


### PR DESCRIPTION
Don't increase the failed authentication attempts counter if "Bypass authentication for localhost" is enabled.

This prevents "Your IP address has been banned after too many failed authentication attempts" if apps accessing the WebUI API (from localhost) misbehave by trying to authenticate with an incorrect or blank username and password while localhost authentication is bypassed.

Fixes #6860 