### PR TITLE
Add support for lt::info_hash_t

### DIFF
--- a/src/base/bittorrent/infohash.cpp
+++ b/src/base/bittorrent/infohash.cpp
@@ -47,7 +47,7 @@ InfoHash::InfoHash(const NativeHash &nativeHash)
 #if LIBTORRENT_VERSION_NUM < 20000
     const auto data = nativeHash.data();
 #else
-    const auto data = nativeHash.v1.data();
+    const auto data = nativeHash.get_best().data();
 #endif
     const QByteArray raw = QByteArray::fromRawData(data, length());
     m_hashString = QString::fromLatin1(raw.toHex());

--- a/src/base/bittorrent/infohash.h
+++ b/src/base/bittorrent/infohash.h
@@ -39,17 +39,19 @@
 
 #include <QString>
 
+#if LIBTORRENT_VERSION_NUM < 20000
+using NativeHash = lt::sha1_hash;
+#else
+using NativeHash = lt::info_hash_t;
+#endif
+
 namespace BitTorrent
 {
     class InfoHash
     {
     public:
         InfoHash();
-#if LIBTORRENT_VERSION_NUM < 20000
-        InfoHash(const lt::sha1_hash &nativeHash);
-#else
-        InfoHash(const lt::info_hash_t &nativeHash);
-#endif
+        InfoHash(const NativeHash &nativeHash);
         InfoHash(const QString &hashString);
         InfoHash(const InfoHash &other) = default;
 
@@ -60,20 +62,12 @@ namespace BitTorrent
 
         bool isValid() const;
 
-#if LIBTORRENT_VERSION_NUM < 20000
-        operator lt::sha1_hash() const;
-#else
-        operator lt::info_hash_t() const;
-#endif
+        operator NativeHash() const;
         operator QString() const;
 
     private:
         bool m_valid;
-#if LIBTORRENT_VERSION_NUM < 20000
-        lt::sha1_hash m_nativeHash;
-#else
-        lt::info_hash_t m_nativeHash;
-#endif
+        NativeHash m_nativeHash;
         QString m_hashString;
     };
 

--- a/src/base/bittorrent/infohash.h
+++ b/src/base/bittorrent/infohash.h
@@ -29,7 +29,13 @@
 #ifndef BITTORRENT_INFOHASH_H
 #define BITTORRENT_INFOHASH_H
 
+#include <libtorrent/version.hpp>
+
+#if LIBTORRENT_VERSION_NUM < 20000
 #include <libtorrent/sha1_hash.hpp>
+#else
+#include <libtorrent/info_hash.hpp>
+#endif
 
 #include <QString>
 
@@ -39,7 +45,11 @@ namespace BitTorrent
     {
     public:
         InfoHash();
+#if LIBTORRENT_VERSION_NUM < 20000
         InfoHash(const lt::sha1_hash &nativeHash);
+#else
+        InfoHash(const lt::info_hash_t &nativeHash);
+#endif
         InfoHash(const QString &hashString);
         InfoHash(const InfoHash &other) = default;
 
@@ -50,12 +60,20 @@ namespace BitTorrent
 
         bool isValid() const;
 
+#if LIBTORRENT_VERSION_NUM < 20000
         operator lt::sha1_hash() const;
+#else
+        operator lt::info_hash_t() const;
+#endif
         operator QString() const;
 
     private:
         bool m_valid;
+#if LIBTORRENT_VERSION_NUM < 20000
         lt::sha1_hash m_nativeHash;
+#else
+        lt::info_hash_t m_nativeHash;
+#endif
         QString m_hashString;
     };
 

--- a/src/base/bittorrent/magneturi.cpp
+++ b/src/base/bittorrent/magneturi.cpp
@@ -31,7 +31,12 @@
 #include <libtorrent/bencode.hpp>
 #include <libtorrent/error_code.hpp>
 #include <libtorrent/magnet_uri.hpp>
+#include <libtorrent/version.hpp>
+#if LIBTORRENT_VERSION_NUM < 20000
 #include <libtorrent/sha1_hash.hpp>
+#else
+#include <libtorrent/info_hash.hpp>
+#endif
 
 #include <QRegularExpression>
 #include <QUrl>
@@ -42,11 +47,12 @@ namespace
 {
     bool isBitTorrentInfoHash(const QString &string)
     {
-        // There are 2 representations for BitTorrent info hash:
+        // There are 2 representations for BitTorrent V1 info hash:
         // 1. 40 chars hex-encoded string
         //      == 20 (SHA-1 length in bytes) * 2 (each byte maps to 2 hex characters)
         // 2. 32 chars Base32 encoded string
         //      == 20 (SHA-1 length in bytes) * 1.6 (the efficiency of Base32 encoding)
+        // TODO: Add support for BitTorrent V2 info hashes
         const int SHA1_HEX_SIZE = BitTorrent::InfoHash::length() * 2;
         const int SHA1_BASE32_SIZE = BitTorrent::InfoHash::length() * 1.6;
 
@@ -73,7 +79,11 @@ MagnetUri::MagnetUri(const QString &source)
     if (ec) return;
 
     m_valid = true;
+#if LIBTORRENT_VERSION_NUM < 20000
     m_hash = m_addTorrentParams.info_hash;
+#else
+    m_hash = m_addTorrentParams.info_hashes;
+#endif
     m_name = QString::fromStdString(m_addTorrentParams.name);
 
     m_trackers.reserve(m_addTorrentParams.trackers.size());

--- a/src/base/bittorrent/torrenthandleimpl.cpp
+++ b/src/base/bittorrent/torrenthandleimpl.cpp
@@ -122,7 +122,11 @@ TorrentHandleImpl::TorrentHandleImpl(Session *session, const lt::torrent_handle 
         m_savePath = Utils::Fs::toNativePath(m_session->categorySavePath(m_category));
 
     updateStatus();
+#if LIBTORRENT_VERSION_NUM < 20000
     m_hash = InfoHash(m_nativeStatus.info_hash);
+#else
+    m_hash = InfoHash(m_nativeStatus.info_hashes);
+#endif
 
     if (hasMetadata()) {
         applyFirstLastPiecePriority(m_hasFirstLastPiecePriority);

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -156,7 +156,11 @@ bool TorrentInfo::isValid() const
 InfoHash TorrentInfo::hash() const
 {
     if (!isValid()) return {};
+#if (LIBTORRENT_VERSION_NUM < 20000)
     return m_nativeInfo->info_hash();
+#else
+    return m_nativeInfo->info_hashes();
+#endif
 }
 
 QString TorrentInfo::name() const


### PR DESCRIPTION
In libtorrent 2.0, lt::sha1_hash is deprecated and replaced with
lt::info_hash_t which can store SHA-1 and SHA-256 hashes simultaniously.
This commit updates qBittorrent's InfoHash wrapper to support
lt::info_hash_t. This commit has no effect for builds with libtorrent
older than 2.0.
This commit does not yet allow parsing of V2 magnet URIs so qBittorrent
does not support V2 torrents yet.