### PR TITLE
Use screen real physical DPI on Windows

### DIFF
--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -66,8 +66,9 @@ qreal Utils::Gui::screenScalingFactor(const QWidget *widget)
         return 1;
 
 #ifdef Q_OS_WIN
-    const int screen = qApp->desktop()->screenNumber(widget);
-    return (QApplication::screens()[screen]->logicalDotsPerInch() / 96);
+    const int screenNumber = qApp->desktop()->screenNumber(widget);
+    const QScreen *screen = QApplication::screens()[screenNumber];
+    return (screen->logicalDotsPerInch() / screen->physicalDotsPerInch());
 #elif defined(Q_OS_MACOS)
     return 1;
 #else


### PR DESCRIPTION
Previously was using a hardcoded value which might lead to issues like #11234.