### PR TITLE
Avoid holding encoded resume data in memory 

### DIFF
--- a/src/base/bittorrent/private/resumedatasavingmanager.cpp
+++ b/src/base/bittorrent/private/resumedatasavingmanager.cpp
@@ -28,11 +28,15 @@
 
 #include "resumedatasavingmanager.h"
 
+#include <libtorrent/bencode.hpp>
+#include <libtorrent/entry.hpp>
+
 #include <QByteArray>
 #include <QSaveFile>
 
 #include "base/logger.h"
 #include "base/utils/fs.h"
+#include "base/utils/io.h"
 
 ResumeDataSavingManager::ResumeDataSavingManager(const QString &resumeFolderPath)
     : m_resumeDataDir(resumeFolderPath)
@@ -45,6 +49,24 @@ void ResumeDataSavingManager::save(const QString &filename, const QByteArray &da
 
     QSaveFile file {filepath};
     if (!file.open(QIODevice::WriteOnly) || (file.write(data) != data.size()) || !file.commit()) {
+        LogMsg(tr("Couldn't save data to '%1'. Error: %2")
+            .arg(filepath, file.errorString()), Log::CRITICAL);
+    }
+}
+
+void ResumeDataSavingManager::save(const QString &filename, const std::shared_ptr<lt::entry> &data) const
+{
+    const QString filepath = m_resumeDataDir.absoluteFilePath(filename);
+
+    QSaveFile file {filepath};
+    if (!file.open(QIODevice::WriteOnly)) {
+        LogMsg(tr("Couldn't save data to '%1'. Error: %2")
+            .arg(filepath, file.errorString()), Log::CRITICAL);
+        return;
+    }
+
+    lt::bencode(Utils::IO::FileDeviceOutputIterator {file}, *data);
+    if ((file.error() != QFileDevice::NoError) || !file.commit()) {
         LogMsg(tr("Couldn't save data to '%1'. Error: %2")
             .arg(filepath, file.errorString()), Log::CRITICAL);
     }

--- a/src/base/bittorrent/private/resumedatasavingmanager.h
+++ b/src/base/bittorrent/private/resumedatasavingmanager.h
@@ -28,6 +28,10 @@
 
 #pragma once
 
+#include <memory>
+
+#include <libtorrent/fwd.hpp>
+
 #include <QDir>
 #include <QObject>
 
@@ -43,8 +47,9 @@ public:
 
 public slots:
     void save(const QString &filename, const QByteArray &data) const;
+    void save(const QString &filename, const std::shared_ptr<lt::entry> &data) const;
     void remove(const QString &filename) const;
 
 private:
-    QDir m_resumeDataDir;
+    const QDir m_resumeDataDir;
 };

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -40,25 +40,6 @@
 #include <iphlpapi.h>
 #endif
 
-#include <QDebug>
-#include <QDir>
-#include <QFile>
-#include <QHostAddress>
-#include <QNetworkAddressEntry>
-#include <QNetworkConfigurationManager>
-#include <QNetworkInterface>
-#include <QRegularExpression>
-#include <QString>
-#include <QThread>
-#include <QTimer>
-#include <QUuid>
-
-#ifdef Q_OS_WIN
-// TODO: Remove together with fixBrokenSavePath()
-#define NEED_TO_FIX_BROKEN_PATH
-#include <QSaveFile>
-#endif
-
 #include <libtorrent/alert_types.hpp>
 #include <libtorrent/bdecode.hpp>
 #include <libtorrent/bencode.hpp>
@@ -76,6 +57,25 @@
 
 #if (LIBTORRENT_VERSION_NUM >= 10200)
 #include <libtorrent/read_resume_data.hpp>
+#endif
+
+#include <QDebug>
+#include <QDir>
+#include <QFile>
+#include <QHostAddress>
+#include <QNetworkAddressEntry>
+#include <QNetworkConfigurationManager>
+#include <QNetworkInterface>
+#include <QRegularExpression>
+#include <QString>
+#include <QThread>
+#include <QTimer>
+#include <QUuid>
+
+#ifdef Q_OS_WIN
+// TODO: Remove together with fixBrokenSavePath()
+#define NEED_TO_FIX_BROKEN_PATH
+#include <QSaveFile>
 #endif
 
 #include "base/algorithm.h"

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -2587,6 +2587,7 @@ void Session::saveResumeData()
 
 void Session::saveTorrentsQueue()
 {
+    // store hash in textual representation
     QMap<int, QString> queue; // Use QMap since it should be ordered by key
     for (const TorrentHandle *torrent : asConst(torrents())) {
         // We require actual (non-cached) queue position here!
@@ -2596,6 +2597,7 @@ void Session::saveTorrentsQueue()
     }
 
     QByteArray data;
+    data.reserve(((InfoHash::length() * 2) + 1) * queue.size());
     for (const QString &hash : asConst(queue))
         data += (hash.toLatin1() + '\n');
 

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -30,6 +30,7 @@
 #ifndef BITTORRENT_SESSION_H
 #define BITTORRENT_SESSION_H
 
+#include <memory>
 #include <vector>
 
 #include <libtorrent/fwd.hpp>
@@ -459,7 +460,7 @@ namespace BitTorrent
         void handleTorrentTrackersChanged(TorrentHandle *const torrent);
         void handleTorrentUrlSeedsAdded(TorrentHandle *const torrent, const QVector<QUrl> &newUrlSeeds);
         void handleTorrentUrlSeedsRemoved(TorrentHandle *const torrent, const QVector<QUrl> &urlSeeds);
-        void handleTorrentResumeDataReady(TorrentHandle *const torrent, const lt::entry &data);
+        void handleTorrentResumeDataReady(TorrentHandle *const torrent, const std::shared_ptr<lt::entry> &data);
         void handleTorrentResumeDataFailed(TorrentHandle *const torrent);
         void handleTorrentTrackerReply(TorrentHandle *const torrent, const QString &trackerUrl);
         void handleTorrentTrackerWarning(TorrentHandle *const torrent, const QString &trackerUrl);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -118,8 +118,10 @@ namespace
     // Misc
     const QString KEY_DOWNLOAD_TRACKER_FAVICON = QStringLiteral(SETTINGS_KEY("DownloadTrackerFavicon"));
 
-    const int TIME_TRAY_BALLOON = 5000;
     const std::chrono::seconds PREVENT_SUSPEND_INTERVAL {60};
+#if !defined(Q_OS_MACOS)
+    const int TIME_TRAY_BALLOON = 5000;
+#endif
 
     // just a shortcut
     inline SettingsStorage *settings()


### PR DESCRIPTION
* Avoid holding encoded resume data in memory
  Now it the encoded resume data will be streamed to file instead of a temporary buffer holding the whole of it.
* Suppress unused variable warning on macOS
* Fix header inclusion order
* Preallocate output buffer