### PR TITLE
Fix outgoing interfaces not getting assigned in case addr is not null.

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1529,10 +1529,11 @@ void Session::configureNetworkInterfaces(lt::settings_pack &settingsPack)
     for (const QString &ip : asConst(getListeningIPs())) {
         const QHostAddress addr {ip};
         if (!addr.isNull()) {
-            endpoints << ((addr.protocol() == QAbstractSocket::IPv6Protocol)
+            const QString ip = ((addr.protocol() == QAbstractSocket::IPv6Protocol)
                           ? ('[' + Utils::Net::canonicalIPv6Addr(addr).toString() + ']')
-                          : addr.toString())
-                         + portString;
+                          : addr.toString());
+            endpoints << (ip + portString);
+            outgoingInterfaces << ip;
         }
         else {
             // ip holds an interface name


### PR DESCRIPTION
Fixes https://github.com/qbittorrent/qBittorrent/issues/12421