### PR TITLE
Fix missing qbt logo on login page in webUI. Closes #7953.

### DIFF
--- a/src/base/http/types.h
+++ b/src/base/http/types.h
@@ -59,6 +59,7 @@ namespace Http
     const char CONTENT_TYPE_JSON[] = "application/json";
     const char CONTENT_TYPE_PNG[] = "image/png";
     const char CONTENT_TYPE_TXT[] = "text/plain; charset=UTF-8";
+    const char CONTENT_TYPE_SVG[] = "image/svg+xml";
 
     // portability: "\r\n" doesn't guarantee mapping to the correct value
     const char CRLF[] = {0x0D, 0x0A, '\0'};

--- a/src/webui/abstractwebapplication.cpp
+++ b/src/webui/abstractwebapplication.cpp
@@ -490,7 +490,8 @@ const QStringMap AbstractWebApplication::CONTENT_TYPE_BY_EXT = {
     { "css", Http::CONTENT_TYPE_CSS },
     { "gif", Http::CONTENT_TYPE_GIF },
     { "png", Http::CONTENT_TYPE_PNG },
-    { "js", Http::CONTENT_TYPE_JS }
+    { "js", Http::CONTENT_TYPE_JS },
+    { "svg", Http::CONTENT_TYPE_SVG }
 };
 
 QStringMap AbstractWebApplication::parseCookie(const Http::Request &request) const

--- a/src/webui/www/private/login.html
+++ b/src/webui/www/private/login.html
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" dir="ltr">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=8" />
     <title>qBittorrent QBT_TR(Web UI)QBT_TR[CONTEXT=OptionsDialog]</title>
     <link rel="stylesheet" type="text/css" href="css/style.css" />
     <script type="text/javascript" src="scripts/mootools-1.2-core-yc.js" charset="utf-8"></script>


### PR DESCRIPTION
Tested on Chrome 62, Firefox 57, IE11.