### PR TITLE
Improvements to search widget

### DIFF
--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -217,7 +217,7 @@ void SearchJobWidget::downloadTorrents()
         downloadTorrent(rowIndex);
 }
 
-void SearchJobWidget::openTorrentPages()
+void SearchJobWidget::openTorrentPages() const
 {
     const QModelIndexList rows {m_ui->resultsBrowser->selectionModel()->selectedRows()};
     for (const QModelIndex &rowIndex : rows) {
@@ -228,21 +228,35 @@ void SearchJobWidget::openTorrentPages()
     }
 }
 
-void SearchJobWidget::copyTorrentURLs()
+void SearchJobWidget::copyTorrentURLs() const
+{
+    copyField(SearchSortModel::DESC_LINK);
+}
+
+void SearchJobWidget::copyTorrentDownloadLinks() const
+{
+    copyField(SearchSortModel::DL_LINK);
+}
+
+void SearchJobWidget::copyTorrentNames() const
+{
+    copyField(SearchSortModel::NAME);
+}
+
+void SearchJobWidget::copyField(const int column) const
 {
     const QModelIndexList rows {m_ui->resultsBrowser->selectionModel()->selectedRows()};
-    QStringList urls;
+    QStringList list;
+
     for (const QModelIndex &rowIndex : rows) {
-        const QString descrLink = m_proxyModel->data(
-                    m_proxyModel->index(rowIndex.row(), SearchSortModel::DESC_LINK)).toString();
-        if (!descrLink.isEmpty())
-            urls << descrLink;
+        const QString field = m_proxyModel->data(
+            m_proxyModel->index(rowIndex.row(), column)).toString();
+        if (!field.isEmpty())
+            list << field;
     }
 
-    if (!urls.empty()) {
-        QClipboard *clipboard = QApplication::clipboard();
-        clipboard->setText(urls.join('\n'));
-    }
+    if (!list.empty())
+        QApplication::clipboard()->setText(list.join('\n'));
 }
 
 void SearchJobWidget::setStatus(Status value)
@@ -385,8 +399,20 @@ void SearchJobWidget::contextMenuEvent(QContextMenuEvent *event)
         GuiIconProvider::instance()->getIcon("application-x-mswinurl"), tr("Open description page"));
     connect(openDescriptionAction, &QAction::triggered, this, &SearchJobWidget::openTorrentPages);
 
-    const QAction *copyDescriptionAction = menu->addAction(
-        GuiIconProvider::instance()->getIcon("edit-copy"), tr("Copy description page URL"));
+    QMenu *copySubMenu = menu->addMenu(
+        GuiIconProvider::instance()->getIcon("edit-copy"), tr("Copy"));
+
+    const QAction *copyNamesAction = copySubMenu->addAction(
+        GuiIconProvider::instance()->getIcon("edit-copy"), tr("Name"));
+    connect(copyNamesAction, &QAction::triggered, this, &SearchJobWidget::copyTorrentNames);
+
+    const QAction *copyDownloadLinkAction = copySubMenu->addAction(
+        GuiIconProvider::instance()->getIcon("edit-copy"), tr("Download link"));
+    connect(copyDownloadLinkAction, &QAction::triggered
+        , this, &SearchJobWidget::copyTorrentDownloadLinks);
+
+    const QAction *copyDescriptionAction = copySubMenu->addAction(
+        GuiIconProvider::instance()->getIcon("edit-copy"), tr("Description page URL"));
     connect(copyDescriptionAction, &QAction::triggered, this, &SearchJobWidget::copyTorrentURLs);
 
     menu->popup(event->globalPos());

--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -382,7 +382,7 @@ void SearchJobWidget::contextMenuEvent(QContextMenuEvent *event)
     menu->addSeparator();
 
     const QAction *openDescriptionAction = menu->addAction(
-        GuiIconProvider::instance()->getIcon("application-x-mswinurl"), tr("Go to description page"));
+        GuiIconProvider::instance()->getIcon("application-x-mswinurl"), tr("Open description page"));
     connect(openDescriptionAction, &QAction::triggered, this, &SearchJobWidget::openTorrentPages);
 
     const QAction *copyDescriptionAction = menu->addAction(

--- a/src/gui/search/searchjobwidget.h
+++ b/src/gui/search/searchjobwidget.h
@@ -82,10 +82,6 @@ public:
 
     void cancelSearch();
 
-    void downloadTorrents();
-    void openTorrentPages();
-    void copyTorrentURLs();
-
 signals:
     void resultsCountUpdated();
     void statusChanged();
@@ -113,6 +109,13 @@ private:
     NameFilteringMode filteringMode() const;
     QHeaderView *header() const;
     void setRowColor(int row, const QColor &color);
+
+    void downloadTorrents();
+    void openTorrentPages() const;
+    void copyTorrentURLs() const;
+    void copyTorrentDownloadLinks() const;
+    void copyTorrentNames() const;
+    void copyField(int column) const;
 
     static QString statusText(Status st);
     static CachedSettingValue<NameFilteringMode> &nameFilteringModeSetting();

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -104,10 +104,7 @@ SearchWidget::SearchWidget(MainWindow *mainWindow)
 #ifndef Q_OS_MAC
     // Icons
     m_ui->searchButton->setIcon(GuiIconProvider::instance()->getIcon("edit-find"));
-    m_ui->downloadButton->setIcon(GuiIconProvider::instance()->getIcon("download"));
-    m_ui->goToDescBtn->setIcon(GuiIconProvider::instance()->getIcon("application-x-mswinurl"));
     m_ui->pluginsButton->setIcon(GuiIconProvider::instance()->getIcon("preferences-system-network"));
-    m_ui->copyURLBtn->setIcon(GuiIconProvider::instance()->getIcon("edit-copy"));
 #else
     // On macOS the icons overlap the text otherwise
     QSize iconSize = m_ui->tabWidget->iconSize();
@@ -217,26 +214,11 @@ SearchWidget::~SearchWidget()
     delete m_ui;
 }
 
-void SearchWidget::updateButtons()
-{
-    if (m_currentSearchTab && (m_currentSearchTab->visibleResultsCount() > 0)) {
-        m_ui->downloadButton->setEnabled(true);
-        m_ui->goToDescBtn->setEnabled(true);
-        m_ui->copyURLBtn->setEnabled(true);
-    }
-    else {
-        m_ui->downloadButton->setEnabled(false);
-        m_ui->goToDescBtn->setEnabled(false);
-        m_ui->copyURLBtn->setEnabled(false);
-    }
-}
-
 void SearchWidget::tabChanged(int index)
 {
     // when we switch from a tab that is not empty to another that is empty
     // the download button doesn't have to be available
     m_currentSearchTab = ((index < 0) ? nullptr : m_allTabs.at(m_ui->tabWidget->currentIndex()));
-    updateButtons();
 }
 
 void SearchWidget::selectMultipleBox(int index)
@@ -324,17 +306,11 @@ void SearchWidget::on_searchButton_clicked()
     m_ui->tabWidget->addTab(newTab, tabName);
     m_ui->tabWidget->setCurrentWidget(newTab);
 
-    connect(newTab, &SearchJobWidget::resultsCountUpdated, this, &SearchWidget::resultsCountUpdated);
     connect(newTab, &SearchJobWidget::statusChanged, this, [this, newTab]() { tabStatusChanged(newTab); });
 
     m_ui->searchButton->setText(tr("Stop"));
     m_activeSearchTab = newTab;
     tabStatusChanged(newTab);
-}
-
-void SearchWidget::resultsCountUpdated()
-{
-    updateButtons();
 }
 
 void SearchWidget::tabStatusChanged(QWidget *tab)
@@ -366,20 +342,4 @@ void SearchWidget::closeTab(int index)
         m_ui->searchButton->setText(tr("Search"));
 
     delete tab;
-}
-
-// Download selected items in search results list
-void SearchWidget::on_downloadButton_clicked()
-{
-    m_allTabs.at(m_ui->tabWidget->currentIndex())->downloadTorrents();
-}
-
-void SearchWidget::on_goToDescBtn_clicked()
-{
-    m_allTabs.at(m_ui->tabWidget->currentIndex())->openTorrentPages();
-}
-
-void SearchWidget::on_copyURLBtn_clicked()
-{
-    m_allTabs.at(m_ui->tabWidget->currentIndex())->copyTorrentURLs();
 }

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -40,6 +40,7 @@
 #include <QRegularExpression>
 #include <QShortcut>
 #include <QTextStream>
+#include <QVector>
 
 #include "base/global.h"
 #include "base/search/searchpluginmanager.h"
@@ -146,7 +147,7 @@ void SearchWidget::fillCatCombobox()
     m_ui->comboCategory->addItem(SearchPluginManager::categoryFullName("all"), QVariant("all"));
 
     using QStrPair = QPair<QString, QString>;
-    QList<QStrPair> tmpList;
+    QVector<QStrPair> tmpList;
     for (const QString &cat : asConst(SearchPluginManager::instance()->getPluginCategories(selectedPlugin())))
         tmpList << qMakePair(SearchPluginManager::categoryFullName(cat), cat);
     std::sort(tmpList.begin(), tmpList.end(), [](const QStrPair &l, const QStrPair &r) { return (QString::localeAwareCompare(l.first, r.first) < 0); });
@@ -168,7 +169,7 @@ void SearchWidget::fillPluginComboBox()
     m_ui->selectPlugin->addItem(tr("Select..."), QVariant("multi"));
 
     using QStrPair = QPair<QString, QString>;
-    QList<QStrPair> tmpList;
+    QVector<QStrPair> tmpList;
     for (const QString &name : asConst(SearchPluginManager::instance()->enabledPlugins()))
         tmpList << qMakePair(SearchPluginManager::instance()->pluginFullName(name), name);
     std::sort(tmpList.begin(), tmpList.end(), [](const QStrPair &l, const QStrPair &r) { return (l.first < r.first); } );

--- a/src/gui/search/searchwidget.h
+++ b/src/gui/search/searchwidget.h
@@ -57,15 +57,11 @@ public:
 
 private slots:
     void on_searchButton_clicked();
-    void on_downloadButton_clicked();
-    void on_goToDescBtn_clicked();
-    void on_copyURLBtn_clicked();
     void on_pluginsButton_clicked();
 
 private:
     void tabChanged(int index);
     void closeTab(int index);
-    void resultsCountUpdated();
     void tabStatusChanged(QWidget *tab);
     void selectMultipleBox(int index);
     void toggleFocusBetweenLineEdits();
@@ -74,7 +70,6 @@ private:
     void fillPluginComboBox();
     void selectActivePage();
     void searchTextEdited(const QString &);
-    void updateButtons();
 
     QString selectedCategory() const;
     QString selectedPlugin() const;

--- a/src/gui/search/searchwidget.ui
+++ b/src/gui/search/searchwidget.ui
@@ -114,36 +114,6 @@ Click the &quot;Search plugins...&quot; button at the bottom right of the window
    <item>
     <layout class="QHBoxLayout" name="layout2">
      <item>
-      <widget class="QPushButton" name="downloadButton">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Download</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="goToDescBtn">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Open description page</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="copyURLBtn">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Copy description page URL</string>
-       </property>
-      </widget>
-     </item>
-     <item>
       <spacer name="spacer2">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/src/gui/search/searchwidget.ui
+++ b/src/gui/search/searchwidget.ui
@@ -129,7 +129,7 @@ Click the &quot;Search plugins...&quot; button at the bottom right of the window
         <bool>false</bool>
        </property>
        <property name="text">
-        <string>Go to description page</string>
+        <string>Open description page</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
* Rename label in search widget
* Add more copy field actions to search widget
  Closes #10250.
* Remove buttons from search widget
  These buttons are replaced by right-click menu actions.
* Replace QList by QVector

Screenshots:
![menu](https://user-images.githubusercontent.com/9395168/60156104-4f657200-981e-11e9-9e9f-7fea3d51705c.png)
![widget](https://user-images.githubusercontent.com/9395168/60150323-cd1f8280-980a-11e9-90b1-5773031f3a6c.png)

