### PR TITLE
Disable certain mouse wheel events in Options dialog

### DIFF
--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -485,10 +485,6 @@ void AdvancedSettings::loadAdvancedSettings()
 template <typename T>
 void AdvancedSettings::addRow(int row, const QString &rowText, T* widget)
 {
-    // ignore mouse wheel event
-    static WheelEventEater filter;
-    widget->installEventFilter(&filter);
-
     setItem(row, PROPERTY, new QTableWidgetItem(rowText));
     setCellWidget(row, VALUE, widget);
 

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -31,27 +31,10 @@
 
 #include <QCheckBox>
 #include <QComboBox>
-#include <QEvent>
 #include <QLabel>
 #include <QLineEdit>
 #include <QSpinBox>
 #include <QTableWidget>
-
-class WheelEventEater: public QObject
-{
-    Q_OBJECT
-
-private:
-    bool eventFilter(QObject *obj, QEvent *event)
-    {
-        switch (event->type()) {
-        case QEvent::Wheel:
-            return true;
-        default:
-            return QObject::eventFilter(obj, event);
-        }
-    }
-};
 
 class AdvancedSettings: public QTableWidget
 {

--- a/src/gui/optionsdlg.h
+++ b/src/gui/optionsdlg.h
@@ -172,22 +172,20 @@ private:
     bool isWebUiEnabled() const;
     QString webUiUsername() const;
     QString webUiPassword() const;
-
-private:
+    // WebUI SSL Cert / key
     bool setSslKey(const QByteArray &key);
     bool setSslCertificate(const QByteArray &cert);
     bool schedTimesOk();
     bool webUIAuthenticationOk();
 
-private:
+    QByteArray m_sslCert, m_sslKey;
+
     Ui::OptionsDialog *m_ui;
     QButtonGroup choiceLanguage;
     QAbstractButton *applyButton;
     AdvancedSettings *advancedSettings;
     QList<QString> addedScanDirs;
     QList<QString> removedScanDirs;
-    // SSL Cert / key
-    QByteArray m_sslCert, m_sslKey;
 };
 
 #endif


### PR DESCRIPTION
The mouse wheel events for QComboBox & QSpinBox widgets in Options dialog are filtered out.