### PR TITLE
Add UPnP lease duration advanced option

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -402,6 +402,7 @@ Session::Session(QObject *parent)
     , m_slowTorrentsInactivityTimer(BITTORRENT_SESSION_KEY("SlowTorrentsInactivityTimer"), 60)
     , m_outgoingPortsMin(BITTORRENT_SESSION_KEY("OutgoingPortsMin"), 0)
     , m_outgoingPortsMax(BITTORRENT_SESSION_KEY("OutgoingPortsMax"), 0)
+    , m_UPnPLeaseDuration(BITTORRENT_SESSION_KEY("UPnPLeaseDuration"), 0)
     , m_ignoreLimitsOnLAN(BITTORRENT_SESSION_KEY("IgnoreLimitsOnLAN"), false)
     , m_includeOverheadInLimits(BITTORRENT_SESSION_KEY("IncludeOverheadInLimits"), false)
     , m_announceIP(BITTORRENT_SESSION_KEY("AnnounceIP"))
@@ -1366,6 +1367,10 @@ void Session::loadLTSettings(lt::settings_pack &settingsPack)
     // Outgoing ports
     settingsPack.set_int(lt::settings_pack::outgoing_port, outgoingPortsMin());
     settingsPack.set_int(lt::settings_pack::num_outgoing_ports, outgoingPortsMax() - outgoingPortsMin() + 1);
+
+#if (LIBTORRENT_VERSION_NUM >= 10206)
+    settingsPack.set_int(lt::settings_pack::upnp_lease_duration, UPnPLeaseDuration());
+#endif
 
     // Include overhead in transfer limits
     settingsPack.set_bool(lt::settings_pack::rate_limit_ip_overhead, includeOverheadInLimits());
@@ -3550,6 +3555,19 @@ void Session::setOutgoingPortsMax(const int max)
 {
     if (max != m_outgoingPortsMax) {
         m_outgoingPortsMax = max;
+        configureDeferred();
+    }
+}
+
+int Session::UPnPLeaseDuration() const
+{
+    return m_UPnPLeaseDuration;
+}
+
+void Session::setUPnPLeaseDuration(const int duration)
+{
+    if (duration != m_UPnPLeaseDuration) {
+        m_UPnPLeaseDuration = duration;
         configureDeferred();
     }
 }

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -367,6 +367,8 @@ namespace BitTorrent
         void setOutgoingPortsMin(int min);
         int outgoingPortsMax() const;
         void setOutgoingPortsMax(int max);
+        int UPnPLeaseDuration() const;
+        void setUPnPLeaseDuration(int duration);
         bool ignoreLimitsOnLAN() const;
         void setIgnoreLimitsOnLAN(bool ignore);
         bool includeOverheadInLimits() const;
@@ -647,6 +649,7 @@ namespace BitTorrent
         CachedSettingValue<int> m_slowTorrentsInactivityTimer;
         CachedSettingValue<int> m_outgoingPortsMin;
         CachedSettingValue<int> m_outgoingPortsMax;
+        CachedSettingValue<int> m_UPnPLeaseDuration;
         CachedSettingValue<bool> m_ignoreLimitsOnLAN;
         CachedSettingValue<bool> m_includeOverheadInLimits;
         CachedSettingValue<QString> m_announceIP;

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -103,6 +103,9 @@ enum AdvSettingsRows
     SOCKET_BACKLOG_SIZE,
     OUTGOING_PORT_MIN,
     OUTGOING_PORT_MAX,
+#if (LIBTORRENT_VERSION_NUM >= 10206)
+    UPNP_LEASE_DURATION,
+#endif
     UTP_MIX_MODE,
     MULTI_CONNECTIONS_PER_IP,
     // embedded tracker
@@ -205,6 +208,10 @@ void AdvancedSettings::saveAdvancedSettings()
     // Outgoing ports
     session->setOutgoingPortsMin(m_spinBoxOutgoingPortsMin.value());
     session->setOutgoingPortsMax(m_spinBoxOutgoingPortsMax.value());
+#if (LIBTORRENT_VERSION_NUM >= 10206)
+    // UPnP lease duration
+    session->setUPnPLeaseDuration(m_spinBoxUPnPLeaseDuration.value());
+#endif
     // uTP-TCP mixed mode
     session->setUtpMixedMode(static_cast<BitTorrent::MixedModeAlgorithm>(m_comboBoxUtpMixedMode.currentIndex()));
     // multiple connections per IP
@@ -476,6 +483,15 @@ void AdvancedSettings::loadAdvancedSettings()
     m_spinBoxOutgoingPortsMax.setMaximum(65535);
     m_spinBoxOutgoingPortsMax.setValue(session->outgoingPortsMax());
     addRow(OUTGOING_PORT_MAX, tr("Outgoing ports (Max) [0: Disabled]"), &m_spinBoxOutgoingPortsMax);
+#if (LIBTORRENT_VERSION_NUM >= 10206)
+    // UPnP lease duration
+    m_spinBoxUPnPLeaseDuration.setMinimum(0);
+    m_spinBoxUPnPLeaseDuration.setMaximum(std::numeric_limits<int>::max());
+    m_spinBoxUPnPLeaseDuration.setValue(session->UPnPLeaseDuration());
+    m_spinBoxUPnPLeaseDuration.setSuffix(tr(" s", " seconds"));
+    addRow(UPNP_LEASE_DURATION, (tr("UPnP lease duration [0: Permanent lease]") + ' ' + makeLink("https://www.libtorrent.org/reference-Settings.html#upnp_lease_duration", "(?)"))
+        , &m_spinBoxUPnPLeaseDuration);
+#endif
     // uTP-TCP mixed mode
     m_comboBoxUtpMixedMode.addItems({tr("Prefer TCP"), tr("Peer proportional (throttles TCP)")});
     m_comboBoxUtpMixedMode.setCurrentIndex(static_cast<int>(session->utpMixedMode()));

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -58,8 +58,8 @@ private:
     template <typename T> void addRow(int row, const QString &text, T *widget);
 
     QSpinBox m_spinBoxAsyncIOThreads, m_spinBoxFilePoolSize, m_spinBoxCheckingMemUsage, m_spinBoxCache,
-             m_spinBoxSaveResumeDataInterval, m_spinBoxOutgoingPortsMin, m_spinBoxOutgoingPortsMax, m_spinBoxListRefresh,
-             m_spinBoxTrackerPort, m_spinBoxCacheTTL, m_spinBoxSendBufferWatermark, m_spinBoxSendBufferLowWatermark,
+             m_spinBoxSaveResumeDataInterval, m_spinBoxOutgoingPortsMin, m_spinBoxOutgoingPortsMax, m_spinBoxUPnPLeaseDuration,
+             m_spinBoxListRefresh, m_spinBoxTrackerPort, m_spinBoxCacheTTL, m_spinBoxSendBufferWatermark, m_spinBoxSendBufferLowWatermark,
              m_spinBoxSendBufferWatermarkFactor, m_spinBoxSocketBacklogSize, m_spinBoxStopTrackerTimeout, m_spinBoxSavePathHistoryLength;
     QCheckBox m_checkBoxOsCache, m_checkBoxRecheckCompleted, m_checkBoxResolveCountries, m_checkBoxResolveHosts, m_checkBoxSuperSeeding,
               m_checkBoxProgramNotifications, m_checkBoxTorrentAddedNotifications, m_checkBoxTrackerFavicon, m_checkBoxTrackerStatus,

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -296,6 +296,8 @@ void AppController::preferencesAction()
     // Outgoing ports
     data["outgoing_ports_min"] = session->outgoingPortsMin();
     data["outgoing_ports_max"] = session->outgoingPortsMax();
+    // UPnP lease duration
+    data["upnp_lease_duration"] = session->UPnPLeaseDuration();
     // uTP-TCP mixed mode
     data["utp_tcp_mixed_mode"] = static_cast<int>(session->utpMixedMode());
     // Multiple connections per IP
@@ -717,6 +719,9 @@ void AppController::setPreferencesAction()
         session->setOutgoingPortsMin(it.value().toInt());
     if (hasKey("outgoing_ports_max"))
         session->setOutgoingPortsMax(it.value().toInt());
+    // UPnP lease duration
+    if (hasKey("upnp_lease_duration"))
+        session->setUPnPLeaseDuration(it.value().toInt());
     // uTP-TCP mixed mode
     if (hasKey("utp_tcp_mixed_mode"))
         session->setUtpMixedMode(static_cast<BitTorrent::MixedModeAlgorithm>(it.value().toInt()));

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1001,6 +1001,14 @@
             </tr>
             <tr>
                 <td>
+                    <label for="UPnPLeaseDuration">QBT_TR(UPnP lease duration [0: Permanent lease]:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#upnp_lease_duration" target="_blank">(?)</a></label>
+                </td>
+                <td>
+                    <input type="text" id="UPnPLeaseDuration" style="width: 15em;" />
+                </td>
+            </tr>
+            <tr>
+                <td>
                     <label for="utpTCPMixedModeAlgorithm">QBT_TR(μTP-TCP mixed mode algorithm:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#mixed_mode_algorithm" target="_blank">(?)</a></label>
                 </td>
                 <td>


### PR DESCRIPTION
This is a new setting added that is pending addition to
libtorrent 1.2.6. This setting is important because some routers do
not support expiration times on port-maps and do not return an error
either, silently failing. The previous default of permanent leases is
retained.