### PR TITLE
Initialize pointers

### DIFF
--- a/src/gui/properties/peerlistwidget.h
+++ b/src/gui/properties/peerlistwidget.h
@@ -77,10 +77,10 @@ private:
 
     void wheelEvent(QWheelEvent *event) override;
 
-    QStandardItemModel *m_listModel;
-    PeerListSortModel *m_proxyModel;
-    PropertiesWidget *m_properties;
-    Net::ReverseResolution *m_resolver;
+    QStandardItemModel *m_listModel = nullptr;
+    PeerListSortModel *m_proxyModel = nullptr;
+    PropertiesWidget *m_properties = nullptr;
+    Net::ReverseResolution *m_resolver = nullptr;
     QHash<QString, QStandardItem *> m_peerItems;
     bool m_resolveCountries;
 };


### PR DESCRIPTION
This is related to a crash occurring (on Windows) at https://github.com/qbittorrent/qBittorrent/blob/7ce26435bd49ba5f74bb4de5f2b6e5d352faa152/src/gui/properties/peerlistwidget.cpp#L208 due to uninitialized `m_resolver`. Note that deleting a `nullptr` is guaranteed to have no effects.

Strange that it runs fine when I was testing on linux :(