### PR TITLE
Travis CI: Find Python syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,19 +24,19 @@ matrix:
     - env: lt_branch=RC_1_0 gui=true build_system=cmake
     - env: lt_branch=RC_1_0 gui=false build_system=cmake
     - python: 3.7
- include:
-   - language: python
-     python: 2.7   # legacy Python
-     addons: true  # override
-     before_install: true
-     install: pip install flake8
-     script: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-   - language: python
-     python: 3.7   # Python
-     addons: true  # override
-     before_install: true
-     install: pip install flake8
-     script: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  include:
+    - language: python
+      python: 2.7   # legacy Python
+      addons: true  # override
+      before_install: true
+      install: pip install flake8
+      script: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    - language: python
+      python: 3.7   # Python
+      addons: true  # override
+      before_install: true
+      install: pip install flake8
+      script: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,14 @@ matrix:
       python: 2.7   # legacy Python
       addons: true  # override
       before_install: true
+      env: build_system=Python
       install: pip install flake8
       script: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
     - language: python
       python: 3.7   # Python
       addons: true  # override
       before_install: true
+      env: build_system=Python
       install: pip install flake8
       script: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,20 @@ matrix:
   allow_failures:
     - env: lt_branch=RC_1_0 gui=true build_system=cmake
     - env: lt_branch=RC_1_0 gui=false build_system=cmake
+    - python: 3.7
+ include:
+   - language: python
+     python: 2.7   # legacy Python
+     addons: true  # override
+     before_install: true
+     install: pip install flake8
+     script: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+   - language: python
+     python: 3.7   # Python
+     addons: true  # override
+     before_install: true
+     install: pip install flake8
+     script: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
 
 branches:
   except:

--- a/src/searchengine/nova/nova2dl.py
+++ b/src/searchengine/nova/nova2dl.py
@@ -44,6 +44,7 @@ for engine in engines:
     try:
         exec("from engines.%s import %s" % (e, e))
         exec("engine_url = %s.url" % e)
+        global engine_url
         supported_engines[engine_url] = e
     except Exception:
         pass

--- a/src/searchengine/nova3/nova2dl.py
+++ b/src/searchengine/nova3/nova2dl.py
@@ -44,6 +44,7 @@ for engine in engines:
     try:
         exec("from engines.%s import %s" % (e, e))
         exec("engine_url = %s.url" % e)
+        global engine_url
         supported_engines[engine_url] = e
     except Exception:
         pass

--- a/src/searchengine/nova3/novaprinter.py
+++ b/src/searchengine/nova3/novaprinter.py
@@ -24,6 +24,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import print_function
+
 
 def prettyPrinter(dictionary):
     dictionary['size'] = anySizeToBytes(dictionary['size'])

--- a/src/searchengine/nova3/sgmllib3.py
+++ b/src/searchengine/nova3/sgmllib3.py
@@ -8,6 +8,8 @@
 # and CDATA (character data -- only end tags are special).  RCDATA is
 # not supported at all.
 
+from __future__ import print_function
+
 import _markupbase
 import re
 


### PR DESCRIPTION
Lint the Python code with the [flake8](http://flake8.pycqa.org) linter to find syntax errors and undefined names that have the potential to halt the runtime.

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree