### PR TITLE
Fix compilation with Qt 5.11 on macOS

### DIFF
--- a/src/gui/hidabletabwidget.h
+++ b/src/gui/hidabletabwidget.h
@@ -34,6 +34,10 @@
 #include <QTabWidget>
 #include <QTabBar>
 
+#ifdef Q_OS_MAC
+#include <QStyle>
+#endif
+
 class HidableTabWidget : public QTabWidget
 {
 public:


### PR DESCRIPTION
Looks like I forgot to include a header in the past, and it bugs us now.