### PR TITLE
Fix compilation with MinGW

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -94,6 +94,7 @@
 #include "trackerentry.h"
 
 #ifdef Q_OS_WIN
+#include <wincrypt.h>
 #include <iphlpapi.h>
 #endif
 


### PR DESCRIPTION
For some reason `iphlpapi.h` uses some definitions from `wincrypt.h` but doesn't include it.