### PR TITLE
Fix TravisCI cmake build on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: cpp
 os:
   - linux
   - osx
-osx_image: xcode7.3
 
 env:
   matrix:
@@ -121,40 +120,16 @@ install:
       # dependencies
       brew update > /dev/null
       brew outdated "pkg-config" || brew upgrade "pkg-config"
-      brew install colormake ccache zlib qt
+      brew install colormake ccache zlib qt libtorrent-rasterbar
       PATH="/usr/local/opt/ccache/libexec:$PATH"
       brew link --force zlib qt
-
-      wget https://builds.shiki.hu/homebrew/version
-      if ! cmp --quiet "version" "$HOME/hombebrew_cache/version" ; then
-        echo "Cached files are different from server. Downloading new ones."
-        # First delete old files
-        rm -r "$HOME/hombebrew_cache"
-        mkdir "$HOME/hombebrew_cache"
-        cp "version" $HOME/hombebrew_cache
-        cd "$HOME/hombebrew_cache"
-        wget https://builds.shiki.hu/homebrew/libtorrent-rasterbar.rb
-        wget https://builds.shiki.hu/homebrew/5146d2df7e48f321511273fb9829ebdc3a6dc519f9ef36a344a343ae524c3ae6--libtorrent-rasterbar-1.1.9+git20180812.0bcf6cef23+patched-configure.el_capitan.bottle.tar.gz
-      fi
-
-      # Copy custom libtorrent bottle to homebrew's download cache so it can find and install it
-      # Also install our custom libtorrent formula by passing the local path to it
-      # These 2 files are restored from Travis' cache.
-      cp "$HOME/hombebrew_cache/5146d2df7e48f321511273fb9829ebdc3a6dc519f9ef36a344a343ae524c3ae6--libtorrent-rasterbar-1.1.9+git20180812.0bcf6cef23+patched-configure.el_capitan.bottle.tar.gz" "$(brew --cache)/downloads"
-      brew install "$HOME/hombebrew_cache/libtorrent-rasterbar.rb"
-      
-      # NOTE about the bottle name
-      # The part before the "--" characters is a sha256 hash of the string
-      # of the URL homebrew itself would use to download the bottle.
-      # In this case the URL is the following:
-      # http://127.0.0.1/libtorrent-rasterbar-1.1.9+git20180812.0bcf6cef23+patched-configure.el_capitan.bottle.tar.gz
 
       if [ "$build_system" = "cmake" ]; then
         brew outdated cmake || brew upgrade cmake
         brew install ninja
 
-        ln -s /usr/local/opt/qt/mkspecs /usr/local/mkspecs
-        ln -s /usr/local/opt/qt/plugins /usr/local/plugins
+        sudo ln -s /usr/local/opt/qt/mkspecs /usr/local/mkspecs
+        sudo ln -s /usr/local/opt/qt/plugins /usr/local/plugins
       fi
 
       MY_CMAKE_OPENSSL_HINT="-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl/"


### PR DESCRIPTION
Instead of hard coding a macOS version to use, now we follow TravisCI default version, currently: xcode9.4.
