### PR TITLE
Replace obsoleted Qt functions

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -341,7 +341,11 @@ void showSplashScreen()
     const QString version = QBT_VERSION;
     painter.setPen(QPen(Qt::white));
     painter.setFont(QFont("Arial", 22, QFont::Black));
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+    painter.drawText(224 - painter.fontMetrics().horizontalAdvance(version), 270, version);
+#else
     painter.drawText(224 - painter.fontMetrics().width(version), 270, version);
+#endif
     QSplashScreen *splash = new QSplashScreen(splashImg);
     splash->show();
     QTimer::singleShot(1500, splash, &QObject::deleteLater);

--- a/src/base/search/searchdownloadhandler.cpp
+++ b/src/base/search/searchdownloadhandler.cpp
@@ -40,7 +40,7 @@ SearchDownloadHandler::SearchDownloadHandler(const QString &siteUrl, const QStri
     , m_downloadProcess {new QProcess {this}}
 {
     m_downloadProcess->setEnvironment(QProcess::systemEnvironment());
-    connect(m_downloadProcess, static_cast<void (QProcess::*)(int)>(&QProcess::finished)
+    connect(m_downloadProcess, qOverload<int, QProcess::ExitStatus>(&QProcess::finished)
             , this, &SearchDownloadHandler::downloadProcessFinished);
     const QStringList params {
         Utils::Fs::toNativePath(m_manager->engineLocation() + "/nova2dl.py"),

--- a/src/base/search/searchhandler.cpp
+++ b/src/base/search/searchhandler.cpp
@@ -76,7 +76,7 @@ SearchHandler::SearchHandler(const QString &pattern, const QString &category, co
 
     connect(m_searchProcess, &QProcess::errorOccurred, this, &SearchHandler::processFailed);
     connect(m_searchProcess, &QProcess::readyReadStandardOutput, this, &SearchHandler::readSearchOutput);
-    connect(m_searchProcess, static_cast<void (QProcess::*)(int)>(&QProcess::finished)
+    connect(m_searchProcess, qOverload<int, QProcess::ExitStatus>(&QProcess::finished)
             , this, &SearchHandler::processFinished);
 
     m_searchTimeout->setSingleShot(true);

--- a/src/gui/autoexpandabledialog.cpp
+++ b/src/gui/autoexpandabledialog.cpp
@@ -80,17 +80,29 @@ void AutoExpandableDialog::showEvent(QShowEvent *e)
 
     // Show dialog and resize textbox to fit the text
     // NOTE: For unknown reason QFontMetrics gets more accurate when called from showEvent.
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+    int wd = m_ui->textEdit->fontMetrics().horizontalAdvance(m_ui->textEdit->text()) + 4;
+#else
     int wd = m_ui->textEdit->fontMetrics().width(m_ui->textEdit->text()) + 4;
+#endif
 
     if (!windowTitle().isEmpty()) {
         // not really the font metrics in window title, so we enlarge it a bit,
         // including the small icon and close button width
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+        int w = fontMetrics().horizontalAdvance(windowTitle()) * 1.8;
+#else
         int w = fontMetrics().width(windowTitle()) * 1.8;
+#endif
         wd = std::max(wd, w);
     }
 
     if (!m_ui->textLabel->text().isEmpty()) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+        int w = m_ui->textLabel->fontMetrics().horizontalAdvance(m_ui->textLabel->text());
+#else
         int w = m_ui->textLabel->fontMetrics().width(m_ui->textLabel->text());
+#endif
         wd = std::max(wd, w);
     }
 

--- a/src/gui/properties/speedplotview.cpp
+++ b/src/gui/properties/speedplotview.cpp
@@ -302,8 +302,13 @@ void SpeedPlotView::paintEvent(QPaintEvent *)
 
     int yAxisWidth = 0;
     for (const QString &label : speedLabels)
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+        if (fontMetrics.horizontalAdvance(label) > yAxisWidth)
+            yAxisWidth = fontMetrics.horizontalAdvance(label);
+#else
         if (fontMetrics.width(label) > yAxisWidth)
             yAxisWidth = fontMetrics.width(label);
+#endif
 
     int i = 0;
     for (const QString &label : speedLabels) {
@@ -370,8 +375,13 @@ void SpeedPlotView::paintEvent(QPaintEvent *)
         if (!property.enable)
             continue;
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+        if (fontMetrics.horizontalAdvance(property.name) > legendWidth)
+            legendWidth = fontMetrics.horizontalAdvance(property.name);
+#else
         if (fontMetrics.width(property.name) > legendWidth)
             legendWidth = fontMetrics.width(property.name);
+#endif
         legendHeight += 1.5 * fontMetrics.height();
     }
 
@@ -385,7 +395,11 @@ void SpeedPlotView::paintEvent(QPaintEvent *)
         if (!property.enable)
             continue;
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+        int nameSize = fontMetrics.horizontalAdvance(property.name);
+#else
         int nameSize = fontMetrics.width(property.name);
+#endif
         double indent = 1.5 * (i++) * fontMetrics.height();
 
         painter.setPen(property.pen);


### PR DESCRIPTION
* Replace obsoleted QFontMetrics::width()
  Qt 5.13 marked QFontMetrics::width() obsolete.
* Replace obsoleted QProcess::finished(int)
  It is replaced by QProcess::finished(int, QProcess::ExitStatus).