### PR TITLE
Read command line parameters from <exeName>.params file

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -51,7 +51,7 @@ Q_IMPORT_PLUGIN(QICOPlugin)
 // NoGUI-only includes
 #include <cstdio>
 #ifdef Q_OS_UNIX
-#include "unistd.h"
+#include <unistd.h>
 #endif
 #endif // DISABLE_GUI
 


### PR DESCRIPTION
The file is mainly intended to put `--portable` there, thus solving user complains from #465. 

Not sure that putting the function to obtain executable path in the utils is the right way to go, because it is used only in `main()`  when the application object is not yet created.