### PR TITLE
Don't process new/updated RSS rules when disabled

### DIFF
--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -424,6 +424,8 @@ bool AutoDownloader::isProcessingEnabled() const
 void AutoDownloader::resetProcessingQueue()
 {
     m_processingQueue.clear();
+    if (!m_processingEnabled) return;
+
     foreach (Article *article, Session::instance()->rootFolder()->articles()) {
         if (!article->isRead() && !article->torrentUrl().isEmpty())
             addJobForArticle(article);


### PR DESCRIPTION
Don't process new/updated RSS auto downloading rules when AutoDownloader is disabled.