### PR TITLE
Fix natural sorting

### DIFF
--- a/src/base/utils/string.cpp
+++ b/src/base/utils/string.cpp
@@ -85,7 +85,10 @@ namespace
 
                 const QChar leftChar = (m_caseSensitivity == Qt::CaseSensitive) ? left[posL] : left[posL].toLower();
                 const QChar rightChar = (m_caseSensitivity == Qt::CaseSensitive) ? right[posR] : right[posR].toLower();
-                if (leftChar == rightChar) {
+                // Compare only non-digits.
+                // Numbers should be compared as a whole
+                // otherwise the string->int conversion can yield a wrong value
+                if ((leftChar == rightChar) && !leftChar.isDigit()) {
                     // compare next character
                     ++posL;
                     ++posR;


### PR DESCRIPTION
Fix natural sorting when the common part of 2 strings ends partially in a number which continues in the uncommon part.

Closes #8080 #6732.