### PR TITLE
Generate version header when configuring project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ src/qbittorrent
 src/qbittorrent-nox
 src/release
 src/debug
+src/base/version.h
 CMakeLists.txt.user*
 qbittorrent.pro.user*
 conf.pri

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,11 +51,26 @@ elseif (MSVC)
     feature_option(MSVC_RUNTIME_DYNAMIC "Use MSVC dynamic runtime library (-MD) instead of static (-MT)" ON)
 endif()
 
-set(QBT_VER_STATUS "alpha1" CACHE STRING "Project status version. Should be empty for release builds.")
-
 include(GNUInstallDirs)
 add_subdirectory(src)
 add_subdirectory(dist)
+
+# Generate version header
+set(QBT_VER_STATUS "alpha1" CACHE STRING "Project status version. Should be empty for release builds.")
+
+set(QBT_PROJECT_VERSION "${qBittorrent_VERSION_MAJOR}.${qBittorrent_VERSION_MINOR}.${qBittorrent_VERSION_PATCH}")
+if (NOT ${qBittorrent_VERSION_TWEAK} EQUAL 0)
+    set(QBT_PROJECT_VERSION "${QBT_PROJECT_VERSION}.${qBittorrent_VERSION_TWEAK}")
+endif()
+set(QBT_PROJECT_VERSION "${QBT_PROJECT_VERSION}${QBT_VER_STATUS}")
+
+file(READ "src/base/version.h.in" versionHeader)
+string(REPLACE "@VER_MAJOR@" ${qBittorrent_VERSION_MAJOR} versionHeader "${versionHeader}")
+string(REPLACE "@VER_MINOR@" ${qBittorrent_VERSION_MINOR} versionHeader "${versionHeader}")
+string(REPLACE "@VER_BUGFIX@" ${qBittorrent_VERSION_PATCH} versionHeader "${versionHeader}")
+string(REPLACE "@VER_BUILD@" ${qBittorrent_VERSION_TWEAK} versionHeader "${versionHeader}")
+string(REPLACE "@PROJECT_VERSION@" ${QBT_PROJECT_VERSION} versionHeader "${versionHeader}")
+file(WRITE "src/base/version.h" "${versionHeader}")
 
 if (VERBOSE_CONFIGURE)
     feature_summary(WHAT ALL)

--- a/cmake/Modules/MacroQbtCommonConfig.cmake
+++ b/cmake/Modules/MacroQbtCommonConfig.cmake
@@ -7,17 +7,6 @@ macro(qbt_common_config)
     # treat value specified by the CXX_STANDARD target property as a requirement by default
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-    # these definitions are only needed for calls to
-    # lt::generate_fingerprint and for the qbittorrent.rc file on Windows
-    add_library(qbt_version_definitions INTERFACE)
-
-    target_compile_definitions(qbt_version_definitions INTERFACE
-        QBT_VERSION_MAJOR=${qBittorrent_VERSION_MAJOR}
-        QBT_VERSION_MINOR=${qBittorrent_VERSION_MINOR}
-        QBT_VERSION_BUGFIX=${qBittorrent_VERSION_PATCH}
-        QBT_VERSION_BUILD=${qBittorrent_VERSION_TWEAK}
-    )
-
     add_library(qbt_common_cfg INTERFACE)
 
     # Full C++ 17 support is required
@@ -27,16 +16,7 @@ macro(qbt_common_config)
         cxx_std_17
     )
 
-    set(QBT_PROJECT_VERSION "${qBittorrent_VERSION_MAJOR}.${qBittorrent_VERSION_MINOR}.${qBittorrent_VERSION_PATCH}")
-    if (NOT ${qBittorrent_VERSION_TWEAK} EQUAL 0)
-        set(QBT_PROJECT_VERSION "${QBT_PROJECT_VERSION}.${qBittorrent_VERSION_TWEAK}")
-    endif()
-
-    set(QBT_FULL_VERSION "${QBT_PROJECT_VERSION}${QBT_VER_STATUS}")
-
     target_compile_definitions(qbt_common_cfg INTERFACE
-        QBT_VERSION="v${QBT_FULL_VERSION}"
-        QBT_VERSION_2="${QBT_FULL_VERSION}"
         QT_DEPRECATED_WARNINGS
         QT_NO_CAST_TO_ASCII
         QT_NO_CAST_FROM_BYTEARRAY

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -61,7 +61,6 @@ target_sources(qbt_app PRIVATE
 
 target_link_libraries(qbt_app PRIVATE
     qbt_base
-    qbt_version_definitions
 )
 
 set_target_properties(qbt_app PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -81,6 +81,7 @@
 #include "base/utils/fs.h"
 #include "base/utils/misc.h"
 #include "base/utils/string.h"
+#include "base/version.h"
 #include "applicationinstancemanager.h"
 #include "filelogger.h"
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -78,6 +78,7 @@ Q_IMPORT_PLUGIN(QICOPlugin)
 
 #include "base/preferences.h"
 #include "base/profile.h"
+#include "base/version.h"
 #include "application.h"
 #include "cmdoptions.h"
 #include "upgrade.h"

--- a/src/app/stacktracedialog.cpp
+++ b/src/app/stacktracedialog.cpp
@@ -32,6 +32,7 @@
 #include <QString>
 
 #include "base/utils/misc.h"
+#include "base/version.h"
 #include "ui_stacktracedialog.h"
 
 StacktraceDialog::StacktraceDialog(QWidget *parent)

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -87,6 +87,7 @@ add_library(qbt_base STATIC
     utils/random.h
     utils/string.h
     utils/version.h
+    version.h
 
     # sources
     asyncfilestorage.cpp
@@ -167,7 +168,6 @@ target_link_libraries(qbt_base
     PRIVATE
         OpenSSL::Crypto OpenSSL::SSL
         ZLIB::ZLIB
-        qbt_version_definitions
     PUBLIC
         LibtorrentRasterbar::torrent-rasterbar
         Qt5::Core Qt5::Network Qt5::Xml

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -86,7 +86,8 @@ HEADERS += \
     $$PWD/utils/password.h \
     $$PWD/utils/random.h \
     $$PWD/utils/string.h \
-    $$PWD/utils/version.h
+    $$PWD/utils/version.h \
+    $$PWD/version.h
 
 SOURCES += \
     $$PWD/asyncfilestorage.cpp \

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -85,6 +85,7 @@
 #include "base/utils/misc.h"
 #include "base/utils/net.h"
 #include "base/utils/random.h"
+#include "base/version.h"
 #include "bandwidthscheduler.h"
 #include "common.h"
 #include "customstorage.h"

--- a/src/base/bittorrent/torrentcreatorthread.cpp
+++ b/src/base/bittorrent/torrentcreatorthread.cpp
@@ -45,6 +45,7 @@
 #include "base/utils/fs.h"
 #include "base/utils/io.h"
 #include "base/utils/string.h"
+#include "base/version.h"
 #include "ltunderlyingtype.h"
 
 namespace

--- a/src/base/net/dnsupdater.cpp
+++ b/src/base/net/dnsupdater.cpp
@@ -34,6 +34,7 @@
 
 #include "base/logger.h"
 #include "base/net/downloadmanager.h"
+#include "base/version.h"
 
 using namespace Net;
 

--- a/src/base/version.h.in
+++ b/src/base/version.h.in
@@ -1,0 +1,37 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2021  Mike Tzou (Chocobo1)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+#define QBT_VERSION_MAJOR @VER_MAJOR@
+#define QBT_VERSION_MINOR @VER_MINOR@
+#define QBT_VERSION_BUGFIX @VER_BUGFIX@
+#define QBT_VERSION_BUILD @VER_BUILD@
+
+#define QBT_VERSION "v@PROJECT_VERSION@"
+#define QBT_VERSION_2 "@PROJECT_VERSION@"

--- a/src/gui/aboutdialog.cpp
+++ b/src/gui/aboutdialog.cpp
@@ -32,6 +32,7 @@
 
 #include "base/unicodestrings.h"
 #include "base/utils/misc.h"
+#include "base/version.h"
 #include "ui_aboutdialog.h"
 #include "uithememanager.h"
 #include "utils.h"

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -70,6 +70,7 @@
 #include "base/utils/fs.h"
 #include "base/utils/misc.h"
 #include "base/utils/password.h"
+#include "base/version.h"
 #include "aboutdialog.h"
 #include "addnewtorrentdialog.h"
 #include "autoexpandabledialog.h"

--- a/src/gui/programupdater.cpp
+++ b/src/gui/programupdater.cpp
@@ -44,6 +44,7 @@
 #endif
 
 #include "base/net/downloadmanager.h"
+#include "base/version.h"
 
 namespace
 {

--- a/src/qbittorrent.rc
+++ b/src/qbittorrent.rc
@@ -4,6 +4,7 @@ IDI_ICON1 ICON "icons\qbittorrent.ico"
 IDI_ICON2 ICON "icons\qbittorrent_file.ico"
 
 #include <windows.h>
+#include "base/version.h"
 
 #define VER_FILEVERSION             QBT_VERSION_MAJOR,QBT_VERSION_MINOR,QBT_VERSION_BUGFIX,QBT_VERSION_BUILD
 #define VER_FILEVERSION_STR         QBT_VERSION

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -57,6 +57,7 @@
 #include "base/utils/net.h"
 #include "base/utils/password.h"
 #include "base/utils/string.h"
+#include "base/version.h"
 #include "../webapplication.h"
 
 void AppController::webapiVersionAction()

--- a/version.pri
+++ b/version.pri
@@ -17,10 +17,11 @@ PROJECT_VERSION = $${VER_MAJOR}.$${VER_MINOR}.$${VER_BUGFIX}
 
 PROJECT_VERSION = $${PROJECT_VERSION}$${VER_STATUS}
 
-DEFINES += QBT_VERSION_MAJOR=$${VER_MAJOR}
-DEFINES += QBT_VERSION_MINOR=$${VER_MINOR}
-DEFINES += QBT_VERSION_BUGFIX=$${VER_BUGFIX}
-DEFINES += QBT_VERSION_BUILD=$${VER_BUILD}
-
-DEFINES += QBT_VERSION=\\\"v$${PROJECT_VERSION}\\\"
-DEFINES += QBT_VERSION_2=\\\"$${PROJECT_VERSION}\\\"
+# Generate version header
+versionHeader = $$cat(src/base/version.h.in, blob)
+versionHeader = $$replace(versionHeader, "@VER_MAJOR@", $$VER_MAJOR)
+versionHeader = $$replace(versionHeader, "@VER_MINOR@", $$VER_MINOR)
+versionHeader = $$replace(versionHeader, "@VER_BUGFIX@", $$VER_BUGFIX)
+versionHeader = $$replace(versionHeader, "@VER_BUILD@", $$VER_BUILD)
+versionHeader = $$replace(versionHeader, "@PROJECT_VERSION@", $$PROJECT_VERSION)
+write_file(src/base/version.h, versionHeader)


### PR DESCRIPTION
The basic idea is we create a version header template at "src/base/version.h.in" and the build systems are expected to replace
strings that are enclosed with @ symbols and generate "src/base/version.h" for other source files to consume/include.