### PR TITLE
Improve content root folder handling

### DIFF
--- a/src/app/upgrade.cpp
+++ b/src/app/upgrade.cpp
@@ -29,12 +29,15 @@
 #include "upgrade.h"
 
 #include <QFile>
+#include <QMetaEnum>
 #include <QVector>
 
+#include "base/bittorrent/torrentcontentlayout.h"
 #include "base/logger.h"
 #include "base/profile.h"
 #include "base/settingsstorage.h"
 #include "base/utils/fs.h"
+#include "base/utils/string.h"
 
 namespace
 {
@@ -79,11 +82,32 @@ namespace
             , QLatin1String("Preferences/WebUI/HTTPS/KeyPath")
             , Utils::Fs::toNativePath(configPath + QLatin1String("WebUIPrivateKey.pem")));
     }
+
+    void upgradeTorrentContentLayout()
+    {
+        const QString oldKey {QLatin1String {"BitTorrent/Session/CreateTorrentSubfolder"}};
+        const QString newKey {QLatin1String {"BitTorrent/Session/TorrentContentLayout"}};
+
+        SettingsStorage *settingsStorage {SettingsStorage::instance()};
+        const QVariant oldData {settingsStorage->loadValue(oldKey)};
+        const QString newData {settingsStorage->loadValue(newKey).toString()};
+
+        if (!newData.isEmpty() || !oldData.isValid())
+            return;
+
+        const bool createSubfolder = oldData.toBool();
+        const BitTorrent::TorrentContentLayout torrentContentLayout =
+                (createSubfolder ? BitTorrent::TorrentContentLayout::Original : BitTorrent::TorrentContentLayout::NoSubfolder);
+
+        settingsStorage->storeValue(newKey, Utils::String::fromEnum(torrentContentLayout));
+        settingsStorage->removeValue(oldKey);
+    }
 }
 
 bool upgrade(const bool /*ask*/)
 {
     exportWebUIHttpsFiles();
+    upgradeTorrentContentLayout();
     return true;
 }
 

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(qbt_base STATIC
     bittorrent/sessionstatus.h
     bittorrent/speedmonitor.h
     bittorrent/statistics.h
+    bittorrent/torrentcontentlayout.h
     bittorrent/torrentcreatorthread.h
     bittorrent/torrenthandle.h
     bittorrent/torrenthandleimpl.h

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -23,6 +23,7 @@ HEADERS += \
     $$PWD/bittorrent/sessionstatus.h \
     $$PWD/bittorrent/speedmonitor.h \
     $$PWD/bittorrent/statistics.h \
+    $$PWD/bittorrent/torrentcontentlayout.h \
     $$PWD/bittorrent/torrentcreatorthread.h \
     $$PWD/bittorrent/torrenthandle.h \
     $$PWD/bittorrent/torrenthandleimpl.h \

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -661,9 +661,7 @@ QString Session::tempPath() const
 QString Session::torrentTempPath(const TorrentInfo &torrentInfo) const
 {
     if ((torrentInfo.filesCount() > 1) && !torrentInfo.hasRootFolder())
-        return tempPath()
-            + QString::fromStdString(torrentInfo.nativeInfo()->orig_files().name())
-            + '/';
+        return tempPath() + torrentInfo.name() + '/';
 
     return tempPath();
 }

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -396,7 +396,7 @@ Session::Session(QObject *parent)
     , m_globalMaxRatio(BITTORRENT_SESSION_KEY("GlobalMaxRatio"), -1, [](qreal r) { return r < 0 ? -1. : r;})
     , m_globalMaxSeedingMinutes(BITTORRENT_SESSION_KEY("GlobalMaxSeedingMinutes"), -1, lowerLimited(-1))
     , m_isAddTorrentPaused(BITTORRENT_SESSION_KEY("AddTorrentPaused"), false)
-    , m_isKeepTorrentTopLevelFolder(BITTORRENT_SESSION_KEY("CreateTorrentSubfolder"), true)
+    , m_torrentContentLayout(BITTORRENT_SESSION_KEY("TorrentContentLayout"), TorrentContentLayout::Original)
     , m_isAppendExtensionEnabled(BITTORRENT_SESSION_KEY("AddExtensionToIncompleteFiles"), false)
     , m_refreshInterval(BITTORRENT_SESSION_KEY("RefreshInterval"), 1500)
     , m_isPreallocationEnabled(BITTORRENT_SESSION_KEY("Preallocation"), false)
@@ -2094,9 +2094,9 @@ LoadTorrentParams Session::initLoadTorrentParams(const AddTorrentParams &addTorr
     loadTorrentParams.tags = addTorrentParams.tags;
     loadTorrentParams.firstLastPiecePriority = addTorrentParams.firstLastPiecePriority;
     loadTorrentParams.hasSeedStatus = addTorrentParams.skipChecking; // do not react on 'torrent_finished_alert' when skipping
-    loadTorrentParams.hasRootFolder = ((addTorrentParams.createSubfolder == TriStateBool::Undefined)
-                        ? isKeepTorrentTopLevelFolder()
-                        : (addTorrentParams.createSubfolder == TriStateBool::True));
+    loadTorrentParams.contentLayout = (addTorrentParams.contentLayout
+                                       ? *addTorrentParams.contentLayout
+                                       : torrentContentLayout());
     loadTorrentParams.forced = (addTorrentParams.addForced == TriStateBool::True);
     loadTorrentParams.paused = ((addTorrentParams.addPaused == TriStateBool::Undefined)
                     ? isAddTorrentPaused()
@@ -2161,8 +2161,7 @@ bool Session::addTorrent_impl(const AddTorrentParams &addTorrentParams, const Ma
     const QString actualSavePath = loadTorrentParams.savePath.isEmpty() ? categorySavePath(loadTorrentParams.category) : loadTorrentParams.savePath;
     if (hasMetadata)
     {
-        if (!loadTorrentParams.hasRootFolder)
-            metadata.stripRootFolder();
+        metadata.setContentLayout(loadTorrentParams.contentLayout);
 
         if (!loadTorrentParams.hasSeedStatus)
         {
@@ -4234,8 +4233,26 @@ bool Session::loadTorrentResumeData(const QByteArray &data, const TorrentInfo &m
         Utils::Fs::toUniformPath(fromLTString(root.dict_find_string_value("qBt-savePath"))));
     torrentParams.hasSeedStatus = root.dict_find_int_value("qBt-seedStatus");
     torrentParams.firstLastPiecePriority = root.dict_find_int_value("qBt-firstLastPiecePriority");
-    torrentParams.hasRootFolder = root.dict_find_int_value("qBt-hasRootFolder");
     torrentParams.seedingTimeLimit = root.dict_find_int_value("qBt-seedingTimeLimit", TorrentHandle::USE_GLOBAL_SEEDING_TIME);
+
+    // TODO: The following code is deprecated. Replace with the commented one after several releases in 4.4.x.
+    // === BEGIN DEPRECATED CODE === //
+    const lt::bdecode_node contentLayoutNode = root.dict_find("qBt-contentLayout");
+    if (contentLayoutNode.type() == lt::bdecode_node::string_t)
+    {
+        const QString contentLayoutStr = fromLTString(contentLayoutNode.string_value());
+        torrentParams.contentLayout = Utils::String::toEnum(contentLayoutStr, TorrentContentLayout::Original);
+    }
+    else
+    {
+        const bool hasRootFolder = root.dict_find_int_value("qBt-hasRootFolder");
+        torrentParams.contentLayout = (hasRootFolder ? TorrentContentLayout::Original : TorrentContentLayout::NoSubfolder);
+    }
+    // === END DEPRECATED CODE === //
+    // === BEGIN REPLACEMENT CODE === //
+//    torrentParams.contentLayout = Utils::String::parse(
+//                fromLTString(root.dict_find_string_value("qBt-contentLayout")), TorrentContentLayout::Default);
+    // === END REPLACEMENT CODE === //
 
     const lt::string_view ratioLimitString = root.dict_find_string_value("qBt-ratioLimit");
     if (ratioLimitString.empty())
@@ -4467,14 +4484,14 @@ std::vector<lt::alert *> Session::getPendingAlerts(const lt::time_duration time)
     return alerts;
 }
 
-bool Session::isKeepTorrentTopLevelFolder() const
+TorrentContentLayout Session::torrentContentLayout() const
 {
-    return m_isKeepTorrentTopLevelFolder;
+    return m_torrentContentLayout;
 }
 
-void Session::setKeepTorrentTopLevelFolder(const bool value)
+void Session::setTorrentContentLayout(const TorrentContentLayout value)
 {
-    m_isKeepTorrentTopLevelFolder = value;
+    m_torrentContentLayout = value;
 }
 
 // Read alerts sent by the BitTorrent session

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -114,7 +114,7 @@ namespace BitTorrent
     // Using `Q_ENUM_NS()` without a wrapper namespace in our case is not advised
     // since `Q_NAMESPACE` cannot be used when the same namespace resides at different files.
     // https://www.kdab.com/new-qt-5-8-meta-object-support-namespaces/#comment-143779
-    namespace SessionSettingsEnums
+    inline namespace SessionSettingsEnums
     {
         Q_NAMESPACE
 
@@ -160,7 +160,6 @@ namespace BitTorrent
         Q_ENUM_NS(OSMemoryPriority)
 #endif
     }
-    using namespace SessionSettingsEnums;
 
     struct SessionMetricIndices
     {
@@ -274,8 +273,8 @@ namespace BitTorrent
         void setPeXEnabled(bool enabled);
         bool isAddTorrentPaused() const;
         void setAddTorrentPaused(bool value);
-        bool isKeepTorrentTopLevelFolder() const;
-        void setKeepTorrentTopLevelFolder(bool value);
+        TorrentContentLayout torrentContentLayout() const;
+        void setTorrentContentLayout(TorrentContentLayout value);
         bool isTrackerEnabled() const;
         void setTrackerEnabled(bool enabled);
         bool isAppendExtensionEnabled() const;
@@ -702,7 +701,7 @@ namespace BitTorrent
         CachedSettingValue<qreal> m_globalMaxRatio;
         CachedSettingValue<int> m_globalMaxSeedingMinutes;
         CachedSettingValue<bool> m_isAddTorrentPaused;
-        CachedSettingValue<bool> m_isKeepTorrentTopLevelFolder;
+        CachedSettingValue<TorrentContentLayout> m_torrentContentLayout;
         CachedSettingValue<bool> m_isAppendExtensionEnabled;
         CachedSettingValue<int> m_refreshInterval;
         CachedSettingValue<bool> m_isPreallocationEnabled;

--- a/src/base/bittorrent/torrentcontentlayout.h
+++ b/src/base/bittorrent/torrentcontentlayout.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2020  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -28,38 +28,24 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
-
-#include <QSet>
-#include <QString>
-#include <QVector>
-
-#include "base/tristatebool.h"
-#include "torrenthandle.h"
-#include "torrentcontentlayout.h"
+#include <QMetaEnum>
 
 namespace BitTorrent
 {
-    enum class DownloadPriority;
-
-    struct AddTorrentParams
+    // Using `Q_ENUM_NS()` without a wrapper namespace in our case is not advised
+    // since `Q_NAMESPACE` cannot be used when the same namespace resides at different files.
+    // https://www.kdab.com/new-qt-5-8-meta-object-support-namespaces/#comment-143779
+    inline namespace TorrentContentLayoutNS
     {
-        QString name;
-        QString category;
-        QSet<QString> tags;
-        QString savePath;
-        bool disableTempPath = false; // e.g. for imported torrents
-        bool sequential = false;
-        bool firstLastPiecePriority = false;
-        TriStateBool addForced;
-        TriStateBool addPaused;
-        QVector<DownloadPriority> filePriorities; // used if TorrentInfo is set
-        bool skipChecking = false;
-        boost::optional<BitTorrent::TorrentContentLayout> contentLayout;
-        TriStateBool useAutoTMM;
-        int uploadLimit = -1;
-        int downloadLimit = -1;
-        int seedingTimeLimit = TorrentHandle::USE_GLOBAL_SEEDING_TIME;
-        qreal ratioLimit = TorrentHandle::USE_GLOBAL_RATIO;
-    };
+        Q_NAMESPACE
+
+        enum class TorrentContentLayout
+        {
+            Original,
+            Subfolder,
+            NoSubfolder
+        };
+
+        Q_ENUM_NS(TorrentContentLayout)
+    }
 }

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -177,8 +177,6 @@ namespace BitTorrent
         virtual bool removeTag(const QString &tag) = 0;
         virtual void removeAllTags() = 0;
 
-        virtual bool hasRootFolder() const = 0;
-
         virtual int filesCount() const = 0;
         virtual int piecesCount() const = 0;
         virtual int piecesHave() const = 0;

--- a/src/base/bittorrent/torrenthandleimpl.cpp
+++ b/src/base/bittorrent/torrenthandleimpl.cpp
@@ -185,17 +185,15 @@ InfoHash TorrentHandleImpl::hash() const
 
 QString TorrentHandleImpl::name() const
 {
-    QString name = m_name;
-    if (!name.isEmpty()) return name;
-
-    name = QString::fromStdString(m_nativeStatus.name);
-    if (!name.isEmpty()) return name;
+    if (!m_name.isEmpty())
+        return m_name;
 
     if (hasMetadata())
-    {
-        name = QString::fromStdString(m_torrentInfo.nativeInfo()->orig_files().name());
-        if (!name.isEmpty()) return name;
-    }
+        return m_torrentInfo.name();
+
+    const QString name = QString::fromStdString(m_nativeStatus.name);
+    if (!name.isEmpty())
+        return name;
 
     return m_hash;
 }

--- a/src/base/bittorrent/torrenthandleimpl.h
+++ b/src/base/bittorrent/torrenthandleimpl.h
@@ -62,11 +62,12 @@ namespace BitTorrent
         QString category;
         QSet<QString> tags;
         QString savePath;
+        TorrentContentLayout contentLayout = TorrentContentLayout::Original;
         bool firstLastPiecePriority = false;
         bool hasSeedStatus = false;
-        bool hasRootFolder = true;
         bool forced = false;
         bool paused = false;
+
 
         qreal ratioLimit = TorrentHandle::USE_GLOBAL_RATIO;
         int seedingTimeLimit = TorrentHandle::USE_GLOBAL_SEEDING_TIME;
@@ -128,8 +129,6 @@ namespace BitTorrent
         bool addTag(const QString &tag) override;
         bool removeTag(const QString &tag) override;
         void removeAllTags() override;
-
-        bool hasRootFolder() const override;
 
         int filesCount() const override;
         int piecesCount() const override;
@@ -319,10 +318,10 @@ namespace BitTorrent
         qreal m_ratioLimit;
         int m_seedingTimeLimit;
         TorrentOperatingMode m_operatingMode;
+        TorrentContentLayout m_contentLayout;
         bool m_hasSeedStatus;
         bool m_fastresumeDataRejected = false;
         bool m_hasMissingFiles = false;
-        bool m_hasRootFolder;
         bool m_hasFirstLastPiecePriority = false;
         bool m_useAutoTMM;
         bool m_isStopped;

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -52,6 +52,29 @@
 
 using namespace BitTorrent;
 
+namespace
+{
+    QString getRootFolder(const QStringList &filePaths)
+    {
+        QString rootFolder;
+        for (const QString &filePath : filePaths)
+        {
+            if (QDir::isAbsolutePath(filePath)) continue;
+
+            const auto filePathElements = filePath.splitRef('/');
+            // if at least one file has no root folder, no common root folder exists
+            if (filePathElements.count() <= 1) return {};
+
+            if (rootFolder.isEmpty())
+                rootFolder = filePathElements.at(0).toString();
+            else if (rootFolder != filePathElements.at(0))
+                return {};
+        }
+
+        return rootFolder;
+    }
+}
+
 TorrentInfo::TorrentInfo(std::shared_ptr<const lt::torrent_info> nativeInfo)
 {
     m_nativeInfo = std::const_pointer_cast<lt::torrent_info>(nativeInfo);
@@ -412,23 +435,7 @@ int TorrentInfo::fileIndex(const QString &fileName) const
 
 QString TorrentInfo::rootFolder() const
 {
-    QString rootFolder;
-    for (int i = 0; i < filesCount(); ++i)
-    {
-        const QString filePath = this->filePath(i);
-        if (QDir::isAbsolutePath(filePath)) continue;
-
-        const auto filePathElements = filePath.splitRef('/');
-        // if at least one file has no root folder, no common root folder exists
-        if (filePathElements.count() <= 1) return "";
-
-        if (rootFolder.isEmpty())
-            rootFolder = filePathElements.at(0).toString();
-        else if (rootFolder != filePathElements.at(0))
-            return "";
-    }
-
-    return rootFolder;
+    return getRootFolder(filePaths());
 }
 
 bool TorrentInfo::hasRootFolder() const
@@ -436,10 +443,26 @@ bool TorrentInfo::hasRootFolder() const
     return !rootFolder().isEmpty();
 }
 
+void TorrentInfo::setContentLayout(const TorrentContentLayout layout)
+{
+    switch (layout)
+    {
+    case TorrentContentLayout::Original:
+        setContentLayout(defaultContentLayout());
+        break;
+    case TorrentContentLayout::Subfolder:
+        if (rootFolder().isEmpty())
+            addRootFolder();
+        break;
+    case TorrentContentLayout::NoSubfolder:
+        if (!rootFolder().isEmpty())
+            stripRootFolder();
+        break;
+    }
+}
+
 void TorrentInfo::stripRootFolder()
 {
-    if (!hasRootFolder()) return;
-
     lt::file_storage files = m_nativeInfo->files();
 
     // Solution for case of renamed root folder
@@ -454,6 +477,32 @@ void TorrentInfo::stripRootFolder()
 
     files.set_name("");
     m_nativeInfo->remap_files(files);
+}
+
+void TorrentInfo::addRootFolder()
+{
+    const QString rootFolder = name();
+    Q_ASSERT(!rootFolder.isEmpty());
+
+    const std::string rootPrefix = Utils::Fs::toNativePath(rootFolder + QLatin1Char {'/'}).toStdString();
+    lt::file_storage files = m_nativeInfo->files();
+    files.set_name(rootFolder.toStdString());
+    for (int i = 0; i < files.num_files(); ++i)
+        files.rename_file(lt::file_index_t {i}, rootPrefix + files.file_path(lt::file_index_t {i}));
+    m_nativeInfo->remap_files(files);
+}
+
+TorrentContentLayout TorrentInfo::defaultContentLayout() const
+{
+    QStringList origFilePaths;
+    origFilePaths.reserve(filesCount());
+    for (int i = 0; i < filesCount(); ++i)
+        origFilePaths << origFilePath(i);
+
+    const QString origRootFolder = getRootFolder(origFilePaths);
+    return (origRootFolder.isEmpty()
+            ? TorrentContentLayout::NoSubfolder
+            : TorrentContentLayout::Subfolder);
 }
 
 std::shared_ptr<lt::torrent_info> TorrentInfo::nativeInfo() const

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -170,7 +170,7 @@ InfoHash TorrentInfo::hash() const
 QString TorrentInfo::name() const
 {
     if (!isValid()) return {};
-    return QString::fromStdString(m_nativeInfo->name());
+    return QString::fromStdString(m_nativeInfo->orig_files().name());
 }
 
 QDateTime TorrentInfo::creationDate() const

--- a/src/base/bittorrent/torrentinfo.h
+++ b/src/base/bittorrent/torrentinfo.h
@@ -34,6 +34,7 @@
 #include <QtContainerFwd>
 
 #include "base/indexrange.h"
+#include "torrentcontentlayout.h"
 
 class QByteArray;
 class QDateTime;
@@ -94,13 +95,17 @@ namespace BitTorrent
 
         QString rootFolder() const;
         bool hasRootFolder() const;
-        void stripRootFolder();
+        void setContentLayout(TorrentContentLayout layout);
 
         std::shared_ptr<lt::torrent_info> nativeInfo() const;
 
     private:
         // returns file index or -1 if fileName is not found
         int fileIndex(const QString &fileName) const;
+        void stripRootFolder();
+        void addRootFolder();
+        TorrentContentLayout defaultContentLayout() const;
+
         std::shared_ptr<lt::torrent_info> m_nativeInfo;
     };
 }

--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -396,7 +396,7 @@ void AutoDownloader::processJob(const QSharedPointer<ProcessingJob> &job)
         params.savePath = rule.savePath();
         params.category = rule.assignedCategory();
         params.addPaused = rule.addPaused();
-        params.createSubfolder = rule.createSubfolder();
+        params.contentLayout = rule.torrentContentLayout();
         if (!rule.savePath().isEmpty())
             params.useAutoTMM = TriStateBool::False;
         const auto torrentURL = job->articleData.value(Article::KeyTorrentURL).toString();

--- a/src/base/rss/rss_autodownloadrule.h
+++ b/src/base/rss/rss_autodownloadrule.h
@@ -29,8 +29,12 @@
 
 #pragma once
 
+#include <boost/optional.hpp>
+
 #include <QSharedDataPointer>
 #include <QVariant>
+
+#include "base/bittorrent/torrentcontentlayout.h"
 
 class QDateTime;
 class QJsonObject;
@@ -79,8 +83,8 @@ namespace RSS
         void setSavePath(const QString &savePath);
         TriStateBool addPaused() const;
         void setAddPaused(TriStateBool addPaused);
-        TriStateBool createSubfolder() const;
-        void setCreateSubfolder(TriStateBool createSubfolder);
+        boost::optional<BitTorrent::TorrentContentLayout> torrentContentLayout() const;
+        void setTorrentContentLayout(boost::optional<BitTorrent::TorrentContentLayout> contentLayout);
         QString assignedCategory() const;
         void setCategory(const QString &category);
 

--- a/src/base/settingvalue.h
+++ b/src/base/settingvalue.h
@@ -78,13 +78,13 @@ public:
 
 private:
     // regular load/save pair
-    template <typename U, typename std::enable_if<!std::is_enum<U>::value, int>::type = 0>
+    template <typename U, typename std::enable_if_t<!std::is_enum<U>::value, int> = 0>
     U loadValue(const U &defaultValue)
     {
         return SettingsStorage::instance()->loadValue(m_keyName, defaultValue).template value<T>();
     }
 
-    template <typename U, typename std::enable_if<!std::is_enum<U>::value, int>::type = 0>
+    template <typename U, typename std::enable_if_t<!std::is_enum<U>::value, int> = 0>
     void storeValue(const U &value)
     {
         SettingsStorage::instance()->storeValue(m_keyName, value);
@@ -92,16 +92,16 @@ private:
 
     // load/save pair for an enum
     // saves literal value of the enum constant, obtained from QMetaEnum
-    template <typename U, typename std::enable_if<std::is_enum<U>::value, int>::type = 0>
+    template <typename U, typename std::enable_if_t<std::is_enum<U>::value, int> = 0>
     U loadValue(const U &defaultValue)
     {
-        return Utils::String::parse(SettingsStorage::instance()->loadValue(m_keyName).toString(), defaultValue);
+        return Utils::String::toEnum(SettingsStorage::instance()->loadValue(m_keyName).toString(), defaultValue);
     }
 
-    template <typename U, typename std::enable_if<std::is_enum<U>::value, int>::type = 0>
+    template <typename U, typename std::enable_if_t<std::is_enum<U>::value, int> = 0>
     void storeValue(const U &value)
     {
-        SettingsStorage::instance()->storeValue(m_keyName, Utils::String::serialize(value));
+        SettingsStorage::instance()->storeValue(m_keyName, Utils::String::fromEnum(value));
     }
 
     const QString m_keyName;

--- a/src/base/settingvalue.h
+++ b/src/base/settingvalue.h
@@ -34,6 +34,7 @@
 #include <QString>
 
 #include "settingsstorage.h"
+#include "utils/string.h"
 
 template <typename T>
 class CachedSettingValue
@@ -94,20 +95,13 @@ private:
     template <typename U, typename std::enable_if<std::is_enum<U>::value, int>::type = 0>
     U loadValue(const U &defaultValue)
     {
-        static_assert(std::is_same<int, typename std::underlying_type<U>::type>::value,
-                      "Enumeration underlying type has to be int");
-
-        bool ok = false;
-        const U res = static_cast<U>(QMetaEnum::fromType<U>().keyToValue(
-            SettingsStorage::instance()->loadValue(m_keyName).toString().toLatin1().constData(), &ok));
-        return ok ? res : defaultValue;
+        return Utils::String::parse(SettingsStorage::instance()->loadValue(m_keyName).toString(), defaultValue);
     }
 
     template <typename U, typename std::enable_if<std::is_enum<U>::value, int>::type = 0>
     void storeValue(const U &value)
     {
-        SettingsStorage::instance()->storeValue(m_keyName,
-            QString::fromLatin1(QMetaEnum::fromType<U>().valueToKey(static_cast<int>(value))));
+        SettingsStorage::instance()->storeValue(m_keyName, Utils::String::serialize(value));
     }
 
     const QString m_keyName;

--- a/src/base/utils/string.h
+++ b/src/base/utils/string.h
@@ -73,20 +73,25 @@ namespace Utils
 
         QString join(const QVector<QStringRef> &strings, const QString &separator);
 
-        template <typename U, typename std::enable_if<std::is_enum<U>::value, int>::type = 0>
-        QString serialize(const U &value)
+        template <typename T, typename std::enable_if_t<std::is_enum<T>::value, int> = 0>
+        QString fromEnum(const T &value)
         {
-            return QString::fromLatin1(QMetaEnum::fromType<U>().valueToKey(static_cast<int>(value)));
-        }
-
-        template <typename U, typename std::enable_if<std::is_enum<U>::value, int>::type = 0>
-        U parse(const QString &serializedValue, const U &defaultValue)
-        {
-            static_assert(std::is_same<int, typename std::underlying_type<U>::type>::value,
+            static_assert(std::is_same<int, typename std::underlying_type_t<T>>::value,
                           "Enumeration underlying type has to be int.");
 
+            const auto metaEnum = QMetaEnum::fromType<T>();
+            return QString::fromLatin1(metaEnum.valueToKey(static_cast<int>(value)));
+        }
+
+        template <typename T, typename std::enable_if_t<std::is_enum<T>::value, int> = 0>
+        T toEnum(const QString &serializedValue, const T &defaultValue)
+        {
+            static_assert(std::is_same<int, typename std::underlying_type_t<T>>::value,
+                          "Enumeration underlying type has to be int.");
+
+            const auto metaEnum = QMetaEnum::fromType<T>();
             bool ok = false;
-            const U value = static_cast<U>(QMetaEnum::fromType<U>().keyToValue(serializedValue.toLatin1().constData(), &ok));
+            const T value = static_cast<T>(metaEnum.keyToValue(serializedValue.toLatin1().constData(), &ok));
             return (ok ? value : defaultValue);
         }
     }

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -123,12 +123,8 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::AddTorrentParams &inP
     const bool rememberLastSavePath = settings()->loadValue(KEY_REMEMBERLASTSAVEPATH, false).toBool();
     m_ui->checkBoxRememberLastSavePath->setChecked(rememberLastSavePath);
 
-    if (m_torrentParams.createSubfolder == TriStateBool::True)
-        m_ui->keepTopLevelFolderCheckBox->setChecked(true);
-    else if (m_torrentParams.createSubfolder == TriStateBool::False)
-        m_ui->keepTopLevelFolderCheckBox->setChecked(false);
-    else
-        m_ui->keepTopLevelFolderCheckBox->setChecked(session->isKeepTorrentTopLevelFolder());
+    m_ui->contentLayoutComboBox->setCurrentIndex(
+                static_cast<int>(m_torrentParams.contentLayout ? *m_torrentParams.contentLayout : session->torrentContentLayout()));
 
     m_ui->sequentialCheckBox->setChecked(m_torrentParams.sequential);
     m_ui->firstLastCheckBox->setChecked(m_torrentParams.firstLastPiecePriority);
@@ -308,7 +304,6 @@ bool AddNewTorrentDialog::loadTorrentImpl()
     m_ui->labelHashData->setText(infoHash);
     setupTreeview();
     TMMChanged(m_ui->comboTTM->currentIndex());
-    m_ui->keepTopLevelFolderCheckBox->setEnabled(m_torrentInfo.hasRootFolder());
     return true;
 }
 
@@ -579,7 +574,7 @@ void AddNewTorrentDialog::accept()
         m_torrentParams.filePriorities = m_contentModel->model()->getFilePriorities();
 
     m_torrentParams.addPaused = TriStateBool(!m_ui->startTorrentCheckBox->isChecked());
-    m_torrentParams.createSubfolder = TriStateBool(m_ui->keepTopLevelFolderCheckBox->isChecked());
+    m_torrentParams.contentLayout = static_cast<BitTorrent::TorrentContentLayout>(m_ui->contentLayoutComboBox->currentIndex());
 
     m_torrentParams.sequential = m_ui->sequentialCheckBox->isChecked();
     m_torrentParams.firstLastPiecePriority = m_ui->firstLastCheckBox->isChecked();
@@ -640,7 +635,6 @@ void AddNewTorrentDialog::updateMetadata(const BitTorrent::TorrentInfo &metadata
     // Update UI
     setupTreeview();
     setMetadataProgressIndicator(false, tr("Metadata retrieval complete"));
-    m_ui->keepTopLevelFolderCheckBox->setEnabled(m_torrentInfo.hasRootFolder());
 }
 
 void AddNewTorrentDialog::setMetadataProgressIndicator(bool visibleIndicator, const QString &labelText)

--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -135,7 +135,7 @@
           </item>
           <item>
            <layout class="QGridLayout" name="gridLayout">
-            <item row="3" column="0">
+            <item row="2" column="0">
              <widget class="QCheckBox" name="doNotDeleteTorrentCheckBox">
               <property name="toolTip">
                <string>When checked, the .torrent file will not be deleted despite the settings at the &quot;Download&quot; page of the options dialog</string>
@@ -152,7 +152,7 @@
               </property>
              </widget>
             </item>
-            <item row="2" column="0">
+            <item row="1" column="0">
              <widget class="QCheckBox" name="skipCheckingCheckBox">
               <property name="text">
                <string>Skip hash check</string>
@@ -166,13 +166,6 @@
               </property>
              </widget>
             </item>
-            <item row="1" column="0">
-             <widget class="QCheckBox" name="keepTopLevelFolderCheckBox">
-              <property name="text">
-               <string>Keep top-level folder</string>
-              </property>
-             </widget>
-            </item>
             <item row="0" column="0">
              <widget class="QCheckBox" name="startTorrentCheckBox">
               <property name="text">
@@ -182,6 +175,52 @@
             </item>
             <item row="0" column="2">
              <spacer name="horizontalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <item>
+             <widget class="QLabel" name="contentLayoutLabel">
+              <property name="text">
+               <string>Content layout:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="contentLayoutComboBox">
+              <property name="currentIndex">
+               <number>0</number>
+              </property>
+              <item>
+               <property name="text">
+                <string>Original</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Create subfolder</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Don't create subfolder</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_4">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -358,7 +358,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     connect(m_ui->checkAdditionDialog, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkAdditionDialogFront, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkStartPaused, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
-    connect(m_ui->checkKeepTopLevelFolder, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->contentLayoutComboBox, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->deleteTorrentBox, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->deleteCancelledTorrentBox, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkExportDir, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
@@ -752,7 +752,7 @@ void OptionsDialog::saveOptions()
     AddNewTorrentDialog::setEnabled(useAdditionDialog());
     AddNewTorrentDialog::setTopLevel(m_ui->checkAdditionDialogFront->isChecked());
     session->setAddTorrentPaused(addTorrentsInPause());
-    session->setKeepTorrentTopLevelFolder(m_ui->checkKeepTopLevelFolder->isChecked());
+    session->setTorrentContentLayout(static_cast<BitTorrent::TorrentContentLayout>(m_ui->contentLayoutComboBox->currentIndex()));
     ScanFoldersModel::instance()->removeFromFSWatcher(m_removedScanDirs);
     ScanFoldersModel::instance()->addToFSWatcher(m_addedScanDirs);
     ScanFoldersModel::instance()->makePersistent();
@@ -1000,7 +1000,7 @@ void OptionsDialog::loadOptions()
     m_ui->checkAdditionDialog->setChecked(AddNewTorrentDialog::isEnabled());
     m_ui->checkAdditionDialogFront->setChecked(AddNewTorrentDialog::isTopLevel());
     m_ui->checkStartPaused->setChecked(session->isAddTorrentPaused());
-    m_ui->checkKeepTopLevelFolder->setChecked(session->isKeepTorrentTopLevelFolder());
+    m_ui->contentLayoutComboBox->setCurrentIndex(static_cast<int>(session->torrentContentLayout()));
     const TorrentFileGuard::AutoDeleteMode autoDeleteMode = TorrentFileGuard::autoDeleteMode();
     m_ui->deleteTorrentBox->setChecked(autoDeleteMode != TorrentFileGuard::Never);
     m_ui->deleteCancelledTorrentBox->setChecked(autoDeleteMode == TorrentFileGuard::Always);

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -769,14 +769,50 @@
                 </widget>
                </item>
                <item>
-                <widget class="QCheckBox" name="checkKeepTopLevelFolder">
-                 <property name="text">
-                  <string>Keep top-level folder</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
+                <layout class="QHBoxLayout" name="horizontalLayout_19">
+                 <item>
+                  <widget class="QLabel" name="contentLayoutLabel">
+                   <property name="text">
+                    <string>Torrent content layout:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="contentLayoutComboBox">
+                   <property name="currentIndex">
+                    <number>0</number>
+                   </property>
+                   <item>
+                    <property name="text">
+                     <string>Original</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Create subfolder</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Don't create subfolder</string>
+                    </property>
+                   </item>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_20">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
                </item>
                <item>
                 <widget class="QCheckBox" name="checkStartPaused">

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -275,11 +275,9 @@ void AutomatedRssDownloader::updateRuleDefinitionBox()
             index = 2;
         m_ui->comboAddPaused->setCurrentIndex(index);
         index = 0;
-        if (m_currentRule.createSubfolder() == TriStateBool::True)
-            index = 1;
-        else if (m_currentRule.createSubfolder() == TriStateBool::False)
-            index = 2;
-        m_ui->comboCreateSubfolder->setCurrentIndex(index);
+        if (m_currentRule.torrentContentLayout())
+            index = static_cast<int>(*m_currentRule.torrentContentLayout()) + 1;
+        m_ui->comboContentLayout->setCurrentIndex(index);
         m_ui->spinIgnorePeriod->setValue(m_currentRule.ignoreDays());
         QDateTime dateTime = m_currentRule.lastMatch();
         QString lMatch;
@@ -320,8 +318,8 @@ void AutomatedRssDownloader::clearRuleDefinitionBox()
     m_ui->spinIgnorePeriod->setValue(0);
     m_ui->comboAddPaused->clearEditText();
     m_ui->comboAddPaused->setCurrentIndex(-1);
-    m_ui->comboCreateSubfolder->clearEditText();
-    m_ui->comboCreateSubfolder->setCurrentIndex(-1);
+    m_ui->comboContentLayout->clearEditText();
+    m_ui->comboContentLayout->setCurrentIndex(-1);
     updateFieldsToolTips(m_ui->checkRegex->isChecked());
     updateMustLineValidity();
     updateMustNotLineValidity();
@@ -355,12 +353,12 @@ void AutomatedRssDownloader::updateEditedRule()
     else if (m_ui->comboAddPaused->currentIndex() == 2)
         addPaused = TriStateBool::False;
     m_currentRule.setAddPaused(addPaused);
-    TriStateBool createSubfolder; // Undefined by default
-    if (m_ui->comboCreateSubfolder->currentIndex() == 1)
-        createSubfolder = TriStateBool::True;
-    else if (m_ui->comboCreateSubfolder->currentIndex() == 2)
-        createSubfolder = TriStateBool::False;
-    m_currentRule.setCreateSubfolder(createSubfolder);
+
+    boost::optional<BitTorrent::TorrentContentLayout> contentLayout;
+    if (m_ui->comboContentLayout->currentIndex() > 0)
+        contentLayout = static_cast<BitTorrent::TorrentContentLayout>(m_ui->comboContentLayout->currentIndex() - 1);
+    m_currentRule.setTorrentContentLayout(contentLayout);
+
     m_currentRule.setIgnoreDays(m_ui->spinIgnorePeriod->value());
 }
 

--- a/src/gui/rss/automatedrssdownloader.ui
+++ b/src/gui/rss/automatedrssdownloader.ui
@@ -325,7 +325,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_10">
             <item>
-             <widget class="QLabel" name="lblKeepTopLevelFolder">
+             <widget class="QLabel" name="lblContentLayout">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
                 <horstretch>0</horstretch>
@@ -333,12 +333,12 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                </sizepolicy>
               </property>
               <property name="text">
-               <string>Keep top-level folder:</string>
+               <string>Torrent content layout:</string>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QComboBox" name="comboCreateSubfolder">
+             <widget class="QComboBox" name="comboContentLayout">
               <item>
                <property name="text">
                 <string>Use global settings</string>
@@ -346,12 +346,17 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
               </item>
               <item>
                <property name="text">
-                <string>Always</string>
+                <string>Original</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Never</string>
+                <string>Create subfolder</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Don't create subfolder</string>
                </property>
               </item>
              </widget>
@@ -471,7 +476,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
   <tabstop>lineSavePath</tabstop>
   <tabstop>spinIgnorePeriod</tabstop>
   <tabstop>comboAddPaused</tabstop>
-  <tabstop>comboCreateSubfolder</tabstop>
+  <tabstop>comboContentLayout</tabstop>
   <tabstop>listFeeds</tabstop>
   <tabstop>treeMatchingArticles</tabstop>
   <tabstop>importBtn</tabstop>

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -56,6 +56,7 @@
 #include "base/utils/misc.h"
 #include "base/utils/net.h"
 #include "base/utils/password.h"
+#include "base/utils/string.h"
 #include "../webapplication.h"
 
 void AppController::webapiVersionAction()
@@ -100,7 +101,7 @@ void AppController::preferencesAction()
 
     // Downloads
     // When adding a torrent
-    data["create_subfolder_enabled"] = session->isKeepTorrentTopLevelFolder();
+    data["torrent_content_layout"] = Utils::String::fromEnum(session->torrentContentLayout());
     data["start_paused_enabled"] = session->isAddTorrentPaused();
     data["auto_delete_mode"] = static_cast<int>(TorrentFileGuard::autoDeleteMode());
     data["preallocate_all"] = session->isPreallocationEnabled();
@@ -355,8 +356,8 @@ void AppController::setPreferencesAction()
 
     // Downloads
     // When adding a torrent
-    if (hasKey("create_subfolder_enabled"))
-        session->setKeepTorrentTopLevelFolder(it.value().toBool());
+    if (hasKey("torrent_content_layout"))
+        session->setTorrentContentLayout(Utils::String::toEnum(it.value().toString(), BitTorrent::TorrentContentLayout::Original));
     if (hasKey("start_paused_enabled"))
         session->setAddTorrentPaused(it.value().toBool());
     if (hasKey("auto_delete_mode"))

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -568,7 +568,6 @@ void TorrentsController::addAction()
     const bool seqDownload = parseBool(params()["sequentialDownload"], false);
     const bool firstLastPiece = parseBool(params()["firstLastPiecePrio"], false);
     const TriStateBool addPaused = parseTriStateBool(params()["paused"]);
-    const TriStateBool rootFolder = parseTriStateBool(params()["root_folder"]);
     const QString savepath = params()["savepath"].trimmed();
     const QString category = params()["category"];
     const QSet<QString> tags = List::toSet(params()["tags"].split(',', QString::SkipEmptyParts));
@@ -577,6 +576,11 @@ void TorrentsController::addAction()
     const int upLimit = params()["upLimit"].toInt();
     const int dlLimit = params()["dlLimit"].toInt();
     const TriStateBool autoTMM = parseTriStateBool(params()["autoTMM"]);
+
+    const QString contentLayoutParam = params()["contentLayout"];
+    const boost::optional<BitTorrent::TorrentContentLayout> contentLayout = (!contentLayoutParam.isEmpty()
+            ? Utils::String::toEnum(contentLayoutParam, BitTorrent::TorrentContentLayout::Original)
+            : boost::optional<BitTorrent::TorrentContentLayout> {});
 
     QList<QNetworkCookie> cookies;
     if (!cookie.isEmpty())
@@ -601,7 +605,7 @@ void TorrentsController::addAction()
     params.sequential = seqDownload;
     params.firstLastPiecePriority = firstLastPiece;
     params.addPaused = addPaused;
-    params.createSubfolder = rootFolder;
+    params.contentLayout = contentLayout;
     params.savePath = savepath;
     params.category = category;
     params.tags = tags;

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -43,7 +43,7 @@
 #include "base/utils/net.h"
 #include "base/utils/version.h"
 
-constexpr Utils::Version<int, 3, 2> API_VERSION {2, 6, 2};
+constexpr Utils::Version<int, 3, 2> API_VERSION {2, 7, 0};
 
 class APIController;
 class WebApplication;

--- a/src/webui/www/private/download.html
+++ b/src/webui/www/private/download.html
@@ -89,11 +89,14 @@
                     </tr>
                     <tr>
                         <td>
-                            <label for="rootFolder">QBT_TR(Keep top-level folder)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                            <label for="contentLayout">QBT_TR(Content layout:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
                         </td>
                         <td>
-                            <input type="hidden" id="rootFolderHidden" name="root_folder" />
-                            <input type="checkbox" id="rootFolder" />
+                            <select id="contentLayout" name="contentLayout">
+                                <option selected value="Original">QBT_TR(Original)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
+                                <option value="Subfolder">QBT_TR(Create subfolder)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
+                                <option value="NoSubfolder">QBT_TR(Don't create subfolder)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
+                            </select>
                         </td>
                     </tr>
                     <tr>

--- a/src/webui/www/private/scripts/download.js
+++ b/src/webui/www/private/scripts/download.js
@@ -82,6 +82,16 @@ window.qBittorrent.Download = (function() {
                 else {
                     $('autoTMM').selectedIndex = 0;
                 }
+
+                if (pref.torrent_content_layout === "Subfolder") {
+                    $('contentLayout').selectedIndex = 1;
+                }
+                else if (pref.torrent_content_layout === "NoSubfolder") {
+                    $('contentLayout').selectedIndex = 2;
+                }
+                else {
+                    $('contentLayout').selectedIndex = 0;
+                }
             }
         }).send();
     };

--- a/src/webui/www/private/upload.html
+++ b/src/webui/www/private/upload.html
@@ -77,11 +77,14 @@
                 </tr>
                 <tr>
                     <td>
-                        <label for="rootFolder">QBT_TR(Keep top-level folder)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                        <label for="contentLayout">QBT_TR(Content layout:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
                     </td>
                     <td>
-                        <input type="hidden" id="rootFolderHidden" name="root_folder" />
-                        <input type="checkbox" id="rootFolder" />
+                        <select id="contentLayout" name="contentLayout">
+                            <option selected value="Original">QBT_TR(Original)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
+                            <option value="Subfolder">QBT_TR(Create subfolder)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
+                            <option value="NoSubfolder">QBT_TR(Don't create subfolder)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
+                        </select>
                     </td>
                 </tr>
                 <tr>

--- a/src/webui/www/private/views/rssDownloader.html
+++ b/src/webui/www/private/views/rssDownloader.html
@@ -248,13 +248,14 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
             <table class="fullWidth">
                 <tr>
                     <td>
-                        <label class="noWrap">QBT_TR(Create Subfolder:)QBT_TR[CONTEXT=AutomatedRssDownloader]</label>
+                        <label class="noWrap">QBT_TR(Torrent content layout:)QBT_TR[CONTEXT=AutomatedRssDownloader]</label>
                     </td>
                     <td class="fullWidth">
-                        <select disabled id="creatSubfolderCombobox" class="fullWidth">
-                            <option value="default">QBT_TR(Use global settings)QBT_TR[CONTEXT=AutomatedRssDownloader]</option>
-                            <option value="always">QBT_TR(Always)QBT_TR[CONTEXT=AutomatedRssDownloader]</option>
-                            <option value="never">QBT_TR(Never)QBT_TR[CONTEXT=AutomatedRssDownloader]</option>
+                        <select disabled id="contentLayoutCombobox" class="fullWidth">
+                            <option value="Default">QBT_TR(Use global settings)QBT_TR[CONTEXT=AutomatedRssDownloader]</option>
+                            <option value="Original">QBT_TR(Original)QBT_TR[CONTEXT=AutomatedRssDownloader]</option>
+                            <option value="Subfolder">QBT_TR(Create subfolder)QBT_TR[CONTEXT=AutomatedRssDownloader]</option>
+                            <option value="NoSubfolder">QBT_TR(Don't create subfolder)QBT_TR[CONTEXT=AutomatedRssDownloader]</option>
                         </select>
                     </td>
                 </tr>
@@ -586,15 +587,18 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                     break;
             }
 
-            switch ($('creatSubfolderCombobox').value) {
-                case 'default':
-                    rulesList[rule].createSubfolder = null;
+            switch ($('contentLayoutCombobox').value) {
+                case 'Default':
+                    rulesList[rule].torrentContentLayout = null;
                     break;
-                case 'always':
-                    rulesList[rule].createSubfolder = true;
+                case 'Original':
+                    rulesList[rule].torrentContentLayout = 'Original';
                     break;
-                case 'never':
-                    rulesList[rule].createSubfolder = false;
+                case 'Subfolder':
+                    rulesList[rule].torrentContentLayout = 'Subfolder';
+                    break;
+                case 'NoSubfolder':
+                    rulesList[rule].torrentContentLayout = 'NoSubfolder';
                     break;
             }
 
@@ -660,7 +664,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                 $('saveToText').disabled = true;
                 $('ignoreDaysValue').disabled = true;
                 $('addPausedCombobox').disabled = true;
-                $('creatSubfolderCombobox').disabled = true;
+                $('contentLayoutCombobox').disabled = true;
 
                 // reset all boxes
                 $('useRegEx').checked = false;
@@ -674,7 +678,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                 $('ignoreDaysValue').value = 0;
                 $('lastMatchText').innerHTML = 'QBT_TR(Last Match: Unknown)QBT_TR[CONTEXT=AutomatedRssDownloader]';
                 $('addPausedCombobox').value = 'default';
-                $('creatSubfolderCombobox').value = 'default';
+                $('contentLayoutCombobox').value = 'Default';
                 rssDownloaderFeedSelectionTable.clear();
                 rssDownloaderArticlesTable.clear();
 
@@ -696,7 +700,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                 $('saveToText').disabled = rulesList[ruleName].savePath ? false : true;
                 $('ignoreDaysValue').disabled = false;
                 $('addPausedCombobox').disabled = false;
-                $('creatSubfolderCombobox').disabled = false;
+                $('contentLayoutCombobox').disabled = false;
 
                 // load rule settings
                 $('useRegEx').checked = rulesList[ruleName].useRegex;
@@ -725,10 +729,10 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                 else
                     $('addPausedCombobox').value = rulesList[ruleName].addPaused ? 'always' : 'never';
 
-                if (rulesList[ruleName].createSubfolder === null)
-                    $('creatSubfolderCombobox').value = 'default';
+                if (rulesList[ruleName].torrentContentLayout === null)
+                    $('contentLayoutCombobox').value = 'Default';
                 else
-                    $('creatSubfolderCombobox').value = rulesList[ruleName].createSubfolder ? 'always' : 'never';
+                    $('contentLayoutCombobox').value = rulesList[ruleName].torrentContentLayout;
 
                 setElementTitles();
 


### PR DESCRIPTION
Implement 3 torrent content layouts:
1. <del>Default</del> Original (follow original layout from torrent metadata)
2. Subfolder (create subfolder for torrent content regardless of original content layout)
3. NoSubfolder (don't create subfolder for torrent content regardless of original content layout)

Closes #12833.