### PR TITLE
Fix wrong logic that disables "prevent sleeping" timer

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1454,8 +1454,11 @@ void MainWindow::loadPreferences(const bool configureSession)
 
     showStatusBar(pref->isStatusbarDisplayed());
 
-    if ((pref->preventFromSuspendWhenDownloading() || pref->preventFromSuspendWhenSeeding()) && !m_preventTimer->isActive()) {
-        m_preventTimer->start(PREVENT_SUSPEND_INTERVAL);
+    if (pref->preventFromSuspendWhenDownloading() || pref->preventFromSuspendWhenSeeding()) {
+        if (!m_preventTimer->isActive()) {
+            updatePowerManagementState();
+            m_preventTimer->start(PREVENT_SUSPEND_INTERVAL);
+        }
     }
     else {
         m_preventTimer->stop();

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -28,6 +28,8 @@
 
 #include "mainwindow.h"
 
+#include <chrono>
+
 #include <QCloseEvent>
 #include <QDebug>
 #include <QDesktopServices>
@@ -99,9 +101,6 @@
 #include "programupdater.h"
 #endif
 
-#define TIME_TRAY_BALLOON 5000
-#define PREVENT_SUSPEND_INTERVAL 60000
-
 namespace
 {
 #define SETTINGS_KEY(name) "GUI/" name
@@ -118,6 +117,9 @@ namespace
 
     // Misc
     const QString KEY_DOWNLOAD_TRACKER_FAVICON = QStringLiteral(SETTINGS_KEY("DownloadTrackerFavicon"));
+
+    const int TIME_TRAY_BALLOON = 5000;
+    const std::chrono::seconds PREVENT_SUSPEND_INTERVAL {60};
 
     // just a shortcut
     inline SettingsStorage *settings()
@@ -776,8 +778,9 @@ void MainWindow::cleanup()
     if (m_systrayCreator)
         m_systrayCreator->stop();
 #endif
-    if (m_preventTimer)
-        m_preventTimer->stop();
+
+    m_preventTimer->stop();
+
 #if (defined(Q_OS_WIN) || defined(Q_OS_MACOS))
     m_programUpdateTimer->stop();
 #endif
@@ -1401,7 +1404,7 @@ void MainWindow::showStatusBar(bool show)
     }
 }
 
-void MainWindow::loadPreferences(bool configureSession)
+void MainWindow::loadPreferences(const bool configureSession)
 {
     Logger::instance()->addMessage(tr("Options were saved successfully."));
     const Preferences *const pref = Preferences::instance();

--- a/src/gui/powermanagement/powermanagement.cpp
+++ b/src/gui/powermanagement/powermanagement.cpp
@@ -30,10 +30,6 @@
 
 #include <QtGlobal>
 
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)) && defined(QT_DBUS_LIB)
-#include "powermanagement_x11.h"
-#endif
-
 #ifdef Q_OS_MACOS
 #include <IOKit/pwr_mgt/IOPMLib.h>
 #endif
@@ -42,9 +38,12 @@
 #include <windows.h>
 #endif
 
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)) && defined(QT_DBUS_LIB)
+#include "powermanagement_x11.h"
+#endif
+
 PowerManagement::PowerManagement(QObject *parent)
     : QObject(parent)
-    , m_busy(false)
 {
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)) && defined(QT_DBUS_LIB)
     m_inhibitor = new PowerManagementInhibitor(this);
@@ -55,7 +54,7 @@ PowerManagement::~PowerManagement()
 {
 }
 
-void PowerManagement::setActivityState(bool busy)
+void PowerManagement::setActivityState(const bool busy)
 {
     if (busy)
         setBusy();

--- a/src/gui/powermanagement/powermanagement.h
+++ b/src/gui/powermanagement/powermanagement.h
@@ -52,10 +52,10 @@ public:
   void setActivityState(bool busy);
 
 private:
-  bool m_busy;
-
   void setBusy();
   void setIdle();
+
+  bool m_busy = false;
 
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)) && defined(QT_DBUS_LIB)
   PowerManagementInhibitor *m_inhibitor;


### PR DESCRIPTION
* Clean up coding style
* Fix wrong logic that disables "prevent sleeping" timer
  Also update power management state early so we don't need to wait for the timer timeout to have the effect.