### PR TITLE
Correctly set items flags in TorrentContentModel 

### DIFF
--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -384,10 +384,13 @@ Qt::ItemFlags TorrentContentModel::flags(const QModelIndex &index) const
     if (!index.isValid())
         return Qt::NoItemFlags;
 
+    Qt::ItemFlags flags {Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsUserCheckable};
     if (itemType(index) == TorrentContentModelItem::FolderType)
-        return Qt::ItemIsEditable | Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsUserCheckable | Qt::ItemIsTristate;
+        flags |= Qt::ItemIsTristate;
+    if (index.column() == TorrentContentModelItem::COL_PRIO)
+        flags |= Qt::ItemIsEditable;
 
-    return Qt::ItemIsEditable | Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsUserCheckable;
+    return flags;
 }
 
 QVariant TorrentContentModel::headerData(int section, Qt::Orientation orientation, int role) const


### PR DESCRIPTION
Only set editable flag on item's where editing is handled in the delegate.

Closes #13515.