### PR TITLE
Update minimum Python version to 3.5.0

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -17,7 +17,7 @@ qBittorrent - A BitTorrent client in C++ / Qt
 
   - pkg-config (compile-time only)
 
-  - Python >= 2.7.9 / 3.3.0 (optional, runtime only)
+  - Python >= 3.5.0 (optional, runtime only)
       * Required by the internal search engine
 
 2a) Compile and install qBittorrent with Qt graphical interface

--- a/src/base/utils/foreignapps.cpp
+++ b/src/base/utils/foreignapps.cpp
@@ -240,7 +240,7 @@ bool Utils::ForeignApps::PythonInfo::isValid() const
 
 bool Utils::ForeignApps::PythonInfo::isSupportedVersion() const
 {
-    return (version >= Version {3, 3, 0});
+    return (version >= Version {3, 5, 0});
 }
 
 PythonInfo Utils::ForeignApps::pythonInfo()

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1773,14 +1773,14 @@ void MainWindow::on_actionSearchWidget_triggered()
 
 #ifdef Q_OS_WIN
             const QMessageBox::StandardButton buttonPressed = QMessageBox::question(this, tr("Old Python Runtime")
-                , tr("Your Python version (%1) is outdated. Minimum requirement: 3.3.0.\nDo you want to install a newer version now?")
+                , tr("Your Python version (%1) is outdated. Minimum requirement: 3.5.0.\nDo you want to install a newer version now?")
                     .arg(pyInfo.version)
                 , (QMessageBox::Yes | QMessageBox::No), QMessageBox::Yes);
             if (buttonPressed == QMessageBox::Yes)
                 installPython();
 #else
             QMessageBox::information(this, tr("Old Python Runtime")
-                , tr("Your Python version (%1) is outdated. Please upgrade to latest version for search engines to work.\nMinimum requirement: 3.3.0.")
+                , tr("Your Python version (%1) is outdated. Please upgrade to latest version for search engines to work.\nMinimum requirement: 3.5.0.")
                 .arg(pyInfo.version));
 #endif
             return;
@@ -2011,9 +2011,9 @@ void MainWindow::installPython()
     setCursor(QCursor(Qt::WaitCursor));
     // Download python
 #ifdef QBT_APP_64BIT
-    const QString installerURL = "https://www.python.org/ftp/python/3.8.1/python-3.8.1-amd64.exe";
+    const QString installerURL = "https://www.python.org/ftp/python/3.8.2/python-3.8.2-amd64.exe";
 #else
-    const QString installerURL = "https://www.python.org/ftp/python/3.8.1/python-3.8.1.exe";
+    const QString installerURL = "https://www.python.org/ftp/python/3.8.2/python-3.8.2.exe";
 #endif
     Net::DownloadManager::instance()->download(
                 Net::DownloadRequest(installerURL).saveToFile(true)


### PR DESCRIPTION
Previous versions are deprecated => https://devguide.python.org/devcycle/#end-of-life-branches

NOTE: We should inform of Python changes in the Changelog or the website so there are less issues.
Related #11813