### PR TITLE
Preserve relative order when moving to top/bottom in queue

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -33,6 +33,7 @@
 #include <cstdlib>
 #include <queue>
 #include <string>
+#include <utility>
 
 #ifdef Q_OS_WIN
 #include <wincrypt.h>
@@ -1699,22 +1700,23 @@ bool Session::cancelLoadMetadata(const InfoHash &hash)
     return true;
 }
 
-void Session::increaseTorrentsQueuePos(const QStringList &hashes)
+void Session::increaseTorrentsQueuePos(const QVector<InfoHash> &hashes)
 {
-    std::priority_queue<QPair<int, TorrentHandle *>,
-            std::vector<QPair<int, TorrentHandle *>>,
-            std::greater<QPair<int, TorrentHandle *>>> torrentQueue;
+    using ElementType = std::pair<int, TorrentHandle *>;
+    std::priority_queue<ElementType
+        , std::vector<ElementType>
+        , std::greater<ElementType>> torrentQueue;
 
     // Sort torrents by queue position
-    for (const InfoHash infoHash : hashes) {
+    for (const InfoHash &infoHash : hashes) {
         TorrentHandle *const torrent = m_torrents.value(infoHash);
         if (torrent && !torrent->isSeed())
-            torrentQueue.push(qMakePair(torrent->queuePosition(), torrent));
+            torrentQueue.emplace(torrent->queuePosition(), torrent);
     }
 
     // Increase torrents queue position (starting with the one in the highest queue position)
     while (!torrentQueue.empty()) {
-        TorrentHandle *const torrent = torrentQueue.top().second;
+        const TorrentHandle *torrent = torrentQueue.top().second;
         torrentQueuePositionUp(torrent->nativeHandle());
         torrentQueue.pop();
     }
@@ -1722,22 +1724,21 @@ void Session::increaseTorrentsQueuePos(const QStringList &hashes)
     saveTorrentsQueue();
 }
 
-void Session::decreaseTorrentsQueuePos(const QStringList &hashes)
+void Session::decreaseTorrentsQueuePos(const QVector<InfoHash> &hashes)
 {
-    std::priority_queue<QPair<int, TorrentHandle *>,
-            std::vector<QPair<int, TorrentHandle *>>,
-            std::less<QPair<int, TorrentHandle *>>> torrentQueue;
+    using ElementType = std::pair<int, TorrentHandle *>;
+    std::priority_queue<ElementType> torrentQueue;
 
     // Sort torrents by queue position
-    for (const InfoHash infoHash : hashes) {
+    for (const InfoHash &infoHash : hashes) {
         TorrentHandle *const torrent = m_torrents.value(infoHash);
         if (torrent && !torrent->isSeed())
-            torrentQueue.push(qMakePair(torrent->queuePosition(), torrent));
+            torrentQueue.emplace(torrent->queuePosition(), torrent);
     }
 
     // Decrease torrents queue position (starting with the one in the lowest queue position)
     while (!torrentQueue.empty()) {
-        TorrentHandle *const torrent = torrentQueue.top().second;
+        const TorrentHandle *torrent = torrentQueue.top().second;
         torrentQueuePositionDown(torrent->nativeHandle());
         torrentQueue.pop();
     }
@@ -1748,22 +1749,23 @@ void Session::decreaseTorrentsQueuePos(const QStringList &hashes)
     saveTorrentsQueue();
 }
 
-void Session::topTorrentsQueuePos(const QStringList &hashes)
+void Session::topTorrentsQueuePos(const QVector<InfoHash> &hashes)
 {
-    std::priority_queue<QPair<int, TorrentHandle *>,
-            std::vector<QPair<int, TorrentHandle *>>,
-            std::greater<QPair<int, TorrentHandle *>>> torrentQueue;
+    using ElementType = std::pair<int, TorrentHandle *>;
+    std::priority_queue<ElementType
+        , std::vector<ElementType>
+        , std::greater<ElementType>> torrentQueue;
 
     // Sort torrents by queue position
-    for (const InfoHash infoHash : hashes) {
+    for (const InfoHash &infoHash : hashes) {
         TorrentHandle *const torrent = m_torrents.value(infoHash);
         if (torrent && !torrent->isSeed())
-            torrentQueue.push(qMakePair(torrent->queuePosition(), torrent));
+            torrentQueue.emplace(torrent->queuePosition(), torrent);
     }
 
     // Top torrents queue position (starting with the one in the highest queue position)
     while (!torrentQueue.empty()) {
-        TorrentHandle *const torrent = torrentQueue.top().second;
+        const TorrentHandle *torrent = torrentQueue.top().second;
         torrentQueuePositionTop(torrent->nativeHandle());
         torrentQueue.pop();
     }
@@ -1771,22 +1773,23 @@ void Session::topTorrentsQueuePos(const QStringList &hashes)
     saveTorrentsQueue();
 }
 
-void Session::bottomTorrentsQueuePos(const QStringList &hashes)
+void Session::bottomTorrentsQueuePos(const QVector<InfoHash> &hashes)
 {
-    std::priority_queue<QPair<int, TorrentHandle *>,
-            std::vector<QPair<int, TorrentHandle *>>,
-            std::less<QPair<int, TorrentHandle *>>> torrentQueue;
+    using ElementType = std::pair<int, TorrentHandle *>;
+    std::priority_queue<ElementType
+        , std::vector<ElementType>
+        , std::less<ElementType>> torrentQueue;
 
     // Sort torrents by queue position
-    for (const InfoHash infoHash : hashes) {
+    for (const InfoHash &infoHash : hashes) {
         TorrentHandle *const torrent = m_torrents.value(infoHash);
         if (torrent && !torrent->isSeed())
-            torrentQueue.push(qMakePair(torrent->queuePosition(), torrent));
+            torrentQueue.emplace(torrent->queuePosition(), torrent);
     }
 
     // Bottom torrents queue position (starting with the one in the lowest queue position)
     while (!torrentQueue.empty()) {
-        TorrentHandle *const torrent = torrentQueue.top().second;
+        const TorrentHandle *torrent = torrentQueue.top().second;
         torrentQueuePositionBottom(torrent->nativeHandle());
         torrentQueue.pop();
     }

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1752,9 +1752,7 @@ void Session::decreaseTorrentsQueuePos(const QVector<InfoHash> &hashes)
 void Session::topTorrentsQueuePos(const QVector<InfoHash> &hashes)
 {
     using ElementType = std::pair<int, TorrentHandle *>;
-    std::priority_queue<ElementType
-        , std::vector<ElementType>
-        , std::greater<ElementType>> torrentQueue;
+    std::priority_queue<ElementType> torrentQueue;
 
     // Sort torrents by queue position
     for (const InfoHash &infoHash : hashes) {
@@ -1763,7 +1761,7 @@ void Session::topTorrentsQueuePos(const QVector<InfoHash> &hashes)
             torrentQueue.emplace(torrent->queuePosition(), torrent);
     }
 
-    // Top torrents queue position (starting with the one in the highest queue position)
+    // Top torrents queue position (starting with the one in the lowest queue position)
     while (!torrentQueue.empty()) {
         const TorrentHandle *torrent = torrentQueue.top().second;
         torrentQueuePositionTop(torrent->nativeHandle());
@@ -1778,7 +1776,7 @@ void Session::bottomTorrentsQueuePos(const QVector<InfoHash> &hashes)
     using ElementType = std::pair<int, TorrentHandle *>;
     std::priority_queue<ElementType
         , std::vector<ElementType>
-        , std::less<ElementType>> torrentQueue;
+        , std::greater<ElementType>> torrentQueue;
 
     // Sort torrents by queue position
     for (const InfoHash &infoHash : hashes) {
@@ -1787,7 +1785,7 @@ void Session::bottomTorrentsQueuePos(const QVector<InfoHash> &hashes)
             torrentQueue.emplace(torrent->queuePosition(), torrent);
     }
 
-    // Bottom torrents queue position (starting with the one in the lowest queue position)
+    // Bottom torrents queue position (starting with the one in the highest queue position)
     while (!torrentQueue.empty()) {
         const TorrentHandle *torrent = torrentQueue.top().second;
         torrentQueuePositionBottom(torrent->nativeHandle());

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -412,10 +412,10 @@ namespace BitTorrent
         bool cancelLoadMetadata(const InfoHash &hash);
 
         void recursiveTorrentDownload(const InfoHash &hash);
-        void increaseTorrentsQueuePos(const QStringList &hashes);
-        void decreaseTorrentsQueuePos(const QStringList &hashes);
-        void topTorrentsQueuePos(const QStringList &hashes);
-        void bottomTorrentsQueuePos(const QStringList &hashes);
+        void increaseTorrentsQueuePos(const QVector<InfoHash> &hashes);
+        void decreaseTorrentsQueuePos(const QVector<InfoHash> &hashes);
+        void topTorrentsQueuePos(const QVector<InfoHash> &hashes);
+        void bottomTorrentsQueuePos(const QVector<InfoHash> &hashes);
 
         // TorrentHandle interface
         void handleTorrentSaveResumeDataRequested(const TorrentHandle *torrent);

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -43,6 +43,7 @@
 #include <QTableView>
 #include <QWheelEvent>
 
+#include "base/bittorrent/infohash.h"
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/torrenthandle.h"
 #include "base/bittorrent/trackerentry.h"
@@ -75,12 +76,12 @@
 
 namespace
 {
-    QStringList extractHashes(const QVector<BitTorrent::TorrentHandle *> &torrents)
+    QVector<BitTorrent::InfoHash> extractHashes(const QVector<BitTorrent::TorrentHandle *> &torrents)
     {
-        QStringList hashes;
-        for (BitTorrent::TorrentHandle *const torrent : torrents)
+        QVector<BitTorrent::InfoHash> hashes;
+        hashes.reserve(torrents.size());
+        for (const BitTorrent::TorrentHandle *torrent : torrents)
             hashes << torrent->hash();
-
         return hashes;
     }
 
@@ -283,10 +284,12 @@ void TransferListWidget::torrentDoubleClicked()
 
 QVector<BitTorrent::TorrentHandle *> TransferListWidget::getSelectedTorrents() const
 {
-    QVector<BitTorrent::TorrentHandle *> torrents;
-    for (const QModelIndex &index : asConst(selectionModel()->selectedRows()))
-        torrents << m_listModel->torrentHandle(mapToSource(index));
+    const QModelIndexList selectedRows = selectionModel()->selectedRows();
 
+    QVector<BitTorrent::TorrentHandle *> torrents;
+    torrents.reserve(selectedRows.size());
+    for (const QModelIndex &index : selectedRows)
+        torrents << m_listModel->torrentHandle(mapToSource(index));
     return torrents;
 }
 

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -40,6 +40,7 @@
 #include <QUrl>
 
 #include "base/bittorrent/downloadpriority.h"
+#include "base/bittorrent/infohash.h"
 #include "base/bittorrent/peeraddress.h"
 #include "base/bittorrent/peerinfo.h"
 #include "base/bittorrent/session.h"
@@ -196,6 +197,15 @@ namespace
         };
 
         return {dht, pex, lsd};
+    }
+
+    QVector<BitTorrent::InfoHash> toInfoHashes(const QStringList &hashes)
+    {
+        QVector<BitTorrent::InfoHash> infoHashes;
+        infoHashes.reserve(hashes.size());
+        for (const QString &hash : hashes)
+            infoHashes << hash;
+        return infoHashes;
     }
 }
 
@@ -901,7 +911,7 @@ void TorrentsController::increasePrioAction()
         throw APIError(APIErrorType::Conflict, tr("Torrent queueing must be enabled"));
 
     const QStringList hashes {params()["hashes"].split('|')};
-    BitTorrent::Session::instance()->increaseTorrentsQueuePos(hashes);
+    BitTorrent::Session::instance()->increaseTorrentsQueuePos(toInfoHashes(hashes));
 }
 
 void TorrentsController::decreasePrioAction()
@@ -912,7 +922,7 @@ void TorrentsController::decreasePrioAction()
         throw APIError(APIErrorType::Conflict, tr("Torrent queueing must be enabled"));
 
     const QStringList hashes {params()["hashes"].split('|')};
-    BitTorrent::Session::instance()->decreaseTorrentsQueuePos(hashes);
+    BitTorrent::Session::instance()->decreaseTorrentsQueuePos(toInfoHashes(hashes));
 }
 
 void TorrentsController::topPrioAction()
@@ -923,7 +933,7 @@ void TorrentsController::topPrioAction()
         throw APIError(APIErrorType::Conflict, tr("Torrent queueing must be enabled"));
 
     const QStringList hashes {params()["hashes"].split('|')};
-    BitTorrent::Session::instance()->topTorrentsQueuePos(hashes);
+    BitTorrent::Session::instance()->topTorrentsQueuePos(toInfoHashes(hashes));
 }
 
 void TorrentsController::bottomPrioAction()
@@ -934,7 +944,7 @@ void TorrentsController::bottomPrioAction()
         throw APIError(APIErrorType::Conflict, tr("Torrent queueing must be enabled"));
 
     const QStringList hashes {params()["hashes"].split('|')};
-    BitTorrent::Session::instance()->bottomTorrentsQueuePos(hashes);
+    BitTorrent::Session::instance()->bottomTorrentsQueuePos(toInfoHashes(hashes));
 }
 
 void TorrentsController::setLocationAction()


### PR DESCRIPTION
* Use InfoHash type in queueing operations
  This avoids redundant type conversions.
* Preserve relative order when moving to top/bottom in queue
  Closes #11312.