### PR TITLE
Fix received metadata handling

### DIFF
--- a/src/base/bittorrent/nativetorrentextension.cpp
+++ b/src/base/bittorrent/nativetorrentextension.cpp
@@ -52,3 +52,11 @@ bool NativeTorrentExtension::on_pause()
     // and other extensions to be also invoked.
     return false;
 }
+
+void NativeTorrentExtension::on_state(const lt::torrent_status::state_t state)
+{
+    if (m_state == lt::torrent_status::downloading_metadata)
+        m_torrentHandle.set_flags(lt::torrent_flags::stop_when_ready);
+
+    m_state = state;
+}

--- a/src/base/bittorrent/nativetorrentextension.h
+++ b/src/base/bittorrent/nativetorrentextension.h
@@ -38,6 +38,8 @@ public:
 
 private:
     bool on_pause() override;
+    void on_state(lt::torrent_status::state_t state) override;
 
     lt::torrent_handle m_torrentHandle;
+    lt::torrent_status::state_t m_state = lt::torrent_status::checking_resume_data;
 };

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -4581,7 +4581,7 @@ void Session::createTorrentHandle(const lt::torrent_handle &nativeHandle)
 
     const LoadTorrentParams params = m_loadingTorrents.take(nativeHandle.info_hash());
 
-    auto *const torrent = new TorrentHandleImpl {this, nativeHandle, params};
+    auto *const torrent = new TorrentHandleImpl {this, nativeHandle, m_nativeSession, params};
     m_torrents.insert(torrent->hash(), torrent);
 
     const bool hasMetadata = torrent->hasMetadata();

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -593,11 +593,11 @@ void Session::setAppendExtensionEnabled(const bool enabled)
 {
     if (isAppendExtensionEnabled() != enabled)
     {
+        m_isAppendExtensionEnabled = enabled;
+
         // append or remove .!qB extension for incomplete files
         for (TorrentHandleImpl *const torrent : asConst(m_torrents))
             torrent->handleAppendExtensionToggled();
-
-        m_isAppendExtensionEnabled = enabled;
     }
 }
 

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -453,8 +453,8 @@ namespace BitTorrent
         bool addTorrent(const MagnetUri &magnetUri, const AddTorrentParams &params = AddTorrentParams());
         bool addTorrent(const TorrentInfo &torrentInfo, const AddTorrentParams &params = AddTorrentParams());
         bool deleteTorrent(const InfoHash &hash, DeleteOption deleteOption = Torrent);
-        bool loadMetadata(const MagnetUri &magnetUri);
-        bool cancelLoadMetadata(const InfoHash &hash);
+        bool downloadMetadata(const MagnetUri &magnetUri);
+        bool cancelDownloadMetadata(const InfoHash &hash);
 
         void recursiveTorrentDownload(const InfoHash &hash);
         void increaseTorrentsQueuePos(const QVector<InfoHash> &hashes);
@@ -497,7 +497,7 @@ namespace BitTorrent
         void fullDiskError(TorrentHandle *torrent, const QString &msg);
         void IPFilterParsed(bool error, int ruleCount);
         void loadTorrentFailed(const QString &error);
-        void metadataLoaded(const TorrentInfo &info);
+        void metadataDownloaded(const TorrentInfo &info);
         void recursiveTorrentDownloadPossible(TorrentHandle *torrent);
         void speedLimitModeChanged(bool alternative);
         void statsUpdated();
@@ -764,7 +764,7 @@ namespace BitTorrent
         QThread *m_ioThread = nullptr;
         ResumeDataSavingManager *m_resumeDataSavingManager = nullptr;
 
-        QSet<InfoHash> m_loadedMetadata;
+        QSet<InfoHash> m_downloadedMetadata;
 
         QHash<InfoHash, TorrentHandleImpl *> m_torrents;
         QHash<InfoHash, LoadTorrentParams> m_loadingTorrents;

--- a/src/base/bittorrent/torrenthandleimpl.h
+++ b/src/base/bittorrent/torrenthandleimpl.h
@@ -80,14 +80,20 @@ namespace BitTorrent
         Overwrite
     };
 
+    enum class MaintenanceJob
+    {
+        None,
+        HandleMetadata
+    };
+
     class TorrentHandleImpl final : public QObject, public TorrentHandle
     {
         Q_DISABLE_COPY(TorrentHandleImpl)
         Q_DECLARE_TR_FUNCTIONS(BitTorrent::TorrentHandleImpl)
 
     public:
-        TorrentHandleImpl(Session *session, const lt::torrent_handle &nativeHandle,
-                          const LoadTorrentParams &params);
+        TorrentHandleImpl(Session *session, lt::session *nativeSession
+                          , const lt::torrent_handle &nativeHandle, const LoadTorrentParams &params);
         ~TorrentHandleImpl() override;
 
         bool isValid() const;
@@ -280,6 +286,7 @@ namespace BitTorrent
         void applyFirstLastPiecePriority(bool enabled, const QVector<DownloadPriority> &updatedFilePrio = {});
 
         Session *const m_session;
+        lt::session *m_nativeSession;
         lt::torrent_handle m_nativeHandle;
         lt::torrent_status m_nativeStatus;
         TorrentState m_state = TorrentState::Unknown;
@@ -293,6 +300,8 @@ namespace BitTorrent
         QQueue<EventTrigger> m_moveFinishedTriggers;
         int m_renameCount = 0;
         bool m_storageIsMoving = false;
+
+        MaintenanceJob m_maintenanceJob = MaintenanceJob::None;
 
         // Until libtorrent provide an "old_name" field in `file_renamed_alert`
         // we will rely on this workaround to remove empty leftover folders

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -347,7 +347,7 @@ bool AddNewTorrentDialog::loadMagnet(const BitTorrent::MagnetUri &magnetUri)
         return false;
     }
 
-    connect(BitTorrent::Session::instance(), &BitTorrent::Session::metadataLoaded, this, &AddNewTorrentDialog::updateMetadata);
+    connect(BitTorrent::Session::instance(), &BitTorrent::Session::metadataDownloaded, this, &AddNewTorrentDialog::updateMetadata);
 
     // Set dialog title
     const QString torrentName = magnetUri.name();
@@ -356,7 +356,7 @@ bool AddNewTorrentDialog::loadMagnet(const BitTorrent::MagnetUri &magnetUri)
     setupTreeview();
     TMMChanged(m_ui->comboTTM->currentIndex());
 
-    BitTorrent::Session::instance()->loadMetadata(magnetUri);
+    BitTorrent::Session::instance()->downloadMetadata(magnetUri);
     setMetadataProgressIndicator(true, tr("Retrieving metadata..."));
     m_ui->labelHashData->setText(infoHash);
 
@@ -613,7 +613,7 @@ void AddNewTorrentDialog::reject()
     if (!m_hasMetadata)
     {
         setMetadataProgressIndicator(false);
-        BitTorrent::Session::instance()->cancelLoadMetadata(m_magnetURI.hash());
+        BitTorrent::Session::instance()->cancelDownloadMetadata(m_magnetURI.hash());
     }
 
     QDialog::reject();
@@ -623,7 +623,7 @@ void AddNewTorrentDialog::updateMetadata(const BitTorrent::TorrentInfo &metadata
 {
     if (metadata.hash() != m_magnetURI.hash()) return;
 
-    disconnect(BitTorrent::Session::instance(), &BitTorrent::Session::metadataLoaded, this, &AddNewTorrentDialog::updateMetadata);
+    disconnect(BitTorrent::Session::instance(), &BitTorrent::Session::metadataDownloaded, this, &AddNewTorrentDialog::updateMetadata);
 
     if (!metadata.isValid())
     {


### PR DESCRIPTION
Now qBittorrent correctly deletes the root folder if the torrent was added via the magnet link and the metadata was received later.
The existing handling is absolutely incorrect. It was based on false premises. I wonder why it took so long for this to be discovered. Although, apparently, there were related Issues, but most likely left without attention due to incorrect explanations. And I almost never use this feature myself.