### PR TITLE
WebUI Statistics parity with GUI

### DIFF
--- a/src/webui/www/public/css/style.css
+++ b/src/webui/www/public/css/style.css
@@ -479,3 +479,8 @@ td.statusBarSeparator {
     background-position: center 1px;
     background-size: 2px 18px;
 }
+
+/* Statistics */
+.statisticsValue {
+    text-align: right;
+}

--- a/src/webui/www/public/scripts/client.js
+++ b/src/webui/www/public/scripts/client.js
@@ -388,10 +388,10 @@ window.addEvent('load', function () {
             $('TotalPeerConnections').set('html', serverState.total_peer_connections);
             $('ReadCacheHits').set('html', serverState.read_cache_hits);
             $('TotalBuffersSize').set('html', friendlyUnit(serverState.total_buffers_size, false));
-            $('WriteCacheOverload').set('html', serverState.write_cache_overload);
-            $('ReadCacheOverload').set('html', serverState.read_cache_overload);
+            $('WriteCacheOverload').set('html', serverState.write_cache_overload + "%");
+            $('ReadCacheOverload').set('html', serverState.read_cache_overload + "%");
             $('QueuedIOJobs').set('html', serverState.queued_io_jobs);
-            $('AverageTimeInQueue').set('html', serverState.average_time_queue);
+            $('AverageTimeInQueue').set('html', serverState.average_time_queue + " ms");
             $('TotalQueuedSize').set('html', friendlyUnit(serverState.total_queued_size, false));
         }
 

--- a/src/webui/www/public/scripts/client.js
+++ b/src/webui/www/public/scripts/client.js
@@ -381,18 +381,18 @@ window.addEvent('load', function () {
 
         // Statistics dialog
         if (document.getElementById("statisticspage")) {
-            $('AlltimeDL').set('html', 'QBT_TR(Alltime download:)QBT_TR[CONTEXT=StatsDialog]' + " " + friendlyUnit(serverState.alltime_dl, false));
-            $('AlltimeUL').set('html', 'QBT_TR(Alltime upload:)QBT_TR[CONTEXT=StatsDialog]' + " " + friendlyUnit(serverState.alltime_ul, false));
-            $('TotalWastedSession').set('html', 'QBT_TR(Total wasted (this session):)QBT_TR[CONTEXT=StatsDialog]' + " " + friendlyUnit(serverState.total_wasted_session, false));
-            $('GlobalRatio').set('html', 'QBT_TR(Global ratio:)QBT_TR[CONTEXT=StatsDialog]' + " " + serverState.global_ratio);
-            $('TotalPeerConnections').set('html', 'QBT_TR(Total peer connections:)QBT_TR[CONTEXT=StatsDialog]' + " " + serverState.total_peer_connections);
-            $('ReadCacheHits').set('html', 'QBT_TR(Read cache hits:)QBT_TR[CONTEXT=StatsDialog]' + " " + serverState.read_cache_hits);
-            $('TotalBuffersSize').set('html', 'QBT_TR(Total buffers size:)QBT_TR[CONTEXT=StatsDialog]' + " " + friendlyUnit(serverState.total_buffers_size, false));
-            $('WriteCacheOverload').set('html', 'QBT_TR(Write cache overload:)QBT_TR[CONTEXT=StatsDialog]' + " " + serverState.write_cache_overload);
-            $('ReadCacheOverload').set('html', 'QBT_TR(Read cache overload:)QBT_TR[CONTEXT=StatsDialog]' + " " + serverState.read_cache_overload);
-            $('QueuedIOJobs').set('html', 'QBT_TR(Queued I/O jobs:)QBT_TR[CONTEXT=StatsDialog]' + " " + serverState.queued_io_jobs);
-            $('AverageTimeInQueue').set('html', 'QBT_TR(Average time in queue:)QBT_TR[CONTEXT=StatsDialog]' + " " + serverState.average_time_queue);
-            $('TotalQueuedSize').set('html', 'QBT_TR(Total queued size:)QBT_TR[CONTEXT=StatsDialog]' + " " + friendlyUnit(serverState.total_queued_size, false));
+            $('AlltimeDL').set('html', friendlyUnit(serverState.alltime_dl, false));
+            $('AlltimeUL').set('html', friendlyUnit(serverState.alltime_ul, false));
+            $('TotalWastedSession').set('html', friendlyUnit(serverState.total_wasted_session, false));
+            $('GlobalRatio').set('html', serverState.global_ratio);
+            $('TotalPeerConnections').set('html', serverState.total_peer_connections);
+            $('ReadCacheHits').set('html', serverState.read_cache_hits);
+            $('TotalBuffersSize').set('html', friendlyUnit(serverState.total_buffers_size, false));
+            $('WriteCacheOverload').set('html', serverState.write_cache_overload);
+            $('ReadCacheOverload').set('html', serverState.read_cache_overload);
+            $('QueuedIOJobs').set('html', serverState.queued_io_jobs);
+            $('AverageTimeInQueue').set('html', serverState.average_time_queue);
+            $('TotalQueuedSize').set('html', friendlyUnit(serverState.total_queued_size, false));
         }
 
         if (serverState.connection_status == "connected")

--- a/src/webui/www/public/statistics.html
+++ b/src/webui/www/public/statistics.html
@@ -1,47 +1,59 @@
 <h3>QBT_TR(User statistics)QBT_TR[CONTEXT=StatsDialog]</h3>
 <table style="width:100%">
     <tr>
-        <td id="AlltimeDL"></td>
+        <td>QBT_TR(Alltime download:)QBT_TR[CONTEXT=StatsDialog]</td>
+        <td id="AlltimeDL" class="statisticsValue"></td>
     </tr>
     <tr>
-        <td id="AlltimeUL"></td>
+        <td>QBT_TR(Alltime upload:)QBT_TR[CONTEXT=StatsDialog]</td>
+        <td id="AlltimeUL" class="statisticsValue"></td>
     </tr>
     <tr>
-        <td id="TotalWastedSession"></td>
+        <td>QBT_TR(Total wasted (this session):)QBT_TR[CONTEXT=StatsDialog]</td>
+        <td id="TotalWastedSession" class="statisticsValue"></td>
     </tr>
     <tr>
-        <td id="GlobalRatio"></td>
+        <td>QBT_TR(Global ratio:)QBT_TR[CONTEXT=StatsDialog]</td>
+        <td id="GlobalRatio" class="statisticsValue"></td>
     </tr>
     <tr>
-        <td id="TotalPeerConnections"></td>
+        <td>QBT_TR(Total peer connections:)QBT_TR[CONTEXT=StatsDialog]</td>
+        <td id="TotalPeerConnections" class="statisticsValue"></td>
     </tr>
 </table>
 
 <h3>QBT_TR(Cache statistics)QBT_TR[CONTEXT=StatsDialog]</h3>
 <table style="width:100%">
     <tr>
-        <td id="ReadCacheHits"></td>
+        <td>QBT_TR(Read cache hits:)QBT_TR[CONTEXT=StatsDialog]</td>
+        <td id="ReadCacheHits" class="statisticsValue"></td>
     </tr>
     <tr>
-        <td id="TotalBuffersSize"></td>
+        <td>QBT_TR(Total buffers size:)QBT_TR[CONTEXT=StatsDialog]</td>
+        <td id="TotalBuffersSize" class="statisticsValue"></td>
     </tr>
 </table>
 
 <h3>QBT_TR(Performance statistics)QBT_TR[CONTEXT=StatsDialog]</h3>
 <table style="width:100%">
     <tr>
-        <td id="WriteCacheOverload"></td>
+        <td>QBT_TR(Write cache overload:)QBT_TR[CONTEXT=StatsDialog]</td>
+        <td id="WriteCacheOverload" class="statisticsValue"></td>
     </tr>
     <tr>
-        <td id="ReadCacheOverload"></td>
+        <td>QBT_TR(Read cache overload:)QBT_TR[CONTEXT=StatsDialog]</td>
+        <td id="ReadCacheOverload" class="statisticsValue"></td>
     </tr>
     <tr>
-        <td id="QueuedIOJobs"></td>
+        <td>QBT_TR(Queued I/O jobs:)QBT_TR[CONTEXT=StatsDialog]</td>
+        <td id="QueuedIOJobs" class="statisticsValue"></td>
     </tr>
     <tr>
-        <td id="AverageTimeInQueue"></td>
+        <td>QBT_TR(Average time in queue:)QBT_TR[CONTEXT=StatsDialog]</td>
+        <td id="AverageTimeInQueue" class="statisticsValue"></td>
     </tr>
-        <tr>
-        <td id="TotalQueuedSize"></td>
+    <tr>
+        <td>QBT_TR(Total queued size:)QBT_TR[CONTEXT=StatsDialog]</td>
+        <td id="TotalQueuedSize" class="statisticsValue"></td>
     </tr>
 </table>


### PR DESCRIPTION
This PR right-aligns stat values while also adding missing units for _Write/Read cache overload_ and _Average time in queue_.

Old WebUI:
<img width="289" alt="screen shot 2017-12-26 at 7 09 08 pm" src="https://user-images.githubusercontent.com/8296030/34366904-8efc696c-ea70-11e7-863b-81da4280a6d7.png">

New WebUI:
<img width="289" alt="screen shot 2017-12-26 at 7 10 03 pm" src="https://user-images.githubusercontent.com/8296030/34366908-946e44ec-ea70-11e7-8044-7571aeb1fd9d.png">

GUI:
<img width="307" alt="screen shot 2017-12-26 at 7 09 34 pm" src="https://user-images.githubusercontent.com/8296030/34366911-9a31aef0-ea70-11e7-922a-f803f41568bc.png">
