### PR TITLE
Detect endianness at compile time

### DIFF
--- a/src/base/net/private/geoipdatabase.cpp
+++ b/src/base/net/private/geoipdatabase.cpp
@@ -38,8 +38,6 @@
 
 namespace
 {
-    const quint32 __ENDIAN_TEST__ = 0x00000001;
-    const bool __IS_LITTLE_ENDIAN__ = (reinterpret_cast<const uchar *>(&__ENDIAN_TEST__)[0] == 0x01);
     const qint32 MAX_FILE_SIZE = 67108864; // 64MB
     const char DB_TYPE[] = "GeoLite2-Country";
     const quint32 MAX_METADATA_SIZE = 131072; // 128KB
@@ -448,8 +446,12 @@ bool GeoIPDatabase::readDataFieldDescriptor(quint32 &offset, DataFieldDescriptor
 
 void GeoIPDatabase::fromBigEndian(uchar *buf, quint32 len) const
 {
-    if (__IS_LITTLE_ENDIAN__)
-        std::reverse(buf, buf + len);
+#if (Q_BYTE_ORDER == Q_LITTLE_ENDIAN)
+    std::reverse(buf, buf + len);
+#else
+    Q_UNUSED(buf);
+    Q_UNUSED(len);
+#endif
 }
 
 QVariant GeoIPDatabase::readMapValue(quint32 &offset, quint32 count) const


### PR DESCRIPTION
My original intention was removing double underscore in variable names.