### PR TITLE
Refactor IP filter parsing code

### DIFF
--- a/src/base/bittorrent/filterparserthread.h
+++ b/src/base/bittorrent/filterparserthread.h
@@ -52,10 +52,12 @@ protected:
     void run() override;
 
 private:
-    int findAndNullDelimiter(char *const data, char delimiter, int start, int end, bool reverse = false);
-    int trim(char *const data, int start, int end);
-    int parseDATFilterFile();
-    int parseP2PFilterFile();
+    enum class Format
+    {
+        DAT,
+        P2P
+    };
+    template <Format format> int parseTxtFilterFile();
     int getlineInStream(QDataStream &stream, std::string &name, char delim);
     int parseP2BFilterFile();
 


### PR DESCRIPTION
This kind of refactoring was a minor desire of mine from the moment I had learnt about string_view (around 2017).
This has an average decrease in parsing time of ~15.50%

The last major refactoring of the parsing code was done by me in ~2017 in #5310.

Some measurements: **old vs new**

1. DAT file 1
529 ms
420 ms

2. DAT file 2
370 ms
314 ms

3. P2P file 1
740 ms
640 ms

4. P2P file 2
345 ms
301 ms



