### PR TITLE
Add more libtorrent options to Advanced Settings

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -268,6 +268,7 @@ Session::Session(QObject *parent)
     , m_announceToAllTrackers(BITTORRENT_SESSION_KEY("AnnounceToAllTrackers"), false)
     , m_announceToAllTiers(BITTORRENT_SESSION_KEY("AnnounceToAllTiers"), true)
     , m_asyncIOThreads(BITTORRENT_SESSION_KEY("AsyncIOThreadsCount"), 4)
+    , m_filePoolSize(BITTORRENT_SESSION_KEY("FilePoolSize"), 40)
     , m_checkingMemUsage(BITTORRENT_SESSION_KEY("CheckingMemUsageSize"), 16)
     , m_diskCacheSize(BITTORRENT_SESSION_KEY("DiskCacheSize"), 64)
     , m_diskCacheTTL(BITTORRENT_SESSION_KEY("DiskCacheTTL"), 60)
@@ -1254,6 +1255,8 @@ void Session::configure(lt::settings_pack &settingsPack)
     settingsPack.set_bool(lt::settings_pack::announce_to_all_tiers, announceToAllTiers());
 
     settingsPack.set_int(lt::settings_pack::aio_threads, asyncIOThreads());
+
+    settingsPack.set_int(lt::settings_pack::file_pool_size, filePoolSize());
 
     const int checkingMemUsageSize = checkingMemUsage() * 64;
     settingsPack.set_int(lt::settings_pack::checking_mem_usage, checkingMemUsageSize);
@@ -2811,6 +2814,20 @@ void Session::setAsyncIOThreads(const int num)
         return;
 
     m_asyncIOThreads = num;
+    configureDeferred();
+}
+
+int Session::filePoolSize() const
+{
+    return m_filePoolSize;
+}
+
+void Session::setFilePoolSize(const int size)
+{
+    if (size == m_filePoolSize)
+        return;
+
+    m_filePoolSize = size;
     configureDeferred();
 }
 

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -320,6 +320,8 @@ namespace BitTorrent
         void setAnnounceToAllTiers(bool val);
         int asyncIOThreads() const;
         void setAsyncIOThreads(int num);
+        int filePoolSize() const;
+        void setFilePoolSize(int size);
         int checkingMemUsage() const;
         void setCheckingMemUsage(int size);
         int diskCacheSize() const;
@@ -587,6 +589,7 @@ namespace BitTorrent
         CachedSettingValue<bool> m_announceToAllTrackers;
         CachedSettingValue<bool> m_announceToAllTiers;
         CachedSettingValue<int> m_asyncIOThreads;
+        CachedSettingValue<int> m_filePoolSize;
         CachedSettingValue<int> m_checkingMemUsage;
         CachedSettingValue<int> m_diskCacheSize;
         CachedSettingValue<int> m_diskCacheTTL;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -340,6 +340,8 @@ namespace BitTorrent
         void setSendBufferLowWatermark(int value);
         int sendBufferWatermarkFactor() const;
         void setSendBufferWatermarkFactor(int value);
+        int socketBacklogSize() const;
+        void setSocketBacklogSize(int value);
         bool isAnonymousModeEnabled() const;
         void setAnonymousModeEnabled(bool enabled);
         bool isQueueingSystemEnabled() const;
@@ -595,6 +597,7 @@ namespace BitTorrent
         CachedSettingValue<int> m_sendBufferWatermark;
         CachedSettingValue<int> m_sendBufferLowWatermark;
         CachedSettingValue<int> m_sendBufferWatermarkFactor;
+        CachedSettingValue<int> m_socketBacklogSize;
         CachedSettingValue<bool> m_isAnonymousModeEnabled;
         CachedSettingValue<bool> m_isQueueingEnabled;
         CachedSettingValue<int> m_maxActiveDownloads;

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -89,6 +89,7 @@ enum AdvSettingsRows
     // libtorrent section
     LIBTORRENT_HEADER,
     ASYNC_IO_THREADS,
+    FILE_POOL_SIZE,
     CHECKING_MEM_USAGE,
     // cache
     DISK_CACHE,
@@ -155,6 +156,8 @@ void AdvancedSettings::saveAdvancedSettings()
 
     // Async IO threads
     session->setAsyncIOThreads(spinBoxAsyncIOThreads.value());
+    // File pool size
+    session->setFilePoolSize(spinBoxFilePoolSize.value());
     // Checking Memory Usage
     session->setCheckingMemUsage(spinBoxCheckingMemUsage.value());
     // Disk write cache
@@ -327,6 +330,13 @@ void AdvancedSettings::loadAdvancedSettings()
     spinBoxAsyncIOThreads.setValue(session->asyncIOThreads());
     addRow(ASYNC_IO_THREADS, (tr("Asynchronous I/O threads") + ' ' + makeLink("https://www.libtorrent.org/reference-Settings.html#aio_threads", "(?)"))
             , &spinBoxAsyncIOThreads);
+
+    // File pool size
+    spinBoxFilePoolSize.setMinimum(1);
+    spinBoxFilePoolSize.setMaximum(std::numeric_limits<int>::max());
+    spinBoxFilePoolSize.setValue(session->filePoolSize());
+    addRow(FILE_POOL_SIZE, (tr("File pool size") + ' ' + makeLink("https://www.libtorrent.org/reference-Settings.html#file_pool_size", "(?)"))
+        , &spinBoxFilePoolSize);
 
     // Checking Memory Usage
     spinBoxCheckingMemUsage.setMinimum(1);

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -100,7 +100,8 @@ enum AdvSettingsRows
     SEND_BUF_WATERMARK,
     SEND_BUF_LOW_WATERMARK,
     SEND_BUF_WATERMARK_FACTOR,
-    // ports
+    // networking & ports
+    SOCKET_BACKLOG_SIZE,
     OUTGOING_PORT_MIN,
     OUTGOING_PORT_MAX,
     UTP_MIX_MODE,
@@ -171,6 +172,8 @@ void AdvancedSettings::saveAdvancedSettings()
     session->setSendBufferWatermark(spinBoxSendBufferWatermark.value());
     session->setSendBufferLowWatermark(spinBoxSendBufferLowWatermark.value());
     session->setSendBufferWatermarkFactor(spinBoxSendBufferWatermarkFactor.value());
+    // Socket listen backlog size
+    session->setSocketBacklogSize(spinBoxSocketBacklogSize.value());
     // Save resume data interval
     session->setSaveResumeDataInterval(spinBoxSaveResumeDataInterval.value());
     // Outgoing ports
@@ -394,6 +397,12 @@ void AdvancedSettings::loadAdvancedSettings()
     spinBoxSendBufferWatermarkFactor.setValue(session->sendBufferWatermarkFactor());
     addRow(SEND_BUF_WATERMARK_FACTOR, (tr("Send buffer watermark factor") + ' ' + makeLink("https://www.libtorrent.org/reference-Settings.html#send_buffer_watermark_factor", "(?)"))
             , &spinBoxSendBufferWatermarkFactor);
+    // Socket listen backlog size
+    spinBoxSocketBacklogSize.setMinimum(1);
+    spinBoxSocketBacklogSize.setMaximum(std::numeric_limits<int>::max());
+    spinBoxSocketBacklogSize.setValue(session->socketBacklogSize());
+    addRow(SOCKET_BACKLOG_SIZE, (tr("Socket backlog size") + ' ' + makeLink("https://www.libtorrent.org/reference-Settings.html#listen_queue_size", "(?)"))
+            , &spinBoxSocketBacklogSize);
     // Save resume data interval
     spinBoxSaveResumeDataInterval.setMinimum(0);
     spinBoxSaveResumeDataInterval.setMaximum(std::numeric_limits<int>::max());

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -59,7 +59,8 @@ private:
     template <typename T> void addRow(int row, const QString &text, T *widget);
 
     QLabel labelQbtLink, labelLibtorrentLink;
-    QSpinBox spinBoxAsyncIOThreads, spinBoxCheckingMemUsage, spinBoxCache, spinBoxSaveResumeDataInterval, spinBoxOutgoingPortsMin, spinBoxOutgoingPortsMax, spinBoxListRefresh,
+    QSpinBox spinBoxAsyncIOThreads, spinBoxFilePoolSize, spinBoxCheckingMemUsage, spinBoxCache,
+             spinBoxSaveResumeDataInterval, spinBoxOutgoingPortsMin, spinBoxOutgoingPortsMax, spinBoxListRefresh,
              spinBoxTrackerPort, spinBoxCacheTTL, spinBoxSendBufferWatermark, spinBoxSendBufferLowWatermark,
              spinBoxSendBufferWatermarkFactor, spinBoxSocketBacklogSize, spinBoxSavePathHistoryLength;
     QCheckBox checkBoxOsCache, checkBoxRecheckCompleted, checkBoxResolveCountries, checkBoxResolveHosts, checkBoxSuperSeeding,

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -61,7 +61,7 @@ private:
     QLabel labelQbtLink, labelLibtorrentLink;
     QSpinBox spinBoxAsyncIOThreads, spinBoxCheckingMemUsage, spinBoxCache, spinBoxSaveResumeDataInterval, spinBoxOutgoingPortsMin, spinBoxOutgoingPortsMax, spinBoxListRefresh,
              spinBoxTrackerPort, spinBoxCacheTTL, spinBoxSendBufferWatermark, spinBoxSendBufferLowWatermark,
-             spinBoxSendBufferWatermarkFactor, spinBoxSavePathHistoryLength;
+             spinBoxSendBufferWatermarkFactor, spinBoxSocketBacklogSize, spinBoxSavePathHistoryLength;
     QCheckBox checkBoxOsCache, checkBoxRecheckCompleted, checkBoxResolveCountries, checkBoxResolveHosts, checkBoxSuperSeeding,
               checkBoxProgramNotifications, checkBoxTorrentAddedNotifications, checkBoxTrackerFavicon, checkBoxTrackerStatus,
               checkBoxConfirmTorrentRecheck, checkBoxConfirmRemoveAllTags, checkBoxListenIPv6, checkBoxAnnounceAllTrackers, checkBoxAnnounceAllTiers,


### PR DESCRIPTION
* Use LogMsg() helper
* Add "Socket backlog size" option
  The default value in libtorrent is 5 which is too small nowadays. The new default value 30 is chosen to be in line with QTcpServer::maxPendingConnections().
* Add "File pool size" option