### PR TITLE
CMake: fix linking against OpenSSL

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -159,6 +159,7 @@ add_library(qbt_base STATIC
 
 target_link_libraries(qbt_base
     PRIVATE
+        OpenSSL::Crypto OpenSSL::SSL
         ZLIB::ZLIB
         qbt_version_definitions
     PUBLIC


### PR DESCRIPTION
This should have been there from the start,
but for some reason, the lack of it didn't cause any issued
for many systems.

---

~WIP. For now just want to see the CI result.~ all good