### PR TITLE
Fix mingw64 build error

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -2686,10 +2686,10 @@ QString Session::networkInterface() const
     return m_networkInterface;
 }
 
-void Session::setNetworkInterface(const QString &interface)
+void Session::setNetworkInterface(const QString &iface)
 {
-    if (interface != networkInterface()) {
-        m_networkInterface = interface;
+    if (iface != networkInterface()) {
+        m_networkInterface = iface;
         configureListeningInterface();
     }
 }

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -309,7 +309,7 @@ namespace BitTorrent
         bool useRandomPort() const;
         void setUseRandomPort(bool value);
         QString networkInterface() const;
-        void setNetworkInterface(const QString &interface);
+        void setNetworkInterface(const QString &iface);
         QString networkInterfaceName() const;
         void setNetworkInterfaceName(const QString &name);
         QString networkInterfaceAddress() const;


### PR DESCRIPTION
mingw64 defines interface, so revert back to previous naming scheme

Fixes: 87864531ab747b10094b4e0efc32ea80c586b6b9
Closes #13649