### PR TITLE
Use QStyledItemDelegate for content views

### DIFF
--- a/src/gui/properties/proplistdelegate.cpp
+++ b/src/gui/properties/proplistdelegate.cpp
@@ -64,7 +64,7 @@ namespace
 }
 
 PropListDelegate::PropListDelegate(PropertiesWidget *properties)
-    : QItemDelegate(properties)
+    : QStyledItemDelegate(properties)
     , m_properties(properties)
 {
 }
@@ -73,13 +73,15 @@ void PropListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
 {
     painter->save();
 
-    QStyleOptionViewItem opt = QItemDelegate::setOptions(index, option);
-    QItemDelegate::drawBackground(painter, opt, index);
+    const QStyle *style = option.widget ? option.widget->style() : QApplication::style();
+    QStyleOptionViewItem opt = option;
+    QStyledItemDelegate::initStyleOption(&opt, index);
 
     switch (index.column()) {
     case PCSIZE:
     case REMAINING:
-        QItemDelegate::drawDisplay(painter, opt, option.rect, Utils::Misc::friendlyUnit(index.data().toLongLong()));
+        opt.text = Utils::Misc::friendlyUnit(index.data().toLongLong());
+        style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, opt.widget);
         break;
 
     case PROGRESS: {
@@ -130,26 +132,28 @@ void PropListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
                 text = tr("Normal", "Normal (priority)");
                 break;
             }
-            QItemDelegate::drawDisplay(painter, opt, option.rect, text);
+            opt.text = text;
+            style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, opt.widget);
         }
         break;
 
     case AVAILABILITY: {
             const qreal availability = index.data().toReal();
             if (availability < 0) {
-                QItemDelegate::drawDisplay(painter, opt, option.rect, tr("N/A"));
+                opt.text = tr("N/A");
             }
             else {
                 const QString value = (availability >= 1.0)
                                         ? QLatin1String("100")
                                         : Utils::String::fromDouble(availability * 100, 1);
-                QItemDelegate::drawDisplay(painter, opt, option.rect, (value + C_THIN_SPACE + QLatin1Char('%')));
+                opt.text = (value + C_THIN_SPACE + QLatin1Char('%'));
             }
+            style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, opt.widget);
         }
         break;
 
     default:
-        QItemDelegate::paint(painter, option, index);
+        QStyledItemDelegate::paint(painter, option, index);
         break;
     }
 

--- a/src/gui/properties/proplistdelegate.h
+++ b/src/gui/properties/proplistdelegate.h
@@ -29,7 +29,7 @@
 #ifndef PROPLISTDELEGATE_H
 #define PROPLISTDELEGATE_H
 
-#include <QItemDelegate>
+#include <QStyledItemDelegate>
 
 class QAbstractItemModel;
 class QModelIndex;
@@ -49,7 +49,7 @@ enum PropColumn
     AVAILABILITY
 };
 
-class PropListDelegate final : public QItemDelegate
+class PropListDelegate final : public QStyledItemDelegate
 {
     Q_OBJECT
 


### PR DESCRIPTION
This PR replaces uses of QItemDelegate with QStyledItemDelegate for content view in Properties widget, QItemDelegate doesn't play well with stylesheets and Qt guys recommend QStyledItemDelegate, One side effect is large row height (I personally likes it and this is the real motivation behind this PR) compare to previous on windows but if anyone wants to stay with previous row height, they can use the stylesheet anyway.

