### PR TITLE
Mark constructors as explicit

### DIFF
--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -55,7 +55,7 @@ namespace
     class Option
     {
     protected:
-        constexpr Option(const char *name, char shortcut = 0)
+        explicit constexpr Option(const char *name, char shortcut = 0)
             : m_name {name}
             , m_shortcut {shortcut}
         {
@@ -102,7 +102,7 @@ namespace
     class BoolOption : protected Option
     {
     public:
-        constexpr BoolOption(const char *name, char shortcut = 0)
+        explicit constexpr BoolOption(const char *name, char shortcut = 0)
             : Option {name, shortcut}
         {
         }
@@ -139,7 +139,7 @@ namespace
     struct StringOption : protected Option
     {
     public:
-        constexpr StringOption(const char *name)
+        explicit constexpr StringOption(const char *name)
             : Option {name, 0}
         {
         }
@@ -186,7 +186,7 @@ namespace
     class IntOption : protected StringOption
     {
     public:
-        constexpr IntOption(const char *name)
+        explicit constexpr IntOption(const char *name)
             : StringOption {name}
         {
         }
@@ -305,25 +305,25 @@ namespace
         return o == s;
     }
 
-    constexpr const BoolOption SHOW_HELP_OPTION = {"help", 'h'};
-    constexpr const BoolOption SHOW_VERSION_OPTION = {"version", 'v'};
+    constexpr const BoolOption SHOW_HELP_OPTION {"help", 'h'};
+    constexpr const BoolOption SHOW_VERSION_OPTION {"version", 'v'};
 #ifdef DISABLE_GUI
-    constexpr const BoolOption DAEMON_OPTION = {"daemon", 'd'};
+    constexpr const BoolOption DAEMON_OPTION {"daemon", 'd'};
 #else
-    constexpr const BoolOption NO_SPLASH_OPTION = {"no-splash"};
+    constexpr const BoolOption NO_SPLASH_OPTION {"no-splash"};
 #endif
-    constexpr const IntOption WEBUI_PORT_OPTION = {"webui-port"};
-    constexpr const StringOption PROFILE_OPTION = {"profile"};
-    constexpr const StringOption CONFIGURATION_OPTION = {"configuration"};
-    constexpr const BoolOption PORTABLE_OPTION = {"portable"};
-    constexpr const BoolOption RELATIVE_FASTRESUME = {"relative-fastresume"};
-    constexpr const StringOption SAVE_PATH_OPTION = {"save-path"};
-    constexpr const TriStateBoolOption PAUSED_OPTION = {"add-paused", true};
-    constexpr const BoolOption SKIP_HASH_CHECK_OPTION = {"skip-hash-check"};
-    constexpr const StringOption CATEGORY_OPTION = {"category"};
-    constexpr const BoolOption SEQUENTIAL_OPTION = {"sequential"};
-    constexpr const BoolOption FIRST_AND_LAST_OPTION = {"first-and-last"};
-    constexpr const TriStateBoolOption SKIP_DIALOG_OPTION = {"skip-dialog", true};
+    constexpr const IntOption WEBUI_PORT_OPTION {"webui-port"};
+    constexpr const StringOption PROFILE_OPTION {"profile"};
+    constexpr const StringOption CONFIGURATION_OPTION {"configuration"};
+    constexpr const BoolOption PORTABLE_OPTION {"portable"};
+    constexpr const BoolOption RELATIVE_FASTRESUME {"relative-fastresume"};
+    constexpr const StringOption SAVE_PATH_OPTION {"save-path"};
+    constexpr const TriStateBoolOption PAUSED_OPTION {"add-paused", true};
+    constexpr const BoolOption SKIP_HASH_CHECK_OPTION {"skip-hash-check"};
+    constexpr const StringOption CATEGORY_OPTION {"category"};
+    constexpr const BoolOption SEQUENTIAL_OPTION {"sequential"};
+    constexpr const BoolOption FIRST_AND_LAST_OPTION {"first-and-last"};
+    constexpr const TriStateBoolOption SKIP_DIALOG_OPTION {"skip-dialog", true};
 }
 
 QBtCommandLineParameters::QBtCommandLineParameters(const QProcessEnvironment &env)

--- a/src/app/cmdoptions.h
+++ b/src/app/cmdoptions.h
@@ -56,14 +56,14 @@ struct QBtCommandLineParameters
     QStringList torrents;
     QString profileDir, configurationName, savePath, category, unknownParameter;
 
-    QBtCommandLineParameters(const QProcessEnvironment&);
+    explicit QBtCommandLineParameters(const QProcessEnvironment&);
     QStringList paramList() const;
 };
 
 class CommandLineParameterError : public std::runtime_error
 {
 public:
-    CommandLineParameterError(const QString &messageForUser);
+    explicit CommandLineParameterError(const QString &messageForUser);
     const QString &messageForUser() const;
 
 private:

--- a/src/base/bittorrent/infohash.cpp
+++ b/src/base/bittorrent/infohash.cpp
@@ -28,6 +28,7 @@
 
 #include "infohash.h"
 
+#include <QByteArray>
 #include <QHash>
 
 using namespace BitTorrent;
@@ -41,28 +42,24 @@ InfoHash::InfoHash(const libtorrent::sha1_hash &nativeHash)
     : m_valid(true)
     , m_nativeHash(nativeHash)
 {
-    char out[(libtorrent::sha1_hash::size * 2) + 1];
-    libtorrent::to_hex(reinterpret_cast<const char*>(&m_nativeHash[0]), libtorrent::sha1_hash::size, out);
-    m_hashString = QString(out);
+    const QByteArray raw = QByteArray::fromRawData(nativeHash.data(), libtorrent::sha1_hash::size);
+    m_hashString = QString::fromLatin1(raw.toHex());
 }
 
 InfoHash::InfoHash(const QString &hashString)
     : m_valid(false)
-    , m_hashString(hashString)
 {
-    QByteArray raw = m_hashString.toLatin1();
-    if (raw.size() == 40)
-        m_valid = libtorrent::from_hex(raw.constData(), 40, reinterpret_cast<char*>(&m_nativeHash[0]));
+    if (hashString.size() != (libtorrent::sha1_hash::size * 2))
+        return;
+
+    const QByteArray raw = QByteArray::fromHex(hashString.toLatin1());
+    if (raw.size() != libtorrent::sha1_hash::size)  // QByteArray::fromHex() will skip over invalid characters
+        return;
+
+    m_valid = true;
+    m_hashString = hashString;
+    m_nativeHash.assign(raw.constData());
 }
-
-
-InfoHash::InfoHash(const InfoHash &other)
-    : m_valid(other.m_valid)
-    , m_nativeHash(other.m_nativeHash)
-    , m_hashString(other.m_hashString)
-{
-}
-
 
 bool InfoHash::isValid() const
 {
@@ -74,25 +71,23 @@ InfoHash::operator libtorrent::sha1_hash() const
     return m_nativeHash;
 }
 
-
 InfoHash::operator QString() const
 {
     return m_hashString;
 }
 
-
-bool InfoHash::operator==(const InfoHash &other) const
+bool BitTorrent::operator==(const InfoHash &left, const InfoHash &right)
 {
-    return (m_nativeHash == other.m_nativeHash);
+    return (static_cast<libtorrent::sha1_hash>(left)
+            == static_cast<libtorrent::sha1_hash>(right));
 }
 
-
-bool InfoHash::operator!=(const InfoHash &other) const
+bool BitTorrent::operator!=(const InfoHash &left, const InfoHash &right)
 {
-    return (m_nativeHash != other.m_nativeHash);
+    return !(left == right);
 }
 
-uint BitTorrent::qHash(const InfoHash &key, uint seed)
+uint BitTorrent::qHash(const InfoHash &key, const uint seed)
 {
-    return qHash(static_cast<QString>(key), seed);
+    return ::qHash(static_cast<QString>(key), seed);
 }

--- a/src/base/bittorrent/infohash.h
+++ b/src/base/bittorrent/infohash.h
@@ -40,14 +40,12 @@ namespace BitTorrent
         InfoHash();
         InfoHash(const libtorrent::sha1_hash &nativeHash);
         InfoHash(const QString &hashString);
-        InfoHash(const InfoHash &other);
+        InfoHash(const InfoHash &other) = default;
 
         bool isValid() const;
 
         operator libtorrent::sha1_hash() const;
         operator QString() const;
-        bool operator==(const InfoHash &other) const;
-        bool operator!=(const InfoHash &other) const;
 
     private:
         bool m_valid;
@@ -55,6 +53,8 @@ namespace BitTorrent
         QString m_hashString;
     };
 
+    bool operator==(const InfoHash &left, const InfoHash &right);
+    bool operator!=(const InfoHash &left, const InfoHash &right);
     uint qHash(const InfoHash &key, uint seed);
 }
 

--- a/src/base/bittorrent/private/statistics.h
+++ b/src/base/bittorrent/private/statistics.h
@@ -15,7 +15,7 @@ class Statistics : public QObject
     Q_DISABLE_COPY(Statistics)
 
 public:
-    Statistics(BitTorrent::Session *session);
+    explicit Statistics(BitTorrent::Session *session);
     ~Statistics();
 
     quint64 getAlltimeDL() const;

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -113,7 +113,7 @@ namespace BitTorrent
         int seedingTimeLimit;
 
         CreateTorrentParams();
-        CreateTorrentParams(const AddTorrentParams &params);
+        explicit CreateTorrentParams(const AddTorrentParams &params);
     };
 
     struct TrackerInfo

--- a/src/base/bittorrent/trackerentry.cpp
+++ b/src/base/bittorrent/trackerentry.cpp
@@ -29,24 +29,17 @@
 #include "trackerentry.h"
 
 #include <QString>
-
-#include "base/utils/misc.h"
-#include "base/utils/string.h"
+#include <QUrl>
 
 using namespace BitTorrent;
 
 TrackerEntry::TrackerEntry(const QString &url)
-    : m_nativeEntry(libtorrent::announce_entry(url.toStdString()))
+    : m_nativeEntry(url.toStdString())
 {
 }
 
 TrackerEntry::TrackerEntry(const libtorrent::announce_entry &nativeEntry)
     : m_nativeEntry(nativeEntry)
-{
-}
-
-TrackerEntry::TrackerEntry(const TrackerEntry &other)
-    : m_nativeEntry(other.m_nativeEntry)
 {
 }
 
@@ -74,23 +67,17 @@ TrackerEntry::Status TrackerEntry::status() const
         return NotWorking;
 }
 
-void TrackerEntry::setTier(int value)
+void TrackerEntry::setTier(const int value)
 {
     m_nativeEntry.tier = value;
-}
-
-TrackerEntry &TrackerEntry::operator=(const TrackerEntry &other)
-{
-    this->m_nativeEntry = other.m_nativeEntry;
-    return *this;
-}
-
-bool TrackerEntry::operator==(const TrackerEntry &other) const
-{
-    return (QUrl(url()) == QUrl(other.url()));
 }
 
 libtorrent::announce_entry TrackerEntry::nativeEntry() const
 {
     return m_nativeEntry;
+}
+
+bool BitTorrent::operator==(const TrackerEntry &left, const TrackerEntry &right)
+{
+    return (QUrl(left.url()) == QUrl(right.url()));
 }

--- a/src/base/bittorrent/trackerentry.h
+++ b/src/base/bittorrent/trackerentry.h
@@ -52,21 +52,22 @@ namespace BitTorrent
 
         TrackerEntry(const QString &url);
         TrackerEntry(const libtorrent::announce_entry &nativeEntry);
-        TrackerEntry(const TrackerEntry &other);
+        TrackerEntry(const TrackerEntry &other) = default;
+        TrackerEntry &operator=(const TrackerEntry &other) = default;
 
         QString url() const;
-        int tier() const;
         Status status() const;
 
+        int tier() const;
         void setTier(int value);
-        TrackerEntry &operator=(const TrackerEntry &other);
-        bool operator==(const TrackerEntry &other) const;
 
         libtorrent::announce_entry nativeEntry() const;
 
     private:
         libtorrent::announce_entry m_nativeEntry;
     };
+
+    bool operator==(const TrackerEntry &left, const TrackerEntry &right);
 }
 
 #endif // BITTORRENT_TRACKERENTRY_H

--- a/src/base/net/private/geoipdatabase.h
+++ b/src/base/net/private/geoipdatabase.h
@@ -55,7 +55,7 @@ public:
     QString lookup(const QHostAddress &hostAddr) const;
 
 private:
-    GeoIPDatabase(quint32 size);
+    explicit GeoIPDatabase(quint32 size);
 
     bool parseMetadata(const QVariantHash &metadata, QString &error);
     bool loadDB(QString &error) const;

--- a/src/base/private/profile_p.h
+++ b/src/base/private/profile_p.h
@@ -55,7 +55,7 @@ namespace Private
         QString profileName() const;
 
     protected:
-        Profile(const QString &configurationName);
+        explicit Profile(const QString &configurationName);
 
         QString configurationSuffix() const;
     private:
@@ -66,7 +66,7 @@ namespace Private
     class DefaultProfile : public Profile
     {
     public:
-        DefaultProfile(const QString &configurationName);
+        explicit DefaultProfile(const QString &configurationName);
 
         QString baseDirectory() const override;
         QString cacheLocation() const override;
@@ -124,7 +124,7 @@ namespace Private
     class Converter : public PathConverter
     {
     public:
-        Converter(const QString &basePath);
+        explicit Converter(const QString &basePath);
         QString toPortablePath(const QString &path) const override;
         QString fromPortablePath(const QString &portablePath) const override;
 

--- a/src/base/rss/rss_feed.cpp
+++ b/src/base/rss/rss_feed.cpp
@@ -131,7 +131,7 @@ void Feed::refresh()
 
     // NOTE: Should we allow manually refreshing for disabled session?
 
-    Net::DownloadHandler *handler = Net::DownloadManager::instance()->download({m_url});
+    Net::DownloadHandler *handler = Net::DownloadManager::instance()->download(m_url);
     connect(handler
             , static_cast<void (Net::DownloadHandler::*)(const QString &, const QByteArray &)>(&Net::DownloadHandler::downloadFinished)
             , this, &Feed::handleDownloadFinished);

--- a/src/base/settingsstorage.cpp
+++ b/src/base/settingsstorage.cpp
@@ -46,7 +46,7 @@ namespace
     class TransactionalSettings
     {
     public:
-        TransactionalSettings(const QString &name)
+        explicit TransactionalSettings(const QString &name)
             : m_name(name)
         {
         }

--- a/src/base/torrentfileguard.h
+++ b/src/base/torrentfileguard.h
@@ -38,7 +38,7 @@ template <typename T> class CachedSettingValue;
 class FileGuard
 {
 public:
-    FileGuard(const QString &path = QString());
+    explicit FileGuard(const QString &path = QString());
     ~FileGuard();
 
     /// Cancels or re-enables deferred file deletion
@@ -56,7 +56,7 @@ class TorrentFileGuard : private FileGuard
     Q_GADGET
 
 public:
-    TorrentFileGuard(const QString &path = QString());
+    explicit TorrentFileGuard(const QString &path = QString());
     ~TorrentFileGuard();
 
     /// marks the torrent file as loaded (added) into the BitTorrent::Session

--- a/src/gui/properties/proplistdelegate.h
+++ b/src/gui/properties/proplistdelegate.h
@@ -53,7 +53,7 @@ class PropListDelegate : public QItemDelegate
     Q_OBJECT
 
 public:
-    PropListDelegate(PropertiesWidget *properties);
+    explicit PropListDelegate(PropertiesWidget *properties);
 
     void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
     void setEditorData(QWidget *editor, const QModelIndex &index) const override;

--- a/src/gui/properties/speedwidget.h
+++ b/src/gui/properties/speedwidget.h
@@ -59,7 +59,7 @@ class SpeedWidget : public QWidget
     Q_OBJECT
 
 public:
-    SpeedWidget(PropertiesWidget *parent);
+    explicit SpeedWidget(PropertiesWidget *parent);
     ~SpeedWidget();
 
 private slots:

--- a/src/gui/properties/trackerlistwidget.h
+++ b/src/gui/properties/trackerlistwidget.h
@@ -63,7 +63,7 @@ public:
         COL_COUNT
     };
 
-    TrackerListWidget(PropertiesWidget *properties);
+    explicit TrackerListWidget(PropertiesWidget *properties);
     ~TrackerListWidget();
 
     int visibleColumnsCount() const;

--- a/src/gui/properties/trackersadditiondialog.cpp
+++ b/src/gui/properties/trackersadditiondialog.cpp
@@ -71,7 +71,7 @@ QStringList TrackersAdditionDialog::newTrackers() const
 void TrackersAdditionDialog::on_uTorrentListButton_clicked()
 {
     m_ui->uTorrentListButton->setEnabled(false);
-    Net::DownloadHandler *handler = Net::DownloadManager::instance()->download({m_ui->lineEditListURL->text()});
+    Net::DownloadHandler *handler = Net::DownloadManager::instance()->download(m_ui->lineEditListURL->text());
     connect(handler, static_cast<void (Net::DownloadHandler::*)(const QString &, const QByteArray &)>(&Net::DownloadHandler::downloadFinished)
             , this, &TrackersAdditionDialog::parseUTorrentList);
     connect(handler, &Net::DownloadHandler::downloadFailed, this, &TrackersAdditionDialog::getTrackerError);

--- a/src/gui/torrentcontentmodelfolder.h
+++ b/src/gui/torrentcontentmodelfolder.h
@@ -39,7 +39,7 @@ public:
     TorrentContentModelFolder(const QString &name, TorrentContentModelFolder *parent);
 
     // Invisible root item constructor
-    TorrentContentModelFolder(const QList<QVariant> &data);
+    explicit TorrentContentModelFolder(const QList<QVariant> &data);
 
     ~TorrentContentModelFolder() override;
 

--- a/src/gui/torrentcontentmodelitem.h
+++ b/src/gui/torrentcontentmodelitem.h
@@ -56,7 +56,7 @@ public:
         FolderType
     };
 
-    TorrentContentModelItem(TorrentContentModelFolder *parent);
+    explicit TorrentContentModelItem(TorrentContentModelFolder *parent);
     virtual ~TorrentContentModelItem();
 
     bool isRootItem() const;


### PR DESCRIPTION
Marking it as explicit makes the object construction step more... explicit, do we really want this? I'm open to ideas.