### PR TITLE
Fix tracker responses being overwritten

### DIFF
--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -81,7 +81,6 @@ namespace BitTorrent
 
     struct TrackerInfo
     {
-        QString lastMessage;
         int numPeers = 0;
     };
 

--- a/src/base/bittorrent/trackerentry.h
+++ b/src/base/bittorrent/trackerentry.h
@@ -34,6 +34,7 @@
 #include <QtGlobal>
 
 class QString;
+class QStringList;
 
 namespace BitTorrent
 {
@@ -55,6 +56,7 @@ namespace BitTorrent
         TrackerEntry &operator=(const TrackerEntry &other) = default;
 
         QString url() const;
+        QStringList messages() const;
         Status status() const;
 
         int tier() const;

--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -365,25 +365,23 @@ void TrackerListWidget::loadTrackers()
 
         const BitTorrent::TrackerInfo data = trackerData.value(trackerURL);
 
-        switch (entry.status()) {
+        const auto status = entry.status();
+        switch (status) {
         case BitTorrent::TrackerEntry::Working:
             item->setText(COL_STATUS, tr("Working"));
-            item->setText(COL_MSG, "");
             break;
         case BitTorrent::TrackerEntry::Updating:
             item->setText(COL_STATUS, tr("Updating..."));
-            item->setText(COL_MSG, "");
             break;
         case BitTorrent::TrackerEntry::NotWorking:
             item->setText(COL_STATUS, tr("Not working"));
-            item->setText(COL_MSG, entry.messages().join(" | "));
             break;
         case BitTorrent::TrackerEntry::NotContacted:
             item->setText(COL_STATUS, tr("Not contacted yet"));
-            item->setText(COL_MSG, "");
             break;
         }
 
+        item->setText(COL_MSG, entry.messages().join(" | "));
         item->setText(COL_PEERS, QString::number(data.numPeers));
         item->setText(COL_SEEDS, ((entry.numSeeds() > -1)
             ? QString::number(entry.numSeeds())

--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -376,7 +376,7 @@ void TrackerListWidget::loadTrackers()
             break;
         case BitTorrent::TrackerEntry::NotWorking:
             item->setText(COL_STATUS, tr("Not working"));
-            item->setText(COL_MSG, data.lastMessage.trimmed());
+            item->setText(COL_MSG, entry.messages().join(" | "));
             break;
         case BitTorrent::TrackerEntry::NotContacted:
             item->setText(COL_STATUS, tr("Not contacted yet"));

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -406,9 +406,7 @@ void TorrentsController::trackersAction()
             {KEY_TRACKER_TIER, tracker.tier()},
             {KEY_TRACKER_STATUS, int(status)},
             {KEY_TRACKER_PEERS_COUNT, data.numPeers},
-            {KEY_TRACKER_MSG, ((status == BitTorrent::TrackerEntry::NotWorking)
-                               ? tracker.messages().join(" | ")
-                               : "")},
+            {KEY_TRACKER_MSG, tracker.messages().join(" | ")},
             {KEY_TRACKER_SEEDS_COUNT, tracker.numSeeds()},
             {KEY_TRACKER_LEECHES_COUNT, tracker.numLeeches()},
             {KEY_TRACKER_DOWNLOADED_COUNT, tracker.numDownloaded()}

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -398,14 +398,17 @@ void TorrentsController::trackersAction()
 
     QHash<QString, BitTorrent::TrackerInfo> trackersData = torrent->trackerInfos();
     for (const BitTorrent::TrackerEntry &tracker : asConst(torrent->trackers())) {
+        const BitTorrent::TrackerEntry::Status status = tracker.status();
         const BitTorrent::TrackerInfo data = trackersData.value(tracker.url());
 
         trackerList << QJsonObject {
             {KEY_TRACKER_URL, tracker.url()},
             {KEY_TRACKER_TIER, tracker.tier()},
-            {KEY_TRACKER_STATUS, static_cast<int>(tracker.status())},
+            {KEY_TRACKER_STATUS, int(status)},
             {KEY_TRACKER_PEERS_COUNT, data.numPeers},
-            {KEY_TRACKER_MSG, data.lastMessage.trimmed()},
+            {KEY_TRACKER_MSG, ((status == BitTorrent::TrackerEntry::NotWorking)
+                               ? tracker.messages().join(" | ")
+                               : "")},
             {KEY_TRACKER_SEEDS_COUNT, tracker.numSeeds()},
             {KEY_TRACKER_LEECHES_COUNT, tracker.numLeeches()},
             {KEY_TRACKER_DOWNLOADED_COUNT, tracker.numDownloaded()}


### PR DESCRIPTION
Some endpoints might fail without any meaningful message while others
could have reported more info. For example IPv6 endpoint might actually
fail to even contact tracker, while IPv4 endpoint have already returned
tracker response which we do not want to overwrite. Before this commit
there were race condition. Endpoint which reported last had its message
shown. In many cases this resulted in tracker response being lost,
overwritten by empty string from errored out endpoint.

Also apart from showing only tracker responses, if none of the endpoints
reported any message, show actual endpoint error message.

All distinct messages for endpoints will be shown. In practice this will
be one message from tracker or endpoint error messages.