### PR TITLE
Fix RSS article is not marked as "read" when torrent is downloaded

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1782,6 +1782,7 @@ void Session::handleDownloadFinished(const Net::DownloadResult &result)
                         , MagnetUri(), TorrentInfo::load(result.data));
         break;
     case Net::DownloadStatus::RedirectedToMagnet:
+        emit downloadFromUrlFinished(result.url);
         addTorrent_impl(CreateTorrentParams(m_downloadedTorrents.take(result.url)), MagnetUri(result.magnet));
         break;
     default:

--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -401,8 +401,7 @@ void AutoDownloader::processJob(const QSharedPointer<ProcessingJob> &job)
         }
         else {
             // waiting for torrent file downloading
-            // normalize URL string via QUrl since DownloadManager do it
-            m_waitingJobs.insert(QUrl(torrentURL).toString(), job);
+            m_waitingJobs.insert(torrentURL, job);
         }
 
         return;


### PR DESCRIPTION
Closes #13020.