### PR TITLE
Do not use 0.0.0.0 or [::] for outgoing interfaces

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1534,7 +1534,9 @@ void Session::configureNetworkInterfaces(lt::settings_pack &settingsPack)
                           ? ('[' + Utils::Net::canonicalIPv6Addr(addr).toString() + ']')
                           : addr.toString());
             endpoints << (ip + portString);
-            outgoingInterfaces << ip;
+
+            if ((ip != "0.0.0.0") && (ip != "[::]"))
+                outgoingInterfaces << ip;
         }
         else {
             // ip holds an interface name


### PR DESCRIPTION
Fixes #12443
Follow up to https://github.com/qbittorrent/qBittorrent/pull/12430

@Chocobo1  @FranciscoPombal 

I have reproduced the problem on my machine verify that this pull request fixes the problem.