### PR TITLE
Make sure we ignore torrent_finished_alert in seed mode

### DIFF
--- a/src/base/bittorrent/torrenthandleimpl.cpp
+++ b/src/base/bittorrent/torrenthandleimpl.cpp
@@ -1459,9 +1459,9 @@ void TorrentHandleImpl::handleTorrentFinishedAlert(const lt::torrent_finished_al
     Q_UNUSED(p);
     qDebug("Got a torrent finished alert for \"%s\"", qUtf8Printable(name()));
     qDebug("Torrent has seed status: %s", m_hasSeedStatus ? "yes" : "no");
-    m_hasMissingFiles = false;
     if (m_hasSeedStatus) return;
 
+    m_hasMissingFiles = false;
     updateStatus();
     m_hasSeedStatus = true;
 


### PR DESCRIPTION
Closes #13057

Looks like someone misplaced the code. 
We weren't supposed to react on torrent_finished_alerts in seed mode(skip hash).

For reference:

https://github.com/qbittorrent/qBittorrent/blob/ca8654d380d3703d89c4b98528c3985a23d96330/src/base/bittorrent/torrenthandleimpl.cpp#L126