### PR TITLE
Improve stats dialog

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -29,10 +29,10 @@
 
 #include "session.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <queue>
 #include <string>
-#include <vector>
 
 #include <QCoreApplication>
 #include <QDateTime>
@@ -4266,11 +4266,10 @@ void Session::handleSessionStatsAlert(libt::session_stats_alert *p)
     m_status.diskWriteQueue = p->values[m_metricIndices.peer.numPeersDownDisk];
     m_status.peersCount = p->values[m_metricIndices.peer.numPeersConnected];
 
-    const auto numBlocksRead = p->values[m_metricIndices.disk.numBlocksRead];
+    const int numBlocksRead = p->values[m_metricIndices.disk.numBlocksRead];
+    const int numBlocksCacheHits = p->values[m_metricIndices.disk.numBlocksCacheHits];
     m_cacheStatus.totalUsedBuffers = p->values[m_metricIndices.disk.diskBlocksInUse];
-    m_cacheStatus.readRatio = numBlocksRead > 0
-            ? static_cast<qreal>(p->values[m_metricIndices.disk.numBlocksCacheHits]) / numBlocksRead
-            : -1;
+    m_cacheStatus.readRatio = static_cast<qreal>(numBlocksCacheHits) / std::max(numBlocksCacheHits + numBlocksRead, 1);
     m_cacheStatus.jobQueueLength = p->values[m_metricIndices.disk.queuedDiskJobs];
 
     quint64 totalJobs = p->values[m_metricIndices.disk.writeJobs] + p->values[m_metricIndices.disk.readJobs]

--- a/src/gui/statsdialog.cpp
+++ b/src/gui/statsdialog.cpp
@@ -77,7 +77,10 @@ void StatsDialog::update()
                 : "-");
     // Cache hits
     qreal readRatio = cs.readRatio;
-    m_ui->labelCacheHits->setText((readRatio >= 0) ? Utils::String::fromDouble(100 * readRatio, 2) : "-");
+    m_ui->labelCacheHits->setText(QString("%1%").arg(
+        readRatio > 0
+        ? Utils::String::fromDouble(100 * readRatio, 2)
+        : "0"));
     // Buffers size
     m_ui->labelTotalBuf->setText(Utils::Misc::friendlyUnit(cs.totalUsedBuffers * 16 * 1024));
     // Disk overload (100%) equivalent

--- a/src/gui/statsdialog.ui
+++ b/src/gui/statsdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>286</width>
-    <height>401</height>
+    <width>265</width>
+    <height>457</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,71 +20,71 @@
       <string>User statistics</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="11" column="0">
+      <item row="3" column="1" alignment="Qt::AlignRight">
+       <widget class="QLabel" name="labelWaste">
+        <property name="text">
+         <string notr="true">TextLabel</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
        <widget class="QLabel" name="labelPeersText">
         <property name="text">
-         <string>Total peer connections:</string>
+         <string>Connected peers:</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item row="2" column="0">
        <widget class="QLabel" name="labelGlobalRatioText">
         <property name="text">
-         <string>Global ratio:</string>
+         <string>All-time share ratio:</string>
         </property>
        </widget>
       </item>
-      <item row="11" column="1" alignment="Qt::AlignRight">
+      <item row="4" column="1" alignment="Qt::AlignRight">
        <widget class="QLabel" name="labelPeers">
         <property name="text">
          <string notr="true">TextLabel</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
+      <item row="1" column="0">
        <widget class="QLabel" name="labelAlltimeDLText">
         <property name="text">
-         <string>Alltime download:</string>
+         <string>All-time download:</string>
         </property>
        </widget>
       </item>
       <item row="1" column="1" alignment="Qt::AlignRight">
-       <widget class="QLabel" name="labelAlltimeUL">
-        <property name="text">
-         <string notr="true">TextLabel</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1" alignment="Qt::AlignRight">
        <widget class="QLabel" name="labelAlltimeDL">
         <property name="text">
          <string notr="true">TextLabel</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="labelAlltimeULText">
-        <property name="text">
-         <string>Alltime upload:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1" alignment="Qt::AlignRight">
+      <item row="2" column="1" alignment="Qt::AlignRight">
        <widget class="QLabel" name="labelGlobalRatio">
         <property name="text">
          <string notr="true">TextLabel</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="labelWasteText">
         <property name="text">
-         <string>Total waste (this session):</string>
+         <string>Session waste:</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1" alignment="Qt::AlignRight">
-       <widget class="QLabel" name="labelWaste">
+      <item row="0" column="0">
+       <widget class="QLabel" name="labelAlltimeULText">
+        <property name="text">
+         <string>All-time upload:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1" alignment="Qt::AlignRight">
+       <widget class="QLabel" name="labelAlltimeUL">
         <property name="text">
          <string notr="true">TextLabel</string>
         </property>
@@ -99,31 +99,31 @@
       <string>Cache statistics</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="0">
+      <item row="0" column="0">
        <widget class="QLabel" name="labelCacheHitsText">
         <property name="text">
          <string>Read cache hits:</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1" alignment="Qt::AlignRight">
+      <item row="0" column="1" alignment="Qt::AlignRight">
        <widget class="QLabel" name="labelCacheHits">
         <property name="text">
          <string notr="true">TextLabel</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1" alignment="Qt::AlignRight">
+      <item row="1" column="1" alignment="Qt::AlignRight">
        <widget class="QLabel" name="labelTotalBuf">
         <property name="text">
          <string notr="true">TextLabel</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="1" column="0">
        <widget class="QLabel" name="labelTotalBufText">
         <property name="text">
-         <string>Total buffers size:</string>
+         <string>Total buffer size:</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
* Redefine CacheStatus.readRatio field.
  Now it is defined as:
  CacheStatus.readRatio = (blocks read from cache) / (blocks read from disk + blocks read from cache)
  The 2 variables in denominator are counted separately and the formula before this change doesn't really make sense

* Add percentage sign to "Read cache hits" stats
* Also remove redundant header include
* Clarify some terms in stats dialog
  Reorder list
* Screenshot
  Before:
  ![Before](https://user-images.githubusercontent.com/9395168/35723997-31a62caa-0837-11e8-9338-7a0474c4c458.png)
  After:
  ![After](https://user-images.githubusercontent.com/9395168/35741469-e1d6b8ca-0872-11e8-82cb-f68b660dabe8.png)

