### PR TITLE
Add support for creating v2 torrents

### DIFF
--- a/src/base/bittorrent/torrentcreatorthread.h
+++ b/src/base/bittorrent/torrentcreatorthread.h
@@ -29,17 +29,32 @@
 #ifndef BITTORRENT_TORRENTCREATORTHREAD_H
 #define BITTORRENT_TORRENTCREATORTHREAD_H
 
+#include <libtorrent/version.hpp>
+
 #include <QStringList>
 #include <QThread>
 
 namespace BitTorrent
 {
+#if (LIBTORRENT_VERSION_NUM >= 20000)
+    enum class TorrentFormat
+    {
+        V1,
+        V2,
+        Hybrid
+    };
+#endif
+
     struct TorrentCreatorParams
     {
         bool isPrivate;
+#if (LIBTORRENT_VERSION_NUM >= 20000)
+        TorrentFormat torrentFormat;
+#else
         bool isAlignmentOptimized;
-        int pieceSize;
         int paddedFileSizeLimit;
+#endif
+        int pieceSize;
         QString inputPath;
         QString savePath;
         QString comment;
@@ -58,8 +73,12 @@ namespace BitTorrent
 
         void create(const TorrentCreatorParams &params);
 
+#if (LIBTORRENT_VERSION_NUM >= 20000)
+        static int calculateTotalPieces(const QString &inputPath, const int pieceSize, const TorrentFormat torrentFormat);
+#else
         static int calculateTotalPieces(const QString &inputPath
             , const int pieceSize, const bool isAlignmentOptimized, int paddedFileSizeLimit);
+#endif
 
     protected:
         void run() override;

--- a/src/gui/torrentcreatordialog.h
+++ b/src/gui/torrentcreatordialog.h
@@ -30,14 +30,12 @@
 #ifndef TORRENTCREATORDIALOG_H
 #define TORRENTCREATORDIALOG_H
 
+#include <libtorrent/version.hpp>
+
 #include <QDialog>
 
+#include "base/bittorrent/torrentcreatorthread.h"
 #include "base/settingvalue.h"
-
-namespace BitTorrent
-{
-    class TorrentCreatorThread;
-}
 
 namespace Ui
 {
@@ -71,7 +69,11 @@ private:
     void setInteractionEnabled(bool enabled) const;
 
     int getPieceSize() const;
+#if (LIBTORRENT_VERSION_NUM >= 20000)
+    BitTorrent::TorrentFormat getTorrentFormat() const;
+#else
     int getPaddedFileSizeLimit() const;
+#endif
 
     Ui::TorrentCreatorDialog *m_ui;
     BitTorrent::TorrentCreatorThread *m_creatorThread;
@@ -82,8 +84,12 @@ private:
     CachedSettingValue<bool> m_storePrivateTorrent;
     CachedSettingValue<bool> m_storeStartSeeding;
     CachedSettingValue<bool> m_storeIgnoreRatio;
+#if (LIBTORRENT_VERSION_NUM >= 20000)
+    CachedSettingValue<int> m_storeTorrentFormat;
+#else
     CachedSettingValue<bool> m_storeOptimizeAlignment;
     CachedSettingValue<int> m_paddedFileSizeLimit;
+#endif
     CachedSettingValue<QString> m_storeLastAddPath;
     CachedSettingValue<QString> m_storeTrackerList;
     CachedSettingValue<QString> m_storeWebSeedList;

--- a/src/gui/torrentcreatordialog.ui
+++ b/src/gui/torrentcreatordialog.ui
@@ -30,8 +30,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>574</width>
-        <height>649</height>
+        <width>560</width>
+        <height>668</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -120,6 +120,63 @@
           <string>Settings</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QWidget" name="widgetTorrentFormat" native="true">
+            <layout class="QHBoxLayout" name="layoutTorrentFormat">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="labelTorrentFormat">
+               <property name="text">
+                <string>Torrent format:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QComboBox" name="comboTorrentFormat">
+               <item>
+                <property name="text">
+                 <string notr="true">V2</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Hybrid</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string notr="true">V1</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_2">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </widget>
+          </item>
           <item>
            <layout class="QHBoxLayout" name="pieceSizeLayout">
             <item>


### PR DESCRIPTION
This option is only available when qbt is built with libtorrent >= 2.0.
Some options are removed since libtorrent 2.0 deprecated them.
[Screenshot](https://user-images.githubusercontent.com/9395168/95658758-5b7a5d80-0b4f-11eb-858d-d0a57d05e584.png)

