### PR TITLE
Fix add multiple peers from webui

### DIFF
--- a/src/webui/www/private/addpeers.html
+++ b/src/webui/www/private/addpeers.html
@@ -42,7 +42,7 @@
                         method: 'post',
                         data: {
                             hashes: hash,
-                            peers: peers.join(';')
+                            peers: peers.join('|')
                         },
                         onFailure: function() {
                             alert("QBT_TR(Unable to add peers. Please ensure you are adhering to the IP:port format.)QBT_TR[CONTEXT=HttpServer]");


### PR DESCRIPTION
The wrong delimiter was used which prevented adding multiple peers at once.