### PR TITLE
Use style options as much as possible for drawing progress bar

### DIFF
--- a/src/gui/progressbardelegate.cpp
+++ b/src/gui/progressbardelegate.cpp
@@ -64,7 +64,8 @@ void ProgressBarDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
 
     QStyleOptionProgressBar newopt;
     newopt.initFrom(&m_dummyProgressBar);
-    newopt.rect = option.rect;
+    static_cast<QStyleOption &>(newopt) = static_cast<const QStyleOption &>(option);
+    newopt.palette = m_dummyProgressBar.palette();
     initProgressStyleOption(newopt, index);
 
     painter->save();


### PR DESCRIPTION
for some weird reason without this progress bar text is cutoff with windows scaling https://github.com/jagannatharjun/qbt-theme/issues/39, same happens with other themes and without a theme as well. I don't like the qt widget paintings stack anymore.