### PR TITLE
Remove C++11 in the v4_1_x branch

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -2,9 +2,6 @@
 TEMPLATE = app
 CONFIG += qt thread silent
 
-# C++11 support
-CONFIG += c++11
-
 # Platform specific configuration
 win32: include(../winconf.pri)
 macx: include(../macxconf.pri)


### PR DESCRIPTION
This is in addition to the changes made in CMakeList.txt in regards to C++14.