### PR TITLE
Always save info dict when saving fastresume (backport to v4_1_x)

### DIFF
--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -508,7 +508,7 @@ bool TorrentHandle::needSaveResumeData() const
 
 void TorrentHandle::saveResumeData()
 {
-    m_nativeHandle.save_resume_data();
+    m_nativeHandle.save_resume_data(lt::torrent_handle::save_info_dict);
     m_session->handleTorrentSaveResumeDataRequested(this);
 }
 


### PR DESCRIPTION
#11104