### PR TITLE
WebUI: Fix wrong file renaming selection range

### DIFF
--- a/src/webui/www/private/rename_file.html
+++ b/src/webui/www/private/rename_file.html
@@ -38,7 +38,7 @@
             const decodedName = decodeURIComponent(name);
             $('rename').value = decodedName;
             $('rename').focus();
-            $('rename').setSelectionRange(0, decodedName.indexOf('.'));
+            $('rename').setSelectionRange(0, decodedName.lastIndexOf('.'));
 
             $('renameButton').addEvent('click', function(e) {
                 new Event(e).stop();


### PR DESCRIPTION
Now select the full file name instead of the part before the first dot.

Before:
![before](https://user-images.githubusercontent.com/19818121/82880307-d2340700-9f70-11ea-95c1-03a9d874dc76.png)

After:
![after](https://user-images.githubusercontent.com/19818121/82880315-d6602480-9f70-11ea-890e-dd1cd111c10d.png)
