### PR TITLE
Fix "Open containing folder" opened the wrong path for folder item

### DIFF
--- a/src/gui/properties/propertieswidget.h
+++ b/src/gui/properties/propertieswidget.h
@@ -82,7 +82,7 @@ public slots:
     void readSettings();
     void saveSettings();
     void reloadPreferences();
-    void openDoubleClickedFile(const QModelIndex &index) const;
+    void openItem(const QModelIndex &index) const;
     void loadTrackers(BitTorrent::TorrentHandle *const torrent);
 
 protected slots:
@@ -107,8 +107,8 @@ private slots:
 private:
     QPushButton *getButtonFromIndex(int index);
     void applyPriorities();
-    void openFile(const QModelIndex &index) const;
-    void openFolder(const QModelIndex &index, bool containingFolder) const;
+    void openParentFolder(const QModelIndex &index) const;
+    QString getFullPath(const QModelIndex &index) const;
 
     Ui::PropertiesWidget *m_ui;
     BitTorrent::TorrentHandle *m_torrent;

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -175,12 +175,14 @@ void Utils::Gui::openPath(const QString &absolutePath)
 // (if possible) the item at the given path
 void Utils::Gui::openFolderSelect(const QString &absolutePath)
 {
-    const QString path = Utils::Fs::toUniformPath(absolutePath);
+    QString path {Utils::Fs::toUniformPath(absolutePath)};
+    const QFileInfo pathInfo {path};
     // If the item to select doesn't exist, try to open its parent
-    if (!QFileInfo::exists(path)) {
+    if (!pathInfo.exists(path)) {
         openPath(path.left(path.lastIndexOf('/')));
         return;
     }
+
 #ifdef Q_OS_WIN
     HRESULT hresult = ::CoInitializeEx(nullptr, COINIT_MULTITHREADED);
     PIDLIST_ABSOLUTE pidl = ::ILCreateFromPathW(reinterpret_cast<PCTSTR>(Utils::Fs::toNativePath(path).utf16()));
@@ -200,6 +202,8 @@ void Utils::Gui::openFolderSelect(const QString &absolutePath)
     }
     else if ((output == "nautilus.desktop") || (output == "org.gnome.Nautilus.desktop")
                  || (output == "nautilus-folder-handler.desktop")) {
+        if (pathInfo.isDir())
+            path = path.left(path.lastIndexOf('/'));
         proc.start("nautilus", {"--version"});
         proc.waitForFinished();
         const QString nautilusVerStr = QString(proc.readLine()).remove(QRegularExpression("[^0-9.]"));
@@ -210,6 +214,8 @@ void Utils::Gui::openFolderSelect(const QString &absolutePath)
             proc.startDetached("nautilus", {"--no-desktop", Utils::Fs::toNativePath(path)});
     }
     else if (output == "nemo.desktop") {
+        if (pathInfo.isDir())
+            path = path.left(path.lastIndexOf('/'));
         proc.startDetached("nemo", {"--no-desktop", Utils::Fs::toNativePath(path)});
     }
     else if ((output == "konqueror.desktop") || (output == "kfmclient_dir.desktop")) {


### PR DESCRIPTION
Previously that action is the same as "Open" action which is wrong behavior, it should be opening the parent folder instead. The wrong behavior is observed on nautilus 3.36.3 and nemo 4.6.5.