### PR TITLE
Use latest CMake on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,10 @@ before_install:
     if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       # setup virtual display for after_success target
       if [ "$gui" = "true" ]; then export "DISPLAY=:99.0" && /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16 ; fi ;
-
+      # CMake from Kitware is installed in /usr/bin
+      # TravisCI installs its own cmake to another location which ovverides other installations
+      # if they don't call the new binary directly
+      alias cmake="/usr/bin/cmake"
     fi
   - |
     if [ "$TRAVIS_OS_NAME" = "osx" ]; then
@@ -111,6 +114,7 @@ install:
       PATH="/usr/local/opt/ccache/libexec:$PATH"
 
       brew update > /dev/null
+      brew upgrade cmake
       brew install ccache colormake boost openssl qt zlib
       brew link --force qt zlib
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,11 @@ if(POLICY CMP0074)
     cmake_policy(SET CMP0074 NEW)
 endif()
 
+# TODO: fix the macOS bundle stuff
+if(POLICY CMP0080)
+    cmake_policy(SET CMP0080 OLD)
+endif()
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
 include(FunctionReadVersion)
 


### PR DESCRIPTION
In the process of merging https://github.com/qbittorrent/qBittorrent/pull/12480, I accidentally clobbered part of a commit from @sledgehammer999 that fixed the travis build (https://github.com/qbittorrent/qBittorrent/commit/5afe892226e4c6c57cd2a9fce8200e7d0b72b2ce). Sorry about that.