### PR TITLE
Put temporary files in qbt own temp folder and cleanups

### DIFF
--- a/qbittorrent.pro
+++ b/qbittorrent.pro
@@ -17,6 +17,10 @@ tarball.commands += rm -fR $${PROJECT_NAME}-$${PROJECT_VERSION}
 
 QMAKE_EXTRA_TARGETS += tarball
 
+# Translations included here (at top level) is to avoid regenerating the .qm files
+# every time when src.pro is processed
+include(src/lang/lang.pri)
+
 # For Qt Creator beautifier
 DISTFILES += \
     uncrustify.cfg

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -2300,7 +2300,7 @@ bool Session::loadMetadata(const MagnetUri &magnetUri)
     p.max_connections = maxConnectionsPerTorrent();
     p.max_uploads = maxUploadsPerTorrent();
 
-    QString savePath = QString("%1/%2").arg(QDir::tempPath(), hash);
+    QString savePath = QString("%1/%2").arg(Utils::Fs::tempPath(), hash);
     p.save_path = Utils::Fs::toNativePath(savePath).toStdString();
 
     // Forced start

--- a/src/base/iconprovider.cpp
+++ b/src/base/iconprovider.cpp
@@ -29,8 +29,6 @@
 
 #include "iconprovider.h"
 
-#include <QString>
-
 IconProvider::IconProvider(QObject *parent)
     : QObject(parent)
 {
@@ -57,7 +55,7 @@ IconProvider *IconProvider::instance()
     return m_instance;
 }
 
-QString IconProvider::getIconPath(const QString &iconId)
+QString IconProvider::getIconPath(const QString &iconId) const
 {
     return ":/icons/qbt-theme/" + iconId + ".png";
 }

--- a/src/base/iconprovider.h
+++ b/src/base/iconprovider.h
@@ -31,8 +31,7 @@
 #define ICONPROVIDER_H
 
 #include <QObject>
-
-class QString;
+#include <QString>
 
 class IconProvider : public QObject
 {
@@ -43,7 +42,7 @@ public:
     static void freeInstance();
     static IconProvider *instance();
 
-    virtual QString getIconPath(const QString &iconId);
+    virtual QString getIconPath(const QString &iconId) const;
 
 protected:
     explicit IconProvider(QObject *parent = nullptr);

--- a/src/gui/guiiconprovider.cpp
+++ b/src/gui/guiiconprovider.cpp
@@ -37,6 +37,7 @@
 #endif
 
 #include "base/preferences.h"
+#include "base/utils/fs.h"
 
 GuiIconProvider::GuiIconProvider(QObject *parent)
     : IconProvider(parent)
@@ -124,7 +125,7 @@ QString GuiIconProvider::getIconPath(const QString &iconId) const
 {
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
     if (m_useSystemTheme) {
-        QString path = QDir::temp().absoluteFilePath(iconId + ".png");
+        QString path = Utils::Fs::tempPath() + iconId + ".png";
         if (!QFile::exists(path)) {
             const QIcon icon = QIcon::fromTheme(iconId);
             if (!icon.isNull())

--- a/src/gui/guiiconprovider.cpp
+++ b/src/gui/guiiconprovider.cpp
@@ -57,12 +57,12 @@ GuiIconProvider *GuiIconProvider::instance()
     return static_cast<GuiIconProvider *>(m_instance);
 }
 
-QIcon GuiIconProvider::getIcon(const QString &iconId)
+QIcon GuiIconProvider::getIcon(const QString &iconId) const
 {
     return getIcon(iconId, iconId);
 }
 
-QIcon GuiIconProvider::getIcon(const QString &iconId, const QString &fallback)
+QIcon GuiIconProvider::getIcon(const QString &iconId, const QString &fallback) const
 {
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
     if (m_useSystemTheme) {
@@ -78,7 +78,7 @@ QIcon GuiIconProvider::getIcon(const QString &iconId, const QString &fallback)
     return QIcon(IconProvider::getIconPath(iconId));
 }
 
-QIcon GuiIconProvider::getFlagIcon(const QString &countryIsoCode)
+QIcon GuiIconProvider::getFlagIcon(const QString &countryIsoCode) const
 {
     if (countryIsoCode.isEmpty()) return QIcon();
     return QIcon(":/icons/flags/" + countryIsoCode.toLower() + ".svg");
@@ -89,7 +89,7 @@ QIcon GuiIconProvider::getFlagIcon(const QString &countryIsoCode)
 // Otherwise, the UI looks broken if the icon is not available
 // in the correct size.
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
-QIcon GuiIconProvider::generateDifferentSizes(const QIcon &icon)
+QIcon GuiIconProvider::generateDifferentSizes(const QIcon &icon) const
 {
     // if icon is loaded from SVG format, it already contains all the required sizes and we shall not resize it
     // In that case it will be available in the following sizes:
@@ -120,7 +120,7 @@ QIcon GuiIconProvider::generateDifferentSizes(const QIcon &icon)
 }
 #endif
 
-QString GuiIconProvider::getIconPath(const QString &iconId)
+QString GuiIconProvider::getIconPath(const QString &iconId) const
 {
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
     if (m_useSystemTheme) {

--- a/src/gui/guiiconprovider.cpp
+++ b/src/gui/guiiconprovider.cpp
@@ -30,6 +30,7 @@
 #include "guiiconprovider.h"
 
 #include <QIcon>
+#include <QVector>
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
 #include <QDir>
 #include <QFile>
@@ -99,16 +100,15 @@ QIcon GuiIconProvider::generateDifferentSizes(const QIcon &icon) const
         return icon;
 
     QIcon newIcon;
-    QList<QSize> requiredSizes;
-    requiredSizes << QSize(16, 16) << QSize(24, 24) << QSize(32, 32);
-    QList<QIcon::Mode> modes;
-    modes << QIcon::Normal << QIcon::Active << QIcon::Selected << QIcon::Disabled;
-    foreach (const QSize &size, requiredSizes) {
-        foreach (QIcon::Mode mode, modes) {
+    const QVector<QSize> requiredSizes {{16, 16}, {24, 24}, {32, 32}};
+    const QVector<QIcon::Mode> modes {QIcon::Normal, QIcon::Active, QIcon::Selected, QIcon::Disabled};
+    for (const QSize &size : requiredSizes) {
+        for (const QIcon::Mode mode : modes) {
             QPixmap pixoff = icon.pixmap(size, mode, QIcon::Off);
             if (pixoff.height() > size.height())
                 pixoff = pixoff.scaled(size, Qt::KeepAspectRatio,  Qt::SmoothTransformation);
             newIcon.addPixmap(pixoff, mode, QIcon::Off);
+
             QPixmap pixon = icon.pixmap(size, mode, QIcon::On);
             if (pixon.height() > size.height())
                 pixon = pixoff.scaled(size, Qt::KeepAspectRatio,  Qt::SmoothTransformation);

--- a/src/gui/guiiconprovider.h
+++ b/src/gui/guiiconprovider.h
@@ -43,10 +43,10 @@ public:
     static void initInstance();
     static GuiIconProvider *instance();
 
-    QIcon getIcon(const QString &iconId);
-    QIcon getIcon(const QString &iconId, const QString &fallback);
-    QIcon getFlagIcon(const QString &countryIsoCode);
-    QString getIconPath(const QString &iconId);
+    QIcon getIcon(const QString &iconId) const;
+    QIcon getIcon(const QString &iconId, const QString &fallback) const;
+    QIcon getFlagIcon(const QString &countryIsoCode) const;
+    QString getIconPath(const QString &iconId) const override;
 
 private slots:
     void configure();
@@ -55,7 +55,7 @@ private:
     explicit GuiIconProvider(QObject *parent = nullptr);
     ~GuiIconProvider();
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
-    QIcon generateDifferentSizes(const QIcon &icon);
+    QIcon generateDifferentSizes(const QIcon &icon) const;
 
     bool m_useSystemTheme;
 #endif

--- a/src/src.pro
+++ b/src/src.pro
@@ -76,7 +76,4 @@ RESOURCES += \
     lang/lang.qrc \
     searchengine/searchengine.qrc
 
-# Translations
-include(lang/lang.pri)
-
 DESTDIR = .


### PR DESCRIPTION
About "Avoid regenerating .qm files unnecessarily", I'm not intending to find a better solution, just reverting back to the old way.
