### PR TITLE
Disable deprecated settings in libtorrent 2.0

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1043,7 +1043,7 @@ void Session::initializeNativeSession()
 #endif
 
     loadLTSettings(pack);
-    m_nativeSession = new lt::session {pack, lt::session_flags_t {0}};
+    m_nativeSession = new lt::session {lt::session_params {pack, {}}};
 
     LogMsg(tr("Peer ID: ") + QString::fromStdString(peerId));
     LogMsg(tr("HTTP User-Agent is '%1'").arg(USER_AGENT));

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1257,18 +1257,21 @@ void Session::loadLTSettings(lt::settings_pack &settingsPack)
     const int checkingMemUsageSize = checkingMemUsage() * 64;
     settingsPack.set_int(lt::settings_pack::checking_mem_usage, checkingMemUsageSize);
 
+#if (LIBTORRENT_VERSION_NUM < 20000)
     const int cacheSize = (diskCacheSize() > -1) ? (diskCacheSize() * 64) : -1;
     settingsPack.set_int(lt::settings_pack::cache_size, cacheSize);
     settingsPack.set_int(lt::settings_pack::cache_expiry, diskCacheTTL());
-    qDebug() << "Using a disk cache size of" << cacheSize << "MiB";
+#endif
 
     lt::settings_pack::io_buffer_mode_t mode = useOSCache() ? lt::settings_pack::enable_os_cache
                                                               : lt::settings_pack::disable_os_cache;
     settingsPack.set_int(lt::settings_pack::disk_io_read_mode, mode);
     settingsPack.set_int(lt::settings_pack::disk_io_write_mode, mode);
 
+#if (LIBTORRENT_VERSION_NUM < 20000)
     settingsPack.set_bool(lt::settings_pack::coalesce_reads, isCoalesceReadWriteEnabled());
     settingsPack.set_bool(lt::settings_pack::coalesce_writes, isCoalesceReadWriteEnabled());
+#endif
 
 #if (LIBTORRENT_VERSION_NUM >= 10202)
     settingsPack.set_bool(lt::settings_pack::piece_extent_affinity, usePieceExtentAffinity());

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -87,11 +87,15 @@ enum AdvSettingsRows
     ASYNC_IO_THREADS,
     FILE_POOL_SIZE,
     CHECKING_MEM_USAGE,
+#if (LIBTORRENT_VERSION_NUM < 20000)
     // cache
     DISK_CACHE,
     DISK_CACHE_TTL,
+#endif
     OS_CACHE,
+#if (LIBTORRENT_VERSION_NUM < 20000)
     COALESCE_RW,
+#endif
 #if (LIBTORRENT_VERSION_NUM >= 10202)
     PIECE_EXTENT_AFFINITY,
 #endif
@@ -147,8 +151,6 @@ AdvancedSettings::AdvancedSettings(QWidget *parent)
     setSelectionMode(QAbstractItemView::NoSelection);
     setEditTriggers(QAbstractItemView::NoEditTriggers);
     // Signals
-    connect(&m_spinBoxCache, qOverload<int>(&QSpinBox::valueChanged)
-            , this, &AdvancedSettings::updateCacheSpinSuffix);
     connect(&m_comboBoxInterface, qOverload<int>(&QComboBox::currentIndexChanged)
             , this, &AdvancedSettings::updateInterfaceAddressCombo);
     connect(&m_spinBoxSaveResumeDataInterval, qOverload<int>(&QSpinBox::valueChanged)
@@ -192,13 +194,17 @@ void AdvancedSettings::saveAdvancedSettings()
     session->setFilePoolSize(m_spinBoxFilePoolSize.value());
     // Checking Memory Usage
     session->setCheckingMemUsage(m_spinBoxCheckingMemUsage.value());
+#if (LIBTORRENT_VERSION_NUM < 20000)
     // Disk write cache
     session->setDiskCacheSize(m_spinBoxCache.value());
     session->setDiskCacheTTL(m_spinBoxCacheTTL.value());
+#endif
     // Enable OS cache
     session->setUseOSCache(m_checkBoxOsCache.isChecked());
+#if (LIBTORRENT_VERSION_NUM < 20000)
     // Coalesce reads & writes
     session->setCoalesceReadWriteEnabled(m_checkBoxCoalesceRW.isChecked());
+#endif
 #if (LIBTORRENT_VERSION_NUM >= 10202)
     // Piece extent affinity
     session->setPieceExtentAffinity(m_checkBoxPieceExtentAffinity.isChecked());
@@ -290,6 +296,7 @@ void AdvancedSettings::saveAdvancedSettings()
     session->setPeerTurnoverInterval(m_spinBoxPeerTurnoverInterval.value());
 }
 
+#if (LIBTORRENT_VERSION_NUM < 20000)
 void AdvancedSettings::updateCacheSpinSuffix(int value)
 {
     if (value == 0)
@@ -299,6 +306,7 @@ void AdvancedSettings::updateCacheSpinSuffix(int value)
     else
         m_spinBoxCache.setSuffix(tr(" MiB"));
 }
+#endif
 
 void AdvancedSettings::updateSaveResumeDataIntervalSuffix(const int value)
 {
@@ -422,7 +430,7 @@ void AdvancedSettings::loadAdvancedSettings()
     m_spinBoxCheckingMemUsage.setSuffix(tr(" MiB"));
     addRow(CHECKING_MEM_USAGE, (tr("Outstanding memory when checking torrents") + ' ' + makeLink("https://www.libtorrent.org/reference-Settings.html#checking_mem_usage", "(?)"))
             , &m_spinBoxCheckingMemUsage);
-
+#if (LIBTORRENT_VERSION_NUM < 20000)
     // Disk write cache
     m_spinBoxCache.setMinimum(-1);
     // When build as 32bit binary, set the maximum at less than 2GB to prevent crashes.
@@ -434,6 +442,8 @@ void AdvancedSettings::loadAdvancedSettings()
 #endif
     m_spinBoxCache.setValue(session->diskCacheSize());
     updateCacheSpinSuffix(m_spinBoxCache.value());
+    connect(&m_spinBoxCache, qOverload<int>(&QSpinBox::valueChanged)
+            , this, &AdvancedSettings::updateCacheSpinSuffix);
     addRow(DISK_CACHE, (tr("Disk cache") + ' ' + makeLink("https://www.libtorrent.org/reference-Settings.html#cache_size", "(?)"))
             , &m_spinBoxCache);
     // Disk cache expiry
@@ -443,14 +453,17 @@ void AdvancedSettings::loadAdvancedSettings()
     m_spinBoxCacheTTL.setSuffix(tr(" s", " seconds"));
     addRow(DISK_CACHE_TTL, (tr("Disk cache expiry interval") + ' ' + makeLink("https://www.libtorrent.org/reference-Settings.html#cache_expiry", "(?)"))
             , &m_spinBoxCacheTTL);
+#endif
     // Enable OS cache
     m_checkBoxOsCache.setChecked(session->useOSCache());
     addRow(OS_CACHE, (tr("Enable OS cache") + ' ' + makeLink("https://www.libtorrent.org/reference-Settings.html#disk_io_write_mode", "(?)"))
             , &m_checkBoxOsCache);
+#if (LIBTORRENT_VERSION_NUM < 20000)
     // Coalesce reads & writes
     m_checkBoxCoalesceRW.setChecked(session->isCoalesceReadWriteEnabled());
     addRow(COALESCE_RW, (tr("Coalesce reads & writes") + ' ' + makeLink("https://www.libtorrent.org/reference-Settings.html#coalesce_reads", "(?)"))
             , &m_checkBoxCoalesceRW);
+#endif
 #if (LIBTORRENT_VERSION_NUM >= 10202)
     // Piece extent affinity
     m_checkBoxPieceExtentAffinity.setChecked(session->usePieceExtentAffinity());

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -151,11 +151,6 @@ AdvancedSettings::AdvancedSettings(QWidget *parent)
     setAlternatingRowColors(true);
     setSelectionMode(QAbstractItemView::NoSelection);
     setEditTriggers(QAbstractItemView::NoEditTriggers);
-    // Signals
-    connect(&m_comboBoxInterface, qOverload<int>(&QComboBox::currentIndexChanged)
-            , this, &AdvancedSettings::updateInterfaceAddressCombo);
-    connect(&m_spinBoxSaveResumeDataInterval, qOverload<int>(&QSpinBox::valueChanged)
-            , this, &AdvancedSettings::updateSaveResumeDataIntervalSuffix);
     // Load settings
     loadAdvancedSettings();
     resizeColumnToContents(0);
@@ -503,6 +498,8 @@ void AdvancedSettings::loadAdvancedSettings()
     m_spinBoxSaveResumeDataInterval.setMinimum(0);
     m_spinBoxSaveResumeDataInterval.setMaximum(std::numeric_limits<int>::max());
     m_spinBoxSaveResumeDataInterval.setValue(session->saveResumeDataInterval());
+    connect(&m_spinBoxSaveResumeDataInterval, qOverload<int>(&QSpinBox::valueChanged)
+        , this, &AdvancedSettings::updateSaveResumeDataIntervalSuffix);
     updateSaveResumeDataIntervalSuffix(m_spinBoxSaveResumeDataInterval.value());
     addRow(SAVE_RESUME_DATA_INTERVAL, tr("Save resume data interval", "How often the fastresume file is saved."), &m_spinBoxSaveResumeDataInterval);
     // Outgoing port Min
@@ -573,6 +570,8 @@ void AdvancedSettings::loadAdvancedSettings()
         m_comboBoxInterface.addItem(session->networkInterfaceName(), currentInterface);
         m_comboBoxInterface.setCurrentIndex(i);
     }
+    connect(&m_comboBoxInterface, qOverload<int>(&QComboBox::currentIndexChanged)
+        , this, &AdvancedSettings::updateInterfaceAddressCombo);
     addRow(NETWORK_IFACE, tr("Network Interface"), &m_comboBoxInterface);
     // Network interface address
     updateInterfaceAddressCombo();

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -49,92 +49,93 @@ namespace
     {
          return QStringLiteral("<a href=\"%1\">%2</a>").arg(url, linkLabel);
     }
-}
 
-enum AdvSettingsCols
-{
-    PROPERTY,
-    VALUE,
-    COL_COUNT
-};
-enum AdvSettingsRows
-{
-    // qBittorrent section
-    QBITTORRENT_HEADER,
+    enum AdvSettingsCols
+    {
+        PROPERTY,
+        VALUE,
+        COL_COUNT
+    };
+
+    enum AdvSettingsRows
+    {
+        // qBittorrent section
+        QBITTORRENT_HEADER,
 #if defined(Q_OS_WIN)
-    OS_MEMORY_PRIORITY,
+        OS_MEMORY_PRIORITY,
 #endif
-    // network interface
-    NETWORK_IFACE,
-    //Optional network address
-    NETWORK_IFACE_ADDRESS,
-    // behavior
-    SAVE_RESUME_DATA_INTERVAL,
-    CONFIRM_RECHECK_TORRENT,
-    RECHECK_COMPLETED,
-    // UI related
-    LIST_REFRESH,
-    RESOLVE_HOSTS,
-    RESOLVE_COUNTRIES,
-    PROGRAM_NOTIFICATIONS,
-    TORRENT_ADDED_NOTIFICATIONS,
-    CONFIRM_REMOVE_ALL_TAGS,
-    DOWNLOAD_TRACKER_FAVICON,
-    SAVE_PATH_HISTORY_LENGTH,
-    ENABLE_SPEED_WIDGET,
-    // libtorrent section
-    LIBTORRENT_HEADER,
-    ASYNC_IO_THREADS,
-    FILE_POOL_SIZE,
-    CHECKING_MEM_USAGE,
+        // network interface
+        NETWORK_IFACE,
+        //Optional network address
+        NETWORK_IFACE_ADDRESS,
+        // behavior
+        SAVE_RESUME_DATA_INTERVAL,
+        CONFIRM_RECHECK_TORRENT,
+        RECHECK_COMPLETED,
+        // UI related
+        LIST_REFRESH,
+        RESOLVE_HOSTS,
+        RESOLVE_COUNTRIES,
+        PROGRAM_NOTIFICATIONS,
+        TORRENT_ADDED_NOTIFICATIONS,
+        CONFIRM_REMOVE_ALL_TAGS,
+        DOWNLOAD_TRACKER_FAVICON,
+        SAVE_PATH_HISTORY_LENGTH,
+        ENABLE_SPEED_WIDGET,
+        // libtorrent section
+        LIBTORRENT_HEADER,
+        ASYNC_IO_THREADS,
+        FILE_POOL_SIZE,
+        CHECKING_MEM_USAGE,
 #if (LIBTORRENT_VERSION_NUM < 20000)
-    // cache
-    DISK_CACHE,
-    DISK_CACHE_TTL,
+        // cache
+        DISK_CACHE,
+        DISK_CACHE_TTL,
 #endif
-    OS_CACHE,
+        OS_CACHE,
 #if (LIBTORRENT_VERSION_NUM < 20000)
-    COALESCE_RW,
+        COALESCE_RW,
 #endif
 #if (LIBTORRENT_VERSION_NUM >= 10202)
-    PIECE_EXTENT_AFFINITY,
+        PIECE_EXTENT_AFFINITY,
 #endif
-    SUGGEST_MODE,
-    SEND_BUF_WATERMARK,
-    SEND_BUF_LOW_WATERMARK,
-    SEND_BUF_WATERMARK_FACTOR,
-    // networking & ports
-    SOCKET_BACKLOG_SIZE,
-    OUTGOING_PORT_MIN,
-    OUTGOING_PORT_MAX,
+        SUGGEST_MODE,
+        SEND_BUF_WATERMARK,
+        SEND_BUF_LOW_WATERMARK,
+        SEND_BUF_WATERMARK_FACTOR,
+        // networking & ports
+        SOCKET_BACKLOG_SIZE,
+        OUTGOING_PORT_MIN,
+        OUTGOING_PORT_MAX,
 #if (LIBTORRENT_VERSION_NUM >= 10206)
-    UPNP_LEASE_DURATION,
+        UPNP_LEASE_DURATION,
 #endif
-    UTP_MIX_MODE,
-    MULTI_CONNECTIONS_PER_IP,
+        UTP_MIX_MODE,
+        MULTI_CONNECTIONS_PER_IP,
 #ifdef HAS_HTTPS_TRACKER_VALIDATION
-    VALIDATE_HTTPS_TRACKER_CERTIFICATE,
+        VALIDATE_HTTPS_TRACKER_CERTIFICATE,
 #endif
-    // embedded tracker
-    TRACKER_STATUS,
-    TRACKER_PORT,
-    // seeding
-    CHOKING_ALGORITHM,
-    SEED_CHOKING_ALGORITHM,
-    // tracker
-    ANNOUNCE_ALL_TRACKERS,
-    ANNOUNCE_ALL_TIERS,
-    ANNOUNCE_IP,
+        // embedded tracker
+        TRACKER_STATUS,
+        TRACKER_PORT,
+        // seeding
+        CHOKING_ALGORITHM,
+        SEED_CHOKING_ALGORITHM,
+        // tracker
+        ANNOUNCE_ALL_TRACKERS,
+        ANNOUNCE_ALL_TIERS,
+        ANNOUNCE_IP,
 #if (LIBTORRENT_VERSION_NUM >= 10207)
-    MAX_CONCURRENT_HTTP_ANNOUNCES,
+        MAX_CONCURRENT_HTTP_ANNOUNCES,
 #endif
-    STOP_TRACKER_TIMEOUT,
-    PEER_TURNOVER,
-    PEER_TURNOVER_CUTOFF,
-    PEER_TURNOVER_INTERVAL,
+        STOP_TRACKER_TIMEOUT,
+        PEER_TURNOVER,
+        PEER_TURNOVER_CUTOFF,
+        PEER_TURNOVER_INTERVAL,
 
-    ROW_COUNT
-};
+        ROW_COUNT
+    };
+}
 
 AdvancedSettings::AdvancedSettings(QWidget *parent)
     : QTableWidget(parent)

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -29,6 +29,8 @@
 #ifndef ADVANCEDSETTINGS_H
 #define ADVANCEDSETTINGS_H
 
+#include <libtorrent/version.hpp>
+
 #include <QCheckBox>
 #include <QComboBox>
 #include <QLineEdit>
@@ -49,7 +51,9 @@ signals:
     void settingsChanged();
 
 private slots:
+#if (LIBTORRENT_VERSION_NUM < 20000)
     void updateCacheSpinSuffix(int value);
+#endif
     void updateSaveResumeDataIntervalSuffix(int value);
     void updateInterfaceAddressCombo();
 
@@ -57,17 +61,22 @@ private:
     void loadAdvancedSettings();
     template <typename T> void addRow(int row, const QString &text, T *widget);
 
-    QSpinBox m_spinBoxAsyncIOThreads, m_spinBoxFilePoolSize, m_spinBoxCheckingMemUsage, m_spinBoxCache,
+    QSpinBox m_spinBoxAsyncIOThreads, m_spinBoxFilePoolSize, m_spinBoxCheckingMemUsage,
              m_spinBoxSaveResumeDataInterval, m_spinBoxOutgoingPortsMin, m_spinBoxOutgoingPortsMax, m_spinBoxUPnPLeaseDuration,
-             m_spinBoxListRefresh, m_spinBoxTrackerPort, m_spinBoxCacheTTL, m_spinBoxSendBufferWatermark, m_spinBoxSendBufferLowWatermark,
+             m_spinBoxListRefresh, m_spinBoxTrackerPort, m_spinBoxSendBufferWatermark, m_spinBoxSendBufferLowWatermark,
              m_spinBoxSendBufferWatermarkFactor, m_spinBoxSocketBacklogSize, m_spinBoxMaxConcurrentHTTPAnnounces, m_spinBoxStopTrackerTimeout,
              m_spinBoxSavePathHistoryLength, m_spinBoxPeerTurnover, m_spinBoxPeerTurnoverCutoff, m_spinBoxPeerTurnoverInterval;
     QCheckBox m_checkBoxOsCache, m_checkBoxRecheckCompleted, m_checkBoxResolveCountries, m_checkBoxResolveHosts,
               m_checkBoxProgramNotifications, m_checkBoxTorrentAddedNotifications, m_checkBoxTrackerFavicon, m_checkBoxTrackerStatus,
               m_checkBoxConfirmTorrentRecheck, m_checkBoxConfirmRemoveAllTags, m_checkBoxAnnounceAllTrackers, m_checkBoxAnnounceAllTiers,
-              m_checkBoxMultiConnectionsPerIp, m_checkBoxValidateHTTPSTrackerCertificate, m_checkBoxPieceExtentAffinity, m_checkBoxSuggestMode, m_checkBoxCoalesceRW, m_checkBoxSpeedWidgetEnabled;
+              m_checkBoxMultiConnectionsPerIp, m_checkBoxValidateHTTPSTrackerCertificate, m_checkBoxPieceExtentAffinity, m_checkBoxSuggestMode, m_checkBoxSpeedWidgetEnabled;
     QComboBox m_comboBoxInterface, m_comboBoxInterfaceAddress, m_comboBoxUtpMixedMode, m_comboBoxChokingAlgorithm, m_comboBoxSeedChokingAlgorithm;
     QLineEdit m_lineEditAnnounceIP;
+
+#if (LIBTORRENT_VERSION_NUM < 20000)
+    QSpinBox m_spinBoxCache, m_spinBoxCacheTTL;
+    QCheckBox m_checkBoxCoalesceRW;
+#endif
 
     // OS dependent settings
 #if defined(Q_OS_WIN)

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -961,7 +961,7 @@
             </tr>
             <tr>
                 <td>
-                    <label for="diskCache">QBT_TR(Disk cache:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#cache_size" target="_blank">(?)</a></label>
+                    <label for="diskCache">QBT_TR(Disk cache (requires libtorrent < 2.0):)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#cache_size" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="diskCache" style="width: 15em;" />&nbsp;&nbsp;QBT_TR(MiB)QBT_TR[CONTEXT=OptionsDialog]
@@ -969,7 +969,7 @@
             </tr>
             <tr>
                 <td>
-                    <label for="diskCacheExpiryInterval">QBT_TR(Disk cache expiry interval:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#cache_expiry" target="_blank">(?)</a></label>
+                    <label for="diskCacheExpiryInterval">QBT_TR(Disk cache expiry interval (requires libtorrent < 2.0):)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#cache_expiry" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="diskCacheExpiryInterval" style="width: 15em;">&nbsp;&nbsp;QBT_TR(s)QBT_TR[CONTEXT=OptionsDialog]
@@ -985,7 +985,7 @@
             </tr>
             <tr>
                 <td>
-                    <label for="coalesceReadsAndWrites">QBT_TR(Coalesce reads & writes:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#coalesce_reads" target="_blank">(?)</a></label>
+                    <label for="coalesceReadsAndWrites">QBT_TR(Coalesce reads & writes (requires libtorrent < 2.0):)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#coalesce_reads" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="checkbox" id="coalesceReadsAndWrites" />


### PR DESCRIPTION
* Disable deprecated libtorrent settings
* Initialize session with `session_params` class
  The old way of initialization is deprecated in libtorrent 2.0.
* Move enums into anonymous namespace
* Move signal connections to appropriate place 