### PR TITLE
Use correct format specifier for new typing

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1539,7 +1539,7 @@ void Session::processShareLimits()
                     seedingTimeLimit = globalMaxSeedingMinutes();
 
                 if (seedingTimeLimit >= 0) {
-                    qDebug("Seeding Time: %d (limit: %d)", seedingTimeInMinutes, seedingTimeLimit);
+                    qDebug("Seeding Time: %lld (limit: %d)", seedingTimeInMinutes, seedingTimeLimit);
 
                     if ((seedingTimeInMinutes <= TorrentHandle::MAX_SEEDING_TIME) && (seedingTimeInMinutes >= seedingTimeLimit)) {
                         Logger *const logger = Logger::instance();


### PR DESCRIPTION
qlonglong is a long long int, so use lld for seedingTimeInMinutes in our print