### PR TITLE
Clear settings file before write

### DIFF
--- a/src/base/settingsstorage.cpp
+++ b/src/base/settingsstorage.cpp
@@ -297,6 +297,7 @@ QString TransactionalSettings::deserialize(const QString &name, QVariantHash &da
 QString TransactionalSettings::serialize(const QString &name, const QVariantHash &data)
 {
     SettingsPtr settings = Profile::instance().applicationSettings(name);
+    settings->clear();
     for (auto i = data.begin(); i != data.end(); ++i)
         settings->setValue(i.key(), i.value());
 


### PR DESCRIPTION
During some upgrade events we (want and try to) remove some legacy settings. We need clear internal QSettings storage before write otherwise the deleted settings wont be really deleted.
@sledgehammer999, please consider it for v4.0.4 as trivial hotfix.