### PR TITLE
Show new paths in native form.

### DIFF
--- a/src/gui/fspathedit.cpp
+++ b/src/gui/fspathedit.cpp
@@ -127,7 +127,7 @@ void FileSystemPathEdit::FileSystemPathEditPrivate::browseActionTriggered()
         throw std::logic_error("Unknown FileSystemPathEdit mode");
     }
     if (!selectedPath.isEmpty())
-        q->setEditWidgetText(selectedPath);
+        q->setEditWidgetText(Utils::Fs::toNativePath(selectedPath));
 }
 
 QString FileSystemPathEdit::FileSystemPathEditPrivate::dialogCaptionOrDefault() const


### PR DESCRIPTION
This shows up on Windows: Choose a new save path from the browse button in "Add New Torrent" dialog and the path is shown with `/` instead of `\`.

@evsh I am not sure if I should have done this in the base class or in the 2 derived classes.