### PR TITLE
Fix for "Content" panel messed up

### DIFF
--- a/src/gui/torrentcontenttreeview.cpp
+++ b/src/gui/torrentcontenttreeview.cpp
@@ -43,6 +43,7 @@ TorrentContentTreeView::TorrentContentTreeView(QWidget *parent)
     QTableView unused;
     unused.setVerticalHeader(header());
     header()->setParent(this);
+    header()->setStretchLastSection(false);
     unused.setVerticalHeader(new QHeaderView(Qt::Horizontal));
 }
 


### PR DESCRIPTION
New QT implementation of QHeaderView is rewritten in 5.10.1 and behaves differently on the property StretchLastSection (true by default).
Setting that property to false while creating the new (unused) QHeaderView for "Content" window solve the issue #8439.