### PR TITLE
Order qbittorrent-nox@.service after network-online.target

### DIFF
--- a/dist/unix/systemd/qbittorrent-nox@.service.in
+++ b/dist/unix/systemd/qbittorrent-nox@.service.in
@@ -1,8 +1,8 @@
 [Unit]
 Description=qBittorrenti-nox service for user %I
-
 Documentation=man:qbittorrent-nox(1)
-After=network.target
+Wants=network-online.target
+After=network-online.target nss-lookup.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
This ensures that `qbittorrent-nox` doesn't start while the network is not up yet.
`network-online.target `is also pulled in with `Wants=` per the systemd documentation—[`systemd.special(7)`](https://www.freedesktop.org/software/systemd/man/systemd.special.html#network-online.target).