### PR TITLE
Mention HTTPS in WebUI magnet link warning

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -967,7 +967,10 @@ window.addEvent('load', function() {
 
 function registerMagnetHandler() {
     if (typeof navigator.registerProtocolHandler !== 'function') {
-        alert("Your browser does not support this feature");
+        if (window.location.protocol !== 'https:')
+            alert(QBT_TR("To use this feature, the WebUI needs to be accessed over HTTPS")QBT_TR[CONTEXT=MainWindow]);
+        else
+            alert(QBT_TR("Your browser does not support this feature")QBT_TR[CONTEXT=MainWindow]);
         return;
     }
 


### PR DESCRIPTION
According to [Mozilla docs](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler), `registerProtocolHandler()` is only available when using secure contexts (i.e. HTTPS for everything outside localhost).

The message "`Your browser does not support this feature`" does not make this obvious and can lead to confusion if the user is using a modern browser.