### PR TITLE
Fix bug in seeding time limit for partial torrents

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1652,7 +1652,7 @@ void Session::processShareLimits()
 
             if (torrent->seedingTimeLimit() != Torrent::NO_SEEDING_TIME_LIMIT)
             {
-                const qlonglong seedingTimeInMinutes = torrent->seedingTime() / 60;
+                const qlonglong seedingTimeInMinutes = torrent->finishedTime() / 60;
                 int seedingTimeLimit = torrent->seedingTimeLimit();
                 if (seedingTimeLimit == Torrent::USE_GLOBAL_SEEDING_TIME)
                 {

--- a/src/base/bittorrent/torrent.h
+++ b/src/base/bittorrent/torrent.h
@@ -223,7 +223,6 @@ namespace BitTorrent
         virtual qlonglong totalUpload() const = 0;
         virtual qlonglong activeTime() const = 0;
         virtual qlonglong finishedTime() const = 0;
-        virtual qlonglong seedingTime() const = 0;
         virtual qlonglong eta() const = 0;
         virtual QVector<qreal> filesProgress() const = 0;
         virtual int seedsCount() const = 0;

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -225,7 +225,6 @@ namespace
         status.flags = params.flags;
         status.active_duration = lt::seconds {params.active_time};
         status.finished_duration = lt::seconds {params.finished_time};
-        status.seeding_duration = lt::seconds {params.seeding_time};
         status.num_complete = params.num_complete;
         status.num_incomplete = params.num_incomplete;
         status.all_time_download = params.total_downloaded;
@@ -1020,11 +1019,6 @@ qlonglong TorrentImpl::finishedTime() const
     return lt::total_seconds(m_nativeStatus.finished_duration);
 }
 
-qlonglong TorrentImpl::seedingTime() const
-{
-    return lt::total_seconds(m_nativeStatus.seeding_duration);
-}
-
 qlonglong TorrentImpl::eta() const
 {
     if (isPaused()) return MAX_ETA;
@@ -1053,7 +1047,7 @@ qlonglong TorrentImpl::eta() const
 
         if (maxSeedingTimeValue >= 0)
         {
-            seedingTimeEta = (maxSeedingTimeValue * 60) - seedingTime();
+            seedingTimeEta = (maxSeedingTimeValue * 60) - finishedTime();
             if (seedingTimeEta < 0)
                 seedingTimeEta = 0;
         }

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -157,7 +157,6 @@ namespace BitTorrent
         qlonglong totalUpload() const override;
         qlonglong activeTime() const override;
         qlonglong finishedTime() const override;
-        qlonglong seedingTime() const override;
         qlonglong eta() const override;
         QVector<qreal> filesProgress() const override;
         int seedsCount() const override;

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -453,7 +453,7 @@ void PropertiesWidget::loadDynamicData()
             if (m_torrent->isSeed())
                 elapsedString = tr("%1 (seeded for %2)", "e.g. 4m39s (seeded for 3m10s)")
                     .arg(Utils::Misc::userFriendlyDuration(m_torrent->activeTime())
-                        , Utils::Misc::userFriendlyDuration(m_torrent->seedingTime()));
+                        , Utils::Misc::userFriendlyDuration(m_torrent->finishedTime()));
             else
                 elapsedString = Utils::Misc::userFriendlyDuration(m_torrent->activeTime());
             m_ui->labelElapsedVal->setText(elapsedString);

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -390,7 +390,7 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
     case TR_AMOUNT_LEFT:
         return unitString(torrent->remainingSize());
     case TR_TIME_ELAPSED:
-        return timeElapsedString(torrent->activeTime(), torrent->seedingTime());
+        return timeElapsedString(torrent->activeTime(), torrent->finishedTime());
     case TR_SAVE_PATH:
         return Utils::Fs::toNativePath(torrent->savePath());
     case TR_COMPLETED:
@@ -459,7 +459,7 @@ QVariant TransferListModel::internalValue(const BitTorrent::Torrent *torrent, co
     case TR_AMOUNT_LEFT:
         return torrent->remainingSize();
     case TR_TIME_ELAPSED:
-        return !alt ? torrent->activeTime() : torrent->seedingTime();
+        return !alt ? torrent->activeTime() : torrent->finishedTime();
     case TR_SAVE_PATH:
         return Utils::Fs::toNativePath(torrent->savePath());
     case TR_COMPLETED:

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -152,7 +152,7 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         {KEY_TORRENT_LAST_SEEN_COMPLETE_TIME, torrent.lastSeenComplete().toSecsSinceEpoch()},
         {KEY_TORRENT_AUTO_TORRENT_MANAGEMENT, torrent.isAutoTMMEnabled()},
         {KEY_TORRENT_TIME_ACTIVE, torrent.activeTime()},
-        {KEY_TORRENT_SEEDING_TIME, torrent.seedingTime()},
+        {KEY_TORRENT_SEEDING_TIME, torrent.finishedTime()},
         {KEY_TORRENT_LAST_ACTIVITY_TIME, getLastActivityTime()},
         {KEY_TORRENT_AVAILABILITY, torrent.distributedCopies()},
 

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -387,7 +387,7 @@ void TorrentsController::propertiesAction()
     dataDict[KEY_TORRENT_INFOHASHV1] = torrent->infoHash().v1().toString();
     dataDict[KEY_TORRENT_INFOHASHV2] = torrent->infoHash().v2().toString();
     dataDict[KEY_PROP_TIME_ELAPSED] = torrent->activeTime();
-    dataDict[KEY_PROP_SEEDING_TIME] = torrent->seedingTime();
+    dataDict[KEY_PROP_SEEDING_TIME] = torrent->finishedTime();
     dataDict[KEY_PROP_ETA] = static_cast<double>(torrent->eta());
     dataDict[KEY_PROP_CONNECT_COUNT] = torrent->connectionsCount();
     dataDict[KEY_PROP_CONNECT_COUNT_LIMIT] = torrent->connectionsLimit();


### PR DESCRIPTION
Apply seeding time limit's action to finished (fully downloaded with excluded content)
instead of seeding torrents.

For your convenience:
```
// finished means all selected files/pieces were downloaded and available
// to other peers (this is always a subset of active time).
// seeding means all files/pieces were downloaded and available to
// peers
```

I wonder if any people consider this bug (IMO) as a feature.