### PR TITLE
Improve qHash functions

### DIFF
--- a/src/base/bittorrent/infohash.cpp
+++ b/src/base/bittorrent/infohash.cpp
@@ -89,5 +89,9 @@ bool BitTorrent::operator!=(const InfoHash &left, const InfoHash &right)
 
 uint BitTorrent::qHash(const InfoHash &key, const uint seed)
 {
+#if (LIBTORRENT_VERSION_NUM < 10200)
     return ::qHash(static_cast<QString>(key), seed);
+#else
+    return ::qHash((std::hash<lt::sha1_hash> {})(key), seed);
+#endif
 }

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -82,7 +82,7 @@ namespace libtorrent
         template <typename T, typename Tag>
         uint qHash(const strong_typedef<T, Tag> &key, const uint seed)
         {
-            return static_cast<uint>((std::hash<strong_typedef<T, Tag>> {})(key) ^ seed);
+            return ::qHash((std::hash<strong_typedef<T, Tag>> {})(key), seed);
         }
     }
 }

--- a/src/base/bittorrent/trackerentry.cpp
+++ b/src/base/bittorrent/trackerentry.cpp
@@ -162,5 +162,5 @@ bool BitTorrent::operator==(const TrackerEntry &left, const TrackerEntry &right)
 
 uint BitTorrent::qHash(const TrackerEntry &key, const uint seed)
 {
-    return (::qHash(key.url(), seed) ^ key.tier());
+    return (::qHash(key.url(), seed) ^ ::qHash(key.tier()));
 }

--- a/src/base/net/downloadmanager.cpp
+++ b/src/base/net/downloadmanager.cpp
@@ -348,7 +348,7 @@ Net::ServiceID Net::ServiceID::fromURL(const QUrl &url)
 
 uint Net::qHash(const ServiceID &serviceID, const uint seed)
 {
-    return ::qHash(serviceID.hostName, seed) ^ serviceID.port;
+    return ::qHash(serviceID.hostName, seed) ^ ::qHash(serviceID.port);
 }
 
 bool Net::operator==(const ServiceID &lhs, const ServiceID &rhs)


### PR DESCRIPTION
* Use faster hash function
  qHash(QString) will need to hash/loop through all the data while the new code will only need one memcpy() and a few bit manipulations.
* Revise qHash function
  Instead of xor and narrowing the integers ourselves, now we let qHash() from Qt do the job properly.
* Use systematic approach to generate hash
  The basic idea is to hash each class member and then mix them with xor operation.
  However the `seed` must be handled with care, it should only be introduced once when mixing the hashes of each class member, otherwise under some circumstances the `seed` might xor with itself and thus break the intended effect.


