### PR TITLE
 Show "N/A" if there is no scrape response

### DIFF
--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -344,7 +344,7 @@ TorrentInfo::PieceRange TorrentInfo::filePieces(int fileIndex) const
                         static_cast<int>((firstOffset + fileSize - 1) / pieceLength()));
 }
 
-void TorrentInfo::renameFile(uint index, const QString &newPath)
+void TorrentInfo::renameFile(const int index, const QString &newPath)
 {
     if (!isValid()) return;
     nativeInfo()->rename_file(index, Utils::Fs::toNativePath(newPath).toStdString());

--- a/src/base/bittorrent/torrentinfo.h
+++ b/src/base/bittorrent/torrentinfo.h
@@ -102,7 +102,7 @@ namespace BitTorrent
         PieceRange filePieces(const QString &file) const;
         PieceRange filePieces(int fileIndex) const;
 
-        void renameFile(uint index, const QString &newPath);
+        void renameFile(int index, const QString &newPath);
 
         QString rootFolder() const;
         bool hasRootFolder() const;

--- a/src/base/net/downloadmanager.cpp
+++ b/src/base/net/downloadmanager.cpp
@@ -64,7 +64,7 @@ namespace
             setAllCookies(cookies);
         }
 
-        ~NetworkCookieJar()
+        ~NetworkCookieJar() override
         {
             QDateTime now = QDateTime::currentDateTime();
             QList<QNetworkCookie> cookies = allCookies();

--- a/src/base/net/private/geoipdatabase.cpp
+++ b/src/base/net/private/geoipdatabase.cpp
@@ -92,12 +92,12 @@ GeoIPDatabase *GeoIPDatabase::load(const QString &filename, QString &error)
     QFile file(filename);
     if (file.size() > MAX_FILE_SIZE) {
         error = tr("Unsupported database file size.");
-        return 0;
+        return nullptr;
     }
 
     if (!file.open(QFile::ReadOnly)) {
         error = file.errorString();
-        return 0;
+        return nullptr;
     }
 
     db = new GeoIPDatabase(file.size());
@@ -105,13 +105,13 @@ GeoIPDatabase *GeoIPDatabase::load(const QString &filename, QString &error)
     if (file.read(reinterpret_cast<char *>(db->m_data), db->m_size) != db->m_size) {
         error = file.errorString();
         delete db;
-        return 0;
+        return nullptr;
     }
 
 
     if (!db->parseMetadata(db->readMetadata(), error) || !db->loadDB(error)) {
         delete db;
-        return 0;
+        return nullptr;
     }
 
     return db;
@@ -122,7 +122,7 @@ GeoIPDatabase *GeoIPDatabase::load(const QByteArray &data, QString &error)
     GeoIPDatabase *db = nullptr;
     if (data.size() > MAX_FILE_SIZE) {
         error = tr("Unsupported database file size.");
-        return 0;
+        return nullptr;
     }
 
     db = new GeoIPDatabase(data.size());
@@ -131,7 +131,7 @@ GeoIPDatabase *GeoIPDatabase::load(const QByteArray &data, QString &error)
 
     if (!db->parseMetadata(db->readMetadata(), error) || !db->loadDB(error)) {
         delete db;
-        return 0;
+        return nullptr;
     }
 
     return db;

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -426,7 +426,7 @@ int AddNewTorrentDialog::indexOfSavePath(const QString &savePath)
 void AddNewTorrentDialog::updateDiskSpaceLabel()
 {
     // Determine torrent size
-    qulonglong torrentSize = 0;
+    qlonglong torrentSize = 0;
 
     if (m_hasMetadata) {
         if (m_contentModel) {

--- a/src/gui/categoryfiltermodel.cpp
+++ b/src/gui/categoryfiltermodel.cpp
@@ -228,7 +228,7 @@ QVariant CategoryFilterModel::data(const QModelIndex &index, int role) const
 
 Qt::ItemFlags CategoryFilterModel::flags(const QModelIndex &index) const
 {
-    if (!index.isValid()) return 0;
+    if (!index.isValid()) return Qt::NoItemFlags;
 
     return Qt::ItemIsEnabled | Qt::ItemIsSelectable;
 }

--- a/src/gui/cookiesmodel.cpp
+++ b/src/gui/cookiesmodel.cpp
@@ -172,7 +172,7 @@ bool CookiesModel::removeRows(int row, int count, const QModelIndex &parent)
 
 Qt::ItemFlags CookiesModel::flags(const QModelIndex &index) const
 {
-    if (!index.isValid()) return 0;
+    if (!index.isValid()) return Qt::NoItemFlags;
 
     return Qt::ItemIsEditable | QAbstractItemModel::flags(index);
 }

--- a/src/gui/guiiconprovider.h
+++ b/src/gui/guiiconprovider.h
@@ -53,7 +53,7 @@ private slots:
 
 private:
     explicit GuiIconProvider(QObject *parent = nullptr);
-    ~GuiIconProvider();
+    ~GuiIconProvider() override;
 
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
     bool m_useSystemTheme;

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1036,7 +1036,7 @@ void MainWindow::on_actionCloseWindow_triggered()
 QWidget *MainWindow::currentTabWidget() const
 {
     if (isMinimized() || !isVisible())
-        return 0;
+        return nullptr;
     if (m_tabs->currentIndex() == 0)
         return m_transferListWidget;
     return m_tabs->currentWidget();
@@ -1437,7 +1437,7 @@ void MainWindow::loadPreferences(bool configureSession)
 #else
     const bool newSystrayIntegration = pref->systrayIntegration();
     m_ui->actionLock->setVisible(newSystrayIntegration);
-    if (newSystrayIntegration != (m_systrayIcon != 0)) {
+    if (newSystrayIntegration != (m_systrayIcon != nullptr)) {
         if (newSystrayIntegration) {
             // create the trayicon
             if (!QSystemTrayIcon::isSystemTrayAvailable()) {

--- a/src/gui/properties/peerlistdelegate.h
+++ b/src/gui/properties/peerlistdelegate.h
@@ -63,7 +63,7 @@ public:
 
     PeerListDelegate(QObject *parent) : QItemDelegate(parent) {}
 
-    ~PeerListDelegate() {}
+    ~PeerListDelegate() override {}
 
     void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override
     {

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -441,7 +441,7 @@ void PeerListWidget::updatePeer(const QString &ip, BitTorrent::TorrentHandle *co
 
 void PeerListWidget::handleResolved(const QString &ip, const QString &hostname)
 {
-    QStandardItem *item = m_peerItems.value(ip, 0);
+    QStandardItem *item = m_peerItems.value(ip, nullptr);
     if (item) {
         qDebug("Resolved %s -> %s", qUtf8Printable(ip), qUtf8Printable(hostname));
         item->setData(hostname, Qt::DisplayRole);

--- a/src/gui/properties/peerlistwidget.h
+++ b/src/gui/properties/peerlistwidget.h
@@ -61,7 +61,7 @@ class PeerListWidget : public QTreeView
 
 public:
     explicit PeerListWidget(PropertiesWidget *parent);
-    ~PeerListWidget();
+    ~PeerListWidget() override;
 
     void loadPeers(BitTorrent::TorrentHandle *const torrent, bool forceHostnameResolution = false);
     QStandardItem *addPeer(const QString &ip, BitTorrent::TorrentHandle *const torrent, const BitTorrent::PeerInfo &peer);

--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -367,13 +367,13 @@ void TrackerListWidget::loadTrackers()
 
         item->setText(COL_RECEIVED, QString::number(data.numPeers));
 #if LIBTORRENT_VERSION_NUM >= 10000
-        item->setText(COL_SEEDS, QString::number(entry.nativeEntry().scrape_complete > 0 ? entry.nativeEntry().scrape_complete : 0));
-        item->setText(COL_PEERS, QString::number(entry.nativeEntry().scrape_incomplete > 0 ? entry.nativeEntry().scrape_incomplete : 0));
-        item->setText(COL_DOWNLOADED, QString::number(entry.nativeEntry().scrape_downloaded > 0 ? entry.nativeEntry().scrape_downloaded : 0));
+        item->setText(COL_SEEDS, (entry.nativeEntry().scrape_complete > -1) ? QString::number(entry.nativeEntry().scrape_complete) : tr("N/A"));
+        item->setText(COL_PEERS, (entry.nativeEntry().scrape_incomplete > -1) ? QString::number(entry.nativeEntry().scrape_incomplete) : tr("N/A"));
+        item->setText(COL_DOWNLOADED, (entry.nativeEntry().scrape_downloaded > -1) ? QString::number(entry.nativeEntry().scrape_downloaded) : tr("N/A"));
 #else
-        item->setText(COL_SEEDS, '0');
-        item->setText(COL_PEERS, '0');
-        item->setText(COL_DOWNLOADED, '0');
+        item->setText(COL_SEEDS, tr("N/A"));
+        item->setText(COL_PEERS, tr("N/A"));
+        item->setText(COL_DOWNLOADED, tr("N/A"));
 #endif
 
         item->setTextAlignment(COL_TIER, (Qt::AlignRight | Qt::AlignVCenter));

--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -73,7 +73,7 @@ TrackerListWidget::TrackerListWidget(PropertiesWidget *properties)
     // To also mitigate the above issue, we have to resize each column when
     // its size is 0, because explicitly 'showing' the column isn't enough
     // in the above scenario.
-    for (unsigned int i = 0; i < COL_COUNT; ++i)
+    for (int i = 0; i < COL_COUNT; ++i)
         if ((columnWidth(i) <= 0) && !isColumnHidden(i))
             resizeColumnToContents(i);
     // Context menu
@@ -150,9 +150,9 @@ QList<QTreeWidgetItem*> TrackerListWidget::getSelectedTrackerItems() const
 
 void TrackerListWidget::setRowColor(int row, QColor color)
 {
-    unsigned int nbColumns = columnCount();
+    const int nbColumns = columnCount();
     QTreeWidgetItem *item = topLevelItem(row);
-    for (unsigned int i = 0; i < nbColumns; ++i)
+    for (int i = 0; i < nbColumns; ++i)
         item->setData(i, Qt::ForegroundRole, color);
 }
 
@@ -333,7 +333,7 @@ void TrackerListWidget::loadTrackers()
     QStringList oldTrackerURLs = m_trackerItems.keys();
     foreach (const BitTorrent::TrackerEntry &entry, torrent->trackers()) {
         QString trackerURL = entry.url();
-        QTreeWidgetItem *item = m_trackerItems.value(trackerURL, 0);
+        QTreeWidgetItem *item = m_trackerItems.value(trackerURL, nullptr);
         if (!item) {
             item = new QTreeWidgetItem();
             item->setText(COL_URL, trackerURL);
@@ -604,7 +604,7 @@ QStringList TrackerListWidget::headerLabels()
 int TrackerListWidget::visibleColumnsCount() const
 {
     int visibleCols = 0;
-    for (unsigned int i = 0; i < COL_COUNT; ++i) {
+    for (int i = 0; i < COL_COUNT; ++i) {
         if (!isColumnHidden(i))
             ++visibleCols;
     }

--- a/src/gui/scanfoldersdelegate.cpp
+++ b/src/gui/scanfoldersdelegate.cpp
@@ -54,7 +54,7 @@ void ScanFoldersDelegate::setEditorData(QWidget *editor, const QModelIndex &inde
 
 QWidget *ScanFoldersDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &, const QModelIndex &index) const
 {
-    if (index.column() != ScanFoldersModel::DOWNLOAD) return 0;
+    if (index.column() != ScanFoldersModel::DOWNLOAD) return nullptr;
 
     QComboBox *editor = new QComboBox(parent);
 
@@ -96,7 +96,7 @@ void ScanFoldersDelegate::setModelData(QWidget *editor, QAbstractItemModel *mode
         model->setData(
                     index,
                     QFileDialog::getExistingDirectory(
-                        0, tr("Select save location"),
+                        nullptr, tr("Select save location"),
                         index.data(Qt::UserRole).toInt() == ScanFoldersModel::CUSTOM_LOCATION ?
                             index.data().toString() :
                             BitTorrent::Session::instance()->defaultSavePath()),

--- a/src/gui/search/pluginselectdialog.cpp
+++ b/src/gui/search/pluginselectdialog.cpp
@@ -258,7 +258,7 @@ QTreeWidgetItem *PluginSelectDialog::findItemWithID(QString id)
             return item;
     }
 
-    return 0;
+    return nullptr;
 }
 
 void PluginSelectDialog::loadSupportedSearchPlugins()
@@ -361,7 +361,7 @@ void PluginSelectDialog::askForPluginUrl()
 void PluginSelectDialog::askForLocalPlugin()
 {
     QStringList pathsList = QFileDialog::getOpenFileNames(
-                0, tr("Select search plugins"), QDir::homePath(),
+                nullptr, tr("Select search plugins"), QDir::homePath(),
                 tr("qBittorrent search plugin") + QLatin1String(" (*.py)")
                 );
     foreach (QString path, pathsList) {

--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -103,7 +103,7 @@ SearchJobWidget::SearchJobWidget(SearchHandler *searchHandler, QWidget *parent)
 
     // Ensure that at least one column is visible at all times
     bool atLeastOne = false;
-    for (unsigned int i = 0; i < SearchSortModel::DL_LINK; ++i) {
+    for (int i = 0; i < SearchSortModel::DL_LINK; ++i) {
         if (!m_ui->resultsBrowser->isColumnHidden(i)) {
             atLeastOne = true;
             break;
@@ -114,7 +114,7 @@ SearchJobWidget::SearchJobWidget(SearchHandler *searchHandler, QWidget *parent)
     // To also mitigate the above issue, we have to resize each column when
     // its size is 0, because explicitly 'showing' the column isn't enough
     // in the above scenario.
-    for (unsigned int i = 0; i < SearchSortModel::DL_LINK; ++i)
+    for (int i = 0; i < SearchSortModel::DL_LINK; ++i)
         if ((m_ui->resultsBrowser->columnWidth(i) <= 0) && !m_ui->resultsBrowser->isColumnHidden(i))
             m_ui->resultsBrowser->resizeColumnToContents(i);
 
@@ -412,7 +412,7 @@ void SearchJobWidget::displayToggleColumnsMenu(const QPoint&)
         actions.append(myAct);
     }
     int visibleCols = 0;
-    for (unsigned int i = 0; i < SearchSortModel::DL_LINK; ++i) {
+    for (int i = 0; i < SearchSortModel::DL_LINK; ++i) {
         if (!m_ui->resultsBrowser->isColumnHidden(i))
             ++visibleCols;
 

--- a/src/gui/tagfiltermodel.cpp
+++ b/src/gui/tagfiltermodel.cpp
@@ -135,7 +135,7 @@ QVariant TagFilterModel::data(const QModelIndex &index, int role) const
 Qt::ItemFlags TagFilterModel::flags(const QModelIndex &index) const
 {
     if (!index.isValid())
-        return 0;
+        return Qt::NoItemFlags;
     return Qt::ItemIsEnabled | Qt::ItemIsSelectable;
 }
 

--- a/src/gui/tagfiltermodel.h
+++ b/src/gui/tagfiltermodel.h
@@ -47,7 +47,7 @@ class TagFilterModel : public QAbstractListModel
 
 public:
     explicit TagFilterModel(QObject *parent = nullptr);
-    ~TagFilterModel();
+    ~TagFilterModel() override;
 
     static bool isSpecialItem(const QModelIndex &index);
 

--- a/src/gui/torrentcontentfiltermodel.h
+++ b/src/gui/torrentcontentfiltermodel.h
@@ -41,7 +41,7 @@ class TorrentContentFilterModel : public QSortFilterProxyModel
 
 public:
     TorrentContentFilterModel(QObject *parent = nullptr);
-    virtual ~TorrentContentFilterModel();
+    ~TorrentContentFilterModel() override;
 
     TorrentContentModel *model() const;
     TorrentContentModelItem::ItemType itemType(const QModelIndex &index) const;

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -377,7 +377,7 @@ QVariant TorrentContentModel::data(const QModelIndex& index, int role) const
 Qt::ItemFlags TorrentContentModel::flags(const QModelIndex &index) const
 {
     if (!index.isValid())
-        return 0;
+        return Qt::NoItemFlags;
 
     if (itemType(index) == TorrentContentModelItem::FolderType)
         return Qt::ItemIsEditable | Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsUserCheckable | Qt::ItemIsTristate;

--- a/src/gui/torrentcontentmodel.h
+++ b/src/gui/torrentcontentmodel.h
@@ -46,7 +46,7 @@ class TorrentContentModel : public QAbstractItemModel
 
 public:
     TorrentContentModel(QObject *parent = nullptr);
-    ~TorrentContentModel();
+    ~TorrentContentModel() override;
 
     void updateFilesProgress(const QVector<qreal> &fp);
     void updateFilesPriorities(const QVector<int> &fprio);

--- a/src/gui/torrentcontentmodelfolder.cpp
+++ b/src/gui/torrentcontentmodelfolder.cpp
@@ -80,7 +80,7 @@ void TorrentContentModelFolder::appendChild(TorrentContentModelItem *item)
 
 TorrentContentModelItem *TorrentContentModelFolder::child(int row) const
 {
-    return m_childItems.value(row, 0);
+    return m_childItems.value(row, nullptr);
 }
 
 TorrentContentModelFolder *TorrentContentModelFolder::childFolderWithName(const QString &name) const
@@ -88,7 +88,7 @@ TorrentContentModelFolder *TorrentContentModelFolder::childFolderWithName(const 
     foreach (TorrentContentModelItem *child, m_childItems)
         if ((child->itemType() == FolderType) && (child->name() == name))
             return static_cast<TorrentContentModelFolder *>(child);
-    return 0;
+    return nullptr;
 }
 
 int TorrentContentModelFolder::childCount() const

--- a/src/gui/torrentcontentmodelfolder.h
+++ b/src/gui/torrentcontentmodelfolder.h
@@ -40,7 +40,7 @@ public:
     // Invisible root item constructor
     TorrentContentModelFolder(const QList<QVariant> &data);
 
-    ~TorrentContentModelFolder();
+    ~TorrentContentModelFolder() override;
 
     ItemType itemType() const override;
 

--- a/src/gui/torrentcreatordialog.h
+++ b/src/gui/torrentcreatordialog.h
@@ -50,7 +50,7 @@ class TorrentCreatorDialog : public QDialog
 
 public:
     TorrentCreatorDialog(QWidget *parent = nullptr, const QString &defaultPath = QString());
-    ~TorrentCreatorDialog();
+    ~TorrentCreatorDialog() override;
     void updateInputPath(const QString &path);
 
 private slots:

--- a/src/gui/transferlistdelegate.cpp
+++ b/src/gui/transferlistdelegate.cpp
@@ -104,7 +104,7 @@ void TransferListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
         break;
     case TransferListModel::TR_UPSPEED:
     case TransferListModel::TR_DLSPEED: {
-            const qulonglong speed = index.data().toULongLong();
+            const int speed = index.data().toInt();
             if (hideValues && !speed)
                 break;
             opt.displayAlignment = Qt::AlignRight | Qt::AlignVCenter;

--- a/src/gui/transferlistfilterswidget.h
+++ b/src/gui/transferlistfilterswidget.h
@@ -71,7 +71,7 @@ class StatusFilterWidget : public BaseFilterWidget
 
 public:
     StatusFilterWidget(QWidget *parent, TransferListWidget *transferList);
-    ~StatusFilterWidget();
+    ~StatusFilterWidget() override;
 
 private slots:
     void updateTorrentNumbers();
@@ -91,7 +91,7 @@ class TrackerFiltersList : public BaseFilterWidget
 
 public:
     TrackerFiltersList(QWidget *parent, TransferListWidget *transferList);
-    ~TrackerFiltersList();
+    ~TrackerFiltersList() override;
 
     // Redefine addItem() to make sure the list stays sorted
     void addItem(const QString &tracker, const QString &hash);

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -240,8 +240,6 @@ QVariant TransferListModel::data(const QModelIndex &index, int role) const
         return torrent->timeSinceActivity();
     case TR_TOTAL_SIZE:
         return torrent->totalSize();
-    default:
-        return QVariant();
     }
 
     return QVariant();
@@ -283,7 +281,7 @@ void TransferListModel::addTorrent(BitTorrent::TorrentHandle *const torrent)
 
 Qt::ItemFlags TransferListModel::flags(const QModelIndex &index) const
 {
-    if (!index.isValid()) return 0;
+    if (!index.isValid()) return Qt::NoItemFlags;
 
     // Explicitly mark as editable
     return QAbstractListModel::flags(index) | Qt::ItemIsEditable;
@@ -291,7 +289,7 @@ Qt::ItemFlags TransferListModel::flags(const QModelIndex &index) const
 
 BitTorrent::TorrentHandle *TransferListModel::torrentHandle(const QModelIndex &index) const
 {
-    if (!index.isValid()) return 0;
+    if (!index.isValid()) return nullptr;
 
     return m_torrents.value(index.row());
 }

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -260,7 +260,7 @@ TransferListWidget::TransferListWidget(QWidget *parent, MainWindow *mainWindow)
 
     //Ensure that at least one column is visible at all times
     bool atLeastOne = false;
-    for (unsigned int i = 0; i < TransferListModel::NB_COLUMNS; ++i) {
+    for (int i = 0; i < TransferListModel::NB_COLUMNS; ++i) {
         if (!isColumnHidden(i)) {
             atLeastOne = true;
             break;
@@ -272,7 +272,7 @@ TransferListWidget::TransferListWidget(QWidget *parent, MainWindow *mainWindow)
     //When adding/removing columns between versions some may
     //end up being size 0 when the new version is launched with
     //a conf file from the previous version.
-    for (unsigned int i = 0; i < TransferListModel::NB_COLUMNS; ++i)
+    for (int i = 0; i < TransferListModel::NB_COLUMNS; ++i)
         if ((columnWidth(i) <= 0) && (!isColumnHidden(i)))
             resizeColumnToContents(i);
 
@@ -713,7 +713,7 @@ void TransferListWidget::displayDLHoSMenu(const QPoint&)
         actions.append(myAct);
     }
     int visibleCols = 0;
-    for (unsigned int i = 0; i < TransferListModel::NB_COLUMNS; ++i) {
+    for (int i = 0; i < TransferListModel::NB_COLUMNS; ++i) {
         if (!isColumnHidden(i))
             ++visibleCols;
 

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -52,7 +52,7 @@ class TransferListWidget : public QTreeView
 
 public:
     TransferListWidget(QWidget *parent, MainWindow *mainWindow);
-    ~TransferListWidget();
+    ~TransferListWidget() override;
     TransferListModel *getSourceModel() const;
 
 public slots:


### PR DESCRIPTION
>scrape_incomplete scrape_complete scrape_downloaded
    if this tracker has returned scrape data, these fields are filled in with valid numbers. Otherwise they are set to -1.
<img src="https://user-images.githubusercontent.com/6451685/45221128-2daff400-b2b9-11e8-915e-acfaefe42dfe.JPG" width="300">

Closes #9460.
