### PR TITLE
Add WebUi\Address config option

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -463,6 +463,16 @@ void Preferences::setServerDomains(const QString &str)
     setValue("Preferences/WebUI/ServerDomains", str);
 }
 
+QString Preferences::getWebUiAddress() const
+{
+    return value("Preferences/WebUI/Address", "*").toString().trimmed();
+}
+
+void Preferences::setWebUiAddress(const QString &addr)
+{
+    setValue("Preferences/WebUI/Address", addr.trimmed());
+}
+
 quint16 Preferences::getWebUiPort() const
 {
     return value("Preferences/WebUI/Port", 8080).toInt();

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -174,6 +174,8 @@ public:
     void setWebUiLocalAuthEnabled(bool enabled);
     QString getServerDomains() const;
     void setServerDomains(const QString &str);
+    QString getWebUiAddress() const;
+    void setWebUiAddress(const QString &addr);
     quint16 getWebUiPort() const;
     void setWebUiPort(quint16 port);
     bool useUPnPForWebUIPort() const;

--- a/src/gui/optionsdlg.cpp
+++ b/src/gui/optionsdlg.cpp
@@ -340,6 +340,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     // Web UI tab
     connect(m_ui->textServerDomains, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->checkWebUi, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->textWebUiAddress, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->spinWebUiPort, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->checkWebUIUPnP, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkWebUiHttps, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
@@ -648,7 +649,8 @@ void OptionsDialog::saveOptions()
     pref->setWebUiEnabled(isWebUiEnabled());
     if (isWebUiEnabled()) {
         pref->setServerDomains(m_ui->textServerDomains->text());
-        pref->setWebUiPort(webUiPort());
+        pref->setWebUiAddress(m_ui->textWebUiAddress->text());
+        pref->setWebUiPort(m_ui->spinWebUiPort->value());
         pref->setUPnPForWebUIPort(m_ui->checkWebUIUPnP->isChecked());
         pref->setWebUiHttpsEnabled(m_ui->checkWebUiHttps->isChecked());
         if (m_ui->checkWebUiHttps->isChecked()) {
@@ -1038,6 +1040,7 @@ void OptionsDialog::loadOptions()
     // Web UI preferences
     m_ui->textServerDomains->setText(pref->getServerDomains());
     m_ui->checkWebUi->setChecked(pref->isWebUiEnabled());
+    m_ui->textWebUiAddress->setText(pref->getWebUiAddress());
     m_ui->spinWebUiPort->setValue(pref->getWebUiPort());
     m_ui->checkWebUIUPnP->setChecked(pref->useUPnPForWebUIPort());
     m_ui->checkWebUiHttps->setChecked(pref->isWebUiHttpsEnabled());
@@ -1503,11 +1506,6 @@ QString OptionsDialog::getFilter() const
 bool OptionsDialog::isWebUiEnabled() const
 {
     return m_ui->checkWebUi->isChecked();
-}
-
-quint16 OptionsDialog::webUiPort() const
-{
-    return m_ui->spinWebUiPort->value();
 }
 
 QString OptionsDialog::webUiUsername() const

--- a/src/gui/optionsdlg.h
+++ b/src/gui/optionsdlg.h
@@ -168,7 +168,6 @@ private:
     int getMaxActiveUploads() const;
     int getMaxActiveTorrents() const;
     bool isWebUiEnabled() const;
-    quint16 webUiPort() const;
     QString webUiUsername() const;
     QString webUiPassword() const;
 

--- a/src/gui/optionsdlg.ui
+++ b/src/gui/optionsdlg.ui
@@ -2758,29 +2758,23 @@
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_2">
                <item>
-                <layout class="QHBoxLayout" name="horizontalLayout_10">
-                 <item>
-                  <widget class="QLabel" name="labelServerDomains">
-                   <property name="text">
-                    <string>Server domains:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLineEdit" name="textServerDomains">
-                   <property name="toolTip">
-                    <string>Whitelist for filtering HTTP Host header values.
-In order to defend against DNS rebinding attack,
-you should put in domain names used by WebUI server.
-
-Use ';' to split multiple entries. Can use wildcard '*'.</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item>
                 <layout class="QHBoxLayout" name="horizontalLayout_2">
+                 <item>
+                  <widget class="QLabel" name="lblWebUiAddress">
+                   <property name="text">
+                    <string>IP address:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLineEdit" name="textWebUiAddress">
+                   <property name="toolTip">
+                    <string>IP address that the Web UI will bind to.
+Specify an IPv4 or IPv6 address. You can specify "0.0.0.0" for any IPv4 address,
+"::" for any IPv6 address, or "*" for both IPv4 and IPv6.</string>
+                   </property>
+                  </widget>
+                 </item>
                  <item>
                   <widget class="QLabel" name="lblWebUiPort">
                    <property name="text">
@@ -2801,18 +2795,27 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
                    </property>
                   </widget>
                  </item>
+                </layout>
+               </item>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayout_10">
                  <item>
-                  <spacer>
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                  <widget class="QLabel" name="labelServerDomains">
+                   <property name="text">
+                    <string>Server domains:</string>
                    </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>21</width>
-                     <height>29</height>
-                    </size>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLineEdit" name="textServerDomains">
+                   <property name="toolTip">
+                    <string>Whitelist for filtering HTTP Host header values.
+In order to defend against DNS rebinding attack,
+you should put in domain names used by WebUI server.
+
+Use ';' to split multiple entries. Can use wildcard '*'.</string>
                    </property>
-                  </spacer>
+                  </widget>
                  </item>
                 </layout>
                </item>

--- a/src/webui/prefjson.cpp
+++ b/src/webui/prefjson.cpp
@@ -163,6 +163,7 @@ QByteArray prefjson::getPreferences()
     data["locale"] = pref->getLocale();
     // HTTP Server
     data["web_ui_domain_list"] = pref->getServerDomains();
+    data["web_ui_address"] = pref->getWebUiAddress();
     data["web_ui_port"] = pref->getWebUiPort();
     data["web_ui_upnp"] = pref->useUPnPForWebUIPort();
     data["use_https"] = pref->isWebUiHttpsEnabled();
@@ -399,6 +400,8 @@ void prefjson::setPreferences(const QString& json)
     // HTTP Server
     if (m.contains("web_ui_domain_list"))
         pref->setServerDomains(m["web_ui_domain_list"].toString());
+    if (m.contains("web_ui_address"))
+        pref->setWebUiAddress(m["web_ui_address"].toString());
     if (m.contains("web_ui_port"))
         pref->setWebUiPort(m["web_ui_port"].toUInt());
     if (m.contains("web_ui_upnp"))

--- a/src/webui/webui.cpp
+++ b/src/webui/webui.cpp
@@ -93,7 +93,11 @@ void WebUI::init()
 #endif
 
         if (!m_httpServer->isListening()) {
-            bool success = m_httpServer->listen(QHostAddress::Any, m_port);
+            const QString addressString = pref->getWebUiAddress();
+            const auto address = (addressString == "*" || addressString.isEmpty())
+                ? QHostAddress::Any : QHostAddress(addressString);
+
+            bool success = m_httpServer->listen(address, m_port);
             if (success) {
                 logger->addMessage(tr("Web UI: Now listening on port %1").arg(m_port));
             }

--- a/src/webui/www/public/preferences_content.html
+++ b/src/webui/www/public/preferences_content.html
@@ -410,8 +410,9 @@
 
 <fieldset class="settings">
   <legend>QBT_TR(Web User Interface (Remote control))QBT_TR[CONTEXT=OptionsDialog]</legend>
-  <label for="webui_domain_textarea">QBT_TR(Server domains:)QBT_TR[CONTEXT=OptionsDialog]</label><textarea id="webui_domain_textarea" rows="1" cols="70"></textarea><br/>
+  <label for="webui_address_value">QBT_TR(IP address:)QBT_TR[CONTEXT=OptionsDialog]</label><input type="text" id="webui_address_value"/>
   <label for="webui_port_value">QBT_TR(Port:)QBT_TR[CONTEXT=OptionsDialog]</label><input type="text" id="webui_port_value" style="width: 4em;"/><br/>
+  <label for="webui_domain_textarea">QBT_TR(Server domains:)QBT_TR[CONTEXT=OptionsDialog]</label><textarea id="webui_domain_textarea" rows="1" cols="70"></textarea><br/>
   <input type="checkbox" id="webui_upnp_checkbox"/>
   <label for="webui_upnp_checkbox">QBT_TR(Use UPnP / NAT-PMP to forward the port from my router)QBT_TR[CONTEXT=OptionsDialog]</label><br/>
   <fieldset class="settings">
@@ -1046,6 +1047,7 @@ loadPreferences = function() {
 
                     // HTTP Server
                     $('webui_domain_textarea').setProperty('value', pref.web_ui_domain_list);
+                    $('webui_address_value').setProperty('value', pref.web_ui_address);
                     $('webui_port_value').setProperty('value', pref.web_ui_port);
                     $('webui_upnp_checkbox').setProperty('checked', pref.web_ui_upnp);
                     $('use_https_checkbox').setProperty('checked', pref.use_https);
@@ -1314,11 +1316,13 @@ applyPreferences = function() {
 
   // HTTP Server
   settings.set('web_ui_domain_list', $('webui_domain_textarea').getProperty('value'));
+  var web_ui_address = $('webui_address_value').getProperty('value').toString();
   var web_ui_port = $('webui_port_value').getProperty('value').toInt();
   if(isNaN(web_ui_port) || web_ui_port < 1 || web_ui_port > 65535) {
     alert("QBT_TR(The port used for the Web UI must be between 1 and 65535.)QBT_TR[CONTEXT=HttpServer]");
     return;
   }
+  settings.set('web_ui_address', web_ui_address);
   settings.set('web_ui_port', web_ui_port);
   settings.set('web_ui_upnp', $('webui_upnp_checkbox').getProperty('checked'));
   settings.set('use_https', $('use_https_checkbox').getProperty('checked'));


### PR DESCRIPTION
As I mentioned in a previous PR, I had an issue with qbittorrent-nox failing to `listen()` on my FreeBSD jail. The reason it was failing is because the webui is hard coded to use `QHostAddress::Any` which tries to bind to IPv4 and IPv6. This caused the failure because my jail has IPv6 disable.

This patch adds a "WebUI\Address" config option. It uses the string parsing built into `QHostAddress`. One caveat is that there is no equivalent string for `QHostAddress::Any`, so I've opted to use the string "*" to mean Any and this is the default.

Since there is parsing now being done in `Preferences`, I've had to add a `PreferencesParsingError` exception class.