### PR TITLE
CMake: Remove additional debugging compiler flags

### DIFF
--- a/cmake/Modules/MacroQbtCompilerSettings.cmake
+++ b/cmake/Modules/MacroQbtCompilerSettings.cmake
@@ -72,21 +72,6 @@ macro(qbt_set_compiler_options)
 
         string(APPEND CMAKE_C_FLAGS " ${_GCC_COMMON_C_AND_CXX_FLAGS_STRING}")
         string(APPEND CMAKE_CXX_FLAGS " ${_GCC_COMMON_C_AND_CXX_FLAGS_STRING} ${_GCC_COMMON_CXX_FLAGS_STRING}")
-
-        # check whether we can enable -Og optimization for debug build
-        check_cxx_compiler_flag(-Og _DEBUG_OPTIMIZATION_LEVEL_IS_SUPPORTED)
-
-        if (_DEBUG_OPTIMIZATION_LEVEL_IS_SUPPORTED)
-            set(QBT_ADDITONAL_FLAGS "-Og -g3 -pipe" CACHE STRING
-                "Additional qBittorent compile flags")
-            set(QBT_ADDITONAL_CXX_FLAGS "-Og -g3 -pipe" CACHE STRING
-                "Additional qBittorent C++ compile flags")
-        else(_DEBUG_OPTIMIZATION_LEVEL_IS_SUPPORTED)
-            set(QBT_ADDITONAL_FLAGS "-O0 -g3 -pipe" CACHE STRING
-                "Additional qBittorent compile flags")
-            set(QBT_ADDITONAL_CXX_FLAGS "-O0 -g3 -pipe" CACHE STRING
-                "Additional qBittorent C++ compile flags")
-        endif (_DEBUG_OPTIMIZATION_LEVEL_IS_SUPPORTED)
     endif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
@@ -98,4 +83,3 @@ macro(qbt_set_compiler_options)
 
 # endif (NOT QBT_ADDITONAL_FLAGS)
 endmacro(qbt_set_compiler_options)
-


### PR DESCRIPTION
Our previous setup lead to two unintended consequences:

* Debug flags were included in both release and debug builds instead
of just debug builds
* Clang doesn't support -gX (where X is the level of debugging
optimization), but we checked for -Og support instead

This commit avoids both of these scenarios by removing the additional
flags altogether. Partial resolution to #11856.