### PR TITLE
Move suffix-labels inside the corresponding spinboxes

### DIFF
--- a/src/gui/optionsdlg.ui
+++ b/src/gui/optionsdlg.ui
@@ -1774,6 +1774,9 @@
                  <property name="enabled">
                   <bool>false</bool>
                  </property>
+                 <property name="suffix">
+                  <string> KiB/s</string>
+                 </property>
                  <property name="minimum">
                   <number>1</number>
                  </property>
@@ -1792,17 +1795,13 @@
                  </property>
                 </widget>
                </item>
-               <item row="0" column="3">
-                <widget class="QLabel" name="label_10">
-                 <property name="text">
-                  <string>KiB/s</string>
-                 </property>
-                </widget>
-               </item>
                <item row="1" column="2">
                 <widget class="QSpinBox" name="spinDownloadLimit">
                  <property name="enabled">
                   <bool>false</bool>
+                 </property>
+                 <property name="suffix">
+                  <string> KiB/s</string>
                  </property>
                  <property name="minimum">
                   <number>1</number>
@@ -1812,13 +1811,6 @@
                  </property>
                  <property name="value">
                   <number>100</number>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="3">
-                <widget class="QLabel" name="label_13">
-                 <property name="text">
-                  <string>KiB/s</string>
                  </property>
                 </widget>
                </item>
@@ -1832,7 +1824,7 @@
                  </property>
                 </widget>
                </item>
-               <item row="0" column="4">
+               <item row="0" column="3">
                 <spacer name="horizontalSpacer">
                  <property name="orientation">
                   <enum>Qt::Horizontal</enum>
@@ -1854,7 +1846,10 @@
                <string>Alternative Rate Limits</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_6">
-               <item row="2" column="0" colspan="5">
+               <item row="0" column="0" rowspan="2">
+                <widget class="QLabel" name="labelAltRate"/>
+               </item>
+               <item row="2" column="0" colspan="4">
                 <widget class="QGroupBox" name="check_schedule">
                  <property name="title">
                   <string>Schedule &amp;the use of alternative rate limits</string>
@@ -1965,9 +1960,6 @@
                  </layout>
                 </widget>
                </item>
-               <item row="0" column="0" rowspan="2">
-                <widget class="QLabel" name="labelAltRate"/>
-               </item>
                <item row="0" column="1">
                 <widget class="QCheckBox" name="checkUploadLimitAlt">
                  <property name="text">
@@ -1987,6 +1979,9 @@
                  <property name="enabled">
                   <bool>false</bool>
                  </property>
+                 <property name="suffix">
+                  <string> KiB/s</string>
+                 </property>
                  <property name="minimum">
                   <number>1</number>
                  </property>
@@ -2003,6 +1998,9 @@
                  <property name="enabled">
                   <bool>false</bool>
                  </property>
+                 <property name="suffix">
+                  <string> KiB/s</string>
+                 </property>
                  <property name="minimum">
                   <number>1</number>
                  </property>
@@ -2015,20 +2013,6 @@
                 </widget>
                </item>
                <item row="0" column="3">
-                <widget class="QLabel" name="label_14">
-                 <property name="text">
-                  <string>KiB/s</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="3">
-                <widget class="QLabel" name="label_15">
-                 <property name="text">
-                  <string>KiB/s</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="4">
                 <spacer name="horizontalSpacer_5">
                  <property name="orientation">
                   <enum>Qt::Horizontal</enum>

--- a/src/gui/optionsdlg.ui
+++ b/src/gui/optionsdlg.ui
@@ -2357,7 +2357,7 @@
                   <bool>false</bool>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_13">
-                  <item row="2" column="3">
+                  <item row="2" column="2">
                    <spacer name="horizontalSpacer_21">
                     <property name="orientation">
                      <enum>Qt::Horizontal</enum>
@@ -2410,7 +2410,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="0" column="3">
+                  <item row="0" column="2">
                    <spacer name="horizontalSpacer_9">
                     <property name="orientation">
                      <enum>Qt::Horizontal</enum>
@@ -2423,7 +2423,7 @@
                     </property>
                    </spacer>
                   </item>
-                  <item row="1" column="3">
+                  <item row="1" column="2">
                    <spacer name="horizontalSpacer_15">
                     <property name="orientation">
                      <enum>Qt::Horizontal</enum>
@@ -2438,6 +2438,9 @@
                   </item>
                   <item row="2" column="1">
                    <widget class="QSpinBox" name="spinSlowTorrentsInactivityTimer">
+                    <property name="suffix">
+                     <string extracomment="seconds"> sec</string>
+                    </property>
                     <property name="minimum">
                      <number>1</number>
                     </property>
@@ -2453,13 +2456,6 @@
                    <widget class="QLabel" name="labelSlowTorrentInactivityTimer">
                     <property name="text">
                      <string>Torrent inactivity timer:</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="2">
-                   <widget class="QLabel" name="labelSeconds">
-                    <property name="text">
-                     <string>seconds</string>
                     </property>
                    </widget>
                   </item>
@@ -2503,23 +2499,6 @@
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
-                </widget>
-               </item>
-               <item row="4" column="4" colspan="2">
-                <widget class="QComboBox" name="comboRatioLimitAct">
-                 <property name="enabled">
-                  <bool>false</bool>
-                 </property>
-                 <item>
-                  <property name="text">
-                   <string>Pause them</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>Remove them</string>
-                  </property>
-                 </item>
                 </widget>
                </item>
                <item row="4" column="6">
@@ -2569,6 +2548,9 @@
                  <property name="alignment">
                   <set>Qt::AlignCenter</set>
                  </property>
+                 <property name="suffix">
+                  <string extracomment="minutes"> min</string>
+                 </property>
                  <property name="maximum">
                   <number>9999999</number>
                  </property>
@@ -2599,18 +2581,28 @@
                  </property>
                 </widget>
                </item>
-               <item row="3" column="5">
-                <widget class="QLabel" name="label_11">
-                 <property name="text">
-                  <string>minutes</string>
-                 </property>
-                </widget>
-               </item>
                <item row="3" column="0" colspan="4">
                 <widget class="QCheckBox" name="checkMaxSeedingMinutes">
                  <property name="text">
                   <string>Seed torrents until their seeding time reaches</string>
                  </property>
+                </widget>
+               </item>
+               <item row="4" column="4">
+                <widget class="QComboBox" name="comboRatioLimitAct">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <item>
+                  <property name="text">
+                   <string>Pause them</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Remove them</string>
+                  </property>
+                 </item>
                 </widget>
                </item>
               </layout>

--- a/src/gui/optionsdlg.ui
+++ b/src/gui/optionsdlg.ui
@@ -2372,7 +2372,7 @@
                  <property name="checked">
                   <bool>false</bool>
                  </property>
-                 <layout class="QGridLayout" name="gridLayout_8">
+                 <layout class="QGridLayout" name="gridLayout_13">
                   <item row="2" column="3">
                    <spacer name="horizontalSpacer_21">
                     <property name="orientation">


### PR DESCRIPTION
![capture2](https://user-images.githubusercontent.com/6451685/36632635-483309aa-1991-11e8-8f7e-82c3697e3ff9.JPG)

Let me know if you think the layout name change doesn't deserve a whole commit.