### PR TITLE
Properly align text label

### DIFF
--- a/src/gui/optionsdlg.ui
+++ b/src/gui/optionsdlg.ui
@@ -1602,6 +1602,19 @@
                    </property>
                   </widget>
                  </item>
+                 <item>
+                  <spacer name="horizontalSpacer_22">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
                 </layout>
                </item>
                <item>


### PR DESCRIPTION
Notice the position of "(More information)":
Before: ![before](https://user-images.githubusercontent.com/9395168/37356057-140688f4-2720-11e8-9000-00a042ee1d32.png)
After: ![after](https://user-images.githubusercontent.com/9395168/37356055-13dde99e-2720-11e8-831b-e56e7c1a92e5.png)
