### PR TITLE
Windows qmake override file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ conf.pri
 Makefile*
 *.pyc
 *.log
+/winconf-user.pri
 
 # Compiled object files
 *.o

--- a/winconf.pri
+++ b/winconf.pri
@@ -66,3 +66,8 @@ win32-g++* {
 else {
     include(winconf-msvc.pri)
 }
+
+# Here you can include your personal overrides
+exists(winconf-user.pri) {
+    include(winconf-user.pri)
+}


### PR DESCRIPTION
The reason for this is that I have to stash before I switch to other branch, because I have custom code in `winconf.pri` and `winconf-msvc.pri`, the other reason I can't use `git add .` or `git commit -a`.
With this PR I can simply put all my custom settings to `winconf-override.pri` and i'm good to go.