### PR TITLE
Fix JavaScript error

### DIFF
--- a/src/webui/www/private/properties_content.html
+++ b/src/webui/www/private/properties_content.html
@@ -149,5 +149,7 @@
 
 <script>
     torrentPeersTable.setup('torrentPeersTableDiv', 'torrentPeersTableFixedHeaderDiv', null);
-    $(getLocalStorageItem('selected_tab', 'PropGeneralLink')).click();
+    var selectedTab = $(getLocalStorageItem('selected_tab', 'PropGeneralLink'));
+    if (selectedTab)
+        selectedTab.click();
 </script>


### PR DESCRIPTION
Fixes a JavaScript error caused by the element lookup returning null

![screen shot 2018-12-07 at 6 14 54 pm](https://user-images.githubusercontent.com/8296030/49678019-e835cb00-fa4f-11e8-998a-94f10c17901b.png)
