### PR TITLE
Don't process webui translation files many times

### DIFF
--- a/qbittorrent.pro
+++ b/qbittorrent.pro
@@ -20,6 +20,7 @@ QMAKE_EXTRA_TARGETS += tarball
 # Translations included here (at top level) is to avoid regenerating the .qm files
 # every time when src.pro is processed
 include(src/lang/lang.pri)
+!nowebui: include(src/webui/www/translations/lang.pri)
 
 # For Qt Creator beautifier
 DISTFILES += \

--- a/src/webui/webui.pri
+++ b/src/webui/webui.pri
@@ -32,25 +32,3 @@ SOURCES += \
     $$PWD/webui.cpp
 
 RESOURCES += $$PWD/www/webui.qrc $$PWD/www/translations/webui_translations.qrc
-
-# WebUI Translation
-isEmpty(QMAKE_LRELEASE) {
-    win32: QMAKE_LRELEASE = $$[QT_INSTALL_BINS]/lrelease.exe
-    else: QMAKE_LRELEASE = $$[QT_INSTALL_BINS]/lrelease
-    unix {
-        equals(QT_MAJOR_VERSION, 5) {
-            !exists($$QMAKE_LRELEASE): QMAKE_LRELEASE = lrelease-qt5
-        }
-    }
-    else {
-        !exists($$QMAKE_LRELEASE): QMAKE_LRELEASE = lrelease
-    }
-}
-WEBUI_TRANSLATIONS = $$files(www/translations/webui_*.ts)
-WEBUI_TRANSLATIONS_NOEXT = $$replace(WEBUI_TRANSLATIONS, ".ts", "")
-message("Building WebUI translations...")
-for(L, WEBUI_TRANSLATIONS_NOEXT) {
-    message("Processing $${L}")
-    system("$$QMAKE_LRELEASE -silent $${L}.ts -qm $${L}.qm")
-    !exists("$${L}.qm"): error("Building WebUI translations failed, cannot continue!")
-}

--- a/src/webui/www/translations/lang.pri
+++ b/src/webui/www/translations/lang.pri
@@ -1,0 +1,22 @@
+# WebUI Translation
+isEmpty(QMAKE_LRELEASE) {
+    win32: QMAKE_LRELEASE = $$[QT_INSTALL_BINS]/lrelease.exe
+    else: QMAKE_LRELEASE = $$[QT_INSTALL_BINS]/lrelease
+    unix {
+        equals(QT_MAJOR_VERSION, 5) {
+            !exists($$QMAKE_LRELEASE): QMAKE_LRELEASE = lrelease-qt5
+        }
+    }
+    else {
+        !exists($$QMAKE_LRELEASE): QMAKE_LRELEASE = lrelease
+    }
+}
+
+WEBUI_TRANSLATIONS = $$files(webui_*.ts)
+WEBUI_TRANSLATIONS_NOEXT = $$replace(WEBUI_TRANSLATIONS, ".ts", "")
+message("Building WebUI translations...")
+for(L, WEBUI_TRANSLATIONS_NOEXT) {
+    message("Processing $${L}")
+    system("$$QMAKE_LRELEASE -silent $${L}.ts -qm $${L}.qm")
+    !exists("$${L}.qm"): error("Building WebUI translations failed, cannot continue!")
+}


### PR DESCRIPTION
At least on windows webui_*.ts files were processed many times before each build adding measurable delays in the build time.
So I mimicked what we do with qbittorrent_*.ts files and it seems to work fine.