### PR TITLE
Implement enum support in CachedSettingValue

### DIFF
--- a/src/base/settingvalue.h
+++ b/src/base/settingvalue.h
@@ -30,7 +30,10 @@
 #define SETTINGVALUE_H
 
 #include <functional>
+#include <type_traits>
+#include <QMetaEnum>
 #include <QString>
+#include <QVariant>
 
 #include "settingsstorage.h"
 
@@ -42,16 +45,14 @@ class CachedSettingValue
 public:
     explicit CachedSettingValue(const char *keyName, const T &defaultValue = T())
         : m_keyName(QLatin1String(keyName))
-        , m_value(SettingsStorage::instance()->loadValue(
-                                m_keyName, defaultValue).template value<T>())
+        , m_value(loadValue(defaultValue))
     {
     }
 
     explicit CachedSettingValue(const char *keyName, const T &defaultValue
             , const ProxyFunc &proxyFunc)
         : m_keyName(QLatin1String(keyName))
-        , m_value(proxyFunc(SettingsStorage::instance()->loadValue(
-                                m_keyName, defaultValue).template value<T>()))
+        , m_value(proxyFunc(loadValue(defaultValue)))
     {
     }
 
@@ -68,11 +69,45 @@ public:
     CachedSettingValue<T> &operator=(const T &newValue)
     {
         m_value = newValue;
-        SettingsStorage::instance()->storeValue(m_keyName, m_value);
+        storeValue(m_value);
         return *this;
     }
 
 private:
+    // regular load/save pair
+    template <typename U, typename std::enable_if<!std::is_enum<U>::value, int>::type = 0>
+    U loadValue(const U &defaultValue)
+    {
+        return SettingsStorage::instance()->loadValue(m_keyName, defaultValue).template value<T>();
+    }
+
+    template <typename U, typename std::enable_if<!std::is_enum<U>::value, int>::type = 0>
+    void storeValue(const U &value)
+    {
+        SettingsStorage::instance()->storeValue(m_keyName, value);
+    }
+
+    // load/save pair for enum
+    // saves literal value of the enum constant, obtained from QMetaEnum
+    template <typename U, typename std::enable_if<std::is_enum<U>::value, int>::type = 0>
+    U loadValue(const U &defaultValue)
+    {
+        static_assert(std::is_same<int, typename std::underlying_type<U>::type>::value,
+                      "Enumeration underlying type has to be int");
+
+        bool ok = false;
+        const U res = static_cast<U>(QMetaEnum::fromType<U>().keyToValue(
+            SettingsStorage::instance()->loadValue(m_keyName, QString()).toString().toLatin1().constData(), &ok));
+        return ok ? res : defaultValue;
+    }
+
+    template <typename U, typename std::enable_if<std::is_enum<U>::value, int>::type = 0>
+    void storeValue(const U &value)
+    {
+        SettingsStorage::instance()->storeValue(m_keyName,
+            QString::fromLatin1(QMetaEnum::fromType<U>().valueToKey(static_cast<int>(value))));
+    }
+
     const QString m_keyName;
     T m_value;
 };

--- a/src/base/settingvalue.h
+++ b/src/base/settingvalue.h
@@ -87,7 +87,7 @@ private:
         SettingsStorage::instance()->storeValue(m_keyName, value);
     }
 
-    // load/save pair for enum
+    // load/save pair for an enum
     // saves literal value of the enum constant, obtained from QMetaEnum
     template <typename U, typename std::enable_if<std::is_enum<U>::value, int>::type = 0>
     U loadValue(const U &defaultValue)
@@ -97,7 +97,7 @@ private:
 
         bool ok = false;
         const U res = static_cast<U>(QMetaEnum::fromType<U>().keyToValue(
-            SettingsStorage::instance()->loadValue(m_keyName, QString()).toString().toLatin1().constData(), &ok));
+            SettingsStorage::instance()->loadValue(m_keyName).toString().toLatin1().constData(), &ok));
         return ok ? res : defaultValue;
     }
 

--- a/src/base/torrentfileguard.cpp
+++ b/src/base/torrentfileguard.cpp
@@ -28,14 +28,8 @@
 
 #include "torrentfileguard.h"
 
-#include <QMetaEnum>
-#include "settingsstorage.h"
+#include "settingvalue.h"
 #include "utils/fs.h"
-
-namespace
-{
-    const QLatin1String KEY_AUTO_DELETE_ENABLED ("Core/AutoDeleteAddedTorrentFile");
-}
 
 FileGuard::FileGuard(const QString &path)
     : m_path {path}
@@ -79,18 +73,17 @@ void TorrentFileGuard::markAsAddedToSession()
 
 TorrentFileGuard::AutoDeleteMode TorrentFileGuard::autoDeleteMode()
 {
-    QMetaEnum meta {modeMetaEnum()};
-    return static_cast<AutoDeleteMode>(meta.keyToValue(SettingsStorage::instance()->loadValue(
-                                                           KEY_AUTO_DELETE_ENABLED, meta.valueToKey(Never)).toByteArray()));
+    return autoDeleteModeSetting();
 }
 
 void TorrentFileGuard::setAutoDeleteMode(TorrentFileGuard::AutoDeleteMode mode)
 {
-    QMetaEnum meta {modeMetaEnum()};
-    SettingsStorage::instance()->storeValue(KEY_AUTO_DELETE_ENABLED, meta.valueToKey(mode));
+    autoDeleteModeSetting() = mode;
 }
 
-QMetaEnum TorrentFileGuard::modeMetaEnum()
+CachedSettingValue<TorrentFileGuard::AutoDeleteMode> &TorrentFileGuard::autoDeleteModeSetting()
 {
-    return QMetaEnum::fromType<AutoDeleteMode>();
+    static CachedSettingValue<AutoDeleteMode> setting("Core/AutoDeleteAddedTorrentFile", AutoDeleteMode::Never);
+    return setting;
 }
+

--- a/src/base/torrentfileguard.h
+++ b/src/base/torrentfileguard.h
@@ -29,10 +29,11 @@
 #ifndef TOFFENTFILEGURAD_H
 #define TOFFENTFILEGURAD_H
 
+#include <QObject>
 #include <QString>
-#include <QMetaType>
 
-class QMetaEnum;
+template <typename T> class CachedSettingValue;
+
 /// Utility class to defer file deletion
 class FileGuard
 {
@@ -62,7 +63,7 @@ public:
     void markAsAddedToSession();
     using FileGuard::setAutoRemove;
 
-    enum AutoDeleteMode     // do not change these names: they are stored in config file
+    enum AutoDeleteMode: int     // do not change these names: they are stored in config file
     {
         Never,
         IfAdded,
@@ -74,9 +75,8 @@ public:
     static void setAutoDeleteMode(AutoDeleteMode mode);
 
 private:
-    static QMetaEnum modeMetaEnum();
-
     TorrentFileGuard(const QString &path, AutoDeleteMode mode);
+    static CachedSettingValue<AutoDeleteMode> &autoDeleteModeSetting();
 
     Q_ENUM(AutoDeleteMode)
     AutoDeleteMode m_mode;

--- a/src/gui/search/searchtab.h
+++ b/src/gui/search/searchtab.h
@@ -31,7 +31,6 @@
 #ifndef SEARCHTAB_H
 #define SEARCHTAB_H
 
-#include <QVariant> // I don't know why <QMetaType> is not enought for Qt's 4.8.7 moc
 #include <QWidget>
 
 #define ENGINE_URL_COLUMN 4
@@ -43,6 +42,8 @@ class QTreeView;
 class QHeaderView;
 class QStandardItemModel;
 class QVBoxLayout;
+
+template <typename T> class CachedSettingValue;
 
 class SearchSortModel;
 class SearchListDelegate;
@@ -59,13 +60,13 @@ class SearchTab: public QWidget
 
 public:
 
-    enum NameFilteringMode
+    enum class NameFilteringMode
     {
         Everywhere,
         OnlyNames
     };
 
-    Q_ENUMS(NameFilteringMode)
+    Q_ENUM(NameFilteringMode)
 
     explicit SearchTab(SearchWidget *parent);
     ~SearchTab();
@@ -105,6 +106,8 @@ private:
     NameFilteringMode filteringMode() const;
     static QString statusText(Status st);
     static QString statusIconName(Status st);
+
+    static CachedSettingValue<NameFilteringMode>& nameFilteringModeSetting();
 
     Ui::SearchTab *m_ui;
     QTreeView *m_resultsBrowser;


### PR DESCRIPTION
Enums are stored as strings, that improves configuration file
readability and maintainability. String values are obtained via
QMetaEnum, and since with Qt 5.5 QMetaEnum::fromType() includes a
static_assert, this has to be a safe method.

So, this change provides a simple way to store enumerations in the config file.