### PR TITLE
Code clean up

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -685,11 +685,8 @@ void Application::cleanup()
         m_window->hide();
 
 #ifdef Q_OS_WIN
-        typedef BOOL (WINAPI *PSHUTDOWNBRCREATE)(HWND, LPCWSTR);
-        const auto shutdownBRCreate = Utils::Misc::loadWinAPI<PSHUTDOWNBRCREATE>("User32.dll", "ShutdownBlockReasonCreate");
-        // Only available on Vista+
-        if (shutdownBRCreate)
-            shutdownBRCreate((HWND)m_window->effectiveWinId(), tr("Saving torrent progress...").toStdWString().c_str());
+        ::ShutdownBlockReasonCreate(reinterpret_cast<HWND>(m_window->effectiveWinId())
+            , tr("Saving torrent progress...").toStdWString().c_str());
 #endif // Q_OS_WIN
 
         // Do manual cleanup in MainWindow to force widgets
@@ -728,11 +725,7 @@ void Application::cleanup()
 #ifndef DISABLE_GUI
     if (m_window) {
 #ifdef Q_OS_WIN
-        using PSHUTDOWNBRDESTROY = BOOL (WINAPI *)(HWND);
-        const auto shutdownBRDestroy = Utils::Misc::loadWinAPI<PSHUTDOWNBRDESTROY>("User32.dll", "ShutdownBlockReasonDestroy");
-        // Only available on Vista+
-        if (shutdownBRDestroy)
-            shutdownBRDestroy(reinterpret_cast<HWND>(m_window->effectiveWinId()));
+        ::ShutdownBlockReasonDestroy(reinterpret_cast<HWND>(m_window->effectiveWinId()));
 #endif // Q_OS_WIN
         delete m_window;
         UIThemeManager::freeInstance();

--- a/src/app/qtlocalpeer/qtlocalpeer.cpp
+++ b/src/app/qtlocalpeer/qtlocalpeer.cpp
@@ -116,14 +116,9 @@ QtLocalPeer::QtLocalPeer(QObject* parent, const QString &appId)
                  + QLatin1Char('-') + QString::number(idNum, 16);
 
 #if defined(Q_OS_WIN)
-    using PPROCESSIDTOSESSIONID = BOOL (WINAPI *)(DWORD, DWORD *);
-    const auto processIdToSessionId = Utils::Misc::loadWinAPI<PPROCESSIDTOSESSIONID>("kernel32.dll", "ProcessIdToSessionId");
-
-    if (processIdToSessionId) {
-        DWORD sessionId = 0;
-        processIdToSessionId(GetCurrentProcessId(), &sessionId);
-        socketName += (QLatin1Char('-') + QString::number(sessionId, 16));
-    }
+    DWORD sessionId = 0;
+    ::ProcessIdToSessionId(GetCurrentProcessId(), &sessionId);
+    socketName += (QLatin1Char('-') + QString::number(sessionId, 16));
 #else
     socketName += (QLatin1Char('-') + QString::number(::getuid(), 16));
 #endif

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1625,7 +1625,7 @@ void Session::banIP(const QString &ip)
 
 // Delete a torrent from the session, given its hash
 // and from the disk, if the corresponding deleteOption is chosen
-bool Session::deleteTorrent(const QString &hash, const DeleteOption deleteOption)
+bool Session::deleteTorrent(const InfoHash &hash, const DeleteOption deleteOption)
 {
     TorrentHandle *const torrent = m_torrents.take(hash);
     if (!torrent) return false;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -407,7 +407,7 @@ namespace BitTorrent
         bool isKnownTorrent(const InfoHash &hash) const;
         bool addTorrent(const QString &source, const AddTorrentParams &params = AddTorrentParams());
         bool addTorrent(const TorrentInfo &torrentInfo, const AddTorrentParams &params = AddTorrentParams());
-        bool deleteTorrent(const QString &hash, DeleteOption deleteOption = Torrent);
+        bool deleteTorrent(const InfoHash &hash, DeleteOption deleteOption = Torrent);
         bool loadMetadata(const MagnetUri &magnetUri);
         bool cancelLoadMetadata(const InfoHash &hash);
 

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -95,18 +95,19 @@ namespace BitTorrent
     class TrackerEntry;
     struct CreateTorrentParams;
 
-    class SessionSettingsEnums
+    // Using `Q_ENUM_NS()` without a wrapper namespace in our case is not advised
+    // since `Q_NAMESPACE` cannot be used when the same namespace resides at different files.
+    // https://www.kdab.com/new-qt-5-8-meta-object-support-namespaces/#comment-143779
+    namespace SessionSettingsEnums
     {
-        Q_GADGET
+        Q_NAMESPACE
 
-    public:
-        // TODO: remove `SessionSettingsEnums` wrapper when we can use `Q_ENUM_NS` directly (QT >= 5.8 only)
         enum class ChokingAlgorithm : int
         {
             FixedSlots = 0,
             RateBased = 1
         };
-        Q_ENUM(ChokingAlgorithm)
+        Q_ENUM_NS(ChokingAlgorithm)
 
         enum class SeedChokingAlgorithm : int
         {
@@ -114,14 +115,14 @@ namespace BitTorrent
             FastestUpload = 1,
             AntiLeech = 2
         };
-        Q_ENUM(SeedChokingAlgorithm)
+        Q_ENUM_NS(SeedChokingAlgorithm)
 
         enum class MixedModeAlgorithm : int
         {
             TCP = 0,
             Proportional = 1
         };
-        Q_ENUM(MixedModeAlgorithm)
+        Q_ENUM_NS(MixedModeAlgorithm)
 
         enum class BTProtocol : int
         {
@@ -129,12 +130,9 @@ namespace BitTorrent
             TCP = 1,
             UTP = 2
         };
-        Q_ENUM(BTProtocol)
-    };
-    using ChokingAlgorithm = SessionSettingsEnums::ChokingAlgorithm;
-    using SeedChokingAlgorithm = SessionSettingsEnums::SeedChokingAlgorithm;
-    using MixedModeAlgorithm = SessionSettingsEnums::MixedModeAlgorithm;
-    using BTProtocol = SessionSettingsEnums::BTProtocol;
+        Q_ENUM_NS(BTProtocol)
+    }
+    using namespace SessionSettingsEnums;
 
     struct SessionMetricIndices
     {

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -30,6 +30,7 @@
 
 #ifdef Q_OS_WIN
 #include <windows.h>
+#include <powrprof.h>
 #include <Shlobj.h>
 #else
 #include <sys/types.h>
@@ -117,16 +118,11 @@ void Utils::Misc::shutdownComputer(const ShutdownDialogAction &action)
     if (GetLastError() != ERROR_SUCCESS)
         return;
 
-    using PSETSUSPENDSTATE = BOOLEAN (WINAPI *)(BOOLEAN, BOOLEAN, BOOLEAN);
-    const auto setSuspendState = Utils::Misc::loadWinAPI<PSETSUSPENDSTATE>("PowrProf.dll", "SetSuspendState");
-
     if (action == ShutdownDialogAction::Suspend) {
-        if (setSuspendState)
-            setSuspendState(false, false, false);
+        ::SetSuspendState(false, false, false);
     }
     else if (action == ShutdownDialogAction::Hibernate) {
-        if (setSuspendState)
-            setSuspendState(true, false, false);
+        ::SetSuspendState(true, false, false);
     }
     else {
         const QString msg = QCoreApplication::translate("misc", "qBittorrent will shutdown the computer now because all downloads are complete.");

--- a/winconf.pri
+++ b/winconf.pri
@@ -34,7 +34,7 @@ win32-g++* {
 
     RC_FILE = qbittorrent_mingw.rc
 
-    LIBS += libadvapi32 libshell32 libuser32 libole32 libwsock32 libws2_32
+    LIBS += libadvapi32 libiphlpapi libole32 libpowrprof libshell32 libuser32 libwsock32 libws2_32
 }
 else:win32-msvc* {
     CONFIG -= embed_manifest_exe
@@ -42,7 +42,7 @@ else:win32-msvc* {
 
     RC_FILE = qbittorrent.rc
 
-    LIBS += advapi32.lib shell32.lib crypt32.lib User32.lib ole32.lib
+    LIBS += advapi32.lib crypt32.lib Iphlpapi.lib ole32.lib PowrProf.lib shell32.lib User32.lib
 }
 
 # See an example build configuration in "conf.pri.windows"


### PR DESCRIPTION
* Call Windows API directly
  We already bumped the OS requirement to Windows 7 and those functions can be called directly without the need to load them first.
* Revise SessionSettingsEnums wrapper
  This simplify the wrapper to become a namespace.
* Change Session::deleteTorrent() first parameter to take InfoHash type
* Avoid redundant lookups

