### PR TITLE
Clean up header inclusion

### DIFF
--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -435,12 +435,12 @@
   <customwidget>
    <class>TorrentContentTreeView</class>
    <extends>QTreeView</extends>
-   <header>torrentcontenttreeview.h</header>
+   <header>gui/torrentcontenttreeview.h</header>
   </customwidget>
   <customwidget>
    <class>FileSystemPathComboEdit</class>
    <extends>QWidget</extends>
-   <header>fspathedit.h</header>
+   <header>gui/fspathedit.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -3388,7 +3388,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
   <customwidget>
    <class>FileSystemPathLineEdit</class>
    <extends>QWidget</extends>
-   <header>fspathedit.h</header>
+   <header>gui/fspathedit.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -68,7 +68,7 @@
 #include "ui_propertieswidget.h"
 
 #ifdef Q_OS_MACOS
-#include "macutilities.h"
+#include "gui/macutilities.h"
 #endif
 
 PropertiesWidget::PropertiesWidget(QWidget *parent)

--- a/src/gui/torrentcategorydialog.ui
+++ b/src/gui/torrentcategorydialog.ui
@@ -87,7 +87,7 @@
   <customwidget>
    <class>FileSystemPathComboEdit</class>
    <extends>QWidget</extends>
-   <header>fspathedit.h</header>
+   <header>gui/fspathedit.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
fixes build errors like that:
```
[ 34%] Building CXX object src/gui/CMakeFiles/qbt_gui.dir/categoryfiltermodel.cpp.o
cd /Users/nick/tmp/qBittorrent/build/src/gui && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -DBOOST_ALL_NO_LIB -DBOOST_NO_CXX11_RVALUE_REFERENCES -DQBT_VERSION=\"v4.3.0alpha1\" -DQBT_VERSION_2=\"4.3.0alpha1\" -DQBT_VERSION_BUGFIX=0 -DQBT_VERSION_BUILD=0 -DQBT_VERSION_MAJOR=4 -DQBT_VERSION_MINOR=3 -DQT_CORE_LIB -DQT_DEPRECATED_WARNINGS -DQT_GUI_LIB -DQT_MACEXTRAS_LIB -DQT_NETWORK_LIB -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_NO_DEBUG_OUTPUT -DQT_STRICT_ITERATORS -DQT_USE_QSTRINGBUILDER -DQT_WIDGETS_LIB -DQT_XML_LIB -DSTACKTRACE -I/Users/nick/tmp/qBittorrent/build/src/gui/qbt_gui_autogen/include -I/Users/nick/tmp/qBittorrent/src -isystem /Users/nick/tmp/qbt-work/include -iframework /Users/nick/tmp/qbt-work/lib -isystem /Users/nick/tmp/qbt-work/lib/QtCore.framework/Headers -isystem /Users/nick/tmp/qbt-work/./mkspecs/macx-clang -isystem /Users/nick/tmp/qbt-work/lib/QtNetwork.framework/Headers -isystem /Users/nick/tmp/qbt-work/lib/QtXml.framework/Headers -isystem /Users/nick/tmp/qbt-work/lib/QtGui.framework/Headers -isystem /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/OpenGL.framework/Headers -isystem /Users/nick/tmp/qbt-work/lib/QtWidgets.framework/Headers -isystem /Users/nick/tmp/qbt-work/lib/QtMacExtras.framework/Headers  -O3 -DNDEBUG -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -mmacosx-version-min=10.13   -DTORRENT_USE_LIBCRYPTO -DTORRENT_USE_OPENSSL -DBOOST_ASIO_ENABLE_CANCELIO -DUNICODE -D_UNICODE -D_FILE_OFFSET_BITS=64 -DTORRENT_LINKING_SHARED -DBOOST_SYSTEM_DYN_LINK -fPIC -std=c++14 -o CMakeFiles/qbt_gui.dir/categoryfiltermodel.cpp.o -c /Users/nick/tmp/qBittorrent/src/gui/categoryfiltermodel.cpp
In file included from /Users/nick/tmp/qBittorrent/src/gui/addnewtorrentdialog.cpp:58:
/Users/nick/tmp/qBittorrent/build/src/gui/qbt_gui_autogen/include/ui_addnewtorrentdialog.h:32:10: fatal error: 'fspathedit.h' file
      not found
#include "fspathedit.h"
         ^~~~~~~~~~~~~~
1 error generated.
make[2]: *** [src/gui/CMakeFiles/qbt_gui.dir/addnewtorrentdialog.cpp.o] Error 1
```
was detected trying to build on macOS using cmake

P.S> still have liking issues, but this is the reason to deal with cmake (I'm not familiar with it)