### PR TITLE
Clear LineEdit on ESC

### DIFF
--- a/src/gui/lineedit/src/lineedit.cpp
+++ b/src/gui/lineedit/src/lineedit.cpp
@@ -40,3 +40,11 @@ void LineEdit::resizeEvent(QResizeEvent *e)
     const int frameWidth = style()->pixelMetric(QStyle::PM_DefaultFrameWidth);
     m_searchButton->move(frameWidth, (e->size().height() - m_searchButton->sizeHint().height()) / 2);
 }
+
+void LineEdit::keyPressEvent(QKeyEvent *event)
+{
+    if ((event->modifiers() == Qt::NoModifier) && (event->key() == Qt::Key_Escape)) {
+        clear();
+    }
+    QLineEdit::keyPressEvent(event);
+}

--- a/src/gui/lineedit/src/lineedit.h
+++ b/src/gui/lineedit/src/lineedit.h
@@ -23,6 +23,7 @@ public:
 
 protected:
     void resizeEvent(QResizeEvent *e) override;
+    void keyPressEvent(QKeyEvent *event) override;
 
 private:
     QToolButton *m_searchButton;


### PR DESCRIPTION
This PR clears LineEdit on ESC keypress, LineEdit is used on three places, as Filter box for torrents, on Content tab for filtering files in a torrent and in search engine.