### PR TITLE
Rework the listening IP/interface selection code

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -303,8 +303,6 @@ namespace BitTorrent
         void setNetworkInterfaceName(const QString &name);
         QString networkInterfaceAddress() const;
         void setNetworkInterfaceAddress(const QString &address);
-        bool isIPv6Enabled() const;
-        void setIPv6Enabled(bool enabled);
         int encryption() const;
         void setEncryption(int state);
         bool isProxyPeerConnectionsEnabled() const;
@@ -532,6 +530,7 @@ namespace BitTorrent
         void configureComponents();
         void initializeNativeSession();
         void loadLTSettings(lt::settings_pack &settingsPack);
+        void configureNetworkInterfaces(lt::settings_pack &settingsPack);
         void configurePeerClasses();
         void adjustLimits(lt::settings_pack &settingsPack);
         void applyBandwidthLimits(lt::settings_pack &settingsPack) const;
@@ -662,7 +661,6 @@ namespace BitTorrent
         CachedSettingValue<QString> m_networkInterface;
         CachedSettingValue<QString> m_networkInterfaceName;
         CachedSettingValue<QString> m_networkInterfaceAddress;
-        CachedSettingValue<bool> m_isIPv6Enabled;
         CachedSettingValue<int> m_encryption;
         CachedSettingValue<bool> m_isProxyPeerConnectionsEnabled;
         CachedSettingValue<ChokingAlgorithm> m_chokingAlgorithm;

--- a/src/base/settingsstorage.cpp
+++ b/src/base/settingsstorage.cpp
@@ -86,7 +86,6 @@ namespace
             {"BitTorrent/Session/BandwidthSchedulerEnabled", "Preferences/Scheduler/Enabled"},
             {"BitTorrent/Session/Port", "Preferences/Connection/PortRangeMin"},
             {"BitTorrent/Session/UseRandomPort", "Preferences/General/UseRandomPort"},
-            {"BitTorrent/Session/IPv6Enabled", "Preferences/Connection/InterfaceListenIPv6"},
             {"BitTorrent/Session/Interface", "Preferences/Connection/Interface"},
             {"BitTorrent/Session/InterfaceName", "Preferences/Connection/InterfaceName"},
             {"BitTorrent/Session/InterfaceAddress", "Preferences/Connection/InterfaceAddress"},

--- a/src/base/utils/net.cpp
+++ b/src/base/utils/net.cpp
@@ -28,6 +28,7 @@
 
 #include "net.h"
 
+#include <QNetworkInterface>
 #include <QSslCertificate>
 #include <QSslKey>
 #include <QString>
@@ -89,6 +90,37 @@ namespace Utils
         QString subnetToString(const Subnet &subnet)
         {
             return subnet.first.toString() + '/' + QString::number(subnet.second);
+        }
+
+        QHostAddress canonicalIPv6Addr(const QHostAddress &addr)
+        {
+            // Link-local IPv6 textual address always contains a scope id (or zone index)
+            // The scope id is appended to the IPv6 address using the '%' character
+            // The scope id can be either a interface name or an interface number
+            // Examples:
+            // fe80::1%ethernet_17
+            // fe80::1%13
+            // The interface number is the mandatory supported way
+            // Unfortunately for us QHostAddress::toString() outputs (at least on Windows)
+            // the interface name, and libtorrent/boost.asio only support an interface number
+            // as scope id. Furthermore, QHostAddress doesn't have any convenient method to
+            // affect this, so we jump through hoops here.
+            if (addr.protocol() != QAbstractSocket::IPv6Protocol)
+                return QHostAddress{addr.toIPv6Address()};
+
+            // QHostAddress::setScopeId(addr.scopeId()); // Even though the docs say that setScopeId
+            // will convert a name to a number, this doesn't happen. Probably a Qt bug.
+            const QString scopeIdTxt = addr.scopeId();
+            if (scopeIdTxt.isEmpty())
+                return addr;
+
+            const int id = QNetworkInterface::interfaceIndexFromName(scopeIdTxt);
+            if (id == 0) // This failure might mean that the scope id was already a number
+                return addr;
+
+            QHostAddress canonical(addr.toIPv6Address());
+            canonical.setScopeId(QString::number(id));
+            return canonical;
         }
 
         QList<QSslCertificate> loadSSLCertificate(const QByteArray &data)

--- a/src/base/utils/net.h
+++ b/src/base/utils/net.h
@@ -50,6 +50,7 @@ namespace Utils
         bool isLoopbackAddress(const QHostAddress &addr);
         bool isIPInRange(const QHostAddress &addr, const QVector<Subnet> &subnets);
         QString subnetToString(const Subnet &subnet);
+        QHostAddress canonicalIPv6Addr(const QHostAddress &addr);
 
         const int MAX_SSL_FILE_SIZE = 1024 * 1024;
         QList<QSslCertificate> loadSSLCertificate(const QByteArray &data);

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -63,7 +63,7 @@ private:
              m_spinBoxSendBufferWatermarkFactor, m_spinBoxSocketBacklogSize, m_spinBoxSavePathHistoryLength;
     QCheckBox m_checkBoxOsCache, m_checkBoxRecheckCompleted, m_checkBoxResolveCountries, m_checkBoxResolveHosts, m_checkBoxSuperSeeding,
               m_checkBoxProgramNotifications, m_checkBoxTorrentAddedNotifications, m_checkBoxTrackerFavicon, m_checkBoxTrackerStatus,
-              m_checkBoxConfirmTorrentRecheck, m_checkBoxConfirmRemoveAllTags, m_checkBoxListenIPv6, m_checkBoxAnnounceAllTrackers, m_checkBoxAnnounceAllTiers,
+              m_checkBoxConfirmTorrentRecheck, m_checkBoxConfirmRemoveAllTags, m_checkBoxAnnounceAllTrackers, m_checkBoxAnnounceAllTiers,
               m_checkBoxMultiConnectionsPerIp, m_checkBoxSuggestMode, m_checkBoxCoalesceRW, m_checkBoxSpeedWidgetEnabled;
     QComboBox m_comboBoxInterface, m_comboBoxInterfaceAddress, m_comboBoxUtpMixedMode, m_comboBoxChokingAlgorithm, m_comboBoxSeedChokingAlgorithm;
     QLineEdit m_lineEditAnnounceIP;

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -259,8 +259,6 @@ void AppController::preferencesAction()
     data["current_network_interface"] = session->networkInterface();
     // Current network interface address
     data["current_interface_address"] = BitTorrent::Session::instance()->networkInterfaceAddress();
-    // Listen on IPv6 address
-    data["listen_on_ipv6_address"] = session->isIPv6Enabled();
     // Save resume data interval
     data["save_resume_data_interval"] = static_cast<double>(session->saveResumeDataInterval());
     // Recheck completed torrents
@@ -654,9 +652,6 @@ void AppController::setPreferencesAction()
         const QHostAddress ifaceAddress {it.value().toString().trimmed()};
         session->setNetworkInterfaceAddress(ifaceAddress.isNull() ? QString {} : ifaceAddress.toString());
     }
-    // Listen on IPv6 address
-    if (hasKey("listen_on_ipv6_address"))
-        session->setIPv6Enabled(it.value().toBool());
     // Save resume data interval
     if (hasKey("save_resume_data_interval"))
         session->setSaveResumeDataInterval(it.value().toInt());
@@ -767,14 +762,22 @@ void AppController::networkInterfaceAddressListAction()
     const QString ifaceName = params().value("iface");
     QJsonArray addressList;
 
+    const auto appendAddress = [&addressList](const QHostAddress &addr)
+    {
+        if (addr.protocol() == QAbstractSocket::IPv6Protocol)
+            addressList.append(Utils::Net::canonicalIPv6Addr(addr).toString());
+        else
+            addressList.append(addr.toString());
+    };
+
     if (ifaceName.isEmpty()) {
-        for (const QHostAddress &ip : asConst(QNetworkInterface::allAddresses()))
-            addressList.append(ip.toString());
+        for (const QHostAddress &addr : asConst(QNetworkInterface::allAddresses()))
+            appendAddress(addr);
     }
     else {
         const QNetworkInterface iface = QNetworkInterface::interfaceFromName(ifaceName);
         for (const QNetworkAddressEntry &entry : asConst(iface.addressEntries()))
-            addressList.append(entry.ip().toString());
+            appendAddress(entry.ip());
     }
 
     setResult(addressList);

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1438,6 +1438,8 @@
                     if (!addresses) return;
 
                     $('optionalIPAddressToBind').options.add(new Option('QBT_TR(All addresses)QBT_TR[CONTEXT=OptionDialog]', ''));
+                    $('optionalIPAddressToBind').options.add(new Option('QBT_TR(All IPv4 addresses)QBT_TR[CONTEXT=OptionDialog]', '0.0.0.0'));
+                    $('optionalIPAddressToBind').options.add(new Option('QBT_TR(All IPv6 addresses)QBT_TR[CONTEXT=OptionDialog]', '::'));
                     addresses.forEach(function(item, index) {
                         $('optionalIPAddressToBind').options.add(new Option(item, item));
                     });


### PR DESCRIPTION
Closes #11561

It started as a simple fix for #11561. But as I dug deeper I fixed more and more things. And it became a full blown refactor.

With this PR:
1. As per 1.2.x docs, the default setting (aka all interfaces + all addresses) is to also explicitly set the IPv6_ANY address
2. Now if a user chooses "all addresses" from a specific interface, we tell libtorrent to bind to that specific interface instead of listing to it all the addresses of the interface. This has the benefit that libtorrent will automatically follow any changes to that interface. This is of benefit to VPN users when their connection drops and then they get assigned a new "local" ip.
3. Two new options in the drop down menu for addresses. `All IPv4 Addresses` and `All IPv6 Addresses`.
4. Due to the above, the option "Listen to IPv6 address" is removed. This warrants a WebAPI major version bump (not done in this PR).
5. I discovered a Qt bug concerning the textual representation of IPv6 and scope id. Read the code comments for details. This bug essentially resulted in libtorrent not binding on the set IPv6 address but instead to `0.0.0.0`.


PS: I am not very good with choosing variable/function names.