### PR TITLE
Implement "Queued moving" state

### DIFF
--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -897,7 +897,7 @@ void TorrentHandle::updateState()
         m_state = TorrentState::CheckingResumeData;
     }
     else if (isMoveInProgress()) {
-        m_state = TorrentState::Moving;
+        m_state = m_nativeStatus.moving_storage ? TorrentState::Moving : TorrentState::QueuedMoving;
     }
     else if (hasMissingFiles()) {
         m_state = TorrentState::MissingFiles;

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -129,6 +129,7 @@ namespace BitTorrent
         PausedDownloading,
         PausedUploading,
 
+        QueuedMoving,
         Moving,
 
         MissingFiles,

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -79,7 +79,8 @@ TransferListModel::TransferListModel(QObject *parent)
           {BitTorrent::TorrentState::CheckingResumeData, tr("Checking resume data", "Used when loading the torrents from disk after qbt is launched. It checks the correctness of the .fastresume file. Normally it is completed in a fraction of a second, unless loading many many torrents.")},
           {BitTorrent::TorrentState::PausedDownloading, tr("Paused")},
           {BitTorrent::TorrentState::PausedUploading, tr("Completed")},
-          {BitTorrent::TorrentState::Moving, tr("Moving", "Torrent local data are being moved/relocated")},
+          {BitTorrent::TorrentState::Moving, tr("[Q] Moving", "Torrent local data are queued to be moved/relocated")},
+          {BitTorrent::TorrentState::QueuedMoving, tr("Moving", "Torrent local data are being moved/relocated")},
           {BitTorrent::TorrentState::MissingFiles, tr("Missing Files")},
           {BitTorrent::TorrentState::Error, tr("Errored", "Torrent status, the torrent has an error")}
       }
@@ -101,6 +102,7 @@ TransferListModel::TransferListModel(QObject *parent)
         {BitTorrent::TorrentState::PausedDownloading, getColorByState(BitTorrent::TorrentState::PausedDownloading)},
         {BitTorrent::TorrentState::PausedUploading, getColorByState(BitTorrent::TorrentState::PausedUploading)},
         {BitTorrent::TorrentState::Moving, getColorByState(BitTorrent::TorrentState::Moving)},
+        {BitTorrent::TorrentState::QueuedMoving, getColorByState(BitTorrent::TorrentState::QueuedMoving)},
         {BitTorrent::TorrentState::MissingFiles, getColorByState(BitTorrent::TorrentState::MissingFiles)},
         {BitTorrent::TorrentState::Error, getColorByState(BitTorrent::TorrentState::Error)}
     }
@@ -631,6 +633,7 @@ QIcon getIconByState(const BitTorrent::TorrentState state)
         return getCompletedIcon();
     case BitTorrent::TorrentState::QueuedDownloading:
     case BitTorrent::TorrentState::QueuedUploading:
+    case BitTorrent::TorrentState::QueuedMoving:
         return getQueuedIcon();
     case BitTorrent::TorrentState::CheckingDownloading:
     case BitTorrent::TorrentState::CheckingUploading:
@@ -688,6 +691,7 @@ QColor getColorByState(const BitTorrent::TorrentState state)
     case BitTorrent::TorrentState::CheckingDownloading:
     case BitTorrent::TorrentState::CheckingUploading:
     case BitTorrent::TorrentState::CheckingResumeData:
+    case BitTorrent::TorrentState::QueuedMoving:
     case BitTorrent::TorrentState::Moving:
         if (!dark)
             return {0, 128, 128}; // Teal

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -325,6 +325,11 @@ QColor TransferListWidget::movingStateForeground() const
     return m_listModel->stateForeground(BitTorrent::TorrentState::Moving);
 }
 
+QColor TransferListWidget::queuedMovingStateForeground() const
+{
+    return m_listModel->stateForeground(BitTorrent::TorrentState::QueuedMoving);
+}
+
 QColor TransferListWidget::missingFilesStateForeground() const
 {
     return m_listModel->stateForeground(BitTorrent::TorrentState::MissingFiles);
@@ -418,6 +423,11 @@ void TransferListWidget::setPausedUploadingStateForeground(const QColor &color)
 void TransferListWidget::setMovingStateForeground(const QColor &color)
 {
     m_listModel->setStateForeground(BitTorrent::TorrentState::Moving, color);
+}
+
+void TransferListWidget::setQueuedMovingStateForeground(const QColor &color)
+{
+    m_listModel->setStateForeground(BitTorrent::TorrentState::QueuedMoving, color);
 }
 
 void TransferListWidget::setMissingFilesStateForeground(const QColor &color)

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -64,6 +64,7 @@ class TransferListWidget : public QTreeView
     Q_PROPERTY(QColor pausedDownloadingStateForeground READ pausedDownloadingStateForeground WRITE setPausedDownloadingStateForeground)
     Q_PROPERTY(QColor pausedUploadingStateForeground READ pausedUploadingStateForeground WRITE setPausedUploadingStateForeground)
     Q_PROPERTY(QColor movingStateForeground READ movingStateForeground WRITE setMovingStateForeground)
+    Q_PROPERTY(QColor queuedMovingStateForeground READ queuedMovingStateForeground WRITE setQueuedMovingStateForeground)
     Q_PROPERTY(QColor missingFilesStateForeground READ missingFilesStateForeground WRITE setMissingFilesStateForeground)
     Q_PROPERTY(QColor errorStateForeground READ errorStateForeground WRITE setErrorStateForeground)
 
@@ -160,6 +161,7 @@ private:
     QColor pausedDownloadingStateForeground() const;
     QColor pausedUploadingStateForeground() const;
     QColor movingStateForeground() const;
+    QColor queuedMovingStateForeground() const;
     QColor missingFilesStateForeground() const;
     QColor errorStateForeground() const;
 
@@ -180,6 +182,7 @@ private:
     void setPausedDownloadingStateForeground(const QColor &color);
     void setPausedUploadingStateForeground(const QColor &color);
     void setMovingStateForeground(const QColor &color);
+    void setQueuedMovingStateForeground(const QColor &color);
     void setMissingFilesStateForeground(const QColor &color);
     void setErrorStateForeground(const QColor &color);
 

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -74,6 +74,8 @@ namespace
             return QLatin1String("checkingResumeData");
         case BitTorrent::TorrentState::Moving:
             return QLatin1String("moving");
+        case BitTorrent::TorrentState::QueuedMoving:
+            return QLatin1String("queuedMoving");
         default:
             return QLatin1String("unknown");
         }

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -880,6 +880,7 @@ window.qBittorrent.DynamicTable = (function() {
                         break;
                     case "queuedDL":
                     case "queuedUP":
+                    case "queuedMoving":
                         state = "queued";
                         break;
                     case "checkingDL":
@@ -966,6 +967,9 @@ window.qBittorrent.DynamicTable = (function() {
                         break;
                     case "moving":
                         status = "QBT_TR(Moving)QBT_TR[CONTEXT=TransferListDelegate]";
+                        break;
+                    case "queuedMoving":
+                        status = "QBT_TR([Q] Moving)QBT_TR[CONTEXT=TransferListDelegate]";
                         break;
                     case "missingFiles":
                         status = "QBT_TR(Missing Files)QBT_TR[CONTEXT=TransferListDelegate]";


### PR DESCRIPTION
It can be useful to distinguish between "Queued for moving" and "Moving" states.