### PR TITLE
Don't disable DHT when using force proxy

### DIFF
--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -1358,7 +1358,6 @@ void OptionsDialog::toggleComboRatioLimitAct()
 void OptionsDialog::enableForceProxy(bool enable)
 {
     m_ui->checkUPnP->setEnabled(!enable);
-    m_ui->checkDHT->setEnabled(!enable);
     m_ui->checkLSD->setEnabled(!enable);
 }
 

--- a/src/webui/www/private/preferences_content.html
+++ b/src/webui/www/private/preferences_content.html
@@ -660,7 +660,6 @@
     updateForceProxySettings = function() {
         var isForceProxyEnabled = (!$('force_proxy_checkbox').getProperty('disabled')) && ($('force_proxy_checkbox').getProperty('checked'));
         $('upnp_checkbox').setProperty('disabled', isForceProxyEnabled);
-        $('dht_checkbox').setProperty('disabled', isForceProxyEnabled);
         $('lsd_checkbox').setProperty('disabled', isForceProxyEnabled);
     };
 


### PR DESCRIPTION
This behavior was changed in libtorrent in https://github.com/arvidn/libtorrent/pull/3251.

Closes #9292