### PR TITLE
Minor fixes

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,54 +1,49 @@
-qBittorrent - A BitTorrent client in C++ / Qt4
+qBittorrent - A BitTorrent client in C++ / Qt
 ------------------------------------------
 
-1) Compile and install qBittorrent with Qt4 Graphical Interface
+1) Compile and install qBittorrent with Qt graphical interface
 
   $ ./configure
   $ make && make install
   $ qbittorrent
 
-  will install and execute qBittorrent hopefully without any problems.
+  will install and execute qBittorrent.
 
   Dependencies:
-    - Qt >= 4.6.0 (libqtgui, libqtcore, libqtnetwork, libqtxml, libqtdbus/optional)
+    - Qt >= 5.5.1
 
-    - pkg-config executable
+    - pkg-config
 
-    - libtorrent-rasterbar by Arvid Norberg (>= 1.0.6)
-        -> http://www.libtorrent.net
-        Be careful: another library (the one used by rTorrent) uses a similar name.
+    - libtorrent-rasterbar >= 1.0.6 (by Arvid Norberg)
+        * https://www.libtorrent.org/
+        * Be careful: another library (the one used by rTorrent) uses a similar name
 
-    - libboost >= 1.35.x (libboost-system)
+    - Boost >= 1.35
 
-    - python >= 2.3 (needed by search engine)
-        * Run time only dependency
+    - Python >= 2.7.9 / 3.3.0 (optional, runtime only)
+        * Required by the internal search engine
 
-    - geoip-database (optional)
-        * If qBittorrent cannot find this database, it will try to resolve countries using the Internet but it will be a lot slower.
-        * Run time only dependency
-
-2) Compile and install qBittorrent without Qt4 Graphical interface
+2) Compile and install qBittorrent without Qt graphical interface
 
   $ ./configure --disable-gui
   $ make && make install
-  $ qbittorrent
+  $ qbittorrent-nox
 
-  will install and execute qBittorrent hopefully without any problems.
+  will install and execute qBittorrent.
 
   Dependencies:
-    - Qt >= 4.4.0 (libqt-devel, libqtcore, libqtnetwork)
+    - Qt >= 5.5.1
 
-    - pkg-config executable
+    - pkg-config
 
-    - libtorrent-rasterbar by Arvid Norberg (>= v1.0.6)
-        -> http://www.libtorrent.net
-        Be careful: another library (the one used by rTorrent) uses a similar name.
+    - libtorrent-rasterbar >= 1.0.6 (by Arvid Norberg)
+        * https://www.libtorrent.org/
+        * Be careful: another library (the one used by rTorrent) uses a similar name
 
-    - libboost: libboost-filesystem, libboost-date-time, libboost-thread, libboost-serialization
-
+    - Boost >= 1.35
 
 DOCUMENTATION:
-Please note that there is a documentation with a "compiling howto" at http://wiki.qbittorrent.org.
+Please note that there is a "Compilation" section at http://wiki.qbittorrent.org.
 
 ------------------------------------------
-Christophe Dumez <chris@qbittorrent.org>
+sledgehammer999 <sledgehammer999@qbittorrent.org>

--- a/src/base/search/searchpluginmanager.cpp
+++ b/src/base/search/searchpluginmanager.cpp
@@ -73,7 +73,7 @@ namespace
 
             // python 2: remove "*.pyc" files
             const QStringList files = QDir(dir).entryList(QDir::Files);
-            for (const QString file : files) {
+            for (const QString &file : files) {
                 if (file.endsWith(".pyc"))
                     Utils::Fs::forceRemove(file);
             }

--- a/src/gui/cookiesdialog.ui
+++ b/src/gui/cookiesdialog.ui
@@ -45,11 +45,7 @@
         </spacer>
        </item>
        <item>
-        <widget class="QToolButton" name="buttonAdd">
-         <property name="text">
-          <string notr="true"/>
-         </property>
-        </widget>
+        <widget class="QToolButton" name="buttonAdd"/>
        </item>
        <item>
         <spacer name="verticalSpacer">
@@ -68,11 +64,7 @@
         </spacer>
        </item>
        <item>
-        <widget class="QToolButton" name="buttonDelete">
-         <property name="text">
-          <string notr="true"/>
-         </property>
-        </widget>
+        <widget class="QToolButton" name="buttonDelete"/>
        </item>
        <item>
         <spacer name="verticalSpacer_3">

--- a/src/gui/deletionconfirmationdialog.ui
+++ b/src/gui/deletionconfirmationdialog.ui
@@ -66,9 +66,6 @@
        <property name="toolTip">
         <string>Remember choice</string>
        </property>
-       <property name="text">
-        <string notr="true"/>
-       </property>
        <property name="iconSize">
         <size>
          <width>24</width>

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -2987,11 +2987,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_11">
                   <item row="0" column="0">
-                   <widget class="QLabel" name="lblSslCertStatus">
-                    <property name="text">
-                     <string notr="true"/>
-                    </property>
-                   </widget>
+                   <widget class="QLabel" name="lblSslCertStatus"/>
                   </item>
                   <item row="0" column="1">
                    <widget class="QLabel" name="lblWebUiCrt">
@@ -3028,11 +3024,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
                    </layout>
                   </item>
                   <item row="1" column="0">
-                   <widget class="QLabel" name="lblSslKeyStatus">
-                    <property name="text">
-                     <string notr="true"/>
-                    </property>
-                   </widget>
+                   <widget class="QLabel" name="lblSslKeyStatus"/>
                   </item>
                   <item row="1" column="1">
                    <widget class="QLabel" name="lblWebUiKey">


### PR DESCRIPTION
* Avoid copy-construct QString in for loop
* Reset button text to default 
  This is to avoid Qt auto-generating code like this:
    `buttonAdd->setText(QStringLiteral(""));`
  Which makes no sense and triggers clazy warning (Wclazy-empty-qstringliteral).
* Update INSTALL file 