### PR TITLE
Fix WebUI encoding of special characters

### DIFF
--- a/src/webui/www/private/rename.html
+++ b/src/webui/www/private/rename.html
@@ -33,7 +33,7 @@
             var name = new URI().getData('name');
             // set text field to current value
             if (name)
-                $('rename').value = escapeHtml(decodeURIComponent(name));
+                $('rename').value = decodeURIComponent(name);
 
             $('rename').focus();
             $('renameButton').addEvent('click', function(e) {


### PR DESCRIPTION
Special characters would get html encoded (`&` -> `&amp;`). This has been tested against several payloads (e.g. `<script>alert(0)</script>`) to ensure it's not vulnerable to XSS.

Closes #10837 

If #10006 is backported to v4.1 then this should be as well.