### PR TITLE
Fix keep alive duration was wrongly in milliseconds instead of seconds

### DIFF
--- a/src/base/http/server.cpp
+++ b/src/base/http/server.cpp
@@ -43,7 +43,7 @@
 
 #include "connection.h"
 
-static const int KEEP_ALIVE_DURATION = 7;  // seconds
+static const int KEEP_ALIVE_DURATION = 7 * 1000;  // milliseconds
 static const int CONNECTIONS_LIMIT = 500;
 static const int CONNECTIONS_SCAN_INTERVAL = 2;  // seconds
 


### PR DESCRIPTION
@sledgehammer999 
If there is going to be v3.3.15. Please include this in.