### PR TITLE
Remove usage of qt5_import_plugins from CMake script

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -159,15 +159,6 @@ if (WEBUI)
     target_link_libraries(qbt_app PRIVATE qbt_webui)
 endif()
 
-if (GUI)
-    if ((CMAKE_SYSTEM_NAME STREQUAL "Windows") OR (CMAKE_SYSTEM_NAME STREQUAL "Darwin"))
-        qt5_import_plugins(qbt_app
-            INCLUDE Qt5::QSvgIconPlugin
-            INCLUDE Qt5::QSvgPlugin
-        )
-    endif()
-endif()
-
 # Installation
 # -----------------------------------------------------------------------------
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
qt5_import_plugins is not necessary and QT automatically
links to our desired libraries anyway.
This fixes CMake builds with older Qt < 5.14 #13430