### PR TITLE
Bump Web API version

### DIFF
--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -41,8 +41,8 @@
 #include "base/http/types.h"
 #include "base/utils/version.h"
 
-constexpr Utils::Version<int, 3, 2> API_VERSION {2, 0, 0};
-constexpr int COMPAT_API_VERSION = 18;
+constexpr Utils::Version<int, 3, 2> API_VERSION {2, 0, 1};
+constexpr int COMPAT_API_VERSION = 19;
 constexpr int COMPAT_API_VERSION_MIN = 18;
 
 class APIController;


### PR DESCRIPTION
As far I see, PR #8782 makes API changes. 

Am I correct that older clients can ignore the new parameter and continue to work?
If so, this PR is correct. Otherwise, I'll

```c++
constexpr Utils::Version<int, 3, 2> API_VERSION {2, 1, 0};
constexpr int COMPAT_API_VERSION = 19;
constexpr int COMPAT_API_VERSION_MIN = 19;
```