### PR TITLE
Avoid inefficient behavior

### DIFF
--- a/src/base/utils/io.cpp
+++ b/src/base/utils/io.cpp
@@ -41,9 +41,11 @@ Utils::IO::FileDeviceOutputIterator::FileDeviceOutputIterator(QFileDevice &devic
 
 Utils::IO::FileDeviceOutputIterator::~FileDeviceOutputIterator()
 {
-    if (m_device->error() == QFileDevice::NoError)
-        m_device->write(*m_buffer);
-    m_buffer->clear();
+    if (m_buffer.use_count() == 1) {
+        if (m_device->error() == QFileDevice::NoError)
+            m_device->write(*m_buffer);
+        m_buffer->clear();
+    }
 }
 
 Utils::IO::FileDeviceOutputIterator &Utils::IO::FileDeviceOutputIterator::operator=(const char c)


### PR DESCRIPTION
Since the class needs to be copy-constructible, there may be many copies of an instance. So instead of writing to the device on every destructor call, only flush buffer on the last destructor call.