### PR TITLE
Focus behavior row in Options dialog

### DIFF
--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -45,7 +45,7 @@
        <enum>QListView::IconMode</enum>
       </property>
       <property name="currentRow">
-       <number>-1</number>
+       <number>0</number>
       </property>
       <item>
        <property name="text">


### PR DESCRIPTION
This PR focus Behavior row, when Options dialog is opened.

Closes #7957

<img width="378" alt="behavior_row_options_dlg" src="https://user-images.githubusercontent.com/86900/59446806-7bd2c480-8e02-11e9-99cc-dfa285a935e5.png">
