### PR TITLE
Consider empty locale  setting as not set. Closes #9735

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -91,7 +91,8 @@ void Preferences::setValue(const QString &key, const QVariant &value)
 // General options
 QString Preferences::getLocale() const
 {
-    return value("Preferences/General/Locale", QLocale::system().name()).toString();
+    const QString localeName = value("Preferences/General/Locale").toString();
+    return (localeName.isEmpty() ? QLocale::system().name() : localeName);
 }
 
 void Preferences::setLocale(const QString &locale)


### PR DESCRIPTION
When WebApplication configures, it compare m_currentLocale  with application locale and (re-)load an appropriate translator if locale was changed. m_currentLocale is set to "" initially so it should be different from all locale and translator should be loaded at the first time. `Preferences::getLocale()` returns system locale if locale setting isn't set. But it doesn't handle the (invalid) case when locale is set to empty string.

This patch make "empty" locale considered as not set (so system locale is returned instead).