### PR TITLE
Load WebUI certificate & key from file path

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -7,6 +7,7 @@ application.cpp
 cmdoptions.cpp
 filelogger.cpp
 main.cpp
+upgrade.cpp
 )
 
 target_include_directories(qBittorrent PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/app/app.pri
+++ b/src/app/app.pri
@@ -17,13 +17,15 @@ usesystemqtsingleapplication {
 HEADERS += \
     $$PWD/application.h \
     $$PWD/cmdoptions.h \
-    $$PWD/filelogger.h
+    $$PWD/filelogger.h \
+    $$PWD/upgrade.h
 
 SOURCES += \
     $$PWD/application.cpp \
     $$PWD/cmdoptions.cpp \
     $$PWD/filelogger.cpp \
-    $$PWD/main.cpp
+    $$PWD/main.cpp \
+    $$PWD/upgrade.cpp
 
 stacktrace {
     unix {
@@ -37,6 +39,3 @@ stacktrace {
         }
     }
 }
-
-# upgrade code
-HEADERS += $$PWD/upgrade.h

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -47,6 +47,7 @@
 #include <QPen>
 #include <QPushButton>
 #include <QSplashScreen>
+#include <QTimer>
 
 #ifdef QBT_STATIC_QT
 #include <QtPlugin>

--- a/src/app/upgrade.cpp
+++ b/src/app/upgrade.cpp
@@ -1,0 +1,84 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2019  Mike Tzou (Chocobo1)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "upgrade.h"
+
+#include <QFile>
+
+#include "base/logger.h"
+#include "base/profile.h"
+#include "base/settingsstorage.h"
+#include "base/utils/fs.h"
+
+namespace
+{
+    void exportWebUIHttpsFiles()
+    {
+        const auto migrate = [](const QString &oldKey, const QString &newKey, const QString &savePath) {
+            SettingsStorage *settingsStorage {SettingsStorage::instance()};
+            const QByteArray oldData {settingsStorage->loadValue(oldKey).toByteArray()};
+            const QString newData {settingsStorage->loadValue(newKey).toString()};
+            const QString errorMsgFormat {QObject::tr("Migrate preferences failed: WebUI https, file: \"%1\", error: \"%2\"")};
+
+            if (!newData.isEmpty() || oldData.isEmpty())
+                return;
+
+            QFile file(savePath);
+            if (!file.open(QIODevice::WriteOnly)) {
+                LogMsg(errorMsgFormat.arg(savePath, file.errorString()) , Log::WARNING);
+                return;
+            }
+            if (file.write(oldData) != oldData.size()) {
+                file.close();
+                Utils::Fs::forceRemove(savePath);
+                LogMsg(errorMsgFormat.arg(savePath, QLatin1String("Write incomplete.")) , Log::WARNING);
+                return;
+            }
+
+            settingsStorage->storeValue(newKey, savePath);
+            settingsStorage->removeValue(oldKey);
+
+            LogMsg(QObject::tr("Migrated preferences: WebUI https, exported data to file: \"%1\"").arg(savePath)
+                , Log::INFO);
+        };
+
+        const QString configPath {specialFolderLocation(SpecialFolder::Config)};
+        migrate(QLatin1String("Preferences/WebUI/HTTPS/Certificate")
+            , QLatin1String("Preferences/WebUI/HTTPS/CertificatePath")
+            , Utils::Fs::toNativePath(configPath + QLatin1String("WebUICertificate.crt")));
+        migrate(QLatin1String("Preferences/WebUI/HTTPS/Key")
+            , QLatin1String("Preferences/WebUI/HTTPS/KeyPath")
+            , Utils::Fs::toNativePath(configPath + QLatin1String("WebUIPrivateKey.pem")));
+    }
+}
+
+bool upgrade(const bool /*ask*/)
+{
+    exportWebUIHttpsFiles();
+    return true;
+}

--- a/src/app/upgrade.h
+++ b/src/app/upgrade.h
@@ -28,9 +28,4 @@
 
 #pragma once
 
-bool upgrade(bool /*ask*/ = true)
-{
-    // Intentionally left no-op as a placeholder for future use
-
-    return true;
-}
+bool upgrade(bool ask = true);

--- a/src/base/http/server.h
+++ b/src/base/http/server.h
@@ -31,13 +31,9 @@
 #ifndef HTTP_SERVER_H
 #define HTTP_SERVER_H
 
-#include <QTcpServer>
-
-#ifndef QT_NO_OPENSSL
 #include <QSslCertificate>
-#include <QSslCipher>
 #include <QSslKey>
-#endif
+#include <QTcpServer>
 
 namespace Http
 {
@@ -50,13 +46,10 @@ namespace Http
         Q_DISABLE_COPY(Server)
 
     public:
-        Server(IRequestHandler *requestHandler, QObject *parent = nullptr);
-        ~Server();
+        explicit Server(IRequestHandler *requestHandler, QObject *parent = nullptr);
 
-#ifndef QT_NO_OPENSSL
-        bool setupHttps(const QByteArray &certificates, const QByteArray &key);
+        bool setupHttps(const QByteArray &certificates, const QByteArray &privateKey);
         void disableHttps();
-#endif
 
     private slots:
         void dropTimedOutConnection();
@@ -67,13 +60,9 @@ namespace Http
         IRequestHandler *m_requestHandler;
         QList<Connection *> m_connections;  // for tracking persistent connections
 
-#ifndef QT_NO_OPENSSL
-        QList<QSslCipher> safeCipherList() const;
-
         bool m_https;
         QList<QSslCertificate> m_certificates;
         QSslKey m_key;
-#endif
     };
 }
 

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -50,7 +50,6 @@
 #endif
 
 #include "global.h"
-#include "logger.h"
 #include "settingsstorage.h"
 #include "utils/fs.h"
 #include "utils/misc.h"

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -633,24 +633,24 @@ void Preferences::setWebUiHttpsEnabled(bool enabled)
     setValue("Preferences/WebUI/HTTPS/Enabled", enabled);
 }
 
-QByteArray Preferences::getWebUiHttpsCertificate() const
+QString Preferences::getWebUIHttpsCertificatePath() const
 {
-    return value("Preferences/WebUI/HTTPS/Certificate").toByteArray();
+    return value("Preferences/WebUI/HTTPS/CertificatePath").toString();
 }
 
-void Preferences::setWebUiHttpsCertificate(const QByteArray &data)
+void Preferences::setWebUIHttpsCertificatePath(const QString &path)
 {
-    setValue("Preferences/WebUI/HTTPS/Certificate", data);
+    setValue("Preferences/WebUI/HTTPS/CertificatePath", path);
 }
 
-QByteArray Preferences::getWebUiHttpsKey() const
+QString Preferences::getWebUIHttpsKeyPath() const
 {
-    return value("Preferences/WebUI/HTTPS/Key").toByteArray();
+    return value("Preferences/WebUI/HTTPS/KeyPath").toString();
 }
 
-void Preferences::setWebUiHttpsKey(const QByteArray &data)
+void Preferences::setWebUIHttpsKeyPath(const QString &path)
 {
-    setValue("Preferences/WebUI/HTTPS/Key", data);
+    setValue("Preferences/WebUI/HTTPS/KeyPath", path);
 }
 
 bool Preferences::isAltWebUiEnabled() const

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -203,10 +203,10 @@ public:
     // HTTPS
     bool isWebUiHttpsEnabled() const;
     void setWebUiHttpsEnabled(bool enabled);
-    QByteArray getWebUiHttpsCertificate() const;
-    void setWebUiHttpsCertificate(const QByteArray &data);
-    QByteArray getWebUiHttpsKey() const;
-    void setWebUiHttpsKey(const QByteArray &data);
+    QString getWebUIHttpsCertificatePath() const;
+    void setWebUIHttpsCertificatePath(const QString &path);
+    QString getWebUIHttpsKeyPath() const;
+    void setWebUIHttpsKeyPath(const QString &path);
     bool isAltWebUiEnabled() const;
     void setAltWebUiEnabled(bool enabled);
     QString getWebUiRootFolder() const;

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -31,18 +31,14 @@
 #define PREFERENCES_H
 
 #include <QDateTime>
-#include <QHostAddress>
 #include <QList>
 #include <QNetworkCookie>
-#include <QReadWriteLock>
 #include <QSize>
 #include <QStringList>
 #include <QTime>
-#include <QTimer>
 #include <QVariant>
 
 #include "base/utils/net.h"
-#include "types.h"
 
 enum SchedulerDays
 {

--- a/src/base/utils/net.cpp
+++ b/src/base/utils/net.cpp
@@ -28,6 +28,8 @@
 
 #include "net.h"
 
+#include <QSslCertificate>
+#include <QSslKey>
 #include <QString>
 
 namespace Utils
@@ -87,6 +89,33 @@ namespace Utils
         QString subnetToString(const Subnet &subnet)
         {
             return subnet.first.toString() + '/' + QString::number(subnet.second);
+        }
+
+        QList<QSslCertificate> loadSSLCertificate(const QByteArray &data)
+        {
+            const QList<QSslCertificate> certs {QSslCertificate::fromData(data)};
+            if (std::any_of(certs.cbegin(), certs.cend(), [](const QSslCertificate &c) { return c.isNull(); }))
+                return {};
+            return certs;
+        }
+
+        bool isSSLCertificatesValid(const QByteArray &data)
+        {
+            return !loadSSLCertificate(data).isEmpty();
+        }
+
+        QSslKey loadSSLKey(const QByteArray &data)
+        {
+            // try different formats
+            QSslKey key {data, QSsl::Rsa};
+            if (!key.isNull())
+                return key;
+            return QSslKey(data, QSsl::Ec);
+        }
+
+        bool isSSLKeyValid(const QByteArray &data)
+        {
+            return !loadSSLKey(data).isNull();
         }
     }
 }

--- a/src/base/utils/net.cpp
+++ b/src/base/utils/net.cpp
@@ -28,7 +28,6 @@
 
 #include "net.h"
 
-#include <QHostAddress>
 #include <QString>
 
 namespace Utils

--- a/src/base/utils/net.h
+++ b/src/base/utils/net.h
@@ -33,6 +33,8 @@
 #include <QList>
 #include <QPair>
 
+class QSslCertificate;
+class QSslKey;
 class QString;
 
 namespace Utils
@@ -47,6 +49,12 @@ namespace Utils
         bool isLoopbackAddress(const QHostAddress &addr);
         bool isIPInRange(const QHostAddress &addr, const QList<Subnet> &subnets);
         QString subnetToString(const Subnet &subnet);
+
+        const int MAX_SSL_FILE_SIZE = 1024 * 1024;
+        QList<QSslCertificate> loadSSLCertificate(const QByteArray &data);
+        bool isSSLCertificatesValid(const QByteArray &data);
+        QSslKey loadSSLKey(const QByteArray &data);
+        bool isSSLKeyValid(const QByteArray &data);
     }
 }
 

--- a/src/base/utils/net.h
+++ b/src/base/utils/net.h
@@ -29,10 +29,10 @@
 #ifndef BASE_UTILS_NET_H
 #define BASE_UTILS_NET_H
 
+#include <QHostAddress>
 #include <QList>
 #include <QPair>
 
-class QHostAddress;
 class QString;
 
 namespace Utils

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -60,7 +60,6 @@ class OptionsDialog : public QDialog
     Q_OBJECT
     using ThisType = OptionsDialog;
 
-private:
     enum Tabs
     {
         TAB_UI,
@@ -71,6 +70,12 @@ private:
         TAB_RSS,
         TAB_WEBUI,
         TAB_ADVANCED
+    };
+
+    enum class ShowError
+    {
+        NotShow,
+        Show
     };
 
 public:
@@ -102,10 +107,10 @@ private slots:
     void on_randomButton_clicked();
     void on_addScanFolderButton_clicked();
     void on_removeScanFolderButton_clicked();
-    void on_btnWebUiCrt_clicked();
-    void on_btnWebUiKey_clicked();
     void on_registerDNSBtn_clicked();
     void setLocale(const QString &localeStr);
+    void webUIHttpsCertChanged(const QString &path, ShowError showError);
+    void webUIHttpsKeyChanged(const QString &path, ShowError showError);
 
 private:
     // Methods
@@ -164,17 +169,14 @@ private:
     int getMaxActiveDownloads() const;
     int getMaxActiveUploads() const;
     int getMaxActiveTorrents() const;
+    // WebUI
     bool isWebUiEnabled() const;
     QString webUiUsername() const;
     QString webUiPassword() const;
-    // WebUI SSL Cert / key
-    bool setSslKey(const QByteArray &key);
-    bool setSslCertificate(const QByteArray &cert);
-    bool schedTimesOk();
     bool webUIAuthenticationOk();
     bool isAlternativeWebUIPathValid();
 
-    QByteArray m_sslCert, m_sslKey;
+    bool schedTimesOk();
 
     Ui::OptionsDialog *m_ui;
     QAbstractButton *m_applyButton;

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -2966,79 +2966,25 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                   <bool>false</bool>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_11">
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="lblSslCertStatus"/>
+                  <item row="1" column="1">
+                   <widget class="QLabel" name="lblWebUiKey">
+                    <property name="text">
+                     <string>Key:</string>
+                    </property>
+                   </widget>
                   </item>
                   <item row="0" column="1">
                    <widget class="QLabel" name="lblWebUiCrt">
                     <property name="text">
                      <string>Certificate:</string>
                     </property>
-                    <property name="alignment">
-                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                    </property>
                    </widget>
                   </item>
-                  <item row="0" column="2">
-                   <layout class="QHBoxLayout" name="horizontalLayout_4">
-                    <item>
-                     <widget class="QPushButton" name="btnWebUiCrt">
-                      <property name="text">
-                       <string>Import SSL Certificate</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <spacer name="horizontalSpacer_12">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>138</width>
-                        <height>28</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                   </layout>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="lblSslCertStatus"/>
                   </item>
                   <item row="1" column="0">
                    <widget class="QLabel" name="lblSslKeyStatus"/>
-                  </item>
-                  <item row="1" column="1">
-                   <widget class="QLabel" name="lblWebUiKey">
-                    <property name="text">
-                     <string>Key:</string>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="2">
-                   <layout class="QHBoxLayout" name="horizontalLayout_5">
-                    <item>
-                     <widget class="QPushButton" name="btnWebUiKey">
-                      <property name="text">
-                       <string>Import SSL Key</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <spacer name="horizontalSpacer_13">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>40</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                   </layout>
                   </item>
                   <item row="2" column="0" colspan="3">
                    <widget class="QLabel" name="lblWebUIInfo">
@@ -3049,6 +2995,12 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                      <bool>true</bool>
                     </property>
                    </widget>
+                  </item>
+                  <item row="0" column="2">
+                   <widget class="FileSystemPathLineEdit" name="textWebUIHttpsCert" native="true"/>
+                  </item>
+                  <item row="1" column="2">
+                   <widget class="FileSystemPathLineEdit" name="textWebUIHttpsKey" native="true"/>
                   </item>
                  </layout>
                 </widget>
@@ -3464,8 +3416,6 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
   <tabstop>comboRatioLimitAct</tabstop>
   <tabstop>checkWebUIUPnP</tabstop>
   <tabstop>checkWebUiHttps</tabstop>
-  <tabstop>btnWebUiCrt</tabstop>
-  <tabstop>btnWebUiKey</tabstop>
   <tabstop>checkBypassLocalAuth</tabstop>
   <tabstop>checkBypassAuthSubnetWhitelist</tabstop>
   <tabstop>IPSubnetWhitelistButton</tabstop>

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -39,11 +39,6 @@
 #include <QTimer>
 #include <QTranslator>
 
-#ifndef QT_NO_OPENSSL
-#include <QSslCertificate>
-#include <QSslKey>
-#endif
-
 #include "base/bittorrent/session.h"
 #include "base/global.h"
 #include "base/net/portforwarder.h"
@@ -210,8 +205,8 @@ void AppController::preferencesAction()
     data["web_ui_port"] = pref->getWebUiPort();
     data["web_ui_upnp"] = pref->useUPnPForWebUIPort();
     data["use_https"] = pref->isWebUiHttpsEnabled();
-    data["ssl_key"] = QString::fromLatin1(pref->getWebUiHttpsKey());
-    data["ssl_cert"] = QString::fromLatin1(pref->getWebUiHttpsCertificate());
+    data["web_ui_https_cert_path"] = pref->getWebUIHttpsCertificatePath();
+    data["web_ui_https_key_path"] = pref->getWebUIHttpsKeyPath();
     // Authentication
     data["web_ui_username"] = pref->getWebUiUsername();
     data["bypass_local_auth"] = !pref->isWebUiLocalAuthEnabled();
@@ -505,18 +500,10 @@ void AppController::setPreferencesAction()
         pref->setUPnPForWebUIPort(m["web_ui_upnp"].toBool());
     if (m.contains("use_https"))
         pref->setWebUiHttpsEnabled(m["use_https"].toBool());
-#ifndef QT_NO_OPENSSL
-    if (m.contains("ssl_key")) {
-        QByteArray raw_key = m["ssl_key"].toString().toLatin1();
-        if (!QSslKey(raw_key, QSsl::Rsa).isNull())
-            pref->setWebUiHttpsKey(raw_key);
-    }
-    if (m.contains("ssl_cert")) {
-        QByteArray raw_cert = m["ssl_cert"].toString().toLatin1();
-        if (!QSslCertificate(raw_cert).isNull())
-            pref->setWebUiHttpsCertificate(raw_cert);
-    }
-#endif
+    if ((it = m.find(QLatin1String("web_ui_https_cert_path"))) != m.constEnd())
+        pref->setWebUIHttpsCertificatePath(it.value().toString());
+    if ((it = m.find(QLatin1String("web_ui_https_key_path"))) != m.constEnd())
+        pref->setWebUIHttpsKeyPath(it.value().toString());
     // Authentication
     if (m.contains("web_ui_username"))
         pref->setWebUiUsername(m["web_ui_username"].toString());

--- a/src/webui/www/private/preferences_content.html
+++ b/src/webui/www/private/preferences_content.html
@@ -682,18 +682,18 @@
             <table>
                 <tr>
                     <td>
-                        <label for="ssl_key_textarea">QBT_TR(Key:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                        <label for="ssl_cert_text">QBT_TR(Certificate:)QBT_TR[CONTEXT=OptionsDialog]</label>
                     </td>
                     <td>
-                        <textarea id="ssl_key_textarea" rows="5" cols="70"></textarea>
+                        <input type="text" id="ssl_cert_text" style="width: 30em;" />
                     </td>
                 </tr>
                 <tr>
                     <td>
-                        <label for="ssl_cert_textarea">QBT_TR(Certificate:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                        <label for="ssl_key_text">QBT_TR(Key:)QBT_TR[CONTEXT=OptionsDialog]</label>
                     </td>
                     <td>
-                        <textarea id="ssl_cert_textarea" rows="5" cols="70"></textarea>
+                        <input type="text" id="ssl_key_text" style="width: 30em;" />
                     </td>
                 </tr>
             </table>
@@ -1043,8 +1043,8 @@
     // Web UI tab
     var updateHttpsSettings = function() {
         var isUseHttpsEnabled = $('use_https_checkbox').getProperty('checked');
-        $('ssl_key_textarea').setProperty('disabled', !isUseHttpsEnabled);
-        $('ssl_cert_textarea').setProperty('disabled', !isUseHttpsEnabled);
+        $('ssl_cert_text').setProperty('disabled', !isUseHttpsEnabled);
+        $('ssl_key_text').setProperty('disabled', !isUseHttpsEnabled);
     };
 
     var updateBypasssAuthSettings = function() {
@@ -1330,8 +1330,8 @@
                     $('webui_port_value').setProperty('value', pref.web_ui_port);
                     $('webui_upnp_checkbox').setProperty('checked', pref.web_ui_upnp);
                     $('use_https_checkbox').setProperty('checked', pref.use_https);
-                    $('ssl_key_textarea').setProperty('value', pref.ssl_key);
-                    $('ssl_cert_textarea').setProperty('value', pref.ssl_cert);
+                    $('ssl_cert_text').setProperty('value', pref.web_ui_https_cert_path);
+                    $('ssl_key_text').setProperty('value', pref.web_ui_https_key_path);
                     updateHttpsSettings();
 
                     // Authentication
@@ -1646,8 +1646,8 @@
         settings.set('web_ui_port', web_ui_port);
         settings.set('web_ui_upnp', $('webui_upnp_checkbox').getProperty('checked'));
         settings.set('use_https', $('use_https_checkbox').getProperty('checked'));
-        settings.set('ssl_key', $('ssl_key_textarea').getProperty('value'));
-        settings.set('ssl_cert', $('ssl_cert_textarea').getProperty('value'));
+        settings.set('web_ui_https_cert_path', $('ssl_cert_text').getProperty('value'));
+        settings.set('web_ui_https_key_path', $('ssl_key_text').getProperty('value'));
 
         // Authentication
         var web_ui_username = $('webui_username_text').getProperty('value');


### PR DESCRIPTION
* Load WebUI certificate & key from file path
  This allow users to update certificate & key more easily, i.e. without the need to import them into qbt.
  Closes #6675, #7547, #8315, #8564.
* Cleanup header inclusion

This will break WebUI users who have https setup, I think it is best suited for qbt v4.2.0 which comes with other WebUI break/changes.

Screenshots:
* ![GUI](https://user-images.githubusercontent.com/9395168/51296404-1519cc80-1a57-11e9-81f6-a153daf76b34.png)
* ![WebUI](https://user-images.githubusercontent.com/9395168/51296405-15b26300-1a57-11e9-8b4c-8bcbb7c5d90a.png)
