### PR TITLE
Use standard folder icon for open file behavior on Windows

### DIFF
--- a/src/gui/fspathedit.cpp
+++ b/src/gui/fspathedit.cpp
@@ -154,7 +154,9 @@ void FileSystemPathEdit::FileSystemPathEditPrivate::modeChanged()
     switch (m_mode) {
     case FileSystemPathEdit::Mode::FileOpen:
     case FileSystemPathEdit::Mode::FileSave:
-        pixmap = QStyle::SP_DialogOpenButton;
+#ifdef Q_OS_WIN
+        pixmap = QStyle::SP_DirOpenIcon;
+#endif
         showDirsOnly = false;
         break;
     case FileSystemPathEdit::Mode::DirectoryOpen:


### PR DESCRIPTION
Changing the icon used for opening a dialog & locating a file.

Before:
![old](https://user-images.githubusercontent.com/9395168/33813542-6699dd6e-de5f-11e7-9916-caa46f3b4845.png)
After:
![new](https://user-images.githubusercontent.com/9395168/33813541-66717626-de5f-11e7-8216-25c03dcb8493.png)

