### PR TITLE
Excess QtConcurrent usage removal

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(LibtorrentRasterbar REQUIRED)
 # Qt
 list(APPEND QBT_QT_COMPONENTS Core Network Xml)
 if (GUI)
-    list (APPEND QBT_QT_COMPONENTS Concurrent Gui Svg Widgets)
+    list (APPEND QBT_QT_COMPONENTS Gui Svg Widgets)
     if (WIN32)
         list (APPEND QBT_QT_COMPONENTS WinExtras)
     endif(WIN32)

--- a/src/gui/properties/CMakeLists.txt
+++ b/src/gui/properties/CMakeLists.txt
@@ -44,4 +44,4 @@ speedplotview.cpp
 
 add_library(qbt_properties STATIC ${QBT_PROPERTIES_HEADERS} ${QBT_PROPERTIES_SOURCES} ${QBT_PROPERTIES_FORMS})
 target_link_libraries(qbt_properties qbt_base)
-target_link_libraries(qbt_properties Qt5::Widgets Qt5::Concurrent)
+target_link_libraries(qbt_properties Qt5::Widgets)

--- a/src/gui/properties/speedwidget.h
+++ b/src/gui/properties/speedwidget.h
@@ -31,7 +31,6 @@
 
 #include <QWidget>
 #include <QComboBox>
-#include <QtConcurrentRun>
 
 #include "speedplotview.h"
 
@@ -64,12 +63,11 @@ public:
 private slots:
     void onPeriodChange(int period);
     void onGraphChange(int id);
+    void update();
 
 private:
-    void update();
     void loadSettings();
     void saveSettings() const;
-    Q_INVOKABLE void graphUpdate();
 
     QVBoxLayout *m_layout;
     QHBoxLayout *m_hlayout;
@@ -81,9 +79,6 @@ private:
     QMenu *m_graphsMenu;
     QList<QAction *> m_graphsMenuActions;
     QSignalMapper *m_graphsSignalMapper;
-
-    QFuture<void> m_updateFuture;
-    bool m_isUpdating;
 };
 
 #endif // SPEEDWIDGET_H

--- a/src/src.pro
+++ b/src/src.pro
@@ -19,7 +19,7 @@ nogui {
     DEFINES += DISABLE_GUI
 } else {
     TARGET = qbittorrent
-    QT += xml concurrent svg widgets
+    QT += xml svg widgets
 
     CONFIG(static) {
         DEFINES += QBT_STATIC_QT


### PR DESCRIPTION
Remove excess QtConcurrent usage in SpeedWidget. Existing usage of QtConcurrent has no meaning because of: 
1. The only task processed inside separate thread is just to copy 10 simple values from one place to another and sleep 1000 msecs. 
2. There is no heavy GUI blocking operations. 
3. It blocks 1 thread in QtConcurrent forever for infinite loop with Sleep(), hogging resources in QtConcurrent thread pull.
4. It adds burden of inter-thread synchronization and context switching. 
5. Maintenance cost for programmers. 