### PR TITLE
Don't use qDeleteAll() on temporaries

### DIFF
--- a/src/base/searchengine.cpp
+++ b/src/base/searchengine.cpp
@@ -84,7 +84,7 @@ SearchEngine::SearchEngine()
 
 SearchEngine::~SearchEngine()
 {
-    qDeleteAll(m_plugins.values());
+    qDeleteAll(m_plugins);
     cancelSearch();
 }
 

--- a/src/gui/properties/trackerlist.cpp
+++ b/src/gui/properties/trackerlist.cpp
@@ -234,7 +234,7 @@ void TrackerList::moveSelectionDown()
 
 void TrackerList::clear()
 {
-    qDeleteAll(m_trackerItems.values());
+    qDeleteAll(m_trackerItems);
     m_trackerItems.clear();
     m_DHTItem->setText(COL_STATUS, "");
     m_DHTItem->setText(COL_SEEDS, "");


### PR DESCRIPTION
qDeleteAll() is being used on an unnecessary temporary container created
by QHash::values().
Using qDeleteAll(mycontainer) instead.