### PR TITLE
Torrent creator: raise maximum piece size to 32 MiB

### DIFF
--- a/src/gui/torrentcreatordlg.cpp
+++ b/src/gui/torrentcreatordlg.cpp
@@ -113,7 +113,7 @@ void TorrentCreatorDlg::onAddFileButtonClicked()
 
 int TorrentCreatorDlg::getPieceSize() const
 {
-    const int pieceSizes[] = {0, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384};  // base unit in KiB
+    const int pieceSizes[] = {0, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768};  // base unit in KiB
     return pieceSizes[m_ui->comboPieceSize->currentIndex()] * 1024;
 }
 

--- a/src/gui/torrentcreatordlg.ui
+++ b/src/gui/torrentcreatordlg.ui
@@ -164,6 +164,11 @@
             <string>16 MiB</string>
            </property>
           </item>
+          <item>
+           <property name="text">
+            <string>32 MiB</string>
+           </property>
+          </item>
          </widget>
         </item>
         <item>


### PR DESCRIPTION
According to https://github.com/arvidn/libtorrent/pull/2669#issuecomment-355553751
It seems there are rare occasions that 32 MiB piece size is needed.