### PR TITLE
Improve "move torrent storage" handling

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -617,7 +617,7 @@ namespace BitTorrent
         std::vector<lt::alert *> getPendingAlerts(lt::time_duration time = lt::time_duration::zero()) const;
 
         void moveTorrentStorage(const MoveStorageJob &job) const;
-        void handleMoveTorrentStorageJobFinished(const QString &errorMessage = {});
+        void handleMoveTorrentStorageJobFinished();
 
         // BitTorrent
         lt::session *m_nativeSession = nullptr;

--- a/src/base/bittorrent/torrenthandleimpl.h
+++ b/src/base/bittorrent/torrenthandleimpl.h
@@ -252,7 +252,7 @@ namespace BitTorrent
         void handleCategorySavePathChanged();
         void handleAppendExtensionToggled();
         void saveResumeData();
-        void handleStorageMoved(const QString &newPath, const QString &errorMessage);
+        void handleMoveStorageJobFinished(bool hasOutstandingJob);
 
         QString actualStorageLocation() const;
 

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -332,13 +332,8 @@ void TransferListWidget::setSelectedTorrentsLocation()
     if (newLocation.isEmpty() || !QDir(newLocation).exists()) return;
 
     // Actually move storage
-    for (BitTorrent::TorrentHandle *const torrent : torrents) {
-        Logger::instance()->addMessage(tr("Set location: moving \"%1\", from \"%2\" to \"%3\""
-            , "Set location: moving \"ubuntu_16_04.iso\", from \"/home/dir1\" to \"/home/dir2\"")
-            .arg(torrent->name(), Utils::Fs::toNativePath(torrent->savePath())
-                , Utils::Fs::toNativePath(newLocation)));
+    for (BitTorrent::TorrentHandle *const torrent : torrents)
         torrent->move(Utils::Fs::expandPathAbs(newLocation));
-    }
 }
 
 void TransferListWidget::pauseAllTorrents()


### PR DESCRIPTION
1. Carefully handle results of each move job.
2. Change "save path" property only after move is complete.
3. Also add more logging to help user side debugging.