### PR TITLE
Raise minimum Qt version to 5.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,14 +52,17 @@ addons:
     sources:
       # sources list: https://github.com/travis-ci/apt-source-safelist/blob/master/ubuntu.json
       - sourceline: 'ppa:qbittorrent-team/qbittorrent-stable'
+      - sourceline: 'ppa:beineri/opt-qt59-xenial'
     packages:
       # packages list: https://github.com/travis-ci/apt-package-safelist/blob/master/ubuntu-trusty
       - [autoconf, automake, colormake]
       - [libboost-dev, libboost-system-dev]
       - libssl-dev
       - libtorrent-rasterbar-dev
-      - [qtbase5-dev, qttools5-dev-tools, libqt5svg5-dev]
+      - [qt59base, qt59svg, qt59tools]
       - zlib1g-dev
+      # required for Qt 5.9 from 'beineri' PPA
+      - libgl1-mesa-dev
   homebrew:
     update: true
     packages:
@@ -85,6 +88,11 @@ before_install:
     if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       # setup virtual display for after_success target
       if [ "$gui" = "true" ]; then export "DISPLAY=:99.0" && /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16 ; fi ;
+      
+      # Qt 5.9
+      PATH=/opt/qt59/bin:${PATH}
+      qmake_conf="$qmake_conf PKG_CONFIG_PATH=/opt/qt59/lib/pkgconfig::$PKG_CONFIG_PATH"
+      cmake_conf="$cmake_conf PKG_CONFIG_PATH=/opt/qt59/lib/pkgconfig::$PKG_CONFIG_PATH"
     fi
   - |
     if [ "$TRAVIS_OS_NAME" = "osx" ]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ include(FeatureSummary)
 
 # version requirements
 set(requiredBoostVersion 1.35)
-set(requiredQtVersion 5.5.1)
+set(requiredQtVersion 5.9.0)
 set(requiredOpensslVersion 1.0)
 set(requiredLibtorrentVersion 1.1.10)
 

--- a/configure
+++ b/configure
@@ -1431,7 +1431,7 @@ Some influential environment variables:
               directories to add to pkg-config's search path
   PKG_CONFIG_LIBDIR
               path overriding pkg-config's built-in search path
-  QT_QMAKE    value of host_bins for Qt5Core >= 5.5.1, overriding pkg-config
+  QT_QMAKE    value of host_bins for Qt5Core >= 5.9.0, overriding pkg-config
   Qt5Svg_CFLAGS
               C compiler flags for Qt5Svg, overriding pkg-config
   Qt5Svg_LIBS linker flags for Qt5Svg, overriding pkg-config
@@ -4498,8 +4498,8 @@ $as_echo "$enable_webui" >&6; }
 esac
 
 if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"Qt5Core >= 5.5.1\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "Qt5Core >= 5.5.1") 2>&5
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"Qt5Core >= 5.9.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "Qt5Core >= 5.9.0") 2>&5
   ac_status=$?
   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
@@ -4508,12 +4508,12 @@ if test -n "$QT_QMAKE"; then
     pkg_cv_QT_QMAKE="$QT_QMAKE"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"Qt5Core >= 5.5.1\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "Qt5Core >= 5.5.1") 2>&5
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"Qt5Core >= 5.9.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "Qt5Core >= 5.9.0") 2>&5
   ac_status=$?
   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_QT_QMAKE=`$PKG_CONFIG --variable="host_bins" "Qt5Core >= 5.5.1" 2>/dev/null`
+  pkg_cv_QT_QMAKE=`$PKG_CONFIG --variable="host_bins" "Qt5Core >= 5.9.0" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -4540,8 +4540,8 @@ fi
 
 fi
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for Qt5 qmake >= 5.5.1" >&5
-$as_echo_n "checking for Qt5 qmake >= 5.5.1... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for Qt5 qmake >= 5.9.0" >&5
+$as_echo_n "checking for Qt5 qmake >= 5.9.0... " >&6; }
 if test "x$QT_QMAKE" != "x"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $QT_QMAKE" >&5
 $as_echo "$QT_QMAKE" >&6; }
@@ -4655,11 +4655,11 @@ case "x$enable_qt_dbus" in #(
   "xyes") :
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
-               { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Qt5DBus >= 5.5.1" >&5
-$as_echo_n "checking for Qt5DBus >= 5.5.1... " >&6; }
+               { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Qt5DBus >= 5.9.0" >&5
+$as_echo_n "checking for Qt5DBus >= 5.9.0... " >&6; }
        if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"Qt5DBus >= 5.5.1\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "Qt5DBus >= 5.5.1") 2>&5
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"Qt5DBus >= 5.9.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "Qt5DBus >= 5.9.0") 2>&5
   ac_status=$?
   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then

--- a/m4/qbittorrent.m4
+++ b/m4/qbittorrent.m4
@@ -5,9 +5,9 @@
 # Sets the QT_QMAKE variable to the path of Qt5 qmake if found.
 # --------------------------------------
 AC_DEFUN([FIND_QT5],
-[PKG_CHECK_EXISTS([Qt5Core >= 5.5.1],
+[PKG_CHECK_EXISTS([Qt5Core >= 5.9.0],
                  [PKG_CHECK_VAR(QT_QMAKE,
-                                [Qt5Core >= 5.5.1],
+                                [Qt5Core >= 5.9.0],
                                 [host_bins])
                  ])
 
@@ -18,7 +18,7 @@ AS_IF([test -f "$QT_QMAKE/qmake"],
                              [QT_QMAKE=""])
               ])
 
-AC_MSG_CHECKING([for Qt5 qmake >= 5.5.1])
+AC_MSG_CHECKING([for Qt5 qmake >= 5.9.0])
 AS_IF([test "x$QT_QMAKE" != "x"],
       [AC_MSG_RESULT([$QT_QMAKE])],
       [AC_MSG_RESULT([not found])]
@@ -29,8 +29,8 @@ AS_IF([test "x$QT_QMAKE" != "x"],
 # Sets the HAVE_QTDBUS variable to true or false.
 # --------------------------------------
 AC_DEFUN([FIND_QTDBUS],
-       [AC_MSG_CHECKING([for Qt5DBus >= 5.5.1])
-       PKG_CHECK_EXISTS([Qt5DBus >= 5.5.1],
+       [AC_MSG_CHECKING([for Qt5DBus >= 5.9.0])
+       PKG_CHECK_EXISTS([Qt5DBus >= 5.9.0],
                         [AC_MSG_RESULT([found])
                          HAVE_QTDBUS=[true]],
                         [AC_MSG_RESULT([not found])


### PR DESCRIPTION
Why Qt 5.9?

It is an LTS version. I would choose the latest one (aka 5.12) but it is too new and mainstream user distros don't support it yet. We could move to it after the next LTS version of Ubuntu comes out that supports it (and probably a few months go by).