### PR TITLE
Some suggestions from Clang-tidy

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -345,7 +345,7 @@ void Application::sendNotificationEmail(const BitTorrent::TorrentHandle *torrent
 
     // Send the notification email
     const Preferences *pref = Preferences::instance();
-    Net::Smtp *smtp = new Net::Smtp(this);
+    auto *smtp = new Net::Smtp(this);
     smtp->sendMail(pref->getMailNotificationSender(),
                      pref->getMailNotificationEmail(),
                      tr("[qBittorrent] '%1' has finished downloading").arg(torrent->name()),

--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -89,8 +89,8 @@ namespace
 
             if ((USAGE_TEXT_COLUMN - usage.length() - 4) > 0)
                 return res + QString(USAGE_TEXT_COLUMN - usage.length() - 4, ' ');
-            else
-                return res;
+
+            return res;
         }
 
     private:
@@ -256,13 +256,13 @@ namespace
             if (parts.size() == 1) {
                 return TriStateBool(m_defaultValue);
             }
-            else if (parts.size() == 2) {
+            if (parts.size() == 2) {
                 QString val = parts[1];
 
                 if ((val.toUpper() == QLatin1String("TRUE")) || (val == QLatin1String("1"))) {
                     return TriStateBool::True;
                 }
-                else if ((val.toUpper() == QLatin1String("FALSE")) || (val == QLatin1String("0"))) {
+                if ((val.toUpper() == QLatin1String("FALSE")) || (val == QLatin1String("0"))) {
                     return TriStateBool::False;
                 }
             }
@@ -281,20 +281,19 @@ namespace
             if (val.isEmpty()) {
                 return TriStateBool(m_defaultValue);
             }
-            else if (val == QLatin1String("-1")) {
+            if (val == QLatin1String("-1")) {
                 return TriStateBool::Undefined;
             }
-            else if ((val.toUpper() == QLatin1String("TRUE")) || (val == QLatin1String("1"))) {
+            if ((val.toUpper() == QLatin1String("TRUE")) || (val == QLatin1String("1"))) {
                 return TriStateBool::True;
             }
-            else if ((val.toUpper() == QLatin1String("FALSE")) || (val == QLatin1String("0"))) {
+            if ((val.toUpper() == QLatin1String("FALSE")) || (val == QLatin1String("0"))) {
                 return TriStateBool::False;
             }
-            else {
-                qDebug() << QObject::tr("Expected %1 in environment variable '%2', but got '%3'")
-                    .arg(QLatin1String("true|false"), envVarName(), val);
-                return TriStateBool::Undefined;
-            }
+
+            qDebug() << QObject::tr("Expected %1 in environment variable '%2', but got '%3'")
+                .arg(QLatin1String("true|false"), envVarName(), val);
+            return TriStateBool::Undefined;
         }
 
         bool m_defaultValue;

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -29,6 +29,7 @@
 
 #include <QtGlobal>
 
+#include <csignal>
 #include <cstdlib>
 
 #if !defined Q_OS_WIN && !defined Q_OS_HAIKU
@@ -59,7 +60,6 @@ Q_IMPORT_PLUGIN(QICOPlugin)
 #include <cstdio>
 #endif // DISABLE_GUI
 
-#include <signal.h>
 #ifdef STACKTRACE
 #ifdef Q_OS_UNIX
 #include "stacktrace.h"

--- a/src/base/bittorrent/private/filterparserthread.cpp
+++ b/src/base/bittorrent/private/filterparserthread.cpp
@@ -177,9 +177,8 @@ int FilterParserThread::parseDATFilterFile()
                 memmove(buffer.data(), buffer.data() + start, offset);
                 break;
             }
-            else {
-                ++nbLine;
-            }
+
+            ++nbLine;
 
             if ((buffer[start] == '#')
                 || ((buffer[start] == '/') && ((start + 1 < dataSize) && (buffer[start + 1] == '/')))) {
@@ -325,9 +324,8 @@ int FilterParserThread::parseP2PFilterFile()
                 memmove(buffer.data(), buffer.data() + start, offset);
                 break;
             }
-            else {
-                ++nbLine;
-            }
+
+            ++nbLine;
 
             if ((buffer[start] == '#')
                 || ((buffer[start] == '/') && ((start + 1 < dataSize) && (buffer[start + 1] == '/')))) {

--- a/src/base/bittorrent/private/speedmonitor.cpp
+++ b/src/base/bittorrent/private/speedmonitor.cpp
@@ -47,10 +47,10 @@ void SpeedMonitor::addSample(const SpeedSample &sample)
 SpeedSampleAvg SpeedMonitor::average() const
 {
     if (m_speedSamples.empty())
-        return SpeedSampleAvg();
+        return {};
 
     const qreal k = qreal(1.) / m_speedSamples.size();
-    return SpeedSampleAvg(m_sum.download * k, m_sum.upload * k);
+    return {m_sum.download * k, m_sum.upload * k};
 }
 
 void SpeedMonitor::reset()

--- a/src/base/bittorrent/private/statistics.cpp
+++ b/src/base/bittorrent/private/statistics.cpp
@@ -30,15 +30,12 @@
 
 #include <QDateTime>
 
-#include <libtorrent/session.hpp>
-
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/sessionstatus.h"
 #include "base/profile.h"
 
 static const qint64 SAVE_INTERVAL = 15 * 60 * 1000;
 
-namespace libt = libtorrent;
 using namespace BitTorrent;
 
 Statistics::Statistics(Session *session)

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -4299,11 +4299,11 @@ namespace
 
         using PCONVERTIFACENAMETOLUID = NETIO_STATUS (WINAPI *)(const WCHAR *, PNET_LUID);
         const auto ConvertIfaceNameToLuid = Utils::Misc::loadWinAPI<PCONVERTIFACENAMETOLUID>("Iphlpapi.dll", "ConvertInterfaceNameToLuidW");
-        if (!ConvertIfaceNameToLuid) return QString();
+        if (!ConvertIfaceNameToLuid) return {};
 
         using PCONVERTIFACELUIDTOGUID = NETIO_STATUS (WINAPI *)(const NET_LUID *, GUID *);
         const auto ConvertIfaceLuidToGuid = Utils::Misc::loadWinAPI<PCONVERTIFACELUIDTOGUID>("Iphlpapi.dll", "ConvertInterfaceLuidToGuid");
-        if (!ConvertIfaceLuidToGuid) return QString();
+        if (!ConvertIfaceLuidToGuid) return {};
 
         NET_LUID luid;
         const LONG res = ConvertIfaceNameToLuid(name.toStdWString().c_str(), &luid);
@@ -4313,7 +4313,7 @@ namespace
                 return QUuid(guid).toString().toUpper();
         }
 
-        return QString();
+        return {};
     }
 #endif
 }

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -297,7 +297,7 @@ QString TorrentHandle::savePath(bool actual) const
 QString TorrentHandle::rootPath(bool actual) const
 {
     if ((filesCount() > 1) && !hasRootFolder())
-        return QString();
+        return {};
 
     const QString firstFilePath = filePath(0);
     const int slashIndex = firstFilePath.indexOf('/');
@@ -593,7 +593,7 @@ QString TorrentHandle::filePath(int index) const
 
 QString TorrentHandle::fileName(int index) const
 {
-    if (!hasMetadata()) return QString();
+    if (!hasMetadata()) return {};
     return Utils::Fs::fileName(filePath(index));
 }
 
@@ -606,7 +606,7 @@ qlonglong TorrentHandle::fileSize(int index) const
 // to all files in a torrent
 QStringList TorrentHandle::absoluteFilePaths() const
 {
-    if (!hasMetadata()) return QStringList();
+    if (!hasMetadata()) return {};
 
     const QDir saveDir(savePath(true));
     QStringList res;
@@ -617,7 +617,7 @@ QStringList TorrentHandle::absoluteFilePaths() const
 
 QStringList TorrentHandle::absoluteFilePathsUnwanted() const
 {
-    if (!hasMetadata()) return QStringList();
+    if (!hasMetadata()) return {};
 
     const QDir saveDir(savePath(true));
     QStringList res;
@@ -987,7 +987,7 @@ QDateTime TorrentHandle::lastSeenComplete() const
     if (m_nativeStatus.last_seen_complete > 0)
         return QDateTime::fromTime_t(m_nativeStatus.last_seen_complete);
     else
-        return QDateTime();
+        return {};
 }
 
 QDateTime TorrentHandle::completedTime() const
@@ -995,7 +995,7 @@ QDateTime TorrentHandle::completedTime() const
     if (m_nativeStatus.completed_time > 0)
         return QDateTime::fromTime_t(m_nativeStatus.completed_time);
     else
-        return QDateTime();
+        return {};
 }
 
 int TorrentHandle::timeSinceUpload() const

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -133,32 +133,32 @@ bool TorrentInfo::isValid() const
 
 InfoHash TorrentInfo::hash() const
 {
-    if (!isValid()) return InfoHash();
+    if (!isValid()) return {};
     return m_nativeInfo->info_hash();
 }
 
 QString TorrentInfo::name() const
 {
-    if (!isValid()) return QString();
+    if (!isValid()) return {};
     return QString::fromStdString(m_nativeInfo->name());
 }
 
 QDateTime TorrentInfo::creationDate() const
 {
-    if (!isValid()) return QDateTime();
+    if (!isValid()) return {};
     const boost::optional<time_t> t = m_nativeInfo->creation_date();
     return t ? QDateTime::fromTime_t(*t) : QDateTime();
 }
 
 QString TorrentInfo::creator() const
 {
-    if (!isValid()) return QString();
+    if (!isValid()) return {};
     return QString::fromStdString(m_nativeInfo->creator());
 }
 
 QString TorrentInfo::comment() const
 {
-    if (!isValid()) return QString();
+    if (!isValid()) return {};
     return QString::fromStdString(m_nativeInfo->comment());
 }
 
@@ -200,7 +200,7 @@ int TorrentInfo::piecesCount() const
 
 QString TorrentInfo::filePath(const int index) const
 {
-    if (!isValid()) return QString();
+    if (!isValid()) return {};
     return Utils::Fs::fromNativePath(QString::fromStdString(m_nativeInfo->files().file_path(index)));
 }
 
@@ -220,7 +220,7 @@ QString TorrentInfo::fileName(const int index) const
 
 QString TorrentInfo::origFilePath(const int index) const
 {
-    if (!isValid()) return QString();
+    if (!isValid()) return {};
     return Utils::Fs::fromNativePath(QString::fromStdString(m_nativeInfo->orig_files().file_path(index)));
 }
 
@@ -238,7 +238,7 @@ qlonglong TorrentInfo::fileOffset(const int index) const
 
 QList<TrackerEntry> TorrentInfo::trackers() const
 {
-    if (!isValid()) return QList<TrackerEntry>();
+    if (!isValid()) return {};
 
     QList<TrackerEntry> trackers;
     for (const libt::announce_entry &tracker : m_nativeInfo->trackers())
@@ -249,7 +249,7 @@ QList<TrackerEntry> TorrentInfo::trackers() const
 
 QList<QUrl> TorrentInfo::urlSeeds() const
 {
-    if (!isValid()) return QList<QUrl>();
+    if (!isValid()) return {};
 
     QList<QUrl> urlSeeds;
     for (const libt::web_seed_entry &webSeed : m_nativeInfo->web_seeds())
@@ -261,8 +261,8 @@ QList<QUrl> TorrentInfo::urlSeeds() const
 
 QByteArray TorrentInfo::metadata() const
 {
-    if (!isValid()) return QByteArray();
-    return QByteArray(m_nativeInfo->metadata().get(), m_nativeInfo->metadata_size());
+    if (!isValid()) return {};
+    return {m_nativeInfo->metadata().get(), m_nativeInfo->metadata_size()};
 }
 
 QStringList TorrentInfo::filesForPiece(const int pieceIndex) const
@@ -281,7 +281,7 @@ QStringList TorrentInfo::filesForPiece(const int pieceIndex) const
 QVector<int> TorrentInfo::fileIndicesForPiece(const int pieceIndex) const
 {
     if (!isValid() || (pieceIndex < 0) || (pieceIndex >= piecesCount()))
-        return QVector<int>();
+        return {};
 
     const std::vector<libt::file_slice> files(
         nativeInfo()->map_block(pieceIndex, 0, nativeInfo()->piece_size(pieceIndex)));

--- a/src/base/bittorrent/trackerentry.cpp
+++ b/src/base/bittorrent/trackerentry.cpp
@@ -59,12 +59,12 @@ TrackerEntry::Status TrackerEntry::status() const
     // true when the tracker hasn't been tried yet.
     if (m_nativeEntry.verified && m_nativeEntry.is_working())
         return Working;
-    else if ((m_nativeEntry.fails == 0) && m_nativeEntry.updating)
+    if ((m_nativeEntry.fails == 0) && m_nativeEntry.updating)
         return Updating;
-    else if (m_nativeEntry.fails == 0)
+    if (m_nativeEntry.fails == 0)
         return NotContacted;
-    else
-        return NotWorking;
+
+    return NotWorking;
 }
 
 void TrackerEntry::setTier(const int value)

--- a/src/base/http/server.cpp
+++ b/src/base/http/server.cpp
@@ -74,7 +74,7 @@ Server::Server(IRequestHandler *requestHandler, QObject *parent)
     setProxy(QNetworkProxy::NoProxy);
     QSslSocket::setDefaultCiphers(safeCipherList());
 
-    QTimer *dropConnectionTimer = new QTimer(this);
+    auto *dropConnectionTimer = new QTimer(this);
     connect(dropConnectionTimer, &QTimer::timeout, this, &Server::dropTimedOutConnection);
     dropConnectionTimer->start(CONNECTIONS_SCAN_INTERVAL * 1000);
 }
@@ -102,7 +102,7 @@ void Server::incomingConnection(qintptr socketDescriptor)
         static_cast<QSslSocket *>(serverSocket)->startServerEncryption();
     }
 
-    Connection *c = new Connection(serverSocket, m_requestHandler, this);
+    auto *c = new Connection(serverSocket, m_requestHandler, this);
     m_connections.append(c);
 }
 

--- a/src/base/logger.cpp
+++ b/src/base/logger.cpp
@@ -98,7 +98,7 @@ QVector<Log::Msg> Logger::getMessages(int lastKnownId) const
         return m_messages;
 
     if (diff <= 0)
-        return QVector<Log::Msg>();
+        return {};
 
     return m_messages.mid(size - diff);
 }
@@ -114,7 +114,7 @@ QVector<Log::Peer> Logger::getPeers(int lastKnownId) const
         return m_peers;
 
     if (diff <= 0)
-        return QVector<Log::Peer>();
+        return {};
 
     return m_peers.mid(size - diff);
 }

--- a/src/base/net/dnsupdater.cpp
+++ b/src/base/net/dnsupdater.cpp
@@ -288,11 +288,11 @@ QUrl DNSUpdater::getRegistrationUrl(int service)
 {
     switch (service) {
     case DNS::DYNDNS:
-        return QUrl("https://www.dyndns.com/account/services/hosts/add.html");
+        return {"https://www.dyndns.com/account/services/hosts/add.html"};
     case DNS::NOIP:
-        return QUrl("https://www.noip.com/remote-access");
+        return {"https://www.noip.com/remote-access"};
     default:
         Q_ASSERT(0);
     }
-    return QUrl();
+    return {};
 }

--- a/src/base/net/geoipmanager.cpp
+++ b/src/base/net/geoipmanager.cpp
@@ -129,7 +129,7 @@ QString GeoIPManager::lookup(const QHostAddress &hostAddr) const
     if (m_enabled && m_geoIPDatabase)
         return m_geoIPDatabase->lookup(hostAddr);
 
-    return QString();
+    return {};
 }
 
 QString GeoIPManager::CountryName(const QString &countryISOCode)

--- a/src/base/net/private/geoipdatabase.cpp
+++ b/src/base/net/private/geoipdatabase.cpp
@@ -176,7 +176,7 @@ QString GeoIPDatabase::lookup(const QHostAddress &hostAddr) const
             fromBigEndian(idPtr, 4);
 
             if (id == m_nodeCount) {
-                return QString();
+                return {};
             }
             if (id > m_nodeCount) {
                 QString country = m_countries.value(id);
@@ -196,7 +196,7 @@ QString GeoIPDatabase::lookup(const QHostAddress &hostAddr) const
         }
     }
 
-    return QString();
+    return {};
 }
 
 #define CHECK_METADATA_REQ(key, type) \
@@ -304,14 +304,14 @@ QVariantHash GeoIPDatabase::readMetadata() const
             return metadata.toHash();
     }
 
-    return QVariantHash();
+    return {};
 }
 
 QVariant GeoIPDatabase::readDataField(quint32 &offset) const
 {
     DataFieldDescriptor descr;
     if (!readDataFieldDescriptor(offset, descr))
-        return QVariant();
+        return {};
 
     quint32 locOffset = offset;
     bool usePointer = false;
@@ -320,7 +320,7 @@ QVariant GeoIPDatabase::readDataField(quint32 &offset) const
         // convert offset from data section to global
         locOffset = descr.offset + (m_nodeCount * m_recordSize / 4) + sizeof(DATA_SECTION_SEPARATOR);
         if (!readDataFieldDescriptor(locOffset, descr))
-            return QVariant();
+            return {};
     }
 
     QVariant fieldValue;
@@ -459,12 +459,12 @@ QVariant GeoIPDatabase::readMapValue(quint32 &offset, quint32 count) const
     for (quint32 i = 0; i < count; ++i) {
         QVariant field = readDataField(offset);
         if (field.userType() != QMetaType::QString)
-            return QVariant();
+            return {};
 
         QString key = field.toString();
         field = readDataField(offset);
         if (field.userType() == QVariant::Invalid)
-            return QVariant();
+            return {};
 
         map[key] = field;
     }
@@ -479,7 +479,7 @@ QVariant GeoIPDatabase::readArrayValue(quint32 &offset, quint32 count) const
     for (quint32 i = 0; i < count; ++i) {
         QVariant field = readDataField(offset);
         if (field.userType() == QVariant::Invalid)
-            return QVariant();
+            return {};
 
         array.append(field);
     }

--- a/src/base/net/private/geoipdatabase.cpp
+++ b/src/base/net/private/geoipdatabase.cpp
@@ -178,7 +178,7 @@ QString GeoIPDatabase::lookup(const QHostAddress &hostAddr) const
             if (id == m_nodeCount) {
                 return QString();
             }
-            else if (id > m_nodeCount) {
+            if (id > m_nodeCount) {
                 QString country = m_countries.value(id);
                 if (country.isEmpty()) {
                     const quint32 offset = id - m_nodeCount - sizeof(DATA_SECTION_SEPARATOR);
@@ -191,9 +191,8 @@ QString GeoIPDatabase::lookup(const QHostAddress &hostAddr) const
                 }
                 return country;
             }
-            else {
-                ptr = m_data + (id * m_nodeSize);
-            }
+
+            ptr = m_data + (id * m_nodeSize);
         }
     }
 
@@ -205,7 +204,7 @@ if (!metadata.contains(#key)) { \
     error = errMsgNotFound.arg(#key); \
     return false; \
 } \
-else if (metadata.value(#key).userType() != QMetaType::type) { \
+if (metadata.value(#key).userType() != QMetaType::type) { \
     error = errMsgInvalid.arg(#key);  \
     return false; \
 }

--- a/src/base/net/private/geoipdatabase.cpp
+++ b/src/base/net/private/geoipdatabase.cpp
@@ -171,7 +171,7 @@ QString GeoIPDatabase::lookup(const QHostAddress &hostAddr) const
                 ptr += m_recordBytes;
 
             quint32 id = 0;
-            uchar *idPtr = reinterpret_cast<uchar *>(&id);
+            auto *idPtr = reinterpret_cast<uchar *>(&id);
             memcpy(&idPtr[4 - m_recordBytes], ptr, m_recordBytes);
             fromBigEndian(idPtr, 4);
 
@@ -298,7 +298,7 @@ QVariantHash GeoIPDatabase::readMetadata() const
     if (index >= 0) {
         if (m_size > MAX_METADATA_SIZE)
             index += (m_size - MAX_METADATA_SIZE); // from begin of all data
-        quint32 offset = static_cast<quint32>(index + strlen(METADATA_BEGIN_MARK));
+        auto offset = static_cast<quint32>(index + strlen(METADATA_BEGIN_MARK));
         QVariant metadata = readDataField(offset);
         if (metadata.userType() == QMetaType::QVariantHash)
             return metadata.toHash();

--- a/src/base/rss/private/rss_parser.cpp
+++ b/src/base/rss/private/rss_parser.cpp
@@ -464,7 +464,7 @@ namespace
                 offset = parts[2].toInt(&ok[0]) * 3600;
                 int offsetMin = parts[3].toInt(&ok[1]);
                 if (!ok[0] || !ok[1] || offsetMin > 59)
-                    return QDateTime();
+                    return {};
                 offset += offsetMin * 60;
                 negOffset = (parts[1] == QLatin1String("-"));
                 if (negOffset)
@@ -494,7 +494,7 @@ namespace
                         for (int i = 0, end = zone.size(); (i < end) && !nonalpha; ++i)
                             nonalpha = !isalpha(zone[i]);
                         if (nonalpha)
-                            return QDateTime();
+                            return {};
                         // TODO: Attempt to recognize the time zone abbreviation?
                         negOffset = true;    // unknown time zone: RFC 2822 treats as '-0000'
                     }

--- a/src/base/rss/private/rss_parser.cpp
+++ b/src/base/rss/private/rss_parser.cpp
@@ -556,22 +556,20 @@ void Parser::parse_impl(const QByteArray &feedData)
                     foundChannel = true;
                     break;
                 }
-                else {
-                    qDebug() << "Skip rss item: " << xml.name();
-                    xml.skipCurrentElement();
-                }
+
+                qDebug() << "Skip rss item: " << xml.name();
+                xml.skipCurrentElement();
             }
             break;
         }
-        else if (xml.name() == "feed") { // Atom feed
+        if (xml.name() == "feed") { // Atom feed
             parseAtomChannel(xml);
             foundChannel = true;
             break;
         }
-        else {
-            qDebug() << "Skip root item: " << xml.name();
-            xml.skipCurrentElement();
-        }
+
+        qDebug() << "Skip root item: " << xml.name();
+        xml.skipCurrentElement();
     }
 
     if (!foundChannel) {

--- a/src/base/rss/rss_autodownloadrule.cpp
+++ b/src/base/rss/rss_autodownloadrule.cpp
@@ -68,7 +68,7 @@ namespace
         switch (static_cast<int>(triStateBool)) {
         case 0:  return false;
         case 1:  return true;
-        default: return QJsonValue();
+        default: return {};
         }
     }
 
@@ -159,7 +159,7 @@ QString computeEpisodeName(const QString &article)
 
     // See if we can extract an season/episode number or date from the title
     if (!match.hasMatch())
-        return QString();
+        return {};
 
     QStringList ret;
     for (int i = 1; i <= match.lastCapturedIndex(); ++i) {

--- a/src/base/rss/rss_item.cpp
+++ b/src/base/rss/rss_item.cpp
@@ -81,8 +81,8 @@ QString Item::joinPath(const QString &path1, const QString &path2)
 {
     if (path1.isEmpty())
         return path2;
-    else
-        return path1 + Item::PathSeparator + path2;
+
+    return (path1 + Item::PathSeparator + path2);
 }
 
 QStringList Item::expandPath(const QString &path)

--- a/src/base/scanfoldersmodel.cpp
+++ b/src/base/scanfoldersmodel.cpp
@@ -107,7 +107,7 @@ int ScanFoldersModel::columnCount(const QModelIndex &parent) const
 QVariant ScanFoldersModel::data(const QModelIndex &index, int role) const
 {
     if (!index.isValid() || (index.row() >= rowCount()))
-        return QVariant();
+        return {};
 
     const PathData *pathData = m_pathList.at(index.row());
     QVariant value;
@@ -141,7 +141,7 @@ QVariant ScanFoldersModel::data(const QModelIndex &index, int role) const
 QVariant ScanFoldersModel::headerData(int section, Qt::Orientation orientation, int role) const
 {
     if ((orientation != Qt::Horizontal) || (role != Qt::DisplayRole) || (section < 0) || (section >= columnCount()))
-        return QVariant();
+        return {};
 
     QVariant title;
 
@@ -311,7 +311,7 @@ QString ScanFoldersModel::downloadPathTorrentFolder(const QString &filePath) con
     if (data->downloadType == CUSTOM_LOCATION)
         return data->downloadPath;
 
-    return  QString();
+    return {};
 }
 
 int ScanFoldersModel::findPathData(const QString &path) const
@@ -399,5 +399,5 @@ QString ScanFoldersModel::pathTypeDisplayName(const PathType type)
     default:
         qDebug("Invalid PathType: %d", type);
     };
-    return QString();
+    return {};
 }

--- a/src/base/scanfoldersmodel.cpp
+++ b/src/base/scanfoldersmodel.cpp
@@ -183,7 +183,7 @@ bool ScanFoldersModel::setData(const QModelIndex &index, const QVariant &value, 
         return false;
 
     if (role == Qt::UserRole) {
-        PathType type = static_cast<PathType>(value.toInt());
+        auto type = static_cast<PathType>(value.toInt());
         if (type == CUSTOM_LOCATION)
             return false;
 

--- a/src/base/settingsstorage.cpp
+++ b/src/base/settingsstorage.cpp
@@ -282,7 +282,7 @@ QString TransactionalSettings::deserialize(const QString &name, QVariantHash &da
     SettingsPtr settings = Profile::instance().applicationSettings(name);
 
     if (settings->allKeys().isEmpty())
-        return QString();
+        return {};
 
     // Copy everything into memory. This means even keys inserted in the file manually
     // or that we don't touch directly in this code (eg disabled by ifdef). This ensures
@@ -314,5 +314,5 @@ QString TransactionalSettings::serialize(const QString &name, const QVariantHash
         Logger::instance()->addMessage(QObject::tr("An unknown error occurred while trying to write the configuration file."), Log::CRITICAL);
         break;
     }
-    return QString();
+    return {};
 }

--- a/src/base/torrentfileguard.cpp
+++ b/src/base/torrentfileguard.cpp
@@ -86,4 +86,3 @@ CachedSettingValue<TorrentFileGuard::AutoDeleteMode> &TorrentFileGuard::autoDele
     static CachedSettingValue<AutoDeleteMode> setting("Core/AutoDeleteAddedTorrentFile", AutoDeleteMode::Never);
     return setting;
 }
-

--- a/src/base/torrentfileguard.h
+++ b/src/base/torrentfileguard.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef TOFFENTFILEGURAD_H
-#define TOFFENTFILEGURAD_H
+#pragma once
 
 #include <QObject>
 #include <QString>
@@ -82,5 +81,3 @@ private:
     AutoDeleteMode m_mode;
     bool m_wasAdded;
 };
-
-#endif // TOFFENTFILEGURAD_H

--- a/src/base/torrentfilter.cpp
+++ b/src/base/torrentfilter.cpp
@@ -174,19 +174,22 @@ bool TorrentFilter::matchState(const BitTorrent::TorrentHandle *const torrent) c
 bool TorrentFilter::matchHash(const BitTorrent::TorrentHandle *const torrent) const
 {
     if (m_hashSet == AnyHash) return true;
-    else return m_hashSet.contains(torrent->hash());
+
+    return m_hashSet.contains(torrent->hash());
 }
 
 bool TorrentFilter::matchCategory(const BitTorrent::TorrentHandle *const torrent) const
 {
     if (m_category.isNull()) return true;
-    else return (torrent->belongsToCategory(m_category));
+
+    return (torrent->belongsToCategory(m_category));
 }
 
 bool TorrentFilter::matchTag(const BitTorrent::TorrentHandle *const torrent) const
 {
     // Empty tag is a special value to indicate we're filtering for untagged torrents.
     if (m_tag.isNull()) return true;
-    else if (m_tag.isEmpty()) return torrent->tags().isEmpty();
-    else return (torrent->hasTag(m_tag));
+    if (m_tag.isEmpty()) return torrent->tags().isEmpty();
+
+    return (torrent->hasTag(m_tag));
 }

--- a/src/base/torrentfilter.cpp
+++ b/src/base/torrentfilter.cpp
@@ -44,7 +44,6 @@ const TorrentFilter TorrentFilter::InactiveTorrent(TorrentFilter::Inactive);
 const TorrentFilter TorrentFilter::ErroredTorrent(TorrentFilter::Errored);
 
 using BitTorrent::TorrentHandle;
-using BitTorrent::TorrentState;
 
 TorrentFilter::TorrentFilter()
     : m_type(All)

--- a/src/base/utils/foreignapps.cpp
+++ b/src/base/utils/foreignapps.cpp
@@ -227,7 +227,7 @@ namespace
                 return path;
         }
 
-        return QString();
+        return {};
     }
 #endif // Q_OS_WIN
 }

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -97,7 +97,7 @@ namespace
         if (sizeInBytes < 0) return false;
 
         int i = 0;
-        qreal rawVal = static_cast<qreal>(sizeInBytes);
+        auto rawVal = static_cast<qreal>(sizeInBytes);
 
         while ((rawVal >= 1024.) && (i <= static_cast<int>(Utils::Misc::SizeUnit::ExbiByte))) {
             rawVal /= 1024.;

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -256,7 +256,7 @@ QPoint Utils::Misc::screenCenter(const QWidget *w)
     QDesktopWidget *desktop = QApplication::desktop();
     int scrn = desktop->screenNumber(parent);  // fallback to `primaryScreen` when parent is invalid
     QRect r = desktop->availableGeometry(scrn);
-    return QPoint(r.x() + (r.width() - w->frameSize().width()) / 2, r.y() + (r.height() - w->frameSize().height()) / 2);
+    return {r.x() + (r.width() - w->frameSize().width()) / 2, r.y() + (r.height() - w->frameSize().height()) / 2};
 }
 #endif
 

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -285,8 +285,8 @@ int Utils::Misc::friendlyUnitPrecision(SizeUnit unit)
     // friendlyUnit's number of digits after the decimal point
     if (unit == SizeUnit::Byte) return 0;
     if (unit <= SizeUnit::MebiByte) return 1;
-    else if (unit == SizeUnit::GibiByte) return 2;
-    else return 3;
+    if (unit == SizeUnit::GibiByte) return 2;
+    return 3;
 }
 
 qlonglong Utils::Misc::sizeInBytes(qreal size, Utils::Misc::SizeUnit unit)

--- a/src/base/utils/net.cpp
+++ b/src/base/utils/net.cpp
@@ -110,7 +110,7 @@ namespace Utils
             QSslKey key {data, QSsl::Rsa};
             if (!key.isNull())
                 return key;
-            return QSslKey(data, QSsl::Ec);
+            return {data, QSsl::Ec};
         }
 
         bool isSSLKeyValid(const QByteArray &data)

--- a/src/gui/autoexpandabledialog.cpp
+++ b/src/gui/autoexpandabledialog.cpp
@@ -71,7 +71,7 @@ QString AutoExpandableDialog::getText(QWidget *parent, const QString &title, con
     if (ok)
         *ok = res;
 
-    if (!res) return QString();
+    if (!res) return {};
 
     return d.m_ui->textEdit->text();
 }

--- a/src/gui/categoryfiltermodel.cpp
+++ b/src/gui/categoryfiltermodel.cpp
@@ -207,7 +207,7 @@ int CategoryFilterModel::columnCount(const QModelIndex &) const
 
 QVariant CategoryFilterModel::data(const QModelIndex &index, int role) const
 {
-    if (!index.isValid()) return QVariant();
+    if (!index.isValid()) return {};
 
     auto item = static_cast<CategoryModelItem *>(index.internalPointer());
 
@@ -224,7 +224,7 @@ QVariant CategoryFilterModel::data(const QModelIndex &index, int role) const
         return item->torrentsCount();
     }
 
-    return QVariant();
+    return {};
 }
 
 Qt::ItemFlags CategoryFilterModel::flags(const QModelIndex &index) const
@@ -240,32 +240,32 @@ QVariant CategoryFilterModel::headerData(int section, Qt::Orientation orientatio
         if (section == 0)
             return tr("Categories");
 
-    return QVariant();
+    return {};
 }
 
 QModelIndex CategoryFilterModel::index(int row, int column, const QModelIndex &parent) const
 {
     if (column > 0)
-        return QModelIndex();
+        return {};
 
     if (parent.isValid() && (parent.column() != 0))
-        return QModelIndex();
+        return {};
 
     auto parentItem = parent.isValid() ? static_cast<CategoryModelItem *>(parent.internalPointer())
                                        : m_rootItem;
     if (row < parentItem->childCount())
         return createIndex(row, column, parentItem->childAt(row));
 
-    return QModelIndex();
+    return {};
 }
 
 QModelIndex CategoryFilterModel::parent(const QModelIndex &index) const
 {
     if (!index.isValid())
-        return QModelIndex();
+        return {};
 
     auto item = static_cast<CategoryModelItem *>(index.internalPointer());
-    if (!item) return QModelIndex();
+    if (!item) return {};
 
     return this->index(item->parent());
 }
@@ -291,13 +291,13 @@ QModelIndex CategoryFilterModel::index(const QString &categoryName) const
 
 QString CategoryFilterModel::categoryName(const QModelIndex &index) const
 {
-    if (!index.isValid()) return QString();
+    if (!index.isValid()) return {};
     return static_cast<CategoryModelItem *>(index.internalPointer())->fullName();
 }
 
 QModelIndex CategoryFilterModel::index(CategoryModelItem *item) const
 {
-    if (!item || !item->parent()) return QModelIndex();
+    if (!item || !item->parent()) return {};
 
     return index(item->pos(), 0, index(item->parent()));
 }

--- a/src/gui/categoryfilterwidget.cpp
+++ b/src/gui/categoryfilterwidget.cpp
@@ -59,7 +59,7 @@ namespace
 CategoryFilterWidget::CategoryFilterWidget(QWidget *parent)
     : QTreeView(parent)
 {
-    CategoryFilterProxyModel *proxyModel = new CategoryFilterProxyModel(this);
+    auto *proxyModel = new CategoryFilterProxyModel(this);
     proxyModel->setSortCaseSensitivity(Qt::CaseInsensitive);
     proxyModel->setSourceModel(new CategoryFilterModel(this));
     setModel(proxyModel);

--- a/src/gui/cookiesmodel.cpp
+++ b/src/gui/cookiesmodel.cpp
@@ -157,7 +157,7 @@ bool CookiesModel::insertRows(int row, int count, const QModelIndex &parent)
 
 bool CookiesModel::removeRows(int row, int count, const QModelIndex &parent)
 {
-    if ((m_cookies.size() == 0)
+    if ((m_cookies.isEmpty())
         || (row >= m_cookies.size())
         || ((row + count) > m_cookies.size()))
         return false;

--- a/src/gui/cookiesmodel.cpp
+++ b/src/gui/cookiesmodel.cpp
@@ -58,7 +58,7 @@ QVariant CookiesModel::headerData(int section, Qt::Orientation orientation, int 
         }
     }
 
-    return QVariant();
+    return {};
 }
 
 QModelIndex CookiesModel::index(int row, int column, const QModelIndex &parent) const
@@ -66,7 +66,7 @@ QModelIndex CookiesModel::index(int row, int column, const QModelIndex &parent) 
     if (parent.isValid() // no items with valid parent
         || (row < 0) || (row >= m_cookies.size())
         || (column < 0) || (column >= NB_COLUMNS))
-        return QModelIndex();
+        return {};
 
     return createIndex(row, column, &m_cookies[row]);
 }
@@ -74,7 +74,7 @@ QModelIndex CookiesModel::index(int row, int column, const QModelIndex &parent) 
 QModelIndex CookiesModel::parent(const QModelIndex &index) const
 {
     Q_UNUSED(index);
-    return QModelIndex();
+    return {};
 }
 
 int CookiesModel::rowCount(const QModelIndex &parent) const
@@ -94,7 +94,7 @@ QVariant CookiesModel::data(const QModelIndex &index, int role) const
 {
     if (!index.isValid() || (index.row() >= m_cookies.size())
         || ((role != Qt::DisplayRole) && (role != Qt::EditRole)))
-        return QVariant();
+        return {};
 
     switch (index.column()) {
     case COL_DOMAIN:
@@ -109,7 +109,7 @@ QVariant CookiesModel::data(const QModelIndex &index, int role) const
         return m_cookies[index.row()].expirationDate();
     }
 
-    return QVariant();
+    return {};
 }
 
 bool CookiesModel::setData(const QModelIndex &index, const QVariant &value, int role)

--- a/src/gui/fspathedit.cpp
+++ b/src/gui/fspathedit.cpp
@@ -184,7 +184,7 @@ FileSystemPathEdit::FileSystemPathEdit(Private::FileEditorWithCompletion *editor
     Q_D(FileSystemPathEdit);
     editor->widget()->setParent(this);
 
-    QHBoxLayout *layout = new QHBoxLayout(this);
+    auto *layout = new QHBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
     layout->addWidget(editor->widget());
     layout->addWidget(d->m_browseBtn);

--- a/src/gui/fspathedit_p.cpp
+++ b/src/gui/fspathedit_p.cpp
@@ -311,7 +311,7 @@ QString Private::FileLineEdit::warningText(FileSystemPathValidator::TestResult r
     case TestResult::CantWrite:
         return tr("Does not have write permission in '%1'");
     default:
-        return QString();
+        return {};
     }
 }
 

--- a/src/gui/fspathedit_p.cpp
+++ b/src/gui/fspathedit_p.cpp
@@ -251,8 +251,7 @@ void Private::FileLineEdit::keyPressEvent(QKeyEvent *e)
         showCompletionPopup();
     }
 
-    const FileSystemPathValidator *validator =
-        qobject_cast<const FileSystemPathValidator *>(this->validator());
+    auto *validator = qobject_cast<const FileSystemPathValidator *>(this->validator());
     if (validator) {
         FileSystemPathValidator::TestResult lastTestResult = validator->lastTestResult();
         QValidator::State lastState = validator->lastValidationState();

--- a/src/gui/guiiconprovider.cpp
+++ b/src/gui/guiiconprovider.cpp
@@ -90,7 +90,7 @@ QIcon GuiIconProvider::getIcon(const QString &iconId, const QString &fallback) c
 
 QIcon GuiIconProvider::getFlagIcon(const QString &countryIsoCode) const
 {
-    if (countryIsoCode.isEmpty()) return QIcon();
+    if (countryIsoCode.isEmpty()) return {};
     return QIcon(":/icons/flags/" + countryIsoCode.toLower() + ".svg");
 }
 

--- a/src/gui/loglistwidget.cpp
+++ b/src/gui/loglistwidget.cpp
@@ -78,7 +78,7 @@ void LogListWidget::keyPressEvent(QKeyEvent *event)
 
 void LogListWidget::appendLine(const QString &line, const Log::MsgType &type)
 {
-    QListWidgetItem *item = new QListWidgetItem;
+    auto *item = new QListWidgetItem;
     // We need to use QLabel here to support rich text
     QLabel *lbl = new QLabel(line);
     lbl->setContentsMargins(4, 2, 4, 2);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -199,7 +199,7 @@ MainWindow::MainWindow(QWidget *parent)
     m_ui->menuAutoShutdownOnDownloadsCompletion->setIcon(GuiIconProvider::instance()->getIcon("application-exit"));
     m_ui->actionManageCookies->setIcon(GuiIconProvider::instance()->getIcon("preferences-web-browser-cookies"));
 
-    QMenu *lockMenu = new QMenu(this);
+    auto *lockMenu = new QMenu(this);
     QAction *defineUiLockPasswdAct = lockMenu->addAction(tr("&Set Password"));
     connect(defineUiLockPasswdAct, &QAction::triggered, this, &MainWindow::defineUILockPassword);
     QAction *clearUiLockPasswdAct = lockMenu->addAction(tr("&Clear Password"));
@@ -222,7 +222,7 @@ MainWindow::MainWindow(QWidget *parent)
     m_splitter = new QSplitter(Qt::Horizontal, this);
     // vSplitter->setChildrenCollapsible(false);
 
-    QSplitter *hSplitter = new QSplitter(Qt::Vertical, this);
+    auto *hSplitter = new QSplitter(Qt::Vertical, this);
     hSplitter->setChildrenCollapsible(false);
     hSplitter->setFrameShape(QFrame::NoFrame);
 
@@ -380,7 +380,7 @@ MainWindow::MainWindow(QWidget *parent)
         QTimer::singleShot(0, this, &MainWindow::on_actionSearchWidget_triggered);
 
     // Auto shutdown actions
-    QActionGroup *autoShutdownGroup = new QActionGroup(this);
+    auto *autoShutdownGroup = new QActionGroup(this);
     autoShutdownGroup->setExclusive(true);
     autoShutdownGroup->addAction(m_ui->actionAutoShutdownDisabled);
     autoShutdownGroup->addAction(m_ui->actionAutoExit);
@@ -555,7 +555,7 @@ void MainWindow::addToolbarContextMenu()
     m_toolbarMenu->addAction(textBesideIcons);
     m_toolbarMenu->addAction(textUnderIcons);
     m_toolbarMenu->addAction(followSystemStyle);
-    QActionGroup *textPositionGroup = new QActionGroup(m_toolbarMenu);
+    auto *textPositionGroup = new QActionGroup(m_toolbarMenu);
     textPositionGroup->addAction(iconsOnly);
     iconsOnly->setCheckable(true);
     textPositionGroup->addAction(textOnly);
@@ -567,7 +567,7 @@ void MainWindow::addToolbarContextMenu()
     textPositionGroup->addAction(followSystemStyle);
     followSystemStyle->setCheckable(true);
 
-    const Qt::ToolButtonStyle buttonStyle = static_cast<Qt::ToolButtonStyle>(pref->getToolbarTextPosition());
+    const auto buttonStyle = static_cast<Qt::ToolButtonStyle>(pref->getToolbarTextPosition());
     if ((buttonStyle >= Qt::ToolButtonIconOnly) && (buttonStyle <= Qt::ToolButtonFollowStyle))
         m_ui->toolBar->setToolButtonStyle(buttonStyle);
     switch (buttonStyle) {
@@ -795,7 +795,7 @@ void MainWindow::cleanup()
 #endif
 
     // remove all child widgets
-    while (QWidget *w = findChild<QWidget * >())
+    while (auto *w = findChild<QWidget *>())
         delete w;
 }
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -758,9 +758,8 @@ void MainWindow::tabChanged(int newTab)
         m_searchFilterAction->setVisible(true);
         return;
     }
-    else {
-        m_searchFilterAction->setVisible(false);
-    }
+    m_searchFilterAction->setVisible(false);
+
     if (m_tabs->currentWidget() == m_searchWidget) {
         qDebug("Changed tab to search engine, giving focus to search input");
         m_searchWidget->giveFocusToSearchInput();

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -1447,14 +1447,14 @@ QString OptionsDialog::getTorrentExportDir() const
 {
     if (m_ui->checkExportDir->isChecked())
         return Utils::Fs::expandPathAbs(m_ui->textExportDir->selectedPath());
-    return QString();
+    return {};
 }
 
 QString OptionsDialog::getFinishedTorrentExportDir() const
 {
     if (m_ui->checkExportDirFin->isChecked())
         return Utils::Fs::expandPathAbs(m_ui->textExportDirFin->selectedPath());
-    return QString();
+    return {};
 }
 
 // Return action on double-click on a downloading torrent set in options

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -454,7 +454,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     m_ui->textTempPath->setMode(FileSystemPathEdit::Mode::DirectorySave);
 
     // disable mouse wheel event on widgets to avoid mis-selection
-    WheelEventEater *wheelEventEater = new WheelEventEater(this);
+    auto *wheelEventEater = new WheelEventEater(this);
     for (QComboBox *widget : asConst(findChildren<QComboBox *>()))
         widget->installEventFilter(wheelEventEater);
     for (QSpinBox *widget : asConst(findChildren<QSpinBox *>()))
@@ -548,7 +548,7 @@ void OptionsDialog::saveOptions()
     // Load the translation
     QString locale = getLocale();
     if (pref->getLocale() != locale) {
-        QTranslator *translator = new QTranslator;
+        auto *translator = new QTranslator;
         if (translator->load(QLatin1String(":/lang/qbittorrent_") + locale))
             qDebug("%s locale recognized, using translation.", qUtf8Printable(locale));
         else
@@ -592,7 +592,7 @@ void OptionsDialog::saveOptions()
         m_ui->checkAssociateMagnetLinks->setEnabled(!m_ui->checkAssociateMagnetLinks->isChecked());
     }
 #endif
-    Application *const app = static_cast<Application*>(QCoreApplication::instance());
+    auto *const app = static_cast<Application *>(QCoreApplication::instance());
     app->setFileLoggerPath(m_ui->textFileLogPath->selectedPath());
     app->setFileLoggerBackup(m_ui->checkFileLogBackup->isChecked());
     app->setFileLoggerMaxSize(m_ui->spinFileLogSize->value() * 1024);

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -1209,32 +1209,32 @@ int OptionsDialog::getMaxConnecs() const
 {
     if (!m_ui->checkMaxConnecs->isChecked())
         return -1;
-    else
-        return m_ui->spinMaxConnec->value();
+
+    return m_ui->spinMaxConnec->value();
 }
 
 int OptionsDialog::getMaxConnecsPerTorrent() const
 {
     if (!m_ui->checkMaxConnecsPerTorrent->isChecked())
         return -1;
-    else
-        return m_ui->spinMaxConnecPerTorrent->value();
+
+    return m_ui->spinMaxConnecPerTorrent->value();
 }
 
 int OptionsDialog::getMaxUploads() const
 {
     if (!m_ui->checkMaxUploads->isChecked())
         return -1;
-    else
-        return m_ui->spinMaxUploads->value();
+
+    return m_ui->spinMaxUploads->value();
 }
 
 int OptionsDialog::getMaxUploadsPerTorrent() const
 {
     if (!m_ui->checkMaxUploadsPerTorrent->isChecked())
         return -1;
-    else
-        return m_ui->spinMaxUploadsPerTorrent->value();
+
+    return m_ui->spinMaxUploadsPerTorrent->value();
 }
 
 void OptionsDialog::on_buttonBox_accepted()
@@ -1645,7 +1645,7 @@ QString OptionsDialog::languageToLocalizedString(const QLocale &locale)
     case QLocale::English: {
         if (locale.country() == QLocale::Australia)
             return QString::fromUtf8(C_LOCALE_ENGLISH_AUSTRALIA);
-        else if (locale.country() == QLocale::UnitedKingdom)
+        if (locale.country() == QLocale::UnitedKingdom)
             return QString::fromUtf8(C_LOCALE_ENGLISH_UNITEDKINGDOM);
         return QString::fromUtf8(C_LOCALE_ENGLISH);
     }

--- a/src/gui/powermanagement/powermanagement_x11.cpp
+++ b/src/gui/powermanagement/powermanagement_x11.cpp
@@ -82,7 +82,7 @@ void PowerManagementInhibitor::requestIdle()
     call.setArguments(args);
 
     QDBusPendingCall pcall = QDBusConnection::sessionBus().asyncCall(call, 1000);
-    QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(pcall, this);
+    auto *watcher = new QDBusPendingCallWatcher(pcall, this);
     connect(watcher, &QDBusPendingCallWatcher::finished, this, &PowerManagementInhibitor::onAsyncReply);
 }
 
@@ -119,7 +119,7 @@ void PowerManagementInhibitor::requestBusy()
     call.setArguments(args);
 
     QDBusPendingCall pcall = QDBusConnection::sessionBus().asyncCall(call, 1000);
-    QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(pcall, this);
+    auto *watcher = new QDBusPendingCallWatcher(pcall, this);
     connect(watcher, &QDBusPendingCallWatcher::finished, this, &PowerManagementInhibitor::onAsyncReply);
 }
 

--- a/src/gui/previewselectdialog.cpp
+++ b/src/gui/previewselectdialog.cpp
@@ -124,7 +124,7 @@ PreviewSelectDialog::~PreviewSelectDialog()
 void PreviewSelectDialog::previewButtonClicked()
 {
     QModelIndexList selectedIndexes = previewList->selectionModel()->selectedRows(FILE_INDEX);
-    if (selectedIndexes.size() == 0) return;
+    if (selectedIndexes.isEmpty()) return;
 
     // Flush data
     m_torrent->flushCache();

--- a/src/gui/programupdater.cpp
+++ b/src/gui/programupdater.cpp
@@ -166,6 +166,6 @@ namespace
         if (xml.isCharacters() && !xml.isWhitespace())
             return xml.text().toString();
 
-        return QString();
+        return {};
     }
 }

--- a/src/gui/properties/piecesbar.cpp
+++ b/src/gui/properties/piecesbar.cpp
@@ -147,9 +147,8 @@ bool PiecesBar::event(QEvent *e)
         showToolTip(static_cast<QHelpEvent *>(e));
         return true;
     }
-    else {
-        return base::event(e);
-    }
+
+    return base::event(e);
 }
 
 void PiecesBar::enterEvent(QEvent *e)

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -198,7 +198,7 @@ void PropertiesWidget::showPiecesDownloaded(bool show)
 void PropertiesWidget::setVisibility(bool visible)
 {
     if (!visible && (m_state == VISIBLE)) {
-        QSplitter *hSplitter = static_cast<QSplitter *>(parentWidget());
+        auto *hSplitter = static_cast<QSplitter *>(parentWidget());
         m_ui->stackedProperties->setVisible(false);
         m_slideSizes = hSplitter->sizes();
         hSplitter->handle(1)->setVisible(false);
@@ -211,7 +211,7 @@ void PropertiesWidget::setVisibility(bool visible)
 
     if (visible && (m_state == REDUCED)) {
         m_ui->stackedProperties->setVisible(true);
-        QSplitter *hSplitter = static_cast<QSplitter *>(parentWidget());
+        auto *hSplitter = static_cast<QSplitter *>(parentWidget());
         hSplitter->handle(1)->setDisabled(false);
         hSplitter->handle(1)->setVisible(true);
         hSplitter->setSizes(m_slideSizes);
@@ -344,7 +344,7 @@ void PropertiesWidget::readSettings()
     if (sizesStr.size() == 2) {
         m_slideSizes << sizesStr.first().toInt();
         m_slideSizes << sizesStr.last().toInt();
-        QSplitter *hSplitter = static_cast<QSplitter *>(parentWidget());
+        auto *hSplitter = static_cast<QSplitter *>(parentWidget());
         hSplitter->setSizes(m_slideSizes);
     }
     const int currentTab = pref->getPropCurTab();
@@ -360,7 +360,7 @@ void PropertiesWidget::saveSettings()
     Preferences *const pref = Preferences::instance();
     pref->setPropVisible(m_state == VISIBLE);
     // Splitter sizes
-    QSplitter *hSplitter = static_cast<QSplitter *>(parentWidget());
+    auto *hSplitter = static_cast<QSplitter *>(parentWidget());
     QList<int> sizes;
     if (m_state == VISIBLE)
         sizes = hSplitter->sizes();

--- a/src/gui/properties/proplistdelegate.cpp
+++ b/src/gui/properties/proplistdelegate.cpp
@@ -153,7 +153,7 @@ void PropListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
 
 void PropListDelegate::setEditorData(QWidget *editor, const QModelIndex &index) const
 {
-    QComboBox *combobox = static_cast<QComboBox *>(editor);
+    auto *combobox = static_cast<QComboBox *>(editor);
     // Set combobox index
     switch (static_cast<BitTorrent::FilePriority>(index.data().toInt())) {
     case BitTorrent::FilePriority::Ignored:
@@ -184,7 +184,7 @@ QWidget *PropListDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
     if (index.data().toInt() == static_cast<int>(BitTorrent::FilePriority::Mixed))
         return nullptr;
 
-    QComboBox *editor = new QComboBox(parent);
+    auto *editor = new QComboBox(parent);
     editor->setFocusPolicy(Qt::StrongFocus);
     editor->addItem(tr("Do not download", "Do not download (priority)"));
     editor->addItem(tr("Normal", "Normal (priority)"));
@@ -195,7 +195,7 @@ QWidget *PropListDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
 
 void PropListDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const
 {
-    QComboBox *combobox = static_cast<QComboBox *>(editor);
+    auto *combobox = static_cast<QComboBox *>(editor);
     int value = combobox->currentIndex();
     qDebug("PropListDelegate: setModelData(%d)", value);
 

--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -466,8 +466,7 @@ void TrackerListWidget::editSelectedTracker()
 
     QList<BitTorrent::TrackerEntry> trackers = torrent->trackers();
     bool match = false;
-    for (int i = 0; i < trackers.size(); ++i) {
-        BitTorrent::TrackerEntry &entry = trackers[i];
+    for (auto &entry : trackers) {
         if (newTrackerURL == QUrl(entry.url())) {
             QMessageBox::warning(this, tr("Tracker editing failed"), tr("The tracker URL already exists."));
             return;

--- a/src/gui/rss/articlelistwidget.cpp
+++ b/src/gui/rss/articlelistwidget.cpp
@@ -117,7 +117,7 @@ void ArticleListWidget::checkInvariant() const
 QListWidgetItem *ArticleListWidget::createItem(RSS::Article *article) const
 {
     Q_ASSERT(article);
-    QListWidgetItem *item = new QListWidgetItem;
+    auto *item = new QListWidgetItem;
 
     item->setData(Qt::DisplayRole, article->title());
     item->setData(Qt::UserRole, reinterpret_cast<quintptr>(article));

--- a/src/gui/rss/feedlistwidget.cpp
+++ b/src/gui/rss/feedlistwidget.cpp
@@ -232,7 +232,7 @@ void FeedListWidget::dropEvent(QDropEvent *event)
 
 QTreeWidgetItem *FeedListWidget::createItem(RSS::Item *rssItem, QTreeWidgetItem *parentItem)
 {
-    QTreeWidgetItem *item = new QTreeWidgetItem;
+    auto *item = new QTreeWidgetItem;
     item->setData(0, Qt::DisplayRole, QString("%1  (%2)").arg(rssItem->name()).arg(rssItem->unreadCount()));
     item->setData(0, Qt::UserRole, reinterpret_cast<quintptr>(rssItem));
     m_rssToTreeItemMapping[rssItem] = item;

--- a/src/gui/rss/htmlbrowser.cpp
+++ b/src/gui/rss/htmlbrowser.cpp
@@ -80,7 +80,7 @@ QVariant HtmlBrowser::loadResource(int type, const QUrl &name)
             m_netManager->get(req);
         }
 
-        return QVariant();
+        return {};
     }
 
     return QTextBrowser::loadResource(type, name);

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -150,7 +150,7 @@ void RSSWidget::displayRSSListMenu(const QPoint &pos)
         m_feedListWidget->clearSelection();
     QMenu myRSSListMenu(this);
     QList<QTreeWidgetItem *> selectedItems = m_feedListWidget->selectedItems();
-    if (selectedItems.size() > 0) {
+    if (!selectedItems.isEmpty()) {
         myRSSListMenu.addAction(m_ui->actionUpdate);
         myRSSListMenu.addAction(m_ui->actionMarkItemsRead);
         myRSSListMenu.addSeparator();

--- a/src/gui/scanfoldersdelegate.cpp
+++ b/src/gui/scanfoldersdelegate.cpp
@@ -44,7 +44,7 @@ ScanFoldersDelegate::ScanFoldersDelegate(QObject *parent, QTreeView *foldersView
 
 void ScanFoldersDelegate::setEditorData(QWidget *editor, const QModelIndex &index) const
 {
-    QComboBox *combobox = static_cast<QComboBox*>(editor);
+    auto *combobox = static_cast<QComboBox*>(editor);
     // Set combobox index
     if (index.data(Qt::UserRole).toInt() == ScanFoldersModel::CUSTOM_LOCATION)
         combobox->setCurrentIndex(4); // '4' is the index of the item after the separator in the QComboBox menu
@@ -56,7 +56,7 @@ QWidget *ScanFoldersDelegate::createEditor(QWidget *parent, const QStyleOptionVi
 {
     if (index.column() != ScanFoldersModel::DOWNLOAD) return nullptr;
 
-    QComboBox *editor = new QComboBox(parent);
+    auto *editor = new QComboBox(parent);
 
     editor->setFocusPolicy(Qt::StrongFocus);
     editor->addItem(ScanFoldersModel::pathTypeDisplayName(ScanFoldersModel::DOWNLOAD_IN_WATCH_FOLDER));
@@ -75,7 +75,7 @@ QWidget *ScanFoldersDelegate::createEditor(QWidget *parent, const QStyleOptionVi
 void ScanFoldersDelegate::comboboxIndexChanged(int index)
 {
     if (index == ScanFoldersModel::CUSTOM_LOCATION) {
-        QWidget *w = static_cast<QWidget *>(sender());
+        auto *w = static_cast<QWidget *>(sender());
         if (w && w->parentWidget())
             w->parentWidget()->setFocus();
     }
@@ -83,7 +83,7 @@ void ScanFoldersDelegate::comboboxIndexChanged(int index)
 
 void ScanFoldersDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const
 {
-    QComboBox *combobox = static_cast<QComboBox*>(editor);
+    auto *combobox = static_cast<QComboBox*>(editor);
     int value = combobox->currentIndex();
 
     switch (value) {

--- a/src/gui/search/pluginselectdialog.cpp
+++ b/src/gui/search/pluginselectdialog.cpp
@@ -270,7 +270,7 @@ void PluginSelectDialog::loadSupportedSearchPlugins()
 
 void PluginSelectDialog::addNewPlugin(const QString &pluginName)
 {
-    QTreeWidgetItem *item = new QTreeWidgetItem(m_ui->pluginsTree);
+    auto *item = new QTreeWidgetItem(m_ui->pluginsTree);
     PluginInfo *plugin = m_pluginManager->pluginInfo(pluginName);
     item->setText(PLUGIN_NAME, plugin->fullName);
     item->setText(PLUGIN_URL, plugin->url);
@@ -326,7 +326,7 @@ void PluginSelectDialog::finishPluginUpdate()
 
 void PluginSelectDialog::on_installButton_clicked()
 {
-    PluginSourceDialog *dlg = new PluginSourceDialog(this);
+    auto *dlg = new PluginSourceDialog(this);
     connect(dlg, &PluginSourceDialog::askForLocalFile, this, &PluginSelectDialog::askForLocalPlugin);
     connect(dlg, &PluginSourceDialog::askForUrl, this, &PluginSelectDialog::askForPluginUrl);
 }

--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -385,7 +385,7 @@ QString SearchJobWidget::statusText(SearchJobWidget::Status st)
     case Status::NoResults:
         return tr("Search returned no results");
     default:
-        return QString();
+        return {};
     }
 }
 

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -83,7 +83,7 @@ namespace
         case SearchJobWidget::Status::NoResults:
             return QLatin1String("task-attention");
         default:
-            return QString();
+            return {};
         }
     }
 }

--- a/src/gui/statusbar.cpp
+++ b/src/gui/statusbar.cpp
@@ -55,7 +55,7 @@ StatusBar::StatusBar(QWidget *parent)
     BitTorrent::Session *const session = BitTorrent::Session::instance();
     connect(session, &BitTorrent::Session::speedLimitModeChanged, this, &StatusBar::updateAltSpeedsBtn);
     QWidget *container = new QWidget(this);
-    QHBoxLayout *layout = new QHBoxLayout(container);
+    auto *layout = new QHBoxLayout(container);
     layout->setContentsMargins(0,0,0,0);
 
     container->setLayout(layout);

--- a/src/gui/tagfiltermodel.cpp
+++ b/src/gui/tagfiltermodel.cpp
@@ -114,7 +114,7 @@ bool TagFilterModel::isSpecialItem(const QModelIndex &index)
 QVariant TagFilterModel::data(const QModelIndex &index, int role) const
 {
     if (!index.isValid() || (index.column() != 0))
-        return QVariant();
+        return {};
 
     const int row = index.internalId();
     Q_ASSERT(isValidRow(row));
@@ -129,7 +129,7 @@ QVariant TagFilterModel::data(const QModelIndex &index, int role) const
     case Qt::UserRole:
         return item.torrentsCount();
     default:
-        return QVariant();
+        return {};
     }
 }
 
@@ -145,13 +145,13 @@ QVariant TagFilterModel::headerData(int section, Qt::Orientation orientation, in
     if ((orientation == Qt::Horizontal) && (role == Qt::DisplayRole))
         if (section == 0)
             return tr("Tags");
-    return QVariant();
+    return {};
 }
 
 QModelIndex TagFilterModel::index(int row, int, const QModelIndex &) const
 {
     if (!isValidRow(row))
-        return QModelIndex();
+        return {};
     return createIndex(row, 0, row);
 }
 
@@ -171,14 +171,14 @@ QModelIndex TagFilterModel::index(const QString &tag) const
 {
     const int row = findRow(tag);
     if (!isValidRow(row))
-        return QModelIndex();
+        return {};
     return index(row, 0, QModelIndex());
 }
 
 QString TagFilterModel::tag(const QModelIndex &index) const
 {
     if (!index.isValid())
-        return QString();
+        return {};
     const int row = index.internalId();
     Q_ASSERT(isValidRow(row));
     return m_tagItems[row].tag();

--- a/src/gui/tagfiltermodel.cpp
+++ b/src/gui/tagfiltermodel.cpp
@@ -326,7 +326,7 @@ QVector<TagModelItem *> TagFilterModel::findItems(const QSet<QString> &tags)
 
 TagModelItem *TagFilterModel::allTagsItem()
 {
-    Q_ASSERT(m_tagItems.size() > 0);
+    Q_ASSERT(!m_tagItems.isEmpty());
     return &m_tagItems[0];
 }
 

--- a/src/gui/tagfilterwidget.cpp
+++ b/src/gui/tagfilterwidget.cpp
@@ -60,7 +60,7 @@ namespace
 TagFilterWidget::TagFilterWidget(QWidget *parent)
     : QTreeView(parent)
 {
-    TagFilterProxyModel *proxyModel = new TagFilterProxyModel(this);
+    auto *proxyModel = new TagFilterProxyModel(this);
     proxyModel->setSortCaseSensitivity(Qt::CaseInsensitive);
     proxyModel->setSourceModel(new TagFilterModel(this));
     setModel(proxyModel);

--- a/src/gui/torrentcontentfiltermodel.cpp
+++ b/src/gui/torrentcontentfiltermodel.cpp
@@ -96,12 +96,11 @@ bool TorrentContentFilterModel::lessThan(const QModelIndex &left, const QModelIn
                 const QString strR = right.data().toString();
                 return Utils::String::naturalLessThan<Qt::CaseInsensitive>(strL, strR);
             }
-            else if ((leftType == TorrentContentModelItem::FolderType) && (sortOrder() == Qt::AscendingOrder)) {
+            if ((leftType == TorrentContentModelItem::FolderType) && (sortOrder() == Qt::AscendingOrder)) {
                 return true;
             }
-            else {
-                return false;
-            }
+
+            return false;
         }
     default:
         return QSortFilterProxyModel::lessThan(left, right);
@@ -136,8 +135,7 @@ bool TorrentContentFilterModel::hasFiltered(const QModelIndex &folder) const
         if (m_model->hasChildren(childIndex)) {
             if (hasFiltered(childIndex))
                 return true;
-            else
-                continue;
+            continue;
         }
         name = childIndex.data().toString();
         if (name.contains(filterRegExp()))

--- a/src/gui/torrentcontentfiltermodel.cpp
+++ b/src/gui/torrentcontentfiltermodel.cpp
@@ -66,10 +66,10 @@ int TorrentContentFilterModel::getFileIndex(const QModelIndex &index) const
 
 QModelIndex TorrentContentFilterModel::parent(const QModelIndex &child) const
 {
-    if (!child.isValid()) return QModelIndex();
+    if (!child.isValid()) return {};
 
     QModelIndex sourceParent = m_model->parent(mapToSource(child));
-    if (!sourceParent.isValid()) return QModelIndex();
+    if (!sourceParent.isValid()) return {};
 
     return mapFromSource(sourceParent);
 }

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -113,12 +113,12 @@ namespace
             const QString ext = info.suffix();
             if (!ext.isEmpty()) {
                 QPixmap cached;
-                if (QPixmapCache::find(ext, &cached)) return QIcon(cached);
+                if (QPixmapCache::find(ext, &cached)) return {cached};
 
                 const QPixmap pixmap = pixmapForExtension(ext);
                 if (!pixmap.isNull()) {
                     QPixmapCache::insert(ext, pixmap);
-                    return QIcon(pixmap);
+                    return {pixmap};
                 }
             }
             return UnifiedFileIconProvider::icon(info);
@@ -140,7 +140,7 @@ namespace
             HRESULT hr = ::SHGetFileInfoW(extWithDot.toStdWString().c_str(),
                 FILE_ATTRIBUTE_NORMAL, &sfi, sizeof(sfi), SHGFI_ICON | SHGFI_USEFILEATTRIBUTES);
             if (FAILED(hr))
-                return QPixmap();
+                return {};
 
             QPixmap iconPixmap = QtWin::fromHICON(sfi.hIcon);
             ::DestroyIcon(sfi.hIcon);
@@ -354,7 +354,7 @@ int TorrentContentModel::getFileIndex(const QModelIndex &index)
 QVariant TorrentContentModel::data(const QModelIndex &index, int role) const
 {
     if (!index.isValid())
-        return QVariant();
+        return {};
 
     auto *item = static_cast<TorrentContentModelItem*>(index.internalPointer());
 
@@ -376,7 +376,7 @@ QVariant TorrentContentModel::data(const QModelIndex &index, int role) const
     if (role == Qt::DisplayRole)
         return item->data(index.column());
 
-    return QVariant();
+    return {};
 }
 
 Qt::ItemFlags TorrentContentModel::flags(const QModelIndex &index) const
@@ -395,16 +395,16 @@ QVariant TorrentContentModel::headerData(int section, Qt::Orientation orientatio
     if ((orientation == Qt::Horizontal) && (role == Qt::DisplayRole))
         return m_rootItem->data(section);
 
-    return QVariant();
+    return {};
 }
 
 QModelIndex TorrentContentModel::index(int row, int column, const QModelIndex &parent) const
 {
     if (parent.isValid() && (parent.column() != 0))
-        return QModelIndex();
+        return {};
 
     if (column >= TorrentContentModelItem::NB_COL)
-        return QModelIndex();
+        return {};
 
     TorrentContentModelFolder *parentItem;
     if (!parent.isValid())
@@ -414,26 +414,26 @@ QModelIndex TorrentContentModel::index(int row, int column, const QModelIndex &p
     Q_ASSERT(parentItem);
 
     if (row >= parentItem->childCount())
-        return QModelIndex();
+        return {};
 
     TorrentContentModelItem *childItem = parentItem->child(row);
     if (childItem)
         return createIndex(row, column, childItem);
-    return QModelIndex();
+    return {};
 }
 
 QModelIndex TorrentContentModel::parent(const QModelIndex &index) const
 {
     if (!index.isValid())
-        return QModelIndex();
+        return {};
 
     auto *childItem = static_cast<TorrentContentModelItem*>(index.internalPointer());
     if (!childItem)
-        return QModelIndex();
+        return {};
 
     TorrentContentModelItem *parentItem = childItem->parent();
     if (parentItem == m_rootItem)
-        return QModelIndex();
+        return {};
 
     return createIndex(parentItem->row(), 0, parentItem);
 }

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -287,8 +287,8 @@ int TorrentContentModel::columnCount(const QModelIndex &parent) const
 {
     if (parent.isValid())
         return static_cast<TorrentContentModelItem*>(parent.internalPointer())->columnCount();
-    else
-        return m_rootItem->columnCount();
+
+    return m_rootItem->columnCount();
 }
 
 bool TorrentContentModel::setData(const QModelIndex &index, const QVariant &value, int role)
@@ -361,8 +361,8 @@ QVariant TorrentContentModel::data(const QModelIndex &index, int role) const
     if ((index.column() == TorrentContentModelItem::COL_NAME) && (role == Qt::DecorationRole)) {
         if (item->itemType() == TorrentContentModelItem::FolderType)
             return getDirectoryIcon();
-        else
-            return m_fileIconProvider->icon(QFileInfo(item->name()));
+
+        return m_fileIconProvider->icon(QFileInfo(item->name()));
     }
 
     if ((index.column() == TorrentContentModelItem::COL_NAME) && (role == Qt::CheckStateRole)) {

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -297,7 +297,7 @@ bool TorrentContentModel::setData(const QModelIndex &index, const QVariant &valu
         return false;
 
     if ((index.column() == TorrentContentModelItem::COL_NAME) && (role == Qt::CheckStateRole)) {
-        TorrentContentModelItem *item = static_cast<TorrentContentModelItem*>(index.internalPointer());
+        auto *item = static_cast<TorrentContentModelItem*>(index.internalPointer());
         qDebug("setData(%s, %d", qUtf8Printable(item->name()), value.toInt());
         if (static_cast<int>(item->priority()) != value.toInt()) {
             BitTorrent::FilePriority prio = BitTorrent::FilePriority::Normal;
@@ -318,7 +318,7 @@ bool TorrentContentModel::setData(const QModelIndex &index, const QVariant &valu
 
     if (role == Qt::EditRole) {
         Q_ASSERT(index.isValid());
-        TorrentContentModelItem *item = static_cast<TorrentContentModelItem*>(index.internalPointer());
+        auto *item = static_cast<TorrentContentModelItem*>(index.internalPointer());
         switch (index.column()) {
         case TorrentContentModelItem::COL_NAME:
             item->setName(value.toString());
@@ -343,7 +343,7 @@ TorrentContentModelItem::ItemType TorrentContentModel::itemType(const QModelInde
 
 int TorrentContentModel::getFileIndex(const QModelIndex &index)
 {
-    TorrentContentModelItem *item = static_cast<TorrentContentModelItem*>(index.internalPointer());
+    auto *item = static_cast<TorrentContentModelItem*>(index.internalPointer());
     if (item->itemType() == TorrentContentModelItem::FileType)
         return static_cast<TorrentContentModelFile*>(item)->fileIndex();
 
@@ -356,7 +356,7 @@ QVariant TorrentContentModel::data(const QModelIndex &index, int role) const
     if (!index.isValid())
         return QVariant();
 
-    TorrentContentModelItem *item = static_cast<TorrentContentModelItem*>(index.internalPointer());
+    auto *item = static_cast<TorrentContentModelItem*>(index.internalPointer());
 
     if ((index.column() == TorrentContentModelItem::COL_NAME) && (role == Qt::DecorationRole)) {
         if (item->itemType() == TorrentContentModelItem::FolderType)
@@ -427,7 +427,7 @@ QModelIndex TorrentContentModel::parent(const QModelIndex &index) const
     if (!index.isValid())
         return QModelIndex();
 
-    TorrentContentModelItem *childItem = static_cast<TorrentContentModelItem*>(index.internalPointer());
+    auto *childItem = static_cast<TorrentContentModelItem*>(index.internalPointer());
     if (!childItem)
         return QModelIndex();
 

--- a/src/gui/torrentcontentmodelitem.cpp
+++ b/src/gui/torrentcontentmodelitem.cpp
@@ -121,7 +121,7 @@ QVariant TorrentContentModelItem::data(int column) const
         return availability();
     default:
         Q_ASSERT(false);
-        return QVariant();
+        return {};
     }
 }
 

--- a/src/gui/torrentcontenttreeview.cpp
+++ b/src/gui/torrentcontenttreeview.cpp
@@ -81,7 +81,7 @@ QModelIndex TorrentContentTreeView::currentNameCell()
     QModelIndex current = currentIndex();
     if (!current.isValid()) {
         Q_ASSERT(false);
-        return QModelIndex();
+        return {};
     }
 
     return model()->index(current.row(), TorrentContentModelItem::COL_NAME, current.parent());

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -543,12 +543,12 @@ QStringList TrackerFiltersList::getHashes(int row)
 {
     if (row == 1)
         return m_trackers.value("");
-    else if (row == 2)
+    if (row == 2)
         return m_errors.keys();
-    else if (row == 3)
+    if (row == 3)
         return m_warnings.keys();
-    else
-        return m_trackers.value(trackerFromRow(row));
+
+     return m_trackers.value(trackerFromRow(row));
 }
 
 TransferListFiltersWidget::TransferListFiltersWidget(QWidget *parent, TransferListWidget *transferList)

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -485,7 +485,7 @@ void TrackerFiltersList::handleNewTorrent(BitTorrent::TorrentHandle *const torre
         addItem(tracker.url(), hash);
 
     //Check for trackerless torrent
-    if (trackers.size() == 0)
+    if (trackers.isEmpty())
         addItem("", hash);
 
     item(0)->setText(tr("All (%1)", "this is for the tracker filter").arg(++m_totalTorrents));
@@ -499,7 +499,7 @@ void TrackerFiltersList::torrentAboutToBeDeleted(BitTorrent::TorrentHandle *cons
         removeItem(tracker.url(), hash);
 
     //Check for trackerless torrent
-    if (trackers.size() == 0)
+    if (trackers.isEmpty())
         removeItem("", hash);
 
     item(0)->setText(tr("All (%1)", "this is for the tracker filter").arg(--m_totalTorrents));

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -129,31 +129,31 @@ StatusFilterWidget::StatusFilterWidget(QWidget *parent, TransferListWidget *tran
             , this, &StatusFilterWidget::updateTorrentNumbers);
 
     // Add status filters
-    QListWidgetItem *all = new QListWidgetItem(this);
+    auto *all = new QListWidgetItem(this);
     all->setData(Qt::DisplayRole, QVariant(tr("All (0)", "this is for the status filter")));
     all->setData(Qt::DecorationRole, QIcon(":/icons/skin/filterall.svg"));
-    QListWidgetItem *downloading = new QListWidgetItem(this);
+    auto *downloading = new QListWidgetItem(this);
     downloading->setData(Qt::DisplayRole, QVariant(tr("Downloading (0)")));
     downloading->setData(Qt::DecorationRole, QIcon(":/icons/skin/downloading.svg"));
-    QListWidgetItem *seeding = new QListWidgetItem(this);
+    auto *seeding = new QListWidgetItem(this);
     seeding->setData(Qt::DisplayRole, QVariant(tr("Seeding (0)")));
     seeding->setData(Qt::DecorationRole, QIcon(":/icons/skin/uploading.svg"));
-    QListWidgetItem *completed = new QListWidgetItem(this);
+    auto *completed = new QListWidgetItem(this);
     completed->setData(Qt::DisplayRole, QVariant(tr("Completed (0)")));
     completed->setData(Qt::DecorationRole, QIcon(":/icons/skin/completed.svg"));
-    QListWidgetItem *resumed = new QListWidgetItem(this);
+    auto *resumed = new QListWidgetItem(this);
     resumed->setData(Qt::DisplayRole, QVariant(tr("Resumed (0)")));
     resumed->setData(Qt::DecorationRole, QIcon(":/icons/skin/resumed.svg"));
-    QListWidgetItem *paused = new QListWidgetItem(this);
+    auto *paused = new QListWidgetItem(this);
     paused->setData(Qt::DisplayRole, QVariant(tr("Paused (0)")));
     paused->setData(Qt::DecorationRole, QIcon(":/icons/skin/paused.svg"));
-    QListWidgetItem *active = new QListWidgetItem(this);
+    auto *active = new QListWidgetItem(this);
     active->setData(Qt::DisplayRole, QVariant(tr("Active (0)")));
     active->setData(Qt::DecorationRole, QIcon(":/icons/skin/filteractive.svg"));
-    QListWidgetItem *inactive = new QListWidgetItem(this);
+    auto *inactive = new QListWidgetItem(this);
     inactive->setData(Qt::DisplayRole, QVariant(tr("Inactive (0)")));
     inactive->setData(Qt::DecorationRole, QIcon(":/icons/skin/filterinactive.svg"));
-    QListWidgetItem *errored = new QListWidgetItem(this);
+    auto *errored = new QListWidgetItem(this);
     errored->setData(Qt::DisplayRole, QVariant(tr("Errored (0)")));
     errored->setData(Qt::DecorationRole, QIcon(":/icons/skin/error.svg"));
 
@@ -198,16 +198,16 @@ TrackerFiltersList::TrackerFiltersList(QWidget *parent, TransferListWidget *tran
     , m_totalTorrents(0)
     , m_downloadTrackerFavicon(true)
 {
-    QListWidgetItem *allTrackers = new QListWidgetItem(this);
+    auto *allTrackers = new QListWidgetItem(this);
     allTrackers->setData(Qt::DisplayRole, QVariant(tr("All (0)", "this is for the tracker filter")));
     allTrackers->setData(Qt::DecorationRole, GuiIconProvider::instance()->getIcon("network-server"));
-    QListWidgetItem *noTracker = new QListWidgetItem(this);
+    auto *noTracker = new QListWidgetItem(this);
     noTracker->setData(Qt::DisplayRole, QVariant(tr("Trackerless (0)")));
     noTracker->setData(Qt::DecorationRole, GuiIconProvider::instance()->getIcon("network-server"));
-    QListWidgetItem *errorTracker = new QListWidgetItem(this);
+    auto *errorTracker = new QListWidgetItem(this);
     errorTracker->setData(Qt::DisplayRole, QVariant(tr("Error (0)")));
     errorTracker->setData(Qt::DecorationRole, style()->standardIcon(QStyle::SP_MessageBoxCritical));
-    QListWidgetItem *warningTracker = new QListWidgetItem(this);
+    auto *warningTracker = new QListWidgetItem(this);
     warningTracker->setData(Qt::DisplayRole, QVariant(tr("Warning (0)")));
     warningTracker->setData(Qt::DecorationRole, style()->standardIcon(QStyle::SP_MessageBoxWarning));
     m_trackers.insert("", QStringList());
@@ -558,10 +558,10 @@ TransferListFiltersWidget::TransferListFiltersWidget(QWidget *parent, TransferLi
     Preferences *const pref = Preferences::instance();
 
     // Construct lists
-    QVBoxLayout *vLayout = new QVBoxLayout(this);
-    QScrollArea *scroll = new QScrollArea(this);
+    auto *vLayout = new QVBoxLayout(this);
+    auto *scroll = new QScrollArea(this);
     QFrame *frame = new QFrame(scroll);
-    QVBoxLayout *frameLayout = new QVBoxLayout(frame);
+    auto *frameLayout = new QVBoxLayout(frame);
     QFont font;
     font.setBold(true);
     font.setCapitalization(QFont::AllUppercase);
@@ -586,7 +586,7 @@ TransferListFiltersWidget::TransferListFiltersWidget(QWidget *parent, TransferLi
     statusLabel->setFont(font);
     frameLayout->addWidget(statusLabel);
 
-    StatusFilterWidget *statusFilters = new StatusFilterWidget(this, transferList);
+    auto *statusFilters = new StatusFilterWidget(this, transferList);
     frameLayout->addWidget(statusFilters);
 
     QCheckBox *categoryLabel = new QCheckBox(tr("Categories"), this);

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -468,6 +468,6 @@ bool isDarkTheme()
 {
     const QPalette pal = QApplication::palette();
     // QPalette::Base is used for the background of the Treeview
-    const QColor color = pal.color(QPalette::Active, QPalette::Base);
+    const QColor &color = pal.color(QPalette::Active, QPalette::Base);
     return (color.lightness() < 127);
 }

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -125,7 +125,7 @@ QVariant TransferListModel::headerData(int section, Qt::Orientation orientation,
             case TR_LAST_ACTIVITY: return tr("Last Activity", "Time passed since a chunk was downloaded/uploaded");
             case TR_TOTAL_SIZE: return tr("Total Size", "i.e. Size including unwanted data");
             default:
-                return QVariant();
+                return {};
             }
         }
         else if (role == Qt::TextAlignmentRole) {
@@ -149,22 +149,22 @@ QVariant TransferListModel::headerData(int section, Qt::Orientation orientation,
             case TR_RATIO:
             case TR_PRIORITY:
             case TR_LAST_ACTIVITY:
-                return QVariant(Qt::AlignRight | Qt::AlignVCenter);
+                return {Qt::AlignRight | Qt::AlignVCenter};
             default:
                 return QAbstractListModel::headerData(section, orientation, role);
             }
         }
     }
 
-    return QVariant();
+    return {};
 }
 
 QVariant TransferListModel::data(const QModelIndex &index, int role) const
 {
-    if (!index.isValid()) return QVariant();
+    if (!index.isValid()) return {};
 
     BitTorrent::TorrentHandle *const torrent = m_torrents.value(index.row());
-    if (!torrent) return QVariant();
+    if (!torrent) return {};
 
     if ((role == Qt::DecorationRole) && (index.column() == TR_NAME))
         return getIconByState(torrent->state());
@@ -173,7 +173,7 @@ QVariant TransferListModel::data(const QModelIndex &index, int role) const
         return getColorByState(torrent->state());
 
     if ((role != Qt::DisplayRole) && (role != Qt::UserRole))
-        return QVariant();
+        return {};
 
     switch (index.column()) {
     case TR_NAME:
@@ -243,7 +243,7 @@ QVariant TransferListModel::data(const QModelIndex &index, int role) const
         return torrent->totalSize();
     }
 
-    return QVariant();
+    return {};
 }
 
 bool TransferListModel::setData(const QModelIndex &index, const QVariant &value, int role)
@@ -366,32 +366,32 @@ QColor getColorByState(BitTorrent::TorrentState state)
     case BitTorrent::TorrentState::ForcedDownloading:
     case BitTorrent::TorrentState::DownloadingMetadata:
         if (!dark)
-            return QColor(34, 139, 34); // Forest Green
+            return {34, 139, 34}; // Forest Green
         else
-            return QColor(50, 205, 50); // Lime Green
+            return {50, 205, 50}; // Lime Green
     case BitTorrent::TorrentState::Allocating:
     case BitTorrent::TorrentState::StalledDownloading:
     case BitTorrent::TorrentState::StalledUploading:
         if (!dark)
-            return QColor(0, 0, 0); // Black
+            return {0, 0, 0}; // Black
         else
-            return QColor(204, 204, 204); // Gray 80
+            return {204, 204, 204}; // Gray 80
     case BitTorrent::TorrentState::Uploading:
     case BitTorrent::TorrentState::ForcedUploading:
         if (!dark)
-            return QColor(65, 105, 225); // Royal Blue
+            return {65, 105, 225}; // Royal Blue
         else
-            return QColor(99, 184, 255); // Steel Blue 1
+            return {99, 184, 255}; // Steel Blue 1
     case BitTorrent::TorrentState::PausedDownloading:
-        return QColor(250, 128, 114); // Salmon
+        return {250, 128, 114}; // Salmon
     case BitTorrent::TorrentState::PausedUploading:
         if (!dark)
-            return QColor(0, 0, 139); // Dark Blue
+            return {0, 0, 139}; // Dark Blue
         else
-            return QColor(79, 148, 205); // Steel Blue 3
+            return {79, 148, 205}; // Steel Blue 3
     case BitTorrent::TorrentState::Error:
     case BitTorrent::TorrentState::MissingFiles:
-        return QColor(255, 0, 0); // red
+        return {255, 0, 0}; // red
     case BitTorrent::TorrentState::QueuedDownloading:
     case BitTorrent::TorrentState::QueuedUploading:
     case BitTorrent::TorrentState::CheckingDownloading:
@@ -399,14 +399,14 @@ QColor getColorByState(BitTorrent::TorrentState state)
     case BitTorrent::TorrentState::CheckingResumeData:
     case BitTorrent::TorrentState::Moving:
         if (!dark)
-            return QColor(0, 128, 128); // Teal
+            return {0, 128, 128}; // Teal
         else
-            return QColor(0, 205, 205); // Cyan 3
+            return {0, 205, 205}; // Cyan 3
     case BitTorrent::TorrentState::Unknown:
-        return QColor(255, 0, 0); // red
+        return {255, 0, 0}; // red
     default:
         Q_ASSERT(false);
-        return QColor(255, 0, 0); // red
+        return {255, 0, 0}; // red
     }
 }
 

--- a/src/gui/transferlistsortmodel.cpp
+++ b/src/gui/transferlistsortmodel.cpp
@@ -104,8 +104,8 @@ bool TransferListSortModel::lessThan(const QModelIndex &left, const QModelIndex 
             // In this case QSortFilterProxyModel::lessThan() converts other types to QString and
             // sorts them.
             // Thus we can't use the code in the default label.
-            const BitTorrent::TorrentState leftValue = left.data().value<BitTorrent::TorrentState>();
-            const BitTorrent::TorrentState rightValue = right.data().value<BitTorrent::TorrentState>();
+            const auto leftValue = left.data().value<BitTorrent::TorrentState>();
+            const auto rightValue = right.data().value<BitTorrent::TorrentState>();
             if (leftValue != rightValue)
                 return leftValue < rightValue;
 
@@ -261,7 +261,7 @@ bool TransferListSortModel::filterAcceptsRow(int sourceRow, const QModelIndex &s
 
 bool TransferListSortModel::matchFilter(int sourceRow, const QModelIndex &sourceParent) const
 {
-    TransferListModel *model = qobject_cast<TransferListModel *>(sourceModel());
+    auto *model = qobject_cast<TransferListModel *>(sourceModel());
     if (!model) return false;
 
     BitTorrent::TorrentHandle *const torrent = model->torrentHandle(model->index(sourceRow, 0, sourceParent));

--- a/src/gui/transferlistsortmodel.cpp
+++ b/src/gui/transferlistsortmodel.cpp
@@ -160,8 +160,8 @@ bool TransferListSortModel::lessThan(const QModelIndex &left, const QModelIndex 
                 const bool isAscendingOrder = (sortOrder() == Qt::AscendingOrder);
                 if (isSeedingL)
                     return !isAscendingOrder;
-                else
-                    return isAscendingOrder;
+
+                return isAscendingOrder;
             }
 
             const qlonglong etaL = left.data().toLongLong();
@@ -171,15 +171,14 @@ bool TransferListSortModel::lessThan(const QModelIndex &left, const QModelIndex 
             if (isInvalidL && isInvalidR) {
                 if (isSeedingL)  // Both seeding
                     return dateLessThan(TransferListModel::TR_SEED_DATE, left, right, true);
-                else
-                    return (prioL < prioR);
+
+                return (prioL < prioR);
             }
-            else if (!isInvalidL && !isInvalidR) {
+            if (!isInvalidL && !isInvalidR) {
                 return (etaL < etaR);
             }
-            else {
-                return !isInvalidL;
-            }
+
+            return !isInvalidL;
         }
 
     case TransferListModel::TR_LAST_ACTIVITY: {
@@ -221,8 +220,8 @@ bool TransferListSortModel::lowerPositionThan(const QModelIndex &left, const QMo
     if ((queueL > 0) || (queueR > 0)) {
         if ((queueL > 0) && (queueR > 0))
             return queueL < queueR;
-        else
-            return queueL != 0;
+
+        return queueL != 0;
     }
 
     // Sort according to TR_SEED_DATE

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -878,7 +878,7 @@ void TransferListWidget::clearSelectionTags()
 void TransferListWidget::displayListMenu(const QPoint&)
 {
     const QModelIndexList selectedIndexes = selectionModel()->selectedRows();
-    if (selectedIndexes.size() == 0) return;
+    if (selectedIndexes.isEmpty()) return;
 
     // Create actions
     QAction actionStart(GuiIconProvider::instance()->getIcon("media-playback-start"), tr("Resume", "Resume/start the torrent"), nullptr);

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -101,7 +101,7 @@ namespace
     QSize CheckBoxIconHelper::sizeHint() const
     {
         const int dim = QCheckBox::sizeHint().height();
-        return QSize(dim, dim);
+        return {dim, dim};
     }
 
     void CheckBoxIconHelper::initStyleOption(QStyleOptionButton *opt) const
@@ -812,7 +812,7 @@ QStringList TransferListWidget::askTagsForSelection(const QString &dialogTitle)
         const QString tagsInput = AutoExpandableDialog::getText(
             this, dialogTitle, tr("Comma-separated tags:"), QLineEdit::Normal, "", &ok).trimmed();
         if (!ok || tagsInput.isEmpty())
-            return QStringList();
+            return {};
         tags = tagsInput.split(',', QString::SkipEmptyParts);
         for (QString &tag : tags) {
             tag = tag.trimmed();

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -153,7 +153,7 @@ namespace
         }
         m_checkBoxOffset.setWidth(layoutPadding.width());
 
-        QHBoxLayout *layout = new QHBoxLayout(this);
+        auto *layout = new QHBoxLayout(this);
         layout->addWidget(m_checkBox);
         layout->addStretch();
         layout->setContentsMargins(layoutPadding.width(), layoutPadding.height(), layoutPadding.width(), layoutPadding.height());

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -96,7 +96,7 @@ QSize Utils::Gui::smallIconSize(const QWidget *widget)
     // Get DPI scaled icon size (device-dependent), see QT source
     // under a 1080p screen is usually 16x16
     const int s = QApplication::style()->pixelMetric(QStyle::PM_SmallIconSize, nullptr, widget);
-    return QSize(s, s);
+    return {s, s};
 }
 
 QSize Utils::Gui::mediumIconSize(const QWidget *widget)
@@ -110,5 +110,5 @@ QSize Utils::Gui::largeIconSize(const QWidget *widget)
     // Get DPI scaled icon size (device-dependent), see QT source
     // under a 1080p screen is usually 32x32
     const int s = QApplication::style()->pixelMetric(QStyle::PM_LargeIconSize, nullptr, widget);
-    return QSize(s, s);
+    return {s, s};
 }

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -329,7 +329,7 @@ void AppController::setPreferencesAction()
 
         // Update deleted folders
         for (auto i = oldScanDirs.cbegin(); i != oldScanDirs.cend(); ++i) {
-            const QString folder = i.key();
+            const QString &folder = i.key();
             if (!scanDirs.contains(folder)) {
                 model->removePath(folder);
                 qDebug("Removed watched folder %s", qUtf8Printable(folder));

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -491,10 +491,11 @@ void AppController::setPreferencesAction()
     if (m.contains("locale")) {
         QString locale = m["locale"].toString();
         if (pref->getLocale() != locale) {
-            QTranslator *translator = new QTranslator;
+            auto *translator = new QTranslator;
             if (translator->load(QLatin1String(":/lang/qbittorrent_") + locale)) {
                 qDebug("%s locale recognized, using translation.", qUtf8Printable(locale));
-            }else{
+            }
+            else {
                 qDebug("%s locale unrecognized, using default (en).", qUtf8Printable(locale));
             }
             qApp->installTranslator(translator);

--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -434,9 +434,9 @@ void SyncController::maindataAction()
     data["torrents"] = torrents;
 
     QVariantHash categories;
-    const auto categoriesList = session->categories();
+    const auto &categoriesList = session->categories();
     for (auto it = categoriesList.cbegin(); it != categoriesList.cend(); ++it) {
-        const auto key = it.key();
+        const auto &key = it.key();
         categories[key] = QVariantMap {
             {"name", key},
             {"savePath", it.value()}

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -94,7 +94,7 @@ namespace
     inline QUrl urlFromHostHeader(const QString &hostHeader)
     {
         if (!hostHeader.contains(QLatin1String("://")))
-            return QUrl(QLatin1String("http://") + hostHeader);
+            return {QLatin1String("http://") + hostHeader};
         return hostHeader;
     }
 

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -509,13 +509,9 @@ QString WebApplication::generateSid() const
     QString sid;
 
     do {
-        const size_t size = 6;
-        quint32 tmp[size];
-
-        for (size_t i = 0; i < size; ++i)
-            tmp[i] = Utils::Random::rand();
-
-        sid = QByteArray::fromRawData(reinterpret_cast<const char *>(tmp), sizeof(quint32) * size).toBase64();
+        const quint32 tmp[] = {Utils::Random::rand(), Utils::Random::rand(), Utils::Random::rand()
+                , Utils::Random::rand(), Utils::Random::rand(), Utils::Random::rand()};
+        sid = QByteArray::fromRawData(reinterpret_cast<const char *>(tmp), sizeof(tmp)).toBase64();
     }
     while (m_sessions.contains(sid));
 


### PR DESCRIPTION
- Don't use 'else' after return/break
- Pass by value and use std::move in some constructors
- Convert to range-based for loop
- Use 'auto' to avoid duplicating the type name
- Use isEmpty() instead of size() for emptiness 
- Convert vars into refs to avoid copy construction from const refs
- Replace deprecated header 'signal.h' with 'csignal' 
- Avoid repeating the return type
- Remove some unused stuff