### PR TITLE
Replace deprecated macro

### DIFF
--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -306,7 +306,7 @@ Example:
 #include <QString>
 #include <QUrl>
 
-#ifdef Q_OS_MAC  // conditional
+#ifdef Q_OS_MACOS  // conditional
 #include <QFont>
 #endif
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,7 +47,7 @@ list(APPEND CMAKE_AUTORCC_OPTIONS -compress 9 -threshold 5)
 if (APPLE)
     # Workaround CMake bug (autogen does not pass required parameters to moc)
     # Relevant issue: https://gitlab.kitware.com/cmake/cmake/issues/18041
-    list(APPEND CMAKE_AUTOMOC_MOC_OPTIONS -DQ_OS_MAC -DQ_OS_DARWIN)
+    list(APPEND CMAKE_AUTOMOC_MOC_OPTIONS -DQ_OS_MACOS -DQ_OS_DARWIN)
 endif ()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -56,9 +56,9 @@
 #include <QSessionManager>
 #include <QSharedMemory>
 #endif // Q_OS_WIN
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 #include <QFileOpenEvent>
-#endif // Q_OS_MAC
+#endif // Q_OS_MACOS
 #endif
 
 #include "base/bittorrent/session.h"
@@ -586,7 +586,7 @@ bool Application::isRunning()
 }
 
 #ifndef DISABLE_GUI
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 bool Application::event(QEvent *ev)
 {
     if (ev->type() == QEvent::FileOpen) {
@@ -605,7 +605,7 @@ bool Application::event(QEvent *ev)
         return BaseApplication::event(ev);
     }
 }
-#endif // Q_OS_MAC
+#endif // Q_OS_MACOS
 #endif // DISABLE_GUI
 
 void Application::initializeTranslation()

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -121,7 +121,9 @@ namespace
     const int MAX_FILELOG_SIZE = 1000 * 1024 * 1024; // 1000MiB
     const int DEFAULT_FILELOG_SIZE = 65 * 1024; // 65KiB
 
+#if !defined(DISABLE_GUI)
     const int PIXMAP_CACHE_SIZE = 64 * 1024 * 1024;  // 64MiB
+#endif
 }
 
 Application::Application(const QString &id, int &argc, char **argv)

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -105,7 +105,7 @@ public:
 
 protected:
 #ifndef DISABLE_GUI
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     bool event(QEvent *) override;
 #endif
 #endif

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -221,7 +221,7 @@ int main(int argc, char *argv[])
 #endif
 #endif // Q_OS_WIN
 
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
         // Since Apple made difficult for users to set PATH, we set here for convenience.
         // Users are supposed to install Homebrew Python for search function.
         // For more info see issue #5571.

--- a/src/base/filesystemwatcher.cpp
+++ b/src/base/filesystemwatcher.cpp
@@ -30,7 +30,7 @@
 
 #include <QtGlobal>
 
-#if defined(Q_OS_MAC) || defined(Q_OS_FREEBSD) || defined(Q_OS_OPENBSD)
+#if defined(Q_OS_MACOS) || defined(Q_OS_FREEBSD) || defined(Q_OS_OPENBSD)
 #include <cstring>
 #include <sys/mount.h>
 #include <sys/param.h>

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -29,7 +29,7 @@
 
 #include "preferences.h"
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 #include <CoreServices/CoreServices.h>
 #endif
 #ifdef Q_OS_WIN
@@ -188,7 +188,7 @@ void Preferences::setHideZeroComboValues(const int n)
 
 // In Mac OS X the dock is sufficient for our needs so we disable the sys tray functionality.
 // See extensive discussion in https://github.com/qbittorrent/qBittorrent/pull/3018
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
 bool Preferences::systrayIntegration() const
 {
     return value("Preferences/General/SystrayEnabled", true).toBool();
@@ -238,7 +238,7 @@ void Preferences::setCloseToTrayNotified(const bool b)
 {
     setValue("Preferences/General/CloseToTrayNotified", b);
 }
-#endif // Q_OS_MAC
+#endif // Q_OS_MACOS
 
 bool Preferences::isToolbarDisplayed() const
 {
@@ -884,7 +884,7 @@ void Preferences::resolvePeerHostNames(const bool resolve)
     setValue("Preferences/Connection/ResolvePeerHostNames", resolve);
 }
 
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
 bool Preferences::useSystemIconTheme() const
 {
     return value("Preferences/Advanced/useSystemIconTheme", true).toBool();
@@ -988,7 +988,7 @@ void Preferences::setMagnetLinkAssoc(const bool set)
 }
 #endif // Q_OS_WIN
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 namespace
 {
     const CFStringRef torrentExtension = CFSTR("torrent");
@@ -1042,7 +1042,7 @@ void Preferences::setMagnetLinkAssoc()
     const CFStringRef myBundleId = CFBundleGetIdentifier(CFBundleGetMainBundle());
     LSSetDefaultHandlerForURLScheme(magnetUrlScheme, myBundleId);
 }
-#endif // Q_OS_MAC
+#endif // Q_OS_MACOS
 
 int Preferences::getTrackerPort() const
 {
@@ -1054,7 +1054,7 @@ void Preferences::setTrackerPort(const int port)
     setValue("Preferences/Advanced/trackerPort", port);
 }
 
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
 bool Preferences::isUpdateCheckEnabled() const
 {
     return value("Preferences/Advanced/updateCheck", true).toBool();
@@ -1096,7 +1096,7 @@ void Preferences::setConfirmRemoveAllTags(const bool enabled)
     setValue("Preferences/Advanced/confirmRemoveAllTags", enabled);
 }
 
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
 TrayIcon::Style Preferences::trayIconStyle() const
 {
     return TrayIcon::Style(value("Preferences/Advanced/TrayIconStyle", TrayIcon::NORMAL).toInt());

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -254,7 +254,7 @@ public:
     void resolvePeerCountries(bool resolve);
     bool resolvePeerHostNames() const;
     void resolvePeerHostNames(bool resolve);
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
     bool useSystemIconTheme() const;
     void useSystemIconTheme(bool enabled);
 #endif
@@ -268,7 +268,7 @@ public:
     static void setTorrentFileAssoc(bool set);
     static void setMagnetLinkAssoc(bool set);
 #endif
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     static bool isTorrentFileAssocSet();
     static bool isMagnetLinkAssocSet();
     static void setTorrentFileAssoc();
@@ -276,7 +276,7 @@ public:
 #endif
     int getTrackerPort() const;
     void setTrackerPort(int port);
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
     bool isUpdateCheckEnabled() const;
     void setUpdateCheckEnabled(bool enabled);
 #endif
@@ -286,7 +286,7 @@ public:
     void setConfirmTorrentRecheck(bool enabled);
     bool confirmRemoveAllTags() const;
     void setConfirmRemoveAllTags(bool enabled);
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
     bool systrayIntegration() const;
     void setSystrayIntegration(bool enabled);
     bool minimizeToTrayNotified() const;
@@ -299,7 +299,7 @@ public:
     void setCloseToTrayNotified(bool b);
     TrayIcon::Style trayIconStyle() const;
     void setTrayIconStyle(TrayIcon::Style style);
-#endif // Q_OS_MAC
+#endif // Q_OS_MACOS
 
     // Stuff that don't appear in the Options GUI but are saved
     // in the same file.

--- a/src/base/private/profile_p.cpp
+++ b/src/base/private/profile_p.cpp
@@ -73,7 +73,7 @@ QString Private::DefaultProfile::configLocation() const
 
 QString Private::DefaultProfile::dataLocation() const
 {
-#if defined(Q_OS_WIN) || defined (Q_OS_MAC)
+#if defined(Q_OS_WIN) || defined (Q_OS_MACOS)
     return locationWithConfigurationName(QStandardPaths::AppLocalDataLocation);
 #else
     // on Linux gods know why qBittorrent creates 'data' subdirectory in ~/.local/share/
@@ -89,7 +89,7 @@ QString Private::DefaultProfile::downloadLocation() const
 
 SettingsPtr Private::DefaultProfile::applicationSettings(const QString &name) const
 {
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
     return SettingsPtr(new QSettings(QSettings::IniFormat, QSettings::UserScope, profileName(), name));
 #else
     return SettingsPtr(new QSettings(profileName(), name));
@@ -135,7 +135,7 @@ QString Private::CustomProfile::downloadLocation() const
 SettingsPtr Private::CustomProfile::applicationSettings(const QString &name) const
 {
     // here we force QSettings::IniFormat format always because we need it to be portable across platforms
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
     constexpr const char *CONF_FILE_EXTENSION = ".ini";
 #else
     constexpr const char *CONF_FILE_EXTENSION = ".conf";

--- a/src/base/utils/fs.cpp
+++ b/src/base/utils/fs.cpp
@@ -39,7 +39,7 @@
 
 #if defined(Q_OS_WIN)
 #include <Windows.h>
-#elif defined(Q_OS_MAC) || defined(Q_OS_FREEBSD) || defined(Q_OS_OPENBSD)
+#elif defined(Q_OS_MACOS) || defined(Q_OS_FREEBSD) || defined(Q_OS_OPENBSD)
 #include <sys/param.h>
 #include <sys/mount.h>
 #elif defined(Q_OS_HAIKU)
@@ -309,7 +309,7 @@ bool Utils::Fs::isNetworkFileSystem(const QString &path)
         return false;
 
     return (::GetDriveTypeW(volumePath.get()) == DRIVE_REMOTE);
-#elif defined(Q_OS_MAC) || defined(Q_OS_OPENBSD)
+#elif defined(Q_OS_MACOS) || defined(Q_OS_OPENBSD)
     QString file = path;
     if (!file.endsWith('/'))
         file += '/';

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -36,7 +36,7 @@
 #include <unistd.h>
 #endif
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 #include <Carbon/Carbon.h>
 #include <CoreServices/CoreServices.h>
 #endif
@@ -51,7 +51,7 @@
 #include <QSet>
 #include <QSysInfo>
 
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC)) && defined(QT_DBUS_LIB)
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)) && defined(QT_DBUS_LIB)
 #include <QDBusInterface>
 #endif
 
@@ -139,7 +139,7 @@ void Utils::Misc::shutdownComputer(const ShutdownDialogAction &action)
     tkp.Privileges[0].Attributes = 0;
     AdjustTokenPrivileges(hToken, FALSE, &tkp, 0, (PTOKEN_PRIVILEGES) NULL, 0);
 
-#elif defined(Q_OS_MAC)
+#elif defined(Q_OS_MACOS)
     AEEventID EventToSend;
     if (action != ShutdownDialogAction::Shutdown)
         EventToSend = kAESleep;

--- a/src/base/utils/string.cpp
+++ b/src/base/utils/string.cpp
@@ -35,7 +35,7 @@
 #include <QLocale>
 #include <QRegExp>
 #include <QtGlobal>
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 #include <QThreadStorage>
 #endif
 
@@ -139,7 +139,7 @@ int Utils::String::naturalCompare(const QString &left, const QString &right, con
     // provide a single `NaturalCompare` instance for easy use
     // https://doc.qt.io/qt-5/threads-reentrancy.html
     if (caseSensitivity == Qt::CaseSensitive) {
-#ifdef Q_OS_MAC  // workaround for Apple xcode: https://stackoverflow.com/a/29929949
+#ifdef Q_OS_MACOS  // workaround for Apple xcode: https://stackoverflow.com/a/29929949
         static QThreadStorage<NaturalCompare> nCmp;
         if (!nCmp.hasLocalData())
             nCmp.setLocalData(NaturalCompare(Qt::CaseSensitive));
@@ -150,7 +150,7 @@ int Utils::String::naturalCompare(const QString &left, const QString &right, con
 #endif
     }
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     static QThreadStorage<NaturalCompare> nCmp;
     if (!nCmp.hasLocalData())
         nCmp.setLocalData(NaturalCompare(Qt::CaseInsensitive));

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -80,7 +80,7 @@ enum AdvSettingsRows
     DOWNLOAD_TRACKER_FAVICON,
     SAVE_PATH_HISTORY_LENGTH,
     ENABLE_SPEED_WIDGET,
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
     USE_ICON_THEME,
 #endif
 
@@ -233,7 +233,7 @@ void AdvancedSettings::saveAdvancedSettings()
     session->setSeedChokingAlgorithm(static_cast<BitTorrent::SeedChokingAlgorithm>(m_comboBoxSeedChokingAlgorithm.currentIndex()));
 
     // Icon theme
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
     pref->useSystemIconTheme(m_checkBoxUseIconTheme.isChecked());
 #endif
     pref->setConfirmTorrentRecheck(m_checkBoxConfirmTorrentRecheck.isChecked());
@@ -515,7 +515,7 @@ void AdvancedSettings::loadAdvancedSettings()
     addRow(SEED_CHOKING_ALGORITHM, (tr("Upload choking algorithm") + ' ' + makeLink("https://www.libtorrent.org/reference-Settings.html#seed_choking_algorithm", "(?)"))
             , &m_comboBoxSeedChokingAlgorithm);
 
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
     m_checkBoxUseIconTheme.setChecked(pref->useSystemIconTheme());
     addRow(USE_ICON_THEME, tr("Use system icon theme"), &m_checkBoxUseIconTheme);
 #endif

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -69,7 +69,7 @@ private:
     QLineEdit m_lineEditAnnounceIP;
 
     // OS dependent settings
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
     QCheckBox m_checkBoxUseIconTheme;
 #endif
 };

--- a/src/gui/categoryfilterwidget.cpp
+++ b/src/gui/categoryfilterwidget.cpp
@@ -69,7 +69,7 @@ CategoryFilterWidget::CategoryFilterWidget(QWidget *parent)
     setUniformRowHeights(true);
     setHeaderHidden(true);
     setIconSize(Utils::Gui::smallIconSize());
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     setAttribute(Qt::WA_MacShowFocusRect, false);
 #endif
     m_defaultIndentation = indentation();

--- a/src/gui/executionlogwidget.cpp
+++ b/src/gui/executionlogwidget.cpp
@@ -44,7 +44,7 @@ ExecutionLogWidget::ExecutionLogWidget(QWidget *parent, const Log::MsgTypes &typ
 {
     m_ui->setupUi(this);
 
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
     m_ui->tabConsole->setTabIcon(0, UIThemeManager::instance()->getIcon("view-calendar-journal"));
     m_ui->tabConsole->setTabIcon(1, UIThemeManager::instance()->getIcon("view-filter"));
 #endif

--- a/src/gui/hidabletabwidget.cpp
+++ b/src/gui/hidabletabwidget.cpp
@@ -30,7 +30,7 @@
 
 #include <QTabBar>
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 #include <QPaintEvent>
 #include <QStyle>
 #endif
@@ -53,7 +53,7 @@ void HidableTabWidget::tabRemoved(const int index)
     tabBar()->setVisible(count() != 1);
 }
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 void HidableTabWidget::paintEvent(QPaintEvent *event)
 {
     // Hide the pane for macintosh style

--- a/src/gui/hidabletabwidget.h
+++ b/src/gui/hidabletabwidget.h
@@ -31,7 +31,7 @@
 
 #include <QTabWidget>
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 class QPaintEvent;
 #endif
 
@@ -44,7 +44,7 @@ private:
     void tabInserted(int index) override;
     void tabRemoved(int index) override;
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     void paintEvent(QPaintEvent *event) override;
 #endif
 };

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -43,11 +43,11 @@
 #include <QtGlobal>
 #include <QTimer>
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 #include <QtMac>
 #include <QtMacExtras>
 #endif
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC)) && defined(QT_DBUS_LIB)
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)) && defined(QT_DBUS_LIB)
 #include <QDBusConnection>
 #include "notifications.h"
 #endif
@@ -92,10 +92,10 @@
 #include "uithememanager.h"
 #include "utils.h"
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 #include "macutilities.h"
 #endif
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
 #include "programupdater.h"
 #endif
 
@@ -132,7 +132,7 @@ MainWindow::MainWindow(QWidget *parent)
     , m_posInitialized(false)
     , m_forceExit(false)
     , m_unlockDlgShowing(false)
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
     , m_wasUpdateCheckEnabled(false)
 #endif
     , m_hasPython(false)
@@ -144,7 +144,7 @@ MainWindow::MainWindow(QWidget *parent)
     setWindowTitle("qBittorrent " QBT_VERSION);
     m_displaySpeedInTitle = pref->speedInTitleBar();
     // Setting icons
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
 #ifdef Q_OS_UNIX
     const QIcon appLogo = Preferences::instance()->useSystemIconTheme()
         ? QIcon::fromTheme("qbittorrent", QIcon(":/icons/skin/qbittorrent-tray.svg"))
@@ -153,7 +153,7 @@ MainWindow::MainWindow(QWidget *parent)
     const QIcon appLogo(":/icons/skin/qbittorrent-tray.svg");
 #endif // Q_OS_UNIX
     setWindowIcon(appLogo);
-#endif // Q_OS_MAC
+#endif // Q_OS_MACOS
 
 #if (defined(Q_OS_UNIX))
     m_ui->actionOptions->setText(tr("Preferences"));
@@ -239,7 +239,7 @@ MainWindow::MainWindow(QWidget *parent)
     m_splitter->setCollapsible(0, true);
     m_splitter->setCollapsible(1, false);
     m_tabs->addTab(m_splitter,
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
         UIThemeManager::instance()->getIcon("folder-remote"),
 #endif
         tr("Transfers"));
@@ -259,7 +259,7 @@ MainWindow::MainWindow(QWidget *parent)
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackerWarning
         , m_transferListFiltersWidget, qOverload<BitTorrent::TorrentHandle *const, const QString &>(&TransferListFiltersWidget::trackerWarning));
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     // Increase top spacing to avoid tab overlapping
     m_ui->centralWidgetLayout->addSpacing(8);
 #endif
@@ -269,7 +269,7 @@ MainWindow::MainWindow(QWidget *parent)
     m_queueSeparator = m_ui->toolBar->insertSeparator(m_ui->actionTopQueuePos);
     m_queueSeparatorMenu = m_ui->menuEdit->insertSeparator(m_ui->actionTopQueuePos);
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     for (QAction *action : asConst(m_ui->toolBar->actions())) {
         if (action->isSeparator()) {
             QWidget *spacer = new QWidget(this);
@@ -291,7 +291,7 @@ MainWindow::MainWindow(QWidget *parent)
         spacer->setMinimumWidth(8);
         m_ui->toolBar->addWidget(spacer);
     }
-#endif // Q_OS_MAC
+#endif // Q_OS_MACOS
 
     // Transfer list slots
     connect(m_ui->actionStart, &QAction::triggered, m_transferListWidget, &TransferListWidget::startSelectedTorrents);
@@ -303,13 +303,13 @@ MainWindow::MainWindow(QWidget *parent)
     connect(m_ui->actionIncreaseQueuePos, &QAction::triggered, m_transferListWidget, &TransferListWidget::increaseQueuePosSelectedTorrents);
     connect(m_ui->actionDecreaseQueuePos, &QAction::triggered, m_transferListWidget, &TransferListWidget::decreaseQueuePosSelectedTorrents);
     connect(m_ui->actionBottomQueuePos, &QAction::triggered, m_transferListWidget, &TransferListWidget::bottomQueuePosSelectedTorrents);
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
     connect(m_ui->actionToggleVisibility, &QAction::triggered, this, [this]() { toggleVisibility(); });
 #endif
     connect(m_ui->actionMinimize, &QAction::triggered, this, &MainWindow::minimizeWindow);
     connect(m_ui->actionUseAlternativeSpeedLimits, &QAction::triggered, this, &MainWindow::toggleAlternativeSpeeds);
 
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
     m_programUpdateTimer = new QTimer(this);
     m_programUpdateTimer->setInterval(60 * 60 * 1000);
     m_programUpdateTimer->setSingleShot(true);
@@ -341,7 +341,7 @@ MainWindow::MainWindow(QWidget *parent)
     setAcceptDrops(true);
     createKeyboardShortcuts();
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     setUnifiedTitleAndToolBarOnMac(true);
 #endif
 
@@ -376,7 +376,7 @@ MainWindow::MainWindow(QWidget *parent)
     autoShutdownGroup->addAction(m_ui->actionAutoShutdown);
     autoShutdownGroup->addAction(m_ui->actionAutoSuspend);
     autoShutdownGroup->addAction(m_ui->actionAutoHibernate);
-#if (!defined(Q_OS_UNIX) || defined(Q_OS_MAC)) || defined(QT_DBUS_LIB)
+#if (!defined(Q_OS_UNIX) || defined(Q_OS_MACOS)) || defined(QT_DBUS_LIB)
     m_ui->actionAutoShutdown->setChecked(pref->shutdownWhenDownloadsComplete());
     m_ui->actionAutoSuspend->setChecked(pref->suspendWhenDownloadsComplete());
     m_ui->actionAutoHibernate->setChecked(pref->hibernateWhenDownloadsComplete());
@@ -393,7 +393,7 @@ MainWindow::MainWindow(QWidget *parent)
     // Load Window state and sizes
     readSettings();
 
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
     if (m_systrayIcon) {
         if (!(pref->startMinimized() || m_uiLocked)) {
             show();
@@ -422,7 +422,7 @@ MainWindow::MainWindow(QWidget *parent)
             activateWindow();
             raise();
         }
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
     }
 #endif
 
@@ -456,7 +456,7 @@ MainWindow::MainWindow(QWidget *parent)
         }
     }
 #endif
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     setupDockClickHandler();
     trayIconMenu()->setAsDockMenu();
 #endif
@@ -669,7 +669,7 @@ void MainWindow::displayRSSTab(bool enable)
         if (!m_rssWidget) {
             m_rssWidget = new RSSWidget(m_tabs);
             connect(m_rssWidget.data(), &RSSWidget::unreadCountUpdated, this, &MainWindow::handleRSSUnreadCountUpdated);
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
             m_tabs->addTab(m_rssWidget, tr("RSS (%1)").arg(RSS::Session::instance()->rootFolder()->unreadCount()));
 #else
             const int indexTab = m_tabs->addTab(m_rssWidget, tr("RSS (%1)").arg(RSS::Session::instance()->rootFolder()->unreadCount()));
@@ -707,7 +707,7 @@ void MainWindow::displaySearchTab(bool enable)
         if (!m_searchWidget) {
             m_searchWidget = new SearchWidget(this);
             m_tabs->insertTab(1, m_searchWidget,
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
                 UIThemeManager::instance()->getIcon("edit-find"),
 #endif
                 tr("Search"));
@@ -771,13 +771,13 @@ void MainWindow::cleanup()
     delete m_rssWidget;
 
     delete m_executableWatcher;
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
     if (m_systrayCreator)
         m_systrayCreator->stop();
 #endif
     if (m_preventTimer)
         m_preventTimer->stop();
-#if (defined(Q_OS_WIN) || defined(Q_OS_MAC))
+#if (defined(Q_OS_WIN) || defined(Q_OS_MACOS))
     m_programUpdateTimer->stop();
 #endif
 
@@ -851,7 +851,7 @@ void MainWindow::createKeyboardShortcuts()
     m_ui->actionDelete->setShortcutContext(Qt::WidgetShortcut);  // nullify its effect: delete key event is handled by respective widgets, not here
     m_ui->actionDownloadFromURL->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_O);
     m_ui->actionExit->setShortcut(Qt::CTRL + Qt::Key_Q);
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     m_ui->actionCloseWindow->setShortcut(QKeySequence::Close);
 #else
     m_ui->actionCloseWindow->setVisible(false);
@@ -878,7 +878,7 @@ void MainWindow::createKeyboardShortcuts()
     m_ui->actionDecreaseQueuePos->setShortcut(Qt::CTRL + Qt::Key_Minus);
     m_ui->actionIncreaseQueuePos->setShortcut(Qt::CTRL + Qt::Key_Plus);
     m_ui->actionTopQueuePos->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_Plus);
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     m_ui->actionMinimize->setShortcut(Qt::CTRL + Qt::Key_M);
     addAction(m_ui->actionMinimize);
 #endif
@@ -998,7 +998,7 @@ void MainWindow::on_actionExit_triggered()
     close();
 }
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 void MainWindow::on_actionCloseWindow_triggered()
 {
     // On macOS window close is basically equivalent to window hide.
@@ -1057,7 +1057,7 @@ void MainWindow::notifyOfUpdate(const QString &)
     m_executableWatcher = nullptr;
 }
 
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
 // Toggle Main window visibility
 void MainWindow::toggleVisibility(const QSystemTrayIcon::ActivationReason reason)
 {
@@ -1084,7 +1084,7 @@ void MainWindow::toggleVisibility(const QSystemTrayIcon::ActivationReason reason
         break;
     }
 }
-#endif // Q_OS_MAC
+#endif // Q_OS_MACOS
 
 // Display About Dialog
 void MainWindow::on_actionAbout_triggered()
@@ -1124,7 +1124,7 @@ void MainWindow::showEvent(QShowEvent *e)
 void MainWindow::closeEvent(QCloseEvent *e)
 {
     Preferences *const pref = Preferences::instance();
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     if (!m_forceExit) {
         hide();
         e->accept();
@@ -1141,7 +1141,7 @@ void MainWindow::closeEvent(QCloseEvent *e)
         }
         return;
     }
-#endif // Q_OS_MAC
+#endif // Q_OS_MACOS
 
     if (pref->confirmOnExit() && BitTorrent::Session::instance()->hasActiveTorrents()) {
         if (e->spontaneous() || m_forceExit) {
@@ -1173,7 +1173,7 @@ void MainWindow::closeEvent(QCloseEvent *e)
         delete m_searchWidget;
 
     hide();
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
     // Hide tray icon
     if (m_systrayIcon)
         m_systrayIcon->hide();
@@ -1201,7 +1201,7 @@ void MainWindow::createTorrentTriggered(const QString &path)
 
 bool MainWindow::event(QEvent *e)
 {
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
     switch (e->type()) {
     case QEvent::WindowStateChange: {
         qDebug("Window change event");
@@ -1246,7 +1246,7 @@ bool MainWindow::event(QEvent *e)
     default:
         break;
     }
-#endif // Q_OS_MAC
+#endif // Q_OS_MACOS
 
     return QMainWindow::event(e);
 }
@@ -1313,7 +1313,7 @@ void MainWindow::dragEnterEvent(QDragEnterEvent *event)
         event->acceptProposedAction();
 }
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 
 static MainWindow *dockMainWindowHandle;
 
@@ -1335,7 +1335,7 @@ void MainWindow::setupDockClickHandler()
     MacUtils::overrideDockClickHandler(dockClickHandler);
 }
 
-#endif // Q_OS_MAC
+#endif // Q_OS_MACOS
 
 /*****************************************************
 *                                                   *
@@ -1405,7 +1405,7 @@ void MainWindow::loadPreferences(bool configureSession)
 {
     Logger::instance()->addMessage(tr("Options were saved successfully."));
     const Preferences *const pref = Preferences::instance();
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     Q_UNUSED(configureSession);
 #else
     const bool newSystrayIntegration = pref->systrayIntegration();
@@ -1472,7 +1472,7 @@ void MainWindow::loadPreferences(bool configureSession)
             m_ui->actionIncreaseQueuePos->setVisible(true);
             m_ui->actionTopQueuePos->setVisible(true);
             m_ui->actionBottomQueuePos->setVisible(true);
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
             m_queueSeparator->setVisible(true);
 #endif
             m_queueSeparatorMenu->setVisible(true);
@@ -1485,7 +1485,7 @@ void MainWindow::loadPreferences(bool configureSession)
             m_ui->actionIncreaseQueuePos->setVisible(false);
             m_ui->actionTopQueuePos->setVisible(false);
             m_ui->actionBottomQueuePos->setVisible(false);
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
             m_queueSeparator->setVisible(false);
 #endif
             m_queueSeparatorMenu->setVisible(false);
@@ -1495,7 +1495,7 @@ void MainWindow::loadPreferences(bool configureSession)
     // Torrent properties
     m_propertiesWidget->reloadPreferences();
 
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
     if (pref->isUpdateCheckEnabled() && !m_wasUpdateCheckEnabled) {
         m_wasUpdateCheckEnabled = true;
         checkProgramUpdate();
@@ -1518,7 +1518,7 @@ void MainWindow::updateGUI()
     const BitTorrent::SessionStatus &status = BitTorrent::Session::instance()->status();
 
     // update global information
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
     if (m_systrayIcon) {
 #ifdef Q_OS_UNIX
         const QString html = QString(QLatin1String(
@@ -1547,7 +1547,7 @@ void MainWindow::updateGUI()
             .arg(Utils::Misc::friendlyUnit(status.payloadDownloadRate)));
     else if (!QtMac::badgeLabelText().isEmpty())
         QtMac::setBadgeLabelText("");
-#endif // Q_OS_MAC
+#endif // Q_OS_MACOS
 
     if (m_displaySpeedInTitle) {
         setWindowTitle(tr("[D: %1, U: %2] qBittorrent %3", "D = Download; U = Upload; %3 is qBittorrent version")
@@ -1560,7 +1560,7 @@ void MainWindow::updateGUI()
 void MainWindow::showNotificationBaloon(const QString &title, const QString &msg) const
 {
     if (!isNotificationsEnabled()) return;
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC)) && defined(QT_DBUS_LIB)
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)) && defined(QT_DBUS_LIB)
     org::freedesktop::Notifications notifications("org.freedesktop.Notifications",
                                                   "/org/freedesktop/Notifications",
                                                   QDBusConnection::sessionBus());
@@ -1580,7 +1580,7 @@ void MainWindow::showNotificationBaloon(const QString &title, const QString &msg
     reply.waitForFinished();
     if (!reply.isError())
         return;
-#elif defined(Q_OS_MAC)
+#elif defined(Q_OS_MACOS)
     MacUtils::displayNotification(title, msg);
 #else
     if (m_systrayIcon && QSystemTrayIcon::supportsMessages())
@@ -1611,7 +1611,7 @@ void MainWindow::downloadFromURLList(const QStringList &urlList)
 *                                                   *
 *****************************************************/
 
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
 void MainWindow::createSystrayDelayed()
 {
     static int timeout = 20;
@@ -1654,14 +1654,14 @@ void MainWindow::createTrayIcon()
     connect(m_systrayIcon.data(), &QSystemTrayIcon::activated, this, &MainWindow::toggleVisibility);
     m_systrayIcon->show();
 }
-#endif // Q_OS_MAC
+#endif // Q_OS_MACOS
 
 QMenu *MainWindow::trayIconMenu()
 {
     if (m_trayIconMenu) return m_trayIconMenu;
 
     m_trayIconMenu = new QMenu(this);
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
     connect(m_trayIconMenu.data(), &QMenu::aboutToShow, this, &MainWindow::updateTrayIconMenu);
     m_trayIconMenu->addAction(m_ui->actionToggleVisibility);
     m_trayIconMenu->addSeparator();
@@ -1678,7 +1678,7 @@ QMenu *MainWindow::trayIconMenu()
     m_trayIconMenu->addSeparator();
     m_trayIconMenu->addAction(m_ui->actionStartAll);
     m_trayIconMenu->addAction(m_ui->actionPauseAll);
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
     m_trayIconMenu->addSeparator();
     m_trayIconMenu->addAction(m_ui->actionExit);
 #endif
@@ -1803,7 +1803,7 @@ void MainWindow::on_actionDownloadFromURL_triggered()
     }
 }
 
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
 void MainWindow::handleUpdateCheckFinished(bool updateAvailable, QString newVersion, bool invokedByUser)
 {
     QMessageBox::StandardButton answer = QMessageBox::Yes;
@@ -1860,7 +1860,7 @@ void MainWindow::on_actionExecutionLogs_triggered(bool checked)
     if (checked) {
         Q_ASSERT(!m_executionLog);
         m_executionLog = new ExecutionLogWidget(m_tabs, static_cast<Log::MsgType>(executionLogMsgTypes()));
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
         m_tabs->addTab(m_executionLog, tr("Execution Log"));
 #else
         const int indexTab = m_tabs->addTab(m_executionLog, tr("Execution Log"));
@@ -1949,12 +1949,12 @@ void MainWindow::updatePowerManagementState()
     m_pwr->setActivityState(inhibitSuspend);
 }
 
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
 QIcon MainWindow::getSystrayIcon() const
 {
     const TrayIcon::Style style = Preferences::instance()->trayIconStyle();
     // on Linux we use theme icons, and icons from resources everywhere else
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
     switch (style) {
     case TrayIcon::NORMAL:
         return QIcon::fromTheme(QLatin1String("qbittorrent-tray"));
@@ -1981,9 +1981,9 @@ QIcon MainWindow::getSystrayIcon() const
     // As a failsafe in case the enum is invalid
     return QIcon(QLatin1String(":/icons/skin/qbittorrent-tray.svg"));
 }
-#endif // Q_OS_MAC
+#endif // Q_OS_MACOS
 
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
 void MainWindow::checkProgramUpdate()
 {
     m_programUpdateTimer->stop(); // If the user had clicked the menu item

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -32,7 +32,7 @@
 #include <QMainWindow>
 #include <QPointer>
 
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
 #include <QSystemTrayIcon>
 #endif
 
@@ -134,7 +134,7 @@ private slots:
     void finishedTorrent(BitTorrent::TorrentHandle *const torrent) const;
     void askRecursiveTorrentDownloadConfirmation(BitTorrent::TorrentHandle *const torrent);
     void optionsSaved();
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
     void handleUpdateCheckFinished(bool updateAvailable, QString newVersion, bool invokedByUser);
 #endif
     void toggleAlternativeSpeeds();
@@ -178,7 +178,7 @@ private slots:
     void on_actionLock_triggered();
     // Check for unpaused downloading or seeding torrents and prevent system suspend/sleep according to preferences
     void updatePowerManagementState();
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
     void checkProgramUpdate();
 #endif
     void toolbarMenuRequested(const QPoint &point);
@@ -187,7 +187,7 @@ private slots:
     void toolbarTextBeside();
     void toolbarTextUnder();
     void toolbarFollowSystem();
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     void on_actionCloseWindow_triggered();
 #else
     void toggleVisibility(const QSystemTrayIcon::ActivationReason reason = QSystemTrayIcon::Trigger);
@@ -196,7 +196,7 @@ private slots:
 #endif
 
 private:
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     void setupDockClickHandler();
 #else
     void createTrayIcon();
@@ -228,7 +228,7 @@ private:
     QPointer<StatsDialog> m_statsDlg;
     QPointer<TorrentCreatorDialog> m_createTorrentDlg;
     QPointer<DownloadFromURLDialog> m_downloadFromURLDialog;
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
     QPointer<QSystemTrayIcon> m_systrayIcon;
     QPointer<QTimer> m_systrayCreator;
 #endif
@@ -252,7 +252,7 @@ private:
     // Power Management
     PowerManagement *m_pwr;
     QTimer *m_preventTimer;
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
     QTimer *m_programUpdateTimer;
     bool m_wasUpdateCheckEnabled;
 #endif

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -182,7 +182,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
 
     // Load options
     loadOptions();
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     m_ui->checkShowSystray->setVisible(false);
 #else
     // Disable systray integration if it is not supported by the system
@@ -198,7 +198,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     m_ui->checkStartup->setVisible(false);
 #endif
 
-#if !(defined(Q_OS_WIN) || defined(Q_OS_MAC))
+#if !(defined(Q_OS_WIN) || defined(Q_OS_MACOS))
     m_ui->groupFileAssociation->setVisible(false);
     m_ui->checkProgramUpdates->setVisible(false);
 #endif
@@ -237,11 +237,11 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     connect(m_ui->checkPreventFromSuspendWhenDownloading, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkPreventFromSuspendWhenSeeding, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->comboTrayIcon, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC)) && !defined(QT_DBUS_LIB)
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)) && !defined(QT_DBUS_LIB)
     m_ui->checkPreventFromSuspendWhenDownloading->setDisabled(true);
     m_ui->checkPreventFromSuspendWhenSeeding->setDisabled(true);
 #endif
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
     connect(m_ui->checkAssociateTorrents, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkAssociateMagnetLinks, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkProgramUpdates, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
@@ -611,7 +611,7 @@ void OptionsDialog::saveOptions()
     pref->setAlternatingRowColors(m_ui->checkAltRowColors->isChecked());
     pref->setHideZeroValues(m_ui->checkHideZero->isChecked());
     pref->setHideZeroComboValues(m_ui->comboHideZero->currentIndex());
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
     pref->setSystrayIntegration(systrayIntegration());
     pref->setTrayIconStyle(TrayIcon::Style(m_ui->comboTrayIcon->currentIndex()));
     pref->setCloseToTray(closeToTray());
@@ -629,7 +629,7 @@ void OptionsDialog::saveOptions()
     Preferences::setTorrentFileAssoc(m_ui->checkAssociateTorrents->isChecked());
     Preferences::setMagnetLinkAssoc(m_ui->checkAssociateMagnetLinks->isChecked());
 #endif
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     if (m_ui->checkAssociateTorrents->isChecked()) {
         Preferences::setTorrentFileAssoc();
         m_ui->checkAssociateTorrents->setChecked(Preferences::isTorrentFileAssocSet());
@@ -641,7 +641,7 @@ void OptionsDialog::saveOptions()
         m_ui->checkAssociateMagnetLinks->setEnabled(!m_ui->checkAssociateMagnetLinks->isChecked());
     }
 #endif
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
     pref->setUpdateCheckEnabled(m_ui->checkProgramUpdates->isChecked());
 #endif
     auto *const app = static_cast<Application *>(QCoreApplication::instance());
@@ -851,7 +851,7 @@ void OptionsDialog::loadOptions()
     m_ui->checkProgramExitConfirm->setChecked(pref->confirmOnExit());
     m_ui->checkProgramAutoExitConfirm->setChecked(!pref->dontConfirmAutoExit());
 
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
     m_ui->checkShowSystray->setChecked(pref->systrayIntegration());
     if (m_ui->checkShowSystray->isChecked()) {
         m_ui->checkMinimizeToSysTray->setChecked(pref->minimizeToTray());
@@ -868,13 +868,13 @@ void OptionsDialog::loadOptions()
     m_ui->checkAssociateTorrents->setChecked(Preferences::isTorrentFileAssocSet());
     m_ui->checkAssociateMagnetLinks->setChecked(Preferences::isMagnetLinkAssocSet());
 #endif
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     m_ui->checkAssociateTorrents->setChecked(Preferences::isTorrentFileAssocSet());
     m_ui->checkAssociateTorrents->setEnabled(!m_ui->checkAssociateTorrents->isChecked());
     m_ui->checkAssociateMagnetLinks->setChecked(Preferences::isMagnetLinkAssocSet());
     m_ui->checkAssociateMagnetLinks->setEnabled(!m_ui->checkAssociateMagnetLinks->isChecked());
 #endif
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
     m_ui->checkProgramUpdates->setChecked(pref->isUpdateCheckEnabled());
 #endif
 
@@ -1222,7 +1222,7 @@ bool OptionsDialog::startMinimized() const
     return m_ui->checkStartMinimized->isChecked();
 }
 
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
 bool OptionsDialog::systrayIntegration() const
 {
     if (!QSystemTrayIcon::isSystemTrayAvailable()) return false;
@@ -1240,7 +1240,7 @@ bool OptionsDialog::closeToTray() const
     if (!m_ui->checkShowSystray->isChecked()) return false;
     return m_ui->checkCloseToSystray->isChecked();
 }
-#endif // Q_OS_MAC
+#endif // Q_OS_MACOS
 
 // Return Share ratio
 qreal OptionsDialog::getMaxRatio() const

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -120,7 +120,7 @@ private:
     static QString languageToLocalizedString(const QLocale &locale);
     // General options
     QString getLocale() const;
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
     bool systrayIntegration() const;
     bool minimizeToTray() const;
     bool closeToTray() const;

--- a/src/gui/powermanagement/powermanagement.cpp
+++ b/src/gui/powermanagement/powermanagement.cpp
@@ -30,11 +30,11 @@
 
 #include <QtGlobal>
 
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC)) && defined(QT_DBUS_LIB)
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)) && defined(QT_DBUS_LIB)
 #include "powermanagement_x11.h"
 #endif
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 #include <IOKit/pwr_mgt/IOPMLib.h>
 #endif
 
@@ -46,7 +46,7 @@ PowerManagement::PowerManagement(QObject *parent)
     : QObject(parent)
     , m_busy(false)
 {
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC)) && defined(QT_DBUS_LIB)
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)) && defined(QT_DBUS_LIB)
     m_inhibitor = new PowerManagementInhibitor(this);
 #endif
 }
@@ -70,9 +70,9 @@ void PowerManagement::setBusy()
 
 #ifdef Q_OS_WIN
     SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED);
-#elif (defined(Q_OS_UNIX) && !defined(Q_OS_MAC)) && defined(QT_DBUS_LIB)
+#elif (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)) && defined(QT_DBUS_LIB)
     m_inhibitor->requestBusy();
-#elif defined(Q_OS_MAC)
+#elif defined(Q_OS_MACOS)
     IOReturn success = IOPMAssertionCreateWithName(kIOPMAssertionTypeNoIdleSleep, kIOPMAssertionLevelOn
         , tr("qBittorrent is active").toCFString(), &m_assertionID);
     if (success != kIOReturnSuccess)
@@ -87,9 +87,9 @@ void PowerManagement::setIdle()
 
 #ifdef Q_OS_WIN
     SetThreadExecutionState(ES_CONTINUOUS);
-#elif (defined(Q_OS_UNIX) && !defined(Q_OS_MAC)) && defined(QT_DBUS_LIB)
+#elif (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)) && defined(QT_DBUS_LIB)
     m_inhibitor->requestIdle();
-#elif defined(Q_OS_MAC)
+#elif defined(Q_OS_MACOS)
     IOPMAssertionRelease(m_assertionID);
 #endif
 }

--- a/src/gui/powermanagement/powermanagement.h
+++ b/src/gui/powermanagement/powermanagement.h
@@ -31,12 +31,12 @@
 
 #include <QObject>
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 // Require Mac OS X >= 10.5
 #include <IOKit/pwr_mgt/IOPMLib.h>
 #endif
 
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC)) && defined(QT_DBUS_LIB)
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)) && defined(QT_DBUS_LIB)
 // Require DBus
 class PowerManagementInhibitor;
 #endif
@@ -57,10 +57,10 @@ private:
   void setBusy();
   void setIdle();
 
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC)) && defined(QT_DBUS_LIB)
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)) && defined(QT_DBUS_LIB)
   PowerManagementInhibitor *m_inhibitor;
 #endif
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
   IOPMAssertionID m_assertionID;
 #endif
 };

--- a/src/gui/programupdater.cpp
+++ b/src/gui/programupdater.cpp
@@ -78,7 +78,7 @@ void ProgramUpdater::rssDownloadFinished(const Net::DownloadResult &result)
 
     qDebug("Finished downloading the new qBittorrent updates RSS");
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     const QString OS_TYPE {"Mac OS X"};
 #elif defined(Q_OS_WIN)
     const QString OS_TYPE {(::IsWindows7OrGreater()

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -67,7 +67,7 @@
 
 #include "ui_propertieswidget.h"
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 #include "macutilities.h"
 #endif
 
@@ -553,7 +553,7 @@ void PropertiesWidget::openFolder(const QModelIndex &index, bool containingFolde
 
     // Flush data
     m_torrent->flushCache();
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     Q_UNUSED(containingFolder);
     MacUtils::openFiles(QSet<QString>{absolutePath});
 #else

--- a/src/gui/properties/proptabbar.cpp
+++ b/src/gui/properties/proptabbar.cpp
@@ -45,7 +45,7 @@ PropTabBar::PropTabBar(QWidget *parent)
     m_btnGroup = new QButtonGroup(this);
     // General tab
     QPushButton *mainInfosButton = new QPushButton(
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
             UIThemeManager::instance()->getIcon("document-properties"),
 #endif
             tr("General"), parent);
@@ -54,7 +54,7 @@ PropTabBar::PropTabBar(QWidget *parent)
     m_btnGroup->addButton(mainInfosButton, MainTab);
     // Trackers tab
     QPushButton *trackersButton = new QPushButton(
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
             UIThemeManager::instance()->getIcon("network-server"),
 #endif
             tr("Trackers"), parent);
@@ -63,7 +63,7 @@ PropTabBar::PropTabBar(QWidget *parent)
     m_btnGroup->addButton(trackersButton, TrackersTab);
     // Peers tab
     QPushButton *peersButton = new QPushButton(
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
             UIThemeManager::instance()->getIcon("edit-find-user"),
 #endif
             tr("Peers"), parent);
@@ -72,7 +72,7 @@ PropTabBar::PropTabBar(QWidget *parent)
     m_btnGroup->addButton(peersButton, PeersTab);
     // URL seeds tab
     QPushButton *URLSeedsButton = new QPushButton(
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
             UIThemeManager::instance()->getIcon("network-server"),
 #endif
             tr("HTTP Sources"), parent);
@@ -81,7 +81,7 @@ PropTabBar::PropTabBar(QWidget *parent)
     m_btnGroup->addButton(URLSeedsButton, URLSeedsTab);
     // Files tab
     QPushButton *filesButton = new QPushButton(
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
             UIThemeManager::instance()->getIcon("inode-directory"),
 #endif
             tr("Content"), parent);
@@ -92,7 +92,7 @@ PropTabBar::PropTabBar(QWidget *parent)
     addItem(new QSpacerItem(0, 0, QSizePolicy::Expanding, QSizePolicy::Fixed));
     // Speed tab
     QPushButton *speedButton = new QPushButton(
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
             UIThemeManager::instance()->getIcon("office-chart-line"),
 #endif
             tr("Speed"), parent);

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -72,7 +72,7 @@ RSSWidget::RSSWidget(QWidget *parent)
     m_ui->actionRename->setIcon(UIThemeManager::instance()->getIcon("edit-rename"));
     m_ui->actionUpdate->setIcon(UIThemeManager::instance()->getIcon("view-refresh"));
     m_ui->actionUpdateAllFeeds->setIcon(UIThemeManager::instance()->getIcon("view-refresh"));
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
     m_ui->newFeedButton->setIcon(UIThemeManager::instance()->getIcon("list-add"));
     m_ui->markReadButton->setIcon(UIThemeManager::instance()->getIcon("mail-mark-read"));
     m_ui->updateAllButton->setIcon(UIThemeManager::instance()->getIcon("view-refresh"));

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -102,7 +102,7 @@ SearchWidget::SearchWidget(MainWindow *mainWindow)
            << "</p></body></html>" << flush;
     m_ui->lineEditSearchPattern->setToolTip(searchPatternHint);
 
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
     // Icons
     m_ui->searchButton->setIcon(UIThemeManager::instance()->getIcon("edit-find"));
     m_ui->pluginsButton->setIcon(UIThemeManager::instance()->getIcon("preferences-system-network"));

--- a/src/gui/statusbar.cpp
+++ b/src/gui/statusbar.cpp
@@ -45,7 +45,7 @@
 StatusBar::StatusBar(QWidget *parent)
     : QStatusBar(parent)
 {
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
     // Redefining global stylesheet breaks certain elements on mac like tabs.
     // Qt checks whether the stylesheet class inherts("QMacStyle") and this becomes false.
     qApp->setStyleSheet("QStatusBar::item { border-width: 0; }");
@@ -111,22 +111,22 @@ StatusBar::StatusBar(QWidget *parent)
 
     QFrame *statusSep1 = new QFrame(this);
     statusSep1->setFrameStyle(QFrame::VLine);
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
     statusSep1->setFrameShadow(QFrame::Raised);
 #endif
     QFrame *statusSep2 = new QFrame(this);
     statusSep2->setFrameStyle(QFrame::VLine);
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
     statusSep2->setFrameShadow(QFrame::Raised);
 #endif
     QFrame *statusSep3 = new QFrame(this);
     statusSep3->setFrameStyle(QFrame::VLine);
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
     statusSep3->setFrameShadow(QFrame::Raised);
 #endif
     QFrame *statusSep4 = new QFrame(this);
     statusSep4->setFrameStyle(QFrame::VLine);
-#ifndef Q_OS_MAC
+#ifndef Q_OS_MACOS
     statusSep4->setFrameShadow(QFrame::Raised);
 #endif
     layout->addWidget(m_DHTLbl);

--- a/src/gui/tagfilterwidget.cpp
+++ b/src/gui/tagfilterwidget.cpp
@@ -69,7 +69,7 @@ TagFilterWidget::TagFilterWidget(QWidget *parent)
     setUniformRowHeights(true);
     setHeaderHidden(true);
     setIconSize(Utils::Gui::smallIconSize());
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
     setAttribute(Qt::WA_MacShowFocusRect, false);
 #endif
     setIndentation(0);

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -43,7 +43,7 @@
 #include <QMimeType>
 #endif
 
-#if defined Q_OS_WIN || defined Q_OS_MAC
+#if defined Q_OS_WIN || defined Q_OS_MACOS
 #define QBT_PIXMAP_CACHE_FOR_FILE_ICONS
 #include <QPixmapCache>
 #endif
@@ -57,7 +57,7 @@
 #include "torrentcontentmodelitem.h"
 #include "uithememanager.h"
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 #include "macutilities.h"
 #endif
 
@@ -121,7 +121,7 @@ namespace
             return iconPixmap;
         }
     };
-#elif defined(Q_OS_MAC)
+#elif defined(Q_OS_MACOS)
     // There is a similar bug on macOS, to be reported to Qt
     // https://github.com/qbittorrent/qBittorrent/pull/6156#issuecomment-316302615
     class MacFileIconProvider final : public CachingFileIconProvider
@@ -184,7 +184,7 @@ TorrentContentModel::TorrentContentModel(QObject *parent)
 {
 #if defined(Q_OS_WIN)
     m_fileIconProvider = new WinShellFileIconProvider();
-#elif defined(Q_OS_MAC)
+#elif defined(Q_OS_MACOS)
     m_fileIconProvider = new MacFileIconProvider();
 #else
     static bool doesBuiltInProviderWork = doesQFileIconProviderWork();

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -103,7 +103,7 @@ BaseFilterWidget::BaseFilterWidget(QWidget *parent, TransferListWidget *transfer
 
     setIconSize(Utils::Gui::smallIconSize());
 
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
     setAttribute(Qt::WA_MacShowFocusRect, false);
 #endif
 

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -69,7 +69,7 @@
 #include "updownratiodialog.h"
 #include "utils.h"
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 #include "macutilities.h"
 #endif
 
@@ -131,7 +131,7 @@ TransferListWidget::TransferListWidget(QWidget *parent, MainWindow *mainWindow)
     setItemsExpandable(false);
     setAutoScroll(true);
     setDragDropMode(QAbstractItemView::DragOnly);
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
     setAttribute(Qt::WA_MacShowFocusRect, false);
 #endif
     header()->setStretchLastSection(false);
@@ -259,7 +259,7 @@ void TransferListWidget::torrentDoubleClicked()
             torrent->pause();
         break;
     case OPEN_DEST:
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
         MacUtils::openFiles(QSet<QString>{torrent->contentPath(true)});
 #else
         if (torrent->filesCount() == 1)
@@ -455,7 +455,7 @@ void TransferListWidget::hideQueuePosColumn(bool hide)
 void TransferListWidget::openSelectedTorrentsFolder() const
 {
     QSet<QString> pathsList;
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     // On macOS you expect both the files and folders to be opened in their parent
     // folders prehilighted for opening, so we use a custom method.
     for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents())) {
@@ -474,7 +474,7 @@ void TransferListWidget::openSelectedTorrentsFolder() const
         }
         pathsList.insert(path);
     }
-#endif // Q_OS_MAC
+#endif // Q_OS_MACOS
 }
 
 void TransferListWidget::previewSelectedTorrents()

--- a/src/gui/uithememanager.cpp
+++ b/src/gui/uithememanager.cpp
@@ -62,7 +62,7 @@ UIThemeManager::UIThemeManager()
         && !QResource::registerResource(pref->customUIThemePath(), "/uitheme"))
         LogMsg(tr("Failed to load UI theme from file: \"%1\"").arg(pref->customUIThemePath()), Log::WARNING);
 
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
     m_useSystemTheme = pref->useSystemIconTheme();
 #endif
 }
@@ -97,7 +97,7 @@ QIcon UIThemeManager::getIcon(const QString &iconId) const
 
 QIcon UIThemeManager::getIcon(const QString &iconId, const QString &fallback) const
 {
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
     if (m_useSystemTheme) {
         QIcon icon = QIcon::fromTheme(iconId);
         if (icon.name() != iconId)
@@ -126,7 +126,7 @@ QIcon UIThemeManager::getFlagIcon(const QString &countryIsoCode) const
 
 QString UIThemeManager::getIconPath(const QString &iconId) const
 {
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
     if (m_useSystemTheme) {
         QString path = Utils::Fs::tempPath() + iconId + ".png";
         if (!QFile::exists(path)) {

--- a/src/gui/uithememanager.h
+++ b/src/gui/uithememanager.h
@@ -54,7 +54,7 @@ private:
     QString getIconPath(const QString &iconId) const;
 
     static UIThemeManager *m_instance;
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MAC))
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
     bool m_useSystemTheme;
 #endif
 };

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -68,7 +68,7 @@ qreal Utils::Gui::screenScalingFactor(const QWidget *widget)
 #ifdef Q_OS_WIN
     const int screen = qApp->desktop()->screenNumber(widget);
     return (QApplication::screens()[screen]->logicalDotsPerInch() / 96);
-#elif defined(Q_OS_MAC)
+#elif defined(Q_OS_MACOS)
     return 1;
 #else
     return widget->devicePixelRatioF();
@@ -181,7 +181,7 @@ void Utils::Gui::openFolderSelect(const QString &absolutePath)
     }
     if ((hresult == S_OK) || (hresult == S_FALSE))
         ::CoUninitialize();
-#elif defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
+#elif defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
     QProcess proc;
     proc.start("xdg-mime", {"query", "default", "inode/directory"});
     proc.waitForFinished();


### PR DESCRIPTION
`Q_OS_MAC` is deprecated and the replacement is `Q_OS_MACOS`.