### PR TITLE
Add esc as minimize hotkey for windows and linux

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -874,8 +874,10 @@ void MainWindow::createKeyboardShortcuts()
     m_ui->actionTopPriority->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_Plus);
 #ifdef Q_OS_MAC
     m_ui->actionMinimize->setShortcut(Qt::CTRL + Qt::Key_M);
-    addAction(m_ui->actionMinimize);
+#else
+    m_ui->actionMinimize->setShortcut(Qt::Key_Escape);
 #endif
+    addAction(m_ui->actionMinimize);
 }
 
 // Keyboard shortcuts slots

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1058,7 +1058,7 @@ void MainWindow::toggleVisibility(const QSystemTrayIcon::ActivationReason reason
                 return;
 
             // Make sure the window is not minimized
-            setWindowState((windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
+            setWindowState((windowState() & ~Qt::WindowMinimized) & Qt::WindowActive);
 
             // Then show it
             show();


### PR DESCRIPTION
About the second commit: When i set a hotkey (any hotkey) inside qbt for minimize, using that hotkey after qbt has been restored from tray once, it un-minimizes the qbt window for the rest of the session. This change doesn't seem to cause any problems and fixes the problem mentioned above.

People want this in #6880. 