### PR TITLE
"Torrent category" improvements. Closes #7328, #5767, #5685, #3834, #2477, #1908

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -13,6 +13,7 @@ bittorrent/private/speedmonitor.h
 bittorrent/private/statistics.h
 bittorrent/session.h
 bittorrent/sessionstatus.h
+bittorrent/torrentcategory.h
 bittorrent/torrentcreatorthread.h
 bittorrent/torrenthandle.h
 bittorrent/torrentinfo.h
@@ -58,6 +59,7 @@ indexrange.h
 logger.h
 preferences.h
 profile.h
+qtcompat.h
 scanfoldersmodel.h
 searchengine.h
 settingsstorage.h
@@ -78,6 +80,7 @@ bittorrent/private/resumedatasavingmanager.cpp
 bittorrent/private/speedmonitor.cpp
 bittorrent/private/statistics.cpp
 bittorrent/session.cpp
+bittorrent/torrentcategory.cpp
 bittorrent/torrentcreatorthread.cpp
 bittorrent/torrenthandle.cpp
 bittorrent/torrentinfo.cpp

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -59,7 +59,6 @@ indexrange.h
 logger.h
 preferences.h
 profile.h
-qtcompat.h
 scanfoldersmodel.h
 searchengine.h
 settingsstorage.h

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -33,6 +33,7 @@ HEADERS += \
     $$PWD/bittorrent/magneturi.h \
     $$PWD/bittorrent/torrentinfo.h \
     $$PWD/bittorrent/torrenthandle.h \
+    $$PWD/bittorrent/torrentcategory.h \
     $$PWD/bittorrent/peerinfo.h \
     $$PWD/bittorrent/trackerentry.h \
     $$PWD/bittorrent/tracker.h \
@@ -93,6 +94,7 @@ SOURCES += \
     $$PWD/bittorrent/magneturi.cpp \
     $$PWD/bittorrent/torrentinfo.cpp \
     $$PWD/bittorrent/torrenthandle.cpp \
+    $$PWD/bittorrent/torrentcategory.cpp \
     $$PWD/bittorrent/peerinfo.cpp \
     $$PWD/bittorrent/trackerentry.cpp \
     $$PWD/bittorrent/tracker.cpp \

--- a/src/base/bittorrent/torrentcategory.cpp
+++ b/src/base/bittorrent/torrentcategory.cpp
@@ -1,0 +1,78 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2017  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "torrentcategory.h"
+
+#include "../utils/fs.h"
+#include "session.h"
+#include "torrenthandle.h"
+
+namespace BitTorrent
+{
+    TorrentCategory::TorrentCategory(const QString &name, Session *session)
+        : QObject {session}
+        , m_session {session}
+        , m_name {name}
+    {
+    }
+
+    QString TorrentCategory::name() const
+    {
+        return m_name;
+    }
+
+    QString TorrentCategory::savePath() const
+    {
+        return m_savePath;
+    }
+
+    void TorrentCategory::setSavePath(const QString &savePath)
+    {
+        QString newSavePath = Utils::Fs::expandPath(savePath);
+        if (m_savePath == newSavePath) return;
+
+        m_savePath = newSavePath;
+        emit savePathChanged();
+    }
+
+    bool TorrentCategory::contains(const TorrentCategory *category) const
+    {
+        return (m_session->isSubcategoriesEnabled()
+                && category
+                && category->name().startsWith(m_name + QLatin1Char('/')));
+    }
+
+    bool TorrentCategory::contains(const TorrentHandle *torrent) const
+    {
+        Q_ASSERT(torrent);
+
+        return (m_name == torrent->category())
+                || (m_session->isSubcategoriesEnabled()
+                    && torrent->category().startsWith(m_name + QLatin1Char('/')));
+    }
+}

--- a/src/base/bittorrent/torrentcategory.h
+++ b/src/base/bittorrent/torrentcategory.h
@@ -1,0 +1,64 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2017  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+#include <QObject>
+
+namespace BitTorrent
+{
+    class Session;
+    class TorrentHandle;
+
+    class TorrentCategory final: public QObject
+    {
+        Q_OBJECT
+        Q_DISABLE_COPY(TorrentCategory)
+
+        friend class Session;
+
+        explicit TorrentCategory(const QString &name, Session *session);
+        ~TorrentCategory() override = default;
+
+    public:
+        QString name() const;
+        QString savePath() const;
+        void setSavePath(const QString &savePath);
+
+        bool contains(const TorrentCategory *category) const;
+        bool contains(const TorrentHandle *torrent) const;
+
+    signals:
+        void savePathChanged();
+
+    private:
+        Session *m_session;
+        QString m_name;
+        QString m_savePath;
+    };
+}

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -82,18 +82,18 @@ namespace libtorrent
 
 namespace BitTorrent
 {
-    struct PeerAddress;
-    class Session;
-    class PeerInfo;
-    class TrackerEntry;
     struct AddTorrentParams;
+    struct PeerAddress;
+    class PeerInfo;
+    class Session;
+    class TrackerEntry;
 
     struct AddTorrentData
     {
         bool resumed;
         // for both new and resumed torrents
         QString name;
-        QString category;
+        QString categoryName;
         QSet<QString> tags;
         QString savePath;
         bool disableTempPath;
@@ -166,7 +166,14 @@ namespace BitTorrent
 
     class TorrentHandle : public QObject
     {
+        Q_OBJECT
         Q_DISABLE_COPY(TorrentHandle)
+
+        friend class Session;
+
+        TorrentHandle(Session *session, const libtorrent::torrent_handle &nativeHandle,
+                          const AddTorrentData &data);
+        ~TorrentHandle() override;
 
     public:
         static const qreal USE_GLOBAL_RATIO;
@@ -177,10 +184,6 @@ namespace BitTorrent
 
         static const qreal MAX_RATIO;
         static const int MAX_SEEDING_TIME;
-
-        TorrentHandle(Session *session, const libtorrent::torrent_handle &nativeHandle,
-                          const AddTorrentData &data);
-        ~TorrentHandle();
 
         bool isValid() const;
         InfoHash hash() const;
@@ -249,8 +252,7 @@ namespace BitTorrent
         bool isAutoTMMEnabled() const;
         void setAutoTMMEnabled(bool enabled);
         QString category() const;
-        bool belongsToCategory(const QString &category) const;
-        bool setCategory(const QString &category);
+        void setCategory(const QString &categoryName);
 
         QSet<QString> tags() const;
         bool hasTag(const QString &tag) const;
@@ -458,7 +460,7 @@ namespace BitTorrent
         // Persistent data
         QString m_name;
         QString m_savePath;
-        QString m_category;
+        QString m_categoryName;
         QSet<QString> m_tags;
         bool m_hasSeedStatus;
         qreal m_ratioLimit;

--- a/src/base/torrentfilter.h
+++ b/src/base/torrentfilter.h
@@ -36,10 +36,9 @@ typedef QSet<QString> QStringSet;
 
 namespace BitTorrent
 {
-
-class TorrentHandle;
-class TorrentState;
-
+    class TorrentCategory;
+    class TorrentHandle;
+    class TorrentState;
 }
 
 class TorrentFilter
@@ -72,16 +71,18 @@ public:
     static const TorrentFilter InactiveTorrent;
     static const TorrentFilter ErroredTorrent;
 
-    TorrentFilter();
+    explicit TorrentFilter(const Type type = All);
     // category & tags: pass empty string for uncategorized / untagged torrents.
     // Pass null string (QString()) to disable filtering (i.e. all torrents).
-    TorrentFilter(const Type type, const QStringSet &hashSet = AnyHash, const QString &category = AnyCategory, const QString &tag = AnyTag);
-    TorrentFilter(const QString &filter, const QStringSet &hashSet = AnyHash, const QString &category = AnyCategory, const QString &tags = AnyTag);
+    TorrentFilter(const Type type, const QStringSet &hashSet
+                           , const QString &categoryName, const QString &tag);
+    explicit TorrentFilter(const QString &filter, const QStringSet &hashSet = AnyHash
+            , const QString &categoryName = AnyCategory, const QString &tags = AnyTag);
 
     bool setType(Type type);
     bool setTypeByName(const QString &filter);
     bool setHashSet(const QStringSet &hashSet);
-    bool setCategory(const QString &category);
+    bool setCategory(const QString &categoryName);
     bool setTag(const QString &tag);
 
     bool match(BitTorrent::TorrentHandle *const torrent) const;
@@ -92,8 +93,9 @@ private:
     bool matchCategory(BitTorrent::TorrentHandle *const torrent) const;
     bool matchTag(BitTorrent::TorrentHandle *const torrent) const;
 
-    Type m_type;
-    QString m_category;
+    Type m_type = All;
+    QString m_categoryName;
+    BitTorrent::TorrentCategory *m_category = nullptr;
     QString m_tag;
     QStringSet m_hashSet;
 };

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -59,6 +59,7 @@ statusbar.h
 tagfiltermodel.h
 tagfilterproxymodel.h
 tagfilterwidget.h
+torrentcategorydialog.h
 torrentcontentfiltermodel.h
 torrentcontentmodel.h
 torrentcontentmodelfile.h
@@ -102,6 +103,7 @@ statusbar.cpp
 tagfiltermodel.cpp
 tagfilterproxymodel.cpp
 tagfilterwidget.cpp
+torrentcategorydialog.cpp
 torrentcontentfiltermodel.cpp
 torrentcontentmodel.cpp
 torrentcontentmodelfile.cpp
@@ -144,6 +146,7 @@ addnewtorrentdialog.ui
 autoexpandabledialog.ui
 statsdialog.ui
 optionsdlg.ui
+torrentcategorydialog.ui
 torrentcreatordlg.ui
 shutdownconfirmdlg.ui
 )

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -121,7 +121,7 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::AddTorrentParams &inP
     ui->doNotDeleteTorrentCheckBox->setVisible(TorrentFileGuard::autoDeleteMode() != TorrentFileGuard::Never);
 
     // Load categories
-    QStringList categories = session->categories();
+    QStringList categories = session->categories().keys();
     std::sort(categories.begin(), categories.end(), Utils::String::naturalCompareCaseInsensitive);
     QString defaultCategory = settings()->loadValue(KEY_DEFAULTCATEGORY).toString();
 
@@ -427,7 +427,8 @@ void AddNewTorrentDialog::categoryChanged(int index)
     Q_UNUSED(index);
 
     if (ui->comboTTM->currentIndex() == 1) {
-        QString savePath = BitTorrent::Session::instance()->categorySavePath(ui->categoryComboBox->currentText());
+        const QString savePath = BitTorrent::Session::instance()->categorySavePath(
+                    ui->categoryComboBox->currentText());
         ui->savePath->setSelectedPath(Utils::Fs::toNativePath(savePath));
     }
 }
@@ -764,7 +765,8 @@ void AddNewTorrentDialog::TMMChanged(int index)
         ui->groupBoxSavePath->setEnabled(false);
         ui->savePath->blockSignals(true);
         ui->savePath->clear();
-        QString savePath = BitTorrent::Session::instance()->categorySavePath(ui->categoryComboBox->currentText());
+        const QString savePath = BitTorrent::Session::instance()->categorySavePath(
+                    ui->categoryComboBox->currentText());
         ui->savePath->addItem(savePath);
         ui->defaultSavePathCheckBox->setVisible(false);
         ui->adv_button->setChecked(true);

--- a/src/gui/categoryfiltermodel.h
+++ b/src/gui/categoryfiltermodel.h
@@ -63,7 +63,7 @@ public:
 
 private slots:
     void categoryAdded(const QString &categoryName);
-    void categoryRemoved(const QString &categoryName);
+    void categoryAboutToBeRemoved(const QString &categoryName);
     void torrentAdded(BitTorrent::TorrentHandle *const torrent);
     void torrentAboutToBeRemoved(BitTorrent::TorrentHandle *const torrent);
     void torrentCategoryChanged(BitTorrent::TorrentHandle *const torrent, const QString &oldCategory);

--- a/src/gui/categoryfilterwidget.cpp
+++ b/src/gui/categoryfilterwidget.cpp
@@ -81,12 +81,12 @@ CategoryFilterWidget::CategoryFilterWidget(QWidget *parent)
     sortByColumn(0, Qt::AscendingOrder);
     setCurrentIndex(model()->index(0, 0));
 
-    connect(this, SIGNAL(collapsed(QModelIndex)), SLOT(callUpdateGeometry()));
-    connect(this, SIGNAL(expanded(QModelIndex)), SLOT(callUpdateGeometry()));
-    connect(this, SIGNAL(customContextMenuRequested(QPoint)), SLOT(showMenu(QPoint)));
-    connect(selectionModel(), SIGNAL(currentRowChanged(QModelIndex,QModelIndex))
-            , SLOT(onCurrentRowChanged(QModelIndex,QModelIndex)));
-    connect(model(), SIGNAL(modelReset()), SLOT(callUpdateGeometry()));
+    connect(this, &QTreeView::collapsed, this, &CategoryFilterWidget::callUpdateGeometry);
+    connect(this, &QTreeView::expanded, this, &CategoryFilterWidget::callUpdateGeometry);
+    connect(this, &QWidget::customContextMenuRequested, this, &CategoryFilterWidget::showMenu);
+    connect(selectionModel(), &QItemSelectionModel::currentRowChanged
+            , this, &CategoryFilterWidget::onCurrentRowChanged);
+    connect(model(), &QAbstractItemModel::modelReset, this, &CategoryFilterWidget::callUpdateGeometry);
 }
 
 QString CategoryFilterWidget::currentCategory() const
@@ -113,7 +113,7 @@ void CategoryFilterWidget::showMenu(QPoint)
     QAction *addAct = menu.addAction(
                           GuiIconProvider::instance()->getIcon("list-add")
                           , tr("Add category..."));
-    connect(addAct, SIGNAL(triggered()), SLOT(addCategory()));
+    connect(addAct, &QAction::triggered, this, &CategoryFilterWidget::addCategory);
 
     auto selectedRows = selectionModel()->selectedRows();
     if (!selectedRows.empty() && !CategoryFilterModel::isSpecialItem(selectedRows.first())) {
@@ -121,36 +121,36 @@ void CategoryFilterWidget::showMenu(QPoint)
             QAction *addSubAct = menu.addAction(
                         GuiIconProvider::instance()->getIcon("list-add")
                         , tr("Add subcategory..."));
-            connect(addSubAct, SIGNAL(triggered()), SLOT(addSubcategory()));
+            connect(addSubAct, &QAction::triggered, this, &CategoryFilterWidget::addSubcategory);
         }
 
         QAction *removeAct = menu.addAction(
                         GuiIconProvider::instance()->getIcon("list-remove")
                         , tr("Remove category"));
-        connect(removeAct, SIGNAL(triggered()), SLOT(removeCategory()));
+        connect(removeAct, &QAction::triggered, this, &CategoryFilterWidget::removeCategory);
     }
 
     QAction *removeUnusedAct = menu.addAction(
                                    GuiIconProvider::instance()->getIcon("list-remove")
                                    , tr("Remove unused categories"));
-    connect(removeUnusedAct, SIGNAL(triggered()), SLOT(removeUnusedCategories()));
+    connect(removeUnusedAct, &QAction::triggered, this, &CategoryFilterWidget::removeUnusedCategories);
 
     menu.addSeparator();
 
     QAction *startAct = menu.addAction(
                             GuiIconProvider::instance()->getIcon("media-playback-start")
                             , tr("Resume torrents"));
-    connect(startAct, SIGNAL(triggered()), SIGNAL(actionResumeTorrentsTriggered()));
+    connect(startAct, &QAction::triggered, this, &CategoryFilterWidget::actionResumeTorrentsTriggered);
 
     QAction *pauseAct = menu.addAction(
                             GuiIconProvider::instance()->getIcon("media-playback-pause")
                             , tr("Pause torrents"));
-    connect(pauseAct, SIGNAL(triggered()), SIGNAL(actionPauseTorrentsTriggered()));
+    connect(pauseAct, &QAction::triggered, this, &CategoryFilterWidget::actionPauseTorrentsTriggered);
 
     QAction *deleteTorrentsAct = menu.addAction(
                                      GuiIconProvider::instance()->getIcon("edit-delete")
                                      , tr("Delete torrents"));
-    connect(deleteTorrentsAct, SIGNAL(triggered()), SIGNAL(actionDeleteTorrentsTriggered()));
+    connect(deleteTorrentsAct, &QAction::triggered, this, &CategoryFilterWidget::actionDeleteTorrentsTriggered);
 
     menu.exec(QCursor::pos());
 }
@@ -167,6 +167,9 @@ void CategoryFilterWidget::callUpdateGeometry()
 
 QSize CategoryFilterWidget::sizeHint() const
 {
+    // The sizeHint must depend on viewportSizeHint,
+    // otherwise widget will not correctly adjust the
+    // size when subcategories are used.
     const QSize viewportSize {viewportSizeHint()};
     return {
         viewportSize.width(),

--- a/src/gui/categoryfilterwidget.cpp
+++ b/src/gui/categoryfilterwidget.cpp
@@ -36,10 +36,10 @@
 
 #include "base/bittorrent/session.h"
 #include "base/utils/misc.h"
-#include "autoexpandabledialog.h"
 #include "categoryfiltermodel.h"
 #include "categoryfilterproxymodel.h"
 #include "guiiconprovider.h"
+#include "torrentcategorydialog.h"
 
 namespace
 {
@@ -124,6 +124,11 @@ void CategoryFilterWidget::showMenu(QPoint)
             connect(addSubAct, &QAction::triggered, this, &CategoryFilterWidget::addSubcategory);
         }
 
+        QAction *editAct = menu.addAction(
+                        GuiIconProvider::instance()->getIcon("document-edit")
+                        , tr("Edit category properties..."));
+        connect(editAct, &QAction::triggered, this, &CategoryFilterWidget::editCategory);
+
         QAction *removeAct = menu.addAction(
                         GuiIconProvider::instance()->getIcon("list-remove")
                         , tr("Remove category"));
@@ -199,38 +204,19 @@ void CategoryFilterWidget::rowsInserted(const QModelIndex &parent, int start, in
     updateGeometry();
 }
 
-QString CategoryFilterWidget::askCategoryName()
-{
-    bool ok;
-    const QString category = AutoExpandableDialog::getText(
-                this, tr("New Category"), tr("Category:"), QLineEdit::Normal, QString(), &ok);
-
-    return ok ? category : QString();
-}
-
 void CategoryFilterWidget::addCategory()
 {
-    const QString category = askCategoryName();
-    if (category.isEmpty()) return;
-
-    if (BitTorrent::Session::instance()->findCategory(category))
-        QMessageBox::warning(this, tr("Category exists"), tr("Category name already exists."));
-    else
-        BitTorrent::Session::instance()->createCategory(category);
+    TorrentCategoryDialog::createCategory(this);
 }
 
 void CategoryFilterWidget::addSubcategory()
 {
-    const QString subcat = askCategoryName();
-    if (subcat.isEmpty()) return;
+    TorrentCategoryDialog::createCategory(this, currentCategory());
+}
 
-    const QString category = QString(QStringLiteral("%1/%2")).arg(currentCategory()).arg(subcat);
-
-    if (BitTorrent::Session::instance()->findCategory(category))
-        QMessageBox::warning(this, tr("Category exists")
-                             , tr("Subcategory name already exists in selected category."));
-    else
-        BitTorrent::Session::instance()->createCategory(category);
+void CategoryFilterWidget::editCategory()
+{
+    TorrentCategoryDialog::editCategory(this, currentCategory());
 }
 
 void CategoryFilterWidget::removeCategory()

--- a/src/gui/categoryfilterwidget.h
+++ b/src/gui/categoryfilterwidget.h
@@ -31,6 +31,7 @@
 class CategoryFilterWidget: public QTreeView
 {
     Q_OBJECT
+    Q_DISABLE_COPY(CategoryFilterWidget)
 
 public:
     explicit CategoryFilterWidget(QWidget *parent = nullptr);

--- a/src/gui/gui.pri
+++ b/src/gui/gui.pri
@@ -62,6 +62,7 @@ HEADERS += \
     $$PWD/rss/htmlbrowser.h \
     $$PWD/fspathedit.h \
     $$PWD/fspathedit_p.h \
+    $$PWD/torrentcategorydialog.h
 
 SOURCES += \
     $$PWD/mainwindow.cpp \
@@ -114,7 +115,8 @@ SOURCES += \
     $$PWD/rss/automatedrssdownloader.cpp \
     $$PWD/rss/htmlbrowser.cpp \
     $$PWD/fspathedit.cpp \
-    $$PWD/fspathedit_p.cpp
+    $$PWD/fspathedit_p.cpp \
+    $$PWD/torrentcategorydialog.cpp
 
 win32|macx {
     HEADERS += $$PWD/programupdater.h
@@ -149,6 +151,7 @@ FORMS += \
     $$PWD/cookiesdialog.ui \
     $$PWD/banlistoptions.ui \
     $$PWD/rss/rsswidget.ui \
-    $$PWD/rss/automatedrssdownloader.ui
+    $$PWD/rss/automatedrssdownloader.ui \
+    $$PWD/torrentcategorydialog.ui
 
 RESOURCES += $$PWD/about.qrc

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -305,7 +305,7 @@ void AutomatedRssDownloader::clearRuleDefinitionBox()
 void AutomatedRssDownloader::initCategoryCombobox()
 {
     // Load torrent categories
-    QStringList categories = BitTorrent::Session::instance()->categories();
+    QStringList categories = BitTorrent::Session::instance()->categories().keys();
     std::sort(categories.begin(), categories.end(), Utils::String::naturalCompareCaseInsensitive);
     m_ui->comboCategory->addItem("");
     m_ui->comboCategory->addItems(categories);

--- a/src/gui/torrentcategorydialog.cpp
+++ b/src/gui/torrentcategorydialog.cpp
@@ -1,0 +1,113 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2017  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "torrentcategorydialog.h"
+
+#include <QMessageBox>
+
+#include "base/bittorrent/session.h"
+#include "base/bittorrent/torrentcategory.h"
+#include "ui_torrentcategorydialog.h"
+
+TorrentCategoryDialog::TorrentCategoryDialog(QWidget *parent)
+    : QDialog {parent}
+    , m_ui {new Ui::TorrentCategoryDialog}
+{
+    m_ui->setupUi(this);
+    m_ui->comboSavePath->setMode(FileSystemPathEdit::Mode::DirectorySave);
+    m_ui->comboSavePath->setDialogCaption(tr("Choose save path"));
+}
+
+TorrentCategoryDialog::~TorrentCategoryDialog()
+{
+    delete m_ui;
+}
+
+QString TorrentCategoryDialog::createCategory(
+        QWidget *parent, const QString &parentCategoryName)
+{
+    QString newCategoryName {parentCategoryName.trimmed()};
+    if (!newCategoryName.isEmpty())
+        newCategoryName += QLatin1Char('/');
+    newCategoryName += tr("New Category");
+
+    TorrentCategoryDialog dialog(parent);
+    dialog.setCategoryName(newCategoryName);
+    while (dialog.exec() == TorrentCategoryDialog::Accepted) {
+        BitTorrent::TorrentCategory *newCategory = BitTorrent::Session::instance()->createCategory(
+                    dialog.categoryName());
+        if (newCategory) {
+            newCategory->setSavePath(dialog.savePath());
+            return newCategory->name();
+        }
+
+        QMessageBox::warning(parent, tr("Couldn't create category")
+                             , tr("Category with given name already exists."));
+    }
+
+    return {};
+}
+
+void TorrentCategoryDialog::editCategory(QWidget *parent, const QString &categoryName)
+{
+    BitTorrent::TorrentCategory *const category {BitTorrent::Session::instance()->findCategory(categoryName)};
+    Q_ASSERT(category);
+
+    TorrentCategoryDialog dialog(parent);
+    dialog.setCategoryNameEditable(false);
+    dialog.setCategoryName(category->name());
+    dialog.setSavePath(category->savePath());
+    if (dialog.exec() == TorrentCategoryDialog::Accepted) {
+        category->setSavePath(dialog.savePath());
+    }
+}
+
+QString TorrentCategoryDialog::categoryName() const
+{
+    return m_ui->textCategoryName->text();
+}
+
+void TorrentCategoryDialog::setCategoryName(const QString &categoryName)
+{
+    m_ui->textCategoryName->setText(categoryName);
+}
+
+QString TorrentCategoryDialog::savePath() const
+{
+    return m_ui->comboSavePath->selectedPath();
+}
+
+void TorrentCategoryDialog::setSavePath(const QString &savePath)
+{
+    m_ui->comboSavePath->setSelectedPath(savePath);
+}
+
+void TorrentCategoryDialog::setCategoryNameEditable(bool editable)
+{
+    m_ui->textCategoryName->setEnabled(editable);
+}

--- a/src/gui/torrentcategorydialog.h
+++ b/src/gui/torrentcategorydialog.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2016  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2017  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -26,38 +26,33 @@
  * exception statement from your version.
  */
 
- #include <QTreeView>
+#pragma once
 
-class CategoryFilterWidget: public QTreeView
+#include <QDialog>
+
+namespace Ui
+{
+    class TorrentCategoryDialog;
+}
+
+class TorrentCategoryDialog: public QDialog
 {
     Q_OBJECT
-    Q_DISABLE_COPY(CategoryFilterWidget)
+    Q_DISABLE_COPY(TorrentCategoryDialog)
+
+    explicit TorrentCategoryDialog(QWidget *parent = nullptr);
+    ~TorrentCategoryDialog() override;
 
 public:
-    explicit CategoryFilterWidget(QWidget *parent = nullptr);
+    static QString createCategory(QWidget *parent, const QString &parentCategoryName = "");
+    static void editCategory(QWidget *parent, const QString &categoryName);
 
-    QString currentCategory() const;
-
-signals:
-    void categoryChanged(const QString &categoryName);
-    void actionResumeTorrentsTriggered();
-    void actionPauseTorrentsTriggered();
-    void actionDeleteTorrentsTriggered();
-
-private slots:
-    void onCurrentRowChanged(const QModelIndex &current, const QModelIndex &previous);
-    void showMenu(QPoint);
-    void callUpdateGeometry();
-    void addCategory();
-    void addSubcategory();
-    void editCategory();
-    void removeCategory();
-    void removeUnusedCategories();
+    QString categoryName() const;
+    void setCategoryName(const QString &categoryName);
+    QString savePath() const;
+    void setSavePath(const QString &savePath);
+    void setCategoryNameEditable(bool editable);
 
 private:
-    QSize sizeHint() const override;
-    QSize minimumSizeHint() const override;
-    void rowsInserted(const QModelIndex &parent, int start, int end) override;
-
-    int m_defaultIndentation;
+    Ui::TorrentCategoryDialog *m_ui;
 };

--- a/src/gui/torrentcategorydialog.ui
+++ b/src/gui/torrentcategorydialog.ui
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TorrentCategoryDialog</class>
+ <widget class="QDialog" name="TorrentCategoryDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>100</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Torrent Category Properties</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="labelCategoryName">
+       <property name="text">
+        <string>Category name:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="textCategoryName"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelSavePath">
+       <property name="text">
+        <string>Explicit save path:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="FileSystemPathComboEdit" name="comboSavePath" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>FileSystemPathComboEdit</class>
+   <extends>QWidget</extends>
+   <header>fspathedit.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>TorrentCategoryDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>TorrentCategoryDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -56,6 +56,7 @@
 #include "optionsdlg.h"
 #include "previewselect.h"
 #include "speedlimitdlg.h"
+#include "torrentcategorydialog.h"
 #include "torrentmodel.h"
 #include "transferlistdelegate.h"
 #include "transferlistsortmodel.h"
@@ -729,11 +730,9 @@ void TransferListWidget::setSelectedAutoTMMEnabled(bool enabled) const
 
 void TransferListWidget::askNewCategoryForSelection()
 {
-    // Ask for category
-    bool ok;
-    const QString category = AutoExpandableDialog::getText(this, tr("New Category"), tr("Category:"), QLineEdit::Normal, "", &ok).trimmed();
-    if (ok && !category.isEmpty())
-        setSelectionCategory(category);
+    const QString newCategoryName {TorrentCategoryDialog::createCategory(this)};
+    if (!newCategoryName.isEmpty())
+        setSelectionCategory(newCategoryName);
 }
 
 void TransferListWidget::askAddTagsForSelection()

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -731,23 +731,9 @@ void TransferListWidget::askNewCategoryForSelection()
 {
     // Ask for category
     bool ok;
-    bool invalid;
-    do {
-        invalid = false;
-        const QString category = AutoExpandableDialog::getText(this, tr("New Category"), tr("Category:"), QLineEdit::Normal, "", &ok).trimmed();
-        if (ok && !category.isEmpty()) {
-            if (!BitTorrent::Session::isValidCategoryName(category)) {
-                QMessageBox::warning(this, tr("Invalid category name"),
-                                     tr("Category name must not contain '\\'.\n"
-                                        "Category name must not start/end with '/'.\n"
-                                        "Category name must not contain '//' sequence."));
-                invalid = true;
-            }
-            else {
-                setSelectionCategory(category);
-            }
-        }
-    } while(invalid);
+    const QString category = AutoExpandableDialog::getText(this, tr("New Category"), tr("Category:"), QLineEdit::Normal, "", &ok).trimmed();
+    if (ok && !category.isEmpty())
+        setSelectionCategory(category);
 }
 
 void TransferListWidget::askAddTagsForSelection()
@@ -998,7 +984,7 @@ void TransferListWidget::displayListMenu(const QPoint&)
     if (selectedIndexes.size() == 1)
         listMenu.addAction(&actionRename);
     // Category Menu
-    QStringList categories = BitTorrent::Session::instance()->categories();
+    QStringList categories = BitTorrent::Session::instance()->categories().keys();
     std::sort(categories.begin(), categories.end(), Utils::String::naturalCompareCaseInsensitive);
     QList<QAction*> categoryActions;
     QMenu *categoryMenu = listMenu.addMenu(GuiIconProvider::instance()->getIcon("view-categories"), tr("Category"));

--- a/src/webui/btjson.cpp
+++ b/src/webui/btjson.cpp
@@ -651,7 +651,7 @@ QByteArray btjson::getSyncMainData(int acceptedResponseId, QVariantMap &lastData
     data["torrents"] = torrents;
 
     QVariantList categories;
-    foreach (const QString &category, session->categories())
+    foreach (const QString &category, session->categories().keys())
         categories << category;
 
     data["categories"] = categories;

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -858,12 +858,8 @@ void WebApplication::action_command_setCategory()
 
     foreach (const QString &hash, hashes) {
         BitTorrent::TorrentHandle *const torrent = BitTorrent::Session::instance()->findTorrent(hash);
-        if (torrent) {
-            if (!torrent->setCategory(category)) {
-                status(400, "Incorrect category name");
-                return;
-            }
-        }
+        if (torrent)
+            torrent->setCategory(category);
     }
 }
 
@@ -872,14 +868,8 @@ void WebApplication::action_command_addCategory()
     CHECK_URI(0);
     CHECK_PARAMETERS("category");
 
-    QString category = request().posts["category"].trimmed();
-
-    if (!BitTorrent::Session::isValidCategoryName(category) && !category.isEmpty()) {
-        status(400, tr("Incorrect category name"));
-        return;
-    }
-
-    BitTorrent::Session::instance()->addCategory(category);
+    BitTorrent::Session::instance()->createCategory(
+                request().posts["category"].trimmed());
 }
 
 void WebApplication::action_command_removeCategories()


### PR DESCRIPTION
1. Implement **TorrentCategory** class to handle category-specific properties (like Save path, etc.).
2. Allow to set initially "unclean" Category names (with mixed and redundant slashes/backslashes). They are corrected at creation of the category.
3. Implement **TorrentCategoryDialog**. It allows set/edit category properties (only "Save path" is available now).

Since I have not introduced any category properties not existing previously I still store categories data as it was before (in application settings, in form of `category-name => save-path` dictionary). But I think we need to change the way their storage later when we will add new properties. I suggest to use JSON, e.g `categories.json` (as I did in the RSS classes).