### PR TITLE
cmake: use C++14 when available

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,13 @@
 set(CMAKE_CXX_STANDARD_REQUIRED True)
-set(CMAKE_CXX_STANDARD "11")
+
+# If C++14 is available, use it as libtorent ABI depends on 11/14 version
+if (cxx_std_14 IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+    message(STATUS "Building in C++14 mode")
+    set(CMAKE_CXX_STANDARD "14")
+else()
+    message(STATUS "Building in C++11 mode")
+    set(CMAKE_CXX_STANDARD "11")
+endif()
 
 include(MacroQbtCompilerSettings)
 qbt_set_compiler_options()


### PR DESCRIPTION
Libtorrent does the same and we have to follow since
its ABI depends on the C++ standard version.

Partially closes #9485.