### PR TITLE
Register protocol handler in WebUI for magnet links

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -677,6 +677,7 @@ window.addEvent('load', function() {
         loadMethod: 'xhr',
         contentURL: 'transferlist.html',
         onContentLoaded: function() {
+            handleDownloadParam();
             updateMainData();
         },
         column: 'mainColumn',
@@ -781,7 +782,47 @@ window.addEvent('load', function() {
         addMainWindowTabsEventListener();
         addSearchPanel();
     }
+
+    registerMagnetHandler();
 });
+
+function registerMagnetHandler() {
+    if (typeof navigator.registerProtocolHandler !== 'function')
+        return;
+
+    const hashParams = getHashParamsFromUrl();
+    hashParams.download = '';
+
+    const templateHashString = Object.toQueryString(hashParams).replace('download=', 'download=%s');
+
+    const templateUrl = location.origin + location.pathname
+        + location.search + '#' + templateHashString;
+
+    navigator.registerProtocolHandler('magnet', templateUrl,
+        'qBittorrent WebUI magnet handler');
+}
+
+function handleDownloadParam() {
+    // Extract torrent URL from download param in WebUI URL hash
+    const hashParams = getHashParamsFromUrl();
+    const url = hashParams.download;
+    if (!url)
+        return;
+
+    // Remove the download param from WebUI URL hash
+    delete hashParams.download;
+    let newHash = Object.toQueryString(hashParams);
+    newHash = newHash ? ('#' + newHash) : '';
+    history.replaceState('', document.title,
+        (location.pathname + location.search + newHash));
+
+    showDownloadPage([url]);
+}
+
+function getHashParamsFromUrl() {
+    const hashString = location.hash ? location.hash.replace(/^#/, '') : '';
+    return (hashString.length > 0) ? String.parseQueryString(hashString) : {};
+}
 
 function closeWindows() {
     MochaUI.closeAll();


### PR DESCRIPTION
Background
----------------
As far as I know, currently adding magnet links for download in the WebUI means copying and pasting the magnet link manually. This PR adds some code to register the WebUI as a handler for magnet links. I just looked and apparently an issue was opened for this at #945, but was never implemented. This seemed easy enough to do so I did it and am currently using it via the alternative WebUI feature.

Changes
------------
 - Modified `client.js` to call `navigator.registerProtocolHandler`, allowing the WebUI to be registered as a handler for magnet links. As I have coded it, magnet links will open the WebUI and encode the magnet link into a query parameter named "magnet".
 - Also added some logic to check for the "magnet" query parameter, and if present open the download page with the magnet url.

MDN documentation for `navigator.registerProtocolHandler`: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler

To enable the WebUI to handle magnet links, the user must authorize it manually. In Google Chrome, this can be done by clicking on the "handler" icon in the browser's address bar.

After doing this, when the user clicks on a magnet link in the browser, the WebUI will be opened and the "add torrrent link" dialog will be automatically opened with the magnet link already added.

Screenshot
----------------
![Screenshot at 2019-04-29 22-55-10](https://user-images.githubusercontent.com/1627957/56943147-08375b00-6ad3-11e9-86d2-194e4ff4574d.png)
