### PR TITLE
Remove automatic save path management

### DIFF
--- a/src/base/bittorrent/addtorrentparams.h
+++ b/src/base/bittorrent/addtorrentparams.h
@@ -53,7 +53,6 @@ namespace BitTorrent
         QVector<DownloadPriority> filePriorities; // used if TorrentInfo is set
         bool skipChecking = false;
         TriStateBool createSubfolder;
-        TriStateBool useAutoTMM;
         int uploadLimit = -1;
         int downloadLimit = -1;
         int seedingTimeLimit = TorrentHandle::USE_GLOBAL_SEEDING_TIME;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -238,26 +238,6 @@ namespace BitTorrent
         bool addTag(const QString &tag);
         bool removeTag(const QString &tag);
 
-        // Torrent Management Mode subsystem (TMM)
-        //
-        // Each torrent can be either in Manual mode or in Automatic mode
-        // In Manual Mode various torrent properties are set explicitly(eg save path)
-        // In Automatic Mode various torrent properties are set implicitly(eg save path)
-        //     based on the associated category.
-        // In Automatic Mode torrent save path can be changed in following cases:
-        //     1. Default save path changed
-        //     2. Torrent category save path changed
-        //     3. Torrent category changed
-        //     (unless otherwise is specified)
-        bool isAutoTMMDisabledByDefault() const;
-        void setAutoTMMDisabledByDefault(bool value);
-        bool isDisableAutoTMMWhenCategoryChanged() const;
-        void setDisableAutoTMMWhenCategoryChanged(bool value);
-        bool isDisableAutoTMMWhenDefaultSavePathChanged() const;
-        void setDisableAutoTMMWhenDefaultSavePathChanged(bool value);
-        bool isDisableAutoTMMWhenCategorySavePathChanged() const;
-        void setDisableAutoTMMWhenCategorySavePathChanged(bool value);
-
         qreal globalMaxRatio() const;
         void setGlobalMaxRatio(qreal ratio);
         int globalMaxSeedingMinutes() const;
@@ -470,7 +450,6 @@ namespace BitTorrent
         void handleTorrentCategoryChanged(TorrentHandleImpl *const torrent, const QString &oldCategory);
         void handleTorrentTagAdded(TorrentHandleImpl *const torrent, const QString &tag);
         void handleTorrentTagRemoved(TorrentHandleImpl *const torrent, const QString &tag);
-        void handleTorrentSavingModeChanged(TorrentHandleImpl *const torrent);
         void handleTorrentMetadataReceived(TorrentHandleImpl *const torrent);
         void handleTorrentPaused(TorrentHandleImpl *const torrent);
         void handleTorrentResumed(TorrentHandleImpl *const torrent);
@@ -514,7 +493,6 @@ namespace BitTorrent
         void torrentPaused(TorrentHandle *torrent);
         void torrentResumed(TorrentHandle *torrent);
         void torrentSavePathChanged(TorrentHandle *torrent);
-        void torrentSavingModeChanged(TorrentHandle *torrent);
         void torrentStorageMoveFailed(TorrentHandle *torrent, const QString &targetPath, const QString &error);
         void torrentStorageMoveFinished(TorrentHandle *torrent, const QString &newPath);
         void torrentsUpdated(const QVector<TorrentHandle *> &torrents);
@@ -727,10 +705,6 @@ namespace BitTorrent
         CachedSettingValue<QString> m_tempPath;
         CachedSettingValue<bool> m_isSubcategoriesEnabled;
         CachedSettingValue<bool> m_isTempPathEnabled;
-        CachedSettingValue<bool> m_isAutoTMMDisabledByDefault;
-        CachedSettingValue<bool> m_isDisableAutoTMMWhenCategoryChanged;
-        CachedSettingValue<bool> m_isDisableAutoTMMWhenDefaultSavePathChanged;
-        CachedSettingValue<bool> m_isDisableAutoTMMWhenCategorySavePathChanged;
         CachedSettingValue<bool> m_isTrackerEnabled;
         CachedSettingValue<int> m_peerTurnover;
         CachedSettingValue<int> m_peerTurnoverCutoff;

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -168,8 +168,6 @@ namespace BitTorrent
 
         virtual bool useTempPath() const = 0;
 
-        virtual bool isAutoTMMEnabled() const = 0;
-        virtual void setAutoTMMEnabled(bool enabled) = 0;
         virtual QString category() const = 0;
         virtual bool belongsToCategory(const QString &category) const = 0;
         virtual bool setCategory(const QString &category) = 0;

--- a/src/base/bittorrent/torrenthandleimpl.h
+++ b/src/base/bittorrent/torrenthandleimpl.h
@@ -111,8 +111,6 @@ namespace BitTorrent
 
         bool useTempPath() const override;
 
-        bool isAutoTMMEnabled() const override;
-        void setAutoTMMEnabled(bool enabled) override;
         QString category() const override;
         bool belongsToCategory(const QString &category) const override;
         bool setCategory(const QString &category) override;
@@ -237,7 +235,6 @@ namespace BitTorrent
         void handleAlert(const lt::alert *a);
         void handleStateUpdate(const lt::torrent_status &nativeStatus);
         void handleTempPathChanged();
-        void handleCategorySavePathChanged();
         void handleAppendExtensionToggled();
         void saveResumeData();
         void handleMoveStorageJobFinished(bool hasOutstandingJob);
@@ -313,7 +310,6 @@ namespace BitTorrent
         bool m_hasMissingFiles = false;
         bool m_hasRootFolder;
         bool m_hasFirstLastPiecePriority = false;
-        bool m_useAutoTMM;
         bool m_isStopped;
 
         bool m_unchecked = false;

--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -397,8 +397,6 @@ void AutoDownloader::processJob(const QSharedPointer<ProcessingJob> &job)
         params.category = rule.assignedCategory();
         params.addPaused = rule.addPaused();
         params.createSubfolder = rule.createSubfolder();
-        if (!rule.savePath().isEmpty())
-            params.useAutoTMM = TriStateBool::False;
         const auto torrentURL = job->articleData.value(Article::KeyTorrentURL).toString();
         BitTorrent::Session::instance()->addTorrent(torrentURL, params);
 

--- a/src/base/scanfoldersmodel.cpp
+++ b/src/base/scanfoldersmodel.cpp
@@ -364,15 +364,9 @@ void ScanFoldersModel::addTorrentsToSession(const QStringList &pathList)
 
         BitTorrent::AddTorrentParams params;
         if (downloadInWatchFolder(file))
-        {
             params.savePath = QFileInfo(file).dir().path();
-            params.useAutoTMM = TriStateBool::False;
-        }
         else if (!downloadInDefaultFolder(file))
-        {
             params.savePath = downloadPathTorrentFolder(file);
-            params.useAutoTMM = TriStateBool::False;
-        }
 
         if (file.endsWith(".magnet", Qt::CaseInsensitive))
         {

--- a/src/gui/addnewtorrentdialog.h
+++ b/src/gui/addnewtorrentdialog.h
@@ -84,7 +84,7 @@ private slots:
     void onSavePathChanged(const QString &newPath);
     void updateMetadata(const BitTorrent::TorrentInfo &metadata);
     void handleDownloadFinished(const Net::DownloadResult &result);
-    void TMMChanged(int index);
+    void onAutoSavePathStateChanged(int state);
     void categoryChanged(int index);
     void doNotDeleteTorrentClicked(bool checked);
 
@@ -104,6 +104,7 @@ private:
     void setMetadataProgressIndicator(bool visibleIndicator, const QString &labelText = {});
     void setupTreeview();
     void setSavePath(const QString &newPath);
+    void setAutoSavePathEnabled(bool enabled);
     void saveTorrentFile();
 
     void showEvent(QShowEvent *event) override;

--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -34,52 +34,21 @@
         <number>0</number>
        </property>
        <item>
-        <layout class="QHBoxLayout" name="managementLayout">
-         <item>
-          <widget class="QLabel" name="labelTorrentManagementMode">
-           <property name="text">
-            <string>Torrent Management Mode:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="comboTTM">
-           <property name="toolTip">
-            <string>Automatic mode means that various torrent properties(eg save path) will be decided by the associated category</string>
-           </property>
-           <item>
-            <property name="text">
-             <string>Manual</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Automatic</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item>
         <widget class="QGroupBox" name="groupBoxSavePath">
          <property name="title">
           <string>Save at</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <widget class="QCheckBox" name="checkBoxAutoSavePath">
+            <property name="text">
+             <string>Assign save path automatically</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
           <item>
            <widget class="FileSystemPathComboEdit" name="savePath" native="true"/>
           </item>
@@ -475,22 +444,6 @@
     <hint type="destinationlabel">
      <x>286</x>
      <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>comboTTM</sender>
-   <signal>currentIndexChanged(int)</signal>
-   <receiver>AddNewTorrentDialog</receiver>
-   <slot>TMMChanged(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>250</x>
-     <y>53</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>467</x>
-     <y>249</y>
     </hint>
    </hints>
   </connection>

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -347,10 +347,6 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     // Downloads tab
     connect(m_ui->textSavePath, &FileSystemPathEdit::selectedPathChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->checkUseSubcategories, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
-    connect(m_ui->comboSavingMode, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
-    connect(m_ui->comboTorrentCategoryChanged, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
-    connect(m_ui->comboCategoryDefaultPathChanged, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
-    connect(m_ui->comboCategoryChanged, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->textTempPath, &FileSystemPathEdit::selectedPathChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->checkAppendqB, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkPreallocateAll, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
@@ -740,10 +736,6 @@ void OptionsDialog::saveOptions()
     // Downloads preferences
     session->setDefaultSavePath(Utils::Fs::expandPathAbs(m_ui->textSavePath->selectedPath()));
     session->setSubcategoriesEnabled(m_ui->checkUseSubcategories->isChecked());
-    session->setAutoTMMDisabledByDefault(m_ui->comboSavingMode->currentIndex() == 0);
-    session->setDisableAutoTMMWhenCategoryChanged(m_ui->comboTorrentCategoryChanged->currentIndex() == 1);
-    session->setDisableAutoTMMWhenCategorySavePathChanged(m_ui->comboCategoryChanged->currentIndex() == 1);
-    session->setDisableAutoTMMWhenDefaultSavePathChanged(m_ui->comboCategoryDefaultPathChanged->currentIndex() == 1);
     session->setTempPathEnabled(m_ui->checkTempFolder->isChecked());
     session->setTempPath(Utils::Fs::expandPathAbs(m_ui->textTempPath->selectedPath()));
     session->setAppendExtensionEnabled(m_ui->checkAppendqB->isChecked());
@@ -1007,10 +999,6 @@ void OptionsDialog::loadOptions()
 
     m_ui->textSavePath->setSelectedPath(session->defaultSavePath());
     m_ui->checkUseSubcategories->setChecked(session->isSubcategoriesEnabled());
-    m_ui->comboSavingMode->setCurrentIndex(!session->isAutoTMMDisabledByDefault());
-    m_ui->comboTorrentCategoryChanged->setCurrentIndex(session->isDisableAutoTMMWhenCategoryChanged());
-    m_ui->comboCategoryChanged->setCurrentIndex(session->isDisableAutoTMMWhenCategorySavePathChanged());
-    m_ui->comboCategoryDefaultPathChanged->setCurrentIndex(session->isDisableAutoTMMWhenDefaultSavePathChanged());
     m_ui->checkTempFolder->setChecked(session->isTempPathEnabled());
     m_ui->textTempPath->setEnabled(m_ui->checkTempFolder->isChecked());
     m_ui->textTempPath->setEnabled(m_ui->checkTempFolder->isChecked());

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -877,182 +877,6 @@
               </property>
               <layout class="QVBoxLayout" name="groupSavingManagementLayout">
                <item>
-                <layout class="QGridLayout" name="gridLayout_3">
-                 <item row="0" column="0">
-                  <widget class="QLabel" name="label_40">
-                   <property name="text">
-                    <string>Default Torrent Management Mode:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1">
-                  <layout class="QHBoxLayout" name="horizontalLayout_70">
-                   <property name="spacing">
-                    <number>10</number>
-                   </property>
-                   <item>
-                    <widget class="QComboBox" name="comboSavingMode">
-                     <property name="toolTip">
-                      <string>Automatic: Various torrent properties (e.g. save path) will be decided by the associated category
-Manual: Various torrent properties (e.g. save path) must be assigned manually</string>
-                     </property>
-                     <item>
-                      <property name="text">
-                       <string>Manual</string>
-                      </property>
-                     </item>
-                     <item>
-                      <property name="text">
-                       <string>Automatic</string>
-                      </property>
-                     </item>
-                    </widget>
-                   </item>
-                   <item>
-                    <spacer name="horizontalSpacer_160">
-                     <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                     </property>
-                     <property name="sizeHint" stdset="0">
-                      <size>
-                       <width>40</width>
-                       <height>20</height>
-                      </size>
-                     </property>
-                    </spacer>
-                   </item>
-                  </layout>
-                 </item>
-                 <item row="1" column="0">
-                  <widget class="QLabel" name="labelTorrentCategoryChanged">
-                   <property name="text">
-                    <string>When Torrent Category changed:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="1">
-                  <layout class="QHBoxLayout" name="horizontalLayout_14">
-                   <item>
-                    <widget class="QComboBox" name="comboTorrentCategoryChanged">
-                     <item>
-                      <property name="text">
-                       <string>Relocate torrent</string>
-                      </property>
-                     </item>
-                     <item>
-                      <property name="text">
-                       <string>Switch torrent to Manual Mode</string>
-                      </property>
-                     </item>
-                    </widget>
-                   </item>
-                   <item>
-                    <spacer name="horizontalSpacer_17">
-                     <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                     </property>
-                     <property name="sizeHint" stdset="0">
-                      <size>
-                       <width>40</width>
-                       <height>20</height>
-                      </size>
-                     </property>
-                    </spacer>
-                   </item>
-                  </layout>
-                 </item>
-                 <item row="2" column="0">
-                  <widget class="QLabel" name="labelCategoryDefaultPathChanged">
-                   <property name="text">
-                    <string>When Default Save Path changed:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="1">
-                  <layout class="QHBoxLayout" name="horizontalLayout_15">
-                   <item>
-                    <widget class="QComboBox" name="comboCategoryDefaultPathChanged">
-                     <property name="currentIndex">
-                      <number>1</number>
-                     </property>
-                     <item>
-                      <property name="text">
-                       <string>Relocate affected torrents</string>
-                      </property>
-                     </item>
-                     <item>
-                      <property name="text">
-                       <string>Switch affected torrents to Manual Mode</string>
-                      </property>
-                     </item>
-                    </widget>
-                   </item>
-                   <item>
-                    <spacer name="horizontalSpacer_18">
-                     <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                     </property>
-                     <property name="sizeHint" stdset="0">
-                      <size>
-                       <width>40</width>
-                       <height>20</height>
-                      </size>
-                     </property>
-                    </spacer>
-                   </item>
-                  </layout>
-                 </item>
-                 <item row="3" column="0">
-                  <widget class="QLabel" name="labelCategoryChanged">
-                   <property name="text">
-                    <string>When Category Save Path changed:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="3" column="1">
-                  <layout class="QHBoxLayout" name="horizontalLayout_17">
-                   <item>
-                    <widget class="QComboBox" name="comboCategoryChanged">
-                     <property name="currentIndex">
-                      <number>1</number>
-                     </property>
-                     <item>
-                      <property name="text">
-                       <string>Relocate affected torrents</string>
-                      </property>
-                     </item>
-                     <item>
-                      <property name="text">
-                       <string>Switch affected torrents to Manual Mode</string>
-                      </property>
-                     </item>
-                    </widget>
-                   </item>
-                   <item>
-                    <spacer name="horizontalSpacer_19">
-                     <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                     </property>
-                     <property name="sizeHint" stdset="0">
-                      <size>
-                       <width>40</width>
-                       <height>20</height>
-                      </size>
-                     </property>
-                    </spacer>
-                   </item>
-                  </layout>
-                 </item>
-                </layout>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="checkUseSubcategories">
-                 <property name="text">
-                  <string>Use Subcategories</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
                 <layout class="QGridLayout" name="gridLayout_4">
                  <item row="1" column="1">
                   <widget class="FileSystemPathLineEdit" name="textTempPath" native="true"/>
@@ -1095,6 +919,13 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
                   <widget class="FileSystemPathLineEdit" name="textExportDir" native="true"/>
                  </item>
                 </layout>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="checkUseSubcategories">
+                 <property name="text">
+                  <string>Use Subcategories</string>
+                 </property>
+                </widget>
                </item>
               </layout>
              </widget>

--- a/src/gui/torrentcreatordialog.cpp
+++ b/src/gui/torrentcreatordialog.cpp
@@ -249,7 +249,6 @@ void TorrentCreatorDialog::handleCreationSuccess(const QString &path, const QStr
             params.ratioLimit = BitTorrent::TorrentHandle::NO_RATIO_LIMIT;
             params.seedingTimeLimit = BitTorrent::TorrentHandle::NO_SEEDING_TIME_LIMIT;
         }
-        params.useAutoTMM = TriStateBool::False;  // otherwise if it is on by default, it will overwrite `savePath` to the default save path
 
         BitTorrent::Session::instance()->addTorrent(info, params);
     }

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -107,7 +107,6 @@ protected slots:
     void setSelectedTorrentsSuperSeeding(bool enabled) const;
     void setSelectedTorrentsSequentialDownload(bool enabled) const;
     void setSelectedFirstLastPiecePrio(bool enabled) const;
-    void setSelectedAutoTMMEnabled(bool enabled) const;
     void askNewCategoryForSelection();
     void saveSettings();
 

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -106,10 +106,6 @@ void AppController::preferencesAction()
     data["preallocate_all"] = session->isPreallocationEnabled();
     data["incomplete_files_ext"] = session->isAppendExtensionEnabled();
     // Saving Management
-    data["auto_tmm_enabled"] = !session->isAutoTMMDisabledByDefault();
-    data["torrent_changed_tmm_enabled"] = !session->isDisableAutoTMMWhenCategoryChanged();
-    data["save_path_changed_tmm_enabled"] = !session->isDisableAutoTMMWhenDefaultSavePathChanged();
-    data["category_changed_tmm_enabled"] = !session->isDisableAutoTMMWhenCategorySavePathChanged();
     data["save_path"] = Utils::Fs::toNativePath(session->defaultSavePath());
     data["temp_path_enabled"] = session->isTempPathEnabled();
     data["temp_path"] = Utils::Fs::toNativePath(session->tempPath());
@@ -366,14 +362,6 @@ void AppController::setPreferencesAction()
         session->setAppendExtensionEnabled(it.value().toBool());
 
     // Saving Management
-    if (hasKey("auto_tmm_enabled"))
-        session->setAutoTMMDisabledByDefault(!it.value().toBool());
-    if (hasKey("torrent_changed_tmm_enabled"))
-        session->setDisableAutoTMMWhenCategoryChanged(!it.value().toBool());
-    if (hasKey("save_path_changed_tmm_enabled"))
-        session->setDisableAutoTMMWhenDefaultSavePathChanged(!it.value().toBool());
-    if (hasKey("category_changed_tmm_enabled"))
-        session->setDisableAutoTMMWhenCategorySavePathChanged(!it.value().toBool());
     if (hasKey("save_path"))
         session->setDefaultSavePath(it.value().toString());
     if (hasKey("temp_path_enabled"))

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -126,7 +126,6 @@ QVariantMap serialize(const BitTorrent::TorrentHandle &torrent)
         {KEY_TORRENT_RATIO_LIMIT, torrent.ratioLimit()},
         {KEY_TORRENT_SEEDING_TIME_LIMIT, torrent.seedingTimeLimit()},
         {KEY_TORRENT_LAST_SEEN_COMPLETE_TIME, torrent.lastSeenComplete().toSecsSinceEpoch()},
-        {KEY_TORRENT_AUTO_TORRENT_MANAGEMENT, torrent.isAutoTMMEnabled()},
         {KEY_TORRENT_TIME_ACTIVE, torrent.activeTime()},
         {KEY_TORRENT_AVAILABILITY, torrent.distributedCopies()},
 

--- a/src/webui/api/serialize/serialize_torrent.h
+++ b/src/webui/api/serialize/serialize_torrent.h
@@ -78,7 +78,6 @@ const char KEY_TORRENT_SEEDING_TIME_LIMIT[] = "seeding_time_limit";
 const char KEY_TORRENT_LAST_SEEN_COMPLETE_TIME[] = "seen_complete";
 const char KEY_TORRENT_LAST_ACTIVITY_TIME[] = "last_activity";
 const char KEY_TORRENT_TOTAL_SIZE[] = "total_size";
-const char KEY_TORRENT_AUTO_TORRENT_MANAGEMENT[] = "auto_tmm";
 const char KEY_TORRENT_TIME_ACTIVE[] = "time_active";
 const char KEY_TORRENT_AVAILABILITY[] = "availability";
 

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -571,7 +571,6 @@ void TorrentsController::addAction()
     const QString torrentName = params()["rename"].trimmed();
     const int upLimit = params()["upLimit"].toInt();
     const int dlLimit = params()["dlLimit"].toInt();
-    const TriStateBool autoTMM = parseTriStateBool(params()["autoTMM"]);
 
     QList<QNetworkCookie> cookies;
     if (!cookie.isEmpty())
@@ -602,7 +601,6 @@ void TorrentsController::addAction()
     params.name = torrentName;
     params.uploadLimit = (upLimit > 0) ? upLimit : -1;
     params.downloadLimit = (dlLimit > 0) ? dlLimit : -1;
-    params.useAutoTMM = autoTMM;
 
     bool partialSuccess = false;
     for (QString url : asConst(urls.split('\n')))
@@ -1030,19 +1028,6 @@ void TorrentsController::renameAction()
 
     name.replace(QRegularExpression("\r?\n|\r"), " ");
     torrent->setName(name);
-}
-
-void TorrentsController::setAutoManagementAction()
-{
-    requireParams({"hashes", "enable"});
-
-    const QStringList hashes {params()["hashes"].split('|')};
-    const bool isEnabled {parseBool(params()["enable"], false)};
-
-    applyToTorrents(hashes, [isEnabled](BitTorrent::TorrentHandle *const torrent)
-    {
-        torrent->setAutoTMMEnabled(isEnabled);
-    });
 }
 
 void TorrentsController::recheckAction()

--- a/src/webui/api/torrentscontroller.h
+++ b/src/webui/api/torrentscontroller.h
@@ -78,7 +78,6 @@ private slots:
     void topPrioAction();
     void bottomPrioAction();
     void setLocationAction();
-    void setAutoManagementAction();
     void setSuperSeedingAction();
     void setForceStartAction();
     void toggleSequentialDownloadAction();


### PR DESCRIPTION
It removes the most unreliable part of automatic save path management, namely automatic movement of torrents when changing related settings (categories, default save path), but keep automatic path assignment when adding a torrent.

![001](https://user-images.githubusercontent.com/5063477/99870348-7545a080-2be3-11eb-9e1d-c34495a70b7a.png)

![002](https://user-images.githubusercontent.com/5063477/99870351-77a7fa80-2be3-11eb-9120-ab8ad0fced7f.png)

Now it satisfies to my last conclusions that it is of little use that some action explicitly applied by the user causes some additional (so-called "automatic") actions (especially such potentially dangerous actions as moving files). The user can (and should) do this manually as well. This will give them more control over what is happening and will avoid the troubles associated with the mass movement of torrents.
Also, this simplification of internal logic will allow me to implement my other changes (replace "Temporary folder" feature with "Move torrent on completion" one) in the most consistent way.