### PR TITLE
Fix wrong comparison result

### DIFF
--- a/src/base/utils/string.cpp
+++ b/src/base/utils/string.cpp
@@ -96,18 +96,29 @@ namespace
                 }
                 else if (leftChar.isDigit() && rightChar.isDigit()) {
                     // Both are digits, compare the numbers
-                    const auto consumeNumber = [](const QString &str, int &pos) -> int
+
+                    const auto numberView = [](const QString &str, int &pos) -> QStringRef
                     {
                         const int start = pos;
                         while ((pos < str.size()) && str[pos].isDigit())
                             ++pos;
-                        return str.midRef(start, (pos - start)).toInt();
+                        return str.midRef(start, (pos - start));
                     };
 
-                    const int numL = consumeNumber(left, posL);
-                    const int numR = consumeNumber(right, posR);
-                    if (numL != numR)
-                        return (numL - numR);
+                    const QStringRef numViewL = numberView(left, posL);
+                    const QStringRef numViewR = numberView(right, posR);
+
+                    if (numViewL.length() != numViewR.length())
+                        return (numViewL.length() - numViewR.length());
+
+                    // both string/view has the same length
+                    for (int i = 0; i < numViewL.length(); ++i) {
+                        const QChar numL = numViewL[i];
+                        const QChar numR = numViewR[i];
+
+                        if (numL != numR)
+                            return (numL.unicode() - numR.unicode());
+                    }
 
                     // String + digits do match and we haven't hit the end of both strings
                     // then continue to consume the remainings


### PR DESCRIPTION
The QString::toInt() might overflow when the string is long.
Closes #10706.

Will backport to v4_1_x branch.