### PR TITLE
 Add checking_mem_usage option to AdvancedSettings

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -276,6 +276,7 @@ Session::Session(QObject *parent)
     , m_announceToAllTrackers(BITTORRENT_SESSION_KEY("AnnounceToAllTrackers"), false)
     , m_announceToAllTiers(BITTORRENT_SESSION_KEY("AnnounceToAllTiers"), true)
     , m_asyncIOThreads(BITTORRENT_SESSION_KEY("AsyncIOThreadsCount"), 4)
+    , m_checkingMemUsage(BITTORRENT_SESSION_KEY("CheckingMemUsageSize"), 16)
     , m_diskCacheSize(BITTORRENT_SESSION_KEY("DiskCacheSize"), 64)
     , m_diskCacheTTL(BITTORRENT_SESSION_KEY("DiskCacheTTL"), 60)
     , m_useOSCache(BITTORRENT_SESSION_KEY("UseOSCache"), true)
@@ -1317,6 +1318,9 @@ void Session::configure(libtorrent::settings_pack &settingsPack)
     settingsPack.set_bool(libt::settings_pack::announce_to_all_tiers, announceToAllTiers());
 
     settingsPack.set_int(libt::settings_pack::aio_threads, asyncIOThreads());
+
+    const int checkingMemUsageSize = checkingMemUsage() * 64;
+    settingsPack.set_int(libt::settings_pack::checking_mem_usage, checkingMemUsageSize);
 
     const int cacheSize = (diskCacheSize() > -1) ? (diskCacheSize() * 64) : -1;
     settingsPack.set_int(libt::settings_pack::cache_size, cacheSize);
@@ -3080,6 +3084,22 @@ void Session::setAsyncIOThreads(const int num)
         return;
 
     m_asyncIOThreads = num;
+    configureDeferred();
+}
+
+int Session::checkingMemUsage() const
+{
+    return qMax(1, m_checkingMemUsage.value());
+}
+
+void Session::setCheckingMemUsage(int size)
+{
+    size = qMax(size, 1);
+
+    if (size == m_checkingMemUsage)
+        return;
+
+    m_checkingMemUsage = size;
     configureDeferred();
 }
 

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -377,6 +377,8 @@ namespace BitTorrent
         void setAnnounceToAllTiers(bool val);
         int asyncIOThreads() const;
         void setAsyncIOThreads(int num);
+        int checkingMemUsage() const;
+        void setCheckingMemUsage(int size);
         int diskCacheSize() const;
         void setDiskCacheSize(int size);
         int diskCacheTTL() const;
@@ -658,6 +660,7 @@ namespace BitTorrent
         CachedSettingValue<bool> m_announceToAllTrackers;
         CachedSettingValue<bool> m_announceToAllTiers;
         CachedSettingValue<int> m_asyncIOThreads;
+        CachedSettingValue<int> m_checkingMemUsage;
         CachedSettingValue<int> m_diskCacheSize;
         CachedSettingValue<int> m_diskCacheTTL;
         CachedSettingValue<bool> m_useOSCache;

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -83,6 +83,7 @@ enum AdvSettingsRows
 #if LIBTORRENT_VERSION_NUM >= 10100
     ASYNC_IO_THREADS,
 #endif
+    CHECKING_MEM_USAGE,
     // cache
     DISK_CACHE,
     DISK_CACHE_TTL,
@@ -152,6 +153,8 @@ void AdvancedSettings::saveAdvancedSettings()
     // Async IO threads
     session->setAsyncIOThreads(spinBoxAsyncIOThreads.value());
 #endif
+    // Checking Memory Usage
+    session->setCheckingMemUsage(spinBoxCheckingMemUsage.value());
     // Disk write cache
     session->setDiskCacheSize(spinBoxCache.value());
     session->setDiskCacheTTL(spinBoxCacheTTL.value());
@@ -325,6 +328,13 @@ void AdvancedSettings::loadAdvancedSettings()
     spinBoxAsyncIOThreads.setValue(session->asyncIOThreads());
     addRow(ASYNC_IO_THREADS, tr("Asynchronous I/O threads"), &spinBoxAsyncIOThreads);
 #endif
+
+    // Checking Memory Usage
+    spinBoxCheckingMemUsage.setMinimum(1);
+    spinBoxCheckingMemUsage.setValue(session->checkingMemUsage());
+    spinBoxCheckingMemUsage.setSuffix(tr(" MiB"));
+    addRow(CHECKING_MEM_USAGE, tr("Outstanding memory when checking torrents"), &spinBoxCheckingMemUsage);
+
     // Disk write cache
     spinBoxCache.setMinimum(-1);
     // When build as 32bit binary, set the maximum at less than 2GB to prevent crashes.

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -59,7 +59,7 @@ private:
     template <typename T> void addRow(int row, const QString &rowText, T *widget);
 
     QLabel labelQbtLink, labelLibtorrentLink;
-    QSpinBox spinBoxAsyncIOThreads, spinBoxCache, spinBoxSaveResumeDataInterval, spinBoxOutgoingPortsMin, spinBoxOutgoingPortsMax, spinBoxListRefresh, spinBoxMaxHalfOpen,
+    QSpinBox spinBoxAsyncIOThreads, spinBoxCheckingMemUsage, spinBoxCache, spinBoxSaveResumeDataInterval, spinBoxOutgoingPortsMin, spinBoxOutgoingPortsMax, spinBoxListRefresh, spinBoxMaxHalfOpen,
              spinBoxTrackerPort, spinBoxCacheTTL, spinBoxSendBufferWatermark, spinBoxSendBufferLowWatermark,
              spinBoxSendBufferWatermarkFactor, spinBoxSavePathHistoryLength;
     QCheckBox checkBoxOsCache, checkBoxRecheckCompleted, checkBoxResolveCountries, checkBoxResolveHosts, checkBoxSuperSeeding,


### PR DESCRIPTION
Adds a spinbox in advanced options to change the libtorrent setting
`checking_mem_usage`.

Potential usefulness: refer to discussion at https://github.com/qbittorrent/qBittorrent/issues/9061