### PR TITLE
Remove unused options from settings file

### DIFF
--- a/src/app/upgrade.cpp
+++ b/src/app/upgrade.cpp
@@ -75,11 +75,27 @@ namespace
             , QLatin1String("Preferences/WebUI/HTTPS/KeyPath")
             , Utils::Fs::toNativePath(configPath + QLatin1String("WebUIPrivateKey.pem")));
     }
+
+    void removeUnusedOptions()
+    {
+        SettingsStorage *settingsStorage {SettingsStorage::instance()};
+        const QVector<QString> removed_options {"BitTorrent/Session/MaxHalfOpenConnections"};
+
+        for(auto const &option : removed_options)
+        {
+            if(!settingsStorage->loadValue(option).isNull())
+            {
+                LogMsg(QObject::tr("Migrated preferences: removed unused option %1").arg(option), Log::INFO);
+                settingsStorage->removeValue(option);
+            }
+        }
+    }
 }
 
 bool upgrade(const bool /*ask*/)
 {
     exportWebUIHttpsFiles();
+    removeUnusedOptions();
     return true;
 }
 


### PR DESCRIPTION
Side note: on all upgrade operations, shouldn't we call `SettingsStorage::save()` right away, regardless of the timer set by the `store` and `remove` operations? When the change is made, the user might open the settings file to inspect the change before the changes have been committed and think it did not work. The timer is 5 seconds, so this is rather unlikely. But still, if there is no downside, why not commit the changes immediately?