### PR TITLE
Find complete files when moving torrent storage

### DIFF
--- a/src/base/bittorrent/customstorage.h
+++ b/src/base/bittorrent/customstorage.h
@@ -49,6 +49,8 @@ public:
     lt::status_t move_storage(const std::string &savePath, lt::move_flags_t flags, lt::storage_error &ec) override;
 
 private:
+    void handleCompleteFiles(const QString &savePath);
+
     lt::aux::vector<lt::download_priority_t, lt::file_index_t> m_filePriorities;
     QString m_savePath;
 };


### PR DESCRIPTION
Provide the same behavior as #12884 but in case of moving storage to the place where complete files exist.