### PR TITLE
Speed Reporting Fixes

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -54,6 +54,8 @@
 #define HAS_HTTPS_TRACKER_VALIDATION
 #endif
 
+constexpr std::chrono::milliseconds STATS_UPDATE_INTERVAL {1000};
+
 class QFile;
 class QNetworkConfiguration;
 class QNetworkConfigurationManager;
@@ -534,7 +536,6 @@ namespace BitTorrent
     private slots:
         void configureDeferred();
         void readAlerts();
-        void enqueueRefresh();
         void processShareLimits();
         void generateResumeData();
         void handleIPFilterParsed(int ruleCount);
@@ -749,7 +750,6 @@ namespace BitTorrent
         QString m_resumeFolderPath;
         QFile *m_resumeFolderLock = nullptr;
 
-        bool m_refreshEnqueued = false;
         QTimer *m_seedingLimitTimer = nullptr;
         QTimer *m_resumeDataTimer = nullptr;
         Statistics *m_statistics = nullptr;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -288,6 +288,8 @@ namespace BitTorrent
         QString finishedTorrentExportDirectory() const;
         void setFinishedTorrentExportDirectory(QString path);
 
+        int downloadRate() const;
+        int uploadRate() const;
         int globalDownloadSpeedLimit() const;
         void setGlobalDownloadSpeedLimit(int limit);
         int globalUploadSpeedLimit() const;
@@ -494,6 +496,7 @@ namespace BitTorrent
         void findIncompleteFiles(const TorrentInfo &torrentInfo, const QString &savePath) const;
 
     signals:
+        void speedRatesUpdated();
         void allTorrentsFinished();
         void categoryAdded(const QString &categoryName);
         void categoryRemoved(const QString &categoryName);
@@ -746,6 +749,8 @@ namespace BitTorrent
 
         int m_numResumeData = 0;
         int m_extraLimit = 0;
+        int m_downloadRate = 0;
+        int m_uploadRate = 0;
         QVector<TrackerEntry> m_additionalTrackerList;
         QString m_resumeFolderPath;
         QFile *m_resumeFolderLock = nullptr;

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -127,7 +127,7 @@ private slots:
     void displayRSSTab();
     void displayExecutionLogTab();
     void focusSearchFilter();
-    void reloadSessionStats();
+    void reloadSessionSpeeds();
     void reloadTorrentStats(const QVector<BitTorrent::TorrentHandle *> &torrents);
     void loadPreferences(bool configureSession = true);
     void addTorrentFailed(const QString &error) const;

--- a/src/gui/properties/speedplotview.cpp
+++ b/src/gui/properties/speedplotview.cpp
@@ -37,6 +37,7 @@
 #include "base/global.h"
 #include "base/unicodestrings.h"
 #include "base/utils/misc.h"
+#include "base/bittorrent/session.h"
 
 namespace
 {
@@ -50,15 +51,17 @@ namespace
         HOUR24_SEC = 24 * 60 * 60
     };
 
-    const int MIN5_BUF_SIZE = 5 * 60;
+    const int UPDATE_INTERVAL_SEC = std::chrono::duration_cast<std::chrono::seconds>(STATS_UPDATE_INTERVAL).count();
+    const int MIN1_BUF_SIZE = MIN1_SEC / UPDATE_INTERVAL_SEC;
+    const int MIN5_BUF_SIZE = MIN5_SEC / UPDATE_INTERVAL_SEC;
     const int MIN30_BUF_SIZE = 5 * 60;
     const int HOUR6_BUF_SIZE = 5 * 60;
     const int HOUR12_BUF_SIZE = 10 * 60;
     const int HOUR24_BUF_SIZE = 10 * 60;
-    const int DIVIDER_30MIN = MIN30_SEC / MIN30_BUF_SIZE;
-    const int DIVIDER_6HOUR = HOUR6_SEC / HOUR6_BUF_SIZE;
-    const int DIVIDER_12HOUR = HOUR12_SEC / HOUR12_BUF_SIZE;
-    const int DIVIDER_24HOUR = HOUR24_SEC / HOUR24_BUF_SIZE;
+    const int DIVIDER_30MIN = (MIN30_SEC / UPDATE_INTERVAL_SEC) / MIN30_BUF_SIZE;
+    const int DIVIDER_6HOUR = (HOUR6_SEC / UPDATE_INTERVAL_SEC) / HOUR6_BUF_SIZE;
+    const int DIVIDER_12HOUR = (HOUR12_SEC / UPDATE_INTERVAL_SEC) / HOUR12_BUF_SIZE;
+    const int DIVIDER_24HOUR = (HOUR24_SEC / UPDATE_INTERVAL_SEC) / HOUR24_BUF_SIZE;
 
 
     // table of supposed nice steps for grid marks to get nice looking quarters of scale
@@ -221,11 +224,11 @@ void SpeedPlotView::setPeriod(const TimePeriod period)
     switch (period)
     {
     case SpeedPlotView::MIN1:
-        m_viewablePointsCount = MIN1_SEC;
+        m_viewablePointsCount = MIN1_BUF_SIZE;
         m_currentData = &m_data5Min;
         break;
     case SpeedPlotView::MIN5:
-        m_viewablePointsCount = MIN5_SEC;
+        m_viewablePointsCount = MIN5_BUF_SIZE;
         m_currentData = &m_data5Min;
         break;
     case SpeedPlotView::MIN30:

--- a/src/gui/properties/speedwidget.cpp
+++ b/src/gui/properties/speedwidget.cpp
@@ -115,9 +115,7 @@ SpeedWidget::SpeedWidget(PropertiesWidget *parent)
 
     loadSettings();
 
-    QTimer *localUpdateTimer = new QTimer(this);
-    connect(localUpdateTimer, &QTimer::timeout, this, &SpeedWidget::update);
-    localUpdateTimer->start(1000);
+    connect(BitTorrent::Session::instance(), &BitTorrent::Session::statsUpdated, this, &SpeedWidget::update);
 
     m_plot->show();
 }

--- a/src/gui/statusbar.cpp
+++ b/src/gui/statusbar.cpp
@@ -147,7 +147,9 @@ StatusBar::StatusBar(QWidget *parent)
     // Is DHT enabled
     m_DHTLbl->setVisible(session->isDHTEnabled());
     refresh();
+    updateSpeedLabels();
     connect(session, &BitTorrent::Session::statsUpdated, this, &StatusBar::refresh);
+    connect(session, &BitTorrent::Session::speedRatesUpdated, this, &StatusBar::updateSpeedLabels);
 }
 
 StatusBar::~StatusBar()
@@ -210,16 +212,17 @@ void StatusBar::updateDHTNodesNumber()
 
 void StatusBar::updateSpeedLabels()
 {
-    const BitTorrent::SessionStatus &sessionStatus = BitTorrent::Session::instance()->status();
+    const BitTorrent::Session *session = BitTorrent::Session::instance();
+    const BitTorrent::SessionStatus &sessionStatus = session->status();
 
-    QString dlSpeedLbl = Utils::Misc::friendlyUnit(sessionStatus.payloadDownloadRate, true);
+    QString dlSpeedLbl = Utils::Misc::friendlyUnit(session->downloadRate(), true);
     const int dlSpeedLimit = BitTorrent::Session::instance()->downloadSpeedLimit();
     if (dlSpeedLimit > 0)
         dlSpeedLbl += " [" + Utils::Misc::friendlyUnit(dlSpeedLimit, true) + ']';
     dlSpeedLbl += " (" + Utils::Misc::friendlyUnit(sessionStatus.totalPayloadDownload) + ')';
     m_dlSpeedLbl->setText(dlSpeedLbl);
 
-    QString upSpeedLbl = Utils::Misc::friendlyUnit(sessionStatus.payloadUploadRate, true);
+    QString upSpeedLbl = Utils::Misc::friendlyUnit(session->uploadRate(), true);
     const int upSpeedLimit = BitTorrent::Session::instance()->uploadSpeedLimit();
     if (upSpeedLimit > 0)
         upSpeedLbl += " [" + Utils::Misc::friendlyUnit(upSpeedLimit, true) + ']';
@@ -231,7 +234,6 @@ void StatusBar::refresh()
 {
     updateConnectionStatus();
     updateDHTNodesNumber();
-    updateSpeedLabels();
 }
 
 void StatusBar::updateAltSpeedsBtn(bool alternative)
@@ -249,6 +251,7 @@ void StatusBar::updateAltSpeedsBtn(bool alternative)
         m_altSpeedsBtn->setDown(false);
     }
     refresh();
+    updateSpeedLabels();
 }
 
 void StatusBar::capDownloadSpeed()
@@ -263,6 +266,7 @@ void StatusBar::capDownloadSpeed()
         qDebug("Setting global download rate limit to %.1fKb/s", newLimit / 1024.);
         session->setDownloadSpeedLimit(newLimit);
         refresh();
+        updateSpeedLabels();
     }
 }
 
@@ -278,5 +282,6 @@ void StatusBar::capUploadSpeed()
         qDebug("Setting global upload rate limit to %.1fKb/s", newLimit / 1024.);
         session->setUploadSpeedLimit(newLimit);
         refresh();
+        updateSpeedLabels();
     }
 }


### PR DESCRIPTION
Basically aims to fix two bugs:
 1. https://github.com/qbittorrent/qBittorrent/issues/12459
 2. speedplotview assumes speed is updated per second but the default value is 1500ms this causes lots of duplicate data in the calculation for the graph.