### PR TITLE
Improvements to cmake build system

### DIFF
--- a/cmake/Modules/MacroQbtCommonConfig.cmake
+++ b/cmake/Modules/MacroQbtCommonConfig.cmake
@@ -95,8 +95,4 @@ macro(qbt_common_config)
         set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
     endif()
 
-    if (CMAKE_GENERATOR MATCHES "Visual Studio")
-        target_compile_options(qbt_common_cfg INTERFACE /MP)
-    endif()
-
 endmacro(qbt_common_config)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,7 @@ if (DBUS)
 endif()
 
 # automatically call Qt moc, rcc and uic as needed for all targets by default
+set(CMAKE_AUTORCC_OPTIONS --compress 9 --threshold 5)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,7 +32,7 @@ else()
 endif()
 # force variable type so that it always shows up in ccmake/cmake-gui frontends
 set_property(CACHE LibtorrentRasterbar_DIR PROPERTY TYPE PATH)
-find_package(Boost ${requiredBoostVersion} REQUIRED COMPONENTS system)
+find_package(Boost ${requiredBoostVersion} REQUIRED)
 find_package(OpenSSL ${requiredOpenSSLVersion} REQUIRED)
 find_package(ZLIB ${requiredZlibVersion} REQUIRED)
 find_package(Qt5 ${requiredQtVersion} REQUIRED COMPONENTS Core Network Xml LinguistTools)


### PR DESCRIPTION
* Don't impose unnecessary compile options on users
This is unexpected for users that take single job compilation as the default (which is always the case since forever). Users can change the default if they wish to use multicore for compilation.
* Remove compile requirement for boost::system
  boost::system is not a dependency for our project.
* Set compression rate for rcc targets
This follows our current setting in src.pro.
