### PR TITLE
Fix received metadata handling

### DIFF
--- a/src/base/bittorrent/nativetorrentextension.cpp
+++ b/src/base/bittorrent/nativetorrentextension.cpp
@@ -52,3 +52,11 @@ bool NativeTorrentExtension::on_pause()
     // and other extensions to be also invoked.
     return false;
 }
+
+void NativeTorrentExtension::on_state(const lt::torrent_status::state_t state)
+{
+    if (m_state == lt::torrent_status::downloading_metadata)
+        m_torrentHandle.set_flags(lt::torrent_flags::stop_when_ready);
+
+    m_state = state;
+}

--- a/src/base/bittorrent/nativetorrentextension.h
+++ b/src/base/bittorrent/nativetorrentextension.h
@@ -38,6 +38,8 @@ public:
 
 private:
     bool on_pause() override;
+    void on_state(lt::torrent_status::state_t state) override;
 
     lt::torrent_handle m_torrentHandle;
+    lt::torrent_status::state_t m_state = lt::torrent_status::checking_resume_data;
 };

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1774,6 +1774,13 @@ void Session::handleDownloadFinished(const Net::DownloadResult &result)
 
 void Session::fileSearchFinished(const InfoHash &id, const QString &savePath, const QStringList &fileNames)
 {
+    TorrentHandleImpl *torrent = m_torrents.value(id);
+    if (torrent)
+    {
+        torrent->fileSearchFinished(savePath, fileNames);
+        return;
+    }
+
     const auto loadingTorrentsIter = m_loadingTorrents.find(id);
     if (loadingTorrentsIter != m_loadingTorrents.end())
     {
@@ -4595,7 +4602,7 @@ void Session::createTorrentHandle(const lt::torrent_handle &nativeHandle)
 
     const LoadTorrentParams params = m_loadingTorrents.take(nativeHandle.info_hash());
 
-    auto *const torrent = new TorrentHandleImpl {this, nativeHandle, params};
+    auto *const torrent = new TorrentHandleImpl {this, m_nativeSession, nativeHandle, params};
     m_torrents.insert(torrent->hash(), torrent);
 
     const bool hasMetadata = torrent->hasMetadata();


### PR DESCRIPTION
This is a reincarnation of the last attempt to fix/improve received metadata handling (#13736).
Now torrent is reloaded internally once metadata is received to correctly apply all needed logic of preprocessing torrent content and finding probably existing files left from previous incomplete download.
Right now, detecting existing files should work the same regardless of how the torrent is added (using .torrent file or Magnet link).

Also, the implemented mechanisms should serve as a basis for future improvements in other aspects (for example, resuming "Missing files" torrent downloads without rechecking).