### PR TITLE
Fix stuck in wrong torrent state

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -4188,6 +4188,10 @@ void Session::createTorrentHandle(const lt::torrent_handle &nativeHandle)
     // Send new torrent signal
     if (!params.restored)
         emit torrentNew(torrent);
+
+    // Torrent could have error just after adding to libtorrent
+    if (torrent->hasError())
+        LogMsg(tr("Torrent errored. Torrent: \"%1\". Error: %2.").arg(torrent->name(), torrent->error()), Log::WARNING);
 }
 
 void Session::handleAddTorrentAlert(const lt::add_torrent_alert *p)

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -899,7 +899,10 @@ TorrentState TorrentHandle::state() const
 
 void TorrentHandle::updateState()
 {
-    if (m_nativeStatus.state == lt::torrent_status::checking_resume_data) {
+    if (hasError()) {
+        m_state = TorrentState::Error;
+    }
+    else if (m_nativeStatus.state == lt::torrent_status::checking_resume_data) {
         m_state = TorrentState::CheckingResumeData;
     }
     else if (isMoveInProgress()) {
@@ -908,8 +911,6 @@ void TorrentHandle::updateState()
     else if (isPaused()) {
         if (hasMissingFiles())
             m_state = TorrentState::MissingFiles;
-        else if (hasError())
-            m_state = TorrentState::Error;
         else
             m_state = isSeed() ? TorrentState::PausedUploading : TorrentState::PausedDownloading;
     }
@@ -961,12 +962,7 @@ bool TorrentHandle::hasMissingFiles() const
 
 bool TorrentHandle::hasError() const
 {
-#if (LIBTORRENT_VERSION_NUM < 10200)
-    return (m_nativeStatus.paused && m_nativeStatus.errc);
-#else
-    return ((m_nativeStatus.flags & lt::torrent_flags::paused)
-            && m_nativeStatus.errc);
-#endif
+    return static_cast<bool>(m_nativeStatus.errc);
 }
 
 bool TorrentHandle::hasFilteredPieces() const

--- a/src/gui/transferlistdelegate.cpp
+++ b/src/gui/transferlistdelegate.cpp
@@ -100,7 +100,10 @@ void TransferListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
         break;
     case TransferListModel::TR_STATUS: {
             const auto state = index.data().value<BitTorrent::TorrentState>();
+            const QString errorMsg = index.data(Qt::UserRole).toString();
             QString display = getStatusString(state);
+            if (state == BitTorrent::TorrentState::Error)
+                display += (": " + errorMsg);
             QItemDelegate::drawDisplay(painter, opt, opt.rect, display);
         }
         break;

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -184,7 +184,7 @@ QVariant TransferListModel::data(const QModelIndex &index, const int role) const
     case TR_PROGRESS:
         return torrent->progress();
     case TR_STATUS:
-        return QVariant::fromValue(torrent->state());
+        return (role == Qt::DisplayRole) ? QVariant::fromValue(torrent->state()) : torrent->error();
     case TR_SEEDS:
         return (role == Qt::DisplayRole) ? torrent->seedsCount() : torrent->totalSeedsCount();
     case TR_PEERS:


### PR DESCRIPTION
Before this patch, adding the torrent in https://github.com/qbittorrent/qBittorrent/issues/11511 and the torrent state will stay in torrent_status::checking_resume_data forever.
This is not the correct state since the `torrent_status.errc` field is non-zero and this commit fixes it.

I haven't got time to check if this breaks other use cases so maybe defer to post v4.2.0 release and testings are welcome.