### PR TITLE
Fix crash when aborting a torrent creation process

### DIFF
--- a/src/base/bittorrent/torrentcreatorthread.cpp
+++ b/src/base/bittorrent/torrentcreatorthread.cpp
@@ -67,7 +67,7 @@ TorrentCreatorThread::TorrentCreatorThread(QObject *parent)
 TorrentCreatorThread::~TorrentCreatorThread()
 {
     requestInterruption();
-    wait(1000);
+    wait();
 }
 
 void TorrentCreatorThread::create(const QString &inputPath, const QString &savePath, const QStringList &trackers,

--- a/src/base/bittorrent/torrentcreatorthread.cpp
+++ b/src/base/bittorrent/torrentcreatorthread.cpp
@@ -35,8 +35,8 @@
 #include <boost/bind.hpp>
 #include <libtorrent/bencode.hpp>
 #include <libtorrent/create_torrent.hpp>
-#include <libtorrent/torrent_info.hpp>
 #include <libtorrent/storage.hpp>
+#include <libtorrent/torrent_info.hpp>
 
 #include <QFile>
 
@@ -44,15 +44,18 @@
 #include "base/utils/misc.h"
 #include "base/utils/string.h"
 
+namespace
+{
+    // do not include files and folders whose
+    // name starts with a .
+    bool fileFilter(const std::string &f)
+    {
+        return !Utils::Fs::fileName(QString::fromStdString(f)).startsWith('.');
+    }
+}
+
 namespace libt = libtorrent;
 using namespace BitTorrent;
-
-// do not include files and folders whose
-// name starts with a .
-bool fileFilter(const std::string &f)
-{
-    return !Utils::Fs::fileName(QString::fromStdString(f)).startsWith('.');
-}
 
 TorrentCreatorThread::TorrentCreatorThread(QObject *parent)
     : QThread(parent)

--- a/src/gui/torrentcreatordlg.cpp
+++ b/src/gui/torrentcreatordlg.cpp
@@ -67,14 +67,14 @@ TorrentCreatorDlg::TorrentCreatorDlg(QWidget *parent, const QString &defaultPath
 
     m_ui->buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Create Torrent"));
 
-    connect(m_ui->addFileButton, SIGNAL(clicked(bool)), SLOT(onAddFileButtonClicked()));
-    connect(m_ui->addFolderButton, SIGNAL(clicked(bool)), SLOT(onAddFolderButtonClicked()));
-    connect(m_ui->buttonBox, SIGNAL(accepted()), SLOT(onCreateButtonClicked()));
-    connect(m_ui->buttonCalcTotalPieces, &QAbstractButton::clicked, this, &TorrentCreatorDlg::updatePiecesCount);
+    connect(m_ui->addFileButton, &QPushButton::clicked, this, &TorrentCreatorDlg::onAddFileButtonClicked);
+    connect(m_ui->addFolderButton, &QPushButton::clicked, this, &TorrentCreatorDlg::onAddFolderButtonClicked);
+    connect(m_ui->buttonBox, &QDialogButtonBox::accepted, this, &TorrentCreatorDlg::onCreateButtonClicked);
+    connect(m_ui->buttonCalcTotalPieces, &QPushButton::clicked, this, &TorrentCreatorDlg::updatePiecesCount);
 
-    connect(m_creatorThread, SIGNAL(creationSuccess(QString, QString)), this, SLOT(handleCreationSuccess(QString, QString)));
-    connect(m_creatorThread, SIGNAL(creationFailure(QString)), this, SLOT(handleCreationFailure(QString)));
-    connect(m_creatorThread, SIGNAL(updateProgress(int)), this, SLOT(updateProgressBar(int)));
+    connect(m_creatorThread, &BitTorrent::TorrentCreatorThread::creationSuccess, this, &TorrentCreatorDlg::handleCreationSuccess);
+    connect(m_creatorThread, &BitTorrent::TorrentCreatorThread::creationFailure, this, &TorrentCreatorDlg::handleCreationFailure);
+    connect(m_creatorThread, &BitTorrent::TorrentCreatorThread::updateProgress, this, &TorrentCreatorDlg::updateProgressBar);
 
     loadSettings();
     updateInputPath(defaultPath);

--- a/src/gui/torrentcreatordlg.cpp
+++ b/src/gui/torrentcreatordlg.cpp
@@ -86,9 +86,6 @@ TorrentCreatorDlg::~TorrentCreatorDlg()
 {
     saveSettings();
 
-    if (m_creatorThread)
-        delete m_creatorThread;
-
     delete m_ui;
 }
 


### PR DESCRIPTION
The wait time wasn't long enough causing the thread to terminate prematurely.
Also, to avoid crashing qbt entirely when creating a torrent for a very big file, I decided to wait indefinitely here.
