### PR TITLE
Use SQLite to store torrents and fastresumes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,7 +22,7 @@ if (Boost_VERSION VERSION_LESS 106000)
     add_definitions(-DBOOST_NO_CXX11_RVALUE_REFERENCES)
 endif()
 
-find_package(Qt5 ${requiredQtVersion} REQUIRED COMPONENTS Core Network Xml LinguistTools)
+find_package(Qt5 ${requiredQtVersion} REQUIRED COMPONENTS Core LinguistTools Network Sql Xml)
 find_package(Qt5Widgets ${requiredQtVersion})
 if (Qt5Widgets_FOUND)
     find_package(Qt5DBus ${requiredQtVersion})

--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -323,6 +323,7 @@ namespace
     constexpr const StringOption CATEGORY_OPTION {"category"};
     constexpr const BoolOption SEQUENTIAL_OPTION {"sequential"};
     constexpr const BoolOption FIRST_AND_LAST_OPTION {"first-and-last"};
+    constexpr const BoolOption EXPORT_TORRENT_DATA_OPTION {"export-torrent-data"};
     constexpr const TriStateBoolOption SKIP_DIALOG_OPTION {"skip-dialog", true};
 }
 
@@ -333,6 +334,7 @@ QBtCommandLineParameters::QBtCommandLineParameters(const QProcessEnvironment &en
     , skipChecking(SKIP_HASH_CHECK_OPTION.value(env))
     , sequential(SEQUENTIAL_OPTION.value(env))
     , firstLastPiecePriority(FIRST_AND_LAST_OPTION.value(env))
+    , exportTorrentData(EXPORT_TORRENT_DATA_OPTION.value(env))
 #ifndef Q_OS_WIN
     , showVersion(false)
 #endif
@@ -383,6 +385,9 @@ QStringList QBtCommandLineParameters::paramList() const
 
     if (firstLastPiecePriority)
         result.append(QLatin1String("@firstLastPiecePriority"));
+
+    if (exportTorrentData)
+        result.append(QLatin1String("@exportTorrentData"));
 
     if (skipDialog == TriStateBool::True) {
         result.append(QLatin1String("@skipDialog=1"));
@@ -457,6 +462,9 @@ QBtCommandLineParameters parseCommandLine(const QStringList &args)
             }
             else if (arg == FIRST_AND_LAST_OPTION) {
                 result.firstLastPiecePriority = true;
+            }
+            else if (arg == EXPORT_TORRENT_DATA_OPTION) {
+                result.exportTorrentData = true;
             }
             else if (arg == SKIP_DIALOG_OPTION) {
                 result.skipDialog = SKIP_DIALOG_OPTION.value(arg);
@@ -558,6 +566,9 @@ QString makeUsage(const QString &prgName)
     stream << SEQUENTIAL_OPTION.usage() << wrapText(QObject::tr("Download files in sequential order")) << '\n';
     stream << FIRST_AND_LAST_OPTION.usage()
            << wrapText(QObject::tr("Download first and last pieces first")) << '\n';
+    stream << EXPORT_TORRENT_DATA_OPTION.usage()
+           << wrapText(QObject::tr("Export torrent data to the saving system used by 4.1.x series. "
+                                   "Torrents/fastresumes will be exported in the BT_backup folder.")) << '\n';
     stream << SKIP_DIALOG_OPTION.usage()
            << wrapText(QObject::tr("Specify whether the \"Add New Torrent\" dialog opens when adding a "
                                    "torrent.")) << '\n';

--- a/src/app/cmdoptions.h
+++ b/src/app/cmdoptions.h
@@ -42,7 +42,7 @@ class QProcessEnvironment;
 
 struct QBtCommandLineParameters
 {
-    bool showHelp, relativeFastresumePaths, portableMode, skipChecking, sequential, firstLastPiecePriority;
+    bool showHelp, relativeFastresumePaths, portableMode, skipChecking, sequential, firstLastPiecePriority, exportTorrentData;
 #ifndef Q_OS_WIN
     bool showVersion;
 #endif

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -233,6 +233,11 @@ int main(int argc, char *argv[])
             return 1;
         }
 
+        if (params.exportTorrentData) {
+            exportTorrentData();
+            return EXIT_SUCCESS;
+        }
+
 #ifdef DISABLE_GUI
         if (params.shouldDaemonize) {
             app.reset(); // Destroy current application

--- a/src/app/upgrade.cpp
+++ b/src/app/upgrade.cpp
@@ -1,5 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2015  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2019  Mike Tzou (Chocobo1)
  *
  * This program is free software; you can redistribute it and/or
@@ -28,12 +29,32 @@
 
 #include "upgrade.h"
 
+#include <QCoreApplication>
+#include <QDir>
 #include <QFile>
+#include <QRegularExpression>
+#include <QString>
+#include <QSqlDatabase>
+#include <QSqlError>
+#include <QSqlQuery>
 
+#ifndef DISABLE_GUI
+#include <QMessageBox>
+#endif
+
+#include <libtorrent/bdecode.hpp>
+#include <libtorrent/error_code.hpp>
+#include <libtorrent/version.hpp>
+
+#include "base/bittorrent/db.h"
+#include "base/bittorrent/session.h"
+#include "base/exceptions.h"
+#include "base/global.h"
 #include "base/logger.h"
 #include "base/profile.h"
 #include "base/settingsstorage.h"
 #include "base/utils/fs.h"
+#include "base/utils/misc.h"
 
 namespace
 {
@@ -75,10 +96,176 @@ namespace
             , QLatin1String("Preferences/WebUI/HTTPS/KeyPath")
             , Utils::Fs::toNativePath(configPath + QLatin1String("WebUIPrivateKey.pem")));
     }
+    
+    bool readFile(const QString &path, QByteArray &buf)
+    {
+        QFile file(path);
+        if (!file.open(QIODevice::ReadOnly)) {
+            qDebug("Cannot read file %s: %s", qUtf8Printable(path), qUtf8Printable(file.errorString()));
+            return false;
+        }
+
+        buf = file.readAll();
+        return true;
+    }
+
+    bool loadTorrentParams(const QByteArray &data, int &prio, QByteArray &magnetUri)
+    {
+        namespace libt = libtorrent;
+
+        libt::error_code ec;
+        libt::bdecode_node fast;
+        libt::bdecode(data.constData(), data.constData() + data.size(), fast, ec);
+        if (ec || (fast.type() != libt::bdecode_node::dict_t)) return false;
+
+        magnetUri = QByteArray::fromStdString(fast.dict_find_string_value("qBt-magnetUri"));
+        prio = fast.dict_find_int_value("qBt-queuePosition");
+
+        return true;
+    }
+
+    bool userAcceptsUpgrade()
+    {
+#ifdef DISABLE_GUI
+        printf("\n*** %s ***\n", qUtf8Printable(QObject::tr("Upgrade")));
+        char ret = '\0';
+        do {
+            printf("%s\n"
+                   , qUtf8Printable(QObject::tr("You updated from an older version that saved things differently. You must migrate to the new saving system. You will not be able to use an older version than v4.2.0 again. Continue? [y/n]")));
+            ret = getchar(); // Read pressed key
+        }
+        while ((ret != 'y') && (ret != 'Y') && (ret != 'n') && (ret != 'N'));
+
+        if ((ret == 'y') || (ret == 'Y'))
+            return true;
+#else
+        QMessageBox msgBox;
+        msgBox.setText(QObject::tr("You updated from an older version that saved things differently. You must migrate to the new saving system. If you continue, you will not be able to use an older version than v4.2.0 again."));
+        msgBox.setWindowTitle(QObject::tr("Upgrade"));
+        msgBox.addButton(QMessageBox::Abort);
+        msgBox.addButton(QMessageBox::Ok);
+        msgBox.setDefaultButton(QMessageBox::Abort);
+        msgBox.show(); // Need to be shown or to moveToCenter does not work
+        msgBox.move(Utils::Misc::screenCenter(&msgBox));
+        if (msgBox.exec() == QMessageBox::Ok)
+            return true;
+#endif // DISABLE_GUI
+
+        return false;
+    }
 }
 
-bool upgrade(const bool /*ask*/)
+bool upgrade(const bool ask)
 {
     exportWebUIHttpsFiles();
+    
+    using namespace BitTorrent::DB;
+    const QString dbFolderPath = Utils::Fs::expandPathAbs(specialFolderLocation(SpecialFolder::Data));
+    const QDir dbFolderDir(dbFolderPath);
+    const QString dbPath = dbFolderDir.absoluteFilePath(QLatin1String{FILENAME});
+    // If db exists don't try to upgrade
+    if (QFile::exists(dbPath))
+        return true;
+
+    const QString backupFolderPath = Utils::Fs::expandPathAbs(specialFolderLocation(SpecialFolder::Data) + "BT_backup");
+    const QDir backupFolderDir(backupFolderPath);
+    QStringList fastresumes = backupFolderDir.entryList(QStringList(QLatin1String("*.fastresume")), QDir::Files, QDir::Unsorted);
+    // This is a brand new install
+    if (fastresumes.isEmpty())
+        return true;
+
+    if (ask && !userAcceptsUpgrade()) return false;
+
+    const QRegularExpression rx(QLatin1String("^([A-Fa-f0-9]{40})\\.fastresume$"));
+    BitTorrent::Session::initiliazeDB();
+
+    QSqlDatabase db = QSqlDatabase::database(MAIN_CONNECTION_NAME);
+    db.transaction();
+    QSqlQuery query(db);
+    query.prepare(QString("INSERT INTO %1 (%2, %3, %4, %5, %6) "
+                          "VALUES (:hash, :metadata, :fastresume, :queue)")
+                  .arg(TABLE_NAME, COL_HASH, COL_METADATA, COL_FASTRESUME, COL_QUEUE));
+
+    const auto insertDBRecord = [&backupFolderDir, &query](const QString &hash, bool customQueue = false, const int queue = -1) -> bool
+    {
+        const QString metadataPath = backupFolderDir.absoluteFilePath(QString("%1.torrent").arg(hash));
+        const QString fastresumePath = backupFolderDir.absoluteFilePath(QString("%1.fastresume").arg(hash));
+        QByteArray fastResumeData;
+        QByteArray metadata;
+        int queuePosition = 0;
+
+        if (!readFile(fastresumePath, fastResumeData)
+            || !loadTorrentParams(fastResumeData, queuePosition, metadata)) return false;
+
+        // At the 1st check if 'metadata' isn't empty it means it contains a magnet URI
+        if (metadata.isEmpty() && !readFile(metadataPath, metadata)) return false;
+
+        query.bindValue(":hash", hash);
+        query.bindValue(":metadata", metadata);
+        query.bindValue(":fastresume", fastResumeData);
+        query.bindValue(":queue", customQueue ? queue : queuePosition);
+        if (!query.exec()) {
+            LogMsg(QCoreApplication::translate("BitTorrent::Session", "Couldn't save torrent %1 into the database. Error: %2")
+                   .arg(hash, query.lastError().text()), Log::CRITICAL);
+            return false;
+        }
+
+        Utils::Fs::forceRemove(metadataPath);
+        Utils::Fs::forceRemove(fastresumePath);
+        return true;
+    };
+
+    bool isQueueingSystemEnabled = SettingsStorage::instance()->loadValue("BitTorrent/Session/QueueingSystemEnabled", true).toBool();
+
+    if (isQueueingSystemEnabled) {
+        const QString queueFilePath {backupFolderDir.absoluteFilePath(QLatin1String {"queue"})};
+        QFile queueFile {queueFilePath};
+
+        // TODO: The following code is deprecated in 4.1.5. Remove after several releases in 4.2.x.
+        // === BEGIN DEPRECATED CODE === //
+        if (!queueFile.exists()) {
+            // Resume downloads in a legacy manner
+            for (const QString &fastresumeName : asConst(fastresumes)) {
+                const QRegularExpressionMatch rxMatch = rx.match(fastresumeName);
+                if (!rxMatch.hasMatch()) continue;
+
+                insertDBRecord(rxMatch.captured(1));
+            }
+
+            db.commit();
+            return true;
+        }
+        // === END DEPRECATED CODE === //
+
+        if (queueFile.open(QFile::ReadOnly)) {
+            QByteArray line;
+            int queuePosition = 0;
+            while (!(line = queueFile.readLine()).isEmpty()) {
+                const QString fastresumeName = QString::fromLatin1(line.trimmed()) + QLatin1String {".fastresume"};
+                const QRegularExpressionMatch rxMatch = rx.match(fastresumeName);
+                if (!rxMatch.hasMatch()) continue;
+
+                fastresumes.removeAll(fastresumeName);
+                if (insertDBRecord(rxMatch.captured(1), true, queuePosition))
+                    ++queuePosition;
+            }
+        }
+        else {
+            LogMsg(QCoreApplication::translate("BitTorrent::Session", "Couldn't load torrents queue from '%1'. Error: %2")
+                   .arg(queueFile.fileName(), queueFile.errorString()), Log::WARNING);
+        }
+
+        queueFile.close();
+        Utils::Fs::forceRemove(queueFilePath);
+    }
+
+    for (const QString &fastresumeName : asConst(fastresumes)) {
+        const QRegularExpressionMatch rxMatch = rx.match(fastresumeName);
+        if (!rxMatch.hasMatch()) continue;
+
+        insertDBRecord(rxMatch.captured(1), true, -1); // -1 because either queueing is disabled or these are seeds
+    }
+
+    db.commit();
     return true;
 }

--- a/src/app/upgrade.h
+++ b/src/app/upgrade.h
@@ -29,3 +29,4 @@
 #pragma once
 
 bool upgrade(bool ask = true);
+void exportTorrentData();

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -50,6 +50,7 @@ search/searchdownloadhandler.h
 search/searchhandler.h
 search/searchpluginmanager.h
 utils/bytearray.h
+utils/db.h
 utils/foreignapps.h
 utils/fs.h
 utils/gzip.h
@@ -148,7 +149,7 @@ target_link_libraries(qbt_base
         ZLIB::ZLIB
     PUBLIC
         LibtorrentRasterbar::torrent-rasterbar
-        Qt5::Core Qt5::Network Qt5::Xml
+        Qt5::Core Qt5::Network Qt5::Sql Qt5::Xml
 )
 
 if (Qt5Widgets_FOUND)

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -3,6 +3,7 @@ HEADERS += \
     $$PWD/asyncfilestorage.h \
     $$PWD/bittorrent/addtorrentparams.h  \
     $$PWD/bittorrent/cachestatus.h \
+    $$PWD/bittorrent/db.h \
     $$PWD/bittorrent/filepriority.h \
     $$PWD/bittorrent/infohash.h \
     $$PWD/bittorrent/magneturi.h \

--- a/src/base/bittorrent/db.h
+++ b/src/base/bittorrent/db.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015, 2018  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2019  sledgehammer999 <hammered999@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -27,22 +27,32 @@
  */
 
 #pragma once
-
-#include <QObject>
-
-class QByteArray;
-
-class ResumeDataSavingManager : public QObject
+namespace BitTorrent
 {
-    Q_OBJECT
-    Q_DISABLE_COPY(ResumeDataSavingManager)
+    namespace DB
+    {
+        const char MAIN_CONNECTION_NAME[] = "torrentsMain";
+        const char FILENAME[] = "torrentData.db";
+        const int VERSION = 1;
 
-public:
-    explicit ResumeDataSavingManager(const QString &dbFilename);
-
-public slots:
-    void save(const QString &hash, const QByteArray &data, int pos) const;
-
-private:
-    QString m_dbFilename;
-};
+        const char TABLE_NAME[] = "torrents";
+        const char COL_HASH[] = "hash";
+        const char COL_METADATA[] = "metadata";
+        const char COL_FASTRESUME[] = "fastresume";
+        const char COL_QUEUE[] = "queue";
+        const char COL_SAVE_PATH[] = "savePath";
+        const char COL_RATIO_LIMIT[] = "ratioLimit";
+        const char COL_SEEDING_TIME_LIMIT[] = "seedingTimeLimit";
+        const char COL_CATEGORY[] = "category";
+        const char COL_TAGS[] = "tags";
+        const char COL_NAME[] = "name";
+        const char COL_SEED_STATUS[] = "seedStatus";
+        const char COL_TMP_PATH_DISABLED[] = "tempPathDisabled";
+        const char COL_HAS_ROOT_FOLDER[] = "hasRootFolder";
+        const char COL_PAUSED[] = "paused";
+        const char COL_FORCED[] = "forced";
+        // magnet URI specific columns
+        const char COL_HAS_FIRST_LAST_PIECE_PRIO[] = "hasFirstLastPiecePrio";
+        const char COL_SEQUENTIAL[] = "sequential";
+    }
+}

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -62,8 +62,6 @@ namespace libtorrent
     struct torrent_finished_alert;
     struct torrent_paused_alert;
     struct torrent_resumed_alert;
-    struct save_resume_data_alert;
-    struct save_resume_data_failed_alert;
     struct file_renamed_alert;
     struct file_rename_failed_alert;
     struct storage_moved_alert;
@@ -337,7 +335,7 @@ namespace BitTorrent
         void forceDHTAnnounce();
         void forceRecheck();
         void renameFile(int index, const QString &name);
-        bool saveTorrentFile(const QString &path);
+        QByteArray metadata() const;
         void prioritizeFiles(const QVector<int> &priorities);
         void setRatioLimit(qreal limit);
         void setSeedingTimeLimit(int limit);
@@ -390,8 +388,6 @@ namespace BitTorrent
         void handleTorrentFinishedAlert(const libtorrent::torrent_finished_alert *p);
         void handleTorrentPausedAlert(const libtorrent::torrent_paused_alert *p);
         void handleTorrentResumedAlert(const libtorrent::torrent_resumed_alert *p);
-        void handleSaveResumeDataAlert(const libtorrent::save_resume_data_alert *p);
-        void handleSaveResumeDataFailedAlert(const libtorrent::save_resume_data_failed_alert *p);
         void handleFastResumeRejectedAlert(const libtorrent::fastresume_rejected_alert *p);
         void handleFileRenamedAlert(const libtorrent::file_renamed_alert *p);
         void handleFileRenameFailedAlert(const libtorrent::file_rename_failed_alert *p);

--- a/src/src.pro
+++ b/src/src.pro
@@ -7,7 +7,7 @@ win32: include(../winconf.pri)
 macx: include(../macxconf.pri)
 unix:!macx: include(../unixconf.pri)
 
-QT += network xml
+QT += network sql xml
 
 nogui {
     TARGET = qbittorrent-nox


### PR DESCRIPTION
I recently played with SQLite and I was fascinated by it. Then I realized how easy things could become for us if we used to save stuff.

Pros:
1. Far easier code for sorting torrents by queue during startup
2. Possibly much faster startup for users with many torrents because now we don't have to read multitudes of **small** files from disk
3. SQLite should have a very robust anti-corruption systems. Far better than anything we can engineer ourselves

I plugged in the new functionality by keeping the current design as much as possible. I didn't attempt to engineer a better code architecture around the new system.
Most of the code you see is old code moved around.

PS: Is anyone more knowledgeable with SQL? I wonder if we should split the table into 2 for performance reasons. One saving hash+metadata and one saving hash+fastresume+queue.