### PR TITLE
Change default stop_tracker_timeout settings

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -471,7 +471,11 @@ Session::Session(QObject *parent)
     , m_ignoreLimitsOnLAN(BITTORRENT_SESSION_KEY("IgnoreLimitsOnLAN"), false)
     , m_includeOverheadInLimits(BITTORRENT_SESSION_KEY("IncludeOverheadInLimits"), false)
     , m_announceIP(BITTORRENT_SESSION_KEY("AnnounceIP"))
+#if (LIBTORRENT_VERSION_NUM >= 10206)
+    , m_stopTrackerTimeout(BITTORRENT_SESSION_KEY("StopTrackerTimeout"), 5)
+#else
     , m_stopTrackerTimeout(BITTORRENT_SESSION_KEY("StopTrackerTimeout"), 1)
+#endif
     , m_maxConnections(BITTORRENT_SESSION_KEY("MaxConnections"), 500, lowerLimited(0, -1))
     , m_maxUploads(BITTORRENT_SESSION_KEY("MaxUploads"), -1, lowerLimited(0, -1))
     , m_maxConnectionsPerTorrent(BITTORRENT_SESSION_KEY("MaxConnectionsPerTorrent"), 100, lowerLimited(0, -1))


### PR DESCRIPTION
*This timeout applies for tracker announce made during pausing of torrents as well as closing of the client.

A 1 second timeout is too low for an announce request to go through for some use cases. 
Specially when your network usage is high and latency is increased. or when you use a TLS secured tracker which requires at least 3 round trips due to the handshake. 

The default should be a bit higher to allow the announces to go through for most use cases. But not high enough to stall the client closing process.

This was probably set to 1 second thinking it would fix delayed exit issue that some users face. 
But even then, qBt takes 3-5 seconds on average to close due to waiting on some other threads(like asyn DNS queries).

5 seconds sound reasonable specially for private tracker users where making your stats count before client closing/pausing a torrent matter.