### PR TITLE
Remove Qt bug workaround

### DIFF
--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -462,12 +462,6 @@ void AdvancedSettings::loadAdvancedSettings()
     bool interfaceExists = currentInterface.isEmpty();
     int i = 1;
     for (const QNetworkInterface &iface : asConst(QNetworkInterface::allInterfaces())) {
-        // This line fixes a Qt bug => https://bugreports.qt.io/browse/QTBUG-52633
-        // Tested in Qt 5.6.0. For more info see:
-        // https://github.com/qbittorrent/qBittorrent/issues/5131
-        // https://github.com/qbittorrent/qBittorrent/pull/5135
-        if (iface.addressEntries().isEmpty()) continue;
-
         m_comboBoxInterface.addItem(iface.humanReadableName(), iface.name());
         if (!currentInterface.isEmpty() && (iface.name() == currentInterface)) {
             m_comboBoxInterface.setCurrentIndex(i);


### PR DESCRIPTION
The Qt bug is fixed in 5.7.1, while we require Qt >= 5.9.0.

Note: Several people should test PR to confirm the duplicate interface issue isn't reintroduced