### PR TITLE
Update remaining size of ignored files to 0

### DIFF
--- a/src/gui/torrentcontentmodelitem.cpp
+++ b/src/gui/torrentcontentmodelitem.cpp
@@ -76,7 +76,7 @@ qreal TorrentContentModelItem::progress() const
 qulonglong TorrentContentModelItem::remaining() const
 {
     Q_ASSERT(!isRootItem());
-    return m_remaining;
+    return (m_priority == BitTorrent::DownloadPriority::Ignored) ? 0 : m_remaining;
 }
 
 qreal TorrentContentModelItem::availability() const


### PR DESCRIPTION
Ignored folders have a remaining size of 0; ignored files should as well. Also fixes a bug with calculating the remaining size of ignored folders.