### PR TITLE
Webui add torrent columns to match gui

### DIFF
--- a/src/webui/btjson.cpp
+++ b/src/webui/btjson.cpp
@@ -94,6 +94,7 @@ static const char KEY_TORRENT_STATE[] = "state";
 static const char KEY_TORRENT_SEQUENTIAL_DOWNLOAD[] = "seq_dl";
 static const char KEY_TORRENT_FIRST_LAST_PIECE_PRIO[] = "f_l_piece_prio";
 static const char KEY_TORRENT_CATEGORY[] = "category";
+static const char KEY_TORRENT_TAGS[] = "tags";
 static const char KEY_TORRENT_SUPER_SEEDING[] = "super_seeding";
 static const char KEY_TORRENT_FORCE_START[] = "force_start";
 static const char KEY_TORRENT_SAVE_PATH[] = "save_path";
@@ -370,6 +371,7 @@ namespace
         if (torrent->hasMetadata())
             ret[KEY_TORRENT_FIRST_LAST_PIECE_PRIO] = torrent->hasFirstLastPiecePriority();
         ret[KEY_TORRENT_CATEGORY] = torrent->category();
+        ret[KEY_TORRENT_TAGS] = torrent->tags().toList().join(", ");
         ret[KEY_TORRENT_SUPER_SEEDING] = torrent->superSeeding();
         ret[KEY_TORRENT_FORCE_START] = torrent->isForced();
         ret[KEY_TORRENT_SAVE_PATH] = Utils::Fs::toNativePath(torrent->savePath());

--- a/src/webui/btjson.cpp
+++ b/src/webui/btjson.cpp
@@ -114,6 +114,7 @@ static const char KEY_TORRENT_LAST_SEEN_COMPLETE_TIME[] = "seen_complete";
 static const char KEY_TORRENT_LAST_ACTIVITY_TIME[] = "last_activity";
 static const char KEY_TORRENT_TOTAL_SIZE[] = "total_size";
 static const char KEY_TORRENT_AUTO_TORRENT_MANAGEMENT[] = "auto_tmm";
+static const char KEY_TORRENT_TIME_ACTIVE[] = "time_active";
 
 // Peer keys
 static const char KEY_PEER_IP[] = "ip";
@@ -389,6 +390,7 @@ namespace
         ret[KEY_TORRENT_RATIO_LIMIT] = torrent->maxRatio();
         ret[KEY_TORRENT_LAST_SEEN_COMPLETE_TIME] = torrent->lastSeenComplete().toTime_t();
         ret[KEY_TORRENT_AUTO_TORRENT_MANAGEMENT] = torrent->isAutoTMMEnabled();
+        ret[KEY_TORRENT_TIME_ACTIVE] = torrent->activeTime();
 
         if (torrent->isPaused() || torrent->isChecking())
             ret[KEY_TORRENT_LAST_ACTIVITY_TIME] = 0;

--- a/src/webui/www/public/scripts/dynamicTable.js
+++ b/src/webui/www/public/scripts/dynamicTable.js
@@ -733,6 +733,7 @@ var TorrentsTable = new Class({
             this.newColumn('state_icon', 'cursor: default', '', 22, true);
             this.newColumn('name', '', 'QBT_TR(Name)QBT_TR[CONTEXT=TorrentModel]', 200, true);
             this.newColumn('size', '', 'QBT_TR(Size)QBT_TR[CONTEXT=TorrentModel]', 100, true);
+            this.newColumn('total_size', '', 'QBT_TR(Total Size)QBT_TR[CONTEXT=TorrentModel]', 100, false);
             this.newColumn('progress', '', 'QBT_TR(Done)QBT_TR[CONTEXT=TorrentModel]', 85, true);
             this.newColumn('status', '', 'QBT_TR(Status)QBT_TR[CONTEXT=TorrentModel]', 100, true);
             this.newColumn('num_seeds', '', 'QBT_TR(Seeds)QBT_TR[CONTEXT=TorrentModel]', 100, true);
@@ -757,7 +758,6 @@ var TorrentsTable = new Class({
             this.newColumn('ratio_limit', '', 'QBT_TR(Ratio Limit)QBT_TR[CONTEXT=TorrentModel]', 100, false);
             this.newColumn('seen_complete', '', 'QBT_TR(Last Seen Complete)QBT_TR[CONTEXT=TorrentModel]', 100, false);
             this.newColumn('last_activity', '', 'QBT_TR(Last Activity)QBT_TR[CONTEXT=TorrentModel]', 100, false);
-            this.newColumn('total_size', '', 'QBT_TR(Total Size)QBT_TR[CONTEXT=TorrentModel]', 100, false);
 
             this.columns['state_icon'].onclick = '';
             this.columns['state_icon'].dataProperties[0] = 'state';

--- a/src/webui/www/public/scripts/dynamicTable.js
+++ b/src/webui/www/public/scripts/dynamicTable.js
@@ -754,6 +754,7 @@ var TorrentsTable = new Class({
             this.newColumn('downloaded_session', '', 'QBT_TR(Session Download)QBT_TR[CONTEXT=TorrentModel]', 100, false);
             this.newColumn('uploaded_session', '', 'QBT_TR(Session Upload)QBT_TR[CONTEXT=TorrentModel]', 100, false);
             this.newColumn('amount_left', '', 'QBT_TR(Remaining)QBT_TR[CONTEXT=TorrentModel]', 100, false);
+            this.newColumn('time_active', '', 'QBT_TR(Time Active)QBT_TR[CONTEXT=TorrentModel]', 100, false);
             this.newColumn('save_path', '', 'QBT_TR(Save path)QBT_TR[CONTEXT=TorrentModel]', 100, false);
             this.newColumn('completed', '', 'QBT_TR(Completed)QBT_TR[CONTEXT=TorrentModel]', 100, false);
             this.newColumn('ratio_limit', '', 'QBT_TR(Ratio Limit)QBT_TR[CONTEXT=TorrentModel]', 100, false);
@@ -1020,6 +1021,12 @@ var TorrentsTable = new Class({
                     td.set('html', '∞');
                 else
                     td.set('html', 'QBT_TR(%1 ago)QBT_TR[CONTEXT=TransferListDelegate]'.replace('%1', friendlyDuration((new Date()) / 1000 - val, true)));
+            };
+
+            // time active
+            this.columns['time_active'].updateTd = function (td, row) {
+                var time = this.getRowValue(row);
+                td.set('html', friendlyDuration(time));
             };
         },
 

--- a/src/webui/www/public/scripts/dynamicTable.js
+++ b/src/webui/www/public/scripts/dynamicTable.js
@@ -743,6 +743,7 @@ var TorrentsTable = new Class({
             this.newColumn('eta', '', 'QBT_TR(ETA)QBT_TR[CONTEXT=TorrentModel]', 100, true);
             this.newColumn('ratio', '', 'QBT_TR(Ratio)QBT_TR[CONTEXT=TorrentModel]', 100, true);
             this.newColumn('category', '', 'QBT_TR(Category)QBT_TR[CONTEXT=TorrentModel]', 100, true);
+            this.newColumn('tags', '', 'QBT_TR(Tags)QBT_TR[CONTEXT=TorrentModel]', 100, true);
             this.newColumn('added_on', '', 'QBT_TR(Added On)QBT_TR[CONTEXT=TorrentModel]', 100, true);
             this.newColumn('completion_on', '', 'QBT_TR(Completed On)QBT_TR[CONTEXT=TorrentModel]', 100, false);
             this.newColumn('tracker', '', 'QBT_TR(Tracker)QBT_TR[CONTEXT=TorrentModel]', 100, false);
@@ -960,6 +961,9 @@ var TorrentsTable = new Class({
                     html = (Math.floor(100 * ratio) / 100).toFixed(2); //Don't round up
                 td.set('html', html);
             };
+
+            // tags
+            this.columns['tags'].updateTd = this.columns['name'].updateTd;
 
             // added on
             this.columns['added_on'].updateTd = function (td, row) {


### PR DESCRIPTION
Adds the two remaining columns that are present in the GUI but missing from the WebUI:

* Add Tags columns
* Add Time Active column
* Reposition Total Size column to match GUI



<img width="500" alt="screen shot 2017-11-27 at 2 10 16 am" src="https://user-images.githubusercontent.com/8296030/33254743-49ada052-d318-11e7-8c9f-a7adeee408a2.png">
<img width="525" alt="screen shot 2017-11-27 at 2 13 37 am" src="https://user-images.githubusercontent.com/8296030/33254838-a8f36006-d318-11e7-8c49-137e9494b16b.png">
