### PR TITLE
Don't round scaling factor

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -136,6 +136,9 @@ int main(int argc, char *argv[])
     // Attribute Qt::AA_EnableHighDpiScaling must be set before QCoreApplication is created
     if (qgetenv("QT_ENABLE_HIGHDPI_SCALING").isEmpty() && qgetenv("QT_AUTO_SCREEN_SCALE_FACTOR").isEmpty())
         Application::setAttribute(Qt::AA_EnableHighDpiScaling, true);
+    // HighDPI scale factor policy must be set before QGuiApplication is created
+    if (qgetenv("QT_SCALE_FACTOR_ROUNDING_POLICY").isEmpty())
+        Application::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
 #endif
 
     try {


### PR DESCRIPTION
Qt 5.14 introduced new feature related to HighDPI screens support,
this parameter is called "scale factor rounding policy", and it is
intended to improve fractional scale factor support (like 150%).
Qt::PassThrough value guarantee that no any rounding will applied to
scale factor, and will be used as is.

this is continuation and fixup of #12102 , based on https://github.com/qbittorrent/qBittorrent/issues/12248#issuecomment-603563053 and https://github.com/qbittorrent/qBittorrent/pull/12102#issuecomment-603625682
unfortunately, [documentation](https://doc.qt.io/qt-5/qt.html#HighDpiScaleFactorRoundingPolicy-enum) lies slightly, required values type is not just `enum`, it is [`enum class`](https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/global/qnamespace.h?h=v5.14.1#n1757), so such long construction must be used...

Fixes #12248 