### PR TITLE
Show ellipsis when WebUI sidebar is too narrow

### DIFF
--- a/src/webui/www/private/css/style.css
+++ b/src/webui/www/private/css/style.css
@@ -410,6 +410,9 @@ div.formRow {
     padding-left: 5px;
     padding-top: 5px;
     display: block;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }
 
 .filterTitle img {
@@ -430,6 +433,9 @@ ul.filterList {
 
 ul.filterList a {
     display: block;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }
 
 ul.filterList li:hover {

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -97,13 +97,11 @@ window.addEvent('load', function() {
         placement: 'left',
         onResize: saveColumnSizes,
         width: filt_w,
-        resizeLimit: [100, 300]
+        resizeLimit: [1, 300]
     });
     new MochaUI.Column({
         id: 'mainColumn',
-        placement: 'main',
-        width: null,
-        resizeLimit: [100, 300]
+        placement: 'main'
     });
 
     setCategoryFilter = function(hash) {


### PR DESCRIPTION
Also allows the WebUI sidebar to be collapsed (dragged to a width of 1).

Before:
<img width="130" alt="screen shot 2018-11-25 at 2 45 30 pm" src="https://user-images.githubusercontent.com/8296030/48983972-cc334080-f0c3-11e8-8bfd-82fda7d651d9.png">

After:
<img width="130" alt="screen shot 2018-11-25 at 2 45 05 pm" src="https://user-images.githubusercontent.com/8296030/48983974-ce959a80-f0c3-11e8-952b-0c5030bb1f71.png">
