### PR TITLE
Fix '+' char not decoded to space correctly

### DIFF
--- a/src/base/bittorrent/tracker.cpp
+++ b/src/base/bittorrent/tracker.cpp
@@ -143,8 +143,8 @@ void Tracker::respondToAnnounceRequest()
         const QByteArray nameComponent = midView(param, 0, sepPos);
         const QByteArray valueComponent = midView(param, (sepPos + 1));
 
-        const QString paramName = QString::fromUtf8(QByteArray::fromPercentEncoding(nameComponent));
-        const QByteArray paramValue = QByteArray::fromPercentEncoding(valueComponent);
+        const QString paramName = QString::fromUtf8(QByteArray::fromPercentEncoding(nameComponent).replace('+', ' '));
+        const QByteArray paramValue = QByteArray::fromPercentEncoding(valueComponent).replace('+', ' ');
         queryParams[paramName] = paramValue;
     }
 

--- a/src/base/bittorrent/tracker.cpp
+++ b/src/base/bittorrent/tracker.cpp
@@ -29,16 +29,11 @@
 
 #include "tracker.h"
 
-#include <vector>
-
 #include <libtorrent/bencode.hpp>
 #include <libtorrent/entry.hpp>
 
-#include "base/global.h"
 #include "base/http/server.h"
 #include "base/preferences.h"
-#include "base/utils/bytearray.h"
-#include "base/utils/string.h"
 
 // static limits
 static const int MAX_TORRENTS = 100;
@@ -133,21 +128,7 @@ Http::Response Tracker::processRequest(const Http::Request &request, const Http:
 
 void Tracker::respondToAnnounceRequest()
 {
-    QMap<QString, QByteArray> queryParams;
-    // Parse GET parameters
-    using namespace Utils::ByteArray;
-    for (const QByteArray &param : asConst(splitToViews(m_request.query, "&"))) {
-        const int sepPos = param.indexOf('=');
-        if (sepPos <= 0) continue; // ignores params without name
-
-        const QByteArray nameComponent = midView(param, 0, sepPos);
-        const QByteArray valueComponent = midView(param, (sepPos + 1));
-
-        const QString paramName = QString::fromUtf8(QByteArray::fromPercentEncoding(nameComponent).replace('+', ' '));
-        const QByteArray paramValue = QByteArray::fromPercentEncoding(valueComponent).replace('+', ' ');
-        queryParams[paramName] = paramValue;
-    }
-
+    const QMap<QString, QByteArray> &queryParams = m_request.query;
     TrackerAnnounceRequest announceReq;
 
     // IP

--- a/src/base/bittorrent/tracker.h
+++ b/src/base/bittorrent/tracker.h
@@ -36,7 +36,6 @@
 
 #include "base/http/irequesthandler.h"
 #include "base/http/responsebuilder.h"
-#include "base/http/types.h"
 
 namespace libtorrent
 {

--- a/src/base/http/types.h
+++ b/src/base/http/types.h
@@ -97,8 +97,8 @@ namespace Http
         QString version;
         QString method;
         QString path;
-        QByteArray query;
         QStringMap headers;
+        QMap<QString, QByteArray> query;
         QStringMap posts;
         QVector<UploadedFile> files;
     };

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -417,19 +417,8 @@ Http::Response WebApplication::processRequest(const Http::Request &request, cons
     m_params.clear();
 
     if (m_request.method == Http::METHOD_GET) {
-        // Parse GET parameters
-        using namespace Utils::ByteArray;
-        for (const QByteArray &param : asConst(splitToViews(m_request.query, "&"))) {
-            const int sepPos = param.indexOf('=');
-            if (sepPos <= 0) continue; // ignores params without name
-
-            const QByteArray nameComponent = midView(param, 0, sepPos);
-            const QByteArray valueComponent = midView(param, (sepPos + 1));
-
-            const QString paramName = QString::fromUtf8(QByteArray::fromPercentEncoding(nameComponent).replace('+', ' '));
-            const QString paramValue = QString::fromUtf8(QByteArray::fromPercentEncoding(valueComponent).replace('+', ' '));
-            m_params[paramName] = paramValue;
-        }
+        for (auto iter = m_request.query.cbegin(); iter != m_request.query.cend(); ++iter)
+            m_params[iter.key()] = QString::fromUtf8(iter.value());
     }
     else {
         m_params = m_request.posts;

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -415,6 +415,7 @@ Http::Response WebApplication::processRequest(const Http::Request &request, cons
     m_request = request;
     m_env = env;
     m_params.clear();
+
     if (m_request.method == Http::METHOD_GET) {
         // Parse GET parameters
         using namespace Utils::ByteArray;
@@ -425,8 +426,8 @@ Http::Response WebApplication::processRequest(const Http::Request &request, cons
             const QByteArray nameComponent = midView(param, 0, sepPos);
             const QByteArray valueComponent = midView(param, (sepPos + 1));
 
-            const QString paramName = QString::fromUtf8(QByteArray::fromPercentEncoding(nameComponent));
-            const QString paramValue = QString::fromUtf8(QByteArray::fromPercentEncoding(valueComponent));
+            const QString paramName = QString::fromUtf8(QByteArray::fromPercentEncoding(nameComponent).replace('+', ' '));
+            const QString paramValue = QString::fromUtf8(QByteArray::fromPercentEncoding(valueComponent).replace('+', ' '));
             m_params[paramName] = paramValue;
         }
     }


### PR DESCRIPTION
* Fix '+' char not decoded to space correctly
  Closes #10606.
* Refactor HTTP query parsing
  The parsing of HTTP query is well defined and it is the same in both places, thus it can be refactored into one.

Will backport to v4_1_x.