### PR TITLE
Enable faster disk space allocation by default

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1042,6 +1042,11 @@ void Session::initializeNativeSession()
     pack.set_bool(lt::settings_pack::upnp_ignore_nonrouters, true);
 #endif
 
+#if (LIBTORRENT_VERSION_NUM > 20000)
+    // preserve the same behavior as in earlier libtorrent versions
+    pack.set_bool(lt::settings_pack::enable_set_file_valid_data, true);
+#endif
+
     loadLTSettings(pack);
     m_nativeSession = new lt::session {pack, lt::session_flags_t {0}};
 


### PR DESCRIPTION
In libtorrent > 2.0, the setting is turned off by default, now we just re-enable it to preserve the behavior as in earlier versions.

Upstream PR: https://github.com/arvidn/libtorrent/pull/5129