### PR TITLE
Update to use latest macOS image for TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
   - osx
 
 dist: bionic
+osx_image: xcode12.2
 
 env:
   matrix:


### PR DESCRIPTION
The default version is so outdated that it needs to rebuild many dependencies. Now we bump it to the latest version so that it can use prebuilt packages.