### PR TITLE
Fix CMD+W not closing the main window

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -843,6 +843,11 @@ void MainWindow::createKeyboardShortcuts()
     m_ui->actionDelete->setShortcutContext(Qt::WidgetShortcut);  // nullify its effect: delete key event is handled by respective widgets, not here
     m_ui->actionDownloadFromURL->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_O);
     m_ui->actionExit->setShortcut(Qt::CTRL + Qt::Key_Q);
+#ifdef Q_OS_MAC
+    m_ui->actionCloseWindow->setShortcut(QKeySequence::Close);
+#else
+    m_ui->actionCloseWindow->setVisible(false);
+#endif
 
     QShortcut *switchTransferShortcut = new QShortcut(Qt::ALT + Qt::Key_1, this);
     connect(switchTransferShortcut, &QShortcut::activated, this, &MainWindow::displayTransferTab);
@@ -977,6 +982,16 @@ void MainWindow::on_actionExit_triggered()
     m_forceExit = true;
     close();
 }
+
+#ifdef Q_OS_MAC
+void MainWindow::on_actionCloseWindow_triggered()
+{
+    // On macOS window close is basically equivalent to window hide.
+    // If you decide to implement this functionality for other OS,
+    // then you will also need ui lock checks like in actionExit. 
+    close();
+}
+#endif
 
 QWidget *MainWindow::currentTabWidget() const
 {

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -187,7 +187,9 @@ private slots:
     void toolbarTextBeside();
     void toolbarTextUnder();
     void toolbarFollowSystem();
-#ifndef Q_OS_MAC
+#ifdef Q_OS_MAC
+    void on_actionCloseWindow_triggered();
+#else
     void toggleVisibility(const QSystemTrayIcon::ActivationReason reason = QSystemTrayIcon::Trigger);
     void createSystrayDelayed();
     void updateTrayIconMenu();

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -90,6 +90,7 @@
     </property>
     <addaction name="actionOpen"/>
     <addaction name="actionDownloadFromURL"/>
+    <addaction name="actionCloseWindow"/>
     <addaction name="separator"/>
     <addaction name="actionExit"/>
    </widget>
@@ -464,6 +465,11 @@
    </property>
    <property name="text">
     <string>Critical Messages</string>
+   </property>
+  </action>
+  <action name="actionCloseWindow">
+   <property name="text">
+    <string>Close Window</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
On macOS one expects CMD+W to close the window but not hide it into the Dock.
There is a relevant [Qt bug](https://bugreports.qt.io/browse/QTBUG-42242), which explains that one needs to provide a `Close Window` entry for this functionality to work.

Please consider merging this into a relatively nearest release, since macOS 4.x is not ready yet, and it will be nice to have this feature land from the beginning.