### PR TITLE
Add custom css feature for the WebUi

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -738,6 +738,26 @@ void Preferences::setWebUiRootFolder(const QString &path)
     setValue("Preferences/WebUI/RootFolder", path);
 }
 
+bool Preferences::isWebUICustomCssEnabled() const
+{
+    return value("Preferences/WebUI/CustomCssEnabled", false).toBool();
+}
+
+void Preferences::setWebUICustomCssEnabled(const bool enabled)
+{
+    setValue("Preferences/WebUI/CustomCssEnabled", enabled);
+}
+
+QString Preferences::getWebUICustomCss() const
+{
+    return value("Preferences/WebUI/CustomCss").toString();
+}
+
+void Preferences::setWebUICustomCss(const QString &css)
+{
+    setValue("Preferences/WebUI/CustomCss", css);
+}
+
 bool Preferences::isWebUICustomHTTPHeadersEnabled() const
 {
     return value("Preferences/WebUI/CustomHTTPHeadersEnabled", false).toBool();

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -223,6 +223,12 @@ public:
     QString getWebUiRootFolder() const;
     void setWebUiRootFolder(const QString &path);
 
+    // WebUI custom stylesheet
+    bool isWebUICustomCssEnabled() const;
+    void setWebUICustomCssEnabled(bool enabled);
+    QString getWebUICustomCss() const;
+    void setWebUICustomCss(const QString &css);
+
     // WebUI custom HTTP headers
     bool isWebUICustomHTTPHeadersEnabled() const;
     void setWebUICustomHTTPHeadersEnabled(bool enabled);

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -503,6 +503,8 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     connect(m_ui->DNSPasswordTxt, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->groupAltWebUI, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->textWebUIRootFolder, &FileSystemPathLineEdit::selectedPathChanged, this, &ThisType::enableApplyButton);
+    connect(m_ui->groupWebUIAddCustomCss, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->textWebUICustomCss, &QPlainTextEdit::textChanged, this, &OptionsDialog::enableApplyButton);
     connect(m_ui->groupWebUIAddCustomHTTPHeaders, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->textWebUICustomHTTPHeaders, &QPlainTextEdit::textChanged, this, &OptionsDialog::enableApplyButton);
 #endif // DISABLE_WEBUI
@@ -864,6 +866,9 @@ void OptionsDialog::saveOptions()
         // Alternative UI
         pref->setAltWebUiEnabled(m_ui->groupAltWebUI->isChecked());
         pref->setWebUiRootFolder(m_ui->textWebUIRootFolder->selectedPath());
+        // Custom Css
+        pref->setWebUICustomCssEnabled(m_ui->groupWebUIAddCustomCss->isChecked());
+        pref->setWebUICustomCss(m_ui->textWebUICustomCss->toPlainText());
         // Custom HTTP headers
         pref->setWebUICustomHTTPHeadersEnabled(m_ui->groupWebUIAddCustomHTTPHeaders->isChecked());
         pref->setWebUICustomHTTPHeaders(m_ui->textWebUICustomHTTPHeaders->toPlainText());
@@ -1247,6 +1252,9 @@ void OptionsDialog::loadOptions()
 
     m_ui->groupAltWebUI->setChecked(pref->isAltWebUiEnabled());
     m_ui->textWebUIRootFolder->setSelectedPath(pref->getWebUiRootFolder());
+    // Custom Css
+    m_ui->groupWebUIAddCustomCss->setChecked(pref->isWebUICustomCssEnabled());
+    m_ui->textWebUICustomCss->setPlainText(pref->getWebUICustomCss());
     // Custom HTTP headers
     m_ui->groupWebUIAddCustomHTTPHeaders->setChecked(pref->isWebUICustomHTTPHeadersEnabled());
     m_ui->textWebUICustomHTTPHeaders->setPlainText(pref->getWebUICustomHTTPHeaders());

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -3157,6 +3157,21 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                 </widget>
                </item>
                <item>
+                <widget class="QGroupBox" name="groupWebUIAddCustomCss">
+                 <property name="title">
+                  <string>Add custom css</string>
+                 </property>
+                 <property name="checkable">
+                  <bool>true</bool>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_36">
+                  <item>
+                   <widget class="QPlainTextEdit" name="textWebUICustomCss"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
                 <widget class="QGroupBox" name="groupBox_3">
                  <property name="title">
                   <string>Security</string>

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -238,6 +238,9 @@ void AppController::preferencesAction()
     // Use alternative Web UI
     data["alternative_webui_enabled"] = pref->isAltWebUiEnabled();
     data["alternative_webui_path"] = pref->getWebUiRootFolder();
+    // Custom Css
+    data["web_ui_custom_css_enabled"] = pref->isWebUICustomCssEnabled();
+    data["web_ui_custom_css"] = pref->getWebUICustomCss();
     // Security
     data["web_ui_clickjacking_protection_enabled"] = pref->isWebUiClickjackingProtectionEnabled();
     data["web_ui_csrf_protection_enabled"] = pref->isWebUiCSRFProtectionEnabled();
@@ -625,6 +628,11 @@ void AppController::setPreferencesAction()
         pref->setAltWebUiEnabled(it.value().toBool());
     if (hasKey("alternative_webui_path"))
         pref->setWebUiRootFolder(it.value().toString());
+    // Custom Css
+    if (hasKey("web_ui_custom_css_enabled"))
+        pref->setWebUICustomCssEnabled(it.value().toBool());
+    if (hasKey("web_ui_custom_css"))
+        pref->setWebUICustomCss(it.value().toString());
     // Security
     if (hasKey("web_ui_clickjacking_protection_enabled"))
         pref->setWebUiClickjackingProtectionEnabled(it.value().toBool());

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -225,6 +225,10 @@ void WebApplication::translateDocument(QString &data) const
 
         data.replace(QLatin1String("${LANG}"), m_currentLocale.left(2));
         data.replace(QLatin1String("${CACHEID}"), m_cacheID);
+
+        QString customCss = m_isCustomCssEnabled ? m_customCss : "";
+        customCss.replace('<', "&lt;");
+        data.replace(QLatin1String("${CUSTOMCSS}"), customCss);
     }
 }
 
@@ -327,6 +331,14 @@ void WebApplication::configure()
             LogMsg(tr("Couldn't load Web UI translation for selected locale (%1).").arg(newLocale), Log::WARNING);
         }
     }
+
+    const bool newIsCustomCssEnabled = pref->isWebUICustomCssEnabled();
+    const QString newCustomCss = pref->getWebUICustomCss();
+    if (m_isCustomCssEnabled != newIsCustomCssEnabled || m_customCss != newCustomCss) {
+        m_translatedFiles.clear();
+    }
+    m_isCustomCssEnabled = newIsCustomCssEnabled;
+    m_customCss = newCustomCss;
 
     m_isLocalAuthEnabled = pref->isWebUiLocalAuthEnabled();
     m_isAuthSubnetWhitelistEnabled = pref->isWebUiAuthSubnetWhitelistEnabled();

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -132,6 +132,8 @@ private:
     QSet<QString> m_publicAPIs;
     bool m_isAltUIUsed = false;
     QString m_rootFolder;
+    bool m_isCustomCssEnabled = false;
+    QString m_customCss;
 
     struct TranslatedFile
     {

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -17,6 +17,7 @@
     <noscript>
         <link rel="stylesheet" type="text/css" href="css/noscript.css?v=${CACHEID}" />
     </noscript>
+    <style>${CUSTOMCSS}</style>
     <script src="scripts/lib/mootools-1.2-core-yc.js"></script>
     <script src="scripts/lib/mootools-1.2-more.js"></script>
     <script src="scripts/lib/mocha-0.9.6-yc.js"></script>

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -804,6 +804,14 @@
         </fieldset>
 
         <fieldset class="settings">
+            <legend>
+                <input type="checkbox" id="webUICustomCssCheckbox" onclick="qBittorrent.Preferences.updateWebUICustomCssSettings();" />
+                <label for="webUICustomCssCheckbox">QBT_TR(Add custom css)QBT_TR[CONTEXT=OptionsDialog]</label>
+            </legend>
+            <textarea id="webUICustomCssTextarea" style="width: 90%;"></textarea>
+        </fieldset>
+
+        <fieldset class="settings">
             <legend>QBT_TR(Security)QBT_TR[CONTEXT=OptionsDialog]</legend>
             <div class="formRow">
                 <input type="checkbox" id="clickjacking_protection_checkbox" />
@@ -1234,6 +1242,7 @@
                 updateHttpsSettings: updateHttpsSettings,
                 updateBypasssAuthSettings: updateBypasssAuthSettings,
                 updateAlternativeWebUISettings: updateAlternativeWebUISettings,
+                updateWebUICustomCssSettings: updateWebUICustomCssSettings,
                 updateHostHeaderValidationSettings: updateHostHeaderValidationSettings,
                 updateWebUICustomHTTPHeadersSettings: updateWebUICustomHTTPHeadersSettings,
                 updateDynDnsSettings: updateDynDnsSettings,
@@ -1471,6 +1480,11 @@
         const updateAlternativeWebUISettings = function() {
             const isUseAlternativeWebUIEnabled = $('use_alt_webui_checkbox').getProperty('checked');
             $('webui_files_location_textarea').setProperty('disabled', !isUseAlternativeWebUIEnabled);
+        };
+
+        const updateWebUICustomCssSettings = function() {
+            const isEnabled = $('webUICustomCssCheckbox').getProperty('checked');
+            $('webUICustomCssTextarea').setProperty('disabled', !isEnabled);
         };
 
         const updateHostHeaderValidationSettings = function() {
@@ -1833,6 +1847,11 @@
                         $('use_alt_webui_checkbox').setProperty('checked', pref.alternative_webui_enabled);
                         $('webui_files_location_textarea').setProperty('value', pref.alternative_webui_path);
                         updateAlternativeWebUISettings();
+
+                        // Custom Css
+                        $('webUICustomCssCheckbox').setProperty('checked', pref.web_ui_custom_css_enabled);
+                        $('webUICustomCssTextarea').setProperty('value', pref.web_ui_custom_css);
+                        updateWebUICustomCssSettings();
 
                         // Security
                         $('clickjacking_protection_checkbox').setProperty('checked', pref.web_ui_clickjacking_protection_enabled);
@@ -2220,6 +2239,10 @@
             }
             settings.set('alternative_webui_enabled', alternative_webui_enabled);
             settings.set('alternative_webui_path', webui_files_location_textarea);
+
+            // Custom Css
+            settings.set('web_ui_custom_css_enabled', $('webUICustomCssCheckbox').getProperty('checked'));
+            settings.set('web_ui_custom_css', $('webUICustomCssTextarea').getProperty('value'));
 
             // Security
             settings.set('web_ui_clickjacking_protection_enabled', $('clickjacking_protection_checkbox').getProperty('checked'));

--- a/src/webui/www/public/index.html
+++ b/src/webui/www/public/index.html
@@ -10,6 +10,7 @@
     <noscript>
         <link rel="stylesheet" type="text/css" href="css/noscript.css?v=${CACHEID}" />
     </noscript>
+    <style>${CUSTOMCSS}</style>
     <script src="scripts/login.js?locale=${LANG}&v=${CACHEID}"></script>
 </head>
 


### PR DESCRIPTION
I came across [this qBitTorrent WebUi theme](https://github.com/iFelix18/Dark-qBittorrent-WebUI) but didn't really like the proposed way to install it. So instead I added a "Custom Css" feature for the WebUi.

Custom css can now be added to the WebUi using 2 new options in the preferences.
It is based on the "translation" feature already present in the WebUi. I am not sure if this is the best way to obtain this result but it probably is the easiest.