### PR TITLE
Fix calculation of 'Average time in queue' stat under libtorrent 1.1.x

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1083,6 +1083,15 @@ void Session::initMetrics()
     m_metricIndices.disk.numBlocksCacheHits = libt::find_metric_idx("disk.num_blocks_cache_hits");
     Q_ASSERT(m_metricIndices.disk.numBlocksCacheHits >= 0);
 
+    m_metricIndices.disk.writeJobs = libt::find_metric_idx("disk.num_write_ops");
+    Q_ASSERT(m_metricIndices.disk.writeJobs >= 0);
+
+    m_metricIndices.disk.readJobs = libt::find_metric_idx("disk.num_read_ops");
+    Q_ASSERT(m_metricIndices.disk.readJobs >= 0);
+
+    m_metricIndices.disk.hashJobs = libt::find_metric_idx("disk.num_blocks_hashed");
+    Q_ASSERT(m_metricIndices.disk.hashJobs >= 0);
+
     m_metricIndices.disk.queuedDiskJobs = libt::find_metric_idx("disk.queued_disk_jobs");
     Q_ASSERT(m_metricIndices.disk.queuedDiskJobs >= 0);
 
@@ -3912,7 +3921,11 @@ void Session::handleSessionStatsAlert(libt::session_stats_alert *p)
             ? static_cast<qreal>(p->values[m_metricIndices.disk.numBlocksCacheHits]) / numBlocksRead
             : -1;
     m_cacheStatus.jobQueueLength = p->values[m_metricIndices.disk.queuedDiskJobs];
-    m_cacheStatus.averageJobTime = p->values[m_metricIndices.disk.diskJobTime];
+
+    quint64 totalJobs = p->values[m_metricIndices.disk.writeJobs] + p->values[m_metricIndices.disk.readJobs]
+                  + p->values[m_metricIndices.disk.hashJobs];
+    m_cacheStatus.averageJobTime = totalJobs > 0
+                                   ? (p->values[m_metricIndices.disk.diskJobTime] / totalJobs) : 0;
 
     emit statsUpdated();
 }

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -188,6 +188,9 @@ namespace BitTorrent
             int diskBlocksInUse = 0;
             int numBlocksRead = 0;
             int numBlocksCacheHits = 0;
+            int writeJobs = 0;
+            int readJobs = 0;
+            int hashJobs = 0;
             int queuedDiskJobs = 0;
             int diskJobTime = 0;
         } disk;


### PR DESCRIPTION
RC_1_1 does the same calculation when it fills the deprecated `cache_status::average_job_time` field.