### PR TITLE
 Pause session till all torrents are fully started 

### DIFF
--- a/src/app/application.h
+++ b/src/app/application.h
@@ -147,6 +147,7 @@ private:
     void runExternalProgram(const BitTorrent::TorrentHandle *torrent) const;
     void sendNotificationEmail(const BitTorrent::TorrentHandle *torrent);
     void validateCommandLineParameters();
+    void handleStartUpFinished();
 };
 
 #endif // APPLICATION_H

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -9,6 +9,7 @@ bittorrent/magneturi.h
 bittorrent/peerinfo.h
 bittorrent/private/bandwidthscheduler.h
 bittorrent/private/filterparserthread.h
+bittorrent/private/resumedataloadingmanager.h
 bittorrent/private/resumedatasavingmanager.h
 bittorrent/private/speedmonitor.h
 bittorrent/private/statistics.h
@@ -81,6 +82,7 @@ bittorrent/magneturi.cpp
 bittorrent/peerinfo.cpp
 bittorrent/private/bandwidthscheduler.cpp
 bittorrent/private/filterparserthread.cpp
+bittorrent/private/resumedataloadingmanager.cpp
 bittorrent/private/resumedatasavingmanager.cpp
 bittorrent/private/speedmonitor.cpp
 bittorrent/private/statistics.cpp

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -8,6 +8,7 @@ HEADERS += \
     $$PWD/bittorrent/peerinfo.h \
     $$PWD/bittorrent/private/bandwidthscheduler.h \
     $$PWD/bittorrent/private/filterparserthread.h \
+    $$PWD/bittorrent/private/resumedataloadingmanager.h \
     $$PWD/bittorrent/private/resumedatasavingmanager.h \
     $$PWD/bittorrent/private/speedmonitor.h \
     $$PWD/bittorrent/private/statistics.h \
@@ -80,6 +81,7 @@ SOURCES += \
     $$PWD/bittorrent/peerinfo.cpp \
     $$PWD/bittorrent/private/bandwidthscheduler.cpp \
     $$PWD/bittorrent/private/filterparserthread.cpp \
+    $$PWD/bittorrent/private/resumedataloadingmanager.cpp \
     $$PWD/bittorrent/private/resumedatasavingmanager.cpp \
     $$PWD/bittorrent/private/speedmonitor.cpp \
     $$PWD/bittorrent/private/statistics.cpp \

--- a/src/base/bittorrent/private/resumedataloadingmanager.cpp
+++ b/src/base/bittorrent/private/resumedataloadingmanager.cpp
@@ -1,0 +1,237 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2018  sledgehammer999 <hammered999@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "resumedataloadingmanager.h"
+
+#include <QDebug>
+#include <QMutexLocker>
+#include <QRegularExpression>
+
+#include "base/logger.h"
+#include "base/profile.h"
+#include "base/bittorrent/session.h"
+#include "base/utils/fs.h"
+
+namespace libt = libtorrent;
+using namespace BitTorrent;
+
+namespace
+{
+    bool readFile(const QString &path, QByteArray &buf);
+    bool loadTorrentResumeData(const QByteArray &data, CreateTorrentParams &torrentParams, int &prio, MagnetUri &magnetUri);
+}
+
+ResumeDataLoadingManager::ResumeDataLoadingManager(const QString &resumeFolderPath)
+    : m_resumeDataReady(false)
+    , m_lock(QMutex::Recursive)
+    , m_resumeDataDir(resumeFolderPath)
+{
+}
+
+void ResumeDataLoadingManager::loadTorrents()
+{
+    QStringList fastresumes = m_resumeDataDir.entryList(
+                QStringList(QLatin1String("*.fastresume")), QDir::Files, QDir::Unsorted);
+
+    int loadedCount = 0;
+    int nextQueuePosition = 1;
+    int numOfRemappedFiles = 0;
+    const QRegularExpression rx(QLatin1String("^([A-Fa-f0-9]{40})\\.fastresume$"));
+    foreach (const QString &fastresumeName, fastresumes) {
+        const QRegularExpressionMatch rxMatch = rx.match(fastresumeName);
+        if (!rxMatch.hasMatch()) continue;
+
+        QString hash = rxMatch.captured(1);
+        QString fastresumePath = m_resumeDataDir.absoluteFilePath(fastresumeName);
+        QByteArray data;
+        CreateTorrentParams torrentParams;
+        MagnetUri magnetUri;
+        int queuePosition;
+        if (readFile(fastresumePath, data) && loadTorrentResumeData(data, torrentParams, queuePosition, magnetUri)) {
+            ++loadedCount;
+            QString filePath = m_resumeDataDir.filePath(QString("%1.torrent").arg(hash));
+
+            if (queuePosition <= nextQueuePosition) {
+                QMutexLocker locker(&m_lock);
+                m_readyResumeData.push_back({hash, magnetUri, torrentParams, TorrentInfo::loadFromFile(filePath), data});
+
+                if (queuePosition == nextQueuePosition) {
+                    ++nextQueuePosition;
+                    while (m_queuedResumeData.contains(nextQueuePosition)) {
+                        m_readyResumeData.push_back(m_queuedResumeData.take(nextQueuePosition));
+                        ++nextQueuePosition;
+                    }
+                }
+
+                if (!m_resumeDataReady) {
+                    emit resumeDataReady();
+                    m_resumeDataReady = true;
+                }
+            }
+            else {
+                int q = queuePosition;
+                for (; m_queuedResumeData.contains(q); ++q) {
+                }
+                if (q != queuePosition) {
+                    ++numOfRemappedFiles;
+                }
+                m_queuedResumeData[q] = {hash, magnetUri, torrentParams, TorrentInfo::loadFromFile(filePath), data};
+            }
+        }
+    }
+
+    if (numOfRemappedFiles > 0)
+        LogMsg(tr("Queue positions were corrected in %1 resume files").arg(numOfRemappedFiles), Log::CRITICAL);
+
+    // readyresumeData might not have been emptied by the main thread yet
+    // so we need to append to that
+    QMutexLocker locker(&m_lock);
+    for (auto it = m_queuedResumeData.cbegin(); it != m_queuedResumeData.cend(); ++it)
+        m_readyResumeData.push_back(it.value());
+    m_queuedResumeData.clear();
+
+    if (!m_resumeDataReady) {
+        emit resumeDataReady();
+        m_resumeDataReady = true;
+    }
+
+    emit loadingFinished(loadedCount);
+}
+
+void ResumeDataLoadingManager::getResumeData(QVector<TorrentResumeData> &out)
+{
+    QMutexLocker locker(&m_lock);
+    out.clear();
+    m_readyResumeData.swap(out);
+    m_resumeDataReady = false;
+}
+
+namespace
+{
+    template <typename Entry>
+    QSet<QString> entryListToSetImpl(const Entry &entry)
+    {
+        Q_ASSERT(entry.type() == Entry::list_t);
+        QSet<QString> output;
+        for (int i = 0; i < entry.list_size(); ++i) {
+            const QString tag = QString::fromStdString(entry.list_string_value_at(i));
+            if (Session::isValidTag(tag))
+                output.insert(tag);
+            else
+                qWarning() << QString("Dropping invalid stored tag: %1").arg(tag);
+        }
+        return output;
+    }
+
+#if LIBTORRENT_VERSION_NUM < 10100
+    bool isList(const libt::lazy_entry *entry)
+    {
+        return entry && (entry->type() == libt::lazy_entry::list_t);
+    }
+
+    QSet<QString> entryListToSet(const libt::lazy_entry *entry)
+    {
+        return entry ? entryListToSetImpl(*entry) : QSet<QString>();
+    }
+#else
+    bool isList(const libt::bdecode_node &entry)
+    {
+        return entry.type() == libt::bdecode_node::list_t;
+    }
+
+    QSet<QString> entryListToSet(const libt::bdecode_node &entry)
+    {
+        return entryListToSetImpl(entry);
+    }
+#endif
+
+    bool readFile(const QString &path, QByteArray &buf)
+    {
+        QFile file(path);
+        if (!file.open(QIODevice::ReadOnly)) {
+            qDebug("Cannot read file %s: %s", qUtf8Printable(path), qUtf8Printable(file.errorString()));
+            return false;
+        }
+
+        buf = file.readAll();
+        return true;
+    }
+
+    bool loadTorrentResumeData(const QByteArray &data, CreateTorrentParams &torrentParams, int &prio,  MagnetUri &magnetUri)
+    {
+        torrentParams = CreateTorrentParams();
+        torrentParams.restored = true;
+        torrentParams.skipChecking = false;
+
+        libt::error_code ec;
+#if LIBTORRENT_VERSION_NUM < 10100
+        libt::lazy_entry fast;
+        libt::lazy_bdecode(data.constData(), data.constData() + data.size(), fast, ec);
+        if (ec || (fast.type() != libt::lazy_entry::dict_t)) return false;
+#else
+        libt::bdecode_node fast;
+        libt::bdecode(data.constData(), data.constData() + data.size(), fast, ec);
+        if (ec || (fast.type() != libt::bdecode_node::dict_t)) return false;
+#endif
+
+        torrentParams.savePath = Profile::instance().fromPortablePath(
+                                   Utils::Fs::fromNativePath(QString::fromStdString(fast.dict_find_string_value("qBt-savePath"))));
+
+        std::string ratioLimitString = fast.dict_find_string_value("qBt-ratioLimit");
+        if (ratioLimitString.empty())
+            torrentParams.ratioLimit = fast.dict_find_int_value("qBt-ratioLimit", TorrentHandle::USE_GLOBAL_RATIO * 1000) / 1000.0;
+        else
+            torrentParams.ratioLimit = QString::fromStdString(ratioLimitString).toDouble();
+        torrentParams.seedingTimeLimit = fast.dict_find_int_value("qBt-seedingTimeLimit", TorrentHandle::USE_GLOBAL_SEEDING_TIME);
+        // **************************************************************************************
+        // Workaround to convert legacy label to category
+        // TODO: Should be removed in future
+        torrentParams.category = QString::fromStdString(fast.dict_find_string_value("qBt-label"));
+        if (torrentParams.category.isEmpty())
+            // **************************************************************************************
+            torrentParams.category = QString::fromStdString(fast.dict_find_string_value("qBt-category"));
+        // auto because the return type depends on the #if above.
+        const auto tagsEntry = fast.dict_find_list("qBt-tags");
+        if (isList(tagsEntry))
+            torrentParams.tags = entryListToSet(tagsEntry);
+        torrentParams.name = QString::fromStdString(fast.dict_find_string_value("qBt-name"));
+        torrentParams.hasSeedStatus = fast.dict_find_int_value("qBt-seedStatus");
+        torrentParams.disableTempPath = fast.dict_find_int_value("qBt-tempPathDisabled");
+        torrentParams.hasRootFolder = fast.dict_find_int_value("qBt-hasRootFolder");
+
+        magnetUri = MagnetUri(QString::fromStdString(fast.dict_find_string_value("qBt-magnetUri")));
+        torrentParams.paused = fast.dict_find_int_value("qBt-paused");
+        torrentParams.forced = fast.dict_find_int_value("qBt-forced");
+        torrentParams.firstLastPiecePriority = fast.dict_find_int_value("qBt-firstLastPiecePriority");
+        torrentParams.sequential = fast.dict_find_int_value("qBt-sequential");
+
+        prio = fast.dict_find_int_value("qBt-queuePosition");
+
+        return true;
+    }
+}

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1354,11 +1354,7 @@ void Session::configure(libtorrent::settings_pack &settingsPack)
     settingsPack.set_int(libt::settings_pack::active_tracker_limit, -1);
     settingsPack.set_int(libt::settings_pack::active_dht_limit, -1);
     settingsPack.set_int(libt::settings_pack::active_lsd_limit, -1);
-    // 1 active torrent force 2 connections. If you have more active torrents * 2 than connection limit,
-    // connection limit will get extended. Multiply max connections or active torrents by 10 for queue.
-    // Ignore -1 values because we don't want to set a max int message queue
-    settingsPack.set_int(libt::settings_pack::alert_queue_size, std::max(1000,
-        10 * std::max(maxActiveTorrents() * 2, maxConnections())));
+    settingsPack.set_int(libt::settings_pack::alert_queue_size, std::numeric_limits<int>::max() / 2);
 
     // Outgoing ports
     settingsPack.set_int(libt::settings_pack::outgoing_port, outgoingPortsMin());
@@ -1633,11 +1629,7 @@ void Session::configure(libtorrent::session_settings &sessionSettings)
     sessionSettings.active_tracker_limit = -1;
     sessionSettings.active_dht_limit = -1;
     sessionSettings.active_lsd_limit = -1;
-    // 1 active torrent force 2 connections. If you have more active torrents * 2 than connection limit,
-    // connection limit will get extended. Multiply max connections or active torrents by 10 for queue.
-    // Ignore -1 values because we don't want to set a max int message queue
-    sessionSettings.alert_queue_size = std::max(1000,
-        10 * std::max(maxActiveTorrents() * 2, maxConnections()));
+    sessionSettings.alert_queue_size = std::numeric_limits<int>::max() / 2;
 
     // Outgoing ports
     sessionSettings.outgoing_ports = std::make_pair(outgoingPortsMin(), outgoingPortsMax());

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -86,6 +86,7 @@
 #include "magneturi.h"
 #include "private/bandwidthscheduler.h"
 #include "private/filterparserthread.h"
+#include "private/resumedataloadingmanager.h"
 #include "private/resumedatasavingmanager.h"
 #include "private/statistics.h"
 #include "torrenthandle.h"
@@ -110,9 +111,6 @@ using namespace BitTorrent;
 
 namespace
 {
-    bool readFile(const QString &path, QByteArray &buf);
-    bool loadTorrentResumeData(const QByteArray &data, CreateTorrentParams &torrentParams, int &prio, MagnetUri &magnetUri);
-
     void torrentQueuePositionUp(const libt::torrent_handle &handle);
     void torrentQueuePositionDown(const libt::torrent_handle &handle);
     void torrentQueuePositionTop(const libt::torrent_handle &handle);
@@ -137,43 +135,6 @@ namespace
             result[i.key()] = i.value();
         return result;
     }
-
-    template <typename Entry>
-    QSet<QString> entryListToSetImpl(const Entry &entry)
-    {
-        Q_ASSERT(entry.type() == Entry::list_t);
-        QSet<QString> output;
-        for (int i = 0; i < entry.list_size(); ++i) {
-            const QString tag = QString::fromStdString(entry.list_string_value_at(i));
-            if (Session::isValidTag(tag))
-                output.insert(tag);
-            else
-                qWarning() << QString("Dropping invalid stored tag: %1").arg(tag);
-        }
-        return output;
-    }
-
-#if LIBTORRENT_VERSION_NUM < 10100
-    bool isList(const libt::lazy_entry *entry)
-    {
-        return entry && (entry->type() == libt::lazy_entry::list_t);
-    }
-
-    QSet<QString> entryListToSet(const libt::lazy_entry *entry)
-    {
-        return entry ? entryListToSetImpl(*entry) : QSet<QString>();
-    }
-#else
-    bool isList(const libt::bdecode_node &entry)
-    {
-        return entry.type() == libt::bdecode_node::list_t;
-    }
-
-    QSet<QString> entryListToSet(const libt::bdecode_node &entry)
-    {
-        return entryListToSetImpl(entry);
-    }
-#endif
 
     QString normalizePath(const QString &path)
     {
@@ -372,6 +333,7 @@ Session::Session(QObject *parent)
     , m_useProxy(false)
     , m_recentErroredTorrentsTimer(new QTimer(this))
     , m_startedCount(0)
+    , m_loadedCount(0)
     , m_started(false)
 {
     Logger *const logger = Logger::instance();
@@ -519,6 +481,7 @@ Session::Session(QObject *parent)
     m_resumeDataSavingManager = new ResumeDataSavingManager(m_resumeFolderPath);
     m_resumeDataSavingManager->moveToThread(m_ioThread);
     connect(m_ioThread, &QThread::finished, m_resumeDataSavingManager, &QObject::deleteLater);
+
     m_ioThread->start();
 
     // Regular saving of fastresume data
@@ -3810,85 +3773,44 @@ void Session::startUpTorrents()
 {
     qDebug("Resuming torrents...");
 
-    const QDir resumeDataDir(m_resumeFolderPath);
-    QStringList fastresumes = resumeDataDir.entryList(
-                QStringList(QLatin1String("*.fastresume")), QDir::Files, QDir::Unsorted);
-    Logger *const logger = Logger::instance();
+    ResumeDataLoadingManager *resumeDataLoadingManager = new ResumeDataLoadingManager(m_resumeFolderPath);
+    resumeDataLoadingManager->moveToThread(m_ioThread);
 
-    typedef struct
+
+
+    const auto startupTorrent = [this, resumeDataLoadingManager]()
     {
-        QString hash;
-        MagnetUri magnetUri;
-        CreateTorrentParams addTorrentData;
-        QByteArray data;
-    } TorrentResumeData;
+        int resumedTorrentsCount = 0;
+        QVector<ResumeDataLoadingManager::TorrentResumeData> resumeData;
+        resumeDataLoadingManager->getResumeData(resumeData);
 
-    int resumedTorrentsCount = 0;
-    const auto startupTorrent = [this, logger, &resumeDataDir, &resumedTorrentsCount](const TorrentResumeData &params)
-    {
-        QString filePath = resumeDataDir.filePath(QString("%1.torrent").arg(params.hash));
-        qDebug() << "Starting up torrent" << params.hash << "...";
-        ++m_startedCount;
-        if (!addTorrent_impl(params.addTorrentData, params.magnetUri, TorrentInfo::loadFromFile(filePath), params.data))
-            logger->addMessage(tr("Unable to resume torrent '%1'.", "e.g: Unable to resume torrent 'hash'.")
-                               .arg(params.hash), Log::CRITICAL);
+        for (const auto rd : resumeData) {
+            qDebug() << "Starting up torrent" << rd.hash << "...";
+            if (!addTorrent_impl(rd.torrentParams, rd.magnetUri, rd.info, rd.data))
+                LogMsg(tr("Unable to resume torrent '%1'.", "e.g: Unable to resume torrent 'hash'.")
+                                   .arg(rd.hash), Log::CRITICAL);
 
-        // process add torrent messages before message queue overflow
-        if ((resumedTorrentsCount % 100) == 0) readAlerts();
+            // process add torrent messages before message queue overflow
+            if ((resumedTorrentsCount % 100) == 0) readAlerts();
 
-        ++resumedTorrentsCount;
+            ++resumedTorrentsCount;
+        }
     };
 
-    qDebug("Starting up torrents");
-    qDebug("Queue size: %d", fastresumes.size());
-    // Resume downloads
-    QMap<int, TorrentResumeData> queuedResumeData;
-    int nextQueuePosition = 1;
-    int numOfRemappedFiles = 0;
-    const QRegularExpression rx(QLatin1String("^([A-Fa-f0-9]{40})\\.fastresume$"));
-    foreach (const QString &fastresumeName, fastresumes) {
-        const QRegularExpressionMatch rxMatch = rx.match(fastresumeName);
-        if (!rxMatch.hasMatch()) continue;
+    const auto torrentsLoaded = [this](int loadedCount)
+    {
+        m_loadedCount = loadedCount;
+        if (m_startedCount == m_loadedCount)
+            handleStartUpFinished();
+    };
 
-        QString hash = rxMatch.captured(1);
-        QString fastresumePath = resumeDataDir.absoluteFilePath(fastresumeName);
-        QByteArray data;
-        CreateTorrentParams torrentParams;
-        MagnetUri magnetUri;
-        int queuePosition;
-        if (readFile(fastresumePath, data) && loadTorrentResumeData(data, torrentParams, queuePosition, magnetUri)) {
-            if (queuePosition <= nextQueuePosition) {
-                startupTorrent({ hash, magnetUri, torrentParams, data });
+    connect(resumeDataLoadingManager, &ResumeDataLoadingManager::resumeDataReady, this, startupTorrent);
+    connect(resumeDataLoadingManager, &ResumeDataLoadingManager::loadingFinished, this, torrentsLoaded);
+    connect(resumeDataLoadingManager, &ResumeDataLoadingManager::loadingFinished, resumeDataLoadingManager, &QObject::deleteLater);
+    connect(m_ioThread, &QThread::finished, resumeDataLoadingManager, &QObject::deleteLater);
 
-                if (queuePosition == nextQueuePosition) {
-                    ++nextQueuePosition;
-                    while (queuedResumeData.contains(nextQueuePosition)) {
-                        startupTorrent(queuedResumeData.take(nextQueuePosition));
-                        ++nextQueuePosition;
-                    }
-                }
-            }
-            else {
-                int q = queuePosition;
-                for (; queuedResumeData.contains(q); ++q) {
-                }
-                if (q != queuePosition) {
-                    ++numOfRemappedFiles;
-                }
-                queuedResumeData[q] = {hash, magnetUri, torrentParams, data};
-            }
-        }
-    }
 
-    if (numOfRemappedFiles > 0) {
-        logger->addMessage(
-            QString(tr("Queue positions were corrected in %1 resume files")).arg(numOfRemappedFiles),
-            Log::CRITICAL);
-    }
-
-    // starting up downloading torrents (queue position > 0)
-    foreach (const TorrentResumeData &torrentResumeData, queuedResumeData)
-        startupTorrent(torrentResumeData);
+    QMetaObject::invokeMethod(resumeDataLoadingManager, "loadTorrents");
 }
 
 quint64 Session::getAlltimeDL() const
@@ -4134,7 +4056,7 @@ void Session::handleAddTorrentAlert(libt::add_torrent_alert *p)
 {
     if (p->error) {
         qDebug("/!\\ Error: Failed to add torrent!");
-        if (!m_started) --m_startedCount;
+        if (!m_started) ++m_startedCount;
         QString msg = QString::fromStdString(p->message());
         Logger::instance()->addMessage(tr("Couldn't add torrent. Reason: %1").arg(msg), Log::WARNING);
         emit addTorrentFailed(msg);
@@ -4147,8 +4069,8 @@ void Session::handleAddTorrentAlert(libt::add_torrent_alert *p)
 void Session::handleTorrentAddedAlert()
 {
     if (m_started) return;
-    --m_startedCount;
-    if (m_startedCount == 0)
+    ++m_startedCount;
+    if (m_startedCount == m_loadedCount)
         handleStartUpFinished();
 }
 
@@ -4506,71 +4428,6 @@ void Session::handleStateUpdateAlert(libt::state_update_alert *p)
 
 namespace
 {
-    bool readFile(const QString &path, QByteArray &buf)
-    {
-        QFile file(path);
-        if (!file.open(QIODevice::ReadOnly)) {
-            qDebug("Cannot read file %s: %s", qUtf8Printable(path), qUtf8Printable(file.errorString()));
-            return false;
-        }
-
-        buf = file.readAll();
-        return true;
-    }
-
-    bool loadTorrentResumeData(const QByteArray &data, CreateTorrentParams &torrentParams, int &prio,  MagnetUri &magnetUri)
-    {
-        torrentParams = CreateTorrentParams();
-        torrentParams.restored = true;
-        torrentParams.skipChecking = false;
-
-        libt::error_code ec;
-#if LIBTORRENT_VERSION_NUM < 10100
-        libt::lazy_entry fast;
-        libt::lazy_bdecode(data.constData(), data.constData() + data.size(), fast, ec);
-        if (ec || (fast.type() != libt::lazy_entry::dict_t)) return false;
-#else
-        libt::bdecode_node fast;
-        libt::bdecode(data.constData(), data.constData() + data.size(), fast, ec);
-        if (ec || (fast.type() != libt::bdecode_node::dict_t)) return false;
-#endif
-
-        torrentParams.savePath = Profile::instance().fromPortablePath(
-            Utils::Fs::fromNativePath(QString::fromStdString(fast.dict_find_string_value("qBt-savePath"))));
-
-        std::string ratioLimitString = fast.dict_find_string_value("qBt-ratioLimit");
-        if (ratioLimitString.empty())
-            torrentParams.ratioLimit = fast.dict_find_int_value("qBt-ratioLimit", TorrentHandle::USE_GLOBAL_RATIO * 1000) / 1000.0;
-        else
-            torrentParams.ratioLimit = QString::fromStdString(ratioLimitString).toDouble();
-        torrentParams.seedingTimeLimit = fast.dict_find_int_value("qBt-seedingTimeLimit", TorrentHandle::USE_GLOBAL_SEEDING_TIME);
-        // **************************************************************************************
-        // Workaround to convert legacy label to category
-        // TODO: Should be removed in future
-        torrentParams.category = QString::fromStdString(fast.dict_find_string_value("qBt-label"));
-        if (torrentParams.category.isEmpty())
-        // **************************************************************************************
-            torrentParams.category = QString::fromStdString(fast.dict_find_string_value("qBt-category"));
-        // auto because the return type depends on the #if above.
-        const auto tagsEntry = fast.dict_find_list("qBt-tags");
-        if (isList(tagsEntry))
-            torrentParams.tags = entryListToSet(tagsEntry);
-        torrentParams.name = QString::fromStdString(fast.dict_find_string_value("qBt-name"));
-        torrentParams.hasSeedStatus = fast.dict_find_int_value("qBt-seedStatus");
-        torrentParams.disableTempPath = fast.dict_find_int_value("qBt-tempPathDisabled");
-        torrentParams.hasRootFolder = fast.dict_find_int_value("qBt-hasRootFolder");
-
-        magnetUri = MagnetUri(QString::fromStdString(fast.dict_find_string_value("qBt-magnetUri")));
-        torrentParams.paused = fast.dict_find_int_value("qBt-paused");
-        torrentParams.forced = fast.dict_find_int_value("qBt-forced");
-        torrentParams.firstLastPiecePriority = fast.dict_find_int_value("qBt-firstLastPiecePriority");
-        torrentParams.sequential = fast.dict_find_int_value("qBt-sequential");
-
-        prio = fast.dict_find_int_value("qBt-queuePosition");
-
-        return true;
-    }
-
     void torrentQueuePositionUp(const libt::torrent_handle &handle)
     {
         try {

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -754,7 +754,7 @@ namespace BitTorrent
         QPointer<BandwidthScheduler> m_bwScheduler;
         // Tracker
         QPointer<Tracker> m_tracker;
-        // fastresume data writing thread
+        // fastresume data writing/loading thread
         QThread *m_ioThread;
         ResumeDataSavingManager *m_resumeDataSavingManager;
 
@@ -773,6 +773,7 @@ namespace BitTorrent
 
         // Used in starting up
         int m_startedCount;
+        int m_loadedCount;
         bool m_started;
 
 #if LIBTORRENT_VERSION_NUM < 10100

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -508,7 +508,6 @@ namespace BitTorrent
         void torrentsUpdated();
         void addTorrentFailed(const QString &error);
         void torrentAdded(BitTorrent::TorrentHandle *const torrent);
-        void torrentNew(BitTorrent::TorrentHandle *const torrent);
         void torrentAboutToBeRemoved(BitTorrent::TorrentHandle *const torrent);
         void torrentPaused(BitTorrent::TorrentHandle *const torrent);
         void torrentResumed(BitTorrent::TorrentHandle *const torrent);
@@ -541,6 +540,7 @@ namespace BitTorrent
         void subcategoriesSupportChanged();
         void tagAdded(const QString &tag);
         void tagRemoved(const QString &tag);
+        void startupFinished();
 
     private slots:
         void configureDeferred();
@@ -610,6 +610,7 @@ namespace BitTorrent
         void handleAlert(libtorrent::alert *a);
         void dispatchTorrentAlert(libtorrent::alert *a);
         void handleAddTorrentAlert(libtorrent::add_torrent_alert *p);
+        void handleTorrentAddedAlert();
         void handleStateUpdateAlert(libtorrent::state_update_alert *p);
         void handleMetadataReceivedAlert(libtorrent::metadata_received_alert *p);
         void handleFileErrorAlert(libtorrent::file_error_alert *p);
@@ -624,6 +625,7 @@ namespace BitTorrent
         void handleListenSucceededAlert(libtorrent::listen_succeeded_alert *p);
         void handleListenFailedAlert(libtorrent::listen_failed_alert *p);
         void handleExternalIPAlert(libtorrent::external_ip_alert *p);
+        void handleStartUpFinished();
 #if LIBTORRENT_VERSION_NUM >= 10100
         void handleSessionStatsAlert(libtorrent::session_stats_alert *p);
 #endif
@@ -768,6 +770,10 @@ namespace BitTorrent
         // I/O errored torrents
         QSet<InfoHash> m_recentErroredTorrents;
         QTimer *m_recentErroredTorrentsTimer;
+
+        // Used in starting up
+        int m_startedCount;
+        bool m_started;
 
 #if LIBTORRENT_VERSION_NUM < 10100
         QMutex m_alertsMutex;

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -1664,20 +1664,18 @@ void TorrentHandle::handleSaveResumeDataFailedAlert(const libtorrent::save_resum
 
 void TorrentHandle::handleFastResumeRejectedAlert(const libtorrent::fastresume_rejected_alert *p)
 {
-    qDebug("/!\\ Fast resume failed for %s, reason: %s", qUtf8Printable(name()), p->message().c_str());
-
-    updateStatus();
     if (p->error.value() == libt::errors::mismatching_file_size) {
         // Mismatching file size (files were probably moved)
-        LogMsg(tr("File sizes mismatch for torrent '%1', pausing it.").arg(name()), Log::CRITICAL);
+        pause();
         m_hasMissingFiles = true;
-        if (!isPaused())
-            pause();
+        LogMsg(tr("File sizes mismatch for torrent '%1', pausing it.").arg(name()), Log::CRITICAL);
     }
     else {
         LogMsg(tr("Fast resume data was rejected for torrent '%1'. Reason: %2. Checking again...")
             .arg(name(), QString::fromStdString(p->message())), Log::CRITICAL);
     }
+
+    updateStatus();
 }
 
 void TorrentHandle::handleFileRenamedAlert(const libtorrent::file_renamed_alert *p)

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -83,7 +83,7 @@ namespace
     }
 }
 
-// AddTorrentData
+// CreateTorrentParams
 
 CreateTorrentParams::CreateTorrentParams()
     : restored(false)

--- a/src/gui/categoryfiltermodel.cpp
+++ b/src/gui/categoryfiltermodel.cpp
@@ -181,6 +181,12 @@ CategoryFilterModel::CategoryFilterModel(QObject *parent)
     connect(session, &Session::categoryRemoved, this, &CategoryFilterModel::categoryRemoved);
     connect(session, &Session::torrentCategoryChanged, this, &CategoryFilterModel::torrentCategoryChanged);
     connect(session, &Session::subcategoriesSupportChanged, this, &CategoryFilterModel::subcategoriesSupportChanged);
+    connect(session, &Session::startupFinished, this, [this, session]()
+    {
+        for (auto it = session->torrents().cbegin(); it != session->torrents().cend(); ++it) {
+            torrentAdded(it.value());
+        }
+    });
     connect(session, &Session::torrentAdded, this, &CategoryFilterModel::torrentAdded);
     connect(session, &Session::torrentAboutToBeRemoved, this, &CategoryFilterModel::torrentAboutToBeRemoved);
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -259,6 +259,8 @@ MainWindow::MainWindow(QWidget *parent)
 #endif
         tr("Transfers"));
 
+    m_tabs->hide();
+
     connect(m_searchFilter, &LineEdit::textChanged, m_transferListWidget, &TransferListWidget::applyNameFilter);
     connect(hSplitter, &QSplitter::splitterMoved, this, &MainWindow::writeSettings);
     connect(m_splitter, &QSplitter::splitterMoved, this, &MainWindow::writeSettings);
@@ -277,7 +279,9 @@ MainWindow::MainWindow(QWidget *parent)
     m_ui->centralWidgetLayout->addSpacing(8);
 #endif
 
-    m_ui->centralWidgetLayout->addWidget(m_tabs);
+    QLabel *startUpLabel = new QLabel(tr("Torrents are being loaded from disk. Please wait..."));
+    startUpLabel->setAlignment(Qt::AlignCenter);
+    m_ui->centralWidgetLayout->addWidget(startUpLabel);
 
     m_prioSeparator = m_ui->toolBar->insertSeparator(m_ui->actionTopPriority);
     m_prioSeparatorMenu = m_ui->menuEdit->insertSeparator(m_ui->actionTopPriority);
@@ -1422,8 +1426,15 @@ void MainWindow::setEnabledWidgets(bool enabled)
     m_ui->centralWidget->setEnabled(enabled);
     m_statusBar->setEnabled(enabled);
 
-    if (enabled)
+    if (enabled) {
         displayRSSTab(m_ui->actionRSSReader->isChecked());
+
+        QLayoutItem *item = m_ui->centralWidgetLayout->takeAt(0);
+        delete item->widget();
+        delete item;
+        m_ui->centralWidgetLayout->addWidget(m_tabs);
+        m_tabs->show();
+    }
 
     m_sessionStarted = enabled;
 }

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -212,7 +212,7 @@ MainWindow::MainWindow(QWidget *parent)
     // Creating Bittorrent session
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::fullDiskError, this, &MainWindow::fullDiskError);
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::addTorrentFailed, this, &MainWindow::addTorrentFailed);
-    connect(BitTorrent::Session::instance(), &BitTorrent::Session::torrentNew,this, &MainWindow::torrentNew);
+    connect(BitTorrent::Session::instance(), &BitTorrent::Session::torrentAdded,this, &MainWindow::torrentNew);
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::torrentFinished, this, &MainWindow::finishedTorrent);
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackerAuthenticationRequired, this, &MainWindow::trackerAuthenticationRequired);
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::downloadFromUrlFailed, this, &MainWindow::handleDownloadFromUrlFailure);

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -100,6 +100,8 @@ public:
     void cleanup();
 
     void showNotificationBaloon(QString title, QString msg) const;
+    // After Application has handled BitTorrent::Session::startupFinished
+    void setEnabledWidgets(bool enabled);
 
 private slots:
     void balloonClicked();
@@ -258,6 +260,7 @@ private:
 #endif
     bool m_hasPython;
     QMenu *m_toolbarMenu;
+    bool m_sessionStarted;
 };
 
 #endif // MAINWINDOW_H

--- a/src/gui/tagfiltermodel.cpp
+++ b/src/gui/tagfiltermodel.cpp
@@ -97,6 +97,12 @@ TagFilterModel::TagFilterModel(QObject *parent)
     connect(session, &Session::tagRemoved, this, &TagFilterModel::tagRemoved);
     connect(session, &Session::torrentTagAdded, this, &TagFilterModel::torrentTagAdded);
     connect(session, &Session::torrentTagRemoved, this, &TagFilterModel::torrentTagRemoved);
+    connect(session, &Session::startupFinished, this, [this, session]()
+    {
+        for (auto it = session->torrents().cbegin(); it != session->torrents().cend(); ++it) {
+            torrentAdded(it.value());
+        }
+    });
     connect(session, &Session::torrentAdded, this, &TagFilterModel::torrentAdded);
     connect(session, &Session::torrentAboutToBeRemoved, this, &TagFilterModel::torrentAboutToBeRemoved);
     populate();

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -91,10 +91,17 @@ BaseFilterWidget::BaseFilterWidget(QWidget *parent, TransferListWidget *transfer
     connect(this, &BaseFilterWidget::customContextMenuRequested, this, &BaseFilterWidget::showMenu);
     connect(this, &BaseFilterWidget::currentRowChanged, this, &BaseFilterWidget::applyFilter);
 
-    connect(BitTorrent::Session::instance(), &BitTorrent::Session::torrentAdded
-            , this, &BaseFilterWidget::handleNewTorrent);
-    connect(BitTorrent::Session::instance(), &BitTorrent::Session::torrentAboutToBeRemoved
-            , this, &BaseFilterWidget::torrentAboutToBeDeleted);
+    using namespace BitTorrent;
+    auto session = Session::instance();
+
+    connect(session, &Session::startupFinished, this, [this, session]()
+    {
+        for (auto it = session->torrents().cbegin(); it != session->torrents().cend(); ++it) {
+            handleNewTorrent(it.value());
+        }
+    });
+    connect(session, &Session::torrentAdded, this, &BaseFilterWidget::handleNewTorrent);
+    connect(session, &Session::torrentAboutToBeRemoved, this, &BaseFilterWidget::torrentAboutToBeDeleted);
 }
 
 QSize BaseFilterWidget::sizeHint() const


### PR DESCRIPTION
There were many user reports that complained that qbt started downloading over their data when they had forgotten to plugin the drive the torrents were in. Or forgotten to mount the partition/share etc.

I was confused because I personally had implemented a measure against this. I was even more confused because I couldn't reproduce it. Until some days ago. After a lot of trial and error it turns out that during startup libtorrent produces a ton of alerts. A lot more than 1000 at a time. And these alerts ended up throwing out of the queue the `fastresume_rejected_alert` alerts, thus my counter measure was never activated. A longer discussion here: https://github.com/arvidn/libtorrent/issues/3045

Naturally as I had delved into this I discovered other inefficiencies. There's a timing issue where the torrent might start downloading and writing data to disk before we have the chance to pause it.
I opted to have the session paused untill all torrents were loaded and handled.

To my experience, the 3 alerts that interest us are received in this order:
`add_torrent_alert` -> `fastresume_rejected_alert` -> `torrent_added_alert`

About the "Temp solution" commit. This is temporary fix in order to publish the PR and have feedback from you. Relevant bug report: https://github.com/arvidn/libtorrent/issues/3071

IMO, it's better to see each commit by itself.

Caveats:
1. I didn't thoroughly test the PR. Please help by doing runs yourselves too.
2. The RC_1_0 code path wasn't even tested if it compiles. I will do it as final step before merge.