### PR TITLE
Use #pragma once instead of include guards

### DIFF
--- a/src/app/cmdoptions.h
+++ b/src/app/cmdoptions.h
@@ -28,8 +28,7 @@
  * exception statement from your version.
  */
 
-#ifndef APP_OPTIONS_H
-#define APP_OPTIONS_H
+#pragma once
 
 #include <stdexcept>
 
@@ -81,5 +80,3 @@ private:
 
 QBtCommandLineParameters parseCommandLine(const QStringList &args);
 void displayUsage(const QString &prgName);
-
-#endif // APP_OPTIONS_H

--- a/src/app/filelogger.h
+++ b/src/app/filelogger.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef FILELOGGER_H
-#define FILELOGGER_H
+#pragma once
 
 #include <QFile>
 #include <QObject>
@@ -73,5 +72,3 @@ private:
     QFile m_logFile;
     QTimer m_flusher;
 };
-
-#endif // FILELOGGER_H

--- a/src/app/qtlocalpeer/qtlocalpeer.h
+++ b/src/app/qtlocalpeer/qtlocalpeer.h
@@ -66,8 +66,7 @@
 ****************************************************************************
 */
 
-#ifndef QTLOCALPEER_H
-#define QTLOCALPEER_H
+#pragma once
 
 #include "qtlockedfile.h"
 
@@ -99,5 +98,3 @@ protected:
 private:
     static const char* ack;
 };
-
-#endif // QTLOCALPEER_H

--- a/src/app/qtlocalpeer/qtlockedfile.h
+++ b/src/app/qtlocalpeer/qtlockedfile.h
@@ -66,8 +66,7 @@
 ****************************************************************************
 */
 
-#ifndef QTLOCKEDFILE_H
-#define QTLOCKEDFILE_H
+#pragma once
 
 #include <QFile>
 
@@ -112,5 +111,3 @@ namespace QtLP_Private
         LockMode m_lock_mode;
     };
 }
-
-#endif

--- a/src/app/stacktrace_win.h
+++ b/src/app/stacktrace_win.h
@@ -18,8 +18,7 @@
 *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
 ***************************************************************************/
 
-#ifndef STACKTRACE_WIN_H
-#define STACKTRACE_WIN_H
+#pragma once
 
 #include <windows.h>
 #include <dbghelp.h>
@@ -355,5 +354,3 @@ const QString straceWin::getBacktrace()
 #pragma warning(pop)
 #pragma optimize("g", on)
 #endif
-
-#endif // STACKTRACE_WIN_H

--- a/src/app/stacktracedialog.h
+++ b/src/app/stacktracedialog.h
@@ -27,8 +27,7 @@
  *
  */
 
-#ifndef STACKTRACEDIALOG_H
-#define STACKTRACEDIALOG_H
+#pragma once
 
 #include <QDialog>
 
@@ -51,5 +50,3 @@ public:
 private:
     Ui::StacktraceDialog *m_ui;
 };
-
-#endif // STACKTRACEDIALOG_H

--- a/src/base/bittorrent/bandwidthscheduler.h
+++ b/src/base/bittorrent/bandwidthscheduler.h
@@ -27,8 +27,7 @@
  * exception statement from your version.
  */
 
-#ifndef BANDWIDTHSCHEDULER_H
-#define BANDWIDTHSCHEDULER_H
+#pragma once
 
 #include <QObject>
 #include <QTimer>
@@ -52,5 +51,3 @@ private:
     QTimer m_timer;
     bool m_lastAlternative;
 };
-
-#endif // BANDWIDTHSCHEDULER_H

--- a/src/base/bittorrent/cachestatus.h
+++ b/src/base/bittorrent/cachestatus.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef BITTORRENT_CACHESTATUS_H
-#define BITTORRENT_CACHESTATUS_H
+#pragma once
 
 #include <QtGlobal>
 
@@ -42,5 +41,3 @@ namespace BitTorrent
         qreal readRatio = 0.0;
     };
 }
-
-#endif // BITTORRENT_CACHESTATUS_H

--- a/src/base/bittorrent/filterparserthread.h
+++ b/src/base/bittorrent/filterparserthread.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef FILTERPARSERTHREAD_H
-#define FILTERPARSERTHREAD_H
+#pragma once
 
 #include <libtorrent/ip_filter.hpp>
 
@@ -64,5 +63,3 @@ private:
     QString m_filePath;
     lt::ip_filter m_filter;
 };
-
-#endif // BITTORRENT_FILTERPARSERTHREAD_H

--- a/src/base/bittorrent/magneturi.h
+++ b/src/base/bittorrent/magneturi.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef BITTORRENT_MAGNETURI_H
-#define BITTORRENT_MAGNETURI_H
+#pragma once
 
 #include <libtorrent/add_torrent_params.hpp>
 
@@ -65,5 +64,3 @@ namespace BitTorrent
         lt::add_torrent_params m_addTorrentParams;
     };
 }
-
-#endif // BITTORRENT_MAGNETURI_H

--- a/src/base/bittorrent/peerinfo.h
+++ b/src/base/bittorrent/peerinfo.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef BITTORRENT_PEERINFO_H
-#define BITTORRENT_PEERINFO_H
+#pragma once
 
 #include <libtorrent/peer_info.hpp>
 
@@ -104,5 +103,3 @@ namespace BitTorrent
         mutable QString m_country;
     };
 }
-
-#endif // BITTORRENT_PEERINFO_H

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -27,8 +27,7 @@
  * exception statement from your version.
  */
 
-#ifndef BITTORRENT_SESSION_H
-#define BITTORRENT_SESSION_H
+#pragma once
 
 #include <memory>
 #include <vector>
@@ -794,5 +793,3 @@ namespace BitTorrent
 Q_DECLARE_METATYPE(std::shared_ptr<lt::entry>)
 const int sharedPtrLtEntryTypeID = qRegisterMetaType<std::shared_ptr<lt::entry>>();
 #endif
-
-#endif // BITTORRENT_SESSION_H

--- a/src/base/bittorrent/sessionstatus.h
+++ b/src/base/bittorrent/sessionstatus.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef BITTORRENT_SESSIONSTATUS_H
-#define BITTORRENT_SESSIONSTATUS_H
+#pragma once
 
 #include <QtGlobal>
 
@@ -74,5 +73,3 @@ namespace BitTorrent
         quint64 peersCount = 0;
     };
 }
-
-#endif // BITTORRENT_SESSIONSTATUS_H

--- a/src/base/bittorrent/speedmonitor.h
+++ b/src/base/bittorrent/speedmonitor.h
@@ -27,8 +27,7 @@
  * exception statement from your version.
  */
 
-#ifndef SPEEDMONITOR_H
-#define SPEEDMONITOR_H
+#pragma once
 
 #ifndef Q_MOC_RUN
 #include <boost/circular_buffer.hpp>
@@ -86,5 +85,3 @@ private:
     boost::circular_buffer<SpeedSample> m_speedSamples;
     SpeedSample m_sum;
 };
-
-#endif // SPEEDMONITOR_H

--- a/src/base/bittorrent/statistics.h
+++ b/src/base/bittorrent/statistics.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef STATISTICS_H
-#define STATISTICS_H
+#pragma once
 
 #include <QObject>
 #include <QTimer>
@@ -67,5 +66,3 @@ private:
 
     QTimer m_timer;
 };
-
-#endif // STATISTICS_H

--- a/src/base/bittorrent/torrentcreatorthread.h
+++ b/src/base/bittorrent/torrentcreatorthread.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef BITTORRENT_TORRENTCREATORTHREAD_H
-#define BITTORRENT_TORRENTCREATORTHREAD_H
+#pragma once
 
 #include <libtorrent/version.hpp>
 
@@ -94,5 +93,3 @@ namespace BitTorrent
         TorrentCreatorParams m_params;
     };
 }
-
-#endif // BITTORRENT_TORRENTCREATORTHREAD_H

--- a/src/base/bittorrent/torrentinfo.h
+++ b/src/base/bittorrent/torrentinfo.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef BITTORRENT_TORRENTINFO_H
-#define BITTORRENT_TORRENTINFO_H
+#pragma once
 
 #include <libtorrent/torrent_info.hpp>
 
@@ -105,5 +104,3 @@ namespace BitTorrent
         std::shared_ptr<lt::torrent_info> m_nativeInfo;
     };
 }
-
-#endif // BITTORRENT_TORRENTINFO_H

--- a/src/base/bittorrent/tracker.h
+++ b/src/base/bittorrent/tracker.h
@@ -28,8 +28,7 @@
  * exception statement from your version.
  */
 
-#ifndef BITTORRENT_TRACKER_H
-#define BITTORRENT_TRACKER_H
+#pragma once
 
 #include <string>
 
@@ -106,5 +105,3 @@ namespace BitTorrent
         QHash<InfoHash, TorrentStats> m_torrents;
     };
 }
-
-#endif // BITTORRENT_TRACKER_H

--- a/src/base/bittorrent/trackerentry.h
+++ b/src/base/bittorrent/trackerentry.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef BITTORRENT_TRACKERENTRY_H
-#define BITTORRENT_TRACKERENTRY_H
+#pragma once
 
 #include <libtorrent/announce_entry.hpp>
 
@@ -73,5 +72,3 @@ namespace BitTorrent
     bool operator==(const TrackerEntry &left, const TrackerEntry &right);
     uint qHash(const TrackerEntry &key, uint seed);
 }
-
-#endif // BITTORRENT_TRACKERENTRY_H

--- a/src/base/filesystemwatcher.h
+++ b/src/base/filesystemwatcher.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef FILESYSTEMWATCHER_H
-#define FILESYSTEMWATCHER_H
+#pragma once
 
 #include <QDir>
 #include <QFileSystemWatcher>
@@ -69,5 +68,3 @@ private:
     QVector<QDir> m_watchedFolders;
     QTimer m_watchTimer;
 };
-
-#endif // FILESYSTEMWATCHER_H

--- a/src/base/http/connection.h
+++ b/src/base/http/connection.h
@@ -28,8 +28,7 @@
  */
 
 
-#ifndef HTTP_CONNECTION_H
-#define HTTP_CONNECTION_H
+#pragma once
 
 #include <QElapsedTimer>
 #include <QObject>
@@ -66,5 +65,3 @@ namespace Http
         QElapsedTimer m_idleTimer;
     };
 }
-
-#endif // HTTP_CONNECTION_H

--- a/src/base/http/irequesthandler.h
+++ b/src/base/http/irequesthandler.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef HTTP_IREQUESTHANDLER_H
-#define HTTP_IREQUESTHANDLER_H
+#pragma once
 
 namespace Http
 {
@@ -42,5 +41,3 @@ namespace Http
         virtual Response processRequest(const Request &request, const Environment &env) = 0;
     };
 }
-
-#endif // HTTP_IREQUESTHANDLER_H

--- a/src/base/http/requestparser.h
+++ b/src/base/http/requestparser.h
@@ -28,8 +28,7 @@
  * exception statement from your version.
  */
 
-#ifndef HTTP_REQUESTPARSER_H
-#define HTTP_REQUESTPARSER_H
+#pragma once
 
 #include "types.h"
 
@@ -70,5 +69,3 @@ namespace Http
         Request m_request;
     };
 }
-
-#endif // HTTP_REQUESTPARSER_H

--- a/src/base/http/responsebuilder.h
+++ b/src/base/http/responsebuilder.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef HTTP_RESPONSEBUILDER_H
-#define HTTP_RESPONSEBUILDER_H
+#pragma once
 
 #include "types.h"
 
@@ -50,5 +49,3 @@ namespace Http
         Response m_response;
     };
 }
-
-#endif // HTTP_RESPONSEBUILDER_H

--- a/src/base/http/responsegenerator.h
+++ b/src/base/http/responsegenerator.h
@@ -28,8 +28,7 @@
  */
 
 
-#ifndef HTTP_RESPONSEGENERATOR_H
-#define HTTP_RESPONSEGENERATOR_H
+#pragma once
 
 class QByteArray;
 class QString;
@@ -42,5 +41,3 @@ namespace Http
     QString httpDate();
     void compressContent(Response &response);
 }
-
-#endif // HTTP_RESPONSEGENERATOR_H

--- a/src/base/http/server.h
+++ b/src/base/http/server.h
@@ -28,8 +28,7 @@
  */
 
 
-#ifndef HTTP_SERVER_H
-#define HTTP_SERVER_H
+#pragma once
 
 #include <QSet>
 #include <QSslCertificate>
@@ -67,5 +66,3 @@ namespace Http
         QSslKey m_key;
     };
 }
-
-#endif // HTTP_SERVER_H

--- a/src/base/http/types.h
+++ b/src/base/http/types.h
@@ -27,8 +27,7 @@
  * exception statement from your version.
  */
 
-#ifndef HTTP_TYPES_H
-#define HTTP_TYPES_H
+#pragma once
 
 #include <QHostAddress>
 #include <QString>
@@ -127,5 +126,3 @@ namespace Http
         }
     };
 }
-
-#endif // HTTP_TYPES_H

--- a/src/base/iconprovider.h
+++ b/src/base/iconprovider.h
@@ -27,8 +27,7 @@
  * exception statement from your version.
  */
 
-#ifndef ICONPROVIDER_H
-#define ICONPROVIDER_H
+#pragma once
 
 #include <QObject>
 
@@ -51,5 +50,3 @@ protected:
 
     static IconProvider *m_instance;
 };
-
-#endif // ICONPROVIDER_H

--- a/src/base/indexrange.h
+++ b/src/base/indexrange.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef QBT_INDEXRANGE_H
-#define QBT_INDEXRANGE_H
+#pragma once
 
 #include <QtGlobal>
 
@@ -169,5 +168,3 @@ private:
     IndexType m_first;
     IndexDiffType m_size;
 };
-
-#endif // QBT_INDEXRANGE_H

--- a/src/base/logger.h
+++ b/src/base/logger.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef LOGGER_H
-#define LOGGER_H
+#pragma once
 
 #include <boost/circular_buffer.hpp>
 
@@ -103,5 +102,3 @@ private:
 
 // Helper function
 void LogMsg(const QString &message, const Log::MsgType &type = Log::NORMAL);
-
-#endif // LOGGER_H

--- a/src/base/net/dnsupdater.h
+++ b/src/base/net/dnsupdater.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef DNSUPDATER_H
-#define DNSUPDATER_H
+#pragma once
 
 #include <QDateTime>
 #include <QHostAddress>
@@ -84,5 +83,3 @@ namespace Net
         QString m_password;
     };
 }
-
-#endif // DNSUPDATER_H

--- a/src/base/net/downloadmanager.h
+++ b/src/base/net/downloadmanager.h
@@ -27,8 +27,7 @@
  * exception statement from your version.
  */
 
-#ifndef NET_DOWNLOADMANAGER_H
-#define NET_DOWNLOADMANAGER_H
+#pragma once
 
 #include <QHash>
 #include <QNetworkAccessManager>
@@ -159,5 +158,3 @@ namespace Net
         connect(handler, &DownloadHandler::finished, context, slot);
     }
 }
-
-#endif // NET_DOWNLOADMANAGER_H

--- a/src/base/net/geoipdatabase.h
+++ b/src/base/net/geoipdatabase.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef GEOIPDATABASE_H
-#define GEOIPDATABASE_H
+#pragma once
 
 #include <QCoreApplication>
 #include <QtGlobal>
@@ -100,5 +99,3 @@ private:
     quint32 m_size;
     uchar *m_data;
 };
-
-#endif // GEOIPDATABASE_H

--- a/src/base/net/geoipmanager.h
+++ b/src/base/net/geoipmanager.h
@@ -27,8 +27,7 @@
  * exception statement from your version.
  */
 
-#ifndef NET_GEOIPMANAGER_H
-#define NET_GEOIPMANAGER_H
+#pragma once
 
 #include <QObject>
 
@@ -73,5 +72,3 @@ namespace Net
         static GeoIPManager *m_instance;
     };
 }
-
-#endif // NET_GEOIPMANAGER_H

--- a/src/base/net/portforwarder.h
+++ b/src/base/net/portforwarder.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef NET_PORTFORWARDER_H
-#define NET_PORTFORWARDER_H
+#pragma once
 
 #include <QObject>
 
@@ -53,5 +52,3 @@ namespace Net
         static PortForwarder *m_instance;
     };
 }
-
-#endif // NET_PORTFORWARDER_H

--- a/src/base/net/proxyconfigurationmanager.h
+++ b/src/base/net/proxyconfigurationmanager.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef NET_PROXYCONFIGURATIONMANAGER_H
-#define NET_PROXYCONFIGURATIONMANAGER_H
+#pragma once
 
 #include <QObject>
 
@@ -85,5 +84,3 @@ namespace Net
         bool m_isProxyOnlyForTorrents;
     };
 }
-
-#endif // NET_PROXYCONFIGURATIONMANAGER_H

--- a/src/base/net/reverseresolution.h
+++ b/src/base/net/reverseresolution.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef NET_REVERSERESOLUTION_H
-#define NET_REVERSERESOLUTION_H
+#pragma once
 
 #include <QCache>
 #include <QObject>
@@ -60,5 +59,3 @@ namespace Net
         QCache<QHostAddress, QString> m_cache;  // <IP, HostName>
     };
 }
-
-#endif // NET_REVERSERESOLUTION_H

--- a/src/base/net/smtp.h
+++ b/src/base/net/smtp.h
@@ -30,8 +30,7 @@
  * This code is based on QxtSmtp from libqxt (http://libqxt.org)
  */
 
-#ifndef SMTP_H
-#define SMTP_H
+#pragma once
 
 #include <QAbstractSocket>
 #include <QByteArray>
@@ -119,5 +118,3 @@ namespace Net
         QString m_password;
     };
 }
-
-#endif // SMTP_H

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -27,8 +27,7 @@
  * exception statement from your version.
  */
 
-#ifndef PREFERENCES_H
-#define PREFERENCES_H
+#pragma once
 
 #include <QtContainerFwd>
 #include <QVariant>
@@ -403,5 +402,3 @@ public slots:
 
     void apply();
 };
-
-#endif // PREFERENCES_H

--- a/src/base/profile.h
+++ b/src/base/profile.h
@@ -27,8 +27,7 @@
  * exception statement from your version.
  */
 
-#ifndef QBT_PROFILE_H
-#define QBT_PROFILE_H
+#pragma once
 
 #include <memory>
 
@@ -82,5 +81,3 @@ private:
 };
 
 QString specialFolderLocation(SpecialFolder folder);
-
-#endif // QBT_PROFILE_H

--- a/src/base/profile_p.h
+++ b/src/base/profile_p.h
@@ -27,8 +27,7 @@
  * exception statement from your version.
  */
 
-#ifndef QBT_PROFILE_P_H
-#define QBT_PROFILE_P_H
+#pragma once
 
 #include <QDir>
 #include <QStandardPaths>
@@ -132,5 +131,3 @@ namespace Private
         QDir m_baseDir;
     };
 }
-
-#endif // QBT_PROFILE_P_H

--- a/src/base/scanfoldersmodel.h
+++ b/src/base/scanfoldersmodel.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef SCANFOLDERSMODEL_H
-#define SCANFOLDERSMODEL_H
+#pragma once
 
 #include <QAbstractListModel>
 #include <QList>
@@ -110,5 +109,3 @@ private:
     QList<PathData*> m_pathList;
     FileSystemWatcher *m_fsWatcher;
 };
-
-#endif // SCANFOLDERSMODEL_H

--- a/src/base/settingsstorage.h
+++ b/src/base/settingsstorage.h
@@ -27,8 +27,7 @@
  * exception statement from your version.
  */
 
-#ifndef SETTINGSSTORAGE_H
-#define SETTINGSSTORAGE_H
+#pragma once
 
 #include <QObject>
 #include <QReadWriteLock>
@@ -61,5 +60,3 @@ private:
     QTimer m_timer;
     mutable QReadWriteLock m_lock;
 };
-
-#endif // SETTINGSSTORAGE_H

--- a/src/base/settingvalue.h
+++ b/src/base/settingvalue.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef SETTINGVALUE_H
-#define SETTINGVALUE_H
+#pragma once
 
 #include <type_traits>
 
@@ -114,5 +113,3 @@ private:
     const QString m_keyName;
     T m_value;
 };
-
-#endif // SETTINGVALUE_H

--- a/src/base/torrentfilter.h
+++ b/src/base/torrentfilter.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef TORRENTFILTER_H
-#define TORRENTFILTER_H
+#pragma once
 
 #include <QSet>
 #include <QString>
@@ -102,5 +101,3 @@ private:
     QString m_tag;
     InfoHashSet m_hashSet;
 };
-
-#endif // TORRENTFILTER_H

--- a/src/base/tristatebool.h
+++ b/src/base/tristatebool.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef TRISTATEBOOL_H
-#define TRISTATEBOOL_H
+#pragma once
 
 class TriStateBool
 {
@@ -68,5 +67,3 @@ constexpr bool operator!=(const TriStateBool &left, const TriStateBool &right)
 {
     return !(left == right);
 }
-
-#endif // TRISTATEBOOL_H

--- a/src/base/types.h
+++ b/src/base/types.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef TYPES_H
-#define TYPES_H
+#pragma once
 
 #include <QtContainerFwd>
 
@@ -42,5 +41,3 @@ enum class ShutdownDialogAction
 };
 
 typedef QMap<QString, QString> QStringMap;
-
-#endif // TYPES_H

--- a/src/base/utils/fs.h
+++ b/src/base/utils/fs.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef UTILS_FS_H
-#define UTILS_FS_H
+#pragma once
 
 /**
  * Utility functions related to file system.
@@ -79,5 +78,3 @@ namespace Utils
 #endif
     }
 }
-
-#endif // UTILS_FS_H

--- a/src/base/utils/gzip.h
+++ b/src/base/utils/gzip.h
@@ -27,8 +27,7 @@
  * exception statement from your version.
  */
 
-#ifndef UTILS_GZIP_H
-#define UTILS_GZIP_H
+#pragma once
 
 class QByteArray;
 
@@ -40,5 +39,3 @@ namespace Utils
         QByteArray decompress(const QByteArray &data, bool *ok = nullptr);
     }
 }
-
-#endif // UTILS_GZIP_H

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef UTILS_MISC_H
-#define UTILS_MISC_H
+#pragma once
 
 #include <QtGlobal>
 
@@ -108,5 +107,3 @@ namespace Utils
 #endif // Q_OS_WIN
     }
 }
-
-#endif // UTILS_MISC_H

--- a/src/base/utils/net.h
+++ b/src/base/utils/net.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef BASE_UTILS_NET_H
-#define BASE_UTILS_NET_H
+#pragma once
 
 #include <QHostAddress>
 #include <QtContainerFwd>
@@ -57,5 +56,3 @@ namespace Utils
         bool isSSLKeyValid(const QByteArray &data);
     }
 }
-
-#endif // BASE_UTILS_NET_H

--- a/src/base/utils/random.h
+++ b/src/base/utils/random.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef UTILS_RANDOM_H
-#define UTILS_RANDOM_H
+#pragma once
 
 #include <cstdint>
 #include <limits>
@@ -39,5 +38,3 @@ namespace Utils
         uint32_t rand(uint32_t min = 0, uint32_t max = std::numeric_limits<uint32_t>::max());
     }
 }
-
-#endif // UTILS_FS_H

--- a/src/base/utils/string.h
+++ b/src/base/utils/string.h
@@ -27,8 +27,7 @@
  * exception statement from your version.
  */
 
-#ifndef UTILS_STRING_H
-#define UTILS_STRING_H
+#pragma once
 
 #include <QChar>
 #include <QString>
@@ -74,5 +73,3 @@ namespace Utils
         QString join(const QVector<QStringRef> &strings, const QString &separator);
     }
 }
-
-#endif // UTILS_STRING_H

--- a/src/base/utils/version.h
+++ b/src/base/utils/version.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef QBITTORRENT_UTILS_VERSION_H
-#define QBITTORRENT_UTILS_VERSION_H
+#pragma once
 
 #include <array>
 #include <stdexcept>
@@ -210,5 +209,3 @@ namespace Utils
         return !(left < right);
     }
 }
-
-#endif // QBITTORRENT_UTILS_VERSION_H

--- a/src/gui/aboutdialog.h
+++ b/src/gui/aboutdialog.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef ABOUTDIALOG_H
-#define ABOUTDIALOG_H
+#pragma once
 
 #include <QDialog>
 
@@ -48,5 +47,3 @@ public:
 private:
     Ui::AboutDialog *m_ui;
 };
-
-#endif // ABOUTDIALOG_H

--- a/src/gui/addnewtorrentdialog.h
+++ b/src/gui/addnewtorrentdialog.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef ADDNEWTORRENTDIALOG_H
-#define ADDNEWTORRENTDIALOG_H
+#pragma once
 
 #include <memory>
 
@@ -122,5 +121,3 @@ private:
     CachedSettingValue<QSize> m_storeDialogSize;
     CachedSettingValue<QByteArray> m_storeSplitterState;
 };
-
-#endif // ADDNEWTORRENTDIALOG_H

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef ADVANCEDSETTINGS_H
-#define ADVANCEDSETTINGS_H
+#pragma once
 
 #include <libtorrent/version.hpp>
 
@@ -86,5 +85,3 @@ private:
     QComboBox m_comboBoxOSMemoryPriority;
 #endif
 };
-
-#endif // ADVANCEDSETTINGS_H

--- a/src/gui/autoexpandabledialog.h
+++ b/src/gui/autoexpandabledialog.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef AUTOEXPANDABLEDIALOG_H
-#define AUTOEXPANDABLEDIALOG_H
+#pragma once
 
 #include <QDialog>
 #include <QLineEdit>
@@ -57,5 +56,3 @@ protected:
 private:
     Ui::AutoExpandableDialog *m_ui;
 };
-
-#endif // AUTOEXPANDABLEDIALOG_H

--- a/src/gui/banlistoptionsdialog.h
+++ b/src/gui/banlistoptionsdialog.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef BANLISTOPTIONSDIALOG_H
-#define BANLISTOPTIONSDIALOG_H
+#pragma once
 
 #include <QDialog>
 
@@ -59,5 +58,3 @@ private:
     QSortFilterProxyModel *m_sortFilter;
     bool m_modified;
 };
-
-#endif // BANLISTOPTIONSDIALOG_H

--- a/src/gui/categoryfiltermodel.h
+++ b/src/gui/categoryfiltermodel.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef CATEGORYFILTERMODEL_H
-#define CATEGORYFILTERMODEL_H
+#pragma once
 
 #include <QAbstractItemModel>
 
@@ -77,5 +76,3 @@ private:
     bool m_isSubcategoriesEnabled;
     CategoryModelItem *m_rootItem;
 };
-
-#endif // CATEGORYFILTERMODEL_H

--- a/src/gui/categoryfilterproxymodel.h
+++ b/src/gui/categoryfilterproxymodel.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef CATEGORYFILTERPROXYMODEL_H
-#define CATEGORYFILTERPROXYMODEL_H
+#pragma once
 
 #include <QSortFilterProxyModel>
 
@@ -49,5 +48,3 @@ private:
     // we added another overload of index(), hence this using directive:
     using QSortFilterProxyModel::index;
 };
-
-#endif // CATEGORYFILTERPROXYMODEL_H

--- a/src/gui/cookiesdialog.h
+++ b/src/gui/cookiesdialog.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef COOKIESDIALOG_H
-#define COOKIESDIALOG_H
+#pragma once
 
 #include <QDialog>
 
@@ -57,5 +56,3 @@ private:
     Ui::CookiesDialog *m_ui;
     CookiesModel *m_cookiesModel;
 };
-
-#endif // COOKIESDIALOG_H

--- a/src/gui/cookiesmodel.h
+++ b/src/gui/cookiesmodel.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef COOKIESMODEL_H
-#define COOKIESMODEL_H
+#pragma once
 
 #include <QAbstractItemModel>
 #include <QList>
@@ -70,5 +69,3 @@ public:
 private:
     mutable QList<QNetworkCookie> m_cookies;
 };
-
-#endif // COOKIESMODEL_H

--- a/src/gui/deletionconfirmationdialog.h
+++ b/src/gui/deletionconfirmationdialog.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef DELETIONCONFIRMATIONDIALOG_H
-#define DELETIONCONFIRMATIONDIALOG_H
+#pragma once
 
 #include <QDialog>
 
@@ -55,5 +54,3 @@ private slots:
 private:
     Ui::DeletionConfirmationDialog *m_ui;
 };
-
-#endif // DELETIONCONFIRMATIONDIALOG_H

--- a/src/gui/downloadfromurldialog.h
+++ b/src/gui/downloadfromurldialog.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef DOWNLOADFROMURL_H
-#define DOWNLOADFROMURL_H
+#pragma once
 
 #include <QDialog>
 
@@ -54,5 +53,3 @@ private slots:
 private:
     Ui::DownloadFromURLDialog *m_ui;
 };
-
-#endif // DOWNLOADFROMURL_H

--- a/src/gui/executionlogwidget.h
+++ b/src/gui/executionlogwidget.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef EXECUTIONLOGWIDGET_H
-#define EXECUTIONLOGWIDGET_H
+#pragma once
 
 #include <QWidget>
 
@@ -58,5 +57,3 @@ private:
     Ui::ExecutionLogWidget *m_ui;
     LogFilterModel *m_messageFilterModel;
 };
-
-#endif // EXECUTIONLOGWIDGET_H

--- a/src/gui/fspathedit.h
+++ b/src/gui/fspathedit.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef QBT_FSPATHEDIT_H
-#define QBT_FSPATHEDIT_H
+#pragma once
 
 #include <QWidget>
 
@@ -149,5 +148,3 @@ private:
     QString editWidgetText() const override;
     void setEditWidgetText(const QString &text) override;
 };
-
-#endif // QBT_FSPATHEDIT_H

--- a/src/gui/fspathedit_p.h
+++ b/src/gui/fspathedit_p.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef QBT_GUI_FSPATHEDIT_P_H
-#define QBT_GUI_FSPATHEDIT_P_H
+#pragma once
 
 #include <QComboBox>
 #include <QFileIconProvider>
@@ -157,5 +156,3 @@ namespace Private
         QString text() const;
     };
 }
-
-#endif // QBT_GUI_FSPATHEDIT_P_H

--- a/src/gui/hidabletabwidget.h
+++ b/src/gui/hidabletabwidget.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef HIDABLETABWIDGET_H
-#define HIDABLETABWIDGET_H
+#pragma once
 
 #include <QTabWidget>
 
@@ -48,5 +47,3 @@ private:
     void paintEvent(QPaintEvent *event) override;
 #endif
 };
-
-#endif // HIDABLETABWIDGET_H

--- a/src/gui/ipsubnetwhitelistoptionsdialog.h
+++ b/src/gui/ipsubnetwhitelistoptionsdialog.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef OPTIONS_IPSUBNETWHITELIST_H
-#define OPTIONS_IPSUBNETWHITELIST_H
+#pragma once
 
 #include <QDialog>
 
@@ -60,5 +59,3 @@ private:
     QSortFilterProxyModel *m_sortFilter;
     bool m_modified;
 };
-
-#endif // OPTIONS_IPSUBNETWHITELIST_H

--- a/src/gui/lineedit.h
+++ b/src/gui/lineedit.h
@@ -7,8 +7,7 @@
 **
 ****************************************************************************/
 
-#ifndef LINEEDIT_H
-#define LINEEDIT_H
+#pragma once
 
 #include <QLineEdit>
 
@@ -28,5 +27,3 @@ protected:
 private:
     QToolButton *m_searchButton;
 };
-
-#endif // LIENEDIT_H

--- a/src/gui/macutilities.h
+++ b/src/gui/macutilities.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef MACUTILITIES_H
-#define MACUTILITIES_H
+#pragma once
 
 #include <objc/objc.h>
 
@@ -44,5 +43,3 @@ namespace MacUtils
     void displayNotification(const QString &title, const QString &message);
     void openFiles(const QSet<QString> &pathsList);
 }
-
-#endif // MACUTILITIES_H

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef MAINWINDOW_H
-#define MAINWINDOW_H
+#pragma once
 
 #include <QMainWindow>
 #include <QPointer>
@@ -263,5 +262,3 @@ private:
     bool m_hasPython;
     QMenu *m_toolbarMenu;
 };
-
-#endif // MAINWINDOW_H

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef OPTIONSDIALOG_H
-#define OPTIONSDIALOG_H
+#pragma once
 
 #include <QDialog>
 
@@ -183,5 +182,3 @@ private:
     QList<QString> m_addedScanDirs;
     QList<QString> m_removedScanDirs;
 };
-
-#endif // OPTIONSDIALOG_H

--- a/src/gui/powermanagement/powermanagement.h
+++ b/src/gui/powermanagement/powermanagement.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef POWERMANAGEMENT_H
-#define POWERMANAGEMENT_H
+#pragma once
 
 #include <QObject>
 
@@ -64,5 +63,3 @@ private:
   IOPMAssertionID m_assertionID;
 #endif
 };
-
-#endif // POWERMANAGEMENT_H

--- a/src/gui/powermanagement/powermanagement_x11.h
+++ b/src/gui/powermanagement/powermanagement_x11.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef POWERMANAGEMENTINHIBITOR_H
-#define POWERMANAGEMENTINHIBITOR_H
+#pragma once
 
 #include <QObject>
 
@@ -63,5 +62,3 @@ private:
 
     bool m_useGSM;
 };
-
-#endif // POWERMANAGEMENTINHIBITOR_H

--- a/src/gui/previewlistdelegate.h
+++ b/src/gui/previewlistdelegate.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef PREVIEWLISTDELEGATE_H
-#define PREVIEWLISTDELEGATE_H
+#pragma once
 
 #include <QItemDelegate>
 
@@ -43,5 +42,3 @@ private:
     void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
     QWidget *createEditor(QWidget *, const QStyleOptionViewItem &, const QModelIndex &) const override;
 };
-
-#endif // PREVIEWLISTDELEGATE_H

--- a/src/gui/previewselectdialog.h
+++ b/src/gui/previewselectdialog.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef PREVIEWSELECTDIALOG_H
-#define PREVIEWSELECTDIALOG_H
+#pragma once
 
 #include <QDialog>
 
@@ -86,5 +85,3 @@ private:
     CachedSettingValue<QSize> m_storeDialogSize;
     CachedSettingValue<QByteArray> m_storeTreeHeaderState;
 };
-
-#endif // PREVIEWSELECTDIALOG_H

--- a/src/gui/programupdater.h
+++ b/src/gui/programupdater.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef PROGRAMUPDATER_H
-#define PROGRAMUPDATER_H
+#pragma once
 
 #include <QObject>
 
@@ -59,5 +58,3 @@ private:
     QString m_updateUrl;
     bool m_invokedByUser;
 };
-
-#endif // PROGRAMUPDATER_H

--- a/src/gui/properties/downloadedpiecesbar.h
+++ b/src/gui/properties/downloadedpiecesbar.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef DOWNLOADEDPIECESBAR_H
-#define DOWNLOADEDPIECESBAR_H
+#pragma once
 
 #include <QBitArray>
 #include <QtContainerFwd>
@@ -63,5 +62,3 @@ private:
     QBitArray m_pieces;
     QBitArray m_downloadedPieces;
 };
-
-#endif // DOWNLOADEDPIECESBAR_H

--- a/src/gui/properties/peerlistsortmodel.h
+++ b/src/gui/properties/peerlistsortmodel.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef PEERLISTSORTMODEL_H
-#define PEERLISTSORTMODEL_H
+#pragma once
 
 #include <QSortFilterProxyModel>
 
@@ -47,5 +46,3 @@ public:
 private:
     bool lessThan(const QModelIndex &left, const QModelIndex &right) const override;
 };
-
-#endif // PEERLISTSORTMODEL_H

--- a/src/gui/properties/peerlistwidget.h
+++ b/src/gui/properties/peerlistwidget.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef PEERLISTWIDGET_H
-#define PEERLISTWIDGET_H
+#pragma once
 
 #include <QHash>
 #include <QSet>
@@ -109,5 +108,3 @@ private:
     QHash<QHostAddress, QSet<QStandardItem *>> m_itemsByIP;  // must be kept in sync with `m_peerItems`
     bool m_resolveCountries;
 };
-
-#endif // PEERLISTWIDGET_H

--- a/src/gui/properties/peersadditiondialog.h
+++ b/src/gui/properties/peersadditiondialog.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef PEERADDITION_H
-#define PEERADDITION_H
+#pragma once
 
 #include <QDialog>
 #include <QVector>
@@ -56,5 +55,3 @@ private:
     Ui::PeersAdditionDialog *m_ui;
     QVector<BitTorrent::PeerAddress> m_peersList;
 };
-
-#endif // PEERADDITION_H

--- a/src/gui/properties/pieceavailabilitybar.h
+++ b/src/gui/properties/pieceavailabilitybar.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef PIECEAVAILABILITYBAR_H
-#define PIECEAVAILABILITYBAR_H
+#pragma once
 
 #include "piecesbar.h"
 
@@ -56,5 +55,3 @@ private:
     // scale int vector to float vector
     QVector<float> intToFloatVector(const QVector<int> &vecin, int reqSize);
 };
-
-#endif // PIECEAVAILABILITYBAR_H

--- a/src/gui/properties/piecesbar.h
+++ b/src/gui/properties/piecesbar.h
@@ -27,8 +27,7 @@
  * exception statement from your version.
  */
 
-#ifndef PIECESBAR_H
-#define PIECESBAR_H
+#pragma once
 
 #include <QColor>
 #include <QImage>
@@ -95,5 +94,3 @@ private:
     bool m_hovered;
     QRect m_highlitedRegion; //!< part of the bar can be highlighted; this rectangle is in the same frame as m_image
 };
-
-#endif // PIECESBAR_H

--- a/src/gui/properties/propertieswidget.h
+++ b/src/gui/properties/propertieswidget.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef PROPERTIESWIDGET_H
-#define PROPERTIESWIDGET_H
+#pragma once
 
 #include <QList>
 #include <QWidget>
@@ -125,5 +124,3 @@ private:
     LineEdit *m_contentFilterLine;
     int m_handleWidth;
 };
-
-#endif // PROPERTIESWIDGET_H

--- a/src/gui/properties/proplistdelegate.h
+++ b/src/gui/properties/proplistdelegate.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef PROPLISTDELEGATE_H
-#define PROPLISTDELEGATE_H
+#pragma once
 
 #include "gui/progressbardelegate.h"
 
@@ -71,5 +70,3 @@ private:
 
     PropertiesWidget *m_properties;
 };
-
-#endif // PROPLISTDELEGATE_H

--- a/src/gui/properties/proptabbar.h
+++ b/src/gui/properties/proptabbar.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef PROPTABBAR_H
-#define PROPTABBAR_H
+#pragma once
 
 #include <QHBoxLayout>
 
@@ -64,5 +63,3 @@ private:
     QButtonGroup *m_btnGroup;
     int m_currentIndex;
 };
-
-#endif // PROPTABBAR_H

--- a/src/gui/properties/speedplotview.h
+++ b/src/gui/properties/speedplotview.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef SPEEDPLOTVIEW_H
-#define SPEEDPLOTVIEW_H
+#pragma once
 
 #ifndef Q_MOC_RUN
 #include <boost/circular_buffer.hpp>
@@ -131,5 +130,3 @@ private:
     TimePeriod m_period;
     int m_viewablePointsCount;
 };
-
-#endif // SPEEDPLOTVIEW_H

--- a/src/gui/properties/speedwidget.h
+++ b/src/gui/properties/speedwidget.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef SPEEDWIDGET_H
-#define SPEEDWIDGET_H
+#pragma once
 
 #include <QComboBox>
 #include <QWidget>
@@ -80,5 +79,3 @@ private:
     QMenu *m_graphsMenu;
     QList<QAction *> m_graphsMenuActions;
 };
-
-#endif // SPEEDWIDGET_H

--- a/src/gui/properties/trackerlistwidget.h
+++ b/src/gui/properties/trackerlistwidget.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef TRACKERLIST_H
-#define TRACKERLIST_H
+#pragma once
 
 #include <QTreeWidget>
 #include <QtContainerFwd>
@@ -95,5 +94,3 @@ private:
     QTreeWidgetItem *m_PEXItem;
     QTreeWidgetItem *m_LSDItem;
 };
-
-#endif // TRACKERLIST_H

--- a/src/gui/properties/trackersadditiondialog.h
+++ b/src/gui/properties/trackersadditiondialog.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef TRACKERSADDITION_H
-#define TRACKERSADDITION_H
+#pragma once
 
 #include <QDialog>
 #include <QtContainerFwd>
@@ -68,5 +67,3 @@ private:
     Ui::TrackersAdditionDialog *m_ui;
     BitTorrent::TorrentHandle *const m_torrent;
 };
-
-#endif // TRACKERSADDITION_H

--- a/src/gui/raisedmessagebox.h
+++ b/src/gui/raisedmessagebox.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef RAISEDMESSAGEBOX_H
-#define RAISEDMESSAGEBOX_H
+#pragma once
 
 #include <QMessageBox>
 
@@ -52,5 +51,3 @@ private:
 
     static QMessageBox::StandardButton impl(const QMessageBox::Icon &icon, QWidget *parent, const QString &title, const QString &text, QMessageBox::StandardButtons buttons = QMessageBox::Ok, QMessageBox::StandardButton defaultButton = QMessageBox::NoButton);
 };
-
-#endif // RAISEDMESSAGEBOX_H

--- a/src/gui/rss/articlelistwidget.h
+++ b/src/gui/rss/articlelistwidget.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef ARTICLELISTWIDGET_H
-#define ARTICLELISTWIDGET_H
+#pragma once
 
 #include <QHash>
 #include <QListWidget>
@@ -63,5 +62,3 @@ private:
     bool m_unreadOnly = false;
     QHash<RSS::Article *, QListWidgetItem *> m_rssArticleToListItemMapping;
 };
-
-#endif // ARTICLELISTWIDGET_H

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -27,8 +27,7 @@
  * exception statement from your version.
  */
 
-#ifndef AUTOMATEDRSSDOWNLOADER_H
-#define AUTOMATEDRSSDOWNLOADER_H
+#pragma once
 
 #include <QDialog>
 #include <QHash>
@@ -106,5 +105,3 @@ private:
     QHash<QString, QListWidgetItem *> m_itemsByRuleName;
     QRegularExpression *m_episodeRegex;
 };
-
-#endif // AUTOMATEDRSSDOWNLOADER_H

--- a/src/gui/rss/feedlistwidget.h
+++ b/src/gui/rss/feedlistwidget.h
@@ -27,8 +27,7 @@
  * exception statement from your version.
  */
 
-#ifndef FEEDLISTWIDGET_H
-#define FEEDLISTWIDGET_H
+#pragma once
 
 #include <QHash>
 #include <QTreeWidget>
@@ -73,5 +72,3 @@ private:
     QHash<RSS::Item *, QTreeWidgetItem *> m_rssToTreeItemMapping;
     QTreeWidgetItem *m_unreadStickyItem;
 };
-
-#endif // FEEDLISTWIDGET_H

--- a/src/gui/rss/htmlbrowser.h
+++ b/src/gui/rss/htmlbrowser.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef HTMLBROWSER_H
-#define HTMLBROWSER_H
+#pragma once
 
 #include <QHash>
 #include <QTextBrowser>
@@ -54,5 +53,3 @@ protected:
 protected slots:
     void resourceLoaded(QNetworkReply *reply);
 };
-
-#endif // HTMLBROWSER_H

--- a/src/gui/rss/rsswidget.h
+++ b/src/gui/rss/rsswidget.h
@@ -28,8 +28,7 @@
  * exception statement from your version.
  */
 
-#ifndef RSSWIDGET_H
-#define RSSWIDGET_H
+#pragma once
 
 #include <QWidget>
 
@@ -86,5 +85,3 @@ private:
     ArticleListWidget *m_articleListWidget;
     FeedListWidget *m_feedListWidget;
 };
-
-#endif // RSSWIDGET_H

--- a/src/gui/scanfoldersdelegate.h
+++ b/src/gui/scanfoldersdelegate.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef SCANFOLDERSDELEGATE_H
-#define SCANFOLDERSDELEGATE_H
+#pragma once
 
 #include <QStyledItemDelegate>
 
@@ -57,5 +56,3 @@ private:
 
     QTreeView *m_folderView;
 };
-
-#endif // SCANFOLDERSDELEGATE_H

--- a/src/gui/search/pluginselectdialog.h
+++ b/src/gui/search/pluginselectdialog.h
@@ -27,8 +27,7 @@
  * exception statement from your version.
  */
 
-#ifndef PLUGINSELECTDIALOG_H
-#define PLUGINSELECTDIALOG_H
+#pragma once
 
 #include <QDialog>
 #include <QStringList>
@@ -97,5 +96,3 @@ private:
     int m_asyncOps;
     int m_pendingUpdates;
 };
-
-#endif // PLUGINSELECTDIALOG_H

--- a/src/gui/search/pluginsourcedialog.h
+++ b/src/gui/search/pluginsourcedialog.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef PLUGINSOURCEDIALOG_H
-#define PLUGINSOURCEDIALOG_H
+#pragma once
 
 #include <QDialog>
 
@@ -55,5 +54,3 @@ private slots:
 private:
     Ui::PluginSourceDialog *m_ui;
 };
-
-#endif // PLUGINSOURCEDIALOG_H

--- a/src/gui/search/searchsortmodel.h
+++ b/src/gui/search/searchsortmodel.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef SEARCHSORTMODEL_H
-#define SEARCHSORTMODEL_H
+#pragma once
 
 #include <QSortFilterProxyModel>
 #include <QStringList>
@@ -96,5 +95,3 @@ private:
     int m_minLeeches, m_maxLeeches;
     qint64 m_minSize, m_maxSize;
 };
-
-#endif // SEARCHSORTMODEL_H

--- a/src/gui/shutdownconfirmdialog.h
+++ b/src/gui/shutdownconfirmdialog.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef SHUTDOWNCONFIRMDIALOG_H
-#define SHUTDOWNCONFIRMDIALOG_H
+#pragma once
 
 #include <QDialog>
 #include <QTimer>
@@ -68,5 +67,3 @@ private:
     ShutdownDialogAction m_action;
     QString m_msg;
 };
-
-#endif // SHUTDOWNCONFIRMDIALOG_H

--- a/src/gui/speedlimitdialog.h
+++ b/src/gui/speedlimitdialog.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef SPEEDLIMITDIALOG_H
-#define SPEEDLIMITDIALOG_H
+#pragma once
 
 #include <QDialog>
 
@@ -55,5 +54,3 @@ private:
 
     Ui::SpeedLimitDialog *m_ui;
 };
-
-#endif // SPEEDLIMITDIALOG_H

--- a/src/gui/statsdialog.h
+++ b/src/gui/statsdialog.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef STATSDIALOG_H
-#define STATSDIALOG_H
+#pragma once
 
 #include <QDialog>
 
@@ -50,5 +49,3 @@ private slots:
 private:
     Ui::StatsDialog *m_ui;
 };
-
-#endif // STATSDIALOG_H

--- a/src/gui/statusbar.h
+++ b/src/gui/statusbar.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef STATUSBAR_H
-#define STATUSBAR_H
+#pragma once
 
 #include <QStatusBar>
 
@@ -72,5 +71,3 @@ private:
     QPushButton *m_connecStatusLblIcon;
     QPushButton *m_altSpeedsBtn;
 };
-
-#endif // STATUSBAR_H

--- a/src/gui/tagfiltermodel.h
+++ b/src/gui/tagfiltermodel.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef TAGFILTERMODEL_H
-#define TAGFILTERMODEL_H
+#pragma once
 
 #include <QAbstractListModel>
 #include <QtContainerFwd>
@@ -83,5 +82,3 @@ private:
 
     QList<TagModelItem> m_tagItems;  // Index corresponds to its row
 };
-
-#endif // TAGFILTERMODEL_H

--- a/src/gui/tagfilterproxymodel.h
+++ b/src/gui/tagfilterproxymodel.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef TAGFILTERPROXYMODEL_H
-#define TAGFILTERPROXYMODEL_H
+#pragma once
 
 #include <QSortFilterProxyModel>
 
@@ -49,5 +48,3 @@ private:
     // we added another overload of index(), hence this using directive:
     using QSortFilterProxyModel::index;
 };
-
-#endif // TAGFILTERPROXYMODEL_H

--- a/src/gui/tagfilterwidget.h
+++ b/src/gui/tagfilterwidget.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef TAGFILTERWIDGET_H
-#define TAGFILTERWIDGET_H
+#pragma once
 
 #include <QTreeView>
 
@@ -60,5 +59,3 @@ private:
     void rowsInserted(const QModelIndex &parent, int start, int end) override;
     QString askTagName();
 };
-
-#endif // TAGFILTERWIDGET_H

--- a/src/gui/torrentcontentfiltermodel.h
+++ b/src/gui/torrentcontentfiltermodel.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef TORRENTCONTENTFILTERMODEL_H
-#define TORRENTCONTENTFILTERMODEL_H
+#pragma once
 
 #include <QSortFilterProxyModel>
 
@@ -63,5 +62,3 @@ private:
 
     TorrentContentModel *m_model;
 };
-
-#endif // TORRENTCONTENTFILTERMODEL_H

--- a/src/gui/torrentcontentmodel.h
+++ b/src/gui/torrentcontentmodel.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef TORRENTCONTENTMODEL_H
-#define TORRENTCONTENTMODEL_H
+#pragma once
 
 #include <QAbstractItemModel>
 #include <QVector>
@@ -89,5 +88,3 @@ private:
     QVector<TorrentContentModelFile *> m_filesIndex;
     QFileIconProvider *m_fileIconProvider;
 };
-
-#endif // TORRENTCONTENTMODEL_H

--- a/src/gui/torrentcontentmodelfile.h
+++ b/src/gui/torrentcontentmodelfile.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef TORRENTCONTENTMODELFILE_H
-#define TORRENTCONTENTMODELFILE_H
+#pragma once
 
 #include "torrentcontentmodelitem.h"
 
@@ -51,5 +50,3 @@ public:
 private:
     int m_fileIndex;
 };
-
-#endif // TORRENTCONTENTMODELFILE_H

--- a/src/gui/torrentcontentmodelfolder.h
+++ b/src/gui/torrentcontentmodelfolder.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef TORRENTCONTENTMODELFOLDER_H
-#define TORRENTCONTENTMODELFOLDER_H
+#pragma once
 
 #include "torrentcontentmodelitem.h"
 
@@ -66,5 +65,3 @@ public:
 private:
     QVector<TorrentContentModelItem*> m_childItems;
 };
-
-#endif // TORRENTCONTENTMODELFOLDER_H

--- a/src/gui/torrentcontentmodelitem.h
+++ b/src/gui/torrentcontentmodelitem.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef TORRENTCONTENTMODELITEM_H
-#define TORRENTCONTENTMODELITEM_H
+#pragma once
 
 #include <QCoreApplication>
 #include <QVector>
@@ -96,5 +95,3 @@ protected:
     qreal m_progress;
     qreal m_availability;
 };
-
-#endif // TORRENTCONTENTMODELITEM_H

--- a/src/gui/torrentcontenttreeview.h
+++ b/src/gui/torrentcontenttreeview.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef TORRENTCONTENTTREEVIEW_H
-#define TORRENTCONTENTTREEVIEW_H
+#pragma once
 
 #include <QTreeView>
 
@@ -51,5 +50,3 @@ public:
 private:
     QModelIndex currentNameCell();
 };
-
-#endif // TORRENTCONTENTTREEVIEW_H

--- a/src/gui/torrentcreatordialog.h
+++ b/src/gui/torrentcreatordialog.h
@@ -27,8 +27,7 @@
  * exception statement from your version.
  */
 
-#ifndef TORRENTCREATORDIALOG_H
-#define TORRENTCREATORDIALOG_H
+#pragma once
 
 #include <libtorrent/version.hpp>
 
@@ -97,5 +96,3 @@ private:
     CachedSettingValue<QString> m_storeLastSavePath;
     CachedSettingValue<QString> m_storeSource;
 };
-
-#endif // TORRENTCREATORDIALOG_H

--- a/src/gui/transferlistfilterswidget.h
+++ b/src/gui/transferlistfilterswidget.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef TRANSFERLISTFILTERSWIDGET_H
-#define TRANSFERLISTFILTERSWIDGET_H
+#pragma once
 
 #include <QFrame>
 #include <QListWidget>
@@ -176,5 +175,3 @@ private:
     CategoryFilterWidget *m_categoryFilterWidget;
     TagFilterWidget *m_tagFilterWidget;
 };
-
-#endif // TRANSFERLISTFILTERSWIDGET_H

--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -27,8 +27,7 @@
  * exception statement from your version.
  */
 
-#ifndef TRANSFERLISTMODEL_H
-#define TRANSFERLISTMODEL_H
+#pragma once
 
 #include <QAbstractListModel>
 #include <QColor>
@@ -128,5 +127,3 @@ private:
 
     HideZeroValuesMode m_hideZeroValuesMode = HideZeroValuesMode::Never;
 };
-
-#endif // TRANSFERLISTMODEL_H

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef TRANSFERLISTWIDGET_H
-#define TRANSFERLISTWIDGET_H
+#pragma once
 
 #include <functional>
 #include <QtContainerFwd>
@@ -129,5 +128,3 @@ private:
     TransferListSortModel *m_sortFilterModel;
     MainWindow *m_mainWindow;
 };
-
-#endif // TRANSFERLISTWIDGET_H

--- a/src/gui/updownratiodialog.h
+++ b/src/gui/updownratiodialog.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef UPDOWNRATIODIALOG_H
-#define UPDOWNRATIODIALOG_H
+#pragma once
 
 #include <QDialog>
 
@@ -61,5 +60,3 @@ private slots:
 private:
     Ui::UpDownRatioDialog *m_ui;
 };
-
-#endif // UPDOWNRATIODIALOG_H

--- a/src/gui/utils.h
+++ b/src/gui/utils.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef UTILS_GUI_H
-#define UTILS_GUI_H
+#pragma once
 
 #include <QSize>
 
@@ -62,5 +61,3 @@ namespace Utils
         void openFolderSelect(const QString &absolutePath);
     }
 }
-
-#endif  // UTILS_GUI_H

--- a/src/webui/webui.h
+++ b/src/webui/webui.h
@@ -26,8 +26,7 @@
  * exception statement from your version.
  */
 
-#ifndef WEBUI_H
-#define WEBUI_H
+#pragma once
 
 #include <QObject>
 #include <QPointer>
@@ -67,5 +66,3 @@ private:
     QPointer<WebApplication> m_webapp;
     quint16 m_port;
 };
-
-#endif // WEBUI_H


### PR DESCRIPTION
---

IMO this was a missed opportunity from the recent coding style update PR. From the coding guidelines:

> `#pragma once` should be used instead of "include guard" in new code:

Why not change old code as well, now? It improves consistency, and also allows us to change this rule to simply "Use \#pragma once as include guard".

I'm aware of the caveats of `#pragma once` (e.g. the hard link stuff), but I don't think they apply to this project under any reasonable circumstance.

Other than the slight consistency win, this is a relatively trivial (and very automatable) change, so I'll close this if there is any good reason that I'm not thinking of right now to keep the old-style include guards in the files that still have them.