### PR TITLE
WebUI: fix the url for banPeers method

### DIFF
--- a/src/webui/www/private/scripts/prop-peers.js
+++ b/src/webui/www/private/scripts/prop-peers.js
@@ -143,7 +143,7 @@ window.qBittorrent.PropPeers = (function() {
 
                 if (confirm('QBT_TR(Are you sure you want to permanently ban the selected peers?)QBT_TR[CONTEXT=PeerListWidget]')) {
                     new Request({
-                        url: 'api/v2/torrents/banPeers',
+                        url: 'api/v2/transfer/banPeers',
                         noCache: true,
                         method: 'post',
                         data: {


### PR DESCRIPTION
It is used in file `prop-peers.js` as the follwing line.

https://github.com/qbittorrent/qBittorrent/blob/ca8654d380d3703d89c4b98528c3985a23d96330/src/webui/www/private/scripts/prop-peers.js#L146

However, the api is defined in `transfercontroller.cpp`.

https://github.com/qbittorrent/qBittorrent/blob/ca8654d380d3703d89c4b98528c3985a23d96330/src/webui/api/transfercontroller.cpp#L120