### PR TITLE
Use a more detailed alert mask where possible

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -392,7 +392,11 @@ Session::Session(QObject *parent)
                     | libt::alert::tracker_notification
                     | libt::alert::status_notification
                     | libt::alert::ip_block_notification
+#if LIBTORRENT_VERSION_NUM < 10110
                     | libt::alert::progress_notification
+#else
+                    | libt::alert::file_progress_notification
+#endif
                     | libt::alert::stats_notification;
 
 #if LIBTORRENT_VERSION_NUM < 10100


### PR DESCRIPTION
Closes #9547 

It helps with not dealing with a ton of unwanted `piece_finished_alert`.