### PR TITLE
Fix missing initializer warning during build

### DIFF
--- a/src/base/utils/version.h
+++ b/src/base/utils/version.h
@@ -50,7 +50,7 @@ namespace Utils
         typedef Version<T, N, Mandatory> ThisType;
 
         constexpr Version()
-            : m_components {}
+            : m_components {{}}
         {
         }
 
@@ -167,7 +167,7 @@ namespace Utils
                 throw std::runtime_error ("Incorrect number of version components");
 
             bool ok = false;
-            ComponentsArray res{};
+            ComponentsArray res {{}};
             for (std::size_t i = 0; i < static_cast<std::size_t>(versionParts.size()); ++i) {
                 res[i] = static_cast<T>(versionParts[i].toInt(&ok));
                 if (!ok)


### PR DESCRIPTION
There are two instances of this:

```
In file included from base/search/searchpluginmanager.h:36:0,
                 from base/search/searchhandler.cpp:37:
./base/utils/version.h: In instantiation of ‘constexpr Utils::Version<T, N, Mandatory>::Version() [with T = short unsigned int; long unsigned int N = 2ul; long unsigned int Mandatory = 2ul]’:
/opt/qt55/include/QtCore/qmetatype.h:756:28:   required from ‘static void* QtMetaTypePrivate::QMetaTypeFunctionHelper<T, Accepted>::Construct(void*, const void*) [with T = Utils::Version<short unsigned int, 2ul>; bool Accepted = true]’
/opt/qt55/include/QtCore/qmetatype.h:1680:76:   required from ‘int qRegisterNormalizedMetaType(const QByteArray&, T*, typename QtPrivate::MetaTypeDefinedHelper<T, (QMetaTypeId2<T>::Defined && (! QMetaTypeId2<T>::IsBuiltIn))>::DefinedType) [with T = Utils::Version<short unsigned int, 2ul>; typename QtPrivate::MetaTypeDefinedHelper<T, (QMetaTypeId2<T>::Defined && (! QMetaTypeId2<T>::IsBuiltIn))>::DefinedType = QtPrivate::MetaTypeDefinedHelper<Utils::Version<short unsigned int, 2ul>, true>::DefinedType]’
/opt/qt55/include/QtCore/qmetatype.h:1705:77:   required from ‘int qRegisterMetaType(const char*, T*, typename QtPrivate::MetaTypeDefinedHelper<T, (QMetaTypeId2<T>::Defined && (! QMetaTypeId2<T>::IsBuiltIn))>::DefinedType) [with T = Utils::Version<short unsigned int, 2ul>; typename QtPrivate::MetaTypeDefinedHelper<T, (QMetaTypeId2<T>::Defined && (! QMetaTypeId2<T>::IsBuiltIn))>::DefinedType = QtPrivate::MetaTypeDefinedHelper<Utils::Version<short unsigned int, 2ul>, true>::DefinedType]’
base/search/searchpluginmanager.h:39:1:   required from here
./base/utils/version.h:53:29: warning: missing initializer for member ‘std::array<short unsigned int, 2ul>::_M_elems’ [-Wmissing-field-initializers]
             : m_components {}
                             ^
```

```
In file included from base/search/searchpluginmanager.h:36:0,
                 from base/search/searchpluginmanager.cpp:30:
./base/utils/version.h: In instantiation of ‘static Utils::Version<T, N, Mandatory>::ComponentsArray Utils::Version<T, N, Mandatory>::parseList(const StringsList&) [with StringsList = QList<QByteArray>; T = short unsigned int; long unsigned int N = 2ul; long unsigned int Mandatory = 2ul; Utils::Version<T, N, Mandatory>::ComponentsArray = std::array<short unsigned int, 2ul>]’:
./base/utils/version.h:181:51:   required from ‘Utils::Version<T, N, Mandatory>::Version(const StringsList&) [with StringsList = QList<QByteArray>; T = short unsigned int; long unsigned int N = 2ul; long unsigned int Mandatory = 2ul]’
./base/utils/version.h:83:42:   required from ‘Utils::Version<T, N, Mandatory>::Version(const QByteArray&) [with T = short unsigned int; long unsigned int N = 2ul; long unsigned int Mandatory = 2ul]’
./base/utils/version.h:151:33:   required from ‘static Utils::Version<T, N, Mandatory> Utils::Version<T, N, Mandatory>::tryParse(const StringClassWithSplitMethod&, const Utils::Version<T, N, Mandatory>&) [with StringClassWithSplitMethod = QByteArray; T = short unsigned int; long unsigned int N = 2ul; long unsigned int Mandatory = 2ul]’
base/search/searchpluginmanager.cpp:488:72:   required from here
./base/utils/version.h:170:33: warning: missing initializer for member ‘std::array<short unsigned int, 2ul>::_M_elems’ [-Wmissing-field-initializers]
             ComponentsArray res{};
                                 ^
```

Inspired by #8551