### PR TITLE
Cache country lookup result in PeerInfo class

### DIFF
--- a/src/base/bittorrent/peerinfo.cpp
+++ b/src/base/bittorrent/peerinfo.cpp
@@ -64,7 +64,9 @@ bool PeerInfo::fromLSD() const
 #ifndef DISABLE_COUNTRIES_RESOLUTION
 QString PeerInfo::country() const
 {
-    return Net::GeoIPManager::instance()->lookup(address().ip);
+    if (m_country.isEmpty())
+        m_country = Net::GeoIPManager::instance()->lookup(address().ip);
+    return m_country;
 }
 #endif
 

--- a/src/base/bittorrent/peerinfo.h
+++ b/src/base/bittorrent/peerinfo.h
@@ -102,6 +102,10 @@ namespace BitTorrent
         qreal m_relevance = 0;
         QString m_flags;
         QString m_flagsDescription;
+
+#ifndef DISABLE_COUNTRIES_RESOLUTION
+        mutable QString m_country;
+#endif
     };
 }
 


### PR DESCRIPTION
The country lookup happens quite often when "Resolve peer countries" option is enabled.