### PR TITLE
Migrate away from deprecated API

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -142,8 +142,12 @@ namespace
     bool loadTorrentResumeData(const QByteArray &data, CreateTorrentParams &torrentParams, int &queuePos, MagnetUri &magnetUri)
     {
         lt::error_code ec;
+#if (LIBTORRENT_VERSION_NUM < 10200)
         lt::bdecode_node root;
         lt::bdecode(data.constData(), (data.constData() + data.size()), root, ec);
+#else
+        const lt::bdecode_node root = lt::bdecode(data, ec);
+#endif
         if (ec || (root.type() != lt::bdecode_node::dict_t)) return false;
 
         torrentParams = CreateTorrentParams();

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -87,11 +87,16 @@ TorrentInfo TorrentInfo::load(const QByteArray &data, QString *error) noexcept
     // used in `torrent_info()` constructor
     const int depthLimit = 100;
     const int tokenLimit = 10000000;
-    lt::error_code ec;
 
+    lt::error_code ec;
+#if (LIBTORRENT_VERSION_NUM < 10200)
     lt::bdecode_node node;
     bdecode(data.constData(), (data.constData() + data.size()), node, ec
         , nullptr, depthLimit, tokenLimit);
+#else
+    const lt::bdecode_node node = lt::bdecode(data, ec
+        , nullptr, depthLimit, tokenLimit);
+#endif
     if (ec) {
         if (error)
             *error = QString::fromStdString(ec.message());


### PR DESCRIPTION
Today I noticed some build warnings, possibly started since this commit: https://github.com/arvidn/libtorrent/commit/78aefcc80648e81ff68a0cab258e7d2739c3ae79
