### PR TITLE
Allow other keypresses in LogListWidget

### DIFF
--- a/src/gui/loglistwidget.cpp
+++ b/src/gui/loglistwidget.cpp
@@ -72,8 +72,8 @@ void LogListWidget::keyPressEvent(QKeyEvent *event)
 {
     if (event->matches(QKeySequence::Copy))
         copySelection();
-    else if (event->matches(QKeySequence::SelectAll))
-        selectAll();
+    else
+        QListWidget::keyPressEvent(event);
 }
 
 void LogListWidget::appendLine(const QString &line, const Log::MsgType &type)


### PR DESCRIPTION
By not emitting the native signal, all other keypresses other than
the copy and select keysequences are ignored. This should reallow
keyboard navigation within LogListWidget objects.

Closes #12172.