### PR TITLE
Match webui statuses to gui, closes #7516

### DIFF
--- a/src/webui/www/public/scripts/dynamicTable.js
+++ b/src/webui/www/public/scripts/dynamicTable.js
@@ -777,23 +777,39 @@ var TorrentsTable = new Class({
             this.columns['state_icon'].updateTd = function (td, row) {
                 var state = this.getRowValue(row);
 
-                if ((state === "forcedDL") || (state === "metaDL"))
-                    state = "downloading";
-                else if (state === "allocating")
-                    state = "stalledDL";
-                else if (state === "forcedUP")
-                    state = "uploading";
-                else if (state === "pausedDL")
-                    state = "paused";
-                else if (state === "pausedUP")
-                    state = "completed";
-                else if ((state === "queuedDL") || (state === "queuedUP"))
-                    state = "queued";
-                else if ((state === "checkingDL") || (state === "checkingUP") ||
-                        (state === "queuedForChecking") || (state === "checkingResumeData"))
-                    state = "checking";
-                else if ((state === "unknown") || (state === "error") || (state === "missingFiles"))
-                    state = "error";
+                switch (state) {
+                    case "forcedDL":
+                    case "metaDL":
+                        state = "downloading";
+                        break;
+                    case "allocating":
+                        state = "stalledDL";
+                        break;
+                    case "forcedUP":
+                        state = "uploading";
+                        break;
+                    case "pausedDL":
+                        state = "paused";
+                        break;
+                    case "pausedUP":
+                        state = "completed";
+                        break;
+                    case "queuedDL":
+                    case "queuedUP":
+                        state = "queued";
+                        break;
+                    case "checkingDL":
+                    case "checkingUP":
+                    case "queuedForChecking":
+                    case "checkingResumeData":
+                        state = "checking";
+                        break;
+                    case "unknown":
+                    case "error":
+                    case "missingFiles":
+                        state = "error";
+                        break;
+                }
 
                 var img_path = 'images/skin/' + state + '.png';
 

--- a/src/webui/www/public/scripts/dynamicTable.js
+++ b/src/webui/www/public/scripts/dynamicTable.js
@@ -811,26 +811,62 @@ var TorrentsTable = new Class({
 
             // status
             this.columns['status'].updateTd = function (td, row) {
-                var status = this.getRowValue(row);
-                if (!status) return;
+                var state = this.getRowValue(row);
+                if (!state) return;
 
-                if ((status === "downloading") || (status === "forcedDL") || (status === "metaDL"))
-                    status = "Downloading";
-                else if ((status === "stalledDL") || (status === "stalledUP") || (status === "allocating"))
-                    status = "Stalled";
-                else if ((status === "uploading") || (status === "forcedUP"))
-                    status = "Uploading";
-                else if (status === "pausedDL")
-                    status = "Paused";
-                else if (status === "pausedUP")
-                    status = "Completed";
-                else if ((status === "queuedDL") || (status === "queuedUP"))
-                    status = "Queued";
-                else if ((status === "checkingDL") || (status === "checkingUP") ||
-                        (status === "queuedForChecking") || (status === "checkingResumeData"))
-                    status = "Checking";
-                else if ((status === "unknown") || (status === "error") || (status === "missingFiles"))
-                    status = "Error";
+                var status;
+                switch (state) {
+                    case "downloading":
+                        status = "Downloading";
+                        break;
+                    case "stalledDL":
+                        status = "Stalled";
+                        break;
+                    case "metaDL":
+                        status = "Downloading metadata";
+                        break;
+                    case "forcedDL":
+                        status = "[F] Downloading";
+                        break;
+                    case "allocating":
+                        status = "Allocating";
+                        break;
+                    case "uploading":
+                    case "stalledUP":
+                        status = "Seeding";
+                        break;
+                    case "forcedUP":
+                        status = "[F] Seeding";
+                        break;
+                    case "queuedDL":
+                    case "queuedUP":
+                        status = "Queued";
+                        break;
+                    case "checkingDL":
+                    case "checkingUP":
+                        status = "Checking";
+                        break;
+                    case "queuedForChecking":
+                        status = "Queued for checking";
+                        break;
+                    case "checkingResumeData":
+                        status = "Checking resume data";
+                        break;
+                    case "pausedDL":
+                        status = "Paused";
+                        break;
+                    case "pausedUP":
+                        status = "Completed";
+                        break;
+                    case "missingFiles":
+                        status = "Missing Files";
+                        break;
+                    case "error":
+                        status = "Errored";
+                        break;
+                    default:
+                        status = "Unknown";
+                }
 
                 td.set('html', status);
             };


### PR DESCRIPTION
This matches the torrent statuses in the webui to the statuses [in the gui](https://github.com/qbittorrent/qBittorrent/blob/e48b97466c15dfec06a32843ff59648949c0e3c8/src/gui/transferlistdelegate.cpp#L226).