### PR TITLE
Skip webui username/password check for active sessions

### DIFF
--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -172,6 +172,11 @@ void WebApplication::action_public_webui()
 
 void WebApplication::action_public_login()
 {
+    if (sessionActive()) {
+        print(QByteArray("Ok."), Http::CONTENT_TYPE_TXT);
+        return;
+    }
+
     const Preferences* const pref = Preferences::instance();
     QCryptographicHash md5(QCryptographicHash::Md5);
 


### PR DESCRIPTION
Also skips the check if the user's session is already active.

Closes #6860 
Replaces #6862