### PR TITLE
Rely on Qt ownership to free resources

### DIFF
--- a/src/base/net/private/downloadhandlerimpl.cpp
+++ b/src/base/net/private/downloadhandlerimpl.cpp
@@ -64,11 +64,6 @@ DownloadHandlerImpl::DownloadHandlerImpl(Net::DownloadManager *manager, const Ne
     m_result.status = Net::DownloadStatus::Success;
 }
 
-DownloadHandlerImpl::~DownloadHandlerImpl()
-{
-    delete m_reply;
-}
-
 void DownloadHandlerImpl::cancel()
 {
     if (m_reply) {
@@ -83,6 +78,7 @@ void DownloadHandlerImpl::cancel()
 void DownloadHandlerImpl::assignNetworkReply(QNetworkReply *reply)
 {
     Q_ASSERT(reply);
+    Q_ASSERT(!m_reply);
 
     m_reply = reply;
     m_reply->setParent(this);

--- a/src/base/net/private/downloadhandlerimpl.h
+++ b/src/base/net/private/downloadhandlerimpl.h
@@ -43,7 +43,6 @@ class DownloadHandlerImpl : public Net::DownloadHandler
 
 public:
     DownloadHandlerImpl(Net::DownloadManager *manager, const Net::DownloadRequest &downloadRequest);
-    ~DownloadHandlerImpl() override;
 
     void cancel() override;
 


### PR DESCRIPTION
The m_reply has already changed parent in `DownloadHandlerImpl::assignNetworkReply()` and thus we can rely on Qt ownership to delete the object.