### PR TITLE
Add missing Preferences to WebUI

### DIFF
--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -1250,6 +1250,10 @@ void OptionsDialog::on_buttonBox_accepted()
             m_ui->tabSelection->setCurrentRow(TAB_WEBUI);
             return;
         }
+        if (!isAlternativeWebUIPathValid()) {
+            m_ui->tabSelection->setCurrentRow(TAB_WEBUI);
+            return;
+        }
         m_applyButton->setEnabled(false);
         this->hide();
         saveOptions();
@@ -1266,6 +1270,10 @@ void OptionsDialog::applySettings(QAbstractButton *button)
             return;
         }
         if (!webUIAuthenticationOk()) {
+            m_ui->tabSelection->setCurrentRow(TAB_WEBUI);
+            return;
+        }
+        if (!isAlternativeWebUIPathValid()) {
             m_ui->tabSelection->setCurrentRow(TAB_WEBUI);
             return;
         }
@@ -1746,6 +1754,15 @@ bool OptionsDialog::webUIAuthenticationOk()
     }
     if (!webUiPassword().isEmpty() && (webUiPassword().length() < 6)) {
         QMessageBox::warning(this, tr("Length Error"), tr("The Web UI password must be at least 6 characters long."));
+        return false;
+    }
+    return true;
+}
+
+bool OptionsDialog::isAlternativeWebUIPathValid()
+{
+    if (m_ui->groupAltWebUI->isChecked() && m_ui->textWebUIRootFolder->selectedPath().trimmed().isEmpty()) {
+        QMessageBox::warning(this, tr("Location Error"), tr("The alternative Web UI files location cannot be blank."));
         return false;
     }
     return true;

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -172,6 +172,7 @@ private:
     bool setSslCertificate(const QByteArray &cert);
     bool schedTimesOk();
     bool webUIAuthenticationOk();
+    bool isAlternativeWebUIPathValid();
 
     QByteArray m_sslCert, m_sslKey;
 

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -941,7 +941,7 @@
                  <item row="3" column="0">
                   <widget class="QLabel" name="labelCategoryChanged">
                    <property name="text">
-                    <string>When Category changed:</string>
+                    <string>When Category Save Path changed:</string>
                    </property>
                   </widget>
                  </item>

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -217,6 +217,9 @@ void AppController::preferencesAction()
     for (const Utils::Net::Subnet &subnet : asConst(pref->getWebUiAuthSubnetWhitelist()))
         authSubnetWhitelistStringList << Utils::Net::subnetToString(subnet);
     data["bypass_auth_subnet_whitelist"] = authSubnetWhitelistStringList.join("\n");
+    // Use alternative Web UI
+    data["alternative_webui_enabled"] = pref->isAltWebUiEnabled();
+    data["alternative_webui_path"] = pref->getWebUiRootFolder();
     // Security
     data["web_ui_clickjacking_protection_enabled"] = pref->isWebUiClickjackingProtectionEnabled();
     data["web_ui_csrf_protection_enabled"] = pref->isWebUiCSRFProtectionEnabled();
@@ -518,6 +521,11 @@ void AppController::setPreferencesAction()
         // recognize new lines and commas as delimiters
         pref->setWebUiAuthSubnetWhitelist(m["bypass_auth_subnet_whitelist"].toString().split(QRegularExpression("\n|,"), QString::SkipEmptyParts));
     }
+    // Use alternative Web UI
+    if ((it = m.find(QLatin1String("alternative_webui_enabled"))) != m.constEnd())
+        pref->setAltWebUiEnabled(it.value().toBool());
+    if ((it = m.find(QLatin1String("alternative_webui_path"))) != m.constEnd())
+        pref->setWebUiRootFolder(it.value().toString());
     // Security
     if (m.contains("web_ui_clickjacking_protection_enabled"))
         pref->setWebUiClickjackingProtectionEnabled(m["web_ui_clickjacking_protection_enabled"].toBool());

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -113,6 +113,7 @@ void AppController::preferencesAction()
     data["scan_dirs"] = nativeDirs;
     // Email notification upon download completion
     data["mail_notification_enabled"] = pref->isMailNotificationEnabled();
+    data["mail_notification_sender"] = pref->getMailNotificationSender();
     data["mail_notification_email"] = pref->getMailNotificationEmail();
     data["mail_notification_smtp"] = pref->getMailNotificationSMTP();
     data["mail_notification_ssl_enabled"] = pref->getMailNotificationSMTPSSL();
@@ -324,6 +325,8 @@ void AppController::setPreferencesAction()
     // Email notification upon download completion
     if (m.contains("mail_notification_enabled"))
         pref->setMailNotificationEnabled(m["mail_notification_enabled"].toBool());
+    if ((it = m.find(QLatin1String("mail_notification_sender"))) != m.constEnd())
+        pref->setMailNotificationSender(it.value().toString());
     if (m.contains("mail_notification_email"))
         pref->setMailNotificationEmail(m["mail_notification_email"].toString());
     if (m.contains("mail_notification_smtp"))

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -87,6 +87,10 @@ void AppController::preferencesAction()
     data["preallocate_all"] = session->isPreallocationEnabled();
     data["incomplete_files_ext"] = session->isAppendExtensionEnabled();
     // Saving Management
+    data["auto_tmm_enabled"] = !session->isAutoTMMDisabledByDefault();
+    data["torrent_changed_tmm_enabled"] = !session->isDisableAutoTMMWhenCategoryChanged();
+    data["save_path_changed_tmm_enabled"] = !session->isDisableAutoTMMWhenDefaultSavePathChanged();
+    data["category_changed_tmm_enabled"] = !session->isDisableAutoTMMWhenCategorySavePathChanged();
     data["save_path"] = Utils::Fs::toNativePath(session->defaultSavePath());
     data["temp_path_enabled"] = session->isTempPathEnabled();
     data["temp_path"] = Utils::Fs::toNativePath(session->tempPath());
@@ -242,6 +246,14 @@ void AppController::setPreferencesAction()
         session->setAppendExtensionEnabled(it.value().toBool());
 
     // Saving Management
+    if ((it = m.find(QLatin1String("auto_tmm_enabled"))) != m.constEnd())
+        session->setAutoTMMDisabledByDefault(!it.value().toBool());
+    if ((it = m.find(QLatin1String("torrent_changed_tmm_enabled"))) != m.constEnd())
+        session->setDisableAutoTMMWhenCategoryChanged(!it.value().toBool());
+    if ((it = m.find(QLatin1String("save_path_changed_tmm_enabled"))) != m.constEnd())
+        session->setDisableAutoTMMWhenDefaultSavePathChanged(!it.value().toBool());
+    if ((it = m.find(QLatin1String("category_changed_tmm_enabled"))) != m.constEnd())
+        session->setDisableAutoTMMWhenCategorySavePathChanged(!it.value().toBool());
     if (m.contains("save_path"))
         session->setDefaultSavePath(m["save_path"].toString());
     if (m.contains("temp_path_enabled"))

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -164,6 +164,7 @@ void AppController::preferencesAction()
     data["bittorrent_protocol"] = static_cast<int>(session->btProtocol());
     data["limit_utp_rate"] = session->isUTPRateLimited();
     data["limit_tcp_overhead"] = session->includeOverheadInLimits();
+    data["limit_lan_peers"] = !session->ignoreLimitsOnLAN();
     // Scheduling
     data["scheduler_enabled"] = session->isBandwidthSchedulerEnabled();
     const QTime start_time = pref->getSchedulerStartTime();
@@ -411,6 +412,8 @@ void AppController::setPreferencesAction()
         session->setUTPRateLimited(m["limit_utp_rate"].toBool());
     if (m.contains("limit_tcp_overhead"))
         session->setIncludeOverheadInLimits(m["limit_tcp_overhead"].toBool());
+    if ((it = m.find(QLatin1String("limit_lan_peers"))) != m.constEnd())
+        session->setIgnoreLimitsOnLAN(!it.value().toBool());
     // Scheduling
     if (m.contains("scheduler_enabled"))
         session->setBandwidthSchedulerEnabled(m["scheduler_enabled"].toBool());

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -188,6 +188,9 @@ void AppController::preferencesAction()
     data["max_active_torrents"] = session->maxActiveTorrents();
     data["max_active_uploads"] = session->maxActiveUploads();
     data["dont_count_slow_torrents"] = session->ignoreSlowTorrentsForQueueing();
+    data["slow_torrent_dl_rate_threshold"] = session->downloadRateForSlowTorrents();
+    data["slow_torrent_ul_rate_threshold"] = session->uploadRateForSlowTorrents();
+    data["slow_torrent_inactive_timer"] = session->slowTorrentsInactivityTimer();
     // Share Ratio Limiting
     data["max_ratio_enabled"] = (session->globalMaxRatio() >= 0.);
     data["max_ratio"] = session->globalMaxRatio();
@@ -450,6 +453,12 @@ void AppController::setPreferencesAction()
         session->setMaxActiveUploads(m["max_active_uploads"].toInt());
     if (m.contains("dont_count_slow_torrents"))
         session->setIgnoreSlowTorrentsForQueueing(m["dont_count_slow_torrents"].toBool());
+    if ((it = m.find(QLatin1String("slow_torrent_dl_rate_threshold"))) != m.constEnd())
+        session->setDownloadRateForSlowTorrents(it.value().toInt());
+    if ((it = m.find(QLatin1String("slow_torrent_ul_rate_threshold"))) != m.constEnd())
+        session->setUploadRateForSlowTorrents(it.value().toInt());
+    if ((it = m.find(QLatin1String("slow_torrent_inactive_timer"))) != m.constEnd())
+        session->setSlowTorrentsInactivityTimer(it.value().toInt());
     // Share Ratio Limiting
     if (m.contains("max_ratio_enabled")) {
         if (m["max_ratio_enabled"].toBool())

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -52,6 +52,7 @@
 #include "base/rss/rss_autodownloader.h"
 #include "base/rss/rss_session.h"
 #include "base/scanfoldersmodel.h"
+#include "base/torrentfileguard.h"
 #include "base/utils/fs.h"
 #include "base/utils/net.h"
 #include "base/utils/password.h"
@@ -84,6 +85,10 @@ void AppController::preferencesAction()
     QVariantMap data;
 
     // Downloads
+    // When adding a torrent
+    data["create_subfolder_enabled"] = session->isCreateTorrentSubfolder();
+    data["start_paused_enabled"] = session->isAddTorrentPaused();
+    data["auto_delete_mode"] = static_cast<int>(TorrentFileGuard::autoDeleteMode());
     data["preallocate_all"] = session->isPreallocationEnabled();
     data["incomplete_files_ext"] = session->isAppendExtensionEnabled();
     // Saving Management
@@ -240,6 +245,14 @@ void AppController::setPreferencesAction()
     QVariantMap::ConstIterator it;
 
     // Downloads
+    // When adding a torrent
+    if ((it = m.find(QLatin1String("create_subfolder_enabled"))) != m.constEnd())
+        session->setCreateTorrentSubfolder(it.value().toBool());
+    if ((it = m.find(QLatin1String("start_paused_enabled"))) != m.constEnd())
+        session->setAddTorrentPaused(it.value().toBool());
+    if ((it = m.find(QLatin1String("auto_delete_mode"))) != m.constEnd())
+        TorrentFileGuard::setAutoDeleteMode(static_cast<TorrentFileGuard::AutoDeleteMode>(it.value().toInt()));
+
     if ((it = m.find(QLatin1String("preallocate_all"))) != m.constEnd())
         session->setPreallocationEnabled(it.value().toBool());
     if ((it = m.find(QLatin1String("incomplete_files_ext"))) != m.constEnd())

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -84,12 +84,15 @@ void AppController::preferencesAction()
     QVariantMap data;
 
     // Downloads
-    // Hard Disk
+    data["preallocate_all"] = session->isPreallocationEnabled();
+    data["incomplete_files_ext"] = session->isAppendExtensionEnabled();
+    // Saving Management
     data["save_path"] = Utils::Fs::toNativePath(session->defaultSavePath());
     data["temp_path_enabled"] = session->isTempPathEnabled();
     data["temp_path"] = Utils::Fs::toNativePath(session->tempPath());
-    data["preallocate_all"] = session->isPreallocationEnabled();
-    data["incomplete_files_ext"] = session->isAppendExtensionEnabled();
+    data["export_dir"] = Utils::Fs::toNativePath(session->torrentExportDirectory());
+    data["export_dir_fin"] = Utils::Fs::toNativePath(session->finishedTorrentExportDirectory());
+    // Automatically add torrents from
     const QVariantHash dirs = pref->getScanDirs();
     QVariantMap nativeDirs;
     for (QVariantHash::const_iterator i = dirs.cbegin(), e = dirs.cend(); i != e; ++i) {
@@ -99,8 +102,6 @@ void AppController::preferencesAction()
             nativeDirs.insert(Utils::Fs::toNativePath(i.key()), Utils::Fs::toNativePath(i.value().toString()));
     }
     data["scan_dirs"] = nativeDirs;
-    data["export_dir"] = Utils::Fs::toNativePath(session->torrentExportDirectory());
-    data["export_dir_fin"] = Utils::Fs::toNativePath(session->finishedTorrentExportDirectory());
     // Email notification upon download completion
     data["mail_notification_enabled"] = pref->isMailNotificationEnabled();
     data["mail_notification_email"] = pref->getMailNotificationEmail();
@@ -232,19 +233,26 @@ void AppController::setPreferencesAction()
     Preferences *const pref = Preferences::instance();
     auto session = BitTorrent::Session::instance();
     const QVariantMap m = QJsonDocument::fromJson(params()["json"].toUtf8()).toVariant().toMap();
+    QVariantMap::ConstIterator it;
 
     // Downloads
-    // Hard Disk
+    if ((it = m.find(QLatin1String("preallocate_all"))) != m.constEnd())
+        session->setPreallocationEnabled(it.value().toBool());
+    if ((it = m.find(QLatin1String("incomplete_files_ext"))) != m.constEnd())
+        session->setAppendExtensionEnabled(it.value().toBool());
+
+    // Saving Management
     if (m.contains("save_path"))
         session->setDefaultSavePath(m["save_path"].toString());
     if (m.contains("temp_path_enabled"))
         session->setTempPathEnabled(m["temp_path_enabled"].toBool());
     if (m.contains("temp_path"))
         session->setTempPath(m["temp_path"].toString());
-    if (m.contains("preallocate_all"))
-        session->setPreallocationEnabled(m["preallocate_all"].toBool());
-    if (m.contains("incomplete_files_ext"))
-        session->setAppendExtensionEnabled(m["incomplete_files_ext"].toBool());
+    if ((it = m.find(QLatin1String("export_dir"))) != m.constEnd())
+        session->setTorrentExportDirectory(it.value().toString());
+    if ((it = m.find(QLatin1String("export_dir_fin"))) != m.constEnd())
+        session->setFinishedTorrentExportDirectory(it.value().toString());
+    // Automatically add torrents from
     if (m.contains("scan_dirs")) {
         const QVariantMap nativeDirs = m["scan_dirs"].toMap();
         QVariantHash oldScanDirs = pref->getScanDirs();
@@ -288,10 +296,6 @@ void AppController::setPreferencesAction()
         }
         pref->setScanDirs(scanDirs);
     }
-    if (m.contains("export_dir"))
-        session->setTorrentExportDirectory(m["export_dir"].toString());
-    if (m.contains("export_dir_fin"))
-        session->setFinishedTorrentExportDirectory(m["export_dir_fin"].toString());
     // Email notification upon download completion
     if (m.contains("mail_notification_enabled"))
         pref->setMailNotificationEnabled(m["mail_notification_enabled"].toBool());
@@ -505,7 +509,6 @@ void AppController::setPreferencesAction()
     // Save preferences
     pref->apply();
 
-    QVariantMap::ConstIterator it;
     if ((it = m.find(QLatin1String("rss_refresh_interval"))) != m.constEnd())
         RSS::Session::instance()->setRefreshInterval(it.value().toUInt());
     if ((it = m.find(QLatin1String("rss_max_articles_per_feed"))) != m.constEnd())

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -469,6 +469,7 @@ void TorrentsController::addAction()
     const QString torrentName = params()["rename"].trimmed();
     const int upLimit = params()["upLimit"].toInt();
     const int dlLimit = params()["dlLimit"].toInt();
+    const TriStateBool autoTMM = parseTriStateBool(params()["autoTMM"]);
 
     QList<QNetworkCookie> cookies;
     if (!cookie.isEmpty()) {
@@ -496,6 +497,7 @@ void TorrentsController::addAction()
     params.name = torrentName;
     params.uploadLimit = (upLimit > 0) ? upLimit : -1;
     params.downloadLimit = (dlLimit > 0) ? dlLimit : -1;
+    params.useAutoTMM = autoTMM;
 
     bool partialSuccess = false;
     for (QString url : asConst(urls.split('\n'))) {

--- a/src/webui/www/private/css/style.css
+++ b/src/webui/www/private/css/style.css
@@ -375,6 +375,10 @@ fieldset.settings label {
     padding: 2px;
 }
 
+fieldset.settings + div.formRow {
+    margin-top: 10px;
+}
+
 div.formRow {
     clear: left;
     display: block;

--- a/src/webui/www/private/css/style.css
+++ b/src/webui/www/private/css/style.css
@@ -375,30 +375,6 @@ fieldset.settings label {
     padding: 2px;
 }
 
-fieldset.settings .leftLabelSmall {
-    width: 5em;
-    float: left;
-    text-align: right;
-    margin-right: 0.5em;
-    display: block;
-}
-
-fieldset.settings .leftLabelMedium {
-    width: 9em;
-    float: left;
-    text-align: right;
-    margin-right: 0.5em;
-    display: block;
-}
-
-fieldset.settings .leftLabelLarge {
-    width: 14em;
-    float: left;
-    text-align: right;
-    margin-right: 0.5em;
-    display: block;
-}
-
 div.formRow {
     clear: left;
     display: block;

--- a/src/webui/www/private/download.html
+++ b/src/webui/www/private/download.html
@@ -22,6 +22,17 @@
                 <table style="margin: auto;">
                     <tr>
                         <td>
+                            <label for="autoTMM">QBT_TR(Torrent Management Mode:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                        </td>
+                        <td>
+                            <select id="autoTMM" name="autoTMM" onchange="changeTMM(this)">
+                                <option selected value="false">Manual</option>
+                                <option value="true">Automatic</option>
+                            </select>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
                             <label for="savepath">QBT_TR(Save files to location:)QBT_TR[CONTEXT=HttpServer]</label>
                         </td>
                         <td>

--- a/src/webui/www/private/download.html
+++ b/src/webui/www/private/download.html
@@ -18,52 +18,98 @@
             <h2 class="vcenter">QBT_TR(Download Torrents from their URLs or Magnet links)QBT_TR[CONTEXT=HttpServer]</h2>
             <textarea id="urls" rows="10" name="urls"></textarea>
             <p>QBT_TR(Only one link per line)QBT_TR[CONTEXT=HttpServer]</p>
-            <fieldset class="settings" style="border: 0; text-align: left;">
-                <div class="formRow" style="margin-top: 6px;">
-                    <label for="savepath" class="leftLabelLarge">QBT_TR(Save files to location:)QBT_TR[CONTEXT=HttpServer]</label>
-                    <input type="text" id="savepath" name="savepath" style="width: 16em;" />
-                </div>
-                <div class="formRow">
-                    <label for="cookie" class="leftLabelLarge">QBT_TR(Cookie:)QBT_TR[CONTEXT=HttpServer]</label>
-                    <input type="text" id="cookie" name="cookie" style="width: 16em;" />
-                </div>
-                <div class="formRow">
-                    <label for="rename" class="leftLabelLarge">QBT_TR(Rename torrent)QBT_TR[CONTEXT=HttpServer]</label>
-                    <input type="text" id="rename" name="rename" style="width: 16em;" />
-                </div>
-                <div class="formRow">
-                    <label for="category" class="leftLabelLarge">QBT_TR(Category:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
-                    <input type="text" id="category" name="category" style="width: 16em;" />
-                </div>
-                <div class="formRow">
-                    <label for="start_torrent" class="leftLabelLarge">QBT_TR(Start torrent)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
-                    <input type="checkbox" id="start_torrent" checked="checked" />
-                    <input type="hidden" id="add_paused" name="paused" value="false" readonly />
-                </div>
-                <div class="formRow">
-                    <label for="skip_checking" class="leftLabelLarge">QBT_TR(Skip hash check)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
-                    <input type="checkbox" id="skip_checking" name="skip_checking" value="true" />
-                </div>
-                <div class="formRow">
-                    <label for="root_folder" class="leftLabelLarge">QBT_TR(Create subfolder)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
-                    <input type="checkbox" id="root_folder" name="root_folder" value="true" checked="checked" />
-                </div>
-                <div class="formRow">
-                    <label for="sequentialDownload" class="leftLabelLarge">QBT_TR(Download in sequential order)QBT_TR[CONTEXT=TransferListWidget]</label>
-                    <input type="checkbox" id="sequentialDownload" name="sequentialDownload" value="true" />
-                </div>
-                <div class="formRow">
-                    <label for="firstLastPiecePrio" class="leftLabelLarge">QBT_TR(Download first and last pieces first)QBT_TR[CONTEXT=TransferListWidget]</label>
-                    <input type="checkbox" id="firstLastPiecePrio" name="firstLastPiecePrio" value="true" />
-                </div>
-                <div class="formRow">
-                    <label for="dlLimit" class="leftLabelLarge">QBT_TR(Limit download rate)QBT_TR[CONTEXT=HttpServer]</label>
-                    <input type="text" id="dlLimit" name="dlLimit" style="width: 16em;" placeholder="Bytes/s" />
-                </div>
-                <div class="formRow">
-                    <label for="upLimit" class="leftLabelLarge">QBT_TR(Limit upload rate)QBT_TR[CONTEXT=HttpServer]</label>
-                    <input type="text" id="upLimit" name="upLimit" style="width: 16em;" placeholder="Bytes/s" />
-                </div>
+            <fieldset class="settings" style="border: 0; text-align: left; margin-top: 6px;">
+                <table style="margin: auto;">
+                    <tr>
+                        <td>
+                            <label for="savepath">QBT_TR(Save files to location:)QBT_TR[CONTEXT=HttpServer]</label>
+                        </td>
+                        <td>
+                            <input type="text" id="savepath" name="savepath" style="width: 16em;" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <label for="cookie">QBT_TR(Cookie:)QBT_TR[CONTEXT=HttpServer]</label>
+                        </td>
+                        <td>
+                            <input type="text" id="cookie" name="cookie" style="width: 16em;" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <label for="rename">QBT_TR(Rename torrent)QBT_TR[CONTEXT=HttpServer]</label>
+                        </td>
+                        <td>
+                            <input type="text" id="rename" name="rename" style="width: 16em;" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <label for="category">QBT_TR(Category:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                        </td>
+                        <td>
+                            <input type="text" id="category" name="category" style="width: 16em;" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <label for="start_torrent">QBT_TR(Start torrent)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                        </td>
+                        <td>
+                            <input type="checkbox" id="start_torrent" checked="checked" />
+                            <input type="hidden" id="add_paused" name="paused" value="false" readonly />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <label for="skip_checking">QBT_TR(Skip hash check)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                        </td>
+                        <td>
+                            <input type="checkbox" id="skip_checking" name="skip_checking" value="true" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <label for="root_folder">QBT_TR(Create subfolder)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                        </td>
+                        <td>
+                            <input type="checkbox" id="root_folder" name="root_folder" value="true" checked="checked" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <label for="sequentialDownload">QBT_TR(Download in sequential order)QBT_TR[CONTEXT=TransferListWidget]</label>
+                        </td>
+                        <td>
+                            <input type="checkbox" id="sequentialDownload" name="sequentialDownload" value="true" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <label for="firstLastPiecePrio">QBT_TR(Download first and last pieces first)QBT_TR[CONTEXT=TransferListWidget]</label>
+                        </td>
+                        <td>
+                            <input type="checkbox" id="firstLastPiecePrio" name="firstLastPiecePrio" value="true" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <label for="dlLimit">QBT_TR(Limit download rate)QBT_TR[CONTEXT=HttpServer]</label>
+                        </td>
+                        <td>
+                            <input type="text" id="dlLimit" name="dlLimit" style="width: 16em;" placeholder="Bytes/s" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <label for="upLimit">QBT_TR(Limit upload rate)QBT_TR[CONTEXT=HttpServer]</label>
+                        </td>
+                        <td>
+                            <input type="text" id="upLimit" name="upLimit" style="width: 16em;" placeholder="Bytes/s" />
+                        </td>
+                    </tr>
+                </table>
                 <div id="submitbutton" style="margin-top: 12px; text-align: center;">
                     <button type="submit" id="submitButton">QBT_TR(Download)QBT_TR[CONTEXT=downloadFromURL]</button>
                 </div>

--- a/src/webui/www/private/download.html
+++ b/src/webui/www/private/download.html
@@ -60,7 +60,12 @@
                             <label for="category">QBT_TR(Category:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
                         </td>
                         <td>
-                            <input type="text" id="category" name="category" style="width: 16em;" />
+                            <div class="select-watched-folder-editable">
+                                <select id="categorySelect" onchange="changeCategorySelect(this)">
+                                    <option selected value="\other"></option>
+                                </select>
+                                <input name="category" type="text" value="" />
+                            </div>
                         </td>
                     </tr>
                     <tr>

--- a/src/webui/www/private/preferences_content.html
+++ b/src/webui/www/private/preferences_content.html
@@ -1,4 +1,20 @@
 <div id="DownloadsTab" class="PrefTab">
+    <fieldset class="settings">
+        <legend>QBT_TR(When adding a torrent)QBT_TR[CONTEXT=OptionsDialog]</legend>
+        <div class="formRow">
+            <input type="checkbox" id="createsubfolder_checkbox" />
+            <label for="createsubfolder_checkbox">QBT_TR(Create subfolder for torrents with multiple files)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </div>
+        <div class="formRow">
+            <input type="checkbox" id="dontstartdownloads_checkbox" />
+            <label for="dontstartauto_checkbox">QBT_TR(Do not start the download automatically)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </div>
+        <div class="formRow">
+            <input type="checkbox" id="deletetorrentfileafter_checkbox" />
+            <label for="deletetorrentafter_checkbox">QBT_TR(Delete .torrent files afterwards)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </div>
+    </fieldset>
+
     <div class="formRow">
         <input type="checkbox" id="preallocateall_checkbox" />
         <label for="preallocateall_checkbox">QBT_TR(Pre-allocate disk space for all files)QBT_TR[CONTEXT=OptionsDialog]</label>
@@ -1026,6 +1042,11 @@
             onSuccess: function(pref) {
                 if (pref) {
                     // Downloads tab
+                    // When adding a torrent
+                    $('createsubfolder_checkbox').setProperty('checked', pref.create_subfolder_enabled);
+                    $('dontstartdownloads_checkbox').setProperty('checked', pref.start_paused_enabled);
+                    $('deletetorrentfileafter_checkbox').setProperty('checked', pref.auto_delete_mode);
+
                     $('preallocateall_checkbox').setProperty('checked', pref.preallocate_all);
                     $('appendext_checkbox').setProperty('checked', pref.incomplete_files_ext);
 
@@ -1274,6 +1295,11 @@
         var settings = new Hash();
         // Validate form data
         // Downloads tab
+        // When adding a torrent
+        settings.set('create_subfolder_enabled', $('createsubfolder_checkbox').getProperty('checked'));
+        settings.set('start_paused_enabled', $('dontstartdownloads_checkbox').getProperty('checked'));
+        settings.set('auto_delete_mode', $('deletetorrentfileafter_checkbox').getProperty('checked'));
+
         settings.set('preallocate_all', $('preallocateall_checkbox').getProperty('checked'));
         settings.set('incomplete_files_ext', $('appendext_checkbox').getProperty('checked'));
 

--- a/src/webui/www/private/preferences_content.html
+++ b/src/webui/www/private/preferences_content.html
@@ -1,21 +1,58 @@
 <div id="DownloadsTab" class="PrefTab">
-    <fieldset class="settings">
-        <legend>QBT_TR(Hard Disk)QBT_TR[CONTEXT=HttpServer]</legend>
-        <div class="formRow">
-            <label for="savepath_text">QBT_TR(Save files to location:)QBT_TR[CONTEXT=HttpServer]</label>
-            <input type="text" id="savepath_text" />
-        </div>
-        <div class="formRow">
-            <input type="checkbox" id="temppath_checkbox" onclick="updateTempDirEnabled();" />
-            <label for="temppath_checkbox">QBT_TR(Keep incomplete torrents in:)QBT_TR[CONTEXT=OptionsDialog]</label>
-            <input type="text" id="temppath_text" />
-        </div>
+    <div class="formRow">
         <input type="checkbox" id="preallocateall_checkbox" />
-        <label for="preallocateall_checkbox">QBT_TR(Pre-allocate disk space for all files)QBT_TR[CONTEXT=OptionsDialog]</label><br/>
+        <label for="preallocateall_checkbox">QBT_TR(Pre-allocate disk space for all files)QBT_TR[CONTEXT=OptionsDialog]</label>
+    </div>
+    <div class="formRow">
         <span id="appendexttr">
             <input type="checkbox" id="appendext_checkbox"/>
             <label for="appendext_checkbox">QBT_TR(Append .!qB extension to incomplete files)QBT_TR[CONTEXT=OptionsDialog]</label>
-        </span><br/><br/> QBT_TR(Automatically add torrents from:)QBT_TR[CONTEXT=OptionsDialog]<br/>
+        </span>
+    </div>
+
+    <fieldset class="settings">
+        <legend>QBT_TR(Saving Management)QBT_TR[CONTEXT=HttpServer]</legend>
+        <table>
+            <tr>
+                <td>
+                    <label for="savepath_text">QBT_TR(Default Save Path:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                </td>
+                <td>
+                    <input type="text" id="savepath_text" />
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <input type="checkbox" id="temppath_checkbox" onclick="updateTempDirEnabled();" />
+                    <label for="temppath_checkbox" >QBT_TR(Keep incomplete torrents in:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                </td>
+                <td>
+                    <input type="text" id="temppath_text" />
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <input type="checkbox" id="exportdir_checkbox" onclick="updateExportDirEnabled();" />
+                    <label for="exportdir_checkbox" >QBT_TR(Copy .torrent files to:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                </td>
+                <td>
+                    <input type="text" id="exportdir_text" /><br/>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <input type="checkbox" id="exportdirfin_checkbox" onclick="updateExportDirFinEnabled();" />
+                    <label for="exportdirfin_checkbox" >QBT_TR(Copy .torrent files for finished downloads to:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                </td>
+                <td>
+                    <input type="text" id="exportdirfin_text" /><br/>
+                </td>
+            </tr>
+        </table>
+    </fieldset>
+
+    <fieldset class="settings">
+        <legend>QBT_TR(Automatically add torrents from:)QBT_TR[CONTEXT=OptionsDialog]</legend>
         <table id="watched_folders_tab" style="border: 1px solid black;">
             <thead>
                 <tr>
@@ -40,13 +77,7 @@
                     </td>
                 </tr>
             </tfoot>
-        </table><br/>
-        <input type="checkbox" id="exportdir_checkbox" onclick="updateExportDirEnabled();" />
-        <label for="exportdir_checkbox">QBT_TR(Copy .torrent files to:)QBT_TR[CONTEXT=OptionsDialog]</label>&nbsp;&nbsp;
-        <input type="text" id="exportdir_text" /><br/>
-        <input type="checkbox" id="exportdirfin_checkbox" onclick="updateExportDirFinEnabled();" />
-        <label for="exportdirfin_checkbox">QBT_TR(Copy .torrent files for finished downloads to:)QBT_TR[CONTEXT=OptionsDialog]</label>&nbsp;&nbsp;
-        <input type="text" id="exportdirfin_text" /><br/>
+        </table>
     </fieldset>
 
     <fieldset class="settings">
@@ -767,26 +798,14 @@
             onSuccess: function(pref) {
                 if (pref) {
                     // Downloads tab
-                    // Hard Disk
+                    $('preallocateall_checkbox').setProperty('checked', pref.preallocate_all);
+                    $('appendext_checkbox').setProperty('checked', pref.incomplete_files_ext);
+
+                    // Saving Managmenet
                     $('savepath_text').setProperty('value', pref.save_path);
                     $('temppath_checkbox').setProperty('checked', pref.temp_path_enabled);
                     $('temppath_text').setProperty('value', pref.temp_path);
                     updateTempDirEnabled();
-                    $('preallocateall_checkbox').setProperty('checked', pref.preallocate_all);
-                    $('appendext_checkbox').setProperty('checked', pref.incomplete_files_ext);
-                    var i = 0;
-                    for (var folder in pref.scan_dirs) {
-                        var sel;
-                        var other = "";
-                        if (typeof pref.scan_dirs[folder] == "string") {
-                            other = pref.scan_dirs[folder];
-                            sel = "other";
-                        }
-                        else {
-                            sel = (pref.scan_dirs[folder] == 0) ? "watch_folder" : "default_folder";
-                        }
-                        pushWatchFolder(i++, folder, sel, other);
-                    }
                     if (pref.export_dir != '') {
                         $('exportdir_checkbox').setProperty('checked', true);
                         $('exportdir_text').setProperty('value', pref.export_dir);
@@ -805,6 +824,21 @@
                         $('exportdirfin_text').setProperty('value', '');
                     }
                     updateExportDirFinEnabled();
+
+                    // Automatically add torrents from
+                    var i = 0;
+                    for (var folder in pref.scan_dirs) {
+                        var sel;
+                        var other = "";
+                        if (typeof pref.scan_dirs[folder] == "string") {
+                            other = pref.scan_dirs[folder];
+                            sel = "other";
+                        }
+                        else {
+                            sel = (pref.scan_dirs[folder] == 0) ? "watch_folder" : "default_folder";
+                        }
+                        pushWatchFolder(i++, folder, sel, other);
+                    }
 
                     // Email notification upon download completion
                     $('mail_notification_checkbox').setProperty('checked', pref.mail_notification_enabled);
@@ -1008,13 +1042,13 @@
         var settings = new Hash();
         // Validate form data
         // Downloads tab
-        // Hard Disk
+        settings.set('preallocate_all', $('preallocateall_checkbox').getProperty('checked'));
+        settings.set('incomplete_files_ext', $('appendext_checkbox').getProperty('checked'));
+
+        // Saving Management
         settings.set('save_path', $('savepath_text').getProperty('value'));
         settings.set('temp_path_enabled', $('temppath_checkbox').getProperty('checked'));
         settings.set('temp_path', $('temppath_text').getProperty('value'));
-        settings.set('preallocate_all', $('preallocateall_checkbox').getProperty('checked'));
-        settings.set('incomplete_files_ext', $('appendext_checkbox').getProperty('checked'));
-        settings.set('scan_dirs', getWatchedFolders());
         if ($('exportdir_checkbox').getProperty('checked'))
             settings.set('export_dir', $('exportdir_text').getProperty('value'));
         else
@@ -1023,6 +1057,9 @@
             settings.set('export_dir_fin', $('exportdirfin_text').getProperty('value'));
         else
             settings.set('export_dir_fin', '');
+
+        // Automatically add torrents from
+        settings.set('scan_dirs', getWatchedFolders());
 
         // Email notification upon download completion
         settings.set('mail_notification_enabled', $('mail_notification_checkbox').getProperty('checked'));

--- a/src/webui/www/private/preferences_content.html
+++ b/src/webui/www/private/preferences_content.html
@@ -1667,8 +1667,14 @@
         settings.set('bypass_auth_subnet_whitelist', $('bypass_auth_subnet_whitelist_textarea').getProperty('value'));
 
         // Use alternative Web UI
-        settings.set('alternative_webui_enabled', $('use_alt_webui_checkbox').getProperty('checked'));
-        settings.set('alternative_webui_path', $('webui_files_location_textarea').getProperty('value'));
+        var alternative_webui_enabled = $('use_alt_webui_checkbox').getProperty('checked');
+        var webui_files_location_textarea = $('webui_files_location_textarea').getProperty('value');
+        if (alternative_webui_enabled && (webui_files_location_textarea.trim() === "")) {
+            alert("QBT_TR(The alternative Web UI files location cannot be blank.)QBT_TR[CONTEXT=OptionsDialog]");
+            return;
+        }
+        settings.set('alternative_webui_enabled', alternative_webui_enabled);
+        settings.set('alternative_webui_path', webui_files_location_textarea);
 
         settings.set('web_ui_clickjacking_protection_enabled', $('clickjacking_protection_checkbox').getProperty('checked'));
         settings.set('web_ui_csrf_protection_enabled', $('csrf_protection_checkbox').getProperty('checked'));

--- a/src/webui/www/private/preferences_content.html
+++ b/src/webui/www/private/preferences_content.html
@@ -36,7 +36,7 @@
                     <label for="exportdir_checkbox" >QBT_TR(Copy .torrent files to:)QBT_TR[CONTEXT=OptionsDialog]</label>
                 </td>
                 <td>
-                    <input type="text" id="exportdir_text" /><br/>
+                    <input type="text" id="exportdir_text" />
                 </td>
             </tr>
             <tr>
@@ -45,7 +45,7 @@
                     <label for="exportdirfin_checkbox" >QBT_TR(Copy .torrent files for finished downloads to:)QBT_TR[CONTEXT=OptionsDialog]</label>
                 </td>
                 <td>
-                    <input type="text" id="exportdirfin_text" /><br/>
+                    <input type="text" id="exportdirfin_text" />
                 </td>
             </tr>
         </table>
@@ -81,8 +81,10 @@
     </fieldset>
 
     <fieldset class="settings">
-        <legend><input type="checkbox" id="mail_notification_checkbox" onclick="updateMailNotification();" />
-            <label for="mail_notification_checkbox">QBT_TR(Email notification upon download completion)QBT_TR[CONTEXT=OptionsDialog]</label></legend>
+        <legend>
+            <input type="checkbox" id="mail_notification_checkbox" onclick="updateMailNotification();" />
+            <label for="mail_notification_checkbox">QBT_TR(Email notification upon download completion)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </legend>
         <table>
             <tr>
                 <td>
@@ -105,7 +107,10 @@
             <input type="checkbox" id="mail_ssl_checkbox" /><label for="mail_ssl_checkbox">QBT_TR(This server requires a secure connection (SSL))QBT_TR[CONTEXT=OptionsDialog]</label>
         </div>
         <fieldset class="settings">
-            <legend><input type="checkbox" id="mail_auth_checkbox" onclick="updateMailAuthSettings();" /><label for="mail_auth_checkbox">QBT_TR(Authentication)QBT_TR[CONTEXT=OptionsDialog]</label></legend>
+            <legend>
+                <input type="checkbox" id="mail_auth_checkbox" onclick="updateMailAuthSettings();" />
+                <label for="mail_auth_checkbox">QBT_TR(Authentication)QBT_TR[CONTEXT=OptionsDialog]</label>
+            </legend>
             <table>
                 <tr>
                     <td>
@@ -128,9 +133,13 @@
     </fieldset>
 
     <fieldset class="settings">
-        <legend><input type="checkbox" id="autorun_checkbox" onclick="updateAutoRun();" />
-            <label for="autorun_checkbox">QBT_TR(Run external program on torrent completion)QBT_TR[CONTEXT=OptionsDialog]</label></legend>
-        <input type="text" id="autorunProg_txt" style="width: 400px;" /><br/>
+        <legend>
+            <input type="checkbox" id="autorun_checkbox" onclick="updateAutoRun();" />
+            <label for="autorun_checkbox">QBT_TR(Run external program on torrent completion)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </legend>
+        <div class="formRow">
+            <input type="text" id="autorunProg_txt" style="width: 400px;" />
+        </div>
         <div style="font-style: italic;">QBT_TR(Supported parameters (case sensitive):)QBT_TR[CONTEXT=OptionsDialog]
             <ul>
                 <li>QBT_TR(%N: Torrent name)QBT_TR[CONTEXT=OptionsDialog]</li>
@@ -150,22 +159,29 @@
 </div>
 
 <div id="ConnectionTab" class="PrefTab invisible">
-    <label>QBT_TR(Enabled protocol:)QBT_TR[CONTEXT=OptionsDialog]</label>
-    <select id="enable_protocol_combobox">
-        <option value="0" selected>QBT_TR(TCP and μTP)QBT_TR[CONTEXT=OptionsDialog]</option>
-        <option value="1">TCP</option>
-        <option value="2">μTP</option>
-    </select><br/>
+    <div class="formRow">
+        <label>QBT_TR(Enabled protocol:)QBT_TR[CONTEXT=OptionsDialog]</label>
+        <select id="enable_protocol_combobox">
+            <option value="0" selected>QBT_TR(TCP and μTP)QBT_TR[CONTEXT=OptionsDialog]</option>
+            <option value="1">TCP</option>
+            <option value="2">μTP</option>
+        </select>
+    </div>
     <fieldset class="settings">
         <legend>QBT_TR(Listening Port)QBT_TR[CONTEXT=OptionsDialog]</legend>
-        <label for="port_value">QBT_TR(Port used for incoming connections:)QBT_TR[CONTEXT=OptionsDialog]</label>
-        <input type="text" id="port_value" style="width: 4em;" />
-        <button style="margin-left: 1em;" onclick="generateRandomPort();">Random</button>
-        <br/>
-        <input type="checkbox" id="upnp_checkbox" />
-        <label for="upnp_checkbox">QBT_TR(Use UPnP / NAT-PMP port forwarding from my router)QBT_TR[CONTEXT=OptionsDialog]</label><br/>
-        <input type="checkbox" id="random_port_checkbox" />
-        <label for="random_port_checkbox">QBT_TR(Use different port on each startup)QBT_TR[CONTEXT=OptionsDialog]</label>
+        <div class="formRow">
+            <label for="port_value">QBT_TR(Port used for incoming connections:)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <input type="text" id="port_value" style="width: 4em;" />
+            <button style="margin-left: 1em;" onclick="generateRandomPort();">Random</button>
+        </div>
+        <div class="formRow">
+            <input type="checkbox" id="upnp_checkbox" />
+            <label for="upnp_checkbox">QBT_TR(Use UPnP / NAT-PMP port forwarding from my router)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </div>
+        <div class="formRow">
+            <input type="checkbox" id="random_port_checkbox" />
+            <label for="random_port_checkbox">QBT_TR(Use different port on each startup)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </div>
     </fieldset>
 
     <fieldset class="settings">
@@ -244,8 +260,10 @@
             <label for="proxy_only_for_torrents_checkbox">QBT_TR(Use proxy only for torrents)QBT_TR[CONTEXT=OptionsDialog]</label>
         </div>
         <fieldset class="settings">
-            <legend><input type="checkbox" id="peer_proxy_auth_checkbox" onclick="updatePeerProxyAuthSettings();" />
-                <label for="peer_proxy_auth_checkbox">QBT_TR(Authentication)QBT_TR[CONTEXT=OptionsDialog]</label></legend>
+            <legend>
+                <input type="checkbox" id="peer_proxy_auth_checkbox" onclick="updatePeerProxyAuthSettings();" />
+                <label for="peer_proxy_auth_checkbox">QBT_TR(Authentication)QBT_TR[CONTEXT=OptionsDialog]</label>
+            </legend>
             <table>
                 <tr>
                     <td>
@@ -271,12 +289,18 @@
     </fieldset>
 
     <fieldset class="settings">
-        <legend><input type="checkbox" id="ipfilter_enabled_checkbox" onclick="updateFilterSettings();" />
-            <label for="ipfilter_enabled_checkbox">QBT_TR(IP Filtering)QBT_TR[CONTEXT=OptionsDialog]</label></legend>
-        <label for="ipfilter_text">QBT_TR(Filter path (.dat, .p2p, .p2b):)QBT_TR[CONTEXT=OptionsDialog]</label>
-        <input type="text" id="ipfilter_text" /><br/>
-        <input type="checkbox" id="ipfilter_trackers_checkbox" />
-        <label for="ipfilter_trackers_checkbox">QBT_TR(Apply to trackers)QBT_TR[CONTEXT=OptionsDialog]</label>
+        <legend>
+            <input type="checkbox" id="ipfilter_enabled_checkbox" onclick="updateFilterSettings();" />
+            <label for="ipfilter_enabled_checkbox">QBT_TR(IP Filtering)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </legend>
+        <div class="formRow">
+            <label for="ipfilter_text">QBT_TR(Filter path (.dat, .p2p, .p2b):)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <input type="text" id="ipfilter_text" />
+        </div>
+        <div class="formRow">
+            <input type="checkbox" id="ipfilter_trackers_checkbox" />
+            <label for="ipfilter_trackers_checkbox">QBT_TR(Apply to trackers)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </div>
         <div class="formRow">
             <fieldset class="settings">
                 <legend>QBT_TR(Manually banned IP addresses...)QBT_TR[CONTEXT=OptionsDialog]</legend>
@@ -323,59 +347,80 @@
         <i>QBT_TR(0 means unlimited)QBT_TR[CONTEXT=OptionsDialog]</i>
 
         <fieldset class="settings">
-            <legend><input type="checkbox" id="limit_sheduling_checkbox" onclick="updateSchedulingEnabled();" />
-                <label for="limit_sheduling_checkbox">QBT_TR(Schedule the use of alternative rate limits)QBT_TR[CONTEXT=OptionsDialog]</label></legend>
-            QBT_TR(From:)QBT_TR[CONTEXT=OptionsDialog]
-            <input type="text" id="schedule_from_hour" style="width: 1.5em;" />:<input type="text" id="schedule_from_min" style="width: 1.5em;" /> QBT_TR(To:)QBT_TR[CONTEXT=OptionsDialog]
-            <input type="text" id="schedule_to_hour" style="width: 1.5em;" />:<input type="text" id="schedule_to_min" style="width: 1.5em;" />
-            <br/> QBT_TR(When:)QBT_TR[CONTEXT=OptionsDialog]
-            <select id="schedule_freq_select">
-                <option value="0">QBT_TR(Every day)QBT_TR[CONTEXT=OptionsDialog]</option>
-                <option value="1">QBT_TR(Weekdays)QBT_TR[CONTEXT=OptionsDialog]</option>
-                <option value="2">QBT_TR(Weekends)QBT_TR[CONTEXT=OptionsDialog]</option>
-                <option value="3">QBT_TR(Monday)QBT_TR[CONTEXT=HttpServer]</option>
-                <option value="4">QBT_TR(Tuesday)QBT_TR[CONTEXT=HttpServer]</option>
-                <option value="5">QBT_TR(Wednesday)QBT_TR[CONTEXT=HttpServer]</option>
-                <option value="6">QBT_TR(Thursday)QBT_TR[CONTEXT=HttpServer]</option>
-                <option value="7">QBT_TR(Friday)QBT_TR[CONTEXT=HttpServer]</option>
-                <option value="8">QBT_TR(Saturday)QBT_TR[CONTEXT=HttpServer]</option>
-                <option value="9">QBT_TR(Sunday)QBT_TR[CONTEXT=HttpServer]</option>
-            </select>
-            <br/>
+            <legend>
+                <input type="checkbox" id="limit_sheduling_checkbox" onclick="updateSchedulingEnabled();" />
+                <label for="limit_sheduling_checkbox">QBT_TR(Schedule the use of alternative rate limits)QBT_TR[CONTEXT=OptionsDialog]</label>
+            </legend>
+            <div class="formRow">
+                QBT_TR(From:)QBT_TR[CONTEXT=OptionsDialog]
+                <input type="text" id="schedule_from_hour" style="width: 1.5em;" />:<input type="text" id="schedule_from_min" style="width: 1.5em;" /> QBT_TR(To:)QBT_TR[CONTEXT=OptionsDialog]
+                <input type="text" id="schedule_to_hour" style="width: 1.5em;" />:<input type="text" id="schedule_to_min" style="width: 1.5em;" />
+            </div>
+            <div class="formRow">
+                QBT_TR(When:)QBT_TR[CONTEXT=OptionsDialog]
+                <select id="schedule_freq_select">
+                    <option value="0">QBT_TR(Every day)QBT_TR[CONTEXT=OptionsDialog]</option>
+                    <option value="1">QBT_TR(Weekdays)QBT_TR[CONTEXT=OptionsDialog]</option>
+                    <option value="2">QBT_TR(Weekends)QBT_TR[CONTEXT=OptionsDialog]</option>
+                    <option value="3">QBT_TR(Monday)QBT_TR[CONTEXT=HttpServer]</option>
+                    <option value="4">QBT_TR(Tuesday)QBT_TR[CONTEXT=HttpServer]</option>
+                    <option value="5">QBT_TR(Wednesday)QBT_TR[CONTEXT=HttpServer]</option>
+                    <option value="6">QBT_TR(Thursday)QBT_TR[CONTEXT=HttpServer]</option>
+                    <option value="7">QBT_TR(Friday)QBT_TR[CONTEXT=HttpServer]</option>
+                    <option value="8">QBT_TR(Saturday)QBT_TR[CONTEXT=HttpServer]</option>
+                    <option value="9">QBT_TR(Sunday)QBT_TR[CONTEXT=HttpServer]</option>
+                </select>
+            </div>
         </fieldset>
     </fieldset>
 
     <fieldset class="settings">
         <legend>QBT_TR(Rate Limits Settings)QBT_TR[CONTEXT=OptionsDialog]</legend>
-        <input type="checkbox" id="limit_utp_rate_checkbox" />
-        <label for="limit_utp_rate_checkbox">QBT_TR(Apply rate limit to µTP protocol)QBT_TR[CONTEXT=OptionsDialog]</label><br/>
-        <input type="checkbox" id="limit_tcp_overhead_checkbox" />
-        <label for="limit_tcp_overhead_checkbox">QBT_TR(Apply rate limit to transport overhead)QBT_TR[CONTEXT=OptionsDialog]</label><br/>
+        <div class="formRow">
+            <input type="checkbox" id="limit_utp_rate_checkbox" />
+            <label for="limit_utp_rate_checkbox">QBT_TR(Apply rate limit to µTP protocol)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </div>
+        <div class="formRow">
+            <input type="checkbox" id="limit_tcp_overhead_checkbox" />
+            <label for="limit_tcp_overhead_checkbox">QBT_TR(Apply rate limit to transport overhead)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </div>
     </fieldset>
 </div>
 
 <div id="BittorrentTab" class="PrefTab invisible">
     <fieldset class="settings">
         <legend>QBT_TR(Privacy)QBT_TR[CONTEXT=OptionsDialog]</legend>
-        <input type="checkbox" id="dht_checkbox" />
-        <label for="dht_checkbox">QBT_TR(Enable DHT (decentralized network) to find more peers)QBT_TR[CONTEXT=OptionsDialog]</label><br/>
-        <input type="checkbox" id="pex_checkbox" />
-        <label for="pex_checkbox">QBT_TR(Enable Peer Exchange (PeX) to find more peers)QBT_TR[CONTEXT=OptionsDialog]</label><br/>
-        <input type="checkbox" id="lsd_checkbox" />
-        <label for="lsd_checkbox">QBT_TR(Enable Local Peer Discovery to find more peers)QBT_TR[CONTEXT=OptionsDialog]</label><br/>
-        <label for="encryption_select">QBT_TR(Encryption mode:)QBT_TR[CONTEXT=OptionsDialog]</label>
-        <select id="encryption_select">
-            <option value="0">QBT_TR(Prefer encryption)QBT_TR[CONTEXT=OptionsDialog]</option>
-            <option value="1">QBT_TR(Require encryption)QBT_TR[CONTEXT=OptionsDialog]</option>
-            <option value="2">QBT_TR(Disable encryption)QBT_TR[CONTEXT=OptionsDialog]</option>
-        </select><br/>
-        <input type="checkbox" id="anonymous_mode_checkbox" />
-        <label for="anonymous_mode_checkbox">QBT_TR(Enable anonymous mode)QBT_TR[CONTEXT=OptionsDialog] (<a target="_blank" href="https://github.com/qbittorrent/qBittorrent/wiki/Anonymous-Mode">QBT_TR(More information)QBT_TR[CONTEXT=HttpServer]</a>)</label><br/>
+        <div class="formRow">
+            <input type="checkbox" id="dht_checkbox" />
+            <label for="dht_checkbox">QBT_TR(Enable DHT (decentralized network) to find more peers)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </div>
+        <div class="formRow">
+            <input type="checkbox" id="pex_checkbox" />
+            <label for="pex_checkbox">QBT_TR(Enable Peer Exchange (PeX) to find more peers)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </div>
+        <div class="formRow">
+            <input type="checkbox" id="lsd_checkbox" />
+            <label for="lsd_checkbox">QBT_TR(Enable Local Peer Discovery to find more peers)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </div>
+        <div class="formRow">
+            <label for="encryption_select">QBT_TR(Encryption mode:)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <select id="encryption_select">
+                <option value="0">QBT_TR(Prefer encryption)QBT_TR[CONTEXT=OptionsDialog]</option>
+                <option value="1">QBT_TR(Require encryption)QBT_TR[CONTEXT=OptionsDialog]</option>
+                <option value="2">QBT_TR(Disable encryption)QBT_TR[CONTEXT=OptionsDialog]</option>
+            </select>
+        </div>
+        <div class="formRow">
+            <input type="checkbox" id="anonymous_mode_checkbox" />
+            <label for="anonymous_mode_checkbox">QBT_TR(Enable anonymous mode)QBT_TR[CONTEXT=OptionsDialog] (<a target="_blank" href="https://github.com/qbittorrent/qBittorrent/wiki/Anonymous-Mode">QBT_TR(More information)QBT_TR[CONTEXT=HttpServer]</a>)</label>
+        </div>
     </fieldset>
 
     <fieldset class="settings">
-        <legend><input type="checkbox" id="queueing_checkbox" onclick="updateQueueingSystem();" />
-            <label for="queueing_checkbox">QBT_TR(Torrent Queueing)QBT_TR[CONTEXT=OptionsDialog]</label></legend>
+        <legend>
+            <input type="checkbox" id="queueing_checkbox" onclick="updateQueueingSystem();" />
+            <label for="queueing_checkbox">QBT_TR(Torrent Queueing)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </legend>
         <table>
             <tr>
                 <td>
@@ -443,8 +488,10 @@
     </fieldset>
 
     <fieldset class="settings">
-        <legend><input type="checkbox" id="add_trackers_checkbox" onclick="updateAddTrackersEnabled();" />
-            <label for="add_trackers_checkbox">QBT_TR(Automatically add these trackers to new downloads:)QBT_TR[CONTEXT=OptionsDialog]</label></legend>
+        <legend>
+            <input type="checkbox" id="add_trackers_checkbox" onclick="updateAddTrackersEnabled();" />
+            <label for="add_trackers_checkbox">QBT_TR(Automatically add these trackers to new downloads:)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </legend>
         <textarea id="add_trackers_textarea" rows="5" cols="70"></textarea>
     </fieldset>
 </div>
@@ -517,15 +564,19 @@
                 <td>
                     <input type="text" id="webui_address_value" />
                     <label for="webui_port_value" style="margin-left: 10px;">QBT_TR(Port:)QBT_TR[CONTEXT=OptionsDialog]</label>
-                    <input type="text" id="webui_port_value" style="width: 4em;" /><br/>
+                    <input type="text" id="webui_port_value" style="width: 4em;" />
                 </td>
             </tr>
         </table>
-        <input type="checkbox" id="webui_upnp_checkbox" />
-        <label for="webui_upnp_checkbox">QBT_TR(Use UPnP / NAT-PMP to forward the port from my router)QBT_TR[CONTEXT=OptionsDialog]</label><br/>
+        <div class="formRow">
+            <input type="checkbox" id="webui_upnp_checkbox" />
+            <label for="webui_upnp_checkbox">QBT_TR(Use UPnP / NAT-PMP to forward the port from my router)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </div>
         <fieldset class="settings">
-            <legend><input type="checkbox" id="use_https_checkbox" onclick="updateHttpsSettings();" />
-                <label for="use_https_checkbox">QBT_TR(Use HTTPS instead of HTTP)QBT_TR[CONTEXT=OptionsDialog]</label></legend>
+            <legend>
+                <input type="checkbox" id="use_https_checkbox" onclick="updateHttpsSettings();" />
+                <label for="use_https_checkbox">QBT_TR(Use HTTPS instead of HTTP)QBT_TR[CONTEXT=OptionsDialog]</label>
+            </legend>
             <table>
                 <tr>
                     <td>
@@ -611,14 +662,16 @@
     </fieldset>
 
     <fieldset class="settings">
-        <legend><input type="checkbox" id="use_dyndns_checkbox" onclick="updateDynDnsSettings();" />
-            <label for="use_dyndns_checkbox">QBT_TR(Update my dynamic domain name)QBT_TR[CONTEXT=OptionsDialog]</label></legend>
+        <legend>
+            <input type="checkbox" id="use_dyndns_checkbox" onclick="updateDynDnsSettings();" />
+            <label for="use_dyndns_checkbox">QBT_TR(Update my dynamic domain name)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </legend>
         <select id="dyndns_select">
             <option value="0">DynDNS</option>
             <option value="1">NO-IP</option>
         </select>
-        <input type="button" value="QBT_TR(Register)QBT_TR[CONTEXT=OptionsDialog]" onclick="registerDynDns();" /><br/><br/>
-        <table>
+        <input type="button" value="QBT_TR(Register)QBT_TR[CONTEXT=OptionsDialog]" onclick="registerDynDns();" />
+        <table style="margin-top: 10px;">
             <tr>
                 <td>
                     <label for="dyndns_domain_text">QBT_TR(Domain name:)QBT_TR[CONTEXT=OptionsDialog]</label>
@@ -647,8 +700,7 @@
     </fieldset>
 </div>
 
-<br/>
-<div style="text-align: center;"><input type="button" value="QBT_TR(Save)QBT_TR[CONTEXT=HttpServer]" onclick="applyPreferences();" /></div>
+<div style="text-align: center; margin-top: 1em;"><input type="button" value="QBT_TR(Save)QBT_TR[CONTEXT=HttpServer]" onclick="applyPreferences();" /></div>
 
 <script>
     // Downloads tab

--- a/src/webui/www/private/preferences_content.html
+++ b/src/webui/www/private/preferences_content.html
@@ -454,6 +454,10 @@
             <input type="checkbox" id="limit_tcp_overhead_checkbox" />
             <label for="limit_tcp_overhead_checkbox">QBT_TR(Apply rate limit to transport overhead)QBT_TR[CONTEXT=OptionsDialog]</label>
         </div>
+        <div class="formRow">
+            <input type="checkbox" id="limit_lan_peers_checkbox" />
+            <label for="limit_lan_peers_checkbox">QBT_TR(Apply rate limit to peers on LAN)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </div>
     </fieldset>
 </div>
 
@@ -1211,6 +1215,7 @@
                     $('enable_protocol_combobox').setProperty('value', pref.bittorrent_protocol);
                     $('limit_utp_rate_checkbox').setProperty('checked', pref.limit_utp_rate);
                     $('limit_tcp_overhead_checkbox').setProperty('checked', pref.limit_tcp_overhead);
+                    $('limit_lan_peers_checkbox').setProperty('checked', pref.limit_lan_peers);
 
                     // Scheduling
                     $('limit_sheduling_checkbox').setProperty('checked', pref.scheduler_enabled);
@@ -1473,6 +1478,7 @@
         settings.set('bittorrent_protocol', $('enable_protocol_combobox').getProperty('value'));
         settings.set('limit_utp_rate', $('limit_utp_rate_checkbox').getProperty('checked'));
         settings.set('limit_tcp_overhead', $('limit_tcp_overhead_checkbox').getProperty('checked'));
+        settings.set('limit_lan_peers', $('limit_lan_peers_checkbox').getProperty('checked'));
 
         // Scheduler
         var scheduling_enabled = $('limit_sheduling_checkbox').getProperty('checked');

--- a/src/webui/www/private/preferences_content.html
+++ b/src/webui/www/private/preferences_content.html
@@ -150,6 +150,14 @@
         <table>
             <tr>
                 <td>
+                    <label for="src_email_txt">QBT_TR(From:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                </td>
+                <td>
+                    <input type="text" id="src_email_txt" />
+                </td>
+            </tr>
+            <tr>
+                <td>
                     <label for="dest_email_txt">QBT_TR(To:)QBT_TR[CONTEXT=OptionsDialog]</label>
                 </td>
                 <td>
@@ -858,6 +866,7 @@
 
     updateMailNotification = function() {
         var isMailNotificationEnabled = $('mail_notification_checkbox').getProperty('checked');
+        $('src_email_txt').setProperty('disabled', !isMailNotificationEnabled);
         $('dest_email_txt').setProperty('disabled', !isMailNotificationEnabled);
         $('smtp_server_txt').setProperty('disabled', !isMailNotificationEnabled);
         $('mail_ssl_checkbox').setProperty('disabled', !isMailNotificationEnabled);
@@ -1093,6 +1102,7 @@
 
                     // Email notification upon download completion
                     $('mail_notification_checkbox').setProperty('checked', pref.mail_notification_enabled);
+                    $('src_email_txt').setProperty('value', pref.mail_notification_sender);
                     $('dest_email_txt').setProperty('value', pref.mail_notification_email);
                     $('smtp_server_txt').setProperty('value', pref.mail_notification_smtp);
                     $('mail_ssl_checkbox').setProperty('checked', pref.mail_notification_ssl_enabled);
@@ -1323,6 +1333,7 @@
 
         // Email notification upon download completion
         settings.set('mail_notification_enabled', $('mail_notification_checkbox').getProperty('checked'));
+        settings.set('mail_notification_sender', $('src_email_txt').getProperty('value'));
         settings.set('mail_notification_email', $('dest_email_txt').getProperty('value'));
         settings.set('mail_notification_smtp', $('smtp_server_txt').getProperty('value'));
         settings.set('mail_notification_ssl_enabled', $('mail_ssl_checkbox').getProperty('checked'));

--- a/src/webui/www/private/preferences_content.html
+++ b/src/webui/www/private/preferences_content.html
@@ -15,6 +15,52 @@
         <table>
             <tr>
                 <td>
+                    <label>QBT_TR(Default Torrent Management Mode:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                </td>
+                <td>
+                    <select id="default_tmm_combobox">
+                        <option value="false" selected>QBT_TR(Manual)QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="true">QBT_TR(Automatic)QBT_TR[CONTEXT=OptionsDialog]</option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <label>QBT_TR(When Torrent Category changed:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                </td>
+                <td>
+                    <select id="torrent_changed_tmm_combobox">
+                        <option value="true">QBT_TR(Relocate torrent)QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="false" selected>QBT_TR(Switch torrent to Manual Mode)QBT_TR[CONTEXT=OptionsDialog]</option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <label>QBT_TR(When Default Save Path changed:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                </td>
+                <td>
+                    <select id="save_path_changed_tmm_combobox">
+                        <option value="true">QBT_TR(Relocate affected torrents)QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="false" selected>QBT_TR(Switch affected torrents to Manual Mode)QBT_TR[CONTEXT=OptionsDialog]</option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <label>QBT_TR(When Category Save Path changed:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                </td>
+                <td>
+                    <select id="category_changed_tmm_combobox">
+                        <option value="true">QBT_TR(Relocate affected torrents)QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="false" selected>QBT_TR(Switch affected torrents to Manual Mode)QBT_TR[CONTEXT=OptionsDialog]</option>
+                    </select>
+                </td>
+            </tr>
+        </table>
+        <table>
+            <tr>
+                <td>
                     <label for="savepath_text">QBT_TR(Default Save Path:)QBT_TR[CONTEXT=OptionsDialog]</label>
                 </td>
                 <td>
@@ -984,6 +1030,10 @@
                     $('appendext_checkbox').setProperty('checked', pref.incomplete_files_ext);
 
                     // Saving Managmenet
+                    $('default_tmm_combobox').setProperty('value', pref.auto_tmm_enabled);
+                    $('torrent_changed_tmm_combobox').setProperty('value', pref.torrent_changed_tmm_enabled);
+                    $('save_path_changed_tmm_combobox').setProperty('value', pref.save_path_changed_tmm_enabled);
+                    $('category_changed_tmm_combobox').setProperty('value', pref.category_changed_tmm_enabled);
                     $('savepath_text').setProperty('value', pref.save_path);
                     $('temppath_checkbox').setProperty('checked', pref.temp_path_enabled);
                     $('temppath_text').setProperty('value', pref.temp_path);
@@ -1228,6 +1278,10 @@
         settings.set('incomplete_files_ext', $('appendext_checkbox').getProperty('checked'));
 
         // Saving Management
+        settings.set('auto_tmm_enabled', $('default_tmm_combobox').getProperty('value'));
+        settings.set('torrent_changed_tmm_enabled', $('torrent_changed_tmm_combobox').getProperty('value'));
+        settings.set('save_path_changed_tmm_enabled', $('save_path_changed_tmm_combobox').getProperty('value'));
+        settings.set('category_changed_tmm_enabled', $('category_changed_tmm_combobox').getProperty('value'));
         settings.set('save_path', $('savepath_text').getProperty('value'));
         settings.set('temp_path_enabled', $('temppath_checkbox').getProperty('checked'));
         settings.set('temp_path', $('temppath_text').getProperty('value'));

--- a/src/webui/www/private/preferences_content.html
+++ b/src/webui/www/private/preferences_content.html
@@ -706,6 +706,15 @@
         </fieldset>
 
         <fieldset class="settings">
+            <legend><input type="checkbox" id="use_alt_webui_checkbox" onclick="updateAlternativeWebUISettings();" />
+                <label for="use_alt_webui_checkbox">QBT_TR(Use alternative Web UI)QBT_TR[CONTEXT=OptionsDialog]</label></legend>
+            <div class="formRow">
+                <label for="webui_files_location_textarea">QBT_TR(Files location:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                <input type="text" id="webui_files_location_textarea" />
+            </div>
+        </fieldset>
+
+        <fieldset class="settings">
             <legend>QBT_TR(Security)QBT_TR[CONTEXT=OptionsDialog]</legend>
             <div class="formRow">
                 <input type="checkbox" id="clickjacking_protection_checkbox" />
@@ -1005,6 +1014,11 @@
         $('bypass_auth_subnet_whitelist_textarea').setProperty('disabled', !isBypassAuthSubnetWhitelistEnabled);
     };
 
+    updateAlternativeWebUISettings = function() {
+        var isUseAlternativeWebUIEnabled = $('use_alt_webui_checkbox').getProperty('checked');
+        $('webui_files_location_textarea').setProperty('disabled', !isUseAlternativeWebUIEnabled);
+    };
+
     updateHostHeaderValidationSettings = function() {
         var isHostHeaderValidationEnabled = $('host_header_validation_checkbox').getProperty('checked');
         $('webui_domain_textarea').setProperty('disabled', !isHostHeaderValidationEnabled);
@@ -1285,6 +1299,11 @@
                     $('bypass_auth_subnet_whitelist_checkbox').setProperty('checked', pref.bypass_auth_subnet_whitelist_enabled);
                     $('bypass_auth_subnet_whitelist_textarea').setProperty('value', pref.bypass_auth_subnet_whitelist);
                     updateBypasssAuthSettings();
+
+                    // Use alternative Web UI
+                    $('use_alt_webui_checkbox').setProperty('checked', pref.alternative_webui_enabled);
+                    $('webui_files_location_textarea').setProperty('value', pref.alternative_webui_path);
+                    updateAlternativeWebUISettings();
 
                     // Security
                     $('clickjacking_protection_checkbox').setProperty('checked', pref.web_ui_clickjacking_protection_enabled);
@@ -1589,6 +1608,10 @@
         settings.set('bypass_local_auth', $('bypass_local_auth_checkbox').getProperty('checked'));
         settings.set('bypass_auth_subnet_whitelist_enabled', $('bypass_auth_subnet_whitelist_checkbox').getProperty('checked'));
         settings.set('bypass_auth_subnet_whitelist', $('bypass_auth_subnet_whitelist_textarea').getProperty('value'));
+
+        // Use alternative Web UI
+        settings.set('alternative_webui_enabled', $('use_alt_webui_checkbox').getProperty('checked'));
+        settings.set('alternative_webui_path', $('webui_files_location_textarea').getProperty('value'));
 
         settings.set('web_ui_clickjacking_protection_enabled', $('clickjacking_protection_checkbox').getProperty('checked'));
         settings.set('web_ui_csrf_protection_enabled', $('csrf_protection_checkbox').getProperty('checked'));

--- a/src/webui/www/private/preferences_content.html
+++ b/src/webui/www/private/preferences_content.html
@@ -83,23 +83,47 @@
     <fieldset class="settings">
         <legend><input type="checkbox" id="mail_notification_checkbox" onclick="updateMailNotification();" />
             <label for="mail_notification_checkbox">QBT_TR(Email notification upon download completion)QBT_TR[CONTEXT=OptionsDialog]</label></legend>
-        <div class="formRow">
-            <label for="dest_email_txt" class="leftLabelMedium">QBT_TR(To:)QBT_TR[CONTEXT=OptionsDialog]</label><input type="text" id="dest_email_txt" />
-        </div>
-        <div class="formRow">
-            <label for="smtp_server_txt" class="leftLabelMedium">QBT_TR(SMTP server:)QBT_TR[CONTEXT=OptionsDialog]</label><input type="text" id="smtp_server_txt" />
-        </div>
+        <table>
+            <tr>
+                <td>
+                    <label for="dest_email_txt">QBT_TR(To:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                </td>
+                <td>
+                    <input type="text" id="dest_email_txt" />
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <label for="smtp_server_txt">QBT_TR(SMTP server:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                </td>
+                <td>
+                    <input type="text" id="smtp_server_txt" />
+                </td>
+            </tr>
+        </table>
         <div class="formRow">
             <input type="checkbox" id="mail_ssl_checkbox" /><label for="mail_ssl_checkbox">QBT_TR(This server requires a secure connection (SSL))QBT_TR[CONTEXT=OptionsDialog]</label>
         </div>
         <fieldset class="settings">
             <legend><input type="checkbox" id="mail_auth_checkbox" onclick="updateMailAuthSettings();" /><label for="mail_auth_checkbox">QBT_TR(Authentication)QBT_TR[CONTEXT=OptionsDialog]</label></legend>
-            <div class="formRow">
-                <label for="mail_username_text" class="leftLabelMedium">QBT_TR(Username:)QBT_TR[CONTEXT=OptionsDialog]</label><input type="text" id="mail_username_text" />
-            </div>
-            <div class="formRow">
-                <label for="mail_password_text" class="leftLabelMedium">QBT_TR(Password:)QBT_TR[CONTEXT=OptionsDialog]</label><input type="password" id="mail_password_text" />
-            </div>
+            <table>
+                <tr>
+                    <td>
+                        <label for="mail_username_text">QBT_TR(Username:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    </td>
+                    <td>
+                        <input type="text" id="mail_username_text" />
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="mail_password_text">QBT_TR(Password:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    </td>
+                    <td>
+                        <input type="password" id="mail_password_text" />
+                    </td>
+                </tr>
+            </table>
         </fieldset>
     </fieldset>
 
@@ -178,23 +202,33 @@
 
     <fieldset class="settings">
         <legend>QBT_TR(Proxy Server)QBT_TR[CONTEXT=OptionsDialog]</legend>
-        <div class="formRow">
-            <label for="peer_proxy_type_select" class="leftLabelSmall">QBT_TR(Type:)QBT_TR[CONTEXT=OptionsDialog]</label>
-            <select id="peer_proxy_type_select" onchange="updatePeerProxySettings();">
-                <option value="none">QBT_TR((None))QBT_TR[CONTEXT=OptionsDialog]</option>
-                <option value="socks4">QBT_TR(SOCKS4)QBT_TR[CONTEXT=OptionsDialog]</option>
-                <option value="socks5">QBT_TR(SOCKS5)QBT_TR[CONTEXT=OptionsDialog]</option>
-                <option value="http">QBT_TR(HTTP)QBT_TR[CONTEXT=OptionsDialog]</option>
-            </select>
-        </div>
-        <div class="formRow">
-            <label for="peer_proxy_host_text" class="leftLabelSmall">QBT_TR(Host:)QBT_TR[CONTEXT=OptionsDialog]</label>
-            <input type="text" id="peer_proxy_host_text" />
-        </div>
-        <div class="formRow">
-            <label for="peer_proxy_port_value" class="leftLabelSmall">QBT_TR(Port:)QBT_TR[CONTEXT=OptionsDialog]</label>
-            <input type="text" id="peer_proxy_port_value" style="width: 4em;" />
-        </div>
+        <table>
+            <tr>
+                <td>
+                    <label for="peer_proxy_type_select">QBT_TR(Type:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                </td>
+                <td>
+                    <select id="peer_proxy_type_select" onchange="updatePeerProxySettings();">
+                        <option value="none">QBT_TR((None))QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="socks4">QBT_TR(SOCKS4)QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="socks5">QBT_TR(SOCKS5)QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="http">QBT_TR(HTTP)QBT_TR[CONTEXT=OptionsDialog]</option>
+                    </select>
+                </td>
+                <td>
+                    <label for="peer_proxy_host_text">QBT_TR(Host:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                </td>
+                <td>
+                    <input type="text" id="peer_proxy_host_text" />
+                </td>
+                <td>
+                    <label for="peer_proxy_port_value">QBT_TR(Port:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                </td>
+                <td>
+                    <input type="text" id="peer_proxy_port_value" style="width: 4em;" />
+                </td>
+            </tr>
+        </table>
         <div class="formRow">
             <input type="checkbox" id="use_peer_proxy_checkbox" />
             <label for="use_peer_proxy_checkbox">QBT_TR(Use proxy for peer connections)QBT_TR[CONTEXT=OptionsDialog]</label>
@@ -210,14 +244,24 @@
         <fieldset class="settings">
             <legend><input type="checkbox" id="peer_proxy_auth_checkbox" onclick="updatePeerProxyAuthSettings();" />
                 <label for="peer_proxy_auth_checkbox">QBT_TR(Authentication)QBT_TR[CONTEXT=OptionsDialog]</label></legend>
-            <div class="formRow">
-                <label for="peer_proxy_username_text" class="leftLabelMedium">QBT_TR(Username:)QBT_TR[CONTEXT=OptionsDialog]</label>
-                <input type="text" id="peer_proxy_username_text" />
-            </div>
-            <div class="formRow">
-                <label for="peer_proxy_password_text" class="leftLabelMedium">QBT_TR(Password:)QBT_TR[CONTEXT=OptionsDialog]</label>
-                <input type="password" id="peer_proxy_password_text" />
-            </div>
+            <table>
+                <tr>
+                    <td>
+                        <label for="peer_proxy_username_text">QBT_TR(Username:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    </td>
+                    <td>
+                        <input type="text" id="peer_proxy_username_text" />
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="peer_proxy_password_text">QBT_TR(Password:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    </td>
+                    <td>
+                        <input type="password" id="peer_proxy_password_text" />
+                    </td>
+                </tr>
+            </table>
         </fieldset>
     </fieldset>
 
@@ -321,18 +365,32 @@
     <fieldset class="settings">
         <legend><input type="checkbox" id="queueing_checkbox" onclick="updateQueueingSystem();" />
             <label for="queueing_checkbox">QBT_TR(Torrent Queueing)QBT_TR[CONTEXT=OptionsDialog]</label></legend>
-        <div class="formRow">
-            <label for="max_active_dl_value" style="margin-left: 20px;" class="leftLabelLarge">QBT_TR(Maximum active downloads:)QBT_TR[CONTEXT=OptionsDialog]</label>
-            <input type="text" id="max_active_dl_value" style="width: 4em;" />
-        </div>
-        <div class="formRow">
-            <label for="max_active_up_value" style="margin-left: 20px;" class="leftLabelLarge">QBT_TR(Maximum active uploads:)QBT_TR[CONTEXT=OptionsDialog]</label>
-            <input type="text" id="max_active_up_value" style="width: 4em;" />
-        </div>
-        <div class="formRow">
-            <label for="max_active_to_value" style="margin-left: 20px;" class="leftLabelLarge">QBT_TR(Maximum active torrents:)QBT_TR[CONTEXT=OptionsDialog]</label>
-            <input type="text" id="max_active_to_value" style="width: 4em;" />
-        </div>
+        <table>
+            <tr>
+                <td>
+                    <label for="max_active_dl_value">QBT_TR(Maximum active downloads:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                </td>
+                <td>
+                    <input type="text" id="max_active_dl_value" style="width: 4em;" />
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <label for="max_active_up_value">QBT_TR(Maximum active uploads:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                </td>
+                <td>
+                    <input type="text" id="max_active_up_value" style="width: 4em;" />
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <label for="max_active_to_value">QBT_TR(Maximum active torrents:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                </td>
+                <td>
+                    <input type="text" id="max_active_to_value" style="width: 4em;" />
+                </td>
+            </tr>
+        </table>
         <div class="formRow">
             <input type="checkbox" id="dont_count_slow_torrents_checkbox" />
             <label for="dont_count_slow_torrents_checkbox">QBT_TR(Do not count slow torrents in these limits)QBT_TR[CONTEXT=OptionsDialog]</label>
@@ -440,33 +498,64 @@
 
     <fieldset class="settings">
         <legend>QBT_TR(Web User Interface (Remote control))QBT_TR[CONTEXT=OptionsDialog]</legend>
-        <label class="leftLabelMedium" for="webui_address_value">QBT_TR(IP address:)QBT_TR[CONTEXT=OptionsDialog]</label><input type="text" id="webui_address_value" />
-        <label for="webui_port_value" style="margin-left: 10px;">QBT_TR(Port:)QBT_TR[CONTEXT=OptionsDialog]</label><input type="text" id="webui_port_value" style="width: 4em;" /><br/>
+        <table>
+            <tr>
+                <td>
+                    <label for="webui_address_value">QBT_TR(IP address:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                </td>
+                <td>
+                    <input type="text" id="webui_address_value" />
+                    <label for="webui_port_value" style="margin-left: 10px;">QBT_TR(Port:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <input type="text" id="webui_port_value" style="width: 4em;" /><br/>
+                </td>
+            </tr>
+        </table>
         <input type="checkbox" id="webui_upnp_checkbox" />
         <label for="webui_upnp_checkbox">QBT_TR(Use UPnP / NAT-PMP to forward the port from my router)QBT_TR[CONTEXT=OptionsDialog]</label><br/>
         <fieldset class="settings">
             <legend><input type="checkbox" id="use_https_checkbox" onclick="updateHttpsSettings();" />
                 <label for="use_https_checkbox">QBT_TR(Use HTTPS instead of HTTP)QBT_TR[CONTEXT=OptionsDialog]</label></legend>
-            <div class="formRow">
-                <label class="leftLabelSmall" for="ssl_key_textarea">QBT_TR(Key:)QBT_TR[CONTEXT=OptionsDialog]</label>
-                <textarea id="ssl_key_textarea" rows="5" cols="70"></textarea>
-            </div>
-            <div class="formRow">
-                <label class="leftLabelSmall" for="ssl_cert_textarea">QBT_TR(Certificate:)QBT_TR[CONTEXT=OptionsDialog]</label>
-                <textarea id="ssl_cert_textarea" rows="5" cols="70"></textarea>
-            </div>
+            <table>
+                <tr>
+                    <td>
+                        <label for="ssl_key_textarea">QBT_TR(Key:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    </td>
+                    <td>
+                        <textarea id="ssl_key_textarea" rows="5" cols="70"></textarea>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="ssl_cert_textarea">QBT_TR(Certificate:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    </td>
+                    <td>
+                        <textarea id="ssl_cert_textarea" rows="5" cols="70"></textarea>
+                    </td>
+                </tr>
+            </table>
             <div style="padding-left: 10px;"><a target="_blank" href="https://httpd.apache.org/docs/current/ssl/ssl_faq.html#aboutcerts">QBT_TR(Information about certificates)QBT_TR[CONTEXT=HttpServer]</a></div>
         </fieldset>
 
         <fieldset class="settings">
             <legend>QBT_TR(Authentication)QBT_TR[CONTEXT=OptionsDialog]</legend>
-            <div class="formRow">
-                <label for="webui_username_text" class="leftLabelSmall">QBT_TR(Username:)QBT_TR[CONTEXT=OptionsDialog]</label><input type="text" id="webui_username_text" />
-            </div>
-            <div class="formRow">
-                <label for="webui_password_text" class="leftLabelSmall">QBT_TR(Password:)QBT_TR[CONTEXT=OptionsDialog]</label>
-                <input type="password" id="webui_password_text" placeholder="QBT_TR(Change current password)QBT_TR[CONTEXT=OptionsDialog]" />
-            </div>
+            <table>
+                <tr>
+                    <td>
+                        <label for="webui_username_text">QBT_TR(Username:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    </td>
+                    <td>
+                        <input type="text" id="webui_username_text" />
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="webui_password_text">QBT_TR(Password:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    </td>
+                    <td>
+                        <input type="password" id="webui_password_text" placeholder="QBT_TR(Change current password)QBT_TR[CONTEXT=OptionsDialog]" />
+                    </td>
+                </tr>
+            </table>
             <div class="formRow">
                 <input type="checkbox" id="bypass_local_auth_checkbox" />
                 <label for="bypass_local_auth_checkbox">QBT_TR(Bypass authentication for clients on localhost)QBT_TR[CONTEXT=OptionsDialog]</label>
@@ -496,10 +585,16 @@
                     <input type="checkbox" id="host_header_validation_checkbox" onclick="updateHostHeaderValidationSettings();" />
                     <label for="host_header_validation_checkbox">QBT_TR(Enable Host header validation)QBT_TR[CONTEXT=OptionsDialog]</label>
                 </legend>
-                <div class="formRow">
-                    <label class="leftLabelMedium" for="webui_domain_textarea">QBT_TR(Server domains:)QBT_TR[CONTEXT=OptionsDialog]</label>
-                    <textarea id="webui_domain_textarea" rows="1" cols="60"></textarea>
-                </div>
+                <table>
+                    <tr>
+                        <td>
+                            <label for="webui_domain_textarea">QBT_TR(Server domains:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                        </td>
+                        <td>
+                            <textarea id="webui_domain_textarea" rows="1" cols="60"></textarea>
+                        </td>
+                    </tr>
+                </table>
             </fieldset>
         </fieldset>
     </fieldset>
@@ -512,15 +607,32 @@
             <option value="1">NO-IP</option>
         </select>
         <input type="button" value="QBT_TR(Register)QBT_TR[CONTEXT=OptionsDialog]" onclick="registerDynDns();" /><br/><br/>
-        <div class="formRow">
-            <label for="dyndns_domain_text" class="leftLabelMedium">QBT_TR(Domain name:)QBT_TR[CONTEXT=OptionsDialog]</label><input type="text" id="dyndns_domain_text" />
-        </div>
-        <div class="formRow">
-            <label for="dyndns_username_text" class="leftLabelMedium">QBT_TR(Username:)QBT_TR[CONTEXT=OptionsDialog]</label><input type="text" id="dyndns_username_text" />
-        </div>
-        <div class="formRow">
-            <label for="dyndns_password_text" class="leftLabelMedium">QBT_TR(Password:)QBT_TR[CONTEXT=OptionsDialog]</label><input type="password" id="dyndns_password_text" />
-        </div>
+        <table>
+            <tr>
+                <td>
+                    <label for="dyndns_domain_text">QBT_TR(Domain name:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                </td>
+                <td>
+                    <input type="text" id="dyndns_domain_text" />
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <label for="dyndns_username_text">QBT_TR(Username:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                </td>
+                <td>
+                    <input type="text" id="dyndns_username_text" />
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <label for="dyndns_password_text">QBT_TR(Password:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                </td>
+                <td>
+                    <input type="password" id="dyndns_password_text" />
+                </td>
+            </tr>
+        </table>
     </fieldset>
 </div>
 

--- a/src/webui/www/private/preferences_content.html
+++ b/src/webui/www/private/preferences_content.html
@@ -133,7 +133,7 @@
                                 <option value="default_folder">QBT_TR(Default save location)QBT_TR[CONTEXT=ScanFoldersModel]</option>
                                 <option value="other">QBT_TR(Other...)QBT_TR[CONTEXT=HttpServer]</option>
                             </select>
-                            <input id="new_watch_folder_other_txt" type="text" value="QBT_TR(Monitored folder)QBT_TR[CONTEXT=ScanFoldersModel]" onchange="changeWatchFolderText(this)" />
+                            <input id="new_watch_folder_other_txt" type="text" value="QBT_TR(Monitored folder)QBT_TR[CONTEXT=ScanFoldersModel]" hidden />
                             <img src="images/qbt-theme/list-add.svg" alt="Add" style="padding-left:170px;width:16px;cursor:pointer;" onclick="addWatchFolder();" />
                         </div>
                     </td>
@@ -795,33 +795,31 @@
 
     changeWatchFolderSelect = function(item) {
         if (item.value == "other") {
+            item.nextElementSibling.hidden = false;
             item.nextElementSibling.value = 'QBT_TR(Type folder here)QBT_TR[CONTEXT=HttpServer]';
             item.nextElementSibling.select();
         }
         else {
+            item.nextElementSibling.hidden = true;
             var text = item.options[item.selectedIndex].innerHTML;
             item.nextElementSibling.value = text;
         }
     };
 
-    changeWatchFolderText = function(item) {
-        item.previousElementSibling.value = 'other';
-    };
-
     pushWatchFolder = function(pos, folder, sel, other) {
         var myinput = "<input id='text_watch_" + pos + "' type='text' value='" + folder + "'>";
+        var disableInput = (sel != "other");
         var mycb = "<div class='select-watched-folder-editable'>"
             + "<select id ='cb_watch_" + pos + "' onchange='changeWatchFolderSelect(this)'>"
             + "<option value='watch_folder'>QBT_TR(Monitored folder)QBT_TR[CONTEXT=ScanFoldersModel]</option>"
             + "<option value='default_folder'>QBT_TR(Default save location)QBT_TR[CONTEXT=ScanFoldersModel]</option>"
             + "<option value='other'>QBT_TR(Other...)QBT_TR[CONTEXT=HttpServer]</option>"
             + "</select>"
-            + "<input id='cb_watch_txt_" + pos + "' type='text' "
-            + "onchange='changeWatchFolderText(this)' /></div>";
+            + "<input id='cb_watch_txt_" + pos + "' type='text' " + (disableInput ? "hidden " : "") + "/></div>";
 
         WatchedFoldersTable.push([myinput, mycb]);
         $('cb_watch_' + pos).setProperty('value', sel);
-        if (sel != "other") {
+        if (disableInput) {
             var elt = $('cb_watch_' + pos);
             other = elt.options[elt.selectedIndex].innerHTML;
         }

--- a/src/webui/www/private/preferences_content.html
+++ b/src/webui/www/private/preferences_content.html
@@ -159,7 +159,9 @@
     <fieldset class="settings">
         <legend>QBT_TR(Listening Port)QBT_TR[CONTEXT=OptionsDialog]</legend>
         <label for="port_value">QBT_TR(Port used for incoming connections:)QBT_TR[CONTEXT=OptionsDialog]</label>
-        <input type="text" id="port_value" style="width: 4em;" /><br/>
+        <input type="text" id="port_value" style="width: 4em;" />
+        <button style="margin-left: 1em;" onclick="generateRandomPort();">Random</button>
+        <br/>
         <input type="checkbox" id="upnp_checkbox" />
         <label for="upnp_checkbox">QBT_TR(Use UPnP / NAT-PMP port forwarding from my router)QBT_TR[CONTEXT=OptionsDialog]</label><br/>
         <input type="checkbox" id="random_port_checkbox" />
@@ -262,6 +264,9 @@
                     </td>
                 </tr>
             </table>
+            <div class="formRow">
+                <span>Info: The password is saved unencrypted</span>
+            </div>
         </fieldset>
     </fieldset>
 
@@ -889,6 +894,13 @@
         else {
             window.open("https://www.dyndns.com/account/services/hosts/add.html", "DynDNS Registration");
         }
+    };
+
+    generateRandomPort = function() {
+        var min = 1024;
+        var max = 65535;
+        var port = Math.floor(Math.random() * (max - min + 1) + min);
+        $('port_value').setProperty('value', port);
     };
 
     time_padding = function(val) {

--- a/src/webui/www/private/preferences_content.html
+++ b/src/webui/www/private/preferences_content.html
@@ -291,6 +291,9 @@
         <legend>QBT_TR(Global Rate Limits)QBT_TR[CONTEXT=OptionsDialog]</legend>
         <table>
             <tr>
+                <td rowspan="2">
+                    <img alt="QBT_TR(Alternative speed limits)QBT_TR[CONTEXT=MainWindow]" src="images/slow_off.png">
+                </td>
                 <td><label for="up_limit_value">QBT_TR(Upload:)QBT_TR[CONTEXT=OptionsDialog]</label></td>
                 <td><input type="number" id="up_limit_value" style="width: 4em;" min="0" />&nbsp;&nbsp;QBT_TR(KiB/s)QBT_TR[CONTEXT=OptionsDialog]</td>
             </tr>
@@ -306,6 +309,9 @@
         <legend>QBT_TR(Alternative Rate Limits)QBT_TR[CONTEXT=OptionsDialog]</legend>
         <table>
             <tr>
+                <td rowspan="2">
+                    <img alt="QBT_TR(Alternative speed limits)QBT_TR[CONTEXT=MainWindow]" src="images/slow.png">
+                </td>
                 <td><label for="alt_up_limit_value">QBT_TR(Upload:)QBT_TR[CONTEXT=OptionsDialog]</label></td>
                 <td><input type="number" id="alt_up_limit_value" style="width: 4em;" min="0" />&nbsp;&nbsp;QBT_TR(KiB/s)QBT_TR[CONTEXT=OptionsDialog]</td>
             </tr>

--- a/src/webui/www/private/preferences_content.html
+++ b/src/webui/www/private/preferences_content.html
@@ -521,10 +521,38 @@
                 </td>
             </tr>
         </table>
-        <div class="formRow">
-            <input type="checkbox" id="dont_count_slow_torrents_checkbox" />
-            <label for="dont_count_slow_torrents_checkbox">QBT_TR(Do not count slow torrents in these limits)QBT_TR[CONTEXT=OptionsDialog]</label>
-        </div>
+        <fieldset class="settings">
+            <legend>
+                <input type="checkbox" id="dont_count_slow_torrents_checkbox" onclick="updateSlowTorrentsSettings();" />
+                <label for="dont_count_slow_torrents_checkbox">QBT_TR(Do not count slow torrents in these limits)QBT_TR[CONTEXT=OptionsDialog]</label>
+            </legend>
+            <table>
+                <tr>
+                    <td>
+                        <label for="dl_rate_threshold">QBT_TR(Download rate threshold:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    </td>
+                    <td>
+                        <input type="text" id="dl_rate_threshold" style="width: 4em;" />&nbsp;&nbsp;QBT_TR(KiB/s)QBT_TR[CONTEXT=OptionsDialog]
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="ul_rate_threshold">QBT_TR(Upload rate threshold:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    </td>
+                    <td>
+                        <input type="text" id="ul_rate_threshold" style="width: 4em;" />&nbsp;&nbsp;QBT_TR(KiB/s)QBT_TR[CONTEXT=OptionsDialog]
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="torrent_inactive_timer">QBT_TR(Torrent inactivity timer:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    </td>
+                    <td>
+                        <input type="text" id="torrent_inactive_timer" style="width: 4em;" />&nbsp;&nbsp;QBT_TR(seconds)QBT_TR[CONTEXT=OptionsDialog]
+                    </td>
+                </tr>
+            </table>
+        </fieldset>
     </fieldset>
 
     <fieldset class="settings">
@@ -985,6 +1013,14 @@
         $('max_active_up_value').setProperty('disabled', !isQueueingEnabled);
         $('max_active_to_value').setProperty('disabled', !isQueueingEnabled);
         $('dont_count_slow_torrents_checkbox').setProperty('disabled', !isQueueingEnabled);
+        updateSlowTorrentsSettings();
+    };
+
+    updateSlowTorrentsSettings = function() {
+        var isDontCountSlowTorrentsEnabled = (!$('dont_count_slow_torrents_checkbox').getProperty('disabled')) && $('dont_count_slow_torrents_checkbox').getProperty('checked');
+        $('dl_rate_threshold').setProperty('disabled', !isDontCountSlowTorrentsEnabled);
+        $('ul_rate_threshold').setProperty('disabled', !isDontCountSlowTorrentsEnabled);
+        $('torrent_inactive_timer').setProperty('disabled', !isDontCountSlowTorrentsEnabled);
     };
 
     updateMaxRatioTimeEnabled = function() {
@@ -1255,6 +1291,9 @@
                     $('max_active_up_value').setProperty('value', pref.max_active_uploads.toInt());
                     $('max_active_to_value').setProperty('value', pref.max_active_torrents.toInt());
                     $('dont_count_slow_torrents_checkbox').setProperty('checked', pref.dont_count_slow_torrents);
+                    $('dl_rate_threshold').setProperty('value', pref.slow_torrent_dl_rate_threshold.toInt());
+                    $('ul_rate_threshold').setProperty('value', pref.slow_torrent_ul_rate_threshold.toInt());
+                    $('torrent_inactive_timer').setProperty('value', pref.slow_torrent_inactive_timer.toInt());
                     updateQueueingSystem();
 
                     // Share Limiting
@@ -1540,6 +1579,24 @@
             }
             settings.set('max_active_torrents', max_active_torrents);
             settings.set('dont_count_slow_torrents', $('dont_count_slow_torrents_checkbox').getProperty('checked'));
+            var dl_rate_threshold = $('dl_rate_threshold').getProperty('value').toInt();
+            if (isNaN(dl_rate_threshold) || (dl_rate_threshold < 1)) {
+                alert("QBT_TR(Download rate threshold must be greater than 0.)QBT_TR[CONTEXT=HttpServer]");
+                return;
+            }
+            settings.set('slow_torrent_dl_rate_threshold', dl_rate_threshold);
+            var ul_rate_threshold = $('ul_rate_threshold').getProperty('value').toInt();
+            if (isNaN(ul_rate_threshold) || (ul_rate_threshold < 1)) {
+                alert("QBT_TR(Upload rate threshold must be greater than 0.)QBT_TR[CONTEXT=HttpServer]");
+                return;
+            }
+            settings.set('slow_torrent_ul_rate_threshold', ul_rate_threshold);
+            var torrent_inactive_timer = $('torrent_inactive_timer').getProperty('value').toInt();
+            if (isNaN(torrent_inactive_timer) || (torrent_inactive_timer < 1)) {
+                alert("QBT_TR(Torrent inactivity timer must be greater than 0.)QBT_TR[CONTEXT=HttpServer]");
+                return;
+            }
+            settings.set('slow_torrent_inactive_timer', torrent_inactive_timer);
         }
 
         // Share Ratio Limiting

--- a/src/webui/www/private/scripts/download.js
+++ b/src/webui/www/private/scripts/download.js
@@ -56,6 +56,9 @@ getPreferences = function() {
             if (pref) {
                 defaultSavePath = pref.save_path;
                 $('savepath').setProperty('value', defaultSavePath);
+                $('root_folder').checked = pref.create_subfolder_enabled;
+                $('start_torrent').checked = !pref.start_paused_enabled;
+
                 if (pref.auto_tmm_enabled == 1) {
                     $('autoTMM').selectedIndex = 1;
                     $('savepath').disabled = true;

--- a/src/webui/www/private/scripts/download.js
+++ b/src/webui/www/private/scripts/download.js
@@ -21,22 +21,39 @@
  * THE SOFTWARE.
  */
 
-getSavePath = function() {
-    new Request({
-        url: 'api/v2/app/defaultSavePath',
+
+getPreferences = function() {
+    new Request.JSON({
+        url: 'api/v2/app/preferences',
         method: 'get',
         noCache: true,
         onFailure: function() {
             alert("Could not contact qBittorrent");
         },
-        onSuccess: function(data) {
-            if (data) {
-                $('savepath').setProperty('value', data);
+        onSuccess: function(pref) {
+            if (pref) {
+                $('savepath').setProperty('value', pref.save_path);
+                if (pref.auto_tmm_enabled == 1) {
+                    $('autoTMM').selectedIndex = 1;
+                    $('savepath').disabled = true;
+                }
+                else {
+                    $('autoTMM').selectedIndex = 0;
+                }
             }
         }
     }).send();
 };
 
+changeTMM = function(item) {
+    if (item.selectedIndex == 1) {
+        $('savepath').disabled = true;
+    }
+    else {
+        $('savepath').disabled = false;
+    }
+};
+
 $(window).addEventListener("load", function() {
-    getSavePath();
+    getPreferences();
 });

--- a/src/webui/www/private/shareratio.html
+++ b/src/webui/www/private/shareratio.html
@@ -150,12 +150,12 @@
 
         <div style="margin-left: 40px; margin-bottom: 5px;">
             <input type="checkbox" id="setRatio" class="shareLimitInput" onclick="enableInputBoxes()" />
-            <label for="setRatio" class="leftLabelLarge">QBT_TR(ratio)QBT_TR[CONTEXT=UpDownRatioDialog]</label>
+            <label for="setRatio">QBT_TR(ratio)QBT_TR[CONTEXT=UpDownRatioDialog]</label>
             <input type="number" id="ratio" value="0.00" step=".01" min="0" max="9999" class="shareLimitInput" />
         </div>
         <div style="margin-left: 40px; margin-bottom: 5px;">
             <input type="checkbox" id="setMinutes" class="shareLimitInput" onclick="enableInputBoxes()" />
-            <label for="setMinutes" class="leftLabelLarge">QBT_TR(minutes)QBT_TR[CONTEXT=UpDownRatioDialog]</label>
+            <label for="setMinutes">QBT_TR(minutes)QBT_TR[CONTEXT=UpDownRatioDialog]</label>
             <input type="number" id="minutes" value="0" step="1" min="0" max="525600" class="shareLimitInput" />
         </div>
         <div style="text-align: center; padding-top: 10px;">

--- a/src/webui/www/private/upload.html
+++ b/src/webui/www/private/upload.html
@@ -50,7 +50,12 @@
                         <label for="category">QBT_TR(Category:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
                     </td>
                     <td>
-                        <input type="text" id="category" name="category" style="width: 16em;" />
+                        <div class="select-watched-folder-editable">
+                            <select id="categorySelect" onchange="changeCategorySelect(this)">
+                                <option selected value="\other"></option>
+                            </select>
+                            <input name="category" type="text" value="" />
+                        </div>
                     </td>
                 </tr>
                 <tr>

--- a/src/webui/www/private/upload.html
+++ b/src/webui/www/private/upload.html
@@ -20,6 +20,17 @@
             <table style="margin: auto;">
                 <tr>
                     <td>
+                        <label for="autoTMM">QBT_TR(Torrent Management Mode:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                    </td>
+                    <td>
+                        <select id="autoTMM" name="autoTMM" onchange="changeTMM(this)">
+                            <option selected value="false">Manual</option>
+                            <option value="true">Automatic</option>
+                        </select>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
                         <label for="savepath">QBT_TR(Save files to location:)QBT_TR[CONTEXT=HttpServer]</label>
                     </td>
                     <td>

--- a/src/webui/www/private/upload.html
+++ b/src/webui/www/private/upload.html
@@ -16,48 +16,90 @@
         <div style="margin-top: 25px; display: inline-block; border: 1px solid lightgrey; border-radius: 4px;">
             <input type="file" id="fileselect" name="fileselect[]" multiple="multiple" />
         </div>
-        <fieldset class="settings" style="border: 0; text-align: left;">
-            <div class="formRow" style="margin-top: 12px;">
-                <label for="savepath" class="leftLabelLarge">QBT_TR(Save files to location:)QBT_TR[CONTEXT=HttpServer]</label>
-                <input type="text" id="savepath" name="savepath" style="width: 16em;" />
-            </div>
-            <div class="formRow">
-                <label for="rename" class="leftLabelLarge">QBT_TR(Rename torrent)QBT_TR[CONTEXT=HttpServer]</label>
-                <input type="text" id="rename" name="rename" style="width: 16em;" />
-            </div>
-            <div class="formRow">
-                <label for="category" class="leftLabelLarge">QBT_TR(Category:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
-                <input type="text" id="category" name="category" style="width: 16em;" />
-            </div>
-            <div class="formRow">
-                <label for="start_torrent" class="leftLabelLarge">QBT_TR(Start torrent)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
-                <input type="checkbox" id="start_torrent" checked="checked" />
-                <input type="hidden" id="add_paused" name="paused" value="false" readonly />
-            </div>
-            <div class="formRow">
-                <label for="skip_checking" class="leftLabelLarge">QBT_TR(Skip hash check)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
-                <input type="checkbox" id="skip_checking" name="skip_checking" value="true" />
-            </div>
-            <div class="formRow">
-                <label for="root_folder" class="leftLabelLarge">QBT_TR(Create subfolder)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
-                <input type="checkbox" id="root_folder" name="root_folder" value="true" checked="checked" />
-            </div>
-            <div class="formRow">
-                <label for="sequentialDownload" class="leftLabelLarge">QBT_TR(Download in sequential order)QBT_TR[CONTEXT=TransferListWidget]</label>
-                <input type="checkbox" id="sequentialDownload" name="sequentialDownload" value="true" />
-            </div>
-            <div class="formRow">
-                <label for="firstLastPiecePrio" class="leftLabelLarge">QBT_TR(Download first and last pieces first)QBT_TR[CONTEXT=TransferListWidget]</label>
-                <input type="checkbox" id="firstLastPiecePrio" name="firstLastPiecePrio" value="true" />
-            </div>
-            <div class="formRow">
-                <label for="dlLimit" class="leftLabelLarge">QBT_TR(Limit download rate)QBT_TR[CONTEXT=HttpServer]</label>
-                <input type="text" id="dlLimit" name="dlLimit" style="width: 16em;" placeholder="Bytes/s" />
-            </div>
-            <div class="formRow">
-                <label for="upLimit" class="leftLabelLarge">QBT_TR(Limit upload rate)QBT_TR[CONTEXT=HttpServer]</label>
-                <input type="text" id="upLimit" name="upLimit" style="width: 16em;" placeholder="Bytes/s" />
-            </div>
+        <fieldset class="settings" style="border: 0; text-align: left; margin-top: 12px;">
+            <table style="margin: auto;">
+                <tr>
+                    <td>
+                        <label for="savepath">QBT_TR(Save files to location:)QBT_TR[CONTEXT=HttpServer]</label>
+                    </td>
+                    <td>
+                        <input type="text" id="savepath" name="savepath" style="width: 16em;" />
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="rename">QBT_TR(Rename torrent)QBT_TR[CONTEXT=HttpServer]</label>
+                    </td>
+                    <td>
+                        <input type="text" id="rename" name="rename" style="width: 16em;" />
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="category">QBT_TR(Category:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                    </td>
+                    <td>
+                        <input type="text" id="category" name="category" style="width: 16em;" />
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="start_torrent">QBT_TR(Start torrent)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                    </td>
+                    <td>
+                        <input type="checkbox" id="start_torrent" checked="checked" />
+                        <input type="hidden" id="add_paused" name="paused" value="false" readonly />
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="skip_checking">QBT_TR(Skip hash check)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                    </td>
+                    <td>
+                        <input type="checkbox" id="skip_checking" name="skip_checking" value="true" />
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="root_folder">QBT_TR(Create subfolder)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                    </td>
+                    <td>
+                        <input type="checkbox" id="root_folder" name="root_folder" value="true" checked="checked" />
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="sequentialDownload">QBT_TR(Download in sequential order)QBT_TR[CONTEXT=TransferListWidget]</label>
+                    </td>
+                    <td>
+                        <input type="checkbox" id="sequentialDownload" name="sequentialDownload" value="true" />
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="firstLastPiecePrio">QBT_TR(Download first and last pieces first)QBT_TR[CONTEXT=TransferListWidget]</label>
+                    </td>
+                    <td>
+                        <input type="checkbox" id="firstLastPiecePrio" name="firstLastPiecePrio" value="true" />
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="dlLimit">QBT_TR(Limit download rate)QBT_TR[CONTEXT=HttpServer]</label>
+                    </td>
+                    <td>
+                        <input type="text" id="dlLimit" name="dlLimit" style="width: 16em;" placeholder="Bytes/s" />
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="upLimit">QBT_TR(Limit upload rate)QBT_TR[CONTEXT=HttpServer]</label>
+                    </td>
+                    <td>
+                        <input type="text" id="upLimit" name="upLimit" style="width: 16em;" placeholder="Bytes/s" />
+                    </td>
+                </tr>
+            </table>
             <div id="submitbutton" style="margin-top: 30px; text-align: center;">
                 <button type="submit" style="font-size: 1em;">QBT_TR(Upload Torrents)QBT_TR[CONTEXT=HttpServer]</button>
             </div>


### PR DESCRIPTION
This adds all the remaining GUI preferences to the WebUI- including a complete Auto TMM implementation- with a few exceptions.

**Added:**

* Downloads tab
  * "When adding a torrent" section
  * Default Torrent Management Mode
  * "When ... changed" options
  * Email "From" field
* Connection tab
  * Random port generator
  * "Password saved unencrypted" info notice
* Speed tab
  * Apply rate limit to peers on LAN
  * Global/Alternate limit icons
* BitTorrent tab
  * Slow torrent thresholds
* Web UI tab
  * Use alternative Web UI

**Not added:**

* Behavior tab (doesn't apply to the WebUI, except maybe the Log file options)
* Downloads tab
  * Torrent download dialog options
  * "Use Subcategories" option (on my to-do list, but not high up)
  * "Also when addition is cancelled" option- doesn't seem to apply to the WebUI
* RSS tab (feature not yet implemented in WebUI)
* Advanced tab

Currently there are a whole bunch of commits to make it easier to review individual features. I'm happy to squash down to fewer commits if desired. There's also going to be a whole bunch of info to add to the WebAPI documentation, which I'll likely get to as this PR gets closer to being merged.

Closes #9080, closes #9701, closes #7521, closes #9070, closes #9831, closes #9851, closes #8337, closes #6314

- [ ] Update Web API documentation