### PR TITLE
Reduce padding in structure

### DIFF
--- a/src/base/logger.cpp
+++ b/src/base/logger.cpp
@@ -72,7 +72,7 @@ void Logger::freeInstance()
 void Logger::addMessage(const QString &message, const Log::MsgType &type)
 {
     QWriteLocker locker(&m_lock);
-    const Log::Msg msg = {m_msgCounter++, QDateTime::currentMSecsSinceEpoch(), type, message};
+    const Log::Msg msg = {m_msgCounter++, type, QDateTime::currentMSecsSinceEpoch(), message};
     m_messages.push_back(msg);
     locker.unlock();
 
@@ -82,7 +82,7 @@ void Logger::addMessage(const QString &message, const Log::MsgType &type)
 void Logger::addPeer(const QString &ip, const bool blocked, const QString &reason)
 {
     QWriteLocker locker(&m_lock);
-    const Log::Peer msg = {m_peerCounter++, QDateTime::currentMSecsSinceEpoch(), ip, blocked, reason};
+    const Log::Peer msg = {m_peerCounter++, blocked, QDateTime::currentMSecsSinceEpoch(), ip, reason};
     m_peers.push_back(msg);
     locker.unlock();
 

--- a/src/base/logger.h
+++ b/src/base/logger.h
@@ -53,17 +53,17 @@ namespace Log
     struct Msg
     {
         int id;
-        qint64 timestamp;
         MsgType type;
+        qint64 timestamp;
         QString message;
     };
 
     struct Peer
     {
         int id;
+        bool blocked;
         qint64 timestamp;
         QString ip;
-        bool blocked;
         QString reason;
     };
 }


### PR DESCRIPTION
Log::Msg originally takes 32 bytes, now shrinks to 24 bytes.
Log::Peer originally takes 40 bytes, now shrinks to 32 bytes.