### PR TITLE
Fix country name misspelling

### DIFF
--- a/src/base/net/geoipmanager.cpp
+++ b/src/base/net/geoipmanager.cpp
@@ -374,7 +374,7 @@ QString GeoIPManager::CountryName(const QString &countryISOCode)
         {"VE", tr("Venezuela, Bolivarian Republic of")},
         {"VG", tr("Virgin Islands, British")},
         {"VI", tr("Virgin Islands, U.S.")},
-        {"VN", tr("Viet Nam")},
+        {"VN", tr("Vietnam")},
         {"VU", tr("Vanuatu")},
         {"WF", tr("Wallis and Futuna")},
         {"WS", tr("Samoa")},


### PR DESCRIPTION
English spelling is "Vietnam". Vietnamese spelling is "Việt Nam" or
"Viet Nam".