### PR TITLE
Report TCPServer errorString() if webui fails to listen to port

### DIFF
--- a/src/webui/webui.cpp
+++ b/src/webui/webui.cpp
@@ -28,6 +28,10 @@
 
 #include "webui.h"
 
+#ifdef DISABLE_GUI
+#include <QCoreApplication>
+#endif
+
 #include "base/http/server.h"
 #include "base/logger.h"
 #include "base/net/dnsupdater.h"
@@ -90,10 +94,17 @@ void WebUI::init()
 
         if (!m_httpServer->isListening()) {
             bool success = m_httpServer->listen(QHostAddress::Any, m_port);
-            if (success)
+            if (success) {
                 logger->addMessage(tr("Web UI: Now listening on port %1").arg(m_port));
-            else
-                logger->addMessage(tr("Web UI: Unable to bind to port %1 : %2").arg(m_port).arg(m_httpServer->errorString()), Log::CRITICAL);
+            }
+            else {
+                const QString errorMsg = tr("Web UI: Unable to bind to port %1. %2").arg(m_port).arg(m_httpServer->errorString());
+                logger->addMessage(errorMsg, Log::CRITICAL);
+#ifdef DISABLE_GUI
+                qCritical() << errorMsg;
+                QCoreApplication::exit(1);
+#endif
+            }
         }
 
         // DynDNS

--- a/src/webui/webui.cpp
+++ b/src/webui/webui.cpp
@@ -93,7 +93,7 @@ void WebUI::init()
             if (success)
                 logger->addMessage(tr("Web UI: Now listening on port %1").arg(m_port));
             else
-                logger->addMessage(tr("Web UI: Unable to bind to port %1").arg(m_port), Log::CRITICAL);
+                logger->addMessage(tr("Web UI: Unable to bind to port %1 : %2").arg(m_port).arg(m_httpServer->errorString()), Log::CRITICAL);
         }
 
         // DynDNS


### PR DESCRIPTION
I'm trying to debug why qbittorrent-nox fails to listen() to the webui port on my FreeBSD 11.1 jail. This missing error string is the first necessary step.

Also this whole block is inside of `if(pref->isWebUiEnabled())`? Wouldn't it make more sense to throw an exception and die instead of starting up and silently failing to start the webui?