### PR TITLE
Ignore RSS articles with non-unique identifiers

### DIFF
--- a/src/base/rss/private/rss_parser.cpp
+++ b/src/base/rss/private/rss_parser.cpp
@@ -635,7 +635,7 @@ void Parser::parseRssArticle(QXmlStreamReader &xml)
     if (article[Article::KeyTorrentURL].toString().isEmpty())
         article[Article::KeyTorrentURL] = altTorrentUrl;
 
-    m_result.articles.prepend(article);
+    addArticle(article);
 }
 
 void Parser::parseRSSChannel(QXmlStreamReader &xml)
@@ -730,7 +730,7 @@ void Parser::parseAtomArticle(QXmlStreamReader &xml)
         }
     }
 
-    m_result.articles.prepend(article);
+    addArticle(article);
 }
 
 void Parser::parseAtomChannel(QXmlStreamReader &xml)
@@ -759,4 +759,21 @@ void Parser::parseAtomChannel(QXmlStreamReader &xml)
             }
         }
     }
+}
+
+void Parser::addArticle(QVariantHash article)
+{
+    QVariant &torrentURL = article[Article::KeyTorrentURL];
+    if (torrentURL.toString().isEmpty())
+        torrentURL = article[Article::KeyLink];
+
+    // If item does not have an ID, fall back to some other identifier.
+    QVariant &localId = article[Article::KeyId];
+    if (localId.toString().isEmpty())
+        localId = article.value(Article::KeyTorrentURL);
+    if (localId.toString().isEmpty())
+        localId = article.value(Article::KeyTitle);
+
+    if (!localId.toString().isEmpty())
+        m_result.articles.prepend(article);
 }

--- a/src/base/rss/private/rss_parser.cpp
+++ b/src/base/rss/private/rss_parser.cpp
@@ -583,6 +583,7 @@ void Parser::parse_impl(const QByteArray &feedData)
 
     emit finished(m_result);
     m_result.articles.clear(); // clear articles only
+    m_articleIDs.clear();
 }
 
 void Parser::parseRssArticle(QXmlStreamReader &xml)
@@ -774,6 +775,20 @@ void Parser::addArticle(QVariantHash article)
     if (localId.toString().isEmpty())
         localId = article.value(Article::KeyTitle);
 
-    if (!localId.toString().isEmpty())
-        m_result.articles.prepend(article);
+    if (localId.toString().isEmpty()) {
+        // The article could not be uniquely identified
+        // since it has no appropriate data.
+        // Just ignore it.
+        return;
+    }
+
+    if (m_articleIDs.contains(localId.toString())) {
+        // The article could not be uniquely identified
+        // since the Feed has duplicate identifiers.
+        // Just ignore it.
+        return;
+    }
+
+    m_articleIDs.insert(localId.toString());
+    m_result.articles.prepend(article);
 }

--- a/src/base/rss/private/rss_parser.h
+++ b/src/base/rss/private/rss_parser.h
@@ -65,6 +65,7 @@ namespace RSS
             void parseRSSChannel(QXmlStreamReader &xml);
             void parseAtomArticle(QXmlStreamReader &xml);
             void parseAtomChannel(QXmlStreamReader &xml);
+            void addArticle(QVariantHash article);
 
             QString m_baseUrl;
             ParsingResult m_result;

--- a/src/base/rss/private/rss_parser.h
+++ b/src/base/rss/private/rss_parser.h
@@ -31,6 +31,7 @@
 
 #include <QList>
 #include <QObject>
+#include <QSet>
 #include <QString>
 #include <QVariantHash>
 
@@ -69,6 +70,7 @@ namespace RSS
 
             QString m_baseUrl;
             ParsingResult m_result;
+            QSet<QString> m_articleIDs;
         };
     }
 }

--- a/src/base/rss/rss_feed.cpp
+++ b/src/base/rss/rss_feed.cpp
@@ -411,24 +411,10 @@ int Feed::updateArticles(const QList<QVariantHash> &loadedArticles)
     QVector<QVariantHash> newArticles;
     newArticles.reserve(loadedArticles.size());
     for (QVariantHash article : loadedArticles) {
-        QVariant &torrentURL = article[Article::KeyTorrentURL];
-        if (torrentURL.toString().isEmpty())
-            torrentURL = article[Article::KeyLink];
-
-        // If item does not have an ID, fall back to some other identifier.
-        QVariant &localId = article[Article::KeyId];
-        if (localId.toString().isEmpty())
-            localId = article.value(Article::KeyTorrentURL);
-        if (localId.toString().isEmpty())
-            localId = article.value(Article::KeyTitle);
-
-        if (localId.toString().isEmpty())
-            continue;
-
         // If article has no publication date we use feed update time as a fallback.
         // To prevent processing of "out-of-limit" articles we must not assign dates
         // that are earlier than the dates of existing articles.
-        const Article *existingArticle = articleByGUID(localId.toString());
+        const Article *existingArticle = articleByGUID(article[Article::KeyId].toString());
         if (existingArticle) {
             dummyPubDate = existingArticle->date().addMSecs(-1);
             continue;


### PR DESCRIPTION
Currently RSS Feed that has duplicated item identifiers can cause application crash.