### PR TITLE
Fix build with --disable-webui

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -105,7 +105,9 @@ Application::Application(const QString &id, int &argc, char **argv)
     , m_running(false)
     , m_shutdownAct(ShutdownDialogAction::Exit)
     , m_commandLineArgs(parseCommandLine(this->arguments()))
+#ifndef DISABLE_WEBUI
     , m_webui(nullptr)
+#endif
 {
     qRegisterMetaType<Log::Msg>("Log::Msg");
 


### PR DESCRIPTION
"app/application.cpp:108:7: error: class 'Application' does not have
any field named 'm_webui'"