### PR TITLE
WebAPI: allow to attach tags while adding torrents

### DIFF
--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -567,6 +567,7 @@ void TorrentsController::addAction()
     const TriStateBool rootFolder = parseTriStateBool(params()["root_folder"]);
     const QString savepath = params()["savepath"].trimmed();
     const QString category = params()["category"];
+    const QSet<QString> tags = List::toSet(params()["tags"].split(',', QString::SkipEmptyParts));
     const QString cookie = params()["cookie"];
     const QString torrentName = params()["rename"].trimmed();
     const int upLimit = params()["upLimit"].toInt();
@@ -599,6 +600,7 @@ void TorrentsController::addAction()
     params.createSubfolder = rootFolder;
     params.savePath = savepath;
     params.category = category;
+    params.tags = tags;
     params.name = torrentName;
     params.uploadLimit = (upLimit > 0) ? upLimit : -1;
     params.downloadLimit = (dlLimit > 0) ? dlLimit : -1;

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -43,7 +43,7 @@
 #include "base/utils/net.h"
 #include "base/utils/version.h"
 
-constexpr Utils::Version<int, 3, 2> API_VERSION {2, 6, 1};
+constexpr Utils::Version<int, 3, 2> API_VERSION {2, 6, 2};
 
 class APIController;
 class WebApplication;


### PR DESCRIPTION
Adds an optional (some may say `missing`) field to `/torrents/add` WebAPI endpoint.

Both no-tag and with-tags cases are tested manually. The change works as intended.