### PR TITLE
Update libtorrent build defines on Windows

### DIFF
--- a/cmake/Modules/FindLibtorrentRasterbar.cmake
+++ b/cmake/Modules/FindLibtorrentRasterbar.cmake
@@ -38,6 +38,8 @@ else()
         # libtorrent is very picky about those. Let's take a set of defaults and
         # hope that they apply. If not, you the user are on your own.
         set(LibtorrentRasterbar_DEFINITIONS
+            -DTORRENT_USE_LIBCRYPTO
+            # TODO: remove the following define as it is not used since OpenSSL >= 1.1
             -DTORRENT_USE_OPENSSL
             -DBOOST_ASIO_ENABLE_CANCELIO
             -DUNICODE -D_UNICODE -D_FILE_OFFSET_BITS=64)

--- a/cmake/Modules/winconf.cmake
+++ b/cmake/Modules/winconf.cmake
@@ -5,8 +5,12 @@ list(APPEND CMAKE_LIBRARY_PATH "$ENV{LIB}")
 set(LibtorrentRasterbar_CUSTOM_DEFINITIONS
     -DBOOST_ASIO_DISABLE_CONNECTEX
     -DBOOST_EXCEPTION_DISABLE
+    -DTORRENT_USE_LIBCRYPTO
+    # TODO: remove the following define as it is not used since OpenSSL >= 1.1
     -DTORRENT_USE_OPENSSL
-    -DTORRENT_DISABLE_RESOLVE_COUNTRIES)
+    # TODO: remove the following define as it is not used since libtorrent >= 1.2
+    -DTORRENT_DISABLE_RESOLVE_COUNTRIES
+)
 
 set(LibtorrentRasterbar_CUSTOM_BOOST_DEPENDENCIES system)
 

--- a/winconf.pri
+++ b/winconf.pri
@@ -3,7 +3,10 @@
 DEFINES += BOOST_ASIO_DISABLE_CONNECTEX
 DEFINES += BOOST_EXCEPTION_DISABLE
 
+DEFINES += TORRENT_USE_LIBCRYPTO
+# TODO: remove the following define as it is not used since OpenSSL >= 1.1
 DEFINES += TORRENT_USE_OPENSSL
+# TODO: remove the following define as it is not used since libtorrent >= 1.2
 DEFINES += TORRENT_DISABLE_RESOLVE_COUNTRIES
 
 DEFINES += NTDDI_VERSION=0x06010000


### PR DESCRIPTION
* `TORRENT_USE_LIBCRYPTO` replaced `TORRENT_USE_OPENSSL` since OpenSSL 1.1.
* `TORRENT_DISABLE_RESOLVE_COUNTRIES` has been removed since libtorrent 1.2.