### PR TITLE
Fix crash in ArticleListWidget. Closes #6896

### DIFF
--- a/src/gui/rss/articlelistwidget.cpp
+++ b/src/gui/rss/articlelistwidget.cpp
@@ -94,6 +94,8 @@ void ArticleListWidget::handleArticleAdded(RSS::Article *rssArticle)
 void ArticleListWidget::handleArticleRead(RSS::Article *rssArticle)
 {
     auto item = mapRSSArticle(rssArticle);
+    if (!item) return;
+
     item->setData(Qt::ForegroundRole, QPalette().color(QPalette::Inactive, QPalette::WindowText));
     item->setData(Qt::DecorationRole, QIcon(":/icons/sphere.png"));
 


### PR DESCRIPTION
ArticleListWidget::handleArticleList() can be called inside
ArticleListWidget::handleArticleAboutToBeRemoved() and list widget
item can be removed at this point. Now we checking for it existence.
Closes #6896.