### PR TITLE
Properly reply to announce request

### DIFF
--- a/src/base/bittorrent/tracker.h
+++ b/src/base/bittorrent/tracker.h
@@ -90,6 +90,8 @@ namespace BitTorrent
 
     private:
         void respondToAnnounceRequest();
+        void registerPeer(const TrackerAnnounceRequest &annonceReq);
+        void unregisterPeer(const TrackerAnnounceRequest &annonceReq);
         void replyWithPeerList(const TrackerAnnounceRequest &annonceReq);
 
         Http::Server *m_server;


### PR DESCRIPTION
Tracker shouldn't add peer with "port=0" to the list but it still should send non-error response to it.