### PR TITLE
Set interface for outgoing traffic.

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1124,6 +1124,7 @@ void Session::configure(libtorrent::settings_pack &settingsPack)
             }
         }
 
+        settingsPack.set_str(libt::settings_pack::outgoing_interfaces, networkInterface().toStdString());
         m_listenInterfaceChanged = false;
     }
 


### PR DESCRIPTION
This sets interface for outgoing traffic to the same as for ingoing
(listetning) with libtorrent 1.1.x.