### PR TITLE
Translation improvement for the source “General”

### DIFF
--- a/src/lang/qbittorrent_zh.ts
+++ b/src/lang/qbittorrent_zh.ts
@@ -6445,7 +6445,7 @@ Those plugins were disabled.</source>
     <message>
         <location filename="../gui/properties/proptabbar.cpp" line="51"/>
         <source>General</source>
-        <translation>普通</translation>
+        <translation>通用</translation>
     </message>
     <message>
         <location filename="../gui/properties/proptabbar.cpp" line="60"/>


### PR DESCRIPTION
For the Chinese translation of "General", change it to "通用" from “普通”.