### PR TITLE
Improve FS watcher

### DIFF
--- a/src/base/filesystemwatcher.cpp
+++ b/src/base/filesystemwatcher.cpp
@@ -104,7 +104,7 @@ void FileSystemWatcher::addPath(const QString &path)
 #endif
 
     // Normal mode
-    qDebug("FS Watching is watching %s in normal mode", qUtf8Printable(path));
+    qDebug("FS Watcher is watching %s in normal mode", qUtf8Printable(path));
     QFileSystemWatcher::addPath(path);
     scanLocalFolder(path);
 }

--- a/src/base/filesystemwatcher.cpp
+++ b/src/base/filesystemwatcher.cpp
@@ -124,7 +124,7 @@ void FileSystemWatcher::removePath(const QString &path)
 
 void FileSystemWatcher::scanLocalFolder(const QString &path)
 {
-    processTorrentsInDir(path);
+    QTimer::singleShot(2000, this, [this, path]() { processTorrentsInDir(path); });
 }
 
 #ifndef Q_OS_WIN

--- a/src/base/filesystemwatcher.cpp
+++ b/src/base/filesystemwatcher.cpp
@@ -151,7 +151,7 @@ void FileSystemWatcher::processPartialTorrents()
         }
 
         if (value >= MAX_PARTIAL_RETRIES) {
-            QFile::rename(torrentPath, torrentPath + ".invalid");
+            QFile::rename(torrentPath, torrentPath + ".qbt_rejected");
             return true;
         }
 

--- a/src/base/filesystemwatcher.h
+++ b/src/base/filesystemwatcher.h
@@ -32,7 +32,6 @@
 #include <QDir>
 #include <QFileSystemWatcher>
 #include <QHash>
-#include <QPointer>
 #include <QStringList>
 #include <QTimer>
 
@@ -46,7 +45,6 @@ class FileSystemWatcher : public QFileSystemWatcher
 
 public:
     explicit FileSystemWatcher(QObject *parent = nullptr);
-    ~FileSystemWatcher();
 
     QStringList directories() const;
     void addPath(const QString &path);
@@ -65,14 +63,14 @@ protected slots:
 private:
     void processTorrentsInDir(const QDir &dir);
 
+    // Partial torrents
+    QHash<QString, int> m_partialTorrents;
+    QTimer m_partialTorrentTimer;
 
 #ifndef Q_OS_WIN
     QList<QDir> m_watchedFolders;
-    QPointer<QTimer> m_watchTimer;
+    QTimer m_watchTimer;
 #endif
-    // Partial torrents
-    QHash<QString, int> m_partialTorrents;
-    QPointer<QTimer> m_partialTorrentTimer;
 };
 
 #endif // FILESYSTEMWATCHER_H

--- a/src/base/filesystemwatcher.h
+++ b/src/base/filesystemwatcher.h
@@ -1,3 +1,31 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2018
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
 #ifndef FILESYSTEMWATCHER_H
 #define FILESYSTEMWATCHER_H
 

--- a/src/base/filesystemwatcher.h
+++ b/src/base/filesystemwatcher.h
@@ -64,9 +64,6 @@ protected slots:
 
 private:
     void processTorrentsInDir(const QDir &dir);
-#if !defined Q_OS_WIN && !defined Q_OS_HAIKU
-    static bool isNetworkFileSystem(const QString &path);
-#endif
 
 
 #ifndef Q_OS_WIN

--- a/src/base/filesystemwatcher.h
+++ b/src/base/filesystemwatcher.h
@@ -56,22 +56,23 @@ signals:
     void torrentsAdded(const QStringList &pathList);
 
 protected slots:
-    void scanLocalFolder(QString path);
-    void scanNetworkFolders();
+    void scanLocalFolder(const QString &path);
     void processPartialTorrents();
+#ifndef Q_OS_WIN
+    void scanNetworkFolders();
+#endif
 
 private:
-    void startPartialTorrentTimer();
-    void addTorrentsFromDir(const QDir &dir, QStringList &torrents);
+    void processTorrentsInDir(const QDir &dir);
 #if !defined Q_OS_WIN && !defined Q_OS_HAIKU
-    static bool isNetworkFileSystem(QString path);
+    static bool isNetworkFileSystem(const QString &path);
 #endif
+
 
 #ifndef Q_OS_WIN
     QList<QDir> m_watchedFolders;
     QPointer<QTimer> m_watchTimer;
 #endif
-    QStringList m_filters;
     // Partial torrents
     QHash<QString, int> m_partialTorrents;
     QPointer<QTimer> m_partialTorrentTimer;

--- a/src/base/utils/fs.h
+++ b/src/base/utils/fs.h
@@ -63,6 +63,10 @@ namespace Utils
         void removeDirRecursive(const QString &path);
 
         QString tempPath();
+
+#if !defined Q_OS_WIN && !defined Q_OS_HAIKU
+        bool isNetworkFileSystem(const QString &path);
+#endif
     }
 }
 


### PR DESCRIPTION
The main point of this PR:
  Add delay before processing FS changes
  This prevents renaming errors in monitored folder, for example: ABC.torrent.part -> ABC.torrent
