### PR TITLE
Change QT_AUTO_SCREEN_SCALE_FACTOR default to 0

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -328,7 +328,7 @@ void showSplashScreen()
 void setupDpi()
 {
     if (qgetenv("QT_AUTO_SCREEN_SCALE_FACTOR").isEmpty())
-        qputenv("QT_AUTO_SCREEN_SCALE_FACTOR", "1");
+        qputenv("QT_AUTO_SCREEN_SCALE_FACTOR", "0");
 }
 #endif  // Q_OS_UNIX
 #endif  // DISABLE_GUI


### PR DESCRIPTION
If the environment variable QT_AUTO_SCREEN_SCALE_FACTOR is not set, default it to 0 to prevent scaling issues such as #6935.