### PR TITLE
Parse URL query string at application level

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -47,6 +47,7 @@ rss/rss_session.h
 search/searchdownloadhandler.h
 search/searchhandler.h
 search/searchpluginmanager.h
+utils/bytearray.h
 utils/fs.h
 utils/gzip.h
 utils/misc.h
@@ -114,6 +115,7 @@ rss/rss_session.cpp
 search/searchdownloadhandler.cpp
 search/searchhandler.cpp
 search/searchpluginmanager.cpp
+utils/bytearray.cpp
 utils/fs.cpp
 utils/gzip.cpp
 utils/misc.cpp

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -62,6 +62,7 @@ HEADERS += \
     $$PWD/tristatebool.h \
     $$PWD/types.h \
     $$PWD/unicodestrings.h \
+    $$PWD/utils/bytearray.h \
     $$PWD/utils/fs.h \
     $$PWD/utils/gzip.h \
     $$PWD/utils/misc.h \
@@ -124,6 +125,7 @@ SOURCES += \
     $$PWD/torrentfileguard.cpp \
     $$PWD/torrentfilter.cpp \
     $$PWD/tristatebool.cpp \
+    $$PWD/utils/bytearray.cpp \
     $$PWD/utils/fs.cpp \
     $$PWD/utils/gzip.cpp \
     $$PWD/utils/misc.cpp \

--- a/src/base/bittorrent/tracker.h
+++ b/src/base/bittorrent/tracker.h
@@ -52,7 +52,7 @@ namespace BitTorrent
     struct Peer
     {
         QString ip;
-        QString peerId;
+        QByteArray peerId;
         int port;
 
         bool operator!=(const Peer &other) const;
@@ -63,7 +63,7 @@ namespace BitTorrent
 
     struct TrackerAnnounceRequest
     {
-        QString infoHash;
+        QByteArray infoHash;
         QString event;
         int numwant;
         Peer peer;
@@ -72,7 +72,7 @@ namespace BitTorrent
     };
 
     typedef QHash<QString, Peer> PeerList;
-    typedef QHash<QString, PeerList> TorrentList;
+    typedef QHash<QByteArray, PeerList> TorrentList;
 
     /* Basic Bittorrent tracker implementation in Qt */
     /* Following http://wiki.theory.org/BitTorrent_Tracker_Protocol */

--- a/src/base/http/types.h
+++ b/src/base/http/types.h
@@ -98,8 +98,8 @@ namespace Http
         QString version;
         QString method;
         QString path;
+        QByteArray query;
         QStringMap headers;
-        QStringMap gets;
         QStringMap posts;
         QVector<UploadedFile> files;
     };

--- a/src/base/utils/bytearray.cpp
+++ b/src/base/utils/bytearray.cpp
@@ -1,0 +1,65 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2018  Mike Tzou (Chocobo1)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "bytearray.h"
+#include <QList>
+
+QList<QByteArray> Utils::ByteArray::splitToViews(const QByteArray &in, const QByteArray &sep, const QString::SplitBehavior behavior)
+{
+    if (sep.isEmpty())
+        return {in};
+
+    QList<QByteArray> ret;
+
+    int head = 0;
+    while (head < in.size()) {
+        int end = in.indexOf(sep, head);
+        if (end < 0)
+            end = in.size();
+
+        // omit empty parts
+        const QByteArray part = QByteArray::fromRawData((in.constData() + head), (end - head));
+        if (!part.isEmpty() || (behavior == QString::KeepEmptyParts))
+            ret += part;
+
+        head = end + sep.size();
+    }
+
+    return ret;
+}
+
+const QByteArray Utils::ByteArray::midView(const QByteArray &in, const int pos, const int len)
+{
+    if ((pos < 0) || (pos >= in.size()) || (len == 0))
+        return {};
+
+    const int validLen = ((len < 0) || (pos + len) >= in.size())
+            ? in.size() - pos
+            : len;
+    return QByteArray::fromRawData(in.constData() + pos, validLen);
+}

--- a/src/base/utils/bytearray.h
+++ b/src/base/utils/bytearray.h
@@ -1,0 +1,45 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2018  Mike Tzou (Chocobo1)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+#include <QByteArray>
+#include <QString>
+
+namespace Utils
+{
+    namespace ByteArray
+    {
+        // Mimic QString::split(sep, behavior)
+        QList<QByteArray> splitToViews(const QByteArray &in, const QByteArray &sep, const QString::SplitBehavior behavior = QString::KeepEmptyParts);
+
+        // Mimic QByteArray::mid(pos, len) but instead of returning a full-copy,
+        // we only return a partial view
+        const QByteArray midView(const QByteArray &in, const int pos, const int len = -1);
+    }
+}

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -124,6 +124,7 @@ private:
     WebSession *m_currentSession = nullptr;
     Http::Request m_request;
     Http::Environment m_env;
+    QMap<QString, QString> m_params;
 
     const QRegularExpression m_apiPathPattern {(QLatin1String("^/api/v2/(?<scope>[A-Za-z_][A-Za-z_0-9]*)/(?<action>[A-Za-z_][A-Za-z_0-9]*)$"))};
     const QRegularExpression m_apiLegacyPathPattern {QLatin1String("^/(?<action>((sync|command|query)/[A-Za-z_][A-Za-z_0-9]*|login|logout))(/(?<hash>[^/]+))?$")};


### PR DESCRIPTION
The exact structure of the query string is not standardised (it's not part of HTTP). So it should be parsed at (web-)application level. Different web applications can expect different data format there.
This patch should fix Embedded Tracker.