### PR TITLE
Add option to enable Super Seeding mode once ratio/time limit is reached. Closes #7160.

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1529,9 +1529,13 @@ void Session::processShareLimits()
                             LogMsg(tr("'%1' reached the maximum ratio you set. Removed.").arg(torrent->name()));
                             deleteTorrent(torrent->hash());
                         }
-                        else if (!torrent->isPaused()) {
+                        else if ((m_maxRatioAction == Pause) && !torrent->isPaused()) {
                             torrent->pause();
                             LogMsg(tr("'%1' reached the maximum ratio you set. Paused.").arg(torrent->name()));
+                        }
+                        else if ((m_maxRatioAction == EnableSuperSeeding) && !torrent->isPaused() && !torrent->superSeeding()) {
+                            torrent->setSuperSeeding(true);
+                            LogMsg(tr("'%1' reached the maximum ratio you set. Enabled super seeding for it.").arg(torrent->name()));
                         }
                         continue;
                     }
@@ -1552,9 +1556,13 @@ void Session::processShareLimits()
                             LogMsg(tr("'%1' reached the maximum seeding time you set. Removed.").arg(torrent->name()));
                             deleteTorrent(torrent->hash());
                         }
-                        else if (!torrent->isPaused()) {
+                        else if ((m_maxRatioAction == Pause) && !torrent->isPaused()) {
                             torrent->pause();
                             LogMsg(tr("'%1' reached the maximum seeding time you set. Paused.").arg(torrent->name()));
+                        }
+                        else if ((m_maxRatioAction == EnableSuperSeeding) && !torrent->isPaused() && !torrent->superSeeding()) {
+                            torrent->setSuperSeeding(true);
+                            LogMsg(tr("'%1' reached the maximum seeding time you set. Enabled super seeding for it.").arg(torrent->name()));
                         }
                     }
                 }

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -62,7 +62,8 @@ class ResumeDataSavingManager;
 enum MaxRatioAction
 {
     Pause,
-    Remove
+    Remove,
+    EnableSuperSeeding
 };
 
 enum TorrentExportFolder

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -2455,9 +2455,6 @@
                  <property name="enabled">
                   <bool>false</bool>
                  </property>
-                 <property name="alignment">
-                  <set>Qt::AlignCenter</set>
-                 </property>
                  <property name="suffix">
                   <string extracomment="minutes"> min</string>
                  </property>
@@ -2501,6 +2498,11 @@
                    <string>Remove them</string>
                   </property>
                  </item>
+                 <item>
+                  <property name="text">
+                   <string>Enable super seeding for them</string>
+                  </property>
+                 </item>
                 </widget>
                </item>
                <item row="1" column="0">
@@ -2514,9 +2516,6 @@
                 <widget class="QDoubleSpinBox" name="spinMaxRatio">
                  <property name="enabled">
                   <bool>false</bool>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignHCenter</set>
                  </property>
                  <property name="maximum">
                   <double>9998.000000000000000</double>

--- a/src/webui/www/private/preferences_content.html
+++ b/src/webui/www/private/preferences_content.html
@@ -579,6 +579,7 @@
                         <select id="max_ratio_act">
                             <option value="0">QBT_TR(Pause them)QBT_TR[CONTEXT=OptionsDialog]</option>
                             <option value="1">QBT_TR(Remove them)QBT_TR[CONTEXT=OptionsDialog]</option>
+                            <option value="2">QBT_TR(Enable super seeding for them)QBT_TR[CONTEXT=OptionsDialog]</option>
                         </select>
                     </td>
                 </tr>


### PR DESCRIPTION
When ratio/time limit is reached, ETA shows zero for affected torrents until qbt restart, after that, infinity. Thought i should point it out in case it's undesirable.