### PR TITLE
Use make_shared where possible

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1199,7 +1199,8 @@ void Session::initializeNativeSession()
         m_nativeSession->add_extension(&lt::create_ut_pex_plugin);
 
 #if (LIBTORRENT_VERSION_NUM < 10200)
-    m_nativeSession->add_extension(boost::shared_ptr<lt::plugin> {new NativeSessionExtension});
+    boost::shared_ptr<lt::plugin> ptr = boost::make_shared<NativeSessionExtension>();
+    m_nativeSession->add_extension(ptr);
 #else
     m_nativeSession->add_extension(std::make_shared<NativeSessionExtension>());
 #endif
@@ -2114,7 +2115,7 @@ bool Session::addTorrent_impl(CreateTorrentParams params, const MagnetUri &magne
             handle.set_upload_mode(false);
 
             if (params.paused) {
-                // Preloaded torrent isn't auto managed already
+                // Preloaded torrent isn't auto managed yet
                 handle.pause();
             }
             else if (!params.forced) {
@@ -2292,7 +2293,7 @@ bool Session::addTorrent_impl(CreateTorrentParams params, const MagnetUri &magne
             handle.unset_flags(lt::torrent_flags::upload_mode);
 
             if (params.paused) {
-                // Preloaded torrent isn't auto managed already
+                // Preloaded torrent isn't auto managed yet
                 handle.pause();
             }
             else if (!params.forced) {


### PR DESCRIPTION
I tried this:
```c++
m_nativeSession->add_extension(boost::make_shared<NativeSessionExtension>());
```

but msvc2017 gives me this error:
```
src\base\bittorrent\session.cpp:1202: error: C2668: 'libtorrent::session_handle::add_extension': ambiguous call to overloaded function
include\libtorrent\session_handle.hpp:536: could be 'void libtorrent::session_handle::add_extension(boost::shared_ptr<libtorrent::plugin>)'
include\libtorrent\session_handle.hpp:534: or       'void libtorrent::session_handle::add_extension(boost::function<boost::shared_ptr<libtorrent::torrent_plugin> (const libtorrent::torrent_handle &,void *)>)'
src\base\bittorrent\session.cpp:1202: while trying to match the argument list '(boost::shared_ptr<NativeSessionExtension>)'
```

Do you know another way to lift the ambiguity for the compiler?