### PR TITLE
WebUI: Implement "Secure" flag for session cookie. Closes #11724

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -653,6 +653,16 @@ void Preferences::setWebUiCSRFProtectionEnabled(const bool enabled)
     setValue("Preferences/WebUI/CSRFProtection", enabled);
 }
 
+bool Preferences::isWebUiSecureCookieEnabled() const
+{
+    return value("Preferences/WebUI/SecureCookie", true).toBool();
+}
+
+void Preferences::setWebUiSecureCookieEnabled(const bool enabled)
+{
+    setValue("Preferences/WebUI/SecureCookie", enabled);
+}
+
 bool Preferences::isWebUIHostHeaderValidationEnabled() const
 {
     return value("Preferences/WebUI/HostHeaderValidation", true).toBool();

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -202,6 +202,8 @@ public:
     void setWebUiClickjackingProtectionEnabled(bool enabled);
     bool isWebUiCSRFProtectionEnabled() const;
     void setWebUiCSRFProtectionEnabled(bool enabled);
+    bool isWebUiSecureCookieEnabled () const;
+    void setWebUiSecureCookieEnabled(bool enabled);
     bool isWebUIHostHeaderValidationEnabled() const;
     void setWebUIHostHeaderValidationEnabled(bool enabled);
 

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -409,6 +409,8 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     connect(m_ui->spinSessionTimeout, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->checkClickjacking, &QCheckBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkCSRFProtection, &QCheckBox::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->checkWebUiHttps, &QGroupBox::toggled, m_ui->checkSecureCookie, &QWidget::setEnabled);
+    connect(m_ui->checkSecureCookie, &QCheckBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->groupHostHeaderValidation, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkDynDNS, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->comboDNSService, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
@@ -793,6 +795,7 @@ void OptionsDialog::saveOptions()
         // Security
         pref->setWebUiClickjackingProtectionEnabled(m_ui->checkClickjacking->isChecked());
         pref->setWebUiCSRFProtectionEnabled(m_ui->checkCSRFProtection->isChecked());
+        pref->setWebUiSecureCookieEnabled(m_ui->checkSecureCookie->isChecked());
         pref->setWebUIHostHeaderValidationEnabled(m_ui->groupHostHeaderValidation->isChecked());
         // DynDNS
         pref->setDynDNSEnabled(m_ui->checkDynDNS->isChecked());
@@ -1165,6 +1168,8 @@ void OptionsDialog::loadOptions()
     // Security
     m_ui->checkClickjacking->setChecked(pref->isWebUiClickjackingProtectionEnabled());
     m_ui->checkCSRFProtection->setChecked(pref->isWebUiCSRFProtectionEnabled());
+    m_ui->checkSecureCookie->setEnabled(pref->isWebUiHttpsEnabled());
+    m_ui->checkSecureCookie->setChecked(pref->isWebUiSecureCookieEnabled());
     m_ui->groupHostHeaderValidation->setChecked(pref->isWebUIHostHeaderValidationEnabled());
 
     m_ui->checkDynDNS->setChecked(pref->isDynDNSEnabled());

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -3055,6 +3055,13 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                    </widget>
                   </item>
                   <item>
+                   <widget class="QCheckBox" name="checkSecureCookie">
+                    <property name="text">
+                     <string>Enable cookie Secure flag (requires HTTPS)</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
                    <widget class="QGroupBox" name="groupHostHeaderValidation">
                     <property name="title">
                      <string>Enable Host header validation</string>

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -239,6 +239,7 @@ void AppController::preferencesAction()
     // Security
     data["web_ui_clickjacking_protection_enabled"] = pref->isWebUiClickjackingProtectionEnabled();
     data["web_ui_csrf_protection_enabled"] = pref->isWebUiCSRFProtectionEnabled();
+    data["web_ui_secure_cookie_enabled"] = pref->isWebUiSecureCookieEnabled();
     data["web_ui_host_header_validation_enabled"] = pref->isWebUIHostHeaderValidationEnabled();
     // Update my dynamic domain name
     data["dyndns_enabled"] = pref->isDynDNSEnabled();
@@ -608,6 +609,8 @@ void AppController::setPreferencesAction()
         pref->setWebUiClickjackingProtectionEnabled(it.value().toBool());
     if (hasKey("web_ui_csrf_protection_enabled"))
         pref->setWebUiCSRFProtectionEnabled(it.value().toBool());
+    if (hasKey("web_ui_secure_cookie_enabled"))
+        pref->setWebUiSecureCookieEnabled(it.value().toBool());
     if (hasKey("web_ui_host_header_validation_enabled"))
         pref->setWebUIHostHeaderValidationEnabled(it.value().toBool());
     // Update my dynamic domain name

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -337,6 +337,7 @@ void WebApplication::configure()
 
     m_isClickjackingProtectionEnabled = pref->isWebUiClickjackingProtectionEnabled();
     m_isCSRFProtectionEnabled = pref->isWebUiCSRFProtectionEnabled();
+    m_isSecureCookieEnabled = pref->isWebUiSecureCookieEnabled();
     m_isHostHeaderValidationEnabled = pref->isWebUIHostHeaderValidationEnabled();
     m_isHttpsEnabled = pref->isWebUiHttpsEnabled();
 
@@ -535,6 +536,7 @@ void WebApplication::sessionStart()
 
     QNetworkCookie cookie(C_SID, m_currentSession->id().toUtf8());
     cookie.setHttpOnly(true);
+    cookie.setSecure(m_isSecureCookieEnabled && m_isHttpsEnabled);
     cookie.setPath(QLatin1String("/"));
     QByteArray cookieRawForm = cookie.toRawForm();
     if (m_isCSRFProtectionEnabled)

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -153,6 +153,7 @@ private:
     QStringList m_domainList;
     bool m_isClickjackingProtectionEnabled;
     bool m_isCSRFProtectionEnabled;
+    bool m_isSecureCookieEnabled;
     bool m_isHostHeaderValidationEnabled;
     bool m_isHttpsEnabled;
     QString m_contentSecurityPolicy;

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -756,6 +756,10 @@
                 <input type="checkbox" id="csrf_protection_checkbox" />
                 <label for="csrf_protection_checkbox">QBT_TR(Enable Cross-Site Request Forgery (CSRF) protection)QBT_TR[CONTEXT=OptionsDialog]</label>
             </div>
+            <div class="formRow">
+                <input type="checkbox" id="secureCookieCheckbox" />
+                <label for="secureCookieCheckbox">QBT_TR(Enable cookie Secure flag (requires HTTPS))QBT_TR[CONTEXT=OptionsDialog]</label>
+            </div>
 
             <fieldset class="settings">
                 <legend>
@@ -1350,6 +1354,7 @@
             const isUseHttpsEnabled = $('use_https_checkbox').getProperty('checked');
             $('ssl_cert_text').setProperty('disabled', !isUseHttpsEnabled);
             $('ssl_key_text').setProperty('disabled', !isUseHttpsEnabled);
+            $('secureCookieCheckbox').setProperty('disabled', !isUseHttpsEnabled);
         };
 
         const updateBypasssAuthSettings = function() {
@@ -1717,6 +1722,7 @@
                         // Security
                         $('clickjacking_protection_checkbox').setProperty('checked', pref.web_ui_clickjacking_protection_enabled);
                         $('csrf_protection_checkbox').setProperty('checked', pref.web_ui_csrf_protection_enabled);
+                        $('secureCookieCheckbox').setProperty('checked', pref.web_ui_secure_cookie_enabled);
                         $('host_header_validation_checkbox').setProperty('checked', pref.web_ui_host_header_validation_enabled);
                         updateHostHeaderValidationSettings();
 
@@ -2082,6 +2088,7 @@
 
             settings.set('web_ui_clickjacking_protection_enabled', $('clickjacking_protection_checkbox').getProperty('checked'));
             settings.set('web_ui_csrf_protection_enabled', $('csrf_protection_checkbox').getProperty('checked'));
+            settings.set('web_ui_secure_cookie_enabled', $('secureCookieCheckbox').getProperty('checked'));
             settings.set('web_ui_host_header_validation_enabled', $('host_header_validation_checkbox').getProperty('checked'));
 
             // Update my dynamic domain name


### PR DESCRIPTION
Closes #11724.

Option is enabled by default for users using qBittorrent's built-in HTTPS capabilities. This flag will never be set if qBittorrent is using plain HTTP.

Users using HTTPS reverse proxies, like "qbt <-> (http) <-> proxy <-> (https) <-> user" should override the flag in the proxy in order to set it, if they wish to do so.

Testing:
- DONE Using HTTP: WebUI works unless secure cookie option is selected (which is expected, and hence the warning beside the option).
- DONE Using built-in HTTPS (with self-signed certs, real certs should not make a difference): works as expected; WebUI still works even if the secure cookie option is disabled (as previously).
- ~TODO~DONE: HTTPS with reverse proxy (like the drawing in https://github.com/qbittorrent/qBittorrent/wiki/Linux-WebUI-HTTPS-with-Let's-Encrypt-certificates-and-NGINX-SSL-reverse-proxy)

I installed `nginx` and used the following config:

```nginx
# Default server configuration
#
server {
    listen 80 default_server;
    listen [::]:80 default_server;

    # SSL configuration
    #
    listen 443 ssl default_server;
    listen [::]:443 ssl default_server;
    # Self signed certs generated by the ssl-cert package
    # Don't use them in a production server!
    #
    include snippets/snakeoil.conf;

    root /var/www/html;

    # Add index.php to the list if you are using PHP
    index index.html index.htm index.nginx-debian.html;

    server_name _;

    location / {
        # First attempt to serve request as file, then
        # as directory, then fall back to displaying a 404.
        try_files $uri $uri/ =404;
    }

    location /qbit/ {
 
        proxy_pass           http://127.0.0.1:8080/;
 
        gzip_proxied         any;
        client_max_body_size 100M; # increased POST request size limit, for allowing adding a lot of torrents at once
 
        proxy_http_version   1.1;
 
        proxy_set_header     Host                              localhost:8080;
        proxy_set_header     X-Forwarded-Proto                 $scheme;
        proxy_set_header     X-Forwarded-Host                  $server_name:$server_port;
        proxy_set_header     X-Forwarded-For                   $remote_addr;
        proxy_set_header     X-Real-IP                         $remote_addr;
 
        proxy_hide_header    Referer;
        proxy_hide_header    Origin;
        proxy_set_header     Referer                           '';
        proxy_set_header     Origin                            '';
 
        # recent versions of qbittorrent already set headers like x-content-type-options, x-frame-options, and x-xss-protection
        add_header           X-Robots-Tag                      none;
        add_header           X-Permitted-Cross-Domain-Policies none;
        add_header           X-Download-Options                noopen;
 
        add_header           Strict-Transport-Security        'max-age=31536000; includeSubDomains; preload' always;
 
        add_header           Allow                             "GET, POST, HEAD" always;
        if ( $request_method !~ ^(GET|POST|HEAD)$ ) {
            return 405;
        }
    }
}
```

This config is close to a real "production" config, except it uses self-signed certs and does not do automatic HTTP->HTTPS redirection, for testing purposes. So the WebUI can be accessed either through either `http://localhost/qbit/` or `https://localhost/qbit/` (`127.0.0.1` can also be used instead of `localhost`).

When the user logs in at `https://localhost/qbit/` and then tries to access `http://localhost/qbit/`, they are unable to do so, and land back in the login page, which proves the cookie's secure flag is working as intended.