### PR TITLE
Create user option to allow remote origin requests to the web API

### DIFF
--- a/src/base/http/types.h
+++ b/src/base/http/types.h
@@ -51,6 +51,7 @@ namespace Http
     const char HEADER_DATE[] = "date";
     const char HEADER_HOST[] = "host";
     const char HEADER_ORIGIN[] = "origin";
+    const char HEADER_ALLOW_ORIGIN[] = "access-control-allow-origin";
     const char HEADER_REFERER[] = "referer";
     const char HEADER_REFERRER_POLICY[] = "referrer-policy";
     const char HEADER_SET_COOKIE[] = "set-cookie";

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -663,6 +663,16 @@ void Preferences::setWebUiClickjackingProtectionEnabled(const bool enabled)
     setValue("Preferences/WebUI/ClickjackingProtection", enabled);
 }
 
+bool Preferences::isWebUiCorsHeaderEnabled() const
+{
+    return value("Preferences/WebUI/CorsHeader", true).toBool();
+}
+
+void Preferences::setWebUiCorsHeaderEnabled(const bool enabled)
+{
+    setValue("Preferences/WebUI/CorsHeader", enabled);
+}
+
 bool Preferences::isWebUiCSRFProtectionEnabled() const
 {
     return value("Preferences/WebUI/CSRFProtection", true).toBool();

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -665,7 +665,7 @@ void Preferences::setWebUiClickjackingProtectionEnabled(const bool enabled)
 
 bool Preferences::isWebUiCorsHeaderEnabled() const
 {
-    return value("Preferences/WebUI/CorsHeader", true).toBool();
+    return value("Preferences/WebUI/CorsHeader", false).toBool();
 }
 
 void Preferences::setWebUiCorsHeaderEnabled(const bool enabled)

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -567,6 +567,16 @@ void Preferences::setServerDomains(const QString &str)
     setValue("Preferences/WebUI/ServerDomains", str);
 }
 
+QString Preferences::getCorsDomain() const
+{
+    return value("Preferences/WebUI/CorsDomain", QChar('*')).toString();
+}
+
+void Preferences::setCorsDomain(const QString &str)
+{
+    setValue("Preferences/WebUI/CorsDomain", str);
+}
+
 QString Preferences::getWebUiAddress() const
 {
     return value("Preferences/WebUI/Address", QChar('*')).toString().trimmed();

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -176,6 +176,8 @@ public:
     void setWebUiEnabled(bool enabled);
     QString getServerDomains() const;
     void setServerDomains(const QString &str);
+    QString getCorsDomain() const;
+    void setCorsDomain(const QString &str);
     QString getWebUiAddress() const;
     void setWebUiAddress(const QString &addr);
     quint16 getWebUiPort() const;

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -204,6 +204,8 @@ public:
     // WebUI security
     bool isWebUiClickjackingProtectionEnabled() const;
     void setWebUiClickjackingProtectionEnabled(bool enabled);
+    bool isWebUiCorsHeaderEnabled() const;
+    void setWebUiCorsHeaderEnabled(bool enabled);
     bool isWebUiCSRFProtectionEnabled() const;
     void setWebUiCSRFProtectionEnabled(bool enabled);
     bool isWebUiSecureCookieEnabled () const;

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -492,6 +492,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     connect(m_ui->spinBanDuration, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->spinSessionTimeout, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->checkClickjacking, &QCheckBox::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->checkCors, &QCheckBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkCSRFProtection, &QCheckBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkWebUiHttps, &QGroupBox::toggled, m_ui->checkSecureCookie, &QWidget::setEnabled);
     connect(m_ui->checkSecureCookie, &QCheckBox::toggled, this, &ThisType::enableApplyButton);
@@ -850,6 +851,7 @@ void OptionsDialog::saveOptions()
         pref->setWebUiAuthSubnetWhitelistEnabled(m_ui->checkBypassAuthSubnetWhitelist->isChecked());
         // Security
         pref->setWebUiClickjackingProtectionEnabled(m_ui->checkClickjacking->isChecked());
+        pref->setWebUiCorsHeaderEnabled(m_ui->checkCors->isChecked());
         pref->setWebUiCSRFProtectionEnabled(m_ui->checkCSRFProtection->isChecked());
         pref->setWebUiSecureCookieEnabled(m_ui->checkSecureCookie->isChecked());
         pref->setWebUIHostHeaderValidationEnabled(m_ui->groupHostHeaderValidation->isChecked());
@@ -1230,6 +1232,7 @@ void OptionsDialog::loadOptions()
 
     // Security
     m_ui->checkClickjacking->setChecked(pref->isWebUiClickjackingProtectionEnabled());
+    m_ui->checkCors->setChecked(pref->isWebUiCorsHeaderEnabled());
     m_ui->checkCSRFProtection->setChecked(pref->isWebUiCSRFProtectionEnabled());
     m_ui->checkSecureCookie->setEnabled(pref->isWebUiHttpsEnabled());
     m_ui->checkSecureCookie->setChecked(pref->isWebUiSecureCookieEnabled());

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -474,6 +474,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     m_ui->textWebUIHttpsKey->setDialogCaption(tr("Select private key"));
 
     connect(m_ui->textServerDomains, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
+    connect(m_ui->textCorsDomain, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->checkWebUi, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->textWebUiAddress, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->spinWebUiPort, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
@@ -492,11 +493,11 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     connect(m_ui->spinBanDuration, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->spinSessionTimeout, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->checkClickjacking, &QCheckBox::toggled, this, &ThisType::enableApplyButton);
-    connect(m_ui->checkCors, &QCheckBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkCSRFProtection, &QCheckBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkWebUiHttps, &QGroupBox::toggled, m_ui->checkSecureCookie, &QWidget::setEnabled);
     connect(m_ui->checkSecureCookie, &QCheckBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->groupHostHeaderValidation, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->groupCorsHeader, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkDynDNS, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->comboDNSService, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->domainNameTxt, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
@@ -834,6 +835,7 @@ void OptionsDialog::saveOptions()
     pref->setWebUiEnabled(isWebUiEnabled());
     if (isWebUiEnabled()) {
         pref->setServerDomains(m_ui->textServerDomains->text());
+        pref->setCorsDomain(m_ui->textCorsDomain->text());
         pref->setWebUiAddress(m_ui->textWebUiAddress->text());
         pref->setWebUiPort(m_ui->spinWebUiPort->value());
         pref->setUPnPForWebUIPort(m_ui->checkWebUIUPnP->isChecked());
@@ -851,7 +853,6 @@ void OptionsDialog::saveOptions()
         pref->setWebUiAuthSubnetWhitelistEnabled(m_ui->checkBypassAuthSubnetWhitelist->isChecked());
         // Security
         pref->setWebUiClickjackingProtectionEnabled(m_ui->checkClickjacking->isChecked());
-        pref->setWebUiCorsHeaderEnabled(m_ui->checkCors->isChecked());
         pref->setWebUiCSRFProtectionEnabled(m_ui->checkCSRFProtection->isChecked());
         pref->setWebUiSecureCookieEnabled(m_ui->checkSecureCookie->isChecked());
         pref->setWebUIHostHeaderValidationEnabled(m_ui->groupHostHeaderValidation->isChecked());
@@ -1215,6 +1216,7 @@ void OptionsDialog::loadOptions()
 
     // Web UI preferences
     m_ui->textServerDomains->setText(pref->getServerDomains());
+    m_ui->textCorsDomain->setText(pref->getCorsDomain());
     m_ui->checkWebUi->setChecked(pref->isWebUiEnabled());
     m_ui->textWebUiAddress->setText(pref->getWebUiAddress());
     m_ui->spinWebUiPort->setValue(pref->getWebUiPort());
@@ -1232,11 +1234,11 @@ void OptionsDialog::loadOptions()
 
     // Security
     m_ui->checkClickjacking->setChecked(pref->isWebUiClickjackingProtectionEnabled());
-    m_ui->checkCors->setChecked(pref->isWebUiCorsHeaderEnabled());
     m_ui->checkCSRFProtection->setChecked(pref->isWebUiCSRFProtectionEnabled());
     m_ui->checkSecureCookie->setEnabled(pref->isWebUiHttpsEnabled());
     m_ui->checkSecureCookie->setChecked(pref->isWebUiSecureCookieEnabled());
     m_ui->groupHostHeaderValidation->setChecked(pref->isWebUIHostHeaderValidationEnabled());
+    m_ui->groupCorsHeader->setChecked(pref->isWebUiCorsHeaderEnabled());
 
     m_ui->checkDynDNS->setChecked(pref->isDynDNSEnabled());
     m_ui->comboDNSService->setCurrentIndex(static_cast<int>(pref->getDynDNSService()));

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -90,7 +90,7 @@
      </widget>
      <widget class="QStackedWidget" name="tabOption">
       <property name="currentIndex">
-       <number>0</number>
+       <number>6</number>
       </property>
       <widget class="QWidget" name="tabBehaviorPage">
        <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -121,9 +121,9 @@
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>0</y>
-             <width>501</width>
-             <height>893</height>
+             <y>-512</y>
+             <width>618</width>
+             <height>1233</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -446,7 +446,7 @@
                   <item>
                    <widget class="QCheckBox" name="checkCloseToSystray">
                     <property name="toolTip">
-                      <string>The systray icon will still be visible when closing the main window</string>
+                     <string>The systray icon will still be visible when closing the main window</string>
                     </property>
                     <property name="text">
                      <string extracomment="The systray icon will still be visible when closing the main window">Close qBittorrent to notification area</string>
@@ -735,8 +735,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>591</width>
-             <height>1138</height>
+             <width>645</width>
+             <height>1401</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout">
@@ -1346,8 +1346,8 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>501</width>
-             <height>745</height>
+             <width>545</width>
+             <height>890</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -1846,8 +1846,8 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>516</width>
-             <height>525</height>
+             <width>459</width>
+             <height>548</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -2183,8 +2183,8 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>513</width>
-             <height>679</height>
+             <width>559</width>
+             <height>886</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -2682,8 +2682,8 @@ Disable encryption: Only connect to peers without protocol encryption</string>
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>516</width>
-             <height>525</height>
+             <width>498</width>
+             <height>466</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_27">
@@ -2851,9 +2851,9 @@ Disable encryption: Only connect to peers without protocol encryption</string>
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>0</y>
-             <width>501</width>
-             <height>636</height>
+             <y>-631</y>
+             <width>541</width>
+             <height>1203</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -3170,13 +3170,6 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                    </widget>
                   </item>
                   <item>
-                   <widget class="QCheckBox" name="checkCors">
-                    <property name="text">
-                     <string>Enable Cross-Origin requests</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
                    <widget class="QCheckBox" name="checkCSRFProtection">
                     <property name="text">
                      <string>Enable Cross-Site Request Forgery (CSRF) protection</string>
@@ -3199,6 +3192,9 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                      <bool>true</bool>
                     </property>
                     <layout class="QVBoxLayout" name="verticalLayout_32">
+                     <property name="bottomMargin">
+                      <number>6</number>
+                     </property>
                      <item>
                       <layout class="QHBoxLayout" name="horizontalLayout_10">
                        <item>
@@ -3218,6 +3214,44 @@ you should put in domain names used by WebUI server.
 Use ';' to split multiple entries. Can use wildcard '*'.</string>
                          </property>
                         </widget>
+                       </item>
+                      </layout>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="groupCorsHeader">
+                    <property name="title">
+                     <string>Allow Cross-Origin requests</string>
+                    </property>
+                    <property name="checkable">
+                     <bool>true</bool>
+                    </property>
+                    <layout class="QVBoxLayout" name="verticalLayout_8">
+                     <property name="leftMargin">
+                      <number>6</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>6</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>6</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>6</number>
+                     </property>
+                     <item>
+                      <layout class="QHBoxLayout" name="horizontalLayout_19">
+                       <item>
+                        <widget class="QLabel" name="labelCorsDomain">
+                         <property name="text">
+                          <string>Origin domain:</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QLineEdit" name="textCorsDomain"/>
                        </item>
                       </layout>
                      </item>

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -90,7 +90,7 @@
      </widget>
      <widget class="QStackedWidget" name="tabOption">
       <property name="currentIndex">
-       <number>6</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="tabBehaviorPage">
        <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -121,7 +121,7 @@
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>-512</y>
+             <y>0</y>
              <width>618</width>
              <height>1233</height>
             </rect>
@@ -2851,7 +2851,7 @@ Disable encryption: Only connect to peers without protocol encryption</string>
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>-631</y>
+             <y>-618</y>
              <width>541</width>
              <height>1203</height>
             </rect>

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -3170,6 +3170,13 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                    </widget>
                   </item>
                   <item>
+                   <widget class="QCheckBox" name="checkCors">
+                    <property name="text">
+                     <string>Enable Cross-Origin requests</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
                    <widget class="QCheckBox" name="checkCSRFProtection">
                     <property name="text">
                      <string>Enable Cross-Site Request Forgery (CSRF) protection</string>

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -218,6 +218,7 @@ void AppController::preferencesAction()
     data["locale"] = pref->getLocale();
     // HTTP Server
     data["web_ui_domain_list"] = pref->getServerDomains();
+    data["web_ui_cors_header"] = pref->getCorsDomain();
     data["web_ui_address"] = pref->getWebUiAddress();
     data["web_ui_port"] = pref->getWebUiPort();
     data["web_ui_upnp"] = pref->useUPnPForWebUIPort();
@@ -579,6 +580,8 @@ void AppController::setPreferencesAction()
     // HTTP Server
     if (hasKey("web_ui_domain_list"))
         pref->setServerDomains(it.value().toString());
+    if (hasKey("web_ui_cors_header"))
+        pref->setCorsDomain(it.value().toString());
     if (hasKey("web_ui_address"))
         pref->setWebUiAddress(it.value().toString());
     if (hasKey("web_ui_port"))

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -240,6 +240,7 @@ void AppController::preferencesAction()
     data["alternative_webui_path"] = pref->getWebUiRootFolder();
     // Security
     data["web_ui_clickjacking_protection_enabled"] = pref->isWebUiClickjackingProtectionEnabled();
+    data["web_ui_cors_header_enabled"] = pref->isWebUiCorsHeaderEnabled();
     data["web_ui_csrf_protection_enabled"] = pref->isWebUiCSRFProtectionEnabled();
     data["web_ui_secure_cookie_enabled"] = pref->isWebUiSecureCookieEnabled();
     data["web_ui_host_header_validation_enabled"] = pref->isWebUIHostHeaderValidationEnabled();
@@ -617,6 +618,8 @@ void AppController::setPreferencesAction()
     // Security
     if (hasKey("web_ui_clickjacking_protection_enabled"))
         pref->setWebUiClickjackingProtectionEnabled(it.value().toBool());
+    if (hasKey("web_ui_cors_header_enabled"))
+        pref->setWebUiCorsHeaderEnabled(it.value().toBool());
     if (hasKey("web_ui_csrf_protection_enabled"))
         pref->setWebUiCSRFProtectionEnabled(it.value().toBool());
     if (hasKey("web_ui_secure_cookie_enabled"))

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -337,6 +337,7 @@ void WebApplication::configure()
 
     m_isClickjackingProtectionEnabled = pref->isWebUiClickjackingProtectionEnabled();
     m_isCorsEnabled = pref->isWebUiCorsHeaderEnabled();
+    m_corsDomain = pref->getCorsDomain();
     m_isCSRFProtectionEnabled = pref->isWebUiCSRFProtectionEnabled();
     m_isSecureCookieEnabled = pref->isWebUiSecureCookieEnabled();
     m_isHostHeaderValidationEnabled = pref->isWebUIHostHeaderValidationEnabled();
@@ -447,7 +448,7 @@ Http::Response WebApplication::processRequest(const Http::Request &request, cons
         header(QLatin1String(Http::HEADER_X_FRAME_OPTIONS), QLatin1String("SAMEORIGIN"));
 
     if (m_isCorsEnabled)
-        header(QLatin1String(Http::HEADER_ALLOW_ORIGIN), QLatin1String("*"));
+        header(QLatin1String(Http::HEADER_ALLOW_ORIGIN), m_corsDomain);
 
     if (!m_isAltUIUsed)
         header(QLatin1String(Http::HEADER_REFERRER_POLICY), QLatin1String("same-origin"));

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -447,7 +447,7 @@ Http::Response WebApplication::processRequest(const Http::Request &request, cons
         header(QLatin1String(Http::HEADER_X_FRAME_OPTIONS), QLatin1String("SAMEORIGIN"));
 
     if (m_isCorsEnabled)
-        header(QLatin1String(Http::HEADER_ALLOW_ORIGIN), QLatin1String("*"))
+        header(QLatin1String(Http::HEADER_ALLOW_ORIGIN), QLatin1String("*"));
 
     if (!m_isAltUIUsed)
         header(QLatin1String(Http::HEADER_REFERRER_POLICY), QLatin1String("same-origin"));

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -336,6 +336,7 @@ void WebApplication::configure()
     std::for_each(m_domainList.begin(), m_domainList.end(), [](QString &entry) { entry = entry.trimmed(); });
 
     m_isClickjackingProtectionEnabled = pref->isWebUiClickjackingProtectionEnabled();
+    m_isCorsEnabled = pref->isWebUiCorsHeaderEnabled();
     m_isCSRFProtectionEnabled = pref->isWebUiCSRFProtectionEnabled();
     m_isSecureCookieEnabled = pref->isWebUiSecureCookieEnabled();
     m_isHostHeaderValidationEnabled = pref->isWebUIHostHeaderValidationEnabled();
@@ -444,6 +445,9 @@ Http::Response WebApplication::processRequest(const Http::Request &request, cons
 
     if (m_isClickjackingProtectionEnabled)
         header(QLatin1String(Http::HEADER_X_FRAME_OPTIONS), QLatin1String("SAMEORIGIN"));
+
+    if (m_isCorsEnabled)
+        header(QLatin1String(Http::HEADER_ALLOW_ORIGIN), QLatin1String("*"))
 
     if (!m_isAltUIUsed)
         header(QLatin1String(Http::HEADER_REFERRER_POLICY), QLatin1String("same-origin"));

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -152,6 +152,7 @@ private:
     // security related
     QStringList m_domainList;
     bool m_isClickjackingProtectionEnabled;
+    bool m_isCorsEnabled;
     bool m_isCSRFProtectionEnabled;
     bool m_isSecureCookieEnabled;
     bool m_isHostHeaderValidationEnabled;

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -151,6 +151,7 @@ private:
 
     // security related
     QStringList m_domainList;
+    QString m_corsDomain;
     bool m_isClickjackingProtectionEnabled;
     bool m_isCorsEnabled;
     bool m_isCSRFProtectionEnabled;

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -762,6 +762,10 @@
                 <label for="clickjacking_protection_checkbox">QBT_TR(Enable clickjacking protection)QBT_TR[CONTEXT=OptionsDialog]</label>
             </div>
             <div class="formRow">
+                <input type="checkbox" id="cors_header_checkbox" />
+                <label for="cors_header_checkbox">QBT_TR(Enable Cross-Origin requests)QBT_TR[CONTEXT=OptionsDialog]</label>
+            </div>
+            <div class="formRow">
                 <input type="checkbox" id="csrf_protection_checkbox" />
                 <label for="csrf_protection_checkbox">QBT_TR(Enable Cross-Site Request Forgery (CSRF) protection)QBT_TR[CONTEXT=OptionsDialog]</label>
             </div>

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1744,6 +1744,7 @@
                         // Security
                         $('clickjacking_protection_checkbox').setProperty('checked', pref.web_ui_clickjacking_protection_enabled);
                         $('csrf_protection_checkbox').setProperty('checked', pref.web_ui_csrf_protection_enabled);
+                        $('cors_header_checkbox').setProperty('checked', perf.web_ui_cors_header_enabled);
                         $('secureCookieCheckbox').setProperty('checked', pref.web_ui_secure_cookie_enabled);
                         $('host_header_validation_checkbox').setProperty('checked', pref.web_ui_host_header_validation_enabled);
                         updateHostHeaderValidationSettings();
@@ -2111,6 +2112,7 @@
             settings.set('alternative_webui_path', webui_files_location_textarea);
 
             settings.set('web_ui_clickjacking_protection_enabled', $('clickjacking_protection_checkbox').getProperty('checked'));
+            settings.set('web_ui_cors_header_enabled', $('cors_header_checkbox').getProperty('checked'));
             settings.set('web_ui_csrf_protection_enabled', $('csrf_protection_checkbox').getProperty('checked'));
             settings.set('web_ui_secure_cookie_enabled', $('secureCookieCheckbox').getProperty('checked'));
             settings.set('web_ui_host_header_validation_enabled', $('host_header_validation_checkbox').getProperty('checked'));

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -762,10 +762,6 @@
                 <label for="clickjacking_protection_checkbox">QBT_TR(Enable clickjacking protection)QBT_TR[CONTEXT=OptionsDialog]</label>
             </div>
             <div class="formRow">
-                <input type="checkbox" id="cors_header_checkbox" />
-                <label for="cors_header_checkbox">QBT_TR(Enable Cross-Origin requests)QBT_TR[CONTEXT=OptionsDialog]</label>
-            </div>
-            <div class="formRow">
                 <input type="checkbox" id="csrf_protection_checkbox" />
                 <label for="csrf_protection_checkbox">QBT_TR(Enable Cross-Site Request Forgery (CSRF) protection)QBT_TR[CONTEXT=OptionsDialog]</label>
             </div>
@@ -786,6 +782,22 @@
                         </td>
                         <td>
                             <textarea id="webui_domain_textarea" rows="1" cols="60"></textarea>
+                        </td>
+                    </tr>
+                </table>
+            </fieldset>
+            <fieldset class="settings">
+                <legend>
+                    <input type="checkbox" id="cors_header_checkbox" onclick="qBittorrent.Preferences.updateCorsHeaderSettings();" />
+                    <label for="cors_header_checkbox">QBT_TR(Enable Cross-Origin requests)QBT_TR[CONTEXT=OptionsDialog]</label>
+                </legend>
+                <table>
+                    <tr>
+                        <td>
+                            <label for="webui_cors_header_text">QBT_TR(Cross-Origin Domain:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                        </td>
+                        <td>
+                            <input type="text" id="webui_cors_header_text" />
                         </td>
                     </tr>
                 </table>
@@ -1143,6 +1155,7 @@
                 updateBypasssAuthSettings: updateBypasssAuthSettings,
                 updateAlternativeWebUISettings: updateAlternativeWebUISettings,
                 updateHostHeaderValidationSettings: updateHostHeaderValidationSettings,
+                updateCorsHeaderSettings: updateCorsHeaderSettings,
                 updateDynDnsSettings: updateDynDnsSettings,
                 registerDynDns: registerDynDns,
                 applyPreferences: applyPreferences
@@ -1390,6 +1403,11 @@
         const updateHostHeaderValidationSettings = function() {
             const isHostHeaderValidationEnabled = $('host_header_validation_checkbox').getProperty('checked');
             $('webui_domain_textarea').setProperty('disabled', !isHostHeaderValidationEnabled);
+        };
+
+        const updateCorsHeaderSettings = function() {
+            const isCorsHeaderEnabled = $('cors_header_checkbox').getProperty('checked');
+            $('webui_cors_header_text').setProperty('disabled', !isCorsHeaderEnabled);
         };
 
         const updateDynDnsSettings = function() {
@@ -1718,6 +1736,7 @@
 
                         // HTTP Server
                         $('webui_domain_textarea').setProperty('value', pref.web_ui_domain_list);
+                        $('webui_cors_header_text').setProperty('value', pref.web_ui_cors_header);
                         $('webui_address_value').setProperty('value', pref.web_ui_address);
                         $('webui_port_value').setProperty('value', pref.web_ui_port);
                         $('webui_upnp_checkbox').setProperty('checked', pref.web_ui_upnp);
@@ -1744,10 +1763,11 @@
                         // Security
                         $('clickjacking_protection_checkbox').setProperty('checked', pref.web_ui_clickjacking_protection_enabled);
                         $('csrf_protection_checkbox').setProperty('checked', pref.web_ui_csrf_protection_enabled);
-                        $('cors_header_checkbox').setProperty('checked', perf.web_ui_cors_header_enabled);
+                        $('cors_header_checkbox').setProperty('checked', pref.web_ui_cors_header_enabled);
                         $('secureCookieCheckbox').setProperty('checked', pref.web_ui_secure_cookie_enabled);
                         $('host_header_validation_checkbox').setProperty('checked', pref.web_ui_host_header_validation_enabled);
                         updateHostHeaderValidationSettings();
+                        updateCorsHeaderSettings();
 
                         // Update my dynamic domain name
                         $('use_dyndns_checkbox').setProperty('checked', pref.dyndns_enabled);
@@ -2066,6 +2086,7 @@
 
             // HTTP Server
             settings.set('web_ui_domain_list', $('webui_domain_textarea').getProperty('value'));
+            settings.set('web_ui_cors_header', $('webui_cors_header_text').getProperty('value'));
             const web_ui_address = $('webui_address_value').getProperty('value').toString();
             const web_ui_port = $('webui_port_value').getProperty('value').toInt();
             if (isNaN(web_ui_port) || web_ui_port < 1 || web_ui_port > 65535) {


### PR DESCRIPTION
This small patch allows the user to enable and enter a domain from where they would like to make requests to the web API.

This change is done through adding a HTTP header known as  `Access-Control-Allow-Origin`. You can read more about it here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin

This is useful for when you want to make requests to your qBittorrent instance from a web UI, hosted on another machine, with another hostname/IP Address.

Solves: #10478 

Screenshots of the UI changes:
Native UI: ![image](https://user-images.githubusercontent.com/37574510/79781128-51646880-833d-11ea-82ff-8bdf55f293af.png)

Web UI: 
![image](https://user-images.githubusercontent.com/37574510/79782023-b10f4380-833e-11ea-9cc8-3d02288f7db4.png)

This is what the reponse headers looks like when the option is enabled:
![image](https://user-images.githubusercontent.com/37574510/79782280-1e22d900-833f-11ea-9497-92866693e7dd.png)

and this is what the headers looks like when the option is disabled
![image](https://user-images.githubusercontent.com/37574510/79782407-532f2b80-833f-11ea-9db3-8356cfc6119a.png)

I was considering adding this as an "Advanced option" instead, if you think that's a better idea I'm more than happy to implement this change that way.



