### PR TITLE
Fix speed limit not applying to IPv6 peers

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -520,7 +520,7 @@ namespace BitTorrent
         void configure(lt::settings_pack &settingsPack);
         void configurePeerClasses();
         void adjustLimits(lt::settings_pack &settingsPack);
-        void applyBandwidthLimits(lt::settings_pack &settingsPack);
+        void applyBandwidthLimits(lt::settings_pack &settingsPack) const;
         void initMetrics();
         void adjustLimits();
         void applyBandwidthLimits();


### PR DESCRIPTION
* Fix speed limit not applying to IPv6 peers
  `TORRENT_USE_IPV6` is not used by libtorrent 1.2 anymore.

~~Will backport to v4_1_x.~~ This issue only affects libtorrent 1.2.