### PR TITLE
Add 12 hour and 24 hour speed graphs. Closes #9686

### DIFF
--- a/src/gui/properties/speedplotview.cpp
+++ b/src/gui/properties/speedplotview.cpp
@@ -327,11 +327,11 @@ void SpeedPlotView::paintEvent(QPaintEvent *)
     painter.drawLine(fullRect.left(), rect.top() + 0.75 * rect.height(), rect.right(), rect.top() + 0.75 * rect.height());
     painter.drawLine(fullRect.left(), rect.bottom(), rect.right(), rect.bottom());
 
-    painter.drawLine(rect.left(), fullRect.top(), rect.left(), fullRect.bottom());
-    painter.drawLine(rect.left() + 0.2 * rect.width(), fullRect.top(), rect.left() + 0.2 * rect.width(), fullRect.bottom());
-    painter.drawLine(rect.left() + 0.4 * rect.width(), fullRect.top(), rect.left() + 0.4 * rect.width(), fullRect.bottom());
-    painter.drawLine(rect.left() + 0.6 * rect.width(), fullRect.top(), rect.left() + 0.6 * rect.width(), fullRect.bottom());
-    painter.drawLine(rect.left() + 0.8 * rect.width(), fullRect.top(), rect.left() + 0.8 * rect.width(), fullRect.bottom());
+    const int TIME_AXIS_DIVISIONS = 6;
+    for (int i = 0; i < TIME_AXIS_DIVISIONS; ++i) {
+        const int x = rect.left() + (i * rect.width()) / TIME_AXIS_DIVISIONS;
+        painter.drawLine(x, fullRect.top(), x, fullRect.bottom());
+    }
 
     // Set antialiasing for graphs
     painter.setRenderHints(QPainter::Antialiasing | QPainter::HighQualityAntialiasing);

--- a/src/gui/properties/speedplotview.h
+++ b/src/gui/properties/speedplotview.h
@@ -64,7 +64,9 @@ public:
         MIN1 = 0,
         MIN5,
         MIN30,
-        HOUR6
+        HOUR6,
+        HOUR12,
+        HOUR24
     };
 
     struct PointData
@@ -76,7 +78,7 @@ public:
     explicit SpeedPlotView(QWidget *parent = nullptr);
 
     void setGraphEnable(GraphID id, bool enable);
-    void setViewableLastPoints(TimePeriod period);
+    void setPeriod(TimePeriod period);
 
     void pushPoint(const PointData &point);
 
@@ -116,8 +118,13 @@ private:
     boost::circular_buffer<PointData> m_data5Min;
     boost::circular_buffer<PointData> m_data30Min;
     boost::circular_buffer<PointData> m_data6Hour;
+    boost::circular_buffer<PointData> m_data12Hour;
+    boost::circular_buffer<PointData> m_data24Hour;
+    boost::circular_buffer<PointData> *m_currentData;
     Averager m_averager30Min;
     Averager m_averager6Hour;
+    Averager m_averager12Hour;
+    Averager m_averager24Hour;
 
     QMap<GraphID, GraphProperties> m_properties;
 

--- a/src/gui/properties/speedwidget.cpp
+++ b/src/gui/properties/speedwidget.cpp
@@ -71,6 +71,8 @@ SpeedWidget::SpeedWidget(PropertiesWidget *parent)
     m_periodCombobox->addItem(tr("5 Minutes"));
     m_periodCombobox->addItem(tr("30 Minutes"));
     m_periodCombobox->addItem(tr("6 Hours"));
+    m_periodCombobox->addItem(tr("12 Hours"));
+    m_periodCombobox->addItem(tr("24 Hours"));
 
     connect(m_periodCombobox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged)
         , this, &SpeedWidget::onPeriodChange);
@@ -148,7 +150,7 @@ void SpeedWidget::update()
 
 void SpeedWidget::onPeriodChange(int period)
 {
-    m_plot->setViewableLastPoints(static_cast<SpeedPlotView::TimePeriod>(period));
+    m_plot->setPeriod(static_cast<SpeedPlotView::TimePeriod>(period));
 }
 
 void SpeedWidget::onGraphChange(int id)


### PR DESCRIPTION
Also change number of time axe divisions from 5 to 6 for convenience.
![shot1](https://user-images.githubusercontent.com/14874367/56455934-5a6bd400-638f-11e9-9e3e-46e45cde4f19.png)
