### PR TITLE
Remove closed connections immediately

### DIFF
--- a/src/base/http/server.cpp
+++ b/src/base/http/server.cpp
@@ -108,15 +108,22 @@ void Server::incomingConnection(const qintptr socketDescriptor)
 
     auto *c = new Connection(serverSocket, m_requestHandler, this);
     m_connections.append(c);
+    connect(serverSocket, &QAbstractSocket::disconnected, this, [c, this]() { removeConnection(c); });
+}
+
+void Server::removeConnection(Connection *connection)
+{
+    m_connections.removeOne(connection);
+    connection->deleteLater();
 }
 
 void Server::dropTimedOutConnection()
 {
     QMutableListIterator<Connection *> i(m_connections);
     while (i.hasNext()) {
-        const auto *connection = i.next();
-        if (connection->isClosed() || connection->hasExpired(KEEP_ALIVE_DURATION)) {
-            delete connection;
+        Connection *connection = i.next();
+        if (connection->hasExpired(KEEP_ALIVE_DURATION)) {
+            connection->deleteLater();
             i.remove();
         }
     }

--- a/src/base/http/server.cpp
+++ b/src/base/http/server.cpp
@@ -107,19 +107,19 @@ void Server::incomingConnection(const qintptr socketDescriptor)
     }
 
     auto *c = new Connection(serverSocket, m_requestHandler, this);
-    m_connections.append(c);
+    m_connections.insert(c);
     connect(serverSocket, &QAbstractSocket::disconnected, this, [c, this]() { removeConnection(c); });
 }
 
 void Server::removeConnection(Connection *connection)
 {
-    m_connections.removeOne(connection);
+    m_connections.remove(connection);
     connection->deleteLater();
 }
 
 void Server::dropTimedOutConnection()
 {
-    QMutableListIterator<Connection *> i(m_connections);
+    QMutableSetIterator<Connection *> i(m_connections);
     while (i.hasNext()) {
         Connection *connection = i.next();
         if (connection->hasExpired(KEEP_ALIVE_DURATION)) {

--- a/src/base/http/server.h
+++ b/src/base/http/server.h
@@ -31,6 +31,7 @@
 #ifndef HTTP_SERVER_H
 #define HTTP_SERVER_H
 
+#include <QSet>
 #include <QSslCertificate>
 #include <QSslKey>
 #include <QTcpServer>
@@ -59,7 +60,7 @@ namespace Http
         void removeConnection(Connection *connection);
 
         IRequestHandler *m_requestHandler;
-        QList<Connection *> m_connections;  // for tracking persistent connections
+        QSet<Connection *> m_connections;  // for tracking persistent connections
 
         bool m_https;
         QList<QSslCertificate> m_certificates;

--- a/src/base/http/server.h
+++ b/src/base/http/server.h
@@ -56,6 +56,7 @@ namespace Http
 
     private:
         void incomingConnection(qintptr socketDescriptor);
+        void removeConnection(Connection *connection);
 
         IRequestHandler *m_requestHandler;
         QList<Connection *> m_connections;  // for tracking persistent connections


### PR DESCRIPTION
Previously it relied on a timer to drop dead connections but that proved to be too slow when there is an incoming burst of connections.

Fixes #10487.

Will backport to v4_1_x.