### PR TITLE
Free disk space in WebUI status bar

### DIFF
--- a/src/webui/CMakeLists.txt
+++ b/src/webui/CMakeLists.txt
@@ -5,6 +5,7 @@ api/apierror.h
 api/appcontroller.h
 api/isessionmanager.h
 api/authcontroller.h
+api/freediskspacechecker.h
 api/logcontroller.h
 api/rsscontroller.h
 api/synccontroller.h
@@ -19,6 +20,7 @@ api/apicontroller.cpp
 api/apierror.cpp
 api/appcontroller.cpp
 api/authcontroller.cpp
+api/freediskspacechecker.cpp
 api/logcontroller.cpp
 api/rsscontroller.cpp
 api/synccontroller.cpp

--- a/src/webui/api/freediskspacechecker.cpp
+++ b/src/webui/api/freediskspacechecker.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2018  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2018  Thomas Piccirello <thomas.piccirello@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -26,37 +26,13 @@
  * exception statement from your version.
  */
 
-#pragma once
+#include "freediskspacechecker.h"
 
-#include "apicontroller.h"
+#include "base/bittorrent/session.h"
+#include "base/utils/fs.h"
 
-struct ISessionManager;
-
-class QThread;
-
-class FreeDiskSpaceChecker;
-
-class SyncController : public APIController
+void FreeDiskSpaceChecker::check()
 {
-    Q_OBJECT
-    Q_DISABLE_COPY(SyncController)
-
-public:
-    using APIController::APIController;
-
-    explicit SyncController(ISessionManager *sessionManager, QObject *parent = nullptr);
-    ~SyncController() override;
-
-private slots:
-    void maindataAction();
-    void torrentPeersAction();
-    void freeDiskSpaceSizeUpdated(qint64 freeSpaceSize);
-
-private:
-    qint64 getFreeDiskSpace();
-
-    qint64 m_freeDiskSpace = 0;
-    qint64 m_freeDiskSpaceLastUpdate = 0;
-    FreeDiskSpaceChecker *m_freeDiskSpaceChecker = nullptr;
-    QThread *m_freeDiskSpaceThread = nullptr;
-};
+    const qint64 freeDiskSpace = Utils::Fs::freeDiskSpaceOnPath(BitTorrent::Session::instance()->defaultSavePath());
+    emit checked(freeDiskSpace);
+}

--- a/src/webui/api/freediskspacechecker.h
+++ b/src/webui/api/freediskspacechecker.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2018  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2018  Thomas Piccirello <thomas.piccirello@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -28,35 +28,19 @@
 
 #pragma once
 
-#include "apicontroller.h"
+#include <QObject>
 
-struct ISessionManager;
-
-class QThread;
-
-class FreeDiskSpaceChecker;
-
-class SyncController : public APIController
+class FreeDiskSpaceChecker : public QObject
 {
     Q_OBJECT
-    Q_DISABLE_COPY(SyncController)
+    Q_DISABLE_COPY(FreeDiskSpaceChecker)
 
 public:
-    using APIController::APIController;
+    FreeDiskSpaceChecker() = default;
 
-    explicit SyncController(ISessionManager *sessionManager, QObject *parent = nullptr);
-    ~SyncController() override;
+public slots:
+    void check();
 
-private slots:
-    void maindataAction();
-    void torrentPeersAction();
-    void freeDiskSpaceSizeUpdated(qint64 freeSpaceSize);
-
-private:
-    qint64 getFreeDiskSpace();
-
-    qint64 m_freeDiskSpace = 0;
-    qint64 m_freeDiskSpaceLastUpdate = 0;
-    FreeDiskSpaceChecker *m_freeDiskSpaceChecker = nullptr;
-    QThread *m_freeDiskSpaceThread = nullptr;
+signals:
+    void checked(qint64 freeSpaceSize);
 };

--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -329,6 +329,8 @@ SyncController::SyncController(ISessionManager *sessionManager, QObject *parent)
     connect(m_freeDiskSpaceChecker, &FreeDiskSpaceChecker::checked, this, &SyncController::freeDiskSpaceSizeUpdated);
 
     m_freeDiskSpaceThread->start();
+    QTimer::singleShot(0, m_freeDiskSpaceChecker, &FreeDiskSpaceChecker::check);
+    m_freeDiskSpaceElapsedTimer.start();
 }
 
 SyncController::~SyncController()
@@ -512,11 +514,11 @@ void SyncController::torrentPeersAction()
 
 qint64 SyncController::getFreeDiskSpace()
 {
-    const qint64 now = QDateTime::currentMSecsSinceEpoch();
-    if ((now - m_freeDiskSpaceLastUpdate) >= FREEDISKSPACE_CHECK_TIMEOUT) {
+    if (m_freeDiskSpaceElapsedTimer.hasExpired(FREEDISKSPACE_CHECK_TIMEOUT)) {
         QTimer::singleShot(0, m_freeDiskSpaceChecker, &FreeDiskSpaceChecker::check);
-        m_freeDiskSpaceLastUpdate = now;
+        m_freeDiskSpaceElapsedTimer.restart();
     }
+
     return m_freeDiskSpace;
 }
 

--- a/src/webui/api/synccontroller.h
+++ b/src/webui/api/synccontroller.h
@@ -28,6 +28,8 @@
 
 #pragma once
 
+#include <QElapsedTimer>
+
 #include "apicontroller.h"
 
 struct ISessionManager;
@@ -56,7 +58,7 @@ private:
     qint64 getFreeDiskSpace();
 
     qint64 m_freeDiskSpace = 0;
-    qint64 m_freeDiskSpaceLastUpdate = 0;
     FreeDiskSpaceChecker *m_freeDiskSpaceChecker = nullptr;
     QThread *m_freeDiskSpaceThread = nullptr;
+    QElapsedTimer m_freeDiskSpaceElapsedTimer;
 };

--- a/src/webui/webui.pri
+++ b/src/webui/webui.pri
@@ -3,6 +3,7 @@ HEADERS += \
     $$PWD/api/apierror.h \
     $$PWD/api/appcontroller.h \
     $$PWD/api/authcontroller.h \
+    $$PWD/api/freediskspacechecker.h \
     $$PWD/api/isessionmanager.h \
     $$PWD/api/logcontroller.h \
     $$PWD/api/rsscontroller.h \
@@ -18,6 +19,7 @@ SOURCES += \
     $$PWD/api/apierror.cpp \
     $$PWD/api/appcontroller.cpp \
     $$PWD/api/authcontroller.cpp \
+    $$PWD/api/freediskspacechecker.cpp \
     $$PWD/api/logcontroller.cpp \
     $$PWD/api/rsscontroller.cpp \
     $$PWD/api/synccontroller.cpp \

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -155,6 +155,8 @@
             <span id="error_div"></span>
             <table style="position: absolute; right: 5px;">
                 <tr>
+                    <td id="freeSpaceOnDisk"></td>
+                    <td class="statusBarSeparator"></td>
                     <td id="DHTNodes"></td>
                     <td class="statusBarSeparator"></td>
                     <td><img id="connectionStatus" alt="Connection Status" src="images/skin/firewalled.svg" style="height: 1.5em;" /></td>

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -421,6 +421,7 @@ window.addEvent('load', function() {
         }
         else
             document.title = "qBittorrent ${VERSION} QBT_TR(Web UI)QBT_TR[CONTEXT=OptionsDialog]";
+        $('freeSpaceOnDisk').set('html', 'QBT_TR(Free space: %1)QBT_TR[CONTEXT=HttpServer]'.replace("%1", friendlyUnit(serverState.free_space_on_disk)));
         $('DHTNodes').set('html', 'QBT_TR(DHT: %1 nodes)QBT_TR[CONTEXT=StatusBar]'.replace("%1", serverState.dht_nodes));
 
         // Statistics dialog

--- a/src/webui/www/private/scripts/misc.js
+++ b/src/webui/www/private/scripts/misc.js
@@ -12,7 +12,7 @@ function friendlyUnit(value, isSpeed) {
         "QBT_TR(EiB)QBT_TR[CONTEXT=misc]"
     ];
 
-    if (value < 0)
+    if ((value === undefined) || (value === null) || (value < 0))
         return "QBT_TR(Unknown)QBT_TR[CONTEXT=misc]";
 
     var i = 0;


### PR DESCRIPTION
> Puts free space on disk (Default save path) in WebUI's status 

This is a continuation of #6829 and addresses the need to poll for free disk space on a separate thread. Comments/suggestions on the QThread implementation are welcome.

<img width="376" alt="screen shot 2018-09-22 at 8 21 36 pm" src="https://user-images.githubusercontent.com/8296030/45922858-2ab22780-bea5-11e8-947b-94273eb7161f.png">

Closes #9680 