### PR TITLE
Allow setting application palette from config.json

### DIFF
--- a/src/gui/uithememanager.h
+++ b/src/gui/uithememanager.h
@@ -29,9 +29,10 @@
 
 #pragma once
 
+#include <QColor>
+#include <QHash>
 #include <QObject>
-
-class QString;
+#include <QString>
 
 class UIThemeManager : public QObject
 {
@@ -49,11 +50,16 @@ public:
     QIcon getIcon(const QString &iconId, const QString &fallback) const;
     QIcon getFlagIcon(const QString &countryIsoCode) const;
 
+    QColor getColor(const QString &id, const QColor &defaultColor) const;
+
 private:
     UIThemeManager(); // singleton class
     QString getIconPath(const QString &iconId) const;
+    void loadColorsFromJSONConfig();
+    void applyPalette() const;
 
     static UIThemeManager *m_instance;
+    QHash<QString, QColor> m_colors;
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
     bool m_useSystemTheme;
 #endif


### PR DESCRIPTION
following #12143 but this time we do it from JSON file(`:uitheme/config.json`)

json file 
```json
{
    "colors": {
        "Palette.Window": "#353535",
        "Palette.WindowText": "white",
        "Palette.Base": "#191919",
        "Palette.AlternateBase": "#353535",
        "Palette.Text": "white",
        "Palette.ToolTipBase": "white",
        "Palette.ToolTipText": "white",
        "Palette.BrightText": "red",
        "Palette.Highlight": "#2a82da",
        "Palette.HighlightedText": "black",
        "Palette.Button": "#353535",
        "Palette.ButtonText": "white",
        "Palette.Link": "#2a82da",
        "Palette.LinkVisited": "darkgrey",
        "Palette.Light": "#353535",
        "Palette.Midlight": "#191919",
        "Palette.Mid": "#191919",
        "Palette.Dark": "darkgrey",
        "Palette.Shadow": "grey",
        "Palette.WindowTextDisabled": "#484848",
        "Palette.TextDisabled": "darkgrey",
        "Palette.ToolTipTextDisabled": "darkgrey",
        "Palette.BrightTextDisabled": "darkred",
        "Palette.HighlightedTextDisabled": "darkgrey",
        "Palette.ButtonTextDisabled": "grey"
    }
}
```
