### PR TITLE
Replace Bytes/s with KiB/s in the adding torrent dialogs in WebUI

### DIFF
--- a/src/webui/www/private/download.html
+++ b/src/webui/www/private/download.html
@@ -114,18 +114,20 @@
                     </tr>
                     <tr>
                         <td>
-                            <label for="dlLimit">QBT_TR(Limit download rate)QBT_TR[CONTEXT=HttpServer]</label>
+                            <label for="dlLimitText">QBT_TR(Limit download rate)QBT_TR[CONTEXT=HttpServer]</label>
                         </td>
                         <td>
-                            <input type="text" id="dlLimit" name="dlLimit" style="width: 16em;" placeholder="Bytes/s" />
+                            <input type="hidden" id="dlLimitHidden" name="dlLimit" />
+                            <input type="text" id="dlLimitText" style="width: 16em;" placeholder="KiB/s" />
                         </td>
                     </tr>
                     <tr>
                         <td>
-                            <label for="upLimit">QBT_TR(Limit upload rate)QBT_TR[CONTEXT=HttpServer]</label>
+                            <label for="upLimitText">QBT_TR(Limit upload rate)QBT_TR[CONTEXT=HttpServer]</label>
                         </td>
                         <td>
-                            <input type="text" id="upLimit" name="upLimit" style="width: 16em;" placeholder="Bytes/s" />
+                            <input type="hidden" id="upLimitHidden" name="upLimit" />
+                            <input type="text" id="upLimitText" style="width: 16em;" placeholder="KiB/s" />
                         </td>
                     </tr>
                 </table>
@@ -154,6 +156,9 @@
         $('downloadForm').addEventListener("submit", function() {
             $('startTorrentHidden').value = $('startTorrent').checked ? 'false' : 'true';
             $('rootFolderHidden').value = $('rootFolder').checked ? 'true' : 'false';
+
+            $('dlLimitHidden').value = $('dlLimitText').value.toInt() * 1024;
+            $('upLimitHidden').value = $('upLimitText').value.toInt() * 1024;
 
             $('download_spinner').style.display = "block";
             submitted = true;

--- a/src/webui/www/private/upload.html
+++ b/src/webui/www/private/upload.html
@@ -102,18 +102,20 @@
                 </tr>
                 <tr>
                     <td>
-                        <label for="dlLimit">QBT_TR(Limit download rate)QBT_TR[CONTEXT=HttpServer]</label>
+                        <label for="dlLimitText">QBT_TR(Limit download rate)QBT_TR[CONTEXT=HttpServer]</label>
                     </td>
                     <td>
-                        <input type="text" id="dlLimit" name="dlLimit" style="width: 16em;" placeholder="Bytes/s" />
+                        <input type="hidden" id="dlLimitHidden" name="dlLimit" />
+                        <input type="text" id="dlLimitText" style="width: 16em;" placeholder="KiB/s" />
                     </td>
                 </tr>
                 <tr>
                     <td>
-                        <label for="upLimit">QBT_TR(Limit upload rate)QBT_TR[CONTEXT=HttpServer]</label>
+                        <label for="upLimitText">QBT_TR(Limit upload rate)QBT_TR[CONTEXT=HttpServer]</label>
                     </td>
                     <td>
-                        <input type="text" id="upLimit" name="upLimit" style="width: 16em;" placeholder="Bytes/s" />
+                        <input type="hidden" id="upLimitHidden" name="upLimit" />
+                        <input type="text" id="upLimitText" style="width: 16em;" placeholder="KiB/s" />
                     </td>
                 </tr>
             </table>
@@ -130,6 +132,9 @@
         $('uploadForm').addEventListener("submit", function() {
             $('startTorrentHidden').value = $('startTorrent').checked ? 'false' : 'true';
             $('rootFolderHidden').value = $('rootFolder').checked ? 'true' : 'false';
+
+            $('dlLimitHidden').value = $('dlLimitText').value.toInt() * 1024;
+            $('upLimitHidden').value = $('upLimitText').value.toInt() * 1024;
 
             $('upload_spinner').style.display = "block";
             submitted = true;


### PR DESCRIPTION
Closes #10017.

Reasons:
1. Nowadays the Internet speed is usually in KiB/s or MiB/s, so it would be more reasonable to use KiB/s as the basic speed unit.
2. The speed limit dialogs use the speed unit KiB/s. For consistency, using KiB/s in the adding torrent dialogs will be better.

PR #10617 touches the WebAPI, and it is closed. In this version the conversion finishes in the front end, the speed limit that will be transferred to the back end is still in `Bytes/s`.

Screenshots:
**Before:**
![upload-before](https://user-images.githubusercontent.com/6760674/57522110-6d514300-7354-11e9-8790-01a93c691923.png)
![url-before](https://user-images.githubusercontent.com/6760674/57522113-6fb39d00-7354-11e9-8f48-f275e8c46ecb.png)

**After:**
![upload-after](https://user-images.githubusercontent.com/6760674/57522115-7215f700-7354-11e9-822b-7323ec250382.png)
![url-after](https://user-images.githubusercontent.com/6760674/57522119-73472400-7354-11e9-9699-34197260f325.png)
