### PR TITLE
Fix CMake Windows compilation

### DIFF
--- a/cmake/Modules/winconf-mingw.cmake
+++ b/cmake/Modules/winconf-mingw.cmake
@@ -6,4 +6,6 @@ list(APPEND LibtorrentRasterbar_CUSTOM_DEFINITIONS
     -D_FILE_OFFSET_BITS=64
     -D__USE_W32_SOCKETS)
 
-link_libraries(advapi32 iphlpapi ole32 powrprof shell32 user32 wsock32 ws2_32)
+# libraries from winconf.pri
+link_libraries(advapi32 iphlpapi ole32 shell32 user32 wsock32 ws2_32)
+

--- a/cmake/Modules/winconf-msvc.cmake
+++ b/cmake/Modules/winconf-msvc.cmake
@@ -1,3 +1,7 @@
 include(MacroConfigureMSVCRuntime)
 set(MSVC_RUNTIME "dynamic")
 configure_msvc_runtime()
+
+# libraries from winconf.pri
+link_libraries(advapi32 crypt32 Iphlpapi ole32 shell32 User32)
+


### PR DESCRIPTION
Tested on MSVC and Msys2-mingw64

I think `qbt_base` is the only one which requires `iphlpapi` plus I don't find where windows libs are specified.