### PR TITLE
Don't try to remove folders for a torrent without metadata

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -4704,17 +4704,17 @@ void Session::handleTorrentDeleteFailedAlert(const lt::torrent_delete_failed_ale
     if (removingTorrentDataIter == m_removingTorrents.end())
         return;
 
-    // libtorrent won't delete the directory if it contains files not listed in the torrent,
-    // so we remove the directory ourselves
-    Utils::Fs::smartRemoveEmptyFolderTree(removingTorrentDataIter->pathToRemove);
-
     if (p->error)
     {
+        // libtorrent won't delete the directory if it contains files not listed in the torrent,
+        // so we remove the directory ourselves
+        Utils::Fs::smartRemoveEmptyFolderTree(removingTorrentDataIter->pathToRemove);
+
         LogMsg(tr("'%1' was removed from the transfer list but the files couldn't be deleted. Error: %2", "'xxx.avi' was removed...")
                 .arg(removingTorrentDataIter->name, QString::fromLocal8Bit(p->error.message().c_str()))
             , Log::WARNING);
     }
-    else
+    else // torrent without metadata, hence no files on disk
     {
         LogMsg(tr("'%1' was removed from the transfer list.", "'xxx.avi' was removed...").arg(removingTorrentDataIter->name));
     }


### PR DESCRIPTION
I discovered this by accident and due to the architectural changes from 4.2.5 to 4.3.0.
In my setup the value of `removingTorrentDataIter->pathToRemove` ended up being the root of my drive (eg `G:\`). Hence `smartRemoveEmptyFolderTree` started scanning the whole drive and qbt froze.

This affects magnets only.
For multifile torrents that are saved in the root of a drive without a toplevel folder the value of `removingTorrentDataIter->pathToRemove` is empty. For singlefile torrents the value is the entire path containing the single file too.