### PR TITLE
Don't consider "Downloading metadata" torrents as active

### DIFF
--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -808,8 +808,7 @@ bool TorrentHandle::isActive() const
     if (m_state == TorrentState::StalledDownloading)
         return (uploadPayloadRate() > 0);
 
-    return m_state == TorrentState::DownloadingMetadata
-            || m_state == TorrentState::Downloading
+    return m_state == TorrentState::Downloading
             || m_state == TorrentState::ForcedDownloading
             || m_state == TorrentState::Uploading
             || m_state == TorrentState::ForcedUploading


### PR DESCRIPTION
`downloadPayloadRate()` i.e. `m_nativeStatus->download_payload_rate` doesn't work for this.
Edit: apparently `m_nativeStatus->download_rate` doesn't either.

Closes #11362 and maybe #11965 if OP of that issue confirms it.