### PR TITLE
Work around the crash occurred in QTimer

### DIFF
--- a/src/webui/api/synccontroller.h
+++ b/src/webui/api/synccontroller.h
@@ -56,6 +56,7 @@ private slots:
 
 private:
     qint64 getFreeDiskSpace();
+    void invokeChecker() const;
 
     qint64 m_freeDiskSpace = 0;
     FreeDiskSpaceChecker *m_freeDiskSpaceChecker = nullptr;


### PR DESCRIPTION
See Qt commit:
https://code.qt.io/cgit/qt/qtbase.git/commit/src/corelib/kernel/qtimer.cpp?id=a623fe8d2a60ff333d5779f877e3b20f0e141ff1

Fixes #9985.

Will backport to 4.1.x branch once this is approved.
