### PR TITLE
[WIP] Patch torrent resume parameters

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -392,7 +392,7 @@ Session::Session(QObject *parent)
                     | libt::alert::tracker_notification
                     | libt::alert::status_notification
                     | libt::alert::ip_block_notification
-                    | libt::alert::progress_notification
+                    | libt::alert::file_progress_notification
                     | libt::alert::stats_notification;
 
 #if LIBTORRENT_VERSION_NUM < 10100


### PR DESCRIPTION
Now that [<https://github.com/arvidn/libtorrent/pull/3301>] is officially merged into Libtorrent's `RC_1_1` branch (which qBittorrent uses for official releases), it is probably reasonable to begin optimizing `progress_notification` alerts. 

Currently, this is just a copy of a patch by @sledgehammer999, from [<https://github.com/qbittorrent/qBittorrent/issues/9547#issuecomment-423763612>].  

The patch lacks any kind of version handling, so it is not yet ready for merging. 

Feel free to make changes to this PR.  I am not personally invested in it.  