### PR TITLE
Revert "Print warning about cmake support status"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
 
-message(WARNING "No official support for cmake build system. If it is broken, please submit patches!")
+message(AUTHOR_WARNING "If the build fails, please try the autotools/qmake method.")
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
 include(FunctionReadVersion)


### PR DESCRIPTION
This reverts commit 239352ad88a6533bbeb317b2f8ce57f34fdcb637.