### PR TITLE
Save option about tracker favicons under correct key

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -132,7 +132,7 @@ namespace
     const QString KEY_NOTIFICATIONS_TORRENTADDED = NOTIFICATIONS_SETTINGS_KEY("TorrentAdded");
 
     // Misc
-    const QString KEY_DOWNLOAD_TRACKER_FAVICON = NOTIFICATIONS_SETTINGS_KEY("DownloadTrackerFavicon");
+    const QString KEY_DOWNLOAD_TRACKER_FAVICON = QStringLiteral(SETTINGS_KEY("DownloadTrackerFavicon"));
 
     // just a shortcut
     inline SettingsStorage *settings()


### PR DESCRIPTION
I made the mistake in fd5d1583de810f6fec780552b29f4e244d943b27
@zeule reminded me yesterday(?)


Better key names are welcome. This PR makes it `GUI/DownloadTrackerFavicon`
I opted to not have upgrade code for this option from its previous key.