### PR TITLE
Update link to wiki

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Filing an issue
 
 ### Must read
-* If you aren't sure, you can ask on the [**forum**](http://forum.qbittorrent.org) or read our [**wiki**](http://wiki.qbittorrent.org) first.
+* If you aren't sure, you can ask on the [**forum**](http://forum.qbittorrent.org) or read our [**wiki**](https://github.com/qbittorrent/qBittorrent/wiki) first.
 * Do a quick **search**. Others might already reported the issue.
 * Write in **English**!
 * Provide **version** information: (You can find version numbers at menu `Help -> About -> Libraries`)

--- a/INSTALL
+++ b/INSTALL
@@ -48,7 +48,7 @@ qBittorrent - A BitTorrent client in C++ / Qt4
 
 
 DOCUMENTATION:
-Please note that there is a documentation with a "compiling howto" at http://wiki.qbittorrent.org.
+Please note that there is a documentation with a "compiling howto" at https://github.com/qbittorrent/qBittorrent/wiki.
 
 ------------------------------------------
 Christophe Dumez <chris@qbittorrent.org>

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For more information please visit:
 http://www.qbittorrent.org
 
 or our wiki here:
-http://wiki.qbittorrent.org
+https://github.com/qbittorrent/qBittorrent/wiki
 
 Use the forum for troubleshooting before reporting bugs:
 http://forum.qbittorrent.org

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -75,7 +75,7 @@
                     <li>
                         <a class="returnFalse">QBT_TR(&Help)QBT_TR[CONTEXT=MainWindow]</a>
                         <ul>
-                            <li><a id="docsLink" target="_blank" href="http://wiki.qbittorrent.org/"><img class="MyMenuIcon" src="theme/help-contents" alt="QBT_TR(&Documentation)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" onload="fixPNG(this)"/>QBT_TR(&Documentation)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li><a id="docsLink" target="_blank" href="https://github.com/qbittorrent/qBittorrent/wiki"><img class="MyMenuIcon" src="theme/help-contents" alt="QBT_TR(&Documentation)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" onload="fixPNG(this)"/>QBT_TR(&Documentation)QBT_TR[CONTEXT=MainWindow]</a></li>
                             <li class="divider"><a id="bugLink" target="_blank" href="http://www.qbittorrent.org/donate"><img class="MyMenuIcon" src="theme/wallet-open" alt="QBT_TR(Do&nate!)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" onload="fixPNG(this)"/>QBT_TR(Do&nate!)QBT_TR[CONTEXT=MainWindow]</a></li>
                             <li><a id="aboutLink"><img class="MyMenuIcon" src="theme/help-about" alt="QBT_TR(&About)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" onload="fixPNG(this)"/>QBT_TR(&About)QBT_TR[CONTEXT=MainWindow]</a></li>
                         </ul>


### PR DESCRIPTION
The [previous link](http://wiki.qbittorrent.org/) is no longer functional.