### PR TITLE
Fix file list expansion on singlefile torrent with folder.

### DIFF
--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -329,7 +329,7 @@ void PropertiesWidget::loadTorrentInfos(BitTorrent::TorrentHandle *const torrent
 
         // List files in torrent
         PropListModel->model()->setupModelData(m_torrent->info());
-        if ((m_torrent->filesCount() > 1) && (PropListModel->model()->rowCount() == 1))
+        if (PropListModel->model()->rowCount() == 1)
             m_ui->filesList->setExpanded(PropListModel->index(0, 0), true);
 
         // Load file priorities


### PR DESCRIPTION
The check that I removed was introduced in the 1st form in 4b2d8a7941bd75a54345bf748258de9c47acd8ed and in the 2nd form in d413bc65eff957aec03fb7fa4e12e6e8f5ca6e91

The check was to not expand when the torrent was stripped. But the 2nd form ended up in not expanding the torrents which are singlefile but the file is inside a folder already.

But there's no harm in always trying to expand the file list. It doesn't crash or output any warning. So I reverted to the old way to not do any checks.