### PR TITLE
Prevent copying value

### DIFF
--- a/src/base/utils/string.h
+++ b/src/base/utils/string.h
@@ -59,7 +59,7 @@ namespace Utils
         {
             if (str.length() < 2) return str;
 
-            for (const QChar quote : quotes)
+            for (const QChar &quote : quotes)
             {
                 if (str.startsWith(quote) && str.endsWith(quote))
                     return str.mid(1, (str.length() - 2));


### PR DESCRIPTION
Fixes compiler warning

```
In file included from app/cmdoptions.cpp:46:

./base/utils/string.h:62:30: warning: loop variable 'quote' of type 'const QChar' creates a copy from type 'const QChar' [-Wrange-loop-analysis]

            for (const QChar quote : quotes)

                             ^

./base/utils/string.h:62:18: note: use reference type 'const QChar &' to prevent copying

            for (const QChar quote : quotes)

                 ^~~~~~~~~~~~~~~~~~~

                             &

./base/utils/string.h:62:30: warning: loop variable 'quote' of type 'const QChar' creates a copy from type 'const QChar' [-Wrange-loop-analysis]

            for (const QChar quote : quotes)

                             ^

app/cmdoptions.cpp:160:39: note: in instantiation of function template specialization 'Utils::String::unquote<QString>' requested here

                return Utils::String::unquote(parts[1], QLatin1String("'\""));

                                      ^

./base/utils/string.h:62:18: note: use reference type 'const QChar &' to prevent copying

            for (const QChar quote : quotes)

                 ^~~~~~~~~~~~~~~~~~~

                             &

2 warnings generated.
```

Build log: https://travis-ci.org/github/qbittorrent/qBittorrent/jobs/752174047#L2326

I think it was changed inadvertently in #13294 