### PR TITLE
Prebuild HTTP headers

### DIFF
--- a/src/base/http/requestparser.cpp
+++ b/src/base/http/requestparser.cpp
@@ -57,7 +57,7 @@ namespace
         return in;
     }
 
-    bool parseHeaderLine(const QString &line, QStringMap &out)
+    bool parseHeaderLine(const QString &line, HeaderMap &out)
     {
         // [rfc7230] 3.2. Header Fields
         const int i = line.indexOf(':');
@@ -287,7 +287,7 @@ bool RequestParser::parseFormData(const QByteArray &data)
     const QString headers = QString::fromLatin1(list[0]);
     const QByteArray payload = viewWithoutEndingWith(list[1], CRLF);
 
-    QStringMap headersMap;
+    HeaderMap headersMap;
     const QVector<QStringRef> headerLines = headers.splitRef(CRLF, QString::SkipEmptyParts);
     for (const auto &line : headerLines) {
         if (line.trimmed().startsWith(HEADER_CONTENT_DISPOSITION, Qt::CaseInsensitive)) {

--- a/src/base/http/responsebuilder.cpp
+++ b/src/base/http/responsebuilder.cpp
@@ -35,9 +35,9 @@ void ResponseBuilder::status(const uint code, const QString &text)
     m_response.status = {code, text};
 }
 
-void ResponseBuilder::header(const QString &name, const QString &value)
+void ResponseBuilder::header(const Header &header)
 {
-    m_response.headers[name] = value;
+    m_response.headers[header.name] = header.value;
 }
 
 void ResponseBuilder::print(const QString &text, const QString &type)

--- a/src/base/http/responsebuilder.cpp
+++ b/src/base/http/responsebuilder.cpp
@@ -35,7 +35,7 @@ void ResponseBuilder::status(const uint code, const QString &text)
     m_response.status = {code, text};
 }
 
-void ResponseBuilder::header(const Header &header)
+void ResponseBuilder::setHeader(const Header &header)
 {
     m_response.headers[header.name] = header.value;
 }

--- a/src/base/http/responsebuilder.h
+++ b/src/base/http/responsebuilder.h
@@ -37,7 +37,7 @@ namespace Http
     {
     public:
         void status(uint code = 200, const QString &text = QLatin1String("OK"));
-        void header(const Header &header);
+        void setHeader(const Header &header);
         void print(const QString &text, const QString &type = CONTENT_TYPE_HTML);
         void print(const QByteArray &data, const QString &type = CONTENT_TYPE_HTML);
         void clear();

--- a/src/base/http/responsebuilder.h
+++ b/src/base/http/responsebuilder.h
@@ -37,7 +37,7 @@ namespace Http
     {
     public:
         void status(uint code = 200, const QString &text = QLatin1String("OK"));
-        void header(const QString &name, const QString &value);
+        void header(const Header &header);
         void print(const QString &text, const QString &type = CONTENT_TYPE_HTML);
         void print(const QByteArray &data, const QString &type = CONTENT_TYPE_HTML);
         void clear();

--- a/src/base/http/types.h
+++ b/src/base/http/types.h
@@ -92,6 +92,12 @@ namespace Http
         QByteArray data;
     };
 
+    struct Header
+    {
+        QString name;
+        QString value;
+    };
+
     struct Request
     {
         QString version;

--- a/src/base/http/types.h
+++ b/src/base/http/types.h
@@ -34,8 +34,6 @@
 #include <QString>
 #include <QVector>
 
-#include "base/types.h"
-
 namespace Http
 {
     const char METHOD_GET[] = "GET";
@@ -98,12 +96,14 @@ namespace Http
         QString value;
     };
 
+    using HeaderMap = QMap<QString, QString>;  // <Header name, Header value>
+
     struct Request
     {
         QString version;
         QString method;
         QString path;
-        QStringMap headers;
+        HeaderMap headers;
         QHash<QString, QByteArray> query;
         QHash<QString, QString> posts;
         QVector<UploadedFile> files;
@@ -118,7 +118,7 @@ namespace Http
     struct Response
     {
         ResponseStatus status;
-        QStringMap headers;
+        HeaderMap headers;
         QByteArray content;
 
         Response(uint code = 200, const QString &text = "OK")

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -400,7 +400,7 @@ void WebApplication::sendFile(const QString &path)
     const auto it = m_translatedFiles.constFind(path);
     if ((it != m_translatedFiles.constEnd()) && (lastModified <= it->lastModified)) {
         print(it->data, it->mimeType);
-        header(Http::HEADER_CACHE_CONTROL, getCachingInterval(it->mimeType));
+        header({Http::HEADER_CACHE_CONTROL, getCachingInterval(it->mimeType)});
         return;
     }
 
@@ -432,7 +432,7 @@ void WebApplication::sendFile(const QString &path)
     }
 
     print(data, mimeType.name());
-    header(Http::HEADER_CACHE_CONTROL, getCachingInterval(mimeType.name()));
+    header({Http::HEADER_CACHE_CONTROL, getCachingInterval(mimeType.name())});
 }
 
 Http::Response WebApplication::processRequest(const Http::Request &request, const Http::Environment &env)
@@ -469,8 +469,8 @@ Http::Response WebApplication::processRequest(const Http::Request &request, cons
             print(error.message(), Http::CONTENT_TYPE_TXT);
     }
 
-    for (const CustomHTTPHeader &prebuiltHeader : asConst(m_prebuiltHeaders))
-        header(prebuiltHeader.name, prebuiltHeader.value);
+    for (const Http::Header &prebuiltHeader : asConst(m_prebuiltHeaders))
+        header(prebuiltHeader);
 
     return response();
 }
@@ -562,7 +562,7 @@ void WebApplication::sessionStart()
     QByteArray cookieRawForm = cookie.toRawForm();
     if (m_isCSRFProtectionEnabled)
         cookieRawForm.append("; SameSite=Strict");
-    header(Http::HEADER_SET_COOKIE, cookieRawForm);
+    header({Http::HEADER_SET_COOKIE, cookieRawForm});
 }
 
 void WebApplication::sessionEnd()
@@ -576,7 +576,7 @@ void WebApplication::sessionEnd()
     delete m_sessions.take(m_currentSession->id());
     m_currentSession = nullptr;
 
-    header(Http::HEADER_SET_COOKIE, cookie.toRawForm());
+    header({Http::HEADER_SET_COOKIE, cookie.toRawForm()});
 }
 
 bool WebApplication::isCrossSiteRequest(const Http::Request &request) const

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -46,6 +46,7 @@
 #include "base/http/httperror.h"
 #include "base/logger.h"
 #include "base/preferences.h"
+#include "base/types.h"
 #include "base/utils/bytearray.h"
 #include "base/utils/fs.h"
 #include "base/utils/misc.h"

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -400,7 +400,7 @@ void WebApplication::sendFile(const QString &path)
     const auto it = m_translatedFiles.constFind(path);
     if ((it != m_translatedFiles.constEnd()) && (lastModified <= it->lastModified)) {
         print(it->data, it->mimeType);
-        header({Http::HEADER_CACHE_CONTROL, getCachingInterval(it->mimeType)});
+        setHeader({Http::HEADER_CACHE_CONTROL, getCachingInterval(it->mimeType)});
         return;
     }
 
@@ -432,7 +432,7 @@ void WebApplication::sendFile(const QString &path)
     }
 
     print(data, mimeType.name());
-    header({Http::HEADER_CACHE_CONTROL, getCachingInterval(mimeType.name())});
+    setHeader({Http::HEADER_CACHE_CONTROL, getCachingInterval(mimeType.name())});
 }
 
 Http::Response WebApplication::processRequest(const Http::Request &request, const Http::Environment &env)
@@ -470,7 +470,7 @@ Http::Response WebApplication::processRequest(const Http::Request &request, cons
     }
 
     for (const Http::Header &prebuiltHeader : asConst(m_prebuiltHeaders))
-        header(prebuiltHeader);
+        setHeader(prebuiltHeader);
 
     return response();
 }
@@ -562,7 +562,7 @@ void WebApplication::sessionStart()
     QByteArray cookieRawForm = cookie.toRawForm();
     if (m_isCSRFProtectionEnabled)
         cookieRawForm.append("; SameSite=Strict");
-    header({Http::HEADER_SET_COOKIE, cookieRawForm});
+    setHeader({Http::HEADER_SET_COOKIE, cookieRawForm});
 }
 
 void WebApplication::sessionEnd()
@@ -576,7 +576,7 @@ void WebApplication::sessionEnd()
     delete m_sessions.take(m_currentSession->id());
     m_currentSession = nullptr;
 
-    header({Http::HEADER_SET_COOKIE, cookie.toRawForm()});
+    setHeader({Http::HEADER_SET_COOKIE, cookie.toRawForm()});
 }
 
 bool WebApplication::isCrossSiteRequest(const Http::Request &request) const

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -156,12 +156,5 @@ private:
     bool m_isHostHeaderValidationEnabled;
     bool m_isHttpsEnabled;
 
-    // Custom HTTP headers
-    struct CustomHTTPHeader
-    {
-        QString name;
-        QString value;
-    };
-
-    QVector<CustomHTTPHeader> m_prebuiltHeaders;
+    QVector<Http::Header> m_prebuiltHeaders;
 };

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -151,12 +151,10 @@ private:
 
     // security related
     QStringList m_domainList;
-    bool m_isClickjackingProtectionEnabled;
     bool m_isCSRFProtectionEnabled;
     bool m_isSecureCookieEnabled;
     bool m_isHostHeaderValidationEnabled;
     bool m_isHttpsEnabled;
-    QString m_contentSecurityPolicy;
 
     // Custom HTTP headers
     struct CustomHTTPHeader
@@ -164,6 +162,6 @@ private:
         QString name;
         QString value;
     };
-    bool m_useCustomHTTPHeaders;
-    QVector<CustomHTTPHeader> m_customHTTPHeaders;
+
+    QVector<CustomHTTPHeader> m_prebuiltHeaders;
 };


### PR DESCRIPTION
* Prebuild HTTP headers as much as possible
  This avoids some branching when building a HTTP response.
* Define and use a proper HTTP header structure
* Rename function
* Define and use Http::HeaderMap type