### PR TITLE
Fix integer narrowing on x86

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -296,7 +296,7 @@ void Application::runExternalProgram(const BitTorrent::TorrentHandle *torrent) c
     program.replace("%N", torrent->name());
     program.replace("%L", torrent->category());
 
-    QStringList tags = torrent->tags().toList();
+    QStringList tags = torrent->tags().values();
     std::sort(tags.begin(), tags.end(), Utils::String::naturalLessThan<Qt::CaseInsensitive>);
     program.replace("%G", tags.join(','));
 

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -726,7 +726,7 @@ bool Session::addTag(const QString &tag)
 
     if (!hasTag(tag)) {
         m_tags.insert(tag);
-        m_storedTags = m_tags.toList();
+        m_storedTags = m_tags.values();
         emit tagAdded(tag);
         return true;
     }
@@ -738,7 +738,7 @@ bool Session::removeTag(const QString &tag)
     if (m_tags.remove(tag)) {
         for (TorrentHandle *const torrent : asConst(torrents()))
             torrent->removeTag(tag);
-        m_storedTags = m_tags.toList();
+        m_storedTags = m_tags.values();
         emit tagRemoved(tag);
         return true;
     }
@@ -3752,7 +3752,7 @@ void Session::startUpTorrents()
         }
 
         if (!queue.empty())
-            fastresumes = queue + fastresumes.toSet().subtract(queue.toSet()).toList();
+            fastresumes = queue + fastresumes.toSet().subtract(queue.toSet()).values();
     }
 
     for (const QString &fastresumeName : asConst(fastresumes)) {

--- a/src/base/search/searchpluginmanager.cpp
+++ b/src/base/search/searchpluginmanager.cpp
@@ -157,7 +157,7 @@ QStringList SearchPluginManager::getPluginCategories(const QString &pluginName) 
             categories << category;
     }
 
-    return categories.toList();
+    return categories.values();
 }
 
 PluginInfo *SearchPluginManager::pluginInfo(const QString &name) const

--- a/src/base/utils/fs.cpp
+++ b/src/base/utils/fs.cpp
@@ -348,7 +348,7 @@ bool Utils::Fs::isNetworkFileSystem(const QString &path)
     // Magic number references:
     // 1. /usr/include/linux/magic.h
     // 2. https://github.com/coreutils/coreutils/blob/master/src/stat.c
-    switch (buf.f_type) {
+    switch (static_cast<unsigned int>(buf.f_type)) {
     case 0xFF534D42:  // CIFS_MAGIC_NUMBER
     case 0x6969:  // NFS_SUPER_MAGIC
     case 0x517B:  // SMB_SUPER_MAGIC

--- a/src/gui/downloadfromurldialog.cpp
+++ b/src/gui/downloadfromurldialog.cpp
@@ -79,7 +79,7 @@ DownloadFromURLDialog::DownloadFromURLDialog(QWidget *parent)
         if (isDownloadable(str))
             uniqueURLs << str;
     }
-    m_ui->textUrls->setText(uniqueURLs.toList().join('\n'));
+    m_ui->textUrls->setText(uniqueURLs.values().join('\n'));
 
     Utils::Gui::resize(this);
     show();
@@ -108,6 +108,6 @@ void DownloadFromURLDialog::downloadButtonClicked()
         return;
     }
 
-    emit urlsReadyToBeDownloaded(uniqueURLs.toList());
+    emit urlsReadyToBeDownloaded(uniqueURLs.values());
     accept();
 }

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -200,7 +200,7 @@ QVariant TransferListModel::data(const QModelIndex &index, const int role) const
     case TR_CATEGORY:
         return torrent->category();
     case TR_TAGS: {
-            QStringList tagsList = torrent->tags().toList();
+            QStringList tagsList = torrent->tags().values();
             tagsList.sort();
             return tagsList.join(", ");
         }

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -102,7 +102,7 @@ QVariantMap serialize(const BitTorrent::TorrentHandle &torrent)
         {KEY_TORRENT_FIRST_LAST_PIECE_PRIO, torrent.hasFirstLastPiecePriority()},
 
         {KEY_TORRENT_CATEGORY, torrent.category()},
-        {KEY_TORRENT_TAGS, torrent.tags().toList().join(", ")},
+        {KEY_TORRENT_TAGS, torrent.tags().values().join(", ")},
         {KEY_TORRENT_SUPER_SEEDING, torrent.superSeeding()},
         {KEY_TORRENT_FORCE_START, torrent.isForced()},
         {KEY_TORRENT_SAVE_PATH, Utils::Fs::toNativePath(torrent.savePath())},


### PR DESCRIPTION
From http://man7.org/linux/man-pages/man2/statfs.2.html
>The __fsword_t type used for various fields in the statfs structure definition is a glibc internal type, not intended for public use...
>Using unsigned int for such variables suffices on most systems.

Will backport to v4_1_x.