### PR TITLE
Set "close to tray" to false as default

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -185,7 +185,7 @@ void Preferences::setMinimizeToTray(bool b)
 
 bool Preferences::closeToTray() const
 {
-    return value("Preferences/General/CloseToTray", true).toBool();
+    return value("Preferences/General/CloseToTray", false).toBool();
 }
 
 void Preferences::setCloseToTray(bool b)


### PR DESCRIPTION
People might not know that this option is active and never look at the options and so mistakenly believe that the program never closes (me included). A chunk of the reports about qBt process that never ends may be because of this.

Closes #6060