### PR TITLE
Center Options dialog when showed

### DIFF
--- a/src/gui/optionsdlg.cpp
+++ b/src/gui/optionsdlg.cpp
@@ -391,8 +391,10 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     m_ui->textTempPath->setDialogCaption(tr("Choose a save directory"));
     m_ui->textTempPath->setMode(FileSystemPathEdit::Mode::DirectorySave);
 
-    show();
     loadWindowState();
+    show();
+    // Have to be called after show(), because splitter width needed
+    loadSplitterState();
 }
 
 void OptionsDialog::initializeLanguageCombo()
@@ -439,6 +441,12 @@ void OptionsDialog::loadWindowState()
     const Preferences* const pref = Preferences::instance();
 
     resize(pref->getPrefSize(this->size()));
+}
+
+void OptionsDialog::loadSplitterState()
+{
+    const Preferences* const pref = Preferences::instance();
+
     const QStringList sizes_str = pref->getPrefHSplitterSizes();
     QList<int> sizes;
     if (sizes_str.size() == 2) {

--- a/src/gui/optionsdlg.h
+++ b/src/gui/optionsdlg.h
@@ -93,6 +93,7 @@ private slots:
     void toggleComboRatioLimitAct();
     void changePage(QListWidgetItem*, QListWidgetItem*);
     void loadWindowState();
+    void loadSplitterState();
     void saveWindowState() const;
     void handleScanFolderViewSelectionChanged();
     void on_IpFilterRefreshBtn_clicked();


### PR DESCRIPTION
The reason for this was, that options dialog overflow at bottom, so Ok and Cancel buttons was out of screen.