### PR TITLE
Fix open path won't work correctly

### DIFF
--- a/src/base/utils/string.h
+++ b/src/base/utils/string.h
@@ -30,7 +30,7 @@
 #ifndef UTILS_STRING_H
 #define UTILS_STRING_H
 
-#include <QLatin1String>
+#include <QChar>
 #include <QVector>
 
 class QString;
@@ -54,13 +54,13 @@ namespace Utils
         QString wildcardToRegex(const QString &pattern);
 
         template <typename T>
-        T unquote(const T &str, const QString &quotes = QLatin1String("\""))
+        T unquote(const T &str, const QString &quotes = QChar('"'))
         {
             if (str.length() < 2) return str;
 
-            for (const auto &quote : quotes) {
+            for (const QChar quote : quotes) {
                 if (str.startsWith(quote) && str.endsWith(quote))
-                    return str.mid(1, str.length() - 2);
+                    return str.mid(1, (str.length() - 2));
             }
 
             return str;

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -545,8 +545,9 @@ void PropertiesWidget::openFolder(const QModelIndex &index, const bool containin
     // FOLDER
     if (m_propListModel->itemType(index) == TorrentContentModelItem::FolderType) {
         // Generate relative path to selected folder
-        QStringList pathItems {index.data().toString()};
-        QModelIndex parent = m_propListModel->parent(index);
+        const QModelIndex nameIndex {index.sibling(index.row(), TorrentContentModelItem::COL_NAME)};
+        QStringList pathItems {nameIndex.data().toString()};
+        QModelIndex parent = m_propListModel->parent(nameIndex);
         while (parent.isValid()) {
             pathItems.prepend(parent.data().toString());
             parent = m_propListModel->parent(parent);

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -517,7 +517,7 @@ void PropertiesWidget::loadUrlSeeds()
     }
 }
 
-void PropertiesWidget::openDoubleClickedFile(const QModelIndex &index)
+void PropertiesWidget::openDoubleClickedFile(const QModelIndex &index) const
 {
     if (!index.isValid() || !m_torrent || !m_torrent->hasMetadata()) return;
 
@@ -527,7 +527,7 @@ void PropertiesWidget::openDoubleClickedFile(const QModelIndex &index)
         openFolder(index, false);
 }
 
-void PropertiesWidget::openFile(const QModelIndex &index)
+void PropertiesWidget::openFile(const QModelIndex &index) const
 {
     int i = m_propListModel->getFileIndex(index);
     const QDir saveDir(m_torrent->savePath(true));
@@ -539,14 +539,13 @@ void PropertiesWidget::openFile(const QModelIndex &index)
     Utils::Gui::openPath(filePath);
 }
 
-void PropertiesWidget::openFolder(const QModelIndex &index, bool containingFolder)
+void PropertiesWidget::openFolder(const QModelIndex &index, const bool containingFolder) const
 {
     QString absolutePath;
     // FOLDER
     if (m_propListModel->itemType(index) == TorrentContentModelItem::FolderType) {
         // Generate relative path to selected folder
-        QStringList pathItems;
-        pathItems << index.data().toString();
+        QStringList pathItems {index.data().toString()};
         QModelIndex parent = m_propListModel->parent(index);
         while (parent.isValid()) {
             pathItems.prepend(parent.data().toString());
@@ -554,12 +553,13 @@ void PropertiesWidget::openFolder(const QModelIndex &index, bool containingFolde
         }
         if (pathItems.isEmpty())
             return;
+
         const QDir saveDir(m_torrent->savePath(true));
         const QString relativePath = pathItems.join('/');
         absolutePath = Utils::Fs::expandPath(saveDir.absoluteFilePath(relativePath));
     }
     else {
-        int i = m_propListModel->getFileIndex(index);
+        const int i = m_propListModel->getFileIndex(index);
         const QDir saveDir(m_torrent->savePath(true));
         const QString relativePath = m_torrent->filePath(i);
         absolutePath = Utils::Fs::expandPath(saveDir.absoluteFilePath(relativePath));
@@ -569,7 +569,7 @@ void PropertiesWidget::openFolder(const QModelIndex &index, bool containingFolde
     m_torrent->flushCache();
 #ifdef Q_OS_MACOS
     Q_UNUSED(containingFolder);
-    MacUtils::openFiles(QSet<QString>{absolutePath});
+    MacUtils::openFiles(QSet<QString> {absolutePath});
 #else
     if (containingFolder)
         Utils::Gui::openFolderSelect(absolutePath);

--- a/src/gui/properties/propertieswidget.h
+++ b/src/gui/properties/propertieswidget.h
@@ -82,7 +82,7 @@ public slots:
     void readSettings();
     void saveSettings();
     void reloadPreferences();
-    void openDoubleClickedFile(const QModelIndex &);
+    void openDoubleClickedFile(const QModelIndex &index) const;
     void loadTrackers(BitTorrent::TorrentHandle *const torrent);
 
 protected slots:
@@ -107,8 +107,8 @@ private slots:
 private:
     QPushButton *getButtonFromIndex(int index);
     void applyPriorities();
-    void openFile(const QModelIndex &index);
-    void openFolder(const QModelIndex &index, bool containingFolder);
+    void openFile(const QModelIndex &index) const;
+    void openFolder(const QModelIndex &index, bool containingFolder) const;
 
     Ui::PropertiesWidget *m_ui;
     BitTorrent::TorrentHandle *m_torrent;


### PR DESCRIPTION
Previously, if double click on the Size number in torrent content tab the path would be an incorrect value and as such open path functionality won't work, this commit fixes it.