### PR TITLE
Add WebUI option to restart qBittorrent

### DIFF
--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -76,6 +76,16 @@ void AppController::shutdownAction()
     QTimer::singleShot(100, qApp, &QCoreApplication::quit);
 }
 
+void AppController::restartAction()
+{
+    qDebug() << "Restart request from Web UI";
+
+    // Special case handling for shutdown, we
+    // need to reply to the Web UI before
+    // actually shutting down.
+    QTimer::singleShot(100, qApp, []() { QCoreApplication::exit(1000); });
+}
+
 void AppController::preferencesAction()
 {
     const Preferences *const pref = Preferences::instance();

--- a/src/webui/api/appcontroller.h
+++ b/src/webui/api/appcontroller.h
@@ -44,6 +44,7 @@ private slots:
     void webapiVersionAction();
     void versionAction();
     void shutdownAction();
+    void restartAction();
     void preferencesAction();
     void setPreferencesAction();
     void defaultSavePathAction();

--- a/src/webui/extra_translations.h
+++ b/src/webui/extra_translations.h
@@ -35,6 +35,7 @@
 const char *QBT_WEBUI_TRANSLATIONS[] = {
     QT_TRANSLATE_NOOP("HttpServer", "Logout"),
     QT_TRANSLATE_NOOP("HttpServer", "Exit qBittorrent"),
+    QT_TRANSLATE_NOOP("HttpServer", "Restart qBittorrent"),
     QT_TRANSLATE_NOOP("HttpServer", "Download Torrents from their URLs or Magnet links"),
     QT_TRANSLATE_NOOP("HttpServer", "Only one link per line"),
     QT_TRANSLATE_NOOP("HttpServer", "Upload local torrent"),

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -42,6 +42,7 @@
                             <li><a id="uploadLink"><img class="MyMenuIcon" alt="QBT_TR(&Add Torrent File...)QBT_TR[CONTEXT=MainWindow]" src="images/qbt-theme/list-add.svg" width="16" height="16"/>QBT_TR(&Add Torrent File...)QBT_TR[CONTEXT=MainWindow]</a></li>
                             <li><a id="downloadLink"><img class="MyMenuIcon" alt="QBT_TR(Add Torrent &Link...)QBT_TR[CONTEXT=MainWindow]" src="images/qbt-theme/insert-link.svg" width="16" height="16"/>QBT_TR(Add Torrent &Link...)QBT_TR[CONTEXT=MainWindow]</a></li>
                             <li class="divider"><a id="logoutLink"><img class="MyMenuIcon" alt="QBT_TR(Logout)QBT_TR[CONTEXT=HttpServer]" src="images/qbt-theme/system-log-out.svg" width="16" height="16"/>QBT_TR(Logout)QBT_TR[CONTEXT=HttpServer]</a></li>
+                            <li><a id="restartLink"><img class="MyMenuIcon" alt="QBT_TR(Restart qBittorrent)QBT_TR[CONTEXT=HttpServer]" src="images/qbt-theme/view-refresh.svg" width="16" height="16"/>QBT_TR(Restart qBittorrent)QBT_TR[CONTEXT=HttpServer]</a></li>
                             <li><a id="shutdownLink"><img class="MyMenuIcon" alt="QBT_TR(Exit qBittorrent)QBT_TR[CONTEXT=HttpServer]" src="images/qbt-theme/application-exit.svg" width="16" height="16"/>QBT_TR(Exit qBittorrent)QBT_TR[CONTEXT=HttpServer]</a></li>
                         </ul>
                     </li>

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -732,6 +732,19 @@ initializeWindows = function() {
         }
     });
 
+    addClickEvent('restart', function(e) {
+        new Event(e).stop();
+        if (confirm('QBT_TR(Are you sure you want to restart qBittorrent?)QBT_TR[CONTEXT=MainWindow]')) {
+            new Request({
+                url: 'api/v2/app/restart',
+                onSuccess: function() {
+                    document.write("<!DOCTYPE html><html lang=\"${LANG}\"><head><meta charset=\"UTF-8\"/><meta http-equiv=\"X-UA-Compatible\" content=\"IE=10\"/><title>QBT_TR(qBittorrent is restarting...)QBT_TR[CONTEXT=HttpServer]</title><script>function check_available(){document.getElementById(\"check_pic\").src=window.location.href+\"/images/qbt-theme/view-refresh.svg\"+\"?now=\"+Math.random();}function check_success(){window.location.href=window.location.href;}setInterval(check_available,1000);</script></head><body style=\"text-align:center;\"><h1>QBT_TR(qBittorrent is restarting...)QBT_TR[CONTEXT=HttpServer]</h1><img style=\"visibility:hidden\" id='check_pic' src=\"/images/qbt-theme/view-refresh.svg\" onload=\"check_success()\"/></body></html>");
+                    stop();
+                }
+            }).send();
+        }
+    });
+
     // Deactivate menu header links
     $$('a.returnFalse').each(function(el) {
         el.addEvent('click', function(e) {

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -725,7 +725,7 @@ initializeWindows = function() {
             new Request({
                 url: 'api/v2/app/shutdown',
                 onSuccess: function() {
-                    document.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\"><html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>QBT_TR(qBittorrent has been shutdown.)QBT_TR[CONTEXT=HttpServer]</title><style type=\"text/css\">body { text-align: center; }</style></head><body><h1>QBT_TR(qBittorrent has been shutdown.)QBT_TR[CONTEXT=HttpServer]</h1></body></html>");
+                    document.write("<!DOCTYPE html><html lang=\"${LANG}\"><head><meta charset=\"UTF-8\"/><meta http-equiv=\"X-UA-Compatible\" content=\"IE=10\"/><title>QBT_TR(qBittorrent has been shutdown.)QBT_TR[CONTEXT=HttpServer]</title></head><body style=\"text-align:center;\"><h1>QBT_TR(qBittorrent has been shutdown.)QBT_TR[CONTEXT=HttpServer]</h1></html>");
                     stop();
                 }
             }).send();


### PR DESCRIPTION
Exiting qBittorrent from the WebUI is trivial thanks to the menu option, but restarting requires logging in to the actual machine. This option is often unfeasible for WebUI users, and what's worse is that certain qBittorrent options require a restart before taking effect.