### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,21 @@ matrix:
   allow_failures:
     - env: lt_branch=RC_1_0 gui=true build_system=cmake
     - env: lt_branch=RC_1_0 gui=false build_system=cmake
+  include:
+    - language: python
+      python: 2.7   # legacy Python
+      addons: true  # override
+      before_install: true
+      env: build_system=Python
+      install: pip install flake8
+      script: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    - language: python
+      python: 3.7   # Python
+      addons: true  # override
+      before_install: true
+      env: build_system=Python
+      install: pip install flake8
+      script: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
 
 branches:
   except:

--- a/src/searchengine/nova/helpers.py
+++ b/src/searchengine/nova/helpers.py
@@ -39,6 +39,11 @@ import StringIO
 import tempfile
 import urllib2
 
+try:
+    unichr        # Python 2
+except NameError:
+    unichr = chr  # Python 3
+
 # Some sites blocks default python User-agent
 user_agent = 'Mozilla/5.0 (X11; Linux i686; rv:38.0) Gecko/20100101 Firefox/38.0'
 headers = {'User-Agent': user_agent}

--- a/src/searchengine/nova/nova2dl.py
+++ b/src/searchengine/nova/nova2dl.py
@@ -44,7 +44,7 @@ for engine in engines:
     try:
         exec("from engines.%s import %s" % (e, e))
         exec("engine_url = %s.url" % e)
-        supported_engines[engine_url] = e
+        supported_engines[engine_url] = e  # noqa: F821
     except Exception:
         pass
 

--- a/src/searchengine/nova/novaprinter.py
+++ b/src/searchengine/nova/novaprinter.py
@@ -28,6 +28,11 @@ import codecs
 import sys
 from io import open
 
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
+
 # Force UTF-8 printing
 sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
 

--- a/src/searchengine/nova/socks.py
+++ b/src/searchengine/nova/socks.py
@@ -200,7 +200,7 @@ class socksocket(socket.socket):
             if authstat[1] != "\x00":
                 # Authentication failed
                 self.close()
-                raise Socks5AuthError,((3,_socks5autherrors[3]))
+                raise Socks5AuthError((3,_socks5autherrors[3]))
             # Authentication succeeded
         else:
             # Reaching here is always bad
@@ -362,7 +362,7 @@ class socksocket(socket.socket):
         To select the proxy server use setproxy().
         """
         # Do a minimal input check first
-        if (type(destpair) in (list,tuple)==False) or (len(destpair)<2) or (type(destpair[0])!=str) or (type(destpair[1])!=int):
+        if (not isinstance(destpair, (list,tuple))) or (len(destpair)<2) or (not isinstance(destpair[0], str)) or (not isinstance(destpair[1], int)):
             raise GeneralProxyError((5,_generalerrors[5]))
         if self.__proxy[0] == PROXY_TYPE_SOCKS5:
             if self.__proxy[2] != None:

--- a/src/searchengine/nova3/nova2dl.py
+++ b/src/searchengine/nova3/nova2dl.py
@@ -44,7 +44,7 @@ for engine in engines:
     try:
         exec("from engines.%s import %s" % (e, e))
         exec("engine_url = %s.url" % e)
-        supported_engines[engine_url] = e
+        supported_engines[engine_url] = e  # noqa: F821
     except Exception:
         pass
 

--- a/src/searchengine/nova3/novaprinter.py
+++ b/src/searchengine/nova3/novaprinter.py
@@ -24,6 +24,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import print_function
+
 
 def prettyPrinter(dictionary):
     dictionary['size'] = anySizeToBytes(dictionary['size'])

--- a/src/searchengine/nova3/sgmllib3.py
+++ b/src/searchengine/nova3/sgmllib3.py
@@ -8,6 +8,7 @@
 # and CDATA (character data -- only end tags are special).  RCDATA is
 # not supported at all.
 
+from __future__ import print_function
 import _markupbase
 import re
 

--- a/src/searchengine/nova3/socks.py
+++ b/src/searchengine/nova3/socks.py
@@ -362,7 +362,7 @@ class socksocket(socket.socket):
         To select the proxy server use setproxy().
         """
         # Do a minimal input check first
-        if (type(destpair) in (list,tuple)==False) or (len(destpair)<2) or (type(destpair[0])!=str) or (type(destpair[1])!=int):
+        if (not isinstance(destpair, (list,tuple))) or (len(destpair)<2) or (not isinstance(destpair[0], str)) or (not isinstance(destpair[1], int)):
             raise GeneralProxyError((5,_generalerrors[5]))
         if self.__proxy[0] == PROXY_TYPE_SOCKS5:
             if self.__proxy[2] != None:


### PR DESCRIPTION
Also adds all the Travis CI testing changes from #10149

Lint the Python code with the [flake8](http://flake8.pycqa.org) linter to find syntax errors and undefined names that have the potential to halt the runtime.

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree