### PR TITLE
Fix issues found by coverity scan

### DIFF
--- a/src/gui/fspathedit_p.cpp
+++ b/src/gui/fspathedit_p.cpp
@@ -42,6 +42,8 @@ Private::FileSystemPathValidator::FileSystemPathValidator(QObject *parent)
     , m_directoriesOnly(false)
     , m_checkReadPermission(false)
     , m_checkWritePermission(false)
+    , m_lastTestResult(TestResult::DoesNotExist)
+    , m_lastValidationState(QValidator::Invalid)
 {
 }
 

--- a/src/gui/search/searchtab.cpp
+++ b/src/gui/search/searchtab.cpp
@@ -54,6 +54,7 @@ SearchTab::SearchTab(SearchWidget *parent)
     : QWidget(parent)
     , m_ui(new Ui::SearchTab())
     , m_parent(parent)
+    , m_status(Status::NoResults)
 {
     m_ui->setupUi(this);
 

--- a/src/gui/search/searchtab.h
+++ b/src/gui/search/searchtab.h
@@ -110,7 +110,6 @@ private:
     static CachedSettingValue<NameFilteringMode>& nameFilteringModeSetting();
 
     Ui::SearchTab *m_ui;
-    QTreeView *m_resultsBrowser;
     QStandardItemModel *m_searchListModel;
     SearchSortModel *m_proxyModel;
     SearchListDelegate *m_searchDelegate;


### PR DESCRIPTION
* Initialize variables
* Remove unused variable

Also
* @sledgehammer999 can you filter out the path `/opt/qt55` in coverity dashboard?
* @glassez, 
  at https://github.com/qbittorrent/qBittorrent/blob/master/src/base/asyncfilestorage.cpp#L41, the exception is handled nowhere, is this behavior intended?
  or RSS function should just fail silently without crashing the program?