### PR TITLE
Add "Coalesce reads & writes" checkbox in advanced options

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -382,6 +382,8 @@ namespace BitTorrent
         void setUseOSCache(bool use);
         bool isGuidedReadCacheEnabled() const;
         void setGuidedReadCacheEnabled(bool enabled);
+        bool isCoalesceReadWriteEnabled() const;
+        void setCoalesceReadWriteEnabled(bool enabled);
         bool isSuggestModeEnabled() const;
         void setSuggestMode(bool mode);
         int sendBufferWatermark() const;
@@ -646,6 +648,7 @@ namespace BitTorrent
         CachedSettingValue<int> m_diskCacheTTL;
         CachedSettingValue<bool> m_useOSCache;
         CachedSettingValue<bool> m_guidedReadCacheEnabled;
+        CachedSettingValue<bool> m_coalesceReadWriteEnabled;
         CachedSettingValue<bool> m_isSuggestMode;
         CachedSettingValue<int> m_sendBufferWatermark;
         CachedSettingValue<int> m_sendBufferLowWatermark;

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -82,6 +82,7 @@ enum AdvSettingsRows
     DISK_CACHE_TTL,
     OS_CACHE,
     GUIDED_READ_CACHE,
+    COALESCE_RW,
     SUGGEST_MODE,
     SEND_BUF_WATERMARK,
     SEND_BUF_LOW_WATERMARK,
@@ -142,6 +143,8 @@ void AdvancedSettings::saveAdvancedSettings()
     session->setUseOSCache(cb_os_cache.isChecked());
     // Guided read cache
     session->setGuidedReadCacheEnabled(cbGuidedReadCache.isChecked());
+    // Coalesce reads & writes
+    session->setCoalesceReadWriteEnabled(cbCoalesceRW.isChecked());
     // Suggest mode
     session->setSuggestMode(cbSuggestMode.isChecked());
     // Send buffer watermark
@@ -313,6 +316,11 @@ void AdvancedSettings::loadAdvancedSettings()
     // Guided read cache
     cbGuidedReadCache.setChecked(session->isGuidedReadCacheEnabled());
     addRow(GUIDED_READ_CACHE, tr("Guided read cache"), &cbGuidedReadCache);
+    // Coalesce reads & writes
+    cbCoalesceRW.setChecked(session->isCoalesceReadWriteEnabled());
+#if LIBTORRENT_VERSION_NUM >= 10107
+    addRow(COALESCE_RW, tr("Coalesce reads & writes"), &cbCoalesceRW);
+#endif
     // Suggest mode
     cbSuggestMode.setChecked(session->isSuggestModeEnabled());
     addRow(SUGGEST_MODE, tr("Send upload piece suggestions"), &cbSuggestMode);

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -80,7 +80,7 @@ private:
     QCheckBox cb_os_cache, cb_recheck_completed, cb_resolve_countries, cb_resolve_hosts, cb_super_seeding,
               cb_program_notifications, cb_torrent_added_notifications, cb_tracker_favicon, cb_tracker_status,
               cb_confirm_torrent_recheck, cb_confirm_remove_all_tags, cb_listen_ipv6, cb_announce_all_trackers, cb_announce_all_tiers,
-              cbGuidedReadCache, cbMultiConnectionsPerIp, cbSuggestMode;
+              cbGuidedReadCache, cbMultiConnectionsPerIp, cbSuggestMode, cbCoalesceRW;
     QComboBox combo_iface, combo_iface_address, comboUtpMixedMode, comboChokingAlgorithm, comboSeedChokingAlgorithm;
     QLineEdit txtAnnounceIP;
 


### PR DESCRIPTION
The setting is defaulted to ON. Closes #8295.