### PR TITLE
Register datatype properly

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -759,4 +759,9 @@ namespace BitTorrent
     };
 }
 
+#if (QT_VERSION < QT_VERSION_CHECK(5, 10, 0))
+Q_DECLARE_METATYPE(std::shared_ptr<lt::entry>)
+const int sharedPtrLtEntryTypeID = qRegisterMetaType<std::shared_ptr<lt::entry>>();
+#endif
+
 #endif // BITTORRENT_SESSION_H


### PR DESCRIPTION
Qt 5.9.5 doesn't seem to recognize it, this patch fixes it.
Fix up: d8401c76f568e463022dd653124e8c99f33d0020.
Related: #12601.