### PR TITLE
CMake improvements

### DIFF
--- a/cmake/Modules/MacroQbtCompilerSettings.cmake
+++ b/cmake/Modules/MacroQbtCompilerSettings.cmake
@@ -59,7 +59,7 @@ macro(qbt_set_compiler_options)
     endif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-        set(QBT_ADDITIONAL_FLAGS "/wd4251 /wd4275 /wd4290 /W4" CACHE STRING "Additional qBittorent compile flags")
+        set(QBT_ADDITIONAL_FLAGS "/wd4251 /wd4275 /wd4290" CACHE STRING "Additional qBittorent compile flags")
     endif ()
 
     string(APPEND CMAKE_C_FLAGS " ${QBT_ADDITIONAL_FLAGS}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(Boost ${requiredBoostVersion} REQUIRED)
 find_package(LibtorrentRasterbar ${requiredLibtorrentVersion} REQUIRED)
 find_package(OpenSSL ${requiredOpensslVersion} REQUIRED)
 
-if (Boost_VERSION VERSION_LESS 106000)
+if (Boost_VERSION_STRING VERSION_LESS 1.60.0)
     add_definitions(-DBOOST_NO_CXX11_RVALUE_REFERENCES)
 endif()
 


### PR DESCRIPTION
Side Effect 1: halves the compile-time when compiled with boost version greater than 1.60

Side Effect 2: reduces compiler warnings noise generated from Qt headers
