### PR TITLE
Use newer libtorrent API (part 3)

### DIFF
--- a/src/base/bittorrent/trackerentry.cpp
+++ b/src/base/bittorrent/trackerentry.cpp
@@ -49,15 +49,16 @@ TrackerEntry::TrackerEntry(const lt::announce_entry &nativeEntry)
 
 QString TrackerEntry::url() const
 {
-    return QString::fromStdString(m_nativeEntry.url);
+    return QString::fromStdString(nativeEntry().url);
 }
 
 bool TrackerEntry::isWorking() const
 {
 #if (LIBTORRENT_VERSION_NUM < 10200)
-    return m_nativeEntry.is_working();
+    return nativeEntry().is_working();
 #else
-    return std::any_of(m_nativeEntry.endpoints.begin(), m_nativeEntry.endpoints.end()
+    const auto &endpoints = nativeEntry().endpoints;
+    return std::any_of(endpoints.begin(), endpoints.end()
                        , [](const lt::announce_endpoint &endpoint)
     {
         return endpoint.is_working();
@@ -67,19 +68,40 @@ bool TrackerEntry::isWorking() const
 
 int TrackerEntry::tier() const
 {
-    return m_nativeEntry.tier;
+    return nativeEntry().tier;
 }
 
 TrackerEntry::Status TrackerEntry::status() const
 {
     // lt::announce_entry::is_working() returns
     // true when the tracker hasn't been tried yet.
-    if (m_nativeEntry.verified && isWorking())
+    if (nativeEntry().verified && isWorking())
         return Working;
-    if ((m_nativeEntry.fails == 0) && m_nativeEntry.updating)
+
+#if (LIBTORRENT_VERSION_NUM < 10200)
+    if ((nativeEntry().fails == 0) && nativeEntry().updating)
         return Updating;
-    if (m_nativeEntry.fails == 0)
+    if (nativeEntry().fails == 0)
         return NotContacted;
+#else
+    const auto &endpoints = nativeEntry().endpoints;
+    const bool allFailed = std::all_of(endpoints.begin(), endpoints.end()
+                                       , [](const lt::announce_endpoint &endpoint)
+    {
+        return (endpoint.fails > 0);
+    });
+    const bool updating = std::any_of(endpoints.begin(), endpoints.end()
+                                      , [](const lt::announce_endpoint &endpoint)
+    {
+        return endpoint.updating;
+    });
+
+    if (!allFailed && updating)
+        return Updating;
+
+    if (!allFailed)
+        return NotContacted;
+#endif
 
     return NotWorking;
 }
@@ -94,8 +116,11 @@ int TrackerEntry::numSeeds() const
 #if (LIBTORRENT_VERSION_NUM < 10200)
     return nativeEntry().scrape_complete;
 #else
-    // FIXME: Handle all possible endpoints.
-    return nativeEntry().endpoints.empty() ? -1 : nativeEntry().endpoints[0].scrape_complete;
+    int max = -1;
+    return nativeEntry().endpoints.empty() ? -1 : nativeEntry().endpoints[0].scrape_incomplete;
+    for (const lt::announce_endpoint &endpoint : nativeEntry().endpoints)
+        max = std::max(max, endpoint.scrape_complete);
+    return max;
 #endif
 }
 
@@ -104,8 +129,11 @@ int TrackerEntry::numLeeches() const
 #if (LIBTORRENT_VERSION_NUM < 10200)
     return nativeEntry().scrape_incomplete;
 #else
-    // FIXME: Handle all possible endpoints.
+    int max = -1;
     return nativeEntry().endpoints.empty() ? -1 : nativeEntry().endpoints[0].scrape_incomplete;
+    for (const lt::announce_endpoint &endpoint : nativeEntry().endpoints)
+        max = std::max(max, endpoint.scrape_incomplete);
+    return max;
 #endif
 }
 
@@ -114,12 +142,15 @@ int TrackerEntry::numDownloaded() const
 #if (LIBTORRENT_VERSION_NUM < 10200)
     return nativeEntry().scrape_downloaded;
 #else
-    // FIXME: Handle all possible endpoints.
-    return nativeEntry().endpoints.empty() ? -1 : nativeEntry().endpoints[0].scrape_downloaded;
+    int max = -1;
+    return nativeEntry().endpoints.empty() ? -1 : nativeEntry().endpoints[0].scrape_incomplete;
+    for (const lt::announce_endpoint &endpoint : nativeEntry().endpoints)
+        max = std::max(max, endpoint.scrape_downloaded);
+    return max;
 #endif
 }
 
-lt::announce_entry TrackerEntry::nativeEntry() const
+const lt::announce_entry &TrackerEntry::nativeEntry() const
 {
     return m_nativeEntry;
 }

--- a/src/base/bittorrent/trackerentry.h
+++ b/src/base/bittorrent/trackerentry.h
@@ -64,7 +64,7 @@ namespace BitTorrent
         int numLeeches() const;
         int numDownloaded() const;
 
-        lt::announce_entry nativeEntry() const;
+        const lt::announce_entry &nativeEntry() const;
 
     private:
         lt::announce_entry m_nativeEntry;


### PR DESCRIPTION
This commit covers trackerentry.cpp only.

This is should be the last (easy) one, to fix the rest of deprecate warnings require non-trivial refactor.