### PR TITLE
Fix file icon loading on Windows.

### DIFF
--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -91,14 +91,18 @@ namespace
         QIcon icon(const QFileInfo &info) const override
         {
             SHFILEINFO sfi = { 0 };
-            HRESULT hr = ::SHGetFileInfoW(info.absoluteFilePath().toStdWString().c_str(),
+            QString nativePath = Utils::Fs::toNativePath(info.absoluteFilePath());
+            HRESULT hr = ::SHGetFileInfoW(nativePath.toStdWString().c_str(),
                 FILE_ATTRIBUTE_NORMAL, &sfi, sizeof(sfi), SHGFI_ICON | SHGFI_USEFILEATTRIBUTES);
             if (FAILED(hr))
                 return UnifiedFileIconProvider::icon(info);
 
             QPixmap iconPixmap = QtWin::fromHICON(sfi.hIcon);
             ::DestroyIcon(sfi.hIcon);
-            return QIcon(iconPixmap);
+            if (!iconPixmap.isNull())
+                return QIcon(iconPixmap);
+            else
+                return UnifiedFileIconProvider::icon(info);
         }
     };
 #elif defined(Q_OS_MAC)


### PR DESCRIPTION
On Windows XP the loading failed. According to comments in
https://stackoverflow.com/questions/37362795/failed-to-get-exe-icon-with-shgetfileinfo
only the file I/O  API is guaranteed to convert between slashes and backslashes.
SHGetFileInfo is not part of it, so we should use backslashes in the path we pass to it.
Also QtWin::fromHICON() might return an empty QPixmap if it fails silenty.