### PR TITLE
Migrate away from deprecated settings

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1088,7 +1088,9 @@ void Session::initializeNativeSession()
     // turn them off before `lt::session` ctor to avoid split second effects
     pack.set_bool(lt::settings_pack::enable_upnp, false);
     pack.set_bool(lt::settings_pack::enable_natpmp, false);
+#if (LIBTORRENT_VERSION_NUM < 10204)
     pack.set_bool(lt::settings_pack::upnp_ignore_nonrouters, true);
+#endif
 
 #if (LIBTORRENT_VERSION_NUM < 10200)
     // Disable support for SSL torrents for now


### PR DESCRIPTION
Libtorrent has deprecated `upnp_ignore_nonrouters` in https://github.com/arvidn/libtorrent/pull/4251