### PR TITLE
Hide additional Web UI search filters on small screens

### DIFF
--- a/src/webui/www/private/views/search.html
+++ b/src/webui/www/private/views/search.html
@@ -49,6 +49,25 @@
         float: right;
     }
 
+    #searchResultsGranularFilters {
+        display: none;
+    }
+
+    #searchResultsGranularFiltersWarning {
+        vertical-align: bottom;
+        margin-left: 10px;
+    }
+
+    @media (min-width: 1060px) {
+        #searchResultsGranularFilters {
+            display: inline-block;
+        }
+
+        #searchResultsGranularFiltersWarning {
+            display: none;
+        }
+    }
+
 </style>
 
 <div id="searchResults">
@@ -86,33 +105,37 @@
                 <option value="everywhere">QBT_TR(Everywhere)QBT_TR[CONTEXT=SearchEngineWidget]</option>
             </select>
 
-            <span style="margin-left: 15px;">QBT_TR(Seeds:)QBT_TR[CONTEXT=SearchEngineWidget]</span>
-            <input type="number" min="0" max="1000" id="searchMinSeedsFilter" value="0" onchange="qBittorrent.Search.searchSeedsFilterChanged()">
-            <span>to</span>
-            <input type="number" min="0" max="1000" id="searchMaxSeedsFilter" value="0" onchange="qBittorrent.Search.searchSeedsFilterChanged()">
+            <img id="searchResultsGranularFiltersWarning" src="images/qbt-theme/dialog-warning.svg" title="QBT_TR(Increase window width to display additional filters)QBT_TR[CONTEXT=SearchEngineWidget]" alt="QBT_TR(Warning)QBT_TR[CONTEXT=SearchEngineWidget]" width="24" height="24">
 
-            <span style="margin-left: 15px;">QBT_TR(Size:)QBT_TR[CONTEXT=SearchEngineWidget]</span>
-            <input type="number" min="0" max="1000" step=".01" value="0.00" id="searchMinSizeFilter" onchange="qBittorrent.Search.searchSizeFilterChanged()">
-            <select id="searchMinSizePrefix" onchange="qBittorrent.Search.searchSizeFilterPrefixChanged()">
-                <option value="0">QBT_TR(B)QBT_TR[CONTEXT=misc]</option>
-                <option value="1">QBT_TR(KiB)QBT_TR[CONTEXT=misc]</option>
-                <option value="2" selected>QBT_TR(MiB)QBT_TR[CONTEXT=misc]</option>
-                <option value="3">QBT_TR(GiB)QBT_TR[CONTEXT=misc]</option>
-                <option value="4">QBT_TR(TiB)QBT_TR[CONTEXT=misc]</option>
-                <option value="5">QBT_TR(PiB)QBT_TR[CONTEXT=misc]</option>
-                <option value="6">QBT_TR(EiB)QBT_TR[CONTEXT=misc]</option>
-            </select>
-            <span>to</span>
-            <input type="number" min="0" max="1000" step=".01" value="0.00" id="searchMaxSizeFilter" onchange="qBittorrent.Search.searchSizeFilterChanged()">
-            <select id="searchMaxSizePrefix" onchange="qBittorrent.Search.searchSizeFilterPrefixChanged()">
-                <option value="0">QBT_TR(B)QBT_TR[CONTEXT=misc]</option>
-                <option value="1">QBT_TR(KiB)QBT_TR[CONTEXT=misc]</option>
-                <option value="2" selected>QBT_TR(MiB)QBT_TR[CONTEXT=misc]</option>
-                <option value="3">QBT_TR(GiB)QBT_TR[CONTEXT=misc]</option>
-                <option value="4">QBT_TR(TiB)QBT_TR[CONTEXT=misc]</option>
-                <option value="5">QBT_TR(PiB)QBT_TR[CONTEXT=misc]</option>
-                <option value="6">QBT_TR(EiB)QBT_TR[CONTEXT=misc]</option>
-            </select>
+            <div id="searchResultsGranularFilters">
+                <span style="margin-left: 15px;">QBT_TR(Seeds:)QBT_TR[CONTEXT=SearchEngineWidget]</span>
+                <input type="number" min="0" max="1000" id="searchMinSeedsFilter" value="0" onchange="qBittorrent.Search.searchSeedsFilterChanged()">
+                <span>to</span>
+                <input type="number" min="0" max="1000" id="searchMaxSeedsFilter" value="0" onchange="qBittorrent.Search.searchSeedsFilterChanged()">
+
+                <span style="margin-left: 15px;">QBT_TR(Size:)QBT_TR[CONTEXT=SearchEngineWidget]</span>
+                <input type="number" min="0" max="1000" step=".01" value="0.00" id="searchMinSizeFilter" onchange="qBittorrent.Search.searchSizeFilterChanged()">
+                <select id="searchMinSizePrefix" onchange="qBittorrent.Search.searchSizeFilterPrefixChanged()">
+                    <option value="0">QBT_TR(B)QBT_TR[CONTEXT=misc]</option>
+                    <option value="1">QBT_TR(KiB)QBT_TR[CONTEXT=misc]</option>
+                    <option value="2" selected>QBT_TR(MiB)QBT_TR[CONTEXT=misc]</option>
+                    <option value="3">QBT_TR(GiB)QBT_TR[CONTEXT=misc]</option>
+                    <option value="4">QBT_TR(TiB)QBT_TR[CONTEXT=misc]</option>
+                    <option value="5">QBT_TR(PiB)QBT_TR[CONTEXT=misc]</option>
+                    <option value="6">QBT_TR(EiB)QBT_TR[CONTEXT=misc]</option>
+                </select>
+                <span>to</span>
+                <input type="number" min="0" max="1000" step=".01" value="0.00" id="searchMaxSizeFilter" onchange="qBittorrent.Search.searchSizeFilterChanged()">
+                <select id="searchMaxSizePrefix" onchange="qBittorrent.Search.searchSizeFilterPrefixChanged()">
+                    <option value="0">QBT_TR(B)QBT_TR[CONTEXT=misc]</option>
+                    <option value="1">QBT_TR(KiB)QBT_TR[CONTEXT=misc]</option>
+                    <option value="2" selected>QBT_TR(MiB)QBT_TR[CONTEXT=misc]</option>
+                    <option value="3">QBT_TR(GiB)QBT_TR[CONTEXT=misc]</option>
+                    <option value="4">QBT_TR(TiB)QBT_TR[CONTEXT=misc]</option>
+                    <option value="5">QBT_TR(PiB)QBT_TR[CONTEXT=misc]</option>
+                    <option value="6">QBT_TR(EiB)QBT_TR[CONTEXT=misc]</option>
+                </select>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
Previously, the filters would collapse into a mostly-hidden, scrollable div. Now, we simply hide the more granular filters when running on a tiny screen.



Closes #11386.

Before:

![Screen Shot 2020-04-30 at 1 23 41 AM](https://user-images.githubusercontent.com/8296030/80688815-3ef6d700-8a81-11ea-8f34-c2ed52c6cd68.png)

After:
![Screen Shot 2020-04-30 at 5 16 40 PM](https://user-images.githubusercontent.com/8296030/80770862-66dc4e00-8b06-11ea-85ea-999a0e6f8a2a.png)
