### PR TITLE
Fix the issue that IPv6 address can't be banned

### DIFF
--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -550,7 +550,7 @@ void SyncController::torrentPeersAction()
             peer[KEY_PEER_COUNTRY] = Net::GeoIPManager::CountryName(pi.country());
         }
 
-        peers[pi.address().ip.toString() + ':' + QString::number(pi.address().port)] = peer;
+        peers[pi.address().toString()] = peer;
     }
     data["peers"] = peers;
 

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -356,11 +356,11 @@
 
     <fieldset class="settings">
         <legend>
-            <input type="checkbox" id="ipfilter_enabled_checkbox" onclick="qBittorrent.Preferences.updateFilterSettings();" />
-            <label for="ipfilter_enabled_checkbox">QBT_TR(IP Filtering)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label>QBT_TR(IP Filtering)QBT_TR[CONTEXT=OptionsDialog]</label>
         </legend>
         <div class="formRow">
-            <label for="ipfilter_text">QBT_TR(Filter path (.dat, .p2p, .p2b):)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <input type="checkbox" id="ipfilter_text_checkbox" onclick="qBittorrent.Preferences.updateFilterSettings();" />
+            <label for="ipfilter_text_checkbox">QBT_TR(Filter path (.dat, .p2p, .p2b):)QBT_TR[CONTEXT=OptionsDialog]</label>
             <input type="text" id="ipfilter_text" />
         </div>
         <div class="formRow">
@@ -1423,10 +1423,8 @@
         };
 
         const updateFilterSettings = function() {
-            const isIPFilterEnabled = $('ipfilter_enabled_checkbox').getProperty('checked');
+            const isIPFilterEnabled = $('ipfilter_text_checkbox').getProperty('checked');
             $('ipfilter_text').setProperty('disabled', !isIPFilterEnabled);
-            $('ipfilter_trackers_checkbox').setProperty('disabled', !isIPFilterEnabled);
-            $('banned_IPs_textarea').setProperty('disabled', !isIPFilterEnabled);
         };
 
         // Speed tab
@@ -1736,7 +1734,7 @@
                         $('peer_proxy_password_text').setProperty('value', pref.proxy_password);
 
                         // IP Filtering
-                        $('ipfilter_enabled_checkbox').setProperty('checked', pref.ip_filter_enabled);
+                        $('ipfilter_text_checkbox').setProperty('checked', pref.ip_filter_enabled);
                         $('ipfilter_text').setProperty('value', pref.ip_filter_path);
                         $('ipfilter_trackers_checkbox').setProperty('checked', pref.ip_filter_trackers);
                         $('banned_IPs_textarea').setProperty('value', pref.banned_IPs);
@@ -2050,7 +2048,7 @@
             settings.set('proxy_password', $('peer_proxy_password_text').getProperty('value'));
 
             // IP Filtering
-            settings.set('ip_filter_enabled', $('ipfilter_enabled_checkbox').getProperty('checked'));
+            settings.set('ip_filter_enabled', $('ipfilter_text_checkbox').getProperty('checked'));
             settings.set('ip_filter_path', $('ipfilter_text').getProperty('value'));
             settings.set('ip_filter_trackers', $('ipfilter_trackers_checkbox').getProperty('checked'));
             settings.set('banned_IPs', $('banned_IPs_textarea').getProperty('value'));


### PR DESCRIPTION
The IPv6 addresses transfered to WebUI are not using the format `[ip]:port` and can't be parsed correctly, so that the IPv6 address can't be banned.

https://github.com/qbittorrent/qBittorrent/blob/66f0e6a8f27ca320cbb0febe88589548c04c40b8/src/webui/api/synccontroller.cpp#L553

The ban action doesn't depend on the ipfilter, and should not be disabled when ipfilter is not enabled.

Edit:
Add the screenshots of changes for WebUI 

Before:
![before](https://user-images.githubusercontent.com/30111323/96659484-a1b69480-1379-11eb-94bc-c57613141d75.PNG)

After:
![after](https://user-images.githubusercontent.com/30111323/96659494-a5e2b200-1379-11eb-898a-ec2dac93a6a8.PNG)
