### PR TITLE
Autotools: Better C++ mode detection and handling

### DIFF
--- a/configure
+++ b/configure
@@ -5013,12 +5013,6 @@ CPPFLAGS="$BOOST_CPPFLAGS $CPPFLAGS"
 LDFLAGS="$BOOST_LDFLAGS $LDFLAGS"
 
 # add workaround for problematic boost version
-ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
-
 # taken from ax_boost_base.m4
 
 
@@ -5039,12 +5033,6 @@ else
   QBT_ADD_DEFINES="$QBT_ADD_DEFINES BOOST_NO_CXX11_RVALUE_REFERENCES"
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
-
 
 
 
@@ -5495,25 +5483,17 @@ $as_echo "yes" >&6; }
                  LIBS="$zlib_LIBS $LIBS"
 fi
 
-# Check compiler C++11 support
-ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
-
-
-
-_tmp="$CXXFLAGS"
-CXXFLAGS="$CXXFLAGS -std=c++11"
+# Check if already in >= C++11 mode because of the flags returned by one of the above packages
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if compiler is using C++11 or later mode" >&5
+$as_echo_n "checking if compiler is using C++11 or later mode... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-#ifndef __cplusplus
-#error "This is not a C++ compiler"
-#elif __cplusplus < 201103L
-#error "This is not a C++11 compiler"
-#endif
+            #ifndef __cplusplus
+            #error "This is not a C++ compiler"
+            #elif __cplusplus < 201103L
+            #error "This is not a C++11 compiler"
+            #endif
 int
 main ()
 {
@@ -5521,25 +5501,34 @@ main ()
   ;
   return 0;
 }
+
 _ACEOF
 if ac_fn_cxx_try_compile "$LINENO"; then :
-
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+                   QBT_CXX11_FOUND="yes"
 else
-  as_fn_error $? "A compiler supporting C++11 is required." "$LINENO" 5
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+                   QBT_CXX11_FOUND="no"
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-CXXFLAGS="$_tmp"
 
-_tmp="$CXXFLAGS"
-CXXFLAGS="$CXXFLAGS $libtorrent_CFLAGS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+# In case of no, check if the compiler can support at least C++11
+# and if yes, enable it leaving a warning to the user
+if test "x$QBT_CXX11_FOUND" = "xno"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if compiler supports C++11" >&5
+$as_echo_n "checking if compiler supports C++11... " >&6; }
+       TMP_CPPFLAGS="$CPPFLAGS"
+       CPPFLAGS="$CPPFLAGS -std=c++11"
+       cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-#ifndef __cplusplus
-#error "This is not a C++ compiler"
-#elif __cplusplus < 201103L
-#error "This is not a C++11 compiler"
-#endif
+            #ifndef __cplusplus
+            #error "This is not a C++ compiler"
+            #elif __cplusplus < 201103L
+            #error "This is not a C++11 compiler"
+            #endif
 int
 main ()
 {
@@ -5547,22 +5536,58 @@ main ()
   ;
   return 0;
 }
+
 _ACEOF
 if ac_fn_cxx_try_compile "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+                         { $as_echo "$as_me:${as_lineno-$LINENO}: checking if C++11 is disabled by the set compiler flags" >&5
+$as_echo_n "checking if C++11 is disabled by the set compiler flags... " >&6; }
+                         # prepend the flag so it won't override conflicting user defined flags
+                         CPPFLAGS="-std=c++11 $TMP_CPPFLAGS"
+                         cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
 
+            #ifndef __cplusplus
+            #error "This is not a C++ compiler"
+            #elif __cplusplus < 201103L
+            #error "This is not a C++11 compiler"
+            #endif
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+                                            CPPFLAGS="$TMP_CPPFLAGS -std=c++11"
+                                            { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: C++11 mode is now force enabled.
+Make sure you use the same C++ mode for qBittorrent and its dependencies.
+To explicitly set qBittorrent to a later mode use CPPFLAGS.
+Example: \`CPPFLAGS=\"\$CPPFLAGS -std=c++14\" ./configure\`" >&5
+$as_echo "$as_me: WARNING: C++11 mode is now force enabled.
+Make sure you use the same C++ mode for qBittorrent and its dependencies.
+To explicitly set qBittorrent to a later mode use CPPFLAGS.
+Example: \`CPPFLAGS=\"\$CPPFLAGS -std=c++14\" ./configure\`" >&2;}
 else
-  as_fn_error $? "Compiler is not working in C++11 or later mode.
-    Make sure you use the same C++ mode for qBittorrent and its dependencies.
-    Example: \`CXXFLAGS=\"\$CXXFLAGS -std=c++11\" ./configure\`" "$LINENO" 5
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+                                            as_fn_error $? "The compiler supports C++11 but the user or a dependency has explicitly enabled a lower mode." "$LINENO" 5
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-CXXFLAGS="$_tmp"
-ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+                         as_fn_error $? "A compiler supporting C++11 is required." "$LINENO" 5
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
+fi
 
 # These are required because autoconf doesn't expand these **particular**
 # vars automatically. And qmake cannot autoexpand them.
@@ -5650,15 +5675,15 @@ extract() {
   for i in $string; do
     case "$(echo "$i" | cut -c1)" in
       '') ;;
-      D) QBT_CONF_DEFINES="$(echo $i | cut -c2-) $QBT_CONF_DEFINES";;
-      I) QBT_CONF_INCLUDES="$(echo $i | cut -c2-) $QBT_CONF_INCLUDES";;
-      *) QBT_CONF_EXTRA_CFLAGS="-$i $QBT_CONF_EXTRA_CFLAGS";;
+      D) QBT_CONF_DEFINES="$QBT_CONF_DEFINES $(echo $i | cut -c2-)";;
+      I) QBT_CONF_INCLUDES="$QBT_CONF_INCLUDES $(echo $i | cut -c2-)";;
+      *) QBT_CONF_EXTRA_CFLAGS="$QBT_CONF_EXTRA_CFLAGS -$i";;
     esac
   done
   IFS=$SAVEIFS
 }
 
-extract "$CFLAGS $CPPFLAGS $CXXFLAGS"
+extract "$CFLAGS $CXXFLAGS $CPPFLAGS"
 QBT_ADD_DEFINES="$QBT_ADD_DEFINES $QBT_CONF_DEFINES"
 
 # Substitute the values of these vars in conf.pri.in

--- a/configure
+++ b/configure
@@ -4995,10 +4995,10 @@ $as_echo "$as_me: Your boost libraries seems to old (version $_version)." >&6;}
 $as_echo "#define HAVE_BOOST /**/" >>confdefs.h
 
         # execute ACTION-IF-FOUND (if present):
-        { $as_echo "$as_me:${as_lineno-$LINENO}: Boost CPPFLAGS: \"$BOOST_CPPFLAGS\"
-                Boost LDFLAGS: \"$BOOST_LDFLAGS\"" >&5
-$as_echo "$as_me: Boost CPPFLAGS: \"$BOOST_CPPFLAGS\"
-                Boost LDFLAGS: \"$BOOST_LDFLAGS\"" >&6;}
+        { $as_echo "$as_me:${as_lineno-$LINENO}: Boost CPPFLAGS: \"$BOOST_CPPFLAGS\"" >&5
+$as_echo "$as_me: Boost CPPFLAGS: \"$BOOST_CPPFLAGS\"" >&6;}
+               { $as_echo "$as_me:${as_lineno-$LINENO}: Boost LDFLAGS: \"$BOOST_LDFLAGS\"" >&5
+$as_echo "$as_me: Boost LDFLAGS: \"$BOOST_LDFLAGS\"" >&6;}
     fi
 
     CPPFLAGS="$CPPFLAGS_SAVED"

--- a/configure
+++ b/configure
@@ -4995,8 +4995,8 @@ $as_echo "$as_me: Your boost libraries seems to old (version $_version)." >&6;}
 $as_echo "#define HAVE_BOOST /**/" >>confdefs.h
 
         # execute ACTION-IF-FOUND (if present):
-        { $as_echo "$as_me:${as_lineno-$LINENO}: Boost CPPFLAGS: \"$BOOST_CPPFLAGS\"" >&5
-$as_echo "$as_me: Boost CPPFLAGS: \"$BOOST_CPPFLAGS\"" >&6;}
+        { $as_echo "$as_me:${as_lineno-$LINENO}: Boost CXXFLAGS: \"$BOOST_CPPFLAGS\"" >&5
+$as_echo "$as_me: Boost CXXFLAGS: \"$BOOST_CPPFLAGS\"" >&6;}
                { $as_echo "$as_me:${as_lineno-$LINENO}: Boost LDFLAGS: \"$BOOST_LDFLAGS\"" >&5
 $as_echo "$as_me: Boost LDFLAGS: \"$BOOST_LDFLAGS\"" >&6;}
     fi
@@ -5009,7 +5009,7 @@ fi
 
 
 
-CPPFLAGS="$BOOST_CPPFLAGS $CPPFLAGS"
+CXXFLAGS="$BOOST_CPPFLAGS $CXXFLAGS"
 LDFLAGS="$BOOST_LDFLAGS $LDFLAGS"
 
 # add workaround for problematic boost version
@@ -5386,7 +5386,7 @@ else
 	libtorrent_LIBS=$pkg_cv_libtorrent_LIBS
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
-	CPPFLAGS="$libtorrent_CFLAGS $CPPFLAGS"
+	CXXFLAGS="$libtorrent_CFLAGS $CXXFLAGS"
                   LIBS="$libtorrent_LIBS $LIBS"
 fi
 
@@ -5479,7 +5479,7 @@ else
 	zlib_LIBS=$pkg_cv_zlib_LIBS
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
-	CPPFLAGS="$zlib_CFLAGS $CPPFLAGS"
+	CXXFLAGS="$zlib_CFLAGS $CXXFLAGS"
                  LIBS="$zlib_LIBS $LIBS"
 fi
 
@@ -5519,8 +5519,8 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 if test "x$QBT_CXX11_FOUND" = "xno"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if compiler supports C++11" >&5
 $as_echo_n "checking if compiler supports C++11... " >&6; }
-       TMP_CPPFLAGS="$CPPFLAGS"
-       CPPFLAGS="$CPPFLAGS -std=c++11"
+       TMP_CXXFLAGS="$CXXFLAGS"
+       CXXFLAGS="$CXXFLAGS -std=c++11"
        cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -5544,7 +5544,7 @@ $as_echo "yes" >&6; }
                          { $as_echo "$as_me:${as_lineno-$LINENO}: checking if C++11 is disabled by the set compiler flags" >&5
 $as_echo_n "checking if C++11 is disabled by the set compiler flags... " >&6; }
                          # prepend the flag so it won't override conflicting user defined flags
-                         CPPFLAGS="-std=c++11 $TMP_CPPFLAGS"
+                         CXXFLAGS="-std=c++11 $TMP_CXXFLAGS"
                          cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -5565,15 +5565,15 @@ _ACEOF
 if ac_fn_cxx_try_compile "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
-                                            CPPFLAGS="$TMP_CPPFLAGS -std=c++11"
+                                            CXXFLAGS="$TMP_CXXFLAGS -std=c++11"
                                             { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: C++11 mode is now force enabled.
 Make sure you use the same C++ mode for qBittorrent and its dependencies.
-To explicitly set qBittorrent to a later mode use CPPFLAGS.
-Example: \`CPPFLAGS=\"\$CPPFLAGS -std=c++14\" ./configure\`" >&5
+To explicitly set qBittorrent to a later mode use CXXFLAGS.
+Example: \`CXXFLAGS=\"\$CXXFLAGS -std=c++14\" ./configure\`" >&5
 $as_echo "$as_me: WARNING: C++11 mode is now force enabled.
 Make sure you use the same C++ mode for qBittorrent and its dependencies.
-To explicitly set qBittorrent to a later mode use CPPFLAGS.
-Example: \`CPPFLAGS=\"\$CPPFLAGS -std=c++14\" ./configure\`" >&2;}
+To explicitly set qBittorrent to a later mode use CXXFLAGS.
+Example: \`CXXFLAGS=\"\$CXXFLAGS -std=c++14\" ./configure\`" >&2;}
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
@@ -5683,7 +5683,7 @@ extract() {
   IFS=$SAVEIFS
 }
 
-extract "$CFLAGS $CXXFLAGS $CPPFLAGS"
+extract "$CFLAGS $CXXFLAGS"
 QBT_ADD_DEFINES="$QBT_ADD_DEFINES $QBT_CONF_DEFINES"
 
 # Substitute the values of these vars in conf.pri.in

--- a/configure.ac
+++ b/configure.ac
@@ -160,8 +160,8 @@ AS_CASE(["x$enable_qt_dbus"],
 
 
 AX_BOOST_BASE([1.35],
-              [AC_MSG_NOTICE([Boost CPPFLAGS: "$BOOST_CPPFLAGS"
-                Boost LDFLAGS: "$BOOST_LDFLAGS"])],
+              [AC_MSG_NOTICE([Boost CPPFLAGS: "$BOOST_CPPFLAGS"])
+               AC_MSG_NOTICE([Boost LDFLAGS: "$BOOST_LDFLAGS"])],
               [AC_MSG_ERROR([Could not find Boost])])
 CPPFLAGS="$BOOST_CPPFLAGS $CPPFLAGS"
 LDFLAGS="$BOOST_LDFLAGS $LDFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -167,7 +167,6 @@ CPPFLAGS="$BOOST_CPPFLAGS $CPPFLAGS"
 LDFLAGS="$BOOST_LDFLAGS $LDFLAGS"
 
 # add workaround for problematic boost version
-AC_LANG_PUSH(C++)
 # taken from ax_boost_base.m4
 m4_define([DETECT_BOOST_VERSION_PROGRAM],
     [AC_LANG_PROGRAM([[#include <boost/version.hpp>]],
@@ -175,7 +174,6 @@ m4_define([DETECT_BOOST_VERSION_PROGRAM],
 
 AC_COMPILE_IFELSE([DETECT_BOOST_VERSION_PROGRAM(106000)], [],
     [QBT_ADD_DEFINES="$QBT_ADD_DEFINES BOOST_NO_CXX11_RVALUE_REFERENCES"])
-AC_LANG_POP([C++])
 
 AX_BOOST_SYSTEM()
 AC_MSG_NOTICE([Boost.System LIB: "$BOOST_SYSTEM_LIB"])
@@ -202,31 +200,37 @@ PKG_CHECK_MODULES(zlib,
                  [CPPFLAGS="$zlib_CFLAGS $CPPFLAGS"
                  LIBS="$zlib_LIBS $LIBS"])
 
-# Check compiler C++11 support
-AC_LANG_PUSH(C++)
-m4_define([DETECT_CPP11_PROGRAM],
-    [AC_LANG_PROGRAM([[
-#ifndef __cplusplus
-#error "This is not a C++ compiler"
-#elif __cplusplus < 201103L
-#error "This is not a C++11 compiler"
-#endif]],
-    [[]])])
-
-_tmp="$CXXFLAGS"
-CXXFLAGS="$CXXFLAGS -std=c++11"
+# Check if already in >= C++11 mode because of the flags returned by one of the above packages
+AC_MSG_CHECKING([if compiler is using C++11 or later mode])
 AC_COMPILE_IFELSE([DETECT_CPP11_PROGRAM()],
-    [],
-    [AC_MSG_ERROR([A compiler supporting C++11 is required.])])
-
-CXXFLAGS="$_tmp $libtorrent_CFLAGS"
-AC_COMPILE_IFELSE([DETECT_CPP11_PROGRAM()],
-    [],
-    [AC_MSG_ERROR([Compiler is not working in C++11 or later mode.
-    Make sure you use the same C++ mode for qBittorrent and its dependencies.
-    Example: `CXXFLAGS="\$CXXFLAGS -std=c++11" ./configure`])])
-CXXFLAGS="$_tmp"
-AC_LANG_POP([C++])
+                  [AC_MSG_RESULT([yes])
+                   QBT_CXX11_FOUND="yes"],
+                  [AC_MSG_RESULT([no])
+                   QBT_CXX11_FOUND="no"])
+                  
+# In case of no, check if the compiler can support at least C++11
+# and if yes, enable it leaving a warning to the user
+AS_IF([test "x$QBT_CXX11_FOUND" = "xno"],
+      [AC_MSG_CHECKING([if compiler supports C++11])
+       TMP_CPPFLAGS="$CPPFLAGS"
+       CPPFLAGS="$CPPFLAGS -std=c++11"
+       AC_COMPILE_IFELSE([DETECT_CPP11_PROGRAM()],
+                        [AC_MSG_RESULT([yes])
+                         AC_MSG_CHECKING([if C++11 is disabled by the set compiler flags])
+                         # prepend the flag so it won't override conflicting user defined flags
+                         CPPFLAGS="-std=c++11 $TMP_CPPFLAGS"
+                         AC_COMPILE_IFELSE([DETECT_CPP11_PROGRAM()],
+                                           [AC_MSG_RESULT([no])
+                                            CPPFLAGS="$TMP_CPPFLAGS -std=c++11"
+                                            AC_MSG_WARN([C++11 mode is now force enabled.
+Make sure you use the same C++ mode for qBittorrent and its dependencies.
+To explicitly set qBittorrent to a later mode use CPPFLAGS.
+Example: `CPPFLAGS="\$CPPFLAGS -std=c++14" ./configure`])],
+                                           [AC_MSG_RESULT([yes])
+                                            AC_MSG_ERROR([The compiler supports C++11 but the user or a dependency has explicitly enabled a lower mode.])])],
+                        [AC_MSG_RESULT([no])
+                         AC_MSG_ERROR([A compiler supporting C++11 is required.])])
+      ])
 
 # These are required because autoconf doesn't expand these **particular**
 # vars automatically. And qmake cannot autoexpand them.
@@ -254,15 +258,15 @@ extract() {
   for i in $string; do
     case "$(echo "$i" | cut -c1)" in
       '') ;;
-      D) QBT_CONF_DEFINES="$(echo $i | cut -c2-) $QBT_CONF_DEFINES";;
-      I) QBT_CONF_INCLUDES="$(echo $i | cut -c2-) $QBT_CONF_INCLUDES";;
-      *) QBT_CONF_EXTRA_CFLAGS="-$i $QBT_CONF_EXTRA_CFLAGS";;
+      D) QBT_CONF_DEFINES="$QBT_CONF_DEFINES $(echo $i | cut -c2-)";;
+      I) QBT_CONF_INCLUDES="$QBT_CONF_INCLUDES $(echo $i | cut -c2-)";;
+      *) QBT_CONF_EXTRA_CFLAGS="$QBT_CONF_EXTRA_CFLAGS -$i";;
     esac
   done
   IFS=$SAVEIFS
 }
 
-extract "$CFLAGS $CPPFLAGS $CXXFLAGS"
+extract "$CFLAGS $CXXFLAGS $CPPFLAGS"
 QBT_ADD_DEFINES="$QBT_ADD_DEFINES $QBT_CONF_DEFINES"
 
 # Substitute the values of these vars in conf.pri.in

--- a/configure.ac
+++ b/configure.ac
@@ -160,10 +160,10 @@ AS_CASE(["x$enable_qt_dbus"],
 
 
 AX_BOOST_BASE([1.35],
-              [AC_MSG_NOTICE([Boost CPPFLAGS: "$BOOST_CPPFLAGS"])
+              [AC_MSG_NOTICE([Boost CXXFLAGS: "$BOOST_CPPFLAGS"])
                AC_MSG_NOTICE([Boost LDFLAGS: "$BOOST_LDFLAGS"])],
               [AC_MSG_ERROR([Could not find Boost])])
-CPPFLAGS="$BOOST_CPPFLAGS $CPPFLAGS"
+CXXFLAGS="$BOOST_CPPFLAGS $CXXFLAGS"
 LDFLAGS="$BOOST_LDFLAGS $LDFLAGS"
 
 # add workaround for problematic boost version
@@ -192,12 +192,12 @@ AS_CASE(["x$with_qtsingleapplication"],
 
 PKG_CHECK_MODULES(libtorrent,
                   [libtorrent-rasterbar >= 1.0.6],
-                  [CPPFLAGS="$libtorrent_CFLAGS $CPPFLAGS"
+                  [CXXFLAGS="$libtorrent_CFLAGS $CXXFLAGS"
                   LIBS="$libtorrent_LIBS $LIBS"])
 
 PKG_CHECK_MODULES(zlib,
                  [zlib >= 1.2.5.2],
-                 [CPPFLAGS="$zlib_CFLAGS $CPPFLAGS"
+                 [CXXFLAGS="$zlib_CFLAGS $CXXFLAGS"
                  LIBS="$zlib_LIBS $LIBS"])
 
 # Check if already in >= C++11 mode because of the flags returned by one of the above packages
@@ -212,20 +212,20 @@ AC_COMPILE_IFELSE([DETECT_CPP11_PROGRAM()],
 # and if yes, enable it leaving a warning to the user
 AS_IF([test "x$QBT_CXX11_FOUND" = "xno"],
       [AC_MSG_CHECKING([if compiler supports C++11])
-       TMP_CPPFLAGS="$CPPFLAGS"
-       CPPFLAGS="$CPPFLAGS -std=c++11"
+       TMP_CXXFLAGS="$CXXFLAGS"
+       CXXFLAGS="$CXXFLAGS -std=c++11"
        AC_COMPILE_IFELSE([DETECT_CPP11_PROGRAM()],
                         [AC_MSG_RESULT([yes])
                          AC_MSG_CHECKING([if C++11 is disabled by the set compiler flags])
                          # prepend the flag so it won't override conflicting user defined flags
-                         CPPFLAGS="-std=c++11 $TMP_CPPFLAGS"
+                         CXXFLAGS="-std=c++11 $TMP_CXXFLAGS"
                          AC_COMPILE_IFELSE([DETECT_CPP11_PROGRAM()],
                                            [AC_MSG_RESULT([no])
-                                            CPPFLAGS="$TMP_CPPFLAGS -std=c++11"
+                                            CXXFLAGS="$TMP_CXXFLAGS -std=c++11"
                                             AC_MSG_WARN([C++11 mode is now force enabled.
 Make sure you use the same C++ mode for qBittorrent and its dependencies.
-To explicitly set qBittorrent to a later mode use CPPFLAGS.
-Example: `CPPFLAGS="\$CPPFLAGS -std=c++14" ./configure`])],
+To explicitly set qBittorrent to a later mode use CXXFLAGS.
+Example: `CXXFLAGS="\$CXXFLAGS -std=c++14" ./configure`])],
                                            [AC_MSG_RESULT([yes])
                                             AC_MSG_ERROR([The compiler supports C++11 but the user or a dependency has explicitly enabled a lower mode.])])],
                         [AC_MSG_RESULT([no])
@@ -266,7 +266,7 @@ extract() {
   IFS=$SAVEIFS
 }
 
-extract "$CFLAGS $CXXFLAGS $CPPFLAGS"
+extract "$CFLAGS $CXXFLAGS"
 QBT_ADD_DEFINES="$QBT_ADD_DEFINES $QBT_CONF_DEFINES"
 
 # Substitute the values of these vars in conf.pri.in

--- a/m4/qbittorrent.m4
+++ b/m4/qbittorrent.m4
@@ -36,3 +36,16 @@ AC_DEFUN([FIND_QTDBUS],
                         [AC_MSG_RESULT([not found])
                          HAVE_QTDBUS=[false]])
 ])
+
+# DETECT_CPP11_PROGRAM()
+# Detects if at least C++11 mode is enabled.
+# --------------------------------------
+AC_DEFUN([DETECT_CPP11_PROGRAM],
+       [AC_LANG_PROGRAM([[
+            #ifndef __cplusplus
+            #error "This is not a C++ compiler"
+            #elif __cplusplus < 201103L
+            #error "This is not a C++11 compiler"
+            #endif]],
+            [[]])
+])


### PR DESCRIPTION
This is a rethinking of how to handle C++ modes. What it does with this PR:
1. If the **enabled** C++ mode is >= C++11, either by compiler default or because another package's compiler flags enabled it, we continue as-is without explicitly modifying compiler flags concerning the C++ mode.
2. If the **enabled** C++ mode is < C++11, then we modify the compiler flags to see if C++11 is supported. If yes, we force it, print a warning message to the user and continue. If not, then we error out.


Minor other fixes:
1. Removed various AC_LANG_PUSH() macros because at the begining AC_LANG(C++) is already set.
2. Refactored a bit so our compiler flag modifications come after the user's preset one in case of number `2` above. Example case: User runs `CPPFLAGS="-std=c++98" ./configure` with a compiler supporting c++11. The 1st test will fail but the 2nd one will succeed. These changes ensure (or try to) that the correct order will be preserved when outputting `conf.pri.in` (aka c++11 comes after c++98)
3. The indentation of the message for the 2nd test is deliberately at the beginning of each line. Otherwise the `configure` script prints it out broken.
4. Included a formatting fix commit for Boost. It doesn't deserve an independent PR.