### PR TITLE
Rename "fromNativePath" to "toUniformPath"

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -172,7 +172,7 @@ namespace
 
     QString normalizePath(const QString &path)
     {
-        QString tmp = Utils::Fs::fromNativePath(path.trimmed());
+        QString tmp = Utils::Fs::toUniformPath(path.trimmed());
         if (!tmp.isEmpty() && !tmp.endsWith('/'))
             return tmp + '/';
         return tmp;
@@ -182,7 +182,7 @@ namespace
     {
         path = path.trimmed();
         if (path.isEmpty())
-            path = Utils::Fs::fromNativePath(defaultPath.trimmed());
+            path = Utils::Fs::toUniformPath(defaultPath.trimmed());
 
         return normalizePath(path);
     }
@@ -610,36 +610,36 @@ void Session::setPreallocationEnabled(const bool enabled)
 
 QString Session::torrentExportDirectory() const
 {
-    return Utils::Fs::fromNativePath(m_torrentExportDirectory);
+    return Utils::Fs::toUniformPath(m_torrentExportDirectory);
 }
 
 void Session::setTorrentExportDirectory(QString path)
 {
-    path = Utils::Fs::fromNativePath(path);
+    path = Utils::Fs::toUniformPath(path);
     if (path != torrentExportDirectory())
         m_torrentExportDirectory = path;
 }
 
 QString Session::finishedTorrentExportDirectory() const
 {
-    return Utils::Fs::fromNativePath(m_finishedTorrentExportDirectory);
+    return Utils::Fs::toUniformPath(m_finishedTorrentExportDirectory);
 }
 
 void Session::setFinishedTorrentExportDirectory(QString path)
 {
-    path = Utils::Fs::fromNativePath(path);
+    path = Utils::Fs::toUniformPath(path);
     if (path != finishedTorrentExportDirectory())
         m_finishedTorrentExportDirectory = path;
 }
 
 QString Session::defaultSavePath() const
 {
-    return Utils::Fs::fromNativePath(m_defaultSavePath);
+    return Utils::Fs::toUniformPath(m_defaultSavePath);
 }
 
 QString Session::tempPath() const
 {
-    return Utils::Fs::fromNativePath(m_tempPath);
+    return Utils::Fs::toUniformPath(m_tempPath);
 }
 
 QString Session::torrentTempPath(const TorrentInfo &torrentInfo) const
@@ -2672,12 +2672,12 @@ void Session::setIPFilteringEnabled(const bool enabled)
 
 QString Session::IPFilterFile() const
 {
-    return Utils::Fs::fromNativePath(m_IPFilterFile);
+    return Utils::Fs::toUniformPath(m_IPFilterFile);
 }
 
 void Session::setIPFilterFile(QString path)
 {
-    path = Utils::Fs::fromNativePath(path);
+    path = Utils::Fs::toUniformPath(path);
     if (path != IPFilterFile()) {
         m_IPFilterFile = path;
         m_IPFilteringChanged = true;
@@ -4345,7 +4345,7 @@ namespace
         if (ec || (fast.type() != lt::bdecode_node::dict_t)) return false;
 
         torrentParams.savePath = Profile::instance().fromPortablePath(
-            Utils::Fs::fromNativePath(fromLTString(fast.dict_find_string_value("qBt-savePath"))));
+            Utils::Fs::toUniformPath(fromLTString(fast.dict_find_string_value("qBt-savePath"))));
 
         LTString ratioLimitString = fast.dict_find_string_value("qBt-ratioLimit");
         if (ratioLimitString.empty())

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -313,9 +313,9 @@ QString TorrentHandle::currentTracker() const
 QString TorrentHandle::savePath(bool actual) const
 {
     if (actual)
-        return Utils::Fs::fromNativePath(nativeActualSavePath());
+        return Utils::Fs::toUniformPath(nativeActualSavePath());
     else
-        return Utils::Fs::fromNativePath(m_savePath);
+        return Utils::Fs::toUniformPath(m_savePath);
 }
 
 QString TorrentHandle::rootPath(bool actual) const
@@ -1296,7 +1296,7 @@ void TorrentHandle::move(QString path)
     m_useAutoTMM = false;
     m_session->handleTorrentSavingModeChanged(this);
 
-    path = Utils::Fs::fromNativePath(path.trimmed());
+    path = Utils::Fs::toUniformPath(path.trimmed());
     if (path.isEmpty())
         path = m_session->defaultSavePath();
     if (!path.endsWith('/'))
@@ -1758,7 +1758,7 @@ void TorrentHandle::handleFileRenamedAlert(const lt::file_renamed_alert *p)
     // for example renaming "a/b/c" to "d/b/c", then folders "a/b" and "a" will
     // be removed if they are empty
     const QString oldFilePath = m_oldPath[LTFileIndex {p->index}].takeFirst();
-    const QString newFilePath = Utils::Fs::fromNativePath(p->new_name());
+    const QString newFilePath = Utils::Fs::toUniformPath(p->new_name());
 
     if (m_oldPath[LTFileIndex {p->index}].isEmpty())
         m_oldPath.remove(LTFileIndex {p->index});

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -227,7 +227,7 @@ int TorrentInfo::piecesCount() const
 QString TorrentInfo::filePath(const int index) const
 {
     if (!isValid()) return {};
-    return Utils::Fs::fromNativePath(
+    return Utils::Fs::toUniformPath(
                 QString::fromStdString(m_nativeInfo->files().file_path(LTFileIndex {index})));
 }
 
@@ -248,7 +248,7 @@ QString TorrentInfo::fileName(const int index) const
 QString TorrentInfo::origFilePath(const int index) const
 {
     if (!isValid()) return {};
-    return Utils::Fs::fromNativePath(
+    return Utils::Fs::toUniformPath(
                 QString::fromStdString(m_nativeInfo->orig_files().file_path(LTFileIndex {index})));
 }
 

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -303,12 +303,12 @@ void Preferences::setWinStartup(const bool b)
 // Downloads
 QString Preferences::lastLocationPath() const
 {
-    return Utils::Fs::fromNativePath(value("Preferences/Downloads/LastLocationPath").toString());
+    return Utils::Fs::toUniformPath(value("Preferences/Downloads/LastLocationPath").toString());
 }
 
 void Preferences::setLastLocationPath(const QString &path)
 {
-    setValue("Preferences/Downloads/LastLocationPath", Utils::Fs::fromNativePath(path));
+    setValue("Preferences/Downloads/LastLocationPath", Utils::Fs::toUniformPath(path));
 }
 
 QVariantHash Preferences::getScanDirs() const
@@ -324,12 +324,12 @@ void Preferences::setScanDirs(const QVariantHash &dirs)
 
 QString Preferences::getScanDirsLastPath() const
 {
-    return Utils::Fs::fromNativePath(value("Preferences/Downloads/ScanDirsLastPath").toString());
+    return Utils::Fs::toUniformPath(value("Preferences/Downloads/ScanDirsLastPath").toString());
 }
 
 void Preferences::setScanDirsLastPath(const QString &path)
 {
-    setValue("Preferences/Downloads/ScanDirsLastPath", Utils::Fs::fromNativePath(path));
+    setValue("Preferences/Downloads/ScanDirsLastPath", Utils::Fs::toUniformPath(path));
 }
 
 bool Preferences::isMailNotificationEnabled() const

--- a/src/base/rss/rss_autodownloadrule.cpp
+++ b/src/base/rss/rss_autodownloadrule.cpp
@@ -571,7 +571,7 @@ QString AutoDownloadRule::savePath() const
 
 void AutoDownloadRule::setSavePath(const QString &savePath)
 {
-    m_dataPtr->savePath = Utils::Fs::fromNativePath(savePath);
+    m_dataPtr->savePath = Utils::Fs::toUniformPath(savePath);
 }
 
 TriStateBool AutoDownloadRule::addPaused() const

--- a/src/base/rss/rss_feed.cpp
+++ b/src/base/rss/rss_feed.cpp
@@ -180,7 +180,7 @@ void Feed::handleMaxArticlesPerFeedChanged(const int n)
 void Feed::handleIconDownloadFinished(const Net::DownloadResult &result)
 {
     if (result.status == Net::DownloadStatus::Success) {
-        m_iconPath = Utils::Fs::fromNativePath(result.filePath);
+        m_iconPath = Utils::Fs::toUniformPath(result.filePath);
         emit iconLoaded(this);
     }
 }

--- a/src/base/scanfoldersmodel.cpp
+++ b/src/base/scanfoldersmodel.cpp
@@ -329,9 +329,9 @@ void ScanFoldersModel::makePersistent()
 
     for (const PathData *pathData : asConst(m_pathList)) {
         if (pathData->downloadType == CUSTOM_LOCATION)
-            dirs.insert(Utils::Fs::fromNativePath(pathData->watchPath), Utils::Fs::fromNativePath(pathData->downloadPath));
+            dirs.insert(Utils::Fs::toUniformPath(pathData->watchPath), Utils::Fs::toUniformPath(pathData->downloadPath));
         else
-            dirs.insert(Utils::Fs::fromNativePath(pathData->watchPath), pathData->downloadType);
+            dirs.insert(Utils::Fs::toUniformPath(pathData->watchPath), pathData->downloadType);
     }
 
     Preferences::instance()->setScanDirs(dirs);

--- a/src/base/search/searchpluginmanager.cpp
+++ b/src/base/search/searchpluginmanager.cpp
@@ -368,7 +368,7 @@ void SearchPluginManager::versionInfoDownloadFinished(const Net::DownloadResult 
 void SearchPluginManager::pluginDownloadFinished(const Net::DownloadResult &result)
 {
     if (result.status == Net::DownloadStatus::Success) {
-        const QString filePath = Utils::Fs::fromNativePath(result.filePath);
+        const QString filePath = Utils::Fs::toUniformPath(result.filePath);
 
         QString pluginName = Utils::Fs::fileName(result.url);
         pluginName.chop(pluginName.size() - pluginName.lastIndexOf('.')); // Remove extension

--- a/src/base/utils/fs.cpp
+++ b/src/base/utils/fs.cpp
@@ -60,17 +60,12 @@
 #include "base/bittorrent/torrenthandle.h"
 #include "base/global.h"
 
-/**
- * Converts a path to a string suitable for display.
- * This function makes sure the directory separator used is consistent
- * with the OS being run.
- */
 QString Utils::Fs::toNativePath(const QString &path)
 {
     return QDir::toNativeSeparators(path);
 }
 
-QString Utils::Fs::fromNativePath(const QString &path)
+QString Utils::Fs::toUniformPath(const QString &path)
 {
     return QDir::fromNativeSeparators(path);
 }
@@ -87,7 +82,7 @@ QString Utils::Fs::fileExtension(const QString &filename)
 
 QString Utils::Fs::fileName(const QString &filePath)
 {
-    const QString path = fromNativePath(filePath);
+    const QString path = toUniformPath(filePath);
     const int slashIndex = path.lastIndexOf('/');
     if (slashIndex == -1)
         return path;
@@ -96,7 +91,7 @@ QString Utils::Fs::fileName(const QString &filePath)
 
 QString Utils::Fs::folderName(const QString &filePath)
 {
-    const QString path = fromNativePath(filePath);
+    const QString path = toUniformPath(filePath);
     const int slashIndex = path.lastIndexOf('/');
     if (slashIndex == -1)
         return path;
@@ -248,7 +243,7 @@ qint64 Utils::Fs::freeDiskSpaceOnPath(const QString &path)
 
 QString Utils::Fs::branchPath(const QString &filePath, QString *removed)
 {
-    QString ret = fromNativePath(filePath);
+    QString ret = toUniformPath(filePath);
     if (ret.endsWith('/'))
         ret.chop(1);
     const int slashIndex = ret.lastIndexOf('/');

--- a/src/base/utils/fs.h
+++ b/src/base/utils/fs.h
@@ -39,8 +39,20 @@ namespace Utils
 {
     namespace Fs
     {
+        /**
+         * Converts a path to a string suitable for display.
+         * This function makes sure the directory separator used is consistent
+         * with the OS being run.
+         */
         QString toNativePath(const QString &path);
-        QString fromNativePath(const QString &path);
+        /**
+         * Converts a path to a string suitable for processing.
+         * This function makes sure the directory separator used is independent
+         * from the OS being run so it is the same on all supported platforms.
+         * Slash ('/') is used as "uniform" directory separator.
+         */
+        QString toUniformPath(const QString &path);
+
         QString fileExtension(const QString &filename);
         QString fileName(const QString &filePath);
         QString folderName(const QString &filePath);

--- a/src/gui/fspathedit.cpp
+++ b/src/gui/fspathedit.cpp
@@ -201,7 +201,7 @@ FileSystemPathEdit::~FileSystemPathEdit()
 
 QString FileSystemPathEdit::selectedPath() const
 {
-    return Utils::Fs::fromNativePath(editWidgetText());
+    return Utils::Fs::toUniformPath(editWidgetText());
 }
 
 void FileSystemPathEdit::setSelectedPath(const QString &val)
@@ -347,7 +347,7 @@ int FileSystemPathComboEdit::count() const
 
 QString FileSystemPathComboEdit::item(int index) const
 {
-    return Utils::Fs::fromNativePath(editWidget<WidgetType>()->itemText(index));
+    return Utils::Fs::toUniformPath(editWidget<WidgetType>()->itemText(index));
 }
 
 void FileSystemPathComboEdit::addItem(const QString &text)

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1368,9 +1368,9 @@ void MainWindow::on_actionOpen_triggered()
         }
 
         // Save last dir to remember it
-        QStringList topDir = Utils::Fs::fromNativePath(pathsList.at(0)).split('/');
+        QStringList topDir = Utils::Fs::toUniformPath(pathsList.at(0)).split('/');
         topDir.removeLast();
-        pref->setMainLastDir(Utils::Fs::fromNativePath(topDir.join('/')));
+        pref->setMainLastDir(Utils::Fs::toUniformPath(topDir.join('/')));
     }
 }
 

--- a/src/gui/search/pluginselectdialog.cpp
+++ b/src/gui/search/pluginselectdialog.cpp
@@ -373,7 +373,7 @@ void PluginSelectDialog::iconDownloadFinished(const Net::DownloadResult &result)
         return;
     }
 
-    const QString filePath = Utils::Fs::fromNativePath(result.filePath);
+    const QString filePath = Utils::Fs::toUniformPath(result.filePath);
 
     // Icon downloaded
     QIcon icon(filePath);

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -469,7 +469,7 @@ void TorrentContentModel::setupModelData(const BitTorrent::TorrentInfo &info)
     // Iterate over files
     for (int i = 0; i < filesCount; ++i) {
         currentParent = m_rootItem;
-        QString path = Utils::Fs::fromNativePath(info.filePath(i));
+        QString path = Utils::Fs::toUniformPath(info.filePath(i));
         // Iterate of parts of the path to create necessary folders
         QStringList pathFolders = path.split('/', QString::SkipEmptyParts);
         pathFolders.removeLast();

--- a/src/gui/torrentcreatordialog.cpp
+++ b/src/gui/torrentcreatordialog.cpp
@@ -139,7 +139,7 @@ void TorrentCreatorDialog::dragEnterEvent(QDragEnterEvent *event)
 // Main function that create a .torrent file
 void TorrentCreatorDialog::onCreateButtonClicked()
 {
-    QString input = Utils::Fs::fromNativePath(m_ui->textInputPath->text()).trimmed();
+    QString input = Utils::Fs::toUniformPath(m_ui->textInputPath->text()).trimmed();
 
     // test if readable
     const QFileInfo fi(input);

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -154,7 +154,7 @@ QPoint Utils::Gui::screenCenter(const QWidget *w)
 // Open the given path with an appropriate application
 void Utils::Gui::openPath(const QString &absolutePath)
 {
-    const QString path = Utils::Fs::fromNativePath(absolutePath);
+    const QString path = Utils::Fs::toUniformPath(absolutePath);
     // Hack to access samba shares with QDesktopServices::openUrl
     if (path.startsWith("//"))
         QDesktopServices::openUrl(Utils::Fs::toNativePath("file:" + path));
@@ -166,7 +166,7 @@ void Utils::Gui::openPath(const QString &absolutePath)
 // (if possible) the item at the given path
 void Utils::Gui::openFolderSelect(const QString &absolutePath)
 {
-    const QString path = Utils::Fs::fromNativePath(absolutePath);
+    const QString path = Utils::Fs::toUniformPath(absolutePath);
     // If the item to select doesn't exist, try to open its parent
     if (!QFileInfo::exists(path)) {
         openPath(path.left(path.lastIndexOf('/')));

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -308,13 +308,13 @@ void AppController::setPreferencesAction()
         QVariantHash scanDirs;
         ScanFoldersModel *model = ScanFoldersModel::instance();
         for (auto i = nativeDirs.cbegin(); i != nativeDirs.cend(); ++i) {
-            QString folder = Utils::Fs::fromNativePath(i.key());
+            QString folder = Utils::Fs::toUniformPath(i.key());
             int downloadType;
             QString downloadPath;
             ScanFoldersModel::PathStatus ec;
             if (i.value().type() == QVariant::String) {
                 downloadType = ScanFoldersModel::CUSTOM_LOCATION;
-                downloadPath = Utils::Fs::fromNativePath(i.value().toString());
+                downloadPath = Utils::Fs::toUniformPath(i.value().toString());
             }
             else {
                 downloadType = i.value().toInt();


### PR DESCRIPTION
Unlike "toNativePath" which name clearly reflects the function result "fromNativePath" has no such clear meaning. Since this function converts path into uniform format "toUniformPath" is better name.