### PR TITLE
Fix regression on resuming torrents without metadata

### DIFF
--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -224,7 +224,7 @@ TorrentHandle::TorrentHandle(Session *session, const libtorrent::torrent_handle 
     if (params.paused) {
         m_startupState = Started;
     }
-    else if (!params.restored) {
+    else if (!params.restored || !hasMetadata()) {
         // Resume torrent because it was added in "resumed" state
         // but it's actually paused during initialization
         m_startupState = Starting;


### PR DESCRIPTION
Resume torrents without metadata if they weren't paused.

Closes #10031