### PR TITLE
Fix singleton class ownership

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -550,7 +550,7 @@ int Application::exec(const QStringList &params)
 #ifndef DISABLE_COUNTRIES_RESOLUTION
         Net::GeoIPManager::initInstance();
 #endif
-        ScanFoldersModel::initInstance(this);
+        ScanFoldersModel::initInstance();
 
 #ifndef DISABLE_WEBUI
         m_webui = new WebUI;

--- a/src/base/scanfoldersmodel.cpp
+++ b/src/base/scanfoldersmodel.cpp
@@ -57,14 +57,10 @@ struct ScanFoldersModel::PathData
 
 ScanFoldersModel *ScanFoldersModel::m_instance = nullptr;
 
-bool ScanFoldersModel::initInstance(QObject *parent)
+void ScanFoldersModel::initInstance()
 {
-    if (!m_instance) {
-        m_instance = new ScanFoldersModel(parent);
-        return true;
-    }
-
-    return false;
+    if (!m_instance)
+        m_instance = new ScanFoldersModel;
 }
 
 void ScanFoldersModel::freeInstance()

--- a/src/base/scanfoldersmodel.h
+++ b/src/base/scanfoldersmodel.h
@@ -65,7 +65,7 @@ public:
         CUSTOM_LOCATION
     };
 
-    static bool initInstance(QObject *parent = nullptr);
+    static void initInstance();
     static void freeInstance();
     static ScanFoldersModel *instance();
 


### PR DESCRIPTION
We shouldn't allow Qt parent ownership in here.

BTW I also evaluated using std::unique_ptr here but only to find it fail to compile due to the class destructor is private.