### PR TITLE
Make peer information flags in peerlist more readable

### DIFF
--- a/src/base/bittorrent/peerinfo.cpp
+++ b/src/base/bittorrent/peerinfo.cpp
@@ -273,18 +273,20 @@ qreal PeerInfo::relevance() const
 
 void PeerInfo::determineFlags()
 {
+    QStringList flagsDescriptionList;
+
     if (isInteresting()) {
         // d = Your client wants to download, but peer doesn't want to send (interested and choked)
         if (isRemoteChocked()) {
             m_flags += "d ";
-            m_flagsDescription += tr("interested(local) and choked(peer)");
-            m_flagsDescription += ", ";
+            flagsDescriptionList += "d = "
+                    + tr("Interested(local) and Choked(peer)");
         }
         else {
             // D = Currently downloading (interested and not choked)
             m_flags += "D ";
-            m_flagsDescription += tr("interested(local) and unchoked(peer)");
-            m_flagsDescription += ", ";
+            flagsDescriptionList += "D = "
+                    + tr("interested(local) and unchoked(peer)");
         }
     }
 
@@ -292,97 +294,95 @@ void PeerInfo::determineFlags()
         // u = Peer wants your client to upload, but your client doesn't want to (interested and choked)
         if (isChocked()) {
             m_flags += "u ";
-            m_flagsDescription += tr("interested(peer) and choked(local)");
-            m_flagsDescription += ", ";
+            flagsDescriptionList += "u = "
+                    + tr("interested(peer) and choked(local)");
         }
         else {
             // U = Currently uploading (interested and not choked)
             m_flags += "U ";
-            m_flagsDescription += tr("interested(peer) and unchoked(local)");
-            m_flagsDescription += ", ";
+            flagsDescriptionList += "U = "
+                    + tr("interested(peer) and unchoked(local)");
         }
     }
 
     // O = Optimistic unchoke
     if (optimisticUnchoke()) {
         m_flags += "O ";
-        m_flagsDescription += tr("optimistic unchoke");
-        m_flagsDescription += ", ";
+        flagsDescriptionList += "O = "
+                + tr("optimistic unchoke");
     }
 
     // S = Peer is snubbed
     if (isSnubbed()) {
         m_flags += "S ";
-        m_flagsDescription += tr("peer snubbed");
-        m_flagsDescription += ", ";
+        flagsDescriptionList += "S = "
+                + tr("peer snubbed");
     }
 
     // I = Peer is an incoming connection
     if (!isLocalConnection()) {
         m_flags += "I ";
-        m_flagsDescription += tr("incoming connection");
-        m_flagsDescription += ", ";
+        flagsDescriptionList += "I = "
+                + tr("incoming connection");
     }
 
     // K = Peer is unchoking your client, but your client is not interested
     if (!isRemoteChocked() && !isInteresting()) {
         m_flags += "K ";
-        m_flagsDescription += tr("not interested(local) and unchoked(peer)");
-        m_flagsDescription += ", ";
+        flagsDescriptionList += "K = "
+                + tr("not interested(local) and unchoked(peer)");
     }
 
     // ? = Your client unchoked the peer but the peer is not interested
     if (!isChocked() && !isRemoteInterested()) {
         m_flags += "? ";
-        m_flagsDescription += tr("not interested(peer) and unchoked(local)");
-        m_flagsDescription += ", ";
+        flagsDescriptionList += "? = "
+                + tr("not interested(peer) and unchoked(local)");
     }
 
     // X = Peer was included in peerlists obtained through Peer Exchange (PEX)
     if (fromPeX()) {
         m_flags += "X ";
-        m_flagsDescription += tr("peer from PEX");
-        m_flagsDescription += ", ";
+        flagsDescriptionList += "X = "
+                + tr("peer from PEX");
     }
 
     // H = Peer was obtained through DHT
     if (fromDHT()) {
         m_flags += "H ";
-        m_flagsDescription += tr("peer from DHT");
-        m_flagsDescription += ", ";
+        flagsDescriptionList += "H = "
+                + tr("peer from DHT");
     }
 
     // E = Peer is using Protocol Encryption (all traffic)
     if (isRC4Encrypted()) {
         m_flags += "E ";
-        m_flagsDescription += tr("encrypted traffic");
-        m_flagsDescription += ", ";
+        flagsDescriptionList += "E = "
+                + tr("encrypted traffic");
     }
 
     // e = Peer is using Protocol Encryption (handshake)
     if (isPlaintextEncrypted()) {
         m_flags += "e ";
-        m_flagsDescription += tr("encrypted handshake");
-        m_flagsDescription += ", ";
+        flagsDescriptionList += "e = "
+                + tr("encrypted handshake");
     }
 
     // P = Peer is using uTorrent uTP
     if (useUTPSocket()) {
         m_flags += "P ";
-        m_flagsDescription += QString::fromUtf8(C_UTP);
-        m_flagsDescription += ", ";
+        flagsDescriptionList += "P = "
+                + QString::fromUtf8(C_UTP);
     }
 
     // L = Peer is local
     if (fromLSD()) {
         m_flags += "L";
-        m_flagsDescription += tr("peer from LSD");
+        flagsDescriptionList += "L = "
+                + tr("peer from LSD");
     }
-
     m_flags = m_flags.trimmed();
-    m_flagsDescription = m_flagsDescription.trimmed();
-    if (m_flagsDescription.endsWith(',', Qt::CaseInsensitive))
-        m_flagsDescription.chop(1);
+    m_flagsDescription = flagsDescriptionList.join('\n');
 }
 
 QString PeerInfo::flags() const


### PR DESCRIPTION
...by separating them with newline and adding the identifier character to the description.

![flags](https://user-images.githubusercontent.com/6451685/34102809-25008b52-e3f3-11e7-8ab1-008bdbbded92.JPG)
