### PR TITLE
Fix mismatch ID

### DIFF
--- a/src/webui/www/private/views/installsearchplugin.html
+++ b/src/webui/www/private/views/installsearchplugin.html
@@ -1,4 +1,4 @@
-<style type="text/css">
+<style>
     #installSearchPluginContainer {
         margin: 10px;
     }

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -7,11 +7,11 @@
         </div>
         <div class="formRow">
             <input type="checkbox" id="dontstartdownloads_checkbox" />
-            <label for="dontstartauto_checkbox">QBT_TR(Do not start the download automatically)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="dontstartdownloads_checkbox">QBT_TR(Do not start the download automatically)QBT_TR[CONTEXT=OptionsDialog]</label>
         </div>
         <div class="formRow">
             <input type="checkbox" id="deletetorrentfileafter_checkbox" />
-            <label for="deletetorrentafter_checkbox">QBT_TR(Delete .torrent files afterwards)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="deletetorrentfileafter_checkbox">QBT_TR(Delete .torrent files afterwards)QBT_TR[CONTEXT=OptionsDialog]</label>
         </div>
     </fieldset>
 

--- a/src/webui/www/private/views/search.html
+++ b/src/webui/www/private/views/search.html
@@ -1,4 +1,4 @@
-<style type="text/css">
+<style>
     #searchPattern {
         width: 500px;
         line-height: 2em;

--- a/src/webui/www/private/views/searchplugins.html
+++ b/src/webui/www/private/views/searchplugins.html
@@ -1,4 +1,4 @@
-<style type="text/css">
+<style>
     #searchPluginsContainer {
         height: calc(100% - 20px);
         margin: 10px;


### PR DESCRIPTION
* Fix mismatch ID
* Remove redundant type attribute
  It already defaults to `text/css` if value is absent (in HTML5).

