### PR TITLE
Improvements to UIThemeManager

### DIFF
--- a/src/gui/rss/feedlistwidget.cpp
+++ b/src/gui/rss/feedlistwidget.cpp
@@ -85,13 +85,13 @@ void FeedListWidget::handleFeedStateChanged(RSS::Feed *feed)
 
     QIcon icon;
     if (feed->isLoading())
-        icon = UIThemeManager::instance()->getIcon(QStringLiteral("loading"));
+        icon = UIThemeManager::instance()->getIcon(QLatin1String("loading"));
     else if (feed->hasError())
-        icon = UIThemeManager::instance()->getIcon(QStringLiteral("unavailable"));
+        icon = UIThemeManager::instance()->getIcon(QLatin1String("unavailable"));
     else if (!feed->iconPath().isEmpty())
         icon = QIcon(feed->iconPath());
     else
-        icon = UIThemeManager::instance()->getIcon(QStringLiteral("application-rss+xml"));
+        icon = UIThemeManager::instance()->getIcon(QLatin1String("application-rss+xml"));
     item->setData(0, Qt::DecorationRole, icon);
 }
 
@@ -237,14 +237,14 @@ QTreeWidgetItem *FeedListWidget::createItem(RSS::Item *rssItem, QTreeWidgetItem 
         if (feed->isLoading())
             icon = UIThemeManager::instance()->getIcon(QLatin1String("loading"));
         else if (feed->hasError())
-            icon = UIThemeManager::instance()->getIcon(QStringLiteral("unavailable"));
+            icon = UIThemeManager::instance()->getIcon(QLatin1String("unavailable"));
         else if (!feed->iconPath().isEmpty())
             icon = QIcon(feed->iconPath());
         else
-            icon = UIThemeManager::instance()->getIcon(QStringLiteral("application-rss+xml"));
+            icon = UIThemeManager::instance()->getIcon(QLatin1String("application-rss+xml"));
     }
     else {
-        icon = UIThemeManager::instance()->getIcon("inode-directory");
+        icon = UIThemeManager::instance()->getIcon(QLatin1String("inode-directory"));
     }
     item->setData(0, Qt::DecorationRole, icon);
 

--- a/src/gui/uithememanager.cpp
+++ b/src/gui/uithememanager.cpp
@@ -31,7 +31,6 @@
 
 #include <QApplication>
 #include <QFile>
-#include <QIcon>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QPalette>
@@ -127,14 +126,15 @@ QIcon UIThemeManager::getIcon(const QString &iconId, const QString &fallback) co
         return icon;
     }
 #endif
-    // cache to avoid rescaling svg icons
-    static QHash<QString, QIcon> iconCache;
-    const auto iter = iconCache.find(iconId);
-    if (iter != iconCache.end())
+
+    // Cache to avoid rescaling svg icons
+    // And don't cache system icons because users might change them at run time
+    const auto iter = m_iconCache.find(iconId);
+    if (iter != m_iconCache.end())
         return *iter;
 
     const QIcon icon {getIconPathFromResources(iconId, fallback)};
-    iconCache[iconId] = icon;
+    m_iconCache[iconId] = icon;
     return icon;
 }
 
@@ -153,7 +153,7 @@ QString UIThemeManager::getIconPath(const QString &iconId) const
 {
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
     if (m_useSystemTheme) {
-        QString path = Utils::Fs::tempPath() + iconId + ".png";
+        QString path = Utils::Fs::tempPath() + iconId + QLatin1String(".png");
         if (!QFile::exists(path)) {
             const QIcon icon = QIcon::fromTheme(iconId);
             if (!icon.isNull())

--- a/src/gui/uithememanager.cpp
+++ b/src/gui/uithememanager.cpp
@@ -76,6 +76,9 @@ void UIThemeManager::initInstance()
 
 UIThemeManager::UIThemeManager()
     : m_useCustomTheme(Preferences::instance()->useCustomUITheme())
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
+    , m_useSystemTheme(Preferences::instance()->useSystemIconTheme())
+#endif
 {
     const Preferences *const pref = Preferences::instance();
     if (m_useCustomTheme) {
@@ -87,10 +90,6 @@ UIThemeManager::UIThemeManager()
             applyPalette();
         }
     }
-
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
-    m_useSystemTheme = pref->useSystemIconTheme();
-#endif
 }
 
 UIThemeManager *UIThemeManager::instance()

--- a/src/gui/uithememanager.h
+++ b/src/gui/uithememanager.h
@@ -64,6 +64,6 @@ private:
     mutable QHash<QString, QIcon> m_iconCache;
     const bool m_useCustomTheme;
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
-    bool m_useSystemTheme;
+    const bool m_useSystemTheme;
 #endif
 };

--- a/src/gui/uithememanager.h
+++ b/src/gui/uithememanager.h
@@ -31,6 +31,7 @@
 
 #include <QColor>
 #include <QHash>
+#include <QIcon>
 #include <QObject>
 #include <QString>
 
@@ -60,6 +61,7 @@ private:
 
     static UIThemeManager *m_instance;
     QHash<QString, QColor> m_colors;
+    mutable QHash<QString, QIcon> m_iconCache;
     const bool m_useCustomTheme;
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
     bool m_useSystemTheme;


### PR DESCRIPTION
* Make the icon cache a class variable
* Make class variable const
* Avoid overuse of QStringLiteral
  This code path doesn't look like frequently used.

