### PR TITLE
Fix sub-sorting of Transfer list

### DIFF
--- a/src/gui/transferlistsortmodel.cpp
+++ b/src/gui/transferlistsortmodel.cpp
@@ -96,7 +96,7 @@ bool TransferListSortModel::lessThan_impl(const QModelIndex &left, const QModelI
 
     const auto invokeLessThanForColumn = [this, &left, &right](const int column) -> bool
     {
-        return lessThan_impl(left.sibling(left.row(), column), right.sibling(left.row(), column));
+        return lessThan_impl(left.sibling(left.row(), column), right.sibling(right.row(), column));
     };
 
     const int sortColumn = left.column();


### PR DESCRIPTION
Closes #12330.

Just a damn typo! Strange that no one had noticed this before... Apparently, sub-sorting isn't so popular.