### PR TITLE
Add a Tags system to the GUI to expand torrent organization / filtering options. Closes #13.

### DIFF
--- a/src/base/bittorrent/addtorrentparams.h
+++ b/src/base/bittorrent/addtorrentparams.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <QSet>
 #include <QString>
 #include <QVector>
 
@@ -39,6 +40,7 @@ namespace BitTorrent
     {
         QString name;
         QString category;
+        QSet<QString> tags;
         QString savePath;
         bool disableTempPath = false; // e.g. for imported torrents
         bool sequential = false;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -44,6 +44,7 @@
 #endif
 #include <QNetworkConfigurationManager>
 #include <QPointer>
+#include <QSet>
 #include <QStringList>
 #include <QVector>
 #include <QWaitCondition>
@@ -223,6 +224,12 @@ namespace BitTorrent
         bool isSubcategoriesEnabled() const;
         void setSubcategoriesEnabled(bool value);
 
+        static bool isValidTag(const QString &tag);
+        QSet<QString> tags() const;
+        bool hasTag(const QString &tag) const;
+        bool addTag(const QString &tag);
+        bool removeTag(const QString &tag);
+
         // Torrent Management Mode subsystem (TMM)
         //
         // Each torrent can be either in Manual mode or in Automatic mode
@@ -400,6 +407,8 @@ namespace BitTorrent
         void handleTorrentShareLimitChanged(TorrentHandle *const torrent);
         void handleTorrentSavePathChanged(TorrentHandle *const torrent);
         void handleTorrentCategoryChanged(TorrentHandle *const torrent, const QString &oldCategory);
+        void handleTorrentTagAdded(TorrentHandle *const torrent, const QString &tag);
+        void handleTorrentTagRemoved(TorrentHandle *const torrent, const QString &tag);
         void handleTorrentSavingModeChanged(TorrentHandle *const torrent);
         void handleTorrentMetadataReceived(TorrentHandle *const torrent);
         void handleTorrentPaused(TorrentHandle *const torrent);
@@ -431,6 +440,8 @@ namespace BitTorrent
         void torrentFinishedChecking(BitTorrent::TorrentHandle *const torrent);
         void torrentSavePathChanged(BitTorrent::TorrentHandle *const torrent);
         void torrentCategoryChanged(BitTorrent::TorrentHandle *const torrent, const QString &oldCategory);
+        void torrentTagAdded(TorrentHandle *const torrent, const QString &tag);
+        void torrentTagRemoved(TorrentHandle *const torrent, const QString &tag);
         void torrentSavingModeChanged(BitTorrent::TorrentHandle *const torrent);
         void allTorrentsFinished();
         void metadataLoaded(const BitTorrent::TorrentInfo &info);
@@ -452,6 +463,8 @@ namespace BitTorrent
         void categoryAdded(const QString &categoryName);
         void categoryRemoved(const QString &categoryName);
         void subcategoriesSupportChanged();
+        void tagAdded(const QString &tag);
+        void tagRemoved(const QString &tag);
 
     private slots:
         void configureDeferred();
@@ -606,6 +619,7 @@ namespace BitTorrent
         CachedSettingValue<bool> m_isForceProxyEnabled;
         CachedSettingValue<bool> m_isProxyPeerConnectionsEnabled;
         CachedSettingValue<QVariantMap> m_storedCategories;
+        CachedSettingValue<QStringList> m_storedTags;
         CachedSettingValue<int> m_maxRatioAction;
         CachedSettingValue<QString> m_defaultSavePath;
         CachedSettingValue<QString> m_tempPath;
@@ -650,6 +664,7 @@ namespace BitTorrent
         QHash<QString, AddTorrentParams> m_downloadedTorrents;
         TorrentStatusReport m_torrentStatusReport;
         QStringMap m_categories;
+        QSet<QString> m_tags;
 
 #if LIBTORRENT_VERSION_NUM < 10100
         QMutex m_alertsMutex;

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -30,12 +30,13 @@
 #ifndef BITTORRENT_TORRENTHANDLE_H
 #define BITTORRENT_TORRENTHANDLE_H
 
-#include <QObject>
-#include <QString>
 #include <QDateTime>
-#include <QQueue>
-#include <QVector>
 #include <QHash>
+#include <QObject>
+#include <QQueue>
+#include <QSet>
+#include <QString>
+#include <QVector>
 
 #include <libtorrent/torrent_handle.hpp>
 #include <libtorrent/version.hpp>
@@ -93,6 +94,7 @@ namespace BitTorrent
         // for both new and resumed torrents
         QString name;
         QString category;
+        QSet<QString> tags;
         QString savePath;
         bool disableTempPath;
         bool sequential;
@@ -247,6 +249,12 @@ namespace BitTorrent
         QString category() const;
         bool belongsToCategory(const QString &category) const;
         bool setCategory(const QString &category);
+
+        QSet<QString> tags() const;
+        bool hasTag(const QString &tag) const;
+        bool addTag(const QString &tag);
+        bool removeTag(const QString &tag);
+        void removeAllTags();
 
         bool hasRootFolder() const;
 
@@ -445,6 +453,7 @@ namespace BitTorrent
         QString m_name;
         QString m_savePath;
         QString m_category;
+        QSet<QString> m_tags;
         bool m_hasSeedStatus;
         qreal m_ratioLimit;
         int m_seedingTimeLimit;

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -1064,6 +1064,16 @@ void Preferences::setConfirmTorrentRecheck(bool enabled)
     setValue("Preferences/Advanced/confirmTorrentRecheck", enabled);
 }
 
+bool Preferences::confirmRemoveAllTags() const
+{
+    return value("Preferences/Advanced/confirmRemoveAllTags", true).toBool();
+}
+
+void Preferences::setConfirmRemoveAllTags(bool enabled)
+{
+    setValue("Preferences/Advanced/confirmRemoveAllTags", enabled);
+}
+
 TrayIcon::Style Preferences::trayIconStyle() const
 {
     return TrayIcon::Style(value("Preferences/Advanced/TrayIconStyle", TrayIcon::NORMAL).toInt());
@@ -1325,6 +1335,16 @@ bool Preferences::getCategoryFilterState() const
 void Preferences::setCategoryFilterState(const bool checked)
 {
     setValue("TransferListFilters/CategoryFilterState", checked);
+}
+
+bool Preferences::getTagFilterState() const
+{
+    return value("TransferListFilters/TagFilterState", true).toBool();
+}
+
+void Preferences::setTagFilterState(const bool checked)
+{
+    setValue("TransferListFilters/TagFilterState", checked);
 }
 
 bool Preferences::getTrackerFilterState() const

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -260,6 +260,8 @@ public:
     void setConfirmTorrentDeletion(bool enabled);
     bool confirmTorrentRecheck() const;
     void setConfirmTorrentRecheck(bool enabled);
+    bool confirmRemoveAllTags() const;
+    void setConfirmRemoveAllTags(bool enabled);
     TrayIcon::Style trayIconStyle() const;
     void setTrayIconStyle(TrayIcon::Style style);
 
@@ -313,6 +315,7 @@ public:
     void setTorImportGeometry(const QByteArray &geometry);
     bool getStatusFilterState() const;
     bool getCategoryFilterState() const;
+    bool getTagFilterState() const;
     bool getTrackerFilterState() const;
     int getTransSelFilter() const;
     void setTransSelFilter(const int &index);
@@ -340,6 +343,7 @@ public:
 public slots:
     void setStatusFilterState(bool checked);
     void setCategoryFilterState(bool checked);
+    void setTagFilterState(bool checked);
     void setTrackerFilterState(bool checked);
 
     void apply();

--- a/src/base/torrentfilter.h
+++ b/src/base/torrentfilter.h
@@ -58,8 +58,10 @@ public:
         Errored
     };
 
+    // These mean any permutation, including no category / tag.
     static const QString AnyCategory;
     static const QStringSet AnyHash;
+    static const QString AnyTag; 
 
     static const TorrentFilter DownloadingTorrent;
     static const TorrentFilter SeedingTorrent;
@@ -71,14 +73,16 @@ public:
     static const TorrentFilter ErroredTorrent;
 
     TorrentFilter();
-    // category: pass empty string for "no category" or null string (QString()) for "any category"
-    TorrentFilter(const Type type, const QStringSet &hashSet = AnyHash, const QString &category = AnyCategory);
-    TorrentFilter(const QString &filter, const QStringSet &hashSet = AnyHash, const QString &category = AnyCategory);
+    // category & tags: pass empty string for uncategorized / untagged torrents.
+    // Pass null string (QString()) to disable filtering (i.e. all torrents).
+    TorrentFilter(const Type type, const QStringSet &hashSet = AnyHash, const QString &category = AnyCategory, const QString &tag = AnyTag);
+    TorrentFilter(const QString &filter, const QStringSet &hashSet = AnyHash, const QString &category = AnyCategory, const QString &tags = AnyTag);
 
     bool setType(Type type);
     bool setTypeByName(const QString &filter);
     bool setHashSet(const QStringSet &hashSet);
     bool setCategory(const QString &category);
+    bool setTag(const QString &tag);
 
     bool match(BitTorrent::TorrentHandle *const torrent) const;
 
@@ -86,9 +90,11 @@ private:
     bool matchState(BitTorrent::TorrentHandle *const torrent) const;
     bool matchHash(BitTorrent::TorrentHandle *const torrent) const;
     bool matchCategory(BitTorrent::TorrentHandle *const torrent) const;
+    bool matchTag(BitTorrent::TorrentHandle *const torrent) const;
 
     Type m_type;
     QString m_category;
+    QString m_tag;
     QStringSet m_hashSet;
 };
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -57,6 +57,9 @@ shutdownconfirmdlg.h
 speedlimitdlg.h
 statsdialog.h
 statusbar.h
+tagfiltermodel.h
+tagfilterproxymodel.h
+tagfilterwidget.h
 torrentcontentfiltermodel.h
 torrentcontentmodel.h
 torrentcontentmodelfile.h
@@ -98,6 +101,9 @@ shutdownconfirmdlg.cpp
 speedlimitdlg.cpp
 statsdialog.cpp
 statusbar.cpp
+tagfiltermodel.cpp
+tagfilterproxymodel.cpp
+tagfilterwidget.cpp
 torrentcontentfiltermodel.cpp
 torrentcontentmodel.cpp
 torrentcontentmodelfile.cpp

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -66,6 +66,7 @@ enum AdvSettingsRows
     RESOLVE_COUNTRIES,
     PROGRAM_NOTIFICATIONS,
     TORRENT_ADDED_NOTIFICATIONS,
+    CONFIRM_REMOVE_ALL_TAGS,
     DOWNLOAD_TRACKER_FAVICON,
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
     USE_ICON_THEME,
@@ -185,6 +186,9 @@ void AdvancedSettings::saveAdvancedSettings()
     pref->useSystemIconTheme(cb_use_icon_theme.isChecked());
 #endif
     pref->setConfirmTorrentRecheck(cb_confirm_torrent_recheck.isChecked());
+
+    pref->setConfirmRemoveAllTags(cb_confirm_remove_all_tags.isChecked());
+
     session->setAnnounceToAllTrackers(cb_announce_all_trackers.isChecked());
 }
 
@@ -377,6 +381,11 @@ void AdvancedSettings::loadAdvancedSettings()
     // Torrent recheck confirmation
     cb_confirm_torrent_recheck.setChecked(pref->confirmTorrentRecheck());
     addRow(CONFIRM_RECHECK_TORRENT, tr("Confirm torrent recheck"), &cb_confirm_torrent_recheck);
+
+    // Remove all tags confirmation
+    cb_confirm_remove_all_tags.setChecked(pref->confirmRemoveAllTags());
+    addRow(CONFIRM_REMOVE_ALL_TAGS, tr("Confirm remove all tags"), &cb_confirm_remove_all_tags);
+
     // Announce to all trackers
     cb_announce_all_trackers.setChecked(session->announceToAllTrackers());
     addRow(ANNOUNCE_ALL_TRACKERS, tr("Always announce to all trackers"), &cb_announce_all_trackers);

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -79,7 +79,7 @@ private:
     QSpinBox spin_cache, spin_save_resume_data_interval, outgoing_ports_min, outgoing_ports_max, spin_list_refresh, spin_maxhalfopen, spin_tracker_port, spin_cache_ttl;
     QCheckBox cb_os_cache, cb_recheck_completed, cb_resolve_countries, cb_resolve_hosts, cb_super_seeding,
               cb_program_notifications, cb_torrent_added_notifications, cb_tracker_favicon, cb_tracker_status,
-              cb_confirm_torrent_recheck, cb_listen_ipv6, cb_announce_all_trackers;
+              cb_confirm_torrent_recheck, cb_confirm_remove_all_tags, cb_listen_ipv6, cb_announce_all_trackers;
     QComboBox combo_iface, combo_iface_address;
     QLineEdit txtAnnounceIP;
 

--- a/src/gui/gui.pri
+++ b/src/gui/gui.pri
@@ -52,6 +52,9 @@ HEADERS += \
     $$PWD/categoryfiltermodel.h \
     $$PWD/categoryfilterproxymodel.h \
     $$PWD/categoryfilterwidget.h \
+    $$PWD/tagfiltermodel.h \
+    $$PWD/tagfilterproxymodel.h \
+    $$PWD/tagfilterwidget.h \
     $$PWD/banlistoptions.h \
     $$PWD/rss/rsswidget.h \
     $$PWD/rss/articlelistwidget.h \
@@ -103,6 +106,9 @@ SOURCES += \
     $$PWD/categoryfiltermodel.cpp \
     $$PWD/categoryfilterproxymodel.cpp \
     $$PWD/categoryfilterwidget.cpp \
+    $$PWD/tagfiltermodel.cpp \
+    $$PWD/tagfilterproxymodel.cpp \
+    $$PWD/tagfilterwidget.cpp \
     $$PWD/banlistoptions.cpp \
     $$PWD/rss/rsswidget.cpp \
     $$PWD/rss/articlelistwidget.cpp \

--- a/src/gui/tagfiltermodel.cpp
+++ b/src/gui/tagfiltermodel.cpp
@@ -1,0 +1,337 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2017  Tony Gregerson <tony.gregerson@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "tagfiltermodel.h"
+
+#include <QDebug>
+#include <QHash>
+#include <QIcon>
+
+#include "base/bittorrent/session.h"
+#include "base/bittorrent/torrenthandle.h"
+#include "guiiconprovider.h"
+
+namespace
+{
+    QString getSpecialAllTag()
+    {
+        static const QString *const ALL_TAG = new QString(" ");
+        Q_ASSERT(!BitTorrent::Session::isValidTag(*ALL_TAG));
+        return *ALL_TAG;
+    }
+
+    QString getSpecialUntaggedTag()
+    {
+        static const QString *const UNTAGGED_TAG = new QString("  ");
+        Q_ASSERT(!BitTorrent::Session::isValidTag(*UNTAGGED_TAG));
+        return *UNTAGGED_TAG;
+    }
+}
+
+class TagModelItem
+{
+public:
+    TagModelItem(const QString &tag, int torrentsCount = 0)
+        : m_tag(tag)
+        , m_torrentsCount(torrentsCount)
+    {
+    }
+
+    QString tag() const
+    {
+        return m_tag;
+    }
+
+    int torrentsCount() const
+    {
+        return m_torrentsCount;
+    }
+
+    void increaseTorrentsCount()
+    {
+        ++m_torrentsCount;
+    }
+
+    void decreaseTorrentsCount()
+    {
+        Q_ASSERT(m_torrentsCount > 0);
+        --m_torrentsCount;
+    }
+
+private:
+    const QString m_tag;
+    int m_torrentsCount;
+};
+
+TagFilterModel::TagFilterModel(QObject *parent)
+    : QAbstractListModel(parent)
+{
+    using Session = BitTorrent::Session;
+    auto session = Session::instance();
+
+    connect(session, &Session::tagAdded, this, &TagFilterModel::tagAdded);
+    connect(session, &Session::tagRemoved, this, &TagFilterModel::tagRemoved);
+    connect(session, &Session::torrentTagAdded, this, &TagFilterModel::torrentTagAdded);
+    connect(session, &Session::torrentTagRemoved, this, &TagFilterModel::torrentTagRemoved);
+    connect(session, &Session::torrentAdded, this, &TagFilterModel::torrentAdded);
+    connect(session, &Session::torrentAboutToBeRemoved, this, &TagFilterModel::torrentAboutToBeRemoved);
+    populate();
+}
+
+TagFilterModel::~TagFilterModel() = default;
+
+bool TagFilterModel::isSpecialItem(const QModelIndex &index)
+{
+    // the first two items are special items: 'All' and 'Untagged'
+    return (!index.parent().isValid() && (index.row() <= 1));
+}
+
+QVariant TagFilterModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid() || index.column() != 0)
+        return QVariant();
+
+    const int row = index.internalId();
+    Q_ASSERT(isValidRow(row));
+    const TagModelItem &item = m_tagItems[row];
+
+    switch (role) {
+    case Qt::DecorationRole:
+        return GuiIconProvider::instance()->getIcon("inode-directory");
+    case Qt::DisplayRole:
+        return QString(QLatin1String("%1 (%2)"))
+               .arg(tagDisplayName(item.tag())).arg(item.torrentsCount());
+    case Qt::UserRole:
+        return item.torrentsCount();
+    default:
+        return QVariant();
+    }
+}
+
+Qt::ItemFlags TagFilterModel::flags(const QModelIndex &index) const
+{
+    if (!index.isValid())
+        return 0;
+    return Qt::ItemIsEnabled | Qt::ItemIsSelectable;
+}
+
+QVariant TagFilterModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if ((orientation == Qt::Horizontal) && (role == Qt::DisplayRole))
+        if (section == 0)
+            return tr("Tags");
+    return QVariant();
+}
+
+QModelIndex TagFilterModel::index(int row, int, const QModelIndex &) const
+{
+    if (!isValidRow(row))
+        return QModelIndex();
+    return createIndex(row, 0, row);
+}
+
+int TagFilterModel::rowCount(const QModelIndex &parent) const
+{
+    if (!parent.isValid())
+        return m_tagItems.count();
+    return 0;
+}
+
+bool TagFilterModel::isValidRow(int row) const
+{
+    return (row >= 0) && (row < m_tagItems.size());
+}
+
+QModelIndex TagFilterModel::index(const QString &tag) const
+{
+    const int row = findRow(tag);
+    if (!isValidRow(row))
+        return QModelIndex();
+    return index(row, 0, QModelIndex());
+}
+
+QString TagFilterModel::tag(const QModelIndex &index) const
+{
+    if (!index.isValid())
+        return QString();
+    const int row = index.internalId();
+    Q_ASSERT(isValidRow(row));
+    return m_tagItems[row].tag();
+}
+
+void TagFilterModel::tagAdded(const QString &tag)
+{
+    const int row = m_tagItems.count();
+    beginInsertRows(QModelIndex(), row, row);
+    addToModel(tag, 0);
+    endInsertRows();
+}
+
+void TagFilterModel::tagRemoved(const QString &tag)
+{
+    QModelIndex i = index(tag);
+    beginRemoveRows(i.parent(), i.row(), i.row());
+    removeFromModel(i.row());
+    endRemoveRows();
+}
+
+void TagFilterModel::torrentTagAdded(BitTorrent::TorrentHandle *const torrent, const QString &tag)
+{
+    if (torrent->tags().count() == 1)
+        untaggedItem()->decreaseTorrentsCount();
+
+    const int row = findRow(tag);
+    Q_ASSERT(isValidRow(row));
+    TagModelItem &item = m_tagItems[row];
+
+    item.increaseTorrentsCount();
+    const QModelIndex i = index(row, 0, QModelIndex());
+    emit dataChanged(i, i);
+}
+
+void TagFilterModel::torrentTagRemoved(BitTorrent::TorrentHandle* const torrent, const QString &tag)
+{
+    Q_ASSERT(torrent->tags().count() >= 0);
+    if (torrent->tags().count() == 0)
+        untaggedItem()->increaseTorrentsCount();
+
+    const int row = findRow(tag);
+    Q_ASSERT(isValidRow(row));
+    TagModelItem &item = m_tagItems[row];
+
+    item.decreaseTorrentsCount();
+    const QModelIndex i = index(row, 0, QModelIndex());
+    emit dataChanged(i, i);
+}
+
+void TagFilterModel::torrentAdded(BitTorrent::TorrentHandle *const torrent)
+{
+    allTagsItem()->increaseTorrentsCount();
+
+    const QVector<TagModelItem *> items = findItems(torrent->tags());
+    if (items.isEmpty())
+        untaggedItem()->increaseTorrentsCount();
+
+    foreach (TagModelItem *item, items)
+        item->increaseTorrentsCount();
+}
+
+void TagFilterModel::torrentAboutToBeRemoved(BitTorrent::TorrentHandle *const torrent)
+{
+    allTagsItem()->decreaseTorrentsCount();
+
+    if (torrent->tags().isEmpty())
+        untaggedItem()->decreaseTorrentsCount();
+
+    foreach (TagModelItem *item, findItems(torrent->tags()))
+        item->decreaseTorrentsCount();
+}
+
+QString TagFilterModel::tagDisplayName(const QString &tag)
+{
+    if (tag == getSpecialAllTag())
+        return tr("All");
+    if (tag == getSpecialUntaggedTag())
+        return tr("Untagged");
+    return tag;
+}
+
+void TagFilterModel::populate()
+{
+    using Torrent = BitTorrent::TorrentHandle;
+
+    auto session = BitTorrent::Session::instance();
+    auto torrents = session->torrents();
+
+    // All torrents
+    addToModel(getSpecialAllTag(), torrents.count());
+
+    const int untaggedCount = std::count_if(torrents.begin(), torrents.end(),
+                                             [](Torrent *torrent) { return torrent->tags().isEmpty(); });
+    addToModel(getSpecialUntaggedTag(), untaggedCount);
+
+    foreach (const QString &tag, session->tags()) {
+        const int count = std::count_if(torrents.begin(), torrents.end(),
+                                        [tag](Torrent *torrent) { return torrent->hasTag(tag); });
+        addToModel(tag, count);
+    }
+}
+
+void TagFilterModel::addToModel(const QString &tag, int count)
+{
+    m_tagItems.append(TagModelItem(tag, count));
+}
+
+void TagFilterModel::removeFromModel(int row)
+{
+    Q_ASSERT(isValidRow(row));
+    m_tagItems.removeAt(row);
+}
+
+int TagFilterModel::findRow(const QString &tag) const
+{
+    for (int i = 0; i < m_tagItems.size(); ++i) {
+        if (m_tagItems[i].tag() == tag)
+            return i;
+    }
+    return -1;
+}
+
+TagModelItem *TagFilterModel::findItem(const QString &tag)
+{
+    const int row = findRow(tag);
+    if (!isValidRow(row))
+        return nullptr;
+    return &m_tagItems[row];
+}
+
+QVector<TagModelItem *> TagFilterModel::findItems(const QSet<QString> &tags)
+{
+    QVector<TagModelItem *> items;
+    items.reserve(tags.size());
+    foreach (const QString &tag, tags) {
+        TagModelItem *item = findItem(tag);
+        if (item)
+            items.push_back(item);
+        else
+            qWarning() << QString("Requested tag '%1' missing from the model.").arg(tag);
+    }
+    return items;
+}
+
+TagModelItem *TagFilterModel::allTagsItem()
+{
+    Q_ASSERT(m_tagItems.size() > 0);
+    return &m_tagItems[0];
+}
+
+TagModelItem *TagFilterModel::untaggedItem()
+{
+    Q_ASSERT(m_tagItems.size() > 1);
+    return &m_tagItems[1];
+}

--- a/src/gui/tagfiltermodel.h
+++ b/src/gui/tagfiltermodel.h
@@ -1,0 +1,88 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2017  Tony Gregerson <tony.gregerson@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#ifndef TAGFILTERMODEL_H
+#define TAGFILTERMODEL_H
+
+#include <QAbstractListModel>
+#include <QHash>
+#include <QModelIndex>
+#include <QSet>
+#include <QVector>
+
+namespace BitTorrent
+{
+    class TorrentHandle;
+}
+
+class TagModelItem;
+
+class TagFilterModel: public QAbstractListModel
+{
+    Q_OBJECT
+
+public:
+    explicit TagFilterModel(QObject *parent = nullptr);
+    ~TagFilterModel();
+
+    static bool isSpecialItem(const QModelIndex &index);
+
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
+    QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+
+    QModelIndex index(const QString &tag) const;
+    QString tag(const QModelIndex &index) const;
+
+private slots:
+    void tagAdded(const QString &tag);
+    void tagRemoved(const QString &tag);
+    void torrentTagAdded(BitTorrent::TorrentHandle *const torrent, const QString &tag);
+    void torrentTagRemoved(BitTorrent::TorrentHandle *const, const QString &tag);
+    void torrentAdded(BitTorrent::TorrentHandle *const torrent);
+    void torrentAboutToBeRemoved(BitTorrent::TorrentHandle *const torrent);
+
+private:
+    static QString tagDisplayName(const QString &tag);
+
+    void populate();
+    void addToModel(const QString &tag, int count);
+    void removeFromModel(int row);
+    bool isValidRow(int row) const;
+    int findRow(const QString &tag) const;
+    TagModelItem *findItem(const QString &tag);
+    QVector<TagModelItem *> findItems(const QSet<QString> &tags);
+    TagModelItem *allTagsItem();
+    TagModelItem *untaggedItem();
+
+    QList<TagModelItem> m_tagItems;  // Index corresponds to its row
+};
+
+#endif // TAGFILTERMODEL_H

--- a/src/gui/tagfilterproxymodel.h
+++ b/src/gui/tagfilterproxymodel.h
@@ -1,6 +1,6 @@
 /*
- * Bittorrent Client using Qt4 and libtorrent.
- * Copyright (C) 2013  Nick Tiskov
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2017  Tony Gregerson <tony.gregerson@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,42 +24,29 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : daymansmail@gmail.com
  */
 
-#ifndef TRANSFERLISTSORTMODEL_H
-#define TRANSFERLISTSORTMODEL_H
+#ifndef TAGFILTERPROXYMODEL_H
+#define TAGFILTERPROXYMODEL_H
 
 #include <QSortFilterProxyModel>
-#include "base/torrentfilter.h"
+#include <QString>
 
-class QStringList;
-
-class TransferListSortModel: public QSortFilterProxyModel
+class TagFilterProxyModel: public QSortFilterProxyModel
 {
-    Q_OBJECT
-
 public:
-    TransferListSortModel(QObject *parent = 0);
+    explicit TagFilterProxyModel(QObject *parent = nullptr);
 
-    void setStatusFilter(TorrentFilter::Type filter);
-    void setCategoryFilter(const QString &category);
-    void disableCategoryFilter();
-    void setTagFilter(const QString &tag);
-    void disableTagFilter();
-    void setTrackerFilter(const QStringList &hashes);
-    void disableTrackerFilter();
+    // TagFilterModel methods which we need to relay
+    QModelIndex index(const QString &tag) const;
+    QString tag(const QModelIndex &index) const;
 
-private:
-    bool lessThan(const QModelIndex &left, const QModelIndex &right) const;
-    bool lowerPositionThan(const QModelIndex &left, const QModelIndex &right) const;
-    bool dateLessThan(const int dateColumn, const QModelIndex &left, const QModelIndex &right, bool sortInvalidInBottom) const;
-    bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const;
-    bool matchFilter(int sourceRow, const QModelIndex &sourceParent) const;
+protected:
+    bool lessThan(const QModelIndex &left, const QModelIndex &right) const override;
 
 private:
-    TorrentFilter m_filter;
+    // we added another overload of index(), hence this using directive:
+    using QSortFilterProxyModel::index;
 };
 
-#endif // TRANSFERLISTSORTMODEL_H
+#endif // TAGFILTERPROXYMODEL_H

--- a/src/gui/tagfilterwidget.cpp
+++ b/src/gui/tagfilterwidget.cpp
@@ -1,0 +1,224 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2017  Tony Gregerson <tony.gregerson@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "tagfilterwidget.h"
+
+#include <QAction>
+#include <QDebug>
+#include <QHeaderView>
+#include <QLayout>
+#include <QMenu>
+#include <QMessageBox>
+
+#include "base/bittorrent/session.h"
+#include "base/utils/misc.h"
+#include "autoexpandabledialog.h"
+#include "guiiconprovider.h"
+#include "tagfiltermodel.h"
+#include "tagfilterproxymodel.h"
+
+namespace
+{
+    QString getTagFilter(const TagFilterProxyModel *const model, const QModelIndex &index)
+    {
+        QString tagFilter; // Defaults to All
+        if (index.isValid()) {
+            if (index.row() == 1)
+                tagFilter = "";  // Untagged
+            else if (index.row() > 1)
+                tagFilter = model->tag(index);
+        }
+        return tagFilter;
+    }
+}
+
+TagFilterWidget::TagFilterWidget(QWidget *parent)
+    : QTreeView(parent)
+{
+    TagFilterProxyModel *proxyModel = new TagFilterProxyModel(this);
+    proxyModel->setSortCaseSensitivity(Qt::CaseInsensitive);
+    proxyModel->setSourceModel(new TagFilterModel(this));
+    setModel(proxyModel);
+    setFrameShape(QFrame::NoFrame);
+    setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    setUniformRowHeights(true);
+    setHeaderHidden(true);
+    setIconSize(Utils::Misc::smallIconSize());
+#if defined(Q_OS_MAC)
+    setAttribute(Qt::WA_MacShowFocusRect, false);
+#endif
+    setContextMenuPolicy(Qt::CustomContextMenu);
+    sortByColumn(0, Qt::AscendingOrder);
+    setCurrentIndex(model()->index(0, 0));
+
+    connect(this, &TagFilterWidget::collapsed, this, &TagFilterWidget::callUpdateGeometry);
+    connect(this, &TagFilterWidget::expanded, this, &TagFilterWidget::callUpdateGeometry);
+    connect(this, &TagFilterWidget::customContextMenuRequested, this, &TagFilterWidget::showMenu);
+    connect(selectionModel(), &QItemSelectionModel::currentRowChanged, this
+            , &TagFilterWidget::onCurrentRowChanged);
+    connect(model(), &QAbstractItemModel::modelReset, this, &TagFilterWidget::callUpdateGeometry);
+}
+
+QString TagFilterWidget::currentTag() const
+{
+    QModelIndex current;
+    auto selectedRows = selectionModel()->selectedRows();
+    if (!selectedRows.isEmpty())
+        current = selectedRows.first();
+
+    return getTagFilter(static_cast<TagFilterProxyModel *>(model()), current);
+}
+
+void TagFilterWidget::onCurrentRowChanged(const QModelIndex &current, const QModelIndex &previous)
+{
+    Q_UNUSED(previous);
+
+    emit tagChanged(getTagFilter(static_cast<TagFilterProxyModel *>(model()), current));
+}
+
+void TagFilterWidget::showMenu(QPoint)
+{
+    QMenu menu(this);
+
+    QAction *addAct = menu.addAction(
+        GuiIconProvider::instance()->getIcon("list-add")
+        , tr("Add tag..."));
+    connect(addAct, &QAction::triggered, this, &TagFilterWidget::addTag);
+
+    auto selectedRows = selectionModel()->selectedRows();
+    if (!selectedRows.empty() && !TagFilterModel::isSpecialItem(selectedRows.first())) {
+        QAction *removeAct = menu.addAction(
+            GuiIconProvider::instance()->getIcon("list-remove")
+            , tr("Remove tag"));
+        connect(removeAct, &QAction::triggered, this, &TagFilterWidget::removeTag);
+    }
+
+    QAction *removeUnusedAct = menu.addAction(
+        GuiIconProvider::instance()->getIcon("list-remove")
+        , tr("Remove unused tags"));
+    connect(removeUnusedAct, &QAction::triggered, this, &TagFilterWidget::removeUnusedTags);
+
+    menu.addSeparator();
+
+    QAction *startAct = menu.addAction(
+        GuiIconProvider::instance()->getIcon("media-playback-start")
+        , tr("Resume torrents"));
+    connect(startAct, &QAction::triggered
+        , this, &TagFilterWidget::actionResumeTorrentsTriggered);
+
+    QAction *pauseAct = menu.addAction(
+        GuiIconProvider::instance()->getIcon("media-playback-pause")
+        , tr("Pause torrents"));
+    connect(pauseAct, &QAction::triggered, this
+        , &TagFilterWidget::actionPauseTorrentsTriggered);
+
+    QAction *deleteTorrentsAct = menu.addAction(
+        GuiIconProvider::instance()->getIcon("edit-delete")
+        , tr("Delete torrents"));
+    connect(deleteTorrentsAct, &QAction::triggered, this
+        , &TagFilterWidget::actionDeleteTorrentsTriggered);
+
+    menu.exec(QCursor::pos());
+}
+
+void TagFilterWidget::callUpdateGeometry()
+{
+    updateGeometry();
+}
+
+QSize TagFilterWidget::sizeHint() const
+{
+    return viewportSizeHint();
+}
+
+QSize TagFilterWidget::minimumSizeHint() const
+{
+    QSize size = sizeHint();
+    size.setWidth(6);
+    return size;
+}
+
+void TagFilterWidget::rowsInserted(const QModelIndex &parent, int start, int end)
+{
+    QTreeView::rowsInserted(parent, start, end);
+    updateGeometry();
+}
+
+QString TagFilterWidget::askTagName()
+{
+    bool ok = false;
+    QString tag = "";
+    bool invalid = true;
+    while (invalid) {
+        invalid = false;
+        tag = AutoExpandableDialog::getText(
+            this, tr("New Tag"), tr("Tag:"), QLineEdit::Normal, tag, &ok).trimmed();
+        if (ok && !tag.isEmpty()) {
+            if (!BitTorrent::Session::isValidTag(tag)) {
+                QMessageBox::warning(
+                    this, tr("Invalid tag name")
+                    , tr("Tag name '%1' is invalid").arg(tag));
+                invalid = true;
+            }
+        }
+    }
+
+    return ok ? tag : QString();
+}
+
+void TagFilterWidget::addTag()
+{
+    const QString tag = askTagName();
+    if (tag.isEmpty()) return;
+
+    if (BitTorrent::Session::instance()->tags().contains(tag))
+        QMessageBox::warning(this, tr("Tag exists"), tr("Tag name already exists."));
+    else
+        BitTorrent::Session::instance()->addTag(tag);
+}
+
+void TagFilterWidget::removeTag()
+{
+    auto selectedRows = selectionModel()->selectedRows();
+    if (!selectedRows.empty() && !TagFilterModel::isSpecialItem(selectedRows.first())) {
+        BitTorrent::Session::instance()->removeTag(
+            static_cast<TagFilterProxyModel *>(model())->tag(selectedRows.first()));
+        updateGeometry();
+    }
+}
+
+void TagFilterWidget::removeUnusedTags()
+{
+    auto session = BitTorrent::Session::instance();
+    foreach (const QString &tag, session->tags())
+        if (model()->data(static_cast<TagFilterProxyModel *>(model())->index(tag), Qt::UserRole) == 0)
+            session->removeTag(tag);
+    updateGeometry();
+}

--- a/src/gui/tagfilterwidget.h
+++ b/src/gui/tagfilterwidget.h
@@ -1,6 +1,6 @@
 /*
- * Bittorrent Client using Qt4 and libtorrent.
- * Copyright (C) 2013  Nick Tiskov
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2017  Tony Gregerson <tony.gregerson@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,42 +24,41 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : daymansmail@gmail.com
  */
 
-#ifndef TRANSFERLISTSORTMODEL_H
-#define TRANSFERLISTSORTMODEL_H
+#ifndef TAGFILTERWIDGET_H
+#define TAGFILTERWIDGET_H
 
-#include <QSortFilterProxyModel>
-#include "base/torrentfilter.h"
+#include <QTreeView>
 
-class QStringList;
-
-class TransferListSortModel: public QSortFilterProxyModel
+class TagFilterWidget: public QTreeView
 {
     Q_OBJECT
 
 public:
-    TransferListSortModel(QObject *parent = 0);
+    explicit TagFilterWidget(QWidget *parent = nullptr);
 
-    void setStatusFilter(TorrentFilter::Type filter);
-    void setCategoryFilter(const QString &category);
-    void disableCategoryFilter();
-    void setTagFilter(const QString &tag);
-    void disableTagFilter();
-    void setTrackerFilter(const QStringList &hashes);
-    void disableTrackerFilter();
+    QString currentTag() const;
+
+signals:
+    void tagChanged(const QString &tag);
+    void actionResumeTorrentsTriggered();
+    void actionPauseTorrentsTriggered();
+    void actionDeleteTorrentsTriggered();
+
+private slots:
+    void onCurrentRowChanged(const QModelIndex &current, const QModelIndex &previous);
+    void showMenu(QPoint);
+    void callUpdateGeometry();
+    void addTag();
+    void removeTag();
+    void removeUnusedTags();
 
 private:
-    bool lessThan(const QModelIndex &left, const QModelIndex &right) const;
-    bool lowerPositionThan(const QModelIndex &left, const QModelIndex &right) const;
-    bool dateLessThan(const int dateColumn, const QModelIndex &left, const QModelIndex &right, bool sortInvalidInBottom) const;
-    bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const;
-    bool matchFilter(int sourceRow, const QModelIndex &sourceParent) const;
-
-private:
-    TorrentFilter m_filter;
+    QSize sizeHint() const override;
+    QSize minimumSizeHint() const override;
+    void rowsInserted(const QModelIndex &parent, int start, int end) override;
+    QString askTagName();
 };
 
-#endif // TRANSFERLISTSORTMODEL_H
+#endif // TAGFILTERWIDGET_H

--- a/src/gui/torrentmodel.cpp
+++ b/src/gui/torrentmodel.cpp
@@ -105,6 +105,7 @@ QVariant TorrentModel::headerData(int section, Qt::Orientation orientation, int 
             case TR_RATIO: return tr("Ratio", "Share ratio");
             case TR_ETA: return tr("ETA", "i.e: Estimated Time of Arrival / Time left");
             case TR_CATEGORY: return tr("Category");
+            case TR_TAGS: return tr("Tags");
             case TR_ADD_DATE: return tr("Added On", "Torrent was added to transfer list on 01/01/2010 08:00");
             case TR_SEED_DATE: return tr("Completed On", "Torrent was completed on 01/01/2010 08:00");
             case TR_TRACKER: return tr("Tracker");
@@ -198,6 +199,11 @@ QVariant TorrentModel::data(const QModelIndex &index, int role) const
         return torrent->realRatio();
     case TR_CATEGORY:
         return torrent->category();
+    case TR_TAGS: {
+            QStringList tagsList = torrent->tags().toList();
+            tagsList.sort();
+            return tagsList.join(", ");
+        }
     case TR_ADD_DATE:
         return torrent->addedTime();
     case TR_SEED_DATE:

--- a/src/gui/torrentmodel.h
+++ b/src/gui/torrentmodel.h
@@ -62,6 +62,7 @@ public:
         TR_ETA,
         TR_RATIO,
         TR_CATEGORY,
+        TR_TAGS,
         TR_ADD_DATE,
         TR_SEED_DATE,
         TR_TRACKER,

--- a/src/gui/transferlistfilterswidget.h
+++ b/src/gui/transferlistfilterswidget.h
@@ -136,6 +136,7 @@ private:
 };
 
 class CategoryFilterWidget;
+class TagFilterWidget;
 
 class TransferListFiltersWidget: public QFrame
 {
@@ -160,13 +161,16 @@ signals:
 
 private slots:
     void onCategoryFilterStateChanged(bool enabled);
+    void onTagFilterStateChanged(bool enabled);
 
 private:
     void toggleCategoryFilter(bool enabled);
+    void toggleTagFilter(bool enabled);
 
     TransferListWidget *m_transferList;
     TrackerFiltersList *m_trackerFilters;
     CategoryFilterWidget *m_categoryFilterWidget;
+    TagFilterWidget *m_tagFilterWidget;
 };
 
 #endif // TRANSFERLISTFILTERSWIDGET_H

--- a/src/gui/transferlistsortmodel.cpp
+++ b/src/gui/transferlistsortmodel.cpp
@@ -59,6 +59,18 @@ void TransferListSortModel::disableCategoryFilter()
         invalidateFilter();
 }
 
+void TransferListSortModel::setTagFilter(const QString &tag)
+{
+    if (m_filter.setTag(tag))
+        invalidateFilter();
+}
+
+void TransferListSortModel::disableTagFilter()
+{
+    if (m_filter.setTag(TorrentFilter::AnyTag))
+        invalidateFilter();
+}
+
 void TransferListSortModel::setTrackerFilter(const QStringList &hashes)
 {
     if (m_filter.setHashSet(hashes.toSet()))
@@ -75,6 +87,7 @@ bool TransferListSortModel::lessThan(const QModelIndex &left, const QModelIndex 
 {
     switch (sortColumn()) {
     case TorrentModel::TR_CATEGORY:
+    case TorrentModel::TR_TAGS:
     case TorrentModel::TR_NAME: {
         QVariant vL = left.data();
         QVariant vR = right.data();

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -31,6 +31,7 @@
 #ifndef TRANSFERLISTWIDGET_H
 #define TRANSFERLISTWIDGET_H
 
+#include <functional>
 #include <QTreeView>
 
 namespace BitTorrent
@@ -60,6 +61,9 @@ public:
 
 public slots:
     void setSelectionCategory(QString category);
+    void addSelectionTag(const QString &tag);
+    void removeSelectionTag(const QString &tag);
+    void clearSelectionTags();
     void setSelectedTorrentsLocation();
     void pauseAllTorrents();
     void resumeAllTorrents();
@@ -89,6 +93,7 @@ public slots:
     void applyNameFilter(const QString& name);
     void applyStatusFilter(int f);
     void applyCategoryFilter(QString category);
+    void applyTagFilter(const QString &tag);
     void applyTrackerFilterAll();
     void applyTrackerFilter(const QStringList &hashes);
     void previewFile(QString filePath);
@@ -116,6 +121,11 @@ signals:
 
 private:
     void wheelEvent(QWheelEvent *event) override;
+    void askAddTagsForSelection();
+    void askRemoveTagsForSelection();
+    void confirmRemoveAllTagsForSelection();
+    QStringList askTagsForSelection(const QString &dialogTitle);
+    void applyToSelectedTorrents(const std::function<void (BitTorrent::TorrentHandle *const)> &fn);
 
     TransferListDelegate *listDelegate;
     TorrentModel *listModel;


### PR DESCRIPTION
This change adds a Tags system to the GUI. Tags are a set of user defined text strings that serve as arbitrary metadata for the purpose of organizing and filtering torrents. 

Tags are conceptually similar to the existing Categories system, with the following differences:

- A torrent can have any number of Tags, whereas only one Category is allowed.
- Tags are unstructured; Categories have a tree structure.
- Tags are not linked into other torrent management systems, like save path assignment. Hence they can be added & removed without any complex side effects.

The motivation for this system was to allow more flexible torrent organization in the GUI - for example, being able to assign multiple filterable labels to a single torrent. This is difficult to do with the existing Categories system, as Categories are integrated with the system for determining save paths. Since a torrent only can only have one save path, the behavior with multiple Categories would be un-intuitive.

The idea of having a single structured category with multiple unstructured tags should be familiar to many users, as it is an organizational pattern commonly employed within torrent trackers and in other popular services like Steam.

**Other designs considered:**
uTorrent addresses this problem with the concept of a Primary Label (analogous to a Category). A torrent may have multiple labels, but only one is considered 'primary'. Only the Primary Label is used in determining unary torrent attributes like the save path, and the others are ignored. Ultimately I discarded this idea, as I felt that it was confusing for users. Having separate category and tags systems is a more established and prevalent organizational pattern.

Additional discussion on designs can be found in the related feature request: https://github.com/qbittorrent/qBittorrent/issues/13

**Implementation**
Since this is my first PR on this project, I aimed for consistency with the existing codebase. I copied the implementation of Categories, and added / removed code as appropriate to suit the different properties of Tags.

**Caveats**
- This PR only adds Tags support in the main GUI, not the Web UI.
- Only simply filtering by a single tag is currently supported, although I would like to add more sophisticated multi-tag filtering with AND / OR logic at some point in the future.

**GUI Changes**

![qbt-tags-select](https://cloud.githubusercontent.com/assets/6699718/26808077/124f6842-4a20-11e7-83bb-c0594c39eb7d.png)

A new Tags widget is added to the left side of the UI. It behaves identically to the Categories widget.

![qbt-tags-menu](https://cloud.githubusercontent.com/assets/6699718/26808089/216f11a6-4a20-11e7-9b59-324f39ddfa56.png)

The menu from the torrent list is slightly tweaked. You can choose to toggle individual tags, or add / remove multiple tags.

![qbt-tags-add](https://cloud.githubusercontent.com/assets/6699718/26808094/2a1104ea-4a20-11e7-8278-de28ffc8587b.png)

To make adding a bunch of tags less tedious, the dialog option allows you to add or remove multiple tags in one operation.

![qbt-tags-remove-confirmation](https://cloud.githubusercontent.com/assets/6699718/26808098/301d5528-4a20-11e7-8ad1-821e56f829ee.png)

To avoid accidents with the 'Remove All Tags' option, it uses a confirmation dialog. This behavior can be disabled in the Advanced Options if desired.
