### PR TITLE
Fix regression that broke installing desktop file

### DIFF
--- a/unixconf.pri
+++ b/unixconf.pri
@@ -36,7 +36,7 @@ nogui:systemd {
 
 # Menu Icon
 !nogui {
-    menuicon.files = dist/unix/qbittorrent.desktop
+    menuicon.files = $$DIST_PATH/qbittorrent.desktop
     menuicon.path = $$DATADIR/applications/
     INSTALLS += menuicon
 


### PR DESCRIPTION
In commit 5d94db9c7940aee9af769ce314c1dd1be9ddc18c the desktop file was moved from src/ to dist/ but the relative path from src/src.pro was switched to an absolute path from the repository root. This broke detection of the file from within qmake.

Fix by using the same $DIST_PATH used elsewhere for consistency, which uses ../dist/.