### PR TITLE
Use lightweight printf instead of iostream

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -74,7 +74,7 @@
 #include "mainwindow.h"
 #include "shutdownconfirmdlg.h"
 #else // DISABLE_GUI
-#include <iostream>
+#include <cstdio>
 #endif // DISABLE_GUI
 
 #ifndef DISABLE_WEBUI
@@ -491,13 +491,16 @@ int Application::exec(const QStringList &params)
 #ifndef DISABLE_WEBUI
     Preferences* const pref = Preferences::instance();
     // Display some information to the user
-    std::cout << std::endl << "******** " << qPrintable(tr("Information")) << " ********" << std::endl;
-    std::cout << qPrintable(tr("To control qBittorrent, access the Web UI at http://localhost:%1").arg(QString::number(pref->getWebUiPort()))) << std::endl;
-    std::cout << qPrintable(tr("The Web UI administrator user name is: %1").arg(pref->getWebUiUsername())) << std::endl;
+    const QString mesg = QString("\n******** %1 ********\n").arg(tr("Information"))
+        + tr("To control qBittorrent, access the Web UI at %1")
+            .arg(QString("http://localhost:") + QString::number(pref->getWebUiPort())) + '\n'
+        + tr("The Web UI administrator user name is: %1").arg(pref->getWebUiUsername()) + '\n';
+    printf("%s", qUtf8Printable(mesg));
     qDebug() << "Password:" << pref->getWebUiPassword();
     if (pref->getWebUiPassword() == "f6fdffe48c908deb0f4c3bd36c032e72") {
-        std::cout << qPrintable(tr("The Web UI administrator password is still the default one: %1").arg("adminadmin")) << std::endl;
-        std::cout << qPrintable(tr("This is a security risk, please consider changing your password from program preferences.")) << std::endl;
+        const QString warning = tr("The Web UI administrator password is still the default one: %1").arg("adminadmin") + '\n'
+            + tr("This is a security risk, please consider changing your password from program preferences.") + '\n';
+        printf("%s", qUtf8Printable(warning));
     }
 #endif // DISABLE_WEBUI
 #else

--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -32,7 +32,7 @@
 
 #include "cmdoptions.h"
 
-#include <iostream>
+#include <cstdio>
 
 #include <QDebug>
 #include <QFileInfo>
@@ -578,7 +578,7 @@ QString makeUsage(const QString &prgName)
 void displayUsage(const QString &prgName)
 {
 #ifndef Q_OS_WIN
-    std::cout << qPrintable(makeUsage(prgName)) << std::endl;
+    printf("%s\n", qUtf8Printable(makeUsage(prgName)));
 #else
     QMessageBox msgBox(QMessageBox::Information, QObject::tr("Help"), makeUsage(prgName), QMessageBox::Ok);
     msgBox.show(); // Need to be shown or to moveToCenter does not work

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -29,6 +29,8 @@
  * Contact : chris@qbittorrent.org
  */
 
+#include <cstdlib>
+
 #include <QDebug>
 #include <QScopedPointer>
 #include <QThread>
@@ -67,15 +69,11 @@ Q_IMPORT_PLUGIN(QICOPlugin)
 #include "stacktrace_win_dlg.h"
 #endif //STACKTRACE_WIN
 
-#include <cstdlib>
-#include <iostream>
-
 #include "application.h"
 #include "base/profile.h"
 #include "base/utils/misc.h"
 #include "base/preferences.h"
 #include "cmdoptions.h"
-
 #include "upgrade.h"
 
 // Signal handlers
@@ -169,7 +167,7 @@ int main(int argc, char *argv[])
 
         // Set environment variable
         if (!qputenv("QBITTORRENT", QBT_VERSION))
-            std::cerr << "Couldn't set environment variable...\n";
+            fprintf(stderr, "Couldn't set environment variable...\n");
 
 #ifndef DISABLE_GUI
         if (!userAgreesWithLegalNotice())
@@ -346,7 +344,7 @@ void setupDpi()
 
 void displayVersion()
 {
-    std::cout << qPrintable(qApp->applicationName()) << " " << QBT_VERSION << std::endl;
+    printf("%s %s\n", qUtf8Printable(qApp->applicationName()), QBT_VERSION);
 }
 
 void displayBadArgMessage(const QString& message)
@@ -359,9 +357,10 @@ void displayBadArgMessage(const QString& message)
     msgBox.move(Utils::Misc::screenCenter(&msgBox));
     msgBox.exec();
 #else
-    std::cerr << qPrintable(QObject::tr("Bad command line: "));
-    std::cerr << qPrintable(message) << std::endl;
-    std::cerr << qPrintable(help) << std::endl;
+    const QString errMsg = QObject::tr("Bad command line: ") + '\n'
+        + message + '\n'
+        + help + '\n';
+    fprintf(stderr, "%s", qUtf8Printable(errMsg));
 #endif
 }
 
@@ -372,9 +371,12 @@ bool userAgreesWithLegalNotice()
         return true;
 
 #ifdef DISABLE_GUI
-    std::cout << std::endl << "*** " << qPrintable(QObject::tr("Legal Notice")) << " ***" << std::endl;
-    std::cout << qPrintable(QObject::tr("qBittorrent is a file sharing program. When you run a torrent, its data will be made available to others by means of upload. Any content you share is your sole responsibility.\n\nNo further notices will be issued.")) << std::endl << std::endl;
-    std::cout << qPrintable(QObject::tr("Press %1 key to accept and continue...").arg("'y'")) << std::endl;
+    const QString eula = QString("\n*** %1 ***\n").arg(QObject::tr("Legal Notice"))
+        + QObject::tr("qBittorrent is a file sharing program. When you run a torrent, its data will be made available to others by means of upload. Any content you share is your sole responsibility.") + "\n\n"
+        + QObject::tr("No further notices will be issued.") + "\n\n"
+        + QObject::tr("Press %1 key to accept and continue...").arg("'y'") + '\n';
+    printf("%s", qUtf8Printable(eula));
+
     char ret = getchar(); // Read pressed key
     if (ret == 'y' || ret == 'Y') {
         // Save the answer

--- a/src/app/upgrade.h
+++ b/src/app/upgrade.h
@@ -61,10 +61,11 @@
 bool userAcceptsUpgrade()
 {
 #ifdef DISABLE_GUI
-    std::cout << std::endl << "*** " << qPrintable(QObject::tr("Upgrade")) << " ***" << std::endl;
+    printf("\n*** %s ***\n", qUtf8Printable(QObject::tr("Upgrade")));
     char ret = '\0';
     do {
-        std::cout << qPrintable(QObject::tr("You updated from an older version that saved things differently. You must migrate to the new saving system. You will not be able to use an older version than v3.3.0 again. Continue? [y/n]")) << std::endl;
+        printf("%s\n"
+            , qUtf8Printable(QObject::tr("You updated from an older version that saved things differently. You must migrate to the new saving system. You will not be able to use an older version than v3.3.0 again. Continue? [y/n]")));
         ret = getchar(); // Read pressed key
     }
     while ((ret != 'y') && (ret != 'Y') && (ret != 'n') && (ret != 'N'));

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -2355,9 +2355,7 @@ void Session::saveResumeData()
         std::vector<libt::alert *> alerts;
         getPendingAlerts(alerts, 30 * 1000);
         if (alerts.empty()) {
-            std::cerr << " aborting with " << m_numResumeData
-                      << " outstanding torrents to save resume data for"
-                      << std::endl;
+            fprintf(stderr, " aborting with %d outstanding torrents to save resume data for\n", m_numResumeData);
             break;
         }
 

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -29,7 +29,6 @@
 
 #include "searchwidget.h"
 
-#include <iostream>
 #ifdef Q_OS_WIN
 #include <cstdlib>
 #endif


### PR DESCRIPTION
* Using iostream usually adds a lot of other operators (<<, endl), whereas
*printf takes only 1 function call.

* Also use qUtf8Printable whenever possible.