### PR TITLE
Fix embedded tracker

### DIFF
--- a/src/base/bittorrent/tracker.h
+++ b/src/base/bittorrent/tracker.h
@@ -98,6 +98,7 @@ namespace BitTorrent
         void registerPeer(const TrackerAnnounceRequest &announceReq);
         void unregisterPeer(const TrackerAnnounceRequest &announceReq);
         void prepareAnnounceResponse(const TrackerAnnounceRequest &announceReq);
+        QHostAddress sanitizeAddress(const QHostAddress &addr, quint16 requestPort);
 
         Http::Server *m_server;
         Http::Request m_request;


### PR DESCRIPTION
Log more request processing events, improve processing of actual + claimed address.

- ~Some of the errors in the announce request processing are now warnings~

- ~Errors and warnings in the announce request processing are now logged~

- ~Client address conversion to plain IPv4 is now logged when it happens~

Follow-up to: https://github.com/qbittorrent/qBittorrent/issues/12257