### PR TITLE
transferlist: added a force reannounce option

### DIFF
--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -683,6 +683,12 @@ void TransferListWidget::recheckSelectedTorrents()
         torrent->forceRecheck();
 }
 
+void TransferListWidget::reannounceSelectedTorrents()
+{
+    foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents())
+        torrent->forceReannounce();
+}
+
 // hide/show columns menu
 void TransferListWidget::displayDLHoSMenu(const QPoint&)
 {
@@ -881,6 +887,8 @@ void TransferListWidget::displayListMenu(const QPoint&)
     connect(&actionSetTorrentPath, SIGNAL(triggered()), this, SLOT(setSelectedTorrentsLocation()));
     QAction actionForce_recheck(GuiIconProvider::instance()->getIcon("document-edit-verify"), tr("Force recheck"), 0);
     connect(&actionForce_recheck, SIGNAL(triggered()), this, SLOT(recheckSelectedTorrents()));
+    QAction actionForce_reannounce(GuiIconProvider::instance()->getIcon("document-edit-verify"), tr("Force reannounce"), 0);
+    connect(&actionForce_reannounce, SIGNAL(triggered()), this, SLOT(reannounceSelectedTorrents()));
     QAction actionCopy_magnet_link(GuiIconProvider::instance()->getIcon("kt-magnet"), tr("Copy magnet link"), 0);
     connect(&actionCopy_magnet_link, SIGNAL(triggered()), this, SLOT(copySelectedMagnetURIs()));
     QAction actionCopy_name(GuiIconProvider::instance()->getIcon("edit-copy"), tr("Copy name"), 0);
@@ -1084,6 +1092,7 @@ void TransferListWidget::displayListMenu(const QPoint&)
         listMenu.addSeparator();
     if (one_has_metadata) {
         listMenu.addAction(&actionForce_recheck);
+        listMenu.addAction(&actionForce_reannounce);
         listMenu.addSeparator();
     }
     listMenu.addAction(&actionOpen_destination_folder);

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -85,6 +85,7 @@ public slots:
     void copySelectedHashes() const;
     void openSelectedTorrentsFolder() const;
     void recheckSelectedTorrents();
+    void reannounceSelectedTorrents();
     void setDlLimitSelectedTorrents();
     void setUpLimitSelectedTorrents();
     void setMaxRatioSelectedTorrents();


### PR DESCRIPTION
Currently as of this writing, you can force a reannounce event for a torrent if you go into the respective torrent's trackerlist and use the context menu there. However, this can be tedious if the user is going through multiple torrents and forcing a reannounce on each one. This pull request remedies that.

Now, there is a new "Force reannounce" option under the context menu for the transferlist. Users can now select a multitude of torrents and select this new option, and it will reannounce to every tracker within each torrent that the user has selected.

There are already a few torrent clients that support such an option, such as Deluge or Transmission. This PR also closes #6448. Feel free to let me know your thoughts!