### PR TITLE
Don't use default CFLAGS, CXXFLAGS from autotools

### DIFF
--- a/configure
+++ b/configure
@@ -2026,6 +2026,8 @@ ac_configure="$SHELL $ac_aux_dir/configure"  # Please don't use this var.
 
 
 
+: ${CFLAGS=""}
+: ${CXXFLAGS=""}
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,8 @@
 AC_INIT([qbittorrent], [v4.4.0alpha], [bugs.qbittorrent.org], [], [https://www.qbittorrent.org/])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])
+: ${CFLAGS=""}
+: ${CXXFLAGS=""}
 AC_PROG_CC
 AC_PROG_CXX
 AC_PROG_SED


### PR DESCRIPTION
Before this commit, autotools will inject `-g -O2` to debug build (`--enable-debug=yes`) and rendering the result binary useless. This
commit fixes it.
https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.70/html_node/C_002b_002b-Compiler.html

Closes #14032.