### PR TITLE
Fix method invocation on Qt < 5.10

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -2278,7 +2278,7 @@ void Session::findIncompleteFiles(const TorrentInfo &torrentInfo, const QString 
     });
 #else
     QMetaObject::invokeMethod(m_fileSearcher, "search"
-                              , Q_ARG(InfoHash, searchId), Q_ARG(QStringList, originalFileNames)
+                              , Q_ARG(BitTorrent::InfoHash, searchId), Q_ARG(QStringList, originalFileNames)
                               , Q_ARG(QString, completeSavePath), Q_ARG(QString, incompleteSavePath));
 #endif
 }


### PR DESCRIPTION
Fixup 0c3fe54b0ba25c8f24fe50a41cf7ab797d53932f

---

I had not tested https://github.com/qbittorrent/qBittorrent/pull/13894 on Ubuntu 18.04 (it has Qt 5.9.5), only on other systems which all had Qt >= 5.10.

Torrents were silently failing to load, with this message being printed to terminal:

```
QMetaObject::invokeMethod: No such method FileSearcher::search(InfoHash,QStringList,QString,QString)
Candidates are:
    search(BitTorrent::InfoHash,QStringList,QString,QString)
```

Luckily, as the message implies, the fix is trivial.