### PR TITLE
Add "Preview file" double-click action

### DIFF
--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -42,6 +42,7 @@ enum DoubleClickAction
 {
     TOGGLE_PAUSE,
     OPEN_DEST,
+    PREVIEW_FILE,
     NO_ACTION
 };
 

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -332,6 +332,11 @@
                     </item>
                     <item>
                      <property name="text">
+                      <string>Preview file, otherwise open destination folder</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
                       <string>No action</string>
                      </property>
                     </item>

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -98,6 +98,18 @@ namespace
         return false;
     }
 
+    void openDestinationFolder(const BitTorrent::TorrentHandle *const torrent)
+    {
+#ifdef Q_OS_MACOS
+        MacUtils::openFiles(QSet<QString>{torrent->contentPath(true)});
+#else
+        if (torrent->filesCount() == 1)
+            Utils::Gui::openFolderSelect(torrent->contentPath(true));
+        else
+            Utils::Gui::openPath(torrent->contentPath(true));
+#endif
+    }
+
     void removeTorrents(const QVector<BitTorrent::TorrentHandle *> &torrents, const bool isDeleteFileSelected)
     {
         auto *session = BitTorrent::Session::instance();
@@ -269,15 +281,19 @@ void TransferListWidget::torrentDoubleClicked()
         else
             torrent->pause();
         break;
+    case PREVIEW_FILE:
+        if (torrentContainsPreviewableFiles(torrent)) {
+            auto *dialog = new PreviewSelectDialog(this, torrent);
+            dialog->setAttribute(Qt::WA_DeleteOnClose);
+            connect(dialog, &PreviewSelectDialog::readyToPreviewFile, this, &TransferListWidget::previewFile);
+            dialog->show();
+        }
+        else {
+            openDestinationFolder(torrent);
+        }
+        break;
     case OPEN_DEST:
-#ifdef Q_OS_MACOS
-        MacUtils::openFiles(QSet<QString>{torrent->contentPath(true)});
-#else
-        if (torrent->filesCount() == 1)
-            Utils::Gui::openFolderSelect(torrent->contentPath(true));
-        else
-            Utils::Gui::openPath(torrent->contentPath(true));
-#endif
+        openDestinationFolder(torrent);
         break;
     }
 }


### PR DESCRIPTION
Let's have an option for completed torrents to do preview on double-click, and if we can't, open destination folder so the user can choose the file they want.

Closes issues #6965, #486.