### PR TITLE
Fix WebUI unreachable issue

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -530,7 +530,7 @@ void Preferences::setWebUiAuthSubnetWhitelist(QStringList subnets)
 
 QString Preferences::getServerDomains() const
 {
-    return value("Preferences/WebUI/ServerDomains", '*').toString();
+    return value("Preferences/WebUI/ServerDomains", QChar('*')).toString();
 }
 
 void Preferences::setServerDomains(const QString &str)
@@ -540,7 +540,7 @@ void Preferences::setServerDomains(const QString &str)
 
 QString Preferences::getWebUiAddress() const
 {
-    return value("Preferences/WebUI/Address", '*').toString().trimmed();
+    return value("Preferences/WebUI/Address", QChar('*')).toString().trimmed();
 }
 
 void Preferences::setWebUiAddress(const QString &addr)


### PR DESCRIPTION
QVariant doesn't have constructor for plain char, by default it converts a plain char into an integer, hence the WebUI issue.
Closes #9333.