### PR TITLE
Fix mingw warning about unrecognized escape sequence

### DIFF
--- a/src/qbittorrent_mingw.rc
+++ b/src/qbittorrent_mingw.rc
@@ -1,3 +1,3 @@
-IDI_ICON1 ICON DISCARDABLE "icons\qbittorrent.ico"
-IDI_ICON2 ICON DISCARDABLE "icons\qbittorrent_file.ico"
+IDI_ICON1 ICON DISCARDABLE "icons/qbittorrent.ico"
+IDI_ICON2 ICON DISCARDABLE "icons/qbittorrent_file.ico"
 1 24 DISCARDABLE "qbittorrent.exe.manifest"


### PR DESCRIPTION
Warning introduced by commit 6203f23f06b

The warnings of mingw (gcc 8.1.0) were:
```
qbittorrent_mingw.rc:1: unrecognized escape sequence
qbittorrent_mingw.rc:2: unrecognized escape sequence
```