### PR TITLE
Fix torrent checking issues

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -551,6 +551,7 @@ namespace BitTorrent
         void handleAddTorrentAlert(const lt::add_torrent_alert *p);
         void handleStateUpdateAlert(const lt::state_update_alert *p);
         void handleMetadataReceivedAlert(const lt::metadata_received_alert *p);
+        void handleTorrentPausedAlert(const lt::torrent_paused_alert *p);
         void handleFileErrorAlert(const lt::file_error_alert *p);
         void handleTorrentRemovedAlert(const lt::torrent_removed_alert *p);
         void handleTorrentDeletedAlert(const lt::torrent_deleted_alert *p);

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -447,12 +447,15 @@ namespace BitTorrent
 
         enum StartupState
         {
-            NotStarted,
-            Starting,
-            Started
+            Preparing, // torrent is preparing to start regular processing
+            Starting, // torrent is prepared and starting to perform regular processing
+            Started // torrent is performing regular processing
         };
+        StartupState m_startupState = Preparing;
+        // Handle torrent state when it starts performing some service job
+        // being in Paused state so it might be unpaused internally and then paused again
+        bool m_pauseWhenReady;
 
-        StartupState m_startupState = NotStarted;
         bool m_unchecked = false;
     };
 }


### PR DESCRIPTION
Start all torrents auto-managed to prevent simultaneous checking of multiple torrents.
Handle checking state of paused torrent to prevent it from being resumed when qBittorrent is closed until checking isn't complete.