### PR TITLE
Don't double delete a pointer

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -802,8 +802,6 @@ void MainWindow::cleanup()
     m_programUpdateTimer->stop();
 #endif
 
-    delete m_searchFilterAction;
-
     // remove all child widgets
     while (QWidget *w = findChild<QWidget * >())
         delete w;


### PR DESCRIPTION
`m_searchFilterAction` is owned by Qt, so we shouldn't delete it manually.
Closes #9819.