### PR TITLE
Use qUtf8Printable() for logging strings

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -554,7 +554,7 @@ bool Application::event(QEvent *ev)
         if (path.isEmpty())
             // Get the url instead
             path = static_cast<QFileOpenEvent *>(ev)->url().toString();
-        qDebug("Received a mac file open event: %s", qPrintable(path));
+        qDebug("Received a mac file open event: %s", qUtf8Printable(path));
         if (m_running)
             processParams(QStringList(path));
         else
@@ -589,16 +589,16 @@ void Application::initializeTranslation()
 
     if (m_qtTranslator.load(QString::fromUtf8("qtbase_") + localeStr, QLibraryInfo::location(QLibraryInfo::TranslationsPath)) ||
         m_qtTranslator.load(QString::fromUtf8("qt_") + localeStr, QLibraryInfo::location(QLibraryInfo::TranslationsPath)))
-            qDebug("Qt %s locale recognized, using translation.", qPrintable(localeStr));
+            qDebug("Qt %s locale recognized, using translation.", qUtf8Printable(localeStr));
     else
-        qDebug("Qt %s locale unrecognized, using default (en).", qPrintable(localeStr));
+        qDebug("Qt %s locale unrecognized, using default (en).", qUtf8Printable(localeStr));
 
     installTranslator(&m_qtTranslator);
 
     if (m_translator.load(QString::fromUtf8(":/lang/qbittorrent_") + localeStr))
-        qDebug("%s locale recognized, using translation.", qPrintable(localeStr));
+        qDebug("%s locale recognized, using translation.", qUtf8Printable(localeStr));
     else
-        qDebug("%s locale unrecognized, using default (en).", qPrintable(localeStr));
+        qDebug("%s locale unrecognized, using default (en).", qUtf8Printable(localeStr));
     installTranslator(&m_translator);
 
 #ifndef DISABLE_GUI

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1658,7 +1658,7 @@ bool Session::deleteTorrent(const QString &hash, bool deleteLocalFiles)
     TorrentHandle *const torrent = m_torrents.take(hash);
     if (!torrent) return false;
 
-    qDebug("Deleting torrent with hash: %s", qPrintable(torrent->hash()));
+    qDebug("Deleting torrent with hash: %s", qUtf8Printable(torrent->hash()));
     emit torrentAboutToBeRemoved(torrent);
 
     // Remove it from session
@@ -1683,10 +1683,10 @@ bool Session::deleteTorrent(const QString &hash, bool deleteLocalFiles)
 #endif
         // Remove unwanted and incomplete files
         foreach (const QString &unwantedFile, unwantedFiles) {
-            qDebug("Removing unwanted file: %s", qPrintable(unwantedFile));
+            qDebug("Removing unwanted file: %s", qUtf8Printable(unwantedFile));
             Utils::Fs::forceRemove(unwantedFile);
             const QString parentFolder = Utils::Fs::branchPath(unwantedFile);
-            qDebug("Attempt to remove parent folder (if empty): %s", qPrintable(parentFolder));
+            qDebug("Attempt to remove parent folder (if empty): %s", qUtf8Printable(parentFolder));
             QDir().rmpath(parentFolder);
         }
     }
@@ -1954,7 +1954,7 @@ bool Session::addTorrent_impl(AddTorrentData addData, const MagnetUri &magnetUri
     }
 
     qDebug("Adding torrent...");
-    qDebug(" -> Hash: %s", qPrintable(hash));
+    qDebug(" -> Hash: %s", qUtf8Printable(hash));
 
     // Preallocation mode
     if (isPreallocationEnabled())
@@ -2031,8 +2031,8 @@ bool Session::loadMetadata(const MagnetUri &magnetUri)
     if (m_loadedMetadata.contains(hash)) return false;
 
     qDebug("Adding torrent to preload metadata...");
-    qDebug(" -> Hash: %s", qPrintable(hash));
-    qDebug(" -> Name: %s", qPrintable(name));
+    qDebug(" -> Hash: %s", qUtf8Printable(hash));
+    qDebug(" -> Name: %s", qUtf8Printable(name));
 
     libt::add_torrent_params p = magnetUri.addTorrentParams();
 
@@ -2114,7 +2114,7 @@ void Session::generateResumeData(bool final)
         if (!final && !torrent->needSaveResumeData()) continue;
 
         saveTorrentResumeData(torrent, final);
-        qDebug("Saving fastresume data for %s", qPrintable(torrent->name()));
+        qDebug("Saving fastresume data for %s", qUtf8Printable(torrent->name()));
     }
 }
 
@@ -2237,7 +2237,7 @@ const QStringList Session::getListeningIPs()
     // Attempt to listen on provided interface
     const QNetworkInterface networkIFace = QNetworkInterface::interfaceFromName(ifaceName);
     if (!networkIFace.isValid()) {
-        qDebug("Invalid network interface: %s", qPrintable(ifaceName));
+        qDebug("Invalid network interface: %s", qUtf8Printable(ifaceName));
         logger->addMessage(tr("The network interface defined is invalid: %1").arg(ifaceName), Log::CRITICAL);
         IPs.append("127.0.0.1"); // Force listening to localhost and avoid accidental connection that will expose user data.
         return IPs;
@@ -3189,7 +3189,7 @@ void Session::handleTorrentFinished(TorrentHandle *const torrent)
         if (torrentRelpath.endsWith(".torrent", Qt::CaseInsensitive)) {
             qDebug("Found possible recursive torrent download.");
             const QString torrentFullpath = torrent->savePath(true) + "/" + torrentRelpath;
-            qDebug("Full subtorrent path is %s", qPrintable(torrentFullpath));
+            qDebug("Full subtorrent path is %s", qUtf8Printable(torrentFullpath));
             TorrentInfo torrentInfo = TorrentInfo::loadFromFile(torrentFullpath);
             if (torrentInfo.isValid()) {
                 qDebug("emitting recursiveTorrentDownloadPossible()");
@@ -3996,7 +3996,7 @@ namespace
     {
         QFile file(path);
         if (!file.open(QIODevice::ReadOnly)) {
-            qDebug("Cannot read file %s: %s", qPrintable(path), qPrintable(file.errorString()));
+            qDebug("Cannot read file %s: %s", qUtf8Printable(path), qUtf8Printable(file.errorString()));
             return false;
         }
 

--- a/src/base/bittorrent/torrentcreatorthread.cpp
+++ b/src/base/bittorrent/torrentcreatorthread.cpp
@@ -135,7 +135,7 @@ void TorrentCreatorThread::run()
         if (isInterruptionRequested()) return;
 
         // create the torrent and print it to out
-        qDebug("Saving to %s", qPrintable(m_savePath));
+        qDebug("Saving to %s", qUtf8Printable(m_savePath));
 #ifdef _MSC_VER
         wchar_t *savePathW = new wchar_t[m_savePath.length() + 1];
         int len = Utils::Fs::toNativePath(m_savePath).toWCharArray(savePathW);

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -67,7 +67,7 @@ TorrentInfo TorrentInfo::loadFromFile(const QString &path, QString &error)
     TorrentInfo info(NativePtr(new libt::torrent_info(Utils::Fs::toNativePath(path).toStdString(), ec)));
     if (ec) {
         error = QString::fromUtf8(ec.message().c_str());
-        qDebug("Cannot load .torrent file: %s", qPrintable(error));
+        qDebug("Cannot load .torrent file: %s", qUtf8Printable(error));
     }
 
     return info;

--- a/src/base/bittorrent/tracker.cpp
+++ b/src/base/bittorrent/tracker.cpp
@@ -109,14 +109,14 @@ Http::Response Tracker::processRequest(const Http::Request &request, const Http:
 {
     clear(); // clear response
 
-    //qDebug("Tracker received the following request:\n%s", qPrintable(parser.toString()));
+    //qDebug("Tracker received the following request:\n%s", qUtf8Printable(parser.toString()));
     // Is request a GET request?
     if (request.method != "GET") {
-        qDebug("Tracker: Unsupported HTTP request: %s", qPrintable(request.method));
+        qDebug("Tracker: Unsupported HTTP request: %s", qUtf8Printable(request.method));
         status(100, "Invalid request type");
     }
     else if (!request.path.startsWith("/announce", Qt::CaseInsensitive)) {
-        qDebug("Tracker: Unrecognized path: %s", qPrintable(request.path));
+        qDebug("Tracker: Unrecognized path: %s", qUtf8Printable(request.path));
         status(100, "Invalid request type");
     }
     else {
@@ -146,7 +146,7 @@ void Tracker::respondToAnnounceRequest()
     annonceReq.infoHash = gets.value("info_hash");
     // info_hash cannot be longer than 20 bytes
     /*if (annonce_req.info_hash.toLatin1().length() > 20) {
-        qDebug("Tracker: Info_hash is not 20 byte long: %s (%d)", qPrintable(annonce_req.info_hash), annonce_req.info_hash.toLatin1().length());
+        qDebug("Tracker: Info_hash is not 20 byte long: %s (%d)", qUtf8Printable(annonce_req.info_hash), annonce_req.info_hash.toLatin1().length());
         status(150, "Invalid infohash");
         return;
       }*/
@@ -160,7 +160,7 @@ void Tracker::respondToAnnounceRequest()
     annonceReq.peer.peerId = gets.value("peer_id");
     // peer_id cannot be longer than 20 bytes
     /*if (annonce_req.peer.peer_id.length() > 20) {
-        qDebug("Tracker: peer_id is not 20 byte long: %s", qPrintable(annonce_req.peer.peer_id));
+        qDebug("Tracker: peer_id is not 20 byte long: %s", qUtf8Printable(annonce_req.peer.peer_id));
         status(151, "Invalid peerid");
         return;
       }*/
@@ -183,7 +183,7 @@ void Tracker::respondToAnnounceRequest()
     annonceReq.event = "";
     if (gets.contains("event")) {
         annonceReq.event = gets.value("event");
-        qDebug("Tracker: event is %s", qPrintable(annonceReq.event));
+        qDebug("Tracker: event is %s", qUtf8Printable(annonceReq.event));
     }
 
     // 5. Get numwant

--- a/src/base/filesystemwatcher.cpp
+++ b/src/base/filesystemwatcher.cpp
@@ -71,7 +71,7 @@ void FileSystemWatcher::addPath(const QString &path)
     // Check if the path points to a network file system or not
     if (isNetworkFileSystem(path)) {
         // Network mode
-        qDebug("Network folder detected: %s", qPrintable(path));
+        qDebug("Network folder detected: %s", qUtf8Printable(path));
         qDebug("Using file polling mode instead of inotify...");
         m_watchedFolders << dir;
         // Set up the watch timer
@@ -84,7 +84,7 @@ void FileSystemWatcher::addPath(const QString &path)
     else {
 #endif
         // Normal mode
-        qDebug("FS Watching is watching %s in normal mode", qPrintable(path));
+        qDebug("FS Watching is watching %s in normal mode", qUtf8Printable(path));
         QFileSystemWatcher::addPath(path);
         scanLocalFolder(path);
 #if !defined Q_OS_WIN && !defined Q_OS_HAIKU
@@ -111,13 +111,13 @@ void FileSystemWatcher::removePath(const QString &path)
 
 void FileSystemWatcher::scanLocalFolder(QString path)
 {
-    qDebug("scanLocalFolder(%s) called", qPrintable(path));
+    qDebug("scanLocalFolder(%s) called", qUtf8Printable(path));
     QStringList torrents;
     // Local folders scan
     addTorrentsFromDir(QDir(path), torrents);
     // Report detected torrent files
     if (!torrents.empty()) {
-        qDebug("The following files are being reported: %s", qPrintable(torrents.join("\n")));
+        qDebug("The following files are being reported: %s", qUtf8Printable(torrents.join("\n")));
         emit torrentsAdded(torrents);
     }
 }
@@ -129,12 +129,12 @@ void FileSystemWatcher::scanNetworkFolders()
     QStringList torrents;
     // Network folders scan
     foreach (const QDir &dir, m_watchedFolders) {
-        //qDebug("FSWatcher: Polling manually folder %s", qPrintable(dir.path()));
+        //qDebug("FSWatcher: Polling manually folder %s", qUtf8Printable(dir.path()));
         addTorrentsFromDir(dir, torrents);
     }
     // Report detected torrent files
     if (!torrents.empty()) {
-        qDebug("The following files are being reported: %s", qPrintable(torrents.join("\n")));
+        qDebug("The following files are being reported: %s", qUtf8Printable(torrents.join("\n")));
         emit torrentsAdded(torrents);
     }
 #endif
@@ -201,7 +201,7 @@ void FileSystemWatcher::addTorrentsFromDir(const QDir &dir, QStringList &torrent
             torrents << fileAbsPath;
         }
         else if (!m_partialTorrents.contains(fileAbsPath)) {
-            qDebug("Partial torrent detected at: %s", qPrintable(fileAbsPath));
+            qDebug("Partial torrent detected at: %s", qUtf8Printable(fileAbsPath));
             qDebug("Delay the file's processing...");
             m_partialTorrents.insert(fileAbsPath, 0);
         }

--- a/src/base/net/downloadhandler.cpp
+++ b/src/base/net/downloadhandler.cpp
@@ -73,11 +73,11 @@ QString DownloadHandler::url() const
 void DownloadHandler::processFinishedDownload()
 {
     QString url = m_reply->url().toString();
-    qDebug("Download finished: %s", qPrintable(url));
+    qDebug("Download finished: %s", qUtf8Printable(url));
     // Check if the request was successful
     if (m_reply->error() != QNetworkReply::NoError) {
         // Failure
-        qDebug("Download failure (%s), reason: %s", qPrintable(url), qPrintable(errorCodeToString(m_reply->error())));
+        qDebug("Download failure (%s), reason: %s", qUtf8Printable(url), qUtf8Printable(errorCodeToString(m_reply->error())));
         emit downloadFailed(m_url, errorCodeToString(m_reply->error()));
         this->deleteLater();
     }
@@ -150,7 +150,7 @@ bool DownloadHandler::saveToFile(const QByteArray &replyData, QString &filePath)
 
     tmpfile->setAutoRemove(false);
     filePath = tmpfile->fileName();
-    qDebug("Temporary filename is: %s", qPrintable(filePath));
+    qDebug("Temporary filename is: %s", qUtf8Printable(filePath));
     if (m_reply->isOpen() || m_reply->open(QIODevice::ReadOnly)) {
         tmpfile->write(replyData);
         tmpfile->close();
@@ -174,7 +174,7 @@ void DownloadHandler::handleRedirection(QUrl newUrl)
         newUrl = m_reply->url().resolved(newUrl);
 
     const QString newUrlString = newUrl.toString();
-    qDebug("Redirecting from %s to %s", qPrintable(m_reply->url().toString()), qPrintable(newUrlString));
+    qDebug("Redirecting from %s to %s", qUtf8Printable(m_reply->url().toString()), qUtf8Printable(newUrlString));
 
     // Redirect to magnet workaround
     if (newUrlString.startsWith("magnet:", Qt::CaseInsensitive)) {

--- a/src/base/net/downloadmanager.cpp
+++ b/src/base/net/downloadmanager.cpp
@@ -143,7 +143,7 @@ DownloadHandler *DownloadManager::downloadUrl(const QString &url, bool saveToFil
     applyProxySettings();
 
     // Process download request
-    qDebug("url is %s", qPrintable(url));
+    qDebug("url is %s", qUtf8Printable(url));
     const QUrl qurl = QUrl(url);
     QNetworkRequest request(qurl);
 

--- a/src/base/net/proxyconfigurationmanager.cpp
+++ b/src/base/net/proxyconfigurationmanager.cpp
@@ -153,7 +153,7 @@ void ProxyConfigurationManager::configureProxy()
         }
 
         qDebug("HTTP communications proxy string: %s"
-               , qPrintable((m_config.type == ProxyType::SOCKS5) || (m_config.type == ProxyType::SOCKS5_PW)
+               , qUtf8Printable((m_config.type == ProxyType::SOCKS5) || (m_config.type == ProxyType::SOCKS5_PW)
                             ? proxyStrSOCK : proxyStrHTTP));
     }
 

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -853,12 +853,12 @@ namespace {
                 delete[] lpSubkey;
 
                 if (res == ERROR_SUCCESS) {
-                    qDebug("Detected possible Python v%s location", qPrintable(version));
+                    qDebug("Detected possible Python v%s location", qUtf8Printable(version));
                     path = getRegValue(hkInstallPath);
                     ::RegCloseKey(hkInstallPath);
 
                     if (!path.isEmpty() && QDir(path).exists("python.exe")) {
-                        qDebug("Found python.exe at %s", qPrintable(path));
+                        qDebug("Found python.exe at %s", qUtf8Printable(path));
                         found = true;
                     }
                 }
@@ -931,7 +931,7 @@ bool Preferences::isMagnetLinkAssocSet()
     if (exe_reg.indexIn(shell_command) < 0)
         return false;
     QString assoc_exe = exe_reg.cap(1);
-    qDebug("exe: %s", qPrintable(assoc_exe));
+    qDebug("exe: %s", qUtf8Printable(assoc_exe));
     if (assoc_exe.compare(Utils::Fs::toNativePath(qApp->applicationFilePath()), Qt::CaseInsensitive) != 0)
         return false;
 

--- a/src/base/profile.cpp
+++ b/src/base/profile.cpp
@@ -104,7 +104,7 @@ void Profile::ensureDirectoryExists(SpecialFolder folder)
 {
     QString locationPath = location(folder);
     if (!locationPath.isEmpty() && !QDir().mkpath(locationPath))
-        qFatal("Could not create required directory '%s'", qPrintable(locationPath));
+        qFatal("Could not create required directory '%s'", qUtf8Printable(locationPath));
 }
 
 QString Profile::toPortablePath(const QString &absolutePath) const

--- a/src/base/scanfoldersmodel.cpp
+++ b/src/base/scanfoldersmodel.cpp
@@ -353,7 +353,7 @@ void ScanFoldersModel::configure()
 void ScanFoldersModel::addTorrentsToSession(const QStringList &pathList)
 {
     foreach (const QString &file, pathList) {
-        qDebug("File %s added", qPrintable(file));
+        qDebug("File %s added", qUtf8Printable(file));
 
         BitTorrent::AddTorrentParams params;
         if (downloadInWatchFolder(file))
@@ -372,7 +372,7 @@ void ScanFoldersModel::addTorrentsToSession(const QStringList &pathList)
                 Utils::Fs::forceRemove(file);
             }
             else {
-                qDebug("Failed to open magnet file: %s", qPrintable(f.errorString()));
+                qDebug("Failed to open magnet file: %s", qUtf8Printable(f.errorString()));
             }
         }
         else {
@@ -382,7 +382,7 @@ void ScanFoldersModel::addTorrentsToSession(const QStringList &pathList)
                 Utils::Fs::forceRemove(file);
             }
             else {
-                qDebug("Ignoring incomplete torrent file: %s", qPrintable(file));
+                qDebug("Ignoring incomplete torrent file: %s", qUtf8Printable(file));
             }
         }
     }

--- a/src/base/searchengine.cpp
+++ b/src/base/searchengine.cpp
@@ -155,7 +155,7 @@ void SearchEngine::updatePlugin(const QString &name)
 // Install or update plugin from file or url
 void SearchEngine::installPlugin(const QString &source)
 {
-    qDebug("Asked to install plugin at %s", qPrintable(source));
+    qDebug("Asked to install plugin at %s", qUtf8Printable(source));
 
     if (Utils::Misc::isUrl(source)) {
         using namespace Net;
@@ -615,7 +615,7 @@ void SearchEngine::parseVersionInfo(const QByteArray &info)
 
         dataCorrect = true;
         if (isUpdateNeeded(pluginName, version)) {
-            qDebug("Plugin: %s is outdated", qPrintable(pluginName));
+            qDebug("Plugin: %s is outdated", qUtf8Printable(pluginName));
             updateInfo[pluginName] = version;
         }
     }
@@ -662,7 +662,7 @@ PluginVersion SearchEngine::getPluginVersion(QString filePath)
 {
     QFile plugin(filePath);
     if (!plugin.exists()) {
-        qDebug("%s plugin does not exist, returning 0.0", qPrintable(filePath));
+        qDebug("%s plugin does not exist, returning 0.0", qUtf8Printable(filePath));
         return {};
     }
 

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -476,7 +476,7 @@ void AddNewTorrentDialog::renameSelectedFile()
         const QString newFilePath = oldFilePath.leftRef(oldFilePath.size() - oldFileName.size()) + newName;
 
         if (oldFileName == newName) {
-            qDebug("Name did not change: %s", qPrintable(oldFileName));
+            qDebug("Name did not change: %s", qUtf8Printable(oldFileName));
             return;
         }
 
@@ -491,7 +491,7 @@ void AddNewTorrentDialog::renameSelectedFile()
             }
         }
 
-        qDebug("Renaming %s to %s", qPrintable(oldFilePath), qPrintable(newFilePath));
+        qDebug("Renaming %s to %s", qUtf8Printable(oldFilePath), qUtf8Printable(newFilePath));
         m_torrentInfo.renameFile(fileIndex, newFilePath);
 
         m_contentModel->setData(modelIndex, newName);
@@ -535,7 +535,7 @@ void AddNewTorrentDialog::renameSelectedFile()
                 QString newName = currentName;
                 newName.replace(0, oldPath.length(), newPath);
                 newName = Utils::Fs::expandPath(newName);
-                qDebug("Rename %s to %s", qPrintable(currentName), qPrintable(newName));
+                qDebug("Rename %s to %s", qUtf8Printable(currentName), qUtf8Printable(newName));
                 m_torrentInfo.renameFile(i, newName);
             }
         }

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1247,7 +1247,7 @@ void MainWindow::dropEvent(QDropEvent *event)
     // Download torrents
     const bool useTorrentAdditionDialog = AddNewTorrentDialog::isEnabled();
     foreach (const QString &file, torrentFiles) {
-        qDebug("Dropped file %s on download list", qPrintable(file));
+        qDebug("Dropped file %s on download list", qUtf8Printable(file));
         if (useTorrentAdditionDialog)
             AddNewTorrentDialog::show(file, this);
         else
@@ -1341,7 +1341,7 @@ void MainWindow::on_actionOpen_triggered()
     const bool useTorrentAdditionDialog = AddNewTorrentDialog::isEnabled();
     if (!pathsList.isEmpty()) {
         foreach (QString file, pathsList) {
-            qDebug("Dropped file %s on download list", qPrintable(file));
+            qDebug("Dropped file %s on download list", qUtf8Printable(file));
             if (useTorrentAdditionDialog)
                 AddNewTorrentDialog::show(file, this);
             else
@@ -2027,7 +2027,7 @@ bool MainWindow::addPythonPathToEnv()
         if (pathEnvar.isNull())
             pathEnvar = "";
         pathEnvar = pythonPath + ";" + pathEnvar;
-        qDebug("New PATH envvar is: %s", qPrintable(pathEnvar));
+        qDebug("New PATH envvar is: %s", qUtf8Printable(pathEnvar));
         qputenv("PATH", Utils::Fs::toNativePath(pathEnvar).toLocal8Bit());
         return true;
     }

--- a/src/gui/optionsdlg.cpp
+++ b/src/gui/optionsdlg.cpp
@@ -476,9 +476,9 @@ void OptionsDialog::saveOptions()
     if (pref->getLocale() != locale) {
         QTranslator *translator = new QTranslator;
         if (translator->load(QString::fromUtf8(":/lang/qbittorrent_") + locale))
-            qDebug("%s locale recognized, using translation.", qPrintable(locale));
+            qDebug("%s locale recognized, using translation.", qUtf8Printable(locale));
         else
-            qDebug("%s locale unrecognized, using default (en).", qPrintable(locale));
+            qDebug("%s locale unrecognized, using default (en).", qUtf8Printable(locale));
         qApp->installTranslator(translator);
     }
 

--- a/src/gui/powermanagement/powermanagement_x11.cpp
+++ b/src/gui/powermanagement/powermanagement_x11.cpp
@@ -136,7 +136,7 @@ void PowerManagementInhibitor::OnAsyncReply(QDBusPendingCallWatcher *call)
 
         if (reply.isError())
         {
-            qDebug("D-Bus: Reply: Error: %s", qPrintable(reply.error().message()));
+            qDebug("D-Bus: Reply: Error: %s", qUtf8Printable(reply.error().message()));
             m_state = error;
         }
         else
@@ -152,7 +152,7 @@ void PowerManagementInhibitor::OnAsyncReply(QDBusPendingCallWatcher *call)
 
         if (reply.isError())
         {
-            qDebug("D-Bus: Reply: Error: %s", qPrintable(reply.error().message()));
+            qDebug("D-Bus: Reply: Error: %s", qUtf8Printable(reply.error().message()));
 
             if (!m_use_gsm)
             {

--- a/src/gui/programupdater.cpp
+++ b/src/gui/programupdater.cpp
@@ -99,9 +99,9 @@ void ProgramUpdater::rssDownloadFinished(const QString &url, const QByteArray &d
         else if (xml.isEndElement()) {
             if (inItem && xml.name() == "item") {
                 if (type.compare(OS_TYPE, Qt::CaseInsensitive) == 0) {
-                    qDebug("The last update available is %s", qPrintable(version));
+                    qDebug("The last update available is %s", qUtf8Printable(version));
                     if (!version.isEmpty()) {
-                        qDebug("Detected version is %s", qPrintable(version));
+                        qDebug("Detected version is %s", qUtf8Printable(version));
                         if (isVersionMoreRecent(version))
                             m_updateUrl = updateLink;
                     }

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -249,7 +249,7 @@ void PeerListWidget::showPeerListMenu(const QPoint &)
         int peerCount = 0;
         foreach (const BitTorrent::PeerAddress &addr, peersList) {
             if (torrent->connectPeer(addr)) {
-                qDebug("Adding peer %s...", qPrintable(addr.ip.toString()));
+                qDebug("Adding peer %s...", qUtf8Printable(addr.ip.toString()));
                 Logger::instance()->addMessage(tr("Manually adding peer '%1'...").arg(addr.ip.toString()));
                 peerCount++;
             }
@@ -442,7 +442,7 @@ void PeerListWidget::handleResolved(const QString &ip, const QString &hostname)
 {
     QStandardItem *item = m_peerItems.value(ip, 0);
     if (item) {
-        qDebug("Resolved %s -> %s", qPrintable(ip), qPrintable(hostname));
+        qDebug("Resolved %s -> %s", qUtf8Printable(ip), qUtf8Printable(hostname));
         item->setData(hostname, Qt::DisplayRole);
     }
 }

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -514,7 +514,7 @@ void PropertiesWidget::loadUrlSeeds()
     const QList<QUrl> hc_seeds = m_torrent->urlSeeds();
     // Add url seeds
     foreach (const QUrl &hc_seed, hc_seeds) {
-        qDebug("Loading URL seed: %s", qPrintable(hc_seed.toString()));
+        qDebug("Loading URL seed: %s", qUtf8Printable(hc_seed.toString()));
         new QListWidgetItem(hc_seed.toString(), m_ui->listWebSeeds);
     }
 }
@@ -535,7 +535,7 @@ void PropertiesWidget::openFile(const QModelIndex &index)
     const QDir saveDir(m_torrent->savePath(true));
     const QString filename = m_torrent->filePath(i);
     const QString file_path = Utils::Fs::expandPath(saveDir.absoluteFilePath(filename));
-    qDebug("Trying to open file at %s", qPrintable(file_path));
+    qDebug("Trying to open file at %s", qUtf8Printable(file_path));
     // Flush data
     m_torrent->flushCache();
     Utils::Misc::openPath(file_path);
@@ -704,7 +704,7 @@ void PropertiesWidget::renameSelectedFile()
         const QString newFilePath = oldFilePath.leftRef(oldFilePath.size() - oldFileName.size()) + newFileName;
 
         if (oldFileName == newFileName) {
-            qDebug("Name did not change: %s", qPrintable(oldFileName));
+            qDebug("Name did not change: %s", qUtf8Printable(oldFileName));
             return;
         }
 
@@ -719,7 +719,7 @@ void PropertiesWidget::renameSelectedFile()
             }
         }
 
-        qDebug("Renaming %s to %s", qPrintable(oldFilePath), qPrintable(newFilePath));
+        qDebug("Renaming %s to %s", qUtf8Printable(oldFilePath), qUtf8Printable(newFilePath));
         m_torrent->renameFile(fileIndex, newFilePath);
 
         PropListModel->setData(modelIndex, newName);
@@ -766,7 +766,7 @@ void PropertiesWidget::renameSelectedFile()
                 if (!forceRecheck && QDir(m_torrent->savePath(true)).exists(newName))
                     forceRecheck = true;
                 newName = Utils::Fs::expandPath(newName);
-                qDebug("Rename %s to %s", qPrintable(currentName), qPrintable(newName));
+                qDebug("Rename %s to %s", qUtf8Printable(currentName), qUtf8Printable(newName));
                 m_torrent->renameFile(i, newName);
             }
         }
@@ -801,7 +801,7 @@ void PropertiesWidget::askWebSeed()
                                                            tr("New URL seed:"), QLineEdit::Normal,
                                                            QString::fromUtf8("http://www."), &ok);
     if (!ok) return;
-    qDebug("Adding %s web seed", qPrintable(url_seed));
+    qDebug("Adding %s web seed", qUtf8Printable(url_seed));
     if (!m_ui->listWebSeeds->findItems(url_seed, Qt::MatchFixedString).empty()) {
         QMessageBox::warning(this, "qBittorrent",
                              tr("This URL seed is already in the list."),

--- a/src/gui/search/pluginselectdlg.cpp
+++ b/src/gui/search/pluginselectdlg.cpp
@@ -128,7 +128,7 @@ void PluginSelectDlg::dropEvent(QDropEvent *event)
     if (files.isEmpty()) return;
 
     foreach (QString file, files) {
-        qDebug("dropped %s", qPrintable(file));
+        qDebug("dropped %s", qUtf8Printable(file));
         startAsyncOp();
         m_pluginManager->installPlugin(file);
     }
@@ -139,7 +139,7 @@ void PluginSelectDlg::dragEnterEvent(QDragEnterEvent *event)
 {
     QString mime;
     foreach (mime, event->mimeData()->formats()) {
-        qDebug("mimeData: %s", qPrintable(mime));
+        qDebug("mimeData: %s", qUtf8Printable(mime));
     }
 
     if (event->mimeData()->hasFormat(QLatin1String("text/plain")) || event->mimeData()->hasFormat(QLatin1String("text/uri-list"))) {
@@ -413,7 +413,7 @@ void PluginSelectDlg::iconDownloaded(const QString &url, QString filePath)
 
 void PluginSelectDlg::iconDownloadFailed(const QString &url, const QString &reason)
 {
-    qDebug("Could not download favicon: %s, reason: %s", qPrintable(url), qPrintable(reason));
+    qDebug("Could not download favicon: %s, reason: %s", qUtf8Printable(url), qUtf8Printable(reason));
 }
 
 void PluginSelectDlg::checkForUpdatesFinished(const QHash<QString, PluginVersion> &updateInfo)

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -153,7 +153,7 @@ void SearchWidget::fillCatCombobox()
     std::sort(tmpList.begin(), tmpList.end(), [](const QStrPair &l, const QStrPair &r) { return (QString::localeAwareCompare(l.first, r.first) < 0); });
 
     foreach (const QStrPair &p, tmpList) {
-        qDebug("Supported category: %s", qPrintable(p.second));
+        qDebug("Supported category: %s", qUtf8Printable(p.second));
         m_ui->comboCategory->addItem(p.first, QVariant(p.second));
     }
 }
@@ -318,7 +318,7 @@ void SearchWidget::on_searchButton_clicked()
     else if (selectedPlugin() == "multi") plugins = m_searchEngine->enabledPlugins();
     else plugins << selectedPlugin();
 
-    qDebug("Search with category: %s", qPrintable(selectedCategory()));
+    qDebug("Search with category: %s", qUtf8Printable(selectedCategory()));
 
     // Update SearchEngine widgets
     m_noSearchResults = true;

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -280,7 +280,7 @@ bool TorrentContentModel::setData(const QModelIndex& index, const QVariant& valu
 
     if ((index.column() == TorrentContentModelItem::COL_NAME) && (role == Qt::CheckStateRole)) {
         TorrentContentModelItem *item = static_cast<TorrentContentModelItem*>(index.internalPointer());
-        qDebug("setData(%s, %d", qPrintable(item->name()), value.toInt());
+        qDebug("setData(%s, %d", qUtf8Printable(item->name()), value.toInt());
         if (item->priority() != value.toInt()) {
             if (value.toInt() == Qt::PartiallyChecked)
                 item->setPriority(prio::MIXED);

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -380,12 +380,12 @@ void TransferListWidget::setSelectedTorrentsLocation()
     if (torrents.isEmpty()) return;
 
     const QString oldLocation = torrents[0]->savePath();
-    qDebug("Old location is %s", qPrintable(oldLocation));
+    qDebug("Old location is %s", qUtf8Printable(oldLocation));
 
     const QString newLocation = QFileDialog::getExistingDirectory(this, tr("Choose save path"), oldLocation,
                                             QFileDialog::DontConfirmOverwrite | QFileDialog::ShowDirsOnly | QFileDialog::HideNameFilterDetails);
     if (newLocation.isEmpty() || !QDir(newLocation).exists()) return;
-    qDebug("New location is %s", qPrintable(newLocation));
+    qDebug("New location is %s", qUtf8Printable(newLocation));
 
     // Actually move storage
     foreach (BitTorrent::TorrentHandle *const torrent, torrents) {
@@ -592,7 +592,7 @@ void TransferListWidget::setDlLimitSelectedTorrents()
     if (!ok) return;
 
     foreach (BitTorrent::TorrentHandle *const torrent, TorrentsList) {
-        qDebug("Applying download speed limit of %ld Kb/s to torrent %s", (newLimit / 1024l), qPrintable(torrent->hash()));
+        qDebug("Applying download speed limit of %ld Kb/s to torrent %s", (newLimit / 1024l), qUtf8Printable(torrent->hash()));
         torrent->setDownloadLimit(newLimit);
     }
 }
@@ -617,7 +617,7 @@ void TransferListWidget::setUpLimitSelectedTorrents()
     if (!ok) return;
 
     foreach (BitTorrent::TorrentHandle *const torrent, TorrentsList) {
-        qDebug("Applying upload speed limit of %ld Kb/s to torrent %s", (newLimit / 1024l), qPrintable(torrent->hash()));
+        qDebug("Applying upload speed limit of %ld Kb/s to torrent %s", (newLimit / 1024l), qUtf8Printable(torrent->hash()));
         torrent->setUploadLimit(newLimit);
     }
 }
@@ -1174,7 +1174,7 @@ void TransferListWidget::applyStatusFilter(int f)
     nameFilterModel->setStatusFilter(static_cast<TorrentFilter::Type>(f));
     // Select first item if nothing is selected
     if (selectionModel()->selectedRows(0).empty() && nameFilterModel->rowCount() > 0) {
-        qDebug("Nothing is selected, selecting first row: %s", qPrintable(nameFilterModel->index(0, TorrentModel::TR_NAME).data().toString()));
+        qDebug("Nothing is selected, selecting first row: %s", qUtf8Printable(nameFilterModel->index(0, TorrentModel::TR_NAME).data().toString()));
         selectionModel()->setCurrentIndex(nameFilterModel->index(0, TorrentModel::TR_NAME), QItemSelectionModel::SelectCurrent | QItemSelectionModel::Rows);
     }
 }

--- a/src/webui/abstractwebapplication.cpp
+++ b/src/webui/abstractwebapplication.cpp
@@ -143,7 +143,7 @@ Http::Response AbstractWebApplication::processRequest(const Http::Request &reque
 void AbstractWebApplication::UnbanTimerEvent()
 {
     UnbanTimer* ubantimer = static_cast<UnbanTimer*>(sender());
-    qDebug("Ban period has expired for %s", qPrintable(ubantimer->peerIp().toString()));
+    qDebug("Ban period has expired for %s", qUtf8Printable(ubantimer->peerIp().toString()));
     clientFailedAttempts_.remove(ubantimer->peerIp());
     ubantimer->deleteLater();
 }
@@ -201,7 +201,7 @@ bool AbstractWebApplication::readFile(const QString& path, QByteArray &data, QSt
     else {
         QFile file(path);
         if (!file.open(QIODevice::ReadOnly)) {
-            qDebug("File %s was not found!", qPrintable(path));
+            qDebug("File %s was not found!", qUtf8Printable(path));
             return false;
         }
 

--- a/src/webui/prefjson.cpp
+++ b/src/webui/prefjson.cpp
@@ -226,10 +226,10 @@ void prefjson::setPreferences(const QString& json)
 
             if (ec == ScanFoldersModel::Ok) {
                 scanDirs.insert(folder, (downloadType == ScanFoldersModel::CUSTOM_LOCATION) ? QVariant(downloadPath) : QVariant(downloadType));
-                qDebug("New watched folder: %s to %s", qPrintable(folder), qPrintable(downloadPath));
+                qDebug("New watched folder: %s to %s", qUtf8Printable(folder), qUtf8Printable(downloadPath));
             }
             else {
-                qDebug("Watched folder %s failed with error %d", qPrintable(folder), ec);
+                qDebug("Watched folder %s failed with error %d", qUtf8Printable(folder), ec);
             }
         }
 
@@ -238,7 +238,7 @@ void prefjson::setPreferences(const QString& json)
             QString folder = folderVariant.toString();
             if (!scanDirs.contains(folder)) {
                 model->removePath(folder);
-                qDebug("Removed watched folder %s", qPrintable(folder));
+                qDebug("Removed watched folder %s", qUtf8Printable(folder));
             }
         }
         pref->setScanDirs(scanDirs);
@@ -387,9 +387,9 @@ void prefjson::setPreferences(const QString& json)
         if (pref->getLocale() != locale) {
             QTranslator *translator = new QTranslator;
             if (translator->load(QString::fromUtf8(":/lang/qbittorrent_") + locale)) {
-                qDebug("%s locale recognized, using translation.", qPrintable(locale));
+                qDebug("%s locale recognized, using translation.", qUtf8Printable(locale));
             }else{
-                qDebug("%s locale unrecognized, using default (en).", qPrintable(locale));
+                qDebug("%s locale unrecognized, using default (en).", qUtf8Printable(locale));
             }
             qApp->installTranslator(translator);
 

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -195,7 +195,7 @@ void WebApplication::action_public_login()
     else {
         QString addr = env().clientAddress.toString();
         increaseFailedAttempts();
-        qDebug("client IP: %s (%d failed attempts)", qPrintable(addr), failedAttempts());
+        qDebug("client IP: %s (%d failed attempts)", qUtf8Printable(addr), failedAttempts());
         print(QByteArray("Fails."), Http::CONTENT_TYPE_TXT);
     }
 }


### PR DESCRIPTION
Qt documentation says:
>qDebug(), qInfo(), qWarning(), qCritical(), qFatal() expect %s arguments
to be UTF-8 encoded, while qPrintable() converts to local 8-bit encoding.
Therefore qUtf8Printable() should be used for logging strings instead of
qPrintable().