### PR TITLE
Retrieve stats on demand when WebUI Stats window is opened

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -3929,6 +3929,37 @@ quint64 Session::getAlltimeUL() const
     return m_statistics->getAlltimeUL();
 }
 
+QVariantMap Session::getStats() const
+{
+    const quint64 atd = getAlltimeDL();
+    const quint64 atu = getAlltimeUL();
+
+    // num_peers is not reliable (adds up peers, which didn't even overcome tcp handshake)
+    quint32 peers = 0;
+    foreach (BitTorrent::TorrentHandle *const torrent, torrents())
+        peers += torrent->peersCount();
+
+    QVariantMap map;
+
+    map["alltime_dl"] = atd;
+    map["alltime_ul"] = atu;
+    map["total_wasted_session"] = m_status.totalWasted;
+    map["global_ratio"] = ((atd > 0) && (atu > 0)) ? Utils::String::fromDouble(static_cast<qreal>(atu) / atd, 2) : "-";
+    map["total_peer_connections"] = m_status.peersCount;
+
+    map["read_cache_hits"] = (m_cacheStatus.readRatio > 0) ? Utils::String::fromDouble(100 * m_cacheStatus.readRatio, 2) : "0";
+    map["total_buffers_size"] = m_cacheStatus.totalUsedBuffers * 16 * 1024;
+
+    map["write_cache_overload"] = ((m_status.diskWriteQueue > 0) && (peers > 0)) ? Utils::String::fromDouble((100. * m_status.diskWriteQueue) / peers, 2) : "0";
+    map["read_cache_overload"] = ((m_status.diskReadQueue > 0) && (peers > 0)) ? Utils::String::fromDouble((100. * m_status.diskReadQueue) / peers, 2) : "0";
+
+    map["queued_io_jobs"] = m_cacheStatus.jobQueueLength;
+    map["average_time_queue"] = m_cacheStatus.averageJobTime;
+    map["total_queued_size"] = m_cacheStatus.queuedBytes;
+
+    return map;
+}
+
 void Session::refresh()
 {
     m_nativeSession->post_torrent_updates();

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -459,6 +459,7 @@ namespace BitTorrent
         const CacheStatus &cacheStatus() const;
         quint64 getAlltimeDL() const;
         quint64 getAlltimeUL() const;
+        QVariantMap getStats() const;
         bool isListening() const;
 
         MaxRatioAction maxRatioAction() const;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -245,6 +245,22 @@ namespace BitTorrent
         Q_DISABLE_COPY(Session)
 
     public:
+        struct OrganizedStats
+        {
+            quint64 allTimeDownload;
+            quint64 allTimeUpload;
+            quint64 totalWasted;
+            QString globalRatio;
+            quint64 peersCount;
+            QString readCacheHits;
+            quint64 totalUsedBuffers;
+            QString writeCacheOverload;
+            QString readCacheOverload;
+            quint64 jobQueueLength;
+            quint64 averageJobTime;
+            quint64 queuedBytes;
+        };
+
         static void initInstance();
         static void freeInstance();
         static Session *instance();
@@ -459,7 +475,7 @@ namespace BitTorrent
         const CacheStatus &cacheStatus() const;
         quint64 getAlltimeDL() const;
         quint64 getAlltimeUL() const;
-        QVariantMap getStats() const;
+        Session::OrganizedStats getOrganizedStats() const;
         bool isListening() const;
 
         MaxRatioAction maxRatioAction() const;

--- a/src/gui/statsdialog.cpp
+++ b/src/gui/statsdialog.cpp
@@ -60,51 +60,30 @@ StatsDialog::~StatsDialog()
 
 void StatsDialog::update()
 {
-    const BitTorrent::SessionStatus &ss = BitTorrent::Session::instance()->status();
-    const BitTorrent::CacheStatus &cs = BitTorrent::Session::instance()->cacheStatus();
+    const QVariantMap stats = BitTorrent::Session::instance()->getStats();
 
     // All-time DL/UL
-    quint64 atd = BitTorrent::Session::instance()->getAlltimeDL();
-    quint64 atu = BitTorrent::Session::instance()->getAlltimeUL();
-    m_ui->labelAlltimeDL->setText(Utils::Misc::friendlyUnit(atd));
-    m_ui->labelAlltimeUL->setText(Utils::Misc::friendlyUnit(atu));
+    m_ui->labelAlltimeDL->setText(Utils::Misc::friendlyUnit(stats["alltime_dl"].toULongLong()));
+    m_ui->labelAlltimeUL->setText(Utils::Misc::friendlyUnit(stats["alltime_ul"].toULongLong()));
     // Total waste (this session)
-    m_ui->labelWaste->setText(Utils::Misc::friendlyUnit(ss.totalWasted));
+    m_ui->labelWaste->setText(Utils::Misc::friendlyUnit(stats["total_wasted_session"].toULongLong()));
     // Global ratio
-    m_ui->labelGlobalRatio->setText(
-                ((atd > 0) && (atu > 0))
-                ? Utils::String::fromDouble(static_cast<qreal>(atu) / atd, 2)
-                : "-");
+    m_ui->labelGlobalRatio->setText(stats["global_ratio"].toString());
+    // Total connected peers
+    m_ui->labelPeers->setText(QString::number(stats["total_peer_connections"].toULongLong()));
     // Cache hits
-    qreal readRatio = cs.readRatio;
-    m_ui->labelCacheHits->setText(QString("%1%").arg(
-        readRatio > 0
-        ? Utils::String::fromDouble(100 * readRatio, 2)
-        : "0"));
+    m_ui->labelCacheHits->setText(stats["read_cache_hits"].toString());
     // Buffers size
-    m_ui->labelTotalBuf->setText(Utils::Misc::friendlyUnit(cs.totalUsedBuffers * 16 * 1024));
+    m_ui->labelTotalBuf->setText(Utils::Misc::friendlyUnit(stats["total_buffers_size"].toULongLong()));
     // Disk overload (100%) equivalent
     // From lt manual: disk_write_queue and disk_read_queue are the number of peers currently waiting on a disk write or disk read
     // to complete before it receives or sends any more data on the socket. It's a metric of how disk bound you are.
 
-    // num_peers is not reliable (adds up peers, which didn't even overcome tcp handshake)
-    quint32 peers = 0;
-    foreach (BitTorrent::TorrentHandle *const torrent, BitTorrent::Session::instance()->torrents())
-        peers += torrent->peersCount();
-
-    m_ui->labelWriteStarve->setText(QString("%1%")
-                                    .arg(((ss.diskWriteQueue > 0) && (peers > 0))
-                                         ? Utils::String::fromDouble((100. * ss.diskWriteQueue) / peers, 2)
-                                         : "0"));
-    m_ui->labelReadStarve->setText(QString("%1%")
-                                   .arg(((ss.diskReadQueue > 0) && (peers > 0))
-                                        ? Utils::String::fromDouble((100. * ss.diskReadQueue) / peers, 2)
-                                        : "0"));
+    m_ui->labelWriteStarve->setText(stats["write_cache_overload"].toString());
+    m_ui->labelReadStarve->setText(stats["read_cache_overload"].toString());
     // Disk queues
-    m_ui->labelQueuedJobs->setText(QString::number(cs.jobQueueLength));
-    m_ui->labelJobsTime->setText(tr("%1 ms", "18 milliseconds").arg(cs.averageJobTime));
-    m_ui->labelQueuedBytes->setText(Utils::Misc::friendlyUnit(cs.queuedBytes));
+    m_ui->labelQueuedJobs->setText(QString::number(stats["queued_io_jobs"].toULongLong()));
+    m_ui->labelJobsTime->setText(tr("%1 ms", "18 milliseconds").arg(stats["average_time_queue"].toULongLong()));
+    m_ui->labelQueuedBytes->setText(Utils::Misc::friendlyUnit(stats["total_queued_size"].toULongLong()));
 
-    // Total connected peers
-    m_ui->labelPeers->setText(QString::number(ss.peersCount));
 }

--- a/src/gui/statsdialog.cpp
+++ b/src/gui/statsdialog.cpp
@@ -60,30 +60,30 @@ StatsDialog::~StatsDialog()
 
 void StatsDialog::update()
 {
-    const QVariantMap stats = BitTorrent::Session::instance()->getStats();
+    const auto stats = BitTorrent::Session::instance()->getOrganizedStats();
 
     // All-time DL/UL
-    m_ui->labelAlltimeDL->setText(Utils::Misc::friendlyUnit(stats["alltime_dl"].toULongLong()));
-    m_ui->labelAlltimeUL->setText(Utils::Misc::friendlyUnit(stats["alltime_ul"].toULongLong()));
+    m_ui->labelAlltimeDL->setText(Utils::Misc::friendlyUnit(stats.allTimeDownload));
+    m_ui->labelAlltimeUL->setText(Utils::Misc::friendlyUnit(stats.allTimeUpload));
     // Total waste (this session)
-    m_ui->labelWaste->setText(Utils::Misc::friendlyUnit(stats["total_wasted_session"].toULongLong()));
+    m_ui->labelWaste->setText(Utils::Misc::friendlyUnit(stats.totalWasted));
     // Global ratio
-    m_ui->labelGlobalRatio->setText(stats["global_ratio"].toString());
+    m_ui->labelGlobalRatio->setText(stats.globalRatio);
     // Total connected peers
-    m_ui->labelPeers->setText(QString::number(stats["total_peer_connections"].toULongLong()));
+    m_ui->labelPeers->setText(QString::number(stats.peersCount));
     // Cache hits
-    m_ui->labelCacheHits->setText(stats["read_cache_hits"].toString());
+    m_ui->labelCacheHits->setText(stats.readCacheHits);
     // Buffers size
-    m_ui->labelTotalBuf->setText(Utils::Misc::friendlyUnit(stats["total_buffers_size"].toULongLong()));
+    m_ui->labelTotalBuf->setText(Utils::Misc::friendlyUnit(stats.totalUsedBuffers));
     // Disk overload (100%) equivalent
     // From lt manual: disk_write_queue and disk_read_queue are the number of peers currently waiting on a disk write or disk read
     // to complete before it receives or sends any more data on the socket. It's a metric of how disk bound you are.
 
-    m_ui->labelWriteStarve->setText(stats["write_cache_overload"].toString());
-    m_ui->labelReadStarve->setText(stats["read_cache_overload"].toString());
+    m_ui->labelWriteStarve->setText(stats.writeCacheOverload);
+    m_ui->labelReadStarve->setText(stats.readCacheOverload);
     // Disk queues
-    m_ui->labelQueuedJobs->setText(QString::number(stats["queued_io_jobs"].toULongLong()));
-    m_ui->labelJobsTime->setText(tr("%1 ms", "18 milliseconds").arg(stats["average_time_queue"].toULongLong()));
-    m_ui->labelQueuedBytes->setText(Utils::Misc::friendlyUnit(stats["total_queued_size"].toULongLong()));
+    m_ui->labelQueuedJobs->setText(QString::number(stats.jobQueueLength));
+    m_ui->labelJobsTime->setText(tr("%1 ms", "18 milliseconds").arg(stats.averageJobTime));
+    m_ui->labelQueuedBytes->setText(Utils::Misc::friendlyUnit(stats.queuedBytes));
 
 }

--- a/src/webui/api/transfercontroller.cpp
+++ b/src/webui/api/transfercontroller.cpp
@@ -75,7 +75,23 @@ void TransferController::infoAction()
 
 void TransferController::statsAction()
 {
-    setResult(QJsonObject::fromVariantMap(BitTorrent::Session::instance()->getStats()));
+    const auto organizedStats = BitTorrent::Session::instance()->getOrganizedStats();
+    QJsonObject stats {
+        {"alltime_dl", QString::number(organizedStats.allTimeDownload)},
+        {"alltime_ul", QString::number(organizedStats.allTimeUpload)},
+        {"total_wasted_session", QString::number(organizedStats.totalWasted)},
+        {"global_ratio", organizedStats.globalRatio},
+        {"total_peer_connections", QString::number(organizedStats.peersCount)},
+        {"read_cache_hits", organizedStats.readCacheHits},
+        {"total_buffers_size", QString::number(organizedStats.totalUsedBuffers)},
+        {"write_cache_overload", organizedStats.writeCacheOverload},
+        {"read_cache_overload", organizedStats.readCacheOverload},
+        {"queued_io_jobs", QString::number(organizedStats.jobQueueLength)},
+        {"average_time_queue", QString::number(organizedStats.averageJobTime)},
+        {"total_queued_size", QString::number(organizedStats.queuedBytes)}
+    };
+
+    setResult(stats);
 }
 
 void TransferController::uploadLimitAction()

--- a/src/webui/api/transfercontroller.cpp
+++ b/src/webui/api/transfercontroller.cpp
@@ -73,6 +73,11 @@ void TransferController::infoAction()
     setResult(dict);
 }
 
+void TransferController::statsAction()
+{
+    setResult(QJsonObject::fromVariantMap(BitTorrent::Session::instance()->getStats()));
+}
+
 void TransferController::uploadLimitAction()
 {
     setResult(QString::number(BitTorrent::Session::instance()->uploadSpeedLimit()));

--- a/src/webui/api/transfercontroller.h
+++ b/src/webui/api/transfercontroller.h
@@ -40,6 +40,7 @@ public:
 
 private slots:
     void infoAction();
+    void statsAction();
     void speedLimitsModeAction();
     void toggleSpeedLimitsModeAction();
     void uploadLimitAction();

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -404,22 +404,6 @@ window.addEvent('load', function() {
             document.title = "qBittorrent ${VERSION} QBT_TR(Web UI)QBT_TR[CONTEXT=OptionsDialog]";
         $('DHTNodes').set('html', 'QBT_TR(DHT: %1 nodes)QBT_TR[CONTEXT=StatusBar]'.replace("%1", serverState.dht_nodes));
 
-        // Statistics dialog
-        if (document.getElementById("statisticspage")) {
-            $('AlltimeDL').set('html', friendlyUnit(serverState.alltime_dl, false));
-            $('AlltimeUL').set('html', friendlyUnit(serverState.alltime_ul, false));
-            $('TotalWastedSession').set('html', friendlyUnit(serverState.total_wasted_session, false));
-            $('GlobalRatio').set('html', serverState.global_ratio);
-            $('TotalPeerConnections').set('html', serverState.total_peer_connections);
-            $('ReadCacheHits').set('html', serverState.read_cache_hits + "%");
-            $('TotalBuffersSize').set('html', friendlyUnit(serverState.total_buffers_size, false));
-            $('WriteCacheOverload').set('html', serverState.write_cache_overload + "%");
-            $('ReadCacheOverload').set('html', serverState.read_cache_overload + "%");
-            $('QueuedIOJobs').set('html', serverState.queued_io_jobs);
-            $('AverageTimeInQueue').set('html', serverState.average_time_queue + " ms");
-            $('TotalQueuedSize').set('html', friendlyUnit(serverState.total_queued_size, false));
-        }
-
         if (serverState.connection_status == "connected")
             $('connectionStatus').src = 'images/skin/connected.svg';
         else if (serverState.connection_status == "firewalled")

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -280,7 +280,7 @@ initializeWindows = function() {
         new MochaUI.Window({
             id: id,
             title: 'QBT_TR(Statistics)QBT_TR[CONTEXT=StatsDialog]',
-            loadMethod: 'xhr',
+            loadMethod: 'iframe',
             contentURL: 'statistics.html',
             maximizable: false,
             padding: 10,

--- a/src/webui/www/private/statistics.html
+++ b/src/webui/www/private/statistics.html
@@ -1,59 +1,113 @@
-<h3>QBT_TR(User statistics)QBT_TR[CONTEXT=StatsDialog]</h3>
-<table style="width:100%">
-    <tr>
-        <td>QBT_TR(All-time upload:)QBT_TR[CONTEXT=StatsDialog]</td>
-        <td id="AlltimeUL" class="statisticsValue"></td>
-    </tr>
-    <tr>
-        <td>QBT_TR(All-time download:)QBT_TR[CONTEXT=StatsDialog]</td>
-        <td id="AlltimeDL" class="statisticsValue"></td>
-    </tr>
-    <tr>
-        <td>QBT_TR(All-time share ratio:)QBT_TR[CONTEXT=StatsDialog]</td>
-        <td id="GlobalRatio" class="statisticsValue"></td>
-    </tr>
-    <tr>
-        <td>QBT_TR(Session waste:)QBT_TR[CONTEXT=StatsDialog]</td>
-        <td id="TotalWastedSession" class="statisticsValue"></td>
-    </tr>
-    <tr>
-        <td>QBT_TR(Connected peers:)QBT_TR[CONTEXT=StatsDialog]</td>
-        <td id="TotalPeerConnections" class="statisticsValue"></td>
-    </tr>
-</table>
+<!DOCTYPE html>
+<html lang="${LANG}">
 
-<h3>QBT_TR(Cache statistics)QBT_TR[CONTEXT=StatsDialog]</h3>
-<table style="width:100%">
-    <tr>
-        <td>QBT_TR(Read cache hits:)QBT_TR[CONTEXT=StatsDialog]</td>
-        <td id="ReadCacheHits" class="statisticsValue"></td>
-    </tr>
-    <tr>
-        <td>QBT_TR(Total buffer size:)QBT_TR[CONTEXT=StatsDialog]</td>
-        <td id="TotalBuffersSize" class="statisticsValue"></td>
-    </tr>
-</table>
+<head>
+    <meta charset="UTF-8" />
+    <title>QBT_TR(Statistics)QBT_TR[CONTEXT=StatsDialog]</title>
+    <link rel="stylesheet" href="css/style.css" type="text/css" />
+    <script src="scripts/lib/mootools-1.2-core-yc.js"></script>
+    <script src="scripts/lib/mootools-1.2-more.js"></script>
+    <script src="scripts/misc.js"></script>
+    <script>
+        var loadStatisticsTimer;
 
-<h3>QBT_TR(Performance statistics)QBT_TR[CONTEXT=StatsDialog]</h3>
-<table style="width:100%">
-    <tr>
-        <td>QBT_TR(Write cache overload:)QBT_TR[CONTEXT=StatsDialog]</td>
-        <td id="WriteCacheOverload" class="statisticsValue"></td>
-    </tr>
-    <tr>
-        <td>QBT_TR(Read cache overload:)QBT_TR[CONTEXT=StatsDialog]</td>
-        <td id="ReadCacheOverload" class="statisticsValue"></td>
-    </tr>
-    <tr>
-        <td>QBT_TR(Queued I/O jobs:)QBT_TR[CONTEXT=StatsDialog]</td>
-        <td id="QueuedIOJobs" class="statisticsValue"></td>
-    </tr>
-    <tr>
-        <td>QBT_TR(Average time in queue:)QBT_TR[CONTEXT=StatsDialog]</td>
-        <td id="AverageTimeInQueue" class="statisticsValue"></td>
-    </tr>
-    <tr>
-        <td>QBT_TR(Total queued size:)QBT_TR[CONTEXT=StatsDialog]</td>
-        <td id="TotalQueuedSize" class="statisticsValue"></td>
-    </tr>
-</table>
+        window.addEvent('domready', function() {
+            getStats();
+        });
+
+        function getStats() {
+            new Request.JSON({
+                url: 'api/v2/transfer/stats',
+                noCache: true,
+                method: 'get',
+                onFailure: function() {
+                    $('error_div').set('html', 'QBT_TR(qBittorrent client is not reachable)QBT_TR[CONTEXT=HttpServer]');
+
+                    clearTimeout(loadStatisticsTimer);
+                    loadStatisticsTimer = getStats.delay(5000);
+                },
+                onSuccess: function(response) {
+                    $('AlltimeDL').set('html', friendlyUnit(response.alltime_dl, false));
+                    $('AlltimeUL').set('html', friendlyUnit(response.alltime_ul, false));
+                    $('TotalWastedSession').set('html', friendlyUnit(response.total_wasted_session, false));
+                    $('GlobalRatio').set('html', response.global_ratio);
+                    $('TotalPeerConnections').set('html', response.total_peer_connections);
+                    $('ReadCacheHits').set('html', response.read_cache_hits + "%");
+                    $('TotalBuffersSize').set('html', friendlyUnit(response.total_buffers_size, false));
+                    $('WriteCacheOverload').set('html', response.write_cache_overload + "%");
+                    $('ReadCacheOverload').set('html', response.read_cache_overload + "%");
+                    $('QueuedIOJobs').set('html', response.queued_io_jobs);
+                    $('AverageTimeInQueue').set('html', response.average_time_queue + " ms");
+                    $('TotalQueuedSize').set('html', friendlyUnit(response.total_queued_size, false));
+
+                    clearTimeout(loadStatisticsTimer);
+                    loadStatisticsTimer = getStats.delay(5000);
+                }
+            }).send();
+        }
+    </script>
+</head>
+
+<body style="padding: 10px 12px;">
+    <h3>QBT_TR(User statistics)QBT_TR[CONTEXT=StatsDialog]</h3>
+    <table style="width:100%">
+        <tr>
+            <td>QBT_TR(All-time upload:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td id="AlltimeUL" class="statisticsValue"></td>
+        </tr>
+        <tr>
+            <td>QBT_TR(All-time download:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td id="AlltimeDL" class="statisticsValue"></td>
+        </tr>
+        <tr>
+            <td>QBT_TR(All-time share ratio:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td id="GlobalRatio" class="statisticsValue"></td>
+        </tr>
+        <tr>
+            <td>QBT_TR(Session waste:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td id="TotalWastedSession" class="statisticsValue"></td>
+        </tr>
+        <tr>
+            <td>QBT_TR(Connected peers:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td id="TotalPeerConnections" class="statisticsValue"></td>
+        </tr>
+    </table>
+
+    <h3>QBT_TR(Cache statistics)QBT_TR[CONTEXT=StatsDialog]</h3>
+    <table style="width:100%">
+        <tr>
+            <td>QBT_TR(Read cache hits:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td id="ReadCacheHits" class="statisticsValue"></td>
+        </tr>
+        <tr>
+            <td>QBT_TR(Total buffer size:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td id="TotalBuffersSize" class="statisticsValue"></td>
+        </tr>
+    </table>
+
+    <h3>QBT_TR(Performance statistics)QBT_TR[CONTEXT=StatsDialog]</h3>
+    <table style="width:100%">
+        <tr>
+            <td>QBT_TR(Write cache overload:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td id="WriteCacheOverload" class="statisticsValue"></td>
+        </tr>
+        <tr>
+            <td>QBT_TR(Read cache overload:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td id="ReadCacheOverload" class="statisticsValue"></td>
+        </tr>
+        <tr>
+            <td>QBT_TR(Queued I/O jobs:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td id="QueuedIOJobs" class="statisticsValue"></td>
+        </tr>
+        <tr>
+            <td>QBT_TR(Average time in queue:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td id="AverageTimeInQueue" class="statisticsValue"></td>
+        </tr>
+        <tr>
+            <td>QBT_TR(Total queued size:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td id="TotalQueuedSize" class="statisticsValue"></td>
+        </tr>
+    </table>
+</body>
+
+</html>


### PR DESCRIPTION
The current method of retrieving + displaying stats is problematic. If the Stats page isn't open when `serverState` comes in on `/sync/maindata`, then the Stats page will remain blank.

This change adds an explicit endpoint for retrieving stats. Stats will also update every 5 seconds. 