### PR TITLE
Support exclusions in WebUI table filters

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1268,12 +1268,9 @@ const TorrentsTable = new Class({
             }
         }
 
-        if (filterTerms) {
-            for (let i = 0; i < filterTerms.length; ++i) {
-                if (name.indexOf(filterTerms[i]) === -1)
-                    return false;
-            }
-        }
+        if ((filterTerms !== undefined) && (filterTerms !== null)
+            && (filterTerms.length > 0) && !containsAllTerms(name, filterTerms))
+            return false;
 
         return true;
     },
@@ -1517,16 +1514,6 @@ const SearchResultsTable = new Class({
     },
 
     getFilteredAndSortedRows: function() {
-        const containsAll = function(text, searchTerms) {
-            text = text.toLowerCase();
-            for (let i = 0; i < searchTerms.length; ++i) {
-                if (text.indexOf(searchTerms[i].toLowerCase()) === -1)
-                    return false;
-            }
-
-            return true;
-        };
-
         const getSizeFilters = function() {
             let minSize = (searchSizeFilter.min > 0.00) ? (searchSizeFilter.min * Math.pow(1024, searchSizeFilter.minUnit)) : 0.00;
             let maxSize = (searchSizeFilter.max > 0.00) ? (searchSizeFilter.max * Math.pow(1024, searchSizeFilter.maxUnit)) : 0.00;
@@ -1571,8 +1558,8 @@ const SearchResultsTable = new Class({
             for (let i = 0; i < rows.length; ++i) {
                 const row = rows[i];
 
-                if (searchInTorrentName && !containsAll(row.full_data.fileName, searchTerms)) continue;
-                if ((filterTerms.length > 0) && !containsAll(row.full_data.fileName, filterTerms)) continue;
+                if (searchInTorrentName && !containsAllTerms(row.full_data.fileName, searchTerms)) continue;
+                if ((filterTerms.length > 0) && !containsAllTerms(row.full_data.fileName, filterTerms)) continue;
                 if ((sizeFilters.min > 0.00) && (row.full_data.fileSize < sizeFilters.min)) continue;
                 if ((sizeFilters.max > 0.00) && (row.full_data.fileSize > sizeFilters.max)) continue;
                 if ((seedsFilters.min > 0) && (row.full_data.nbSeeders < seedsFilters.min)) continue;
@@ -1907,12 +1894,7 @@ const TorrentFilesTable = new Class({
             }
         }
 
-        const lowercaseName = node.name.toLowerCase();
-        const matchesFilter = filterTerms.every(function(term) {
-            return (lowercaseName.indexOf(term) !== -1);
-        });
-
-        if (matchesFilter) {
+        if (containsAllTerms(node.name, filterTerms)) {
             const row = this.getRow(node);
             filteredRows.push(row);
             return true;

--- a/src/webui/www/private/scripts/misc.js
+++ b/src/webui/www/private/scripts/misc.js
@@ -167,3 +167,37 @@ function toFixedPointString(number, digits) {
     const power = Math.pow(10, digits);
     return (Math.floor(power * number) / power).toFixed(digits);
 }
+
+/**
+ *
+ * @param {String} text the text to search
+ * @param {Array<String>} terms terms to search for within the text
+ * @returns {Boolean} true if all terms match the text, false otherwise
+ */
+function containsAllTerms(text, terms) {
+    const textToSearch = text.toLowerCase();
+    for (let i = 0; i < terms.length; ++i) {
+        const term = terms[i].trim().toLowerCase();
+        if ((term[0] === '-')) {
+            // ignore lonely -
+            if (term.length === 1)
+                continue;
+            // disallow any text after -
+            if (textToSearch.indexOf(term.substring(1)) !== -1)
+                return false;
+        }
+        else if ((term[0] === '+')) {
+            // ignore lonely +
+            if (term.length === 1)
+                continue;
+            // require any text after +
+            if (textToSearch.indexOf(term.substring(1)) === -1)
+                return false;
+        }
+        else if (textToSearch.indexOf(term) === -1){
+            return false;
+        }
+    }
+
+    return true;
+}


### PR DESCRIPTION
This PR adds support for exclusions in the WebUI's table filters (torrents table, search table, torrent content table). It uses a `-` to indicate a term that should be excluded, and a `+` to include a term that should be included (e.g. you can search for a hypen with `+-`). Terms without a leading `+` are treated the same as terms with a leading `+`.

This feature has only been added to the WebUI due to the GUI already containing exclusion support via regex. The benefit of this syntax is that it's already commonly support by the web and doesn't require knowledge of regex.

Closes #10241


Examples:
<img width="716" alt="Screen Shot 2019-07-14 at 9 41 16 PM" src="https://user-images.githubusercontent.com/8296030/61195939-3e22bf00-a680-11e9-92b9-ba9c340a9c5c.png">
<img width="702" alt="Screen Shot 2019-07-14 at 9 41 23 PM" src="https://user-images.githubusercontent.com/8296030/61195943-411daf80-a680-11e9-86ed-eae94b22de68.png">
<img width="766" alt="Screen Shot 2019-07-14 at 9 41 30 PM" src="https://user-images.githubusercontent.com/8296030/61195946-43800980-a680-11e9-8e0e-88545cd6c80a.png">
<img width="785" alt="Screen Shot 2019-07-14 at 9 41 42 PM" src="https://user-images.githubusercontent.com/8296030/61195949-45e26380-a680-11e9-9c6f-0406259752c6.png">
<img width="636" alt="Screen Shot 2019-07-14 at 9 43 00 PM" src="https://user-images.githubusercontent.com/8296030/61195971-61e60500-a680-11e9-93e1-28a4a3eca0a0.png">
