### PR TITLE
Prepare infrastructure for font customization

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -116,6 +116,11 @@ void Preferences::setUseCustomUITheme(const bool use)
     setValue("Preferences/General/UseCustomUITheme", use);
 }
 
+QString Preferences::getFontColor(int n, const QString &default_color) const
+{
+    return value("Preferences/Colors/" + QString::number(n), default_color).toString();
+}
+
 QString Preferences::customUIThemePath() const
 {
     return value("Preferences/General/CustomUIThemePath").toString();

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -100,6 +100,7 @@ public:
     void setLocale(const QString &locale);
     bool useCustomUITheme() const;
     void setUseCustomUITheme(bool use);
+    QString getFontColor(int n, const QString &default_color) const;
     QString customUIThemePath() const;
     void setCustomUIThemePath(const QString &path);
     bool deleteTorrentFilesAsDefault() const;

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -39,6 +39,7 @@
 #include "base/bittorrent/torrenthandle.h"
 #include "base/global.h"
 #include "base/utils/fs.h"
+#include "base/preferences.h"
 
 static QIcon getIconByState(BitTorrent::TorrentState state);
 static QColor getColorByState(BitTorrent::TorrentState state);
@@ -378,6 +379,8 @@ QIcon getIconByState(const BitTorrent::TorrentState state)
 
 QColor getColorByState(const BitTorrent::TorrentState state)
 {
+    const Preferences *const pref = Preferences::instance();
+
     // Color names taken from http://cloford.com/resources/colours/500col.htm
     bool dark = isDarkTheme();
 
@@ -386,32 +389,32 @@ QColor getColorByState(const BitTorrent::TorrentState state)
     case BitTorrent::TorrentState::ForcedDownloading:
     case BitTorrent::TorrentState::DownloadingMetadata:
         if (!dark)
-            return {34, 139, 34}; // Forest Green
+            return pref->getFontColor(0, "#228b22"); // Forest Green
         else
-            return {50, 205, 50}; // Lime Green
+            return pref->getFontColor(100, "#32cd32"); // Lime Green
     case BitTorrent::TorrentState::Allocating:
     case BitTorrent::TorrentState::StalledDownloading:
     case BitTorrent::TorrentState::StalledUploading:
         if (!dark)
-            return {0, 0, 0}; // Black
+            return pref->getFontColor(1, "#000000"); // Black
         else
-            return {204, 204, 204}; // Gray 80
+            return pref->getFontColor(101, "#cccccc"); // Gray 80
     case BitTorrent::TorrentState::Uploading:
     case BitTorrent::TorrentState::ForcedUploading:
         if (!dark)
-            return {65, 105, 225}; // Royal Blue
+            return pref->getFontColor(2, "#4169e1"); // Royal Blue
         else
-            return {99, 184, 255}; // Steel Blue 1
+            return pref->getFontColor(102, "#63b8ff"); // Steel Blue 1
     case BitTorrent::TorrentState::PausedDownloading:
-        return {250, 128, 114}; // Salmon
+        return pref->getFontColor(3, "#fa8072"); // Salmon
     case BitTorrent::TorrentState::PausedUploading:
         if (!dark)
-            return {0, 0, 139}; // Dark Blue
+            return pref->getFontColor(4, "#00008b"); // Dark Blue
         else
-            return {79, 148, 205}; // Steel Blue 3
+            return pref->getFontColor(104, "#4f94cd"); // Steel Blue 3
     case BitTorrent::TorrentState::Error:
     case BitTorrent::TorrentState::MissingFiles:
-        return {255, 0, 0}; // red
+        return pref->getFontColor(5, "#ff0000"); // red
     case BitTorrent::TorrentState::QueuedDownloading:
     case BitTorrent::TorrentState::QueuedUploading:
     case BitTorrent::TorrentState::CheckingDownloading:
@@ -419,14 +422,14 @@ QColor getColorByState(const BitTorrent::TorrentState state)
     case BitTorrent::TorrentState::CheckingResumeData:
     case BitTorrent::TorrentState::Moving:
         if (!dark)
-            return {0, 128, 128}; // Teal
+            return pref->getFontColor(6, "#008080"); // Teal
         else
-            return {0, 205, 205}; // Cyan 3
+            return pref->getFontColor(106, "#00cdcd"); // Cyan 3
     case BitTorrent::TorrentState::Unknown:
-        return {255, 0, 0}; // red
+        return pref->getFontColor(7, "#ff0000"); // red
     default:
         Q_ASSERT(false);
-        return {255, 0, 0}; // red
+        return pref->getFontColor(8, "#ff0000"); // red
     }
 }
 


### PR DESCRIPTION
Allow font colors for transfer list to be specified in preferences file.
If there are none (current situation), use defaults.