### PR TITLE
Do password hashing properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ before_install:
     if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       qbtconf="$qbtconf --prefix="$qbt_path" PKG_CONFIG_PATH=/opt/qt55/lib/pkgconfig:$PKG_CONFIG_PATH"
     else
-      qbtconf="$qbtconf --prefix="$qbt_path""
+      qbtconf="$qbtconf --prefix="$qbt_path" PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig:$PKG_CONFIG_PATH"
     fi
 
   # options for specific branches
@@ -120,7 +120,8 @@ install:
       # dependencies
       brew update > /dev/null
       brew outdated "pkg-config" || brew upgrade "pkg-config"
-      brew install colormake ccache zlib qt libtorrent-rasterbar
+      brew install colormake ccache zlib qt openssl libtorrent-rasterbar
+
       PATH="/usr/local/opt/ccache/libexec:$PATH"
       brew link --force zlib qt
 
@@ -130,9 +131,9 @@ install:
 
         sudo ln -s /usr/local/opt/qt/mkspecs /usr/local/mkspecs
         sudo ln -s /usr/local/opt/qt/plugins /usr/local/plugins
-      fi
 
-      MY_CMAKE_OPENSSL_HINT="-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl/"
+        MY_CMAKE_OPENSSL_HINT="-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl/"
+      fi
     fi
   - |
     if [ "$TRAVIS_BRANCH" != "$coverity_branch" ]; then
@@ -159,8 +160,8 @@ script:
         # For some reason for RC_1_1 we need to also specify the OpenSSL compiler/linker flags
         # Homebrew doesn't symlink OpenSSL for security reasons
         ./bootstrap.sh
-        ./configure $qbtconf CXXFLAGS="$CXXFLAGS $(PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig:$PKG_CONFIG_PATH" pkg-config --cflags openssl) -std=c++14" \
-          LDFLAGS="$LDFLAGS $(PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig:$PKG_CONFIG_PATH" pkg-config --libs openssl)"
+        ./configure $qbtconf CXXFLAGS="$CXXFLAGS -std=c++14"
+
         sed -i "" -e "s/^\(CC.*&&\).*$/\1 $CC/" src/Makefile  # workaround for Qt & ccache: https://bugreports.qt.io/browse/QTBUG-31034
         sed -i "" -e "s/^\(CXX.*&&\).*$/\1 $CXX/" src/Makefile
         sed -i "" -e 's/^\(CXXFLAGS.*\)$/\1 -Wno-unused-local-typedefs -Wno-inconsistent-missing-override/' src/Makefile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ include(FeatureSummary)
 # version requirements
 set(requiredBoostVersion 1.35)
 set(requiredQtVersion 5.5.1)
+set(requiredOpensslVersion 1.0)
 
 if(WIN32)
     include(winconf)

--- a/configure
+++ b/configure
@@ -601,6 +601,8 @@ EXPAND_BINDIR
 EXPAND_PREFIX
 zlib_LIBS
 zlib_CFLAGS
+openssl_LIBS
+openssl_CFLAGS
 libtorrent_LIBS
 libtorrent_CFLAGS
 BOOST_SYSTEM_LIB
@@ -745,6 +747,8 @@ Qt5Svg_CFLAGS
 Qt5Svg_LIBS
 libtorrent_CFLAGS
 libtorrent_LIBS
+openssl_CFLAGS
+openssl_LIBS
 zlib_CFLAGS
 zlib_LIBS'
 
@@ -1433,6 +1437,10 @@ Some influential environment variables:
               C compiler flags for libtorrent, overriding pkg-config
   libtorrent_LIBS
               linker flags for libtorrent, overriding pkg-config
+  openssl_CFLAGS
+              C compiler flags for openssl, overriding pkg-config
+  openssl_LIBS
+              linker flags for openssl, overriding pkg-config
   zlib_CFLAGS C compiler flags for zlib, overriding pkg-config
   zlib_LIBS   linker flags for zlib, overriding pkg-config
 
@@ -5388,6 +5396,99 @@ else
 $as_echo "yes" >&6; }
 	CXXFLAGS="$libtorrent_CFLAGS $CXXFLAGS"
                   LIBS="$libtorrent_LIBS $LIBS"
+fi
+
+
+pkg_failed=no
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for openssl" >&5
+$as_echo_n "checking for openssl... " >&6; }
+
+if test -n "$openssl_CFLAGS"; then
+    pkg_cv_openssl_CFLAGS="$openssl_CFLAGS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"openssl >= 1.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "openssl >= 1.0") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_openssl_CFLAGS=`$PKG_CONFIG --cflags "openssl >= 1.0" 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+if test -n "$openssl_LIBS"; then
+    pkg_cv_openssl_LIBS="$openssl_LIBS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"openssl >= 1.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "openssl >= 1.0") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_openssl_LIBS=`$PKG_CONFIG --libs "openssl >= 1.0" 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+
+
+
+if test $pkg_failed = yes; then
+   	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+        _pkg_short_errors_supported=yes
+else
+        _pkg_short_errors_supported=no
+fi
+        if test $_pkg_short_errors_supported = yes; then
+	        openssl_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "openssl >= 1.0" 2>&1`
+        else
+	        openssl_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "openssl >= 1.0" 2>&1`
+        fi
+	# Put the nasty error message in config.log where it belongs
+	echo "$openssl_PKG_ERRORS" >&5
+
+	as_fn_error $? "Package requirements (openssl >= 1.0) were not met:
+
+$openssl_PKG_ERRORS
+
+Consider adjusting the PKG_CONFIG_PATH environment variable if you
+installed software in a non-standard prefix.
+
+Alternatively, you may set the environment variables openssl_CFLAGS
+and openssl_LIBS to avoid the need to call pkg-config.
+See the pkg-config man page for more details." "$LINENO" 5
+elif test $pkg_failed = untried; then
+     	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+	{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "The pkg-config script could not be found or is too old.  Make sure it
+is in your PATH or set the PKG_CONFIG environment variable to the full
+path to pkg-config.
+
+Alternatively, you may set the environment variables openssl_CFLAGS
+and openssl_LIBS to avoid the need to call pkg-config.
+See the pkg-config man page for more details.
+
+To get pkg-config, see <http://pkg-config.freedesktop.org/>.
+See \`config.log' for more details" "$LINENO" 5; }
+else
+	openssl_CFLAGS=$pkg_cv_openssl_CFLAGS
+	openssl_LIBS=$pkg_cv_openssl_LIBS
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+	CXXFLAGS="$openssl_CFLAGS $CXXFLAGS"
+                  LIBS="$openssl_LIBS $LIBS"
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -195,6 +195,11 @@ PKG_CHECK_MODULES(libtorrent,
                   [CXXFLAGS="$libtorrent_CFLAGS $CXXFLAGS"
                   LIBS="$libtorrent_LIBS $LIBS"])
 
+PKG_CHECK_MODULES(openssl,
+                  [openssl >= 1.0],
+                  [CXXFLAGS="$openssl_CFLAGS $CXXFLAGS"
+                  LIBS="$openssl_LIBS $LIBS"])
+
 PKG_CHECK_MODULES(zlib,
                  [zlib >= 1.2.5.2],
                  [CXXFLAGS="$zlib_CFLAGS $CXXFLAGS"
@@ -207,7 +212,7 @@ AC_COMPILE_IFELSE([DETECT_CPP11_PROGRAM()],
                    QBT_CXX11_FOUND="yes"],
                   [AC_MSG_RESULT([no])
                    QBT_CXX11_FOUND="no"])
-                  
+
 # In case of no, check if the compiler can support at least C++11
 # and if yes, enable it leaving a warning to the user
 AS_IF([test "x$QBT_CXX11_FOUND" = "xno"],

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ include(QbtTargetSources)
 
 find_package(Boost ${requiredBoostVersion} REQUIRED)
 find_package(LibtorrentRasterbar REQUIRED)
+find_package(OpenSSL ${requiredOpensslVersion} REQUIRED)
 
 if (Boost_VERSION VERSION_LESS 106000)
     add_definitions(-DBOOST_NO_CXX11_RVALUE_REFERENCES)

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -525,8 +525,8 @@ int Application::exec(const QStringList &params)
             .arg(QString("http://localhost:") + QString::number(pref->getWebUiPort())) + '\n'
         + tr("The Web UI administrator user name is: %1").arg(pref->getWebUiUsername()) + '\n';
     printf("%s", qUtf8Printable(mesg));
-    qDebug() << "Password:" << pref->getWebUiPassword();
-    if (pref->getWebUiPassword() == "f6fdffe48c908deb0f4c3bd36c032e72") {
+
+    if (pref->getWebUIPassword() == "ARQ77eY1NUZaQsuDHbIMCA==:0WMRkYTUWVT9wVvdDtHAjU9b3b7uB8NR1Gur2hmQCvCDpm39Q+PsJRJPaCU51dEiz+dTzh8qbPsL8WkFljQYFQ==") {
         const QString warning = tr("The Web UI administrator password is still the default one: %1").arg("adminadmin") + '\n'
             + tr("This is a security risk, please consider changing your password from program preferences.") + '\n';
         printf("%s", qUtf8Printable(warning));

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -522,12 +522,12 @@ int Application::exec(const QStringList &params)
     // Display some information to the user
     const QString mesg = QString("\n******** %1 ********\n").arg(tr("Information"))
         + tr("To control qBittorrent, access the Web UI at %1")
-            .arg(QString("http://localhost:") + QString::number(pref->getWebUiPort())) + '\n'
-        + tr("The Web UI administrator user name is: %1").arg(pref->getWebUiUsername()) + '\n';
+            .arg(QString("http://localhost:") + QString::number(pref->getWebUiPort())) + '\n';
     printf("%s", qUtf8Printable(mesg));
 
     if (pref->getWebUIPassword() == "ARQ77eY1NUZaQsuDHbIMCA==:0WMRkYTUWVT9wVvdDtHAjU9b3b7uB8NR1Gur2hmQCvCDpm39Q+PsJRJPaCU51dEiz+dTzh8qbPsL8WkFljQYFQ==") {
-        const QString warning = tr("The Web UI administrator password is still the default one: %1").arg("adminadmin") + '\n'
+        const QString warning = tr("The Web UI administrator username is: %1").arg(pref->getWebUiUsername()) + '\n'
+            + tr("The Web UI administrator password is still the default one: %1").arg("adminadmin") + '\n'
             + tr("This is a security risk, please consider changing your password from program preferences.") + '\n';
         printf("%s", qUtf8Printable(warning));
     }

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -54,6 +54,7 @@ utils/fs.h
 utils/gzip.h
 utils/misc.h
 utils/net.h
+utils/password.h
 utils/random.h
 utils/string.h
 utils/version.h
@@ -123,6 +124,7 @@ utils/fs.cpp
 utils/gzip.cpp
 utils/misc.cpp
 utils/net.cpp
+utils/password.cpp
 utils/random.cpp
 utils/string.cpp
 asyncfilestorage.cpp

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -69,6 +69,7 @@ HEADERS += \
     $$PWD/utils/gzip.h \
     $$PWD/utils/misc.h \
     $$PWD/utils/net.h \
+    $$PWD/utils/password.h \
     $$PWD/utils/random.h \
     $$PWD/utils/string.h \
     $$PWD/utils/version.h
@@ -133,5 +134,6 @@ SOURCES += \
     $$PWD/utils/gzip.cpp \
     $$PWD/utils/misc.cpp \
     $$PWD/utils/net.cpp \
+    $$PWD/utils/password.cpp \
     $$PWD/utils/random.cpp \
     $$PWD/utils/string.cpp

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -582,28 +582,16 @@ void Preferences::setWebUiUsername(const QString &username)
     setValue("Preferences/WebUI/Username", username);
 }
 
-QString Preferences::getWebUiPassword() const
+QByteArray Preferences::getWebUIPassword() const
 {
-    QString passHa1 = value("Preferences/WebUI/Password_ha1").toString();
-    if (passHa1.isEmpty()) {
-        QCryptographicHash md5(QCryptographicHash::Md5);
-        md5.addData("adminadmin");
-        passHa1 = md5.result().toHex();
-    }
-    return passHa1;
+    // default: adminadmin
+    const QByteArray defaultValue = "ARQ77eY1NUZaQsuDHbIMCA==:0WMRkYTUWVT9wVvdDtHAjU9b3b7uB8NR1Gur2hmQCvCDpm39Q+PsJRJPaCU51dEiz+dTzh8qbPsL8WkFljQYFQ==";
+    return value("Preferences/WebUI/Password_PBKDF2", defaultValue).toByteArray();
 }
 
-void Preferences::setWebUiPassword(const QString &newPassword)
+void Preferences::setWebUIPassword(const QByteArray &password)
 {
-    // Do not overwrite current password with its hash
-    if (newPassword == getWebUiPassword())
-        return;
-
-    // Encode to md5 and save
-    QCryptographicHash md5(QCryptographicHash::Md5);
-    md5.addData(newPassword.toLocal8Bit());
-
-    setValue("Preferences/WebUI/Password_ha1", md5.result().toHex());
+    setValue("Preferences/WebUI/Password_PBKDF2", password);
 }
 
 bool Preferences::isWebUiClickjackingProtectionEnabled() const

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -29,7 +29,6 @@
 
 #include "preferences.h"
 
-#include <QCryptographicHash>
 #include <QDir>
 #include <QLocale>
 #include <QMutableListIterator>
@@ -725,22 +724,14 @@ void Preferences::setDynDNSPassword(const QString &password)
 }
 
 // Advanced settings
-void Preferences::clearUILockPassword()
+QByteArray Preferences::getUILockPassword() const
 {
-    setValue("Locking/password", QString());
+    return value("Locking/password_PBKDF2").toByteArray();
 }
 
-QString Preferences::getUILockPasswordMD5() const
+void Preferences::setUILockPassword(const QByteArray &password)
 {
-    return value("Locking/password").toString();
-}
-
-void Preferences::setUILockPassword(const QString &clearPassword)
-{
-    QCryptographicHash md5(QCryptographicHash::Md5);
-    md5.addData(clearPassword.toLocal8Bit());
-    QString md5Password = md5.result().toHex();
-    setValue("Locking/password", md5Password);
+    setValue("Locking/password_PBKDF2", password);
 }
 
 bool Preferences::isUILocked() const

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -193,8 +193,8 @@ public:
     void setWebUiAuthSubnetWhitelist(QStringList subnets);
     QString getWebUiUsername() const;
     void setWebUiUsername(const QString &username);
-    QString getWebUiPassword() const;
-    void setWebUiPassword(const QString &newPassword);
+    QByteArray getWebUIPassword() const;
+    void setWebUIPassword(const QByteArray &password);
 
     // WebUI security
     bool isWebUiClickjackingProtectionEnabled() const;

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -229,9 +229,8 @@ public:
     void setDynDNSPassword(const QString &password);
 
     // Advanced settings
-    void setUILockPassword(const QString &clearPassword);
-    void clearUILockPassword();
-    QString getUILockPasswordMD5() const;
+    QByteArray getUILockPassword() const;
+    void setUILockPassword(const QByteArray &password);
     bool isUILocked() const;
     void setUILocked(bool locked);
     bool isAutoRunEnabled() const;

--- a/src/base/utils/password.cpp
+++ b/src/base/utils/password.cpp
@@ -1,0 +1,120 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2018  Mike Tzou (Chocobo1)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "password.h"
+
+#include <array>
+
+#include <openssl/evp.h>
+
+#include <QByteArray>
+#include <QList>
+#include <QString>
+
+#include "bytearray.h"
+#include "random.h"
+#include "string.h"
+
+namespace Utils
+{
+    namespace Password
+    {
+        namespace PBKDF2
+        {
+            const int hashIterations = 100000;
+            const auto hashMethod = EVP_sha512();
+        }
+    }
+}
+
+// Implements constant-time comparison to protect against timing attacks
+// Taken from https://crackstation.net/hashing-security.htm
+bool Utils::Password::slowEquals(const QByteArray &a, const QByteArray &b)
+{
+    const int lengthA = a.length();
+    const int lengthB = b.length();
+
+    int diff = lengthA ^ lengthB;
+    for (int i = 0; (i < lengthA) && (i < lengthB); ++i)
+        diff |= a[i] ^ b[i];
+
+    return (diff == 0);
+}
+
+QByteArray Utils::Password::PBKDF2::generate(const QString &password)
+{
+    return generate(password.toUtf8());
+}
+
+QByteArray Utils::Password::PBKDF2::generate(const QByteArray &password)
+{
+    const std::array<uint32_t, 4> salt {{Random::rand(), Random::rand()
+        , Random::rand(), Random::rand()}};
+
+    std::array<unsigned char, 64> outBuf {};
+    const int hmacResult = PKCS5_PBKDF2_HMAC(password.constData(), password.size()
+        , reinterpret_cast<const unsigned char *>(salt.data()), (sizeof(salt[0]) * salt.size())
+        , hashIterations, hashMethod
+        , outBuf.size(), outBuf.data());
+    if (hmacResult != 1)
+        return {};
+
+    const QByteArray saltView = QByteArray::fromRawData(
+        reinterpret_cast<const char *>(salt.data()), (sizeof(salt[0]) * salt.size()));
+    const QByteArray outBufView = QByteArray::fromRawData(
+        reinterpret_cast<const char *>(outBuf.data()), outBuf.size());
+
+    return (saltView.toBase64() + ':' + outBufView.toBase64());
+}
+
+bool Utils::Password::PBKDF2::verify(const QByteArray &secret, const QString &password)
+{
+    return verify(secret, password.toUtf8());
+}
+
+bool Utils::Password::PBKDF2::verify(const QByteArray &secret, const QByteArray &password)
+{
+    const QList<QByteArray> list = ByteArray::splitToViews(secret, ":", QString::SkipEmptyParts);
+    if (list.size() != 2)
+        return false;
+
+    const QByteArray salt = QByteArray::fromBase64(list[0]);
+    const QByteArray key = QByteArray::fromBase64(list[1]);
+
+    std::array<unsigned char, 64> outBuf {};
+    const int hmacResult = PKCS5_PBKDF2_HMAC(password.constData(), password.size()
+        , reinterpret_cast<const unsigned char *>(salt.constData()), salt.size()
+        , hashIterations, hashMethod
+        , outBuf.size(), outBuf.data());
+    if (hmacResult != 1)
+        return false;
+
+    const QByteArray outBufView = QByteArray::fromRawData(
+        reinterpret_cast<const char *>(outBuf.data()), outBuf.size());
+    return slowEquals(key, outBufView);
+}

--- a/src/base/utils/password.h
+++ b/src/base/utils/password.h
@@ -1,7 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015  Vladimir Golovnev <glassez@yandex.ru>
- * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
+ * Copyright (C) 2018  Mike Tzou (Chocobo1)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -27,45 +26,26 @@
  * exception statement from your version.
  */
 
-#ifndef UTILS_STRING_H
-#define UTILS_STRING_H
+#pragma once
 
-#include <QLatin1String>
-#include <QString>
-
-class TriStateBool;
+class QByteArray;
+class QString;
 
 namespace Utils
 {
-    namespace String
+    namespace Password
     {
-        QString fromDouble(double n, int precision);
+        // Implements constant-time comparison to protect against timing attacks
+        // Taken from https://crackstation.net/hashing-security.htm
+        bool slowEquals(const QByteArray &a, const QByteArray &b);
 
-        int naturalCompare(const QString &left, const QString &right, const Qt::CaseSensitivity caseSensitivity);
-        template <Qt::CaseSensitivity caseSensitivity>
-        bool naturalLessThan(const QString &left, const QString &right)
+        namespace PBKDF2
         {
-            return (naturalCompare(left, right, caseSensitivity) < 0);
+            QByteArray generate(const QString &password);
+            QByteArray generate(const QByteArray &password);
+
+            bool verify(const QByteArray &secret, const QString &password);
+            bool verify(const QByteArray &secret, const QByteArray &password);
         }
-
-        QString wildcardToRegex(const QString &pattern);
-
-        template <typename T>
-        T unquote(const T &str, const QString &quotes = QLatin1String("\""))
-        {
-            if (str.length() < 2) return str;
-
-            for (auto const quote : quotes) {
-                if (str.startsWith(quote) && str.endsWith(quote))
-                    return str.mid(1, str.length() - 2);
-            }
-
-            return str;
-        }
-
-        bool parseBool(const QString &string, const bool defaultValue);
-        TriStateBool parseTriStateBool(const QString &string);
     }
 }
-
-#endif // UTILS_STRING_H

--- a/src/base/utils/string.cpp
+++ b/src/base/utils/string.cpp
@@ -31,7 +31,6 @@
 
 #include <cmath>
 
-#include <QByteArray>
 #include <QCollator>
 #include <QLocale>
 #include <QRegExp>
@@ -162,20 +161,6 @@ QString Utils::String::fromDouble(double n, int precision)
 
     double prec = std::pow(10.0, precision);
     return QLocale::system().toString(std::floor(n * prec) / prec, 'f', precision);
-}
-
-// Implements constant-time comparison to protect against timing attacks
-// Taken from https://crackstation.net/hashing-security.htm
-bool Utils::String::slowEquals(const QByteArray &a, const QByteArray &b)
-{
-    int lengthA = a.length();
-    int lengthB = b.length();
-
-    int diff = lengthA ^ lengthB;
-    for (int i = 0; (i < lengthA) && (i < lengthB); ++i)
-        diff |= a[i] ^ b[i];
-
-    return (diff == 0);
 }
 
 // This is marked as internal in QRegExp.cpp, but is exported. The alternative would be to

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -109,7 +109,7 @@ private slots:
     void fullDiskError(BitTorrent::TorrentHandle *const torrent, QString msg) const;
     void handleDownloadFromUrlFailure(QString, QString) const;
     void tabChanged(int newTab);
-    void defineUILockPassword();
+    bool defineUILockPassword();
     void clearUILockPassword();
     bool unlockUI();
     void notifyOfUpdate(QString);

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -59,6 +59,7 @@
 #include "base/torrentfileguard.h"
 #include "base/unicodestrings.h"
 #include "base/utils/fs.h"
+#include "base/utils/password.h"
 #include "base/utils/random.h"
 #include "addnewtorrentdialog.h"
 #include "advancedsettings.h"
@@ -728,7 +729,8 @@ void OptionsDialog::saveOptions()
         }
         // Authentication
         pref->setWebUiUsername(webUiUsername());
-        pref->setWebUiPassword(webUiPassword());
+        if (!webUiPassword().isEmpty())
+            pref->setWebUIPassword(Utils::Password::PBKDF2::generate(webUiPassword()));
         pref->setWebUiLocalAuthEnabled(!m_ui->checkBypassLocalAuth->isChecked());
         pref->setWebUiAuthSubnetWhitelistEnabled(m_ui->checkBypassAuthSubnetWhitelist->isChecked());
         // Security
@@ -1090,7 +1092,6 @@ void OptionsDialog::loadOptions()
     setSslCertificate(pref->getWebUiHttpsCertificate());
     setSslKey(pref->getWebUiHttpsKey());
     m_ui->textWebUiUsername->setText(pref->getWebUiUsername());
-    m_ui->textWebUiPassword->setText(pref->getWebUiPassword());
     m_ui->checkBypassLocalAuth->setChecked(!pref->isWebUiLocalAuthEnabled());
     m_ui->checkBypassAuthSubnetWhitelist->setChecked(pref->isWebUiAuthSubnetWhitelistEnabled());
     m_ui->IPSubnetWhitelistButton->setEnabled(m_ui->checkBypassAuthSubnetWhitelist->isChecked());
@@ -1743,7 +1744,7 @@ bool OptionsDialog::webUIAuthenticationOk()
         QMessageBox::warning(this, tr("Length Error"), tr("The Web UI username must be at least 3 characters long."));
         return false;
     }
-    if (webUiPassword().length() < 6) {
+    if (!webUiPassword().isEmpty() && (webUiPassword().length() < 6)) {
         QMessageBox::warning(this, tr("Length Error"), tr("The Web UI password must be at least 6 characters long."));
         return false;
     }

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -3074,14 +3074,11 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                   </item>
                   <item row="3" column="1">
                    <widget class="QLineEdit" name="textWebUiPassword">
-                    <property name="text">
-                     <string/>
-                    </property>
-                    <property name="maxLength">
-                     <number>1000</number>
-                    </property>
                     <property name="echoMode">
                      <enum>QLineEdit::Password</enum>
+                    </property>
+                    <property name="placeholderText">
+                     <string>Change current password</string>
                     </property>
                    </widget>
                   </item>

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -54,6 +54,7 @@
 #include "base/scanfoldersmodel.h"
 #include "base/utils/fs.h"
 #include "base/utils/net.h"
+#include "base/utils/password.h"
 #include "../webapplication.h"
 
 void AppController::webapiVersionAction()
@@ -198,7 +199,6 @@ void AppController::preferencesAction()
     data["ssl_cert"] = QString::fromLatin1(pref->getWebUiHttpsCertificate());
     // Authentication
     data["web_ui_username"] = pref->getWebUiUsername();
-    data["web_ui_password"] = pref->getWebUiPassword();
     data["bypass_local_auth"] = !pref->isWebUiLocalAuthEnabled();
     data["bypass_auth_subnet_whitelist_enabled"] = pref->isWebUiAuthSubnetWhitelistEnabled();
     QStringList authSubnetWhitelistStringList;
@@ -474,7 +474,7 @@ void AppController::setPreferencesAction()
     if (m.contains("web_ui_username"))
         pref->setWebUiUsername(m["web_ui_username"].toString());
     if (m.contains("web_ui_password"))
-        pref->setWebUiPassword(m["web_ui_password"].toString());
+        pref->setWebUIPassword(Utils::Password::PBKDF2::generate(m["web_ui_password"].toByteArray()));
     if (m.contains("bypass_local_auth"))
         pref->setWebUiLocalAuthEnabled(!m["bypass_local_auth"].toBool());
     if (m.contains("bypass_auth_subnet_whitelist_enabled"))

--- a/src/webui/www/private/preferences_content.html
+++ b/src/webui/www/private/preferences_content.html
@@ -433,7 +433,8 @@
                 <label for="webui_username_text" class="leftLabelSmall">QBT_TR(Username:)QBT_TR[CONTEXT=OptionsDialog]</label><input type="text" id="webui_username_text" />
             </div>
             <div class="formRow">
-                <label for="webui_password_text" class="leftLabelSmall">QBT_TR(Password:)QBT_TR[CONTEXT=OptionsDialog]</label><input type="password" id="webui_password_text" />
+                <label for="webui_password_text" class="leftLabelSmall">QBT_TR(Password:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                <input type="password" id="webui_password_text" placeholder="QBT_TR(Change current password)QBT_TR[CONTEXT=OptionsDialog]" />
             </div>
             <div class="formRow">
                 <input type="checkbox" id="bypass_local_auth_checkbox" />
@@ -980,7 +981,6 @@
 
                     // Authentication
                     $('webui_username_text').setProperty('value', pref.web_ui_username);
-                    $('webui_password_text').setProperty('value', pref.web_ui_password);
                     $('bypass_local_auth_checkbox').setProperty('checked', pref.bypass_local_auth);
                     $('bypass_auth_subnet_whitelist_checkbox').setProperty('checked', pref.bypass_auth_subnet_whitelist_enabled);
                     $('bypass_auth_subnet_whitelist_textarea').setProperty('value', pref.bypass_auth_subnet_whitelist);
@@ -1264,12 +1264,14 @@
             return;
         }
         var web_ui_password = $('webui_password_text').getProperty('value');
-        if (web_ui_password.length < 6) {
+        if ((0 < web_ui_password.length) && (web_ui_password.length < 6)) {
             alert("QBT_TR(The Web UI password must be at least 6 characters long.)QBT_TR[CONTEXT=OptionsDialog]");
             return;
         }
+
         settings.set('web_ui_username', web_ui_username);
-        settings.set('web_ui_password', web_ui_password);
+        if (web_ui_password.length > 0)
+            settings.set('web_ui_password', web_ui_password);
         settings.set('bypass_local_auth', $('bypass_local_auth_checkbox').getProperty('checked'));
         settings.set('bypass_auth_subnet_whitelist_enabled', $('bypass_auth_subnet_whitelist_checkbox').getProperty('checked'));
         settings.set('bypass_auth_subnet_whitelist', $('bypass_auth_subnet_whitelist_textarea').getProperty('value'));


### PR DESCRIPTION
Some notes:
* openssl >= 1.0 is now a required dependency.
* This PR makes stored password hash very much harder to crack compared to previously used method.
  This basically means even if bad actor acquired your password hash, he won't be able to easily compute your real password (assuming the real password is good enough for brute force attack).
* UI changes: [GUI](https://user-images.githubusercontent.com/9395168/49236436-135c6100-f437-11e8-913e-f5c8f9ab384c.png), [WebUI](https://user-images.githubusercontent.com/9395168/49236438-135c6100-f437-11e8-967f-95b72df29e59.png)
* PBKDF2 is chosen because qbt already uses openssl which saves us from adding another library, and also it is the only method openssl implemented AFAIK.
* PBKDF2 parameters are chosen to be in line with 1password settings: https://support.1password.com/pbkdf2/
* I've not provide mitigation code yet, that is, user need to change the password from the default one after upgrading, is this really required?
