### PR TITLE
Use Qt provided forward declaration header

### DIFF
--- a/src/app/filelogger.cpp
+++ b/src/app/filelogger.cpp
@@ -33,6 +33,7 @@
 #include <QDateTime>
 #include <QDir>
 #include <QTextStream>
+#include <QVector>
 
 #include "base/global.h"
 #include "base/logger.h"

--- a/src/app/upgrade.cpp
+++ b/src/app/upgrade.cpp
@@ -29,6 +29,7 @@
 #include "upgrade.h"
 
 #include <QFile>
+#include <QVector>
 
 #include "base/logger.h"
 #include "base/profile.h"

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -41,6 +41,7 @@
 #include <QHash>
 #include <QPointer>
 #include <QSet>
+#include <QtContainerFwd>
 #include <QVector>
 
 #include "base/settingvalue.h"
@@ -58,7 +59,6 @@ class QFile;
 class QNetworkConfiguration;
 class QNetworkConfigurationManager;
 class QString;
-class QStringList;
 class QThread;
 class QTimer;
 class QUrl;

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -31,6 +31,8 @@
 
 #include <type_traits>
 
+#include <QHash>
+
 namespace BitTorrent
 {
     uint qHash(const TorrentState key, const uint seed)

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -29,15 +29,12 @@
 
 #pragma once
 
-#include <QHash>
 #include <QMetaType>
-#include <QSet>
 #include <QString>
-#include <QVector>
+#include <QtContainerFwd>
 
 class QBitArray;
 class QDateTime;
-class QStringList;
 class QUrl;
 
 namespace BitTorrent

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -40,6 +40,7 @@
 #include <QString>
 #include <QStringList>
 #include <QUrl>
+#include <QVector>
 
 #include "base/exceptions.h"
 #include "base/global.h"

--- a/src/base/bittorrent/torrentinfo.h
+++ b/src/base/bittorrent/torrentinfo.h
@@ -32,14 +32,13 @@
 #include <libtorrent/torrent_info.hpp>
 
 #include <QCoreApplication>
-#include <QVector>
+#include <QtContainerFwd>
 
 #include "base/indexrange.h"
 
 class QByteArray;
 class QDateTime;
 class QString;
-class QStringList;
 class QUrl;
 
 namespace BitTorrent

--- a/src/base/filesystemwatcher.h
+++ b/src/base/filesystemwatcher.h
@@ -32,10 +32,9 @@
 #include <QDir>
 #include <QFileSystemWatcher>
 #include <QHash>
+#include <QtContainerFwd>
 #include <QTimer>
 #include <QVector>
-
-class QStringList;
 
 /*
  * Subclassing QFileSystemWatcher in order to support Network File

--- a/src/base/logger.cpp
+++ b/src/base/logger.cpp
@@ -31,6 +31,7 @@
 #include <algorithm>
 
 #include <QDateTime>
+#include <QVector>
 
 namespace
 {

--- a/src/base/logger.h
+++ b/src/base/logger.h
@@ -34,7 +34,7 @@
 #include <QObject>
 #include <QReadWriteLock>
 #include <QString>
-#include <QVector>
+#include <QtContainerFwd>
 
 const int MAX_LOG_MESSAGES = 20000;
 

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -41,6 +41,7 @@
 #include <QCoreApplication>
 #include <QDateTime>
 #include <QDir>
+#include <QList>
 #include <QLocale>
 #include <QNetworkCookie>
 #include <QSettings>

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -30,16 +30,15 @@
 #ifndef PREFERENCES_H
 #define PREFERENCES_H
 
-#include <QList>
+#include <QtContainerFwd>
+#include <QVariant>
 
 #include "base/utils/net.h"
 
 class QDateTime;
 class QNetworkCookie;
 class QSize;
-class QStringList;
 class QTime;
-class QVariant;
 
 enum SchedulerDays
 {

--- a/src/base/scanfoldersmodel.h
+++ b/src/base/scanfoldersmodel.h
@@ -31,8 +31,7 @@
 
 #include <QAbstractListModel>
 #include <QList>
-
-class QStringList;
+#include <QtContainerFwd>
 
 class FileSystemWatcher;
 

--- a/src/base/search/searchhandler.cpp
+++ b/src/base/search/searchhandler.cpp
@@ -31,6 +31,7 @@
 
 #include <QProcess>
 #include <QTimer>
+#include <QVector>
 
 #include "base/global.h"
 #include "base/utils/foreignapps.h"

--- a/src/base/search/searchhandler.h
+++ b/src/base/search/searchhandler.h
@@ -33,7 +33,7 @@
 #include <QList>
 #include <QObject>
 #include <QString>
-#include <QVector>
+#include <QtContainerFwd>
 
 class QProcess;
 class QTimer;

--- a/src/base/types.h
+++ b/src/base/types.h
@@ -29,7 +29,7 @@
 #ifndef TYPES_H
 #define TYPES_H
 
-#include <QMap>
+#include <QtContainerFwd>
 
 const qlonglong MAX_ETA = 8640000;
 

--- a/src/base/utils/bytearray.cpp
+++ b/src/base/utils/bytearray.cpp
@@ -29,6 +29,7 @@
 #include "bytearray.h"
 
 #include <QByteArray>
+#include <QVector>
 
 QVector<QByteArray> Utils::ByteArray::splitToViews(const QByteArray &in, const QByteArray &sep, const QString::SplitBehavior behavior)
 {

--- a/src/base/utils/bytearray.h
+++ b/src/base/utils/bytearray.h
@@ -29,7 +29,7 @@
 #pragma once
 
 #include <QString>
-#include <QVector>
+#include <QtContainerFwd>
 
 class QByteArray;
 

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -52,6 +52,7 @@
 #include <QRegularExpression>
 #include <QSet>
 #include <QSysInfo>
+#include <QVector>
 
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)) && defined(QT_DBUS_LIB)
 #include <QDBusInterface>

--- a/src/base/utils/net.cpp
+++ b/src/base/utils/net.cpp
@@ -28,10 +28,13 @@
 
 #include "net.h"
 
+#include <QList>
 #include <QNetworkInterface>
+#include <QPair>
 #include <QSslCertificate>
 #include <QSslKey>
 #include <QString>
+#include <QVector>
 
 namespace Utils
 {

--- a/src/base/utils/net.h
+++ b/src/base/utils/net.h
@@ -30,9 +30,7 @@
 #define BASE_UTILS_NET_H
 
 #include <QHostAddress>
-#include <QList>
-#include <QPair>
-#include <QVector>
+#include <QtContainerFwd>
 
 class QSslCertificate;
 class QSslKey;

--- a/src/base/utils/password.cpp
+++ b/src/base/utils/password.cpp
@@ -34,6 +34,7 @@
 
 #include <QByteArray>
 #include <QString>
+#include <QVector>
 
 #include "bytearray.h"
 #include "random.h"

--- a/src/base/utils/string.cpp
+++ b/src/base/utils/string.cpp
@@ -35,6 +35,7 @@
 #include <QLocale>
 #include <QRegExp>
 #include <QtGlobal>
+#include <QVector>
 
 #if defined(Q_OS_MACOS) || defined(__MINGW32__)
 #define QBT_USES_QTHREADSTORAGE

--- a/src/base/utils/string.h
+++ b/src/base/utils/string.h
@@ -31,9 +31,10 @@
 #define UTILS_STRING_H
 
 #include <QChar>
-#include <QVector>
+#include <QString>
+#include <Qt>
+#include <QtContainerFwd>
 
-class QString;
 class QStringRef;
 
 class TriStateBool;

--- a/src/gui/fspathedit_p.h
+++ b/src/gui/fspathedit_p.h
@@ -32,15 +32,14 @@
 #include <QComboBox>
 #include <QFileIconProvider>
 #include <QLineEdit>
+#include <QtContainerFwd>
 #include <QValidator>
-#include <QVector>
 
 class QAction;
 class QCompleter;
 class QContextMenuEvent;
 class QFileSystemModel;
 class QKeyEvent;
-class QStringList;
 class QStringRef;
 
 namespace Private

--- a/src/gui/properties/downloadedpiecesbar.cpp
+++ b/src/gui/properties/downloadedpiecesbar.cpp
@@ -31,6 +31,7 @@
 #include <cmath>
 
 #include <QDebug>
+#include <QVector>
 
 namespace
 {

--- a/src/gui/properties/downloadedpiecesbar.h
+++ b/src/gui/properties/downloadedpiecesbar.h
@@ -30,7 +30,7 @@
 #define DOWNLOADEDPIECESBAR_H
 
 #include <QBitArray>
-#include <QVector>
+#include <QtContainerFwd>
 
 #include "piecesbar.h"
 

--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -42,6 +42,7 @@
 #include <QTableView>
 #include <QTreeWidgetItem>
 #include <QUrl>
+#include <QVector>
 
 #include "base/bittorrent/peerinfo.h"
 #include "base/bittorrent/session.h"

--- a/src/gui/properties/trackerlistwidget.h
+++ b/src/gui/properties/trackerlistwidget.h
@@ -30,7 +30,7 @@
 #define TRACKERLIST_H
 
 #include <QTreeWidget>
-#include <QVector>
+#include <QtContainerFwd>
 
 class PropertiesWidget;
 

--- a/src/gui/properties/trackersadditiondialog.h
+++ b/src/gui/properties/trackersadditiondialog.h
@@ -30,9 +30,9 @@
 #define TRACKERSADDITION_H
 
 #include <QDialog>
+#include <QtContainerFwd>
 
 class QString;
-class QStringList;
 
 namespace BitTorrent
 {

--- a/src/gui/search/pluginselectdialog.h
+++ b/src/gui/search/pluginselectdialog.h
@@ -31,11 +31,11 @@
 #define PLUGINSELECTDIALOG_H
 
 #include <QDialog>
+#include <QStringList>
 
 #include "base/search/searchpluginmanager.h"
 
 class QDropEvent;
-class QStringList;
 class QTreeWidgetItem;
 
 namespace Net

--- a/src/gui/tagfiltermodel.cpp
+++ b/src/gui/tagfiltermodel.cpp
@@ -30,6 +30,8 @@
 
 #include <QDebug>
 #include <QIcon>
+#include <QSet>
+#include <QVector>
 
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/torrenthandle.h"

--- a/src/gui/tagfiltermodel.h
+++ b/src/gui/tagfiltermodel.h
@@ -30,8 +30,7 @@
 #define TAGFILTERMODEL_H
 
 #include <QAbstractListModel>
-#include <QSet>
-#include <QVector>
+#include <QtContainerFwd>
 
 class QModelIndex;
 

--- a/src/gui/trackerentriesdialog.cpp
+++ b/src/gui/trackerentriesdialog.cpp
@@ -31,6 +31,7 @@
 #include <algorithm>
 
 #include <QHash>
+#include <QVector>
 
 #include "base/bittorrent/trackerentry.h"
 #include "ui_trackerentriesdialog.h"

--- a/src/gui/trackerentriesdialog.h
+++ b/src/gui/trackerentriesdialog.h
@@ -29,7 +29,7 @@
 #pragma once
 
 #include <QDialog>
-#include <QVector>
+#include <QtContainerFwd>
 
 #include "base/settingvalue.h"
 

--- a/src/webui/api/apicontroller.cpp
+++ b/src/webui/api/apicontroller.cpp
@@ -30,8 +30,10 @@
 
 #include <algorithm>
 
+#include <QHash>
 #include <QJsonDocument>
 #include <QMetaObject>
+#include <QVector>
 
 #include "apierror.h"
 

--- a/src/webui/api/apicontroller.h
+++ b/src/webui/api/apicontroller.h
@@ -28,10 +28,9 @@
 
 #pragma once
 
-#include <QHash>
 #include <QObject>
 #include <QVariant>
-#include <QVector>
+#include <QtContainerFwd>
 
 class QString;
 

--- a/src/webui/api/logcontroller.cpp
+++ b/src/webui/api/logcontroller.cpp
@@ -76,18 +76,18 @@ void LogController::mainAction()
 
     for (const Log::Msg &msg : asConst(logger->getMessages(lastKnownId)))
     {
-        if (!((msg.type == Log::NORMAL && isNormal)
-              || (msg.type == Log::INFO && isInfo)
-              || (msg.type == Log::WARNING && isWarning)
-              || (msg.type == Log::CRITICAL && isCritical)))
+        if (!(((msg.type == Log::NORMAL) && isNormal)
+              || ((msg.type == Log::INFO) && isInfo)
+              || ((msg.type == Log::WARNING) && isWarning)
+              || ((msg.type == Log::CRITICAL) && isCritical)))
             continue;
 
         msgList.append(QJsonObject
         {
-            {KEY_LOG_ID, msg.id},
-            {KEY_LOG_TIMESTAMP, msg.timestamp},
-            {KEY_LOG_MSG_TYPE, msg.type},
-            {KEY_LOG_MSG_MESSAGE, msg.message}
+            {QLatin1String(KEY_LOG_ID), msg.id},
+            {QLatin1String(KEY_LOG_TIMESTAMP), msg.timestamp},
+            {QLatin1String(KEY_LOG_MSG_TYPE), msg.type},
+            {QLatin1String(KEY_LOG_MSG_MESSAGE), msg.message}
         });
     }
 
@@ -106,10 +106,8 @@ void LogController::mainAction()
 //   - last_known_id (int): exclude messages with id <= 'last_known_id' (default -1)
 void LogController::peersAction()
 {
-    int lastKnownId;
-    bool ok;
-
-    lastKnownId = params()["last_known_id"].toInt(&ok);
+    bool ok = false;
+    int lastKnownId = params()["last_known_id"].toInt(&ok);
     if (!ok)
         lastKnownId = -1;
 
@@ -120,11 +118,11 @@ void LogController::peersAction()
     {
         peerList.append(QJsonObject
         {
-            {KEY_LOG_ID, peer.id},
-            {KEY_LOG_TIMESTAMP, peer.timestamp},
-            {KEY_LOG_PEER_IP, peer.ip},
-            {KEY_LOG_PEER_BLOCKED, peer.blocked},
-            {KEY_LOG_PEER_REASON, peer.reason}
+            {QLatin1String(KEY_LOG_ID), peer.id},
+            {QLatin1String(KEY_LOG_TIMESTAMP), peer.timestamp},
+            {QLatin1String(KEY_LOG_PEER_IP), peer.ip},
+            {QLatin1String(KEY_LOG_PEER_BLOCKED), peer.blocked},
+            {QLatin1String(KEY_LOG_PEER_REASON), peer.reason}
         });
     }
 

--- a/src/webui/api/logcontroller.cpp
+++ b/src/webui/api/logcontroller.cpp
@@ -30,6 +30,7 @@
 
 #include <QJsonArray>
 #include <QJsonObject>
+#include <QVector>
 
 #include "base/global.h"
 #include "base/logger.h"

--- a/src/webui/api/logcontroller.h
+++ b/src/webui/api/logcontroller.h
@@ -30,7 +30,7 @@
 
 #include "apicontroller.h"
 
-class LogController : public APIController
+class LogController final : public APIController
 {
     Q_OBJECT
     Q_DISABLE_COPY(LogController)

--- a/src/webui/api/rsscontroller.cpp
+++ b/src/webui/api/rsscontroller.cpp
@@ -32,6 +32,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
+#include <QVector>
 
 #include "base/rss/rss_article.h"
 #include "base/rss/rss_autodownloader.h"

--- a/src/webui/api/rsscontroller.h
+++ b/src/webui/api/rsscontroller.h
@@ -30,7 +30,7 @@
 
 #include "apicontroller.h"
 
-class RSSController : public APIController
+class RSSController final : public APIController
 {
     Q_OBJECT
     Q_DISABLE_COPY(RSSController)

--- a/src/webui/api/searchcontroller.cpp
+++ b/src/webui/api/searchcontroller.cpp
@@ -30,8 +30,10 @@
 
 #include <limits>
 
+#include <QHash>
 #include <QJsonArray>
 #include <QJsonObject>
+#include <QList>
 #include <QSharedPointer>
 
 #include "base/global.h"

--- a/src/webui/api/searchcontroller.h
+++ b/src/webui/api/searchcontroller.h
@@ -28,15 +28,13 @@
 
 #pragma once
 
-#include <QHash>
-#include <QList>
+#include <QtContainerFwd>
 
 #include "base/search/searchpluginmanager.h"
 #include "apicontroller.h"
 
 class QJsonArray;
 class QJsonObject;
-class QStringList;
 
 struct ISession;
 struct SearchResult;

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -29,6 +29,8 @@
 #include "serialize_torrent.h"
 
 #include <QDateTime>
+#include <QSet>
+#include <QVector>
 
 #include "base/bittorrent/infohash.h"
 #include "base/bittorrent/torrenthandle.h"


### PR DESCRIPTION
When I was trying to compile qbt with Qt6, the compiler complains about the redefine of `class QStringList;`. It is actually because we forward declare it, so this PR drop the manually declared ones and uses the forward declaration header from Qt to work around it. Since the change is beneficial for Qt5 too and thus a PR for it.

Off topic: Qt 6 introduce numerous incompatible changes that I don't think we will able to support both Qt5 & Qt6 at the same time. I reckon we should wait for Qt6 LTS (or even the second LTS) and consider the switch until then.