### PR TITLE
Improve code of  RSS auto-downloading rule. Closes #8933

### DIFF
--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -365,19 +365,7 @@ void AutoDownloader::processJob(const QSharedPointer<ProcessingJob> &job)
     for (AutoDownloadRule &rule: m_rules) {
         if (!rule.isEnabled()) continue;
         if (!rule.feedURLs().contains(job->feedURL)) continue;
-        if (!rule.matches(job->articleData.value(Article::KeyTitle).toString())) continue;
-
-        auto articleDate = job->articleData.value(Article::KeyDate).toDateTime();
-        // if rule is in ignoring state do nothing with matched torrent
-        if (rule.ignoreDays() > 0) {
-            if (rule.lastMatch().isValid()) {
-                if (articleDate < rule.lastMatch().addDays(rule.ignoreDays()))
-                    return;
-            }
-        }
-
-        rule.setLastMatch(articleDate);
-        rule.appendLastComputedEpisode();
+        if (!rule.accepts(job->articleData)) continue;
 
         m_dirty = true;
         storeDeferred();

--- a/src/base/rss/rss_autodownloadrule.h
+++ b/src/base/rss/rss_autodownloadrule.h
@@ -95,7 +95,11 @@ namespace RSS
         static AutoDownloadRule fromLegacyDict(const QVariantHash &dict);
 
     private:
-        bool matches(const QString &articleTitle, const QString &expression) const;
+        bool matchesMustContainExpression(const QString &articleTitle) const;
+        bool matchesMustNotContainExpression(const QString &articleTitle) const;
+        bool matchesEpisodeFilterExpression(const QString &articleTitle) const;
+        bool matchesSmartEpisodeFilter(const QString &articleTitle) const;
+        bool matchesExpression(const QString &articleTitle, const QString &expression) const;
         QRegularExpression cachedRegex(const QString &expression, bool isRegex = true) const;
 
         QSharedDataPointer<AutoDownloadRuleData> m_dataPtr;

--- a/src/base/rss/rss_autodownloadrule.h
+++ b/src/base/rss/rss_autodownloadrule.h
@@ -71,7 +71,6 @@ namespace RSS
         QString episodeFilter() const;
         void setEpisodeFilter(const QString &e);
 
-        void appendLastComputedEpisode();
         QStringList previouslyMatchedEpisodes() const;
         void setPreviouslyMatchedEpisodes(const QStringList &previouslyMatchedEpisodes);
 
@@ -82,7 +81,8 @@ namespace RSS
         QString assignedCategory() const;
         void setCategory(const QString &category);
 
-        bool matches(const QString &articleTitle) const;
+        bool matches(const QVariantHash &articleData) const;
+        bool accepts(const QVariantHash &articleData);
 
         AutoDownloadRule &operator=(const AutoDownloadRule &other);
         bool operator==(const AutoDownloadRule &other) const;

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -114,6 +114,8 @@ AutomatedRssDownloader::AutomatedRssDownloader(QWidget *parent)
     connect(m_ui->checkRegex, &QCheckBox::stateChanged, this, &AutomatedRssDownloader::updateMustLineValidity);
     connect(m_ui->checkRegex, &QCheckBox::stateChanged, this, &AutomatedRssDownloader::updateMustNotLineValidity);
     connect(m_ui->checkSmart, &QCheckBox::stateChanged, this, &AutomatedRssDownloader::handleRuleDefinitionChanged);
+    connect(m_ui->spinIgnorePeriod, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged)
+            , this, &AutomatedRssDownloader::handleRuleDefinitionChanged);
 
     connect(m_ui->listFeeds, &QListWidget::itemChanged, this, &AutomatedRssDownloader::handleFeedCheckStateChange);
 
@@ -581,7 +583,7 @@ void AutomatedRssDownloader::updateMatchingArticles()
 
             QStringList matchingArticles;
             foreach (auto article, feed->articles())
-                if (rule.matches(article->title()))
+                if (rule.matches(article->data()))
                     matchingArticles << article->title();
             if (!matchingArticles.isEmpty())
                 addFeedArticlesToTree(feed, matchingArticles);

--- a/src/gui/rss/automatedrssdownloader.ui
+++ b/src/gui/rss/automatedrssdownloader.ui
@@ -107,17 +107,6 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="checkSmart">
-            <property name="toolTip">
-		    <string>Smart Episode Filter will check the episode number to prevent downloading of duplicates.
-Supports the formats: S01E01, 1x1, 2017.01.01 and 01.01.2017 (Date formats also support - as a separator)</string>
-            </property>
-            <property name="text">
-             <string>Use Smart Episode Filter</string>
-            </property>
-           </widget>
-          </item>
-          <item>
            <layout class="QGridLayout" name="gridLayout">
             <item row="0" column="0">
              <widget class="QLabel" name="label_4">
@@ -190,6 +179,17 @@ Supports the formats: S01E01, 1x1, 2017.01.01 and 01.01.2017 (Date formats also 
              <widget class="QLineEdit" name="lineEFilter"/>
             </item>
            </layout>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="checkSmart">
+            <property name="toolTip">
+            <string>Smart Episode Filter will check the episode number to prevent downloading of duplicates.
+Supports the formats: S01E01, 1x1, 2017.01.01 and 01.01.2017 (Date formats also support - as a separator)</string>
+            </property>
+            <property name="text">
+             <string>Use Smart Episode Filter</string>
+            </property>
+           </widget>
           </item>
           <item>
            <widget class="Line" name="line">


### PR DESCRIPTION
Current matching code has a bug. When Episode filter matches the article it prevents Smart filter from execution.
Now the matching code correctly process all sub-filters.