### PR TITLE
Do not show completion when text is not being edited

### DIFF
--- a/src/gui/fspathedit_p.cpp
+++ b/src/gui/fspathedit_p.cpp
@@ -207,8 +207,6 @@ Private::FileLineEdit::FileLineEdit(QWidget *parent)
     m_completer->setModel(m_completerModel);
     m_completer->setCompletionMode(QCompleter::PopupCompletion);
     setCompleter(m_completer);
-
-    connect(m_completerModel, &QFileSystemModel::directoryLoaded, this, &FileLineEdit::showCompletionPopup);
 }
 
 Private::FileLineEdit::~FileLineEdit()

--- a/src/gui/fspathedit_p.h
+++ b/src/gui/fspathedit_p.h
@@ -132,11 +132,9 @@ namespace Private
         void keyPressEvent(QKeyEvent *event) override;
         void contextMenuEvent(QContextMenuEvent *event) override;
 
-    private slots:
-        void showCompletionPopup();
-
     private:
         static QString warningText(FileSystemPathValidator::TestResult r);
+        void showCompletionPopup();
 
         QFileSystemModel *m_completerModel;
         QCompleter *m_completer;


### PR DESCRIPTION
This fixes the bug when completion popup is shown when AddNewTorrent dialog is activated and  default save path is set to file system or drive root.  