### PR TITLE
Add CTRL + I keyboard shortcut to open statistics (command + I on Mac)

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -883,6 +883,7 @@ void MainWindow::createKeyboardShortcuts()
 
     m_ui->actionDocumentation->setShortcut(QKeySequence::HelpContents);
     m_ui->actionOptions->setShortcut(Qt::ALT + Qt::Key_O);
+    m_ui->actionStatistics->setShortcut(Qt::CTRL + Qt::Key_I);
     m_ui->actionStart->setShortcut(Qt::CTRL + Qt::Key_S);
     m_ui->actionStartAll->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_S);
     m_ui->actionPause->setShortcut(Qt::CTRL + Qt::Key_P);


### PR DESCRIPTION
Hi!

I hope this was the correct way to implement it, it worked perfectly on Mac. I missed an easy way to open the statistics on the current qBittorrent so I hope you guys will merge this.

By the way, ``CTRL + I`` is consistent with VLC's more information & codec information shortcuts.

Thanks