### PR TITLE
Simplify TrackerEntry::status() logic

### DIFF
--- a/src/base/bittorrent/trackerentry.cpp
+++ b/src/base/bittorrent/trackerentry.cpp
@@ -52,24 +52,6 @@ QString TrackerEntry::url() const
     return QString::fromStdString(nativeEntry().url);
 }
 
-bool TrackerEntry::isWorking() const
-{
-    // lt::announce_entry::is_working() returns
-    // true when the tracker hasn't been tried yet.
-#if (LIBTORRENT_VERSION_NUM < 10200)
-    return nativeEntry().verified && nativeEntry().is_working();
-#else
-    if (!nativeEntry().verified)
-        return false;
-    const auto &endpoints = nativeEntry().endpoints;
-    return std::any_of(endpoints.begin(), endpoints.end()
-                       , [](const lt::announce_endpoint &endpoint)
-    {
-        return endpoint.is_working();
-    });
-#endif
-}
-
 int TrackerEntry::tier() const
 {
     return nativeEntry().tier;
@@ -77,35 +59,36 @@ int TrackerEntry::tier() const
 
 TrackerEntry::Status TrackerEntry::status() const
 {
-    if (isWorking())
-        return Working;
-
 #if (LIBTORRENT_VERSION_NUM < 10200)
-    if ((nativeEntry().fails == 0) && nativeEntry().updating)
+    if (nativeEntry().fails > 0)
+        return NotWorking;
+
+    if (nativeEntry().updating)
         return Updating;
-    if (nativeEntry().fails == 0)
-        return NotContacted;
 #else
     const auto &endpoints = nativeEntry().endpoints;
-    const bool allFailed = std::all_of(endpoints.begin(), endpoints.end()
-                                       , [](const lt::announce_endpoint &endpoint)
+
+    const bool allFailed = !endpoints.empty() && std::all_of(endpoints.begin(), endpoints.end()
+        , [](const lt::announce_endpoint &endpoint)
     {
         return (endpoint.fails > 0);
     });
-    const bool updating = std::any_of(endpoints.begin(), endpoints.end()
-                                      , [](const lt::announce_endpoint &endpoint)
+    if (allFailed)
+        return NotWorking;
+
+    const bool isUpdating = std::any_of(endpoints.begin(), endpoints.end()
+        , [](const lt::announce_endpoint &endpoint)
     {
         return endpoint.updating;
     });
-
-    if (!allFailed && updating)
+    if (isUpdating)
         return Updating;
-
-    if (!allFailed)
-        return NotContacted;
 #endif
 
-    return NotWorking;
+    if (!nativeEntry().verified)
+        return NotContacted;
+
+    return Working;
 }
 
 void TrackerEntry::setTier(const int value)

--- a/src/base/bittorrent/trackerentry.h
+++ b/src/base/bittorrent/trackerentry.h
@@ -55,7 +55,6 @@ namespace BitTorrent
         TrackerEntry &operator=(const TrackerEntry &other) = default;
 
         QString url() const;
-        bool isWorking() const;
         Status status() const;
 
         int tier() const;


### PR DESCRIPTION
This is an attempt to simplify `TrackerEntry::status()` which currently has convoluted logic.

Although it passed my rudimentary tests, more testing are appreciated! Just keep an eye on the Tracker Status column in Trackers tab, see if it shows the correct/usual status.
@thalieht 