### PR TITLE
Unify translation files loading action

### DIFF
--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -146,6 +146,7 @@ private:
     QMap<QString, TranslatedFile> m_translatedFiles;
     QString m_currentLocale;
     QTranslator m_translator;
+    bool m_translationFileLoaded = false;
 
     bool m_isLocalAuthEnabled;
     bool m_isAuthSubnetWhitelistEnabled;

--- a/src/webui/www/translations/webui_en.ts
+++ b/src/webui/www/translations/webui_en.ts
@@ -5,7 +5,7 @@
     <name>AboutDlg</name>
     <message>
         <source>About</source>
-        <translation type="unfinished" />
+        <translation>About</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Since it is possible alternative WebUI could be coded in languages other than English, WebUI must be able to load user-provided webui_en.qm.
