### PR TITLE
Increase WebUI window heights

### DIFF
--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -153,7 +153,7 @@ const initializeWindows = function() {
             paddingVertical: 0,
             paddingHorizontal: 0,
             width: loadWindowWidth(id, 500),
-            height: loadWindowHeight(id, 420),
+            height: loadWindowHeight(id, 600),
             onResize: function() {
                 saveWindowSize(id);
             }
@@ -179,7 +179,7 @@ const initializeWindows = function() {
             paddingVertical: 0,
             paddingHorizontal: 0,
             width: loadWindowWidth(id, 700),
-            height: loadWindowHeight(id, 500),
+            height: loadWindowHeight(id, 600),
             onResize: function() {
                 saveWindowSize(id);
             }
@@ -200,7 +200,7 @@ const initializeWindows = function() {
             paddingVertical: 0,
             paddingHorizontal: 0,
             width: loadWindowWidth(id, 500),
-            height: loadWindowHeight(id, 260),
+            height: loadWindowHeight(id, 460),
             onResize: function() {
                 saveWindowSize(id);
             }
@@ -928,7 +928,7 @@ const initializeWindows = function() {
             toolbarURL: 'aboutToolbar.html',
             padding: 10,
             width: loadWindowWidth(id, 550),
-            height: loadWindowHeight(id, 290),
+            height: loadWindowHeight(id, 360),
             onResize: function() {
                 saveWindowSize(id);
             }


### PR DESCRIPTION
All windows should display their full content without a scroll bar, when possible. Using a max height of 600px to avoid unnecessarily tall windows.

![Screen Shot 2019-08-06 at 1 43 24 AM](https://user-images.githubusercontent.com/8296030/62525518-6b304080-b7ec-11e9-8b8c-f4623a458c15.png)
![Screen Shot 2019-08-06 at 1 43 37 AM](https://user-images.githubusercontent.com/8296030/62525527-6c616d80-b7ec-11e9-9d72-f1d997929050.png)
