### PR TITLE
Linux/Wayland: make window title bar icon work

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -125,6 +125,7 @@ Application::Application(const QString &id, int &argc, char **argv)
     qRegisterMetaType<Log::Msg>("Log::Msg");
 
     setApplicationName("qBittorrent");
+    setOrganizationDomain("qbittorrent.org");
     validateCommandLineParameters();
 
     const QString profileDir = m_commandLineArgs.portableMode
@@ -146,6 +147,9 @@ Application::Application(const QString &id, int &argc, char **argv)
 #if !defined(DISABLE_GUI)
     setAttribute(Qt::AA_UseHighDpiPixmaps, true);  // opt-in to the high DPI pixmap support
     setQuitOnLastWindowClosed(false);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
+    setDesktopFileName("org.qbittorrent.qBittorrent");
+#endif
 #endif
 
 #if defined(Q_OS_WIN) && !defined(DISABLE_GUI)


### PR DESCRIPTION
https://github.com/flathub/org.qbittorrent.qBittorrent/issues/18

Otherwise, only a generic icon is shown.

This must match the naming scheme of `dist/unix/org.qbittorrent.qBittorrent.desktop`.

Also `QGuiApplication::setDesktopFileName("org.qbittorrent.qBittorrent");` needs to be added somewhere.