### PR TITLE
search only when category is supported by plugin

### DIFF
--- a/src/searchengine/nova/nova2.py
+++ b/src/searchengine/nova/nova2.py
@@ -128,8 +128,8 @@ def run_search(engine_list):
         engine = engine()
         #avoid exceptions due to invalid category
         if hasattr(engine, 'supported_categories'):
-            cat = cat if cat in engine.supported_categories else "all"
-            engine.search(what, cat)
+            if cat in engine.supported_categories:
+                engine.search(what, cat)
         else:
             engine.search(what)
         return True

--- a/src/searchengine/nova3/nova2.py
+++ b/src/searchengine/nova3/nova2.py
@@ -127,8 +127,8 @@ def run_search(engine_list):
         engine = engine()
         #avoid exceptions due to invalid category
         if hasattr(engine, 'supported_categories'):
-            cat = cat if cat in engine.supported_categories else "all"
-            engine.search(what, cat)
+            if cat in engine.supported_categories:
+                engine.search(what, cat)
         else:
             engine.search(what)
 


### PR DESCRIPTION
closes #8053 
this removes the clutter from plugins that do not support the selected category