### PR TITLE
Better Python path detection on Windows

### DIFF
--- a/src/base/utils/foreignapps.cpp
+++ b/src/base/utils/foreignapps.cpp
@@ -190,9 +190,17 @@ namespace
                     path = getRegValue(hkInstallPath);
                     ::RegCloseKey(hkInstallPath);
 
-                    if (!path.isEmpty() && QDir(path).exists("python.exe")) {
-                        found = true;
-                        path = QDir(path).filePath("python.exe");
+                    if (!path.isEmpty()) {
+                        const QDir baseDir {path};
+
+                        if (baseDir.exists("python3.exe")) {
+                            found = true;
+                            path = baseDir.filePath("python3.exe");
+                        }
+                        else if (baseDir.exists("python.exe")) {
+                            found = true;
+                            path = baseDir.filePath("python.exe");
+                        }
                     }
                 }
             }
@@ -223,9 +231,13 @@ namespace
         // Fallback: Detect python from default locations
         const QFileInfoList dirs = QDir("C:/").entryInfoList({"Python*"}, QDir::Dirs, (QDir::Name | QDir::Reversed));
         for (const QFileInfo &info : dirs) {
-            const QString path {info.absolutePath() + "/python.exe"};
-            if (QFile::exists(path))
-                return path;
+            const QString py3Path {info.absolutePath() + "/python3.exe"};
+            if (QFile::exists(py3Path))
+                return py3Path;
+
+            const QString pyPath {info.absolutePath() + "/python.exe"};
+            if (QFile::exists(pyPath))
+                return pyPath;
         }
 
         return {};
@@ -247,14 +259,9 @@ PythonInfo Utils::ForeignApps::pythonInfo()
 {
     static PythonInfo pyInfo;
     if (!pyInfo.isValid()) {
-#if defined(Q_OS_UNIX)
-        // On Unix-Like systems python3 should always exist
-        // https://www.python.org/dev/peps/pep-0394/
         if (testPythonInstallation("python3", pyInfo))
             return pyInfo;
-#endif
-        // Look for "python" in Windows and in UNIX if "python3" is
-        // not detected.
+
         if (testPythonInstallation("python", pyInfo))
             return pyInfo;
 


### PR DESCRIPTION
This PR modifies the functions that look for the path of the Python executable on Windows by adding a special case for when both Python 2 and Python 3 are installed on the system*. In such environments, it's very common that `python` will point to the Python 2 executable and `python3` will, of course, point to Python 3. In the past, the function would only look for `python.exe` files, hence trying to use the unsupported Python 2 executable.

This PR introduces the following changes:
 - After querying the Python path from the registry, it will first try to look for `python3.exe`. If it can't find it, it will look for `python.exe`.
 - Same thing happens when looking into the `C:/Python*` folder
 - `Utils::ForeignApps::pythonInfo()` will first try to retrieve the location of the Python executable from the registry, and only then call `testPythonInstallation()` on `python`**

It would be nice if this got merged/fixed, since I can't use search engines right now because of this issue :) 

*) An example scenario for this is when you develop software in both Python and Node.js. You'd probably want to write Python 3 compatible programs, but at the same time, some Node.js dependencies rely on Python 2 for building binaries (I know, it's dumb, and I wish it wasn't like that). Python 3 on Windows will install the executable as `python.exe` by default, but this breaks some Node.js binary builds, so you'd have to have both versions installed and rename the Python 3 executable to `python3.exe`.

**) I wasn't sure if I should just remove the condition for UNIX systems (since `pythonInfo()` looks for `python3` in the PATH first in that case) or make the function check the registry first, since I feel like this is a change that the maintainers might want to decide upon. I went with registry, but I can change it upon feedback.