### PR TITLE
Don't use margins in FileSystemPathEdit widgets.

### DIFF
--- a/src/gui/fspathedit.cpp
+++ b/src/gui/fspathedit.cpp
@@ -182,6 +182,7 @@ FileSystemPathEdit::FileSystemPathEdit(Private::FileEditorWithCompletion *editor
     editor->widget()->setParent(this);
 
     QHBoxLayout *layout = new QHBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
     layout->addWidget(editor->widget());
     layout->addWidget(d->m_browseBtn);
 


### PR DESCRIPTION
Introduced in 30081e0.

I discovered this from the most obvious offending place:

Before:
![before](https://user-images.githubusercontent.com/273315/30721317-15e0a854-9f34-11e7-9a6a-ba5ee4f02e59.jpg)

After:
![after](https://user-images.githubusercontent.com/273315/30721324-1cfb0f3a-9f34-11e7-9927-f2e4c483f382.jpg)

Other places where it is used are tighter now too.