### PR TITLE
Get library version strings at runtime

### DIFF
--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -83,7 +83,7 @@ namespace
         QString envVarName() const
         {
             return QLatin1String("QBT_")
-                   + QString(QLatin1String(m_name)).toUpper().replace(QLatin1Char('-'), QLatin1Char('_'));
+                   + QString::fromLatin1(m_name).toUpper().replace(QLatin1Char('-'), QLatin1Char('_'));
         }
 
     public:

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -43,8 +43,9 @@
 #endif
 
 #include <boost/version.hpp>
-#include <openssl/opensslv.h>
 #include <libtorrent/version.hpp>
+#include <openssl/crypto.h>
+#include <openssl/opensslv.h>
 #include <zlib.h>
 
 #include <QCoreApplication>
@@ -445,29 +446,37 @@ QString Utils::Misc::boostVersionString()
 {
     // static initialization for usage in signal handler
     static const QString ver = QString("%1.%2.%3")
-                               .arg(BOOST_VERSION / 100000)
-                               .arg((BOOST_VERSION / 100) % 1000)
-                               .arg(BOOST_VERSION % 100);
+        .arg(QString::number(BOOST_VERSION / 100000)
+            , QString::number((BOOST_VERSION / 100) % 1000)
+            , QString::number(BOOST_VERSION % 100));
     return ver;
 }
 
 QString Utils::Misc::libtorrentVersionString()
 {
     // static initialization for usage in signal handler
-    static const QString ver = LIBTORRENT_VERSION;
-    return ver;
+#if (LIBTORRENT_VERSION_NUM < 10200)
+    static const auto version {QString::fromLatin1(libtorrent::version())};
+#else
+    static const auto version {QString::fromLatin1(lt::version())};
+#endif
+    return version;
 }
 
 QString Utils::Misc::opensslVersionString()
 {
-    const QString version {OPENSSL_VERSION_TEXT};
+#if (OPENSSL_VERSION_NUMBER >= 0x1010000f)
+    static const auto version {QString::fromLatin1(OpenSSL_version(OPENSSL_VERSION))};
+#else
+    static const auto version {QString::fromLatin1(SSLeay_version(SSLEAY_VERSION))};
+#endif
     return version.splitRef(' ', QString::SkipEmptyParts)[1].toString();
 }
 
 QString Utils::Misc::zlibVersionString()
 {
     // static initialization for usage in signal handler
-    static const QString version {ZLIB_VERSION};
+    static const auto version {QString::fromLatin1(zlibVersion())};
     return version;
 }
 

--- a/src/gui/executionlogwidget.cpp
+++ b/src/gui/executionlogwidget.cpp
@@ -88,7 +88,7 @@ void ExecutionLogWidget::addLogMessage(const Log::Msg &msg)
     }
 
     const QDateTime time = QDateTime::fromMSecsSinceEpoch(msg.timestamp);
-    const QString text = QString(QLatin1String("<font color='grey'>%1</font> - <font color='%2'>%3</font>"))
+    const QString text = QString::fromLatin1("<font color='grey'>%1</font> - <font color='%2'>%3</font>")
         .arg(time.toString(Qt::SystemLocaleShortDate), colorName, msg.message);
     m_msgList->appendLine(text, msg.type);
 }
@@ -96,7 +96,7 @@ void ExecutionLogWidget::addLogMessage(const Log::Msg &msg)
 void ExecutionLogWidget::addPeerMessage(const Log::Peer &peer)
 {
     const QDateTime time = QDateTime::fromMSecsSinceEpoch(peer.timestamp);
-    const QString msg = QString(QLatin1String("<font color='grey'>%1</font> - <font color='red'>%2</font>"))
+    const QString msg = QString::fromLatin1("<font color='grey'>%1</font> - <font color='red'>%2</font>")
         .arg(time.toString(Qt::SystemLocaleShortDate), peer.ip);
 
     const QString text = peer.blocked

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1525,7 +1525,7 @@ void MainWindow::reloadSessionStats()
 #else
     if (m_systrayIcon) {
 #ifdef Q_OS_UNIX
-        const QString toolTip = QString(QLatin1String(
+        const QString toolTip = QString::fromLatin1(
                 "<div style='background-color: #678db2; color: #fff;height: 18px; font-weight: bold; margin-bottom: 5px;'>"
                 "qBittorrent"
                 "</div>"
@@ -1534,7 +1534,7 @@ void MainWindow::reloadSessionStats()
                 "</div>"
                 "<div style='vertical-align: baseline; height: 18px;'>"
                 "<img src=':/icons/skin/seeding.svg' height='14'/>&nbsp;%2"
-                "</div>"))
+                "</div>")
             .arg(tr("DL speed: %1", "e.g: Download speed: 10 KiB/s").arg(Utils::Misc::friendlyUnit(status.payloadDownloadRate, true))
                  , tr("UP speed: %1", "e.g: Upload speed: 10 KiB/s").arg(Utils::Misc::friendlyUnit(status.payloadUploadRate, true)));
 #else

--- a/src/gui/statusbar.cpp
+++ b/src/gui/statusbar.cpp
@@ -64,7 +64,7 @@ StatusBar::StatusBar(QWidget *parent)
     m_connecStatusLblIcon->setCursor(Qt::PointingHandCursor);
     m_connecStatusLblIcon->setIcon(QIcon(":/icons/skin/firewalled.svg"));
     m_connecStatusLblIcon->setToolTip(
-        QString(QLatin1String("<b>%1</b><br><i>%2</i>")).arg(tr("Connection status:")
+        QString::fromLatin1("<b>%1</b><br><i>%2</i>").arg(tr("Connection status:")
             , tr("No direct connections. This may indicate network configuration problems.")));
     connect(m_connecStatusLblIcon, &QAbstractButton::clicked, this, &StatusBar::connectionButtonClicked);
 

--- a/src/gui/tagfiltermodel.cpp
+++ b/src/gui/tagfiltermodel.cpp
@@ -124,7 +124,7 @@ QVariant TagFilterModel::data(const QModelIndex &index, int role) const
     case Qt::DecorationRole:
         return UIThemeManager::instance()->getIcon("inode-directory");
     case Qt::DisplayRole:
-        return QString(QLatin1String("%1 (%2)"))
+        return QString::fromLatin1("%1 (%2)")
                .arg(tagDisplayName(item.tag())).arg(item.torrentsCount());
     case Qt::UserRole:
         return item.torrentsCount();

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -292,7 +292,7 @@ QString TransferListModel::displayValue(const BitTorrent::TorrentHandle *torrent
     {
         progress *= 100;
         return (static_cast<int>(progress) == 100)
-                ? QString {QLatin1String {"100%"}}
+                ? QString::fromLatin1("100%")
                 : Utils::String::fromDouble(progress, 1) + '%';
     };
 

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -126,7 +126,7 @@ private:
     QHash<QString, QString> m_params;
     const QString m_cacheID;
 
-    const QRegularExpression m_apiPathPattern {(QLatin1String("^/api/v2/(?<scope>[A-Za-z_][A-Za-z_0-9]*)/(?<action>[A-Za-z_][A-Za-z_0-9]*)$"))};
+    const QRegularExpression m_apiPathPattern {QLatin1String("^/api/v2/(?<scope>[A-Za-z_][A-Za-z_0-9]*)/(?<action>[A-Za-z_][A-Za-z_0-9]*)$")};
 
     QHash<QString, APIController *> m_apiControllers;
     QSet<QString> m_publicAPIs;


### PR DESCRIPTION
We mostly use boost in header-only mode, so it is a non-trivial job to get the version string at runtime.