### PR TITLE
[CI/Win] Add artifacts

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -56,8 +56,12 @@ build_script:
   - qmake qbittorrent.pro && cd src && qmake src.pro
   - jom -j2 -f Makefile.Release
   
+after_build:
+  - cd %REPO_DIR%
+  - 7z a -mm=Deflate -mfb=258 -mpass=15 -r qbt_cibuild.zip ".\src\release\qbittorrent.exe" ".\src\release\qbittorrent.pde"
+  
 artifacts:
-  - path: release # pack the entire release directory
-    name: qbtexe
-
+  - path: qbt_cibuild.zip
+    name: qbt_cibuild
+  
 test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -55,5 +55,9 @@ build_script:
   - lupdate -extensions c,cpp,h,hpp,ui .
   - qmake qbittorrent.pro && cd src && qmake src.pro
   - jom -j2 -f Makefile.Release
+  
+artifacts:
+  - path: release # pack the entire release directory
+    name: qbtexe
 
 test: off


### PR DESCRIPTION
### details
The [AppVeyor artifact](https://www.appveyor.com/docs/packaging-artifacts/) feature allows the content of the the `release` directory (and the containing `qbittorrent.exe` file) that is built during the compilation process to be collected and published on the AppVeyor builds page.

This will allow PR maintainers to download a copy of the built binary and test it on their system before merging the PR.