### PR TITLE
Use RSS feed update time as a fallback. Closes #8959

### DIFF
--- a/src/base/rss/rss_autodownloadrule.cpp
+++ b/src/base/rss/rss_autodownloadrule.cpp
@@ -384,6 +384,8 @@ bool AutoDownloadRule::accepts(const QVariantHash &articleData)
         m_dataPtr->previouslyMatchedEpisodes.append(m_dataPtr->lastComputedEpisode);
         m_dataPtr->lastComputedEpisode.clear();
     }
+
+    return true;
 }
 
 AutoDownloadRule &AutoDownloadRule::operator=(const AutoDownloadRule &other)

--- a/src/base/rss/rss_feed.cpp
+++ b/src/base/rss/rss_feed.cpp
@@ -212,7 +212,13 @@ void Feed::handleParsingFinished(const RSS::Private::ParsingResult &result)
         m_lastBuildDate = result.lastBuildDate;
 
         int newArticlesCount = 0;
-        for (const QVariantHash &varHash : result.articles) {
+        const QDateTime now {QDateTime::currentDateTime()};
+        for (QVariantHash varHash : result.articles) {
+            // if article has no publication date we use feed update time as a fallback
+            QVariant &articleDate = varHash[Article::KeyDate];
+            if (!articleDate.toDateTime().isValid())
+                articleDate = now;
+
             try {
                 auto article = new Article(this, varHash);
                 if (addArticle(article))


### PR DESCRIPTION
Some sites omit publication date in its RSS feed articles
that prevents "Ignore Subsequent Matches" to work properly.
