### PR TITLE
Fix I/O error after fetching magnet metadata

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -2300,7 +2300,7 @@ bool Session::loadMetadata(const MagnetUri &magnetUri)
     p.max_connections = maxConnectionsPerTorrent();
     p.max_uploads = maxUploadsPerTorrent();
 
-    QString savePath = QString("%1/%2").arg(Utils::Fs::tempPath(), hash);
+    const QString savePath = Utils::Fs::tempPath() + static_cast<QString>(hash);
     p.save_path = Utils::Fs::toNativePath(savePath).toStdString();
 
     // Forced start


### PR DESCRIPTION
Issue report: https://github.com/qbittorrent/qBittorrent/commit/9612a75faa32ef852cc5485db7b788ec73138500#commitcomment-30026061