### PR TITLE
support changes to plugin API in libtorrent-2.0

### DIFF
--- a/src/base/bittorrent/nativesessionextension.cpp
+++ b/src/base/bittorrent/nativesessionextension.cpp
@@ -53,12 +53,12 @@ lt::feature_flags_t NativeSessionExtension::implemented_features()
     return alert_feature;
 }
 
-std::shared_ptr<lt::torrent_plugin> NativeSessionExtension::new_torrent(const lt::torrent_handle &torrentHandle, void *)
+std::shared_ptr<lt::torrent_plugin> NativeSessionExtension::new_torrent(const lt::torrent_handle &torrentHandle, ClientData)
 {
     return std::make_shared<NativeTorrentExtension>(torrentHandle);
 }
 #else
-boost::shared_ptr<lt::torrent_plugin> NativeSessionExtension::new_torrent(const lt::torrent_handle &torrentHandle, void *)
+boost::shared_ptr<lt::torrent_plugin> NativeSessionExtension::new_torrent(const lt::torrent_handle &torrentHandle, ClientData)
 {
     return boost::make_shared<NativeTorrentExtension>(torrentHandle);
 }

--- a/src/base/bittorrent/nativesessionextension.h
+++ b/src/base/bittorrent/nativesessionextension.h
@@ -33,11 +33,17 @@
 
 class NativeSessionExtension final : public lt::plugin
 {
+#if (LIBTORRENT_VERSION_NUM >= 20000)
+    using ClientData = lt::client_data_t;
+#else
+    using ClientData = void *;
+#endif
+
 #if (LIBTORRENT_VERSION_NUM >= 10200)
     lt::feature_flags_t implemented_features() override;
-    std::shared_ptr<lt::torrent_plugin> new_torrent(const lt::torrent_handle &torrentHandle, void *userData) override;
+    std::shared_ptr<lt::torrent_plugin> new_torrent(const lt::torrent_handle &torrentHandle, ClientData) override;
 #else
-    boost::shared_ptr<lt::torrent_plugin> new_torrent(const lt::torrent_handle &torrentHandle, void *userData) override;
+    boost::shared_ptr<lt::torrent_plugin> new_torrent(const lt::torrent_handle &torrentHandle, ClientData) override;
 #endif
     void on_alert(const lt::alert *alert) override;
 };


### PR DESCRIPTION
libtorrent-2.0 introduced a type-safe alternative to void* (lt::client_data_t)
for passing user-data into plugins. qBT doesn't use any user data in its
plugins, but the signatures have changed nevertheless, and qBT need to update to
be compatible with libtorrent-2.0.