### PR TITLE
Show any multiple connections from the same IP in peer list

### DIFF
--- a/src/base/bittorrent/peeraddress.cpp
+++ b/src/base/bittorrent/peeraddress.cpp
@@ -68,3 +68,13 @@ QString PeerAddress::toString() const
         : ip.toString();
     return (ipStr + ':' + QString::number(port));
 }
+
+bool BitTorrent::operator==(const BitTorrent::PeerAddress &left, const BitTorrent::PeerAddress &right)
+{
+    return (left.ip == right.ip) && (left.port == right.port);
+}
+
+uint BitTorrent::qHash(const BitTorrent::PeerAddress &addr, const uint seed)
+{
+    return (::qHash(addr.ip, seed) ^ ::qHash(addr.port));
+}

--- a/src/base/bittorrent/peeraddress.h
+++ b/src/base/bittorrent/peeraddress.h
@@ -42,4 +42,7 @@ namespace BitTorrent
         static PeerAddress parse(const QString &address);
         QString toString() const;
     };
+
+    bool operator==(const PeerAddress &left, const PeerAddress &right);
+    uint qHash(const PeerAddress &addr, uint seed);
 }

--- a/src/gui/properties/peerlistwidget.h
+++ b/src/gui/properties/peerlistwidget.h
@@ -38,6 +38,8 @@ class QStandardItemModel;
 class PeerListSortModel;
 class PropertiesWidget;
 
+struct PeerEndpoint;
+
 namespace BitTorrent
 {
     class TorrentHandle;
@@ -73,7 +75,7 @@ private slots:
     void handleResolved(const QString &ip, const QString &hostname);
 
 private:
-    void updatePeer(const QString &ip, const BitTorrent::TorrentHandle *torrent, const BitTorrent::PeerInfo &peer, bool &isNewPeer);
+    void updatePeer(const BitTorrent::TorrentHandle *torrent, const BitTorrent::PeerInfo &peer, bool &isNewPeer);
 
     void wheelEvent(QWheelEvent *event) override;
 
@@ -81,7 +83,7 @@ private:
     PeerListSortModel *m_proxyModel = nullptr;
     PropertiesWidget *m_properties = nullptr;
     Net::ReverseResolution *m_resolver = nullptr;
-    QHash<QString, QStandardItem *> m_peerItems;
+    QHash<PeerEndpoint, QStandardItem *> m_peerItems;
     bool m_resolveCountries;
 };
 


### PR DESCRIPTION
The uniqueness of peers is now determined by their IP and port
instead of just their IP.

closes #11845