### PR TITLE
Update torrent status on move enqueued

### DIFF
--- a/src/base/bittorrent/torrenthandleimpl.cpp
+++ b/src/base/bittorrent/torrenthandleimpl.cpp
@@ -1359,8 +1359,10 @@ void TorrentHandleImpl::resume_impl(bool forced)
 
 void TorrentHandleImpl::moveStorage(const QString &newPath, const MoveStorageMode mode)
 {
-    if (m_session->addMoveTorrentStorageJob(this, newPath, mode))
+    if (m_session->addMoveTorrentStorageJob(this, newPath, mode)) {
         m_storageIsMoving = true;
+        updateStatus();
+    }
 }
 
 void TorrentHandleImpl::renameFile(const int index, const QString &name)


### PR DESCRIPTION
We need to explicitly update torrent status when "move storage" is enqueued otherwise it will updated only with some another state update that can take long time (or it is even never caused for paused torrents).