### PR TITLE
WebUI: Add option to also rename containing folder when renaming torrent

### DIFF
--- a/src/base/utils/fs.cpp
+++ b/src/base/utils/fs.cpp
@@ -174,6 +174,29 @@ void Utils::Fs::removeDirRecursive(const QString &path)
 }
 
 /**
+ * Removes empty directory and its empty sub directories recursively.
+ */
+bool Utils::Fs::removeEmptyDir(const QString &dirName)
+{
+    bool result = true;
+    QDir dir(dirName);
+
+    if (dir.exists()) {
+        QDirIterator it(dirName, QDir::NoDotAndDotDot | QDir::System | QDir::Hidden | QDir::AllDirs);
+        while (it.hasNext()) {
+            const QString subDir = it.next();
+            result = removeEmptyDir(subDir);
+
+            if (!result) {
+                return result;
+            }
+        }
+        result = dir.rmdir(dirName);
+    }
+    return result;
+}
+
+/**
  * Returns the size of a file.
  * If the file is a folder, it will compute its size based on its content.
  *

--- a/src/base/utils/fs.h
+++ b/src/base/utils/fs.h
@@ -71,6 +71,7 @@ namespace Utils
         bool smartRemoveEmptyFolderTree(const QString &path);
         bool forceRemove(const QString &filePath);
         void removeDirRecursive(const QString &path);
+        bool removeEmptyDir(const QString &path);
 
         QString tempPath();
 

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -1020,7 +1020,7 @@ void TorrentsController::renameAction()
     // Remove old folder
     const QDir oldFolder(torrent->savePath(true) + '/' + oldContainingPath);
     int timeout = 10;
-    while (!QDir().rmpath(oldFolder.absolutePath()) && (timeout > 0)) {
+    while (!Utils::Fs::removeEmptyDir(oldFolder.absolutePath()) && (timeout > 0)) {
         QThread::msleep(100);
         --timeout;
     }

--- a/src/webui/www/private/rename.html
+++ b/src/webui/www/private/rename.html
@@ -35,6 +35,8 @@
             if (name)
                 $('rename').value = decodeURIComponent(name);
 
+            $('renameContainingFolder').checked = localStorage.getItem('renameContainingFolder') == 'true';
+
             $('rename').focus();
             $('renameButton').addEvent('click', function(e) {
                 new Event(e).stop();
@@ -43,6 +45,14 @@
                 if (name === null || name === "")
                     return false;
 
+                const renameContainingFolder = $('renameContainingFolder').checked;
+                try {
+                    localStorage.setItem('renameContainingFolder', renameContainingFolder);
+                }
+                catch (err) {
+                    console.error(err);
+                }
+
                 const hash = new URI().getData('hash');
                 if (hash) {
                     new Request({
@@ -50,7 +60,8 @@
                         method: 'post',
                         data: {
                             hash: hash,
-                            name: name
+                            name: name,
+                            renameContainingFolder: renameContainingFolder
                         },
                         onComplete: function() {
                             window.parent.closeWindows();
@@ -66,6 +77,10 @@
     <div style="padding: 10px 10px 0px 10px;">
         <p style="font-weight: bold;">QBT_TR(New name)QBT_TR[CONTEXT=TransferListWidget]:</p>
         <input type="text" id="rename" value="" maxlength="255" style="width: 220px;" />
+        <br />
+        <br />
+        <input type="checkbox" id="renameContainingFolder" />
+        <label for="renameContainingFolder">QBT_TR(Also rename containing folder)QBT_TR[CONTEXT=TransferListWidget]</label>
         <div style="text-align: center; padding-top: 10px;">
             <input type="button" value="QBT_TR(Save)QBT_TR[CONTEXT=HttpServer]" id="renameButton" />
         </div>

--- a/src/webui/www/private/rename.html
+++ b/src/webui/www/private/rename.html
@@ -65,7 +65,7 @@
 <body>
     <div style="padding: 10px 10px 0px 10px;">
         <p style="font-weight: bold;">QBT_TR(New name)QBT_TR[CONTEXT=TransferListWidget]:</p>
-        <input type="text" id="rename" value="" maxlength="100" style="width: 220px;" />
+        <input type="text" id="rename" value="" maxlength="255" style="width: 220px;" />
         <div style="text-align: center; padding-top: 10px;">
             <input type="button" value="QBT_TR(Save)QBT_TR[CONTEXT=HttpServer]" id="renameButton" />
         </div>

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -513,7 +513,7 @@ const initializeWindows = function() {
                     paddingVertical: 0,
                     paddingHorizontal: 0,
                     width: 250,
-                    height: 100
+                    height: 140
                 });
             }
         }


### PR DESCRIPTION
In native GUI, users can rename the containing folder of a torrent in the torrent content tree view, but unfortunately this feature doesn't exist in WebUI.

Since the torrent name is identical (or I was wrong?) to containing folder's name, I would like to suggest a simple approach to implement this feature:

Add an option "Also rename containing folder" to the the torrent rename window. If this options is checked when renaming a torrent, the containing folder of the torrent will also be renamed to match the new torrent name.

Actually this approach can also used in native GUI, to improve the UI consistent.

Note: Users can also use slash in torrent name to organize the files of different torrent to same parent containing folder.

For example, if I have 2 torrents `Anime1` and `Anime2`, and I rename them to `OVA/Anime1` and `OVA/Anime2` with the option "Also rename containing folder" checked, then both `Anime1` and `Anime2` folder will be moved in to an automatically created `OVA` folder.
