### PR TITLE
Align Properties Tabbar in center

### DIFF
--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -76,6 +76,7 @@ PropertiesWidget::PropertiesWidget(QWidget *parent)
     : QWidget(parent)
     , m_ui(new Ui::PropertiesWidget())
     , m_torrent(nullptr)
+    , m_handleWidth(-1)
 {
     m_ui->setupUi(this);
     setAutoFillBackground(true);
@@ -144,7 +145,7 @@ PropertiesWidget::PropertiesWidget(QWidget *parent)
     m_ui->vBoxLayoutPeerPage->addWidget(m_peerList);
     // Tab bar
     m_tabBar = new PropTabBar(nullptr);
-    m_tabBar->setContentsMargins(0, 5, 0, 0);
+    m_tabBar->setContentsMargins(0, 5, 0, 5);
     m_ui->verticalLayout->addLayout(m_tabBar);
     connect(m_tabBar, &PropTabBar::tabChanged, m_ui->stackedProperties, &QStackedWidget::setCurrentIndex);
     connect(m_tabBar, &PropTabBar::tabChanged, this, &PropertiesWidget::saveSettings);
@@ -192,7 +193,7 @@ void PropertiesWidget::showPiecesDownloaded(bool show)
         m_ui->lineBelowBars->setVisible(show);
 }
 
-void PropertiesWidget::setVisibility(bool visible)
+void PropertiesWidget::setVisibility(const bool visible)
 {
     if (!visible && (m_state == VISIBLE)) {
         const int tabBarHeight = m_tabBar->geometry().height(); // take height before hiding
@@ -201,6 +202,8 @@ void PropertiesWidget::setVisibility(bool visible)
         m_slideSizes = hSplitter->sizes();
         hSplitter->handle(1)->setVisible(false);
         hSplitter->handle(1)->setDisabled(true);
+        m_handleWidth = hSplitter->handleWidth();
+        hSplitter->setHandleWidth(0);
         const QList<int> sizes {(hSplitter->geometry().height() - tabBarHeight), tabBarHeight};
         hSplitter->setSizes(sizes);
         setMaximumSize(maximumSize().width(), tabBarHeight);
@@ -211,6 +214,8 @@ void PropertiesWidget::setVisibility(bool visible)
     if (visible && (m_state == REDUCED)) {
         m_ui->stackedProperties->setVisible(true);
         auto *hSplitter = static_cast<QSplitter *>(parentWidget());
+        if (m_handleWidth != -1)
+            hSplitter->setHandleWidth(m_handleWidth);
         hSplitter->handle(1)->setDisabled(false);
         hSplitter->handle(1)->setVisible(true);
         hSplitter->setSizes(m_slideSizes);

--- a/src/gui/properties/propertieswidget.h
+++ b/src/gui/properties/propertieswidget.h
@@ -123,6 +123,7 @@ private:
     PieceAvailabilityBar *m_piecesAvailability;
     PropTabBar *m_tabBar;
     LineEdit *m_contentFilterLine;
+    int m_handleWidth;
 };
 
 #endif // PROPERTIESWIDGET_H

--- a/src/gui/properties/propertieswidget.ui
+++ b/src/gui/properties/propertieswidget.ui
@@ -23,6 +23,9 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
+   <property name="spacing">
+    <number>0</number>
+   </property>
    <item>
     <widget class="QStackedWidget" name="stackedProperties">
      <property name="currentIndex">


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/34717789/70389933-ea788f80-19eb-11ea-8579-4ee186876e6e.png)
![image](https://user-images.githubusercontent.com/34717789/70390717-7a6e0780-19f3-11ea-9b87-0b2c05add99c.png)


New:
![image](https://user-images.githubusercontent.com/34717789/70389943-01b77d00-19ec-11ea-9d83-c071df41306d.png)
![image](https://user-images.githubusercontent.com/34717789/70390704-61655680-19f3-11ea-80bb-2e680e916a74.png)


Disproportionate spacing don't look good.
