### PR TITLE
Fix translation issues

### DIFF
--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -1162,7 +1162,7 @@
                  <item row="1" column="0">
                   <widget class="QLabel" name="label_2">
                    <property name="text">
-                    <string>To:</string>
+                    <string comment="To receiver">To:</string>
                    </property>
                   </widget>
                  </item>
@@ -1182,7 +1182,7 @@
                  <item row="0" column="0">
                   <widget class="QLabel" name="label_25">
                    <property name="text">
-                    <string>From:</string>
+                    <string comment="From sender">From:</string>
                    </property>
                   </widget>
                  </item>
@@ -1908,7 +1908,7 @@
                   <item row="0" column="0">
                    <widget class="QLabel" name="label_6">
                     <property name="text">
-                     <string extracomment="from (time1 to time2)">From:</string>
+                     <string comment="From start time">From:</string>
                     </property>
                    </widget>
                   </item>
@@ -1932,7 +1932,7 @@
                   <item row="0" column="2">
                    <widget class="QLabel" name="label_17">
                     <property name="text">
-                     <string extracomment="time1 to time2">To:</string>
+                     <string comment="To end time">To:</string>
                     </property>
                    </widget>
                   </item>

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -349,7 +349,7 @@
                 </tr>
             </table>
             <div class="formRow">
-                <span>Info: The password is saved unencrypted</span>
+                <span>QBT_TR(Info: The password is saved unencrypted)QBT_TR[CONTEXT=OptionsDialog]</span>
             </div>
         </fieldset>
     </fieldset>
@@ -2035,7 +2035,7 @@
         settings.set('save_resume_data_interval', $('saveResumeDataInterval').getProperty('value'));
         settings.set('recheck_completed_torrents', $('recheckTorrentsOnCompletion').getProperty('checked'));
         settings.set('resolve_peer_countries', $('resolvePeerCountries').getProperty('checked'));
-        
+
         // libtorrent section
         settings.set('async_io_threads', $('asyncIOThreads').getProperty('value'));
         settings.set('file_pool_size', $('filePoolSize').getProperty('value'));


### PR DESCRIPTION
By using disambiguation field instead of comment field to differentiate translations.

Closes #11062.
