### PR TITLE
UI: Display full SSL version for correct LibreSSL version reporting

### DIFF
--- a/src/app/stacktracedialog.cpp
+++ b/src/app/stacktracedialog.cpp
@@ -74,7 +74,7 @@ void StacktraceDialog::setStacktraceString(const QString &sigName, const QString
             .arg(QString::number(QT_POINTER_SIZE * 8)
                  , Utils::Misc::libtorrentVersionString()
                  , Utils::Misc::boostVersionString()
-                 , Utils::Misc::opensslVersionString()
+                 , Utils::Misc::sslVersionString()
                  , Utils::Misc::zlibVersionString()
                  , Utils::Misc::osName()
                  , sigName

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -459,14 +459,14 @@ QString Utils::Misc::libtorrentVersionString()
     return version;
 }
 
-QString Utils::Misc::opensslVersionString()
+QString Utils::Misc::sslVersionString()
 {
 #if (OPENSSL_VERSION_NUMBER >= 0x1010000f)
     static const auto version {QString::fromLatin1(OpenSSL_version(OPENSSL_VERSION))};
 #else
     static const auto version {QString::fromLatin1(SSLeay_version(SSLEAY_VERSION))};
 #endif
-    return version.splitRef(' ', QString::SkipEmptyParts)[1].toString();
+    return version.splitRef(" ")[1].toString() + version.splitRef(" ")[0].toString().prepend(" (").append(")");
 }
 
 QString Utils::Misc::zlibVersionString()

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -69,7 +69,7 @@ namespace Utils
         QString osName();
         QString boostVersionString();
         QString libtorrentVersionString();
-        QString opensslVersionString();
+        QString sslVersionString();
         QString zlibVersionString();
 
         QString unitString(SizeUnit unit, bool isSpeed = false);

--- a/src/gui/aboutdialog.cpp
+++ b/src/gui/aboutdialog.cpp
@@ -93,7 +93,7 @@ AboutDialog::AboutDialog(QWidget *parent)
     m_ui->labelQtVer->setText(QT_VERSION_STR);
     m_ui->labelLibtVer->setText(Utils::Misc::libtorrentVersionString());
     m_ui->labelBoostVer->setText(Utils::Misc::boostVersionString());
-    m_ui->labelOpensslVer->setText(Utils::Misc::opensslVersionString());
+    m_ui->labelSslVer->setText(Utils::Misc::sslVersionString());
     m_ui->labelZlibVer->setText(Utils::Misc::zlibVersionString());
 
     const QString DBIPText = QString(

--- a/src/gui/aboutdialog.ui
+++ b/src/gui/aboutdialog.ui
@@ -424,7 +424,7 @@
          <item row="3" column="1">
           <widget class="QLabel" name="label_11">
            <property name="text">
-            <string notr="true">OpenSSL:</string>
+            <string notr="true">SSL:</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -435,7 +435,7 @@
           </widget>
          </item>
          <item row="3" column="2">
-          <widget class="QLabel" name="labelOpensslVer">
+          <widget class="QLabel" name="labelSslVer">
            <property name="textInteractionFlags">
             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
            </property>

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -74,7 +74,7 @@ void AppController::buildInfoAction()
         {"qt", QT_VERSION_STR},
         {"libtorrent", Utils::Misc::libtorrentVersionString()},
         {"boost", Utils::Misc::boostVersionString()},
-        {"openssl", Utils::Misc::opensslVersionString()},
+        {"ssl", Utils::Misc::sslVersionString()},
         {"zlib", Utils::Misc::zlibVersionString()},
         {"bitness", (QT_POINTER_SIZE * 8)}
     };

--- a/src/webui/www/private/views/about.html
+++ b/src/webui/www/private/views/about.html
@@ -668,8 +668,8 @@
             <td><span id="boostVersion"></span></td>
         </tr>
         <tr>
-            <td>OpenSSL:</td>
-            <td><span id="opensslVersion"></span></td>
+            <td>SSL:</td>
+            <td><span id="sslVersion"></span></td>
         </tr>
         <tr>
             <td>zlib:</td>
@@ -696,7 +696,7 @@
                 $('qtVersion').textContent = info.qt;
                 $('libtorrentVersion').textContent = info.libtorrent;
                 $('boostVersion').textContent = info.boost;
-                $('opensslVersion').textContent = info.openssl;
+                $('sslVersion').textContent = info.ssl;
                 $('zlibVersion').textContent = info.zlib;
                 $('qbittorrentVersion').textContent += " (" + info.bitness + "-bit)";
             }


### PR DESCRIPTION
Currently the UI displays `OpenSSL: 3.2.1`

Updated UI:

![Screenshot from 2020-09-19 00-16-57](https://user-images.githubusercontent.com/45819748/93596954-57ef2d00-fa0e-11ea-919c-0d9fdd73e15c.png)

Cheers