### PR TITLE
Fix Enter button behavior in web UI textarea

### DIFF
--- a/src/webui/www/private/addtrackers.html
+++ b/src/webui/www/private/addtrackers.html
@@ -14,10 +14,6 @@
             new Keyboard({
                 defaultEventType: 'keydown',
                 events: {
-                    'Enter': function(event) {
-                        $('addTrackersButton').click();
-                        event.preventDefault();
-                    },
                     'Escape': function(event) {
                         window.parent.closeWindows();
                         event.preventDefault();


### PR DESCRIPTION
Hitting the enter button inside the textarea would submit the form, rather than advancing to the next line.