### PR TITLE
Expose the libtorrent fields for "dont_count_slow_torrents" to GUI. Closes #5713

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -396,6 +396,12 @@ namespace BitTorrent
         void setQueueingSystemEnabled(bool enabled);
         bool ignoreSlowTorrentsForQueueing() const;
         void setIgnoreSlowTorrentsForQueueing(bool ignore);
+        int downloadRateForSlowTorrents() const;
+        void setDownloadRateForSlowTorrents(int rateInKibiBytes);
+        int uploadRateForSlowTorrents() const;
+        void setUploadRateForSlowTorrents(int rateInKibiBytes);
+        int slowTorrentsInactivityTimer() const;
+        void setSlowTorrentsInactivityTimer(int timeInSeconds);
         int outgoingPortsMin() const;
         void setOutgoingPortsMin(int min);
         int outgoingPortsMax() const;
@@ -656,6 +662,9 @@ namespace BitTorrent
         CachedSettingValue<int> m_maxActiveUploads;
         CachedSettingValue<int> m_maxActiveTorrents;
         CachedSettingValue<bool> m_ignoreSlowTorrentsForQueueing;
+        CachedSettingValue<int> m_downloadRateForSlowTorrents;
+        CachedSettingValue<int> m_uploadRateForSlowTorrents;
+        CachedSettingValue<int> m_slowTorrentsInactivityTimer;
         CachedSettingValue<int> m_outgoingPortsMin;
         CachedSettingValue<int> m_outgoingPortsMax;
         CachedSettingValue<bool> m_ignoreLimitsOnLAN;

--- a/src/gui/optionsdlg.cpp
+++ b/src/gui/optionsdlg.cpp
@@ -344,9 +344,20 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     connect(m_ui->spinMaxActiveDownloads, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->spinMaxActiveUploads, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->spinMaxActiveTorrents, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
-    connect(m_ui->checkIgnoreSlowTorrentsForQueueing, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->checkIgnoreSlowTorrentsForQueueing, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->spinDownloadRateForSlowTorrents, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
+    connect(m_ui->spinUploadRateForSlowTorrents, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
+    connect(m_ui->spinSlowTorrentsInactivityTimer, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->checkEnableAddTrackers, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->textTrackers, &QPlainTextEdit::textChanged, this, &ThisType::enableApplyButton);
+
+    const QString slowTorrentsExplanation = QLatin1String("<html><body><p>")
+            + tr("A torrent will be considered slow if its download and upload rates stay below these values for \"Torrent inactivity timer\" seconds")
+            + QLatin1String("</p></body></html>");
+    m_ui->labelDownloadRateForSlowTorrents->setToolTip(slowTorrentsExplanation);
+    m_ui->labelUploadRateForSlowTorrents->setToolTip(slowTorrentsExplanation);
+    m_ui->labelSlowTorrentInactivityTimer->setToolTip(slowTorrentsExplanation);
+
 #ifndef DISABLE_WEBUI
     // Web UI tab
     connect(m_ui->textServerDomains, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
@@ -652,6 +663,9 @@ void OptionsDialog::saveOptions()
     session->setMaxActiveUploads(m_ui->spinMaxActiveUploads->value());
     session->setMaxActiveTorrents(m_ui->spinMaxActiveTorrents->value());
     session->setIgnoreSlowTorrentsForQueueing(m_ui->checkIgnoreSlowTorrentsForQueueing->isChecked());
+    session->setDownloadRateForSlowTorrents(m_ui->spinDownloadRateForSlowTorrents->value());
+    session->setUploadRateForSlowTorrents(m_ui->spinUploadRateForSlowTorrents->value());
+    session->setSlowTorrentsInactivityTimer(m_ui->spinSlowTorrentsInactivityTimer->value());
     // End Queueing system preferences
     // Web UI
     pref->setWebUiEnabled(isWebUiEnabled());
@@ -1021,6 +1035,9 @@ void OptionsDialog::loadOptions()
     m_ui->spinMaxActiveUploads->setValue(session->maxActiveUploads());
     m_ui->spinMaxActiveTorrents->setValue(session->maxActiveTorrents());
     m_ui->checkIgnoreSlowTorrentsForQueueing->setChecked(session->ignoreSlowTorrentsForQueueing());
+    m_ui->spinDownloadRateForSlowTorrents->setValue(session->downloadRateForSlowTorrents());
+    m_ui->spinUploadRateForSlowTorrents->setValue(session->uploadRateForSlowTorrents());
+    m_ui->spinSlowTorrentsInactivityTimer->setValue(session->slowTorrentsInactivityTimer());
 
     if (session->globalMaxRatio() >= 0.) {
         // Enable

--- a/src/gui/optionsdlg.ui
+++ b/src/gui/optionsdlg.ui
@@ -2362,10 +2362,124 @@
                 </spacer>
                </item>
                <item row="3" column="0" colspan="3">
-                <widget class="QCheckBox" name="checkIgnoreSlowTorrentsForQueueing">
-                 <property name="text">
+                <widget class="QGroupBox" name="checkIgnoreSlowTorrentsForQueueing">
+                 <property name="title">
                   <string>Do not count slow torrents in these limits</string>
                  </property>
+                 <property name="checkable">
+                  <bool>true</bool>
+                 </property>
+                 <property name="checked">
+                  <bool>false</bool>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_8">
+                  <item row="2" column="3">
+                   <spacer name="horizontalSpacer_21">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QSpinBox" name="spinDownloadRateForSlowTorrents">
+                    <property name="suffix">
+                     <string> KiB/s</string>
+                    </property>
+                    <property name="maximum">
+                     <number>2000000</number>
+                    </property>
+                    <property name="value">
+                     <number>2</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QSpinBox" name="spinUploadRateForSlowTorrents">
+                    <property name="suffix">
+                     <string> KiB/s</string>
+                    </property>
+                    <property name="maximum">
+                     <number>2000000</number>
+                    </property>
+                    <property name="value">
+                     <number>2</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="labelUploadRateForSlowTorrents">
+                    <property name="text">
+                     <string>Upload rate threshold:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="labelDownloadRateForSlowTorrents">
+                    <property name="text">
+                     <string>Download rate threshold:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="3">
+                   <spacer name="horizontalSpacer_9">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item row="1" column="3">
+                   <spacer name="horizontalSpacer_15">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item row="2" column="1">
+                   <widget class="QSpinBox" name="spinSlowTorrentsInactivityTimer">
+                    <property name="minimum">
+                     <number>1</number>
+                    </property>
+                    <property name="maximum">
+                     <number>999999</number>
+                    </property>
+                    <property name="value">
+                     <number>60</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="labelSlowTorrentInactivityTimer">
+                    <property name="text">
+                     <string>Torrent inactivity timer:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="2">
+                   <widget class="QLabel" name="labelSeconds">
+                    <property name="text">
+                     <string>seconds</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
                 </widget>
                </item>
               </layout>
@@ -2772,8 +2886,8 @@
                   <widget class="QLineEdit" name="textWebUiAddress">
                    <property name="toolTip">
                     <string>IP address that the Web UI will bind to.
-Specify an IPv4 or IPv6 address. You can specify "0.0.0.0" for any IPv4 address,
-"::" for any IPv6 address, or "*" for both IPv4 and IPv6.</string>
+Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv4 address,
+&quot;::&quot; for any IPv6 address, or &quot;*&quot; for both IPv4 and IPv6.</string>
                    </property>
                   </widget>
                  </item>
@@ -2984,7 +3098,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="6" column="1" colspan="1">
+                  <item row="6" column="1">
                    <widget class="QPushButton" name="IPSubnetWhitelistButton">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -3266,7 +3380,6 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
   <tabstop>spinMaxActiveDownloads</tabstop>
   <tabstop>spinMaxActiveUploads</tabstop>
   <tabstop>spinMaxActiveTorrents</tabstop>
-  <tabstop>checkIgnoreSlowTorrentsForQueueing</tabstop>
   <tabstop>checkMaxRatio</tabstop>
   <tabstop>spinMaxRatio</tabstop>
   <tabstop>checkMaxSeedingMinutes</tabstop>


### PR DESCRIPTION
[inactive_down_rate
inactive_up_rate](https://www.libtorrent.org/reference-Settings.html#inactive_down_rate)
[auto_manage_startup](https://www.libtorrent.org/reference-Settings.html#auto_manage_startup)

The docs for `auto_manage_startup` don't mention it but AFAIK [it's only used with dont_count_slow_torrents](https://github.com/arvidn/libtorrent/blob/d2e874fca8af9cf9a09f3a9a9080e1e5a66eb974/src/torrent.cpp#L9114)

What i'm worried about is that the labels may not be descriptive enough.

![slowtorrents](https://user-images.githubusercontent.com/6451685/35909352-01a80bea-0bfc-11e8-8973-2a45f29166fa.JPG)
