### PR TITLE
Change "Add new torrent" dialog to horizontal layout

### DIFF
--- a/src/base/unicodestrings.h
+++ b/src/base/unicodestrings.h
@@ -38,8 +38,6 @@
 // See issue #3059 for more details (https://github.com/qbittorrent/qBittorrent/issues/3059).
 const char C_INFINITY[] = "∞";
 const char C_NON_BREAKING_SPACE[] = " ";
-const char C_UP[] = "▲";
-const char C_DOWN[] = "▼";
 const char C_COPYRIGHT[] = "©";
 const char C_THIN_SPACE[] = " ";
 const char C_UTP[] = "μTP";

--- a/src/gui/addnewtorrentdialog.h
+++ b/src/gui/addnewtorrentdialog.h
@@ -32,11 +32,11 @@
 #include <memory>
 
 #include <QDialog>
-#include <QShortcut>
 
 #include "base/bittorrent/addtorrentparams.h"
 #include "base/bittorrent/infohash.h"
 #include "base/bittorrent/torrentinfo.h"
+#include "base/settingvalue.h"
 
 namespace BitTorrent
 {
@@ -79,7 +79,6 @@ public:
     static void show(const QString &source, QWidget *parent);
 
 private slots:
-    void showAdvancedSettings(bool show);
     void displayContentTreeMenu(const QPoint &);
     void updateDiskSpaceLabel();
     void onSavePathChanged(const QString &newPath);
@@ -105,7 +104,6 @@ private:
     void saveState();
     void setMetadataProgressIndicator(bool visibleIndicator, const QString &labelText = {});
     void setupTreeview();
-    void setCommentText(const QString &str) const;
     void setSavePath(const QString &newPath);
 
     void showEvent(QShowEvent *event) override;
@@ -120,6 +118,9 @@ private:
     int m_oldIndex;
     std::unique_ptr<TorrentFileGuard> m_torrentGuard;
     BitTorrent::AddTorrentParams m_torrentParams;
+
+    CachedSettingValue<QSize> m_storeDialogSize;
+    CachedSettingValue<QByteArray> m_storeSplitterState;
 };
 
 #endif // ADDNEWTORRENTDIALOG_H

--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -6,35 +6,344 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>414</width>
-    <height>630</height>
+    <width>900</width>
+    <height>620</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="AddNewTorrentDialogLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="childrenCollapsible">
+      <bool>false</bool>
+     </property>
+     <widget class="QFrame" name="torrentoptionsFrame">
+      <layout class="QVBoxLayout" name="mainlayout_addui">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <layout class="QHBoxLayout" name="managementLayout">
+         <item>
+          <widget class="QLabel" name="labelTorrentManagementMode">
+           <property name="text">
+            <string>Torrent Management Mode:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="comboTTM">
+           <property name="toolTip">
+            <string>Automatic mode means that various torrent properties(eg save path) will be decided by the associated category</string>
+           </property>
+           <item>
+            <property name="text">
+             <string>Manual</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Automatic</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBoxSavePath">
+         <property name="title">
+          <string>Save at</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <widget class="FileSystemPathComboEdit" name="savePath" native="true"/>
+          </item>
+          <item alignment="Qt::AlignRight">
+           <widget class="QCheckBox" name="checkBoxRememberLastSavePath">
+            <property name="text">
+             <string>Remember last used save path</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBoxSettings">
+         <property name="title">
+          <string>Torrent settings</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <item>
+           <layout class="QHBoxLayout" name="categoryLayout">
+            <item>
+             <widget class="QLabel" name="labelCategory">
+              <property name="text">
+               <string>Category:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="categoryComboBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="editable">
+               <bool>true</bool>
+              </property>
+              <property name="insertPolicy">
+               <enum>QComboBox::InsertAtTop</enum>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item alignment="Qt::AlignRight">
+           <widget class="QCheckBox" name="defaultCategoryCheckbox">
+            <property name="text">
+             <string>Set as default category</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QGridLayout" name="gridLayout">
+            <item row="3" column="0">
+             <widget class="QCheckBox" name="doNotDeleteTorrentCheckBox">
+              <property name="toolTip">
+               <string>When checked, the .torrent file will not be deleted despite the settings at the &quot;Download&quot; page of the options dialog</string>
+              </property>
+              <property name="text">
+               <string>Do not delete .torrent file</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QCheckBox" name="firstLastCheckBox">
+              <property name="text">
+               <string>Download first and last pieces first</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QCheckBox" name="skipCheckingCheckBox">
+              <property name="text">
+               <string>Skip hash check</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QCheckBox" name="sequentialCheckBox">
+              <property name="text">
+               <string>Download in sequential order</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QCheckBox" name="createSubfolderCheckBox">
+              <property name="text">
+               <string>Create subfolder</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QCheckBox" name="startTorrentCheckBox">
+              <property name="text">
+               <string>Start torrent</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <spacer name="horizontalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="infoGroup">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="title">
+          <string>Torrent information</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="1" column="0">
+           <widget class="QLabel" name="labelDate">
+            <property name="text">
+             <string>Date:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="labelSizeData"/>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="labelDateData"/>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelSize">
+            <property name="text">
+             <string>Size:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLabel" name="labelHashData">
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QScrollArea" name="scrollArea">
+            <property name="styleSheet">
+             <string notr="true">background-color: rgba(0, 0, 0, 0);</string>
+            </property>
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="widgetResizable">
+             <bool>true</bool>
+            </property>
+            <widget class="QWidget" name="scrollAreaWidgetContents">
+             <property name="geometry">
+              <rect>
+               <x>0</x>
+               <y>0</y>
+               <width>421</width>
+               <height>68</height>
+              </rect>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_2">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <widget class="QLabel" name="labelCommentData">
+                <property name="textFormat">
+                 <enum>Qt::RichText</enum>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+                <property name="openExternalLinks">
+                 <bool>true</bool>
+                </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::TextBrowserInteraction</set>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="labelHash">
+            <property name="text">
+             <string>Hash:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="labelComment">
+            <property name="text">
+             <string>Comment:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="TorrentContentTreeView" name="contentTreeView">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>1</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="contextMenuPolicy">
+       <enum>Qt::CustomContextMenu</enum>
+      </property>
+      <property name="selectionMode">
+       <enum>QAbstractItemView::ExtendedSelection</enum>
+      </property>
+      <property name="sortingEnabled">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonsHLayout">
      <item>
-      <widget class="QLabel" name="labelTorrentManagementMode">
+      <widget class="QCheckBox" name="checkBoxNeverShow">
        <property name="text">
-        <string>Torrent Management Mode:</string>
+        <string>Never show again</string>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="comboTTM">
-       <property name="toolTip">
-        <string>Automatic mode means that various torrent properties(eg save path) will be decided by the associated category</string>
-       </property>
-       <item>
-        <property name="text">
-         <string>Manual</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Automatic</string>
-        </property>
-       </item>
       </widget>
      </item>
      <item>
@@ -53,289 +362,7 @@
     </layout>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBoxSavePath">
-     <property name="title">
-      <string>Save at</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <widget class="FileSystemPathComboEdit" name="savePath" native="true"/>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="checkBoxRememberLastSavePath">
-        <property name="text">
-         <string>Remember last used save path</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="doNotDeleteTorrentCheckBox">
-     <property name="toolTip">
-      <string>When checked, the .torrent file will not be deleted despite the settings at the &quot;Download&quot; page of the options dialog</string>
-     </property>
-     <property name="text">
-      <string>Do not delete .torrent file</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="checkBoxNeverShow">
-     <property name="text">
-      <string>Never show again</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QToolButton" name="toolButtonAdvanced">
-     <property name="text">
-      <string notr="true">▼</string>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBoxSettings">
-     <property name="title">
-      <string>Torrent settings</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="1" column="2">
-       <widget class="QCheckBox" name="defaultCategoryCheckbox">
-        <property name="text">
-         <string>Set as default category</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <layout class="QHBoxLayout" name="horizontalLayout_1">
-        <item>
-         <widget class="QLabel" name="label_5">
-          <property name="text">
-           <string>Category:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QComboBox" name="categoryComboBox">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="editable">
-           <bool>true</bool>
-          </property>
-          <property name="insertPolicy">
-           <enum>QComboBox::InsertAtTop</enum>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="startTorrentCheckBox">
-        <property name="text">
-         <string>Start torrent</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="skipCheckingCheckBox">
-        <property name="text">
-         <string>Skip hash check</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <spacer name="horizontalSpacer2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Fixed</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>35</width>
-          <height>0</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="2" column="0">
-       <widget class="QCheckBox" name="createSubfolderCheckBox">
-        <property name="text">
-         <string>Create subfolder</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QCheckBox" name="sequentialCheckBox">
-        <property name="text">
-         <string>Download in sequential order</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QCheckBox" name="firstLastCheckBox">
-        <property name="text">
-         <string>Download first and last pieces first</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="infoGroup">
-     <property name="title">
-      <string>Torrent information</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="2" column="1">
-       <widget class="QLabel" name="lblhash">
-        <property name="text">
-         <string/>
-        </property>
-        <property name="textFormat">
-         <enum>Qt::PlainText</enum>
-        </property>
-        <property name="textInteractionFlags">
-         <set>Qt::TextSelectableByMouse</set>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Hash:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0" colspan="2">
-       <widget class="TorrentContentTreeView" name="contentTreeView">
-        <property name="contextMenuPolicy">
-         <enum>Qt::CustomContextMenu</enum>
-        </property>
-        <property name="selectionMode">
-         <enum>QAbstractItemView::ExtendedSelection</enum>
-        </property>
-        <property name="sortingEnabled">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLabel" name="labelDate">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Date:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Size:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLabel" name="labelSize">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Comment:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QScrollArea" name="scrollArea">
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
-        <property name="widgetResizable">
-         <bool>true</bool>
-        </property>
-        <widget class="QWidget" name="scrollAreaWidgetContents_2">
-         <property name="geometry">
-          <rect>
-           <x>0</x>
-           <y>0</y>
-           <width>321</width>
-           <height>69</height>
-          </rect>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QLabel" name="commentLabel">
-            <property name="text">
-             <string/>
-            </property>
-            <property name="textFormat">
-             <enum>Qt::RichText</enum>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-            <property name="openExternalLinks">
-             <bool>true</bool>
-            </property>
-            <property name="textInteractionFlags">
-             <set>Qt::TextBrowserInteraction</set>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="buttonsHLayout">
+    <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QProgressBar" name="progMetaLoading">
        <property name="sizePolicy">
@@ -353,13 +380,17 @@
        <property name="textVisible">
         <bool>false</bool>
        </property>
-       <property name="format">
-        <string notr="true">%p%</string>
-       </property>
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="lblMetaLoading"/>
+      <widget class="QLabel" name="lblMetaLoading">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QDialogButtonBox" name="buttonBox">
@@ -405,18 +436,6 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
- <tabstops>
-  <tabstop>savePath</tabstop>
-  <tabstop>checkBoxRememberLastSavePath</tabstop>
-  <tabstop>checkBoxNeverShow</tabstop>
-  <tabstop>toolButtonAdvanced</tabstop>
-  <tabstop>startTorrentCheckBox</tabstop>
-  <tabstop>skipCheckingCheckBox</tabstop>
-  <tabstop>categoryComboBox</tabstop>
-  <tabstop>defaultCategoryCheckbox</tabstop>
-  <tabstop>scrollArea</tabstop>
-  <tabstop>contentTreeView</tabstop>
- </tabstops>
  <resources/>
  <connections>
   <connection>
@@ -426,8 +445,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>403</x>
-     <y>579</y>
+     <x>928</x>
+     <y>855</y>
     </hint>
     <hint type="destinationlabel">
      <x>157</x>
@@ -442,28 +461,12 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>403</x>
-     <y>579</y>
+     <x>928</x>
+     <y>855</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>
      <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>categoryComboBox</sender>
-   <signal>currentIndexChanged(int)</signal>
-   <receiver>AddNewTorrentDialog</receiver>
-   <slot>categoryChanged(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>337</x>
-     <y>205</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>403</x>
-     <y>160</y>
     </hint>
    </hints>
   </connection>
@@ -474,12 +477,28 @@
    <slot>TMMChanged(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>200</x>
-     <y>19</y>
+     <x>250</x>
+     <y>53</y>
     </hint>
     <hint type="destinationlabel">
-     <x>206</x>
-     <y>294</y>
+     <x>467</x>
+     <y>249</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>categoryComboBox</sender>
+   <signal>currentIndexChanged(int)</signal>
+   <receiver>AddNewTorrentDialog</receiver>
+   <slot>categoryChanged(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>266</x>
+     <y>231</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>467</x>
+     <y>249</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
This is adopted from PR #9591, I reverted some (many actually) changes and also improved a bit.
Main difference to PR #9591 are:
* It doesn't add additional widgets (clickable labels, checkbox word warps), all widgets are from stock, IMO it is inappropriate to introduce them in layout-change PR.
* Avoid setting widgets attributes explicitly when it is the same as the default.
* Correctly remember the horizontal splitter state.
* Follow previous settings layout closely, I don't think qbt should 100% copy utorrent's layout and reverted some questionable widget placements.

Screenshots:
Old: ![old](https://user-images.githubusercontent.com/9395168/57352943-8f529600-7199-11e9-84fd-a65bbd25791e.png)
New: ![new2](https://user-images.githubusercontent.com/9395168/57421477-97184600-723e-11e9-9722-ff985937fbf1.png)
Previous attempts: [1](https://user-images.githubusercontent.com/9395168/57352944-8feb2c80-7199-11e9-969b-c79990228437.png)
