### PR TITLE
Add "create subfolder" option to RSS auto-download rules

### DIFF
--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -385,6 +385,7 @@ void AutoDownloader::processJob(const QSharedPointer<ProcessingJob> &job)
         params.savePath = rule.savePath();
         params.category = rule.assignedCategory();
         params.addPaused = rule.addPaused();
+        params.createSubfolder = rule.createSubfolder();
         if (!rule.savePath().isEmpty())
             params.useAutoTMM = TriStateBool::False;
         const auto torrentURL = job->articleData.value(Article::KeyTorrentURL).toString();

--- a/src/base/rss/rss_autodownloadrule.cpp
+++ b/src/base/rss/rss_autodownloadrule.cpp
@@ -102,6 +102,7 @@ const QString Str_AssignedCategory(QStringLiteral("assignedCategory"));
 const QString Str_LastMatch(QStringLiteral("lastMatch"));
 const QString Str_IgnoreDays(QStringLiteral("ignoreDays"));
 const QString Str_AddPaused(QStringLiteral("addPaused"));
+const QString Str_CreateSubfolder(QStringLiteral("createSubfolder"));
 const QString Str_SmartFilter(QStringLiteral("smartFilter"));
 const QString Str_PreviouslyMatched(QStringLiteral("previouslyMatchedEpisodes"));
 
@@ -123,6 +124,7 @@ namespace RSS
         QString savePath;
         QString category;
         TriStateBool addPaused = TriStateBool::Undefined;
+        TriStateBool createSubfolder = TriStateBool::Undefined;
 
         bool smartFilter = false;
         QStringList previouslyMatchedEpisodes;
@@ -144,6 +146,7 @@ namespace RSS
                     && (savePath == other.savePath)
                     && (category == other.category)
                     && (addPaused == other.addPaused)
+                    && (createSubfolder == other.createSubfolder)
                     && (smartFilter == other.smartFilter);
         }
     };
@@ -439,6 +442,7 @@ QJsonObject AutoDownloadRule::toJsonObject() const
         , {Str_LastMatch, lastMatch().toString(Qt::RFC2822Date)}
         , {Str_IgnoreDays, ignoreDays()}
         , {Str_AddPaused, triStateBoolToJsonValue(addPaused())}
+        , {Str_CreateSubfolder, triStateBoolToJsonValue(createSubfolder())}
         , {Str_SmartFilter, useSmartFilter()}
         , {Str_PreviouslyMatched, QJsonArray::fromStringList(previouslyMatchedEpisodes())}};
 }
@@ -455,6 +459,7 @@ AutoDownloadRule AutoDownloadRule::fromJsonObject(const QJsonObject &jsonObj, co
     rule.setSavePath(jsonObj.value(Str_SavePath).toString());
     rule.setCategory(jsonObj.value(Str_AssignedCategory).toString());
     rule.setAddPaused(jsonValueToTriStateBool(jsonObj.value(Str_AddPaused)));
+    rule.setCreateSubfolder(jsonValueToTriStateBool(jsonObj.value(Str_CreateSubfolder)));
     rule.setLastMatch(QDateTime::fromString(jsonObj.value(Str_LastMatch).toString(), Qt::RFC2822Date));
     rule.setIgnoreDays(jsonObj.value(Str_IgnoreDays).toInt());
     rule.setUseSmartFilter(jsonObj.value(Str_SmartFilter).toBool(false));
@@ -582,6 +587,16 @@ TriStateBool AutoDownloadRule::addPaused() const
 void AutoDownloadRule::setAddPaused(const TriStateBool &addPaused)
 {
     m_dataPtr->addPaused = addPaused;
+}
+
+TriStateBool AutoDownloadRule::createSubfolder() const
+{
+    return m_dataPtr->createSubfolder;
+}
+
+void AutoDownloadRule::setCreateSubfolder(const TriStateBool &createSubfolder)
+{
+    m_dataPtr->createSubfolder = createSubfolder;
 }
 
 QString AutoDownloadRule::assignedCategory() const

--- a/src/base/rss/rss_autodownloadrule.h
+++ b/src/base/rss/rss_autodownloadrule.h
@@ -79,6 +79,8 @@ namespace RSS
         void setSavePath(const QString &savePath);
         TriStateBool addPaused() const;
         void setAddPaused(const TriStateBool &addPaused);
+        TriStateBool createSubfolder() const;
+        void setCreateSubfolder(const TriStateBool &createSubfolder);
         QString assignedCategory() const;
         void setCategory(const QString &category);
 

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -269,6 +269,12 @@ void AutomatedRssDownloader::updateRuleDefinitionBox()
         else if (m_currentRule.addPaused() == TriStateBool::False)
             index = 2;
         m_ui->comboAddPaused->setCurrentIndex(index);
+        index = 0;
+        if (m_currentRule.createSubfolder() == TriStateBool::True)
+            index = 1;
+        else if (m_currentRule.createSubfolder() == TriStateBool::False)
+            index = 2;
+        m_ui->comboCreateSubfolder->setCurrentIndex(index);
         m_ui->spinIgnorePeriod->setValue(m_currentRule.ignoreDays());
         QDateTime dateTime = m_currentRule.lastMatch();
         QString lMatch;
@@ -308,6 +314,8 @@ void AutomatedRssDownloader::clearRuleDefinitionBox()
     m_ui->spinIgnorePeriod->setValue(0);
     m_ui->comboAddPaused->clearEditText();
     m_ui->comboAddPaused->setCurrentIndex(-1);
+    m_ui->comboCreateSubfolder->clearEditText();
+    m_ui->comboCreateSubfolder->setCurrentIndex(-1);
     updateFieldsToolTips(m_ui->checkRegex->isChecked());
     updateMustLineValidity();
     updateMustNotLineValidity();
@@ -341,6 +349,12 @@ void AutomatedRssDownloader::updateEditedRule()
     else if (m_ui->comboAddPaused->currentIndex() == 2)
         addPaused = TriStateBool::False;
     m_currentRule.setAddPaused(addPaused);
+    TriStateBool createSubfolder; // Undefined by default
+    if (m_ui->comboCreateSubfolder->currentIndex() == 1)
+        createSubfolder = TriStateBool::True;
+    else if (m_ui->comboCreateSubfolder->currentIndex() == 2)
+        createSubfolder = TriStateBool::False;
+    m_currentRule.setCreateSubfolder(createSubfolder);
     m_currentRule.setIgnoreDays(m_ui->spinIgnorePeriod->value());
 }
 

--- a/src/gui/rss/automatedrssdownloader.ui
+++ b/src/gui/rss/automatedrssdownloader.ui
@@ -322,6 +322,42 @@ Supports the formats: S01E01, 1x1, 2017.01.01 and 01.01.2017 (Date formats also 
             </item>
            </layout>
           </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_10">
+            <item>
+             <widget class="QLabel" name="lblCreateSubfolder">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Create Subfolder:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="comboCreateSubfolder">
+              <item>
+               <property name="text">
+                <string>Use global settings</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Always</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Never</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+           </layout>
+          </item>
          </layout>
         </widget>
        </item>
@@ -435,6 +471,7 @@ Supports the formats: S01E01, 1x1, 2017.01.01 and 01.01.2017 (Date formats also 
   <tabstop>lineSavePath</tabstop>
   <tabstop>spinIgnorePeriod</tabstop>
   <tabstop>comboAddPaused</tabstop>
+  <tabstop>comboCreateSubfolder</tabstop>
   <tabstop>listFeeds</tabstop>
   <tabstop>treeMatchingArticles</tabstop>
   <tabstop>importBtn</tabstop>


### PR DESCRIPTION
When adding a torrent through the "add a torrent" dialog, there's an option to enable/disable creating a subfolder (with the same name as the torrent) when the torrent contains multiple files. However, this option cannot be set when using auto-download RSS rules, and it always creates such folder.

This commit adds a new option to the RSS auto-download rule editing screen that allows specifying this setting (defaulting to the global setting value). It would also expose the setting to the [RSS Web API](https://github.com/qbittorrent/qBittorrent/wiki/Web-API-Documentation#set-auto-downloading-rule) (adding a "createSubfolder" bool field).

![](https://i.imgur.com/H1qoUF9.png)

**Note**: I didn't change any localization files (for the new label text) as I'm unsure of the localization workflow in this project.

Closes #9414.
