### PR TITLE
Update GitHub Actions CI actions versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: checkout repository
-      uses: actions/checkout@v2.3.2
+      uses: actions/checkout@v2.3.3
 
     - name: install all build dependencies except libtorrent from Ubuntu repos
       run: |
@@ -70,7 +70,7 @@ jobs:
         cmake --build build
 
     - name: upload artifact as zip
-      uses: actions/upload-artifact@v2.1.3
+      uses: actions/upload-artifact@v2.2.0
       with:
         name: qBittorrent-CI-Ubuntu_${{ matrix.os }}-${{ matrix.qbt_gui }}
         path: |
@@ -92,7 +92,7 @@ jobs:
 
     steps:
     - name: checkout repository
-      uses: actions/checkout@v2.3.2
+      uses: actions/checkout@v2.3.3
 
     # - ninja is needed for building qBittorrent (because it's preferrable, not a hard requirement)
     - name: install additional required packages with chocolatey
@@ -100,7 +100,7 @@ jobs:
         choco install ninja
 
     - name: setup vcpkg (cached, if possible)
-      uses: lukka/run-vcpkg@v3.3
+      uses: lukka/run-vcpkg@v4.1
       with:
         vcpkgDirectory: ${{ env.VCPKG_DEST_WIN }}
         vcpkgGitCommitId: ${{ env.VCPKG_COMMIT }}
@@ -134,7 +134,7 @@ jobs:
 
     # NOTE: this is necessary to correctly find and use cl.exe with the Ninja generator for now
     - name: setup devcmd
-      uses: ilammy/msvc-dev-cmd@v1.3.0
+      uses: ilammy/msvc-dev-cmd@v1.4.1
 
     - name: build qBittorrent
       shell: cmd
@@ -149,7 +149,7 @@ jobs:
         cmake --build build
 
     - name: upload artifact as zip
-      uses: actions/upload-artifact@v2.1.3
+      uses: actions/upload-artifact@v2.2.0
       with:
         name: qBittorrent-CI-Windows_x64-static-release
         path: |
@@ -175,7 +175,7 @@ jobs:
 
     steps:
     - name: checkout repository
-      uses: actions/checkout@v2.3.2
+      uses: actions/checkout@v2.3.3
 
     # - ninja is needed for building qBittorrent (because it's preferrable, not a hard requirement)
     # - pkg-config is needed for some vcpkg installations
@@ -185,7 +185,7 @@ jobs:
         brew install ninja pkg-config
 
     - name: setup vcpkg (cached, if possible)
-      uses: lukka/run-vcpkg@v3.3
+      uses: lukka/run-vcpkg@v4.1
       with:
         vcpkgDirectory: ${{ env.VCPKG_DEST_MACOS }}
         vcpkgGitCommitId: ${{ env.VCPKG_COMMIT }}
@@ -234,7 +234,7 @@ jobs:
         cmake --build build
 
     - name: upload artifact as zip
-      uses: actions/upload-artifact@v2.1.3
+      uses: actions/upload-artifact@v2.2.0
       with:
         name: qBittorrent-CI-macOS_x64-static-release_${{ matrix.qbt_gui }}
         path: |


### PR DESCRIPTION
Should fix all of the ```Warning: The `set-env` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/``` warnings we've been getting on CI runs and prevent total breakage in the future.

EDIT:

See:

https://github.com/ilammy/msvc-dev-cmd/releases/tag/v1.4.1
https://github.com/lukka/run-vcpkg/releases/tag/v4.1

Other version bumps were just regular updates/maintenance releases.

No annotations :tada: https://github.com/qbittorrent/qBittorrent/actions/runs/327272055