### PR TITLE
Use https for www.qbittorrent.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can also download it from [here](https://github.com/qbittorrent/qBittorrent/
 
 ### Misc:
 For more information please visit:
-http://www.qbittorrent.org
+https://www.qbittorrent.org
 
 or our wiki here:
 http://wiki.qbittorrent.org

--- a/configure
+++ b/configure
@@ -583,7 +583,7 @@ PACKAGE_TARNAME='qbittorrent'
 PACKAGE_VERSION='v3.2.0alpha'
 PACKAGE_STRING='qbittorrent v3.2.0alpha'
 PACKAGE_BUGREPORT='bugs.qbittorrent.org'
-PACKAGE_URL='http://www.qbittorrent.org/'
+PACKAGE_URL='https://www.qbittorrent.org/'
 
 ac_subst_vars='am__EXEEXT_FALSE
 am__EXEEXT_TRUE
@@ -1426,7 +1426,7 @@ Use these variables to override the choices made by `configure' or to help
 it to find libraries and programs with nonstandard names/locations.
 
 Report bugs to <bugs.qbittorrent.org>.
-qbittorrent home page: <http://www.qbittorrent.org/>.
+qbittorrent home page: <https://www.qbittorrent.org/>.
 _ACEOF
 ac_status=$?
 fi
@@ -6139,7 +6139,7 @@ Configuration commands:
 $config_commands
 
 Report bugs to <bugs.qbittorrent.org>.
-qbittorrent home page: <http://www.qbittorrent.org/>."
+qbittorrent home page: <https://www.qbittorrent.org/>."
 
 _ACEOF
 cat >>$CONFIG_STATUS <<_ACEOF || ac_write_fail=1
@@ -7454,7 +7454,7 @@ Configuration commands:
 $config_commands
 
 Report bugs to <bugs.qbittorrent.org>.
-qbittorrent home page: <http://www.qbittorrent.org/>."
+qbittorrent home page: <https://www.qbittorrent.org/>."
 
 _ACEOF
 cat >>$CONFIG_STATUS <<_ACEOF || ac_write_fail=1

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([qbittorrent], [v3.2.0alpha], [bugs.qbittorrent.org], [], [http://www.qbittorrent.org/])
+AC_INIT([qbittorrent], [v3.2.0alpha], [bugs.qbittorrent.org], [], [https://www.qbittorrent.org/])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CC

--- a/dist/unix/qbittorrent.appdata.xml
+++ b/dist/unix/qbittorrent.appdata.xml
@@ -56,7 +56,7 @@
    </image>
     </screenshot>
   </screenshots>
-  <url type="homepage">http://www.qbittorrent.org/</url>
+  <url type="homepage">https://www.qbittorrent.org/</url>
   <update_contact>sledgehammer999@qbittorrent.org</update_contact>
   <developer_name>The qBittorrent Project</developer_name>
   <url type="bugtracker">http://bugs.qbittorrent.org/</url>

--- a/dist/windows/installer.nsi
+++ b/dist/windows/installer.nsi
@@ -86,7 +86,7 @@ Section $(inst_qbt_req) ;"qBittorrent (required)"
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qBittorrent" "UninstallString" '"$INSTDIR\uninst.exe"'
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qBittorrent" "DisplayIcon" '"$INSTDIR\qbittorrent.exe",0'
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qBittorrent" "Publisher" "The qBittorrent project"
-  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qBittorrent" "URLInfoAbout" "http://www.qbittorrent.org"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qBittorrent" "URLInfoAbout" "https://www.qbittorrent.org"
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qBittorrent" "DisplayVersion" "${PROG_VERSION}"
   WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qBittorrent" "NoModify" 1
   WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\qBittorrent" "NoRepair" 1

--- a/src/gui/about_imp.h
+++ b/src/gui/about_imp.h
@@ -59,7 +59,7 @@ public:
             "%1\n\n"
             "%2\n\n"
             "<table>"
-            "<tr><td>%3</td><td><a href=\"http://www.qbittorrent.org\">http://www.qbittorrent.org</a></td></tr>"
+            "<tr><td>%3</td><td><a href=\"https://www.qbittorrent.org\">https://www.qbittorrent.org</a></td></tr>"
             "<tr><td>%4</td><td><a href=\"http://forum.qbittorrent.org\">http://forum.qbittorrent.org</a></td></tr>"
             "<tr><td>%5</td><td><a href=\"http://bugs.qbittorrent.org\">http://bugs.qbittorrent.org</a></td></tr>"
             "</table>"

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -988,7 +988,7 @@ void MainWindow::on_actionCloseWindow_triggered()
 {
     // On macOS window close is basically equivalent to window hide.
     // If you decide to implement this functionality for other OS,
-    // then you will also need ui lock checks like in actionExit. 
+    // then you will also need ui lock checks like in actionExit.
     close();
 }
 #endif
@@ -1854,7 +1854,7 @@ void MainWindow::toggleAlternativeSpeeds()
 
 void MainWindow::on_actionDonateMoney_triggered()
 {
-    QDesktopServices::openUrl(QUrl("http://www.qbittorrent.org/donate"));
+    QDesktopServices::openUrl(QUrl("https://www.qbittorrent.org/donate"));
 }
 
 void MainWindow::showConnectionSettings()

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -77,7 +77,7 @@
                         <a class="returnFalse">QBT_TR(&Help)QBT_TR[CONTEXT=MainWindow]</a>
                         <ul>
                             <li><a id="docsLink" target="_blank" href="http://wiki.qbittorrent.org/"><img class="MyMenuIcon" src="theme/help-contents" alt="QBT_TR(&Documentation)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" onload="fixPNG(this)"/>QBT_TR(&Documentation)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li class="divider"><a id="bugLink" target="_blank" href="http://www.qbittorrent.org/donate"><img class="MyMenuIcon" src="theme/wallet-open" alt="QBT_TR(Do&nate!)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" onload="fixPNG(this)"/>QBT_TR(Do&nate!)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li class="divider"><a id="bugLink" target="_blank" href="https://www.qbittorrent.org/donate"><img class="MyMenuIcon" src="theme/wallet-open" alt="QBT_TR(Do&nate!)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" onload="fixPNG(this)"/>QBT_TR(Do&nate!)QBT_TR[CONTEXT=MainWindow]</a></li>
                             <li><a id="aboutLink"><img class="MyMenuIcon" src="theme/help-about" alt="QBT_TR(&About)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" onload="fixPNG(this)"/>QBT_TR(&About)QBT_TR[CONTEXT=MainWindow]</a></li>
                         </ul>
                     </li>

--- a/src/webui/www/public/about.html
+++ b/src/webui/www/public/about.html
@@ -2,7 +2,7 @@
 <h3>qBittorrent ${VERSION} QBT_TR(Web UI)QBT_TR[CONTEXT=OptionsDialog]</h3>
 <p>QBT_TR(An advanced BitTorrent client programmed in C++, based on Qt toolkit and libtorrent-rasterbar.)QBT_TR[CONTEXT=about]</p>
 <p>Copyright (c) 2011-2017 The qBittorrent project</p>
-<p>QBT_TR(Home Page:)QBT_TR[CONTEXT=about] <a target="_blank" href="http://www.qbittorrent.org"> http://www.qbittorrent.org</a></p>
+<p>QBT_TR(Home Page:)QBT_TR[CONTEXT=about] <a target="_blank" href="https://www.qbittorrent.org"> https://www.qbittorrent.org</a></p>
 <p>QBT_TR(Bug Tracker:)QBT_TR[CONTEXT=about] <a target="_blank" href="http://bugs.qbittorrent.org"> http://bugs.qbittorrent.org</a></p>
 <p>QBT_TR(Forum:)QBT_TR[CONTEXT=about] <a target="_blank" href="http://forum.qbittorrent.org"> http://forum.qbittorrent.org</a></p>
 <p>QBT_TR(IRC: #qbittorrent on Freenode)QBT_TR[CONTEXT=HttpServer]</p>


### PR DESCRIPTION
www.qbittorrent.org has implemented HSTS (strict-transport-security) for the www subdomain. This PR changes all links to use https for www.qbittorrent.org.

<img width="439" alt="screen shot 2017-12-26 at 6 23 41 pm" src="https://user-images.githubusercontent.com/8296030/34366479-266eecae-ea6a-11e7-8ca9-4750871a174f.png">

