### PR TITLE
Never save resume data for already paused torrents

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -2350,7 +2350,7 @@ void Session::generateResumeData(bool final)
 {
     foreach (TorrentHandle *const torrent, m_torrents) {
         if (!torrent->isValid()) continue;
-        if (torrent->isChecking()) continue;
+        if (torrent->isChecking() || torrent->isPaused()) continue;
         if (!final && !torrent->needSaveResumeData()) continue;
         if (torrent->hasMissingFiles() || torrent->hasError()) continue;
 

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -2350,9 +2350,9 @@ void Session::generateResumeData(bool final)
 {
     foreach (TorrentHandle *const torrent, m_torrents) {
         if (!torrent->isValid()) continue;
-        if (torrent->hasMissingFiles()) continue;
-        if (torrent->isChecking() || torrent->hasError()) continue;
+        if (torrent->isChecking()) continue;
         if (!final && !torrent->needSaveResumeData()) continue;
+        if (torrent->hasMissingFiles() || torrent->hasError()) continue;
 
         saveTorrentResumeData(torrent, final);
     }


### PR DESCRIPTION
Paused torrent should not have any resume data changes.
Since resume data is already saved for such torrent (or at least is currently saving) we can to save no resume data anymore until it is resumed back.
This should prevent unnecessary load on the disk, as well as significantly reduce the application shutdown time for those users who have a lot of torrents, most of which are paused (do not forget that the final saving causes a forced update of the torrent state, which is quite expensive).