### PR TITLE
WebUI: fix populating statistics window

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -622,7 +622,7 @@ window.addEvent('load', function() {
         $('DHTNodes').set('html', 'QBT_TR(DHT: %1 nodes)QBT_TR[CONTEXT=StatusBar]'.replace("%1", serverState.dht_nodes));
 
         // Statistics dialog
-        if (document.getElementById("statisticspage")) {
+        if (document.getElementById("statisticsContent")) {
             $('AlltimeDL').set('html', window.qBittorrent.Misc.friendlyUnit(serverState.alltime_dl, false));
             $('AlltimeUL').set('html', window.qBittorrent.Misc.friendlyUnit(serverState.alltime_ul, false));
             $('TotalWastedSession').set('html', window.qBittorrent.Misc.friendlyUnit(serverState.total_wasted_session, false));

--- a/src/webui/www/private/views/statistics.html
+++ b/src/webui/www/private/views/statistics.html
@@ -1,59 +1,59 @@
-<h3>QBT_TR(User statistics)QBT_TR[CONTEXT=StatsDialog]</h3>
-<table style="width:100%">
-    <tr>
-        <td>QBT_TR(All-time upload:)QBT_TR[CONTEXT=StatsDialog]</td>
-        <td id="AlltimeUL" class="statisticsValue"></td>
-    </tr>
-    <tr>
-        <td>QBT_TR(All-time download:)QBT_TR[CONTEXT=StatsDialog]</td>
-        <td id="AlltimeDL" class="statisticsValue"></td>
-    </tr>
-    <tr>
-        <td>QBT_TR(All-time share ratio:)QBT_TR[CONTEXT=StatsDialog]</td>
-        <td id="GlobalRatio" class="statisticsValue"></td>
-    </tr>
-    <tr>
-        <td>QBT_TR(Session waste:)QBT_TR[CONTEXT=StatsDialog]</td>
-        <td id="TotalWastedSession" class="statisticsValue"></td>
-    </tr>
-    <tr>
-        <td>QBT_TR(Connected peers:)QBT_TR[CONTEXT=StatsDialog]</td>
-        <td id="TotalPeerConnections" class="statisticsValue"></td>
-    </tr>
-</table>
-
-<h3>QBT_TR(Cache statistics)QBT_TR[CONTEXT=StatsDialog]</h3>
-<table style="width:100%">
-    <tr>
-        <td>QBT_TR(Read cache hits:)QBT_TR[CONTEXT=StatsDialog]</td>
-        <td id="ReadCacheHits" class="statisticsValue"></td>
-    </tr>
-    <tr>
-        <td>QBT_TR(Total buffer size:)QBT_TR[CONTEXT=StatsDialog]</td>
-        <td id="TotalBuffersSize" class="statisticsValue"></td>
-    </tr>
-</table>
-
-<h3>QBT_TR(Performance statistics)QBT_TR[CONTEXT=StatsDialog]</h3>
-<table style="width:100%">
-    <tr>
-        <td>QBT_TR(Write cache overload:)QBT_TR[CONTEXT=StatsDialog]</td>
-        <td id="WriteCacheOverload" class="statisticsValue"></td>
-    </tr>
-    <tr>
-        <td>QBT_TR(Read cache overload:)QBT_TR[CONTEXT=StatsDialog]</td>
-        <td id="ReadCacheOverload" class="statisticsValue"></td>
-    </tr>
-    <tr>
-        <td>QBT_TR(Queued I/O jobs:)QBT_TR[CONTEXT=StatsDialog]</td>
-        <td id="QueuedIOJobs" class="statisticsValue"></td>
-    </tr>
-    <tr>
-        <td>QBT_TR(Average time in queue:)QBT_TR[CONTEXT=StatsDialog]</td>
-        <td id="AverageTimeInQueue" class="statisticsValue"></td>
-    </tr>
-    <tr>
-        <td>QBT_TR(Total queued size:)QBT_TR[CONTEXT=StatsDialog]</td>
-        <td id="TotalQueuedSize" class="statisticsValue"></td>
-    </tr>
-</table>
+<div id="statisticsContent">
+    <h3>QBT_TR(User statistics)QBT_TR[CONTEXT=StatsDialog]</h3>
+    <table style="width:100%">
+        <tr>
+            <td>QBT_TR(All-time upload:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td id="AlltimeUL" class="statisticsValue"></td>
+        </tr>
+        <tr>
+            <td>QBT_TR(All-time download:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td id="AlltimeDL" class="statisticsValue"></td>
+        </tr>
+        <tr>
+            <td>QBT_TR(All-time share ratio:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td id="GlobalRatio" class="statisticsValue"></td>
+        </tr>
+        <tr>
+            <td>QBT_TR(Session waste:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td id="TotalWastedSession" class="statisticsValue"></td>
+        </tr>
+        <tr>
+            <td>QBT_TR(Connected peers:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td id="TotalPeerConnections" class="statisticsValue"></td>
+        </tr>
+    </table>
+    <h3>QBT_TR(Cache statistics)QBT_TR[CONTEXT=StatsDialog]</h3>
+    <table style="width:100%">
+        <tr>
+            <td>QBT_TR(Read cache hits:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td id="ReadCacheHits" class="statisticsValue"></td>
+        </tr>
+        <tr>
+            <td>QBT_TR(Total buffer size:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td id="TotalBuffersSize" class="statisticsValue"></td>
+        </tr>
+    </table>
+    <h3>QBT_TR(Performance statistics)QBT_TR[CONTEXT=StatsDialog]</h3>
+    <table style="width:100%">
+        <tr>
+            <td>QBT_TR(Write cache overload:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td id="WriteCacheOverload" class="statisticsValue"></td>
+        </tr>
+        <tr>
+            <td>QBT_TR(Read cache overload:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td id="ReadCacheOverload" class="statisticsValue"></td>
+        </tr>
+        <tr>
+            <td>QBT_TR(Queued I/O jobs:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td id="QueuedIOJobs" class="statisticsValue"></td>
+        </tr>
+        <tr>
+            <td>QBT_TR(Average time in queue:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td id="AverageTimeInQueue" class="statisticsValue"></td>
+        </tr>
+        <tr>
+            <td>QBT_TR(Total queued size:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td id="TotalQueuedSize" class="statisticsValue"></td>
+        </tr>
+    </table>
+</div>


### PR DESCRIPTION
Closes #11665

Problem fixed is unique to the statistics window (other windows, like `about.html ` were not affected).