### PR TITLE
CMake: Use Qt built-in ZLib when possible

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -1,4 +1,7 @@
-find_package(ZLIB 1.2.5.2 REQUIRED)
+find_package(Qt5Zlib ${requiredQtVersion})
+if (NOT Qt5Zlib_FOUND)
+    find_package(ZLIB 1.2.5.2 REQUIRED)
+endif()
 
 add_library(qbt_base STATIC
     # headers
@@ -160,12 +163,16 @@ add_library(qbt_base STATIC
 )
 
 target_link_libraries(qbt_base
-    PRIVATE
-        ZLIB::ZLIB
     PUBLIC
         LibtorrentRasterbar::torrent-rasterbar
         Qt5::Core Qt5::Network Qt5::Xml
 )
+
+if (Qt5Zlib_FOUND)
+    target_link_libraries(qbt_base PRIVATE Qt5::Zlib)
+else()
+    target_link_libraries(qbt_base PRIVATE ZLIB::ZLIB)
+endif()
 
 if (Qt5DBus_FOUND)
     target_link_libraries(qbt_base PRIVATE Qt5::DBus)

--- a/src/base/utils/gzip.cpp
+++ b/src/base/utils/gzip.cpp
@@ -36,6 +36,9 @@
 #ifndef ZLIB_CONST
 #define ZLIB_CONST  // make z_stream.next_in const
 #endif
+#ifndef Z_SOLO
+#define Z_SOLO  // prevent unnecessary function name aliases (e.g. "compress")
+#endif
 #include <zlib.h>
 
 QByteArray Utils::Gzip::compress(const QByteArray &data, const int level, bool *ok)

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -61,6 +61,13 @@
 #include "base/unicodestrings.h"
 #include "base/utils/string.h"
 
+#ifdef Byte
+// Unfortunately ZLib can define "Byte" macro (aka "z_Byte") that conflicts
+// with qBittorrent names (e.g. "SizeUnit::Byte" becomes "SizeUnit::z_Byte").
+// We can safely undef it in this file.
+#undef Byte
+#endif
+
 namespace
 {
     const struct { const char *source; const char *comment; } units[] = {


### PR DESCRIPTION
On some platforms latest Qt versions allow to use built-in ZLib library.