### PR TITLE
Fixed typo in function name isSplashScreenDisabled()

### DIFF
--- a/src/gui/optionsdlg.cpp
+++ b/src/gui/optionsdlg.cpp
@@ -512,7 +512,7 @@ void OptionsDialog::saveOptions()
     pref->setMinimizeToTray(minimizeToTray());
     pref->setStartMinimized(startMinimized());
 #endif
-    pref->setSplashScreenDisabled(isSlashScreenDisabled());
+    pref->setSplashScreenDisabled(isSplashScreenDisabled());
     pref->setConfirmOnExit(m_ui->checkProgramExitConfirm->isChecked());
     pref->setDontConfirmAutoExit(!m_ui->checkProgramAutoExitConfirm->isChecked());
     pref->setPreventFromSuspend(preventFromSuspend());
@@ -1320,7 +1320,7 @@ void OptionsDialog::enableProxy(int index)
     }
 }
 
-bool OptionsDialog::isSlashScreenDisabled() const
+bool OptionsDialog::isSplashScreenDisabled() const
 {
     return !m_ui->checkShowSplash->isChecked();
 }

--- a/src/gui/optionsdlg.h
+++ b/src/gui/optionsdlg.h
@@ -122,7 +122,7 @@ private:
     bool closeToTray() const;
 #endif
     bool startMinimized() const;
-    bool isSlashScreenDisabled() const;
+    bool isSplashScreenDisabled() const;
     bool preventFromSuspend() const;
 #ifdef Q_OS_WIN
     bool WinStartup() const;


### PR DESCRIPTION
Found this typo while poking around