### PR TITLE
Disable warnings in the bundled QtSingleAppplication and fix CMake builds in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,18 +62,12 @@ addons:
       - sourceline: 'ppa:adrozdoff/cmake'
     packages:
       # packages list: https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise
-      - autoconf
-      - automake
-      - cmake
-      - colormake
+      - [autoconf, automake, colormake]
+      - [cmake, ninja-build]
       - libssl-dev
-      - libboost-dev
-      - libboost-system-dev
+      - [libboost-dev, libboost-system-dev]
       - libtorrent-rasterbar-dev
-      # Qt 5.5.1
-      - qt55base
-      - qt55tools
-      - ninja-build
+      - [qt55base, qt55tools]
       - [gcc-6, g++-6]
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ addons:
       # Qt 5.5.1
       - qt55base
       - qt55tools
+      - ninja-build
 
 before_install:
   # only allow specific build for coverity scan, others will stop
@@ -143,7 +144,7 @@ install:
 
       if [ "$build_system" = "cmake" ]; then
         brew unlink cmake
-        brew install cmake
+        brew install cmake ninja
 
         brew install qt5
         brew link --force qt5
@@ -175,7 +176,8 @@ script:
       mkdir build
       cd build
       cmake -DGUI=${gui} -DCMAKE_INSTALL_PREFIX="$qbt_path" "$MY_CMAKE_OPENSSL_HINT" \
-        -G "Unix Makefiles" -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE ..
+        -G "Ninja" -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE ..
+      BUILD_TOOL="ninja"
     fi
     if [ "$build_system" = "qmake" ]; then
       ./bootstrap.sh && ./configure $qbtconf
@@ -184,8 +186,9 @@ script:
         sed -i "" -e "s/^\(CXX.*&&\).*$/\1 $CXX/" src/Makefile
         sed -i "" -e 's/^\(CXXFLAGS.*\)$/\1 -Wno-unused-local-typedefs -Wno-inconsistent-missing-override/' src/Makefile
       fi
+      BUILD_TOOL="make"
     fi
-  - make && make install
+  - $BUILD_TOOL && $BUILD_TOOL install
 
 after_success:
   - if [ "$gui" = true ]; then qbt_exe="qbittorrent" ; else qbt_exe="qbittorrent-nox" ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ addons:
   apt:
     sources:
       # sources list: https://github.com/travis-ci/apt-source-whitelist/blob/master/ubuntu.json
-      #- ubuntu-toolchain-r-test
+      - ubuntu-toolchain-r-test
       #- boost-latest
       - sourceline: 'ppa:qbittorrent-team/qbittorrent-stable'
       - sourceline: 'ppa:beineri/opt-qt551-trusty'
@@ -74,6 +74,7 @@ addons:
       - qt55base
       - qt55tools
       - ninja-build
+      - [gcc-6, g++-6]
 
 before_install:
   # only allow specific build for coverity scan, others will stop
@@ -95,6 +96,11 @@ before_install:
 
       # Qt 5
       PATH=/opt/qt55/bin:${PATH}
+
+      if [ "$build_system" = "cmake" ]; then
+          COMPILER_VERSION=6
+          export CXX="${CXX}-${COMPILER_VERSION}" CC="${CC}-${COMPILER_VERSION}"
+      fi
     fi
 
   # print settings

--- a/src/app/qtsingleapplication/CMakeLists.txt
+++ b/src/app/qtsingleapplication/CMakeLists.txt
@@ -20,6 +20,10 @@ add_library(qtsingleapplication ${QBT_QTSINGLEAPPLICATION_HEADERS} ${QBT_QTSINGL
 target_include_directories(qtsingleapplication INTERFACE "${qtsingleapplication_SOURCE_DIR}")
 target_link_qt_components(qtsingleapplication Network)
 
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    target_compile_options(qtsingleapplication PRIVATE "-w") # disable warning for 3rdparty code
+endif()
+
 if (GUI)
     target_link_qt_components(qtsingleapplication Widgets)
 endif (GUI)


### PR DESCRIPTION
This fixes CMake compilation with bundled QtSingleApplication, which is broken now due to the removed already -Wno-error=old-style-cast flag.