### PR TITLE
Add option to tune download history list length. Closes #4043.

### DIFF
--- a/src/gui/addnewtorrentdialog.h
+++ b/src/gui/addnewtorrentdialog.h
@@ -53,18 +53,24 @@ namespace Ui
 class TorrentContentFilterModel;
 class TorrentFileGuard;
 class PropListDelegate;
+template <typename T> class CachedSettingValue;
 
 class AddNewTorrentDialog: public QDialog
 {
     Q_OBJECT
 
 public:
+    static constexpr int minPathHistoryLength = 0;
+    static constexpr int maxPathHistoryLength = 99;
+
     ~AddNewTorrentDialog();
 
     static bool isEnabled();
     static void setEnabled(bool value);
     static bool isTopLevel();
     static void setTopLevel(bool value);
+    static int savePathHistoryLength();
+    static void setSavePathHistoryLength(int value);
 
     static void show(QString source, const BitTorrent::AddTorrentParams &inParams, QWidget *parent);
     static void show(QString source, QWidget *parent);
@@ -99,6 +105,7 @@ private:
     void setupTreeview();
     void setCommentText(const QString &str) const;
     void setSavePath(const QString &newPath);
+    static CachedSettingValue<int> &savePathHistoryLengthSetting();
 
     void showEvent(QShowEvent *event) override;
 

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -37,6 +37,7 @@
 #include "base/bittorrent/session.h"
 #include "base/preferences.h"
 #include "base/unicodestrings.h"
+#include "gui/addnewtorrentdialog.h"
 #include "gui/mainwindow.h"
 
 enum AdvSettingsCols
@@ -69,6 +70,7 @@ enum AdvSettingsRows
     TORRENT_ADDED_NOTIFICATIONS,
     CONFIRM_REMOVE_ALL_TAGS,
     DOWNLOAD_TRACKER_FAVICON,
+    SAVE_PATH_HISTORY_LENGTH,
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
     USE_ICON_THEME,
 #endif
@@ -196,6 +198,7 @@ void AdvancedSettings::saveAdvancedSettings()
     mainWindow->setTorrentAddedNotificationsEnabled(cb_torrent_added_notifications.isChecked());
     // Misc GUI properties
     mainWindow->setDownloadTrackerFavicon(cb_tracker_favicon.isChecked());
+    AddNewTorrentDialog::setSavePathHistoryLength(spinSavePathHistoryLength.value());
 
     // Tracker
     session->setTrackerEnabled(cb_tracker_status.isChecked());
@@ -418,7 +421,10 @@ void AdvancedSettings::loadAdvancedSettings()
     // Download tracker's favicon
     cb_tracker_favicon.setChecked(mainWindow->isDownloadTrackerFavicon());
     addRow(DOWNLOAD_TRACKER_FAVICON, tr("Download tracker's favicon"), &cb_tracker_favicon);
-
+    // Save path history length
+    spinSavePathHistoryLength.setRange(AddNewTorrentDialog::minPathHistoryLength, AddNewTorrentDialog::maxPathHistoryLength);
+    spinSavePathHistoryLength.setValue(AddNewTorrentDialog::savePathHistoryLength());
+    addRow(SAVE_PATH_HISTORY_LENGTH, tr("Save path history length"), &spinSavePathHistoryLength);
     // Tracker State
     cb_tracker_status.setChecked(session->isTrackerEnabled());
     addRow(TRACKER_STATUS, tr("Enable embedded tracker"), &cb_tracker_status);

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -76,7 +76,7 @@ private:
 
     QLabel labelQbtLink, labelLibtorrentLink;
     QSpinBox spin_cache, spin_save_resume_data_interval, outgoing_ports_min, outgoing_ports_max, spin_list_refresh, spin_maxhalfopen, spin_tracker_port, spin_cache_ttl,
-             spinSendBufferWatermark, spinSendBufferLowWatermark, spinSendBufferWatermarkFactor;
+             spinSendBufferWatermark, spinSendBufferLowWatermark, spinSendBufferWatermarkFactor, spinSavePathHistoryLength;
     QCheckBox cb_os_cache, cb_recheck_completed, cb_resolve_countries, cb_resolve_hosts, cb_super_seeding,
               cb_program_notifications, cb_torrent_added_notifications, cb_tracker_favicon, cb_tracker_status,
               cb_confirm_torrent_recheck, cb_confirm_remove_all_tags, cb_listen_ipv6, cb_announce_all_trackers, cbGuidedReadCache, cbMultiConnectionsPerIp,

--- a/src/gui/fspathedit.cpp
+++ b/src/gui/fspathedit.cpp
@@ -362,6 +362,16 @@ void FileSystemPathComboEdit::setCurrentIndex(int index)
     editWidget<WidgetType>()->setCurrentIndex(index);
 }
 
+int FileSystemPathComboEdit::maxVisibleItems() const
+{
+    return editWidget<WidgetType>()->maxVisibleItems();
+}
+
+void FileSystemPathComboEdit::setMaxVisibleItems(int maxItems)
+{
+    editWidget<WidgetType>()->setMaxVisibleItems(maxItems);
+}
+
 QString FileSystemPathComboEdit::editWidgetText() const
 {
     return editWidget<WidgetType>()->currentText();

--- a/src/gui/fspathedit.h
+++ b/src/gui/fspathedit.h
@@ -143,6 +143,9 @@ public:
     int currentIndex() const;
     void setCurrentIndex(int index);
 
+    int maxVisibleItems() const;
+    void setMaxVisibleItems(int maxItems);
+
 private:
     QString editWidgetText() const override;
     void setEditWidgetText(const QString &text) override;


### PR DESCRIPTION
Unlike the author of #4084, I decided to put the option into the advanced settings, because I consider the Downloads page overflooded already. Let me know if you want to change this, please.