### PR TITLE
Require '#pragma once' in new code

### DIFF
--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -240,7 +240,23 @@ Example:
 
 ```
 
-### 9. Misc. ###
+### 9. Include guard. ###
+`#pragma once` should be used instead of "include guard" in new code:
+```c++
+// examplewidget.h
+
+#pragma once
+
+#include <QWidget>
+
+class ExampleWidget : public QWidget
+{
+    // (some code omitted)
+};
+
+```
+
+### 10. Misc. ###
 
 * Line breaks for long lines with operation:
 


### PR DESCRIPTION
Coding style changes suggestion.
The my reasons:
1. Less code for the same thing,
2. Use special thing, not the workaround.