### PR TITLE
Fix torrent file selection in Finder on mac

### DIFF
--- a/src/gui/macutilities.h
+++ b/src/gui/macutilities.h
@@ -36,5 +36,6 @@
 QPixmap pixmapForExtension(const QString &ext, const QSize &size);
 void overrideDockClickHandler(bool (*dockClickHandler)(id, SEL, ...));
 void displayNotification(const QString &title, const QString &message);
+void openFiles(const QSet<QString> &pathsList);
 
 #endif // MACUTILITIES_H

--- a/src/gui/macutilities.h
+++ b/src/gui/macutilities.h
@@ -33,9 +33,12 @@
 #include <QSize>
 #include <objc/objc.h>
 
-QPixmap pixmapForExtension(const QString &ext, const QSize &size);
-void overrideDockClickHandler(bool (*dockClickHandler)(id, SEL, ...));
-void displayNotification(const QString &title, const QString &message);
-void openFiles(const QSet<QString> &pathsList);
+namespace MacUtils
+{
+    QPixmap pixmapForExtension(const QString &ext, const QSize &size);
+    void overrideDockClickHandler(bool (*dockClickHandler)(id, SEL, ...));
+    void displayNotification(const QString &title, const QString &message);
+    void openFiles(const QSet<QString> &pathsList);
+}
 
 #endif // MACUTILITIES_H

--- a/src/gui/macutilities.mm
+++ b/src/gui/macutilities.mm
@@ -33,64 +33,67 @@
 #include <objc/message.h>
 #import <Cocoa/Cocoa.h>
 
-QPixmap pixmapForExtension(const QString &ext, const QSize &size)
+namespace MacUtils
 {
-    @autoreleasepool {
-        NSImage *image = [[NSWorkspace sharedWorkspace] iconForFileType:ext.toNSString()];
-        if (image) {
-            NSRect rect = NSMakeRect(0, 0, size.width(), size.height());
-            CGImageRef cgImage = [image CGImageForProposedRect:&rect context:nil hints:nil];
-            return QtMac::fromCGImageRef(cgImage);
+    QPixmap pixmapForExtension(const QString &ext, const QSize &size)
+    {
+        @autoreleasepool {
+            NSImage *image = [[NSWorkspace sharedWorkspace] iconForFileType:ext.toNSString()];
+            if (image) {
+                NSRect rect = NSMakeRect(0, 0, size.width(), size.height());
+                CGImageRef cgImage = [image CGImageForProposedRect:&rect context:nil hints:nil];
+                return QtMac::fromCGImageRef(cgImage);
+            }
+
+            return QPixmap();
         }
-        
-        return QPixmap();
     }
-}
 
-void overrideDockClickHandler(bool (*dockClickHandler)(id, SEL, ...))
-{
-    NSApplication *appInst = [NSApplication sharedApplication];
-    
-    if (!appInst)
-        return;
-    
-    Class delClass = [[appInst delegate] class];
-    SEL shouldHandle = sel_registerName("applicationShouldHandleReopen:hasVisibleWindows:");
-    
-    if (class_getInstanceMethod(delClass, shouldHandle)) {
-        if (class_replaceMethod(delClass, shouldHandle, (IMP)dockClickHandler, "B@:"))
-            qDebug("Registered dock click handler (replaced original method)");
-        else
-            qWarning("Failed to replace method for dock click handler");
+    void overrideDockClickHandler(bool (*dockClickHandler)(id, SEL, ...))
+    {
+        NSApplication *appInst = [NSApplication sharedApplication];
+
+        if (!appInst)
+            return;
+
+        Class delClass = [[appInst delegate] class];
+        SEL shouldHandle = sel_registerName("applicationShouldHandleReopen:hasVisibleWindows:");
+
+        if (class_getInstanceMethod(delClass, shouldHandle)) {
+            if (class_replaceMethod(delClass, shouldHandle, (IMP)dockClickHandler, "B@:"))
+                qDebug("Registered dock click handler (replaced original method)");
+            else
+                qWarning("Failed to replace method for dock click handler");
+        }
+        else {
+            if (class_addMethod(delClass, shouldHandle, (IMP)dockClickHandler, "B@:"))
+                qDebug("Registered dock click handler");
+            else
+                qWarning("Failed to register dock click handler");
+        }
     }
-    else {
-        if (class_addMethod(delClass, shouldHandle, (IMP)dockClickHandler, "B@:"))
-            qDebug("Registered dock click handler");
-        else
-            qWarning("Failed to register dock click handler");
+
+    void displayNotification(const QString &title, const QString &message)
+    {
+        @autoreleasepool {
+            NSUserNotification *notification = [[NSUserNotification alloc] init];
+            notification.title = title.toNSString();
+            notification.informativeText = message.toNSString();
+            notification.soundName = NSUserNotificationDefaultSoundName;
+
+            [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
+        }
     }
-}
 
-void displayNotification(const QString &title, const QString &message)
-{
-    @autoreleasepool {
-        NSUserNotification *notification = [[NSUserNotification alloc] init];
-        notification.title = title.toNSString();
-        notification.informativeText = message.toNSString();
-        notification.soundName = NSUserNotificationDefaultSoundName;
+    void openFiles(const QSet<QString> &pathsList)
+    {
+        @autoreleasepool {
+            NSMutableArray *pathURLs = [NSMutableArray arrayWithCapacity:pathsList.size()];
 
-        [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
-    }
-}
+            for (const auto &path : pathsList)
+                [pathURLs addObject:[NSURL fileURLWithPath:path.toNSString()]];
 
-void openFiles(const QSet<QString> &pathsList)
-{
-    @autoreleasepool {
-        NSMutableArray *pathURLs = [NSMutableArray arrayWithCapacity:pathsList.size()];
-
-        for (const auto &path : pathsList)
-            [pathURLs addObject:[NSURL fileURLWithPath:path.toNSString()]];
-
-        [[NSWorkspace sharedWorkspace] activateFileViewerSelectingURLs:pathURLs];
+            [[NSWorkspace sharedWorkspace] activateFileViewerSelectingURLs:pathURLs];
+        }
     }
 }

--- a/src/gui/macutilities.mm
+++ b/src/gui/macutilities.mm
@@ -28,6 +28,7 @@
 
 #include "macutilities.h"
 
+#include <QSet>
 #include <QtMac>
 #include <objc/message.h>
 #import <Cocoa/Cocoa.h>
@@ -79,5 +80,17 @@ void displayNotification(const QString &title, const QString &message)
         notification.soundName = NSUserNotificationDefaultSoundName;
 
         [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
+    }
+}
+
+void openFiles(const QSet<QString> &pathsList)
+{
+    @autoreleasepool {
+        NSMutableArray *pathURLs = [NSMutableArray arrayWithCapacity:pathsList.size()];
+
+        for (const auto &path : pathsList)
+            [pathURLs addObject:[NSURL fileURLWithPath:path.toNSString()]];
+
+        [[NSWorkspace sharedWorkspace] activateFileViewerSelectingURLs:pathURLs];
     }
 }

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1298,7 +1298,7 @@ static bool dockClickHandler(id self, SEL cmd, ...)
 void MainWindow::setupDockClickHandler()
 {
     dockMainWindowHandle = this;
-    overrideDockClickHandler(dockClickHandler);
+    MacUtils::overrideDockClickHandler(dockClickHandler);
 }
 
 #endif
@@ -1557,7 +1557,7 @@ void MainWindow::showNotificationBaloon(QString title, QString msg) const
     if (!reply.isError())
         return;
 #elif defined(Q_OS_MAC)
-    displayNotification(title, msg);
+    MacUtils::displayNotification(title, msg);
 #else
     if (m_systrayIcon && QSystemTrayIcon::supportsMessages())
         m_systrayIcon->showMessage(title, msg, QSystemTrayIcon::Information, TIME_TRAY_BALLOON);

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -65,6 +65,10 @@
 
 #include "ui_propertieswidget.h"
 
+#ifdef Q_OS_MAC
+#include "macutilities.h"
+#endif
+
 PropertiesWidget::PropertiesWidget(QWidget *parent, MainWindow *mainWindow, TransferListWidget *transferList)
     : QWidget(parent)
     , m_ui(new Ui::PropertiesWidget())
@@ -574,10 +578,14 @@ void PropertiesWidget::openFolder(const QModelIndex &index, bool containingFolde
 
     // Flush data
     m_torrent->flushCache();
+#ifdef Q_OS_MAC
+    MacUtils::openFiles(QSet<QString>{absolutePath});
+#else
     if (containingFolder)
         Utils::Misc::openFolderSelect(absolutePath);
     else
         Utils::Misc::openPath(absolutePath);
+#endif
 }
 
 void PropertiesWidget::displayFilesListMenu(const QPoint &)

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -150,7 +150,7 @@ namespace
     {
         QPixmap pixmapForExtension(const QString &ext) const override
         {
-            return ::pixmapForExtension(ext, QSize(32, 32));
+            return MacUtils::pixmapForExtension(ext, QSize(32, 32));
         }
     };
 #else

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -559,7 +559,7 @@ void TransferListWidget::openSelectedTorrentsFolder() const
         QString path = torrent->contentPath(true);
         pathsList.insert(path);
     }
-    openFiles(pathsList);
+    MacUtils::openFiles(pathsList);
 #else
     foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents()) {
         QString path = torrent->contentPath(true);

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -62,6 +62,10 @@
 #include "transferlistsortmodel.h"
 #include "updownratiodlg.h"
 
+#ifdef Q_OS_MAC
+#include "macutilities.h"
+#endif
+
 namespace
 {
     using ToggleFn = std::function<void (Qt::CheckState)>;
@@ -548,6 +552,15 @@ void TransferListWidget::hidePriorityColumn(bool hide)
 void TransferListWidget::openSelectedTorrentsFolder() const
 {
     QSet<QString> pathsList;
+#ifdef Q_OS_MAC
+    // On macOS you expect both the files and folders to be opened in their parent
+    // folders prehilighted for opening, so we use a custom method.
+    foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents()) {
+        QString path = torrent->contentPath(true);
+        pathsList.insert(path);
+    }
+    openFiles(pathsList);
+#else
     foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents()) {
         QString path = torrent->contentPath(true);
         if (!pathsList.contains(path)) {
@@ -558,6 +571,7 @@ void TransferListWidget::openSelectedTorrentsFolder() const
         }
         pathsList.insert(path);
     }
+#endif
 }
 
 void TransferListWidget::previewSelectedTorrents()

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -362,10 +362,14 @@ void TransferListWidget::torrentDoubleClicked()
             torrent->pause();
         break;
     case OPEN_DEST:
+#ifdef Q_OS_MAC
+        MacUtils::openFiles(QSet<QString>{torrent->contentPath(true)});
+#else
         if (torrent->filesCount() == 1)
             Utils::Misc::openFolderSelect(torrent->contentPath(true));
         else
             Utils::Misc::openPath(torrent->contentPath(true));
+#endif
         break;
     }
 }


### PR DESCRIPTION
On macOS one expects standard behaviour for all "Reveal in Finder"-like commands, thus including "Open destination folder" qBittorrent has. The idea is to open as many Finder windows as necessary selecting all the necessary files (and folders) in each.

There are several places on the internet discussing this issue (e.g. [1](https://stackoverflow.com/questions/42133029/can-qt-on-mac-open-finder-and-selecthighlight-some-files-in-the-opened-finder), [2](https://stackoverflow.com/questions/9137692/qdesktopservicesopenurl-with-selecting-specified-file-in-explorer)), and it is fairly easy to implement the desired behaviour by invoking the native API.

Please consider merging this into a relatively nearest release, since macOS 4.x is not ready yet, and it will be nice to have this feature land from the beginning.