### PR TITLE
Don't resume "paused" torrents when put into "checking" state by libtorrent

### DIFF
--- a/src/base/bittorrent/nativetorrentextension.cpp
+++ b/src/base/bittorrent/nativetorrentextension.cpp
@@ -49,17 +49,6 @@ NativeTorrentExtension::NativeTorrentExtension(const lt::torrent_handle &torrent
 {
 }
 
-// This method is called when state of torrent is changed
-void NativeTorrentExtension::on_state(const lt::torrent_status::state_t state)
-{
-    // When a torrent enters "checking files" state while paused, we temporarily resume it
-    // (really we just allow libtorrent to resume it by enabling auto management for it).
-    if (state == lt::torrent_status::checking_files) {
-        if (isPaused(m_torrentHandle.status({})))
-            m_torrentHandle.set_flags(lt::torrent_flags::stop_when_ready | lt::torrent_flags::auto_managed);
-    }
-}
-
 bool NativeTorrentExtension::on_pause()
 {
     if (!isAutoManaged(m_torrentHandle.status({})))

--- a/src/base/bittorrent/nativetorrentextension.h
+++ b/src/base/bittorrent/nativetorrentextension.h
@@ -37,7 +37,6 @@ public:
     explicit NativeTorrentExtension(const lt::torrent_handle &torrentHandle);
 
 private:
-    void on_state(lt::torrent_status::state_t state) override;
     bool on_pause() override;
 
     lt::torrent_handle m_torrentHandle;

--- a/src/base/bittorrent/torrenthandleimpl.cpp
+++ b/src/base/bittorrent/torrenthandleimpl.cpp
@@ -743,48 +743,61 @@ void TorrentHandleImpl::updateState()
     if (m_nativeStatus.state == lt::torrent_status::checking_resume_data) {
         m_state = TorrentState::CheckingResumeData;
     }
-    else if (m_nativeStatus.state == lt::torrent_status::checking_files) {
-        m_state = m_hasSeedStatus ? TorrentState::CheckingUploading : TorrentState::CheckingDownloading;
-    }
-    else if (m_nativeStatus.state == lt::torrent_status::allocating) {
-        m_state = TorrentState::Allocating;
-    }
-    else if (isMoveInProgress()) {
-        m_state = TorrentState::Moving;
-    }
-    else if (hasError()) {
-        m_state = TorrentState::Error;
-    }
-    else if (hasMissingFiles()) {
-        m_state = TorrentState::MissingFiles;
-    }
     else if (isPaused()) {
-        m_state = isSeed() ? TorrentState::PausedUploading : TorrentState::PausedDownloading;
-    }
-    else if (m_session->isQueueingSystemEnabled() && isQueued() && !isChecking()) {
-        m_state = isSeed() ? TorrentState::QueuedUploading : TorrentState::QueuedDownloading;
+        if (isMoveInProgress()) {
+            m_state = TorrentState::Moving;
+        }
+        else if (hasMissingFiles()) {
+            m_state = TorrentState::MissingFiles;
+        }
+        else if (hasError()) {
+            m_state = TorrentState::Error;
+        }
+        else {
+            m_state = isSeed() ? TorrentState::PausedUploading : TorrentState::PausedDownloading;
+        }
     }
     else {
-        switch (m_nativeStatus.state) {
-        case lt::torrent_status::finished:
-        case lt::torrent_status::seeding:
-            if (isForced())
-                m_state = TorrentState::ForcedUploading;
-            else
-                m_state = m_nativeStatus.upload_payload_rate > 0 ? TorrentState::Uploading : TorrentState::StalledUploading;
-            break;
-        case lt::torrent_status::downloading_metadata:
-            m_state = TorrentState::DownloadingMetadata;
-            break;
-        case lt::torrent_status::downloading:
-            if (isForced())
-                m_state = TorrentState::ForcedDownloading;
-            else
-                m_state = m_nativeStatus.download_payload_rate > 0 ? TorrentState::Downloading : TorrentState::StalledDownloading;
-            break;
-        default:
-            qWarning("Unrecognized torrent status, should not happen!!! status was %d", m_nativeStatus.state);
-            m_state = TorrentState::Unknown;
+        if (m_nativeStatus.state == lt::torrent_status::checking_files) {
+            m_state = m_hasSeedStatus ? TorrentState::CheckingUploading : TorrentState::CheckingDownloading;
+        }
+        else if (m_nativeStatus.state == lt::torrent_status::allocating) {
+            m_state = TorrentState::Allocating;
+        }
+        else if (isMoveInProgress()) {
+            m_state = TorrentState::Moving;
+        }
+        else if (hasMissingFiles()) {
+            m_state = TorrentState::MissingFiles;
+        }
+        else if (hasError()) {
+            m_state = TorrentState::Error;
+        }
+        else if (m_session->isQueueingSystemEnabled() && isQueued() && !isChecking()) {
+            m_state = isSeed() ? TorrentState::QueuedUploading : TorrentState::QueuedDownloading;
+        }
+        else {
+            switch (m_nativeStatus.state) {
+            case lt::torrent_status::finished:
+            case lt::torrent_status::seeding:
+                if (isForced())
+                    m_state = TorrentState::ForcedUploading;
+                else
+                    m_state = m_nativeStatus.upload_payload_rate > 0 ? TorrentState::Uploading : TorrentState::StalledUploading;
+                break;
+            case lt::torrent_status::downloading_metadata:
+                m_state = TorrentState::DownloadingMetadata;
+                break;
+            case lt::torrent_status::downloading:
+                if (isForced())
+                    m_state = TorrentState::ForcedDownloading;
+                else
+                    m_state = m_nativeStatus.download_payload_rate > 0 ? TorrentState::Downloading : TorrentState::StalledDownloading;
+                break;
+            default:
+                qWarning("Unrecognized torrent status, should not happen!!! status was %d", m_nativeStatus.state);
+                m_state = TorrentState::Unknown;
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #13576.
Closes #13635.

Requires libtorrent >= 1.2.4 (but I didn't change build system projects, because we were still going to increase it to 1.2.10 or even 1.2.11 if it was released before the next release of qBittorrent).