### PR TITLE
Use non-recursive mutex

### DIFF
--- a/src/base/logger.cpp
+++ b/src/base/logger.cpp
@@ -49,7 +49,6 @@ Logger *Logger::m_instance = nullptr;
 Logger::Logger()
     : m_messages(MAX_LOG_MESSAGES)
     , m_peers(MAX_LOG_MESSAGES)
-    , m_lock(QReadWriteLock::Recursive)
 {
 }
 
@@ -75,9 +74,9 @@ void Logger::freeInstance()
 void Logger::addMessage(const QString &message, const Log::MsgType &type)
 {
     QWriteLocker locker(&m_lock);
-
     const Log::Msg temp = {m_msgCounter++, QDateTime::currentMSecsSinceEpoch(), type, message.toHtmlEscaped()};
     m_messages.push_back(temp);
+    locker.unlock();
 
     emit newLogMessage(temp);
 }
@@ -85,9 +84,9 @@ void Logger::addMessage(const QString &message, const Log::MsgType &type)
 void Logger::addPeer(const QString &ip, const bool blocked, const QString &reason)
 {
     QWriteLocker locker(&m_lock);
-
     const Log::Peer temp = {m_peerCounter++, QDateTime::currentMSecsSinceEpoch(), ip.toHtmlEscaped(), blocked, reason.toHtmlEscaped()};
     m_peers.push_back(temp);
+    locker.unlock();
 
     emit newLogPeer(temp);
 }

--- a/src/base/logger.cpp
+++ b/src/base/logger.cpp
@@ -74,26 +74,26 @@ void Logger::freeInstance()
 void Logger::addMessage(const QString &message, const Log::MsgType &type)
 {
     QWriteLocker locker(&m_lock);
-    const Log::Msg temp = {m_msgCounter++, QDateTime::currentMSecsSinceEpoch(), type, message.toHtmlEscaped()};
-    m_messages.push_back(temp);
+    const Log::Msg msg = {m_msgCounter++, QDateTime::currentMSecsSinceEpoch(), type, message.toHtmlEscaped()};
+    m_messages.push_back(msg);
     locker.unlock();
 
-    emit newLogMessage(temp);
+    emit newLogMessage(msg);
 }
 
 void Logger::addPeer(const QString &ip, const bool blocked, const QString &reason)
 {
     QWriteLocker locker(&m_lock);
-    const Log::Peer temp = {m_peerCounter++, QDateTime::currentMSecsSinceEpoch(), ip.toHtmlEscaped(), blocked, reason.toHtmlEscaped()};
-    m_peers.push_back(temp);
+    const Log::Peer msg = {m_peerCounter++, QDateTime::currentMSecsSinceEpoch(), ip.toHtmlEscaped(), blocked, reason.toHtmlEscaped()};
+    m_peers.push_back(msg);
     locker.unlock();
 
-    emit newLogPeer(temp);
+    emit newLogPeer(msg);
 }
 
 QVector<Log::Msg> Logger::getMessages(const int lastKnownId) const
 {
-    QReadLocker locker(&m_lock);
+    const QReadLocker locker(&m_lock);
 
     const int diff = m_msgCounter - lastKnownId - 1;
     const int size = m_messages.size();
@@ -109,7 +109,7 @@ QVector<Log::Msg> Logger::getMessages(const int lastKnownId) const
 
 QVector<Log::Peer> Logger::getPeers(const int lastKnownId) const
 {
-    QReadLocker locker(&m_lock);
+    const QReadLocker locker(&m_lock);
 
     const int diff = m_peerCounter - lastKnownId - 1;
     const int size = m_peers.size();

--- a/src/base/settingsstorage.cpp
+++ b/src/base/settingsstorage.cpp
@@ -201,8 +201,9 @@ bool SettingsStorage::save()
 
 QVariant SettingsStorage::loadValue(const QString &key, const QVariant &defaultValue) const
 {
+    const QString realKey = mapKey(key);
     const QReadLocker locker(&m_lock);
-    return m_data.value(mapKey(key), defaultValue);
+    return m_data.value(realKey, defaultValue);
 }
 
 void SettingsStorage::storeValue(const QString &key, const QVariant &value)

--- a/src/base/settingsstorage.cpp
+++ b/src/base/settingsstorage.cpp
@@ -155,7 +155,6 @@ SettingsStorage *SettingsStorage::m_instance = nullptr;
 SettingsStorage::SettingsStorage()
     : m_data{TransactionalSettings(QLatin1String("qBittorrent")).read()}
     , m_dirty(false)
-    , m_lock(QReadWriteLock::Recursive)
 {
     m_timer.setSingleShot(true);
     m_timer.setInterval(5 * 1000);


### PR DESCRIPTION
The related classes doesn't really need recursive mutex so drop it. And if it is really required it usually indicates bad design and we should avoid it anyway.
Or they really are required... please let me know why.