### PR TITLE
Fix constant status of '[F] Downloading'. Closes #7628.

### DIFF
--- a/src/gui/torrentmodel.cpp
+++ b/src/gui/torrentmodel.cpp
@@ -184,7 +184,7 @@ QVariant TorrentModel::data(const QModelIndex &index, int role) const
     case TR_PROGRESS:
         return torrent->progress();
     case TR_STATUS:
-        return static_cast<int>(torrent->state());
+        return QVariant::fromValue(torrent->state());
     case TR_SEEDS:
         return (role == Qt::DisplayRole) ? torrent->seedsCount() : torrent->totalSeedsCount();
     case TR_PEERS:

--- a/src/gui/transferlistsortmodel.cpp
+++ b/src/gui/transferlistsortmodel.cpp
@@ -98,6 +98,20 @@ bool TransferListSortModel::lessThan(const QModelIndex &left, const QModelIndex 
         return (result < 0);
     }
 
+    case TorrentModel::TR_STATUS: {
+        // QSortFilterProxyModel::lessThan() uses the < operator only for specific QVariant types
+        // so our custom type is outside that list.
+        // In this case QSortFilterProxyModel::lessThan() converts other types to QString and
+        // sorts them.
+        // Thus we can't use the code in the default label.
+        const BitTorrent::TorrentState leftValue = left.data().value<BitTorrent::TorrentState>();
+        const BitTorrent::TorrentState rightValue = right.data().value<BitTorrent::TorrentState>();
+        if (leftValue != rightValue)
+            return leftValue < rightValue;
+
+        return lowerPositionThan(left, right);
+    }
+
     case TorrentModel::TR_ADD_DATE:
     case TorrentModel::TR_SEED_DATE:
     case TorrentModel::TR_SEEN_COMPLETE_DATE: {


### PR DESCRIPTION
This issue is reproducible under Ubuntu Xenial, that's why we haven't already caught this.
I am not sure if it is caused by the Qt version (5.5.1) or the gcc version(5.3.1).

I somehow believe that the Xenial environment is more strict and more "correct". Let me explain briefly the situation:

1. The `enum class BitTorrent::TorrentState` is declared as `Q_DECLARE_METATYPE(BitTorrent::TorrentState)` too. This allows to use it inside a `QVariant`
2. In `TorrentModel::data()` for the `TR_STATUS` column we first converted the `TorrentState` to `int` and then we returned the **int** as a `QVariant`
3.  In `TransferListDelegate::paint()` for the `TR_STATUS` column we tell the QVariant to convert the underlying `int` type to an `enum class` named `BitTorrent::TorrentState`. This fails and returns `0`, which is the value assigned for `TorrentState::ForcedDownloading`, thus constantly printing the same status regardless of the actual torrent state.

So now I made it pass around a QVariant with underlying type of `BitTorrent::TorrentState`.
I would register the [comparators](https://doc.qt.io/qt-5/qmetatype.html#registerComparators) for QVariant, but [QSortFilterProxyModel::lessThan()](https://doc.qt.io/qt-5/qsortfilterproxymodel.html#lessThan) behaves differently.

PS: Thank god, Qt is so well documented. Otherwise, I wouldn't have figured out why the sorting fails miserably.