### PR TITLE
Refactor ip subnet whitelist

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -487,10 +487,18 @@ QList<Utils::Net::Subnet> Preferences::getWebUiAuthSubnetWhitelist() const
     return subnets;
 }
 
-void Preferences::setWebUiAuthSubnetWhitelist(const QList<Utils::Net::Subnet> &subnets)
+void Preferences::setWebUiAuthSubnetWhitelist(const QStringList &subnets)
 {
+    QList<Utils::Net::Subnet> filteredSubnets;
+    foreach (QString subnetString, subnets) {
+        bool ok = false;
+        const Utils::Net::Subnet subnet = Utils::Net::parseSubnet(subnetString.trimmed(), &ok);
+        if (ok)
+            filteredSubnets.append(subnet);
+    }
+
     QStringList subnetsStringList;
-    for (const Utils::Net::Subnet &subnet : subnets)
+    for (const Utils::Net::Subnet &subnet : filteredSubnets)
         subnetsStringList.append(Utils::Net::subnetToString(subnet));
 
     setValue("Preferences/WebUI/AuthSubnetWhitelist", subnetsStringList);

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -35,6 +35,7 @@
 #include <QCryptographicHash>
 #include <QDir>
 #include <QLocale>
+#include <QMutableListIterator>
 #include <QPair>
 #include <QSettings>
 
@@ -487,21 +488,17 @@ QList<Utils::Net::Subnet> Preferences::getWebUiAuthSubnetWhitelist() const
     return subnets;
 }
 
-void Preferences::setWebUiAuthSubnetWhitelist(const QStringList &subnets)
+void Preferences::setWebUiAuthSubnetWhitelist(QStringList subnets)
 {
-    QList<Utils::Net::Subnet> filteredSubnets;
-    foreach (QString subnetString, subnets) {
+    QMutableListIterator<QString> i(subnets);
+    while (i.hasNext()) {
         bool ok = false;
-        const Utils::Net::Subnet subnet = Utils::Net::parseSubnet(subnetString.trimmed(), &ok);
-        if (ok)
-            filteredSubnets.append(subnet);
+        const Utils::Net::Subnet subnet = Utils::Net::parseSubnet(i.next().trimmed(), &ok);
+        if (!ok)
+            i.remove();
     }
 
-    QStringList subnetsStringList;
-    for (const Utils::Net::Subnet &subnet : filteredSubnets)
-        subnetsStringList.append(Utils::Net::subnetToString(subnet));
-
-    setValue("Preferences/WebUI/AuthSubnetWhitelist", subnetsStringList);
+    setValue("Preferences/WebUI/AuthSubnetWhitelist", subnets);
 }
 
 QString Preferences::getServerDomains() const

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -191,7 +191,7 @@ public:
     bool isWebUiAuthSubnetWhitelistEnabled() const;
     void setWebUiAuthSubnetWhitelistEnabled(bool enabled);
     QList<Utils::Net::Subnet> getWebUiAuthSubnetWhitelist() const;
-    void setWebUiAuthSubnetWhitelist(const QList<Utils::Net::Subnet> &subnets);
+    void setWebUiAuthSubnetWhitelist(const QStringList &subnets);
     QString getWebUiUsername() const;
     void setWebUiUsername(const QString &username);
     QString getWebUiPassword() const;

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -191,7 +191,7 @@ public:
     bool isWebUiAuthSubnetWhitelistEnabled() const;
     void setWebUiAuthSubnetWhitelistEnabled(bool enabled);
     QList<Utils::Net::Subnet> getWebUiAuthSubnetWhitelist() const;
-    void setWebUiAuthSubnetWhitelist(const QStringList &subnets);
+    void setWebUiAuthSubnetWhitelist(QStringList subnets);
     QString getWebUiUsername() const;
     void setWebUiUsername(const QString &username);
     QString getWebUiPassword() const;

--- a/src/gui/ipsubnetwhitelistoptionsdialog.cpp
+++ b/src/gui/ipsubnetwhitelistoptionsdialog.cpp
@@ -68,12 +68,10 @@ void IPSubnetWhitelistOptionsDialog::on_buttonBox_accepted()
 {
     if (m_modified) {
         // save to session
-        QList<Utils::Net::Subnet> subnets;
+        QStringList subnets;
         // Operate on the m_sortFilter to grab the strings in sorted order
-        for (int i = 0; i < m_sortFilter->rowCount(); ++i) {
-            const QString subnet = m_sortFilter->index(i, 0).data().toString();
-            subnets.append(QHostAddress::parseSubnet(subnet));
-        }
+        for (int i = 0; i < m_sortFilter->rowCount(); ++i)
+            subnets.append(m_sortFilter->index(i, 0).data().toString());
         Preferences::instance()->setWebUiAuthSubnetWhitelist(subnets);
         QDialog::accept();
     }

--- a/src/gui/ipsubnetwhitelistoptionsdialog.ui
+++ b/src/gui/ipsubnetwhitelistoptionsdialog.ui
@@ -25,7 +25,7 @@
      <property name="frameShadow">
       <enum>QFrame::Raised</enum>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_21">
+     <layout class="QVBoxLayout" name="verticalLayout_31">
       <item>
        <widget class="QTreeView" name="whitelistedIPSubnetList">
         <property name="rootIsDecorated">
@@ -46,7 +46,7 @@
        </widget>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_18">
+       <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QLineEdit" name="txtIPSubnet">
           <property name="placeholderText">
@@ -54,6 +54,10 @@
           </property>
          </widget>
         </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_12">
         <item>
          <widget class="QPushButton" name="buttonWhitelistIPSubnet">
           <property name="text">

--- a/src/webui/prefjson.cpp
+++ b/src/webui/prefjson.cpp
@@ -437,16 +437,8 @@ void prefjson::setPreferences(const QString& json)
     if (m.contains("bypass_auth_subnet_whitelist_enabled"))
         pref->setWebUiAuthSubnetWhitelistEnabled(m["bypass_auth_subnet_whitelist_enabled"].toBool());
     if (m.contains("bypass_auth_subnet_whitelist")) {
-        QList<Utils::Net::Subnet> subnets;
-        // recognize new line and comma as delimiters
-        foreach (QString subnetString, m["bypass_auth_subnet_whitelist"].toString().split(QRegularExpression("\n|,"), QString::SkipEmptyParts)) {
-            bool ok = false;
-            const Utils::Net::Subnet subnet = Utils::Net::parseSubnet(subnetString.trimmed(), &ok);
-            if (ok)
-                subnets.append(subnet);
-        }
-
-        pref->setWebUiAuthSubnetWhitelist(subnets);
+        // recognize new lines and commas as delimiters
+        pref->setWebUiAuthSubnetWhitelist(m["bypass_auth_subnet_whitelist"].toString().split(QRegularExpression("\n|,"), QString::SkipEmptyParts));
     }
     // Update my dynamic domain name
     if (m.contains("dyndns_enabled"))


### PR DESCRIPTION
This PR increases the size of the textbox in the ip subnet whitelist gui. It also moves subnet validation directly to `Preferences::setWebUiAuthSubnetWhitelist()` to improve core library robustness (while simplify the calling code).