### PR TITLE
Options dialog save windows state in destructor

### DIFF
--- a/src/gui/optionsdlg.cpp
+++ b/src/gui/optionsdlg.cpp
@@ -421,6 +421,9 @@ void OptionsDialog::initializeLanguageCombo()
 OptionsDialog::~OptionsDialog()
 {
     qDebug("-> destructing Options");
+
+    saveWindowState();
+
     foreach (const QString &path, addedScanDirs)
         ScanFoldersModel::instance()->removePath(path);
     ScanFoldersModel::instance()->configure(); // reloads "removed" paths
@@ -1211,7 +1214,7 @@ void OptionsDialog::on_buttonBox_accepted()
         this->hide();
         saveOptions();
     }
-    saveWindowState();
+
     accept();
 }
 


### PR DESCRIPTION
Option dialog's state will be saved on cancel action too.