### PR TITLE
Raise total stack size on Windows

### DIFF
--- a/winconf-msvc.pri
+++ b/winconf-msvc.pri
@@ -12,7 +12,8 @@ strace_win {
 }
 
 CONFIG -= embed_manifest_exe
-QMAKE_LFLAGS += "/OPT:REF /OPT:ICF /MANIFEST:EMBED /MANIFESTINPUT:$$quote($${PWD}/src/qbittorrent.exe.manifest) /STACK:0x800000"
+QMAKE_LFLAGS += "/MANIFEST:EMBED /MANIFESTINPUT:$$quote($${PWD}/src/qbittorrent.exe.manifest) /STACK:0x800000"
+QMAKE_LFLAGS_RELEASE += "/OPT:REF /OPT:ICF"
 
 RC_FILE = qbittorrent.rc
 

--- a/winconf-msvc.pri
+++ b/winconf-msvc.pri
@@ -12,7 +12,7 @@ strace_win {
 }
 
 CONFIG -= embed_manifest_exe
-QMAKE_LFLAGS += "/OPT:REF /OPT:ICF /MANIFEST:EMBED /MANIFESTINPUT:$$quote($${PWD}/src/qbittorrent.exe.manifest)"
+QMAKE_LFLAGS += "/OPT:REF /OPT:ICF /MANIFEST:EMBED /MANIFESTINPUT:$$quote($${PWD}/src/qbittorrent.exe.manifest) /STACK:0x800000"
 
 RC_FILE = qbittorrent.rc
 


### PR DESCRIPTION
The report in #7021 imply that there are recursive calls in `boost::asio::ssl` and I concluded that all stack space had exhausted, eventually qbt crash.

* Raise total stack size on Windows to 8 MB. Closes #7021.
  MSVC default was 1 MB.
  8 MB is also the default of arch linux (x64), so I follow that.
  https://docs.microsoft.com/en-us/cpp/build/reference/stack-stack-allocations
* Separate "Release mode" linker options

