### PR TITLE
CMake: fix MSVC __cplusplus

### DIFF
--- a/cmake/Modules/MacroQbtCommonConfig.cmake
+++ b/cmake/Modules/MacroQbtCommonConfig.cmake
@@ -79,6 +79,8 @@ macro(qbt_common_config)
         target_compile_options(qbt_common_cfg INTERFACE
             /guard:cf
             /utf-8
+            # https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
+            /Zc:__cplusplus
         )
         target_link_options(qbt_common_cfg INTERFACE
             /guard:cf


### PR DESCRIPTION
---

See this comment onward in the libtorrent issue tracker: https://github.com/arvidn/libtorrent/issues/5114#issuecomment-740586691.

Basically, this prevents deprecation warnings due to erroneous values of the `__cplusplus` macro on MSVC. See https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/ for more info. The only reason this is not default is because otherwise it would break legacy code relying on MSVC to always setting this to the same value.

I realize the commit title might not be the best, open to suggestions.