### PR TITLE
Simplify torrent startup handling 

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -12,6 +12,8 @@ bittorrent/peerinfo.h
 bittorrent/private/bandwidthscheduler.h
 bittorrent/private/filterparserthread.h
 bittorrent/private/ltunderlyingtype.h
+bittorrent/private/nativesessionextension.h
+bittorrent/private/nativetorrentextension.h
 bittorrent/private/portforwarderimpl.h
 bittorrent/private/resumedatasavingmanager.h
 bittorrent/private/speedmonitor.h
@@ -88,6 +90,8 @@ bittorrent/peeraddress.cpp
 bittorrent/peerinfo.cpp
 bittorrent/private/bandwidthscheduler.cpp
 bittorrent/private/filterparserthread.cpp
+bittorrent/private/nativesessionextension.cpp
+bittorrent/private/nativetorrentextension.cpp
 bittorrent/private/portforwarderimpl.cpp
 bittorrent/private/resumedatasavingmanager.cpp
 bittorrent/private/speedmonitor.cpp

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -11,6 +11,8 @@ HEADERS += \
     $$PWD/bittorrent/private/bandwidthscheduler.h \
     $$PWD/bittorrent/private/filterparserthread.h \
     $$PWD/bittorrent/private/ltunderlyingtype.h \
+    $$PWD/bittorrent/private/nativesessionextension.h \
+    $$PWD/bittorrent/private/nativetorrentextension.h \
     $$PWD/bittorrent/private/portforwarderimpl.h \
     $$PWD/bittorrent/private/resumedatasavingmanager.h \
     $$PWD/bittorrent/private/speedmonitor.h \
@@ -87,6 +89,8 @@ SOURCES += \
     $$PWD/bittorrent/peerinfo.cpp \
     $$PWD/bittorrent/private/bandwidthscheduler.cpp \
     $$PWD/bittorrent/private/filterparserthread.cpp \
+    $$PWD/bittorrent/private/nativesessionextension.cpp \
+    $$PWD/bittorrent/private/nativetorrentextension.cpp \
     $$PWD/bittorrent/private/portforwarderimpl.cpp \
     $$PWD/bittorrent/private/resumedatasavingmanager.cpp \
     $$PWD/bittorrent/private/speedmonitor.cpp \

--- a/src/base/bittorrent/private/nativesessionextension.cpp
+++ b/src/base/bittorrent/private/nativesessionextension.cpp
@@ -1,0 +1,74 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2020  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "nativesessionextension.h"
+
+#include <libtorrent/alert_types.hpp>
+
+#include "nativetorrentextension.h"
+
+namespace
+{
+    void handleFastresumeRejectedAlert(const lt::fastresume_rejected_alert *alert)
+    {
+        if (alert->error.value() == lt::errors::mismatching_file_size) {
+#if (LIBTORRENT_VERSION_NUM < 10200)
+            alert->handle.auto_managed(false);
+#else
+            alert->handle.unset_flags(lt::torrent_flags::auto_managed);
+#endif
+            alert->handle.pause();
+        }
+    }
+}
+
+#if (LIBTORRENT_VERSION_NUM >= 10200)
+lt::feature_flags_t NativeSessionExtension::implemented_features()
+{
+    return alert_feature;
+}
+
+std::shared_ptr<lt::torrent_plugin> NativeSessionExtension::new_torrent(const lt::torrent_handle &torrentHandle, void *)
+{
+    return std::make_shared<NativeTorrentExtension>(torrentHandle);
+}
+#else
+boost::shared_ptr<lt::torrent_plugin> NativeSessionExtension::new_torrent(const lt::torrent_handle &torrentHandle, void *)
+{
+    return boost::shared_ptr<lt::torrent_plugin> {new NativeTorrentExtension {torrentHandle}};
+}
+#endif
+
+void NativeSessionExtension::on_alert(const lt::alert *alert)
+{
+    switch (alert->type()) {
+    case lt::fastresume_rejected_alert::alert_type:
+        handleFastresumeRejectedAlert(static_cast<const lt::fastresume_rejected_alert *>(alert));
+        break;
+    }
+}

--- a/src/base/bittorrent/private/nativesessionextension.h
+++ b/src/base/bittorrent/private/nativesessionextension.h
@@ -1,0 +1,43 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2020  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+#include <libtorrent/extensions.hpp>
+#include <libtorrent/version.hpp>
+
+class NativeSessionExtension : public lt::plugin
+{
+#if (LIBTORRENT_VERSION_NUM >= 10200)
+    lt::feature_flags_t implemented_features() override;
+    std::shared_ptr<lt::torrent_plugin> new_torrent(const lt::torrent_handle &torrentHandle, void *userData) override;
+#else
+    boost::shared_ptr<lt::torrent_plugin> new_torrent(const lt::torrent_handle &torrentHandle, void *userData) override;
+#endif
+    void on_alert(const lt::alert *alert) override;
+};

--- a/src/base/bittorrent/private/nativetorrentextension.cpp
+++ b/src/base/bittorrent/private/nativetorrentextension.cpp
@@ -1,0 +1,94 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2020  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "nativetorrentextension.h"
+
+#include <libtorrent/torrent_status.hpp>
+
+namespace
+{
+    bool isPaused(const lt::torrent_status &torrentStatus)
+    {
+#if (LIBTORRENT_VERSION_NUM < 10200)
+        return (torrentStatus.paused && !torrentStatus.auto_managed);
+#else
+        return ((torrentStatus.flags & lt::torrent_flags::paused)
+                && !(torrentStatus.flags & lt::torrent_flags::auto_managed));
+#endif
+    }
+
+    bool isAutoManaged(const lt::torrent_status &torrentStatus)
+    {
+#if (LIBTORRENT_VERSION_NUM < 10200)
+        return torrentStatus.auto_managed;
+#else
+        return bool {torrentStatus.flags & lt::torrent_flags::auto_managed};
+#endif
+    }
+}
+
+NativeTorrentExtension::NativeTorrentExtension(const lt::torrent_handle &torrentHandle)
+    : m_torrentHandle {torrentHandle}
+{
+}
+
+// This method is called when state of torrent is changed
+#if (LIBTORRENT_VERSION_NUM < 10200)
+void NativeTorrentExtension::on_state(const int state)
+#else
+void NativeTorrentExtension::on_state(const lt::torrent_status::state_t state)
+#endif
+{
+    // When a torrent enters "checking files" state while paused, we temporarily resume it
+    // (really we just allow libtorrent to resume it by enabling auto management for it).
+    if (state == lt::torrent_status::checking_files) {
+        if (isPaused(m_torrentHandle.status({}))) {
+#if (LIBTORRENT_VERSION_NUM < 10200)
+            m_torrentHandle.stop_when_ready(true);
+            m_torrentHandle.auto_managed(true);
+#else
+            m_torrentHandle.set_flags(lt::torrent_flags::stop_when_ready | lt::torrent_flags::auto_managed);
+#endif
+        }
+    }
+}
+
+bool NativeTorrentExtension::on_pause()
+{
+    if (!isAutoManaged(m_torrentHandle.status({}))) {
+#if (LIBTORRENT_VERSION_NUM < 10200)
+        m_torrentHandle.stop_when_ready(false);
+#else
+        m_torrentHandle.unset_flags(lt::torrent_flags::stop_when_ready);
+#endif
+    }
+
+    // return `false` to allow standard handler
+    // and other extensions to be also invoked.
+    return false;
+}

--- a/src/base/bittorrent/private/nativetorrentextension.h
+++ b/src/base/bittorrent/private/nativetorrentextension.h
@@ -1,0 +1,49 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2020  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+#include <libtorrent/extensions.hpp>
+#include <libtorrent/torrent_handle.hpp>
+#include <libtorrent/version.hpp>
+
+class NativeTorrentExtension : public lt::torrent_plugin
+{
+public:
+    explicit NativeTorrentExtension(const lt::torrent_handle &torrentHandle);
+
+private:
+#if (LIBTORRENT_VERSION_NUM < 10200)
+    void on_state(int state) override;
+#else
+    void on_state(lt::torrent_status::state_t state) override;
+#endif
+    bool on_pause() override;
+
+    lt::torrent_handle m_torrentHandle;
+};

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -566,7 +566,6 @@ namespace BitTorrent
         void handleAddTorrentAlert(const lt::add_torrent_alert *p);
         void handleStateUpdateAlert(const lt::state_update_alert *p);
         void handleMetadataReceivedAlert(const lt::metadata_received_alert *p);
-        void handleTorrentPausedAlert(const lt::torrent_paused_alert *p);
         void handleFileErrorAlert(const lt::file_error_alert *p);
         void handleTorrentRemovedAlert(const lt::torrent_removed_alert *p);
         void handleTorrentDeletedAlert(const lt::torrent_deleted_alert *p);

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -443,20 +443,8 @@ namespace BitTorrent
         bool m_hasMissingFiles;
         bool m_hasRootFolder;
         bool m_needsToSetFirstLastPiecePriority;
-        bool m_needsToStartForced;
 
         QHash<QString, TrackerInfo> m_trackerInfos;
-
-        enum StartupState
-        {
-            Preparing, // torrent is preparing to start regular processing
-            Starting, // torrent is prepared and starting to perform regular processing
-            Started // torrent is performing regular processing
-        };
-        StartupState m_startupState = Preparing;
-        // Handle torrent state when it starts performing some service job
-        // being in Paused state so it might be unpaused internally and then paused again
-        bool m_pauseWhenReady;
 
         bool m_unchecked = false;
     };


### PR DESCRIPTION
Well, I finally managed to get rid of these terrible, hard to understand and maintain "torrent startup states".
Now we can just create torrent (both add new torrent or restore previously existing one) in its real state (paused, running or force running). If fastresume data will be rejected due to missing files torrent is paused by libtorrent session extension (in libtorrent working thread). We only need to handle an appropriate alert and mark torrent as "Missing files".