### PR TITLE
Delegate GUI scaling work to Qt

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -133,6 +133,12 @@ int main(int argc, char *argv[])
     // We must save it here because QApplication constructor may change it
     bool isOneArg = (argc == 2);
 
+#if !defined(DISABLE_GUI) && (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    // Attribute Qt::AA_EnableHighDpiScaling must be set before QCoreApplication is created
+    if (qgetenv("QT_ENABLE_HIGHDPI_SCALING").isEmpty() && qgetenv("QT_AUTO_SCREEN_SCALE_FACTOR").isEmpty())
+        Application::setAttribute(Qt::AA_EnableHighDpiScaling, true);
+#endif
+
     try {
         // Create Application
         const QString appId = QLatin1String("qBittorrent-") + Utils::Misc::getUserIDString();

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -62,6 +62,10 @@ void Utils::Gui::resize(QWidget *widget, const QSize &newSize)
 
 qreal Utils::Gui::screenScalingFactor(const QWidget *widget)
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    Q_UNUSED(widget);
+    return 1;
+#else
     if (!widget)
         return 1;
 
@@ -77,6 +81,7 @@ qreal Utils::Gui::screenScalingFactor(const QWidget *widget)
 #else
     return widget->devicePixelRatioF();
 #endif // Q_OS_WIN
+#endif // QT_VERSION
 }
 
 QPixmap Utils::Gui::scaledPixmap(const QIcon &icon, const QWidget *widget, const int height)


### PR DESCRIPTION
First of all, this pull request was created only due to @FranciscoPombal  request after some our discussion in #8255 and @Chocobo1 confirmation that even such dirty pull request will be useful, see https://github.com/qbittorrent/qBittorrent/issues/8255#issuecomment-593131793 and few next for details.
All these changes are just quick and dirty fixes, and this pull request is intended to start the discussion how to improve them.
After that, issues like #8255 , #11234 , #11445 and many other related can be closed.

These changes make qBittorrent look much better on HiDPI screens, especially on Windows. Linux systems (at least X11-based) are also affected by these changes, see few screenshots below from my KDE system (2 first screenshots show qBittorrent installed from official PPA, another 2 - from [my own custom repository](https://software.opensuse.org//download.html?project=home%3Anikoneko&package=qbittorrent)), also few comments from other similar threads (https://github.com/qbittorrent/qBittorrent/issues/11445#issuecomment-549781293 and https://github.com/qbittorrent/qBittorrent/issues/11234#issuecomment-532107318 for example).

Original qBittorrent from official stable PPA on KDE:
<img width="1280" alt="Screenshot 2020-03-02 21 47 00" src="https://user-images.githubusercontent.com/947647/75708446-dfbf5500-5cd1-11ea-9a15-450dc40a60fb.png">
<img width="1280" alt="Screenshot 2020-03-02 21 47 16" src="https://user-images.githubusercontent.com/947647/75708478-f1a0f800-5cd1-11ea-85b2-67fcf49a3804.png">

[Patched](https://build.opensuse.org/package/show/home:nikoneko/qbittorrent) qBittorrent from [my own custom repo](https://software.opensuse.org//download.html?project=home%3Anikoneko&package=qbittorrent) on the same KDE system:
<img width="1280" alt="Screenshot 2020-03-02 21 51 54" src="https://user-images.githubusercontent.com/947647/75708485-f2d22500-5cd1-11ea-9689-d16ae5891f23.png">
<img width="1280" alt="Screenshot 2020-03-02 21 52 11" src="https://user-images.githubusercontent.com/947647/75708486-f36abb80-5cd1-11ea-872f-f00a5ce60de7.png">

In both cases all settings and data files where removed, so this is look "out of the box", main window looks almost the same, but difference in About and Preferences dialogs size are significant. On Windows difference is much more significant, see links to comments above.

What is included in these changes (what I did to achieve that) - just delegated everything geometry-related to Qt, nothing more.

First of all of these changes are 2 QApplication flags:
- [Qt::AA_UseHighDpiPixmaps](https://doc.qt.io/qt-5/qt.html#ApplicationAttribute-enum) - this forces QIcon to use HiDPI versions of required images if they can be generated from existing (for example, image source is SVG or PNG with enough resolution
- [Qt::AA_EnableHighDpiScaling](https://doc.qt.io/qt-5/qt.html#ApplicationAttribute-enum) - this does the most of work... I don't really know what happens inside Qt, but it leads to awesome results, and it works on Windows and Linux. For example, on Linux systems [QWidget::devicePixelRatioF()](https://doc.qt.io/qt-5/qpaintdevice.html#devicePixelRatioF) even can return fractional numbers according to used scaling factor. Only one thing I noticed working with this feature, it somehow fakes screen dpi, because even I called [QSreen:: physicalDotsPerInch()](https://doc.qt.io/qt-5/qscreen.html#physicalDotsPerInch-prop) I got not real number, but without this flag real number is returned. [QScreen:: logicalDotsPerInch()](https://doc.qt.io/qt-5/qscreen.html#logicalDotsPerInch-prop) value is also changes depending on this flag. One more observation: on Windows I saw only devicePixelRatio = 2.0, doesn't matter what scaling factor is set (I didn't try > 200%), anything > 100% -> devicePixelRatio = 2.0. But despite on this visually window is properly scaled (i.e. scale factor is respected).

The rest of changes just to make that mentioned flags work correctly - remove/disable any resize/scale logic (i.e. do not resize anything manually and use QIcon for all images). Just quick hacks, nothing more.

One more note, these changes may have NO effect with static Qt build, at least on Windows. I didn't try it with recent Qt versions, just because of insanely long time for Qt building on Windows, but tried similar things long time ago (2015-2016), when I had much more powerful PC rather than my >5 years old MacBook Pro, so it didn't work. Static Qt just unable to correctly detect environment in which it runs, and this is somehow related to its plugin system. Very long time ago (in ~2014) I saw information somewhere in Qt documentation (online, aka pages for Qt developers) saying that static build even officially not supported, and all issues are under users responsibility.
But this is very old information, a lot of things may changed, so any confirmation or contradiction of this is required.