### PR TITLE
Initialize struct variables

### DIFF
--- a/src/base/net/private/geoipdatabase.cpp
+++ b/src/base/net/private/geoipdatabase.cpp
@@ -64,10 +64,10 @@ namespace
 
 struct DataFieldDescriptor
 {
-    DataType fieldType;
+    DataType fieldType {DataType::Unknown};
     union
     {
-        quint32 fieldSize;
+        quint32 fieldSize = 0;
         quint32 offset; // Pointer
     };
 };


### PR DESCRIPTION
clang static analyzer was emitting some warning about uninitialized variable usage and this patch fixes it. IMO it is a good idea to have default values anyway.