### PR TITLE
Use timestamp from alert

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -508,7 +508,6 @@ Session::Session(QObject *parent)
     new PortForwarderImpl {m_nativeSession};
 
     initMetrics();
-    m_statsUpdateTimer.start();
 
     qDebug("* BitTorrent Session constructed");
 }
@@ -4207,7 +4206,9 @@ void Session::handleExternalIPAlert(const lt::external_ip_alert *p)
 
 void Session::handleSessionStatsAlert(const lt::session_stats_alert *p)
 {
-    const qreal interval = m_statsUpdateTimer.restart() / 1000.;
+    const qreal interval = lt::total_milliseconds(p->timestamp() - m_statsLastTimestamp) / 1000.;
+    m_statsLastTimestamp = p->timestamp();
+
 #if (LIBTORRENT_VERSION_NUM < 10200)
     const auto &stats = p->values;
 #else

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -3787,7 +3787,6 @@ void Session::handleAlert(const lt::alert *a)
 {
     try {
         switch (a->type()) {
-        case lt::stats_alert::alert_type:
         case lt::file_renamed_alert::alert_type:
         case lt::file_completed_alert::alert_type:
         case lt::torrent_finished_alert::alert_type:

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -34,7 +34,6 @@
 
 #include <libtorrent/fwd.hpp>
 
-#include <QElapsedTimer>
 #include <QFile>
 #include <QHash>
 #include <QList>
@@ -701,7 +700,7 @@ namespace BitTorrent
         QTimer *m_recentErroredTorrentsTimer;
 
         SessionMetricIndices m_metricIndices;
-        QElapsedTimer m_statsUpdateTimer;
+        lt::time_point m_statsLastTimestamp = lt::clock_type::now();
 
         SessionStatus m_status;
         CacheStatus m_cacheStatus;


### PR DESCRIPTION
* Use alert's timestamp
  This way has better accuracy than running our own timer.
* Remove unused stats_alert handler
  Fixup 0fe9cd05c4aca8be9820cd489c8fa57173df6ed3.