### PR TITLE
Move and recheck progress

### DIFF
--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -1445,8 +1445,8 @@ void TorrentHandle::handleStorageMovedAlert(const libtorrent::storage_moved_aler
         return;
     }
 
-    qDebug("Torrent is successfully moved from %s to %s"
-        , qUtf8Printable(m_moveStorageInfo.oldPath), qUtf8Printable(m_moveStorageInfo.newPath));
+    LogMsg(tr("Successfully moved torrent: %1. New path: %2").arg(name(), m_moveStorageInfo.newPath));
+
     const QDir oldDir {m_moveStorageInfo.oldPath};
     if ((oldDir == QDir(m_session->torrentTempPath(info())))
             && (oldDir != QDir(m_session->tempPath()))) {

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -519,15 +519,19 @@ int TorrentHandle::piecesHave() const
 
 qreal TorrentHandle::progress() const
 {
-    if (!m_nativeStatus.total_wanted)
-        return 0.;
+    if (!isChecking()) {
+        if (!m_nativeStatus.total_wanted)
+            return 0.;
 
-    if (m_nativeStatus.total_wanted_done == m_nativeStatus.total_wanted)
-        return 1.;
+        if (m_nativeStatus.total_wanted_done == m_nativeStatus.total_wanted)
+            return 1.;
 
-    float progress = static_cast<float>(m_nativeStatus.total_wanted_done) / m_nativeStatus.total_wanted;
-    Q_ASSERT((progress >= 0.f) && (progress <= 1.f));
-    return progress;
+        qreal progress = static_cast<qreal>(m_nativeStatus.total_wanted_done) / m_nativeStatus.total_wanted;
+        Q_ASSERT((progress >= 0.f) && (progress <= 1.f));
+        return progress;
+    }
+
+    return m_nativeStatus.progress;
 }
 
 QString TorrentHandle::category() const

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -149,6 +149,8 @@ namespace BitTorrent
         PausedDownloading,
         PausedUploading,
 
+        Moving,
+
         MissingFiles,
         Error
     };

--- a/src/gui/torrentmodel.cpp
+++ b/src/gui/torrentmodel.cpp
@@ -349,6 +349,7 @@ QIcon getIconByState(BitTorrent::TorrentState state)
     case BitTorrent::TorrentState::QueuedForChecking:
 #endif
     case BitTorrent::TorrentState::CheckingResumeData:
+    case BitTorrent::TorrentState::Moving:
         return getCheckingIcon();
     case BitTorrent::TorrentState::Unknown:
     case BitTorrent::TorrentState::MissingFiles:
@@ -404,6 +405,7 @@ QColor getColorByState(BitTorrent::TorrentState state)
     case BitTorrent::TorrentState::QueuedForChecking:
 #endif
     case BitTorrent::TorrentState::CheckingResumeData:
+    case BitTorrent::TorrentState::Moving:
         if (!dark)
             return QColor(0, 128, 128); // Teal
         else

--- a/src/gui/transferlistdelegate.cpp
+++ b/src/gui/transferlistdelegate.cpp
@@ -272,6 +272,9 @@ QString TransferListDelegate::getStatusString(const BitTorrent::TorrentState sta
     case BitTorrent::TorrentState::PausedUploading:
         str = tr("Completed");
         break;
+    case BitTorrent::TorrentState::Moving:
+        str = tr("Moving", "Torrent local data are being moved/relocated");
+        break;
     case BitTorrent::TorrentState::MissingFiles:
         str = tr("Missing Files");
         break;

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -76,6 +76,8 @@ namespace
 #endif
         case BitTorrent::TorrentState::CheckingResumeData:
             return QLatin1String("checkingResumeData");
+        case BitTorrent::TorrentState::Moving:
+            return QLatin1String("moving");
         default:
             return QLatin1String("unknown");
         }

--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -327,7 +327,7 @@ namespace
 // Each value of the 'torrents' dictionary contains map. The map can contain following keys:
 //  - "name": Torrent name
 //  - "size": Torrent size
-//  - "progress: Torrent progress
+//  - "progress": Torrent progress
 //  - "dlspeed": Torrent download speed
 //  - "upspeed": Torrent upload speed
 //  - "priority": Torrent priority (-1 if queuing is disabled)

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -132,7 +132,7 @@ namespace
 //   - "hash": Torrent hash
 //   - "name": Torrent name
 //   - "size": Torrent size
-//   - "progress: Torrent progress
+//   - "progress": Torrent progress
 //   - "dlspeed": Torrent download speed
 //   - "upspeed": Torrent upload speed
 //   - "priority": Torrent priority (-1 if queuing is disabled)

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -814,6 +814,7 @@ var TorrentsTable = new Class({
                 case "checkingUP":
                 case "queuedForChecking":
                 case "checkingResumeData":
+                case "moving":
                     state = "checking";
                     break;
                 case "unknown":
@@ -886,6 +887,9 @@ var TorrentsTable = new Class({
                     break;
                 case "pausedUP":
                     status = "Completed";
+                    break;
+                case "moving":
+                    status = "Moving";
                     break;
                 case "missingFiles":
                     status = "Missing Files";


### PR DESCRIPTION
See individual commit messages for explanation.

~~**Attention**
The 1st commit was made on a false assumption. It turns out that libtorrent currently doesn't report the move progress, so I opened https://github.com/arvidn/libtorrent/issues/2923.
Please review as if the feature exists. I won't merge current PR before libtorrent adds the feature.
If the feature is denied I'll modify this PR too.~