### PR TITLE
Fix ignoring of incorrect version strings in search plugins. Closes #7101

### DIFF
--- a/src/base/utils/version.h
+++ b/src/base/utils/version.h
@@ -117,7 +117,7 @@ namespace Utils
         {
             // find the last one non-zero component
             std::size_t lastSignificantIndex = N - 1;
-            while (lastSignificantIndex >= 0 && (*this)[lastSignificantIndex] == 0)
+            while (lastSignificantIndex > 0 && (*this)[lastSignificantIndex] == 0)
                 --lastSignificantIndex;
 
             if (lastSignificantIndex + 1 < Mandatory)     // lastSignificantIndex >= 0


### PR DESCRIPTION
Printing of Version with all components set to zero was segfaulting due
to underflow in array index. Also add log message for such plugins.