### PR TITLE
Fix WebUI is not reachable via IPv6

### DIFF
--- a/src/webui/abstractwebapplication.cpp
+++ b/src/webui/abstractwebapplication.cpp
@@ -86,6 +86,14 @@ struct WebSession
     }
 };
 
+namespace
+{
+    inline QUrl urlFromHostHeader(const QString &hostHeader)
+    {
+        return QUrl(QLatin1String("http://") + hostHeader);
+    }
+}
+
 // AbstractWebApplication
 
 AbstractWebApplication::AbstractWebApplication(QObject *parent)
@@ -415,7 +423,7 @@ bool AbstractWebApplication::isCrossSiteRequest(const Http::Request &request) co
 
     // sent with CORS requests, as well as with POST requests
     if (!originValue.isEmpty()) {
-        const bool isInvalid = !isSameOrigin(QUrl::fromUserInput(targetOrigin), originValue);
+        const bool isInvalid = !isSameOrigin(urlFromHostHeader(targetOrigin), originValue);
         if (isInvalid)
             Logger::instance()->addMessage(tr("WebUI: Origin header & Target origin mismatch!") + "\n"
                 + tr("Source IP: '%1'. Origin header: '%2'. Target origin: '%3'")
@@ -425,7 +433,7 @@ bool AbstractWebApplication::isCrossSiteRequest(const Http::Request &request) co
     }
 
     if (!refererValue.isEmpty()) {
-        const bool isInvalid = !isSameOrigin(QUrl::fromUserInput(targetOrigin), refererValue);
+        const bool isInvalid = !isSameOrigin(urlFromHostHeader(targetOrigin), refererValue);
         if (isInvalid)
             Logger::instance()->addMessage(tr("WebUI: Referer header & Target origin mismatch!") + "\n"
                 + tr("Source IP: '%1'. Referer header: '%2'. Target origin: '%3'")
@@ -439,7 +447,7 @@ bool AbstractWebApplication::isCrossSiteRequest(const Http::Request &request) co
 
 bool AbstractWebApplication::validateHostHeader(const QStringList &domains) const
 {
-    const QUrl hostHeader = QUrl::fromUserInput(request().headers[Http::HEADER_HOST]);
+    const QUrl hostHeader = urlFromHostHeader(request().headers[Http::HEADER_HOST]);
     const QString requestHost = hostHeader.host();
 
     // (if present) try matching host header's port with local port


### PR DESCRIPTION
For some reason `QUrl::fromUserInput()` incorrectly treat URLs like `[::1]:8080` as local files (at least on Windows).