### PR TITLE
Various macOS UI improvements

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,12 +17,21 @@ if (GUI)
     if (WIN32)
         list (APPEND QBT_QT_COMPONENTS WinExtras)
     endif(WIN32)
+    if (APPLE)
+        list (APPEND QBT_GUI_OPTIONAL_LINK_LIBRARIES objc)
+        list (APPEND QBT_QT_COMPONENTS MacExtras)
+    endif (APPLE)
 endif (GUI)
 if (DBUS)
     list (APPEND QBT_QT_COMPONENTS DBus)
 endif (DBUS)
 find_package(Qt5 5.5.1 COMPONENTS ${QBT_QT_COMPONENTS} REQUIRED)
 
+if (GUI AND APPLE)
+    # Fix MOC inability to detect macOS. This seems to only affect cmake.
+    # Relevant issue: https://bugreports.qt.io/browse/QTBUG-58325
+    set(CMAKE_AUTOMOC_MOC_OPTIONS ${CMAKE_AUTOMOC_MOC_OPTIONS} -DQ_OS_MAC)
+endif ()
 
 set(CMAKE_AUTOMOC True)
 list(APPEND CMAKE_AUTORCC_OPTIONS -compress 9 -threshold 5)

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -208,14 +208,15 @@ int main(int argc, char *argv[])
 #endif
 
 #if defined(Q_OS_MAC)
-{
-    // Since Apple made difficult for users to set PATH, we set here for convenience.
-    // Users are supposed to install Homebrew Python for search function.
-    // For more info see issue #5571.
-    QByteArray path = "/usr/local/bin:";
-    path += qgetenv("PATH");
-    qputenv("PATH", path.constData());
-}
+        // Since Apple made difficult for users to set PATH, we set here for convenience.
+        // Users are supposed to install Homebrew Python for search function.
+        // For more info see issue #5571.
+        QByteArray path = "/usr/local/bin:";
+        path += qgetenv("PATH");
+        qputenv("PATH", path.constData());
+        
+        // On OS X the standard is to not show icons in the menus
+        app->setAttribute(Qt::AA_DontShowIconsInMenus);
 #endif
 
 #ifndef DISABLE_GUI

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -161,6 +161,9 @@ void Preferences::setHideZeroComboValues(int n)
     setValue("Preferences/General/HideZeroComboValues", n);
 }
 
+// In Mac OS X the dock is sufficient for our needs so we disable the sys tray functionality.
+// See extensive discussion in https://github.com/qbittorrent/qBittorrent/pull/3018
+#ifndef Q_OS_MAC
 bool Preferences::systrayIntegration() const
 {
     return value("Preferences/General/SystrayEnabled", true).toBool();
@@ -169,26 +172,6 @@ bool Preferences::systrayIntegration() const
 void Preferences::setSystrayIntegration(bool enabled)
 {
     setValue("Preferences/General/SystrayEnabled", enabled);
-}
-
-bool Preferences::isToolbarDisplayed() const
-{
-    return value("Preferences/General/ToolbarDisplayed", true).toBool();
-}
-
-void Preferences::setToolbarDisplayed(bool displayed)
-{
-    setValue("Preferences/General/ToolbarDisplayed", displayed);
-}
-
-bool Preferences::isStatusbarDisplayed() const
-{
-    return value("Preferences/General/StatusbarDisplayed", true).toBool();
-}
-
-void Preferences::setStatusbarDisplayed(bool displayed)
-{
-    setValue("Preferences/General/StatusbarDisplayed", displayed);
 }
 
 bool Preferences::minimizeToTray() const
@@ -209,6 +192,27 @@ bool Preferences::closeToTray() const
 void Preferences::setCloseToTray(bool b)
 {
     setValue("Preferences/General/CloseToTray", b);
+}
+#endif
+
+bool Preferences::isToolbarDisplayed() const
+{
+    return value("Preferences/General/ToolbarDisplayed", true).toBool();
+}
+
+void Preferences::setToolbarDisplayed(bool displayed)
+{
+    setValue("Preferences/General/ToolbarDisplayed", displayed);
+}
+
+bool Preferences::isStatusbarDisplayed() const
+{
+    return value("Preferences/General/StatusbarDisplayed", true).toBool();
+}
+
+void Preferences::setStatusbarDisplayed(bool displayed)
+{
+    setValue("Preferences/General/StatusbarDisplayed", displayed);
 }
 
 bool Preferences::startMinimized() const
@@ -1084,6 +1088,7 @@ void Preferences::setConfirmRemoveAllTags(bool enabled)
     setValue("Preferences/Advanced/confirmRemoveAllTags", enabled);
 }
 
+#ifndef Q_OS_MAC
 TrayIcon::Style Preferences::trayIconStyle() const
 {
     return TrayIcon::Style(value("Preferences/Advanced/TrayIconStyle", TrayIcon::NORMAL).toInt());
@@ -1093,6 +1098,7 @@ void Preferences::setTrayIconStyle(TrayIcon::Style style)
 {
     setValue("Preferences/Advanced/TrayIconStyle", style);
 }
+#endif
 
 // Stuff that don't appear in the Options GUI but are saved
 // in the same file.

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -115,16 +115,10 @@ public:
     void setHideZeroValues(bool b);
     int getHideZeroComboValues() const;
     void setHideZeroComboValues(int n);
-    bool systrayIntegration() const;
-    void setSystrayIntegration(bool enabled);
-    bool isToolbarDisplayed() const;
-    void setToolbarDisplayed(bool displayed);
     bool isStatusbarDisplayed() const;
     void setStatusbarDisplayed(bool displayed);
-    bool minimizeToTray() const;
-    void setMinimizeToTray(bool b);
-    bool closeToTray() const;
-    void setCloseToTray(bool b);
+    bool isToolbarDisplayed() const;
+    void setToolbarDisplayed(bool displayed);
     bool startMinimized() const;
     void setStartMinimized(bool b);
     bool isSplashScreenDisabled() const;
@@ -264,8 +258,16 @@ public:
     void setConfirmTorrentRecheck(bool enabled);
     bool confirmRemoveAllTags() const;
     void setConfirmRemoveAllTags(bool enabled);
+#ifndef Q_OS_MAC
+    bool systrayIntegration() const;
+    void setSystrayIntegration(bool enabled);
+    bool minimizeToTray() const;
+    void setMinimizeToTray(bool b);
+    bool closeToTray() const;
+    void setCloseToTray(bool b);
     TrayIcon::Style trayIconStyle() const;
     void setTrayIconStyle(TrayIcon::Style style);
+#endif
 
     // Stuff that don't appear in the Options GUI but are saved
     // in the same file.

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -153,3 +153,7 @@ target_link_libraries(qbt_gui qbt_lineedit qbt_powermanagement qbt_rss qbt_prope
 if(WIN32)
     target_link_libraries(qbt_gui Qt5::WinExtras)
 endif(WIN32)
+
+if (APPLE)
+    target_link_libraries(qbt_gui Qt5::MacExtras)
+endif()

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -214,7 +214,11 @@ void AddNewTorrentDialog::show(QString source, const BitTorrent::AddTorrentParam
             ok = dlg->loadTorrent(source);
 
         if (ok)
+#ifdef Q_OS_MAC
+            dlg->exec();
+#else
             dlg->open();
+#endif
         else
             delete dlg;
     }

--- a/src/gui/categoryfilterwidget.cpp
+++ b/src/gui/categoryfilterwidget.cpp
@@ -71,8 +71,11 @@ CategoryFilterWidget::CategoryFilterWidget(QWidget *parent)
     setUniformRowHeights(true);
     setHeaderHidden(true);
     setIconSize(Utils::Misc::smallIconSize());
-#if defined(Q_OS_MAC)
+#ifdef Q_OS_MAC
     setAttribute(Qt::WA_MacShowFocusRect, false);
+    m_defaultIndentation = indentation();
+    if (!BitTorrent::Session::instance()->isSubcategoriesEnabled())
+        setIndentation(0);
 #endif
     setContextMenuPolicy(Qt::CustomContextMenu);
     sortByColumn(0, Qt::AscendingOrder);
@@ -154,6 +157,12 @@ void CategoryFilterWidget::showMenu(QPoint)
 
 void CategoryFilterWidget::callUpdateGeometry()
 {
+#ifdef Q_OS_MAC
+    if (!BitTorrent::Session::instance()->isSubcategoriesEnabled())
+        setIndentation(0);
+    else
+        setIndentation(m_defaultIndentation);
+#endif
     updateGeometry();
 }
 

--- a/src/gui/categoryfilterwidget.h
+++ b/src/gui/categoryfilterwidget.h
@@ -57,4 +57,8 @@ private:
     QSize minimumSizeHint() const override;
     void rowsInserted(const QModelIndex &parent, int start, int end) override;
     QString askCategoryName();
+
+#ifdef Q_OS_MAC
+    int m_defaultIndentation;
+#endif
 };

--- a/src/gui/executionlog.cpp
+++ b/src/gui/executionlog.cpp
@@ -47,8 +47,10 @@ ExecutionLog::ExecutionLog(QWidget *parent, const Log::MsgTypes &types)
 
     m_msgList = new LogListWidget(MAX_LOG_MESSAGES, Log::MsgTypes(types));
 
+#ifndef Q_OS_MAC
     ui->tabConsole->setTabIcon(0, GuiIconProvider::instance()->getIcon("view-calendar-journal"));
     ui->tabConsole->setTabIcon(1, GuiIconProvider::instance()->getIcon("view-filter"));
+#endif
     ui->tabGeneral->layout()->addWidget(m_msgList);
     ui->tabBan->layout()->addWidget(m_peerList);
 

--- a/src/gui/hidabletabwidget.h
+++ b/src/gui/hidabletabwidget.h
@@ -43,13 +43,22 @@ public:
     }
 
 protected:
-    void tabInserted(int index)
+#ifdef Q_OS_MAC
+    void paintEvent(QPaintEvent* event) override
+    {
+        // Hide the pane for macintosh style
+        if (!style()->inherits("QMacStyle"))
+            QTabWidget::paintEvent(event);
+    }
+#endif
+
+    void tabInserted(int index) override
     {
         QTabWidget::tabInserted(index);
         tabBar()->setVisible(count() != 1);
     }
 
-    void tabRemoved(int index)
+    void tabRemoved(int index) override
     {
         //QTabWidget::tabInserted(index);
         QTabWidget::tabRemoved(index);

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -32,8 +32,11 @@
 #define MAINWINDOW_H
 
 #include <QMainWindow>
-#include <QSystemTrayIcon>
 #include <QPointer>
+
+#ifndef Q_OS_MAC
+#include <QSystemTrayIcon>
+#endif
 
 class QCloseEvent;
 class QFileSystemWatcher;
@@ -102,15 +105,11 @@ public:
     void showNotificationBaloon(QString title, QString msg) const;
 
 private slots:
-    void toggleVisibility(const QSystemTrayIcon::ActivationReason reason = QSystemTrayIcon::Trigger);
-
     void balloonClicked();
     void writeSettings();
     void readSettings();
-    void createTrayIcon();
     void fullDiskError(BitTorrent::TorrentHandle *const torrent, QString msg) const;
     void handleDownloadFromUrlFailure(QString, QString) const;
-    void createSystrayDelayed();
     void tabChanged(int newTab);
     void defineUILockPassword();
     void clearUILockPassword();
@@ -118,7 +117,6 @@ private slots:
     void notifyOfUpdate(QString);
     void showConnectionSettings();
     void minimizeWindow();
-    void updateTrayIconMenu();
     // Keyboard shortcuts
     void createKeyboardShortcuts();
     void displayTransferTab() const;
@@ -191,7 +189,15 @@ private slots:
     void toolbarFollowSystem();
 
 private:
+#ifdef Q_OS_MAC
+    void setupDockClickHandler();
+#else
+    void toggleVisibility(const QSystemTrayIcon::ActivationReason reason = QSystemTrayIcon::Trigger);
+    void createTrayIcon();
+    void createSystrayDelayed();
+    void updateTrayIconMenu();
     QIcon getSystrayIcon() const;
+#endif
 #ifdef Q_OS_WIN
     bool addPythonPathToEnv();
     void installPython();
@@ -221,8 +227,10 @@ private:
     QPointer<StatsDialog> m_statsDlg;
     QPointer<TorrentCreatorDlg> m_createTorrentDlg;
     QPointer<downloadFromURL> m_downloadFromURLDialog;
+#ifndef Q_OS_MAC
     QPointer<QSystemTrayIcon> m_systrayIcon;
     QPointer<QTimer> m_systrayCreator;
+#endif
     QPointer<QMenu> m_trayIconMenu;
     TransferListWidget *m_transferListWidget;
     TransferListFiltersWidget *m_transferListFiltersWidget;

--- a/src/gui/optionsdlg.h
+++ b/src/gui/optionsdlg.h
@@ -114,9 +114,11 @@ private:
     static QString languageToLocalizedString(const QLocale &locale);
     // General options
     QString getLocale() const;
+#ifndef Q_OS_MAC
     bool systrayIntegration() const;
     bool minimizeToTray() const;
     bool closeToTray() const;
+#endif
     bool startMinimized() const;
     bool isSlashScreenDisabled() const;
     bool preventFromSuspend() const;

--- a/src/gui/properties/proptabbar.cpp
+++ b/src/gui/properties/proptabbar.cpp
@@ -43,34 +43,58 @@ PropTabBar::PropTabBar(QWidget *parent) :
   setSpacing(3);
   m_btnGroup = new QButtonGroup(this);
   // General tab
-  QPushButton *main_infos_button = new QPushButton(GuiIconProvider::instance()->getIcon("document-properties"), tr("General"), parent);
+  QPushButton *main_infos_button = new QPushButton(
+#ifndef Q_OS_MAC
+    GuiIconProvider::instance()->getIcon("document-properties"),
+#endif
+    tr("General"), parent);
   main_infos_button->setShortcut(Qt::ALT + Qt::Key_G);
   addWidget(main_infos_button);
   m_btnGroup->addButton(main_infos_button, MAIN_TAB);
   // Trackers tab
-  QPushButton *trackers_button = new QPushButton(GuiIconProvider::instance()->getIcon("network-server"), tr("Trackers"), parent);
+  QPushButton *trackers_button = new QPushButton(
+#ifndef Q_OS_MAC
+    GuiIconProvider::instance()->getIcon("network-server"),
+#endif
+    tr("Trackers"), parent);
   trackers_button->setShortcut(Qt::ALT + Qt::Key_C);
   addWidget(trackers_button);
   m_btnGroup->addButton(trackers_button, TRACKERS_TAB);
   // Peers tab
-  QPushButton *peers_button = new QPushButton(GuiIconProvider::instance()->getIcon("edit-find-user"), tr("Peers"), parent);
+  QPushButton *peers_button = new QPushButton(
+#ifndef Q_OS_MAC
+    GuiIconProvider::instance()->getIcon("edit-find-user"),
+#endif
+    tr("Peers"), parent);
   peers_button->setShortcut(Qt::ALT + Qt::Key_R);
   addWidget(peers_button);
   m_btnGroup->addButton(peers_button, PEERS_TAB);
   // URL seeds tab
-  QPushButton *urlseeds_button = new QPushButton(GuiIconProvider::instance()->getIcon("network-server"), tr("HTTP Sources"), parent);
+  QPushButton *urlseeds_button = new QPushButton(
+#ifndef Q_OS_MAC
+    GuiIconProvider::instance()->getIcon("network-server"),
+#endif
+    tr("HTTP Sources"), parent);
   urlseeds_button->setShortcut(Qt::ALT + Qt::Key_B);
   addWidget(urlseeds_button);
   m_btnGroup->addButton(urlseeds_button, URLSEEDS_TAB);
   // Files tab
-  QPushButton *files_button = new QPushButton(GuiIconProvider::instance()->getIcon("inode-directory"), tr("Content"), parent);
+  QPushButton *files_button = new QPushButton(
+#ifndef Q_OS_MAC
+    GuiIconProvider::instance()->getIcon("inode-directory"),
+#endif
+    tr("Content"), parent);
   files_button->setShortcut(Qt::ALT + Qt::Key_Z);
   addWidget(files_button);
   m_btnGroup->addButton(files_button, FILES_TAB);
   // Spacer
   addItem(new QSpacerItem(0, 0, QSizePolicy::Expanding, QSizePolicy::Fixed));
   // Speed tab
-  QPushButton *speed_button = new QPushButton(GuiIconProvider::instance()->getIcon("office-chart-line"), tr("Speed"), parent);
+  QPushButton *speed_button = new QPushButton(
+#ifndef Q_OS_MAC
+    GuiIconProvider::instance()->getIcon("office-chart-line"),
+#endif
+    tr("Speed"), parent);
   speed_button->setShortcut(Qt::ALT + Qt::Key_D);
   addWidget(speed_button);
   m_btnGroup->addButton(speed_button, SPEED_TAB);

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -72,10 +72,12 @@ RSSWidget::RSSWidget(QWidget *parent)
     m_ui->actionRename->setIcon(GuiIconProvider::instance()->getIcon("edit-rename"));
     m_ui->actionUpdate->setIcon(GuiIconProvider::instance()->getIcon("view-refresh"));
     m_ui->actionUpdateAllFeeds->setIcon(GuiIconProvider::instance()->getIcon("view-refresh"));
+#ifndef Q_OS_MAC
     m_ui->newFeedButton->setIcon(GuiIconProvider::instance()->getIcon("list-add"));
     m_ui->markReadButton->setIcon(GuiIconProvider::instance()->getIcon("mail-mark-read"));
     m_ui->updateAllButton->setIcon(GuiIconProvider::instance()->getIcon("view-refresh"));
     m_ui->rssDownloaderBtn->setIcon(GuiIconProvider::instance()->getIcon("download"));
+#endif
 
     m_articleListWidget = new ArticleListWidget(m_ui->splitterMain);
     m_ui->splitterMain->insertWidget(0, m_articleListWidget);

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -99,12 +99,19 @@ SearchWidget::SearchWidget(MainWindow *mainWindow)
            << "</p></body></html>" << flush;
     m_ui->m_searchPattern->setToolTip(searchPatternHint);
 
+#ifndef Q_OS_MAC
     // Icons
     m_ui->searchButton->setIcon(GuiIconProvider::instance()->getIcon("edit-find"));
     m_ui->downloadButton->setIcon(GuiIconProvider::instance()->getIcon("download"));
     m_ui->goToDescBtn->setIcon(GuiIconProvider::instance()->getIcon("application-x-mswinurl"));
     m_ui->pluginsButton->setIcon(GuiIconProvider::instance()->getIcon("preferences-system-network"));
     m_ui->copyURLBtn->setIcon(GuiIconProvider::instance()->getIcon("edit-copy"));
+#else
+    // On macOS the icons overlap the text otherwise
+    QSize iconSize = m_ui->tabWidget->iconSize();
+    iconSize.setWidth(iconSize.width() + 16);
+    m_ui->tabWidget->setIconSize(iconSize);
+#endif
     connect(m_ui->tabWidget, &QTabWidget::tabCloseRequested, this, &SearchWidget::closeTab);
 
     m_searchEngine = new SearchEngine;

--- a/src/gui/statusbar.cpp
+++ b/src/gui/statusbar.cpp
@@ -45,7 +45,11 @@
 StatusBar::StatusBar(QWidget *parent)
     : QStatusBar(parent)
 {
+#ifndef Q_OS_MAC
+    // Redefining global stylesheet breaks certain elements on mac like tabs.
+    // Qt checks whether the stylesheet class inherts("QMacStyle") and this becomes false.
     qApp->setStyleSheet("QStatusBar::item { border-width: 0; }");
+#endif
 
     BitTorrent::Session *const session = BitTorrent::Session::instance();
     connect(session, &BitTorrent::Session::speedLimitModeChanged, this, &StatusBar::updateAltSpeedsBtn);
@@ -108,16 +112,24 @@ StatusBar::StatusBar(QWidget *parent)
 
     QFrame *statusSep1 = new QFrame(this);
     statusSep1->setFrameStyle(QFrame::VLine);
+#ifndef Q_OS_MAC
     statusSep1->setFrameShadow(QFrame::Raised);
+#endif
     QFrame *statusSep2 = new QFrame(this);
     statusSep2->setFrameStyle(QFrame::VLine);
+#ifndef Q_OS_MAC
     statusSep2->setFrameShadow(QFrame::Raised);
+#endif
     QFrame *statusSep3 = new QFrame(this);
     statusSep3->setFrameStyle(QFrame::VLine);
+#ifndef Q_OS_MAC
     statusSep3->setFrameShadow(QFrame::Raised);
+#endif
     QFrame *statusSep4 = new QFrame(this);
     statusSep4->setFrameStyle(QFrame::VLine);
+#ifndef Q_OS_MAC
     statusSep4->setFrameShadow(QFrame::Raised);
+#endif
     layout->addWidget(m_DHTLbl);
     layout->addWidget(statusSep1);
     layout->addWidget(m_connecStatusLblIcon);

--- a/src/gui/tagfilterwidget.cpp
+++ b/src/gui/tagfilterwidget.cpp
@@ -73,6 +73,7 @@ TagFilterWidget::TagFilterWidget(QWidget *parent)
     setIconSize(Utils::Misc::smallIconSize());
 #if defined(Q_OS_MAC)
     setAttribute(Qt::WA_MacShowFocusRect, false);
+    setIndentation(0);
 #endif
     setContextMenuPolicy(Qt::CustomContextMenu);
     sortByColumn(0, Qt::AscendingOrder);

--- a/src/src.pro
+++ b/src/src.pro
@@ -23,6 +23,8 @@ nogui {
     DEFINES += DISABLE_GUI
     TARGET = qbittorrent-nox
 } else {
+    macx: QT += macextras
+    macx: LIBS += -lobjc
     QT += xml concurrent svg widgets
     CONFIG(static) {
         DEFINES += QBT_STATIC_QT


### PR DESCRIPTION
Hello,

This pull-request consolidates and fixes most of the existing changes (e.g. #4757 and #2096) and brings us other improvements. Whereas this is not a complete fix to all design issues in qBittorrent in regards to macOS, this is certainly a good start.

Please let me know what you consider important to change (if anything), and let's get this merged :)

The changelist includes:

- [x] Removed icons from main and right-click menus (thx #4757);
- [x] Removed icons from buttons (this also is invalid in macOS);
- [x] Removed tray statusbar support from macOS (thx #4757);
- [x] Removed Hide and Quit duplicate entries from Dock menu (thx #4757);
- [x] Reduced horizontal category indentation (it looks terrible on macOS and does nothing);
- [x] Enabled Dock minimisation instead of quitting on window close (thx #4757, fixed window restoration);
- [x] Replaced toolbar separators by spacers, there is no such concept on macOS;
- [x] Added download speed badge to dock icon (thx #2096);
- [x] Fixed awkward tab widget border and spacing looking terrible;
- [x] Fixed horizontal toolbar appearing in preferences list;
- [x] Renamed Options to Preferences in the toolbar and window title (thx #3018);
- [x] Removed ambiguous window icons;
- [x] Fixed multiple torrent addition windows being inaccessible (thx #6206).

<details>
  <summary>Screenshots</summary>

![before](https://user-images.githubusercontent.com/4348897/27018853-464ec676-4f3c-11e7-8b1b-bb1ffff46b15.png)
![after](https://user-images.githubusercontent.com/4348897/27018855-49ec7436-4f3c-11e7-9c73-f05ff0370272.png)

</details>

Regarding separator → spacer replacement: I am thinking of removing them entirely, since they do not really add much clarity, but to my eyes it looks fine either way. If you think it is better to remove them, let me know.

Regarding Dock restoration: it is a very annoying bug (or shall I say feature) in Qt, no event is delivered to the dispatcher when you click on the icon regardless of the docs. The only reason is to use native APIs, and although it is a little ugly, it works well.

Regarding the badges: the API Qt offers is very limited, and one cannot display more than a single line, and its length is very short. To avoid dotted shortening even the "D: " prefix was removed. Unfortunately it also does not allow colouring, and to avoid different sorts of confusion I decided not to add the uploading speed badge.

Even though I am open for a discussion on what is worth changing and may even make another pull-request fixing certain other areas, I will not add any new features to the current one.

Among the macOS-specific issues I am aware of are all the menu/app icons. They are supposed to be greyscale, not coloured. And I am actually wondering how would you prefer to change it?