### PR TITLE
Don't create subfolder inside temp folder. Closes #5503

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -210,7 +210,7 @@ namespace BitTorrent
         void setTempPath(QString path);
         bool isTempPathEnabled() const;
         void setTempPathEnabled(bool enabled);
-        QString torrentTempPath(const InfoHash &hash) const;
+        QString torrentTempPath(const TorrentInfo &torrentInfo) const;
 
         static bool isValidCategoryName(const QString &name);
         // returns category itself and all top level categories

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -1498,7 +1498,7 @@ void TorrentHandle::handleStorageMovedAlert(libtorrent::storage_moved_alert *p)
     }
 
     qDebug("Torrent is successfully moved from %s to %s", qPrintable(m_oldPath), qPrintable(m_newPath));
-    if (QDir(m_oldPath) == QDir(m_session->torrentTempPath(hash()))) {
+    if (QDir(m_oldPath) == QDir(m_session->torrentTempPath(info()))) {
         qDebug() << "Removing torrent temp folder:" << m_oldPath;
         Utils::Fs::smartRemoveEmptyFolderTree(m_oldPath);
     }
@@ -1926,9 +1926,9 @@ void TorrentHandle::adjustActualSavePath_impl()
         path = savePath();
     }
     else {
-        // Moving all downloading torrents to temporary save path
-        path = m_session->torrentTempPath(hash());
-        qDebug() << "Moving torrent to its temp save path:" << path;
+        // Moving all downloading torrents to temporary folder
+        path = m_session->torrentTempPath(info());
+        qDebug() << "Moving torrent to its temporary folder:" << path;
     }
 
     moveStorage(Utils::Fs::toNativePath(path));

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -308,9 +308,29 @@ int BitTorrent::TorrentInfo::fileIndex(const QString& fileName) const
     return -1;
 }
 
+bool TorrentInfo::hasRootFolder() const
+{
+    QString testRootFolder;
+    for (int i = 0; i < filesCount(); ++i) {
+        const QString filePath = this->filePath(i);
+        if (QDir::isAbsolutePath(filePath)) continue;
+
+        const auto filePathElements = filePath.splitRef('/');
+        // if at least one file has no root folder, no common root folder exists
+        if (filePathElements.count() <= 1) return false;
+
+        if (testRootFolder.isEmpty())
+            testRootFolder = filePathElements.at(0).toString();
+        else if (testRootFolder != filePathElements.at(0))
+            return false;
+    }
+
+    return true;
+}
+
 void TorrentInfo::stripRootFolder()
 {
-    if (filesCount() <= 1) return;
+    if (!hasRootFolder()) return;
 
     libtorrent::file_storage files = m_nativeInfo->files();
 

--- a/src/base/bittorrent/torrentinfo.h
+++ b/src/base/bittorrent/torrentinfo.h
@@ -100,6 +100,8 @@ namespace BitTorrent
         PieceRange filePieces(int fileIndex) const;
 
         void renameFile(uint index, const QString &newPath);
+
+        bool hasRootFolder() const;
         void stripRootFolder();
 
         NativePtr nativeInfo() const;


### PR DESCRIPTION
This PR get rid from creation of subfolders inside temporary folder. The single exception is multifile torrents with stripped root folder. They have subfolders with its original root name.