### PR TITLE
 Disable "Upload mode" when start preloaded torrent. Closes #10751

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1862,10 +1862,13 @@ bool Session::addTorrent_impl(CreateTorrentParams params, const MagnetUri &magne
             --m_extraLimit;
 
             try {
+                // Preloaded torrent is in "Upload mode" so we need to disable it
+                // otherwise the torrent never be downloaded (until application restart)
 #if (LIBTORRENT_VERSION_NUM < 10200)
                 handle.auto_managed(false);
+                handle.set_upload_mode(false);
 #else
-                handle.unset_flags(lt::torrent_flags::auto_managed);
+                handle.unset_flags(lt::torrent_flags::auto_managed | lt::torrent_flags::upload_mode);
 #endif
                 handle.pause();
             }

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1865,7 +1865,7 @@ bool Session::addTorrent_impl(CreateTorrentParams params, const MagnetUri &magne
 #if (LIBTORRENT_VERSION_NUM < 10200)
                 handle.auto_managed(false);
 #else
-                handle.set_flags(lt::torrent_flags::auto_managed);
+                handle.unset_flags(lt::torrent_flags::auto_managed);
 #endif
                 handle.pause();
             }

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1959,7 +1959,7 @@ bool Session::addTorrent_impl(CreateTorrentParams params, const MagnetUri &magne
 #else
         p.flags &= ~lt::torrent_flags::seed_mode;
 #endif
-}
+    }
 
     if (!fromMagnetUri) {
         if (params.restored) {


### PR DESCRIPTION
Someone added "optimization" for a preloaded torrent so that it doesn't create any additional files, but forgot to disable it if such a torrent needs to continue downloading.