### PR TITLE
Add SameSite attribute to WebUI session cookie

### DIFF
--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -656,7 +656,10 @@ void WebApplication::sessionStart()
     QNetworkCookie cookie(C_SID, m_currentSession->id().toUtf8());
     cookie.setHttpOnly(true);
     cookie.setPath(QLatin1String("/"));
-    header(Http::HEADER_SET_COOKIE, cookie.toRawForm());
+    QByteArray cookieRawForm = cookie.toRawForm();
+    if (m_isCSRFProtectionEnabled)
+        cookieRawForm.append("; SameSite=Strict");
+    header(Http::HEADER_SET_COOKIE, cookieRawForm);
 }
 
 void WebApplication::sessionEnd()


### PR DESCRIPTION
This attribute prevents the cookie from being submitted on any cross-site request, strongly limiting CSRF.

Closes #9877.