### PR TITLE
Avoid word wrap in webui footer

### DIFF
--- a/src/webui/www/private/css/Layout.css
+++ b/src/webui/www/private/css/Layout.css
@@ -433,3 +433,11 @@ td.speedLabel {
     cursor: pointer;
     min-width: 18em;
 }
+
+#freeSpaceOnDisk {
+    white-space: nowrap;
+}
+
+#DHTNodes {
+    white-space: nowrap;
+}


### PR DESCRIPTION
Previous:
![TIM图片20190629005525](https://user-images.githubusercontent.com/38249940/60358577-002f6500-9a09-11e9-93a9-708ddeb9e811.png)
After:
![TIM截图20190629012140](https://user-images.githubusercontent.com/38249940/60359670-489c5200-9a0c-11e9-9240-3dba54e1fe46.png)

BTW, how about also applying this to the speed labels? i.e. replacing the `min-width: 18em;` in `td.speedLabel`.