### PR TITLE
Fix compilation error with msvc 16.6

### DIFF
--- a/src/gui/fspathedit.cpp
+++ b/src/gui/fspathedit.cpp
@@ -29,6 +29,7 @@
 #include "fspathedit.h"
 
 #include <memory>
+#include <stdexcept>
 
 #include <QAction>
 #include <QApplication>


### PR DESCRIPTION
Today I updated to msvc 16.6  and start getting this error 

```
..\src\gui\fspathedit.cpp(130): error C2039: 'logic_error': is not a member of 'std'                                    C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.26.28801\include\memory(24): note: see declaration of 'std'                                                                                                      ..\src\gui\fspathedit.cpp(130): error C3861: 'logic_error': identifier not found                                        ..\src\gui\fspathedit.cpp(149): error C2039: 'logic_error': is not a member of 'std'                                    C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.26.28801\include\memory(24): note: see declaration of 'std'                                                                                                      ..\src\gui\fspathedit.cpp(149): error C3861: 'logic_error': identifier not found                                        ..\src\gui\fspathedit.cpp(171): error C2039: 'logic_error': is not a member of 'std'                                    C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.26.28801\include\memory(24): note: see declaration of 'std'                                                                                                     
 ..\src\gui\fspathedit.cpp(171): error C3861: 'logic_error': identifier not found
```

https://github.com/qbittorrent/qBittorrent/pull/12874#issuecomment-631629201