### PR TITLE
Fix warnings from linters

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -283,7 +283,7 @@ void Application::runExternalProgram(BitTorrent::TorrentHandle *const torrent) c
     program.replace("%I", torrent->hash());
 
     Logger *logger = Logger::instance();
-    logger->addMessage(tr("Torrent: %1, running external program, command: %2").arg(torrent->name()).arg(program));
+    logger->addMessage(tr("Torrent: %1, running external program, command: %2").arg(torrent->name(), program));
 
 #if defined(Q_OS_UNIX)
     QProcess::startDetached(QLatin1String("/bin/sh"), {QLatin1String("-c"), program});

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -112,7 +112,7 @@ protected:
 #ifdef Q_OS_MAC
     bool event(QEvent *);
 #endif
-    bool notify(QObject* receiver, QEvent* event);
+    bool notify(QObject* receiver, QEvent* event) override;
 #endif
 
 private slots:

--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -216,7 +216,7 @@ namespace
             int res = val.toInt(&ok);
             if (!ok) {
                 qDebug() << QObject::tr("Expected integer number in environment variable '%1', but got '%2'")
-                    .arg(envVarName()).arg(val);
+                    .arg(envVarName(), val);
                 return defaultValue;
             }
             return res;
@@ -293,7 +293,7 @@ namespace
             }
             else {
                 qDebug() << QObject::tr("Expected %1 in environment variable '%2', but got '%3'")
-                    .arg(QLatin1String("true|false")).arg(envVarName()).arg(val);
+                    .arg(QLatin1String("true|false"), envVarName(), val);
                 return TriStateBool::Undefined;
             }
         }

--- a/src/base/bittorrent/private/resumedatasavingmanager.cpp
+++ b/src/base/bittorrent/private/resumedatasavingmanager.cpp
@@ -49,7 +49,7 @@ void ResumeDataSavingManager::saveResumeData(QString infoHash, QByteArray data) 
         resumeFile.write(data);
         if (!resumeFile.commit()) {
             Logger::instance()->addMessage(QString("Couldn't save resume data in %1. Error: %2")
-                                           .arg(filepath).arg(resumeFile.errorString()), Log::WARNING);
+                                           .arg(filepath, resumeFile.errorString()), Log::WARNING);
         }
     }
 }

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -2280,7 +2280,7 @@ bool Session::loadMetadata(const MagnetUri &magnetUri)
     p.max_connections = maxConnectionsPerTorrent();
     p.max_uploads = maxUploadsPerTorrent();
 
-    QString savePath = QString("%1/%2").arg(QDir::tempPath()).arg(hash);
+    QString savePath = QString("%1/%2").arg(QDir::tempPath(), hash);
     p.save_path = Utils::Fs::toNativePath(savePath).toStdString();
 
     // Forced start
@@ -3520,7 +3520,7 @@ void Session::handleTorrentSavingModeChanged(TorrentHandle * const torrent)
 void Session::handleTorrentTrackersAdded(TorrentHandle *const torrent, const QList<TrackerEntry> &newTrackers)
 {
     foreach (const TrackerEntry &newTracker, newTrackers)
-        Logger::instance()->addMessage(tr("Tracker '%1' was added to torrent '%2'").arg(newTracker.url()).arg(torrent->name()));
+        Logger::instance()->addMessage(tr("Tracker '%1' was added to torrent '%2'").arg(newTracker.url(), torrent->name()));
     emit trackersAdded(torrent, newTrackers);
     if (torrent->trackers().size() == newTrackers.size())
         emit trackerlessStateChanged(torrent, false);
@@ -3530,7 +3530,7 @@ void Session::handleTorrentTrackersAdded(TorrentHandle *const torrent, const QLi
 void Session::handleTorrentTrackersRemoved(TorrentHandle *const torrent, const QList<TrackerEntry> &deletedTrackers)
 {
     foreach (const TrackerEntry &deletedTracker, deletedTrackers)
-        Logger::instance()->addMessage(tr("Tracker '%1' was deleted from torrent '%2'").arg(deletedTracker.url()).arg(torrent->name()));
+        Logger::instance()->addMessage(tr("Tracker '%1' was deleted from torrent '%2'").arg(deletedTracker.url(), torrent->name()));
     emit trackersRemoved(torrent, deletedTrackers);
     if (torrent->trackers().size() == 0)
         emit trackerlessStateChanged(torrent, true);
@@ -3545,13 +3545,13 @@ void Session::handleTorrentTrackersChanged(TorrentHandle *const torrent)
 void Session::handleTorrentUrlSeedsAdded(TorrentHandle *const torrent, const QList<QUrl> &newUrlSeeds)
 {
     foreach (const QUrl &newUrlSeed, newUrlSeeds)
-        Logger::instance()->addMessage(tr("URL seed '%1' was added to torrent '%2'").arg(newUrlSeed.toString()).arg(torrent->name()));
+        Logger::instance()->addMessage(tr("URL seed '%1' was added to torrent '%2'").arg(newUrlSeed.toString(), torrent->name()));
 }
 
 void Session::handleTorrentUrlSeedsRemoved(TorrentHandle *const torrent, const QList<QUrl> &urlSeeds)
 {
     foreach (const QUrl &urlSeed, urlSeeds)
-        Logger::instance()->addMessage(tr("URL seed '%1' was removed from torrent '%2'").arg(urlSeed.toString()).arg(torrent->name()));
+        Logger::instance()->addMessage(tr("URL seed '%1' was removed from torrent '%2'").arg(urlSeed.toString(), torrent->name()));
 }
 
 void Session::handleTorrentMetadataReceived(TorrentHandle *const torrent)
@@ -4147,8 +4147,8 @@ void Session::handleTorrentDeleteFailedAlert(libt::torrent_delete_failed_alert *
     Utils::Fs::smartRemoveEmptyFolderTree(tmpRemovingTorrentData.savePathToRemove);
 
     LogMsg(tr("'%1' was removed from the transfer list but the files couldn't be deleted. Error: %2", "'xxx.avi' was removed...")
-           .arg(tmpRemovingTorrentData.name)
-           .arg(QString::fromLocal8Bit(p->error.message().c_str())), Log::CRITICAL);
+           .arg(tmpRemovingTorrentData.name, QString::fromLocal8Bit(p->error.message().c_str()))
+           , Log::CRITICAL);
 }
 
 void Session::handleMetadataReceivedAlert(libt::metadata_received_alert *p)
@@ -4171,7 +4171,7 @@ void Session::handleFileErrorAlert(libt::file_error_alert *p)
     if (torrent) {
         QString msg = QString::fromStdString(p->message());
         Logger::instance()->addMessage(tr("An I/O error occurred, '%1' paused. %2")
-                           .arg(torrent->name()).arg(msg));
+                           .arg(torrent->name(), msg));
         emit fullDiskError(torrent, msg);
     }
 }
@@ -4247,7 +4247,9 @@ void Session::handleListenSucceededAlert(libt::listen_succeeded_alert *p)
     else if (p->sock_type == libt::listen_succeeded_alert::tcp_ssl)
         proto = "TCP_SSL";
     qDebug() << "Successfully listening on " << proto << p->endpoint.address().to_string(ec).c_str() << "/" << p->endpoint.port();
-    Logger::instance()->addMessage(tr("qBittorrent is successfully listening on interface %1 port: %2/%3", "e.g: qBittorrent is successfully listening on interface 192.168.0.1 port: TCP/6881").arg(p->endpoint.address().to_string(ec).c_str()).arg(proto).arg(QString::number(p->endpoint.port())), Log::INFO);
+    Logger::instance()->addMessage(
+        tr("qBittorrent is successfully listening on interface %1 port: %2/%3", "e.g: qBittorrent is successfully listening on interface 192.168.0.1 port: TCP/6881")
+            .arg(p->endpoint.address().to_string(ec).c_str(), proto, QString::number(p->endpoint.port())), Log::INFO);
 
     // Force reannounce on all torrents because some trackers blacklist some ports
     std::vector<libt::torrent_handle> torrents = m_nativeSession->get_torrents();
@@ -4273,10 +4275,11 @@ void Session::handleListenFailedAlert(libt::listen_failed_alert *p)
         proto = "SOCKS5";
     qDebug() << "Failed listening on " << proto << p->endpoint.address().to_string(ec).c_str() << "/" << p->endpoint.port();
     Logger::instance()->addMessage(
-                tr("qBittorrent failed listening on interface %1 port: %2/%3. Reason: %4.",
-                   "e.g: qBittorrent failed listening on interface 192.168.0.1 port: TCP/6881. Reason: already in use.")
-                .arg(p->endpoint.address().to_string(ec).c_str()).arg(proto).arg(QString::number(p->endpoint.port()))
-                .arg(QString::fromLocal8Bit(p->error.message().c_str())), Log::CRITICAL);
+        tr("qBittorrent failed listening on interface %1 port: %2/%3. Reason: %4.",
+            "e.g: qBittorrent failed listening on interface 192.168.0.1 port: TCP/6881. Reason: already in use.")
+        .arg(p->endpoint.address().to_string(ec).c_str(), proto, QString::number(p->endpoint.port())
+            , QString::fromLocal8Bit(p->error.message().c_str()))
+        , Log::CRITICAL);
 }
 
 void Session::handleExternalIPAlert(libt::external_ip_alert *p)

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -1472,7 +1472,7 @@ void TorrentHandle::handleStorageMovedFailedAlert(libtorrent::storage_moved_fail
     }
 
     LogMsg(QCoreApplication::translate(i18nContext, "Could not move torrent: '%1'. Reason: %2")
-                                   .arg(name()).arg(QString::fromStdString(p->message())), Log::CRITICAL);
+                                   .arg(name(), QString::fromStdString(p->message())), Log::CRITICAL);
 
     m_moveStorageInfo.newPath.clear();
     if (!m_moveStorageInfo.queuedPath.isEmpty()) {
@@ -1656,7 +1656,7 @@ void TorrentHandle::handleFastResumeRejectedAlert(libtorrent::fastresume_rejecte
     }
     else {
         logger->addMessage(QCoreApplication::translate(i18nContext, "Fast resume data was rejected for torrent '%1'. Reason: %2. Checking again...")
-                           .arg(name()).arg(QString::fromStdString(p->message())), Log::CRITICAL);
+                           .arg(name(), QString::fromStdString(p->message())), Log::CRITICAL);
     }
 }
 
@@ -1679,7 +1679,7 @@ void TorrentHandle::handleFileRenamedAlert(libtorrent::file_renamed_alert *p)
         QString newPath = newPathParts.join("/");
         if (!newPathParts.isEmpty() && (oldPath != newPath)) {
             qDebug("oldPath(%s) != newPath(%s)", qUtf8Printable(oldPath), qUtf8Printable(newPath));
-            oldPath = QString("%1/%2").arg(savePath(true)).arg(oldPath);
+            oldPath = QString("%1/%2").arg(savePath(true), oldPath);
             qDebug("Detected folder renaming, attempt to delete old folder: %s", qUtf8Printable(oldPath));
             QDir().rmpath(oldPath);
         }

--- a/src/base/net/downloadhandler.cpp
+++ b/src/base/net/downloadhandler.cpp
@@ -121,7 +121,7 @@ void DownloadHandler::checkDownloadSize(qint64 bytesReceived, qint64 bytesTotal)
         // Total number of bytes is available
         if (bytesTotal > m_sizeLimit) {
             m_reply->abort();
-            emit downloadFailed(m_url, msg.arg(Utils::Misc::friendlyUnit(bytesTotal)).arg(Utils::Misc::friendlyUnit(m_sizeLimit)));
+            emit downloadFailed(m_url, msg.arg(Utils::Misc::friendlyUnit(bytesTotal), Utils::Misc::friendlyUnit(m_sizeLimit)));
         }
         else {
             disconnect(m_reply, SIGNAL(downloadProgress(qint64, qint64)), this, SLOT(checkDownloadSize(qint64, qint64)));
@@ -129,7 +129,7 @@ void DownloadHandler::checkDownloadSize(qint64 bytesReceived, qint64 bytesTotal)
     }
     else if (bytesReceived  > m_sizeLimit) {
         m_reply->abort();
-        emit downloadFailed(m_url, msg.arg(Utils::Misc::friendlyUnit(bytesReceived)).arg(Utils::Misc::friendlyUnit(m_sizeLimit)));
+        emit downloadFailed(m_url, msg.arg(Utils::Misc::friendlyUnit(bytesReceived), Utils::Misc::friendlyUnit(m_sizeLimit)));
     }
 }
 

--- a/src/base/net/geoipmanager.cpp
+++ b/src/base/net/geoipmanager.cpp
@@ -96,15 +96,14 @@ void GeoIPManager::loadDatabase()
     }
 
     QString filepath = Utils::Fs::expandPathAbs(
-                QString("%1%2/%3").arg(specialFolderLocation(SpecialFolder::Data))
-                .arg(GEOIP_FOLDER).arg(GEOIP_FILENAME));
+        QString("%1%2/%3").arg(specialFolderLocation(SpecialFolder::Data), GEOIP_FOLDER, GEOIP_FILENAME));
 
     QString error;
     m_geoIPDatabase = GeoIPDatabase::load(filepath, error);
     if (m_geoIPDatabase)
         Logger::instance()->addMessage(tr("GeoIP database loaded. Type: %1. Build time: %2.")
-                                       .arg(m_geoIPDatabase->type()).arg(m_geoIPDatabase->buildEpoch().toString()),
-                                       Log::INFO);
+            .arg(m_geoIPDatabase->type(), m_geoIPDatabase->buildEpoch().toString()),
+            Log::INFO);
     else
         Logger::instance()->addMessage(tr("Couldn't load GeoIP database. Reason: %1").arg(error), Log::WARNING);
 
@@ -432,13 +431,13 @@ void GeoIPManager::downloadFinished(const QString &url, QByteArray data)
                 delete m_geoIPDatabase;
             m_geoIPDatabase = geoIPDatabase;
             Logger::instance()->addMessage(tr("GeoIP database loaded. Type: %1. Build time: %2.")
-                                           .arg(m_geoIPDatabase->type()).arg(m_geoIPDatabase->buildEpoch().toString()),
-                                           Log::INFO);
+                .arg(m_geoIPDatabase->type(), m_geoIPDatabase->buildEpoch().toString()),
+                Log::INFO);
             QString targetPath = Utils::Fs::expandPathAbs(
                         specialFolderLocation(SpecialFolder::Data) + GEOIP_FOLDER);
             if (!QDir(targetPath).exists())
                 QDir().mkpath(targetPath);
-            QFile targetFile(QString("%1/%2").arg(targetPath).arg(GEOIP_FILENAME));
+            QFile targetFile(QString("%1/%2").arg(targetPath, GEOIP_FILENAME));
             if (!targetFile.open(QFile::WriteOnly) || (targetFile.write(data) == -1)) {
                 Logger::instance()->addMessage(
                             tr("Couldn't save downloaded GeoIP database file."), Log::WARNING);

--- a/src/base/net/proxyconfigurationmanager.cpp
+++ b/src/base/net/proxyconfigurationmanager.cpp
@@ -135,18 +135,18 @@ void ProxyConfigurationManager::configureProxy()
     if (!m_isProxyOnlyForTorrents) {
         switch (m_config.type) {
         case ProxyType::HTTP_PW:
-            proxyStrHTTP = QString("http://%1:%2@%3:%4").arg(m_config.username)
-                    .arg(m_config.password).arg(m_config.ip).arg(m_config.port);
+            proxyStrHTTP = QString("http://%1:%2@%3:%4").arg(m_config.username
+                , m_config.password, m_config.ip, QString::number(m_config.port));
             break;
         case ProxyType::HTTP:
-            proxyStrHTTP = QString("http://%1:%2").arg(m_config.ip).arg(m_config.port);
+            proxyStrHTTP = QString("http://%1:%2").arg(m_config.ip, m_config.port);
             break;
         case ProxyType::SOCKS5:
-            proxyStrSOCK = QString("%1:%2").arg(m_config.ip).arg(m_config.port);
+            proxyStrSOCK = QString("%1:%2").arg(m_config.ip, m_config.port);
             break;
         case ProxyType::SOCKS5_PW:
-            proxyStrSOCK = QString("%1:%2@%3:%4").arg(m_config.username)
-                    .arg(m_config.password).arg(m_config.ip).arg(m_config.port);
+            proxyStrSOCK = QString("%1:%2@%3:%4").arg(m_config.username
+                , m_config.password, m_config.ip, QString::number(m_config.port));
             break;
         default:
             qDebug("Disabling HTTP communications proxy");

--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -120,7 +120,7 @@ AutoDownloader::AutoDownloader()
     connect(m_fileStorage, &AsyncFileStorage::failed, [](const QString &fileName, const QString &errorString)
     {
         LogMsg(tr("Couldn't save RSS AutoDownloader data in %1. Error: %2")
-               .arg(fileName).arg(errorString), Log::CRITICAL);
+               .arg(fileName, errorString), Log::CRITICAL);
     });
 
     m_ioThread->start();
@@ -417,7 +417,7 @@ void AutoDownloader::load()
         loadRules(rulesFile.readAll());
     else
         LogMsg(tr("Couldn't read RSS AutoDownloader rules from %1. Error: %2")
-               .arg(rulesFile.fileName()).arg(rulesFile.errorString()), Log::CRITICAL);
+               .arg(rulesFile.fileName(), rulesFile.errorString()), Log::CRITICAL);
 }
 
 void AutoDownloader::loadRules(const QByteArray &data)

--- a/src/base/rss/rss_feed.cpp
+++ b/src/base/rss/rss_feed.cpp
@@ -189,7 +189,7 @@ void Feed::handleDownloadFailed(const QString &url, const QString &error)
     m_isLoading = false;
     m_hasError = true;
 
-    LogMsg(tr("Failed to download RSS feed at '%1'. Reason: %2").arg(url).arg(error)
+    LogMsg(tr("Failed to download RSS feed at '%1'. Reason: %2").arg(url, error)
            , Log::WARNING);
 
     emit stateChanged(this);
@@ -199,7 +199,7 @@ void Feed::handleParsingFinished(const RSS::Private::ParsingResult &result)
 {
     if (!result.error.isEmpty()) {
         m_hasError = true;
-        LogMsg(tr("Failed to parse RSS feed at '%1'. Reason: %2").arg(m_url).arg(result.error)
+        LogMsg(tr("Failed to parse RSS feed at '%1'. Reason: %2").arg(m_url, result.error)
                , Log::WARNING);
     }
     else {
@@ -249,7 +249,7 @@ void Feed::load()
     }
     else {
         LogMsg(tr("Couldn't read RSS Session data from %1. Error: %2")
-               .arg(m_dataFileName).arg(file.errorString())
+               .arg(m_dataFileName, file.errorString())
                , Log::WARNING);
     }
 }
@@ -389,7 +389,7 @@ void Feed::downloadIcon()
     // Download the RSS Feed icon
     // XXX: This works for most sites but it is not perfect
     const QUrl url(m_url);
-    auto iconUrl = QString("%1://%2/favicon.ico").arg(url.scheme()).arg(url.host());
+    auto iconUrl = QString("%1://%2/favicon.ico").arg(url.scheme(), url.host());
     Net::DownloadHandler *handler = Net::DownloadManager::instance()->downloadUrl(iconUrl, true);
     connect(handler
             , static_cast<void (Net::DownloadHandler::*)(const QString &, const QString &)>(&Net::DownloadHandler::downloadFinished)

--- a/src/base/rss/rss_session.cpp
+++ b/src/base/rss/rss_session.cpp
@@ -79,7 +79,7 @@ Session::Session()
     connect(m_confFileStorage, &AsyncFileStorage::failed, [](const QString &fileName, const QString &errorString)
     {
         Logger::instance()->addMessage(QString("Couldn't save RSS Session configuration in %1. Error: %2")
-                                       .arg(fileName).arg(errorString), Log::WARNING);
+                                       .arg(fileName, errorString), Log::WARNING);
     });
 
     m_dataFileStorage = new AsyncFileStorage(
@@ -89,7 +89,7 @@ Session::Session()
     connect(m_dataFileStorage, &AsyncFileStorage::failed, [](const QString &fileName, const QString &errorString)
     {
         Logger::instance()->addMessage(QString("Couldn't save RSS Session data in %1. Error: %2")
-                                       .arg(fileName).arg(errorString), Log::WARNING);
+                                       .arg(fileName, errorString), Log::WARNING);
     });
 
     m_itemsByPath.insert("", new Folder); // root folder
@@ -257,7 +257,7 @@ void Session::load()
     if (!itemsFile.open(QFile::ReadOnly)) {
         Logger::instance()->addMessage(
                     QString("Couldn't read RSS Session data from %1. Error: %2")
-                    .arg(itemsFile.fileName()).arg(itemsFile.errorString()), Log::WARNING);
+                    .arg(itemsFile.fileName(), itemsFile.errorString()), Log::WARNING);
         return;
     }
 
@@ -266,7 +266,7 @@ void Session::load()
     if (jsonError.error != QJsonParseError::NoError) {
         Logger::instance()->addMessage(
                     QString("Couldn't parse RSS Session data from %1. Error: %2")
-                    .arg(itemsFile.fileName()).arg(jsonError.errorString()), Log::WARNING);
+                    .arg(itemsFile.fileName(), jsonError.errorString()), Log::WARNING);
         return;
     }
 
@@ -293,7 +293,7 @@ void Session::loadFolder(const QJsonObject &jsonObj, Folder *folder)
         else if (!val.isObject()) {
             Logger::instance()->addMessage(
                         QString("Couldn't load RSS Item '%1'. Invalid data format.")
-                        .arg(QString("%1\\%2").arg(folder->path()).arg(key)), Log::WARNING);
+                        .arg(QString("%1\\%2").arg(folder->path(), key)), Log::WARNING);
         }
         else {
             QJsonObject valObj = val.toObject();
@@ -301,7 +301,7 @@ void Session::loadFolder(const QJsonObject &jsonObj, Folder *folder)
                 if (!valObj["url"].isString()) {
                     Logger::instance()->addMessage(
                                 QString("Couldn't load RSS Feed '%1'. URL is required.")
-                                .arg(QString("%1\\%2").arg(folder->path()).arg(key)), Log::WARNING);
+                                .arg(QString("%1\\%2").arg(folder->path(), key)), Log::WARNING);
                     continue;
                 }
 

--- a/src/base/search/searchpluginmanager.cpp
+++ b/src/base/search/searchpluginmanager.cpp
@@ -148,7 +148,7 @@ void SearchPluginManager::enablePlugin(const QString &name, bool enabled)
 // Updates shipped plugin
 void SearchPluginManager::updatePlugin(const QString &name)
 {
-    installPlugin(QString("%1%2.py").arg(m_updateUrl).arg(name));
+    installPlugin(QString("%1%2.py").arg(m_updateUrl, name));
 }
 
 // Install or update plugin from file or url
@@ -247,12 +247,12 @@ bool SearchPluginManager::uninstallPlugin(const QString &name)
 void SearchPluginManager::updateIconPath(PluginInfo * const plugin)
 {
     if (!plugin) return;
-    QString iconPath = QString("%1/%2.png").arg(pluginsLocation()).arg(plugin->name);
+    QString iconPath = QString("%1/%2.png").arg(pluginsLocation(), plugin->name);
     if (QFile::exists(iconPath)) {
         plugin->iconPath = iconPath;
     }
     else {
-        iconPath = QString("%1/%2.ico").arg(pluginsLocation()).arg(plugin->name);
+        iconPath = QString("%1/%2.ico").arg(pluginsLocation(), plugin->name);
         if (QFile::exists(iconPath))
             plugin->iconPath = iconPath;
     }
@@ -513,7 +513,7 @@ bool SearchPluginManager::isUpdateNeeded(QString pluginName, PluginVersion newVe
 
 QString SearchPluginManager::pluginPath(const QString &name)
 {
-    return QString("%1/%2.py").arg(pluginsLocation()).arg(name);
+    return QString("%1/%2.py").arg(pluginsLocation(), name);
 }
 
 PluginVersion SearchPluginManager::getPluginVersion(QString filePath)
@@ -537,7 +537,7 @@ PluginVersion SearchPluginManager::getPluginVersion(QString filePath)
             version = PluginVersion::tryParse(line, invalidVersion);
             if (version == invalidVersion) {
                 LogMsg(tr("Search plugin '%1' contains invalid version string ('%2')")
-                    .arg(Utils::Fs::fileName(filePath)).arg(QString::fromUtf8(line)), Log::MsgType::WARNING);
+                    .arg(Utils::Fs::fileName(filePath), QString::fromUtf8(line)), Log::MsgType::WARNING);
             }
             else {
                 qDebug() << "plugin" << filePath << "version: " << version;

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -460,12 +460,12 @@ QString Utils::Misc::userFriendlyDuration(qlonglong seconds)
     qlonglong hours = minutes / 60;
     minutes -= hours * 60;
     if (hours < 24)
-        return QCoreApplication::translate("misc", "%1h %2m", "e.g: 3hours 5minutes").arg(QString::number(hours)).arg(QString::number(minutes));
+        return QCoreApplication::translate("misc", "%1h %2m", "e.g: 3hours 5minutes").arg(QString::number(hours), QString::number(minutes));
 
     qlonglong days = hours / 24;
     hours -= days * 24;
     if (days < 100)
-        return QCoreApplication::translate("misc", "%1d %2h", "e.g: 2days 10hours").arg(QString::number(days)).arg(QString::number(hours));
+        return QCoreApplication::translate("misc", "%1d %2h", "e.g: 2days 10hours").arg(QString::number(days), QString::number(hours));
 
     return QString::fromUtf8(C_INFINITY);
 }
@@ -639,9 +639,9 @@ QString Utils::Misc::osName()
     // static initialization for usage in signal handler
     static const QString name =
         QString("%1 %2 %3")
-        .arg(QSysInfo::prettyProductName())
-        .arg(QSysInfo::kernelVersion())
-        .arg(QSysInfo::currentCpuArchitecture());
+        .arg(QSysInfo::prettyProductName()
+            , QSysInfo::kernelVersion()
+            , QSysInfo::currentCpuArchitecture());
     return name;
 }
 

--- a/src/gui/about_imp.h
+++ b/src/gui/about_imp.h
@@ -68,11 +68,11 @@ public:
             "<tr><td>%5</td><td><a href=\"http://bugs.qbittorrent.org\">http://bugs.qbittorrent.org</a></td></tr>"
             "</table>"
             "</p>")
-            .arg(tr("An advanced BitTorrent client programmed in C++, based on Qt toolkit and libtorrent-rasterbar."))
-            .arg(tr("Copyright %1 2006-2018 The qBittorrent project").arg(QString::fromUtf8(C_COPYRIGHT)))
-            .arg(tr("Home Page:"))
-            .arg(tr("Forum:"))
-            .arg(tr("Bug Tracker:"));
+            .arg(tr("An advanced BitTorrent client programmed in C++, based on Qt toolkit and libtorrent-rasterbar.")
+                , tr("Copyright %1 2006-2018 The qBittorrent project").arg(QString::fromUtf8(C_COPYRIGHT))
+                , tr("Home Page:")
+                , tr("Forum:")
+                , tr("Bug Tracker:"));
         lb_about->setText(aboutText);
 
         labelMascot->setPixmap(Utils::Gui::scaledPixmap(":/icons/skin/mascot.png", this));

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -288,7 +288,8 @@ bool AddNewTorrentDialog::loadTorrent(const QString &torrentPath)
     QString error;
     m_torrentInfo = BitTorrent::TorrentInfo::loadFromFile(m_filePath, &error);
     if (!m_torrentInfo.isValid()) {
-        MessageBoxRaised::critical(this, tr("Invalid torrent"), tr("Failed to load the torrent: %1.\nError: %2", "Don't remove the '\n' characters. They insert a newline.").arg(Utils::Fs::toNativePath(m_filePath)).arg(error));
+        MessageBoxRaised::critical(this, tr("Invalid torrent"), tr("Failed to load the torrent: %1.\nError: %2", "Don't remove the '\n' characters. They insert a newline.")
+            .arg(Utils::Fs::toNativePath(m_filePath), error));
         return false;
     }
 
@@ -768,7 +769,8 @@ void AddNewTorrentDialog::setupTreeview()
 
 void AddNewTorrentDialog::handleDownloadFailed(const QString &url, const QString &reason)
 {
-    MessageBoxRaised::critical(this, tr("Download Error"), QString("Cannot download '%1': %2").arg(url).arg(reason));
+    MessageBoxRaised::critical(this, tr("Download Error"),
+        QString("Cannot download '%1': %2").arg(url, reason));
     this->deleteLater();
 }
 

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -284,12 +284,13 @@ void AdvancedSettings::loadAdvancedSettings()
     boldFont.setBold(true);
     addRow(QBITTORRENT_HEADER, tr("qBittorrent Section"), &labelQbtLink);
     item(QBITTORRENT_HEADER, PROPERTY)->setFont(boldFont);
-    labelQbtLink.setText(QString("<a href=\"%1\">%2</a>").arg("https://github.com/qbittorrent/qBittorrent/wiki/Explanation-of-Options-in-qBittorrent#Advanced").arg(tr("Open documentation")));
+    labelQbtLink.setText(QString("<a href=\"%1\">%2</a>")
+        .arg("https://github.com/qbittorrent/qBittorrent/wiki/Explanation-of-Options-in-qBittorrent#Advanced", tr("Open documentation")));
     labelQbtLink.setOpenExternalLinks(true);
 
     addRow(LIBTORRENT_HEADER, tr("libtorrent Section"), &labelLibtorrentLink);
     item(LIBTORRENT_HEADER, PROPERTY)->setFont(boldFont);
-    labelLibtorrentLink.setText(QString("<a href=\"%1\">%2</a>").arg("https://www.libtorrent.org/reference.html").arg(tr("Open documentation")));
+    labelLibtorrentLink.setText(QString("<a href=\"%1\">%2</a>").arg("https://www.libtorrent.org/reference.html", tr("Open documentation")));
     labelLibtorrentLink.setOpenExternalLinks(true);
     // Disk write cache
     spin_cache.setMinimum(-1);

--- a/src/gui/categoryfiltermodel.cpp
+++ b/src/gui/categoryfiltermodel.cpp
@@ -74,7 +74,7 @@ public:
         if (!m_parent || m_parent->name().isEmpty())
             return m_name;
 
-        return QString("%1/%2").arg(m_parent->fullName()).arg(m_name);
+        return QString("%1/%2").arg(m_parent->fullName(), m_name);
     }
 
     CategoryModelItem *parent() const

--- a/src/gui/executionlog.cpp
+++ b/src/gui/executionlog.cpp
@@ -105,7 +105,8 @@ void ExecutionLog::addPeerMessage(const Log::Peer& peer)
     QDateTime time = QDateTime::fromMSecsSinceEpoch(peer.timestamp);
 
     if (peer.blocked)
-        text = "<font color='grey'>" + time.toString(Qt::SystemLocaleShortDate) + "</font> - " + tr("<font color='red'>%1</font> was blocked %2", "x.y.z.w was blocked").arg(peer.ip).arg(peer.reason);
+        text = "<font color='grey'>" + time.toString(Qt::SystemLocaleShortDate) + "</font> - "
+            + tr("<font color='red'>%1</font> was blocked %2", "x.y.z.w was blocked").arg(peer.ip, peer.reason);
     else
         text = "<font color='grey'>" + time.toString(Qt::SystemLocaleShortDate) + "</font> - " + tr("<font color='red'>%1</font> was banned", "x.y.z.w was banned").arg(peer.ip);
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -832,7 +832,9 @@ void MainWindow::finishedTorrent(BitTorrent::TorrentHandle *const torrent) const
 // Notification when disk is full
 void MainWindow::fullDiskError(BitTorrent::TorrentHandle *const torrent, QString msg) const
 {
-    showNotificationBaloon(tr("I/O Error", "i.e: Input/Output Error"), tr("An I/O error occurred for torrent '%1'.\n Reason: %2", "e.g: An error occurred for torrent 'xxx.avi'.\n Reason: disk is full.").arg(torrent->name()).arg(msg));
+    showNotificationBaloon(tr("I/O Error", "i.e: Input/Output Error")
+        , tr("An I/O error occurred for torrent '%1'.\n Reason: %2"
+            , "e.g: An error occurred for torrent 'xxx.avi'.\n Reason: disk is full.").arg(torrent->name(), msg));
 }
 
 void MainWindow::createKeyboardShortcuts()
@@ -937,7 +939,8 @@ void MainWindow::askRecursiveTorrentDownloadConfirmation(BitTorrent::TorrentHand
 void MainWindow::handleDownloadFromUrlFailure(QString url, QString reason) const
 {
     // Display a message box
-    showNotificationBaloon(tr("URL download error"), tr("Couldn't download file at URL '%1', reason: %2.").arg(url).arg(reason));
+    showNotificationBaloon(tr("URL download error")
+        , tr("Couldn't download file at URL '%1', reason: %2.").arg(url, reason));
 }
 
 void MainWindow::on_actionSetGlobalUploadLimit_triggered()
@@ -1542,9 +1545,9 @@ void MainWindow::updateGUI()
 
     if (m_displaySpeedInTitle) {
         setWindowTitle(tr("[D: %1, U: %2] qBittorrent %3", "D = Download; U = Upload; %3 is qBittorrent version")
-                       .arg(Utils::Misc::friendlyUnit(status.payloadDownloadRate, true))
-                       .arg(Utils::Misc::friendlyUnit(status.payloadUploadRate, true))
-                       .arg(QBT_VERSION));
+            .arg(Utils::Misc::friendlyUnit(status.payloadDownloadRate, true)
+                , Utils::Misc::friendlyUnit(status.payloadUploadRate, true)
+                , QBT_VERSION));
     }
 }
 
@@ -1740,7 +1743,8 @@ void MainWindow::on_actionSearchWidget_triggered()
         // Check if python is already in PATH
         if (pythonVersion > 0)
             // Prevent translators from messing with PATH
-            Logger::instance()->addMessage(tr("Python found in %1: %2", "Python found in PATH: /usr/local/bin:/usr/bin:/etc/bin").arg("PATH").arg(qgetenv("PATH").constData()), Log::INFO);
+            Logger::instance()->addMessage(tr("Python found in %1: %2", "Python found in PATH: /usr/local/bin:/usr/bin:/etc/bin")
+                .arg("PATH", qgetenv("PATH").constData()), Log::INFO);
 #ifdef Q_OS_WIN
         else if (addPythonPathToEnv())
             pythonVersion = Utils::Misc::pythonVersion();

--- a/src/gui/optionsdlg.cpp
+++ b/src/gui/optionsdlg.cpp
@@ -273,17 +273,17 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     connect(m_ui->autoRun_txt, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
 
     const QString autoRunStr = QString("%1\n    %2\n    %3\n    %4\n    %5\n    %6\n    %7\n    %8\n    %9\n    %10\n%11")
-                               .arg(tr("Supported parameters (case sensitive):"))
-                               .arg(tr("%N: Torrent name"))
-                               .arg(tr("%L: Category"))
-                               .arg(tr("%F: Content path (same as root path for multifile torrent)"))
-                               .arg(tr("%R: Root path (first torrent subdirectory path)"))
-                               .arg(tr("%D: Save path"))
-                               .arg(tr("%C: Number of files"))
-                               .arg(tr("%Z: Torrent size (bytes)"))
-                               .arg(tr("%T: Current tracker"))
-                               .arg(tr("%I: Info hash"))
-                               .arg(tr("Tip: Encapsulate parameter with quotation marks to avoid text being cut off at whitespace (e.g., \"%N\")"));
+        .arg(tr("Supported parameters (case sensitive):")
+            , tr("%N: Torrent name")
+            , tr("%L: Category")
+            , tr("%F: Content path (same as root path for multifile torrent)")
+            , tr("%R: Root path (first torrent subdirectory path)")
+            , tr("%D: Save path")
+            , tr("%C: Number of files")
+            , tr("%Z: Torrent size (bytes)")
+            , tr("%T: Current tracker"))
+        .arg(tr("%I: Info hash")
+            , tr("Tip: Encapsulate parameter with quotation marks to avoid text being cut off at whitespace (e.g., \"%N\")"));
     m_ui->autoRun_param->setText(autoRunStr);
 
     // Connection tab
@@ -1518,7 +1518,7 @@ void OptionsDialog::on_addScanFolderButton_clicked()
         }
 
         if (!error.isEmpty())
-            QMessageBox::critical(this, tr("Adding entry failed"), QString("%1\n%2").arg(error).arg(dir));
+            QMessageBox::critical(this, tr("Adding entry failed"), QString("%1\n%2").arg(error, dir));
     }
 }
 

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -413,11 +413,11 @@ void PropertiesWidget::loadDynamicData()
     case PropTabBar::MainTab: {
             m_ui->labelWastedVal->setText(Utils::Misc::friendlyUnit(m_torrent->wastedSize()));
 
-            m_ui->labelUpTotalVal->setText(tr("%1 (%2 this session)").arg(Utils::Misc::friendlyUnit(m_torrent->totalUpload()))
-                                   .arg(Utils::Misc::friendlyUnit(m_torrent->totalPayloadUpload())));
+            m_ui->labelUpTotalVal->setText(tr("%1 (%2 this session)").arg(Utils::Misc::friendlyUnit(m_torrent->totalUpload())
+                , Utils::Misc::friendlyUnit(m_torrent->totalPayloadUpload())));
 
-            m_ui->labelDlTotalVal->setText(tr("%1 (%2 this session)").arg(Utils::Misc::friendlyUnit(m_torrent->totalDownload()))
-                                   .arg(Utils::Misc::friendlyUnit(m_torrent->totalPayloadDownload())));
+            m_ui->labelDlTotalVal->setText(tr("%1 (%2 this session)").arg(Utils::Misc::friendlyUnit(m_torrent->totalDownload())
+                , Utils::Misc::friendlyUnit(m_torrent->totalPayloadDownload())));
 
             m_ui->labelUpLimitVal->setText(m_torrent->uploadLimit() <= 0 ? QString::fromUtf8(C_INFINITY) : Utils::Misc::friendlyUnit(m_torrent->uploadLimit(), true));
 
@@ -426,8 +426,8 @@ void PropertiesWidget::loadDynamicData()
             QString elapsedString;
             if (m_torrent->isSeed())
                 elapsedString = tr("%1 (seeded for %2)", "e.g. 4m39s (seeded for 3m10s)")
-                              .arg(Utils::Misc::userFriendlyDuration(m_torrent->activeTime()))
-                              .arg(Utils::Misc::userFriendlyDuration(m_torrent->seedingTime()));
+                    .arg(Utils::Misc::userFriendlyDuration(m_torrent->activeTime())
+                        , Utils::Misc::userFriendlyDuration(m_torrent->seedingTime()));
             else
                 elapsedString = Utils::Misc::userFriendlyDuration(m_torrent->activeTime());
             m_ui->labelElapsedVal->setText(elapsedString);
@@ -446,20 +446,20 @@ void PropertiesWidget::loadDynamicData()
             m_ui->labelShareRatioVal->setText(ratio > BitTorrent::TorrentHandle::MAX_RATIO ? QString::fromUtf8(C_INFINITY) : Utils::String::fromDouble(ratio, 2));
 
             m_ui->labelSeedsVal->setText(tr("%1 (%2 total)", "%1 and %2 are numbers, e.g. 3 (10 total)")
-                                           .arg(QString::number(m_torrent->seedsCount()))
-                                           .arg(QString::number(m_torrent->totalSeedsCount())));
+                .arg(QString::number(m_torrent->seedsCount())
+                    , QString::number(m_torrent->totalSeedsCount())));
 
             m_ui->labelPeersVal->setText(tr("%1 (%2 total)", "%1 and %2 are numbers, e.g. 3 (10 total)")
-                                           .arg(QString::number(m_torrent->leechsCount()))
-                                           .arg(QString::number(m_torrent->totalLeechersCount())));
+                .arg(QString::number(m_torrent->leechsCount())
+                    , QString::number(m_torrent->totalLeechersCount())));
 
             m_ui->labelDlSpeedVal->setText(tr("%1 (%2 avg.)", "%1 and %2 are speed rates, e.g. 200KiB/s (100KiB/s avg.)")
-                                              .arg(Utils::Misc::friendlyUnit(m_torrent->downloadPayloadRate(), true))
-                                              .arg(Utils::Misc::friendlyUnit(m_torrent->totalDownload() / (1 + m_torrent->activeTime() - m_torrent->finishedTime()), true)));
+                .arg(Utils::Misc::friendlyUnit(m_torrent->downloadPayloadRate(), true)
+                    , Utils::Misc::friendlyUnit(m_torrent->totalDownload() / (1 + m_torrent->activeTime() - m_torrent->finishedTime()), true)));
 
             m_ui->labelUpSpeedVal->setText(tr("%1 (%2 avg.)", "%1 and %2 are speed rates, e.g. 200KiB/s (100KiB/s avg.)")
-                                                  .arg(Utils::Misc::friendlyUnit(m_torrent->uploadPayloadRate(), true))
-                                                  .arg(Utils::Misc::friendlyUnit(m_torrent->totalUpload() / (1 + m_torrent->activeTime()), true)));
+                .arg(Utils::Misc::friendlyUnit(m_torrent->uploadPayloadRate(), true)
+                    , Utils::Misc::friendlyUnit(m_torrent->totalUpload() / (1 + m_torrent->activeTime()), true)));
 
             m_ui->labelLastSeenCompleteVal->setText(m_torrent->lastSeenComplete().isValid() ? m_torrent->lastSeenComplete().toString(Qt::DefaultLocaleShortDate) : tr("Never"));
 

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -60,8 +60,8 @@ const QString EXT_LEGACY {QStringLiteral(".rssrules")};
 
 AutomatedRssDownloader::AutomatedRssDownloader(QWidget *parent)
     : QDialog(parent)
-    , m_formatFilterJSON(QString("%1 (*%2)").arg(tr("Rules")).arg(EXT_JSON))
-    , m_formatFilterLegacy(QString("%1 (*%2)").arg(tr("Rules (legacy)")).arg(EXT_LEGACY))
+    , m_formatFilterJSON(QString("%1 (*%2)").arg(tr("Rules"), EXT_JSON))
+    , m_formatFilterLegacy(QString("%1 (*%2)").arg(tr("Rules (legacy)"), EXT_LEGACY))
     , m_ui(new Ui::AutomatedRssDownloader)
     , m_currentRuleItem(nullptr)
 {
@@ -405,7 +405,7 @@ void AutomatedRssDownloader::on_exportBtn_clicked()
     QString selectedFilter {m_formatFilterJSON};
     QString path = QFileDialog::getSaveFileName(
                 this, tr("Export RSS rules"), QDir::homePath()
-                , QString("%1;;%2").arg(m_formatFilterJSON).arg(m_formatFilterLegacy), &selectedFilter);
+                , QString("%1;;%2").arg(m_formatFilterJSON, m_formatFilterLegacy), &selectedFilter);
     if (path.isEmpty()) return;
 
     const RSS::AutoDownloader::RulesFileFormat format {
@@ -437,7 +437,7 @@ void AutomatedRssDownloader::on_importBtn_clicked()
     QString selectedFilter {m_formatFilterJSON};
     QString path = QFileDialog::getOpenFileName(
                 this, tr("Import RSS rules"), QDir::homePath()
-                , QString("%1;;%2").arg(m_formatFilterJSON).arg(m_formatFilterLegacy), &selectedFilter);
+                , QString("%1;;%2").arg(m_formatFilterJSON, m_formatFilterLegacy), &selectedFilter);
     if (path.isEmpty() || !QFile::exists(path))
         return;
 
@@ -657,7 +657,7 @@ void AutomatedRssDownloader::updateFieldsToolTips(bool regex)
     tip += tr("An expression with an empty %1 clause (e.g. %2)",
               "We talk about regex/wildcards in the RSS filters section here."
               " So a valid sentence would be: An expression with an empty | clause (e.g. expr|)"
-              ).arg("<tt>|</tt>").arg("<tt>expr|</tt>");
+              ).arg("<tt>|</tt>", "<tt>expr|</tt>");
     m_ui->lineContains->setToolTip(tip + tr(" will match all articles.") + "</p>");
     m_ui->lineNotContains->setToolTip(tip + tr(" will exclude all articles.") + "</p>");
 }

--- a/src/gui/search/pluginselectdlg.cpp
+++ b/src/gui/search/pluginselectdlg.cpp
@@ -387,9 +387,9 @@ void PluginSelectDlg::iconDownloaded(const QString &url, QString filePath)
             if (!plugin) continue;
 
             QString iconPath = QString("%1/%2.%3")
-                               .arg(SearchPluginManager::pluginsLocation())
-                               .arg(id)
-                               .arg(url.endsWith(".ico", Qt::CaseInsensitive) ? "ico" : "png");
+                .arg(SearchPluginManager::pluginsLocation()
+                    , id
+                    , url.endsWith(".ico", Qt::CaseInsensitive) ? "ico" : "png");
             if (QFile::copy(filePath, iconPath)) {
                 // This 2nd check is necessary. Some favicons (eg from piratebay)
                 // decode fine without an ext, but fail to do so when appending the ext
@@ -448,7 +448,8 @@ void PluginSelectDlg::pluginInstalled(const QString &name)
 void PluginSelectDlg::pluginInstallationFailed(const QString &name, const QString &reason)
 {
     finishAsyncOp();
-    QMessageBox::information(this, tr("Search plugin install"), tr("Couldn't install \"%1\" search engine plugin. %2").arg(name).arg(reason));
+    QMessageBox::information(this, tr("Search plugin install")
+        , tr("Couldn't install \"%1\" search engine plugin. %2").arg(name, reason));
     finishPluginUpdate();
 }
 
@@ -465,6 +466,7 @@ void PluginSelectDlg::pluginUpdated(const QString &name)
 void PluginSelectDlg::pluginUpdateFailed(const QString &name, const QString &reason)
 {
     finishAsyncOp();
-    QMessageBox::information(this, tr("Search plugin update"), tr("Couldn't update \"%1\" search engine plugin. %2").arg(name).arg(reason));
+    QMessageBox::information(this, tr("Search plugin update")
+        , tr("Couldn't update \"%1\" search engine plugin. %2").arg(name, reason));
     finishPluginUpdate();
 }

--- a/src/gui/statusbar.cpp
+++ b/src/gui/statusbar.cpp
@@ -65,9 +65,8 @@ StatusBar::StatusBar(QWidget *parent)
     m_connecStatusLblIcon->setCursor(Qt::PointingHandCursor);
     m_connecStatusLblIcon->setIcon(QIcon(":/icons/skin/firewalled.png"));
     m_connecStatusLblIcon->setToolTip(
-                QString(QLatin1String("<b>%1</b><br><i>%2</i>"))
-                .arg(tr("Connection status:"))
-                .arg(tr("No direct connections. This may indicate network configuration problems.")));
+        QString(QLatin1String("<b>%1</b><br><i>%2</i>")).arg(tr("Connection status:")
+            , tr("No direct connections. This may indicate network configuration problems.")));
     connect(m_connecStatusLblIcon, &QAbstractButton::clicked, this, &StatusBar::connectionButtonClicked);
 
     m_dlSpeedLbl = new QPushButton(this);

--- a/src/gui/torrentcreatordlg.cpp
+++ b/src/gui/torrentcreatordlg.cpp
@@ -200,7 +200,8 @@ void TorrentCreatorDlg::handleCreationSuccess(const QString &path, const QString
 
         BitTorrent::Session::instance()->addTorrent(t, params);
     }
-    QMessageBox::information(this, tr("Torrent creator"), QString("%1\n%2").arg(tr("Torrent created:")).arg(Utils::Fs::toNativePath(path)));
+    QMessageBox::information(this, tr("Torrent creator")
+        , QString("%1\n%2").arg(tr("Torrent created:"), Utils::Fs::toNativePath(path)));
     setInteractionEnabled(true);
 }
 

--- a/src/gui/transferlistdelegate.cpp
+++ b/src/gui/transferlistdelegate.cpp
@@ -126,8 +126,8 @@ void TransferListDelegate::paint(QPainter * painter, const QStyleOptionViewItem 
         const int seedingTime = index.data(Qt::UserRole).toInt();
         const QString txt = (seedingTime > 0)
             ? tr("%1 (seeded for %2)", "e.g. 4m39s (seeded for 3m10s)")
-                .arg(Utils::Misc::userFriendlyDuration(elapsedTime))
-                .arg(Utils::Misc::userFriendlyDuration(seedingTime))
+                .arg(Utils::Misc::userFriendlyDuration(elapsedTime)
+                    , Utils::Misc::userFriendlyDuration(seedingTime))
             : Utils::Misc::userFriendlyDuration(elapsedTime);
         QItemDelegate::drawDisplay(painter, opt, opt.rect, txt);
         break;

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -398,7 +398,9 @@ void TransferListWidget::setSelectedTorrentsLocation()
 
     // Actually move storage
     foreach (BitTorrent::TorrentHandle *const torrent, torrents) {
-        Logger::instance()->addMessage(tr("Set location: moving \"%1\", from \"%2\" to \"%3\"", "Set location: moving \"ubuntu_16_04.iso\", from \"/home/dir1\" to \"/home/dir2\"").arg(torrent->name()).arg(torrent->savePath()).arg(newLocation));
+        Logger::instance()->addMessage(tr("Set location: moving \"%1\", from \"%2\" to \"%3\""
+            , "Set location: moving \"ubuntu_16_04.iso\", from \"/home/dir1\" to \"/home/dir2\"")
+            .arg(torrent->name(), torrent->savePath(), newLocation));
         torrent->move(Utils::Fs::expandPathAbs(newLocation));
     }
 }

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -110,7 +110,7 @@ protected:
 protected slots:
     void torrentDoubleClicked();
     void displayListMenu(const QPoint&);
-    void currentChanged(const QModelIndex& current, const QModelIndex&);
+    void currentChanged(const QModelIndex& current, const QModelIndex&) override;
     void toggleSelectedTorrentsSuperSeeding() const;
     void toggleSelectedTorrentsSequentialDownload() const;
     void toggleSelectedFirstLastPiecePrio() const;

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -726,7 +726,7 @@ void TorrentsController::setLocationAction()
     applyToTorrents(hashes, [newLocation](BitTorrent::TorrentHandle *torrent)
     {
         LogMsg(tr("WebUI Set location: moving \"%1\", from \"%2\" to \"%3\"")
-               .arg(torrent->name()).arg(torrent->savePath()).arg(newLocation));
+               .arg(torrent->name(), torrent->savePath(), newLocation));
         torrent->move(Utils::Fs::expandPathAbs(newLocation));
     });
 }

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -456,7 +456,7 @@ void WebApplication::sendFile(const QString &path)
         qDebug("File %s was not found!", qUtf8Printable(path));
         throw NotFoundHTTPError();
     }
-    
+
     if (file.size() > MAX_ALLOWED_FILESIZE) {
         qWarning("%s: exceeded the maximum allowed file size!", qUtf8Printable(path));
         throw InternalServerErrorHTTPError(tr("Exceeded the maximum allowed file size (%1)!")
@@ -579,7 +579,7 @@ bool WebApplication::isAuthNeeded()
 
 bool WebApplication::isPublicAPI(const QString &scope, const QString &action) const
 {
-    return m_publicAPIs.contains(QString::fromLatin1("%1/%2").arg(scope).arg(action));
+    return m_publicAPIs.contains(QString::fromLatin1("%1/%2").arg(scope, action));
 }
 
 void WebApplication::sessionStart()
@@ -643,7 +643,7 @@ bool WebApplication::isCrossSiteRequest(const Http::Request &request) const
         const bool isInvalid = !isSameOrigin(urlFromHostHeader(targetOrigin), originValue);
         if (isInvalid)
             LogMsg(tr("WebUI: Origin header & Target origin mismatch! Source IP: '%1'. Origin header: '%2'. Target origin: '%3'")
-                   .arg(m_env.clientAddress.toString()).arg(originValue).arg(targetOrigin)
+                   .arg(m_env.clientAddress.toString(), originValue, targetOrigin)
                    , Log::WARNING);
         return isInvalid;
     }
@@ -652,7 +652,7 @@ bool WebApplication::isCrossSiteRequest(const Http::Request &request) const
         const bool isInvalid = !isSameOrigin(urlFromHostHeader(targetOrigin), refererValue);
         if (isInvalid)
             LogMsg(tr("WebUI: Referer header & Target origin mismatch! Source IP: '%1'. Referer header: '%2'. Target origin: '%3'")
-                   .arg(m_env.clientAddress.toString()).arg(refererValue).arg(targetOrigin)
+                   .arg(m_env.clientAddress.toString(), refererValue, targetOrigin)
                    , Log::WARNING);
         return isInvalid;
     }
@@ -701,7 +701,7 @@ bool WebApplication::validateHostHeader(const QStringList &domains) const
     }
 
     LogMsg(tr("WebUI: Invalid Host header. Request source IP: '%1'. Received Host header: '%2'")
-           .arg(m_env.clientAddress.toString()).arg(m_request.headers[Http::HEADER_HOST])
+           .arg(m_env.clientAddress.toString(), m_request.headers[Http::HEADER_HOST])
             , Log::WARNING);
     return false;
 }

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -88,7 +88,7 @@ public:
     explicit WebApplication(QObject *parent = nullptr);
     ~WebApplication() override;
 
-    Http::Response processRequest(const Http::Request &request, const Http::Environment &env);
+    Http::Response processRequest(const Http::Request &request, const Http::Environment &env) override;
 
     QString clientId() const override;
     WebSession *session() override;


### PR DESCRIPTION
* Fix clang warnings for missing 'override' specifier
  Example: warning: 'notify' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]

* Fix clazy warning
  The warning name is "qstring-arg".
  Use QString::arg() multi-arguments overload whenever possible to avoid temporary allocations.
