### PR TITLE
Make uncrustify.cfg available to QtCreator IDE

### DIFF
--- a/qbittorrent.pro
+++ b/qbittorrent.pro
@@ -17,3 +17,7 @@ tarball.commands += xz -f $${PROJECT_NAME}-$${PROJECT_VERSION}.tar &&
 tarball.commands += rm -fR $${PROJECT_NAME}-$${PROJECT_VERSION}
 
 QMAKE_EXTRA_TARGETS += tarball
+
+# For Qt Creator beautifier
+DISTFILES += \
+    uncrustify.cfg


### PR DESCRIPTION
Make uncrustify.cfg available to integrated into QT Creator IDE beautifier plugin.
![uncrutify](https://user-images.githubusercontent.com/14874367/38245512-8be50730-3768-11e8-8593-114c9acc4cc9.png)
