### PR TITLE
Reorganize UI theme selection

### DIFF
--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -82,10 +82,6 @@ enum AdvSettingsRows
     DOWNLOAD_TRACKER_FAVICON,
     SAVE_PATH_HISTORY_LENGTH,
     ENABLE_SPEED_WIDGET,
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
-    USE_ICON_THEME,
-#endif
-
     // libtorrent section
     LIBTORRENT_HEADER,
     ASYNC_IO_THREADS,
@@ -252,10 +248,6 @@ void AdvancedSettings::saveAdvancedSettings()
     // Seed choking algorithm
     session->setSeedChokingAlgorithm(static_cast<BitTorrent::SeedChokingAlgorithm>(m_comboBoxSeedChokingAlgorithm.currentIndex()));
 
-    // Icon theme
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
-    pref->useSystemIconTheme(m_checkBoxUseIconTheme.isChecked());
-#endif
     pref->setConfirmTorrentRecheck(m_checkBoxConfirmTorrentRecheck.isChecked());
 
     pref->setConfirmRemoveAllTags(m_checkBoxConfirmRemoveAllTags.isChecked());
@@ -561,10 +553,6 @@ void AdvancedSettings::loadAdvancedSettings()
     addRow(SEED_CHOKING_ALGORITHM, (tr("Upload choking algorithm") + ' ' + makeLink("https://www.libtorrent.org/reference-Settings.html#seed_choking_algorithm", "(?)"))
             , &m_comboBoxSeedChokingAlgorithm);
 
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
-    m_checkBoxUseIconTheme.setChecked(pref->useSystemIconTheme());
-    addRow(USE_ICON_THEME, tr("Use system icon theme"), &m_checkBoxUseIconTheme);
-#endif
     // Torrent recheck confirmation
     m_checkBoxConfirmTorrentRecheck.setChecked(pref->confirmTorrentRecheck());
     addRow(CONFIRM_RECHECK_TORRENT, tr("Confirm torrent recheck"), &m_checkBoxConfirmTorrentRecheck);

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -69,9 +69,7 @@ private:
     QLineEdit m_lineEditAnnounceIP;
 
     // OS dependent settings
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
-    QCheckBox m_checkBoxUseIconTheme;
-#elif defined(Q_OS_WIN)
+#if defined(Q_OS_WIN)
     QComboBox m_comboBoxOSMemoryPriority;
 #endif
 };

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -175,7 +175,17 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     // Languages supported
     initializeLanguageCombo();
 
-    initializeThemeCombo();
+    m_ui->checkUseCustomTheme->setChecked(Preferences::instance()->useCustomUITheme());
+    m_ui->customThemeFilePath->setSelectedPath(Preferences::instance()->customUIThemePath());
+    m_ui->customThemeFilePath->setMode(FileSystemPathEdit::Mode::FileOpen);
+    m_ui->customThemeFilePath->setDialogCaption(tr("Select qBittorrent UI Theme file"));
+    m_ui->customThemeFilePath->setFileNameFilter(tr("qBittorrent UI Theme file (*.qbtheme)"));
+
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
+    m_ui->checkUseSystemIcon->setChecked(Preferences::instance()->useSystemIconTheme());
+#else
+    m_ui->checkUseSystemIcon->setVisible(false);
+#endif
 
     // Load week days (scheduler)
     m_ui->comboBoxScheduleDays->addItems(translatedWeekdayNames());
@@ -218,7 +228,11 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     // Apply button is activated when a value is changed
     // Behavior tab
     connect(m_ui->comboI18n, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
-    connect(m_ui->comboTheme, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
+    connect(m_ui->checkUseCustomTheme, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->customThemeFilePath, &FileSystemPathEdit::selectedPathChanged, this, &ThisType::enableApplyButton);
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
+    connect(m_ui->checkUseSystemIcon, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+#endif
     connect(m_ui->confirmDeletion, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkAltRowColors, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkHideZero, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
@@ -496,38 +510,6 @@ void OptionsDialog::initializeLanguageCombo()
     }
 }
 
-void OptionsDialog::initializeThemeCombo()
-{
-    m_ui->comboTheme->addItem(tr("Default"));
-    const QString customUIThemePath = Preferences::instance()->customUIThemePath();
-    if (!customUIThemePath.isEmpty())
-        m_ui->comboTheme->addItem(Utils::Fs::toNativePath(customUIThemePath));
-    m_ui->comboTheme->insertSeparator(m_ui->comboTheme->count());
-    m_ui->comboTheme->addItem(tr("Select..."));
-    m_ui->comboTheme->setCurrentIndex(Preferences::instance()->useCustomUITheme() ? 1 : 0);
-
-    connect(m_ui->comboTheme, qOverload<int>(&QComboBox::currentIndexChanged), this, [this](const int index)
-    {
-        if (index != (m_ui->comboTheme->count() - 1))
-            return;
-
-        m_uiThemeFilePath = QFileDialog::getOpenFileName(this, tr("Select qBittorrent theme file"), {}, tr("qBittorrent Theme File (*.qbtheme)"));
-        m_ui->comboTheme->blockSignals(true);
-        if (!m_uiThemeFilePath.isEmpty()) {
-            if (m_ui->comboTheme->count() == 3)
-                m_ui->comboTheme->insertItem(1, Utils::Fs::toNativePath(m_uiThemeFilePath));
-            else
-                m_ui->comboTheme->setItemText(1, Utils::Fs::toNativePath(m_uiThemeFilePath));
-            m_ui->comboTheme->setCurrentIndex(1);
-        }
-        else {
-            // don't leave "Select..." as current text
-            m_ui->comboTheme->setCurrentIndex(Preferences::instance()->useCustomUITheme() ? 1 : 0);
-        }
-        m_ui->comboTheme->blockSignals(false);
-    });
-}
-
 // Main destructor
 OptionsDialog::~OptionsDialog()
 {
@@ -599,13 +581,12 @@ void OptionsDialog::saveOptions()
     // Behavior preferences
     pref->setLocale(locale);
 
-    if (!m_uiThemeFilePath.isEmpty()
-        && (m_ui->comboTheme->currentIndex() == 1)) {
-        // only change if current selection is still new m_uiThemeFilePath
-        pref->setCustomUIThemePath(m_uiThemeFilePath);
-        m_uiThemeFilePath.clear();
-    }
-    pref->setUseCustomUITheme(m_ui->comboTheme->currentIndex() == 1);
+    pref->setUseCustomUITheme(m_ui->checkUseCustomTheme->isChecked());
+    pref->setCustomUIThemePath(m_ui->customThemeFilePath->selectedPath());
+
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
+    pref->useSystemIconTheme(m_ui->checkUseSystemIcon->isChecked());
+#endif
 
     pref->setConfirmTorrentDeletion(m_ui->confirmDeletion->isChecked());
     pref->setAlternatingRowColors(m_ui->checkAltRowColors->isChecked());

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -117,7 +117,6 @@ private:
     void saveOptions();
     void loadOptions();
     void initializeLanguageCombo();
-    void initializeThemeCombo();
     static QString languageToLocalizedString(const QLocale &locale);
     // General options
     QString getLocale() const;
@@ -184,7 +183,6 @@ private:
     AdvancedSettings *m_advancedSettings;
     QList<QString> m_addedScanDirs;
     QList<QString> m_removedScanDirs;
-    QString m_uiThemeFilePath;
 };
 
 #endif // OPTIONSDIALOG_H

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -133,14 +133,56 @@
                <string>Interface</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_81">
-               <item row="0" column="0">
+               <item row="3" column="0" colspan="3">
+                <widget class="QGroupBox" name="checkUseCustomTheme">
+                 <property name="title">
+                  <string>Use custom UI Theme</string>
+                 </property>
+                 <property name="checkable">
+                  <bool>true</bool>
+                 </property>
+                 <layout class="QHBoxLayout" name="horizontalLayout_18">
+                  <item>
+                   <widget class="QLabel" name="label_16">
+                    <property name="text">
+                     <string>UI Theme file:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="FileSystemPathLineEdit" name="customThemeFilePath" native="true"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item row="1" column="2">
+                <spacer name="horizontalSpacer_111">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>200</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="1" column="0">
                 <widget class="QLabel" name="label_9">
                  <property name="text">
                   <string>Language:</string>
                  </property>
                 </widget>
                </item>
-               <item row="0" column="1">
+               <item row="2" column="0" colspan="2">
+                <widget class="QCheckBox" name="checkUseSystemIcon">
+                 <property name="text">
+                  <string>Use system icon theme</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
                 <widget class="QComboBox" name="comboI18n">
                  <property name="minimumSize">
                   <size>
@@ -156,56 +198,15 @@
                  </property>
                 </widget>
                </item>
-               <item row="0" column="2">
-                <widget class="QLabel" name="lbl_i18n_info_2">
-                 <property name="font">
-                  <font>
-                   <italic>true</italic>
-                  </font>
-                 </property>
-                 <property name="text">
-                  <string>(Requires restart)</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="3">
-                <spacer name="horizontalSpacer_111">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>200</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item row="1" column="0">
+               <item row="0" column="0" colspan="2">
                 <widget class="QLabel" name="label_15">
-                 <property name="text">
-                  <string>Theme:</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="1">
-                <widget class="QComboBox" name="comboTheme"/>
-               </item>
-               <item row="1" column="2">
-                <widget class="QLabel" name="lbl_i18n_info_3">
                  <property name="font">
                   <font>
                    <italic>true</italic>
                   </font>
                  </property>
                  <property name="text">
-                  <string>(Requires restart)</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                  <string>Changing Interface settings requires application restart</string>
                  </property>
                 </widget>
                </item>
@@ -3244,6 +3245,9 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
  <tabstops>
   <tabstop>tabOption</tabstop>
   <tabstop>comboI18n</tabstop>
+  <tabstop>checkUseSystemIcon</tabstop>
+  <tabstop>checkUseCustomTheme</tabstop>
+  <tabstop>customThemeFilePath</tabstop>
   <tabstop>checkStartPaused</tabstop>
   <tabstop>spinPort</tabstop>
   <tabstop>checkUPnP</tabstop>


### PR DESCRIPTION
Old:
![image](https://user-images.githubusercontent.com/34717789/59619595-8239a700-9148-11e9-80ac-563ae3e94bd4.png)
New: 
![image](https://user-images.githubusercontent.com/34717789/63225489-2645da00-c1ee-11e9-894f-1f14aae35f11.png)
![image](https://user-images.githubusercontent.com/34717789/63225507-470e2f80-c1ee-11e9-8c00-7e85574c2645.png)

Why GroupBox?
I want to add an option for "Use default Icon set".
