### PR TITLE
Increase speed limit dialog's default maximum

### DIFF
--- a/src/gui/speedlimitdialog.cpp
+++ b/src/gui/speedlimitdialog.cpp
@@ -102,5 +102,6 @@ void SpeedLimitDialog::setupDialog(long maxSlider, long val)
 
     m_ui->bandwidthSlider->setMaximum(maxSlider);
     m_ui->bandwidthSlider->setValue(val);
+    m_ui->spinBandwidth->setMaximum(maxSlider);
     updateSpinValue(val);
 }

--- a/src/gui/speedlimitdialog.h
+++ b/src/gui/speedlimitdialog.h
@@ -43,7 +43,7 @@ class SpeedLimitDialog : public QDialog
 public:
     explicit SpeedLimitDialog(QWidget *parent);
     ~SpeedLimitDialog();
-    static long askSpeedLimit(QWidget *parent, bool *ok, const QString &title, long defaultVal, long maxVal = 10240000);
+    static long askSpeedLimit(QWidget *parent, bool *ok, const QString &title, long defaultVal, long maxVal = 102400000);
 
 private slots:
     void updateSpinValue(int val);


### PR DESCRIPTION
This PR changes the default maximum in the speed limit dialog from 10MiB/s to 100MiB/s, as it is a more realistic limit to want to select now that gigabit connections are common.

This affects the global upload and download speed limit dialogs triggered by clicking the status bar, which call `SpeedLimitDialog::askSpeedLimit` without overriding `maxVal`, but not the per-torrent ones, which use the global speed limit for `maxVal`.

This also fixes a related bug where the maximum value of the QSpinBox is not set at initialization. Now, both the QSpinBox and QSlider receive the same maximum.

Closes #10542.