### PR TITLE
Minor cleanups

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -34,13 +34,16 @@
 #include <queue>
 #include <string>
 
-#include <QCoreApplication>
+#ifdef Q_OS_WIN
+#include <wincrypt.h>
+#include <iphlpapi.h>
+#endif
+
 #include <QDebug>
 #include <QDir>
 #include <QHostAddress>
 #include <QNetworkAddressEntry>
 #include <QNetworkInterface>
-#include <QProcess>
 #include <QRegularExpression>
 #include <QString>
 #include <QThread>
@@ -50,12 +53,10 @@
 #include <libtorrent/alert_types.hpp>
 #include <libtorrent/bdecode.hpp>
 #include <libtorrent/bencode.hpp>
-#include <libtorrent/disk_io_thread.hpp>
 #include <libtorrent/error_code.hpp>
 #include <libtorrent/extensions/ut_metadata.hpp>
 #include <libtorrent/extensions/ut_pex.hpp>
 #include <libtorrent/extensions/smart_ban.hpp>
-#include <libtorrent/identify_client.hpp>
 #include <libtorrent/ip_filter.hpp>
 #include <libtorrent/magnet_uri.hpp>
 #include <libtorrent/session.hpp>
@@ -78,7 +79,6 @@
 #include "base/utils/misc.h"
 #include "base/utils/net.h"
 #include "base/utils/random.h"
-#include "base/utils/string.h"
 #include "magneturi.h"
 #include "private/bandwidthscheduler.h"
 #include "private/filterparserthread.h"
@@ -88,11 +88,6 @@
 #include "torrenthandle.h"
 #include "tracker.h"
 #include "trackerentry.h"
-
-#ifdef Q_OS_WIN
-#include <wincrypt.h>
-#include <iphlpapi.h>
-#endif
 
 #if defined(Q_OS_WIN) && (_WIN32_WINNT < 0x0600)
 using NETIO_STATUS = LONG;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -36,13 +36,9 @@
 #include <QFile>
 #include <QHash>
 #include <QList>
-#include <QMap>
 #include <QNetworkConfigurationManager>
 #include <QPointer>
 #include <QSet>
-#include <QStringList>
-#include <QVector>
-#include <QWaitCondition>
 
 #include "base/settingvalue.h"
 #include "base/tristatebool.h"
@@ -55,8 +51,8 @@
 
 class QThread;
 class QTimer;
-class QStringList;
 class QString;
+class QStringList;
 class QUrl;
 
 class FilterParserThread;

--- a/src/base/settingvalue.h
+++ b/src/base/settingvalue.h
@@ -29,7 +29,6 @@
 #ifndef SETTINGVALUE_H
 #define SETTINGVALUE_H
 
-#include <functional>
 #include <type_traits>
 
 #include <QMetaEnum>
@@ -41,8 +40,6 @@
 template <typename T>
 class CachedSettingValue
 {
-    using ProxyFunc = std::function<T (const T&)>;
-
 public:
     explicit CachedSettingValue(const char *keyName, const T &defaultValue = T())
         : m_keyName(QLatin1String(keyName))
@@ -50,8 +47,11 @@ public:
     {
     }
 
+    // The signature of the ProxyFunc should be equivalent to the following:
+    // T proxyFunc(const T &a);
+    template <typename ProxyFunc>
     explicit CachedSettingValue(const char *keyName, const T &defaultValue
-            , const ProxyFunc &proxyFunc)
+                                , ProxyFunc proxyFunc)
         : m_keyName(QLatin1String(keyName))
         , m_value(proxyFunc(loadValue(defaultValue)))
     {

--- a/src/gui/torrentcategorydialog.cpp
+++ b/src/gui/torrentcategorydialog.cpp
@@ -28,7 +28,6 @@
 
 #include "torrentcategorydialog.h"
 
-#include <QMap>
 #include <QMessageBox>
 
 #include "base/bittorrent/session.h"

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -34,7 +34,6 @@
 #include <QFileIconProvider>
 #include <QFileInfo>
 #include <QIcon>
-#include <QMap>
 
 #if defined(Q_OS_WIN)
 #include <Windows.h>

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -537,7 +537,7 @@ void WebApplication::sessionStart()
 
     // remove outdated sessions
     const qint64 now = QDateTime::currentMSecsSinceEpoch() / 1000;
-    const QMap<QString, WebSession *> sessionsCopy {m_sessions};
+    const QHash<QString, WebSession *> sessionsCopy {m_sessions};
     for (const auto session : sessionsCopy) {
         if ((now - session->timestamp()) > INACTIVE_TIME)
             delete m_sessions.take(session->id());

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -30,7 +30,6 @@
 
 #include <QDateTime>
 #include <QHash>
-#include <QMap>
 #include <QObject>
 #include <QRegularExpression>
 #include <QSet>
@@ -120,7 +119,7 @@ private:
     bool validateHostHeader(const QStringList &domains) const;
 
     // Persistent data
-    QMap<QString, WebSession *> m_sessions;
+    QHash<QString, WebSession *> m_sessions;
 
     // Current data
     WebSession *m_currentSession = nullptr;
@@ -141,7 +140,7 @@ private:
         QByteArray data;
         QDateTime lastModified;
     };
-    QMap<QString, TranslatedFile> m_translatedFiles;
+    QHash<QString, TranslatedFile> m_translatedFiles;
     QString m_currentLocale;
     QTranslator m_translator;
     bool m_translationFileLoaded = false;


### PR DESCRIPTION
* Avoid performance penalty from type erasure
  On average the *`class`* initialization is 0.1% faster and the result binary is 10 KB smaller.
* Replace QMap with QHash when sensible
* Remove unused headers