### PR TITLE
Control sequential download per global and per torrent basis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ conf.pri
 Makefile*
 *.pyc
 *.log
+*.autosave
 
 # Compiled object files
 *.o

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -42,6 +42,7 @@ HEADERS += \
     $$PWD/bittorrent/private/filterparserthread.h \
     $$PWD/bittorrent/private/statistics.h \
     $$PWD/bittorrent/private/resumedatasavingmanager.h \
+    $$PWD/bittorrent/private/sequentialdownloadsguard.h \
     $$PWD/rss/rss_article.h \
     $$PWD/rss/rss_item.h \
     $$PWD/rss/rss_feed.h \
@@ -64,7 +65,7 @@ HEADERS += \
     $$PWD/torrentfilter.h \
     $$PWD/scanfoldersmodel.h \
     $$PWD/searchengine.h \
-    $$PWD/global.h
+    $$PWD/global.h \
 
 SOURCES += \
     $$PWD/asyncfilestorage.cpp \
@@ -102,6 +103,7 @@ SOURCES += \
     $$PWD/bittorrent/private/filterparserthread.cpp \
     $$PWD/bittorrent/private/statistics.cpp \
     $$PWD/bittorrent/private/resumedatasavingmanager.cpp \
+    $$PWD/bittorrent/private/sequentialdownloadsguard.cpp \
     $$PWD/rss/rss_article.cpp \
     $$PWD/rss/rss_item.cpp \
     $$PWD/rss/rss_feed.cpp \
@@ -121,4 +123,4 @@ SOURCES += \
     $$PWD/torrentfileguard.cpp \
     $$PWD/torrentfilter.cpp \
     $$PWD/scanfoldersmodel.cpp \
-    $$PWD/searchengine.cpp
+    $$PWD/searchengine.cpp \

--- a/src/base/bittorrent/addtorrentparams.h
+++ b/src/base/bittorrent/addtorrentparams.h
@@ -44,6 +44,10 @@ namespace BitTorrent
         QString savePath;
         bool disableTempPath = false; // e.g. for imported torrents
         bool sequential = false;
+        /**
+           @brief Used to override global Sequential download setting.
+         */
+        bool sequentialOverride = false;
         bool firstLastPiecePriority = false;
         TriStateBool addForced;
         TriStateBool addPaused;

--- a/src/base/bittorrent/private/sequentialdownloadsguard.cpp
+++ b/src/base/bittorrent/private/sequentialdownloadsguard.cpp
@@ -1,0 +1,128 @@
+#include "sequentialdownloadsguard.h"
+
+#include <QDebug>
+
+#include "base/bittorrent/session.h"
+#include "base/bittorrent/torrenthandle.h"
+#include "base/logger.h"
+#include "base/utils/fs.h"
+#include "base/utils/misc.h"
+
+using namespace BitTorrent;
+
+/**
+   @brief SequentialDownloadsGuard explicit Constructor.
+ */
+SequentialDownloadsGuard::SequentialDownloadsGuard(Session *const session, QTimer *const sequentialGuardTimer)
+    : QObject(session)
+    , m_session(session)
+    , m_sequentialGuardTimer(sequentialGuardTimer)
+{
+}
+
+/**
+   @brief Recheck Sequential download for all active torrents.
+ */
+void SequentialDownloadsGuard::recheckSequentialDownloads()
+{
+    // Increase QTimer interval after first shot
+    increaseTimerInterval();
+
+    foreach (TorrentHandle *const torrentHandle, m_session->torrents())
+        if (torrentHandle->isActive() && torrentHandle->isDownloading())
+            updateSequentialDownload(torrentHandle);
+}
+
+/**
+   @brief Enable / Disable Sequential download by torrents availability, torrent has to be previewable
+   to enable sequential download.
+ */
+void SequentialDownloadsGuard::updateSequentialDownload(TorrentHandle *const torrentHandle)
+{
+    // TODO: tmp to remove before merge PR, so other contributors can check the behavior silver
+    qDebug() << torrentHandle->name() << ":"
+             << "sd" << (torrentHandle->isSequentialDownload() ? "[ON]" : "[OFF]")
+             << "flp" << (torrentHandle->hasFirstLastPiecePriority() ? "[ON]" : "[OFF]")
+             << "sdo" << (torrentHandle->isSequentialDownloadOverride() ? "[ON]" : "[OFF]");
+
+    if (isSequentialDownloadEnabled(torrentHandle)
+        && (torrentHandle->distributedCopies() > AVAILABILITY_LIMIT)
+        && torrentHandle->isPreviewable())
+        enableSequentialDownload(torrentHandle);
+    else
+        disableSequentialDownload(torrentHandle);
+}
+
+/**
+   @brief Is Sequential download enabled?
+
+   Takes into account global setting in Options dialog and possible override
+   in Add new Torrent dialog.
+ */
+bool SequentialDownloadsGuard::isSequentialDownloadEnabled(TorrentHandle *const torrentHandle) const
+{
+    // If Sequential download was overriden in Add new Torrent dialog, return
+    // that overriden value
+    if (m_session->isSequentialDownload() != torrentHandle->isSequentialDownloadOverride())
+        return torrentHandle->isSequentialDownloadOverride();
+
+    return m_session->isSequentialDownload();
+}
+
+/**
+   @brief Increase QTimer interval after first shot.
+ */
+void SequentialDownloadsGuard::increaseTimerInterval()
+{
+    if (!m_intervalIncreased) {
+        m_sequentialGuardTimer->start(SEQ_DOWNLOAD_REFRESH_INTERVAL);
+        m_intervalIncreased = true;
+    }
+}
+
+/**
+   @brief Enable Sequential download and first/last pieces and log message.
+ */
+void SequentialDownloadsGuard::enableSequentialDownload(TorrentHandle *const torrentHandle)
+{
+    const bool isSequentialDownload = torrentHandle->isSequentialDownload();
+    const bool hasFirstLastPiecePriority = torrentHandle->hasFirstLastPiecePriority();
+
+    // Separated if needed, because of fastresume
+    if (!isSequentialDownload)
+        torrentHandle->setSequentialDownload(true);
+    if (!hasFirstLastPiecePriority)
+        torrentHandle->setFirstLastPiecePriority(true);
+
+    // Log Sequential download Guard's result, only when status changed
+    if (!isSequentialDownload || !hasFirstLastPiecePriority)
+        logResult(torrentHandle);
+}
+
+/**
+   @brief Disable Sequential download and first/last pieces and log message.
+ */
+void SequentialDownloadsGuard::disableSequentialDownload(TorrentHandle *const torrentHandle)
+{
+    if (torrentHandle->isSequentialDownload()) {
+        torrentHandle->setSequentialDownload(false);
+        torrentHandle->setFirstLastPiecePriority(false);
+
+        // Log Sequential download Guard's result, only when status changed
+        logResult(torrentHandle);
+    }
+}
+
+/**
+   @brief Log Sequential download Guard's result.
+ */
+void SequentialDownloadsGuard::logResult(TorrentHandle *const torrentHandle) const
+{
+    QString logMessage = tr("Torrent '%1' : sequential download %2, first/last pieces %3")
+        .arg(torrentHandle->name())
+        .arg(torrentHandle->isSequentialDownload() ? tr("[ON]") : tr("[OFF]"))
+        .arg(torrentHandle->hasFirstLastPiecePriority() ? tr("[ON]") : tr("[OFF]"));
+
+    Logger::instance()->addMessage(logMessage, Log::NORMAL);
+    qDebug("%s", qUtf8Printable(logMessage));
+}

--- a/src/base/bittorrent/private/sequentialdownloadsguard.h
+++ b/src/base/bittorrent/private/sequentialdownloadsguard.h
@@ -1,0 +1,58 @@
+#ifndef SEQUENTIALDOWNLOADGUARD_H
+#define SEQUENTIALDOWNLOADGUARD_H
+
+#include <QObject>
+
+class QTimer;
+
+namespace BitTorrent
+{
+    class Session;
+    class TorrentHandle;
+
+    /**
+       @brief Enable / Disable Sequential download by torrents availability.
+
+       Enable / Disable Sequential download by torrents availability, torrent has to be previewable
+       to enable sequential download.
+       Sequential download can be enabled globally, in main options and per torrent
+       in Add new Torrent dialog.
+     */
+    class SequentialDownloadsGuard : public QObject
+    {
+        Q_OBJECT
+
+    public:
+        explicit SequentialDownloadsGuard(Session *const session, QTimer *const sequentialGuardTimer);
+
+        static const int SEQ_DOWNLOAD_FIRST_REFRESH_INTERVAL = 5 * 1000; // 5sec
+
+    public slots:
+        void recheckSequentialDownloads();
+
+    private:
+        void updateSequentialDownload(TorrentHandle *const torrentHandle);
+        bool isSequentialDownloadEnabled(TorrentHandle *const torrentHandle) const;
+        void increaseTimerInterval();
+        void enableSequentialDownload(TorrentHandle *const torrentHandle);
+        void disableSequentialDownload(TorrentHandle *const torrentHandle);
+        void logResult(TorrentHandle *const torrentHandle) const;
+
+        Session *m_session;
+        QTimer *m_sequentialGuardTimer;
+        bool m_intervalIncreased = false;
+
+        /**
+           @brief If availability is higher than this value, sequential download for a torrent
+           will be enabled.
+         */
+        static const int AVAILABILITY_LIMIT = 10;
+        /**
+           @brief Sequential download timer will be set to this value after first shot.
+         */
+        static const int SEQ_DOWNLOAD_REFRESH_INTERVAL = 15 * 1000; // 15sec
+        // TODO: this could be configurable in advanced settings, will see what contributors says to QTimer implementation :) silver
+    };
+}
+
+#endif // SEQUENTIALDOWNLOADGUARD_H

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -136,6 +136,7 @@ namespace BitTorrent
     class TorrentHandle;
     class Tracker;
     class MagnetUri;
+    class SequentialDownloadsGuard;
     class TrackerEntry;
     struct AddTorrentData;
 
@@ -299,6 +300,8 @@ namespace BitTorrent
         void setAddTorrentPaused(bool value);
         bool isCreateTorrentSubfolder() const;
         void setCreateTorrentSubfolder(bool value);
+        bool isSequentialDownload() const;
+        void setSequentialDownload(const bool enabled);
         bool isTrackerEnabled() const;
         void setTrackerEnabled(bool enabled);
         bool isAppendExtensionEnabled() const;
@@ -543,6 +546,7 @@ namespace BitTorrent
         bool hasPerTorrentSeedingTimeLimit() const;
 
         void initResumeFolder();
+        void initSequentialDownloadGuard();
 
         // Session configuration
         Q_INVOKABLE void configure();
@@ -694,6 +698,7 @@ namespace BitTorrent
         CachedSettingValue<bool> m_isDisableAutoTMMWhenCategorySavePathChanged;
         CachedSettingValue<bool> m_isTrackerEnabled;
         CachedSettingValue<QStringList> m_bannedIPs;
+        CachedSettingValue<bool> m_isSequentialDownload;
 
         // Order is important. This needs to be declared after its CachedSettingsValue
         // counterpart, because it uses it for initialization in the constructor
@@ -711,6 +716,8 @@ namespace BitTorrent
         QTimer *m_refreshTimer;
         QTimer *m_seedingLimitTimer;
         QTimer *m_resumeDataTimer;
+        QTimer *m_sequentialGuardTimer;
+        SequentialDownloadsGuard *m_sequentialDownloadGuard;
         Statistics *m_statistics;
         // IP filtering
         QPointer<FilterParserThread> m_filterParser;

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -98,6 +98,10 @@ namespace BitTorrent
         QString savePath;
         bool disableTempPath;
         bool sequential;
+        /**
+           @brief Used to override global Sequential download setting.
+         */
+        bool sequentialOverride;
         bool firstLastPiecePriority;
         bool hasSeedStatus;
         bool skipChecking;
@@ -196,6 +200,15 @@ namespace BitTorrent
         qlonglong pieceLength() const;
         qlonglong wastedSize() const;
         QString currentTracker() const;
+        bool isPreviewable() const;
+        /**
+           @brief Was Sequential download overriden in Add new Torrent dialog?
+         */
+        bool isSequentialDownloadOverride() const;
+        /**
+           @brief Setter for Sequential download override.
+         */
+        void setSequentialDownloadOverride(const bool value);
 
         // 1. savePath() - the path where all the files and subfolders of torrent are stored (as always).
         // 2. rootPath() - absolute path of torrent file tree (save path + first item from 1st torrent file path).
@@ -467,6 +480,7 @@ namespace BitTorrent
         bool m_hasMissingFiles;
         bool m_hasRootFolder;
         bool m_needsToSetFirstLastPiecePriority;
+        bool m_sequentialDownloadOverride;
 
         bool m_pauseAfterRecheck;
         bool m_needSaveResumeData;

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -103,6 +103,8 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::AddTorrentParams &inP
     else
         ui->startTorrentCheckBox->setChecked(!session->isAddTorrentPaused());
 
+    ui->sequentialDownloadCheckbox->setChecked(session->isSequentialDownload());
+
     ui->comboTTM->blockSignals(true); // the TreeView size isn't correct if the slot does it job at this point
     ui->comboTTM->setCurrentIndex(!session->isAutoTMMDisabledByDefault());
     ui->comboTTM->blockSignals(false);
@@ -635,6 +637,9 @@ void AddNewTorrentDialog::accept()
     }
 
     setEnabled(!ui->never_show_cb->isChecked());
+
+    // Sequential download override setting, checkbox in Add new Torrent dialog
+    m_torrentParams.sequentialOverride = ui->sequentialDownloadCheckbox->isChecked();
 
     // Add torrent
     if (!m_hasMetadata)

--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -181,6 +181,13 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="2">
+       <widget class="QCheckBox" name="sequentialDownloadCheckbox">
+        <property name="text">
+         <string>Sequential download</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/gui/optionsdlg.cpp
+++ b/src/gui/optionsdlg.cpp
@@ -233,6 +233,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     connect(m_ui->checkAdditionDialogFront, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkStartPaused, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkCreateSubfolder, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->checkSequentialDownload, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->deleteTorrentBox, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->deleteCancelledTorrentBox, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkExportDir, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
@@ -549,6 +550,7 @@ void OptionsDialog::saveOptions()
     AddNewTorrentDialog::setTopLevel(m_ui->checkAdditionDialogFront->isChecked());
     session->setAddTorrentPaused(addTorrentsInPause());
     session->setCreateTorrentSubfolder(m_ui->checkCreateSubfolder->isChecked());
+    session->setSequentialDownload(m_ui->checkSequentialDownload->isChecked());
     ScanFoldersModel::instance()->removeFromFSWatcher(removedScanDirs);
     ScanFoldersModel::instance()->addToFSWatcher(addedScanDirs);
     ScanFoldersModel::instance()->makePersistent();
@@ -760,6 +762,7 @@ void OptionsDialog::loadOptions()
     m_ui->checkAdditionDialogFront->setChecked(AddNewTorrentDialog::isTopLevel());
     m_ui->checkStartPaused->setChecked(session->isAddTorrentPaused());
     m_ui->checkCreateSubfolder->setChecked(session->isCreateTorrentSubfolder());
+    m_ui->checkSequentialDownload->setChecked(session->isSequentialDownload());
     const TorrentFileGuard::AutoDeleteMode autoDeleteMode = TorrentFileGuard::autoDeleteMode();
     m_ui->deleteTorrentBox->setChecked(autoDeleteMode != TorrentFileGuard::Never);
     m_ui->deleteCancelledTorrentBox->setChecked(autoDeleteMode == TorrentFileGuard::Always);

--- a/src/gui/optionsdlg.ui
+++ b/src/gui/optionsdlg.ui
@@ -725,6 +725,13 @@
                 </widget>
                </item>
                <item>
+                <widget class="QCheckBox" name="checkSequentialDownload">
+                 <property name="text">
+                  <string>Enable Sequential download for previewable torrents</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <widget class="QGroupBox" name="deleteTorrentBox">
                  <property name="toolTip">
                   <string>Should the .torrent file be deleted after adding it</string>


### PR DESCRIPTION
Will be possible to enable sequential download per whole app and per torrent.

The checkbox, which will control whole app, might be in `Downloads - When adding a torrent - Enable Sequential download`.

For per torrent it will be in `Add new torrent modal - Torrent settings - Sequential download`.

When checkbox will be checked in `main options`, so checkbox in `add new torrent dialog` will be checked by default and vice versa.

Of course, on the defaults this checkbox will be unchecked, so nothing changes and the default behavior will be like it's now.

When Sequential download will be selected through checkbox in main options or selected through checkbox in add new torrent modal, so availability should be checked, e.g. should be higher than 10.

So the behavior will be, e.g. this checkbox will be checked in `main options`, torrent will be added and download starts normally, not like sequential download, but when the availability will be higher than 10. torrent will be switched to sequential download.

Related task #7448 