### PR TITLE
Allow setting larger checking memory usage in GUI

### DIFF
--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -324,6 +324,13 @@ void AdvancedSettings::loadAdvancedSettings()
 
     // Checking Memory Usage
     spinBoxCheckingMemUsage.setMinimum(1);
+    // When build as 32bit binary, set the maximum value lower to prevent crashes.
+#if (QT_POINTER_SIZE == 8)
+    spinBoxCheckingMemUsage.setMaximum(1024);
+#else
+    // Allocate at most 128MiB out of the remaining 512MiB (see the cache part below)
+    spinBoxCheckingMemUsage.setMaximum(128);
+#endif
     spinBoxCheckingMemUsage.setValue(session->checkingMemUsage());
     spinBoxCheckingMemUsage.setSuffix(tr(" MiB"));
     addRow(CHECKING_MEM_USAGE, tr("Outstanding memory when checking torrents"), &spinBoxCheckingMemUsage);


### PR DESCRIPTION
The maximum value is currently [99MiB](http://doc.qt.io/qt-5/qspinbox.html#maximum-prop). Allowing setting it larger helps to easier do benchmark. For 32-bit builds, a slight increase from 99MiB to 128MiB should not contribute to any problem.