### PR TITLE
Support building with libtorrent 2.0

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(qbt_base STATIC
     bittorrent/bandwidthscheduler.h
     bittorrent/cachestatus.h
     bittorrent/common.h
-    bittorrent/customstorage.h
+    bittorrent/customstorageordisk.h
     bittorrent/downloadpriority.h
     bittorrent/filterparserthread.h
     bittorrent/infohash.h
@@ -87,7 +87,7 @@ add_library(qbt_base STATIC
     # sources
     asyncfilestorage.cpp
     bittorrent/bandwidthscheduler.cpp
-    bittorrent/customstorage.cpp
+    bittorrent/customstorageordisk.cpp
     bittorrent/downloadpriority.cpp
     bittorrent/filterparserthread.cpp
     bittorrent/infohash.cpp

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -5,7 +5,7 @@ HEADERS += \
     $$PWD/bittorrent/bandwidthscheduler.h \
     $$PWD/bittorrent/cachestatus.h \
     $$PWD/bittorrent/common.h \
-    $$PWD/bittorrent/customstorage.h \
+    $$PWD/bittorrent/customstorageordisk.h \
     $$PWD/bittorrent/downloadpriority.h \
     $$PWD/bittorrent/filterparserthread.h \
     $$PWD/bittorrent/infohash.h \
@@ -87,7 +87,7 @@ HEADERS += \
 SOURCES += \
     $$PWD/asyncfilestorage.cpp \
     $$PWD/bittorrent/bandwidthscheduler.cpp \
-    $$PWD/bittorrent/customstorage.cpp \
+    $$PWD/bittorrent/customstorageordisk.cpp \
     $$PWD/bittorrent/downloadpriority.cpp \
     $$PWD/bittorrent/filterparserthread.cpp \
     $$PWD/bittorrent/infohash.cpp \

--- a/src/base/bittorrent/customdisk.cpp
+++ b/src/base/bittorrent/customdisk.cpp
@@ -1,0 +1,29 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2020  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+// New code goes here.

--- a/src/base/bittorrent/customdisk.h
+++ b/src/base/bittorrent/customdisk.h
@@ -1,0 +1,29 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2020  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+// New code goes here.

--- a/src/base/bittorrent/customstorageordisk.cpp
+++ b/src/base/bittorrent/customstorageordisk.cpp
@@ -1,0 +1,35 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2020  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include <libtorrent/version.hpp>
+
+#if (LIBTORRENT_VERSION_NUM < 20000)
+#include "customstorage.cpp"
+#else
+#include "customdisk.cpp"
+#endif

--- a/src/base/bittorrent/customstorageordisk.h
+++ b/src/base/bittorrent/customstorageordisk.h
@@ -1,0 +1,35 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2020  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include <libtorrent/version.hpp>
+
+#if (LIBTORRENT_VERSION_NUM < 20000)
+#include "customstorage.h"
+#else
+#include "customdisk.h"
+#endif

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -55,6 +55,7 @@
 #include <libtorrent/session_stats.hpp>
 #include <libtorrent/session_status.hpp>
 #include <libtorrent/torrent_info.hpp>
+#include <libtorrent/version.hpp>
 
 #include <QDebug>
 #include <QDir>
@@ -87,7 +88,7 @@
 #include "base/utils/random.h"
 #include "bandwidthscheduler.h"
 #include "common.h"
-#include "customstorage.h"
+#include "customstorageordisk.h"
 #include "filterparserthread.h"
 #include "ltunderlyingtype.h"
 #include "magneturi.h"
@@ -2110,7 +2111,9 @@ bool Session::loadTorrent(LoadTorrentParams params)
 {
     lt::add_torrent_params &p = params.ltAddTorrentParams;
 
+    #if LIBTORRENT_VERSION_NUM < 20000
     p.storage = customStorageConstructor;
+    #endif
     // Limits
     p.max_connections = maxConnectionsPerTorrent();
     p.max_uploads = maxUploadsPerTorrent();
@@ -2196,7 +2199,9 @@ bool Session::loadMetadata(const MagnetUri &magnetUri)
     // Solution to avoid accidental file writes
     p.flags |= lt::torrent_flags::upload_mode;
 
+    #if LIBTORRENT_VERSION_NUM < 20000
     p.storage = customStorageConstructor;
+    #endif
 
     // Adding torrent to BitTorrent session
     lt::error_code ec;


### PR DESCRIPTION
Add support for linking with libtorrent 2.0. Please note that after this patch qBittorrent built with libtorrent 2.0 is not feature complete (yet).
This commit adds customstorageordisk which is really just customstorage for libtorrent < 2.0 and customdisk for libtorrent >= 2.0.

This commit does NOT:
 - implement `disk_interface` that replaces `storage_interface`
   (Which means there is no disk I/O customization for builds with libtorrent 2.0.)
 - migrate to V2 hashes
   (So everywhere code uses the V1 hashes, even if hybrid torrent was added. V2 hashes are basically ignored. This produces deprecation warnings, since V1 hashes handle is deprecated.)
 - make sure V2 and hybrid URLs are supported

I'll prepare follow-up patches that actually take advantage of libtorrent 2.0 support for V2 during the weekend. Should I pile them on in this PR or create new PRs?