### PR TITLE
Tighten up qtsingleapplication

### DIFF
--- a/src/app/qtsingleapplication/qtlocalpeer.cpp
+++ b/src/app/qtsingleapplication/qtlocalpeer.cpp
@@ -191,6 +191,12 @@ void QtLocalPeer::receiveConnection()
     QByteArray uMsg;
     quint32 remaining;
     ds >> remaining;
+    if (remaining > 65535) {
+        // drop suspiciously large data
+        delete socket;
+        return;
+    }
+
     uMsg.resize(remaining);
     int got = 0;
     char* uMsgBuf = uMsg.data();

--- a/src/app/qtsingleapplication/qtlocalpeer.cpp
+++ b/src/app/qtsingleapplication/qtlocalpeer.cpp
@@ -101,6 +101,7 @@ QtLocalPeer::QtLocalPeer(QObject* parent, const QString &appId)
 #endif
 
     server = new QLocalServer(this);
+    server->setSocketOptions(QLocalServer::UserAccessOption);
     QString lockName = QDir(QDir::tempPath()).absolutePath()
                        + QLatin1Char('/') + socketName
                        + QLatin1String("-lockfile");


### PR DESCRIPTION
* Drop suspiciously large data
  This is to avoid exhausting system memory.
* Restrict QLocalServer access
  The default is world access which means even even unprivileged local accounts can connect to it too.

Tested on Windows & linux.
qtsingleapplication is outdated and I don't like to add local patches to it. We really should look into replacing it or consider maintaining it ourselves.

Will backport to v4_1_x.