### PR TITLE
Adjust minimum alternative rate limits to zero

### DIFF
--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -2017,7 +2017,7 @@
                   <string> KiB/s</string>
                  </property>
                  <property name="minimum">
-                  <number>1</number>
+                  <number>0</number>
                  </property>
                  <property name="maximum">
                   <number>1000000</number>
@@ -2036,7 +2036,7 @@
                   <string> KiB/s</string>
                  </property>
                  <property name="minimum">
-                  <number>1</number>
+                  <number>0</number>
                  </property>
                  <property name="maximum">
                   <number>1000000</number>


### PR DESCRIPTION
I don't know if there was a reason for not having `0` as an option. If it's allowed, there you go.