### PR TITLE
Hide Web UI context menu on new touch interaction

### DIFF
--- a/src/webui/www/private/scripts/contextmenu.js
+++ b/src/webui/www/private/scripts/contextmenu.js
@@ -208,6 +208,9 @@ var ContextMenu = new Class({
         $(document.body).addEvent('click', function() {
             this.hide();
         }.bind(this));
+        $(document.body).addEvent('touchstart', function() {
+            this.hide();
+        }.bind(this));
     },
 
     updateMenuItems: function() {},


### PR DESCRIPTION
This makes the context menu behave more naturally on mobile. Follow up to #10931.