### PR TITLE
Fix logs not clearly visible for custom styles

### DIFF
--- a/src/gui/loglistwidget.cpp
+++ b/src/gui/loglistwidget.cpp
@@ -68,6 +68,11 @@ void LogListWidget::showMsgTypes(const Log::MsgTypes &types)
     }
 }
 
+int LogListWidget::sizeHintForRow(const int) const
+{
+    return m_maxRowHeight;
+}
+
 void LogListWidget::keyPressEvent(QKeyEvent *event)
 {
     if (event->matches(QKeySequence::Copy))
@@ -82,9 +87,9 @@ void LogListWidget::appendLine(const QString &line, const Log::MsgType &type)
     auto *lbl = new QLabel(line);
     lbl->setTextFormat(Qt::RichText);
     lbl->setContentsMargins(4, 2, 4, 2);
+    m_maxRowHeight = std::max(m_maxRowHeight, lbl->height());
 
     auto *item = new QListWidgetItem;
-    item->setSizeHint(lbl->sizeHint());
     item->setData(Qt::UserRole, type);
     insertItem(0, item);
     setItemWidget(item, lbl);

--- a/src/gui/loglistwidget.h
+++ b/src/gui/loglistwidget.h
@@ -53,8 +53,11 @@ protected:
     void keyPressEvent(QKeyEvent *event) override;
 
 private:
+    int sizeHintForRow(int row) const override;
+    
     const int m_maxLines;
     Log::MsgTypes m_types;
+    int m_maxRowHeight = -1;
 };
 
 #endif // LOGLISTWIDGET_H


### PR DESCRIPTION
until https://github.com/qbittorrent/qBittorrent/pull/12144 is accepted....

before
![image](https://user-images.githubusercontent.com/34717789/77878334-b4e70300-7275-11ea-8dbc-5d2ddb24edc6.png)

After
![image](https://user-images.githubusercontent.com/34717789/77878351-be706b00-7275-11ea-85dd-8c68a9c11caf.png)
![image](https://user-images.githubusercontent.com/34717789/77879269-a863aa00-7277-11ea-8e71-437c33d93d9e.png)



This way it even respects sizes from the stylesheets

