### PR TITLE
Find existing files in separate thread

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(qbt_base STATIC
     bittorrent/common.h
     bittorrent/customstorage.h
     bittorrent/downloadpriority.h
+    bittorrent/filesearcher.h
     bittorrent/filterparserthread.h
     bittorrent/infohash.h
     bittorrent/ltqhash.h
@@ -90,6 +91,7 @@ add_library(qbt_base STATIC
     bittorrent/bandwidthscheduler.cpp
     bittorrent/customstorage.cpp
     bittorrent/downloadpriority.cpp
+    bittorrent/filesearcher.cpp
     bittorrent/filterparserthread.cpp
     bittorrent/infohash.cpp
     bittorrent/magneturi.cpp

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -7,6 +7,7 @@ HEADERS += \
     $$PWD/bittorrent/common.h \
     $$PWD/bittorrent/customstorage.h \
     $$PWD/bittorrent/downloadpriority.h \
+    $$PWD/bittorrent/filesearcher.h \
     $$PWD/bittorrent/filterparserthread.h \
     $$PWD/bittorrent/infohash.h \
     $$PWD/bittorrent/ltqhash.h \
@@ -90,6 +91,7 @@ SOURCES += \
     $$PWD/bittorrent/bandwidthscheduler.cpp \
     $$PWD/bittorrent/customstorage.cpp \
     $$PWD/bittorrent/downloadpriority.cpp \
+    $$PWD/bittorrent/filesearcher.cpp \
     $$PWD/bittorrent/filterparserthread.cpp \
     $$PWD/bittorrent/infohash.cpp \
     $$PWD/bittorrent/magneturi.cpp \

--- a/src/base/bittorrent/filesearcher.h
+++ b/src/base/bittorrent/filesearcher.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2020  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -28,40 +28,25 @@
 
 #pragma once
 
-#include <libtorrent/sha1_hash.hpp>
-
-#include <QMetaType>
-#include <QString>
+#include <QObject>
 
 namespace BitTorrent
 {
-    class InfoHash
-    {
-    public:
-        InfoHash();
-        InfoHash(const lt::sha1_hash &nativeHash);
-        InfoHash(const QString &hashString);
-        InfoHash(const InfoHash &other) = default;
-
-        static constexpr int length()
-        {
-            return lt::sha1_hash::size();
-        }
-
-        bool isValid() const;
-
-        operator lt::sha1_hash() const;
-        operator QString() const;
-
-    private:
-        bool m_valid;
-        lt::sha1_hash m_nativeHash;
-        QString m_hashString;
-    };
-
-    bool operator==(const InfoHash &left, const InfoHash &right);
-    bool operator!=(const InfoHash &left, const InfoHash &right);
-    uint qHash(const InfoHash &key, uint seed);
+    class InfoHash;
 }
 
-Q_DECLARE_METATYPE(BitTorrent::InfoHash)
+class FileSearcher final : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY(FileSearcher)
+
+public:
+    FileSearcher() = default;
+
+public slots:
+    void search(const BitTorrent::InfoHash &id, const QStringList &originalFileNames
+                , const QString &completeSavePath, const QString &incompleteSavePath);
+
+signals:
+    void searchFinished(const BitTorrent::InfoHash &id, const QString &savePath, const QStringList &fileNames);
+};

--- a/src/base/bittorrent/infohash.cpp
+++ b/src/base/bittorrent/infohash.cpp
@@ -33,6 +33,8 @@
 
 using namespace BitTorrent;
 
+const int InfoHashTypeId = qRegisterMetaType<InfoHash>();
+
 InfoHash::InfoHash()
     : m_valid(false)
 {

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -593,11 +593,11 @@ void Session::setAppendExtensionEnabled(const bool enabled)
 {
     if (isAppendExtensionEnabled() != enabled)
     {
+        m_isAppendExtensionEnabled = enabled;
+
         // append or remove .!qB extension for incomplete files
         for (TorrentHandleImpl *const torrent : asConst(m_torrents))
             torrent->handleAppendExtensionToggled();
-
-        m_isAppendExtensionEnabled = enabled;
     }
 }
 

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -453,8 +453,8 @@ namespace BitTorrent
         bool addTorrent(const MagnetUri &magnetUri, const AddTorrentParams &params = AddTorrentParams());
         bool addTorrent(const TorrentInfo &torrentInfo, const AddTorrentParams &params = AddTorrentParams());
         bool deleteTorrent(const InfoHash &hash, DeleteOption deleteOption = Torrent);
-        bool loadMetadata(const MagnetUri &magnetUri);
-        bool cancelLoadMetadata(const InfoHash &hash);
+        bool downloadMetadata(const MagnetUri &magnetUri);
+        bool cancelDownloadMetadata(const InfoHash &hash);
 
         void recursiveTorrentDownload(const InfoHash &hash);
         void increaseTorrentsQueuePos(const QVector<InfoHash> &hashes);
@@ -497,7 +497,7 @@ namespace BitTorrent
         void fullDiskError(TorrentHandle *torrent, const QString &msg);
         void IPFilterParsed(bool error, int ruleCount);
         void loadTorrentFailed(const QString &error);
-        void metadataLoaded(const TorrentInfo &info);
+        void metadataDownloaded(const TorrentInfo &info);
         void recursiveTorrentDownloadPossible(TorrentHandle *torrent);
         void speedLimitModeChanged(bool alternative);
         void statsUpdated();
@@ -764,7 +764,7 @@ namespace BitTorrent
         QThread *m_ioThread = nullptr;
         ResumeDataSavingManager *m_resumeDataSavingManager = nullptr;
 
-        QSet<InfoHash> m_loadedMetadata;
+        QSet<InfoHash> m_downloadedMetadata;
 
         QHash<InfoHash, TorrentHandleImpl *> m_torrents;
         QHash<InfoHash, LoadTorrentParams> m_loadingTorrents;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -64,6 +64,7 @@ class QTimer;
 class QUrl;
 
 class BandwidthScheduler;
+class FileSearcher;
 class FilterParserThread;
 class ResumeDataSavingManager;
 class Statistics;
@@ -488,6 +489,8 @@ namespace BitTorrent
 
         bool addMoveTorrentStorageJob(TorrentHandleImpl *torrent, const QString &newPath, MoveStorageMode mode);
 
+        void findIncompleteFiles(const TorrentInfo &torrentInfo, const QString &savePath) const;
+
     signals:
         void allTorrentsFinished();
         void categoryAdded(const QString &categoryName);
@@ -510,7 +513,7 @@ namespace BitTorrent
         void torrentFinished(TorrentHandle *torrent);
         void torrentFinishedChecking(TorrentHandle *torrent);
         void torrentLoaded(TorrentHandle *torrent);
-        void torrentMetadataLoaded(TorrentHandle *torrent);
+        void torrentMetadataReceived(TorrentHandle *torrent);
         void torrentPaused(TorrentHandle *torrent);
         void torrentResumed(TorrentHandle *torrent);
         void torrentSavePathChanged(TorrentHandle *torrent);
@@ -537,6 +540,7 @@ namespace BitTorrent
         void handleIPFilterParsed(int ruleCount);
         void handleIPFilterError();
         void handleDownloadFinished(const Net::DownloadResult &result);
+        void fileSearchFinished(const InfoHash &id, const QString &savePath, const QStringList &fileNames);
 
         // Session reconfiguration triggers
         void networkOnlineStateChanged(bool online);
@@ -593,7 +597,6 @@ namespace BitTorrent
         bool loadTorrent(LoadTorrentParams params);
         LoadTorrentParams initLoadTorrentParams(const AddTorrentParams &addTorrentParams);
         bool addTorrent_impl(const AddTorrentParams &addTorrentParams, const MagnetUri &magnetUri, TorrentInfo torrentInfo = TorrentInfo());
-        bool findIncompleteFiles(TorrentInfo &torrentInfo, QString &savePath) const;
 
         void updateSeedingLimitTimer();
         void exportTorrentFile(const TorrentHandle *torrent, TorrentExportFolder folder = TorrentExportFolder::Regular);
@@ -763,6 +766,7 @@ namespace BitTorrent
         // fastresume data writing thread
         QThread *m_ioThread = nullptr;
         ResumeDataSavingManager *m_resumeDataSavingManager = nullptr;
+        FileSearcher *m_fileSearcher = nullptr;
 
         QSet<InfoHash> m_downloadedMetadata;
 

--- a/src/base/bittorrent/torrenthandleimpl.h
+++ b/src/base/bittorrent/torrenthandleimpl.h
@@ -250,7 +250,6 @@ namespace BitTorrent
         void updateStatus();
         void updateStatus(const lt::torrent_status &nativeStatus);
         void updateState();
-        void updateTorrentInfo();
 
         void handleFastResumeRejectedAlert(const lt::fastresume_rejected_alert *p);
         void handleFileCompletedAlert(const lt::file_completed_alert *p);

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -347,7 +347,7 @@ bool AddNewTorrentDialog::loadMagnet(const BitTorrent::MagnetUri &magnetUri)
         return false;
     }
 
-    connect(BitTorrent::Session::instance(), &BitTorrent::Session::metadataLoaded, this, &AddNewTorrentDialog::updateMetadata);
+    connect(BitTorrent::Session::instance(), &BitTorrent::Session::metadataDownloaded, this, &AddNewTorrentDialog::updateMetadata);
 
     // Set dialog title
     const QString torrentName = magnetUri.name();
@@ -356,7 +356,7 @@ bool AddNewTorrentDialog::loadMagnet(const BitTorrent::MagnetUri &magnetUri)
     setupTreeview();
     TMMChanged(m_ui->comboTTM->currentIndex());
 
-    BitTorrent::Session::instance()->loadMetadata(magnetUri);
+    BitTorrent::Session::instance()->downloadMetadata(magnetUri);
     setMetadataProgressIndicator(true, tr("Retrieving metadata..."));
     m_ui->labelHashData->setText(infoHash);
 
@@ -613,7 +613,7 @@ void AddNewTorrentDialog::reject()
     if (!m_hasMetadata)
     {
         setMetadataProgressIndicator(false);
-        BitTorrent::Session::instance()->cancelLoadMetadata(m_magnetURI.hash());
+        BitTorrent::Session::instance()->cancelDownloadMetadata(m_magnetURI.hash());
     }
 
     QDialog::reject();
@@ -623,7 +623,7 @@ void AddNewTorrentDialog::updateMetadata(const BitTorrent::TorrentInfo &metadata
 {
     if (metadata.hash() != m_magnetURI.hash()) return;
 
-    disconnect(BitTorrent::Session::instance(), &BitTorrent::Session::metadataLoaded, this, &AddNewTorrentDialog::updateMetadata);
+    disconnect(BitTorrent::Session::instance(), &BitTorrent::Session::metadataDownloaded, this, &AddNewTorrentDialog::updateMetadata);
 
     if (!metadata.isValid())
     {

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -104,7 +104,7 @@ PropertiesWidget::PropertiesWidget(QWidget *parent)
     connect(m_propListDelegate, &PropListDelegate::filteredFilesChanged, this, &PropertiesWidget::filteredFilesChanged);
     connect(m_ui->stackedProperties, &QStackedWidget::currentChanged, this, &PropertiesWidget::loadDynamicData);
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::torrentSavePathChanged, this, &PropertiesWidget::updateSavePath);
-    connect(BitTorrent::Session::instance(), &BitTorrent::Session::torrentMetadataLoaded, this, &PropertiesWidget::updateTorrentInfos);
+    connect(BitTorrent::Session::instance(), &BitTorrent::Session::torrentMetadataReceived, this, &PropertiesWidget::updateTorrentInfos);
     connect(m_ui->filesList, &QAbstractItemView::clicked
             , m_ui->filesList, qOverload<const QModelIndex &>(&QAbstractItemView::edit));
     connect(m_ui->filesList, &QWidget::customContextMenuRequested, this, &PropertiesWidget::displayFilesListMenu);
@@ -404,7 +404,7 @@ void PropertiesWidget::loadDynamicData()
     switch (m_ui->stackedProperties->currentIndex())
     {
     case PropTabBar::MainTab:
-    {
+        {
             m_ui->labelWastedVal->setText(Utils::Misc::friendlyUnit(m_torrent->wastedSize()));
 
             m_ui->labelUpTotalVal->setText(tr("%1 (%2 this session)").arg(Utils::Misc::friendlyUnit(m_torrent->totalUpload())

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -142,7 +142,7 @@ TransferListModel::TransferListModel(QObject *parent)
     connect(Session::instance(), &Session::torrentsUpdated, this, &TransferListModel::handleTorrentsUpdated);
 
     connect(Session::instance(), &Session::torrentFinished, this, &TransferListModel::handleTorrentStatusUpdated);
-    connect(Session::instance(), &Session::torrentMetadataLoaded, this, &TransferListModel::handleTorrentStatusUpdated);
+    connect(Session::instance(), &Session::torrentMetadataReceived, this, &TransferListModel::handleTorrentStatusUpdated);
     connect(Session::instance(), &Session::torrentResumed, this, &TransferListModel::handleTorrentStatusUpdated);
     connect(Session::instance(), &Session::torrentPaused, this, &TransferListModel::handleTorrentStatusUpdated);
     connect(Session::instance(), &Session::torrentFinishedChecking, this, &TransferListModel::handleTorrentStatusUpdated);


### PR DESCRIPTION
These are fixes, improvements and cleanups that I made along the way to solve the problem of processing the received metadata (still in progress).
They have an independent value, so I don't want them to wait for the main part to finish.

For testers:
It should correctly find existing files (both with and without .!qb extensions, and located in a temporary folder if there are no files in the main folder) when adding a torrent. In other words, it should behave like a master, except that the files are searched in a separate thread. If there are a large number of files in the torrent, it may cause a certain interval between adding the torrent and the moment when it appears in the list (instead of hanging the interface in the master).
Please also note if there are any regressions.