### PR TITLE
Fix sorting of country flags column in Peers tab.

### DIFF
--- a/src/gui/categoryfilterproxymodel.cpp
+++ b/src/gui/categoryfilterproxymodel.cpp
@@ -54,8 +54,6 @@ bool CategoryFilterProxyModel::lessThan(const QModelIndex &left, const QModelInd
 
     int result = Utils::String::naturalCompare(left.data().toString(), right.data().toString()
         , Qt::CaseInsensitive);
-    if (result != 0)
-        return (result < 0);
 
-    return (left < right);
+    return (result < 0);
 }

--- a/src/gui/properties/peerlistsortmodel.h
+++ b/src/gui/properties/peerlistsortmodel.h
@@ -53,17 +53,11 @@ protected:
                 const QString strL = left.data().toString();
                 const QString strR = right.data().toString();
                 const int result = Utils::String::naturalCompare(strL, strR, Qt::CaseInsensitive);
-                if (result != 0)
-                    return (result < 0);
-
-                return (left < right);
-            }
+                return (result < 0);
+        }
             break;
         default:
-            if (left.data() != right.data())
-                return QSortFilterProxyModel::lessThan(left, right);
-
-            return (left < right);
+            return QSortFilterProxyModel::lessThan(left, right);
         };
     }
 };

--- a/src/gui/search/searchsortmodel.cpp
+++ b/src/gui/search/searchsortmodel.cpp
@@ -113,17 +113,11 @@ bool SearchSortModel::lessThan(const QModelIndex &left, const QModelIndex &right
             const QString strL = left.data().toString();
             const QString strR = right.data().toString();
             const int result = Utils::String::naturalCompare(strL, strR, Qt::CaseInsensitive);
-            if (result != 0)
-                return (result < 0);
-
-            return (left < right);
-        }
+            return (result < 0);
+    }
         break;
     default:
-        if (left.data() != right.data())
-            return base::lessThan(left, right);
-
-        return (left < right);
+        return base::lessThan(left, right);
     };
 }
 

--- a/src/gui/tagfilterproxymodel.cpp
+++ b/src/gui/tagfilterproxymodel.cpp
@@ -54,8 +54,5 @@ bool TagFilterProxyModel::lessThan(const QModelIndex &left, const QModelIndex &r
 
     int result = Utils::String::naturalCompare(left.data().toString(), right.data().toString()
         , Qt::CaseInsensitive);
-    if (result != 0)
-        return (result < 0);
-
-    return (left < right);
+    return (result < 0);
 }

--- a/src/gui/transferlistsortmodel.cpp
+++ b/src/gui/transferlistsortmodel.cpp
@@ -95,10 +95,7 @@ bool TransferListSortModel::lessThan(const QModelIndex &left, const QModelIndex 
             return lowerPositionThan(left, right);
 
         const int result = Utils::String::naturalCompare(vL.toString(), vR.toString(), Qt::CaseInsensitive);
-        if (result != 0)
-            return (result < 0);
-
-        return (left < right);
+        return (result < 0);
     }
 
     case TorrentModel::TR_ADD_DATE:


### PR DESCRIPTION
Mentioned in https://github.com/qbittorrent/qBittorrent/issues/8080#issuecomment-353078550

`sortRole()` is used because of https://github.com/qbittorrent/qBittorrent/blob/b8277614ecf719e5ec1f710aa1ef68407f587577/src/gui/properties/peerlistwidget.cpp#L452