### PR TITLE
Avoid crashes on torrent search

### DIFF
--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -163,6 +163,8 @@ SearchJobWidget::SearchJobWidget(SearchHandler *searchHandler, QWidget *parent)
 
     QShortcut *enterHotkey = new QShortcut(Qt::Key_Return, m_ui->resultsBrowser, nullptr, nullptr, Qt::WidgetShortcut);
     connect(enterHotkey, &QShortcut::activated, this, &SearchJobWidget::downloadTorrents);
+
+    setStatusTip(statusText(m_status));
 }
 
 SearchJobWidget::~SearchJobWidget()

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -337,7 +337,7 @@ void SearchWidget::on_searchButton_clicked()
     m_ui->tabWidget->setCurrentWidget(newTab);
 
     connect(newTab, &SearchJobWidget::resultsCountUpdated, this, &SearchWidget::resultsCountUpdated);
-    connect(newTab, &SearchJobWidget::statusChanged, this, [this, &newTab]() { tabStatusChanged(newTab); });
+    connect(newTab, &SearchJobWidget::statusChanged, this, [this, newTab]() { tabStatusChanged(newTab); });
 
     m_ui->searchButton->setText(tr("Stop"));
     m_activeSearchTab = newTab;


### PR DESCRIPTION
qbittorrent closes itself without any error message when a search tab
should be notified of a status change: fixed bad pointer variable catch
in lambda code.
Added also default tooltip "Searching..." on tab creation.