### PR TITLE
Fix "preview file" action not working

### DIFF
--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -2187,7 +2187,7 @@ void TorrentHandle::setSuperSeeding(const bool enable)
 #endif
 }
 
-void TorrentHandle::flushCache()
+void TorrentHandle::flushCache() const
 {
     m_nativeHandle.flush_cache();
 }

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -324,7 +324,7 @@ namespace BitTorrent
         void setUploadLimit(int limit);
         void setDownloadLimit(int limit);
         void setSuperSeeding(bool enable);
-        void flushCache();
+        void flushCache() const;
         void addTrackers(const QVector<TrackerEntry> &trackers);
         void replaceTrackers(const QVector<TrackerEntry> &trackers);
         void addUrlSeeds(const QVector<QUrl> &urlSeeds);

--- a/src/gui/previewselectdialog.cpp
+++ b/src/gui/previewselectdialog.cpp
@@ -45,7 +45,7 @@
 
 #define SETTINGS_KEY(name) "PreviewSelectDialog/" name
 
-PreviewSelectDialog::PreviewSelectDialog(QWidget *parent, BitTorrent::TorrentHandle *const torrent)
+PreviewSelectDialog::PreviewSelectDialog(QWidget *parent, const BitTorrent::TorrentHandle *torrent)
     : QDialog(parent)
     , m_ui(new Ui::PreviewSelectDialog)
     , m_torrent(torrent)
@@ -53,13 +53,12 @@ PreviewSelectDialog::PreviewSelectDialog(QWidget *parent, BitTorrent::TorrentHan
     , m_storeTreeHeaderState(SETTINGS_KEY("HeaderState"))
 {
     m_ui->setupUi(this);
-    setAttribute(Qt::WA_DeleteOnClose);
 
     m_ui->buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Preview"));
     connect(m_ui->buttonBox, &QDialogButtonBox::accepted, this, &PreviewSelectDialog::previewButtonClicked);
     connect(m_ui->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
-    Preferences *const pref = Preferences::instance();
+    const Preferences *pref = Preferences::instance();
     // Preview list
     m_previewListModel = new QStandardItemModel(0, NB_COLUMNS, this);
     m_previewListModel->setHeaderData(NAME, Qt::Horizontal, tr("Name"));

--- a/src/gui/previewselectdialog.cpp
+++ b/src/gui/previewselectdialog.cpp
@@ -54,6 +54,9 @@ PreviewSelectDialog::PreviewSelectDialog(QWidget *parent, const BitTorrent::Torr
 {
     m_ui->setupUi(this);
 
+    m_ui->label->setText(tr("The following files from torrent \"%1\" support previewing, please select one of them:")
+        .arg(m_torrent->name()));
+
     m_ui->buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Preview"));
     connect(m_ui->buttonBox, &QDialogButtonBox::accepted, this, &PreviewSelectDialog::previewButtonClicked);
     connect(m_ui->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
@@ -125,7 +128,8 @@ void PreviewSelectDialog::previewButtonClicked()
     if (!QFile::exists(path)) {
         const bool isSingleFile = (m_previewListModel->rowCount() == 1);
         QWidget *parent = isSingleFile ? this->parentWidget() : this;
-        QMessageBox::critical(parent, tr("Preview impossible"), tr("Sorry, we can't preview this file"));
+        QMessageBox::critical(parent, tr("Preview impossible")
+            , tr("Sorry, we can't preview this file: \"%1\".").arg(Utils::Fs::toNativePath(path)));
         if (isSingleFile)
             reject();
         return;

--- a/src/gui/previewselectdialog.cpp
+++ b/src/gui/previewselectdialog.cpp
@@ -101,16 +101,6 @@ PreviewSelectDialog::PreviewSelectDialog(QWidget *parent, const BitTorrent::Torr
 
     // Restore dialog state
     loadWindowState();
-
-    if (m_previewListModel->rowCount() == 1) {
-        qDebug("Torrent file only contains one file, no need to display selection dialog before preview");
-        // Only one file : no choice
-        previewButtonClicked();
-    }
-    else {
-        qDebug("Displaying media file selection dialog for preview");
-        show();
-    }
 }
 
 PreviewSelectDialog::~PreviewSelectDialog()
@@ -161,13 +151,21 @@ void PreviewSelectDialog::loadWindowState()
 
 void PreviewSelectDialog::showEvent(QShowEvent *event)
 {
-    Q_UNUSED(event);
+    // event originated from system
+    if (event->spontaneous()) {
+        QDialog::showEvent(event);
+        return;
+    }
 
     // Default size, have to be called after show(), because width is needed
     // Set Name column width to 60% of TreeView
     if (!m_headerStateInitialized) {
-        int nameSize = (m_ui->previewList->size().width() * 0.6);
+        const int nameSize = (m_ui->previewList->size().width() * 0.6);
         m_ui->previewList->header()->resizeSection(0, nameSize);
         m_headerStateInitialized = true;
     }
+
+    // Only one file, no choice
+    if (m_previewListModel->rowCount() <= 1)
+        previewButtonClicked();
 }

--- a/src/gui/previewselectdialog.cpp
+++ b/src/gui/previewselectdialog.cpp
@@ -112,21 +112,26 @@ PreviewSelectDialog::~PreviewSelectDialog()
 
 void PreviewSelectDialog::previewButtonClicked()
 {
-    QModelIndexList selectedIndexes = m_ui->previewList->selectionModel()->selectedRows(FILE_INDEX);
+    const QModelIndexList selectedIndexes = m_ui->previewList->selectionModel()->selectedRows(FILE_INDEX);
     if (selectedIndexes.isEmpty()) return;
 
     // Flush data
     m_torrent->flushCache();
 
-    QStringList absolutePaths(m_torrent->absoluteFilePaths());
+    const QStringList absolutePaths = m_torrent->absoluteFilePaths();
     // Only one file should be selected
-    QString path = absolutePaths.at(selectedIndexes.at(0).data().toInt());
+    const QString path = absolutePaths.at(selectedIndexes.at(0).data().toInt());
     // File
-    if (QFile::exists(path))
-        emit readyToPreviewFile(path);
-    else
-        QMessageBox::critical(this->parentWidget(), tr("Preview impossible"), tr("Sorry, we can't preview this file"));
+    if (!QFile::exists(path)) {
+        const bool isSingleFile = (m_previewListModel->rowCount() == 1);
+        QWidget *parent = isSingleFile ? this->parentWidget() : this;
+        QMessageBox::critical(parent, tr("Preview impossible"), tr("Sorry, we can't preview this file"));
+        if (isSingleFile)
+            reject();
+        return;
+    }
 
+    emit readyToPreviewFile(path);
     accept();
 }
 

--- a/src/gui/previewselectdialog.h
+++ b/src/gui/previewselectdialog.h
@@ -60,26 +60,25 @@ public:
         NB_COLUMNS
     };
 
-    PreviewSelectDialog(QWidget *parent, BitTorrent::TorrentHandle *const torrent);
+    PreviewSelectDialog(QWidget *parent, const BitTorrent::TorrentHandle *torrent);
     ~PreviewSelectDialog();
 
 signals:
     void readyToPreviewFile(QString) const;
 
-protected:
-    void showEvent(QShowEvent *event) override;
-
 private slots:
     void previewButtonClicked();
 
 private:
+    void showEvent(QShowEvent *event) override;
+
     void loadWindowState();
     void saveWindowState();
 
     Ui::PreviewSelectDialog *m_ui;
     QStandardItemModel *m_previewListModel;
     PreviewListDelegate *m_listDelegate;
-    BitTorrent::TorrentHandle *const m_torrent;
+    const BitTorrent::TorrentHandle *m_torrent;
     bool m_headerStateInitialized = false;
 
     // Settings

--- a/src/gui/previewselectdialog.ui
+++ b/src/gui/previewselectdialog.ui
@@ -16,9 +16,6 @@
   <layout class="QVBoxLayout">
    <item>
     <widget class="QLabel" name="label">
-     <property name="text">
-      <string>The following files support previewing, please select one of them:</string>
-     </property>
      <property name="wordWrap">
       <bool>true</bool>
      </property>

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -506,6 +506,7 @@ void TransferListWidget::previewSelectedTorrents()
             auto *dialog = new PreviewSelectDialog(this, torrent);
             dialog->setAttribute(Qt::WA_DeleteOnClose);
             connect(dialog, &PreviewSelectDialog::readyToPreviewFile, this, &TransferListWidget::previewFile);
+            dialog->show();
         }
         else {
             QMessageBox::critical(this, tr("Unable to preview"), tr("The selected torrent does not contain previewable files"));

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -501,9 +501,10 @@ void TransferListWidget::openSelectedTorrentsFolder() const
 
 void TransferListWidget::previewSelectedTorrents()
 {
-    for (BitTorrent::TorrentHandle *const torrent : asConst(getSelectedTorrents())) {
+    for (const BitTorrent::TorrentHandle *torrent : asConst(getSelectedTorrents())) {
         if (torrentContainsPreviewableFiles(torrent)) {
-            const auto *dialog = new PreviewSelectDialog(this, torrent);
+            auto *dialog = new PreviewSelectDialog(this, torrent);
+            dialog->setAttribute(Qt::WA_DeleteOnClose);
             connect(dialog, &PreviewSelectDialog::readyToPreviewFile, this, &TransferListWidget::previewFile);
         }
         else {

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -509,7 +509,8 @@ void TransferListWidget::previewSelectedTorrents()
             dialog->show();
         }
         else {
-            QMessageBox::critical(this, tr("Unable to preview"), tr("The selected torrent does not contain previewable files"));
+            QMessageBox::critical(this, tr("Unable to preview"), tr("The selected torrent \"%1\" does not contain previewable files")
+                .arg(torrent->name()));
         }
     }
 }


### PR DESCRIPTION
* Clean up PreviewSelectDialog class
* Fix preview action not working
  Root cause is the PreviewSelectDialog::readyToPreviewFile signal is emitted before it is connected to a slot.
  Only single-file torrents are affected.
* Don't close preview dialog if selected file failed to open 
  User may have made a mis-selection and this should not close the dialog (only when the torrent has multiple previewable files).
* Show torrent name in "preview file" related dialogs