### PR TITLE
WebAPI: fix validating wrong header field. Closes #7311.

### DIFF
--- a/src/webui/abstractwebapplication.cpp
+++ b/src/webui/abstractwebapplication.cpp
@@ -420,8 +420,7 @@ bool AbstractWebApplication::isCrossSiteRequest(const Http::Request &request) co
 
 bool AbstractWebApplication::validateHostHeader(const Http::Request &request, const Http::Environment &env, const QStringList &domains) const
 {
-    const QUrl hostHeader = QUrl::fromUserInput(
-                                request.headers.value(Http::HEADER_X_FORWARDED_HOST, request.headers.value(Http::HEADER_HOST)));
+    const QUrl hostHeader = QUrl::fromUserInput(request.headers.value(Http::HEADER_HOST));
 
     // (if present) try matching host header's port with local port
     const int requestPort = hostHeader.port();


### PR DESCRIPTION
X-Forwarded-Host is a foreign proxy setting, it isn't the same as qbt's local setting and thus it makes no sense to verify it.

@sledgehammer999 if v3_3_x has another release, please include this in.
IMO this issue isn't serious enough to do a new release just for it.
Also probably best to include this in 3.4 beta 2 (if there is going to be one).
