### PR TITLE
Fix application of speed limits on LAN and μTP connections.

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1481,14 +1481,10 @@ void Session::configurePeerClasses()
     peerClassTypeFilter.add(libt::peer_class_type_filter::tcp_socket, libt::session::tcp_peer_class_id);
     peerClassTypeFilter.add(libt::peer_class_type_filter::ssl_tcp_socket, libt::session::tcp_peer_class_id);
     peerClassTypeFilter.add(libt::peer_class_type_filter::i2p_socket, libt::session::tcp_peer_class_id);
-    if (isUTPRateLimited()) {
-        peerClassTypeFilter.add(libt::peer_class_type_filter::utp_socket
-            , libt::session::local_peer_class_id);
-        peerClassTypeFilter.add(libt::peer_class_type_filter::utp_socket
+    if (!isUTPRateLimited()) {
+        peerClassTypeFilter.disallow(libt::peer_class_type_filter::utp_socket
             , libt::session::global_peer_class_id);
-        peerClassTypeFilter.add(libt::peer_class_type_filter::ssl_utp_socket
-            , libt::session::local_peer_class_id);
-        peerClassTypeFilter.add(libt::peer_class_type_filter::ssl_utp_socket
+        peerClassTypeFilter.disallow(libt::peer_class_type_filter::ssl_utp_socket
             , libt::session::global_peer_class_id);
     }
     m_nativeSession->set_peer_class_type_filter(peerClassTypeFilter);


### PR DESCRIPTION
Closes #7745.

**Testing methodology**
I run the testing build in a VM and the host OS run the official 4.0.2 x64 build. The VM acted as the leecher. I created a new torrent from local files, so I won't get polluted by external peers.
For μTP, I forced the leecher to connect only through μTP.

The only problem I cannot fix is this: The μTP limiting/unlimiting takes effect only for new connections.
I'll open a bug report on libtorrent to see if this intended.

For me at least, the peer classes documentation is a bit confusing or light on details.
So in addition to looking the various code comments on the relevant headers about classes and functions used, you can also look at my small discussion with arvid on the mailing list: https://sourceforge.net/p/libtorrent/mailman/message/36134756/