### PR TITLE
Make the announce url working with every selected torrents. Closes #2428

### DIFF
--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -134,7 +134,7 @@ PropertiesWidget::PropertiesWidget(QWidget *parent, MainWindow *main_window, Tra
     pieces_availability->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
     // Tracker list
-    trackerList = new TrackerList(this);
+    trackerList = new TrackerList(transferList, this);
     m_ui->trackerUpButton->setIcon(GuiIconProvider::instance()->getIcon("go-up"));
     m_ui->trackerUpButton->setIconSize(Utils::Misc::smallIconSize());
     m_ui->trackerDownButton->setIcon(GuiIconProvider::instance()->getIcon("go-down"));

--- a/src/gui/properties/trackerlist.h
+++ b/src/gui/properties/trackerlist.h
@@ -51,6 +51,7 @@ class TrackerList: public QTreeWidget {
   Q_DISABLE_COPY(TrackerList)
 
 private:
+  TransferListWidget *transferList;
   PropertiesWidget *properties;
   QHash<QString, QTreeWidgetItem*> tracker_items;
   QTreeWidgetItem* dht_item;
@@ -61,7 +62,7 @@ private:
   QShortcut *copyHotkey;
 
 public:
-  TrackerList(PropertiesWidget *properties);
+  TrackerList(TransferListWidget *transferList, PropertiesWidget *properties);
   ~TrackerList();
 
 protected:

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -57,6 +57,7 @@ public:
     TransferListWidget(QWidget *parent, MainWindow *main_window);
     ~TransferListWidget();
     TorrentModel* getSourceModel() const;
+    QList<BitTorrent::TorrentHandle *> getSelectedTorrents() const;
 
 public slots:
     void setSelectionCategory(QString category);
@@ -98,7 +99,6 @@ protected:
     QModelIndex mapToSource(const QModelIndex &index) const;
     QModelIndex mapFromSource(const QModelIndex &index) const;
     bool loadSettings();
-    QList<BitTorrent::TorrentHandle *> getSelectedTorrents() const;
 
 protected slots:
     void torrentDoubleClicked();


### PR DESCRIPTION
I am getting the list of selected torrent from the transferlist widget instead of the property one.

If this commit is accepted, I will do the same with the suppression and addition of announce urls.