### PR TITLE
Fix Web UI search categories only working in English

### DIFF
--- a/src/webui/api/searchcontroller.cpp
+++ b/src/webui/api/searchcontroller.cpp
@@ -43,8 +43,6 @@
 #include "apierror.h"
 #include "isessionmanager.h"
 
-class SearchPluginManager;
-
 using SearchHandlerPtr = QSharedPointer<SearchHandler>;
 using SearchHandlerDict = QMap<int, SearchHandlerPtr>;
 
@@ -58,6 +56,32 @@ namespace
         auto activeSearches = session->getData<QSet<int>>(ACTIVE_SEARCHES);
         if (activeSearches.remove(id))
             session->setData(ACTIVE_SEARCHES, QVariant::fromValue(activeSearches));
+    }
+
+    /**
+    * Returns the search categories in JSON format.
+    *
+    * The return value is an array of dictionaries.
+    * The dictionary keys are:
+    *   - "id"
+    *   - "name"
+    */
+    QJsonArray getPluginCategories(QStringList categories)
+    {
+        QJsonArray categoriesInfo {QJsonObject {
+            {QLatin1String("id"), "all"},
+            {QLatin1String("name"), SearchPluginManager::categoryFullName("all")}
+        }};
+
+        categories.sort(Qt::CaseInsensitive);
+        for (const QString &category : categories) {
+            categoriesInfo << QJsonObject {
+                {QLatin1String("id"), category},
+                {QLatin1String("name"), SearchPluginManager::categoryFullName(category)}
+            };
+        }
+
+        return categoriesInfo;
     }
 }
 
@@ -199,19 +223,6 @@ void SearchController::deleteAction()
     session->setData(SEARCH_HANDLERS, QVariant::fromValue(searchHandlers));
 
     removeActiveSearch(session, id);
-}
-
-void SearchController::categoriesAction()
-{
-    QStringList categories;
-    const QString name = params()["pluginName"].trimmed();
-
-    categories << SearchPluginManager::categoryFullName("all");
-    for (const QString &category : asConst(SearchPluginManager::instance()->getPluginCategories(name)))
-        categories << SearchPluginManager::categoryFullName(category);
-
-    const QJsonArray result = QJsonArray::fromStringList(categories);
-    setResult(result);
 }
 
 void SearchController::pluginsAction()
@@ -363,7 +374,7 @@ QJsonArray SearchController::getPluginsInfo(const QStringList &plugins) const
             {"version", QString(pluginInfo->version)},
             {"fullName", pluginInfo->fullName},
             {"url", pluginInfo->url},
-            {"supportedCategories", QJsonArray::fromStringList(pluginInfo->supportedCategories)},
+            {"supportedCategories", getPluginCategories(pluginInfo->supportedCategories)},
             {"enabled", pluginInfo->enabled}
         };
     }

--- a/src/webui/api/searchcontroller.h
+++ b/src/webui/api/searchcontroller.h
@@ -55,7 +55,6 @@ private slots:
     void statusAction();
     void resultsAction();
     void deleteAction();
-    void categoriesAction();
     void pluginsAction();
     void installPluginAction();
     void uninstallPluginAction();

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -43,7 +43,7 @@
 #include "base/utils/net.h"
 #include "base/utils/version.h"
 
-constexpr Utils::Version<int, 3, 2> API_VERSION {2, 5, 1};
+constexpr Utils::Version<int, 3, 2> API_VERSION {2, 6, 0};
 
 class APIController;
 class WebApplication;

--- a/src/webui/www/private/views/search.html
+++ b/src/webui/www/private/views/search.html
@@ -335,8 +335,6 @@
                 const plugins = $('pluginsSelect').getProperty('value');
 
                 if (!pattern || !category || !plugins) return;
-                if (category === "QBT_TR(All categories)QBT_TR[CONTEXT=SearchEngineWidget]")
-                    category = "all";
 
                 resetFilters();
 
@@ -462,36 +460,43 @@
             const populateCategorySelect = function(categories) {
                 const categoryHtml = [];
                 categories.each(function(category) {
-                    categoryHtml.push("<option>" + category + "</option>");
+                    const option = new Element("option");
+                    option.set("value", category.id);
+                    option.set("html", category.name);
+                    categoryHtml.push(option.outerHTML);
                 });
 
                 // first category is "All Categories"
-                if (categoryHtml.length > 1)
+                if (categoryHtml.length > 1) {
                     // add separator
-                    categoryHtml.splice(1, 0, "<option disabled>──────────</option>");
+                    const option = new Element("option");
+                    option.set("disabled", true);
+                    option.set("html", "──────────");
+                    categoryHtml.splice(1, 0, option.outerHTML);
+                }
 
                 $('categorySelect').set('html', categoryHtml.join(""));
             };
 
             const selectedPlugin = $('pluginsSelect').get("value");
+
             if ((selectedPlugin === "all") || (selectedPlugin === "enabled")) {
-                const url = new URI('api/v2/search/categories');
-                url.setData('name', selectedPlugin);
-                new Request.JSON({
-                    url: url,
-                    noCache: true,
-                    method: 'get',
-                    onSuccess: function(response) {
-                        populateCategorySelect(response);
-                    }
-                }).send();
+                const uniqueCategories = {};
+                for (const plugin of searchPlugins) {
+                    if ((selectedPlugin === "enabled") && !plugin.enabled) continue
+                    for (const category of plugin.supportedCategories) {
+                        if (uniqueCategories[category.id] === undefined) {
+                            uniqueCategories[category.id] = category;
+                        }
+                     }
+                }
+                // we must sort the ids to maintain consistent order.
+                const categories = Object.keys(uniqueCategories).sort().map(id => uniqueCategories[id]);
+                populateCategorySelect(categories);
             }
             else {
-                let plugins = ["QBT_TR(All categories)QBT_TR[CONTEXT=SearchEngineWidget]"];
                 const plugin = getPlugin(selectedPlugin);
-                if (plugin !== null)
-                    plugins = plugins.concat(plugin.supportedCategories);
-
+                const plugins = (plugin === null) ? [] : plugin.supportedCategories
                 populateCategorySelect(plugins);
             }
 


### PR DESCRIPTION
The Web UI's default "All categories" option used its translated name, rather than its id, as its value. This caused the option not to work when using other languages. Additionally, the Web UI only ever displayed search categories by their id, so they were never translated. Translated category names are now shown instead.

Closes #10239.

Before:
![Screen Shot 2020-04-30 at 1 00 07 AM](https://user-images.githubusercontent.com/8296030/80686737-0d304100-8a7e-11ea-98c2-8a3ba2cacf53.png)

After:
![Screen Shot 2020-04-30 at 1 01 55 AM](https://user-images.githubusercontent.com/8296030/80686835-3650d180-8a7e-11ea-8e65-431239de806e.png)


**TODO**
- [x] Update Web API documentation