### PR TITLE
[WIP]Introduce explicit portable edition

### DIFF
--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -314,7 +314,11 @@ namespace
     constexpr const IntOption WEBUI_PORT_OPTION = {"webui-port"};
     constexpr const StringOption PROFILE_OPTION = {"profile"};
     constexpr const StringOption CONFIGURATION_OPTION = {"configuration"};
-    constexpr const BoolOption PORTABLE_OPTION = {"portable"};
+#ifdef QBT_PORTABLE
+    constexpr const TriStateBoolOption PORTABLE_OPTION = {"portable", true};
+#else
+    constexpr const TriStateBoolOption PORTABLE_OPTION = {"portable", false};
+#endif
     constexpr const BoolOption RELATIVE_FASTRESUME = {"relative-fastresume"};
     constexpr const StringOption SAVE_PATH_OPTION = {"save-path"};
     constexpr const TriStateBoolOption PAUSED_OPTION = {"add-paused", true};
@@ -328,7 +332,12 @@ namespace
 QBtCommandLineParameters::QBtCommandLineParameters(const QProcessEnvironment &env)
     : showHelp(false)
     , relativeFastresumePaths(RELATIVE_FASTRESUME.value(env))
-    , portableMode(PORTABLE_OPTION.value(env))
+    , portableMode((PORTABLE_OPTION.value(env) == TriStateBool::True)
+#ifdef QBT_PORTABLE
+                   || (PORTABLE_OPTION.value(env) == TriStateBool::Undefined))
+#else
+                   || !(PORTABLE_OPTION.value(env) == TriStateBool::Undefined))
+#endif
     , skipChecking(SKIP_HASH_CHECK_OPTION.value(env))
     , sequential(SEQUENTIAL_OPTION.value(env))
     , firstLastPiecePriority(FIRST_AND_LAST_OPTION.value(env))

--- a/src/src.pro
+++ b/src/src.pro
@@ -12,12 +12,17 @@ unix:!macx: include(../unixconf.pri)
 
 QT += network xml
 
+portable:DEFINES += QBT_PORTABLE
+
 nogui {
+    portable:TARGET = qbittorrent-nox-portable
+    else:TARGET = qbittorrent-nox
     TARGET = qbittorrent-nox
     QT -= gui
     DEFINES += DISABLE_GUI
 } else {
-    TARGET = qbittorrent
+    portable:TARGET = qbittorrent-portable
+    else:TARGET = qbittorrent
     QT += xml svg widgets
 
     CONFIG(static) {


### PR DESCRIPTION
This is an alternative to #9349.
I am not explicitly against #9349. I am just offering an alternative here. It is up to discussion.
Merits for this approach:
1. User can explicitly choose a portable edition which launches automatically in portable mode
2. Both portable and non-portable editions can switch mode by passing the correct command line parameter to the app. Users can create a wrapper script that does it.
3. Since I am going to have a portable option in the downloads page anyway, it doesn't matter to me if I compile it again for the portable version.
4. Less complicated code than #9349.

**Caveat**
1. This isn't meant for code review. It is a quick implementation to show an alternative. If approved, I'll welcome code reviews
2. I didn't make the necessary changes to the build systems. Those are easy and the purpose of this PR, for the moment, is as a proof-of-concept.