### PR TITLE
Improve Search handling

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -44,6 +44,9 @@ rss/rss_feed.h
 rss/rss_folder.h
 rss/rss_item.h
 rss/rss_session.h
+search/searchdownloadhandler.h
+search/searchhandler.h
+search/searchpluginmanager.h
 utils/fs.h
 utils/gzip.h
 utils/misc.h
@@ -61,7 +64,6 @@ logger.h
 preferences.h
 profile.h
 scanfoldersmodel.h
-searchengine.h
 settingsstorage.h
 torrentfileguard.h
 torrentfilter.h
@@ -109,6 +111,9 @@ rss/rss_feed.cpp
 rss/rss_folder.cpp
 rss/rss_item.cpp
 rss/rss_session.cpp
+search/searchdownloadhandler.cpp
+search/searchhandler.cpp
+search/searchpluginmanager.cpp
 utils/fs.cpp
 utils/gzip.cpp
 utils/misc.cpp
@@ -123,7 +128,6 @@ logger.cpp
 preferences.cpp
 profile.cpp
 scanfoldersmodel.cpp
-searchengine.cpp
 settingsstorage.cpp
 torrentfileguard.cpp
 torrentfilter.cpp

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -52,7 +52,9 @@ HEADERS += \
     $$PWD/rss/rss_item.h \
     $$PWD/rss/rss_session.h \
     $$PWD/scanfoldersmodel.h \
-    $$PWD/searchengine.h \
+    $$PWD/search/searchhandler.h \
+    $$PWD/search/searchdownloadhandler.h \
+    $$PWD/search/searchpluginmanager.h \
     $$PWD/settingsstorage.h \
     $$PWD/settingvalue.h \
     $$PWD/torrentfileguard.h \
@@ -115,7 +117,9 @@ SOURCES += \
     $$PWD/rss/rss_item.cpp \
     $$PWD/rss/rss_session.cpp \
     $$PWD/scanfoldersmodel.cpp \
-    $$PWD/searchengine.cpp \
+    $$PWD/search/searchdownloadhandler.cpp \
+    $$PWD/search/searchhandler.cpp \
+    $$PWD/search/searchpluginmanager.cpp \
     $$PWD/settingsstorage.cpp \
     $$PWD/torrentfileguard.cpp \
     $$PWD/torrentfilter.cpp \

--- a/src/base/search/searchdownloadhandler.cpp
+++ b/src/base/search/searchdownloadhandler.cpp
@@ -1,0 +1,66 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2018  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "searchdownloadhandler.h"
+
+#include <QProcess>
+
+#include "../utils/fs.h"
+#include "../utils/misc.h"
+#include "searchpluginmanager.h"
+
+SearchDownloadHandler::SearchDownloadHandler(const QString &siteUrl, const QString &url, SearchPluginManager *manager)
+    : QObject {manager}
+    , m_manager {manager}
+    , m_downloadProcess {new QProcess {this}}
+{
+    m_downloadProcess->setEnvironment(QProcess::systemEnvironment());
+    connect(m_downloadProcess, static_cast<void (QProcess::*)(int)>(&QProcess::finished)
+            , this, &SearchDownloadHandler::downloadProcessFinished);
+    const QStringList params {
+        Utils::Fs::toNativePath(m_manager->engineLocation() + "/nova2dl.py"),
+        siteUrl,
+        url
+    };
+    // Launch search
+    m_downloadProcess->start(Utils::Misc::pythonExecutable(), params, QIODevice::ReadOnly);
+}
+
+void SearchDownloadHandler::downloadProcessFinished(int exitcode)
+{
+    QString path;
+
+    if ((exitcode == 0) && (m_downloadProcess->exitStatus() == QProcess::NormalExit)) {
+        const QString line = QString::fromUtf8(m_downloadProcess->readAllStandardOutput()).trimmed();
+        const QVector<QStringRef> parts = line.splitRef(' ');
+        if (parts.size() == 2)
+            path = parts[0].toString();
+    }
+
+    emit downloadFinished(path);
+}

--- a/src/base/search/searchdownloadhandler.h
+++ b/src/base/search/searchdownloadhandler.h
@@ -1,7 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015, 2018  Vladimir Golovnev <glassez@yandex.ru>
- * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
+ * Copyright (C) 2018  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -29,62 +28,26 @@
 
 #pragma once
 
-#include <QList>
-#include <QPointer>
-#include <QWidget>
+#include <QObject>
 
-class QSignalMapper;
-class QTabWidget;
-
-class MainWindow;
+class QProcess;
 class SearchPluginManager;
-class SearchTab;
 
-namespace Ui
-{
-    class SearchWidget;
-}
-
-class SearchWidget : public QWidget
+class SearchDownloadHandler : public QObject
 {
     Q_OBJECT
-    Q_DISABLE_COPY(SearchWidget)
+    Q_DISABLE_COPY(SearchDownloadHandler)
 
-public:
-    explicit SearchWidget(MainWindow *mainWindow);
-    ~SearchWidget() override;
+    friend class SearchPluginManager;
 
-    void giveFocusToSearchInput();
+    SearchDownloadHandler(const QString &siteUrl, const QString &url, SearchPluginManager *manager);
 
-private slots:
-    void on_searchButton_clicked();
-    void on_downloadButton_clicked();
-    void on_goToDescBtn_clicked();
-    void on_copyURLBtn_clicked();
-    void on_pluginsButton_clicked();
+signals:
+    void downloadFinished(const QString &path);
 
 private:
-    void tabChanged(int index);
-    void closeTab(int index);
-    void resultsCountUpdated();
-    void tabStatusChanged(QWidget *tab);
-    void selectMultipleBox(int index);
+    void downloadProcessFinished(int exitcode);
 
-    void fillCatCombobox();
-    void fillPluginComboBox();
-    void selectActivePage();
-    void searchTextEdited(QString);
-    void updateButtons();
-
-    QString selectedCategory() const;
-    QString selectedPlugin() const;
-
-    Ui::SearchWidget *m_ui;
-    SearchPluginManager *m_searchManager;
-    QSignalMapper *m_tabStatusChangedMapper;
-    QPointer<SearchTab> m_currentSearchTab; // Selected tab
-    QPointer<SearchTab> m_activeSearchTab; // Tab with running search
-    QList<SearchTab *> m_allTabs; // To store all tabs
-    MainWindow *m_mainWindow;
-    bool m_isNewQueryString;
+    SearchPluginManager *m_manager;
+    QProcess *m_downloadProcess;
 };

--- a/src/base/search/searchhandler.cpp
+++ b/src/base/search/searchhandler.cpp
@@ -1,0 +1,199 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2015, 2018  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "searchhandler.h"
+
+#include <QProcess>
+#include <QTimer>
+
+#include "../utils/fs.h"
+#include "../utils/misc.h"
+#include "searchpluginmanager.h"
+
+namespace
+{
+    enum SearchResultColumn
+    {
+        PL_DL_LINK,
+        PL_NAME,
+        PL_SIZE,
+        PL_SEEDS,
+        PL_LEECHS,
+        PL_ENGINE_URL,
+        PL_DESC_LINK,
+        NB_PLUGIN_COLUMNS
+    };
+}
+
+SearchHandler::SearchHandler(const QString &pattern, const QString &category, const QStringList &usedPlugins, SearchPluginManager *manager)
+    : QObject {manager}
+    , m_pattern {pattern}
+    , m_category {category}
+    , m_usedPlugins {usedPlugins}
+    , m_manager {manager}
+    , m_searchProcess {new QProcess {this}}
+    , m_searchTimeout {new QTimer {this}}
+{
+    // Load environment variables (proxy)
+    m_searchProcess->setEnvironment(QProcess::systemEnvironment());
+
+    const QStringList params {
+        Utils::Fs::toNativePath(m_manager->engineLocation() + "/nova2.py"),
+        m_usedPlugins.join(","),
+        m_category
+    };
+
+    // Launch search
+    m_searchProcess->setProgram(Utils::Misc::pythonExecutable());
+    m_searchProcess->setArguments(params + m_pattern.split(" "));
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+    connect(m_searchProcess, &QProcess::errorOccurred, this, &SearchHandler::processFailed);
+#else
+    connect(m_searchProcess, static_cast<void(QProcess::*)(QProcess::ProcessError)>(&QProcess::error)
+            , this, &SearchHandler::processFailed);
+#endif
+    connect(m_searchProcess, &QProcess::readyReadStandardOutput, this, &SearchHandler::readSearchOutput);
+    connect(m_searchProcess, static_cast<void (QProcess::*)(int)>(&QProcess::finished)
+            , this, &SearchHandler::processFinished);
+
+    m_searchTimeout->setSingleShot(true);
+    connect(m_searchTimeout, &QTimer::timeout, this, &SearchHandler::cancelSearch);
+    m_searchTimeout->start(180000); // 3 min
+
+    // deferred start allows clients to handle starting-related signals
+    QTimer::singleShot(0, this, [this]() { m_searchProcess->start(QIODevice::ReadOnly); });
+}
+
+bool SearchHandler::isActive() const
+{
+    return (m_searchProcess->state() != QProcess::NotRunning);
+}
+
+void SearchHandler::cancelSearch()
+{
+    if ((m_searchProcess->state() == QProcess::NotRunning) || m_searchCancelled)
+        return;
+
+#ifdef Q_OS_WIN
+    m_searchProcess->kill();
+#else
+    m_searchProcess->terminate();
+#endif
+    m_searchCancelled = true;
+    m_searchTimeout->stop();
+}
+
+// Slot called when QProcess is Finished
+// QProcess can be finished for 3 reasons:
+// Error | Stopped by user | Finished normally
+void SearchHandler::processFinished(int exitcode)
+{
+    m_searchTimeout->stop();
+
+    if (m_searchCancelled)
+        emit searchFinished(true);
+    else if ((m_searchProcess->exitStatus() == QProcess::NormalExit) && (exitcode == 0))
+        emit searchFinished(false);
+    else
+        emit searchFailed();
+}
+
+// search QProcess return output as soon as it gets new
+// stuff to read. We split it into lines and parse each
+// line to SearchResult calling parseSearchResult().
+void SearchHandler::readSearchOutput()
+{
+    QByteArray output = m_searchProcess->readAllStandardOutput();
+    output.replace("\r", "");
+    QList<QByteArray> lines = output.split('\n');
+    if (!m_searchResultLineTruncated.isEmpty())
+        lines.prepend(m_searchResultLineTruncated + lines.takeFirst());
+    m_searchResultLineTruncated = lines.takeLast().trimmed();
+
+    QList<SearchResult> searchResultList;
+    foreach (const QByteArray &line, lines) {
+        SearchResult searchResult;
+        if (parseSearchResult(QString::fromUtf8(line), searchResult))
+            searchResultList << searchResult;
+    }
+
+    if (!searchResultList.isEmpty()) {
+        m_results.append(searchResultList);
+        emit newSearchResults(searchResultList);
+    }
+}
+
+void SearchHandler::processFailed()
+{
+    if (!m_searchCancelled)
+        emit searchFailed();
+}
+
+// Parse one line of search results list
+// Line is in the following form:
+// file url | file name | file size | nb seeds | nb leechers | Search engine url
+bool SearchHandler::parseSearchResult(const QString &line, SearchResult &searchResult)
+{
+    const QStringList parts = line.split("|");
+    const int nbFields = parts.size();
+    if (nbFields < (NB_PLUGIN_COLUMNS - 1)) return false; // -1 because desc_link is optional
+
+    searchResult = SearchResult();
+    searchResult.fileUrl = parts.at(PL_DL_LINK).trimmed(); // download URL
+    searchResult.fileName = parts.at(PL_NAME).trimmed(); // Name
+    searchResult.fileSize = parts.at(PL_SIZE).trimmed().toLongLong(); // Size
+    bool ok = false;
+    searchResult.nbSeeders = parts.at(PL_SEEDS).trimmed().toLongLong(&ok); // Seeders
+    if (!ok || (searchResult.nbSeeders < 0))
+        searchResult.nbSeeders = -1;
+    searchResult.nbLeechers = parts.at(PL_LEECHS).trimmed().toLongLong(&ok); // Leechers
+    if (!ok || (searchResult.nbLeechers < 0))
+        searchResult.nbLeechers = -1;
+    searchResult.siteUrl = parts.at(PL_ENGINE_URL).trimmed(); // Search site URL
+    if (nbFields == NB_PLUGIN_COLUMNS)
+        searchResult.descrLink = parts.at(PL_DESC_LINK).trimmed(); // Description Link
+
+    return true;
+}
+
+SearchPluginManager *SearchHandler::manager() const
+{
+    return m_manager;
+}
+
+QList<SearchResult> SearchHandler::results() const
+{
+    return m_results;
+}
+
+QString SearchHandler::pattern() const
+{
+    return m_pattern;
+}

--- a/src/base/search/searchhandler.h
+++ b/src/base/search/searchhandler.h
@@ -29,62 +29,62 @@
 
 #pragma once
 
+#include <QByteArray>
 #include <QList>
-#include <QPointer>
-#include <QWidget>
+#include <QObject>
 
-class QSignalMapper;
-class QTabWidget;
+class QProcess;
+class QTimer;
 
-class MainWindow;
-class SearchPluginManager;
-class SearchTab;
-
-namespace Ui
+struct SearchResult
 {
-    class SearchWidget;
-}
+    QString fileName;
+    QString fileUrl;
+    qlonglong fileSize;
+    qlonglong nbSeeders;
+    qlonglong nbLeechers;
+    QString siteUrl;
+    QString descrLink;
+};
 
-class SearchWidget : public QWidget
+class SearchPluginManager;
+
+class SearchHandler : public QObject
 {
     Q_OBJECT
-    Q_DISABLE_COPY(SearchWidget)
+    Q_DISABLE_COPY(SearchHandler)
+
+    friend class SearchPluginManager;
+
+    SearchHandler(const QString &pattern, const QString &category
+                  , const QStringList &usedPlugins, SearchPluginManager *manager);
 
 public:
-    explicit SearchWidget(MainWindow *mainWindow);
-    ~SearchWidget() override;
+    bool isActive() const;
+    QString pattern() const;
+    SearchPluginManager *manager() const;
+    QList<SearchResult> results() const;
 
-    void giveFocusToSearchInput();
+    void cancelSearch();
 
-private slots:
-    void on_searchButton_clicked();
-    void on_downloadButton_clicked();
-    void on_goToDescBtn_clicked();
-    void on_copyURLBtn_clicked();
-    void on_pluginsButton_clicked();
+signals:
+    void searchFinished(bool cancelled = false);
+    void searchFailed();
+    void newSearchResults(const QList<SearchResult> &results);
 
 private:
-    void tabChanged(int index);
-    void closeTab(int index);
-    void resultsCountUpdated();
-    void tabStatusChanged(QWidget *tab);
-    void selectMultipleBox(int index);
+    void readSearchOutput();
+    void processFailed();
+    void processFinished(int exitcode);
+    bool parseSearchResult(const QString &line, SearchResult &searchResult);
 
-    void fillCatCombobox();
-    void fillPluginComboBox();
-    void selectActivePage();
-    void searchTextEdited(QString);
-    void updateButtons();
-
-    QString selectedCategory() const;
-    QString selectedPlugin() const;
-
-    Ui::SearchWidget *m_ui;
-    SearchPluginManager *m_searchManager;
-    QSignalMapper *m_tabStatusChangedMapper;
-    QPointer<SearchTab> m_currentSearchTab; // Selected tab
-    QPointer<SearchTab> m_activeSearchTab; // Tab with running search
-    QList<SearchTab *> m_allTabs; // To store all tabs
-    MainWindow *m_mainWindow;
-    bool m_isNewQueryString;
+    const QString m_pattern;
+    const QString m_category;
+    const QStringList m_usedPlugins;
+    SearchPluginManager *m_manager;
+    QProcess *m_searchProcess;
+    QTimer *m_searchTimeout;
+    QByteArray m_searchResultLineTruncated;
+    bool m_searchCancelled = false;
+    QList<SearchResult> m_results;
 };

--- a/src/base/search/searchpluginmanager.h
+++ b/src/base/search/searchpluginmanager.h
@@ -61,6 +61,8 @@ public:
     SearchPluginManager();
     ~SearchPluginManager() override;
 
+    static SearchPluginManager *instance();
+
     QStringList allPlugins() const;
     QStringList enabledPlugins() const;
     QStringList supportedCategories() const;
@@ -107,6 +109,7 @@ private:
 
     static QString pluginPath(const QString &name);
 
+    static QPointer<SearchPluginManager> m_instance;
     static const QHash<QString, QString> m_categoryNames;
 
     const QString m_updateUrl;

--- a/src/base/search/searchpluginmanager.h
+++ b/src/base/search/searchpluginmanager.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2015, 2018  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
@@ -27,18 +27,13 @@
  * exception statement from your version.
  */
 
-#ifndef SEARCHENGINE_H
-#define SEARCHENGINE_H
+#pragma once
 
 #include <QHash>
-#include <QList>
 #include <QMetaType>
 #include <QObject>
 
 #include "base/utils/version.h"
-
-class QProcess;
-class QTimer;
 
 using PluginVersion = Utils::Version<unsigned short, 2>;
 Q_DECLARE_METATYPE(PluginVersion)
@@ -54,31 +49,22 @@ struct PluginInfo
     bool enabled;
 };
 
-struct SearchResult
-{
-    QString fileName;
-    QString fileUrl;
-    qlonglong fileSize;
-    qlonglong nbSeeders;
-    qlonglong nbLeechers;
-    QString siteUrl;
-    QString descrLink;
-};
+class SearchDownloadHandler;
+class SearchHandler;
 
-class SearchEngine: public QObject
+class SearchPluginManager : public QObject
 {
     Q_OBJECT
+    Q_DISABLE_COPY(SearchPluginManager)
 
 public:
-    SearchEngine();
-    ~SearchEngine();
+    SearchPluginManager();
+    ~SearchPluginManager() override;
 
     QStringList allPlugins() const;
     QStringList enabledPlugins() const;
     QStringList supportedCategories() const;
     PluginInfo *pluginInfo(const QString &name) const;
-
-    bool isActive() const;
 
     void enablePlugin(const QString &name, bool enabled = true);
     void updatePlugin(const QString &name);
@@ -87,22 +73,16 @@ public:
     static void updateIconPath(PluginInfo * const plugin);
     void checkForUpdates();
 
-    void startSearch(const QString &pattern, const QString &category, const QStringList &usedPlugins);
-    void cancelSearch();
-
-    void downloadTorrent(const QString &siteUrl, const QString &url);
+    SearchHandler *startSearch(const QString &pattern, const QString &category, const QStringList &usedPlugins);
+    SearchDownloadHandler *downloadTorrent(const QString &siteUrl, const QString &url);
 
     static PluginVersion getPluginVersion(QString filePath);
     static QString categoryFullName(const QString &categoryName);
     QString pluginFullName(const QString &pluginName);
     static QString pluginsLocation();
+    static QString engineLocation();
 
 signals:
-    void searchStarted();
-    void searchFinished(bool cancelled);
-    void searchFailed();
-    void newSearchResults(const QList<SearchResult> &results);
-
     void pluginEnabled(const QString &name, bool enabled);
     void pluginInstalled(const QString &name);
     void pluginInstallationFailed(const QString &name, const QString &reason);
@@ -113,40 +93,23 @@ signals:
     void checkForUpdatesFinished(const QHash<QString, PluginVersion> &updateInfo);
     void checkForUpdatesFailed(const QString &reason);
 
-    void torrentFileDownloaded(const QString &path);
-
-private slots:
-    void onTimeout();
-    void readSearchOutput();
-    void processFinished(int exitcode);
-    void versionInfoDownloaded(const QString &url, const QByteArray &data);
-    void versionInfoDownloadFailed(const QString &url, const QString &reason);
-    void pluginDownloaded(const QString &url, QString filePath);
-    void pluginDownloadFailed(const QString &url, const QString &reason);
-    void torrentFileDownloadFinished(int exitcode);
-
 private:
     void update();
     void updateNova();
-    bool parseSearchResult(const QString &line, SearchResult &searchResult);
     void parseVersionInfo(const QByteArray &info);
     void installPlugin_impl(const QString &name, const QString &path);
     bool isUpdateNeeded(QString pluginName, PluginVersion newVersion) const;
 
-    static QString engineLocation();
+    void versionInfoDownloaded(const QString &url, const QByteArray &data);
+    void versionInfoDownloadFailed(const QString &url, const QString &reason);
+    void pluginDownloaded(const QString &url, QString filePath);
+    void pluginDownloadFailed(const QString &url, const QString &reason);
+
     static QString pluginPath(const QString &name);
-    static QHash<QString, QString> initializeCategoryNames();
 
     static const QHash<QString, QString> m_categoryNames;
 
     const QString m_updateUrl;
 
     QHash<QString, PluginInfo*> m_plugins;
-    QProcess *m_searchProcess;
-    bool m_searchStopped;
-    QTimer *m_searchTimeout;
-    QByteArray m_searchResultLineTruncated;
-    QList<QProcess*> m_downloaders;
 };
-
-#endif // SEARCHENGINE_H

--- a/src/gui/search/pluginselectdlg.cpp
+++ b/src/gui/search/pluginselectdlg.cpp
@@ -61,7 +61,7 @@ enum PluginColumns
     PLUGIN_ID
 };
 
-PluginSelectDlg::PluginSelectDlg(SearchEngine *pluginManager, QWidget *parent)
+PluginSelectDlg::PluginSelectDlg(SearchPluginManager *pluginManager, QWidget *parent)
     : QDialog(parent)
     , m_ui(new Ui::PluginSelectDlg())
     , m_pluginManager(pluginManager)
@@ -90,12 +90,12 @@ PluginSelectDlg::PluginSelectDlg(SearchEngine *pluginManager, QWidget *parent)
 
     loadSupportedSearchPlugins();
 
-    connect(m_pluginManager, &SearchEngine::pluginInstalled, this, &PluginSelectDlg::pluginInstalled);
-    connect(m_pluginManager, &SearchEngine::pluginInstallationFailed, this, &PluginSelectDlg::pluginInstallationFailed);
-    connect(m_pluginManager, &SearchEngine::pluginUpdated, this, &PluginSelectDlg::pluginUpdated);
-    connect(m_pluginManager, &SearchEngine::pluginUpdateFailed, this, &PluginSelectDlg::pluginUpdateFailed);
-    connect(m_pluginManager, &SearchEngine::checkForUpdatesFinished, this, &PluginSelectDlg::checkForUpdatesFinished);
-    connect(m_pluginManager, &SearchEngine::checkForUpdatesFailed, this, &PluginSelectDlg::checkForUpdatesFailed);
+    connect(m_pluginManager, &SearchPluginManager::pluginInstalled, this, &PluginSelectDlg::pluginInstalled);
+    connect(m_pluginManager, &SearchPluginManager::pluginInstallationFailed, this, &PluginSelectDlg::pluginInstallationFailed);
+    connect(m_pluginManager, &SearchPluginManager::pluginUpdated, this, &PluginSelectDlg::pluginUpdated);
+    connect(m_pluginManager, &SearchPluginManager::pluginUpdateFailed, this, &PluginSelectDlg::pluginUpdateFailed);
+    connect(m_pluginManager, &SearchPluginManager::checkForUpdatesFinished, this, &PluginSelectDlg::checkForUpdatesFinished);
+    connect(m_pluginManager, &SearchPluginManager::checkForUpdatesFailed, this, &PluginSelectDlg::checkForUpdatesFailed);
 
     Utils::Gui::resize(this);
     show();
@@ -387,7 +387,7 @@ void PluginSelectDlg::iconDownloaded(const QString &url, QString filePath)
             if (!plugin) continue;
 
             QString iconPath = QString("%1/%2.%3")
-                               .arg(SearchEngine::pluginsLocation())
+                               .arg(SearchPluginManager::pluginsLocation())
                                .arg(id)
                                .arg(url.endsWith(".ico", Qt::CaseInsensitive) ? "ico" : "png");
             if (QFile::copy(filePath, iconPath)) {

--- a/src/gui/search/pluginselectdlg.h
+++ b/src/gui/search/pluginselectdlg.h
@@ -34,7 +34,7 @@
 
 #include <QDialog>
 
-#include "base/searchengine.h"
+#include "base/search/searchpluginmanager.h"
 
 class QDropEvent;
 class QStringList;
@@ -50,7 +50,7 @@ class PluginSelectDlg: public QDialog
     Q_OBJECT
 
 public:
-    explicit PluginSelectDlg(SearchEngine *pluginManager, QWidget *parent = 0);
+    explicit PluginSelectDlg(SearchPluginManager *pluginManager, QWidget *parent = 0);
     ~PluginSelectDlg();
 
     QList<QTreeWidgetItem*> findItemsWithUrl(QString url);
@@ -89,7 +89,7 @@ private:
     void finishPluginUpdate();
 
     Ui::PluginSelectDlg *m_ui;
-    SearchEngine *m_pluginManager;
+    SearchPluginManager *m_pluginManager;
     QStringList m_updatedPlugins;
     int m_asyncOps;
     int m_pendingUpdates;

--- a/src/gui/search/searchwidget.h
+++ b/src/gui/search/searchwidget.h
@@ -37,7 +37,6 @@ class QSignalMapper;
 class QTabWidget;
 
 class MainWindow;
-class SearchPluginManager;
 class SearchTab;
 
 namespace Ui
@@ -80,7 +79,6 @@ private:
     QString selectedPlugin() const;
 
     Ui::SearchWidget *m_ui;
-    SearchPluginManager *m_searchManager;
     QSignalMapper *m_tabStatusChangedMapper;
     QPointer<SearchTab> m_currentSearchTab; // Selected tab
     QPointer<SearchTab> m_activeSearchTab; // Tab with running search


### PR DESCRIPTION
Legacy SearchEngine class really has three roles:
  1. Manage search plugins,
  2. Handle the search job, and
  3. Handle the download of the torrent file using the search plugin.
Now it is splitted into 3 classes: SearchManager, SearchHandler and SearchDownloadHandler.

Search GUI is also improved.

Make SearchManager singleton to be accessible from different UI.
NOTE: in GUI application SearchManager instance is still created legacy way. This behavior will be changed later when I complete some other research on the application core.