### PR TITLE
Add option for hashing_threads setting 

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -342,6 +342,8 @@ namespace BitTorrent
         void setPeerTurnoverInterval(int num);
         int asyncIOThreads() const;
         void setAsyncIOThreads(int num);
+        int hashingThreads() const;
+        void setHashingThreads(int num);
         int filePoolSize() const;
         void setFilePoolSize(int size);
         int checkingMemUsage() const;
@@ -651,6 +653,7 @@ namespace BitTorrent
         CachedSettingValue<bool> m_announceToAllTrackers;
         CachedSettingValue<bool> m_announceToAllTiers;
         CachedSettingValue<int> m_asyncIOThreads;
+        CachedSettingValue<int> m_hashingThreads;
         CachedSettingValue<int> m_filePoolSize;
         CachedSettingValue<int> m_checkingMemUsage;
         CachedSettingValue<int> m_diskCacheSize;

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -85,6 +85,9 @@ namespace
         // libtorrent section
         LIBTORRENT_HEADER,
         ASYNC_IO_THREADS,
+#if (LIBTORRENT_VERSION_NUM >= 20000)
+        HASHING_THREADS,
+#endif
         FILE_POOL_SIZE,
         CHECKING_MEM_USAGE,
 #if (LIBTORRENT_VERSION_NUM < 20000)
@@ -187,6 +190,10 @@ void AdvancedSettings::saveAdvancedSettings()
 #endif
     // Async IO threads
     session->setAsyncIOThreads(m_spinBoxAsyncIOThreads.value());
+#if (LIBTORRENT_VERSION_NUM >= 20000)
+    // Hashing threads
+    session->setHashingThreads(m_spinBoxHashingThreads.value());
+#endif
     // File pool size
     session->setFilePoolSize(m_spinBoxFilePoolSize.value());
     // Checking Memory Usage
@@ -409,6 +416,16 @@ void AdvancedSettings::loadAdvancedSettings()
     m_spinBoxAsyncIOThreads.setValue(session->asyncIOThreads());
     addRow(ASYNC_IO_THREADS, (tr("Asynchronous I/O threads") + ' ' + makeLink("https://www.libtorrent.org/reference-Settings.html#aio_threads", "(?)"))
             , &m_spinBoxAsyncIOThreads);
+
+#if (LIBTORRENT_VERSION_NUM >= 20000)
+    // Hashing threads
+    m_spinBoxHashingThreads.setMinimum(1);
+    m_spinBoxHashingThreads.setMaximum(1024);
+    m_spinBoxHashingThreads.setValue(session->hashingThreads());
+    addRow(HASHING_THREADS, (tr("Hashing threads") + ' ' + makeLink("https://www.libtorrent.org/reference-Settings.html#hashing_threads", "(?)"))
+            , &m_spinBoxHashingThreads);
+#endif
+
     // File pool size
     m_spinBoxFilePoolSize.setMinimum(1);
     m_spinBoxFilePoolSize.setMaximum(std::numeric_limits<int>::max());

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -77,6 +77,8 @@ private:
 #if (LIBTORRENT_VERSION_NUM < 20000)
     QSpinBox m_spinBoxCache, m_spinBoxCacheTTL;
     QCheckBox m_checkBoxCoalesceRW;
+#else
+    QSpinBox m_spinBoxHashingThreads;
 #endif
 
     // OS dependent settings

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -277,6 +277,8 @@ void AppController::preferencesAction()
     // libtorrent preferences
     // Async IO threads
     data["async_io_threads"] = session->asyncIOThreads();
+    // Hashing threads
+    data["hashing_threads"] = session->hashingThreads();
     // File pool size
     data["file_pool_size"] = session->filePoolSize();
     // Checking memory usage
@@ -701,6 +703,9 @@ void AppController::setPreferencesAction()
     // Async IO threads
     if (hasKey("async_io_threads"))
         session->setAsyncIOThreads(it.value().toInt());
+    // Hashing threads
+    if (hasKey("hashing_threads"))
+        session->setHashingThreads(it.value().toInt());
     // File pool size
     if (hasKey("file_pool_size"))
         session->setFilePoolSize(it.value().toInt());

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -945,6 +945,14 @@
             </tr>
             <tr>
                 <td>
+                    <label for="hashingThreads">QBT_TR(Hashing threads (requires libtorrent >= 2.0):)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#hashing_threads" target="_blank">(?)</a></label>
+                </td>
+                <td>
+                    <input type="text" id="hashingThreads" style="width: 15em;" />
+                </td>
+            </tr>
+            <tr>
+                <td>
                     <label for="filePoolSize">QBT_TR(File pool size:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#file_pool_size" target="_blank">(?)</a></label>
                 </td>
                 <td>
@@ -1871,6 +1879,7 @@
                         $('resolvePeerCountries').setProperty('checked', pref.resolve_peer_countries);
                         // libtorrent section
                         $('asyncIOThreads').setProperty('value', pref.async_io_threads);
+                        $('hashingThreads').setProperty('value', pref.hashing_threads);
                         $('filePoolSize').setProperty('value', pref.file_pool_size);
                         $('outstandMemoryWhenCheckingTorrents').setProperty('value', pref.checking_memory_use);
                         $('diskCache').setProperty('value', pref.disk_cache);
@@ -2257,6 +2266,7 @@
 
             // libtorrent section
             settings.set('async_io_threads', $('asyncIOThreads').getProperty('value'));
+            settings.set('hashing_threads', $('hashingThreads').getProperty('value'));
             settings.set('file_pool_size', $('filePoolSize').getProperty('value'));
             settings.set('checking_memory_use', $('outstandMemoryWhenCheckingTorrents').getProperty('value'));
             settings.set('disk_cache', $('diskCache').getProperty('value'));


### PR DESCRIPTION
This PR exposes libtorrent 2.0 configuration option `lt::settings_pack::hashing_threads` to a UI so that user can configure the number of hashing threads. This parameter is ignored by libtorrent prior to v2.

Here is the relevant part from [the official migration guide](https://www.libtorrent.org/upgrade_to_2.0-ref.html):
> aio_threads and hashing_threads
>
> In previous versions of libtorrent, the number of disk threads to use were configured by `settings_pack::aio_threads`. Every fourth thread was dedicated to run hash jobs, i.e. computing SHA-1 piece hashes to compare them against the expected hash.
>
> This setting has now been split up to allow controlling the number of dedicated hash threads independently from the number of generic disk I/O threads. `settings_pack::hashing_threads` is now used to control the number of threads dedicated to computing hashes.