### PR TITLE
Improve handling of torrent startup/recheck

### DIFF
--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -1719,7 +1719,9 @@ void TorrentHandle::handleFileRenamedAlert(const libtorrent::file_renamed_alert 
         }
     }
 
-    updateStatus();
+    // We don't really need to call updateStatus() in this place.
+    // All we need to do is make sure we have a valid instance of the TorrentInfo object.
+    m_torrentInfo = TorrentInfo {m_nativeHandle.torrent_file()};
 
     --m_renameCount;
     while (!isMoveInProgress() && (m_renameCount == 0) && !m_moveFinishedTriggers.isEmpty())
@@ -1737,7 +1739,9 @@ void TorrentHandle::handleFileRenameFailedAlert(const libtorrent::file_rename_fa
 
 void TorrentHandle::handleFileCompletedAlert(const libtorrent::file_completed_alert *p)
 {
-    updateStatus();
+    // We don't really need to call updateStatus() in this place.
+    // All we need to do is make sure we have a valid instance of the TorrentInfo object.
+    m_torrentInfo = TorrentInfo {m_nativeHandle.torrent_file()};
 
     qDebug("A file completed download in torrent \"%s\"", qUtf8Printable(name()));
     if (m_session->isAppendExtensionEnabled()) {
@@ -2000,8 +2004,6 @@ void TorrentHandle::setDownloadLimit(int limit)
 void TorrentHandle::setSuperSeeding(bool enable)
 {
     m_nativeHandle.super_seeding(enable);
-    if (superSeeding() != enable)
-        updateStatus();
 }
 
 void TorrentHandle::flushCache()
@@ -2094,8 +2096,6 @@ void TorrentHandle::prioritizeFiles(const QVector<int> &priorities)
     // Restore first/last piece first option if necessary
     if (firstLastPieceFirst)
         setFirstLastPiecePriorityImpl(true, priorities);
-
-    updateStatus();
 }
 
 QVector<qreal> TorrentHandle::availableFileFractions() const

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -191,7 +191,6 @@ TorrentHandle::TorrentHandle(Session *session, const libtorrent::torrent_handle 
     , m_hasRootFolder(params.hasRootFolder)
     , m_needsToSetFirstLastPiecePriority(false)
     , m_needsToStartForced(params.forced)
-    , m_pauseAfterRecheck(false)
 {
     if (m_useAutoTMM)
         m_savePath = Utils::Fs::toNativePath(m_session->categorySavePath(m_category));
@@ -1275,11 +1274,9 @@ void TorrentHandle::forceRecheck()
     m_unchecked = false;
 
     if (isPaused()) {
-        m_pauseAfterRecheck = true;
+        m_nativeHandle.stop_when_ready(true);
         resume_impl(true, true);
     }
-
-    m_nativeHandle.force_recheck();
 }
 
 void TorrentHandle::setSequentialDownload(bool b)
@@ -1587,11 +1584,6 @@ void TorrentHandle::handleTorrentCheckedAlert(const libtorrent::torrent_checked_
 
         adjustActualSavePath();
         manageIncompleteFiles();
-
-        if (m_pauseAfterRecheck) {
-            m_pauseAfterRecheck = false;
-            pause();
-        }
     }
 
     m_session->handleTorrentChecked(this);

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -463,7 +463,6 @@ namespace BitTorrent
         bool m_needsToSetFirstLastPiecePriority;
         bool m_needsToStartForced;
 
-        bool m_pauseAfterRecheck;
         QHash<QString, TrackerInfo> m_trackerInfos;
 
         enum StartupState

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -461,11 +461,19 @@ namespace BitTorrent
         bool m_hasMissingFiles;
         bool m_hasRootFolder;
         bool m_needsToSetFirstLastPiecePriority;
+        bool m_needsToStartForced;
 
         bool m_pauseAfterRecheck;
         QHash<QString, TrackerInfo> m_trackerInfos;
 
-        bool m_started = false;
+        enum StartupState
+        {
+            NotStarted,
+            Starting,
+            Started
+        };
+
+        StartupState m_startupState = NotStarted;
         bool m_unchecked = false;
     };
 }


### PR DESCRIPTION
Add/restore all torrents in "paused" state and then resume those that need to be really "resumed" (added/restored in "resumed" state).
Keep torrents with missing files paused.
Force recheck torrent with missing files when it's resumed by the user.