### PR TITLE
Show current save path in 'Set location' window

### DIFF
--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -403,17 +403,20 @@ initializeWindows = function() {
     setLocationFN = function() {
         var hashes = torrentsTable.selectedRowsIds();
         if (hashes.length) {
+            var hash = hashes[0];
+            var row = torrentsTable.rows[hash];
+            var path = encodeURIComponent(row.full_data.save_path);
             new MochaUI.Window({
                 id: 'setLocationPage',
                 title: "QBT_TR(Set location)QBT_TR[CONTEXT=TransferListWidget]",
                 loadMethod: 'iframe',
-                contentURL: 'setlocation.html?hashes=' + hashes.join('|'),
+                contentURL: 'setlocation.html?hashes=' + hashes.join('|') + '&path=' + path,
                 scrollbars: false,
                 resizable: false,
                 maximizable: false,
                 paddingVertical: 0,
                 paddingHorizontal: 0,
-                width: 250,
+                width: 400,
                 height: 100
             });
         }

--- a/src/webui/www/private/setlocation.html
+++ b/src/webui/www/private/setlocation.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="css/style.css" type="text/css" />
     <script src="scripts/lib/mootools-1.2-core-yc.js"></script>
     <script src="scripts/lib/mootools-1.2-more.js"></script>
+    <script src="scripts/misc.js"></script>
     <script>
         var setLocationKeyboardEvents = new Keyboard({
             defaultEventType: 'keydown',
@@ -20,6 +21,11 @@
         setLocationKeyboardEvents.activate();
 
         window.addEvent('domready', function() {
+            var path = new URI().getData('path');
+            // set text field to current value
+            if (path)
+                $('setLocation').value = escapeHtml(decodeURIComponent(path));
+
             $('setLocation').focus();
             $('setLocationButton').addEvent('click', function(e) {
                 new Event(e).stop();
@@ -48,7 +54,7 @@
 <body>
     <div style="padding: 10px 10px 0px 10px;">
         <p style="font-weight: bold;">QBT_TR(Location)QBT_TR[CONTEXT=TransferListWidget]:</p>
-        <input type="text" id="setLocation" value="" maxlength="100" style="width: 220px;" />
+        <input type="text" id="setLocation" value="" maxlength="100" style="width: 370px;" />
         <div style="text-align: center; padding-top: 10px;">
             <input type="button" value="QBT_TR(Save)QBT_TR[CONTEXT=HttpServer]" id="setLocationButton" />
         </div>


### PR DESCRIPTION
The feature is useful when the user needs to move their torrent to a
sub or parent folder. If more than one torrent is chosen, the path
of the first selected torrent is used. The window was made wider to
allow more convenient editing of long paths.