### PR TITLE
Add additional tracker info to WebUI

### DIFF
--- a/src/base/bittorrent/trackerentry.h
+++ b/src/base/bittorrent/trackerentry.h
@@ -44,10 +44,10 @@ namespace BitTorrent
     public:
         enum Status
         {
-            NotContacted,
-            Working,
-            Updating,
-            NotWorking
+            NotContacted = 1,
+            Working = 2,
+            Updating = 3,
+            NotWorking = 4
         };
 
         TrackerEntry(const QString &url);

--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -367,15 +367,9 @@ void TrackerListWidget::loadTrackers()
         }
 
         item->setText(COL_PEERS, QString::number(data.numPeers));
-#if LIBTORRENT_VERSION_NUM >= 10000
         item->setText(COL_SEEDS, (entry.nativeEntry().scrape_complete > -1) ? QString::number(entry.nativeEntry().scrape_complete) : tr("N/A"));
         item->setText(COL_LEECHES, (entry.nativeEntry().scrape_incomplete > -1) ? QString::number(entry.nativeEntry().scrape_incomplete) : tr("N/A"));
         item->setText(COL_DOWNLOADED, (entry.nativeEntry().scrape_downloaded > -1) ? QString::number(entry.nativeEntry().scrape_downloaded) : tr("N/A"));
-#else
-        item->setText(COL_SEEDS, tr("N/A"));
-        item->setText(COL_LEECHES, tr("N/A"));
-        item->setText(COL_DOWNLOADED, tr("N/A"));
-#endif
 
         item->setTextAlignment(COL_TIER, (Qt::AlignRight | Qt::AlignVCenter));
         item->setTextAlignment(COL_PEERS, (Qt::AlignRight | Qt::AlignVCenter));

--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -534,9 +534,9 @@ void TrackerListWidget::showTrackerListMenu(QPoint)
     QAction *delAct = nullptr;
     QAction *editAct = nullptr;
     if (!getSelectedTrackerItems().isEmpty()) {
+        editAct = menu.addAction(GuiIconProvider::instance()->getIcon("edit-rename"),tr("Edit tracker URL..."));
         delAct = menu.addAction(GuiIconProvider::instance()->getIcon("list-remove"), tr("Remove tracker"));
         copyAct = menu.addAction(GuiIconProvider::instance()->getIcon("edit-copy"), tr("Copy tracker URL"));
-        editAct = menu.addAction(GuiIconProvider::instance()->getIcon("edit-rename"),tr("Edit selected tracker URL"));
     }
     QAction *reannounceSelAct = nullptr;
     QAction *reannounceAllAct = nullptr;

--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -97,23 +97,23 @@ TrackerListWidget::TrackerListWidget(PropertiesWidget *properties)
     insertTopLevelItem(2, m_LSDItem);
     setRowColor(2, QColor("grey"));
     // Set static items alignment
-    m_DHTItem->setTextAlignment(COL_RECEIVED, (Qt::AlignRight | Qt::AlignVCenter));
-    m_PEXItem->setTextAlignment(COL_RECEIVED, (Qt::AlignRight | Qt::AlignVCenter));
-    m_LSDItem->setTextAlignment(COL_RECEIVED, (Qt::AlignRight | Qt::AlignVCenter));
-    m_DHTItem->setTextAlignment(COL_SEEDS, (Qt::AlignRight | Qt::AlignVCenter));
-    m_PEXItem->setTextAlignment(COL_SEEDS, (Qt::AlignRight | Qt::AlignVCenter));
-    m_LSDItem->setTextAlignment(COL_SEEDS, (Qt::AlignRight | Qt::AlignVCenter));
     m_DHTItem->setTextAlignment(COL_PEERS, (Qt::AlignRight | Qt::AlignVCenter));
     m_PEXItem->setTextAlignment(COL_PEERS, (Qt::AlignRight | Qt::AlignVCenter));
     m_LSDItem->setTextAlignment(COL_PEERS, (Qt::AlignRight | Qt::AlignVCenter));
+    m_DHTItem->setTextAlignment(COL_SEEDS, (Qt::AlignRight | Qt::AlignVCenter));
+    m_PEXItem->setTextAlignment(COL_SEEDS, (Qt::AlignRight | Qt::AlignVCenter));
+    m_LSDItem->setTextAlignment(COL_SEEDS, (Qt::AlignRight | Qt::AlignVCenter));
+    m_DHTItem->setTextAlignment(COL_LEECHES, (Qt::AlignRight | Qt::AlignVCenter));
+    m_PEXItem->setTextAlignment(COL_LEECHES, (Qt::AlignRight | Qt::AlignVCenter));
+    m_LSDItem->setTextAlignment(COL_LEECHES, (Qt::AlignRight | Qt::AlignVCenter));
     m_DHTItem->setTextAlignment(COL_DOWNLOADED, (Qt::AlignRight | Qt::AlignVCenter));
     m_PEXItem->setTextAlignment(COL_DOWNLOADED, (Qt::AlignRight | Qt::AlignVCenter));
     m_LSDItem->setTextAlignment(COL_DOWNLOADED, (Qt::AlignRight | Qt::AlignVCenter));
     // Set header alignment
     headerItem()->setTextAlignment(COL_TIER, (Qt::AlignRight | Qt::AlignVCenter));
-    headerItem()->setTextAlignment(COL_RECEIVED, (Qt::AlignRight | Qt::AlignVCenter));
-    headerItem()->setTextAlignment(COL_SEEDS, (Qt::AlignRight | Qt::AlignVCenter));
     headerItem()->setTextAlignment(COL_PEERS, (Qt::AlignRight | Qt::AlignVCenter));
+    headerItem()->setTextAlignment(COL_SEEDS, (Qt::AlignRight | Qt::AlignVCenter));
+    headerItem()->setTextAlignment(COL_LEECHES, (Qt::AlignRight | Qt::AlignVCenter));
     headerItem()->setTextAlignment(COL_DOWNLOADED, (Qt::AlignRight | Qt::AlignVCenter));
     // Set hotkeys
     m_editHotkey = new QShortcut(Qt::Key_F2, this, nullptr, nullptr, Qt::WidgetShortcut);
@@ -245,15 +245,15 @@ void TrackerListWidget::clear()
     m_trackerItems.clear();
     m_DHTItem->setText(COL_STATUS, "");
     m_DHTItem->setText(COL_SEEDS, "");
-    m_DHTItem->setText(COL_PEERS, "");
+    m_DHTItem->setText(COL_LEECHES, "");
     m_DHTItem->setText(COL_MSG, "");
     m_PEXItem->setText(COL_STATUS, "");
     m_PEXItem->setText(COL_SEEDS, "");
-    m_PEXItem->setText(COL_PEERS, "");
+    m_PEXItem->setText(COL_LEECHES, "");
     m_PEXItem->setText(COL_MSG, "");
     m_LSDItem->setText(COL_STATUS, "");
     m_LSDItem->setText(COL_SEEDS, "");
-    m_LSDItem->setText(COL_PEERS, "");
+    m_LSDItem->setText(COL_LEECHES, "");
     m_LSDItem->setText(COL_MSG, "");
 }
 
@@ -314,11 +314,11 @@ void TrackerListWidget::loadStickyItems(BitTorrent::TorrentHandle *const torrent
     }
 
     m_DHTItem->setText(COL_SEEDS, QString::number(seedsDHT));
-    m_DHTItem->setText(COL_PEERS, QString::number(peersDHT));
+    m_DHTItem->setText(COL_LEECHES, QString::number(peersDHT));
     m_PEXItem->setText(COL_SEEDS, QString::number(seedsPeX));
-    m_PEXItem->setText(COL_PEERS, QString::number(peersPeX));
+    m_PEXItem->setText(COL_LEECHES, QString::number(peersPeX));
     m_LSDItem->setText(COL_SEEDS, QString::number(seedsLSD));
-    m_LSDItem->setText(COL_PEERS, QString::number(peersLSD));
+    m_LSDItem->setText(COL_LEECHES, QString::number(peersLSD));
 }
 
 void TrackerListWidget::loadTrackers()
@@ -366,21 +366,21 @@ void TrackerListWidget::loadTrackers()
             break;
         }
 
-        item->setText(COL_RECEIVED, QString::number(data.numPeers));
+        item->setText(COL_PEERS, QString::number(data.numPeers));
 #if LIBTORRENT_VERSION_NUM >= 10000
         item->setText(COL_SEEDS, (entry.nativeEntry().scrape_complete > -1) ? QString::number(entry.nativeEntry().scrape_complete) : tr("N/A"));
-        item->setText(COL_PEERS, (entry.nativeEntry().scrape_incomplete > -1) ? QString::number(entry.nativeEntry().scrape_incomplete) : tr("N/A"));
+        item->setText(COL_LEECHES, (entry.nativeEntry().scrape_incomplete > -1) ? QString::number(entry.nativeEntry().scrape_incomplete) : tr("N/A"));
         item->setText(COL_DOWNLOADED, (entry.nativeEntry().scrape_downloaded > -1) ? QString::number(entry.nativeEntry().scrape_downloaded) : tr("N/A"));
 #else
         item->setText(COL_SEEDS, tr("N/A"));
-        item->setText(COL_PEERS, tr("N/A"));
+        item->setText(COL_LEECHES, tr("N/A"));
         item->setText(COL_DOWNLOADED, tr("N/A"));
 #endif
 
         item->setTextAlignment(COL_TIER, (Qt::AlignRight | Qt::AlignVCenter));
-        item->setTextAlignment(COL_RECEIVED, (Qt::AlignRight | Qt::AlignVCenter));
-        item->setTextAlignment(COL_SEEDS, (Qt::AlignRight | Qt::AlignVCenter));
         item->setTextAlignment(COL_PEERS, (Qt::AlignRight | Qt::AlignVCenter));
+        item->setTextAlignment(COL_SEEDS, (Qt::AlignRight | Qt::AlignVCenter));
+        item->setTextAlignment(COL_LEECHES, (Qt::AlignRight | Qt::AlignVCenter));
         item->setTextAlignment(COL_DOWNLOADED, (Qt::AlignRight | Qt::AlignVCenter));
     }
     // Remove old trackers
@@ -592,9 +592,9 @@ QStringList TrackerListWidget::headerLabels()
         "#"
         , tr("URL")
         , tr("Status")
-        , tr("Received")
-        , tr("Seeds")
         , tr("Peers")
+        , tr("Seeds")
+        , tr("Leeches")
         , tr("Downloaded")
         , tr("Message")
     };

--- a/src/gui/properties/trackerlistwidget.h
+++ b/src/gui/properties/trackerlistwidget.h
@@ -54,9 +54,9 @@ public:
         COL_TIER,
         COL_URL,
         COL_STATUS,
-        COL_RECEIVED,
-        COL_SEEDS,
         COL_PEERS,
+        COL_SEEDS,
+        COL_LEECHES,
         COL_DOWNLOADED,
         COL_MSG,
 

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -56,8 +56,12 @@
 // Tracker keys
 const char KEY_TRACKER_URL[] = "url";
 const char KEY_TRACKER_STATUS[] = "status";
+const char KEY_TRACKER_TIER[] = "tier";
 const char KEY_TRACKER_MSG[] = "msg";
-const char KEY_TRACKER_PEERS[] = "num_peers";
+const char KEY_TRACKER_PEERS_COUNT[] = "num_peers";
+const char KEY_TRACKER_SEEDS_COUNT[] = "num_seeds";
+const char KEY_TRACKER_LEECHES_COUNT[] = "num_leeches";
+const char KEY_TRACKER_DOWNLOADED_COUNT[] = "num_downloaded";
 
 // Web seed keys
 const char KEY_WEBSEED_URL[] = "url";
@@ -295,7 +299,11 @@ void TorrentsController::propertiesAction()
 // The dictionary keys are:
 //   - "url": Tracker URL
 //   - "status": Tracker status
-//   - "num_peers": Tracker peer count
+//   - "tier": Tracker tier
+//   - "num_peers": Number of peers this torrent is currently connected to
+//   - "num_seeds": Number of peers that have the whole file
+//   - "num_leeches": Number of peers that are still downloading
+//   - "num_downloaded": Tracker downloaded count
 //   - "msg": Tracker message (last)
 void TorrentsController::trackersAction()
 {
@@ -323,9 +331,14 @@ void TorrentsController::trackersAction()
         case BitTorrent::TrackerEntry::NotWorking:
             status = tr("Not working"); break;
         }
+        trackerDict[KEY_TRACKER_TIER] = tracker.tier();
         trackerDict[KEY_TRACKER_STATUS] = status;
-        trackerDict[KEY_TRACKER_PEERS] = data.numPeers;
+        trackerDict[KEY_TRACKER_PEERS_COUNT] = data.numPeers;
         trackerDict[KEY_TRACKER_MSG] = data.lastMessage.trimmed();
+
+        trackerDict[KEY_TRACKER_SEEDS_COUNT] =  tracker.nativeEntry().scrape_complete;
+        trackerDict[KEY_TRACKER_LEECHES_COUNT] =  tracker.nativeEntry().scrape_incomplete;
+        trackerDict[KEY_TRACKER_DOWNLOADED_COUNT] =  tracker.nativeEntry().scrape_downloaded;
 
         trackerList.append(trackerDict);
     }

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -386,22 +386,11 @@ void TorrentsController::trackersAction()
     QHash<QString, BitTorrent::TrackerInfo> trackersData = torrent->trackerInfos();
     for (const BitTorrent::TrackerEntry &tracker : asConst(torrent->trackers())) {
         const BitTorrent::TrackerInfo data = trackersData.value(tracker.url());
-        QString status;
-        switch (tracker.status()) {
-        case BitTorrent::TrackerEntry::NotContacted:
-            status = tr("Not contacted yet"); break;
-        case BitTorrent::TrackerEntry::Updating:
-            status = tr("Updating..."); break;
-        case BitTorrent::TrackerEntry::Working:
-            status = tr("Working"); break;
-        case BitTorrent::TrackerEntry::NotWorking:
-            status = tr("Not working"); break;
-        }
 
         trackerList << QVariantMap {
             {KEY_TRACKER_URL, tracker.url()},
             {KEY_TRACKER_TIER, tracker.tier()},
-            {KEY_TRACKER_STATUS, status},
+            {KEY_TRACKER_STATUS, static_cast<int>(tracker.status())},
             {KEY_TRACKER_PEERS_COUNT, data.numPeers},
             {KEY_TRACKER_MSG, data.lastMessage.trimmed()},
             {KEY_TRACKER_SEEDS_COUNT, tracker.nativeEntry().scrape_complete},

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -385,8 +385,6 @@ void TorrentsController::trackersAction()
 
     QHash<QString, BitTorrent::TrackerInfo> trackersData = torrent->trackerInfos();
     for (const BitTorrent::TrackerEntry &tracker : asConst(torrent->trackers())) {
-        QVariantMap trackerDict;
-        trackerDict[KEY_TRACKER_URL] = tracker.url();
         const BitTorrent::TrackerInfo data = trackersData.value(tracker.url());
         QString status;
         switch (tracker.status()) {
@@ -399,16 +397,17 @@ void TorrentsController::trackersAction()
         case BitTorrent::TrackerEntry::NotWorking:
             status = tr("Not working"); break;
         }
-        trackerDict[KEY_TRACKER_TIER] = tracker.tier();
-        trackerDict[KEY_TRACKER_STATUS] = status;
-        trackerDict[KEY_TRACKER_PEERS_COUNT] = data.numPeers;
-        trackerDict[KEY_TRACKER_MSG] = data.lastMessage.trimmed();
 
-        trackerDict[KEY_TRACKER_SEEDS_COUNT] =  tracker.nativeEntry().scrape_complete;
-        trackerDict[KEY_TRACKER_LEECHES_COUNT] =  tracker.nativeEntry().scrape_incomplete;
-        trackerDict[KEY_TRACKER_DOWNLOADED_COUNT] =  tracker.nativeEntry().scrape_downloaded;
-
-        trackerList.append(trackerDict);
+        trackerList << QVariantMap {
+            {KEY_TRACKER_URL, tracker.url()},
+            {KEY_TRACKER_TIER, tracker.tier()},
+            {KEY_TRACKER_STATUS, status},
+            {KEY_TRACKER_PEERS_COUNT, data.numPeers},
+            {KEY_TRACKER_MSG, data.lastMessage.trimmed()},
+            {KEY_TRACKER_SEEDS_COUNT, tracker.nativeEntry().scrape_complete},
+            {KEY_TRACKER_LEECHES_COUNT, tracker.nativeEntry().scrape_incomplete},
+            {KEY_TRACKER_DOWNLOADED_COUNT, tracker.nativeEntry().scrape_downloaded}
+        };
     }
 
     setResult(QJsonArray::fromVariantList(trackerList));

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -114,12 +114,12 @@ namespace
     void applyToTorrents(const QStringList &hashes, const std::function<void (BitTorrent::TorrentHandle *torrent)> &func)
     {
         if ((hashes.size() == 1) && (hashes[0] == QLatin1String("all"))) {
-            for (BitTorrent::TorrentHandle *torrent : asConst(BitTorrent::Session::instance()->torrents()))
+            for (BitTorrent::TorrentHandle *const torrent : asConst(BitTorrent::Session::instance()->torrents()))
                 func(torrent);
         }
         else {
             for (const QString &hash : hashes) {
-                BitTorrent::TorrentHandle *torrent = BitTorrent::Session::instance()->findTorrent(hash);
+                BitTorrent::TorrentHandle *const torrent = BitTorrent::Session::instance()->findTorrent(hash);
                 if (torrent)
                     func(torrent);
             }
@@ -548,7 +548,7 @@ void TorrentsController::pauseAction()
     checkParams({"hashes"});
 
     const QStringList hashes = params()["hashes"].split('|');
-    applyToTorrents(hashes, [](BitTorrent::TorrentHandle *torrent) { torrent->pause(); });
+    applyToTorrents(hashes, [](BitTorrent::TorrentHandle *const torrent) { torrent->pause(); });
 }
 
 void TorrentsController::resumeAction()
@@ -556,7 +556,7 @@ void TorrentsController::resumeAction()
     checkParams({"hashes"});
 
     const QStringList hashes = params()["hashes"].split('|');
-    applyToTorrents(hashes, [](BitTorrent::TorrentHandle *torrent) { torrent->resume(); });
+    applyToTorrents(hashes, [](BitTorrent::TorrentHandle *const torrent) { torrent->resume(); });
 }
 
 void TorrentsController::filePrioAction()
@@ -606,7 +606,7 @@ void TorrentsController::uploadLimitAction()
     QVariantMap map;
     for (const QString &hash : hashes) {
         int limit = -1;
-        BitTorrent::TorrentHandle *const torrent = BitTorrent::Session::instance()->findTorrent(hash);
+        const BitTorrent::TorrentHandle *const torrent = BitTorrent::Session::instance()->findTorrent(hash);
         if (torrent)
             limit = torrent->uploadLimit();
         map[hash] = limit;
@@ -623,7 +623,7 @@ void TorrentsController::downloadLimitAction()
     QVariantMap map;
     for (const QString &hash : hashes) {
         int limit = -1;
-        BitTorrent::TorrentHandle *const torrent = BitTorrent::Session::instance()->findTorrent(hash);
+        const BitTorrent::TorrentHandle *const torrent = BitTorrent::Session::instance()->findTorrent(hash);
         if (torrent)
             limit = torrent->downloadLimit();
         map[hash] = limit;
@@ -641,7 +641,7 @@ void TorrentsController::setUploadLimitAction()
         limit = -1;
 
     const QStringList hashes {params()["hashes"].split('|')};
-    applyToTorrents(hashes, [limit](BitTorrent::TorrentHandle *torrent) { torrent->setUploadLimit(limit); });
+    applyToTorrents(hashes, [limit](BitTorrent::TorrentHandle *const torrent) { torrent->setUploadLimit(limit); });
 }
 
 void TorrentsController::setDownloadLimitAction()
@@ -653,7 +653,7 @@ void TorrentsController::setDownloadLimitAction()
         limit = -1;
 
     const QStringList hashes {params()["hashes"].split('|')};
-    applyToTorrents(hashes, [limit](BitTorrent::TorrentHandle *torrent) { torrent->setDownloadLimit(limit); });
+    applyToTorrents(hashes, [limit](BitTorrent::TorrentHandle *const torrent) { torrent->setDownloadLimit(limit); });
 }
 
 void TorrentsController::setShareLimitsAction()
@@ -664,7 +664,7 @@ void TorrentsController::setShareLimitsAction()
     const qlonglong seedingTimeLimit = params()["seedingTimeLimit"].toLongLong();
     const QStringList hashes = params()["hashes"].split('|');
 
-    applyToTorrents(hashes, [ratioLimit, seedingTimeLimit](BitTorrent::TorrentHandle *torrent)
+    applyToTorrents(hashes, [ratioLimit, seedingTimeLimit](BitTorrent::TorrentHandle *const torrent)
     {
         torrent->setRatioLimit(ratioLimit);
         torrent->setSeedingTimeLimit(seedingTimeLimit);
@@ -676,7 +676,7 @@ void TorrentsController::toggleSequentialDownloadAction()
     checkParams({"hashes"});
 
     const QStringList hashes {params()["hashes"].split('|')};
-    applyToTorrents(hashes, [](BitTorrent::TorrentHandle *torrent) { torrent->toggleSequentialDownload(); });
+    applyToTorrents(hashes, [](BitTorrent::TorrentHandle *const torrent) { torrent->toggleSequentialDownload(); });
 }
 
 void TorrentsController::toggleFirstLastPiecePrioAction()
@@ -684,7 +684,7 @@ void TorrentsController::toggleFirstLastPiecePrioAction()
     checkParams({"hashes"});
 
     const QStringList hashes {params()["hashes"].split('|')};
-    applyToTorrents(hashes, [](BitTorrent::TorrentHandle *torrent) { torrent->toggleFirstLastPiecePriority(); });
+    applyToTorrents(hashes, [](BitTorrent::TorrentHandle *const torrent) { torrent->toggleFirstLastPiecePriority(); });
 }
 
 void TorrentsController::setSuperSeedingAction()
@@ -693,7 +693,7 @@ void TorrentsController::setSuperSeedingAction()
 
     const bool value {parseBool(params()["value"], false)};
     const QStringList hashes {params()["hashes"].split('|')};
-    applyToTorrents(hashes, [value](BitTorrent::TorrentHandle *torrent) { torrent->setSuperSeeding(value); });
+    applyToTorrents(hashes, [value](BitTorrent::TorrentHandle *const torrent) { torrent->setSuperSeeding(value); });
 }
 
 void TorrentsController::setForceStartAction()
@@ -702,7 +702,7 @@ void TorrentsController::setForceStartAction()
 
     const bool value {parseBool(params()["value"], false)};
     const QStringList hashes {params()["hashes"].split('|')};
-    applyToTorrents(hashes, [value](BitTorrent::TorrentHandle *torrent) { torrent->resume(value); });
+    applyToTorrents(hashes, [value](BitTorrent::TorrentHandle *const torrent) { torrent->resume(value); });
 }
 
 void TorrentsController::deleteAction()
@@ -711,7 +711,7 @@ void TorrentsController::deleteAction()
 
     const QStringList hashes {params()["hashes"].split('|')};
     const bool deleteFiles {parseBool(params()["deleteFiles"], false)};
-    applyToTorrents(hashes, [deleteFiles](BitTorrent::TorrentHandle *torrent)
+    applyToTorrents(hashes, [deleteFiles](BitTorrent::TorrentHandle *const torrent)
     {
         BitTorrent::Session::instance()->deleteTorrent(torrent->hash(), deleteFiles);
     });
@@ -779,7 +779,7 @@ void TorrentsController::setLocationAction()
     if (!QFileInfo(newLocation).isWritable())
         throw APIError(APIErrorType::AccessDenied, tr("Cannot write to directory"));
 
-    applyToTorrents(hashes, [newLocation](BitTorrent::TorrentHandle *torrent)
+    applyToTorrents(hashes, [newLocation](BitTorrent::TorrentHandle *const torrent)
     {
         LogMsg(tr("WebUI Set location: moving \"%1\", from \"%2\" to \"%3\"")
             .arg(torrent->name(), Utils::Fs::toNativePath(torrent->savePath()), Utils::Fs::toNativePath(newLocation)));
@@ -812,7 +812,7 @@ void TorrentsController::setAutoManagementAction()
     const QStringList hashes {params()["hashes"].split('|')};
     const bool isEnabled {parseBool(params()["enable"], false)};
 
-    applyToTorrents(hashes, [isEnabled](BitTorrent::TorrentHandle *torrent)
+    applyToTorrents(hashes, [isEnabled](BitTorrent::TorrentHandle *const torrent)
     {
         torrent->setAutoTMMEnabled(isEnabled);
     });
@@ -823,7 +823,7 @@ void TorrentsController::recheckAction()
     checkParams({"hashes"});
 
     const QStringList hashes {params()["hashes"].split('|')};
-    applyToTorrents(hashes, [](BitTorrent::TorrentHandle *torrent) { torrent->forceRecheck(); });
+    applyToTorrents(hashes, [](BitTorrent::TorrentHandle *const torrent) { torrent->forceRecheck(); });
 }
 
 void TorrentsController::reannounceAction()
@@ -831,7 +831,7 @@ void TorrentsController::reannounceAction()
     checkParams({"hashes"});
 
     const QStringList hashes {params()["hashes"].split('|')};
-    applyToTorrents(hashes, [](BitTorrent::TorrentHandle *torrent) { torrent->forceReannounce(); });
+    applyToTorrents(hashes, [](BitTorrent::TorrentHandle *const torrent) { torrent->forceReannounce(); });
 }
 
 void TorrentsController::setCategoryAction()
@@ -841,7 +841,7 @@ void TorrentsController::setCategoryAction()
     const QStringList hashes {params()["hashes"].split('|')};
     const QString category {params()["category"].trimmed()};
 
-    applyToTorrents(hashes, [category](BitTorrent::TorrentHandle *torrent)
+    applyToTorrents(hashes, [category](BitTorrent::TorrentHandle *const torrent)
     {
         if (!torrent->setCategory(category))
             throw APIError(APIErrorType::Conflict, tr("Incorrect category name"));

--- a/src/webui/api/torrentscontroller.h
+++ b/src/webui/api/torrentscontroller.h
@@ -59,6 +59,8 @@ private slots:
     void addAction();
     void deleteAction();
     void addTrackersAction();
+    void editTrackerAction();
+    void removeTrackersAction();
     void filePrioAction();
     void uploadLimitAction();
     void downloadLimitAction();

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -43,9 +43,9 @@
 #include "base/utils/net.h"
 #include "base/utils/version.h"
 
-constexpr Utils::Version<int, 3, 2> API_VERSION {2, 1, 1};
-constexpr int COMPAT_API_VERSION = 22;
-constexpr int COMPAT_API_VERSION_MIN = 21;
+constexpr Utils::Version<int, 3, 2> API_VERSION {2, 2, 0};
+constexpr int COMPAT_API_VERSION = 23;
+constexpr int COMPAT_API_VERSION_MIN = 23;
 
 class APIController;
 class WebApplication;

--- a/src/webui/www/private/css/style.css
+++ b/src/webui/www/private/css/style.css
@@ -450,12 +450,6 @@ td.generalLabel {
     line-height: 25px;
 }
 
-#addTrackersPlus {
-    width: 16px;
-    cursor: pointer;
-    margin-bottom: -3px;
-}
-
 .unselectable {
     -webkit-touch-callout: none;
     -webkit-user-select: none;

--- a/src/webui/www/private/edittracker.html
+++ b/src/webui/www/private/edittracker.html
@@ -3,33 +3,43 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(Trackers addition dialog)QBT_TR[CONTEXT=TrackersAdditionDialog]</title>
+    <title>QBT_TR(Tracker editing)QBT_TR[CONTEXT=TrackerListWidget]</title>
     <link rel="stylesheet" href="css/style.css" type="text/css" />
     <script src="scripts/lib/mootools-1.2-core-yc.js"></script>
     <script src="scripts/lib/mootools-1.2-more.js"></script>
     <script>
+        'use strict';
+
         window.addEvent('domready', function() {
             var setLocationKeyboardEvents = new Keyboard({
                 defaultEventType: 'keydown',
                 events: {
                     'enter': function(event) {
-                        $('addTrackersButton').click();
+                        $('editTrackerButton').click();
                         event.preventDefault();
                     }
                 }
             });
             setLocationKeyboardEvents.activate();
 
-            $('trackersUrls').focus();
-            $('addTrackersButton').addEvent('click', function(e) {
+            var currentUrl = new URI().getData('url');
+            if (!currentUrl)
+                return false;
+
+            var decodedUrl = decodeURIComponent(currentUrl);
+            $('trackerUrl').value = decodedUrl;
+            $('trackerUrl').focus();
+
+            $('editTrackerButton').addEvent('click', function(e) {
                 new Event(e).stop();
                 var hash = new URI().getData('hash');
                 new Request({
-                    url: 'api/v2/torrents/addTrackers',
+                    url: 'api/v2/torrents/editTracker',
                     method: 'post',
                     data: {
                         hash: hash,
-                        urls: $('trackersUrls').value
+                        origUrl: decodedUrl,
+                        newUrl: $('trackerUrl').value
                     },
                     onComplete: function() {
                         window.parent.closeWindows();
@@ -43,10 +53,12 @@
 <body>
     <div style="text-align: center;">
         <br/>
-        <h2 class="vcenter">QBT_TR(List of trackers to add (one per line):)QBT_TR[CONTEXT=TrackersAdditionDialog]</h2>
-        <textarea name="list" id="trackersUrls" rows="10" cols="1"></textarea>
+        <h2 class="vcenter">QBT_TR(Tracker URL:)QBT_TR[CONTEXT=TrackerListWidget]</h2>
+        <div style="text-align: center; padding-top: 10px;">
+            <input id="trackerUrl" style="width: 90%;" />
+        </div>
         <br/>
-        <input type="button" value="QBT_TR(Add)QBT_TR[CONTEXT=HttpServer]" id="addTrackersButton" />
+        <input type="button" value="QBT_TR(Edit)QBT_TR[CONTEXT=HttpServer]" id="editTrackerButton" />
     </div>
 </body>
 

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -158,6 +158,12 @@
         <li><a href="#PauseTorrentsByCategory"><img src="images/qbt-theme/media-playback-pause.svg" alt="QBT_TR(Pause torrents)QBT_TR[CONTEXT=CategoryFilterWidget]"/> QBT_TR(Pause torrents)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
         <li><a href="#DeleteTorrentsByCategory"><img src="images/qbt-theme/edit-delete.svg" alt="QBT_TR(Delete torrents)QBT_TR[CONTEXT=CategoryFilterWidget]"/> QBT_TR(Delete torrents)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
     </ul>
+    <ul id="torrentTrackersMenu" class="contextMenu">
+        <li><a href="#AddTracker"><img src="images/qbt-theme/list-add.svg" alt="QBT_TR(Add a new tracker...)QBT_TR[CONTEXT=TrackerListWidget]"/> QBT_TR(Add a new tracker...)QBT_TR[CONTEXT=TrackerListWidget]</a></li>
+        <li class="separator"><a href="#EditTracker"><img src="images/qbt-theme/document-edit.svg" alt="QBT_TR(Edit tracker URL...)QBT_TR[CONTEXT=TrackerListWidget]"/> QBT_TR(Edit tracker URL...)QBT_TR[CONTEXT=TrackerListWidget]</a></li>
+        <li><a href="#RemoveTracker"><img src="images/qbt-theme/list-remove.svg" alt="QBT_TR(Remove tracker)QBT_TR[CONTEXT=TrackerListWidget]"/> QBT_TR(Remove tracker)QBT_TR[CONTEXT=TrackerListWidget]</a></li>
+        <li><a href="#CopyTrackerUrl" id="CopyTrackerUrl"><img src="images/qbt-theme/edit-copy.svg" alt="QBT_TR(Copy tracker URL)QBT_TR[CONTEXT=TrackerListWidget]"/> QBT_TR(Copy tracker URL)QBT_TR[CONTEXT=TrackerListWidget]</a></li>
+    </ul>
     <div id="desktopFooterWrapper">
         <div id="desktopFooter">
             <span id="error_div"></span>

--- a/src/webui/www/private/properties_content.html
+++ b/src/webui/www/private/properties_content.html
@@ -84,10 +84,14 @@
         <table class="dynamicTable" style="width: 100%">
             <thead>
                 <tr>
+                    <th style="width: 5%;">QBT_TR(#)QBT_TR[CONTEXT=TrackerListWidget]</th>
                     <th style="width: 30%;">QBT_TR(URL)QBT_TR[CONTEXT=TrackerListWidget] <img src="images/qbt-theme/list-add.svg" id="addTrackersPlus" alt="Add Trackers" /></th>
                     <th style="width: 10%;">QBT_TR(Status)QBT_TR[CONTEXT=TrackerListWidget]</th>
-                    <th style="width: 10%;">QBT_TR(Peers)QBT_TR[CONTEXT=TrackerListWidget]</th>
-                    <th style="width: 50%;">QBT_TR(Message)QBT_TR[CONTEXT=TrackerListWidget]</th>
+                    <th style="width: 5%;">QBT_TR(Peers)QBT_TR[CONTEXT=TrackerListWidget]</th>
+                    <th style="width: 5%;">QBT_TR(Seeds)QBT_TR[CONTEXT=TrackerListWidget]</th>
+                    <th style="width: 5%;">QBT_TR(Leeches)QBT_TR[CONTEXT=TrackerListWidget]</th>
+                    <th style="width: 5%;">QBT_TR(Downloaded)QBT_TR[CONTEXT=TrackerListWidget]</th>
+                    <th style="width: 35%;">QBT_TR(Message)QBT_TR[CONTEXT=TrackerListWidget]</th>
                 </tr>
             </thead>
             <tbody id="trackersTable"></tbody>

--- a/src/webui/www/private/properties_content.html
+++ b/src/webui/www/private/properties_content.html
@@ -85,7 +85,7 @@
             <thead>
                 <tr>
                     <th style="width: 5%;">QBT_TR(#)QBT_TR[CONTEXT=TrackerListWidget]</th>
-                    <th style="width: 30%;">QBT_TR(URL)QBT_TR[CONTEXT=TrackerListWidget] <img src="images/qbt-theme/list-add.svg" id="addTrackersPlus" alt="Add Trackers" /></th>
+                    <th style="width: 30%;">QBT_TR(URL)QBT_TR[CONTEXT=TrackerListWidget]</th>
                     <th style="width: 10%;">QBT_TR(Status)QBT_TR[CONTEXT=TrackerListWidget]</th>
                     <th style="width: 5%;">QBT_TR(Peers)QBT_TR[CONTEXT=TrackerListWidget]</th>
                     <th style="width: 5%;">QBT_TR(Seeds)QBT_TR[CONTEXT=TrackerListWidget]</th>

--- a/src/webui/www/private/scripts/prop-trackers.js
+++ b/src/webui/www/private/scripts/prop-trackers.js
@@ -90,10 +90,29 @@ var loadTrackersData = function() {
             if (trackers) {
                 // Update Trackers data
                 trackers.each(function(tracker) {
+                    var status;
+                    switch (tracker.status) {
+                        case 0:
+                            status = "QBT_TR(Disabled)QBT_TR[CONTEXT=TrackerListWidget]";
+                            break;
+                        case 1:
+                            status = "QBT_TR(Not contacted yet)QBT_TR[CONTEXT=TrackerListWidget]";
+                            break;
+                        case 2:
+                            status = "QBT_TR(Working)QBT_TR[CONTEXT=TrackerListWidget]";
+                            break;
+                        case 3:
+                            status = "QBT_TR(Updating...)QBT_TR[CONTEXT=TrackerListWidget]";
+                            break;
+                        case 4:
+                            status = "QBT_TR(Not working)QBT_TR[CONTEXT=TrackerListWidget]";
+                            break;
+                    }
+
                     var row = [
                         tracker.tier,
                         escapeHtml(tracker.url),
-                        tracker.status,
+                        status,
                         tracker.num_peers,
                         (tracker.num_seeds >= 0) ? tracker.num_seeds : "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]",
                         (tracker.num_leeches >= 0) ? tracker.num_leeches : "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]",

--- a/src/webui/www/private/scripts/prop-trackers.js
+++ b/src/webui/www/private/scripts/prop-trackers.js
@@ -32,7 +32,7 @@ var trackersDynTable = new Class({
     },
 
     insertRow: function(row) {
-        var url = row[0];
+        var url = row[1];
         if (this.rows.has(url)) {
             var tableRow = this.rows.get(url);
             this.updateRow(tableRow, row);
@@ -85,12 +85,17 @@ var loadTrackersData = function() {
             if (trackers) {
                 // Update Trackers data
                 trackers.each(function(tracker) {
-                    var row = [];
-                    row.length = 4;
-                    row[0] = escapeHtml(tracker.url);
-                    row[1] = tracker.status;
-                    row[2] = tracker.num_peers;
-                    row[3] = escapeHtml(tracker.msg);
+                    var row = [
+                        tracker.tier,
+                        escapeHtml(tracker.url),
+                        tracker.status,
+                        tracker.num_peers,
+                        (tracker.num_seeds >= 0) ? tracker.num_seeds : "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]",
+                        (tracker.num_leeches >= 0) ? tracker.num_leeches : "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]",
+                        (tracker.num_downloaded >= 0) ? tracker.num_downloaded : "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]",
+                        escapeHtml(tracker.msg)
+                    ];
+
                     tTable.insertRow(row);
                 });
             }

--- a/src/webui/www/private/scripts/prop-trackers.js
+++ b/src/webui/www/private/scripts/prop-trackers.js
@@ -2,9 +2,10 @@ var trackersDynTable = new Class({
 
     initialize: function() {},
 
-    setup: function(table) {
+    setup: function(table, contextMenu) {
         this.table = $(table);
         this.rows = new Hash();
+        this.contextMenu = contextMenu;
     },
 
     removeRow: function(url) {
@@ -46,11 +47,13 @@ var trackersDynTable = new Class({
             td.set('html', row[i]);
             td.injectInside(tr);
         }
+        this.contextMenu.addTarget(tr);
         tr.injectInside(this.table);
-    },
+    }
 });
 
 var current_hash = "";
+var selectedTracker = "";
 
 var loadTrackersDataTimer;
 var loadTrackersData = function() {
@@ -61,13 +64,13 @@ var loadTrackersData = function() {
     }
     var new_hash = torrentsTable.getCurrentTorrentHash();
     if (new_hash === "") {
-        tTable.removeAllRows();
+        torrentTrackersTable.removeAllRows();
         clearTimeout(loadTrackersDataTimer);
         loadTrackersDataTimer = loadTrackersData.delay(10000);
         return;
     }
     if (new_hash != current_hash) {
-        tTable.removeAllRows();
+        torrentTrackersTable.removeAllRows();
         current_hash = new_hash;
     }
     var url = new URI('api/v2/torrents/trackers?hash=' + current_hash);
@@ -82,6 +85,8 @@ var loadTrackersData = function() {
         },
         onSuccess: function(trackers) {
             $('error_div').set('html', '');
+            torrentTrackersTable.removeAllRows();
+
             if (trackers) {
                 // Update Trackers data
                 trackers.each(function(tracker) {
@@ -96,11 +101,8 @@ var loadTrackersData = function() {
                         escapeHtml(tracker.msg)
                     ];
 
-                    tTable.insertRow(row);
+                    torrentTrackersTable.insertRow(row);
                 });
-            }
-            else {
-                tTable.removeAllRows();
             }
             clearTimeout(loadTrackersDataTimer);
             loadTrackersDataTimer = loadTrackersData.delay(10000);
@@ -113,11 +115,42 @@ var updateTrackersData = function() {
     loadTrackersData();
 };
 
-tTable = new trackersDynTable();
-tTable.setup($('trackersTable'));
+var torrentTrackersContextMenu = new ContextMenu({
+    targets: '.torrentTrackersMenuTarget',
+    menu: 'torrentTrackersMenu',
+    actions: {
+        AddTracker: function(element, ref) {
+            addTrackerFN();
+        },
+        EditTracker: function(element, ref) {
+            editTrackerFN(element);
+        },
+        RemoveTracker: function(element, ref) {
+            removeTrackerFN(element);
+        }
+    },
+    offsets: {
+        x: -15,
+        y: 2
+    },
+    onShow: function() {
+        var element = this.options.element;
+        selectedTracker = element;
+        if (element.childNodes[1].innerText.indexOf("** [") === 0) {
+            this.hideItem('EditTracker');
+            this.hideItem('RemoveTracker');
+            this.hideItem('CopyTrackerUrl');
+        }
+        else {
+            this.showItem('EditTracker');
+            this.showItem('RemoveTracker');
+            this.showItem('CopyTrackerUrl');
+        }
+        this.options.element.firstChild.click();
+    }
+});
 
-// Add trackers code
-$('addTrackersPlus').addEvent('click', function addTrackerDlg() {
+var addTrackerFN = function() {
     if (current_hash.length === 0) return;
     new MochaUI.Window({
         id: 'trackersPage',
@@ -131,6 +164,62 @@ $('addTrackersPlus').addEvent('click', function addTrackerDlg() {
         paddingVertical: 0,
         paddingHorizontal: 0,
         width: 500,
-        height: 250
+        height: 250,
+        onCloseComplete: function() {
+            updateTrackersData();
+        }
     });
+};
+
+var editTrackerFN = function(element) {
+    if (current_hash.length === 0) return;
+
+    var trackerUrl = encodeURIComponent(element.childNodes[1].innerText);
+    new MochaUI.Window({
+        id: 'trackersPage',
+        title: "QBT_TR(Tracker editing)QBT_TR[CONTEXT=TrackerListWidget]",
+        loadMethod: 'iframe',
+        contentURL: 'edittracker.html?hash=' + current_hash + '&url=' + trackerUrl,
+        scrollbars: true,
+        resizable: false,
+        maximizable: false,
+        closable: true,
+        paddingVertical: 0,
+        paddingHorizontal: 0,
+        width: 500,
+        height: 150,
+        onCloseComplete: function() {
+            updateTrackersData();
+        }
+    });
+};
+
+var removeTrackerFN = function(element) {
+    if (current_hash.length === 0) return;
+
+    var trackerUrl = element.childNodes[1].innerText;
+    new Request({
+        url: 'api/v2/torrents/removeTrackers',
+        method: 'post',
+        data: {
+            hash: current_hash,
+            urls: trackerUrl
+        },
+        onSuccess: function() {
+            updateTrackersData();
+        }
+    }).send();
+};
+
+torrentTrackersTable = new trackersDynTable();
+torrentTrackersTable.setup($('trackersTable'), torrentTrackersContextMenu);
+
+new ClipboardJS('#CopyTrackerUrl', {
+    text: function(trigger) {
+        if (selectedTracker) {
+            var url = selectedTracker.childNodes[1].innerText;
+            selectedTracker = "";
+            return url;
+        }
+    }
 });

--- a/src/webui/www/webui.qrc
+++ b/src/webui/www/webui.qrc
@@ -11,6 +11,7 @@
         <file>private/css/Window.css</file>
         <file>private/download.html</file>
         <file>private/downloadlimit.html</file>
+        <file>private/edittracker.html</file>
         <file>private/filters.html</file>
         <file>private/index.html</file>
         <file>private/installsearchplugin.html</file>


### PR DESCRIPTION
Note: This does not break anything in the existing `/torrents/trackers` API; it only adds additional info


Before:
<img width="785" alt="screen shot 2018-08-20 at 12 15 27 am" src="https://user-images.githubusercontent.com/8296030/44322007-3a0f0280-a419-11e8-85f6-60f4eb881fc3.png">

After:
<img width="826" alt="screen shot 2018-08-20 at 1 31 46 am" src="https://user-images.githubusercontent.com/8296030/44322013-3c715c80-a419-11e8-9880-4a775d2b91b9.png">

GUI, for comparison:
<img width="865" alt="screen shot 2018-08-20 at 12 33 03 am" src="https://user-images.githubusercontent.com/8296030/44322017-41361080-a419-11e8-85b3-ac3284bc3834.png">


**Context menu:**

webui: 
<img width="493" alt="screen shot 2018-09-02 at 6 35 26 pm" src="https://user-images.githubusercontent.com/8296030/44961425-1353d000-aedf-11e8-8168-46fd2c004a01.png">


gui: 
<img width="583" alt="screen shot 2018-09-02 at 6 44 04 pm" src="https://user-images.githubusercontent.com/8296030/44961520-477bc080-aee0-11e8-8797-48f0b755a5d2.png">


**Category editing**

webui:
<img width="514" alt="screen shot 2018-09-02 at 6 30 49 pm" src="https://user-images.githubusercontent.com/8296030/44961384-65e0bc80-aede-11e8-8ff2-43be744f4c48.png">

gui:
<img width="380" alt="screen shot 2018-09-02 at 6 31 52 pm" src="https://user-images.githubusercontent.com/8296030/44961393-8c065c80-aede-11e8-9c9b-6d316143ecc0.png">

- [x] Update WebAPI documentation

Closes #7934, closes #6797, closes #3024