### PR TITLE
WebUI: Fix first row renaming in files tab

### DIFF
--- a/src/webui/www/private/scripts/prop-files.js
+++ b/src/webui/www/private/scripts/prop-files.js
@@ -524,7 +524,7 @@ window.qBittorrent.PropFiles = (function() {
                 const hash = torrentsTable.getCurrentTorrentHash();
                 if (!hash) return;
                 const rowId = torrentFilesTable.selectedRowsIds()[0];
-                if (!rowId) return;
+                if (rowId === undefined) return;
                 const row = torrentFilesTable.rows[rowId];
                 if (!row) return;
                 const node = torrentFilesTable.getNode(rowId);


### PR DESCRIPTION
Ids started from zero and first row converts to false.
Closes #11826.