### PR TITLE
Correctly check if torrent passed during application start already exists

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -519,15 +519,15 @@ int Application::exec(const QStringList &params)
 #endif // DISABLE_GUI
 
     m_running = true;
+
+    // Now UI is ready to process signals from Session
+    BitTorrent::Session::instance()->startUpTorrents();
+
     m_paramsQueue = params + m_paramsQueue;
     if (!m_paramsQueue.isEmpty()) {
         processParams(m_paramsQueue);
         m_paramsQueue.clear();
     }
-
-    // Now UI is ready to process signals from Session
-    BitTorrent::Session::instance()->startUpTorrents();
-
     return BaseApplication::exec();
 }
 


### PR DESCRIPTION
I discovered this randomly.

I am surprised no one noticed for so long(https://github.com/qbittorrent/qBittorrent/commit/21a72c651f4439352942bec3573f0325b99765e9).

What it fixes: If qbittorrent doesn't run and it is launched with a torrent/magnet it couldn't check if that torrent/magnet was already in the queue because we hadn't loaded the queue yet.

What it doesn't fix: Normally it should display that it was able to merge trackers. But instead it says that `Cannot add this torrent. Perhaps it is already in adding state.`. That's due to the async adding of torrents.
IMO, only way to solve this is to emit a signal when all the async torrents are dealt with and then process the new torrents/magnets. Something that I didn't have time to do.

Any thoughts on this PR?