### PR TITLE
Read piece for torrents added with skip hash only for older libtorrent

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -4224,9 +4224,11 @@ void Session::handleAlert(const lt::alert *a)
         case lt::file_error_alert::alert_type:
             handleFileErrorAlert(static_cast<const lt::file_error_alert*>(a));
             break;
+#if (LIBTORRENT_VERSION_NUM < 10208)
         case lt::read_piece_alert::alert_type:
             handleReadPieceAlert(static_cast<const lt::read_piece_alert*>(a));
             break;
+#endif
         case lt::add_torrent_alert::alert_type:
             handleAddTorrentAlert(static_cast<const lt::add_torrent_alert*>(a));
             break;
@@ -4357,9 +4359,11 @@ void Session::createTorrentHandle(const lt::torrent_handle &nativeHandle)
     if (torrent->hasError())
         LogMsg(tr("Torrent errored. Torrent: \"%1\". Error: %2.").arg(torrent->name(), torrent->error()), Log::WARNING);
 
-    // Check if file(s) exist when using seed mode
+#if (LIBTORRENT_VERSION_NUM < 10208)
+    // Check if file(s) exist when using skip hash check
     if (params.skipChecking && torrent->hasMetadata())
         nativeHandle.read_piece(lt::piece_index_t(0));
+#endif
 }
 
 void Session::handleAddTorrentAlert(const lt::add_torrent_alert *p)
@@ -4464,6 +4468,7 @@ void Session::handleFileErrorAlert(const lt::file_error_alert *p)
     m_recentErroredTorrentsTimer->start();
 }
 
+#if (LIBTORRENT_VERSION_NUM < 10208)
 void Session::handleReadPieceAlert(const lt::read_piece_alert *p) const
 {
     if (p->error) {
@@ -4471,6 +4476,7 @@ void Session::handleReadPieceAlert(const lt::read_piece_alert *p) const
         p->handle.force_recheck();
     }
 }
+#endif
 
 void Session::handlePortmapWarningAlert(const lt::portmap_error_alert *p)
 {

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -590,7 +590,9 @@ namespace BitTorrent
         void handleStateUpdateAlert(const lt::state_update_alert *p);
         void handleMetadataReceivedAlert(const lt::metadata_received_alert *p);
         void handleFileErrorAlert(const lt::file_error_alert *p);
+#if (LIBTORRENT_VERSION_NUM < 10208)
         void handleReadPieceAlert(const lt::read_piece_alert *p) const;
+#endif
         void handleTorrentRemovedAlert(const lt::torrent_removed_alert *p);
         void handleTorrentDeletedAlert(const lt::torrent_deleted_alert *p);
         void handleTorrentDeleteFailedAlert(const lt::torrent_delete_failed_alert *p);


### PR DESCRIPTION
Since https://github.com/arvidn/libtorrent/pull/4808 got merged libtorrent now checks for file size mismatches for torrents added with Skip Hash. 
Now torrents get paused with a missing files error if files are missing when added with skip hash. 
So calling read_piece() is no longer necessary.