### PR TITLE
TravisCI: Use libtorrent with deprecated functions disabled for Linux builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,14 +55,13 @@ addons:
   apt:
     sources:
       # sources list: https://github.com/travis-ci/apt-source-safelist/blob/master/ubuntu.json
-      - sourceline: 'ppa:qbittorrent-team/qbittorrent-stable'
+      - sourceline: 'ppa:qbittorrent-team/qbt-libtorrent-travisci'
       - sourceline: 'ppa:beineri/opt-qt59-xenial'
     packages:
       # packages list: https://github.com/travis-ci/apt-package-safelist/blob/master/ubuntu-trusty
       - [autoconf, automake, colormake]
       - [libboost-dev, libboost-system-dev]
       - libssl-dev
-      - libtorrent-rasterbar-dev
       - [qt59base, qt59svg, qt59tools]
       - zlib1g-dev
       # required for Qt 5.9 from 'beineri' PPA
@@ -132,7 +131,7 @@ install:
       ccache -V && ccache --show-stats && ccache --zero-stats
     fi
   - |
-    if [ "$libt_branch" = "RC_1_2" ] && [ "$TRAVIS_OS_NAME" = "linux" ]; then
+    if [ "$libt_branch" = "RC_1_1" ] && [ "$TRAVIS_OS_NAME" = "linux" ]; then
       wget https://builds.shiki.hu/travis/deb/version
       if ! cmp --quiet "version" "$HOME/travis/deb/version" ; then
         echo "Cached files are different from server. Downloading new ones."
@@ -141,11 +140,16 @@ install:
         mkdir "$HOME/travis/deb"
         cp "version" $HOME/travis/deb
         cd "$HOME/travis/deb"
-        wget https://builds.shiki.hu/travis/deb/libtorrent-rasterbar-dev_1.2.x_amd64.deb
-        wget https://builds.shiki.hu/travis/deb/libtorrent-rasterbar10_1.2.x_amd64.deb
+        wget https://builds.shiki.hu/travis/deb/libtorrent-rasterbar-dev_1.1.x_amd64.deb
+        wget https://builds.shiki.hu/travis/deb/libtorrent-rasterbar9_1.1.x_amd64.deb
       fi
 
-      sudo dpkg -i "$HOME/travis/deb/libtorrent-rasterbar-dev_1.2.x_amd64.deb" "$HOME/travis/deb/libtorrent-rasterbar10_1.2.x_amd64.deb"
+      sudo dpkg -i "$HOME/travis/deb/libtorrent-rasterbar-dev_1.1.x_amd64.deb" "$HOME/travis/deb/libtorrent-rasterbar9_1.1.x_amd64.deb"
+    fi
+  - |
+    if [ "$libt_branch" = "RC_1_2" ] && [ "$TRAVIS_OS_NAME" = "linux" ]; then
+      # Will install latest 1.2.x daily build from the PPA
+      sudo apt-get -y install libtorrent-rasterbar-dev
     fi
   - |
     if [ "$libt_branch" = "RC_1_1" ] && [ "$TRAVIS_OS_NAME" = "osx" ]; then

--- a/src/base/bittorrent/private/nativetorrentextension.cpp
+++ b/src/base/bittorrent/private/nativetorrentextension.cpp
@@ -47,7 +47,7 @@ namespace
 #if (LIBTORRENT_VERSION_NUM < 10200)
         return torrentStatus.auto_managed;
 #else
-        return bool {torrentStatus.flags & lt::torrent_flags::auto_managed};
+        return static_cast<bool>(torrentStatus.flags & lt::torrent_flags::auto_managed);
 #endif
     }
 }

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -2599,7 +2599,7 @@ void Session::saveTorrentsQueue()
     QMap<int, QString> queue; // Use QMap since it should be ordered by key
     for (const TorrentHandleImpl *torrent : asConst(m_torrents)) {
         // We require actual (non-cached) queue position here!
-        const int queuePos = LTUnderlyingType<LTQueuePosition> {torrent->nativeHandle().queue_position()};
+        const int queuePos = static_cast<LTUnderlyingType<LTQueuePosition>>(torrent->nativeHandle().queue_position());
         if (queuePos >= 0)
             queue[queuePos] = torrent->hash();
     }

--- a/src/base/bittorrent/torrentcreatorthread.cpp
+++ b/src/base/bittorrent/torrentcreatorthread.cpp
@@ -164,7 +164,7 @@ void TorrentCreatorThread::run()
         lt::set_piece_hashes(newTorrent, Utils::Fs::toNativePath(parentPath).toStdString()
             , [this, &newTorrent](const LTPieceIndex n)
         {
-            sendProgressSignal(LTUnderlyingType<LTPieceIndex> {n}, newTorrent.num_pieces());
+            sendProgressSignal(static_cast<LTUnderlyingType<LTPieceIndex>>(n), newTorrent.num_pieces());
         });
         // Set qBittorrent as creator and add user comment to
         // torrent_info structure

--- a/src/base/bittorrent/torrenthandleimpl.cpp
+++ b/src/base/bittorrent/torrenthandleimpl.cpp
@@ -354,7 +354,7 @@ bool TorrentHandleImpl::isAutoManaged() const
 #if (LIBTORRENT_VERSION_NUM < 10200)
     return m_nativeStatus.auto_managed;
 #else
-    return bool {m_nativeStatus.flags & lt::torrent_flags::auto_managed};
+    return static_cast<bool>(m_nativeStatus.flags & lt::torrent_flags::auto_managed);
 #endif
 }
 
@@ -699,7 +699,7 @@ QVector<DownloadPriority> TorrentHandleImpl::filePriorities() const
     QVector<DownloadPriority> ret;
     std::transform(fp.cbegin(), fp.cend(), std::back_inserter(ret), [](LTDownloadPriority priority)
     {
-        return static_cast<DownloadPriority>(LTUnderlyingType<LTDownloadPriority> {priority});
+        return static_cast<DownloadPriority>(static_cast<LTUnderlyingType<LTDownloadPriority>>(priority));
     });
     return ret;
 }
@@ -822,7 +822,7 @@ bool TorrentHandleImpl::isSequentialDownload() const
 #if (LIBTORRENT_VERSION_NUM < 10200)
     return m_nativeStatus.sequential_download;
 #else
-    return bool {m_nativeStatus.flags & lt::torrent_flags::sequential_download};
+    return static_cast<bool>(m_nativeStatus.flags & lt::torrent_flags::sequential_download);
 #endif
 }
 
@@ -1148,7 +1148,7 @@ bool TorrentHandleImpl::superSeeding() const
 #if (LIBTORRENT_VERSION_NUM < 10200)
     return m_nativeStatus.super_seeding;
 #else
-    return bool {m_nativeStatus.flags & lt::torrent_flags::super_seeding};
+    return static_cast<bool>(m_nativeStatus.flags & lt::torrent_flags::super_seeding);
 #endif
 }
 
@@ -1185,7 +1185,7 @@ QBitArray TorrentHandleImpl::downloadingPieces() const
 #if (LIBTORRENT_VERSION_NUM < 10200)
         result.setBit(info.piece_index);
 #else
-        result.setBit(LTUnderlyingType<LTPieceIndex> {info.piece_index});
+        result.setBit(static_cast<LTUnderlyingType<LTPieceIndex>>(info.piece_index));
 #endif
 
     return result;
@@ -1737,7 +1737,7 @@ void TorrentHandleImpl::handleFileRenamedAlert(const lt::file_renamed_alert *p)
 void TorrentHandleImpl::handleFileRenameFailedAlert(const lt::file_rename_failed_alert *p)
 {
     LogMsg(tr("File rename failed. Torrent: \"%1\", file: \"%2\", reason: \"%3\"")
-        .arg(name(), filePath(LTUnderlyingType<LTFileIndex> {p->index})
+        .arg(name(), filePath(static_cast<LTUnderlyingType<LTFileIndex>>(p->index))
              , QString::fromLocal8Bit(p->error.message().c_str())), Log::WARNING);
 
     m_oldPath[p->index].removeFirst();
@@ -1760,12 +1760,12 @@ void TorrentHandleImpl::handleFileCompletedAlert(const lt::file_completed_alert 
 
     qDebug("A file completed download in torrent \"%s\"", qUtf8Printable(name()));
     if (m_session->isAppendExtensionEnabled()) {
-        QString name = filePath(LTUnderlyingType<LTFileIndex> {p->index});
+        QString name = filePath(static_cast<LTUnderlyingType<LTFileIndex>>(p->index));
         if (name.endsWith(QB_EXT)) {
             const QString oldName = name;
             name.chop(QB_EXT.size());
             qDebug("Renaming %s to %s", qUtf8Printable(oldName), qUtf8Printable(name));
-            renameFile(LTUnderlyingType<LTFileIndex> {p->index}, name);
+            renameFile(static_cast<LTUnderlyingType<LTFileIndex>>(p->index), name);
         }
     }
 }


### PR DESCRIPTION
I had a little bit of trouble making the debian packaging scripts work on the raw libtorrent folder for the PPA. It seems to work now!!!

Additionally this PR forces the RC_1_1 code path to really use RC_1_1 package and not the RC_1_2 package (from the qbittorrent-stable ppa for xenial).

Both RC_1_1/RC_1_2 are with deprecated functions disabled. I believe this is what was asked a while back.