### PR TITLE
Fix quoting of alert() in client.js

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -968,9 +968,9 @@ window.addEvent('load', function() {
 function registerMagnetHandler() {
     if (typeof navigator.registerProtocolHandler !== 'function') {
         if (window.location.protocol !== 'https:')
-            alert(QBT_TR("To use this feature, the WebUI needs to be accessed over HTTPS")QBT_TR[CONTEXT=MainWindow]);
+            alert("QBT_TR(To use this feature, the WebUI needs to be accessed over HTTPS)QBT_TR[CONTEXT=MainWindow]");
         else
-            alert(QBT_TR("Your browser does not support this feature")QBT_TR[CONTEXT=MainWindow]);
+            alert("QBT_TR(Your browser does not support this feature)QBT_TR[CONTEXT=MainWindow]");
         return;
     }
 


### PR DESCRIPTION
Fix `alert()` I broke in #11615 .