### PR TITLE
Stop saving fastresume data on interval for paused/completed torrents

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -2357,6 +2357,9 @@ void Session::generateResumeData(bool final)
 {
     foreach (TorrentHandle *const torrent, m_torrents) {
         if (!torrent->isValid()) continue;
+        if ((torrent->state() == TorrentState::PausedDownloading)
+            || (torrent->state() == TorrentState::PausedUploading))
+            continue;
         if (torrent->hasMissingFiles()) continue;
         if (torrent->isChecking() || torrent->hasError()) continue;
         if (!final && !torrent->needSaveResumeData()) continue;


### PR DESCRIPTION
AFAIK when torrents are paused/completed there is no need to save anything in their fastresume files periodically, especially after #9180.