### PR TITLE
Fix delete key has no effect due to "Ambiguous shortcut overload"

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -840,6 +840,7 @@ void MainWindow::createKeyboardShortcuts()
     m_ui->actionCreateTorrent->setShortcut(QKeySequence::New);
     m_ui->actionOpen->setShortcut(QKeySequence::Open);
     m_ui->actionDelete->setShortcut(QKeySequence::Delete);
+    m_ui->actionDelete->setShortcutContext(Qt::WidgetShortcut);  // nullify its effect: delete key event is handled by respective widgets, not here
     m_ui->actionDownloadFromURL->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_O);
     m_ui->actionExit->setShortcut(Qt::CTRL + Qt::Key_Q);
 

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -285,6 +285,7 @@ TransferListWidget::TransferListWidget(QWidget *parent, MainWindow *mainWindow)
     connect(header(), SIGNAL(sortIndicatorChanged(int, Qt::SortOrder)), this, SLOT(saveSettings()));
 
     m_editHotkey = new QShortcut(Qt::Key_F2, this, SLOT(renameSelectedTorrent()), 0, Qt::WidgetShortcut);
+    m_deleteHotkey = new QShortcut(QKeySequence::Delete, this, SLOT(softDeleteSelectedTorrents()), 0, Qt::WidgetShortcut);
     m_permDeleteHotkey = new QShortcut(Qt::SHIFT + Qt::Key_Delete, this, SLOT(permDeleteSelectedTorrents()), 0, Qt::WidgetShortcut);
     m_doubleClickHotkey = new QShortcut(Qt::Key_Return, this, SLOT(torrentDoubleClicked()), 0, Qt::WidgetShortcut);
     m_recheckHotkey = new QShortcut(Qt::CTRL + Qt::Key_R, this, SLOT(recheckSelectedTorrents()), 0, Qt::WidgetShortcut);

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -132,6 +132,7 @@ private:
     TransferListSortModel *m_sortFilterModel;
     MainWindow *m_mainWindow;
     QShortcut *m_editHotkey;
+    QShortcut *m_deleteHotkey;
     QShortcut *m_permDeleteHotkey;
     QShortcut *m_doubleClickHotkey;
     QShortcut *m_recheckHotkey;


### PR DESCRIPTION
As discussed in https://github.com/qbittorrent/qBittorrent/pull/7550#issuecomment-335027918 .

We want to show the accelerator key in the menu but without hitting the ambiguous overload error.

Also, if this PR is accepted, I shall close #7550.