### PR TITLE
Fix renaming completed files

### DIFF
--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -712,7 +712,10 @@ void PropertiesWidget::renameSelectedFile()
             newName.chop(QB_EXT.size());
         const QString oldFileName = m_torrent->fileName(fileIndex);
         const QString oldFilePath = m_torrent->filePath(fileIndex);
-        const QString newFileName = newName + (BitTorrent::Session::instance()->isAppendExtensionEnabled() ? QB_EXT : QString());
+
+        const bool useFilenameExt = BitTorrent::Session::instance()->isAppendExtensionEnabled()
+            && (m_torrent->filesProgress()[fileIndex] != 1);
+        const QString newFileName = newName + (useFilenameExt ? QB_EXT : QString());
         const QString newFilePath = oldFilePath.leftRef(oldFilePath.size() - oldFileName.size()) + newFileName;
 
         if (oldFileName == newFileName) {


### PR DESCRIPTION
Check whether the file is already downloaded before appending QB_EXT to filename.
Closes #8039.