### PR TITLE
Remove redundant null checks

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -977,8 +977,7 @@ Session::~Session()
 
     // We must delete FilterParserThread
     // before we delete lt::session
-    if (m_filterParser)
-        delete m_filterParser;
+    delete m_filterParser;
 
     // We must delete PortForwarderImpl before
     // we delete lt::session
@@ -1002,10 +1001,8 @@ void Session::initInstance()
 
 void Session::freeInstance()
 {
-    if (m_instance) {
-        delete m_instance;
-        m_instance = nullptr;
-    }
+    delete m_instance;
+    m_instance = nullptr;
 }
 
 Session *Session::instance()
@@ -1605,8 +1602,7 @@ void Session::enableTracker(const bool enable)
         m_tracker->start();
     }
     else {
-        if (m_tracker)
-            delete m_tracker;
+        delete m_tracker;
     }
 }
 

--- a/src/base/iconprovider.cpp
+++ b/src/base/iconprovider.cpp
@@ -46,10 +46,8 @@ void IconProvider::initInstance()
 
 void IconProvider::freeInstance()
 {
-    if (m_instance) {
-        delete m_instance;
-        m_instance = nullptr;
-    }
+    delete m_instance;
+    m_instance = nullptr;
 }
 
 IconProvider *IconProvider::instance()

--- a/src/base/logger.cpp
+++ b/src/base/logger.cpp
@@ -65,10 +65,8 @@ void Logger::initInstance()
 
 void Logger::freeInstance()
 {
-    if (m_instance) {
-        delete m_instance;
-        m_instance = nullptr;
-    }
+    delete m_instance;
+    m_instance = nullptr;
 }
 
 void Logger::addMessage(const QString &message, const Log::MsgType &type)

--- a/src/base/net/downloadmanager.cpp
+++ b/src/base/net/downloadmanager.cpp
@@ -152,10 +152,8 @@ void Net::DownloadManager::initInstance()
 
 void Net::DownloadManager::freeInstance()
 {
-    if (m_instance) {
-        delete m_instance;
-        m_instance = nullptr;
-    }
+    delete m_instance;
+    m_instance = nullptr;
 }
 
 Net::DownloadManager *Net::DownloadManager::instance()

--- a/src/base/net/geoipmanager.cpp
+++ b/src/base/net/geoipmanager.cpp
@@ -63,8 +63,7 @@ GeoIPManager::GeoIPManager()
 
 GeoIPManager::~GeoIPManager()
 {
-    if (m_geoIPDatabase)
-        delete m_geoIPDatabase;
+    delete m_geoIPDatabase;
 }
 
 void GeoIPManager::initInstance()
@@ -75,10 +74,8 @@ void GeoIPManager::initInstance()
 
 void GeoIPManager::freeInstance()
 {
-    if (m_instance) {
-        delete m_instance;
-        m_instance = nullptr;
-    }
+    delete m_instance;
+    m_instance = nullptr;
 }
 
 GeoIPManager *GeoIPManager::instance()
@@ -88,10 +85,8 @@ GeoIPManager *GeoIPManager::instance()
 
 void GeoIPManager::loadDatabase()
 {
-    if (m_geoIPDatabase) {
-        delete m_geoIPDatabase;
-        m_geoIPDatabase = nullptr;
-    }
+    delete m_geoIPDatabase;
+    m_geoIPDatabase = nullptr;
 
     const QString filepath = Utils::Fs::expandPathAbs(
         QString("%1%2/%3").arg(specialFolderLocation(SpecialFolder::Data), GEOIP_FOLDER, GEOIP_FILENAME));
@@ -398,7 +393,7 @@ void GeoIPManager::configure()
         if (m_enabled && !m_geoIPDatabase) {
             loadDatabase();
         }
-        else if (!m_enabled && m_geoIPDatabase) {
+        else if (!m_enabled) {
             delete m_geoIPDatabase;
             m_geoIPDatabase = nullptr;
         }
@@ -423,8 +418,7 @@ void GeoIPManager::downloadFinished(const DownloadResult &result)
     GeoIPDatabase *geoIPDatabase = GeoIPDatabase::load(data, error);
     if (geoIPDatabase) {
         if (!m_geoIPDatabase || (geoIPDatabase->buildEpoch() > m_geoIPDatabase->buildEpoch())) {
-            if (m_geoIPDatabase)
-                delete m_geoIPDatabase;
+            delete m_geoIPDatabase;
             m_geoIPDatabase = geoIPDatabase;
             LogMsg(tr("GeoIP database loaded. Type: %1. Build time: %2.")
                 .arg(m_geoIPDatabase->type(), m_geoIPDatabase->buildEpoch().toString()),

--- a/src/base/net/private/downloadhandlerimpl.cpp
+++ b/src/base/net/private/downloadhandlerimpl.cpp
@@ -63,8 +63,7 @@ DownloadHandlerImpl::DownloadHandlerImpl(const Net::DownloadRequest &downloadReq
 
 DownloadHandlerImpl::~DownloadHandlerImpl()
 {
-    if (m_reply)
-        delete m_reply;
+    delete m_reply;
 }
 
 void DownloadHandlerImpl::cancel()

--- a/src/base/net/proxyconfigurationmanager.cpp
+++ b/src/base/net/proxyconfigurationmanager.cpp
@@ -84,10 +84,8 @@ void ProxyConfigurationManager::initInstance()
 
 void ProxyConfigurationManager::freeInstance()
 {
-    if (m_instance) {
-        delete m_instance;
-        m_instance = nullptr;
-    }
+    delete m_instance;
+    m_instance = nullptr;
 }
 
 ProxyConfigurationManager *ProxyConfigurationManager::instance()

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -77,10 +77,8 @@ void Preferences::initInstance()
 
 void Preferences::freeInstance()
 {
-    if (m_instance) {
-        delete m_instance;
-        m_instance = nullptr;
-    }
+    delete m_instance;
+    m_instance = nullptr;
 }
 
 const QVariant Preferences::value(const QString &key, const QVariant &defaultValue) const

--- a/src/base/scanfoldersmodel.cpp
+++ b/src/base/scanfoldersmodel.cpp
@@ -69,10 +69,8 @@ bool ScanFoldersModel::initInstance(QObject *parent)
 
 void ScanFoldersModel::freeInstance()
 {
-    if (m_instance) {
-        delete m_instance;
-        m_instance = nullptr;
-    }
+    delete m_instance;
+    m_instance = nullptr;
 }
 
 ScanFoldersModel *ScanFoldersModel::instance()

--- a/src/base/search/searchpluginmanager.cpp
+++ b/src/base/search/searchpluginmanager.cpp
@@ -104,8 +104,7 @@ SearchPluginManager *SearchPluginManager::instance()
 
 void SearchPluginManager::freeInstance()
 {
-    if (m_instance)
-        delete m_instance;
+    delete m_instance;
 }
 
 QStringList SearchPluginManager::allPlugins() const

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -678,7 +678,7 @@ void MainWindow::displayRSSTab(bool enable)
 #endif
         }
     }
-    else if (m_rssWidget) {
+    else {
         delete m_rssWidget;
     }
 }
@@ -714,7 +714,7 @@ void MainWindow::displaySearchTab(bool enable)
                 tr("Search"));
         }
     }
-    else if (m_searchWidget) {
+    else {
         delete m_searchWidget;
     }
 }
@@ -1170,8 +1170,7 @@ void MainWindow::closeEvent(QCloseEvent *e)
     }
 
     // abort search if any
-    if (m_searchWidget)
-        delete m_searchWidget;
+    delete m_searchWidget;
 
     hide();
 #ifndef Q_OS_MACOS
@@ -1875,7 +1874,7 @@ void MainWindow::on_actionExecutionLogs_triggered(bool checked)
         m_tabs->setTabIcon(indexTab, UIThemeManager::instance()->getIcon("view-calendar-journal"));
 #endif
     }
-    else if (m_executionLog) {
+    else {
         delete m_executionLog;
     }
 

--- a/src/gui/private/fspathedit_p.cpp
+++ b/src/gui/private/fspathedit_p.cpp
@@ -259,10 +259,8 @@ void Private::FileLineEdit::keyPressEvent(QKeyEvent *e)
         FileSystemPathValidator::TestResult lastTestResult = validator->lastTestResult();
         QValidator::State lastState = validator->lastValidationState();
         if (lastTestResult == FileSystemPathValidator::TestResult::OK) {
-            if (m_warningAction) {
-                delete m_warningAction;
-                m_warningAction = nullptr;
-            }
+            delete m_warningAction;
+            m_warningAction = nullptr;
         }
         else {
             if (!m_warningAction) {

--- a/src/gui/uithememanager.cpp
+++ b/src/gui/uithememanager.cpp
@@ -43,10 +43,8 @@ UIThemeManager *UIThemeManager::m_instance = nullptr;
 
 void UIThemeManager::freeInstance()
 {
-    if (m_instance) {
-        delete m_instance;
-        m_instance = nullptr;
-    }
+    delete m_instance;
+    m_instance = nullptr;
 }
 
 void UIThemeManager::initInstance()

--- a/src/webui/webui.cpp
+++ b/src/webui/webui.cpp
@@ -127,21 +127,15 @@ void WebUI::configure()
                 m_dnsUpdater->updateCredentials();
         }
         else {
-            if (m_dnsUpdater)
-                delete m_dnsUpdater;
+            delete m_dnsUpdater;
         }
     }
     else {
         Net::PortForwarder::instance()->deletePort(oldPort);
 
-        if (m_httpServer)
-            delete m_httpServer;
-
-        if (m_webapp)
-            delete m_webapp;
-
-        if (m_dnsUpdater)
-            delete m_dnsUpdater;
+        delete m_httpServer;
+        delete m_webapp;
+        delete m_dnsUpdater;
     }
 }
 


### PR DESCRIPTION
Attempting to delete a null pointer is a noop in C++.

Closes #2864.

[1] https://isocpp.org/wiki/faq/freestore-mgmt#delete-handles-null