### PR TITLE
Revise TriStateBool class

### DIFF
--- a/src/base/rss/rss_autodownloadrule.cpp
+++ b/src/base/rss/rss_autodownloadrule.cpp
@@ -64,7 +64,7 @@ namespace
 
     QJsonValue triStateBoolToJsonValue(const TriStateBool &triStateBool)
     {
-        switch (static_cast<int>(triStateBool)) {
+        switch (static_cast<signed char>(triStateBool)) {
         case 0:  return false;
         case 1:  return true;
         default: return {};
@@ -82,7 +82,7 @@ namespace
 
     int triStateBoolToAddPausedLegacy(const TriStateBool &triStateBool)
     {
-        switch (static_cast<int>(triStateBool)) {
+        switch (static_cast<signed char>(triStateBool)) {
         case 0:  return 2; // never
         case 1:  return 1; // always
         default: return 0; // default

--- a/src/base/tristatebool.h
+++ b/src/base/tristatebool.h
@@ -38,9 +38,9 @@ public:
 
     constexpr TriStateBool() = default;
     constexpr TriStateBool(const TriStateBool &other) = default;
-    explicit constexpr TriStateBool(int value)
-        : m_value(value < 0 ? -1 : (value > 0 ? 1 : 0))
+    explicit constexpr TriStateBool(const bool boolean)
     {
+        *this = boolean ? True : False;
     }
 
     explicit constexpr operator int() const
@@ -56,6 +56,11 @@ public:
     }
 
 private:
+    explicit constexpr TriStateBool(const int value)
+        : m_value((value < 0) ? -1 : ((value > 0) ? 1 : 0))
+    {
+    }
+
     signed char m_value = -1; // Undefined by default
 };
 

--- a/src/base/tristatebool.h
+++ b/src/base/tristatebool.h
@@ -43,12 +43,12 @@ public:
         *this = boolean ? True : False;
     }
 
-    explicit constexpr operator int() const
+    TriStateBool &operator=(const TriStateBool &other) = default;  // TODO: add constexpr when using C++17
+
+    explicit constexpr operator signed char() const
     {
         return m_value;
     }
-
-    TriStateBool &operator=(const TriStateBool &other) = default;  // add constexpr when using C++17
 
     constexpr friend bool operator==(const TriStateBool &left, const TriStateBool &right)
     {


### PR DESCRIPTION
~~IMO it is not really required that `TriStateBool` has an `operator int()`, especially when `int` is larger than the private variable's type `signed char`. An observer of type `signed char` is also suitable for `switch()` statements which takes an integer type.~~