### PR TITLE
Updates entry for libtorrent to build properly on macOS

### DIFF
--- a/src/base/bittorrent/tracker.cpp
+++ b/src/base/bittorrent/tracker.cpp
@@ -65,15 +65,15 @@ QString Peer::uid() const
 
 libtorrent::entry Peer::toEntry(const bool noPeerId) const
 {
-    libtorrent::entry dict;
-    auto & peerMap = dict.dict();
+    libtorrent::entry entry;
+    auto &peerMap = entry.dict();
 
     if (!noPeerId)
         peerMap["id"] = libtorrent::entry(peerId.toStdString());
     peerMap["ip"] = libtorrent::entry(ip.toString().toStdString());
     peerMap["port"] = libtorrent::entry(port);
 
-    return dict;
+    return entry;
 }
 
 // Tracker
@@ -268,7 +268,8 @@ void Tracker::unregisterPeer(const TrackerAnnounceRequest &announceReq)
 void Tracker::replyWithPeerList(const TrackerAnnounceRequest &announceReq)
 {
     // Prepare the entry for bencoding
-    libtorrent::entry::dictionary_type replyDict;
+    libtorrent::entry entry;
+    auto &replyDict = entry.dict();
     replyDict["interval"] = libtorrent::entry(ANNOUNCE_INTERVAL);
 
     libtorrent::entry::list_type peerList;
@@ -276,10 +277,9 @@ void Tracker::replyWithPeerList(const TrackerAnnounceRequest &announceReq)
         peerList.push_back(p.toEntry(announceReq.noPeerId));
     replyDict["peers"] = libtorrent::entry(peerList);
 
-    const libtorrent::entry replyEntry(replyDict);
     // bencode
     QByteArray reply;
-    libtorrent::bencode(std::back_inserter(reply), replyEntry);
+    libtorrent::bencode(std::back_inserter(reply), entry);
     qDebug("Tracker: reply with the following bencoded data:\n %s", reply.constData());
 
     // HTTP reply

--- a/src/base/bittorrent/tracker.cpp
+++ b/src/base/bittorrent/tracker.cpp
@@ -267,21 +267,21 @@ void Tracker::unregisterPeer(const TrackerAnnounceRequest &announceReq)
 
 void Tracker::replyWithPeerList(const TrackerAnnounceRequest &announceReq)
 {
-//    // Prepare the entry for bencoding
-//    libtorrent::entry::dictionary_type replyDict;
-//    replyDict["interval"] = libtorrent::entry(ANNOUNCE_INTERVAL);
-//
-//    libtorrent::entry::list_type peerList;
-//    for (const Peer &p : m_torrents.value(announceReq.infoHash))
-//        peerList.push_back(p.toEntry(announceReq.noPeerId));
-//    replyDict["peers"] = libtorrent::entry(peerList);
-//
-//    const libtorrent::entry replyEntry(replyDict);
-//    // bencode
-//    QByteArray reply;
-//    libtorrent::bencode(std::back_inserter(reply), replyEntry);
-//    qDebug("Tracker: reply with the following bencoded data:\n %s", reply.constData());
-//
-//    // HTTP reply
-//    print(reply, Http::CONTENT_TYPE_TXT);
+    // Prepare the entry for bencoding
+    libtorrent::entry::dictionary_type replyDict;
+    replyDict["interval"] = libtorrent::entry(ANNOUNCE_INTERVAL);
+
+    libtorrent::entry::list_type peerList;
+    for (const Peer &p : m_torrents.value(announceReq.infoHash))
+        peerList.push_back(p.toEntry(announceReq.noPeerId));
+    replyDict["peers"] = libtorrent::entry(peerList);
+
+    const libtorrent::entry replyEntry(replyDict);
+    // bencode
+    QByteArray reply;
+    libtorrent::bencode(std::back_inserter(reply), replyEntry);
+    qDebug("Tracker: reply with the following bencoded data:\n %s", reply.constData());
+
+    // HTTP reply
+    print(reply, Http::CONTENT_TYPE_TXT);
 }

--- a/src/base/bittorrent/tracker.cpp
+++ b/src/base/bittorrent/tracker.cpp
@@ -65,13 +65,15 @@ QString Peer::uid() const
 
 libtorrent::entry Peer::toEntry(const bool noPeerId) const
 {
-    libtorrent::entry::dictionary_type peerMap;
+    libtorrent::entry dict;
+    auto & peerMap = dict.dict();
+
     if (!noPeerId)
         peerMap["id"] = libtorrent::entry(peerId.toStdString());
     peerMap["ip"] = libtorrent::entry(ip.toString().toStdString());
     peerMap["port"] = libtorrent::entry(port);
 
-    return libtorrent::entry(peerMap);
+    return dict;
 }
 
 // Tracker
@@ -265,21 +267,21 @@ void Tracker::unregisterPeer(const TrackerAnnounceRequest &announceReq)
 
 void Tracker::replyWithPeerList(const TrackerAnnounceRequest &announceReq)
 {
-    // Prepare the entry for bencoding
-    libtorrent::entry::dictionary_type replyDict;
-    replyDict["interval"] = libtorrent::entry(ANNOUNCE_INTERVAL);
-
-    libtorrent::entry::list_type peerList;
-    for (const Peer &p : m_torrents.value(announceReq.infoHash))
-        peerList.push_back(p.toEntry(announceReq.noPeerId));
-    replyDict["peers"] = libtorrent::entry(peerList);
-
-    const libtorrent::entry replyEntry(replyDict);
-    // bencode
-    QByteArray reply;
-    libtorrent::bencode(std::back_inserter(reply), replyEntry);
-    qDebug("Tracker: reply with the following bencoded data:\n %s", reply.constData());
-
-    // HTTP reply
-    print(reply, Http::CONTENT_TYPE_TXT);
+//    // Prepare the entry for bencoding
+//    libtorrent::entry::dictionary_type replyDict;
+//    replyDict["interval"] = libtorrent::entry(ANNOUNCE_INTERVAL);
+//
+//    libtorrent::entry::list_type peerList;
+//    for (const Peer &p : m_torrents.value(announceReq.infoHash))
+//        peerList.push_back(p.toEntry(announceReq.noPeerId));
+//    replyDict["peers"] = libtorrent::entry(peerList);
+//
+//    const libtorrent::entry replyEntry(replyDict);
+//    // bencode
+//    QByteArray reply;
+//    libtorrent::bencode(std::back_inserter(reply), replyEntry);
+//    qDebug("Tracker: reply with the following bencoded data:\n %s", reply.constData());
+//
+//    // HTTP reply
+//    print(reply, Http::CONTENT_TYPE_TXT);
 }


### PR DESCRIPTION
TravisCI:
```bash
Undefined symbols for architecture x86_64:
  "libtorrent::entry::entry(std::__1::map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, libtorrent::entry, libtorrent::aux::strview_less, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, libtorrent::entry> > >)", referenced from:
      BitTorrent::Peer::toEntry(bool) const in tracker.o
      BitTorrent::Tracker::replyWithPeerList(BitTorrent::TrackerAnnounceRequest const&) in tracker.o
```

This is working with libtorrent 1.2 as well.