### PR TITLE
Revise usage of BOOST_NO_CXX11_RVALUE_REFERENCES

### DIFF
--- a/conf.pri.windows
+++ b/conf.pri.windows
@@ -50,6 +50,8 @@ DEFINES += BOOST_USE_WINAPI_VERSION=0x0501
 #DEFINES += BOOST_ASIO_SEPARATE_COMPILATION
 # Enable if building against libtorrent 1.0.x (RC_1_0) (dynamic linking)
 #DEFINES += BOOST_ASIO_DYN_LINK
+# Enable if encountered build error with boost version <= 1.59
+#DEFINES += BOOST_NO_CXX11_RVALUE_REFERENCES
 
 # Enable if building against libtorrent 1.1.x (RC_1_1)
 # built with this flag defined

--- a/configure
+++ b/configure
@@ -5014,6 +5014,40 @@ fi
 CPPFLAGS="$BOOST_CPPFLAGS $CPPFLAGS"
 LDFLAGS="$BOOST_LDFLAGS $LDFLAGS"
 
+# add workaround for problematic boost version
+ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+# taken from ax_boost_base.m4
+
+
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <boost/version.hpp>
+int
+main ()
+{
+(void) ((void)sizeof(char[1 - 2*!!((BOOST_VERSION) < (106000))]));
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+
+else
+  QBT_ADD_DEFINES="$QBT_ADD_DEFINES BOOST_NO_CXX11_RVALUE_REFERENCES"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
 
 
 # Check whether --with-boost-system was given.

--- a/configure.ac
+++ b/configure.ac
@@ -168,6 +168,17 @@ AX_BOOST_BASE([1.35],
 CPPFLAGS="$BOOST_CPPFLAGS $CPPFLAGS"
 LDFLAGS="$BOOST_LDFLAGS $LDFLAGS"
 
+# add workaround for problematic boost version
+AC_LANG_PUSH(C++)
+# taken from ax_boost_base.m4
+m4_define([DETECT_BOOST_VERSION_PROGRAM],
+    [AC_LANG_PROGRAM([[#include <boost/version.hpp>]],
+                     [[(void) ((void)sizeof(char[1 - 2*!!((BOOST_VERSION) < ($1))]));]])])
+
+AC_COMPILE_IFELSE([DETECT_BOOST_VERSION_PROGRAM(106000)], [],
+    [QBT_ADD_DEFINES="$QBT_ADD_DEFINES BOOST_NO_CXX11_RVALUE_REFERENCES"])
+AC_LANG_POP([C++])
+
 AX_BOOST_SYSTEM()
 AC_MSG_NOTICE([Boost.System LIB: "$BOOST_SYSTEM_LIB"])
 LIBS="$BOOST_SYSTEM_LIB $LIBS"

--- a/src/src.pro
+++ b/src/src.pro
@@ -4,7 +4,6 @@ CONFIG += qt thread silent
 
 # C++11 support
 CONFIG += c++11
-DEFINES += BOOST_NO_CXX11_RVALUE_REFERENCES
 
 # Platform specific configuration
 win32: include(../winconf.pri)


### PR DESCRIPTION
Now the flag will be present when building with boost version <= 1.59.
Closes #8990.
