### PR TITLE
TriStateBool? Nah, Trool.

### DIFF
--- a/src/base/bittorrent/addtorrentparams.h
+++ b/src/base/bittorrent/addtorrentparams.h
@@ -45,13 +45,13 @@ namespace BitTorrent
         bool disableTempPath = false; // e.g. for imported torrents
         bool sequential = false;
         bool firstLastPiecePriority = false;
-        TriStateBool addForced;
-        TriStateBool addPaused;
+        Trool addForced;
+        Trool addPaused;
         QVector<int> filePriorities; // used if TorrentInfo is set
         bool ignoreShareLimits = false;
         bool skipChecking = false;
-        TriStateBool createSubfolder;
-        TriStateBool useAutoTMM;
+        Trool createSubfolder;
+        Trool useAutoTMM;
         int uploadLimit = -1;
         int downloadLimit = -1;
     };

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -113,22 +113,22 @@ CreateTorrentParams::CreateTorrentParams(const AddTorrentParams &params)
     , firstLastPiecePriority(params.firstLastPiecePriority)
     , hasSeedStatus(params.skipChecking) // do not react on 'torrent_finished_alert' when skipping
     , skipChecking(params.skipChecking)
-    , hasRootFolder(params.createSubfolder == TriStateBool::Undefined
+    , hasRootFolder(params.createSubfolder == Trool::Undefined
                     ? Session::instance()->isCreateTorrentSubfolder()
-                    : params.createSubfolder == TriStateBool::True)
-    , forced(params.addForced == TriStateBool::True)
-    , paused(params.addPaused == TriStateBool::Undefined
+                    : params.createSubfolder == Trool::True)
+    , forced(params.addForced == Trool::True)
+    , paused(params.addPaused == Trool::Undefined
                 ? Session::instance()->isAddTorrentPaused()
-                : params.addPaused == TriStateBool::True)
+                : params.addPaused == Trool::True)
     , uploadLimit(params.uploadLimit)
     , downloadLimit(params.downloadLimit)
     , filePriorities(params.filePriorities)
     , ratioLimit(params.ignoreShareLimits ? TorrentHandle::NO_RATIO_LIMIT : TorrentHandle::USE_GLOBAL_RATIO)
     , seedingTimeLimit(params.ignoreShareLimits ? TorrentHandle::NO_SEEDING_TIME_LIMIT : TorrentHandle::USE_GLOBAL_SEEDING_TIME)
 {
-    bool useAutoTMM = (params.useAutoTMM == TriStateBool::Undefined
+    bool useAutoTMM = (params.useAutoTMM == Trool::Undefined
                        ? !Session::instance()->isAutoTMMDisabledByDefault()
-                       : params.useAutoTMM == TriStateBool::True);
+                       : params.useAutoTMM == Trool::True);
     if (useAutoTMM)
         savePath = "";
     else if (savePath.trimmed().isEmpty())

--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -375,7 +375,7 @@ void AutoDownloader::processJob(const QSharedPointer<ProcessingJob> &job)
         params.category = rule.assignedCategory();
         params.addPaused = rule.addPaused();
         if (!rule.savePath().isEmpty())
-            params.useAutoTMM = TriStateBool::False;
+            params.useAutoTMM = Trool::False;
         auto torrentURL = job->articleData.value(Article::KeyTorrentURL).toString();
         BitTorrent::Session::instance()->addTorrent(torrentURL, params);
 

--- a/src/base/rss/rss_autodownloadrule.cpp
+++ b/src/base/rss/rss_autodownloadrule.cpp
@@ -50,18 +50,18 @@
 
 namespace
 {
-    TriStateBool jsonValueToTriStateBool(const QJsonValue &jsonVal)
+    Trool jsonValueToTriStateBool(const QJsonValue &jsonVal)
     {
         if (jsonVal.isBool())
-            return TriStateBool(jsonVal.toBool());
+            return Trool(jsonVal.toBool());
 
         if (!jsonVal.isNull())
             qDebug() << Q_FUNC_INFO << "Incorrect value" << jsonVal.toVariant();
 
-        return TriStateBool::Undefined;
+        return Trool::Undefined;
     }
 
-    QJsonValue triStateBoolToJsonValue(const TriStateBool &triStateBool)
+    QJsonValue triStateBoolToJsonValue(const Trool &triStateBool)
     {
         switch (static_cast<int>(triStateBool)) {
         case 0:  return false;
@@ -70,16 +70,16 @@ namespace
         }
     }
 
-    TriStateBool addPausedLegacyToTriStateBool(int val)
+    Trool addPausedLegacyToTriStateBool(int val)
     {
         switch (val) {
-        case 1:  return TriStateBool::True; // always
-        case 2:  return TriStateBool::False; // never
-        default: return TriStateBool::Undefined; // default
+        case 1:  return Trool::True; // always
+        case 2:  return Trool::False; // never
+        default: return Trool::Undefined; // default
         }
     }
 
-    int triStateBoolToAddPausedLegacy(const TriStateBool &triStateBool)
+    int triStateBoolToAddPausedLegacy(const Trool &triStateBool)
     {
         switch (static_cast<int>(triStateBool)) {
         case 0:  return 2; // never
@@ -121,7 +121,7 @@ namespace RSS
 
         QString savePath;
         QString category;
-        TriStateBool addPaused = TriStateBool::Undefined;
+        Trool addPaused = Trool::Undefined;
 
         bool smartFilter = false;
         QStringList previouslyMatchedEpisodes;
@@ -553,12 +553,12 @@ void AutoDownloadRule::setSavePath(const QString &savePath)
     m_dataPtr->savePath = Utils::Fs::fromNativePath(savePath);
 }
 
-TriStateBool AutoDownloadRule::addPaused() const
+Trool AutoDownloadRule::addPaused() const
 {
     return m_dataPtr->addPaused;
 }
 
-void AutoDownloadRule::setAddPaused(const TriStateBool &addPaused)
+void AutoDownloadRule::setAddPaused(const Trool &addPaused)
 {
     m_dataPtr->addPaused = addPaused;
 }

--- a/src/base/rss/rss_autodownloadrule.h
+++ b/src/base/rss/rss_autodownloadrule.h
@@ -35,7 +35,7 @@
 
 class QJsonObject;
 class QRegularExpression;
-class TriStateBool;
+class Trool;
 
 namespace RSS
 {
@@ -76,8 +76,8 @@ namespace RSS
 
         QString savePath() const;
         void setSavePath(const QString &savePath);
-        TriStateBool addPaused() const;
-        void setAddPaused(const TriStateBool &addPaused);
+        Trool addPaused() const;
+        void setAddPaused(const Trool &addPaused);
         QString assignedCategory() const;
         void setCategory(const QString &category);
 

--- a/src/base/tristatebool.cpp
+++ b/src/base/tristatebool.cpp
@@ -28,6 +28,6 @@
 
 #include "tristatebool.h"
 
-const TriStateBool TriStateBool::Undefined(-1);
-const TriStateBool TriStateBool::False(0);
-const TriStateBool TriStateBool::True(1);
+const Trool Trool::Undefined(-1);
+const Trool Trool::False(0);
+const Trool Trool::True(1);

--- a/src/base/tristatebool.h
+++ b/src/base/tristatebool.h
@@ -29,16 +29,16 @@
 #ifndef TRISTATEBOOL_H
 #define TRISTATEBOOL_H
 
-class TriStateBool
+class Trool
 {
 public:
-    static const TriStateBool Undefined;
-    static const TriStateBool False;
-    static const TriStateBool True;
+    static const Trool Undefined;
+    static const Trool False;
+    static const Trool True;
 
-    constexpr TriStateBool() = default;
-    constexpr TriStateBool(const TriStateBool &other) = default;
-    explicit constexpr TriStateBool(int value)
+    constexpr Trool() = default;
+    constexpr Trool(const Trool &other) = default;
+    explicit constexpr Trool(int value)
         : m_value(value < 0 ? -1 : (value > 0 ? 1 : 0))
     {
     }
@@ -48,14 +48,14 @@ public:
         return m_value;
     }
 
-    TriStateBool &operator=(const TriStateBool &other) = default;  // add constexpr when using C++14
+    Trool &operator=(const Trool &other) = default;  // add constexpr when using C++14
 
-    constexpr bool operator==(const TriStateBool &other) const
+    constexpr bool operator==(const Trool &other) const
     {
         return (m_value == other.m_value);
     }
 
-    constexpr bool operator!=(const TriStateBool &other) const
+    constexpr bool operator!=(const Trool &other) const
     {
         return !operator==(other);
     }

--- a/src/base/utils/string.cpp
+++ b/src/base/utils/string.cpp
@@ -194,11 +194,11 @@ bool Utils::String::parseBool(const QString &string, const bool defaultValue)
     return (string.compare("true", Qt::CaseInsensitive) == 0) ? true : false;
 }
 
-TriStateBool Utils::String::parseTriStateBool(const QString &string)
+Trool Utils::String::parseTriStateBool(const QString &string)
 {
     if (string.compare("true", Qt::CaseInsensitive) == 0)
-        return TriStateBool::True;
+        return Trool::True;
     if (string.compare("false", Qt::CaseInsensitive) == 0)
-        return TriStateBool::False;
-    return TriStateBool::Undefined;
+        return Trool::False;
+    return Trool::Undefined;
 }

--- a/src/base/utils/string.h
+++ b/src/base/utils/string.h
@@ -34,7 +34,7 @@
 
 class QByteArray;
 class QLatin1String;
-class TriStateBool;
+class Trool;
 
 namespace Utils
 {
@@ -69,7 +69,7 @@ namespace Utils
         }
 
         bool parseBool(const QString &string, const bool defaultValue);
-        TriStateBool parseTriStateBool(const QString &string);
+        Trool parseTriStateBool(const QString &string);
     }
 }
 


### PR DESCRIPTION
**Disclaimer**: ~~Kind of~~ a stupid PR

TL;DR: **just a rename of a class** (TriStateBool to Trool)

While at first I thought it was funny, I think the real reason I opened this PR is I actually do like Trool better. I don't know if you want this big of a change in the repo, but it's out there. (I looked up to see if it had any meanings and it's something stupid) I'm not a native-speaker but it doesn't sound odd or anything to me. I think the relationship to `bool` is visible.

Just now went on Wikipedia, and [this article](https://en.wikipedia.org/wiki/Three-valued_logic) lists these for alternative names to three-valued logic: trinary logic, trivalent, ternary, or trilean. "Trinary" is basically like "binary", and "ternary" is an operator. "trivalent" and "trilean" are left. And I think those aren't as sound as "Trool". Anyway, I'm pretty sure nobody is even going comment or even read this whole thing so I'm going to stop typing now.

PS I know even the builds are failing, just a shot in the dark.