### PR TITLE
Implement "Sequential downloading" feature. Closes #6835

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -547,7 +547,7 @@ namespace BitTorrent
         void generateResumeData(bool final = false);
         void handleIPFilterParsed(int ruleCount);
         void handleIPFilterError();
-        void handleDownloadFinished(const QString &url, const QString &filePath);
+        void handleDownloadFinished(const QString &url, const QByteArray &data);
         void handleDownloadFailed(const QString &url, const QString &reason);
         void handleRedirectedToMagnet(const QString &url, const QString &magnetUri);
 

--- a/src/base/net/dnsupdater.cpp
+++ b/src/base/net/dnsupdater.cpp
@@ -75,9 +75,8 @@ void DNSUpdater::checkPublicIP()
 {
     Q_ASSERT(m_state == OK);
 
-    DownloadHandler *handler = DownloadManager::instance()->downloadUrl(
-                "http://checkip.dyndns.org", false, 0, false,
-                "qBittorrent/" QBT_VERSION_2);
+    DownloadHandler *handler = DownloadManager::instance()->download(
+                DownloadRequest("http://checkip.dyndns.org").userAgent("qBittorrent/" QBT_VERSION_2));
     connect(handler, static_cast<void (Net::DownloadHandler::*)(const QString &, const QByteArray &)>(&Net::DownloadHandler::downloadFinished)
             , this, &DNSUpdater::ipRequestFinished);
     connect(handler, &Net::DownloadHandler::downloadFailed, this, &DNSUpdater::ipRequestFailed);
@@ -123,9 +122,8 @@ void DNSUpdater::updateDNSService()
     qDebug() << Q_FUNC_INFO;
 
     m_lastIPCheckTime = QDateTime::currentDateTime();
-    DownloadHandler *handler = DownloadManager::instance()->downloadUrl(
-                getUpdateUrl(), false, 0, false,
-                "qBittorrent/" QBT_VERSION_2);
+    DownloadHandler *handler = DownloadManager::instance()->download(
+                DownloadRequest(getUpdateUrl()).userAgent("qBittorrent/" QBT_VERSION_2));
     connect(handler, static_cast<void (Net::DownloadHandler::*)(const QString &, const QByteArray &)>(&Net::DownloadHandler::downloadFinished)
             , this, &DNSUpdater::ipUpdateFinished);
     connect(handler, &Net::DownloadHandler::downloadFailed, this, &DNSUpdater::ipUpdateFailed);

--- a/src/base/net/downloadhandler.h
+++ b/src/base/net/downloadhandler.h
@@ -31,6 +31,7 @@
 #define NET_DOWNLOADHANDLER_H
 
 #include <QObject>
+#include "downloadmanager.h"
 
 class QNetworkAccessManager;
 class QNetworkReply;
@@ -45,7 +46,7 @@ namespace Net
         Q_OBJECT
 
     public:
-        DownloadHandler(QNetworkReply *reply, DownloadManager *manager, bool saveToFile = false, qint64 limit = 0, bool handleRedirectToMagnet = false);
+        DownloadHandler(QNetworkReply *reply, DownloadManager *manager, const DownloadRequest &downloadRequest);
         ~DownloadHandler();
 
         QString url() const;
@@ -67,10 +68,7 @@ namespace Net
 
         QNetworkReply *m_reply;
         DownloadManager *m_manager;
-        bool m_saveToFile;
-        qint64 m_sizeLimit;
-        bool m_handleRedirectToMagnet;
-        QString m_url;
+        const DownloadRequest m_downloadRequest;
     };
 }
 

--- a/src/base/net/downloadhandler.h
+++ b/src/base/net/downloadhandler.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2015, 2018  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
@@ -33,7 +33,6 @@
 #include <QObject>
 #include "downloadmanager.h"
 
-class QNetworkAccessManager;
 class QNetworkReply;
 class QUrl;
 
@@ -44,10 +43,14 @@ namespace Net
     class DownloadHandler : public QObject
     {
         Q_OBJECT
+        Q_DISABLE_COPY(DownloadHandler)
+
+        friend class DownloadManager;
+
+        DownloadHandler(QNetworkReply *reply, DownloadManager *manager, const DownloadRequest &downloadRequest);
 
     public:
-        DownloadHandler(QNetworkReply *reply, DownloadManager *manager, const DownloadRequest &downloadRequest);
-        ~DownloadHandler();
+        ~DownloadHandler() override;
 
         QString url() const;
 
@@ -62,7 +65,7 @@ namespace Net
         void checkDownloadSize(qint64 bytesReceived, qint64 bytesTotal);
 
     private:
-        void init();
+        void assignNetworkReply(QNetworkReply *reply);
         bool saveToFile(const QByteArray &replyData, QString &filePath);
         void handleRedirection(QUrl newUrl);
 

--- a/src/base/net/downloadmanager.cpp
+++ b/src/base/net/downloadmanager.cpp
@@ -155,11 +155,6 @@ Net::DownloadManager *Net::DownloadManager::instance()
     return m_instance;
 }
 
-Net::DownloadHandler *Net::DownloadManager::downloadUrl(const QString &url, bool saveToFile, qint64 limit, bool handleRedirectToMagnet, const QString &userAgent)
-{
-    return download(DownloadRequest(url).saveToFile(saveToFile).limit(limit).handleRedirectToMagnet(handleRedirectToMagnet).userAgent(userAgent));
-}
-
 Net::DownloadHandler *Net::DownloadManager::download(const DownloadRequest &downloadRequest)
 {
     // Process download request

--- a/src/base/net/downloadmanager.cpp
+++ b/src/base/net/downloadmanager.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2015, 2018  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
@@ -103,28 +103,46 @@ namespace
             return QNetworkCookieJar::setCookiesFromUrl(cookies, url);
         }
     };
+
+    QNetworkRequest createNetworkRequest(const Net::DownloadRequest &downloadRequest)
+    {
+        QNetworkRequest request {downloadRequest.url()};
+
+        if (downloadRequest.userAgent().isEmpty())
+            request.setRawHeader("User-Agent", DEFAULT_USER_AGENT);
+        else
+            request.setRawHeader("User-Agent", downloadRequest.userAgent().toUtf8());
+
+        // Spoof HTTP Referer to allow adding torrent link from Torcache/KickAssTorrents
+        request.setRawHeader("Referer", request.url().toEncoded().data());
+        // Accept gzip
+        request.setRawHeader("Accept-Encoding", "gzip");
+
+        return request;
+    }
 }
 
-using namespace Net;
+Net::DownloadManager *Net::DownloadManager::m_instance = nullptr;
 
-DownloadManager *DownloadManager::m_instance = nullptr;
-
-DownloadManager::DownloadManager(QObject *parent)
+Net::DownloadManager::DownloadManager(QObject *parent)
     : QObject(parent)
 {
 #ifndef QT_NO_OPENSSL
     connect(&m_networkManager, &QNetworkAccessManager::sslErrors, this, &Net::DownloadManager::ignoreSslErrors);
 #endif
+    connect(&m_networkManager, &QNetworkAccessManager::finished, this, &DownloadManager::handleReplyFinished);
+    connect(ProxyConfigurationManager::instance(), &ProxyConfigurationManager::proxyConfigurationChanged
+            , this, &DownloadManager::applyProxySettings);
     m_networkManager.setCookieJar(new NetworkCookieJar(this));
 }
 
-void DownloadManager::initInstance()
+void Net::DownloadManager::initInstance()
 {
     if (!m_instance)
         m_instance = new DownloadManager;
 }
 
-void DownloadManager::freeInstance()
+void Net::DownloadManager::freeInstance()
 {
     if (m_instance) {
         delete m_instance;
@@ -132,64 +150,70 @@ void DownloadManager::freeInstance()
     }
 }
 
-DownloadManager *DownloadManager::instance()
+Net::DownloadManager *Net::DownloadManager::instance()
 {
     return m_instance;
 }
 
-DownloadHandler *DownloadManager::downloadUrl(const QString &url, bool saveToFile, qint64 limit, bool handleRedirectToMagnet, const QString &userAgent)
+Net::DownloadHandler *Net::DownloadManager::downloadUrl(const QString &url, bool saveToFile, qint64 limit, bool handleRedirectToMagnet, const QString &userAgent)
 {
     return download(DownloadRequest(url).saveToFile(saveToFile).limit(limit).handleRedirectToMagnet(handleRedirectToMagnet).userAgent(userAgent));
 }
 
-DownloadHandler *DownloadManager::download(const DownloadRequest &downloadRequest)
+Net::DownloadHandler *Net::DownloadManager::download(const DownloadRequest &downloadRequest)
 {
-    // Update proxy settings
-    applyProxySettings();
-
     // Process download request
-    QNetworkRequest request(downloadRequest.url());
+    const QNetworkRequest request = createNetworkRequest(downloadRequest);
+    const ServiceID id = ServiceID::fromURL(request.url());
+    const bool isSequentialService = m_sequentialServices.contains(id);
+    if (!isSequentialService || !m_busyServices.contains(id)) {
+        qDebug("Downloading %s...", qUtf8Printable(downloadRequest.url()));
+        if (isSequentialService)
+            m_busyServices.insert(id);
+        return new DownloadHandler {
+            m_networkManager.get(request), this, downloadRequest};
+    }
 
-    if (downloadRequest.userAgent().isEmpty())
-        request.setRawHeader("User-Agent", DEFAULT_USER_AGENT);
-    else
-        request.setRawHeader("User-Agent", downloadRequest.userAgent().toUtf8());
-
-    // Spoof HTTP Referer to allow adding torrent link from Torcache/KickAssTorrents
-    request.setRawHeader("Referer", request.url().toEncoded().data());
-
-    qDebug("Downloading %s...", request.url().toEncoded().data());
-    // accept gzip
-    request.setRawHeader("Accept-Encoding", "gzip");
-    return new DownloadHandler(m_networkManager.get(request), this, downloadRequest);
+    auto *downloadHandler = new DownloadHandler {nullptr, this, downloadRequest};
+    connect(downloadHandler, &DownloadHandler::destroyed, this, [this, id, downloadHandler]()
+    {
+        m_waitingJobs[id].removeOne(downloadHandler);
+    });
+    m_waitingJobs[id].enqueue(downloadHandler);
+    return downloadHandler;
 }
 
-QList<QNetworkCookie> DownloadManager::cookiesForUrl(const QUrl &url) const
+void Net::DownloadManager::registerSequentialService(const Net::ServiceID &serviceID)
+{
+    m_sequentialServices.insert(serviceID);
+}
+
+QList<QNetworkCookie> Net::DownloadManager::cookiesForUrl(const QUrl &url) const
 {
     return m_networkManager.cookieJar()->cookiesForUrl(url);
 }
 
-bool DownloadManager::setCookiesFromUrl(const QList<QNetworkCookie> &cookieList, const QUrl &url)
+bool Net::DownloadManager::setCookiesFromUrl(const QList<QNetworkCookie> &cookieList, const QUrl &url)
 {
     return m_networkManager.cookieJar()->setCookiesFromUrl(cookieList, url);
 }
 
-QList<QNetworkCookie> DownloadManager::allCookies() const
+QList<QNetworkCookie> Net::DownloadManager::allCookies() const
 {
     return static_cast<NetworkCookieJar *>(m_networkManager.cookieJar())->allCookies();
 }
 
-void DownloadManager::setAllCookies(const QList<QNetworkCookie> &cookieList)
+void Net::DownloadManager::setAllCookies(const QList<QNetworkCookie> &cookieList)
 {
     static_cast<NetworkCookieJar *>(m_networkManager.cookieJar())->setAllCookies(cookieList);
 }
 
-bool DownloadManager::deleteCookie(const QNetworkCookie &cookie)
+bool Net::DownloadManager::deleteCookie(const QNetworkCookie &cookie)
 {
     return static_cast<NetworkCookieJar *>(m_networkManager.cookieJar())->deleteCookie(cookie);
 }
 
-void DownloadManager::applyProxySettings()
+void Net::DownloadManager::applyProxySettings()
 {
     auto proxyManager = ProxyConfigurationManager::instance();
     ProxyConfiguration proxyConfig = proxyManager->proxyConfiguration();
@@ -210,7 +234,7 @@ void DownloadManager::applyProxySettings()
         }
         // Authentication?
         if (proxyManager->isAuthenticationRequired()) {
-            qDebug("Proxy requires authentication, authenticating");
+            qDebug("Proxy requires authentication, authenticating...");
             proxy.setUser(proxyConfig.username);
             proxy.setPassword(proxyConfig.password);
         }
@@ -222,8 +246,23 @@ void DownloadManager::applyProxySettings()
     m_networkManager.setProxy(proxy);
 }
 
+void Net::DownloadManager::handleReplyFinished(QNetworkReply *reply)
+{
+    const ServiceID id = ServiceID::fromURL(reply->url());
+    auto waitingJobsIter = m_waitingJobs.find(id);
+    if ((waitingJobsIter == m_waitingJobs.end()) || waitingJobsIter.value().isEmpty()) {
+        m_busyServices.remove(id);
+        return;
+    }
+
+    DownloadHandler *handler = waitingJobsIter.value().dequeue();
+    qDebug("Downloading %s...", qUtf8Printable(handler->m_downloadRequest.url()));
+    handler->assignNetworkReply(m_networkManager.get(createNetworkRequest(handler->m_downloadRequest)));
+    handler->disconnect(this);
+}
+
 #ifndef QT_NO_OPENSSL
-void DownloadManager::ignoreSslErrors(QNetworkReply *reply, const QList<QSslError> &errors)
+void Net::DownloadManager::ignoreSslErrors(QNetworkReply *reply, const QList<QSslError> &errors)
 {
     Q_UNUSED(errors)
     // Ignore all SSL errors
@@ -289,4 +328,19 @@ Net::DownloadRequest &Net::DownloadRequest::handleRedirectToMagnet(bool value)
 {
     m_handleRedirectToMagnet = value;
     return *this;
+}
+
+Net::ServiceID Net::ServiceID::fromURL(const QUrl &url)
+{
+    return {url.host(), url.port(80)};
+}
+
+uint Net::qHash(const ServiceID &serviceID, uint seed)
+{
+    return ::qHash(serviceID.hostName, seed) ^ serviceID.port;
+}
+
+bool Net::operator==(const ServiceID &lhs, const ServiceID &rhs)
+{
+    return ((lhs.hostName == rhs.hostName) && (lhs.port == rhs.port));
 }

--- a/src/base/net/downloadmanager.h
+++ b/src/base/net/downloadmanager.h
@@ -42,9 +42,39 @@ namespace Net
 {
     class DownloadHandler;
 
+    class DownloadRequest
+    {
+    public:
+        DownloadRequest(const QString &url);
+        DownloadRequest(const DownloadRequest &other) = default;
+
+        QString url() const;
+        DownloadRequest &url(const QString &value);
+
+        QString userAgent() const;
+        DownloadRequest &userAgent(const QString &value);
+
+        qint64 limit() const;
+        DownloadRequest &limit(qint64 value);
+
+        bool saveToFile() const;
+        DownloadRequest &saveToFile(bool value);
+
+        bool handleRedirectToMagnet() const;
+        DownloadRequest &handleRedirectToMagnet(bool value);
+
+    private:
+        QString m_url;
+        QString m_userAgent;
+        qint64 m_limit = 0;
+        bool m_saveToFile = false;
+        bool m_handleRedirectToMagnet = false;
+    };
+
     class DownloadManager : public QObject
     {
         Q_OBJECT
+        Q_DISABLE_COPY(DownloadManager)
 
     public:
         static void initInstance();
@@ -52,6 +82,7 @@ namespace Net
         static DownloadManager *instance();
 
         DownloadHandler *downloadUrl(const QString &url, bool saveToFile = false, qint64 limit = 0, bool handleRedirectToMagnet = false, const QString &userAgent = "");
+        DownloadHandler *download(const DownloadRequest &downloadRequest);
         QList<QNetworkCookie> cookiesForUrl(const QUrl &url) const;
         bool setCookiesFromUrl(const QList<QNetworkCookie> &cookieList, const QUrl &url);
         QList<QNetworkCookie> allCookies() const;

--- a/src/base/net/downloadmanager.h
+++ b/src/base/net/downloadmanager.h
@@ -93,7 +93,6 @@ namespace Net
         static void freeInstance();
         static DownloadManager *instance();
 
-        DownloadHandler *downloadUrl(const QString &url, bool saveToFile = false, qint64 limit = 0, bool handleRedirectToMagnet = false, const QString &userAgent = "");
         DownloadHandler *download(const DownloadRequest &downloadRequest);
 
         void registerSequentialService(const ServiceID &serviceID);

--- a/src/base/net/geoipmanager.cpp
+++ b/src/base/net/geoipmanager.cpp
@@ -118,7 +118,7 @@ void GeoIPManager::manageDatabaseUpdate()
 
 void GeoIPManager::downloadDatabaseFile()
 {
-    DownloadHandler *handler = DownloadManager::instance()->downloadUrl(DATABASE_URL);
+    DownloadHandler *handler = DownloadManager::instance()->download({DATABASE_URL});
     connect(handler, static_cast<void (Net::DownloadHandler::*)(const QString &, const QByteArray &)>(&Net::DownloadHandler::downloadFinished)
             , this, &GeoIPManager::downloadFinished);
     connect(handler, &Net::DownloadHandler::downloadFailed, this, &GeoIPManager::downloadFailed);

--- a/src/base/rss/rss_feed.cpp
+++ b/src/base/rss/rss_feed.cpp
@@ -88,6 +88,8 @@ Feed::Feed(const QUuid &uid, const QString &url, const QString &path, Session *s
     else
         connect(m_session, &Session::processingStateChanged, this, &Feed::handleSessionProcessingEnabledChanged);
 
+    Net::DownloadManager::instance()->registerSequentialService(Net::ServiceID::fromURL(m_url));
+
     load();
 }
 

--- a/src/base/rss/rss_feed.cpp
+++ b/src/base/rss/rss_feed.cpp
@@ -129,7 +129,7 @@ void Feed::refresh()
 
     // NOTE: Should we allow manually refreshing for disabled session?
 
-    Net::DownloadHandler *handler = Net::DownloadManager::instance()->downloadUrl(m_url);
+    Net::DownloadHandler *handler = Net::DownloadManager::instance()->download({m_url});
     connect(handler
             , static_cast<void (Net::DownloadHandler::*)(const QString &, const QByteArray &)>(&Net::DownloadHandler::downloadFinished)
             , this, &Feed::handleDownloadFinished);
@@ -418,7 +418,8 @@ void Feed::downloadIcon()
     // XXX: This works for most sites but it is not perfect
     const QUrl url(m_url);
     auto iconUrl = QString("%1://%2/favicon.ico").arg(url.scheme(), url.host());
-    Net::DownloadHandler *handler = Net::DownloadManager::instance()->downloadUrl(iconUrl, true);
+    Net::DownloadHandler *handler = Net::DownloadManager::instance()->download(
+            Net::DownloadRequest(iconUrl).saveToFile(true));
     connect(handler
             , static_cast<void (Net::DownloadHandler::*)(const QString &, const QString &)>(&Net::DownloadHandler::downloadFinished)
             , this, &Feed::handleIconDownloadFinished);

--- a/src/base/search/searchpluginmanager.cpp
+++ b/src/base/search/searchpluginmanager.cpp
@@ -170,7 +170,7 @@ void SearchPluginManager::installPlugin(const QString &source)
 
     if (Utils::Misc::isUrl(source)) {
         using namespace Net;
-        DownloadHandler *handler = DownloadManager::instance()->downloadUrl(source, true);
+        DownloadHandler *handler = DownloadManager::instance()->download(DownloadRequest(source).saveToFile(true));
         connect(handler, static_cast<void (DownloadHandler::*)(const QString &, const QString &)>(&DownloadHandler::downloadFinished)
                 , this, &SearchPluginManager::pluginDownloaded);
         connect(handler, &DownloadHandler::downloadFailed, this, &SearchPluginManager::pluginDownloadFailed);
@@ -274,7 +274,7 @@ void SearchPluginManager::checkForUpdates()
 {
     // Download version file from update server
     using namespace Net;
-    DownloadHandler *handler = DownloadManager::instance()->downloadUrl(m_updateUrl + "versions.txt");
+    DownloadHandler *handler = DownloadManager::instance()->download({m_updateUrl + "versions.txt"});
     connect(handler, static_cast<void (DownloadHandler::*)(const QString &, const QByteArray &)>(&DownloadHandler::downloadFinished)
             , this, &SearchPluginManager::versionInfoDownloaded);
     connect(handler, &DownloadHandler::downloadFailed, this, &SearchPluginManager::versionInfoDownloadFailed);

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -230,7 +230,9 @@ void AddNewTorrentDialog::show(QString source, const BitTorrent::AddTorrentParam
 
     if (Utils::Misc::isUrl(source)) {
         // Launch downloader
-        Net::DownloadHandler *handler = Net::DownloadManager::instance()->downloadUrl(source, true, 10485760 /* 10MB */, true);
+        // TODO: Don't save loaded torrent to file, just use downloaded data!
+        Net::DownloadHandler *handler = Net::DownloadManager::instance()->download(
+                Net::DownloadRequest(source).limit(10485760 /* 10MB */).handleRedirectToMagnet(true).saveToFile(true));
         connect(handler, static_cast<void (Net::DownloadHandler::*)(const QString &, const QString &)>(&Net::DownloadHandler::downloadFinished)
                 , dlg, &AddNewTorrentDialog::handleDownloadFinished);
         connect(handler, &Net::DownloadHandler::downloadFailed, dlg, &AddNewTorrentDialog::handleDownloadFailed);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -2043,11 +2043,11 @@ void MainWindow::installPython()
 {
     setCursor(QCursor(Qt::WaitCursor));
     // Download python
-    Net::DownloadHandler *handler = nullptr;
-    if (QSysInfo::windowsVersion() >= QSysInfo::WV_VISTA)
-        handler = Net::DownloadManager::instance()->downloadUrl("https://www.python.org/ftp/python/3.5.2/python-3.5.2.exe", true);
-    else
-        handler = Net::DownloadManager::instance()->downloadUrl("https://www.python.org/ftp/python/3.4.4/python-3.4.4.msi", true);
+    const QString installerURL = ((QSysInfo::windowsVersion() >= QSysInfo::WV_VISTA)
+                                  ? "https://www.python.org/ftp/python/3.5.2/python-3.5.2.exe"
+                                  : "https://www.python.org/ftp/python/3.4.4/python-3.4.4.msi");
+    Net::DownloadHandler *handler = Net::DownloadManager::instance()->download(
+                                        Net::DownloadRequest(installerURL).saveToFile(true));
 
     using Func = void (Net::DownloadHandler::*)(const QString &, const QString &);
     connect(handler, static_cast<Func>(&Net::DownloadHandler::downloadFinished), this, &MainWindow::pythonDownloadSuccess);

--- a/src/gui/programupdater.cpp
+++ b/src/gui/programupdater.cpp
@@ -61,11 +61,10 @@ ProgramUpdater::ProgramUpdater(QObject *parent, bool invokedByUser)
 
 void ProgramUpdater::checkForUpdates()
 {
-    Net::DownloadHandler *handler = Net::DownloadManager::instance()->downloadUrl(
-                RSS_URL, false, 0, false,
-                // Don't change this User-Agent. In case our updater goes haywire,
-                // the filehost can identify it and contact us.
-                "qBittorrent/" QBT_VERSION_2 " ProgramUpdater (www.qbittorrent.org)");
+    // Don't change this User-Agent. In case our updater goes haywire,
+    // the filehost can identify it and contact us.
+    Net::DownloadHandler *handler = Net::DownloadManager::instance()->download(
+                Net::DownloadRequest(RSS_URL).userAgent("qBittorrent/" QBT_VERSION_2 " ProgramUpdater (www.qbittorrent.org)"));
     connect(handler, static_cast<void (Net::DownloadHandler::*)(const QString &, const QByteArray &)>(&Net::DownloadHandler::downloadFinished)
             , this, &ProgramUpdater::rssDownloadFinished);
     connect(handler, &Net::DownloadHandler::downloadFailed, this, &ProgramUpdater::rssDownloadFailed);

--- a/src/gui/properties/trackersadditiondialog.h
+++ b/src/gui/properties/trackersadditiondialog.h
@@ -57,7 +57,7 @@ public:
 
 public slots:
     void on_uTorrentListButton_clicked();
-    void parseUTorrentList(const QString &, const QString &path);
+    void parseUTorrentList(const QString &, const QByteArray &data);
     void getTrackerError(const QString &, const QString &error);
 
 private:

--- a/src/gui/search/pluginselectdialog.cpp
+++ b/src/gui/search/pluginselectdialog.cpp
@@ -292,7 +292,8 @@ void PluginSelectDialog::addNewPlugin(QString pluginName)
     else {
         // Icon is missing, we must download it
         using namespace Net;
-        DownloadHandler *handler = DownloadManager::instance()->downloadUrl(plugin->url + "/favicon.ico", true);
+        DownloadHandler *handler = DownloadManager::instance()->download(
+                    DownloadRequest(plugin->url + "/favicon.ico").saveToFile(true));
         connect(handler, static_cast<void (DownloadHandler::*)(const QString &, const QString &)>(&DownloadHandler::downloadFinished)
                 , this, &PluginSelectDialog::iconDownloaded);
         connect(handler, &DownloadHandler::downloadFailed, this, &PluginSelectDialog::iconDownloadFailed);

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -404,7 +404,8 @@ void TrackerFiltersList::trackerWarning(const QString &hash, const QString &trac
 void TrackerFiltersList::downloadFavicon(const QString& url)
 {
     if (!m_downloadTrackerFavicon) return;
-    Net::DownloadHandler *h = Net::DownloadManager::instance()->downloadUrl(url, true);
+    Net::DownloadHandler *h = Net::DownloadManager::instance()->download(
+                Net::DownloadRequest(url).saveToFile(true));
     using Func = void (Net::DownloadHandler::*)(const QString &, const QString &);
     connect(h, static_cast<Func>(&Net::DownloadHandler::downloadFinished), this
             , &TrackerFiltersList::handleFavicoDownload);


### PR DESCRIPTION
QNetworkAccessManager executes network requests in parallel.
From **QNetworkAccessManager** doc:
>Currently, for the HTTP protocol on desktop platforms, 6 requests are executed in parallel for one host/port combination.

This may lead to blocking on some sites. In particular, when a user has multiple RSS feeds from a single site, their update often fails.
This feature allows you to register specific sites (hostname and port pair) as "sequential services" and prevent parallel requests to them.