### PR TITLE
Options to better memory control by libtorrent. Closes #7029.

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -2818,12 +2818,12 @@ void Session::setDiskCacheSize(int size)
     }
 }
 
-uint Session::diskCacheTTL() const
+int Session::diskCacheTTL() const
 {
     return m_diskCacheTTL;
 }
 
-void Session::setDiskCacheTTL(uint ttl)
+void Session::setDiskCacheTTL(int ttl)
 {
     if (ttl != m_diskCacheTTL) {
         m_diskCacheTTL = ttl;
@@ -2928,12 +2928,12 @@ void Session::setIgnoreSlowTorrentsForQueueing(bool ignore)
     }
 }
 
-uint Session::outgoingPortsMin() const
+int Session::outgoingPortsMin() const
 {
     return m_outgoingPortsMin;
 }
 
-void Session::setOutgoingPortsMin(uint min)
+void Session::setOutgoingPortsMin(int min)
 {
     if (min != m_outgoingPortsMin) {
         m_outgoingPortsMin = min;
@@ -2941,12 +2941,12 @@ void Session::setOutgoingPortsMin(uint min)
     }
 }
 
-uint Session::outgoingPortsMax() const
+int Session::outgoingPortsMax() const
 {
     return m_outgoingPortsMax;
 }
 
-void Session::setOutgoingPortsMax(uint max)
+void Session::setOutgoingPortsMax(int max)
 {
     if (max != m_outgoingPortsMax) {
         m_outgoingPortsMax = max;

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -378,6 +378,10 @@ Session::Session(QObject *parent)
     sessionSettings.connection_speed = 20; // default is 10
     sessionSettings.no_connect_privileged_ports = false;
     sessionSettings.seed_choking_algorithm = libt::session_settings::fastest_upload;
+    // Disk cache pool is rarely tested in libtorrent and doesn't free buffers
+    // Soon to be deprecated there
+    // More info: https://github.com/arvidn/libtorrent/issues/2251
+    sessionSettings.use_disk_cache_pool = false;
     configure(sessionSettings);
     m_nativeSession->set_settings(sessionSettings);
     configureListeningInterface();
@@ -405,6 +409,10 @@ Session::Session(QObject *parent)
     pack.set_int(libt::settings_pack::connection_speed, 20); // default is 10
     pack.set_bool(libt::settings_pack::no_connect_privileged_ports, false);
     pack.set_int(libt::settings_pack::seed_choking_algorithm, libt::settings_pack::fastest_upload);
+    // Disk cache pool is rarely tested in libtorrent and doesn't free buffers
+    // Soon to be deprecated there
+    // More info: https://github.com/arvidn/libtorrent/issues/2251
+    pack.set_bool(libt::settings_pack::use_disk_cache_pool, false);
     configure(pack);
 
     m_nativeSession = new libt::session(pack, 0);
@@ -1239,8 +1247,8 @@ void Session::configure(libtorrent::settings_pack &settingsPack)
     settingsPack.set_bool(libt::settings_pack::announce_to_all_trackers, announceToAll);
     settingsPack.set_bool(libt::settings_pack::announce_to_all_tiers, announceToAll);
 
-    const int cacheSize = diskCacheSize();
-    settingsPack.set_int(libt::settings_pack::cache_size, (cacheSize > 0) ? cacheSize * 64 : -1);
+    const int cacheSize = (diskCacheSize() > -1) ? diskCacheSize() * 64 : -1;
+    settingsPack.set_int(libt::settings_pack::cache_size, cacheSize);
     settingsPack.set_int(libt::settings_pack::cache_expiry, diskCacheTTL());
     qDebug() << "Using a disk cache size of" << cacheSize << "MiB";
 
@@ -1456,8 +1464,8 @@ void Session::configure(libtorrent::session_settings &sessionSettings)
     bool announceToAll = announceToAllTrackers();
     sessionSettings.announce_to_all_trackers = announceToAll;
     sessionSettings.announce_to_all_tiers = announceToAll;
-    int cacheSize = diskCacheSize();
-    sessionSettings.cache_size = (cacheSize > 0) ? cacheSize * 64 : -1;
+    const int cacheSize = (diskCacheSize() > -1) ? diskCacheSize() * 64 : -1;
+    sessionSettings.cache_size = cacheSize;
     sessionSettings.cache_expiry = diskCacheTTL();
     qDebug() << "Using a disk cache size of" << cacheSize << "MiB";
     libt::session_settings::io_buffer_mode_t mode = useOSCache() ? libt::session_settings::enable_os_cache
@@ -2782,27 +2790,27 @@ void Session::setAnnounceToAllTrackers(bool val)
     }
 }
 
-uint Session::diskCacheSize() const
+int Session::diskCacheSize() const
 {
-    uint size = m_diskCacheSize;
+    int size = m_diskCacheSize;
     // These macros may not be available on compilers other than MSVC and GCC
 #if defined(__x86_64__) || defined(_M_X64)
-    size = qMin(size, 4096u);  // 4GiB
+    size = qMin(size, 4096);  // 4GiB
 #else
     // When build as 32bit binary, set the maximum at less than 2GB to prevent crashes
     // allocate 1536MiB and leave 512MiB to the rest of program data in RAM
-    size = qMin(size, 1536u);
+    size = qMin(size, 1536);
 #endif
     return size;
 }
 
-void Session::setDiskCacheSize(uint size)
+void Session::setDiskCacheSize(int size)
 {
 #if defined(__x86_64__) || defined(_M_X64)
-    size = qMin(size, 4096u);  // 4GiB
+    size = qMin(size, 4096);  // 4GiB
 #else
     // allocate 1536MiB and leave 512MiB to the rest of program data in RAM
-    size = qMin(size, 1536u);
+    size = qMin(size, 1536);
 #endif
     if (size != m_diskCacheSize) {
         m_diskCacheSize = size;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -329,8 +329,8 @@ namespace BitTorrent
         void setAnnounceToAllTrackers(bool val);
         int diskCacheSize() const;
         void setDiskCacheSize(int size);
-        uint diskCacheTTL() const;
-        void setDiskCacheTTL(uint ttl);
+        int diskCacheTTL() const;
+        void setDiskCacheTTL(int ttl);
         bool useOSCache() const;
         void setUseOSCache(bool use);
         bool isAnonymousModeEnabled() const;
@@ -339,10 +339,10 @@ namespace BitTorrent
         void setQueueingSystemEnabled(bool enabled);
         bool ignoreSlowTorrentsForQueueing() const;
         void setIgnoreSlowTorrentsForQueueing(bool ignore);
-        uint outgoingPortsMin() const;
-        void setOutgoingPortsMin(uint min);
-        uint outgoingPortsMax() const;
-        void setOutgoingPortsMax(uint max);
+        int outgoingPortsMin() const;
+        void setOutgoingPortsMin(int min);
+        int outgoingPortsMax() const;
+        void setOutgoingPortsMax(int max);
         bool ignoreLimitsOnLAN() const;
         void setIgnoreLimitsOnLAN(bool ignore);
         bool includeOverheadInLimits() const;
@@ -573,7 +573,7 @@ namespace BitTorrent
         CachedSettingValue<QString> m_IPFilterFile;
         CachedSettingValue<bool> m_announceToAllTrackers;
         CachedSettingValue<int> m_diskCacheSize;
-        CachedSettingValue<uint> m_diskCacheTTL;
+        CachedSettingValue<int> m_diskCacheTTL;
         CachedSettingValue<bool> m_useOSCache;
         CachedSettingValue<bool> m_isAnonymousModeEnabled;
         CachedSettingValue<bool> m_isQueueingEnabled;
@@ -581,8 +581,8 @@ namespace BitTorrent
         CachedSettingValue<int> m_maxActiveUploads;
         CachedSettingValue<int> m_maxActiveTorrents;
         CachedSettingValue<bool> m_ignoreSlowTorrentsForQueueing;
-        CachedSettingValue<uint> m_outgoingPortsMin;
-        CachedSettingValue<uint> m_outgoingPortsMax;
+        CachedSettingValue<int> m_outgoingPortsMin;
+        CachedSettingValue<int> m_outgoingPortsMax;
         CachedSettingValue<bool> m_ignoreLimitsOnLAN;
         CachedSettingValue<bool> m_includeOverheadInLimits;
         CachedSettingValue<QString> m_announceIP;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -327,8 +327,8 @@ namespace BitTorrent
         void setIPFilterFile(QString path);
         bool announceToAllTrackers() const;
         void setAnnounceToAllTrackers(bool val);
-        uint diskCacheSize() const;
-        void setDiskCacheSize(uint size);
+        int diskCacheSize() const;
+        void setDiskCacheSize(int size);
         uint diskCacheTTL() const;
         void setDiskCacheTTL(uint ttl);
         bool useOSCache() const;
@@ -572,7 +572,7 @@ namespace BitTorrent
         CachedSettingValue<bool> m_isTrackerFilteringEnabled;
         CachedSettingValue<QString> m_IPFilterFile;
         CachedSettingValue<bool> m_announceToAllTrackers;
-        CachedSettingValue<uint> m_diskCacheSize;
+        CachedSettingValue<int> m_diskCacheSize;
         CachedSettingValue<uint> m_diskCacheTTL;
         CachedSettingValue<bool> m_useOSCache;
         CachedSettingValue<bool> m_isAnonymousModeEnabled;

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -194,7 +194,9 @@ void AdvancedSettings::saveAdvancedSettings()
 
 void AdvancedSettings::updateCacheSpinSuffix(int value)
 {
-    if (value <= 0)
+    if (value == 0)
+        spin_cache.setSuffix(tr(" (disabled)"));
+    else if (value < 0)
         spin_cache.setSuffix(tr(" (auto)"));
     else
         spin_cache.setSuffix(tr(" MiB"));
@@ -255,7 +257,7 @@ void AdvancedSettings::loadAdvancedSettings()
     labelLibtorrentLink.setText(QString("<a href=\"%1\">%2</a>").arg("http://www.libtorrent.org/reference.html").arg(tr("Open documentation")));
     labelLibtorrentLink.setOpenExternalLinks(true);
     // Disk write cache
-    spin_cache.setMinimum(0);
+    spin_cache.setMinimum(-1);
     // When build as 32bit binary, set the maximum at less than 2GB to prevent crashes.
     // These macros may not be available on compilers other than MSVC and GCC
 #if defined(__x86_64__) || defined(_M_X64)


### PR DESCRIPTION
See details in this bug report I filed: https://github.com/arvidn/libtorrent/issues/2251

From that thread `use_disk_cache_pool` seems to not be well tested and they're in favor of removing it.

The change in the meaning of the value of `cache_size` shouldn't change older client behavior compiled against RC_1_0, since it seems that branch contains a bug making the cache behave the same for `-1` and `0` values. And by my limited testing to bigger values too.

The 2nd commit is self-explanatory. Why store them as uints when libtorrent will take them as ints?