### PR TITLE
Specify Content-Type in Web API error responses

### DIFF
--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -466,8 +466,7 @@ Http::Response WebApplication::processRequest(const Http::Request &request, cons
     }
     catch (const HTTPError &error) {
         status(error.statusCode(), error.statusText());
-        if (!error.message().isEmpty())
-            print(error.message(), Http::CONTENT_TYPE_TXT);
+        print((!error.message().isEmpty() ? error.message() : error.statusText()), Http::CONTENT_TYPE_TXT);
     }
 
     for (const Http::Header &prebuiltHeader : asConst(m_prebuiltHeaders))


### PR DESCRIPTION
Errors lacking a custom message (e.g. 404) don't specify a `Content-Type` header, causing browsers to download the response. With this PR, the error will now be displayed properly.