### PR TITLE
Move helper functions to Utils::Gui namespace

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -41,6 +41,7 @@
 
 #include <QAtomicInt>
 #include <QDebug>
+#include <QDir>
 #include <QLibraryInfo>
 #include <QProcess>
 
@@ -55,6 +56,7 @@
 #endif // Q_OS_MAC
 #include "addnewtorrentdialog.h"
 #include "gui/guiiconprovider.h"
+#include "gui/utils.h"
 #include "mainwindow.h"
 #include "shutdownconfirmdialog.h"
 #else // DISABLE_GUI
@@ -529,7 +531,7 @@ int Application::exec(const QStringList &params)
         msgBox.setText(tr("Application failed to start."));
         msgBox.setInformativeText(err.message());
         msgBox.show(); // Need to be shown or to moveToCenter does not work
-        msgBox.move(Utils::Misc::screenCenter(&msgBox));
+        msgBox.move(Utils::Gui::screenCenter(&msgBox));
         msgBox.exec();
 #endif
         return 1;

--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -45,6 +45,10 @@
 #include "base/utils/misc.h"
 #include "base/utils/string.h"
 
+#ifndef DISABLE_GUI
+#include "gui/utils.h"
+#endif
+
 namespace
 {
     const int USAGE_INDENTATION = 4;
@@ -580,7 +584,7 @@ void displayUsage(const QString &prgName)
 #else
     QMessageBox msgBox(QMessageBox::Information, QObject::tr("Help"), makeUsage(prgName), QMessageBox::Ok);
     msgBox.show(); // Need to be shown or to moveToCenter does not work
-    msgBox.move(Utils::Misc::screenCenter(&msgBox));
+    msgBox.move(Utils::Gui::screenCenter(&msgBox));
     msgBox.exec();
 #endif
 }

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -76,6 +76,10 @@ Q_IMPORT_PLUGIN(QICOPlugin)
 #include "cmdoptions.h"
 #include "upgrade.h"
 
+#ifndef DISABLE_GUI
+#include "gui/utils.h"
+#endif
+
 // Signal handlers
 void sigNormalHandler(int signum);
 #ifdef STACKTRACE
@@ -328,7 +332,7 @@ void displayBadArgMessage(const QString &message)
     QMessageBox msgBox(QMessageBox::Critical, QObject::tr("Bad command line"),
                        message + QLatin1Char('\n') + help, QMessageBox::Ok);
     msgBox.show(); // Need to be shown or to moveToCenter does not work
-    msgBox.move(Utils::Misc::screenCenter(&msgBox));
+    msgBox.move(Utils::Gui::screenCenter(&msgBox));
     msgBox.exec();
 #else
     const QString errMsg = QObject::tr("Bad command line: ") + '\n'
@@ -364,7 +368,7 @@ bool userAgreesWithLegalNotice()
     msgBox.addButton(QObject::tr("Cancel"), QMessageBox::RejectRole);
     const QAbstractButton *agreeButton = msgBox.addButton(QObject::tr("I Agree"), QMessageBox::AcceptRole);
     msgBox.show(); // Need to be shown or to moveToCenter does not work
-    msgBox.move(Utils::Misc::screenCenter(&msgBox));
+    msgBox.move(Utils::Gui::screenCenter(&msgBox));
     msgBox.exec();
     if (msgBox.clickedButton() == agreeButton) {
         // Save the answer

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -32,12 +32,9 @@
 #include <algorithm>
 #include <type_traits>
 
-#include <QBitArray>
-#include <QByteArray>
-#include <QDebug>
-#include <QDir>
-#include <QFile>
-#include <QStringList>
+#ifdef Q_OS_WIN
+#include <windows.h>
+#endif
 
 #include <libtorrent/address.hpp>
 #include <libtorrent/alert_types.hpp>
@@ -47,17 +44,20 @@
 #include <libtorrent/magnet_uri.hpp>
 #include <libtorrent/time.hpp>
 
-#ifdef Q_OS_WIN
-#include <windows.h>
-#endif
+#include <QBitArray>
+#include <QDateTime>
+#include <QDebug>
+#include <QDir>
+#include <QFile>
+#include <QStringList>
+#include <QUrl>
 
 #include "base/global.h"
 #include "base/logger.h"
 #include "base/preferences.h"
 #include "base/profile.h"
+#include "base/tristatebool.h"
 #include "base/utils/fs.h"
-#include "base/utils/misc.h"
-#include "base/utils/string.h"
 #include "peerinfo.h"
 #include "session.h"
 #include "trackerentry.h"

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -32,7 +32,9 @@
 
 #include <functional>
 
-#include <QDateTime>
+#include <libtorrent/torrent_handle.hpp>
+#include <libtorrent/torrent_status.hpp>
+
 #include <QHash>
 #include <QObject>
 #include <QQueue>
@@ -40,50 +42,47 @@
 #include <QString>
 #include <QVector>
 
-#include <libtorrent/torrent_handle.hpp>
-#include <libtorrent/torrent_status.hpp>
-
-#include "base/tristatebool.h"
 #include "private/speedmonitor.h"
 #include "infohash.h"
 #include "torrentinfo.h"
 
-class QBitArray;
-class QStringList;
-template<typename T, typename U> struct QPair;
-
 extern const QString QB_EXT;
+
+class QBitArray;
+class QDateTime;
+class QStringList;
+class QUrl;
 
 namespace libtorrent
 {
     class alert;
+    struct fastresume_rejected_alert;
+    struct file_completed_alert;
+    struct file_renamed_alert;
+    struct file_rename_failed_alert;
+    struct metadata_received_alert;
+    struct save_resume_data_alert;
+    struct save_resume_data_failed_alert;
     struct stats_alert;
+    struct storage_moved_alert;
+    struct storage_moved_failed_alert;
     struct torrent_checked_alert;
     struct torrent_finished_alert;
     struct torrent_paused_alert;
     struct torrent_resumed_alert;
-    struct save_resume_data_alert;
-    struct save_resume_data_failed_alert;
-    struct file_renamed_alert;
-    struct file_rename_failed_alert;
-    struct storage_moved_alert;
-    struct storage_moved_failed_alert;
-    struct metadata_received_alert;
-    struct file_completed_alert;
+    struct torrent_status;
     struct tracker_error_alert;
     struct tracker_reply_alert;
     struct tracker_warning_alert;
-    struct fastresume_rejected_alert;
-    struct torrent_status;
 }
 
 namespace BitTorrent
 {
-    struct PeerAddress;
-    class Session;
     class PeerInfo;
+    class Session;
     class TrackerEntry;
     struct AddTorrentParams;
+    struct PeerAddress;
 
     struct CreateTorrentParams
     {

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -30,14 +30,15 @@
 
 #include <libtorrent/error_code.hpp>
 
+#include <QByteArray>
 #include <QDateTime>
 #include <QDebug>
+#include <QDir>
 #include <QString>
+#include <QStringList>
 #include <QUrl>
 
 #include "base/utils/fs.h"
-#include "base/utils/misc.h"
-#include "base/utils/string.h"
 #include "infohash.h"
 #include "trackerentry.h"
 

--- a/src/base/bittorrent/torrentinfo.h
+++ b/src/base/bittorrent/torrentinfo.h
@@ -33,7 +33,6 @@
 
 #include <QCoreApplication>
 #include <QList>
-#include <QtGlobal>
 #include <QVector>
 
 #include "base/indexrange.h"

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -29,9 +29,6 @@
 #ifndef UTILS_MISC_H
 #define UTILS_MISC_H
 
-#include <ctime>
-#include <vector>
-
 #include <QtGlobal>
 
 #ifdef Q_OS_WIN
@@ -39,14 +36,10 @@
 #include <Windows.h>
 #endif
 
-#include <QDir>
-#include <QPoint>
-#include <QSize>
 #include <QString>
 #include <QStringList>
-#include <QUrl>
 
-#include "base/types.h"
+enum class ShutdownDialogAction;
 
 /*  Miscellaneous functions that can be useful */
 
@@ -98,13 +91,6 @@ namespace Utils
         QStringList toStringList(const QList<bool> &l);
         QList<int> intListfromStringList(const QStringList &l);
         QList<bool> boolListfromStringList(const QStringList &l);
-
-#ifndef DISABLE_GUI
-        void openPath(const QString &absolutePath);
-        void openFolderSelect(const QString &absolutePath);
-
-        QPoint screenCenter(const QWidget *w);
-#endif
 
 #ifdef Q_OS_WIN
         QString windowsSystemPath();

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -29,6 +29,7 @@
 #include "addnewtorrentdialog.h"
 
 #include <QDebug>
+#include <QDir>
 #include <QFile>
 #include <QMenu>
 #include <QPushButton>

--- a/src/gui/macutilities.h
+++ b/src/gui/macutilities.h
@@ -29,9 +29,13 @@
 #ifndef MACUTILITIES_H
 #define MACUTILITIES_H
 
-#include <QPixmap>
-#include <QSize>
 #include <objc/objc.h>
+
+#include <QSet>
+
+class QPixmap;
+class QSize;
+class QString;
 
 namespace MacUtils
 {

--- a/src/gui/macutilities.mm
+++ b/src/gui/macutilities.mm
@@ -28,10 +28,14 @@
 
 #include "macutilities.h"
 
-#include <QSet>
-#include <QtMac>
-#include <objc/message.h>
 #import <Cocoa/Cocoa.h>
+#include <objc/message.h>
+
+#include <QPixmap>
+#include <QSet>
+#include <QSize>
+#include <QString>
+#include <QtMac>
 
 namespace MacUtils
 {

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -107,10 +107,6 @@
 #include "programupdater.h"
 #endif
 
-#ifdef Q_OS_MAC
-void qt_mac_set_dock_menu(QMenu *menu);
-#endif
-
 #define TIME_TRAY_BALLOON 5000
 #define PREVENT_SUSPEND_INTERVAL 60000
 
@@ -469,7 +465,7 @@ MainWindow::MainWindow(QWidget *parent)
 #endif
 #ifdef Q_OS_MAC
     setupDockClickHandler();
-    qt_mac_set_dock_menu(trayIconMenu());
+    trayIconMenu()->setAsDockMenu();
 #endif
 }
 
@@ -1815,7 +1811,6 @@ void MainWindow::on_actionDownloadFromURL_triggered()
 }
 
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
-
 void MainWindow::handleUpdateCheckFinished(bool updateAvailable, QString newVersion, bool invokedByUser)
 {
     QMessageBox::StandardButton answer = QMessageBox::Yes;

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1130,7 +1130,7 @@ void MainWindow::showEvent(QShowEvent *e)
 
     // Make sure the window is initially centered
     if (!m_posInitialized) {
-        move(Utils::Misc::screenCenter(this));
+        move(Utils::Gui::screenCenter(this));
         m_posInitialized = true;
     }
 }

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -30,12 +30,14 @@
 
 #include <QAction>
 #include <QDebug>
+#include <QDir>
 #include <QHeaderView>
 #include <QListWidgetItem>
 #include <QMenu>
 #include <QSplitter>
 #include <QStackedWidget>
 #include <QThread>
+#include <QUrl>
 
 #include "base/bittorrent/filepriority.h"
 #include "base/bittorrent/session.h"
@@ -527,7 +529,7 @@ void PropertiesWidget::openFile(const QModelIndex &index)
     qDebug("Trying to open file at %s", qUtf8Printable(filePath));
     // Flush data
     m_torrent->flushCache();
-    Utils::Misc::openPath(filePath);
+    Utils::Gui::openPath(filePath);
 }
 
 void PropertiesWidget::openFolder(const QModelIndex &index, bool containingFolder)
@@ -563,9 +565,9 @@ void PropertiesWidget::openFolder(const QModelIndex &index, bool containingFolde
     MacUtils::openFiles(QSet<QString>{absolutePath});
 #else
     if (containingFolder)
-        Utils::Misc::openFolderSelect(absolutePath);
+        Utils::Gui::openFolderSelect(absolutePath);
     else
-        Utils::Misc::openPath(absolutePath);
+        Utils::Gui::openPath(absolutePath);
 #endif
 }
 

--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -35,10 +35,9 @@
 #include <QHeaderView>
 #include <QMenu>
 #include <QPalette>
-#include <QSortFilterProxyModel>
 #include <QStandardItemModel>
 #include <QTableView>
-#include <QTreeView>
+#include <QUrl>
 
 #include "base/bittorrent/session.h"
 #include "base/preferences.h"

--- a/src/gui/search/searchjobwidget.h
+++ b/src/gui/search/searchjobwidget.h
@@ -36,7 +36,6 @@
 
 class QHeaderView;
 class QModelIndex;
-class QStandardItem;
 class QStandardItemModel;
 
 template <typename T> class CachedSettingValue;

--- a/src/gui/shutdownconfirmdialog.cpp
+++ b/src/gui/shutdownconfirmdialog.cpp
@@ -35,7 +35,6 @@
 #include <QStyle>
 
 #include "base/preferences.h"
-#include "base/utils/misc.h"
 #include "ui_shutdownconfirmdialog.h"
 #include "utils.h"
 
@@ -63,7 +62,7 @@ ShutdownConfirmDialog::ShutdownConfirmDialog(QWidget *parent, const ShutdownDial
 
     // Always on top
     setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
-    move(Utils::Misc::screenCenter(this));
+    move(Utils::Gui::screenCenter(this));
 
     m_timer.setInterval(1000); // 1sec
     connect(&m_timer, &QTimer::timeout, this, &ShutdownConfirmDialog::updateSeconds);

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -30,6 +30,7 @@
 #include "transferlistmodel.h"
 
 #include <QApplication>
+#include <QDateTime>
 #include <QDebug>
 #include <QIcon>
 #include <QPalette>

--- a/src/gui/transferlistsortmodel.cpp
+++ b/src/gui/transferlistsortmodel.cpp
@@ -28,13 +28,13 @@
 
 #include "transferlistsortmodel.h"
 
+#include <QDateTime>
 #include <QStringList>
 
 #include "base/bittorrent/torrenthandle.h"
 #include "base/types.h"
 #include "base/utils/string.h"
 #include "transferlistmodel.h"
-
 
 TransferListSortModel::TransferListSortModel(QObject *parent)
     : QSortFilterProxyModel(parent)

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -63,6 +63,7 @@
 #include "transferlistmodel.h"
 #include "transferlistsortmodel.h"
 #include "updownratiodialog.h"
+#include "utils.h"
 
 #ifdef Q_OS_MAC
 #include "macutilities.h"
@@ -341,7 +342,7 @@ TransferListModel *TransferListWidget::getSourceModel() const
 
 void TransferListWidget::previewFile(const QString &filePath)
 {
-    Utils::Misc::openPath(filePath);
+    Utils::Gui::openPath(filePath);
 }
 
 inline QModelIndex TransferListWidget::mapToSource(const QModelIndex &index) const
@@ -386,9 +387,9 @@ void TransferListWidget::torrentDoubleClicked()
         MacUtils::openFiles(QSet<QString>{torrent->contentPath(true)});
 #else
         if (torrent->filesCount() == 1)
-            Utils::Misc::openFolderSelect(torrent->contentPath(true));
+            Utils::Gui::openFolderSelect(torrent->contentPath(true));
         else
-            Utils::Misc::openPath(torrent->contentPath(true));
+            Utils::Gui::openPath(torrent->contentPath(true));
 #endif
         break;
     }
@@ -592,9 +593,9 @@ void TransferListWidget::openSelectedTorrentsFolder() const
         QString path = torrent->contentPath(true);
         if (!pathsList.contains(path)) {
             if (torrent->filesCount() == 1)
-                Utils::Misc::openFolderSelect(path);
+                Utils::Gui::openFolderSelect(path);
             else
-                Utils::Misc::openPath(path);
+                Utils::Gui::openPath(path);
         }
         pathsList.insert(path);
     }

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -28,13 +28,29 @@
 
 #include "utils.h"
 
+#ifdef Q_OS_WIN
+#include <Objbase.h>
+#include <Shlobj.h>
+#endif
+
 #include <QApplication>
+#include <QDesktopServices>
 #include <QDesktopWidget>
+#include <QFileInfo>
+#include <QIcon>
+#include <QPixmap>
 #include <QPixmapCache>
+#include <QPoint>
+#include <QProcess>
+#include <QRegularExpression>
 #include <QScreen>
 #include <QStyle>
+#include <QUrl>
 #include <QWidget>
 #include <QWindow>
+
+#include "base/utils/fs.h"
+#include "base/utils/version.h"
 
 void Utils::Gui::resize(QWidget *widget, const QSize &newSize)
 {
@@ -111,4 +127,94 @@ QSize Utils::Gui::largeIconSize(const QWidget *widget)
     // under a 1080p screen is usually 32x32
     const int s = QApplication::style()->pixelMetric(QStyle::PM_LargeIconSize, nullptr, widget);
     return {s, s};
+}
+
+QPoint Utils::Gui::screenCenter(const QWidget *w)
+{
+    // Returns the QPoint which the widget will be placed center on screen (where parent resides)
+
+    if (!w)
+        return {};
+
+    QRect r = QGuiApplication::primaryScreen()->availableGeometry();
+    const QPoint primaryScreenCenter {(r.x() + (r.width() - w->frameSize().width()) / 2), (r.y() + (r.height() - w->frameSize().height()) / 2)};
+
+    const QWidget *parent = w->parentWidget();
+    if (!parent)
+        return primaryScreenCenter;
+
+    const QWindow *window = parent->window()->windowHandle();
+    if (!window)
+        return primaryScreenCenter;
+
+    const QScreen *screen = window->screen();
+    if (!screen)
+        return primaryScreenCenter;
+
+    r = screen->availableGeometry();
+    return {(r.x() + (r.width() - w->frameSize().width()) / 2), (r.y() + (r.height() - w->frameSize().height()) / 2)};
+}
+
+// Open the given path with an appropriate application
+void Utils::Gui::openPath(const QString &absolutePath)
+{
+    const QString path = Utils::Fs::fromNativePath(absolutePath);
+    // Hack to access samba shares with QDesktopServices::openUrl
+    if (path.startsWith("//"))
+        QDesktopServices::openUrl(Utils::Fs::toNativePath("file:" + path));
+    else
+        QDesktopServices::openUrl(QUrl::fromLocalFile(path));
+}
+
+// Open the parent directory of the given path with a file manager and select
+// (if possible) the item at the given path
+void Utils::Gui::openFolderSelect(const QString &absolutePath)
+{
+    const QString path = Utils::Fs::fromNativePath(absolutePath);
+    // If the item to select doesn't exist, try to open its parent
+    if (!QFileInfo::exists(path)) {
+        openPath(path.left(path.lastIndexOf('/')));
+        return;
+    }
+#ifdef Q_OS_WIN
+    HRESULT hresult = ::CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+    PIDLIST_ABSOLUTE pidl = ::ILCreateFromPathW(reinterpret_cast<PCTSTR>(Utils::Fs::toNativePath(path).utf16()));
+    if (pidl) {
+        ::SHOpenFolderAndSelectItems(pidl, 0, nullptr, 0);
+        ::ILFree(pidl);
+    }
+    if ((hresult == S_OK) || (hresult == S_FALSE))
+        ::CoUninitialize();
+#elif defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
+    QProcess proc;
+    proc.start("xdg-mime", {"query", "default", "inode/directory"});
+    proc.waitForFinished();
+    const QString output = proc.readLine().simplified();
+    if ((output == "dolphin.desktop") || (output == "org.kde.dolphin.desktop")) {
+        proc.startDetached("dolphin", {"--select", Utils::Fs::toNativePath(path)});
+    }
+    else if ((output == "nautilus.desktop") || (output == "org.gnome.Nautilus.desktop")
+                 || (output == "nautilus-folder-handler.desktop")) {
+        proc.start("nautilus", {"--version"});
+        proc.waitForFinished();
+        const QString nautilusVerStr = QString(proc.readLine()).remove(QRegularExpression("[^0-9.]"));
+        using NautilusVersion = Utils::Version<int, 3>;
+        if (NautilusVersion::tryParse(nautilusVerStr, {1, 0, 0}) > NautilusVersion {3, 28})
+            proc.startDetached("nautilus", {Utils::Fs::toNativePath(path)});
+        else
+            proc.startDetached("nautilus", {"--no-desktop", Utils::Fs::toNativePath(path)});
+    }
+    else if (output == "nemo.desktop") {
+        proc.startDetached("nemo", {"--no-desktop", Utils::Fs::toNativePath(path)});
+    }
+    else if ((output == "konqueror.desktop") || (output == "kfmclient_dir.desktop")) {
+        proc.startDetached("konqueror", {"--select", Utils::Fs::toNativePath(path)});
+    }
+    else {
+        // "caja" manager can't pinpoint the file, see: https://github.com/qbittorrent/qBittorrent/issues/5003
+        openPath(path.left(path.lastIndexOf('/')));
+    }
+#else
+    openPath(path.left(path.lastIndexOf('/')));
+#endif
 }

--- a/src/gui/utils.h
+++ b/src/gui/utils.h
@@ -29,11 +29,11 @@
 #ifndef UTILS_GUI_H
 #define UTILS_GUI_H
 
-#include <QtGlobal>
-#include <QPixmap>
 #include <QSize>
 
 class QIcon;
+class QPixmap;
+class QPoint;
 class QWidget;
 
 namespace Utils
@@ -55,6 +55,11 @@ namespace Utils
         QSize smallIconSize(const QWidget *widget = nullptr);
         QSize mediumIconSize(const QWidget *widget = nullptr);
         QSize largeIconSize(const QWidget *widget = nullptr);
+
+        QPoint screenCenter(const QWidget *w);
+
+        void openPath(const QString &absolutePath);
+        void openFolderSelect(const QString &absolutePath);
     }
 }
 

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -28,6 +28,8 @@
 
 #include "serialize_torrent.h"
 
+#include <QDateTime>
+
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/torrenthandle.h"
 #include "base/utils/fs.h"


### PR DESCRIPTION
* Move helper functions to Utils::Gui namespace
  Those are moved:
  ```c++
  void Utils::Misc::openPath(const QString &absolutePath);
  void Utils::Misc::openFolderSelect(const QString &absolutePath);
  QPoint Utils::Misc::screenCenter(const QWidget *w);
  ```
* Replace deprecated `qt_mac_set_dock_menu()`