### PR TITLE
Fix unable to control add torrent dialogs when opened simultaneously

### DIFF
--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -93,16 +93,13 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::AddTorrentParams &inP
     // TODO: set dialog file properties using m_torrentParams.filePriorities
     m_ui->setupUi(this);
     setAttribute(Qt::WA_DeleteOnClose);
+
     m_ui->lblMetaLoading->setVisible(false);
     m_ui->progMetaLoading->setVisible(false);
 
     m_ui->savePath->setMode(FileSystemPathEdit::Mode::DirectorySave);
     m_ui->savePath->setDialogCaption(tr("Choose save path"));
     m_ui->savePath->setMaxVisibleItems(20);
-
-#ifdef Q_OS_MAC
-    setModal(true);
-#endif
 
     const auto *session = BitTorrent::Session::instance();
 
@@ -241,7 +238,7 @@ void AddNewTorrentDialog::show(const QString &source, const BitTorrent::AddTorre
         : dlg->loadTorrentFile(source);
 
     if (isLoaded)
-        dlg->open();
+        dlg->QDialog::show();
     else
         delete dlg;
 }

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -600,9 +600,6 @@ void AddNewTorrentDialog::displayContentTreeMenu(const QPoint &)
 
 void AddNewTorrentDialog::accept()
 {
-    if (!m_hasMetadata)
-        disconnect(this, SLOT(updateMetadata(const BitTorrent::TorrentInfo&)));
-
     // TODO: Check if destination actually exists
     m_torrentParams.skipChecking = m_ui->skipCheckingCheckBox->isChecked();
 
@@ -648,7 +645,6 @@ void AddNewTorrentDialog::accept()
 void AddNewTorrentDialog::reject()
 {
     if (!m_hasMetadata) {
-        disconnect(this, SLOT(updateMetadata(BitTorrent::TorrentInfo)));
         setMetadataProgressIndicator(false);
         BitTorrent::Session::instance()->cancelLoadMetadata(m_hash);
     }
@@ -660,7 +656,8 @@ void AddNewTorrentDialog::updateMetadata(const BitTorrent::TorrentInfo &info)
 {
     if (info.hash() != m_hash) return;
 
-    disconnect(this, SLOT(updateMetadata(BitTorrent::TorrentInfo)));
+    disconnect(BitTorrent::Session::instance(), &BitTorrent::Session::metadataLoaded, this, &AddNewTorrentDialog::updateMetadata);
+
     if (!info.isValid()) {
         RaisedMessageBox::critical(this, tr("I/O Error"), ("Invalid metadata."));
         setMetadataProgressIndicator(false, tr("Invalid metadata"));

--- a/src/gui/downloadfromurldialog.cpp
+++ b/src/gui/downloadfromurldialog.cpp
@@ -47,7 +47,6 @@ namespace
             || str.startsWith("https://", Qt::CaseInsensitive)
             || str.startsWith("ftp://", Qt::CaseInsensitive)
             || str.startsWith("magnet:", Qt::CaseInsensitive)
-            || str.startsWith("bc://bt/", Qt::CaseInsensitive)
             || ((str.size() == 40) && !str.contains(QRegularExpression("[^0-9A-Fa-f]")))
             || ((str.size() == 32) && !str.contains(QRegularExpression("[^2-7A-Za-z]"))));
     }

--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -261,7 +261,7 @@ void SearchJobWidget::downloadTorrent(const QModelIndex &rowIndex)
     const QString siteUrl = m_proxyModel->data(
                 m_proxyModel->index(rowIndex.row(), SearchSortModel::ENGINE_URL)).toString();
 
-    if (torrentUrl.startsWith("bc://bt/", Qt::CaseInsensitive) || torrentUrl.startsWith("magnet:", Qt::CaseInsensitive)) {
+    if (torrentUrl.startsWith("magnet:", Qt::CaseInsensitive)) {
         addTorrentToSession(torrentUrl);
     }
     else {


### PR DESCRIPTION
* Drop support for "BC Link" format
  Fixup 19d6de7.
* Fix unable to control add torrent dialogs when opened simultaneously

Personally I would just make `AddNewTorrentDialog` default to non-modal rather than going this contrived way, however I guess that won't be accepted by others easily.