### PR TITLE
Expose LibTorrent peer_turnover settings

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -375,6 +375,9 @@ Session::Session(QObject *parent)
     , m_isDisableAutoTMMWhenDefaultSavePathChanged(BITTORRENT_SESSION_KEY("DisableAutoTMMTriggers/DefaultSavePathChanged"), true)
     , m_isDisableAutoTMMWhenCategorySavePathChanged(BITTORRENT_SESSION_KEY("DisableAutoTMMTriggers/CategorySavePathChanged"), true)
     , m_isTrackerEnabled(BITTORRENT_KEY("TrackerEnabled"), false)
+    , m_peerTurnover(BITTORRENT_SESSION_KEY("PeerTurnover"), 4)
+    , m_peerTurnoverCutoff(BITTORRENT_SESSION_KEY("PeerTurnoverCutOff"), 90)
+    , m_peerTurnoverInterval(BITTORRENT_SESSION_KEY("PeerTurnoverInterval"), 300)
     , m_bannedIPs("State/BannedIPs"
                   , QStringList()
                   , [](const QStringList &value)
@@ -1207,6 +1210,10 @@ void Session::loadLTSettings(lt::settings_pack &settingsPack)
 
     settingsPack.set_bool(lt::settings_pack::announce_to_all_trackers, announceToAllTrackers());
     settingsPack.set_bool(lt::settings_pack::announce_to_all_tiers, announceToAllTiers());
+
+    settingsPack.set_int(lt::settings_pack::peer_turnover, peerTurnover());
+    settingsPack.set_int(lt::settings_pack::peer_turnover_cutoff, peerTurnoverCutoff());
+    settingsPack.set_int(lt::settings_pack::peer_turnover_interval, peerTurnoverInterval());
 
     settingsPack.set_int(lt::settings_pack::aio_threads, asyncIOThreads());
     settingsPack.set_int(lt::settings_pack::file_pool_size, filePoolSize());
@@ -2932,6 +2939,48 @@ void Session::setAnnounceToAllTiers(const bool val)
         m_announceToAllTiers = val;
         configureDeferred();
     }
+}
+
+int Session::peerTurnover() const
+{
+    return m_peerTurnover;
+}
+
+void Session::setPeerTurnover(const int val)
+{
+    if (val == m_peerTurnover)
+        return;
+
+    m_peerTurnover = val;
+    configureDeferred();
+}
+
+int Session::peerTurnoverCutoff() const
+{
+    return m_peerTurnoverCutoff;
+}
+
+void Session::setPeerTurnoverCutoff(const int val)
+{
+    if (val == m_peerTurnoverCutoff)
+        return;
+
+    m_peerTurnoverCutoff = val;
+    configureDeferred();
+}
+
+int Session::peerTurnoverInterval() const
+{
+    return m_peerTurnoverInterval;
+}
+
+void Session::setPeerTurnoverInterval(const int val)
+{
+    if (val == m_peerTurnoverInterval)
+        return;
+    
+    m_peerTurnoverInterval = val;
+    configureDeferred();
 }
 
 int Session::asyncIOThreads() const

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -334,6 +334,12 @@ namespace BitTorrent
         void setAnnounceToAllTrackers(bool val);
         bool announceToAllTiers() const;
         void setAnnounceToAllTiers(bool val);
+        int peerTurnover() const;
+        void setPeerTurnover(int num);
+        int peerTurnoverCutoff() const;
+        void setPeerTurnoverCutoff(int num);
+        int peerTurnoverInterval() const;
+        void setPeerTurnoverInterval(int num);
         int asyncIOThreads() const;
         void setAsyncIOThreads(int num);
         int filePoolSize() const;
@@ -717,6 +723,9 @@ namespace BitTorrent
         CachedSettingValue<bool> m_isDisableAutoTMMWhenDefaultSavePathChanged;
         CachedSettingValue<bool> m_isDisableAutoTMMWhenCategorySavePathChanged;
         CachedSettingValue<bool> m_isTrackerEnabled;
+        CachedSettingValue<int> m_peerTurnover;
+        CachedSettingValue<int> m_peerTurnoverCutoff;
+        CachedSettingValue<int> m_peerTurnoverInterval;
         CachedSettingValue<QStringList> m_bannedIPs;
 #if defined(Q_OS_WIN)
         CachedSettingValue<OSMemoryPriority> m_OSMemoryPriority;

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -122,6 +122,9 @@ enum AdvSettingsRows
     ANNOUNCE_ALL_TIERS,
     ANNOUNCE_IP,
     STOP_TRACKER_TIMEOUT,
+    PEER_TURNOVER,
+    PEER_TURNOVER_CUTOFF,
+    PEER_TURNOVER_INTERVAL,
 
     ROW_COUNT
 };
@@ -274,6 +277,10 @@ void AdvancedSettings::saveAdvancedSettings()
 
     session->setAnnounceToAllTrackers(m_checkBoxAnnounceAllTrackers.isChecked());
     session->setAnnounceToAllTiers(m_checkBoxAnnounceAllTiers.isChecked());
+
+    session->setPeerTurnover(m_spinBoxPeerTurnover.value());
+    session->setPeerTurnoverCutoff(m_spinBoxPeerTurnoverCutoff.value());
+    session->setPeerTurnoverInterval(m_spinBoxPeerTurnoverInterval.value());
 }
 
 void AdvancedSettings::updateCacheSpinSuffix(int value)
@@ -609,6 +616,25 @@ void AdvancedSettings::loadAdvancedSettings()
     // Announce to all tiers
     m_checkBoxAnnounceAllTiers.setChecked(session->announceToAllTiers());
     addRow(ANNOUNCE_ALL_TIERS, tr("Always announce to all tiers"), &m_checkBoxAnnounceAllTiers);
+
+    m_spinBoxPeerTurnover.setMinimum(0);
+    m_spinBoxPeerTurnover.setMaximum(100);
+    m_spinBoxPeerTurnover.setValue(session->peerTurnover());
+    m_spinBoxPeerTurnover.setSuffix(" %");
+    addRow(PEER_TURNOVER, (tr("Peer turnover disconnect percentage") + ' ' + makeLink("https://www.libtorrent.org/reference-Settings.html#peer_turnover", "(?)"))
+            , &m_spinBoxPeerTurnover);
+    m_spinBoxPeerTurnoverCutoff.setMinimum(0);
+    m_spinBoxPeerTurnoverCutoff.setMaximum(100);
+    m_spinBoxPeerTurnoverCutoff.setSuffix(" %");
+    m_spinBoxPeerTurnoverCutoff.setValue(session->peerTurnoverCutoff());
+    addRow(PEER_TURNOVER_CUTOFF, (tr("Peer turnover threshold percentage") + ' ' + makeLink("https://www.libtorrent.org/reference-Settings.html#peer_turnover", "(?)"))
+            , &m_spinBoxPeerTurnoverCutoff);
+    m_spinBoxPeerTurnoverInterval.setMinimum(30);
+    m_spinBoxPeerTurnoverInterval.setMaximum(3600);
+    m_spinBoxPeerTurnoverInterval.setSuffix(tr(" s", " seconds"));
+    m_spinBoxPeerTurnoverInterval.setValue(session->peerTurnoverInterval());
+    addRow(PEER_TURNOVER_INTERVAL, (tr("Peer turnover disconnect interval") + ' ' + makeLink("https://www.libtorrent.org/reference-Settings.html#peer_turnover", "(?)"))
+            , &m_spinBoxPeerTurnoverInterval);
 }
 
 template <typename T>

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -60,7 +60,8 @@ private:
     QSpinBox m_spinBoxAsyncIOThreads, m_spinBoxFilePoolSize, m_spinBoxCheckingMemUsage, m_spinBoxCache,
              m_spinBoxSaveResumeDataInterval, m_spinBoxOutgoingPortsMin, m_spinBoxOutgoingPortsMax, m_spinBoxUPnPLeaseDuration,
              m_spinBoxListRefresh, m_spinBoxTrackerPort, m_spinBoxCacheTTL, m_spinBoxSendBufferWatermark, m_spinBoxSendBufferLowWatermark,
-             m_spinBoxSendBufferWatermarkFactor, m_spinBoxSocketBacklogSize, m_spinBoxStopTrackerTimeout, m_spinBoxSavePathHistoryLength;
+             m_spinBoxSendBufferWatermarkFactor, m_spinBoxSocketBacklogSize, m_spinBoxStopTrackerTimeout, m_spinBoxSavePathHistoryLength,
+             m_spinBoxPeerTurnover, m_spinBoxPeerTurnoverCutoff, m_spinBoxPeerTurnoverInterval;
     QCheckBox m_checkBoxOsCache, m_checkBoxRecheckCompleted, m_checkBoxResolveCountries, m_checkBoxResolveHosts,
               m_checkBoxProgramNotifications, m_checkBoxTorrentAddedNotifications, m_checkBoxTrackerFavicon, m_checkBoxTrackerStatus,
               m_checkBoxConfirmTorrentRecheck, m_checkBoxConfirmRemoveAllTags, m_checkBoxAnnounceAllTrackers, m_checkBoxAnnounceAllTiers,

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -322,6 +322,10 @@ void AppController::preferencesAction()
     data["announce_ip"] = session->announceIP();
     // Stop tracker timeout
     data["stop_tracker_timeout"] = session->stopTrackerTimeout();
+    // Peer Turnover
+    data["peer_turnover"] = session->peerTurnover();
+    data["peer_turnover_cutoff"] = session->peerTurnoverCutoff();
+    data["peer_turnover_interval"] = session->peerTurnoverInterval();
 
     setResult(data);
 }
@@ -768,6 +772,13 @@ void AppController::setPreferencesAction()
     // Stop tracker timeout
     if (hasKey("stop_tracker_timeout"))
         session->setStopTrackerTimeout(it.value().toInt());
+    // Peer Turnover
+    if (hasKey("peer_turnover"))
+        session->setPeerTurnover(it.value().toInt());
+    if (hasKey("peer_turnover_cutoff"))
+        session->setPeerTurnoverCutoff(it.value().toInt());
+    if (hasKey("peer_turnover_interval"))
+        session->setPeerTurnoverInterval(it.value().toInt());
 
     // Save preferences
     pref->apply();

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1161,6 +1161,30 @@
                     <input type="text" id="stopTrackerTimeout" style="width: 15em;" />
                 </td>
              </tr>
+             <tr>
+                <td>
+                    <label for="peerTurnover">QBT_TR(Peer turnover disconnect percentage:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#peer_turnover" target="_blank">(?)</a></label>
+                </td>
+                <td>
+                    <input type="text" id="peerTurnover" style="width: 15em;" />&nbsp;&nbsp;%
+                </td>
+             </tr>
+             <tr>
+                <td>
+                    <label for="peerTurnoverCutoff">QBT_TR(Peer turnover threshold percentage:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#peer_turnover" target="_blank">(?)</a></label>
+                </td>
+                <td>
+                    <input type="text" id="peerTurnoverCutoff" style="width: 15em;" />&nbsp;&nbsp;%
+                </td>
+             </tr>
+             <tr>
+                <td>
+                    <label for="peerTurnoverInterval">QBT_TR(Peer turnover disconnect interval:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#peer_turnover" target="_blank">(?)</a></label>
+                </td>
+                <td>
+                    <input type="text" id="peerTurnoverInterval" style="width: 15em;" />&nbsp;&nbsp;s
+                </td>
+             </tr>
         </table>
     </fieldset>
 </div>
@@ -1863,6 +1887,9 @@
                         $('announceAllTiers').setProperty('checked', pref.announce_to_all_tiers);
                         $('announceIP').setProperty('value', pref.announce_ip);
                         $('stopTrackerTimeout').setProperty('value', pref.stop_tracker_timeout);
+                        $('peerTurnover').setProperty('value', pref.peer_turnover);
+                        $('peerTurnoverCutoff').setProperty('value', pref.peer_turnover_cutoff);
+                        $('peerTurnoverInterval').setProperty('value', pref.peer_turnover_interval);
                     }
                 }
             }).send();
@@ -2245,6 +2272,9 @@
             settings.set('announce_to_all_tiers', $('announceAllTiers').getProperty('checked'));
             settings.set('announce_ip', $('announceIP').getProperty('value'));
             settings.set('stop_tracker_timeout', $('stopTrackerTimeout').getProperty('value'));
+            settings.set('peer_turnover', $('peerTurnover').getProperty('value'));
+            settings.set('peer_turnover_cutoff', $('peerTurnoverCutoff').getProperty('value'));
+            settings.set('peer_turnover_interval', $('peerTurnoverInterval').getProperty('value'));
 
             // Send it to qBT
             const json_str = JSON.encode(settings);


### PR DESCRIPTION
This PR exposes the LibTorrent Peer Turnover Settings in qBT Advanced Settings in order to allow users to adjust how frequently slow and uninteresting connections are closed to allow potentially better / faster connections to be made.

The default settings are to turnover peers when the number of connections is at least 90% of allowed global or per torrent connections, and to disconnect the least attractive 4% of these connections every 5 minutes.

See https://www.libtorrent.org/reference-Settings.html#peer_turnover