### PR TITLE
Only add Search combobox separators as needed

### DIFF
--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -144,7 +144,6 @@ void SearchWidget::fillCatCombobox()
 {
     m_ui->comboCategory->clear();
     m_ui->comboCategory->addItem(SearchEngine::categoryFullName("all"), QVariant("all"));
-    m_ui->comboCategory->insertSeparator(1);
 
     using QStrPair = QPair<QString, QString>;
     QList<QStrPair> tmpList;
@@ -156,6 +155,9 @@ void SearchWidget::fillCatCombobox()
         qDebug("Supported category: %s", qUtf8Printable(p.second));
         m_ui->comboCategory->addItem(p.first, QVariant(p.second));
     }
+    
+    if (m_ui->comboCategory->count() > 1)
+        m_ui->comboCategory->insertSeparator(1);
 }
 
 void SearchWidget::fillPluginComboBox()
@@ -164,7 +166,6 @@ void SearchWidget::fillPluginComboBox()
     m_ui->selectPlugin->addItem(tr("Only enabled"), QVariant("enabled"));
     m_ui->selectPlugin->addItem(tr("All plugins"), QVariant("all"));
     m_ui->selectPlugin->addItem(tr("Select..."), QVariant("multi"));
-    m_ui->selectPlugin->insertSeparator(3);
 
     using QStrPair = QPair<QString, QString>;
     QList<QStrPair> tmpList;
@@ -174,6 +175,9 @@ void SearchWidget::fillPluginComboBox()
 
     foreach (const QStrPair &p, tmpList)
         m_ui->selectPlugin->addItem(p.first, QVariant(p.second));
+
+    if (m_ui->selectPlugin->count() > 3)
+        m_ui->selectPlugin->insertSeparator(3);
 }
 
 QString SearchWidget::selectedCategory() const


### PR DESCRIPTION
This PR only adds separators to the Search tab's comboboxes if there are additional items to separate.

### Before

<img width="193" src="https://user-images.githubusercontent.com/8296030/34972947-ec3b1e6a-fa52-11e7-909c-4b5060ad01ca.png">
<img width="243" src="https://user-images.githubusercontent.com/8296030/34972953-f140de90-fa52-11e7-9ff4-2aaf4d9b6b3f.png">

### After

<img width="310" alt="screen shot 2018-01-16 at 12 11 39 am" src="https://user-images.githubusercontent.com/8296030/34972977-0a879c54-fa53-11e7-8620-c65692061b71.png">
<img width="327" alt="screen shot 2018-01-16 at 12 11 33 am" src="https://user-images.githubusercontent.com/8296030/34972983-111a7d20-fa53-11e7-8bcf-359d68f1d1a0.png">
<img width="231" alt="screen shot 2018-01-16 at 12 18 11 am" src="https://user-images.githubusercontent.com/8296030/34972985-14fc0918-fa53-11e7-951b-f86256cef384.png">
