### PR TITLE
Git: Ignore "build" directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ src/icons/qbt-theme/build-icons/node_modules/
 src/icons/skin/build-icons/node_modules/
 src/icons/skin/build-icons/icons/*.png
 
+# CMake build directory
+build/
+
 # Web UI tools
 node_modules
 package-lock.json


### PR DESCRIPTION
Typically, CMake builds are executed in a folder named `build` inside the top-level directory directory.

Example: `mkdir build && cd build && cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ..`

This folder should be recursively ignored by git, so that build products don't pollute the unstaged files list.