### PR TITLE
Set QTextOption::NoWrap property in "Download from URLs" dialog

### DIFF
--- a/src/gui/downloadfromurldlg.h
+++ b/src/gui/downloadfromurldlg.h
@@ -56,6 +56,8 @@ class downloadFromURL : public QDialog, private Ui::downloadFromURL
       connect(buttonBox, &QDialogButtonBox::accepted, this, &downloadFromURL::downloadButtonClicked);
       connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
+      textUrls->setWordWrapMode(QTextOption::NoWrap);
+
       // Paste clipboard if there is an URL in it
       QString clip_txt = qApp->clipboard()->text();
       QStringList clip_txt_list = clip_txt.split(QString::fromUtf8("\n"));


### PR DESCRIPTION
This makes it easier to put each magnet link on its own line.
And there is this "One link per line" message...

* Before:
  ![before](https://user-images.githubusercontent.com/9395168/31131563-17531930-a88d-11e7-906a-94b83edf6f0e.png)
* After:
  ![after](https://user-images.githubusercontent.com/9395168/31131562-174d2e6c-a88d-11e7-93db-51a2ab5b4ca2.png)

BTW, my preference: `QTextOption::NoWrap` > `QTextOption::WrapAnywhere` > `QTextOption::WordWrap` (current git master).