### PR TITLE
Replace deprecated function on macOS

### DIFF
--- a/src/gui/powermanagement/powermanagement.cpp
+++ b/src/gui/powermanagement/powermanagement.cpp
@@ -73,7 +73,8 @@ void PowerManagement::setBusy()
 #elif (defined(Q_OS_UNIX) && !defined(Q_OS_MAC)) && defined(QT_DBUS_LIB)
     m_inhibitor->requestBusy();
 #elif defined(Q_OS_MAC)
-    IOReturn success = IOPMAssertionCreate(kIOPMAssertionTypeNoIdleSleep, kIOPMAssertionLevelOn, &m_assertionID);
+    IOReturn success = IOPMAssertionCreateWithName(kIOPMAssertionTypeNoIdleSleep, kIOPMAssertionLevelOn
+        , tr("qBittorrent is active").toCFString(), &m_assertionID);
     if (success != kIOReturnSuccess)
         m_busy = false;
 #endif


### PR DESCRIPTION
`IOPMAssertionCreate` is marked deprecated starting from Snow Leopard (10.6).
`IOPMAssertionCreateWithName` is available starting from Snow Leopard (10.6).
Since the minimum macOS we support is Mavericks (10.9), we should be able to do the replace.

Closes #8993.
