### PR TITLE
Don't create temporary substrings

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -401,7 +401,7 @@ void Application::processParams(const QStringList &params)
         }
 
         if (param.startsWith(QLatin1String("@addPaused="))) {
-            torrentParams.addPaused = param.mid(11).toInt() ? TriStateBool::True : TriStateBool::False;
+            torrentParams.addPaused = param.midRef(11).toInt() ? TriStateBool::True : TriStateBool::False;
             continue;
         }
 
@@ -426,7 +426,7 @@ void Application::processParams(const QStringList &params)
         }
 
         if (param.startsWith(QLatin1String("@skipDialog="))) {
-            skipTorrentDialog = param.mid(12).toInt() ? TriStateBool::True : TriStateBool::False;
+            skipTorrentDialog = param.midRef(12).toInt() ? TriStateBool::True : TriStateBool::False;
             continue;
         }
 

--- a/src/base/rss/rss_autodownloadrule.cpp
+++ b/src/base/rss/rss_autodownloadrule.cpp
@@ -302,7 +302,7 @@ bool AutoDownloadRule::matches(const QString &articleTitle) const
                 QRegularExpression reg(cachedRegex(partialPattern1));
 
                 if (ep.endsWith('-')) { // Infinite range
-                    int epOurs = ep.left(ep.size() - 1).toInt();
+                    int epOurs = ep.leftRef(ep.size() - 1).toInt();
 
                     // Extract partial match from article and compare as digits
                     matcher = reg.match(articleTitle);


### PR DESCRIPTION
Avoid temporary allocations.
QString::xxxRef() returns a QStringRef. QStringRef avoids the memory
allocation and reference counting overhead of a standard QString by simply
referencing a part of the original string.