### PR TITLE
Move WebUI copy actions under a submenu

### DIFF
--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -151,9 +151,14 @@
                 <li><a href="#queueBottom"><img src="images/qbt-theme/go-bottom.svg" alt="QBT_TR(Move to bottom)QBT_TR[CONTEXT=TransferListWidget]"/> QBT_TR(Move to bottom)QBT_TR[CONTEXT=TransferListWidget]</a></li>
             </ul>
         </li>
-        <li class="separator"><a href="#" id="copyName" class="copyToClipboard"><img src="images/qbt-theme/edit-copy.svg" alt="QBT_TR(Copy name)QBT_TR[CONTEXT=TransferListWidget]"/>  QBT_TR(Copy name)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-        <li><a href="#" id="copyHash" class="copyToClipboard"><img src="images/qbt-theme/edit-copy.svg" alt="QBT_TR(Copy hash)QBT_TR[CONTEXT=TransferListWidget]"/>  QBT_TR(Copy hash)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-        <li><a href="#" id="copyMagnetLink" class="copyToClipboard"><img src="images/qbt-theme/kt-magnet.svg" alt="QBT_TR(Copy magnet link)QBT_TR[CONTEXT=TransferListWidget]"/>  QBT_TR(Copy magnet link)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li>
+            <a href="#" class="arrow-right"><img src="images/qbt-theme/edit-copy.svg" alt="QBT_TR(Copy)QBT_TR[CONTEXT=TransferListWidget]"/> QBT_TR(Copy)QBT_TR[CONTEXT=TransferListWidget]</a>
+            <ul>
+                <li><a href="#" id="copyName" class="copyToClipboard"><img src="images/qbt-theme/edit-copy.svg" alt="QBT_TR(Name)QBT_TR[CONTEXT=TransferListWidget]"/>  QBT_TR(Name)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+                <li><a href="#" id="copyHash" class="copyToClipboard"><img src="images/qbt-theme/edit-copy.svg" alt="QBT_TR(Hash)QBT_TR[CONTEXT=TransferListWidget]"/>  QBT_TR(Hash)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+                <li><a href="#" id="copyMagnetLink" class="copyToClipboard"><img src="images/qbt-theme/kt-magnet.svg" alt="QBT_TR(Magnet link)QBT_TR[CONTEXT=TransferListWidget]"/>  QBT_TR(Magnet link)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+            </ul>
+        </li>
     </ul>
     <ul id="categoriesFilterMenu" class="contextMenu">
         <li><a href="#createCategory"><img src="images/qbt-theme/list-add.svg" alt="QBT_TR(Add category...)QBT_TR[CONTEXT=CategoryFilterWidget]"/> QBT_TR(Add category...)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>


### PR DESCRIPTION
WebUI implementation of #10850

<img width="449" alt="Screen Shot 2019-07-14 at 8 36 07 PM" src="https://user-images.githubusercontent.com/8296030/61194562-1aa74680-a677-11e9-978c-5f8dbe5d3150.png">

Right click menu for search jobs (partially #10850 and #10852) will be in a different PR