### PR TITLE
Add option to align file to piece boundary when creating new torrent

### DIFF
--- a/src/base/bittorrent/torrentcreatorthread.cpp
+++ b/src/base/bittorrent/torrentcreatorthread.cpp
@@ -54,7 +54,7 @@ namespace
 #else
     using LTCreateFlags = lt::create_flags_t;
     using LTPieceIndex = lt::piece_index_t;
-#endif    
+#endif
 
     // do not include files and folders whose
     // name starts with a .
@@ -138,8 +138,8 @@ void TorrentCreatorThread::run()
 
         if (isInterruptionRequested()) return;
 
-        lt::create_torrent newTorrent(fs, m_params.pieceSize, -1
-                                        , (m_params.isAlignmentOptimized ? lt::create_torrent::optimize_alignment : LTCreateFlags {}));
+        lt::create_torrent newTorrent(fs, m_params.pieceSize, m_params.paddedFileSizeLimit
+            , (m_params.isAlignmentOptimized ? lt::create_torrent::optimize_alignment : LTCreateFlags {}));
 
         // Add url seeds
         for (QString seed : asConst(m_params.urlSeeds)) {
@@ -205,7 +205,7 @@ void TorrentCreatorThread::run()
     }
 }
 
-int TorrentCreatorThread::calculateTotalPieces(const QString &inputPath, const int pieceSize, const bool isAlignmentOptimized)
+int TorrentCreatorThread::calculateTotalPieces(const QString &inputPath, const int pieceSize, const bool isAlignmentOptimized, const int paddedFileSizeLimit)
 {
     if (inputPath.isEmpty())
         return 0;
@@ -213,6 +213,6 @@ int TorrentCreatorThread::calculateTotalPieces(const QString &inputPath, const i
     lt::file_storage fs;
     lt::add_files(fs, Utils::Fs::toNativePath(inputPath).toStdString(), fileFilter);
 
-    return lt::create_torrent(fs, pieceSize, -1
-                                , (isAlignmentOptimized ? lt::create_torrent::optimize_alignment : LTCreateFlags {})).num_pieces();
+    return lt::create_torrent(fs, pieceSize, paddedFileSizeLimit
+        , (isAlignmentOptimized ? lt::create_torrent::optimize_alignment : LTCreateFlags {})).num_pieces();
 }

--- a/src/base/bittorrent/torrentcreatorthread.h
+++ b/src/base/bittorrent/torrentcreatorthread.h
@@ -39,6 +39,7 @@ namespace BitTorrent
         bool isPrivate;
         bool isAlignmentOptimized;
         int pieceSize;
+        int paddedFileSizeLimit;
         QString inputPath;
         QString savePath;
         QString comment;
@@ -57,7 +58,8 @@ namespace BitTorrent
 
         void create(const TorrentCreatorParams &params);
 
-        static int calculateTotalPieces(const QString &inputPath, int pieceSize, bool isAlignmentOptimized);
+        static int calculateTotalPieces(const QString &inputPath
+            , const int pieceSize, const bool isAlignmentOptimized, int paddedFileSizeLimit);
 
     protected:
         void run() override;

--- a/src/gui/torrentcreatordialog.h
+++ b/src/gui/torrentcreatordialog.h
@@ -68,8 +68,10 @@ private:
 
     void saveSettings();
     void loadSettings();
+    void setInteractionEnabled(bool enabled) const;
+
     int getPieceSize() const;
-    void setInteractionEnabled(bool enabled);
+    int getPaddedFileSizeLimit() const;
 
     Ui::TorrentCreatorDialog *m_ui;
     BitTorrent::TorrentCreatorThread *m_creatorThread;
@@ -81,6 +83,7 @@ private:
     CachedSettingValue<bool> m_storeStartSeeding;
     CachedSettingValue<bool> m_storeIgnoreRatio;
     CachedSettingValue<bool> m_storeOptimizeAlignment;
+    CachedSettingValue<int> m_paddedFileSizeLimit;
     CachedSettingValue<QString> m_storeLastAddPath;
     CachedSettingValue<QString> m_storeTrackerList;
     CachedSettingValue<QString> m_storeWebSeedList;

--- a/src/gui/torrentcreatordialog.ui
+++ b/src/gui/torrentcreatordialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>592</width>
-    <height>658</height>
+    <height>731</height>
    </rect>
   </property>
   <property name="acceptDrops">
@@ -225,13 +225,58 @@
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="checkOptimizeAlignment">
-        <property name="text">
+       <widget class="QGroupBox" name="checkOptimizeAlignment">
+        <property name="title">
          <string>Optimize alignment</string>
         </property>
-        <property name="checked">
+        <property name="checkable">
          <bool>true</bool>
         </property>
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_4">
+           <item>
+            <widget class="QLabel" name="lblPaddedFileSizeLimit">
+             <property name="text">
+              <string>Align to piece boundary for files larger than:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="spinPaddedFileSizeLimit">
+             <property name="specialValueText">
+              <string>Disabled</string>
+             </property>
+             <property name="suffix">
+              <string> KiB</string>
+             </property>
+             <property name="minimum">
+              <number>-1</number>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+             <property name="value">
+              <number>-1</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>


### PR DESCRIPTION
Alignment is achieved by adding dummy pad files between files which is handled by libtorrent.
Closes #10460.

See: [screenshot](https://user-images.githubusercontent.com/9395168/64578054-cedff780-d3b0-11e9-80c8-888a2d429add.png)

Ref: https://www.libtorrent.org/reference-Create_Torrents.html#create_torrent