### PR TITLE
Don't use HTML in Linux tray tooltip

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1540,27 +1540,9 @@ void MainWindow::reloadSessionStats()
     }
 #else
     if (m_systrayIcon) {
-#ifdef Q_OS_UNIX
-        const QString toolTip = QString::fromLatin1(
-                "<div style='background-color: #678db2; color: #fff;height: 18px; font-weight: bold; margin-bottom: 5px;'>"
-                "qBittorrent"
-                "</div>"
-                "<div style='vertical-align: baseline; height: 18px;'>"
-                "<img src='%1' height='14'/>&nbsp;%2"
-                "</div>"
-                "<div style='vertical-align: baseline; height: 18px;'>"
-                "<img src='%3' height='14'/>&nbsp;%4"
-                "</div>")
-            .arg(UIThemeManager::instance()->getIconPath("downloading_small")
-                 , tr("DL speed: %1", "e.g: Download speed: 10 KiB/s").arg(Utils::Misc::friendlyUnit(status.payloadDownloadRate, true))
-                 , UIThemeManager::instance()->getIconPath("seeding")
-                 , tr("UP speed: %1", "e.g: Upload speed: 10 KiB/s").arg(Utils::Misc::friendlyUnit(status.payloadUploadRate, true)));
-#else
-        // OSes such as Windows do not support html here
         const QString toolTip = QString::fromLatin1("%1\n%2").arg(
             tr("DL speed: %1", "e.g: Download speed: 10 KiB/s").arg(Utils::Misc::friendlyUnit(status.payloadDownloadRate, true))
             , tr("UP speed: %1", "e.g: Upload speed: 10 KiB/s").arg(Utils::Misc::friendlyUnit(status.payloadUploadRate, true)));
-#endif // Q_OS_UNIX
         m_systrayIcon->setToolTip(toolTip); // tray icon
     }
 #endif  // Q_OS_MACOS


### PR DESCRIPTION
Someone mentioned it will be possible to set a message in the tooltip's subtext in Qt6 (in which, some basic HTML is allowed (for icons)) but i can't find any info on it, https://doc-snapshots.qt.io/qt6-dev/qsystemtrayicon.html doesn't mention any overload for `QSystemTrayIcon::setToolTip()` unless they meant something else. If someone can verify i'll leave a TODO for Qt6 in the code.

If there is another way to set subtext in tooltip, i don't know it and i won't be looking for it so... merge this before the next release if no one else looks into this issue.