### PR TITLE
Add custom widget for speed button in the status bar

### DIFF
--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -329,10 +329,14 @@ QString Utils::Misc::pythonVersionComplete()
     return version;
 }
 
-QString Utils::Misc::unitString(Utils::Misc::SizeUnit unit)
+QString Utils::Misc::unitString(Utils::Misc::SizeUnit unit, bool isSpeed)
 {
-    return QCoreApplication::translate("misc",
+    QString res = QCoreApplication::translate("misc",
                                        units[static_cast<int>(unit)].source, units[static_cast<int>(unit)].comment);
+    if (isSpeed)
+        res += QCoreApplication::translate("misc", "/s", "per second");
+
+    return res;
 }
 
 // return best userfriendly storage unit (B, KiB, MiB, GiB, TiB, ...)
@@ -358,18 +362,23 @@ bool Utils::Misc::friendlyUnit(qint64 sizeInBytes, qreal &val, Utils::Misc::Size
 
 QString Utils::Misc::friendlyUnit(qint64 bytesValue, bool isSpeed)
 {
+    return friendlyUnit(bytesValue, 0, QChar(), isSpeed);
+}
+
+QString Utils::Misc::friendlyUnit(qint64 bytesValue, int fieldWidth, QChar fill, bool isSpeed)
+{
     SizeUnit unit;
     qreal friendlyVal;
     if (!friendlyUnit(bytesValue, friendlyVal, unit))
         return QCoreApplication::translate("misc", "Unknown", "Unknown (size)");
-    QString ret;
+
+    QString numberPart;
     if (unit == SizeUnit::Byte)
-        ret = QString::number(bytesValue) + QString::fromUtf8(C_NON_BREAKING_SPACE) + unitString(unit);
+        numberPart = QString(QLatin1String("%1")).arg(bytesValue, fieldWidth, 10, fill);
     else
-        ret = Utils::String::fromDouble(friendlyVal, friendlyUnitPrecision(unit)) + QString::fromUtf8(C_NON_BREAKING_SPACE) + unitString(unit);
-    if (isSpeed)
-        ret += QCoreApplication::translate("misc", "/s", "per second");
-    return ret;
+        numberPart = QString(QLatin1String("%1")).arg(friendlyVal, fieldWidth, 'f', friendlyUnitPrecision(unit), fill);
+
+    return numberPart + QString::fromUtf8(C_NON_BREAKING_SPACE) + unitString(unit, isSpeed);
 }
 
 int Utils::Misc::friendlyUnitPrecision(SizeUnit unit)

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -77,12 +77,13 @@ namespace Utils
         QString pythonExecutable();
         QString pythonVersionComplete();
 
-        QString unitString(SizeUnit unit);
+        QString unitString(SizeUnit unit, bool isSpeed = false);
 
         // return best user friendly storage unit (B, KiB, MiB, GiB, TiB)
         // value must be given in bytes
         bool friendlyUnit(qint64 sizeInBytes, qreal& val, SizeUnit& unit);
         QString friendlyUnit(qint64 bytesValue, bool isSpeed = false);
+        QString friendlyUnit(qint64 bytesValue, int fieldWidth, QChar fill, bool isSpeed = false);
         int friendlyUnitPrecision(SizeUnit unit);
         qint64 sizeInBytes(qreal size, SizeUnit unit);
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -56,6 +56,7 @@ shutdownconfirmdlg.h
 speedlimitdlg.h
 statsdialog.h
 statusbar.h
+statusspeedbutton.h
 tagfiltermodel.h
 tagfilterproxymodel.h
 tagfilterwidget.h
@@ -99,6 +100,7 @@ shutdownconfirmdlg.cpp
 speedlimitdlg.cpp
 statsdialog.cpp
 statusbar.cpp
+statusspeedbutton.cpp
 tagfiltermodel.cpp
 tagfilterproxymodel.cpp
 tagfilterwidget.cpp

--- a/src/gui/gui.pri
+++ b/src/gui/gui.pri
@@ -19,6 +19,7 @@ HEADERS += \
     $$PWD/torrentcontenttreeview.h \
     $$PWD/deletionconfirmationdlg.h \
     $$PWD/statusbar.h \
+    $$PWD/statusspeedbutton.h \
     $$PWD/speedlimitdlg.h \
     $$PWD/about_imp.h \
     $$PWD/previewselect.h \
@@ -86,6 +87,7 @@ SOURCES += \
     $$PWD/statsdialog.cpp \
     $$PWD/messageboxraised.cpp \
     $$PWD/statusbar.cpp \
+    $$PWD/statusspeedbutton.cpp \
     $$PWD/advancedsettings.cpp \
     $$PWD/trackerlogin.cpp \
     $$PWD/optionsdlg.cpp \

--- a/src/gui/statusbar.h
+++ b/src/gui/statusbar.h
@@ -34,6 +34,8 @@
 class QLabel;
 class QPushButton;
 
+class StatusSpeedButton;
+
 namespace BitTorrent
 {
     struct SessionStatus;
@@ -66,8 +68,8 @@ private:
     void updateDHTNodesNumber();
     void updateSpeedLabels();
 
-    QPushButton *m_dlSpeedLbl;
-    QPushButton *m_upSpeedLbl;
+    StatusSpeedButton *m_dlSpeedBtn;
+    StatusSpeedButton *m_upSpeedBtn;
     QLabel *m_DHTLbl;
     QPushButton *m_connecStatusLblIcon;
     QPushButton *m_altSpeedsBtn;

--- a/src/gui/statusspeedbutton.cpp
+++ b/src/gui/statusspeedbutton.cpp
@@ -1,0 +1,216 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2017  Eugene Shalygin <eugene.shalygin@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "statusspeedbutton.h"
+
+#include <cmath>
+
+#include <QApplication>
+#include <QStyleOptionButton>
+#include <QStylePainter>
+#include <QTextOption>
+
+#include "base/unicodestrings.h"
+#include "base/utils/misc.h"
+
+StatusSpeedButton::Section::Section(const QString &templateText, int minDigits,
+                                    bool isSpeed, bool onlyGrow,
+                                    const StatusSpeedButton::SharedInfo *sharedInfo)
+    : m_text {emptyText()}
+    , m_lastValue {static_cast<quint64>(-1)}
+    , m_template {templateText}
+    , m_minDigits {minDigits}
+    , m_isSpeed {isSpeed}
+    , m_onlyGrow {onlyGrow}
+    , m_sharedInfo {sharedInfo}
+{
+}
+
+QStaticText StatusSpeedButton::Section::emptyText()
+{
+    QStaticText res;
+    res.setTextFormat(Qt::PlainText);
+    res.setTextOption({QLocale().textDirection() == Qt::LeftToRight ? Qt::AlignRight : Qt::AlignLeft});
+    return res;
+}
+
+const QStaticText & StatusSpeedButton::Section::text() const
+{
+    return m_text;
+}
+
+void StatusSpeedButton::Section::setValue(quint64 bytes)
+{
+    if (bytes == m_lastValue) return;
+
+    Utils::Misc::SizeUnit unit;
+    qreal dummy;
+    friendlyUnit(static_cast<qint64>(bytes), dummy, unit);
+
+    // the widget font is not monospaced, thus some digits occupy much less space than others.
+    // we prepend '1' to account for possible highest value of 1023.99
+    QString numberText = m_sharedInfo->unityDigit + Utils::Misc::friendlyUnit(static_cast<qint64>(bytes),
+        m_minDigits + 1 + Utils::Misc::friendlyUnitPrecision(unit), m_sharedInfo->widestDigit, m_isSpeed);
+
+    // now we replace all other digits with the widest one
+    for (int i = 0; i < numberText.size(); ++i) {
+        if (numberText[i].isDigit()) {
+            numberText[i] = m_sharedInfo->widestDigit;
+        }
+    }
+    // and we've got probably the most wide possible number
+
+    const qreal oldWidth = m_text.textWidth();
+    const QString newText = m_template.arg(Utils::Misc::friendlyUnit(static_cast<qint64>(bytes), m_isSpeed));
+    if (newText != m_text.text()) {
+        m_text.setText(newText);
+        const qreal newWidth = QFontMetricsF(m_sharedInfo->widget->font(), m_sharedInfo->widget)
+            .width(m_template.arg(numberText));
+        if (std::abs(newWidth - oldWidth) > 0.5 && (!m_onlyGrow || (newWidth > oldWidth))) {
+            m_text.setTextWidth(newWidth);
+            m_sharedInfo->widget->updateGeometry();
+        }
+        m_sharedInfo->widget->update();
+    }
+}
+
+void StatusSpeedButton::Section::clear()
+{
+    const bool wasEmpty = m_text.text().isEmpty();
+    m_text = emptyText();
+    if (!wasEmpty) {
+        m_sharedInfo->widget->updateGeometry();
+        m_sharedInfo->widget->update();
+    }
+}
+
+StatusSpeedButton::StatusSpeedButton(QWidget *parent)
+    : QPushButton {parent}
+    , m_sharedInfo {widestDecimalDigit(), QLocale().toString(1)[0], this}
+    , m_currentSpeed {QLatin1String("%1"), 3, true, true, &m_sharedInfo}
+    , m_speedLimit {QLatin1String("[%1]"), 3, true, false, &m_sharedInfo}
+    , m_totalPayload {QLatin1String("(%1)"), 2, false, false, &m_sharedInfo}
+{
+    setFocusPolicy(Qt::NoFocus);
+    setCursor(Qt::PointingHandCursor);
+
+    QFontMetrics fm {this->font(), this};
+    m_separatorWidth = fm.width(QLatin1Char(' '));
+
+    setCurrentSpeed(0);
+    setSpeedLimit(0);
+    setTotalPayload(0);
+}
+
+void StatusSpeedButton::setCurrentSpeed(quint64 currentSpeed)
+{
+    m_currentSpeed.setValue(currentSpeed);
+}
+
+void StatusSpeedButton::setSpeedLimit(int speedLimit)
+{
+    if (speedLimit)
+        m_speedLimit.setValue(static_cast<quint64>(speedLimit));
+    else
+        m_speedLimit.clear();
+}
+
+void StatusSpeedButton::setTotalPayload(quint64 totalPayload)
+{
+    if (totalPayload > 0)
+        m_totalPayload.setValue(totalPayload);
+    else
+        m_totalPayload.clear();
+}
+
+QSize StatusSpeedButton::sizeHint() const
+{
+    QStyleOptionButton style;
+    style.initFrom(this);
+    const int margin = this->style()->subElementRect(QStyle::SE_PushButtonContents, &style, this).left();
+
+    int totalContentWidth = m_currentSpeed.text().textWidth(); // always rendered
+    if (m_speedLimit.text().textWidth() >= 0) {
+        totalContentWidth += m_separatorWidth + m_speedLimit.text().textWidth();
+    }
+    if (m_totalPayload.text().textWidth() >= 0) {
+        totalContentWidth += m_separatorWidth + m_totalPayload.text().textWidth();
+    }
+    if (!icon().isNull()) {
+        totalContentWidth += iconSize().width() + margin;
+    }
+    return QSize(totalContentWidth + 2 * margin, base::sizeHint().height());
+}
+
+void StatusSpeedButton::paintEvent(QPaintEvent* /*event*/)
+{
+    QStyleOptionButton style;
+    style.initFrom(this);
+    style.icon = QIcon(); // we will draw icon ourselves
+    style.features |= QStyleOptionButton::Flat;
+    QStylePainter painter(this);
+    painter.drawControl(QStyle::CE_PushButton, style);
+
+    const QPoint offset = this->style()->subElementRect(QStyle::SE_PushButtonContents, &style, this).topLeft();
+
+    int hPos = offset.x();
+
+    if (!icon().isNull()) {
+        QRect iconRect(offset, iconSize());
+        icon().paint(&painter, iconRect, Qt::AlignVCenter);
+        hPos += iconSize().width() + offset.x();
+    }
+
+    painter.drawStaticText(hPos, 0, m_currentSpeed.text());
+    hPos += m_currentSpeed.text().textWidth();
+    hPos += m_separatorWidth;
+    if (m_speedLimit.text().textWidth() > 0) {
+        painter.drawStaticText(hPos, 0, m_speedLimit.text());
+        hPos += m_speedLimit.text().textWidth();
+        hPos += m_separatorWidth;
+    }
+    if (m_totalPayload.text().textWidth() > 0) {
+        painter.drawStaticText(hPos, 0, m_totalPayload.text());
+    }
+}
+
+const QChar StatusSpeedButton::widestDecimalDigit()
+{
+    const QString digits = QLocale().toString(1234567890);
+    qreal maxWidth = 0.;
+    QChar digit;
+    QFontMetricsF fm {font(), this};
+    for (int i = 0; i < digits.size(); ++i) {
+        const qreal dWidth = fm.width(digits[i]);
+        if (dWidth > maxWidth) {
+            maxWidth = dWidth;
+            digit = digits[i];
+        }
+    }
+    return digit;
+}

--- a/src/gui/statusspeedbutton.h
+++ b/src/gui/statusspeedbutton.h
@@ -1,0 +1,110 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2017  Eugene Shalygin <eugene.shalygin@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#ifndef QBT_STATUSSPEEDBUTTON_H
+#define QBT_STATUSSPEEDBUTTON_H
+
+#include <QPushButton>
+#include <QStaticText>
+
+/**
+* @brief Status bar button with speed text
+*
+* Allocates three fields for current speed, speed limit, and payload size and tries
+* to minimise width variations for those fields
+*
+*/
+class StatusSpeedButton : public QPushButton
+{
+    using base = QPushButton;
+
+public:
+    explicit StatusSpeedButton(QWidget *parent = nullptr);
+
+    void setCurrentSpeed(quint64 currentSpeed);
+    void setSpeedLimit(int speedLimit);
+    void setTotalPayload(quint64 totalPayload);
+
+protected:
+    QSize sizeHint() const override;
+    void paintEvent(QPaintEvent *event) override;
+
+private:
+
+    struct SharedInfo
+    {
+        QChar widestDigit;
+        QChar unityDigit;
+        QWidget *widget;
+    };
+
+    class Section
+    {
+    public:
+        Section(const QString &templateText, int minDigits, bool isSpeed, bool onlyGrow,
+                const SharedInfo *sharedInfo);
+        /**
+        * @brief Sets new text possibly updating width
+
+        * @param[in] bytes new value (bytes)
+        */
+        void setValue(quint64 bytes);
+        void clear();
+
+        const QStaticText &text() const;
+
+    private:
+        static QStaticText emptyText();
+
+        QStaticText m_text;
+        quint64 m_lastValue;
+
+        QString m_template;
+        int m_minDigits;
+        bool m_isSpeed; // move to the template?
+        bool m_onlyGrow;
+
+        const SharedInfo *m_sharedInfo;
+    };
+
+    /**
+    * @brief Find widest digits in the current widget font
+    */
+    const QChar widestDecimalDigit();
+
+
+    SharedInfo m_sharedInfo;
+
+    Section m_currentSpeed;
+    Section m_speedLimit;
+    Section m_totalPayload;
+
+    int m_separatorWidth;
+};
+
+#endif // QBT_STATUSSPEEDBUTTON_H


### PR DESCRIPTION
Since a proportional font is used usually for GUI texts, the width
of speed status labels can fluctuate significantly due to speed changes
and digit variability. Because of that the download speed button jitters
in the status bar from left to right, creating unpleasant visual
experience.

Here we replace it with a custom widget, that attempts to allocate
constant-sized placeholders for its text labels, thus eliminating the
jitter.

Example of the problem: https://streamable.com/jhsqz