### PR TITLE
Fix crash on some systems when creating address object for 255.255.25…

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1418,8 +1418,11 @@ void Session::configure(libtorrent::settings_pack &settingsPack)
 void Session::configurePeerClasses()
 {
     libt::ip_filter f;
-    f.add_rule(libt::address_v4::from_string("0.0.0.0")
-               , libt::address_v4::from_string("255.255.255.255")
+    // address_v4::from_string("255.255.255.255") crashes on some people's systems
+    // so instead we use address_v4::broadcast()
+    // Proactively do the same for 0.0.0.0 and address_v4::any()
+    f.add_rule(libt::address_v4::any()
+               , libt::address_v4::broadcast()
                , 1 << libt::session::global_peer_class_id);
 #if TORRENT_USE_IPV6
     // IPv6 may not be available on OS and the parsing


### PR DESCRIPTION
…5.255

Closes #7735.

Do you agree with addressv4::any() usage?
Any other comments?