### PR TITLE
Set default file log size to 65 KiB and delete backup logs older than…

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -87,7 +87,7 @@ namespace
     const QString KEY_FILELOGGER_PATH = FILELOGGER_SETTINGS_KEY("Path");
     const QString KEY_FILELOGGER_BACKUP = FILELOGGER_SETTINGS_KEY("Backup");
     const QString KEY_FILELOGGER_DELETEOLD = FILELOGGER_SETTINGS_KEY("DeleteOld");
-    const QString KEY_FILELOGGER_MAXSIZE = FILELOGGER_SETTINGS_KEY("MaxSize");
+    const QString KEY_FILELOGGER_MAXSIZEBYTES = FILELOGGER_SETTINGS_KEY("MaxSizeBytes");
     const QString KEY_FILELOGGER_AGE = FILELOGGER_SETTINGS_KEY("Age");
     const QString KEY_FILELOGGER_AGETYPE = FILELOGGER_SETTINGS_KEY("AgeType");
 
@@ -98,6 +98,10 @@ namespace
     const char PARAMS_SEPARATOR[] = "|";
 
     const QString DEFAULT_PORTABLE_MODE_PROFILE_DIR = QLatin1String("profile");
+
+    const int MIN_FILELOG_SIZE = 1024; // 1KiB
+    const int MAX_FILELOG_SIZE = 1000 * 1024 * 1024; // 1000MiB
+    const int DEFAULT_FILELOG_SIZE = 65 * 1024; // 65KiB
 }
 
 Application::Application(const QString &id, int &argc, char **argv)
@@ -221,29 +225,22 @@ void Application::setFileLoggerDeleteOld(bool value)
 
 int Application::fileLoggerMaxSize() const
 {
-    int val = settings()->loadValue(KEY_FILELOGGER_MAXSIZE, 10).toInt();
-    if (val < 1)
-        return 1;
-    if (val > 1000)
-        return 1000;
-    return val;
+    int val = settings()->loadValue(KEY_FILELOGGER_MAXSIZEBYTES, DEFAULT_FILELOG_SIZE).toInt();
+    return std::min(std::max(val, MIN_FILELOG_SIZE), MAX_FILELOG_SIZE);
 }
 
-void Application::setFileLoggerMaxSize(const int value)
+void Application::setFileLoggerMaxSize(const int bytes)
 {
+    int clampedValue = std::min(std::max(bytes, MIN_FILELOG_SIZE), MAX_FILELOG_SIZE);
     if (m_fileLogger)
-        m_fileLogger->setMaxSize(value);
-    settings()->storeValue(KEY_FILELOGGER_MAXSIZE, std::min(std::max(value, 1), 1000));
+        m_fileLogger->setMaxSize(clampedValue);
+    settings()->storeValue(KEY_FILELOGGER_MAXSIZEBYTES, clampedValue);
 }
 
 int Application::fileLoggerAge() const
 {
-    int val = settings()->loadValue(KEY_FILELOGGER_AGE, 6).toInt();
-    if (val < 1)
-        return 1;
-    if (val > 365)
-        return 365;
-    return val;
+    int val = settings()->loadValue(KEY_FILELOGGER_AGE, 1).toInt();
+    return std::min(std::max(val, 1), 365);
 }
 
 void Application::setFileLoggerAge(const int value)

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -101,7 +101,7 @@ public:
     bool isFileLoggerDeleteOld() const;
     void setFileLoggerDeleteOld(bool value);
     int fileLoggerMaxSize() const;
-    void setFileLoggerMaxSize(const int value);
+    void setFileLoggerMaxSize(const int bytes);
     int fileLoggerAge() const;
     void setFileLoggerAge(const int value);
     int fileLoggerAgeType() const;

--- a/src/app/filelogger.cpp
+++ b/src/app/filelogger.cpp
@@ -135,7 +135,7 @@ void FileLogger::addLogMessage(const Log::Msg &msg)
 
     str << QDateTime::fromMSecsSinceEpoch(msg.timestamp).toString(Qt::ISODate) << " - " << msg.message << endl;
 
-    if (m_backup && (m_logFile->size() >= (m_maxSize * 1024 * 1024))) {
+    if (m_backup && (m_logFile->size() >= m_maxSize)) {
         closeLogFile();
         int counter = 0;
         QString backupLogFilename = m_path + ".bak";

--- a/src/gui/optionsdlg.cpp
+++ b/src/gui/optionsdlg.cpp
@@ -537,7 +537,7 @@ void OptionsDialog::saveOptions()
     Application * const app = static_cast<Application*>(QCoreApplication::instance());
     app->setFileLoggerPath(m_ui->textFileLogPath->selectedPath());
     app->setFileLoggerBackup(m_ui->checkFileLogBackup->isChecked());
-    app->setFileLoggerMaxSize(m_ui->spinFileLogSize->value());
+    app->setFileLoggerMaxSize(m_ui->spinFileLogSize->value() * 1024);
     app->setFileLoggerAge(m_ui->spinFileLogAge->value());
     app->setFileLoggerAgeType(m_ui->comboFileLogAgeType->currentIndex());
     app->setFileLoggerDeleteOld(m_ui->checkFileLogDelete->isChecked());
@@ -765,7 +765,7 @@ void OptionsDialog::loadOptions()
     m_ui->checkFileLogDelete->setChecked(fileLogDelete);
     m_ui->spinFileLogAge->setEnabled(fileLogDelete);
     m_ui->comboFileLogAgeType->setEnabled(fileLogDelete);
-    m_ui->spinFileLogSize->setValue(app->fileLoggerMaxSize());
+    m_ui->spinFileLogSize->setValue(app->fileLoggerMaxSize() / 1024);
     m_ui->spinFileLogAge->setValue(app->fileLoggerAge());
     m_ui->comboFileLogAgeType->setCurrentIndex(app->fileLoggerAgeType());
     // End General preferences

--- a/src/gui/optionsdlg.ui
+++ b/src/gui/optionsdlg.ui
@@ -535,16 +535,16 @@
                  <item>
                   <widget class="QSpinBox" name="spinFileLogSize">
                    <property name="suffix">
-                    <string> MB</string>
+                    <string> KiB</string>
                    </property>
                    <property name="minimum">
                     <number>1</number>
                    </property>
                    <property name="maximum">
-                    <number>1000</number>
+                    <number>1024000</number>
                    </property>
                    <property name="value">
-                    <number>10</number>
+                    <number>65</number>
                    </property>
                   </widget>
                  </item>


### PR DESCRIPTION
... 1 month.

I think the current defaults are bit too much.
Current defaults: 10 MiB max file log size, delete backup logs older than 6 months
New defaults: 65 KiB max file log size, delete backup logs older than 1 month

I created a new key to save the setting as bytes and not as MiB.
The users' settings will be reset for the log file size. Is it worth it implementing migration code for this case?
I vote for no.