### PR TITLE
By default use dynamic runtime with MSVC on CMake

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,6 +143,7 @@ jobs:
           -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_DEST_WIN }}\scripts\buildsystems\vcpkg.cmake ^
           -DVCPKG_TARGET_TRIPLET=x64-windows-static-release ^
           -DVERBOSE_CONFIGURE=ON ^
+          -DMSVC_RUNTIME_DYNAMIC=OFF ^
           --graphviz=build\target_graph.dot
         cmake --build build
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
         OFF "NOT GUI" OFF
     )
 elseif (MSVC)
-    feature_option(MSVC_RUNTIME_DYNAMIC "Use MSVC dynamic runtime library (-MD) instead of static (-MT)" OFF)
+    feature_option(MSVC_RUNTIME_DYNAMIC "Use MSVC dynamic runtime library (-MD) instead of static (-MT)" ON)
 endif()
 
 set(QBT_VER_STATUS "alpha1" CACHE STRING "Project status version. Should be empty for release builds.")


### PR DESCRIPTION
This was default before CMake overhaul, and it doesn't
make sense to use static builds with daily developement.
Also static Qt builds are not readily available on Windows.