### PR TITLE
Disable libtorrent-1.2 custom storage when building against libtorrent-2.0

### DIFF
--- a/src/base/bittorrent/customstorage.cpp
+++ b/src/base/bittorrent/customstorage.cpp
@@ -28,7 +28,7 @@
 
 #include "customstorage.h"
 
-#if (LIBTORRENT_VERSION_NUM >= 10200)
+#if (LIBTORRENT_VERSION_NUM >= 10200) && (LIBTORRENT_VERSION_NUM < 20000)
 #include <libtorrent/download_priority.hpp>
 
 #include <QDir>

--- a/src/base/bittorrent/customstorage.h
+++ b/src/base/bittorrent/customstorage.h
@@ -30,7 +30,7 @@
 
 #include <libtorrent/version.hpp>
 
-#if (LIBTORRENT_VERSION_NUM >= 10200)
+#if (LIBTORRENT_VERSION_NUM >= 10200) && (LIBTORRENT_VERSION_NUM < 20000)
 #include <libtorrent/aux_/vector.hpp>
 #include <libtorrent/fwd.hpp>
 #include <libtorrent/storage.hpp>

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -2113,7 +2113,7 @@ bool Session::addTorrent(const TorrentInfo &torrentInfo, const AddTorrentParams 
 bool Session::addTorrent_impl(CreateTorrentParams params, const MagnetUri &magnetUri,
                               TorrentInfo torrentInfo, const QByteArray &fastresumeData)
 {
-#if (LIBTORRENT_VERSION_NUM < 10200)
+#if (LIBTORRENT_VERSION_NUM < 10200) || (LIBTORRENT_VERSION_NUM >= 20000)
     params.savePath = normalizeSavePath(params.savePath, "");
 
     if (!params.category.isEmpty()) {
@@ -2532,7 +2532,7 @@ bool Session::loadMetadata(const MagnetUri &magnetUri)
     const QString savePath = Utils::Fs::tempPath() + static_cast<QString>(hash);
     p.save_path = Utils::Fs::toNativePath(savePath).toStdString();
 
-#if (LIBTORRENT_VERSION_NUM < 10200)
+#if (LIBTORRENT_VERSION_NUM < 10200) || (LIBTORRENT_VERSION_NUM >= 20000)
     // Forced start
     p.flags &= ~lt::add_torrent_params::flag_paused;
     p.flags &= ~lt::add_torrent_params::flag_auto_managed;
@@ -2548,7 +2548,7 @@ bool Session::loadMetadata(const MagnetUri &magnetUri)
     p.flags |= lt::torrent_flags::upload_mode;
 
     p.storage = customStorageConstructor;
-#endif    
+#endif
 
     // Adding torrent to BitTorrent session
     lt::error_code ec;


### PR DESCRIPTION
libtorrent-2.0 has a new disk I/O subsystem and a different (incompatible)
storage customization point. The custom storage used in qBT is not supported by
libtorrent-2.0. Just like how it's disabled for older versions of libtorrent,
also disable it for newer versions.