### PR TITLE
Don't use functions deprecated in Qt 5.15 

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -387,7 +387,16 @@ void Application::runExternalProgram(const BitTorrent::TorrentHandle *torrent) c
     // enable command injection via torrent name and other arguments
     // (especially when some automated download mechanism has been setup).
     // See: https://github.com/qbittorrent/qBittorrent/issues/10925
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+    QStringList args = QProcess::splitCommand(program);
+    if (args.isEmpty())
+        return;
+
+    const QString command = args.takeFirst();
+    QProcess::startDetached(command, args);
+#else
     QProcess::startDetached(program);
+#endif
 #endif
 }
 

--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -565,7 +565,6 @@ QString makeUsage(const QString &prgName)
            << QLatin1String("QBT_NO_SPLASH=1 ") << prgName << '\n'
            << wrapText(QObject::tr("Command line parameters take precedence over environment variables"), 0) << '\n';
 
-    stream << flush;
     return text;
 }
 

--- a/src/base/algorithm.h
+++ b/src/base/algorithm.h
@@ -54,7 +54,7 @@ namespace Algorithm
     {
         auto it = dict.begin();
         while (it != dict.end())
-            it = (p(it.key(), it.value()) ? dict.erase(it) : (it + 1));
+            it = (p(it.key(), it.value()) ? dict.erase(it) : ++it);
     }
 
     // To be used with set types, such as QSet, std::set
@@ -64,6 +64,6 @@ namespace Algorithm
     {
         auto it = set.begin();
         while (it != set.end())
-            it = (p(*it) ? set.erase(it) : (it + 1));
+            it = (p(*it) ? set.erase(it) : ++it);
     }
 }

--- a/src/base/net/smtp.cpp
+++ b/src/base/net/smtp.cpp
@@ -113,8 +113,12 @@ Smtp::Smtp(QObject *parent)
 
     connect(m_socket, &QIODevice::readyRead, this, &Smtp::readyRead);
     connect(m_socket, &QAbstractSocket::disconnected, this, &QObject::deleteLater);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+    connect(m_socket, &QAbstractSocket::errorOccurred, this, &Smtp::error);
+#else
     connect(m_socket, qOverload<QAbstractSocket::SocketError>(&QAbstractSocket::error)
             , this, &Smtp::error);
+#endif
 
     // Test hmacMD5 function (http://www.faqs.org/rfcs/rfc2202.html)
     Q_ASSERT(hmacMD5("Jefe", "what do ya want for nothing?").toHex()

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -451,7 +451,14 @@ void PeerListWidget::wheelEvent(QWheelEvent *event)
         // Shift + scroll = horizontal scroll
         event->accept();
 
-        QWheelEvent scrollHEvent(event->pos(), event->globalPos(), event->delta(), event->buttons(), event->modifiers(), Qt::Horizontal);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        QWheelEvent scrollHEvent(event->position(), event->globalPosition()
+            , event->pixelDelta(), event->angleDelta().transposed(), event->buttons()
+            , event->modifiers(), event->phase(), event->inverted(), event->source());
+#else
+        QWheelEvent scrollHEvent(event->pos(), event->globalPos()
+            , event->delta(), event->buttons(), event->modifiers(), Qt::Horizontal);
+#endif
         QTreeView::wheelEvent(&scrollHEvent);
         return;
     }

--- a/src/gui/properties/proptabbar.cpp
+++ b/src/gui/properties/proptabbar.cpp
@@ -100,8 +100,13 @@ PropTabBar::PropTabBar(QWidget *parent)
     addWidget(speedButton);
     m_btnGroup->addButton(speedButton, SpeedTab);
     // SIGNAL/SLOT
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+    connect(m_btnGroup, &QButtonGroup::idClicked
+            , this, &PropTabBar::setCurrentIndex);
+#else
     connect(m_btnGroup, qOverload<int>(&QButtonGroup::buttonClicked)
             , this, &PropTabBar::setCurrentIndex);
+#endif
     // Disable buttons focus
     for (QAbstractButton *btn : asConst(m_btnGroup->buttons()))
         btn->setFocusPolicy(Qt::NoFocus);

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -99,7 +99,7 @@ SearchWidget::SearchWidget(MainWindow *mainWindow)
            << tr("<b>&quot;foo bar&quot;</b>: search for <b>foo bar</b>",
                  "Search phrase example, illustrates quotes usage, double quoted"
                  "pair of space delimited words, the whole pair is highlighted")
-           << "</p></body></html>" << flush;
+           << "</p></body></html>";
     m_ui->lineEditSearchPattern->setToolTip(searchPatternHint);
 
 #ifndef Q_OS_MACOS

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -599,18 +599,15 @@ int TrackerFiltersList::rowFromTracker(const QString &tracker) const
 
 QString TrackerFiltersList::getHost(const QString &tracker) const
 {
-    QUrl url(tracker);
-    QString longHost = url.host();
-    QString tld = url.topLevelDomain();
-    // We get empty tld when it is invalid or an IPv4/IPv6 address,
-    // so just return the full host
-    if (tld.isEmpty())
-        return longHost;
     // We want the domain + tld. Subdomains should be disregarded
-    int index = longHost.lastIndexOf('.', -(tld.size() + 1));
-    if (index == -1)
-        return longHost;
-    return longHost.mid(index + 1);
+    const QUrl url {tracker};
+    const QString host {url.host()};
+
+    // host is in IP format
+    if (!QHostAddress(host).isNull())
+        return host;
+
+    return host.section('.', -2, -1);
 }
 
 QStringList TrackerFiltersList::getHashes(const int row) const

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -1204,7 +1204,14 @@ void TransferListWidget::wheelEvent(QWheelEvent *event)
         // Shift + scroll = horizontal scroll
         event->accept();
 
-        QWheelEvent scrollHEvent(event->pos(), event->globalPos(), event->delta(), event->buttons(), event->modifiers(), Qt::Horizontal);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        QWheelEvent scrollHEvent(event->position(), event->globalPosition()
+            , event->pixelDelta(), event->angleDelta().transposed(), event->buttons()
+            , event->modifiers(), event->phase(), event->inverted(), event->source());
+#else
+        QWheelEvent scrollHEvent(event->pos(), event->globalPos()
+            , event->delta(), event->buttons(), event->modifiers(), Qt::Horizontal);
+#endif
         QTreeView::wheelEvent(&scrollHEvent);
         return;
     }


### PR DESCRIPTION
* Don't use deprecated QTextStreamFunctions::flush()
* Don't use deprecated QSet::iterator::operator+(int)
* Don't use deprecated QAbstractSocket::error()
* Don't use QWheelEvent deprecated functions
* Don't use deprecated QButtonGroup::buttonClicked()
* Don't use deprecated QUrl::topLevelDomain()
* Don't use deprecated QProcess::startDetached() overload 
