### PR TITLE
Expand single-item folders in torrent content

### DIFF
--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -625,8 +625,12 @@ void AddNewTorrentDialog::setupTreeview()
         m_ui->contentTreeView->hideColumn(REMAINING);
         m_ui->contentTreeView->hideColumn(AVAILABILITY);
 
-        // Expand root folder
-        m_ui->contentTreeView->setExpanded(m_contentModel->index(0, 0), true);
+        // Expand single-item folders recursively
+        QModelIndex currentIndex;
+        while (m_contentModel->rowCount(currentIndex) == 1) {
+            currentIndex = m_contentModel->index(0, 0, currentIndex);
+            m_ui->contentTreeView->setExpanded(currentIndex, true);
+        }
     }
 
     updateDiskSpaceLabel();

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -322,8 +322,13 @@ void PropertiesWidget::loadTorrentInfos(BitTorrent::TorrentHandle *const torrent
 
         // List files in torrent
         m_propListModel->model()->setupModelData(m_torrent->info());
-        if (m_propListModel->model()->rowCount() == 1)
-            m_ui->filesList->setExpanded(m_propListModel->index(0, 0), true);
+
+        // Expand single-item folders recursively
+        QModelIndex currentIndex;
+        while (m_propListModel->rowCount(currentIndex) == 1) {
+            currentIndex = m_propListModel->index(0, 0, currentIndex);
+            m_ui->filesList->setExpanded(currentIndex, true);
+        }
 
         // Load file priorities
         m_propListModel->model()->updateFilesPriorities(m_torrent->filePriorities());


### PR DESCRIPTION
Expand single-item folders recursively in Content tab.

Closes #11525.