### PR TITLE
Add helper for loading Windows system functions

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -64,7 +64,6 @@
 
 #ifndef DISABLE_GUI
 #ifdef Q_OS_WIN
-#include <windows.h>
 #include <QSessionManager>
 #include <QSharedMemory>
 #endif // Q_OS_WIN
@@ -682,7 +681,7 @@ void Application::cleanup()
 
 #ifdef Q_OS_WIN
         typedef BOOL (WINAPI *PSHUTDOWNBRCREATE)(HWND, LPCWSTR);
-        PSHUTDOWNBRCREATE shutdownBRCreate = (PSHUTDOWNBRCREATE)::GetProcAddress(::GetModuleHandleW(L"User32.dll"), "ShutdownBlockReasonCreate");
+        const auto shutdownBRCreate = Utils::Misc::loadWinAPI<PSHUTDOWNBRCREATE>("User32.dll", "ShutdownBlockReasonCreate");
         // Only available on Vista+
         if (shutdownBRCreate)
             shutdownBRCreate((HWND)m_window->effectiveWinId(), tr("Saving torrent progress...").toStdWString().c_str());
@@ -724,7 +723,7 @@ void Application::cleanup()
     if (m_window) {
 #ifdef Q_OS_WIN
         typedef BOOL (WINAPI *PSHUTDOWNBRDESTROY)(HWND);
-        PSHUTDOWNBRDESTROY shutdownBRDestroy = (PSHUTDOWNBRDESTROY)::GetProcAddress(::GetModuleHandleW(L"User32.dll"), "ShutdownBlockReasonDestroy");
+        const auto shutdownBRDestroy = Utils::Misc::loadWinAPI<PSHUTDOWNBRDESTROY>("User32.dll", "ShutdownBlockReasonDestroy");
         // Only available on Vista+
         if (shutdownBRDestroy)
             shutdownBRDestroy((HWND)m_window->effectiveWinId());

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -4543,11 +4543,11 @@ namespace
             return uuid.toString().toUpper(); // Libtorrent expects the GUID in uppercase
 
         using PCONVERTIFACENAMETOLUID = NETIO_STATUS (WINAPI *)(const WCHAR *, PNET_LUID);
-        PCONVERTIFACENAMETOLUID ConvertIfaceNameToLuid = reinterpret_cast<PCONVERTIFACENAMETOLUID>(::GetProcAddress(::GetModuleHandleW(L"Iphlpapi.dll"), "ConvertInterfaceNameToLuidW"));
+        const auto ConvertIfaceNameToLuid = Utils::Misc::loadWinAPI<PCONVERTIFACENAMETOLUID>("Iphlpapi.dll", "ConvertInterfaceNameToLuidW");
         if (!ConvertIfaceNameToLuid) return QString();
 
         using PCONVERTIFACELUIDTOGUID = NETIO_STATUS (WINAPI *)(const NET_LUID *, GUID *);
-        PCONVERTIFACELUIDTOGUID ConvertIfaceLuidToGuid = reinterpret_cast<PCONVERTIFACELUIDTOGUID>(::GetProcAddress(::GetModuleHandleW(L"Iphlpapi.dll"), "ConvertInterfaceLuidToGuid"));
+        const auto ConvertIfaceLuidToGuid = Utils::Misc::loadWinAPI<PCONVERTIFACELUIDTOGUID>("Iphlpapi.dll", "ConvertInterfaceLuidToGuid");
         if (!ConvertIfaceLuidToGuid) return QString();
 
         NET_LUID luid;

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -124,7 +124,10 @@ void Utils::Misc::shutdownComputer(const ShutdownDialogAction &action)
             setSuspendState(true, false, false);
     }
     else {
-        InitiateSystemShutdownA(0, QCoreApplication::translate("misc", "qBittorrent will shutdown the computer now because all downloads are complete.").toLocal8Bit().data(), 10, true, false);
+        const QString msg = QCoreApplication::translate("misc", "qBittorrent will shutdown the computer now because all downloads are complete.");
+        std::unique_ptr<wchar_t[]> msgWchar(new wchar_t[msg.length() + 1] {});
+        msg.toWCharArray(msgWchar.get());
+        ::InitiateSystemShutdownW(nullptr, msgWchar.get(), 10, true, false);
     }
 
     // Disable shutdown privilege.

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -28,34 +28,18 @@
  * Contact : chris@qbittorrent.org
  */
 
-#include <QUrl>
-#include <QDir>
-#include <QFileInfo>
-#include <QDateTime>
-#include <QByteArray>
-#include <QDebug>
-#include <QProcess>
-#include <QRegularExpression>
-#include <QSysInfo>
+#include "misc.h"
+
 #include <boost/version.hpp>
 #include <libtorrent/version.hpp>
-
-#ifdef DISABLE_GUI
-#include <QCoreApplication>
-#else
-#include <QApplication>
-#include <QDesktopWidget>
-#include <QStyle>
-#endif
 
 #ifdef Q_OS_WIN
 #include <windows.h>
 #include <powrprof.h>
 #include <Shlobj.h>
-const int UNLEN = 256;
 #else
-#include <unistd.h>
 #include <sys/types.h>
+#include <unistd.h>
 #endif
 
 #ifdef Q_OS_MAC
@@ -63,33 +47,47 @@ const int UNLEN = 256;
 #include <Carbon/Carbon.h>
 #endif
 
-#ifndef DISABLE_GUI
+#include <QByteArray>
+#include <QDateTime>
+#include <QDebug>
+#include <QDir>
+#include <QFileInfo>
+#include <QProcess>
+#include <QRegularExpression>
+#include <QSysInfo>
+#include <QUrl>
+
+#ifdef DISABLE_GUI
+#include <QCoreApplication>
+#else
+#include <QApplication>
+#include <QDesktopServices>
+#include <QDesktopWidget>
+#include <QProcess>
+#include <QStyle>
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC)) && defined(QT_DBUS_LIB)
 #include <QDBusInterface>
 #include <QDBusMessage>
 #endif
-#endif // DISABLE_GUI
-
-#ifndef DISABLE_GUI
-#include <QDesktopServices>
-#include <QProcess>
 #endif
 
 #include "base/utils/string.h"
 #include "base/unicodestrings.h"
 #include "base/logger.h"
-#include "misc.h"
 #include "fs.h"
 
-static struct { const char *source; const char *comment; } units[] = {
-    QT_TRANSLATE_NOOP3("misc", "B", "bytes"),
-    QT_TRANSLATE_NOOP3("misc", "KiB", "kibibytes (1024 bytes)"),
-    QT_TRANSLATE_NOOP3("misc", "MiB", "mebibytes (1024 kibibytes)"),
-    QT_TRANSLATE_NOOP3("misc", "GiB", "gibibytes (1024 mibibytes)"),
-    QT_TRANSLATE_NOOP3("misc", "TiB", "tebibytes (1024 gibibytes)"),
-    QT_TRANSLATE_NOOP3("misc", "PiB", "pebibytes (1024 tebibytes)"),
-    QT_TRANSLATE_NOOP3("misc", "EiB", "exbibytes (1024 pebibytes)")
-};
+namespace
+{
+    const struct { const char *source; const char *comment; } units[] = {
+        QT_TRANSLATE_NOOP3("misc", "B", "bytes"),
+        QT_TRANSLATE_NOOP3("misc", "KiB", "kibibytes (1024 bytes)"),
+        QT_TRANSLATE_NOOP3("misc", "MiB", "mebibytes (1024 kibibytes)"),
+        QT_TRANSLATE_NOOP3("misc", "GiB", "gibibytes (1024 mibibytes)"),
+        QT_TRANSLATE_NOOP3("misc", "TiB", "tebibytes (1024 gibibytes)"),
+        QT_TRANSLATE_NOOP3("misc", "PiB", "pebibytes (1024 tebibytes)"),
+        QT_TRANSLATE_NOOP3("misc", "EiB", "exbibytes (1024 pebibytes)")
+    };
+}
 
 void Utils::Misc::shutdownComputer(const ShutdownDialogAction &action)
 {
@@ -474,6 +472,7 @@ QString Utils::Misc::getUserIDString()
 {
     QString uid = "0";
 #ifdef Q_OS_WIN
+    const int UNLEN = 256;
     WCHAR buffer[UNLEN + 1] = {0};
     DWORD buffer_len = sizeof(buffer) / sizeof(*buffer);
     if (GetUserNameW(buffer, &buffer_len))

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -34,6 +34,13 @@
 #include <ctime>
 #include <vector>
 
+#include <QtGlobal>
+
+#ifdef Q_OS_WIN
+#include <memory>
+#include <Windows.h>
+#endif
+
 #include <QDir>
 #include <QFile>
 #include <QPoint>
@@ -109,6 +116,22 @@ namespace Utils
 
 #ifdef Q_OS_WIN
         QString windowsSystemPath();
+
+        template <typename T>
+        T loadWinAPI(const QString &source, const char *funcName)
+        {
+            QString path = windowsSystemPath();
+            if (!path.endsWith('\\'))
+                path += '\\';
+
+            path += source;
+
+            std::unique_ptr<wchar_t[]> pathWchar(new wchar_t[path.length() + 1] {});
+            path.toWCharArray(pathWchar.get());
+
+            return reinterpret_cast<T>(
+                ::GetProcAddress(::LoadLibraryW(pathWchar.get()), funcName));
+        }
 #endif
     }
 }

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -31,15 +31,17 @@
 #ifndef UTILS_MISC_H
 #define UTILS_MISC_H
 
+#include <ctime>
 #include <vector>
+
+#include <QDir>
+#include <QFile>
+#include <QPoint>
+#include <QSize>
 #include <QString>
 #include <QStringList>
-#include <ctime>
-#include <QPoint>
-#include <QFile>
-#include <QDir>
 #include <QUrl>
-#include <QSize>
+
 #include "base/types.h"
 
 /*  Miscellaneous functions that can be useful */

--- a/winconf.pri
+++ b/winconf.pri
@@ -33,8 +33,8 @@ win32-g++* {
     }
 
     RC_FILE = qbittorrent_mingw.rc
-    
-    LIBS += libadvapi32 libshell32 libuser32 libole32 libwsock32 libws2_32 libpowrprof
+
+    LIBS += libadvapi32 libshell32 libuser32 libole32 libwsock32 libws2_32
 }
 else:win32-msvc* {
     CONFIG -= embed_manifest_exe
@@ -42,8 +42,8 @@ else:win32-msvc* {
     QMAKE_LFLAGS_RELEASE += "/OPT:REF /OPT:ICF"
 
     RC_FILE = qbittorrent.rc
-    
-    LIBS += advapi32.lib shell32.lib crypt32.lib User32.lib ole32.lib PowrProf.lib
+
+    LIBS += advapi32.lib shell32.lib crypt32.lib User32.lib ole32.lib
 }
 
 # See an example build configuration in "conf.pri.windows"


### PR DESCRIPTION
The dlls should be loaded from windows\system32 explicitly, otherwise it poses a security risk.