### PR TITLE
Detect dark mode when custom theme is used

### DIFF
--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -33,6 +33,8 @@
 #include <QAbstractListModel>
 #include <QList>
 
+class QWidget;
+
 namespace BitTorrent
 {
     class InfoHash;
@@ -102,6 +104,7 @@ private slots:
 private:
     QList<BitTorrent::TorrentHandle *> m_torrentList;  // maps row number to torrent handle
     QHash<BitTorrent::TorrentHandle *, int> m_torrentMap;  // maps torrent handle to row number
+    const QWidget *const m_view;
 };
 
 #endif // TRANSFERLISTMODEL_H


### PR DESCRIPTION
I noticed in #6434 that users complained about text colors when using a dark theme and I realized that the hardcoded colors for darkthemes weren't used.
I turns out that when setting a StyleSheet the QPallette of:
* `QApplication::palette()`
* `QApplication::palette(m_transferListWidget)`
* `QApplication::palette("TransferListWidget")`
* `QApplication::palette("QTreeView")`

stays to the default theme. This is barely mentioned in the docs.
However `QWidget::palette()` returns a correct palette.

Unfortunately, I didn't have another idea on how to pass down the view to the model. It feels like a hack.

PS: I don't know if this new code will affect tranfserlist drawing speed with many torrents in the queue.
PS2: I know that there is another PR pending for text colors, but this should be used as a quick fix until the final solution is done.