### PR TITLE
Add missing "override" 

### DIFF
--- a/src/app/application.h
+++ b/src/app/application.h
@@ -110,7 +110,7 @@ public:
 protected:
 #ifndef DISABLE_GUI
 #ifdef Q_OS_MAC
-    bool event(QEvent *);
+    bool event(QEvent *) override;
 #endif
     bool notify(QObject* receiver, QEvent* event) override;
 #endif


### PR DESCRIPTION
```
../../qBittorrent/src/app/application.h:113:10: warning: 'event' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    bool event(QEvent *);
         ^
../../Qt-5.10.1/lib/QtWidgets.framework/Headers/qapplication.h:204:10: note: overridden virtual function is here
    bool event(QEvent *) Q_DECL_OVERRIDE;
         ^
1 warning generated.
```