### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,242 @@
+name: GitHub Actions CI
+
+# Cache is used for all Windows and macOS dependencies (size approx. 1230 * 2 + 1850 = 4310 MiB)
+# Cache is not used for Ubuntu builds, because it already has all dependencies except
+# the appropriate libtorrent version, which only takes 3-5 minutes to build from source anyway
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    types: [edited, opened, reopened, synchronize]
+    branches: [ master ]
+
+env:
+  # Qt: 5.15.0
+  # libtorrent: RC_1_2 HEAD, 1.2.10
+  VCPKG_COMMIT: 32eccc18191fbb57b159784a1724d2d00613ae82
+  VCPKG_DEST_MACOS: /Users/runner/qbt_tools/vcpkg
+  VCPKG_DEST_WIN: C:\qbt_tools\vcpkg
+  UBUNTU_LIBTORRENT_VERSION: libtorrent-1.2.10
+
+jobs:
+
+  ci_ubuntu:
+    name: Ubuntu
+
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-18.04]
+        qbt_gui: ["GUI=ON", "GUI=OFF"]
+      fail-fast: false
+
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: checkout repository
+      uses: actions/checkout@v2.3.2
+
+    - name: install all build dependencies except libtorrent from Ubuntu repos
+      run: |
+        sudo apt install \
+          build-essential cmake git ninja-build pkg-config \
+          libssl-dev libgeoip-dev zlib1g-dev \
+          libboost-dev libboost-chrono-dev libboost-random-dev libboost-system-dev \
+          libqt5svg5-dev qtbase5-dev qttools5-dev
+
+    - name: install libtorrent from source
+      run: |
+        git clone https://github.com/arvidn/libtorrent && cd libtorrent
+        git checkout ${{ env.UBUNTU_LIBTORRENT_VERSION }}
+        cmake -B cmake-build-dir -G "Ninja" \
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -Ddeprecated-functions=OFF \
+          --graphviz=cmake-build-dir/target_graph.dot
+        cmake --build cmake-build-dir
+        sudo cmake --install cmake-build-dir --prefix /usr/local
+
+    - name: build qBittorrent
+      run: |
+        cmake -B build -G "Ninja" \
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -D${{ matrix.qbt_gui }} \
+          -DVERBOSE_CONFIGURE=ON \
+          --graphviz=build/target_graph.dot
+        cmake --build build
+
+    - name: upload artifact as zip
+      uses: actions/upload-artifact@v2.1.3
+      with:
+        name: qBittorrent-CI-Ubuntu_${{ matrix.os }}-${{ matrix.qbt_gui }}
+        path: |
+          build/compile_commands.json
+          build/target_graph.dot
+          build/qbittorrent
+          build/qbittorrent-nox
+          libtorrent/cmake-build-dir/compile_commands.json
+          libtorrent/cmake-build-dir/target_graph.dot
+
+  ci_windows:
+    name: Windows + vcpkg
+
+    runs-on: windows-2019
+
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+    - name: checkout repository
+      uses: actions/checkout@v2.3.2
+
+    # - ninja is needed for building qBittorrent (because it's preferrable, not a hard requirement)
+    - name: install additional required packages with chocolatey
+      run: |
+        choco install ninja
+
+    - name: setup vcpkg (cached, if possible)
+      uses: lukka/run-vcpkg@v3.3
+      with:
+        vcpkgDirectory: ${{ env.VCPKG_DEST_WIN }}
+        vcpkgGitCommitId: ${{ env.VCPKG_COMMIT }}
+        setupOnly: true
+
+    # Tell vcpkg to only build Release variants of the dependencies
+    - name: configure vcpkg triplet overlay for release builds only
+      run: |
+        New-Item -Path ${{ github.workspace }} -Name "triplets_overlay" -ItemType Directory
+        Copy-Item ${{ env.RUNVCPKG_VCPKG_ROOT }}/triplets/x64-windows-static.cmake `
+          ${{ github.workspace }}/triplets_overlay/x64-windows-static-release.cmake
+        Add-Content ${{ github.workspace }}/triplets_overlay/x64-windows-static-release.cmake `
+          -Value "set(VCPKG_BUILD_TYPE release)"
+
+    # clear buildtrees after each package installation to reduce disk space requirements
+    - name: install dependencies via vcpkg
+      run: |
+        $packages = `
+          "boost-circular-buffer:x64-windows-static-release",
+          "libtorrent:x64-windows-static-release",
+          "qt5-base:x64-windows-static-release",
+          "qt5-svg:x64-windows-static-release",
+          "qt5-tools:x64-windows-static-release",
+          "qt5-winextras:x64-windows-static-release"
+        foreach($package in $packages)
+        {
+          ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg.exe install $package `
+            --overlay-triplets=${{ github.workspace }}/triplets_overlay `
+            --clean-after-build
+        }
+
+    # NOTE: this is necessary to correctly find and use cl.exe with the Ninja generator for now
+    - name: setup devcmd
+      uses: ilammy/msvc-dev-cmd@v1.3.0
+
+    - name: build qBittorrent
+      shell: cmd
+      run: |
+        cmake -B build -G "Ninja" ^
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
+          -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_DEST_WIN }}\scripts\buildsystems\vcpkg.cmake ^
+          -DVCPKG_TARGET_TRIPLET=x64-windows-static-release ^
+          -DVERBOSE_CONFIGURE=ON ^
+          --graphviz=build\target_graph.dot
+        cmake --build build
+
+    - name: upload artifact as zip
+      uses: actions/upload-artifact@v2.1.3
+      with:
+        name: qBittorrent-CI-Windows_x64-static-release
+        path: |
+          build/compile_commands.json
+          build/target_graph.dot
+          build/qbittorrent.exe
+          build/qbittorrent.pdb
+          dist/windows/qt.conf
+
+  ci_macos:
+    name: macOS + vcpkg
+
+    strategy:
+      matrix:
+        qbt_gui: ["GUI=ON", "GUI=OFF"]
+      fail-fast: false
+
+    runs-on: macos-10.15
+
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+    - name: checkout repository
+      uses: actions/checkout@v2.3.2
+
+    # - ninja is needed for building qBittorrent (because it's preferrable, not a hard requirement)
+    # - pkg-config is needed for some vcpkg installations
+    - name: install additional required packages with homebrew
+      shell: bash
+      run: |
+        brew install ninja pkg-config
+
+    - name: setup vcpkg (cached, if possible)
+      uses: lukka/run-vcpkg@v3.3
+      with:
+        vcpkgDirectory: ${{ env.VCPKG_DEST_MACOS }}
+        vcpkgGitCommitId: ${{ env.VCPKG_COMMIT }}
+        setupOnly: true
+
+    - name: configure vcpkg triplet overlay for release builds only
+      run: |
+        New-Item -Path ${{ github.workspace }} -Name "triplets_overlay" -ItemType Directory
+        Copy-Item ${{ env.RUNVCPKG_VCPKG_ROOT }}/triplets/x64-osx.cmake `
+          ${{ github.workspace }}/triplets_overlay/x64-osx-release.cmake
+        Add-Content ${{ github.workspace }}/triplets_overlay/x64-osx-release.cmake `
+          -Value "set(VCPKG_BUILD_TYPE release)"
+
+    # NOTE: Avoids a libtorrent ABI issue. See https://github.com/arvidn/libtorrent/issues/4965
+    - name: force AppleClang to compile libtorrent with C++14
+      run: |
+        (Get-Content -path ${{ env.RUNVCPKG_VCPKG_ROOT }}/ports/libtorrent/portfile.cmake).Replace( `
+          '${FEATURE_OPTIONS}', '${FEATURE_OPTIONS} -DCMAKE_CXX_STANDARD=14') `
+          | Set-Content -Path ${{ env.RUNVCPKG_VCPKG_ROOT }}/ports/libtorrent/portfile.cmake
+
+    - name: install dependencies via vcpkg
+      run: |
+        $packages = `
+          "boost-circular-buffer:x64-osx-release",
+          "libtorrent:x64-osx-release",
+          "qt5-base:x64-osx-release",
+          "qt5-svg:x64-osx-release",
+          "qt5-tools:x64-osx-release",
+          "qt5-macextras:x64-osx-release"
+        foreach($package in $packages)
+        {
+          ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg install $package `
+            --overlay-triplets=${{ github.workspace }}/triplets_overlay `
+            --clean-after-build
+        }
+
+    - name: build qBittorrent
+      shell: bash
+      run: |
+        cmake -B build -G "Ninja" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_DEST_MACOS }}/scripts/buildsystems/vcpkg.cmake \
+          -DVCPKG_TARGET_TRIPLET=x64-osx-release \
+          -D${{ matrix.qbt_gui }} \
+          -DVERBOSE_CONFIGURE=ON \
+          --graphviz=build/target_graph.dot
+        cmake --build build
+
+    - name: upload artifact as zip
+      uses: actions/upload-artifact@v2.1.3
+      with:
+        name: qBittorrent-CI-macOS_x64-static-release_${{ matrix.qbt_gui }}
+        path: |
+          build/compile_commands.json
+          build/target_graph.dot
+          build/qbittorrent.app
+          build/qbittorrent-nox.app


### PR DESCRIPTION
- Ubuntu 18.04/20.04, GUI ON/OFF
- Windows 2019
- macOS 10.15 GUI ON/OFF

---

~Depends on ~https://github.com/qbittorrent/qBittorrent/pull/12746~ https://github.com/qbittorrent/qBittorrent/pull/13327 (it's rebased on top of that one).~ `master` is now ready for this.

- The workflow runs on pushes to master or any events from PRs that target master.

- It takes 10 to 15 minutes to complete if cached.
The very first time around (or if the caches are dropped due to not being used for a week) there will be no caches. Without caches, it takes 1:30 to 3 hours.

- It's quite readable and maintainable: only ~230~ 240 lines for all OS/GUI combinations we currently have in CI, plus Ubuntu 20.04, which we currently don't have. It does not depend in any way on packages/archives from builds.shiki.hu. All dependencies are built from official sources, and it's easier to change out their versions.
- It only covers building with CMake. If something similar is desirable for qmake builds, I think it should be done in another workflow file.
- The build artifacts are published after the build is finished, which may come in handy for testing purposes.

Example cached run: https://github.com/FranciscoPombal/qBittorrent/actions/runs/223928661

---

Most of this is based on lessons learned from https://github.com/qbittorrent/qBittorrent/pull/13070. Both can coexist and are independent of each other, but this one is the one that will use caching (cache space is limited to 5 GiB), because nobody wants CI that takes hours to complete, whereas nightly builds with various combinations of dependency versions for user testing on Windows is not as time-sensitive.