### PR TITLE
Fix "Free space on disk:" label not updated on Category change in Auto mode

### DIFF
--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -421,6 +421,7 @@ void AddNewTorrentDialog::categoryChanged(int index)
     if (m_ui->comboTTM->currentIndex() == 1) {
         QString savePath = BitTorrent::Session::instance()->categorySavePath(m_ui->categoryComboBox->currentText());
         m_ui->savePath->setSelectedPath(Utils::Fs::toNativePath(savePath));
+        updateDiskSpaceLabel();
     }
 }
 
@@ -682,6 +683,7 @@ void AddNewTorrentDialog::TMMChanged(int index)
         m_ui->savePath->clear();
         QString savePath = BitTorrent::Session::instance()->categorySavePath(m_ui->categoryComboBox->currentText());
         m_ui->savePath->addItem(savePath);
+        updateDiskSpaceLabel();
     }
 }
 


### PR DESCRIPTION
Closes #8772.
This will fix issue that "Free space on disk:" label in 
Add New Torrent dialog not updated on Category change
when Torrent Management Mode is on Auto mode.