### PR TITLE
Don't copy QChar in for loop

### DIFF
--- a/src/base/utils/string.h
+++ b/src/base/utils/string.h
@@ -58,7 +58,7 @@ namespace Utils
         {
             if (str.length() < 2) return str;
 
-            for (const QChar quote : quotes)
+            for (const QChar &quote : quotes)
             {
                 if (str.startsWith(quote) && str.endsWith(quote))
                     return str.mid(1, (str.length() - 2));


### PR DESCRIPTION
Fix '-Wrange-loop-analysis' warning appeared at least on macOS

There are a lot of same warnings (but from different source files) are produced during compilation, and all of them are came from the one place. The example of that warning goes below.
```
/Users/nick/Documents/Qt/qbt/qBittorrent/src/base/utils/string.h:61: warning: loop variable 'quote' of type 'const QChar' creates a copy from type 'const QChar' [-Wrange-loop-analysis]
In file included from ../../qBittorrent/src/app/application.cpp:83:
../../qBittorrent/src/base/utils/string.h:61:30: warning: loop variable 'quote' of type 'const QChar' creates a copy from type 'const QChar' [-Wrange-loop-analysis]
            for (const QChar quote : quotes)
                             ^
../../qBittorrent/src/base/utils/string.h:61:18: note: use reference type 'const QChar &' to prevent copying
            for (const QChar quote : quotes)
                 ^~~~~~~~~~~~~~~~~~~
                             &
```
Warnings appear at least with Qt 5.15.x and Xcode 11.7 or Xcode 12.x. These warnings are not related to Qt obsolete/deprecated APIs.