### PR TITLE
Increase the download request size limit from 10 to 100 MiB 

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1809,7 +1809,7 @@ bool Session::addTorrent(const QString &source, const AddTorrentParams &params)
     if (Net::DownloadManager::hasSupportedScheme(source)) {
         LogMsg(tr("Downloading '%1', please wait...", "e.g: Downloading 'xxx.torrent', please wait...").arg(source));
         // Launch downloader
-        Net::DownloadManager::instance()->download(Net::DownloadRequest(source).limit(10485760 /* 10MB */)
+        Net::DownloadManager::instance()->download(Net::DownloadRequest(source).limit(MAX_TORRENT_SIZE)
                                                    , this, &Session::handleDownloadFinished);
         m_downloadedTorrents[source] = params;
         return true;

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -41,6 +41,7 @@
 
 #include "base/global.h"
 #include "base/utils/fs.h"
+#include "base/utils/misc.h"
 #include "infohash.h"
 #include "trackerentry.h"
 
@@ -119,7 +120,7 @@ TorrentInfo TorrentInfo::loadFromFile(const QString &path, QString *error) noexc
 
     if (file.size() > MAX_TORRENT_SIZE) {
         if (error)
-            *error = tr("File size exceeds max limit %1").arg(MAX_TORRENT_SIZE);
+            *error = tr("File size exceeds max limit %1").arg(Utils::Misc::friendlyUnit(MAX_TORRENT_SIZE));
         return TorrentInfo();
     }
 

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -39,6 +39,7 @@
 #include <QStringList>
 #include <QUrl>
 
+#include "base/global.h"
 #include "base/utils/fs.h"
 #include "infohash.h"
 #include "trackerentry.h"
@@ -116,10 +117,9 @@ TorrentInfo TorrentInfo::loadFromFile(const QString &path, QString *error) noexc
         return TorrentInfo();
     }
 
-    const qint64 fileSizeLimit = 100 * 1024 * 1024;  // 100 MB
-    if (file.size() > fileSizeLimit) {
+    if (file.size() > MAX_TORRENT_SIZE) {
         if (error)
-            *error = tr("File size exceeds max limit %1").arg(fileSizeLimit);
+            *error = tr("File size exceeds max limit %1").arg(MAX_TORRENT_SIZE);
         return TorrentInfo();
     }
 

--- a/src/base/global.h
+++ b/src/base/global.h
@@ -36,6 +36,7 @@
 #endif
 
 const char C_TORRENT_FILE_EXTENSION[] = ".torrent";
+const int MAX_TORRENT_SIZE = 100 * 1024 * 1024; // 100 MiB
 
 template <typename T>
 constexpr typename std::add_const<T>::type &asConst(T &t) noexcept { return t; }

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -238,7 +238,7 @@ void AddNewTorrentDialog::show(const QString &source, const BitTorrent::AddTorre
     if (Net::DownloadManager::hasSupportedScheme(source)) {
         // Launch downloader
         Net::DownloadManager::instance()->download(
-                    Net::DownloadRequest(source).limit(10485760 /* 10MB */)
+                    Net::DownloadRequest(source).limit(MAX_TORRENT_SIZE)
                     , dlg, &AddNewTorrentDialog::handleDownloadFinished);
         return;
     }


### PR DESCRIPTION
As suggested in https://github.com/qbittorrent/qBittorrent/issues/9319#issuecomment-412750091 to allow downloading bigger .torrents.

Closes #8331