### PR TITLE
Fix notification display on macOS

### DIFF
--- a/src/gui/macutilities.h
+++ b/src/gui/macutilities.h
@@ -35,5 +35,6 @@
 
 QPixmap pixmapForExtension(const QString &ext, const QSize &size);
 void overrideDockClickHandler(bool (*dockClickHandler)(id, SEL, ...));
+void displayNotification(const QString &title, const QString &message);
 
 #endif // MACUTILITIES_H

--- a/src/gui/macutilities.mm
+++ b/src/gui/macutilities.mm
@@ -69,3 +69,15 @@ void overrideDockClickHandler(bool (*dockClickHandler)(id, SEL, ...))
             qWarning("Failed to register dock click handler");
     }
 }
+
+void displayNotification(const QString &title, const QString &message)
+{
+    @autoreleasepool {
+        NSUserNotification *notification = [[NSUserNotification alloc] init];
+        notification.title = title.toNSString();
+        notification.informativeText = message.toNSString();
+        notification.soundName = NSUserNotificationDefaultSoundName;
+
+        [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
+    }
+}

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1553,7 +1553,9 @@ void MainWindow::showNotificationBaloon(QString title, QString msg) const
     reply.waitForFinished();
     if (!reply.isError())
         return;
-#elif (!defined(Q_OS_MAC))
+#elif defined(Q_OS_MAC)
+    displayNotification(title, msg);
+#else
     if (m_systrayIcon && QSystemTrayIcon::supportsMessages())
         m_systrayIcon->showMessage(title, msg, QSystemTrayIcon::Information, TIME_TRAY_BALLOON);
 #endif


### PR DESCRIPTION
This got accidentally broken as a result of #6952. Now uses a native API, which is available since [10.8](https://developer.apple.com/documentation/foundation/nsusernotification), and thus should be fine.