### PR TITLE
Fix typo in systemd service file

### DIFF
--- a/dist/unix/systemd/qbittorrent-nox@.service.in
+++ b/dist/unix/systemd/qbittorrent-nox@.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=qBittorrenti-nox service for user %I
+Description=qBittorrent-nox service for user %I
 Documentation=man:qbittorrent-nox(1)
 Wants=network-online.target
 After=network-online.target nss-lookup.target


### PR DESCRIPTION
`qBittorrenti` -> `qBittorrent`

Pretty inconsequential, but I've been staring at it for years and I finally decided to do something about it.