### PR TITLE
Remove misleading translation comment

### DIFF
--- a/src/gui/rss/automatedrssdownloader.ui
+++ b/src/gui/rss/automatedrssdownloader.ui
@@ -251,7 +251,7 @@ Supports the formats: S01E01, 1x1, 2017.01.01 and 01.01.2017 (Date formats also 
             <item>
              <widget class="QLabel" name="lblIgnoreDays">
               <property name="text">
-               <string comment="... X days">Ignore Subsequent Matches for (0 to Disable)</string>
+               <string extracomment="... X days">Ignore Subsequent Matches for (0 to Disable)</string>
               </property>
              </widget>
             </item>

--- a/src/gui/torrentcreatordialog.ui
+++ b/src/gui/torrentcreatordialog.ui
@@ -291,7 +291,7 @@
       <item row="0" column="1">
        <widget class="QTextEdit" name="trackersList">
         <property name="toolTip">
-         <string comment="A tracker tier is a group of trackers, consisting of a main tracker and its mirrors.">You can separate tracker tiers / groups with an empty line.</string>
+         <string>You can separate tracker tiers / groups with an empty line.</string>
         </property>
         <property name="acceptRichText">
          <bool>false</bool>


### PR DESCRIPTION
* Remove misleading translation comment
  Also it was using the wrong field for translation comment.
* Fix wrong field for translation comment
  The `comment` field is used for disambiguation between identical strings. Our case here should use the `extracomment` field which meant as comment for translators.


