### PR TITLE
Fix main menu item location on macOS

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -326,6 +326,13 @@ MainWindow::MainWindow(QWidget *parent)
     m_ui->actionCheckForUpdates->setVisible(false);
 #endif
 
+    // Certain menu items should reside at specific places on macOS.
+    // Qt partially does it on its own, but updates and different languages require tuning.
+    m_ui->actionExit->setMenuRole(QAction::QuitRole);
+    m_ui->actionAbout->setMenuRole(QAction::AboutRole);
+    m_ui->actionCheckForUpdates->setMenuRole(QAction::ApplicationSpecificRole);
+    m_ui->actionOptions->setMenuRole(QAction::PreferencesRole);
+
     connect(m_ui->actionManageCookies, &QAction::triggered, this, &MainWindow::manageCookies);
 
     m_pwr = new PowerManagement(this);


### PR DESCRIPTION
There is just another macOS UI issue I did not spot in my initial patch.
On macOS `About <name>`, `Check For Updates…`, `Preferences…`, and `Quit <name>` should reside in the main menu column. Like it is [now](https://user-images.githubusercontent.com/4348897/28383842-2b7ceca4-6ccb-11e7-89a6-69e060e0f513.png).

Qt attempts to reorder the items automatically, but mostly fails. `Check For Updates` is definitely not around, and other languages are just messed up. A solution is to provide a MenuRole.

Also asking for this to go to 3.4.0, since it is very minor and in fact should have been part of #6952 if I noticed.