### PR TITLE
Show "∞" instead of " -1" in Preferences

### DIFF
--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -2294,6 +2294,9 @@
                </item>
                <item row="0" column="1">
                 <widget class="QSpinBox" name="spinMaxActiveDownloads">
+                 <property name="specialValueText">
+                  <string>∞</string>
+                 </property>
                  <property name="minimum">
                   <number>-1</number>
                  </property>
@@ -2314,6 +2317,9 @@
                </item>
                <item row="1" column="1">
                 <widget class="QSpinBox" name="spinMaxActiveUploads">
+                 <property name="specialValueText">
+                  <string>∞</string>
+                 </property>
                  <property name="minimum">
                   <number>-1</number>
                  </property>
@@ -2334,6 +2340,9 @@
                </item>
                <item row="2" column="1">
                 <widget class="QSpinBox" name="spinMaxActiveTorrents">
+                 <property name="specialValueText">
+                  <string>∞</string>
+                 </property>
                  <property name="minimum">
                   <number>-1</number>
                  </property>


### PR DESCRIPTION
Instead of showing "-1" for unlimited, showing  "∞" for better understanding. Screenshot is given below:

![Screenshot from 2020-01-21 20-04-45](https://user-images.githubusercontent.com/30504976/72813473-91a84200-3c8d-11ea-83f7-f5be620b532b.png)


I have used already existing code from speed section:
![Screenshot from 2020-01-21 20-38-10](https://user-images.githubusercontent.com/30504976/72813701-00859b00-3c8e-11ea-8bcb-6306fc9dc6e2.png)

Closes #9236

