### PR TITLE
Fix WebUI Auto TMM context menu bug

### DIFF
--- a/src/webui/www/private/scripts/contextmenu.js
+++ b/src/webui/www/private/scripts/contextmenu.js
@@ -345,10 +345,13 @@ var TorrentsTableContextMenu = new Class({
         else if (!there_are_paused && !there_are_force_start)
             this.hideItem('Start');
 
-        if (!all_are_auto_tmm && there_are_auto_tmm)
+        if (!all_are_auto_tmm && there_are_auto_tmm) {
             this.hideItem('AutoTorrentManagement');
-        else
+        }
+        else {
+            this.showItem('AutoTorrentManagement');
             this.setItemChecked('AutoTorrentManagement', all_are_auto_tmm);
+        }
 
     },
 


### PR DESCRIPTION
When multiple torrents are selected with different Auto TMM values, the Auto TMM context menu option is hidden. This option is never unhidden, requiring a refresh of the page.