### PR TITLE
Right click menu improvements

### DIFF
--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -478,8 +478,7 @@ void AddNewTorrentDialog::displayContentTreeMenu(const QPoint &)
         menu->addSeparator();
     }
 
-    QMenu *subMenu = new QMenu(menu);
-    subMenu->setTitle(tr("Priority"));
+    QMenu *subMenu = menu->addMenu(tr("Priority"));
 
     connect(m_ui->actionNotDownloaded, &QAction::triggered, subMenu, [applyPriorities]()
     {
@@ -504,8 +503,6 @@ void AddNewTorrentDialog::displayContentTreeMenu(const QPoint &)
         applyPriorities(BitTorrent::DownloadPriority::Maximum);
     });
     subMenu->addAction(m_ui->actionMaximum);
-
-    menu->addMenu(subMenu);
 
     menu->popup(QCursor::pos());
 }

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -528,21 +528,17 @@ void MainWindow::addToolbarContextMenu()
     m_ui->toolBar->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(m_ui->toolBar, &QWidget::customContextMenuRequested, this, &MainWindow::toolbarMenuRequested);
 
-    QAction *iconsOnly = new QAction(tr("Icons Only"), m_toolbarMenu);
+    QAction *iconsOnly = m_toolbarMenu->addAction(tr("Icons Only"));
     connect(iconsOnly, &QAction::triggered, this, &MainWindow::toolbarIconsOnly);
-    QAction *textOnly = new QAction(tr("Text Only"), m_toolbarMenu);
+    QAction *textOnly = m_toolbarMenu->addAction(tr("Text Only"));
     connect(textOnly, &QAction::triggered, this, &MainWindow::toolbarTextOnly);
-    QAction *textBesideIcons = new QAction(tr("Text Alongside Icons"), m_toolbarMenu);
+    QAction *textBesideIcons =  m_toolbarMenu->addAction(tr("Text Alongside Icons"));
     connect(textBesideIcons, &QAction::triggered, this, &MainWindow::toolbarTextBeside);
-    QAction *textUnderIcons = new QAction(tr("Text Under Icons"), m_toolbarMenu);
+    QAction *textUnderIcons = m_toolbarMenu->addAction(tr("Text Under Icons"));
     connect(textUnderIcons, &QAction::triggered, this, &MainWindow::toolbarTextUnder);
-    QAction *followSystemStyle = new QAction(tr("Follow System Style"), m_toolbarMenu);
+    QAction *followSystemStyle = m_toolbarMenu->addAction(tr("Follow System Style"));
     connect(followSystemStyle, &QAction::triggered, this, &MainWindow::toolbarFollowSystem);
-    m_toolbarMenu->addAction(iconsOnly);
-    m_toolbarMenu->addAction(textOnly);
-    m_toolbarMenu->addAction(textBesideIcons);
-    m_toolbarMenu->addAction(textUnderIcons);
-    m_toolbarMenu->addAction(followSystemStyle);
+
     auto *textPositionGroup = new QActionGroup(m_toolbarMenu);
     textPositionGroup->addAction(iconsOnly);
     iconsOnly->setCheckable(true);
@@ -693,11 +689,9 @@ void MainWindow::showFilterContextMenu(const QPoint &)
     menu->setAttribute(Qt::WA_DeleteOnClose);
     menu->addSeparator();
 
-    QAction *useRegexAct = new QAction(tr("Use regular expressions"), menu);
+    QAction *useRegexAct = menu->addAction(tr("Use regular expressions"));
     useRegexAct->setCheckable(true);
     useRegexAct->setChecked(pref->getRegexAsFilteringPatternForTransferList());
-    menu->addAction(useRegexAct);
-
     connect(useRegexAct, &QAction::toggled, pref, &Preferences::setRegexAsFilteringPatternForTransferList);
     connect(useRegexAct, &QAction::toggled, this, [this]() { m_transferListWidget->applyNameFilter(m_searchFilter->text()); });
 

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -600,10 +600,8 @@ void PropertiesWidget::displayFilesListMenu(const QPoint &)
         menu->addSeparator();
     }
 
-    QMenu *subMenu = new QMenu(menu);
-
     if (!m_torrent->isSeed()) {
-        subMenu->setTitle(tr("Priority"));
+        QMenu *subMenu = menu->addMenu(tr("Priority"));
 
         const auto applyPriorities = [this, selectedRows](const BitTorrent::DownloadPriority prio)
         {
@@ -639,8 +637,6 @@ void PropertiesWidget::displayFilesListMenu(const QPoint &)
             applyPriorities(BitTorrent::DownloadPriority::Maximum);
         });
         subMenu->addAction(m_ui->actionMaximum);
-
-        menu->addMenu(subMenu);
     }
 
     // The selected torrent might have disappeared during exec()

--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -361,11 +361,9 @@ void SearchJobWidget::showFilterContextMenu(const QPoint &)
     menu->setAttribute(Qt::WA_DeleteOnClose);
     menu->addSeparator();
 
-    QAction *useRegexAct = new QAction(tr("Use regular expressions"), menu);
+    QAction *useRegexAct = menu->addAction(tr("Use regular expressions"));
     useRegexAct->setCheckable(true);
     useRegexAct->setChecked(pref->getRegexAsFilteringPatternForSearchJob());
-    menu->addAction(useRegexAct);
-
     connect(useRegexAct, &QAction::toggled, pref, &Preferences::setRegexAsFilteringPatternForSearchJob);
     connect(useRegexAct, &QAction::toggled, this, [this]() { filterSearchResults(m_lineEditSearchResultsFilter->text()); });
 

--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -370,6 +370,28 @@ void SearchJobWidget::showFilterContextMenu(const QPoint &)
     menu->popup(QCursor::pos());
 }
 
+void SearchJobWidget::contextMenuEvent(QContextMenuEvent *event)
+{
+    auto *menu = new QMenu(this);
+    menu->setAttribute(Qt::WA_DeleteOnClose);
+
+    const QAction *downloadAction = menu->addAction(
+        GuiIconProvider::instance()->getIcon("download"), tr("Download"));
+    connect(downloadAction, &QAction::triggered, this, &SearchJobWidget::downloadTorrents);
+
+    menu->addSeparator();
+
+    const QAction *openDescriptionAction = menu->addAction(
+        GuiIconProvider::instance()->getIcon("application-x-mswinurl"), tr("Go to description page"));
+    connect(openDescriptionAction, &QAction::triggered, this, &SearchJobWidget::openTorrentPages);
+
+    const QAction *copyDescriptionAction = menu->addAction(
+        GuiIconProvider::instance()->getIcon("edit-copy"), tr("Copy description page URL"));
+    connect(copyDescriptionAction, &QAction::triggered, this, &SearchJobWidget::copyTorrentURLs);
+
+    menu->popup(event->globalPos());
+}
+
 QString SearchJobWidget::statusText(SearchJobWidget::Status st)
 {
     switch (st) {

--- a/src/gui/search/searchjobwidget.h
+++ b/src/gui/search/searchjobwidget.h
@@ -99,6 +99,7 @@ private:
     void updateFilter();
     void filterSearchResults(const QString &name);
     void showFilterContextMenu(const QPoint &);
+    void contextMenuEvent(QContextMenuEvent *event) override;
     void displayToggleColumnsMenu(const QPoint &);
     void onItemDoubleClicked(const QModelIndex &index);
     void searchFinished(bool cancelled);

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -691,7 +691,7 @@ void TransferListWidget::setMaxRatioSelectedTorrents()
     auto dialog = new UpDownRatioDialog(useGlobalValue, currentMaxRatio, BitTorrent::TorrentHandle::MAX_RATIO,
                        currentMaxSeedingTime, BitTorrent::TorrentHandle::MAX_SEEDING_TIME, this);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
-    connect(dialog, &QDialog::accepted, this, [this, dialog, torrents]()
+    connect(dialog, &QDialog::accepted, this, [dialog, torrents]()
     {
         for (BitTorrent::TorrentHandle *const torrent : torrents) {
             const qreal ratio = (dialog->useDefault()

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -894,57 +894,60 @@ void TransferListWidget::displayListMenu(const QPoint &)
     const QModelIndexList selectedIndexes = selectionModel()->selectedRows();
     if (selectedIndexes.isEmpty()) return;
 
+    QMenu *listMenu = new QMenu(this);
+    listMenu->setAttribute(Qt::WA_DeleteOnClose);
+
     // Create actions
-    QAction *actionStart = new QAction(GuiIconProvider::instance()->getIcon("media-playback-start"), tr("Resume", "Resume/start the torrent"), this);
+    QAction *actionStart = new QAction(GuiIconProvider::instance()->getIcon("media-playback-start"), tr("Resume", "Resume/start the torrent"), listMenu);
     connect(actionStart, &QAction::triggered, this, &TransferListWidget::startSelectedTorrents);
-    QAction *actionPause = new QAction(GuiIconProvider::instance()->getIcon("media-playback-pause"), tr("Pause", "Pause the torrent"), this);
+    QAction *actionPause = new QAction(GuiIconProvider::instance()->getIcon("media-playback-pause"), tr("Pause", "Pause the torrent"), listMenu);
     connect(actionPause, &QAction::triggered, this, &TransferListWidget::pauseSelectedTorrents);
-    QAction *actionForceStart = new QAction(GuiIconProvider::instance()->getIcon("media-seek-forward"), tr("Force Resume", "Force Resume/start the torrent"), this);
+    QAction *actionForceStart = new QAction(GuiIconProvider::instance()->getIcon("media-seek-forward"), tr("Force Resume", "Force Resume/start the torrent"), listMenu);
     connect(actionForceStart, &QAction::triggered, this, &TransferListWidget::forceStartSelectedTorrents);
-    QAction *actionDelete = new QAction(GuiIconProvider::instance()->getIcon("edit-delete"), tr("Delete", "Delete the torrent"), this);
+    QAction *actionDelete = new QAction(GuiIconProvider::instance()->getIcon("edit-delete"), tr("Delete", "Delete the torrent"), listMenu);
     connect(actionDelete, &QAction::triggered, this, &TransferListWidget::softDeleteSelectedTorrents);
-    QAction *actionPreviewFile = new QAction(GuiIconProvider::instance()->getIcon("view-preview"), tr("Preview file..."), this);
+    QAction *actionPreviewFile = new QAction(GuiIconProvider::instance()->getIcon("view-preview"), tr("Preview file..."), listMenu);
     connect(actionPreviewFile, &QAction::triggered, this, &TransferListWidget::previewSelectedTorrents);
-    QAction *actionSetMaxRatio = new QAction(QIcon(QLatin1String(":/icons/skin/ratio.svg")), tr("Limit share ratio..."), this);
+    QAction *actionSetMaxRatio = new QAction(QIcon(QLatin1String(":/icons/skin/ratio.svg")), tr("Limit share ratio..."), listMenu);
     connect(actionSetMaxRatio, &QAction::triggered, this, &TransferListWidget::setMaxRatioSelectedTorrents);
-    QAction *actionSetUploadLimit = new QAction(GuiIconProvider::instance()->getIcon("kt-set-max-upload-speed"), tr("Limit upload rate..."), this);
+    QAction *actionSetUploadLimit = new QAction(GuiIconProvider::instance()->getIcon("kt-set-max-upload-speed"), tr("Limit upload rate..."), listMenu);
     connect(actionSetUploadLimit, &QAction::triggered, this, &TransferListWidget::setUpLimitSelectedTorrents);
-    QAction *actionSetDownloadLimit = new QAction(GuiIconProvider::instance()->getIcon("kt-set-max-download-speed"), tr("Limit download rate..."), this);
+    QAction *actionSetDownloadLimit = new QAction(GuiIconProvider::instance()->getIcon("kt-set-max-download-speed"), tr("Limit download rate..."), listMenu);
     connect(actionSetDownloadLimit, &QAction::triggered, this, &TransferListWidget::setDlLimitSelectedTorrents);
-    QAction *actionOpenDestinationFolder = new QAction(GuiIconProvider::instance()->getIcon("inode-directory"), tr("Open destination folder"), this);
+    QAction *actionOpenDestinationFolder = new QAction(GuiIconProvider::instance()->getIcon("inode-directory"), tr("Open destination folder"), listMenu);
     connect(actionOpenDestinationFolder, &QAction::triggered, this, &TransferListWidget::openSelectedTorrentsFolder);
-    QAction *actionIncreasePriority = new QAction(GuiIconProvider::instance()->getIcon("go-up"), tr("Move up", "i.e. move up in the queue"), this);
+    QAction *actionIncreasePriority = new QAction(GuiIconProvider::instance()->getIcon("go-up"), tr("Move up", "i.e. move up in the queue"), listMenu);
     connect(actionIncreasePriority, &QAction::triggered, this, &TransferListWidget::increasePrioSelectedTorrents);
-    QAction *actionDecreasePriority = new QAction(GuiIconProvider::instance()->getIcon("go-down"), tr("Move down", "i.e. Move down in the queue"), this);
+    QAction *actionDecreasePriority = new QAction(GuiIconProvider::instance()->getIcon("go-down"), tr("Move down", "i.e. Move down in the queue"), listMenu);
     connect(actionDecreasePriority, &QAction::triggered, this, &TransferListWidget::decreasePrioSelectedTorrents);
-    QAction *actionTopPriority = new QAction(GuiIconProvider::instance()->getIcon("go-top"), tr("Move to top", "i.e. Move to top of the queue"), this);
+    QAction *actionTopPriority = new QAction(GuiIconProvider::instance()->getIcon("go-top"), tr("Move to top", "i.e. Move to top of the queue"), listMenu);
     connect(actionTopPriority, &QAction::triggered, this, &TransferListWidget::topPrioSelectedTorrents);
-    QAction *actionBottomPriority = new QAction(GuiIconProvider::instance()->getIcon("go-bottom"), tr("Move to bottom", "i.e. Move to bottom of the queue"), this);
+    QAction *actionBottomPriority = new QAction(GuiIconProvider::instance()->getIcon("go-bottom"), tr("Move to bottom", "i.e. Move to bottom of the queue"), listMenu);
     connect(actionBottomPriority, &QAction::triggered, this, &TransferListWidget::bottomPrioSelectedTorrents);
-    QAction *actionSetTorrentPath = new QAction(GuiIconProvider::instance()->getIcon("inode-directory"), tr("Set location..."), this);
+    QAction *actionSetTorrentPath = new QAction(GuiIconProvider::instance()->getIcon("inode-directory"), tr("Set location..."), listMenu);
     connect(actionSetTorrentPath, &QAction::triggered, this, &TransferListWidget::setSelectedTorrentsLocation);
-    QAction *actionForceRecheck = new QAction(GuiIconProvider::instance()->getIcon("document-edit-verify"), tr("Force recheck"), this);
+    QAction *actionForceRecheck = new QAction(GuiIconProvider::instance()->getIcon("document-edit-verify"), tr("Force recheck"), listMenu);
     connect(actionForceRecheck, &QAction::triggered, this, &TransferListWidget::recheckSelectedTorrents);
-    QAction *actionForceReannounce = new QAction(GuiIconProvider::instance()->getIcon("document-edit-verify"), tr("Force reannounce"), this);
+    QAction *actionForceReannounce = new QAction(GuiIconProvider::instance()->getIcon("document-edit-verify"), tr("Force reannounce"), listMenu);
     connect(actionForceReannounce, &QAction::triggered, this, &TransferListWidget::reannounceSelectedTorrents);
-    QAction *actionCopyMagnetLink = new QAction(GuiIconProvider::instance()->getIcon("kt-magnet"), tr("Magnet link"), this);
+    QAction *actionCopyMagnetLink = new QAction(GuiIconProvider::instance()->getIcon("kt-magnet"), tr("Magnet link"), listMenu);
     connect(actionCopyMagnetLink, &QAction::triggered, this, &TransferListWidget::copySelectedMagnetURIs);
-    QAction *actionCopyName = new QAction(GuiIconProvider::instance()->getIcon("edit-copy"), tr("Name"), this);
+    QAction *actionCopyName = new QAction(GuiIconProvider::instance()->getIcon("edit-copy"), tr("Name"), listMenu);
     connect(actionCopyName, &QAction::triggered, this, &TransferListWidget::copySelectedNames);
-    QAction *actionCopyHash = new QAction(GuiIconProvider::instance()->getIcon("edit-copy"), tr("Hash"), this);
+    QAction *actionCopyHash = new QAction(GuiIconProvider::instance()->getIcon("edit-copy"), tr("Hash"), listMenu);
     connect(actionCopyHash, &QAction::triggered, this, &TransferListWidget::copySelectedHashes);
-    QAction *actionSuperSeedingMode = new QAction(tr("Super seeding mode"), this);
+    QAction *actionSuperSeedingMode = new QAction(tr("Super seeding mode"), listMenu);
     actionSuperSeedingMode->setCheckable(true);
     connect(actionSuperSeedingMode, &QAction::triggered, this, &TransferListWidget::toggleSelectedTorrentsSuperSeeding);
-    QAction *actionRename = new QAction(GuiIconProvider::instance()->getIcon("edit-rename"), tr("Rename..."), this);
+    QAction *actionRename = new QAction(GuiIconProvider::instance()->getIcon("edit-rename"), tr("Rename..."), listMenu);
     connect(actionRename, &QAction::triggered, this, &TransferListWidget::renameSelectedTorrent);
-    QAction *actionSequentialDownload = new QAction(tr("Download in sequential order"), this);
+    QAction *actionSequentialDownload = new QAction(tr("Download in sequential order"), listMenu);
     actionSequentialDownload->setCheckable(true);
     connect(actionSequentialDownload, &QAction::triggered, this, &TransferListWidget::toggleSelectedTorrentsSequentialDownload);
-    QAction *actionFirstLastPiecePrio = new QAction(tr("Download first and last pieces first"), this);
+    QAction *actionFirstLastPiecePrio = new QAction(tr("Download first and last pieces first"), listMenu);
     actionFirstLastPiecePrio->setCheckable(true);
     connect(actionFirstLastPiecePrio, &QAction::triggered, this, &TransferListWidget::toggleSelectedFirstLastPiecePrio);
-    QAction *actionAutoTMM = new QAction(tr("Automatic Torrent Management"), this);
+    QAction *actionAutoTMM = new QAction(tr("Automatic Torrent Management"), listMenu);
     actionAutoTMM->setCheckable(true);
     actionAutoTMM->setToolTip(tr("Automatic mode means that various torrent properties(eg save path) will be decided by the associated category"));
     connect(actionAutoTMM, &QAction::triggered, this, &TransferListWidget::setSelectedAutoTMMEnabled);
@@ -1030,9 +1033,6 @@ void TransferListWidget::displayListMenu(const QPoint &)
             break;
         }
     }
-
-    QMenu *listMenu = new QMenu(this);
-    listMenu->setAttribute(Qt::WA_DeleteOnClose);
 
     if (needsStart)
         listMenu->addAction(actionStart);

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -889,7 +889,7 @@ void TransferListWidget::clearSelectionTags()
     applyToSelectedTorrents([](BitTorrent::TorrentHandle *const torrent) { torrent->removeAllTags(); });
 }
 
-void TransferListWidget::displayListMenu(const QPoint&)
+void TransferListWidget::displayListMenu(const QPoint &)
 {
     const QModelIndexList selectedIndexes = selectionModel()->selectedRows();
     if (selectedIndexes.isEmpty()) return;
@@ -927,11 +927,11 @@ void TransferListWidget::displayListMenu(const QPoint&)
     connect(actionForceRecheck, &QAction::triggered, this, &TransferListWidget::recheckSelectedTorrents);
     QAction *actionForceReannounce = new QAction(GuiIconProvider::instance()->getIcon("document-edit-verify"), tr("Force reannounce"), this);
     connect(actionForceReannounce, &QAction::triggered, this, &TransferListWidget::reannounceSelectedTorrents);
-    QAction *actionCopyMagnetLink = new QAction(GuiIconProvider::instance()->getIcon("kt-magnet"), tr("Copy magnet link"), this);
+    QAction *actionCopyMagnetLink = new QAction(GuiIconProvider::instance()->getIcon("kt-magnet"), tr("Magnet link"), this);
     connect(actionCopyMagnetLink, &QAction::triggered, this, &TransferListWidget::copySelectedMagnetURIs);
-    QAction *actionCopyName = new QAction(GuiIconProvider::instance()->getIcon("edit-copy"), tr("Copy name"), this);
+    QAction *actionCopyName = new QAction(GuiIconProvider::instance()->getIcon("edit-copy"), tr("Name"), this);
     connect(actionCopyName, &QAction::triggered, this, &TransferListWidget::copySelectedNames);
-    QAction *actionCopyHash = new QAction(GuiIconProvider::instance()->getIcon("edit-copy"), tr("Copy hash"), this);
+    QAction *actionCopyHash = new QAction(GuiIconProvider::instance()->getIcon("edit-copy"), tr("Hash"), this);
     connect(actionCopyHash, &QAction::triggered, this, &TransferListWidget::copySelectedHashes);
     QAction *actionSuperSeedingMode = new QAction(tr("Super seeding mode"), this);
     actionSuperSeedingMode->setCheckable(true);
@@ -1160,10 +1160,12 @@ void TransferListWidget::displayListMenu(const QPoint&)
         prioMenu->addAction(actionDecreasePriority);
         prioMenu->addAction(actionBottomPriority);
     }
-    listMenu->addSeparator();
-    listMenu->addAction(actionCopyName);
-    listMenu->addAction(actionCopyHash);
-    listMenu->addAction(actionCopyMagnetLink);
+
+    QMenu *copySubMenu = listMenu->addMenu(
+        GuiIconProvider::instance()->getIcon("edit-copy"), tr("Copy"));
+    copySubMenu->addAction(actionCopyName);
+    copySubMenu->addAction(actionCopyHash);
+    copySubMenu->addAction(actionCopyMagnetLink);
 
     listMenu->popup(QCursor::pos());
 }

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -103,7 +103,7 @@ protected:
 
 protected slots:
     void torrentDoubleClicked();
-    void displayListMenu(const QPoint&);
+    void displayListMenu(const QPoint &);
     void currentChanged(const QModelIndex &current, const QModelIndex&) override;
     void toggleSelectedTorrentsSuperSeeding() const;
     void toggleSelectedTorrentsSequentialDownload() const;


### PR DESCRIPTION
* Move copy actions under a submenu
  ![pic1](https://user-images.githubusercontent.com/9395168/60062325-58294b80-972b-11e9-9241-9cb83c2ba069.png)
* Avoid allocating a new menu/action manually
* Properly deallocate actions when menu closed 
* Add right click menu to SearchJobWidget
  ![pic2](https://user-images.githubusercontent.com/9395168/60062326-58294b80-972b-11e9-9b35-2500d0ea28be.png)
* Remove unused lambda capture

