### PR TITLE
Drop support for "BC Link" format

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -2094,7 +2094,7 @@ bool Session::addTorrent(const QString &source, const AddTorrentParams &params)
 {
     // `source`: .torrent file path/url or magnet uri
 
-    if (Utils::Misc::isUrl(source)) {
+    if (Net::DownloadManager::hasSupportedScheme(source)) {
         LogMsg(tr("Downloading '%1', please wait...", "e.g: Downloading 'xxx.torrent', please wait...").arg(source));
         // Launch downloader
         Net::DownloadHandler *handler =

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -2090,12 +2090,9 @@ TorrentStatusReport Session::torrentStatusReport() const
     return m_torrentStatusReport;
 }
 
-// source - .torrent file path/url or magnet uri
-bool Session::addTorrent(QString source, const AddTorrentParams &params)
+bool Session::addTorrent(const QString &source, const AddTorrentParams &params)
 {
-    MagnetUri magnetUri(source);
-    if (magnetUri.isValid())
-        return addTorrent_impl(CreateTorrentParams(params), magnetUri);
+    // `source`: .torrent file path/url or magnet uri
 
     if (Utils::Misc::isUrl(source)) {
         LogMsg(tr("Downloading '%1', please wait...", "e.g: Downloading 'xxx.torrent', please wait...").arg(source));
@@ -2109,6 +2106,10 @@ bool Session::addTorrent(QString source, const AddTorrentParams &params)
         m_downloadedTorrents[handler->url()] = params;
         return true;
     }
+
+    const MagnetUri magnetUri {source};
+    if (magnetUri.isValid())
+        return addTorrent_impl(CreateTorrentParams(params), magnetUri);
 
     TorrentFileGuard guard(source);
     if (addTorrent_impl(CreateTorrentParams(params)

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -469,7 +469,7 @@ namespace BitTorrent
         void banIP(const QString &ip);
 
         bool isKnownTorrent(const InfoHash &hash) const;
-        bool addTorrent(QString source, const AddTorrentParams &params = AddTorrentParams());
+        bool addTorrent(const QString &source, const AddTorrentParams &params = AddTorrentParams());
         bool addTorrent(const TorrentInfo &torrentInfo, const AddTorrentParams &params = AddTorrentParams());
         bool deleteTorrent(const QString &hash, bool deleteLocalFiles = false);
         bool loadMetadata(const MagnetUri &magnetUri);

--- a/src/base/net/downloadmanager.cpp
+++ b/src/base/net/downloadmanager.cpp
@@ -29,6 +29,8 @@
 
 #include "downloadmanager.h"
 
+#include <algorithm>
+
 #include <QDateTime>
 #include <QDebug>
 #include <QNetworkCookie>
@@ -208,6 +210,15 @@ void Net::DownloadManager::setAllCookies(const QList<QNetworkCookie> &cookieList
 bool Net::DownloadManager::deleteCookie(const QNetworkCookie &cookie)
 {
     return static_cast<NetworkCookieJar *>(m_networkManager.cookieJar())->deleteCookie(cookie);
+}
+
+bool Net::DownloadManager::hasSupportedScheme(const QString &url)
+{
+    const QStringList schemes = instance()->m_networkManager.supportedSchemes();
+    return std::any_of(schemes.cbegin(), schemes.cend(), [&url](const QString &scheme)
+    {
+        return url.startsWith((scheme + QLatin1Char(':')), Qt::CaseInsensitive);
+    });
 }
 
 void Net::DownloadManager::applyProxySettings()

--- a/src/base/net/downloadmanager.h
+++ b/src/base/net/downloadmanager.h
@@ -103,6 +103,8 @@ namespace Net
         void setAllCookies(const QList<QNetworkCookie> &cookieList);
         bool deleteCookie(const QNetworkCookie &cookie);
 
+        static bool hasSupportedScheme(const QString &url);
+
     private slots:
     #ifndef QT_NO_OPENSSL
         void ignoreSslErrors(QNetworkReply *, const QList<QSslError> &);

--- a/src/base/search/searchpluginmanager.cpp
+++ b/src/base/search/searchpluginmanager.cpp
@@ -50,7 +50,6 @@
 #include "base/utils/bytearray.h"
 #include "base/utils/foreignapps.h"
 #include "base/utils/fs.h"
-#include "base/utils/misc.h"
 #include "searchdownloadhandler.h"
 #include "searchhandler.h"
 
@@ -198,7 +197,7 @@ void SearchPluginManager::installPlugin(const QString &source)
 {
     clearPythonCache(engineLocation());
 
-    if (Utils::Misc::isUrl(source)) {
+    if (Net::DownloadManager::hasSupportedScheme(source)) {
         using namespace Net;
         DownloadHandler *handler = DownloadManager::instance()->download(DownloadRequest(source).saveToFile(true));
         connect(handler, static_cast<void (DownloadHandler::*)(const QString &, const QString &)>(&DownloadHandler::downloadFinished)

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -414,14 +414,6 @@ QList<bool> Utils::Misc::boolListfromStringList(const QStringList &l)
     return ret;
 }
 
-bool Utils::Misc::isUrl(const QString &s)
-{
-    static const QRegularExpression reURLScheme(
-                "http[s]?|ftp", QRegularExpression::CaseInsensitiveOption);
-
-    return reURLScheme.match(QUrl(s).scheme()).hasMatch();
-}
-
 QString Utils::Misc::parseHtmlLinks(const QString &rawText)
 {
     QString result = rawText;

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -71,7 +71,6 @@ namespace Utils
         };
 
         QString parseHtmlLinks(const QString &rawText);
-        bool isUrl(const QString &s);
 
         void shutdownComputer(const ShutdownDialogAction &action);
 

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -227,7 +227,7 @@ void AddNewTorrentDialog::saveState()
     settings()->storeValue(KEY_EXPANDED, m_ui->toolButtonAdvanced->isChecked());
 }
 
-void AddNewTorrentDialog::show(QString source, const BitTorrent::AddTorrentParams &inParams, QWidget *parent)
+void AddNewTorrentDialog::show(const QString &source, const BitTorrent::AddTorrentParams &inParams, QWidget *parent)
 {
     AddNewTorrentDialog *dlg = new AddNewTorrentDialog(inParams, parent);
 
@@ -240,27 +240,27 @@ void AddNewTorrentDialog::show(QString source, const BitTorrent::AddTorrentParam
                 , dlg, &AddNewTorrentDialog::handleDownloadFinished);
         connect(handler, &Net::DownloadHandler::downloadFailed, dlg, &AddNewTorrentDialog::handleDownloadFailed);
         connect(handler, &Net::DownloadHandler::redirectedToMagnet, dlg, &AddNewTorrentDialog::handleRedirectedToMagnet);
+        return;
+    }
+
+    const BitTorrent::MagnetUri magnetUri(source);
+    const bool isLoaded = magnetUri.isValid()
+        ? dlg->loadMagnet(magnetUri)
+        : dlg->loadTorrent(source);
+
+    if (isLoaded) {
+#ifdef Q_OS_MAC
+        dlg->exec();
+#else
+        dlg->open();
+#endif
     }
     else {
-        bool ok = false;
-        BitTorrent::MagnetUri magnetUri(source);
-        if (magnetUri.isValid())
-            ok = dlg->loadMagnet(magnetUri);
-        else
-            ok = dlg->loadTorrent(source);
-
-        if (ok)
-#ifdef Q_OS_MAC
-            dlg->exec();
-#else
-            dlg->open();
-#endif
-        else
-            delete dlg;
+        delete dlg;
     }
 }
 
-void AddNewTorrentDialog::show(QString source, QWidget *parent)
+void AddNewTorrentDialog::show(const QString &source, QWidget *parent)
 {
     show(source, BitTorrent::AddTorrentParams(), parent);
 }

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -231,7 +231,7 @@ void AddNewTorrentDialog::show(const QString &source, const BitTorrent::AddTorre
 {
     AddNewTorrentDialog *dlg = new AddNewTorrentDialog(inParams, parent);
 
-    if (Utils::Misc::isUrl(source)) {
+    if (Net::DownloadManager::hasSupportedScheme(source)) {
         // Launch downloader
         // TODO: Don't save loaded torrent to file, just use downloaded data!
         Net::DownloadHandler *handler = Net::DownloadManager::instance()->download(

--- a/src/gui/addnewtorrentdialog.h
+++ b/src/gui/addnewtorrentdialog.h
@@ -68,8 +68,8 @@ public:
     static int savePathHistoryLength();
     static void setSavePathHistoryLength(int value);
 
-    static void show(QString source, const BitTorrent::AddTorrentParams &inParams, QWidget *parent);
-    static void show(QString source, QWidget *parent);
+    static void show(const QString &source, const BitTorrent::AddTorrentParams &inParams, QWidget *parent);
+    static void show(const QString &source, QWidget *parent);
 
 private slots:
     void showAdvancedSettings(bool show);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -60,6 +60,7 @@
 #include "base/bittorrent/torrenthandle.h"
 #include "base/global.h"
 #include "base/logger.h"
+#include "base/net/downloadmanager.h"
 #include "base/preferences.h"
 #include "base/rss/rss_folder.h"
 #include "base/rss/rss_session.h"
@@ -1295,7 +1296,7 @@ void MainWindow::dropEvent(QDropEvent *event)
     for (const QString &file : asConst(files)) {
         const bool isTorrentLink = (file.startsWith("magnet:", Qt::CaseInsensitive)
             || file.endsWith(C_TORRENT_FILE_EXTENSION, Qt::CaseInsensitive)
-            || Utils::Misc::isUrl(file));
+            || Net::DownloadManager::hasSupportedScheme(file));
         if (isTorrentLink)
             torrentFiles << file;
         else

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -38,7 +38,6 @@
 #include <QMimeData>
 #include <QProcess>
 #include <QPushButton>
-#include <QRegularExpression>
 #include <QScrollBar>
 #include <QShortcut>
 #include <QSplitter>
@@ -1628,11 +1627,7 @@ void MainWindow::showNotificationBaloon(QString title, QString msg) const
 void MainWindow::downloadFromURLList(const QStringList &urlList)
 {
     const bool useTorrentAdditionDialog = AddNewTorrentDialog::isEnabled();
-    for (QString url : urlList) {
-        if (((url.size() == 40) && !url.contains(QRegularExpression("[^0-9A-Fa-f]")))
-            || ((url.size() == 32) && !url.contains(QRegularExpression("[^2-7A-Za-z]"))))
-            url = "magnet:?xt=urn:btih:" + url;
-
+    for (const QString &url : urlList) {
         if (useTorrentAdditionDialog)
             AddNewTorrentDialog::show(url, this);
         else

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -48,7 +48,6 @@
 #include "base/rss/rss_feed.h"
 #include "base/rss/rss_folder.h"
 #include "base/rss/rss_session.h"
-#include "base/utils/misc.h"
 #include "addnewtorrentdialog.h"
 #include "articlelistwidget.h"
 #include "autoexpandabledialog.h"
@@ -249,7 +248,7 @@ void RSSWidget::on_newFeedButton_clicked()
 {
     // Ask for feed URL
     const QString clipText = qApp->clipboard()->text();
-    const QString defaultURL = (Utils::Misc::isUrl(clipText) ? clipText : "http://");
+    const QString defaultURL = Net::DownloadManager::hasSupportedScheme(clipText) ? clipText : "http://";
 
     bool ok;
     QString newURL = AutoExpandableDialog::getText(

--- a/src/gui/search/pluginselectdialog.cpp
+++ b/src/gui/search/pluginselectdialog.cpp
@@ -43,7 +43,6 @@
 #include "base/net/downloadhandler.h"
 #include "base/net/downloadmanager.h"
 #include "base/utils/fs.h"
-#include "base/utils/misc.h"
 #include "autoexpandabledialog.h"
 #include "guiiconprovider.h"
 #include "pluginsourcedialog.h"
@@ -337,7 +336,7 @@ void PluginSelectDialog::askForPluginUrl()
     bool ok = false;
     QString clipTxt = qApp->clipboard()->text();
     QString defaultUrl = "http://";
-    if (Utils::Misc::isUrl(clipTxt) && clipTxt.endsWith(".py"))
+    if (Net::DownloadManager::hasSupportedScheme(clipTxt) && clipTxt.endsWith(".py"))
       defaultUrl = clipTxt;
     QString url = AutoExpandableDialog::getText(
                 this, tr("New search engine plugin URL"),


### PR DESCRIPTION
* The format is marked obsolete on 2009.12.28 and has been replaced by magnet links.
  http://wiki.bitcomet.com/inside_bitcomet#bc_link_format_obsoleted_as_of_v117
  https://www.bitcomet.com/en/changelog
* Cleanup code