### PR TITLE
Fix empty torrent name in TorrentHandle.m_name

### DIFF
--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -606,6 +606,8 @@ void AddNewTorrentDialog::accept()
     if (!m_hasMetadata)
         disconnect(this, SLOT(updateMetadata(const BitTorrent::TorrentInfo&)));
 
+    m_torrentParams.name = m_torrentInfo.name();
+
     // TODO: Check if destination actually exists
     m_torrentParams.skipChecking = ui->skipCheckingCheckBox->isChecked();
 


### PR DESCRIPTION
When I add torrent I have empty `BitTorrent::TorrentHandle->m_name` in `session->m_torrents`, the same after fastresume ( restart app ), torrent name is not saved to fastresume file.