### PR TITLE
Use delegate provided rect for textRect in LogItemDelegate

### DIFF
--- a/src/gui/log/loglistview.cpp
+++ b/src/gui/log/loglistview.cpp
@@ -71,8 +71,7 @@ namespace
             QStyledItemDelegate::paint(painter, option, index); // paints background, focus rect and selection rect
 
             const QStyle *style = option.widget ? option.widget->style() : QApplication::style();
-            const QRect textRect = style->subElementRect(QStyle::SE_ItemViewItemText, &option, option.widget)
-                                   .adjusted(1, 0, 0, 0); // shift 1 to avoid text being too close to focus rect
+            const QRect textRect = option.rect.adjusted(1, 0, 0, 0); // shift 1 to avoid text being too close to focus rect
 
             // for unknown reasons (fixme) painter won't accept some font properties
             // until they are set explicitly, and we have to manually set some font properties


### PR DESCRIPTION
Previously we get textRect from QStyle but on some OS this returns invalid rect

fixes https://github.com/qbittorrent/qBittorrent/issues/12698