### PR TITLE
Fix stop tracker timeout issue on high latency connections.

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1078,7 +1078,7 @@ void Session::initializeNativeSession()
     pack.set_str(lt::settings_pack::user_agent, USER_AGENT);
     pack.set_bool(lt::settings_pack::use_dht_as_fallback, false);
     // Speed up exit
-    pack.set_int(lt::settings_pack::stop_tracker_timeout, 1);
+    pack.set_int(lt::settings_pack::stop_tracker_timeout, 5);
     pack.set_int(lt::settings_pack::auto_scrape_interval, 1200); // 20 minutes
     pack.set_int(lt::settings_pack::auto_scrape_min_interval, 900); // 15 minutes
     pack.set_int(lt::settings_pack::connection_speed, 20); // default is 10


### PR DESCRIPTION
By default libtorrent uses a 5 second timeout for stop event.
But qBit is using a 1 second timeout for stop event (when you pause a torrent or close the client).
It's a very low default for a high latency connection. I was getting tracker timeout issue everytime I paused a torrent on a particular tracker with a 350 ms latency. Never had issues with annoucing to that tracker. Only stop events caused the timeout. Turns out the default announce timeout is much higher (10 seconds) in libtorrent and qBit doesn't alter that. It only alters the stop_tracker timeout values. So setting it to the default 5 second is a reasonable value and should prevent tracker timeouts on high latency connections.