### PR TITLE
Initialize variables properly

### DIFF
--- a/src/app/stacktrace_win.h
+++ b/src/app/stacktrace_win.h
@@ -138,7 +138,7 @@ bool straceWin::makeRelativePath(const QString& dir, QString& file)
 
 QString straceWin::getSourcePathAndLineNumber(HANDLE hProcess, DWORD64 addr)
 {
-    IMAGEHLP_LINE64 line = {0};
+    IMAGEHLP_LINE64 line {};
     line.SizeOfStruct = sizeof(IMAGEHLP_LINE64);
     DWORD dwDisplacement = 0;
 

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -132,7 +132,7 @@ namespace
         QPixmap pixmapForExtension(const QString &ext) const override
         {
             const QString extWithDot = QLatin1Char('.') + ext;
-            SHFILEINFO sfi = { 0 };
+            SHFILEINFO sfi {};
             HRESULT hr = ::SHGetFileInfoW(extWithDot.toStdWString().c_str(),
                 FILE_ATTRIBUTE_NORMAL, &sfi, sizeof(sfi), SHGFI_ICON | SHGFI_USEFILEATTRIBUTES);
             if (FAILED(hr))


### PR DESCRIPTION
The warning was:
```
gui/torrentcontentmodel.cpp:135:33: warning: missing initializer for member '_SHFILEINFOW::iIcon' [-Wmissing-field-initializers]
gui/torrentcontentmodel.cpp:135:33: warning: missing initializer for member '_SHFILEINFOW::dwAttributes' [-Wmissing-field-initializers]
gui/torrentcontentmodel.cpp:135:33: warning: missing initializer for member '_SHFILEINFOW::szDisplayName' [-Wmissing-field-initializers]
gui/torrentcontentmodel.cpp:135:33: warning: missing initializer for member '_SHFILEINFOW::szTypeName' [-Wmissing-field-initializers]
```