### PR TITLE
Implement tri-state checkbox action in menu

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -35,6 +35,7 @@ mainwindow.h
 optionsdialog.h
 previewlistdelegate.h
 previewselectdialog.h
+private/tristatewidget.h
 raisedmessagebox.h
 scanfoldersdelegate.h
 shutdownconfirmdialog.h
@@ -58,6 +59,7 @@ transferlistfilterswidget.h
 transferlistmodel.h
 transferlistsortmodel.h
 transferlistwidget.h
+tristateaction.h
 uithememanager.h
 updownratiodialog.h
 utils.h
@@ -82,6 +84,7 @@ loglistwidget.cpp
 mainwindow.cpp
 optionsdialog.cpp
 previewselectdialog.cpp
+private/tristatewidget.cpp
 raisedmessagebox.cpp
 scanfoldersdelegate.cpp
 shutdownconfirmdialog.cpp
@@ -105,6 +108,7 @@ transferlistfilterswidget.cpp
 transferlistmodel.cpp
 transferlistsortmodel.cpp
 transferlistwidget.cpp
+tristateaction.cpp
 uithememanager.cpp
 updownratiodialog.cpp
 utils.cpp

--- a/src/gui/gui.pri
+++ b/src/gui/gui.pri
@@ -29,6 +29,7 @@ HEADERS += \
     $$PWD/optionsdialog.h \
     $$PWD/previewlistdelegate.h \
     $$PWD/previewselectdialog.h \
+    $$PWD/private/tristatewidget.h \
     $$PWD/raisedmessagebox.h \
     $$PWD/rss/articlelistwidget.h \
     $$PWD/rss/automatedrssdownloader.h \
@@ -63,6 +64,7 @@ HEADERS += \
     $$PWD/transferlistmodel.h \
     $$PWD/transferlistsortmodel.h \
     $$PWD/transferlistwidget.h \
+    $$PWD/tristateaction.h \
     $$PWD/uithememanager.h \
     $$PWD/updownratiodialog.h \
     $$PWD/utils.h
@@ -87,6 +89,7 @@ SOURCES += \
     $$PWD/mainwindow.cpp \
     $$PWD/optionsdialog.cpp \
     $$PWD/previewselectdialog.cpp \
+    $$PWD/private/tristatewidget.cpp \
     $$PWD/raisedmessagebox.cpp \
     $$PWD/rss/articlelistwidget.cpp \
     $$PWD/rss/automatedrssdownloader.cpp \
@@ -121,6 +124,7 @@ SOURCES += \
     $$PWD/transferlistmodel.cpp \
     $$PWD/transferlistsortmodel.cpp \
     $$PWD/transferlistwidget.cpp \
+    $$PWD/tristateaction.cpp \
     $$PWD/uithememanager.cpp \
     $$PWD/updownratiodialog.cpp \
     $$PWD/utils.cpp

--- a/src/gui/private/tristatewidget.cpp
+++ b/src/gui/private/tristatewidget.cpp
@@ -1,0 +1,144 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2019  Mike Tzou (Chocobo1)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "tristatewidget.h"
+
+#include <QApplication>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPaintEvent>
+#include <QString>
+#include <QStyle>
+#include <QStyleOptionMenuItem>
+
+TriStateWidget::TriStateWidget(const QString &text, QWidget *parent)
+    : QWidget {parent}
+    , m_closeOnTriggered {true}
+    , m_checkState {Qt::Unchecked}
+    , m_text {text}
+{
+    setMouseTracking(true);  // for visual effects via mouse navigation
+    setFocusPolicy(Qt::TabFocus);  // for visual effects via keyboard navigation
+}
+
+void TriStateWidget::setCheckState(const Qt::CheckState checkState)
+{
+    m_checkState = checkState;
+}
+
+void TriStateWidget::setCloseOnTriggered(const bool enabled)
+{
+    m_closeOnTriggered = enabled;
+}
+
+QSize TriStateWidget::minimumSizeHint() const
+{
+    QStyleOptionMenuItem opt;
+    opt.initFrom(this);
+    opt.menuHasCheckableItems = true;
+    const QSize contentSize = fontMetrics().size(Qt::TextSingleLine, m_text);
+    return style()->sizeFromContents(QStyle::CT_MenuItem, &opt, contentSize, this);
+}
+
+void TriStateWidget::paintEvent(QPaintEvent *)
+{
+    QStyleOptionMenuItem opt;
+    opt.initFrom(this);
+    opt.menuItemType = QStyleOptionMenuItem::Normal;
+    opt.checkType = QStyleOptionMenuItem::NonExclusive;
+    opt.menuHasCheckableItems = true;
+    opt.text = m_text;
+
+    switch (m_checkState) {
+    case Qt::PartiallyChecked:
+        opt.state |= QStyle::State_NoChange;
+        break;
+    case Qt::Checked:
+        opt.checked = true;
+        break;
+    case Qt::Unchecked:
+        opt.checked = false;
+        break;
+    };
+
+    if ((opt.state & QStyle::State_HasFocus)
+        || rect().contains(mapFromGlobal(QCursor::pos()))) {
+        opt.state |= QStyle::State_Selected;
+
+        if (QApplication::mouseButtons() != Qt::NoButton)
+            opt.state |= QStyle::State_Sunken;
+    }
+
+    QPainter painter {this};
+    style()->drawControl(QStyle::CE_MenuItem, &opt, &painter, this);
+}
+
+void TriStateWidget::mouseReleaseEvent(QMouseEvent *event)
+{
+    toggleCheckState();
+
+    if (m_closeOnTriggered) {
+        // parent `triggered` signal will be emitted
+        QWidget::mouseReleaseEvent(event);
+    }
+    else {
+        update();
+        // need to emit parent `triggered` signal manually
+        emit triggered(m_checkState == Qt::Checked);
+    }
+}
+
+void TriStateWidget::keyPressEvent(QKeyEvent *event)
+{
+    if ((event->key() == Qt::Key_Return)
+        || (event->key() == Qt::Key_Enter)) {
+        toggleCheckState();
+
+        if (!m_closeOnTriggered) {
+            update();
+            // need to emit parent `triggered` signal manually
+            emit triggered(m_checkState == Qt::Checked);
+            return;
+        }
+    }
+
+    QWidget::keyPressEvent(event);
+}
+
+void TriStateWidget::toggleCheckState()
+{
+    switch (m_checkState) {
+    case Qt::Unchecked:
+    case Qt::PartiallyChecked:
+        m_checkState = Qt::Checked;
+        break;
+    case Qt::Checked:
+        m_checkState = Qt::Unchecked;
+        break;
+    };
+}

--- a/src/gui/private/tristatewidget.h
+++ b/src/gui/private/tristatewidget.h
@@ -1,0 +1,61 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2019  Mike Tzou (Chocobo1)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+#include <QWidget>
+
+class QString;
+
+class TriStateWidget : public QWidget
+{
+    Q_OBJECT
+    Q_DISABLE_COPY(TriStateWidget)
+
+public:
+    TriStateWidget(const QString &text, QWidget *parent);
+
+    void setCheckState(Qt::CheckState checkState);
+    void setCloseOnTriggered(bool enabled);
+
+signals:
+    void triggered(bool checked) const;
+
+private:
+    QSize minimumSizeHint() const override;
+
+    void paintEvent(QPaintEvent *) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
+    void keyPressEvent(QKeyEvent *event) override;
+
+    void toggleCheckState();
+
+    bool m_closeOnTriggered;
+    Qt::CheckState m_checkState;
+    const QString m_text;
+};

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -106,9 +106,9 @@ protected slots:
     void torrentDoubleClicked();
     void displayListMenu(const QPoint &);
     void currentChanged(const QModelIndex &current, const QModelIndex&) override;
-    void toggleSelectedTorrentsSuperSeeding() const;
-    void toggleSelectedTorrentsSequentialDownload() const;
-    void toggleSelectedFirstLastPiecePrio() const;
+    void setSelectedTorrentsSuperSeeding(bool enabled) const;
+    void setSelectedTorrentsSequentialDownload(bool enabled) const;
+    void setSelectedFirstLastPiecePrio(bool enabled) const;
     void setSelectedAutoTMMEnabled(bool enabled) const;
     void askNewCategoryForSelection();
     void saveSettings();

--- a/src/gui/tristateaction.cpp
+++ b/src/gui/tristateaction.cpp
@@ -1,0 +1,62 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2019  Mike Tzou (Chocobo1)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "tristateaction.h"
+
+#include <QString>
+#include <QWidget>
+
+#include "private/tristatewidget.h"
+
+TriStateAction::TriStateAction(const QString &text, QWidget *parent)
+    : QWidgetAction {parent}
+    , m_triStateWidget {new TriStateWidget {text, parent}}
+{
+    setCheckable(true);
+
+    // required for QAction::setChecked(bool) to work
+    connect(this, &QAction::toggled, this, [this](const bool checked)
+    {
+        m_triStateWidget->setCheckState(checked ? Qt::Checked : Qt::Unchecked);
+    });
+
+    connect(m_triStateWidget, &TriStateWidget::triggered, this, &QAction::setChecked);
+    connect(m_triStateWidget, &TriStateWidget::triggered, this, &QAction::triggered);
+    setDefaultWidget(m_triStateWidget);
+}
+
+void TriStateAction::setCheckState(const Qt::CheckState checkState)
+{
+    QWidgetAction::setChecked((checkState == Qt::Checked) ? true : false);
+    m_triStateWidget->setCheckState(checkState);
+}
+
+void TriStateAction::setCloseOnTriggered(const bool enabled)
+{
+    m_triStateWidget->setCloseOnTriggered(enabled);
+}

--- a/src/gui/tristateaction.h
+++ b/src/gui/tristateaction.h
@@ -1,0 +1,53 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2019  Mike Tzou (Chocobo1)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+#include <QWidgetAction>
+
+class QString;
+class QWidget;
+
+class TriStateWidget;
+
+// TriStateWidget is responsible for checkbox state (tri-state) and paint events while
+// TriStateAction will keep in sync with it. This allows connecting with the usual
+// QAction::triggered slot.
+class TriStateAction : public QWidgetAction
+{
+public:
+    TriStateAction(const QString &text, QWidget *parent);
+
+    // should use this function instead of QAction::setChecked(bool)
+    void setCheckState(Qt::CheckState checkState);
+
+    void setCloseOnTriggered(bool enabled);
+
+private:
+    TriStateWidget *m_triStateWidget;
+};


### PR DESCRIPTION
The new TriStateAction class is an improvement of the old one in the sense that:
1. Have public method to set states.
2. Can connect to the usual Qt slots.
3. Draws checkbox at the correct offset (where QAction draws) in menu
   and better handling of mouse clicking and keyboard navigating.
   old:
  ![old](https://user-images.githubusercontent.com/9395168/61101080-19b9bd80-a49b-11e9-8aab-035b1a928be1.png)
   new:
  ![new](https://user-images.githubusercontent.com/9395168/61113505-07527a80-a4c1-11e9-9385-a0ef39260862.png)
