### PR TITLE
Changes to asConst to fix overloading and std::add_const on reference type T

### DIFF
--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -501,7 +501,7 @@ QString wrapText(const QString &text, int initialIndentation = USAGE_TEXT_COLUMN
     QStringList lines = {words.first()};
     int currentLineMaxLength = wrapAtColumn - initialIndentation;
 
-    for (const QString &word : asConst(words.mid(1))) {
+    for (const QString &word : asConstMove(words.mid(1))) {
         if (lines.last().length() + word.length() + 1 < currentLineMaxLength) {
             lines.last().append(' ' + word);
         }

--- a/src/app/filelogger.cpp
+++ b/src/app/filelogger.cpp
@@ -49,7 +49,7 @@ FileLogger::FileLogger(const QString &path, const bool backup, const int maxSize
         this->deleteOld(age, ageType);
 
     const Logger *const logger = Logger::instance();
-    for (const Log::Msg &msg : asConst(logger->getMessages()))
+    for (const Log::Msg &msg : asConstMove(logger->getMessages()))
         addLogMessage(msg);
 
     connect(logger, &Logger::newLogMessage, this, &FileLogger::addLogMessage);

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -194,7 +194,7 @@ namespace
 
         for (auto i = categories.cbegin(); i != categories.cend(); ++i) {
             const QString &category = i.key();
-            for (const QString &subcat : asConst(Session::expandCategory(category))) {
+            for (const QString &subcat : asConstMove(Session::expandCategory(category))) {
                 if (!expanded.contains(subcat))
                     expanded[subcat] = "";
             }
@@ -704,7 +704,7 @@ bool Session::addCategory(const QString &name, const QString &savePath)
         return false;
 
     if (isSubcategoriesEnabled()) {
-        for (const QString &parent : asConst(expandCategory(name))) {
+        for (const QString &parent : asConstMove(expandCategory(name))) {
             if ((parent != name) && !m_categories.contains(parent)) {
                 m_categories[parent] = "";
                 emit categoryAdded(parent);
@@ -727,12 +727,12 @@ bool Session::editCategory(const QString &name, const QString &savePath)
     m_categories[name] = savePath;
     m_storedCategories = map_cast(m_categories);
     if (isDisableAutoTMMWhenCategorySavePathChanged()) {
-        for (TorrentHandle *const torrent : asConst(torrents()))
+        for (TorrentHandle *const torrent : asConstMove(torrents()))
             if (torrent->category() == name)
                 torrent->setAutoTMMEnabled(false);
     }
     else {
-        for (TorrentHandle *const torrent : asConst(torrents()))
+        for (TorrentHandle *const torrent : asConstMove(torrents()))
             if (torrent->category() == name)
                 torrent->handleCategorySavePathChanged();
     }
@@ -742,7 +742,7 @@ bool Session::editCategory(const QString &name, const QString &savePath)
 
 bool Session::removeCategory(const QString &name)
 {
-    for (TorrentHandle *const torrent : asConst(torrents()))
+    for (TorrentHandle *const torrent : asConstMove(torrents()))
         if (torrent->belongsToCategory(name))
             torrent->setCategory("");
 
@@ -829,7 +829,7 @@ bool Session::addTag(const QString &tag)
 bool Session::removeTag(const QString &tag)
 {
     if (m_tags.remove(tag)) {
-        for (TorrentHandle *const torrent : asConst(torrents()))
+        for (TorrentHandle *const torrent : asConstMove(torrents()))
             torrent->removeTag(tag);
         m_storedTags = m_tags.toList();
         emit tagRemoved(tag);
@@ -1019,7 +1019,7 @@ void Session::configure()
 void Session::processBannedIPs(libt::ip_filter &filter)
 {
     // First, import current filter
-    for (const QString &ip : asConst(m_bannedIPs.value())) {
+    for (const QString &ip : asConstMove(m_bannedIPs.value())) {
         boost::system::error_code ec;
         const libt::address addr = libt::address::from_string(ip.toLatin1().constData(), ec);
         Q_ASSERT(!ec);
@@ -1487,7 +1487,7 @@ void Session::enableBandwidthScheduler()
 void Session::populateAdditionalTrackers()
 {
     m_additionalTrackerList.clear();
-    for (QString tracker : asConst(additionalTrackers().split('\n'))) {
+    for (QString tracker : asConstMove(additionalTrackers().split('\n'))) {
         tracker = tracker.trimmed();
         if (!tracker.isEmpty())
             m_additionalTrackerList << tracker;
@@ -1498,7 +1498,7 @@ void Session::processShareLimits()
 {
     qDebug("Processing share limits...");
 
-    for (TorrentHandle *const torrent : asConst(torrents())) {
+    for (TorrentHandle *const torrent : asConstMove(torrents())) {
         if (torrent->isSeed() && !torrent->isForced()) {
             if (torrent->ratioLimit() != TorrentHandle::NO_RATIO_LIMIT) {
                 const qreal ratio = torrent->realRatio();
@@ -2132,7 +2132,7 @@ void Session::saveResumeData()
 void Session::saveTorrentsQueue()
 {
     QMap<int, QString> queue; // Use QMap since it should be ordered by key
-    for (const TorrentHandle *torrent : asConst(torrents())) {
+    for (const TorrentHandle *torrent : asConstMove(torrents())) {
         // We require actual (non-cached) queue position here!
         const int queuePos = torrent->nativeHandle().queue_position();
         if (queuePos >= 0)
@@ -2162,10 +2162,10 @@ void Session::setDefaultSavePath(QString path)
     m_defaultSavePath = path;
 
     if (isDisableAutoTMMWhenDefaultSavePathChanged())
-        for (TorrentHandle *const torrent : asConst(torrents()))
+        for (TorrentHandle *const torrent : asConstMove(torrents()))
             torrent->setAutoTMMEnabled(false);
     else
-        for (TorrentHandle *const torrent : asConst(torrents()))
+        for (TorrentHandle *const torrent : asConstMove(torrents()))
             torrent->handleCategorySavePathChanged();
 }
 

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -610,7 +610,7 @@ bool TorrentHandle::removeTag(const QString &tag)
 
 void TorrentHandle::removeAllTags()
 {
-    for (const QString &tag : asConst(tags()))
+    for (const QString &tag : asConstMove(tags()))
         removeTag(tag);
 }
 

--- a/src/base/global.h
+++ b/src/base/global.h
@@ -43,7 +43,7 @@ constexpr typename std::add_const<T>::type &asConst(T &t) noexcept { return t; }
 
 // Forward rvalue as const
 template <typename T>
-constexpr typename std::add_const<T>::type asConst(T &&t) noexcept { return std::move(t); }
+constexpr typename std::add_const<T>::type asConstMove(T &&t) noexcept { return std::move(t); }
 
 // Prevent const rvalue arguments
 template <typename T>

--- a/src/base/global.h
+++ b/src/base/global.h
@@ -43,7 +43,7 @@ constexpr typename std::add_const<T>::type &asConst(T &t) noexcept { return t; }
 
 // Forward rvalue as const
 template <typename T>
-constexpr typename std::add_const<T>::type asConstMove(T &&t) noexcept { return std::move(t); }
+constexpr typename std::remove_cv_t<std::remove_reference_t<T>> asConstMove(T &&t) noexcept { return t; }
 
 // Prevent const rvalue arguments
 template <typename T>

--- a/src/base/http/requestparser.cpp
+++ b/src/base/http/requestparser.cpp
@@ -194,7 +194,7 @@ bool RequestParser::parseRequestLine(const QString &line)
 
         // [rfc3986] 2.4 When to Encode or Decode
         // URL components should be separated before percent-decoding
-        for (const QByteArray &param : asConst(splitToViews(query, "&"))) {
+        for (const QByteArray &param : asConstMove(splitToViews(query, "&"))) {
             const int eqCharPos = param.indexOf('=');
             if (eqCharPos <= 0) continue;  // ignores params without name
 

--- a/src/base/net/downloadmanager.cpp
+++ b/src/base/net/downloadmanager.cpp
@@ -65,7 +65,7 @@ namespace
         {
             const QDateTime now = QDateTime::currentDateTime();
             QList<QNetworkCookie> cookies = Preferences::instance()->getNetworkCookies();
-            for (const QNetworkCookie &cookie : asConst(Preferences::instance()->getNetworkCookies())) {
+            for (const QNetworkCookie &cookie : asConstMove(Preferences::instance()->getNetworkCookies())) {
                 if (cookie.isSessionCookie() || (cookie.expirationDate() <= now))
                     cookies.removeAll(cookie);
             }
@@ -77,7 +77,7 @@ namespace
         {
             const QDateTime now = QDateTime::currentDateTime();
             QList<QNetworkCookie> cookies = allCookies();
-            for (const QNetworkCookie &cookie : asConst(allCookies())) {
+            for (const QNetworkCookie &cookie : asConstMove(allCookies())) {
                 if (cookie.isSessionCookie() || (cookie.expirationDate() <= now))
                     cookies.removeAll(cookie);
             }
@@ -92,7 +92,7 @@ namespace
         {
             const QDateTime now = QDateTime::currentDateTime();
             QList<QNetworkCookie> cookies = QNetworkCookieJar::cookiesForUrl(url);
-            for (const QNetworkCookie &cookie : asConst(QNetworkCookieJar::cookiesForUrl(url))) {
+            for (const QNetworkCookie &cookie : asConstMove(QNetworkCookieJar::cookiesForUrl(url))) {
                 if (!cookie.isSessionCookie() && (cookie.expirationDate() <= now))
                     cookies.removeAll(cookie);
             }

--- a/src/base/net/smtp.cpp
+++ b/src/base/net/smtp.cpp
@@ -292,7 +292,7 @@ QByteArray Smtp::encodeMimeHeader(const QString &key, const QString &value, cons
     if (!prefix.isEmpty()) line += prefix;
     if (!value.contains("=?") && latin1->canEncode(value)) {
         bool firstWord = true;
-        for (const QByteArray &word : asConst(value.toLatin1().split(' '))) {
+        for (const QByteArray &word : asConstMove(value.toLatin1().split(' '))) {
             if (line.size() > 78) {
                 rv = rv + line + "\r\n";
                 line.clear();

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -504,7 +504,7 @@ void Preferences::setWebUiAuthSubnetWhitelistEnabled(const bool enabled)
 QList<Utils::Net::Subnet> Preferences::getWebUiAuthSubnetWhitelist() const
 {
     QList<Utils::Net::Subnet> subnets;
-    for (const QString &rawSubnet : asConst(value("Preferences/WebUI/AuthSubnetWhitelist").toStringList())) {
+    for (const QString &rawSubnet : asConstMove(value("Preferences/WebUI/AuthSubnetWhitelist").toStringList())) {
         bool ok = false;
         const Utils::Net::Subnet subnet = Utils::Net::parseSubnet(rawSubnet.trimmed(), &ok);
         if (ok)

--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -241,7 +241,7 @@ void AutoDownloader::importRules(const QByteArray &data, const AutoDownloader::R
 QByteArray AutoDownloader::exportRulesToJSONFormat() const
 {
     QJsonObject jsonObj;
-    for (const auto &rule : asConst(rules()))
+    for (const auto &rule : asConstMove(rules()))
         jsonObj.insert(rule.name(), rule.toJsonObject());
 
     return QJsonDocument(jsonObj).toJson();
@@ -249,14 +249,14 @@ QByteArray AutoDownloader::exportRulesToJSONFormat() const
 
 void AutoDownloader::importRulesFromJSONFormat(const QByteArray &data)
 {
-    for (const auto &rule : asConst(rulesFromJSON(data)))
+    for (const auto &rule : asConstMove(rulesFromJSON(data)))
         insertRule(rule);
 }
 
 QByteArray AutoDownloader::exportRulesToLegacyFormat() const
 {
     QVariantHash dict;
-    for (const auto &rule : asConst(rules()))
+    for (const auto &rule : asConstMove(rules()))
         dict[rule.name()] = rule.toLegacyDict();
 
     QByteArray data;
@@ -473,7 +473,7 @@ void AutoDownloader::resetProcessingQueue()
     m_processingQueue.clear();
     if (!m_processingEnabled) return;
 
-    for (Article *article : asConst(Session::instance()->rootFolder()->articles())) {
+    for (Article *article : asConstMove(Session::instance()->rootFolder()->articles())) {
         if (!article->isRead() && !article->torrentUrl().isEmpty())
             addJobForArticle(article);
     }

--- a/src/base/rss/rss_autodownloadrule.cpp
+++ b/src/base/rss/rss_autodownloadrule.cpp
@@ -464,7 +464,7 @@ AutoDownloadRule AutoDownloadRule::fromJsonObject(const QJsonObject &jsonObj, co
     QStringList feedURLs;
     if (feedsVal.isString())
         feedURLs << feedsVal.toString();
-    else for (const QJsonValue &urlVal : asConst(feedsVal.toArray()))
+    else for (const QJsonValue &urlVal : asConstMove(feedsVal.toArray()))
         feedURLs << urlVal.toString();
     rule.setFeedURLs(feedURLs);
 
@@ -474,7 +474,7 @@ AutoDownloadRule AutoDownloadRule::fromJsonObject(const QJsonObject &jsonObj, co
         previouslyMatched << previouslyMatchedVal.toString();
     }
     else {
-        for (const QJsonValue &val : asConst(previouslyMatchedVal.toArray()))
+        for (const QJsonValue &val : asConstMove(previouslyMatchedVal.toArray()))
             previouslyMatched << val.toString();
     }
     rule.setPreviouslyMatchedEpisodes(previouslyMatched);

--- a/src/base/rss/rss_feed.cpp
+++ b/src/base/rss/rss_feed.cpp
@@ -300,7 +300,7 @@ void Feed::loadArticlesLegacy()
     const SettingsPtr qBTRSSFeeds = Profile::instance().applicationSettings(QStringLiteral("qBittorrent-rss-feeds"));
     const QVariantHash allOldItems = qBTRSSFeeds->value("old_items").toHash();
 
-    for (const QVariant &var : asConst(allOldItems.value(m_url).toList())) {
+    for (const QVariant &var : asConstMove(allOldItems.value(m_url).toList())) {
         auto hash = var.toHash();
         // update legacy keys
         hash[Article::KeyLink] = hash.take(QLatin1String("news_link"));

--- a/src/base/rss/rss_folder.cpp
+++ b/src/base/rss/rss_folder.cpp
@@ -49,7 +49,7 @@ Folder::~Folder()
 {
     emit aboutToBeDestroyed(this);
 
-    for (auto item : asConst(items()))
+    for (auto item : asConstMove(items()))
         delete item;
 }
 
@@ -57,7 +57,7 @@ QList<Article *> Folder::articles() const
 {
     QList<Article *> news;
 
-    for (Item *item : asConst(items())) {
+    for (Item *item : asConstMove(items())) {
         int n = news.size();
         news << item->articles();
         std::inplace_merge(news.begin(), news.begin() + n, news.end()
@@ -80,13 +80,13 @@ int Folder::unreadCount() const
 
 void Folder::markAsRead()
 {
-    for (Item *item : asConst(items()))
+    for (Item *item : asConstMove(items()))
         item->markAsRead();
 }
 
 void Folder::refresh()
 {
-    for (Item *item : asConst(items()))
+    for (Item *item : asConstMove(items()))
         item->refresh();
 }
 
@@ -98,7 +98,7 @@ QList<Item *> Folder::items() const
 QJsonValue Folder::toJsonValue(bool withData) const
 {
     QJsonObject jsonObj;
-    for (Item *item : asConst(items()))
+    for (Item *item : asConstMove(items()))
         jsonObj.insert(item->name(), item->toJsonValue(withData));
 
     return jsonObj;
@@ -111,7 +111,7 @@ void Folder::handleItemUnreadCountChanged()
 
 void Folder::cleanup()
 {
-    for (Item *item : asConst(items()))
+    for (Item *item : asConstMove(items()))
         item->cleanup();
 }
 
@@ -126,7 +126,7 @@ void Folder::addItem(Item *item)
     connect(item, &Item::articleAboutToBeRemoved, this, &Item::articleAboutToBeRemoved);
     connect(item, &Item::unreadCountChanged, this, &Folder::handleItemUnreadCountChanged);
 
-    for (auto article : asConst(item->articles()))
+    for (auto article : asConstMove(item->articles()))
         emit newArticle(article);
 
     if (item->unreadCount() > 0)
@@ -137,7 +137,7 @@ void Folder::removeItem(Item *item)
 {
     Q_ASSERT(m_items.contains(item));
 
-    for (auto article : asConst(item->articles()))
+    for (auto article : asConstMove(item->articles()))
         emit articleAboutToBeRemoved(article);
 
     item->disconnect(this);

--- a/src/base/rss/rss_session.cpp
+++ b/src/base/rss/rss_session.cpp
@@ -284,7 +284,7 @@ void Session::load()
 void Session::loadFolder(const QJsonObject &jsonObj, Folder *folder)
 {
     bool updated = false;
-    for (const QString &key : asConst(jsonObj.keys())) {
+    for (const QString &key : asConstMove(jsonObj.keys())) {
         const QJsonValue val {jsonObj[key]};
         if (val.isString()) {
             // previous format (reduced form) doesn't contain UID
@@ -356,7 +356,7 @@ void Session::loadLegacy()
         const QString parentFolderPath = Item::parentPath(legacyPath);
         const QString feedUrl = Item::relativeName(legacyPath);
 
-        for (const QString &folderPath : asConst(Item::expandPath(parentFolderPath)))
+        for (const QString &folderPath : asConstMove(Item::expandPath(parentFolderPath)))
             addFolder(folderPath);
 
         const QString feedPath = feedAliases[i].isEmpty()

--- a/src/base/settingsstorage.cpp
+++ b/src/base/settingsstorage.cpp
@@ -287,7 +287,7 @@ QString TransactionalSettings::deserialize(const QString &name, QVariantHash &da
     // Copy everything into memory. This means even keys inserted in the file manually
     // or that we don't touch directly in this code (eg disabled by ifdef). This ensures
     // that they will be copied over when save our settings to disk.
-    for (const QString &key : asConst(settings->allKeys()))
+    for (const QString &key : asConstMove(settings->allKeys()))
         data.insert(key, settings->value(key));
 
     return settings->fileName();

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -289,7 +289,7 @@ void AdvancedSettings::updateInterfaceAddressCombo()
     };
 
     if (ifaceName.isEmpty()) {
-        for (const QHostAddress &ip : asConst(QNetworkInterface::allAddresses()))
+        for (const QHostAddress &ip : asConstMove(QNetworkInterface::allAddresses()))
             populateCombo(ip.toString(), ip.protocol());
     }
     else {
@@ -445,7 +445,7 @@ void AdvancedSettings::loadAdvancedSettings()
     const QString currentInterface = session->networkInterface();
     bool interfaceExists = currentInterface.isEmpty();
     int i = 1;
-    for (const QNetworkInterface &iface : asConst(QNetworkInterface::allInterfaces())) {
+    for (const QNetworkInterface &iface : asConstMove(QNetworkInterface::allInterfaces())) {
         // This line fixes a Qt bug => https://bugreports.qt.io/browse/QTBUG-52633
         // Tested in Qt 5.6.0. For more info see:
         // https://github.com/qbittorrent/qBittorrent/issues/5131

--- a/src/gui/categoryfiltermodel.cpp
+++ b/src/gui/categoryfiltermodel.cpp
@@ -408,7 +408,7 @@ void CategoryFilterModel::populate()
         const QString &category = i.key();
         if (m_isSubcategoriesEnabled) {
             CategoryModelItem *parent = m_rootItem;
-            for (const QString &subcat : asConst(session->expandCategory(category))) {
+            for (const QString &subcat : asConstMove(session->expandCategory(category))) {
                 const QString subcatName = shortName(subcat);
                 if (!parent->hasChild(subcatName)) {
                     new CategoryModelItem(
@@ -437,7 +437,7 @@ CategoryModelItem *CategoryFilterModel::findItem(const QString &fullName) const
         return m_rootItem->child(fullName);
 
     CategoryModelItem *item = m_rootItem;
-    for (const QString &subcat : asConst(BitTorrent::Session::expandCategory(fullName))) {
+    for (const QString &subcat : asConstMove(BitTorrent::Session::expandCategory(fullName))) {
         const QString subcatName = shortName(subcat);
         if (!item->hasChild(subcatName)) return nullptr;
         item = item->child(subcatName);

--- a/src/gui/categoryfilterwidget.cpp
+++ b/src/gui/categoryfilterwidget.cpp
@@ -231,7 +231,7 @@ void CategoryFilterWidget::removeCategory()
 void CategoryFilterWidget::removeUnusedCategories()
 {
     auto session = BitTorrent::Session::instance();
-    for (const QString &category : asConst(session->categories().keys())) {
+    for (const QString &category : asConstMove(session->categories().keys())) {
         if (model()->data(static_cast<CategoryFilterProxyModel *>(model())->index(category), Qt::UserRole) == 0)
             session->removeCategory(category);
     }

--- a/src/gui/executionlogwidget.cpp
+++ b/src/gui/executionlogwidget.cpp
@@ -53,9 +53,9 @@ ExecutionLogWidget::ExecutionLogWidget(QWidget *parent, const Log::MsgTypes &typ
     m_ui->tabBan->layout()->addWidget(m_peerList);
 
     const Logger *const logger = Logger::instance();
-    for (const Log::Msg &msg : asConst(logger->getMessages()))
+    for (const Log::Msg &msg : asConstMove(logger->getMessages()))
         addLogMessage(msg);
-    for (const Log::Peer &peer : asConst(logger->getPeers()))
+    for (const Log::Peer &peer : asConstMove(logger->getPeers()))
         addPeerMessage(peer);
     connect(logger, &Logger::newLogMessage, this, &ExecutionLogWidget::addLogMessage);
     connect(logger, &Logger::newLogPeer, this, &ExecutionLogWidget::addPeerMessage);

--- a/src/gui/ipsubnetwhitelistoptionsdialog.cpp
+++ b/src/gui/ipsubnetwhitelistoptionsdialog.cpp
@@ -46,7 +46,7 @@ IPSubnetWhitelistOptionsDialog::IPSubnetWhitelistOptionsDialog(QWidget *parent)
     m_ui->setupUi(this);
 
     QStringList authSubnetWhitelistStringList;
-    for (const Utils::Net::Subnet &subnet : asConst(Preferences::instance()->getWebUiAuthSubnetWhitelist()))
+    for (const Utils::Net::Subnet &subnet : asConstMove(Preferences::instance()->getWebUiAuthSubnetWhitelist()))
         authSubnetWhitelistStringList << Utils::Net::subnetToString(subnet);
     m_model = new QStringListModel(authSubnetWhitelistStringList, this);
 
@@ -99,7 +99,7 @@ void IPSubnetWhitelistOptionsDialog::on_buttonWhitelistIPSubnet_clicked()
 
 void IPSubnetWhitelistOptionsDialog::on_buttonDeleteIPSubnet_clicked()
 {
-    for (const auto &i : asConst(m_ui->whitelistedIPSubnetList->selectionModel()->selectedIndexes()))
+    for (const auto &i : asConstMove(m_ui->whitelistedIPSubnetList->selectionModel()->selectedIndexes()))
         m_sortFilter->removeRow(i.row());
 
     m_modified = true;

--- a/src/gui/loglistwidget.cpp
+++ b/src/gui/loglistwidget.cpp
@@ -101,7 +101,7 @@ void LogListWidget::copySelection()
     const QRegularExpression htmlTag("<[^>]+>");
 
     QStringList strings;
-    for (QListWidgetItem *it : asConst(selectedItems()))
+    for (QListWidgetItem *it : asConstMove(selectedItems()))
         strings << static_cast<QLabel*>(itemWidget(it))->text().remove(htmlTag);
 
     QApplication::clipboard()->setText(strings.join('\n'));

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -275,7 +275,7 @@ MainWindow::MainWindow(QWidget *parent)
     m_prioSeparatorMenu = m_ui->menuEdit->insertSeparator(m_ui->actionTopPriority);
 
 #ifdef Q_OS_MAC
-    for (QAction *action : asCosntMove(m_ui->toolBar->actions())) {
+    for (QAction *action : asConstMove(m_ui->toolBar->actions())) {
         if (action->isSeparator()) {
             QWidget *spacer = new QWidget(this);
             spacer->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1222,7 +1222,7 @@ bool MainWindow::event(QEvent *e)
                 qDebug() << "Has active window:" << (qApp->activeWindow() != nullptr);
                 // Check if there is a modal window
                 bool hasModalWindow = false;
-                for (QWidget *widget : asConst(QApplication::allWidgets())) {
+                for (QWidget *widget : asConstMove(QApplication::allWidgets())) {
                     if (widget->isModal()) {
                         hasModalWindow = true;
                         break;
@@ -1268,7 +1268,7 @@ void MainWindow::dropEvent(QDropEvent *event)
     // remove scheme
     QStringList files;
     if (event->mimeData()->hasUrls()) {
-        for (const QUrl &url : asConst(event->mimeData()->urls())) {
+        for (const QUrl &url : asConstMove(event->mimeData()->urls())) {
             if (url.isEmpty())
                 continue;
 
@@ -1316,7 +1316,7 @@ void MainWindow::dropEvent(QDropEvent *event)
 // Decode if we accept drag 'n drop or not
 void MainWindow::dragEnterEvent(QDragEnterEvent *event)
 {
-    for (const QString &mime : asConst(event->mimeData()->formats()))
+    for (const QString &mime : asConstMove(event->mimeData()->formats()))
         qDebug("mimeData: %s", mime.toLocal8Bit().data());
     if (event->mimeData()->hasFormat("text/plain") || event->mimeData()->hasFormat("text/uri-list"))
         event->acceptProposedAction();

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -275,7 +275,7 @@ MainWindow::MainWindow(QWidget *parent)
     m_prioSeparatorMenu = m_ui->menuEdit->insertSeparator(m_ui->actionTopPriority);
 
 #ifdef Q_OS_MAC
-    for (QAction *action : asConst(m_ui->toolBar->actions())) {
+    for (QAction *action : asCosntMove(m_ui->toolBar->actions())) {
         if (action->isSeparator()) {
             QWidget *spacer = new QWidget(this);
             spacer->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -455,9 +455,9 @@ OptionsDialog::OptionsDialog(QWidget *parent)
 
     // disable mouse wheel event on widgets to avoid mis-selection
     auto *wheelEventEater = new WheelEventEater(this);
-    for (QComboBox *widget : asConst(findChildren<QComboBox *>()))
+    for (QComboBox *widget : asConstMove(findChildren<QComboBox *>()))
         widget->installEventFilter(wheelEventEater);
-    for (QSpinBox *widget : asConst(findChildren<QSpinBox *>()))
+    for (QSpinBox *widget : asConstMove(findChildren<QSpinBox *>()))
         widget->installEventFilter(wheelEventEater);
 
     loadWindowState();

--- a/src/gui/properties/peersadditiondialog.cpp
+++ b/src/gui/properties/peersadditiondialog.cpp
@@ -62,7 +62,7 @@ void PeersAdditionDialog::validateInput()
                     QMessageBox::Ok);
         return;
     }
-    for (const QString &peer : asConst(m_ui->textEditPeers->toPlainText().trimmed().split('\n'))) {
+    for (const QString &peer : asConstMove(m_ui->textEditPeers->toPlainText().trimmed().split('\n'))) {
         BitTorrent::PeerAddress addr = parsePeer(peer);
         if (!addr.ip.isNull()) {
             m_peersList.append(addr);

--- a/src/gui/properties/proptabbar.cpp
+++ b/src/gui/properties/proptabbar.cpp
@@ -103,7 +103,7 @@ PropTabBar::PropTabBar(QWidget *parent)
     connect(m_btnGroup, static_cast<void (QButtonGroup::*)(int)>(&QButtonGroup::buttonClicked)
             , this, &PropTabBar::setCurrentIndex);
     // Disable buttons focus
-    for (QAbstractButton *btn : asConst(m_btnGroup->buttons()))
+    for (QAbstractButton *btn : asConstMove(m_btnGroup->buttons()))
         btn->setFocusPolicy(Qt::NoFocus);
 }
 

--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -290,7 +290,7 @@ void TrackerListWidget::loadStickyItems(BitTorrent::TorrentHandle *const torrent
     // XXX: libtorrent should provide this info...
     // Count peers from DHT, PeX, LSD
     uint seedsDHT = 0, seedsPeX = 0, seedsLSD = 0, peersDHT = 0, peersPeX = 0, peersLSD = 0;
-    for (const BitTorrent::PeerInfo &peer : asConst(torrent->peers())) {
+    for (const BitTorrent::PeerInfo &peer : asConstMove(torrent->peers())) {
         if (peer.isConnecting()) continue;
 
         if (peer.fromDHT()) {
@@ -332,7 +332,7 @@ void TrackerListWidget::loadTrackers()
     // Load actual trackers information
     QHash<QString, BitTorrent::TrackerInfo> trackerData = torrent->trackerInfos();
     QStringList oldTrackerURLs = m_trackerItems.keys();
-    for (const BitTorrent::TrackerEntry &entry : asConst(torrent->trackers())) {
+    for (const BitTorrent::TrackerEntry &entry : asConstMove(torrent->trackers())) {
         QString trackerURL = entry.url();
         QTreeWidgetItem *item = m_trackerItems.value(trackerURL, nullptr);
         if (!item) {
@@ -389,7 +389,7 @@ void TrackerListWidget::askForTrackers()
     if (!torrent) return;
 
     QList<BitTorrent::TrackerEntry> trackers;
-    for (const QString &tracker : asConst(TrackersAdditionDialog::askForTrackers(this, torrent)))
+    for (const QString &tracker : asConstMove(TrackersAdditionDialog::askForTrackers(this, torrent)))
         trackers << tracker;
 
     torrent->addTrackers(trackers);

--- a/src/gui/properties/trackersadditiondialog.cpp
+++ b/src/gui/properties/trackersadditiondialog.cpp
@@ -59,7 +59,7 @@ TrackersAdditionDialog::~TrackersAdditionDialog()
 QStringList TrackersAdditionDialog::newTrackers() const
 {
     QStringList cleanTrackers;
-    for (QString url : asConst(m_ui->textEditTrackersList->toPlainText().split('\n'))) {
+    for (QString url : asConstMove(m_ui->textEditTrackersList->toPlainText().split('\n'))) {
         url = url.trimmed();
         if (!url.isEmpty())
             cleanTrackers << url;

--- a/src/gui/rss/articlelistwidget.cpp
+++ b/src/gui/rss/articlelistwidget.cpp
@@ -69,7 +69,7 @@ void ArticleListWidget::setRSSItem(RSS::Item *rssItem, bool unreadOnly)
         connect(m_rssItem, &RSS::Item::articleRead, this, &ArticleListWidget::handleArticleRead);
         connect(m_rssItem, &RSS::Item::articleAboutToBeRemoved, this, &ArticleListWidget::handleArticleAboutToBeRemoved);
 
-        for (const auto article : asConst(rssItem->articles())) {
+        for (const auto article : asConstMove(rssItem->articles())) {
             if (!(m_unreadOnly && article->isRead())) {
                 auto item = createItem(article);
                 addItem(item);

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -132,7 +132,7 @@ AutomatedRssDownloader::AutomatedRssDownloader(QWidget *parent)
     loadFeedList();
 
     m_ui->listRules->blockSignals(true);
-    for (const RSS::AutoDownloadRule &rule : asConst(RSS::AutoDownloader::instance()->rules()))
+    for (const RSS::AutoDownloadRule &rule : asConstMove(RSS::AutoDownloader::instance()->rules()))
         createRuleItem(rule);
     m_ui->listRules->blockSignals(false);
 
@@ -182,7 +182,7 @@ void AutomatedRssDownloader::loadFeedList()
 {
     const QSignalBlocker feedListSignalBlocker(m_ui->listFeeds);
 
-    for (const auto feed : asConst(RSS::Session::instance()->feeds())) {
+    for (const auto feed : asConstMove(RSS::Session::instance()->feeds())) {
         QListWidgetItem *item = new QListWidgetItem(feed->name(), m_ui->listFeeds);
         item->setData(Qt::UserRole, feed->url());
         item->setFlags(item->flags() | Qt::ItemIsUserCheckable | Qt::ItemIsTristate);
@@ -549,7 +549,7 @@ void AutomatedRssDownloader::clearSelectedRuleDownloadedEpisodeList()
 void AutomatedRssDownloader::handleFeedCheckStateChange(QListWidgetItem *feedItem)
 {
     const QString feedURL = feedItem->data(Qt::UserRole).toString();
-    for (QListWidgetItem *ruleItem : asConst(m_ui->listRules->selectedItems())) {
+    for (QListWidgetItem *ruleItem : asConstMove(m_ui->listRules->selectedItems())) {
         RSS::AutoDownloadRule rule = (ruleItem == m_currentRuleItem
                                        ? m_currentRule
                                        : RSS::AutoDownloader::instance()->ruleByName(ruleItem->text()));
@@ -573,16 +573,16 @@ void AutomatedRssDownloader::updateMatchingArticles()
 {
     m_ui->treeMatchingArticles->clear();
 
-    for (const QListWidgetItem *ruleItem : asConst(m_ui->listRules->selectedItems())) {
+    for (const QListWidgetItem *ruleItem : asConstMove(m_ui->listRules->selectedItems())) {
         RSS::AutoDownloadRule rule = (ruleItem == m_currentRuleItem
                                        ? m_currentRule
                                        : RSS::AutoDownloader::instance()->ruleByName(ruleItem->text()));
-        for (const QString &feedURL : asConst(rule.feedURLs())) {
+        for (const QString &feedURL : asConstMove(rule.feedURLs())) {
             auto feed = RSS::Session::instance()->feedByURL(feedURL);
             if (!feed) continue; // feed doesn't exist
 
             QStringList matchingArticles;
-            for (const auto article : asConst(feed->articles()))
+            for (const auto article : asConstMove(feed->articles()))
                 if (rule.matches(article->data()))
                     matchingArticles << article->title();
             if (!matchingArticles.isEmpty())
@@ -676,7 +676,7 @@ void AutomatedRssDownloader::updateMustLineValidity()
         if (isRegex)
             tokens << text;
         else
-            for (const QString &token : asConst(text.split('|')))
+            for (const QString &token : asConstMove(text.split('|')))
                 tokens << Utils::String::wildcardToRegex(token);
 
         for (const QString &token : asConst(tokens)) {
@@ -714,7 +714,7 @@ void AutomatedRssDownloader::updateMustNotLineValidity()
         if (isRegex)
             tokens << text;
         else
-            for (const QString &token : asConst(text.split('|')))
+            for (const QString &token : asConstMove(text.split('|')))
                 tokens << Utils::String::wildcardToRegex(token);
 
         for (const QString &token : asConst(tokens)) {

--- a/src/gui/rss/feedlistwidget.cpp
+++ b/src/gui/rss/feedlistwidget.cpp
@@ -220,7 +220,7 @@ void FeedListWidget::dropEvent(QDropEvent *event)
                                : RSS::Session::instance()->rootFolder());
 
     // move as much items as possible
-    for (QTreeWidgetItem *srcItem : asConst(selectedItems())) {
+    for (QTreeWidgetItem *srcItem : asConstMove(selectedItems())) {
         auto rssItem = getRSSItem(srcItem);
         RSS::Session::instance()->moveItem(rssItem, RSS::Item::joinPath(destFolder->path(), rssItem->name()));
     }
@@ -265,7 +265,7 @@ QTreeWidgetItem *FeedListWidget::createItem(RSS::Item *rssItem, QTreeWidgetItem 
 
 void FeedListWidget::fill(QTreeWidgetItem *parent, RSS::Folder *rssParent)
 {
-    for (const auto rssItem : asConst(rssParent->items())) {
+    for (const auto rssItem : asConstMove(rssParent->items())) {
         QTreeWidgetItem *item = createItem(rssItem, parent);
         // Recursive call if this is a folder.
         if (auto folder = qobject_cast<RSS::Folder *>(rssItem))

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -186,7 +186,7 @@ void RSSWidget::displayItemsListMenu(const QPoint &)
 {
     bool hasTorrent = false;
     bool hasLink = false;
-    for (const QListWidgetItem *item : asConst(m_articleListWidget->selectedItems())) {
+    for (const QListWidgetItem *item : asConstMove(m_articleListWidget->selectedItems())) {
         auto article = reinterpret_cast<RSS::Article *>(item->data(Qt::UserRole).value<quintptr>());
         Q_ASSERT(article);
 
@@ -308,7 +308,7 @@ void RSSWidget::loadFoldersOpenState()
     const QStringList openedFolders = Preferences::instance()->getRssOpenFolders();
     for (const QString &varPath : openedFolders) {
         QTreeWidgetItem *parent = nullptr;
-        for (const QString &name : asConst(varPath.split('\\'))) {
+        for (const QString &name : asConstMove(varPath.split('\\'))) {
             int nbChildren = (parent ? parent->childCount() : m_feedListWidget->topLevelItemCount());
             for (int i = 0; i < nbChildren; ++i) {
                 QTreeWidgetItem *child = (parent ? parent->child(i) : m_feedListWidget->topLevelItem(i));
@@ -325,7 +325,7 @@ void RSSWidget::loadFoldersOpenState()
 void RSSWidget::saveFoldersOpenState()
 {
     QStringList openedFolders;
-    for (QTreeWidgetItem *item : asConst(m_feedListWidget->getAllOpenedFolders()))
+    for (QTreeWidgetItem *item : asConstMove(m_feedListWidget->getAllOpenedFolders()))
         openedFolders << m_feedListWidget->itemPath(item);
     Preferences::instance()->setRssOpenFolders(openedFolders);
 }
@@ -337,7 +337,7 @@ void RSSWidget::refreshAllFeeds()
 
 void RSSWidget::downloadSelectedTorrents()
 {
-    for (QListWidgetItem *item : asConst(m_articleListWidget->selectedItems())) {
+    for (QListWidgetItem *item : asConstMove(m_articleListWidget->selectedItems())) {
         auto article = reinterpret_cast<RSS::Article *>(item->data(Qt::UserRole).value<quintptr>());
         Q_ASSERT(article);
 
@@ -356,7 +356,7 @@ void RSSWidget::downloadSelectedTorrents()
 // open the url of the selected RSS articles in the Web browser
 void RSSWidget::openSelectedArticlesUrls()
 {
-    for (QListWidgetItem *item : asConst(m_articleListWidget->selectedItems())) {
+    for (QListWidgetItem *item : asConstMove(m_articleListWidget->selectedItems())) {
         auto article = reinterpret_cast<RSS::Article *>(item->data(Qt::UserRole).value<quintptr>());
         Q_ASSERT(article);
 
@@ -397,7 +397,7 @@ void RSSWidget::renameSelectedRSSItem()
 
 void RSSWidget::refreshSelectedItems()
 {
-    for (QTreeWidgetItem *item : asConst(m_feedListWidget->selectedItems())) {
+    for (QTreeWidgetItem *item : asConstMove(m_feedListWidget->selectedItems())) {
         if (item == m_feedListWidget->stickyUnreadItem()) {
             refreshAllFeeds();
             return;
@@ -410,7 +410,7 @@ void RSSWidget::refreshSelectedItems()
 void RSSWidget::copySelectedFeedsURL()
 {
     QStringList URLs;
-    for (QTreeWidgetItem *item : asConst(m_feedListWidget->selectedItems())) {
+    for (QTreeWidgetItem *item : asConstMove(m_feedListWidget->selectedItems())) {
         if (auto feed = qobject_cast<RSS::Feed *>(m_feedListWidget->getRSSItem(item)))
             URLs << feed->url();
     }
@@ -425,7 +425,7 @@ void RSSWidget::handleCurrentFeedItemChanged(QTreeWidgetItem *currentItem)
 
 void RSSWidget::on_markReadButton_clicked()
 {
-    for (QTreeWidgetItem *item : asConst(m_feedListWidget->selectedItems())) {
+    for (QTreeWidgetItem *item : asConstMove(m_feedListWidget->selectedItems())) {
         m_feedListWidget->getRSSItem(item)->markAsRead();
         if (item == m_feedListWidget->stickyUnreadItem())
             break; // all items was read

--- a/src/gui/search/pluginselectdialog.cpp
+++ b/src/gui/search/pluginselectdialog.cpp
@@ -109,7 +109,7 @@ void PluginSelectDialog::dropEvent(QDropEvent *event)
 
     QStringList files;
     if (event->mimeData()->hasUrls()) {
-        for (const QUrl &url : asConst(event->mimeData()->urls())) {
+        for (const QUrl &url : asConstMove(event->mimeData()->urls())) {
             if (!url.isEmpty()) {
                 if (url.scheme().compare("file", Qt::CaseInsensitive) == 0)
                     files << url.toLocalFile();
@@ -134,7 +134,7 @@ void PluginSelectDialog::dropEvent(QDropEvent *event)
 // Decode if we accept drag 'n drop or not
 void PluginSelectDialog::dragEnterEvent(QDragEnterEvent *event)
 {
-    for (const QString &mime : asConst(event->mimeData()->formats())) {
+    for (const QString &mime : asConstMove(event->mimeData()->formats())) {
         qDebug("mimeData: %s", qUtf8Printable(mime));
     }
 
@@ -186,7 +186,7 @@ void PluginSelectDialog::on_closeButton_clicked()
 void PluginSelectDialog::on_actionUninstall_triggered()
 {
     bool error = false;
-    for (QTreeWidgetItem *item : asConst(m_ui->pluginsTree->selectedItems())) {
+    for (QTreeWidgetItem *item : asConstMove(m_ui->pluginsTree->selectedItems())) {
         int index = m_ui->pluginsTree->indexOfTopLevelItem(item);
         Q_ASSERT(index != -1);
         QString id = item->text(PLUGIN_ID);
@@ -210,7 +210,7 @@ void PluginSelectDialog::on_actionUninstall_triggered()
 
 void PluginSelectDialog::enableSelection(bool enable)
 {
-    for (QTreeWidgetItem *item : asConst(m_ui->pluginsTree->selectedItems())) {
+    for (QTreeWidgetItem *item : asConstMove(m_ui->pluginsTree->selectedItems())) {
         int index = m_ui->pluginsTree->indexOfTopLevelItem(item);
         Q_ASSERT(index != -1);
         QString id = item->text(PLUGIN_ID);
@@ -263,7 +263,7 @@ void PluginSelectDialog::loadSupportedSearchPlugins()
 {
     // Some clean up first
     m_ui->pluginsTree->clear();
-    for (const QString &name : asConst(m_pluginManager->allPlugins()))
+    for (const QString &name : asConstMove(m_pluginManager->allPlugins()))
         addNewPlugin(name);
 }
 
@@ -381,7 +381,7 @@ void PluginSelectDialog::iconDownloadFinished(const Net::DownloadResult &result)
     QList<QSize> sizes = icon.availableSizes();
     bool invalid = (sizes.isEmpty() || icon.pixmap(sizes.first()).isNull());
     if (!invalid) {
-        for (QTreeWidgetItem *item : asConst(findItemsWithUrl(result.url))) {
+        for (QTreeWidgetItem *item : asConstMove(findItemsWithUrl(result.url))) {
             QString id = item->text(PLUGIN_ID);
             PluginInfo *plugin = m_pluginManager->pluginInfo(id);
             if (!plugin) continue;

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -162,7 +162,7 @@ void SearchWidget::fillCatCombobox()
 
     using QStrPair = QPair<QString, QString>;
     QList<QStrPair> tmpList;
-    for (const QString &cat : asConst(SearchPluginManager::instance()->getPluginCategories(selectedPlugin())))
+    for (const QString &cat : asConstMove(SearchPluginManager::instance()->getPluginCategories(selectedPlugin())))
         tmpList << qMakePair(SearchPluginManager::categoryFullName(cat), cat);
     std::sort(tmpList.begin(), tmpList.end(), [](const QStrPair &l, const QStrPair &r) { return (QString::localeAwareCompare(l.first, r.first) < 0); });
 
@@ -184,7 +184,7 @@ void SearchWidget::fillPluginComboBox()
 
     using QStrPair = QPair<QString, QString>;
     QList<QStrPair> tmpList;
-    for (const QString &name : asConst(SearchPluginManager::instance()->enabledPlugins()))
+    for (const QString &name : asConstMove(SearchPluginManager::instance()->enabledPlugins()))
         tmpList << qMakePair(SearchPluginManager::instance()->pluginFullName(name), name);
     std::sort(tmpList.begin(), tmpList.end(), [](const QStrPair &l, const QStrPair &r) { return (l.first < r.first); } );
 

--- a/src/gui/tagfiltermodel.cpp
+++ b/src/gui/tagfiltermodel.cpp
@@ -248,7 +248,7 @@ void TagFilterModel::torrentAboutToBeRemoved(BitTorrent::TorrentHandle *const to
     if (torrent->tags().isEmpty())
         untaggedItem()->decreaseTorrentsCount();
 
-    for (TagModelItem *item : asConst(findItems(torrent->tags())))
+    for (TagModelItem *item : asConstMove(findItems(torrent->tags())))
         item->decreaseTorrentsCount();
 }
 
@@ -275,7 +275,7 @@ void TagFilterModel::populate()
                                              [](Torrent *torrent) { return torrent->tags().isEmpty(); });
     addToModel(getSpecialUntaggedTag(), untaggedCount);
 
-    for (const QString &tag : asConst(session->tags())) {
+    for (const QString &tag : asConstMove(session->tags())) {
         const int count = std::count_if(torrents.cbegin(), torrents.cend(),
                                         [tag](Torrent *torrent) { return torrent->hasTag(tag); });
         addToModel(tag, count);

--- a/src/gui/tagfilterwidget.cpp
+++ b/src/gui/tagfilterwidget.cpp
@@ -223,7 +223,7 @@ void TagFilterWidget::removeTag()
 void TagFilterWidget::removeUnusedTags()
 {
     auto session = BitTorrent::Session::instance();
-    for (const QString &tag : asConst(session->tags()))
+    for (const QString &tag : asConstMove(session->tags()))
         if (model()->data(static_cast<TagFilterProxyModel *>(model())->index(tag), Qt::UserRole) == 0)
             session->removeTag(tag);
     updateGeometry();

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -63,7 +63,7 @@ TransferListModel::TransferListModel(QObject *parent)
 {
     // Load the torrents
     using namespace BitTorrent;
-    for (TorrentHandle *const torrent : asConst(Session::instance()->torrents()))
+    for (TorrentHandle *const torrent : asConstMove(Session::instance()->torrents()))
         addTorrent(torrent);
 
     // Listen for torrent changes

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -398,7 +398,7 @@ void TransferListWidget::torrentDoubleClicked()
 QList<BitTorrent::TorrentHandle *> TransferListWidget::getSelectedTorrents() const
 {
     QList<BitTorrent::TorrentHandle *> torrents;
-    for (const QModelIndex &index : asConst(selectionModel()->selectedRows()))
+    for (const QModelIndex &index : asConstMove(selectionModel()->selectedRows()))
         torrents << m_listModel->torrentHandle(mapToSource(index));
 
     return torrents;
@@ -429,25 +429,25 @@ void TransferListWidget::setSelectedTorrentsLocation()
 
 void TransferListWidget::pauseAllTorrents()
 {
-    for (BitTorrent::TorrentHandle *const torrent : asConst(BitTorrent::Session::instance()->torrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConstMove(BitTorrent::Session::instance()->torrents()))
         torrent->pause();
 }
 
 void TransferListWidget::resumeAllTorrents()
 {
-    for (BitTorrent::TorrentHandle *const torrent : asConst(BitTorrent::Session::instance()->torrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConstMove(BitTorrent::Session::instance()->torrents()))
         torrent->resume();
 }
 
 void TransferListWidget::startSelectedTorrents()
 {
-    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConstMove(getSelectedTorrents()))
         torrent->resume();
 }
 
 void TransferListWidget::forceStartSelectedTorrents()
 {
-    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConstMove(getSelectedTorrents()))
         torrent->resume(true);
 }
 
@@ -462,7 +462,7 @@ void TransferListWidget::startVisibleTorrents()
 
 void TransferListWidget::pauseSelectedTorrents()
 {
-    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConstMove(getSelectedTorrents()))
         torrent->pause();
 }
 
@@ -545,7 +545,7 @@ void TransferListWidget::bottomPrioSelectedTorrents()
 void TransferListWidget::copySelectedMagnetURIs() const
 {
     QStringList magnetUris;
-    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConstMove(getSelectedTorrents()))
         magnetUris << torrent->toMagnetUri();
 
     qApp->clipboard()->setText(magnetUris.join('\n'));
@@ -554,7 +554,7 @@ void TransferListWidget::copySelectedMagnetURIs() const
 void TransferListWidget::copySelectedNames() const
 {
     QStringList torrentNames;
-    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConstMove(getSelectedTorrents()))
         torrentNames << torrent->name();
 
     qApp->clipboard()->setText(torrentNames.join('\n'));
@@ -563,7 +563,7 @@ void TransferListWidget::copySelectedNames() const
 void TransferListWidget::copySelectedHashes() const
 {
     QStringList torrentHashes;
-    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConstMove(getSelectedTorrents()))
         torrentHashes << torrent->hash();
 
     qApp->clipboard()->setText(torrentHashes.join('\n'));
@@ -583,13 +583,13 @@ void TransferListWidget::openSelectedTorrentsFolder() const
 #ifdef Q_OS_MAC
     // On macOS you expect both the files and folders to be opened in their parent
     // folders prehilighted for opening, so we use a custom method.
-    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents())) {
+    for (BitTorrent::TorrentHandle *const torrent : asConstMove(getSelectedTorrents())) {
         QString path = torrent->contentPath(true);
         pathsList.insert(path);
     }
     MacUtils::openFiles(pathsList);
 #else
-    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents())) {
+    for (BitTorrent::TorrentHandle *const torrent : asConstMove(getSelectedTorrents())) {
         QString path = torrent->contentPath(true);
         if (!pathsList.contains(path)) {
             if (torrent->filesCount() == 1)
@@ -604,7 +604,7 @@ void TransferListWidget::openSelectedTorrentsFolder() const
 
 void TransferListWidget::previewSelectedTorrents()
 {
-    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents())) {
+    for (BitTorrent::TorrentHandle *const torrent : asConstMove(getSelectedTorrents())) {
         if (torrentContainsPreviewableFiles(torrent))
             new PreviewSelectDialog(this, torrent);
         else
@@ -615,7 +615,7 @@ void TransferListWidget::previewSelectedTorrents()
 void TransferListWidget::setDlLimitSelectedTorrents()
 {
     QList<BitTorrent::TorrentHandle *> torrentsList;
-    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents())) {
+    for (BitTorrent::TorrentHandle *const torrent : asConstMove(getSelectedTorrents())) {
         if (torrent->isSeed())
             continue;
         torrentsList += torrent;
@@ -705,13 +705,13 @@ void TransferListWidget::recheckSelectedTorrents()
         if (ret != QMessageBox::Yes) return;
     }
 
-    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConstMove(getSelectedTorrents()))
         torrent->forceRecheck();
 }
 
 void TransferListWidget::reannounceSelectedTorrents()
 {
-    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConstMove(getSelectedTorrents()))
         torrent->forceReannounce();
 }
 
@@ -757,7 +757,7 @@ void TransferListWidget::displayDLHoSMenu(const QPoint&)
 
 void TransferListWidget::toggleSelectedTorrentsSuperSeeding() const
 {
-    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents())) {
+    for (BitTorrent::TorrentHandle *const torrent : asConstMove(getSelectedTorrents())) {
         if (torrent->hasMetadata())
             torrent->setSuperSeeding(!torrent->superSeeding());
     }
@@ -765,19 +765,19 @@ void TransferListWidget::toggleSelectedTorrentsSuperSeeding() const
 
 void TransferListWidget::toggleSelectedTorrentsSequentialDownload() const
 {
-    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConstMove(getSelectedTorrents()))
         torrent->toggleSequentialDownload();
 }
 
 void TransferListWidget::toggleSelectedFirstLastPiecePrio() const
 {
-    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConstMove(getSelectedTorrents()))
         torrent->toggleFirstLastPiecePriority();
 }
 
 void TransferListWidget::setSelectedAutoTMMEnabled(bool enabled) const
 {
-    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents()))
+    for (BitTorrent::TorrentHandle *const torrent : asConstMove(getSelectedTorrents()))
         torrent->setAutoTMMEnabled(enabled);
 }
 
@@ -830,7 +830,7 @@ QStringList TransferListWidget::askTagsForSelection(const QString &dialogTitle)
 
 void TransferListWidget::applyToSelectedTorrents(const std::function<void (BitTorrent::TorrentHandle *const)> &fn)
 {
-    for (const QModelIndex &index : asConst(selectionModel()->selectedRows())) {
+    for (const QModelIndex &index : asConstMove(selectionModel()->selectedRows())) {
         BitTorrent::TorrentHandle *const torrent = m_listModel->torrentHandle(mapToSource(index));
         Q_ASSERT(torrent);
         fn(torrent);
@@ -858,7 +858,7 @@ void TransferListWidget::renameSelectedTorrent()
 
 void TransferListWidget::setSelectionCategory(const QString &category)
 {
-    for (const QModelIndex &index : asConst(selectionModel()->selectedRows()))
+    for (const QModelIndex &index : asConstMove(selectionModel()->selectedRows()))
         m_listModel->setData(m_listModel->index(mapToSource(index).row(), TransferListModel::TR_CATEGORY), category, Qt::DisplayRole);
 }
 

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -225,7 +225,7 @@ void AppController::preferencesAction()
     data["bypass_local_auth"] = !pref->isWebUiLocalAuthEnabled();
     data["bypass_auth_subnet_whitelist_enabled"] = pref->isWebUiAuthSubnetWhitelistEnabled();
     QStringList authSubnetWhitelistStringList;
-    for (const Utils::Net::Subnet &subnet : asConst(pref->getWebUiAuthSubnetWhitelist()))
+    for (const Utils::Net::Subnet &subnet : asConstMove(pref->getWebUiAuthSubnetWhitelist()))
         authSubnetWhitelistStringList << Utils::Net::subnetToString(subnet);
     data["bypass_auth_subnet_whitelist"] = authSubnetWhitelistStringList.join("\n");
     // Use alternative Web UI

--- a/src/webui/api/logcontroller.cpp
+++ b/src/webui/api/logcontroller.cpp
@@ -72,7 +72,7 @@ void LogController::mainAction()
     Logger *const logger = Logger::instance();
     QVariantList msgList;
 
-    for (const Log::Msg &msg : asConst(logger->getMessages(lastKnownId))) {
+    for (const Log::Msg &msg : asConstMove(logger->getMessages(lastKnownId))) {
         if (!((msg.type == Log::NORMAL && isNormal)
               || (msg.type == Log::INFO && isInfo)
               || (msg.type == Log::WARNING && isWarning)
@@ -111,7 +111,7 @@ void LogController::peersAction()
     Logger *const logger = Logger::instance();
     QVariantList peerList;
 
-    for (const Log::Peer &peer : asConst(logger->getPeers(lastKnownId))) {
+    for (const Log::Peer &peer : asConstMove(logger->getPeers(lastKnownId))) {
         QVariantMap map;
         map[KEY_LOG_ID] = peer.id;
         map[KEY_LOG_TIMESTAMP] = peer.timestamp;

--- a/src/webui/api/searchcontroller.cpp
+++ b/src/webui/api/searchcontroller.cpp
@@ -202,7 +202,7 @@ void SearchController::categoriesAction()
     const QString name = params()["pluginName"].trimmed();
 
     categories << SearchPluginManager::categoryFullName("all");
-    for (const QString &category : asConst(SearchPluginManager::instance()->getPluginCategories(name)))
+    for (const QString &category : asConstMove(SearchPluginManager::instance()->getPluginCategories(name)))
         categories << SearchPluginManager::categoryFullName(category);
 
     const QJsonArray result = QJsonArray::fromStringList(categories);
@@ -263,7 +263,7 @@ void SearchController::checkForUpdatesFinished(const QHash<QString, PluginVersio
     LogMsg(tr("Updating %1 plugins").arg(updateInfo.size()), Log::INFO);
 
     SearchPluginManager *const pluginManager = SearchPluginManager::instance();
-    for (const QString &pluginName : asConst(updateInfo.keys())) {
+    for (const QString &pluginName : asConstMove(updateInfo.keys())) {
         LogMsg(tr("Updating plugin %1").arg(pluginName), Log::INFO);
         pluginManager->updatePlugin(pluginName);
     }

--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -415,7 +415,7 @@ void SyncController::maindataAction()
 
     BitTorrent::Session *const session = BitTorrent::Session::instance();
 
-    for (BitTorrent::TorrentHandle *const torrent : asConst(session->torrents())) {
+    for (BitTorrent::TorrentHandle *const torrent : asConstMove(session->torrents())) {
         QVariantMap map = serialize(*torrent);
         map.remove(KEY_TORRENT_HASH);
 

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -119,7 +119,7 @@ namespace
     void applyToTorrents(const QStringList &hashes, const std::function<void (BitTorrent::TorrentHandle *torrent)> &func)
     {
         if ((hashes.size() == 1) && (hashes[0] == QLatin1String("all"))) {
-            for (BitTorrent::TorrentHandle *const torrent : asConst(BitTorrent::Session::instance()->torrents()))
+            for (BitTorrent::TorrentHandle *const torrent : asConstMove(BitTorrent::Session::instance()->torrents()))
                 func(torrent);
         }
         else {
@@ -134,7 +134,7 @@ namespace
     QVariantList getStickyTrackers(const BitTorrent::TorrentHandle *const torrent)
     {
         uint seedsDHT = 0, seedsPeX = 0, seedsLSD = 0, leechesDHT = 0, leechesPeX = 0, leechesLSD = 0;
-        for (const BitTorrent::PeerInfo &peer : asConst(torrent->peers())) {
+        for (const BitTorrent::PeerInfo &peer : asConstMove(torrent->peers())) {
             if (peer.isConnecting()) continue;
 
             if (peer.isSeed()) {
@@ -239,7 +239,7 @@ void TorrentsController::infoAction()
 
     QVariantList torrentList;
     TorrentFilter torrentFilter(filter, (hashSet.isEmpty() ? TorrentFilter::AnyHash : hashSet), category);
-    for (BitTorrent::TorrentHandle *const torrent : asConst(BitTorrent::Session::instance()->torrents())) {
+    for (BitTorrent::TorrentHandle *const torrent : asConstMove(BitTorrent::Session::instance()->torrents())) {
         if (torrentFilter.match(torrent))
             torrentList.append(serialize(*torrent));
     }
@@ -384,7 +384,7 @@ void TorrentsController::trackersAction()
     QVariantList trackerList = getStickyTrackers(torrent);
 
     QHash<QString, BitTorrent::TrackerInfo> trackersData = torrent->trackerInfos();
-    for (const BitTorrent::TrackerEntry &tracker : asConst(torrent->trackers())) {
+    for (const BitTorrent::TrackerEntry &tracker : asConstMove(torrent->trackers())) {
         const BitTorrent::TrackerInfo data = trackersData.value(tracker.url());
 
         trackerList << QVariantMap {
@@ -416,7 +416,7 @@ void TorrentsController::webseedsAction()
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 
-    for (const QUrl &webseed : asConst(torrent->urlSeeds())) {
+    for (const QUrl &webseed : asConstMove(torrent->urlSeeds())) {
         QVariantMap webSeedDict;
         webSeedDict[KEY_WEBSEED_URL] = webseed.toString();
         webSeedList.append(webSeedDict);
@@ -570,7 +570,7 @@ void TorrentsController::addAction()
     params.useAutoTMM = autoTMM;
 
     bool partialSuccess = false;
-    for (QString url : asConst(urls.split('\n'))) {
+    for (QString url : asConstMove(urls.split('\n'))) {
         url = url.trimmed();
         if (!url.isEmpty()) {
             Net::DownloadManager::instance()->setCookiesFromUrl(cookies, QUrl::fromEncoded(url.toUtf8()));
@@ -605,7 +605,7 @@ void TorrentsController::addTrackersAction()
         throw APIError(APIErrorType::NotFound);
 
     QList<BitTorrent::TrackerEntry> trackers;
-    for (const QString &urlStr : asConst(params()["urls"].split('\n'))) {
+    for (const QString &urlStr : asConstMove(params()["urls"].split('\n'))) {
         const QUrl url {urlStr.trimmed()};
         if (url.isValid())
             trackers << url.toString();


### PR DESCRIPTION
1. std::add_const does not work on T if its a reference.
2. vscode cpp linter is complaining that there are more than 1 instance of overloaded asConst with the same signature. These changes make it clearer which is which...

```more than one instance of overloaded function "asConst" matches the argument list: -- function template "std::add_const<T>::type &asConst(T &t) noexcept" -- function template "std::add_const<T>::type asConst(T &&t) noexcept" -- argument types are: ...```