### PR TITLE
Fix dereferencing freed pointer

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1724,8 +1724,8 @@ void Session::processShareLimits()
                     if ((ratio <= TorrentHandle::MAX_RATIO) && (ratio >= ratioLimit)) {
                         Logger* const logger = Logger::instance();
                         if (m_maxRatioAction == Remove) {
-                            deleteTorrent(torrent->hash());
                             logger->addMessage(tr("'%1' reached the maximum ratio you set. Removed.").arg(torrent->name()));
+                            deleteTorrent(torrent->hash());
                         }
                         else if (!torrent->isPaused()) {
                             torrent->pause();
@@ -1748,8 +1748,8 @@ void Session::processShareLimits()
                     if ((seedingTimeInMinutes <= TorrentHandle::MAX_SEEDING_TIME) && (seedingTimeInMinutes >= seedingTimeLimit)) {
                         Logger* const logger = Logger::instance();
                         if (m_maxRatioAction == Remove) {
-                            deleteTorrent(torrent->hash());
                             logger->addMessage(tr("'%1' reached the maximum seeding time you set. Removed.").arg(torrent->name()));
+                            deleteTorrent(torrent->hash());
                         }
                         else if (!torrent->isPaused()) {
                             torrent->pause();


### PR DESCRIPTION
The torrent is removed from session after `deleteTorrent()`
yet we still invoke `torrent->name()`, thus result in crash.

I imagine using shared_ptr for torrent handle pointer could be a lot better.