### PR TITLE
Add option to show/hide webui status bar

### DIFF
--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -62,8 +62,9 @@
                         <a class="returnFalse">QBT_TR(&View)QBT_TR[CONTEXT=MainWindow]</a>
                         <ul>
                         <li><a id="showTopToolbarLink"><img class="MyMenuIcon" src="theme/checked" alt="QBT_TR(&Top Toolbar)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" onload="fixPNG(this)"/>QBT_TR(&Top Toolbar)QBT_TR[CONTEXT=MainWindow]</a></li>
+                        <li><a id="showStatusBarLink"><img class="MyMenuIcon" src="theme/checked" alt="QBT_TR(&Status Bar)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" onload="fixPNG(this)"/>QBT_TR(&Status Bar)QBT_TR[CONTEXT=MainWindow]</a></li>
                         <li><a id="speedInBrowserTitleBarLink"><img class="MyMenuIcon" src="theme/checked" alt="QBT_TR(S&peed in Title Bar)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" onload="fixPNG(this)"/>QBT_TR(S&peed in Title Bar)QBT_TR[CONTEXT=MainWindow]</a></li>
-                        <li><a id=StatisticsLink ><img class="MyMenuIcon" src="theme/view-statistics" alt="QBT_TR(&Statistics)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" onload="fixPNG(this)"/>QBT_TR(&Statistics)QBT_TR[CONTEXT=MainWindow]</a></li>
+                        <li class="divider"><a id=StatisticsLink ><img class="MyMenuIcon" src="theme/view-statistics" alt="QBT_TR(&Statistics)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" onload="fixPNG(this)"/>QBT_TR(&Statistics)QBT_TR[CONTEXT=MainWindow]</a></li>
                         </ul>
                     </li>
                     <li>

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -161,11 +161,20 @@ window.addEvent('load', function () {
         $('mochaToolbar').addClass('invisible');
     }
 
+    // Show Status Bar is enabled by default
+    var showStatusBar = true;
+    if (localStorage.getItem('show_status_bar') !== null)
+        showStatusBar = localStorage.getItem('show_status_bar') === "true";
+    if (!showStatusBar) {
+        $('showStatusBarLink').firstChild.style.opacity = '0';
+        $('desktopFooterWrapper').addClass('invisible');
+    }
+
     var speedInTitle = localStorage.getItem('speed_in_browser_title_bar') == "true";
     if (!speedInTitle)
         $('speedInBrowserTitleBarLink').firstChild.style.opacity = '0';
 
-    // After Show Top Toolbar
+    // After showing/hiding the toolbar + status bar
     MochaUI.Desktop.setDesktopSize();
 
     var syncMainDataLastResponseId = 0;
@@ -471,6 +480,20 @@ window.addEvent('load', function () {
         else {
             $('showTopToolbarLink').firstChild.style.opacity = '0';
             $('mochaToolbar').addClass('invisible');
+        }
+        MochaUI.Desktop.setDesktopSize();
+    });
+
+    $('showStatusBarLink').addEvent('click', function(e) {
+        showStatusBar = !showStatusBar;
+        localStorage.setItem('show_status_bar', showStatusBar.toString());
+        if (showStatusBar) {
+            $('showStatusBarLink').firstChild.style.opacity = '1';
+            $('desktopFooterWrapper').removeClass('invisible');
+        }
+        else {
+            $('showStatusBarLink').firstChild.style.opacity = '0';
+            $('desktopFooterWrapper').addClass('invisible');
         }
         MochaUI.Desktop.setDesktopSize();
     });


### PR DESCRIPTION
This feature matches the functionality of the GUI. I've also added a divider between _Speed in Title Bar_ and _Statistics_ to more closely match the GUI.

Old WebUI:
<img width="164" alt="screen shot 2017-12-26 at 7 29 50 pm" src="https://user-images.githubusercontent.com/8296030/34367039-34c977fc-ea73-11e7-8ba7-8399daac9195.png">

New WebUI:
<img width="171" alt="screen shot 2017-12-26 at 7 25 31 pm" src="https://user-images.githubusercontent.com/8296030/34367026-f98dced6-ea72-11e7-8933-fb0248db6e96.png">

GUI:
<img width="342" alt="screen shot 2017-12-26 at 7 25 48 pm" src="https://user-images.githubusercontent.com/8296030/34367031-fd3dde22-ea72-11e7-95aa-c73ecb834825.png">
