### PR TITLE
Fix macOS window restoration after using hide icon

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1283,14 +1283,11 @@ static bool dockClickHandler(id self, SEL cmd, ...)
     Q_UNUSED(self)
     Q_UNUSED(cmd)
 
-    qDebug("Dock icon clicked!");
-
     if (dockMainWindowHandle && !dockMainWindowHandle->isVisible()) {
         dockMainWindowHandle->activate();
     }
 
-    // Return NO (false) to suppress the default OS X actions
-    return false;
+    return true;
 }
 
 void MainWindow::setupDockClickHandler()


### PR DESCRIPTION
I fixed the bugs with cross icon in #6952, yet managed to break hide icon (the middle one) unfortunately, which resulted in one being unable to restore the window after hiding it via the yellow icon. This change ensures that both icons work just fine.

Please merge into 3.4.0. From what I can tell there are no conflicts with #7253.