### PR TITLE
Fix fully-qualified-moc-types clazy warning

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -514,8 +514,8 @@ namespace BitTorrent
         void torrentStorageMoveFailed(BitTorrent::TorrentHandle *const torrent, const QString &targetPath, const QString &error);
         void torrentStorageMoveFinished(BitTorrent::TorrentHandle *const torrent, const QString &newPath);
         void torrentsUpdated(const QVector<BitTorrent::TorrentHandle *> &torrents);
-        void torrentTagAdded(TorrentHandle *const torrent, const QString &tag);
-        void torrentTagRemoved(TorrentHandle *const torrent, const QString &tag);
+        void torrentTagAdded(BitTorrent::TorrentHandle *const torrent, const QString &tag);
+        void torrentTagRemoved(BitTorrent::TorrentHandle *const torrent, const QString &tag);
         void trackerError(BitTorrent::TorrentHandle *const torrent, const QString &tracker);
         void trackerlessStateChanged(BitTorrent::TorrentHandle *const torrent, bool trackerless);
         void trackersAdded(BitTorrent::TorrentHandle *const torrent, const QVector<BitTorrent::TrackerEntry> &trackers);


### PR DESCRIPTION
Link to [fully-qualified-moc-types](https://github.com/KDE/clazy/blob/master/docs/checks/README-fully-qualified-moc-types.md)