### PR TITLE
Reselect webui torrents after full_update. Temporary fix for #8209.

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -289,9 +289,11 @@ window.addEvent('load', function () {
             onSuccess : function (response) {
                 $('error_div').set('html', '');
                 if (response) {
+                    var torrentsTableSelectedRows;
                     var update_categories = false;
                     var full_update = (response['full_update'] === true);
                     if (full_update) {
+                        torrentsTableSelectedRows = torrentsTable.selectedRowsIds();
                         torrentsTable.clear();
                         category_list = {};
                     }
@@ -348,6 +350,10 @@ window.addEvent('load', function () {
                         updateCategoryList();
                         torrentsTableContextMenu.updateCategoriesSubMenu(category_list);
                     }
+
+                    if (full_update)
+                        // re-select previously selected rows
+                        torrentsTable.reselectRows(torrentsTableSelectedRows);
                 }
                 clearTimeout(syncMainDataTimer);
                 syncMainDataTimer = syncMainData.delay(syncMainDataTimerPeriod);

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -489,19 +489,14 @@ var DynamicTable = new Class({
         },
 
         selectRow : function (rowId) {
-            this.selectedRows.empty();
+            this.deselectAll();
             this.selectedRows.push(rowId);
-            var trs = this.tableBody.getElements('tr');
-            for (var i = 0; i < trs.length; i++) {
-                var tr = trs[i];
-                if (tr.rowId == rowId) {
-                    if (!tr.hasClass('selected'))
-                        tr.addClass('selected');
-                }
+            this.tableBody.getElements('tr').each(function(tr) {
+                if (tr.rowId == rowId)
+                    tr.addClass('selected');
                 else
-                if (tr.hasClass('selected'))
                     tr.removeClass('selected');
-            }
+            });
             this.onSelectedRowChanged();
         },
 

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -500,6 +500,15 @@ var DynamicTable = new Class({
             this.onSelectedRowChanged();
         },
 
+        reselectRows : function(rowIds) {
+            this.deselectAll();
+            this.selectedRows = rowIds.slice();
+            this.tableBody.getElements('tr').each(function(tr) {
+                if (rowIds.indexOf(tr.rowId) > -1)
+                    tr.addClass('selected');
+            });
+        },
+
         onSelectedRowChanged : function () {},
 
         updateRowData : function (data) {


### PR DESCRIPTION
This PR saves Torrent Table's selected row ids prior to a full_update, and then re-selects them once the update completes. The purpose is two-fold:

1. Provide a better user experience by saving the user's selection when a full update occurs
2. Provide a temporary fix for the excessive full updates issue 