### PR TITLE
Use global style options for drawing progress in TransferList

### DIFF
--- a/src/gui/transferlistdelegate.cpp
+++ b/src/gui/transferlistdelegate.cpp
@@ -70,7 +70,7 @@ void TransferListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
 #endif
 
     painter->save();
-    style->drawControl(QStyle::CE_ProgressBar, &newopt, painter, option.widget);
+    style->drawControl(QStyle::CE_ProgressBar, &newopt, painter);
     painter->restore();
 }
 


### PR DESCRIPTION
Fixes https://github.com/jagannatharjun/qbt-theme/issues/22

One can't specify stylesheet for progress bar inside a View 