### PR TITLE
Include & print caught signal in stackdump

### DIFF
--- a/src/app/stacktrace.h
+++ b/src/app/stacktrace.h
@@ -14,7 +14,7 @@
 /** Print a demangled stack backtrace of the caller function to FILE* out. */
 static inline void print_stacktrace(FILE *out = stderr, unsigned int max_frames = 63)
 {
-    fprintf(out, "stack trace:\n");
+    fprintf(out, "Stack trace:\n");
 
     // storage array for stack trace address data
     std::vector<void *> addrlist(max_frames + 1);

--- a/src/app/stacktrace_win_dlg.h
+++ b/src/app/stacktrace_win_dlg.h
@@ -40,13 +40,13 @@ class StraceDlg : public QDialog, private Ui::errorDialog
     Q_OBJECT
 
 public:
-    StraceDlg(QWidget* parent = 0)
+    StraceDlg(QWidget *parent = nullptr)
         : QDialog(parent)
     {
         setupUi(this);
     }
 
-    void setStacktraceString(const QString& trace)
+    void setStacktraceString(const QString &sigName, const QString &trace)
     {
         // try to call Qt function as less as possible
         QString htmlStr = QString(
@@ -68,14 +68,16 @@ public:
             "Libtorrent version: %1<br/>"
             "Qt version: " QT_VERSION_STR "<br/>"
             "Boost version: %2<br/>"
-            "OS version: %3"
-            "</font></p><br/>"
-            "<pre><code>%4</code></pre>"
+            "OS version: %3<br/><br/>"
+            "Caught signal: %4"
+            "</font></p>"
+            "<pre><code>%5</code></pre>"
             "<br/><hr><br/><br/>")
-            .arg(Utils::Misc::libtorrentVersionString())
-            .arg(Utils::Misc::boostVersionString())
-            .arg(Utils::Misc::osName())
-            .arg(trace);
+                .arg(Utils::Misc::libtorrentVersionString())
+                .arg(Utils::Misc::boostVersionString())
+                .arg(Utils::Misc::osName())
+                .arg(sigName)
+                .arg(trace);
 
         errorText->setHtml(htmlStr);
     }


### PR DESCRIPTION
I noticed that signal information is often missing in reported stackdumps...

Examples:
* linux:
```
*************************************************************
Please file a bug report at http://bug.qbittorrent.org and provide the following information:

qBittorrent version: v3.4.0beta2

Caught signal: SIGABRT
Stack trace:
  /usr/lib/libc.so.6 : gsignal()+0x110  [0x7f8647f958a0]
  /usr/lib/libc.so.6 : abort()+0x1c9  [0x7f8647f96f09]
  src/qbittorrent : TorrentCreatorDlg::TorrentCreatorDlg(QWidget*, QString const&)+0x48c  [0x55b786aa66bc]
  src/qbittorrent : MainWindow::createTorrentTriggered(QString const&)+0x85  [0x55b786a31805]
```

* windows:
```
qBittorrent version: v3.4.0beta2 (64-bit)
Libtorrent version: 1.1.5.0
Qt version: 5.7.1
Boost version: 1.65.1
OS version: Windows 7 SP 1 6.1.7601 x86_64

Caught signal: SIGABRT
#  0 qbittorrent.exe      0x000000013f72790e straceWin::getBacktrace()[ app\stacktrace_win.h : 213 ]
#  1 qbittorrent.exe      0x000000013f7298dc sigAbnormalHandler(signum)[ app\main.cpp : 311 ]
#  2 qbittorrent.exe      0x000000014042c70f raise(signum)[ d:\rs1\minkernel\crts\ucrt\src\appcrt\misc\signal.cpp : 516 ]
#  3 qbittorrent.exe      0x000000013f8ae5e0 TorrentCreatorDlg::TorrentCreatorDlg(parent, defaultPath)[ gui\torrentcreatordlg.cpp : 82 ]
#  4 qbittorrent.exe      0x000000013f849bb1 MainWindow::createTorrentTriggered(path)[ gui\mainwindow.cpp : 1170 ]
#  5 qbittorrent.exe      0x000000013f84e2a3 MainWindow::on_actionCreateTorrent_triggered()[ gui\mainwindow.cpp : 1160 ]
#  6 qbittorrent.exe      0x000000013f8f2df0 MainWindow::qt_metacall(_c, _id, _a)[ release\moc_mainwindow.cpp : 475 ]
#  7 qbittorrent.exe      0x0000000140234beb QMetaObject::activate()
```
