### PR TITLE
Don't call non-existent elements (part 2)

### DIFF
--- a/src/webui/www/private/scripts/download.js
+++ b/src/webui/www/private/scripts/download.js
@@ -72,7 +72,6 @@ window.qBittorrent.Download = (function() {
 
                 defaultSavePath = pref.save_path;
                 $('savepath').setProperty('value', defaultSavePath);
-                $('rootFolder').checked = pref.create_subfolder_enabled;
                 $('startTorrent').checked = !pref.start_paused_enabled;
 
                 if (pref.auto_tmm_enabled == 1) {


### PR DESCRIPTION
Fixed a regression where the script tries to access elements that no longer
exist on the page, because they were replaced with others by a previous change.

Closes #14092.

Sorry, the structure of the Web application is alien to me (besides, I believe that qBittorrent web application is not designed in the best way), so it is difficult for me to clean up here. It would be easier if someone maintain it, but we still don't have a web developer.
Not sure if it would be better, continue trying to propagate with grief in half the main changes in WebUI, or just leave it without any care.