### PR TITLE
Disable processing socket events in findIncompleteFiles()

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -2217,8 +2217,6 @@ bool Session::findIncompleteFiles(TorrentInfo &torrentInfo, QString &savePath) c
                 found = true;
                 torrentInfo.renameFile(i, filePath + QB_EXT);
             }
-            if ((i % 100) == 0)
-                qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
         }
 
         return found;


### PR DESCRIPTION
Related to bda5be8e4ce3dd998805427af862e134bdc7daa1, but this time is from webUI.