### PR TITLE
Rename torrent if content was initially renamed. Closes #8910

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -2149,12 +2149,26 @@ bool Session::addTorrent_impl(AddTorrentData addData, const MagnetUri &magnetUri
         p = magnetUri.addTorrentParams();
     }
     else if (torrentInfo.isValid()) {
-        if (!addData.resumed && !addData.hasRootFolder)
-            torrentInfo.stripRootFolder();
+        if (!addData.resumed) {
+            if (!addData.hasRootFolder)
+                torrentInfo.stripRootFolder();
 
-        // Metadata
-        if (!addData.resumed && !addData.hasSeedStatus)
-            findIncompleteFiles(torrentInfo, savePath);
+            // Metadata
+            if (!addData.hasSeedStatus)
+                findIncompleteFiles(torrentInfo, savePath);
+
+            // if torrent name wasn't explicitly set we handle the case of
+            // initial renaming of torrent content and rename torrent accordingly
+            if (addData.name.isEmpty()) {
+                QString contentName = torrentInfo.rootFolder();
+                if (contentName.isEmpty() && (torrentInfo.filesCount() == 1))
+                    contentName = torrentInfo.fileName(0);
+
+                if (!contentName.isEmpty() && (contentName != torrentInfo.name()))
+                    addData.name = contentName;
+            }
+        }
+
         p.ti = torrentInfo.nativeInfo();
         hash = torrentInfo.hash();
     }

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -362,24 +362,29 @@ int BitTorrent::TorrentInfo::fileIndex(const QString& fileName) const
     return -1;
 }
 
-bool TorrentInfo::hasRootFolder() const
+QString TorrentInfo::rootFolder() const
 {
-    QString testRootFolder;
+    QString rootFolder;
     for (int i = 0; i < filesCount(); ++i) {
         const QString filePath = this->filePath(i);
         if (QDir::isAbsolutePath(filePath)) continue;
 
         const auto filePathElements = filePath.splitRef('/');
         // if at least one file has no root folder, no common root folder exists
-        if (filePathElements.count() <= 1) return false;
+        if (filePathElements.count() <= 1) return "";
 
-        if (testRootFolder.isEmpty())
-            testRootFolder = filePathElements.at(0).toString();
-        else if (testRootFolder != filePathElements.at(0))
-            return false;
+        if (rootFolder.isEmpty())
+            rootFolder = filePathElements.at(0).toString();
+        else if (rootFolder != filePathElements.at(0))
+            return "";
     }
 
-    return true;
+    return rootFolder;
+}
+
+bool TorrentInfo::hasRootFolder() const
+{
+    return !rootFolder().isEmpty();
 }
 
 void TorrentInfo::stripRootFolder()

--- a/src/base/bittorrent/torrentinfo.h
+++ b/src/base/bittorrent/torrentinfo.h
@@ -104,6 +104,7 @@ namespace BitTorrent
 
         void renameFile(uint index, const QString &newPath);
 
+        QString rootFolder() const;
         bool hasRootFolder() const;
         void stripRootFolder();
 


### PR DESCRIPTION
Traditionally the torrent name is the name of its content (i.e. the file name for single-file torrents or root folder name for multi-file torrents).
qBittorrent allows you to rename torrent and its content independently. However, when a user renames the contents of a torrent when it is added, it usually expects the torrent name to follow the name of its contents.