### PR TITLE
Change "Add new torrent" dialog layout

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -20,6 +20,8 @@ banlistoptionsdialog.h
 categoryfiltermodel.h
 categoryfilterproxymodel.h
 categoryfilterwidget.h
+checkboxwordwrap.h 
+clickablelabel.h
 cookiesdialog.h
 cookiesmodel.h
 deletionconfirmationdialog.h
@@ -68,6 +70,8 @@ banlistoptionsdialog.cpp
 categoryfiltermodel.cpp
 categoryfilterproxymodel.cpp
 categoryfilterwidget.cpp
+checkboxwordwrap.cpp 
+clickablelabel.cpp
 cookiesdialog.cpp
 cookiesmodel.cpp
 downloadfromurldialog.cpp

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -780,7 +780,7 @@ void AddNewTorrentDialog::TMMChanged(int index)
 
 void AddNewTorrentDialog::setCommentText(const QString &str) const
 {
-    m_ui->commentLabel->setText(str);
+    m_ui->commentText->setText(str);
 }
 
 void AddNewTorrentDialog::doNotDeleteTorrentClicked(bool checked)

--- a/src/gui/addnewtorrentdialog.h
+++ b/src/gui/addnewtorrentdialog.h
@@ -79,7 +79,6 @@ public:
     static void show(const QString &source, QWidget *parent);
 
 private slots:
-    void showAdvancedSettings(bool show);
     void displayContentTreeMenu(const QPoint &);
     void updateDiskSpaceLabel();
     void onSavePathChanged(const QString &newPath);

--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -833,6 +833,19 @@
    <item>
     <layout class="QHBoxLayout" name="buttonsHLayout">
      <item>
+      <widget class="QCheckBox" name="checkBoxNeverShow">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Never show again</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QProgressBar" name="progMetaLoading">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -860,19 +873,6 @@
         <font>
          <pointsize>10</pointsize>
         </font>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="checkBoxNeverShow">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Never show again</string>
        </property>
       </widget>
      </item>
@@ -941,7 +941,6 @@
   <tabstop>categoryComboBox</tabstop>
   <tabstop>labelCommentScroll</tabstop>
   <tabstop>contentTreeView</tabstop>
-  <tabstop>checkBoxNeverShow</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -6,332 +6,816 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>414</width>
-    <height>630</height>
+    <width>936</width>
+    <height>590</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <layout class="QVBoxLayout" name="AddNewTorrentDialogLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="labelTorrentManagementMode">
-       <property name="text">
-        <string>Torrent Management Mode:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="comboTTM">
-       <property name="toolTip">
-        <string>Automatic mode means that various torrent properties(eg save path) will be decided by the associated category</string>
-       </property>
-       <item>
-        <property name="text">
-         <string>Manual</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Automatic</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBoxSavePath">
-     <property name="title">
-      <string>Save at</string>
+    <widget class="QSplitter" name="splitter">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <widget class="FileSystemPathComboEdit" name="savePath" native="true"/>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="checkBoxRememberLastSavePath">
-        <property name="text">
-         <string>Remember last used save path</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="doNotDeleteTorrentCheckBox">
-     <property name="toolTip">
-      <string>When checked, the .torrent file will not be deleted despite the settings at the &quot;Download&quot; page of the options dialog</string>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-     <property name="text">
-      <string>Do not delete .torrent file</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="checkBoxNeverShow">
-     <property name="text">
-      <string>Never show again</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QToolButton" name="toolButtonAdvanced">
-     <property name="text">
-      <string notr="true">▼</string>
-     </property>
-     <property name="checkable">
+     <property name="opaqueResize">
       <bool>true</bool>
      </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBoxSettings">
-     <property name="title">
-      <string>Torrent settings</string>
+     <property name="childrenCollapsible">
+      <bool>false</bool>
      </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="1" column="2">
-       <widget class="QCheckBox" name="defaultCategoryCheckbox">
-        <property name="text">
-         <string>Set as default category</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <layout class="QHBoxLayout" name="horizontalLayout_1">
-        <item>
-         <widget class="QLabel" name="label_5">
-          <property name="text">
-           <string>Category:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QComboBox" name="categoryComboBox">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="editable">
-           <bool>true</bool>
-          </property>
-          <property name="insertPolicy">
-           <enum>QComboBox::InsertAtTop</enum>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="startTorrentCheckBox">
-        <property name="text">
-         <string>Start torrent</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="skipCheckingCheckBox">
-        <property name="text">
-         <string>Skip hash check</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <spacer name="horizontalSpacer2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Fixed</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>35</width>
-          <height>0</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="2" column="0">
-       <widget class="QCheckBox" name="createSubfolderCheckBox">
-        <property name="text">
-         <string>Create subfolder</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QCheckBox" name="sequentialCheckBox">
-        <property name="text">
-         <string>Download in sequential order</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QCheckBox" name="firstLastCheckBox">
-        <property name="text">
-         <string>Download first and last pieces first</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="infoGroup">
-     <property name="title">
-      <string>Torrent information</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="2" column="1">
-       <widget class="QLabel" name="lblhash">
-        <property name="text">
-         <string/>
-        </property>
-        <property name="textFormat">
-         <enum>Qt::PlainText</enum>
-        </property>
-        <property name="textInteractionFlags">
-         <set>Qt::TextSelectableByMouse</set>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Hash:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0" colspan="2">
-       <widget class="TorrentContentTreeView" name="contentTreeView">
-        <property name="contextMenuPolicy">
-         <enum>Qt::CustomContextMenu</enum>
-        </property>
-        <property name="selectionMode">
-         <enum>QAbstractItemView::ExtendedSelection</enum>
-        </property>
-        <property name="sortingEnabled">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLabel" name="labelDate">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Date:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Size:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLabel" name="labelSize">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Comment:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QScrollArea" name="scrollArea">
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
-        <property name="widgetResizable">
-         <bool>true</bool>
-        </property>
-        <widget class="QWidget" name="scrollAreaWidgetContents_2">
-         <property name="geometry">
-          <rect>
-           <x>0</x>
-           <y>0</y>
-           <width>321</width>
-           <height>69</height>
-          </rect>
+     <widget class="QFrame" name="torrentoptionsFrame">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>550</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>550</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+      <layout class="QVBoxLayout" name="mainlayout_addui">
+       <property name="spacing">
+        <number>4</number>
+       </property>
+       <property name="sizeConstraint">
+        <enum>QLayout::SetDefaultConstraint</enum>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QGroupBox" name="groupBoxSavePath">
+         <property name="font">
+          <font>
+           <pointsize>10</pointsize>
+          </font>
+         </property>
+         <property name="title">
+          <string>Save at</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout">
+          <property name="spacing">
+           <number>3</number>
+          </property>
           <property name="leftMargin">
-           <number>0</number>
+           <number>3</number>
           </property>
           <property name="topMargin">
-           <number>0</number>
+           <number>6</number>
           </property>
           <property name="rightMargin">
-           <number>0</number>
+           <number>3</number>
           </property>
           <property name="bottomMargin">
-           <number>0</number>
+           <number>6</number>
           </property>
           <item>
-           <widget class="QLabel" name="commentLabel">
+           <layout class="QHBoxLayout" name="managementLayout">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>3</number>
+            </property>
+            <property name="rightMargin">
+             <number>6</number>
+            </property>
+            <property name="bottomMargin">
+             <number>3</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="labelTorrentManagementMode">
+              <property name="font">
+               <font>
+                <pointsize>10</pointsize>
+               </font>
+              </property>
+              <property name="text">
+               <string>Torrent Management Mode:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="comboTTM">
+              <property name="font">
+               <font>
+                <pointsize>10</pointsize>
+               </font>
+              </property>
+              <property name="toolTip">
+               <string>Automatic mode means that various torrent properties(eg save path) will be decided by the associated category</string>
+              </property>
+              <item>
+               <property name="text">
+                <string>Manual</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Automatic</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer">
+              <property name="font">
+               <font>
+                <pointsize>10</pointsize>
+               </font>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Expanding</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="CheckBoxWordWrap" name="createSubfolderCheckBox">
+              <property name="minimumSize">
+               <size>
+                <width>200</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="mouseTracking">
+               <bool>true</bool>
+              </property>
+              <property name="focusPolicy">
+               <enum>Qt::StrongFocus</enum>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">font: 10pt &quot;Cantarell&quot;;</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+              <property name="text">
+               <string>Create subfolder</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="FileSystemPathComboEdit" name="savePath" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>10</pointsize>
+             </font>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="rememberPathLayout">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>3</number>
+            </property>
+            <property name="rightMargin">
+             <number>6</number>
+            </property>
+            <property name="bottomMargin">
+             <number>3</number>
+            </property>
+            <item>
+             <widget class="CheckBoxWordWrap" name="checkBoxRememberLastSavePath">
+              <property name="styleSheet">
+               <string notr="true">font: 10pt &quot;Cantarell&quot;;</string>
+              </property>
+              <property name="text">
+               <string>Remember last used save path</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBoxSettings">
+         <property name="font">
+          <font>
+           <pointsize>10</pointsize>
+          </font>
+         </property>
+         <property name="title">
+          <string>Torrent settings</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <property name="spacing">
+           <number>6</number>
+          </property>
+          <property name="leftMargin">
+           <number>3</number>
+          </property>
+          <property name="topMargin">
+           <number>6</number>
+          </property>
+          <property name="rightMargin">
+           <number>3</number>
+          </property>
+          <property name="bottomMargin">
+           <number>3</number>
+          </property>
+          <item>
+           <layout class="QHBoxLayout" name="categoryLayout">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>6</number>
+            </property>
+            <property name="bottomMargin">
+             <number>6</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="labelCategory">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>10</pointsize>
+               </font>
+              </property>
+              <property name="text">
+               <string>Category:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="categoryComboBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>170</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="baseSize">
+               <size>
+                <width>150</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>11</pointsize>
+               </font>
+              </property>
+              <property name="editable">
+               <bool>true</bool>
+              </property>
+              <property name="insertPolicy">
+               <enum>QComboBox::InsertAtTop</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="CheckBoxWordWrap" name="defaultCategoryCheckbox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>250</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>10</pointsize>
+                <kerning>true</kerning>
+               </font>
+              </property>
+              <property name="mouseTracking">
+               <bool>true</bool>
+              </property>
+              <property name="focusPolicy">
+               <enum>Qt::StrongFocus</enum>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">font: 10pt &quot;Cantarell&quot;;</string>
+              </property>
+              <property name="text">
+               <string>Set as default category</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QGridLayout" name="gridLayout">
+            <property name="sizeConstraint">
+             <enum>QLayout::SetDefaultConstraint</enum>
+            </property>
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>6</number>
+            </property>
+            <property name="rightMargin">
+             <number>6</number>
+            </property>
+            <property name="bottomMargin">
+             <number>6</number>
+            </property>
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <item row="2" column="0">
+             <widget class="CheckBoxWordWrap" name="startTorrentCheckBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">font: 10pt &quot;Cantarell&quot;;</string>
+              </property>
+              <property name="text">
+               <string>Start torrent</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="CheckBoxWordWrap" name="skipCheckingCheckBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">font: 10pt &quot;Cantarell&quot;;</string>
+              </property>
+              <property name="text">
+               <string>Skip hash check</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="CheckBoxWordWrap" name="sequentialCheckBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="font">
+               <font>
+                <family>Cantarell</family>
+                <pointsize>10</pointsize>
+                <weight>50</weight>
+                <italic>false</italic>
+                <bold>false</bold>
+               </font>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">font: 10pt &quot;Cantarell&quot;;</string>
+              </property>
+              <property name="text">
+               <string>Download in sequential order</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="CheckBoxWordWrap" name="firstLastCheckBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">font: 10pt &quot;Cantarell&quot;;</string>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string>Download first and last pieces first</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <widget class="CheckBoxWordWrap" name="doNotDeleteTorrentCheckBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="mouseTracking">
+               <bool>true</bool>
+              </property>
+              <property name="focusPolicy">
+               <enum>Qt::StrongFocus</enum>
+              </property>
+              <property name="toolTip">
+               <string>When checked, the .torrent file will not be deleted despite the settings at the &quot;Download&quot; page of the options dialog</string>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">font: 10pt &quot;Cantarell&quot;;</string>
+              </property>
+              <property name="text">
+               <string>Do not delete .torrent file</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="infoGroup">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>10</pointsize>
+          </font>
+         </property>
+         <property name="title">
+          <string>Torrent information</string>
+         </property>
+         <property name="flat">
+          <bool>false</bool>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="3" column="1">
+           <widget class="QLabel" name="labelSizeData">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>10</pointsize>
+             </font>
+            </property>
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="labelHash">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>10</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>Hash:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="labelSize">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>10</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>Size:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLabel" name="labelDate">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>10</pointsize>
+             </font>
+            </property>
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="margin">
+             <number>0</number>
+            </property>
+            <property name="indent">
+             <number>-1</number>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLabel" name="labelHashData">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>10</pointsize>
+             </font>
+            </property>
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
+            </property>
             <property name="text">
              <string/>
             </property>
             <property name="textFormat">
-             <enum>Qt::RichText</enum>
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="labelDatedata">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>10</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>Date:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="labelComment">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Ignored">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>10</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>Comment:</string>
+            </property>
+            <property name="scaledContents">
+             <bool>false</bool>
             </property>
             <property name="alignment">
              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
             </property>
-            <property name="wordWrap">
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QScrollArea" name="labelCommentScroll">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>10</pointsize>
+             </font>
+            </property>
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="horizontalScrollBarPolicy">
+             <enum>Qt::ScrollBarAlwaysOff</enum>
+            </property>
+            <property name="sizeAdjustPolicy">
+             <enum>QAbstractScrollArea::AdjustToContents</enum>
+            </property>
+            <property name="widgetResizable">
              <bool>true</bool>
             </property>
-            <property name="openExternalLinks">
-             <bool>true</bool>
-            </property>
-            <property name="textInteractionFlags">
-             <set>Qt::TextBrowserInteraction</set>
-            </property>
+            <widget class="QWidget" name="scrollAreaWidgetContents">
+             <property name="geometry">
+              <rect>
+               <x>0</x>
+               <y>0</y>
+               <width>457</width>
+               <height>138</height>
+              </rect>
+             </property>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <layout class="QHBoxLayout" name="horizontalLayout_2">
+              <property name="spacing">
+               <number>0</number>
+              </property>
+              <property name="sizeConstraint">
+               <enum>QLayout::SetNoConstraint</enum>
+              </property>
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <widget class="QLabel" name="commentLabel">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>10</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::RichText</enum>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+                <property name="openExternalLinks">
+                 <bool>true</bool>
+                </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::TextBrowserInteraction</set>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
            </widget>
           </item>
          </layout>
         </widget>
-       </widget>
-      </item>
-     </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="TorrentContentTreeView" name="contentTreeView">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>300</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+      <property name="contextMenuPolicy">
+       <enum>Qt::CustomContextMenu</enum>
+      </property>
+      <property name="selectionMode">
+       <enum>QAbstractItemView::ExtendedSelection</enum>
+      </property>
+      <property name="sortingEnabled">
+       <bool>true</bool>
+      </property>
+     </widget>
     </widget>
    </item>
    <item>
@@ -359,10 +843,40 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="lblMetaLoading"/>
+      <widget class="QLabel" name="lblMetaLoading">
+       <property name="font">
+        <font>
+         <pointsize>10</pointsize>
+        </font>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="checkBoxNeverShow">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Never show again</string>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>10</pointsize>
+        </font>
+       </property>
        <property name="standardButtons">
         <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
        </property>
@@ -394,6 +908,11 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>CheckBoxWordWrap</class>
+   <extends>QWidget</extends>
+   <header>checkboxwordwrap.h</header>
+  </customwidget>
+  <customwidget>
    <class>TorrentContentTreeView</class>
    <extends>QTreeView</extends>
    <header>torrentcontenttreeview.h</header>
@@ -406,16 +925,11 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>savePath</tabstop>
-  <tabstop>checkBoxRememberLastSavePath</tabstop>
-  <tabstop>checkBoxNeverShow</tabstop>
-  <tabstop>toolButtonAdvanced</tabstop>
-  <tabstop>startTorrentCheckBox</tabstop>
-  <tabstop>skipCheckingCheckBox</tabstop>
+  <tabstop>comboTTM</tabstop>
   <tabstop>categoryComboBox</tabstop>
-  <tabstop>defaultCategoryCheckbox</tabstop>
-  <tabstop>scrollArea</tabstop>
+  <tabstop>labelCommentScroll</tabstop>
   <tabstop>contentTreeView</tabstop>
+  <tabstop>checkBoxNeverShow</tabstop>
  </tabstops>
  <resources/>
  <connections>
@@ -426,8 +940,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>403</x>
-     <y>579</y>
+     <x>777</x>
+     <y>490</y>
     </hint>
     <hint type="destinationlabel">
      <x>157</x>
@@ -442,28 +956,12 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>403</x>
-     <y>579</y>
+     <x>777</x>
+     <y>490</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>
      <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>categoryComboBox</sender>
-   <signal>currentIndexChanged(int)</signal>
-   <receiver>AddNewTorrentDialog</receiver>
-   <slot>categoryChanged(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>337</x>
-     <y>205</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>403</x>
-     <y>160</y>
     </hint>
    </hints>
   </connection>
@@ -474,12 +972,28 @@
    <slot>TMMChanged(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>200</x>
-     <y>19</y>
+     <x>250</x>
+     <y>53</y>
     </hint>
     <hint type="destinationlabel">
-     <x>206</x>
-     <y>294</y>
+     <x>467</x>
+     <y>249</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>categoryComboBox</sender>
+   <signal>currentIndexChanged(int)</signal>
+   <receiver>AddNewTorrentDialog</receiver>
+   <slot>categoryChanged(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>233</x>
+     <y>171</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>467</x>
+     <y>249</y>
     </hint>
    </hints>
   </connection>

--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>936</width>
-    <height>590</height>
+    <width>863</width>
+    <height>600</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -451,7 +451,7 @@
        <item>
         <widget class="QGroupBox" name="infoGroup">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -463,7 +463,7 @@
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
-          <item row="3" column="1">
+          <item row="4" column="1">
            <widget class="QLabel" name="labelSizeData">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -479,7 +479,7 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
+          <item row="5" column="0">
            <widget class="QLabel" name="labelHash">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -492,7 +492,7 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
+          <item row="4" column="0">
            <widget class="QLabel" name="labelSize">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -505,7 +505,7 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="3" column="1">
            <widget class="QLabel" name="labelDate">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -527,7 +527,7 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="5" column="1">
            <widget class="QLabel" name="labelHashData">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -549,7 +549,7 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="3" column="0">
            <widget class="QLabel" name="labelDatedata">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -562,10 +562,10 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="0">
+          <item row="6" column="0">
            <widget class="QLabel" name="labelComment">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Ignored">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
@@ -581,108 +581,23 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="1">
-           <widget class="QScrollArea" name="labelCommentScroll">
+          <item row="6" column="1">
+           <widget class="QTextBrowser" name="commentText">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
+            <property name="styleSheet">
+             <string notr="true">background-color: rgba(0, 0, 0, 0);</string>
             </property>
             <property name="frameShape">
              <enum>QFrame::NoFrame</enum>
             </property>
-            <property name="horizontalScrollBarPolicy">
-             <enum>Qt::ScrollBarAlwaysOff</enum>
-            </property>
-            <property name="sizeAdjustPolicy">
-             <enum>QAbstractScrollArea::AdjustToContents</enum>
-            </property>
-            <property name="widgetResizable">
+            <property name="openExternalLinks">
              <bool>true</bool>
             </property>
-            <widget class="QWidget" name="scrollAreaWidgetContents">
-             <property name="geometry">
-              <rect>
-               <x>0</x>
-               <y>0</y>
-               <width>445</width>
-               <height>120</height>
-              </rect>
-             </property>
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>0</height>
-              </size>
-             </property>
-             <layout class="QHBoxLayout" name="horizontalLayout_2">
-              <property name="spacing">
-               <number>0</number>
-              </property>
-              <property name="sizeConstraint">
-               <enum>QLayout::SetNoConstraint</enum>
-              </property>
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
-               <number>0</number>
-              </property>
-              <item>
-               <widget class="QLabel" name="commentLabel">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>0</width>
-                  <height>0</height>
-                 </size>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="textFormat">
-                 <enum>Qt::RichText</enum>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-                </property>
-                <property name="wordWrap">
-                 <bool>true</bool>
-                </property>
-                <property name="openExternalLinks">
-                 <bool>true</bool>
-                </property>
-                <property name="textInteractionFlags">
-                 <set>Qt::TextBrowserInteraction</set>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
            </widget>
           </item>
          </layout>
@@ -731,6 +646,22 @@
       </widget>
      </item>
      <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Preferred</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
       <widget class="QProgressBar" name="progMetaLoading">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -751,6 +682,22 @@
         <string notr="true">%p%</string>
        </property>
       </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Expanding</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
      </item>
      <item>
       <widget class="QLabel" name="lblMetaLoading"/>
@@ -813,7 +760,6 @@
  <tabstops>
   <tabstop>comboTTM</tabstop>
   <tabstop>categoryComboBox</tabstop>
-  <tabstop>labelCommentScroll</tabstop>
   <tabstop>contentTreeView</tabstop>
  </tabstops>
  <resources/>
@@ -825,8 +771,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>777</x>
-     <y>490</y>
+     <x>928</x>
+     <y>855</y>
     </hint>
     <hint type="destinationlabel">
      <x>157</x>
@@ -841,8 +787,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>777</x>
-     <y>490</y>
+     <x>928</x>
+     <y>855</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>
@@ -873,8 +819,8 @@
    <slot>categoryChanged(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>233</x>
-     <y>171</y>
+     <x>266</x>
+     <y>231</y>
     </hint>
     <hint type="destinationlabel">
      <x>467</x>

--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -175,31 +175,6 @@
               </property>
              </spacer>
             </item>
-            <item>
-             <widget class="CheckBoxWordWrap" name="createSubfolderCheckBox">
-              <property name="minimumSize">
-               <size>
-                <width>200</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="mouseTracking">
-               <bool>true</bool>
-              </property>
-              <property name="focusPolicy">
-               <enum>Qt::StrongFocus</enum>
-              </property>
-              <property name="styleSheet">
-               <string notr="true">font: 10pt &quot;Cantarell&quot;;</string>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-              <property name="text">
-               <string>Create subfolder</string>
-              </property>
-             </widget>
-            </item>
            </layout>
           </item>
           <item>
@@ -232,7 +207,44 @@
              <number>3</number>
             </property>
             <item>
+             <widget class="CheckBoxWordWrap" name="createSubfolderCheckBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+                <horstretch>1</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>200</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="mouseTracking">
+               <bool>true</bool>
+              </property>
+              <property name="focusPolicy">
+               <enum>Qt::StrongFocus</enum>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">font: 10pt &quot;Cantarell&quot;;</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+              <property name="text">
+               <string>Create subfolder</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="CheckBoxWordWrap" name="checkBoxRememberLastSavePath">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+                <horstretch>1</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="styleSheet">
                <string notr="true">font: 10pt &quot;Cantarell&quot;;</string>
               </property>
@@ -705,8 +717,8 @@
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>457</width>
-               <height>138</height>
+               <width>454</width>
+               <height>147</height>
               </rect>
              </property>
              <property name="sizePolicy">

--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -56,11 +56,6 @@
         <height>16777215</height>
        </size>
       </property>
-      <property name="font">
-       <font>
-        <pointsize>10</pointsize>
-       </font>
-      </property>
       <layout class="QVBoxLayout" name="mainlayout_addui">
        <property name="spacing">
         <number>4</number>
@@ -82,11 +77,6 @@
        </property>
        <item>
         <widget class="QGroupBox" name="groupBoxSavePath">
-         <property name="font">
-          <font>
-           <pointsize>10</pointsize>
-          </font>
-         </property>
          <property name="title">
           <string>Save at</string>
          </property>
@@ -122,11 +112,6 @@
             </property>
             <item>
              <widget class="QLabel" name="labelTorrentManagementMode">
-              <property name="font">
-               <font>
-                <pointsize>10</pointsize>
-               </font>
-              </property>
               <property name="text">
                <string>Torrent Management Mode:</string>
               </property>
@@ -134,11 +119,6 @@
             </item>
             <item>
              <widget class="QComboBox" name="comboTTM">
-              <property name="font">
-               <font>
-                <pointsize>10</pointsize>
-               </font>
-              </property>
               <property name="toolTip">
                <string>Automatic mode means that various torrent properties(eg save path) will be decided by the associated category</string>
               </property>
@@ -156,11 +136,6 @@
             </item>
             <item>
              <spacer name="horizontalSpacer">
-              <property name="font">
-               <font>
-                <pointsize>10</pointsize>
-               </font>
-              </property>
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
@@ -184,11 +159,6 @@
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>10</pointsize>
-             </font>
             </property>
            </widget>
           </item>
@@ -260,11 +230,6 @@
        </item>
        <item>
         <widget class="QGroupBox" name="groupBoxSettings">
-         <property name="font">
-          <font>
-           <pointsize>10</pointsize>
-          </font>
-         </property>
          <property name="title">
           <string>Torrent settings</string>
          </property>
@@ -303,11 +268,6 @@
                 <verstretch>0</verstretch>
                </sizepolicy>
               </property>
-              <property name="font">
-               <font>
-                <pointsize>10</pointsize>
-               </font>
-              </property>
               <property name="text">
                <string>Category:</string>
               </property>
@@ -333,11 +293,6 @@
                 <height>0</height>
                </size>
               </property>
-              <property name="font">
-               <font>
-                <pointsize>11</pointsize>
-               </font>
-              </property>
               <property name="editable">
                <bool>true</bool>
               </property>
@@ -359,12 +314,6 @@
                 <width>250</width>
                 <height>0</height>
                </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>10</pointsize>
-                <kerning>true</kerning>
-               </font>
               </property>
               <property name="mouseTracking">
                <bool>true</bool>
@@ -442,15 +391,6 @@
                 <verstretch>0</verstretch>
                </sizepolicy>
               </property>
-              <property name="font">
-               <font>
-                <family>Cantarell</family>
-                <pointsize>10</pointsize>
-                <weight>50</weight>
-                <italic>false</italic>
-                <bold>false</bold>
-               </font>
-              </property>
               <property name="styleSheet">
                <string notr="true">font: 10pt &quot;Cantarell&quot;;</string>
               </property>
@@ -516,11 +456,6 @@
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="font">
-          <font>
-           <pointsize>10</pointsize>
-          </font>
-         </property>
          <property name="title">
           <string>Torrent information</string>
          </property>
@@ -535,11 +470,6 @@
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>10</pointsize>
-             </font>
             </property>
             <property name="frameShape">
              <enum>QFrame::NoFrame</enum>
@@ -557,11 +487,6 @@
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="font">
-             <font>
-              <pointsize>10</pointsize>
-             </font>
-            </property>
             <property name="text">
              <string>Hash:</string>
             </property>
@@ -575,11 +500,6 @@
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="font">
-             <font>
-              <pointsize>10</pointsize>
-             </font>
-            </property>
             <property name="text">
              <string>Size:</string>
             </property>
@@ -592,11 +512,6 @@
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>10</pointsize>
-             </font>
             </property>
             <property name="frameShape">
              <enum>QFrame::NoFrame</enum>
@@ -620,11 +535,6 @@
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="font">
-             <font>
-              <pointsize>10</pointsize>
-             </font>
-            </property>
             <property name="frameShape">
              <enum>QFrame::NoFrame</enum>
             </property>
@@ -647,11 +557,6 @@
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="font">
-             <font>
-              <pointsize>10</pointsize>
-             </font>
-            </property>
             <property name="text">
              <string>Date:</string>
             </property>
@@ -664,11 +569,6 @@
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>10</pointsize>
-             </font>
             </property>
             <property name="text">
              <string>Comment:</string>
@@ -695,11 +595,6 @@
               <height>0</height>
              </size>
             </property>
-            <property name="font">
-             <font>
-              <pointsize>10</pointsize>
-             </font>
-            </property>
             <property name="frameShape">
              <enum>QFrame::NoFrame</enum>
             </property>
@@ -717,8 +612,8 @@
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>454</width>
-               <height>147</height>
+               <width>445</width>
+               <height>120</height>
               </rect>
              </property>
              <property name="sizePolicy">
@@ -766,11 +661,6 @@
                   <height>0</height>
                  </size>
                 </property>
-                <property name="font">
-                 <font>
-                  <pointsize>10</pointsize>
-                 </font>
-                </property>
                 <property name="text">
                  <string/>
                 </property>
@@ -812,11 +702,6 @@
         <width>300</width>
         <height>0</height>
        </size>
-      </property>
-      <property name="font">
-       <font>
-        <pointsize>10</pointsize>
-       </font>
       </property>
       <property name="contextMenuPolicy">
        <enum>Qt::CustomContextMenu</enum>
@@ -868,13 +753,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="lblMetaLoading">
-       <property name="font">
-        <font>
-         <pointsize>10</pointsize>
-        </font>
-       </property>
-      </widget>
+      <widget class="QLabel" name="lblMetaLoading"/>
      </item>
      <item>
       <widget class="QDialogButtonBox" name="buttonBox">
@@ -883,11 +762,6 @@
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
-       </property>
-       <property name="font">
-        <font>
-         <pointsize>10</pointsize>
-        </font>
        </property>
        <property name="standardButtons">
         <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>

--- a/src/gui/checkboxwordwrap.cpp
+++ b/src/gui/checkboxwordwrap.cpp
@@ -1,0 +1,95 @@
+#include "checkboxwordwrap.h"
+
+CheckBoxWordWrap::CheckBoxWordWrap(QWidget *parent)
+    : QWidget(parent)
+    , m_hMainLayout(new QHBoxLayout(this))
+    , m_checkBox(new QCheckBox(this))
+    , m_label(new ClickableLabel(this))
+{
+    init();
+}
+
+CheckBoxWordWrap::CheckBoxWordWrap(const QString &text, QWidget *parent)
+    : QWidget(parent)
+    , m_hMainLayout(new QHBoxLayout(this))
+    , m_checkBox(new QCheckBox(this))
+    , m_label(new ClickableLabel(text, this))
+{
+    init();
+}
+
+CheckBoxWordWrap::~CheckBoxWordWrap()
+{
+    delete m_label;
+    delete m_checkBox;
+    delete m_hMainLayout;
+}
+
+bool CheckBoxWordWrap::isChecked() const
+{
+    return m_checkBox->isChecked();
+}
+
+bool CheckBoxWordWrap::isWordWrap() const
+{
+    return m_label->wordWrap();
+}
+
+void CheckBoxWordWrap::setWordWrap(bool wordwrap)
+{
+    m_label->setWordWrap(wordwrap);
+}
+
+QString CheckBoxWordWrap::text() const
+{
+    return m_label->text();
+}
+
+void CheckBoxWordWrap::setText(const QString &text)
+{
+    m_label->setText(text);
+}
+
+QSize CheckBoxWordWrap::sizeHint() const
+{
+    QFontMetrics fm(m_label->font());
+    QRect bRect = fm.boundingRect(m_label->rect(), int(Qt::AlignLeft | Qt::AlignVCenter | Qt::TextWordWrap), m_label->text());
+    QSize ret = QSize(QWidget::sizeHint().width(), bRect.height());
+    return ret;
+}
+
+void CheckBoxWordWrap::setChecked(bool checked)
+{
+    m_checkBox->setChecked(checked);
+}
+
+void CheckBoxWordWrap::labelIsClicked()
+{
+    m_checkBox->setChecked(!isChecked());
+}
+
+void CheckBoxWordWrap::chIsClicked()
+{
+    emit clicked(isChecked());
+}
+
+void CheckBoxWordWrap::resizeEvent(QResizeEvent *event)
+{
+    QWidget::resizeEvent(event);
+    updateGeometry();
+}
+
+void CheckBoxWordWrap::init()
+{
+    m_hMainLayout->setContentsMargins(0, 0, 0, 0);
+    m_hMainLayout->addWidget(m_checkBox);
+    m_hMainLayout->addWidget(m_label);
+
+    m_checkBox->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
+    m_label->setWordWrap(true);
+
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+    connect(m_label, SIGNAL(clicked()), this, SLOT(labelIsClicked()));
+    connect(m_label, SIGNAL(clicked()), this, SLOT(chIsClicked()));
+    connect(m_checkBox, SIGNAL(clicked()), this, SLOT(chIsClicked()));
+}

--- a/src/gui/checkboxwordwrap.h
+++ b/src/gui/checkboxwordwrap.h
@@ -1,0 +1,50 @@
+#ifndef CHECKBOXWORDWRAP_H
+#define CHECKBOXWORDWRAP_H
+
+#include <QWidget>
+#include <QHBoxLayout>
+#include <QCheckBox>
+
+#include "clickablelabel.h"
+
+class CheckBoxWordWrap : public QWidget
+{
+    Q_OBJECT
+
+    Q_PROPERTY(bool checked READ isChecked WRITE setChecked)
+    Q_PROPERTY(bool wordwrap READ isWordWrap WRITE setWordWrap)
+    Q_PROPERTY(QString text READ text WRITE setText)
+
+public:
+    CheckBoxWordWrap(QWidget *parent = Q_NULLPTR);
+    CheckBoxWordWrap(const QString &text, QWidget *parent = Q_NULLPTR);
+    ~CheckBoxWordWrap();
+    bool isChecked() const;
+    bool isWordWrap() const;
+    void setWordWrap(bool wordwrap);
+    QString text() const;
+    void setText(const QString &text);
+    QSize sizeHint() const override;
+
+signals:
+    void clicked(bool Checked);
+
+public slots:
+    void setChecked(bool checked);
+    void chIsClicked();
+
+private slots:
+    void labelIsClicked();
+
+protected:
+    void resizeEvent(QResizeEvent *event) override;
+
+private:
+    void init();
+    QHBoxLayout     *m_hMainLayout;
+    QCheckBox       *m_checkBox;
+    ClickableLabel  *m_label;
+
+};
+
+#endif

--- a/src/gui/clickablelabel.cpp
+++ b/src/gui/clickablelabel.cpp
@@ -1,0 +1,24 @@
+#include "clickablelabel.h"
+
+ClickableLabel::ClickableLabel(QWidget *parent, Qt::WindowFlags f)
+    : QLabel(parent, f)
+{
+
+}
+
+ClickableLabel::ClickableLabel(const QString &text, QWidget *parent, Qt::WindowFlags f)
+    : QLabel(text, parent, f)
+{
+
+}
+
+ClickableLabel::~ClickableLabel()
+{
+
+}
+
+void ClickableLabel::mouseReleaseEvent(QMouseEvent *event)
+{
+    Q_UNUSED(event);
+    emit clicked();
+}

--- a/src/gui/clickablelabel.h
+++ b/src/gui/clickablelabel.h
@@ -1,0 +1,27 @@
+#ifndef CLICKABLELABEL_H
+#define CLICKABLELABEL_H
+
+#include <QLabel>
+#include <QMouseEvent>
+
+/**
+ * @brief The ClickableLabel class
+ * https://wiki.qt.io/Clickable_QLabel
+ */
+class ClickableLabel : public QLabel
+{
+    Q_OBJECT
+public:
+    explicit ClickableLabel(QWidget *parent = Q_NULLPTR, Qt::WindowFlags f = Qt::WindowFlags());
+    explicit ClickableLabel(const QString &text, QWidget *parent = Q_NULLPTR, Qt::WindowFlags f = Qt::WindowFlags());
+    ~ClickableLabel() override;
+
+signals:
+    void clicked();
+
+protected:
+    void mouseReleaseEvent(QMouseEvent *event) override;
+
+};
+
+#endif // CLICKABLELABEL_H

--- a/src/gui/gui.pri
+++ b/src/gui/gui.pri
@@ -13,6 +13,8 @@ HEADERS += \
     $$PWD/banlistoptionsdialog.h \
     $$PWD/categoryfiltermodel.h \
     $$PWD/categoryfilterproxymodel.h \
+    $$PWD/clickablelabel.h \
+    $$PWD/checkboxwordwrap.h \
     $$PWD/categoryfilterwidget.h \
     $$PWD/cookiesdialog.h \
     $$PWD/cookiesmodel.h \
@@ -73,6 +75,8 @@ SOURCES += \
     $$PWD/categoryfiltermodel.cpp \
     $$PWD/categoryfilterproxymodel.cpp \
     $$PWD/categoryfilterwidget.cpp \
+    $$PWD/clickablelabel.cpp \
+    $$PWD/checkboxwordwrap.cpp \
     $$PWD/cookiesdialog.cpp \
     $$PWD/cookiesmodel.cpp \
     $$PWD/downloadfromurldialog.cpp \


### PR DESCRIPTION
#9359 
like μTorrent style [qBittorrent x64 win](https://yadi.sk/d/EmP2O6B_jVlRUg) | [fedora rpm x64]() | [fedora src-rpm x64]()
UPD:
[fedora rpm x64](https://yadi.sk/d/2V6xiPIK5Mnj0g) | [fedora src-rpm x64](https://yadi.sk/d/DIGRX-FEVxsh8Q) | [qBittorrent x64 win](https://yadi.sk/d/EmP2O6B_jVlRUg)
UI in Fedora 28 Gnome:
![2018-09-23 14-10-35](https://user-images.githubusercontent.com/2264893/45925273-5a603e80-bf3c-11e8-9741-fed091cde8f4.png)
![2018-09-23 14-11-23](https://user-images.githubusercontent.com/2264893/45925274-5a603e80-bf3c-11e8-8037-85ca06657ea5.png)
