### PR TITLE
Update conf.pri.windows from #8701

### DIFF
--- a/conf.pri.windows
+++ b/conf.pri.windows
@@ -58,4 +58,4 @@ DEFINES += BOOST_USE_WINAPI_VERSION=0x0501
 #DEFINES += TORRENT_LINKING_SHARED
 
 # Enable stack trace support
-CONFIG += strace_win
+CONFIG += stacktrace


### PR DESCRIPTION
It is advised to update the stack trace statement since #8701, otherwise people may forget to change it, which results in no pdb file generated for Windows distribution package.