### PR TITLE
Add ability to require an http request to be a POST

### DIFF
--- a/src/base/http/types.h
+++ b/src/base/http/types.h
@@ -39,6 +39,7 @@ namespace Http
     const char METHOD_GET[] = "GET";
     const char METHOD_POST[] = "POST";
 
+    const char HEADER_ALLOW[] = "allow";
     const char HEADER_CACHE_CONTROL[] = "cache-control";
     const char HEADER_CONNECTION[] = "connection";
     const char HEADER_CONTENT_DISPOSITION[] = "content-disposition";

--- a/src/webui/api/apicontroller.cpp
+++ b/src/webui/api/apicontroller.cpp
@@ -41,8 +41,16 @@ APIController::APIController(ISessionManager *sessionManager, QObject *parent)
 {
 }
 
-QVariant APIController::run(const QString &action, const StringMap &params, const DataMap &data)
+QVariant APIController::run(const QString &action, const StringMap &params, const DataMap &data, ExecutionContext context)
 {
+    const bool isSafe = isActionSafe(action);
+    const bool isUnsafe = isActionUnsafe(action);
+    if ((isSafe && (context == ExecutionContext::Unsafe)) || (isUnsafe && (context == ExecutionContext::Safe)))
+        throw APIError(APIErrorType::MethodNotAllowed);
+    // require a mapping to safe/unsafe
+    if (!isSafe && !isUnsafe)
+        throw APIError(APIErrorType::NotFound);
+
     m_result.clear(); // clear result
     m_params = params;
     m_data = data;

--- a/src/webui/api/apicontroller.h
+++ b/src/webui/api/apicontroller.h
@@ -30,6 +30,7 @@
 
 #include <QHash>
 #include <QObject>
+#include <QSet>
 #include <QVariant>
 #include <QVector>
 
@@ -39,6 +40,12 @@ struct ISessionManager;
 
 using DataMap = QHash<QString, QByteArray>;
 using StringMap = QHash<QString, QString>;
+
+enum class ExecutionContext
+{
+    Unsafe = 0,
+    Safe = 1
+};
 
 class APIController : public QObject
 {
@@ -53,7 +60,7 @@ class APIController : public QObject
 public:
     explicit APIController(ISessionManager *sessionManager, QObject *parent = nullptr);
 
-    QVariant run(const QString &action, const StringMap &params, const DataMap &data = {});
+    QVariant run(const QString &action, const StringMap &params, const DataMap &data, ExecutionContext context);
 
     ISessionManager *sessionManager() const;
 
@@ -67,6 +74,9 @@ protected:
     void setResult(const QJsonObject &result);
 
 private:
+    virtual bool isActionSafe(const QString &actionName) const = 0;
+    virtual bool isActionUnsafe(const QString &actionName) const = 0;
+
     ISessionManager *m_sessionManager;
     StringMap m_params;
     DataMap m_data;

--- a/src/webui/api/apierror.h
+++ b/src/webui/api/apierror.h
@@ -36,7 +36,8 @@ enum class APIErrorType
     BadData,
     NotFound,
     AccessDenied,
-    Conflict
+    Conflict,
+    MethodNotAllowed
 };
 
 class APIError : public RuntimeError

--- a/src/webui/api/appcontroller.h
+++ b/src/webui/api/appcontroller.h
@@ -32,13 +32,22 @@
 
 #include "apicontroller.h"
 
-class AppController : public APIController
+class AppController final : public APIController
 {
     Q_OBJECT
     Q_DISABLE_COPY(AppController)
 
 public:
     using APIController::APIController;
+
+    bool isActionSafe(const QString &actionName) const override
+    {
+        return m_safeActions.contains(actionName);
+    }
+    bool isActionUnsafe(const QString &actionName) const override
+    {
+        return m_unsafeActions.contains(actionName);
+    }
 
 private slots:
     void webapiVersionAction();
@@ -48,7 +57,22 @@ private slots:
     void preferencesAction();
     void setPreferencesAction();
     void defaultSavePathAction();
-    
+
     void networkInterfaceListAction();
     void networkInterfaceAddressListAction();
+
+private:
+    const QSet<QString> m_safeActions {
+        "webapiVersion",
+        "version",
+        "buildInfo",
+        "preferences",
+        "defaultSavePath",
+        "networkInterfaceList",
+        "networkInterfaceAddressList"
+    };
+    const QSet<QString> m_unsafeActions {
+        "shutdown",
+        "setPreferences"
+    };
 };

--- a/src/webui/api/authcontroller.h
+++ b/src/webui/api/authcontroller.h
@@ -35,7 +35,7 @@
 
 class QString;
 
-class AuthController : public APIController
+class AuthController final : public APIController
 {
     Q_OBJECT
     Q_DISABLE_COPY(AuthController)
@@ -43,11 +43,26 @@ class AuthController : public APIController
 public:
     using APIController::APIController;
 
+    bool isActionSafe(const QString &actionName) const override
+    {
+        return m_safeActions.contains(actionName);
+    }
+    bool isActionUnsafe(const QString &actionName) const override
+    {
+        return m_unsafeActions.contains(actionName);
+    }
+
 private slots:
     void loginAction();
     void logoutAction() const;
 
 private:
+    const QSet<QString> m_safeActions;
+    const QSet<QString> m_unsafeActions {
+        "login",
+        "logout"
+    };
+
     bool isBanned() const;
     int failedAttemptsCount() const;
     void increaseFailedAttempts();

--- a/src/webui/api/logcontroller.h
+++ b/src/webui/api/logcontroller.h
@@ -30,7 +30,7 @@
 
 #include "apicontroller.h"
 
-class LogController : public APIController
+class LogController final : public APIController
 {
     Q_OBJECT
     Q_DISABLE_COPY(LogController)
@@ -38,7 +38,23 @@ class LogController : public APIController
 public:
     using APIController::APIController;
 
+    bool isActionSafe(const QString &actionName) const override
+    {
+        return m_safeActions.contains(actionName);
+    }
+    bool isActionUnsafe(const QString &actionName) const override
+    {
+        return m_unsafeActions.contains(actionName);
+    }
+
 private slots:
     void mainAction();
     void peersAction();
+
+private:
+    const QSet<QString> m_safeActions {
+        "main",
+        "peers",
+    };
+    const QSet<QString> m_unsafeActions;
 };

--- a/src/webui/api/rsscontroller.h
+++ b/src/webui/api/rsscontroller.h
@@ -30,13 +30,22 @@
 
 #include "apicontroller.h"
 
-class RSSController : public APIController
+class RSSController final : public APIController
 {
     Q_OBJECT
     Q_DISABLE_COPY(RSSController)
 
 public:
     using APIController::APIController;
+
+    bool isActionSafe(const QString &actionName) const override
+    {
+        return m_safeActions.contains(actionName);
+    }
+    bool isActionUnsafe(const QString &actionName) const override
+    {
+        return m_unsafeActions.contains(actionName);
+    }
 
 private slots:
     void addFolderAction();
@@ -51,4 +60,22 @@ private slots:
     void removeRuleAction();
     void rulesAction();
     void matchingArticlesAction();
+
+private:
+    const QSet<QString> m_safeActions {
+        "items",
+        "rules",
+        "matchingArticles"
+    };
+    const QSet<QString> m_unsafeActions {
+        "addFolder",
+        "addFeed",
+        "removeItem",
+        "moveItem",
+        "markAsRead",
+        "refreshItem",
+        "setRule",
+        "renameRule",
+        "removeRule"
+    };
 };

--- a/src/webui/api/searchcontroller.h
+++ b/src/webui/api/searchcontroller.h
@@ -41,13 +41,22 @@ class QStringList;
 struct ISession;
 struct SearchResult;
 
-class SearchController : public APIController
+class SearchController final : public APIController
 {
     Q_OBJECT
     Q_DISABLE_COPY(SearchController)
 
 public:
     using APIController::APIController;
+
+    bool isActionSafe(const QString &actionName) const override
+    {
+        return m_safeActions.contains(actionName);
+    }
+    bool isActionUnsafe(const QString &actionName) const override
+    {
+        return m_unsafeActions.contains(actionName);
+    }
 
 private slots:
     void startAction();
@@ -63,6 +72,21 @@ private slots:
 
 private:
     const int MAX_CONCURRENT_SEARCHES = 5;
+
+    const QSet<QString> m_safeActions {
+        "status",
+        "results",
+        "plugins"
+    };
+    const QSet<QString> m_unsafeActions {
+        "start",
+        "stop",
+        "delete",
+        "installPlugin",
+        "uninstallPlugin",
+        "enablePlugin",
+        "updatePlugins"
+    };
 
     void checkForUpdatesFinished(const QHash<QString, PluginVersion> &updateInfo);
     void checkForUpdatesFailed(const QString &reason);

--- a/src/webui/api/synccontroller.h
+++ b/src/webui/api/synccontroller.h
@@ -38,13 +38,22 @@ class QThread;
 
 class FreeDiskSpaceChecker;
 
-class SyncController : public APIController
+class SyncController final : public APIController
 {
     Q_OBJECT
     Q_DISABLE_COPY(SyncController)
 
 public:
     using APIController::APIController;
+
+    bool isActionSafe(const QString &actionName) const override
+    {
+        return m_safeActions.contains(actionName);
+    }
+    bool isActionUnsafe(const QString &actionName) const override
+    {
+        return m_unsafeActions.contains(actionName);
+    }
 
     explicit SyncController(ISessionManager *sessionManager, QObject *parent = nullptr);
     ~SyncController() override;
@@ -55,6 +64,12 @@ private slots:
     void freeDiskSpaceSizeUpdated(qint64 freeSpaceSize);
 
 private:
+    const QSet<QString> m_safeActions {
+        "maindata",
+        "torrentPeers"
+    };
+    const QSet<QString> m_unsafeActions;
+
     qint64 getFreeDiskSpace();
     void invokeChecker() const;
 

--- a/src/webui/api/torrentscontroller.h
+++ b/src/webui/api/torrentscontroller.h
@@ -30,13 +30,22 @@
 
 #include "apicontroller.h"
 
-class TorrentsController : public APIController
+class TorrentsController final : public APIController
 {
     Q_OBJECT
     Q_DISABLE_COPY(TorrentsController)
 
 public:
     using APIController::APIController;
+
+    bool isActionSafe(const QString &actionName) const override
+    {
+        return m_safeActions.contains(actionName);
+    }
+    bool isActionUnsafe(const QString &actionName) const override
+    {
+        return m_unsafeActions.contains(actionName);
+    }
 
 private slots:
     void infoAction();
@@ -84,4 +93,55 @@ private slots:
     void toggleSequentialDownloadAction();
     void toggleFirstLastPiecePrioAction();
     void renameFileAction();
+
+private:
+    const QSet<QString> m_safeActions {
+        "info",
+        "properties",
+        "trackers",
+        "webseeds",
+        "files",
+        "pieceHashes",
+        "pieceStates",
+        "categories",
+        "tags",
+        "uploadLimit",
+        "downloadLimit"
+    };
+    const QSet<QString> m_unsafeActions {
+        "resume",
+        "pause",
+        "recheck",
+        "reannounce",
+        "rename",
+        "setCategory",
+        "createCategory",
+        "editCategory",
+        "removeCategories",
+        "addTags",
+        "removeTags",
+        "createTags",
+        "deleteTags",
+        "add",
+        "delete",
+        "addTrackers",
+        "editTracker",
+        "removeTrackers",
+        "addPeers",
+        "filePrio",
+        "setUploadLimit",
+        "setDownloadLimit",
+        "setShareLimits",
+        "increasePrio",
+        "decreasePrio",
+        "topPrio",
+        "bottomPrio",
+        "setLocation",
+        "setAutoManagement",
+        "setSuperSeeding",
+        "setForceStart",
+        "toggleSequentialDownload",
+        "toggleFirstLastPiecePrio",
+        "renameFile"
+    };
 };

--- a/src/webui/api/transfercontroller.h
+++ b/src/webui/api/transfercontroller.h
@@ -30,13 +30,22 @@
 
 #include "apicontroller.h"
 
-class TransferController : public APIController
+class TransferController final : public APIController
 {
     Q_OBJECT
     Q_DISABLE_COPY(TransferController)
 
 public:
     using APIController::APIController;
+
+    bool isActionSafe(const QString &actionName) const override
+    {
+        return m_safeActions.contains(actionName);
+    }
+    bool isActionUnsafe(const QString &actionName) const override
+    {
+        return m_unsafeActions.contains(actionName);
+    }
 
 private slots:
     void infoAction();
@@ -47,4 +56,18 @@ private slots:
     void setUploadLimitAction();
     void setDownloadLimitAction();
     void banPeersAction();
+
+private:
+    const QSet<QString> m_safeActions {
+        "info",
+        "speedLimitsMode",
+        "uploadLimit",
+        "downloadLimit"
+    };
+    const QSet<QString> m_unsafeActions {
+        "toggleSpeedLimitsMode",
+        "setUploadLimit",
+        "setDownloadLimit",
+        "banPeers"
+    };
 };

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -1024,6 +1024,7 @@ const initializeWindows = function() {
         if (confirm('QBT_TR(Are you sure you want to quit qBittorrent?)QBT_TR[CONTEXT=MainWindow]')) {
             new Request({
                 url: 'api/v2/app/shutdown',
+                method: 'post',
                 onSuccess: function() {
                     document.write('<!doctype html><html lang="${LANG}"><head> <meta charset="utf-8"> <title>QBT_TR(qBittorrent has been shutdown)QBT_TR[CONTEXT=HttpServer]</title></head><body> <h1 style="text-align: center;">QBT_TR(qBittorrent has been shutdown)QBT_TR[CONTEXT=HttpServer]</h1></body></html>');
                     document.close();

--- a/src/webui/www/private/scripts/speedslider.js
+++ b/src/webui/www/private/scripts/speedslider.js
@@ -35,7 +35,7 @@ MochaUI.extend({
             let maximum = 500;
             new Request({
                 url: 'api/v2/transfer/uploadLimit',
-                method: 'post',
+                method: 'get',
                 data: {},
                 onSuccess: function(data) {
                     if (data) {
@@ -85,7 +85,7 @@ MochaUI.extend({
                         new Request.JSON({
                             url: 'api/v2/torrents/uploadLimit',
                             noCache : true,
-                            method: 'post',
+                            method: 'get',
                             data: {
                                 hashes: hashes.join('|')
                             },
@@ -137,7 +137,7 @@ MochaUI.extend({
             let maximum = 500;
             new Request({
                 url: 'api/v2/transfer/downloadLimit',
-                method: 'post',
+                method: 'get',
                 data: {},
                 onSuccess: function(data) {
                     if (data) {
@@ -187,7 +187,7 @@ MochaUI.extend({
                         new Request.JSON({
                             url: 'api/v2/torrents/downloadLimit',
                             noCache : true,
-                            method: 'post',
+                            method: 'get',
                             data: {
                                 hashes: hashes.join('|')
                             },

--- a/src/webui/www/private/views/search.html
+++ b/src/webui/www/private/views/search.html
@@ -639,7 +639,7 @@
             new Request.JSON({
                 url: url,
                 noCache: true,
-                method: 'post',
+                method: 'get',
                 data: {
                     id: activeSearchId,
                     limit: maxResults,


### PR DESCRIPTION
I've started with requiring POST for login/logout. In the near term we should require POST for all non-idempotent methods. We can also add support for requiring GET for certain methods, but I don't think this is as important.

Bumping the Web API version to 2.2.0.