### PR TITLE
Fix wrong data used for comparison

### DIFF
--- a/src/gui/torrentcontentfiltermodel.cpp
+++ b/src/gui/torrentcontentfiltermodel.cpp
@@ -42,6 +42,7 @@ TorrentContentFilterModel::TorrentContentFilterModel(QObject *parent)
     setFilterRole(TorrentContentModel::UnderlyingDataRole);
     setDynamicSortFilter(true);
     setSortCaseSensitivity(Qt::CaseInsensitive);
+    setSortRole(TorrentContentModel::UnderlyingDataRole);
 }
 
 TorrentContentModel *TorrentContentFilterModel::model() const

--- a/src/gui/transferlistsortmodel.cpp
+++ b/src/gui/transferlistsortmodel.cpp
@@ -41,6 +41,7 @@
 TransferListSortModel::TransferListSortModel(QObject *parent)
     : QSortFilterProxyModel {parent}
 {
+    setSortRole(TransferListModel::UnderlyingDataRole);
     QMetaType::registerComparators<BitTorrent::TorrentState>();
 }
 


### PR DESCRIPTION
In torrent transfer list we should use underlying data for sorting, not displayed values.

Closes #13818.