### PR TITLE
Save fastresumes on deletion for torrents in the queue

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -645,6 +645,7 @@ namespace BitTorrent
 
         bool m_deferredConfigureScheduled;
         bool m_IPFilteringChanged;
+        bool m_torrentsQueueChanged;
 #if LIBTORRENT_VERSION_NUM >= 10100
         bool m_listenInterfaceChanged; // optimization
 #endif


### PR DESCRIPTION
I didn't do it in `Session::deleteTorrent` to avoid saving fastresumes n times*deleted torrents but now there's the risk of forgetting to do it if a new way to delete a torrent is introduced (hope i didn't miss any myself).