### PR TITLE
Bump Web API version

### DIFF
--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -43,8 +43,8 @@
 #include "base/utils/net.h"
 #include "base/utils/version.h"
 
-constexpr Utils::Version<int, 3, 2> API_VERSION {2, 2, 0};
-constexpr int COMPAT_API_VERSION = 23;
+constexpr Utils::Version<int, 3, 2> API_VERSION {2, 2, 1};
+constexpr int COMPAT_API_VERSION = 24;
 constexpr int COMPAT_API_VERSION_MIN = 23;
 
 class APIController;


### PR DESCRIPTION
This corrects an oversight of v4.1.8.
I intend to release v4.1.8.1 with this fix and port it to master.

I want make sure that I increased the correct `API_VERSION` number.