### PR TITLE
WebAPI: Add torrent content_path to info endpoint

### DIFF
--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -108,6 +108,7 @@ QVariantMap serialize(const BitTorrent::TorrentHandle &torrent)
         {KEY_TORRENT_SUPER_SEEDING, torrent.superSeeding()},
         {KEY_TORRENT_FORCE_START, torrent.isForced()},
         {KEY_TORRENT_SAVE_PATH, Utils::Fs::toNativePath(torrent.savePath())},
+        {KEY_TORRENT_CONTENT_PATH, Utils::Fs::toNativePath(torrent.contentPath())},
         {KEY_TORRENT_ADDED_ON, torrent.addedTime().toSecsSinceEpoch()},
         {KEY_TORRENT_COMPLETION_ON, torrent.completedTime().toSecsSinceEpoch()},
         {KEY_TORRENT_TRACKER, torrent.currentTracker()},

--- a/src/webui/api/serialize/serialize_torrent.h
+++ b/src/webui/api/serialize/serialize_torrent.h
@@ -58,6 +58,7 @@ const char KEY_TORRENT_TAGS[] = "tags";
 const char KEY_TORRENT_SUPER_SEEDING[] = "super_seeding";
 const char KEY_TORRENT_FORCE_START[] = "force_start";
 const char KEY_TORRENT_SAVE_PATH[] = "save_path";
+const char KEY_TORRENT_CONTENT_PATH[] = "content_path";
 const char KEY_TORRENT_ADDED_ON[] = "added_on";
 const char KEY_TORRENT_COMPLETION_ON[] = "completion_on";
 const char KEY_TORRENT_TRACKER[] = "tracker";


### PR DESCRIPTION
I'm not familiar with the API jargon so let me know if i said something wrong in the commit.