### PR TITLE
 Combine up/down speed limiting to one dialog 

### DIFF
--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -2145,12 +2145,20 @@ void TorrentHandle::setSeedingTimeLimit(int limit)
 
 void TorrentHandle::setUploadLimit(const int limit)
 {
-    m_nativeHandle.set_upload_limit(limit);
+     if (limit == uploadLimit())
+         return;
+
+     m_nativeHandle.set_upload_limit(limit);
+     saveResumeData();
 }
 
 void TorrentHandle::setDownloadLimit(const int limit)
 {
+    if (limit == downloadLimit())
+        return;
+
     m_nativeHandle.set_download_limit(limit);
+    saveResumeData();
 }
 
 void TorrentHandle::setSuperSeeding(const bool enable)

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -163,10 +163,7 @@ MainWindow::MainWindow(QWidget *parent)
 
     m_ui->actionOpen->setIcon(UIThemeManager::instance()->getIcon("list-add"));
     m_ui->actionDownloadFromURL->setIcon(UIThemeManager::instance()->getIcon("insert-link"));
-    m_ui->actionSetUploadLimit->setIcon(UIThemeManager::instance()->getIcon("kt-set-max-upload-speed"));
-    m_ui->actionSetDownloadLimit->setIcon(UIThemeManager::instance()->getIcon("kt-set-max-download-speed"));
-    m_ui->actionSetGlobalUploadLimit->setIcon(UIThemeManager::instance()->getIcon("kt-set-max-upload-speed"));
-    m_ui->actionSetGlobalDownloadLimit->setIcon(UIThemeManager::instance()->getIcon("kt-set-max-download-speed"));
+    m_ui->actionSetGlobalSpeedLimits->setIcon(UIThemeManager::instance()->getIcon("speedometer"));
     m_ui->actionCreateTorrent->setIcon(UIThemeManager::instance()->getIcon("document-edit"));
     m_ui->actionAbout->setIcon(UIThemeManager::instance()->getIcon("help-about"));
     m_ui->actionStatistics->setIcon(UIThemeManager::instance()->getIcon("view-statistics"));
@@ -955,34 +952,24 @@ void MainWindow::handleDownloadFromUrlFailure(const QString &url, const QString 
         , tr("Couldn't download file at URL '%1', reason: %2.").arg(url, reason));
 }
 
-void MainWindow::on_actionSetGlobalUploadLimit_triggered()
+void MainWindow::on_actionSetGlobalSpeedLimits_triggered()
 {
     qDebug() << Q_FUNC_INFO;
 
     BitTorrent::Session *const session = BitTorrent::Session::instance();
-    bool ok = false;
-    const long newLimit = SpeedLimitDialog::askSpeedLimit(
-        this, &ok, tr("Global Upload Speed Limit"), session->uploadSpeedLimit());
+    const bool isAltLimitEnabled = session->isAltGlobalSpeedLimitEnabled();
+    SpeedLimits speedLimits = {
+        session->uploadSpeedLimit(),
+        session->downloadSpeedLimit(),
+        isAltLimitEnabled ? session->altGlobalUploadSpeedLimit() : session->globalUploadSpeedLimit(),
+        isAltLimitEnabled ? session->altGlobalDownloadSpeedLimit() : session->globalDownloadSpeedLimit()
+    };
+    const QString title = session->isAltGlobalSpeedLimitEnabled() ? tr("Global Alternative Rate Limits") : tr("Global Rate Limits");
+    const bool ok = SpeedLimitDialog::askNewSpeedLimits(this, title, speedLimits);
+    if (!ok) return;
 
-    if (ok) {
-        qDebug("Setting global upload rate limit to %.1fKb/s", newLimit / 1024.);
-        session->setUploadSpeedLimit(newLimit);
-    }
-}
-
-void MainWindow::on_actionSetGlobalDownloadLimit_triggered()
-{
-    qDebug() << Q_FUNC_INFO;
-
-    BitTorrent::Session *const session = BitTorrent::Session::instance();
-    bool ok = false;
-    const long newLimit = SpeedLimitDialog::askSpeedLimit(
-        this, &ok, tr("Global Download Speed Limit"), session->downloadSpeedLimit());
-
-    if (ok) {
-        qDebug("Setting global download rate limit to %.1fKb/s", newLimit / 1024.);
-        session->setDownloadSpeedLimit(newLimit);
-    }
+    session->setDownloadSpeedLimit(speedLimits.downloadLimit);
+    session->setUploadSpeedLimit(speedLimits.uploadLimit);
 }
 
 // Necessary if we want to close the window
@@ -1673,8 +1660,7 @@ QMenu *MainWindow::trayIconMenu()
     updateAltSpeedsBtn(isAltBWEnabled);
     m_ui->actionUseAlternativeSpeedLimits->setChecked(isAltBWEnabled);
     m_trayIconMenu->addAction(m_ui->actionUseAlternativeSpeedLimits);
-    m_trayIconMenu->addAction(m_ui->actionSetGlobalDownloadLimit);
-    m_trayIconMenu->addAction(m_ui->actionSetGlobalUploadLimit);
+    m_trayIconMenu->addAction(m_ui->actionSetGlobalSpeedLimits);
     m_trayIconMenu->addSeparator();
     m_trayIconMenu->addAction(m_ui->actionStartAll);
     m_trayIconMenu->addAction(m_ui->actionPauseAll);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -958,18 +958,19 @@ void MainWindow::on_actionSetGlobalSpeedLimits_triggered()
 
     BitTorrent::Session *const session = BitTorrent::Session::instance();
     const bool isAltLimitEnabled = session->isAltGlobalSpeedLimitEnabled();
-    SpeedLimits speedLimits = {
+    OldSpeedLimits oldSpeedLimits = {
         session->uploadSpeedLimit(),
         session->downloadSpeedLimit(),
         isAltLimitEnabled ? session->altGlobalUploadSpeedLimit() : session->globalUploadSpeedLimit(),
         isAltLimitEnabled ? session->altGlobalDownloadSpeedLimit() : session->globalDownloadSpeedLimit()
     };
-    const QString title = session->isAltGlobalSpeedLimitEnabled() ? tr("Global Alternative Rate Limits") : tr("Global Rate Limits");
-    const bool ok = SpeedLimitDialog::askNewSpeedLimits(this, title, speedLimits);
+    NewSpeedLimits newSpeedLimits;
+    const QString title = isAltLimitEnabled ? tr("Global Alternative Speed Limits") : tr("Global Speed Limits");
+    const bool ok = SpeedLimitDialog::askNewSpeedLimits(this, title, oldSpeedLimits, newSpeedLimits);
     if (!ok) return;
 
-    session->setDownloadSpeedLimit(speedLimits.downloadLimit);
-    session->setUploadSpeedLimit(speedLimits.uploadLimit);
+    session->setDownloadSpeedLimit(newSpeedLimits.downloadLimit);
+    session->setUploadSpeedLimit(newSpeedLimits.uploadLimit);
 }
 
 // Necessary if we want to close the window

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -169,8 +169,7 @@ private slots:
     void on_actionStatistics_triggered();
     void on_actionCreateTorrent_triggered();
     void on_actionOptions_triggered();
-    void on_actionSetGlobalUploadLimit_triggered();
-    void on_actionSetGlobalDownloadLimit_triggered();
+    void on_actionSetGlobalSpeedLimits_triggered();
     void on_actionDocumentation_triggered() const;
     void on_actionOpen_triggered();
     void on_actionDownloadFromURL_triggered();

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -223,29 +223,14 @@
     <string>Torrent &amp;Creator</string>
    </property>
   </action>
-  <action name="actionSetUploadLimit">
-   <property name="text">
-    <string>Set Upload Limit...</string>
-   </property>
-  </action>
-  <action name="actionSetDownloadLimit">
-   <property name="text">
-    <string>Set Download Limit...</string>
-   </property>
-  </action>
   <action name="actionDocumentation">
    <property name="text">
     <string>&amp;Documentation</string>
    </property>
   </action>
-  <action name="actionSetGlobalDownloadLimit">
+  <action name="actionSetGlobalSpeedLimits">
    <property name="text">
-    <string>Set Global Download Limit...</string>
-   </property>
-  </action>
-  <action name="actionSetGlobalUploadLimit">
-   <property name="text">
-    <string>Set Global Upload Limit...</string>
+    <string>Set Global Rate Limits...</string>
    </property>
   </action>
   <action name="actionBottomQueuePos">
@@ -297,10 +282,10 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Alternative Speed Limits</string>
+    <string>Alternative Rate Limits</string>
    </property>
    <property name="toolTip">
-    <string>Alternative Speed Limits</string>
+    <string>Alternative Rate Limits</string>
    </property>
   </action>
   <action name="actionTopToolBar">

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -230,7 +230,7 @@
   </action>
   <action name="actionSetGlobalSpeedLimits">
    <property name="text">
-    <string>Set Global Rate Limits...</string>
+    <string>Set Global Speed Limits...</string>
    </property>
   </action>
   <action name="actionBottomQueuePos">
@@ -282,10 +282,10 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Alternative Rate Limits</string>
+    <string>Alternative Speed Limits</string>
    </property>
    <property name="toolTip">
-    <string>Alternative Rate Limits</string>
+    <string>Alternative Speed Limits</string>
    </property>
   </action>
   <action name="actionTopToolBar">

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -1812,7 +1812,7 @@
                   <string> KiB/s</string>
                  </property>
                  <property name="maximum">
-                  <number>1000000</number>
+                  <number>2000000</number>
                  </property>
                  <property name="value">
                   <number>100</number>
@@ -1828,7 +1828,7 @@
                   <string> KiB/s</string>
                  </property>
                  <property name="maximum">
-                  <number>1000000</number>
+                  <number>2000000</number>
                  </property>
                  <property name="value">
                   <number>100</number>
@@ -1883,7 +1883,7 @@
                   <string> KiB/s</string>
                  </property>
                  <property name="maximum">
-                  <number>1000000</number>
+                  <number>2000000</number>
                  </property>
                  <property name="value">
                   <number>10</number>
@@ -2013,7 +2013,7 @@
                   <string> KiB/s</string>
                  </property>
                  <property name="maximum">
-                  <number>1000000</number>
+                  <number>2000000</number>
                  </property>
                  <property name="value">
                   <number>10</number>

--- a/src/gui/speedlimitdialog.cpp
+++ b/src/gui/speedlimitdialog.cpp
@@ -52,24 +52,25 @@ SpeedLimitDialog::~SpeedLimitDialog()
     delete m_ui;
 }
 
-bool SpeedLimitDialog::askNewSpeedLimits(QWidget *parent, const QString &title, SpeedLimits &speedLimits)
+bool SpeedLimitDialog::askNewSpeedLimits(QWidget *parent, const QString &title
+        , const OldSpeedLimits &oldSpeedLimits, NewSpeedLimits &newSpeedLimits)
 {
     SpeedLimitDialog dlg(parent);
     dlg.setWindowTitle(title);
-    dlg.setupDialog(speedLimits);
+    dlg.setupDialog(oldSpeedLimits);
 
     if (dlg.exec() != QDialog::Accepted)
         return false;
 
     if (dlg.getUploadSpeedLimit() < 0)
-        speedLimits.uploadLimit = 0;
+        newSpeedLimits.uploadLimit = 0;
     else
-        speedLimits.uploadLimit = (dlg.getUploadSpeedLimit() * 1024);
+        newSpeedLimits.uploadLimit = (dlg.getUploadSpeedLimit() * 1024);
 
     if (dlg.getDownloadSpeedLimit() < 0)
-        speedLimits.downloadLimit = 0;
+        newSpeedLimits.downloadLimit = 0;
     else
-        speedLimits.downloadLimit = (dlg.getDownloadSpeedLimit() * 1024);
+        newSpeedLimits.downloadLimit = (dlg.getDownloadSpeedLimit() * 1024);
 
     return true;
 }
@@ -131,11 +132,11 @@ int SpeedLimitDialog::getUploadSpeedLimit() const
     return m_ui->spinUploadLimit->value();
 }
 
-void SpeedLimitDialog::setupDialog(const SpeedLimits &speedLimits)
+void SpeedLimitDialog::setupDialog(const OldSpeedLimits &oldSpeedLimits)
 {
-    m_globalUploadLimit = (speedLimits.maxUploadLimit / 1024);
-    m_globalDownloadLimit = (speedLimits.maxDownloadLimit / 1024);
-    m_isGlobalLimits = speedLimits.isGlobalLimits;
+    m_globalUploadLimit = (oldSpeedLimits.maxUploadLimit / 1024);
+    m_globalDownloadLimit = (oldSpeedLimits.maxDownloadLimit / 1024);
+    m_isGlobalLimits = oldSpeedLimits.isGlobalLimits;
 
     if (!m_isGlobalLimits)
         m_ui->labelWarningIcon->setPixmap(Utils::Gui::scaledPixmapSvg(":/icons/qbt-theme/dialog-warning.svg", this, 16));
@@ -147,8 +148,8 @@ void SpeedLimitDialog::setupDialog(const SpeedLimits &speedLimits)
     retainHiddenSpace.setRetainSizeWhenHidden(true);
     m_ui->labelWarning->setSizePolicy(retainHiddenSpace);
 
-    const int uploadVal = qMax(0, (speedLimits.uploadLimit / 1024));
-    const int downloadVal = qMax(0, (speedLimits.downloadLimit / 1024));
+    const int uploadVal = qMax(0, (oldSpeedLimits.uploadLimit / 1024));
+    const int downloadVal = qMax(0, (oldSpeedLimits.downloadLimit / 1024));
     int maxUpload = (m_globalUploadLimit <= 0) ? 10000 : m_globalUploadLimit;
     int maxDownload = (m_globalDownloadLimit <= 0) ? 10000 : m_globalDownloadLimit;
 

--- a/src/gui/speedlimitdialog.h
+++ b/src/gui/speedlimitdialog.h
@@ -36,13 +36,19 @@ namespace Ui
     class SpeedLimitDialog;
 }
 
-struct SpeedLimits
+struct OldSpeedLimits
 {
     int uploadLimit = 0;
     int downloadLimit = 0;
     int maxUploadLimit = 0;
     int maxDownloadLimit = 0;
     bool isGlobalLimits = true;
+};
+
+struct NewSpeedLimits
+{
+    int uploadLimit = 0;
+    int downloadLimit = 0;
 };
 
 class SpeedLimitDialog : public QDialog
@@ -52,7 +58,8 @@ class SpeedLimitDialog : public QDialog
 public:
     explicit SpeedLimitDialog(QWidget *parent);
     ~SpeedLimitDialog();
-    static bool askNewSpeedLimits(QWidget *parent, const QString &title, SpeedLimits &speedLimits);
+    static bool askNewSpeedLimits(QWidget *parent, const QString &title
+            , const OldSpeedLimits &oldSpeedLimits, NewSpeedLimits &newSpeedLimits);
 
 private slots:
     void updateUploadSpinValue(int val);
@@ -61,7 +68,7 @@ private slots:
     void updateDownloadSliderValue(int val);
 
 private:
-    void setupDialog(const SpeedLimits &speedLimits);
+    void setupDialog(const OldSpeedLimits &oldSpeedLimits);
     int getUploadSpeedLimit() const;
     int getDownloadSpeedLimit() const;
     void hideShowWarning();

--- a/src/gui/speedlimitdialog.h
+++ b/src/gui/speedlimitdialog.h
@@ -36,6 +36,15 @@ namespace Ui
     class SpeedLimitDialog;
 }
 
+struct SpeedLimits
+{
+    int uploadLimit = 0;
+    int downloadLimit = 0;
+    int maxUploadLimit = 0;
+    int maxDownloadLimit = 0;
+    bool isGlobalLimits = true;
+};
+
 class SpeedLimitDialog : public QDialog
 {
     Q_OBJECT
@@ -43,15 +52,23 @@ class SpeedLimitDialog : public QDialog
 public:
     explicit SpeedLimitDialog(QWidget *parent);
     ~SpeedLimitDialog();
-    static long askSpeedLimit(QWidget *parent, bool *ok, const QString &title, long defaultVal, long maxVal = 10240000);
+    static bool askNewSpeedLimits(QWidget *parent, const QString &title, SpeedLimits &speedLimits);
 
 private slots:
-    void updateSpinValue(int val);
-    void updateSliderValue(int val);
+    void updateUploadSpinValue(int val);
+    void updateDownloadSpinValue(int val);
+    void updateUploadSliderValue(int val);
+    void updateDownloadSliderValue(int val);
 
 private:
-    void setupDialog(long maxSlider, long val);
-    int getSpeedLimit() const;
+    void setupDialog(const SpeedLimits &speedLimits);
+    int getUploadSpeedLimit() const;
+    int getDownloadSpeedLimit() const;
+    void hideShowWarning();
+
+    int m_globalUploadLimit;
+    int m_globalDownloadLimit;
+    bool m_isGlobalLimits;
 
     Ui::SpeedLimitDialog *m_ui;
 };

--- a/src/gui/speedlimitdialog.ui
+++ b/src/gui/speedlimitdialog.ui
@@ -6,22 +6,28 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>338</width>
-    <height>83</height>
+    <width>386</width>
+    <height>172</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QSlider" name="bandwidthSlider">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSpinBox" name="spinBandwidth">
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="1" column="2">
+      <widget class="QSpinBox" name="spinDownloadLimit">
        <property name="specialValueText">
         <string>∞</string>
        </property>
@@ -29,11 +35,86 @@
         <string> KiB/s</string>
        </property>
        <property name="maximum">
-        <number>65535</number>
+        <number>2000000</number>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QSlider" name="sliderUploadLimit">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Upload:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QSlider" name="sliderDownloadLimit">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QSpinBox" name="spinUploadLimit">
+       <property name="specialValueText">
+        <string>∞</string>
+       </property>
+       <property name="suffix">
+        <string> KiB/s</string>
+       </property>
+       <property name="maximum">
+        <number>2000000</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Download:</string>
        </property>
       </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="labelWarningIcon">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="labelWarning">
+       <property name="text">
+        <string>Warning: These will not exceed the global limits</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">

--- a/src/gui/statusbar.cpp
+++ b/src/gui/statusbar.cpp
@@ -246,17 +246,18 @@ void StatusBar::capSpeed()
 {
     BitTorrent::Session *const session = BitTorrent::Session::instance();
     const bool isAltLimitEnabled = session->isAltGlobalSpeedLimitEnabled();
-    SpeedLimits speedLimits = {
+    OldSpeedLimits oldSpeedLimits = {
         session->uploadSpeedLimit(),
         session->downloadSpeedLimit(),
         isAltLimitEnabled ? session->altGlobalUploadSpeedLimit() : session->globalUploadSpeedLimit(),
         isAltLimitEnabled ? session->altGlobalDownloadSpeedLimit() : session->globalDownloadSpeedLimit()
     };
-    const QString title = session->isAltGlobalSpeedLimitEnabled() ? tr("Global Alternative Rate Limits") : tr("Global Rate Limits");
-    const bool ok = SpeedLimitDialog::askNewSpeedLimits(parentWidget(), title, speedLimits);
+    NewSpeedLimits newSpeedLimits;
+    const QString title = session->isAltGlobalSpeedLimitEnabled() ? tr("Global Alternative Speed Limits") : tr("Global Speed Limits");
+    const bool ok = SpeedLimitDialog::askNewSpeedLimits(parentWidget(), title, oldSpeedLimits, newSpeedLimits);
     if (!ok) return;
 
-    session->setDownloadSpeedLimit(speedLimits.downloadLimit);
-    session->setUploadSpeedLimit(speedLimits.uploadLimit);
+    session->setDownloadSpeedLimit(newSpeedLimits.downloadLimit);
+    session->setUploadSpeedLimit(newSpeedLimits.uploadLimit);
     refresh();
 }

--- a/src/gui/statusbar.h
+++ b/src/gui/statusbar.h
@@ -58,8 +58,7 @@ public slots:
 private slots:
     void refresh();
     void updateAltSpeedsBtn(bool alternative);
-    void capDownloadSpeed();
-    void capUploadSpeed();
+    void capSpeed();
 
 private:
     void updateConnectionStatus();

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -514,19 +514,20 @@ void TransferListWidget::setSpeedLimitsSelectedTorrents()
 
     const BitTorrent::Session *session = BitTorrent::Session::instance();
     const bool isAltLimitEnabled = session->isAltGlobalSpeedLimitEnabled();
-    SpeedLimits speedLimits = {
+    OldSpeedLimits oldSpeedLimits = {
         oldUploadLimit,
         oldDownloadLimit,
         isAltLimitEnabled ? session->altGlobalUploadSpeedLimit() : session->globalUploadSpeedLimit(),
         isAltLimitEnabled ? session->altGlobalDownloadSpeedLimit() : session->globalDownloadSpeedLimit(),
         false
     };
-    const bool ok = SpeedLimitDialog::askNewSpeedLimits(this, tr("Torrent Rate Limits"), speedLimits);
+    NewSpeedLimits newSpeedLimits;
+    const bool ok = SpeedLimitDialog::askNewSpeedLimits(this, tr("Torrent Speed Limits"), oldSpeedLimits, newSpeedLimits);
     if (!ok) return;
 
     for (BitTorrent::TorrentHandle *const torrent : torrentsList) {
-        torrent->setUploadLimit(speedLimits.uploadLimit);
-        torrent->setDownloadLimit(speedLimits.downloadLimit);
+        torrent->setUploadLimit(newSpeedLimits.uploadLimit);
+        torrent->setDownloadLimit(newSpeedLimits.downloadLimit);
     }
 }
 
@@ -804,7 +805,7 @@ void TransferListWidget::displayListMenu(const QPoint &)
     connect(actionPreviewFile, &QAction::triggered, this, &TransferListWidget::previewSelectedTorrents);
     auto *actionSetMaxRatio = new QAction(QIcon(QLatin1String(":/icons/skin/ratio.svg")), tr("Limit share ratio..."), listMenu);
     connect(actionSetMaxRatio, &QAction::triggered, this, &TransferListWidget::setMaxRatioSelectedTorrents);
-    auto *actionSetSpeedLimits = new QAction(UIThemeManager::instance()->getIcon("speedometer"), tr("Limit speed rate..."), listMenu);
+    auto *actionSetSpeedLimits = new QAction(UIThemeManager::instance()->getIcon("speedometer"), tr("Limit speed rates..."), listMenu);
     connect(actionSetSpeedLimits, &QAction::triggered, this, &TransferListWidget::setSpeedLimitsSelectedTorrents);
     auto *actionOpenDestinationFolder = new QAction(UIThemeManager::instance()->getIcon("inode-directory"), tr("Open destination folder"), listMenu);
     connect(actionOpenDestinationFolder, &QAction::triggered, this, &TransferListWidget::openSelectedTorrentsFolder);

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -490,58 +490,43 @@ void TransferListWidget::previewSelectedTorrents()
     }
 }
 
-void TransferListWidget::setDlLimitSelectedTorrents()
+void TransferListWidget::setSpeedLimitsSelectedTorrents()
 {
-    QVector<BitTorrent::TorrentHandle *> torrentsList;
-    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents())) {
-        if (torrent->isSeed())
-            continue;
-        torrentsList += torrent;
-    }
+    const QVector<BitTorrent::TorrentHandle *> torrentsList = getSelectedTorrents();
     if (torrentsList.empty()) return;
 
-    int oldLimit = torrentsList.first()->downloadLimit();
-    for (BitTorrent::TorrentHandle *const torrent : asConst(torrentsList)) {
-        if (torrent->downloadLimit() != oldLimit) {
-            oldLimit = -1;
+    int oldUploadLimit = torrentsList.first()->uploadLimit();
+    int oldDownloadLimit = torrentsList.first()->downloadLimit();
+
+    for (const BitTorrent::TorrentHandle *torrent : torrentsList) {
+        if (torrent->uploadLimit() != oldUploadLimit) {
+            oldUploadLimit = -1;
             break;
         }
     }
 
-    bool ok = false;
-    const long newLimit = SpeedLimitDialog::askSpeedLimit(
-                this, &ok, tr("Torrent Download Speed Limiting"), oldLimit
-                , BitTorrent::Session::instance()->globalDownloadSpeedLimit());
-    if (!ok) return;
-
-    for (BitTorrent::TorrentHandle *const torrent : asConst(torrentsList)) {
-        qDebug("Applying download speed limit of %ld Kb/s to torrent %s", (newLimit / 1024l), qUtf8Printable(torrent->hash()));
-        torrent->setDownloadLimit(newLimit);
-    }
-}
-
-void TransferListWidget::setUpLimitSelectedTorrents()
-{
-    QVector<BitTorrent::TorrentHandle *> torrentsList = getSelectedTorrents();
-    if (torrentsList.empty()) return;
-
-    int oldLimit = torrentsList.first()->uploadLimit();
-    for (BitTorrent::TorrentHandle *const torrent : asConst(torrentsList)) {
-        if (torrent->uploadLimit() != oldLimit) {
-            oldLimit = -1;
+    for (const BitTorrent::TorrentHandle *torrent : torrentsList) {
+        if (torrent->downloadLimit() != oldDownloadLimit) {
+            oldDownloadLimit = -1;
             break;
         }
     }
 
-    bool ok = false;
-    const long newLimit = SpeedLimitDialog::askSpeedLimit(
-                this, &ok, tr("Torrent Upload Speed Limiting"), oldLimit
-                , BitTorrent::Session::instance()->globalUploadSpeedLimit());
+    const BitTorrent::Session *session = BitTorrent::Session::instance();
+    const bool isAltLimitEnabled = session->isAltGlobalSpeedLimitEnabled();
+    SpeedLimits speedLimits = {
+        oldUploadLimit,
+        oldDownloadLimit,
+        isAltLimitEnabled ? session->altGlobalUploadSpeedLimit() : session->globalUploadSpeedLimit(),
+        isAltLimitEnabled ? session->altGlobalDownloadSpeedLimit() : session->globalDownloadSpeedLimit(),
+        false
+    };
+    const bool ok = SpeedLimitDialog::askNewSpeedLimits(this, tr("Torrent Rate Limits"), speedLimits);
     if (!ok) return;
 
-    for (BitTorrent::TorrentHandle *const torrent : asConst(torrentsList)) {
-        qDebug("Applying upload speed limit of %ld Kb/s to torrent %s", (newLimit / 1024l), qUtf8Printable(torrent->hash()));
-        torrent->setUploadLimit(newLimit);
+    for (BitTorrent::TorrentHandle *const torrent : torrentsList) {
+        torrent->setUploadLimit(speedLimits.uploadLimit);
+        torrent->setDownloadLimit(speedLimits.downloadLimit);
     }
 }
 
@@ -819,10 +804,8 @@ void TransferListWidget::displayListMenu(const QPoint &)
     connect(actionPreviewFile, &QAction::triggered, this, &TransferListWidget::previewSelectedTorrents);
     auto *actionSetMaxRatio = new QAction(QIcon(QLatin1String(":/icons/skin/ratio.svg")), tr("Limit share ratio..."), listMenu);
     connect(actionSetMaxRatio, &QAction::triggered, this, &TransferListWidget::setMaxRatioSelectedTorrents);
-    auto *actionSetUploadLimit = new QAction(UIThemeManager::instance()->getIcon("kt-set-max-upload-speed"), tr("Limit upload rate..."), listMenu);
-    connect(actionSetUploadLimit, &QAction::triggered, this, &TransferListWidget::setUpLimitSelectedTorrents);
-    auto *actionSetDownloadLimit = new QAction(UIThemeManager::instance()->getIcon("kt-set-max-download-speed"), tr("Limit download rate..."), listMenu);
-    connect(actionSetDownloadLimit, &QAction::triggered, this, &TransferListWidget::setDlLimitSelectedTorrents);
+    auto *actionSetSpeedLimits = new QAction(UIThemeManager::instance()->getIcon("speedometer"), tr("Limit speed rate..."), listMenu);
+    connect(actionSetSpeedLimits, &QAction::triggered, this, &TransferListWidget::setSpeedLimitsSelectedTorrents);
     auto *actionOpenDestinationFolder = new QAction(UIThemeManager::instance()->getIcon("inode-directory"), tr("Open destination folder"), listMenu);
     connect(actionOpenDestinationFolder, &QAction::triggered, this, &TransferListWidget::openSelectedTorrentsFolder);
     auto *actionIncreaseQueuePos = new QAction(UIThemeManager::instance()->getIcon("go-up"), tr("Move up", "i.e. move up in the queue"), listMenu);
@@ -1029,9 +1012,7 @@ void TransferListWidget::displayListMenu(const QPoint &)
     listMenu->addAction(actionAutoTMM);
 
     listMenu->addSeparator();
-    if (oneNotSeed)
-        listMenu->addAction(actionSetDownloadLimit);
-    listMenu->addAction(actionSetUploadLimit);
+    listMenu->addAction(actionSetSpeedLimits);
     listMenu->addAction(actionSetMaxRatio);
     if (!oneNotSeed && oneHasMetadata) {
         actionSuperSeedingMode->setCheckState(allSameSuperSeeding

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -79,8 +79,7 @@ public slots:
     void openSelectedTorrentsFolder() const;
     void recheckSelectedTorrents();
     void reannounceSelectedTorrents();
-    void setDlLimitSelectedTorrents();
-    void setUpLimitSelectedTorrents();
+    void setSpeedLimitsSelectedTorrents();
     void setMaxRatioSelectedTorrents();
     void previewSelectedTorrents();
     void hideQueuePosColumn(bool hide);


### PR DESCRIPTION
With and without icons on the left whichever you prefer. Note that the first 2 pics are before the reservation of the warning labels' space.
![no icons](https://user-images.githubusercontent.com/6451685/63845938-7f063700-c993-11e9-897d-c997a36b1907.JPG)
![2icons16](https://user-images.githubusercontent.com/6451685/63845939-7f9ecd80-c993-11e9-8539-155500237d71.JPG)
![warning](https://user-images.githubusercontent.com/6451685/63845940-7f9ecd80-c993-11e9-9483-bf5c2087ce6b.JPG)

Closes #1425