### PR TITLE
Separate URL components before percent-decoding. Closes #9116

### DIFF
--- a/src/base/bittorrent/tracker.cpp
+++ b/src/base/bittorrent/tracker.cpp
@@ -140,8 +140,11 @@ void Tracker::respondToAnnounceRequest()
         const int sepPos = param.indexOf('=');
         if (sepPos <= 0) continue; // ignores params without name
 
-        const QString paramName {QString::fromUtf8(param.constData(), sepPos)};
-        const QByteArray paramValue {param.mid(sepPos + 1)};
+        const QByteArray nameComponent = midView(param, 0, sepPos);
+        const QByteArray valueComponent = midView(param, (sepPos + 1));
+
+        const QString paramName = QString::fromUtf8(QByteArray::fromPercentEncoding(nameComponent));
+        const QByteArray paramValue = QByteArray::fromPercentEncoding(valueComponent);
         queryParams[paramName] = paramValue;
     }
 

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -423,10 +423,11 @@ Http::Response WebApplication::processRequest(const Http::Request &request, cons
             const int sepPos = param.indexOf('=');
             if (sepPos <= 0) continue; // ignores params without name
 
-            const QString paramName {QString::fromUtf8(param.constData(), sepPos)};
-            const int valuePos = sepPos + 1;
-            const QString paramValue {
-                QString::fromUtf8(param.constData() + valuePos, param.size() - valuePos)};
+            const QByteArray nameComponent = midView(param, 0, sepPos);
+            const QByteArray valueComponent = midView(param, (sepPos + 1));
+
+            const QString paramName = QString::fromUtf8(QByteArray::fromPercentEncoding(nameComponent));
+            const QString paramValue = QString::fromUtf8(QByteArray::fromPercentEncoding(valueComponent));
             m_params[paramName] = paramValue;
         }
     }


### PR DESCRIPTION
Allow special characters in query string parameters.

NOTE: this PR should be backported to 4.1 branch.
