### PR TITLE
Use SVG image for WebUI favicon

### DIFF
--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -6,6 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=10" />
     <title>qBittorrent Web UI</title>
     <link rel="icon" type="image/png" href="images/skin/qbittorrent32.png" />
+    <link rel="icon" type="image/svg+xml" href="images/skin/qbittorrent-tray.svg" />
     <link rel="stylesheet" type="text/css" href="css/dynamicTable.css?v=${CACHEID}" />
     <link rel="stylesheet" type="text/css" href="css/style.css?v=${CACHEID}" />
     <!--<link rel="stylesheet" type="text/css" href="css/Content.css" />-->

--- a/src/webui/www/public/index.html
+++ b/src/webui/www/public/index.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8" />
     <title>qBittorrent QBT_TR(Web UI)QBT_TR[CONTEXT=OptionsDialog]</title>
     <link rel="icon" type="image/png" href="images/skin/qbittorrent32.png" />
+    <link rel="icon" type="image/svg+xml" href="images/skin/qbittorrent-tray.svg" />
     <link rel="stylesheet" type="text/css" href="css/login.css?v=${CACHEID}" />
     <noscript>
         <link rel="stylesheet" type="text/css" href="css/noscript.css?v=${CACHEID}" />


### PR DESCRIPTION
This will allow browsers to get high quality icon with required resolution
instead of resizing some small raster image.
Browsers can have even more benefit from it. For example, Firefox uses high
resolution icon to display it in "Top Sites" instead of page preview.

Nothing changes for browsers which doesn't support SVG favicons, older PNG
icon is set as fallback, so it will be used in such case.

P.S> I'm not Web developer and know too little about Web-related stuff. I just found [this interesting note](https://superuser.com/a/1495054) about Firefox' "Top Sites" and [this page demonstrating SVG favicons](http://dahlström.net/svg/favicon/favicon.html). so I decided to test this stuff, view attached screenshot to see what happened.

![Screenshot 2020-02-08 23 34 29](https://user-images.githubusercontent.com/947647/74092031-0540b080-4ad0-11ea-915d-e511be4a26d4.png)