### PR TITLE
Fix embedded tracker

### DIFF
--- a/src/base/bittorrent/tracker.cpp
+++ b/src/base/bittorrent/tracker.cpp
@@ -272,6 +272,12 @@ void Tracker::processAnnounceRequest()
     announceReq.socketAddress = m_env.clientAddress;
     announceReq.claimedAddress = queryParams.value(ANNOUNCE_REQUEST_IP);
 
+    // Enforce using IPv4 if address is indeed IPv4 or if it is an IPv4-mapped IPv6 address
+    bool ok = false;
+    const qint32 decimalIPv4 = announceReq.socketAddress.toIPv4Address(&ok);
+    if (ok)
+        announceReq.socketAddress = QHostAddress(decimalIPv4);
+
     // 1. info_hash
     const auto infoHashIter = queryParams.find(ANNOUNCE_REQUEST_INFO_HASH);
     if (infoHashIter == queryParams.end())
@@ -387,7 +393,7 @@ void Tracker::prepareAnnounceResponse(const TrackerAnnounceRequest &announceReq)
         {ANNOUNCE_RESPONSE_COMPLETE, torrentStats.seeders},
         {ANNOUNCE_RESPONSE_INCOMPLETE, (torrentStats.peers.size() - torrentStats.seeders)},
 
-        // [BEP-24] Tracker Returns External IP
+        // [BEP-24] Tracker Returns External IP (partial support - might not work properly for all IPv6 cases)
         {ANNOUNCE_RESPONSE_EXTERNAL_IP, toBigEndianByteArray(announceReq.socketAddress).toStdString()}
     };
 

--- a/src/base/bittorrent/tracker.cpp
+++ b/src/base/bittorrent/tracker.cpp
@@ -392,26 +392,26 @@ void Tracker::prepareAnnounceResponse(const TrackerAnnounceRequest &announceReq)
     };
 
     // peer list
-    // [BEP-7] IPv6 Tracker Extension (partial support)
+    // [BEP-7] IPv6 Tracker Extension (partial support - only the part that concerns BEP-23)
     // [BEP-23] Tracker Returns Compact Peer Lists
     if (announceReq.compact) {
-        lt::entry::list_type peerList;
-        lt::entry::list_type peer6List;
+        lt::entry::string_type peers;
+        lt::entry::string_type peers6;
 
         int counter = 0;
         for (const Peer &peer : asConst(torrentStats.peers)) {
             if (counter++ >= announceReq.numwant)
                 break;
 
-            if (peer.endpoint.size() == 6)  // IPv4
-                peerList.emplace_back(peer.endpoint);
-            else if (peer.endpoint.size() == 18)  // IPv6
-                peer6List.emplace_back(peer.endpoint);
+            if (peer.endpoint.size() == 6)  // IPv4 + port
+                peers.append(peer.endpoint);
+            else if (peer.endpoint.size() == 18)  // IPv6 + port
+                peers6.append(peer.endpoint);
         }
 
-        replyDict[ANNOUNCE_RESPONSE_PEERS] = peerList;  // required, even it's empty
-        if (!peer6List.empty())
-            replyDict[ANNOUNCE_RESPONSE_PEERS6] = peer6List;
+        replyDict[ANNOUNCE_RESPONSE_PEERS] = peers;  // required, even it's empty
+        if (!peers6.empty())
+            replyDict[ANNOUNCE_RESPONSE_PEERS6] = peers6;
     }
     else {
         lt::entry::list_type peerList;

--- a/src/base/bittorrent/tracker.cpp
+++ b/src/base/bittorrent/tracker.cpp
@@ -107,8 +107,8 @@ namespace
         case QAbstractSocket::IPv6Protocol: {
                 const Q_IPV6ADDR ipv6 = addr.toIPv6Address();
                 QByteArray ret;
-                for (int i = (sizeof(ipv6.c) - 1); i >= 0; --i)
-                    ret.append(static_cast<char>(ipv6.c[i]));
+                for (const quint8 i : ipv6.c)
+                    ret.append(i);
                 return ret;
             }
 


### PR DESCRIPTION
Assorted changes to improve the embedded tracker.

Most likely will fix this issue: https://github.com/qbittorrent/qBittorrent/issues/11949, but I am not 100% sure. Further improvements may be needed.

Still, these changes are significant enough that they fixed my attempted reproduction of the issue outlined in https://github.com/qbittorrent/qBittorrent/issues/11949#issuecomment-581534535.

Some observations:

1. BEP-24 (tracker returns external ip) seems to be working for IPv4, but it does not seem to be working properly for IPv6. It will need further testing/improvements (e.g. NAT check and such) until we can claim full compliance. Without the "Embedded tracker: don't use IPv4-mapped v6" commit, for example, it was returning the IPv4-mapped IPv6 address, instead of the proper external IPv4 or external IPv6.
2. I used the Fedora Linux tracker (which is an HTTP tracker) for comparison during the development of this PR. It responds to an `event=stopped` request with the usual bencoded dict except with an empty `peers` key (e.g. `d8:completei132e10:incompletei0e8:intervali1645e12:min intervali822e5:peers0:e`). Contrary to them, we respond with an empty `200 OK`. This leads to qBittorrent listing the embedded tracker as "Not working" every time a torrent that uses it is stopped.

Concerning the 2nd point, BEP-3 (official protocol spec) and BEP-52 (v2 spec) both say tracker responses "must have two keys: interval, which maps to the number of seconds the downloader should wait between regular rerequests, and peers." (I assume this means the other keys are optional).

Thus, the Fedora tracker is fully compliant in this respect but ours isn't. Additionally, when stopping the torrent, qBittorrent lists the status of the tracker as either "Working" or "Not Working", instead of resetting back to "Not contacted yet". To fix this we need to:

- ~Modify the embedded tracker to work like the Fedora tracker;~ EDIT: done in this PR
- ~Modify some other qBittorrent logic to always list all trackers as "Not contacted yet" when a torrent is paused - if it is understood that "Not contacted yet" really means "Not contacted _since torrent was last resumed_";~ EDIT: to be discussed at https://github.com/qbittorrent/qBittorrent/issues/12061

~This last discussion about the appropriate response to an `event=stopped` request and qBittorent's (client-side) behavior on stopping torrents is only meant to be food-for-thought, and should probably be addressed as a whole in another PR.~

Should I add this PR to the 4.2.2 milestone?