### PR TITLE
Recheck on completion only if not in uploading state

### DIFF
--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -1591,7 +1591,7 @@ void TorrentHandle::handleTorrentFinishedAlert(const libtorrent::torrent_finishe
         m_moveFinishedTriggers.append(boost::bind(&Session::handleTorrentFinished, m_session, this));
     }
     else {
-        if (recheckTorrentsOnCompletion)
+        if (recheckTorrentsOnCompletion && !isUploading())
             forceRecheck();
         m_session->handleTorrentFinished(this);
     }


### PR DESCRIPTION
Prevent rechecking on completion if the torrent is in an uploading state
to prevent an endless loop of rechecking.
This seems to happen if you start seeding a new file with no fastresume file.