### PR TITLE
Improve qmake configuration file for cross compilation

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -68,8 +68,8 @@ include(base/base.pri)
 !nowebui: include(webui/webui.pri)
 
 isEmpty(QMAKE_LRELEASE) {
-    win32: QMAKE_LRELEASE = $$[QT_INSTALL_BINS]/lrelease.exe
-    else: QMAKE_LRELEASE = $$[QT_INSTALL_BINS]/lrelease
+    win32: QMAKE_LRELEASE = $$[QT_HOST_BINS]/lrelease.exe
+    else: QMAKE_LRELEASE = $$[QT_HOST_BINS]/lrelease
     unix {
         equals(QT_MAJOR_VERSION, 5) {
             !exists($$QMAKE_LRELEASE): QMAKE_LRELEASE = lrelease-qt5


### PR DESCRIPTION
Refer to the [qt.io](https://doc.qt.io/qt-5/configure-linux-device.html).

When cross-compiling the qt5, the `-hostprefix` can be used to separate host tools like qmake, rcc, lrelease and so on from the binaries for the target devices. In this situation, the `QT_HOST_BINS` and `QT_INSTALL_BINS` have different values and they are the same when `-hostprefix` is not specificed.

Therefore, I think we should use `QT_HOST_BINS` instead of `QT_INSTALL_BINS` in the following lines.
https://github.com/qbittorrent/qBittorrent/blob/37d7323ac0c8f6b444b48230ca40b75975c7485a/src/src.pro#L71-L72

Have compiled the source successfully on Linux and Windows.