### PR TITLE
Add IPv4 wildcard pattern matching for the listening IP addresses

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -330,6 +330,7 @@ Session::Session(QObject *parent)
     , m_networkInterface(BITTORRENT_SESSION_KEY("Interface"))
     , m_networkInterfaceName(BITTORRENT_SESSION_KEY("InterfaceName"))
     , m_networkInterfaceAddress(BITTORRENT_SESSION_KEY("InterfaceAddress"))
+    , m_bindAddressPattern(BITTORRENT_SESSION_KEY("BindAddressPattern"))
     , m_isIPv6Enabled(BITTORRENT_SESSION_KEY("IPv6Enabled"), false)
     , m_encryption(BITTORRENT_SESSION_KEY("Encryption"), 0)
     , m_isForceProxyEnabled(BITTORRENT_SESSION_KEY("ForceProxy"), true)
@@ -2735,6 +2736,19 @@ void Session::setNetworkInterfaceAddress(const QString &address)
 {
     if (address != networkInterfaceAddress()) {
         m_networkInterfaceAddress = address;
+        configureListeningInterface();
+    }
+}
+
+QString Session::bindAddressPattern() const
+{
+    return m_bindAddressPattern;
+}
+
+void Session::setBindAddressPattern(const QString &pattern)
+{
+    if (pattern != bindAddressPattern()) {
+        m_bindAddressPattern = pattern;
         configureListeningInterface();
     }
 }

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -581,6 +581,7 @@ namespace BitTorrent
         void applyBandwidthLimits();
         void processBannedIPs(libtorrent::ip_filter &filter);
         const QStringList getListeningIPs();
+        static bool addressPatternMatches(const QString &address, const QString &pattern);
         void configureListeningInterface();
         void enableTracker(bool enable);
         void enableBandwidthScheduler();

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -350,6 +350,8 @@ namespace BitTorrent
         void setNetworkInterfaceName(const QString &name);
         QString networkInterfaceAddress() const;
         void setNetworkInterfaceAddress(const QString &address);
+        QString bindAddressPattern() const;
+        void setBindAddressPattern(const QString &pattern);
         bool isIPv6Enabled() const;
         void setIPv6Enabled(bool enabled);
         int encryption() const;
@@ -694,6 +696,7 @@ namespace BitTorrent
         CachedSettingValue<QString> m_networkInterface;
         CachedSettingValue<QString> m_networkInterfaceName;
         CachedSettingValue<QString> m_networkInterfaceAddress;
+        CachedSettingValue<QString> m_bindAddressPattern;
         CachedSettingValue<bool> m_isIPv6Enabled;
         CachedSettingValue<int> m_encryption;
         CachedSettingValue<bool> m_isForceProxyEnabled;

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -54,6 +54,7 @@ enum AdvSettingsRows
     NETWORK_IFACE,
     //Optional network address
     NETWORK_IFACE_ADDRESS,
+    NETWORK_IFACE_ADDRESS_PATTERN,
     NETWORK_LISTEN_IPV6,
     // behavior
     SAVE_RESUME_DATA_INTERVAL,
@@ -188,6 +189,9 @@ void AdvancedSettings::saveAdvancedSettings()
         QHostAddress ifaceAddr(combo_iface_address.currentText().trimmed());
         ifaceAddr.isNull() ? session->setNetworkInterfaceAddress(QString::null) : session->setNetworkInterfaceAddress(ifaceAddr.toString());
     }
+
+    session->setBindAddressPattern(txtBindIPPattern.text().trimmed());
+
     session->setIPv6Enabled(cb_listen_ipv6.isChecked());
     // Announce IP
     QHostAddress addr(txtAnnounceIP.text().trimmed());
@@ -406,6 +410,12 @@ void AdvancedSettings::loadAdvancedSettings()
     // Network interface address
     updateInterfaceAddressCombo();
     addRow(NETWORK_IFACE_ADDRESS, tr("Optional IP Address to bind to (requires restart)"), &combo_iface_address);
+
+    addRow(NETWORK_IFACE_ADDRESS_PATTERN,
+           tr("Optional pattern of the IPv4 Address (e.g. '10.*.*.*') to bind to (requires restart)"),
+           &txtBindIPPattern);
+    txtBindIPPattern.setText(session->bindAddressPattern());
+
     // Listen on IPv6 address
     cb_listen_ipv6.setChecked(session->isIPv6Enabled());
     addRow(NETWORK_LISTEN_IPV6, tr("Listen on IPv6 address (requires restart)"), &cb_listen_ipv6);

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -82,7 +82,7 @@ private:
               cb_confirm_torrent_recheck, cb_confirm_remove_all_tags, cb_listen_ipv6, cb_announce_all_trackers, cb_announce_all_tiers,
               cbGuidedReadCache, cbMultiConnectionsPerIp, cbSuggestMode;
     QComboBox combo_iface, combo_iface_address, comboUtpMixedMode, comboChokingAlgorithm, comboSeedChokingAlgorithm;
-    QLineEdit txtAnnounceIP;
+    QLineEdit txtAnnounceIP, txtBindIPPattern;
 
     // OS dependent settings
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)


### PR DESCRIPTION
On some systems, names of the network interfaces can change over time (when installing/uninstalling adapters), so the private and the public interface might be swapped with each other. This adds the optional and simple IPv4 wildcard pattern matching to make sure qBitTorrent doesn't listen outside on the IP addresses that doesn't match the pattern.