### PR TITLE
Remove max character limit of location path

### DIFF
--- a/src/webui/www/private/setlocation.html
+++ b/src/webui/www/private/setlocation.html
@@ -68,7 +68,7 @@
 <body>
     <div style="padding: 10px 10px 0px 10px;">
         <p style="font-weight: bold;">QBT_TR(Location)QBT_TR[CONTEXT=TransferListWidget]:</p>
-        <input type="text" id="setLocation" value="" maxlength="100" autocorrect="off" autocapitalize="none" style="width: 370px;" />
+        <input type="text" id="setLocation" value="" autocorrect="off" autocapitalize="none" style="width: 370px;" />
         <div style="float: none; width: 370px;" id="error_div">&nbsp;</div>
         <div style="text-align: center; padding-top: 10px;">
             <input type="button" value="QBT_TR(Save)QBT_TR[CONTEXT=HttpServer]" id="setLocationButton" />


### PR DESCRIPTION
I changed maxlength because we couldn't modify the path of the location when he is more than 100 character.