### PR TITLE
Use smaller data type for TriStateBool

### DIFF
--- a/src/base/tristatebool.h
+++ b/src/base/tristatebool.h
@@ -47,7 +47,7 @@ public:
     bool operator!=(const TriStateBool &other) const;
 
 private:
-    int m_value = -1; // Undefined by default
+    signed char m_value = -1; // Undefined by default
 };
 
 #endif // TRISTATEBOOL_H


### PR DESCRIPTION
It seems a single byte is sufficient.
Comments welcome!
