### PR TITLE
Fix crash when exiting qbt with search plugin update dialog open

### DIFF
--- a/src/base/searchengine.cpp
+++ b/src/base/searchengine.cpp
@@ -141,6 +141,8 @@ void SearchEngine::enablePlugin(const QString &name, bool enabled)
         else if (!disabledPlugins.contains(name))
             disabledPlugins.append(name);
         pref->setSearchEngDisabled(disabledPlugins);
+
+        emit pluginEnabled(name, enabled);
     }
 }
 
@@ -239,6 +241,7 @@ bool SearchEngine::uninstallPlugin(const QString &name)
     // Remove it from supported engines
     delete m_plugins.take(name);
 
+    emit pluginUninstalled(name);
     return true;
 }
 

--- a/src/base/searchengine.h
+++ b/src/base/searchengine.h
@@ -103,8 +103,10 @@ signals:
     void searchFailed();
     void newSearchResults(const QList<SearchResult> &results);
 
+    void pluginEnabled(const QString &name, bool enabled);
     void pluginInstalled(const QString &name);
     void pluginInstallationFailed(const QString &name, const QString &reason);
+    void pluginUninstalled(const QString &name);
     void pluginUpdated(const QString &name);
     void pluginUpdateFailed(const QString &name, const QString &reason);
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -311,7 +311,7 @@ MainWindow::MainWindow(QWidget *parent)
     connect(m_ui->actionDecreasePriority, &QAction::triggered, m_transferListWidget, &TransferListWidget::decreasePrioSelectedTorrents);
     connect(m_ui->actionBottomPriority, &QAction::triggered, m_transferListWidget, &TransferListWidget::bottomPrioSelectedTorrents);
 #ifndef Q_OS_MAC
-    connect(m_ui->actionToggleVisibility, &QAction::triggered, [this](){ toggleVisibility(); });
+    connect(m_ui->actionToggleVisibility, &QAction::triggered, this, [this]() { toggleVisibility(); });
 #endif
     connect(m_ui->actionMinimize, &QAction::triggered, this, &MainWindow::minimizeWindow);
     connect(m_ui->actionUseAlternativeSpeedLimits, &QAction::triggered, this, &MainWindow::toggleAlternativeSpeeds);

--- a/src/gui/search/pluginselectdlg.cpp
+++ b/src/gui/search/pluginselectdlg.cpp
@@ -103,7 +103,6 @@ PluginSelectDlg::PluginSelectDlg(SearchEngine *pluginManager, QWidget *parent)
 
 PluginSelectDlg::~PluginSelectDlg()
 {
-    emit pluginsChanged();
     delete m_ui;
 }
 
@@ -461,7 +460,6 @@ void PluginSelectDlg::pluginUpdated(const QString &name)
     item->setText(PLUGIN_VERSION, version);
     m_updatedPlugins.append(name);
     finishPluginUpdate();
-
 }
 
 void PluginSelectDlg::pluginUpdateFailed(const QString &name, const QString &reason)

--- a/src/gui/search/pluginselectdlg.h
+++ b/src/gui/search/pluginselectdlg.h
@@ -56,9 +56,6 @@ public:
     QList<QTreeWidgetItem*> findItemsWithUrl(QString url);
     QTreeWidgetItem* findItemWithID(QString id);
 
-signals:
-    void pluginsChanged();
-
 protected:
     void dropEvent(QDropEvent *event);
     void dragEnterEvent(QDragEnterEvent *event);

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -121,11 +121,19 @@ SearchWidget::SearchWidget(MainWindow *mainWindow)
     connect(m_searchEngine, &SearchEngine::searchFailed, this, &SearchWidget::searchFailed);
     connect(m_searchEngine, &SearchEngine::torrentFileDownloaded, this, &SearchWidget::addTorrentToSession);
 
-    // Fill in category combobox
-    fillCatCombobox();
-    fillPluginComboBox();
+    const auto onPluginChanged = [this]()
+    {
+        fillCatCombobox();
+        fillPluginComboBox();
+        selectActivePage();
+    };
+    connect(m_searchEngine, &SearchEngine::pluginInstalled, this, onPluginChanged);
+    connect(m_searchEngine, &SearchEngine::pluginUninstalled, this, onPluginChanged);
+    connect(m_searchEngine, &SearchEngine::pluginUpdated, this, onPluginChanged);
+    connect(m_searchEngine, &SearchEngine::pluginEnabled, this, onPluginChanged);
 
-    selectActivePage();
+    // Fill in category combobox
+    onPluginChanged();
 
     connect(m_ui->m_searchPattern, &LineEdit::returnPressed, m_ui->searchButton, &QPushButton::click);
     connect(m_ui->m_searchPattern, &LineEdit::textEdited, this, &SearchWidget::searchTextEdited);
@@ -248,10 +256,7 @@ void SearchWidget::addTorrentToSession(const QString &source)
 
 void SearchWidget::on_pluginsButton_clicked()
 {
-    PluginSelectDlg *dlg = new PluginSelectDlg(m_searchEngine, this);
-    connect(dlg, &PluginSelectDlg::pluginsChanged, this, &SearchWidget::fillCatCombobox);
-    connect(dlg, &PluginSelectDlg::pluginsChanged, this, &SearchWidget::fillPluginComboBox);
-    connect(dlg, &PluginSelectDlg::pluginsChanged, this, &SearchWidget::selectActivePage);
+    new PluginSelectDlg(m_searchEngine, this);
 }
 
 void SearchWidget::searchTextEdited(QString)


### PR DESCRIPTION
Crash reproduce steps:
1. open search plugins dialog, the one that install/update plugins, leave it open.
2. minimize qbt to tray.
3. right click on tray icon and quit qbt.
