### PR TITLE
Fix possible crash when using both share limits

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1788,6 +1788,7 @@ void Session::processShareLimits()
                             torrent->pause();
                             logger->addMessage(tr("'%1' reached the maximum ratio you set. Paused.").arg(torrent->name()));
                         }
+                        continue;
                     }
                 }
             }


### PR DESCRIPTION
It also prevents unnecessary parsing, no need to (possibly) pause|delete twice.

I managed to reproduce the crash (sometimes) by having a torrent exceed my chosen ratio _and_ seeding time and then i chose the `Remove them` option to delete the torrent. The log showed the "torrent removed" messages for both ratio and seeding time (the times it didn't crash).
My observation is that the larger the torrent, the higher the chance to crash. Actually i don't think i managed to get a torrent to crash that is a few MB size (files), it just constantly replaced the first 8 chars of the torrent name with gibberish in the log msg of removal for seeding time... in linux. Couldn't reproduce this "8-char" in the official 4.0.4 Win.  

Fixes #7692 Fixes #7935 Fixes #8206 Fixes #8329 Fixes #8376 Fixes #8473 
