### PR TITLE
Add Torrent Creator to Webui

### DIFF
--- a/src/webui/CMakeLists.txt
+++ b/src/webui/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(qbt_webui STATIC
 # headers
 api/apicontroller.h
 api/apierror.h
+api/apitorrentcreatorthread.h
 api/appcontroller.h
 api/authcontroller.h
 api/freediskspacechecker.h
@@ -19,6 +20,7 @@ webui.h
 # sources
 api/apicontroller.cpp
 api/apierror.cpp
+api/apitorrentcreatorthread.cpp
 api/appcontroller.cpp
 api/authcontroller.cpp
 api/freediskspacechecker.cpp

--- a/src/webui/api/apitorrentcreatorthread.cpp
+++ b/src/webui/api/apitorrentcreatorthread.cpp
@@ -1,0 +1,82 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2020  Nicolas Peugnet <n.peugnet@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "apitorrentcreatorthread.h"
+
+APITorrentCreatorThread::APITorrentCreatorThread(int creatorId, QObject *parent)
+    : BitTorrent::TorrentCreatorThread(parent), m_id(creatorId)
+{
+    connect(this, &BitTorrent::TorrentCreatorThread::creationSuccess, this, &APITorrentCreatorThread::forwardCreationSuccess);
+    connect(this, &BitTorrent::TorrentCreatorThread::creationFailure, this, &APITorrentCreatorThread::forwardCreationFailure);
+    connect(this, &BitTorrent::TorrentCreatorThread::updateProgress, this, &APITorrentCreatorThread::forwardUpdateProgress);
+}
+
+void APITorrentCreatorThread::forwardCreationSuccess(const QString &path, const QString &branchPath)
+{
+    struct TorrentCreatorStatus status
+    {
+        true
+        , false
+        , 100
+        , path
+        , branchPath
+        , QString()
+        , this
+    };
+    emit creationUpdate(m_id, status);
+}
+
+void APITorrentCreatorThread::forwardCreationFailure(const QString &msg)
+{
+    struct TorrentCreatorStatus status
+    {
+        false
+        , true
+        , 0
+        , QString()
+        , QString()
+        , msg
+        , this
+    };
+    emit creationUpdate(m_id, status);
+}
+
+void APITorrentCreatorThread::forwardUpdateProgress(int progress)
+{
+    struct TorrentCreatorStatus status
+    {
+        false
+        , false
+        , progress
+        , QString()
+        , QString()
+        , QString()
+        , this
+    };
+    emit creationUpdate(m_id, status);
+}

--- a/src/webui/api/apitorrentcreatorthread.h
+++ b/src/webui/api/apitorrentcreatorthread.h
@@ -1,0 +1,61 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2020  Nicolas Peugnet <n.peugnet@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+#include "base/bittorrent/torrentcreatorthread.h"
+
+struct TorrentCreatorStatus
+{
+    bool success;
+    bool failure;
+    int progress;
+    QString path;
+    QString branchPath;
+    QString msg;
+    QThread *thread;
+};
+
+class APITorrentCreatorThread : public BitTorrent::TorrentCreatorThread
+{
+    Q_OBJECT
+
+public:
+    explicit APITorrentCreatorThread(int creatorId, QObject *parent = nullptr);
+
+signals:
+    void creationUpdate(int creatorId, const struct TorrentCreatorStatus &status);
+
+private slots:
+    void forwardCreationFailure(const QString &msg);
+    void forwardCreationSuccess(const QString &path, const QString &branchPath);
+    void forwardUpdateProgress(int progress);
+
+private:
+    int m_id;
+};

--- a/src/webui/api/torrentscontroller.h
+++ b/src/webui/api/torrentscontroller.h
@@ -29,6 +29,11 @@
 #pragma once
 
 #include "apicontroller.h"
+#include "apitorrentcreatorthread.h"
+
+struct ISessionManager;
+
+class QMutex;
 
 class TorrentsController : public APIController
 {
@@ -37,6 +42,9 @@ class TorrentsController : public APIController
 
 public:
     using APIController::APIController;
+
+    explicit TorrentsController(ISessionManager *sessionManager, QObject *parent = nullptr);
+    ~TorrentsController() override;
 
 private slots:
     void infoAction();
@@ -61,6 +69,9 @@ private slots:
     void createTagsAction();
     void deleteTagsAction();
     void tagsAction();
+    void createAction();
+    void creatorStatusAction();
+    void torrentCreationUpdated(int creatorId, const struct TorrentCreatorStatus &status);
     void addAction();
     void deleteAction();
     void addTrackersAction();
@@ -84,4 +95,9 @@ private slots:
     void toggleSequentialDownloadAction();
     void toggleFirstLastPiecePrioAction();
     void renameFileAction();
+
+private:
+    int m_torrentCreatorCount = 0;
+    QHash<int, struct TorrentCreatorStatus> m_torrentCreatorStatus;
+    mutable QMutex *m_torrentCreatorStatusMutex;
 };

--- a/src/webui/webui.pri
+++ b/src/webui/webui.pri
@@ -1,6 +1,7 @@
 HEADERS += \
     $$PWD/api/apicontroller.h \
     $$PWD/api/apierror.h \
+    $$PWD/api/apitorrentcreatorthread.h \
     $$PWD/api/appcontroller.h \
     $$PWD/api/authcontroller.h \
     $$PWD/api/freediskspacechecker.h \
@@ -18,6 +19,7 @@ HEADERS += \
 SOURCES += \
     $$PWD/api/apicontroller.cpp \
     $$PWD/api/apierror.cpp \
+    $$PWD/api/apitorrentcreatorthread.cpp \
     $$PWD/api/appcontroller.cpp \
     $$PWD/api/authcontroller.cpp \
     $$PWD/api/freediskspacechecker.cpp \


### PR DESCRIPTION
Hi, I started to add the torrent creator to the Webui. It is still far from finished, but as it requires a fair amount of changes in the WebAPI I thought it would be better to start the pull request early so that you could help me design the API.

Also I am not very experienced in c++ and this is my first time contributing to such a big project so I used [this previous commit](https://github.com/qbittorrent/qBittorrent/commit/2aea235e343f3c1b3d00273872d5944b25ed6f1e) as an inspiration.

For now I have added 2 endpoints:

- `torrents/create` with the following parameters:

  - `isPrivate` bool
  - `isAlignmentOptimized` bool
  - `piecesSize` int
  - `paddedFileSizeLimit` int
  - `inputPath` string
  - `savePath` string
  - `comment` string
  - `source` string
  - `trackers` string
  - `urlSeeds` string

  and with a JSON return of this form, where `id` is the id of the TorrentCreatorTread:
  ```json
  {
      "id": 0
  }
  ```

- `torrents/creatorStatus` with the following parameters:

  - `id` int

  and with a JSON return of this form:
  ```json
  {
      "branchPath": "/home/nicolas/Videos/test/",
      "failure": false,
      "msg": "",
      "path": "/home/nicolas/Videos/test/test.torrent",
      "progress": 100,
      "success": true
  }
  ```

For now my idea was that the webui would poll the second endpoint to check for status updates. Maybe the `SyncController` would have been a better place.

I also thought about adding another API call to destroy the creatorStatus entry and its associated thread.

I will add the Torrent Creator window to the webui once the API is ready.

I am totally open to every suggestions as I believe what I have done is far from perfect.