### PR TITLE
Skip user input events when adding torrent. Closes #7327

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -2054,7 +2054,7 @@ bool Session::findIncompleteFiles(TorrentInfo &torrentInfo, QString &savePath) c
                 torrentInfo.renameFile(i, filePath + QB_EXT);
             }
             if ((i % 100) == 0)
-                qApp->processEvents();
+                qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
         }
 
         return found;


### PR DESCRIPTION
Perhaps this PR also fixes many other similar issues.