### PR TITLE
Cleanup Info.plist

### DIFF
--- a/dist/mac/Info.plist
+++ b/dist/mac/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>qBittorrent</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>
@@ -21,6 +25,10 @@
 			<array>
 				<string>org.bittorrent.torrent</string>
 			</array>
+			<key>NSExportableTypes</key>
+			<array>
+				<string>org.bittorrent.torrent</string>
+			</array>
 			<key>LSIsAppleDefaultForType</key>
 			<true/>
 		</dict>
@@ -28,6 +36,8 @@
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>magnet</string>
@@ -46,20 +56,18 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>4.2.0</string>
-	<key>CFBundleSignature</key>
-	<string>qBit</string>
 	<key>CFBundleExecutable</key>
 	<string>@EXECUTABLE@</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.qbittorrent</string>
+	<string>org.qbittorrent.qBittorrent</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>${MACOSX_DEPLOYMENT_TARGET}.0</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-	<key>NSHighResolutionCapable</key>
-	<string>True</string>
 	<key>NSAppleScriptEnabled</key>
 	<string>YES</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2006-2018 The qBittorrent project</string>
+	<string>Copyright © 2006-2019 The qBittorrent project</string>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Added few required/recommended and removed obsolete/deprecated keys according to [Apple developers documentation](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/AboutInformationPropertyListFiles.html).

- [more info about CF* keys](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/TP40009249-SW1)
- [more info about **NSAppTransportSecurity** key](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW33)

I'm not an experienced macOS developer, I'm just enthusiast, which mostly writes software in Qt. so I changed Info.plist based on my own experience + analyzed few default macOS programs and read the docs to make the final decision. review from any experienced macOS developer is appreciated.

**LSMinimumSystemVersion** value was got based on own experience. According to [documentation](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/20001431-113253) , it requires "three numbers version format", but [qmake](http://doc.qt.io/qt-5/qmake-variable-reference.html#qmake-macosx-deployment-target) produces only two numbers (i.e. major and minor, checked experimentally), so I hardcoded "thrird zero". this maybe looks slightly strange, but this is replaced correctly. and nothing strange in terms of bash...

**NSHighResolutionCapable** has no effect anymore at least with Qt 5.6 release. I also found and used it for my software in 2014, but I dropped it long time ago and have no issues on Retina display. moreover, this key is undocumented, and possibly now is not supported at all.
Qt apps build with Qt 5.6 on Mavericks have no issues without this key, app with newer Qt on newer macOS look even better.

finally few words about why I added "magic" **NSAppTransportSecurity** key. recently I wrote stream media player and first problem I faced it was unable to connect to any http resource... I tried to download few random html pages (also from http) and this also didn't work. httpS worked fine. I saw some output in console, so that was a tip for right direction. than I found this key.
I think that such software as a torrent client *must have* this key in Info.plist, because it must be able to download anything from anywhere. I think at least RSS downloader and torrent metadata download may be affected, but I can't confirm: I never used RSS and very rarely used magnet links on macOS using qBittorrent. updater also will be affected if it uses pure http link and QNetworkManager to fetch it. so in any case this key will not harm anything.