### PR TITLE
Inhibit sleep for running downloads or uploads regardless of network activity

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1863,20 +1863,26 @@ TorrentHandle *Session::findTorrent(const InfoHash &hash) const
 
 bool Session::hasActiveTorrents() const
 {
-    foreach (TorrentHandle *const torrent, m_torrents)
-        if (TorrentFilter::ActiveTorrent.match(torrent))
-            return true;
-
-    return false;
+    return std::any_of(m_torrents.begin(), m_torrents.end(), [](TorrentHandle *torrent)
+    {
+        return TorrentFilter::ActiveTorrent.match(torrent);
+    });
 }
 
 bool Session::hasUnfinishedTorrents() const
 {
-    foreach (TorrentHandle *const torrent, m_torrents)
-        if (!torrent->isSeed() && !torrent->isPaused())
-            return true;
+    return std::any_of(m_torrents.begin(), m_torrents.end(), [](const TorrentHandle *torrent)
+    {
+        return (!torrent->isSeed() && !torrent->isPaused());
+    });
+}
 
-    return false;
+bool Session::hasRunningSeed() const
+{
+    return std::any_of(m_torrents.begin(), m_torrents.end(), [](const TorrentHandle *torrent)
+    {
+        return (torrent->isSeed() && !torrent->isPaused());
+    });
 }
 
 void Session::banIP(const QString &ip)

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -454,6 +454,7 @@ namespace BitTorrent
         TorrentStatusReport torrentStatusReport() const;
         bool hasActiveTorrents() const;
         bool hasUnfinishedTorrents() const;
+        bool hasRunningSeed() const;
         const SessionStatus &status() const;
         const CacheStatus &cacheStatus() const;
         quint64 getAlltimeDL() const;

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -123,8 +123,10 @@ public:
     void setStartMinimized(bool b);
     bool isSplashScreenDisabled() const;
     void setSplashScreenDisabled(bool b);
-    bool preventFromSuspend() const;
-    void setPreventFromSuspend(bool b);
+    bool preventFromSuspendWhenDownloading() const;
+    void setPreventFromSuspendWhenDownloading(bool b);
+    bool preventFromSuspendWhenSeeding() const;
+    void setPreventFromSuspendWhenSeeding(bool b);
 #ifdef Q_OS_WIN
     bool WinStartup() const;
     void setWinStartup(bool b);

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -173,8 +173,8 @@ private slots:
     void on_actionDownloadFromURL_triggered();
     void on_actionExit_triggered();
     void on_actionLock_triggered();
-    // Check for active torrents and set preventing from suspend state
-    void checkForActiveTorrents();
+    // Check for unpaused downloading or seeding torrents and prevent system suspend/sleep according to preferences
+    void updatePowerManagementState();
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     void checkProgramUpdate();
 #endif

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -225,10 +225,12 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     connect(m_ui->checkShowSplash, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkProgramExitConfirm, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkProgramAutoExitConfirm, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
-    connect(m_ui->checkPreventFromSuspend, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->checkPreventFromSuspendWhenDownloading, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->checkPreventFromSuspendWhenSeeding, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->comboTrayIcon, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC)) && !defined(QT_DBUS_LIB)
-    m_ui->checkPreventFromSuspend->setDisabled(true);
+    m_ui->checkPreventFromSuspendWhenDownloading->setDisabled(true);
+    m_ui->checkPreventFromSuspendWhenSeeding->setDisabled(true);
 #endif
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     connect(m_ui->checkAssociateTorrents, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
@@ -556,7 +558,8 @@ void OptionsDialog::saveOptions()
     pref->setSplashScreenDisabled(isSplashScreenDisabled());
     pref->setConfirmOnExit(m_ui->checkProgramExitConfirm->isChecked());
     pref->setDontConfirmAutoExit(!m_ui->checkProgramAutoExitConfirm->isChecked());
-    pref->setPreventFromSuspend(preventFromSuspend());
+    pref->setPreventFromSuspendWhenDownloading(m_ui->checkPreventFromSuspendWhenDownloading->isChecked());
+    pref->setPreventFromSuspendWhenSeeding(m_ui->checkPreventFromSuspendWhenSeeding->isChecked());
 #ifdef Q_OS_WIN
     pref->setWinStartup(WinStartup());
     // Windows: file association settings
@@ -793,7 +796,8 @@ void OptionsDialog::loadOptions()
     }
 #endif
 
-    m_ui->checkPreventFromSuspend->setChecked(pref->preventFromSuspend());
+    m_ui->checkPreventFromSuspendWhenDownloading->setChecked(pref->preventFromSuspendWhenDownloading());
+    m_ui->checkPreventFromSuspendWhenSeeding->setChecked(pref->preventFromSuspendWhenSeeding());
 
 #ifdef Q_OS_WIN
     m_ui->checkStartup->setChecked(pref->WinStartup());
@@ -1406,11 +1410,6 @@ bool OptionsDialog::WinStartup() const
     return m_ui->checkStartup->isChecked();
 }
 #endif
-
-bool OptionsDialog::preventFromSuspend() const
-{
-    return m_ui->checkPreventFromSuspend->isChecked();
-}
 
 bool OptionsDialog::preAllocateAllFiles() const
 {

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -122,7 +122,6 @@ private:
 #endif
     bool startMinimized() const;
     bool isSplashScreenDisabled() const;
-    bool preventFromSuspend() const;
 #ifdef Q_OS_WIN
     bool WinStartup() const;
 #endif

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -479,9 +479,16 @@
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_16">
                <item>
-                <widget class="QCheckBox" name="checkPreventFromSuspend">
+                <widget class="QCheckBox" name="checkPreventFromSuspendWhenDownloading">
                  <property name="text">
-                  <string>Inhibit system sleep when torrents are active</string>
+                  <string>Inhibit system sleep when torrents are downloading</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="checkPreventFromSuspendWhenSeeding">
+                 <property name="text">
+                  <string>Inhibit system sleep when torrents are seeding</string>
                  </property>
                 </widget>
                </item>
@@ -3369,7 +3376,8 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
   <tabstop>comboTrayIcon</tabstop>
   <tabstop>checkAssociateTorrents</tabstop>
   <tabstop>checkAssociateMagnetLinks</tabstop>
-  <tabstop>checkPreventFromSuspend</tabstop>
+  <tabstop>checkPreventFromSuspendWhenDownloading</tabstop>
+  <tabstop>checkPreventFromSuspendWhenSeeding</tabstop>
   <tabstop>checkAdditionDialog</tabstop>
   <tabstop>checkAdditionDialogFront</tabstop>
   <tabstop>checkPreallocateAll</tabstop>


### PR DESCRIPTION
"Active torrents" is a somewhat unintuitive concept to base preventing sleep on, as torrents can become active or inactive on the network at any time. This brings some predictability to the inhibit sleep option, and will inhibit sleep as long as there are unpaused downloads or uploads, regardless of network activity.
![screenshot from 2018-07-26 17-45-26](https://user-images.githubusercontent.com/597166/43290324-ca5ab4aa-90fb-11e8-9615-856157b86bf3.png)
