### PR TITLE
PEP 8 compliant version comments in search plugins

### DIFF
--- a/src/base/search/searchpluginmanager.cpp
+++ b/src/base/search/searchpluginmanager.cpp
@@ -554,19 +554,17 @@ PluginVersion SearchPluginManager::getPluginVersion(QString filePath)
 
     PluginVersion version;
     while (!plugin.atEnd()) {
-        QByteArray line = plugin.readLine();
-        if (line.startsWith("#VERSION: ")) {
-            line = line.split(' ').last().trimmed();
-            version = PluginVersion::tryParse(line, invalidVersion);
-            if (version == invalidVersion) {
-                LogMsg(tr("Search plugin '%1' contains invalid version string ('%2')")
-                    .arg(Utils::Fs::fileName(filePath), QString::fromUtf8(line)), Log::MsgType::WARNING);
-            }
-            else {
-                qDebug() << "plugin" << filePath << "version: " << version;
-            }
-            break;
+        const QString line = QString(plugin.readLine()).remove(' ');
+        if (!line.startsWith("#VERSION:", Qt::CaseInsensitive)) continue;
+
+        const QString versionStr = line.mid(9);
+        version = PluginVersion::tryParse(versionStr, invalidVersion);
+        if (version == invalidVersion) {
+            LogMsg(tr("Search plugin '%1' contains invalid version string ('%2')")
+                .arg(Utils::Fs::fileName(filePath), line), Log::MsgType::WARNING);
         }
+
+        break;
     }
     return version;
 }


### PR DESCRIPTION
It always bugs me that when I press auto-format in my IDE it destroys the version numbering for my search plugins.

See PEP 8 Style Guide

https://www.python.org/dev/peps/pep-0008/#inline-comments