### PR TITLE
Use newer libtorrent API (part 5)

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -4042,9 +4042,14 @@ void Session::handleTorrentDeleteFailedAlert(const lt::torrent_delete_failed_ale
     // so we remove the directory ourselves
     Utils::Fs::smartRemoveEmptyFolderTree(tmpRemovingTorrentData.savePathToRemove);
 
-    LogMsg(tr("'%1' was removed from the transfer list but the files couldn't be deleted. Error: %2", "'xxx.avi' was removed...")
-           .arg(tmpRemovingTorrentData.name, QString::fromLocal8Bit(p->error.message().c_str()))
-           , Log::CRITICAL);
+    if (p->error) {
+        LogMsg(tr("'%1' was removed from the transfer list but the files couldn't be deleted. Error: %2", "'xxx.avi' was removed...")
+                .arg(tmpRemovingTorrentData.name, QString::fromStdString(p->error.message()))
+            , Log::WARNING);
+    }
+    else {
+        LogMsg(tr("'%1' was removed from the transfer list.", "'xxx.avi' was removed...").arg(tmpRemovingTorrentData.name));
+    }
 }
 
 void Session::handleMetadataReceivedAlert(const lt::metadata_received_alert *p)

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -1365,6 +1365,8 @@ void TorrentHandle::setSequentialDownload(const bool enable)
         m_nativeStatus.flags &= ~lt::torrent_flags::sequential_download;  // prevent return cached value
     }
 #endif
+
+    saveResumeData();
 }
 
 void TorrentHandle::toggleSequentialDownload()
@@ -1418,6 +1420,8 @@ void TorrentHandle::setFirstLastPiecePriorityImpl(const bool enabled, const QVec
 
     LogMsg(tr("Download first and last piece first: %1, torrent: '%2'")
         .arg((enabled ? tr("On") : tr("Off")), name()));
+
+    saveResumeData();
 }
 
 void TorrentHandle::toggleFirstLastPiecePriority()


### PR DESCRIPTION
* Use newer libtorrent API
  This should be the last part from me. The remaining are session settings that are still in use in libt 1.1.
  Of course `#if` conditionals can be added to them, however the number is large and will greatly reduce readability. IMO better remove them when qbt drop libt 1.1 support.
* Fix torrent properties not saved for paused torrents
  Will backport to v4_1_x.
* ~~Remove duplicate "sequential download" key
  libtorrent already records them so we don't need to handle them manually.~~
* Use proper log message when there are no error
  Will backport to v4_1_x.