### PR TITLE
Move JavaScript code into explicit namespaces

### DIFF
--- a/src/webui/www/private/addpeers.html
+++ b/src/webui/www/private/addpeers.html
@@ -61,7 +61,7 @@
             <p>QBT_TR(List of peers to add (one IP per line):)QBT_TR[CONTEXT=PeersAdditionDialog]</p>
             <textarea id="peers" rows="10" style="width: 100%;" placeholder="QBT_TR(Format: IPv4:port / [IPv6]:port)QBT_TR[CONTEXT=PeersAdditionDialog]"></textarea>
             <div style="margin-top: 10px; text-align: center;">
-                <button onclick="window.parent.closeWindows();">QBT_TR(Cancel)QBT_TR[CONTEXT=PeersAdditionDialog]</button>
+                <button onclick="parent.closeWindows();">QBT_TR(Cancel)QBT_TR[CONTEXT=PeersAdditionDialog]</button>
                 <button id="addPeersOk">QBT_TR(Ok)QBT_TR[CONTEXT=PeersAdditionDialog]</button>
             </div>
         </div>

--- a/src/webui/www/private/download.html
+++ b/src/webui/www/private/download.html
@@ -27,7 +27,7 @@
                             <label for="autoTMM">QBT_TR(Torrent Management Mode:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
                         </td>
                         <td>
-                            <select id="autoTMM" name="autoTMM" onchange="changeTMM(this)">
+                            <select id="autoTMM" name="autoTMM" onchange="qBittorrent.Download.changeTMM(this)">
                                 <option selected value="false">Manual</option>
                                 <option value="true">Automatic</option>
                             </select>
@@ -63,7 +63,7 @@
                         </td>
                         <td>
                             <div class="select-watched-folder-editable">
-                                <select id="categorySelect" onchange="changeCategorySelect(this)">
+                                <select id="categorySelect" onchange="qBittorrent.Download.changeCategorySelect(this)">
                                     <option selected value="\other"></option>
                                 </select>
                                 <input name="category" type="text" value="" />

--- a/src/webui/www/private/newcategory.html
+++ b/src/webui/www/private/newcategory.html
@@ -30,18 +30,18 @@
         }).activate();
 
         window.addEvent('domready', function() {
-            const uriAction = safeTrim(new URI().getData('action'));
-            const uriHashes = safeTrim(new URI().getData('hashes'));
-            const uriCategoryName = safeTrim(new URI().getData('categoryName'));
-            const uriSavePath = safeTrim(new URI().getData('savePath'));
+            const uriAction = window.qBittorrent.Misc.safeTrim(new URI().getData('action'));
+            const uriHashes = window.qBittorrent.Misc.safeTrim(new URI().getData('hashes'));
+            const uriCategoryName = window.qBittorrent.Misc.safeTrim(new URI().getData('categoryName'));
+            const uriSavePath = window.qBittorrent.Misc.safeTrim(new URI().getData('savePath'));
 
             if (uriAction === "edit") {
                 if (!uriCategoryName)
                     return false;
 
                 $('categoryName').set('disabled', true);
-                $('categoryName').set('value', escapeHtml(uriCategoryName));
-                $('savePath').set('value', escapeHtml(uriSavePath));
+                $('categoryName').set('value', window.qBittorrent.Misc.escapeHtml(uriCategoryName));
+                $('savePath').set('value', window.qBittorrent.Misc.escapeHtml(uriSavePath));
                 $('savePath').focus();
             }
             else {
@@ -90,7 +90,7 @@
                                 }).send();
                             },
                             onError: function() {
-                                alert("QBT_TR(Unable to create category)QBT_TR[CONTEXT=HttpServer] " + escapeHtml(categoryName));
+                                alert("QBT_TR(Unable to create category)QBT_TR[CONTEXT=HttpServer] " + window.qBittorrent.Misc.escapeHtml(categoryName));
                             }
                         }).send();
                         break;

--- a/src/webui/www/private/newtag.html
+++ b/src/webui/www/private/newtag.html
@@ -30,8 +30,8 @@
         }).activate();
 
         window.addEvent('domready', function() {
-            const uriAction = safeTrim(new URI().getData('action'));
-            const uriHashes = safeTrim(new URI().getData('hashes'));
+            const uriAction = window.qBittorrent.Misc.safeTrim(new URI().getData('action'));
+            const uriHashes = window.qBittorrent.Misc.safeTrim(new URI().getData('hashes'));
 
             if (uriAction === 'create')
                 $('legendText').innerText = 'QBT_TR(Tag:)QBT_TR[CONTEXT=TagFilterWidget]';

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -24,20 +24,9 @@
 
 'use strict';
 
-this.torrentsTable = new TorrentsTable();
-const torrentTrackersTable = new TorrentTrackersTable();
-const torrentPeersTable = new TorrentPeersTable();
-const torrentFilesTable = new TorrentFilesTable();
-const searchResultsTable = new SearchResultsTable();
-const searchPluginsTable = new SearchPluginsTable();
+this.torrentsTable = new window.qBittorrent.DynamicTable.TorrentsTable();
 
 let updatePropertiesPanel = function() {};
-
-let updateTorrentData = function() {};
-let updateTrackersData = function() {};
-let updateTorrentPeersData = function() {};
-let updateWebSeedsData = function() {};
-let updateTorrentFilesData = function() {};
 
 this.updateMainData = function() {};
 let alternativeSpeedLimits = false;
@@ -365,12 +354,12 @@ window.addEvent('load', function() {
         const create_link = function(hash, text, count) {
             const html = '<a href="#" onclick="setCategoryFilter(' + hash + ');return false;">'
                 + '<img src="images/qbt-theme/inode-directory.svg"/>'
-                + escapeHtml(text) + ' (' + count + ')' + '</a>';
+                + window.qBittorrent.Misc.escapeHtml(text) + ' (' + count + ')' + '</a>';
             const el = new Element('li', {
                 id: hash,
                 html: html
             });
-            categoriesFilterContextMenu.addTarget(el);
+            window.qBittorrent.Filters.categoriesFilterContextMenu.addTarget(el);
             return el;
         };
 
@@ -422,12 +411,12 @@ window.addEvent('load', function() {
         const createLink = function(hash, text, count) {
             const html = '<a href="#" onclick="setTagFilter(' + hash + ');return false;">'
                 + '<img src="images/qbt-theme/inode-directory.svg"/>'
-                + escapeHtml(text) + ' (' + count + ')' + '</a>';
+                + window.qBittorrent.Misc.escapeHtml(text) + ' (' + count + ')' + '</a>';
             const el = new Element('li', {
                 id: hash,
                 html: html
             });
-            tagsFilterContextMenu.addTarget(el);
+            window.qBittorrent.Filters.tagsFilterContextMenu.addTarget(el);
             return el;
         };
 
@@ -579,11 +568,11 @@ window.addEvent('load', function() {
                     updateFiltersList();
                     if (update_categories) {
                         updateCategoryList();
-                        torrentsTableContextMenu.updateCategoriesSubMenu(category_list);
+                        window.qBittorrent.TransferList.contextMenu.updateCategoriesSubMenu(category_list);
                     }
                     if (updateTags) {
                         updateTagList();
-                        torrentsTableContextMenu.updateTagsSubMenu(tagList);
+                        window.qBittorrent.TransferList.contextMenu.updateTagsSubMenu(tagList);
                     }
 
                     if (full_update)
@@ -603,39 +592,39 @@ window.addEvent('load', function() {
     };
 
     const processServerState = function() {
-        let transfer_info = friendlyUnit(serverState.dl_info_speed, true);
+        let transfer_info = window.qBittorrent.Misc.friendlyUnit(serverState.dl_info_speed, true);
         if (serverState.dl_rate_limit > 0)
-            transfer_info += " [" + friendlyUnit(serverState.dl_rate_limit, true) + "]";
-        transfer_info += " (" + friendlyUnit(serverState.dl_info_data, false) + ")";
+            transfer_info += " [" + window.qBittorrent.Misc.friendlyUnit(serverState.dl_rate_limit, true) + "]";
+        transfer_info += " (" + window.qBittorrent.Misc.friendlyUnit(serverState.dl_info_data, false) + ")";
         $("DlInfos").set('html', transfer_info);
-        transfer_info = friendlyUnit(serverState.up_info_speed, true);
+        transfer_info = window.qBittorrent.Misc.friendlyUnit(serverState.up_info_speed, true);
         if (serverState.up_rate_limit > 0)
-            transfer_info += " [" + friendlyUnit(serverState.up_rate_limit, true) + "]";
-        transfer_info += " (" + friendlyUnit(serverState.up_info_data, false) + ")";
+            transfer_info += " [" + window.qBittorrent.Misc.friendlyUnit(serverState.up_rate_limit, true) + "]";
+        transfer_info += " (" + window.qBittorrent.Misc.friendlyUnit(serverState.up_info_data, false) + ")";
         $("UpInfos").set('html', transfer_info);
         if (speedInTitle) {
-            document.title = "QBT_TR([D: %1, U: %2] qBittorrent %3)QBT_TR[CONTEXT=MainWindow]".replace("%1", friendlyUnit(serverState.dl_info_speed, true)).replace("%2", friendlyUnit(serverState.up_info_speed, true)).replace("%3", qbtVersion());
+            document.title = "QBT_TR([D: %1, U: %2] qBittorrent %3)QBT_TR[CONTEXT=MainWindow]".replace("%1", window.qBittorrent.Misc.friendlyUnit(serverState.dl_info_speed, true)).replace("%2", window.qBittorrent.Misc.friendlyUnit(serverState.up_info_speed, true)).replace("%3", qbtVersion());
             document.title += " QBT_TR(Web UI)QBT_TR[CONTEXT=OptionsDialog]";
         }
         else
             document.title = ("qBittorrent " + qbtVersion() + " QBT_TR(Web UI)QBT_TR[CONTEXT=OptionsDialog]");
-        $('freeSpaceOnDisk').set('html', 'QBT_TR(Free space: %1)QBT_TR[CONTEXT=HttpServer]'.replace("%1", friendlyUnit(serverState.free_space_on_disk)));
+        $('freeSpaceOnDisk').set('html', 'QBT_TR(Free space: %1)QBT_TR[CONTEXT=HttpServer]'.replace("%1", window.qBittorrent.Misc.friendlyUnit(serverState.free_space_on_disk)));
         $('DHTNodes').set('html', 'QBT_TR(DHT: %1 nodes)QBT_TR[CONTEXT=StatusBar]'.replace("%1", serverState.dht_nodes));
 
         // Statistics dialog
         if (document.getElementById("statisticspage")) {
-            $('AlltimeDL').set('html', friendlyUnit(serverState.alltime_dl, false));
-            $('AlltimeUL').set('html', friendlyUnit(serverState.alltime_ul, false));
-            $('TotalWastedSession').set('html', friendlyUnit(serverState.total_wasted_session, false));
+            $('AlltimeDL').set('html', window.qBittorrent.Misc.friendlyUnit(serverState.alltime_dl, false));
+            $('AlltimeUL').set('html', window.qBittorrent.Misc.friendlyUnit(serverState.alltime_ul, false));
+            $('TotalWastedSession').set('html', window.qBittorrent.Misc.friendlyUnit(serverState.total_wasted_session, false));
             $('GlobalRatio').set('html', serverState.global_ratio);
             $('TotalPeerConnections').set('html', serverState.total_peer_connections);
             $('ReadCacheHits').set('html', serverState.read_cache_hits + "%");
-            $('TotalBuffersSize').set('html', friendlyUnit(serverState.total_buffers_size, false));
+            $('TotalBuffersSize').set('html', window.qBittorrent.Misc.friendlyUnit(serverState.total_buffers_size, false));
             $('WriteCacheOverload').set('html', serverState.write_cache_overload + "%");
             $('ReadCacheOverload').set('html', serverState.read_cache_overload + "%");
             $('QueuedIOJobs').set('html', serverState.queued_io_jobs);
             $('AverageTimeInQueue').set('html', serverState.average_time_queue + " ms");
-            $('TotalQueuedSize').set('html', friendlyUnit(serverState.total_queued_size, false));
+            $('TotalQueuedSize').set('html', window.qBittorrent.Misc.friendlyUnit(serverState.total_queued_size, false));
         }
 
         if (serverState.connection_status == "connected")
@@ -790,7 +779,7 @@ window.addEvent('load', function() {
 
     const showSearchTab = function() {
         if (!searchTabInitialized) {
-            initSearchTab();
+            window.qBittorrent.Search.init();
             searchTabInitialized = true;
         }
 
@@ -878,16 +867,26 @@ window.addEvent('load', function() {
             MochaUI.initializeTabs('propertiesTabs');
 
             updatePropertiesPanel = function() {
-                if (!$('prop_general').hasClass('invisible'))
-                    updateTorrentData();
-                else if (!$('prop_trackers').hasClass('invisible'))
-                    updateTrackersData();
-                else if (!$('prop_peers').hasClass('invisible'))
-                    updateTorrentPeersData();
-                else if (!$('prop_webseeds').hasClass('invisible'))
-                    updateWebSeedsData();
-                else if (!$('prop_files').hasClass('invisible'))
-                    updateTorrentFilesData();
+                if (!$('prop_general').hasClass('invisible')) {
+                    if (window.qBittorrent.PropGeneral !== undefined)
+                        window.qBittorrent.PropGeneral.updateData();
+                }
+                else if (!$('prop_trackers').hasClass('invisible')) {
+                    if (window.qBittorrent.PropTrackers !== undefined)
+                        window.qBittorrent.PropTrackers.updateData();
+                }
+                else if (!$('prop_peers').hasClass('invisible')) {
+                    if (window.qBittorrent.PropPeers !== undefined)
+                        window.qBittorrent.PropPeers.updateData();
+                }
+                else if (!$('prop_webseeds').hasClass('invisible')) {
+                    if (window.qBittorrent.PropWebseeds !== undefined)
+                        window.qBittorrent.PropWebseeds.updateData();
+                }
+                else if (!$('prop_files').hasClass('invisible')) {
+                    if (window.qBittorrent.PropFiles !== undefined)
+                        window.qBittorrent.PropFiles.updateData();
+                }
             };
 
             $('PropGeneralLink').addEvent('click', function(e) {

--- a/src/webui/www/private/scripts/contextmenu.js
+++ b/src/webui/www/private/scripts/contextmenu.js
@@ -28,497 +28,515 @@
 
 'use strict';
 
-let lastShownContextMenu = null;
-const ContextMenu = new Class({
-    //implements
-    Implements: [Options, Events],
+if (window.qBittorrent === undefined) {
+    window.qBittorrent = {};
+}
 
-    //options
-    options: {
-        actions: {},
-        menu: 'menu_id',
-        stopEvent: true,
-        targets: 'body',
-        offsets: {
-            x: 0,
-            y: 0
+window.qBittorrent.ContextMenu = (function() {
+    const exports = function() {
+        return {
+            ContextMenu: ContextMenu,
+            TorrentsTableContextMenu: TorrentsTableContextMenu,
+            CategoriesFilterContextMenu: CategoriesFilterContextMenu,
+            TagsFilterContextMenu: TagsFilterContextMenu,
+            SearchPluginsTableContextMenu: SearchPluginsTableContextMenu
+        };
+    };
+
+    let lastShownContextMenu = null;
+    const ContextMenu = new Class({
+        //implements
+        Implements: [Options, Events],
+
+        //options
+        options: {
+            actions: {},
+            menu: 'menu_id',
+            stopEvent: true,
+            targets: 'body',
+            offsets: {
+                x: 0,
+                y: 0
+            },
+            onShow: $empty,
+            onHide: $empty,
+            onClick: $empty,
+            fadeSpeed: 200,
+            touchTimer: 600
         },
-        onShow: $empty,
-        onHide: $empty,
-        onClick: $empty,
-        fadeSpeed: 200,
-        touchTimer: 600
-    },
 
-    //initialization
-    initialize: function(options) {
-        //set options
-        this.setOptions(options);
+        //initialization
+        initialize: function(options) {
+            //set options
+            this.setOptions(options);
 
-        //option diffs menu
-        this.menu = $(this.options.menu);
-        this.targets = $$(this.options.targets);
+            //option diffs menu
+            this.menu = $(this.options.menu);
+            this.targets = $$(this.options.targets);
 
-        //fx
-        this.fx = new Fx.Tween(this.menu, {
-            property: 'opacity',
-            duration: this.options.fadeSpeed,
-            onComplete: function() {
-                if (this.getStyle('opacity')) {
-                    this.setStyle('visibility', 'visible');
-                }
-                else {
-                    this.setStyle('visibility', 'hidden');
-                }
-            }.bind(this.menu)
-        });
+            //fx
+            this.fx = new Fx.Tween(this.menu, {
+                property: 'opacity',
+                duration: this.options.fadeSpeed,
+                onComplete: function() {
+                    if (this.getStyle('opacity')) {
+                        this.setStyle('visibility', 'visible');
+                    }
+                    else {
+                        this.setStyle('visibility', 'hidden');
+                    }
+                }.bind(this.menu)
+            });
 
-        //hide and begin the listener
-        this.hide().startListener();
+            //hide and begin the listener
+            this.hide().startListener();
+
+            //hide the menu
+            this.menu.setStyles({
+                'position': 'absolute',
+                'top': '-900000px',
+                'display': 'block'
+            });
+        },
+
+        adjustMenuPosition: function(e) {
+            this.updateMenuItems();
+
+            const scrollableMenuMaxHeight = document.documentElement.clientHeight * 0.75;
+
+            if (this.menu.hasClass('scrollableMenu'))
+                this.menu.setStyle('max-height', scrollableMenuMaxHeight);
+
+            // draw the menu off-screen to know the menu dimensions
+            this.menu.setStyles({
+                left: '-999em',
+                top: '-999em'
+            });
+
+            // position the menu
+            let xPosMenu = e.page.x + this.options.offsets.x;
+            let yPosMenu = e.page.y + this.options.offsets.y;
+            if (xPosMenu + this.menu.offsetWidth > document.documentElement.clientWidth)
+                xPosMenu -= this.menu.offsetWidth;
+            if (yPosMenu + this.menu.offsetHeight > document.documentElement.clientHeight)
+                yPosMenu = document.documentElement.clientHeight - this.menu.offsetHeight;
+            if (xPosMenu < 0)
+                xPosMenu = 0;
+            if (yPosMenu < 0)
+                yPosMenu = 0;
+            this.menu.setStyles({
+                left: xPosMenu,
+                top: yPosMenu,
+                position: 'absolute',
+                'z-index': '2000'
+            });
+
+            // position the sub-menu
+            const uls = this.menu.getElementsByTagName('ul');
+            for (let i = 0; i < uls.length; ++i) {
+                const ul = uls[i];
+                if (ul.hasClass('scrollableMenu'))
+                    ul.setStyle('max-height', scrollableMenuMaxHeight);
+                const rectParent = ul.parentNode.getBoundingClientRect();
+                const xPosOrigin = rectParent.left;
+                const yPosOrigin = rectParent.bottom;
+                let xPos = xPosOrigin + rectParent.width - 1;
+                let yPos = yPosOrigin - rectParent.height - 1;
+                if (xPos + ul.offsetWidth > document.documentElement.clientWidth)
+                    xPos -= (ul.offsetWidth + rectParent.width - 2);
+                if (yPos + ul.offsetHeight > document.documentElement.clientHeight)
+                    yPos = document.documentElement.clientHeight - ul.offsetHeight;
+                if (xPos < 0)
+                    xPos = 0;
+                if (yPos < 0)
+                    yPos = 0;
+                ul.setStyles({
+                    'margin-left': xPos - xPosOrigin,
+                    'margin-top': yPos - yPosOrigin
+                });
+            }
+        },
+
+        setupEventListeners: function(elem) {
+            elem.addEvent('contextmenu', function(e) {
+                this.triggerMenu(e, elem);
+            }.bind(this));
+            elem.addEvent('click', function(e) {
+                this.hide();
+            }.bind(this));
+
+            elem.addEvent('touchstart', function(e) {
+                e.preventDefault();
+                clearTimeout(this.touchstartTimer);
+                this.hide();
+
+                const touchstartEvent = e;
+                this.touchstartTimer = setTimeout(function() {
+                    this.triggerMenu(touchstartEvent, elem);
+                }.bind(this), this.options.touchTimer);
+            }.bind(this));
+            elem.addEvent('touchend', function(e) {
+                e.preventDefault();
+                clearTimeout(this.touchstartTimer);
+            }.bind(this));
+        },
+
+        addTarget: function(t) {
+            this.targets[this.targets.length] = t;
+            this.setupEventListeners(t);
+        },
+
+        triggerMenu: function(e, el) {
+            if (this.options.disabled)
+                return;
+
+            //prevent default, if told to
+            if (this.options.stopEvent) {
+                e.stop();
+            }
+            //record this as the trigger
+            this.options.element = $(el);
+            this.adjustMenuPosition(e);
+            //show the menu
+            this.show();
+        },
+
+        //get things started
+        startListener: function() {
+            /* all elements */
+            this.targets.each(function(el) {
+                this.setupEventListeners(el);
+            }.bind(this), this);
+
+            /* menu items */
+            this.menu.getElements('a').each(function(item) {
+                item.addEvent('click', function(e) {
+                    e.preventDefault();
+                    if (!item.hasClass('disabled')) {
+                        this.execute(item.get('href').split('#')[1], $(this.options.element));
+                        this.fireEvent('click', [item, e]);
+                    }
+                }.bind(this));
+            }, this);
+
+            //hide on body click
+            $(document.body).addEvent('click', function() {
+                this.hide();
+            }.bind(this));
+        },
+
+        updateMenuItems: function() {},
+
+        //show menu
+        show: function(trigger) {
+            if (lastShownContextMenu && lastShownContextMenu != this)
+                lastShownContextMenu.hide();
+            this.fx.start(1);
+            this.fireEvent('show');
+            this.shown = true;
+            lastShownContextMenu = this;
+            return this;
+        },
 
         //hide the menu
-        this.menu.setStyles({
-            'position': 'absolute',
-            'top': '-900000px',
-            'display': 'block'
-        });
-    },
+        hide: function(trigger) {
+            if (this.shown) {
+                this.fx.start(0);
+                //this.menu.fade('out');
+                this.fireEvent('hide');
+                this.shown = false;
+            }
+            return this;
+        },
 
-    adjustMenuPosition: function(e) {
-        this.updateMenuItems();
+        setItemChecked: function(item, checked) {
+            this.menu.getElement('a[href$=' + item + ']').firstChild.style.opacity =
+                checked ? '1' : '0';
+            return this;
+        },
 
-        const scrollableMenuMaxHeight = document.documentElement.clientHeight * 0.75;
+        getItemChecked: function(item) {
+            return '0' != this.menu.getElement('a[href$=' + item + ']').firstChild.style.opacity;
+        },
 
-        if (this.menu.hasClass('scrollableMenu'))
-            this.menu.setStyle('max-height', scrollableMenuMaxHeight);
+        //hide an item
+        hideItem: function(item) {
+            this.menu.getElement('a[href$=' + item + ']').parentNode.addClass('invisible');
+            return this;
+        },
 
-        // draw the menu off-screen to know the menu dimensions
-        this.menu.setStyles({
-            left: '-999em',
-            top: '-999em'
-        });
+        //show an item
+        showItem: function(item) {
+            this.menu.getElement('a[href$=' + item + ']').parentNode.removeClass('invisible');
+            return this;
+        },
 
-        // position the menu
-        let xPosMenu = e.page.x + this.options.offsets.x;
-        let yPosMenu = e.page.y + this.options.offsets.y;
-        if (xPosMenu + this.menu.offsetWidth > document.documentElement.clientWidth)
-            xPosMenu -= this.menu.offsetWidth;
-        if (yPosMenu + this.menu.offsetHeight > document.documentElement.clientHeight)
-            yPosMenu = document.documentElement.clientHeight - this.menu.offsetHeight;
-        if (xPosMenu < 0)
-            xPosMenu = 0;
-        if (yPosMenu < 0)
-            yPosMenu = 0;
-        this.menu.setStyles({
-            left: xPosMenu,
-            top: yPosMenu,
-            position: 'absolute',
-            'z-index': '2000'
-        });
+        //disable the entire menu
+        disable: function() {
+            this.options.disabled = true;
+            return this;
+        },
 
-        // position the sub-menu
-        const uls = this.menu.getElementsByTagName('ul');
-        for (let i = 0; i < uls.length; ++i) {
-            const ul = uls[i];
-            if (ul.hasClass('scrollableMenu'))
-                ul.setStyle('max-height', scrollableMenuMaxHeight);
-            const rectParent = ul.parentNode.getBoundingClientRect();
-            const xPosOrigin = rectParent.left;
-            const yPosOrigin = rectParent.bottom;
-            let xPos = xPosOrigin + rectParent.width - 1;
-            let yPos = yPosOrigin - rectParent.height - 1;
-            if (xPos + ul.offsetWidth > document.documentElement.clientWidth)
-                xPos -= (ul.offsetWidth + rectParent.width - 2);
-            if (yPos + ul.offsetHeight > document.documentElement.clientHeight)
-                yPos = document.documentElement.clientHeight - ul.offsetHeight;
-            if (xPos < 0)
-                xPos = 0;
-            if (yPos < 0)
-                yPos = 0;
-            ul.setStyles({
-                'margin-left': xPos - xPosOrigin,
-                'margin-top': yPos - yPosOrigin
-            });
+        //enable the entire menu
+        enable: function() {
+            this.options.disabled = false;
+            return this;
+        },
+
+        //execute an action
+        execute: function(action, element) {
+            if (this.options.actions[action]) {
+                this.options.actions[action](element, this, action);
+            }
+            return this;
         }
-    },
+    });
 
-    setupEventListeners: function(elem) {
-        elem.addEvent('contextmenu', function(e) {
-            this.triggerMenu(e, elem);
-        }.bind(this));
-        elem.addEvent('click', function(e) {
-            this.hide();
-        }.bind(this));
+    const TorrentsTableContextMenu = new Class({
+        Extends: ContextMenu,
 
-        elem.addEvent('touchstart', function(e) {
-            e.preventDefault();
-            clearTimeout(this.touchstartTimer);
-            this.hide();
+        updateMenuItems: function() {
+            let all_are_seq_dl = true;
+            let there_are_seq_dl = false;
+            let all_are_f_l_piece_prio = true;
+            let there_are_f_l_piece_prio = false;
+            let all_are_downloaded = true;
+            let all_are_paused = true;
+            let there_are_paused = false;
+            let all_are_force_start = true;
+            let there_are_force_start = false;
+            let all_are_super_seeding = true;
+            let all_are_auto_tmm = true;
+            let there_are_auto_tmm = false;
+            const tagsSelectionState = Object.clone(tagList);
 
-            const touchstartEvent = e;
-            this.touchstartTimer = setTimeout(function() {
-                this.triggerMenu(touchstartEvent, elem);
-            }.bind(this), this.options.touchTimer);
-        }.bind(this));
-        elem.addEvent('touchend', function(e) {
-            e.preventDefault();
-            clearTimeout(this.touchstartTimer);
-        }.bind(this));
-    },
+            const h = torrentsTable.selectedRowsIds();
+            h.each(function(item, index) {
+                const data = torrentsTable.rows.get(item).full_data;
 
-    addTarget: function(t) {
-        this.targets[this.targets.length] = t;
-        this.setupEventListeners(t);
-    },
-
-    triggerMenu: function(e, el) {
-        if (this.options.disabled)
-            return;
-
-        //prevent default, if told to
-        if (this.options.stopEvent) {
-            e.stop();
-        }
-        //record this as the trigger
-        this.options.element = $(el);
-        this.adjustMenuPosition(e);
-        //show the menu
-        this.show();
-    },
-
-    //get things started
-    startListener: function() {
-        /* all elements */
-        this.targets.each(function(el) {
-            this.setupEventListeners(el);
-        }.bind(this), this);
-
-        /* menu items */
-        this.menu.getElements('a').each(function(item) {
-            item.addEvent('click', function(e) {
-                e.preventDefault();
-                if (!item.hasClass('disabled')) {
-                    this.execute(item.get('href').split('#')[1], $(this.options.element));
-                    this.fireEvent('click', [item, e]);
-                }
-            }.bind(this));
-        }, this);
-
-        //hide on body click
-        $(document.body).addEvent('click', function() {
-            this.hide();
-        }.bind(this));
-    },
-
-    updateMenuItems: function() {},
-
-    //show menu
-    show: function(trigger) {
-        if (lastShownContextMenu && lastShownContextMenu != this)
-            lastShownContextMenu.hide();
-        this.fx.start(1);
-        this.fireEvent('show');
-        this.shown = true;
-        lastShownContextMenu = this;
-        return this;
-    },
-
-    //hide the menu
-    hide: function(trigger) {
-        if (this.shown) {
-            this.fx.start(0);
-            //this.menu.fade('out');
-            this.fireEvent('hide');
-            this.shown = false;
-        }
-        return this;
-    },
-
-    setItemChecked: function(item, checked) {
-        this.menu.getElement('a[href$=' + item + ']').firstChild.style.opacity =
-            checked ? '1' : '0';
-        return this;
-    },
-
-    getItemChecked: function(item) {
-        return '0' != this.menu.getElement('a[href$=' + item + ']').firstChild.style.opacity;
-    },
-
-    //hide an item
-    hideItem: function(item) {
-        this.menu.getElement('a[href$=' + item + ']').parentNode.addClass('invisible');
-        return this;
-    },
-
-    //show an item
-    showItem: function(item) {
-        this.menu.getElement('a[href$=' + item + ']').parentNode.removeClass('invisible');
-        return this;
-    },
-
-    //disable the entire menu
-    disable: function() {
-        this.options.disabled = true;
-        return this;
-    },
-
-    //enable the entire menu
-    enable: function() {
-        this.options.disabled = false;
-        return this;
-    },
-
-    //execute an action
-    execute: function(action, element) {
-        if (this.options.actions[action]) {
-            this.options.actions[action](element, this, action);
-        }
-        return this;
-    }
-});
-
-const TorrentsTableContextMenu = new Class({
-    Extends: ContextMenu,
-
-    updateMenuItems: function() {
-        let all_are_seq_dl = true;
-        let there_are_seq_dl = false;
-        let all_are_f_l_piece_prio = true;
-        let there_are_f_l_piece_prio = false;
-        let all_are_downloaded = true;
-        let all_are_paused = true;
-        let there_are_paused = false;
-        let all_are_force_start = true;
-        let there_are_force_start = false;
-        let all_are_super_seeding = true;
-        let all_are_auto_tmm = true;
-        let there_are_auto_tmm = false;
-        const tagsSelectionState = Object.clone(tagList);
-
-        const h = torrentsTable.selectedRowsIds();
-        h.each(function(item, index) {
-            const data = torrentsTable.rows.get(item).full_data;
-
-            if (data['seq_dl'] !== true)
-                all_are_seq_dl = false;
-            else
-                there_are_seq_dl = true;
-
-            if (data['f_l_piece_prio'] !== true)
-                all_are_f_l_piece_prio = false;
-            else
-                there_are_f_l_piece_prio = true;
-
-            if (data['progress'] != 1.0) // not downloaded
-                all_are_downloaded = false;
-            else if (data['super_seeding'] !== true)
-                all_are_super_seeding = false;
-
-            if (data['state'] != 'pausedUP' && data['state'] != 'pausedDL')
-                all_are_paused = false;
-            else
-                there_are_paused = true;
-
-            if (data['force_start'] !== true)
-                all_are_force_start = false;
-            else
-                there_are_force_start = true;
-
-            if (data['auto_tmm'] === true)
-                there_are_auto_tmm = true;
-            else
-                all_are_auto_tmm = false;
-
-            const torrentTags = data['tags'].split(', ');
-            for (const key in tagsSelectionState) {
-                const tag = tagsSelectionState[key];
-                const tagExists = torrentTags.contains(tag.name);
-                if ((tag.checked !== undefined) && (tag.checked != tagExists))
-                    tag.indeterminate = true;
-                if (tag.checked === undefined)
-                    tag.checked = tagExists;
+                if (data['seq_dl'] !== true)
+                    all_are_seq_dl = false;
                 else
-                    tag.checked = tag.checked && tagExists;
-            }
-        });
+                    there_are_seq_dl = true;
 
-        let show_seq_dl = true;
+                if (data['f_l_piece_prio'] !== true)
+                    all_are_f_l_piece_prio = false;
+                else
+                    there_are_f_l_piece_prio = true;
 
-        if (!all_are_seq_dl && there_are_seq_dl)
-            show_seq_dl = false;
+                if (data['progress'] != 1.0) // not downloaded
+                    all_are_downloaded = false;
+                else if (data['super_seeding'] !== true)
+                    all_are_super_seeding = false;
 
-        let show_f_l_piece_prio = true;
+                if (data['state'] != 'pausedUP' && data['state'] != 'pausedDL')
+                    all_are_paused = false;
+                else
+                    there_are_paused = true;
 
-        if (!all_are_f_l_piece_prio && there_are_f_l_piece_prio)
-            show_f_l_piece_prio = false;
+                if (data['force_start'] !== true)
+                    all_are_force_start = false;
+                else
+                    there_are_force_start = true;
 
-        if (all_are_downloaded) {
-            this.hideItem('downloadLimit');
-            this.menu.getElement('a[href$=uploadLimit]').parentNode.addClass('separator');
-            this.hideItem('sequentialDownload');
-            this.hideItem('firstLastPiecePrio');
-            this.showItem('superSeeding');
-            this.setItemChecked('superSeeding', all_are_super_seeding);
-        }
-        else {
-            if (!show_seq_dl && show_f_l_piece_prio)
-                this.menu.getElement('a[href$=firstLastPiecePrio]').parentNode.addClass('separator');
-            else
-                this.menu.getElement('a[href$=firstLastPiecePrio]').parentNode.removeClass('separator');
+                if (data['auto_tmm'] === true)
+                    there_are_auto_tmm = true;
+                else
+                    all_are_auto_tmm = false;
 
-            if (show_seq_dl)
-                this.showItem('sequentialDownload');
-            else
+                const torrentTags = data['tags'].split(', ');
+                for (const key in tagsSelectionState) {
+                    const tag = tagsSelectionState[key];
+                    const tagExists = torrentTags.contains(tag.name);
+                    if ((tag.checked !== undefined) && (tag.checked != tagExists))
+                        tag.indeterminate = true;
+                    if (tag.checked === undefined)
+                        tag.checked = tagExists;
+                    else
+                        tag.checked = tag.checked && tagExists;
+                }
+            });
+
+            let show_seq_dl = true;
+
+            if (!all_are_seq_dl && there_are_seq_dl)
+                show_seq_dl = false;
+
+            let show_f_l_piece_prio = true;
+
+            if (!all_are_f_l_piece_prio && there_are_f_l_piece_prio)
+                show_f_l_piece_prio = false;
+
+            if (all_are_downloaded) {
+                this.hideItem('downloadLimit');
+                this.menu.getElement('a[href$=uploadLimit]').parentNode.addClass('separator');
                 this.hideItem('sequentialDownload');
-
-            if (show_f_l_piece_prio)
-                this.showItem('firstLastPiecePrio');
-            else
                 this.hideItem('firstLastPiecePrio');
-
-            this.setItemChecked('sequentialDownload', all_are_seq_dl);
-            this.setItemChecked('firstLastPiecePrio', all_are_f_l_piece_prio);
-
-            this.showItem('downloadLimit');
-            this.menu.getElement('a[href$=uploadLimit]').parentNode.removeClass('separator');
-            this.hideItem('superSeeding');
-        }
-
-        this.showItem('start');
-        this.showItem('pause');
-        this.showItem('forceStart');
-        if (all_are_paused)
-            this.hideItem('pause');
-        else if (all_are_force_start)
-            this.hideItem('forceStart');
-        else if (!there_are_paused && !there_are_force_start)
-            this.hideItem('start');
-
-        if (!all_are_auto_tmm && there_are_auto_tmm) {
-            this.hideItem('autoTorrentManagement');
-        }
-        else {
-            this.showItem('autoTorrentManagement');
-            this.setItemChecked('autoTorrentManagement', all_are_auto_tmm);
-        }
-
-        const contextTagList = $('contextTagList');
-        for (const tagHash in tagList) {
-            const checkbox = contextTagList.getElement('a[href=#Tag/' + tagHash + '] input[type=checkbox]');
-            const checkboxState = tagsSelectionState[tagHash];
-            checkbox.indeterminate = checkboxState.indeterminate;
-            checkbox.checked = checkboxState.checked;
-        }
-    },
-
-    updateCategoriesSubMenu: function(category_list) {
-        const categoryList = $('contextCategoryList');
-        categoryList.empty();
-        categoryList.appendChild(new Element('li', {
-            html: '<a href="javascript:torrentNewCategoryFN();"><img src="images/qbt-theme/list-add.svg" alt="QBT_TR(New...)QBT_TR[CONTEXT=TransferListWidget]"/> QBT_TR(New...)QBT_TR[CONTEXT=TransferListWidget]</a>'
-        }));
-        categoryList.appendChild(new Element('li', {
-            html: '<a href="javascript:torrentSetCategoryFN(0);"><img src="images/qbt-theme/edit-clear.svg" alt="QBT_TR(Reset)QBT_TR[CONTEXT=TransferListWidget]"/> QBT_TR(Reset)QBT_TR[CONTEXT=TransferListWidget]</a>'
-        }));
-
-        const sortedCategories = [];
-        Object.each(category_list, function(category) {
-            sortedCategories.push(category.name);
-        });
-        sortedCategories.sort();
-
-        let first = true;
-        Object.each(sortedCategories, function(categoryName) {
-            const categoryHash = genHash(categoryName);
-            const el = new Element('li', {
-                html: '<a href="javascript:torrentSetCategoryFN(\'' + categoryHash + '\');"><img src="images/qbt-theme/inode-directory.svg"/> ' + escapeHtml(categoryName) + '</a>'
-            });
-            if (first) {
-                el.addClass('separator');
-                first = false;
+                this.showItem('superSeeding');
+                this.setItemChecked('superSeeding', all_are_super_seeding);
             }
-            categoryList.appendChild(el);
-        });
-    },
+            else {
+                if (!show_seq_dl && show_f_l_piece_prio)
+                    this.menu.getElement('a[href$=firstLastPiecePrio]').parentNode.addClass('separator');
+                else
+                    this.menu.getElement('a[href$=firstLastPiecePrio]').parentNode.removeClass('separator');
 
-    updateTagsSubMenu: function(tagList) {
-        const contextTagList = $('contextTagList');
-        while (contextTagList.firstChild !== null)
-            contextTagList.removeChild(contextTagList.firstChild);
+                if (show_seq_dl)
+                    this.showItem('sequentialDownload');
+                else
+                    this.hideItem('sequentialDownload');
 
-        contextTagList.appendChild(new Element('li', {
-            html: '<a href="javascript:torrentAddTagsFN();">'
-                + '<img src="images/qbt-theme/list-add.svg" alt="QBT_TR(Add...)QBT_TR[CONTEXT=TransferListWidget]"/>'
-                + ' QBT_TR(Add...)QBT_TR[CONTEXT=TransferListWidget]'
-                + '</a>'
-        }));
-        contextTagList.appendChild(new Element('li', {
-            html: '<a href="javascript:torrentRemoveAllTagsFN();">'
-                + '<img src="images/qbt-theme/edit-clear.svg" alt="QBT_TR(Remove All)QBT_TR[CONTEXT=TransferListWidget]"/>'
-                + ' QBT_TR(Remove All)QBT_TR[CONTEXT=TransferListWidget]'
-                + '</a>'
-        }));
+                if (show_f_l_piece_prio)
+                    this.showItem('firstLastPiecePrio');
+                else
+                    this.hideItem('firstLastPiecePrio');
 
-        const sortedTags = [];
-        for (const key in tagList)
-            sortedTags.push(tagList[key].name);
-        sortedTags.sort();
+                this.setItemChecked('sequentialDownload', all_are_seq_dl);
+                this.setItemChecked('firstLastPiecePrio', all_are_f_l_piece_prio);
 
-        for (let i = 0; i < sortedTags.length; ++i) {
-            const tagName = sortedTags[i];
-            const tagHash = genHash(tagName);
-            const el = new Element('li', {
-                html: '<a href="#Tag/' + tagHash + '" onclick="event.preventDefault(); torrentSetTagsFN(\'' + tagHash + '\', !event.currentTarget.getElement(\'input[type=checkbox]\').checked);">'
-                    + '<input type="checkbox" onclick="this.checked = !this.checked;"> ' + escapeHtml(tagName)
-                    + '</a>'
+                this.showItem('downloadLimit');
+                this.menu.getElement('a[href$=uploadLimit]').parentNode.removeClass('separator');
+                this.hideItem('superSeeding');
+            }
+
+            this.showItem('start');
+            this.showItem('pause');
+            this.showItem('forceStart');
+            if (all_are_paused)
+                this.hideItem('pause');
+            else if (all_are_force_start)
+                this.hideItem('forceStart');
+            else if (!there_are_paused && !there_are_force_start)
+                this.hideItem('start');
+
+            if (!all_are_auto_tmm && there_are_auto_tmm) {
+                this.hideItem('autoTorrentManagement');
+            }
+            else {
+                this.showItem('autoTorrentManagement');
+                this.setItemChecked('autoTorrentManagement', all_are_auto_tmm);
+            }
+
+            const contextTagList = $('contextTagList');
+            for (const tagHash in tagList) {
+                const checkbox = contextTagList.getElement('a[href=#Tag/' + tagHash + '] input[type=checkbox]');
+                const checkboxState = tagsSelectionState[tagHash];
+                checkbox.indeterminate = checkboxState.indeterminate;
+                checkbox.checked = checkboxState.checked;
+            }
+        },
+
+        updateCategoriesSubMenu: function(category_list) {
+            const categoryList = $('contextCategoryList');
+            categoryList.empty();
+            categoryList.appendChild(new Element('li', {
+                html: '<a href="javascript:torrentNewCategoryFN();"><img src="images/qbt-theme/list-add.svg" alt="QBT_TR(New...)QBT_TR[CONTEXT=TransferListWidget]"/> QBT_TR(New...)QBT_TR[CONTEXT=TransferListWidget]</a>'
+            }));
+            categoryList.appendChild(new Element('li', {
+                html: '<a href="javascript:torrentSetCategoryFN(0);"><img src="images/qbt-theme/edit-clear.svg" alt="QBT_TR(Reset)QBT_TR[CONTEXT=TransferListWidget]"/> QBT_TR(Reset)QBT_TR[CONTEXT=TransferListWidget]</a>'
+            }));
+
+            const sortedCategories = [];
+            Object.each(category_list, function(category) {
+                sortedCategories.push(category.name);
             });
-            if (i === 0)
-                el.addClass('separator');
-            contextTagList.appendChild(el);
+            sortedCategories.sort();
+
+            let first = true;
+            Object.each(sortedCategories, function(categoryName) {
+                const categoryHash = genHash(categoryName);
+                const el = new Element('li', {
+                    html: '<a href="javascript:torrentSetCategoryFN(\'' + categoryHash + '\');"><img src="images/qbt-theme/inode-directory.svg"/> ' + window.qBittorrent.Misc.escapeHtml(categoryName) + '</a>'
+                });
+                if (first) {
+                    el.addClass('separator');
+                    first = false;
+                }
+                categoryList.appendChild(el);
+            });
+        },
+
+        updateTagsSubMenu: function(tagList) {
+            const contextTagList = $('contextTagList');
+            while (contextTagList.firstChild !== null)
+                contextTagList.removeChild(contextTagList.firstChild);
+
+            contextTagList.appendChild(new Element('li', {
+                html: '<a href="javascript:torrentAddTagsFN();">'
+                    + '<img src="images/qbt-theme/list-add.svg" alt="QBT_TR(Add...)QBT_TR[CONTEXT=TransferListWidget]"/>'
+                    + ' QBT_TR(Add...)QBT_TR[CONTEXT=TransferListWidget]'
+                    + '</a>'
+            }));
+            contextTagList.appendChild(new Element('li', {
+                html: '<a href="javascript:torrentRemoveAllTagsFN();">'
+                    + '<img src="images/qbt-theme/edit-clear.svg" alt="QBT_TR(Remove All)QBT_TR[CONTEXT=TransferListWidget]"/>'
+                    + ' QBT_TR(Remove All)QBT_TR[CONTEXT=TransferListWidget]'
+                    + '</a>'
+            }));
+
+            const sortedTags = [];
+            for (const key in tagList)
+                sortedTags.push(tagList[key].name);
+            sortedTags.sort();
+
+            for (let i = 0; i < sortedTags.length; ++i) {
+                const tagName = sortedTags[i];
+                const tagHash = genHash(tagName);
+                const el = new Element('li', {
+                    html: '<a href="#Tag/' + tagHash + '" onclick="event.preventDefault(); torrentSetTagsFN(\'' + tagHash + '\', !event.currentTarget.getElement(\'input[type=checkbox]\').checked);">'
+                        + '<input type="checkbox" onclick="this.checked = !this.checked;"> ' + window.qBittorrent.Misc.escapeHtml(tagName)
+                        + '</a>'
+                });
+                if (i === 0)
+                    el.addClass('separator');
+                contextTagList.appendChild(el);
+            }
         }
-    }
-});
+    });
 
-const CategoriesFilterContextMenu = new Class({
-    Extends: ContextMenu,
-    updateMenuItems: function() {
-        const id = this.options.element.id;
-        if ((id != CATEGORIES_ALL) && (id != CATEGORIES_UNCATEGORIZED)) {
-            this.showItem('editCategory');
-            this.showItem('deleteCategory');
+    const CategoriesFilterContextMenu = new Class({
+        Extends: ContextMenu,
+        updateMenuItems: function() {
+            const id = this.options.element.id;
+            if ((id != CATEGORIES_ALL) && (id != CATEGORIES_UNCATEGORIZED)) {
+                this.showItem('editCategory');
+                this.showItem('deleteCategory');
+            }
+            else {
+                this.hideItem('editCategory');
+                this.hideItem('deleteCategory');
+            }
         }
-        else {
-            this.hideItem('editCategory');
-            this.hideItem('deleteCategory');
+    });
+
+    const TagsFilterContextMenu = new Class({
+        Extends: ContextMenu,
+        updateMenuItems: function() {
+            const id = this.options.element.id;
+            if ((id !== TAGS_ALL.toString()) && (id !== TAGS_UNTAGGED.toString()))
+                this.showItem('deleteTag');
+            else
+                this.hideItem('deleteTag');
         }
-    }
-});
+    });
 
-const TagsFilterContextMenu = new Class({
-    Extends: ContextMenu,
-    updateMenuItems: function() {
-        const id = this.options.element.id;
-        if ((id !== TAGS_ALL.toString()) && (id !== TAGS_UNTAGGED.toString()))
-            this.showItem('deleteTag');
-        else
-            this.hideItem('deleteTag');
-    }
-});
+    const SearchPluginsTableContextMenu = new Class({
+        Extends: ContextMenu,
 
-const SearchPluginsTableContextMenu = new Class({
-    Extends: ContextMenu,
+        updateMenuItems: function() {
+            const enabledColumnIndex = function(text) {
+                const columns = $("searchPluginsTableFixedHeaderRow").getChildren("th");
+                for (let i = 0; i < columns.length; ++i)
+                    if (columns[i].get("html") === "Enabled")
+                        return i;
+            };
 
-    updateMenuItems: function() {
-        const enabledColumnIndex = function(text) {
-            const columns = $("searchPluginsTableFixedHeaderRow").getChildren("th");
-            for (let i = 0; i < columns.length; ++i)
-                if (columns[i].get("html") === "Enabled")
-                    return i;
-        };
+            this.showItem('Enabled');
+            this.setItemChecked('Enabled', this.options.element.getChildren("td")[enabledColumnIndex()].get("html") === "Yes");
 
-        this.showItem('Enabled');
-        this.setItemChecked('Enabled', this.options.element.getChildren("td")[enabledColumnIndex()].get("html") === "Yes");
+            this.showItem('Uninstall');
+        }
+    });
 
-        this.showItem('Uninstall');
-    }
-});
+    return exports();
+})();

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -33,1956 +33,1975 @@
 
 'use strict';
 
-let DynamicTableHeaderContextMenuClass = null;
-let ProgressColumnWidth = -1;
+if (window.qBittorrent === undefined) {
+    window.qBittorrent = {};
+}
 
-const DynamicTable = new Class({
+window.qBittorrent.DynamicTable = (function() {
+    const exports = function() {
+        return {
+            TorrentsTable: TorrentsTable,
+            TorrentPeersTable: TorrentPeersTable,
+            SearchResultsTable: SearchResultsTable,
+            SearchPluginsTable: SearchPluginsTable,
+            TorrentTrackersTable: TorrentTrackersTable,
+            TorrentFilesTable: TorrentFilesTable
+        };
+    };
 
-    initialize: function() {},
+    let DynamicTableHeaderContextMenuClass = null;
+    let ProgressColumnWidth = -1;
 
-    setup: function(dynamicTableDivId, dynamicTableFixedHeaderDivId, contextMenu) {
-        this.dynamicTableDivId = dynamicTableDivId;
-        this.dynamicTableFixedHeaderDivId = dynamicTableFixedHeaderDivId;
-        this.fixedTableHeader = $(dynamicTableFixedHeaderDivId).getElements('tr')[0];
-        this.hiddenTableHeader = $(dynamicTableDivId).getElements('tr')[0];
-        this.tableBody = $(dynamicTableDivId).getElements('tbody')[0];
-        this.rows = new Hash();
-        this.selectedRows = [];
-        this.columns = [];
-        this.contextMenu = contextMenu;
-        this.sortedColumn = LocalPreferences.get('sorted_column_' + this.dynamicTableDivId, 0);
-        this.reverseSort = LocalPreferences.get('reverse_sort_' + this.dynamicTableDivId, '0');
-        this.initColumns();
-        this.loadColumnsOrder();
-        this.updateTableHeaders();
-        this.setupCommonEvents();
-        this.setupHeaderEvents();
-        this.setupHeaderMenu();
-        this.setSortedColumnIcon(this.sortedColumn, null, (this.reverseSort === '1'));
-    },
+    const DynamicTable = new Class({
 
-    setupCommonEvents: function() {
-        const scrollFn = function() {
-            $(this.dynamicTableFixedHeaderDivId).getElements('table')[0].style.left = -$(this.dynamicTableDivId).scrollLeft + 'px';
-        }.bind(this);
+        initialize: function() {},
 
-        $(this.dynamicTableDivId).addEvent('scroll', scrollFn);
+        setup: function(dynamicTableDivId, dynamicTableFixedHeaderDivId, contextMenu) {
+            this.dynamicTableDivId = dynamicTableDivId;
+            this.dynamicTableFixedHeaderDivId = dynamicTableFixedHeaderDivId;
+            this.fixedTableHeader = $(dynamicTableFixedHeaderDivId).getElements('tr')[0];
+            this.hiddenTableHeader = $(dynamicTableDivId).getElements('tr')[0];
+            this.tableBody = $(dynamicTableDivId).getElements('tbody')[0];
+            this.rows = new Hash();
+            this.selectedRows = [];
+            this.columns = [];
+            this.contextMenu = contextMenu;
+            this.sortedColumn = LocalPreferences.get('sorted_column_' + this.dynamicTableDivId, 0);
+            this.reverseSort = LocalPreferences.get('reverse_sort_' + this.dynamicTableDivId, '0');
+            this.initColumns();
+            this.loadColumnsOrder();
+            this.updateTableHeaders();
+            this.setupCommonEvents();
+            this.setupHeaderEvents();
+            this.setupHeaderMenu();
+            this.setSortedColumnIcon(this.sortedColumn, null, (this.reverseSort === '1'));
+        },
 
-        // if the table exists within a panel
-        if ($(this.dynamicTableDivId).getParent('.panel')) {
-            const resizeFn = function() {
-                const panel = $(this.dynamicTableDivId).getParent('.panel');
-                let h = panel.getBoundingClientRect().height - $(this.dynamicTableFixedHeaderDivId).getBoundingClientRect().height;
-                $(this.dynamicTableDivId).style.height = h + 'px';
+        setupCommonEvents: function() {
+            const scrollFn = function() {
+                $(this.dynamicTableFixedHeaderDivId).getElements('table')[0].style.left = -$(this.dynamicTableDivId).scrollLeft + 'px';
+            }.bind(this);
 
-                // Workaround due to inaccurate calculation of elements heights by browser
+            $(this.dynamicTableDivId).addEvent('scroll', scrollFn);
 
-                let n = 2;
-
-                while (panel.clientWidth != panel.offsetWidth && n > 0) { // is panel vertical scrollbar visible ?
-                    --n;
-                    h -= 0.5;
+            // if the table exists within a panel
+            if ($(this.dynamicTableDivId).getParent('.panel')) {
+                const resizeFn = function() {
+                    const panel = $(this.dynamicTableDivId).getParent('.panel');
+                    let h = panel.getBoundingClientRect().height - $(this.dynamicTableFixedHeaderDivId).getBoundingClientRect().height;
                     $(this.dynamicTableDivId).style.height = h + 'px';
-                }
 
-                this.lastPanelHeight = panel.getBoundingClientRect().height;
-            }.bind(this);
+                    // Workaround due to inaccurate calculation of elements heights by browser
 
-            $(this.dynamicTableDivId).getParent('.panel').addEvent('resize', resizeFn);
+                    let n = 2;
 
-            this.lastPanelHeight = 0;
+                    while (panel.clientWidth != panel.offsetWidth && n > 0) { // is panel vertical scrollbar visible ?
+                        --n;
+                        h -= 0.5;
+                        $(this.dynamicTableDivId).style.height = h + 'px';
+                    }
 
-            // Workaround. Resize event is called not always (for example it isn't called when browser window changes it's size)
-
-            const checkResizeFn = function() {
-                const panel = $(this.dynamicTableDivId).getParent('.panel');
-                if (this.lastPanelHeight != panel.getBoundingClientRect().height) {
                     this.lastPanelHeight = panel.getBoundingClientRect().height;
-                    panel.fireEvent('resize');
-                }
-            }.bind(this);
+                }.bind(this);
 
-            setInterval(checkResizeFn, 500);
-        }
-    },
+                $(this.dynamicTableDivId).getParent('.panel').addEvent('resize', resizeFn);
 
-    setupHeaderEvents: function() {
-        this.currentHeaderAction = '';
-        this.canResize = false;
+                this.lastPanelHeight = 0;
 
-        const resetElementBorderStyle = function(el, side) {
-            if (side === 'left' || side !== 'right') {
-                el.setStyle('border-left-style', '');
-                el.setStyle('border-left-color', '');
-                el.setStyle('border-left-width', '');
+                // Workaround. Resize event is called not always (for example it isn't called when browser window changes it's size)
+
+                const checkResizeFn = function() {
+                    const panel = $(this.dynamicTableDivId).getParent('.panel');
+                    if (this.lastPanelHeight != panel.getBoundingClientRect().height) {
+                        this.lastPanelHeight = panel.getBoundingClientRect().height;
+                        panel.fireEvent('resize');
+                    }
+                }.bind(this);
+
+                setInterval(checkResizeFn, 500);
             }
-            if (side === 'right' || side !== 'left') {
-                el.setStyle('border-right-style', '');
-                el.setStyle('border-right-color', '');
-                el.setStyle('border-right-width', '');
-            }
-        };
+        },
 
-        const mouseMoveFn = function(e) {
-            const brect = e.target.getBoundingClientRect();
-            const mouseXRelative = e.event.clientX - brect.left;
-            if (this.currentHeaderAction === '') {
-                if (brect.width - mouseXRelative < 5) {
-                    this.resizeTh = e.target;
-                    this.canResize = true;
-                    e.target.getParent("tr").style.cursor = 'col-resize';
-                }
-                else if ((mouseXRelative < 5) && e.target.getPrevious('[class=""]')) {
-                    this.resizeTh = e.target.getPrevious('[class=""]');
-                    this.canResize = true;
-                    e.target.getParent("tr").style.cursor = 'col-resize';
-                }
-                else {
-                    this.canResize = false;
-                    e.target.getParent("tr").style.cursor = '';
-                }
-            }
-            if (this.currentHeaderAction === 'drag') {
-                const previousVisibleSibling = e.target.getPrevious('[class=""]');
-                let borderChangeElement = previousVisibleSibling;
-                let changeBorderSide = 'right';
-
-                if (mouseXRelative > brect.width / 2) {
-                    borderChangeElement = e.target;
-                    this.dropSide = 'right';
-                }
-                else {
-                    this.dropSide = 'left';
-                }
-
-                e.target.getParent("tr").style.cursor = 'move';
-
-                if (!previousVisibleSibling) { // right most column
-                    borderChangeElement = e.target;
-
-                    if (mouseXRelative <= brect.width / 2)
-                        changeBorderSide = 'left';
-                }
-
-                borderChangeElement.setStyle('border-' + changeBorderSide + '-style', 'solid');
-                borderChangeElement.setStyle('border-' + changeBorderSide + '-color', '#e60');
-                borderChangeElement.setStyle('border-' + changeBorderSide + '-width', 'initial');
-
-                resetElementBorderStyle(borderChangeElement, changeBorderSide === 'right' ? 'left' : 'right');
-
-                borderChangeElement.getSiblings('[class=""]').each(function(el) {
-                    resetElementBorderStyle(el);
-                });
-            }
-            this.lastHoverTh = e.target;
-            this.lastClientX = e.event.clientX;
-        }.bind(this);
-
-        const mouseOutFn = function(e) {
-            resetElementBorderStyle(e.target);
-        }.bind(this);
-
-        const onBeforeStart = function(el) {
-            this.clickedTh = el;
-            this.currentHeaderAction = 'start';
-            this.dragMovement = false;
-            this.dragStartX = this.lastClientX;
-        }.bind(this);
-
-        const onStart = function(el, event) {
-            if (this.canResize) {
-                this.currentHeaderAction = 'resize';
-                this.startWidth = this.resizeTh.getStyle('width').toFloat();
-            }
-            else {
-                this.currentHeaderAction = 'drag';
-                el.setStyle('background-color', '#C1D5E7');
-            }
-        }.bind(this);
-
-        const onDrag = function(el, event) {
-            if (this.currentHeaderAction === 'resize') {
-                let width = this.startWidth + (event.page.x - this.dragStartX);
-                if (width < 16)
-                    width = 16;
-                this.columns[this.resizeTh.columnName].width = width;
-                this.updateColumn(this.resizeTh.columnName);
-            }
-        }.bind(this);
-
-        const onComplete = function(el, event) {
-            resetElementBorderStyle(this.lastHoverTh);
-            el.setStyle('background-color', '');
-            if (this.currentHeaderAction === 'resize')
-                LocalPreferences.set('column_' + this.resizeTh.columnName + '_width_' + this.dynamicTableDivId, this.columns[this.resizeTh.columnName].width);
-            if ((this.currentHeaderAction === 'drag') && (el !== this.lastHoverTh)) {
-                this.saveColumnsOrder();
-                const val = LocalPreferences.get('columns_order_' + this.dynamicTableDivId).split(',');
-                val.erase(el.columnName);
-                let pos = val.indexOf(this.lastHoverTh.columnName);
-                if (this.dropSide === 'right') ++pos;
-                val.splice(pos, 0, el.columnName);
-                LocalPreferences.set('columns_order_' + this.dynamicTableDivId, val.join(','));
-                this.loadColumnsOrder();
-                this.updateTableHeaders();
-                while (this.tableBody.firstChild)
-                    this.tableBody.removeChild(this.tableBody.firstChild);
-                this.updateTable(true);
-            }
-            if (this.currentHeaderAction === 'drag') {
-                resetElementBorderStyle(el);
-                el.getSiblings('[class=""]').each(function(el) {
-                    resetElementBorderStyle(el);
-                });
-            }
+        setupHeaderEvents: function() {
             this.currentHeaderAction = '';
-        }.bind(this);
+            this.canResize = false;
 
-        const onCancel = function(el) {
-            this.currentHeaderAction = '';
-            this.setSortedColumn(el.columnName);
-        }.bind(this);
-
-        const ths = this.fixedTableHeader.getElements('th');
-
-        for (let i = 0; i < ths.length; ++i) {
-            const th = ths[i];
-            th.addEvent('mousemove', mouseMoveFn);
-            th.addEvent('mouseout', mouseOutFn);
-            th.makeResizable({
-                modifiers: {
-                    x: '',
-                    y: ''
-                },
-                onBeforeStart: onBeforeStart,
-                onStart: onStart,
-                onDrag: onDrag,
-                onComplete: onComplete,
-                onCancel: onCancel
-            });
-        }
-    },
-
-    setupDynamicTableHeaderContextMenuClass: function() {
-        if (!DynamicTableHeaderContextMenuClass) {
-            DynamicTableHeaderContextMenuClass = new Class({
-                Extends: ContextMenu,
-                updateMenuItems: function() {
-                    for (let i = 0; i < this.dynamicTable.columns.length; ++i) {
-                        if (this.dynamicTable.columns[i].caption === '')
-                            continue;
-                        if (this.dynamicTable.columns[i].visible !== '0')
-                            this.setItemChecked(this.dynamicTable.columns[i].name, true);
-                        else
-                            this.setItemChecked(this.dynamicTable.columns[i].name, false);
-                    }
+            const resetElementBorderStyle = function(el, side) {
+                if (side === 'left' || side !== 'right') {
+                    el.setStyle('border-left-style', '');
+                    el.setStyle('border-left-color', '');
+                    el.setStyle('border-left-width', '');
                 }
-            });
-        }
-    },
-
-    showColumn: function(columnName, show) {
-        this.columns[columnName].visible = show ? '1' : '0';
-        LocalPreferences.set('column_' + columnName + '_visible_' + this.dynamicTableDivId, show ? '1' : '0');
-        this.updateColumn(columnName);
-    },
-
-    setupHeaderMenu: function() {
-        this.setupDynamicTableHeaderContextMenuClass();
-
-        const menuId = this.dynamicTableDivId + '_headerMenu';
-
-        const ul = new Element('ul', {
-            id: menuId,
-            class: 'contextMenu scrollableMenu'
-        });
-
-        const createLi = function(columnName, text) {
-            const html = '<a href="#' + columnName + '" ><img src="images/qbt-theme/checked.svg"/>' + escapeHtml(text) + '</a>';
-            return new Element('li', {
-                html: html
-            });
-        };
-
-        const actions = {};
-
-        const onMenuItemClicked = function(element, ref, action) {
-            this.showColumn(action, this.columns[action].visible === '0');
-        }.bind(this);
-
-        for (let i = 0; i < this.columns.length; ++i) {
-            const text = this.columns[i].caption;
-            if (text === '')
-                continue;
-            ul.appendChild(createLi(this.columns[i].name, text));
-            actions[this.columns[i].name] = onMenuItemClicked;
-        }
-
-        ul.inject(document.body);
-
-        this.headerContextMenu = new DynamicTableHeaderContextMenuClass({
-            targets: '#' + this.dynamicTableFixedHeaderDivId + ' tr',
-            actions: actions,
-            menu: menuId,
-            offsets: {
-                x: -15,
-                y: 2
-            }
-        });
-
-        this.headerContextMenu.dynamicTable = this;
-    },
-
-    initColumns: function() {},
-
-    newColumn: function(name, style, caption, defaultWidth, defaultVisible) {
-        const column = {};
-        column['name'] = name;
-        column['title'] = name;
-        column['visible'] = LocalPreferences.get('column_' + name + '_visible_' + this.dynamicTableDivId, defaultVisible ? '1' : '0');
-        column['force_hide'] = false;
-        column['caption'] = caption;
-        column['style'] = style;
-        column['width'] = LocalPreferences.get('column_' + name + '_width_' + this.dynamicTableDivId, defaultWidth);
-        column['dataProperties'] = [name];
-        column['getRowValue'] = function(row, pos) {
-            if (pos === undefined)
-                pos = 0;
-            return row['full_data'][this.dataProperties[pos]];
-        };
-        column['compareRows'] = function(row1, row2) {
-            if (this.getRowValue(row1) < this.getRowValue(row2))
-                return -1;
-            else if (this.getRowValue(row1) > this.getRowValue(row2))
-                return 1;
-            else return 0;
-        };
-        column['updateTd'] = function(td, row) {
-            const value = this.getRowValue(row)
-            td.innerHTML = value;
-            td.title = value;
-        };
-        column['onResize'] = null;
-        this.columns.push(column);
-        this.columns[name] = column;
-
-        this.hiddenTableHeader.appendChild(new Element('th'));
-        this.fixedTableHeader.appendChild(new Element('th'));
-    },
-
-    loadColumnsOrder: function() {
-        const columnsOrder = [];
-        const val = LocalPreferences.get('columns_order_' + this.dynamicTableDivId);
-        if (val === null || val === undefined) return;
-        val.split(',').forEach(function(v) {
-            if ((v in this.columns) && (!columnsOrder.contains(v)))
-                columnsOrder.push(v);
-        }.bind(this));
-
-        for (let i = 0; i < this.columns.length; ++i)
-            if (!columnsOrder.contains(this.columns[i].name))
-                columnsOrder.push(this.columns[i].name);
-
-        for (let i = 0; i < this.columns.length; ++i)
-            this.columns[i] = this.columns[columnsOrder[i]];
-    },
-
-    saveColumnsOrder: function() {
-        let val = '';
-        for (let i = 0; i < this.columns.length; ++i) {
-            if (i > 0)
-                val += ',';
-            val += this.columns[i].name;
-        }
-        LocalPreferences.set('columns_order_' + this.dynamicTableDivId, val);
-    },
-
-    updateTableHeaders: function() {
-        this.updateHeader(this.hiddenTableHeader);
-        this.updateHeader(this.fixedTableHeader);
-    },
-
-    updateHeader: function(header) {
-        const ths = header.getElements('th');
-
-        for (let i = 0; i < ths.length; ++i) {
-            const th = ths[i];
-            th._this = this;
-            th.setAttribute('title', this.columns[i].caption);
-            th.innerHTML = this.columns[i].caption;
-            th.setAttribute('style', 'width: ' + this.columns[i].width + 'px;' + this.columns[i].style);
-            th.columnName = this.columns[i].name;
-            th.addClass('column_' + th.columnName);
-            if ((this.columns[i].visible == '0') || this.columns[i].force_hide)
-                th.addClass('invisible');
-            else
-                th.removeClass('invisible');
-        }
-    },
-
-    getColumnPos: function(columnName) {
-        for (let i = 0; i < this.columns.length; ++i)
-            if (this.columns[i].name == columnName)
-                return i;
-        return -1;
-    },
-
-    updateColumn: function(columnName) {
-        const pos = this.getColumnPos(columnName);
-        const visible = ((this.columns[pos].visible != '0') && !this.columns[pos].force_hide);
-        const ths = this.hiddenTableHeader.getElements('th');
-        const fths = this.fixedTableHeader.getElements('th');
-        const trs = this.tableBody.getElements('tr');
-        const style = 'width: ' + this.columns[pos].width + 'px;' + this.columns[pos].style;
-
-        ths[pos].setAttribute('style', style);
-        fths[pos].setAttribute('style', style);
-
-        if (visible) {
-            ths[pos].removeClass('invisible');
-            fths[pos].removeClass('invisible');
-            for (let i = 0; i < trs.length; ++i)
-                trs[i].getElements('td')[pos].removeClass('invisible');
-        }
-        else {
-            ths[pos].addClass('invisible');
-            fths[pos].addClass('invisible');
-            for (let j = 0; j < trs.length; ++j)
-                trs[j].getElements('td')[pos].addClass('invisible');
-        }
-        if (this.columns[pos].onResize !== null) {
-            this.columns[pos].onResize(columnName);
-        }
-    },
-
-    getSortedColumn: function() {
-        return LocalPreferences.get('sorted_column_' + this.dynamicTableDivId);
-    },
-
-    setSortedColumn: function(column) {
-        if (column != this.sortedColumn) {
-            const oldColumn = this.sortedColumn;
-            this.sortedColumn = column;
-            this.reverseSort = '0';
-            this.setSortedColumnIcon(column, oldColumn, false);
-        }
-        else {
-            // Toggle sort order
-            this.reverseSort = this.reverseSort === '0' ? '1' : '0';
-            this.setSortedColumnIcon(column, null, (this.reverseSort === '1'));
-        }
-        LocalPreferences.set('sorted_column_' + this.dynamicTableDivId, column);
-        LocalPreferences.set('reverse_sort_' + this.dynamicTableDivId, this.reverseSort);
-        this.updateTable(false);
-    },
-
-    setSortedColumnIcon: function(newColumn, oldColumn, isReverse) {
-        const getCol = function(headerDivId, colName) {
-            const colElem = $$("#" + headerDivId + " .column_" + colName);
-            if (colElem.length == 1)
-                return colElem[0];
-            return null;
-        };
-
-        const colElem = getCol(this.dynamicTableFixedHeaderDivId, newColumn);
-        if (colElem !== null) {
-            colElem.addClass('sorted');
-            if (isReverse)
-                colElem.addClass('reverse');
-            else
-                colElem.removeClass('reverse');
-        }
-        const oldColElem = getCol(this.dynamicTableFixedHeaderDivId, oldColumn);
-        if (oldColElem !== null) {
-            oldColElem.removeClass('sorted');
-            oldColElem.removeClass('reverse');
-        }
-    },
-
-    getSelectedRowId: function() {
-        if (this.selectedRows.length > 0)
-            return this.selectedRows[0];
-        return '';
-    },
-
-    isRowSelected: function(rowId) {
-        return this.selectedRows.contains(rowId);
-    },
-
-    altRow: function() {
-        if (!MUI.ieLegacySupport)
-            return;
-
-        const trs = this.tableBody.getElements('tr');
-        trs.each(function(el, i) {
-            if (i % 2) {
-                el.addClass('alt');
-            }
-            else {
-                el.removeClass('alt');
-            }
-        }.bind(this));
-    },
-
-    selectAll: function() {
-        this.deselectAll();
-
-        const trs = this.tableBody.getElements('tr');
-        for (let i = 0; i < trs.length; ++i) {
-            const tr = trs[i];
-            this.selectedRows.push(tr.rowId);
-            if (!tr.hasClass('selected'))
-                tr.addClass('selected');
-        }
-    },
-
-    deselectAll: function() {
-        this.selectedRows.empty();
-    },
-
-    selectRow: function(rowId) {
-        this.selectedRows.push(rowId);
-        this.setRowClass();
-        this.onSelectedRowChanged();
-    },
-
-    deselectRow: function(rowId) {
-        this.selectedRows.erase(rowId);
-        this.setRowClass();
-        this.onSelectedRowChanged();
-    },
-
-    selectRows: function(rowId1, rowId2) {
-        this.deselectAll();
-        if (rowId1 === rowId2) {
-            this.selectRow(rowId1);
-            return;
-        }
-
-        let select = false;
-        const that = this;
-        this.tableBody.getElements('tr').each(function(tr) {
-            if ((tr.rowId == rowId1) || (tr.rowId == rowId2)) {
-                select = !select;
-                that.selectedRows.push(tr.rowId);
-            }
-            else if (select) {
-                that.selectedRows.push(tr.rowId);
-            }
-        });
-        this.setRowClass();
-        this.onSelectedRowChanged();
-    },
-
-    reselectRows: function(rowIds) {
-        this.deselectAll();
-        this.selectedRows = rowIds.slice();
-        this.tableBody.getElements('tr').each(function(tr) {
-            if (rowIds.indexOf(tr.rowId) > -1)
-                tr.addClass('selected');
-        });
-    },
-
-    setRowClass: function() {
-        const that = this;
-        this.tableBody.getElements('tr').each(function(tr) {
-            if (that.isRowSelected(tr.rowId))
-                tr.addClass('selected');
-            else
-                tr.removeClass('selected');
-        });
-    },
-
-    onSelectedRowChanged: function() {},
-
-    updateRowData: function(data) {
-        const rowId = data['rowId'];
-        let row;
-
-        if (!this.rows.has(rowId)) {
-            row = {};
-            this.rows.set(rowId, row);
-            row['full_data'] = {};
-            row['rowId'] = rowId;
-        }
-        else
-            row = this.rows.get(rowId);
-
-        row['data'] = data;
-
-        for (const x in data)
-            row['full_data'][x] = data[x];
-    },
-
-    getFilteredAndSortedRows: function() {
-        const filteredRows = [];
-
-        const rows = this.rows.getValues();
-
-        for (let i = 0; i < rows.length; ++i) {
-            filteredRows.push(rows[i]);
-            filteredRows[rows[i].rowId] = rows[i];
-        }
-
-        filteredRows.sort(function(row1, row2) {
-            const column = this.columns[this.sortedColumn];
-            const res = column.compareRows(row1, row2);
-            if (this.reverseSort === '0')
-                return res;
-            else
-                return -res;
-        }.bind(this));
-        return filteredRows;
-    },
-
-    getTrByRowId: function(rowId) {
-        const trs = this.tableBody.getElements('tr');
-        for (let i = 0; i < trs.length; ++i)
-            if (trs[i].rowId == rowId)
-                return trs[i];
-        return null;
-    },
-
-    updateTable: function(fullUpdate) {
-        if (fullUpdate === undefined)
-            fullUpdate = false;
-
-        const rows = this.getFilteredAndSortedRows();
-
-        for (let i = 0; i < this.selectedRows.length; ++i)
-            if (!(this.selectedRows[i] in rows)) {
-                this.selectedRows.splice(i, 1);
-                --i;
-            }
-
-        const trs = this.tableBody.getElements('tr');
-
-        for (let rowPos = 0; rowPos < rows.length; ++rowPos) {
-            const rowId = rows[rowPos]['rowId'];
-            let tr_found = false;
-            for (let j = rowPos; j < trs.length; ++j)
-                if (trs[j]['rowId'] == rowId) {
-                    tr_found = true;
-                    if (rowPos == j)
-                        break;
-                    trs[j].inject(trs[rowPos], 'before');
-                    const tmpTr = trs[j];
-                    trs.splice(j, 1);
-                    trs.splice(rowPos, 0, tmpTr);
-                    break;
+                if (side === 'right' || side !== 'left') {
+                    el.setStyle('border-right-style', '');
+                    el.setStyle('border-right-color', '');
+                    el.setStyle('border-right-width', '');
                 }
-            if (tr_found) // row already exists in the table
-                this.updateRow(trs[rowPos], fullUpdate);
-            else { // else create a new row in the table
-                const tr = new Element('tr');
+            };
 
-                tr['rowId'] = rows[rowPos]['rowId'];
-
-                tr._this = this;
-                tr.addEvent('contextmenu', function(e) {
-                    if (!this._this.isRowSelected(this.rowId)) {
-                        this._this.deselectAll();
-                        this._this.selectRow(this.rowId);
+            const mouseMoveFn = function(e) {
+                const brect = e.target.getBoundingClientRect();
+                const mouseXRelative = e.event.clientX - brect.left;
+                if (this.currentHeaderAction === '') {
+                    if (brect.width - mouseXRelative < 5) {
+                        this.resizeTh = e.target;
+                        this.canResize = true;
+                        e.target.getParent("tr").style.cursor = 'col-resize';
                     }
-                    return true;
-                });
-                tr.addEvent('click', function(e) {
-                    e.stop();
-                    if (e.control || e.meta) {
-                        // CTRL/CMD ⌘ key was pressed
-                        if (this._this.isRowSelected(this.rowId))
-                            this._this.deselectRow(this.rowId);
-                        else
-                            this._this.selectRow(this.rowId);
-                    }
-                    else if (e.shift && (this._this.selectedRows.length == 1)) {
-                        // Shift key was pressed
-                        this._this.selectRows(this._this.getSelectedRowId(), this.rowId);
+                    else if ((mouseXRelative < 5) && e.target.getPrevious('[class=""]')) {
+                        this.resizeTh = e.target.getPrevious('[class=""]');
+                        this.canResize = true;
+                        e.target.getParent("tr").style.cursor = 'col-resize';
                     }
                     else {
-                        // Simple selection
-                        this._this.deselectAll();
-                        this._this.selectRow(this.rowId);
+                        this.canResize = false;
+                        e.target.getParent("tr").style.cursor = '';
                     }
-                    return false;
-                });
-                tr.addEvent('touchstart', function(e) {
-                    if (!this._this.isRowSelected(this.rowId)) {
-                        this._this.deselectAll();
-                        this._this.selectRow(this.rowId);
-                    }
-                    return false;
-                });
-
-                this.setupTr(tr);
-
-                for (let k = 0; k < this.columns.length; ++k) {
-                    const td = new Element('td');
-                    if ((this.columns[k].visible == '0') || this.columns[k].force_hide)
-                        td.addClass('invisible');
-                    td.injectInside(tr);
                 }
+                if (this.currentHeaderAction === 'drag') {
+                    const previousVisibleSibling = e.target.getPrevious('[class=""]');
+                    let borderChangeElement = previousVisibleSibling;
+                    let changeBorderSide = 'right';
 
-                // Insert
-                if (rowPos >= trs.length) {
-                    tr.inject(this.tableBody);
-                    trs.push(tr);
+                    if (mouseXRelative > brect.width / 2) {
+                        borderChangeElement = e.target;
+                        this.dropSide = 'right';
+                    }
+                    else {
+                        this.dropSide = 'left';
+                    }
+
+                    e.target.getParent("tr").style.cursor = 'move';
+
+                    if (!previousVisibleSibling) { // right most column
+                        borderChangeElement = e.target;
+
+                        if (mouseXRelative <= brect.width / 2)
+                            changeBorderSide = 'left';
+                    }
+
+                    borderChangeElement.setStyle('border-' + changeBorderSide + '-style', 'solid');
+                    borderChangeElement.setStyle('border-' + changeBorderSide + '-color', '#e60');
+                    borderChangeElement.setStyle('border-' + changeBorderSide + '-width', 'initial');
+
+                    resetElementBorderStyle(borderChangeElement, changeBorderSide === 'right' ? 'left' : 'right');
+
+                    borderChangeElement.getSiblings('[class=""]').each(function(el) {
+                        resetElementBorderStyle(el);
+                    });
+                }
+                this.lastHoverTh = e.target;
+                this.lastClientX = e.event.clientX;
+            }.bind(this);
+
+            const mouseOutFn = function(e) {
+                resetElementBorderStyle(e.target);
+            }.bind(this);
+
+            const onBeforeStart = function(el) {
+                this.clickedTh = el;
+                this.currentHeaderAction = 'start';
+                this.dragMovement = false;
+                this.dragStartX = this.lastClientX;
+            }.bind(this);
+
+            const onStart = function(el, event) {
+                if (this.canResize) {
+                    this.currentHeaderAction = 'resize';
+                    this.startWidth = this.resizeTh.getStyle('width').toFloat();
                 }
                 else {
-                    tr.inject(trs[rowPos], 'before');
-                    trs.splice(rowPos, 0, tr);
+                    this.currentHeaderAction = 'drag';
+                    el.setStyle('background-color', '#C1D5E7');
                 }
+            }.bind(this);
 
-                // Update context menu
-                if (this.contextMenu)
-                    this.contextMenu.addTarget(tr);
-
-                this.updateRow(tr, true);
-            }
-        }
-
-        let rowPos = rows.length;
-
-        while ((rowPos < trs.length) && (trs.length > 0)) {
-            trs[trs.length - 1].dispose();
-            trs.pop();
-        }
-    },
-
-    setupTr: function(tr) {},
-
-    updateRow: function(tr, fullUpdate) {
-        const row = this.rows.get(tr.rowId);
-        const data = row[fullUpdate ? 'full_data' : 'data'];
-
-        const tds = tr.getElements('td');
-        for (let i = 0; i < this.columns.length; ++i) {
-            if (data.hasOwnProperty(this.columns[i].dataProperties[0]))
-                this.columns[i].updateTd(tds[i], row);
-        }
-        row['data'] = {};
-    },
-
-    removeRow: function(rowId) {
-        this.selectedRows.erase(rowId);
-        const tr = this.getTrByRowId(rowId);
-        if (tr !== null) {
-            tr.dispose();
-            this.rows.erase(rowId);
-            return true;
-        }
-        return false;
-    },
-
-    clear: function() {
-        this.deselectAll();
-        this.rows.empty();
-        const trs = this.tableBody.getElements('tr');
-        while (trs.length > 0) {
-            trs[trs.length - 1].dispose();
-            trs.pop();
-        }
-    },
-
-    selectedRowsIds: function() {
-        return this.selectedRows.slice();
-    },
-
-    getRowIds: function() {
-        return this.rows.getKeys();
-    },
-});
-
-const TorrentsTable = new Class({
-    Extends: DynamicTable,
-
-    initColumns: function() {
-        this.newColumn('priority', '', '#', 30, true);
-        this.newColumn('state_icon', 'cursor: default', '', 22, true);
-        this.newColumn('name', '', 'QBT_TR(Name)QBT_TR[CONTEXT=TransferListModel]', 200, true);
-        this.newColumn('size', '', 'QBT_TR(Size)QBT_TR[CONTEXT=TransferListModel]', 100, true);
-        this.newColumn('total_size', '', 'QBT_TR(Total Size)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-        this.newColumn('progress', '', 'QBT_TR(Done)QBT_TR[CONTEXT=TransferListModel]', 85, true);
-        this.newColumn('status', '', 'QBT_TR(Status)QBT_TR[CONTEXT=TransferListModel]', 100, true);
-        this.newColumn('num_seeds', '', 'QBT_TR(Seeds)QBT_TR[CONTEXT=TransferListModel]', 100, true);
-        this.newColumn('num_leechs', '', 'QBT_TR(Peers)QBT_TR[CONTEXT=TransferListModel]', 100, true);
-        this.newColumn('dlspeed', '', 'QBT_TR(Down Speed)QBT_TR[CONTEXT=TransferListModel]', 100, true);
-        this.newColumn('upspeed', '', 'QBT_TR(Up Speed)QBT_TR[CONTEXT=TransferListModel]', 100, true);
-        this.newColumn('eta', '', 'QBT_TR(ETA)QBT_TR[CONTEXT=TransferListModel]', 100, true);
-        this.newColumn('ratio', '', 'QBT_TR(Ratio)QBT_TR[CONTEXT=TransferListModel]', 100, true);
-        this.newColumn('category', '', 'QBT_TR(Category)QBT_TR[CONTEXT=TransferListModel]', 100, true);
-        this.newColumn('tags', '', 'QBT_TR(Tags)QBT_TR[CONTEXT=TransferListModel]', 100, true);
-        this.newColumn('added_on', '', 'QBT_TR(Added On)QBT_TR[CONTEXT=TransferListModel]', 100, true);
-        this.newColumn('completion_on', '', 'QBT_TR(Completed On)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-        this.newColumn('tracker', '', 'QBT_TR(Tracker)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-        this.newColumn('dl_limit', '', 'QBT_TR(Down Limit)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-        this.newColumn('up_limit', '', 'QBT_TR(Up Limit)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-        this.newColumn('downloaded', '', 'QBT_TR(Downloaded)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-        this.newColumn('uploaded', '', 'QBT_TR(Uploaded)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-        this.newColumn('downloaded_session', '', 'QBT_TR(Session Download)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-        this.newColumn('uploaded_session', '', 'QBT_TR(Session Upload)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-        this.newColumn('amount_left', '', 'QBT_TR(Remaining)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-        this.newColumn('time_active', '', 'QBT_TR(Time Active)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-        this.newColumn('save_path', '', 'QBT_TR(Save path)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-        this.newColumn('completed', '', 'QBT_TR(Completed)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-        this.newColumn('max_ratio', '', 'QBT_TR(Ratio Limit)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-        this.newColumn('seen_complete', '', 'QBT_TR(Last Seen Complete)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-        this.newColumn('last_activity', '', 'QBT_TR(Last Activity)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-        this.newColumn('availability', '', 'QBT_TR(Availability)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-
-        this.columns['state_icon'].onclick = '';
-        this.columns['state_icon'].dataProperties[0] = 'state';
-
-        this.columns['num_seeds'].dataProperties.push('num_complete');
-        this.columns['num_leechs'].dataProperties.push('num_incomplete');
-
-        this.initColumnsFunctions();
-    },
-
-    initColumnsFunctions: function() {
-
-        // state_icon
-        this.columns['state_icon'].updateTd = function(td, row) {
-            let state = this.getRowValue(row);
-            // normalize states
-            switch (state) {
-                case "forcedDL":
-                case "metaDL":
-                    state = "downloading";
-                    break;
-                case "allocating":
-                    state = "stalledDL";
-                    break;
-                case "forcedUP":
-                    state = "uploading";
-                    break;
-                case "pausedDL":
-                    state = "paused";
-                    break;
-                case "pausedUP":
-                    state = "completed";
-                    break;
-                case "queuedDL":
-                case "queuedUP":
-                    state = "queued";
-                    break;
-                case "checkingDL":
-                case "checkingUP":
-                case "queuedForChecking":
-                case "checkingResumeData":
-                case "moving":
-                    state = "checking";
-                    break;
-                case "unknown":
-                case "missingFiles":
-                    state = "error";
-                    break;
-                default:
-                    break; // do nothing
-            }
-
-            const img_path = 'images/skin/' + state + '.svg';
-
-            if (td.getChildren('img').length > 0) {
-                const img = td.getChildren('img')[0];
-                if (img.src.indexOf(img_path) < 0) {
-                    img.set('src', img_path);
-                    img.set('title', state);
+            const onDrag = function(el, event) {
+                if (this.currentHeaderAction === 'resize') {
+                    let width = this.startWidth + (event.page.x - this.dragStartX);
+                    if (width < 16)
+                        width = 16;
+                    this.columns[this.resizeTh.columnName].width = width;
+                    this.updateColumn(this.resizeTh.columnName);
                 }
-            }
-            else {
-                td.adopt(new Element('img', {
-                    'src': img_path,
-                    'class': 'stateIcon',
-                    'title': state
-                }));
-            }
-        };
+            }.bind(this);
 
-        // status
-        this.columns['status'].updateTd = function(td, row) {
-            const state = this.getRowValue(row);
-            if (!state) return;
-
-            let status;
-            switch (state) {
-                case "downloading":
-                    status = "QBT_TR(Downloading)QBT_TR[CONTEXT=TransferListDelegate]";
-                    break;
-                case "stalledDL":
-                    status = "QBT_TR(Stalled)QBT_TR[CONTEXT=TransferListDelegate]";
-                    break;
-                case "metaDL":
-                    status = "QBT_TR(Downloading metadata)QBT_TR[CONTEXT=TransferListDelegate]";
-                    break;
-                case "forcedDL":
-                    status = "QBT_TR([F] Downloading)QBT_TR[CONTEXT=TransferListDelegate]";
-                    break;
-                case "allocating":
-                    status = "QBT_TR(Allocating)QBT_TR[CONTEXT=TransferListDelegate]";
-                    break;
-                case "uploading":
-                case "stalledUP":
-                    status = "QBT_TR(Seeding)QBT_TR[CONTEXT=TransferListDelegate]";
-                    break;
-                case "forcedUP":
-                    status = "QBT_TR([F] Seeding)QBT_TR[CONTEXT=TransferListDelegate]";
-                    break;
-                case "queuedDL":
-                case "queuedUP":
-                    status = "QBT_TR(Queued)QBT_TR[CONTEXT=TransferListDelegate]";
-                    break;
-                case "checkingDL":
-                case "checkingUP":
-                    status = "QBT_TR(Checking)QBT_TR[CONTEXT=TransferListDelegate]";
-                    break;
-                case "queuedForChecking":
-                    status = "QBT_TR(Queued for checking)QBT_TR[CONTEXT=TransferListDelegate]";
-                    break;
-                case "checkingResumeData":
-                    status = "QBT_TR(Checking resume data)QBT_TR[CONTEXT=TransferListDelegate]";
-                    break;
-                case "pausedDL":
-                    status = "QBT_TR(Paused)QBT_TR[CONTEXT=TransferListDelegate]";
-                    break;
-                case "pausedUP":
-                    status = "QBT_TR(Completed)QBT_TR[CONTEXT=TransferListDelegate]";
-                    break;
-                case "moving":
-                    status = "QBT_TR(Moving)QBT_TR[CONTEXT=TransferListDelegate]";
-                    break;
-                case "missingFiles":
-                    status = "QBT_TR(Missing Files)QBT_TR[CONTEXT=TransferListDelegate]";
-                    break;
-                case "error":
-                    status = "QBT_TR(Errored)QBT_TR[CONTEXT=TransferListDelegate]";
-                    break;
-                default:
-                    status = "QBT_TR(Unknown)QBT_TR[CONTEXT=HttpServer]";
-            }
-
-            td.set('html', status);
-            td.set('title', status);
-        };
-
-        // priority
-        this.columns['priority'].updateTd = function(td, row) {
-            const queuePos = this.getRowValue(row);
-            const formattedQueuePos = (queuePos < 1) ? '*' : queuePos;
-            td.set('html', formattedQueuePos);
-            td.set('title', formattedQueuePos);
-        };
-
-        this.columns['priority'].compareRows = function(row1, row2) {
-            let row1_val = this.getRowValue(row1);
-            let row2_val = this.getRowValue(row2);
-            if (row1_val < 1)
-                row1_val = 1000000;
-            if (row2_val < 1)
-                row2_val = 1000000;
-            if (row1_val < row2_val)
-                return -1;
-            else if (row1_val > row2_val)
-                return 1;
-            else return 0;
-        };
-
-        // name, category, tags
-        this.columns['name'].updateTd = function(td, row) {
-            const name = escapeHtml(this.getRowValue(row))
-            td.set('html', name);
-            td.set('title', name);
-        };
-        this.columns['category'].updateTd = this.columns['name'].updateTd;
-        this.columns['tags'].updateTd = this.columns['name'].updateTd;
-
-        this.columns['name'].compareRows = function(row1, row2) {
-            const row1Val = this.getRowValue(row1);
-            const row2Val = this.getRowValue(row2);
-            return row1Val.localeCompare(row2Val, undefined, {numeric: true, sensitivity: 'base'});
-        };
-        this.columns['category'].compareRows = this.columns['name'].compareRows;
-        this.columns['tags'].compareRows = this.columns['name'].compareRows;
-
-        // size
-        this.columns['size'].updateTd = function(td, row) {
-            const size = friendlyUnit(this.getRowValue(row), false);
-            td.set('html', size);
-            td.set('title', size);
-        };
-
-        // progress
-        this.columns['progress'].updateTd = function(td, row) {
-            const progress = this.getRowValue(row);
-            let progressFormated = (progress * 100).round(1);
-            if (progressFormated == 100.0 && progress != 1.0)
-                progressFormated = 99.9;
-
-            if (td.getChildren('div').length > 0) {
-                const div = td.getChildren('div')[0];
-                if (td.resized) {
-                    td.resized = false;
-                    div.setWidth(ProgressColumnWidth - 5);
+            const onComplete = function(el, event) {
+                resetElementBorderStyle(this.lastHoverTh);
+                el.setStyle('background-color', '');
+                if (this.currentHeaderAction === 'resize')
+                    LocalPreferences.set('column_' + this.resizeTh.columnName + '_width_' + this.dynamicTableDivId, this.columns[this.resizeTh.columnName].width);
+                if ((this.currentHeaderAction === 'drag') && (el !== this.lastHoverTh)) {
+                    this.saveColumnsOrder();
+                    const val = LocalPreferences.get('columns_order_' + this.dynamicTableDivId).split(',');
+                    val.erase(el.columnName);
+                    let pos = val.indexOf(this.lastHoverTh.columnName);
+                    if (this.dropSide === 'right') ++pos;
+                    val.splice(pos, 0, el.columnName);
+                    LocalPreferences.set('columns_order_' + this.dynamicTableDivId, val.join(','));
+                    this.loadColumnsOrder();
+                    this.updateTableHeaders();
+                    while (this.tableBody.firstChild)
+                        this.tableBody.removeChild(this.tableBody.firstChild);
+                    this.updateTable(true);
                 }
-                if (div.getValue() != progressFormated)
-                    div.setValue(progressFormated);
-            }
-            else {
-                if (ProgressColumnWidth < 0)
-                    ProgressColumnWidth = td.offsetWidth;
-                td.adopt(new ProgressBar(progressFormated.toFloat(), {
-                    'width': ProgressColumnWidth - 5
-                }));
-                td.resized = false;
-            }
-        };
-
-        this.columns['progress'].onResize = function(columnName) {
-            const pos = this.getColumnPos(columnName);
-            const trs = this.tableBody.getElements('tr');
-            ProgressColumnWidth = -1;
-            for (let i = 0; i < trs.length; ++i) {
-                const td = trs[i].getElements('td')[pos];
-                if (ProgressColumnWidth < 0)
-                    ProgressColumnWidth = td.offsetWidth;
-                td.resized = true;
-                this.columns[columnName].updateTd(td, this.rows.get(trs[i].rowId));
-            }
-        }.bind(this);
-
-        // num_seeds
-        this.columns['num_seeds'].updateTd = function(td, row) {
-            const num_seeds = this.getRowValue(row, 0);
-            const num_complete = this.getRowValue(row, 1);
-            let html = num_seeds;
-            if (num_complete != -1)
-                html += ' (' + num_complete + ')';
-            td.set('html', html);
-            td.set('title', html);
-        };
-        this.columns['num_seeds'].compareRows = function(row1, row2) {
-            const num_seeds1 = this.getRowValue(row1, 0);
-            const num_complete1 = this.getRowValue(row1, 1);
-
-            const num_seeds2 = this.getRowValue(row2, 0);
-            const num_complete2 = this.getRowValue(row2, 1);
-
-            if (num_complete1 < num_complete2)
-                return -1;
-            else if (num_complete1 > num_complete2)
-                return 1;
-            else if (num_seeds1 < num_seeds2)
-                return -1;
-            else if (num_seeds1 > num_seeds2)
-                return 1;
-            else return 0;
-        };
-
-        // num_leechs
-        this.columns['num_leechs'].updateTd = this.columns['num_seeds'].updateTd;
-        this.columns['num_leechs'].compareRows = this.columns['num_seeds'].compareRows;
-
-        // dlspeed
-        this.columns['dlspeed'].updateTd = function(td, row) {
-            const speed = friendlyUnit(this.getRowValue(row), true);
-            td.set('html', speed);
-            td.set('title', speed);
-        };
-
-        // upspeed
-        this.columns['upspeed'].updateTd = this.columns['dlspeed'].updateTd;
-
-        // eta
-        this.columns['eta'].updateTd = function(td, row) {
-            const eta = friendlyDuration(this.getRowValue(row));
-            td.set('html', eta);
-            td.set('title', eta);
-        };
-
-        // ratio
-        this.columns['ratio'].updateTd = function(td, row) {
-            const ratio = this.getRowValue(row);
-            const string = (ratio === -1) ? '∞' : toFixedPointString(ratio, 2);
-            td.set('html', string);
-            td.set('title', string);
-        };
-
-        // added on
-        this.columns['added_on'].updateTd = function(td, row) {
-            const date = new Date(this.getRowValue(row) * 1000).toLocaleString();
-            td.set('html', date);
-            td.set('title', date);
-        };
-
-        // completion_on
-        this.columns['completion_on'].updateTd = function(td, row) {
-            const val = this.getRowValue(row);
-            if ((val === 0xffffffff) || (val < 0)) {
-                td.set('html', '');
-                td.set('title', '');
-            }
-            else {
-                const date = new Date(this.getRowValue(row) * 1000).toLocaleString();
-                td.set('html', date);
-                td.set('title', date);
-            }
-        };
-
-        // seen_complete
-        this.columns['seen_complete'].updateTd = this.columns['completion_on'].updateTd;
-
-        //  dl_limit, up_limit
-        this.columns['dl_limit'].updateTd = function(td, row) {
-            const speed = this.getRowValue(row);
-            if (speed === 0) {
-                td.set('html', '∞');
-                td.set('title', '∞');
-            }
-            else {
-                const formattedSpeed = friendlyUnit(speed, true);
-                td.set('html', formattedSpeed);
-                td.set('title', formattedSpeed);
-            }
-        };
-
-        this.columns['up_limit'].updateTd = this.columns['dl_limit'].updateTd;
-
-        // downloaded, uploaded, downloaded_session, uploaded_session, amount_left, completed, total_size
-        this.columns['downloaded'].updateTd = this.columns['size'].updateTd;
-        this.columns['uploaded'].updateTd = this.columns['size'].updateTd;
-        this.columns['downloaded_session'].updateTd = this.columns['size'].updateTd;
-        this.columns['uploaded_session'].updateTd = this.columns['size'].updateTd;
-        this.columns['amount_left'].updateTd = this.columns['size'].updateTd;
-        this.columns['amount_left'].updateTd = this.columns['size'].updateTd;
-        this.columns['completed'].updateTd = this.columns['size'].updateTd;
-        this.columns['total_size'].updateTd = this.columns['size'].updateTd;
-
-        // save_path, tracker
-        this.columns['save_path'].updateTd = this.columns['name'].updateTd;
-        this.columns['tracker'].updateTd = this.columns['name'].updateTd;
-
-        // max_ratio
-        this.columns['max_ratio'].updateTd = this.columns['ratio'].updateTd;
-
-        // last_activity
-        this.columns['last_activity'].updateTd = function(td, row) {
-            const val = this.getRowValue(row);
-            if (val < 1) {
-                td.set('html', '∞');
-                td.set('title', '∞');
-            }
-            else {
-                const formattedVal = 'QBT_TR(%1 ago)QBT_TR[CONTEXT=TransferListDelegate]'.replace('%1', friendlyDuration((new Date()) / 1000 - val));
-                td.set('html', formattedVal);
-                td.set('title', formattedVal);
-            }
-        };
-
-        // time active
-        this.columns['time_active'].updateTd = function(td, row) {
-            const time = friendlyDuration(this.getRowValue(row));
-            td.set('html', time);
-            td.set('title', time);
-        };
-
-        // availability
-        this.columns['availability'].updateTd = function(td, row) {
-            const value = toFixedPointString(this.getRowValue(row), 3);
-            td.set('html', value);
-            td.set('title', value);
-        };
-    },
-
-    applyFilter: function(row, filterName, categoryHash, tagHash, filterTerms) {
-        const state = row['full_data'].state;
-        const name = row['full_data'].name.toLowerCase();
-        let inactive = false;
-        let r;
-
-        switch (filterName) {
-            case 'downloading':
-                if (state != 'downloading' && !~state.indexOf('DL'))
-                    return false;
-                break;
-            case 'seeding':
-                if (state != 'uploading' && state != 'forcedUP' && state != 'stalledUP' && state != 'queuedUP' && state != 'checkingUP')
-                    return false;
-                break;
-            case 'completed':
-                if (state != 'uploading' && !~state.indexOf('UP'))
-                    return false;
-                break;
-            case 'paused':
-                if (!~state.indexOf('paused'))
-                    return false;
-                break;
-            case 'resumed':
-                if (~state.indexOf('paused'))
-                    return false;
-                break;
-            case 'inactive':
-                inactive = true;
-                // fallthrough
-            case 'active':
-                if (state == 'stalledDL')
-                    r = (row['full_data'].upspeed > 0);
-                else
-                    r = state == 'metaDL' || state == 'downloading' || state == 'forcedDL' || state == 'uploading' || state == 'forcedUP';
-                if (r == inactive)
-                    return false;
-                break;
-            case 'errored':
-                if (state != 'error' && state != "unknown" && state != "missingFiles")
-                    return false;
-                break;
-        }
-
-        const categoryHashInt = parseInt(categoryHash);
-        if (!isNaN(categoryHashInt)) {
-            switch (categoryHashInt) {
-                case CATEGORIES_ALL:
-                    break;  // do nothing
-                case CATEGORIES_UNCATEGORIZED:
-                    if (row['full_data'].category.length !== 0)
-                        return false;
-                    break;  // do nothing
-                default:
-                    if (categoryHashInt !== genHash(row['full_data'].category))
-                        return false;
-            }
-        }
-
-        const tagHashInt = parseInt(tagHash);
-        const isNumber = !isNaN(tagHashInt);
-        if (isNumber) {
-            switch (tagHashInt) {
-                case TAGS_ALL:
-                    break;  // do nothing
-
-                case TAGS_UNTAGGED:
-                    if (row['full_data'].tags.length !== 0)
-                        return false;
-                    break;  // do nothing
-
-                default:
-                    let rowTags = row['full_data'].tags.split(', ');
-                    rowTags = rowTags.map(function(tag) {
-                        return genHash(tag);
+                if (this.currentHeaderAction === 'drag') {
+                    resetElementBorderStyle(el);
+                    el.getSiblings('[class=""]').each(function(el) {
+                        resetElementBorderStyle(el);
                     });
-                    if (!rowTags.contains(tagHashInt))
-                        return false;
+                }
+                this.currentHeaderAction = '';
+            }.bind(this);
+
+            const onCancel = function(el) {
+                this.currentHeaderAction = '';
+                this.setSortedColumn(el.columnName);
+            }.bind(this);
+
+            const ths = this.fixedTableHeader.getElements('th');
+
+            for (let i = 0; i < ths.length; ++i) {
+                const th = ths[i];
+                th.addEvent('mousemove', mouseMoveFn);
+                th.addEvent('mouseout', mouseOutFn);
+                th.makeResizable({
+                    modifiers: {
+                        x: '',
+                        y: ''
+                    },
+                    onBeforeStart: onBeforeStart,
+                    onStart: onStart,
+                    onDrag: onDrag,
+                    onComplete: onComplete,
+                    onCancel: onCancel
+                });
             }
-        }
+        },
 
-        if ((filterTerms !== undefined) && (filterTerms !== null)
-            && (filterTerms.length > 0) && !containsAllTerms(name, filterTerms))
-            return false;
+        setupDynamicTableHeaderContextMenuClass: function() {
+            if (!DynamicTableHeaderContextMenuClass) {
+                DynamicTableHeaderContextMenuClass = new Class({
+                    Extends: window.qBittorrent.ContextMenu.ContextMenu,
+                    updateMenuItems: function() {
+                        for (let i = 0; i < this.dynamicTable.columns.length; ++i) {
+                            if (this.dynamicTable.columns[i].caption === '')
+                                continue;
+                            if (this.dynamicTable.columns[i].visible !== '0')
+                                this.setItemChecked(this.dynamicTable.columns[i].name, true);
+                            else
+                                this.setItemChecked(this.dynamicTable.columns[i].name, false);
+                        }
+                    }
+                });
+            }
+        },
 
-        return true;
-    },
+        showColumn: function(columnName, show) {
+            this.columns[columnName].visible = show ? '1' : '0';
+            LocalPreferences.set('column_' + columnName + '_visible_' + this.dynamicTableDivId, show ? '1' : '0');
+            this.updateColumn(columnName);
+        },
 
-    getFilteredTorrentsNumber: function(filterName, categoryHash, tagHash) {
-        let cnt = 0;
-        const rows = this.rows.getValues();
+        setupHeaderMenu: function() {
+            this.setupDynamicTableHeaderContextMenuClass();
 
-        for (let i = 0; i < rows.length; ++i)
-            if (this.applyFilter(rows[i], filterName, categoryHash, tagHash, null)) ++cnt;
-        return cnt;
-    },
+            const menuId = this.dynamicTableDivId + '_headerMenu';
 
-    getFilteredTorrentsHashes: function(filterName, categoryHash, tagHash) {
-        const rowsHashes = [];
-        const rows = this.rows.getValues();
+            const ul = new Element('ul', {
+                id: menuId,
+                class: 'contextMenu scrollableMenu'
+            });
 
-        for (let i = 0; i < rows.length; ++i)
-            if (this.applyFilter(rows[i], filterName, categoryHash, tagHash, null))
-                rowsHashes.push(rows[i]['rowId']);
+            const createLi = function(columnName, text) {
+                const html = '<a href="#' + columnName + '" ><img src="images/qbt-theme/checked.svg"/>' + window.qBittorrent.Misc.escapeHtml(text) + '</a>';
+                return new Element('li', {
+                    html: html
+                });
+            };
 
-        return rowsHashes;
-    },
+            const actions = {};
 
-    getFilteredAndSortedRows: function() {
-        const filteredRows = [];
+            const onMenuItemClicked = function(element, ref, action) {
+                this.showColumn(action, this.columns[action].visible === '0');
+            }.bind(this);
 
-        const rows = this.rows.getValues();
-        const filterText = $('torrentsFilterInput').value.trim().toLowerCase();
-        const filterTerms = (filterText.length > 0) ? filterText.split(" ") : null;
+            for (let i = 0; i < this.columns.length; ++i) {
+                const text = this.columns[i].caption;
+                if (text === '')
+                    continue;
+                ul.appendChild(createLi(this.columns[i].name, text));
+                actions[this.columns[i].name] = onMenuItemClicked;
+            }
 
-        for (let i = 0; i < rows.length; ++i) {
-            if (this.applyFilter(rows[i], selected_filter, selected_category, selectedTag, filterTerms)) {
+            ul.inject(document.body);
+
+            this.headerContextMenu = new DynamicTableHeaderContextMenuClass({
+                targets: '#' + this.dynamicTableFixedHeaderDivId + ' tr',
+                actions: actions,
+                menu: menuId,
+                offsets: {
+                    x: -15,
+                    y: 2
+                }
+            });
+
+            this.headerContextMenu.dynamicTable = this;
+        },
+
+        initColumns: function() {},
+
+        newColumn: function(name, style, caption, defaultWidth, defaultVisible) {
+            const column = {};
+            column['name'] = name;
+            column['title'] = name;
+            column['visible'] = LocalPreferences.get('column_' + name + '_visible_' + this.dynamicTableDivId, defaultVisible ? '1' : '0');
+            column['force_hide'] = false;
+            column['caption'] = caption;
+            column['style'] = style;
+            column['width'] = LocalPreferences.get('column_' + name + '_width_' + this.dynamicTableDivId, defaultWidth);
+            column['dataProperties'] = [name];
+            column['getRowValue'] = function(row, pos) {
+                if (pos === undefined)
+                    pos = 0;
+                return row['full_data'][this.dataProperties[pos]];
+            };
+            column['compareRows'] = function(row1, row2) {
+                if (this.getRowValue(row1) < this.getRowValue(row2))
+                    return -1;
+                else if (this.getRowValue(row1) > this.getRowValue(row2))
+                    return 1;
+                else return 0;
+            };
+            column['updateTd'] = function(td, row) {
+                const value = this.getRowValue(row)
+                td.innerHTML = value;
+                td.title = value;
+            };
+            column['onResize'] = null;
+            this.columns.push(column);
+            this.columns[name] = column;
+
+            this.hiddenTableHeader.appendChild(new Element('th'));
+            this.fixedTableHeader.appendChild(new Element('th'));
+        },
+
+        loadColumnsOrder: function() {
+            const columnsOrder = [];
+            const val = LocalPreferences.get('columns_order_' + this.dynamicTableDivId);
+            if (val === null || val === undefined) return;
+            val.split(',').forEach(function(v) {
+                if ((v in this.columns) && (!columnsOrder.contains(v)))
+                    columnsOrder.push(v);
+            }.bind(this));
+
+            for (let i = 0; i < this.columns.length; ++i)
+                if (!columnsOrder.contains(this.columns[i].name))
+                    columnsOrder.push(this.columns[i].name);
+
+            for (let i = 0; i < this.columns.length; ++i)
+                this.columns[i] = this.columns[columnsOrder[i]];
+        },
+
+        saveColumnsOrder: function() {
+            let val = '';
+            for (let i = 0; i < this.columns.length; ++i) {
+                if (i > 0)
+                    val += ',';
+                val += this.columns[i].name;
+            }
+            LocalPreferences.set('columns_order_' + this.dynamicTableDivId, val);
+        },
+
+        updateTableHeaders: function() {
+            this.updateHeader(this.hiddenTableHeader);
+            this.updateHeader(this.fixedTableHeader);
+        },
+
+        updateHeader: function(header) {
+            const ths = header.getElements('th');
+
+            for (let i = 0; i < ths.length; ++i) {
+                const th = ths[i];
+                th._this = this;
+                th.setAttribute('title', this.columns[i].caption);
+                th.innerHTML = this.columns[i].caption;
+                th.setAttribute('style', 'width: ' + this.columns[i].width + 'px;' + this.columns[i].style);
+                th.columnName = this.columns[i].name;
+                th.addClass('column_' + th.columnName);
+                if ((this.columns[i].visible == '0') || this.columns[i].force_hide)
+                    th.addClass('invisible');
+                else
+                    th.removeClass('invisible');
+            }
+        },
+
+        getColumnPos: function(columnName) {
+            for (let i = 0; i < this.columns.length; ++i)
+                if (this.columns[i].name == columnName)
+                    return i;
+            return -1;
+        },
+
+        updateColumn: function(columnName) {
+            const pos = this.getColumnPos(columnName);
+            const visible = ((this.columns[pos].visible != '0') && !this.columns[pos].force_hide);
+            const ths = this.hiddenTableHeader.getElements('th');
+            const fths = this.fixedTableHeader.getElements('th');
+            const trs = this.tableBody.getElements('tr');
+            const style = 'width: ' + this.columns[pos].width + 'px;' + this.columns[pos].style;
+
+            ths[pos].setAttribute('style', style);
+            fths[pos].setAttribute('style', style);
+
+            if (visible) {
+                ths[pos].removeClass('invisible');
+                fths[pos].removeClass('invisible');
+                for (let i = 0; i < trs.length; ++i)
+                    trs[i].getElements('td')[pos].removeClass('invisible');
+            }
+            else {
+                ths[pos].addClass('invisible');
+                fths[pos].addClass('invisible');
+                for (let j = 0; j < trs.length; ++j)
+                    trs[j].getElements('td')[pos].addClass('invisible');
+            }
+            if (this.columns[pos].onResize !== null) {
+                this.columns[pos].onResize(columnName);
+            }
+        },
+
+        getSortedColumn: function() {
+            return LocalPreferences.get('sorted_column_' + this.dynamicTableDivId);
+        },
+
+        setSortedColumn: function(column) {
+            if (column != this.sortedColumn) {
+                const oldColumn = this.sortedColumn;
+                this.sortedColumn = column;
+                this.reverseSort = '0';
+                this.setSortedColumnIcon(column, oldColumn, false);
+            }
+            else {
+                // Toggle sort order
+                this.reverseSort = this.reverseSort === '0' ? '1' : '0';
+                this.setSortedColumnIcon(column, null, (this.reverseSort === '1'));
+            }
+            LocalPreferences.set('sorted_column_' + this.dynamicTableDivId, column);
+            LocalPreferences.set('reverse_sort_' + this.dynamicTableDivId, this.reverseSort);
+            this.updateTable(false);
+        },
+
+        setSortedColumnIcon: function(newColumn, oldColumn, isReverse) {
+            const getCol = function(headerDivId, colName) {
+                const colElem = $$("#" + headerDivId + " .column_" + colName);
+                if (colElem.length == 1)
+                    return colElem[0];
+                return null;
+            };
+
+            const colElem = getCol(this.dynamicTableFixedHeaderDivId, newColumn);
+            if (colElem !== null) {
+                colElem.addClass('sorted');
+                if (isReverse)
+                    colElem.addClass('reverse');
+                else
+                    colElem.removeClass('reverse');
+            }
+            const oldColElem = getCol(this.dynamicTableFixedHeaderDivId, oldColumn);
+            if (oldColElem !== null) {
+                oldColElem.removeClass('sorted');
+                oldColElem.removeClass('reverse');
+            }
+        },
+
+        getSelectedRowId: function() {
+            if (this.selectedRows.length > 0)
+                return this.selectedRows[0];
+            return '';
+        },
+
+        isRowSelected: function(rowId) {
+            return this.selectedRows.contains(rowId);
+        },
+
+        altRow: function() {
+            if (!MUI.ieLegacySupport)
+                return;
+
+            const trs = this.tableBody.getElements('tr');
+            trs.each(function(el, i) {
+                if (i % 2) {
+                    el.addClass('alt');
+                }
+                else {
+                    el.removeClass('alt');
+                }
+            }.bind(this));
+        },
+
+        selectAll: function() {
+            this.deselectAll();
+
+            const trs = this.tableBody.getElements('tr');
+            for (let i = 0; i < trs.length; ++i) {
+                const tr = trs[i];
+                this.selectedRows.push(tr.rowId);
+                if (!tr.hasClass('selected'))
+                    tr.addClass('selected');
+            }
+        },
+
+        deselectAll: function() {
+            this.selectedRows.empty();
+        },
+
+        selectRow: function(rowId) {
+            this.selectedRows.push(rowId);
+            this.setRowClass();
+            this.onSelectedRowChanged();
+        },
+
+        deselectRow: function(rowId) {
+            this.selectedRows.erase(rowId);
+            this.setRowClass();
+            this.onSelectedRowChanged();
+        },
+
+        selectRows: function(rowId1, rowId2) {
+            this.deselectAll();
+            if (rowId1 === rowId2) {
+                this.selectRow(rowId1);
+                return;
+            }
+
+            let select = false;
+            const that = this;
+            this.tableBody.getElements('tr').each(function(tr) {
+                if ((tr.rowId == rowId1) || (tr.rowId == rowId2)) {
+                    select = !select;
+                    that.selectedRows.push(tr.rowId);
+                }
+                else if (select) {
+                    that.selectedRows.push(tr.rowId);
+                }
+            });
+            this.setRowClass();
+            this.onSelectedRowChanged();
+        },
+
+        reselectRows: function(rowIds) {
+            this.deselectAll();
+            this.selectedRows = rowIds.slice();
+            this.tableBody.getElements('tr').each(function(tr) {
+                if (rowIds.indexOf(tr.rowId) > -1)
+                    tr.addClass('selected');
+            });
+        },
+
+        setRowClass: function() {
+            const that = this;
+            this.tableBody.getElements('tr').each(function(tr) {
+                if (that.isRowSelected(tr.rowId))
+                    tr.addClass('selected');
+                else
+                    tr.removeClass('selected');
+            });
+        },
+
+        onSelectedRowChanged: function() {},
+
+        updateRowData: function(data) {
+            const rowId = data['rowId'];
+            let row;
+
+            if (!this.rows.has(rowId)) {
+                row = {};
+                this.rows.set(rowId, row);
+                row['full_data'] = {};
+                row['rowId'] = rowId;
+            }
+            else
+                row = this.rows.get(rowId);
+
+            row['data'] = data;
+
+            for (const x in data)
+                row['full_data'][x] = data[x];
+        },
+
+        getFilteredAndSortedRows: function() {
+            const filteredRows = [];
+
+            const rows = this.rows.getValues();
+
+            for (let i = 0; i < rows.length; ++i) {
                 filteredRows.push(rows[i]);
                 filteredRows[rows[i].rowId] = rows[i];
             }
-        }
 
-        filteredRows.sort(function(row1, row2) {
-            const column = this.columns[this.sortedColumn];
-            const res = column.compareRows(row1, row2);
-            if (this.reverseSort === '0')
-                return res;
-            else
-                return -res;
-        }.bind(this));
-        return filteredRows;
-    },
+            filteredRows.sort(function(row1, row2) {
+                const column = this.columns[this.sortedColumn];
+                const res = column.compareRows(row1, row2);
+                if (this.reverseSort === '0')
+                    return res;
+                else
+                    return -res;
+            }.bind(this));
+            return filteredRows;
+        },
 
-    setupTr: function(tr) {
-        tr.addEvent('dblclick', function(e) {
-            e.stop();
-            this._this.deselectAll();
-            this._this.selectRow(this.rowId);
-            const row = this._this.rows.get(this.rowId);
-            const state = row['full_data'].state;
-            if (~state.indexOf('paused'))
-                startFN();
-            else
-                pauseFN();
-            return true;
-        });
-        tr.addClass("torrentsTableContextMenuTarget");
-    },
+        getTrByRowId: function(rowId) {
+            const trs = this.tableBody.getElements('tr');
+            for (let i = 0; i < trs.length; ++i)
+                if (trs[i].rowId == rowId)
+                    return trs[i];
+            return null;
+        },
 
-    getCurrentTorrentHash: function() {
-        return this.getSelectedRowId();
-    },
+        updateTable: function(fullUpdate) {
+            if (fullUpdate === undefined)
+                fullUpdate = false;
 
-    onSelectedRowChanged: function() {
-        updatePropertiesPanel();
-    }
-});
+            const rows = this.getFilteredAndSortedRows();
 
-const TorrentPeersTable = new Class({
-    Extends: DynamicTable,
+            for (let i = 0; i < this.selectedRows.length; ++i)
+                if (!(this.selectedRows[i] in rows)) {
+                    this.selectedRows.splice(i, 1);
+                    --i;
+                }
 
-    initColumns: function() {
-        this.newColumn('country', '', 'QBT_TR(Country)QBT_TR[CONTEXT=PeerListWidget]', 22, true);
-        this.newColumn('ip', '', 'QBT_TR(IP)QBT_TR[CONTEXT=PeerListWidget]', 80, true);
-        this.newColumn('port', '', 'QBT_TR(Port)QBT_TR[CONTEXT=PeerListWidget]', 35, true);
-        this.newColumn('connection', '', 'QBT_TR(Connection)QBT_TR[CONTEXT=PeerListWidget]', 50, true);
-        this.newColumn('flags', '', 'QBT_TR(Flags)QBT_TR[CONTEXT=PeerListWidget]', 50, true);
-        this.newColumn('client', '', 'QBT_TR(Client)QBT_TR[CONTEXT=PeerListWidget]', 140, true);
-        this.newColumn('progress', '', 'QBT_TR(Progress)QBT_TR[CONTEXT=PeerListWidget]', 50, true);
-        this.newColumn('dl_speed', '', 'QBT_TR(Down Speed)QBT_TR[CONTEXT=PeerListWidget]', 50, true);
-        this.newColumn('up_speed', '', 'QBT_TR(Up Speed)QBT_TR[CONTEXT=PeerListWidget]', 50, true);
-        this.newColumn('downloaded', '', 'QBT_TR(Downloaded)QBT_TR[CONTEXT=PeerListWidget]', 50, true);
-        this.newColumn('uploaded', '', 'QBT_TR(Uploaded)QBT_TR[CONTEXT=PeerListWidget]', 50, true);
-        this.newColumn('relevance', '', 'QBT_TR(Relevance)QBT_TR[CONTEXT=PeerListWidget]', 30, true);
-        this.newColumn('files', '', 'QBT_TR(Files)QBT_TR[CONTEXT=PeerListWidget]', 100, true);
+            const trs = this.tableBody.getElements('tr');
 
-        this.columns['country'].dataProperties.push('country_code');
-        this.columns['flags'].dataProperties.push('flags_desc');
-        this.initColumnsFunctions();
-    },
+            for (let rowPos = 0; rowPos < rows.length; ++rowPos) {
+                const rowId = rows[rowPos]['rowId'];
+                let tr_found = false;
+                for (let j = rowPos; j < trs.length; ++j)
+                    if (trs[j]['rowId'] == rowId) {
+                        tr_found = true;
+                        if (rowPos == j)
+                            break;
+                        trs[j].inject(trs[rowPos], 'before');
+                        const tmpTr = trs[j];
+                        trs.splice(j, 1);
+                        trs.splice(rowPos, 0, tmpTr);
+                        break;
+                    }
+                if (tr_found) // row already exists in the table
+                    this.updateRow(trs[rowPos], fullUpdate);
+                else { // else create a new row in the table
+                    const tr = new Element('tr');
 
-    initColumnsFunctions: function() {
+                    tr['rowId'] = rows[rowPos]['rowId'];
 
-        // country
+                    tr._this = this;
+                    tr.addEvent('contextmenu', function(e) {
+                        if (!this._this.isRowSelected(this.rowId)) {
+                            this._this.deselectAll();
+                            this._this.selectRow(this.rowId);
+                        }
+                        return true;
+                    });
+                    tr.addEvent('click', function(e) {
+                        e.stop();
+                        if (e.control || e.meta) {
+                            // CTRL/CMD ⌘ key was pressed
+                            if (this._this.isRowSelected(this.rowId))
+                                this._this.deselectRow(this.rowId);
+                            else
+                                this._this.selectRow(this.rowId);
+                        }
+                        else if (e.shift && (this._this.selectedRows.length == 1)) {
+                            // Shift key was pressed
+                            this._this.selectRows(this._this.getSelectedRowId(), this.rowId);
+                        }
+                        else {
+                            // Simple selection
+                            this._this.deselectAll();
+                            this._this.selectRow(this.rowId);
+                        }
+                        return false;
+                    });
+                    tr.addEvent('touchstart', function(e) {
+                        if (!this._this.isRowSelected(this.rowId)) {
+                            this._this.deselectAll();
+                            this._this.selectRow(this.rowId);
+                        }
+                        return false;
+                    });
 
-        this.columns['country'].updateTd = function(td, row) {
-            const country = this.getRowValue(row, 0);
-            const country_code = this.getRowValue(row, 1);
+                    this.setupTr(tr);
 
-            if (!country_code) {
-                if (td.getChildren('img').length > 0)
-                    td.getChildren('img')[0].dispose();
-                return;
+                    for (let k = 0; k < this.columns.length; ++k) {
+                        const td = new Element('td');
+                        if ((this.columns[k].visible == '0') || this.columns[k].force_hide)
+                            td.addClass('invisible');
+                        td.injectInside(tr);
+                    }
+
+                    // Insert
+                    if (rowPos >= trs.length) {
+                        tr.inject(this.tableBody);
+                        trs.push(tr);
+                    }
+                    else {
+                        tr.inject(trs[rowPos], 'before');
+                        trs.splice(rowPos, 0, tr);
+                    }
+
+                    // Update context menu
+                    if (this.contextMenu)
+                        this.contextMenu.addTarget(tr);
+
+                    this.updateRow(tr, true);
+                }
             }
 
-            const img_path = 'images/flags/' + country_code + '.svg';
+            let rowPos = rows.length;
 
-            if (td.getChildren('img').length > 0) {
-                const img = td.getChildren('img')[0];
-                img.set('src', img_path);
-                img.set('class', 'flags');
-                img.set('alt', country);
-                img.set('title', country);
+            while ((rowPos < trs.length) && (trs.length > 0)) {
+                trs[trs.length - 1].dispose();
+                trs.pop();
             }
-            else
-                td.adopt(new Element('img', {
-                    'src': img_path,
-                    'class': 'flags',
-                    'alt': country,
-                    'title': country
-                }));
-        };
+        },
 
-        // ip
+        setupTr: function(tr) {},
 
-        this.columns['ip'].compareRows = function(row1, row2) {
-            const ip1 = this.getRowValue(row1);
-            const ip2 = this.getRowValue(row2);
+        updateRow: function(tr, fullUpdate) {
+            const row = this.rows.get(tr.rowId);
+            const data = row[fullUpdate ? 'full_data' : 'data'];
 
-            const a = ip1.split(".");
-            const b = ip2.split(".");
-
-            for (let i = 0; i < 4; ++i) {
-                if (a[i] != b[i])
-                    return a[i] - b[i];
+            const tds = tr.getElements('td');
+            for (let i = 0; i < this.columns.length; ++i) {
+                if (data.hasOwnProperty(this.columns[i].dataProperties[0]))
+                    this.columns[i].updateTd(tds[i], row);
             }
+            row['data'] = {};
+        },
 
-            return 0;
-        };
-
-        // progress, relevance
-
-        this.columns['progress'].updateTd = function(td, row) {
-            const progress = this.getRowValue(row);
-            let progressFormated = (progress * 100).round(1);
-            if (progressFormated == 100.0 && progress != 1.0)
-                progressFormated = 99.9;
-            progressFormated += "%";
-            td.set('html', progressFormated);
-            td.set('title', progressFormated);
-        };
-
-        this.columns['relevance'].updateTd = this.columns['progress'].updateTd;
-
-        // dl_speed, up_speed
-
-        this.columns['dl_speed'].updateTd = function(td, row) {
-            const speed = this.getRowValue(row);
-            if (speed === 0) {
-                td.set('html', '');
-                td.set('title', '');
+        removeRow: function(rowId) {
+            this.selectedRows.erase(rowId);
+            const tr = this.getTrByRowId(rowId);
+            if (tr !== null) {
+                tr.dispose();
+                this.rows.erase(rowId);
+                return true;
             }
-            else {
-                const formattedSpeed = friendlyUnit(speed, true);
-                td.set('html', formattedSpeed);
-                td.set('title', formattedSpeed);
+            return false;
+        },
+
+        clear: function() {
+            this.deselectAll();
+            this.rows.empty();
+            const trs = this.tableBody.getElements('tr');
+            while (trs.length > 0) {
+                trs[trs.length - 1].dispose();
+                trs.pop();
             }
-        };
+        },
 
-        this.columns['up_speed'].updateTd = this.columns['dl_speed'].updateTd;
+        selectedRowsIds: function() {
+            return this.selectedRows.slice();
+        },
 
-        // downloaded, uploaded
+        getRowIds: function() {
+            return this.rows.getKeys();
+        },
+    });
 
-        this.columns['downloaded'].updateTd = function(td, row) {
-            const downloaded = friendlyUnit(this.getRowValue(row), false);
-            td.set('html', downloaded);
-            td.set('title', downloaded);
-        };
+    const TorrentsTable = new Class({
+        Extends: DynamicTable,
 
-        this.columns['uploaded'].updateTd = this.columns['downloaded'].updateTd;
+        initColumns: function() {
+            this.newColumn('priority', '', '#', 30, true);
+            this.newColumn('state_icon', 'cursor: default', '', 22, true);
+            this.newColumn('name', '', 'QBT_TR(Name)QBT_TR[CONTEXT=TransferListModel]', 200, true);
+            this.newColumn('size', '', 'QBT_TR(Size)QBT_TR[CONTEXT=TransferListModel]', 100, true);
+            this.newColumn('total_size', '', 'QBT_TR(Total Size)QBT_TR[CONTEXT=TransferListModel]', 100, false);
+            this.newColumn('progress', '', 'QBT_TR(Done)QBT_TR[CONTEXT=TransferListModel]', 85, true);
+            this.newColumn('status', '', 'QBT_TR(Status)QBT_TR[CONTEXT=TransferListModel]', 100, true);
+            this.newColumn('num_seeds', '', 'QBT_TR(Seeds)QBT_TR[CONTEXT=TransferListModel]', 100, true);
+            this.newColumn('num_leechs', '', 'QBT_TR(Peers)QBT_TR[CONTEXT=TransferListModel]', 100, true);
+            this.newColumn('dlspeed', '', 'QBT_TR(Down Speed)QBT_TR[CONTEXT=TransferListModel]', 100, true);
+            this.newColumn('upspeed', '', 'QBT_TR(Up Speed)QBT_TR[CONTEXT=TransferListModel]', 100, true);
+            this.newColumn('eta', '', 'QBT_TR(ETA)QBT_TR[CONTEXT=TransferListModel]', 100, true);
+            this.newColumn('ratio', '', 'QBT_TR(Ratio)QBT_TR[CONTEXT=TransferListModel]', 100, true);
+            this.newColumn('category', '', 'QBT_TR(Category)QBT_TR[CONTEXT=TransferListModel]', 100, true);
+            this.newColumn('tags', '', 'QBT_TR(Tags)QBT_TR[CONTEXT=TransferListModel]', 100, true);
+            this.newColumn('added_on', '', 'QBT_TR(Added On)QBT_TR[CONTEXT=TransferListModel]', 100, true);
+            this.newColumn('completion_on', '', 'QBT_TR(Completed On)QBT_TR[CONTEXT=TransferListModel]', 100, false);
+            this.newColumn('tracker', '', 'QBT_TR(Tracker)QBT_TR[CONTEXT=TransferListModel]', 100, false);
+            this.newColumn('dl_limit', '', 'QBT_TR(Down Limit)QBT_TR[CONTEXT=TransferListModel]', 100, false);
+            this.newColumn('up_limit', '', 'QBT_TR(Up Limit)QBT_TR[CONTEXT=TransferListModel]', 100, false);
+            this.newColumn('downloaded', '', 'QBT_TR(Downloaded)QBT_TR[CONTEXT=TransferListModel]', 100, false);
+            this.newColumn('uploaded', '', 'QBT_TR(Uploaded)QBT_TR[CONTEXT=TransferListModel]', 100, false);
+            this.newColumn('downloaded_session', '', 'QBT_TR(Session Download)QBT_TR[CONTEXT=TransferListModel]', 100, false);
+            this.newColumn('uploaded_session', '', 'QBT_TR(Session Upload)QBT_TR[CONTEXT=TransferListModel]', 100, false);
+            this.newColumn('amount_left', '', 'QBT_TR(Remaining)QBT_TR[CONTEXT=TransferListModel]', 100, false);
+            this.newColumn('time_active', '', 'QBT_TR(Time Active)QBT_TR[CONTEXT=TransferListModel]', 100, false);
+            this.newColumn('save_path', '', 'QBT_TR(Save path)QBT_TR[CONTEXT=TransferListModel]', 100, false);
+            this.newColumn('completed', '', 'QBT_TR(Completed)QBT_TR[CONTEXT=TransferListModel]', 100, false);
+            this.newColumn('max_ratio', '', 'QBT_TR(Ratio Limit)QBT_TR[CONTEXT=TransferListModel]', 100, false);
+            this.newColumn('seen_complete', '', 'QBT_TR(Last Seen Complete)QBT_TR[CONTEXT=TransferListModel]', 100, false);
+            this.newColumn('last_activity', '', 'QBT_TR(Last Activity)QBT_TR[CONTEXT=TransferListModel]', 100, false);
+            this.newColumn('availability', '', 'QBT_TR(Availability)QBT_TR[CONTEXT=TransferListModel]', 100, false);
 
-        // flags
+            this.columns['state_icon'].onclick = '';
+            this.columns['state_icon'].dataProperties[0] = 'state';
 
-        this.columns['flags'].updateTd = function(td, row) {
-            td.innerHTML = this.getRowValue(row, 0);
-            td.title = this.getRowValue(row, 1);
-        };
+            this.columns['num_seeds'].dataProperties.push('num_complete');
+            this.columns['num_leechs'].dataProperties.push('num_incomplete');
 
-        // files
+            this.initColumnsFunctions();
+        },
 
-        this.columns['files'].updateTd = function(td, row) {
-            td.innerHTML = escapeHtml(this.getRowValue(row, 0).replace(/\n/g, ';'));
-            td.title = escapeHtml(this.getRowValue(row, 0));
-        };
+        initColumnsFunctions: function() {
 
-    }
-});
+            // state_icon
+            this.columns['state_icon'].updateTd = function(td, row) {
+                let state = this.getRowValue(row);
+                // normalize states
+                switch (state) {
+                    case "forcedDL":
+                    case "metaDL":
+                        state = "downloading";
+                        break;
+                    case "allocating":
+                        state = "stalledDL";
+                        break;
+                    case "forcedUP":
+                        state = "uploading";
+                        break;
+                    case "pausedDL":
+                        state = "paused";
+                        break;
+                    case "pausedUP":
+                        state = "completed";
+                        break;
+                    case "queuedDL":
+                    case "queuedUP":
+                        state = "queued";
+                        break;
+                    case "checkingDL":
+                    case "checkingUP":
+                    case "queuedForChecking":
+                    case "checkingResumeData":
+                    case "moving":
+                        state = "checking";
+                        break;
+                    case "unknown":
+                    case "missingFiles":
+                        state = "error";
+                        break;
+                    default:
+                        break; // do nothing
+                }
 
-const SearchResultsTable = new Class({
-    Extends: DynamicTable,
+                const img_path = 'images/skin/' + state + '.svg';
 
-    initColumns: function() {
-        this.newColumn('fileName', '', 'QBT_TR(Name)QBT_TR[CONTEXT=SearchResultsTable]', 500, true);
-        this.newColumn('fileSize', '', 'QBT_TR(Size)QBT_TR[CONTEXT=SearchResultsTable]', 100, true);
-        this.newColumn('nbSeeders', '', 'QBT_TR(Seeders)QBT_TR[CONTEXT=SearchResultsTable]', 100, true);
-        this.newColumn('nbLeechers', '', 'QBT_TR(Leechers)QBT_TR[CONTEXT=SearchResultsTable]', 100, true);
-        this.newColumn('siteUrl', '', 'QBT_TR(Search engine)QBT_TR[CONTEXT=SearchResultsTable]', 250, true);
-
-        this.initColumnsFunctions();
-    },
-
-    initColumnsFunctions: function() {
-        const displayText = function(td, row) {
-            const value = escapeHtml(this.getRowValue(row));
-            td.set('html', value);
-            td.set('title', value);
-        }
-        const displaySize = function(td, row) {
-            const size = friendlyUnit(this.getRowValue(row), false);
-            td.set('html', size);
-            td.set('title', size);
-        }
-        const displayNum = function(td, row) {
-            const value = escapeHtml(this.getRowValue(row));
-            const formattedValue = (value === "-1") ? "Unknown" : value;
-            td.set('html', formattedValue);
-            td.set('title', formattedValue);
-        }
-
-        this.columns['fileName'].updateTd = displayText;
-        this.columns['fileSize'].updateTd = displaySize;
-        this.columns['nbSeeders'].updateTd = displayNum;
-        this.columns['nbLeechers'].updateTd = displayNum;
-        this.columns['siteUrl'].updateTd = displayText;
-    },
-
-    getFilteredAndSortedRows: function() {
-        const getSizeFilters = function() {
-            let minSize = (searchSizeFilter.min > 0.00) ? (searchSizeFilter.min * Math.pow(1024, searchSizeFilter.minUnit)) : 0.00;
-            let maxSize = (searchSizeFilter.max > 0.00) ? (searchSizeFilter.max * Math.pow(1024, searchSizeFilter.maxUnit)) : 0.00;
-
-            if ((minSize > maxSize) && (maxSize > 0.00)) {
-                const tmp = minSize;
-                minSize = maxSize;
-                maxSize = tmp;
-            }
-
-            return {
-                min: minSize,
-                max: maxSize
-            }
-        };
-
-        const getSeedsFilters = function() {
-            let minSeeds = (searchSeedsFilter.min > 0) ? searchSeedsFilter.min : 0;
-            let maxSeeds = (searchSeedsFilter.max > 0) ? searchSeedsFilter.max : 0;
-
-            if ((minSeeds > maxSeeds) && (maxSeeds > 0)) {
-                const tmp = minSeeds;
-                minSeeds = maxSeeds;
-                maxSeeds = tmp;
-            }
-
-            return {
-                min: minSeeds,
-                max: maxSeeds
-            }
-        };
-
-        let filteredRows = [];
-        const rows = this.rows.getValues();
-        const searchTerms = searchPattern.toLowerCase().split(" ");
-        const filterTerms = searchFilterPattern.toLowerCase().split(" ");
-        const sizeFilters = getSizeFilters();
-        const seedsFilters = getSeedsFilters();
-        const searchInTorrentName = $('searchInTorrentName').get('value') === "names";
-
-        if (searchInTorrentName || (filterTerms.length > 0) || (searchSizeFilter.min > 0.00) || (searchSizeFilter.max > 0.00)) {
-            for (let i = 0; i < rows.length; ++i) {
-                const row = rows[i];
-
-                if (searchInTorrentName && !containsAllTerms(row.full_data.fileName, searchTerms)) continue;
-                if ((filterTerms.length > 0) && !containsAllTerms(row.full_data.fileName, filterTerms)) continue;
-                if ((sizeFilters.min > 0.00) && (row.full_data.fileSize < sizeFilters.min)) continue;
-                if ((sizeFilters.max > 0.00) && (row.full_data.fileSize > sizeFilters.max)) continue;
-                if ((seedsFilters.min > 0) && (row.full_data.nbSeeders < seedsFilters.min)) continue;
-                if ((seedsFilters.max > 0) && (row.full_data.nbSeeders > seedsFilters.max)) continue;
-
-                filteredRows.push(row);
-            }
-        }
-        else {
-            filteredRows = rows;
-        }
-
-        filteredRows.sort(function(row1, row2) {
-            const column = this.columns[this.sortedColumn];
-            const res = column.compareRows(row1, row2);
-            if (this.reverseSort === '0')
-                return res;
-            else
-                return -res;
-        }.bind(this));
-
-        return filteredRows;
-    },
-
-    setupTr: function(tr) {
-        tr.addClass("searchTableRow");
-    }
-});
-
-const SearchPluginsTable = new Class({
-    Extends: DynamicTable,
-
-    initColumns: function() {
-        this.newColumn('fullName', '', 'QBT_TR(Name)QBT_TR[CONTEXT=SearchPluginsTable]', 175, true);
-        this.newColumn('version', '', 'QBT_TR(Version)QBT_TR[CONTEXT=SearchPluginsTable]', 100, true);
-        this.newColumn('url', '', 'QBT_TR(Url)QBT_TR[CONTEXT=SearchPluginsTable]', 175, true);
-        this.newColumn('enabled', '', 'QBT_TR(Enabled)QBT_TR[CONTEXT=SearchPluginsTable]', 100, true);
-
-        this.initColumnsFunctions();
-    },
-
-    initColumnsFunctions: function() {
-        const displayText = function(td, row) {
-            const value = escapeHtml(this.getRowValue(row));
-            td.set('html', value);
-            td.set('title', value);
-        }
-
-        this.columns['fullName'].updateTd = displayText;
-        this.columns['version'].updateTd = displayText;
-        this.columns['url'].updateTd = displayText;
-        this.columns['enabled'].updateTd = function(td, row) {
-            const value = this.getRowValue(row);
-            if (value) {
-                td.set('html', "Yes");
-                td.set('title', "Yes");
-                td.getParent("tr").addClass("green");
-                td.getParent("tr").removeClass("red");
-            }
-            else {
-                td.set('html', "No");
-                td.set('title', "No");
-                td.getParent("tr").addClass("red");
-                td.getParent("tr").removeClass("green");
-            }
-        };
-    },
-
-    setupTr: function(tr) {
-        tr.addClass("searchPluginsTableRow");
-    }
-});
-
-const TorrentTrackersTable = new Class({
-    Extends: DynamicTable,
-
-    initColumns: function() {
-        this.newColumn('tier', '', 'QBT_TR(Tier)QBT_TR[CONTEXT=TrackerListWidget]', 35, true);
-        this.newColumn('url', '', 'QBT_TR(URL)QBT_TR[CONTEXT=TrackerListWidget]', 250, true);
-        this.newColumn('status', '', 'QBT_TR(Status)QBT_TR[CONTEXT=TrackerListWidget]', 125, true);
-        this.newColumn('peers', '', 'QBT_TR(Peers)QBT_TR[CONTEXT=TrackerListWidget]', 75, true);
-        this.newColumn('seeds', '', 'QBT_TR(Seeds)QBT_TR[CONTEXT=TrackerListWidget]', 75, true);
-        this.newColumn('leeches', '', 'QBT_TR(Leeches)QBT_TR[CONTEXT=TrackerListWidget]', 75, true);
-        this.newColumn('downloaded', '', 'QBT_TR(Downloaded)QBT_TR[CONTEXT=TrackerListWidget]', 100, true);
-        this.newColumn('message', '', 'QBT_TR(Message)QBT_TR[CONTEXT=TrackerListWidget]', 250, true);
-    },
-});
-
-const TorrentFilesTable = new Class({
-    Extends: DynamicTable,
-
-    filterTerms: [],
-    prevFilterTerms: [],
-    prevRowsString: null,
-    prevFilteredRows: [],
-    prevSortedColumn: null,
-    prevReverseSort: null,
-    fileTree: new FileTree(),
-
-    populateTable: function(root) {
-        this.fileTree.setRoot(root);
-        root.children.each(function(node) {
-            this._addNodeToTable(node, 0);
-        }.bind(this));
-    },
-
-    _addNodeToTable: function(node, depth) {
-        node.depth = depth;
-
-        if (node.isFolder) {
-            const data = {
-                rowId: node.rowId,
-                size: node.size,
-                checked: node.checked,
-                remaining: node.remaining,
-                progress: node.progress,
-                priority: normalizePriority(node.priority),
-                availability: node.availability,
-                fileId: -1,
-                name: node.name
-            };
-
-            node.data = data;
-            node.full_data = data;
-            this.updateRowData(data);
-        }
-        else {
-            node.data.rowId = node.rowId;
-            node.full_data = node.data;
-            this.updateRowData(node.data);
-        }
-
-        node.children.each(function(child) {
-            this._addNodeToTable(child, depth + 1);
-        }.bind(this));
-    },
-
-    getRoot: function() {
-        return this.fileTree.getRoot();
-    },
-
-    getNode: function(rowId) {
-        return this.fileTree.getNode(rowId);
-    },
-
-    getRow: function(node) {
-        const rowId = this.fileTree.getRowId(node);
-        return this.rows.get(rowId);
-    },
-
-    initColumns: function() {
-        this.newColumn('checked', '', '', 50, true);
-        this.newColumn('name', '', 'QBT_TR(Name)QBT_TR[CONTEXT=TrackerListWidget]', 300, true);
-        this.newColumn('size', '', 'QBT_TR(Size)QBT_TR[CONTEXT=TrackerListWidget]', 75, true);
-        this.newColumn('progress', '', 'QBT_TR(Progress)QBT_TR[CONTEXT=TrackerListWidget]', 100, true);
-        this.newColumn('priority', '', 'QBT_TR(Download Priority)QBT_TR[CONTEXT=TrackerListWidget]', 150, true);
-        this.newColumn('remaining', '', 'QBT_TR(Remaining)QBT_TR[CONTEXT=TrackerListWidget]', 75, true);
-        this.newColumn('availability', '', 'QBT_TR(Availability)QBT_TR[CONTEXT=TrackerListWidget]', 75, true);
-
-        this.initColumnsFunctions();
-    },
-
-    initColumnsFunctions: function() {
-        const that = this;
-        const displaySize = function(td, row) {
-            const size = friendlyUnit(this.getRowValue(row), false);
-            td.set('html', size);
-            td.set('title', size);
-        }
-        const displayPercentage = function(td, row) {
-            const value = friendlyPercentage(this.getRowValue(row));
-            td.set('html', value);
-            td.set('title', value);
-        };
-
-        this.columns['name'].updateTd = function(td, row) {
-            const id = row.rowId;
-            const fileNameId = 'filesTablefileName' + id;
-            const node = that.getNode(id);
-
-            if (node.isFolder) {
-                const value = this.getRowValue(row);
-                const collapseIconId = 'filesTableCollapseIcon' + id;
-                const dirImgId = 'filesTableDirImg' + id;
-                if ($(dirImgId)) {
-                    // just update file name
-                    $(fileNameId).textContent = escapeHtml(value);
+                if (td.getChildren('img').length > 0) {
+                    const img = td.getChildren('img')[0];
+                    if (img.src.indexOf(img_path) < 0) {
+                        img.set('src', img_path);
+                        img.set('title', state);
+                    }
                 }
                 else {
-                    const collapseIcon = new Element('img', {
-                        src: 'images/qbt-theme/go-down.svg',
-                        styles: {
-                            'margin-left': (node.depth * 20)
-                        },
-                        class: "filesTableCollapseIcon",
-                        id: collapseIconId,
-                        "data-id": id,
-                        onclick: "collapseIconClicked(this)"
-                    });
-                    const span = new Element('span', {
-                        text: escapeHtml(value),
-                        id: fileNameId
-                    });
-                    const dirImg = new Element('img', {
-                        src: 'images/qbt-theme/inode-directory.svg',
-                        styles: {
-                            'width': 15,
-                            'padding-right': 5,
-                            'margin-bottom': -3
-                        },
-                        id: dirImgId
-                    });
-                    const html = collapseIcon.outerHTML + dirImg.outerHTML + span.outerHTML;
-                    td.set('html', html);
+                    td.adopt(new Element('img', {
+                        'src': img_path,
+                        'class': 'stateIcon',
+                        'title': state
+                    }));
+                }
+            };
+
+            // status
+            this.columns['status'].updateTd = function(td, row) {
+                const state = this.getRowValue(row);
+                if (!state) return;
+
+                let status;
+                switch (state) {
+                    case "downloading":
+                        status = "QBT_TR(Downloading)QBT_TR[CONTEXT=TransferListDelegate]";
+                        break;
+                    case "stalledDL":
+                        status = "QBT_TR(Stalled)QBT_TR[CONTEXT=TransferListDelegate]";
+                        break;
+                    case "metaDL":
+                        status = "QBT_TR(Downloading metadata)QBT_TR[CONTEXT=TransferListDelegate]";
+                        break;
+                    case "forcedDL":
+                        status = "QBT_TR([F] Downloading)QBT_TR[CONTEXT=TransferListDelegate]";
+                        break;
+                    case "allocating":
+                        status = "QBT_TR(Allocating)QBT_TR[CONTEXT=TransferListDelegate]";
+                        break;
+                    case "uploading":
+                    case "stalledUP":
+                        status = "QBT_TR(Seeding)QBT_TR[CONTEXT=TransferListDelegate]";
+                        break;
+                    case "forcedUP":
+                        status = "QBT_TR([F] Seeding)QBT_TR[CONTEXT=TransferListDelegate]";
+                        break;
+                    case "queuedDL":
+                    case "queuedUP":
+                        status = "QBT_TR(Queued)QBT_TR[CONTEXT=TransferListDelegate]";
+                        break;
+                    case "checkingDL":
+                    case "checkingUP":
+                        status = "QBT_TR(Checking)QBT_TR[CONTEXT=TransferListDelegate]";
+                        break;
+                    case "queuedForChecking":
+                        status = "QBT_TR(Queued for checking)QBT_TR[CONTEXT=TransferListDelegate]";
+                        break;
+                    case "checkingResumeData":
+                        status = "QBT_TR(Checking resume data)QBT_TR[CONTEXT=TransferListDelegate]";
+                        break;
+                    case "pausedDL":
+                        status = "QBT_TR(Paused)QBT_TR[CONTEXT=TransferListDelegate]";
+                        break;
+                    case "pausedUP":
+                        status = "QBT_TR(Completed)QBT_TR[CONTEXT=TransferListDelegate]";
+                        break;
+                    case "moving":
+                        status = "QBT_TR(Moving)QBT_TR[CONTEXT=TransferListDelegate]";
+                        break;
+                    case "missingFiles":
+                        status = "QBT_TR(Missing Files)QBT_TR[CONTEXT=TransferListDelegate]";
+                        break;
+                    case "error":
+                        status = "QBT_TR(Errored)QBT_TR[CONTEXT=TransferListDelegate]";
+                        break;
+                    default:
+                        status = "QBT_TR(Unknown)QBT_TR[CONTEXT=HttpServer]";
+                }
+
+                td.set('html', status);
+                td.set('title', status);
+            };
+
+            // priority
+            this.columns['priority'].updateTd = function(td, row) {
+                const queuePos = this.getRowValue(row);
+                const formattedQueuePos = (queuePos < 1) ? '*' : queuePos;
+                td.set('html', formattedQueuePos);
+                td.set('title', formattedQueuePos);
+            };
+
+            this.columns['priority'].compareRows = function(row1, row2) {
+                let row1_val = this.getRowValue(row1);
+                let row2_val = this.getRowValue(row2);
+                if (row1_val < 1)
+                    row1_val = 1000000;
+                if (row2_val < 1)
+                    row2_val = 1000000;
+                if (row1_val < row2_val)
+                    return -1;
+                else if (row1_val > row2_val)
+                    return 1;
+                else return 0;
+            };
+
+            // name, category, tags
+            this.columns['name'].updateTd = function(td, row) {
+                const name = window.qBittorrent.Misc.escapeHtml(this.getRowValue(row))
+                td.set('html', name);
+                td.set('title', name);
+            };
+            this.columns['category'].updateTd = this.columns['name'].updateTd;
+            this.columns['tags'].updateTd = this.columns['name'].updateTd;
+
+            this.columns['name'].compareRows = function(row1, row2) {
+                const row1Val = this.getRowValue(row1);
+                const row2Val = this.getRowValue(row2);
+                return row1Val.localeCompare(row2Val, undefined, {numeric: true, sensitivity: 'base'});
+            };
+            this.columns['category'].compareRows = this.columns['name'].compareRows;
+            this.columns['tags'].compareRows = this.columns['name'].compareRows;
+
+            // size
+            this.columns['size'].updateTd = function(td, row) {
+                const size = window.qBittorrent.Misc.friendlyUnit(this.getRowValue(row), false);
+                td.set('html', size);
+                td.set('title', size);
+            };
+
+            // progress
+            this.columns['progress'].updateTd = function(td, row) {
+                const progress = this.getRowValue(row);
+                let progressFormated = (progress * 100).round(1);
+                if (progressFormated == 100.0 && progress != 1.0)
+                    progressFormated = 99.9;
+
+                if (td.getChildren('div').length > 0) {
+                    const div = td.getChildren('div')[0];
+                    if (td.resized) {
+                        td.resized = false;
+                        div.setWidth(ProgressColumnWidth - 5);
+                    }
+                    if (div.getValue() != progressFormated)
+                        div.setValue(progressFormated);
+                }
+                else {
+                    if (ProgressColumnWidth < 0)
+                        ProgressColumnWidth = td.offsetWidth;
+                    td.adopt(new window.qBittorrent.ProgressBar.ProgressBar(progressFormated.toFloat(), {
+                        'width': ProgressColumnWidth - 5
+                    }));
+                    td.resized = false;
+                }
+            };
+
+            this.columns['progress'].onResize = function(columnName) {
+                const pos = this.getColumnPos(columnName);
+                const trs = this.tableBody.getElements('tr');
+                ProgressColumnWidth = -1;
+                for (let i = 0; i < trs.length; ++i) {
+                    const td = trs[i].getElements('td')[pos];
+                    if (ProgressColumnWidth < 0)
+                        ProgressColumnWidth = td.offsetWidth;
+                    td.resized = true;
+                    this.columns[columnName].updateTd(td, this.rows.get(trs[i].rowId));
+                }
+            }.bind(this);
+
+            // num_seeds
+            this.columns['num_seeds'].updateTd = function(td, row) {
+                const num_seeds = this.getRowValue(row, 0);
+                const num_complete = this.getRowValue(row, 1);
+                let html = num_seeds;
+                if (num_complete != -1)
+                    html += ' (' + num_complete + ')';
+                td.set('html', html);
+                td.set('title', html);
+            };
+            this.columns['num_seeds'].compareRows = function(row1, row2) {
+                const num_seeds1 = this.getRowValue(row1, 0);
+                const num_complete1 = this.getRowValue(row1, 1);
+
+                const num_seeds2 = this.getRowValue(row2, 0);
+                const num_complete2 = this.getRowValue(row2, 1);
+
+                if (num_complete1 < num_complete2)
+                    return -1;
+                else if (num_complete1 > num_complete2)
+                    return 1;
+                else if (num_seeds1 < num_seeds2)
+                    return -1;
+                else if (num_seeds1 > num_seeds2)
+                    return 1;
+                else return 0;
+            };
+
+            // num_leechs
+            this.columns['num_leechs'].updateTd = this.columns['num_seeds'].updateTd;
+            this.columns['num_leechs'].compareRows = this.columns['num_seeds'].compareRows;
+
+            // dlspeed
+            this.columns['dlspeed'].updateTd = function(td, row) {
+                const speed = window.qBittorrent.Misc.friendlyUnit(this.getRowValue(row), true);
+                td.set('html', speed);
+                td.set('title', speed);
+            };
+
+            // upspeed
+            this.columns['upspeed'].updateTd = this.columns['dlspeed'].updateTd;
+
+            // eta
+            this.columns['eta'].updateTd = function(td, row) {
+                const eta = window.qBittorrent.Misc.friendlyDuration(this.getRowValue(row));
+                td.set('html', eta);
+                td.set('title', eta);
+            };
+
+            // ratio
+            this.columns['ratio'].updateTd = function(td, row) {
+                const ratio = this.getRowValue(row);
+                const string = (ratio === -1) ? '∞' : window.qBittorrent.Misc.toFixedPointString(ratio, 2);
+                td.set('html', string);
+                td.set('title', string);
+            };
+
+            // added on
+            this.columns['added_on'].updateTd = function(td, row) {
+                const date = new Date(this.getRowValue(row) * 1000).toLocaleString();
+                td.set('html', date);
+                td.set('title', date);
+            };
+
+            // completion_on
+            this.columns['completion_on'].updateTd = function(td, row) {
+                const val = this.getRowValue(row);
+                if ((val === 0xffffffff) || (val < 0)) {
+                    td.set('html', '');
+                    td.set('title', '');
+                }
+                else {
+                    const date = new Date(this.getRowValue(row) * 1000).toLocaleString();
+                    td.set('html', date);
+                    td.set('title', date);
+                }
+            };
+
+            // seen_complete
+            this.columns['seen_complete'].updateTd = this.columns['completion_on'].updateTd;
+
+            //  dl_limit, up_limit
+            this.columns['dl_limit'].updateTd = function(td, row) {
+                const speed = this.getRowValue(row);
+                if (speed === 0) {
+                    td.set('html', '∞');
+                    td.set('title', '∞');
+                }
+                else {
+                    const formattedSpeed = window.qBittorrent.Misc.friendlyUnit(speed, true);
+                    td.set('html', formattedSpeed);
+                    td.set('title', formattedSpeed);
+                }
+            };
+
+            this.columns['up_limit'].updateTd = this.columns['dl_limit'].updateTd;
+
+            // downloaded, uploaded, downloaded_session, uploaded_session, amount_left, completed, total_size
+            this.columns['downloaded'].updateTd = this.columns['size'].updateTd;
+            this.columns['uploaded'].updateTd = this.columns['size'].updateTd;
+            this.columns['downloaded_session'].updateTd = this.columns['size'].updateTd;
+            this.columns['uploaded_session'].updateTd = this.columns['size'].updateTd;
+            this.columns['amount_left'].updateTd = this.columns['size'].updateTd;
+            this.columns['amount_left'].updateTd = this.columns['size'].updateTd;
+            this.columns['completed'].updateTd = this.columns['size'].updateTd;
+            this.columns['total_size'].updateTd = this.columns['size'].updateTd;
+
+            // save_path, tracker
+            this.columns['save_path'].updateTd = this.columns['name'].updateTd;
+            this.columns['tracker'].updateTd = this.columns['name'].updateTd;
+
+            // max_ratio
+            this.columns['max_ratio'].updateTd = this.columns['ratio'].updateTd;
+
+            // last_activity
+            this.columns['last_activity'].updateTd = function(td, row) {
+                const val = this.getRowValue(row);
+                if (val < 1) {
+                    td.set('html', '∞');
+                    td.set('title', '∞');
+                }
+                else {
+                    const formattedVal = 'QBT_TR(%1 ago)QBT_TR[CONTEXT=TransferListDelegate]'.replace('%1', window.qBittorrent.Misc.friendlyDuration((new Date()) / 1000 - val));
+                    td.set('html', formattedVal);
+                    td.set('title', formattedVal);
+                }
+            };
+
+            // time active
+            this.columns['time_active'].updateTd = function(td, row) {
+                const time = window.qBittorrent.Misc.friendlyDuration(this.getRowValue(row));
+                td.set('html', time);
+                td.set('title', time);
+            };
+
+            // availability
+            this.columns['availability'].updateTd = function(td, row) {
+                const value = window.qBittorrent.Misc.toFixedPointString(this.getRowValue(row), 3);
+                td.set('html', value);
+                td.set('title', value);
+            };
+        },
+
+        applyFilter: function(row, filterName, categoryHash, tagHash, filterTerms) {
+            const state = row['full_data'].state;
+            const name = row['full_data'].name.toLowerCase();
+            let inactive = false;
+            let r;
+
+            switch (filterName) {
+                case 'downloading':
+                    if (state != 'downloading' && !~state.indexOf('DL'))
+                        return false;
+                    break;
+                case 'seeding':
+                    if (state != 'uploading' && state != 'forcedUP' && state != 'stalledUP' && state != 'queuedUP' && state != 'checkingUP')
+                        return false;
+                    break;
+                case 'completed':
+                    if (state != 'uploading' && !~state.indexOf('UP'))
+                        return false;
+                    break;
+                case 'paused':
+                    if (!~state.indexOf('paused'))
+                        return false;
+                    break;
+                case 'resumed':
+                    if (~state.indexOf('paused'))
+                        return false;
+                    break;
+                case 'inactive':
+                    inactive = true;
+                    // fallthrough
+                case 'active':
+                    if (state == 'stalledDL')
+                        r = (row['full_data'].upspeed > 0);
+                    else
+                        r = state == 'metaDL' || state == 'downloading' || state == 'forcedDL' || state == 'uploading' || state == 'forcedUP';
+                    if (r == inactive)
+                        return false;
+                    break;
+                case 'errored':
+                    if (state != 'error' && state != "unknown" && state != "missingFiles")
+                        return false;
+                    break;
+            }
+
+            const categoryHashInt = parseInt(categoryHash);
+            if (!isNaN(categoryHashInt)) {
+                switch (categoryHashInt) {
+                    case CATEGORIES_ALL:
+                        break;  // do nothing
+                    case CATEGORIES_UNCATEGORIZED:
+                        if (row['full_data'].category.length !== 0)
+                            return false;
+                        break;  // do nothing
+                    default:
+                        if (categoryHashInt !== genHash(row['full_data'].category))
+                            return false;
+                }
+            }
+
+            const tagHashInt = parseInt(tagHash);
+            const isNumber = !isNaN(tagHashInt);
+            if (isNumber) {
+                switch (tagHashInt) {
+                    case TAGS_ALL:
+                        break;  // do nothing
+
+                    case TAGS_UNTAGGED:
+                        if (row['full_data'].tags.length !== 0)
+                            return false;
+                        break;  // do nothing
+
+                    default:
+                        let rowTags = row['full_data'].tags.split(', ');
+                        rowTags = rowTags.map(function(tag) {
+                            return genHash(tag);
+                        });
+                        if (!rowTags.contains(tagHashInt))
+                            return false;
+                }
+            }
+
+            if ((filterTerms !== undefined) && (filterTerms !== null)
+                && (filterTerms.length > 0) && !window.qBittorrent.Misc.containsAllTerms(name, filterTerms))
+                return false;
+
+            return true;
+        },
+
+        getFilteredTorrentsNumber: function(filterName, categoryHash, tagHash) {
+            let cnt = 0;
+            const rows = this.rows.getValues();
+
+            for (let i = 0; i < rows.length; ++i)
+                if (this.applyFilter(rows[i], filterName, categoryHash, tagHash, null)) ++cnt;
+            return cnt;
+        },
+
+        getFilteredTorrentsHashes: function(filterName, categoryHash, tagHash) {
+            const rowsHashes = [];
+            const rows = this.rows.getValues();
+
+            for (let i = 0; i < rows.length; ++i)
+                if (this.applyFilter(rows[i], filterName, categoryHash, tagHash, null))
+                    rowsHashes.push(rows[i]['rowId']);
+
+            return rowsHashes;
+        },
+
+        getFilteredAndSortedRows: function() {
+            const filteredRows = [];
+
+            const rows = this.rows.getValues();
+            const filterText = $('torrentsFilterInput').value.trim().toLowerCase();
+            const filterTerms = (filterText.length > 0) ? filterText.split(" ") : null;
+
+            for (let i = 0; i < rows.length; ++i) {
+                if (this.applyFilter(rows[i], selected_filter, selected_category, selectedTag, filterTerms)) {
+                    filteredRows.push(rows[i]);
+                    filteredRows[rows[i].rowId] = rows[i];
+                }
+            }
+
+            filteredRows.sort(function(row1, row2) {
+                const column = this.columns[this.sortedColumn];
+                const res = column.compareRows(row1, row2);
+                if (this.reverseSort === '0')
+                    return res;
+                else
+                    return -res;
+            }.bind(this));
+            return filteredRows;
+        },
+
+        setupTr: function(tr) {
+            tr.addEvent('dblclick', function(e) {
+                e.stop();
+                this._this.deselectAll();
+                this._this.selectRow(this.rowId);
+                const row = this._this.rows.get(this.rowId);
+                const state = row['full_data'].state;
+                if (~state.indexOf('paused'))
+                    startFN();
+                else
+                    pauseFN();
+                return true;
+            });
+            tr.addClass("torrentsTableContextMenuTarget");
+        },
+
+        getCurrentTorrentHash: function() {
+            return this.getSelectedRowId();
+        },
+
+        onSelectedRowChanged: function() {
+            updatePropertiesPanel();
+        }
+    });
+
+    const TorrentPeersTable = new Class({
+        Extends: DynamicTable,
+
+        initColumns: function() {
+            this.newColumn('country', '', 'QBT_TR(Country)QBT_TR[CONTEXT=PeerListWidget]', 22, true);
+            this.newColumn('ip', '', 'QBT_TR(IP)QBT_TR[CONTEXT=PeerListWidget]', 80, true);
+            this.newColumn('port', '', 'QBT_TR(Port)QBT_TR[CONTEXT=PeerListWidget]', 35, true);
+            this.newColumn('connection', '', 'QBT_TR(Connection)QBT_TR[CONTEXT=PeerListWidget]', 50, true);
+            this.newColumn('flags', '', 'QBT_TR(Flags)QBT_TR[CONTEXT=PeerListWidget]', 50, true);
+            this.newColumn('client', '', 'QBT_TR(Client)QBT_TR[CONTEXT=PeerListWidget]', 140, true);
+            this.newColumn('progress', '', 'QBT_TR(Progress)QBT_TR[CONTEXT=PeerListWidget]', 50, true);
+            this.newColumn('dl_speed', '', 'QBT_TR(Down Speed)QBT_TR[CONTEXT=PeerListWidget]', 50, true);
+            this.newColumn('up_speed', '', 'QBT_TR(Up Speed)QBT_TR[CONTEXT=PeerListWidget]', 50, true);
+            this.newColumn('downloaded', '', 'QBT_TR(Downloaded)QBT_TR[CONTEXT=PeerListWidget]', 50, true);
+            this.newColumn('uploaded', '', 'QBT_TR(Uploaded)QBT_TR[CONTEXT=PeerListWidget]', 50, true);
+            this.newColumn('relevance', '', 'QBT_TR(Relevance)QBT_TR[CONTEXT=PeerListWidget]', 30, true);
+            this.newColumn('files', '', 'QBT_TR(Files)QBT_TR[CONTEXT=PeerListWidget]', 100, true);
+
+            this.columns['country'].dataProperties.push('country_code');
+            this.columns['flags'].dataProperties.push('flags_desc');
+            this.initColumnsFunctions();
+        },
+
+        initColumnsFunctions: function() {
+
+            // country
+
+            this.columns['country'].updateTd = function(td, row) {
+                const country = this.getRowValue(row, 0);
+                const country_code = this.getRowValue(row, 1);
+
+                if (!country_code) {
+                    if (td.getChildren('img').length > 0)
+                        td.getChildren('img')[0].dispose();
+                    return;
+                }
+
+                const img_path = 'images/flags/' + country_code + '.svg';
+
+                if (td.getChildren('img').length > 0) {
+                    const img = td.getChildren('img')[0];
+                    img.set('src', img_path);
+                    img.set('class', 'flags');
+                    img.set('alt', country);
+                    img.set('title', country);
+                }
+                else
+                    td.adopt(new Element('img', {
+                        'src': img_path,
+                        'class': 'flags',
+                        'alt': country,
+                        'title': country
+                    }));
+            };
+
+            // ip
+
+            this.columns['ip'].compareRows = function(row1, row2) {
+                const ip1 = this.getRowValue(row1);
+                const ip2 = this.getRowValue(row2);
+
+                const a = ip1.split(".");
+                const b = ip2.split(".");
+
+                for (let i = 0; i < 4; ++i) {
+                    if (a[i] != b[i])
+                        return a[i] - b[i];
+                }
+
+                return 0;
+            };
+
+            // progress, relevance
+
+            this.columns['progress'].updateTd = function(td, row) {
+                const progress = this.getRowValue(row);
+                let progressFormated = (progress * 100).round(1);
+                if (progressFormated == 100.0 && progress != 1.0)
+                    progressFormated = 99.9;
+                progressFormated += "%";
+                td.set('html', progressFormated);
+                td.set('title', progressFormated);
+            };
+
+            this.columns['relevance'].updateTd = this.columns['progress'].updateTd;
+
+            // dl_speed, up_speed
+
+            this.columns['dl_speed'].updateTd = function(td, row) {
+                const speed = this.getRowValue(row);
+                if (speed === 0) {
+                    td.set('html', '');
+                    td.set('title', '');
+                }
+                else {
+                    const formattedSpeed = window.qBittorrent.Misc.friendlyUnit(speed, true);
+                    td.set('html', formattedSpeed);
+                    td.set('title', formattedSpeed);
+                }
+            };
+
+            this.columns['up_speed'].updateTd = this.columns['dl_speed'].updateTd;
+
+            // downloaded, uploaded
+
+            this.columns['downloaded'].updateTd = function(td, row) {
+                const downloaded = window.qBittorrent.Misc.friendlyUnit(this.getRowValue(row), false);
+                td.set('html', downloaded);
+                td.set('title', downloaded);
+            };
+
+            this.columns['uploaded'].updateTd = this.columns['downloaded'].updateTd;
+
+            // flags
+
+            this.columns['flags'].updateTd = function(td, row) {
+                td.innerHTML = this.getRowValue(row, 0);
+                td.title = this.getRowValue(row, 1);
+            };
+
+            // files
+
+            this.columns['files'].updateTd = function(td, row) {
+                td.innerHTML = window.qBittorrent.Misc.escapeHtml(this.getRowValue(row, 0).replace(/\n/g, ';'));
+                td.title = window.qBittorrent.Misc.escapeHtml(this.getRowValue(row, 0));
+            };
+
+        }
+    });
+
+    const SearchResultsTable = new Class({
+        Extends: DynamicTable,
+
+        initColumns: function() {
+            this.newColumn('fileName', '', 'QBT_TR(Name)QBT_TR[CONTEXT=SearchResultsTable]', 500, true);
+            this.newColumn('fileSize', '', 'QBT_TR(Size)QBT_TR[CONTEXT=SearchResultsTable]', 100, true);
+            this.newColumn('nbSeeders', '', 'QBT_TR(Seeders)QBT_TR[CONTEXT=SearchResultsTable]', 100, true);
+            this.newColumn('nbLeechers', '', 'QBT_TR(Leechers)QBT_TR[CONTEXT=SearchResultsTable]', 100, true);
+            this.newColumn('siteUrl', '', 'QBT_TR(Search engine)QBT_TR[CONTEXT=SearchResultsTable]', 250, true);
+
+            this.initColumnsFunctions();
+        },
+
+        initColumnsFunctions: function() {
+            const displayText = function(td, row) {
+                const value = window.qBittorrent.Misc.escapeHtml(this.getRowValue(row));
+                td.set('html', value);
+                td.set('title', value);
+            }
+            const displaySize = function(td, row) {
+                const size = window.qBittorrent.Misc.friendlyUnit(this.getRowValue(row), false);
+                td.set('html', size);
+                td.set('title', size);
+            }
+            const displayNum = function(td, row) {
+                const value = window.qBittorrent.Misc.escapeHtml(this.getRowValue(row));
+                const formattedValue = (value === "-1") ? "Unknown" : value;
+                td.set('html', formattedValue);
+                td.set('title', formattedValue);
+            }
+
+            this.columns['fileName'].updateTd = displayText;
+            this.columns['fileSize'].updateTd = displaySize;
+            this.columns['nbSeeders'].updateTd = displayNum;
+            this.columns['nbLeechers'].updateTd = displayNum;
+            this.columns['siteUrl'].updateTd = displayText;
+        },
+
+        getFilteredAndSortedRows: function() {
+            const getSizeFilters = function() {
+                let minSize = (window.qBittorrent.Search.searchSizeFilter.min > 0.00) ? (window.qBittorrent.Search.searchSizeFilter.min * Math.pow(1024, window.qBittorrent.Search.searchSizeFilter.minUnit)) : 0.00;
+                let maxSize = (window.qBittorrent.Search.searchSizeFilter.max > 0.00) ? (window.qBittorrent.Search.searchSizeFilter.max * Math.pow(1024, window.qBittorrent.Search.searchSizeFilter.maxUnit)) : 0.00;
+
+                if ((minSize > maxSize) && (maxSize > 0.00)) {
+                    const tmp = minSize;
+                    minSize = maxSize;
+                    maxSize = tmp;
+                }
+
+                return {
+                    min: minSize,
+                    max: maxSize
+                }
+            };
+
+            const getSeedsFilters = function() {
+                let minSeeds = (window.qBittorrent.Search.searchSeedsFilter.min > 0) ? window.qBittorrent.Search.searchSeedsFilter.min : 0;
+                let maxSeeds = (window.qBittorrent.Search.searchSeedsFilter.max > 0) ? window.qBittorrent.Search.searchSeedsFilter.max : 0;
+
+                if ((minSeeds > maxSeeds) && (maxSeeds > 0)) {
+                    const tmp = minSeeds;
+                    minSeeds = maxSeeds;
+                    maxSeeds = tmp;
+                }
+
+                return {
+                    min: minSeeds,
+                    max: maxSeeds
+                }
+            };
+
+            let filteredRows = [];
+            const rows = this.rows.getValues();
+            const searchTerms = window.qBittorrent.Search.searchText.pattern.toLowerCase().split(" ");
+            const filterTerms = window.qBittorrent.Search.searchText.filterPattern.toLowerCase().split(" ");
+            const sizeFilters = getSizeFilters();
+            const seedsFilters = getSeedsFilters();
+            const searchInTorrentName = $('searchInTorrentName').get('value') === "names";
+
+            if (searchInTorrentName || (filterTerms.length > 0) || (window.qBittorrent.Search.searchSizeFilter.min > 0.00) || (window.qBittorrent.Search.searchSizeFilter.max > 0.00)) {
+                for (let i = 0; i < rows.length; ++i) {
+                    const row = rows[i];
+
+                if (searchInTorrentName && !window.qBittorrent.Misc.containsAllTerms(row.full_data.fileName, searchTerms)) continue;
+                if ((filterTerms.length > 0) && !window.qBittorrent.Misc.containsAllTerms(row.full_data.fileName, filterTerms)) continue;
+                    if ((sizeFilters.min > 0.00) && (row.full_data.fileSize < sizeFilters.min)) continue;
+                    if ((sizeFilters.max > 0.00) && (row.full_data.fileSize > sizeFilters.max)) continue;
+                    if ((seedsFilters.min > 0) && (row.full_data.nbSeeders < seedsFilters.min)) continue;
+                    if ((seedsFilters.max > 0) && (row.full_data.nbSeeders > seedsFilters.max)) continue;
+
+                    filteredRows.push(row);
                 }
             }
             else {
+                filteredRows = rows;
+            }
+
+            filteredRows.sort(function(row1, row2) {
+                const column = this.columns[this.sortedColumn];
+                const res = column.compareRows(row1, row2);
+                if (this.reverseSort === '0')
+                    return res;
+                else
+                    return -res;
+            }.bind(this));
+
+            return filteredRows;
+        },
+
+        setupTr: function(tr) {
+            tr.addClass("searchTableRow");
+        }
+    });
+
+    const SearchPluginsTable = new Class({
+        Extends: DynamicTable,
+
+        initColumns: function() {
+            this.newColumn('fullName', '', 'QBT_TR(Name)QBT_TR[CONTEXT=SearchPluginsTable]', 175, true);
+            this.newColumn('version', '', 'QBT_TR(Version)QBT_TR[CONTEXT=SearchPluginsTable]', 100, true);
+            this.newColumn('url', '', 'QBT_TR(Url)QBT_TR[CONTEXT=SearchPluginsTable]', 175, true);
+            this.newColumn('enabled', '', 'QBT_TR(Enabled)QBT_TR[CONTEXT=SearchPluginsTable]', 100, true);
+
+            this.initColumnsFunctions();
+        },
+
+        initColumnsFunctions: function() {
+            const displayText = function(td, row) {
+                const value = window.qBittorrent.Misc.escapeHtml(this.getRowValue(row));
+                td.set('html', value);
+                td.set('title', value);
+            }
+
+            this.columns['fullName'].updateTd = displayText;
+            this.columns['version'].updateTd = displayText;
+            this.columns['url'].updateTd = displayText;
+            this.columns['enabled'].updateTd = function(td, row) {
                 const value = this.getRowValue(row);
-                const span = new Element('span', {
-                    text: escapeHtml(value),
-                    id: fileNameId,
-                    styles: {
-                        'margin-left': ((node.depth + 1) * 20)
+                if (value) {
+                    td.set('html', "Yes");
+                    td.set('title', "Yes");
+                    td.getParent("tr").addClass("green");
+                    td.getParent("tr").removeClass("red");
+                }
+                else {
+                    td.set('html', "No");
+                    td.set('title', "No");
+                    td.getParent("tr").addClass("red");
+                    td.getParent("tr").removeClass("green");
+                }
+            };
+        },
+
+        setupTr: function(tr) {
+            tr.addClass("searchPluginsTableRow");
+        }
+    });
+
+    const TorrentTrackersTable = new Class({
+        Extends: DynamicTable,
+
+        initColumns: function() {
+            this.newColumn('tier', '', 'QBT_TR(Tier)QBT_TR[CONTEXT=TrackerListWidget]', 35, true);
+            this.newColumn('url', '', 'QBT_TR(URL)QBT_TR[CONTEXT=TrackerListWidget]', 250, true);
+            this.newColumn('status', '', 'QBT_TR(Status)QBT_TR[CONTEXT=TrackerListWidget]', 125, true);
+            this.newColumn('peers', '', 'QBT_TR(Peers)QBT_TR[CONTEXT=TrackerListWidget]', 75, true);
+            this.newColumn('seeds', '', 'QBT_TR(Seeds)QBT_TR[CONTEXT=TrackerListWidget]', 75, true);
+            this.newColumn('leeches', '', 'QBT_TR(Leeches)QBT_TR[CONTEXT=TrackerListWidget]', 75, true);
+            this.newColumn('downloaded', '', 'QBT_TR(Downloaded)QBT_TR[CONTEXT=TrackerListWidget]', 100, true);
+            this.newColumn('message', '', 'QBT_TR(Message)QBT_TR[CONTEXT=TrackerListWidget]', 250, true);
+        },
+    });
+
+    const TorrentFilesTable = new Class({
+        Extends: DynamicTable,
+
+        filterTerms: [],
+        prevFilterTerms: [],
+        prevRowsString: null,
+        prevFilteredRows: [],
+        prevSortedColumn: null,
+        prevReverseSort: null,
+        fileTree: new window.qBittorrent.FileTree.FileTree(),
+
+        populateTable: function(root) {
+            this.fileTree.setRoot(root);
+            root.children.each(function(node) {
+                this._addNodeToTable(node, 0);
+            }.bind(this));
+        },
+
+        _addNodeToTable: function(node, depth) {
+            node.depth = depth;
+
+            if (node.isFolder) {
+                const data = {
+                    rowId: node.rowId,
+                    size: node.size,
+                    checked: node.checked,
+                    remaining: node.remaining,
+                    progress: node.progress,
+                    priority: window.qBittorrent.PropFiles.normalizePriority(node.priority),
+                    availability: node.availability,
+                    fileId: -1,
+                    name: node.name
+                };
+
+                node.data = data;
+                node.full_data = data;
+                this.updateRowData(data);
+            }
+            else {
+                node.data.rowId = node.rowId;
+                node.full_data = node.data;
+                this.updateRowData(node.data);
+            }
+
+            node.children.each(function(child) {
+                this._addNodeToTable(child, depth + 1);
+            }.bind(this));
+        },
+
+        getRoot: function() {
+            return this.fileTree.getRoot();
+        },
+
+        getNode: function(rowId) {
+            return this.fileTree.getNode(rowId);
+        },
+
+        getRow: function(node) {
+            const rowId = this.fileTree.getRowId(node);
+            return this.rows.get(rowId);
+        },
+
+        initColumns: function() {
+            this.newColumn('checked', '', '', 50, true);
+            this.newColumn('name', '', 'QBT_TR(Name)QBT_TR[CONTEXT=TrackerListWidget]', 300, true);
+            this.newColumn('size', '', 'QBT_TR(Size)QBT_TR[CONTEXT=TrackerListWidget]', 75, true);
+            this.newColumn('progress', '', 'QBT_TR(Progress)QBT_TR[CONTEXT=TrackerListWidget]', 100, true);
+            this.newColumn('priority', '', 'QBT_TR(Download Priority)QBT_TR[CONTEXT=TrackerListWidget]', 150, true);
+            this.newColumn('remaining', '', 'QBT_TR(Remaining)QBT_TR[CONTEXT=TrackerListWidget]', 75, true);
+            this.newColumn('availability', '', 'QBT_TR(Availability)QBT_TR[CONTEXT=TrackerListWidget]', 75, true);
+
+            this.initColumnsFunctions();
+        },
+
+        initColumnsFunctions: function() {
+            const that = this;
+            const displaySize = function(td, row) {
+                const size = window.qBittorrent.Misc.friendlyUnit(this.getRowValue(row), false);
+                td.set('html', size);
+                td.set('title', size);
+            }
+            const displayPercentage = function(td, row) {
+                const value = window.qBittorrent.Misc.friendlyPercentage(this.getRowValue(row));
+                td.set('html', value);
+                td.set('title', value);
+            };
+
+            this.columns['name'].updateTd = function(td, row) {
+                const id = row.rowId;
+                const fileNameId = 'filesTablefileName' + id;
+                const node = that.getNode(id);
+
+                if (node.isFolder) {
+                    const value = this.getRowValue(row);
+                    const collapseIconId = 'filesTableCollapseIcon' + id;
+                    const dirImgId = 'filesTableDirImg' + id;
+                    if ($(dirImgId)) {
+                        // just update file name
+                        $(fileNameId).textContent = window.qBittorrent.Misc.escapeHtml(value);
                     }
-                });
-                td.set('html', span.outerHTML);
-            }
-        };
-
-        this.columns['checked'].updateTd = function(td, row) {
-            const id = row.rowId;
-            const value = this.getRowValue(row);
-
-            if (isDownloadCheckboxExists(id)) {
-                updateDownloadCheckbox(id, value);
-            }
-            else {
-                const treeImg = new Element('img', {
-                    src: 'images/L.gif',
-                    styles: {
-                        'margin-bottom': -2
+                    else {
+                        const collapseIcon = new Element('img', {
+                            src: 'images/qbt-theme/go-down.svg',
+                            styles: {
+                                'margin-left': (node.depth * 20)
+                            },
+                            class: "filesTableCollapseIcon",
+                            id: collapseIconId,
+                            "data-id": id,
+                            onclick: "qBittorrent.PropFiles.collapseIconClicked(this)"
+                        });
+                        const span = new Element('span', {
+                            text: window.qBittorrent.Misc.escapeHtml(value),
+                            id: fileNameId
+                        });
+                        const dirImg = new Element('img', {
+                            src: 'images/qbt-theme/inode-directory.svg',
+                            styles: {
+                                'width': 15,
+                                'padding-right': 5,
+                                'margin-bottom': -3
+                            },
+                            id: dirImgId
+                        });
+                        const html = collapseIcon.outerHTML + dirImg.outerHTML + span.outerHTML;
+                        td.set('html', html);
                     }
-                });
-                td.adopt(treeImg, createDownloadCheckbox(id, row.full_data.fileId, value));
+                }
+                else {
+                    const value = this.getRowValue(row);
+                    const span = new Element('span', {
+                        text: window.qBittorrent.Misc.escapeHtml(value),
+                        id: fileNameId,
+                        styles: {
+                            'margin-left': ((node.depth + 1) * 20)
+                        }
+                    });
+                    td.set('html', span.outerHTML);
+                }
+            };
+
+            this.columns['checked'].updateTd = function(td, row) {
+                const id = row.rowId;
+                const value = this.getRowValue(row);
+
+                if (window.qBittorrent.PropFiles.isDownloadCheckboxExists(id)) {
+                    window.qBittorrent.PropFiles.updateDownloadCheckbox(id, value);
+                }
+                else {
+                    const treeImg = new Element('img', {
+                        src: 'images/L.gif',
+                        styles: {
+                            'margin-bottom': -2
+                        }
+                    });
+                    td.adopt(treeImg, window.qBittorrent.PropFiles.createDownloadCheckbox(id, row.full_data.fileId, value));
+                }
+            };
+
+            this.columns['size'].updateTd = displaySize;
+
+            this.columns['progress'].updateTd = function(td, row) {
+                const id = row.rowId;
+                const value = this.getRowValue(row);
+
+                const progressBar = $('pbf_' + id);
+                if (progressBar === null) {
+                    td.adopt(new window.qBittorrent.ProgressBar.ProgressBar(value.toFloat(), {
+                        id: 'pbf_' + id,
+                        width: 80
+                    }));
+                }
+                else {
+                    progressBar.setValue(value.toFloat());
+                }
+            };
+
+            this.columns['priority'].updateTd = function(td, row) {
+                const id = row.rowId;
+                const value = this.getRowValue(row);
+
+                if (window.qBittorrent.PropFiles.isPriorityComboExists(id))
+                    window.qBittorrent.PropFiles.updatePriorityCombo(id, value);
+                else
+                    td.adopt(window.qBittorrent.PropFiles.createPriorityCombo(id, row.full_data.fileId, value));
+            };
+
+            this.columns['remaining'].updateTd = displaySize;
+            this.columns['availability'].updateTd = displayPercentage;
+        },
+
+        altRow: function() {
+            let addClass = false;
+            const trs = this.tableBody.getElements('tr');
+            trs.each(function(tr) {
+                if (tr.hasClass("invisible"))
+                    return;
+
+                if (addClass){
+                    tr.addClass("alt");
+                    tr.removeClass("nonAlt");
+                }
+                else {
+                    tr.removeClass("alt");
+                    tr.addClass("nonAlt");
+                }
+                addClass = !addClass;
+            }.bind(this));
+        },
+
+        _sortNodesByColumn: function(nodes, column) {
+            nodes.sort(function(row1, row2) {
+                // list folders before files when sorting by name
+                if (column.name === "name") {
+                    const node1 = this.getNode(row1.data.rowId);
+                    const node2 = this.getNode(row2.data.rowId);
+                    if (node1.isFolder && !node2.isFolder)
+                        return -1;
+                    if (node2.isFolder && !node1.isFolder)
+                        return 1;
+                }
+
+                const res = column.compareRows(row1, row2);
+                return (this.reverseSort === '0') ? res : -res;
+            }.bind(this));
+
+            nodes.each(function(node) {
+                if (node.children.length > 0)
+                    this._sortNodesByColumn(node.children, column);
+            }.bind(this));
+        },
+
+        _filterNodes: function(node, filterTerms, filteredRows) {
+            if (node.isFolder) {
+                const childAdded = node.children.reduce(function (acc, child) {
+                    // we must execute the function before ORing w/ acc or we'll stop checking child nodes after the first successful match
+                    return (this._filterNodes(child, filterTerms, filteredRows) || acc);
+                }.bind(this), false);
+
+                if (childAdded) {
+                    const row = this.getRow(node);
+                    filteredRows.push(row);
+                    return true;
+                }
             }
-        };
 
-        this.columns['size'].updateTd = displaySize;
-
-        this.columns['progress'].updateTd = function(td, row) {
-            const id = row.rowId;
-            const value = this.getRowValue(row);
-
-            const progressBar = $('pbf_' + id);
-            if (progressBar === null) {
-                td.adopt(new ProgressBar(value.toFloat(), {
-                    id: 'pbf_' + id,
-                    width: 80
-                }));
-            }
-            else {
-                progressBar.setValue(value.toFloat());
-            }
-        };
-
-        this.columns['priority'].updateTd = function(td, row) {
-            const id = row.rowId;
-            const value = this.getRowValue(row);
-
-            if (isPriorityComboExists(id))
-                updatePriorityCombo(id, value);
-            else
-                td.adopt(createPriorityCombo(id, row.full_data.fileId, value));
-        };
-
-        this.columns['remaining'].updateTd = displaySize;
-        this.columns['availability'].updateTd = displayPercentage;
-    },
-
-    altRow: function() {
-        let addClass = false;
-        const trs = this.tableBody.getElements('tr');
-        trs.each(function(tr) {
-            if (tr.hasClass("invisible"))
-                return;
-
-            if (addClass){
-                tr.addClass("alt");
-                tr.removeClass("nonAlt");
-            }
-            else {
-                tr.removeClass("alt");
-                tr.addClass("nonAlt");
-            }
-            addClass = !addClass;
-        }.bind(this));
-    },
-
-    _sortNodesByColumn: function(nodes, column) {
-        nodes.sort(function(row1, row2) {
-            // list folders before files when sorting by name
-            if (column.name === "name") {
-                const node1 = this.getNode(row1.data.rowId);
-                const node2 = this.getNode(row2.data.rowId);
-                if (node1.isFolder && !node2.isFolder)
-                    return -1;
-                if (node2.isFolder && !node1.isFolder)
-                    return 1;
-            }
-
-            const res = column.compareRows(row1, row2);
-            return (this.reverseSort === '0') ? res : -res;
-        }.bind(this));
-
-        nodes.each(function(node) {
-            if (node.children.length > 0)
-                this._sortNodesByColumn(node.children, column);
-        }.bind(this));
-    },
-
-    _filterNodes: function(node, filterTerms, filteredRows) {
-        if (node.isFolder) {
-            const childAdded = node.children.reduce(function (acc, child) {
-                // we must execute the function before ORing w/ acc or we'll stop checking child nodes after the first successful match
-                return (this._filterNodes(child, filterTerms, filteredRows) || acc);
-            }.bind(this), false);
-
-            if (childAdded) {
+            if (window.qBittorrent.Misc.containsAllTerms(node.name, filterTerms)) {
                 const row = this.getRow(node);
                 filteredRows.push(row);
                 return true;
             }
-        }
 
-        if (containsAllTerms(node.name, filterTerms)) {
-            const row = this.getRow(node);
-            filteredRows.push(row);
-            return true;
-        }
+            return false;
+        },
 
-        return false;
-    },
+        setFilter: function(text) {
+            const filterTerms = text.trim().toLowerCase().split(' ');
+            if ((filterTerms.length === 1) && (filterTerms[0] === ''))
+                this.filterTerms = [];
+            else
+                this.filterTerms = filterTerms;
+        },
 
-    setFilter: function(text) {
-        const filterTerms = text.trim().toLowerCase().split(' ');
-        if ((filterTerms.length === 1) && (filterTerms[0] === ''))
-            this.filterTerms = [];
-        else
-            this.filterTerms = filterTerms;
-    },
+        getFilteredAndSortedRows: function() {
+            if (this.getRoot() === null)
+                return [];
 
-    getFilteredAndSortedRows: function() {
-        if (this.getRoot() === null)
-            return [];
+            const generateRowsSignature = function(rows) {
+                const rowsData = rows.map(function(row) {
+                    return row.full_data;
+                });
+                return JSON.stringify(rowsData);
+            };
 
-        const generateRowsSignature = function(rows) {
-            const rowsData = rows.map(function(row) {
-                return row.full_data;
-            });
-            return JSON.stringify(rowsData);
-        };
+            const getFilteredRows = function() {
+                if (this.filterTerms.length === 0) {
+                    const nodeArray = this.fileTree.toArray();
+                    const filteredRows = nodeArray.map(function(node) {
+                        return this.getRow(node);
+                    }.bind(this));
+                    return filteredRows;
+                }
 
-        const getFilteredRows = function() {
-            if (this.filterTerms.length === 0) {
-                const nodeArray = this.fileTree.toArray();
-                const filteredRows = nodeArray.map(function(node) {
-                    return this.getRow(node);
+                const filteredRows = [];
+                this.getRoot().children.each(function(child) {
+                    this._filterNodes(child, this.filterTerms, filteredRows);
                 }.bind(this));
+                filteredRows.reverse();
                 return filteredRows;
+            }.bind(this);
+
+            const hasRowsChanged = function(rowsString, prevRowsStringString) {
+                const rowsChanged = (rowsString !== prevRowsStringString);
+                const isFilterTermsChanged = this.filterTerms.reduce(function(acc, term, index) {
+                    return (acc || (term !== this.prevFilterTerms[index]));
+                }.bind(this), false);
+                const isFilterChanged = ((this.filterTerms.length !== this.prevFilterTerms.length)
+                    || ((this.filterTerms.length > 0) && isFilterTermsChanged));
+                const isSortedColumnChanged = (this.prevSortedColumn !== this.sortedColumn);
+                const isReverseSortChanged = (this.prevReverseSort !== this.reverseSort);
+
+                return (rowsChanged || isFilterChanged || isSortedColumnChanged || isReverseSortChanged);
+            }.bind(this);
+
+            const rowsString = generateRowsSignature(this.rows);
+            if (!hasRowsChanged(rowsString, this.prevRowsString)) {
+                return this.prevFilteredRows;
             }
 
-            const filteredRows = [];
-            this.getRoot().children.each(function(child) {
-                this._filterNodes(child, this.filterTerms, filteredRows);
-            }.bind(this));
-            filteredRows.reverse();
+            // sort, then filter
+            const column = this.columns[this.sortedColumn];
+            this._sortNodesByColumn(this.getRoot().children, column);
+            const filteredRows = getFilteredRows();
+
+            this.prevFilterTerms = this.filterTerms;
+            this.prevRowsString = rowsString;
+            this.prevFilteredRows = filteredRows;
+            this.prevSortedColumn = this.sortedColumn;
+            this.prevReverseSort = this.reverseSort;
             return filteredRows;
-        }.bind(this);
+        },
 
-        const hasRowsChanged = function(rowsString, prevRowsStringString) {
-            const rowsChanged = (rowsString !== prevRowsStringString);
-            const isFilterTermsChanged = this.filterTerms.reduce(function(acc, term, index) {
-                return (acc || (term !== this.prevFilterTerms[index]));
-            }.bind(this), false);
-            const isFilterChanged = ((this.filterTerms.length !== this.prevFilterTerms.length)
-                || ((this.filterTerms.length > 0) && isFilterTermsChanged));
-            const isSortedColumnChanged = (this.prevSortedColumn !== this.sortedColumn);
-            const isReverseSortChanged = (this.prevReverseSort !== this.reverseSort);
-
-            return (rowsChanged || isFilterChanged || isSortedColumnChanged || isReverseSortChanged);
-        }.bind(this);
-
-        const rowsString = generateRowsSignature(this.rows);
-        if (!hasRowsChanged(rowsString, this.prevRowsString)) {
-            return this.prevFilteredRows;
+        setIgnored: function(rowId, ignore) {
+            const row = this.rows.get(rowId);
+            if (ignore)
+                row.full_data.remaining = 0;
+            else
+                row.full_data.remaining = (row.full_data.size * (1.0 - (row.full_data.progress / 100)));
         }
+    });
 
-        // sort, then filter
-        const column = this.columns[this.sortedColumn];
-        this._sortNodesByColumn(this.getRoot().children, column);
-        const filteredRows = getFilteredRows();
-
-        this.prevFilterTerms = this.filterTerms;
-        this.prevRowsString = rowsString;
-        this.prevFilteredRows = filteredRows;
-        this.prevSortedColumn = this.sortedColumn;
-        this.prevReverseSort = this.reverseSort;
-        return filteredRows;
-    },
-
-    setIgnored: function(rowId, ignore) {
-        const row = this.rows.get(rowId);
-        if (ignore)
-            row.full_data.remaining = 0;
-        else
-            row.full_data.remaining = (row.full_data.size * (1.0 - (row.full_data.progress / 100)));
-    }
-});
+    return exports();
+})();
 
 /*************************************************************/

--- a/src/webui/www/private/scripts/filesystem.js
+++ b/src/webui/www/private/scripts/filesystem.js
@@ -30,32 +30,49 @@
 
 // This file is the JavaScript implementation of base/utils/fs.cpp
 
-const QB_EXT = '.!qB';
-const PathSeparator = '/';
-
-/**
- * Returns the file extension part of a file name.
- */
-function fileExtension(filename) {
-    const name = filename.endsWith(QB_EXT)
-        ? filename.substring(0, filename.length - QB_EXT.length)
-        : filename;
-    const pointIndex = name.lastIndexOf('.');
-    if (pointIndex === -1)
-        return '';
-    return name.substring(pointIndex + 1);
+if (window.qBittorrent === undefined) {
+    window.qBittorrent = {};
 }
 
-function fileName(filepath) {
-    const slashIndex = filepath.lastIndexOf(PathSeparator);
-    if (slashIndex === -1)
-        return filepath;
-    return filepath.substring(slashIndex + 1);
-}
+window.qBittorrent.Filesystem = (function() {
+    const exports = function() {
+        return {
+            PathSeparator: PathSeparator,
+            fileExtension: fileExtension,
+            fileName: fileName,
+            folderName: folderName
+        };
+    };
 
-function folderName(filepath) {
-    const slashIndex = filepath.lastIndexOf(PathSeparator);
-    if (slashIndex === -1)
-        return filepath;
-    return filepath.substring(0, slashIndex);
-}
+    const QB_EXT = '.!qB';
+    const PathSeparator = '/';
+
+    /**
+     * Returns the file extension part of a file name.
+     */
+    const fileExtension = function(filename) {
+        const name = filename.endsWith(QB_EXT)
+            ? filename.substring(0, filename.length - QB_EXT.length)
+            : filename;
+        const pointIndex = name.lastIndexOf('.');
+        if (pointIndex === -1)
+            return '';
+        return name.substring(pointIndex + 1);
+    };
+
+    const fileName = function(filepath) {
+        const slashIndex = filepath.lastIndexOf(PathSeparator);
+        if (slashIndex === -1)
+            return filepath;
+        return filepath.substring(slashIndex + 1);
+    };
+
+    const folderName = function(filepath) {
+        const slashIndex = filepath.lastIndexOf(PathSeparator);
+        if (slashIndex === -1)
+            return filepath;
+        return filepath.substring(0, slashIndex);
+    };
+
+    return exports();
+})();

--- a/src/webui/www/private/scripts/misc.js
+++ b/src/webui/www/private/scripts/misc.js
@@ -28,166 +28,188 @@
 
 'use strict';
 
-/*
- * JS counterpart of the function in src/misc.cpp
- */
-function friendlyUnit(value, isSpeed) {
-    const units = [
-        "QBT_TR(B)QBT_TR[CONTEXT=misc]",
-        "QBT_TR(KiB)QBT_TR[CONTEXT=misc]",
-        "QBT_TR(MiB)QBT_TR[CONTEXT=misc]",
-        "QBT_TR(GiB)QBT_TR[CONTEXT=misc]",
-        "QBT_TR(TiB)QBT_TR[CONTEXT=misc]",
-        "QBT_TR(PiB)QBT_TR[CONTEXT=misc]",
-        "QBT_TR(EiB)QBT_TR[CONTEXT=misc]"
-    ];
-
-    if ((value === undefined) || (value === null) || (value < 0))
-        return "QBT_TR(Unknown)QBT_TR[CONTEXT=misc]";
-
-    let i = 0;
-    while (value >= 1024.0 && i < 6) {
-        value /= 1024.0;
-        ++i;
-    }
-
-    function friendlyUnitPrecision(sizeUnit) {
-        if (sizeUnit <= 2) return 1; // KiB, MiB
-        else if (sizeUnit === 3) return 2; // GiB
-        else return 3; // TiB, PiB, EiB
-    }
-
-    let ret;
-    if (i === 0)
-        ret = value + " " + units[i];
-    else {
-        const precision = friendlyUnitPrecision(i);
-        const offset = Math.pow(10, precision);
-        // Don't round up
-        ret = (Math.floor(offset * value) / offset).toFixed(precision) + " " + units[i];
-    }
-
-    if (isSpeed)
-        ret += "QBT_TR(/s)QBT_TR[CONTEXT=misc]";
-    return ret;
+if (window.qBittorrent === undefined) {
+    window.qBittorrent = {};
 }
 
-/*
- * JS counterpart of the function in src/misc.cpp
- */
-function friendlyDuration(seconds) {
-    const MAX_ETA = 8640000;
-    if (seconds < 0 || seconds >= MAX_ETA)
-        return "∞";
-    if (seconds === 0)
-        return "0";
-    if (seconds < 60)
-        return "QBT_TR(< 1m)QBT_TR[CONTEXT=misc]";
-    let minutes = seconds / 60;
-    if (minutes < 60)
-        return "QBT_TR(%1m)QBT_TR[CONTEXT=misc]".replace("%1", parseInt(minutes));
-    let hours = minutes / 60;
-    minutes = minutes % 60;
-    if (hours < 24)
-        return "QBT_TR(%1h %2m)QBT_TR[CONTEXT=misc]".replace("%1", parseInt(hours)).replace("%2", parseInt(minutes));
-    const days = hours / 24;
-    hours = hours % 24;
-    if (days < 100)
-        return "QBT_TR(%1d %2h)QBT_TR[CONTEXT=misc]".replace("%1", parseInt(days)).replace("%2", parseInt(hours));
-    return "∞";
-}
-
-function friendlyPercentage(value) {
-    let percentage = (value * 100).round(1);
-    if (isNaN(percentage) || (percentage < 0))
-        percentage = 0;
-    if (percentage > 100)
-        percentage = 100;
-    return percentage.toFixed(1) + "%";
-}
-
-function friendlyFloat(value, precision) {
-    return parseFloat(value).toFixed(precision);
-}
-
-/*
- * From: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
- */
-if (!Date.prototype.toISOString) {
-    (function() {
-
-        function pad(number) {
-            if (number < 10) {
-                return '0' + number;
-            }
-            return number;
-        }
-
-        Date.prototype.toISOString = function() {
-            return this.getUTCFullYear()
-                + '-' + pad(this.getUTCMonth() + 1)
-                + '-' + pad(this.getUTCDate())
-                + 'T' + pad(this.getUTCHours())
-                + ':' + pad(this.getUTCMinutes())
-                + ':' + pad(this.getUTCSeconds())
-                + '.' + (this.getUTCMilliseconds() / 1000).toFixed(3).slice(2, 5)
-                + 'Z';
+window.qBittorrent.Misc = (function() {
+    const exports = function() {
+        return {
+            friendlyUnit: friendlyUnit,
+            friendlyDuration: friendlyDuration,
+            friendlyPercentage: friendlyPercentage,
+            friendlyFloat: friendlyFloat,
+            parseHtmlLinks: parseHtmlLinks,
+            escapeHtml: escapeHtml,
+            safeTrim: safeTrim,
+            toFixedPointString: toFixedPointString,
+            containsAllTerms: containsAllTerms
         };
+    };
 
-    }());
-}
+    /*
+    * JS counterpart of the function in src/misc.cpp
+    */
+    const friendlyUnit = function(value, isSpeed) {
+        const units = [
+            "QBT_TR(B)QBT_TR[CONTEXT=misc]",
+            "QBT_TR(KiB)QBT_TR[CONTEXT=misc]",
+            "QBT_TR(MiB)QBT_TR[CONTEXT=misc]",
+            "QBT_TR(GiB)QBT_TR[CONTEXT=misc]",
+            "QBT_TR(TiB)QBT_TR[CONTEXT=misc]",
+            "QBT_TR(PiB)QBT_TR[CONTEXT=misc]",
+            "QBT_TR(EiB)QBT_TR[CONTEXT=misc]"
+        ];
 
-/*
- * JS counterpart of the function in src/misc.cpp
- */
-function parseHtmlLinks(text) {
-    const exp = /(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig;
-    return text.replace(exp, "<a target='_blank' href='$1'>$1</a>");
-}
+        if ((value === undefined) || (value === null) || (value < 0))
+            return "QBT_TR(Unknown)QBT_TR[CONTEXT=misc]";
 
-function escapeHtml(str) {
-    const div = document.createElement('div');
-    div.appendChild(document.createTextNode(str));
-    return div.innerHTML;
-}
-
-function safeTrim(value) {
-    try {
-        return value.trim();
-    }
-    catch (e) {
-        if (e instanceof TypeError)
-            return "";
-        throw e;
-    }
-}
-
-function toFixedPointString(number, digits) {
-    // Do not round up number
-    const power = Math.pow(10, digits);
-    return (Math.floor(power * number) / power).toFixed(digits);
-}
-
-/**
- *
- * @param {String} text the text to search
- * @param {Array<String>} terms terms to search for within the text
- * @returns {Boolean} true if all terms match the text, false otherwise
- */
-function containsAllTerms(text, terms) {
-    const textToSearch = text.toLowerCase();
-    return terms.every((function(term) {
-        const isTermRequired = (term[0] === '+');
-        const isTermExcluded = (term[0] === '-');
-        if (isTermRequired || isTermExcluded) {
-            // ignore lonely +/-
-            if (term.length === 1)
-                return true;
-
-            term = term.substring(1);
+        let i = 0;
+        while (value >= 1024.0 && i < 6) {
+            value /= 1024.0;
+            ++i;
         }
 
-        const textContainsTerm = (textToSearch.indexOf(term) !== -1);
-        return isTermExcluded ? !textContainsTerm : textContainsTerm;
-    }));
-}
+        function friendlyUnitPrecision(sizeUnit) {
+            if (sizeUnit <= 2) return 1; // KiB, MiB
+            else if (sizeUnit === 3) return 2; // GiB
+            else return 3; // TiB, PiB, EiB
+        }
+
+        let ret;
+        if (i === 0)
+            ret = value + " " + units[i];
+        else {
+            const precision = friendlyUnitPrecision(i);
+            const offset = Math.pow(10, precision);
+            // Don't round up
+            ret = (Math.floor(offset * value) / offset).toFixed(precision) + " " + units[i];
+        }
+
+        if (isSpeed)
+            ret += "QBT_TR(/s)QBT_TR[CONTEXT=misc]";
+        return ret;
+    }
+
+    /*
+    * JS counterpart of the function in src/misc.cpp
+    */
+    const friendlyDuration = function(seconds) {
+        const MAX_ETA = 8640000;
+        if (seconds < 0 || seconds >= MAX_ETA)
+            return "∞";
+        if (seconds === 0)
+            return "0";
+        if (seconds < 60)
+            return "QBT_TR(< 1m)QBT_TR[CONTEXT=misc]";
+        let minutes = seconds / 60;
+        if (minutes < 60)
+            return "QBT_TR(%1m)QBT_TR[CONTEXT=misc]".replace("%1", parseInt(minutes));
+        let hours = minutes / 60;
+        minutes = minutes % 60;
+        if (hours < 24)
+            return "QBT_TR(%1h %2m)QBT_TR[CONTEXT=misc]".replace("%1", parseInt(hours)).replace("%2", parseInt(minutes));
+        const days = hours / 24;
+        hours = hours % 24;
+        if (days < 100)
+            return "QBT_TR(%1d %2h)QBT_TR[CONTEXT=misc]".replace("%1", parseInt(days)).replace("%2", parseInt(hours));
+        return "∞";
+    }
+
+    const friendlyPercentage = function(value) {
+        let percentage = (value * 100).round(1);
+        if (isNaN(percentage) || (percentage < 0))
+            percentage = 0;
+        if (percentage > 100)
+            percentage = 100;
+        return percentage.toFixed(1) + "%";
+    }
+
+    const friendlyFloat = function(value, precision) {
+        return parseFloat(value).toFixed(precision);
+    }
+
+    /*
+    * From: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
+    */
+    if (!Date.prototype.toISOString) {
+        (function() {
+
+            function pad(number) {
+                if (number < 10) {
+                    return '0' + number;
+                }
+                return number;
+            }
+
+            Date.prototype.toISOString = function() {
+                return this.getUTCFullYear()
+                    + '-' + pad(this.getUTCMonth() + 1)
+                    + '-' + pad(this.getUTCDate())
+                    + 'T' + pad(this.getUTCHours())
+                    + ':' + pad(this.getUTCMinutes())
+                    + ':' + pad(this.getUTCSeconds())
+                    + '.' + (this.getUTCMilliseconds() / 1000).toFixed(3).slice(2, 5)
+                    + 'Z';
+            };
+
+        }());
+    }
+
+    /*
+    * JS counterpart of the function in src/misc.cpp
+    */
+    const parseHtmlLinks = function(text) {
+        const exp = /(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig;
+        return text.replace(exp, "<a target='_blank' href='$1'>$1</a>");
+    }
+
+    const escapeHtml = function(str) {
+        const div = document.createElement('div');
+        div.appendChild(document.createTextNode(str));
+        return div.innerHTML;
+    }
+
+    const safeTrim = function(value) {
+        try {
+            return value.trim();
+        }
+        catch (e) {
+            if (e instanceof TypeError)
+                return "";
+            throw e;
+        }
+    }
+
+    const toFixedPointString = function(number, digits) {
+        // Do not round up number
+        const power = Math.pow(10, digits);
+        return (Math.floor(power * number) / power).toFixed(digits);
+    }
+
+    /**
+     *
+     * @param {String} text the text to search
+     * @param {Array<String>} terms terms to search for within the text
+     * @returns {Boolean} true if all terms match the text, false otherwise
+     */
+    const containsAllTerms = function(text, terms) {
+        const textToSearch = text.toLowerCase();
+        return terms.every((function(term) {
+            const isTermRequired = (term[0] === '+');
+            const isTermExcluded = (term[0] === '-');
+            if (isTermRequired || isTermExcluded) {
+                // ignore lonely +/-
+                if (term.length === 1)
+                    return true;
+
+                term = term.substring(1);
+            }
+
+            const textContainsTerm = (textToSearch.indexOf(term) !== -1);
+            return isTermExcluded ? !textContainsTerm : textContainsTerm;
+        }));
+    }
+
+    return exports();
+})();

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -38,7 +38,7 @@
    ----------------------------------------------------------------- */
 'use strict';
 
-const LocalPreferences = new LocalPreferencesClass();
+const LocalPreferences = new window.qBittorrent.LocalPreferences.LocalPreferencesClass();
 
 let saveWindowSize = function() {};
 let loadWindowWidth = function() {};

--- a/src/webui/www/private/scripts/preferences.js
+++ b/src/webui/www/private/scripts/preferences.js
@@ -28,20 +28,34 @@
 
 'use strict';
 
-const LocalPreferencesClass = new Class({
-    get: function(key, defaultValue) {
-        const value = localStorage.getItem(key);
-        return ((value === null) && (defaultValue !== undefined))
-            ? defaultValue
-            : value;
-    },
+if (window.qBittorrent === undefined) {
+    window.qBittorrent = {};
+}
 
-    set: function(key, value) {
-        try {
-            localStorage.setItem(key, value);
+window.qBittorrent.LocalPreferences = (function() {
+    const exports = function() {
+        return {
+            LocalPreferencesClass: LocalPreferencesClass
+        };
+    };
+
+    const LocalPreferencesClass = new Class({
+        get: function(key, defaultValue) {
+            const value = localStorage.getItem(key);
+            return ((value === null) && (defaultValue !== undefined))
+                ? defaultValue
+                : value;
+        },
+
+        set: function(key, value) {
+            try {
+                localStorage.setItem(key, value);
+            }
+            catch (err) {
+                console.error(err);
+            }
         }
-        catch (err) {
-            console.error(err);
-        }
-    }
-})
+    })
+
+    return exports();
+})();

--- a/src/webui/www/private/scripts/progressbar.js
+++ b/src/webui/www/private/scripts/progressbar.js
@@ -28,113 +28,126 @@
 
 'use strict';
 
-const ProgressBar = new Class({
-    initialize: function(value, parameters) {
-        const vals = {
-            'id': 'progressbar_' + (ProgressBars++),
-            'value': $pick(value, 0),
-            'width': 0,
-            'height': 0,
-            'darkbg': '#006',
-            'darkfg': '#fff',
-            'lightbg': '#fff',
-            'lightfg': '#000'
+if (window.qBittorrent === undefined) {
+    window.qBittorrent = {};
+}
+
+window.qBittorrent.ProgressBar = (function() {
+    const exports = function() {
+        return {
+            ProgressBar: ProgressBar
         };
-        if (parameters && $type(parameters) == 'object') $extend(vals, parameters);
-        if (vals.height < 12) vals.height = 12;
-        const obj = new Element('div', {
-            'id': vals.id,
-            'class': 'progressbar_wrapper',
-            'styles': {
-                'border': '1px solid #000',
-                'width': vals.width,
-                'height': vals.height,
-                'position': 'relative',
-                'margin': '0 auto'
-            }
-        });
-        obj.vals = vals;
-        obj.vals.value = $pick(value, 0); // Fix by Chris
-        obj.vals.dark = new Element('div', {
-            'id': vals.id + '_dark',
-            'class': 'progressbar_dark',
-            'styles': {
-                'width': vals.width,
-                'height': vals.height,
-                'background': vals.darkbg,
-                'color': vals.darkfg,
-                'position': 'absolute',
-                'text-align': 'center',
-                'left': 0,
-                'top': 0,
-                'line-height': vals.height
-            }
-        });
-        obj.vals.light = new Element('div', {
-            'id': vals.id + '_light',
-            'class': 'progressbar_light',
-            'styles': {
-                'width': vals.width,
-                'height': vals.height,
-                'background': vals.lightbg,
-                'color': vals.lightfg,
-                'position': 'absolute',
-                'text-align': 'center',
-                'left': 0,
-                'top': 0,
-                'line-height': vals.height
-            }
-        });
-        obj.appendChild(obj.vals.dark);
-        obj.appendChild(obj.vals.light);
-        obj.getValue = ProgressBar_getValue;
-        obj.setValue = ProgressBar_setValue;
-        obj.setWidth = ProgressBar_setWidth;
-        if (vals.width) obj.setValue(vals.value);
-        else setTimeout('ProgressBar_checkForParent("' + obj.id + '")', 1);
-        return obj;
+    };
+
+    let ProgressBars = 0;
+    const ProgressBar = new Class({
+        initialize: function(value, parameters) {
+            const vals = {
+                'id': 'progressbar_' + (ProgressBars++),
+                'value': $pick(value, 0),
+                'width': 0,
+                'height': 0,
+                'darkbg': '#006',
+                'darkfg': '#fff',
+                'lightbg': '#fff',
+                'lightfg': '#000'
+            };
+            if (parameters && $type(parameters) == 'object') $extend(vals, parameters);
+            if (vals.height < 12) vals.height = 12;
+            const obj = new Element('div', {
+                'id': vals.id,
+                'class': 'progressbar_wrapper',
+                'styles': {
+                    'border': '1px solid #000',
+                    'width': vals.width,
+                    'height': vals.height,
+                    'position': 'relative',
+                    'margin': '0 auto'
+                }
+            });
+            obj.vals = vals;
+            obj.vals.value = $pick(value, 0); // Fix by Chris
+            obj.vals.dark = new Element('div', {
+                'id': vals.id + '_dark',
+                'class': 'progressbar_dark',
+                'styles': {
+                    'width': vals.width,
+                    'height': vals.height,
+                    'background': vals.darkbg,
+                    'color': vals.darkfg,
+                    'position': 'absolute',
+                    'text-align': 'center',
+                    'left': 0,
+                    'top': 0,
+                    'line-height': vals.height
+                }
+            });
+            obj.vals.light = new Element('div', {
+                'id': vals.id + '_light',
+                'class': 'progressbar_light',
+                'styles': {
+                    'width': vals.width,
+                    'height': vals.height,
+                    'background': vals.lightbg,
+                    'color': vals.lightfg,
+                    'position': 'absolute',
+                    'text-align': 'center',
+                    'left': 0,
+                    'top': 0,
+                    'line-height': vals.height
+                }
+            });
+            obj.appendChild(obj.vals.dark);
+            obj.appendChild(obj.vals.light);
+            obj.getValue = ProgressBar_getValue;
+            obj.setValue = ProgressBar_setValue;
+            obj.setWidth = ProgressBar_setWidth;
+            if (vals.width) obj.setValue(vals.value);
+            else setTimeout('ProgressBar_checkForParent("' + obj.id + '")', 1);
+            return obj;
+        }
+    });
+
+    function ProgressBar_getValue() {
+        return this.vals.value;
     }
-});
 
-function ProgressBar_getValue() {
-    return this.vals.value;
-}
-
-function ProgressBar_setValue(value) {
-    value = parseFloat(value);
-    if (isNaN(value)) value = 0;
-    if (value > 100) value = 100;
-    if (value < 0) value = 0;
-    this.vals.value = value;
-    this.vals.dark.empty();
-    this.vals.light.empty();
-    this.vals.dark.appendText(value.round(1).toFixed(1) + '%');
-    this.vals.light.appendText(value.round(1).toFixed(1) + '%');
-    const r = parseInt(this.vals.width * (value / 100));
-    this.vals.dark.setStyle('clip', 'rect(0,' + r + 'px,' + this.vals.height + 'px,0)');
-    this.vals.light.setStyle('clip', 'rect(0,' + this.vals.width + 'px,' + this.vals.height + 'px,' + r + 'px)');
-}
-
-function ProgressBar_setWidth(value) {
-    if (this.vals.width !== value) {
-        this.vals.width = value;
-        this.setStyle('width', value);
-        this.vals.dark.setStyle('width', value);
-        this.vals.light.setStyle('width', value);
-        this.setValue(this.vals.value);
+    function ProgressBar_setValue(value) {
+        value = parseFloat(value);
+        if (isNaN(value)) value = 0;
+        if (value > 100) value = 100;
+        if (value < 0) value = 0;
+        this.vals.value = value;
+        this.vals.dark.empty();
+        this.vals.light.empty();
+        this.vals.dark.appendText(value.round(1).toFixed(1) + '%');
+        this.vals.light.appendText(value.round(1).toFixed(1) + '%');
+        const r = parseInt(this.vals.width * (value / 100));
+        this.vals.dark.setStyle('clip', 'rect(0,' + r + 'px,' + this.vals.height + 'px,0)');
+        this.vals.light.setStyle('clip', 'rect(0,' + this.vals.width + 'px,' + this.vals.height + 'px,' + r + 'px)');
     }
-}
 
-function ProgressBar_checkForParent(id) {
-    const obj = $(id);
-    if (!obj) return;
-    if (!obj.parentNode) return setTimeout('ProgressBar_checkForParent("' + id + '")', 1);
-    obj.setStyle('width', '100%');
-    const w = obj.offsetWidth;
-    obj.vals.dark.setStyle('width', w);
-    obj.vals.light.setStyle('width', w);
-    obj.vals.width = w;
-    obj.setValue(obj.vals.value);
-}
+    function ProgressBar_setWidth(value) {
+        if (this.vals.width !== value) {
+            this.vals.width = value;
+            this.setStyle('width', value);
+            this.vals.dark.setStyle('width', value);
+            this.vals.light.setStyle('width', value);
+            this.setValue(this.vals.value);
+        }
+    }
 
-let ProgressBars = 0;
+    function ProgressBar_checkForParent(id) {
+        const obj = $(id);
+        if (!obj) return;
+        if (!obj.parentNode) return setTimeout('ProgressBar_checkForParent("' + id + '")', 1);
+        obj.setStyle('width', '100%');
+        const w = obj.offsetWidth;
+        obj.vals.dark.setStyle('width', w);
+        obj.vals.light.setStyle('width', w);
+        obj.vals.width = w;
+        obj.setValue(obj.vals.value);
+    }
+
+    return exports();
+})();

--- a/src/webui/www/private/scripts/prop-files.js
+++ b/src/webui/www/private/scripts/prop-files.js
@@ -28,647 +28,672 @@
 
 'use strict';
 
-let is_seed = true;
-this.current_hash = "";
+if (window.qBittorrent === undefined) {
+    window.qBittorrent = {};
+}
 
-const normalizePriority = function(priority) {
-    switch (priority) {
-        case FilePriority.Ignored:
-        case FilePriority.Normal:
-        case FilePriority.High:
-        case FilePriority.Maximum:
-        case FilePriority.Mixed:
-            return priority;
-        default:
-            return FilePriority.Normal;
-    }
-};
-
-const getAllChildren = function(id, fileId) {
-    const node = torrentFilesTable.getNode(id);
-    if (!node.isFolder) {
+window.qBittorrent.PropFiles = (function() {
+    const exports = function() {
         return {
-            rowIds: [id],
-            fileIds: [fileId]
+            normalizePriority: normalizePriority,
+            isDownloadCheckboxExists: isDownloadCheckboxExists,
+            createDownloadCheckbox: createDownloadCheckbox,
+            updateDownloadCheckbox: updateDownloadCheckbox,
+            isPriorityComboExists: isPriorityComboExists,
+            createPriorityCombo: createPriorityCombo,
+            updatePriorityCombo: updatePriorityCombo,
+            updateData: updateData,
+            collapseIconClicked: collapseIconClicked
         };
+    };
+
+    const torrentFilesTable = new window.qBittorrent.DynamicTable.TorrentFilesTable();
+    const FilePriority = window.qBittorrent.FileTree.FilePriority;
+    const TriState = window.qBittorrent.FileTree.TriState;
+    let is_seed = true;
+    let current_hash = "";
+
+    const normalizePriority = function(priority) {
+        switch (priority) {
+            case FilePriority.Ignored:
+            case FilePriority.Normal:
+            case FilePriority.High:
+            case FilePriority.Maximum:
+            case FilePriority.Mixed:
+                return priority;
+            default:
+                return FilePriority.Normal;
+        }
+    };
+
+    const getAllChildren = function(id, fileId) {
+        const node = torrentFilesTable.getNode(id);
+        if (!node.isFolder) {
+            return {
+                rowIds: [id],
+                fileIds: [fileId]
+            };
+        }
+
+        const rowIds = [];
+        const fileIds = [];
+
+        const getChildFiles = function(node) {
+            if (node.isFolder) {
+                node.children.each(function(child) {
+                    getChildFiles(child);
+                });
+            }
+            else {
+                rowIds.push(node.data.rowId);
+                fileIds.push(node.data.fileId);
+            }
+        };
+
+        node.children.each(function(child) {
+            getChildFiles(child);
+        });
+
+        return {
+            rowIds: rowIds,
+            fileIds: fileIds
+        };
+    };
+
+    const fileCheckboxClicked = function(e) {
+        e.stopPropagation();
+
+        const checkbox = e.target;
+        const priority = checkbox.checked ? FilePriority.Normal : FilePriority.Ignored;
+        const id = checkbox.get('data-id');
+        const fileId = checkbox.get('data-file-id');
+
+        const rows = getAllChildren(id, fileId);
+
+        setFilePriority(rows.rowIds, rows.fileIds, priority);
+        updateGlobalCheckbox();
+    };
+
+    const fileComboboxChanged = function(e) {
+        const combobox = e.target;
+        const priority = combobox.value;
+        const id = combobox.get('data-id');
+        const fileId = combobox.get('data-file-id');
+
+        const rows = getAllChildren(id, fileId);
+
+        setFilePriority(rows.rowIds, rows.fileIds, priority);
+        updateGlobalCheckbox();
+    };
+
+    const isDownloadCheckboxExists = function(id) {
+        return ($('cbPrio' + id) !== null);
+    };
+
+    const createDownloadCheckbox = function(id, fileId, checked) {
+        const checkbox = new Element('input');
+        checkbox.set('type', 'checkbox');
+        checkbox.set('id', 'cbPrio' + id);
+        checkbox.set('data-id', id);
+        checkbox.set('data-file-id', fileId);
+        checkbox.set('class', 'DownloadedCB');
+        checkbox.addEvent('click', fileCheckboxClicked);
+
+        updateCheckbox(checkbox, checked);
+        return checkbox;
+    };
+
+    const updateDownloadCheckbox = function(id, checked) {
+        const checkbox = $('cbPrio' + id);
+        updateCheckbox(checkbox, checked);
+    };
+
+    const updateCheckbox = function(checkbox, checked) {
+        switch (checked) {
+            case TriState.Checked:
+                setCheckboxChecked(checkbox);
+                break;
+            case TriState.Unchecked:
+                setCheckboxUnchecked(checkbox);
+                break;
+            case TriState.Partial:
+                setCheckboxPartial(checkbox);
+                break;
+        }
     }
 
-    const rowIds = [];
-    const fileIds = [];
+    const isPriorityComboExists = function(id) {
+        return ($('comboPrio' + id) !== null);
+    };
 
-    const getChildFiles = function(node) {
-        if (node.isFolder) {
-            node.children.each(function(child) {
-                getChildFiles(child);
+    const createPriorityOptionElement = function(priority, selected, html) {
+        const elem = new Element('option');
+        elem.set('value', priority.toString());
+        elem.set('html', html);
+        if (selected)
+            elem.setAttribute('selected', '');
+        return elem;
+    };
+
+    const createPriorityCombo = function(id, fileId, selectedPriority) {
+        const select = new Element('select');
+        select.set('id', 'comboPrio' + id);
+        select.set('data-id', id);
+        select.set('data-file-id', fileId);
+        select.set('disabled', is_seed);
+        select.addClass('combo_priority');
+        select.addEvent('change', fileComboboxChanged);
+
+        createPriorityOptionElement(FilePriority.Ignored, (FilePriority.Ignored === selectedPriority), 'QBT_TR(Do not download)QBT_TR[CONTEXT=PropListDelegate]').injectInside(select);
+        createPriorityOptionElement(FilePriority.Normal, (FilePriority.Normal === selectedPriority), 'QBT_TR(Normal)QBT_TR[CONTEXT=PropListDelegate]').injectInside(select);
+        createPriorityOptionElement(FilePriority.High, (FilePriority.High === selectedPriority), 'QBT_TR(High)QBT_TR[CONTEXT=PropListDelegate]').injectInside(select);
+        createPriorityOptionElement(FilePriority.Maximum, (FilePriority.Maximum === selectedPriority), 'QBT_TR(Maximum)QBT_TR[CONTEXT=PropListDelegate]').injectInside(select);
+
+        // "Mixed" priority is for display only; it shouldn't be selectable
+        const mixedPriorityOption = createPriorityOptionElement(FilePriority.Mixed, (FilePriority.Mixed === selectedPriority), 'QBT_TR(Mixed)QBT_TR[CONTEXT=PropListDelegate]');
+        mixedPriorityOption.set('disabled', true);
+        mixedPriorityOption.injectInside(select);
+
+        return select;
+    };
+
+    const updatePriorityCombo = function(id, selectedPriority) {
+        const combobox = $('comboPrio' + id);
+
+        if (parseInt(combobox.value) !== selectedPriority)
+            selectComboboxPriority(combobox, selectedPriority);
+
+        if (combobox.disabled !== is_seed)
+            combobox.disabled = is_seed;
+    };
+
+    const selectComboboxPriority = function(combobox, priority) {
+        const options = combobox.options;
+        for (let i = 0; i < options.length; ++i) {
+            const option = options[i];
+            if (parseInt(option.value) === priority)
+                option.setAttribute('selected', '');
+            else
+                option.removeAttribute('selected');
+        }
+
+        combobox.value = priority;
+    };
+
+    const switchCheckboxState = function(e) {
+        e.stopPropagation();
+
+        const rowIds = [];
+        const fileIds = [];
+        let priority = FilePriority.Ignored;
+        const checkbox = $('tristate_cb');
+
+        if (checkbox.state === "checked") {
+            setCheckboxUnchecked(checkbox);
+            // set file priority for all checked to Ignored
+            torrentFilesTable.getFilteredAndSortedRows().forEach(function(row) {
+                const rowId = row.rowId;
+                const fileId = row.full_data.fileId;
+                const isChecked = (row.full_data.checked === TriState.Checked);
+                const isFolder = (fileId === -1);
+                if (!isFolder && isChecked) {
+                    rowIds.push(rowId);
+                    fileIds.push(fileId);
+                }
             });
         }
         else {
-            rowIds.push(node.data.rowId);
-            fileIds.push(node.data.fileId);
-        }
-    };
-
-    node.children.each(function(child) {
-        getChildFiles(child);
-    });
-
-    return {
-        rowIds: rowIds,
-        fileIds: fileIds
-    };
-};
-
-const fileCheckboxClicked = function(e) {
-    e.stopPropagation();
-
-    const checkbox = e.target;
-    const priority = checkbox.checked ? FilePriority.Normal : FilePriority.Ignored;
-    const id = checkbox.get('data-id');
-    const fileId = checkbox.get('data-file-id');
-
-    const rows = getAllChildren(id, fileId);
-
-    setFilePriority(rows.rowIds, rows.fileIds, priority);
-    updateGlobalCheckbox();
-};
-
-const fileComboboxChanged = function(e) {
-    const combobox = e.target;
-    const priority = combobox.value;
-    const id = combobox.get('data-id');
-    const fileId = combobox.get('data-file-id');
-
-    const rows = getAllChildren(id, fileId);
-
-    setFilePriority(rows.rowIds, rows.fileIds, priority);
-    updateGlobalCheckbox();
-};
-
-const isDownloadCheckboxExists = function(id) {
-    return ($('cbPrio' + id) !== null);
-};
-
-const createDownloadCheckbox = function(id, fileId, checked) {
-    const checkbox = new Element('input');
-    checkbox.set('type', 'checkbox');
-    checkbox.set('id', 'cbPrio' + id);
-    checkbox.set('data-id', id);
-    checkbox.set('data-file-id', fileId);
-    checkbox.set('class', 'DownloadedCB');
-    checkbox.addEvent('click', fileCheckboxClicked);
-
-    updateCheckbox(checkbox, checked);
-    return checkbox;
-};
-
-const updateDownloadCheckbox = function(id, checked) {
-    const checkbox = $('cbPrio' + id);
-    updateCheckbox(checkbox, checked);
-};
-
-const updateCheckbox = function(checkbox, checked) {
-    switch (checked) {
-        case TriState.Checked:
             setCheckboxChecked(checkbox);
-            break;
-        case TriState.Unchecked:
-            setCheckboxUnchecked(checkbox);
-            break;
-        case TriState.Partial:
-            setCheckboxPartial(checkbox);
-            break;
-    }
-}
-
-const isPriorityComboExists = function(id) {
-    return ($('comboPrio' + id) !== null);
-};
-
-const createPriorityOptionElement = function(priority, selected, html) {
-    const elem = new Element('option');
-    elem.set('value', priority.toString());
-    elem.set('html', html);
-    if (selected)
-        elem.setAttribute('selected', '');
-    return elem;
-};
-
-const createPriorityCombo = function(id, fileId, selectedPriority) {
-    const select = new Element('select');
-    select.set('id', 'comboPrio' + id);
-    select.set('data-id', id);
-    select.set('data-file-id', fileId);
-    select.set('disabled', is_seed);
-    select.addClass('combo_priority');
-    select.addEvent('change', fileComboboxChanged);
-
-    createPriorityOptionElement(FilePriority.Ignored, (FilePriority.Ignored === selectedPriority), 'QBT_TR(Do not download)QBT_TR[CONTEXT=PropListDelegate]').injectInside(select);
-    createPriorityOptionElement(FilePriority.Normal, (FilePriority.Normal === selectedPriority), 'QBT_TR(Normal)QBT_TR[CONTEXT=PropListDelegate]').injectInside(select);
-    createPriorityOptionElement(FilePriority.High, (FilePriority.High === selectedPriority), 'QBT_TR(High)QBT_TR[CONTEXT=PropListDelegate]').injectInside(select);
-    createPriorityOptionElement(FilePriority.Maximum, (FilePriority.Maximum === selectedPriority), 'QBT_TR(Maximum)QBT_TR[CONTEXT=PropListDelegate]').injectInside(select);
-
-    // "Mixed" priority is for display only; it shouldn't be selectable
-    const mixedPriorityOption = createPriorityOptionElement(FilePriority.Mixed, (FilePriority.Mixed === selectedPriority), 'QBT_TR(Mixed)QBT_TR[CONTEXT=PropListDelegate]');
-    mixedPriorityOption.set('disabled', true);
-    mixedPriorityOption.injectInside(select);
-
-    return select;
-};
-
-const updatePriorityCombo = function(id, selectedPriority) {
-    const combobox = $('comboPrio' + id);
-
-    if (parseInt(combobox.value) !== selectedPriority)
-        selectComboboxPriority(combobox, selectedPriority);
-
-    if (combobox.disabled !== is_seed)
-        combobox.disabled = is_seed;
-};
-
-const selectComboboxPriority = function(combobox, priority) {
-    const options = combobox.options;
-    for (let i = 0; i < options.length; ++i) {
-        const option = options[i];
-        if (parseInt(option.value) === priority)
-            option.setAttribute('selected', '');
-        else
-            option.removeAttribute('selected');
-    }
-
-    combobox.value = priority;
-};
-
-const switchCheckboxState = function(e) {
-    e.stopPropagation();
-
-    const rowIds = [];
-    const fileIds = [];
-    let priority = FilePriority.Ignored;
-    const checkbox = $('tristate_cb');
-
-    if (checkbox.state === "checked") {
-        setCheckboxUnchecked(checkbox);
-        // set file priority for all checked to Ignored
-        torrentFilesTable.getFilteredAndSortedRows().forEach(function(row) {
-            const rowId = row.rowId;
-            const fileId = row.full_data.fileId;
-            const isChecked = (row.full_data.checked === TriState.Checked);
-            const isFolder = (fileId === -1);
-            if (!isFolder && isChecked) {
-                rowIds.push(rowId);
-                fileIds.push(fileId);
-            }
-        });
-    }
-    else {
-        setCheckboxChecked(checkbox);
-        priority = FilePriority.Normal;
-        // set file priority for all unchecked to Normal
-        torrentFilesTable.getFilteredAndSortedRows().forEach(function(row) {
-            const rowId = row.rowId;
-            const fileId = row.full_data.fileId;
-            const isUnchecked = (row.full_data.checked === TriState.Unchecked);
-            const isFolder = (fileId === -1);
-            if (!isFolder && isUnchecked) {
-                rowIds.push(rowId);
-                fileIds.push(fileId);
-            }
-        });
-    }
-
-    if (rowIds.length > 0)
-        setFilePriority(rowIds, fileIds, priority);
-};
-
-const updateGlobalCheckbox = function() {
-    const checkbox = $('tristate_cb');
-    if (isAllCheckboxesChecked())
-        setCheckboxChecked(checkbox);
-    else if (isAllCheckboxesUnchecked())
-        setCheckboxUnchecked(checkbox);
-    else
-        setCheckboxPartial(checkbox);
-};
-
-const setCheckboxChecked = function(checkbox) {
-    checkbox.state = "checked";
-    checkbox.indeterminate = false;
-    checkbox.checked = true;
-};
-
-const setCheckboxUnchecked = function(checkbox) {
-    checkbox.state = "unchecked";
-    checkbox.indeterminate = false;
-    checkbox.checked = false;
-};
-
-const setCheckboxPartial = function(checkbox) {
-    checkbox.state = "partial";
-    checkbox.indeterminate = true;
-};
-
-const isAllCheckboxesChecked = function() {
-    const checkboxes = $$('input.DownloadedCB');
-    for (let i = 0; i < checkboxes.length; ++i) {
-        if (!checkboxes[i].checked)
-            return false;
-    }
-    return true;
-};
-
-const isAllCheckboxesUnchecked = function() {
-    const checkboxes = $$('input.DownloadedCB');
-    for (let i = 0; i < checkboxes.length; ++i) {
-        if (checkboxes[i].checked)
-            return false;
-    }
-    return true;
-};
-
-const setFilePriority = function(ids, fileIds, priority) {
-    if (current_hash === "") return;
-
-    clearTimeout(loadTorrentFilesDataTimer);
-    new Request({
-        url: 'api/v2/torrents/filePrio',
-        method: 'post',
-        data: {
-            'hash': current_hash,
-            'id': fileIds.join('|'),
-            'priority': priority
-        },
-        onComplete: function() {
-            loadTorrentFilesDataTimer = loadTorrentFilesData.delay(1000);
+            priority = FilePriority.Normal;
+            // set file priority for all unchecked to Normal
+            torrentFilesTable.getFilteredAndSortedRows().forEach(function(row) {
+                const rowId = row.rowId;
+                const fileId = row.full_data.fileId;
+                const isUnchecked = (row.full_data.checked === TriState.Unchecked);
+                const isFolder = (fileId === -1);
+                if (!isFolder && isUnchecked) {
+                    rowIds.push(rowId);
+                    fileIds.push(fileId);
+                }
+            });
         }
-    }).send();
 
-    const ignore = (priority === FilePriority.Ignored);
-    ids.forEach(function(_id) {
-        torrentFilesTable.setIgnored(_id, ignore);
+        if (rowIds.length > 0)
+            setFilePriority(rowIds, fileIds, priority);
+    };
 
-        const combobox = $('comboPrio' + _id);
-        if (combobox !== null)
-            selectComboboxPriority(combobox, priority);
-    });
+    const updateGlobalCheckbox = function() {
+        const checkbox = $('tristate_cb');
+        if (isAllCheckboxesChecked())
+            setCheckboxChecked(checkbox);
+        else if (isAllCheckboxesUnchecked())
+            setCheckboxUnchecked(checkbox);
+        else
+            setCheckboxPartial(checkbox);
+    };
 
-    torrentFilesTable.updateTable(false);
-};
+    const setCheckboxChecked = function(checkbox) {
+        checkbox.state = "checked";
+        checkbox.indeterminate = false;
+        checkbox.checked = true;
+    };
 
-let loadTorrentFilesDataTimer;
-const loadTorrentFilesData = function() {
-    if ($('prop_files').hasClass('invisible')
-        || $('propertiesPanel_collapseToggle').hasClass('panel-expand')) {
-        // Tab changed, don't do anything
-        return;
-    }
-    const new_hash = torrentsTable.getCurrentTorrentHash();
-    if (new_hash === "") {
-        torrentFilesTable.clear();
+    const setCheckboxUnchecked = function(checkbox) {
+        checkbox.state = "unchecked";
+        checkbox.indeterminate = false;
+        checkbox.checked = false;
+    };
+
+    const setCheckboxPartial = function(checkbox) {
+        checkbox.state = "partial";
+        checkbox.indeterminate = true;
+    };
+
+    const isAllCheckboxesChecked = function() {
+        const checkboxes = $$('input.DownloadedCB');
+        for (let i = 0; i < checkboxes.length; ++i) {
+            if (!checkboxes[i].checked)
+                return false;
+        }
+        return true;
+    };
+
+    const isAllCheckboxesUnchecked = function() {
+        const checkboxes = $$('input.DownloadedCB');
+        for (let i = 0; i < checkboxes.length; ++i) {
+            if (checkboxes[i].checked)
+                return false;
+        }
+        return true;
+    };
+
+    const setFilePriority = function(ids, fileIds, priority) {
+        if (current_hash === "") return;
+
         clearTimeout(loadTorrentFilesDataTimer);
-        loadTorrentFilesDataTimer = loadTorrentFilesData.delay(5000);
-        return;
-    }
-    let loadedNewTorrent = false;
-    if (new_hash != current_hash) {
-        torrentFilesTable.clear();
-        current_hash = new_hash;
-        loadedNewTorrent = true;
-    }
-    const url = new URI('api/v2/torrents/files?hash=' + current_hash);
-    new Request.JSON({
-        url: url,
-        noCache: true,
-        method: 'get',
-        onComplete: function() {
+        new Request({
+            url: 'api/v2/torrents/filePrio',
+            method: 'post',
+            data: {
+                'hash': current_hash,
+                'id': fileIds.join('|'),
+                'priority': priority
+            },
+            onComplete: function() {
+                loadTorrentFilesDataTimer = loadTorrentFilesData.delay(1000);
+            }
+        }).send();
+
+        const ignore = (priority === FilePriority.Ignored);
+        ids.forEach(function(_id) {
+            torrentFilesTable.setIgnored(_id, ignore);
+
+            const combobox = $('comboPrio' + _id);
+            if (combobox !== null)
+                selectComboboxPriority(combobox, priority);
+        });
+
+        torrentFilesTable.updateTable(false);
+    };
+
+    let loadTorrentFilesDataTimer;
+    const loadTorrentFilesData = function() {
+        if ($('prop_files').hasClass('invisible')
+            || $('propertiesPanel_collapseToggle').hasClass('panel-expand')) {
+            // Tab changed, don't do anything
+            return;
+        }
+        const new_hash = torrentsTable.getCurrentTorrentHash();
+        if (new_hash === "") {
+            torrentFilesTable.clear();
             clearTimeout(loadTorrentFilesDataTimer);
             loadTorrentFilesDataTimer = loadTorrentFilesData.delay(5000);
-        },
-        onSuccess: function(files) {
-            clearTimeout(torrentFilesFilterInputTimer);
-
-            if (files.length === 0) {
-                torrentFilesTable.clear();
-            }
-            else {
-                handleNewTorrentFiles(files);
-                if (loadedNewTorrent)
-                    collapseAllNodes();
-            }
+            return;
         }
-    }).send();
-};
+        let loadedNewTorrent = false;
+        if (new_hash != current_hash) {
+            torrentFilesTable.clear();
+            current_hash = new_hash;
+            loadedNewTorrent = true;
+        }
+        const url = new URI('api/v2/torrents/files?hash=' + current_hash);
+        new Request.JSON({
+            url: url,
+            noCache: true,
+            method: 'get',
+            onComplete: function() {
+                clearTimeout(loadTorrentFilesDataTimer);
+                loadTorrentFilesDataTimer = loadTorrentFilesData.delay(5000);
+            },
+            onSuccess: function(files) {
+                clearTimeout(torrentFilesFilterInputTimer);
 
-updateTorrentFilesData = function() {
-    clearTimeout(loadTorrentFilesDataTimer);
-    loadTorrentFilesData();
-};
-
-const handleNewTorrentFiles = function(files) {
-    is_seed = (files.length > 0) ? files[0].is_seed : true;
-
-    const rows = files.map(function(file, index) {
-        let progress = (file.progress * 100).round(1);
-        if ((progress === 100) && (file.progress < 1))
-            progress = 99.9;
-
-        const name = escapeHtml(file.name);
-        const ignore = (file.priority === FilePriority.Ignored);
-        const checked = (ignore ? TriState.Unchecked : TriState.Checked);
-        const remaining = (ignore ? 0 : (file.size * (1.0 - file.progress)));
-        const row = {
-            fileId: index,
-            checked: checked,
-            fileName: name,
-            name: fileName(name),
-            size: file.size,
-            progress: progress,
-            priority: normalizePriority(file.priority),
-            remaining: remaining,
-            availability: file.availability
-        };
-
-        return row;
-    });
-
-    addRowsToTable(rows);
-    updateGlobalCheckbox();
-};
-
-const addRowsToTable = function(rows) {
-    const selectedFiles = torrentFilesTable.selectedRowsIds();
-    let rowId = 0;
-
-    const rootNode = new FolderNode();
-
-    rows.forEach(function(row) {
-        let parent = rootNode;
-        const pathFolders = row.fileName.split(PathSeparator);
-        pathFolders.pop();
-        pathFolders.forEach(function(folderName) {
-            if (folderName === '.unwanted')
-                return;
-
-            let parentNode = null;
-            if (parent.children !== null) {
-                for (let i = 0; i < parent.children.length; ++i) {
-                    const childFolder = parent.children[i];
-                    if (childFolder.name === folderName) {
-                        parentNode = childFolder;
-                        break;
-                    }
+                if (files.length === 0) {
+                    torrentFilesTable.clear();
+                }
+                else {
+                    handleNewTorrentFiles(files);
+                    if (loadedNewTorrent)
+                        collapseAllNodes();
                 }
             }
-            if (parentNode === null) {
-                parentNode = new FolderNode();
-                parentNode.name = folderName;
-                parentNode.rowId = rowId;
-                parentNode.root = parent;
-                parent.addChild(parentNode);
+        }).send();
+    };
 
-                ++rowId;
-            }
+    const updateData = function() {
+        clearTimeout(loadTorrentFilesDataTimer);
+        loadTorrentFilesData();
+    };
 
-            parent = parentNode;
+    const handleNewTorrentFiles = function(files) {
+        is_seed = (files.length > 0) ? files[0].is_seed : true;
+
+        const rows = files.map(function(file, index) {
+            let progress = (file.progress * 100).round(1);
+            if ((progress === 100) && (file.progress < 1))
+                progress = 99.9;
+
+            const name = window.qBittorrent.Misc.escapeHtml(file.name);
+            const ignore = (file.priority === FilePriority.Ignored);
+            const checked = (ignore ? TriState.Unchecked : TriState.Checked);
+            const remaining = (ignore ? 0 : (file.size * (1.0 - file.progress)));
+            const row = {
+                fileId: index,
+                checked: checked,
+                fileName: name,
+                name: window.qBittorrent.Filesystem.fileName(name),
+                size: file.size,
+                progress: progress,
+                priority: normalizePriority(file.priority),
+                remaining: remaining,
+                availability: file.availability
+            };
+
+            return row;
         });
 
-        const isChecked = row.checked ? TriState.Checked : TriState.Unchecked;
-        const remaining = (row.priority === FilePriority.Ignored) ? 0 : row.remaining;
-        const childNode = new FileNode();
-        childNode.name = row.name;
-        childNode.rowId = rowId;
-        childNode.size = row.size;
-        childNode.checked = isChecked;
-        childNode.remaining = remaining;
-        childNode.progress = row.progress;
-        childNode.priority = row.priority;
-        childNode.availability = row.availability;
-        childNode.root = parent;
-        childNode.data = row;
-        parent.addChild(childNode);
+        addRowsToTable(rows);
+        updateGlobalCheckbox();
+    };
 
-        ++rowId;
-    }.bind(this));
+    const addRowsToTable = function(rows) {
+        const selectedFiles = torrentFilesTable.selectedRowsIds();
+        let rowId = 0;
 
-    torrentFilesTable.populateTable(rootNode);
-    torrentFilesTable.updateTable(false);
-    torrentFilesTable.altRow();
+        const rootNode = new window.qBittorrent.FileTree.FolderNode();
 
-    if (selectedFiles.length > 0)
-        torrentFilesTable.reselectRows(selectedFiles);
-};
+        rows.forEach(function(row) {
+            let parent = rootNode;
+            const pathFolders = row.fileName.split(window.qBittorrent.Filesystem.PathSeparator);
+            pathFolders.pop();
+            pathFolders.forEach(function(folderName) {
+                if (folderName === '.unwanted')
+                    return;
 
-const collapseIconClicked = function(event) {
-    const id = event.get("data-id");
-    const node = torrentFilesTable.getNode(id);
-    const isCollapsed = (event.parentElement.get("data-collapsed") === "true");
+                let parentNode = null;
+                if (parent.children !== null) {
+                    for (let i = 0; i < parent.children.length; ++i) {
+                        const childFolder = parent.children[i];
+                        if (childFolder.name === folderName) {
+                            parentNode = childFolder;
+                            break;
+                        }
+                    }
+                }
+                if (parentNode === null) {
+                    parentNode = new window.qBittorrent.FileTree.FolderNode();
+                    parentNode.name = folderName;
+                    parentNode.rowId = rowId;
+                    parentNode.root = parent;
+                    parent.addChild(parentNode);
 
-    if (isCollapsed)
-        expandNode(node);
-    else
-        collapseNode(node);
-};
+                    ++rowId;
+                }
 
-const filesPriorityMenuClicked = function(priority) {
-    const selectedRows = torrentFilesTable.selectedRowsIds();
-    if (selectedRows.length === 0) return;
+                parent = parentNode;
+            });
 
-    const rowIds = [];
-    const fileIds = [];
-    selectedRows.forEach(function(rowId) {
-        const elem = $('comboPrio' + rowId);
-        rowIds.push(rowId);
-        fileIds.push(elem.get("data-file-id"));
-    });
+            const isChecked = row.checked ? TriState.Checked : TriState.Unchecked;
+            const remaining = (row.priority === FilePriority.Ignored) ? 0 : row.remaining;
+            const childNode = new window.qBittorrent.FileTree.FileNode();
+            childNode.name = row.name;
+            childNode.rowId = rowId;
+            childNode.size = row.size;
+            childNode.checked = isChecked;
+            childNode.remaining = remaining;
+            childNode.progress = row.progress;
+            childNode.priority = row.priority;
+            childNode.availability = row.availability;
+            childNode.root = parent;
+            childNode.data = row;
+            parent.addChild(childNode);
 
-    const uniqueRowIds = {};
-    const uniqueFileIds = {};
-    for (let i = 0; i < rowIds.length; ++i) {
-        const rows = getAllChildren(rowIds[i], fileIds[i]);
-        rows.rowIds.forEach(function(rowId) {
-            uniqueRowIds[rowId] = true;
-        });
-        rows.fileIds.forEach(function(fileId) {
-            uniqueFileIds[fileId] = true;
-        });
-    }
+            ++rowId;
+        }.bind(this));
 
-    setFilePriority(Object.keys(uniqueRowIds), Object.keys(uniqueFileIds), priority);
-};
+        torrentFilesTable.populateTable(rootNode);
+        torrentFilesTable.updateTable(false);
+        torrentFilesTable.altRow();
 
-const torrentFilesContextMenu = new ContextMenu({
-    targets: '#torrentFilesTableDiv tr',
-    menu: 'torrentFilesMenu',
-    actions: {
+        if (selectedFiles.length > 0)
+            torrentFilesTable.reselectRows(selectedFiles);
+    };
 
-        FilePrioIgnore: function(element, ref) {
-            filesPriorityMenuClicked(FilePriority.Ignored);
-        },
-        FilePrioNormal: function(element, ref) {
-            filesPriorityMenuClicked(FilePriority.Normal);
-        },
-        FilePrioHigh: function(element, ref) {
-            filesPriorityMenuClicked(FilePriority.High);
-        },
-        FilePrioMaximum: function(element, ref) {
-            filesPriorityMenuClicked(FilePriority.Maximum);
-        }
-    },
-    offsets: {
-        x: -15,
-        y: 2
-    },
-    onShow: function() {
-        if (is_seed)
-            this.hideItem('FilePrio');
+    const collapseIconClicked = function(event) {
+        const id = event.get("data-id");
+        const node = torrentFilesTable.getNode(id);
+        const isCollapsed = (event.parentElement.get("data-collapsed") === "true");
+
+        if (isCollapsed)
+            expandNode(node);
         else
-            this.showItem('FilePrio');
-    }
-});
+            collapseNode(node);
+    };
 
-torrentFilesTable.setup('torrentFilesTableDiv', 'torrentFilesTableFixedHeaderDiv', torrentFilesContextMenu);
-// inject checkbox into table header
-const tableHeaders = $$('#torrentFilesTableFixedHeaderDiv .dynamicTableHeader th');
-if (tableHeaders.length > 0) {
-    const checkbox = new Element('input');
-    checkbox.set('type', 'checkbox');
-    checkbox.set('id', 'tristate_cb');
-    checkbox.addEvent('click', switchCheckboxState);
+    const filesPriorityMenuClicked = function(priority) {
+        const selectedRows = torrentFilesTable.selectedRowsIds();
+        if (selectedRows.length === 0) return;
 
-    const checkboxTH = tableHeaders[0];
-    checkbox.injectInside(checkboxTH);
-}
+        const rowIds = [];
+        const fileIds = [];
+        selectedRows.forEach(function(rowId) {
+            const elem = $('comboPrio' + rowId);
+            rowIds.push(rowId);
+            fileIds.push(elem.get("data-file-id"));
+        });
 
-// default sort by name column
-if (torrentFilesTable.getSortedColumn() === null)
-    torrentFilesTable.setSortedColumn('name');
+        const uniqueRowIds = {};
+        const uniqueFileIds = {};
+        for (let i = 0; i < rowIds.length; ++i) {
+            const rows = getAllChildren(rowIds[i], fileIds[i]);
+            rows.rowIds.forEach(function(rowId) {
+                uniqueRowIds[rowId] = true;
+            });
+            rows.fileIds.forEach(function(fileId) {
+                uniqueFileIds[fileId] = true;
+            });
+        }
 
-let prevTorrentFilesFilterValue;
-let torrentFilesFilterInputTimer = null;
-// listen for changes to torrentFilesFilterInput
-$('torrentFilesFilterInput').addEvent('input', function() {
-    const value = $('torrentFilesFilterInput').get("value");
-    if (value !== prevTorrentFilesFilterValue) {
-        prevTorrentFilesFilterValue = value;
-        torrentFilesTable.setFilter(value);
-        clearTimeout(torrentFilesFilterInputTimer);
-        torrentFilesFilterInputTimer = setTimeout(function() {
-            if (current_hash === "") return;
-            torrentFilesTable.updateTable(false);
+        setFilePriority(Object.keys(uniqueRowIds), Object.keys(uniqueFileIds), priority);
+    };
 
-            if (value.trim() === "")
-                collapseAllNodes();
+    const torrentFilesContextMenu = new window.qBittorrent.ContextMenu.ContextMenu({
+        targets: '#torrentFilesTableDiv tr',
+        menu: 'torrentFilesMenu',
+        actions: {
+
+            FilePrioIgnore: function(element, ref) {
+                filesPriorityMenuClicked(FilePriority.Ignored);
+            },
+            FilePrioNormal: function(element, ref) {
+                filesPriorityMenuClicked(FilePriority.Normal);
+            },
+            FilePrioHigh: function(element, ref) {
+                filesPriorityMenuClicked(FilePriority.High);
+            },
+            FilePrioMaximum: function(element, ref) {
+                filesPriorityMenuClicked(FilePriority.Maximum);
+            }
+        },
+        offsets: {
+            x: -15,
+            y: 2
+        },
+        onShow: function() {
+            if (is_seed)
+                this.hideItem('FilePrio');
             else
-                expandAllNodes();
-        }, 400);
+                this.showItem('FilePrio');
+        }
+    });
+
+    torrentFilesTable.setup('torrentFilesTableDiv', 'torrentFilesTableFixedHeaderDiv', torrentFilesContextMenu);
+    // inject checkbox into table header
+    const tableHeaders = $$('#torrentFilesTableFixedHeaderDiv .dynamicTableHeader th');
+    if (tableHeaders.length > 0) {
+        const checkbox = new Element('input');
+        checkbox.set('type', 'checkbox');
+        checkbox.set('id', 'tristate_cb');
+        checkbox.addEvent('click', switchCheckboxState);
+
+        const checkboxTH = tableHeaders[0];
+        checkbox.injectInside(checkboxTH);
     }
-});
 
-/**
- * Show/hide a node's row
- */
-const _hideNode = function(node, shouldHide) {
-    const span = $('filesTablefileName' + node.rowId);
-    // span won't exist if row has been filtered out
-    if (span === null)
-        return;
-    const rowElem = span.parentElement.parentElement;
-    if (shouldHide)
-        rowElem.addClass("invisible");
-    else
-        rowElem.removeClass("invisible");
-}
+    // default sort by name column
+    if (torrentFilesTable.getSortedColumn() === null)
+        torrentFilesTable.setSortedColumn('name');
 
-/**
- * Update a node's collapsed state and icon
- */
-const _updateNodeState = function(node, isCollapsed) {
-    const span = $('filesTablefileName' + node.rowId);
-    // span won't exist if row has been filtered out
-    if (span === null)
-        return;
-    const td = span.parentElement;
-    const rowElem = td.parentElement;
+    let prevTorrentFilesFilterValue;
+    let torrentFilesFilterInputTimer = null;
+    // listen for changes to torrentFilesFilterInput
+    $('torrentFilesFilterInput').addEvent('input', function() {
+        const value = $('torrentFilesFilterInput').get("value");
+        if (value !== prevTorrentFilesFilterValue) {
+            prevTorrentFilesFilterValue = value;
+            torrentFilesTable.setFilter(value);
+            clearTimeout(torrentFilesFilterInputTimer);
+            torrentFilesFilterInputTimer = setTimeout(function() {
+                if (current_hash === "") return;
+                torrentFilesTable.updateTable(false);
 
-    // store collapsed state
-    td.set("data-collapsed", isCollapsed);
-
-    // rotate the collapse icon
-    const collapseIcon = td.getElementsByClassName("filesTableCollapseIcon")[0];
-    if (isCollapsed)
-        collapseIcon.addClass("rotate");
-    else
-        collapseIcon.removeClass("rotate");
-}
-
-const _isCollapsed = function(node) {
-    const span = $('filesTablefileName' + node.rowId);
-    if (span === null)
-        return true;
-
-    const td = span.parentElement;
-    return (td.get("data-collapsed") === "true");
-};
-
-const expandNode = function(node) {
-    _collapseNode(node, false, false, false);
-    torrentFilesTable.altRow();
-};
-
-const collapseNode = function(node) {
-    _collapseNode(node, true, false, false);
-    torrentFilesTable.altRow();
-};
-
-const expandAllNodes = function() {
-    const root = torrentFilesTable.getRoot();
-    root.children.each(function(node) {
-        node.children.each(function(child) {
-            _collapseNode(child, false, true, false);
-        });
+                if (value.trim() === "")
+                    collapseAllNodes();
+                else
+                    expandAllNodes();
+            }, 400);
+        }
     });
-    torrentFilesTable.altRow();
-};
 
-const collapseAllNodes = function() {
-    const root = torrentFilesTable.getRoot();
-    root.children.each(function(node) {
-        node.children.each(function(child) {
-            _collapseNode(child, true, true, false);
+    /**
+     * Show/hide a node's row
+     */
+    const _hideNode = function(node, shouldHide) {
+        const span = $('filesTablefileName' + node.rowId);
+        // span won't exist if row has been filtered out
+        if (span === null)
+            return;
+        const rowElem = span.parentElement.parentElement;
+        if (shouldHide)
+            rowElem.addClass("invisible");
+        else
+            rowElem.removeClass("invisible");
+    }
+
+    /**
+     * Update a node's collapsed state and icon
+     */
+    const _updateNodeState = function(node, isCollapsed) {
+        const span = $('filesTablefileName' + node.rowId);
+        // span won't exist if row has been filtered out
+        if (span === null)
+            return;
+        const td = span.parentElement;
+        const rowElem = td.parentElement;
+
+        // store collapsed state
+        td.set("data-collapsed", isCollapsed);
+
+        // rotate the collapse icon
+        const collapseIcon = td.getElementsByClassName("filesTableCollapseIcon")[0];
+        if (isCollapsed)
+            collapseIcon.addClass("rotate");
+        else
+            collapseIcon.removeClass("rotate");
+    }
+
+    const _isCollapsed = function(node) {
+        const span = $('filesTablefileName' + node.rowId);
+        if (span === null)
+            return true;
+
+        const td = span.parentElement;
+        return (td.get("data-collapsed") === "true");
+    };
+
+    const expandNode = function(node) {
+        _collapseNode(node, false, false, false);
+        torrentFilesTable.altRow();
+    };
+
+    const collapseNode = function(node) {
+        _collapseNode(node, true, false, false);
+        torrentFilesTable.altRow();
+    };
+
+    const expandAllNodes = function() {
+        const root = torrentFilesTable.getRoot();
+        root.children.each(function(node) {
+            node.children.each(function(child) {
+                _collapseNode(child, false, true, false);
+            });
         });
-    });
-    torrentFilesTable.altRow();
-}
+        torrentFilesTable.altRow();
+    };
 
-/**
- * Collapses a folder node with the option to recursively collapse all children
- * @param {FolderNode} node the node to collapse/expand
- * @param {boolean} shouldCollapse true if the node should be collapsed, false if it should be expanded
- * @param {boolean} applyToChildren true if the node's children should also be collapsed, recursively
- * @param {boolean} isChildNode true if the current node is a child of the original node we collapsed/expanded
- */
-const _collapseNode = function(node, shouldCollapse, applyToChildren, isChildNode) {
-    if (!node.isFolder)
-        return;
+    const collapseAllNodes = function() {
+        const root = torrentFilesTable.getRoot();
+        root.children.each(function(node) {
+            node.children.each(function(child) {
+                _collapseNode(child, true, true, false);
+            });
+        });
+        torrentFilesTable.altRow();
+    }
 
-    const shouldExpand = !shouldCollapse;
-    const isNodeCollapsed = _isCollapsed(node);
-    const nodeInCorrectState = ((shouldCollapse && isNodeCollapsed) || (shouldExpand && !isNodeCollapsed));
-    const canSkipNode = (isChildNode && (!applyToChildren || nodeInCorrectState));
-    if (!isChildNode || applyToChildren || !canSkipNode)
-        _updateNodeState(node, shouldCollapse);
-
-    node.children.each(function(child) {
-        _hideNode(child, shouldCollapse);
-
-        if (!child.isFolder)
+    /**
+     * Collapses a folder node with the option to recursively collapse all children
+     * @param {FolderNode} node the node to collapse/expand
+     * @param {boolean} shouldCollapse true if the node should be collapsed, false if it should be expanded
+     * @param {boolean} applyToChildren true if the node's children should also be collapsed, recursively
+     * @param {boolean} isChildNode true if the current node is a child of the original node we collapsed/expanded
+     */
+    const _collapseNode = function(node, shouldCollapse, applyToChildren, isChildNode) {
+        if (!node.isFolder)
             return;
 
-        // don't expand children that have been independently collapsed, unless applyToChildren is true
-        const shouldExpandChildren = (shouldExpand && applyToChildren);
-        const isChildCollapsed = _isCollapsed(child);
-        if (!shouldExpandChildren && isChildCollapsed)
-            return;
+        const shouldExpand = !shouldCollapse;
+        const isNodeCollapsed = _isCollapsed(node);
+        const nodeInCorrectState = ((shouldCollapse && isNodeCollapsed) || (shouldExpand && !isNodeCollapsed));
+        const canSkipNode = (isChildNode && (!applyToChildren || nodeInCorrectState));
+        if (!isChildNode || applyToChildren || !canSkipNode)
+            _updateNodeState(node, shouldCollapse);
 
-        _collapseNode(child, shouldCollapse, applyToChildren, true);
-    });
-};
+        node.children.each(function(child) {
+            _hideNode(child, shouldCollapse);
+
+            if (!child.isFolder)
+                return;
+
+            // don't expand children that have been independently collapsed, unless applyToChildren is true
+            const shouldExpandChildren = (shouldExpand && applyToChildren);
+            const isChildCollapsed = _isCollapsed(child);
+            if (!shouldExpandChildren && isChildCollapsed)
+                return;
+
+            _collapseNode(child, shouldCollapse, applyToChildren, true);
+        });
+    };
+
+    return exports();
+})();

--- a/src/webui/www/private/scripts/prop-general.js
+++ b/src/webui/www/private/scripts/prop-general.js
@@ -28,172 +28,186 @@
 
 'use strict';
 
-const clearData = function() {
-    $('time_elapsed').set('html', '');
-    $('eta').set('html', '');
-    $('nb_connections').set('html', '');
-    $('total_downloaded').set('html', '');
-    $('total_uploaded').set('html', '');
-    $('dl_speed').set('html', '');
-    $('up_speed').set('html', '');
-    $('dl_limit').set('html', '');
-    $('up_limit').set('html', '');
-    $('total_wasted').set('html', '');
-    $('seeds').set('html', '');
-    $('peers').set('html', '');
-    $('share_ratio').set('html', '');
-    $('reannounce').set('html', '');
-    $('last_seen').set('html', '');
-    $('total_size').set('html', '');
-    $('pieces').set('html', '');
-    $('created_by').set('html', '');
-    $('addition_date').set('html', '');
-    $('completion_date').set('html', '');
-    $('creation_date').set('html', '');
-    $('torrent_hash').set('html', '');
-    $('save_path').set('html', '');
-    $('comment').set('html', '');
-};
+if (window.qBittorrent === undefined) {
+    window.qBittorrent = {};
+}
 
-let loadTorrentDataTimer;
-const loadTorrentData = function() {
-    if ($('prop_general').hasClass('invisible')
-        || $('propertiesPanel_collapseToggle').hasClass('panel-expand')) {
-        // Tab changed, don't do anything
-        return;
-    }
-    const current_hash = torrentsTable.getCurrentTorrentHash();
-    if (current_hash === "") {
-        clearData();
-        clearTimeout(loadTorrentDataTimer);
-        loadTorrentDataTimer = loadTorrentData.delay(5000);
-        return;
-    }
-    // Display hash
-    $('torrent_hash').set('html', current_hash);
-    const url = new URI('api/v2/torrents/properties?hash=' + current_hash);
-    new Request.JSON({
-        url: url,
-        noCache: true,
-        method: 'get',
-        onFailure: function() {
-            $('error_div').set('html', 'QBT_TR(qBittorrent client is not reachable)QBT_TR[CONTEXT=HttpServer]');
-            clearTimeout(loadTorrentDataTimer);
-            loadTorrentDataTimer = loadTorrentData.delay(10000);
-        },
-        onSuccess: function(data) {
-            $('error_div').set('html', '');
-            if (data) {
-                let temp;
-                // Update Torrent data
-                if (data.seeding_time > 0)
-                    temp = "QBT_TR(%1 (%2 this session))QBT_TR[CONTEXT=PropertiesWidget]"
-                    .replace("%1", friendlyDuration(data.time_elapsed))
-                    .replace("%2", friendlyDuration(data.seeding_time));
-                else
-                    temp = friendlyDuration(data.time_elapsed);
-                $('time_elapsed').set('html', temp);
+window.qBittorrent.PropGeneral = (function() {
+    const exports = function() {
+        return {
+            updateData: updateData
+        };
+    };
 
-                $('eta').set('html', friendlyDuration(data.eta));
+    const clearData = function() {
+        $('time_elapsed').set('html', '');
+        $('eta').set('html', '');
+        $('nb_connections').set('html', '');
+        $('total_downloaded').set('html', '');
+        $('total_uploaded').set('html', '');
+        $('dl_speed').set('html', '');
+        $('up_speed').set('html', '');
+        $('dl_limit').set('html', '');
+        $('up_limit').set('html', '');
+        $('total_wasted').set('html', '');
+        $('seeds').set('html', '');
+        $('peers').set('html', '');
+        $('share_ratio').set('html', '');
+        $('reannounce').set('html', '');
+        $('last_seen').set('html', '');
+        $('total_size').set('html', '');
+        $('pieces').set('html', '');
+        $('created_by').set('html', '');
+        $('addition_date').set('html', '');
+        $('completion_date').set('html', '');
+        $('creation_date').set('html', '');
+        $('torrent_hash').set('html', '');
+        $('save_path').set('html', '');
+        $('comment').set('html', '');
+    };
 
-                temp = "QBT_TR(%1 (%2 max))QBT_TR[CONTEXT=PropertiesWidget]"
-                    .replace("%1", data.nb_connections)
-                    .replace("%2", data.nb_connections_limit < 0 ? "∞" : data.nb_connections_limit);
-                $('nb_connections').set('html', temp);
-
-                temp = "QBT_TR(%1 (%2 this session))QBT_TR[CONTEXT=PropertiesWidget]"
-                    .replace("%1", friendlyUnit(data.total_downloaded))
-                    .replace("%2", friendlyUnit(data.total_downloaded_session));
-                $('total_downloaded').set('html', temp);
-
-                temp = "QBT_TR(%1 (%2 this session))QBT_TR[CONTEXT=PropertiesWidget]"
-                    .replace("%1", friendlyUnit(data.total_uploaded))
-                    .replace("%2", friendlyUnit(data.total_uploaded_session));
-                $('total_uploaded').set('html', temp);
-
-                temp = "QBT_TR(%1 (%2 avg.))QBT_TR[CONTEXT=PropertiesWidget]"
-                    .replace("%1", friendlyUnit(data.dl_speed, true))
-                    .replace("%2", friendlyUnit(data.dl_speed_avg, true));
-                $('dl_speed').set('html', temp);
-
-                temp = "QBT_TR(%1 (%2 avg.))QBT_TR[CONTEXT=PropertiesWidget]"
-                    .replace("%1", friendlyUnit(data.up_speed, true))
-                    .replace("%2", friendlyUnit(data.up_speed_avg, true));
-                $('up_speed').set('html', temp);
-
-                temp = (data.dl_limit == -1 ? "∞" : friendlyUnit(data.dl_limit, true));
-                $('dl_limit').set('html', temp);
-
-                temp = (data.up_limit == -1 ? "∞" : friendlyUnit(data.up_limit, true));
-                $('up_limit').set('html', temp);
-
-                $('total_wasted').set('html', friendlyUnit(data.total_wasted));
-
-                temp = "QBT_TR(%1 (%2 total))QBT_TR[CONTEXT=PropertiesWidget]"
-                    .replace("%1", data.seeds)
-                    .replace("%2", data.seeds_total);
-                $('seeds').set('html', temp);
-
-                temp = "QBT_TR(%1 (%2 total))QBT_TR[CONTEXT=PropertiesWidget]"
-                    .replace("%1", data.peers)
-                    .replace("%2", data.peers_total);
-                $('peers').set('html', temp);
-
-                $('share_ratio').set('html', data.share_ratio.toFixed(2));
-
-                $('reannounce').set('html', friendlyDuration(data.reannounce));
-
-                if (data.last_seen != -1)
-                    temp = new Date(data.last_seen * 1000).toLocaleString();
-                else
-                    temp = "QBT_TR(Never)QBT_TR[CONTEXT=PropertiesWidget]";
-                $('last_seen').set('html', temp);
-
-                $('total_size').set('html', friendlyUnit(data.total_size));
-
-                if (data.pieces_num != -1)
-                    temp = "QBT_TR(%1 x %2 (have %3))QBT_TR[CONTEXT=PropertiesWidget]"
-                    .replace("%1", data.pieces_num)
-                    .replace("%2", friendlyUnit(data.piece_size))
-                    .replace("%3", data.pieces_have);
-                else
-                    temp = "QBT_TR(Unknown)QBT_TR[CONTEXT=HttpServer]";
-                $('pieces').set('html', temp);
-
-                $('created_by').set('html', escapeHtml(data.created_by));
-                if (data.addition_date != -1)
-                    temp = new Date(data.addition_date * 1000).toLocaleString();
-                else
-                    temp = "QBT_TR(Unknown)QBT_TR[CONTEXT=HttpServer]";
-
-                $('addition_date').set('html', temp);
-                if (data.completion_date != -1)
-                    temp = new Date(data.completion_date * 1000).toLocaleString();
-                else
-                    temp = "";
-
-                $('completion_date').set('html', temp);
-
-                if (data.creation_date != -1)
-                    temp = new Date(data.creation_date * 1000).toLocaleString();
-                else
-                    temp = "QBT_TR(Unknown)QBT_TR[CONTEXT=HttpServer]";
-                $('creation_date').set('html', temp);
-
-                $('save_path').set('html', data.save_path);
-
-                $('comment').set('html', parseHtmlLinks(escapeHtml(data.comment)));
-            }
-            else {
-                clearData();
-            }
+    let loadTorrentDataTimer;
+    const loadTorrentData = function() {
+        if ($('prop_general').hasClass('invisible')
+            || $('propertiesPanel_collapseToggle').hasClass('panel-expand')) {
+            // Tab changed, don't do anything
+            return;
+        }
+        const current_hash = torrentsTable.getCurrentTorrentHash();
+        if (current_hash === "") {
+            clearData();
             clearTimeout(loadTorrentDataTimer);
             loadTorrentDataTimer = loadTorrentData.delay(5000);
+            return;
         }
-    }).send();
-};
+        // Display hash
+        $('torrent_hash').set('html', current_hash);
+        const url = new URI('api/v2/torrents/properties?hash=' + current_hash);
+        new Request.JSON({
+            url: url,
+            noCache: true,
+            method: 'get',
+            onFailure: function() {
+                $('error_div').set('html', 'QBT_TR(qBittorrent client is not reachable)QBT_TR[CONTEXT=HttpServer]');
+                clearTimeout(loadTorrentDataTimer);
+                loadTorrentDataTimer = loadTorrentData.delay(10000);
+            },
+            onSuccess: function(data) {
+                $('error_div').set('html', '');
+                if (data) {
+                    let temp;
+                    // Update Torrent data
+                    if (data.seeding_time > 0)
+                        temp = "QBT_TR(%1 (%2 this session))QBT_TR[CONTEXT=PropertiesWidget]"
+                        .replace("%1", window.qBittorrent.Misc.friendlyDuration(data.time_elapsed))
+                        .replace("%2", window.qBittorrent.Misc.friendlyDuration(data.seeding_time));
+                    else
+                        temp = window.qBittorrent.Misc.friendlyDuration(data.time_elapsed);
+                    $('time_elapsed').set('html', temp);
 
-updateTorrentData = function() {
-    clearTimeout(loadTorrentDataTimer);
-    loadTorrentData();
-};
+                    $('eta').set('html', window.qBittorrent.Misc.friendlyDuration(data.eta));
+
+                    temp = "QBT_TR(%1 (%2 max))QBT_TR[CONTEXT=PropertiesWidget]"
+                        .replace("%1", data.nb_connections)
+                        .replace("%2", data.nb_connections_limit < 0 ? "∞" : data.nb_connections_limit);
+                    $('nb_connections').set('html', temp);
+
+                    temp = "QBT_TR(%1 (%2 this session))QBT_TR[CONTEXT=PropertiesWidget]"
+                        .replace("%1", window.qBittorrent.Misc.friendlyUnit(data.total_downloaded))
+                        .replace("%2", window.qBittorrent.Misc.friendlyUnit(data.total_downloaded_session));
+                    $('total_downloaded').set('html', temp);
+
+                    temp = "QBT_TR(%1 (%2 this session))QBT_TR[CONTEXT=PropertiesWidget]"
+                        .replace("%1", window.qBittorrent.Misc.friendlyUnit(data.total_uploaded))
+                        .replace("%2", window.qBittorrent.Misc.friendlyUnit(data.total_uploaded_session));
+                    $('total_uploaded').set('html', temp);
+
+                    temp = "QBT_TR(%1 (%2 avg.))QBT_TR[CONTEXT=PropertiesWidget]"
+                        .replace("%1", window.qBittorrent.Misc.friendlyUnit(data.dl_speed, true))
+                        .replace("%2", window.qBittorrent.Misc.friendlyUnit(data.dl_speed_avg, true));
+                    $('dl_speed').set('html', temp);
+
+                    temp = "QBT_TR(%1 (%2 avg.))QBT_TR[CONTEXT=PropertiesWidget]"
+                        .replace("%1", window.qBittorrent.Misc.friendlyUnit(data.up_speed, true))
+                        .replace("%2", window.qBittorrent.Misc.friendlyUnit(data.up_speed_avg, true));
+                    $('up_speed').set('html', temp);
+
+                    temp = (data.dl_limit == -1 ? "∞" : window.qBittorrent.Misc.friendlyUnit(data.dl_limit, true));
+                    $('dl_limit').set('html', temp);
+
+                    temp = (data.up_limit == -1 ? "∞" : window.qBittorrent.Misc.friendlyUnit(data.up_limit, true));
+                    $('up_limit').set('html', temp);
+
+                    $('total_wasted').set('html', window.qBittorrent.Misc.friendlyUnit(data.total_wasted));
+
+                    temp = "QBT_TR(%1 (%2 total))QBT_TR[CONTEXT=PropertiesWidget]"
+                        .replace("%1", data.seeds)
+                        .replace("%2", data.seeds_total);
+                    $('seeds').set('html', temp);
+
+                    temp = "QBT_TR(%1 (%2 total))QBT_TR[CONTEXT=PropertiesWidget]"
+                        .replace("%1", data.peers)
+                        .replace("%2", data.peers_total);
+                    $('peers').set('html', temp);
+
+                    $('share_ratio').set('html', data.share_ratio.toFixed(2));
+
+                    $('reannounce').set('html', window.qBittorrent.Misc.friendlyDuration(data.reannounce));
+
+                    if (data.last_seen != -1)
+                        temp = new Date(data.last_seen * 1000).toLocaleString();
+                    else
+                        temp = "QBT_TR(Never)QBT_TR[CONTEXT=PropertiesWidget]";
+                    $('last_seen').set('html', temp);
+
+                    $('total_size').set('html', window.qBittorrent.Misc.friendlyUnit(data.total_size));
+
+                    if (data.pieces_num != -1)
+                        temp = "QBT_TR(%1 x %2 (have %3))QBT_TR[CONTEXT=PropertiesWidget]"
+                        .replace("%1", data.pieces_num)
+                        .replace("%2", window.qBittorrent.Misc.friendlyUnit(data.piece_size))
+                        .replace("%3", data.pieces_have);
+                    else
+                        temp = "QBT_TR(Unknown)QBT_TR[CONTEXT=HttpServer]";
+                    $('pieces').set('html', temp);
+
+                    $('created_by').set('html', window.qBittorrent.Misc.escapeHtml(data.created_by));
+                    if (data.addition_date != -1)
+                        temp = new Date(data.addition_date * 1000).toLocaleString();
+                    else
+                        temp = "QBT_TR(Unknown)QBT_TR[CONTEXT=HttpServer]";
+
+                    $('addition_date').set('html', temp);
+                    if (data.completion_date != -1)
+                        temp = new Date(data.completion_date * 1000).toLocaleString();
+                    else
+                        temp = "";
+
+                    $('completion_date').set('html', temp);
+
+                    if (data.creation_date != -1)
+                        temp = new Date(data.creation_date * 1000).toLocaleString();
+                    else
+                        temp = "QBT_TR(Unknown)QBT_TR[CONTEXT=HttpServer]";
+                    $('creation_date').set('html', temp);
+
+                    $('save_path').set('html', data.save_path);
+
+                    $('comment').set('html', window.qBittorrent.Misc.parseHtmlLinks(window.qBittorrent.Misc.escapeHtml(data.comment)));
+                }
+                else {
+                    clearData();
+                }
+                clearTimeout(loadTorrentDataTimer);
+                loadTorrentDataTimer = loadTorrentData.delay(5000);
+            }
+        }).send();
+    };
+
+    const updateData = function() {
+        clearTimeout(loadTorrentDataTimer);
+        loadTorrentData();
+    };
+
+    return exports();
+})();

--- a/src/webui/www/private/scripts/prop-peers.js
+++ b/src/webui/www/private/scripts/prop-peers.js
@@ -28,144 +28,160 @@
 
 'use strict';
 
-let loadTorrentPeersTimer;
-let syncTorrentPeersLastResponseId = 0;
-let show_flags = true;
-const loadTorrentPeersData = function() {
-    if ($('prop_peers').hasClass('invisible')
-        || $('propertiesPanel_collapseToggle').hasClass('panel-expand')) {
-        syncTorrentPeersLastResponseId = 0;
-        torrentPeersTable.clear();
-        return;
-    }
-    const current_hash = torrentsTable.getCurrentTorrentHash();
-    if (current_hash === "") {
-        syncTorrentPeersLastResponseId = 0;
-        torrentPeersTable.clear();
-        clearTimeout(loadTorrentPeersTimer);
-        loadTorrentPeersTimer = loadTorrentPeersData.delay(getSyncMainDataInterval());
-        return;
-    }
-    const url = new URI('api/v2/sync/torrentPeers');
-    url.setData('rid', syncTorrentPeersLastResponseId);
-    url.setData('hash', current_hash);
-    new Request.JSON({
-        url: url,
-        noCache: true,
-        method: 'get',
-        onComplete: function() {
+if (window.qBittorrent === undefined) {
+    window.qBittorrent = {};
+}
+
+window.qBittorrent.PropPeers = (function() {
+    const exports = function() {
+        return {
+            updateData: updateData
+        }
+    };
+
+    const torrentPeersTable = new window.qBittorrent.DynamicTable.TorrentPeersTable();
+    let loadTorrentPeersTimer;
+    let syncTorrentPeersLastResponseId = 0;
+    let show_flags = true;
+
+    const loadTorrentPeersData = function() {
+        if ($('prop_peers').hasClass('invisible')
+            || $('propertiesPanel_collapseToggle').hasClass('panel-expand')) {
+            syncTorrentPeersLastResponseId = 0;
+            torrentPeersTable.clear();
+            return;
+        }
+        const current_hash = torrentsTable.getCurrentTorrentHash();
+        if (current_hash === "") {
+            syncTorrentPeersLastResponseId = 0;
+            torrentPeersTable.clear();
             clearTimeout(loadTorrentPeersTimer);
             loadTorrentPeersTimer = loadTorrentPeersData.delay(getSyncMainDataInterval());
-        },
-        onSuccess: function(response) {
-            $('error_div').set('html', '');
-            if (response) {
-                const full_update = (response['full_update'] === true);
-                if (full_update)
+            return;
+        }
+        const url = new URI('api/v2/sync/torrentPeers');
+        url.setData('rid', syncTorrentPeersLastResponseId);
+        url.setData('hash', current_hash);
+        new Request.JSON({
+            url: url,
+            noCache: true,
+            method: 'get',
+            onComplete: function() {
+                clearTimeout(loadTorrentPeersTimer);
+                loadTorrentPeersTimer = loadTorrentPeersData.delay(getSyncMainDataInterval());
+            },
+            onSuccess: function(response) {
+                $('error_div').set('html', '');
+                if (response) {
+                    const full_update = (response['full_update'] === true);
+                    if (full_update)
+                        torrentPeersTable.clear();
+                    if (response['rid'])
+                        syncTorrentPeersLastResponseId = response['rid'];
+                    if (response['peers']) {
+                        for (const key in response['peers']) {
+                            response['peers'][key]['rowId'] = key;
+
+                            if (response['peers'][key]['client'])
+                                response['peers'][key]['client'] = window.qBittorrent.Misc.escapeHtml(response['peers'][key]['client']);
+
+                            torrentPeersTable.updateRowData(response['peers'][key]);
+                        }
+                    }
+                    if (response['peers_removed']) {
+                        response['peers_removed'].each(function(hash) {
+                            torrentPeersTable.removeRow(hash);
+                        });
+                    }
+                    torrentPeersTable.updateTable(full_update);
+                    torrentPeersTable.altRow();
+
+                    if (response['show_flags']) {
+                        if (show_flags != response['show_flags']) {
+                            show_flags = response['show_flags'];
+                            torrentPeersTable.columns['country'].force_hide = !show_flags;
+                            torrentPeersTable.updateColumn('country');
+                        }
+                    }
+                }
+                else {
                     torrentPeersTable.clear();
-                if (response['rid'])
-                    syncTorrentPeersLastResponseId = response['rid'];
-                if (response['peers']) {
-                    for (const key in response['peers']) {
-                        response['peers'][key]['rowId'] = key;
-
-                        if (response['peers'][key]['client'])
-                            response['peers'][key]['client'] = escapeHtml(response['peers'][key]['client']);
-
-                        torrentPeersTable.updateRowData(response['peers'][key]);
-                    }
                 }
-                if (response['peers_removed']) {
-                    response['peers_removed'].each(function(hash) {
-                        torrentPeersTable.removeRow(hash);
-                    });
-                }
-                torrentPeersTable.updateTable(full_update);
-                torrentPeersTable.altRow();
+            }
+        }).send();
+    };
 
-                if (response['show_flags']) {
-                    if (show_flags != response['show_flags']) {
-                        show_flags = response['show_flags'];
-                        torrentPeersTable.columns['country'].force_hide = !show_flags;
-                        torrentPeersTable.updateColumn('country');
-                    }
+    const updateData = function() {
+        clearTimeout(loadTorrentPeersTimer);
+        loadTorrentPeersData();
+    };
+
+    const torrentPeersContextMenu = new window.qBittorrent.ContextMenu.ContextMenu({
+        targets: '#torrentPeersTableDiv',
+        menu: 'torrentPeersMenu',
+        actions: {
+            addPeer: function(element, ref) {
+                const hash = torrentsTable.getCurrentTorrentHash();
+                if (!hash)
+                    return;
+
+                new MochaUI.Window({
+                    id: 'addPeersPage',
+                    title: "QBT_TR(Add Peers)QBT_TR[CONTEXT=PeersAdditionDialog]",
+                    loadMethod: 'iframe',
+                    contentURL: 'addpeers.html?hash=' + hash,
+                    scrollbars: false,
+                    resizable: false,
+                    maximizable: false,
+                    paddingVertical: 0,
+                    paddingHorizontal: 0,
+                    width: 350,
+                    height: 240
+                });
+            },
+            banPeer: function(element, ref) {
+                const selectedPeers = torrentPeersTable.selectedRowsIds();
+                if (selectedPeers.length === 0)
+                    return;
+
+                if (confirm('QBT_TR(Are you sure you want to permanently ban the selected peers?)QBT_TR[CONTEXT=PeerListWidget]')) {
+                    new Request({
+                        url: 'api/v2/torrents/banPeers',
+                        noCache: true,
+                        method: 'post',
+                        data: {
+                            hash: torrentsTable.getCurrentTorrentHash(),
+                            peers: selectedPeers.join('|')
+                        }
+                    }).send();
                 }
+            }
+        },
+        offsets: {
+            x: -15,
+            y: 2
+        },
+        onShow: function() {
+            const selectedPeers = torrentPeersTable.selectedRowsIds();
+
+            if (selectedPeers.length >= 1) {
+                this.showItem('copyPeer');
+                this.showItem('banPeer');
             }
             else {
-                torrentPeersTable.clear();
+                this.hideItem('copyPeer');
+                this.hideItem('banPeer');
             }
         }
-    }).send();
-};
+    });
 
-updateTorrentPeersData = function() {
-    clearTimeout(loadTorrentPeersTimer);
-    loadTorrentPeersData();
-};
-
-const torrentPeersContextMenu = new ContextMenu({
-    targets: '#torrentPeersTableDiv',
-    menu: 'torrentPeersMenu',
-    actions: {
-        addPeer: function(element, ref) {
-            const hash = torrentsTable.getCurrentTorrentHash();
-            if (!hash)
-                return;
-
-            new MochaUI.Window({
-                id: 'addPeersPage',
-                title: "QBT_TR(Add Peers)QBT_TR[CONTEXT=PeersAdditionDialog]",
-                loadMethod: 'iframe',
-                contentURL: 'addpeers.html?hash=' + hash,
-                scrollbars: false,
-                resizable: false,
-                maximizable: false,
-                paddingVertical: 0,
-                paddingHorizontal: 0,
-                width: 350,
-                height: 240
-            });
-        },
-        banPeer: function(element, ref) {
-            const selectedPeers = torrentPeersTable.selectedRowsIds();
-            if (selectedPeers.length === 0)
-                return;
-
-            if (confirm('QBT_TR(Are you sure you want to permanently ban the selected peers?)QBT_TR[CONTEXT=PeerListWidget]')) {
-                new Request({
-                    url: 'api/v2/torrents/banPeers',
-                    noCache: true,
-                    method: 'post',
-                    data: {
-                        hash: torrentsTable.getCurrentTorrentHash(),
-                        peers: selectedPeers.join('|')
-                    }
-                }).send();
-            }
+    new ClipboardJS('#CopyPeerInfo', {
+        text: function(trigger) {
+            return torrentPeersTable.selectedRowsIds().join("\n");
         }
-    },
-    offsets: {
-        x: -15,
-        y: 2
-    },
-    onShow: function() {
-        const selectedPeers = torrentPeersTable.selectedRowsIds();
+    });
 
-        if (selectedPeers.length >= 1) {
-            this.showItem('copyPeer');
-            this.showItem('banPeer');
-        }
-        else {
-            this.hideItem('copyPeer');
-            this.hideItem('banPeer');
-        }
-    }
-});
+    torrentPeersTable.setup('torrentPeersTableDiv', 'torrentPeersTableFixedHeaderDiv', torrentPeersContextMenu);
 
-new ClipboardJS('#CopyPeerInfo', {
-    text: function(trigger) {
-        return torrentPeersTable.selectedRowsIds().join("\n");
-    }
-});
-
-torrentPeersTable.setup('torrentPeersTableDiv', 'torrentPeersTableFixedHeaderDiv', torrentPeersContextMenu);
+    return exports();
+})();

--- a/src/webui/www/private/scripts/prop-trackers.js
+++ b/src/webui/www/private/scripts/prop-trackers.js
@@ -28,195 +28,211 @@
 
 'use strict';
 
-this.current_hash = "";
+if (window.qBittorrent === undefined) {
+    window.qBittorrent = {};
+}
 
-let loadTrackersDataTimer;
-const loadTrackersData = function() {
-    if ($('prop_trackers').hasClass('invisible')
-        || $('propertiesPanel_collapseToggle').hasClass('panel-expand')) {
-        // Tab changed, don't do anything
-        return;
-    }
-    const new_hash = torrentsTable.getCurrentTorrentHash();
-    if (new_hash === "") {
-        torrentTrackersTable.clear();
-        clearTimeout(loadTrackersDataTimer);
-        loadTrackersDataTimer = loadTrackersData.delay(10000);
-        return;
-    }
-    if (new_hash != current_hash) {
-        torrentTrackersTable.clear();
-        current_hash = new_hash;
-    }
-    const url = new URI('api/v2/torrents/trackers?hash=' + current_hash);
-    new Request.JSON({
-        url: url,
-        noCache: true,
-        method: 'get',
-        onComplete: function() {
+window.qBittorrent.PropTrackers = (function() {
+    const exports = function() {
+        return {
+            updateData: updateData
+        };
+    };
+
+    let current_hash = "";
+
+    const torrentTrackersTable = new window.qBittorrent.DynamicTable.TorrentTrackersTable();
+    let loadTrackersDataTimer;
+
+    const loadTrackersData = function() {
+        if ($('prop_trackers').hasClass('invisible')
+            || $('propertiesPanel_collapseToggle').hasClass('panel-expand')) {
+            // Tab changed, don't do anything
+            return;
+        }
+        const new_hash = torrentsTable.getCurrentTorrentHash();
+        if (new_hash === "") {
+            torrentTrackersTable.clear();
             clearTimeout(loadTrackersDataTimer);
             loadTrackersDataTimer = loadTrackersData.delay(10000);
-        },
-        onSuccess: function(trackers) {
-            const selectedTrackers = torrentTrackersTable.selectedRowsIds();
+            return;
+        }
+        if (new_hash != current_hash) {
             torrentTrackersTable.clear();
+            current_hash = new_hash;
+        }
+        const url = new URI('api/v2/torrents/trackers?hash=' + current_hash);
+        new Request.JSON({
+            url: url,
+            noCache: true,
+            method: 'get',
+            onComplete: function() {
+                clearTimeout(loadTrackersDataTimer);
+                loadTrackersDataTimer = loadTrackersData.delay(10000);
+            },
+            onSuccess: function(trackers) {
+                const selectedTrackers = torrentTrackersTable.selectedRowsIds();
+                torrentTrackersTable.clear();
 
-            if (trackers) {
-                trackers.each(function(tracker) {
-                    const url = escapeHtml(tracker.url);
-                    let status;
-                    switch (tracker.status) {
-                        case 0:
-                            status = "QBT_TR(Disabled)QBT_TR[CONTEXT=TrackerListWidget]";
-                            break;
-                        case 1:
-                            status = "QBT_TR(Not contacted yet)QBT_TR[CONTEXT=TrackerListWidget]";
-                            break;
-                        case 2:
-                            status = "QBT_TR(Working)QBT_TR[CONTEXT=TrackerListWidget]";
-                            break;
-                        case 3:
-                            status = "QBT_TR(Updating...)QBT_TR[CONTEXT=TrackerListWidget]";
-                            break;
-                        case 4:
-                            status = "QBT_TR(Not working)QBT_TR[CONTEXT=TrackerListWidget]";
-                            break;
-                    }
+                if (trackers) {
+                    trackers.each(function(tracker) {
+                        const url = window.qBittorrent.Misc.escapeHtml(tracker.url);
+                        let status;
+                        switch (tracker.status) {
+                            case 0:
+                                status = "QBT_TR(Disabled)QBT_TR[CONTEXT=TrackerListWidget]";
+                                break;
+                            case 1:
+                                status = "QBT_TR(Not contacted yet)QBT_TR[CONTEXT=TrackerListWidget]";
+                                break;
+                            case 2:
+                                status = "QBT_TR(Working)QBT_TR[CONTEXT=TrackerListWidget]";
+                                break;
+                            case 3:
+                                status = "QBT_TR(Updating...)QBT_TR[CONTEXT=TrackerListWidget]";
+                                break;
+                            case 4:
+                                status = "QBT_TR(Not working)QBT_TR[CONTEXT=TrackerListWidget]";
+                                break;
+                        }
 
-                    const row = {
-                        rowId: url,
-                        tier: tracker.tier,
-                        url: url,
-                        status: status,
-                        peers: tracker.num_peers,
-                        seeds: (tracker.num_seeds >= 0) ? tracker.num_seeds : "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]",
-                        leeches: (tracker.num_leeches >= 0) ? tracker.num_leeches : "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]",
-                        downloaded: (tracker.num_downloaded >= 0) ? tracker.num_downloaded : "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]",
-                        message: escapeHtml(tracker.msg)
-                    };
+                        const row = {
+                            rowId: url,
+                            tier: tracker.tier,
+                            url: url,
+                            status: status,
+                            peers: tracker.num_peers,
+                            seeds: (tracker.num_seeds >= 0) ? tracker.num_seeds : "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]",
+                            leeches: (tracker.num_leeches >= 0) ? tracker.num_leeches : "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]",
+                            downloaded: (tracker.num_downloaded >= 0) ? tracker.num_downloaded : "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]",
+                            message: window.qBittorrent.Misc.escapeHtml(tracker.msg)
+                        };
 
-                    torrentTrackersTable.updateRowData(row);
-                });
+                        torrentTrackersTable.updateRowData(row);
+                    });
 
-                torrentTrackersTable.updateTable(false);
-                torrentTrackersTable.altRow();
+                    torrentTrackersTable.updateTable(false);
+                    torrentTrackersTable.altRow();
 
-                if (selectedTrackers.length > 0)
-                    torrentTrackersTable.reselectRows(selectedTrackers);
+                    if (selectedTrackers.length > 0)
+                        torrentTrackersTable.reselectRows(selectedTrackers);
+                }
+            }
+        }).send();
+    };
+
+    const updateData = function() {
+        clearTimeout(loadTrackersDataTimer);
+        loadTrackersData();
+    };
+
+    const torrentTrackersContextMenu = new window.qBittorrent.ContextMenu.ContextMenu({
+        targets: '#torrentTrackersTableDiv',
+        menu: 'torrentTrackersMenu',
+        actions: {
+            AddTracker: function(element, ref) {
+                addTrackerFN();
+            },
+            EditTracker: function(element, ref) {
+                // only allow editing of one row
+                element.firstChild.click();
+                editTrackerFN(element);
+            },
+            RemoveTracker: function(element, ref) {
+                removeTrackerFN(element);
+            }
+        },
+        offsets: {
+            x: -15,
+            y: 2
+        },
+        onShow: function() {
+            const selectedTrackers = torrentTrackersTable.selectedRowsIds();
+            const containsStaticTracker = selectedTrackers.some(function(tracker) {
+                return (tracker.indexOf("** [") === 0);
+            });
+
+            if (containsStaticTracker || (selectedTrackers.length === 0)) {
+                this.hideItem('EditTracker');
+                this.hideItem('RemoveTracker');
+                this.hideItem('CopyTrackerUrl');
+            }
+            else {
+                this.showItem('EditTracker');
+                this.showItem('RemoveTracker');
+                this.showItem('CopyTrackerUrl');
             }
         }
-    }).send();
-};
+    });
 
-updateTrackersData = function() {
-    clearTimeout(loadTrackersDataTimer);
-    loadTrackersData();
-};
-
-const torrentTrackersContextMenu = new ContextMenu({
-    targets: '#torrentTrackersTableDiv',
-    menu: 'torrentTrackersMenu',
-    actions: {
-        AddTracker: function(element, ref) {
-            addTrackerFN();
-        },
-        EditTracker: function(element, ref) {
-            // only allow editing of one row
-            element.firstChild.click();
-            editTrackerFN(element);
-        },
-        RemoveTracker: function(element, ref) {
-            removeTrackerFN(element);
-        }
-    },
-    offsets: {
-        x: -15,
-        y: 2
-    },
-    onShow: function() {
-        const selectedTrackers = torrentTrackersTable.selectedRowsIds();
-        const containsStaticTracker = selectedTrackers.some(function(tracker) {
-            return (tracker.indexOf("** [") === 0);
+    const addTrackerFN = function() {
+        if (current_hash.length === 0) return;
+        new MochaUI.Window({
+            id: 'trackersPage',
+            title: "QBT_TR(Trackers addition dialog)QBT_TR[CONTEXT=TrackersAdditionDialog]",
+            loadMethod: 'iframe',
+            contentURL: 'addtrackers.html?hash=' + current_hash,
+            scrollbars: true,
+            resizable: false,
+            maximizable: false,
+            closable: true,
+            paddingVertical: 0,
+            paddingHorizontal: 0,
+            width: 500,
+            height: 250,
+            onCloseComplete: function() {
+                updateData();
+            }
         });
+    };
 
-        if (containsStaticTracker || (selectedTrackers.length === 0)) {
-            this.hideItem('EditTracker');
-            this.hideItem('RemoveTracker');
-            this.hideItem('CopyTrackerUrl');
-        }
-        else {
-            this.showItem('EditTracker');
-            this.showItem('RemoveTracker');
-            this.showItem('CopyTrackerUrl');
-        }
-    }
-});
+    const editTrackerFN = function(element) {
+        if (current_hash.length === 0) return;
 
-const addTrackerFN = function() {
-    if (current_hash.length === 0) return;
-    new MochaUI.Window({
-        id: 'trackersPage',
-        title: "QBT_TR(Trackers addition dialog)QBT_TR[CONTEXT=TrackersAdditionDialog]",
-        loadMethod: 'iframe',
-        contentURL: 'addtrackers.html?hash=' + current_hash,
-        scrollbars: true,
-        resizable: false,
-        maximizable: false,
-        closable: true,
-        paddingVertical: 0,
-        paddingHorizontal: 0,
-        width: 500,
-        height: 250,
-        onCloseComplete: function() {
-            updateTrackersData();
-        }
-    });
-};
+        const trackerUrl = encodeURIComponent(element.childNodes[1].innerText);
+        new MochaUI.Window({
+            id: 'trackersPage',
+            title: "QBT_TR(Tracker editing)QBT_TR[CONTEXT=TrackerListWidget]",
+            loadMethod: 'iframe',
+            contentURL: 'edittracker.html?hash=' + current_hash + '&url=' + trackerUrl,
+            scrollbars: true,
+            resizable: false,
+            maximizable: false,
+            closable: true,
+            paddingVertical: 0,
+            paddingHorizontal: 0,
+            width: 500,
+            height: 150,
+            onCloseComplete: function() {
+                updateData();
+            }
+        });
+    };
 
-const editTrackerFN = function(element) {
-    if (current_hash.length === 0) return;
+    const removeTrackerFN = function(element) {
+        if (current_hash.length === 0) return;
 
-    const trackerUrl = encodeURIComponent(element.childNodes[1].innerText);
-    new MochaUI.Window({
-        id: 'trackersPage',
-        title: "QBT_TR(Tracker editing)QBT_TR[CONTEXT=TrackerListWidget]",
-        loadMethod: 'iframe',
-        contentURL: 'edittracker.html?hash=' + current_hash + '&url=' + trackerUrl,
-        scrollbars: true,
-        resizable: false,
-        maximizable: false,
-        closable: true,
-        paddingVertical: 0,
-        paddingHorizontal: 0,
-        width: 500,
-        height: 150,
-        onCloseComplete: function() {
-            updateTrackersData();
+        const selectedTrackers = torrentTrackersTable.selectedRowsIds();
+        new Request({
+            url: 'api/v2/torrents/removeTrackers',
+            method: 'post',
+            data: {
+                hash: current_hash,
+                urls: selectedTrackers.join("|")
+            },
+            onSuccess: function() {
+                updateData();
+            }
+        }).send();
+    };
+
+    new ClipboardJS('#CopyTrackerUrl', {
+        text: function(trigger) {
+            return torrentTrackersTable.selectedRowsIds().join("\n");
         }
     });
-};
 
-const removeTrackerFN = function(element) {
-    if (current_hash.length === 0) return;
+    torrentTrackersTable.setup('torrentTrackersTableDiv', 'torrentTrackersTableFixedHeaderDiv', torrentTrackersContextMenu);
 
-    const selectedTrackers = torrentTrackersTable.selectedRowsIds();
-    new Request({
-        url: 'api/v2/torrents/removeTrackers',
-        method: 'post',
-        data: {
-            hash: current_hash,
-            urls: selectedTrackers.join("|")
-        },
-        onSuccess: function() {
-            updateTrackersData();
-        }
-    }).send();
-};
-
-new ClipboardJS('#CopyTrackerUrl', {
-    text: function(trigger) {
-        return torrentTrackersTable.selectedRowsIds().join("\n");
-    }
-});
-
-torrentTrackersTable.setup('torrentTrackersTableDiv', 'torrentTrackersTableFixedHeaderDiv', torrentTrackersContextMenu);
+    return exports();
+})();

--- a/src/webui/www/private/scripts/prop-webseeds.js
+++ b/src/webui/www/private/scripts/prop-webseeds.js
@@ -28,112 +28,126 @@
 
 'use strict';
 
-const webseedsDynTable = new Class({
+if (window.qBittorrent === undefined) {
+    window.qBittorrent = {};
+}
 
-    initialize: function() {},
+window.qBittorrent.PropWebseeds = (function() {
+    const exports = function() {
+        return {
+            updateData: updateData
+        };
+    };
 
-    setup: function(table) {
-        this.table = $(table);
-        this.rows = new Hash();
-    },
+    const webseedsDynTable = new Class({
 
-    removeRow: function(url) {
-        if (this.rows.has(url)) {
-            const tr = this.rows.get(url);
-            tr.dispose();
-            this.rows.erase(url);
+        initialize: function() {},
+
+        setup: function(table) {
+            this.table = $(table);
+            this.rows = new Hash();
+        },
+
+        removeRow: function(url) {
+            if (this.rows.has(url)) {
+                const tr = this.rows.get(url);
+                tr.dispose();
+                this.rows.erase(url);
+                return true;
+            }
+            return false;
+        },
+
+        removeAllRows: function() {
+            this.rows.each(function(tr, url) {
+                this.removeRow(url);
+            }.bind(this));
+        },
+
+        updateRow: function(tr, row) {
+            const tds = tr.getElements('td');
+            for (let i = 0; i < row.length; ++i) {
+                tds[i].set('html', row[i]);
+            }
             return true;
-        }
-        return false;
-    },
+        },
 
-    removeAllRows: function() {
-        this.rows.each(function(tr, url) {
-            this.removeRow(url);
-        }.bind(this));
-    },
+        insertRow: function(row) {
+            const url = row[0];
+            if (this.rows.has(url)) {
+                const tableRow = this.rows.get(url);
+                this.updateRow(tableRow, row);
+                return;
+            }
+            //this.removeRow(id);
+            const tr = new Element('tr');
+            this.rows.set(url, tr);
+            for (let i = 0; i < row.length; ++i) {
+                const td = new Element('td');
+                td.set('html', row[i]);
+                td.injectInside(tr);
+            }
+            tr.injectInside(this.table);
+        },
+    });
 
-    updateRow: function(tr, row) {
-        const tds = tr.getElements('td');
-        for (let i = 0; i < row.length; ++i) {
-            tds[i].set('html', row[i]);
-        }
-        return true;
-    },
+    let current_hash = "";
 
-    insertRow: function(row) {
-        const url = row[0];
-        if (this.rows.has(url)) {
-            const tableRow = this.rows.get(url);
-            this.updateRow(tableRow, row);
+    let loadWebSeedsDataTimer;
+    const loadWebSeedsData = function() {
+        if ($('prop_webseeds').hasClass('invisible')
+            || $('propertiesPanel_collapseToggle').hasClass('panel-expand')) {
+            // Tab changed, don't do anything
             return;
         }
-        //this.removeRow(id);
-        const tr = new Element('tr');
-        this.rows.set(url, tr);
-        for (let i = 0; i < row.length; ++i) {
-            const td = new Element('td');
-            td.set('html', row[i]);
-            td.injectInside(tr);
-        }
-        tr.injectInside(this.table);
-    },
-});
-
-this.current_hash = "";
-
-let loadWebSeedsDataTimer;
-const loadWebSeedsData = function() {
-    if ($('prop_webseeds').hasClass('invisible')
-        || $('propertiesPanel_collapseToggle').hasClass('panel-expand')) {
-        // Tab changed, don't do anything
-        return;
-    }
-    const new_hash = torrentsTable.getCurrentTorrentHash();
-    if (new_hash === "") {
-        wsTable.removeAllRows();
-        clearTimeout(loadWebSeedsDataTimer);
-        loadWebSeedsDataTimer = loadWebSeedsData.delay(10000);
-        return;
-    }
-    if (new_hash != current_hash) {
-        wsTable.removeAllRows();
-        current_hash = new_hash;
-    }
-    const url = new URI('api/v2/torrents/webseeds?hash=' + current_hash);
-    new Request.JSON({
-        url: url,
-        noCache: true,
-        method: 'get',
-        onFailure: function() {
-            $('error_div').set('html', 'QBT_TR(qBittorrent client is not reachable)QBT_TR[CONTEXT=HttpServer]');
-            clearTimeout(loadWebSeedsDataTimer);
-            loadWebSeedsDataTimer = loadWebSeedsData.delay(20000);
-        },
-        onSuccess: function(webseeds) {
-            $('error_div').set('html', '');
-            if (webseeds) {
-                // Update WebSeeds data
-                webseeds.each(function(webseed) {
-                    const row = [];
-                    row.length = 1;
-                    row[0] = webseed.url;
-                    wsTable.insertRow(row);
-                });
-            }
-            else {
-                wsTable.removeAllRows();
-            }
+        const new_hash = torrentsTable.getCurrentTorrentHash();
+        if (new_hash === "") {
+            wsTable.removeAllRows();
             clearTimeout(loadWebSeedsDataTimer);
             loadWebSeedsDataTimer = loadWebSeedsData.delay(10000);
+            return;
         }
-    }).send();
-};
+        if (new_hash != current_hash) {
+            wsTable.removeAllRows();
+            current_hash = new_hash;
+        }
+        const url = new URI('api/v2/torrents/webseeds?hash=' + current_hash);
+        new Request.JSON({
+            url: url,
+            noCache: true,
+            method: 'get',
+            onFailure: function() {
+                $('error_div').set('html', 'QBT_TR(qBittorrent client is not reachable)QBT_TR[CONTEXT=HttpServer]');
+                clearTimeout(loadWebSeedsDataTimer);
+                loadWebSeedsDataTimer = loadWebSeedsData.delay(20000);
+            },
+            onSuccess: function(webseeds) {
+                $('error_div').set('html', '');
+                if (webseeds) {
+                    // Update WebSeeds data
+                    webseeds.each(function(webseed) {
+                        const row = [];
+                        row.length = 1;
+                        row[0] = webseed.url;
+                        wsTable.insertRow(row);
+                    });
+                }
+                else {
+                    wsTable.removeAllRows();
+                }
+                clearTimeout(loadWebSeedsDataTimer);
+                loadWebSeedsDataTimer = loadWebSeedsData.delay(10000);
+            }
+        }).send();
+    };
 
-updateWebSeedsData = function() {
-    clearTimeout(loadWebSeedsDataTimer);
-    loadWebSeedsData();
-};
+    const updateData = function() {
+        clearTimeout(loadWebSeedsDataTimer);
+        loadWebSeedsData();
+    };
 
-const wsTable = new webseedsDynTable();
-wsTable.setup($('webseedsTable'));
+    const wsTable = new webseedsDynTable();
+    wsTable.setup($('webseedsTable'));
+
+    return exports();
+})();

--- a/src/webui/www/private/setlocation.html
+++ b/src/webui/www/private/setlocation.html
@@ -33,7 +33,7 @@
             const path = new URI().getData('path');
             // set text field to current value
             if (path)
-                $('setLocation').value = escapeHtml(decodeURIComponent(path));
+                $('setLocation').value = window.qBittorrent.Misc.escapeHtml(decodeURIComponent(path));
 
             $('setLocation').focus();
             $('setLocationButton').addEvent('click', function(e) {

--- a/src/webui/www/private/shareratio.html
+++ b/src/webui/www/private/shareratio.html
@@ -37,9 +37,9 @@
             const origValues = new URI().getData('orig').split('|');
 
             const values = {
-                ratioLimit: friendlyFloat(origValues[0], 2),
+                ratioLimit: window.qBittorrent.Misc.friendlyFloat(origValues[0], 2),
                 seedingTimeLimit: parseInt(origValues[1]),
-                maxRatio: friendlyFloat(origValues[2], 2),
+                maxRatio: window.qBittorrent.Misc.friendlyFloat(origValues[2], 2),
                 maxSeedingTime: parseInt(origValues[3])
             };
 

--- a/src/webui/www/private/upload.html
+++ b/src/webui/www/private/upload.html
@@ -23,7 +23,7 @@
                         <label for="autoTMM">QBT_TR(Torrent Management Mode:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
                     </td>
                     <td>
-                        <select id="autoTMM" name="autoTMM" onchange="changeTMM(this)">
+                        <select id="autoTMM" name="autoTMM" onchange="qBittorrent.Download.changeTMM(this)">
                             <option selected value="false">Manual</option>
                             <option value="true">Automatic</option>
                         </select>
@@ -51,7 +51,7 @@
                     </td>
                     <td>
                         <div class="select-watched-folder-editable">
-                            <select id="categorySelect" onchange="changeCategorySelect(this)">
+                            <select id="categorySelect" onchange="qBittorrent.Download.changeCategorySelect(this)">
                                 <option selected value="\other"></option>
                             </select>
                             <input name="category" type="text" value="" />

--- a/src/webui/www/private/views/about.html
+++ b/src/webui/www/private/views/about.html
@@ -681,22 +681,24 @@
 <script>
     'use strict';
 
-    $('qbittorrentVersion').innerText = ("qBittorrent " + qbtVersion()
+    (function() {
+        $('qbittorrentVersion').innerText = ("qBittorrent " + qbtVersion()
         + " QBT_TR(Web UI)QBT_TR[CONTEXT=OptionsDialog]");
 
-    new Request.JSON({
-        url: 'api/v2/app/buildInfo',
-        method: 'get',
-        noCache: true,
-        onSuccess: function(info) {
-            if (!info) return;
+        new Request.JSON({
+            url: 'api/v2/app/buildInfo',
+            method: 'get',
+            noCache: true,
+            onSuccess: function(info) {
+                if (!info) return;
 
-            $('qtVersion').textContent = info.qt;
-            $('libtorrentVersion').textContent = info.libtorrent;
-            $('boostVersion').textContent = info.boost;
-            $('opensslVersion').textContent = info.openssl;
-            $('zlibVersion').textContent = info.zlib;
-            $('qbittorrentVersion').textContent += " (" + info.bitness + "-bit)";
-        }
-    }).send();
+                $('qtVersion').textContent = info.qt;
+                $('libtorrentVersion').textContent = info.libtorrent;
+                $('boostVersion').textContent = info.boost;
+                $('opensslVersion').textContent = info.openssl;
+                $('zlibVersion').textContent = info.zlib;
+                $('qbittorrentVersion').textContent += " (" + info.bitness + "-bit)";
+            }
+        }).send();
+    })();
 </script>

--- a/src/webui/www/private/views/aboutToolbar.html
+++ b/src/webui/www/private/views/aboutToolbar.html
@@ -13,35 +13,37 @@
 <script>
     'use strict';
 
-    MochaUI.initializeTabs('aboutTabs');
+    (function() {
+        MochaUI.initializeTabs('aboutTabs');
 
-    $('aboutAboutLink').addEvent('click', function() {
-        $$('.aboutTabContent').addClass('invisible');
-        $('aboutAboutContent').removeClass('invisible');
-    });
+        $('aboutAboutLink').addEvent('click', function() {
+            $$('.aboutTabContent').addClass('invisible');
+            $('aboutAboutContent').removeClass('invisible');
+        });
 
-    $('aboutAuthorLink').addEvent('click', function() {
-        $$('.aboutTabContent').addClass('invisible');
-        $('aboutAuthorContent').removeClass('invisible');
-    });
+        $('aboutAuthorLink').addEvent('click', function() {
+            $$('.aboutTabContent').addClass('invisible');
+            $('aboutAuthorContent').removeClass('invisible');
+        });
 
-    $('aboutSpecialThanksLink').addEvent('click', function() {
-        $$('.aboutTabContent').addClass('invisible');
-        $('aboutSpecialThanksContent').removeClass('invisible');
-    });
+        $('aboutSpecialThanksLink').addEvent('click', function() {
+            $$('.aboutTabContent').addClass('invisible');
+            $('aboutSpecialThanksContent').removeClass('invisible');
+        });
 
-    $('aboutTranslatorsLink').addEvent('click', function() {
-        $$('.aboutTabContent').addClass('invisible');
-        $('aboutTranslatorsContent').removeClass('invisible');
-    });
+        $('aboutTranslatorsLink').addEvent('click', function() {
+            $$('.aboutTabContent').addClass('invisible');
+            $('aboutTranslatorsContent').removeClass('invisible');
+        });
 
-    $('aboutLicenseLink').addEvent('click', function() {
-        $$('.aboutTabContent').addClass('invisible');
-        $('aboutLicenseContent').removeClass('invisible');
-    });
+        $('aboutLicenseLink').addEvent('click', function() {
+            $$('.aboutTabContent').addClass('invisible');
+            $('aboutLicenseContent').removeClass('invisible');
+        });
 
-    $('aboutLibrariesLink').addEvent('click', function() {
-        $$('.aboutTabContent').addClass('invisible');
-        $('aboutLibrariesContent').removeClass('invisible');
-    });
+        $('aboutLibrariesLink').addEvent('click', function() {
+            $$('.aboutTabContent').addClass('invisible');
+            $('aboutLibrariesContent').removeClass('invisible');
+        });
+    })();
 </script>

--- a/src/webui/www/private/views/filters.html
+++ b/src/webui/www/private/views/filters.html
@@ -32,79 +32,94 @@
 <script>
     'use strict';
 
-    const categoriesFilterContextMenu = new CategoriesFilterContextMenu({
-        targets: '.categoriesFilterContextMenuTarget',
-        menu: 'categoriesFilterMenu',
-        actions: {
-            createCategory: function(element, ref) {
-                createCategoryFN();
+    if (window.qBittorrent === undefined) {
+        window.qBittorrent = {};
+    }
+
+    window.qBittorrent.Filters = (function() {
+        const exports = function() {
+            return {
+                categoriesFilterContextMenu: categoriesFilterContextMenu,
+                tagsFilterContextMenu: tagsFilterContextMenu
+            };
+        };
+
+        const categoriesFilterContextMenu = new window.qBittorrent.ContextMenu.CategoriesFilterContextMenu({
+            targets: '.categoriesFilterContextMenuTarget',
+            menu: 'categoriesFilterMenu',
+            actions: {
+                createCategory: function(element, ref) {
+                    createCategoryFN();
+                },
+                editCategory: function(element, ref) {
+                    editCategoryFN(element.id);
+                },
+                deleteCategory: function(element, ref) {
+                    removeCategoryFN(element.id);
+                },
+                deleteUnusedCategories: function(element, ref) {
+                    deleteUnusedCategoriesFN();
+                },
+                startTorrentsByCategory: function(element, ref) {
+                    startTorrentsByCategoryFN(element.id);
+                },
+                pauseTorrentsByCategory: function(element, ref) {
+                    pauseTorrentsByCategoryFN(element.id);
+                },
+                deleteTorrentsByCategory: function(element, ref) {
+                    deleteTorrentsByCategoryFN(element.id);
+                }
             },
-            editCategory: function(element, ref) {
-                editCategoryFN(element.id);
+            offsets: {
+                x: -15,
+                y: 2
             },
-            deleteCategory: function(element, ref) {
-                removeCategoryFN(element.id);
-            },
-            deleteUnusedCategories: function(element, ref) {
-                deleteUnusedCategoriesFN();
-            },
-            startTorrentsByCategory: function(element, ref) {
-                startTorrentsByCategoryFN(element.id);
-            },
-            pauseTorrentsByCategory: function(element, ref) {
-                pauseTorrentsByCategoryFN(element.id);
-            },
-            deleteTorrentsByCategory: function(element, ref) {
-                deleteTorrentsByCategoryFN(element.id);
+            onShow: function() {
+                this.options.element.firstChild.click();
             }
-        },
-        offsets: {
-            x: -15,
-            y: 2
-        },
-        onShow: function() {
-            this.options.element.firstChild.click();
-        }
-    });
+        });
 
-    const tagsFilterContextMenu = new TagsFilterContextMenu({
-        targets: '.tagsFilterContextMenuTarget',
-        menu: 'tagsFilterMenu',
-        actions: {
-            createTag: function(element, ref) {
-                createTagFN();
+        const tagsFilterContextMenu = new window.qBittorrent.ContextMenu.TagsFilterContextMenu({
+            targets: '.tagsFilterContextMenuTarget',
+            menu: 'tagsFilterMenu',
+            actions: {
+                createTag: function(element, ref) {
+                    createTagFN();
+                },
+                deleteTag: function(element, ref) {
+                    removeTagFN(element.id);
+                },
+                deleteUnusedTags: function(element, ref) {
+                    deleteUnusedTagsFN();
+                },
+                startTorrentsByTag: function(element, ref) {
+                    startTorrentsByTagFN(element.id);
+                },
+                pauseTorrentsByTag: function(element, ref) {
+                    pauseTorrentsByTagFN(element.id);
+                },
+                deleteTorrentsByTag: function(element, ref) {
+                    deleteTorrentsByTagFN(element.id);
+                }
             },
-            deleteTag: function(element, ref) {
-                removeTagFN(element.id);
+            offsets: {
+                x: -15,
+                y: 2
             },
-            deleteUnusedTags: function(element, ref) {
-                deleteUnusedTagsFN();
-            },
-            startTorrentsByTag: function(element, ref) {
-                startTorrentsByTagFN(element.id);
-            },
-            pauseTorrentsByTag: function(element, ref) {
-                pauseTorrentsByTagFN(element.id);
-            },
-            deleteTorrentsByTag: function(element, ref) {
-                deleteTorrentsByTagFN(element.id);
+            onShow: function() {
+                this.options.element.firstChild.click();
             }
-        },
-        offsets: {
-            x: -15,
-            y: 2
-        },
-        onShow: function() {
-            this.options.element.firstChild.click();
-        }
-    });
+        });
 
-    if (LocalPreferences.get('filter_status_collapsed') === "true")
-        toggleFilterDisplay('status');
+        if (LocalPreferences.get('filter_status_collapsed') === "true")
+            toggleFilterDisplay('status');
 
-    if (LocalPreferences.get('filter_category_collapsed') === "true")
-        toggleFilterDisplay('category');
+        if (LocalPreferences.get('filter_category_collapsed') === "true")
+            toggleFilterDisplay('category');
 
-    if (LocalPreferences.get('filter_tag_collapsed') === "true")
-        toggleFilterDisplay('tag');
+        if (LocalPreferences.get('filter_tag_collapsed') === "true")
+            toggleFilterDisplay('tag');
+
+        return exports();
+    })();
 </script>

--- a/src/webui/www/private/views/installsearchplugin.html
+++ b/src/webui/www/private/views/installsearchplugin.html
@@ -20,8 +20,8 @@
     <div>
         <input type="text" id="newPluginPath" placeholder="QBT_TR(URL or local directory)QBT_TR[CONTEXT=PluginSourceDlg]" autocorrect="off" autocapitalize="none" />
         <div style="margin-top: 10px; text-align: center;">
-            <button id="newPluginCancel" onclick="closeSearchWindow('installSearchPlugin');">QBT_TR(Cancel)QBT_TR[CONTEXT=PluginSourceDlg]</button>
-            <button id="newPluginOk" onclick="newPluginOk();">QBT_TR(Ok)QBT_TR[CONTEXT=PluginSourceDlg]</button>
+            <button id="newPluginCancel" onclick="qBittorrent.SearchPlugins.closeSearchWindow('installSearchPlugin');">QBT_TR(Cancel)QBT_TR[CONTEXT=PluginSourceDlg]</button>
+            <button id="newPluginOk" onclick="qBittorrent.InstallSearchPlugin.newPluginOk();">QBT_TR(Ok)QBT_TR[CONTEXT=PluginSourceDlg]</button>
         </div>
     </div>
 </div>
@@ -29,41 +29,55 @@
 <script>
     'use strict';
 
-    this.initInstallSearchPlugin = function() {
-        new Keyboard({
-            defaultEventType: 'keydown',
-            events: {
-                'Enter': function(e) {
-                    // accept enter key as a click
-                    new Event(e).stop();
+    if (window.qBittorrent === undefined) {
+        window.qBittorrent = {};
+    }
 
-                    const elem = e.event.srcElement;
-                    if ((elem.id === "newPluginPath") || (elem.id === "newPluginOk"))
-                        newPluginOk();
-                    else if (elem.id === "newPluginCancel")
-                        closeSearchWindow('installSearchPlugin');
+    window.qBittorrent.InstallSearchPlugin = (function() {
+        const exports = function() {
+            return {
+                newPluginOk: newPluginOk
+            };
+        };
+
+        const init = function() {
+            new Keyboard({
+                defaultEventType: 'keydown',
+                events: {
+                    'Enter': function(e) {
+                        // accept enter key as a click
+                        new Event(e).stop();
+
+                        const elem = e.event.srcElement;
+                        if ((elem.id === "newPluginPath") || (elem.id === "newPluginOk"))
+                            newPluginOk();
+                        else if (elem.id === "newPluginCancel")
+                            window.qBittorrent.SearchPlugins.closeSearchWindow('installSearchPlugin');
+                    }
                 }
-            }
-        }).activate();
+            }).activate();
 
-        $('newPluginPath').select();
-    };
+            $('newPluginPath').select();
+        };
 
-    this.newPluginOk = function() {
-        const path = $("newPluginPath").get("value").trim();
-        if (path)
-            new Request({
-                url: 'api/v2/search/installPlugin',
-                noCache: true,
-                method: 'post',
-                data: {
-                    sources: path,
-                },
-                onRequest: function() {
-                    closeSearchWindow('installSearchPlugin');
-                }
-            }).send();
-    };
+        const newPluginOk = function() {
+            const path = $("newPluginPath").get("value").trim();
+            if (path)
+                new Request({
+                    url: 'api/v2/search/installPlugin',
+                    noCache: true,
+                    method: 'post',
+                    data: {
+                        sources: path,
+                    },
+                    onRequest: function() {
+                        window.qBittorrent.SearchPlugins.closeSearchWindow('installSearchPlugin');
+                    }
+                }).send();
+        };
 
-    initInstallSearchPlugin();
+        init();
+
+        return exports();
+    })();
 </script>

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1465,7 +1465,7 @@
                         $('preallocateall_checkbox').setProperty('checked', pref.preallocate_all);
                         $('appendext_checkbox').setProperty('checked', pref.incomplete_files_ext);
 
-                        // Saving Managmenet
+                        // Saving Management
                         $('default_tmm_combobox').setProperty('value', pref.auto_tmm_enabled);
                         $('torrent_changed_tmm_combobox').setProperty('value', pref.torrent_changed_tmm_enabled);
                         $('save_path_changed_tmm_combobox').setProperty('value', pref.save_path_changed_tmm_enabled);

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -85,7 +85,7 @@
             </tr>
             <tr>
                 <td>
-                    <input type="checkbox" id="temppath_checkbox" onclick="updateTempDirEnabled();" />
+                    <input type="checkbox" id="temppath_checkbox" onclick="qBittorrent.Preferences.updateTempDirEnabled();" />
                     <label for="temppath_checkbox">QBT_TR(Keep incomplete torrents in:)QBT_TR[CONTEXT=OptionsDialog]</label>
                 </td>
                 <td>
@@ -94,7 +94,7 @@
             </tr>
             <tr>
                 <td>
-                    <input type="checkbox" id="exportdir_checkbox" onclick="updateExportDirEnabled();" />
+                    <input type="checkbox" id="exportdir_checkbox" onclick="qBittorrent.Preferences.updateExportDirEnabled();" />
                     <label for="exportdir_checkbox">QBT_TR(Copy .torrent files to:)QBT_TR[CONTEXT=OptionsDialog]</label>
                 </td>
                 <td>
@@ -103,7 +103,7 @@
             </tr>
             <tr>
                 <td>
-                    <input type="checkbox" id="exportdirfin_checkbox" onclick="updateExportDirFinEnabled();" />
+                    <input type="checkbox" id="exportdirfin_checkbox" onclick="qBittorrent.Preferences.updateExportDirFinEnabled();" />
                     <label for="exportdirfin_checkbox">QBT_TR(Copy .torrent files for finished downloads to:)QBT_TR[CONTEXT=OptionsDialog]</label>
                 </td>
                 <td>
@@ -128,13 +128,13 @@
                     <td style="padding-top:4px;"><input type="text" id="new_watch_folder_txt" autocorrect="off" autocapitalize="none" /></td>
                     <td style="padding-top:4px;">
                         <div class="select-watched-folder-editable">
-                            <select id="new_watch_folder_select" onchange="changeWatchFolderSelect(this)">
+                            <select id="new_watch_folder_select" onchange="qBittorrent.Preferences.changeWatchFolderSelect(this)">
                                 <option selected value="watch_folder">QBT_TR(Monitored folder)QBT_TR[CONTEXT=ScanFoldersModel]</option>
                                 <option value="default_folder">QBT_TR(Default save location)QBT_TR[CONTEXT=ScanFoldersModel]</option>
                                 <option value="other">QBT_TR(Other...)QBT_TR[CONTEXT=HttpServer]</option>
                             </select>
                             <input id="new_watch_folder_other_txt" type="text" value="QBT_TR(Monitored folder)QBT_TR[CONTEXT=ScanFoldersModel]" hidden />
-                            <img src="images/qbt-theme/list-add.svg" alt="Add" style="padding-left:170px;width:16px;cursor:pointer;" onclick="addWatchFolder();" />
+                            <img src="images/qbt-theme/list-add.svg" alt="Add" style="padding-left:170px;width:16px;cursor:pointer;" onclick="qBittorrent.Preferences.addWatchFolder();" />
                         </div>
                     </td>
                 </tr>
@@ -144,7 +144,7 @@
 
     <fieldset class="settings">
         <legend>
-            <input type="checkbox" id="mail_notification_checkbox" onclick="updateMailNotification();" />
+            <input type="checkbox" id="mail_notification_checkbox" onclick="qBittorrent.Preferences.updateMailNotification();" />
             <label for="mail_notification_checkbox">QBT_TR(Email notification upon download completion)QBT_TR[CONTEXT=OptionsDialog]</label>
         </legend>
         <table>
@@ -178,7 +178,7 @@
         </div>
         <fieldset class="settings">
             <legend>
-                <input type="checkbox" id="mail_auth_checkbox" onclick="updateMailAuthSettings();" />
+                <input type="checkbox" id="mail_auth_checkbox" onclick="qBittorrent.Preferences.updateMailAuthSettings();" />
                 <label for="mail_auth_checkbox">QBT_TR(Authentication)QBT_TR[CONTEXT=OptionsDialog]</label>
             </legend>
             <table>
@@ -204,7 +204,7 @@
 
     <fieldset class="settings">
         <legend>
-            <input type="checkbox" id="autorun_checkbox" onclick="updateAutoRun();" />
+            <input type="checkbox" id="autorun_checkbox" onclick="qBittorrent.Preferences.updateAutoRun();" />
             <label for="autorun_checkbox">QBT_TR(Run external program on torrent completion)QBT_TR[CONTEXT=OptionsDialog]</label>
         </legend>
         <div class="formRow">
@@ -242,14 +242,14 @@
         <div class="formRow">
             <label for="port_value">QBT_TR(Port used for incoming connections:)QBT_TR[CONTEXT=OptionsDialog]</label>
             <input type="text" id="port_value" style="width: 4em;" />
-            <button style="margin-left: 1em;" onclick="generateRandomPort();">Random</button>
+            <button style="margin-left: 1em;" onclick="qBittorrent.Preferences.generateRandomPort();">Random</button>
         </div>
         <div class="formRow">
             <input type="checkbox" id="upnp_checkbox" />
             <label for="upnp_checkbox">QBT_TR(Use UPnP / NAT-PMP port forwarding from my router)QBT_TR[CONTEXT=OptionsDialog]</label>
         </div>
         <div class="formRow">
-            <input type="checkbox" id="random_port_checkbox" onclick="updatePortValueEnabled();" />
+            <input type="checkbox" id="random_port_checkbox" onclick="qBittorrent.Preferences.updatePortValueEnabled();" />
             <label for="random_port_checkbox">QBT_TR(Use different port on each startup)QBT_TR[CONTEXT=OptionsDialog]</label>
         </div>
     </fieldset>
@@ -259,28 +259,28 @@
         <table>
             <tr>
                 <td>
-                    <input type="checkbox" id="max_connec_checkbox" onclick="updateMaxConnecEnabled();" />
+                    <input type="checkbox" id="max_connec_checkbox" onclick="qBittorrent.Preferences.updateMaxConnecEnabled();" />
                     <label for="max_connec_checkbox">QBT_TR(Global maximum number of connections:)QBT_TR[CONTEXT=OptionsDialog]</label>
                 </td>
                 <td><input type="text" id="max_connec_value" style="width: 4em;" /></td>
             </tr>
             <tr>
                 <td>
-                    <input type="checkbox" id="max_connec_per_torrent_checkbox" onclick="updateMaxConnecPerTorrentEnabled();" />
+                    <input type="checkbox" id="max_connec_per_torrent_checkbox" onclick="qBittorrent.Preferences.updateMaxConnecPerTorrentEnabled();" />
                     <label for="max_connec_per_torrent_checkbox">QBT_TR(Maximum number of connections per torrent:)QBT_TR[CONTEXT=OptionsDialog]</label>
                 </td>
                 <td><input type="text" id="max_connec_per_torrent_value" style="width: 4em;" /></td>
             </tr>
             <tr>
                 <td>
-                    <input type="checkbox" id="max_uploads_checkbox" onclick="updateMaxUploadsEnabled();" />
+                    <input type="checkbox" id="max_uploads_checkbox" onclick="qBittorrent.Preferences.updateMaxUploadsEnabled();" />
                     <label for="max_uploads_checkbox">QBT_TR(Global maximum number of upload slots:)QBT_TR[CONTEXT=OptionsDialog]</label>
                 </td>
                 <td><input type="text" id="max_uploads_value" style="width: 4em;" /></td>
             </tr>
             <tr>
                 <td>
-                    <input type="checkbox" id="max_uploads_per_torrent_checkbox" onclick="updateMaxUploadsPerTorrentEnabled();" />
+                    <input type="checkbox" id="max_uploads_per_torrent_checkbox" onclick="qBittorrent.Preferences.updateMaxUploadsPerTorrentEnabled();" />
                     <label for="max_uploads_per_torrent_checkbox">QBT_TR(Maximum number of upload slots per torrent:)QBT_TR[CONTEXT=OptionsDialog]</label>
                 </td>
                 <td><input type="text" id="max_uploads_per_torrent_value" style="width: 4em;" /></td>
@@ -296,7 +296,7 @@
                     <label for="peer_proxy_type_select">QBT_TR(Type:)QBT_TR[CONTEXT=OptionsDialog]</label>
                 </td>
                 <td>
-                    <select id="peer_proxy_type_select" onchange="updatePeerProxySettings();">
+                    <select id="peer_proxy_type_select" onchange="qBittorrent.Preferences.updatePeerProxySettings();">
                         <option value="none">QBT_TR((None))QBT_TR[CONTEXT=OptionsDialog]</option>
                         <option value="socks4">QBT_TR(SOCKS4)QBT_TR[CONTEXT=OptionsDialog]</option>
                         <option value="socks5">QBT_TR(SOCKS5)QBT_TR[CONTEXT=OptionsDialog]</option>
@@ -327,7 +327,7 @@
         </div>
         <fieldset class="settings">
             <legend>
-                <input type="checkbox" id="peer_proxy_auth_checkbox" onclick="updatePeerProxyAuthSettings();" />
+                <input type="checkbox" id="peer_proxy_auth_checkbox" onclick="qBittorrent.Preferences.updatePeerProxyAuthSettings();" />
                 <label for="peer_proxy_auth_checkbox">QBT_TR(Authentication)QBT_TR[CONTEXT=OptionsDialog]</label>
             </legend>
             <table>
@@ -356,7 +356,7 @@
 
     <fieldset class="settings">
         <legend>
-            <input type="checkbox" id="ipfilter_enabled_checkbox" onclick="updateFilterSettings();" />
+            <input type="checkbox" id="ipfilter_enabled_checkbox" onclick="qBittorrent.Preferences.updateFilterSettings();" />
             <label for="ipfilter_enabled_checkbox">QBT_TR(IP Filtering)QBT_TR[CONTEXT=OptionsDialog]</label>
         </legend>
         <div class="formRow">
@@ -414,7 +414,7 @@
 
         <fieldset class="settings">
             <legend>
-                <input type="checkbox" id="limit_sheduling_checkbox" onclick="updateSchedulingEnabled();" />
+                <input type="checkbox" id="limit_sheduling_checkbox" onclick="qBittorrent.Preferences.updateSchedulingEnabled();" />
                 <label for="limit_sheduling_checkbox">QBT_TR(Schedule the use of alternative rate limits)QBT_TR[CONTEXT=OptionsDialog]</label>
             </legend>
             <div class="formRow">
@@ -488,7 +488,7 @@
 
     <fieldset class="settings">
         <legend>
-            <input type="checkbox" id="queueing_checkbox" onclick="updateQueueingSystem();" />
+            <input type="checkbox" id="queueing_checkbox" onclick="qBittorrent.Preferences.updateQueueingSystem();" />
             <label for="queueing_checkbox">QBT_TR(Torrent Queueing)QBT_TR[CONTEXT=OptionsDialog]</label>
         </legend>
         <table>
@@ -519,7 +519,7 @@
         </table>
         <fieldset class="settings">
             <legend>
-                <input type="checkbox" id="dont_count_slow_torrents_checkbox" onclick="updateSlowTorrentsSettings();" />
+                <input type="checkbox" id="dont_count_slow_torrents_checkbox" onclick="qBittorrent.Preferences.updateSlowTorrentsSettings();" />
                 <label for="dont_count_slow_torrents_checkbox">QBT_TR(Do not count slow torrents in these limits)QBT_TR[CONTEXT=OptionsDialog]</label>
             </legend>
             <table>
@@ -556,7 +556,7 @@
         <table>
             <tr>
                 <td>
-                    <input type="checkbox" id="max_ratio_checkbox" onclick="updateMaxRatioTimeEnabled();" />
+                    <input type="checkbox" id="max_ratio_checkbox" onclick="qBittorrent.Preferences.updateMaxRatioTimeEnabled();" />
                     <label for="max_ratio_checkbox">QBT_TR(Seed torrents until their ratio reaches)QBT_TR[CONTEXT=OptionsDialog]</label>
                 </td>
                 <td>
@@ -564,7 +564,7 @@
                 </td>
                 <tr>
                     <td>
-                        <input type="checkbox" id="max_seeding_time_checkbox" onclick="updateMaxRatioTimeEnabled();" />
+                        <input type="checkbox" id="max_seeding_time_checkbox" onclick="qBittorrent.Preferences.updateMaxRatioTimeEnabled();" />
                         <label for="max_seeding_time_checkbox">QBT_TR(Seed torrents until their seeding time reaches)QBT_TR[CONTEXT=OptionsDialog]</label>
                     </td>
                     <td>
@@ -588,7 +588,7 @@
 
     <fieldset class="settings">
         <legend>
-            <input type="checkbox" id="add_trackers_checkbox" onclick="updateAddTrackersEnabled();" />
+            <input type="checkbox" id="add_trackers_checkbox" onclick="qBittorrent.Preferences.updateAddTrackersEnabled();" />
             <label for="add_trackers_checkbox">QBT_TR(Automatically add these trackers to new downloads:)QBT_TR[CONTEXT=OptionsDialog]</label>
         </legend>
         <textarea id="add_trackers_textarea" rows="5" cols="70"></textarea>
@@ -673,7 +673,7 @@
         </div>
         <fieldset class="settings">
             <legend>
-                <input type="checkbox" id="use_https_checkbox" onclick="updateHttpsSettings();" />
+                <input type="checkbox" id="use_https_checkbox" onclick="qBittorrent.Preferences.updateHttpsSettings();" />
                 <label for="use_https_checkbox">QBT_TR(Use HTTPS instead of HTTP)QBT_TR[CONTEXT=OptionsDialog]</label>
             </legend>
             <table>
@@ -722,7 +722,7 @@
                 <label for="bypass_local_auth_checkbox">QBT_TR(Bypass authentication for clients on localhost)QBT_TR[CONTEXT=OptionsDialog]</label>
             </div>
             <div class="formRow">
-                <input type="checkbox" id="bypass_auth_subnet_whitelist_checkbox" onclick="updateBypasssAuthSettings();" />
+                <input type="checkbox" id="bypass_auth_subnet_whitelist_checkbox" onclick="qBittorrent.Preferences.updateBypasssAuthSettings();" />
                 <label for="bypass_auth_subnet_whitelist_checkbox">QBT_TR(Bypass authentication for clients in whitelisted IP subnets)QBT_TR[CONTEXT=OptionsDialog]</label>
             </div>
             <div class="formRow" style="padding-left: 30px; padding-top: 5px;">
@@ -737,7 +737,7 @@
         </fieldset>
 
         <fieldset class="settings">
-            <legend><input type="checkbox" id="use_alt_webui_checkbox" onclick="updateAlternativeWebUISettings();" />
+            <legend><input type="checkbox" id="use_alt_webui_checkbox" onclick="qBittorrent.Preferences.updateAlternativeWebUISettings();" />
                 <label for="use_alt_webui_checkbox">QBT_TR(Use alternative Web UI)QBT_TR[CONTEXT=OptionsDialog]</label></legend>
             <div class="formRow">
                 <label for="webui_files_location_textarea">QBT_TR(Files location:)QBT_TR[CONTEXT=OptionsDialog]</label>
@@ -758,7 +758,7 @@
 
             <fieldset class="settings">
                 <legend>
-                    <input type="checkbox" id="host_header_validation_checkbox" onclick="updateHostHeaderValidationSettings();" />
+                    <input type="checkbox" id="host_header_validation_checkbox" onclick="qBittorrent.Preferences.updateHostHeaderValidationSettings();" />
                     <label for="host_header_validation_checkbox">QBT_TR(Enable Host header validation)QBT_TR[CONTEXT=OptionsDialog]</label>
                 </legend>
                 <table>
@@ -777,14 +777,14 @@
 
     <fieldset class="settings">
         <legend>
-            <input type="checkbox" id="use_dyndns_checkbox" onclick="updateDynDnsSettings();" />
+            <input type="checkbox" id="use_dyndns_checkbox" onclick="qBittorrent.Preferences.updateDynDnsSettings();" />
             <label for="use_dyndns_checkbox">QBT_TR(Update my dynamic domain name)QBT_TR[CONTEXT=OptionsDialog]</label>
         </legend>
         <select id="dyndns_select">
             <option value="0">DynDNS</option>
             <option value="1">NO-IP</option>
         </select>
-        <input type="button" value="QBT_TR(Register)QBT_TR[CONTEXT=OptionsDialog]" onclick="registerDynDns();" />
+        <input type="button" value="QBT_TR(Register)QBT_TR[CONTEXT=OptionsDialog]" onclick="qBittorrent.Preferences.registerDynDns();" />
         <table style="margin-top: 10px;">
             <tr>
                 <td>
@@ -1079,1019 +1079,1062 @@
     </fieldset>
 </div>
 
-<div style="text-align: center; margin-top: 1em;"><input type="button" value="QBT_TR(Save)QBT_TR[CONTEXT=HttpServer]" onclick="applyPreferences();" /></div>
+<div style="text-align: center; margin-top: 1em;"><input type="button" value="QBT_TR(Save)QBT_TR[CONTEXT=HttpServer]" onclick="qBittorrent.Preferences.applyPreferences();" /></div>
 
 <script>
     'use strict';
 
-    // Downloads tab
-    this.WatchedFoldersTable = new HtmlTable($("watched_folders_tab"));
-
-    this.updateTempDirEnabled = function() {
-        const isTempDirEnabled = $('temppath_checkbox').getProperty('checked');
-        $('temppath_text').setProperty('disabled', !isTempDirEnabled);
-    };
-
-    this.addWatchFolder = function() {
-        const new_folder = $('new_watch_folder_txt').getProperty('value').trim();
-        if (new_folder.length <= 0) return;
-
-        const new_other = $('new_watch_folder_other_txt').getProperty('value').trim();
-        if (new_other.length <= 0) return;
-
-        const new_select = $('new_watch_folder_select').getProperty('value').trim();
-
-        const i = $('watched_folders_tab').getChildren('tbody')[0].getChildren('tr').length;
-        pushWatchFolder(i, new_folder, new_select, new_other);
-
-        // Clear fields
-        $('new_watch_folder_txt').setProperty('value', '');
-        const elt = $('new_watch_folder_select');
-        elt.setProperty('value', 'watch_folder');
-        const text = elt.options[elt.selectedIndex].innerHTML;
-        $('new_watch_folder_other_txt').setProperty('value', text);
-    };
-
-    this.changeWatchFolderSelect = function(item) {
-        if (item.value == "other") {
-            item.nextElementSibling.hidden = false;
-            item.nextElementSibling.value = 'QBT_TR(Type folder here)QBT_TR[CONTEXT=HttpServer]';
-            item.nextElementSibling.select();
-        }
-        else {
-            item.nextElementSibling.hidden = true;
-            const text = item.options[item.selectedIndex].innerHTML;
-            item.nextElementSibling.value = text;
-        }
-    };
-
-    this.pushWatchFolder = function(pos, folder, sel, other) {
-        const myinput = "<input id='text_watch_" + pos + "' type='text' value='" + folder + "'>";
-        const disableInput = (sel != "other");
-        const mycb = "<div class='select-watched-folder-editable'>"
-            + "<select id ='cb_watch_" + pos + "' onchange='changeWatchFolderSelect(this)'>"
-            + "<option value='watch_folder'>QBT_TR(Monitored folder)QBT_TR[CONTEXT=ScanFoldersModel]</option>"
-            + "<option value='default_folder'>QBT_TR(Default save location)QBT_TR[CONTEXT=ScanFoldersModel]</option>"
-            + "<option value='other'>QBT_TR(Other...)QBT_TR[CONTEXT=HttpServer]</option>"
-            + "</select>"
-            + "<input id='cb_watch_txt_" + pos + "' type='text' " + (disableInput ? "hidden " : "") + "/></div>";
-
-        WatchedFoldersTable.push([myinput, mycb]);
-        $('cb_watch_' + pos).setProperty('value', sel);
-        if (disableInput) {
-            const elt = $('cb_watch_' + pos);
-            other = elt.options[elt.selectedIndex].innerHTML;
-        }
-        $('cb_watch_txt_' + pos).setProperty('value', other);
-    };
-
-    this.getWatchedFolders = function() {
-        const nb_folders = $("watched_folders_tab").getChildren("tbody")[0].getChildren("tr").length;
-        const folders = new Hash();
-        for (let i = 0; i < nb_folders; ++i) {
-            const fpath = $('text_watch_' + i).getProperty('value').trim();
-            if (fpath.length > 0) {
-                let other;
-                const sel = $('cb_watch_' + i).getProperty('value').trim();
-                if (sel == "other") {
-                    other = $('cb_watch_txt_' + i).getProperty('value').trim();
-                }
-                else {
-                    other = (sel == "watch_folder") ? 0 : 1;
-                }
-                folders.set(fpath, other);
-            }
-        }
-        return folders;
-    };
-
-    this.updateExportDirEnabled = function() {
-        const isExportDirEnabled = $('exportdir_checkbox').getProperty('checked');
-        $('exportdir_text').setProperty('disabled', !isExportDirEnabled);
-    };
-
-    this.updateExportDirFinEnabled = function() {
-        const isExportDirFinEnabled = $('exportdirfin_checkbox').getProperty('checked');
-        $('exportdirfin_text').setProperty('disabled', !isExportDirFinEnabled);
-    };
-
-    this.updateMailNotification = function() {
-        const isMailNotificationEnabled = $('mail_notification_checkbox').getProperty('checked');
-        $('src_email_txt').setProperty('disabled', !isMailNotificationEnabled);
-        $('dest_email_txt').setProperty('disabled', !isMailNotificationEnabled);
-        $('smtp_server_txt').setProperty('disabled', !isMailNotificationEnabled);
-        $('mail_ssl_checkbox').setProperty('disabled', !isMailNotificationEnabled);
-        $('mail_auth_checkbox').setProperty('disabled', !isMailNotificationEnabled);
-
-        if (!isMailNotificationEnabled) {
-            $('mail_auth_checkbox').setProperty('checked', !isMailNotificationEnabled);
-            updateMailAuthSettings();
-        }
-    };
-
-    this.updateMailAuthSettings = function() {
-        const isMailAuthEnabled = $('mail_auth_checkbox').getProperty('checked');
-        $('mail_username_text').setProperty('disabled', !isMailAuthEnabled);
-        $('mail_password_text').setProperty('disabled', !isMailAuthEnabled);
-    };
-
-    this.updateAutoRun = function() {
-        const isAutoRunEnabled = $('autorun_checkbox').getProperty('checked');
-        $('autorunProg_txt').setProperty('disabled', !isAutoRunEnabled);
-    };
-
-    // Connection tab
-    this.updatePortValueEnabled = function() {
-        const checked = $('random_port_checkbox').getProperty('checked');
-        $('port_value').setProperty('disabled', checked);
-    };
-
-    this.updateMaxConnecEnabled = function() {
-        const isMaxConnecEnabled = $('max_connec_checkbox').getProperty('checked');
-        $('max_connec_value').setProperty('disabled', !isMaxConnecEnabled);
-    };
-
-    this.updateMaxConnecPerTorrentEnabled = function() {
-        const isMaxConnecPerTorrentEnabled = $('max_connec_per_torrent_checkbox').getProperty('checked');
-        $('max_connec_per_torrent_value').setProperty('disabled', !isMaxConnecPerTorrentEnabled);
-    };
-
-    this.updateMaxUploadsEnabled = function() {
-        const isMaxUploadsEnabled = $('max_uploads_checkbox').getProperty('checked');
-        $('max_uploads_value').setProperty('disabled', !isMaxUploadsEnabled);
-    };
-
-    this.updateMaxUploadsPerTorrentEnabled = function() {
-        const isMaxUploadsPerTorrentEnabled = $('max_uploads_per_torrent_checkbox').getProperty('checked');
-        $('max_uploads_per_torrent_value').setProperty('disabled', !isMaxUploadsPerTorrentEnabled);
-    };
-
-    this.updatePeerProxySettings = function() {
-        const isPeerProxyTypeSelected = $('peer_proxy_type_select').getProperty('value') != "none";
-        $('peer_proxy_host_text').setProperty('disabled', !isPeerProxyTypeSelected);
-        $('peer_proxy_port_value').setProperty('disabled', !isPeerProxyTypeSelected);
-        $('use_peer_proxy_checkbox').setProperty('disabled', !isPeerProxyTypeSelected);
-        $('proxy_only_for_torrents_checkbox').setProperty('disabled', !isPeerProxyTypeSelected);
-
-        if (isPeerProxyTypeSelected) {
-            const isPeerProxyTypeSocks5 = $('peer_proxy_type_select').getProperty('value') == "socks5";
-            $('peer_proxy_auth_checkbox').setProperty('disabled', !isPeerProxyTypeSocks5);
-
-            if (!isPeerProxyTypeSocks5) {
-                $('peer_proxy_auth_checkbox').setProperty('checked', isPeerProxyTypeSocks5);
-                updatePeerProxyAuthSettings();
-            }
-        }
-        else {
-            $('peer_proxy_auth_checkbox').setProperty('disabled', !isPeerProxyTypeSelected);
-            $('peer_proxy_auth_checkbox').setProperty('checked', isPeerProxyTypeSelected);
-            updatePeerProxyAuthSettings();
-        }
-    };
-
-    this.updatePeerProxyAuthSettings = function() {
-        const isPeerProxyAuthEnabled = $('peer_proxy_auth_checkbox').getProperty('checked');
-        $('peer_proxy_username_text').setProperty('disabled', !isPeerProxyAuthEnabled);
-        $('peer_proxy_password_text').setProperty('disabled', !isPeerProxyAuthEnabled);
-    };
-
-    this.updateFilterSettings = function() {
-        const isIPFilterEnabled = $('ipfilter_enabled_checkbox').getProperty('checked');
-        $('ipfilter_text').setProperty('disabled', !isIPFilterEnabled);
-        $('ipfilter_trackers_checkbox').setProperty('disabled', !isIPFilterEnabled);
-        $('banned_IPs_textarea').setProperty('disabled', !isIPFilterEnabled);
-    };
-
-    // Speed tab
-    this.updateSchedulingEnabled = function() {
-        const isLimitSchedulingEnabled = $('limit_sheduling_checkbox').getProperty('checked');
-        $('schedule_from_hour').setProperty('disabled', !isLimitSchedulingEnabled);
-        $('schedule_from_min').setProperty('disabled', !isLimitSchedulingEnabled);
-        $('schedule_to_hour').setProperty('disabled', !isLimitSchedulingEnabled);
-        $('schedule_to_min').setProperty('disabled', !isLimitSchedulingEnabled);
-        $('schedule_freq_select').setProperty('disabled', !isLimitSchedulingEnabled);
-    };
-
-    // Bittorrent tab
-    this.updateQueueingSystem = function() {
-        const isQueueingEnabled = $('queueing_checkbox').getProperty('checked');
-        $('max_active_dl_value').setProperty('disabled', !isQueueingEnabled);
-        $('max_active_up_value').setProperty('disabled', !isQueueingEnabled);
-        $('max_active_to_value').setProperty('disabled', !isQueueingEnabled);
-        $('dont_count_slow_torrents_checkbox').setProperty('disabled', !isQueueingEnabled);
-        updateSlowTorrentsSettings();
-    };
-
-    this.updateSlowTorrentsSettings = function() {
-        const isDontCountSlowTorrentsEnabled = (!$('dont_count_slow_torrents_checkbox').getProperty('disabled')) && $('dont_count_slow_torrents_checkbox').getProperty('checked');
-        $('dl_rate_threshold').setProperty('disabled', !isDontCountSlowTorrentsEnabled);
-        $('ul_rate_threshold').setProperty('disabled', !isDontCountSlowTorrentsEnabled);
-        $('torrent_inactive_timer').setProperty('disabled', !isDontCountSlowTorrentsEnabled);
-    };
-
-    this.updateMaxRatioTimeEnabled = function() {
-        const isMaxRatioEnabled = $('max_ratio_checkbox').getProperty('checked');
-        $('max_ratio_value').setProperty('disabled', !isMaxRatioEnabled);
-
-        const isMaxSeedingTimeEnabled = $('max_seeding_time_checkbox').getProperty('checked');
-        $('max_seeding_time_value').setProperty('disabled', !isMaxSeedingTimeEnabled);
-
-        $('max_ratio_act').setProperty('disabled', !(isMaxRatioEnabled || isMaxSeedingTimeEnabled));
-    };
-
-    this.updateAddTrackersEnabled = function() {
-        const isAddTrackersEnabled = $('add_trackers_checkbox').getProperty('checked');
-        $('add_trackers_textarea').setProperty('disabled', !isAddTrackersEnabled);
-    };
-
-    // Web UI tab
-    this.updateHttpsSettings = function() {
-        const isUseHttpsEnabled = $('use_https_checkbox').getProperty('checked');
-        $('ssl_cert_text').setProperty('disabled', !isUseHttpsEnabled);
-        $('ssl_key_text').setProperty('disabled', !isUseHttpsEnabled);
-    };
-
-    this.updateBypasssAuthSettings = function() {
-        const isBypassAuthSubnetWhitelistEnabled = $('bypass_auth_subnet_whitelist_checkbox').getProperty('checked');
-        $('bypass_auth_subnet_whitelist_textarea').setProperty('disabled', !isBypassAuthSubnetWhitelistEnabled);
-    };
-
-    this.updateAlternativeWebUISettings = function() {
-        const isUseAlternativeWebUIEnabled = $('use_alt_webui_checkbox').getProperty('checked');
-        $('webui_files_location_textarea').setProperty('disabled', !isUseAlternativeWebUIEnabled);
-    };
-
-    this.updateHostHeaderValidationSettings = function() {
-        const isHostHeaderValidationEnabled = $('host_header_validation_checkbox').getProperty('checked');
-        $('webui_domain_textarea').setProperty('disabled', !isHostHeaderValidationEnabled);
-    };
-
-    this.updateDynDnsSettings = function() {
-        const isDynDnsEnabled = $('use_dyndns_checkbox').getProperty('checked');
-        $('dyndns_select').setProperty('disabled', !isDynDnsEnabled);
-        $('dyndns_domain_text').setProperty('disabled', !isDynDnsEnabled);
-        $('dyndns_username_text').setProperty('disabled', !isDynDnsEnabled);
-        $('dyndns_password_text').setProperty('disabled', !isDynDnsEnabled);
-    };
-
-    this.registerDynDns = function() {
-        if ($('dyndns_select').getProperty('value').toInt() == 1) {
-            window.open("http://www.no-ip.com/services/managed_dns/free_dynamic_dns.html", "NO-IP Registration");
-        }
-        else {
-            window.open("https://www.dyndns.com/account/services/hosts/add.html", "DynDNS Registration");
-        }
-    };
-
-    this.generateRandomPort = function() {
-        const min = 1024;
-        const max = 65535;
-        const port = Math.floor(Math.random() * (max - min + 1) + min);
-        $('port_value').setProperty('value', port);
-    };
-
-    this.time_padding = function(val) {
-        let ret = val.toString();
-        if (ret.length == 1)
-            ret = '0' + ret;
-        return ret;
-    };
-
-    // Advanced Tab
-    this.updateNetworkInterfaces = function(default_iface) {
-        const url = 'api/v2/app/networkInterfaceList';
-        $('networkInterface').empty();
-        new Request.JSON({
-            url: url,
-            method: 'get',
-            noCache: true,
-            onFailure: function() {
-                alert("Could not contact qBittorrent");
-            },
-            onSuccess: function(ifaces) {
-                if (!ifaces) return;
-
-                $('networkInterface').options.add(new Option('QBT_TR(Any interface)QBT_TR[CONTEXT=OptionsDialog]', ''));
-                ifaces.forEach(function(item, index) {
-                    $('networkInterface').options.add(new Option(item.name, item.value));
-                });
-                $('networkInterface').setProperty('value', default_iface);
-            }
-        }).send();
-    };
-
-    this.updateInterfaceAddresses = function(iface, default_addr) {
-        const url = 'api/v2/app/networkInterfaceAddressList';
-        $('optionalIPAddressToBind').empty();
-        new Request.JSON({
-            url: url,
-            method: 'get',
-            noCache: true,
-            data: {
-                'iface': iface
-            },
-            onFailure: function() {
-                alert("Could not contact qBittorrent");
-            },
-            onSuccess: function(addresses) {
-                if (!addresses) return;
-
-                $('optionalIPAddressToBind').options.add(new Option('QBT_TR(All addresses)QBT_TR[CONTEXT=OptionDialog]', ''));
-                addresses.forEach(function(item, index) {
-                    $('optionalIPAddressToBind').options.add(new Option(item, item));
-                });
-                $('optionalIPAddressToBind').setProperty('value', default_addr);
-            }
-        }).send();
+    if (window.qBittorrent === undefined) {
+        window.qBittorrent = {};
     }
 
-    this.loadPreferences = function() {
-        const url = 'api/v2/app/preferences';
-        new Request.JSON({
-            url: url,
-            method: 'get',
-            noCache: true,
-            onFailure: function() {
-                alert("Could not contact qBittorrent");
-            },
-            onSuccess: function(pref) {
-                if (pref) {
-                    // Downloads tab
-                    // When adding a torrent
-                    $('createsubfolder_checkbox').setProperty('checked', pref.create_subfolder_enabled);
-                    $('dontstartdownloads_checkbox').setProperty('checked', pref.start_paused_enabled);
-                    $('deletetorrentfileafter_checkbox').setProperty('checked', pref.auto_delete_mode);
+    window.qBittorrent.Preferences = (function() {
+        const exports = function() {
+            return {
+                updateTempDirEnabled: updateTempDirEnabled,
+                updateExportDirEnabled: updateExportDirEnabled,
+                updateExportDirFinEnabled: updateExportDirFinEnabled,
+                addWatchFolder: addWatchFolder,
+                changeWatchFolderSelect: changeWatchFolderSelect,
+                updateMailNotification: updateMailNotification,
+                updateMailAuthSettings: updateMailAuthSettings,
+                updateAutoRun: updateAutoRun,
+                generateRandomPort: generateRandomPort,
+                updatePortValueEnabled: updatePortValueEnabled,
+                updateMaxConnecEnabled: updateMaxConnecEnabled,
+                updateMaxConnecPerTorrentEnabled: updateMaxConnecPerTorrentEnabled,
+                updateMaxUploadsEnabled: updateMaxUploadsEnabled,
+                updateMaxUploadsPerTorrentEnabled: updateMaxUploadsPerTorrentEnabled,
+                updatePeerProxySettings: updatePeerProxySettings,
+                updatePeerProxyAuthSettings: updatePeerProxyAuthSettings,
+                updateFilterSettings: updateFilterSettings,
+                updateSchedulingEnabled: updateSchedulingEnabled,
+                updateQueueingSystem: updateQueueingSystem,
+                updateSlowTorrentsSettings: updateSlowTorrentsSettings,
+                updateMaxRatioTimeEnabled: updateMaxRatioTimeEnabled,
+                updateMaxRatioTimeEnabled: updateMaxRatioTimeEnabled,
+                updateAddTrackersEnabled: updateAddTrackersEnabled,
+                updateHttpsSettings: updateHttpsSettings,
+                updateBypasssAuthSettings: updateBypasssAuthSettings,
+                updateAlternativeWebUISettings: updateAlternativeWebUISettings,
+                updateHostHeaderValidationSettings: updateHostHeaderValidationSettings,
+                updateDynDnsSettings: updateDynDnsSettings,
+                registerDynDns: registerDynDns,
+                applyPreferences: applyPreferences
+            };
+        };
 
-                    $('preallocateall_checkbox').setProperty('checked', pref.preallocate_all);
-                    $('appendext_checkbox').setProperty('checked', pref.incomplete_files_ext);
+        // Downloads tab
+        const WatchedFoldersTable = new HtmlTable($("watched_folders_tab"));
 
-                    // Saving Managmenet
-                    $('default_tmm_combobox').setProperty('value', pref.auto_tmm_enabled);
-                    $('torrent_changed_tmm_combobox').setProperty('value', pref.torrent_changed_tmm_enabled);
-                    $('save_path_changed_tmm_combobox').setProperty('value', pref.save_path_changed_tmm_enabled);
-                    $('category_changed_tmm_combobox').setProperty('value', pref.category_changed_tmm_enabled);
-                    $('savepath_text').setProperty('value', pref.save_path);
-                    $('temppath_checkbox').setProperty('checked', pref.temp_path_enabled);
-                    $('temppath_text').setProperty('value', pref.temp_path);
-                    updateTempDirEnabled();
-                    if (pref.export_dir != '') {
-                        $('exportdir_checkbox').setProperty('checked', true);
-                        $('exportdir_text').setProperty('value', pref.export_dir);
+        const updateTempDirEnabled = function() {
+            const isTempDirEnabled = $('temppath_checkbox').getProperty('checked');
+            $('temppath_text').setProperty('disabled', !isTempDirEnabled);
+        };
+
+        const addWatchFolder = function() {
+            const new_folder = $('new_watch_folder_txt').getProperty('value').trim();
+            if (new_folder.length <= 0) return;
+
+            const new_other = $('new_watch_folder_other_txt').getProperty('value').trim();
+            if (new_other.length <= 0) return;
+
+            const new_select = $('new_watch_folder_select').getProperty('value').trim();
+
+            const i = $('watched_folders_tab').getChildren('tbody')[0].getChildren('tr').length;
+            pushWatchFolder(i, new_folder, new_select, new_other);
+
+            // Clear fields
+            $('new_watch_folder_txt').setProperty('value', '');
+            const elt = $('new_watch_folder_select');
+            elt.setProperty('value', 'watch_folder');
+            const text = elt.options[elt.selectedIndex].innerHTML;
+            $('new_watch_folder_other_txt').setProperty('value', text);
+        };
+
+        const changeWatchFolderSelect = function(item) {
+            if (item.value == "other") {
+                item.nextElementSibling.hidden = false;
+                item.nextElementSibling.value = 'QBT_TR(Type folder here)QBT_TR[CONTEXT=HttpServer]';
+                item.nextElementSibling.select();
+            }
+            else {
+                item.nextElementSibling.hidden = true;
+                const text = item.options[item.selectedIndex].innerHTML;
+                item.nextElementSibling.value = text;
+            }
+        };
+
+        const pushWatchFolder = function(pos, folder, sel, other) {
+            const myinput = "<input id='text_watch_" + pos + "' type='text' value='" + folder + "'>";
+            const disableInput = (sel != "other");
+            const mycb = "<div class='select-watched-folder-editable'>"
+                + "<select id ='cb_watch_" + pos + "' onchange='qBittorrent.Preferences.changeWatchFolderSelect(this)'>"
+                + "<option value='watch_folder'>QBT_TR(Monitored folder)QBT_TR[CONTEXT=ScanFoldersModel]</option>"
+                + "<option value='default_folder'>QBT_TR(Default save location)QBT_TR[CONTEXT=ScanFoldersModel]</option>"
+                + "<option value='other'>QBT_TR(Other...)QBT_TR[CONTEXT=HttpServer]</option>"
+                + "</select>"
+                + "<input id='cb_watch_txt_" + pos + "' type='text' " + (disableInput ? "hidden " : "") + "/></div>";
+
+            WatchedFoldersTable.push([myinput, mycb]);
+            $('cb_watch_' + pos).setProperty('value', sel);
+            if (disableInput) {
+                const elt = $('cb_watch_' + pos);
+                other = elt.options[elt.selectedIndex].innerHTML;
+            }
+            $('cb_watch_txt_' + pos).setProperty('value', other);
+        };
+
+        const getWatchedFolders = function() {
+            const nb_folders = $("watched_folders_tab").getChildren("tbody")[0].getChildren("tr").length;
+            const folders = new Hash();
+            for (let i = 0; i < nb_folders; ++i) {
+                const fpath = $('text_watch_' + i).getProperty('value').trim();
+                if (fpath.length > 0) {
+                    let other;
+                    const sel = $('cb_watch_' + i).getProperty('value').trim();
+                    if (sel == "other") {
+                        other = $('cb_watch_txt_' + i).getProperty('value').trim();
                     }
                     else {
-                        $('exportdir_checkbox').setProperty('checked', false);
-                        $('exportdir_text').setProperty('value', '');
+                        other = (sel == "watch_folder") ? 0 : 1;
                     }
-                    updateExportDirEnabled();
-                    if (pref.export_dir_fin != '') {
-                        $('exportdirfin_checkbox').setProperty('checked', true);
-                        $('exportdirfin_text').setProperty('value', pref.export_dir_fin);
-                    }
-                    else {
-                        $('exportdirfin_checkbox').setProperty('checked', false);
-                        $('exportdirfin_text').setProperty('value', '');
-                    }
-                    updateExportDirFinEnabled();
-
-                    // Automatically add torrents from
-                    let i = 0;
-                    for (const folder in pref.scan_dirs) {
-                        let sel;
-                        let other = "";
-                        if (typeof pref.scan_dirs[folder] == "string") {
-                            other = pref.scan_dirs[folder];
-                            sel = "other";
-                        }
-                        else {
-                            sel = (pref.scan_dirs[folder] == 0) ? "watch_folder" : "default_folder";
-                        }
-                        pushWatchFolder(i++, folder, sel, other);
-                    }
-
-                    // Email notification upon download completion
-                    $('mail_notification_checkbox').setProperty('checked', pref.mail_notification_enabled);
-                    $('src_email_txt').setProperty('value', pref.mail_notification_sender);
-                    $('dest_email_txt').setProperty('value', pref.mail_notification_email);
-                    $('smtp_server_txt').setProperty('value', pref.mail_notification_smtp);
-                    $('mail_ssl_checkbox').setProperty('checked', pref.mail_notification_ssl_enabled);
-                    $('mail_auth_checkbox').setProperty('checked', pref.mail_notification_auth_enabled);
-                    $('mail_username_text').setProperty('value', pref.mail_notification_username);
-                    $('mail_password_text').setProperty('value', pref.mail_notification_password);
-                    updateMailNotification();
-                    updateMailAuthSettings();
-
-                    // Run an external program on torrent completion
-                    $('autorun_checkbox').setProperty('checked', pref.autorun_enabled);
-                    $('autorunProg_txt').setProperty('value', pref.autorun_program);
-                    updateAutoRun();
-
-                    // Connection tab
-                    // Listening Port
-                    $('port_value').setProperty('value', pref.listen_port.toInt());
-                    $('upnp_checkbox').setProperty('checked', pref.upnp);
-                    $('random_port_checkbox').setProperty('checked', pref.random_port);
-                    updatePortValueEnabled();
-
-                    // Connections Limits
-                    const max_connec = pref.max_connec.toInt();
-                    if (max_connec <= 0) {
-                        $('max_connec_checkbox').setProperty('checked', false);
-                        $('max_connec_value').setProperty('value', 500);
-                    }
-                    else {
-                        $('max_connec_checkbox').setProperty('checked', true);
-                        $('max_connec_value').setProperty('value', max_connec);
-                    }
-                    updateMaxConnecEnabled();
-                    const max_connec_per_torrent = pref.max_connec_per_torrent.toInt();
-                    if (max_connec_per_torrent <= 0) {
-                        $('max_connec_per_torrent_checkbox').setProperty('checked', false);
-                        $('max_connec_per_torrent_value').setProperty('value', 100);
-                    }
-                    else {
-                        $('max_connec_per_torrent_checkbox').setProperty('checked', true);
-                        $('max_connec_per_torrent_value').setProperty('value', max_connec_per_torrent);
-                    }
-                    updateMaxConnecPerTorrentEnabled();
-                    const max_uploads = pref.max_uploads.toInt();
-                    if (max_uploads <= 0) {
-                        $('max_uploads_checkbox').setProperty('checked', false);
-                        $('max_uploads_value').setProperty('value', 8);
-                    }
-                    else {
-                        $('max_uploads_checkbox').setProperty('checked', true);
-                        $('max_uploads_value').setProperty('value', max_uploads);
-                    }
-                    updateMaxUploadsEnabled();
-                    const max_uploads_per_torrent = pref.max_uploads_per_torrent.toInt();
-                    if (max_uploads_per_torrent <= 0) {
-                        $('max_uploads_per_torrent_checkbox').setProperty('checked', false);
-                        $('max_uploads_per_torrent_value').setProperty('value', 4);
-                    }
-                    else {
-                        $('max_uploads_per_torrent_checkbox').setProperty('checked', true);
-                        $('max_uploads_per_torrent_value').setProperty('value', max_uploads_per_torrent);
-                    }
-                    updateMaxUploadsPerTorrentEnabled();
-
-                    // Proxy Server
-                    switch (pref.proxy_type.toInt()) {
-                        case 5: //SOCKS4
-                            $('peer_proxy_type_select').setProperty('value', 'socks4');
-                            break;
-                        case 2: // SOCKS5
-                        case 4: // SOCKS5_PW
-                            $('peer_proxy_type_select').setProperty('value', 'socks5');
-                            break;
-                        case 1: // HTTP
-                        case 3: // HTTP_PW
-                            $('peer_proxy_type_select').setProperty('value', 'http');
-                            break;
-                        default: // NONE
-                            $('peer_proxy_type_select').setProperty('value', 'none');
-                    }
-                    updatePeerProxySettings();
-                    $('peer_proxy_host_text').setProperty('value', pref.proxy_ip);
-                    $('peer_proxy_port_value').setProperty('value', pref.proxy_port);
-                    $('use_peer_proxy_checkbox').setProperty('checked', pref.proxy_peer_connections);
-                    $('proxy_only_for_torrents_checkbox').setProperty('checked', pref.proxy_torrents_only);
-                    $('peer_proxy_auth_checkbox').setProperty('checked', pref.proxy_auth_enabled);
-                    updatePeerProxyAuthSettings();
-                    $('peer_proxy_username_text').setProperty('value', pref.proxy_username);
-                    $('peer_proxy_password_text').setProperty('value', pref.proxy_password);
-
-                    // IP Filtering
-                    $('ipfilter_enabled_checkbox').setProperty('checked', pref.ip_filter_enabled);
-                    $('ipfilter_text').setProperty('value', pref.ip_filter_path);
-                    $('ipfilter_trackers_checkbox').setProperty('checked', pref.ip_filter_trackers);
-                    $('banned_IPs_textarea').setProperty('value', pref.banned_IPs);
-                    updateFilterSettings();
-
-                    // Speed tab
-                    // Global Rate Limits
-                    $('up_limit_value').setProperty('value', (pref.up_limit.toInt() / 1024));
-                    $('dl_limit_value').setProperty('value', (pref.dl_limit.toInt() / 1024));
-                    // Alternative Global Rate Limits
-                    $('alt_up_limit_value').setProperty('value', (pref.alt_up_limit.toInt() / 1024));
-                    $('alt_dl_limit_value').setProperty('value', (pref.alt_dl_limit.toInt() / 1024));
-
-                    $('enable_protocol_combobox').setProperty('value', pref.bittorrent_protocol);
-                    $('limit_utp_rate_checkbox').setProperty('checked', pref.limit_utp_rate);
-                    $('limit_tcp_overhead_checkbox').setProperty('checked', pref.limit_tcp_overhead);
-                    $('limit_lan_peers_checkbox').setProperty('checked', pref.limit_lan_peers);
-
-                    // Scheduling
-                    $('limit_sheduling_checkbox').setProperty('checked', pref.scheduler_enabled);
-                    $('schedule_from_hour').setProperty('value', time_padding(pref.schedule_from_hour));
-                    $('schedule_from_min').setProperty('value', time_padding(pref.schedule_from_min));
-                    $('schedule_to_hour').setProperty('value', time_padding(pref.schedule_to_hour));
-                    $('schedule_to_min').setProperty('value', time_padding(pref.schedule_to_min));
-                    $('schedule_freq_select').setProperty('value', pref.scheduler_days);
-                    updateSchedulingEnabled();
-
-                    // Bittorrent tab
-                    // Privacy
-                    $('dht_checkbox').setProperty('checked', pref.dht);
-                    $('pex_checkbox').setProperty('checked', pref.pex);
-                    $('lsd_checkbox').setProperty('checked', pref.lsd);
-                    const encryption = pref.encryption.toInt();
-                    $('encryption_select').getChildren('option')[encryption].setAttribute('selected', '');
-                    $('anonymous_mode_checkbox').setProperty('checked', pref.anonymous_mode);
-
-                    // Torrent Queueing
-                    $('queueing_checkbox').setProperty('checked', pref.queueing_enabled);
-                    $('max_active_dl_value').setProperty('value', pref.max_active_downloads.toInt());
-                    $('max_active_up_value').setProperty('value', pref.max_active_uploads.toInt());
-                    $('max_active_to_value').setProperty('value', pref.max_active_torrents.toInt());
-                    $('dont_count_slow_torrents_checkbox').setProperty('checked', pref.dont_count_slow_torrents);
-                    $('dl_rate_threshold').setProperty('value', pref.slow_torrent_dl_rate_threshold.toInt());
-                    $('ul_rate_threshold').setProperty('value', pref.slow_torrent_ul_rate_threshold.toInt());
-                    $('torrent_inactive_timer').setProperty('value', pref.slow_torrent_inactive_timer.toInt());
-                    updateQueueingSystem();
-
-                    // Share Limiting
-                    $('max_ratio_checkbox').setProperty('checked', pref.max_ratio_enabled);
-                    if (pref.max_ratio_enabled)
-                        $('max_ratio_value').setProperty('value', pref.max_ratio);
-                    else
-                        $('max_ratio_value').setProperty('value', 1);
-                    $('max_seeding_time_checkbox').setProperty('checked', pref.max_seeding_time_enabled);
-                    if (pref.max_seeding_time_enabled)
-                        $('max_seeding_time_value').setProperty('value', pref.max_seeding_time.toInt());
-                    else
-                        $('max_seeding_time_value').setProperty('value', 1440);
-                    const max_ratio_act = pref.max_ratio_act.toInt();
-                    $('max_ratio_act').getChildren('option')[max_ratio_act].setAttribute('selected', '');
-                    updateMaxRatioTimeEnabled();
-
-                    // Add trackers
-                    $('add_trackers_checkbox').setProperty('checked', pref.add_trackers_enabled);
-                    $('add_trackers_textarea').setProperty('value', pref.add_trackers);
-                    updateAddTrackersEnabled();
-
-                    // Web UI tab
-                    // Language
-                    $('locale_select').setProperty('value', pref.locale);
-
-                    // HTTP Server
-                    $('webui_domain_textarea').setProperty('value', pref.web_ui_domain_list);
-                    $('webui_address_value').setProperty('value', pref.web_ui_address);
-                    $('webui_port_value').setProperty('value', pref.web_ui_port);
-                    $('webui_upnp_checkbox').setProperty('checked', pref.web_ui_upnp);
-                    $('use_https_checkbox').setProperty('checked', pref.use_https);
-                    $('ssl_cert_text').setProperty('value', pref.web_ui_https_cert_path);
-                    $('ssl_key_text').setProperty('value', pref.web_ui_https_key_path);
-                    updateHttpsSettings();
-
-                    // Authentication
-                    $('webui_username_text').setProperty('value', pref.web_ui_username);
-                    $('bypass_local_auth_checkbox').setProperty('checked', pref.bypass_local_auth);
-                    $('bypass_auth_subnet_whitelist_checkbox').setProperty('checked', pref.bypass_auth_subnet_whitelist_enabled);
-                    $('bypass_auth_subnet_whitelist_textarea').setProperty('value', pref.bypass_auth_subnet_whitelist);
-                    updateBypasssAuthSettings();
-                    $('webUISessionTimeoutInput').setProperty('value', pref.web_ui_session_timeout.toInt());
-
-                    // Use alternative Web UI
-                    $('use_alt_webui_checkbox').setProperty('checked', pref.alternative_webui_enabled);
-                    $('webui_files_location_textarea').setProperty('value', pref.alternative_webui_path);
-                    updateAlternativeWebUISettings();
-
-                    // Security
-                    $('clickjacking_protection_checkbox').setProperty('checked', pref.web_ui_clickjacking_protection_enabled);
-                    $('csrf_protection_checkbox').setProperty('checked', pref.web_ui_csrf_protection_enabled);
-                    $('host_header_validation_checkbox').setProperty('checked', pref.web_ui_host_header_validation_enabled);
-                    updateHostHeaderValidationSettings();
-
-                    // Update my dynamic domain name
-                    $('use_dyndns_checkbox').setProperty('checked', pref.dyndns_enabled);
-                    $('dyndns_select').setProperty('value', pref.dyndns_service);
-                    $('dyndns_domain_text').setProperty('value', pref.dyndns_domain);
-                    $('dyndns_username_text').setProperty('value', pref.dyndns_username);
-                    $('dyndns_password_text').setProperty('value', pref.dyndns_password);
-                    updateDynDnsSettings();
-
-                    // Advanced settings
-                    // qBittorrent section
-                    updateNetworkInterfaces(pref.current_network_interface);
-                    updateInterfaceAddresses(pref.current_network_interface, pref.current_interface_address);
-                    $('listenOnIPv6Address').setProperty('checked', pref.listen_on_ipv6_address);
-                    $('saveResumeDataInterval').setProperty('value', pref.save_resume_data_interval);
-                    $('recheckTorrentsOnCompletion').setProperty('checked', pref.recheck_completed_torrents);
-                    $('resolvePeerCountries').setProperty('checked', pref.resolve_peer_countries);
-                    // libtorrent section
-                    $('asyncIOThreads').setProperty('value', pref.async_io_threads);
-                    $('filePoolSize').setProperty('value', pref.file_pool_size);
-                    $('outstandMemoryWhenCheckingTorrents').setProperty('value', pref.checking_memory_use);
-                    $('diskCache').setProperty('value', pref.disk_cache);
-                    $('diskCacheExpiryInterval').setProperty('value', pref.disk_cache_ttl);
-                    $('enableOSCache').setProperty('checked', pref.enable_os_cache);
-                    $('coalesceReadsAndWrites').setProperty('checked', pref.enable_coalesce_read_write);
-                    $('sendUploadPieceSuggestions').setProperty('checked', pref.enable_upload_suggestions);
-                    $('sendBufferWatermark').setProperty('value', pref.send_buffer_watermark);
-                    $('sendBufferLowWatermark').setProperty('value', pref.send_buffer_low_watermark);
-                    $('sendBufferWatermarkFactor').setProperty('value', pref.send_buffer_watermark_factor);
-                    $('socketBacklogSize').setProperty('value', pref.socket_backlog_size);
-                    $('outgoingPortsMin').setProperty('value', pref.outgoing_ports_min);
-                    $('outgoingPortsMax').setProperty('value', pref.outgoing_ports_max);
-                    $('utpTCPMixedModeAlgorithm').setProperty('value', pref.utp_tcp_mixed_mode);
-                    $('allowMultipleConnectionsFromTheSameIPAddress').setProperty('checked', pref.enable_multi_connections_from_same_ip);
-                    $('enableEmbeddedTracker').setProperty('checked', pref.enable_embedded_tracker);
-                    $('embeddedTrackerPort').setProperty('value', pref.embedded_tracker_port);
-                    $('uploadSlotsBehavior').setProperty('value', pref.upload_slots_behavior);
-                    $('uploadChokingAlgorithm').setProperty('value', pref.upload_choking_algorithm);
-                    $('strictSuperSeeding').setProperty('checked', pref.enable_super_seeding);
-                    $('announceAllTrackers').setProperty('checked', pref.announce_to_all_trackers);
-                    $('announceAllTiers').setProperty('checked', pref.announce_to_all_tiers);
-                    $('announceIP').setProperty('value', pref.announce_ip);
+                    folders.set(fpath, other);
                 }
             }
-        }).send();
-    };
+            return folders;
+        };
 
-    this.applyPreferences = function() {
-        const settings = new Hash();
-        // Validate form data
-        // Downloads tab
-        // When adding a torrent
-        settings.set('create_subfolder_enabled', $('createsubfolder_checkbox').getProperty('checked'));
-        settings.set('start_paused_enabled', $('dontstartdownloads_checkbox').getProperty('checked'));
-        settings.set('auto_delete_mode', $('deletetorrentfileafter_checkbox').getProperty('checked'));
+        const updateExportDirEnabled = function() {
+            const isExportDirEnabled = $('exportdir_checkbox').getProperty('checked');
+            $('exportdir_text').setProperty('disabled', !isExportDirEnabled);
+        };
 
-        settings.set('preallocate_all', $('preallocateall_checkbox').getProperty('checked'));
-        settings.set('incomplete_files_ext', $('appendext_checkbox').getProperty('checked'));
+        const updateExportDirFinEnabled = function() {
+            const isExportDirFinEnabled = $('exportdirfin_checkbox').getProperty('checked');
+            $('exportdirfin_text').setProperty('disabled', !isExportDirFinEnabled);
+        };
 
-        // Saving Management
-        settings.set('auto_tmm_enabled', $('default_tmm_combobox').getProperty('value'));
-        settings.set('torrent_changed_tmm_enabled', $('torrent_changed_tmm_combobox').getProperty('value'));
-        settings.set('save_path_changed_tmm_enabled', $('save_path_changed_tmm_combobox').getProperty('value'));
-        settings.set('category_changed_tmm_enabled', $('category_changed_tmm_combobox').getProperty('value'));
-        settings.set('save_path', $('savepath_text').getProperty('value'));
-        settings.set('temp_path_enabled', $('temppath_checkbox').getProperty('checked'));
-        settings.set('temp_path', $('temppath_text').getProperty('value'));
-        if ($('exportdir_checkbox').getProperty('checked'))
-            settings.set('export_dir', $('exportdir_text').getProperty('value'));
-        else
-            settings.set('export_dir', '');
-        if ($('exportdirfin_checkbox').getProperty('checked'))
-            settings.set('export_dir_fin', $('exportdirfin_text').getProperty('value'));
-        else
-            settings.set('export_dir_fin', '');
+        const updateMailNotification = function() {
+            const isMailNotificationEnabled = $('mail_notification_checkbox').getProperty('checked');
+            $('src_email_txt').setProperty('disabled', !isMailNotificationEnabled);
+            $('dest_email_txt').setProperty('disabled', !isMailNotificationEnabled);
+            $('smtp_server_txt').setProperty('disabled', !isMailNotificationEnabled);
+            $('mail_ssl_checkbox').setProperty('disabled', !isMailNotificationEnabled);
+            $('mail_auth_checkbox').setProperty('disabled', !isMailNotificationEnabled);
 
-        // Automatically add torrents from
-        settings.set('scan_dirs', getWatchedFolders());
+            if (!isMailNotificationEnabled) {
+                $('mail_auth_checkbox').setProperty('checked', !isMailNotificationEnabled);
+                updateMailAuthSettings();
+            }
+        };
 
-        // Email notification upon download completion
-        settings.set('mail_notification_enabled', $('mail_notification_checkbox').getProperty('checked'));
-        settings.set('mail_notification_sender', $('src_email_txt').getProperty('value'));
-        settings.set('mail_notification_email', $('dest_email_txt').getProperty('value'));
-        settings.set('mail_notification_smtp', $('smtp_server_txt').getProperty('value'));
-        settings.set('mail_notification_ssl_enabled', $('mail_ssl_checkbox').getProperty('checked'));
-        settings.set('mail_notification_auth_enabled', $('mail_auth_checkbox').getProperty('checked'));
-        settings.set('mail_notification_username', $('mail_username_text').getProperty('value'));
-        settings.set('mail_notification_password', $('mail_password_text').getProperty('value'));
+        const updateMailAuthSettings = function() {
+            const isMailAuthEnabled = $('mail_auth_checkbox').getProperty('checked');
+            $('mail_username_text').setProperty('disabled', !isMailAuthEnabled);
+            $('mail_password_text').setProperty('disabled', !isMailAuthEnabled);
+        };
 
-        // Run an external program on torrent completion
-        settings.set('autorun_enabled', $('autorun_checkbox').getProperty('checked'));
-        settings.set('autorun_program', $('autorunProg_txt').getProperty('value'));
+        const updateAutoRun = function() {
+            const isAutoRunEnabled = $('autorun_checkbox').getProperty('checked');
+            $('autorunProg_txt').setProperty('disabled', !isAutoRunEnabled);
+        };
 
         // Connection tab
-        // Listening Port
-        const listen_port = $('port_value').getProperty('value').toInt();
-        if (isNaN(listen_port) || listen_port < 1 || listen_port > 65535) {
-            alert("QBT_TR(The port used for incoming connections must be between 1 and 65535.)QBT_TR[CONTEXT=HttpServer]");
-            return;
-        }
-        settings.set('listen_port', listen_port);
-        settings.set('upnp', $('upnp_checkbox').getProperty('checked'));
-        settings.set('random_port', $('random_port_checkbox').getProperty('checked'));
+        const updatePortValueEnabled = function() {
+            const checked = $('random_port_checkbox').getProperty('checked');
+            $('port_value').setProperty('disabled', checked);
+        };
 
-        // Connections Limits
-        let max_connec = -1;
-        if ($('max_connec_checkbox').getProperty('checked')) {
-            max_connec = $('max_connec_value').getProperty('value').toInt();
-            if (isNaN(max_connec) || max_connec <= 0) {
-                alert("QBT_TR(Maximum number of connections limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
-                return;
-            }
-        }
-        settings.set('max_connec', max_connec);
-        let max_connec_per_torrent = -1;
-        if ($('max_connec_per_torrent_checkbox').getProperty('checked')) {
-            max_connec_per_torrent = $('max_connec_per_torrent_value').getProperty('value').toInt();
-            if (isNaN(max_connec_per_torrent) || max_connec_per_torrent <= 0) {
-                alert("QBT_TR(Maximum number of connections per torrent limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
-                return;
-            }
-        }
-        settings.set('max_connec_per_torrent', max_connec_per_torrent);
-        let max_uploads = -1;
-        if ($('max_uploads_checkbox').getProperty('checked')) {
-            max_uploads = $('max_uploads_value').getProperty('value').toInt();
-            if (isNaN(max_uploads) || max_uploads <= 0) {
-                alert("QBT_TR(Global number of upload slots limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
-                return;
-            }
-        }
-        settings.set('max_uploads', max_uploads);
-        let max_uploads_per_torrent = -1;
-        if ($('max_uploads_per_torrent_checkbox').getProperty('checked')) {
-            max_uploads_per_torrent = $('max_uploads_per_torrent_value').getProperty('value').toInt();
-            if (isNaN(max_uploads_per_torrent) || max_uploads_per_torrent <= 0) {
-                alert("QBT_TR(Maximum number of upload slots per torrent limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
-                return;
-            }
-        }
-        settings.set('max_uploads_per_torrent', max_uploads_per_torrent);
+        const updateMaxConnecEnabled = function() {
+            const isMaxConnecEnabled = $('max_connec_checkbox').getProperty('checked');
+            $('max_connec_value').setProperty('disabled', !isMaxConnecEnabled);
+        };
 
-        // Proxy Server
-        const proxy_type_str = $('peer_proxy_type_select').getProperty('value');
-        let proxy_type = 0;
-        let proxy_auth_enabled = false;
-        if (proxy_type_str == "socks5") {
-            if ($('peer_proxy_auth_checkbox').getProperty('checked')) {
-                proxy_type = 4;
-                proxy_auth_enabled = true;
+        const updateMaxConnecPerTorrentEnabled = function() {
+            const isMaxConnecPerTorrentEnabled = $('max_connec_per_torrent_checkbox').getProperty('checked');
+            $('max_connec_per_torrent_value').setProperty('disabled', !isMaxConnecPerTorrentEnabled);
+        };
+
+        const updateMaxUploadsEnabled = function() {
+            const isMaxUploadsEnabled = $('max_uploads_checkbox').getProperty('checked');
+            $('max_uploads_value').setProperty('disabled', !isMaxUploadsEnabled);
+        };
+
+        const updateMaxUploadsPerTorrentEnabled = function() {
+            const isMaxUploadsPerTorrentEnabled = $('max_uploads_per_torrent_checkbox').getProperty('checked');
+            $('max_uploads_per_torrent_value').setProperty('disabled', !isMaxUploadsPerTorrentEnabled);
+        };
+
+        const updatePeerProxySettings = function() {
+            const isPeerProxyTypeSelected = $('peer_proxy_type_select').getProperty('value') != "none";
+            $('peer_proxy_host_text').setProperty('disabled', !isPeerProxyTypeSelected);
+            $('peer_proxy_port_value').setProperty('disabled', !isPeerProxyTypeSelected);
+            $('use_peer_proxy_checkbox').setProperty('disabled', !isPeerProxyTypeSelected);
+            $('proxy_only_for_torrents_checkbox').setProperty('disabled', !isPeerProxyTypeSelected);
+
+            if (isPeerProxyTypeSelected) {
+                const isPeerProxyTypeSocks5 = $('peer_proxy_type_select').getProperty('value') == "socks5";
+                $('peer_proxy_auth_checkbox').setProperty('disabled', !isPeerProxyTypeSocks5);
+
+                if (!isPeerProxyTypeSocks5) {
+                    $('peer_proxy_auth_checkbox').setProperty('checked', isPeerProxyTypeSocks5);
+                    updatePeerProxyAuthSettings();
+                }
             }
             else {
-                proxy_type = 2;
+                $('peer_proxy_auth_checkbox').setProperty('disabled', !isPeerProxyTypeSelected);
+                $('peer_proxy_auth_checkbox').setProperty('checked', isPeerProxyTypeSelected);
+                updatePeerProxyAuthSettings();
             }
-        }
-        else {
-            if (proxy_type_str == "socks4") {
-                proxy_type = 5;
+        };
+
+        const updatePeerProxyAuthSettings = function() {
+            const isPeerProxyAuthEnabled = $('peer_proxy_auth_checkbox').getProperty('checked');
+            $('peer_proxy_username_text').setProperty('disabled', !isPeerProxyAuthEnabled);
+            $('peer_proxy_password_text').setProperty('disabled', !isPeerProxyAuthEnabled);
+        };
+
+        const updateFilterSettings = function() {
+            const isIPFilterEnabled = $('ipfilter_enabled_checkbox').getProperty('checked');
+            $('ipfilter_text').setProperty('disabled', !isIPFilterEnabled);
+            $('ipfilter_trackers_checkbox').setProperty('disabled', !isIPFilterEnabled);
+            $('banned_IPs_textarea').setProperty('disabled', !isIPFilterEnabled);
+        };
+
+        // Speed tab
+        const updateSchedulingEnabled = function() {
+            const isLimitSchedulingEnabled = $('limit_sheduling_checkbox').getProperty('checked');
+            $('schedule_from_hour').setProperty('disabled', !isLimitSchedulingEnabled);
+            $('schedule_from_min').setProperty('disabled', !isLimitSchedulingEnabled);
+            $('schedule_to_hour').setProperty('disabled', !isLimitSchedulingEnabled);
+            $('schedule_to_min').setProperty('disabled', !isLimitSchedulingEnabled);
+            $('schedule_freq_select').setProperty('disabled', !isLimitSchedulingEnabled);
+        };
+
+        // Bittorrent tab
+        const updateQueueingSystem = function() {
+            const isQueueingEnabled = $('queueing_checkbox').getProperty('checked');
+            $('max_active_dl_value').setProperty('disabled', !isQueueingEnabled);
+            $('max_active_up_value').setProperty('disabled', !isQueueingEnabled);
+            $('max_active_to_value').setProperty('disabled', !isQueueingEnabled);
+            $('dont_count_slow_torrents_checkbox').setProperty('disabled', !isQueueingEnabled);
+            updateSlowTorrentsSettings();
+        };
+
+        const updateSlowTorrentsSettings = function() {
+            const isDontCountSlowTorrentsEnabled = (!$('dont_count_slow_torrents_checkbox').getProperty('disabled')) && $('dont_count_slow_torrents_checkbox').getProperty('checked');
+            $('dl_rate_threshold').setProperty('disabled', !isDontCountSlowTorrentsEnabled);
+            $('ul_rate_threshold').setProperty('disabled', !isDontCountSlowTorrentsEnabled);
+            $('torrent_inactive_timer').setProperty('disabled', !isDontCountSlowTorrentsEnabled);
+        };
+
+        const updateMaxRatioTimeEnabled = function() {
+            const isMaxRatioEnabled = $('max_ratio_checkbox').getProperty('checked');
+            $('max_ratio_value').setProperty('disabled', !isMaxRatioEnabled);
+
+            const isMaxSeedingTimeEnabled = $('max_seeding_time_checkbox').getProperty('checked');
+            $('max_seeding_time_value').setProperty('disabled', !isMaxSeedingTimeEnabled);
+
+            $('max_ratio_act').setProperty('disabled', !(isMaxRatioEnabled || isMaxSeedingTimeEnabled));
+        };
+
+        const updateAddTrackersEnabled = function() {
+            const isAddTrackersEnabled = $('add_trackers_checkbox').getProperty('checked');
+            $('add_trackers_textarea').setProperty('disabled', !isAddTrackersEnabled);
+        };
+
+        // Web UI tab
+        const updateHttpsSettings = function() {
+            const isUseHttpsEnabled = $('use_https_checkbox').getProperty('checked');
+            $('ssl_cert_text').setProperty('disabled', !isUseHttpsEnabled);
+            $('ssl_key_text').setProperty('disabled', !isUseHttpsEnabled);
+        };
+
+        const updateBypasssAuthSettings = function() {
+            const isBypassAuthSubnetWhitelistEnabled = $('bypass_auth_subnet_whitelist_checkbox').getProperty('checked');
+            $('bypass_auth_subnet_whitelist_textarea').setProperty('disabled', !isBypassAuthSubnetWhitelistEnabled);
+        };
+
+        const updateAlternativeWebUISettings = function() {
+            const isUseAlternativeWebUIEnabled = $('use_alt_webui_checkbox').getProperty('checked');
+            $('webui_files_location_textarea').setProperty('disabled', !isUseAlternativeWebUIEnabled);
+        };
+
+        const updateHostHeaderValidationSettings = function() {
+            const isHostHeaderValidationEnabled = $('host_header_validation_checkbox').getProperty('checked');
+            $('webui_domain_textarea').setProperty('disabled', !isHostHeaderValidationEnabled);
+        };
+
+        const updateDynDnsSettings = function() {
+            const isDynDnsEnabled = $('use_dyndns_checkbox').getProperty('checked');
+            $('dyndns_select').setProperty('disabled', !isDynDnsEnabled);
+            $('dyndns_domain_text').setProperty('disabled', !isDynDnsEnabled);
+            $('dyndns_username_text').setProperty('disabled', !isDynDnsEnabled);
+            $('dyndns_password_text').setProperty('disabled', !isDynDnsEnabled);
+        };
+
+        const registerDynDns = function() {
+            if ($('dyndns_select').getProperty('value').toInt() == 1) {
+                window.open("http://www.no-ip.com/services/managed_dns/free_dynamic_dns.html", "NO-IP Registration");
             }
             else {
-                if (proxy_type_str == "http") {
-                    if ($('peer_proxy_auth_checkbox').getProperty('checked')) {
-                        proxy_type = 3;
-                        proxy_auth_enabled = true;
+                window.open("https://www.dyndns.com/account/services/hosts/add.html", "DynDNS Registration");
+            }
+        };
+
+        const generateRandomPort = function() {
+            const min = 1024;
+            const max = 65535;
+            const port = Math.floor(Math.random() * (max - min + 1) + min);
+            $('port_value').setProperty('value', port);
+        };
+
+        const time_padding = function(val) {
+            let ret = val.toString();
+            if (ret.length == 1)
+                ret = '0' + ret;
+            return ret;
+        };
+
+        // Advanced Tab
+        const updateNetworkInterfaces = function(default_iface) {
+            const url = 'api/v2/app/networkInterfaceList';
+            $('networkInterface').empty();
+            new Request.JSON({
+                url: url,
+                method: 'get',
+                noCache: true,
+                onFailure: function() {
+                    alert("Could not contact qBittorrent");
+                },
+                onSuccess: function(ifaces) {
+                    if (!ifaces) return;
+
+                    $('networkInterface').options.add(new Option('QBT_TR(Any interface)QBT_TR[CONTEXT=OptionsDialog]', ''));
+                    ifaces.forEach(function(item, index) {
+                        $('networkInterface').options.add(new Option(item.name, item.value));
+                    });
+                    $('networkInterface').setProperty('value', default_iface);
+                }
+            }).send();
+        };
+
+        const updateInterfaceAddresses = function(iface, default_addr) {
+            const url = 'api/v2/app/networkInterfaceAddressList';
+            $('optionalIPAddressToBind').empty();
+            new Request.JSON({
+                url: url,
+                method: 'get',
+                noCache: true,
+                data: {
+                    'iface': iface
+                },
+                onFailure: function() {
+                    alert("Could not contact qBittorrent");
+                },
+                onSuccess: function(addresses) {
+                    if (!addresses) return;
+
+                    $('optionalIPAddressToBind').options.add(new Option('QBT_TR(All addresses)QBT_TR[CONTEXT=OptionDialog]', ''));
+                    addresses.forEach(function(item, index) {
+                        $('optionalIPAddressToBind').options.add(new Option(item, item));
+                    });
+                    $('optionalIPAddressToBind').setProperty('value', default_addr);
+                }
+            }).send();
+        }
+
+        const loadPreferences = function() {
+            const url = 'api/v2/app/preferences';
+            new Request.JSON({
+                url: url,
+                method: 'get',
+                noCache: true,
+                onFailure: function() {
+                    alert("Could not contact qBittorrent");
+                },
+                onSuccess: function(pref) {
+                    if (pref) {
+                        // Downloads tab
+                        // When adding a torrent
+                        $('createsubfolder_checkbox').setProperty('checked', pref.create_subfolder_enabled);
+                        $('dontstartdownloads_checkbox').setProperty('checked', pref.start_paused_enabled);
+                        $('deletetorrentfileafter_checkbox').setProperty('checked', pref.auto_delete_mode);
+
+                        $('preallocateall_checkbox').setProperty('checked', pref.preallocate_all);
+                        $('appendext_checkbox').setProperty('checked', pref.incomplete_files_ext);
+
+                        // Saving Managmenet
+                        $('default_tmm_combobox').setProperty('value', pref.auto_tmm_enabled);
+                        $('torrent_changed_tmm_combobox').setProperty('value', pref.torrent_changed_tmm_enabled);
+                        $('save_path_changed_tmm_combobox').setProperty('value', pref.save_path_changed_tmm_enabled);
+                        $('category_changed_tmm_combobox').setProperty('value', pref.category_changed_tmm_enabled);
+                        $('savepath_text').setProperty('value', pref.save_path);
+                        $('temppath_checkbox').setProperty('checked', pref.temp_path_enabled);
+                        $('temppath_text').setProperty('value', pref.temp_path);
+                        updateTempDirEnabled();
+                        if (pref.export_dir != '') {
+                            $('exportdir_checkbox').setProperty('checked', true);
+                            $('exportdir_text').setProperty('value', pref.export_dir);
+                        }
+                        else {
+                            $('exportdir_checkbox').setProperty('checked', false);
+                            $('exportdir_text').setProperty('value', '');
+                        }
+                        updateExportDirEnabled();
+                        if (pref.export_dir_fin != '') {
+                            $('exportdirfin_checkbox').setProperty('checked', true);
+                            $('exportdirfin_text').setProperty('value', pref.export_dir_fin);
+                        }
+                        else {
+                            $('exportdirfin_checkbox').setProperty('checked', false);
+                            $('exportdirfin_text').setProperty('value', '');
+                        }
+                        updateExportDirFinEnabled();
+
+                        // Automatically add torrents from
+                        let i = 0;
+                        for (const folder in pref.scan_dirs) {
+                            let sel;
+                            let other = "";
+                            if (typeof pref.scan_dirs[folder] == "string") {
+                                other = pref.scan_dirs[folder];
+                                sel = "other";
+                            }
+                            else {
+                                sel = (pref.scan_dirs[folder] == 0) ? "watch_folder" : "default_folder";
+                            }
+                            pushWatchFolder(i++, folder, sel, other);
+                        }
+
+                        // Email notification upon download completion
+                        $('mail_notification_checkbox').setProperty('checked', pref.mail_notification_enabled);
+                        $('src_email_txt').setProperty('value', pref.mail_notification_sender);
+                        $('dest_email_txt').setProperty('value', pref.mail_notification_email);
+                        $('smtp_server_txt').setProperty('value', pref.mail_notification_smtp);
+                        $('mail_ssl_checkbox').setProperty('checked', pref.mail_notification_ssl_enabled);
+                        $('mail_auth_checkbox').setProperty('checked', pref.mail_notification_auth_enabled);
+                        $('mail_username_text').setProperty('value', pref.mail_notification_username);
+                        $('mail_password_text').setProperty('value', pref.mail_notification_password);
+                        updateMailNotification();
+                        updateMailAuthSettings();
+
+                        // Run an external program on torrent completion
+                        $('autorun_checkbox').setProperty('checked', pref.autorun_enabled);
+                        $('autorunProg_txt').setProperty('value', pref.autorun_program);
+                        updateAutoRun();
+
+                        // Connection tab
+                        // Listening Port
+                        $('port_value').setProperty('value', pref.listen_port.toInt());
+                        $('upnp_checkbox').setProperty('checked', pref.upnp);
+                        $('random_port_checkbox').setProperty('checked', pref.random_port);
+                        updatePortValueEnabled();
+
+                        // Connections Limits
+                        const max_connec = pref.max_connec.toInt();
+                        if (max_connec <= 0) {
+                            $('max_connec_checkbox').setProperty('checked', false);
+                            $('max_connec_value').setProperty('value', 500);
+                        }
+                        else {
+                            $('max_connec_checkbox').setProperty('checked', true);
+                            $('max_connec_value').setProperty('value', max_connec);
+                        }
+                        updateMaxConnecEnabled();
+                        const max_connec_per_torrent = pref.max_connec_per_torrent.toInt();
+                        if (max_connec_per_torrent <= 0) {
+                            $('max_connec_per_torrent_checkbox').setProperty('checked', false);
+                            $('max_connec_per_torrent_value').setProperty('value', 100);
+                        }
+                        else {
+                            $('max_connec_per_torrent_checkbox').setProperty('checked', true);
+                            $('max_connec_per_torrent_value').setProperty('value', max_connec_per_torrent);
+                        }
+                        updateMaxConnecPerTorrentEnabled();
+                        const max_uploads = pref.max_uploads.toInt();
+                        if (max_uploads <= 0) {
+                            $('max_uploads_checkbox').setProperty('checked', false);
+                            $('max_uploads_value').setProperty('value', 8);
+                        }
+                        else {
+                            $('max_uploads_checkbox').setProperty('checked', true);
+                            $('max_uploads_value').setProperty('value', max_uploads);
+                        }
+                        updateMaxUploadsEnabled();
+                        const max_uploads_per_torrent = pref.max_uploads_per_torrent.toInt();
+                        if (max_uploads_per_torrent <= 0) {
+                            $('max_uploads_per_torrent_checkbox').setProperty('checked', false);
+                            $('max_uploads_per_torrent_value').setProperty('value', 4);
+                        }
+                        else {
+                            $('max_uploads_per_torrent_checkbox').setProperty('checked', true);
+                            $('max_uploads_per_torrent_value').setProperty('value', max_uploads_per_torrent);
+                        }
+                        updateMaxUploadsPerTorrentEnabled();
+
+                        // Proxy Server
+                        switch (pref.proxy_type.toInt()) {
+                            case 5: //SOCKS4
+                                $('peer_proxy_type_select').setProperty('value', 'socks4');
+                                break;
+                            case 2: // SOCKS5
+                            case 4: // SOCKS5_PW
+                                $('peer_proxy_type_select').setProperty('value', 'socks5');
+                                break;
+                            case 1: // HTTP
+                            case 3: // HTTP_PW
+                                $('peer_proxy_type_select').setProperty('value', 'http');
+                                break;
+                            default: // NONE
+                                $('peer_proxy_type_select').setProperty('value', 'none');
+                        }
+                        updatePeerProxySettings();
+                        $('peer_proxy_host_text').setProperty('value', pref.proxy_ip);
+                        $('peer_proxy_port_value').setProperty('value', pref.proxy_port);
+                        $('use_peer_proxy_checkbox').setProperty('checked', pref.proxy_peer_connections);
+                        $('proxy_only_for_torrents_checkbox').setProperty('checked', pref.proxy_torrents_only);
+                        $('peer_proxy_auth_checkbox').setProperty('checked', pref.proxy_auth_enabled);
+                        updatePeerProxyAuthSettings();
+                        $('peer_proxy_username_text').setProperty('value', pref.proxy_username);
+                        $('peer_proxy_password_text').setProperty('value', pref.proxy_password);
+
+                        // IP Filtering
+                        $('ipfilter_enabled_checkbox').setProperty('checked', pref.ip_filter_enabled);
+                        $('ipfilter_text').setProperty('value', pref.ip_filter_path);
+                        $('ipfilter_trackers_checkbox').setProperty('checked', pref.ip_filter_trackers);
+                        $('banned_IPs_textarea').setProperty('value', pref.banned_IPs);
+                        updateFilterSettings();
+
+                        // Speed tab
+                        // Global Rate Limits
+                        $('up_limit_value').setProperty('value', (pref.up_limit.toInt() / 1024));
+                        $('dl_limit_value').setProperty('value', (pref.dl_limit.toInt() / 1024));
+                        // Alternative Global Rate Limits
+                        $('alt_up_limit_value').setProperty('value', (pref.alt_up_limit.toInt() / 1024));
+                        $('alt_dl_limit_value').setProperty('value', (pref.alt_dl_limit.toInt() / 1024));
+
+                        $('enable_protocol_combobox').setProperty('value', pref.bittorrent_protocol);
+                        $('limit_utp_rate_checkbox').setProperty('checked', pref.limit_utp_rate);
+                        $('limit_tcp_overhead_checkbox').setProperty('checked', pref.limit_tcp_overhead);
+                        $('limit_lan_peers_checkbox').setProperty('checked', pref.limit_lan_peers);
+
+                        // Scheduling
+                        $('limit_sheduling_checkbox').setProperty('checked', pref.scheduler_enabled);
+                        $('schedule_from_hour').setProperty('value', time_padding(pref.schedule_from_hour));
+                        $('schedule_from_min').setProperty('value', time_padding(pref.schedule_from_min));
+                        $('schedule_to_hour').setProperty('value', time_padding(pref.schedule_to_hour));
+                        $('schedule_to_min').setProperty('value', time_padding(pref.schedule_to_min));
+                        $('schedule_freq_select').setProperty('value', pref.scheduler_days);
+                        updateSchedulingEnabled();
+
+                        // Bittorrent tab
+                        // Privacy
+                        $('dht_checkbox').setProperty('checked', pref.dht);
+                        $('pex_checkbox').setProperty('checked', pref.pex);
+                        $('lsd_checkbox').setProperty('checked', pref.lsd);
+                        const encryption = pref.encryption.toInt();
+                        $('encryption_select').getChildren('option')[encryption].setAttribute('selected', '');
+                        $('anonymous_mode_checkbox').setProperty('checked', pref.anonymous_mode);
+
+                        // Torrent Queueing
+                        $('queueing_checkbox').setProperty('checked', pref.queueing_enabled);
+                        $('max_active_dl_value').setProperty('value', pref.max_active_downloads.toInt());
+                        $('max_active_up_value').setProperty('value', pref.max_active_uploads.toInt());
+                        $('max_active_to_value').setProperty('value', pref.max_active_torrents.toInt());
+                        $('dont_count_slow_torrents_checkbox').setProperty('checked', pref.dont_count_slow_torrents);
+                        $('dl_rate_threshold').setProperty('value', pref.slow_torrent_dl_rate_threshold.toInt());
+                        $('ul_rate_threshold').setProperty('value', pref.slow_torrent_ul_rate_threshold.toInt());
+                        $('torrent_inactive_timer').setProperty('value', pref.slow_torrent_inactive_timer.toInt());
+                        updateQueueingSystem();
+
+                        // Share Limiting
+                        $('max_ratio_checkbox').setProperty('checked', pref.max_ratio_enabled);
+                        if (pref.max_ratio_enabled)
+                            $('max_ratio_value').setProperty('value', pref.max_ratio);
+                        else
+                            $('max_ratio_value').setProperty('value', 1);
+                        $('max_seeding_time_checkbox').setProperty('checked', pref.max_seeding_time_enabled);
+                        if (pref.max_seeding_time_enabled)
+                            $('max_seeding_time_value').setProperty('value', pref.max_seeding_time.toInt());
+                        else
+                            $('max_seeding_time_value').setProperty('value', 1440);
+                        const max_ratio_act = pref.max_ratio_act.toInt();
+                        $('max_ratio_act').getChildren('option')[max_ratio_act].setAttribute('selected', '');
+                        updateMaxRatioTimeEnabled();
+
+                        // Add trackers
+                        $('add_trackers_checkbox').setProperty('checked', pref.add_trackers_enabled);
+                        $('add_trackers_textarea').setProperty('value', pref.add_trackers);
+                        updateAddTrackersEnabled();
+
+                        // Web UI tab
+                        // Language
+                        $('locale_select').setProperty('value', pref.locale);
+
+                        // HTTP Server
+                        $('webui_domain_textarea').setProperty('value', pref.web_ui_domain_list);
+                        $('webui_address_value').setProperty('value', pref.web_ui_address);
+                        $('webui_port_value').setProperty('value', pref.web_ui_port);
+                        $('webui_upnp_checkbox').setProperty('checked', pref.web_ui_upnp);
+                        $('use_https_checkbox').setProperty('checked', pref.use_https);
+                        $('ssl_cert_text').setProperty('value', pref.web_ui_https_cert_path);
+                        $('ssl_key_text').setProperty('value', pref.web_ui_https_key_path);
+                        updateHttpsSettings();
+
+                        // Authentication
+                        $('webui_username_text').setProperty('value', pref.web_ui_username);
+                        $('bypass_local_auth_checkbox').setProperty('checked', pref.bypass_local_auth);
+                        $('bypass_auth_subnet_whitelist_checkbox').setProperty('checked', pref.bypass_auth_subnet_whitelist_enabled);
+                        $('bypass_auth_subnet_whitelist_textarea').setProperty('value', pref.bypass_auth_subnet_whitelist);
+                        updateBypasssAuthSettings();
+                        $('webUISessionTimeoutInput').setProperty('value', pref.web_ui_session_timeout.toInt());
+
+                        // Use alternative Web UI
+                        $('use_alt_webui_checkbox').setProperty('checked', pref.alternative_webui_enabled);
+                        $('webui_files_location_textarea').setProperty('value', pref.alternative_webui_path);
+                        updateAlternativeWebUISettings();
+
+                        // Security
+                        $('clickjacking_protection_checkbox').setProperty('checked', pref.web_ui_clickjacking_protection_enabled);
+                        $('csrf_protection_checkbox').setProperty('checked', pref.web_ui_csrf_protection_enabled);
+                        $('host_header_validation_checkbox').setProperty('checked', pref.web_ui_host_header_validation_enabled);
+                        updateHostHeaderValidationSettings();
+
+                        // Update my dynamic domain name
+                        $('use_dyndns_checkbox').setProperty('checked', pref.dyndns_enabled);
+                        $('dyndns_select').setProperty('value', pref.dyndns_service);
+                        $('dyndns_domain_text').setProperty('value', pref.dyndns_domain);
+                        $('dyndns_username_text').setProperty('value', pref.dyndns_username);
+                        $('dyndns_password_text').setProperty('value', pref.dyndns_password);
+                        updateDynDnsSettings();
+
+                        // Advanced settings
+                        // qBittorrent section
+                        updateNetworkInterfaces(pref.current_network_interface);
+                        updateInterfaceAddresses(pref.current_network_interface, pref.current_interface_address);
+                        $('listenOnIPv6Address').setProperty('checked', pref.listen_on_ipv6_address);
+                        $('saveResumeDataInterval').setProperty('value', pref.save_resume_data_interval);
+                        $('recheckTorrentsOnCompletion').setProperty('checked', pref.recheck_completed_torrents);
+                        $('resolvePeerCountries').setProperty('checked', pref.resolve_peer_countries);
+                        // libtorrent section
+                        $('asyncIOThreads').setProperty('value', pref.async_io_threads);
+                        $('filePoolSize').setProperty('value', pref.file_pool_size);
+                        $('outstandMemoryWhenCheckingTorrents').setProperty('value', pref.checking_memory_use);
+                        $('diskCache').setProperty('value', pref.disk_cache);
+                        $('diskCacheExpiryInterval').setProperty('value', pref.disk_cache_ttl);
+                        $('enableOSCache').setProperty('checked', pref.enable_os_cache);
+                        $('coalesceReadsAndWrites').setProperty('checked', pref.enable_coalesce_read_write);
+                        $('sendUploadPieceSuggestions').setProperty('checked', pref.enable_upload_suggestions);
+                        $('sendBufferWatermark').setProperty('value', pref.send_buffer_watermark);
+                        $('sendBufferLowWatermark').setProperty('value', pref.send_buffer_low_watermark);
+                        $('sendBufferWatermarkFactor').setProperty('value', pref.send_buffer_watermark_factor);
+                        $('socketBacklogSize').setProperty('value', pref.socket_backlog_size);
+                        $('outgoingPortsMin').setProperty('value', pref.outgoing_ports_min);
+                        $('outgoingPortsMax').setProperty('value', pref.outgoing_ports_max);
+                        $('utpTCPMixedModeAlgorithm').setProperty('value', pref.utp_tcp_mixed_mode);
+                        $('allowMultipleConnectionsFromTheSameIPAddress').setProperty('checked', pref.enable_multi_connections_from_same_ip);
+                        $('enableEmbeddedTracker').setProperty('checked', pref.enable_embedded_tracker);
+                        $('embeddedTrackerPort').setProperty('value', pref.embedded_tracker_port);
+                        $('uploadSlotsBehavior').setProperty('value', pref.upload_slots_behavior);
+                        $('uploadChokingAlgorithm').setProperty('value', pref.upload_choking_algorithm);
+                        $('strictSuperSeeding').setProperty('checked', pref.enable_super_seeding);
+                        $('announceAllTrackers').setProperty('checked', pref.announce_to_all_trackers);
+                        $('announceAllTiers').setProperty('checked', pref.announce_to_all_tiers);
+                        $('announceIP').setProperty('value', pref.announce_ip);
                     }
-                    else {
-                        proxy_type = 1;
+                }
+            }).send();
+        };
+
+        const applyPreferences = function() {
+            const settings = new Hash();
+            // Validate form data
+            // Downloads tab
+            // When adding a torrent
+            settings.set('create_subfolder_enabled', $('createsubfolder_checkbox').getProperty('checked'));
+            settings.set('start_paused_enabled', $('dontstartdownloads_checkbox').getProperty('checked'));
+            settings.set('auto_delete_mode', $('deletetorrentfileafter_checkbox').getProperty('checked'));
+
+            settings.set('preallocate_all', $('preallocateall_checkbox').getProperty('checked'));
+            settings.set('incomplete_files_ext', $('appendext_checkbox').getProperty('checked'));
+
+            // Saving Management
+            settings.set('auto_tmm_enabled', $('default_tmm_combobox').getProperty('value'));
+            settings.set('torrent_changed_tmm_enabled', $('torrent_changed_tmm_combobox').getProperty('value'));
+            settings.set('save_path_changed_tmm_enabled', $('save_path_changed_tmm_combobox').getProperty('value'));
+            settings.set('category_changed_tmm_enabled', $('category_changed_tmm_combobox').getProperty('value'));
+            settings.set('save_path', $('savepath_text').getProperty('value'));
+            settings.set('temp_path_enabled', $('temppath_checkbox').getProperty('checked'));
+            settings.set('temp_path', $('temppath_text').getProperty('value'));
+            if ($('exportdir_checkbox').getProperty('checked'))
+                settings.set('export_dir', $('exportdir_text').getProperty('value'));
+            else
+                settings.set('export_dir', '');
+            if ($('exportdirfin_checkbox').getProperty('checked'))
+                settings.set('export_dir_fin', $('exportdirfin_text').getProperty('value'));
+            else
+                settings.set('export_dir_fin', '');
+
+            // Automatically add torrents from
+            settings.set('scan_dirs', getWatchedFolders());
+
+            // Email notification upon download completion
+            settings.set('mail_notification_enabled', $('mail_notification_checkbox').getProperty('checked'));
+            settings.set('mail_notification_sender', $('src_email_txt').getProperty('value'));
+            settings.set('mail_notification_email', $('dest_email_txt').getProperty('value'));
+            settings.set('mail_notification_smtp', $('smtp_server_txt').getProperty('value'));
+            settings.set('mail_notification_ssl_enabled', $('mail_ssl_checkbox').getProperty('checked'));
+            settings.set('mail_notification_auth_enabled', $('mail_auth_checkbox').getProperty('checked'));
+            settings.set('mail_notification_username', $('mail_username_text').getProperty('value'));
+            settings.set('mail_notification_password', $('mail_password_text').getProperty('value'));
+
+            // Run an external program on torrent completion
+            settings.set('autorun_enabled', $('autorun_checkbox').getProperty('checked'));
+            settings.set('autorun_program', $('autorunProg_txt').getProperty('value'));
+
+            // Connection tab
+            // Listening Port
+            const listen_port = $('port_value').getProperty('value').toInt();
+            if (isNaN(listen_port) || listen_port < 1 || listen_port > 65535) {
+                alert("QBT_TR(The port used for incoming connections must be between 1 and 65535.)QBT_TR[CONTEXT=HttpServer]");
+                return;
+            }
+            settings.set('listen_port', listen_port);
+            settings.set('upnp', $('upnp_checkbox').getProperty('checked'));
+            settings.set('random_port', $('random_port_checkbox').getProperty('checked'));
+
+            // Connections Limits
+            let max_connec = -1;
+            if ($('max_connec_checkbox').getProperty('checked')) {
+                max_connec = $('max_connec_value').getProperty('value').toInt();
+                if (isNaN(max_connec) || max_connec <= 0) {
+                    alert("QBT_TR(Maximum number of connections limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
+                    return;
+                }
+            }
+            settings.set('max_connec', max_connec);
+            let max_connec_per_torrent = -1;
+            if ($('max_connec_per_torrent_checkbox').getProperty('checked')) {
+                max_connec_per_torrent = $('max_connec_per_torrent_value').getProperty('value').toInt();
+                if (isNaN(max_connec_per_torrent) || max_connec_per_torrent <= 0) {
+                    alert("QBT_TR(Maximum number of connections per torrent limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
+                    return;
+                }
+            }
+            settings.set('max_connec_per_torrent', max_connec_per_torrent);
+            let max_uploads = -1;
+            if ($('max_uploads_checkbox').getProperty('checked')) {
+                max_uploads = $('max_uploads_value').getProperty('value').toInt();
+                if (isNaN(max_uploads) || max_uploads <= 0) {
+                    alert("QBT_TR(Global number of upload slots limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
+                    return;
+                }
+            }
+            settings.set('max_uploads', max_uploads);
+            let max_uploads_per_torrent = -1;
+            if ($('max_uploads_per_torrent_checkbox').getProperty('checked')) {
+                max_uploads_per_torrent = $('max_uploads_per_torrent_value').getProperty('value').toInt();
+                if (isNaN(max_uploads_per_torrent) || max_uploads_per_torrent <= 0) {
+                    alert("QBT_TR(Maximum number of upload slots per torrent limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
+                    return;
+                }
+            }
+            settings.set('max_uploads_per_torrent', max_uploads_per_torrent);
+
+            // Proxy Server
+            const proxy_type_str = $('peer_proxy_type_select').getProperty('value');
+            let proxy_type = 0;
+            let proxy_auth_enabled = false;
+            if (proxy_type_str == "socks5") {
+                if ($('peer_proxy_auth_checkbox').getProperty('checked')) {
+                    proxy_type = 4;
+                    proxy_auth_enabled = true;
+                }
+                else {
+                    proxy_type = 2;
+                }
+            }
+            else {
+                if (proxy_type_str == "socks4") {
+                    proxy_type = 5;
+                }
+                else {
+                    if (proxy_type_str == "http") {
+                        if ($('peer_proxy_auth_checkbox').getProperty('checked')) {
+                            proxy_type = 3;
+                            proxy_auth_enabled = true;
+                        }
+                        else {
+                            proxy_type = 1;
+                        }
                     }
                 }
             }
-        }
-        settings.set('proxy_type', proxy_type);
-        settings.set('proxy_auth_enabled', proxy_auth_enabled);
-        settings.set('proxy_ip', $('peer_proxy_host_text').getProperty('value'));
-        settings.set('proxy_port', $('peer_proxy_port_value').getProperty('value').toInt());
-        settings.set('proxy_peer_connections', $('use_peer_proxy_checkbox').getProperty('checked'));
-        settings.set('proxy_torrents_only', $('proxy_only_for_torrents_checkbox').getProperty('checked'));
-        settings.set('proxy_username', $('peer_proxy_username_text').getProperty('value'));
-        settings.set('proxy_password', $('peer_proxy_password_text').getProperty('value'));
+            settings.set('proxy_type', proxy_type);
+            settings.set('proxy_auth_enabled', proxy_auth_enabled);
+            settings.set('proxy_ip', $('peer_proxy_host_text').getProperty('value'));
+            settings.set('proxy_port', $('peer_proxy_port_value').getProperty('value').toInt());
+            settings.set('proxy_peer_connections', $('use_peer_proxy_checkbox').getProperty('checked'));
+            settings.set('proxy_torrents_only', $('proxy_only_for_torrents_checkbox').getProperty('checked'));
+            settings.set('proxy_username', $('peer_proxy_username_text').getProperty('value'));
+            settings.set('proxy_password', $('peer_proxy_password_text').getProperty('value'));
 
-        // IP Filtering
-        settings.set('ip_filter_enabled', $('ipfilter_enabled_checkbox').getProperty('checked'));
-        settings.set('ip_filter_path', $('ipfilter_text').getProperty('value'));
-        settings.set('ip_filter_trackers', $('ipfilter_trackers_checkbox').getProperty('checked'));
-        settings.set('banned_IPs', $('banned_IPs_textarea').getProperty('value'));
+            // IP Filtering
+            settings.set('ip_filter_enabled', $('ipfilter_enabled_checkbox').getProperty('checked'));
+            settings.set('ip_filter_path', $('ipfilter_text').getProperty('value'));
+            settings.set('ip_filter_trackers', $('ipfilter_trackers_checkbox').getProperty('checked'));
+            settings.set('banned_IPs', $('banned_IPs_textarea').getProperty('value'));
 
-        // Speed tab
-        // Global Rate Limits
-        const up_limit = $('up_limit_value').getProperty('value').toInt() * 1024;
-        if (isNaN(up_limit) || up_limit < 0) {
-            alert("QBT_TR(Global upload rate limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
-            return;
-        }
-        settings.set('up_limit', up_limit);
-
-        const dl_limit = $('dl_limit_value').getProperty('value').toInt() * 1024;
-        if (isNaN(dl_limit) || dl_limit < 0) {
-            alert("QBT_TR(Global download rate limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
-            return;
-        }
-        settings.set('dl_limit', dl_limit);
-
-        // Alternative Global Rate Limits
-        const alt_up_limit = $('alt_up_limit_value').getProperty('value').toInt() * 1024;
-        if (isNaN(alt_up_limit) || alt_up_limit < 0) {
-            alert("QBT_TR(Alternative upload rate limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
-            return;
-        }
-        settings.set('alt_up_limit', alt_up_limit);
-
-        const alt_dl_limit = $('alt_dl_limit_value').getProperty('value').toInt() * 1024;
-        if (isNaN(alt_dl_limit) || alt_dl_limit < 0) {
-            alert("QBT_TR(Alternative download rate limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
-            return;
-        }
-        settings.set('alt_dl_limit', alt_dl_limit);
-
-        settings.set('bittorrent_protocol', $('enable_protocol_combobox').getProperty('value'));
-        settings.set('limit_utp_rate', $('limit_utp_rate_checkbox').getProperty('checked'));
-        settings.set('limit_tcp_overhead', $('limit_tcp_overhead_checkbox').getProperty('checked'));
-        settings.set('limit_lan_peers', $('limit_lan_peers_checkbox').getProperty('checked'));
-
-        // Scheduler
-        const scheduling_enabled = $('limit_sheduling_checkbox').getProperty('checked');
-        settings.set('scheduler_enabled', scheduling_enabled);
-        if (scheduling_enabled) {
-            settings.set('schedule_from_hour', $('schedule_from_hour').getProperty('value').toInt());
-            settings.set('schedule_from_min', $('schedule_from_min').getProperty('value').toInt());
-            settings.set('schedule_to_hour', $('schedule_to_hour').getProperty('value').toInt());
-            settings.set('schedule_to_min', $('schedule_to_min').getProperty('value').toInt());
-            settings.set('scheduler_days', $('schedule_freq_select').getProperty('value').toInt());
-        }
-
-        // Bittorrent tab
-        // Privacy
-        settings.set('dht', $('dht_checkbox').getProperty('checked'));
-        settings.set('pex', $('pex_checkbox').getProperty('checked'));
-        settings.set('lsd', $('lsd_checkbox').getProperty('checked'));
-        settings.set('encryption', $('encryption_select').getSelected()[0].getProperty('value'));
-        settings.set('anonymous_mode', $('anonymous_mode_checkbox').getProperty('checked'));
-
-        // Torrent Queueing
-        settings.set('queueing_enabled', $('queueing_checkbox').getProperty('checked'));
-        if ($('queueing_checkbox').getProperty('checked')) {
-            const max_active_downloads = $('max_active_dl_value').getProperty('value').toInt();
-            if (isNaN(max_active_downloads) || max_active_downloads < -1) {
-                alert("QBT_TR(Maximum active downloads must be greater than -1.)QBT_TR[CONTEXT=HttpServer]");
+            // Speed tab
+            // Global Rate Limits
+            const up_limit = $('up_limit_value').getProperty('value').toInt() * 1024;
+            if (isNaN(up_limit) || up_limit < 0) {
+                alert("QBT_TR(Global upload rate limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
                 return;
             }
-            settings.set('max_active_downloads', max_active_downloads);
-            const max_active_uploads = $('max_active_up_value').getProperty('value').toInt();
-            if (isNaN(max_active_uploads) || max_active_uploads < -1) {
-                alert("QBT_TR(Maximum active uploads must be greater than -1.)QBT_TR[CONTEXT=HttpServer]");
+            settings.set('up_limit', up_limit);
+
+            const dl_limit = $('dl_limit_value').getProperty('value').toInt() * 1024;
+            if (isNaN(dl_limit) || dl_limit < 0) {
+                alert("QBT_TR(Global download rate limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
                 return;
             }
-            settings.set('max_active_uploads', max_active_uploads);
-            const max_active_torrents = $('max_active_to_value').getProperty('value').toInt();
-            if (isNaN(max_active_torrents) || max_active_torrents < -1) {
-                alert("QBT_TR(Maximum active torrents must be greater than -1.)QBT_TR[CONTEXT=HttpServer]");
+            settings.set('dl_limit', dl_limit);
+
+            // Alternative Global Rate Limits
+            const alt_up_limit = $('alt_up_limit_value').getProperty('value').toInt() * 1024;
+            if (isNaN(alt_up_limit) || alt_up_limit < 0) {
+                alert("QBT_TR(Alternative upload rate limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
                 return;
             }
-            settings.set('max_active_torrents', max_active_torrents);
-            settings.set('dont_count_slow_torrents', $('dont_count_slow_torrents_checkbox').getProperty('checked'));
-            const dl_rate_threshold = $('dl_rate_threshold').getProperty('value').toInt();
-            if (isNaN(dl_rate_threshold) || (dl_rate_threshold < 1)) {
-                alert("QBT_TR(Download rate threshold must be greater than 0.)QBT_TR[CONTEXT=HttpServer]");
+            settings.set('alt_up_limit', alt_up_limit);
+
+            const alt_dl_limit = $('alt_dl_limit_value').getProperty('value').toInt() * 1024;
+            if (isNaN(alt_dl_limit) || alt_dl_limit < 0) {
+                alert("QBT_TR(Alternative download rate limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
                 return;
             }
-            settings.set('slow_torrent_dl_rate_threshold', dl_rate_threshold);
-            const ul_rate_threshold = $('ul_rate_threshold').getProperty('value').toInt();
-            if (isNaN(ul_rate_threshold) || (ul_rate_threshold < 1)) {
-                alert("QBT_TR(Upload rate threshold must be greater than 0.)QBT_TR[CONTEXT=HttpServer]");
+            settings.set('alt_dl_limit', alt_dl_limit);
+
+            settings.set('bittorrent_protocol', $('enable_protocol_combobox').getProperty('value'));
+            settings.set('limit_utp_rate', $('limit_utp_rate_checkbox').getProperty('checked'));
+            settings.set('limit_tcp_overhead', $('limit_tcp_overhead_checkbox').getProperty('checked'));
+            settings.set('limit_lan_peers', $('limit_lan_peers_checkbox').getProperty('checked'));
+
+            // Scheduler
+            const scheduling_enabled = $('limit_sheduling_checkbox').getProperty('checked');
+            settings.set('scheduler_enabled', scheduling_enabled);
+            if (scheduling_enabled) {
+                settings.set('schedule_from_hour', $('schedule_from_hour').getProperty('value').toInt());
+                settings.set('schedule_from_min', $('schedule_from_min').getProperty('value').toInt());
+                settings.set('schedule_to_hour', $('schedule_to_hour').getProperty('value').toInt());
+                settings.set('schedule_to_min', $('schedule_to_min').getProperty('value').toInt());
+                settings.set('scheduler_days', $('schedule_freq_select').getProperty('value').toInt());
+            }
+
+            // Bittorrent tab
+            // Privacy
+            settings.set('dht', $('dht_checkbox').getProperty('checked'));
+            settings.set('pex', $('pex_checkbox').getProperty('checked'));
+            settings.set('lsd', $('lsd_checkbox').getProperty('checked'));
+            settings.set('encryption', $('encryption_select').getSelected()[0].getProperty('value'));
+            settings.set('anonymous_mode', $('anonymous_mode_checkbox').getProperty('checked'));
+
+            // Torrent Queueing
+            settings.set('queueing_enabled', $('queueing_checkbox').getProperty('checked'));
+            if ($('queueing_checkbox').getProperty('checked')) {
+                const max_active_downloads = $('max_active_dl_value').getProperty('value').toInt();
+                if (isNaN(max_active_downloads) || max_active_downloads < -1) {
+                    alert("QBT_TR(Maximum active downloads must be greater than -1.)QBT_TR[CONTEXT=HttpServer]");
+                    return;
+                }
+                settings.set('max_active_downloads', max_active_downloads);
+                const max_active_uploads = $('max_active_up_value').getProperty('value').toInt();
+                if (isNaN(max_active_uploads) || max_active_uploads < -1) {
+                    alert("QBT_TR(Maximum active uploads must be greater than -1.)QBT_TR[CONTEXT=HttpServer]");
+                    return;
+                }
+                settings.set('max_active_uploads', max_active_uploads);
+                const max_active_torrents = $('max_active_to_value').getProperty('value').toInt();
+                if (isNaN(max_active_torrents) || max_active_torrents < -1) {
+                    alert("QBT_TR(Maximum active torrents must be greater than -1.)QBT_TR[CONTEXT=HttpServer]");
+                    return;
+                }
+                settings.set('max_active_torrents', max_active_torrents);
+                settings.set('dont_count_slow_torrents', $('dont_count_slow_torrents_checkbox').getProperty('checked'));
+                const dl_rate_threshold = $('dl_rate_threshold').getProperty('value').toInt();
+                if (isNaN(dl_rate_threshold) || (dl_rate_threshold < 1)) {
+                    alert("QBT_TR(Download rate threshold must be greater than 0.)QBT_TR[CONTEXT=HttpServer]");
+                    return;
+                }
+                settings.set('slow_torrent_dl_rate_threshold', dl_rate_threshold);
+                const ul_rate_threshold = $('ul_rate_threshold').getProperty('value').toInt();
+                if (isNaN(ul_rate_threshold) || (ul_rate_threshold < 1)) {
+                    alert("QBT_TR(Upload rate threshold must be greater than 0.)QBT_TR[CONTEXT=HttpServer]");
+                    return;
+                }
+                settings.set('slow_torrent_ul_rate_threshold', ul_rate_threshold);
+                const torrent_inactive_timer = $('torrent_inactive_timer').getProperty('value').toInt();
+                if (isNaN(torrent_inactive_timer) || (torrent_inactive_timer < 1)) {
+                    alert("QBT_TR(Torrent inactivity timer must be greater than 0.)QBT_TR[CONTEXT=HttpServer]");
+                    return;
+                }
+                settings.set('slow_torrent_inactive_timer', torrent_inactive_timer);
+            }
+
+            // Share Ratio Limiting
+            let max_ratio = -1;
+            if ($('max_ratio_checkbox').getProperty('checked')) {
+                max_ratio = $('max_ratio_value').getProperty('value');
+                if (isNaN(max_ratio) || max_ratio < 0 || max_ratio > 9998) {
+                    alert("QBT_TR(Share ratio limit must be between 0 and 9998.)QBT_TR[CONTEXT=HttpServer]");
+                    return;
+                }
+            }
+            settings.set('max_ratio_enabled', $('max_ratio_checkbox').getProperty('checked'));
+            settings.set('max_ratio', max_ratio);
+            settings.set('max_ratio_act', $('max_ratio_act').getProperty('value').toInt());
+
+            let max_seeding_time = -1;
+            if ($('max_seeding_time_checkbox').getProperty('checked')) {
+                max_seeding_time = $('max_seeding_time_value').getProperty('value').toInt();
+                if (isNaN(max_seeding_time) || max_seeding_time < 0 || max_seeding_time > 525600) {
+                    alert("QBT_TR(Seeding time limit must be between 0 and 525600 minutes.)QBT_TR[CONTEXT=HttpServer]");
+                    return;
+                }
+            }
+            settings.set('max_seeding_time_enabled', $('max_seeding_time_checkbox').getProperty('checked'));
+            settings.set('max_seeding_time', max_seeding_time);
+            settings.set('max_ratio_act', $('max_ratio_act').getProperty('value').toInt());
+
+            // Add trackers
+            settings.set('add_trackers_enabled', $('add_trackers_checkbox').getProperty('checked'));
+            settings.set('add_trackers', $('add_trackers_textarea').getProperty('value'));
+
+            // Web UI tab
+            // Language
+            settings.set('locale', $('locale_select').getProperty('value'));
+
+            // HTTP Server
+            settings.set('web_ui_domain_list', $('webui_domain_textarea').getProperty('value'));
+            const web_ui_address = $('webui_address_value').getProperty('value').toString();
+            const web_ui_port = $('webui_port_value').getProperty('value').toInt();
+            if (isNaN(web_ui_port) || web_ui_port < 1 || web_ui_port > 65535) {
+                alert("QBT_TR(The port used for the Web UI must be between 1 and 65535.)QBT_TR[CONTEXT=HttpServer]");
                 return;
             }
-            settings.set('slow_torrent_ul_rate_threshold', ul_rate_threshold);
-            const torrent_inactive_timer = $('torrent_inactive_timer').getProperty('value').toInt();
-            if (isNaN(torrent_inactive_timer) || (torrent_inactive_timer < 1)) {
-                alert("QBT_TR(Torrent inactivity timer must be greater than 0.)QBT_TR[CONTEXT=HttpServer]");
+            settings.set('web_ui_address', web_ui_address);
+            settings.set('web_ui_port', web_ui_port);
+            settings.set('web_ui_upnp', $('webui_upnp_checkbox').getProperty('checked'));
+            settings.set('use_https', $('use_https_checkbox').getProperty('checked'));
+            settings.set('web_ui_https_cert_path', $('ssl_cert_text').getProperty('value'));
+            settings.set('web_ui_https_key_path', $('ssl_key_text').getProperty('value'));
+
+            // Authentication
+            const web_ui_username = $('webui_username_text').getProperty('value');
+            if (web_ui_username.length < 3) {
+                alert("QBT_TR(The Web UI username must be at least 3 characters long.)QBT_TR[CONTEXT=OptionsDialog]");
                 return;
             }
-            settings.set('slow_torrent_inactive_timer', torrent_inactive_timer);
-        }
-
-        // Share Ratio Limiting
-        let max_ratio = -1;
-        if ($('max_ratio_checkbox').getProperty('checked')) {
-            max_ratio = $('max_ratio_value').getProperty('value');
-            if (isNaN(max_ratio) || max_ratio < 0 || max_ratio > 9998) {
-                alert("QBT_TR(Share ratio limit must be between 0 and 9998.)QBT_TR[CONTEXT=HttpServer]");
+            const web_ui_password = $('webui_password_text').getProperty('value');
+            if ((0 < web_ui_password.length) && (web_ui_password.length < 6)) {
+                alert("QBT_TR(The Web UI password must be at least 6 characters long.)QBT_TR[CONTEXT=OptionsDialog]");
                 return;
             }
-        }
-        settings.set('max_ratio_enabled', $('max_ratio_checkbox').getProperty('checked'));
-        settings.set('max_ratio', max_ratio);
-        settings.set('max_ratio_act', $('max_ratio_act').getProperty('value').toInt());
 
-        let max_seeding_time = -1;
-        if ($('max_seeding_time_checkbox').getProperty('checked')) {
-            max_seeding_time = $('max_seeding_time_value').getProperty('value').toInt();
-            if (isNaN(max_seeding_time) || max_seeding_time < 0 || max_seeding_time > 525600) {
-                alert("QBT_TR(Seeding time limit must be between 0 and 525600 minutes.)QBT_TR[CONTEXT=HttpServer]");
+            settings.set('web_ui_username', web_ui_username);
+            if (web_ui_password.length > 0)
+                settings.set('web_ui_password', web_ui_password);
+            settings.set('bypass_local_auth', $('bypass_local_auth_checkbox').getProperty('checked'));
+            settings.set('bypass_auth_subnet_whitelist_enabled', $('bypass_auth_subnet_whitelist_checkbox').getProperty('checked'));
+            settings.set('bypass_auth_subnet_whitelist', $('bypass_auth_subnet_whitelist_textarea').getProperty('value'));
+            settings.set('web_ui_session_timeout', $('webUISessionTimeoutInput').getProperty('value'));
+
+            // Use alternative Web UI
+            const alternative_webui_enabled = $('use_alt_webui_checkbox').getProperty('checked');
+            const webui_files_location_textarea = $('webui_files_location_textarea').getProperty('value');
+            if (alternative_webui_enabled && (webui_files_location_textarea.trim() === "")) {
+                alert("QBT_TR(The alternative Web UI files location cannot be blank.)QBT_TR[CONTEXT=OptionsDialog]");
                 return;
             }
-        }
-        settings.set('max_seeding_time_enabled', $('max_seeding_time_checkbox').getProperty('checked'));
-        settings.set('max_seeding_time', max_seeding_time);
-        settings.set('max_ratio_act', $('max_ratio_act').getProperty('value').toInt());
+            settings.set('alternative_webui_enabled', alternative_webui_enabled);
+            settings.set('alternative_webui_path', webui_files_location_textarea);
 
-        // Add trackers
-        settings.set('add_trackers_enabled', $('add_trackers_checkbox').getProperty('checked'));
-        settings.set('add_trackers', $('add_trackers_textarea').getProperty('value'));
+            settings.set('web_ui_clickjacking_protection_enabled', $('clickjacking_protection_checkbox').getProperty('checked'));
+            settings.set('web_ui_csrf_protection_enabled', $('csrf_protection_checkbox').getProperty('checked'));
+            settings.set('web_ui_host_header_validation_enabled', $('host_header_validation_checkbox').getProperty('checked'));
 
-        // Web UI tab
-        // Language
-        settings.set('locale', $('locale_select').getProperty('value'));
+            // Update my dynamic domain name
+            settings.set('dyndns_enabled', $('use_dyndns_checkbox').getProperty('checked'));
+            settings.set('dyndns_service', $('dyndns_select').getProperty('value'));
+            settings.set('dyndns_domain', $('dyndns_domain_text').getProperty('value'));
+            settings.set('dyndns_username', $('dyndns_username_text').getProperty('value'));
+            settings.set('dyndns_password', $('dyndns_password_text').getProperty('value'));
 
-        // HTTP Server
-        settings.set('web_ui_domain_list', $('webui_domain_textarea').getProperty('value'));
-        const web_ui_address = $('webui_address_value').getProperty('value').toString();
-        const web_ui_port = $('webui_port_value').getProperty('value').toInt();
-        if (isNaN(web_ui_port) || web_ui_port < 1 || web_ui_port > 65535) {
-            alert("QBT_TR(The port used for the Web UI must be between 1 and 65535.)QBT_TR[CONTEXT=HttpServer]");
-            return;
-        }
-        settings.set('web_ui_address', web_ui_address);
-        settings.set('web_ui_port', web_ui_port);
-        settings.set('web_ui_upnp', $('webui_upnp_checkbox').getProperty('checked'));
-        settings.set('use_https', $('use_https_checkbox').getProperty('checked'));
-        settings.set('web_ui_https_cert_path', $('ssl_cert_text').getProperty('value'));
-        settings.set('web_ui_https_key_path', $('ssl_key_text').getProperty('value'));
+            // Update advanced settings
+            // qBittorrent section
+            settings.set('current_network_interface', $('networkInterface').getProperty('value'));
+            settings.set('current_interface_address', $('optionalIPAddressToBind').getProperty('value'));
+            settings.set('listen_on_ipv6_address', $('listenOnIPv6Address').getProperty('checked'));
+            settings.set('save_resume_data_interval', $('saveResumeDataInterval').getProperty('value'));
+            settings.set('recheck_completed_torrents', $('recheckTorrentsOnCompletion').getProperty('checked'));
+            settings.set('resolve_peer_countries', $('resolvePeerCountries').getProperty('checked'));
 
-        // Authentication
-        const web_ui_username = $('webui_username_text').getProperty('value');
-        if (web_ui_username.length < 3) {
-            alert("QBT_TR(The Web UI username must be at least 3 characters long.)QBT_TR[CONTEXT=OptionsDialog]");
-            return;
-        }
-        const web_ui_password = $('webui_password_text').getProperty('value');
-        if ((0 < web_ui_password.length) && (web_ui_password.length < 6)) {
-            alert("QBT_TR(The Web UI password must be at least 6 characters long.)QBT_TR[CONTEXT=OptionsDialog]");
-            return;
-        }
+            // libtorrent section
+            settings.set('async_io_threads', $('asyncIOThreads').getProperty('value'));
+            settings.set('file_pool_size', $('filePoolSize').getProperty('value'));
+            settings.set('checking_memory_use', $('outstandMemoryWhenCheckingTorrents').getProperty('value'));
+            settings.set('disk_cache', $('diskCache').getProperty('value'));
+            settings.set('disk_cache_ttl', $('diskCacheExpiryInterval').getProperty('value'));
+            settings.set('enable_os_cache', $('enableOSCache').getProperty('checked'));
+            settings.set('enable_coalesce_read_write', $('coalesceReadsAndWrites').getProperty('checked'));
+            settings.set('enable_upload_suggestions', $('sendUploadPieceSuggestions').getProperty('checked'));
+            settings.set('send_buffer_watermark', $('sendBufferWatermark').getProperty('value'));
+            settings.set('send_buffer_low_watermark', $('sendBufferLowWatermark').getProperty('value'));
+            settings.set('send_buffer_watermark_factor', $('sendBufferWatermarkFactor').getProperty('value'));
+            settings.set('socket_backlog_size', $('socketBacklogSize').getProperty('value'));
+            settings.set('outgoing_ports_min', $('outgoingPortsMin').getProperty('value'));
+            settings.set('outgoing_ports_max', $('outgoingPortsMax').getProperty('value'));
+            settings.set('utp_tcp_mixed_mode', $('utpTCPMixedModeAlgorithm').getProperty('value'));
+            settings.set('enable_multi_connections_from_same_ip', $('allowMultipleConnectionsFromTheSameIPAddress').getProperty('checked'));
+            settings.set('enable_embedded_tracker', $('enableEmbeddedTracker').getProperty('checked'));
+            settings.set('embedded_tracker_port', $('embeddedTrackerPort').getProperty('value'));
+            settings.set('upload_slots_behavior', $('uploadSlotsBehavior').getProperty('value'));
+            settings.set('upload_choking_algorithm', $('uploadChokingAlgorithm').getProperty('value'));
+            settings.set('enable_super_seeding', $('strictSuperSeeding').getProperty('checked'));
+            settings.set('announce_to_all_trackers', $('announceAllTrackers').getProperty('checked'));
+            settings.set('announce_to_all_tiers', $('announceAllTiers').getProperty('checked'));
+            settings.set('announce_ip', $('announceIP').getProperty('value'));
 
-        settings.set('web_ui_username', web_ui_username);
-        if (web_ui_password.length > 0)
-            settings.set('web_ui_password', web_ui_password);
-        settings.set('bypass_local_auth', $('bypass_local_auth_checkbox').getProperty('checked'));
-        settings.set('bypass_auth_subnet_whitelist_enabled', $('bypass_auth_subnet_whitelist_checkbox').getProperty('checked'));
-        settings.set('bypass_auth_subnet_whitelist', $('bypass_auth_subnet_whitelist_textarea').getProperty('value'));
-        settings.set('web_ui_session_timeout', $('webUISessionTimeoutInput').getProperty('value'));
+            // Send it to qBT
+            const json_str = JSON.encode(settings);
 
-        // Use alternative Web UI
-        const alternative_webui_enabled = $('use_alt_webui_checkbox').getProperty('checked');
-        const webui_files_location_textarea = $('webui_files_location_textarea').getProperty('value');
-        if (alternative_webui_enabled && (webui_files_location_textarea.trim() === "")) {
-            alert("QBT_TR(The alternative Web UI files location cannot be blank.)QBT_TR[CONTEXT=OptionsDialog]");
-            return;
-        }
-        settings.set('alternative_webui_enabled', alternative_webui_enabled);
-        settings.set('alternative_webui_path', webui_files_location_textarea);
+            new Request({
+                url: 'api/v2/app/setPreferences',
+                method: 'post',
+                data: {
+                    'json': json_str,
+                },
+                onFailure: function() {
+                    alert("QBT_TR(Unable to save program preferences, qBittorrent is probably unreachable.)QBT_TR[CONTEXT=HttpServer]");
+                    window.parent.closeWindows();
+                },
+                onSuccess: function() {
+                    // Close window
+                    window.parent.location.reload();
+                    window.parent.closeWindows();
+                }
+            }).send();
+        };
 
-        settings.set('web_ui_clickjacking_protection_enabled', $('clickjacking_protection_checkbox').getProperty('checked'));
-        settings.set('web_ui_csrf_protection_enabled', $('csrf_protection_checkbox').getProperty('checked'));
-        settings.set('web_ui_host_header_validation_enabled', $('host_header_validation_checkbox').getProperty('checked'));
+        $('networkInterface').addEvent('change', function() {
+            updateInterfaceAddresses($(this).getProperty('value'), '');
+        });
 
-        // Update my dynamic domain name
-        settings.set('dyndns_enabled', $('use_dyndns_checkbox').getProperty('checked'));
-        settings.set('dyndns_service', $('dyndns_select').getProperty('value'));
-        settings.set('dyndns_domain', $('dyndns_domain_text').getProperty('value'));
-        settings.set('dyndns_username', $('dyndns_username_text').getProperty('value'));
-        settings.set('dyndns_password', $('dyndns_password_text').getProperty('value'));
+        loadPreferences();
 
-        // Update advanced settings
-        // qBittorrent section
-        settings.set('current_network_interface', $('networkInterface').getProperty('value'));
-        settings.set('current_interface_address', $('optionalIPAddressToBind').getProperty('value'));
-        settings.set('listen_on_ipv6_address', $('listenOnIPv6Address').getProperty('checked'));
-        settings.set('save_resume_data_interval', $('saveResumeDataInterval').getProperty('value'));
-        settings.set('recheck_completed_torrents', $('recheckTorrentsOnCompletion').getProperty('checked'));
-        settings.set('resolve_peer_countries', $('resolvePeerCountries').getProperty('checked'));
-
-        // libtorrent section
-        settings.set('async_io_threads', $('asyncIOThreads').getProperty('value'));
-        settings.set('file_pool_size', $('filePoolSize').getProperty('value'));
-        settings.set('checking_memory_use', $('outstandMemoryWhenCheckingTorrents').getProperty('value'));
-        settings.set('disk_cache', $('diskCache').getProperty('value'));
-        settings.set('disk_cache_ttl', $('diskCacheExpiryInterval').getProperty('value'));
-        settings.set('enable_os_cache', $('enableOSCache').getProperty('checked'));
-        settings.set('enable_coalesce_read_write', $('coalesceReadsAndWrites').getProperty('checked'));
-        settings.set('enable_upload_suggestions', $('sendUploadPieceSuggestions').getProperty('checked'));
-        settings.set('send_buffer_watermark', $('sendBufferWatermark').getProperty('value'));
-        settings.set('send_buffer_low_watermark', $('sendBufferLowWatermark').getProperty('value'));
-        settings.set('send_buffer_watermark_factor', $('sendBufferWatermarkFactor').getProperty('value'));
-        settings.set('socket_backlog_size', $('socketBacklogSize').getProperty('value'));
-        settings.set('outgoing_ports_min', $('outgoingPortsMin').getProperty('value'));
-        settings.set('outgoing_ports_max', $('outgoingPortsMax').getProperty('value'));
-        settings.set('utp_tcp_mixed_mode', $('utpTCPMixedModeAlgorithm').getProperty('value'));
-        settings.set('enable_multi_connections_from_same_ip', $('allowMultipleConnectionsFromTheSameIPAddress').getProperty('checked'));
-        settings.set('enable_embedded_tracker', $('enableEmbeddedTracker').getProperty('checked'));
-        settings.set('embedded_tracker_port', $('embeddedTrackerPort').getProperty('value'));
-        settings.set('upload_slots_behavior', $('uploadSlotsBehavior').getProperty('value'));
-        settings.set('upload_choking_algorithm', $('uploadChokingAlgorithm').getProperty('value'));
-        settings.set('enable_super_seeding', $('strictSuperSeeding').getProperty('checked'));
-        settings.set('announce_to_all_trackers', $('announceAllTrackers').getProperty('checked'));
-        settings.set('announce_to_all_tiers', $('announceAllTiers').getProperty('checked'));
-        settings.set('announce_ip', $('announceIP').getProperty('value'));
-
-        // Send it to qBT
-        const json_str = JSON.encode(settings);
-
-        new Request({
-            url: 'api/v2/app/setPreferences',
-            method: 'post',
-            data: {
-                'json': json_str,
-            },
-            onFailure: function() {
-                alert("QBT_TR(Unable to save program preferences, qBittorrent is probably unreachable.)QBT_TR[CONTEXT=HttpServer]");
-                window.parent.closeWindows();
-            },
-            onSuccess: function() {
-                // Close window
-                window.parent.location.reload();
-                window.parent.closeWindows();
-            }
-        }).send();
-    };
-
-    $('networkInterface').addEvent('change', function() {
-        updateInterfaceAddresses($(this).getProperty('value'), '');
-    });
-
-    loadPreferences();
+        return exports();
+    })();
 </script>

--- a/src/webui/www/private/views/preferencesToolbar.html
+++ b/src/webui/www/private/views/preferencesToolbar.html
@@ -14,31 +14,33 @@
 <script>
     'use strict';
 
-    // Tabs
-    MochaUI.initializeTabs('preferencesTabs');
+    (function() {
+        // Tabs
+        MochaUI.initializeTabs('preferencesTabs');
 
-    $('PrefDownloadsLink').addEvent('click', function(e) {
-        $$('.PrefTab').addClass('invisible');
-        $('DownloadsTab').removeClass('invisible');
-    });
-    $('PrefConnectionLink').addEvent('click', function(e) {
-        $$('.PrefTab').addClass('invisible');
-        $('ConnectionTab').removeClass('invisible');
-    });
-    $('PrefSpeedLink').addEvent('click', function(e) {
-        $$('.PrefTab').addClass('invisible');
-        $('SpeedTab').removeClass('invisible');
-    });
-    $('PrefBittorrentLink').addEvent('click', function(e) {
-        $$('.PrefTab').addClass('invisible');
-        $('BittorrentTab').removeClass('invisible');
-    });
-    $('PrefWebUILink').addEvent('click', function(e) {
-        $$('.PrefTab').addClass('invisible');
-        $('WebUITab').removeClass('invisible');
-    });
-    $('PrefAdvancedLink').addEvent('click', function(e) {
-        $$('.PrefTab').addClass('invisible');
-        $('AdvancedTab').removeClass('invisible');
-    });
+        $('PrefDownloadsLink').addEvent('click', function(e) {
+            $$('.PrefTab').addClass('invisible');
+            $('DownloadsTab').removeClass('invisible');
+        });
+        $('PrefConnectionLink').addEvent('click', function(e) {
+            $$('.PrefTab').addClass('invisible');
+            $('ConnectionTab').removeClass('invisible');
+        });
+        $('PrefSpeedLink').addEvent('click', function(e) {
+            $$('.PrefTab').addClass('invisible');
+            $('SpeedTab').removeClass('invisible');
+        });
+        $('PrefBittorrentLink').addEvent('click', function(e) {
+            $$('.PrefTab').addClass('invisible');
+            $('BittorrentTab').removeClass('invisible');
+        });
+        $('PrefWebUILink').addEvent('click', function(e) {
+            $$('.PrefTab').addClass('invisible');
+            $('WebUITab').removeClass('invisible');
+        });
+        $('PrefAdvancedLink').addEvent('click', function(e) {
+            $$('.PrefTab').addClass('invisible');
+            $('AdvancedTab').removeClass('invisible');
+        });
+    })();
 </script>

--- a/src/webui/www/private/views/properties.html
+++ b/src/webui/www/private/views/properties.html
@@ -155,7 +155,9 @@
 <script>
     'use strict';
 
-    const selectedTab = $(LocalPreferences.get('selected_tab', 'PropGeneralLink'));
-    if (selectedTab)
-        selectedTab.click();
+    (function() {
+        const selectedTab = $(LocalPreferences.get('selected_tab', 'PropGeneralLink'));
+        if (selectedTab)
+            selectedTab.click();
+    })();
 </script>

--- a/src/webui/www/private/views/search.html
+++ b/src/webui/www/private/views/search.html
@@ -59,9 +59,9 @@
     <div style="overflow: hidden; height: 70px;">
         <div style="margin: 20px 0; height: 30px;">
             <input type="text" id="searchPattern" class="searchInputField" placeholder="QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]" autocorrect="off" autocapitalize="none" />
-            <select id="categorySelect" class="searchInputField" onchange="categorySelected()"></select>
-            <select id="pluginsSelect" class="searchInputField" onchange="pluginSelected()"></select>
-            <button id="startSearchButton" class="searchInputField" onclick="startStopSearch()">QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]</button>
+            <select id="categorySelect" class="searchInputField" onchange="qBittorrent.Search.categorySelected()"></select>
+            <select id="pluginsSelect" class="searchInputField" onchange="qBittorrent.Search.pluginSelected()"></select>
+            <button id="startSearchButton" class="searchInputField" onclick="qBittorrent.Search.startStopSearch()">QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]</button>
         </div>
     </div>
 
@@ -85,19 +85,19 @@
 
         <div style="display: inline-block; float: right;">
             <label for="searchInTorrentName" style="margin-left: 15px;">QBT_TR(Search in:)QBT_TR[CONTEXT=SearchEngineWidget]</label>
-            <select id="searchInTorrentName" onchange="searchInTorrentName()">
+            <select id="searchInTorrentName" onchange="qBittorrent.Search.searchInTorrentName()">
                 <option value="names">QBT_TR(Torrent names only)QBT_TR[CONTEXT=SearchEngineWidget]</option>
                 <option value="everywhere">QBT_TR(Everywhere)QBT_TR[CONTEXT=SearchEngineWidget]</option>
             </select>
 
             <span style="margin-left: 15px;">QBT_TR(Seeds:)QBT_TR[CONTEXT=SearchEngineWidget]</span>
-            <input type="number" min="0" max="1000" id="searchMinSeedsFilter" value="0" onchange="searchSeedsFilterChanged()">
+            <input type="number" min="0" max="1000" id="searchMinSeedsFilter" value="0" onchange="qBittorrent.Search.searchSeedsFilterChanged()">
             <span>to</span>
-            <input type="number" min="0" max="1000" id="searchMaxSeedsFilter" value="0" onchange="searchSeedsFilterChanged()">
+            <input type="number" min="0" max="1000" id="searchMaxSeedsFilter" value="0" onchange="qBittorrent.Search.searchSeedsFilterChanged()">
 
             <span style="margin-left: 15px;">QBT_TR(Size:)QBT_TR[CONTEXT=SearchEngineWidget]</span>
-            <input type="number" min="0" max="1000" step=".01" value="0.00" id="searchMinSizeFilter" onchange="searchSizeFilterChanged()">
-            <select id="searchMinSizePrefix" onchange="searchSizeFilterPrefixChanged()">
+            <input type="number" min="0" max="1000" step=".01" value="0.00" id="searchMinSizeFilter" onchange="qBittorrent.Search.searchSizeFilterChanged()">
+            <select id="searchMinSizePrefix" onchange="qBittorrent.Search.searchSizeFilterPrefixChanged()">
                 <option value="0">QBT_TR(B)QBT_TR[CONTEXT=misc]</option>
                 <option value="1">QBT_TR(KiB)QBT_TR[CONTEXT=misc]</option>
                 <option value="2" selected>QBT_TR(MiB)QBT_TR[CONTEXT=misc]</option>
@@ -107,8 +107,8 @@
                 <option value="6">QBT_TR(EiB)QBT_TR[CONTEXT=misc]</option>
             </select>
             <span>to</span>
-            <input type="number" min="0" max="1000" step=".01" value="0.00" id="searchMaxSizeFilter" onchange="searchSizeFilterChanged()">
-            <select id="searchMaxSizePrefix" onchange="searchSizeFilterPrefixChanged()">
+            <input type="number" min="0" max="1000" step=".01" value="0.00" id="searchMaxSizeFilter" onchange="qBittorrent.Search.searchSizeFilterChanged()">
+            <select id="searchMaxSizePrefix" onchange="qBittorrent.Search.searchSizeFilterPrefixChanged()">
                 <option value="0">QBT_TR(B)QBT_TR[CONTEXT=misc]</option>
                 <option value="1">QBT_TR(KiB)QBT_TR[CONTEXT=misc]</option>
                 <option value="2" selected>QBT_TR(MiB)QBT_TR[CONTEXT=misc]</option>
@@ -139,7 +139,7 @@
     </div>
 
     <div style="height: 30px; padding-top: 10px;">
-        <button id="manageSearchPlugins" onclick="manageSearchPlugins()">QBT_TR(Search plugins...)QBT_TR[CONTEXT=SearchEngineWidget]</button>
+        <button id="manageSearchPlugins" onclick="qBittorrent.Search.manageSearchPlugins()">QBT_TR(Search plugins...)QBT_TR[CONTEXT=SearchEngineWidget]</button>
     </div>
 </div>
 
@@ -159,521 +159,554 @@
 <script>
     'use strict';
 
-    let loadSearchResultsTimer;
-    let loadSearchPluginsTimer;
-    let searchResultsRowId = 0;
-    let searchRunning = false;
-    let requestCount = 0;
-    let searchPlugins = [];
-    let prevSearchPluginsResponse;
-    let searchPattern = "";
-    let searchFilterPattern = "";
-    const searchSeedsFilter = {
-        min: 0,
-        max: 0
-    };
-    const searchSizeFilter = {
-        min: 0.00,
-        minUnit: 2, // B = 0, KiB = 1, MiB = 2, GiB = 3, TiB = 4, PiB = 5, EiB = 6
-        max: 0.00,
-        maxUnit: 3
-    };
-    let prevNameFilterValue;
-    let selectedCategory = "QBT_TR(All categories)QBT_TR[CONTEXT=SearchEngineWidget]";
-    let selectedPlugin = "all";
-    let prevSelectedPlugin;
-    let activeSearchId = null;
+    if (window.qBittorrent === undefined) {
+        window.qBittorrent = {};
+    }
 
-    const initSearchTab = function() {
-        // load "Search in" preference from local storage
-        $('searchInTorrentName').set('value', (LocalPreferences.get('search_in_filter') === "names") ? "names" : "everywhere");
-        const searchResultsTableContextMenu = new ContextMenu({
-            targets: '.searchTableRow',
-            menu: 'searchResultsTableMenu',
-            actions: {
-                Download: downloadSearchTorrent,
-                OpenDescriptionUrl: openSearchTorrentDescriptionUrl
-            },
-            offsets: {
-                x: -15,
-                y: -53
-            }
-        });
-        searchResultsTable.setup('searchResultsTableDiv', 'searchResultsTableFixedHeaderDiv', searchResultsTableContextMenu);
-        getPlugins();
-
-        let searchInNameFilterTimer = null;
-        // listen for changes to searchInNameFilter
-        $('searchInNameFilter').addEvent('input', function() {
-            const value = $('searchInNameFilter').get("value");
-            if (value !== prevNameFilterValue) {
-                prevNameFilterValue = value;
-                clearTimeout(searchInNameFilterTimer);
-                searchInNameFilterTimer = setTimeout(function() {
-                    searchFilterPattern = value;
-                    searchFilterChanged();
-                }, 400);
-            }
-        });
-
-        new Keyboard({
-            defaultEventType: 'keydown',
-            events: {
-                'Enter': function(e) {
-                    // accept enter key as a click
-                    new Event(e).stop();
-
-                    const elem = e.event.srcElement;
-                    if (elem.className.contains("searchInputField")) {
-                        $('startSearchButton').click();
-                        return;
-                    }
-
-                    switch (elem.id) {
-                        case "manageSearchPlugins":
-                            manageSearchPlugins();
-                            break;
-                    }
-                }
-            }
-        }).activate();
-    };
-
-    const startSearch = function(pattern, category, plugins) {
-        clearTimeout(loadSearchResultsTimer);
-        searchResultsTable.clear();
-        $('numSearchResultsVisible').set('html', searchResultsTable.getFilteredAndSortedRows().length);
-        $('numSearchResultsTotal').set('html', searchResultsTable.getRowIds().length);
-        searchResultsRowId = 0;
-        requestCount = 0;
-
-        const url = new URI('api/v2/search/start');
-        new Request.JSON({
-            url: url,
-            noCache: true,
-            method: 'post',
-            data: {
-                pattern: pattern,
-                category: category,
-                plugins: plugins
-            },
-            onSuccess: function(response) {
-                $('startSearchButton').set('text', 'QBT_TR(Stop)QBT_TR[CONTEXT=SearchEngineWidget]');
-                searchRunning = true;
-                activeSearchId = response.id;
-                updateSearchResultsData();
-            }
-        }).send();
-    };
-
-    const stopSearch = function() {
-        const url = new URI('api/v2/search/stop');
-        new Request({
-            url: url,
-            noCache: true,
-            method: 'post',
-            data: {
-                id: activeSearchId
-            },
-            onSuccess: function(response) {
-                resetSearchState();
-            }
-        }).send();
-    };
-
-    const startStopSearch = function() {
-        if (!searchRunning || !activeSearchId) {
-            const pattern = $('searchPattern').getProperty('value').trim();
-            let category = $('categorySelect').getProperty('value');
-            const plugins = $('pluginsSelect').getProperty('value');
-
-            if (!pattern || !category || !plugins) return;
-            if (category === "QBT_TR(All categories)QBT_TR[CONTEXT=SearchEngineWidget]")
-                category = "all";
-
-            resetFilters();
-
-            searchPattern = pattern;
-            startSearch(pattern, category, plugins);
-        }
-        else {
-            stopSearch();
-        }
-    };
-
-    const openSearchTorrentDescriptionUrl = function() {
-        searchResultsTable.selectedRowsIds().each(function(rowId) {
-            window.open(searchResultsTable.rows.get(rowId).full_data.descrLink, "_blank");
-        });
-    };
-
-    const copySearchTorrentName = function() {
-        const names = [];
-        searchResultsTable.selectedRowsIds().each(function(rowId) {
-            names.push(searchResultsTable.rows.get(rowId).full_data.fileName);
-        });
-        return names.join("\n");
-    };
-
-    const copySearchTorrentDownloadLink = function() {
-        const urls = [];
-        searchResultsTable.selectedRowsIds().each(function(rowId) {
-            urls.push(searchResultsTable.rows.get(rowId).full_data.fileUrl);
-        });
-        return urls.join("\n");
-    };
-
-    const copySearchTorrentDescriptionUrl = function() {
-        const urls = [];
-        searchResultsTable.selectedRowsIds().each(function(rowId) {
-            urls.push(searchResultsTable.rows.get(rowId).full_data.descrLink);
-        });
-        return urls.join("\n");
-    };
-
-    const downloadSearchTorrent = function() {
-        const urls = [];
-        searchResultsTable.selectedRowsIds().each(function(rowId) {
-            urls.push(encodeURIComponent(searchResultsTable.rows.get(rowId).full_data.fileUrl));
-        });
-
-        // only proceed if at least 1 row was selected
-        if (!urls.length) return;
-
-        showDownloadPage(urls);
-    };
-
-    const manageSearchPlugins = function() {
-        const id = 'searchPlugins';
-        if (!$(id))
-            new MochaUI.Window({
-                id: id,
-                title: "QBT_TR(Search plugins)QBT_TR[CONTEXT=PluginSelectDlg]",
-                loadMethod: 'xhr',
-                contentURL: 'views/searchplugins.html',
-                scrollbars: false,
-                maximizable: false,
-                paddingVertical: 0,
-                paddingHorizontal: 0,
-                width: loadWindowWidth(id, 600),
-                height: loadWindowHeight(id, 360),
-                onResize: function() {
-                    saveWindowSize(id);
-                },
-                onBeforeBuild: function() {
-                    loadSearchPlugins();
-                },
-                onClose: function() {
-                    clearTimeout(loadSearchPluginsTimer);
-                }
-            });
-    };
-
-    const loadSearchPlugins = function() {
-        getPlugins();
-        loadSearchPluginsTimer = loadSearchPlugins.delay(2000);
-    };
-
-    const categorySelected = function() {
-        selectedCategory = $("categorySelect").get("value");
-    };
-
-    const pluginSelected = function() {
-        selectedPlugin = $("pluginsSelect").get("value");
-
-        if (selectedPlugin !== prevSelectedPlugin) {
-            prevSelectedPlugin = selectedPlugin;
-            getSearchCategories();
-        }
-    };
-
-    const reselectCategory = function() {
-        for (let i = 0; i < $("categorySelect").options.length; ++i)
-            if ($("categorySelect").options[i].get("value") === selectedCategory)
-                $("categorySelect").options[i].selected = true;
-
-        categorySelected();
-    };
-
-    const reselectPlugin = function() {
-        for (let i = 0; i < $("pluginsSelect").options.length; ++i)
-            if ($("pluginsSelect").options[i].get("value") === selectedPlugin)
-                $("pluginsSelect").options[i].selected = true;
-
-        pluginSelected();
-    };
-
-    const resetSearchState = function() {
-        clearTimeout(loadSearchResultsTimer);
-        $('startSearchButton').set('text', 'QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]');
-        searchResultsRowId = 0;
-        searchRunning = false;
-        activeSearchId = null;
-    };
-
-    const getSearchCategories = function() {
-        const populateCategorySelect = function(categories) {
-            const categoryHtml = [];
-            categories.each(function(category) {
-                categoryHtml.push("<option>" + category + "</option>");
-            });
-
-            // first category is "All Categories"
-            if (categoryHtml.length > 1)
-                // add separator
-                categoryHtml.splice(1, 0, "<option disabled>──────────</option>");
-
-            $('categorySelect').set('html', categoryHtml.join(""));
+    window.qBittorrent.Search = (function() {
+        const exports = function() {
+            return {
+                startStopSearch: startStopSearch,
+                manageSearchPlugins: manageSearchPlugins,
+                searchPlugins: searchPlugins,
+                searchText: searchText,
+                searchSeedsFilter: searchSeedsFilter,
+                searchSizeFilter: searchSizeFilter,
+                init: init,
+                getPlugin: getPlugin,
+                searchInTorrentName: searchInTorrentName,
+                categorySelected: categorySelected,
+                pluginSelected: pluginSelected,
+                searchSeedsFilterChanged: searchSeedsFilterChanged,
+                searchSizeFilterChanged: searchSizeFilterChanged,
+                searchSizeFilterPrefixChanged: searchSizeFilterPrefixChanged
+            };
         };
 
-        const selectedPlugin = $('pluginsSelect').get("value");
-        if ((selectedPlugin === "all") || (selectedPlugin === "enabled")) {
-            const url = new URI('api/v2/search/categories');
-            url.setData('name', selectedPlugin);
+        let searchResultsTable;
+        let loadSearchResultsTimer;
+        let loadSearchPluginsTimer;
+        let searchResultsRowId = 0;
+        let searchRunning = false;
+        let requestCount = 0;
+        const searchPlugins = [];
+        let prevSearchPluginsResponse;
+        const searchText = {
+            pattern: "",
+            filterPattern: ""
+        };
+        const searchSeedsFilter = {
+            min: 0,
+            max: 0
+        };
+        const searchSizeFilter = {
+            min: 0.00,
+            minUnit: 2, // B = 0, KiB = 1, MiB = 2, GiB = 3, TiB = 4, PiB = 5, EiB = 6
+            max: 0.00,
+            maxUnit: 3
+        };
+        let prevNameFilterValue;
+        let selectedCategory = "QBT_TR(All categories)QBT_TR[CONTEXT=SearchEngineWidget]";
+        let selectedPlugin = "all";
+        let prevSelectedPlugin;
+        let activeSearchId = null;
+
+        const init = function() {
+            // load "Search in" preference from local storage
+            $('searchInTorrentName').set('value', (LocalPreferences.get('search_in_filter') === "names") ? "names" : "everywhere");
+            const searchResultsTableContextMenu = new window.qBittorrent.ContextMenu.ContextMenu({
+                targets: '.searchTableRow',
+                menu: 'searchResultsTableMenu',
+                actions: {
+                    Download: downloadSearchTorrent,
+                    OpenDescriptionUrl: openSearchTorrentDescriptionUrl
+                },
+                offsets: {
+                    x: -15,
+                    y: -53
+                }
+            });
+            searchResultsTable = new window.qBittorrent.DynamicTable.SearchResultsTable();
+            searchResultsTable.setup('searchResultsTableDiv', 'searchResultsTableFixedHeaderDiv', searchResultsTableContextMenu);
+            getPlugins();
+
+            let searchInNameFilterTimer = null;
+            // listen for changes to searchInNameFilter
+            $('searchInNameFilter').addEvent('input', function() {
+                const value = $('searchInNameFilter').get("value");
+                if (value !== prevNameFilterValue) {
+                    prevNameFilterValue = value;
+                    clearTimeout(searchInNameFilterTimer);
+                    searchInNameFilterTimer = setTimeout(function() {
+                        searchText.filterPattern = value;
+                        searchFilterChanged();
+                    }, 400);
+                }
+            });
+
+            new Keyboard({
+                defaultEventType: 'keydown',
+                events: {
+                    'Enter': function(e) {
+                        // accept enter key as a click
+                        new Event(e).stop();
+
+                        const elem = e.event.srcElement;
+                        if (elem.className.contains("searchInputField")) {
+                            $('startSearchButton').click();
+                            return;
+                        }
+
+                        switch (elem.id) {
+                            case "manageSearchPlugins":
+                                manageSearchPlugins();
+                                break;
+                        }
+                    }
+                }
+            }).activate();
+        };
+
+        const startSearch = function(pattern, category, plugins) {
+            clearTimeout(loadSearchResultsTimer);
+            searchResultsTable.clear();
+            $('numSearchResultsVisible').set('html', searchResultsTable.getFilteredAndSortedRows().length);
+            $('numSearchResultsTotal').set('html', searchResultsTable.getRowIds().length);
+            searchResultsRowId = 0;
+            requestCount = 0;
+
+            const url = new URI('api/v2/search/start');
             new Request.JSON({
                 url: url,
                 noCache: true,
-                method: 'get',
+                method: 'post',
+                data: {
+                    pattern: pattern,
+                    category: category,
+                    plugins: plugins
+                },
                 onSuccess: function(response) {
-                    populateCategorySelect(response);
+                    $('startSearchButton').set('text', 'QBT_TR(Stop)QBT_TR[CONTEXT=SearchEngineWidget]');
+                    searchRunning = true;
+                    activeSearchId = response.id;
+                    updateSearchResultsData();
                 }
             }).send();
-        }
-        else {
-            let plugins = ["QBT_TR(All categories)QBT_TR[CONTEXT=SearchEngineWidget]"];
-            const plugin = getPlugin(selectedPlugin);
-            if (plugin !== null)
-                plugins = plugins.concat(plugin.supportedCategories);
+        };
 
-            populateCategorySelect(plugins);
-        }
-
-        reselectCategory();
-    };
-
-    const getPlugins = function() {
-        new Request.JSON({
-            url: new URI('api/v2/search/plugins'),
-            noCache: true,
-            method: 'get',
-            onSuccess: function(response) {
-                if (response !== prevSearchPluginsResponse) {
-                    prevSearchPluginsResponse = response;
-                    searchPlugins = response;
-
-                    const pluginsHtml = [];
-                    pluginsHtml.push('<option value="enabled">QBT_TR(Only enabled)QBT_TR[CONTEXT=SearchEngineWidget]</option>');
-                    pluginsHtml.push('<option value="all">QBT_TR(All plugins)QBT_TR[CONTEXT=SearchEngineWidget]</option>');
-
-                    const searchPluginsEmpty = (searchPlugins.length === 0);
-                    if (searchPluginsEmpty) {
-                        $('searchResultsNoPlugins').style.display = "block";
-                        $('searchResultsFilters').style.display = "none";
-                        $('searchResultsTableContainer').style.display = "none";
-                    }
-                    else {
-                        $('searchResultsNoPlugins').style.display = "none";
-                        $('searchResultsFilters').style.display = "block";
-                        $('searchResultsTableContainer').style.display = "block";
-
-                        // sort plugins alphabetically
-                        const allPlugins = searchPlugins.sort(function(pluginA, pluginB) {
-                            const a = pluginA.fullName.toLowerCase();
-                            const b = pluginB.fullName.toLowerCase();
-                            if (a < b) return -1;
-                            if (a > b) return 1;
-                            return 0;
-                        });
-
-                        allPlugins.each(function(plugin) {
-                            if (plugin.enabled === true)
-                                pluginsHtml.push("<option value='" + escapeHtml(plugin.name) + "'>" + escapeHtml(plugin.fullName) + "</option>");
-                        });
-
-                        if (pluginsHtml.length > 2)
-                            pluginsHtml.splice(2, 0, "<option disabled>──────────</option>");
-                    }
-
-                    $('pluginsSelect').set('html', pluginsHtml.join(""));
-
-                    $('searchPattern').setProperty('disabled', searchPluginsEmpty);
-                    $('categorySelect').setProperty('disabled', searchPluginsEmpty);
-                    $('pluginsSelect').setProperty('disabled', searchPluginsEmpty);
-                    $('startSearchButton').setProperty('disabled', searchPluginsEmpty);
-
-                    if (typeof updateSearchPluginsTable === "function")
-                        updateSearchPluginsTable();
-
-                    reselectPlugin();
-                }
-            }
-        }).send();
-    };
-
-    const getPlugin = function(name) {
-        for (let i = 0; i < searchPlugins.length; ++i)
-            if (searchPlugins[i].name === name)
-                return searchPlugins[i];
-
-        return null;
-    };
-
-    const searchInTorrentName = function() {
-        if ($('searchInTorrentName').get('value') === "names")
-            LocalPreferences.set('search_in_filter', "names");
-        else
-            LocalPreferences.set('search_in_filter', "everywhere");
-
-        searchFilterChanged();
-    };
-
-    const resetFilters = function() {
-        // reset filters
-        $('searchMinSeedsFilter').set('value', '0');
-        $('searchMaxSeedsFilter').set('value', '0');
-        $('searchMinSizeFilter').set('value', '0.00');
-        $('searchMinSizePrefix').set('value', '2'); // MiB
-        $('searchMaxSizeFilter').set('value', '0.00');
-        $('searchMaxSizePrefix').set('value', '3'); // GiB
-    };
-
-    const searchSeedsFilterChanged = function() {
-        searchSeedsFilter.min = $('searchMinSeedsFilter').get('value');
-        searchSeedsFilter.max = $('searchMaxSeedsFilter').get('value');
-
-        searchFilterChanged();
-    };
-
-    const searchSizeFilterChanged = function() {
-        searchSizeFilter.min = $('searchMinSizeFilter').get('value');
-        searchSizeFilter.minUnit = $('searchMinSizePrefix').get('value');
-        searchSizeFilter.max = $('searchMaxSizeFilter').get('value');
-        searchSizeFilter.maxUnit = $('searchMaxSizePrefix').get('value');
-
-        searchFilterChanged();
-    };
-
-    const searchSizeFilterPrefixChanged = function() {
-        if (($('searchMinSizeFilter').get('value') != 0) || ($('searchMaxSizeFilter').get('value') != 0))
-            searchSizeFilterChanged();
-    };
-
-    const searchFilterChanged = function() {
-        searchResultsTable.updateTable();
-        $('numSearchResultsVisible').set('html', searchResultsTable.getFilteredAndSortedRows().length);
-    };
-
-    const setupSearchTableEvents = function(enable) {
-        if (enable)
-            $$(".searchTableRow").each(function(target) {
-                target.addEventListener('dblclick', downloadSearchTorrent, false);
-            });
-        else
-            $$(".searchTableRow").each(function(target) {
-                target.removeEventListener('dblclick', downloadSearchTorrent, false);
-            });
-    };
-
-    const loadSearchResultsData = function() {
-        const maxResults = 500;
-        const url = new URI('api/v2/search/results');
-        new Request.JSON({
-            url: url,
-            noCache: true,
-            method: 'post',
-            data: {
-                id: activeSearchId,
-                limit: maxResults,
-                offset: searchResultsRowId
-            },
-            onFailure: function(response) {
-                if (response.status === 400) {
-                    // bad params. search id is invalid
+        const stopSearch = function() {
+            const url = new URI('api/v2/search/stop');
+            new Request({
+                url: url,
+                noCache: true,
+                method: 'post',
+                data: {
+                    id: activeSearchId
+                },
+                onSuccess: function(response) {
                     resetSearchState();
                 }
-                else {
-                    clearTimeout(loadSearchResultsTimer);
-                    loadSearchResultsTimer = loadSearchResultsData.delay(3000);
-                }
-            },
-            onSuccess: function(response) {
-                $('error_div').set('html', '');
+            }).send();
+        };
 
-                // check if user stopped the search prior to receiving the response
-                if (!searchRunning) {
-                    clearTimeout(loadSearchResultsTimer);
-                    searchResultsRowId = 0;
-                    return;
-                }
+        const startStopSearch = function() {
+            if (!searchRunning || !activeSearchId) {
+                const pattern = $('searchPattern').getProperty('value').trim();
+                let category = $('categorySelect').getProperty('value');
+                const plugins = $('pluginsSelect').getProperty('value');
 
-                if (response) {
-                    setupSearchTableEvents(false);
+                if (!pattern || !category || !plugins) return;
+                if (category === "QBT_TR(All categories)QBT_TR[CONTEXT=SearchEngineWidget]")
+                    category = "all";
 
-                    if (response.results) {
-                        const results = response.results;
-                        for (let i = 0; i < results.length; ++i) {
-                            const result = results[i];
-                            const row = {
-                                rowId: searchResultsRowId,
-                                descrLink: result.descrLink,
-                                fileName: result.fileName,
-                                fileSize: result.fileSize,
-                                fileUrl: result.fileUrl,
-                                nbLeechers: result.nbLeechers,
-                                nbSeeders: result.nbSeeders,
-                                siteUrl: result.siteUrl,
-                            };
+                resetFilters();
 
-                            searchResultsTable.updateRowData(row);
-                            ++searchResultsRowId;
+                searchText.pattern = pattern;
+                startSearch(pattern, category, plugins);
+            }
+            else {
+                stopSearch();
+            }
+        };
+
+        const openSearchTorrentDescriptionUrl = function() {
+            searchResultsTable.selectedRowsIds().each(function(rowId) {
+                window.open(searchResultsTable.rows.get(rowId).full_data.descrLink, "_blank");
+            });
+        };
+
+        const copySearchTorrentName = function() {
+            const names = [];
+            searchResultsTable.selectedRowsIds().each(function(rowId) {
+                names.push(searchResultsTable.rows.get(rowId).full_data.fileName);
+            });
+            return names.join("\n");
+        };
+
+        const copySearchTorrentDownloadLink = function() {
+            const urls = [];
+            searchResultsTable.selectedRowsIds().each(function(rowId) {
+                urls.push(searchResultsTable.rows.get(rowId).full_data.fileUrl);
+            });
+            return urls.join("\n");
+        };
+
+        const copySearchTorrentDescriptionUrl = function() {
+            const urls = [];
+            searchResultsTable.selectedRowsIds().each(function(rowId) {
+                urls.push(searchResultsTable.rows.get(rowId).full_data.descrLink);
+            });
+            return urls.join("\n");
+        };
+
+        const downloadSearchTorrent = function() {
+            const urls = [];
+            searchResultsTable.selectedRowsIds().each(function(rowId) {
+                urls.push(encodeURIComponent(searchResultsTable.rows.get(rowId).full_data.fileUrl));
+            });
+
+            // only proceed if at least 1 row was selected
+            if (!urls.length) return;
+
+            showDownloadPage(urls);
+        };
+
+        const manageSearchPlugins = function() {
+            const id = 'searchPlugins';
+            if (!$(id))
+                new MochaUI.Window({
+                    id: id,
+                    title: "QBT_TR(Search plugins)QBT_TR[CONTEXT=PluginSelectDlg]",
+                    loadMethod: 'xhr',
+                    contentURL: 'views/searchplugins.html',
+                    scrollbars: false,
+                    maximizable: false,
+                    paddingVertical: 0,
+                    paddingHorizontal: 0,
+                    width: loadWindowWidth(id, 600),
+                    height: loadWindowHeight(id, 360),
+                    onResize: function() {
+                        saveWindowSize(id);
+                    },
+                    onBeforeBuild: function() {
+                        loadSearchPlugins();
+                    },
+                    onClose: function() {
+                        clearTimeout(loadSearchPluginsTimer);
+                    }
+                });
+        };
+
+        const loadSearchPlugins = function() {
+            getPlugins();
+            loadSearchPluginsTimer = loadSearchPlugins.delay(2000);
+        };
+
+        const categorySelected = function() {
+            selectedCategory = $("categorySelect").get("value");
+        };
+
+        const pluginSelected = function() {
+            selectedPlugin = $("pluginsSelect").get("value");
+
+            if (selectedPlugin !== prevSelectedPlugin) {
+                prevSelectedPlugin = selectedPlugin;
+                getSearchCategories();
+            }
+        };
+
+        const reselectCategory = function() {
+            for (let i = 0; i < $("categorySelect").options.length; ++i)
+                if ($("categorySelect").options[i].get("value") === selectedCategory)
+                    $("categorySelect").options[i].selected = true;
+
+            categorySelected();
+        };
+
+        const reselectPlugin = function() {
+            for (let i = 0; i < $("pluginsSelect").options.length; ++i)
+                if ($("pluginsSelect").options[i].get("value") === selectedPlugin)
+                    $("pluginsSelect").options[i].selected = true;
+
+            pluginSelected();
+        };
+
+        const resetSearchState = function() {
+            clearTimeout(loadSearchResultsTimer);
+            $('startSearchButton').set('text', 'QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]');
+            searchResultsRowId = 0;
+            searchRunning = false;
+            activeSearchId = null;
+        };
+
+        const getSearchCategories = function() {
+            const populateCategorySelect = function(categories) {
+                const categoryHtml = [];
+                categories.each(function(category) {
+                    categoryHtml.push("<option>" + category + "</option>");
+                });
+
+                // first category is "All Categories"
+                if (categoryHtml.length > 1)
+                    // add separator
+                    categoryHtml.splice(1, 0, "<option disabled>──────────</option>");
+
+                $('categorySelect').set('html', categoryHtml.join(""));
+            };
+
+            const selectedPlugin = $('pluginsSelect').get("value");
+            if ((selectedPlugin === "all") || (selectedPlugin === "enabled")) {
+                const url = new URI('api/v2/search/categories');
+                url.setData('name', selectedPlugin);
+                new Request.JSON({
+                    url: url,
+                    noCache: true,
+                    method: 'get',
+                    onSuccess: function(response) {
+                        populateCategorySelect(response);
+                    }
+                }).send();
+            }
+            else {
+                let plugins = ["QBT_TR(All categories)QBT_TR[CONTEXT=SearchEngineWidget]"];
+                const plugin = getPlugin(selectedPlugin);
+                if (plugin !== null)
+                    plugins = plugins.concat(plugin.supportedCategories);
+
+                populateCategorySelect(plugins);
+            }
+
+            reselectCategory();
+        };
+
+        const getPlugins = function() {
+            new Request.JSON({
+                url: new URI('api/v2/search/plugins'),
+                noCache: true,
+                method: 'get',
+                onSuccess: function(response) {
+                    if (response !== prevSearchPluginsResponse) {
+                        prevSearchPluginsResponse = response;
+                        searchPlugins.length = 0;
+                        response.forEach(function(plugin) {
+                            searchPlugins.push(plugin);
+                        })
+
+                        const pluginsHtml = [];
+                        pluginsHtml.push('<option value="enabled">QBT_TR(Only enabled)QBT_TR[CONTEXT=SearchEngineWidget]</option>');
+                        pluginsHtml.push('<option value="all">QBT_TR(All plugins)QBT_TR[CONTEXT=SearchEngineWidget]</option>');
+
+                        const searchPluginsEmpty = (searchPlugins.length === 0);
+                        if (searchPluginsEmpty) {
+                            $('searchResultsNoPlugins').style.display = "block";
+                            $('searchResultsFilters').style.display = "none";
+                            $('searchResultsTableContainer').style.display = "none";
+                        }
+                        else {
+                            $('searchResultsNoPlugins').style.display = "none";
+                            $('searchResultsFilters').style.display = "block";
+                            $('searchResultsTableContainer').style.display = "block";
+
+                            // sort plugins alphabetically
+                            const allPlugins = searchPlugins.sort(function(pluginA, pluginB) {
+                                const a = pluginA.fullName.toLowerCase();
+                                const b = pluginB.fullName.toLowerCase();
+                                if (a < b) return -1;
+                                if (a > b) return 1;
+                                return 0;
+                            });
+
+                            allPlugins.each(function(plugin) {
+                                if (plugin.enabled === true)
+                                    pluginsHtml.push("<option value='" + window.qBittorrent.Misc.escapeHtml(plugin.name) + "'>" + window.qBittorrent.Misc.escapeHtml(plugin.fullName) + "</option>");
+                            });
+
+                            if (pluginsHtml.length > 2)
+                                pluginsHtml.splice(2, 0, "<option disabled>──────────</option>");
                         }
 
-                        $('numSearchResultsVisible').set('html', searchResultsTable.getFilteredAndSortedRows().length);
-                        $('numSearchResultsTotal').set('html', searchResultsTable.getRowIds().length);
+                        $('pluginsSelect').set('html', pluginsHtml.join(""));
+
+                        $('searchPattern').setProperty('disabled', searchPluginsEmpty);
+                        $('categorySelect').setProperty('disabled', searchPluginsEmpty);
+                        $('pluginsSelect').setProperty('disabled', searchPluginsEmpty);
+                        $('startSearchButton').setProperty('disabled', searchPluginsEmpty);
+
+                        if (window.qBittorrent.SearchPlugins !== undefined)
+                            window.qBittorrent.SearchPlugins.updateTable();
+
+                        reselectPlugin();
                     }
+                }
+            }).send();
+        };
 
-                    searchResultsTable.updateTable();
-                    searchResultsTable.altRow();
+        const getPlugin = function(name) {
+            for (let i = 0; i < searchPlugins.length; ++i)
+                if (searchPlugins[i].name === name)
+                    return searchPlugins[i];
 
-                    if ((response.status === "Stopped") && (searchResultsRowId >= response.total)) {
+            return null;
+        };
+
+        const searchInTorrentName = function() {
+            if ($('searchInTorrentName').get('value') === "names")
+                LocalPreferences.set('search_in_filter', "names");
+            else
+                LocalPreferences.set('search_in_filter', "everywhere");
+
+            searchFilterChanged();
+        };
+
+        const resetFilters = function() {
+            // reset filters
+            $('searchMinSeedsFilter').set('value', '0');
+            $('searchMaxSeedsFilter').set('value', '0');
+            $('searchMinSizeFilter').set('value', '0.00');
+            $('searchMinSizePrefix').set('value', '2'); // MiB
+            $('searchMaxSizeFilter').set('value', '0.00');
+            $('searchMaxSizePrefix').set('value', '3'); // GiB
+        };
+
+        const searchSeedsFilterChanged = function() {
+            searchSeedsFilter.min = $('searchMinSeedsFilter').get('value');
+            searchSeedsFilter.max = $('searchMaxSeedsFilter').get('value');
+
+            searchFilterChanged();
+        };
+
+        const searchSizeFilterChanged = function() {
+            searchSizeFilter.min = $('searchMinSizeFilter').get('value');
+            searchSizeFilter.minUnit = $('searchMinSizePrefix').get('value');
+            searchSizeFilter.max = $('searchMaxSizeFilter').get('value');
+            searchSizeFilter.maxUnit = $('searchMaxSizePrefix').get('value');
+
+            searchFilterChanged();
+        };
+
+        const searchSizeFilterPrefixChanged = function() {
+            if (($('searchMinSizeFilter').get('value') != 0) || ($('searchMaxSizeFilter').get('value') != 0))
+                searchSizeFilterChanged();
+        };
+
+        const searchFilterChanged = function() {
+            searchResultsTable.updateTable();
+            $('numSearchResultsVisible').set('html', searchResultsTable.getFilteredAndSortedRows().length);
+        };
+
+        const setupSearchTableEvents = function(enable) {
+            if (enable)
+                $$(".searchTableRow").each(function(target) {
+                    target.addEventListener('dblclick', downloadSearchTorrent, false);
+                });
+            else
+                $$(".searchTableRow").each(function(target) {
+                    target.removeEventListener('dblclick', downloadSearchTorrent, false);
+                });
+        };
+
+        const loadSearchResultsData = function() {
+            const maxResults = 500;
+            const url = new URI('api/v2/search/results');
+            new Request.JSON({
+                url: url,
+                noCache: true,
+                method: 'post',
+                data: {
+                    id: activeSearchId,
+                    limit: maxResults,
+                    offset: searchResultsRowId
+                },
+                onFailure: function(response) {
+                    if (response.status === 400) {
+                        // bad params. search id is invalid
                         resetSearchState();
+                    }
+                    else {
+                        clearTimeout(loadSearchResultsTimer);
+                        loadSearchResultsTimer = loadSearchResultsData.delay(3000);
+                    }
+                },
+                onSuccess: function(response) {
+                    $('error_div').set('html', '');
+
+                    // check if user stopped the search prior to receiving the response
+                    if (!searchRunning) {
+                        clearTimeout(loadSearchResultsTimer);
+                        searchResultsRowId = 0;
                         return;
                     }
 
-                    setupSearchTableEvents(true);
+                    if (response) {
+                        setupSearchTableEvents(false);
+
+                        if (response.results) {
+                            const results = response.results;
+                            for (let i = 0; i < results.length; ++i) {
+                                const result = results[i];
+                                const row = {
+                                    rowId: searchResultsRowId,
+                                    descrLink: result.descrLink,
+                                    fileName: result.fileName,
+                                    fileSize: result.fileSize,
+                                    fileUrl: result.fileUrl,
+                                    nbLeechers: result.nbLeechers,
+                                    nbSeeders: result.nbSeeders,
+                                    siteUrl: result.siteUrl,
+                                };
+
+                                searchResultsTable.updateRowData(row);
+                                ++searchResultsRowId;
+                            }
+
+                            $('numSearchResultsVisible').set('html', searchResultsTable.getFilteredAndSortedRows().length);
+                            $('numSearchResultsTotal').set('html', searchResultsTable.getRowIds().length);
+                        }
+
+                        searchResultsTable.updateTable();
+                        searchResultsTable.altRow();
+
+                        if ((response.status === "Stopped") && (searchResultsRowId >= response.total)) {
+                            resetSearchState();
+                            return;
+                        }
+
+                        setupSearchTableEvents(true);
+                    }
+
+                    let timeout = 1000;
+                    if (requestCount > 30)
+                        timeout = 3000;
+                    else if (requestCount > 10)
+                        timeout = 2000;
+
+                    clearTimeout(loadSearchResultsTimer);
+                    loadSearchResultsTimer = loadSearchResultsData.delay(timeout);
+                    ++requestCount;
                 }
+            }).send();
+        };
 
-                let timeout = 1000;
-                if (requestCount > 30)
-                    timeout = 3000;
-                else if (requestCount > 10)
-                    timeout = 2000;
+        const updateSearchResultsData = function() {
+            clearTimeout(loadSearchResultsTimer);
+            loadSearchResultsTimer = loadSearchResultsData.delay(500);
+        };
 
-                clearTimeout(loadSearchResultsTimer);
-                loadSearchResultsTimer = loadSearchResultsData.delay(timeout);
-                ++requestCount;
+        new ClipboardJS('.copySearchDataToClipboard', {
+            text: function(trigger) {
+                switch (trigger.id) {
+                    case "copySearchTorrentName":
+                        return copySearchTorrentName();
+                    case "copySearchTorrentDownloadLink":
+                        return copySearchTorrentDownloadLink();
+                    case "copySearchTorrentDescriptionUrl":
+                        return copySearchTorrentDescriptionUrl();
+                    default:
+                        return "";
+                }
             }
-        }).send();
-    };
+        });
 
-    const updateSearchResultsData = function() {
-        clearTimeout(loadSearchResultsTimer);
-        loadSearchResultsTimer = loadSearchResultsData.delay(500);
-    };
-
-    new ClipboardJS('.copySearchDataToClipboard', {
-        text: function(trigger) {
-            switch (trigger.id) {
-                case "copySearchTorrentName":
-                    return copySearchTorrentName();
-                case "copySearchTorrentDownloadLink":
-                    return copySearchTorrentDownloadLink();
-                case "copySearchTorrentDescriptionUrl":
-                    return copySearchTorrentDescriptionUrl();
-                default:
-                    return "";
-            }
-        }
-    });
-
+        return exports();
+    })();
 </script>

--- a/src/webui/www/private/views/searchplugins.html
+++ b/src/webui/www/private/views/searchplugins.html
@@ -65,9 +65,9 @@
     <span>QBT_TR(Warning: Be sure to comply with your country's copyright laws when downloading torrents from any of these search engines.)QBT_TR[CONTEXT=PluginSelectDlg]</span>
     <span style="font-style: italic;">QBT_TR(You can get new search engine plugins here:)QBT_TR[CONTEXT=PluginSelectDlg] <a href="http://plugins.qbittorrent.org" target="_blank">http://plugins.qbittorrent.org</a></span>
     <div style="width: 100%; margin-top: 10px;">
-        <button style="width: 33%; line-height: 1.4em;" onclick="installPlugin();">QBT_TR(Install new plugin)QBT_TR[CONTEXT=PluginSelectDlg]</button>
-        <button style="width: 33%; line-height: 1.4em;" onclick="checkForUpdates();">QBT_TR(Check for updates)QBT_TR[CONTEXT=PluginSelectDlg]</button>
-        <button style="width: 32%; line-height: 1.4em;" onclick="closeSearchWindow('searchPlugins');">QBT_TR(Close)QBT_TR[CONTEXT=PluginSelectDlg]</button>
+        <button style="width: 33%; line-height: 1.4em;" onclick="qBittorrent.SearchPlugins.installPlugin();">QBT_TR(Install new plugin)QBT_TR[CONTEXT=PluginSelectDlg]</button>
+        <button style="width: 33%; line-height: 1.4em;" onclick="qBittorrent.SearchPlugins.checkForUpdates();">QBT_TR(Check for updates)QBT_TR[CONTEXT=PluginSelectDlg]</button>
+        <button style="width: 32%; line-height: 1.4em;" onclick="qBittorrent.SearchPlugins.closeSearchWindow('searchPlugins');">QBT_TR(Close)QBT_TR[CONTEXT=PluginSelectDlg]</button>
     </div>
 </div>
 
@@ -79,142 +79,161 @@
 <script>
     'use strict';
 
-    this.searchPluginsTableContextMenu = undefined;
-    this.prevOffsetLeft = undefined;
-    this.prevOffsetTop = undefined;
+    if (window.qBittorrent === undefined) {
+        window.qBittorrent = {};
+    }
 
-    this.initSearchPlugins = function() {
-        searchPluginsTableContextMenu = new SearchPluginsTableContextMenu({
-            targets: '.searchPluginsTableRow',
-            menu: 'searchPluginsTableMenu',
-            actions: {
-                Enabled: enablePlugin,
-                Uninstall: uninstallPlugin
-            },
-            offsets: calculateContextMenuOffsets()
-        });
-        searchPluginsTable.setup('searchPluginsTableDiv', 'searchPluginsTableFixedHeaderDiv', searchPluginsTableContextMenu);
-        updateSearchPluginsTable();
-    };
-
-    this.closeSearchWindow = function(id) {
-        window.parent.MochaUI.closeWindow(window.parent.$(id));
-    };
-
-    this.installPlugin = function(path) {
-        new MochaUI.Window({
-            id: 'installSearchPlugin',
-            title: "QBT_TR(Install plugin)QBT_TR[CONTEXT=PluginSourceDlg]",
-            loadMethod: 'xhr',
-            contentURL: 'views/installsearchplugin.html',
-            scrollbars: false,
-            resizable: false,
-            maximizable: false,
-            paddingVertical: 0,
-            paddingHorizontal: 0,
-            width: 500,
-            height: 120
-        });
-    };
-
-    this.uninstallPlugin = function() {
-        const plugins = searchPluginsTable.selectedRowsIds().join('|');
-        const url = new URI('api/v2/search/uninstallPlugin');
-        new Request({
-            url: url,
-            noCache: true,
-            method: 'post',
-            data: {
-                names: plugins,
-            }
-        }).send();
-    };
-
-    this.enablePlugin = function() {
-        const plugins = searchPluginsTable.selectedRowsIds();
-        let enable = true;
-        if (plugins && plugins.length)
-            enable = !getPlugin(plugins[0]).enabled;
-
-        const url = new URI('api/v2/search/enablePlugin');
-        new Request({
-            url: url,
-            noCache: true,
-            method: 'post',
-            data: {
-                names: plugins.join('|'),
-                enable: enable
-            }
-        }).send();
-    };
-
-    this.checkForUpdates = function() {
-        const url = new URI('api/v2/search/updatePlugins');
-        new Request({
-            url: url,
-            noCache: true,
-            method: 'post'
-        }).send();
-    };
-
-    this.calculateContextMenuOffsets = function() {
-        prevOffsetLeft = document.getElementById("searchPlugins").getBoundingClientRect().left;
-        prevOffsetTop = document.getElementById("searchPlugins").getBoundingClientRect().top;
-
-        return {
-            x: -(prevOffsetLeft + 20),
-            y: -(prevOffsetTop + 2)
+    window.qBittorrent.SearchPlugins = (function() {
+        const exports = function() {
+            return {
+                closeSearchWindow: closeSearchWindow,
+                installPlugin: installPlugin,
+                checkForUpdates: checkForUpdates,
+                updateTable: updateTable
+            };
         };
-    };
 
-    this.updateSearchPluginsTableContextMenuOffset = function() {
-        // only re-calculate if window has moved
-        if ((prevOffsetLeft !== document.getElementById("searchPlugins").getBoundingClientRect().left) || (prevOffsetTop !== document.getElementById("searchPlugins").getBoundingClientRect().top))
-            searchPluginsTableContextMenu.options.offsets = calculateContextMenuOffsets();
-    };
+        let searchPluginsTable;
+        let searchPluginsTableContextMenu;
+        let prevOffsetLeft;
+        let prevOffsetTop;
 
-    this.setupSearchPluginTableEvents = function(enable) {
-        if (enable)
-            $$(".searchPluginsTableRow").each(function(target) {
-                target.addEventListener('dblclick', enablePlugin, false);
-                target.addEventListener('contextmenu', updateSearchPluginsTableContextMenuOffset, true);
+        const initSearchPlugins = function() {
+            searchPluginsTable = new window.qBittorrent.DynamicTable.SearchPluginsTable();
+            searchPluginsTableContextMenu = new window.qBittorrent.ContextMenu.SearchPluginsTableContextMenu({
+                targets: '.searchPluginsTableRow',
+                menu: 'searchPluginsTableMenu',
+                actions: {
+                    Enabled: enablePlugin,
+                    Uninstall: uninstallPlugin
+                },
+                offsets: calculateContextMenuOffsets()
             });
-        else
-            $$(".searchPluginsTableRow").each(function(target) {
-                target.removeEventListener('dblclick', enablePlugin, false);
-                target.removeEventListener('contextmenu', updateSearchPluginsTableContextMenuOffset, true);
+            searchPluginsTable.setup('searchPluginsTableDiv', 'searchPluginsTableFixedHeaderDiv', searchPluginsTableContextMenu);
+            updateTable();
+        };
+
+        const closeSearchWindow = function(id) {
+            window.parent.MochaUI.closeWindow(window.parent.$(id));
+        };
+
+        const installPlugin = function(path) {
+            new MochaUI.Window({
+                id: 'installSearchPlugin',
+                title: "QBT_TR(Install plugin)QBT_TR[CONTEXT=PluginSourceDlg]",
+                loadMethod: 'xhr',
+                contentURL: 'views/installsearchplugin.html',
+                scrollbars: false,
+                resizable: false,
+                maximizable: false,
+                paddingVertical: 0,
+                paddingHorizontal: 0,
+                width: 500,
+                height: 120
             });
-    };
+        };
 
-    this.updateSearchPluginsTable = function() {
-        // clear event listeners
-        setupSearchPluginTableEvents(false);
-
-        const oldPlugins = Object.keys(searchPluginsTable.rows);
-        // remove old rows from the table
-        for (let i = 0; i < oldPlugins.length; ++i) {
-            let found = false;
-            for (let j = 0; j < searchPlugins.length; ++j) {
-                if (searchPlugins[j].name === oldPlugins[i]) {
-                    found = true;
-                    break;
+        const uninstallPlugin = function() {
+            const plugins = searchPluginsTable.selectedRowsIds().join('|');
+            const url = new URI('api/v2/search/uninstallPlugin');
+            new Request({
+                url: url,
+                noCache: true,
+                method: 'post',
+                data: {
+                    names: plugins,
                 }
+            }).send();
+        };
+
+        const enablePlugin = function() {
+            const plugins = searchPluginsTable.selectedRowsIds();
+            let enable = true;
+            if (plugins && plugins.length)
+                enable = !window.qBittorrent.Search.getPlugin(plugins[0]).enabled;
+
+            const url = new URI('api/v2/search/enablePlugin');
+            new Request({
+                url: url,
+                noCache: true,
+                method: 'post',
+                data: {
+                    names: plugins.join('|'),
+                    enable: enable
+                }
+            }).send();
+        };
+
+        const checkForUpdates = function() {
+            const url = new URI('api/v2/search/updatePlugins');
+            new Request({
+                url: url,
+                noCache: true,
+                method: 'post'
+            }).send();
+        };
+
+        const calculateContextMenuOffsets = function() {
+            prevOffsetLeft = document.getElementById("searchPlugins").getBoundingClientRect().left;
+            prevOffsetTop = document.getElementById("searchPlugins").getBoundingClientRect().top;
+
+            return {
+                x: -(prevOffsetLeft + 20),
+                y: -(prevOffsetTop + 2)
+            };
+        };
+
+        const updateSearchPluginsTableContextMenuOffset = function() {
+            // only re-calculate if window has moved
+            if ((prevOffsetLeft !== document.getElementById("searchPlugins").getBoundingClientRect().left) || (prevOffsetTop !== document.getElementById("searchPlugins").getBoundingClientRect().top))
+                searchPluginsTableContextMenu.options.offsets = calculateContextMenuOffsets();
+        };
+
+        const setupSearchPluginTableEvents = function(enable) {
+            if (enable)
+                $$(".searchPluginsTableRow").each(function(target) {
+                    target.addEventListener('dblclick', enablePlugin, false);
+                    target.addEventListener('contextmenu', updateSearchPluginsTableContextMenuOffset, true);
+                });
+            else
+                $$(".searchPluginsTableRow").each(function(target) {
+                    target.removeEventListener('dblclick', enablePlugin, false);
+                    target.removeEventListener('contextmenu', updateSearchPluginsTableContextMenuOffset, true);
+                });
+        };
+
+        const updateTable = function() {
+            // clear event listeners
+            setupSearchPluginTableEvents(false);
+
+            const oldPlugins = Object.keys(searchPluginsTable.rows);
+            // remove old rows from the table
+            for (let i = 0; i < oldPlugins.length; ++i) {
+                let found = false;
+                for (let j = 0; j < window.qBittorrent.Search.searchPlugins.length; ++j) {
+                    if (window.qBittorrent.Search.searchPlugins[j].name === oldPlugins[i]) {
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found)
+                    searchPluginsTable.removeRow(oldPlugins[i]);
             }
-            if (!found)
-                searchPluginsTable.removeRow(oldPlugins[i]);
-        }
 
-        for (let i = 0; i < searchPlugins.length; ++i) {
-            searchPlugins[i].rowId = searchPlugins[i].name;
-            searchPluginsTable.updateRowData(searchPlugins[i]);
-        }
+            for (let i = 0; i < window.qBittorrent.Search.searchPlugins.length; ++i) {
+                window.qBittorrent.Search.searchPlugins[i].rowId = window.qBittorrent.Search.searchPlugins[i].name;
+                searchPluginsTable.updateRowData(window.qBittorrent.Search.searchPlugins[i]);
+            }
 
-        searchPluginsTable.updateTable();
-        searchPluginsTable.altRow();
+            searchPluginsTable.updateTable();
+            searchPluginsTable.altRow();
 
-        // add event listeners
-        setupSearchPluginTableEvents(true);
-    };
+            // add event listeners
+            setupSearchPluginTableEvents(true);
+        };
 
-    initSearchPlugins();
+        initSearchPlugins();
+
+        return exports();
+    })();
 </script>

--- a/src/webui/www/private/views/transferlist.html
+++ b/src/webui/www/private/views/transferlist.html
@@ -18,81 +18,95 @@
 <script>
     'use strict';
 
-    //create a context menu
-    const torrentsTableContextMenu = new TorrentsTableContextMenu({
-        targets: '.torrentsTableContextMenuTarget',
-        menu: 'torrentsTableMenu',
-        actions: {
-            start: function(element, ref) {
-                startFN();
-            },
-            pause: function(element, ref) {
-                pauseFN();
-            },
-            forceStart: function(element, ref) {
-                setForceStartFN();
-            },
+    if (window.qBittorrent === undefined) {
+        window.qBittorrent = {};
+    }
 
-            delete: function(element, ref) {
-                deleteFN();
-            },
+    window.qBittorrent.TransferList = (function() {
+        const exports = function() {
+            return {
+                contextMenu: contextMenu,
+            };
+        };
 
-            setLocation: function(element, ref) {
-                setLocationFN();
-            },
+        //create a context menu
+        const contextMenu = new window.qBittorrent.ContextMenu.TorrentsTableContextMenu({
+            targets: '.torrentsTableContextMenuTarget',
+            menu: 'torrentsTableMenu',
+            actions: {
+                start: function(element, ref) {
+                    startFN();
+                },
+                pause: function(element, ref) {
+                    pauseFN();
+                },
+                forceStart: function(element, ref) {
+                    setForceStartFN();
+                },
 
-            rename: function(element, ref) {
-                renameFN();
-            },
-            queueTop: function(element, ref) {
-                setQueuePositionFN('topPrio');
-            },
-            queueUp: function(element, ref) {
-                setQueuePositionFN('increasePrio');
-            },
-            queueDown: function(element, ref) {
-                setQueuePositionFN('decreasePrio');
-            },
-            queueBottom: function(element, ref) {
-                setQueuePositionFN('bottomPrio');
-            },
+                delete: function(element, ref) {
+                    deleteFN();
+                },
 
-            downloadLimit: function(element, ref) {
-                downloadLimitFN();
-            },
-            uploadLimit: function(element, ref) {
-                uploadLimitFN();
-            },
-            shareRatio: function(element, ref) {
-                shareRatioFN();
-            },
+                setLocation: function(element, ref) {
+                    setLocationFN();
+                },
 
-            sequentialDownload: function(element, ref) {
-                toggleSequentialDownloadFN();
-            },
-            firstLastPiecePrio: function(element, ref) {
-                toggleFirstLastPiecePrioFN();
-            },
+                rename: function(element, ref) {
+                    renameFN();
+                },
+                queueTop: function(element, ref) {
+                    setQueuePositionFN('topPrio');
+                },
+                queueUp: function(element, ref) {
+                    setQueuePositionFN('increasePrio');
+                },
+                queueDown: function(element, ref) {
+                    setQueuePositionFN('decreasePrio');
+                },
+                queueBottom: function(element, ref) {
+                    setQueuePositionFN('bottomPrio');
+                },
 
-            autoTorrentManagement: function(element, ref) {
-                autoTorrentManagementFN();
-            },
-            forceRecheck: function(element, ref) {
-                recheckFN();
-            },
-            forceReannounce: function(element, ref) {
-                reannounceFN();
-            },
+                downloadLimit: function(element, ref) {
+                    downloadLimitFN();
+                },
+                uploadLimit: function(element, ref) {
+                    uploadLimitFN();
+                },
+                shareRatio: function(element, ref) {
+                    shareRatioFN();
+                },
 
-            superSeeding: function(element, ref) {
-                setSuperSeedingFN(!ref.getItemChecked('superSeeding'));
+                sequentialDownload: function(element, ref) {
+                    toggleSequentialDownloadFN();
+                },
+                firstLastPiecePrio: function(element, ref) {
+                    toggleFirstLastPiecePrioFN();
+                },
+
+                autoTorrentManagement: function(element, ref) {
+                    autoTorrentManagementFN();
+                },
+                forceRecheck: function(element, ref) {
+                    recheckFN();
+                },
+                forceReannounce: function(element, ref) {
+                    reannounceFN();
+                },
+
+                superSeeding: function(element, ref) {
+                    setSuperSeedingFN(!ref.getItemChecked('superSeeding'));
+                }
+            },
+            offsets: {
+                x: -15,
+                y: 2
             }
-        },
-        offsets: {
-            x: -15,
-            y: 2
-        }
-    });
+        });
 
-    torrentsTable.setup('torrentsTableDiv', 'torrentsTableFixedHeaderDiv', torrentsTableContextMenu);
+        torrentsTable.setup('torrentsTableDiv', 'torrentsTableFixedHeaderDiv', contextMenu);
+
+        return exports();
+    })();
 </script>


### PR DESCRIPTION
This PR cleans up the global namespace by explicitly exporting shared values. All html views and JavaScript files have been converted to use explicit exports except for `client.js` and `mocha-init.js`. Both `client` and `mocha-init` are enormous and aren't worth the effort right now.

I've tested this PR pretty thoroughly, but it's a large change with an even larger surface area. Testing from others is welcome.