### PR TITLE
Bugfix: Make webui really exit on error.

### DIFF
--- a/src/webui/webui.cpp
+++ b/src/webui/webui.cpp
@@ -106,7 +106,7 @@ void WebUI::init()
                 logger->addMessage(errorMsg, Log::CRITICAL);
 #ifdef DISABLE_GUI
                 qCritical() << errorMsg;
-                QCoreApplication::exit(1);
+                exit(1);
 #endif
             }
         }


### PR DESCRIPTION
Earlier someone added a patch to my PR to make the webui not only log better errors when the `listen()` call fails, but also exit.

They used `QCoreApplication::exit()`, but this doesn't actually work because when `WebUI::init()` is called we haven't entered the QT run loop yet. The `QCoreApplication::exit()` call does nothing and `qbittorrent-nox` continues on without being bound to any address.

This patch just simply changes it to use `exit()`, but maybe there is a better way to handle fatal errors during initialization?

A standard way of throwing exceptions with a try/catch block outside of the init sequence? 

I don't know QT very well, but for example if all of this connection logic could be changed to happen first thing during the run loop, then `QCoreApplication::exit()` would work well as the run loop would immediately exit with an error.