### PR TITLE
Cache more preference values in WebApplication

### DIFF
--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -39,6 +39,7 @@
 #include "base/http/irequesthandler.h"
 #include "base/http/responsebuilder.h"
 #include "base/http/types.h"
+#include "base/utils/net.h"
 #include "base/utils/version.h"
 
 constexpr Utils::Version<int, 3, 2> API_VERSION {2, 0, 1};
@@ -133,7 +134,6 @@ private:
     QSet<QString> m_publicAPIs;
     bool m_isAltUIUsed = false;
     QString m_rootFolder;
-    QStringList m_domainList;
 
     struct TranslatedFile
     {
@@ -143,7 +143,12 @@ private:
     QMap<QString, TranslatedFile> m_translatedFiles;
     QString m_currentLocale;
 
+    bool m_isLocalAuthEnabled;
+    bool m_isAuthSubnetWhitelistEnabled;
+    QList<Utils::Net::Subnet> m_authSubnetWhitelist;
+
     // security related
+    QStringList m_domainList;
     bool m_isClickjackingProtectionEnabled;
     bool m_isCSRFProtectionEnabled;
     bool m_isHttpsEnabled;


### PR DESCRIPTION
The newly cached values are used for every request, so it make sense to avoid the overhead fetching from Preference class.
Also group the cached values in a struct.