### PR TITLE
Make SettingsStorage to be non thread-safe

### DIFF
--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -38,7 +38,6 @@
 #include <QList>
 #include <QSize>
 #include <QTimer>
-#include <QReadWriteLock>
 #include <QNetworkCookie>
 #include <QVariant>
 

--- a/src/base/settingsstorage.h
+++ b/src/base/settingsstorage.h
@@ -33,13 +33,14 @@
 #include <QObject>
 #include <QVariantHash>
 #include <QTimer>
-#include <QReadWriteLock>
 
 class SettingsStorage: public QObject
 {
     Q_OBJECT
+    Q_DISABLE_COPY(SettingsStorage)
+
     SettingsStorage();
-    ~SettingsStorage();
+    ~SettingsStorage() override;
 
 public:
     static void initInstance();
@@ -59,7 +60,6 @@ private:
     QVariantHash m_data;
     bool m_dirty;
     QTimer m_timer;
-    mutable QReadWriteLock m_lock;
 };
 
 #endif // SETTINGSSTORAGE_H


### PR DESCRIPTION
Remove read/write locking from SettingsStorage and assert that its
methods are called in the main application thread.

We do not really want the SettingsStorage component was thread safe. All the application components live in the main thread, but just some auxiliary tasks (that should not be configurable directly) are executed in separate threads. So the thread safety of this "popular" component just creates unnecessary costs.