### PR TITLE
Avoid unnecessary memory writes

### DIFF
--- a/src/base/bittorrent/peerinfo.cpp
+++ b/src/base/bittorrent/peerinfo.cpp
@@ -208,11 +208,10 @@ qlonglong PeerInfo::totalDownload() const
 QBitArray PeerInfo::pieces() const
 {
     QBitArray result(m_nativeInfo.pieces.size());
-
-    int i = 0;
-    for (const bool bit : m_nativeInfo.pieces)
-        result.setBit(i++, bit);
-
+    for (int i = 0; i < result.size(); ++i) {
+        if (m_nativeInfo.pieces[i])
+            result.setBit(i, true);
+    }
     return result;
 }
 

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -1202,10 +1202,10 @@ QVector<PeerInfo> TorrentHandle::peers() const
 QBitArray TorrentHandle::pieces() const
 {
     QBitArray result(m_nativeStatus.pieces.size());
-
-    for (int i = 0; i < m_nativeStatus.pieces.size(); ++i)
-        result.setBit(i, m_nativeStatus.pieces.get_bit(LTPieceIndex {i}));
-
+    for (int i = 0; i < result.size(); ++i) {
+        if (m_nativeStatus.pieces[LTPieceIndex {i}])
+            result.setBit(i, true);
+    }
     return result;
 }
 


### PR DESCRIPTION
Before this change, qbt spent ~1% in these two functions, now it only spends about ~0.5% in my naive testing.

I also tested `QBitArray::fromBits()` which is even faster, but unfortunately libtorrent `bitfield` is incompatible with it.
Probably worth mentioning is that I observed no noticeable inefficiency in qbt code during my naive testing and these 2 functions here are the most outstanding ones (still insignificant but the changes are simple so I would commit it).
