### PR TITLE
Avoid holding entire file in memory

### DIFF
--- a/src/base/bittorrent/torrentcreatorthread.cpp
+++ b/src/base/bittorrent/torrentcreatorthread.cpp
@@ -182,20 +182,10 @@ void TorrentCreatorThread::run()
         if (isInterruptionRequested()) return;
 
         // create the torrent
-        std::ofstream outfile(
-#ifdef _MSC_VER
-            Utils::Fs::toNativePath(m_params.savePath).toStdWString().c_str()
-#else
-            Utils::Fs::toNativePath(m_params.savePath).toUtf8().constData()
-#endif
-            , (std::ios_base::out | std::ios_base::binary | std::ios_base::trunc));
-        if (outfile.fail())
+        QFile outfile {m_params.savePath};
+        if (!outfile.open(QIODevice::WriteOnly))
             throw std::runtime_error(tr("create new torrent file failed").toStdString());
-
-        if (isInterruptionRequested()) return;
-
-        lt::bencode(std::ostream_iterator<char>(outfile), entry);
-        outfile.close();
+        lt::bencode(Utils::Fs::FileOutputIterator {outfile}, entry);
 
         emit updateProgress(100);
         emit creationSuccess(m_params.savePath, parentPath);

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -166,13 +166,10 @@ void TorrentInfo::saveToFile(const QString &path) const
 #endif
     const lt::entry torrentEntry = torrentCreator.generate();
 
-    QByteArray out;
-    out.reserve(1024 * 1024);  // most torrent file sizes are under 1 MB
-    lt::bencode(std::back_inserter(out), torrentEntry);
-
-    QFile torrentFile{path};
-    if (!torrentFile.open(QIODevice::WriteOnly) || (torrentFile.write(out) != out.size()))
+    QFile torrentFile {path};
+    if (!torrentFile.open(QIODevice::WriteOnly))
         throw RuntimeError {torrentFile.errorString()};
+    lt::bencode(Utils::Fs::FileOutputIterator {torrentFile}, torrentEntry);
 }
 
 bool TorrentInfo::isValid() const

--- a/src/base/utils/fs.cpp
+++ b/src/base/utils/fs.cpp
@@ -54,11 +54,50 @@
 #include <QDirIterator>
 #include <QFile>
 #include <QFileInfo>
+#include <QIODevice>
 #include <QStorageInfo>
 #include <QRegularExpression>
 
 #include "base/bittorrent/torrenthandle.h"
 #include "base/global.h"
+
+Utils::Fs::FileOutputIterator::FileOutputIterator(QIODevice &device, const int bufferSize)
+    : m_device {device}
+    , m_bufferSize {bufferSize}
+{
+    m_buffer.reserve(m_bufferSize);
+}
+
+Utils::Fs::FileOutputIterator::~FileOutputIterator()
+{
+    m_device.write(m_buffer);
+    m_buffer.clear();
+}
+
+Utils::Fs::FileOutputIterator &Utils::Fs::FileOutputIterator::operator=(const char c)
+{
+    m_buffer.append(c);
+    if (m_buffer.size() >= m_bufferSize) {
+        m_device.write(m_buffer);
+        m_buffer.clear();
+    }
+    return *this;
+}
+
+Utils::Fs::FileOutputIterator &Utils::Fs::FileOutputIterator::operator*()
+{
+    return *this;
+}
+
+Utils::Fs::FileOutputIterator &Utils::Fs::FileOutputIterator::operator++()
+{
+    return *this;
+}
+
+Utils::Fs::FileOutputIterator &Utils::Fs::FileOutputIterator::operator++(int)
+{
+    return *this;
+}
 
 QString Utils::Fs::toNativePath(const QString &path)
 {

--- a/src/base/utils/fs.h
+++ b/src/base/utils/fs.h
@@ -33,12 +33,38 @@
  * Utility functions related to file system.
  */
 
+#include <iterator>
+
+#include <QByteArray>
 #include <QString>
+
+class QIODevice;
 
 namespace Utils
 {
     namespace Fs
     {
+        // A wrapper class that satisfy LegacyOutputIterator requirement
+        class FileOutputIterator
+            : public std::iterator<std::output_iterator_tag, void, void, void, void>
+        {
+        public:
+            explicit FileOutputIterator(QIODevice &device, const int bufferSize = (4 * 1024));
+            ~FileOutputIterator();
+
+            // mimic std::ostream_iterator behavior
+            FileOutputIterator &operator=(const char c);
+            // TODO: make these `constexpr` in C++17
+            FileOutputIterator &operator*();
+            FileOutputIterator &operator++();
+            FileOutputIterator &operator++(int);
+
+        private:
+            QIODevice &m_device;
+            QByteArray m_buffer;
+            const int m_bufferSize;
+        };
+
         /**
          * Converts a path to a string suitable for display.
          * This function makes sure the directory separator used is consistent


### PR DESCRIPTION
Previously we need a file buffer that is as large as the file size and this could be a problem when user has less free memory available or having very large data. Now with the help of `FileOutputIterator`,
we can have a much smaller, fixed size immediate file buffer and also the code looks nice with `lt::bencode()`.