### PR TITLE
Remove DISABLE_COUNTRIES_RESOLUTION define

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,8 +58,6 @@ endif()
 # we need options here, at the top level, because they are used not only in "src" subdir, but in the "dist" dir too
 include(CompileFeature)
 
-optional_compile_definitions(COUNTRIES_RESOLUTION FEATURE DESCRIPTION "Enable resolving peers IP addresses to countries"
-    DEFAULT ON DISABLED DISABLE_COUNTRIES_RESOLUTION)
 optional_compile_definitions(STACKTRACE FEATURE DESCRIPTION "Enable stacktraces"
     DEFAULT ON ENABLED STACKTRACE)
 optional_compile_definitions(GUI FEATURE DESCRIPTION "Build GUI application"

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -566,9 +566,7 @@ int Application::exec(const QStringList &params)
         connect(BitTorrent::Session::instance(), &BitTorrent::Session::torrentFinished, this, &Application::torrentFinished);
         connect(BitTorrent::Session::instance(), &BitTorrent::Session::allTorrentsFinished, this, &Application::allTorrentsFinished, Qt::QueuedConnection);
 
-#ifndef DISABLE_COUNTRIES_RESOLUTION
         Net::GeoIPManager::initInstance();
-#endif
         ScanFoldersModel::initInstance();
 
 #ifndef DISABLE_WEBUI
@@ -760,9 +758,7 @@ void Application::cleanup()
 
     ScanFoldersModel::freeInstance();
     BitTorrent::Session::freeInstance();
-#ifndef DISABLE_COUNTRIES_RESOLUTION
     Net::GeoIPManager::freeInstance();
-#endif
     Net::DownloadManager::freeInstance();
     Net::ProxyConfigurationManager::freeInstance();
     Preferences::freeInstance();

--- a/src/base/bittorrent/peerinfo.cpp
+++ b/src/base/bittorrent/peerinfo.cpp
@@ -59,14 +59,12 @@ bool PeerInfo::fromLSD() const
     return static_cast<bool>(m_nativeInfo.source & lt::peer_info::lsd);
 }
 
-#ifndef DISABLE_COUNTRIES_RESOLUTION
 QString PeerInfo::country() const
 {
     if (m_country.isEmpty())
         m_country = Net::GeoIPManager::instance()->lookup(address().ip);
     return m_country;
 }
-#endif
 
 bool PeerInfo::isInteresting() const
 {

--- a/src/base/bittorrent/peerinfo.h
+++ b/src/base/bittorrent/peerinfo.h
@@ -89,9 +89,7 @@ namespace BitTorrent
         qreal relevance() const;
         QString flags() const;
         QString flagsDescription() const;
-#ifndef DISABLE_COUNTRIES_RESOLUTION
         QString country() const;
-#endif
         int downloadingPieceIndex() const;
 
     private:
@@ -103,9 +101,7 @@ namespace BitTorrent
         QString m_flags;
         QString m_flagsDescription;
 
-#ifndef DISABLE_COUNTRIES_RESOLUTION
         mutable QString m_country;
-#endif
     };
 }
 

--- a/src/config.h.cmakein
+++ b/src/config.h.cmakein
@@ -2,7 +2,6 @@
 
 #ifndef QBT_USE_GUI
 #define DISABLE_GUI
-#define DISABLE_COUNTRIES_RESOLUTION
 #endif
 
 #cmakedefine QBT_USE_WEBUI

--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -522,11 +522,7 @@ void SyncController::torrentPeersAction()
 
     const QVector<BitTorrent::PeerInfo> peersList = torrent->peers();
 
-#ifndef DISABLE_COUNTRIES_RESOLUTION
     bool resolvePeerCountries = Preferences::instance()->resolvePeerCountries();
-#else
-    bool resolvePeerCountries = false;
-#endif
 
     data[KEY_SYNC_TORRENT_PEERS_SHOW_FLAGS] = resolvePeerCountries;
 
@@ -549,12 +545,10 @@ void SyncController::torrentPeersAction()
             {KEY_PEER_FILES, torrent->info().filesForPiece(pi.downloadingPieceIndex()).join('\n')}
         };
 
-#ifndef DISABLE_COUNTRIES_RESOLUTION
         if (resolvePeerCountries) {
             peer[KEY_PEER_COUNTRY_CODE] = pi.country().toLower();
             peer[KEY_PEER_COUNTRY] = Net::GeoIPManager::CountryName(pi.country());
         }
-#endif
 
         peers[pi.address().ip.toString() + ':' + QString::number(pi.address().port)] = peer;
     }


### PR DESCRIPTION
Follow-up to the findings in https://github.com/qbittorrent/qBittorrent/pull/12746. This PR will either fix the support for the feature or remove it entirely, depending on the decision.

@qbittorrent/demigods @qbittorrent/bug-handlers @qbittorrent/frequent-contributors  opinions?

@Chocobo1 votes for removing it (https://github.com/qbittorrent/qBittorrent/pull/12746#issuecomment-654197260):

> `COUNTRIES_RESOLUTION` exists in cmake and source code but not in autotools. I would prefer we remove this define/configure option from our codebase.

Devil's advocate would say "well, we could add support in autotools as well".

Personally I don't care either way about the compile-time defines, we already have a runtime setting to manage this, and I'm fine with just that.