### PR TITLE
Add "Remember me" option in WebUI

### DIFF
--- a/src/webui/api/authcontroller.cpp
+++ b/src/webui/api/authcontroller.cpp
@@ -47,6 +47,7 @@ void AuthController::loginAction()
     const QString clientAddr {sessionManager()->clientId()};
     const QString usernameFromWeb {params()["username"]};
     const QString passwordFromWeb {params()["password"]};
+    const bool rememberFromWeb {static_cast<bool>(params()["remember"].toInt())};
 
     if (isBanned()) {
         LogMsg(tr("WebAPI login failure. Reason: IP has been banned, IP: %1, username: %2")
@@ -66,7 +67,10 @@ void AuthController::loginAction()
     if (usernameEqual && passwordEqual) {
         m_clientFailedLogins.remove(clientAddr);
 
-        sessionManager()->sessionStart();
+        if (rememberFromWeb)
+            sessionManager()->sessionStartPermanently();
+        else
+            sessionManager()->sessionStart();
         setResult(QLatin1String("Ok."));
         LogMsg(tr("WebAPI login success. IP: %1").arg(clientAddr));
     }

--- a/src/webui/api/isessionmanager.h
+++ b/src/webui/api/isessionmanager.h
@@ -50,5 +50,6 @@ struct ISessionManager
     virtual QString clientId() const = 0;
     virtual ISession *session() = 0;
     virtual void sessionStart() = 0;
+    virtual void sessionStartPermanently() = 0;
     virtual void sessionEnd() = 0;
 };

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -639,8 +639,10 @@ bool WebApplication::validateHostHeader(const QStringList &domains) const
 
 // WebSession
 
-WebSession::WebSession(const QString &sid)
+WebSession::WebSession(const QString &sid, const bool persistent)
     : m_sid {sid}
+    , m_persistent {persistent}
+    , m_createTime {QDateTime::currentMSecsSinceEpoch() / 1000}
 {
     updateTimestamp();
 }
@@ -648,6 +650,16 @@ WebSession::WebSession(const QString &sid)
 QString WebSession::id() const
 {
     return m_sid;
+}
+
+bool WebSession::persistent() const
+{
+    return m_persistent;
+}
+
+qint64 WebSession::createTime() const
+{
+    return m_createTime;
 }
 
 qint64 WebSession::timestamp() const

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -531,15 +531,15 @@ bool WebApplication::isPublicAPI(const QString &scope, const QString &action) co
 
 void WebApplication::sessionStart()
 {
-    doSessionStart(false);
+    startSession(false);
 }
 
 void WebApplication::sessionStartPermanently()
 {
-    doSessionStart(true);
+    startSession(true);
 }
 
-void WebApplication::doSessionStart(const bool persistence)
+void WebApplication::startSession(const bool persistence)
 {
     Q_ASSERT(!m_currentSession);
 

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -475,13 +475,13 @@ void WebApplication::sessionInitialize()
         m_currentSession = m_sessions.value(sessionId);
         if (m_currentSession) {
             const qint64 now = QDateTime::currentMSecsSinceEpoch() / 1000;
-            if ((now - m_currentSession->m_timestamp) > INACTIVE_TIME) {
+            if ((now - m_currentSession->m_lastActiveTime) > INACTIVE_TIME) {
                 // session is outdated - removing it
                 delete m_sessions.take(sessionId);
                 m_currentSession = nullptr;
             }
             else {
-                m_currentSession->updateTimestamp();
+                m_currentSession->updateLastActiveTime();
             }
         }
         else {
@@ -529,7 +529,7 @@ void WebApplication::sessionStart()
     const qint64 now = QDateTime::currentMSecsSinceEpoch() / 1000;
     const QHash<QString, WebSession *> sessionsCopy {m_sessions};
     for (const auto session : sessionsCopy) {
-        if ((now - session->timestamp()) > INACTIVE_TIME)
+        if ((now - session->lastActiveTime()) > INACTIVE_TIME)
             delete m_sessions.take(session->id());
     }
 
@@ -644,7 +644,7 @@ WebSession::WebSession(const QString &sid, const bool persistent)
     , m_persistent {persistent}
     , m_createTime {QDateTime::currentMSecsSinceEpoch() / 1000}
 {
-    updateTimestamp();
+    updateLastActiveTime();
 }
 
 QString WebSession::id() const
@@ -662,9 +662,9 @@ qint64 WebSession::createTime() const
     return m_createTime;
 }
 
-qint64 WebSession::timestamp() const
+qint64 WebSession::lastActiveTime() const
 {
-    return m_timestamp;
+    return m_lastActiveTime;
 }
 
 QVariant WebSession::getData(const QString &id) const
@@ -677,7 +677,7 @@ void WebSession::setData(const QString &id, const QVariant &data)
     m_data[id] = data;
 }
 
-void WebSession::updateTimestamp()
+void WebSession::updateLastActiveTime()
 {
-    m_timestamp = QDateTime::currentMSecsSinceEpoch() / 1000;
+    m_lastActiveTime = QDateTime::currentMSecsSinceEpoch() / 1000;
 }

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -55,9 +55,11 @@ class WebSession : public ISession
     friend class WebApplication;
 
 public:
-    explicit WebSession(const QString &sid);
+    explicit WebSession(const QString &sid, const bool persistent = false);
 
     QString id() const override;
+    bool persistent() const;
+    qint64 createTime() const;
     qint64 timestamp() const;
 
     QVariant getData(const QString &id) const override;
@@ -67,6 +69,8 @@ private:
     void updateTimestamp();
 
     const QString m_sid;
+    const bool m_persistent;
+    qint64 m_createTime;
     qint64 m_timestamp;
     QVariantHash m_data;
 };

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -104,7 +104,7 @@ public:
     const Http::Environment &env() const;
 
 private:
-    void doSessionStart(const bool persistence);
+    void startSession(const bool persistence);
 
     void doProcessRequest();
     void configure();

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -60,18 +60,18 @@ public:
     QString id() const override;
     bool persistent() const;
     qint64 createTime() const;
-    qint64 timestamp() const;
+    qint64 lastActiveTime() const;
 
     QVariant getData(const QString &id) const override;
     void setData(const QString &id, const QVariant &data) override;
 
 private:
-    void updateTimestamp();
+    void updateLastActiveTime();
 
     const QString m_sid;
     const bool m_persistent;
     qint64 m_createTime;
-    qint64 m_timestamp;
+    qint64 m_lastActiveTime;
     QVariantHash m_data;
 };
 

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -49,6 +49,7 @@ class WebApplication;
 
 constexpr char C_SID[] = "SID"; // name of session id cookie
 constexpr int INACTIVE_TIME = 900; // Session inactive time (in secs = 15 min.)
+constexpr int PERSISTENCE_AVAILABLE_TIME = 31536000; // Persistent session available time (should be a large number; here is 1 year.)
 
 class WebSession : public ISession
 {
@@ -96,12 +97,15 @@ public:
     QString clientId() const override;
     WebSession *session() override;
     void sessionStart() override;
+    void sessionStartPermanently() override;
     void sessionEnd() override;
 
     const Http::Request &request() const;
     const Http::Environment &env() const;
 
 private:
+    void doSessionStart(const bool persistence);
+
     void doProcessRequest();
     void configure();
 
@@ -117,6 +121,7 @@ private:
     QString generateSid() const;
     void sessionInitialize();
     bool isAuthNeeded();
+    bool isSessionExpired(const WebSession *session) const;
     bool isPublicAPI(const QString &scope, const QString &action) const;
 
     bool isCrossSiteRequest(const Http::Request &request) const;

--- a/src/webui/www/public/css/login.css
+++ b/src/webui/www/public/css/login.css
@@ -16,6 +16,10 @@ body {
     margin-bottom: 5px;
 }
 
+.clearfix {
+    overflow: auto;
+}
+
 #main {
     margin-left: auto;
     margin-right: auto;
@@ -28,8 +32,16 @@ body {
     padding: 10px;
 }
 
+#username, #password {
+    width: 12em;
+}
+
 #error_msg {
     color: #f00;
+}
+
+#remember_group {
+    float: left;
 }
 
 #login {

--- a/src/webui/www/public/index.html
+++ b/src/webui/www/public/index.html
@@ -29,7 +29,11 @@
                 <div class="row">
                     <label for="password">QBT_TR(Password)QBT_TR[CONTEXT=HttpServer]</label><br />
                     <input type="password" id="password" name="password" autocomplete="current-password" /></div>
-                <div class="row">
+                <div class="row clearfix">
+                    <div id="remember_group">
+                        <input type="checkbox" id="remember" name="remember" />
+                        <label for="remember">QBT_TR(Remember Me)QBT_TR[CONTEXT=HttpServer]</label>
+                    </div>
                     <input type="submit" id="login" value="QBT_TR(Login)QBT_TR[CONTEXT=HttpServer]" />
                 </div>
             </form>

--- a/src/webui/www/public/scripts/login.js
+++ b/src/webui/www/public/scripts/login.js
@@ -59,7 +59,8 @@ function submitLoginForm() {
 
     var usernameElement = document.getElementById('username');
     var passwordElement = document.getElementById('password');
-    var queryString = "username=" + encodeURIComponent(usernameElement.value) + "&password=" + encodeURIComponent(passwordElement.value);
+    var rememberElement = document.getElementById('remember');
+    var queryString = "username=" + encodeURIComponent(usernameElement.value) + "&password=" + encodeURIComponent(passwordElement.value) + '&remember=' + encodeURIComponent(rememberElement.checked ? 1 : 0);
     xhr.send(queryString);
 
     // clear the field


### PR DESCRIPTION
Closes #10443.

I've done the following works:
**Front end:**
1. Add a `Remember Me` check box to the left of the `Login` button.
2. At the beginning the form looks a little bit crowded, so I widen the text box to 12em (Previously the width is not specified, but I guess the width is around 10em)
Before:
![login-before](https://user-images.githubusercontent.com/6760674/57569075-6b55b580-7422-11e9-9078-a1af03082eac.png)
After:
![login-after](https://user-images.githubusercontent.com/6760674/57569079-6f81d300-7422-11e9-93d7-7ee94b4f6d4e.png)

**Back end:**
1. If the `Remember Me` option is enabled, 
   * The controller will set a cookie with an expiration time to the user. The expiration time is a large enough number. Here I set the cookie will be expired after a year.
   * The expiration time of the session will be the same as the cookie. A session won't be expired even if a user doesn't do anything in 15 minutes (`INACTIVE_TIME`).
2. If the `Remember Me` option is not enabled, the controller behaves the same as before.

I have tested the code, and it behaves as expected.