### PR TITLE
Show torrent name in "add new torrent" dialog on merging trackers

### DIFF
--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -263,12 +263,12 @@ bool AddNewTorrentDialog::loadTorrent(const QString &torrentPath)
         BitTorrent::TorrentHandle *const torrent = BitTorrent::Session::instance()->findTorrent(m_hash);
         if (torrent) {
             if (torrent->isPrivate() || m_torrentInfo.isPrivate()) {
-                MessageBoxRaised::critical(this, tr("Already in download list"), tr("Torrent is already in download list. Trackers weren't merged because it is a private torrent."), QMessageBox::Ok);
+                MessageBoxRaised::critical(this, tr("Already in download list"), tr("Torrent '%1' is already in download list. Trackers weren't merged because it is a private torrent.").arg(torrent->name()), QMessageBox::Ok);
             }
             else {
                 torrent->addTrackers(m_torrentInfo.trackers());
                 torrent->addUrlSeeds(m_torrentInfo.urlSeeds());
-                MessageBoxRaised::information(this, tr("Already in download list"), tr("Torrent is already in download list. Trackers were merged."), QMessageBox::Ok);
+                MessageBoxRaised::information(this, tr("Already in download list"), tr("Torrent '%1' is already in download list. Trackers were merged.").arg(torrent->name()), QMessageBox::Ok);
             }
         }
         else {
@@ -297,12 +297,12 @@ bool AddNewTorrentDialog::loadMagnet(const BitTorrent::MagnetUri &magnetUri)
         BitTorrent::TorrentHandle *const torrent = BitTorrent::Session::instance()->findTorrent(m_hash);
         if (torrent) {
             if (torrent->isPrivate()) {
-                MessageBoxRaised::critical(this, tr("Already in download list"), tr("Torrent is already in download list. Trackers weren't merged because it is a private torrent."), QMessageBox::Ok);
+                MessageBoxRaised::critical(this, tr("Already in download list"), tr("Torrent '%1' is already in download list. Trackers weren't merged because it is a private torrent.").arg(torrent->name()), QMessageBox::Ok);
             }
             else {
                 torrent->addTrackers(magnetUri.trackers());
                 torrent->addUrlSeeds(magnetUri.urlSeeds());
-                MessageBoxRaised::information(this, tr("Already in download list"), tr("Magnet link is already in download list. Trackers were merged."), QMessageBox::Ok);
+                MessageBoxRaised::information(this, tr("Already in download list"), tr("Magnet link '%1' is already in download list. Trackers were merged.").arg(torrent->name()), QMessageBox::Ok);
             }
         }
         else {
@@ -556,7 +556,7 @@ void AddNewTorrentDialog::populateSavePathComboBox()
     foreach (const QString &savePath, settings()->loadValue(KEY_SAVEPATHHISTORY).toStringList())
         if (QDir(savePath) != defaultSaveDir)
             ui->savePath->addItem(savePath);
-    
+
     if (!m_torrentParams.savePath.isEmpty())
         setSavePath(m_torrentParams.savePath);
 }


### PR DESCRIPTION
It is confusing if the dialog doesn't show the existing torrent name.