### PR TITLE
Don't create temporary containers just to iterate over them

### DIFF
--- a/src/app/upgrade.h
+++ b/src/app/upgrade.h
@@ -186,9 +186,10 @@ bool upgrade(bool ask = true)
         }
     }
 
-    foreach (const QString &hash, oldResumeData.keys()) {
-        QVariantHash oldTorrent = oldResumeData[hash].toHash();
+    for (auto i = oldResumeData.cbegin(); i != oldResumeData.cend(); ++i) {
+        const QVariantHash oldTorrent = i.value().toHash();
         if (oldTorrent.value("is_magnet", false).toBool()) {
+            const QString &hash = i.key();
             libtorrent::entry resumeData;
             resumeData["qBt-magnetUri"] = oldTorrent.value("magnet_uri").toString().toStdString();
             resumeData["qBt-paused"] = false;

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -55,6 +55,7 @@ utils/net.h
 utils/random.h
 utils/string.h
 utils/version.h
+algorithm.h
 asyncfilestorage.h
 exceptions.h
 filesystemwatcher.h

--- a/src/base/algorithm.h
+++ b/src/base/algorithm.h
@@ -1,0 +1,41 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2018  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+namespace Dict
+{
+    // To be used with QMap, QHash and it's variants
+    template <typename Dictionary, typename BinaryPredicate>
+    void removeIf(Dictionary &&dict, BinaryPredicate p)
+    {
+        auto it = dict.begin();
+        while (it != dict.end())
+            it = (p(it.key(), it.value()) ? dict.erase(it) : it + 1);
+    }
+}

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -1,4 +1,5 @@
 HEADERS += \
+    $$PWD/algorithm.h \
     $$PWD/asyncfilestorage.h \
     $$PWD/bittorrent/addtorrentparams.h  \
     $$PWD/bittorrent/cachestatus.h \

--- a/src/base/net/portforwarder.cpp
+++ b/src/base/net/portforwarder.cpp
@@ -121,8 +121,10 @@ void PortForwarder::start()
     settingsPack.set_bool(libt::settings_pack::enable_natpmp, true);
     m_provider->apply_settings(settingsPack);
 #endif
-    foreach (quint16 port, m_mappedPorts.keys())
-        m_mappedPorts[port] = m_provider->add_port_mapping(libt::session::tcp, port, port);
+    for (auto i = m_mappedPorts.begin(); i != m_mappedPorts.end(); ++i) {
+        // quint16 port = i.key();
+        i.value() = m_provider->add_port_mapping(libt::session::tcp, i.key(), i.key());
+    }
     m_active = true;
     Logger::instance()->addMessage(tr("UPnP / NAT-PMP support [ON]"), Log::INFO);
 }

--- a/src/base/search/searchpluginmanager.cpp
+++ b/src/base/search/searchpluginmanager.cpp
@@ -38,6 +38,7 @@
 #include <QPointer>
 #include <QProcess>
 
+#include "base/global.h"
 #include "base/logger.h"
 #include "base/net/downloadmanager.h"
 #include "base/net/downloadhandler.h"
@@ -99,7 +100,7 @@ QStringList SearchPluginManager::allPlugins() const
 QStringList SearchPluginManager::enabledPlugins() const
 {
     QStringList plugins;
-    foreach (const PluginInfo *plugin, m_plugins.values()) {
+    for (const PluginInfo *plugin : qAsConst(m_plugins)) {
         if (plugin->enabled)
             plugins << plugin->name;
     }
@@ -110,7 +111,7 @@ QStringList SearchPluginManager::enabledPlugins() const
 QStringList SearchPluginManager::supportedCategories() const
 {
     QStringList result;
-    foreach (const PluginInfo *plugin, m_plugins.values()) {
+    for (const PluginInfo *plugin : qAsConst(m_plugins)) {
         if (plugin->enabled) {
             foreach (QString cat, plugin->supportedCategories) {
                 if (!result.contains(cat))

--- a/src/gui/categoryfiltermodel.cpp
+++ b/src/gui/categoryfiltermodel.cpp
@@ -405,7 +405,8 @@ void CategoryFilterModel::populate()
                                     , [](Torrent *torrent) { return torrent->category().isEmpty(); })));
 
     using Torrent = BitTorrent::TorrentHandle;
-    foreach (const QString &category, session->categories().keys()) {
+    for (auto i = session->categories().cbegin(); i != session->categories().cend(); ++i) {
+        const QString &category = i.key();
         if (m_isSubcategoriesEnabled) {
             CategoryModelItem *parent = m_rootItem;
             foreach (const QString &subcat, session->expandCategory(category)) {

--- a/src/gui/categoryfilterwidget.cpp
+++ b/src/gui/categoryfilterwidget.cpp
@@ -232,8 +232,10 @@ void CategoryFilterWidget::removeCategory()
 void CategoryFilterWidget::removeUnusedCategories()
 {
     auto session = BitTorrent::Session::instance();
-    foreach (const QString &category, session->categories().keys())
+    for (auto i = session->categories().cbegin(); i != session->categories().cend(); ++i) {
+        const QString &category = i.key();
         if (model()->data(static_cast<CategoryFilterProxyModel *>(model())->index(category), Qt::UserRole) == 0)
             session->removeCategory(category);
+    }
     updateGeometry();
 }

--- a/src/gui/search/pluginselectdlg.cpp
+++ b/src/gui/search/pluginselectdlg.cpp
@@ -424,10 +424,10 @@ void PluginSelectDlg::checkForUpdatesFinished(const QHash<QString, PluginVersion
         return;
     }
 
-    foreach (const QString &pluginName, updateInfo.keys()) {
+    for (auto i = updateInfo.cbegin(); i != updateInfo.cend(); ++i) {
         startAsyncOp();
         m_pendingUpdates++;
-        m_pluginManager->updatePlugin(pluginName);
+        m_pluginManager->updatePlugin(i.key());
     }
 }
 

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -333,7 +333,8 @@ void TrackerFiltersList::setDownloadTrackerFavicon(bool value)
     m_downloadTrackerFavicon = value;
 
     if (m_downloadTrackerFavicon) {
-        foreach (const QString &tracker, m_trackers.keys()) {
+        for (auto i = m_trackers.cbegin(); i != m_trackers.cend(); ++i) {
+            const QString &tracker = i.key();
             if (!tracker.isEmpty())
                 downloadFavicon(QString("http://%1/favicon.ico").arg(tracker));
         }

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -91,7 +91,7 @@ void AppController::preferencesAction()
     data["incomplete_files_ext"] = session->isAppendExtensionEnabled();
     const QVariantHash dirs = pref->getScanDirs();
     QVariantMap nativeDirs;
-    for (QVariantHash::const_iterator i = dirs.begin(), e = dirs.end(); i != e; ++i) {
+    for (QVariantHash::const_iterator i = dirs.cbegin(), e = dirs.cend(); i != e; ++i) {
         if (i.value().type() == QVariant::Int)
             nativeDirs.insert(Utils::Fs::toNativePath(i.key()), i.value().toInt());
         else
@@ -246,7 +246,7 @@ void AppController::setPreferencesAction()
         QVariantHash oldScanDirs = pref->getScanDirs();
         QVariantHash scanDirs;
         ScanFoldersModel *model = ScanFoldersModel::instance();
-        for (QVariantMap::const_iterator i = nativeDirs.begin(), e = nativeDirs.end(); i != e; ++i) {
+        for (QVariantMap::const_iterator i = nativeDirs.cbegin(), e = nativeDirs.cend(); i != e; ++i) {
             QString folder = Utils::Fs::fromNativePath(i.key());
             int downloadType;
             QString downloadPath;
@@ -275,8 +275,8 @@ void AppController::setPreferencesAction()
         }
 
         // Update deleted folders
-        foreach (QVariant folderVariant, oldScanDirs.keys()) {
-            QString folder = folderVariant.toString();
+        for (auto i = oldScanDirs.cbegin(); i != oldScanDirs.cend(); ++i) {
+            QString folder = i.key();
             if (!scanDirs.contains(folder)) {
                 model->removePath(folder);
                 qDebug("Removed watched folder %s", qUtf8Printable(folder));


### PR DESCRIPTION
Stops temporary containers being created needlessly due to API misuse.
For example, it’s common for developers to assume QHash::values() and
QHash::keys() are free and abuse them, failing to realize their
implementation internally actually iterates the whole container, allocates
memory, and fills a new QList.

Found using clazy.