### PR TITLE
Fix GeoDB download in systems with non-C locales

### DIFF
--- a/src/base/net/geoipmanager.cpp
+++ b/src/base/net/geoipmanager.cpp
@@ -33,6 +33,7 @@
 #include <QDir>
 #include <QFile>
 #include <QHostAddress>
+#include <QLocale>
 
 #include "base/logger.h"
 #include "base/preferences.h"
@@ -124,8 +125,8 @@ void GeoIPManager::manageDatabaseUpdate()
 
 void GeoIPManager::downloadDatabaseFile()
 {
-    const QDate curDate = QDateTime::currentDateTimeUtc().date();
-    const QString curUrl = DATABASE_URL.arg(curDate.toString("yyyy-MM"));
+    const QDateTime curDatetime = QDateTime::currentDateTimeUtc();
+    const QString curUrl = DATABASE_URL.arg(QLocale::c().toString(curDatetime, "yyyy-MM"));
     DownloadManager::instance()->download({curUrl}, this, &GeoIPManager::downloadFinished);
 }
 


### PR DESCRIPTION
Closes #13318.

---

The linked bug report provides an example with an Arabic system locale. The date was being formatted according to the system locale, so in this case, qBittorrent was attempting to download the database file from the following download URL, which includes the date in an Arabic script: `https://download.db-ip.com/free/dbip-country-lite-٢٠٢٠-٠٩.mmdb.gz`.

To fix it, force the date formatting to be done against the `C` (POSIX) locale.