### PR TITLE
Added delete files & force options to Share Ratio Limiting WebUI. Closes #8151 & #8074

### DIFF
--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -6,7 +6,8 @@ For programming languages other than C++ (e.g. JavaScript) used in this reposito
 **Note 2:** You can use the `uncrustify` program/tool to clean up any source file. Use it with the `uncrustify.cfg` configuration file found in the root folder.  
 **Note 3:** There is also a style for QtCreator but it doesn't cover all cases. In QtCreator `Tools->Options...->C++->Code Style->Import...` and choose the `codingStyleQtCreator.xml` file found in the root folder.  
 
-### 1. Curly braces ###
+### 1. New lines & curly braces ###
+
 #### a. Function blocks, class/struct definitions, namespaces ####
 ```c++
 int myFunction(int a)
@@ -91,18 +92,8 @@ default:
 }
 ```
 
-#### d. Brace enclosed initializers ####
-Unlike single-line functions, you must not insert spaces between the brackets and concluded expressions.<br/>
-But you must insert a space between the variable name and initializer.
-```c++
-Class obj {}; // empty
-Class obj {expr};
-Class obj {expr1, /*...,*/ exprN};
-QVariantMap map {{"key1", 5}, {"key2", 10}};
-```
-
-### 2. If blocks ###
-#### a. Multiple tests ####
+#### d. If-else statements ####
+The `else if`/`else` must be on their own lines:
 ```c++
 if (condition) {
     // code
@@ -114,40 +105,71 @@ else {
     // code
 }
 ```
-The `else if`/`else` must be on their own lines.
 
-#### b. Single statement if blocks ####
-**Most** single statement if blocks should look like this:
+#### e. Single statement if blocks ####
+Most single statement if blocks should look like this:
 ```c++
 if (condition)
     a = a + b;
 ```
 
-One acceptable exception to this **can be** `return`, `break` or `continue` statements, provided that the test condition isn't very long. However you can choose to use the first rule instead.
+One acceptable exception to this can be `return`, `break` or `continue` statements,
+provided that the test condition isn't very long and its body statement occupies only one line.
+However you can still choose to use the first rule.
 ```c++
-a = myFunction();
-b = a * 1500;
+if (a > 0) return;
 
-if (b > 0) return;
-c = 100 / b;
+while (p) {
+    // ...
+    if (!b) continue;
+}
 ```
 
-#### c. Using curly braces for single statement if blocks ####
+#### f. Acceptable conditions to omit braces ####
+When the conditional statement in `if`/`else` has only one line and its body occupy only one line,
+this also applies to loops statements.  
+Notice that for a series of `if - else` branches, if one branch needs braces then all branches must add braces.
+```c++
+if (a < b)  // conditional statement
+    do(a);  // body
 
-However, there are cases where curly braces for single statement if blocks **should** be used.
-* If some branch needs braces then all others should use them. Unless you have multiple `else if` in a row and the one needing the braces is only for a very small sub-block of code.
-* Another exception would be when we have nested if blocks or generally multiple levels of code that affect code readability.
+if (a < b)
+    do(a);
+else if (a > b)
+    do(b);
+else
+    do(c);
 
-Generally it will depend on the particular piece of code and would be determined on how readable that piece of code is. **If in doubt** always use braces if one of the above exceptions applies.
+if (a < b) {
+    do(a);
+}
+else if (a > b) {  // curly braces required here, then all branches should also add them
+    do(b);
+    do(d);
+}
+else {
+    do(c);
+}
+```
 
-### 3. Indentation ###
+#### g. Brace enclosed initializers ####
+Unlike single-line functions, you must not insert spaces between the brackets and concluded expressions.<br/>
+But you must insert a space between the variable name and initializer.
+```c++
+Class obj {}; // empty
+Class obj {expr};
+Class obj {expr1, /*...,*/ exprN};
+QVariantMap map {{"key1", 5}, {"key2", 10}};
+```
+
+### 2. Indentation ###
 4 spaces.
 
-### 4. File encoding and line endings. ###
+### 3. File encoding and line endings. ###
 
 UTF-8 and Unix-like line ending (LF). Unless some platform specific files need other encodings/line endings.
 
-### 5. Initialization lists. ###
+### 4. Initialization lists. ###
 Initialization lists should be vertical. This will allow for more easily readable diffs. The initialization colon should be indented and in its own line along with first argument. The rest of the arguments should be indented too and have the comma prepended.
 ```c++
 myClass::myClass(int a, int b, int c, int d)
@@ -160,7 +182,7 @@ myClass::myClass(int a, int b, int c, int d)
 }
 ```
 
-### 6. Enums. ###
+### 5. Enums. ###
 Enums should be vertical. This will allow for more easily readable diffs. The members should be indented.
 ```c++
 enum Days
@@ -175,7 +197,7 @@ enum Days
 };
 ```
 
-### 7. Names. ###
+### 6. Names. ###
 All names should be camelCased.
 
 #### a. Type names and namespaces ####
@@ -209,7 +231,7 @@ class MyClass
 }
 ```
 
-### 8. Header inclusion order. ###
+### 7. Header inclusion order. ###
 The headers should be placed in the following order:
  1. Module header (in .cpp)
  2. System/Qt/Boost etc. headers (split in subcategories if you have many).
@@ -242,7 +264,7 @@ Example:
 
 ```
 
-### 9. Include guard. ###
+### 8. Include guard. ###
 `#pragma once` should be used instead of "include guard" in new code:
 ```c++
 // examplewidget.h
@@ -258,7 +280,7 @@ class ExampleWidget : public QWidget
 
 ```
 
-### 10. Misc. ###
+### 9. Misc. ###
 
 * Line breaks for long lines with operation:
 
@@ -345,4 +367,5 @@ i++, j--;  // No
 8. If commit fixes a reported issue, mention it in the message body (e.g. `Closes #4134.`)
 
 ### 11. Not covered above ###
-If something isn't covered above, just follow the same style the file you are editing has. If that particular detail isn't present in the file you are editing, then use whatever the rest of the project uses.
+If something isn't covered above, just follow the same style the file you are editing has.  
+*This guide is not exhaustive and the style for a particular piece of code not specified here will be determined by project members on code review.*

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -74,7 +74,7 @@
 #include "mainwindow.h"
 #include "shutdownconfirmdlg.h"
 #else // DISABLE_GUI
-#include <iostream>
+#include <cstdio>
 #endif // DISABLE_GUI
 
 #ifndef DISABLE_WEBUI
@@ -491,13 +491,16 @@ int Application::exec(const QStringList &params)
 #ifndef DISABLE_WEBUI
     Preferences* const pref = Preferences::instance();
     // Display some information to the user
-    std::cout << std::endl << "******** " << qPrintable(tr("Information")) << " ********" << std::endl;
-    std::cout << qPrintable(tr("To control qBittorrent, access the Web UI at http://localhost:%1").arg(QString::number(pref->getWebUiPort()))) << std::endl;
-    std::cout << qPrintable(tr("The Web UI administrator user name is: %1").arg(pref->getWebUiUsername())) << std::endl;
+    const QString mesg = QString("\n******** %1 ********\n").arg(tr("Information"))
+        + tr("To control qBittorrent, access the Web UI at %1")
+            .arg(QString("http://localhost:") + QString::number(pref->getWebUiPort())) + '\n'
+        + tr("The Web UI administrator user name is: %1").arg(pref->getWebUiUsername()) + '\n';
+    printf("%s", qUtf8Printable(mesg));
     qDebug() << "Password:" << pref->getWebUiPassword();
     if (pref->getWebUiPassword() == "f6fdffe48c908deb0f4c3bd36c032e72") {
-        std::cout << qPrintable(tr("The Web UI administrator password is still the default one: %1").arg("adminadmin")) << std::endl;
-        std::cout << qPrintable(tr("This is a security risk, please consider changing your password from program preferences.")) << std::endl;
+        const QString warning = tr("The Web UI administrator password is still the default one: %1").arg("adminadmin") + '\n'
+            + tr("This is a security risk, please consider changing your password from program preferences.") + '\n';
+        printf("%s", qUtf8Printable(warning));
     }
 #endif // DISABLE_WEBUI
 #else

--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -32,7 +32,7 @@
 
 #include "cmdoptions.h"
 
-#include <iostream>
+#include <cstdio>
 
 #include <QDebug>
 #include <QFileInfo>
@@ -578,7 +578,7 @@ QString makeUsage(const QString &prgName)
 void displayUsage(const QString &prgName)
 {
 #ifndef Q_OS_WIN
-    std::cout << qPrintable(makeUsage(prgName)) << std::endl;
+    printf("%s\n", qUtf8Printable(makeUsage(prgName)));
 #else
     QMessageBox msgBox(QMessageBox::Information, QObject::tr("Help"), makeUsage(prgName), QMessageBox::Ok);
     msgBox.show(); // Need to be shown or to moveToCenter does not work

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -29,6 +29,8 @@
  * Contact : chris@qbittorrent.org
  */
 
+#include <cstdlib>
+
 #include <QDebug>
 #include <QScopedPointer>
 #include <QThread>
@@ -67,15 +69,11 @@ Q_IMPORT_PLUGIN(QICOPlugin)
 #include "stacktrace_win_dlg.h"
 #endif //STACKTRACE_WIN
 
-#include <cstdlib>
-#include <iostream>
-
 #include "application.h"
 #include "base/profile.h"
 #include "base/utils/misc.h"
 #include "base/preferences.h"
 #include "cmdoptions.h"
-
 #include "upgrade.h"
 
 // Signal handlers
@@ -169,7 +167,7 @@ int main(int argc, char *argv[])
 
         // Set environment variable
         if (!qputenv("QBITTORRENT", QBT_VERSION))
-            std::cerr << "Couldn't set environment variable...\n";
+            fprintf(stderr, "Couldn't set environment variable...\n");
 
 #ifndef DISABLE_GUI
         if (!userAgreesWithLegalNotice())
@@ -346,7 +344,7 @@ void setupDpi()
 
 void displayVersion()
 {
-    std::cout << qPrintable(qApp->applicationName()) << " " << QBT_VERSION << std::endl;
+    printf("%s %s\n", qUtf8Printable(qApp->applicationName()), QBT_VERSION);
 }
 
 void displayBadArgMessage(const QString& message)
@@ -359,9 +357,10 @@ void displayBadArgMessage(const QString& message)
     msgBox.move(Utils::Misc::screenCenter(&msgBox));
     msgBox.exec();
 #else
-    std::cerr << qPrintable(QObject::tr("Bad command line: "));
-    std::cerr << qPrintable(message) << std::endl;
-    std::cerr << qPrintable(help) << std::endl;
+    const QString errMsg = QObject::tr("Bad command line: ") + '\n'
+        + message + '\n'
+        + help + '\n';
+    fprintf(stderr, "%s", qUtf8Printable(errMsg));
 #endif
 }
 
@@ -372,9 +371,12 @@ bool userAgreesWithLegalNotice()
         return true;
 
 #ifdef DISABLE_GUI
-    std::cout << std::endl << "*** " << qPrintable(QObject::tr("Legal Notice")) << " ***" << std::endl;
-    std::cout << qPrintable(QObject::tr("qBittorrent is a file sharing program. When you run a torrent, its data will be made available to others by means of upload. Any content you share is your sole responsibility.\n\nNo further notices will be issued.")) << std::endl << std::endl;
-    std::cout << qPrintable(QObject::tr("Press %1 key to accept and continue...").arg("'y'")) << std::endl;
+    const QString eula = QString("\n*** %1 ***\n").arg(QObject::tr("Legal Notice"))
+        + QObject::tr("qBittorrent is a file sharing program. When you run a torrent, its data will be made available to others by means of upload. Any content you share is your sole responsibility.") + "\n\n"
+        + QObject::tr("No further notices will be issued.") + "\n\n"
+        + QObject::tr("Press %1 key to accept and continue...").arg("'y'") + '\n';
+    printf("%s", qUtf8Printable(eula));
+
     char ret = getchar(); // Read pressed key
     if (ret == 'y' || ret == 'Y') {
         // Save the answer

--- a/src/app/upgrade.h
+++ b/src/app/upgrade.h
@@ -61,10 +61,11 @@
 bool userAcceptsUpgrade()
 {
 #ifdef DISABLE_GUI
-    std::cout << std::endl << "*** " << qPrintable(QObject::tr("Upgrade")) << " ***" << std::endl;
+    printf("\n*** %s ***\n", qUtf8Printable(QObject::tr("Upgrade")));
     char ret = '\0';
     do {
-        std::cout << qPrintable(QObject::tr("You updated from an older version that saved things differently. You must migrate to the new saving system. You will not be able to use an older version than v3.3.0 again. Continue? [y/n]")) << std::endl;
+        printf("%s\n"
+            , qUtf8Printable(QObject::tr("You updated from an older version that saved things differently. You must migrate to the new saving system. You will not be able to use an older version than v3.3.0 again. Continue? [y/n]")));
         ret = getchar(); // Read pressed key
     }
     while ((ret != 'y') && (ret != 'Y') && (ret != 'n') && (ret != 'N'));

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1789,16 +1789,16 @@ void Session::processShareLimits()
                     if ((ratio <= TorrentHandle::MAX_RATIO) && (ratio >= ratioLimit)) {
                         Logger* const logger = Logger::instance();
                         if (m_maxRatioAction == Remove) {
-                            logger->addMessage(tr("'%1' reached the maximum ratio you set. Removed.").arg(torrent->name()));
+                            logger->addMessage(tr("'%1' reached the maximum ratio you set. Removed torrent.").arg(torrent->name()));
                             deleteTorrent(torrent->hash());
                         }
                         else if (m_maxRatioAction == Delete) {
-                            logger->addMessage(tr("'%1' reached the maximum ratio you set. Deleted.").arg(torrent->name()));
-                            deleteTorrent(torrent->hash(),true);
+                            logger->addMessage(tr("'%1' reached the maximum ratio you set. Removed torrent + folder.").arg(torrent->name()));
+                            deleteTorrent(torrent->hash(), true);
                         }
-                        else if (m_maxRatioAction == Force) {
-                            logger->addMessage(tr("'%1' reached the maximum ratio you set. Force Delete.").arg(torrent->name()));
-                            deleteTorrent(torrent->hash(),true, true);
+                        else if (m_maxRatioAction == ForceDelete) {
+                            logger->addMessage(tr("'%1' reached the maximum ratio you set. Removed torrent + folder (force).").arg(torrent->name()));
+                            deleteTorrent(torrent->hash(), true, true);
                         }
                         else if (!torrent->isPaused()) {
                             torrent->pause();
@@ -1822,16 +1822,16 @@ void Session::processShareLimits()
                     if ((seedingTimeInMinutes <= TorrentHandle::MAX_SEEDING_TIME) && (seedingTimeInMinutes >= seedingTimeLimit)) {
                         Logger* const logger = Logger::instance();
                         if (m_maxRatioAction == Remove) {
-                            logger->addMessage(tr("'%1' reached the maximum seeding time you set. Removed.").arg(torrent->name()));
+                            logger->addMessage(tr("'%1' reached the maximum seeding time you set. Removed torrent.").arg(torrent->name()));
                             deleteTorrent(torrent->hash());
                         }
                         else if (m_maxRatioAction == Delete) {
-                            logger->addMessage(tr("'%1' reached the maximum seeding time you set. Deleted.").arg(torrent->name()));
-                            deleteTorrent(torrent->hash(),true);
+                            logger->addMessage(tr("'%1' reached the maximum seeding time you set. Removed torrent + folder.").arg(torrent->name()));
+                            deleteTorrent(torrent->hash(), true);
                         }
-                        else if (m_maxRatioAction == Force) {
-                            logger->addMessage(tr("'%1' reached the maximum seeding time you set. Force Delete.").arg(torrent->name()));
-                            deleteTorrent(torrent->hash(),true, true);
+                        else if (m_maxRatioAction == ForceDelete) {
+                            logger->addMessage(tr("'%1' reached the maximum seeding time you set. Removed torrent + folder (force).").arg(torrent->name()));
+                            deleteTorrent(torrent->hash(), true, true);
                         }
                         else if (!torrent->isPaused()) {
                             torrent->pause();

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -2381,9 +2381,7 @@ void Session::saveResumeData()
         std::vector<libt::alert *> alerts;
         getPendingAlerts(alerts, 30 * 1000);
         if (alerts.empty()) {
-            std::cerr << " aborting with " << m_numResumeData
-                      << " outstanding torrents to save resume data for"
-                      << std::endl;
+            fprintf(stderr, " aborting with %d outstanding torrents to save resume data for\n", m_numResumeData);
             break;
         }
 

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -123,7 +123,7 @@ enum MaxRatioAction
     Pause,
     Remove,
     Delete,
-    Force
+    ForceDelete
 };
 
 enum TorrentExportFolder

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -121,7 +121,9 @@ class ResumeDataSavingManager;
 enum MaxRatioAction
 {
     Pause,
-    Remove
+    Remove,
+    Delete,
+    Force
 };
 
 enum TorrentExportFolder
@@ -465,7 +467,7 @@ namespace BitTorrent
         bool isKnownTorrent(const InfoHash &hash) const;
         bool addTorrent(QString source, const AddTorrentParams &params = AddTorrentParams());
         bool addTorrent(const TorrentInfo &torrentInfo, const AddTorrentParams &params = AddTorrentParams());
-        bool deleteTorrent(const QString &hash, bool deleteLocalFiles = false);
+        bool deleteTorrent(const QString &hash, bool deleteLocalFiles = false, bool deleteForce = false);
         bool loadMetadata(const MagnetUri &magnetUri);
         bool cancelLoadMetadata(const InfoHash &hash);
 

--- a/src/gui/optionsdlg.ui
+++ b/src/gui/optionsdlg.ui
@@ -2622,22 +2622,22 @@
                  </property>
                  <item>
                   <property name="text">
-                   <string>Pause Torrents</string>
+                   <string>Pause torrents</string>
                   </property>
                  </item>
                  <item>
                   <property name="text">
-                   <string>Remove Torrents</string>
+                   <string>Remove torrents</string>
                   </property>
                  </item>
                  <item>
                   <property name="text">
-                   <string>Remove Torrents + Files</string>
+                   <string>Remove torrents + folders</string>
                   </property>
                  </item>
                  <item>
                   <property name="text">
-                   <string>Remove Torrents + Files + Force</string>
+                   <string>Remove torrents + folders (force)</string>
                   </property>
                  </item>
                 </widget>

--- a/src/gui/optionsdlg.ui
+++ b/src/gui/optionsdlg.ui
@@ -2622,12 +2622,22 @@
                  </property>
                  <item>
                   <property name="text">
-                   <string>Pause them</string>
+                   <string>Pause Torrents</string>
                   </property>
                  </item>
                  <item>
                   <property name="text">
-                   <string>Remove them</string>
+                   <string>Remove Torrents</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Remove Torrents + Files</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Remove Torrents + Files + Force</string>
                   </property>
                  </item>
                 </widget>

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -29,7 +29,6 @@
 
 #include "searchwidget.h"
 
-#include <iostream>
 #ifdef Q_OS_WIN
 #include <cstdlib>
 #endif

--- a/src/webui/www/private/preferences_content.html
+++ b/src/webui/www/private/preferences_content.html
@@ -340,8 +340,10 @@
   </td>
   <td>
   <select id="max_ratio_act">
-    <option value="0">QBT_TR(Pause them)QBT_TR[CONTEXT=OptionsDialog]</option>
-    <option value="1">QBT_TR(Remove them)QBT_TR[CONTEXT=OptionsDialog]</option>
+    <option value="0">QBT_TR(Pause Torrents)QBT_TR[CONTEXT=OptionsDialog]</option>
+    <option value="1">QBT_TR(Remove Torrents)QBT_TR[CONTEXT=OptionsDialog]</option>
+    <option value="2">QBT_TR(Remove Torrents + Files)QBT_TR[CONTEXT=OptionsDialog]</option>
+    <option value="3">QBT_TR(Remove Torrents + Files + Force)QBT_TR[CONTEXT=OptionsDialog]</option>
   </select>
   </td>
   </tr>

--- a/src/webui/www/private/preferences_content.html
+++ b/src/webui/www/private/preferences_content.html
@@ -340,10 +340,10 @@
   </td>
   <td>
   <select id="max_ratio_act">
-    <option value="0">QBT_TR(Pause Torrents)QBT_TR[CONTEXT=OptionsDialog]</option>
-    <option value="1">QBT_TR(Remove Torrents)QBT_TR[CONTEXT=OptionsDialog]</option>
-    <option value="2">QBT_TR(Remove Torrents + Files)QBT_TR[CONTEXT=OptionsDialog]</option>
-    <option value="3">QBT_TR(Remove Torrents + Files + Force)QBT_TR[CONTEXT=OptionsDialog]</option>
+    <option value="0">QBT_TR(Pause torrents)QBT_TR[CONTEXT=OptionsDialog]</option>
+    <option value="1">QBT_TR(Remove torrents)QBT_TR[CONTEXT=OptionsDialog]</option>
+    <option value="2">QBT_TR(Remove torrents + folders)QBT_TR[CONTEXT=OptionsDialog]</option>
+    <option value="3">QBT_TR(Remove torrents + folders (force))QBT_TR[CONTEXT=OptionsDialog]</option>
   </select>
   </td>
   </tr>


### PR DESCRIPTION
Closes #8151 & #8074. Added options to the webui to allow  for a couple new behaviors and reformatted previous options text to clarify... Options would now be as follows with behaviors as described:

- **Pause torrents**
    _Pauses torrents as before, no change in functionality_
- **Remove torrents**
    _Removes torrents as before, no change in functionality_
- **Remove torrents + folders**
    _Removes torrents and folders/files that are part of the torrent package (leaves behind non-empty dirs due to files from things like extracts)_
- **Remove torrents + folders (force)**
    _Removes torrents and folders/files that are part of the torrent root directory regardless of if they were part of the torrent package or not. (**Note:** This option allows for cleanup of any files in the torrent folder that weren't part of the torrent package (e.g. rar extracts)... but it also means that if you keep any files here intentionally when the cleanup runs they will be deleted)_

Updated formatting based on reviews:
![image](https://user-images.githubusercontent.com/5385821/38289476-4444b150-378b-11e8-9998-d16100c4e364.png)
