### PR TITLE
Allow setting seq & first/last from context menu without metadata

### DIFF
--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -963,27 +963,23 @@ void TransferListWidget::displayListMenu(const QPoint&)
             oneHasMetadata = true;
         if (!torrent->isSeed()) {
             oneNotSeed = true;
-            if (torrent->hasMetadata()) {
-                if (first) {
-                    sequentialDownloadMode = torrent->isSequentialDownload();
-                    prioritizeFirstLast = torrent->hasFirstLastPiecePriority();
-                }
-                else {
-                    if (sequentialDownloadMode != torrent->isSequentialDownload())
-                        allSameSequentialDownloadMode = false;
-                    if (prioritizeFirstLast != torrent->hasFirstLastPiecePriority())
-                        allSamePrioFirstlast = false;
-                }
+            if (first) {
+                sequentialDownloadMode = torrent->isSequentialDownload();
+                prioritizeFirstLast = torrent->hasFirstLastPiecePriority();
+            }
+            else {
+                if (sequentialDownloadMode != torrent->isSequentialDownload())
+                    allSameSequentialDownloadMode = false;
+                if (prioritizeFirstLast != torrent->hasFirstLastPiecePriority())
+                    allSamePrioFirstlast = false;
             }
         }
         else {
             if (!oneNotSeed && allSameSuperSeeding && torrent->hasMetadata()) {
-                if (first) {
+                if (first)
                     superSeedingMode = torrent->superSeeding();
-                }
                 else if (superSeedingMode != torrent->superSeeding())
                     allSameSuperSeeding = false;
-
             }
         }
         if (!torrent->isForced())
@@ -1082,7 +1078,7 @@ void TransferListWidget::displayListMenu(const QPoint&)
         listMenu.addAction(&actionPreviewFile);
         addedPreviewAction = true;
     }
-    if (oneNotSeed && oneHasMetadata) {
+    if (oneNotSeed) {
         if (allSameSequentialDownloadMode) {
             actionSequentialDownload.setChecked(sequentialDownloadMode);
             listMenu.addAction(&actionSequentialDownload);


### PR DESCRIPTION
The fact that you can now set these options from the new torrent dialog got me thinking if this is possible and it turns out that it is, tested.

P.S. I know the commit msg is longer than 50 chars but i can't shrink it even more.