### PR TITLE
Don't create 'data' subdirectory on Linux

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,7 @@ These are unstable/unsupported platforms, and in all likelihood, whatever the is
 *   **For performance-related issues**, include as much profiling data as you can (resource usage graphs, etc).
 
 *   Paste the **qBittorrent log** (or put the contents of the log in a gist and provide a link to the gist). The log can be viewed in the GUI (View -> Log -> tick all boxes). If you can't do that, the file is at:
-    -   Linux: `~/.local/share/data/qBittorrent/logs/qBittorrent.log`
+    -   Linux: `~/.local/share/qBittorrent/logs/qBittorrent.log`
     -   Windows: `%LocalAppData%\qBittorrent\logs`
     -   macOS: `~/Library/Application Support/qBittorrent/qBittorrent.log`
 

--- a/src/base/profile_p.cpp
+++ b/src/base/profile_p.cpp
@@ -76,9 +76,21 @@ QString Private::DefaultProfile::dataLocation() const
 #if defined(Q_OS_WIN) || defined (Q_OS_MACOS)
     return locationWithConfigurationName(QStandardPaths::AppLocalDataLocation);
 #else
-    // on Linux gods know why qBittorrent creates 'data' subdirectory in ~/.local/share/
-    return QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
+    // On Linux keep using the legacy directory ~/.local/share/data/ if it exists
+    const QString legacyDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
         + QLatin1String("/data/") + profileName() + QLatin1Char('/');
+
+    const QString dataDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
+        + QLatin1Char('/') + profileName() + QLatin1Char('/');
+
+    if (QDir(legacyDir).exists()) {
+        qWarning("The legacy data directory '%s' is used. It is recommended to move its content to '%s'",
+            qUtf8Printable(legacyDir), qUtf8Printable(dataDir));
+
+        return legacyDir;
+    }
+
+    return dataDir;
 #endif
 }
 


### PR DESCRIPTION
Any reason to use on Linux the unusual path
```
~/.local/share/data/qBittorrent
```
instead of
```
~/.local/share/qBittorrent
```
?