### PR TITLE
Enable more compiler warnings on linux

### DIFF
--- a/unixconf.pri
+++ b/unixconf.pri
@@ -12,7 +12,7 @@ exists($$OUT_PWD/../conf.pri) {
 # COMPILATION SPECIFIC
 !nogui:dbus: QT += dbus
 
-QMAKE_CXXFLAGS += -Wformat -Wformat-security
+QMAKE_CXXFLAGS += -Wall -Wextra -Wpedantic -Wformat-security
 !haiku: QMAKE_LFLAGS_APP += -rdynamic
 
 # Man page


### PR DESCRIPTION
Those warning flags are most common IMO. Surprisingly the code base still compiles cleanly without any new warning (on my system)!

GCC manual:
https://gcc.gnu.org/onlinedocs/gcc-8.1.0/gcc/Warning-Options.html#Warning-Options
