### PR TITLE
Inherit text color for filter list elements

### DIFF
--- a/src/webui/www/private/css/style.css
+++ b/src/webui/www/private/css/style.css
@@ -457,6 +457,7 @@ ul.filterList a {
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+    color: inherit;
 }
 
 ul.filterList li:hover {


### PR DESCRIPTION
Filter list (left side panel) in WebUI is implemented using <a> tags,
CSS defines default style for all <a> elements, and specific style for
filter list elements. Default style for <a> elements sets color, and
this color also used in list. This is looks not so well. So lets just
inherit text color from parent element, and as so as it is not set, so
default text color will be used.
This makes filter list looks like other UI elemets, making all UI more
consistent (like in desktop app).

P.S> I'm not web developer, I know too little in web-related stuff. This change was experimentally achieved using Firefox' web developer tools.

before:
<img width="1280" alt="Screenshot 2020-02-11 22 18 53" src="https://user-images.githubusercontent.com/947647/74273003-b9387a80-4d20-11ea-8b43-560c26f9bb44.png">
after:
<img width="1280" alt="Screenshot 2020-02-11 22 27 37" src="https://user-images.githubusercontent.com/947647/74273030-c5243c80-4d20-11ea-854f-a750bbedc126.png">
Note color change: orange -> dark gray. As for me, it looks much better, especially if a lot of torrents in the list.