### PR TITLE
Throw 404 errors in case torrents are not found

### DIFF
--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -127,8 +127,9 @@ namespace
         else {
             for (const QString &hash : hashes) {
                 BitTorrent::TorrentHandle *const torrent = BitTorrent::Session::instance()->findTorrent(hash);
-                if (torrent)
-                    func(torrent);
+                if (!torrent)
+                    throw APIError(APIErrorType::NotFound);
+                func(torrent);
             }
         }
     }
@@ -792,8 +793,9 @@ void TorrentsController::uploadLimitAction()
     for (const QString &hash : hashes) {
         int limit = -1;
         const BitTorrent::TorrentHandle *const torrent = BitTorrent::Session::instance()->findTorrent(hash);
-        if (torrent)
-            limit = torrent->uploadLimit();
+        if (!torrent)
+            throw APIError(APIErrorType::NotFound);
+        limit = torrent->uploadLimit();
         map[hash] = limit;
     }
 
@@ -809,8 +811,9 @@ void TorrentsController::downloadLimitAction()
     for (const QString &hash : hashes) {
         int limit = -1;
         const BitTorrent::TorrentHandle *const torrent = BitTorrent::Session::instance()->findTorrent(hash);
-        if (torrent)
-            limit = torrent->downloadLimit();
+        if (!torrent)
+            throw APIError(APIErrorType::NotFound);
+        limit = torrent->downloadLimit();
         map[hash] = limit;
     }
 


### PR DESCRIPTION
This commit adds more `APIError(APIErrorType::NotFound)`
exceptions in the `TorrentsController::uploadLimitAction`
and `TorrentsController::downloadLimitAction` actions.

With these changes, the API consumer is able to catch
previously silenced errors.