### PR TITLE
Don't call non-existent elements

### DIFF
--- a/src/webui/www/private/download.html
+++ b/src/webui/www/private/download.html
@@ -157,7 +157,6 @@
 
         $('downloadForm').addEventListener("submit", function() {
             $('startTorrentHidden').value = $('startTorrent').checked ? 'false' : 'true';
-            $('rootFolderHidden').value = $('rootFolder').checked ? 'true' : 'false';
 
             $('dlLimitHidden').value = $('dlLimitText').value.toInt() * 1024;
             $('upLimitHidden').value = $('upLimitText').value.toInt() * 1024;

--- a/src/webui/www/private/upload.html
+++ b/src/webui/www/private/upload.html
@@ -134,7 +134,6 @@
 
         $('uploadForm').addEventListener("submit", function() {
             $('startTorrentHidden').value = $('startTorrent').checked ? 'false' : 'true';
-            $('rootFolderHidden').value = $('rootFolder').checked ? 'true' : 'false';
 
             $('dlLimitHidden').value = $('dlLimitText').value.toInt() * 1024;
             $('upLimitHidden').value = $('upLimitText').value.toInt() * 1024;


### PR DESCRIPTION
Fixed a regression where the script tries to access elements that no longer exist on the page, because they were replaced with  others by a previous change.

Closes #14083.
Closes #14084.