### PR TITLE
Save updated resume data for completed torrents 

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1796,7 +1796,7 @@ void Session::bottomTorrentsQueuePos(const QStringList &hashes)
     saveTorrentsQueue();
 }
 
-void Session::handleTorrentSaveResumeDataRequested(TorrentHandle *const torrent)
+void Session::handleTorrentSaveResumeDataRequested(const TorrentHandle *torrent)
 {
     qDebug("Saving resume data is requested for torrent '%s'...", qUtf8Printable(torrent->name()));
     ++m_numResumeData;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -427,6 +427,7 @@ namespace BitTorrent
         void bottomTorrentsQueuePos(const QStringList &hashes);
 
         // TorrentHandle interface
+        void handleTorrentSaveResumeDataRequested(TorrentHandle *const torrent);
         void handleTorrentShareLimitChanged(TorrentHandle *const torrent);
         void handleTorrentNameChanged(TorrentHandle *const torrent);
         void handleTorrentSavePathChanged(TorrentHandle *const torrent);
@@ -544,7 +545,6 @@ namespace BitTorrent
 
         void updateSeedingLimitTimer();
         void exportTorrentFile(TorrentHandle *const torrent, TorrentExportFolder folder = TorrentExportFolder::Regular);
-        void saveTorrentResumeData(TorrentHandle *const torrent);
 
         void handleAlert(const lt::alert *a);
         void dispatchTorrentAlert(const lt::alert *a);

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -427,7 +427,7 @@ namespace BitTorrent
         void bottomTorrentsQueuePos(const QStringList &hashes);
 
         // TorrentHandle interface
-        void handleTorrentSaveResumeDataRequested(TorrentHandle *const torrent);
+        void handleTorrentSaveResumeDataRequested(const TorrentHandle *torrent);
         void handleTorrentShareLimitChanged(TorrentHandle *const torrent);
         void handleTorrentNameChanged(TorrentHandle *const torrent);
         void handleTorrentSavePathChanged(TorrentHandle *const torrent);

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -530,6 +530,7 @@ bool TorrentHandle::needSaveResumeData() const
 void TorrentHandle::saveResumeData()
 {
     m_nativeHandle.save_resume_data();
+    m_session->handleTorrentSaveResumeDataRequested(this);
 }
 
 int TorrentHandle::filesCount() const

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -438,6 +438,7 @@ namespace BitTorrent
         qreal m_ratioLimit;
         int m_seedingTimeLimit;
         bool m_tempPathDisabled;
+        bool m_fastresumeDataRejected;
         bool m_hasMissingFiles;
         bool m_hasRootFolder;
         bool m_needsToSetFirstLastPiecePriority;


### PR DESCRIPTION
If fastresume data was rejected we need to save updated resume data after torrent finishes rechecking.

Also fixes handling of requested torrent resume data. Session should increase an appropriate counter each time the torrent resume data is requested to save.