### PR TITLE
More informative message on adding an existing torrent

### DIFF
--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -283,10 +283,10 @@ namespace BitTorrent
         virtual void setDownloadLimit(int limit) = 0;
         virtual void setSuperSeeding(bool enable) = 0;
         virtual void flushCache() const = 0;
-        virtual void addTrackers(const QVector<TrackerEntry> &trackers) = 0;
+        virtual int addTrackers(const QVector<TrackerEntry> &trackers) = 0;
         virtual void replaceTrackers(const QVector<TrackerEntry> &trackers) = 0;
-        virtual void addUrlSeeds(const QVector<QUrl> &urlSeeds) = 0;
-        virtual void removeUrlSeeds(const QVector<QUrl> &urlSeeds) = 0;
+        virtual int addUrlSeeds(const QVector<QUrl> &urlSeeds) = 0;
+        virtual int removeUrlSeeds(const QVector<QUrl> &urlSeeds) = 0;
         virtual bool connectPeer(const PeerAddress &peerAddress) = 0;
         virtual void clearPeers() = 0;
 

--- a/src/base/bittorrent/torrenthandleimpl.cpp
+++ b/src/base/bittorrent/torrenthandleimpl.cpp
@@ -321,7 +321,7 @@ QHash<QString, TrackerInfo> TorrentHandleImpl::trackerInfos() const
     return m_trackerInfos;
 }
 
-void TorrentHandleImpl::addTrackers(const QVector<TrackerEntry> &trackers)
+int TorrentHandleImpl::addTrackers(const QVector<TrackerEntry> &trackers)
 {
     QSet<TrackerEntry> currentTrackers;
     for (const lt::announce_entry &entry : m_nativeHandle.trackers())
@@ -339,6 +339,8 @@ void TorrentHandleImpl::addTrackers(const QVector<TrackerEntry> &trackers)
 
     if (!newTrackers.isEmpty())
         m_session->handleTorrentTrackersAdded(this, newTrackers);
+
+    return newTrackers.count();
 }
 
 void TorrentHandleImpl::replaceTrackers(const QVector<TrackerEntry> &trackers)
@@ -391,7 +393,7 @@ QVector<QUrl> TorrentHandleImpl::urlSeeds() const
     return urlSeeds;
 }
 
-void TorrentHandleImpl::addUrlSeeds(const QVector<QUrl> &urlSeeds)
+int TorrentHandleImpl::addUrlSeeds(const QVector<QUrl> &urlSeeds)
 {
     const std::set<std::string> currentSeeds = m_nativeHandle.url_seeds();
 
@@ -408,9 +410,11 @@ void TorrentHandleImpl::addUrlSeeds(const QVector<QUrl> &urlSeeds)
 
     if (!addedUrlSeeds.isEmpty())
         m_session->handleTorrentUrlSeedsAdded(this, addedUrlSeeds);
+
+    return addedUrlSeeds.count();
 }
 
-void TorrentHandleImpl::removeUrlSeeds(const QVector<QUrl> &urlSeeds)
+int TorrentHandleImpl::removeUrlSeeds(const QVector<QUrl> &urlSeeds)
 {
     const std::set<std::string> currentSeeds = m_nativeHandle.url_seeds();
 
@@ -427,6 +431,8 @@ void TorrentHandleImpl::removeUrlSeeds(const QVector<QUrl> &urlSeeds)
 
     if (!removedUrlSeeds.isEmpty())
         m_session->handleTorrentUrlSeedsRemoved(this, removedUrlSeeds);
+
+    return removedUrlSeeds.count();
 }
 
 void TorrentHandleImpl::clearPeers()

--- a/src/base/bittorrent/torrenthandleimpl.h
+++ b/src/base/bittorrent/torrenthandleimpl.h
@@ -220,10 +220,10 @@ namespace BitTorrent
         void setDownloadLimit(int limit) override;
         void setSuperSeeding(bool enable) override;
         void flushCache() const override;
-        void addTrackers(const QVector<TrackerEntry> &trackers) override;
+        int addTrackers(const QVector<TrackerEntry> &trackers) override;
         void replaceTrackers(const QVector<TrackerEntry> &trackers) override;
-        void addUrlSeeds(const QVector<QUrl> &urlSeeds) override;
-        void removeUrlSeeds(const QVector<QUrl> &urlSeeds) override;
+        int addUrlSeeds(const QVector<QUrl> &urlSeeds) override;
+        int removeUrlSeeds(const QVector<QUrl> &urlSeeds) override;
         bool connectPeer(const PeerAddress &peerAddress) override;
         void clearPeers() override;
 

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -284,17 +284,21 @@ bool AddNewTorrentDialog::loadTorrentImpl()
         BitTorrent::TorrentHandle *const torrent = BitTorrent::Session::instance()->findTorrent(infoHash);
         if (torrent) {
             if (torrent->isPrivate() || m_torrentInfo.isPrivate()) {
-                RaisedMessageBox::warning(this, tr("Torrent is already present"), tr("Torrent '%1' is already in the transfer list. Trackers haven't been merged because it is a private torrent.").arg(torrent->name()), QMessageBox::Ok);
+                RaisedMessageBox::warning(this, tr("Torrent is already present"), tr("Torrent '%1' is already in the transfer list.").arg(torrent->name()) + " " + tr("Trackers haven't been merged because it is a private torrent."), QMessageBox::Ok);
             }
             else {
+                QStringList message;
+
                 int newTrackersLen = torrent->addTrackers(m_torrentInfo.trackers());
                 int newUrlSeedsLen = torrent->addUrlSeeds(m_torrentInfo.urlSeeds());
-                if (newTrackersLen > 0) {
-                    RaisedMessageBox::information(this, tr("Torrent is already present"), tr("Torrent '%1' is already in the transfer list. Trackers have been merged.").arg(torrent->name()), QMessageBox::Ok);
-                }
-                else {
-                    RaisedMessageBox::information(this, tr("Torrent is already present"), tr("Torrent '%1' is already in the transfer list. No new trackers were added.").arg(torrent->name()), QMessageBox::Ok);
-                }
+
+                if (newTrackersLen > 0)
+                    message << tr("%1 new tracker(s)").arg(newTrackersLen);
+
+                if (newUrlSeedsLen > 0)
+                    message << tr("%1 new url seed(s)").arg(newUrlSeedsLen);
+
+                RaisedMessageBox::information(this, tr("Torrent is already present"), tr("Torrent '%1' is already in the transfer list").arg(torrent->name()) + (message.count() > 0 ? (tr(", %1 have been merged.").arg(message.join(tr(" and ")))): "."), QMessageBox::Ok);
             }
         }
         else {
@@ -325,17 +329,21 @@ bool AddNewTorrentDialog::loadMagnet(const BitTorrent::MagnetUri &magnetUri)
         BitTorrent::TorrentHandle *const torrent = BitTorrent::Session::instance()->findTorrent(infoHash);
         if (torrent) {
             if (torrent->isPrivate()) {
-                RaisedMessageBox::warning(this, tr("Torrent is already present"), tr("Torrent '%1' is already in the transfer list. Trackers haven't been merged because it is a private torrent.").arg(torrent->name()), QMessageBox::Ok);
+                RaisedMessageBox::warning(this, tr("Torrent is already present"), tr("Magnet link '%1' is already in the transfer list.").arg(torrent->name() + " " + tr("Trackers haven't been merged because it is a private torrent.")), QMessageBox::Ok);
             }
             else {
+                QStringList message;
+
                 int newTrackersLen = torrent->addTrackers(magnetUri.trackers());
                 int newUrlSeedsLen = torrent->addUrlSeeds(magnetUri.urlSeeds());
-                if (newTrackersLen > 0) {
-                    RaisedMessageBox::information(this, tr("Torrent is already present"), tr("Magnet link '%1' is already in the transfer list. Trackers have been merged.").arg(torrent->name()), QMessageBox::Ok);
-                }
-                else {
-                    RaisedMessageBox::information(this, tr("Torrent is already present"), tr("Magnet link '%1' is already in the transfer list. No new trackers were added.").arg(torrent->name()), QMessageBox::Ok);
-                }
+
+                if (newTrackersLen > 0)
+                    message << tr("%1 new tracker(s)").arg(newTrackersLen);
+
+                if (newUrlSeedsLen > 0)
+                    message << tr("%1 new url seed(s)").arg(newUrlSeedsLen);
+
+                RaisedMessageBox::information(this, tr("Torrent is already present"), tr("Magnet link '%1' is already in the transfer list").arg(torrent->name()) + (message.count() > 0 ? (tr(", %1 have been merged.").arg(message.join(tr(" and ")))): "."), QMessageBox::Ok);
             }
         }
         else {

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -287,9 +287,14 @@ bool AddNewTorrentDialog::loadTorrentImpl()
                 RaisedMessageBox::warning(this, tr("Torrent is already present"), tr("Torrent '%1' is already in the transfer list. Trackers haven't been merged because it is a private torrent.").arg(torrent->name()), QMessageBox::Ok);
             }
             else {
-                torrent->addTrackers(m_torrentInfo.trackers());
-                torrent->addUrlSeeds(m_torrentInfo.urlSeeds());
-                RaisedMessageBox::information(this, tr("Torrent is already present"), tr("Torrent '%1' is already in the transfer list. Trackers have been merged.").arg(torrent->name()), QMessageBox::Ok);
+                int newTrackersLen = torrent->addTrackers(m_torrentInfo.trackers());
+                int newUrlSeedsLen = torrent->addUrlSeeds(m_torrentInfo.urlSeeds());
+                if (newTrackersLen > 0) {
+                    RaisedMessageBox::information(this, tr("Torrent is already present"), tr("Torrent '%1' is already in the transfer list. Trackers have been merged.").arg(torrent->name()), QMessageBox::Ok);
+                }
+                else {
+                    RaisedMessageBox::information(this, tr("Torrent is already present"), tr("Torrent '%1' is already in the transfer list. No new trackers were added.").arg(torrent->name()), QMessageBox::Ok);
+                }
             }
         }
         else {
@@ -323,9 +328,14 @@ bool AddNewTorrentDialog::loadMagnet(const BitTorrent::MagnetUri &magnetUri)
                 RaisedMessageBox::warning(this, tr("Torrent is already present"), tr("Torrent '%1' is already in the transfer list. Trackers haven't been merged because it is a private torrent.").arg(torrent->name()), QMessageBox::Ok);
             }
             else {
-                torrent->addTrackers(magnetUri.trackers());
-                torrent->addUrlSeeds(magnetUri.urlSeeds());
-                RaisedMessageBox::information(this, tr("Torrent is already present"), tr("Magnet link '%1' is already in the transfer list. Trackers have been merged.").arg(torrent->name()), QMessageBox::Ok);
+                int newTrackersLen = torrent->addTrackers(magnetUri.trackers());
+                int newUrlSeedsLen = torrent->addUrlSeeds(magnetUri.urlSeeds());
+                if (newTrackersLen > 0) {
+                    RaisedMessageBox::information(this, tr("Torrent is already present"), tr("Magnet link '%1' is already in the transfer list. Trackers have been merged.").arg(torrent->name()), QMessageBox::Ok);
+                }
+                else {
+                    RaisedMessageBox::information(this, tr("Torrent is already present"), tr("Magnet link '%1' is already in the transfer list. No new trackers were added.").arg(torrent->name()), QMessageBox::Ok);
+                }
             }
         }
         else {


### PR DESCRIPTION
### Description
The "Torrent is already present" dialog in qBittorrent can benefit from a better, more detailed message. For example, there is currently the following message in the GUI which does not correctly reflect what is happening.

| <img width="435" alt="qbittorrent-message" src="https://user-images.githubusercontent.com/4673812/47945783-b645bc00-df19-11e8-969c-c1e779ce7cce.png"> |
| --- |
| <sup>"Trackers have been merged" is displayed even though there are no _new_ trackers to be merged.</sup> |


The aim of this patch is to deliver a better, more informative confirmation message to the user.

### Scope of the PR
In order to achieve this, the following requirements should be met:

1. **Changing / implementing new APIs** e.g.:<br/>
    - the methods such as `addTrackers()` should return an `int` value reflecting the number of _updated_ trackers. (Zero if no _new_ trackers were added.)
2. **Splitting some translation strings** <br/>e.g. the following sentences should be split:
    - Torrent '%1' is already in the transfer list. Trackers have been merged.
    - Magnet link '%1' is already in the transfer list. Trackers have been merged.
    &nbsp;
    1. Torrent '%1' is already in the transfer list.
    2. Magnet link '%1' is already in the transfer list.
    3. Trackers have been merged.
    4. No new trackers were added.<br/><sup>(additionally, the this translation string must be added.)</sup>

**Note:** This PR is a rework of #9808, which I closed in favor of this one.