### PR TITLE
Enable native Windows 10 dark theme support by default

### DIFF
--- a/dist/windows/qt.conf
+++ b/dist/windows/qt.conf
@@ -2,4 +2,4 @@
 Translations = translations
 
 [Platforms]
-;WindowsArguments = dpiawareness=1
+WindowsArguments = darkmode=2;,dpiawareness=1

--- a/dist/windows/qt.conf
+++ b/dist/windows/qt.conf
@@ -2,4 +2,4 @@
 Translations = translations
 
 [Platforms]
-WindowsArguments = darkmode=2;,dpiawareness=1
+WindowsArguments = darkmode=2;,dpiawareness=1,fontengine=freetype


### PR DESCRIPTION
Settings related to workarounds to HiDPI issues
are still commented out by default.

---

See https://github.com/qbittorrent/qBittorrent/issues/13675#issuecomment-742888636 and Ctrl+F `darkmode` here: https://doc.qt.io/qt-5/qguiapplication.html

I did not test on a Windows version lower than Windows 10 1903, but I think in such cases Qt simply ignores this. However, it would be nice for someone to confirm this before merging, since we still support those versions.

The new font related argument that is commented out comes from here: https://github.com/qbittorrent/qBittorrent/issues/13749#issuecomment-742873508 and this whole discussion: https://github.com/qbittorrent/qBittorrent/issues/12295

Screenshots:

<details>
<summary>Click to expand</summary>

![dark mode ss1](https://user-images.githubusercontent.com/42386382/101896533-0edbee80-3ba1-11eb-813f-2898350c5ebb.png)
![dark mode ss5](https://user-images.githubusercontent.com/42386382/101896539-113e4880-3ba1-11eb-9ab0-65fb038a69e8.png)
![dark mode ss4](https://user-images.githubusercontent.com/42386382/101896544-126f7580-3ba1-11eb-9d8b-d208fede81c9.png)
![dark mode ss3](https://user-images.githubusercontent.com/42386382/101896547-13080c00-3ba1-11eb-83be-1cda11d28892.png)
![dark mode ss2](https://user-images.githubusercontent.com/42386382/101896549-13080c00-3ba1-11eb-99c2-a325705ee2b4.png)

It respects title bars and window borders color changes:

Go to Settings->Personalisation->Colours->"Choose your accent colour"
Show the accent colour on the following surfaces->Check/Enable Title bars and windows borders

![dark mode ss7](https://user-images.githubusercontent.com/42386382/101898803-a858cf80-3ba4-11eb-8ad1-e3b087c9a3f7.png)
![dark mode ss6](https://user-images.githubusercontent.com/42386382/101898808-aabb2980-3ba4-11eb-8bbf-7e54fd61c625.png)
</details>