### PR TITLE
Fix crash in #7952

### DIFF
--- a/src/gui/categoryfilterproxymodel.cpp
+++ b/src/gui/categoryfilterproxymodel.cpp
@@ -57,5 +57,5 @@ bool CategoryFilterProxyModel::lessThan(const QModelIndex &left, const QModelInd
     if (result != 0)
         return (result < 0);
 
-    return (mapFromSource(left) < mapFromSource(right));
+    return (left < right);
 }

--- a/src/gui/properties/peerlistsortmodel.h
+++ b/src/gui/properties/peerlistsortmodel.h
@@ -56,14 +56,14 @@ protected:
                 if (result != 0)
                     return (result < 0);
 
-                return (mapFromSource(left) < mapFromSource(right));
+                return (left < right);
             }
             break;
         default:
             if (left.data() != right.data())
                 return QSortFilterProxyModel::lessThan(left, right);
 
-            return (mapFromSource(left) < mapFromSource(right));
+            return (left < right);
         };
     }
 };

--- a/src/gui/search/searchsortmodel.cpp
+++ b/src/gui/search/searchsortmodel.cpp
@@ -116,14 +116,14 @@ bool SearchSortModel::lessThan(const QModelIndex &left, const QModelIndex &right
             if (result != 0)
                 return (result < 0);
 
-            return (mapFromSource(left) < mapFromSource(right));
+            return (left < right);
         }
         break;
     default:
         if (left.data() != right.data())
             return base::lessThan(left, right);
 
-        return (mapFromSource(left) < mapFromSource(right));
+        return (left < right);
     };
 }
 

--- a/src/gui/tagfilterproxymodel.cpp
+++ b/src/gui/tagfilterproxymodel.cpp
@@ -57,5 +57,5 @@ bool TagFilterProxyModel::lessThan(const QModelIndex &left, const QModelIndex &r
     if (result != 0)
         return (result < 0);
 
-    return (mapFromSource(left) < mapFromSource(right));
+    return (left < right);
 }

--- a/src/gui/transferlistsortmodel.cpp
+++ b/src/gui/transferlistsortmodel.cpp
@@ -98,7 +98,7 @@ bool TransferListSortModel::lessThan(const QModelIndex &left, const QModelIndex 
         if (result != 0)
             return (result < 0);
 
-        return (mapFromSource(left) < mapFromSource(right));
+        return (left < right);
     }
 
     case TorrentModel::TR_ADD_DATE:


### PR DESCRIPTION
mapFromSource() didn't work as expected, when used in lessThan(), it sometimes returns an invalid QModelIndex.
A crash is observed when filtering source model via filterAcceptsRow() in #7952, the crash is due to endless recursive of filterAcceptsRow() & lessThan() calling each other and mapFromSource() is the culprit of it.

This also removes the stable sort functionality.
Sorry for the inconvenience.

@sledgehammer999 
Currently the filter function in search tab is unusable. Maybe a new minor release is required.