### PR TITLE
Fix wrong QString::arg() usage that leads to crash

### DIFF
--- a/src/base/net/proxyconfigurationmanager.cpp
+++ b/src/base/net/proxyconfigurationmanager.cpp
@@ -139,10 +139,10 @@ void ProxyConfigurationManager::configureProxy()
                 , m_config.password, m_config.ip, QString::number(m_config.port));
             break;
         case ProxyType::HTTP:
-            proxyStrHTTP = QString("http://%1:%2").arg(m_config.ip, m_config.port);
+            proxyStrHTTP = QString("http://%1:%2").arg(m_config.ip, QString::number(m_config.port));
             break;
         case ProxyType::SOCKS5:
-            proxyStrSOCK = QString("%1:%2").arg(m_config.ip, m_config.port);
+            proxyStrSOCK = QString("%1:%2").arg(m_config.ip, QString::number(m_config.port));
             break;
         case ProxyType::SOCKS5_PW:
             proxyStrSOCK = QString("%1:%2@%3:%4").arg(m_config.username


### PR DESCRIPTION
We need to be careful when using the multi-arg version of
QString::arg() and passing as 2nd, 3rd etc parameter an int.
It doesn't do the same as passing multiple QStrings.