### PR TITLE
Add options in AddNewTorrentDialog

### DIFF
--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -126,6 +126,9 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::AddTorrentParams &inP
     else
         m_ui->createSubfolderCheckBox->setChecked(session->isCreateTorrentSubfolder());
 
+    m_ui->sequentialCheckBox->setChecked(m_torrentParams.sequential);
+    m_ui->firstLastCheckBox->setChecked(m_torrentParams.firstLastPiecePriority);
+
     m_ui->skipCheckingCheckBox->setChecked(m_torrentParams.skipChecking);
     m_ui->doNotDeleteTorrentCheckBox->setVisible(TorrentFileGuard::autoDeleteMode() != TorrentFileGuard::Never);
 
@@ -657,6 +660,9 @@ void AddNewTorrentDialog::accept()
 
     m_torrentParams.addPaused = TriStateBool(!m_ui->startTorrentCheckBox->isChecked());
     m_torrentParams.createSubfolder = TriStateBool(m_ui->createSubfolderCheckBox->isChecked());
+
+    m_torrentParams.sequential = m_ui->sequentialCheckBox->isChecked();
+    m_torrentParams.firstLastPiecePriority = m_ui->firstLastCheckBox->isChecked();
 
     QString savePath = m_ui->savePath->selectedPath();
     if (m_ui->comboTTM->currentIndex() != 1) { // 0 is Manual mode and 1 is Automatic mode. Handle all non 1 values as manual mode.

--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -181,6 +181,20 @@
         </property>
        </widget>
       </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="sequentialCheckBox">
+        <property name="text">
+         <string>Download in sequential order</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QCheckBox" name="firstLastCheckBox">
+        <property name="text">
+         <string>Download first and last pieces first</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
The new checkboxes are: "Download in sequential order", "Download first and last pieces first".
screenshot:
![latest](https://user-images.githubusercontent.com/9395168/42982796-96f15802-8c15-11e8-9723-d94a3942697e.png)
history: [pic1](https://user-images.githubusercontent.com/9395168/42895320-16c0748a-8aec-11e8-8156-b54d8c9b11cd.png)
