### PR TITLE
Add "Preserve file order" option to torrent creator. Closes #5652

### DIFF
--- a/src/base/bittorrent/torrentcreatorthread.cpp
+++ b/src/base/bittorrent/torrentcreatorthread.cpp
@@ -92,7 +92,8 @@ void TorrentCreatorThread::run()
 
         if (isInterruptionRequested()) return;
 
-        libt::create_torrent newTorrent(fs, m_params.pieceSize);
+        libt::create_torrent newTorrent(fs, m_params.pieceSize, -1
+            , (m_params.isAlignmentOptimized ? libt::create_torrent::optimize_alignment : 0));
 
         // Add url seeds
         foreach (QString seed, m_params.urlSeeds) {

--- a/src/base/bittorrent/torrentcreatorthread.cpp
+++ b/src/base/bittorrent/torrentcreatorthread.cpp
@@ -157,12 +157,13 @@ void TorrentCreatorThread::run()
     }
 }
 
-int TorrentCreatorThread::calculateTotalPieces(const QString &inputPath, const int pieceSize)
+int TorrentCreatorThread::calculateTotalPieces(const QString &inputPath, const int pieceSize, const bool isAlignmentOptimized)
 {
     if (inputPath.isEmpty())
         return 0;
 
     libt::file_storage fs;
     libt::add_files(fs, Utils::Fs::toNativePath(inputPath).toStdString(), fileFilter);
-    return libt::create_torrent(fs, pieceSize).num_pieces();
+    return libt::create_torrent(fs, pieceSize, -1
+        , (isAlignmentOptimized ? libt::create_torrent::optimize_alignment : 0)).num_pieces();
 }

--- a/src/base/bittorrent/torrentcreatorthread.h
+++ b/src/base/bittorrent/torrentcreatorthread.h
@@ -39,6 +39,7 @@ namespace BitTorrent
     struct TorrentCreatorParams
     {
         bool isPrivate;
+        bool isAlignmentOptimized;
         int pieceSize;
         QString inputPath;
         QString savePath;

--- a/src/base/bittorrent/torrentcreatorthread.h
+++ b/src/base/bittorrent/torrentcreatorthread.h
@@ -59,7 +59,7 @@ namespace BitTorrent
 
         void create(const TorrentCreatorParams &params);
 
-        static int calculateTotalPieces(const QString &inputPath, const int pieceSize);
+        static int calculateTotalPieces(const QString &inputPath, const int pieceSize, const bool isAlignmentOptimized);
 
     protected:
         void run();

--- a/src/gui/torrentcreatordlg.cpp
+++ b/src/gui/torrentcreatordlg.cpp
@@ -55,6 +55,7 @@ TorrentCreatorDlg::TorrentCreatorDlg(QWidget *parent, const QString &defaultPath
     , m_storePrivateTorrent(SETTINGS_KEY("PrivateTorrent"))
     , m_storeStartSeeding(SETTINGS_KEY("StartSeeding"))
     , m_storeIgnoreRatio(SETTINGS_KEY("IgnoreRatio"))
+    , m_storeOptimizeAlignment(SETTINGS_KEY("OptimizeAlignment"), true)
     , m_storeLastAddPath(SETTINGS_KEY("LastAddPath"), QDir::homePath())
     , m_storeTrackerList(SETTINGS_KEY("TrackerList"))
     , m_storeWebSeedList(SETTINGS_KEY("WebSeedList"))
@@ -169,7 +170,8 @@ void TorrentCreatorDlg::onCreateButtonClicked()
     const QString source = m_ui->lineEditSource->text();
 
     // run the creator thread
-    m_creatorThread->create({ m_ui->checkPrivate->isChecked(), getPieceSize()
+    m_creatorThread->create({ m_ui->checkPrivate->isChecked()
+        , m_ui->checkOptimizeAlignment->isChecked(), getPieceSize()
         , input, destination, comment, source, trackers, urlSeeds });
 }
 
@@ -241,6 +243,7 @@ void TorrentCreatorDlg::saveSettings()
     m_storePrivateTorrent = m_ui->checkPrivate->isChecked();
     m_storeStartSeeding = m_ui->checkStartSeeding->isChecked();
     m_storeIgnoreRatio = m_ui->checkIgnoreShareLimits->isChecked();
+    m_storeOptimizeAlignment = m_ui->checkOptimizeAlignment->isChecked();
 
     m_storeTrackerList = m_ui->trackersList->toPlainText();
     m_storeWebSeedList = m_ui->URLSeedsList->toPlainText();
@@ -258,6 +261,7 @@ void TorrentCreatorDlg::loadSettings()
     m_ui->checkPrivate->setChecked(m_storePrivateTorrent);
     m_ui->checkStartSeeding->setChecked(m_storeStartSeeding);
     m_ui->checkIgnoreShareLimits->setChecked(m_storeIgnoreRatio);
+    m_ui->checkOptimizeAlignment->setChecked(m_storeOptimizeAlignment);
     m_ui->checkIgnoreShareLimits->setEnabled(m_ui->checkStartSeeding->isChecked());
 
     m_ui->trackersList->setPlainText(m_storeTrackerList);

--- a/src/gui/torrentcreatordlg.cpp
+++ b/src/gui/torrentcreatordlg.cpp
@@ -215,8 +215,9 @@ void TorrentCreatorDlg::updateProgressBar(int progress)
 void TorrentCreatorDlg::updatePiecesCount()
 {
     const QString path = m_ui->textInputPath->text().trimmed();
+    const bool isAlignmentOptimized = m_ui->checkOptimizeAlignment->isChecked();
 
-    const int count = BitTorrent::TorrentCreatorThread::calculateTotalPieces(path, getPieceSize());
+    const int count = BitTorrent::TorrentCreatorThread::calculateTotalPieces(path, getPieceSize(), isAlignmentOptimized);
     m_ui->labelTotalPieces->setText(QString::number(count));
 }
 

--- a/src/gui/torrentcreatordlg.h
+++ b/src/gui/torrentcreatordlg.h
@@ -80,6 +80,7 @@ private:
     CachedSettingValue<bool> m_storePrivateTorrent;
     CachedSettingValue<bool> m_storeStartSeeding;
     CachedSettingValue<bool> m_storeIgnoreRatio;
+    CachedSettingValue<bool> m_storeOptimizeAlignment;
     CachedSettingValue<QString> m_storeLastAddPath;
     CachedSettingValue<QString> m_storeTrackerList;
     CachedSettingValue<QString> m_storeWebSeedList;

--- a/src/gui/torrentcreatordlg.ui
+++ b/src/gui/torrentcreatordlg.ui
@@ -224,6 +224,16 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QCheckBox" name="checkOptimizeAlignment">
+        <property name="text">
+         <string>Optimize alignment</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -329,6 +339,7 @@
   <tabstop>checkPrivate</tabstop>
   <tabstop>checkStartSeeding</tabstop>
   <tabstop>checkIgnoreShareLimits</tabstop>
+  <tabstop>checkOptimizeAlignment</tabstop>
   <tabstop>trackersList</tabstop>
   <tabstop>URLSeedsList</tabstop>
   <tabstop>txtComment</tabstop>


### PR DESCRIPTION
Adds an optional "Preserve file order" checkbox when creating torrents (like in utorrent and others). Mainly used in private trackers.

Tested on windows, would be nice if someone could check if it works on linux / osx as intended - Chocobo1 said similar code hadn't worked in the past for some reason (full details unknown) in https://github.com/qbittorrent/qBittorrent/issues/5652.