### PR TITLE
Properly pre-select the selected torrent's current ratio limiting options in UpDownRatioDlg

### DIFF
--- a/src/app/upgrade.h
+++ b/src/app/upgrade.h
@@ -195,7 +195,7 @@ bool upgrade(bool ask = true)
             resumeData["qBt-forced"] = false;
 
             resumeData["qBt-savePath"] = oldTorrent.value("save_path").toString().toStdString();
-            resumeData["qBt-ratioLimit"] = QString::number(oldTorrent.value("max_ratio", -2).toReal()).toStdString();
+            resumeData["qBt-ratioLimit"] = static_cast<int>(oldTorrent.value("max_ratio", -2).toReal() * 1000);
             resumeData["qBt-label"] = oldTorrent.value("label").toString().toStdString();
             resumeData["qBt-name"] = oldTorrent.value("name").toString().toStdString();
             resumeData["qBt-seedStatus"] = oldTorrent.value("seed").toBool();

--- a/src/base/bittorrent/infohash.h
+++ b/src/base/bittorrent/infohash.h
@@ -29,8 +29,8 @@
 #ifndef BITTORRENT_INFOHASH_H
 #define BITTORRENT_INFOHASH_H
 
-#include <libtorrent/sha1_hash.hpp>
 #include <QString>
+#include <libtorrent/sha1_hash.hpp>
 
 namespace BitTorrent
 {

--- a/src/base/bittorrent/magneturi.h
+++ b/src/base/bittorrent/magneturi.h
@@ -29,8 +29,8 @@
 #ifndef BITTORRENT_MAGNETURI_H
 #define BITTORRENT_MAGNETURI_H
 
-#include <QString>
 #include <QList>
+#include <QString>
 #include <QUrl>
 
 #include <libtorrent/add_torrent_params.hpp>

--- a/src/base/bittorrent/peerinfo.cpp
+++ b/src/base/bittorrent/peerinfo.cpp
@@ -26,11 +26,12 @@
  * exception statement from your version.
  */
 
-#include "base/net/geoipmanager.h"
-#include "base/utils/string.h"
-#include "base/unicodestrings.h"
-#include "base/bittorrent/torrenthandle.h"
 #include "peerinfo.h"
+
+#include "base/bittorrent/torrenthandle.h"
+#include "base/net/geoipmanager.h"
+#include "base/unicodestrings.h"
+#include "base/utils/string.h"
 
 namespace libt = libtorrent;
 using namespace BitTorrent;
@@ -99,7 +100,6 @@ bool PeerInfo::isRemoteChocked() const
     return (m_nativeInfo.flags & libt::peer_info::remote_choked);
 }
 
-
 bool PeerInfo::isSupportsExtensions() const
 {
     return (m_nativeInfo.flags & libt::peer_info::supports_extensions);
@@ -114,7 +114,6 @@ bool PeerInfo::isHandshake() const
 {
     return (m_nativeInfo.flags & libt::peer_info::handshake);
 }
-
 
 bool PeerInfo::isConnecting() const
 {
@@ -136,7 +135,6 @@ bool PeerInfo::optimisticUnchoke() const
     return (m_nativeInfo.flags & libt::peer_info::optimistic_unchoke);
 }
 
-
 bool PeerInfo::isSnubbed() const
 {
     return (m_nativeInfo.flags & libt::peer_info::snubbed);
@@ -151,7 +149,6 @@ bool PeerInfo::isEndgameMode() const
 {
     return (m_nativeInfo.flags & libt::peer_info::endgame_mode);
 }
-
 
 bool PeerInfo::isHolepunched() const
 {
@@ -183,7 +180,6 @@ bool PeerInfo::isPlaintextEncrypted() const
     return (m_nativeInfo.flags & libt::peer_info::plaintext_encrypted);
 }
 
-
 PeerAddress PeerInfo::address() const
 {
     return PeerAddress(QHostAddress(QString::fromStdString(m_nativeInfo.ip.address().to_string())),
@@ -195,7 +191,6 @@ QString PeerInfo::client() const
     return QString::fromStdString(m_nativeInfo.client);
 }
 
-
 qreal PeerInfo::progress() const
 {
     return m_nativeInfo.progress;
@@ -206,7 +201,6 @@ int PeerInfo::payloadUpSpeed() const
     return m_nativeInfo.payload_up_speed;
 }
 
-
 int PeerInfo::payloadDownSpeed() const
 {
     return m_nativeInfo.payload_down_speed;
@@ -216,7 +210,6 @@ qlonglong PeerInfo::totalUpload() const
 {
     return m_nativeInfo.total_upload;
 }
-
 
 qlonglong PeerInfo::totalDownload() const
 {
@@ -239,7 +232,7 @@ QString PeerInfo::connectionType() const
         return QString::fromUtf8(C_UTP);
 
     QString connection;
-    switch(m_nativeInfo.connection_type) {
+    switch (m_nativeInfo.connection_type) {
     case libt::peer_info::http_seed:
     case libt::peer_info::web_seed:
         connection = "Web";
@@ -281,14 +274,14 @@ qreal PeerInfo::relevance() const
 void PeerInfo::determineFlags()
 {
     if (isInteresting()) {
-        //d = Your client wants to download, but peer doesn't want to send (interested and choked)
+        // d = Your client wants to download, but peer doesn't want to send (interested and choked)
         if (isRemoteChocked()) {
             m_flags += "d ";
             m_flagsDescription += tr("interested(local) and choked(peer)");
             m_flagsDescription += ", ";
         }
         else {
-            //D = Currently downloading (interested and not choked)
+            // D = Currently downloading (interested and not choked)
             m_flags += "D ";
             m_flagsDescription += tr("interested(local) and unchoked(peer)");
             m_flagsDescription += ", ";
@@ -296,92 +289,91 @@ void PeerInfo::determineFlags()
     }
 
     if (isRemoteInterested()) {
-        //u = Peer wants your client to upload, but your client doesn't want to (interested and choked)
+        // u = Peer wants your client to upload, but your client doesn't want to (interested and choked)
         if (isChocked()) {
             m_flags += "u ";
             m_flagsDescription += tr("interested(peer) and choked(local)");
             m_flagsDescription += ", ";
         }
         else {
-            //U = Currently uploading (interested and not choked)
+            // U = Currently uploading (interested and not choked)
             m_flags += "U ";
             m_flagsDescription += tr("interested(peer) and unchoked(local)");
             m_flagsDescription += ", ";
         }
     }
 
-    //O = Optimistic unchoke
+    // O = Optimistic unchoke
     if (optimisticUnchoke()) {
         m_flags += "O ";
         m_flagsDescription += tr("optimistic unchoke");
         m_flagsDescription += ", ";
     }
 
-    //S = Peer is snubbed
+    // S = Peer is snubbed
     if (isSnubbed()) {
         m_flags += "S ";
         m_flagsDescription += tr("peer snubbed");
         m_flagsDescription += ", ";
     }
 
-    //I = Peer is an incoming connection
+    // I = Peer is an incoming connection
     if (!isLocalConnection()) {
         m_flags += "I ";
         m_flagsDescription += tr("incoming connection");
         m_flagsDescription += ", ";
     }
 
-    //K = Peer is unchoking your client, but your client is not interested
+    // K = Peer is unchoking your client, but your client is not interested
     if (!isRemoteChocked() && !isInteresting()) {
         m_flags += "K ";
         m_flagsDescription += tr("not interested(local) and unchoked(peer)");
         m_flagsDescription += ", ";
     }
 
-    //? = Your client unchoked the peer but the peer is not interested
+    // ? = Your client unchoked the peer but the peer is not interested
     if (!isChocked() && !isRemoteInterested()) {
         m_flags += "? ";
         m_flagsDescription += tr("not interested(peer) and unchoked(local)");
         m_flagsDescription += ", ";
     }
 
-    //X = Peer was included in peerlists obtained through Peer Exchange (PEX)
+    // X = Peer was included in peerlists obtained through Peer Exchange (PEX)
     if (fromPeX()) {
         m_flags += "X ";
         m_flagsDescription += tr("peer from PEX");
         m_flagsDescription += ", ";
     }
 
-    //H = Peer was obtained through DHT
+    // H = Peer was obtained through DHT
     if (fromDHT()) {
         m_flags += "H ";
         m_flagsDescription += tr("peer from DHT");
         m_flagsDescription += ", ";
     }
 
-    //E = Peer is using Protocol Encryption (all traffic)
+    // E = Peer is using Protocol Encryption (all traffic)
     if (isRC4Encrypted()) {
         m_flags += "E ";
         m_flagsDescription += tr("encrypted traffic");
         m_flagsDescription += ", ";
     }
 
-    //e = Peer is using Protocol Encryption (handshake)
+    // e = Peer is using Protocol Encryption (handshake)
     if (isPlaintextEncrypted()) {
         m_flags += "e ";
         m_flagsDescription += tr("encrypted handshake");
         m_flagsDescription += ", ";
     }
 
-    //P = Peer is using uTorrent uTP
-
+    // P = Peer is using uTorrent uTP
     if (useUTPSocket()) {
         m_flags += "P ";
         m_flagsDescription += QString::fromUtf8(C_UTP);
         m_flagsDescription += ", ";
     }
 
-    //L = Peer is local
+    // L = Peer is local
     if (fromLSD()) {
         m_flags += "L";
         m_flagsDescription += tr("peer from LSD");

--- a/src/base/bittorrent/peerinfo.h
+++ b/src/base/bittorrent/peerinfo.h
@@ -29,11 +29,11 @@
 #ifndef BITTORRENT_PEERINFO_H
 #define BITTORRENT_PEERINFO_H
 
-#include <libtorrent/peer_info.hpp>
-
-#include <QHostAddress>
 #include <QBitArray>
 #include <QCoreApplication>
+#include <QHostAddress>
+
+#include <libtorrent/peer_info.hpp>
 
 namespace BitTorrent
 {

--- a/src/base/bittorrent/private/filterparserthread.cpp
+++ b/src/base/bittorrent/private/filterparserthread.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libt.
- * Copyright (C) 2006  Christophe Dumez
+ * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,16 +24,14 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : chris@qbittorrent.org
  */
 
 #include "filterparserthread.h"
 
+#include <cctype>
+
 #include <QDataStream>
 #include <QFile>
-
-#include <cctype>
 
 #include "base/logger.h"
 

--- a/src/base/bittorrent/private/filterparserthread.h
+++ b/src/base/bittorrent/private/filterparserthread.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2006  Christophe Dumez
+ * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,8 +24,6 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : chris@qbittorrent.org
  */
 
 #ifndef FILTERPARSERTHREAD_H
@@ -42,7 +40,7 @@ class FilterParserThread : public QThread
     Q_OBJECT
 
 public:
-    FilterParserThread(QObject *parent = 0);
+    FilterParserThread(QObject *parent = nullptr);
     ~FilterParserThread();
     void processFilterFile(const QString &filePath);
     libtorrent::ip_filter IPfilter();

--- a/src/base/bittorrent/private/resumedatasavingmanager.h
+++ b/src/base/bittorrent/private/resumedatasavingmanager.h
@@ -29,11 +29,11 @@
 #ifndef RESUMEDATASAVINGMANAGER_H
 #define RESUMEDATASAVINGMANAGER_H
 
-#include <QObject>
 #include <QByteArray>
 #include <QDir>
+#include <QObject>
 
-class ResumeDataSavingManager: public QObject
+class ResumeDataSavingManager : public QObject
 {
     Q_OBJECT
 

--- a/src/base/bittorrent/private/statistics.cpp
+++ b/src/base/bittorrent/private/statistics.cpp
@@ -4,9 +4,9 @@
 
 #include <libtorrent/session.hpp>
 
+#include "base/bittorrent/session.h"
 #include "base/bittorrent/sessionstatus.h"
 #include "base/profile.h"
-#include "base/bittorrent/session.h"
 
 static const qint64 SAVE_INTERVAL = 15 * 60 * 1000;
 

--- a/src/base/bittorrent/private/statistics.h
+++ b/src/base/bittorrent/private/statistics.h
@@ -4,7 +4,10 @@
 #include <QObject>
 #include <QTimer>
 
-namespace BitTorrent { class Session; }
+namespace BitTorrent
+{
+    class Session;
+}
 
 class Statistics : QObject
 {

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -29,6 +29,10 @@
 
 #include "session.h"
 
+#include <cstdlib>
+#include <queue>
+#include <vector>
+
 #include <QCoreApplication>
 #include <QDateTime>
 #include <QDebug>
@@ -42,10 +46,6 @@
 #include <QThread>
 #include <QTimer>
 #include <QUuid>
-
-#include <cstdlib>
-#include <queue>
-#include <vector>
 
 #include <libtorrent/alert_types.hpp>
 #if LIBTORRENT_VERSION_NUM >= 10100
@@ -71,24 +71,24 @@
 #include <libtorrent/torrent_info.hpp>
 
 #include "base/logger.h"
-#include "base/profile.h"
 #include "base/net/downloadhandler.h"
 #include "base/net/downloadmanager.h"
 #include "base/net/portforwarder.h"
 #include "base/net/proxyconfigurationmanager.h"
+#include "base/profile.h"
 #include "base/torrentfileguard.h"
 #include "base/torrentfilter.h"
 #include "base/unicodestrings.h"
-#include "base/utils/net.h"
-#include "base/utils/misc.h"
 #include "base/utils/fs.h"
+#include "base/utils/misc.h"
+#include "base/utils/net.h"
 #include "base/utils/random.h"
 #include "base/utils/string.h"
 #include "magneturi.h"
-#include "private/filterparserthread.h"
-#include "private/statistics.h"
 #include "private/bandwidthscheduler.h"
+#include "private/filterparserthread.h"
 #include "private/resumedatasavingmanager.h"
+#include "private/statistics.h"
 #include "torrenthandle.h"
 #include "tracker.h"
 #include "trackerentry.h"

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -3383,7 +3383,7 @@ bool Session::isKnownTorrent(const InfoHash &hash) const
 
 void Session::updateSeedingLimitTimer()
 {
-    if ((globalMaxRatio() == -1) && !hasPerTorrentRatioLimit()
+    if ((globalMaxRatio() == TorrentHandle::NO_RATIO_LIMIT) && !hasPerTorrentRatioLimit()
         && (globalMaxSeedingMinutes() == TorrentHandle::NO_SEEDING_TIME_LIMIT) && !hasPerTorrentSeedingTimeLimit()) {
         if (m_seedingLimitTimer->isActive())
             m_seedingLimitTimer->stop();

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -31,6 +31,7 @@
 
 #include <cstdlib>
 #include <queue>
+#include <string>
 #include <vector>
 
 #include <QCoreApplication>
@@ -4371,7 +4372,12 @@ namespace
 
         torrentData.savePath = Profile::instance().fromPortablePath(
             Utils::Fs::fromNativePath(QString::fromStdString(fast.dict_find_string_value("qBt-savePath"))));
-        torrentData.ratioLimit = QString::fromStdString(fast.dict_find_string_value("qBt-ratioLimit")).toDouble();
+
+        std::string ratioLimitString = fast.dict_find_string_value("qBt-ratioLimit");
+        if (ratioLimitString.empty())
+            torrentData.ratioLimit = fast.dict_find_int_value("qBt-ratioLimit", TorrentHandle::USE_GLOBAL_RATIO * 1000) / 1000.0;
+        else
+            torrentData.ratioLimit = QString::fromStdString(ratioLimitString).toDouble();
         torrentData.seedingTimeLimit = fast.dict_find_int_value("qBt-seedingTimeLimit", TorrentHandle::USE_GLOBAL_SEEDING_TIME);
         // **************************************************************************************
         // Workaround to convert legacy label to category

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -1180,38 +1180,20 @@ qreal TorrentHandle::distributedCopies() const
     return m_nativeStatus.distributed_copies;
 }
 
-qreal TorrentHandle::maxRatio(bool *usesGlobalRatio) const
+qreal TorrentHandle::maxRatio() const
 {
-    qreal ratioLimit = m_ratioLimit;
+    if (m_ratioLimit == USE_GLOBAL_RATIO)
+        return m_session->globalMaxRatio();
 
-    if (ratioLimit == USE_GLOBAL_RATIO) {
-        ratioLimit = m_session->globalMaxRatio();
-        if (usesGlobalRatio)
-            *usesGlobalRatio = true;
-    }
-    else {
-        if (usesGlobalRatio)
-            *usesGlobalRatio = false;
-    }
-
-    return ratioLimit;
+    return m_ratioLimit;
 }
 
-int TorrentHandle::maxSeedingTime(bool *usesGlobalSeedingTime) const
+int TorrentHandle::maxSeedingTime() const
 {
-    int seedingTimeLimit = m_seedingTimeLimit;
+    if (m_seedingTimeLimit == USE_GLOBAL_SEEDING_TIME)
+        return m_session->globalMaxSeedingMinutes();
 
-    if (seedingTimeLimit == USE_GLOBAL_SEEDING_TIME) {
-        seedingTimeLimit = m_session->globalMaxSeedingMinutes();
-        if (usesGlobalSeedingTime)
-            *usesGlobalSeedingTime = true;
-    }
-    else {
-        if (usesGlobalSeedingTime)
-            *usesGlobalSeedingTime = false;
-    }
-
-    return seedingTimeLimit;
+    return m_seedingTimeLimit;
 }
 
 qreal TorrentHandle::realRatio() const
@@ -1688,7 +1670,7 @@ void TorrentHandle::handleSaveResumeDataAlert(libtorrent::save_resume_data_alert
     }
     resumeData["qBt-savePath"] = m_useAutoTMM ? "" : Profile::instance().toPortablePath(m_savePath).toStdString();
     resumeData["qBt-ratioLimit"] = QString::number(m_ratioLimit).toStdString();
-    resumeData["qBt-seedingTimeLimit"] = QString::number(m_seedingTimeLimit).toStdString();
+    resumeData["qBt-seedingTimeLimit"] = m_seedingTimeLimit;
     resumeData["qBt-category"] = m_category.toStdString();
     resumeData["qBt-tags"] = setToEntryList(m_tags);
     resumeData["qBt-name"] = m_name.toStdString();

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -1670,7 +1670,7 @@ void TorrentHandle::handleSaveResumeDataAlert(libtorrent::save_resume_data_alert
         resumeData["save_path"] = Profile::instance().toPortablePath(QString::fromStdString(savePath)).toStdString();
     }
     resumeData["qBt-savePath"] = m_useAutoTMM ? "" : Profile::instance().toPortablePath(m_savePath).toStdString();
-    resumeData["qBt-ratioLimit"] = QString::number(m_ratioLimit).toStdString();
+    resumeData["qBt-ratioLimit"] = static_cast<int>(m_ratioLimit * 1000);
     resumeData["qBt-seedingTimeLimit"] = m_seedingTimeLimit;
     resumeData["qBt-category"] = m_category.toStdString();
     resumeData["qBt-tags"] = setToEntryList(m_tags);

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -27,21 +27,23 @@
  * exception statement from your version.
  */
 
+#include "torrenthandle.h"
+
 #include <algorithm>
 #include <type_traits>
 
-#include <QDebug>
-#include <QStringList>
-#include <QFile>
-#include <QDir>
-#include <QByteArray>
 #include <QBitArray>
+#include <QByteArray>
+#include <QDebug>
+#include <QDir>
+#include <QFile>
+#include <QStringList>
 
-#include <libtorrent/entry.hpp>
-#include <libtorrent/bencode.hpp>
 #include <libtorrent/address.hpp>
 #include <libtorrent/alert_types.hpp>
+#include <libtorrent/bencode.hpp>
 #include <libtorrent/create_torrent.hpp>
+#include <libtorrent/entry.hpp>
 #include <libtorrent/magnet_uri.hpp>
 #if LIBTORRENT_VERSION_NUM >= 10100
 #include <libtorrent/time.hpp>
@@ -56,13 +58,12 @@
 #include "base/logger.h"
 #include "base/preferences.h"
 #include "base/profile.h"
-#include "base/utils/string.h"
 #include "base/utils/fs.h"
 #include "base/utils/misc.h"
-#include "session.h"
+#include "base/utils/string.h"
 #include "peerinfo.h"
+#include "session.h"
 #include "trackerentry.h"
-#include "torrenthandle.h"
 
 const QString QB_EXT {".!qB"};
 

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -328,8 +328,8 @@ namespace BitTorrent
         QBitArray downloadingPieces() const;
         QVector<int> pieceAvailability() const;
         qreal distributedCopies() const;
-        qreal maxRatio(bool *usesGlobalRatio = 0) const;
-        int maxSeedingTime(bool *usesGlobalSeedingTime = 0) const;
+        qreal maxRatio() const;
+        int maxSeedingTime() const;
         qreal realRatio() const;
         int uploadPayloadRate() const;
         int downloadPayloadRate() const;

--- a/src/base/bittorrent/tracker.cpp
+++ b/src/base/bittorrent/tracker.cpp
@@ -1,7 +1,7 @@
 /*
  * Bittorrent Client using Qt4 and libtorrent.
  * Copyright (C) 2015  Vladimir Golovnev <glassez@yandex.ru>
- * Copyright (C) 2006  Christophe Dumez
+ * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -25,16 +25,15 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : chris@qbittorrent.org
  */
 
 #include <vector>
+
 #include <libtorrent/bencode.hpp>
 #include <libtorrent/entry.hpp>
 
-#include "base/preferences.h"
 #include "base/http/server.h"
+#include "base/preferences.h"
 #include "base/utils/string.h"
 #include "tracker.h"
 

--- a/src/base/bittorrent/tracker.h
+++ b/src/base/bittorrent/tracker.h
@@ -1,7 +1,7 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
  * Copyright (C) 2015  Vladimir Golovnev <glassez@yandex.ru>
- * Copyright (C) 2010  Christophe Dumez
+ * Copyright (C) 2010  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -25,17 +25,16 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : chris@qbittorrent.org
  */
 
 #ifndef BITTORRENT_TRACKER_H
 #define BITTORRENT_TRACKER_H
 
 #include <QHash>
-#include "base/http/types.h"
-#include "base/http/responsebuilder.h"
+
 #include "base/http/irequesthandler.h"
+#include "base/http/responsebuilder.h"
+#include "base/http/types.h"
 
 namespace libtorrent
 {
@@ -82,7 +81,7 @@ namespace BitTorrent
         Q_DISABLE_COPY(Tracker)
 
     public:
-        explicit Tracker(QObject *parent = 0);
+        explicit Tracker(QObject *parent = nullptr);
         ~Tracker();
 
         bool start();

--- a/src/base/filesystemwatcher.cpp
+++ b/src/base/filesystemwatcher.cpp
@@ -12,9 +12,9 @@
 #endif
 #endif
 
-#include "base/preferences.h"
-#include "base/bittorrent/torrentinfo.h"
 #include "base/bittorrent/magneturi.h"
+#include "base/bittorrent/torrentinfo.h"
+#include "base/preferences.h"
 #include "filesystemwatcher.h"
 
 #ifndef CIFS_MAGIC_NUMBER

--- a/src/base/filesystemwatcher.h
+++ b/src/base/filesystemwatcher.h
@@ -1,12 +1,12 @@
 #ifndef FILESYSTEMWATCHER_H
 #define FILESYSTEMWATCHER_H
 
-#include <QFileSystemWatcher>
 #include <QDir>
-#include <QTimer>
+#include <QFileSystemWatcher>
+#include <QHash>
 #include <QPointer>
 #include <QStringList>
-#include <QHash>
+#include <QTimer>
 
 /*
  * Subclassing QFileSystemWatcher in order to support Network File
@@ -17,7 +17,7 @@ class FileSystemWatcher : public QFileSystemWatcher
     Q_OBJECT
 
 public:
-    explicit FileSystemWatcher(QObject *parent = 0);
+    explicit FileSystemWatcher(QObject *parent = nullptr);
     ~FileSystemWatcher();
 
     QStringList directories() const;

--- a/src/base/http/requestparser.h
+++ b/src/base/http/requestparser.h
@@ -1,7 +1,7 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
  * Copyright (C) 2014  Vladimir Golovnev <glassez@yandex.ru>
- * Copyright (C) 2006  Ishan Arora and Christophe Dumez
+ * Copyright (C) 2006  Ishan Arora and Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -25,8 +25,6 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : chris@qbittorrent.org
  */
 
 #ifndef HTTP_REQUESTPARSER_H

--- a/src/base/http/responsebuilder.h
+++ b/src/base/http/responsebuilder.h
@@ -37,7 +37,7 @@ namespace Http
     class ResponseBuilder : public QObject
     {
     public:
-        explicit ResponseBuilder(QObject *parent = 0);
+        explicit ResponseBuilder(QObject *parent = nullptr);
 
     protected:
         void status(uint code = 200, const QString &text = QLatin1String("OK"));

--- a/src/base/http/responsegenerator.cpp
+++ b/src/base/http/responsegenerator.cpp
@@ -1,7 +1,7 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
  * Copyright (C) 2014  Vladimir Golovnev <glassez@yandex.ru>
- * Copyright (C) 2006  Ishan Arora and Christophe Dumez
+ * Copyright (C) 2006  Ishan Arora and Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -25,8 +25,6 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : chris@qbittorrent.org
  */
 
 #include "responsegenerator.h"
@@ -69,7 +67,7 @@ QByteArray Http::toByteArray(Response response)
 QString Http::httpDate()
 {
     // [RFC 7231] 7.1.1.1. Date/Time Formats
-   // example: "Sun, 06 Nov 1994 08:49:37 GMT"
+    // example: "Sun, 06 Nov 1994 08:49:37 GMT"
 
     return QLocale::c().toString(QDateTime::currentDateTimeUtc(), QLatin1String("ddd, dd MMM yyyy HH:mm:ss"))
         .append(QLatin1String(" GMT"));

--- a/src/base/http/responsegenerator.h
+++ b/src/base/http/responsegenerator.h
@@ -1,7 +1,7 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
  * Copyright (C) 2014  Vladimir Golovnev <glassez@yandex.ru>
- * Copyright (C) 2006  Ishan Arora and Christophe Dumez
+ * Copyright (C) 2006  Ishan Arora and Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -25,8 +25,6 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : chris@qbittorrent.org
  */
 
 

--- a/src/base/http/server.cpp
+++ b/src/base/http/server.cpp
@@ -34,7 +34,6 @@
 #include <QNetworkProxy>
 #include <QStringList>
 #include <QTimer>
-
 #ifndef QT_NO_OPENSSL
 #include <QSslSocket>
 #else
@@ -123,15 +122,13 @@ bool Server::setupHttps(const QByteArray &certificates, const QByteArray &key)
     const QList<QSslCertificate> certs = QSslCertificate::fromData(certificates);
     const bool areCertsValid = !certs.empty() && std::all_of(certs.begin(), certs.end(), [](const QSslCertificate &c) { return !c.isNull(); });
 
-    if (!sslKey.isNull() && areCertsValid)
-    {
+    if (!sslKey.isNull() && areCertsValid) {
         m_key = sslKey;
         m_certificates = certs;
         m_https = true;
         return true;
     }
-    else
-    {
+    else {
         disableHttps();
         return false;
     }
@@ -164,4 +161,4 @@ QList<QSslCipher> Server::safeCipherList() const
 
     return safeCiphers;
 }
-#endif
+#endif // QT_NO_OPENSSL

--- a/src/base/http/server.h
+++ b/src/base/http/server.h
@@ -25,8 +25,6 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : chris@qbittorrent.org
  */
 
 
@@ -46,13 +44,13 @@ namespace Http
     class IRequestHandler;
     class Connection;
 
-    class Server: public QTcpServer
+    class Server : public QTcpServer
     {
         Q_OBJECT
         Q_DISABLE_COPY(Server)
 
     public:
-        Server(IRequestHandler *requestHandler, QObject *parent = 0);
+        Server(IRequestHandler *requestHandler, QObject *parent = nullptr);
         ~Server();
 
 #ifndef QT_NO_OPENSSL
@@ -67,7 +65,7 @@ namespace Http
         void incomingConnection(qintptr socketDescriptor);
 
         IRequestHandler *m_requestHandler;
-        QList<Connection *> m_connections;  // for tracking persistence connections
+        QList<Connection *> m_connections;  // for tracking persistent connections
 
 #ifndef QT_NO_OPENSSL
         QList<QSslCipher> safeCipherList() const;

--- a/src/base/net/dnsupdater.cpp
+++ b/src/base/net/dnsupdater.cpp
@@ -1,6 +1,6 @@
 /*
- * Bittorrent Client using Qt4 and libtorrent.
- * Copyright (C) 2011  Christophe Dumez
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2011  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,8 +24,6 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : chris@qbittorrent.org
  */
 
 #include <QDebug>
@@ -34,8 +32,8 @@
 #include <QUrlQuery>
 
 #include "base/logger.h"
-#include "base/net/downloadmanager.h"
 #include "base/net/downloadhandler.h"
+#include "base/net/downloadmanager.h"
 #include "dnsupdater.h"
 
 using namespace Net;
@@ -143,7 +141,7 @@ QString DNSUpdater::getUpdateUrl() const
 
     Q_ASSERT(!m_lastIP.isNull());
     // Service specific
-    switch(m_service) {
+    switch (m_service) {
     case DNS::DYNDNS:
         url.setHost("members.dyndns.org");
         break;
@@ -230,7 +228,6 @@ void DNSUpdater::processIPUpdateReply(const QString &reply)
     if (code == "abuse") {
         logger->addMessage(tr("Dynamic DNS error: Your username was blocked due to abuse."), Log::CRITICAL);
         m_state = FATAL;
-        return;
     }
 }
 
@@ -289,7 +286,7 @@ void DNSUpdater::updateCredentials()
 
 QUrl DNSUpdater::getRegistrationUrl(int service)
 {
-    switch(service) {
+    switch (service) {
     case DNS::DYNDNS:
         return QUrl("https://www.dyndns.com/account/services/hosts/add.html");
     case DNS::NOIP:

--- a/src/base/net/dnsupdater.h
+++ b/src/base/net/dnsupdater.h
@@ -1,6 +1,6 @@
 /*
- * Bittorrent Client using Qt4 and libtorrent.
- * Copyright (C) 2011  Christophe Dumez
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2011  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,16 +24,14 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : chris@qbittorrent.org
  */
 
 #ifndef DNSUPDATER_H
 #define DNSUPDATER_H
 
-#include <QObject>
-#include <QHostAddress>
 #include <QDateTime>
+#include <QHostAddress>
+#include <QObject>
 #include <QTimer>
 
 #include "base/preferences.h"
@@ -41,12 +39,12 @@
 namespace Net
 {
     // Based on http://www.dyndns.com/developers/specs/
-    class DNSUpdater: public QObject
+    class DNSUpdater : public QObject
     {
         Q_OBJECT
 
     public:
-        explicit DNSUpdater(QObject *parent = 0);
+        explicit DNSUpdater(QObject *parent = nullptr);
         ~DNSUpdater();
 
         static QUrl getRegistrationUrl(int service);

--- a/src/base/net/downloadhandler.cpp
+++ b/src/base/net/downloadhandler.cpp
@@ -27,20 +27,21 @@
  * exception statement from your version.
  */
 
-#include <QTemporaryFile>
-#include <QNetworkAccessManager>
-#include <QNetworkRequest>
-#include <QNetworkReply>
-#include <QNetworkProxy>
-#include <QNetworkCookie>
-#include <QUrl>
+#include "downloadhandler.h"
+
 #include <QDebug>
+#include <QNetworkAccessManager>
+#include <QNetworkCookie>
+#include <QNetworkProxy>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QTemporaryFile>
+#include <QUrl>
 
 #include "base/utils/fs.h"
 #include "base/utils/gzip.h"
 #include "base/utils/misc.h"
 #include "downloadmanager.h"
-#include "downloadhandler.h"
 
 static QString errorCodeToString(QNetworkReply::NetworkError status);
 
@@ -192,14 +193,14 @@ void DownloadHandler::handleRedirection(QUrl newUrl)
         m_reply->deleteLater();
         m_reply = tmp->m_reply;
         init();
-        tmp->m_reply = 0;
+        tmp->m_reply = nullptr;
         delete tmp;
     }
 }
 
 QString errorCodeToString(QNetworkReply::NetworkError status)
 {
-    switch(status) {
+    switch (status) {
     case QNetworkReply::HostNotFoundError:
         return QObject::tr("The remote host name was not found (invalid hostname)");
     case QNetworkReply::OperationCanceledError:

--- a/src/base/net/downloadhandler.h
+++ b/src/base/net/downloadhandler.h
@@ -32,11 +32,9 @@
 
 #include <QObject>
 
-QT_BEGIN_NAMESPACE
 class QNetworkAccessManager;
 class QNetworkReply;
 class QUrl;
-QT_END_NAMESPACE
 
 namespace Net
 {

--- a/src/base/net/geoipmanager.cpp
+++ b/src/base/net/geoipmanager.cpp
@@ -27,21 +27,22 @@
  * exception statement from your version.
  */
 
-#include <QDebug>
-#include <QFile>
-#include <QDir>
-#include <QHostAddress>
+#include "geoipmanager.h"
+
 #include <QDateTime>
+#include <QDebug>
+#include <QDir>
+#include <QFile>
+#include <QHostAddress>
 
 #include "base/logger.h"
 #include "base/preferences.h"
 #include "base/profile.h"
 #include "base/utils/fs.h"
 #include "base/utils/gzip.h"
-#include "downloadmanager.h"
 #include "downloadhandler.h"
+#include "downloadmanager.h"
 #include "private/geoipdatabase.h"
-#include "geoipmanager.h"
 
 static const char DATABASE_URL[] = "https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.mmdb.gz";
 static const char GEOIP_FOLDER[] = "GeoIP";
@@ -52,11 +53,11 @@ using namespace Net;
 
 // GeoIPManager
 
-GeoIPManager *GeoIPManager::m_instance = 0;
+GeoIPManager *GeoIPManager::m_instance = nullptr;
 
 GeoIPManager::GeoIPManager()
     : m_enabled(false)
-    , m_geoIPDatabase(0)
+    , m_geoIPDatabase(nullptr)
 {
     configure();
     connect(Preferences::instance(), SIGNAL(changed()), SLOT(configure()));
@@ -78,7 +79,7 @@ void GeoIPManager::freeInstance()
 {
     if (m_instance) {
         delete m_instance;
-        m_instance = 0;
+        m_instance = nullptr;
     }
 }
 
@@ -91,7 +92,7 @@ void GeoIPManager::loadDatabase()
 {
     if (m_geoIPDatabase) {
         delete m_geoIPDatabase;
-        m_geoIPDatabase = 0;
+        m_geoIPDatabase = nullptr;
     }
 
     QString filepath = Utils::Fs::expandPathAbs(
@@ -407,7 +408,7 @@ void GeoIPManager::configure()
         }
         else if (!m_enabled && m_geoIPDatabase) {
             delete m_geoIPDatabase;
-            m_geoIPDatabase = 0;
+            m_geoIPDatabase = nullptr;
         }
     }
 }

--- a/src/base/net/geoipmanager.h
+++ b/src/base/net/geoipmanager.h
@@ -30,8 +30,8 @@
 #ifndef NET_GEOIPMANAGER_H
 #define NET_GEOIPMANAGER_H
 
-#include <QObject>
 #include <QCache>
+#include <QObject>
 
 class QHostAddress;
 class QString;

--- a/src/base/net/portforwarder.cpp
+++ b/src/base/net/portforwarder.cpp
@@ -65,7 +65,7 @@ void PortForwarder::freeInstance()
 {
     if (m_instance) {
         delete m_instance;
-        m_instance = 0;
+        m_instance = nullptr;
     }
 }
 
@@ -143,4 +143,4 @@ void PortForwarder::stop()
     Logger::instance()->addMessage(tr("UPnP / NAT-PMP support [OFF]"), Log::INFO);
 }
 
-PortForwarder *PortForwarder::m_instance = 0;
+PortForwarder *PortForwarder::m_instance = nullptr;

--- a/src/base/net/portforwarder.h
+++ b/src/base/net/portforwarder.h
@@ -29,8 +29,8 @@
 #ifndef NET_PORTFORWARDER_H
 #define NET_PORTFORWARDER_H
 
-#include <QObject>
 #include <QHash>
+#include <QObject>
 
 namespace libtorrent
 {
@@ -56,7 +56,7 @@ namespace Net
         void deletePort(quint16 port);
 
     private:
-        explicit PortForwarder(libtorrent::session *const provider, QObject *parent = 0);
+        explicit PortForwarder(libtorrent::session *const provider, QObject *parent = nullptr);
         ~PortForwarder();
 
         void start();

--- a/src/base/net/smtp.cpp
+++ b/src/base/net/smtp.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2011  Christophe Dumez
+ * Copyright (C) 2011  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,8 +24,6 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : chris@qbittorrent.org
  */
 
 /*
@@ -33,22 +31,23 @@
  */
 
 #include "smtp.h"
-#include "base/preferences.h"
-#include "base/logger.h"
 
+#include <QCryptographicHash>
+#include <QDebug>
+#include <QHostAddress>
+#include <QHostInfo>
+#include <QNetworkInterface>
+#include <QStringList>
+#include <QTextCodec>
 #include <QTextStream>
 #ifndef QT_NO_OPENSSL
 #include <QSslSocket>
 #else
 #include <QTcpSocket>
 #endif
-#include <QTextCodec>
-#include <QDebug>
-#include <QHostAddress>
-#include <QHostInfo>
-#include <QNetworkInterface>
-#include <QCryptographicHash>
-#include <QStringList>
+
+#include "base/logger.h"
+#include "base/preferences.h"
 
 namespace
 {

--- a/src/base/net/smtp.h
+++ b/src/base/net/smtp.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2011  Christophe Dumez
+ * Copyright (C) 2011  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,8 +24,6 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : chris@qbittorrent.org
  */
 
 /*
@@ -35,22 +33,20 @@
 #ifndef SMTP_H
 #define SMTP_H
 
-#include <QString>
-#include <QObject>
+#include <QAbstractSocket>
 #include <QByteArray>
 #include <QHash>
-#include <QAbstractSocket>
 #include <QMetaType>
+#include <QObject>
+#include <QString>
 
-QT_BEGIN_NAMESPACE
-class QTextStream;
 #ifndef QT_NO_OPENSSL
 class QSslSocket;
 #else
 class QTcpSocket;
 #endif
 class QTextCodec;
-QT_END_NAMESPACE
+class QTextStream;
 
 namespace Net
 {
@@ -59,7 +55,7 @@ namespace Net
         Q_OBJECT
 
     public:
-        Smtp(QObject *parent = 0);
+        Smtp(QObject *parent = nullptr);
         ~Smtp();
 
         void sendMail(const QString &from, const QString &to, const QString &subject, const QString &body);
@@ -126,4 +122,4 @@ namespace Net
     };
 }
 
-#endif
+#endif // SMTP_H

--- a/src/gui/banlistoptions.cpp
+++ b/src/gui/banlistoptions.cpp
@@ -27,15 +27,15 @@
  */
 
 #include "banlistoptions.h"
-#include "ui_banlistoptions.h"
 
-#include <QMessageBox>
 #include <QHostAddress>
+#include <QMessageBox>
 #include <QSortFilterProxyModel>
 #include <QStringListModel>
 
 #include "base/bittorrent/session.h"
 #include "base/utils/net.h"
+#include "ui_banlistoptions.h"
 
 BanListOptions::BanListOptions(QWidget *parent)
     : QDialog(parent)

--- a/src/gui/banlistoptions.h
+++ b/src/gui/banlistoptions.h
@@ -39,12 +39,12 @@ namespace Ui
     class BanListOptions;
 }
 
-class BanListOptions: public QDialog
+class BanListOptions : public QDialog
 {
     Q_OBJECT
 
 public:
-    explicit BanListOptions(QWidget *parent = 0);
+    explicit BanListOptions(QWidget *parent = nullptr);
     ~BanListOptions();
 
 private slots:

--- a/src/gui/cookiesdialog.cpp
+++ b/src/gui/cookiesdialog.cpp
@@ -30,10 +30,10 @@
 
 #include <algorithm>
 
-#include "base/settingsstorage.h"
 #include "base/net/downloadmanager.h"
-#include "guiiconprovider.h"
+#include "base/settingsstorage.h"
 #include "cookiesmodel.h"
+#include "guiiconprovider.h"
 #include "ui_cookiesdialog.h"
 
 #define SETTINGS_KEY(name) "CookiesDialog/" name

--- a/src/gui/cookiesdialog.h
+++ b/src/gui/cookiesdialog.h
@@ -43,7 +43,7 @@ class CookiesDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit CookiesDialog(QWidget *parent = 0);
+    explicit CookiesDialog(QWidget *parent = nullptr);
     ~CookiesDialog();
 
 public slots:

--- a/src/gui/cookiesmodel.cpp
+++ b/src/gui/cookiesmodel.cpp
@@ -26,8 +26,9 @@
  * exception statement from your version.
  */
 
-#include <QDateTime>
 #include "cookiesmodel.h"
+
+#include <QDateTime>
 
 CookiesModel::CookiesModel(const QList<QNetworkCookie> &cookies, QObject *parent)
     : QAbstractItemModel(parent)
@@ -43,8 +44,7 @@ QList<QNetworkCookie> CookiesModel::cookies() const
 QVariant CookiesModel::headerData(int section, Qt::Orientation orientation, int role) const
 {
     if ((role == Qt::DisplayRole) && (orientation == Qt::Horizontal)) {
-        switch (section)
-        {
+        switch (section) {
         case COL_DOMAIN:
             return tr("Domain");
         case COL_PATH:

--- a/src/gui/cookiesmodel.h
+++ b/src/gui/cookiesmodel.h
@@ -49,7 +49,7 @@ public:
         NB_COLUMNS
     };
 
-    explicit CookiesModel(const QList<QNetworkCookie> &cookies, QObject *parent = 0);
+    explicit CookiesModel(const QList<QNetworkCookie> &cookies, QObject *parent = nullptr);
 
     QList<QNetworkCookie> cookies() const;
 

--- a/src/gui/previewlistdelegate.h
+++ b/src/gui/previewlistdelegate.h
@@ -1,6 +1,6 @@
 /*
- * Bittorrent Client using Qt4 and libtorrent.
- * Copyright (C) 2006  Christophe Dumez
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,73 +24,78 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : chris@qbittorrent.org
  */
 
 #ifndef PREVIEWLISTDELEGATE_H
 #define PREVIEWLISTDELEGATE_H
 
+#include <QApplication>
 #include <QItemDelegate>
-#include <QStyleOptionProgressBar>
-#include <QStyleOptionViewItem>
 #include <QModelIndex>
 #include <QPainter>
-#include <QApplication>
+#ifdef Q_OS_WIN
+#include <QProxyStyle>
+#endif
+#include <QStyleOptionProgressBar>
+#include <QStyleOptionViewItem>
+
 #include "base/utils/misc.h"
 #include "base/utils/string.h"
 #include "previewselectdialog.h"
 
-#ifdef Q_OS_WIN
-#include <QProxyStyle>
-#endif
+class PreviewListDelegate : public QItemDelegate
+{
+    Q_OBJECT
 
-class PreviewListDelegate: public QItemDelegate {
-  Q_OBJECT
-
-  public:
-    PreviewListDelegate(QObject *parent=0) : QItemDelegate(parent) {}
+public:
+    PreviewListDelegate(QObject *parent = nullptr)
+        : QItemDelegate(parent)
+    {
+    }
 
     ~PreviewListDelegate() {}
 
-    void paint(QPainter * painter, const QStyleOptionViewItem & option, const QModelIndex & index) const {
-      painter->save();
-      QStyleOptionViewItem opt = QItemDelegate::setOptions(index, option);
+    void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
+    {
+        painter->save();
+        QStyleOptionViewItem opt = QItemDelegate::setOptions(index, option);
 
-      switch(index.column()) {
+        switch (index.column()) {
         case PreviewSelectDialog::SIZE:
-          QItemDelegate::drawBackground(painter, opt, index);
-          QItemDelegate::drawDisplay(painter, opt, option.rect, Utils::Misc::friendlyUnit(index.data().toLongLong()));
-          break;
-        case PreviewSelectDialog::PROGRESS:{
-          QStyleOptionProgressBar newopt;
-          qreal progress = index.data().toDouble()*100.;
-          newopt.rect = opt.rect;
-          newopt.text = ((progress == 100.0) ? QString("100%") : Utils::String::fromDouble(progress, 1) + "%");
-          newopt.progress = static_cast<int>(progress);
-          newopt.maximum = 100;
-          newopt.minimum = 0;
-          newopt.state |= QStyle::State_Enabled;
-          newopt.textVisible = true;
+            QItemDelegate::drawBackground(painter, opt, index);
+            QItemDelegate::drawDisplay(painter, opt, option.rect, Utils::Misc::friendlyUnit(index.data().toLongLong()));
+            break;
+        case PreviewSelectDialog::PROGRESS: {
+                QStyleOptionProgressBar newopt;
+                qreal progress = index.data().toDouble() * 100.;
+                newopt.rect = opt.rect;
+                newopt.text = ((progress == 100.0) ? QString("100%") : Utils::String::fromDouble(progress, 1) + "%");
+                newopt.progress = static_cast<int>(progress);
+                newopt.maximum = 100;
+                newopt.minimum = 0;
+                newopt.state |= QStyle::State_Enabled;
+                newopt.textVisible = true;
 #ifndef Q_OS_WIN
-          QApplication::style()->drawControl(QStyle::CE_ProgressBar, &newopt, painter);
+                QApplication::style()->drawControl(QStyle::CE_ProgressBar, &newopt, painter);
 #else
-          // XXX: To avoid having the progress text on the right of the bar
-          QProxyStyle st("fusion");
-          st.drawControl(QStyle::CE_ProgressBar, &newopt, painter, 0);
+                // XXX: To avoid having the progress text on the right of the bar
+                QProxyStyle st("fusion");
+                st.drawControl(QStyle::CE_ProgressBar, &newopt, painter, 0);
 #endif
-          break;
-        }
+            }
+            break;
         default:
-          QItemDelegate::paint(painter, option, index);
-      }
-      painter->restore();
+            QItemDelegate::paint(painter, option, index);
+        }
+
+        painter->restore();
     }
 
-    QWidget* createEditor(QWidget*, const QStyleOptionViewItem &, const QModelIndex &) const {
-      // No editor here
-      return 0;
+    QWidget *createEditor(QWidget *, const QStyleOptionViewItem &, const QModelIndex &) const
+    {
+        // No editor here
+        return nullptr;
     }
 };
 
-#endif
+#endif // PREVIEWLISTDELEGATE_H

--- a/src/gui/properties/peerlistdelegate.h
+++ b/src/gui/properties/peerlistdelegate.h
@@ -1,6 +1,6 @@
 /*
- * Bittorrent Client using Qt4 and libtorrent.
- * Copyright (C) 2006  Christophe Dumez
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,8 +24,6 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : chris@qbittorrent.org
  */
 
 #ifndef PEERLISTDELEGATE_H
@@ -38,7 +36,7 @@
 #include "base/utils/misc.h"
 #include "base/utils/string.h"
 
-class PeerListDelegate: public QItemDelegate
+class PeerListDelegate : public QItemDelegate
 {
     Q_OBJECT
 
@@ -77,34 +75,33 @@ public:
         QItemDelegate::drawBackground(painter, opt, index);
 
         switch (index.column()) {
-        case PORT: {
+        case PORT:
             opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
             QItemDelegate::drawDisplay(painter, opt, option.rect, index.data().toString());
-            }
             break;
         case TOT_DOWN:
         case TOT_UP: {
-            qlonglong size = index.data().toLongLong();
-            if (hideValues && (size <= 0))
-                break;
-            opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
-            QItemDelegate::drawDisplay(painter, opt, option.rect, Utils::Misc::friendlyUnit(size));
+                qlonglong size = index.data().toLongLong();
+                if (hideValues && (size <= 0))
+                    break;
+                opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
+                QItemDelegate::drawDisplay(painter, opt, option.rect, Utils::Misc::friendlyUnit(size));
             }
             break;
         case DOWN_SPEED:
         case UP_SPEED: {
-            qreal speed = index.data().toDouble();
-            if (speed <= 0.0)
-                break;
-            opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
-            QItemDelegate::drawDisplay(painter, opt, opt.rect, Utils::Misc::friendlyUnit(speed, true));
+                qreal speed = index.data().toDouble();
+                if (speed <= 0.0)
+                    break;
+                opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
+                QItemDelegate::drawDisplay(painter, opt, opt.rect, Utils::Misc::friendlyUnit(speed, true));
             }
             break;
         case PROGRESS:
         case RELEVANCE: {
-            qreal progress = index.data().toDouble();
-            opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
-            QItemDelegate::drawDisplay(painter, opt, opt.rect, Utils::String::fromDouble(progress * 100.0, 1) + "%");
+                qreal progress = index.data().toDouble();
+                opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;
+                QItemDelegate::drawDisplay(painter, opt, opt.rect, Utils::String::fromDouble(progress * 100.0, 1) + "%");
             }
             break;
         default:

--- a/src/gui/properties/peerlistsortmodel.h
+++ b/src/gui/properties/peerlistsortmodel.h
@@ -34,12 +34,12 @@
 
 #include "peerlistdelegate.h"
 
-class PeerListSortModel: public QSortFilterProxyModel
+class PeerListSortModel : public QSortFilterProxyModel
 {
     Q_OBJECT
 
 public:
-    PeerListSortModel(QObject *parent = 0)
+    PeerListSortModel(QObject *parent = nullptr)
         : QSortFilterProxyModel(parent)
     {
     }

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -1,6 +1,6 @@
 /*
- * Bittorrent Client using Qt4 and libtorrent.
- * Copyright (C) 2006  Christophe Dumez
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,36 +24,34 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : chris@qbittorrent.org
  */
 
 #include "peerlistwidget.h"
 
 #include <QApplication>
-#include <QStandardItemModel>
-#include <QSortFilterProxyModel>
-#include <QSet>
+#include <QClipboard>
 #include <QHeaderView>
 #include <QMenu>
-#include <QClipboard>
 #include <QMessageBox>
-#include <QWheelEvent>
+#include <QSet>
+#include <QSortFilterProxyModel>
+#include <QStandardItemModel>
 #include <QTableView>
+#include <QWheelEvent>
 
-#include "base/net/reverseresolution.h"
-#include "base/bittorrent/torrenthandle.h"
 #include "base/bittorrent/peerinfo.h"
-#include "base/preferences.h"
+#include "base/bittorrent/torrenthandle.h"
 #include "base/logger.h"
-#include "base/unicodestrings.h"
-#include "propertieswidget.h"
 #include "base/net/geoipmanager.h"
-#include "peersadditiondlg.h"
-#include "speedlimitdlg.h"
+#include "base/net/reverseresolution.h"
+#include "base/preferences.h"
+#include "base/unicodestrings.h"
 #include "guiiconprovider.h"
 #include "peerlistdelegate.h"
 #include "peerlistsortmodel.h"
+#include "peersadditiondlg.h"
+#include "propertieswidget.h"
+#include "speedlimitdlg.h"
 
 PeerListWidget::PeerListWidget(PropertiesWidget *parent)
     : QTreeView(parent)

--- a/src/gui/properties/peerlistwidget.h
+++ b/src/gui/properties/peerlistwidget.h
@@ -1,6 +1,6 @@
 /*
- * Bittorrent Client using Qt4 and libtorrent.
- * Copyright (C) 2006  Christophe Dumez
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,18 +24,16 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : chris@qbittorrent.org
  */
 
 #ifndef PEERLISTWIDGET_H
 #define PEERLISTWIDGET_H
 
-#include <QTreeView>
 #include <QHash>
 #include <QPointer>
 #include <QSet>
 #include <QShortcut>
+#include <QTreeView>
 
 namespace Net
 {
@@ -46,11 +44,9 @@ class PeerListDelegate;
 class PeerListSortModel;
 class PropertiesWidget;
 
-QT_BEGIN_NAMESPACE
 class QSortFilterProxyModel;
 class QStandardItem;
 class QStandardItemModel;
-QT_END_NAMESPACE
 
 namespace BitTorrent
 {
@@ -59,7 +55,7 @@ namespace BitTorrent
     struct PeerAddress;
 }
 
-class PeerListWidget: public QTreeView
+class PeerListWidget : public QTreeView
 {
     Q_OBJECT
 

--- a/src/gui/properties/speedplotview.h
+++ b/src/gui/properties/speedplotview.h
@@ -35,9 +35,10 @@
 
 #include <QGraphicsView>
 #include <QMap>
+
 class QPen;
 
-class SpeedPlotView: public QGraphicsView
+class SpeedPlotView : public QGraphicsView
 {
     Q_OBJECT
 
@@ -71,7 +72,7 @@ public:
         int y[NB_GRAPHS];
     };
 
-    explicit SpeedPlotView(QWidget *parent = 0);
+    explicit SpeedPlotView(QWidget *parent = nullptr);
 
     void setGraphEnable(GraphID id, bool enable);
     void setViewableLastPoints(TimePeriod period);

--- a/src/gui/properties/trackerlist.h
+++ b/src/gui/properties/trackerlist.h
@@ -43,7 +43,7 @@ namespace BitTorrent
     class TorrentHandle;
 }
 
-class TrackerList: public QTreeWidget
+class TrackerList : public QTreeWidget
 {
     Q_OBJECT
     Q_DISABLE_COPY(TrackerList)

--- a/src/gui/rss/htmlbrowser.cpp
+++ b/src/gui/rss/htmlbrowser.cpp
@@ -1,18 +1,18 @@
 #include "htmlbrowser.h"
 
-#include <QDebug>
-#include <QNetworkRequest>
-#include <QNetworkReply>
-#include <QNetworkDiskCache>
-#include <QStyle>
 #include <QApplication>
-#include <QDir>
 #include <QDateTime>
+#include <QDir>
+#include <QDebug>
+#include <QNetworkDiskCache>
+#include <QNetworkReply>
+#include <QNetworkRequest>
 #include <QScrollBar>
+#include <QStyle>
 
 #include "base/profile.h"
 
-HtmlBrowser::HtmlBrowser(QWidget* parent)
+HtmlBrowser::HtmlBrowser(QWidget *parent)
     : QTextBrowser(parent)
 {
     m_netManager = new QNetworkAccessManager(this);
@@ -31,20 +31,20 @@ HtmlBrowser::~HtmlBrowser()
 
 QVariant HtmlBrowser::loadResource(int type, const QUrl &name)
 {
-    if(type == QTextDocument::ImageResource) {
+    if (type == QTextDocument::ImageResource) {
         QUrl url(name);
-        if(url.scheme().isEmpty())
+        if (url.scheme().isEmpty())
             url.setScheme("http");
 
         QIODevice *dev = m_diskCache->data(url);
-        if(dev != 0) {
+        if (dev != nullptr) {
             qDebug() << "HtmlBrowser::loadResource() cache " << url.toString();
             QByteArray res = dev->readAll();
             delete dev;
             return res;
         }
 
-        if(!m_activeRequests.contains(url)) {
+        if (!m_activeRequests.contains(url)) {
             m_activeRequests.insert(url, true);
             qDebug() << "HtmlBrowser::loadResource() get " << url.toString();
             QNetworkRequest req(url);
@@ -62,7 +62,7 @@ void HtmlBrowser::resourceLoaded(QNetworkReply *reply)
 {
     m_activeRequests.remove(reply->request().url());
 
-    if(reply->error() == QNetworkReply::NoError && reply->size() > 0) {
+    if ((reply->error() == QNetworkReply::NoError) && (reply->size() > 0)) {
         qDebug() << "HtmlBrowser::resourceLoaded() save " << reply->request().url().toString();
     }
     else {
@@ -79,8 +79,8 @@ void HtmlBrowser::resourceLoaded(QNetworkReply *reply)
         metaData.setLastModified(QDateTime::currentDateTime());
         metaData.setExpirationDate(QDateTime::currentDateTime().addDays(1));
         QIODevice *dev = m_diskCache->prepare(metaData);
-        if(!dev)
-            return;
+        if (!dev) return;
+
         QApplication::style()->standardIcon(QStyle::SP_MessageBoxWarning).pixmap(32, 32).save(dev, "PNG");
         m_diskCache->insert(dev);
     }

--- a/src/gui/rss/htmlbrowser.h
+++ b/src/gui/rss/htmlbrowser.h
@@ -1,19 +1,19 @@
 #ifndef HTMLBROWSER_H
 #define HTMLBROWSER_H
 
-#include <QTextBrowser>
 #include <QHash>
+#include <QTextBrowser>
 
 class QNetworkAccessManager;
 class QNetworkDiskCache;
 class QNetworkReply;
 
-class HtmlBrowser: public QTextBrowser
+class HtmlBrowser : public QTextBrowser
 {
     Q_OBJECT
 
 public:
-    explicit HtmlBrowser(QWidget* parent = 0);
+    explicit HtmlBrowser(QWidget* parent = nullptr);
     ~HtmlBrowser();
 
     virtual QVariant loadResource(int type, const QUrl &name);

--- a/src/gui/shutdownconfirmdlg.h
+++ b/src/gui/shutdownconfirmdlg.h
@@ -39,7 +39,7 @@ namespace Ui
     class confirmShutdownDlg;
 }
 
-class ShutdownConfirmDlg: public QDialog
+class ShutdownConfirmDlg : public QDialog
 {
     Q_OBJECT
 

--- a/src/gui/speedlimitdlg.cpp
+++ b/src/gui/speedlimitdlg.cpp
@@ -1,6 +1,6 @@
 /*
- * Bittorrent Client using Qt4 and libtorrent.
- * Copyright (C) 2006  Christophe Dumez
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,14 +24,12 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : chris@qbittorrent.org
  */
 
 #include "speedlimitdlg.h"
 
-#include "ui_bandwidth_limit.h"
 #include "base/unicodestrings.h"
+#include "ui_bandwidth_limit.h"
 
 SpeedLimitDialog::SpeedLimitDialog(QWidget *parent)
     : QDialog(parent)

--- a/src/gui/speedlimitdlg.h
+++ b/src/gui/speedlimitdlg.h
@@ -1,6 +1,6 @@
 /*
- * Bittorrent Client using Qt4 and libtorrent.
- * Copyright (C) 2006  Christophe Dumez
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,8 +24,6 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : chris@qbittorrent.org
  */
 
 #ifndef BANDWIDTH_ALLOCATION_H
@@ -33,16 +31,19 @@
 
 #include <QDialog>
 #include <QList>
-#include "base/utils/misc.h"
+
 #include "base/bittorrent/session.h"
+#include "base/utils/misc.h"
 
 namespace Ui
 {
     class bandwidth_dlg;
 }
 
-class SpeedLimitDialog : public QDialog {
+class SpeedLimitDialog : public QDialog
+{
     Q_OBJECT
+
 public:
     explicit SpeedLimitDialog(QWidget *parent);
     ~SpeedLimitDialog();
@@ -58,4 +59,4 @@ private:
     Ui::bandwidth_dlg *m_ui;
 };
 
-#endif
+#endif // BANDWIDTH_ALLOCATION_H

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -627,14 +627,18 @@ void TransferListWidget::setMaxRatioSelectedTorrents()
     const QList<BitTorrent::TorrentHandle *> torrents = getSelectedTorrents();
     if (torrents.isEmpty()) return;
 
-    bool useGlobalValue = true;
     qreal currentMaxRatio = BitTorrent::Session::instance()->globalMaxRatio();
     if (torrents.count() == 1)
-        currentMaxRatio = torrents[0]->maxRatio(&useGlobalValue);
+        currentMaxRatio = torrents[0]->maxRatio();
 
     int currentMaxSeedingTime = BitTorrent::Session::instance()->globalMaxSeedingMinutes();
     if (torrents.count() == 1)
-        currentMaxSeedingTime = torrents[0]->maxSeedingTime(&useGlobalValue);
+        currentMaxSeedingTime = torrents[0]->maxSeedingTime();
+
+    bool useGlobalValue = true;
+    if (torrents.count() == 1)
+        useGlobalValue = (torrents[0]->ratioLimit() == BitTorrent::TorrentHandle::USE_GLOBAL_RATIO)
+                && (torrents[0]->seedingTimeLimit() == BitTorrent::TorrentHandle::USE_GLOBAL_SEEDING_TIME);
 
     UpDownRatioDlg dlg(useGlobalValue, currentMaxRatio, BitTorrent::TorrentHandle::MAX_RATIO,
                        currentMaxSeedingTime, BitTorrent::TorrentHandle::MAX_SEEDING_TIME, this);

--- a/src/gui/updownratiodlg.cpp
+++ b/src/gui/updownratiodlg.cpp
@@ -1,6 +1,7 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2011  Christian Kandeler, Christophe Dumez
+ * Copyright (C) 2011  Christian Kandeler
+ * Copyright (C) 2011  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,8 +25,6 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : chris@qbittorrent.org
  */
 
 #include "updownratiodlg.h"
@@ -33,53 +32,52 @@
 #include <QMessageBox>
 
 #include "base/bittorrent/session.h"
-
 #include "ui_updownratiodlg.h"
 
 UpDownRatioDlg::UpDownRatioDlg(bool useDefault, qreal initialRatioValue,
                                qreal maxRatioValue, int initialTimeValue,
                                int maxTimeValue, QWidget *parent)
     : QDialog(parent)
-    , ui(new Ui::UpDownRatioDlg)
+    , m_ui(new Ui::UpDownRatioDlg)
 {
-    ui->setupUi(this);
+    m_ui->setupUi(this);
 
     if (useDefault) {
-        ui->useDefaultButton->setChecked(true);
+        m_ui->useDefaultButton->setChecked(true);
     }
-    else if ((initialRatioValue == -1) && (initialTimeValue == -1)) {
-        ui->noLimitButton->setChecked(true);
+    else if ((initialRatioValue == -1.) && (initialTimeValue == -1)) {
+        m_ui->noLimitButton->setChecked(true);
         initialRatioValue = BitTorrent::Session::instance()->globalMaxRatio();
         initialTimeValue = BitTorrent::Session::instance()->globalMaxSeedingMinutes();
     }
     else {
-        ui->torrentLimitButton->setChecked(true);
+        m_ui->torrentLimitButton->setChecked(true);
 
         if (initialRatioValue >= 0)
-            ui->checkMaxRatio->setChecked(true);
+            m_ui->checkMaxRatio->setChecked(true);
 
         if (initialTimeValue >= 0)
-            ui->checkMaxTime->setChecked(true);
+            m_ui->checkMaxTime->setChecked(true);
     }
 
-    ui->ratioSpinBox->setMinimum(0);
-    ui->ratioSpinBox->setMaximum(maxRatioValue);
-    ui->ratioSpinBox->setValue(initialRatioValue);
+    m_ui->ratioSpinBox->setMinimum(0);
+    m_ui->ratioSpinBox->setMaximum(maxRatioValue);
+    m_ui->ratioSpinBox->setValue(initialRatioValue);
 
-    ui->timeSpinBox->setMinimum(0);
-    ui->timeSpinBox->setMaximum(maxTimeValue);
-    ui->timeSpinBox->setValue(initialTimeValue);
+    m_ui->timeSpinBox->setMinimum(0);
+    m_ui->timeSpinBox->setMaximum(maxTimeValue);
+    m_ui->timeSpinBox->setValue(initialTimeValue);
 
-    connect(ui->buttonGroup, SIGNAL(buttonClicked(int)), SLOT(handleRatioTypeChanged()));
-    connect(ui->checkMaxRatio, SIGNAL(toggled(bool)), this, SLOT(enableRatioSpin()));
-    connect(ui->checkMaxTime, SIGNAL(toggled(bool)), this, SLOT(enableTimeSpin()));
+    connect(m_ui->buttonGroup, SIGNAL(buttonClicked(int)), SLOT(handleRatioTypeChanged()));
+    connect(m_ui->checkMaxRatio, SIGNAL(toggled(bool)), this, SLOT(enableRatioSpin()));
+    connect(m_ui->checkMaxTime, SIGNAL(toggled(bool)), this, SLOT(enableTimeSpin()));
 
     handleRatioTypeChanged();
 }
 
 void UpDownRatioDlg::accept()
 {
-    if (ui->torrentLimitButton->isChecked() && !ui->checkMaxRatio->isChecked() && !ui->checkMaxTime->isChecked())
+    if (m_ui->torrentLimitButton->isChecked() && !m_ui->checkMaxRatio->isChecked() && !m_ui->checkMaxTime->isChecked())
         QMessageBox::critical(this, tr("No share limit method selected"),
                               tr("Please select a limit method first"));
     else
@@ -88,40 +86,40 @@ void UpDownRatioDlg::accept()
 
 bool UpDownRatioDlg::useDefault() const
 {
-    return ui->useDefaultButton->isChecked();
+    return m_ui->useDefaultButton->isChecked();
 }
 
 qreal UpDownRatioDlg::ratio() const
 {
-    return (ui->noLimitButton->isChecked() || !ui->checkMaxRatio->isChecked()) ? -1 : ui->ratioSpinBox->value();
+    return (m_ui->noLimitButton->isChecked() || !m_ui->checkMaxRatio->isChecked()) ? -1. : m_ui->ratioSpinBox->value();
 }
 
 int UpDownRatioDlg::seedingTime() const
 {
-    return (ui->noLimitButton->isChecked() || !ui->checkMaxTime->isChecked()) ? -1 : ui->timeSpinBox->value();
+    return (m_ui->noLimitButton->isChecked() || !m_ui->checkMaxTime->isChecked()) ? -1 : m_ui->timeSpinBox->value();
 }
 
 void UpDownRatioDlg::handleRatioTypeChanged()
 {
     // ui->ratioSpinBox->setEnabled(ui->torrentLimitButton->isChecked());
-    ui->checkMaxRatio->setEnabled(ui->torrentLimitButton->isChecked());
-    ui->checkMaxTime->setEnabled(ui->torrentLimitButton->isChecked());
+    m_ui->checkMaxRatio->setEnabled(m_ui->torrentLimitButton->isChecked());
+    m_ui->checkMaxTime->setEnabled(m_ui->torrentLimitButton->isChecked());
 
-    ui->ratioSpinBox->setEnabled(ui->torrentLimitButton->isChecked() && ui->checkMaxRatio->isChecked());
-    ui->timeSpinBox->setEnabled(ui->torrentLimitButton->isChecked() && ui->checkMaxTime->isChecked());
+    m_ui->ratioSpinBox->setEnabled(m_ui->torrentLimitButton->isChecked() && m_ui->checkMaxRatio->isChecked());
+    m_ui->timeSpinBox->setEnabled(m_ui->torrentLimitButton->isChecked() && m_ui->checkMaxTime->isChecked());
 }
 
 void UpDownRatioDlg::enableRatioSpin()
 {
-    ui->ratioSpinBox->setEnabled(ui->checkMaxRatio->isChecked());
+    m_ui->ratioSpinBox->setEnabled(m_ui->checkMaxRatio->isChecked());
 }
 
 void UpDownRatioDlg::enableTimeSpin()
 {
-    ui->timeSpinBox->setEnabled(ui->checkMaxTime->isChecked());
+    m_ui->timeSpinBox->setEnabled(m_ui->checkMaxTime->isChecked());
 }
 
 UpDownRatioDlg::~UpDownRatioDlg()
 {
-    delete ui;
+    delete m_ui;
 }

--- a/src/gui/updownratiodlg.h
+++ b/src/gui/updownratiodlg.h
@@ -1,7 +1,7 @@
 /*
- * Bittorrent Client using Qt4 and libtorrent.
- * Copyright (C) 2011  Christian Kandeler, Christophe Dumez
- *
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2011  Christian Kandeler
+ * Copyright (C) 2011  Christophe Dumez <chris@qbittorrent.org>
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
@@ -24,8 +24,6 @@
  * modify file(s), you may extend this exception to your version of the file(s),
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
- *
- * Contact : chris@qbittorrent.org
  */
 
 #ifndef UPDOWNRATIODLG_H
@@ -33,20 +31,19 @@
 
 #include <QDialog>
 
-QT_BEGIN_NAMESPACE
-namespace Ui {
+namespace Ui
+{
     class UpDownRatioDlg;
 }
-QT_END_NAMESPACE
 
 class UpDownRatioDlg : public QDialog
 {
     Q_OBJECT
 
 public:
-    explicit UpDownRatioDlg(bool useDefault, qreal initialValue, qreal maxValue,
-        int initialTimeValue, int maxTimeValue,
-        QWidget *parent = 0);
+    UpDownRatioDlg(bool useDefault, qreal initialValue, qreal maxValue,
+            int initialTimeValue, int maxTimeValue,
+            QWidget *parent = nullptr);
     ~UpDownRatioDlg();
 
     bool useDefault() const;
@@ -62,7 +59,7 @@ private slots:
     void enableTimeSpin();
 
 private:
-    Ui::UpDownRatioDlg *ui;
+    Ui::UpDownRatioDlg *m_ui;
 };
 
 #endif // UPDOWNRATIODLG_H

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -26,14 +26,16 @@
  * exception statement from your version.
  */
 
-#include <QDebug>
-#include <QCoreApplication>
-#include <QTimer>
-#include <QCryptographicHash>
-#include <QRegularExpression>
+#include "webapplication.h"
 
 #include <queue>
 #include <vector>
+
+#include <QCoreApplication>
+#include <QCryptographicHash>
+#include <QDebug>
+#include <QRegularExpression>
+#include <QTimer>
 
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/torrenthandle.h"
@@ -50,7 +52,6 @@
 #include "btjson.h"
 #include "jsonutils.h"
 #include "prefjson.h"
-#include "webapplication.h"
 #include "websessiondata.h"
 
 static const int API_VERSION = 15;
@@ -203,7 +204,7 @@ void WebApplication::action_public_login()
         return;
     }
 
-    const Preferences* const pref = Preferences::instance();
+    const Preferences *const pref = Preferences::instance();
     QCryptographicHash md5(QCryptographicHash::Md5);
 
     md5.addData(request().posts["password"].toLocal8Bit());
@@ -565,12 +566,12 @@ void WebApplication::action_command_setFilePrio()
     CHECK_URI(0);
     CHECK_PARAMETERS("hash" << "id" << "priority");
     QString hash = request().posts["hash"];
-    int file_id = request().posts["id"].toInt();
+    int fileID = request().posts["id"].toInt();
     int priority = request().posts["priority"].toInt();
     BitTorrent::TorrentHandle *const torrent = BitTorrent::Session::instance()->findTorrent(hash);
 
     if (torrent && torrent->hasMetadata())
-        torrent->setFilePriority(file_id, priority);
+        torrent->setFilePriority(fileID, priority);
 }
 
 void WebApplication::action_command_getGlobalUpLimit()
@@ -801,15 +802,13 @@ void WebApplication::action_command_setLocation()
     QStringList hashes = request().posts["hashes"].split("|");
     QString newLocation = request().posts["location"].trimmed();
 
-    // check location exists
+    // check if the location exists
     if (newLocation.isEmpty() || !QDir(newLocation).exists())
         return;
 
     foreach (const QString &hash, hashes) {
         BitTorrent::TorrentHandle *const torrent = BitTorrent::Session::instance()->findTorrent(hash);
         if (torrent) {
-            // get old location
-            const QString oldLocation = torrent->savePath();
             Logger::instance()->addMessage(tr("WebUI Set location: moving \"%1\", from \"%2\" to \"%3\"").arg(torrent->name()).arg(torrent->savePath()).arg(newLocation));
 
             torrent->move(Utils::Fs::expandPathAbs(newLocation));
@@ -945,7 +944,7 @@ void WebApplication::doProcessRequest()
 
 void WebApplication::parsePath()
 {
-    if(request().path == "/") action_ = WEBUI_ACTION;
+    if (request().path == "/") action_ = WEBUI_ACTION;
 
     // check action for requested path
     QStringList pathItems = request().path.split('/', QString::SkipEmptyParts);

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -32,12 +32,12 @@
 #include <QStringList>
 #include "abstractwebapplication.h"
 
-class WebApplication: public AbstractWebApplication
+class WebApplication : public AbstractWebApplication
 {
     Q_DISABLE_COPY(WebApplication)
 
 public:
-    explicit WebApplication(QObject* parent = 0);
+    explicit WebApplication(QObject *parent = nullptr);
 
 private:
     // Actions


### PR DESCRIPTION
...and alot of coding style.

Currently when you set the ratio options on a torrent, `Use global share limit` is always pre-selected on first creation of the dialog on that torrent in this qbit session.

I hope the coding guidelines PR gets accepted or i'm in trouble (spaces around colons)...