### PR TITLE
Add Q_OBJECT macro to classes.

### DIFF
--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -155,6 +155,7 @@ namespace BitTorrent
 
     class TorrentHandle : public QObject
     {
+        Q_OBJECT
         Q_DISABLE_COPY(TorrentHandle)
 
     public:

--- a/src/gui/search/searchlistdelegate.h
+++ b/src/gui/search/searchlistdelegate.h
@@ -35,6 +35,8 @@
 
 class SearchListDelegate: public QItemDelegate
 {
+    Q_OBJECT
+
 public:
     explicit SearchListDelegate(QObject *parent);
 


### PR DESCRIPTION
Those classes have used tr() in methods, thus it must be given a translation context via `Q_OBJECT`
Partially addresses #8220.

@sledgehammer999 
Can you verify that this fixes the "* lacks Q_OBJECT macro" warnings?
`lupdate` crashes in both linux, windows for me.