### PR TITLE
Fetch Favicons via google

### DIFF
--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -57,6 +57,8 @@
 #include "transferlistdelegate.h"
 #include "transferlistwidget.h"
 
+const QLatin1String GOOGLE_FAVICON_URL("https://www.google.com/s2/favicons?domain=");
+
 FiltersBase::FiltersBase(QWidget *parent, TransferListWidget *transferList)
     : QListWidget(parent)
     , transferList(transferList)
@@ -393,7 +395,10 @@ void TrackerFiltersList::downloadFavicon(const QString& url)
 
 void TrackerFiltersList::handleFavicoDownload(const QString& url, const QString& filePath)
 {
-    QString host = getHost(url);
+    QString host = url.startsWith(GOOGLE_FAVICON_URL)
+                            ? url.mid(GOOGLE_FAVICON_URL.size())
+                            : getHost(url);
+
     if (!m_trackers.contains(host)) {
         Utils::Fs::forceRemove(filePath);
         return;
@@ -420,8 +425,12 @@ void TrackerFiltersList::handleFavicoDownload(const QString& url, const QString&
 void TrackerFiltersList::handleFavicoFailure(const QString& url, const QString& error)
 {
     Q_UNUSED(error)
-    if (url.endsWith(".ico", Qt::CaseInsensitive))
+    if (url.endsWith(".ico", Qt::CaseInsensitive)) {
         downloadFavicon(url.left(url.size() - 4) + ".png");
+    }
+    else if (!url.startsWith(GOOGLE_FAVICON_URL)) {
+        downloadFavicon(GOOGLE_FAVICON_URL + getHost(url));
+    }
 }
 
 void TrackerFiltersList::showMenu(QPoint)


### PR DESCRIPTION
I don't know if that is useful but I was downloading a torrent from ubuntu.com and qBT didn't recognize its favicon that's why I thought about using Google to grab the favicon without worrying about details.
google will be used only in case of failure of getting {root}/favicon.ico or {root}/favicon.png

Time benchmarking: varies from 3 to 8 ms to fetch via Google.

the only drawback is that it returns a generic icon if there is no favicon.