### PR TITLE
allow search plugins sorting. closes #7526

### DIFF
--- a/src/gui/search/pluginselectdlg.cpp
+++ b/src/gui/search/pluginselectdlg.cpp
@@ -82,6 +82,7 @@ PluginSelectDlg::PluginSelectDlg(SearchEngine *pluginManager, QWidget *parent)
     m_ui->pluginsTree->header()->resizeSection(1, 80);
     m_ui->pluginsTree->header()->resizeSection(2, 200);
     m_ui->pluginsTree->hideColumn(PLUGIN_ID);
+    m_ui->pluginsTree->header()->setSortIndicator(0, Qt::AscendingOrder);
 
     m_ui->actionUninstall->setIcon(GuiIconProvider::instance()->getIcon("list-remove"));
 

--- a/src/gui/search/pluginselectdlg.ui
+++ b/src/gui/search/pluginselectdlg.ui
@@ -45,6 +45,9 @@
      <property name="itemsExpandable">
       <bool>false</bool>
      </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
      <column>
       <property name="text">
        <string>Name</string>


### PR DESCRIPTION
enabled sorting for installed plugins list. closes #7526 
![screenshot_2017-10-03_16-49-10](https://user-images.githubusercontent.com/947647/31129035-1f2773d0-a85c-11e7-8848-e6282e5bce1e.png)
