### PR TITLE
Improve AdvancedSettings::addRow()

### DIFF
--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -303,18 +303,14 @@ void AdvancedSettings::loadAdvancedSettings()
     const BitTorrent::Session *const session = BitTorrent::Session::instance();
 
     // add section headers
-    QFont boldFont;
-    boldFont.setBold(true);
-    addRow(QBITTORRENT_HEADER, tr("qBittorrent Section"), &labelQbtLink);
-    item(QBITTORRENT_HEADER, PROPERTY)->setFont(boldFont);
     labelQbtLink.setText(QString("<a href=\"%1\">%2</a>")
         .arg("https://github.com/qbittorrent/qBittorrent/wiki/Explanation-of-Options-in-qBittorrent#Advanced", tr("Open documentation")));
     labelQbtLink.setOpenExternalLinks(true);
+    addRow(QBITTORRENT_HEADER, QString("<b>%1</b>").arg(tr("qBittorrent Section")), &labelQbtLink);
 
-    addRow(LIBTORRENT_HEADER, tr("libtorrent Section"), &labelLibtorrentLink);
-    item(LIBTORRENT_HEADER, PROPERTY)->setFont(boldFont);
     labelLibtorrentLink.setText(QString("<a href=\"%1\">%2</a>").arg("https://www.libtorrent.org/reference.html", tr("Open documentation")));
     labelLibtorrentLink.setOpenExternalLinks(true);
+    addRow(LIBTORRENT_HEADER, QString("<b>%1</b>").arg(tr("libtorrent Section")), &labelLibtorrentLink);
 
     // Async IO threads
     spinBoxAsyncIOThreads.setMinimum(1);
@@ -523,17 +519,20 @@ void AdvancedSettings::loadAdvancedSettings()
 }
 
 template <typename T>
-void AdvancedSettings::addRow(int row, const QString &rowText, T *widget)
+void AdvancedSettings::addRow(const int row, const QString &text, T *widget)
 {
-    setItem(row, PROPERTY, new QTableWidgetItem(rowText));
+    auto label = new QLabel(text);
+    label->setOpenExternalLinks(true);
+
+    setCellWidget(row, PROPERTY, label);
     setCellWidget(row, VALUE, widget);
 
     if (std::is_same<T, QCheckBox>::value)
-        connect(widget, SIGNAL(stateChanged(int)), SIGNAL(settingsChanged()));
+        connect(widget, SIGNAL(stateChanged(int)), this, SIGNAL(settingsChanged()));
     else if (std::is_same<T, QSpinBox>::value)
-        connect(widget, SIGNAL(valueChanged(int)), SIGNAL(settingsChanged()));
+        connect(widget, SIGNAL(valueChanged(int)), this, SIGNAL(settingsChanged()));
     else if (std::is_same<T, QComboBox>::value)
-        connect(widget, SIGNAL(currentIndexChanged(int)), SIGNAL(settingsChanged()));
+        connect(widget, SIGNAL(currentIndexChanged(int)), this, SIGNAL(settingsChanged()));
     else if (std::is_same<T, QLineEdit>::value)
-        connect(widget, SIGNAL(textChanged(QString)), SIGNAL(settingsChanged()));
+        connect(widget, SIGNAL(textChanged(QString)), this, SIGNAL(settingsChanged()));
 }

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -56,7 +56,7 @@ private slots:
 
 private:
     void loadAdvancedSettings();
-    template <typename T> void addRow(int row, const QString &rowText, T *widget);
+    template <typename T> void addRow(int row, const QString &text, T *widget);
 
     QLabel labelQbtLink, labelLibtorrentLink;
     QSpinBox spinBoxAsyncIOThreads, spinBoxCheckingMemUsage, spinBoxCache, spinBoxSaveResumeDataInterval, spinBoxOutgoingPortsMin, spinBoxOutgoingPortsMax, spinBoxListRefresh, spinBoxMaxHalfOpen,


### PR DESCRIPTION
1. Add context to connect().
2. Use QLabel in the left table cell, this allows using rich text formatting, such as HTML links.
  This is idea comes from https://github.com/qbittorrent/qBittorrent/pull/10003#issuecomment-447592606

@thalieht you can then have html links in the label, see labelQbtLink.setText for format example.
And perhaps it is better to have the html link in a separate text for easy reading, as such: "label_text <a href="https://www.google.com">(link)</a>" or "label_text <a href="https://www.google.com">(?)</a>"