### PR TITLE
Remove autocorrect/autocapitalise in WebUI

### DIFF
--- a/src/webui/www/private/download.html
+++ b/src/webui/www/private/download.html
@@ -14,7 +14,7 @@
 
 <body>
     <iframe id="download_frame" name="download_frame" class="invisible" src="javascript:false;"></iframe>
-    <form action="api/v2/torrents/add" enctype="multipart/form-data" method="post" id="downloadForm" style="text-align: center;" target="download_frame">
+    <form action="api/v2/torrents/add" enctype="multipart/form-data" method="post" id="downloadForm" style="text-align: center;" target="download_frame" autocorrect="off" autocapitalize="none">
         <div style="text-align: center;">
             <br/>
             <h2 class="vcenter">QBT_TR(Download Torrents from their URLs or Magnet links)QBT_TR[CONTEXT=HttpServer]</h2>

--- a/src/webui/www/private/preferences_content.html
+++ b/src/webui/www/private/preferences_content.html
@@ -80,7 +80,7 @@
                     <label for="savepath_text">QBT_TR(Default Save Path:)QBT_TR[CONTEXT=OptionsDialog]</label>
                 </td>
                 <td>
-                    <input type="text" id="savepath_text" />
+                    <input type="text" id="savepath_text" autocorrect="off" autocapitalize="none" />
                 </td>
             </tr>
             <tr>
@@ -89,7 +89,7 @@
                     <label for="temppath_checkbox">QBT_TR(Keep incomplete torrents in:)QBT_TR[CONTEXT=OptionsDialog]</label>
                 </td>
                 <td>
-                    <input type="text" id="temppath_text" />
+                    <input type="text" id="temppath_text" autocorrect="off" autocapitalize="none" />
                 </td>
             </tr>
             <tr>
@@ -98,7 +98,7 @@
                     <label for="exportdir_checkbox">QBT_TR(Copy .torrent files to:)QBT_TR[CONTEXT=OptionsDialog]</label>
                 </td>
                 <td>
-                    <input type="text" id="exportdir_text" />
+                    <input type="text" id="exportdir_text" autocorrect="off" autocapitalize="none" />
                 </td>
             </tr>
             <tr>
@@ -107,7 +107,7 @@
                     <label for="exportdirfin_checkbox">QBT_TR(Copy .torrent files for finished downloads to:)QBT_TR[CONTEXT=OptionsDialog]</label>
                 </td>
                 <td>
-                    <input type="text" id="exportdirfin_text" />
+                    <input type="text" id="exportdirfin_text" autocorrect="off" autocapitalize="none" />
                 </td>
             </tr>
         </table>
@@ -125,7 +125,7 @@
             <tbody></tbody>
             <tfoot>
                 <tr>
-                    <td style="padding-top:4px;"><input type="text" id="new_watch_folder_txt" /></td>
+                    <td style="padding-top:4px;"><input type="text" id="new_watch_folder_txt" autocorrect="off" autocapitalize="none" /></td>
                     <td style="padding-top:4px;">
                         <div class="select-watched-folder-editable">
                             <select id="new_watch_folder_select" onchange="changeWatchFolderSelect(this)">

--- a/src/webui/www/private/setlocation.html
+++ b/src/webui/www/private/setlocation.html
@@ -68,7 +68,7 @@
 <body>
     <div style="padding: 10px 10px 0px 10px;">
         <p style="font-weight: bold;">QBT_TR(Location)QBT_TR[CONTEXT=TransferListWidget]:</p>
-        <input type="text" id="setLocation" value="" maxlength="100" style="width: 370px;" />
+        <input type="text" id="setLocation" value="" maxlength="100" autocorrect="off" autocapitalize="none" style="width: 370px;" />
         <div style="float: none; width: 370px;" id="error_div">&nbsp;</div>
         <div style="text-align: center; padding-top: 10px;">
             <input type="button" value="QBT_TR(Save)QBT_TR[CONTEXT=HttpServer]" id="setLocationButton" />

--- a/src/webui/www/private/upload.html
+++ b/src/webui/www/private/upload.html
@@ -12,7 +12,7 @@
 
 <body>
     <iframe id="upload_frame" name="upload_frame" class="invisible" src="javascript:false;"></iframe>
-    <form action="api/v2/torrents/add" enctype="multipart/form-data" method="post" id="uploadForm" style="text-align: center;" target="upload_frame">
+    <form action="api/v2/torrents/add" enctype="multipart/form-data" method="post" id="uploadForm" style="text-align: center;" target="upload_frame" autocorrect="off" autocapitalize="none">
         <div style="margin-top: 25px; display: inline-block; border: 1px solid lightgrey; border-radius: 4px;">
             <input type="file" id="fileselect" name="fileselect[]" multiple="multiple" />
         </div>


### PR DESCRIPTION
Closes an issue in #9796 the autocorrect and autocapitalise should be removed from filepath inputs, this is a larger issue for mobile devices using the WebUI.

This is the same commit as what should be in #9841 however when trying to rebase I closed that commit.