### PR TITLE
Work around crashing in Qt networking library

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -518,7 +518,7 @@ void MainWindow::setTorrentAddedNotificationsEnabled(bool value)
 
 bool MainWindow::isDownloadTrackerFavicon() const
 {
-    return settings()->loadValue(KEY_DOWNLOAD_TRACKER_FAVICON, true).toBool();
+    return settings()->loadValue(KEY_DOWNLOAD_TRACKER_FAVICON, false).toBool();
 }
 
 void MainWindow::setDownloadTrackerFavicon(bool value)

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -238,8 +238,7 @@ MainWindow::MainWindow(QWidget *parent)
     // m_transferListWidget->setStyleSheet("QTreeView {border: none;}");  // borderless
     m_propertiesWidget = new PropertiesWidget(hSplitter);
     connect(m_transferListWidget, &TransferListWidget::currentTorrentChanged, m_propertiesWidget, &PropertiesWidget::loadTorrentInfos);
-    m_transferListFiltersWidget = new TransferListFiltersWidget(m_splitter, m_transferListWidget);
-    m_transferListFiltersWidget->setDownloadTrackerFavicon(isDownloadTrackerFavicon());
+    m_transferListFiltersWidget = new TransferListFiltersWidget(m_splitter, m_transferListWidget, isDownloadTrackerFavicon());
     hSplitter->addWidget(m_transferListWidget);
     hSplitter->addWidget(m_propertiesWidget);
     m_splitter->addWidget(m_transferListFiltersWidget);

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -192,10 +192,10 @@ void StatusFilterWidget::handleNewTorrent(BitTorrent::TorrentHandle *const) {}
 
 void StatusFilterWidget::torrentAboutToBeDeleted(BitTorrent::TorrentHandle *const) {}
 
-TrackerFiltersList::TrackerFiltersList(QWidget *parent, TransferListWidget *transferList)
+TrackerFiltersList::TrackerFiltersList(QWidget *parent, TransferListWidget *transferList, const bool downloadFavicon)
     : BaseFilterWidget(parent, transferList)
     , m_totalTorrents(0)
-    , m_downloadTrackerFavicon(true)
+    , m_downloadTrackerFavicon(downloadFavicon)
 {
     auto *allTrackers = new QListWidgetItem(this);
     allTrackers->setData(Qt::DisplayRole, QVariant(tr("All (0)", "this is for the tracker filter")));
@@ -545,7 +545,7 @@ QStringList TrackerFiltersList::getHashes(int row)
      return m_trackers.value(trackerFromRow(row));
 }
 
-TransferListFiltersWidget::TransferListFiltersWidget(QWidget *parent, TransferListWidget *transferList)
+TransferListFiltersWidget::TransferListFiltersWidget(QWidget *parent, TransferListWidget *transferList, const bool downloadFavicon)
     : QFrame(parent)
     , m_transferList(transferList)
 {
@@ -625,7 +625,7 @@ TransferListFiltersWidget::TransferListFiltersWidget(QWidget *parent, TransferLi
     trackerLabel->setFont(font);
     frameLayout->addWidget(trackerLabel);
 
-    m_trackerFilters = new TrackerFiltersList(this, transferList);
+    m_trackerFilters = new TrackerFiltersList(this, transferList, downloadFavicon);
     frameLayout->addWidget(m_trackerFilters);
 
     connect(statusLabel, &QCheckBox::toggled, statusFilters, &StatusFilterWidget::toggleFilter);

--- a/src/gui/transferlistfilterswidget.h
+++ b/src/gui/transferlistfilterswidget.h
@@ -98,7 +98,7 @@ class TrackerFiltersList : public BaseFilterWidget
     Q_DISABLE_COPY(TrackerFiltersList)
 
 public:
-    TrackerFiltersList(QWidget *parent, TransferListWidget *transferList);
+    TrackerFiltersList(QWidget *parent, TransferListWidget *transferList, bool downloadFavicon);
     ~TrackerFiltersList() override;
 
     // Redefine addItem() to make sure the list stays sorted
@@ -144,7 +144,7 @@ class TransferListFiltersWidget : public QFrame
     Q_OBJECT
 
 public:
-    TransferListFiltersWidget(QWidget *parent, TransferListWidget *transferList);
+    TransferListFiltersWidget(QWidget *parent, TransferListWidget *transferList, bool downloadFavicon);
     void setDownloadTrackerFavicon(bool value);
 
 public slots:


### PR DESCRIPTION
The workaround comes from:
https://github.com/qbittorrent/qBittorrent/issues/9667#issuecomment-464445025

Closes #9667.

Will backport to 4.1.x branch once approved.

@sledgehammer999 
This would be another blocker before 4.1.x release.