### PR TITLE
Convert all foreach() to range-based for()

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -428,7 +428,7 @@ void Application::processParams(const QStringList &params)
     BitTorrent::AddTorrentParams torrentParams;
     TriStateBool skipTorrentDialog;
 
-    foreach (QString param, params) {
+    for (QString param : params) {
         param = param.trimmed();
 
         // Process strings indicating options specified by the user.

--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -486,7 +486,7 @@ CommandLineParameterError::CommandLineParameterError(const QString &messageForUs
 {
 }
 
-const QString& CommandLineParameterError::messageForUser() const
+const QString &CommandLineParameterError::messageForUser() const
 {
     return m_messageForUser;
 }

--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -41,6 +41,7 @@
 #include <QMessageBox>
 #endif
 
+#include "base/global.h"
 #include "base/utils/misc.h"
 #include "base/utils/string.h"
 
@@ -497,7 +498,7 @@ QString wrapText(const QString &text, int initialIndentation = USAGE_TEXT_COLUMN
     QStringList lines = {words.first()};
     int currentLineMaxLength = wrapAtColumn - initialIndentation;
 
-    foreach (const QString &word, words.mid(1)) {
+    for (const QString &word : copyAsConst(words.mid(1))) {
         if (lines.last().length() + word.length() + 1 < currentLineMaxLength) {
             lines.last().append(' ' + word);
         }

--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -498,7 +498,7 @@ QString wrapText(const QString &text, int initialIndentation = USAGE_TEXT_COLUMN
     QStringList lines = {words.first()};
     int currentLineMaxLength = wrapAtColumn - initialIndentation;
 
-    for (const QString &word : copyAsConst(words.mid(1))) {
+    for (const QString &word : asConst(words.mid(1))) {
         if (lines.last().length() + word.length() + 1 < currentLineMaxLength) {
             lines.last().append(' ' + word);
         }

--- a/src/app/filelogger.cpp
+++ b/src/app/filelogger.cpp
@@ -51,7 +51,7 @@ FileLogger::FileLogger(const QString &path, const bool backup, const int maxSize
         this->deleteOld(age, ageType);
 
     const Logger *const logger = Logger::instance();
-    for (const Log::Msg &msg : copyAsConst(logger->getMessages()))
+    for (const Log::Msg &msg : asConst(logger->getMessages()))
         addLogMessage(msg);
 
     connect(logger, &Logger::newLogMessage, this, &FileLogger::addLogMessage);
@@ -88,7 +88,7 @@ void FileLogger::deleteOld(const int age, const FileLogAgeType ageType)
     QDateTime date = QDateTime::currentDateTime();
     QDir dir(Utils::Fs::branchPath(m_path));
 
-    for (const QFileInfo &file : copyAsConst(dir.entryInfoList(QStringList("qbittorrent.log.bak*"), QDir::Files | QDir::Writable, QDir::Time | QDir::Reversed))) {
+    for (const QFileInfo &file : asConst(dir.entryInfoList(QStringList("qbittorrent.log.bak*"), QDir::Files | QDir::Writable, QDir::Time | QDir::Reversed))) {
         QDateTime modificationDate = file.lastModified();
         switch (ageType) {
         case DAYS:

--- a/src/app/filelogger.cpp
+++ b/src/app/filelogger.cpp
@@ -33,6 +33,7 @@
 #include <QFile>
 #include <QTextStream>
 
+#include "base/global.h"
 #include "base/logger.h"
 #include "base/utils/fs.h"
 
@@ -50,7 +51,7 @@ FileLogger::FileLogger(const QString &path, const bool backup, const int maxSize
         this->deleteOld(age, ageType);
 
     const Logger *const logger = Logger::instance();
-    foreach (const Log::Msg &msg, logger->getMessages())
+    for (const Log::Msg &msg : copyAsConst(logger->getMessages()))
         addLogMessage(msg);
 
     connect(logger, &Logger::newLogMessage, this, &FileLogger::addLogMessage);
@@ -87,7 +88,7 @@ void FileLogger::deleteOld(const int age, const FileLogAgeType ageType)
     QDateTime date = QDateTime::currentDateTime();
     QDir dir(Utils::Fs::branchPath(m_path));
 
-    foreach (const QFileInfo file, dir.entryInfoList(QStringList("qbittorrent.log.bak*"), QDir::Files | QDir::Writable, QDir::Time | QDir::Reversed)) {
+    for (const QFileInfo &file : copyAsConst(dir.entryInfoList(QStringList("qbittorrent.log.bak*"), QDir::Files | QDir::Writable, QDir::Time | QDir::Reversed))) {
         QDateTime modificationDate = file.lastModified();
         switch (ageType) {
         case DAYS:

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -202,7 +202,7 @@ int main(int argc, char *argv[])
         // this is the default in Qt6
         app->setAttribute(Qt::AA_DisableWindowContextHelpButton);
 #endif
-#endif
+#endif // Q_OS_WIN
 
 #if defined(Q_OS_MAC)
         // Since Apple made difficult for users to set PATH, we set here for convenience.

--- a/src/app/upgrade.h
+++ b/src/app/upgrade.h
@@ -83,7 +83,7 @@ bool userAcceptsUpgrade()
     msgBox.move(Utils::Misc::screenCenter(&msgBox));
     if (msgBox.exec() == QMessageBox::Ok)
         return true;
-#endif
+#endif // DISABLE_GUI
 
     return false;
 }

--- a/src/app/upgrade.h
+++ b/src/app/upgrade.h
@@ -179,9 +179,9 @@ bool upgrade(bool ask = true)
 
     // ****************************************************************************************
     // Silently converts old v3.3.x .fastresume files
-    QStringList backupFiles_3_3 = backupFolderDir.entryList(
+    const QStringList backupFiles_3_3 = backupFolderDir.entryList(
                 QStringList(QLatin1String("*.fastresume.*")), QDir::Files, QDir::Unsorted);
-    foreach (const QString &backupFile, backupFiles_3_3)
+    for (const QString &backupFile : backupFiles_3_3)
         upgradeResumeFile(backupFolderDir.absoluteFilePath(backupFile));
     // ****************************************************************************************
 
@@ -197,10 +197,10 @@ bool upgrade(bool ask = true)
 
     if (ask && !userAcceptsUpgrade()) return false;
 
-    QStringList backupFiles = backupFolderDir.entryList(
+    const QStringList backupFiles = backupFolderDir.entryList(
                 QStringList(QLatin1String("*.fastresume")), QDir::Files, QDir::Unsorted);
     const QRegularExpression rx(QLatin1String("^([A-Fa-f0-9]{40})\\.fastresume$"));
-    foreach (QString backupFile, backupFiles) {
+    for (const QString &backupFile : backupFiles) {
         const QRegularExpressionMatch rxMatch = rx.match(backupFile);
         if (rxMatch.hasMatch()) {
             const QString hashStr = rxMatch.captured(1);
@@ -265,7 +265,7 @@ void migratePlistToIni(const QString &application)
     plistFile->setFallbacksEnabled(false);
     const QStringList plist = plistFile->allKeys();
     if (!plist.isEmpty()) {
-        foreach (const QString &key, plist)
+        for (const QString &key : plist)
             iniFile.setValue(key, plistFile->value(key));
         plistFile->clear();
     }

--- a/src/base/bittorrent/magneturi.cpp
+++ b/src/base/bittorrent/magneturi.cpp
@@ -83,10 +83,10 @@ MagnetUri::MagnetUri(const QString &source)
     m_hash = m_addTorrentParams.info_hash;
     m_name = QString::fromStdString(m_addTorrentParams.name);
 
-    foreach (const std::string &tracker, m_addTorrentParams.trackers)
+    for (const std::string &tracker : m_addTorrentParams.trackers)
         m_trackers.append(QString::fromStdString(tracker));
 
-    foreach (const std::string &urlSeed, m_addTorrentParams.url_seeds)
+    for (const std::string &urlSeed : m_addTorrentParams.url_seeds)
         m_urlSeeds.append(QUrl(urlSeed.c_str()));
 }
 

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -199,7 +199,7 @@ namespace
 
         for (auto i = categories.cbegin(); i != categories.cend(); ++i) {
             const QString &category = i.key();
-            foreach (const QString &subcat, Session::expandCategory(category)) {
+            for (const QString &subcat : copyAsConst(Session::expandCategory(category))) {
                 if (!expanded.contains(subcat))
                     expanded[subcat] = "";
             }
@@ -610,7 +610,7 @@ void Session::setTempPathEnabled(bool enabled)
 {
     if (enabled != isTempPathEnabled()) {
         m_isTempPathEnabled = enabled;
-        foreach (TorrentHandle *const torrent, m_torrents)
+        for (TorrentHandle *const torrent : qAsConst(m_torrents))
             torrent->handleTempPathChanged();
     }
 }
@@ -624,7 +624,7 @@ void Session::setAppendExtensionEnabled(bool enabled)
 {
     if (isAppendExtensionEnabled() != enabled) {
         // append or remove .!qB extension for incomplete files
-        foreach (TorrentHandle *const torrent, m_torrents)
+        for (TorrentHandle *const torrent : qAsConst(m_torrents))
             torrent->handleAppendExtensionToggled();
 
         m_isAppendExtensionEnabled = enabled;
@@ -752,7 +752,7 @@ bool Session::addCategory(const QString &name, const QString &savePath)
         return false;
 
     if (isSubcategoriesEnabled()) {
-        foreach (const QString &parent, expandCategory(name)) {
+        for (const QString &parent : copyAsConst(expandCategory(name))) {
             if ((parent != name) && !m_categories.contains(parent)) {
                 m_categories[parent] = "";
                 emit categoryAdded(parent);
@@ -775,12 +775,12 @@ bool Session::editCategory(const QString &name, const QString &savePath)
     m_categories[name] = savePath;
     m_storedCategories = map_cast(m_categories);
     if (isDisableAutoTMMWhenCategorySavePathChanged()) {
-        foreach (TorrentHandle *const torrent, torrents())
+        for (TorrentHandle *const torrent : copyAsConst(torrents()))
             if (torrent->category() == name)
                 torrent->setAutoTMMEnabled(false);
     }
     else {
-        foreach (TorrentHandle *const torrent, torrents())
+        for (TorrentHandle *const torrent : copyAsConst(torrents()))
             if (torrent->category() == name)
                 torrent->handleCategorySavePathChanged();
     }
@@ -790,7 +790,7 @@ bool Session::editCategory(const QString &name, const QString &savePath)
 
 bool Session::removeCategory(const QString &name)
 {
-    foreach (TorrentHandle *const torrent, torrents())
+    for (TorrentHandle *const torrent : copyAsConst(torrents()))
         if (torrent->belongsToCategory(name))
             torrent->setCategory("");
 
@@ -877,7 +877,7 @@ bool Session::addTag(const QString &tag)
 bool Session::removeTag(const QString &tag)
 {
     if (m_tags.remove(tag)) {
-        foreach (TorrentHandle *const torrent, torrents())
+        for (TorrentHandle *const torrent : copyAsConst(torrents()))
             torrent->removeTag(tag);
         m_storedTags = m_tags.toList();
         emit tagRemoved(tag);
@@ -1085,7 +1085,7 @@ void Session::configure()
 void Session::processBannedIPs(libt::ip_filter &filter)
 {
     // First, import current filter
-    foreach (const QString &ip, m_bannedIPs.value()) {
+    for (const QString &ip : copyAsConst(m_bannedIPs.value())) {
         boost::system::error_code ec;
         libt::address addr = libt::address::from_string(ip.toLatin1().constData(), ec);
         Q_ASSERT(!ec);
@@ -1204,7 +1204,7 @@ void Session::configure(libtorrent::settings_pack &settingsPack)
         const ushort port = this->port();
         std::pair<int, int> ports(port, port);
         settingsPack.set_int(libt::settings_pack::max_retry_port_bind, ports.second - ports.first);
-        foreach (QString ip, getListeningIPs()) {
+        for (QString ip : getListeningIPs()) {
             libt::error_code ec;
             std::string interfacesStr;
 
@@ -1770,7 +1770,7 @@ void Session::enableBandwidthScheduler()
 void Session::populateAdditionalTrackers()
 {
     m_additionalTrackerList.clear();
-    foreach (QString tracker, additionalTrackers().split('\n')) {
+    for (QString tracker : copyAsConst(additionalTrackers().split('\n'))) {
         tracker = tracker.trimmed();
         if (!tracker.isEmpty())
             m_additionalTrackerList << tracker;
@@ -1781,7 +1781,7 @@ void Session::processShareLimits()
 {
     qDebug("Processing share limits...");
 
-    foreach (TorrentHandle *const torrent, m_torrents) {
+    for (TorrentHandle *const torrent : copyAsConst(torrents())) {
         if (torrent->isSeed() && !torrent->isForced()) {
             if (torrent->ratioLimit() != TorrentHandle::NO_RATIO_LIMIT) {
                 const qreal ratio = torrent->realRatio();
@@ -1934,7 +1934,7 @@ bool Session::deleteTorrent(const QString &hash, bool deleteLocalFiles)
         m_nativeSession->remove_torrent(torrent->nativeHandle(), libt::session::delete_partfile);
 #endif
         // Remove unwanted and incomplete files
-        foreach (const QString &unwantedFile, unwantedFiles) {
+        for (const QString &unwantedFile : qAsConst(unwantedFiles)) {
             qDebug("Removing unwanted file: %s", qUtf8Printable(unwantedFile));
             Utils::Fs::forceRemove(unwantedFile);
             const QString parentFolder = Utils::Fs::branchPath(unwantedFile);
@@ -1948,7 +1948,7 @@ bool Session::deleteTorrent(const QString &hash, bool deleteLocalFiles)
     QStringList filters;
     filters << QString("%1.*").arg(torrent->hash());
     const QStringList files = resumeDataDir.entryList(filters, QDir::Files, QDir::Unsorted);
-    foreach (const QString &file, files)
+    for (const QString &file : files)
         Utils::Fs::forceRemove(resumeDataDir.absoluteFilePath(file));
 
     delete torrent;
@@ -1983,7 +1983,7 @@ void Session::increaseTorrentsPriority(const QStringList &hashes)
             std::greater<QPair<int, TorrentHandle *>>> torrentQueue;
 
     // Sort torrents by priority
-    foreach (const InfoHash &infoHash, hashes) {
+    for (const InfoHash infoHash : hashes) {
         TorrentHandle *const torrent = m_torrents.value(infoHash);
         if (torrent && !torrent->isSeed())
             torrentQueue.push(qMakePair(torrent->queuePosition(), torrent));
@@ -2006,7 +2006,7 @@ void Session::decreaseTorrentsPriority(const QStringList &hashes)
             std::less<QPair<int, TorrentHandle *>>> torrentQueue;
 
     // Sort torrents by priority
-    foreach (const InfoHash &infoHash, hashes) {
+    for (const InfoHash infoHash : hashes) {
         TorrentHandle *const torrent = m_torrents.value(infoHash);
         if (torrent && !torrent->isSeed())
             torrentQueue.push(qMakePair(torrent->queuePosition(), torrent));
@@ -2032,7 +2032,7 @@ void Session::topTorrentsPriority(const QStringList &hashes)
             std::greater<QPair<int, TorrentHandle *>>> torrentQueue;
 
     // Sort torrents by priority
-    foreach (const InfoHash &infoHash, hashes) {
+    for (const InfoHash infoHash : hashes) {
         TorrentHandle *const torrent = m_torrents.value(infoHash);
         if (torrent && !torrent->isSeed())
             torrentQueue.push(qMakePair(torrent->queuePosition(), torrent));
@@ -2055,7 +2055,7 @@ void Session::bottomTorrentsPriority(const QStringList &hashes)
             std::less<QPair<int, TorrentHandle *>>> torrentQueue;
 
     // Sort torrents by priority
-    foreach (const InfoHash &infoHash, hashes) {
+    for (const InfoHash infoHash : hashes) {
         TorrentHandle *const torrent = m_torrents.value(infoHash);
         if (torrent && !torrent->isSeed())
             torrentQueue.push(qMakePair(torrent->queuePosition(), torrent));
@@ -2367,7 +2367,7 @@ void Session::exportTorrentFile(TorrentHandle *const torrent, TorrentExportFolde
 
 void Session::generateResumeData(bool final)
 {
-    foreach (TorrentHandle *const torrent, m_torrents) {
+    for (TorrentHandle *const torrent : qAsConst(m_torrents)) {
         if (!torrent->isValid()) continue;
         if (torrent->isChecking() || torrent->isPaused()) continue;
         if (!final && !torrent->needSaveResumeData()) continue;
@@ -2444,10 +2444,10 @@ void Session::setDefaultSavePath(QString path)
     m_defaultSavePath = path;
 
     if (isDisableAutoTMMWhenDefaultSavePathChanged())
-        foreach (TorrentHandle *const torrent, torrents())
+        for (TorrentHandle *const torrent : copyAsConst(torrents()))
             torrent->setAutoTMMEnabled(false);
     else
-        foreach (TorrentHandle *const torrent, torrents())
+        for (TorrentHandle *const torrent : copyAsConst(torrents()))
             torrent->handleCategorySavePathChanged();
 }
 
@@ -2458,7 +2458,7 @@ void Session::setTempPath(QString path)
 
     m_tempPath = path;
 
-    foreach (TorrentHandle *const torrent, m_torrents)
+    for (TorrentHandle *const torrent : qAsConst(m_torrents))
         torrent->handleTempPathChanged();
 }
 
@@ -2532,7 +2532,7 @@ const QStringList Session::getListeningIPs()
     QHostAddress ip;
     QString ipString;
     QAbstractSocket::NetworkLayerProtocol protocol;
-    foreach (const QNetworkAddressEntry &entry, addresses) {
+    for (const QNetworkAddressEntry &entry : addresses) {
         ip = entry.ip();
         ipString = ip.toString();
         protocol = ip.protocol();
@@ -2578,7 +2578,7 @@ void Session::configureListeningInterface()
     libt::error_code ec;
     const QStringList IPs = getListeningIPs();
 
-    foreach (const QString ip, IPs) {
+    for (const QString ip : IPs) {
         if (ip.isEmpty()) {
             logger->addMessage(tr("qBittorrent is trying to listen on any interface port: %1", "e.g: qBittorrent is trying to listen on any interface port: TCP/6881").arg(QString::number(port)), Log::INFO);
             m_nativeSession->listen_on(ports, ec, 0, libt::session::listen_no_system_port);
@@ -3776,7 +3776,7 @@ void Session::handleTorrentTrackerWarning(TorrentHandle *const torrent, const QS
 
 bool Session::hasPerTorrentRatioLimit() const
 {
-    foreach (TorrentHandle *const torrent, m_torrents)
+    for (TorrentHandle *const torrent : qAsConst(m_torrents))
         if (torrent->ratioLimit() >= 0) return true;
 
     return false;
@@ -3784,7 +3784,7 @@ bool Session::hasPerTorrentRatioLimit() const
 
 bool Session::hasPerTorrentSeedingTimeLimit() const
 {
-    foreach (TorrentHandle *const torrent, m_torrents)
+    for (TorrentHandle *const torrent : qAsConst(m_torrents))
         if (torrent->seedingTimeLimit() >= 0) return true;
 
     return false;
@@ -3928,7 +3928,7 @@ void Session::startUpTorrents()
             QMap<int, TorrentResumeData> queuedResumeData;
             int nextQueuePosition = 1;
             int numOfRemappedFiles = 0;
-            foreach (const QString &fastresumeName, fastresumes) {
+            for (const QString &fastresumeName : qAsConst(fastresumes)) {
                 const QRegularExpressionMatch rxMatch = rx.match(fastresumeName);
                 if (!rxMatch.hasMatch()) continue;
 
@@ -3967,7 +3967,7 @@ void Session::startUpTorrents()
             }
 
             // starting up downloading torrents (queue position > 0)
-            foreach (const TorrentResumeData &torrentResumeData, queuedResumeData)
+            for (const TorrentResumeData &torrentResumeData : qAsConst(queuedResumeData))
                 startupTorrent(torrentResumeData);
 
             return;
@@ -4547,14 +4547,14 @@ void Session::handleStateUpdateAlert(libt::state_update_alert *p)
     updateStats();
 #endif
 
-    foreach (const libt::torrent_status &status, p->status) {
+    for (const libt::torrent_status &status : p->status) {
         TorrentHandle *const torrent = m_torrents.value(status.info_hash);
         if (torrent)
             torrent->handleStateUpdate(status);
     }
 
     m_torrentStatusReport = TorrentStatusReport();
-    foreach (TorrentHandle *const torrent, m_torrents) {
+    for (TorrentHandle *const torrent : qAsConst(m_torrents)) {
         if (torrent->isDownloading())
             ++m_torrentStatusReport.nbDownloading;
         if (torrent->isUploading())

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -199,7 +199,7 @@ namespace
 
         for (auto i = categories.cbegin(); i != categories.cend(); ++i) {
             const QString &category = i.key();
-            for (const QString &subcat : copyAsConst(Session::expandCategory(category))) {
+            for (const QString &subcat : asConst(Session::expandCategory(category))) {
                 if (!expanded.contains(subcat))
                     expanded[subcat] = "";
             }
@@ -610,7 +610,7 @@ void Session::setTempPathEnabled(bool enabled)
 {
     if (enabled != isTempPathEnabled()) {
         m_isTempPathEnabled = enabled;
-        for (TorrentHandle *const torrent : qAsConst(m_torrents))
+        for (TorrentHandle *const torrent : asConst(m_torrents))
             torrent->handleTempPathChanged();
     }
 }
@@ -624,7 +624,7 @@ void Session::setAppendExtensionEnabled(bool enabled)
 {
     if (isAppendExtensionEnabled() != enabled) {
         // append or remove .!qB extension for incomplete files
-        for (TorrentHandle *const torrent : qAsConst(m_torrents))
+        for (TorrentHandle *const torrent : asConst(m_torrents))
             torrent->handleAppendExtensionToggled();
 
         m_isAppendExtensionEnabled = enabled;
@@ -752,7 +752,7 @@ bool Session::addCategory(const QString &name, const QString &savePath)
         return false;
 
     if (isSubcategoriesEnabled()) {
-        for (const QString &parent : copyAsConst(expandCategory(name))) {
+        for (const QString &parent : asConst(expandCategory(name))) {
             if ((parent != name) && !m_categories.contains(parent)) {
                 m_categories[parent] = "";
                 emit categoryAdded(parent);
@@ -775,12 +775,12 @@ bool Session::editCategory(const QString &name, const QString &savePath)
     m_categories[name] = savePath;
     m_storedCategories = map_cast(m_categories);
     if (isDisableAutoTMMWhenCategorySavePathChanged()) {
-        for (TorrentHandle *const torrent : copyAsConst(torrents()))
+        for (TorrentHandle *const torrent : asConst(torrents()))
             if (torrent->category() == name)
                 torrent->setAutoTMMEnabled(false);
     }
     else {
-        for (TorrentHandle *const torrent : copyAsConst(torrents()))
+        for (TorrentHandle *const torrent : asConst(torrents()))
             if (torrent->category() == name)
                 torrent->handleCategorySavePathChanged();
     }
@@ -790,7 +790,7 @@ bool Session::editCategory(const QString &name, const QString &savePath)
 
 bool Session::removeCategory(const QString &name)
 {
-    for (TorrentHandle *const torrent : copyAsConst(torrents()))
+    for (TorrentHandle *const torrent : asConst(torrents()))
         if (torrent->belongsToCategory(name))
             torrent->setCategory("");
 
@@ -877,7 +877,7 @@ bool Session::addTag(const QString &tag)
 bool Session::removeTag(const QString &tag)
 {
     if (m_tags.remove(tag)) {
-        for (TorrentHandle *const torrent : copyAsConst(torrents()))
+        for (TorrentHandle *const torrent : asConst(torrents()))
             torrent->removeTag(tag);
         m_storedTags = m_tags.toList();
         emit tagRemoved(tag);
@@ -1085,7 +1085,7 @@ void Session::configure()
 void Session::processBannedIPs(libt::ip_filter &filter)
 {
     // First, import current filter
-    for (const QString &ip : copyAsConst(m_bannedIPs.value())) {
+    for (const QString &ip : asConst(m_bannedIPs.value())) {
         boost::system::error_code ec;
         libt::address addr = libt::address::from_string(ip.toLatin1().constData(), ec);
         Q_ASSERT(!ec);
@@ -1770,7 +1770,7 @@ void Session::enableBandwidthScheduler()
 void Session::populateAdditionalTrackers()
 {
     m_additionalTrackerList.clear();
-    for (QString tracker : copyAsConst(additionalTrackers().split('\n'))) {
+    for (QString tracker : asConst(additionalTrackers().split('\n'))) {
         tracker = tracker.trimmed();
         if (!tracker.isEmpty())
             m_additionalTrackerList << tracker;
@@ -1781,7 +1781,7 @@ void Session::processShareLimits()
 {
     qDebug("Processing share limits...");
 
-    for (TorrentHandle *const torrent : copyAsConst(torrents())) {
+    for (TorrentHandle *const torrent : asConst(torrents())) {
         if (torrent->isSeed() && !torrent->isForced()) {
             if (torrent->ratioLimit() != TorrentHandle::NO_RATIO_LIMIT) {
                 const qreal ratio = torrent->realRatio();
@@ -1934,7 +1934,7 @@ bool Session::deleteTorrent(const QString &hash, bool deleteLocalFiles)
         m_nativeSession->remove_torrent(torrent->nativeHandle(), libt::session::delete_partfile);
 #endif
         // Remove unwanted and incomplete files
-        for (const QString &unwantedFile : qAsConst(unwantedFiles)) {
+        for (const QString &unwantedFile : asConst(unwantedFiles)) {
             qDebug("Removing unwanted file: %s", qUtf8Printable(unwantedFile));
             Utils::Fs::forceRemove(unwantedFile);
             const QString parentFolder = Utils::Fs::branchPath(unwantedFile);
@@ -2367,7 +2367,7 @@ void Session::exportTorrentFile(TorrentHandle *const torrent, TorrentExportFolde
 
 void Session::generateResumeData(bool final)
 {
-    for (TorrentHandle *const torrent : qAsConst(m_torrents)) {
+    for (TorrentHandle *const torrent : asConst(m_torrents)) {
         if (!torrent->isValid()) continue;
         if (torrent->isChecking() || torrent->isPaused()) continue;
         if (!final && !torrent->needSaveResumeData()) continue;
@@ -2414,7 +2414,7 @@ void Session::saveResumeData()
 void Session::saveTorrentsQueue()
 {
     QMap<int, QString> queue; // Use QMap since it should be ordered by key
-    for (const TorrentHandle *torrent : copyAsConst(torrents())) {
+    for (const TorrentHandle *torrent : asConst(torrents())) {
         // We require actual (non-cached) queue position here!
         const int queuePos = torrent->nativeHandle().queue_position();
         if (queuePos >= 0)
@@ -2422,7 +2422,7 @@ void Session::saveTorrentsQueue()
     }
 
     QByteArray data;
-    for (const QString &hash : qAsConst(queue))
+    for (const QString &hash : asConst(queue))
         data += (hash.toLatin1() + '\n');
 
     const QString filename = QLatin1String {"queue"};
@@ -2444,10 +2444,10 @@ void Session::setDefaultSavePath(QString path)
     m_defaultSavePath = path;
 
     if (isDisableAutoTMMWhenDefaultSavePathChanged())
-        for (TorrentHandle *const torrent : copyAsConst(torrents()))
+        for (TorrentHandle *const torrent : asConst(torrents()))
             torrent->setAutoTMMEnabled(false);
     else
-        for (TorrentHandle *const torrent : copyAsConst(torrents()))
+        for (TorrentHandle *const torrent : asConst(torrents()))
             torrent->handleCategorySavePathChanged();
 }
 
@@ -2458,7 +2458,7 @@ void Session::setTempPath(QString path)
 
     m_tempPath = path;
 
-    for (TorrentHandle *const torrent : qAsConst(m_torrents))
+    for (TorrentHandle *const torrent : asConst(m_torrents))
         torrent->handleTempPathChanged();
 }
 
@@ -3776,7 +3776,7 @@ void Session::handleTorrentTrackerWarning(TorrentHandle *const torrent, const QS
 
 bool Session::hasPerTorrentRatioLimit() const
 {
-    for (TorrentHandle *const torrent : qAsConst(m_torrents))
+    for (TorrentHandle *const torrent : asConst(m_torrents))
         if (torrent->ratioLimit() >= 0) return true;
 
     return false;
@@ -3784,7 +3784,7 @@ bool Session::hasPerTorrentRatioLimit() const
 
 bool Session::hasPerTorrentSeedingTimeLimit() const
 {
-    for (TorrentHandle *const torrent : qAsConst(m_torrents))
+    for (TorrentHandle *const torrent : asConst(m_torrents))
         if (torrent->seedingTimeLimit() >= 0) return true;
 
     return false;
@@ -3928,7 +3928,7 @@ void Session::startUpTorrents()
             QMap<int, TorrentResumeData> queuedResumeData;
             int nextQueuePosition = 1;
             int numOfRemappedFiles = 0;
-            for (const QString &fastresumeName : qAsConst(fastresumes)) {
+            for (const QString &fastresumeName : asConst(fastresumes)) {
                 const QRegularExpressionMatch rxMatch = rx.match(fastresumeName);
                 if (!rxMatch.hasMatch()) continue;
 
@@ -3967,7 +3967,7 @@ void Session::startUpTorrents()
             }
 
             // starting up downloading torrents (queue position > 0)
-            for (const TorrentResumeData &torrentResumeData : qAsConst(queuedResumeData))
+            for (const TorrentResumeData &torrentResumeData : asConst(queuedResumeData))
                 startupTorrent(torrentResumeData);
 
             return;
@@ -3989,7 +3989,7 @@ void Session::startUpTorrents()
             fastresumes = queue + fastresumes.toSet().subtract(queue.toSet()).toList();
     }
 
-    for (const QString &fastresumeName : qAsConst(fastresumes)) {
+    for (const QString &fastresumeName : asConst(fastresumes)) {
         const QRegularExpressionMatch rxMatch = rx.match(fastresumeName);
         if (!rxMatch.hasMatch()) continue;
 
@@ -4554,7 +4554,7 @@ void Session::handleStateUpdateAlert(libt::state_update_alert *p)
     }
 
     m_torrentStatusReport = TorrentStatusReport();
-    for (TorrentHandle *const torrent : qAsConst(m_torrents)) {
+    for (TorrentHandle *const torrent : asConst(m_torrents)) {
         if (torrent->isDownloading())
             ++m_torrentStatusReport.nbDownloading;
         if (torrent->isUploading())

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -469,7 +469,7 @@ Session::Session(QObject *parent)
     });
 
     configurePeerClasses();
-#endif
+#endif // LIBTORRENT_VERSION_NUM < 10100
 
     // Enabling plugins
     //m_nativeSession->add_extension(&libt::create_metadata_plugin);
@@ -1253,7 +1253,7 @@ void Session::configure(libtorrent::settings_pack &settingsPack)
         }
 #else
         settingsPack.set_str(libt::settings_pack::outgoing_interfaces, networkInterface().toStdString());
-#endif
+#endif // Q_OS_WIN
         m_listenInterfaceChanged = false;
     }
 
@@ -1462,7 +1462,7 @@ void Session::configurePeerClasses()
                    , 1 << libt::session::global_peer_class_id);
     }
     catch (std::exception &) {}
-#endif
+#endif // TORRENT_USE_IPV6
     if (ignoreLimitsOnLAN()) {
         // local networks
         f.add_rule(libt::address_v4::from_string("10.0.0.0")
@@ -1501,7 +1501,7 @@ void Session::configurePeerClasses()
                        , 1 << libt::session::local_peer_class_id);
         }
         catch (std::exception &) {}
-#endif
+#endif // TORRENT_USE_IPV6
     }
     m_nativeSession->set_peer_class_filter(f);
 
@@ -1518,7 +1518,7 @@ void Session::configurePeerClasses()
     m_nativeSession->set_peer_class_type_filter(peerClassTypeFilter);
 }
 
-#else
+#else // LIBTORRENT_VERSION_NUM >= 10100
 
 void Session::adjustLimits(libt::session_settings &sessionSettings)
 {
@@ -1735,7 +1735,7 @@ void Session::configure(libtorrent::session_settings &sessionSettings)
         break;
     }
 }
-#endif
+#endif // LIBTORRENT_VERSION_NUM >= 10100
 
 void Session::enableTracker(bool enable)
 {
@@ -1983,8 +1983,8 @@ void Session::increaseTorrentsPriority(const QStringList &hashes)
             std::greater<QPair<int, TorrentHandle *>>> torrentQueue;
 
     // Sort torrents by priority
-    foreach (const InfoHash &hash, hashes) {
-        TorrentHandle *const torrent = m_torrents.value(hash);
+    foreach (const InfoHash &infoHash, hashes) {
+        TorrentHandle *const torrent = m_torrents.value(infoHash);
         if (torrent && !torrent->isSeed())
             torrentQueue.push(qMakePair(torrent->queuePosition(), torrent));
     }
@@ -2006,8 +2006,8 @@ void Session::decreaseTorrentsPriority(const QStringList &hashes)
             std::less<QPair<int, TorrentHandle *>>> torrentQueue;
 
     // Sort torrents by priority
-    foreach (const InfoHash &hash, hashes) {
-        TorrentHandle *const torrent = m_torrents.value(hash);
+    foreach (const InfoHash &infoHash, hashes) {
+        TorrentHandle *const torrent = m_torrents.value(infoHash);
         if (torrent && !torrent->isSeed())
             torrentQueue.push(qMakePair(torrent->queuePosition(), torrent));
     }
@@ -2032,8 +2032,8 @@ void Session::topTorrentsPriority(const QStringList &hashes)
             std::greater<QPair<int, TorrentHandle *>>> torrentQueue;
 
     // Sort torrents by priority
-    foreach (const InfoHash &hash, hashes) {
-        TorrentHandle *const torrent = m_torrents.value(hash);
+    foreach (const InfoHash &infoHash, hashes) {
+        TorrentHandle *const torrent = m_torrents.value(infoHash);
         if (torrent && !torrent->isSeed())
             torrentQueue.push(qMakePair(torrent->queuePosition(), torrent));
     }
@@ -2055,8 +2055,8 @@ void Session::bottomTorrentsPriority(const QStringList &hashes)
             std::less<QPair<int, TorrentHandle *>>> torrentQueue;
 
     // Sort torrents by priority
-    foreach (const InfoHash &hash, hashes) {
-        TorrentHandle *const torrent = m_torrents.value(hash);
+    foreach (const InfoHash &infoHash, hashes) {
+        TorrentHandle *const torrent = m_torrents.value(infoHash);
         if (torrent && !torrent->isSeed())
             torrentQueue.push(qMakePair(torrent->queuePosition(), torrent));
     }
@@ -2397,7 +2397,7 @@ void Session::saveResumeData()
             break;
         }
 
-        for (const auto a: alerts) {
+        for (const auto a : alerts) {
             switch (a->type()) {
             case libt::save_resume_data_failed_alert::alert_type:
             case libt::save_resume_data_alert::alert_type:
@@ -2598,7 +2598,7 @@ void Session::configureListeningInterface()
 #else
     m_listenInterfaceChanged = true;
     configureDeferred();
-#endif
+#endif // LIBTORRENT_VERSION_NUM < 10100
 }
 
 int Session::globalDownloadSpeedLimit() const
@@ -3011,7 +3011,7 @@ void Session::setMaxConnectionsPerTorrent(int max)
         m_maxConnectionsPerTorrent = max;
 
         // Apply this to all session torrents
-        for (const auto &handle: m_nativeSession->get_torrents()) {
+        for (const auto &handle : m_nativeSession->get_torrents()) {
             if (!handle.is_valid()) continue;
             try {
                 handle.set_max_connections(max);
@@ -3033,7 +3033,7 @@ void Session::setMaxUploadsPerTorrent(int max)
         m_maxUploadsPerTorrent = max;
 
         // Apply this to all session torrents
-        for (const auto &handle: m_nativeSession->get_torrents()) {
+        for (const auto &handle : m_nativeSession->get_torrents()) {
             if (!handle.is_valid()) continue;
             try {
                 handle.set_max_uploads(max);
@@ -4095,7 +4095,7 @@ void Session::readAlerts()
     std::vector<libt::alert *> alerts;
     getPendingAlerts(alerts);
 
-    for (const auto a: alerts) {
+    for (const auto a : alerts) {
         handleAlert(a);
 #if LIBTORRENT_VERSION_NUM < 10100
         delete a;
@@ -4502,7 +4502,7 @@ void Session::handleSessionStatsAlert(libt::session_stats_alert *p)
 
     emit statsUpdated();
 }
-#else
+#else // LIBTORRENT_VERSION_NUM >= 10100
 void Session::updateStats()
 {
     libt::session_status ss = m_nativeSession->status();
@@ -4539,7 +4539,7 @@ void Session::updateStats()
 
     emit statsUpdated();
 }
-#endif
+#endif // LIBTORRENT_VERSION_NUM >= 10100
 
 void Session::handleStateUpdateAlert(libt::state_update_alert *p)
 {
@@ -4590,7 +4590,7 @@ namespace
         return true;
     }
 
-    bool loadTorrentResumeData(const QByteArray &data, CreateTorrentParams &torrentParams, int &prio,  MagnetUri &magnetUri)
+    bool loadTorrentResumeData(const QByteArray &data, CreateTorrentParams &torrentParams, int &prio, MagnetUri &magnetUri)
     {
         torrentParams = CreateTorrentParams();
         torrentParams.restored = true;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -237,7 +237,7 @@ namespace BitTorrent
             int diskJobTime = 0;
         } disk;
     };
-#endif
+#endif // LIBTORRENT_VERSION_NUM >= 10100
 
     class Session : public QObject
     {

--- a/src/base/bittorrent/torrentcreatorthread.cpp
+++ b/src/base/bittorrent/torrentcreatorthread.cpp
@@ -141,14 +141,14 @@ void TorrentCreatorThread::run()
 #endif
 
         // Add url seeds
-        foreach (QString seed, m_params.urlSeeds) {
+        for (QString seed : qAsConst(m_params.urlSeeds)) {
             seed = seed.trimmed();
             if (!seed.isEmpty())
                 newTorrent.add_url_seed(seed.toStdString());
         }
 
         int tier = 0;
-        foreach (const QString &tracker, m_params.trackers) {
+        for (const QString &tracker : qAsConst(m_params.trackers)) {
             if (tracker.isEmpty())
                 ++tier;
             else

--- a/src/base/bittorrent/torrentcreatorthread.cpp
+++ b/src/base/bittorrent/torrentcreatorthread.cpp
@@ -110,7 +110,7 @@ void TorrentCreatorThread::run()
             QStringList fileNames;
             QHash<QString, boost::int64_t> fileSizeMap;
 
-            for (const auto &dir : qAsConst(dirs)) {
+            for (const auto &dir : asConst(dirs)) {
                 QStringList tmpNames;  // natural sort files within each dir
 
                 QDirIterator fileIter(dir, QDir::Files);
@@ -126,7 +126,7 @@ void TorrentCreatorThread::run()
                 fileNames += tmpNames;
             }
 
-            for (const auto &fileName : qAsConst(fileNames))
+            for (const auto &fileName : asConst(fileNames))
                 fs.add_file(fileName.toStdString(), fileSizeMap[fileName]);
         }
 
@@ -141,14 +141,14 @@ void TorrentCreatorThread::run()
 #endif
 
         // Add url seeds
-        for (QString seed : qAsConst(m_params.urlSeeds)) {
+        for (QString seed : asConst(m_params.urlSeeds)) {
             seed = seed.trimmed();
             if (!seed.isEmpty())
                 newTorrent.add_url_seed(seed.toStdString());
         }
 
         int tier = 0;
-        for (const QString &tracker : qAsConst(m_params.trackers)) {
+        for (const QString &tracker : asConst(m_params.trackers)) {
             if (tracker.isEmpty())
                 ++tier;
             else

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -158,14 +158,14 @@ namespace
 {
     // new constructor is available
     template<typename T, typename std::enable_if<std::is_constructible<T, libt::torrent_info, bool>::value, int>::type = 0>
-    T makeTorrentCreator(const libtorrent::torrent_info & ti)
+    T makeTorrentCreator(const libtorrent::torrent_info &ti)
     {
         return T(ti, true);
     }
 
     // new constructor isn't available
     template<typename T, typename std::enable_if<!std::is_constructible<T, libt::torrent_info, bool>::value, int>::type = 0>
-    T makeTorrentCreator(const libtorrent::torrent_info & ti)
+    T makeTorrentCreator(const libtorrent::torrent_info &ti)
     {
         return T(ti);
     }
@@ -623,7 +623,7 @@ QString TorrentHandle::filePath(int index) const
 
 QString TorrentHandle::fileName(int index) const
 {
-    if (!hasMetadata()) return  QString();
+    if (!hasMetadata()) return QString();
     return Utils::Fs::fileName(filePath(index));
 }
 
@@ -636,7 +636,7 @@ qlonglong TorrentHandle::fileSize(int index) const
 // to all files in a torrent
 QStringList TorrentHandle::absoluteFilePaths() const
 {
-    if (!hasMetadata()) return  QStringList();
+    if (!hasMetadata()) return QStringList();
 
     QDir saveDir(savePath(true));
     QStringList res;
@@ -647,7 +647,7 @@ QStringList TorrentHandle::absoluteFilePaths() const
 
 QStringList TorrentHandle::absoluteFilePathsUnwanted() const
 {
-    if (!hasMetadata()) return  QStringList();
+    if (!hasMetadata()) return QStringList();
 
     QDir saveDir(savePath(true));
     QStringList res;
@@ -2063,7 +2063,7 @@ void TorrentHandle::prioritizeFiles(const QVector<int> &priorities)
                 if (created) {
                     // Hide the folder on Windows
                     qDebug() << "Hiding folder (Windows)";
-                    std::wstring winPath =  Utils::Fs::toNativePath(unwantedAbsPath).toStdWString();
+                    std::wstring winPath = Utils::Fs::toNativePath(unwantedAbsPath).toStdWString();
                     DWORD dwAttrs = ::GetFileAttributesW(winPath.c_str());
                     bool ret = ::SetFileAttributesW(winPath.c_str(), dwAttrs | FILE_ATTRIBUTE_HIDDEN);
                     Q_ASSERT(ret != 0); Q_UNUSED(ret);

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -55,6 +55,7 @@
 #include <windows.h>
 #endif
 
+#include "base/global.h"
 #include "base/logger.h"
 #include "base/preferences.h"
 #include "base/profile.h"
@@ -77,7 +78,7 @@ namespace
     ListType setToEntryList(const QSet<QString> &input)
     {
         ListType entryList;
-        foreach (const QString &setValue, input)
+        for (const QString &setValue : input)
             entryList.emplace_back(setValue.toStdString());
         return entryList;
     }
@@ -374,10 +375,9 @@ QString TorrentHandle::nativeActualSavePath() const
 QList<TrackerEntry> TorrentHandle::trackers() const
 {
     QList<TrackerEntry> entries;
-    std::vector<libt::announce_entry> announces;
+    const std::vector<libt::announce_entry> announces = m_nativeHandle.trackers();
 
-    announces = m_nativeHandle.trackers();
-    foreach (const libt::announce_entry &tracker, announces)
+    for (const libt::announce_entry &tracker : announces)
         entries << tracker;
 
     return entries;
@@ -391,7 +391,7 @@ QHash<QString, TrackerInfo> TorrentHandle::trackerInfos() const
 void TorrentHandle::addTrackers(const QList<TrackerEntry> &trackers)
 {
     QList<TrackerEntry> addedTrackers;
-    foreach (const TrackerEntry &tracker, trackers) {
+    for (const TrackerEntry &tracker : trackers) {
         if (addTracker(tracker))
             addedTrackers << tracker;
     }
@@ -400,13 +400,13 @@ void TorrentHandle::addTrackers(const QList<TrackerEntry> &trackers)
         m_session->handleTorrentTrackersAdded(this, addedTrackers);
 }
 
-void TorrentHandle::replaceTrackers(QList<TrackerEntry> trackers)
+void TorrentHandle::replaceTrackers(const QList<TrackerEntry> &trackers)
 {
     QList<TrackerEntry> existingTrackers = this->trackers();
     QList<TrackerEntry> addedTrackers;
 
     std::vector<libt::announce_entry> announces;
-    foreach (const TrackerEntry &tracker, trackers) {
+    for (const TrackerEntry &tracker : trackers) {
         announces.push_back(tracker.nativeEntry());
         if (!existingTrackers.contains(tracker))
             addedTrackers << tracker;
@@ -438,9 +438,9 @@ bool TorrentHandle::addTracker(const TrackerEntry &tracker)
 QList<QUrl> TorrentHandle::urlSeeds() const
 {
     QList<QUrl> urlSeeds;
-    std::set<std::string> seeds = m_nativeHandle.url_seeds();
+    const std::set<std::string> seeds = m_nativeHandle.url_seeds();
 
-    foreach (const std::string &urlSeed, seeds)
+    for (const std::string &urlSeed : seeds)
         urlSeeds.append(QUrl(urlSeed.c_str()));
 
     return urlSeeds;
@@ -449,7 +449,7 @@ QList<QUrl> TorrentHandle::urlSeeds() const
 void TorrentHandle::addUrlSeeds(const QList<QUrl> &urlSeeds)
 {
     QList<QUrl> addedUrlSeeds;
-    foreach (const QUrl &urlSeed, urlSeeds) {
+    for (const QUrl &urlSeed : urlSeeds) {
         if (addUrlSeed(urlSeed))
             addedUrlSeeds << urlSeed;
     }
@@ -461,7 +461,7 @@ void TorrentHandle::addUrlSeeds(const QList<QUrl> &urlSeeds)
 void TorrentHandle::removeUrlSeeds(const QList<QUrl> &urlSeeds)
 {
     QList<QUrl> removedUrlSeeds;
-    foreach (const QUrl &urlSeed, urlSeeds) {
+    for (const QUrl &urlSeed : urlSeeds) {
         if (removeUrlSeed(urlSeed))
             removedUrlSeeds << urlSeed;
     }
@@ -596,8 +596,7 @@ bool TorrentHandle::removeTag(const QString &tag)
 
 void TorrentHandle::removeAllTags()
 {
-    // QT automatically copies the container in foreach, so it's safe to mutate it.
-    foreach (const QString &tag, m_tags)
+    for (const QString &tag : copyAsConst(tags()))
         removeTag(tag);
 }
 
@@ -883,9 +882,9 @@ bool TorrentHandle::hasError() const
 
 bool TorrentHandle::hasFilteredPieces() const
 {
-    std::vector<int> pp = m_nativeHandle.piece_priorities();
+    const std::vector<int> pp = m_nativeHandle.piece_priorities();
 
-    foreach (const int priority, pp)
+    for (const int priority : pp)
         if (priority == 0) return true;
 
     return false;
@@ -1087,7 +1086,7 @@ QList<PeerInfo> TorrentHandle::peers() const
 
     m_nativeHandle.get_peer_info(nativePeers);
 
-    foreach (const libt::peer_info &peer, nativePeers)
+    for (const libt::peer_info &peer : nativePeers)
         peers << PeerInfo(this, peer);
 
     return peers;

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -596,7 +596,7 @@ bool TorrentHandle::removeTag(const QString &tag)
 
 void TorrentHandle::removeAllTags()
 {
-    for (const QString &tag : copyAsConst(tags()))
+    for (const QString &tag : asConst(tags()))
         removeTag(tag);
 }
 

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -356,7 +356,7 @@ namespace BitTorrent
         void setSuperSeeding(bool enable);
         void flushCache();
         void addTrackers(const QList<TrackerEntry> &trackers);
-        void replaceTrackers(QList<TrackerEntry> trackers);
+        void replaceTrackers(const QList<TrackerEntry> &trackers);
         void addUrlSeeds(const QList<QUrl> &urlSeeds);
         void removeUrlSeeds(const QList<QUrl> &urlSeeds);
         bool connectPeer(const PeerAddress &peerAddress);

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -350,7 +350,7 @@ void TorrentInfo::renameFile(const int index, const QString &newPath)
     nativeInfo()->rename_file(index, Utils::Fs::toNativePath(newPath).toStdString());
 }
 
-int BitTorrent::TorrentInfo::fileIndex(const QString& fileName) const
+int BitTorrent::TorrentInfo::fileIndex(const QString &fileName) const
 {
     // the check whether the object is valid is not needed here
     // because if filesCount() returns -1 the loop exits immediately

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -247,7 +247,7 @@ QList<TrackerEntry> TorrentInfo::trackers() const
     if (!isValid()) return QList<TrackerEntry>();
 
     QList<TrackerEntry> trackers;
-    foreach (const libt::announce_entry &tracker, m_nativeInfo->trackers())
+    for (const libt::announce_entry &tracker : m_nativeInfo->trackers())
         trackers.append(tracker);
 
     return trackers;
@@ -258,7 +258,7 @@ QList<QUrl> TorrentInfo::urlSeeds() const
     if (!isValid()) return QList<QUrl>();
 
     QList<QUrl> urlSeeds;
-    foreach (const libt::web_seed_entry &webSeed, m_nativeInfo->web_seeds())
+    for (const libt::web_seed_entry &webSeed : m_nativeInfo->web_seeds())
         if (webSeed.type == libt::web_seed_entry::url_seed)
             urlSeeds.append(QUrl(webSeed.url.c_str()));
 

--- a/src/base/bittorrent/tracker.cpp
+++ b/src/base/bittorrent/tracker.cpp
@@ -136,7 +136,7 @@ void Tracker::respondToAnnounceRequest()
     QMap<QString, QByteArray> queryParams;
     // Parse GET parameters
     using namespace Utils::ByteArray;
-    for (const QByteArray &param : copyAsConst(splitToViews(m_request.query, "&"))) {
+    for (const QByteArray &param : asConst(splitToViews(m_request.query, "&"))) {
         const int sepPos = param.indexOf('=');
         if (sepPos <= 0) continue; // ignores params without name
 

--- a/src/base/filesystemwatcher.cpp
+++ b/src/base/filesystemwatcher.cpp
@@ -64,7 +64,7 @@ FileSystemWatcher::FileSystemWatcher(QObject *parent)
 QStringList FileSystemWatcher::directories() const
 {
     QStringList dirs = QFileSystemWatcher::directories();
-    for (const QDir &dir : qAsConst(m_watchedFolders))
+    for (const QDir &dir : asConst(m_watchedFolders))
         dirs << dir.canonicalPath();
     return dirs;
 }
@@ -113,7 +113,7 @@ void FileSystemWatcher::scanLocalFolder(const QString &path)
 
 void FileSystemWatcher::scanNetworkFolders()
 {
-    for (const QDir &dir : qAsConst(m_watchedFolders))
+    for (const QDir &dir : asConst(m_watchedFolders))
         processTorrentsInDir(dir);
 }
 

--- a/src/base/global.h
+++ b/src/base/global.h
@@ -33,16 +33,13 @@
 
 const char C_TORRENT_FILE_EXTENSION[] = ".torrent";
 
-
-#if QT_VERSION < QT_VERSION_CHECK(5, 7, 0)
 template <typename T>
-constexpr typename std::add_const<T>::type &qAsConst(T &t) noexcept { return t; }
+constexpr typename std::add_const<T>::type &asConst(T &t) noexcept { return t; }
 
-// prevent rvalue arguments:
+// Forward rvalue as const
 template <typename T>
-void qAsConst(const T &&) = delete;
-#endif
+constexpr typename std::add_const<T>::type asConst(T &&t) noexcept { return std::move(t); }
 
-// returns a const object copy
+// Prevent const rvalue arguments
 template <typename T>
-constexpr typename std::add_const<T>::type copyAsConst(T &&t) noexcept { return std::move(t); }
+void asConst(const T &&) = delete;

--- a/src/base/http/connection.cpp
+++ b/src/base/http/connection.cpp
@@ -133,7 +133,7 @@ bool Connection::acceptsGzipEncoding(QString codings)
 
     const auto isCodingAvailable = [](const QStringList &list, const QString &encoding) -> bool
     {
-        foreach (const QString &str, list) {
+        for (const QString &str : list) {
             if (!str.startsWith(encoding))
                 continue;
 

--- a/src/base/http/server.cpp
+++ b/src/base/http/server.cpp
@@ -146,9 +146,9 @@ QList<QSslCipher> Server::safeCipherList() const
     const QStringList badCiphers = {"idea", "rc4"};
     const QList<QSslCipher> allCiphers = QSslSocket::supportedCiphers();
     QList<QSslCipher> safeCiphers;
-    foreach (const QSslCipher &cipher, allCiphers) {
+    for (const QSslCipher &cipher : allCiphers) {
         bool isSafe = true;
-        foreach (const QString &badCipher, badCiphers) {
+        for (const QString &badCipher : badCiphers) {
             if (cipher.name().contains(badCipher, Qt::CaseInsensitive)) {
                 isSafe = false;
                 break;

--- a/src/base/http/types.h
+++ b/src/base/http/types.h
@@ -107,7 +107,7 @@ namespace Http
         uint code;
         QString text;
 
-        ResponseStatus(uint code = 200, const QString& text = "OK"): code(code), text(text) {}
+        ResponseStatus(uint code = 200, const QString &text = "OK"): code(code), text(text) {}
     };
 
     struct Response
@@ -116,7 +116,7 @@ namespace Http
         QStringMap headers;
         QByteArray content;
 
-        Response(uint code = 200, const QString& text = "OK"): status(code, text) {}
+        Response(uint code = 200, const QString &text = "OK"): status(code, text) {}
     };
 }
 

--- a/src/base/net/downloadmanager.cpp
+++ b/src/base/net/downloadmanager.cpp
@@ -39,6 +39,7 @@
 #include <QSslError>
 #include <QUrl>
 
+#include "base/global.h"
 #include "base/preferences.h"
 #include "downloadhandler.h"
 #include "proxyconfigurationmanager.h"
@@ -56,7 +57,7 @@ namespace
         {
             QDateTime now = QDateTime::currentDateTime();
             QList<QNetworkCookie> cookies = Preferences::instance()->getNetworkCookies();
-            foreach (const QNetworkCookie &cookie, Preferences::instance()->getNetworkCookies()) {
+            for (const QNetworkCookie &cookie : copyAsConst(Preferences::instance()->getNetworkCookies())) {
                 if (cookie.isSessionCookie() || (cookie.expirationDate() <= now))
                     cookies.removeAll(cookie);
             }
@@ -68,7 +69,7 @@ namespace
         {
             QDateTime now = QDateTime::currentDateTime();
             QList<QNetworkCookie> cookies = allCookies();
-            foreach (const QNetworkCookie &cookie, allCookies()) {
+            for (const QNetworkCookie &cookie : copyAsConst(allCookies())) {
                 if (cookie.isSessionCookie() || (cookie.expirationDate() <= now))
                     cookies.removeAll(cookie);
             }
@@ -83,7 +84,7 @@ namespace
         {
             QDateTime now = QDateTime::currentDateTime();
             QList<QNetworkCookie> cookies = QNetworkCookieJar::cookiesForUrl(url);
-            foreach (const QNetworkCookie &cookie, QNetworkCookieJar::cookiesForUrl(url)) {
+            for (const QNetworkCookie &cookie : copyAsConst(QNetworkCookieJar::cookiesForUrl(url))) {
                 if (!cookie.isSessionCookie() && (cookie.expirationDate() <= now))
                     cookies.removeAll(cookie);
             }
@@ -95,7 +96,7 @@ namespace
         {
             QDateTime now = QDateTime::currentDateTime();
             QList<QNetworkCookie> cookies = cookieList;
-            foreach (const QNetworkCookie &cookie, cookieList) {
+            for (const QNetworkCookie &cookie : cookieList) {
                 if (!cookie.isSessionCookie() && (cookie.expirationDate() <= now))
                     cookies.removeAll(cookie);
             }

--- a/src/base/net/downloadmanager.cpp
+++ b/src/base/net/downloadmanager.cpp
@@ -57,7 +57,7 @@ namespace
         {
             QDateTime now = QDateTime::currentDateTime();
             QList<QNetworkCookie> cookies = Preferences::instance()->getNetworkCookies();
-            for (const QNetworkCookie &cookie : copyAsConst(Preferences::instance()->getNetworkCookies())) {
+            for (const QNetworkCookie &cookie : asConst(Preferences::instance()->getNetworkCookies())) {
                 if (cookie.isSessionCookie() || (cookie.expirationDate() <= now))
                     cookies.removeAll(cookie);
             }
@@ -69,7 +69,7 @@ namespace
         {
             QDateTime now = QDateTime::currentDateTime();
             QList<QNetworkCookie> cookies = allCookies();
-            for (const QNetworkCookie &cookie : copyAsConst(allCookies())) {
+            for (const QNetworkCookie &cookie : asConst(allCookies())) {
                 if (cookie.isSessionCookie() || (cookie.expirationDate() <= now))
                     cookies.removeAll(cookie);
             }
@@ -84,7 +84,7 @@ namespace
         {
             QDateTime now = QDateTime::currentDateTime();
             QList<QNetworkCookie> cookies = QNetworkCookieJar::cookiesForUrl(url);
-            for (const QNetworkCookie &cookie : copyAsConst(QNetworkCookieJar::cookiesForUrl(url))) {
+            for (const QNetworkCookie &cookie : asConst(QNetworkCookieJar::cookiesForUrl(url))) {
                 if (!cookie.isSessionCookie() && (cookie.expirationDate() <= now))
                     cookies.removeAll(cookie);
             }

--- a/src/base/net/proxyconfigurationmanager.cpp
+++ b/src/base/net/proxyconfigurationmanager.cpp
@@ -40,7 +40,7 @@ const QString KEY_PASSWORD = SETTINGS_KEY("Password");
 
 namespace
 {
-    inline SettingsStorage *settings() { return  SettingsStorage::instance(); }
+    inline SettingsStorage *settings() { return SettingsStorage::instance(); }
 
     inline bool isSameConfig(const Net::ProxyConfiguration &conf1, const Net::ProxyConfiguration &conf2)
     {

--- a/src/base/net/smtp.cpp
+++ b/src/base/net/smtp.cpp
@@ -291,7 +291,7 @@ QByteArray Smtp::encodeMimeHeader(const QString &key, const QString &value, QTex
     if (!prefix.isEmpty()) line += prefix;
     if (!value.contains("=?") && latin1->canEncode(value)) {
         bool firstWord = true;
-        foreach (const QByteArray& word, value.toLatin1().split(' ')) {
+        foreach (const QByteArray &word, value.toLatin1().split(' ')) {
             if (line.size() > 78) {
                 rv = rv + line + "\r\n";
                 line.clear();

--- a/src/base/net/smtp.cpp
+++ b/src/base/net/smtp.cpp
@@ -43,6 +43,7 @@
 #include <QTcpSocket>
 #endif
 
+#include "base/global.h"
 #include "base/logger.h"
 #include "base/preferences.h"
 
@@ -291,7 +292,7 @@ QByteArray Smtp::encodeMimeHeader(const QString &key, const QString &value, QTex
     if (!prefix.isEmpty()) line += prefix;
     if (!value.contains("=?") && latin1->canEncode(value)) {
         bool firstWord = true;
-        foreach (const QByteArray &word, value.toLatin1().split(' ')) {
+        for (const QByteArray &word : copyAsConst(value.toLatin1().split(' '))) {
             if (line.size() > 78) {
                 rv = rv + line + "\r\n";
                 line.clear();

--- a/src/base/net/smtp.cpp
+++ b/src/base/net/smtp.cpp
@@ -292,7 +292,7 @@ QByteArray Smtp::encodeMimeHeader(const QString &key, const QString &value, QTex
     if (!prefix.isEmpty()) line += prefix;
     if (!value.contains("=?") && latin1->canEncode(value)) {
         bool firstWord = true;
-        for (const QByteArray &word : copyAsConst(value.toLatin1().split(' '))) {
+        for (const QByteArray &word : asConst(value.toLatin1().split(' '))) {
             if (line.size() > 78) {
                 rv = rv + line + "\r\n";
                 line.clear();

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -212,7 +212,7 @@ void Preferences::setCloseToTrayNotified(bool b)
 {
     setValue("Preferences/General/CloseToTrayNotified", b);
 }
-#endif
+#endif // Q_OS_MAC
 
 bool Preferences::isToolbarDisplayed() const
 {
@@ -293,7 +293,7 @@ void Preferences::setWinStartup(bool b)
         settings.remove("qBittorrent");
     }
 }
-#endif
+#endif // Q_OS_WIN
 
 // Downloads
 QString Preferences::lastLocationPath() const
@@ -967,7 +967,7 @@ void Preferences::setMagnetLinkAssoc(bool set)
 
     SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, 0, 0);
 }
-#endif
+#endif // Q_OS_WIN
 
 #ifdef Q_OS_MAC
 namespace
@@ -1023,7 +1023,7 @@ void Preferences::setMagnetLinkAssoc()
     CFStringRef myBundleId = CFBundleGetIdentifier(CFBundleGetMainBundle());
     LSSetDefaultHandlerForURLScheme(magnetUrlScheme, myBundleId);
 }
-#endif
+#endif // Q_OS_MAC
 
 int Preferences::getTrackerPort() const
 {

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -50,6 +50,7 @@
 #include <CoreServices/CoreServices.h>
 #endif
 
+#include "global.h"
 #include "logger.h"
 #include "settingsstorage.h"
 #include "utils/fs.h"
@@ -505,7 +506,7 @@ void Preferences::setWebUiAuthSubnetWhitelistEnabled(bool enabled)
 QList<Utils::Net::Subnet> Preferences::getWebUiAuthSubnetWhitelist() const
 {
     QList<Utils::Net::Subnet> subnets;
-    foreach (const QString &rawSubnet, value("Preferences/WebUI/AuthSubnetWhitelist").toStringList()) {
+    for (const QString &rawSubnet : copyAsConst(value("Preferences/WebUI/AuthSubnetWhitelist").toStringList())) {
         bool ok = false;
         const Utils::Net::Subnet subnet = Utils::Net::parseSubnet(rawSubnet.trimmed(), &ok);
         if (ok)
@@ -1426,8 +1427,8 @@ void Preferences::setToolbarTextPosition(const int position)
 QList<QNetworkCookie> Preferences::getNetworkCookies() const
 {
     QList<QNetworkCookie> cookies;
-    QStringList rawCookies = value("Network/Cookies").toStringList();
-    foreach (const QString &rawCookie, rawCookies)
+    const QStringList rawCookies = value("Network/Cookies").toStringList();
+    for (const QString &rawCookie : rawCookies)
         cookies << QNetworkCookie::parseCookies(rawCookie.toUtf8());
 
     return cookies;
@@ -1436,7 +1437,7 @@ QList<QNetworkCookie> Preferences::getNetworkCookies() const
 void Preferences::setNetworkCookies(const QList<QNetworkCookie> &cookies)
 {
     QStringList rawCookies;
-    foreach (const QNetworkCookie &cookie, cookies)
+    for (const QNetworkCookie &cookie : cookies)
         rawCookies << cookie.toRawForm();
 
     setValue("Network/Cookies", rawCookies);
@@ -1477,10 +1478,10 @@ void Preferences::upgrade()
 {
     SettingsStorage *settingsStorage = SettingsStorage::instance();
 
-    QStringList labels = value("TransferListFilters/customLabels").toStringList();
+    const QStringList labels = value("TransferListFilters/customLabels").toStringList();
     if (!labels.isEmpty()) {
         QVariantMap categories = value("BitTorrent/Session/Categories").toMap();
-        foreach (const QString &label, labels) {
+        for (const QString &label : labels) {
             if (!categories.contains(label))
                 categories[label] = "";
         }

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -506,7 +506,7 @@ void Preferences::setWebUiAuthSubnetWhitelistEnabled(bool enabled)
 QList<Utils::Net::Subnet> Preferences::getWebUiAuthSubnetWhitelist() const
 {
     QList<Utils::Net::Subnet> subnets;
-    for (const QString &rawSubnet : copyAsConst(value("Preferences/WebUI/AuthSubnetWhitelist").toStringList())) {
+    for (const QString &rawSubnet : asConst(value("Preferences/WebUI/AuthSubnetWhitelist").toStringList())) {
         bool ok = false;
         const Utils::Net::Subnet subnet = Utils::Net::parseSubnet(rawSubnet.trimmed(), &ok);
         if (ok)

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -299,7 +299,7 @@ public:
     void setCloseToTrayNotified(bool b);
     TrayIcon::Style trayIconStyle() const;
     void setTrayIconStyle(TrayIcon::Style style);
-#endif
+#endif // Q_OS_MAC
 
     // Stuff that don't appear in the Options GUI but are saved
     // in the same file.

--- a/src/base/rss/private/rss_parser.cpp
+++ b/src/base/rss/private/rss_parser.cpp
@@ -435,13 +435,13 @@ namespace
         if (leapSecond)
             second = 59;   // apparently a leap second - validate below, once time zone is known
         int month = 0;
-        for ( ; (month < 12)  &&  (parts[nmonth] != shortMonth[month]); ++month);
+        for ( ; (month < 12) && (parts[nmonth] != shortMonth[month]); ++month);
         int dayOfWeek = -1;
         if (!parts[nwday].isEmpty()) {
             // Look up the weekday name
-            while (++dayOfWeek < 7 && (shortDay[dayOfWeek] != parts[nwday]));
+            while ((++dayOfWeek < 7) && (shortDay[dayOfWeek] != parts[nwday]));
             if (dayOfWeek >= 7)
-                for (dayOfWeek = 0; dayOfWeek < 7 && (longDay[dayOfWeek] != parts[nwday]); ++dayOfWeek);
+                for (dayOfWeek = 0; (dayOfWeek < 7) && (longDay[dayOfWeek] != parts[nwday]); ++dayOfWeek);
         }
 
         //       if (month >= 12 || dayOfWeek >= 7
@@ -450,7 +450,7 @@ namespace
         int i = parts[nyear].size();
         if (i < 4) {
             // It's an obsolete year specification with less than 4 digits
-            year += (i == 2  &&  year < 50) ? 2000 : 1900;
+            year += ((i == 2) && (year < 50)) ? 2000 : 1900;
         }
 
         // Parse the UTC offset part
@@ -473,17 +473,17 @@ namespace
             else {
                 // Check for an obsolete time zone name
                 QByteArray zone = parts[10].toLatin1();
-                if (zone.length() == 1  &&  isalpha(zone[0])  &&  toupper(zone[0]) != 'J') {
+                if ((zone.length() == 1) && (isalpha(zone[0])) && (toupper(zone[0]) != 'J')) {
                     negOffset = true;    // military zone: RFC 2822 treats as '-0000'
                 }
-                else if (zone != "UT" && zone != "GMT") { // treated as '+0000'
+                else if ((zone != "UT") && (zone != "GMT")) { // treated as '+0000'
                     offset = (zone == "EDT")
                             ? -4 * 3600
                             : ((zone == "EST") || (zone == "CDT"))
                               ? -5 * 3600
                               : ((zone == "CST") || (zone == "MDT"))
                                 ? -6 * 3600
-                                : (zone == "MST" || zone == "PDT")
+                                : ((zone == "MST") || (zone == "PDT"))
                                   ? -7 * 3600
                                   : (zone == "PST")
                                     ? -8 * 3600
@@ -502,12 +502,12 @@ namespace
             }
         }
 
-        QDate qdate(year, month + 1, day);   // convert date, and check for out-of-range
-        if (!qdate.isValid())
+        QDate qDate(year, month + 1, day);   // convert date, and check for out-of-range
+        if (!qDate.isValid())
             return QDateTime::currentDateTime();
 
         QTime qTime(hour, minute, second);
-        QDateTime result(qdate, qTime, Qt::UTC);
+        QDateTime result(qDate, qTime, Qt::UTC);
         if (offset)
             result = result.addSecs(-offset);
         if (!result.isValid())

--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -241,7 +241,7 @@ void AutoDownloader::importRules(const QByteArray &data, AutoDownloader::RulesFi
 QByteArray AutoDownloader::exportRulesToJSONFormat() const
 {
     QJsonObject jsonObj;
-    for (const auto &rule : copyAsConst(rules()))
+    for (const auto &rule : asConst(rules()))
         jsonObj.insert(rule.name(), rule.toJsonObject());
 
     return QJsonDocument(jsonObj).toJson();
@@ -249,14 +249,14 @@ QByteArray AutoDownloader::exportRulesToJSONFormat() const
 
 void AutoDownloader::importRulesFromJSONFormat(const QByteArray &data)
 {
-    for (const auto &rule : copyAsConst(rulesFromJSON(data)))
+    for (const auto &rule : asConst(rulesFromJSON(data)))
         insertRule(rule);
 }
 
 QByteArray AutoDownloader::exportRulesToLegacyFormat() const
 {
     QVariantHash dict;
-    for (const auto &rule : copyAsConst(rules()))
+    for (const auto &rule : asConst(rules()))
         dict[rule.name()] = rule.toLegacyDict();
 
     QByteArray data;
@@ -276,7 +276,7 @@ void AutoDownloader::importRulesFromLegacyFormat(const QByteArray &data)
     if (in.status() != QDataStream::Ok)
         throw ParsingError(tr("Invalid data format"));
 
-    for (const QVariant &val : qAsConst(dict))
+    for (const QVariant &val : asConst(dict))
         insertRule(AutoDownloadRule::fromLegacyDict(val.toHash()));
 }
 
@@ -451,7 +451,7 @@ void AutoDownloader::store()
     m_savingTimer.stop();
 
     QJsonObject jsonObj;
-    for (const auto &rule : qAsConst(m_rules))
+    for (const auto &rule : asConst(m_rules))
         jsonObj.insert(rule.name(), rule.toJsonObject());
 
     m_fileStorage->store(RulesFileName, QJsonDocument(jsonObj).toJson());
@@ -473,7 +473,7 @@ void AutoDownloader::resetProcessingQueue()
     m_processingQueue.clear();
     if (!m_processingEnabled) return;
 
-    for (Article *article : copyAsConst(Session::instance()->rootFolder()->articles())) {
+    for (Article *article : asConst(Session::instance()->rootFolder()->articles())) {
         if (!article->isRead() && !article->torrentUrl().isEmpty())
             addJobForArticle(article);
     }

--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -373,7 +373,7 @@ void AutoDownloader::addJobForArticle(Article *article)
 
 void AutoDownloader::processJob(const QSharedPointer<ProcessingJob> &job)
 {
-    for (AutoDownloadRule &rule: m_rules) {
+    for (AutoDownloadRule &rule : m_rules) {
         if (!rule.isEnabled()) continue;
         if (!rule.feedURLs().contains(job->feedURL)) continue;
         if (!rule.accepts(job->articleData)) continue;

--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -435,8 +435,8 @@ void AutoDownloader::loadRules(const QByteArray &data)
 void AutoDownloader::loadRulesLegacy()
 {
     SettingsPtr settings = Profile::instance().applicationSettings(QStringLiteral("qBittorrent-rss"));
-    QVariantHash rules = settings->value(QStringLiteral("download_rules")).toHash();
-    foreach (const QVariant &ruleVar, rules) {
+    const QVariantHash rules = settings->value(QStringLiteral("download_rules")).toHash();
+    for (const QVariant &ruleVar : rules) {
         auto rule = AutoDownloadRule::fromLegacyDict(ruleVar.toHash());
         if (!rule.name().isEmpty())
             insertRule(rule);
@@ -451,7 +451,7 @@ void AutoDownloader::store()
     m_savingTimer.stop();
 
     QJsonObject jsonObj;
-    foreach (auto rule, m_rules)
+    for (const auto &rule : qAsConst(m_rules))
         jsonObj.insert(rule.name(), rule.toJsonObject());
 
     m_fileStorage->store(RulesFileName, QJsonDocument(jsonObj).toJson());
@@ -473,7 +473,7 @@ void AutoDownloader::resetProcessingQueue()
     m_processingQueue.clear();
     if (!m_processingEnabled) return;
 
-    foreach (Article *article, Session::instance()->rootFolder()->articles()) {
+    for (Article *article : copyAsConst(Session::instance()->rootFolder()->articles())) {
         if (!article->isRead() && !article->torrentUrl().isEmpty())
             addJobForArticle(article);
     }

--- a/src/base/rss/rss_autodownloadrule.cpp
+++ b/src/base/rss/rss_autodownloadrule.cpp
@@ -442,7 +442,7 @@ AutoDownloadRule AutoDownloadRule::fromJsonObject(const QJsonObject &jsonObj, co
     QStringList feedURLs;
     if (feedsVal.isString())
         feedURLs << feedsVal.toString();
-    else foreach (const QJsonValue &urlVal, feedsVal.toArray())
+    else for (const QJsonValue &urlVal : copyAsConst(feedsVal.toArray()))
         feedURLs << urlVal.toString();
     rule.setFeedURLs(feedURLs);
 
@@ -452,7 +452,7 @@ AutoDownloadRule AutoDownloadRule::fromJsonObject(const QJsonObject &jsonObj, co
         previouslyMatched << previouslyMatchedVal.toString();
     }
     else {
-        foreach (const QJsonValue &val, previouslyMatchedVal.toArray())
+        for (const QJsonValue &val : copyAsConst(previouslyMatchedVal.toArray()))
             previouslyMatched << val.toString();
     }
     rule.setPreviouslyMatchedEpisodes(previouslyMatched);

--- a/src/base/rss/rss_autodownloadrule.cpp
+++ b/src/base/rss/rss_autodownloadrule.cpp
@@ -237,7 +237,7 @@ bool AutoDownloadRule::matchesMustContainExpression(const QString &articleTitle)
 
     // Each expression is either a regex, or a set of wildcards separated by whitespace.
     // Accept if any complete expression matches.
-    for (const QString &expression : qAsConst(m_dataPtr->mustContain)) {
+    for (const QString &expression : asConst(m_dataPtr->mustContain)) {
         // A regex of the form "expr|" will always match, so do the same for wildcards
         if (matchesExpression(articleTitle, expression))
             return true;
@@ -253,7 +253,7 @@ bool AutoDownloadRule::matchesMustNotContainExpression(const QString &articleTit
 
     // Each expression is either a regex, or a set of wildcards separated by whitespace.
     // Reject if any complete expression matches.
-    for (const QString &expression : qAsConst(m_dataPtr->mustNotContain)) {
+    for (const QString &expression : asConst(m_dataPtr->mustNotContain)) {
         // A regex of the form "expr|" will always match, so do the same for wildcards
         if (matchesExpression(articleTitle, expression))
             return false;
@@ -442,7 +442,7 @@ AutoDownloadRule AutoDownloadRule::fromJsonObject(const QJsonObject &jsonObj, co
     QStringList feedURLs;
     if (feedsVal.isString())
         feedURLs << feedsVal.toString();
-    else for (const QJsonValue &urlVal : copyAsConst(feedsVal.toArray()))
+    else for (const QJsonValue &urlVal : asConst(feedsVal.toArray()))
         feedURLs << urlVal.toString();
     rule.setFeedURLs(feedURLs);
 
@@ -452,7 +452,7 @@ AutoDownloadRule AutoDownloadRule::fromJsonObject(const QJsonObject &jsonObj, co
         previouslyMatched << previouslyMatchedVal.toString();
     }
     else {
-        for (const QJsonValue &val : copyAsConst(previouslyMatchedVal.toArray()))
+        for (const QJsonValue &val : asConst(previouslyMatchedVal.toArray()))
             previouslyMatched << val.toString();
     }
     rule.setPreviouslyMatchedEpisodes(previouslyMatched);

--- a/src/base/rss/rss_autodownloadrule.cpp
+++ b/src/base/rss/rss_autodownloadrule.cpp
@@ -246,7 +246,7 @@ bool AutoDownloadRule::matchesMustContainExpression(const QString &articleTitle)
     return false;
 }
 
-bool AutoDownloadRule::matchesMustNotContainExpression(const QString& articleTitle) const
+bool AutoDownloadRule::matchesMustNotContainExpression(const QString &articleTitle) const
 {
     if (m_dataPtr->mustNotContain.empty())
         return true;
@@ -262,7 +262,7 @@ bool AutoDownloadRule::matchesMustNotContainExpression(const QString& articleTit
     return true;
 }
 
-bool AutoDownloadRule::matchesEpisodeFilterExpression(const QString& articleTitle) const
+bool AutoDownloadRule::matchesEpisodeFilterExpression(const QString &articleTitle) const
 {
     // Reset the lastComputedEpisode, we don't want to leak it between matches
     m_dataPtr->lastComputedEpisode.clear();
@@ -332,7 +332,7 @@ bool AutoDownloadRule::matchesEpisodeFilterExpression(const QString& articleTitl
     return false;
 }
 
-bool AutoDownloadRule::matchesSmartEpisodeFilter(const QString& articleTitle) const
+bool AutoDownloadRule::matchesSmartEpisodeFilter(const QString &articleTitle) const
 {
     if (!useSmartFilter())
         return true;

--- a/src/base/rss/rss_feed.cpp
+++ b/src/base/rss/rss_feed.cpp
@@ -109,7 +109,7 @@ QList<Article *> Feed::articles() const
 void Feed::markAsRead()
 {
     auto oldUnreadCount = m_unreadCount;
-    foreach (Article *article, m_articles) {
+    for (Article *article : qAsConst(m_articles)) {
         if (!article->isRead()) {
             article->disconnect(this);
             article->markAsRead();
@@ -282,9 +282,9 @@ void Feed::loadArticles(const QByteArray &data)
         return;
     }
 
-    QJsonArray jsonArr = jsonDoc.array();
+    const QJsonArray jsonArr = jsonDoc.array();
     int i = -1;
-    foreach (const QJsonValue &jsonVal, jsonArr) {
+    for (const QJsonValue &jsonVal : jsonArr) {
         ++i;
         if (!jsonVal.isObject()) {
             LogMsg(tr("Couldn't load RSS article '%1#%2'. Invalid data format.").arg(m_url).arg(i)
@@ -304,9 +304,9 @@ void Feed::loadArticles(const QByteArray &data)
 void Feed::loadArticlesLegacy()
 {
     SettingsPtr qBTRSSFeeds = Profile::instance().applicationSettings(QStringLiteral("qBittorrent-rss-feeds"));
-    QVariantHash allOldItems = qBTRSSFeeds->value("old_items").toHash();
+    const QVariantHash allOldItems = qBTRSSFeeds->value("old_items").toHash();
 
-    foreach (const QVariant &var, allOldItems.value(m_url).toList()) {
+    for (const QVariant &var : copyAsConst(allOldItems.value(m_url).toList())) {
         auto hash = var.toHash();
         // update legacy keys
         hash[Article::KeyLink] = hash.take(QLatin1String("news_link"));
@@ -329,7 +329,7 @@ void Feed::store()
     m_savingTimer.stop();
 
     QJsonArray jsonArr;
-    foreach (Article *article, m_articles)
+    for (Article *article :qAsConst(m_articles))
         jsonArr << article->toJsonObject();
 
     m_session->dataFileStorage()->store(m_dataFileName, QJsonDocument(jsonArr).toJson());

--- a/src/base/rss/rss_feed.cpp
+++ b/src/base/rss/rss_feed.cpp
@@ -109,7 +109,7 @@ QList<Article *> Feed::articles() const
 void Feed::markAsRead()
 {
     auto oldUnreadCount = m_unreadCount;
-    for (Article *article : qAsConst(m_articles)) {
+    for (Article *article : asConst(m_articles)) {
         if (!article->isRead()) {
             article->disconnect(this);
             article->markAsRead();
@@ -306,7 +306,7 @@ void Feed::loadArticlesLegacy()
     SettingsPtr qBTRSSFeeds = Profile::instance().applicationSettings(QStringLiteral("qBittorrent-rss-feeds"));
     const QVariantHash allOldItems = qBTRSSFeeds->value("old_items").toHash();
 
-    for (const QVariant &var : copyAsConst(allOldItems.value(m_url).toList())) {
+    for (const QVariant &var : asConst(allOldItems.value(m_url).toList())) {
         auto hash = var.toHash();
         // update legacy keys
         hash[Article::KeyLink] = hash.take(QLatin1String("news_link"));
@@ -329,7 +329,7 @@ void Feed::store()
     m_savingTimer.stop();
 
     QJsonArray jsonArr;
-    for (Article *article :qAsConst(m_articles))
+    for (Article *article :asConst(m_articles))
         jsonArr << article->toJsonObject();
 
     m_session->dataFileStorage()->store(m_dataFileName, QJsonDocument(jsonArr).toJson());
@@ -507,7 +507,7 @@ QJsonValue Feed::toJsonValue(bool withData) const
         jsonObj.insert(KEY_HASERROR, hasError());
 
         QJsonArray jsonArr;
-        for (Article *article : qAsConst(m_articles))
+        for (Article *article : asConst(m_articles))
             jsonArr << article->toJsonObject();
         jsonObj.insert(KEY_ARTICLES, jsonArr);
     }

--- a/src/base/rss/rss_folder.cpp
+++ b/src/base/rss/rss_folder.cpp
@@ -123,7 +123,7 @@ void Folder::addItem(Item *item)
     connect(item, &Item::articleAboutToBeRemoved, this, &Item::articleAboutToBeRemoved);
     connect(item, &Item::unreadCountChanged, this, &Folder::handleItemUnreadCountChanged);
 
-    for (auto article: copyAsConst(item->articles()))
+    for (auto article : copyAsConst(item->articles()))
         emit newArticle(article);
 
     if (item->unreadCount() > 0)
@@ -134,7 +134,7 @@ void Folder::removeItem(Item *item)
 {
     Q_ASSERT(m_items.contains(item));
 
-    for (auto article: copyAsConst(item->articles()))
+    for (auto article : copyAsConst(item->articles()))
         emit articleAboutToBeRemoved(article);
 
     item->disconnect(this);

--- a/src/base/rss/rss_folder.cpp
+++ b/src/base/rss/rss_folder.cpp
@@ -47,7 +47,7 @@ Folder::~Folder()
 {
     emit aboutToBeDestroyed(this);
 
-    for (auto item : copyAsConst(items()))
+    for (auto item : asConst(items()))
         delete item;
 }
 
@@ -55,7 +55,7 @@ QList<Article *> Folder::articles() const
 {
     QList<Article *> news;
 
-    for (Item *item : copyAsConst(items())) {
+    for (Item *item : asConst(items())) {
         int n = news.size();
         news << item->articles();
         std::inplace_merge(news.begin(), news.begin() + n, news.end()
@@ -70,20 +70,20 @@ QList<Article *> Folder::articles() const
 int Folder::unreadCount() const
 {
     int count = 0;
-    for (Item *item : copyAsConst(items()))
+    for (Item *item : asConst(items()))
         count += item->unreadCount();
     return count;
 }
 
 void Folder::markAsRead()
 {
-    for (Item *item : copyAsConst(items()))
+    for (Item *item : asConst(items()))
         item->markAsRead();
 }
 
 void Folder::refresh()
 {
-    for (Item *item : copyAsConst(items()))
+    for (Item *item : asConst(items()))
         item->refresh();
 }
 
@@ -95,7 +95,7 @@ QList<Item *> Folder::items() const
 QJsonValue Folder::toJsonValue(bool withData) const
 {
     QJsonObject jsonObj;
-    for (Item *item : copyAsConst(items()))
+    for (Item *item : asConst(items()))
         jsonObj.insert(item->name(), item->toJsonValue(withData));
 
     return jsonObj;
@@ -108,7 +108,7 @@ void Folder::handleItemUnreadCountChanged()
 
 void Folder::cleanup()
 {
-    for (Item *item : copyAsConst(items()))
+    for (Item *item : asConst(items()))
         item->cleanup();
 }
 
@@ -123,7 +123,7 @@ void Folder::addItem(Item *item)
     connect(item, &Item::articleAboutToBeRemoved, this, &Item::articleAboutToBeRemoved);
     connect(item, &Item::unreadCountChanged, this, &Folder::handleItemUnreadCountChanged);
 
-    for (auto article : copyAsConst(item->articles()))
+    for (auto article : asConst(item->articles()))
         emit newArticle(article);
 
     if (item->unreadCount() > 0)
@@ -134,7 +134,7 @@ void Folder::removeItem(Item *item)
 {
     Q_ASSERT(m_items.contains(item));
 
-    for (auto article : copyAsConst(item->articles()))
+    for (auto article : asConst(item->articles()))
         emit articleAboutToBeRemoved(article);
 
     item->disconnect(this);

--- a/src/base/rss/rss_folder.cpp
+++ b/src/base/rss/rss_folder.cpp
@@ -47,7 +47,7 @@ Folder::~Folder()
 {
     emit aboutToBeDestroyed(this);
 
-    foreach (auto item, items())
+    for (auto item : copyAsConst(items()))
         delete item;
 }
 
@@ -55,7 +55,7 @@ QList<Article *> Folder::articles() const
 {
     QList<Article *> news;
 
-    foreach (Item *item, items()) {
+    for (Item *item : copyAsConst(items())) {
         int n = news.size();
         news << item->articles();
         std::inplace_merge(news.begin(), news.begin() + n, news.end()
@@ -70,20 +70,20 @@ QList<Article *> Folder::articles() const
 int Folder::unreadCount() const
 {
     int count = 0;
-    foreach (Item *item, items())
+    for (Item *item : copyAsConst(items()))
         count += item->unreadCount();
     return count;
 }
 
 void Folder::markAsRead()
 {
-    foreach (Item *item, items())
+    for (Item *item : copyAsConst(items()))
         item->markAsRead();
 }
 
 void Folder::refresh()
 {
-    foreach (Item *item, items())
+    for (Item *item : copyAsConst(items()))
         item->refresh();
 }
 
@@ -95,7 +95,7 @@ QList<Item *> Folder::items() const
 QJsonValue Folder::toJsonValue(bool withData) const
 {
     QJsonObject jsonObj;
-    foreach (Item *item, items())
+    for (Item *item : copyAsConst(items()))
         jsonObj.insert(item->name(), item->toJsonValue(withData));
 
     return jsonObj;
@@ -108,7 +108,7 @@ void Folder::handleItemUnreadCountChanged()
 
 void Folder::cleanup()
 {
-    foreach (Item *item, items())
+    for (Item *item : copyAsConst(items()))
         item->cleanup();
 }
 

--- a/src/base/rss/rss_session.cpp
+++ b/src/base/rss/rss_session.cpp
@@ -41,6 +41,7 @@
 #include <QVariantHash>
 
 #include "../asyncfilestorage.h"
+#include "../global.h"
 #include "../logger.h"
 #include "../profile.h"
 #include "../settingsstorage.h"
@@ -283,7 +284,7 @@ void Session::load()
 void Session::loadFolder(const QJsonObject &jsonObj, Folder *folder)
 {
     bool updated = false;
-    foreach (const QString &key, jsonObj.keys()) {
+    for (const QString &key : copyAsConst(jsonObj.keys())) {
         const QJsonValue val {jsonObj[key]};
         if (val.isString()) {
             // previous format (reduced form) doesn't contain UID
@@ -355,7 +356,7 @@ void Session::loadLegacy()
         const QString parentFolderPath = Item::parentPath(legacyPath);
         const QString feedUrl = Item::relativeName(legacyPath);
 
-        foreach (const QString &folderPath, Item::expandPath(parentFolderPath))
+        for (const QString &folderPath : copyAsConst(Item::expandPath(parentFolderPath)))
             addFolder(folderPath);
 
         const QString feedPath = feedAliases[i].isEmpty()

--- a/src/base/rss/rss_session.cpp
+++ b/src/base/rss/rss_session.cpp
@@ -284,7 +284,7 @@ void Session::load()
 void Session::loadFolder(const QJsonObject &jsonObj, Folder *folder)
 {
     bool updated = false;
-    for (const QString &key : copyAsConst(jsonObj.keys())) {
+    for (const QString &key : asConst(jsonObj.keys())) {
         const QJsonValue val {jsonObj[key]};
         if (val.isString()) {
             // previous format (reduced form) doesn't contain UID
@@ -356,7 +356,7 @@ void Session::loadLegacy()
         const QString parentFolderPath = Item::parentPath(legacyPath);
         const QString feedUrl = Item::relativeName(legacyPath);
 
-        for (const QString &folderPath : copyAsConst(Item::expandPath(parentFolderPath)))
+        for (const QString &folderPath : asConst(Item::expandPath(parentFolderPath)))
             addFolder(folderPath);
 
         const QString feedPath = feedAliases[i].isEmpty()

--- a/src/base/scanfoldersmodel.cpp
+++ b/src/base/scanfoldersmodel.cpp
@@ -35,6 +35,7 @@
 
 #include "bittorrent/session.h"
 #include "filesystemwatcher.h"
+#include "global.h"
 #include "preferences.h"
 #include "utils/fs.h"
 
@@ -254,7 +255,7 @@ void ScanFoldersModel::addToFSWatcher(const QStringList &watchPaths)
     if (!m_fsWatcher)
         return; // addPath() wasn't called before this
 
-    foreach (const QString &path, watchPaths) {
+    for (const QString &path : watchPaths) {
         QDir watchDir(path);
         const QString canonicalWatchPath = watchDir.canonicalPath();
         m_fsWatcher->addPath(canonicalWatchPath);
@@ -282,7 +283,7 @@ bool ScanFoldersModel::removePath(const QString &path, bool removeFromFSWatcher)
 
 void ScanFoldersModel::removeFromFSWatcher(const QStringList &watchPaths)
 {
-    foreach (const QString &path, watchPaths)
+    for (const QString &path : watchPaths)
         m_fsWatcher->removePath(path);
 }
 
@@ -326,7 +327,7 @@ void ScanFoldersModel::makePersistent()
 {
     QVariantHash dirs;
 
-    foreach (const PathData *pathData, m_pathList) {
+    for (const PathData *pathData : qAsConst(m_pathList)) {
         if (pathData->downloadType == CUSTOM_LOCATION)
             dirs.insert(Utils::Fs::fromNativePath(pathData->watchPath), Utils::Fs::fromNativePath(pathData->downloadPath));
         else
@@ -350,7 +351,7 @@ void ScanFoldersModel::configure()
 
 void ScanFoldersModel::addTorrentsToSession(const QStringList &pathList)
 {
-    foreach (const QString &file, pathList) {
+    for (const QString &file : pathList) {
         qDebug("File %s added", qUtf8Printable(file));
 
         BitTorrent::AddTorrentParams params;

--- a/src/base/scanfoldersmodel.cpp
+++ b/src/base/scanfoldersmodel.cpp
@@ -327,7 +327,7 @@ void ScanFoldersModel::makePersistent()
 {
     QVariantHash dirs;
 
-    for (const PathData *pathData : qAsConst(m_pathList)) {
+    for (const PathData *pathData : asConst(m_pathList)) {
         if (pathData->downloadType == CUSTOM_LOCATION)
             dirs.insert(Utils::Fs::fromNativePath(pathData->watchPath), Utils::Fs::fromNativePath(pathData->downloadPath));
         else

--- a/src/base/search/searchhandler.cpp
+++ b/src/base/search/searchhandler.cpp
@@ -139,7 +139,7 @@ void SearchHandler::readSearchOutput()
     m_searchResultLineTruncated = lines.takeLast().trimmed();
 
     QList<SearchResult> searchResultList;
-    for (const QByteArray &line : qAsConst(lines)) {
+    for (const QByteArray &line : asConst(lines)) {
         SearchResult searchResult;
         if (parseSearchResult(QString::fromUtf8(line), searchResult))
             searchResultList << searchResult;

--- a/src/base/search/searchhandler.cpp
+++ b/src/base/search/searchhandler.cpp
@@ -32,6 +32,7 @@
 #include <QProcess>
 #include <QTimer>
 
+#include "../global.h"
 #include "../utils/foreignapps.h"
 #include "../utils/fs.h"
 #include "searchpluginmanager.h"
@@ -138,7 +139,7 @@ void SearchHandler::readSearchOutput()
     m_searchResultLineTruncated = lines.takeLast().trimmed();
 
     QList<SearchResult> searchResultList;
-    foreach (const QByteArray &line, lines) {
+    for (const QByteArray &line : qAsConst(lines)) {
         SearchResult searchResult;
         if (parseSearchResult(QString::fromUtf8(line), searchResult))
             searchResultList << searchResult;

--- a/src/base/search/searchpluginmanager.cpp
+++ b/src/base/search/searchpluginmanager.cpp
@@ -133,7 +133,7 @@ QStringList SearchPluginManager::supportedCategories() const
     QStringList result;
     for (const PluginInfo *plugin : qAsConst(m_plugins)) {
         if (plugin->enabled) {
-            foreach (QString cat, plugin->supportedCategories) {
+            for (const QString &cat : plugin->supportedCategories) {
                 if (!result.contains(cat))
                     result << cat;
             }
@@ -277,9 +277,8 @@ bool SearchPluginManager::uninstallPlugin(const QString &name)
     QDir pluginsFolder(pluginsLocation());
     QStringList filters;
     filters << name + ".*";
-    QStringList files = pluginsFolder.entryList(filters, QDir::Files, QDir::Unsorted);
-    QString file;
-    foreach (file, files)
+    const QStringList files = pluginsFolder.entryList(filters, QDir::Files, QDir::Unsorted);
+    for (const QString &file : files)
         Utils::Fs::forceRemove(pluginsFolder.absoluteFilePath(file));
     // Remove it from supported engines
     delete m_plugins.take(name);

--- a/src/base/search/searchpluginmanager.cpp
+++ b/src/base/search/searchpluginmanager.cpp
@@ -65,7 +65,7 @@ namespace
         while (iter.hasNext())
             dirs += iter.next();
 
-        for (const QString &dir : qAsConst(dirs)) {
+        for (const QString &dir : asConst(dirs)) {
             // python 3: remove "__pycache__" folders
             if (dir.endsWith("/__pycache__")) {
                 Utils::Fs::removeDirRecursive(dir);
@@ -120,7 +120,7 @@ QStringList SearchPluginManager::allPlugins() const
 QStringList SearchPluginManager::enabledPlugins() const
 {
     QStringList plugins;
-    for (const PluginInfo *plugin : qAsConst(m_plugins)) {
+    for (const PluginInfo *plugin : asConst(m_plugins)) {
         if (plugin->enabled)
             plugins << plugin->name;
     }
@@ -131,7 +131,7 @@ QStringList SearchPluginManager::enabledPlugins() const
 QStringList SearchPluginManager::supportedCategories() const
 {
     QStringList result;
-    for (const PluginInfo *plugin : qAsConst(m_plugins)) {
+    for (const PluginInfo *plugin : asConst(m_plugins)) {
         if (plugin->enabled) {
             for (const QString &cat : plugin->supportedCategories) {
                 if (!result.contains(cat))
@@ -154,7 +154,7 @@ QStringList SearchPluginManager::getPluginCategories(const QString &pluginName) 
         plugins << pluginName.trimmed();
 
     QSet<QString> categories;
-    for (const QString &name : qAsConst(plugins)) {
+    for (const QString &name : asConst(plugins)) {
         const PluginInfo *plugin = pluginInfo(name);
         if (!plugin) continue; // plugin wasn't found
         for (const QString &category : plugin->supportedCategories)

--- a/src/base/settingsstorage.cpp
+++ b/src/base/settingsstorage.cpp
@@ -287,7 +287,7 @@ QString TransactionalSettings::deserialize(const QString &name, QVariantHash &da
     // Copy everything into memory. This means even keys inserted in the file manually
     // or that we don't touch directly in this code (eg disabled by ifdef). This ensures
     // that they will be copied over when save our settings to disk.
-    for (const QString &key : copyAsConst(settings->allKeys()))
+    for (const QString &key : asConst(settings->allKeys()))
         data.insert(key, settings->value(key));
 
     return settings->fileName();

--- a/src/base/settingsstorage.cpp
+++ b/src/base/settingsstorage.cpp
@@ -33,6 +33,7 @@
 #include <QFile>
 #include <QHash>
 
+#include "global.h"
 #include "logger.h"
 #include "profile.h"
 #include "utils/fs.h"
@@ -286,7 +287,7 @@ QString TransactionalSettings::deserialize(const QString &name, QVariantHash &da
     // Copy everything into memory. This means even keys inserted in the file manually
     // or that we don't touch directly in this code (eg disabled by ifdef). This ensures
     // that they will be copied over when save our settings to disk.
-    foreach (const QString &key, settings->allKeys())
+    for (const QString &key : copyAsConst(settings->allKeys()))
         data.insert(key, settings->value(key));
 
     return settings->fileName();

--- a/src/base/utils/foreignapps.cpp
+++ b/src/base/utils/foreignapps.cpp
@@ -229,7 +229,7 @@ namespace
 
         return QString();
     }
-#endif
+#endif // Q_OS_WIN
 }
 
 bool Utils::ForeignApps::PythonInfo::isValid() const

--- a/src/base/utils/fs.cpp
+++ b/src/base/utils/fs.cpp
@@ -133,7 +133,7 @@ bool Utils::Fs::smartRemoveEmptyFolderTree(const QString &path)
     std::sort(dirList.begin(), dirList.end()
               , [](const QString &l, const QString &r) { return l.count('/') > r.count('/'); });
 
-    for (const QString &p : qAsConst(dirList)) {
+    for (const QString &p : asConst(dirList)) {
         // remove unwanted files
         for (const QString &f : deleteFilesList) {
             forceRemove(p + f);

--- a/src/base/utils/fs.cpp
+++ b/src/base/utils/fs.cpp
@@ -329,7 +329,7 @@ bool Utils::Fs::isNetworkFileSystem(const QString &path)
     return ((strncmp(buf.f_fstypename, "cifs", sizeof(buf.f_fstypename)) == 0)
         || (strncmp(buf.f_fstypename, "nfs", sizeof(buf.f_fstypename)) == 0)
         || (strncmp(buf.f_fstypename, "smbfs", sizeof(buf.f_fstypename)) == 0));
-#else
+#else // Q_OS_WIN
     QString file = path;
     if (!file.endsWith('/'))
         file += '/';
@@ -351,6 +351,6 @@ bool Utils::Fs::isNetworkFileSystem(const QString &path)
     default:
         return false;
     }
-#endif
+#endif // Q_OS_WIN
 }
-#endif
+#endif // Q_OS_HAIKU

--- a/src/base/utils/fs.cpp
+++ b/src/base/utils/fs.cpp
@@ -141,7 +141,7 @@ bool Utils::Fs::smartRemoveEmptyFolderTree(const QString &path)
 
         // remove temp files on linux (file ends with '~'), e.g. `filename~`
         QDir dir(p);
-        QStringList tmpFileList = dir.entryList(QDir::Files);
+        const QStringList tmpFileList = dir.entryList(QDir::Files);
         for (const QString &f : tmpFileList) {
             if (f.endsWith('~'))
                 forceRemove(p + f);

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -66,7 +66,7 @@
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
 #include "base/utils/version.h"
 #endif
-#endif
+#endif // DISABLE_GUI
 
 #include "base/logger.h"
 #include "base/unicodestrings.h"

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -391,7 +391,7 @@ QString Utils::Misc::getUserIDString()
 QStringList Utils::Misc::toStringList(const QList<bool> &l)
 {
     QStringList ret;
-    foreach (const bool &b, l)
+    for (const bool b : l)
         ret << (b ? "1" : "0");
     return ret;
 }
@@ -399,7 +399,7 @@ QStringList Utils::Misc::toStringList(const QList<bool> &l)
 QList<int> Utils::Misc::intListfromStringList(const QStringList &l)
 {
     QList<int> ret;
-    foreach (const QString &s, l)
+    for (const QString &s : l)
         ret << s.toInt();
     return ret;
 }
@@ -407,7 +407,7 @@ QList<int> Utils::Misc::intListfromStringList(const QStringList &l)
 QList<bool> Utils::Misc::boolListfromStringList(const QStringList &l)
 {
     QList<bool> ret;
-    foreach (const QString &s, l)
+    for (const QString &s : l)
         ret << (s == "1");
     return ret;
 }

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -124,7 +124,7 @@ namespace Utils
             return reinterpret_cast<T>(
                 ::GetProcAddress(::LoadLibraryW(pathWchar.get()), funcName));
         }
-#endif
+#endif // Q_OS_WIN
     }
 }
 

--- a/src/base/utils/string.h
+++ b/src/base/utils/string.h
@@ -60,7 +60,7 @@ namespace Utils
         {
             if (str.length() < 2) return str;
 
-            for (auto const quote : quotes) {
+            for (const auto &quote : quotes) {
                 if (str.startsWith(quote) && str.endsWith(quote))
                     return str.mid(1, str.length() - 2);
             }

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -143,7 +143,7 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::AddTorrentParams &inP
         m_ui->categoryComboBox->addItem(defaultCategory);
     m_ui->categoryComboBox->addItem("");
 
-    for (const QString &category : qAsConst(categories))
+    for (const QString &category : asConst(categories))
         if (category != defaultCategory && category != m_torrentParams.category)
             m_ui->categoryComboBox->addItem(category);
 
@@ -398,7 +398,7 @@ void AddNewTorrentDialog::saveSavePathHistory() const
     // Get current history
     QStringList history = settings()->loadValue(KEY_SAVEPATHHISTORY).toStringList();
     QVector<QDir> historyDirs;
-    for (const QString &path : qAsConst(history))
+    for (const QString &path : asConst(history))
         historyDirs << QDir {path};
 
     const QDir selectedSavePath {m_ui->savePath->selectedPath()};

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -143,7 +143,7 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::AddTorrentParams &inP
         m_ui->categoryComboBox->addItem(defaultCategory);
     m_ui->categoryComboBox->addItem("");
 
-    foreach (const QString &category, categories)
+    for (const QString &category : qAsConst(categories))
         if (category != defaultCategory && category != m_torrentParams.category)
             m_ui->categoryComboBox->addItem(category);
 
@@ -631,7 +631,7 @@ void AddNewTorrentDialog::displayContentTreeMenu(const QPoint &)
                 prio = prio::IGNORED;
 
             qDebug("Setting files priority");
-            foreach (const QModelIndex &index, selectedRows) {
+            for (const QModelIndex &index : selectedRows) {
                 qDebug("Setting priority(%d) for file at row %d", prio, index.row());
                 m_contentModel->setData(m_contentModel->index(index.row(), PRIORITY, index.parent()), prio);
             }

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -425,7 +425,7 @@ void AdvancedSettings::loadAdvancedSettings()
     const QString currentInterface = session->networkInterface();
     bool interfaceExists = currentInterface.isEmpty();
     int i = 1;
-    foreach (const QNetworkInterface& iface, QNetworkInterface::allInterfaces()) {
+    foreach (const QNetworkInterface &iface, QNetworkInterface::allInterfaces()) {
         // This line fixes a Qt bug => https://bugreports.qt.io/browse/QTBUG-52633
         // Tested in Qt 5.6.0. For more info see:
         // https://github.com/qbittorrent/qBittorrent/issues/5131

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -36,6 +36,7 @@
 #include <QNetworkInterface>
 
 #include "base/bittorrent/session.h"
+#include "base/global.h"
 #include "base/preferences.h"
 #include "base/unicodestrings.h"
 #include "app/application.h"
@@ -286,13 +287,13 @@ void AdvancedSettings::updateInterfaceAddressCombo()
     };
 
     if (ifaceName.isEmpty()) {
-        foreach (const QHostAddress &ip, QNetworkInterface::allAddresses())
+        for (const QHostAddress &ip : copyAsConst(QNetworkInterface::allAddresses()))
             populateCombo(ip.toString(), ip.protocol());
     }
     else {
         const QNetworkInterface iface = QNetworkInterface::interfaceFromName(ifaceName);
         const QList<QNetworkAddressEntry> addresses = iface.addressEntries();
-        foreach (const QNetworkAddressEntry &entry, addresses) {
+        for (const QNetworkAddressEntry &entry : addresses) {
             const QHostAddress ip = entry.ip();
             populateCombo(ip.toString(), ip.protocol());
         }
@@ -425,7 +426,7 @@ void AdvancedSettings::loadAdvancedSettings()
     const QString currentInterface = session->networkInterface();
     bool interfaceExists = currentInterface.isEmpty();
     int i = 1;
-    foreach (const QNetworkInterface &iface, QNetworkInterface::allInterfaces()) {
+    for (const QNetworkInterface &iface : copyAsConst(QNetworkInterface::allInterfaces())) {
         // This line fixes a Qt bug => https://bugreports.qt.io/browse/QTBUG-52633
         // Tested in Qt 5.6.0. For more info see:
         // https://github.com/qbittorrent/qBittorrent/issues/5131

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -287,7 +287,7 @@ void AdvancedSettings::updateInterfaceAddressCombo()
     };
 
     if (ifaceName.isEmpty()) {
-        for (const QHostAddress &ip : copyAsConst(QNetworkInterface::allAddresses()))
+        for (const QHostAddress &ip : asConst(QNetworkInterface::allAddresses()))
             populateCombo(ip.toString(), ip.protocol());
     }
     else {
@@ -426,7 +426,7 @@ void AdvancedSettings::loadAdvancedSettings()
     const QString currentInterface = session->networkInterface();
     bool interfaceExists = currentInterface.isEmpty();
     int i = 1;
-    for (const QNetworkInterface &iface : copyAsConst(QNetworkInterface::allInterfaces())) {
+    for (const QNetworkInterface &iface : asConst(QNetworkInterface::allInterfaces())) {
         // This line fixes a Qt bug => https://bugreports.qt.io/browse/QTBUG-52633
         // Tested in Qt 5.6.0. For more info see:
         // https://github.com/qbittorrent/qBittorrent/issues/5131

--- a/src/gui/banlistoptionsdialog.cpp
+++ b/src/gui/banlistoptionsdialog.cpp
@@ -107,8 +107,8 @@ void BanListOptionsDialog::on_buttonBanIP_clicked()
 
 void BanListOptionsDialog::on_buttonDeleteIP_clicked()
 {
-    QModelIndexList selection = m_ui->bannedIPList->selectionModel()->selectedIndexes();
-    for (auto &i : selection)
+    const QModelIndexList selection = m_ui->bannedIPList->selectionModel()->selectedIndexes();
+    for (const auto &i : selection)
         m_sortFilter->removeRow(i.row());
 
     m_modified = true;

--- a/src/gui/categoryfiltermodel.cpp
+++ b/src/gui/categoryfiltermodel.cpp
@@ -408,7 +408,7 @@ void CategoryFilterModel::populate()
         const QString &category = i.key();
         if (m_isSubcategoriesEnabled) {
             CategoryModelItem *parent = m_rootItem;
-            for (const QString &subcat : copyAsConst(session->expandCategory(category))) {
+            for (const QString &subcat : asConst(session->expandCategory(category))) {
                 const QString subcatName = shortName(subcat);
                 if (!parent->hasChild(subcatName)) {
                     new CategoryModelItem(
@@ -437,7 +437,7 @@ CategoryModelItem *CategoryFilterModel::findItem(const QString &fullName) const
         return m_rootItem->child(fullName);
 
     CategoryModelItem *item = m_rootItem;
-    for (const QString &subcat : copyAsConst(BitTorrent::Session::expandCategory(fullName))) {
+    for (const QString &subcat : asConst(BitTorrent::Session::expandCategory(fullName))) {
         const QString subcatName = shortName(subcat);
         if (!item->hasChild(subcatName)) return nullptr;
         item = item->child(subcatName);

--- a/src/gui/categoryfiltermodel.cpp
+++ b/src/gui/categoryfiltermodel.cpp
@@ -33,6 +33,7 @@
 
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/torrenthandle.h"
+#include "base/global.h"
 #include "guiiconprovider.h"
 
 class CategoryModelItem
@@ -407,7 +408,7 @@ void CategoryFilterModel::populate()
         const QString &category = i.key();
         if (m_isSubcategoriesEnabled) {
             CategoryModelItem *parent = m_rootItem;
-            foreach (const QString &subcat, session->expandCategory(category)) {
+            for (const QString &subcat : copyAsConst(session->expandCategory(category))) {
                 const QString subcatName = shortName(subcat);
                 if (!parent->hasChild(subcatName)) {
                     new CategoryModelItem(
@@ -436,7 +437,7 @@ CategoryModelItem *CategoryFilterModel::findItem(const QString &fullName) const
         return m_rootItem->child(fullName);
 
     CategoryModelItem *item = m_rootItem;
-    foreach (const QString &subcat, BitTorrent::Session::expandCategory(fullName)) {
+    for (const QString &subcat : copyAsConst(BitTorrent::Session::expandCategory(fullName))) {
         const QString subcatName = shortName(subcat);
         if (!item->hasChild(subcatName)) return nullptr;
         item = item->child(subcatName);

--- a/src/gui/categoryfilterwidget.cpp
+++ b/src/gui/categoryfilterwidget.cpp
@@ -231,7 +231,7 @@ void CategoryFilterWidget::removeCategory()
 void CategoryFilterWidget::removeUnusedCategories()
 {
     auto session = BitTorrent::Session::instance();
-    for (const QString &category : copyAsConst(session->categories().keys())) {
+    for (const QString &category : asConst(session->categories().keys())) {
         if (model()->data(static_cast<CategoryFilterProxyModel *>(model())->index(category), Qt::UserRole) == 0)
             session->removeCategory(category);
     }

--- a/src/gui/cookiesdialog.cpp
+++ b/src/gui/cookiesdialog.cpp
@@ -101,6 +101,6 @@ void CookiesDialog::onButtonDeleteClicked()
         }
     );
 
-    for (const QModelIndex &idx : qAsConst(idxs))
+    for (const QModelIndex &idx : asConst(idxs))
         m_cookiesModel->removeRow(idx.row());
 }

--- a/src/gui/cookiesdialog.cpp
+++ b/src/gui/cookiesdialog.cpp
@@ -30,6 +30,7 @@
 
 #include <algorithm>
 
+#include "base/global.h"
 #include "base/net/downloadmanager.h"
 #include "base/settingsstorage.h"
 #include "cookiesmodel.h"
@@ -100,6 +101,6 @@ void CookiesDialog::onButtonDeleteClicked()
         }
     );
 
-    for (const QModelIndex &idx : idxs)
+    for (const QModelIndex &idx : qAsConst(idxs))
         m_cookiesModel->removeRow(idx.row());
 }

--- a/src/gui/executionlogwidget.cpp
+++ b/src/gui/executionlogwidget.cpp
@@ -32,6 +32,7 @@
 #include <QDateTime>
 #include <QPalette>
 
+#include "base/global.h"
 #include "guiiconprovider.h"
 #include "loglistwidget.h"
 #include "ui_executionlogwidget.h"
@@ -52,9 +53,9 @@ ExecutionLogWidget::ExecutionLogWidget(QWidget *parent, const Log::MsgTypes &typ
     m_ui->tabBan->layout()->addWidget(m_peerList);
 
     const Logger *const logger = Logger::instance();
-    foreach (const Log::Msg &msg, logger->getMessages())
+    for (const Log::Msg &msg : copyAsConst(logger->getMessages()))
         addLogMessage(msg);
-    foreach (const Log::Peer &peer, logger->getPeers())
+    for (const Log::Peer &peer : copyAsConst(logger->getPeers()))
         addPeerMessage(peer);
     connect(logger, &Logger::newLogMessage, this, &ExecutionLogWidget::addLogMessage);
     connect(logger, &Logger::newLogPeer, this, &ExecutionLogWidget::addPeerMessage);

--- a/src/gui/executionlogwidget.cpp
+++ b/src/gui/executionlogwidget.cpp
@@ -53,9 +53,9 @@ ExecutionLogWidget::ExecutionLogWidget(QWidget *parent, const Log::MsgTypes &typ
     m_ui->tabBan->layout()->addWidget(m_peerList);
 
     const Logger *const logger = Logger::instance();
-    for (const Log::Msg &msg : copyAsConst(logger->getMessages()))
+    for (const Log::Msg &msg : asConst(logger->getMessages()))
         addLogMessage(msg);
-    for (const Log::Peer &peer : copyAsConst(logger->getPeers()))
+    for (const Log::Peer &peer : asConst(logger->getPeers()))
         addPeerMessage(peer);
     connect(logger, &Logger::newLogMessage, this, &ExecutionLogWidget::addLogMessage);
     connect(logger, &Logger::newLogPeer, this, &ExecutionLogWidget::addPeerMessage);

--- a/src/gui/fspathedit.cpp
+++ b/src/gui/fspathedit.cpp
@@ -350,7 +350,7 @@ void FileSystemPathComboEdit::addItem(const QString &text)
     editWidget<WidgetType>()->addItem(Utils::Fs::toNativePath(text));
 }
 
-void FileSystemPathComboEdit::insertItem(int index, const QString& text)
+void FileSystemPathComboEdit::insertItem(int index, const QString &text)
 {
     editWidget<WidgetType>()->insertItem(index, Utils::Fs::toNativePath(text));
 }

--- a/src/gui/ipsubnetwhitelistoptionsdialog.cpp
+++ b/src/gui/ipsubnetwhitelistoptionsdialog.cpp
@@ -46,7 +46,7 @@ IPSubnetWhitelistOptionsDialog::IPSubnetWhitelistOptionsDialog(QWidget *parent)
     m_ui->setupUi(this);
 
     QStringList authSubnetWhitelistStringList;
-    for (const Utils::Net::Subnet &subnet : copyAsConst(Preferences::instance()->getWebUiAuthSubnetWhitelist()))
+    for (const Utils::Net::Subnet &subnet : asConst(Preferences::instance()->getWebUiAuthSubnetWhitelist()))
         authSubnetWhitelistStringList << Utils::Net::subnetToString(subnet);
     m_model = new QStringListModel(authSubnetWhitelistStringList, this);
 
@@ -99,7 +99,7 @@ void IPSubnetWhitelistOptionsDialog::on_buttonWhitelistIPSubnet_clicked()
 
 void IPSubnetWhitelistOptionsDialog::on_buttonDeleteIPSubnet_clicked()
 {
-    for (const auto &i : copyAsConst(m_ui->whitelistedIPSubnetList->selectionModel()->selectedIndexes()))
+    for (const auto &i : asConst(m_ui->whitelistedIPSubnetList->selectionModel()->selectedIndexes()))
         m_sortFilter->removeRow(i.row());
 
     m_modified = true;

--- a/src/gui/loglistwidget.cpp
+++ b/src/gui/loglistwidget.cpp
@@ -98,7 +98,7 @@ void LogListWidget::copySelection()
 {
     static const QRegularExpression htmlTag("<[^>]+>");
     QStringList strings;
-    for (QListWidgetItem* it : copyAsConst(selectedItems()))
+    for (QListWidgetItem* it : asConst(selectedItems()))
         strings << static_cast<QLabel*>(itemWidget(it))->text().remove(htmlTag);
 
     QApplication::clipboard()->setText(strings.join('\n'));

--- a/src/gui/loglistwidget.cpp
+++ b/src/gui/loglistwidget.cpp
@@ -36,6 +36,7 @@
 #include <QListWidgetItem>
 #include <QRegularExpression>
 
+#include "base/global.h"
 #include "guiiconprovider.h"
 
 LogListWidget::LogListWidget(int maxLines, const Log::MsgTypes &types, QWidget *parent)
@@ -97,7 +98,7 @@ void LogListWidget::copySelection()
 {
     static const QRegularExpression htmlTag("<[^>]+>");
     QStringList strings;
-    foreach (QListWidgetItem* it, selectedItems())
+    for (QListWidgetItem* it : copyAsConst(selectedItems()))
         strings << static_cast<QLabel*>(itemWidget(it))->text().remove(htmlTag);
 
     QApplication::clipboard()->setText(strings.join('\n'));

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -284,7 +284,7 @@ MainWindow::MainWindow(QWidget *parent)
     m_prioSeparatorMenu = m_ui->menuEdit->insertSeparator(m_ui->actionTopPriority);
 
 #ifdef Q_OS_MAC
-    for (QAction *action : copyAsConst(m_ui->toolBar->actions())) {
+    for (QAction *action : asConst(m_ui->toolBar->actions())) {
         if (action->isSeparator()) {
             QWidget *spacer = new QWidget(this);
             spacer->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
@@ -1239,7 +1239,7 @@ bool MainWindow::event(QEvent *e)
                 qDebug() << "Has active window:" << (qApp->activeWindow() != nullptr);
                 // Check if there is a modal window
                 bool hasModalWindow = false;
-                for (QWidget *widget : copyAsConst(QApplication::allWidgets())) {
+                for (QWidget *widget : asConst(QApplication::allWidgets())) {
                     if (widget->isModal()) {
                         hasModalWindow = true;
                         break;
@@ -1285,7 +1285,7 @@ void MainWindow::dropEvent(QDropEvent *event)
     // remove scheme
     QStringList files;
     if (event->mimeData()->hasUrls()) {
-        for (const QUrl &url : copyAsConst(event->mimeData()->urls())) {
+        for (const QUrl &url : asConst(event->mimeData()->urls())) {
             if (url.isEmpty())
                 continue;
 
@@ -1300,7 +1300,7 @@ void MainWindow::dropEvent(QDropEvent *event)
 
     // differentiate ".torrent" files/links & magnet links from others
     QStringList torrentFiles, otherFiles;
-    for (const QString &file : qAsConst(files)) {
+    for (const QString &file : asConst(files)) {
         const bool isTorrentLink = (file.startsWith("magnet:", Qt::CaseInsensitive)
             || file.endsWith(C_TORRENT_FILE_EXTENSION, Qt::CaseInsensitive)
             || Utils::Misc::isUrl(file));
@@ -1312,7 +1312,7 @@ void MainWindow::dropEvent(QDropEvent *event)
 
     // Download torrents
     const bool useTorrentAdditionDialog = AddNewTorrentDialog::isEnabled();
-    for (const QString &file : qAsConst(torrentFiles)) {
+    for (const QString &file : asConst(torrentFiles)) {
         if (useTorrentAdditionDialog)
             AddNewTorrentDialog::show(file, this);
         else
@@ -1321,7 +1321,7 @@ void MainWindow::dropEvent(QDropEvent *event)
     if (!torrentFiles.isEmpty()) return;
 
     // Create torrent
-    for (const QString &file : qAsConst(otherFiles)) {
+    for (const QString &file : asConst(otherFiles)) {
         createTorrentTriggered(file);
 
         // currently only hande the first entry
@@ -1333,7 +1333,7 @@ void MainWindow::dropEvent(QDropEvent *event)
 // Decode if we accept drag 'n drop or not
 void MainWindow::dragEnterEvent(QDragEnterEvent *event)
 {
-    for (const QString &mime : copyAsConst(event->mimeData()->formats()))
+    for (const QString &mime : asConst(event->mimeData()->formats()))
         qDebug("mimeData: %s", mime.toLocal8Bit().data());
     if (event->mimeData()->hasFormat("text/plain") || event->mimeData()->hasFormat("text/uri-list"))
         event->acceptProposedAction();

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -305,7 +305,7 @@ MainWindow::MainWindow(QWidget *parent)
         spacer->setMinimumWidth(8);
         m_ui->toolBar->addWidget(spacer);
     }
-#endif
+#endif // Q_OS_MAC
 
     // Transfer list slots
     connect(m_ui->actionStart, &QAction::triggered, m_transferListWidget, &TransferListWidget::startSelectedTorrents);
@@ -1110,7 +1110,7 @@ void MainWindow::toggleVisibility(const QSystemTrayIcon::ActivationReason reason
         break;
     }
 }
-#endif
+#endif // Q_OS_MAC
 
 // Display About Dialog
 void MainWindow::on_actionAbout_triggered()
@@ -1272,7 +1272,7 @@ bool MainWindow::event(QEvent *e)
     default:
         break;
     }
-#endif
+#endif // Q_OS_MAC
 
     return QMainWindow::event(e);
 }
@@ -1361,7 +1361,7 @@ void MainWindow::setupDockClickHandler()
     MacUtils::overrideDockClickHandler(dockClickHandler);
 }
 
-#endif
+#endif // Q_OS_MAC
 
 /*****************************************************
 *                                                   *

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -284,7 +284,7 @@ MainWindow::MainWindow(QWidget *parent)
     m_prioSeparatorMenu = m_ui->menuEdit->insertSeparator(m_ui->actionTopPriority);
 
 #ifdef Q_OS_MAC
-    foreach (QAction *action, m_ui->toolBar->actions()) {
+    for (QAction *action : copyAsConst(m_ui->toolBar->actions())) {
         if (action->isSeparator()) {
             QWidget *spacer = new QWidget(this);
             spacer->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
@@ -1239,7 +1239,7 @@ bool MainWindow::event(QEvent *e)
                 qDebug() << "Has active window:" << (qApp->activeWindow() != nullptr);
                 // Check if there is a modal window
                 bool hasModalWindow = false;
-                foreach (QWidget *widget, QApplication::allWidgets()) {
+                for (QWidget *widget : copyAsConst(QApplication::allWidgets())) {
                     if (widget->isModal()) {
                         hasModalWindow = true;
                         break;
@@ -1285,7 +1285,7 @@ void MainWindow::dropEvent(QDropEvent *event)
     // remove scheme
     QStringList files;
     if (event->mimeData()->hasUrls()) {
-        foreach (const QUrl &url, event->mimeData()->urls()) {
+        for (const QUrl &url : copyAsConst(event->mimeData()->urls())) {
             if (url.isEmpty())
                 continue;
 
@@ -1300,7 +1300,7 @@ void MainWindow::dropEvent(QDropEvent *event)
 
     // differentiate ".torrent" files/links & magnet links from others
     QStringList torrentFiles, otherFiles;
-    foreach (const QString &file, files) {
+    for (const QString &file : qAsConst(files)) {
         const bool isTorrentLink = (file.startsWith("magnet:", Qt::CaseInsensitive)
             || file.endsWith(C_TORRENT_FILE_EXTENSION, Qt::CaseInsensitive)
             || Utils::Misc::isUrl(file));
@@ -1312,7 +1312,7 @@ void MainWindow::dropEvent(QDropEvent *event)
 
     // Download torrents
     const bool useTorrentAdditionDialog = AddNewTorrentDialog::isEnabled();
-    foreach (const QString &file, torrentFiles) {
+    for (const QString &file : qAsConst(torrentFiles)) {
         if (useTorrentAdditionDialog)
             AddNewTorrentDialog::show(file, this);
         else
@@ -1321,7 +1321,7 @@ void MainWindow::dropEvent(QDropEvent *event)
     if (!torrentFiles.isEmpty()) return;
 
     // Create torrent
-    foreach (const QString &file, otherFiles) {
+    for (const QString &file : qAsConst(otherFiles)) {
         createTorrentTriggered(file);
 
         // currently only hande the first entry
@@ -1333,7 +1333,7 @@ void MainWindow::dropEvent(QDropEvent *event)
 // Decode if we accept drag 'n drop or not
 void MainWindow::dragEnterEvent(QDragEnterEvent *event)
 {
-    foreach (const QString &mime, event->mimeData()->formats())
+    for (const QString &mime : copyAsConst(event->mimeData()->formats()))
         qDebug("mimeData: %s", mime.toLocal8Bit().data());
     if (event->mimeData()->hasFormat("text/plain") || event->mimeData()->hasFormat("text/uri-list"))
         event->acceptProposedAction();
@@ -1382,7 +1382,7 @@ void MainWindow::on_actionOpen_triggered()
 
     const bool useTorrentAdditionDialog = AddNewTorrentDialog::isEnabled();
     if (!pathsList.isEmpty()) {
-        foreach (QString file, pathsList) {
+        for (const QString &file : pathsList) {
             qDebug("Dropped file %s on download list", qUtf8Printable(file));
             if (useTorrentAdditionDialog)
                 AddNewTorrentDialog::show(file, this);
@@ -1635,7 +1635,7 @@ void MainWindow::showNotificationBaloon(QString title, QString msg) const
 void MainWindow::downloadFromURLList(const QStringList &urlList)
 {
     const bool useTorrentAdditionDialog = AddNewTorrentDialog::isEnabled();
-    foreach (QString url, urlList) {
+    for (QString url : urlList) {
         if (((url.size() == 40) && !url.contains(QRegularExpression("[^0-9A-Fa-f]")))
             || ((url.size() == 32) && !url.contains(QRegularExpression("[^2-7A-Za-z]"))))
             url = "magnet:?xt=urn:btih:" + url;

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -439,9 +439,9 @@ OptionsDialog::OptionsDialog(QWidget *parent)
 
     // disable mouse wheel event on widgets to avoid mis-selection
     WheelEventEater *wheelEventEater = new WheelEventEater(this);
-    for (QComboBox *widget : copyAsConst(findChildren<QComboBox *>()))
+    for (QComboBox *widget : asConst(findChildren<QComboBox *>()))
         widget->installEventFilter(wheelEventEater);
-    for (QSpinBox *widget : copyAsConst(findChildren<QSpinBox *>()))
+    for (QSpinBox *widget : asConst(findChildren<QSpinBox *>()))
         widget->installEventFilter(wheelEventEater);
 
     loadWindowState();
@@ -479,7 +479,7 @@ OptionsDialog::~OptionsDialog()
 
     saveWindowState();
 
-    for (const QString &path : qAsConst(m_addedScanDirs))
+    for (const QString &path : asConst(m_addedScanDirs))
         ScanFoldersModel::instance()->removePath(path);
     ScanFoldersModel::instance()->configure(); // reloads "removed" paths
     delete m_ui;

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -145,8 +145,8 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     m_ui->hsplitter->setCollapsible(0, false);
     m_ui->hsplitter->setCollapsible(1, false);
     // Get apply button in button box
-    QList<QAbstractButton *> buttons = m_ui->buttonBox->buttons();
-    foreach (QAbstractButton *button, buttons) {
+    const QList<QAbstractButton *> buttons = m_ui->buttonBox->buttons();
+    for (QAbstractButton *button : buttons) {
         if (m_ui->buttonBox->buttonRole(button) == QDialogButtonBox::ApplyRole) {
             m_applyButton = button;
             break;
@@ -455,7 +455,7 @@ void OptionsDialog::initializeLanguageCombo()
     // List language files
     const QDir langDir(":/lang");
     const QStringList langFiles = langDir.entryList(QStringList("qbittorrent_*.qm"), QDir::Files);
-    foreach (const QString langFile, langFiles) {
+    for (const QString &langFile : langFiles) {
         QString localeStr = langFile.mid(12); // remove "qbittorrent_"
         localeStr.chop(3); // Remove ".qm"
         QString languageName;
@@ -479,7 +479,7 @@ OptionsDialog::~OptionsDialog()
 
     saveWindowState();
 
-    foreach (const QString &path, m_addedScanDirs)
+    for (const QString &path : qAsConst(m_addedScanDirs))
         ScanFoldersModel::instance()->removePath(path);
     ScanFoldersModel::instance()->configure(); // reloads "removed" paths
     delete m_ui;
@@ -1490,7 +1490,7 @@ void OptionsDialog::on_removeScanFolderButton_clicked()
     if (selected.isEmpty())
         return;
     Q_ASSERT(selected.count() == ScanFoldersModel::instance()->columnCount());
-    foreach (const QModelIndex &index, selected) {
+    for (const QModelIndex &index : selected) {
         if (index.column() == ScanFoldersModel::WATCH)
             m_removedScanDirs << index.data().toString();
     }

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -148,7 +148,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     QList<QAbstractButton *> buttons = m_ui->buttonBox->buttons();
     foreach (QAbstractButton *button, buttons) {
         if (m_ui->buttonBox->buttonRole(button) == QDialogButtonBox::ApplyRole) {
-            applyButton = button;
+            m_applyButton = button;
             break;
         }
     }
@@ -410,13 +410,13 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     connect(m_ui->btnEditRules, &QPushButton::clicked, this, [this]() { AutomatedRssDownloader(this).exec(); });
 
     // Disable apply Button
-    applyButton->setEnabled(false);
+    m_applyButton->setEnabled(false);
     // Tab selection mechanism
     connect(m_ui->tabSelection, &QListWidget::currentItemChanged, this, &ThisType::changePage);
     // Load Advanced settings
-    advancedSettings = new AdvancedSettings(m_ui->tabAdvancedPage);
-    m_ui->advPageLayout->addWidget(advancedSettings);
-    connect(advancedSettings, &AdvancedSettings::settingsChanged, this, &ThisType::enableApplyButton);
+    m_advancedSettings = new AdvancedSettings(m_ui->tabAdvancedPage);
+    m_ui->advPageLayout->addWidget(m_advancedSettings);
+    connect(m_advancedSettings, &AdvancedSettings::settingsChanged, this, &ThisType::enableApplyButton);
 
     m_ui->textFileLogPath->setDialogCaption(tr("Choose a save directory"));
     m_ui->textFileLogPath->setMode(FileSystemPathEdit::Mode::DirectorySave);
@@ -479,7 +479,7 @@ OptionsDialog::~OptionsDialog()
 
     saveWindowState();
 
-    foreach (const QString &path, addedScanDirs)
+    foreach (const QString &path, m_addedScanDirs)
         ScanFoldersModel::instance()->removePath(path);
     ScanFoldersModel::instance()->configure(); // reloads "removed" paths
     delete m_ui;
@@ -527,7 +527,7 @@ void OptionsDialog::saveWindowState() const
 
 void OptionsDialog::saveOptions()
 {
-    applyButton->setEnabled(false);
+    m_applyButton->setEnabled(false);
     Preferences *const pref = Preferences::instance();
     // Load the translation
     QString locale = getLocale();
@@ -611,11 +611,11 @@ void OptionsDialog::saveOptions()
     AddNewTorrentDialog::setTopLevel(m_ui->checkAdditionDialogFront->isChecked());
     session->setAddTorrentPaused(addTorrentsInPause());
     session->setCreateTorrentSubfolder(m_ui->checkCreateSubfolder->isChecked());
-    ScanFoldersModel::instance()->removeFromFSWatcher(removedScanDirs);
-    ScanFoldersModel::instance()->addToFSWatcher(addedScanDirs);
+    ScanFoldersModel::instance()->removeFromFSWatcher(m_removedScanDirs);
+    ScanFoldersModel::instance()->addToFSWatcher(m_addedScanDirs);
     ScanFoldersModel::instance()->makePersistent();
-    removedScanDirs.clear();
-    addedScanDirs.clear();
+    m_removedScanDirs.clear();
+    m_addedScanDirs.clear();
     session->setTorrentExportDirectory(getTorrentExportDir());
     session->setFinishedTorrentExportDirectory(getFinishedTorrentExportDir());
     pref->setMailNotificationEnabled(m_ui->groupMailNotification->isChecked());
@@ -734,7 +734,7 @@ void OptionsDialog::saveOptions()
     // End Web UI
     // End preferences
     // Save advanced settings
-    advancedSettings->saveAdvancedSettings();
+    m_advancedSettings->saveAdvancedSettings();
     // Assume that user changed multiple settings
     // so it's best to save immediately
     pref->apply();
@@ -1226,7 +1226,7 @@ int OptionsDialog::getMaxUploadsPerTorrent() const
 
 void OptionsDialog::on_buttonBox_accepted()
 {
-    if (applyButton->isEnabled()) {
+    if (m_applyButton->isEnabled()) {
         if (!schedTimesOk()) {
             m_ui->tabSelection->setCurrentRow(TAB_SPEED);
             return;
@@ -1235,7 +1235,7 @@ void OptionsDialog::on_buttonBox_accepted()
             m_ui->tabSelection->setCurrentRow(TAB_WEBUI);
             return;
         }
-        applyButton->setEnabled(false);
+        m_applyButton->setEnabled(false);
         this->hide();
         saveOptions();
     }
@@ -1245,7 +1245,7 @@ void OptionsDialog::on_buttonBox_accepted()
 
 void OptionsDialog::applySettings(QAbstractButton *button)
 {
-    if (button == applyButton) {
+    if (button == m_applyButton) {
         if (!schedTimesOk()) {
             m_ui->tabSelection->setCurrentRow(TAB_SPEED);
             return;
@@ -1277,7 +1277,7 @@ bool OptionsDialog::useAdditionDialog() const
 
 void OptionsDialog::enableApplyButton()
 {
-    applyButton->setEnabled(true);
+    m_applyButton->setEnabled(true);
 }
 
 void OptionsDialog::toggleComboRatioLimitAct()
@@ -1472,7 +1472,7 @@ void OptionsDialog::on_addScanFolderButton_clicked()
             break;
         default:
             pref->setScanDirsLastPath(dir);
-            addedScanDirs << dir;
+            m_addedScanDirs << dir;
             for (int i = 0; i < ScanFoldersModel::instance()->columnCount(); ++i)
                 m_ui->scanFoldersView->resizeColumnToContents(i);
             enableApplyButton();
@@ -1492,7 +1492,7 @@ void OptionsDialog::on_removeScanFolderButton_clicked()
     Q_ASSERT(selected.count() == ScanFoldersModel::instance()->columnCount());
     foreach (const QModelIndex &index, selected) {
         if (index.column() == ScanFoldersModel::WATCH)
-            removedScanDirs << index.data().toString();
+            m_removedScanDirs << index.data().toString();
     }
     ScanFoldersModel::instance()->removePath(selected.first().row(), false);
 }

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -176,11 +176,10 @@ private:
     QByteArray m_sslCert, m_sslKey;
 
     Ui::OptionsDialog *m_ui;
-    QButtonGroup choiceLanguage;
-    QAbstractButton *applyButton;
-    AdvancedSettings *advancedSettings;
-    QList<QString> addedScanDirs;
-    QList<QString> removedScanDirs;
+    QAbstractButton *m_applyButton;
+    AdvancedSettings *m_advancedSettings;
+    QList<QString> m_addedScanDirs;
+    QList<QString> m_removedScanDirs;
 };
 
 #endif // OPTIONSDIALOG_H

--- a/src/gui/programupdater.cpp
+++ b/src/gui/programupdater.cpp
@@ -141,7 +141,7 @@ bool ProgramUpdater::isVersionMoreRecent(const QString &remoteVersion) const
         qDebug() << Q_FUNC_INFO << "local version:" << localVersion << "/" << QBT_VERSION;
         QStringList remoteParts = remoteVersion.split('.');
         QStringList localParts = localVersion.split('.');
-        for (int i = 0; i<qMin(remoteParts.size(), localParts.size()); ++i) {
+        for (int i = 0; i < qMin(remoteParts.size(), localParts.size()); ++i) {
             if (remoteParts[i].toInt() > localParts[i].toInt())
                 return true;
             if (remoteParts[i].toInt() < localParts[i].toInt())

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -103,7 +103,7 @@ PeerListWidget::PeerListWidget(PropertiesWidget *parent)
         hideColumn(PeerListDelegate::COUNTRY);
     // Ensure that at least one column is visible at all times
     bool atLeastOne = false;
-    for (unsigned int i = 0; i < PeerListDelegate::IP_HIDDEN; ++i) {
+    for (int i = 0; i < PeerListDelegate::IP_HIDDEN; ++i) {
         if (!isColumnHidden(i)) {
             atLeastOne = true;
             break;
@@ -114,7 +114,7 @@ PeerListWidget::PeerListWidget(PropertiesWidget *parent)
     // To also mitigate the above issue, we have to resize each column when
     // its size is 0, because explicitly 'showing' the column isn't enough
     // in the above scenario.
-    for (unsigned int i = 0; i < PeerListDelegate::IP_HIDDEN; ++i)
+    for (int i = 0; i < PeerListDelegate::IP_HIDDEN; ++i)
         if ((columnWidth(i) <= 0) && !isColumnHidden(i))
             resizeColumnToContents(i);
     // Context menu
@@ -169,7 +169,7 @@ void PeerListWidget::displayToggleColumnsMenu(const QPoint &)
         actions.append(myAct);
     }
     int visibleCols = 0;
-    for (unsigned int i = 0; i < PeerListDelegate::IP_HIDDEN; ++i) {
+    for (int i = 0; i < PeerListDelegate::IP_HIDDEN; ++i) {
         if (!isColumnHidden(i))
             ++visibleCols;
 
@@ -321,7 +321,7 @@ void PeerListWidget::clear()
     int nbrows = m_listModel->rowCount();
     if (nbrows > 0) {
         qDebug("Cleared %d peers", nbrows);
-        m_listModel->removeRows(0,  nbrows);
+        m_listModel->removeRows(0, nbrows);
     }
 }
 

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -248,9 +248,9 @@ void PeerListWidget::showPeerListMenu(const QPoint &)
     if (!act) return;
 
     if (act == addPeerAct) {
-        QList<BitTorrent::PeerAddress> peersList = PeersAdditionDialog::askForPeers(this);
+        const QList<BitTorrent::PeerAddress> peersList = PeersAdditionDialog::askForPeers(this);
         int peerCount = 0;
-        foreach (const BitTorrent::PeerAddress &addr, peersList) {
+        for (const BitTorrent::PeerAddress &addr : peersList) {
             if (torrent->connectPeer(addr)) {
                 qDebug("Adding peer %s...", qUtf8Printable(addr.ip.toString()));
                 Logger::instance()->addMessage(tr("Manually adding peer '%1'...").arg(addr.ip.toString()));
@@ -284,8 +284,8 @@ void PeerListWidget::banSelectedPeers()
                                     QString(), 0, 1);
     if (ret) return;
 
-    QModelIndexList selectedIndexes = selectionModel()->selectedRows();
-    foreach (const QModelIndex &index, selectedIndexes) {
+    const QModelIndexList selectedIndexes = selectionModel()->selectedRows();
+    for (const QModelIndex &index : selectedIndexes) {
         int row = m_proxyModel->mapToSource(index).row();
         QString ip = m_listModel->data(m_listModel->index(row, PeerListDelegate::IP_HIDDEN)).toString();
         qDebug("Banning peer %s...", ip.toLocal8Bit().data());
@@ -298,9 +298,9 @@ void PeerListWidget::banSelectedPeers()
 
 void PeerListWidget::copySelectedPeers()
 {
-    QModelIndexList selectedIndexes = selectionModel()->selectedRows();
+    const QModelIndexList selectedIndexes = selectionModel()->selectedRows();
     QStringList selectedPeers;
-    foreach (const QModelIndex &index, selectedIndexes) {
+    for (const QModelIndex &index : selectedIndexes) {
         int row = m_proxyModel->mapToSource(index).row();
         QString ip = m_listModel->data(m_listModel->index(row, PeerListDelegate::IP_HIDDEN)).toString();
         QString myport = m_listModel->data(m_listModel->index(row, PeerListDelegate::PORT)).toString();
@@ -339,10 +339,10 @@ void PeerListWidget::loadPeers(BitTorrent::TorrentHandle *const torrent, bool fo
 {
     if (!torrent) return;
 
-    QList<BitTorrent::PeerInfo> peers = torrent->peers();
+    const QList<BitTorrent::PeerInfo> peers = torrent->peers();
     QSet<QString> oldPeersSet = m_peerItems.keys().toSet();
 
-    foreach (const BitTorrent::PeerInfo &peer, peers) {
+    for (const BitTorrent::PeerInfo &peer : peers) {
         BitTorrent::PeerAddress addr = peer.address();
         if (addr.ip.isNull()) continue;
 

--- a/src/gui/properties/peersadditiondialog.cpp
+++ b/src/gui/properties/peersadditiondialog.cpp
@@ -62,7 +62,7 @@ void PeersAdditionDialog::validateInput()
                     QMessageBox::Ok);
         return;
     }
-    for (const QString &peer : copyAsConst(m_ui->textEditPeers->toPlainText().trimmed().split('\n'))) {
+    for (const QString &peer : asConst(m_ui->textEditPeers->toPlainText().trimmed().split('\n'))) {
         BitTorrent::PeerAddress addr = parsePeer(peer);
         if (!addr.ip.isNull()) {
             m_peersList.append(addr);

--- a/src/gui/properties/peersadditiondialog.cpp
+++ b/src/gui/properties/peersadditiondialog.cpp
@@ -31,6 +31,7 @@
 #include <QHostAddress>
 #include <QMessageBox>
 
+#include "base/global.h"
 #include "ui_peersadditiondialog.h"
 
 PeersAdditionDialog::PeersAdditionDialog(QWidget *parent)
@@ -61,7 +62,7 @@ void PeersAdditionDialog::validateInput()
                     QMessageBox::Ok);
         return;
     }
-    foreach (const QString &peer, m_ui->textEditPeers->toPlainText().trimmed().split('\n')) {
+    for (const QString &peer : copyAsConst(m_ui->textEditPeers->toPlainText().trimmed().split('\n'))) {
         BitTorrent::PeerAddress addr = parsePeer(peer);
         if (!addr.ip.isNull()) {
             m_peersList.append(addr);

--- a/src/gui/properties/piecesbar.cpp
+++ b/src/gui/properties/piecesbar.cpp
@@ -259,7 +259,7 @@ void PiecesBar::showToolTip(const QHelpEvent *e)
             stream << "<html><body>";
             PieceIndexToImagePos transform {m_torrent->info(), m_image};
             int pieceIndex = transform.pieceIndex(imagePos);
-            QVector<int> files {m_torrent->info().fileIndicesForPiece(pieceIndex)};
+            const QVector<int> files {m_torrent->info().fileIndicesForPiece(pieceIndex)};
 
             QString tooltipTitle;
             if (files.count() > 1) {

--- a/src/gui/properties/piecesbar.cpp
+++ b/src/gui/properties/piecesbar.cpp
@@ -275,7 +275,7 @@ void PiecesBar::showToolTip(const QHelpEvent *e)
             DetailedTooltipRenderer renderer(stream, tooltipTitle);
 
             const bool isFileNameCorrectionNeeded = this->isFileNameCorrectionNeeded();
-            for (int f: files) {
+            for (int f : files) {
                 QString filePath {m_torrent->info().filePath(f)};
                 if (isFileNameCorrectionNeeded)
                     filePath.replace(QLatin1String("/.unwanted"), QString());

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -511,7 +511,7 @@ void PropertiesWidget::loadUrlSeeds()
     qDebug("Loading URL seeds");
     const QList<QUrl> hcSeeds = m_torrent->urlSeeds();
     // Add url seeds
-    foreach (const QUrl &hcSeed, hcSeeds) {
+    for (const QUrl &hcSeed : hcSeeds) {
         qDebug("Loading URL seed: %s", qUtf8Printable(hcSeed.toString()));
         new QListWidgetItem(hcSeed.toString(), m_ui->listWebSeeds);
     }
@@ -582,7 +582,7 @@ void PropertiesWidget::displayFilesListMenu(const QPoint &)
 {
     if (!m_torrent) return;
 
-    QModelIndexList selectedRows = m_ui->filesList->selectionModel()->selectedRows(0);
+    const QModelIndexList selectedRows = m_ui->filesList->selectionModel()->selectedRows(0);
     if (selectedRows.empty()) return;
 
     QMenu myFilesLlistMenu;
@@ -630,7 +630,7 @@ void PropertiesWidget::displayFilesListMenu(const QPoint &)
             prio = prio::IGNORED;
 
         qDebug("Setting files priority");
-        foreach (QModelIndex index, selectedRows) {
+        for (const QModelIndex &index : selectedRows) {
             qDebug("Setting priority(%d) for file at row %d", prio, index.row());
             m_propListModel->setData(m_propListModel->index(index.row(), PRIORITY, index.parent()), prio);
         }
@@ -847,7 +847,7 @@ void PropertiesWidget::deleteSelectedUrlSeeds()
     if (selectedItems.isEmpty()) return;
 
     QList<QUrl> urlSeeds;
-    foreach (const QListWidgetItem *item, selectedItems)
+    for (const QListWidgetItem *item : selectedItems)
         urlSeeds << item->text();
 
     m_torrent->removeUrlSeeds(urlSeeds);
@@ -861,7 +861,7 @@ void PropertiesWidget::copySelectedWebSeedsToClipboard() const
     if (selectedItems.isEmpty()) return;
 
     QStringList urlsToCopy;
-    foreach (QListWidgetItem *item, selectedItems)
+    for (const QListWidgetItem *item : selectedItems)
         urlsToCopy << item->text();
 
     QApplication::clipboard()->setText(urlsToCopy.join('\n'));

--- a/src/gui/properties/proptabbar.cpp
+++ b/src/gui/properties/proptabbar.cpp
@@ -33,6 +33,7 @@
 #include <QPushButton>
 #include <QSpacerItem>
 
+#include "base/global.h"
 #include "guiiconprovider.h"
 
 PropTabBar::PropTabBar(QWidget *parent)
@@ -102,7 +103,7 @@ PropTabBar::PropTabBar(QWidget *parent)
     connect(m_btnGroup, static_cast<void (QButtonGroup::*)(int)>(&QButtonGroup::buttonClicked)
             , this, &PropTabBar::setCurrentIndex);
     // Disable buttons focus
-    foreach (QAbstractButton *btn, m_btnGroup->buttons())
+    for (QAbstractButton *btn : copyAsConst(m_btnGroup->buttons()))
         btn->setFocusPolicy(Qt::NoFocus);
 }
 

--- a/src/gui/properties/proptabbar.cpp
+++ b/src/gui/properties/proptabbar.cpp
@@ -103,7 +103,7 @@ PropTabBar::PropTabBar(QWidget *parent)
     connect(m_btnGroup, static_cast<void (QButtonGroup::*)(int)>(&QButtonGroup::buttonClicked)
             , this, &PropTabBar::setCurrentIndex);
     // Disable buttons focus
-    for (QAbstractButton *btn : copyAsConst(m_btnGroup->buttons()))
+    for (QAbstractButton *btn : asConst(m_btnGroup->buttons()))
         btn->setFocusPolicy(Qt::NoFocus);
 }
 

--- a/src/gui/properties/speedplotview.cpp
+++ b/src/gui/properties/speedplotview.cpp
@@ -348,7 +348,7 @@ void SpeedPlotView::paintEvent(QPaintEvent *)
 
     double legendHeight = 0;
     int legendWidth = 0;
-    for (const auto &property : qAsConst(m_properties)) {
+    for (const auto &property : asConst(m_properties)) {
         if (!property.enable)
             continue;
 
@@ -363,7 +363,7 @@ void SpeedPlotView::paintEvent(QPaintEvent *)
     painter.fillRect(legendBackgroundRect, legendBackgroundColor);
 
     i = 0;
-    for (const auto &property : qAsConst(m_properties)) {
+    for (const auto &property : asConst(m_properties)) {
         if (!property.enable)
             continue;
 

--- a/src/gui/properties/speedplotview.cpp
+++ b/src/gui/properties/speedplotview.cpp
@@ -274,7 +274,7 @@ void SpeedPlotView::paintEvent(QPaintEvent *)
     rect.adjust(0, fontMetrics.height(), 0, 0); // Add top padding for top speed text
 
     // draw Y axis speed labels
-    QVector<QString> speedLabels = {
+    const QVector<QString> speedLabels = {
         formatLabel(niceScale.arg, niceScale.unit),
         formatLabel((0.75 * niceScale.arg), niceScale.unit),
         formatLabel((0.50 * niceScale.arg), niceScale.unit),

--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -290,7 +290,7 @@ void TrackerListWidget::loadStickyItems(BitTorrent::TorrentHandle *const torrent
     // XXX: libtorrent should provide this info...
     // Count peers from DHT, PeX, LSD
     uint seedsDHT = 0, seedsPeX = 0, seedsLSD = 0, peersDHT = 0, peersPeX = 0, peersLSD = 0;
-    for (const BitTorrent::PeerInfo &peer : copyAsConst(torrent->peers())) {
+    for (const BitTorrent::PeerInfo &peer : asConst(torrent->peers())) {
         if (peer.isConnecting()) continue;
 
         if (peer.fromDHT()) {
@@ -332,7 +332,7 @@ void TrackerListWidget::loadTrackers()
     // Load actual trackers information
     QHash<QString, BitTorrent::TrackerInfo> trackerData = torrent->trackerInfos();
     QStringList oldTrackerURLs = m_trackerItems.keys();
-    for (const BitTorrent::TrackerEntry &entry : copyAsConst(torrent->trackers())) {
+    for (const BitTorrent::TrackerEntry &entry : asConst(torrent->trackers())) {
         QString trackerURL = entry.url();
         QTreeWidgetItem *item = m_trackerItems.value(trackerURL, nullptr);
         if (!item) {
@@ -384,7 +384,7 @@ void TrackerListWidget::loadTrackers()
         item->setTextAlignment(COL_DOWNLOADED, (Qt::AlignRight | Qt::AlignVCenter));
     }
     // Remove old trackers
-    for (const QString &tracker : qAsConst(oldTrackerURLs))
+    for (const QString &tracker : asConst(oldTrackerURLs))
         delete m_trackerItems.take(tracker);
 }
 
@@ -395,7 +395,7 @@ void TrackerListWidget::askForTrackers()
     if (!torrent) return;
 
     QList<BitTorrent::TrackerEntry> trackers;
-    for (const QString &tracker : copyAsConst(TrackersAdditionDialog::askForTrackers(this, torrent)))
+    for (const QString &tracker : asConst(TrackersAdditionDialog::askForTrackers(this, torrent)))
         trackers << tracker;
 
     torrent->addTrackers(trackers);

--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -45,6 +45,7 @@
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/torrenthandle.h"
 #include "base/bittorrent/trackerentry.h"
+#include "base/global.h"
 #include "base/preferences.h"
 #include "base/utils/misc.h"
 #include "autoexpandabledialog.h"
@@ -140,7 +141,7 @@ QList<QTreeWidgetItem*> TrackerListWidget::getSelectedTrackerItems() const
 {
     const QList<QTreeWidgetItem *> selectedTrackerItems = selectedItems();
     QList<QTreeWidgetItem *> selectedTrackers;
-    foreach (QTreeWidgetItem *item, selectedTrackerItems) {
+    for (QTreeWidgetItem *item : selectedTrackerItems) {
         if (indexOfTopLevelItem(item) >= NB_STICKY_ITEM) // Ignore STICKY ITEMS
             selectedTrackers << item;
     }
@@ -163,11 +164,11 @@ void TrackerListWidget::moveSelectionUp()
         clear();
         return;
     }
-    QList<QTreeWidgetItem *> selectedTrackerItems = getSelectedTrackerItems();
+    const QList<QTreeWidgetItem *> selectedTrackerItems = getSelectedTrackerItems();
     if (selectedTrackerItems.isEmpty()) return;
 
     bool change = false;
-    foreach (QTreeWidgetItem *item, selectedTrackerItems) {
+    for (QTreeWidgetItem *item : selectedTrackerItems) {
         int index = indexOfTopLevelItem(item);
         if (index > NB_STICKY_ITEM) {
             insertTopLevelItem(index - 1, takeTopLevelItem(index));
@@ -178,7 +179,7 @@ void TrackerListWidget::moveSelectionUp()
 
     // Restore selection
     QItemSelectionModel *selection = selectionModel();
-    foreach (QTreeWidgetItem *item, selectedTrackerItems)
+    for (QTreeWidgetItem *item : selectedTrackerItems)
         selection->select(indexFromItem(item), (QItemSelectionModel::Rows | QItemSelectionModel::Select));
 
     setSelectionModel(selection);
@@ -204,7 +205,7 @@ void TrackerListWidget::moveSelectionDown()
         clear();
         return;
     }
-    QList<QTreeWidgetItem *> selectedTrackerItems = getSelectedTrackerItems();
+    const QList<QTreeWidgetItem *> selectedTrackerItems = getSelectedTrackerItems();
     if (selectedTrackerItems.isEmpty()) return;
 
     bool change = false;
@@ -219,7 +220,7 @@ void TrackerListWidget::moveSelectionDown()
 
     // Restore selection
     QItemSelectionModel *selection = selectionModel();
-    foreach (QTreeWidgetItem *item, selectedTrackerItems)
+    for (QTreeWidgetItem *item : selectedTrackerItems)
         selection->select(indexFromItem(item), (QItemSelectionModel::Rows | QItemSelectionModel::Select));
 
     setSelectionModel(selection);
@@ -289,7 +290,7 @@ void TrackerListWidget::loadStickyItems(BitTorrent::TorrentHandle *const torrent
     // XXX: libtorrent should provide this info...
     // Count peers from DHT, PeX, LSD
     uint seedsDHT = 0, seedsPeX = 0, seedsLSD = 0, peersDHT = 0, peersPeX = 0, peersLSD = 0;
-    foreach (const BitTorrent::PeerInfo &peer, torrent->peers()) {
+    for (const BitTorrent::PeerInfo &peer : copyAsConst(torrent->peers())) {
         if (peer.isConnecting()) continue;
 
         if (peer.fromDHT()) {
@@ -331,7 +332,7 @@ void TrackerListWidget::loadTrackers()
     // Load actual trackers information
     QHash<QString, BitTorrent::TrackerInfo> trackerData = torrent->trackerInfos();
     QStringList oldTrackerURLs = m_trackerItems.keys();
-    foreach (const BitTorrent::TrackerEntry &entry, torrent->trackers()) {
+    for (const BitTorrent::TrackerEntry &entry : copyAsConst(torrent->trackers())) {
         QString trackerURL = entry.url();
         QTreeWidgetItem *item = m_trackerItems.value(trackerURL, nullptr);
         if (!item) {
@@ -383,7 +384,7 @@ void TrackerListWidget::loadTrackers()
         item->setTextAlignment(COL_DOWNLOADED, (Qt::AlignRight | Qt::AlignVCenter));
     }
     // Remove old trackers
-    foreach (const QString &tracker, oldTrackerURLs)
+    for (const QString &tracker : qAsConst(oldTrackerURLs))
         delete m_trackerItems.take(tracker);
 }
 
@@ -394,7 +395,7 @@ void TrackerListWidget::askForTrackers()
     if (!torrent) return;
 
     QList<BitTorrent::TrackerEntry> trackers;
-    foreach (const QString &tracker, TrackersAdditionDialog::askForTrackers(this, torrent))
+    for (const QString &tracker : copyAsConst(TrackersAdditionDialog::askForTrackers(this, torrent)))
         trackers << tracker;
 
     torrent->addTrackers(trackers);
@@ -402,11 +403,11 @@ void TrackerListWidget::askForTrackers()
 
 void TrackerListWidget::copyTrackerUrl()
 {
-    QList<QTreeWidgetItem *> selectedTrackerItems = getSelectedTrackerItems();
+    const QList<QTreeWidgetItem *> selectedTrackerItems = getSelectedTrackerItems();
     if (selectedTrackerItems.isEmpty()) return;
 
     QStringList urlsToCopy;
-    foreach (QTreeWidgetItem *item, selectedTrackerItems) {
+    for (const QTreeWidgetItem *item : selectedTrackerItems) {
         QString trackerURL = item->data(COL_URL, Qt::DisplayRole).toString();
         qDebug() << QString("Copy: ") + trackerURL;
         urlsToCopy << trackerURL;
@@ -423,11 +424,11 @@ void TrackerListWidget::deleteSelectedTrackers()
         return;
     }
 
-    QList<QTreeWidgetItem *> selectedTrackerItems = getSelectedTrackerItems();
+    const QList<QTreeWidgetItem *> selectedTrackerItems = getSelectedTrackerItems();
     if (selectedTrackerItems.isEmpty()) return;
 
     QStringList urlsToRemove;
-    foreach (QTreeWidgetItem *item, selectedTrackerItems) {
+    for (const QTreeWidgetItem *item : selectedTrackerItems) {
         QString trackerURL = item->data(COL_URL, Qt::DisplayRole).toString();
         urlsToRemove << trackerURL;
         m_trackerItems.remove(trackerURL);
@@ -436,8 +437,8 @@ void TrackerListWidget::deleteSelectedTrackers()
 
     // Iterate over the trackers and remove the selected ones
     QList<BitTorrent::TrackerEntry> remainingTrackers;
-    QList<BitTorrent::TrackerEntry> trackers = torrent->trackers();
-    foreach (const BitTorrent::TrackerEntry &entry, trackers) {
+    const QList<BitTorrent::TrackerEntry> trackers = torrent->trackers();
+    for (const BitTorrent::TrackerEntry &entry : trackers) {
         if (!urlsToRemove.contains(entry.url()))
             remainingTrackers.push_back(entry);
     }
@@ -493,7 +494,7 @@ void TrackerListWidget::editSelectedTracker()
 
 void TrackerListWidget::reannounceSelected()
 {
-    QList<QTreeWidgetItem *> selItems = selectedItems();
+    const QList<QTreeWidgetItem *> selItems = selectedItems();
     if (selItems.isEmpty()) return;
 
     BitTorrent::TorrentHandle *const torrent = m_properties->getCurrentTorrent();
@@ -501,7 +502,7 @@ void TrackerListWidget::reannounceSelected()
 
     QList<BitTorrent::TrackerEntry> trackers = torrent->trackers();
 
-    foreach (QTreeWidgetItem* item, selItems) {
+    for (const QTreeWidgetItem *item : selItems) {
         // DHT case
         if (item == m_DHTItem) {
             torrent->forceDHTAnnounce();

--- a/src/gui/properties/trackersadditiondialog.cpp
+++ b/src/gui/properties/trackersadditiondialog.cpp
@@ -34,6 +34,7 @@
 
 #include "base/bittorrent/torrenthandle.h"
 #include "base/bittorrent/trackerentry.h"
+#include "base/global.h"
 #include "base/net/downloadhandler.h"
 #include "base/net/downloadmanager.h"
 #include "base/utils/fs.h"
@@ -59,7 +60,7 @@ TrackersAdditionDialog::~TrackersAdditionDialog()
 QStringList TrackersAdditionDialog::newTrackers() const
 {
     QStringList cleanTrackers;
-    foreach (QString url, m_ui->textEditTrackersList->toPlainText().split('\n')) {
+    for (QString url : copyAsConst(m_ui->textEditTrackersList->toPlainText().split('\n'))) {
         url = url.trimmed();
         if (!url.isEmpty())
             cleanTrackers << url;
@@ -83,8 +84,8 @@ void TrackersAdditionDialog::parseUTorrentList(const QString &, const QByteArray
     // Load from torrent handle
     QList<BitTorrent::TrackerEntry> existingTrackers = m_torrent->trackers();
     // Load from current user list
-    QStringList tmp = m_ui->textEditTrackersList->toPlainText().split('\n');
-    foreach (const QString &userURL, tmp) {
+    const QStringList tmp = m_ui->textEditTrackersList->toPlainText().split('\n');
+    for (const QString &userURL : tmp) {
         BitTorrent::TrackerEntry userTracker(userURL);
         if (!existingTrackers.contains(userTracker))
             existingTrackers << userTracker;

--- a/src/gui/properties/trackersadditiondialog.cpp
+++ b/src/gui/properties/trackersadditiondialog.cpp
@@ -60,7 +60,7 @@ TrackersAdditionDialog::~TrackersAdditionDialog()
 QStringList TrackersAdditionDialog::newTrackers() const
 {
     QStringList cleanTrackers;
-    for (QString url : copyAsConst(m_ui->textEditTrackersList->toPlainText().split('\n'))) {
+    for (QString url : asConst(m_ui->textEditTrackersList->toPlainText().split('\n'))) {
         url = url.trimmed();
         if (!url.isEmpty())
             cleanTrackers << url;

--- a/src/gui/rss/articlelistwidget.cpp
+++ b/src/gui/rss/articlelistwidget.cpp
@@ -30,6 +30,7 @@
 
 #include <QListWidgetItem>
 
+#include "base/global.h"
 #include "base/rss/rss_article.h"
 #include "base/rss/rss_item.h"
 
@@ -68,7 +69,7 @@ void ArticleListWidget::setRSSItem(RSS::Item *rssItem, bool unreadOnly)
         connect(m_rssItem, &RSS::Item::articleRead, this, &ArticleListWidget::handleArticleRead);
         connect(m_rssItem, &RSS::Item::articleAboutToBeRemoved, this, &ArticleListWidget::handleArticleAboutToBeRemoved);
 
-        foreach (auto article, rssItem->articles()) {
+        for (const auto article : copyAsConst(rssItem->articles())) {
             if (!(m_unreadOnly && article->isRead())) {
                 auto item = createItem(article);
                 addItem(item);

--- a/src/gui/rss/articlelistwidget.cpp
+++ b/src/gui/rss/articlelistwidget.cpp
@@ -69,7 +69,7 @@ void ArticleListWidget::setRSSItem(RSS::Item *rssItem, bool unreadOnly)
         connect(m_rssItem, &RSS::Item::articleRead, this, &ArticleListWidget::handleArticleRead);
         connect(m_rssItem, &RSS::Item::articleAboutToBeRemoved, this, &ArticleListWidget::handleArticleAboutToBeRemoved);
 
-        for (const auto article : copyAsConst(rssItem->articles())) {
+        for (const auto article : asConst(rssItem->articles())) {
             if (!(m_unreadOnly && article->isRead())) {
                 auto item = createItem(article);
                 addItem(item);

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -41,6 +41,7 @@
 #include <QString>
 
 #include "base/bittorrent/session.h"
+#include "base/global.h"
 #include "base/preferences.h"
 #include "base/rss/rss_article.h"
 #include "base/rss/rss_autodownloader.h"
@@ -131,7 +132,7 @@ AutomatedRssDownloader::AutomatedRssDownloader(QWidget *parent)
     loadFeedList();
 
     m_ui->listRules->blockSignals(true);
-    foreach (const RSS::AutoDownloadRule &rule, RSS::AutoDownloader::instance()->rules())
+    for (const RSS::AutoDownloadRule &rule : copyAsConst(RSS::AutoDownloader::instance()->rules()))
         createRuleItem(rule);
     m_ui->listRules->blockSignals(false);
 
@@ -181,7 +182,7 @@ void AutomatedRssDownloader::loadFeedList()
 {
     const QSignalBlocker feedListSignalBlocker(m_ui->listFeeds);
 
-    foreach (auto feed, RSS::Session::instance()->feeds()) {
+    for (const auto feed : copyAsConst(RSS::Session::instance()->feeds())) {
         QListWidgetItem *item = new QListWidgetItem(feed->name(), m_ui->listFeeds);
         item->setData(Qt::UserRole, feed->url());
         item->setFlags(item->flags() | Qt::ItemIsUserCheckable | Qt::ItemIsTristate);
@@ -211,7 +212,7 @@ void AutomatedRssDownloader::updateFeedList()
         bool allEnabled = true;
         bool anyEnabled = false;
 
-        foreach (const QListWidgetItem *ruleItem, selection) {
+        for (const QListWidgetItem *ruleItem : qAsConst(selection)) {
             auto rule = RSS::AutoDownloader::instance()->ruleByName(ruleItem->text());
             if (rule.feedURLs().contains(feedURL))
                 anyEnabled = true;
@@ -384,7 +385,7 @@ void AutomatedRssDownloader::on_removeRuleBtn_clicked()
     if (QMessageBox::question(this, tr("Rule deletion confirmation"), confirmText, QMessageBox::Yes, QMessageBox::No) != QMessageBox::Yes)
         return;
 
-    foreach (QListWidgetItem *item, selection)
+    for (const QListWidgetItem *item : selection)
         RSS::AutoDownloader::instance()->removeRule(item->text());
 }
 
@@ -548,7 +549,7 @@ void AutomatedRssDownloader::clearSelectedRuleDownloadedEpisodeList()
 void AutomatedRssDownloader::handleFeedCheckStateChange(QListWidgetItem *feedItem)
 {
     const QString feedURL = feedItem->data(Qt::UserRole).toString();
-    foreach (QListWidgetItem *ruleItem, m_ui->listRules->selectedItems()) {
+    for (QListWidgetItem *ruleItem : copyAsConst(m_ui->listRules->selectedItems())) {
         RSS::AutoDownloadRule rule = (ruleItem == m_currentRuleItem
                                        ? m_currentRule
                                        : RSS::AutoDownloader::instance()->ruleByName(ruleItem->text()));
@@ -572,16 +573,16 @@ void AutomatedRssDownloader::updateMatchingArticles()
 {
     m_ui->treeMatchingArticles->clear();
 
-    foreach (const QListWidgetItem *ruleItem, m_ui->listRules->selectedItems()) {
+    for (const QListWidgetItem *ruleItem : copyAsConst(m_ui->listRules->selectedItems())) {
         RSS::AutoDownloadRule rule = (ruleItem == m_currentRuleItem
                                        ? m_currentRule
                                        : RSS::AutoDownloader::instance()->ruleByName(ruleItem->text()));
-        foreach (const QString &feedURL, rule.feedURLs()) {
+        for (const QString &feedURL : copyAsConst(rule.feedURLs())) {
             auto feed = RSS::Session::instance()->feedByURL(feedURL);
             if (!feed) continue; // feed doesn't exist
 
             QStringList matchingArticles;
-            foreach (auto article, feed->articles())
+            for (const auto article : copyAsConst(feed->articles()))
                 if (rule.matches(article->data()))
                     matchingArticles << article->title();
             if (!matchingArticles.isEmpty())
@@ -620,7 +621,7 @@ void AutomatedRssDownloader::addFeedArticlesToTree(RSS::Feed *feed, const QStrin
     }
 
     // Insert the articles
-    foreach (const QString &article, articles) {
+    for (const QString &article : articles) {
         QPair<QString, QString> key(feed->name(), article);
 
         if (!m_treeListEntries.contains(key)) {
@@ -675,10 +676,10 @@ void AutomatedRssDownloader::updateMustLineValidity()
         if (isRegex)
             tokens << text;
         else
-            foreach (const QString &token, text.split('|'))
+            for (const QString &token : copyAsConst(text.split('|')))
                 tokens << Utils::String::wildcardToRegex(token);
 
-        foreach (const QString &token, tokens) {
+        for (const QString &token : qAsConst(tokens)) {
             QRegularExpression reg(token, QRegularExpression::CaseInsensitiveOption);
             if (!reg.isValid()) {
                 if (isRegex)
@@ -713,10 +714,10 @@ void AutomatedRssDownloader::updateMustNotLineValidity()
         if (isRegex)
             tokens << text;
         else
-            foreach (const QString &token, text.split('|'))
+            for (const QString &token : copyAsConst(text.split('|')))
                 tokens << Utils::String::wildcardToRegex(token);
 
-        foreach (const QString &token, tokens) {
+        for (const QString &token : qAsConst(tokens)) {
             QRegularExpression reg(token, QRegularExpression::CaseInsensitiveOption);
             if (!reg.isValid()) {
                 if (isRegex)

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -132,7 +132,7 @@ AutomatedRssDownloader::AutomatedRssDownloader(QWidget *parent)
     loadFeedList();
 
     m_ui->listRules->blockSignals(true);
-    for (const RSS::AutoDownloadRule &rule : copyAsConst(RSS::AutoDownloader::instance()->rules()))
+    for (const RSS::AutoDownloadRule &rule : asConst(RSS::AutoDownloader::instance()->rules()))
         createRuleItem(rule);
     m_ui->listRules->blockSignals(false);
 
@@ -182,7 +182,7 @@ void AutomatedRssDownloader::loadFeedList()
 {
     const QSignalBlocker feedListSignalBlocker(m_ui->listFeeds);
 
-    for (const auto feed : copyAsConst(RSS::Session::instance()->feeds())) {
+    for (const auto feed : asConst(RSS::Session::instance()->feeds())) {
         QListWidgetItem *item = new QListWidgetItem(feed->name(), m_ui->listFeeds);
         item->setData(Qt::UserRole, feed->url());
         item->setFlags(item->flags() | Qt::ItemIsUserCheckable | Qt::ItemIsTristate);
@@ -212,7 +212,7 @@ void AutomatedRssDownloader::updateFeedList()
         bool allEnabled = true;
         bool anyEnabled = false;
 
-        for (const QListWidgetItem *ruleItem : qAsConst(selection)) {
+        for (const QListWidgetItem *ruleItem : asConst(selection)) {
             auto rule = RSS::AutoDownloader::instance()->ruleByName(ruleItem->text());
             if (rule.feedURLs().contains(feedURL))
                 anyEnabled = true;
@@ -549,7 +549,7 @@ void AutomatedRssDownloader::clearSelectedRuleDownloadedEpisodeList()
 void AutomatedRssDownloader::handleFeedCheckStateChange(QListWidgetItem *feedItem)
 {
     const QString feedURL = feedItem->data(Qt::UserRole).toString();
-    for (QListWidgetItem *ruleItem : copyAsConst(m_ui->listRules->selectedItems())) {
+    for (QListWidgetItem *ruleItem : asConst(m_ui->listRules->selectedItems())) {
         RSS::AutoDownloadRule rule = (ruleItem == m_currentRuleItem
                                        ? m_currentRule
                                        : RSS::AutoDownloader::instance()->ruleByName(ruleItem->text()));
@@ -573,16 +573,16 @@ void AutomatedRssDownloader::updateMatchingArticles()
 {
     m_ui->treeMatchingArticles->clear();
 
-    for (const QListWidgetItem *ruleItem : copyAsConst(m_ui->listRules->selectedItems())) {
+    for (const QListWidgetItem *ruleItem : asConst(m_ui->listRules->selectedItems())) {
         RSS::AutoDownloadRule rule = (ruleItem == m_currentRuleItem
                                        ? m_currentRule
                                        : RSS::AutoDownloader::instance()->ruleByName(ruleItem->text()));
-        for (const QString &feedURL : copyAsConst(rule.feedURLs())) {
+        for (const QString &feedURL : asConst(rule.feedURLs())) {
             auto feed = RSS::Session::instance()->feedByURL(feedURL);
             if (!feed) continue; // feed doesn't exist
 
             QStringList matchingArticles;
-            for (const auto article : copyAsConst(feed->articles()))
+            for (const auto article : asConst(feed->articles()))
                 if (rule.matches(article->data()))
                     matchingArticles << article->title();
             if (!matchingArticles.isEmpty())
@@ -676,10 +676,10 @@ void AutomatedRssDownloader::updateMustLineValidity()
         if (isRegex)
             tokens << text;
         else
-            for (const QString &token : copyAsConst(text.split('|')))
+            for (const QString &token : asConst(text.split('|')))
                 tokens << Utils::String::wildcardToRegex(token);
 
-        for (const QString &token : qAsConst(tokens)) {
+        for (const QString &token : asConst(tokens)) {
             QRegularExpression reg(token, QRegularExpression::CaseInsensitiveOption);
             if (!reg.isValid()) {
                 if (isRegex)
@@ -714,10 +714,10 @@ void AutomatedRssDownloader::updateMustNotLineValidity()
         if (isRegex)
             tokens << text;
         else
-            for (const QString &token : copyAsConst(text.split('|')))
+            for (const QString &token : asConst(text.split('|')))
                 tokens << Utils::String::wildcardToRegex(token);
 
-        for (const QString &token : qAsConst(tokens)) {
+        for (const QString &token : asConst(tokens)) {
             QRegularExpression reg(token, QRegularExpression::CaseInsensitiveOption);
             if (!reg.isValid()) {
                 if (isRegex)

--- a/src/gui/rss/feedlistwidget.cpp
+++ b/src/gui/rss/feedlistwidget.cpp
@@ -33,6 +33,7 @@
 #include <QDropEvent>
 #include <QTreeWidgetItem>
 
+#include "base/global.h"
 #include "base/rss/rss_article.h"
 #include "base/rss/rss_feed.h"
 #include "base/rss/rss_folder.h"
@@ -219,7 +220,7 @@ void FeedListWidget::dropEvent(QDropEvent *event)
                                : RSS::Session::instance()->rootFolder());
 
     // move as much items as possible
-    foreach (QTreeWidgetItem *srcItem, selectedItems()) {
+    for (QTreeWidgetItem *srcItem : copyAsConst(selectedItems())) {
         auto rssItem = getRSSItem(srcItem);
         RSS::Session::instance()->moveItem(rssItem, RSS::Item::joinPath(destFolder->path(), rssItem->name()));
     }
@@ -264,7 +265,7 @@ QTreeWidgetItem *FeedListWidget::createItem(RSS::Item *rssItem, QTreeWidgetItem 
 
 void FeedListWidget::fill(QTreeWidgetItem *parent, RSS::Folder *rssParent)
 {
-    foreach (auto rssItem, rssParent->items()) {
+    for (const auto rssItem : copyAsConst(rssParent->items())) {
         QTreeWidgetItem *item = createItem(rssItem, parent);
         // Recursive call if this is a folder.
         if (auto folder = qobject_cast<RSS::Folder *>(rssItem))

--- a/src/gui/rss/feedlistwidget.cpp
+++ b/src/gui/rss/feedlistwidget.cpp
@@ -220,7 +220,7 @@ void FeedListWidget::dropEvent(QDropEvent *event)
                                : RSS::Session::instance()->rootFolder());
 
     // move as much items as possible
-    for (QTreeWidgetItem *srcItem : copyAsConst(selectedItems())) {
+    for (QTreeWidgetItem *srcItem : asConst(selectedItems())) {
         auto rssItem = getRSSItem(srcItem);
         RSS::Session::instance()->moveItem(rssItem, RSS::Item::joinPath(destFolder->path(), rssItem->name()));
     }
@@ -265,7 +265,7 @@ QTreeWidgetItem *FeedListWidget::createItem(RSS::Item *rssItem, QTreeWidgetItem 
 
 void FeedListWidget::fill(QTreeWidgetItem *parent, RSS::Folder *rssParent)
 {
-    for (const auto rssItem : copyAsConst(rssParent->items())) {
+    for (const auto rssItem : asConst(rssParent->items())) {
         QTreeWidgetItem *item = createItem(rssItem, parent);
         // Recursive call if this is a folder.
         if (auto folder = qobject_cast<RSS::Folder *>(rssItem))

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -41,6 +41,7 @@
 #include <QString>
 
 #include "base/bittorrent/session.h"
+#include "base/global.h"
 #include "base/net/downloadmanager.h"
 #include "base/preferences.h"
 #include "base/rss/rss_article.h"
@@ -186,7 +187,7 @@ void RSSWidget::displayItemsListMenu(const QPoint &)
 {
     bool hasTorrent = false;
     bool hasLink = false;
-    foreach (const QListWidgetItem *item, m_articleListWidget->selectedItems()) {
+    for (const QListWidgetItem *item : copyAsConst(m_articleListWidget->selectedItems())) {
         auto article = reinterpret_cast<RSS::Article *>(item->data(Qt::UserRole).value<quintptr>());
         Q_ASSERT(article);
 
@@ -286,7 +287,7 @@ void RSSWidget::on_newFeedButton_clicked()
 
 void RSSWidget::deleteSelectedItems()
 {
-    QList<QTreeWidgetItem *> selectedItems = m_feedListWidget->selectedItems();
+    const QList<QTreeWidgetItem *> selectedItems = m_feedListWidget->selectedItems();
     if (selectedItems.isEmpty())
         return;
     if ((selectedItems.size() == 1) && (selectedItems.first() == m_feedListWidget->stickyUnreadItem()))
@@ -298,7 +299,7 @@ void RSSWidget::deleteSelectedItems()
     if (answer == QMessageBox::No)
         return;
 
-    foreach (QTreeWidgetItem *item, selectedItems)
+    for (QTreeWidgetItem *item : selectedItems)
         if (item != m_feedListWidget->stickyUnreadItem())
             RSS::Session::instance()->removeItem(m_feedListWidget->itemPath(item));
 }
@@ -306,9 +307,9 @@ void RSSWidget::deleteSelectedItems()
 void RSSWidget::loadFoldersOpenState()
 {
     const QStringList openedFolders = Preferences::instance()->getRssOpenFolders();
-    foreach (const QString &varPath, openedFolders) {
+    for (const QString &varPath : openedFolders) {
         QTreeWidgetItem *parent = nullptr;
-        foreach (const QString &name, varPath.split('\\')) {
+        for (const QString &name : copyAsConst(varPath.split('\\'))) {
             int nbChildren = (parent ? parent->childCount() : m_feedListWidget->topLevelItemCount());
             for (int i = 0; i < nbChildren; ++i) {
                 QTreeWidgetItem *child = (parent ? parent->child(i) : m_feedListWidget->topLevelItem(i));
@@ -325,7 +326,7 @@ void RSSWidget::loadFoldersOpenState()
 void RSSWidget::saveFoldersOpenState()
 {
     QStringList openedFolders;
-    foreach (QTreeWidgetItem *item, m_feedListWidget->getAllOpenedFolders())
+    for (QTreeWidgetItem *item : copyAsConst(m_feedListWidget->getAllOpenedFolders()))
         openedFolders << m_feedListWidget->itemPath(item);
     Preferences::instance()->setRssOpenFolders(openedFolders);
 }
@@ -337,7 +338,7 @@ void RSSWidget::refreshAllFeeds()
 
 void RSSWidget::downloadSelectedTorrents()
 {
-    foreach (QListWidgetItem *item, m_articleListWidget->selectedItems()) {
+    for (QListWidgetItem *item : copyAsConst(m_articleListWidget->selectedItems())) {
         auto article = reinterpret_cast<RSS::Article *>(item->data(Qt::UserRole).value<quintptr>());
         Q_ASSERT(article);
 
@@ -356,7 +357,7 @@ void RSSWidget::downloadSelectedTorrents()
 // open the url of the selected RSS articles in the Web browser
 void RSSWidget::openSelectedArticlesUrls()
 {
-    foreach (QListWidgetItem *item, m_articleListWidget->selectedItems()) {
+    for (QListWidgetItem *item : copyAsConst(m_articleListWidget->selectedItems())) {
         auto article = reinterpret_cast<RSS::Article *>(item->data(Qt::UserRole).value<quintptr>());
         Q_ASSERT(article);
 
@@ -397,7 +398,7 @@ void RSSWidget::renameSelectedRSSItem()
 
 void RSSWidget::refreshSelectedItems()
 {
-    foreach (QTreeWidgetItem *item, m_feedListWidget->selectedItems()) {
+    for (QTreeWidgetItem *item : copyAsConst(m_feedListWidget->selectedItems())) {
         if (item == m_feedListWidget->stickyUnreadItem()) {
             refreshAllFeeds();
             return;
@@ -410,7 +411,7 @@ void RSSWidget::refreshSelectedItems()
 void RSSWidget::copySelectedFeedsURL()
 {
     QStringList URLs;
-    foreach (QTreeWidgetItem *item, m_feedListWidget->selectedItems()) {
+    for (QTreeWidgetItem *item : copyAsConst(m_feedListWidget->selectedItems())) {
         if (auto feed = qobject_cast<RSS::Feed *>(m_feedListWidget->getRSSItem(item)))
             URLs << feed->url();
     }
@@ -425,7 +426,7 @@ void RSSWidget::handleCurrentFeedItemChanged(QTreeWidgetItem *currentItem)
 
 void RSSWidget::on_markReadButton_clicked()
 {
-    foreach (QTreeWidgetItem *item, m_feedListWidget->selectedItems()) {
+    for (QTreeWidgetItem *item : copyAsConst(m_feedListWidget->selectedItems())) {
         m_feedListWidget->getRSSItem(item)->markAsRead();
         if (item == m_feedListWidget->stickyUnreadItem())
             break; // all items was read

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -187,7 +187,7 @@ void RSSWidget::displayItemsListMenu(const QPoint &)
 {
     bool hasTorrent = false;
     bool hasLink = false;
-    for (const QListWidgetItem *item : copyAsConst(m_articleListWidget->selectedItems())) {
+    for (const QListWidgetItem *item : asConst(m_articleListWidget->selectedItems())) {
         auto article = reinterpret_cast<RSS::Article *>(item->data(Qt::UserRole).value<quintptr>());
         Q_ASSERT(article);
 
@@ -309,7 +309,7 @@ void RSSWidget::loadFoldersOpenState()
     const QStringList openedFolders = Preferences::instance()->getRssOpenFolders();
     for (const QString &varPath : openedFolders) {
         QTreeWidgetItem *parent = nullptr;
-        for (const QString &name : copyAsConst(varPath.split('\\'))) {
+        for (const QString &name : asConst(varPath.split('\\'))) {
             int nbChildren = (parent ? parent->childCount() : m_feedListWidget->topLevelItemCount());
             for (int i = 0; i < nbChildren; ++i) {
                 QTreeWidgetItem *child = (parent ? parent->child(i) : m_feedListWidget->topLevelItem(i));
@@ -326,7 +326,7 @@ void RSSWidget::loadFoldersOpenState()
 void RSSWidget::saveFoldersOpenState()
 {
     QStringList openedFolders;
-    for (QTreeWidgetItem *item : copyAsConst(m_feedListWidget->getAllOpenedFolders()))
+    for (QTreeWidgetItem *item : asConst(m_feedListWidget->getAllOpenedFolders()))
         openedFolders << m_feedListWidget->itemPath(item);
     Preferences::instance()->setRssOpenFolders(openedFolders);
 }
@@ -338,7 +338,7 @@ void RSSWidget::refreshAllFeeds()
 
 void RSSWidget::downloadSelectedTorrents()
 {
-    for (QListWidgetItem *item : copyAsConst(m_articleListWidget->selectedItems())) {
+    for (QListWidgetItem *item : asConst(m_articleListWidget->selectedItems())) {
         auto article = reinterpret_cast<RSS::Article *>(item->data(Qt::UserRole).value<quintptr>());
         Q_ASSERT(article);
 
@@ -357,7 +357,7 @@ void RSSWidget::downloadSelectedTorrents()
 // open the url of the selected RSS articles in the Web browser
 void RSSWidget::openSelectedArticlesUrls()
 {
-    for (QListWidgetItem *item : copyAsConst(m_articleListWidget->selectedItems())) {
+    for (QListWidgetItem *item : asConst(m_articleListWidget->selectedItems())) {
         auto article = reinterpret_cast<RSS::Article *>(item->data(Qt::UserRole).value<quintptr>());
         Q_ASSERT(article);
 
@@ -398,7 +398,7 @@ void RSSWidget::renameSelectedRSSItem()
 
 void RSSWidget::refreshSelectedItems()
 {
-    for (QTreeWidgetItem *item : copyAsConst(m_feedListWidget->selectedItems())) {
+    for (QTreeWidgetItem *item : asConst(m_feedListWidget->selectedItems())) {
         if (item == m_feedListWidget->stickyUnreadItem()) {
             refreshAllFeeds();
             return;
@@ -411,7 +411,7 @@ void RSSWidget::refreshSelectedItems()
 void RSSWidget::copySelectedFeedsURL()
 {
     QStringList URLs;
-    for (QTreeWidgetItem *item : copyAsConst(m_feedListWidget->selectedItems())) {
+    for (QTreeWidgetItem *item : asConst(m_feedListWidget->selectedItems())) {
         if (auto feed = qobject_cast<RSS::Feed *>(m_feedListWidget->getRSSItem(item)))
             URLs << feed->url();
     }
@@ -426,7 +426,7 @@ void RSSWidget::handleCurrentFeedItemChanged(QTreeWidgetItem *currentItem)
 
 void RSSWidget::on_markReadButton_clicked()
 {
-    for (QTreeWidgetItem *item : copyAsConst(m_feedListWidget->selectedItems())) {
+    for (QTreeWidgetItem *item : asConst(m_feedListWidget->selectedItems())) {
         m_feedListWidget->getRSSItem(item)->markAsRead();
         if (item == m_feedListWidget->stickyUnreadItem())
             break; // all items was read

--- a/src/gui/search/pluginselectdialog.cpp
+++ b/src/gui/search/pluginselectdialog.cpp
@@ -39,6 +39,7 @@
 #include <QMimeData>
 #include <QTableView>
 
+#include "base/global.h"
 #include "base/net/downloadhandler.h"
 #include "base/net/downloadmanager.h"
 #include "base/utils/fs.h"
@@ -110,7 +111,7 @@ void PluginSelectDialog::dropEvent(QDropEvent *event)
 
     QStringList files;
     if (event->mimeData()->hasUrls()) {
-        foreach (const QUrl &url, event->mimeData()->urls()) {
+        for (const QUrl &url : copyAsConst(event->mimeData()->urls())) {
             if (!url.isEmpty()) {
                 if (url.scheme().compare("file", Qt::CaseInsensitive) == 0)
                     files << url.toLocalFile();
@@ -125,7 +126,7 @@ void PluginSelectDialog::dropEvent(QDropEvent *event)
 
     if (files.isEmpty()) return;
 
-    foreach (QString file, files) {
+    for (const QString &file : qAsConst(files)) {
         qDebug("dropped %s", qUtf8Printable(file));
         startAsyncOp();
         m_pluginManager->installPlugin(file);
@@ -135,8 +136,7 @@ void PluginSelectDialog::dropEvent(QDropEvent *event)
 // Decode if we accept drag 'n drop or not
 void PluginSelectDialog::dragEnterEvent(QDragEnterEvent *event)
 {
-    QString mime;
-    foreach (mime, event->mimeData()->formats()) {
+    for (const QString &mime : copyAsConst(event->mimeData()->formats())) {
         qDebug("mimeData: %s", qUtf8Printable(mime));
     }
 
@@ -188,7 +188,7 @@ void PluginSelectDialog::on_closeButton_clicked()
 void PluginSelectDialog::on_actionUninstall_triggered()
 {
     bool error = false;
-    foreach (QTreeWidgetItem *item, m_ui->pluginsTree->selectedItems()) {
+    for (QTreeWidgetItem *item : copyAsConst(m_ui->pluginsTree->selectedItems())) {
         int index = m_ui->pluginsTree->indexOfTopLevelItem(item);
         Q_ASSERT(index != -1);
         QString id = item->text(PLUGIN_ID);
@@ -212,7 +212,7 @@ void PluginSelectDialog::on_actionUninstall_triggered()
 
 void PluginSelectDialog::enableSelection(bool enable)
 {
-    foreach (QTreeWidgetItem *item, m_ui->pluginsTree->selectedItems()) {
+    for (QTreeWidgetItem *item : copyAsConst(m_ui->pluginsTree->selectedItems())) {
         int index = m_ui->pluginsTree->indexOfTopLevelItem(item);
         Q_ASSERT(index != -1);
         QString id = item->text(PLUGIN_ID);
@@ -265,7 +265,7 @@ void PluginSelectDialog::loadSupportedSearchPlugins()
 {
     // Some clean up first
     m_ui->pluginsTree->clear();
-    foreach (QString name, m_pluginManager->allPlugins())
+    for (const QString &name : copyAsConst(m_pluginManager->allPlugins()))
         addNewPlugin(name);
 }
 
@@ -360,11 +360,11 @@ void PluginSelectDialog::askForPluginUrl()
 
 void PluginSelectDialog::askForLocalPlugin()
 {
-    QStringList pathsList = QFileDialog::getOpenFileNames(
+    const QStringList pathsList = QFileDialog::getOpenFileNames(
                 nullptr, tr("Select search plugins"), QDir::homePath(),
                 tr("qBittorrent search plugin") + QLatin1String(" (*.py)")
                 );
-    foreach (QString path, pathsList) {
+    for (const QString &path : pathsList) {
         startAsyncOp();
         m_pluginManager->installPlugin(path);
     }
@@ -380,7 +380,7 @@ void PluginSelectDialog::iconDownloaded(const QString &url, QString filePath)
     QList<QSize> sizes = icon.availableSizes();
     bool invalid = (sizes.isEmpty() || icon.pixmap(sizes.first()).isNull());
     if (!invalid) {
-        foreach (QTreeWidgetItem *item, findItemsWithUrl(url)) {
+        for (QTreeWidgetItem *item : copyAsConst(findItemsWithUrl(url))) {
             QString id = item->text(PLUGIN_ID);
             PluginInfo *plugin = m_pluginManager->pluginInfo(id);
             if (!plugin) continue;

--- a/src/gui/search/pluginselectdialog.cpp
+++ b/src/gui/search/pluginselectdialog.cpp
@@ -111,7 +111,7 @@ void PluginSelectDialog::dropEvent(QDropEvent *event)
 
     QStringList files;
     if (event->mimeData()->hasUrls()) {
-        for (const QUrl &url : copyAsConst(event->mimeData()->urls())) {
+        for (const QUrl &url : asConst(event->mimeData()->urls())) {
             if (!url.isEmpty()) {
                 if (url.scheme().compare("file", Qt::CaseInsensitive) == 0)
                     files << url.toLocalFile();
@@ -126,7 +126,7 @@ void PluginSelectDialog::dropEvent(QDropEvent *event)
 
     if (files.isEmpty()) return;
 
-    for (const QString &file : qAsConst(files)) {
+    for (const QString &file : asConst(files)) {
         qDebug("dropped %s", qUtf8Printable(file));
         startAsyncOp();
         m_pluginManager->installPlugin(file);
@@ -136,7 +136,7 @@ void PluginSelectDialog::dropEvent(QDropEvent *event)
 // Decode if we accept drag 'n drop or not
 void PluginSelectDialog::dragEnterEvent(QDragEnterEvent *event)
 {
-    for (const QString &mime : copyAsConst(event->mimeData()->formats())) {
+    for (const QString &mime : asConst(event->mimeData()->formats())) {
         qDebug("mimeData: %s", qUtf8Printable(mime));
     }
 
@@ -188,7 +188,7 @@ void PluginSelectDialog::on_closeButton_clicked()
 void PluginSelectDialog::on_actionUninstall_triggered()
 {
     bool error = false;
-    for (QTreeWidgetItem *item : copyAsConst(m_ui->pluginsTree->selectedItems())) {
+    for (QTreeWidgetItem *item : asConst(m_ui->pluginsTree->selectedItems())) {
         int index = m_ui->pluginsTree->indexOfTopLevelItem(item);
         Q_ASSERT(index != -1);
         QString id = item->text(PLUGIN_ID);
@@ -212,7 +212,7 @@ void PluginSelectDialog::on_actionUninstall_triggered()
 
 void PluginSelectDialog::enableSelection(bool enable)
 {
-    for (QTreeWidgetItem *item : copyAsConst(m_ui->pluginsTree->selectedItems())) {
+    for (QTreeWidgetItem *item : asConst(m_ui->pluginsTree->selectedItems())) {
         int index = m_ui->pluginsTree->indexOfTopLevelItem(item);
         Q_ASSERT(index != -1);
         QString id = item->text(PLUGIN_ID);
@@ -265,7 +265,7 @@ void PluginSelectDialog::loadSupportedSearchPlugins()
 {
     // Some clean up first
     m_ui->pluginsTree->clear();
-    for (const QString &name : copyAsConst(m_pluginManager->allPlugins()))
+    for (const QString &name : asConst(m_pluginManager->allPlugins()))
         addNewPlugin(name);
 }
 
@@ -380,7 +380,7 @@ void PluginSelectDialog::iconDownloaded(const QString &url, QString filePath)
     QList<QSize> sizes = icon.availableSizes();
     bool invalid = (sizes.isEmpty() || icon.pixmap(sizes.first()).isNull());
     if (!invalid) {
-        for (QTreeWidgetItem *item : copyAsConst(findItemsWithUrl(url))) {
+        for (QTreeWidgetItem *item : asConst(findItemsWithUrl(url))) {
             QString id = item->text(PLUGIN_ID);
             PluginInfo *plugin = m_pluginManager->pluginInfo(id);
             if (!plugin) continue;

--- a/src/gui/search/searchsortmodel.cpp
+++ b/src/gui/search/searchsortmodel.cpp
@@ -128,7 +128,7 @@ bool SearchSortModel::filterAcceptsRow(int sourceRow, const QModelIndex &sourceP
     const QAbstractItemModel *const sourceModel = this->sourceModel();
     if (m_isNameFilterEnabled && !m_searchTerm.isEmpty()) {
         QString name = sourceModel->data(sourceModel->index(sourceRow, NAME, sourceParent)).toString();
-        for (const QString &word : qAsConst(m_searchTermWords)) {
+        for (const QString &word : asConst(m_searchTermWords)) {
             int i = name.indexOf(word, 0, Qt::CaseInsensitive);
             if (i == -1) {
                 return false;

--- a/src/gui/search/searchsortmodel.cpp
+++ b/src/gui/search/searchsortmodel.cpp
@@ -28,6 +28,8 @@
 
 #include "searchsortmodel.h"
 
+#include "base/global.h"
+
 SearchSortModel::SearchSortModel(QObject *parent)
     : base(parent)
     , m_isNameFilterEnabled(false)
@@ -126,7 +128,7 @@ bool SearchSortModel::filterAcceptsRow(int sourceRow, const QModelIndex &sourceP
     const QAbstractItemModel *const sourceModel = this->sourceModel();
     if (m_isNameFilterEnabled && !m_searchTerm.isEmpty()) {
         QString name = sourceModel->data(sourceModel->index(sourceRow, NAME, sourceParent)).toString();
-        for (const QString &word : m_searchTermWords) {
+        for (const QString &word : qAsConst(m_searchTermWords)) {
             int i = name.indexOf(word, 0, Qt::CaseInsensitive);
             if (i == -1) {
                 return false;

--- a/src/gui/search/searchsortmodel.cpp
+++ b/src/gui/search/searchsortmodel.cpp
@@ -126,7 +126,7 @@ bool SearchSortModel::filterAcceptsRow(int sourceRow, const QModelIndex &sourceP
     const QAbstractItemModel *const sourceModel = this->sourceModel();
     if (m_isNameFilterEnabled && !m_searchTerm.isEmpty()) {
         QString name = sourceModel->data(sourceModel->index(sourceRow, NAME, sourceParent)).toString();
-        for (const QString &word: m_searchTermWords) {
+        for (const QString &word : m_searchTermWords) {
             int i = name.indexOf(word, 0, Qt::CaseInsensitive);
             if (i == -1) {
                 return false;

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -167,11 +167,11 @@ void SearchWidget::fillCatCombobox()
 
     using QStrPair = QPair<QString, QString>;
     QList<QStrPair> tmpList;
-    for (const QString &cat : copyAsConst(SearchPluginManager::instance()->getPluginCategories(selectedPlugin())))
+    for (const QString &cat : asConst(SearchPluginManager::instance()->getPluginCategories(selectedPlugin())))
         tmpList << qMakePair(SearchPluginManager::categoryFullName(cat), cat);
     std::sort(tmpList.begin(), tmpList.end(), [](const QStrPair &l, const QStrPair &r) { return (QString::localeAwareCompare(l.first, r.first) < 0); });
 
-    for (const QStrPair &p : qAsConst(tmpList)) {
+    for (const QStrPair &p : asConst(tmpList)) {
         qDebug("Supported category: %s", qUtf8Printable(p.second));
         m_ui->comboCategory->addItem(p.first, QVariant(p.second));
     }
@@ -189,11 +189,11 @@ void SearchWidget::fillPluginComboBox()
 
     using QStrPair = QPair<QString, QString>;
     QList<QStrPair> tmpList;
-    for (const QString &name : copyAsConst(SearchPluginManager::instance()->enabledPlugins()))
+    for (const QString &name : asConst(SearchPluginManager::instance()->enabledPlugins()))
         tmpList << qMakePair(SearchPluginManager::instance()->pluginFullName(name), name);
     std::sort(tmpList.begin(), tmpList.end(), [](const QStrPair &l, const QStrPair &r) { return (l.first < r.first); } );
 
-    for (const QStrPair &p : qAsConst(tmpList))
+    for (const QStrPair &p : asConst(tmpList))
         m_ui->selectPlugin->addItem(p.first, QVariant(p.second));
 
     if (m_ui->selectPlugin->count() > 3)

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -49,6 +49,7 @@
 #include <QTreeView>
 
 #include "base/bittorrent/session.h"
+#include "base/global.h"
 #include "base/preferences.h"
 #include "base/search/searchpluginmanager.h"
 #include "base/search/searchhandler.h"
@@ -166,11 +167,11 @@ void SearchWidget::fillCatCombobox()
 
     using QStrPair = QPair<QString, QString>;
     QList<QStrPair> tmpList;
-    foreach (const QString &cat, SearchPluginManager::instance()->getPluginCategories(selectedPlugin()))
+    for (const QString &cat : copyAsConst(SearchPluginManager::instance()->getPluginCategories(selectedPlugin())))
         tmpList << qMakePair(SearchPluginManager::categoryFullName(cat), cat);
     std::sort(tmpList.begin(), tmpList.end(), [](const QStrPair &l, const QStrPair &r) { return (QString::localeAwareCompare(l.first, r.first) < 0); });
 
-    foreach (const QStrPair &p, tmpList) {
+    for (const QStrPair &p : qAsConst(tmpList)) {
         qDebug("Supported category: %s", qUtf8Printable(p.second));
         m_ui->comboCategory->addItem(p.first, QVariant(p.second));
     }
@@ -188,11 +189,11 @@ void SearchWidget::fillPluginComboBox()
 
     using QStrPair = QPair<QString, QString>;
     QList<QStrPair> tmpList;
-    foreach (const QString &name, SearchPluginManager::instance()->enabledPlugins())
+    for (const QString &name : copyAsConst(SearchPluginManager::instance()->enabledPlugins()))
         tmpList << qMakePair(SearchPluginManager::instance()->pluginFullName(name), name);
     std::sort(tmpList.begin(), tmpList.end(), [](const QStrPair &l, const QStrPair &r) { return (l.first < r.first); } );
 
-    foreach (const QStrPair &p, tmpList)
+    for (const QStrPair &p : qAsConst(tmpList))
         m_ui->selectPlugin->addItem(p.first, QVariant(p.second));
 
     if (m_ui->selectPlugin->count() > 3)

--- a/src/gui/statsdialog.cpp
+++ b/src/gui/statsdialog.cpp
@@ -32,6 +32,7 @@
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/sessionstatus.h"
 #include "base/bittorrent/torrenthandle.h"
+#include "base/global.h"
 #include "base/utils/misc.h"
 #include "base/utils/string.h"
 #include "ui_statsdialog.h"
@@ -89,7 +90,7 @@ void StatsDialog::update()
 
     // num_peers is not reliable (adds up peers, which didn't even overcome tcp handshake)
     quint32 peers = 0;
-    foreach (BitTorrent::TorrentHandle *const torrent, BitTorrent::Session::instance()->torrents())
+    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(BitTorrent::Session::instance()->torrents()))
         peers += torrent->peersCount();
 
     m_ui->labelWriteStarve->setText(QString("%1%")

--- a/src/gui/statsdialog.cpp
+++ b/src/gui/statsdialog.cpp
@@ -90,7 +90,7 @@ void StatsDialog::update()
 
     // num_peers is not reliable (adds up peers, which didn't even overcome tcp handshake)
     quint32 peers = 0;
-    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(BitTorrent::Session::instance()->torrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConst(BitTorrent::Session::instance()->torrents()))
         peers += torrent->peersCount();
 
     m_ui->labelWriteStarve->setText(QString("%1%")

--- a/src/gui/tagfiltermodel.cpp
+++ b/src/gui/tagfiltermodel.cpp
@@ -33,6 +33,7 @@
 
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/torrenthandle.h"
+#include "base/global.h"
 #include "guiiconprovider.h"
 
 namespace
@@ -236,7 +237,7 @@ void TagFilterModel::torrentAdded(BitTorrent::TorrentHandle *const torrent)
     if (items.isEmpty())
         untaggedItem()->increaseTorrentsCount();
 
-    foreach (TagModelItem *item, items)
+    for (TagModelItem *item : items)
         item->increaseTorrentsCount();
 }
 
@@ -247,7 +248,7 @@ void TagFilterModel::torrentAboutToBeRemoved(BitTorrent::TorrentHandle *const to
     if (torrent->tags().isEmpty())
         untaggedItem()->decreaseTorrentsCount();
 
-    foreach (TagModelItem *item, findItems(torrent->tags()))
+    for (TagModelItem *item : copyAsConst(findItems(torrent->tags())))
         item->decreaseTorrentsCount();
 }
 
@@ -274,7 +275,7 @@ void TagFilterModel::populate()
                                              [](Torrent *torrent) { return torrent->tags().isEmpty(); });
     addToModel(getSpecialUntaggedTag(), untaggedCount);
 
-    foreach (const QString &tag, session->tags()) {
+    for (const QString &tag : copyAsConst(session->tags())) {
         const int count = std::count_if(torrents.begin(), torrents.end(),
                                         [tag](Torrent *torrent) { return torrent->hasTag(tag); });
         addToModel(tag, count);
@@ -313,7 +314,7 @@ QVector<TagModelItem *> TagFilterModel::findItems(const QSet<QString> &tags)
 {
     QVector<TagModelItem *> items;
     items.reserve(tags.size());
-    foreach (const QString &tag, tags) {
+    for (const QString &tag : tags) {
         TagModelItem *item = findItem(tag);
         if (item)
             items.push_back(item);

--- a/src/gui/tagfiltermodel.cpp
+++ b/src/gui/tagfiltermodel.cpp
@@ -248,7 +248,7 @@ void TagFilterModel::torrentAboutToBeRemoved(BitTorrent::TorrentHandle *const to
     if (torrent->tags().isEmpty())
         untaggedItem()->decreaseTorrentsCount();
 
-    for (TagModelItem *item : copyAsConst(findItems(torrent->tags())))
+    for (TagModelItem *item : asConst(findItems(torrent->tags())))
         item->decreaseTorrentsCount();
 }
 
@@ -275,7 +275,7 @@ void TagFilterModel::populate()
                                              [](Torrent *torrent) { return torrent->tags().isEmpty(); });
     addToModel(getSpecialUntaggedTag(), untaggedCount);
 
-    for (const QString &tag : copyAsConst(session->tags())) {
+    for (const QString &tag : asConst(session->tags())) {
         const int count = std::count_if(torrents.begin(), torrents.end(),
                                         [tag](Torrent *torrent) { return torrent->hasTag(tag); });
         addToModel(tag, count);

--- a/src/gui/tagfilterwidget.cpp
+++ b/src/gui/tagfilterwidget.cpp
@@ -223,7 +223,7 @@ void TagFilterWidget::removeTag()
 void TagFilterWidget::removeUnusedTags()
 {
     auto session = BitTorrent::Session::instance();
-    for (const QString &tag : copyAsConst(session->tags()))
+    for (const QString &tag : asConst(session->tags()))
         if (model()->data(static_cast<TagFilterProxyModel *>(model())->index(tag), Qt::UserRole) == 0)
             session->removeTag(tag);
     updateGeometry();

--- a/src/gui/tagfilterwidget.cpp
+++ b/src/gui/tagfilterwidget.cpp
@@ -35,6 +35,7 @@
 #include <QMessageBox>
 
 #include "base/bittorrent/session.h"
+#include "base/global.h"
 #include "autoexpandabledialog.h"
 #include "guiiconprovider.h"
 #include "tagfiltermodel.h"
@@ -222,7 +223,7 @@ void TagFilterWidget::removeTag()
 void TagFilterWidget::removeUnusedTags()
 {
     auto session = BitTorrent::Session::instance();
-    foreach (const QString &tag, session->tags())
+    for (const QString &tag : copyAsConst(session->tags()))
         if (model()->data(static_cast<TagFilterProxyModel *>(model())->index(tag), Qt::UserRole) == 0)
             session->removeTag(tag);
     updateGeometry();

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -267,14 +267,14 @@ QVector<int> TorrentContentModel::getFilePriorities() const
 {
     QVector<int> prio;
     prio.reserve(m_filesIndex.size());
-    for (const TorrentContentModelFile *file : qAsConst(m_filesIndex))
+    for (const TorrentContentModelFile *file : asConst(m_filesIndex))
         prio.push_back(file->priority());
     return prio;
 }
 
 bool TorrentContentModel::allFiltered() const
 {
-    for (const TorrentContentModelFile *fileItem : qAsConst(m_filesIndex))
+    for (const TorrentContentModelFile *fileItem : asConst(m_filesIndex))
         if (fileItem->priority() != prio::IGNORED)
             return false;
     return true;
@@ -477,7 +477,7 @@ void TorrentContentModel::setupModelData(const BitTorrent::TorrentInfo &info)
         // Iterate of parts of the path to create necessary folders
         QStringList pathFolders = path.split('/', QString::SkipEmptyParts);
         pathFolders.removeLast();
-        for (const QString &pathPart : qAsConst(pathFolders)) {
+        for (const QString &pathPart : asConst(pathFolders)) {
             if (pathPart == ".unwanted")
                 continue;
             TorrentContentModelFolder* newParent = currentParent->childFolderWithName(pathPart);

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -48,6 +48,7 @@
 #include <QPixmapCache>
 #endif
 
+#include "base/global.h"
 #include "base/utils/misc.h"
 #include "base/utils/fs.h"
 #include "guiiconprovider.h"
@@ -266,14 +267,14 @@ QVector<int> TorrentContentModel::getFilePriorities() const
 {
     QVector<int> prio;
     prio.reserve(m_filesIndex.size());
-    foreach (const TorrentContentModelFile *file, m_filesIndex)
+    for (const TorrentContentModelFile *file : qAsConst(m_filesIndex))
         prio.push_back(file->priority());
     return prio;
 }
 
 bool TorrentContentModel::allFiltered() const
 {
-    foreach (const TorrentContentModelFile *fileItem, m_filesIndex)
+    for (const TorrentContentModelFile *fileItem : qAsConst(m_filesIndex))
         if (fileItem->priority() != prio::IGNORED)
             return false;
     return true;
@@ -476,7 +477,7 @@ void TorrentContentModel::setupModelData(const BitTorrent::TorrentInfo &info)
         // Iterate of parts of the path to create necessary folders
         QStringList pathFolders = path.split('/', QString::SkipEmptyParts);
         pathFolders.removeLast();
-        foreach (const QString &pathPart, pathFolders) {
+        for (const QString &pathPart : qAsConst(pathFolders)) {
             if (pathPart == ".unwanted")
                 continue;
             TorrentContentModelFolder* newParent = currentParent->childFolderWithName(pathPart);

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -146,7 +146,7 @@ namespace
 #elif defined(Q_OS_MAC)
     // There is a similar bug on macOS, to be reported to Qt
     // https://github.com/qbittorrent/qBittorrent/pull/6156#issuecomment-316302615
-    class MacFileIconProvider final: public CachingFileIconProvider
+    class MacFileIconProvider final : public CachingFileIconProvider
     {
         QPixmap pixmapForExtension(const QString &ext) const override
         {
@@ -346,7 +346,7 @@ int TorrentContentModel::getFileIndex(const QModelIndex &index)
     return -1;
 }
 
-QVariant TorrentContentModel::data(const QModelIndex& index, int role) const
+QVariant TorrentContentModel::data(const QModelIndex &index, int role) const
 {
     if (!index.isValid())
         return QVariant();

--- a/src/gui/torrentcontentmodel.h
+++ b/src/gui/torrentcontentmodel.h
@@ -54,13 +54,13 @@ public:
     QVector<int> getFilePriorities() const;
     bool allFiltered() const;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
-    bool setData(const QModelIndex &index, const QVariant& value, int role = Qt::EditRole) override;
+    bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
     TorrentContentModelItem::ItemType itemType(const QModelIndex &index) const;
     int getFileIndex(const QModelIndex &index);
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
     Qt::ItemFlags flags(const QModelIndex &index) const override;
     QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
-    QModelIndex index(int row, int column, const QModelIndex& parent = QModelIndex()) const override;
+    QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
     QModelIndex parent(const QModelIndex &index) const override;
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     void clear();

--- a/src/gui/torrentcontentmodelfolder.cpp
+++ b/src/gui/torrentcontentmodelfolder.cpp
@@ -29,6 +29,7 @@
 #include "torrentcontentmodelfolder.h"
 
 #include "base/bittorrent/torrenthandle.h"
+#include "base/global.h"
 
 TorrentContentModelFolder::TorrentContentModelFolder(const QString &name, TorrentContentModelFolder *parent)
     : TorrentContentModelItem(parent)
@@ -85,7 +86,7 @@ TorrentContentModelItem *TorrentContentModelFolder::child(int row) const
 
 TorrentContentModelFolder *TorrentContentModelFolder::childFolderWithName(const QString &name) const
 {
-    foreach (TorrentContentModelItem *child, m_childItems)
+    for (TorrentContentModelItem *child : qAsConst(m_childItems))
         if ((child->itemType() == FolderType) && (child->name() == name))
             return static_cast<TorrentContentModelFolder *>(child);
     return nullptr;
@@ -132,7 +133,7 @@ void TorrentContentModelFolder::setPriority(int newPriority, bool updateParent)
 
     // Update children
     if (m_priority != prio::MIXED)
-        foreach (TorrentContentModelItem *child, m_childItems)
+        for (TorrentContentModelItem *child : qAsConst(m_childItems))
             child->setPriority(m_priority, false);
 }
 
@@ -141,7 +142,7 @@ void TorrentContentModelFolder::recalculateProgress()
     qreal tProgress = 0;
     qulonglong tSize = 0;
     qulonglong tRemaining = 0;
-    foreach (TorrentContentModelItem *child, m_childItems) {
+    for (TorrentContentModelItem *child : qAsConst(m_childItems)) {
         if (child->priority() == prio::IGNORED)
             continue;
 
@@ -164,7 +165,7 @@ void TorrentContentModelFolder::recalculateAvailability()
     qreal tAvailability = 0;
     qulonglong tSize = 0;
     bool foundAnyData = false;
-    foreach (TorrentContentModelItem *child, m_childItems) {
+    for (TorrentContentModelItem *child : qAsConst(m_childItems)) {
         if (child->priority() == prio::IGNORED)
             continue;
 

--- a/src/gui/torrentcontentmodelfolder.cpp
+++ b/src/gui/torrentcontentmodelfolder.cpp
@@ -86,7 +86,7 @@ TorrentContentModelItem *TorrentContentModelFolder::child(int row) const
 
 TorrentContentModelFolder *TorrentContentModelFolder::childFolderWithName(const QString &name) const
 {
-    for (TorrentContentModelItem *child : qAsConst(m_childItems))
+    for (TorrentContentModelItem *child : asConst(m_childItems))
         if ((child->itemType() == FolderType) && (child->name() == name))
             return static_cast<TorrentContentModelFolder *>(child);
     return nullptr;
@@ -133,7 +133,7 @@ void TorrentContentModelFolder::setPriority(int newPriority, bool updateParent)
 
     // Update children
     if (m_priority != prio::MIXED)
-        for (TorrentContentModelItem *child : qAsConst(m_childItems))
+        for (TorrentContentModelItem *child : asConst(m_childItems))
             child->setPriority(m_priority, false);
 }
 
@@ -142,7 +142,7 @@ void TorrentContentModelFolder::recalculateProgress()
     qreal tProgress = 0;
     qulonglong tSize = 0;
     qulonglong tRemaining = 0;
-    for (TorrentContentModelItem *child : qAsConst(m_childItems)) {
+    for (TorrentContentModelItem *child : asConst(m_childItems)) {
         if (child->priority() == prio::IGNORED)
             continue;
 
@@ -165,7 +165,7 @@ void TorrentContentModelFolder::recalculateAvailability()
     qreal tAvailability = 0;
     qulonglong tSize = 0;
     bool foundAnyData = false;
-    for (TorrentContentModelItem *child : qAsConst(m_childItems)) {
+    for (TorrentContentModelItem *child : asConst(m_childItems)) {
         if (child->priority() == prio::IGNORED)
             continue;
 

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -40,6 +40,7 @@
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/torrenthandle.h"
 #include "base/bittorrent/trackerentry.h"
+#include "base/global.h"
 #include "base/logger.h"
 #include "base/net/downloadhandler.h"
 #include "base/net/downloadmanager.h"
@@ -219,7 +220,7 @@ TrackerFiltersList::TrackerFiltersList(QWidget *parent, TransferListWidget *tran
 
 TrackerFiltersList::~TrackerFiltersList()
 {
-    foreach (const QString &iconPath, m_iconPaths)
+    for (const QString &iconPath : qAsConst(m_iconPaths))
         Utils::Fs::forceRemove(iconPath);
 }
 
@@ -487,8 +488,8 @@ void TrackerFiltersList::applyFilter(int row)
 void TrackerFiltersList::handleNewTorrent(BitTorrent::TorrentHandle *const torrent)
 {
     QString hash = torrent->hash();
-    QList<BitTorrent::TrackerEntry> trackers = torrent->trackers();
-    foreach (const BitTorrent::TrackerEntry &tracker, trackers)
+    const QList<BitTorrent::TrackerEntry> trackers = torrent->trackers();
+    for (const BitTorrent::TrackerEntry &tracker : trackers)
         addItem(tracker.url(), hash);
 
     //Check for trackerless torrent
@@ -501,8 +502,8 @@ void TrackerFiltersList::handleNewTorrent(BitTorrent::TorrentHandle *const torre
 void TrackerFiltersList::torrentAboutToBeDeleted(BitTorrent::TorrentHandle *const torrent)
 {
     QString hash = torrent->hash();
-    QList<BitTorrent::TrackerEntry> trackers = torrent->trackers();
-    foreach (const BitTorrent::TrackerEntry &tracker, trackers)
+    const QList<BitTorrent::TrackerEntry> trackers = torrent->trackers();
+    for (const BitTorrent::TrackerEntry &tracker : trackers)
         removeItem(tracker.url(), hash);
 
     //Check for trackerless torrent
@@ -662,13 +663,13 @@ void TransferListFiltersWidget::setDownloadTrackerFavicon(bool value)
 
 void TransferListFiltersWidget::addTrackers(BitTorrent::TorrentHandle *const torrent, const QList<BitTorrent::TrackerEntry> &trackers)
 {
-    foreach (const BitTorrent::TrackerEntry &tracker, trackers)
+    for (const BitTorrent::TrackerEntry &tracker : trackers)
         m_trackerFilters->addItem(tracker.url(), torrent->hash());
 }
 
 void TransferListFiltersWidget::removeTrackers(BitTorrent::TorrentHandle *const torrent, const QList<BitTorrent::TrackerEntry> &trackers)
 {
-    foreach (const BitTorrent::TrackerEntry &tracker, trackers)
+    for (const BitTorrent::TrackerEntry &tracker : trackers)
         m_trackerFilters->removeItem(tracker.url(), torrent->hash());
 }
 

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -220,7 +220,7 @@ TrackerFiltersList::TrackerFiltersList(QWidget *parent, TransferListWidget *tran
 
 TrackerFiltersList::~TrackerFiltersList()
 {
-    for (const QString &iconPath : qAsConst(m_iconPaths))
+    for (const QString &iconPath : asConst(m_iconPaths))
         Utils::Fs::forceRemove(iconPath);
 }
 

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -404,7 +404,7 @@ void TrackerFiltersList::trackerWarning(const QString &hash, const QString &trac
         applyFilter(3);
 }
 
-void TrackerFiltersList::downloadFavicon(const QString& url)
+void TrackerFiltersList::downloadFavicon(const QString &url)
 {
     if (!m_downloadTrackerFavicon) return;
     Net::DownloadHandler *h = Net::DownloadManager::instance()->download(
@@ -416,7 +416,7 @@ void TrackerFiltersList::downloadFavicon(const QString& url)
             , &TrackerFiltersList::handleFavicoFailure);
 }
 
-void TrackerFiltersList::handleFavicoDownload(const QString& url, const QString& filePath)
+void TrackerFiltersList::handleFavicoDownload(const QString &url, const QString &filePath)
 {
     QString host = url.startsWith(GOOGLE_FAVICON_URL)
                             ? url.mid(GOOGLE_FAVICON_URL.size())

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -62,7 +62,7 @@ TransferListModel::TransferListModel(QObject *parent)
 {
     // Load the torrents
     using namespace BitTorrent;
-    for (TorrentHandle *const torrent : copyAsConst(Session::instance()->torrents()))
+    for (TorrentHandle *const torrent : asConst(Session::instance()->torrents()))
         addTorrent(torrent);
 
     // Listen for torrent changes

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -36,6 +36,7 @@
 
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/torrenthandle.h"
+#include "base/global.h"
 #include "base/torrentfilter.h"
 #include "base/utils/fs.h"
 
@@ -61,7 +62,7 @@ TransferListModel::TransferListModel(QObject *parent)
 {
     // Load the torrents
     using namespace BitTorrent;
-    foreach (TorrentHandle *const torrent, Session::instance()->torrents())
+    for (TorrentHandle *const torrent : copyAsConst(Session::instance()->torrents()))
         addTorrent(torrent);
 
     // Listen for torrent changes

--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -83,7 +83,7 @@ public:
 
     explicit TransferListModel(QObject *parent = nullptr);
 
-    int rowCount(const QModelIndex& index = QModelIndex()) const override;
+    int rowCount(const QModelIndex &index = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent=QModelIndex()) const override;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
     bool setData(const QModelIndex &index, const QVariant &value, int role) override;

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -582,7 +582,7 @@ void TransferListWidget::openSelectedTorrentsFolder() const
         }
         pathsList.insert(path);
     }
-#endif
+#endif // Q_OS_MAC
 }
 
 void TransferListWidget::previewSelectedTorrents()
@@ -595,16 +595,16 @@ void TransferListWidget::previewSelectedTorrents()
 
 void TransferListWidget::setDlLimitSelectedTorrents()
 {
-    QList<BitTorrent::TorrentHandle *> TorrentsList;
+    QList<BitTorrent::TorrentHandle *> torrentsList;
     foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents()) {
         if (torrent->isSeed())
             continue;
-        TorrentsList += torrent;
+        torrentsList += torrent;
     }
-    if (TorrentsList.empty()) return;
+    if (torrentsList.empty()) return;
 
-    int oldLimit = TorrentsList.first()->downloadLimit();
-    foreach (BitTorrent::TorrentHandle *const torrent, TorrentsList) {
+    int oldLimit = torrentsList.first()->downloadLimit();
+    foreach (BitTorrent::TorrentHandle *const torrent, torrentsList) {
         if (torrent->downloadLimit() != oldLimit) {
             oldLimit = -1;
             break;
@@ -617,7 +617,7 @@ void TransferListWidget::setDlLimitSelectedTorrents()
                 , BitTorrent::Session::instance()->globalDownloadSpeedLimit());
     if (!ok) return;
 
-    foreach (BitTorrent::TorrentHandle *const torrent, TorrentsList) {
+    foreach (BitTorrent::TorrentHandle *const torrent, torrentsList) {
         qDebug("Applying download speed limit of %ld Kb/s to torrent %s", (newLimit / 1024l), qUtf8Printable(torrent->hash()));
         torrent->setDownloadLimit(newLimit);
     }
@@ -625,11 +625,11 @@ void TransferListWidget::setDlLimitSelectedTorrents()
 
 void TransferListWidget::setUpLimitSelectedTorrents()
 {
-    QList<BitTorrent::TorrentHandle *> TorrentsList = getSelectedTorrents();
-    if (TorrentsList.empty()) return;
+    QList<BitTorrent::TorrentHandle *> torrentsList = getSelectedTorrents();
+    if (torrentsList.empty()) return;
 
-    int oldLimit = TorrentsList.first()->uploadLimit();
-    foreach (BitTorrent::TorrentHandle *const torrent, TorrentsList) {
+    int oldLimit = torrentsList.first()->uploadLimit();
+    foreach (BitTorrent::TorrentHandle *const torrent, torrentsList) {
         if (torrent->uploadLimit() != oldLimit) {
             oldLimit = -1;
             break;
@@ -642,7 +642,7 @@ void TransferListWidget::setUpLimitSelectedTorrents()
                 , BitTorrent::Session::instance()->globalUploadSpeedLimit());
     if (!ok) return;
 
-    foreach (BitTorrent::TorrentHandle *const torrent, TorrentsList) {
+    foreach (BitTorrent::TorrentHandle *const torrent, torrentsList) {
         qDebug("Applying upload speed limit of %ld Kb/s to torrent %s", (newLimit / 1024l), qUtf8Printable(torrent->hash()));
         torrent->setUploadLimit(newLimit);
     }
@@ -1144,7 +1144,7 @@ void TransferListWidget::displayListMenu(const QPoint&)
     }
 }
 
-void TransferListWidget::currentChanged(const QModelIndex& current, const QModelIndex&)
+void TransferListWidget::currentChanged(const QModelIndex &current, const QModelIndex&)
 {
     qDebug("CURRENT CHANGED");
     BitTorrent::TorrentHandle *torrent = nullptr;

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -43,6 +43,7 @@
 
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/torrenthandle.h"
+#include "base/global.h"
 #include "base/logger.h"
 #include "base/preferences.h"
 #include "base/torrentfilter.h"
@@ -72,7 +73,7 @@ namespace
     QStringList extractHashes(const QList<BitTorrent::TorrentHandle *> &torrents)
     {
         QStringList hashes;
-        foreach (BitTorrent::TorrentHandle *const torrent, torrents)
+        for (BitTorrent::TorrentHandle *const torrent : torrents)
             hashes << torrent->hash();
 
         return hashes;
@@ -381,7 +382,7 @@ void TransferListWidget::torrentDoubleClicked()
 QList<BitTorrent::TorrentHandle *> TransferListWidget::getSelectedTorrents() const
 {
     QList<BitTorrent::TorrentHandle *> torrents;
-    foreach (const QModelIndex &index, selectionModel()->selectedRows())
+    for (const QModelIndex &index : copyAsConst(selectionModel()->selectedRows()))
         torrents << m_listModel->torrentHandle(mapToSource(index));
 
     return torrents;
@@ -401,7 +402,7 @@ void TransferListWidget::setSelectedTorrentsLocation()
     qDebug("New location is %s", qUtf8Printable(newLocation));
 
     // Actually move storage
-    foreach (BitTorrent::TorrentHandle *const torrent, torrents) {
+    for (BitTorrent::TorrentHandle *const torrent : torrents) {
         Logger::instance()->addMessage(tr("Set location: moving \"%1\", from \"%2\" to \"%3\""
             , "Set location: moving \"ubuntu_16_04.iso\", from \"/home/dir1\" to \"/home/dir2\"")
             .arg(torrent->name(), Utils::Fs::toNativePath(torrent->savePath())
@@ -412,25 +413,25 @@ void TransferListWidget::setSelectedTorrentsLocation()
 
 void TransferListWidget::pauseAllTorrents()
 {
-    foreach (BitTorrent::TorrentHandle *const torrent, BitTorrent::Session::instance()->torrents())
+    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(BitTorrent::Session::instance()->torrents()))
         torrent->pause();
 }
 
 void TransferListWidget::resumeAllTorrents()
 {
-    foreach (BitTorrent::TorrentHandle *const torrent, BitTorrent::Session::instance()->torrents())
+    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(BitTorrent::Session::instance()->torrents()))
         torrent->resume();
 }
 
 void TransferListWidget::startSelectedTorrents()
 {
-    foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents())
+    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents()))
         torrent->resume();
 }
 
 void TransferListWidget::forceStartSelectedTorrents()
 {
-    foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents())
+    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents()))
         torrent->resume(true);
 }
 
@@ -445,7 +446,7 @@ void TransferListWidget::startVisibleTorrents()
 
 void TransferListWidget::pauseSelectedTorrents()
 {
-    foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents())
+    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents()))
         torrent->pause();
 }
 
@@ -478,7 +479,7 @@ void TransferListWidget::deleteSelectedTorrents(bool deleteLocalFiles)
     if (Preferences::instance()->confirmTorrentDeletion()
         && !DeletionConfirmationDialog::askForDeletionConfirmation(this, deleteLocalFiles, torrents.size(), torrents[0]->name()))
         return;
-    foreach (BitTorrent::TorrentHandle *const torrent, torrents)
+    for (BitTorrent::TorrentHandle *const torrent : torrents)
         BitTorrent::Session::instance()->deleteTorrent(torrent->hash(), deleteLocalFiles);
 }
 
@@ -495,7 +496,7 @@ void TransferListWidget::deleteVisibleTorrents()
         && !DeletionConfirmationDialog::askForDeletionConfirmation(this, deleteLocalFiles, torrents.size(), torrents[0]->name()))
         return;
 
-    foreach (BitTorrent::TorrentHandle *const torrent, torrents)
+    for (BitTorrent::TorrentHandle *const torrent : qAsConst(torrents))
         BitTorrent::Session::instance()->deleteTorrent(torrent->hash(), deleteLocalFiles);
 }
 
@@ -528,7 +529,7 @@ void TransferListWidget::bottomPrioSelectedTorrents()
 void TransferListWidget::copySelectedMagnetURIs() const
 {
     QStringList magnetUris;
-    foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents())
+    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents()))
         magnetUris << torrent->toMagnetUri();
 
     qApp->clipboard()->setText(magnetUris.join('\n'));
@@ -537,7 +538,7 @@ void TransferListWidget::copySelectedMagnetURIs() const
 void TransferListWidget::copySelectedNames() const
 {
     QStringList torrentNames;
-    foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents())
+    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents()))
         torrentNames << torrent->name();
 
     qApp->clipboard()->setText(torrentNames.join('\n'));
@@ -546,7 +547,7 @@ void TransferListWidget::copySelectedNames() const
 void TransferListWidget::copySelectedHashes() const
 {
     QStringList torrentHashes;
-    foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents())
+    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents()))
         torrentHashes << torrent->hash();
 
     qApp->clipboard()->setText(torrentHashes.join('\n'));
@@ -566,13 +567,13 @@ void TransferListWidget::openSelectedTorrentsFolder() const
 #ifdef Q_OS_MAC
     // On macOS you expect both the files and folders to be opened in their parent
     // folders prehilighted for opening, so we use a custom method.
-    foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents()) {
+    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents())) {
         QString path = torrent->contentPath(true);
         pathsList.insert(path);
     }
     MacUtils::openFiles(pathsList);
 #else
-    foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents()) {
+    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents())) {
         QString path = torrent->contentPath(true);
         if (!pathsList.contains(path)) {
             if (torrent->filesCount() == 1)
@@ -587,7 +588,7 @@ void TransferListWidget::openSelectedTorrentsFolder() const
 
 void TransferListWidget::previewSelectedTorrents()
 {
-    foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents()) {
+    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents())) {
         if (torrent->hasMetadata())
             new PreviewSelectDialog(this, torrent);
     }
@@ -596,7 +597,7 @@ void TransferListWidget::previewSelectedTorrents()
 void TransferListWidget::setDlLimitSelectedTorrents()
 {
     QList<BitTorrent::TorrentHandle *> torrentsList;
-    foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents()) {
+    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents())) {
         if (torrent->isSeed())
             continue;
         torrentsList += torrent;
@@ -604,7 +605,7 @@ void TransferListWidget::setDlLimitSelectedTorrents()
     if (torrentsList.empty()) return;
 
     int oldLimit = torrentsList.first()->downloadLimit();
-    foreach (BitTorrent::TorrentHandle *const torrent, torrentsList) {
+    for (BitTorrent::TorrentHandle *const torrent : qAsConst(torrentsList)) {
         if (torrent->downloadLimit() != oldLimit) {
             oldLimit = -1;
             break;
@@ -617,7 +618,7 @@ void TransferListWidget::setDlLimitSelectedTorrents()
                 , BitTorrent::Session::instance()->globalDownloadSpeedLimit());
     if (!ok) return;
 
-    foreach (BitTorrent::TorrentHandle *const torrent, torrentsList) {
+    for (BitTorrent::TorrentHandle *const torrent : qAsConst(torrentsList)) {
         qDebug("Applying download speed limit of %ld Kb/s to torrent %s", (newLimit / 1024l), qUtf8Printable(torrent->hash()));
         torrent->setDownloadLimit(newLimit);
     }
@@ -629,7 +630,7 @@ void TransferListWidget::setUpLimitSelectedTorrents()
     if (torrentsList.empty()) return;
 
     int oldLimit = torrentsList.first()->uploadLimit();
-    foreach (BitTorrent::TorrentHandle *const torrent, torrentsList) {
+    for (BitTorrent::TorrentHandle *const torrent : qAsConst(torrentsList)) {
         if (torrent->uploadLimit() != oldLimit) {
             oldLimit = -1;
             break;
@@ -642,7 +643,7 @@ void TransferListWidget::setUpLimitSelectedTorrents()
                 , BitTorrent::Session::instance()->globalUploadSpeedLimit());
     if (!ok) return;
 
-    foreach (BitTorrent::TorrentHandle *const torrent, torrentsList) {
+    for (BitTorrent::TorrentHandle *const torrent : qAsConst(torrentsList)) {
         qDebug("Applying upload speed limit of %ld Kb/s to torrent %s", (newLimit / 1024l), qUtf8Printable(torrent->hash()));
         torrent->setUploadLimit(newLimit);
     }
@@ -670,7 +671,7 @@ void TransferListWidget::setMaxRatioSelectedTorrents()
                        currentMaxSeedingTime, BitTorrent::TorrentHandle::MAX_SEEDING_TIME, this);
     if (dlg.exec() != QDialog::Accepted) return;
 
-    foreach (BitTorrent::TorrentHandle *const torrent, torrents) {
+    for (BitTorrent::TorrentHandle *const torrent : torrents) {
         qreal ratio = (dlg.useDefault() ? BitTorrent::TorrentHandle::USE_GLOBAL_RATIO : dlg.ratio());
         torrent->setRatioLimit(ratio);
 
@@ -686,13 +687,13 @@ void TransferListWidget::recheckSelectedTorrents()
         if (ret != QMessageBox::Yes) return;
     }
 
-    foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents())
+    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents()))
         torrent->forceRecheck();
 }
 
 void TransferListWidget::reannounceSelectedTorrents()
 {
-    foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents())
+    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents()))
         torrent->forceReannounce();
 }
 
@@ -738,7 +739,7 @@ void TransferListWidget::displayDLHoSMenu(const QPoint&)
 
 void TransferListWidget::toggleSelectedTorrentsSuperSeeding() const
 {
-    foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents()) {
+    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents())) {
         if (torrent->hasMetadata())
             torrent->setSuperSeeding(!torrent->superSeeding());
     }
@@ -746,19 +747,19 @@ void TransferListWidget::toggleSelectedTorrentsSuperSeeding() const
 
 void TransferListWidget::toggleSelectedTorrentsSequentialDownload() const
 {
-    foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents())
+    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents()))
         torrent->toggleSequentialDownload();
 }
 
 void TransferListWidget::toggleSelectedFirstLastPiecePrio() const
 {
-    foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents())
+    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents()))
         torrent->toggleFirstLastPiecePriority();
 }
 
 void TransferListWidget::setSelectedAutoTMMEnabled(bool enabled) const
 {
-    foreach (BitTorrent::TorrentHandle *const torrent, getSelectedTorrents())
+    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents()))
         torrent->setAutoTMMEnabled(enabled);
 }
 
@@ -772,7 +773,7 @@ void TransferListWidget::askNewCategoryForSelection()
 void TransferListWidget::askAddTagsForSelection()
 {
     const QStringList tags = askTagsForSelection(tr("Add Tags"));
-    foreach (const QString &tag, tags)
+    for (const QString &tag : tags)
         addSelectionTag(tag);
 }
 
@@ -811,7 +812,7 @@ QStringList TransferListWidget::askTagsForSelection(const QString &dialogTitle)
 
 void TransferListWidget::applyToSelectedTorrents(const std::function<void (BitTorrent::TorrentHandle *const)> &fn)
 {
-    foreach (const QModelIndex &index, selectionModel()->selectedRows()) {
+    for (const QModelIndex &index : copyAsConst(selectionModel()->selectedRows())) {
         BitTorrent::TorrentHandle *const torrent = m_listModel->torrentHandle(mapToSource(index));
         Q_ASSERT(torrent);
         fn(torrent);
@@ -839,7 +840,7 @@ void TransferListWidget::renameSelectedTorrent()
 
 void TransferListWidget::setSelectionCategory(QString category)
 {
-    foreach (const QModelIndex &index, selectionModel()->selectedRows())
+    for (const QModelIndex &index : copyAsConst(selectionModel()->selectedRows()))
         m_listModel->setData(m_listModel->index(mapToSource(index).row(), TransferListModel::TR_CATEGORY), category, Qt::DisplayRole);
 }
 
@@ -860,7 +861,7 @@ void TransferListWidget::clearSelectionTags()
 
 void TransferListWidget::displayListMenu(const QPoint&)
 {
-    QModelIndexList selectedIndexes = selectionModel()->selectedRows();
+    const QModelIndexList selectedIndexes = selectionModel()->selectedRows();
     if (selectedIndexes.size() == 0) return;
 
     // Create actions
@@ -936,7 +937,7 @@ void TransferListWidget::displayListMenu(const QPoint&)
 
     BitTorrent::TorrentHandle *torrent;
     qDebug("Displaying menu");
-    foreach (const QModelIndex &index, selectedIndexes) {
+    for (const QModelIndex &index : selectedIndexes) {
         // Get the file name
         // Get handle and pause the torrent
         torrent = m_listModel->torrentHandle(mapToSource(index));
@@ -1022,7 +1023,7 @@ void TransferListWidget::displayListMenu(const QPoint&)
     categoryActions << categoryMenu->addAction(GuiIconProvider::instance()->getIcon("list-add"), tr("New...", "New category..."));
     categoryActions << categoryMenu->addAction(GuiIconProvider::instance()->getIcon("edit-clear"), tr("Reset", "Reset category"));
     categoryMenu->addSeparator();
-    foreach (QString category, categories) {
+    for (QString category : qAsConst(categories)) {
         category.replace('&', "&&");  // avoid '&' becomes accelerator key
         QAction *cat = new QAction(GuiIconProvider::instance()->getIcon("inode-directory"), category, categoryMenu);
         if (allSameCategory && (category == firstCategory)) {
@@ -1041,7 +1042,7 @@ void TransferListWidget::displayListMenu(const QPoint&)
     tagsActions << tagsMenu->addAction(GuiIconProvider::instance()->getIcon("list-add"), tr("Add...", "Add / assign multiple tags..."));
     tagsActions << tagsMenu->addAction(GuiIconProvider::instance()->getIcon("edit-clear"), tr("Remove All", "Remove all tags"));
     tagsMenu->addSeparator();
-    foreach (QString tag, tags) {
+    for (const QString &tag : qAsConst(tags)) {
         const Qt::CheckState initialState = tagsInAll.contains(tag) ? Qt::Checked
                                             : tagsInAny.contains(tag) ? Qt::PartiallyChecked
                                             : Qt::Unchecked;

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -382,7 +382,7 @@ void TransferListWidget::torrentDoubleClicked()
 QList<BitTorrent::TorrentHandle *> TransferListWidget::getSelectedTorrents() const
 {
     QList<BitTorrent::TorrentHandle *> torrents;
-    for (const QModelIndex &index : copyAsConst(selectionModel()->selectedRows()))
+    for (const QModelIndex &index : asConst(selectionModel()->selectedRows()))
         torrents << m_listModel->torrentHandle(mapToSource(index));
 
     return torrents;
@@ -413,25 +413,25 @@ void TransferListWidget::setSelectedTorrentsLocation()
 
 void TransferListWidget::pauseAllTorrents()
 {
-    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(BitTorrent::Session::instance()->torrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConst(BitTorrent::Session::instance()->torrents()))
         torrent->pause();
 }
 
 void TransferListWidget::resumeAllTorrents()
 {
-    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(BitTorrent::Session::instance()->torrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConst(BitTorrent::Session::instance()->torrents()))
         torrent->resume();
 }
 
 void TransferListWidget::startSelectedTorrents()
 {
-    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents()))
         torrent->resume();
 }
 
 void TransferListWidget::forceStartSelectedTorrents()
 {
-    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents()))
         torrent->resume(true);
 }
 
@@ -446,7 +446,7 @@ void TransferListWidget::startVisibleTorrents()
 
 void TransferListWidget::pauseSelectedTorrents()
 {
-    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents()))
         torrent->pause();
 }
 
@@ -496,7 +496,7 @@ void TransferListWidget::deleteVisibleTorrents()
         && !DeletionConfirmationDialog::askForDeletionConfirmation(this, deleteLocalFiles, torrents.size(), torrents[0]->name()))
         return;
 
-    for (BitTorrent::TorrentHandle *const torrent : qAsConst(torrents))
+    for (BitTorrent::TorrentHandle *const torrent : asConst(torrents))
         BitTorrent::Session::instance()->deleteTorrent(torrent->hash(), deleteLocalFiles);
 }
 
@@ -529,7 +529,7 @@ void TransferListWidget::bottomPrioSelectedTorrents()
 void TransferListWidget::copySelectedMagnetURIs() const
 {
     QStringList magnetUris;
-    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents()))
         magnetUris << torrent->toMagnetUri();
 
     qApp->clipboard()->setText(magnetUris.join('\n'));
@@ -538,7 +538,7 @@ void TransferListWidget::copySelectedMagnetURIs() const
 void TransferListWidget::copySelectedNames() const
 {
     QStringList torrentNames;
-    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents()))
         torrentNames << torrent->name();
 
     qApp->clipboard()->setText(torrentNames.join('\n'));
@@ -547,7 +547,7 @@ void TransferListWidget::copySelectedNames() const
 void TransferListWidget::copySelectedHashes() const
 {
     QStringList torrentHashes;
-    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents()))
         torrentHashes << torrent->hash();
 
     qApp->clipboard()->setText(torrentHashes.join('\n'));
@@ -567,13 +567,13 @@ void TransferListWidget::openSelectedTorrentsFolder() const
 #ifdef Q_OS_MAC
     // On macOS you expect both the files and folders to be opened in their parent
     // folders prehilighted for opening, so we use a custom method.
-    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents())) {
+    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents())) {
         QString path = torrent->contentPath(true);
         pathsList.insert(path);
     }
     MacUtils::openFiles(pathsList);
 #else
-    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents())) {
+    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents())) {
         QString path = torrent->contentPath(true);
         if (!pathsList.contains(path)) {
             if (torrent->filesCount() == 1)
@@ -588,7 +588,7 @@ void TransferListWidget::openSelectedTorrentsFolder() const
 
 void TransferListWidget::previewSelectedTorrents()
 {
-    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents())) {
+    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents())) {
         if (torrent->hasMetadata())
             new PreviewSelectDialog(this, torrent);
     }
@@ -597,7 +597,7 @@ void TransferListWidget::previewSelectedTorrents()
 void TransferListWidget::setDlLimitSelectedTorrents()
 {
     QList<BitTorrent::TorrentHandle *> torrentsList;
-    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents())) {
+    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents())) {
         if (torrent->isSeed())
             continue;
         torrentsList += torrent;
@@ -605,7 +605,7 @@ void TransferListWidget::setDlLimitSelectedTorrents()
     if (torrentsList.empty()) return;
 
     int oldLimit = torrentsList.first()->downloadLimit();
-    for (BitTorrent::TorrentHandle *const torrent : qAsConst(torrentsList)) {
+    for (BitTorrent::TorrentHandle *const torrent : asConst(torrentsList)) {
         if (torrent->downloadLimit() != oldLimit) {
             oldLimit = -1;
             break;
@@ -618,7 +618,7 @@ void TransferListWidget::setDlLimitSelectedTorrents()
                 , BitTorrent::Session::instance()->globalDownloadSpeedLimit());
     if (!ok) return;
 
-    for (BitTorrent::TorrentHandle *const torrent : qAsConst(torrentsList)) {
+    for (BitTorrent::TorrentHandle *const torrent : asConst(torrentsList)) {
         qDebug("Applying download speed limit of %ld Kb/s to torrent %s", (newLimit / 1024l), qUtf8Printable(torrent->hash()));
         torrent->setDownloadLimit(newLimit);
     }
@@ -630,7 +630,7 @@ void TransferListWidget::setUpLimitSelectedTorrents()
     if (torrentsList.empty()) return;
 
     int oldLimit = torrentsList.first()->uploadLimit();
-    for (BitTorrent::TorrentHandle *const torrent : qAsConst(torrentsList)) {
+    for (BitTorrent::TorrentHandle *const torrent : asConst(torrentsList)) {
         if (torrent->uploadLimit() != oldLimit) {
             oldLimit = -1;
             break;
@@ -643,7 +643,7 @@ void TransferListWidget::setUpLimitSelectedTorrents()
                 , BitTorrent::Session::instance()->globalUploadSpeedLimit());
     if (!ok) return;
 
-    for (BitTorrent::TorrentHandle *const torrent : qAsConst(torrentsList)) {
+    for (BitTorrent::TorrentHandle *const torrent : asConst(torrentsList)) {
         qDebug("Applying upload speed limit of %ld Kb/s to torrent %s", (newLimit / 1024l), qUtf8Printable(torrent->hash()));
         torrent->setUploadLimit(newLimit);
     }
@@ -687,13 +687,13 @@ void TransferListWidget::recheckSelectedTorrents()
         if (ret != QMessageBox::Yes) return;
     }
 
-    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents()))
         torrent->forceRecheck();
 }
 
 void TransferListWidget::reannounceSelectedTorrents()
 {
-    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents()))
         torrent->forceReannounce();
 }
 
@@ -739,7 +739,7 @@ void TransferListWidget::displayDLHoSMenu(const QPoint&)
 
 void TransferListWidget::toggleSelectedTorrentsSuperSeeding() const
 {
-    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents())) {
+    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents())) {
         if (torrent->hasMetadata())
             torrent->setSuperSeeding(!torrent->superSeeding());
     }
@@ -747,19 +747,19 @@ void TransferListWidget::toggleSelectedTorrentsSuperSeeding() const
 
 void TransferListWidget::toggleSelectedTorrentsSequentialDownload() const
 {
-    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents()))
         torrent->toggleSequentialDownload();
 }
 
 void TransferListWidget::toggleSelectedFirstLastPiecePrio() const
 {
-    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents()))
         torrent->toggleFirstLastPiecePriority();
 }
 
 void TransferListWidget::setSelectedAutoTMMEnabled(bool enabled) const
 {
-    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(getSelectedTorrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents()))
         torrent->setAutoTMMEnabled(enabled);
 }
 
@@ -812,7 +812,7 @@ QStringList TransferListWidget::askTagsForSelection(const QString &dialogTitle)
 
 void TransferListWidget::applyToSelectedTorrents(const std::function<void (BitTorrent::TorrentHandle *const)> &fn)
 {
-    for (const QModelIndex &index : copyAsConst(selectionModel()->selectedRows())) {
+    for (const QModelIndex &index : asConst(selectionModel()->selectedRows())) {
         BitTorrent::TorrentHandle *const torrent = m_listModel->torrentHandle(mapToSource(index));
         Q_ASSERT(torrent);
         fn(torrent);
@@ -840,7 +840,7 @@ void TransferListWidget::renameSelectedTorrent()
 
 void TransferListWidget::setSelectionCategory(QString category)
 {
-    for (const QModelIndex &index : copyAsConst(selectionModel()->selectedRows()))
+    for (const QModelIndex &index : asConst(selectionModel()->selectedRows()))
         m_listModel->setData(m_listModel->index(mapToSource(index).row(), TransferListModel::TR_CATEGORY), category, Qt::DisplayRole);
 }
 
@@ -1023,7 +1023,7 @@ void TransferListWidget::displayListMenu(const QPoint&)
     categoryActions << categoryMenu->addAction(GuiIconProvider::instance()->getIcon("list-add"), tr("New...", "New category..."));
     categoryActions << categoryMenu->addAction(GuiIconProvider::instance()->getIcon("edit-clear"), tr("Reset", "Reset category"));
     categoryMenu->addSeparator();
-    for (QString category : qAsConst(categories)) {
+    for (QString category : asConst(categories)) {
         category.replace('&', "&&");  // avoid '&' becomes accelerator key
         QAction *cat = new QAction(GuiIconProvider::instance()->getIcon("inode-directory"), category, categoryMenu);
         if (allSameCategory && (category == firstCategory)) {
@@ -1042,7 +1042,7 @@ void TransferListWidget::displayListMenu(const QPoint&)
     tagsActions << tagsMenu->addAction(GuiIconProvider::instance()->getIcon("list-add"), tr("Add...", "Add / assign multiple tags..."));
     tagsActions << tagsMenu->addAction(GuiIconProvider::instance()->getIcon("edit-clear"), tr("Remove All", "Remove all tags"));
     tagsMenu->addSeparator();
-    for (const QString &tag : qAsConst(tags)) {
+    for (const QString &tag : asConst(tags)) {
         const Qt::CheckState initialState = tagsInAll.contains(tag) ? Qt::Checked
                                             : tagsInAny.contains(tag) ? Qt::PartiallyChecked
                                             : Qt::Unchecked;

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -106,7 +106,7 @@ protected:
 protected slots:
     void torrentDoubleClicked();
     void displayListMenu(const QPoint&);
-    void currentChanged(const QModelIndex& current, const QModelIndex&) override;
+    void currentChanged(const QModelIndex &current, const QModelIndex&) override;
     void toggleSelectedTorrentsSuperSeeding() const;
     void toggleSelectedTorrentsSequentialDownload() const;
     void toggleSelectedFirstLastPiecePrio() const;

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -202,7 +202,7 @@ void AppController::preferencesAction()
     data["bypass_local_auth"] = !pref->isWebUiLocalAuthEnabled();
     data["bypass_auth_subnet_whitelist_enabled"] = pref->isWebUiAuthSubnetWhitelistEnabled();
     QStringList authSubnetWhitelistStringList;
-    for (const Utils::Net::Subnet &subnet : copyAsConst(pref->getWebUiAuthSubnetWhitelist()))
+    for (const Utils::Net::Subnet &subnet : asConst(pref->getWebUiAuthSubnetWhitelist()))
         authSubnetWhitelistStringList << Utils::Net::subnetToString(subnet);
     data["bypass_auth_subnet_whitelist"] = authSubnetWhitelistStringList.join("\n");
     // Security

--- a/src/webui/api/logcontroller.cpp
+++ b/src/webui/api/logcontroller.cpp
@@ -72,7 +72,7 @@ void LogController::mainAction()
     Logger *const logger = Logger::instance();
     QVariantList msgList;
 
-    for (const Log::Msg &msg : copyAsConst(logger->getMessages(lastKnownId))) {
+    for (const Log::Msg &msg : asConst(logger->getMessages(lastKnownId))) {
         if (!((msg.type == Log::NORMAL && isNormal)
               || (msg.type == Log::INFO && isInfo)
               || (msg.type == Log::WARNING && isWarning)
@@ -111,7 +111,7 @@ void LogController::peersAction()
     Logger *const logger = Logger::instance();
     QVariantList peerList;
 
-    for (const Log::Peer &peer : copyAsConst(logger->getPeers(lastKnownId))) {
+    for (const Log::Peer &peer : asConst(logger->getPeers(lastKnownId))) {
         QVariantMap map;
         map[KEY_LOG_ID] = peer.id;
         map[KEY_LOG_TIMESTAMP] = peer.timestamp;

--- a/src/webui/api/logcontroller.cpp
+++ b/src/webui/api/logcontroller.cpp
@@ -30,6 +30,7 @@
 
 #include <QJsonArray>
 
+#include "base/global.h"
 #include "base/logger.h"
 #include "base/utils/string.h"
 
@@ -71,7 +72,7 @@ void LogController::mainAction()
     Logger *const logger = Logger::instance();
     QVariantList msgList;
 
-    foreach (const Log::Msg &msg, logger->getMessages(lastKnownId)) {
+    for (const Log::Msg &msg : copyAsConst(logger->getMessages(lastKnownId))) {
         if (!((msg.type == Log::NORMAL && isNormal)
               || (msg.type == Log::INFO && isInfo)
               || (msg.type == Log::WARNING && isWarning)
@@ -110,7 +111,7 @@ void LogController::peersAction()
     Logger *const logger = Logger::instance();
     QVariantList peerList;
 
-    foreach (const Log::Peer &peer, logger->getPeers(lastKnownId)) {
+    for (const Log::Peer &peer : copyAsConst(logger->getPeers(lastKnownId))) {
         QVariantMap map;
         map[KEY_LOG_ID] = peer.id;
         map[KEY_LOG_TIMESTAMP] = peer.timestamp;

--- a/src/webui/api/searchcontroller.cpp
+++ b/src/webui/api/searchcontroller.cpp
@@ -202,7 +202,7 @@ void SearchController::categoriesAction()
     const QString name = params()["pluginName"].trimmed();
 
     categories << SearchPluginManager::categoryFullName("all");
-    for (const QString &category : copyAsConst(SearchPluginManager::instance()->getPluginCategories(name)))
+    for (const QString &category : asConst(SearchPluginManager::instance()->getPluginCategories(name)))
         categories << SearchPluginManager::categoryFullName(category);
 
     const QJsonArray result = QJsonArray::fromStringList(categories);
@@ -263,7 +263,7 @@ void SearchController::checkForUpdatesFinished(const QHash<QString, PluginVersio
     LogMsg(tr("Updating %1 plugins").arg(updateInfo.size()), Log::INFO);
 
     SearchPluginManager *const pluginManager = SearchPluginManager::instance();
-    for (const QString &pluginName : copyAsConst(updateInfo.keys())) {
+    for (const QString &pluginName : asConst(updateInfo.keys())) {
         LogMsg(tr("Updating plugin %1").arg(pluginName), Log::INFO);
         pluginManager->updatePlugin(pluginName);
     }

--- a/src/webui/api/searchcontroller.cpp
+++ b/src/webui/api/searchcontroller.cpp
@@ -263,7 +263,7 @@ void SearchController::checkForUpdatesFinished(const QHash<QString, PluginVersio
     LogMsg(tr("Updating %1 plugins").arg(updateInfo.size()), Log::INFO);
 
     SearchPluginManager *const pluginManager = SearchPluginManager::instance();
-    for (const QString &pluginName : updateInfo.keys()) {
+    for (const QString &pluginName : copyAsConst(updateInfo.keys())) {
         LogMsg(tr("Updating plugin %1").arg(pluginName), Log::INFO);
         pluginManager->updatePlugin(pluginName);
     }

--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -35,6 +35,7 @@
 #include "base/bittorrent/peerinfo.h"
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/torrenthandle.h"
+#include "base/global.h"
 #include "base/net/geoipmanager.h"
 #include "base/preferences.h"
 #include "base/utils/fs.h"
@@ -133,7 +134,7 @@ namespace
 
         // num_peers is not reliable (adds up peers, which didn't even overcome tcp handshake)
         quint32 peers = 0;
-        foreach (BitTorrent::TorrentHandle *const torrent, BitTorrent::Session::instance()->torrents())
+        for (BitTorrent::TorrentHandle *const torrent : copyAsConst(BitTorrent::Session::instance()->torrents()))
             peers += torrent->peersCount();
         map[KEY_TRANSFER_WRITE_CACHE_OVERLOAD] = ((sessionStatus.diskWriteQueue > 0) && (peers > 0)) ? Utils::String::fromDouble((100. * sessionStatus.diskWriteQueue) / peers, 2) : "0";
         map[KEY_TRANSFER_READ_CACHE_OVERLOAD] = ((sessionStatus.diskReadQueue > 0) && (peers > 0)) ? Utils::String::fromDouble((100. * sessionStatus.diskReadQueue) / peers, 2) : "0";
@@ -268,7 +269,7 @@ namespace
             syncData = data;
         }
         else {
-            foreach (QVariant item, data) {
+            for (const QVariant &item : data) {
                 if (!prevData.contains(item))
                     // new list item found - append it to syncData
                     syncData.append(item);
@@ -409,7 +410,7 @@ void SyncController::maindataAction()
 
     BitTorrent::Session *const session = BitTorrent::Session::instance();
 
-    foreach (BitTorrent::TorrentHandle *const torrent, session->torrents()) {
+    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(session->torrents())) {
         QVariantMap map = serialize(*torrent);
         map.remove(KEY_TORRENT_HASH);
 
@@ -468,7 +469,7 @@ void SyncController::torrentPeersAction()
 
     QVariantMap data;
     QVariantHash peers;
-    QList<BitTorrent::PeerInfo> peersList = torrent->peers();
+    const QList<BitTorrent::PeerInfo> peersList = torrent->peers();
 #ifndef DISABLE_COUNTRIES_RESOLUTION
     bool resolvePeerCountries = Preferences::instance()->resolvePeerCountries();
 #else
@@ -477,7 +478,7 @@ void SyncController::torrentPeersAction()
 
     data[KEY_SYNC_TORRENT_PEERS_SHOW_FLAGS] = resolvePeerCountries;
 
-    foreach (const BitTorrent::PeerInfo &pi, peersList) {
+    for (const BitTorrent::PeerInfo &pi : peersList) {
         if (pi.address().ip.isNull()) continue;
         QVariantMap peer;
 #ifndef DISABLE_COUNTRIES_RESOLUTION

--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -134,7 +134,7 @@ namespace
 
         // num_peers is not reliable (adds up peers, which didn't even overcome tcp handshake)
         quint32 peers = 0;
-        for (BitTorrent::TorrentHandle *const torrent : copyAsConst(BitTorrent::Session::instance()->torrents()))
+        for (BitTorrent::TorrentHandle *const torrent : asConst(BitTorrent::Session::instance()->torrents()))
             peers += torrent->peersCount();
         map[KEY_TRANSFER_WRITE_CACHE_OVERLOAD] = ((sessionStatus.diskWriteQueue > 0) && (peers > 0)) ? Utils::String::fromDouble((100. * sessionStatus.diskWriteQueue) / peers, 2) : "0";
         map[KEY_TRANSFER_READ_CACHE_OVERLOAD] = ((sessionStatus.diskReadQueue > 0) && (peers > 0)) ? Utils::String::fromDouble((100. * sessionStatus.diskReadQueue) / peers, 2) : "0";
@@ -410,7 +410,7 @@ void SyncController::maindataAction()
 
     BitTorrent::Session *const session = BitTorrent::Session::instance();
 
-    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(session->torrents())) {
+    for (BitTorrent::TorrentHandle *const torrent : asConst(session->torrents())) {
         QVariantMap map = serialize(*torrent);
         map.remove(KEY_TORRENT_HASH);
 

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -113,7 +113,7 @@ namespace
     void applyToTorrents(const QStringList &hashes, const std::function<void (BitTorrent::TorrentHandle *torrent)> &func)
     {
         if ((hashes.size() == 1) && (hashes[0] == QLatin1String("all"))) {
-            foreach (BitTorrent::TorrentHandle *torrent, BitTorrent::Session::instance()->torrents())
+            for (BitTorrent::TorrentHandle *torrent : copyAsConst(BitTorrent::Session::instance()->torrents()))
                 func(torrent);
         }
         else {
@@ -167,7 +167,7 @@ void TorrentsController::infoAction()
 
     QVariantList torrentList;
     TorrentFilter torrentFilter(filter, (hashSet.isEmpty() ? TorrentFilter::AnyHash : hashSet), category);
-    foreach (BitTorrent::TorrentHandle *const torrent, BitTorrent::Session::instance()->torrents()) {
+    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(BitTorrent::Session::instance()->torrents())) {
         if (torrentFilter.match(torrent))
             torrentList.append(serialize(*torrent));
     }
@@ -307,7 +307,7 @@ void TorrentsController::trackersAction()
         throw APIError(APIErrorType::NotFound);
 
     QHash<QString, BitTorrent::TrackerInfo> trackersData = torrent->trackerInfos();
-    foreach (const BitTorrent::TrackerEntry &tracker, torrent->trackers()) {
+    for (const BitTorrent::TrackerEntry &tracker : copyAsConst(torrent->trackers())) {
         QVariantMap trackerDict;
         trackerDict[KEY_TRACKER_URL] = tracker.url();
         const BitTorrent::TrackerInfo data = trackersData.value(tracker.url());
@@ -346,7 +346,7 @@ void TorrentsController::webseedsAction()
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 
-    foreach (const QUrl &webseed, torrent->urlSeeds()) {
+    for (const QUrl &webseed : copyAsConst(torrent->urlSeeds())) {
         QVariantMap webSeedDict;
         webSeedDict[KEY_WEBSEED_URL] = webseed.toString();
         webSeedList.append(webSeedDict);
@@ -419,7 +419,7 @@ void TorrentsController::pieceHashesAction()
 
     const QVector<QByteArray> hashes = torrent->info().pieceHashes();
     pieceHashes.reserve(hashes.size());
-    foreach (const QByteArray &hash, hashes)
+    for (const QByteArray &hash : hashes)
         pieceHashes.append(hash.toHex());
 
     setResult(QJsonArray::fromVariantList(pieceHashes));
@@ -531,7 +531,7 @@ void TorrentsController::addTrackersAction()
     BitTorrent::TorrentHandle *const torrent = BitTorrent::Session::instance()->findTorrent(hash);
     if (torrent) {
         QList<BitTorrent::TrackerEntry> trackers;
-        foreach (QString url, params()["urls"].split('\n')) {
+        for (QString url : copyAsConst(params()["urls"].split('\n'))) {
             url = url.trimmed();
             if (!url.isEmpty())
                 trackers << url;
@@ -575,7 +575,7 @@ void TorrentsController::uploadLimitAction()
 
     const QStringList hashes {params()["hashes"].split('|')};
     QVariantMap map;
-    foreach (const QString &hash, hashes) {
+    for (const QString &hash : hashes) {
         int limit = -1;
         BitTorrent::TorrentHandle *const torrent = BitTorrent::Session::instance()->findTorrent(hash);
         if (torrent)
@@ -592,7 +592,7 @@ void TorrentsController::downloadLimitAction()
 
     const QStringList hashes {params()["hashes"].split('|')};
     QVariantMap map;
-    foreach (const QString &hash, hashes) {
+    for (const QString &hash : hashes) {
         int limit = -1;
         BitTorrent::TorrentHandle *const torrent = BitTorrent::Session::instance()->findTorrent(hash);
         if (torrent)

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -113,7 +113,7 @@ namespace
     void applyToTorrents(const QStringList &hashes, const std::function<void (BitTorrent::TorrentHandle *torrent)> &func)
     {
         if ((hashes.size() == 1) && (hashes[0] == QLatin1String("all"))) {
-            for (BitTorrent::TorrentHandle *torrent : copyAsConst(BitTorrent::Session::instance()->torrents()))
+            for (BitTorrent::TorrentHandle *torrent : asConst(BitTorrent::Session::instance()->torrents()))
                 func(torrent);
         }
         else {
@@ -167,7 +167,7 @@ void TorrentsController::infoAction()
 
     QVariantList torrentList;
     TorrentFilter torrentFilter(filter, (hashSet.isEmpty() ? TorrentFilter::AnyHash : hashSet), category);
-    for (BitTorrent::TorrentHandle *const torrent : copyAsConst(BitTorrent::Session::instance()->torrents())) {
+    for (BitTorrent::TorrentHandle *const torrent : asConst(BitTorrent::Session::instance()->torrents())) {
         if (torrentFilter.match(torrent))
             torrentList.append(serialize(*torrent));
     }
@@ -307,7 +307,7 @@ void TorrentsController::trackersAction()
         throw APIError(APIErrorType::NotFound);
 
     QHash<QString, BitTorrent::TrackerInfo> trackersData = torrent->trackerInfos();
-    for (const BitTorrent::TrackerEntry &tracker : copyAsConst(torrent->trackers())) {
+    for (const BitTorrent::TrackerEntry &tracker : asConst(torrent->trackers())) {
         QVariantMap trackerDict;
         trackerDict[KEY_TRACKER_URL] = tracker.url();
         const BitTorrent::TrackerInfo data = trackersData.value(tracker.url());
@@ -346,7 +346,7 @@ void TorrentsController::webseedsAction()
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 
-    for (const QUrl &webseed : copyAsConst(torrent->urlSeeds())) {
+    for (const QUrl &webseed : asConst(torrent->urlSeeds())) {
         QVariantMap webSeedDict;
         webSeedDict[KEY_WEBSEED_URL] = webseed.toString();
         webSeedList.append(webSeedDict);
@@ -498,7 +498,7 @@ void TorrentsController::addAction()
     params.downloadLimit = (dlLimit > 0) ? dlLimit : -1;
 
     bool partialSuccess = false;
-    for (QString url : copyAsConst(urls.split('\n'))) {
+    for (QString url : asConst(urls.split('\n'))) {
         url = url.trimmed();
         if (!url.isEmpty()) {
             Net::DownloadManager::instance()->setCookiesFromUrl(cookies, QUrl::fromEncoded(url.toUtf8()));
@@ -531,7 +531,7 @@ void TorrentsController::addTrackersAction()
     BitTorrent::TorrentHandle *const torrent = BitTorrent::Session::instance()->findTorrent(hash);
     if (torrent) {
         QList<BitTorrent::TrackerEntry> trackers;
-        for (QString url : copyAsConst(params()["urls"].split('\n'))) {
+        for (QString url : asConst(params()["urls"].split('\n'))) {
             url = url.trimmed();
             if (!url.isEmpty())
                 trackers << url;

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -525,7 +525,7 @@ Http::Response WebApplication::processRequest(const Http::Request &request, cons
     if (m_request.method == Http::METHOD_GET) {
         // Parse GET parameters
         using namespace Utils::ByteArray;
-        for (const QByteArray &param : copyAsConst(splitToViews(m_request.query, "&"))) {
+        for (const QByteArray &param : asConst(splitToViews(m_request.query, "&"))) {
             const int sepPos = param.indexOf('=');
             if (sepPos <= 0) continue; // ignores params without name
 

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -649,7 +649,8 @@ void WebApplication::sessionStart()
 
     // remove outdated sessions
     const qint64 now = QDateTime::currentMSecsSinceEpoch() / 1000;
-    foreach (const auto session, m_sessions) {
+    const QMap<QString, WebSession *> sessionsCopy {m_sessions};
+    for (const auto session : sessionsCopy) {
         if ((now - session->timestamp()) > INACTIVE_TIME)
             delete m_sessions.take(session->id());
     }


### PR DESCRIPTION
...and fix coding style for various things.
I gave it a shot in converting a few "foreach" to "for" but i'm not sure i have grasped how qAsConst() and copyAsConst() should be used. From my understanding qAsConst() should be used for non-const qt containers and copyAsConst() for methods returning non-const qt containers? If i understood correctly i'll do the rest as well.

Another question is do you want me to change include guards to `#pragma once` in all header files?