### PR TITLE
Don't replace existing files when manually relocating torrent

### DIFF
--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -421,8 +421,8 @@ namespace BitTorrent
 
         void adjustActualSavePath();
         void adjustActualSavePath_impl();
-        void move_impl(QString path);
-        void moveStorage(const QString &newPath);
+        void move_impl(QString path, bool overwrite);
+        void moveStorage(const QString &newPath, bool overwrite);
         void manageIncompleteFiles();
         bool addTracker(const TrackerEntry &tracker);
         bool addUrlSeed(const QUrl &urlSeed);
@@ -437,11 +437,16 @@ namespace BitTorrent
 
         InfoHash m_hash;
 
-        QString m_oldPath;
-        QString m_newPath;
-        // m_queuedPath is where files should be moved to,
-        // when current moving is completed
-        QString m_queuedPath;
+        struct
+        {
+            QString oldPath;
+            QString newPath;
+            // queuedPath is where files should be moved to,
+            // when current moving is completed
+            QString queuedPath;
+            bool queuedOverwrite = true;
+        } m_moveStorageInfo;
+
         // m_moveFinishedTriggers is activated only when the following conditions are met:
         // all file rename jobs complete, all file move jobs complete
         QQueue<EventTrigger> m_moveFinishedTriggers;


### PR DESCRIPTION
Since a lot of users prefer to move the files of the torrent manually and then use the "Set location", they lose the existing data and get broken torrent (there are many issues about it on this bugtracker). This PR should fix the problem.

P.S. Auto Torrent Management feature isn't affected  by this PR. It always overwrite existing files.