### PR TITLE
Fix confusion in date format description

### DIFF
--- a/src/gui/rss/automatedrssdownloader.ui
+++ b/src/gui/rss/automatedrssdownloader.ui
@@ -184,7 +184,7 @@
            <widget class="QCheckBox" name="checkSmart">
             <property name="toolTip">
              <string>Smart Episode Filter will check the episode number to prevent downloading of duplicates.
-Supports the formats: S01E01, 1x1, 2017.01.01 and 01.01.2017 (Date formats also support - as a separator)</string>
+Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also support - as a separator)</string>
             </property>
             <property name="text">
              <string>Use Smart Episode Filter</string>

--- a/src/webui/www/private/views/rssDownloader.html
+++ b/src/webui/www/private/views/rssDownloader.html
@@ -189,7 +189,7 @@
                 </tr>
             </table>
             <div class="formRow" title="QBT_TR(Smart Episode Filter will check the episode number to prevent downloading of duplicates.
-Supports the formats: S01E01, 1x1, 2017.01.01 and 01.01.2017 (Date formats also support - as a separator))QBT_TR[CONTEXT=AutomatedRssDownloader]">
+Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also support - as a separator))QBT_TR[CONTEXT=AutomatedRssDownloader]">
                 <input disabled type="checkbox" id="useSmartFilter" />
                 <label for="useSmartFilter">QBT_TR(Use Smart Episode Filter)QBT_TR[CONTEXT=AutomatedRssDownloader]</label>
             </div>


### PR DESCRIPTION
Change date notation from
**2017.01.01 and 01.01.2017**
to
**2017.12.31 and 31.12.2017**
to prevent confusion between "MM" and "DD".

@glassez This pull request should be only one commit. I used squash in my own fork on GitHub, using separate branches. This seems to work in the online editor, but needs some preparation on my side. I closed my previous pull request because some stuff went wrong and reverting commits creates new commits... so.