### PR TITLE
Let libtorrent decide whether to resume a torrent

### DIFF
--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -1497,7 +1497,8 @@ void TorrentHandle::resume_impl(bool forced)
     }
 
     setAutoManaged(!forced);
-    m_nativeHandle.resume();
+    if (forced)
+        m_nativeHandle.resume();
 }
 
 void TorrentHandle::moveStorage(const QString &newPath, bool overwrite)


### PR DESCRIPTION
When "user" resumes a torrent allow libtorrent decide whether to really resume it according to current limits.