### PR TITLE
Fix localhost is banned while auth bypass enabled. Closes #6860

### DIFF
--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -181,7 +181,7 @@ void WebApplication::action_public_login()
     bool equalUser = Utils::String::slowEquals(request().posts["username"].toUtf8(), pref->getWebUiUsername().toUtf8());
     bool equalPass = Utils::String::slowEquals(pass.toUtf8(), pref->getWebUiPassword().toUtf8());
 
-    if (equalUser && equalPass) {
+    if ((equalUser && equalPass) || !isAuthNeeded()) {
         sessionStart();
         print(QByteArray("Ok."), Http::CONTENT_TYPE_TXT);
     }


### PR DESCRIPTION
If "Bypass authentication for localhost" is enabled and a local application authenticates with the WebUI API using a blank or incorrect password, a ban should not occur.

Currently applications utilizing the WebUI API can attempt an authentication and still gain access to the API, but after five of these authentications localhost is banned, even though authentication for localhost has been bypassed.

Fixes #6860 