### PR TITLE
Do not list not contacted trackers as error

### DIFF
--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -1654,14 +1654,13 @@ void TorrentHandle::handleTrackerErrorAlert(const lt::tracker_error_alert *p)
 
     // Starting with libtorrent 1.2.x each tracker has multiple local endpoints from which
     // an announce is attempted. Some endpoints might succeed while others might fail.
-    // Emit the signal only if all endpoints have failed. TrackerEntry::isWorking() returns
-    // true if at least one endpoint works.
+    // Emit the signal only if all endpoints have failed.
     const QVector<TrackerEntry> trackerList = trackers();
     const auto iter = std::find_if(trackerList.cbegin(), trackerList.cend(), [&trackerUrl](const TrackerEntry &entry)
     {
         return (entry.url() == trackerUrl);
     });
-    if ((iter != trackerList.cend()) && !iter->isWorking())
+    if ((iter != trackerList.cend()) && (iter->status() == TrackerEntry::NotWorking))
         m_session->handleTorrentTrackerError(this, trackerUrl);
 }
 


### PR DESCRIPTION
Qbt is listing "Not contacted" trackers as error. It shouldn't do that. Partially patches #11997