### PR TITLE
Find complete files when checking torrent

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(qbt_base STATIC
     bittorrent/addtorrentparams.h
     bittorrent/bandwidthscheduler.h
     bittorrent/cachestatus.h
+    bittorrent/customstorage.h
     bittorrent/downloadpriority.h
     bittorrent/filterparserthread.h
     bittorrent/infohash.h
@@ -87,6 +88,7 @@ add_library(qbt_base STATIC
     # sources
     asyncfilestorage.cpp
     bittorrent/bandwidthscheduler.cpp
+    bittorrent/customstorage.cpp
     bittorrent/downloadpriority.cpp
     bittorrent/filterparserthread.cpp
     bittorrent/infohash.cpp

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(qbt_base STATIC
     bittorrent/addtorrentparams.h
     bittorrent/bandwidthscheduler.h
     bittorrent/cachestatus.h
+    bittorrent/common.h
     bittorrent/customstorage.h
     bittorrent/downloadpriority.h
     bittorrent/filterparserthread.h

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -1,9 +1,10 @@
 HEADERS += \
     $$PWD/algorithm.h \
     $$PWD/asyncfilestorage.h \
-    $$PWD/bittorrent/addtorrentparams.h  \
+    $$PWD/bittorrent/addtorrentparams.h \
     $$PWD/bittorrent/bandwidthscheduler.h \
     $$PWD/bittorrent/cachestatus.h \
+    $$PWD/bittorrent/common.h \
     $$PWD/bittorrent/customstorage.h \
     $$PWD/bittorrent/downloadpriority.h \
     $$PWD/bittorrent/filterparserthread.h \

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -4,6 +4,7 @@ HEADERS += \
     $$PWD/bittorrent/addtorrentparams.h  \
     $$PWD/bittorrent/bandwidthscheduler.h \
     $$PWD/bittorrent/cachestatus.h \
+    $$PWD/bittorrent/customstorage.h \
     $$PWD/bittorrent/downloadpriority.h \
     $$PWD/bittorrent/filterparserthread.h \
     $$PWD/bittorrent/infohash.h \
@@ -85,6 +86,7 @@ HEADERS += \
 SOURCES += \
     $$PWD/asyncfilestorage.cpp \
     $$PWD/bittorrent/bandwidthscheduler.cpp \
+    $$PWD/bittorrent/customstorage.cpp \
     $$PWD/bittorrent/downloadpriority.cpp \
     $$PWD/bittorrent/filterparserthread.cpp \
     $$PWD/bittorrent/infohash.cpp \

--- a/src/base/bittorrent/common.h
+++ b/src/base/bittorrent/common.h
@@ -1,7 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015  Vladimir Golovnev <glassez@yandex.ru>
- * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
+ * Copyright (C) 2020  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -27,35 +26,9 @@
  * exception statement from your version.
  */
 
-#include "torrenthandle.h"
+#pragma once
 
-#include <type_traits>
+#include <QString>
 
-namespace BitTorrent
-{
-    uint qHash(const BitTorrent::TorrentState key, const uint seed)
-    {
-        return ::qHash(static_cast<std::underlying_type_t<TorrentState>>(key), seed);
-    }
-
-    // TorrentHandle
-
-    const qreal TorrentHandle::USE_GLOBAL_RATIO = -2.;
-    const qreal TorrentHandle::NO_RATIO_LIMIT = -1.;
-
-    const int TorrentHandle::USE_GLOBAL_SEEDING_TIME = -2;
-    const int TorrentHandle::NO_SEEDING_TIME_LIMIT = -1;
-
-    const qreal TorrentHandle::MAX_RATIO = 9999.;
-    const int TorrentHandle::MAX_SEEDING_TIME = 525600;
-
-    void TorrentHandle::toggleSequentialDownload()
-    {
-        setSequentialDownload(!isSequentialDownload());
-    }
-
-    void TorrentHandle::toggleFirstLastPiecePriority()
-    {
-        setFirstLastPiecePriority(!hasFirstLastPiecePriority());
-    }
-}
+// TODO: Make it inline in C++17
+extern const QString QB_EXT;

--- a/src/base/bittorrent/customstorage.cpp
+++ b/src/base/bittorrent/customstorage.cpp
@@ -34,8 +34,7 @@
 #include <QDir>
 
 #include "base/utils/fs.h"
-
-extern const QString QB_EXT {QStringLiteral(".!qB")};
+#include "common.h"
 
 lt::storage_interface *customStorageConstructor(const lt::storage_params &params, lt::file_pool &pool)
 {

--- a/src/base/bittorrent/customstorage.cpp
+++ b/src/base/bittorrent/customstorage.cpp
@@ -1,0 +1,94 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2020  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "customstorage.h"
+
+#if (LIBTORRENT_VERSION_NUM >= 10200)
+#include <libtorrent/download_priority.hpp>
+
+#include <QDir>
+
+#include "base/utils/fs.h"
+
+extern const QString QB_EXT {QStringLiteral(".!qB")};
+
+lt::storage_interface *customStorageConstructor(const lt::storage_params &params, lt::file_pool &pool)
+{
+    return new CustomStorage {params, pool};
+}
+
+CustomStorage::CustomStorage(const lt::storage_params &params, lt::file_pool &filePool)
+    : lt::default_storage {params, filePool}
+{
+    m_savePath = Utils::Fs::expandPathAbs(QString::fromStdString(params.path));
+}
+
+bool CustomStorage::verify_resume_data(const lt::add_torrent_params &rd, const lt::aux::vector<std::string, lt::file_index_t> &links, lt::storage_error &ec)
+{
+    const QDir saveDir {m_savePath};
+
+    const lt::file_storage &fileStorage = files();
+    for (const lt::file_index_t fileIndex : fileStorage.file_range()) {
+        // ignore files that have priority 0
+        if ((m_filePriorities.end_index() > fileIndex) && (m_filePriorities[fileIndex] == lt::dont_download))
+            continue;
+
+        // ignore pad files
+        if (fileStorage.pad_file_at(fileIndex)) continue;
+
+        const QString filePath = QString::fromStdString(fileStorage.file_path(fileIndex));
+        if (filePath.endsWith(QB_EXT)) {
+            const QString completeFilePath = filePath.left(filePath.size() - QB_EXT.size());
+            QFile completeFile {saveDir.absoluteFilePath(completeFilePath)};
+            if (completeFile.exists()) {
+                QFile currentFile {saveDir.absoluteFilePath(filePath)};
+                if (currentFile.exists())
+                    currentFile.remove();
+                completeFile.rename(currentFile.fileName());
+            }
+        }
+    }
+
+    return lt::default_storage::verify_resume_data(rd, links, ec);
+}
+
+void CustomStorage::set_file_priority(lt::aux::vector<lt::download_priority_t, lt::file_index_t> &priorities, lt::storage_error &ec)
+{
+    m_filePriorities = priorities;
+    lt::default_storage::set_file_priority(priorities, ec);
+}
+
+lt::status_t CustomStorage::move_storage(const std::string &savePath, lt::move_flags_t flags, lt::storage_error &ec)
+{
+    const lt::status_t ret = lt::default_storage::move_storage(savePath, flags, ec);
+    if (ret != lt::status_t::fatal_disk_error)
+        m_savePath = Utils::Fs::expandPathAbs(QString::fromStdString(savePath));
+
+    return ret;
+}
+#endif

--- a/src/base/bittorrent/customstorage.h
+++ b/src/base/bittorrent/customstorage.h
@@ -1,0 +1,55 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2020  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+#include <libtorrent/version.hpp>
+
+#if (LIBTORRENT_VERSION_NUM >= 10200)
+#include <libtorrent/aux_/vector.hpp>
+#include <libtorrent/fwd.hpp>
+#include <libtorrent/storage.hpp>
+
+#include <QString>
+
+lt::storage_interface *customStorageConstructor(const lt::storage_params &params, lt::file_pool &pool);
+
+class CustomStorage final : public lt::default_storage
+{
+public:
+    explicit CustomStorage(const lt::storage_params &params, lt::file_pool &filePool);
+
+    bool verify_resume_data(const lt::add_torrent_params &rd, const lt::aux::vector<std::string, lt::file_index_t> &links, lt::storage_error &ec) override;
+    void set_file_priority(lt::aux::vector<lt::download_priority_t, lt::file_index_t> &priorities, lt::storage_error &ec) override;
+    lt::status_t move_storage(const std::string &savePath, lt::move_flags_t flags, lt::storage_error &ec) override;
+
+private:
+    lt::aux::vector<lt::download_priority_t, lt::file_index_t> m_filePriorities;
+    QString m_savePath;
+};
+#endif

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -94,6 +94,7 @@
 #include "base/utils/net.h"
 #include "base/utils/random.h"
 #include "bandwidthscheduler.h"
+#include "common.h"
 #include "customstorage.h"
 #include "filterparserthread.h"
 #include "ltunderlyingtype.h"

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -94,6 +94,7 @@
 #include "base/utils/net.h"
 #include "base/utils/random.h"
 #include "bandwidthscheduler.h"
+#include "customstorage.h"
 #include "filterparserthread.h"
 #include "ltunderlyingtype.h"
 #include "magneturi.h"
@@ -2456,6 +2457,8 @@ bool Session::addTorrent_impl(CreateTorrentParams params, const MagnetUri &magne
     p.max_connections = maxConnectionsPerTorrent();
     p.max_uploads = maxUploadsPerTorrent();
 
+    p.storage = customStorageConstructor;
+
     m_addingTorrents.insert(hash, params);
     // Adding torrent to BitTorrent session
     m_nativeSession->async_add_torrent(p);
@@ -2528,21 +2531,23 @@ bool Session::loadMetadata(const MagnetUri &magnetUri)
     const QString savePath = Utils::Fs::tempPath() + static_cast<QString>(hash);
     p.save_path = Utils::Fs::toNativePath(savePath).toStdString();
 
-    // Forced start
 #if (LIBTORRENT_VERSION_NUM < 10200)
+    // Forced start
     p.flags &= ~lt::add_torrent_params::flag_paused;
     p.flags &= ~lt::add_torrent_params::flag_auto_managed;
-#else
-    p.flags &= ~lt::torrent_flags::paused;
-    p.flags &= ~lt::torrent_flags::auto_managed;
-#endif
 
     // Solution to avoid accidental file writes
-#if (LIBTORRENT_VERSION_NUM < 10200)
     p.flags |= lt::add_torrent_params::flag_upload_mode;
 #else
+    // Forced start
+    p.flags &= ~lt::torrent_flags::paused;
+    p.flags &= ~lt::torrent_flags::auto_managed;
+
+    // Solution to avoid accidental file writes
     p.flags |= lt::torrent_flags::upload_mode;
-#endif
+
+    p.storage = customStorageConstructor;
+#endif    
 
     // Adding torrent to BitTorrent session
     lt::error_code ec;

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -40,8 +40,6 @@ class QDateTime;
 class QStringList;
 class QUrl;
 
-extern const QString QB_EXT;
-
 namespace BitTorrent
 {
     enum class DownloadPriority;

--- a/src/base/bittorrent/torrenthandleimpl.cpp
+++ b/src/base/bittorrent/torrenthandleimpl.cpp
@@ -65,12 +65,15 @@
 #include "base/tristatebool.h"
 #include "base/utils/fs.h"
 #include "base/utils/string.h"
+#include "common.h"
 #include "downloadpriority.h"
 #include "ltunderlyingtype.h"
 #include "peeraddress.h"
 #include "peerinfo.h"
 #include "session.h"
 #include "trackerentry.h"
+
+const QString QB_EXT {QStringLiteral(".!qB")};
 
 using namespace BitTorrent;
 

--- a/src/base/utils/fs.cpp
+++ b/src/base/utils/fs.cpp
@@ -58,7 +58,7 @@
 #include <QStorageInfo>
 #include <QRegularExpression>
 
-#include "base/bittorrent/torrenthandle.h"
+#include "base/bittorrent/common.h"
 #include "base/global.h"
 
 QString Utils::Fs::toNativePath(const QString &path)

--- a/src/gui/previewselectdialog.cpp
+++ b/src/gui/previewselectdialog.cpp
@@ -36,6 +36,7 @@
 #include <QStandardItemModel>
 #include <QTableView>
 
+#include "base/bittorrent/common.h"
 #include "base/bittorrent/torrenthandle.h"
 #include "base/preferences.h"
 #include "base/utils/fs.h"

--- a/src/gui/torrentcontentmodelfile.cpp
+++ b/src/gui/torrentcontentmodelfile.cpp
@@ -28,7 +28,7 @@
 
 #include "torrentcontentmodelfile.h"
 
-#include "base/bittorrent/torrenthandle.h"
+#include "base/bittorrent/common.h"
 #include "torrentcontentmodelfolder.h"
 
 TorrentContentModelFile::TorrentContentModelFile(const QString &fileName, qulonglong fileSize,

--- a/src/gui/torrentcontentmodelfolder.cpp
+++ b/src/gui/torrentcontentmodelfolder.cpp
@@ -30,7 +30,7 @@
 
 #include <QVariant>
 
-#include "base/bittorrent/torrenthandle.h"
+#include "base/bittorrent/common.h"
 #include "base/global.h"
 
 TorrentContentModelFolder::TorrentContentModelFolder(const QString &name, TorrentContentModelFolder *parent)

--- a/src/gui/torrentcontenttreeview.cpp
+++ b/src/gui/torrentcontenttreeview.cpp
@@ -37,6 +37,7 @@
 #include <QTableView>
 #include <QThread>
 
+#include "base/bittorrent/common.h"
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/torrenthandle.h"
 #include "base/bittorrent/torrentinfo.h"

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -39,6 +39,7 @@
 #include <QRegularExpression>
 #include <QUrl>
 
+#include "base/bittorrent/common.h"
 #include "base/bittorrent/downloadpriority.h"
 #include "base/bittorrent/infohash.h"
 #include "base/bittorrent/peeraddress.h"


### PR DESCRIPTION
Users often put completed files (obtained from another sources) in the torrent folder and perform "force recheck", but qBittorrent keeps proceed with incomplete ones before. Now it prefers files without ".!qb" extension when torrent is checking.
It is implemented via the extension of default torrent storage to make sure that operations with files are performed when they are released by libtorrent. An additional advantage is that file renaming also occurs in the disk thread.

"Find complete files" when moving torrent storage is scheduled to be implemented after merging this PR.

These PRs should close some of "checking"-related Issues, but I'm not sure exactly which ones, nor am I sure they will close these Issues completely, so I didn't link them here.

P.S. It doesn't support libtorrent-1.1 (softly, it will simply remain without this feature) and I'm extremely not in the mood to care about it. So if there are contradictions here, I'd even rather wait to merge it when we drop libtorrent-1.1 support than waste my time on adding libtorrent-1.1 support (it shouldn't be that difficult, but I don't have the ability to test and maintain it there).