### PR TITLE
Calculate search categories based on selected plugin

### DIFF
--- a/src/base/search/searchpluginmanager.cpp
+++ b/src/base/search/searchpluginmanager.cpp
@@ -38,6 +38,7 @@
 #include <QPointer>
 #include <QProcess>
 
+#include "base/global.h"
 #include "base/logger.h"
 #include "base/net/downloadmanager.h"
 #include "base/net/downloadhandler.h"
@@ -120,6 +121,27 @@ QStringList SearchPluginManager::supportedCategories() const
     }
 
     return result;
+}
+
+QStringList SearchPluginManager::getPluginCategories(const QString &pluginName) const
+{
+    QStringList plugins;
+    if (pluginName == "all")
+        plugins = allPlugins();
+    else if ((pluginName == "enabled") || (pluginName == "multi"))
+        plugins = enabledPlugins();
+    else
+        plugins << pluginName.trimmed();
+
+    QSet<QString> categories;
+    for (const QString &pluginName : qAsConst(plugins)) {
+        const PluginInfo *plugin = pluginInfo(pluginName);
+        if (!plugin) continue; // plugin wasn't found
+        for (const QString &category : plugin->supportedCategories)
+            categories << category;
+    }
+
+    return categories.toList();
 }
 
 PluginInfo *SearchPluginManager::pluginInfo(const QString &name) const

--- a/src/base/search/searchpluginmanager.h
+++ b/src/base/search/searchpluginmanager.h
@@ -66,6 +66,7 @@ public:
     QStringList allPlugins() const;
     QStringList enabledPlugins() const;
     QStringList supportedCategories() const;
+    QStringList getPluginCategories(const QString &pluginName) const;
     PluginInfo *pluginInfo(const QString &name) const;
 
     void enablePlugin(const QString &name, bool enabled = true);

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -139,8 +139,8 @@ SearchWidget::SearchWidget(MainWindow *mainWindow)
     auto *searchManager = new SearchPluginManager;
     const auto onPluginChanged = [this]()
     {
-        fillCatCombobox();
         fillPluginComboBox();
+        fillCatCombobox();
         selectActivePage();
     };
     connect(searchManager, &SearchPluginManager::pluginInstalled, this, onPluginChanged);
@@ -155,6 +155,8 @@ SearchWidget::SearchWidget(MainWindow *mainWindow)
     connect(m_ui->m_searchPattern, &LineEdit::textEdited, this, &SearchWidget::searchTextEdited);
     connect(m_ui->selectPlugin, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged)
             , this, &SearchWidget::selectMultipleBox);
+    connect(m_ui->selectPlugin, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged)
+            , this, &SearchWidget::fillCatCombobox);
 }
 
 void SearchWidget::fillCatCombobox()
@@ -164,7 +166,7 @@ void SearchWidget::fillCatCombobox()
 
     using QStrPair = QPair<QString, QString>;
     QList<QStrPair> tmpList;
-    foreach (const QString &cat, SearchPluginManager::instance()->supportedCategories())
+    foreach (const QString &cat, SearchPluginManager::instance()->getPluginCategories(selectedPlugin()))
         tmpList << qMakePair(SearchPluginManager::categoryFullName(cat), cat);
     std::sort(tmpList.begin(), tmpList.end(), [](const QStrPair &l, const QStrPair &r) { return (QString::localeAwareCompare(l.first, r.first) < 0); });
 
@@ -172,7 +174,7 @@ void SearchWidget::fillCatCombobox()
         qDebug("Supported category: %s", qUtf8Printable(p.second));
         m_ui->comboCategory->addItem(p.first, QVariant(p.second));
     }
-    
+
     if (m_ui->comboCategory->count() > 1)
         m_ui->comboCategory->insertSeparator(1);
 }


### PR DESCRIPTION
 Uses the selected plugin to determine the supported search categories.

Before:
<img width="283" alt="screen shot 2018-01-24 at 2 42 32 am" src="https://user-images.githubusercontent.com/8296030/35320423-c155dbd0-00b1-11e8-9539-63f03080a50d.png">
<img width="271" alt="screen shot 2018-01-24 at 2 42 41 am" src="https://user-images.githubusercontent.com/8296030/35320427-c5dc957c-00b1-11e8-883a-92b062cd4bcf.png">
<img width="269" alt="screen shot 2018-01-24 at 2 42 54 am" src="https://user-images.githubusercontent.com/8296030/35320430-c7530030-00b1-11e8-9dad-c32496a32390.png">


After:
<img width="278" alt="screen shot 2018-01-24 at 2 52 41 am" src="https://user-images.githubusercontent.com/8296030/35320433-ca214b46-00b1-11e8-9b56-c98da97a89be.png">
<img width="268" alt="screen shot 2018-01-24 at 2 52 49 am" src="https://user-images.githubusercontent.com/8296030/35320446-cf7fb852-00b1-11e8-9332-369b5ddfe85b.png">
<img width="267" alt="screen shot 2018-01-24 at 2 52 57 am" src="https://user-images.githubusercontent.com/8296030/35320450-d11a812e-00b1-11e8-89ed-3cbb09c5bd8e.png">
