### PR TITLE
Show active torrent filters in transfer list

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -171,6 +171,16 @@ void Preferences::setHideZeroValues(const bool b)
     setValue("Preferences/General/HideZeroValues", b);
 }
 
+bool Preferences::isActiveFiltersLabelVisible() const
+{
+    return value("Preferences/General/isActiveFiltersLabelVisible", true).toBool();
+}
+
+void Preferences::setActiveFiltersLableVisibility(const bool b)
+{
+    setValue("Preferences/General/isActiveFiltersLabelVisible", b);
+}
+
 int Preferences::getHideZeroComboValues() const
 {
     return value("Preferences/General/HideZeroComboValues", 0).toInt();

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -114,6 +114,8 @@ public:
     void setHideZeroValues(bool b);
     int getHideZeroComboValues() const;
     void setHideZeroComboValues(int n);
+    bool isActiveFiltersLabelVisible() const;
+    void setActiveFiltersLableVisibility(bool b);
     bool isStatusbarDisplayed() const;
     void setStatusbarDisplayed(bool displayed);
     bool isToolbarDisplayed() const;

--- a/src/gui/categoryfilterwidget.cpp
+++ b/src/gui/categoryfilterwidget.cpp
@@ -97,6 +97,23 @@ QString CategoryFilterWidget::currentCategory() const
     return getCategoryFilter(static_cast<CategoryFilterProxyModel *>(model()), current);
 }
 
+QString CategoryFilterWidget::currentCategoryFullText() const
+{
+    const QModelIndexList selectedRows = selectionModel()->selectedRows();
+    if (selectedRows.isEmpty())
+        return {};
+
+    const QModelIndex proxyIndex = selectedRows.first();
+    if (proxyIndex.row() == 0)
+        return {};
+
+    const CategoryFilterProxyModel *proxyModel = static_cast<const CategoryFilterProxyModel *>(model());
+    const QModelIndex current = proxyModel->mapToSource(proxyIndex);
+    return tr("%1 (%2)")
+           .arg(static_cast<CategoryFilterModel *>(proxyModel->sourceModel())->categoryName(current)
+                , current.data(Qt::UserRole).toString());
+}
+
 void CategoryFilterWidget::onCurrentRowChanged(const QModelIndex &current, const QModelIndex &previous)
 {
     Q_UNUSED(previous);

--- a/src/gui/categoryfilterwidget.h
+++ b/src/gui/categoryfilterwidget.h
@@ -39,6 +39,7 @@ public:
     explicit CategoryFilterWidget(QWidget *parent = nullptr);
 
     QString currentCategory() const;
+    QString currentCategoryFullText() const;
 
 signals:
     void categoryChanged(const QString &categoryName);

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -301,6 +301,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     connect(m_ui->checkUseSystemIcon, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
 #endif
     connect(m_ui->confirmDeletion, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->showActiveFiltersLabel, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkAltRowColors, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkHideZero, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkHideZero, &QAbstractButton::toggled, m_ui->comboHideZero, &QWidget::setEnabled);
@@ -663,6 +664,7 @@ void OptionsDialog::saveOptions()
 #endif
 
     pref->setConfirmTorrentDeletion(m_ui->confirmDeletion->isChecked());
+    pref->setActiveFiltersLableVisibility(m_ui->showActiveFiltersLabel->isChecked());
     pref->setAlternatingRowColors(m_ui->checkAltRowColors->isChecked());
     pref->setHideZeroValues(m_ui->checkHideZero->isChecked());
     pref->setHideZeroComboValues(m_ui->comboHideZero->currentIndex());
@@ -911,6 +913,7 @@ void OptionsDialog::loadOptions()
     // Behavior preferences
     setLocale(pref->getLocale());
     m_ui->confirmDeletion->setChecked(pref->confirmTorrentDeletion());
+    m_ui->showActiveFiltersLabel->setChecked(pref->isActiveFiltersLabelVisible());
     m_ui->checkAltRowColors->setChecked(pref->useAlternatingRowColors());
     m_ui->checkHideZero->setChecked(pref->getHideZeroValues());
     m_ui->comboHideZero->setEnabled(m_ui->checkHideZero->isChecked());

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -233,6 +233,16 @@
                 </widget>
                </item>
                <item>
+                <widget class="QCheckBox" name="showActiveFiltersLabel">
+                 <property name="text">
+                  <string>Show active filters in transfer list (if any)</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <widget class="QCheckBox" name="checkAltRowColors">
                  <property name="text">
                   <string extracomment="In table elements, every other row will have a grey background.">Use alternating row colors</string>

--- a/src/gui/tagfilterwidget.cpp
+++ b/src/gui/tagfilterwidget.cpp
@@ -95,6 +95,15 @@ QString TagFilterWidget::currentTag() const
     return getTagFilter(static_cast<TagFilterProxyModel *>(model()), current);
 }
 
+QString TagFilterWidget::currentTagText() const
+{
+    const auto selectedRows = selectionModel()->selectedRows();
+    if (selectedRows.isEmpty() || (selectedRows.first().row() == 0))
+        return {};;
+
+    return selectedRows.first().data().toString();
+}
+
 void TagFilterWidget::onCurrentRowChanged(const QModelIndex &current, const QModelIndex &previous)
 {
     Q_UNUSED(previous);

--- a/src/gui/tagfilterwidget.h
+++ b/src/gui/tagfilterwidget.h
@@ -39,6 +39,7 @@ public:
     explicit TagFilterWidget(QWidget *parent = nullptr);
 
     QString currentTag() const;
+    QString currentTagText() const;
 
 signals:
     void tagChanged(const QString &tag);

--- a/src/gui/transferlistfilterswidget.h
+++ b/src/gui/transferlistfilterswidget.h
@@ -36,6 +36,7 @@ class QCheckBox;
 class QResizeEvent;
 
 class TransferListWidget;
+class ActiveFiltersLabel;
 
 namespace BitTorrent
 {
@@ -58,6 +59,10 @@ public:
 
     QSize sizeHint() const override;
     QSize minimumSizeHint() const override;
+    QListWidgetItem *currentFilter() const; // returns null for "all" filter
+
+signals:
+    void currentFilterChanged();
 
 public slots:
     void toggleFilter(bool checked);
@@ -147,6 +152,8 @@ class TransferListFiltersWidget : public QFrame
 public:
     TransferListFiltersWidget(QWidget *parent, TransferListWidget *transferList, bool downloadFavicon);
     void setDownloadTrackerFavicon(bool value);
+    QWidget *activeFiltersLabel() const;
+    int activeFiltersCount() const;
 
 public slots:
     void addTrackers(BitTorrent::TorrentHandle *const torrent, const QVector<BitTorrent::TrackerEntry> &trackers);
@@ -160,6 +167,7 @@ signals:
     void trackerSuccess(const QString &hash, const QString &tracker);
     void trackerError(const QString &hash, const QString &tracker);
     void trackerWarning(const QString &hash, const QString &tracker);
+    void activeFiltersCountChanged(int count);
 
 private slots:
     void onCategoryFilterStateChanged(bool enabled);
@@ -173,6 +181,7 @@ private:
     TrackerFiltersList *m_trackerFilters;
     CategoryFilterWidget *m_categoryFilterWidget;
     TagFilterWidget *m_tagFilterWidget;
+    ActiveFiltersLabel *m_activeFiltersLabel;
 };
 
 #endif // TRANSFERLISTFILTERSWIDGET_H


### PR DESCRIPTION
Before this, the tracker list in the filters panel will grow very big, and you won't be able to see other filters, that produce confusion when multiple filters are selected, especially in cases when you're filtering on the basis of a tracker and another filter since they normally won't fit in one view and you can't track active filters in one glance. this PR introduces an overlay at the bottom of the transfer list with all the active filters as text (1), with this user can check active filters without scrolling the whole filter list. 

(1)
![image](https://user-images.githubusercontent.com/34717789/97808038-44c8b180-1c8a-11eb-8763-34eb9515124c.png)

