### PR TITLE
Use license key for downloading GeoIP db

### DIFF
--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -76,6 +76,7 @@ HEADERS += \
     $$PWD/utils/password.h \
     $$PWD/utils/random.h \
     $$PWD/utils/string.h \
+    $$PWD/utils/tar.h \
     $$PWD/utils/version.h
 
 SOURCES += \
@@ -143,4 +144,5 @@ SOURCES += \
     $$PWD/utils/net.cpp \
     $$PWD/utils/password.cpp \
     $$PWD/utils/random.cpp \
-    $$PWD/utils/string.cpp
+    $$PWD/utils/string.cpp \
+    $$PWD/utils/tar.cpp

--- a/src/base/net/geoipmanager.h
+++ b/src/base/net/geoipmanager.h
@@ -69,6 +69,7 @@ namespace Net
 
         bool m_enabled;
         GeoIPDatabase *m_geoIPDatabase;
+        QString m_dbCompleteUrl;
 
         static GeoIPManager *m_instance;
     };

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -896,6 +896,16 @@ void Preferences::resolvePeerCountries(const bool resolve)
     setValue("Preferences/Connection/ResolvePeerCountries", resolve);
 }
 
+QString Preferences::geoIPLicenseKey() const
+{
+    return value("GeoIP/LicenseKey").toString();
+}
+
+void Preferences::setGeoIPLicenseKey(const QString &key)
+{
+    setValue("GeoIP/LicenseKey", key);
+}
+
 bool Preferences::resolvePeerHostNames() const
 {
     return value("Preferences/Connection/ResolvePeerHostNames", false).toBool();

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -258,6 +258,8 @@ public:
     void recheckTorrentsOnCompletion(bool recheck);
     bool resolvePeerCountries() const;
     void resolvePeerCountries(bool resolve);
+    QString geoIPLicenseKey() const;
+    void setGeoIPLicenseKey(const QString &key);
     bool resolvePeerHostNames() const;
     void resolvePeerHostNames(bool resolve);
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))

--- a/src/base/utils/tar.cpp
+++ b/src/base/utils/tar.cpp
@@ -1,0 +1,244 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2020  sledgehammer999 <hammered999@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "tar.h"
+
+#include <QCoreApplication>
+#include <QHash>
+
+#include "base/utils/bytearray.h"
+#include "base/utils/fs.h"
+
+namespace
+{
+    const int TAR_HEADER_SIZE = 512;
+
+    const int TAR_FILENAME_OFFSET = 0;
+    const int TAR_FILESIZE_OFFSET = 124;
+    const int TAR_CHECKSUM_OFFSET = 148;
+    const int TAR_FILETYPE_OFFSET = 156;
+    const int TAR_FILENAME_PREFIX_OFFSET = 345;
+
+    const int TAR_FILENAME_SIZE = 100;
+    const int TAR_FILESIZE_SIZE = 12;
+    const int TAR_CHECKSUM_SIZE = 8;
+    const int TAR_FILENAME_PREFIX_SIZE = 155;
+
+    enum class State
+    {
+        Empty,
+        Invalid,
+        Valid
+    };
+
+    int octalToDec(const QByteArray &data)
+    {
+        // only the ASCII characters from '0' to '7' are valid
+        int number = 0;
+        for (const char byte : data) {
+            if (byte < '0' || byte > '7') // skip trailing invalid bytes
+                break;
+
+            number = (8 * number) + (byte - '0');
+        }
+
+        return number;
+    }
+
+    State verifyAndCheckNull(const QByteArray &data)
+    {
+        int calculatedChecksum = 0;
+        for (int i = 0; i < TAR_CHECKSUM_OFFSET; ++i)
+            calculatedChecksum += static_cast<uchar>(data.at(i));
+
+        calculatedChecksum += TAR_CHECKSUM_SIZE * ' '; // 8 ASCII spaces for the checksum field
+
+        for (int i = TAR_FILETYPE_OFFSET; i < data.size(); ++i)
+            calculatedChecksum += static_cast<uchar>(data.at(i));
+
+        const int checkSum = octalToDec(Utils::ByteArray::midView(data, TAR_CHECKSUM_OFFSET, TAR_CHECKSUM_SIZE));
+        if ((calculatedChecksum == TAR_CHECKSUM_SIZE * ' ') && (checkSum == 0))
+            return State::Empty;
+        else if (calculatedChecksum == checkSum)
+            return State::Valid;
+
+        return State::Invalid;
+    }
+
+    State parseHeader(const QByteArray &header, QString &fileName, int &fileSize, Utils::Tar::EntryType &entryType)
+    {
+        if (header.size() != TAR_HEADER_SIZE)
+            return State::Invalid;
+
+        State state = verifyAndCheckNull(header);
+
+        // Invalid header: The first header field represents the filename.
+        // If the 1st byte is null then we can't extract a name. So the whole header becomes invalid to us.
+        if ((state == State::Valid) && header.startsWith('\0'))
+            return State::Invalid;
+        else if (state != State::Valid)
+            return state;
+
+        fileSize = octalToDec(Utils::ByteArray::midView(header, TAR_FILESIZE_OFFSET, TAR_FILESIZE_SIZE));
+        entryType = static_cast<Utils::Tar::EntryType>(header.at(TAR_FILETYPE_OFFSET));
+
+        const QByteArray name = Utils::ByteArray::midView(header, TAR_FILENAME_OFFSET, TAR_FILENAME_SIZE);
+        const int nameLen = strlen(name);
+        if (nameLen == 0)
+            return State::Invalid;
+
+        const QByteArray namePrefix = Utils::ByteArray::midView(header, TAR_FILENAME_PREFIX_OFFSET, TAR_FILENAME_PREFIX_SIZE);
+        const int namePrefixLen = strlen(namePrefix);
+
+        const QString fullName = (namePrefixLen > 0)
+                                  ? QString::fromUtf8(namePrefix.constData(), namePrefixLen)
+                                    + '/' + QString::fromUtf8(name.constData(), nameLen)
+                                  : QString::fromUtf8(name.constData(), nameLen);
+
+        fileName = Utils::Fs::toValidFileSystemName(fullName, true);
+
+        return State::Valid;
+    }
+}
+
+QHash<QString, QByteArray> Utils::Tar::untar(const QByteArray &data, QString &errorString)
+{
+    QHash<QString, QByteArray> files;
+    StreamReader reader(data);
+    while (reader.readNext()) {
+        if (!(reader.entryType() == EntryType::FileAscii
+              || reader.entryType() == EntryType::FileNull)) {
+            continue;
+        }
+
+        files.insert(reader.fileName(), reader.fileData());
+    }
+
+    errorString = reader.errorString();
+    return files;
+}
+
+Utils::Tar::StreamReader::StreamReader(const QByteArray &data)
+    : m_data(data)
+{
+    if (m_data.size() < TAR_HEADER_SIZE) {
+        m_errorString = QCoreApplication::translate(
+                            "Utils::Tar",
+                            "The tar file is only %1 bytes long.",
+                            "'tar' should be left untranslated. It is a filetype.")
+                        .arg(m_data.size());
+    }
+}
+
+bool Utils::Tar::StreamReader::readNext()
+{
+    if (atEnd() || hasError())
+        return false;
+
+    int dataSize = m_data.size();
+    if (dataSize - m_pos < TAR_HEADER_SIZE) {
+        m_errorString = QCoreApplication::translate(
+                            "Utils::Tar",
+                            "The tar file has ended prematurely",
+                            "'tar' should be left untranslated. It is a filetype.");
+        return false;
+    }
+
+    State state = parseHeader(Utils::ByteArray::midView(m_data, m_pos, TAR_HEADER_SIZE), m_fileName, m_fileSize, m_EntryType);
+
+    if (state == State::Empty) {
+        m_pos = dataSize;
+        return false;
+    }
+
+    if (state == State::Invalid) {
+        m_errorString = QCoreApplication::translate(
+                            "Utils::Tar",
+                            "The tar file has an invalid header at position %1",
+                            "'tar' should be left untranslated. It is a filetype.")
+                        .arg(m_pos);
+        return false;
+    }
+
+    const int fileSize = m_fileSize;
+    const int availableSize = m_data.size() - m_pos - TAR_HEADER_SIZE;
+    if (availableSize < fileSize) {
+        m_errorString = QCoreApplication::translate(
+                            "Utils::Tar",
+                            "The tar file has ended prematurely",
+                            "'tar' should be left untranslated. It is a filetype.");
+        return false;
+    }
+
+    m_fileDataStart = m_pos + TAR_HEADER_SIZE;
+    const int padding = (m_fileSize > 0) ? (TAR_HEADER_SIZE - (m_fileSize % TAR_HEADER_SIZE))
+                                       : 0;
+
+
+    m_pos += TAR_HEADER_SIZE + m_fileSize + padding;
+    return true;
+}
+
+QString Utils::Tar::StreamReader::fileName() const
+{
+    if (atEnd() || hasError())
+        return {};
+
+    return m_fileName;
+}
+
+QByteArray Utils::Tar::StreamReader::fileData() const
+{
+    if (atEnd() || hasError())
+        return {};
+
+    return {m_data.constData() + m_fileDataStart, m_fileSize};
+}
+
+Utils::Tar::EntryType Utils::Tar::StreamReader::entryType() const
+{
+    if (atEnd() || hasError())
+        return EntryType::Unknown;
+
+    return m_EntryType;
+}
+
+bool Utils::Tar::StreamReader::atEnd() const
+{
+    return (m_pos >= m_data.size());
+}
+
+bool Utils::Tar::StreamReader::hasError() const
+{
+    return !errorString().isEmpty();
+}
+
+QString Utils::Tar::StreamReader::errorString() const
+{
+    return m_errorString;
+}

--- a/src/base/utils/tar.h
+++ b/src/base/utils/tar.h
@@ -1,0 +1,74 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2020  sledgehammer999 <hammered999@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+#include <QByteArray>
+#include <QString>
+
+namespace Utils
+{
+    namespace Tar
+    {
+        QHash<QString, QByteArray> untar(const QByteArray &data, QString &errorString);
+
+        enum class EntryType : unsigned char
+        {
+            FileNull = '\0',
+            FileAscii = '0',
+            // We don't care about the other file types
+
+            Unknown = std::numeric_limits<unsigned char>::max()
+        };
+
+        class StreamReader
+        {
+        public:
+            explicit StreamReader(const QByteArray &data);
+            explicit StreamReader(const QByteArray &&data) = delete;
+
+            bool readNext();
+            QString fileName() const;
+            QByteArray fileData() const;
+            EntryType entryType() const;
+
+            bool atEnd() const;
+            bool hasError() const;
+            QString errorString() const;
+
+        private:
+            const QByteArray m_data;
+            QString m_errorString;
+            QString m_fileName;
+            EntryType m_EntryType = EntryType::Unknown;
+            int m_fileSize = 0;
+            int m_pos = 0;
+            int m_fileDataStart = 0;
+        };
+    }
+}

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -76,6 +76,7 @@ enum AdvSettingsRows
     LIST_REFRESH,
     RESOLVE_HOSTS,
     RESOLVE_COUNTRIES,
+    GEOIP_LICENSE_KEY,
     PROGRAM_NOTIFICATIONS,
     TORRENT_ADDED_NOTIFICATIONS,
     CONFIRM_REMOVE_ALL_TAGS,
@@ -211,6 +212,7 @@ void AdvancedSettings::saveAdvancedSettings()
     session->setRefreshInterval(m_spinBoxListRefresh.value());
     // Peer resolution
     pref->resolvePeerCountries(m_checkBoxResolveCountries.isChecked());
+    pref->setGeoIPLicenseKey(m_lineEditGeoIPLicense.text().trimmed());
     pref->resolvePeerHostNames(m_checkBoxResolveHosts.isChecked());
     // Super seeding
     session->setSuperSeedingEnabled(m_checkBoxSuperSeeding.isChecked());
@@ -492,6 +494,10 @@ void AdvancedSettings::loadAdvancedSettings()
     // Resolve Peer countries
     m_checkBoxResolveCountries.setChecked(pref->resolvePeerCountries());
     addRow(RESOLVE_COUNTRIES, tr("Resolve peer countries (GeoIP)"), &m_checkBoxResolveCountries);
+    // Resolve Peer countries
+    m_lineEditGeoIPLicense.setText(pref->geoIPLicenseKey());
+    addRow(GEOIP_LICENSE_KEY, (tr("GeoIP license key") + ' ' + makeLink("https://github.com/qbittorrent/qBittorrent/wiki/How-to-use-MaxMind's-GeoIP-database", "(?)"))
+           , &m_lineEditGeoIPLicense);
     // Resolve peer hosts
     m_checkBoxResolveHosts.setChecked(pref->resolvePeerHostNames());
     addRow(RESOLVE_HOSTS, tr("Resolve peer host names"), &m_checkBoxResolveHosts);

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -66,7 +66,7 @@ private:
               m_checkBoxConfirmTorrentRecheck, m_checkBoxConfirmRemoveAllTags, m_checkBoxAnnounceAllTrackers, m_checkBoxAnnounceAllTiers,
               m_checkBoxMultiConnectionsPerIp, m_checkBoxSuggestMode, m_checkBoxCoalesceRW, m_checkBoxSpeedWidgetEnabled;
     QComboBox m_comboBoxInterface, m_comboBoxInterfaceAddress, m_comboBoxUtpMixedMode, m_comboBoxChokingAlgorithm, m_comboBoxSeedChokingAlgorithm;
-    QLineEdit m_lineEditAnnounceIP;
+    QLineEdit m_lineEditAnnounceIP, m_lineEditGeoIPLicense;
 
     // OS dependent settings
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))


### PR DESCRIPTION
This is a quick implementation of my suggestion in #11792

The new link serves a `.tar.gz` file instead of a `.gz` file. This archive contains 1 directory with 3 files. The db, a license text file and a copyright text file. I opted to extract and dump all of them in the `GeoIP` folder (stripping their root folder). Just in case the user goes snooping around, he will find the additional files.

It seems that the tar file format is something very simple, so I opted to implement a very-tailored to our needs parsing code instead of importing the myriad of other libraries out there. Those other libs offer a lot more than we need.
The file format is explained very well [here](https://en.wikipedia.org/wiki/Tar_(computing)#File_format). Basically it is a flat file in the form of `header+filedata+header+filedata+...`

With this change a db is loaded either by using a user provided license key or by parsing a user provided file (eg user kept a copy from their previous installation or some 3rd party has decided to distribute a copy of the db).

**Why don't we provide a copy of the db?** Well, if the contents of the db really fall under the GDPR/CCPA then I don't want to handle conforming to those 2 laws. Let each user have the legal responsibility.

PS: I wonder if MaxMind will notice the sudden influx of new user registrations if this PR goes through