### PR TITLE
Clazy fixes

### DIFF
--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -160,7 +160,7 @@ namespace
                 return Utils::String::unquote(parts[1], QLatin1String("'\""));
             throw CommandLineParameterError(QObject::tr("Parameter '%1' must follow syntax '%1=%2'",
                                                         "e.g. Parameter '--webui-port' must follow syntax '--webui-port=value'")
-                                            .arg(fullParameter()).arg(QLatin1String("<value>")));
+                                            .arg(fullParameter(), QLatin1String("<value>")));
         }
 
         QString value(const QProcessEnvironment &env, const QString &defaultValue = {}) const
@@ -206,7 +206,7 @@ namespace
             if (!ok)
                 throw CommandLineParameterError(QObject::tr("Parameter '%1' must follow syntax '%1=%2'",
                                                             "e.g. Parameter '--webui-port' must follow syntax '--webui-port=<value>'")
-                                                .arg(fullParameter()).arg(QLatin1String("<integer value>")));
+                                                .arg(fullParameter(), QLatin1String("<integer value>")));
             return res;
         }
 
@@ -274,8 +274,7 @@ namespace
             throw CommandLineParameterError(QObject::tr("Parameter '%1' must follow syntax '%1=%2'",
                                                         "e.g. Parameter '--add-paused' must follow syntax "
                                                         "'--add-paused=<true|false>'")
-                                            .arg(fullParameter())
-                                            .arg(QLatin1String("<true|false>")));
+                                            .arg(fullParameter(), QLatin1String("<true|false>")));
         }
 
         TriStateBool value(const QProcessEnvironment &env) const

--- a/src/base/bittorrent/tracker.cpp
+++ b/src/base/bittorrent/tracker.cpp
@@ -238,7 +238,7 @@ Http::Response Tracker::processRequest(const Http::Request &request, const Http:
         if (request.method != Http::HEADER_REQUEST_METHOD_GET)
             throw MethodNotAllowedHTTPError();
 
-        if (request.path.toLower().startsWith(ANNOUNCE_REQUEST_PATH))
+        if (request.path.startsWith(ANNOUNCE_REQUEST_PATH, Qt::CaseInsensitive))
             processAnnounceRequest();
         else
             throw NotFoundHTTPError();


### PR DESCRIPTION
https://github.com/qbittorrent/qBittorrent/pull/13431 superseded https://github.com/qbittorrent/qBittorrent/pull/13425, so here are some other fixes - it no longer makes sense to follow Clazy's `fully-qualified-moc-types` recommendation.

https://github.com/KDE/clazy/blob/master/docs/checks/README-qstring-arg.md (carried over from the previous PR)
https://github.com/KDE/clazy/blob/master/docs/checks/README-qstring-insensitive-allocation.md (new)