### PR TITLE
Replace Bytes/s with KiB/s in the adding torrent dialogs in WebUI

### DIFF
--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -565,8 +565,8 @@ void TorrentsController::addAction()
     params.savePath = savepath;
     params.category = category;
     params.name = torrentName;
-    params.uploadLimit = (upLimit > 0) ? upLimit : -1;
-    params.downloadLimit = (dlLimit > 0) ? dlLimit : -1;
+    params.uploadLimit = (upLimit > 0) ? (upLimit * 1024) : -1;
+    params.downloadLimit = (dlLimit > 0) ? (dlLimit * 1024) : -1;
     params.useAutoTMM = autoTMM;
 
     bool partialSuccess = false;

--- a/src/webui/www/private/download.html
+++ b/src/webui/www/private/download.html
@@ -117,7 +117,7 @@
                             <label for="dlLimit">QBT_TR(Limit download rate)QBT_TR[CONTEXT=HttpServer]</label>
                         </td>
                         <td>
-                            <input type="text" id="dlLimit" name="dlLimit" style="width: 16em;" placeholder="Bytes/s" />
+                            <input type="text" id="dlLimit" name="dlLimit" style="width: 16em;" placeholder="KiB/s" />
                         </td>
                     </tr>
                     <tr>
@@ -125,7 +125,7 @@
                             <label for="upLimit">QBT_TR(Limit upload rate)QBT_TR[CONTEXT=HttpServer]</label>
                         </td>
                         <td>
-                            <input type="text" id="upLimit" name="upLimit" style="width: 16em;" placeholder="Bytes/s" />
+                            <input type="text" id="upLimit" name="upLimit" style="width: 16em;" placeholder="KiB/s" />
                         </td>
                     </tr>
                 </table>

--- a/src/webui/www/private/upload.html
+++ b/src/webui/www/private/upload.html
@@ -105,7 +105,7 @@
                         <label for="dlLimit">QBT_TR(Limit download rate)QBT_TR[CONTEXT=HttpServer]</label>
                     </td>
                     <td>
-                        <input type="text" id="dlLimit" name="dlLimit" style="width: 16em;" placeholder="Bytes/s" />
+                        <input type="text" id="dlLimit" name="dlLimit" style="width: 16em;" placeholder="KiB/s" />
                     </td>
                 </tr>
                 <tr>
@@ -113,7 +113,7 @@
                         <label for="upLimit">QBT_TR(Limit upload rate)QBT_TR[CONTEXT=HttpServer]</label>
                     </td>
                     <td>
-                        <input type="text" id="upLimit" name="upLimit" style="width: 16em;" placeholder="Bytes/s" />
+                        <input type="text" id="upLimit" name="upLimit" style="width: 16em;" placeholder="KiB/s" />
                     </td>
                 </tr>
             </table>


### PR DESCRIPTION
Closes #10017.

Reasons:
1. Nowadays the Internet speed is usually in KiB/s or MiB/s, so it would be more reasonable to use KiB/s as the basic speed unit.
2. The speed limit dialogs use the speed unit KiB/s. For consistency, using KiB/s in the adding torrent dialogs will be better.

Screenshots:
**Before:**
![upload-before](https://user-images.githubusercontent.com/6760674/57522110-6d514300-7354-11e9-8790-01a93c691923.png)
![url-before](https://user-images.githubusercontent.com/6760674/57522113-6fb39d00-7354-11e9-8f48-f275e8c46ecb.png)

**After:**
![upload-after](https://user-images.githubusercontent.com/6760674/57522115-7215f700-7354-11e9-822b-7323ec250382.png)
![url-after](https://user-images.githubusercontent.com/6760674/57522119-73472400-7354-11e9-9699-34197260f325.png)
