### PR TITLE
Drop notification about move storage finished

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -4947,9 +4947,6 @@ void Session::handleStorageMovedFailedAlert(const lt::storage_moved_failed_alert
     LogMsg(tr("Failed to move \"%1\" from \"%2\" to \"%3\". Reason: %4.")
            .arg(torrentName, currentLocation, currentJob.path, errorMessage), Log::CRITICAL);
 
-    if (torrent)
-        emit torrentStorageMoveFailed(torrent, currentJob.path, errorMessage);
-
     handleMoveTorrentStorageJobFinished();
 }
 

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -4929,9 +4929,6 @@ void Session::handleStorageMovedAlert(const lt::storage_moved_alert *p)
     const QString torrentName = (torrent ? torrent->name() : QString {infoHash});
     LogMsg(tr("\"%1\" is successfully moved to \"%2\".").arg(torrentName, newPath));
 
-    if (torrent)
-        emit torrentStorageMoveFinished(torrent, newPath);
-
     handleMoveTorrentStorageJobFinished();
 }
 

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -524,7 +524,6 @@ namespace BitTorrent
         void torrentResumed(TorrentHandle *torrent);
         void torrentSavePathChanged(TorrentHandle *torrent);
         void torrentSavingModeChanged(TorrentHandle *torrent);
-        void torrentStorageMoveFailed(TorrentHandle *torrent, const QString &targetPath, const QString &error);
         void torrentsUpdated(const QVector<TorrentHandle *> &torrents);
         void torrentTagAdded(TorrentHandle *torrent, const QString &tag);
         void torrentTagRemoved(TorrentHandle *torrent, const QString &tag);

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -525,7 +525,6 @@ namespace BitTorrent
         void torrentSavePathChanged(TorrentHandle *torrent);
         void torrentSavingModeChanged(TorrentHandle *torrent);
         void torrentStorageMoveFailed(TorrentHandle *torrent, const QString &targetPath, const QString &error);
-        void torrentStorageMoveFinished(TorrentHandle *torrent, const QString &newPath);
         void torrentsUpdated(const QVector<TorrentHandle *> &torrents);
         void torrentTagAdded(TorrentHandle *torrent, const QString &tag);
         void torrentTagRemoved(TorrentHandle *torrent, const QString &tag);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -208,7 +208,6 @@ MainWindow::MainWindow(QWidget *parent)
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::downloadFromUrlFailed, this, &MainWindow::handleDownloadFromUrlFailure);
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::speedLimitModeChanged, this, &MainWindow::updateAltSpeedsBtn);
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::recursiveTorrentDownloadPossible, this, &MainWindow::askRecursiveTorrentDownloadConfirmation);
-    connect(BitTorrent::Session::instance(), &BitTorrent::Session::torrentStorageMoveFailed, this, &MainWindow::moveTorrentFailed);
 
     qDebug("create tabWidget");
     m_tabs = new HidableTabWidget(this);
@@ -868,11 +867,6 @@ void MainWindow::torrentNew(BitTorrent::TorrentHandle *const torrent) const
 void MainWindow::finishedTorrent(BitTorrent::TorrentHandle *const torrent) const
 {
     showNotificationBaloon(tr("Download completion"), tr("'%1' has finished downloading.", "e.g: xxx.avi has finished downloading.").arg(torrent->name()));
-}
-
-void MainWindow::moveTorrentFailed(BitTorrent::TorrentHandle *const torrent, const QString &targetPath, const QString &error) const
-{
-    showNotificationBaloon(tr("Torrent moving failed"), tr("'%1' has failed moving files to '%2'. Reason: %3").arg(torrent->name(), targetPath, error));
 }
 
 // Notification when disk is full

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -208,7 +208,6 @@ MainWindow::MainWindow(QWidget *parent)
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::downloadFromUrlFailed, this, &MainWindow::handleDownloadFromUrlFailure);
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::speedLimitModeChanged, this, &MainWindow::updateAltSpeedsBtn);
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::recursiveTorrentDownloadPossible, this, &MainWindow::askRecursiveTorrentDownloadConfirmation);
-    connect(BitTorrent::Session::instance(), &BitTorrent::Session::torrentStorageMoveFinished, this, &MainWindow::moveTorrentFinished);
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::torrentStorageMoveFailed, this, &MainWindow::moveTorrentFailed);
 
     qDebug("create tabWidget");
@@ -869,11 +868,6 @@ void MainWindow::torrentNew(BitTorrent::TorrentHandle *const torrent) const
 void MainWindow::finishedTorrent(BitTorrent::TorrentHandle *const torrent) const
 {
     showNotificationBaloon(tr("Download completion"), tr("'%1' has finished downloading.", "e.g: xxx.avi has finished downloading.").arg(torrent->name()));
-}
-
-void MainWindow::moveTorrentFinished(BitTorrent::TorrentHandle *const torrent, const QString &newPath) const
-{
-    showNotificationBaloon(tr("Torrent moving finished"), tr("'%1' has finished moving files to '%2'.").arg(torrent->name(), newPath));
 }
 
 void MainWindow::moveTorrentFailed(BitTorrent::TorrentHandle *const torrent, const QString &targetPath, const QString &error) const

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -132,7 +132,6 @@ private slots:
     void addTorrentFailed(const QString &error) const;
     void torrentNew(BitTorrent::TorrentHandle *const torrent) const;
     void finishedTorrent(BitTorrent::TorrentHandle *const torrent) const;
-    void moveTorrentFailed(BitTorrent::TorrentHandle *const torrent, const QString &targetPath, const QString &error) const;
     void askRecursiveTorrentDownloadConfirmation(BitTorrent::TorrentHandle *const torrent);
     void optionsSaved();
 #if defined(Q_OS_WIN) || defined(Q_OS_MACOS)

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -132,7 +132,6 @@ private slots:
     void addTorrentFailed(const QString &error) const;
     void torrentNew(BitTorrent::TorrentHandle *const torrent) const;
     void finishedTorrent(BitTorrent::TorrentHandle *const torrent) const;
-    void moveTorrentFinished(BitTorrent::TorrentHandle *const torrent, const QString &newPath) const;
     void moveTorrentFailed(BitTorrent::TorrentHandle *const torrent, const QString &targetPath, const QString &error) const;
     void askRecursiveTorrentDownloadConfirmation(BitTorrent::TorrentHandle *const torrent);
     void optionsSaved();


### PR DESCRIPTION
It also drops notification about move storage failed. But it looks like it's more important so it might make sense to leave it out. If so, I'll delete the second commit from this PR.

Closes #13643.