### PR TITLE
[Search Engine] Fix invalid certificates

### DIFF
--- a/src/searchengine/nova/helpers.py
+++ b/src/searchengine/nova/helpers.py
@@ -1,4 +1,4 @@
-#VERSION: 1.43
+#VERSION: 1.45
 
 # Author:
 #  Christophe DUMEZ (chris@qbittorrent.org)
@@ -35,12 +35,16 @@ import os
 import re
 import socket
 import socks
+import ssl
 import StringIO
 import tempfile
 import urllib2
 
+# Some sites have invalid certificates
+ssl._create_default_https_context = ssl._create_unverified_context
+
 # Some sites blocks default python User-agent
-user_agent = 'Mozilla/5.0 (X11; Linux i686; rv:38.0) Gecko/20100101 Firefox/38.0'
+user_agent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:64.0) Gecko/20100101 Firefox/64.0'
 headers = {'User-Agent': user_agent}
 # SOCKS5 Proxy support
 if ("sock_proxy" in os.environ) and (len(os.environ["sock_proxy"].strip()) > 0):

--- a/src/searchengine/nova3/helpers.py
+++ b/src/searchengine/nova3/helpers.py
@@ -1,4 +1,4 @@
-#VERSION: 1.42
+#VERSION: 1.45
 
 # Author:
 #  Christophe DUMEZ (chris@qbittorrent.org)
@@ -34,13 +34,17 @@ import os
 import re
 import socket
 import socks
+import ssl
 import tempfile
 import urllib.error
 import urllib.parse
 import urllib.request
 
+# Some sites have invalid certificates
+ssl._create_default_https_context = ssl._create_unverified_context
+
 # Some sites blocks default python User-agent
-user_agent = 'Mozilla/5.0 (X11; Linux i686; rv:38.0) Gecko/20100101 Firefox/38.0'
+user_agent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:64.0) Gecko/20100101 Firefox/64.0'
 headers = {'User-Agent': user_agent}
 # SOCKS5 Proxy support
 if "sock_proxy" in os.environ and len(os.environ["sock_proxy"].strip()) > 0:


### PR DESCRIPTION
Limetorrents and piratebay plugins are not working in Windows due to SSL certificates validation. This PR fixes that.

Tested in:
* Windows 10 / Python2
* Windows 10 / Python3
* Linux / Python2
* Linux / Python3