### PR TITLE
Fixes for WebUI

### DIFF
--- a/src/base/search/searchpluginmanager.cpp
+++ b/src/base/search/searchpluginmanager.cpp
@@ -318,7 +318,7 @@ SearchHandler *SearchPluginManager::startSearch(const QString &pattern, const QS
 
 QString SearchPluginManager::categoryFullName(const QString &categoryName)
 {
-    static const QHash<QString, QString> categoryTable {
+    const QHash<QString, QString> categoryTable {
         {"all", tr("All categories")},
         {"movies", tr("Movies")},
         {"tv", tr("TV shows")},

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1602,14 +1602,14 @@ window.qBittorrent.DynamicTable = (function() {
             this.columns['enabled'].updateTd = function(td, row) {
                 const value = this.getRowValue(row);
                 if (value) {
-                    td.set('text', "Yes");
-                    td.set('title', "Yes");
+                    td.set('text', 'QBT_TR(Yes)QBT_TR[CONTEXT=SearchPluginsTable]');
+                    td.set('title', 'QBT_TR(Yes)QBT_TR[CONTEXT=SearchPluginsTable]');
                     td.getParent("tr").addClass("green");
                     td.getParent("tr").removeClass("red");
                 }
                 else {
-                    td.set('text', "No");
-                    td.set('title', "No");
+                    td.set('text', 'QBT_TR(No)QBT_TR[CONTEXT=SearchPluginsTable]');
+                    td.set('title', 'QBT_TR(No)QBT_TR[CONTEXT=SearchPluginsTable]');
                     td.getParent("tr").addClass("red");
                     td.getParent("tr").removeClass("green");
                 }

--- a/src/webui/www/private/views/search.html
+++ b/src/webui/www/private/views/search.html
@@ -11,17 +11,14 @@
 
     #categorySelect {
         width: 150px;
-        height: 20px;
     }
 
     #pluginsSelect {
         width: 150px;
-        height: 20px;
     }
 
     #startSearchButton {
         width: 90px;
-        height: 20px;
     }
 
     #searchResultsNoPlugins {
@@ -49,7 +46,6 @@
     }
 
     #manageSearchPlugins {
-        line-height: 1.5em;
         float: right;
     }
 


### PR DESCRIPTION
* Fix missing translations in search plugins dialog
* Unify HTML elements height
  Specifying a height value might cut the displayed text, so let it auto decide.
  Before: ![before](https://user-images.githubusercontent.com/9395168/70134920-ef73d100-16c3-11ea-81a6-ee6a747dfe82.png)
  After: ![after](https://user-images.githubusercontent.com/9395168/70134919-ef73d100-16c3-11ea-9cfb-428d58ce04ea.png)
* Fix incorrect translation displayed after language change
  It is expected in WebUI that the language change applies immediately (without a program restart) and this static caching prevents that.

