### PR TITLE
Remove redundant suffix from TorrentHandle class name

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -63,7 +63,7 @@
 
 #include "base/bittorrent/infohash.h"
 #include "base/bittorrent/session.h"
-#include "base/bittorrent/torrenthandle.h"
+#include "base/bittorrent/torrent.h"
 #include "base/exceptions.h"
 #include "base/iconprovider.h"
 #include "base/logger.h"
@@ -311,7 +311,7 @@ void Application::processMessage(const QString &message)
         m_paramsQueue.append(params);
 }
 
-void Application::runExternalProgram(const BitTorrent::TorrentHandle *torrent) const
+void Application::runExternalProgram(const BitTorrent::Torrent *torrent) const
 {
     QString program = Preferences::instance()->getAutoRunProgram().trimmed();
     program.replace("%N", torrent->name());
@@ -405,7 +405,7 @@ void Application::runExternalProgram(const BitTorrent::TorrentHandle *torrent) c
 #endif
 }
 
-void Application::sendNotificationEmail(const BitTorrent::TorrentHandle *torrent)
+void Application::sendNotificationEmail(const BitTorrent::Torrent *torrent)
 {
     // Prepare mail content
     const QString content = tr("Torrent name: %1").arg(torrent->name()) + '\n'
@@ -424,7 +424,7 @@ void Application::sendNotificationEmail(const BitTorrent::TorrentHandle *torrent
                      content);
 }
 
-void Application::torrentFinished(BitTorrent::TorrentHandle *const torrent)
+void Application::torrentFinished(BitTorrent::Torrent *const torrent)
 {
     Preferences *const pref = Preferences::instance();
 

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -59,7 +59,7 @@ class FileLogger;
 
 namespace BitTorrent
 {
-    class TorrentHandle;
+    class Torrent;
 }
 
 namespace RSS
@@ -112,7 +112,7 @@ protected:
 
 private slots:
     void processMessage(const QString &message);
-    void torrentFinished(BitTorrent::TorrentHandle *const torrent);
+    void torrentFinished(BitTorrent::Torrent *const torrent);
     void allTorrentsFinished();
     void cleanup();
 #if (!defined(DISABLE_GUI) && defined(Q_OS_WIN))
@@ -142,6 +142,6 @@ private:
 
     void initializeTranslation();
     void processParams(const QStringList &params);
-    void runExternalProgram(const BitTorrent::TorrentHandle *torrent) const;
-    void sendNotificationEmail(const BitTorrent::TorrentHandle *torrent);
+    void runExternalProgram(const BitTorrent::Torrent *torrent) const;
+    void sendNotificationEmail(const BitTorrent::Torrent *torrent);
 };

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -25,10 +25,10 @@ add_library(qbt_base STATIC
     bittorrent/sessionstatus.h
     bittorrent/speedmonitor.h
     bittorrent/statistics.h
+    bittorrent/torrent.h
     bittorrent/torrentcontentlayout.h
     bittorrent/torrentcreatorthread.h
-    bittorrent/torrenthandle.h
-    bittorrent/torrenthandleimpl.h
+    bittorrent/torrentimpl.h
     bittorrent/torrentinfo.h
     bittorrent/tracker.h
     bittorrent/trackerentry.h
@@ -107,9 +107,9 @@ add_library(qbt_base STATIC
     bittorrent/session.cpp
     bittorrent/speedmonitor.cpp
     bittorrent/statistics.cpp
+    bittorrent/torrent.cpp
     bittorrent/torrentcreatorthread.cpp
-    bittorrent/torrenthandle.cpp
-    bittorrent/torrenthandleimpl.cpp
+    bittorrent/torrentimpl.cpp
     bittorrent/torrentinfo.cpp
     bittorrent/tracker.cpp
     bittorrent/trackerentry.cpp

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -24,10 +24,10 @@ HEADERS += \
     $$PWD/bittorrent/sessionstatus.h \
     $$PWD/bittorrent/speedmonitor.h \
     $$PWD/bittorrent/statistics.h \
+    $$PWD/bittorrent/torrent.h \
     $$PWD/bittorrent/torrentcontentlayout.h \
     $$PWD/bittorrent/torrentcreatorthread.h \
-    $$PWD/bittorrent/torrenthandle.h \
-    $$PWD/bittorrent/torrenthandleimpl.h \
+    $$PWD/bittorrent/torrentimpl.h \
     $$PWD/bittorrent/torrentinfo.h \
     $$PWD/bittorrent/tracker.h \
     $$PWD/bittorrent/trackerentry.h \
@@ -107,9 +107,9 @@ SOURCES += \
     $$PWD/bittorrent/session.cpp \
     $$PWD/bittorrent/speedmonitor.cpp \
     $$PWD/bittorrent/statistics.cpp \
+    $$PWD/bittorrent/torrent.cpp \
     $$PWD/bittorrent/torrentcreatorthread.cpp \
-    $$PWD/bittorrent/torrenthandle.cpp \
-    $$PWD/bittorrent/torrenthandleimpl.cpp \
+    $$PWD/bittorrent/torrentimpl.cpp \
     $$PWD/bittorrent/torrentinfo.cpp \
     $$PWD/bittorrent/tracker.cpp \
     $$PWD/bittorrent/trackerentry.cpp \

--- a/src/base/bittorrent/addtorrentparams.h
+++ b/src/base/bittorrent/addtorrentparams.h
@@ -34,7 +34,7 @@
 #include <QString>
 #include <QVector>
 
-#include "torrenthandle.h"
+#include "torrent.h"
 #include "torrentcontentlayout.h"
 
 namespace BitTorrent
@@ -58,7 +58,7 @@ namespace BitTorrent
         std::optional<bool> useAutoTMM;
         int uploadLimit = -1;
         int downloadLimit = -1;
-        int seedingTimeLimit = TorrentHandle::USE_GLOBAL_SEEDING_TIME;
-        qreal ratioLimit = TorrentHandle::USE_GLOBAL_RATIO;
+        int seedingTimeLimit = Torrent::USE_GLOBAL_SEEDING_TIME;
+        qreal ratioLimit = Torrent::USE_GLOBAL_RATIO;
     };
 }

--- a/src/base/bittorrent/peerinfo.cpp
+++ b/src/base/bittorrent/peerinfo.cpp
@@ -30,14 +30,14 @@
 
 #include <QBitArray>
 
-#include "base/bittorrent/torrenthandle.h"
+#include "base/bittorrent/torrent.h"
 #include "base/net/geoipmanager.h"
 #include "base/unicodestrings.h"
 #include "peeraddress.h"
 
 using namespace BitTorrent;
 
-PeerInfo::PeerInfo(const TorrentHandle *torrent, const lt::peer_info &nativeInfo)
+PeerInfo::PeerInfo(const Torrent *torrent, const lt::peer_info &nativeInfo)
     : m_nativeInfo(nativeInfo)
 {
     calcRelevance(torrent);
@@ -226,7 +226,7 @@ QString PeerInfo::connectionType() const
         : QLatin1String {"Web"};
 }
 
-void PeerInfo::calcRelevance(const TorrentHandle *torrent)
+void PeerInfo::calcRelevance(const Torrent *torrent)
 {
     const QBitArray allPieces = torrent->pieces();
     const QBitArray peerPieces = pieces();

--- a/src/base/bittorrent/peerinfo.h
+++ b/src/base/bittorrent/peerinfo.h
@@ -36,7 +36,7 @@ class QBitArray;
 
 namespace BitTorrent
 {
-    class TorrentHandle;
+    class Torrent;
     struct PeerAddress;
 
     class PeerInfo
@@ -45,7 +45,7 @@ namespace BitTorrent
 
     public:
         PeerInfo() = default;
-        PeerInfo(const TorrentHandle *torrent, const lt::peer_info &nativeInfo);
+        PeerInfo(const Torrent *torrent, const lt::peer_info &nativeInfo);
 
         bool fromDHT() const;
         bool fromPeX() const;
@@ -92,7 +92,7 @@ namespace BitTorrent
         int downloadingPieceIndex() const;
 
     private:
-        void calcRelevance(const TorrentHandle *torrent);
+        void calcRelevance(const Torrent *torrent);
         void determineFlags();
 
         lt::peer_info m_nativeInfo = {};

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -85,8 +85,8 @@ enum MaxRatioAction
 
 enum DeleteOption
 {
-    Torrent,
-    TorrentAndFiles
+    DeleteTorrent,
+    DeleteTorrentAndFiles
 };
 
 enum TorrentExportFolder
@@ -104,8 +104,8 @@ namespace BitTorrent
 {
     class InfoHash;
     class MagnetUri;
-    class TorrentHandle;
-    class TorrentHandleImpl;
+    class Torrent;
+    class TorrentImpl;
     class Tracker;
     class TrackerEntry;
     struct LoadTorrentParams;
@@ -440,8 +440,8 @@ namespace BitTorrent
 #endif
 
         void startUpTorrents();
-        TorrentHandle *findTorrent(const InfoHash &hash) const;
-        QVector<TorrentHandle *> torrents() const;
+        Torrent *findTorrent(const InfoHash &hash) const;
+        QVector<Torrent *> torrents() const;
         bool hasActiveTorrents() const;
         bool hasUnfinishedTorrents() const;
         bool hasRunningSeed() const;
@@ -460,7 +460,7 @@ namespace BitTorrent
         bool addTorrent(const QString &source, const AddTorrentParams &params = AddTorrentParams());
         bool addTorrent(const MagnetUri &magnetUri, const AddTorrentParams &params = AddTorrentParams());
         bool addTorrent(const TorrentInfo &torrentInfo, const AddTorrentParams &params = AddTorrentParams());
-        bool deleteTorrent(const InfoHash &hash, DeleteOption deleteOption = Torrent);
+        bool deleteTorrent(const InfoHash &hash, DeleteOption deleteOption = DeleteTorrent);
         bool downloadMetadata(const MagnetUri &magnetUri);
         bool cancelDownloadMetadata(const InfoHash &hash);
 
@@ -470,31 +470,31 @@ namespace BitTorrent
         void topTorrentsQueuePos(const QVector<InfoHash> &hashes);
         void bottomTorrentsQueuePos(const QVector<InfoHash> &hashes);
 
-        // TorrentHandle interface
-        void handleTorrentSaveResumeDataRequested(const TorrentHandleImpl *torrent);
-        void handleTorrentShareLimitChanged(TorrentHandleImpl *const torrent);
-        void handleTorrentNameChanged(TorrentHandleImpl *const torrent);
-        void handleTorrentSavePathChanged(TorrentHandleImpl *const torrent);
-        void handleTorrentCategoryChanged(TorrentHandleImpl *const torrent, const QString &oldCategory);
-        void handleTorrentTagAdded(TorrentHandleImpl *const torrent, const QString &tag);
-        void handleTorrentTagRemoved(TorrentHandleImpl *const torrent, const QString &tag);
-        void handleTorrentSavingModeChanged(TorrentHandleImpl *const torrent);
-        void handleTorrentMetadataReceived(TorrentHandleImpl *const torrent);
-        void handleTorrentPaused(TorrentHandleImpl *const torrent);
-        void handleTorrentResumed(TorrentHandleImpl *const torrent);
-        void handleTorrentChecked(TorrentHandleImpl *const torrent);
-        void handleTorrentFinished(TorrentHandleImpl *const torrent);
-        void handleTorrentTrackersAdded(TorrentHandleImpl *const torrent, const QVector<TrackerEntry> &newTrackers);
-        void handleTorrentTrackersRemoved(TorrentHandleImpl *const torrent, const QVector<TrackerEntry> &deletedTrackers);
-        void handleTorrentTrackersChanged(TorrentHandleImpl *const torrent);
-        void handleTorrentUrlSeedsAdded(TorrentHandleImpl *const torrent, const QVector<QUrl> &newUrlSeeds);
-        void handleTorrentUrlSeedsRemoved(TorrentHandleImpl *const torrent, const QVector<QUrl> &urlSeeds);
-        void handleTorrentResumeDataReady(TorrentHandleImpl *const torrent, const std::shared_ptr<lt::entry> &data);
-        void handleTorrentTrackerReply(TorrentHandleImpl *const torrent, const QString &trackerUrl);
-        void handleTorrentTrackerWarning(TorrentHandleImpl *const torrent, const QString &trackerUrl);
-        void handleTorrentTrackerError(TorrentHandleImpl *const torrent, const QString &trackerUrl);
+        // Torrent interface
+        void handleTorrentSaveResumeDataRequested(const TorrentImpl *torrent);
+        void handleTorrentShareLimitChanged(TorrentImpl *const torrent);
+        void handleTorrentNameChanged(TorrentImpl *const torrent);
+        void handleTorrentSavePathChanged(TorrentImpl *const torrent);
+        void handleTorrentCategoryChanged(TorrentImpl *const torrent, const QString &oldCategory);
+        void handleTorrentTagAdded(TorrentImpl *const torrent, const QString &tag);
+        void handleTorrentTagRemoved(TorrentImpl *const torrent, const QString &tag);
+        void handleTorrentSavingModeChanged(TorrentImpl *const torrent);
+        void handleTorrentMetadataReceived(TorrentImpl *const torrent);
+        void handleTorrentPaused(TorrentImpl *const torrent);
+        void handleTorrentResumed(TorrentImpl *const torrent);
+        void handleTorrentChecked(TorrentImpl *const torrent);
+        void handleTorrentFinished(TorrentImpl *const torrent);
+        void handleTorrentTrackersAdded(TorrentImpl *const torrent, const QVector<TrackerEntry> &newTrackers);
+        void handleTorrentTrackersRemoved(TorrentImpl *const torrent, const QVector<TrackerEntry> &deletedTrackers);
+        void handleTorrentTrackersChanged(TorrentImpl *const torrent);
+        void handleTorrentUrlSeedsAdded(TorrentImpl *const torrent, const QVector<QUrl> &newUrlSeeds);
+        void handleTorrentUrlSeedsRemoved(TorrentImpl *const torrent, const QVector<QUrl> &urlSeeds);
+        void handleTorrentResumeDataReady(TorrentImpl *const torrent, const std::shared_ptr<lt::entry> &data);
+        void handleTorrentTrackerReply(TorrentImpl *const torrent, const QString &trackerUrl);
+        void handleTorrentTrackerWarning(TorrentImpl *const torrent, const QString &trackerUrl);
+        void handleTorrentTrackerError(TorrentImpl *const torrent, const QString &trackerUrl);
 
-        bool addMoveTorrentStorageJob(TorrentHandleImpl *torrent, const QString &newPath, MoveStorageMode mode);
+        bool addMoveTorrentStorageJob(TorrentImpl *torrent, const QString &newPath, MoveStorageMode mode);
 
         void findIncompleteFiles(const TorrentInfo &torrentInfo, const QString &savePath) const;
 
@@ -504,37 +504,37 @@ namespace BitTorrent
         void categoryRemoved(const QString &categoryName);
         void downloadFromUrlFailed(const QString &url, const QString &reason);
         void downloadFromUrlFinished(const QString &url);
-        void fullDiskError(TorrentHandle *torrent, const QString &msg);
+        void fullDiskError(Torrent *torrent, const QString &msg);
         void IPFilterParsed(bool error, int ruleCount);
         void loadTorrentFailed(const QString &error);
         void metadataDownloaded(const TorrentInfo &info);
-        void recursiveTorrentDownloadPossible(TorrentHandle *torrent);
+        void recursiveTorrentDownloadPossible(Torrent *torrent);
         void speedLimitModeChanged(bool alternative);
         void statsUpdated();
         void subcategoriesSupportChanged();
         void tagAdded(const QString &tag);
         void tagRemoved(const QString &tag);
-        void torrentAboutToBeRemoved(TorrentHandle *torrent);
-        void torrentAdded(TorrentHandle *torrent);
-        void torrentCategoryChanged(TorrentHandle *torrent, const QString &oldCategory);
-        void torrentFinished(TorrentHandle *torrent);
-        void torrentFinishedChecking(TorrentHandle *torrent);
-        void torrentLoaded(TorrentHandle *torrent);
-        void torrentMetadataReceived(TorrentHandle *torrent);
-        void torrentPaused(TorrentHandle *torrent);
-        void torrentResumed(TorrentHandle *torrent);
-        void torrentSavePathChanged(TorrentHandle *torrent);
-        void torrentSavingModeChanged(TorrentHandle *torrent);
-        void torrentsUpdated(const QVector<TorrentHandle *> &torrents);
-        void torrentTagAdded(TorrentHandle *torrent, const QString &tag);
-        void torrentTagRemoved(TorrentHandle *torrent, const QString &tag);
-        void trackerError(TorrentHandle *torrent, const QString &tracker);
-        void trackerlessStateChanged(TorrentHandle *torrent, bool trackerless);
-        void trackersAdded(TorrentHandle *torrent, const QVector<TrackerEntry> &trackers);
-        void trackersChanged(TorrentHandle *torrent);
-        void trackersRemoved(TorrentHandle *torrent, const QVector<TrackerEntry> &trackers);
-        void trackerSuccess(TorrentHandle *torrent, const QString &tracker);
-        void trackerWarning(TorrentHandle *torrent, const QString &tracker);
+        void torrentAboutToBeRemoved(Torrent *torrent);
+        void torrentAdded(Torrent *torrent);
+        void torrentCategoryChanged(Torrent *torrent, const QString &oldCategory);
+        void torrentFinished(Torrent *torrent);
+        void torrentFinishedChecking(Torrent *torrent);
+        void torrentLoaded(Torrent *torrent);
+        void torrentMetadataReceived(Torrent *torrent);
+        void torrentPaused(Torrent *torrent);
+        void torrentResumed(Torrent *torrent);
+        void torrentSavePathChanged(Torrent *torrent);
+        void torrentSavingModeChanged(Torrent *torrent);
+        void torrentsUpdated(const QVector<Torrent *> &torrents);
+        void torrentTagAdded(Torrent *torrent, const QString &tag);
+        void torrentTagRemoved(Torrent *torrent, const QString &tag);
+        void trackerError(Torrent *torrent, const QString &tracker);
+        void trackerlessStateChanged(Torrent *torrent, bool trackerless);
+        void trackersAdded(Torrent *torrent, const QVector<TrackerEntry> &trackers);
+        void trackersChanged(Torrent *torrent);
+        void trackersRemoved(Torrent *torrent, const QVector<TrackerEntry> &trackers);
+        void trackerSuccess(Torrent *torrent, const QString &tracker);
+        void trackerWarning(Torrent *torrent, const QString &tracker);
 
     private slots:
         void configureDeferred();
@@ -604,7 +604,7 @@ namespace BitTorrent
         bool addTorrent_impl(const std::variant<MagnetUri, TorrentInfo> &source, const AddTorrentParams &addTorrentParams);
 
         void updateSeedingLimitTimer();
-        void exportTorrentFile(const TorrentHandle *torrent, TorrentExportFolder folder = TorrentExportFolder::Regular);
+        void exportTorrentFile(const Torrent *torrent, TorrentExportFolder folder = TorrentExportFolder::Regular);
 
         void handleAlert(const lt::alert *a);
         void dispatchTorrentAlert(const lt::alert *a);
@@ -629,7 +629,7 @@ namespace BitTorrent
         void handleStorageMovedFailedAlert(const lt::storage_moved_failed_alert *p);
         void handleSocks5Alert(const lt::socks5_alert *p) const;
 
-        void createTorrentHandle(const lt::torrent_handle &nativeHandle);
+        void createTorrent(const lt::torrent_handle &nativeHandle);
 
         void saveResumeData();
         void saveTorrentsQueue();
@@ -771,7 +771,7 @@ namespace BitTorrent
 
         QSet<InfoHash> m_downloadedMetadata;
 
-        QHash<InfoHash, TorrentHandleImpl *> m_torrents;
+        QHash<InfoHash, TorrentImpl *> m_torrents;
         QHash<InfoHash, LoadTorrentParams> m_loadingTorrents;
         QHash<QString, AddTorrentParams> m_downloadedTorrents;
         QHash<InfoHash, RemovingTorrentData> m_removingTorrents;

--- a/src/base/bittorrent/torrent.cpp
+++ b/src/base/bittorrent/torrent.cpp
@@ -27,7 +27,7 @@
  * exception statement from your version.
  */
 
-#include "torrenthandle.h"
+#include "torrent.h"
 
 #include <type_traits>
 
@@ -40,33 +40,33 @@ namespace BitTorrent
         return ::qHash(static_cast<std::underlying_type_t<TorrentState>>(key), seed);
     }
 
-    // TorrentHandle
+    // Torrent
 
-    const qreal TorrentHandle::USE_GLOBAL_RATIO = -2.;
-    const qreal TorrentHandle::NO_RATIO_LIMIT = -1.;
+    const qreal Torrent::USE_GLOBAL_RATIO = -2.;
+    const qreal Torrent::NO_RATIO_LIMIT = -1.;
 
-    const int TorrentHandle::USE_GLOBAL_SEEDING_TIME = -2;
-    const int TorrentHandle::NO_SEEDING_TIME_LIMIT = -1;
+    const int Torrent::USE_GLOBAL_SEEDING_TIME = -2;
+    const int Torrent::NO_SEEDING_TIME_LIMIT = -1;
 
-    const qreal TorrentHandle::MAX_RATIO = 9999.;
-    const int TorrentHandle::MAX_SEEDING_TIME = 525600;
+    const qreal Torrent::MAX_RATIO = 9999.;
+    const int Torrent::MAX_SEEDING_TIME = 525600;
 
-    bool TorrentHandle::isResumed() const
+    bool Torrent::isResumed() const
     {
         return !isPaused();
     }
 
-    qlonglong TorrentHandle::remainingSize() const
+    qlonglong Torrent::remainingSize() const
     {
         return wantedSize() - completedSize();
     }
 
-    void TorrentHandle::toggleSequentialDownload()
+    void Torrent::toggleSequentialDownload()
     {
         setSequentialDownload(!isSequentialDownload());
     }
 
-    void TorrentHandle::toggleFirstLastPiecePriority()
+    void Torrent::toggleFirstLastPiecePriority()
     {
         setFirstLastPiecePriority(!hasFirstLastPiecePriority());
     }

--- a/src/base/bittorrent/torrent.h
+++ b/src/base/bittorrent/torrent.h
@@ -91,7 +91,7 @@ namespace BitTorrent
 
     uint qHash(TorrentState key, uint seed);
 
-    class TorrentHandle : public AbstractFileStorage
+    class Torrent : public AbstractFileStorage
     {
     public:
         static const qreal USE_GLOBAL_RATIO;
@@ -103,7 +103,7 @@ namespace BitTorrent
         static const qreal MAX_RATIO;
         static const int MAX_SEEDING_TIME;
 
-        virtual ~TorrentHandle() = default;
+        virtual ~Torrent() = default;
 
         virtual InfoHash hash() const = 0;
         virtual QString name() const = 0;

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -27,7 +27,7 @@
  * exception statement from your version.
  */
 
-#include "torrenthandleimpl.h"
+#include "torrentimpl.h"
 
 #include <algorithm>
 #include <memory>
@@ -98,9 +98,9 @@ namespace
     }
 }
 
-// TorrentHandleImpl
+// TorrentImpl
 
-TorrentHandleImpl::TorrentHandleImpl(Session *session, lt::session *nativeSession
+TorrentImpl::TorrentImpl(Session *session, lt::session *nativeSession
                                      , const lt::torrent_handle &nativeHandle, const LoadTorrentParams &params)
     : QObject(session)
     , m_session(session)
@@ -161,19 +161,19 @@ TorrentHandleImpl::TorrentHandleImpl(Session *session, lt::session *nativeSessio
     // == END UPGRADE CODE ==
 }
 
-TorrentHandleImpl::~TorrentHandleImpl() {}
+TorrentImpl::~TorrentImpl() {}
 
-bool TorrentHandleImpl::isValid() const
+bool TorrentImpl::isValid() const
 {
     return m_nativeHandle.is_valid();
 }
 
-InfoHash TorrentHandleImpl::hash() const
+InfoHash TorrentImpl::hash() const
 {
     return m_hash;
 }
 
-QString TorrentHandleImpl::name() const
+QString TorrentImpl::name() const
 {
     if (!m_name.isEmpty())
         return m_name;
@@ -188,58 +188,58 @@ QString TorrentHandleImpl::name() const
     return m_hash;
 }
 
-QDateTime TorrentHandleImpl::creationDate() const
+QDateTime TorrentImpl::creationDate() const
 {
     return m_torrentInfo.creationDate();
 }
 
-QString TorrentHandleImpl::creator() const
+QString TorrentImpl::creator() const
 {
     return m_torrentInfo.creator();
 }
 
-QString TorrentHandleImpl::comment() const
+QString TorrentImpl::comment() const
 {
     return m_torrentInfo.comment();
 }
 
-bool TorrentHandleImpl::isPrivate() const
+bool TorrentImpl::isPrivate() const
 {
     return m_torrentInfo.isPrivate();
 }
 
-qlonglong TorrentHandleImpl::totalSize() const
+qlonglong TorrentImpl::totalSize() const
 {
     return m_torrentInfo.totalSize();
 }
 
 // size without the "don't download" files
-qlonglong TorrentHandleImpl::wantedSize() const
+qlonglong TorrentImpl::wantedSize() const
 {
     return m_nativeStatus.total_wanted;
 }
 
-qlonglong TorrentHandleImpl::completedSize() const
+qlonglong TorrentImpl::completedSize() const
 {
     return m_nativeStatus.total_wanted_done;
 }
 
-qlonglong TorrentHandleImpl::pieceLength() const
+qlonglong TorrentImpl::pieceLength() const
 {
     return m_torrentInfo.pieceLength();
 }
 
-qlonglong TorrentHandleImpl::wastedSize() const
+qlonglong TorrentImpl::wastedSize() const
 {
     return (m_nativeStatus.total_failed_bytes + m_nativeStatus.total_redundant_bytes);
 }
 
-QString TorrentHandleImpl::currentTracker() const
+QString TorrentImpl::currentTracker() const
 {
     return QString::fromStdString(m_nativeStatus.current_tracker);
 }
 
-QString TorrentHandleImpl::savePath(bool actual) const
+QString TorrentImpl::savePath(bool actual) const
 {
     if (actual)
         return Utils::Fs::toUniformPath(actualStorageLocation());
@@ -247,7 +247,7 @@ QString TorrentHandleImpl::savePath(bool actual) const
         return Utils::Fs::toUniformPath(m_savePath);
 }
 
-QString TorrentHandleImpl::rootPath(bool actual) const
+QString TorrentImpl::rootPath(bool actual) const
 {
     if (!hasMetadata())
         return {};
@@ -260,7 +260,7 @@ QString TorrentHandleImpl::rootPath(bool actual) const
         return QDir(savePath(actual)).absoluteFilePath(firstFilePath);
 }
 
-QString TorrentHandleImpl::contentPath(const bool actual) const
+QString TorrentImpl::contentPath(const bool actual) const
 {
     if (!hasMetadata())
         return {};
@@ -274,12 +274,12 @@ QString TorrentHandleImpl::contentPath(const bool actual) const
     return savePath(actual);
 }
 
-bool TorrentHandleImpl::isAutoTMMEnabled() const
+bool TorrentImpl::isAutoTMMEnabled() const
 {
     return m_useAutoTMM;
 }
 
-void TorrentHandleImpl::setAutoTMMEnabled(bool enabled)
+void TorrentImpl::setAutoTMMEnabled(bool enabled)
 {
     if (m_useAutoTMM == enabled) return;
 
@@ -290,12 +290,12 @@ void TorrentHandleImpl::setAutoTMMEnabled(bool enabled)
         move_impl(m_session->categorySavePath(m_category), MoveStorageMode::Overwrite);
 }
 
-QString TorrentHandleImpl::actualStorageLocation() const
+QString TorrentImpl::actualStorageLocation() const
 {
     return QString::fromStdString(m_nativeStatus.save_path);
 }
 
-void TorrentHandleImpl::setAutoManaged(const bool enable)
+void TorrentImpl::setAutoManaged(const bool enable)
 {
     if (enable)
         m_nativeHandle.set_flags(lt::torrent_flags::auto_managed);
@@ -303,7 +303,7 @@ void TorrentHandleImpl::setAutoManaged(const bool enable)
         m_nativeHandle.unset_flags(lt::torrent_flags::auto_managed);
 }
 
-QVector<TrackerEntry> TorrentHandleImpl::trackers() const
+QVector<TrackerEntry> TorrentImpl::trackers() const
 {
     const std::vector<lt::announce_entry> nativeTrackers = m_nativeHandle.trackers();
 
@@ -316,12 +316,12 @@ QVector<TrackerEntry> TorrentHandleImpl::trackers() const
     return entries;
 }
 
-QHash<QString, TrackerInfo> TorrentHandleImpl::trackerInfos() const
+QHash<QString, TrackerInfo> TorrentImpl::trackerInfos() const
 {
     return m_trackerInfos;
 }
 
-void TorrentHandleImpl::addTrackers(const QVector<TrackerEntry> &trackers)
+void TorrentImpl::addTrackers(const QVector<TrackerEntry> &trackers)
 {
     QSet<TrackerEntry> currentTrackers;
     for (const lt::announce_entry &entry : m_nativeHandle.trackers())
@@ -343,7 +343,7 @@ void TorrentHandleImpl::addTrackers(const QVector<TrackerEntry> &trackers)
         m_session->handleTorrentTrackersAdded(this, newTrackers);
 }
 
-void TorrentHandleImpl::replaceTrackers(const QVector<TrackerEntry> &trackers)
+void TorrentImpl::replaceTrackers(const QVector<TrackerEntry> &trackers)
 {
     QVector<TrackerEntry> currentTrackers = this->trackers();
 
@@ -383,7 +383,7 @@ void TorrentHandleImpl::replaceTrackers(const QVector<TrackerEntry> &trackers)
     }
 }
 
-QVector<QUrl> TorrentHandleImpl::urlSeeds() const
+QVector<QUrl> TorrentImpl::urlSeeds() const
 {
     const std::set<std::string> currentSeeds = m_nativeHandle.url_seeds();
 
@@ -396,7 +396,7 @@ QVector<QUrl> TorrentHandleImpl::urlSeeds() const
     return urlSeeds;
 }
 
-void TorrentHandleImpl::addUrlSeeds(const QVector<QUrl> &urlSeeds)
+void TorrentImpl::addUrlSeeds(const QVector<QUrl> &urlSeeds)
 {
     const std::set<std::string> currentSeeds = m_nativeHandle.url_seeds();
 
@@ -417,7 +417,7 @@ void TorrentHandleImpl::addUrlSeeds(const QVector<QUrl> &urlSeeds)
         m_session->handleTorrentUrlSeedsAdded(this, addedUrlSeeds);
 }
 
-void TorrentHandleImpl::removeUrlSeeds(const QVector<QUrl> &urlSeeds)
+void TorrentImpl::removeUrlSeeds(const QVector<QUrl> &urlSeeds)
 {
     const std::set<std::string> currentSeeds = m_nativeHandle.url_seeds();
 
@@ -438,12 +438,12 @@ void TorrentHandleImpl::removeUrlSeeds(const QVector<QUrl> &urlSeeds)
         m_session->handleTorrentUrlSeedsRemoved(this, removedUrlSeeds);
 }
 
-void TorrentHandleImpl::clearPeers()
+void TorrentImpl::clearPeers()
 {
     m_nativeHandle.clear_peers();
 }
 
-bool TorrentHandleImpl::connectPeer(const PeerAddress &peerAddress)
+bool TorrentImpl::connectPeer(const PeerAddress &peerAddress)
 {
     lt::error_code ec;
     const lt::address addr = lt::make_address(peerAddress.ip.toString().toStdString(), ec);
@@ -465,35 +465,35 @@ bool TorrentHandleImpl::connectPeer(const PeerAddress &peerAddress)
     return true;
 }
 
-bool TorrentHandleImpl::needSaveResumeData() const
+bool TorrentImpl::needSaveResumeData() const
 {
     if (m_isStopped && !(m_nativeStatus.flags & lt::torrent_flags::auto_managed))
         return false;
     return m_nativeStatus.need_save_resume;
 }
 
-void TorrentHandleImpl::saveResumeData()
+void TorrentImpl::saveResumeData()
 {
     m_nativeHandle.save_resume_data();
     m_session->handleTorrentSaveResumeDataRequested(this);
 }
 
-int TorrentHandleImpl::filesCount() const
+int TorrentImpl::filesCount() const
 {
     return m_torrentInfo.filesCount();
 }
 
-int TorrentHandleImpl::piecesCount() const
+int TorrentImpl::piecesCount() const
 {
     return m_torrentInfo.piecesCount();
 }
 
-int TorrentHandleImpl::piecesHave() const
+int TorrentImpl::piecesHave() const
 {
     return m_nativeStatus.num_pieces;
 }
 
-qreal TorrentHandleImpl::progress() const
+qreal TorrentImpl::progress() const
 {
     if (isChecking())
         return m_nativeStatus.progress;
@@ -509,12 +509,12 @@ qreal TorrentHandleImpl::progress() const
     return progress;
 }
 
-QString TorrentHandleImpl::category() const
+QString TorrentImpl::category() const
 {
     return m_category;
 }
 
-bool TorrentHandleImpl::belongsToCategory(const QString &category) const
+bool TorrentImpl::belongsToCategory(const QString &category) const
 {
     if (m_category.isEmpty()) return category.isEmpty();
     if (!Session::isValidCategoryName(category)) return false;
@@ -527,17 +527,17 @@ bool TorrentHandleImpl::belongsToCategory(const QString &category) const
     return false;
 }
 
-QSet<QString> TorrentHandleImpl::tags() const
+QSet<QString> TorrentImpl::tags() const
 {
     return m_tags;
 }
 
-bool TorrentHandleImpl::hasTag(const QString &tag) const
+bool TorrentImpl::hasTag(const QString &tag) const
 {
     return m_tags.contains(tag);
 }
 
-bool TorrentHandleImpl::addTag(const QString &tag)
+bool TorrentImpl::addTag(const QString &tag)
 {
     if (!Session::isValidTag(tag))
         return false;
@@ -554,7 +554,7 @@ bool TorrentHandleImpl::addTag(const QString &tag)
     return false;
 }
 
-bool TorrentHandleImpl::removeTag(const QString &tag)
+bool TorrentImpl::removeTag(const QString &tag)
 {
     if (m_tags.remove(tag))
     {
@@ -564,46 +564,46 @@ bool TorrentHandleImpl::removeTag(const QString &tag)
     return false;
 }
 
-void TorrentHandleImpl::removeAllTags()
+void TorrentImpl::removeAllTags()
 {
     for (const QString &tag : asConst(tags()))
         removeTag(tag);
 }
 
-QDateTime TorrentHandleImpl::addedTime() const
+QDateTime TorrentImpl::addedTime() const
 {
     return QDateTime::fromSecsSinceEpoch(m_nativeStatus.added_time);
 }
 
-qreal TorrentHandleImpl::ratioLimit() const
+qreal TorrentImpl::ratioLimit() const
 {
     return m_ratioLimit;
 }
 
-int TorrentHandleImpl::seedingTimeLimit() const
+int TorrentImpl::seedingTimeLimit() const
 {
     return m_seedingTimeLimit;
 }
 
-QString TorrentHandleImpl::filePath(int index) const
+QString TorrentImpl::filePath(int index) const
 {
     return m_torrentInfo.filePath(index);
 }
 
-QString TorrentHandleImpl::fileName(int index) const
+QString TorrentImpl::fileName(int index) const
 {
     if (!hasMetadata()) return {};
     return Utils::Fs::fileName(filePath(index));
 }
 
-qlonglong TorrentHandleImpl::fileSize(int index) const
+qlonglong TorrentImpl::fileSize(int index) const
 {
     return m_torrentInfo.fileSize(index);
 }
 
 // Return a list of absolute paths corresponding
 // to all files in a torrent
-QStringList TorrentHandleImpl::absoluteFilePaths() const
+QStringList TorrentImpl::absoluteFilePaths() const
 {
     if (!hasMetadata()) return {};
 
@@ -614,7 +614,7 @@ QStringList TorrentHandleImpl::absoluteFilePaths() const
     return res;
 }
 
-QVector<DownloadPriority> TorrentHandleImpl::filePriorities() const
+QVector<DownloadPriority> TorrentImpl::filePriorities() const
 {
     const std::vector<lt::download_priority_t> fp = m_nativeHandle.get_file_priorities();
 
@@ -626,17 +626,17 @@ QVector<DownloadPriority> TorrentHandleImpl::filePriorities() const
     return ret;
 }
 
-TorrentInfo TorrentHandleImpl::info() const
+TorrentInfo TorrentImpl::info() const
 {
     return m_torrentInfo;
 }
 
-bool TorrentHandleImpl::isPaused() const
+bool TorrentImpl::isPaused() const
 {
     return m_isStopped;
 }
 
-bool TorrentHandleImpl::isQueued() const
+bool TorrentImpl::isQueued() const
 {
     // Torrent is Queued if it isn't in Paused state but paused internally
     return (!isPaused()
@@ -644,13 +644,13 @@ bool TorrentHandleImpl::isQueued() const
             && (m_nativeStatus.flags & lt::torrent_flags::paused));
 }
 
-bool TorrentHandleImpl::isChecking() const
+bool TorrentImpl::isChecking() const
 {
     return ((m_nativeStatus.state == lt::torrent_status::checking_files)
             || (m_nativeStatus.state == lt::torrent_status::checking_resume_data));
 }
 
-bool TorrentHandleImpl::isDownloading() const
+bool TorrentImpl::isDownloading() const
 {
     return m_state == TorrentState::Downloading
             || m_state == TorrentState::DownloadingMetadata
@@ -661,7 +661,7 @@ bool TorrentHandleImpl::isDownloading() const
             || m_state == TorrentState::ForcedDownloading;
 }
 
-bool TorrentHandleImpl::isUploading() const
+bool TorrentImpl::isUploading() const
 {
     return m_state == TorrentState::Uploading
             || m_state == TorrentState::StalledUploading
@@ -670,7 +670,7 @@ bool TorrentHandleImpl::isUploading() const
             || m_state == TorrentState::ForcedUploading;
 }
 
-bool TorrentHandleImpl::isCompleted() const
+bool TorrentImpl::isCompleted() const
 {
     return m_state == TorrentState::Uploading
             || m_state == TorrentState::StalledUploading
@@ -680,7 +680,7 @@ bool TorrentHandleImpl::isCompleted() const
             || m_state == TorrentState::ForcedUploading;
 }
 
-bool TorrentHandleImpl::isActive() const
+bool TorrentImpl::isActive() const
 {
     if (m_state == TorrentState::StalledDownloading)
         return (uploadPayloadRate() > 0);
@@ -693,44 +693,44 @@ bool TorrentHandleImpl::isActive() const
             || m_state == TorrentState::Moving;
 }
 
-bool TorrentHandleImpl::isInactive() const
+bool TorrentImpl::isInactive() const
 {
     return !isActive();
 }
 
-bool TorrentHandleImpl::isErrored() const
+bool TorrentImpl::isErrored() const
 {
     return m_state == TorrentState::MissingFiles
             || m_state == TorrentState::Error;
 }
 
-bool TorrentHandleImpl::isSeed() const
+bool TorrentImpl::isSeed() const
 {
     return ((m_nativeStatus.state == lt::torrent_status::finished)
             || (m_nativeStatus.state == lt::torrent_status::seeding));
 }
 
-bool TorrentHandleImpl::isForced() const
+bool TorrentImpl::isForced() const
 {
     return (!isPaused() && (m_operatingMode == TorrentOperatingMode::Forced));
 }
 
-bool TorrentHandleImpl::isSequentialDownload() const
+bool TorrentImpl::isSequentialDownload() const
 {
     return static_cast<bool>(m_nativeStatus.flags & lt::torrent_flags::sequential_download);
 }
 
-bool TorrentHandleImpl::hasFirstLastPiecePriority() const
+bool TorrentImpl::hasFirstLastPiecePriority() const
 {
     return m_hasFirstLastPiecePriority;
 }
 
-TorrentState TorrentHandleImpl::state() const
+TorrentState TorrentImpl::state() const
 {
     return m_state;
 }
 
-void TorrentHandleImpl::updateState()
+void TorrentImpl::updateState()
 {
     if (m_nativeStatus.state == lt::torrent_status::checking_resume_data)
     {
@@ -792,22 +792,22 @@ void TorrentHandleImpl::updateState()
     }
 }
 
-bool TorrentHandleImpl::hasMetadata() const
+bool TorrentImpl::hasMetadata() const
 {
     return m_torrentInfo.isValid();
 }
 
-bool TorrentHandleImpl::hasMissingFiles() const
+bool TorrentImpl::hasMissingFiles() const
 {
     return m_hasMissingFiles;
 }
 
-bool TorrentHandleImpl::hasError() const
+bool TorrentImpl::hasError() const
 {
     return static_cast<bool>(m_nativeStatus.errc);
 }
 
-bool TorrentHandleImpl::hasFilteredPieces() const
+bool TorrentImpl::hasFilteredPieces() const
 {
     const std::vector<lt::download_priority_t> pp = m_nativeHandle.get_piece_priorities();
     return std::any_of(pp.cbegin(), pp.cend(), [](const lt::download_priority_t priority)
@@ -816,44 +816,44 @@ bool TorrentHandleImpl::hasFilteredPieces() const
     });
 }
 
-int TorrentHandleImpl::queuePosition() const
+int TorrentImpl::queuePosition() const
 {
     if (m_nativeStatus.queue_position < lt::queue_position_t {0}) return 0;
 
     return static_cast<int>(m_nativeStatus.queue_position) + 1;
 }
 
-QString TorrentHandleImpl::error() const
+QString TorrentImpl::error() const
 {
     return QString::fromStdString(m_nativeStatus.errc.message());
 }
 
-qlonglong TorrentHandleImpl::totalDownload() const
+qlonglong TorrentImpl::totalDownload() const
 {
     return m_nativeStatus.all_time_download;
 }
 
-qlonglong TorrentHandleImpl::totalUpload() const
+qlonglong TorrentImpl::totalUpload() const
 {
     return m_nativeStatus.all_time_upload;
 }
 
-qlonglong TorrentHandleImpl::activeTime() const
+qlonglong TorrentImpl::activeTime() const
 {
     return lt::total_seconds(m_nativeStatus.active_duration);
 }
 
-qlonglong TorrentHandleImpl::finishedTime() const
+qlonglong TorrentImpl::finishedTime() const
 {
     return lt::total_seconds(m_nativeStatus.finished_duration);
 }
 
-qlonglong TorrentHandleImpl::seedingTime() const
+qlonglong TorrentImpl::seedingTime() const
 {
     return lt::total_seconds(m_nativeStatus.seeding_duration);
 }
 
-qlonglong TorrentHandleImpl::eta() const
+qlonglong TorrentImpl::eta() const
 {
     if (isPaused()) return MAX_ETA;
 
@@ -894,7 +894,7 @@ qlonglong TorrentHandleImpl::eta() const
     return (wantedSize() - completedSize()) / speedAverage.download;
 }
 
-QVector<qreal> TorrentHandleImpl::filesProgress() const
+QVector<qreal> TorrentImpl::filesProgress() const
 {
     if (!hasMetadata())
         return {};
@@ -917,50 +917,50 @@ QVector<qreal> TorrentHandleImpl::filesProgress() const
     return result;
 }
 
-int TorrentHandleImpl::seedsCount() const
+int TorrentImpl::seedsCount() const
 {
     return m_nativeStatus.num_seeds;
 }
 
-int TorrentHandleImpl::peersCount() const
+int TorrentImpl::peersCount() const
 {
     return m_nativeStatus.num_peers;
 }
 
-int TorrentHandleImpl::leechsCount() const
+int TorrentImpl::leechsCount() const
 {
     return (m_nativeStatus.num_peers - m_nativeStatus.num_seeds);
 }
 
-int TorrentHandleImpl::totalSeedsCount() const
+int TorrentImpl::totalSeedsCount() const
 {
     return (m_nativeStatus.num_complete > 0) ? m_nativeStatus.num_complete : m_nativeStatus.list_seeds;
 }
 
-int TorrentHandleImpl::totalPeersCount() const
+int TorrentImpl::totalPeersCount() const
 {
     const int peers = m_nativeStatus.num_complete + m_nativeStatus.num_incomplete;
     return (peers > 0) ? peers : m_nativeStatus.list_peers;
 }
 
-int TorrentHandleImpl::totalLeechersCount() const
+int TorrentImpl::totalLeechersCount() const
 {
     return (m_nativeStatus.num_incomplete > 0) ? m_nativeStatus.num_incomplete : (m_nativeStatus.list_peers - m_nativeStatus.list_seeds);
 }
 
-int TorrentHandleImpl::completeCount() const
+int TorrentImpl::completeCount() const
 {
     // additional info: https://github.com/qbittorrent/qBittorrent/pull/5300#issuecomment-267783646
     return m_nativeStatus.num_complete;
 }
 
-int TorrentHandleImpl::incompleteCount() const
+int TorrentImpl::incompleteCount() const
 {
     // additional info: https://github.com/qbittorrent/qBittorrent/pull/5300#issuecomment-267783646
     return m_nativeStatus.num_incomplete;
 }
 
-QDateTime TorrentHandleImpl::lastSeenComplete() const
+QDateTime TorrentImpl::lastSeenComplete() const
 {
     if (m_nativeStatus.last_seen_complete > 0)
         return QDateTime::fromSecsSinceEpoch(m_nativeStatus.last_seen_complete);
@@ -968,7 +968,7 @@ QDateTime TorrentHandleImpl::lastSeenComplete() const
         return {};
 }
 
-QDateTime TorrentHandleImpl::completedTime() const
+QDateTime TorrentImpl::completedTime() const
 {
     if (m_nativeStatus.completed_time > 0)
         return QDateTime::fromSecsSinceEpoch(m_nativeStatus.completed_time);
@@ -976,21 +976,21 @@ QDateTime TorrentHandleImpl::completedTime() const
         return {};
 }
 
-qlonglong TorrentHandleImpl::timeSinceUpload() const
+qlonglong TorrentImpl::timeSinceUpload() const
 {
     if (m_nativeStatus.last_upload.time_since_epoch().count() == 0)
         return -1;
     return lt::total_seconds(lt::clock_type::now() - m_nativeStatus.last_upload);
 }
 
-qlonglong TorrentHandleImpl::timeSinceDownload() const
+qlonglong TorrentImpl::timeSinceDownload() const
 {
     if (m_nativeStatus.last_download.time_since_epoch().count() == 0)
         return -1;
     return lt::total_seconds(lt::clock_type::now() - m_nativeStatus.last_download);
 }
 
-qlonglong TorrentHandleImpl::timeSinceActivity() const
+qlonglong TorrentImpl::timeSinceActivity() const
 {
     const qlonglong upTime = timeSinceUpload();
     const qlonglong downTime = timeSinceDownload();
@@ -999,37 +999,37 @@ qlonglong TorrentHandleImpl::timeSinceActivity() const
         : std::min(upTime, downTime);
 }
 
-int TorrentHandleImpl::downloadLimit() const
+int TorrentImpl::downloadLimit() const
 {
     return m_nativeHandle.download_limit();
 }
 
-int TorrentHandleImpl::uploadLimit() const
+int TorrentImpl::uploadLimit() const
 {
     return m_nativeHandle.upload_limit();
 }
 
-bool TorrentHandleImpl::superSeeding() const
+bool TorrentImpl::superSeeding() const
 {
     return static_cast<bool>(m_nativeStatus.flags & lt::torrent_flags::super_seeding);
 }
 
-bool TorrentHandleImpl::isDHTDisabled() const
+bool TorrentImpl::isDHTDisabled() const
 {
     return static_cast<bool>(m_nativeStatus.flags & lt::torrent_flags::disable_dht);
 }
 
-bool TorrentHandleImpl::isPEXDisabled() const
+bool TorrentImpl::isPEXDisabled() const
 {
     return static_cast<bool>(m_nativeStatus.flags & lt::torrent_flags::disable_pex);
 }
 
-bool TorrentHandleImpl::isLSDDisabled() const
+bool TorrentImpl::isLSDDisabled() const
 {
     return static_cast<bool>(m_nativeStatus.flags & lt::torrent_flags::disable_lsd);
 }
 
-QVector<PeerInfo> TorrentHandleImpl::peers() const
+QVector<PeerInfo> TorrentImpl::peers() const
 {
     std::vector<lt::peer_info> nativePeers;
     m_nativeHandle.get_peer_info(nativePeers);
@@ -1041,7 +1041,7 @@ QVector<PeerInfo> TorrentHandleImpl::peers() const
     return peers;
 }
 
-QBitArray TorrentHandleImpl::pieces() const
+QBitArray TorrentImpl::pieces() const
 {
     QBitArray result(m_nativeStatus.pieces.size());
     for (int i = 0; i < result.size(); ++i)
@@ -1052,7 +1052,7 @@ QBitArray TorrentHandleImpl::pieces() const
     return result;
 }
 
-QBitArray TorrentHandleImpl::downloadingPieces() const
+QBitArray TorrentImpl::downloadingPieces() const
 {
     QBitArray result(piecesCount());
 
@@ -1065,7 +1065,7 @@ QBitArray TorrentHandleImpl::downloadingPieces() const
     return result;
 }
 
-QVector<int> TorrentHandleImpl::pieceAvailability() const
+QVector<int> TorrentImpl::pieceAvailability() const
 {
     std::vector<int> avail;
     m_nativeHandle.piece_availability(avail);
@@ -1073,12 +1073,12 @@ QVector<int> TorrentHandleImpl::pieceAvailability() const
     return Vector::fromStdVector(avail);
 }
 
-qreal TorrentHandleImpl::distributedCopies() const
+qreal TorrentImpl::distributedCopies() const
 {
     return m_nativeStatus.distributed_copies;
 }
 
-qreal TorrentHandleImpl::maxRatio() const
+qreal TorrentImpl::maxRatio() const
 {
     if (m_ratioLimit == USE_GLOBAL_RATIO)
         return m_session->globalMaxRatio();
@@ -1086,7 +1086,7 @@ qreal TorrentHandleImpl::maxRatio() const
     return m_ratioLimit;
 }
 
-int TorrentHandleImpl::maxSeedingTime() const
+int TorrentImpl::maxSeedingTime() const
 {
     if (m_seedingTimeLimit == USE_GLOBAL_SEEDING_TIME)
         return m_session->globalMaxSeedingMinutes();
@@ -1094,7 +1094,7 @@ int TorrentHandleImpl::maxSeedingTime() const
     return m_seedingTimeLimit;
 }
 
-qreal TorrentHandleImpl::realRatio() const
+qreal TorrentImpl::realRatio() const
 {
     const int64_t upload = m_nativeStatus.all_time_upload;
     // special case for a seeder who lost its stats, also assume nobody will import a 99% done torrent
@@ -1110,42 +1110,42 @@ qreal TorrentHandleImpl::realRatio() const
     return (ratio > MAX_RATIO) ? MAX_RATIO : ratio;
 }
 
-int TorrentHandleImpl::uploadPayloadRate() const
+int TorrentImpl::uploadPayloadRate() const
 {
     return m_nativeStatus.upload_payload_rate;
 }
 
-int TorrentHandleImpl::downloadPayloadRate() const
+int TorrentImpl::downloadPayloadRate() const
 {
     return m_nativeStatus.download_payload_rate;
 }
 
-qlonglong TorrentHandleImpl::totalPayloadUpload() const
+qlonglong TorrentImpl::totalPayloadUpload() const
 {
     return m_nativeStatus.total_payload_upload;
 }
 
-qlonglong TorrentHandleImpl::totalPayloadDownload() const
+qlonglong TorrentImpl::totalPayloadDownload() const
 {
     return m_nativeStatus.total_payload_download;
 }
 
-int TorrentHandleImpl::connectionsCount() const
+int TorrentImpl::connectionsCount() const
 {
     return m_nativeStatus.num_connections;
 }
 
-int TorrentHandleImpl::connectionsLimit() const
+int TorrentImpl::connectionsLimit() const
 {
     return m_nativeStatus.connections_limit;
 }
 
-qlonglong TorrentHandleImpl::nextAnnounce() const
+qlonglong TorrentImpl::nextAnnounce() const
 {
     return lt::total_seconds(m_nativeStatus.next_announce);
 }
 
-void TorrentHandleImpl::setName(const QString &name)
+void TorrentImpl::setName(const QString &name)
 {
     if (m_name != name)
     {
@@ -1154,7 +1154,7 @@ void TorrentHandleImpl::setName(const QString &name)
     }
 }
 
-bool TorrentHandleImpl::setCategory(const QString &category)
+bool TorrentImpl::setCategory(const QString &category)
 {
     if (m_category != category)
     {
@@ -1177,7 +1177,7 @@ bool TorrentHandleImpl::setCategory(const QString &category)
     return true;
 }
 
-void TorrentHandleImpl::move(QString path)
+void TorrentImpl::move(QString path)
 {
     if (m_useAutoTMM)
     {
@@ -1194,7 +1194,7 @@ void TorrentHandleImpl::move(QString path)
     move_impl(path, MoveStorageMode::KeepExistingFiles);
 }
 
-void TorrentHandleImpl::move_impl(QString path, const MoveStorageMode mode)
+void TorrentImpl::move_impl(QString path, const MoveStorageMode mode)
 {
     if (path == savePath()) return;
     path = Utils::Fs::toNativePath(path);
@@ -1210,17 +1210,17 @@ void TorrentHandleImpl::move_impl(QString path, const MoveStorageMode mode)
     }
 }
 
-void TorrentHandleImpl::forceReannounce(int index)
+void TorrentImpl::forceReannounce(int index)
 {
     m_nativeHandle.force_reannounce(0, index);
 }
 
-void TorrentHandleImpl::forceDHTAnnounce()
+void TorrentImpl::forceDHTAnnounce()
 {
     m_nativeHandle.force_dht_announce();
 }
 
-void TorrentHandleImpl::forceRecheck()
+void TorrentImpl::forceRecheck()
 {
     if (!hasMetadata()) return;
 
@@ -1236,7 +1236,7 @@ void TorrentHandleImpl::forceRecheck()
     }
 }
 
-void TorrentHandleImpl::setSequentialDownload(const bool enable)
+void TorrentImpl::setSequentialDownload(const bool enable)
 {
     if (enable)
     {
@@ -1252,7 +1252,7 @@ void TorrentHandleImpl::setSequentialDownload(const bool enable)
     saveResumeData();
 }
 
-void TorrentHandleImpl::setFirstLastPiecePriority(const bool enabled)
+void TorrentImpl::setFirstLastPiecePriority(const bool enabled)
 {
     if (m_hasFirstLastPiecePriority == enabled)
         return;
@@ -1267,7 +1267,7 @@ void TorrentHandleImpl::setFirstLastPiecePriority(const bool enabled)
     saveResumeData();
 }
 
-void TorrentHandleImpl::applyFirstLastPiecePriority(const bool enabled, const QVector<DownloadPriority> &updatedFilePrio)
+void TorrentImpl::applyFirstLastPiecePriority(const bool enabled, const QVector<DownloadPriority> &updatedFilePrio)
 {
     Q_ASSERT(hasMetadata());
 
@@ -1301,12 +1301,12 @@ void TorrentHandleImpl::applyFirstLastPiecePriority(const bool enabled, const QV
     m_nativeHandle.prioritize_pieces(piecePriorities);
 }
 
-void TorrentHandleImpl::fileSearchFinished(const QString &savePath, const QStringList &fileNames)
+void TorrentImpl::fileSearchFinished(const QString &savePath, const QStringList &fileNames)
 {
     endReceivedMetadataHandling(savePath, fileNames);
 }
 
-void TorrentHandleImpl::endReceivedMetadataHandling(const QString &savePath, const QStringList &fileNames)
+void TorrentImpl::endReceivedMetadataHandling(const QString &savePath, const QStringList &fileNames)
 {
     lt::add_torrent_params &p = m_ltAddTorrentParams;
 
@@ -1328,7 +1328,7 @@ void TorrentHandleImpl::endReceivedMetadataHandling(const QString &savePath, con
     m_session->handleTorrentMetadataReceived(this);
 }
 
-void TorrentHandleImpl::reload()
+void TorrentImpl::reload()
 {
     const auto queuePos = m_nativeHandle.queue_position();
 
@@ -1359,7 +1359,7 @@ void TorrentHandleImpl::reload()
     m_torrentInfo = TorrentInfo {m_nativeHandle.torrent_file()};
 }
 
-void TorrentHandleImpl::pause()
+void TorrentImpl::pause()
 {
     if (!m_isStopped)
     {
@@ -1376,7 +1376,7 @@ void TorrentHandleImpl::pause()
     }
 }
 
-void TorrentHandleImpl::resume(const TorrentOperatingMode mode)
+void TorrentImpl::resume(const TorrentOperatingMode mode)
 {
     if (hasError())
         m_nativeHandle.clear_error();
@@ -1410,7 +1410,7 @@ void TorrentHandleImpl::resume(const TorrentOperatingMode mode)
     }
 }
 
-void TorrentHandleImpl::moveStorage(const QString &newPath, const MoveStorageMode mode)
+void TorrentImpl::moveStorage(const QString &newPath, const MoveStorageMode mode)
 {
     if (m_session->addMoveTorrentStorageJob(this, newPath, mode))
     {
@@ -1419,7 +1419,7 @@ void TorrentHandleImpl::moveStorage(const QString &newPath, const MoveStorageMod
     }
 }
 
-void TorrentHandleImpl::renameFile(const int index, const QString &path)
+void TorrentImpl::renameFile(const int index, const QString &path)
 {
     const QString oldPath = filePath(index);
     m_oldPath[lt::file_index_t {index}].push_back(oldPath);
@@ -1427,12 +1427,12 @@ void TorrentHandleImpl::renameFile(const int index, const QString &path)
     m_nativeHandle.rename_file(lt::file_index_t {index}, Utils::Fs::toNativePath(path).toStdString());
 }
 
-void TorrentHandleImpl::handleStateUpdate(const lt::torrent_status &nativeStatus)
+void TorrentImpl::handleStateUpdate(const lt::torrent_status &nativeStatus)
 {
     updateStatus(nativeStatus);
 }
 
-void TorrentHandleImpl::handleMoveStorageJobFinished(const bool hasOutstandingJob)
+void TorrentImpl::handleMoveStorageJobFinished(const bool hasOutstandingJob)
 {
     m_storageIsMoving = hasOutstandingJob;
 
@@ -1450,7 +1450,7 @@ void TorrentHandleImpl::handleMoveStorageJobFinished(const bool hasOutstandingJo
         m_moveFinishedTriggers.takeFirst()();
 }
 
-void TorrentHandleImpl::handleTrackerReplyAlert(const lt::tracker_reply_alert *p)
+void TorrentImpl::handleTrackerReplyAlert(const lt::tracker_reply_alert *p)
 {
     const QString trackerUrl(p->tracker_url());
     qDebug("Received a tracker reply from %s (Num_peers = %d)", qUtf8Printable(trackerUrl), p->num_peers);
@@ -1460,7 +1460,7 @@ void TorrentHandleImpl::handleTrackerReplyAlert(const lt::tracker_reply_alert *p
     m_session->handleTorrentTrackerReply(this, trackerUrl);
 }
 
-void TorrentHandleImpl::handleTrackerWarningAlert(const lt::tracker_warning_alert *p)
+void TorrentImpl::handleTrackerWarningAlert(const lt::tracker_warning_alert *p)
 {
     const QString trackerUrl = p->tracker_url();
     const QString message = p->warning_message();
@@ -1471,7 +1471,7 @@ void TorrentHandleImpl::handleTrackerWarningAlert(const lt::tracker_warning_aler
     m_session->handleTorrentTrackerWarning(this, trackerUrl);
 }
 
-void TorrentHandleImpl::handleTrackerErrorAlert(const lt::tracker_error_alert *p)
+void TorrentImpl::handleTrackerErrorAlert(const lt::tracker_error_alert *p)
 {
     const QString trackerUrl = p->tracker_url();
     const QString message = p->error_message();
@@ -1490,7 +1490,7 @@ void TorrentHandleImpl::handleTrackerErrorAlert(const lt::tracker_error_alert *p
         m_session->handleTorrentTrackerError(this, trackerUrl);
 }
 
-void TorrentHandleImpl::handleTorrentCheckedAlert(const lt::torrent_checked_alert *p)
+void TorrentImpl::handleTorrentCheckedAlert(const lt::torrent_checked_alert *p)
 {
     Q_UNUSED(p);
     qDebug("\"%s\" have just finished checking.", qUtf8Printable(name()));
@@ -1524,7 +1524,7 @@ void TorrentHandleImpl::handleTorrentCheckedAlert(const lt::torrent_checked_aler
     m_session->handleTorrentChecked(this);
 }
 
-void TorrentHandleImpl::handleTorrentFinishedAlert(const lt::torrent_finished_alert *p)
+void TorrentImpl::handleTorrentFinishedAlert(const lt::torrent_finished_alert *p)
 {
     Q_UNUSED(p);
     qDebug("Got a torrent finished alert for \"%s\"", qUtf8Printable(name()));
@@ -1553,17 +1553,17 @@ void TorrentHandleImpl::handleTorrentFinishedAlert(const lt::torrent_finished_al
     }
 }
 
-void TorrentHandleImpl::handleTorrentPausedAlert(const lt::torrent_paused_alert *p)
+void TorrentImpl::handleTorrentPausedAlert(const lt::torrent_paused_alert *p)
 {
     Q_UNUSED(p);
 }
 
-void TorrentHandleImpl::handleTorrentResumedAlert(const lt::torrent_resumed_alert *p)
+void TorrentImpl::handleTorrentResumedAlert(const lt::torrent_resumed_alert *p)
 {
     Q_UNUSED(p);
 }
 
-void TorrentHandleImpl::handleSaveResumeDataAlert(const lt::save_resume_data_alert *p)
+void TorrentImpl::handleSaveResumeDataAlert(const lt::save_resume_data_alert *p)
 {
     if (!m_hasMissingFiles)
     {
@@ -1639,13 +1639,13 @@ void TorrentHandleImpl::handleSaveResumeDataAlert(const lt::save_resume_data_ale
     m_session->handleTorrentResumeDataReady(this, resumeDataPtr);
 }
 
-void TorrentHandleImpl::handleSaveResumeDataFailedAlert(const lt::save_resume_data_failed_alert *p)
+void TorrentImpl::handleSaveResumeDataFailedAlert(const lt::save_resume_data_failed_alert *p)
 {
     Q_UNUSED(p);
     Q_ASSERT_X(false, Q_FUNC_INFO, "This point should be unreachable since libtorrent 1.2.11");
 }
 
-void TorrentHandleImpl::handleFastResumeRejectedAlert(const lt::fastresume_rejected_alert *p)
+void TorrentImpl::handleFastResumeRejectedAlert(const lt::fastresume_rejected_alert *p)
 {
     m_fastresumeDataRejected = true;
 
@@ -1662,7 +1662,7 @@ void TorrentHandleImpl::handleFastResumeRejectedAlert(const lt::fastresume_rejec
     }
 }
 
-void TorrentHandleImpl::handleFileRenamedAlert(const lt::file_renamed_alert *p)
+void TorrentImpl::handleFileRenamedAlert(const lt::file_renamed_alert *p)
 {
     // Remove empty leftover folders
     // For example renaming "a/b/c" to "d/b/c", then folders "a/b" and "a" will
@@ -1706,7 +1706,7 @@ void TorrentHandleImpl::handleFileRenamedAlert(const lt::file_renamed_alert *p)
         saveResumeData();  // otherwise the new path will not be saved
 }
 
-void TorrentHandleImpl::handleFileRenameFailedAlert(const lt::file_rename_failed_alert *p)
+void TorrentImpl::handleFileRenameFailedAlert(const lt::file_rename_failed_alert *p)
 {
     LogMsg(tr("File rename failed. Torrent: \"%1\", file: \"%2\", reason: \"%3\"")
         .arg(name(), filePath(static_cast<LTUnderlyingType<lt::file_index_t>>(p->index))
@@ -1724,7 +1724,7 @@ void TorrentHandleImpl::handleFileRenameFailedAlert(const lt::file_rename_failed
         saveResumeData();  // otherwise the new path will not be saved
 }
 
-void TorrentHandleImpl::handleFileCompletedAlert(const lt::file_completed_alert *p)
+void TorrentImpl::handleFileCompletedAlert(const lt::file_completed_alert *p)
 {
     qDebug("A file completed download in torrent \"%s\"", qUtf8Printable(name()));
     if (m_session->isAppendExtensionEnabled())
@@ -1740,7 +1740,7 @@ void TorrentHandleImpl::handleFileCompletedAlert(const lt::file_completed_alert 
     }
 }
 
-void TorrentHandleImpl::handleMetadataReceivedAlert(const lt::metadata_received_alert *p)
+void TorrentImpl::handleMetadataReceivedAlert(const lt::metadata_received_alert *p)
 {
     Q_UNUSED(p);
 
@@ -1750,31 +1750,31 @@ void TorrentHandleImpl::handleMetadataReceivedAlert(const lt::metadata_received_
     saveResumeData();
 }
 
-void TorrentHandleImpl::handlePerformanceAlert(const lt::performance_alert *p) const
+void TorrentImpl::handlePerformanceAlert(const lt::performance_alert *p) const
 {
     LogMsg((tr("Performance alert: ") + QString::fromStdString(p->message()))
            , Log::INFO);
 }
 
-void TorrentHandleImpl::handleTempPathChanged()
+void TorrentImpl::handleTempPathChanged()
 {
     adjustActualSavePath();
 }
 
-void TorrentHandleImpl::handleCategorySavePathChanged()
+void TorrentImpl::handleCategorySavePathChanged()
 {
     if (m_useAutoTMM)
         move_impl(m_session->categorySavePath(m_category), MoveStorageMode::Overwrite);
 }
 
-void TorrentHandleImpl::handleAppendExtensionToggled()
+void TorrentImpl::handleAppendExtensionToggled()
 {
     if (!hasMetadata()) return;
 
     manageIncompleteFiles();
 }
 
-void TorrentHandleImpl::handleAlert(const lt::alert *a)
+void TorrentImpl::handleAlert(const lt::alert *a)
 {
     switch (a->type())
     {
@@ -1826,7 +1826,7 @@ void TorrentHandleImpl::handleAlert(const lt::alert *a)
     }
 }
 
-void TorrentHandleImpl::manageIncompleteFiles()
+void TorrentImpl::manageIncompleteFiles()
 {
     const bool isAppendExtensionEnabled = m_session->isAppendExtensionEnabled();
     const QVector<qreal> fp = filesProgress();
@@ -1861,7 +1861,7 @@ void TorrentHandleImpl::manageIncompleteFiles()
     }
 }
 
-void TorrentHandleImpl::adjustActualSavePath()
+void TorrentImpl::adjustActualSavePath()
 {
     if (!isMoveInProgress())
         adjustActualSavePath_impl();
@@ -1869,7 +1869,7 @@ void TorrentHandleImpl::adjustActualSavePath()
         m_moveFinishedTriggers.append([this]() { adjustActualSavePath_impl(); });
 }
 
-void TorrentHandleImpl::adjustActualSavePath_impl()
+void TorrentImpl::adjustActualSavePath_impl()
 {
     const bool needUseTempDir = useTempPath();
     const QDir tempDir {m_session->torrentTempPath(info())};
@@ -1896,27 +1896,27 @@ void TorrentHandleImpl::adjustActualSavePath_impl()
     moveStorage(Utils::Fs::toNativePath(targetDir.absolutePath()), MoveStorageMode::Overwrite);
 }
 
-lt::torrent_handle TorrentHandleImpl::nativeHandle() const
+lt::torrent_handle TorrentImpl::nativeHandle() const
 {
     return m_nativeHandle;
 }
 
-bool TorrentHandleImpl::isMoveInProgress() const
+bool TorrentImpl::isMoveInProgress() const
 {
     return m_storageIsMoving;
 }
 
-bool TorrentHandleImpl::useTempPath() const
+bool TorrentImpl::useTempPath() const
 {
     return m_session->isTempPathEnabled() && !(isSeed() || m_hasSeedStatus);
 }
 
-void TorrentHandleImpl::updateStatus()
+void TorrentImpl::updateStatus()
 {
     updateStatus(m_nativeHandle.status());
 }
 
-void TorrentHandleImpl::updateStatus(const lt::torrent_status &nativeStatus)
+void TorrentImpl::updateStatus(const lt::torrent_status &nativeStatus)
 {
     m_nativeStatus = nativeStatus;
     updateState();
@@ -1935,7 +1935,7 @@ void TorrentHandleImpl::updateStatus(const lt::torrent_status &nativeStatus)
     }
 }
 
-void TorrentHandleImpl::setRatioLimit(qreal limit)
+void TorrentImpl::setRatioLimit(qreal limit)
 {
     if (limit < USE_GLOBAL_RATIO)
         limit = NO_RATIO_LIMIT;
@@ -1949,7 +1949,7 @@ void TorrentHandleImpl::setRatioLimit(qreal limit)
     }
 }
 
-void TorrentHandleImpl::setSeedingTimeLimit(int limit)
+void TorrentImpl::setSeedingTimeLimit(int limit)
 {
     if (limit < USE_GLOBAL_SEEDING_TIME)
         limit = NO_SEEDING_TIME_LIMIT;
@@ -1963,7 +1963,7 @@ void TorrentHandleImpl::setSeedingTimeLimit(int limit)
     }
 }
 
-void TorrentHandleImpl::setUploadLimit(const int limit)
+void TorrentImpl::setUploadLimit(const int limit)
 {
     if (limit == uploadLimit())
         return;
@@ -1972,7 +1972,7 @@ void TorrentHandleImpl::setUploadLimit(const int limit)
     saveResumeData();
 }
 
-void TorrentHandleImpl::setDownloadLimit(const int limit)
+void TorrentImpl::setDownloadLimit(const int limit)
 {
     if (limit == downloadLimit())
         return;
@@ -1981,7 +1981,7 @@ void TorrentHandleImpl::setDownloadLimit(const int limit)
     saveResumeData();
 }
 
-void TorrentHandleImpl::setSuperSeeding(const bool enable)
+void TorrentImpl::setSuperSeeding(const bool enable)
 {
     if (enable == superSeeding())
         return;
@@ -1993,7 +1993,7 @@ void TorrentHandleImpl::setSuperSeeding(const bool enable)
     saveResumeData();
 }
 
-void TorrentHandleImpl::setDHTDisabled(const bool disable)
+void TorrentImpl::setDHTDisabled(const bool disable)
 {
     if (disable == isDHTDisabled())
         return;
@@ -2005,7 +2005,7 @@ void TorrentHandleImpl::setDHTDisabled(const bool disable)
     saveResumeData();
 }
 
-void TorrentHandleImpl::setPEXDisabled(const bool disable)
+void TorrentImpl::setPEXDisabled(const bool disable)
 {
     if (disable == isPEXDisabled())
         return;
@@ -2017,7 +2017,7 @@ void TorrentHandleImpl::setPEXDisabled(const bool disable)
     saveResumeData();
 }
 
-void TorrentHandleImpl::setLSDDisabled(const bool disable)
+void TorrentImpl::setLSDDisabled(const bool disable)
 {
     if (disable == isLSDDisabled())
         return;
@@ -2029,17 +2029,17 @@ void TorrentHandleImpl::setLSDDisabled(const bool disable)
     saveResumeData();
 }
 
-void TorrentHandleImpl::flushCache() const
+void TorrentImpl::flushCache() const
 {
     m_nativeHandle.flush_cache();
 }
 
-QString TorrentHandleImpl::createMagnetURI() const
+QString TorrentImpl::createMagnetURI() const
 {
     return QString::fromStdString(lt::make_magnet_uri(m_nativeHandle));
 }
 
-void TorrentHandleImpl::prioritizeFiles(const QVector<DownloadPriority> &priorities)
+void TorrentImpl::prioritizeFiles(const QVector<DownloadPriority> &priorities)
 {
     if (!hasMetadata()) return;
     if (priorities.size() != filesCount()) return;
@@ -2067,7 +2067,7 @@ void TorrentHandleImpl::prioritizeFiles(const QVector<DownloadPriority> &priorit
         applyFirstLastPiecePriority(true, priorities);
 }
 
-QVector<qreal> TorrentHandleImpl::availableFileFractions() const
+QVector<qreal> TorrentImpl::availableFileFractions() const
 {
     const int filesCount = this->filesCount();
     if (filesCount <= 0) return {};

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -46,7 +46,7 @@
 
 #include "infohash.h"
 #include "speedmonitor.h"
-#include "torrenthandle.h"
+#include "torrent.h"
 #include "torrentinfo.h"
 
 namespace BitTorrent
@@ -69,8 +69,8 @@ namespace BitTorrent
         bool paused = false;
 
 
-        qreal ratioLimit = TorrentHandle::USE_GLOBAL_RATIO;
-        int seedingTimeLimit = TorrentHandle::USE_GLOBAL_SEEDING_TIME;
+        qreal ratioLimit = Torrent::USE_GLOBAL_RATIO;
+        int seedingTimeLimit = Torrent::USE_GLOBAL_SEEDING_TIME;
 
         bool restored = false;  // is existing torrent job?
     };
@@ -87,15 +87,15 @@ namespace BitTorrent
         HandleMetadata
     };
 
-    class TorrentHandleImpl final : public QObject, public TorrentHandle
+    class TorrentImpl final : public QObject, public Torrent
     {
-        Q_DISABLE_COPY(TorrentHandleImpl)
-        Q_DECLARE_TR_FUNCTIONS(BitTorrent::TorrentHandleImpl)
+        Q_DISABLE_COPY(TorrentImpl)
+        Q_DECLARE_TR_FUNCTIONS(BitTorrent::TorrentImpl)
 
     public:
-        TorrentHandleImpl(Session *session, lt::session *nativeSession
+        TorrentImpl(Session *session, lt::session *nativeSession
                           , const lt::torrent_handle &nativeHandle, const LoadTorrentParams &params);
-        ~TorrentHandleImpl() override;
+        ~TorrentImpl() override;
 
         bool isValid() const;
 

--- a/src/base/torrentfilter.cpp
+++ b/src/base/torrentfilter.cpp
@@ -29,7 +29,7 @@
 #include "torrentfilter.h"
 
 #include "bittorrent/infohash.h"
-#include "bittorrent/torrenthandle.h"
+#include "bittorrent/torrent.h"
 
 const QString TorrentFilter::AnyCategory;
 const InfoHashSet TorrentFilter::AnyHash {{}};
@@ -47,7 +47,7 @@ const TorrentFilter TorrentFilter::StalledUploadingTorrent(TorrentFilter::Stalle
 const TorrentFilter TorrentFilter::StalledDownloadingTorrent(TorrentFilter::StalledDownloading);
 const TorrentFilter TorrentFilter::ErroredTorrent(TorrentFilter::Errored);
 
-using BitTorrent::TorrentHandle;
+using BitTorrent::Torrent;
 
 TorrentFilter::TorrentFilter(const Type type, const InfoHashSet &hashSet, const QString &category, const QString &tag)
     : m_type(type)
@@ -146,14 +146,14 @@ bool TorrentFilter::setTag(const QString &tag)
     return false;
 }
 
-bool TorrentFilter::match(const TorrentHandle *const torrent) const
+bool TorrentFilter::match(const Torrent *const torrent) const
 {
     if (!torrent) return false;
 
     return (matchState(torrent) && matchHash(torrent) && matchCategory(torrent) && matchTag(torrent));
 }
 
-bool TorrentFilter::matchState(const BitTorrent::TorrentHandle *const torrent) const
+bool TorrentFilter::matchState(const BitTorrent::Torrent *const torrent) const
 {
     switch (m_type)
     {
@@ -187,21 +187,21 @@ bool TorrentFilter::matchState(const BitTorrent::TorrentHandle *const torrent) c
     }
 }
 
-bool TorrentFilter::matchHash(const BitTorrent::TorrentHandle *const torrent) const
+bool TorrentFilter::matchHash(const BitTorrent::Torrent *const torrent) const
 {
     if (m_hashSet == AnyHash) return true;
 
     return m_hashSet.contains(torrent->hash());
 }
 
-bool TorrentFilter::matchCategory(const BitTorrent::TorrentHandle *const torrent) const
+bool TorrentFilter::matchCategory(const BitTorrent::Torrent *const torrent) const
 {
     if (m_category.isNull()) return true;
 
     return (torrent->belongsToCategory(m_category));
 }
 
-bool TorrentFilter::matchTag(const BitTorrent::TorrentHandle *const torrent) const
+bool TorrentFilter::matchTag(const BitTorrent::Torrent *const torrent) const
 {
     // Empty tag is a special value to indicate we're filtering for untagged torrents.
     if (m_tag.isNull()) return true;

--- a/src/base/torrentfilter.h
+++ b/src/base/torrentfilter.h
@@ -35,7 +35,7 @@
 
 namespace BitTorrent
 {
-    class TorrentHandle;
+    class Torrent;
 }
 
 using InfoHashSet = QSet<BitTorrent::InfoHash>;
@@ -88,13 +88,13 @@ public:
     bool setCategory(const QString &category);
     bool setTag(const QString &tag);
 
-    bool match(const BitTorrent::TorrentHandle *torrent) const;
+    bool match(const BitTorrent::Torrent *torrent) const;
 
 private:
-    bool matchState(const BitTorrent::TorrentHandle *torrent) const;
-    bool matchHash(const BitTorrent::TorrentHandle *torrent) const;
-    bool matchCategory(const BitTorrent::TorrentHandle *torrent) const;
-    bool matchTag(const BitTorrent::TorrentHandle *torrent) const;
+    bool matchState(const BitTorrent::Torrent *torrent) const;
+    bool matchHash(const BitTorrent::Torrent *torrent) const;
+    bool matchCategory(const BitTorrent::Torrent *torrent) const;
+    bool matchTag(const BitTorrent::Torrent *torrent) const;
 
     Type m_type {All};
     QString m_category;

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -42,7 +42,7 @@
 #include "base/bittorrent/infohash.h"
 #include "base/bittorrent/magneturi.h"
 #include "base/bittorrent/session.h"
-#include "base/bittorrent/torrenthandle.h"
+#include "base/bittorrent/torrent.h"
 #include "base/exceptions.h"
 #include "base/global.h"
 #include "base/net/downloadmanager.h"
@@ -275,7 +275,7 @@ bool AddNewTorrentDialog::loadTorrentImpl()
     // Prevent showing the dialog if download is already present
     if (BitTorrent::Session::instance()->isKnownTorrent(infoHash))
     {
-        BitTorrent::TorrentHandle *const torrent = BitTorrent::Session::instance()->findTorrent(infoHash);
+        BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->findTorrent(infoHash);
         if (torrent)
         {
             if (torrent->isPrivate() || m_torrentInfo.isPrivate())
@@ -316,7 +316,7 @@ bool AddNewTorrentDialog::loadMagnet(const BitTorrent::MagnetUri &magnetUri)
     // Prevent showing the dialog if download is already present
     if (BitTorrent::Session::instance()->isKnownTorrent(infoHash))
     {
-        BitTorrent::TorrentHandle *const torrent = BitTorrent::Session::instance()->findTorrent(infoHash);
+        BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->findTorrent(infoHash);
         if (torrent)
         {
             if (torrent->isPrivate())

--- a/src/gui/categoryfiltermodel.cpp
+++ b/src/gui/categoryfiltermodel.cpp
@@ -32,7 +32,7 @@
 #include <QIcon>
 
 #include "base/bittorrent/session.h"
-#include "base/bittorrent/torrenthandle.h"
+#include "base/bittorrent/torrent.h"
 #include "base/global.h"
 #include "uithememanager.h"
 
@@ -336,7 +336,7 @@ void CategoryFilterModel::categoryRemoved(const QString &categoryName)
     }
 }
 
-void CategoryFilterModel::torrentAdded(BitTorrent::TorrentHandle *const torrent)
+void CategoryFilterModel::torrentAdded(BitTorrent::Torrent *const torrent)
 {
     CategoryModelItem *item = findItem(torrent->category());
     Q_ASSERT(item);
@@ -345,7 +345,7 @@ void CategoryFilterModel::torrentAdded(BitTorrent::TorrentHandle *const torrent)
     m_rootItem->childAt(0)->increaseTorrentsCount();
 }
 
-void CategoryFilterModel::torrentAboutToBeRemoved(BitTorrent::TorrentHandle *const torrent)
+void CategoryFilterModel::torrentAboutToBeRemoved(BitTorrent::Torrent *const torrent)
 {
     CategoryModelItem *item = findItem(torrent->category());
     Q_ASSERT(item);
@@ -354,7 +354,7 @@ void CategoryFilterModel::torrentAboutToBeRemoved(BitTorrent::TorrentHandle *con
     m_rootItem->childAt(0)->decreaseTorrentsCount();
 }
 
-void CategoryFilterModel::torrentCategoryChanged(BitTorrent::TorrentHandle *const torrent, const QString &oldCategory)
+void CategoryFilterModel::torrentCategoryChanged(BitTorrent::Torrent *const torrent, const QString &oldCategory)
 {
     QModelIndex i;
 
@@ -403,7 +403,7 @@ void CategoryFilterModel::populate()
     m_rootItem->addChild(UID_ALL, new CategoryModelItem(nullptr, tr("All"), torrents.count()));
 
     // Uncategorized torrents
-    using Torrent = BitTorrent::TorrentHandle;
+    using Torrent = BitTorrent::Torrent;
     m_rootItem->addChild(
                 UID_UNCATEGORIZED
                 , new CategoryModelItem(
@@ -411,7 +411,7 @@ void CategoryFilterModel::populate()
                     , std::count_if(torrents.begin(), torrents.end()
                                     , [](Torrent *torrent) { return torrent->category().isEmpty(); })));
 
-    using Torrent = BitTorrent::TorrentHandle;
+    using Torrent = BitTorrent::Torrent;
     for (auto i = session->categories().cbegin(); i != session->categories().cend(); ++i)
     {
         const QString &category = i.key();

--- a/src/gui/categoryfiltermodel.h
+++ b/src/gui/categoryfiltermodel.h
@@ -36,7 +36,7 @@ class CategoryModelItem;
 
 namespace BitTorrent
 {
-    class TorrentHandle;
+    class Torrent;
 }
 
 class CategoryFilterModel final : public QAbstractItemModel
@@ -63,9 +63,9 @@ public:
 private slots:
     void categoryAdded(const QString &categoryName);
     void categoryRemoved(const QString &categoryName);
-    void torrentAdded(BitTorrent::TorrentHandle *const torrent);
-    void torrentAboutToBeRemoved(BitTorrent::TorrentHandle *const torrent);
-    void torrentCategoryChanged(BitTorrent::TorrentHandle *const torrent, const QString &oldCategory);
+    void torrentAdded(BitTorrent::Torrent *const torrent);
+    void torrentAboutToBeRemoved(BitTorrent::Torrent *const torrent);
+    void torrentCategoryChanged(BitTorrent::Torrent *const torrent, const QString &oldCategory);
     void subcategoriesSupportChanged();
 
 private:

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -58,7 +58,7 @@
 
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/sessionstatus.h"
-#include "base/bittorrent/torrenthandle.h"
+#include "base/bittorrent/torrent.h"
 #include "base/global.h"
 #include "base/logger.h"
 #include "base/net/downloadmanager.h"
@@ -260,11 +260,11 @@ MainWindow::MainWindow(QWidget *parent)
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackerlessStateChanged, m_transferListFiltersWidget, &TransferListFiltersWidget::changeTrackerless);
 
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackerSuccess
-        , m_transferListFiltersWidget, qOverload<const BitTorrent::TorrentHandle *, const QString &>(&TransferListFiltersWidget::trackerSuccess));
+        , m_transferListFiltersWidget, qOverload<const BitTorrent::Torrent *, const QString &>(&TransferListFiltersWidget::trackerSuccess));
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackerError
-        , m_transferListFiltersWidget, qOverload<const BitTorrent::TorrentHandle *, const QString &>(&TransferListFiltersWidget::trackerError));
+        , m_transferListFiltersWidget, qOverload<const BitTorrent::Torrent *, const QString &>(&TransferListFiltersWidget::trackerError));
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackerWarning
-        , m_transferListFiltersWidget, qOverload<const BitTorrent::TorrentHandle *, const QString &>(&TransferListFiltersWidget::trackerWarning));
+        , m_transferListFiltersWidget, qOverload<const BitTorrent::Torrent *, const QString &>(&TransferListFiltersWidget::trackerWarning));
 
 #ifdef Q_OS_MACOS
     // Increase top spacing to avoid tab overlapping
@@ -858,20 +858,20 @@ void MainWindow::addTorrentFailed(const QString &error) const
 }
 
 // called when a torrent was added
-void MainWindow::torrentNew(BitTorrent::TorrentHandle *const torrent) const
+void MainWindow::torrentNew(BitTorrent::Torrent *const torrent) const
 {
     if (isTorrentAddedNotificationsEnabled())
         showNotificationBaloon(tr("Torrent added"), tr("'%1' was added.", "e.g: xxx.avi was added.").arg(torrent->name()));
 }
 
 // called when a torrent has finished
-void MainWindow::finishedTorrent(BitTorrent::TorrentHandle *const torrent) const
+void MainWindow::finishedTorrent(BitTorrent::Torrent *const torrent) const
 {
     showNotificationBaloon(tr("Download completion"), tr("'%1' has finished downloading.", "e.g: xxx.avi has finished downloading.").arg(torrent->name()));
 }
 
 // Notification when disk is full
-void MainWindow::fullDiskError(BitTorrent::TorrentHandle *const torrent, const QString &msg) const
+void MainWindow::fullDiskError(BitTorrent::Torrent *const torrent, const QString &msg) const
 {
     showNotificationBaloon(tr("I/O Error", "i.e: Input/Output Error")
         , tr("An I/O error occurred for torrent '%1'.\n Reason: %2"
@@ -961,7 +961,7 @@ void MainWindow::displayExecutionLogTab()
 
 // End of keyboard shortcuts slots
 
-void MainWindow::askRecursiveTorrentDownloadConfirmation(BitTorrent::TorrentHandle *const torrent)
+void MainWindow::askRecursiveTorrentDownloadConfirmation(BitTorrent::Torrent *const torrent)
 {
     Preferences *const pref = Preferences::instance();
     if (pref->recursiveDownloadDisabled()) return;
@@ -1639,7 +1639,7 @@ void MainWindow::reloadSessionStats()
     }
 }
 
-void MainWindow::reloadTorrentStats(const QVector<BitTorrent::TorrentHandle *> &torrents)
+void MainWindow::reloadTorrentStats(const QVector<BitTorrent::Torrent *> &torrents)
 {
     if (currentTabWidget() == m_transferListWidget)
     {

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -58,7 +58,7 @@ class TransferListWidget;
 
 namespace BitTorrent
 {
-    class TorrentHandle;
+    class Torrent;
 }
 
 namespace Net
@@ -110,7 +110,7 @@ private slots:
     void balloonClicked();
     void writeSettings();
     void readSettings();
-    void fullDiskError(BitTorrent::TorrentHandle *const torrent, const QString &msg) const;
+    void fullDiskError(BitTorrent::Torrent *const torrent, const QString &msg) const;
     void handleDownloadFromUrlFailure(const QString &, const QString &) const;
     void tabChanged(int newTab);
     bool defineUILockPassword();
@@ -127,12 +127,12 @@ private slots:
     void displayExecutionLogTab();
     void focusSearchFilter();
     void reloadSessionStats();
-    void reloadTorrentStats(const QVector<BitTorrent::TorrentHandle *> &torrents);
+    void reloadTorrentStats(const QVector<BitTorrent::Torrent *> &torrents);
     void loadPreferences(bool configureSession = true);
     void addTorrentFailed(const QString &error) const;
-    void torrentNew(BitTorrent::TorrentHandle *const torrent) const;
-    void finishedTorrent(BitTorrent::TorrentHandle *const torrent) const;
-    void askRecursiveTorrentDownloadConfirmation(BitTorrent::TorrentHandle *const torrent);
+    void torrentNew(BitTorrent::Torrent *const torrent) const;
+    void finishedTorrent(BitTorrent::Torrent *const torrent) const;
+    void askRecursiveTorrentDownloadConfirmation(BitTorrent::Torrent *const torrent);
     void optionsSaved();
 #if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
     void handleUpdateCheckFinished(bool updateAvailable, QString newVersion, bool invokedByUser);

--- a/src/gui/previewselectdialog.cpp
+++ b/src/gui/previewselectdialog.cpp
@@ -37,7 +37,7 @@
 #include <QTableView>
 
 #include "base/bittorrent/common.h"
-#include "base/bittorrent/torrenthandle.h"
+#include "base/bittorrent/torrent.h"
 #include "base/preferences.h"
 #include "base/utils/fs.h"
 #include "base/utils/misc.h"
@@ -47,7 +47,7 @@
 
 #define SETTINGS_KEY(name) "PreviewSelectDialog/" name
 
-PreviewSelectDialog::PreviewSelectDialog(QWidget *parent, const BitTorrent::TorrentHandle *torrent)
+PreviewSelectDialog::PreviewSelectDialog(QWidget *parent, const BitTorrent::Torrent *torrent)
     : QDialog(parent)
     , m_ui(new Ui::PreviewSelectDialog)
     , m_torrent(torrent)

--- a/src/gui/previewselectdialog.h
+++ b/src/gui/previewselectdialog.h
@@ -36,7 +36,7 @@ class QStandardItemModel;
 
 namespace BitTorrent
 {
-    class TorrentHandle;
+    class Torrent;
 }
 namespace Ui
 {
@@ -60,7 +60,7 @@ public:
         NB_COLUMNS
     };
 
-    PreviewSelectDialog(QWidget *parent, const BitTorrent::TorrentHandle *torrent);
+    PreviewSelectDialog(QWidget *parent, const BitTorrent::Torrent *torrent);
     ~PreviewSelectDialog();
 
 signals:
@@ -78,7 +78,7 @@ private:
     Ui::PreviewSelectDialog *m_ui;
     QStandardItemModel *m_previewListModel;
     PreviewListDelegate *m_listDelegate;
-    const BitTorrent::TorrentHandle *m_torrent;
+    const BitTorrent::Torrent *m_torrent;
     bool m_headerStateInitialized = false;
 
     // Settings

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -47,7 +47,7 @@
 #include "base/bittorrent/peeraddress.h"
 #include "base/bittorrent/peerinfo.h"
 #include "base/bittorrent/session.h"
-#include "base/bittorrent/torrenthandle.h"
+#include "base/bittorrent/torrent.h"
 #include "base/global.h"
 #include "base/logger.h"
 #include "base/net/geoipmanager.h"
@@ -260,7 +260,7 @@ void PeerListWidget::updatePeerCountryResolutionState()
 
 void PeerListWidget::showPeerListMenu(const QPoint &)
 {
-    BitTorrent::TorrentHandle *const torrent = m_properties->getCurrentTorrent();
+    BitTorrent::Torrent *const torrent = m_properties->getCurrentTorrent();
     if (!torrent) return;
 
     QMenu *menu = new QMenu(this);
@@ -370,7 +370,7 @@ void PeerListWidget::saveSettings() const
     Preferences::instance()->setPeerListState(header()->saveState());
 }
 
-void PeerListWidget::loadPeers(const BitTorrent::TorrentHandle *torrent)
+void PeerListWidget::loadPeers(const BitTorrent::Torrent *torrent)
 {
     if (!torrent) return;
 
@@ -406,7 +406,7 @@ void PeerListWidget::loadPeers(const BitTorrent::TorrentHandle *torrent)
     }
 }
 
-void PeerListWidget::updatePeer(const BitTorrent::TorrentHandle *torrent, const BitTorrent::PeerInfo &peer, bool &isNewPeer)
+void PeerListWidget::updatePeer(const BitTorrent::Torrent *torrent, const BitTorrent::PeerInfo &peer, bool &isNewPeer)
 {
     const PeerEndpoint peerEndpoint {peer.address(), peer.connectionType()};
     const QString peerIp = peerEndpoint.address.ip.toString();

--- a/src/gui/properties/peerlistwidget.h
+++ b/src/gui/properties/peerlistwidget.h
@@ -43,7 +43,7 @@ struct PeerEndpoint;
 
 namespace BitTorrent
 {
-    class TorrentHandle;
+    class Torrent;
     class PeerInfo;
 }
 
@@ -80,7 +80,7 @@ public:
     explicit PeerListWidget(PropertiesWidget *parent);
     ~PeerListWidget() override;
 
-    void loadPeers(const BitTorrent::TorrentHandle *torrent);
+    void loadPeers(const BitTorrent::Torrent *torrent);
     void updatePeerHostNameResolutionState();
     void updatePeerCountryResolutionState();
     void clear();
@@ -96,7 +96,7 @@ private slots:
     void handleResolved(const QHostAddress &ip, const QString &hostname) const;
 
 private:
-    void updatePeer(const BitTorrent::TorrentHandle *torrent, const BitTorrent::PeerInfo &peer, bool &isNewPeer);
+    void updatePeer(const BitTorrent::Torrent *torrent, const BitTorrent::PeerInfo &peer, bool &isNewPeer);
 
     void wheelEvent(QWheelEvent *event) override;
 

--- a/src/gui/properties/piecesbar.cpp
+++ b/src/gui/properties/piecesbar.cpp
@@ -38,7 +38,7 @@
 #include <QToolTip>
 
 #include "base/indexrange.h"
-#include "base/bittorrent/torrenthandle.h"
+#include "base/bittorrent/torrent.h"
 #include "base/bittorrent/torrentinfo.h"
 #include "base/utils/misc.h"
 
@@ -119,7 +119,7 @@ PiecesBar::PiecesBar(QWidget *parent)
     setMouseTracking(true);
 }
 
-void PiecesBar::setTorrent(const BitTorrent::TorrentHandle *torrent)
+void PiecesBar::setTorrent(const BitTorrent::Torrent *torrent)
 {
     m_torrent = torrent;
     if (!m_torrent)

--- a/src/gui/properties/piecesbar.h
+++ b/src/gui/properties/piecesbar.h
@@ -37,7 +37,7 @@ class QHelpEvent;
 
 namespace BitTorrent
 {
-    class TorrentHandle;
+    class Torrent;
 }
 
 class PiecesBar : public QWidget
@@ -49,7 +49,7 @@ class PiecesBar : public QWidget
 public:
     explicit PiecesBar(QWidget *parent = nullptr);
 
-    void setTorrent(const BitTorrent::TorrentHandle *torrent);
+    void setTorrent(const BitTorrent::Torrent *torrent);
 
     virtual void clear();
 
@@ -87,7 +87,7 @@ private:
     virtual bool updateImage(QImage &image) = 0;
     void updatePieceColors();
 
-    const BitTorrent::TorrentHandle *m_torrent;
+    const BitTorrent::Torrent *m_torrent;
     QImage m_image;
     // buffered 256 levels gradient from bg_color to piece_color
     QVector<QRgb> m_pieceColors;

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -45,7 +45,7 @@
 #include "base/bittorrent/downloadpriority.h"
 #include "base/bittorrent/infohash.h"
 #include "base/bittorrent/session.h"
-#include "base/bittorrent/torrenthandle.h"
+#include "base/bittorrent/torrent.h"
 #include "base/preferences.h"
 #include "base/unicodestrings.h"
 #include "base/utils/fs.h"
@@ -265,7 +265,7 @@ void PropertiesWidget::clear()
     m_propListModel->model()->clear();
 }
 
-BitTorrent::TorrentHandle *PropertiesWidget::getCurrentTorrent() const
+BitTorrent::Torrent *PropertiesWidget::getCurrentTorrent() const
 {
     return m_torrent;
 }
@@ -285,25 +285,25 @@ QTreeView *PropertiesWidget::getFilesList() const
     return m_ui->filesList;
 }
 
-void PropertiesWidget::updateSavePath(BitTorrent::TorrentHandle *const torrent)
+void PropertiesWidget::updateSavePath(BitTorrent::Torrent *const torrent)
 {
     if (torrent == m_torrent)
         m_ui->labelSavePathVal->setText(Utils::Fs::toNativePath(m_torrent->savePath()));
 }
 
-void PropertiesWidget::loadTrackers(BitTorrent::TorrentHandle *const torrent)
+void PropertiesWidget::loadTrackers(BitTorrent::Torrent *const torrent)
 {
     if (torrent == m_torrent)
         m_trackerList->loadTrackers();
 }
 
-void PropertiesWidget::updateTorrentInfos(BitTorrent::TorrentHandle *const torrent)
+void PropertiesWidget::updateTorrentInfos(BitTorrent::Torrent *const torrent)
 {
     if (torrent == m_torrent)
         loadTorrentInfos(m_torrent);
 }
 
-void PropertiesWidget::loadTorrentInfos(BitTorrent::TorrentHandle *const torrent)
+void PropertiesWidget::loadTorrentInfos(BitTorrent::Torrent *const torrent)
 {
     clear();
     m_torrent = torrent;
@@ -437,7 +437,7 @@ void PropertiesWidget::loadDynamicData()
 
             // Update ratio info
             const qreal ratio = m_torrent->realRatio();
-            m_ui->labelShareRatioVal->setText(ratio > BitTorrent::TorrentHandle::MAX_RATIO ? QString::fromUtf8(C_INFINITY) : Utils::String::fromDouble(ratio, 2));
+            m_ui->labelShareRatioVal->setText(ratio > BitTorrent::Torrent::MAX_RATIO ? QString::fromUtf8(C_INFINITY) : Utils::String::fromDouble(ratio, 2));
 
             m_ui->labelSeedsVal->setText(tr("%1 (%2 total)", "%1 and %2 are numbers, e.g. 3 (10 total)")
                 .arg(QString::number(m_torrent->seedsCount())

--- a/src/gui/properties/propertieswidget.h
+++ b/src/gui/properties/propertieswidget.h
@@ -45,7 +45,7 @@ class TrackerListWidget;
 
 namespace BitTorrent
 {
-    class TorrentHandle;
+    class Torrent;
 }
 
 namespace Ui
@@ -68,24 +68,24 @@ public:
     explicit PropertiesWidget(QWidget *parent);
     ~PropertiesWidget() override;
 
-    BitTorrent::TorrentHandle *getCurrentTorrent() const;
+    BitTorrent::Torrent *getCurrentTorrent() const;
     TrackerListWidget *getTrackerList() const;
     PeerListWidget *getPeerList() const;
     QTreeView *getFilesList() const;
 
 public slots:
     void setVisibility(bool visible);
-    void loadTorrentInfos(BitTorrent::TorrentHandle *const torrent);
+    void loadTorrentInfos(BitTorrent::Torrent *const torrent);
     void loadDynamicData();
     void clear();
     void readSettings();
     void saveSettings();
     void reloadPreferences();
     void openItem(const QModelIndex &index) const;
-    void loadTrackers(BitTorrent::TorrentHandle *const torrent);
+    void loadTrackers(BitTorrent::Torrent *const torrent);
 
 protected slots:
-    void updateTorrentInfos(BitTorrent::TorrentHandle *const torrent);
+    void updateTorrentInfos(BitTorrent::Torrent *const torrent);
     void loadUrlSeeds();
     void askWebSeed();
     void deleteSelectedUrlSeeds();
@@ -101,7 +101,7 @@ protected slots:
 private slots:
     void configure();
     void filterText(const QString &filter);
-    void updateSavePath(BitTorrent::TorrentHandle *const torrent);
+    void updateSavePath(BitTorrent::Torrent *const torrent);
 
 private:
     QPushButton *getButtonFromIndex(int index);
@@ -110,7 +110,7 @@ private:
     QString getFullPath(const QModelIndex &index) const;
 
     Ui::PropertiesWidget *m_ui;
-    BitTorrent::TorrentHandle *m_torrent;
+    BitTorrent::Torrent *m_torrent;
     SlideState m_state;
     TorrentContentFilterModel *m_propListModel;
     PropListDelegate *m_propListDelegate;

--- a/src/gui/properties/proplistdelegate.cpp
+++ b/src/gui/properties/proplistdelegate.cpp
@@ -41,7 +41,7 @@
 #endif
 
 #include "base/bittorrent/downloadpriority.h"
-#include "base/bittorrent/torrenthandle.h"
+#include "base/bittorrent/torrent.h"
 #include "gui/torrentcontentmodel.h"
 #include "propertieswidget.h"
 
@@ -111,7 +111,7 @@ QWidget *PropListDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
 
     if (m_properties)
     {
-        const BitTorrent::TorrentHandle *torrent = m_properties->getCurrentTorrent();
+        const BitTorrent::Torrent *torrent = m_properties->getCurrentTorrent();
         if (!torrent || !torrent->hasMetadata() || torrent->isSeed())
             return nullptr;
     }

--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -46,7 +46,7 @@
 
 #include "base/bittorrent/peerinfo.h"
 #include "base/bittorrent/session.h"
-#include "base/bittorrent/torrenthandle.h"
+#include "base/bittorrent/torrent.h"
 #include "base/bittorrent/trackerentry.h"
 #include "base/global.h"
 #include "base/preferences.h"
@@ -172,7 +172,7 @@ void TrackerListWidget::setRowColor(const int row, const QColor &color)
 
 void TrackerListWidget::moveSelectionUp()
 {
-    BitTorrent::TorrentHandle *const torrent = m_properties->getCurrentTorrent();
+    BitTorrent::Torrent *const torrent = m_properties->getCurrentTorrent();
     if (!torrent)
     {
         clear();
@@ -218,7 +218,7 @@ void TrackerListWidget::moveSelectionUp()
 
 void TrackerListWidget::moveSelectionDown()
 {
-    BitTorrent::TorrentHandle *const torrent = m_properties->getCurrentTorrent();
+    BitTorrent::Torrent *const torrent = m_properties->getCurrentTorrent();
     if (!torrent)
     {
         clear();
@@ -281,7 +281,7 @@ void TrackerListWidget::clear()
     m_LSDItem->setText(COL_MSG, "");
 }
 
-void TrackerListWidget::loadStickyItems(const BitTorrent::TorrentHandle *torrent)
+void TrackerListWidget::loadStickyItems(const BitTorrent::Torrent *torrent)
 {
     const QString working {tr("Working")};
     const QString disabled {tr("Disabled")};
@@ -361,7 +361,7 @@ void TrackerListWidget::loadStickyItems(const BitTorrent::TorrentHandle *torrent
 void TrackerListWidget::loadTrackers()
 {
     // Load trackers from torrent handle
-    const BitTorrent::TorrentHandle *torrent = m_properties->getCurrentTorrent();
+    const BitTorrent::Torrent *torrent = m_properties->getCurrentTorrent();
     if (!torrent) return;
 
     loadStickyItems(torrent);
@@ -438,7 +438,7 @@ void TrackerListWidget::loadTrackers()
 // Ask the user for new trackers and add them to the torrent
 void TrackerListWidget::askForTrackers()
 {
-    BitTorrent::TorrentHandle *const torrent = m_properties->getCurrentTorrent();
+    BitTorrent::Torrent *const torrent = m_properties->getCurrentTorrent();
     if (!torrent) return;
 
     QVector<BitTorrent::TrackerEntry> trackers;
@@ -466,7 +466,7 @@ void TrackerListWidget::copyTrackerUrl()
 
 void TrackerListWidget::deleteSelectedTrackers()
 {
-    BitTorrent::TorrentHandle *const torrent = m_properties->getCurrentTorrent();
+    BitTorrent::Torrent *const torrent = m_properties->getCurrentTorrent();
     if (!torrent)
     {
         clear();
@@ -504,7 +504,7 @@ void TrackerListWidget::deleteSelectedTrackers()
 
 void TrackerListWidget::editSelectedTracker()
 {
-    BitTorrent::TorrentHandle *const torrent = m_properties->getCurrentTorrent();
+    BitTorrent::Torrent *const torrent = m_properties->getCurrentTorrent();
     if (!torrent) return;
 
     const QVector<QTreeWidgetItem *> selectedTrackerItems = getSelectedTrackerItems();
@@ -555,7 +555,7 @@ void TrackerListWidget::reannounceSelected()
     const QList<QTreeWidgetItem *> selItems = selectedItems();
     if (selItems.isEmpty()) return;
 
-    BitTorrent::TorrentHandle *const torrent = m_properties->getCurrentTorrent();
+    BitTorrent::Torrent *const torrent = m_properties->getCurrentTorrent();
     if (!torrent) return;
 
     const QVector<BitTorrent::TrackerEntry> trackers = torrent->trackers();
@@ -585,7 +585,7 @@ void TrackerListWidget::reannounceSelected()
 
 void TrackerListWidget::showTrackerListMenu(const QPoint &)
 {
-    BitTorrent::TorrentHandle *const torrent = m_properties->getCurrentTorrent();
+    BitTorrent::Torrent *const torrent = m_properties->getCurrentTorrent();
     if (!torrent) return;
 
     QMenu *menu = new QMenu(this);
@@ -617,7 +617,7 @@ void TrackerListWidget::showTrackerListMenu(const QPoint &)
         const QAction *reannounceAllAct = menu->addAction(UIThemeManager::instance()->getIcon("view-refresh"), tr("Force reannounce to all trackers"));
         connect(reannounceAllAct, &QAction::triggered, this, [this]()
         {
-            BitTorrent::TorrentHandle *h = m_properties->getCurrentTorrent();
+            BitTorrent::Torrent *h = m_properties->getCurrentTorrent();
             h->forceReannounce();
             h->forceDHTAnnounce();
         });

--- a/src/gui/properties/trackerlistwidget.h
+++ b/src/gui/properties/trackerlistwidget.h
@@ -35,7 +35,7 @@ class PropertiesWidget;
 
 namespace BitTorrent
 {
-    class TorrentHandle;
+    class Torrent;
 }
 
 class TrackerListWidget : public QTreeWidget
@@ -70,7 +70,7 @@ public slots:
     void moveSelectionDown();
 
     void clear();
-    void loadStickyItems(const BitTorrent::TorrentHandle *torrent);
+    void loadStickyItems(const BitTorrent::Torrent *torrent);
     void loadTrackers();
     void askForTrackers();
     void copyTrackerUrl();

--- a/src/gui/properties/trackersadditiondialog.cpp
+++ b/src/gui/properties/trackersadditiondialog.cpp
@@ -32,14 +32,14 @@
 #include <QMessageBox>
 #include <QStringList>
 
-#include "base/bittorrent/torrenthandle.h"
+#include "base/bittorrent/torrent.h"
 #include "base/bittorrent/trackerentry.h"
 #include "base/global.h"
 #include "base/net/downloadmanager.h"
 #include "gui/uithememanager.h"
 #include "ui_trackersadditiondialog.h"
 
-TrackersAdditionDialog::TrackersAdditionDialog(QWidget *parent, BitTorrent::TorrentHandle *const torrent)
+TrackersAdditionDialog::TrackersAdditionDialog(QWidget *parent, BitTorrent::Torrent *const torrent)
     : QDialog(parent)
     , m_ui(new Ui::TrackersAdditionDialog())
     , m_torrent(torrent)
@@ -129,7 +129,7 @@ void TrackersAdditionDialog::torrentListDownloadFinished(const Net::DownloadResu
         QMessageBox::information(this, tr("No change"), tr("No additional trackers were found."), QMessageBox::Ok);
 }
 
-QStringList TrackersAdditionDialog::askForTrackers(QWidget *parent, BitTorrent::TorrentHandle *const torrent)
+QStringList TrackersAdditionDialog::askForTrackers(QWidget *parent, BitTorrent::Torrent *const torrent)
 {
     QStringList trackers;
     TrackersAdditionDialog dlg(parent, torrent);

--- a/src/gui/properties/trackersadditiondialog.h
+++ b/src/gui/properties/trackersadditiondialog.h
@@ -35,7 +35,7 @@ class QString;
 
 namespace BitTorrent
 {
-    class TorrentHandle;
+    class Torrent;
 }
 
 namespace Net
@@ -53,11 +53,11 @@ class TrackersAdditionDialog : public QDialog
     Q_OBJECT
 
 public:
-    TrackersAdditionDialog(QWidget *parent, BitTorrent::TorrentHandle *const torrent);
+    TrackersAdditionDialog(QWidget *parent, BitTorrent::Torrent *const torrent);
     ~TrackersAdditionDialog();
 
     QStringList newTrackers() const;
-    static QStringList askForTrackers(QWidget *parent, BitTorrent::TorrentHandle *const torrent);
+    static QStringList askForTrackers(QWidget *parent, BitTorrent::Torrent *const torrent);
 
 public slots:
     void on_uTorrentListButton_clicked();
@@ -65,5 +65,5 @@ public slots:
 
 private:
     Ui::TrackersAdditionDialog *m_ui;
-    BitTorrent::TorrentHandle *const m_torrent;
+    BitTorrent::Torrent *const m_torrent;
 };

--- a/src/gui/statsdialog.cpp
+++ b/src/gui/statsdialog.cpp
@@ -33,7 +33,7 @@
 #include "base/bittorrent/cachestatus.h"
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/sessionstatus.h"
-#include "base/bittorrent/torrenthandle.h"
+#include "base/bittorrent/torrent.h"
 #include "base/global.h"
 #include "base/utils/misc.h"
 #include "base/utils/string.h"

--- a/src/gui/tagfiltermodel.cpp
+++ b/src/gui/tagfiltermodel.cpp
@@ -34,7 +34,7 @@
 #include <QVector>
 
 #include "base/bittorrent/session.h"
-#include "base/bittorrent/torrenthandle.h"
+#include "base/bittorrent/torrent.h"
 #include "base/global.h"
 #include "uithememanager.h"
 
@@ -203,7 +203,7 @@ void TagFilterModel::tagRemoved(const QString &tag)
     endRemoveRows();
 }
 
-void TagFilterModel::torrentTagAdded(BitTorrent::TorrentHandle *const torrent, const QString &tag)
+void TagFilterModel::torrentTagAdded(BitTorrent::Torrent *const torrent, const QString &tag)
 {
     if (torrent->tags().count() == 1)
         untaggedItem()->decreaseTorrentsCount();
@@ -217,7 +217,7 @@ void TagFilterModel::torrentTagAdded(BitTorrent::TorrentHandle *const torrent, c
     emit dataChanged(i, i);
 }
 
-void TagFilterModel::torrentTagRemoved(BitTorrent::TorrentHandle *const torrent, const QString &tag)
+void TagFilterModel::torrentTagRemoved(BitTorrent::Torrent *const torrent, const QString &tag)
 {
     if (torrent->tags().empty())
         untaggedItem()->increaseTorrentsCount();
@@ -232,7 +232,7 @@ void TagFilterModel::torrentTagRemoved(BitTorrent::TorrentHandle *const torrent,
     emit dataChanged(i, i);
 }
 
-void TagFilterModel::torrentAdded(BitTorrent::TorrentHandle *const torrent)
+void TagFilterModel::torrentAdded(BitTorrent::Torrent *const torrent)
 {
     allTagsItem()->increaseTorrentsCount();
 
@@ -244,7 +244,7 @@ void TagFilterModel::torrentAdded(BitTorrent::TorrentHandle *const torrent)
         item->increaseTorrentsCount();
 }
 
-void TagFilterModel::torrentAboutToBeRemoved(BitTorrent::TorrentHandle *const torrent)
+void TagFilterModel::torrentAboutToBeRemoved(BitTorrent::Torrent *const torrent)
 {
     allTagsItem()->decreaseTorrentsCount();
 
@@ -266,7 +266,7 @@ QString TagFilterModel::tagDisplayName(const QString &tag)
 
 void TagFilterModel::populate()
 {
-    using Torrent = BitTorrent::TorrentHandle;
+    using Torrent = BitTorrent::Torrent;
 
     const auto *session = BitTorrent::Session::instance();
     const auto torrents = session->torrents();

--- a/src/gui/tagfiltermodel.h
+++ b/src/gui/tagfiltermodel.h
@@ -37,7 +37,7 @@ class TagModelItem;
 
 namespace BitTorrent
 {
-    class TorrentHandle;
+    class Torrent;
 }
 
 class TagFilterModel final : public QAbstractListModel
@@ -62,10 +62,10 @@ public:
 private slots:
     void tagAdded(const QString &tag);
     void tagRemoved(const QString &tag);
-    void torrentTagAdded(BitTorrent::TorrentHandle *const torrent, const QString &tag);
-    void torrentTagRemoved(BitTorrent::TorrentHandle *const, const QString &tag);
-    void torrentAdded(BitTorrent::TorrentHandle *const torrent);
-    void torrentAboutToBeRemoved(BitTorrent::TorrentHandle *const torrent);
+    void torrentTagAdded(BitTorrent::Torrent *const torrent, const QString &tag);
+    void torrentTagRemoved(BitTorrent::Torrent *const, const QString &tag);
+    void torrentAdded(BitTorrent::Torrent *const torrent);
+    void torrentAboutToBeRemoved(BitTorrent::Torrent *const torrent);
 
 private:
     static QString tagDisplayName(const QString &tag);

--- a/src/gui/torrentcontenttreeview.cpp
+++ b/src/gui/torrentcontenttreeview.cpp
@@ -40,7 +40,7 @@
 #include "base/bittorrent/abstractfilestorage.h"
 #include "base/bittorrent/common.h"
 #include "base/bittorrent/session.h"
-#include "base/bittorrent/torrenthandle.h"
+#include "base/bittorrent/torrent.h"
 #include "base/bittorrent/torrentinfo.h"
 #include "base/exceptions.h"
 #include "base/global.h"

--- a/src/gui/torrentcontenttreeview.h
+++ b/src/gui/torrentcontenttreeview.h
@@ -33,7 +33,7 @@
 namespace BitTorrent
 {
     class AbstractFileStorage;
-    class TorrentHandle;
+    class Torrent;
     class TorrentInfo;
 }
 

--- a/src/gui/torrentcreatordialog.cpp
+++ b/src/gui/torrentcreatordialog.cpp
@@ -246,8 +246,8 @@ void TorrentCreatorDialog::handleCreationSuccess(const QString &path, const QStr
         params.skipChecking = true;
         if (m_ui->checkIgnoreShareLimits->isChecked())
         {
-            params.ratioLimit = BitTorrent::TorrentHandle::NO_RATIO_LIMIT;
-            params.seedingTimeLimit = BitTorrent::TorrentHandle::NO_SEEDING_TIME_LIMIT;
+            params.ratioLimit = BitTorrent::Torrent::NO_RATIO_LIMIT;
+            params.seedingTimeLimit = BitTorrent::Torrent::NO_SEEDING_TIME_LIMIT;
         }
         params.useAutoTMM = false;  // otherwise if it is on by default, it will overwrite `savePath` to the default save path
 

--- a/src/gui/torrentoptionsdialog.cpp
+++ b/src/gui/torrentoptionsdialog.cpp
@@ -33,7 +33,7 @@
 
 #include "base/bittorrent/infohash.h"
 #include "base/bittorrent/session.h"
-#include "base/bittorrent/torrenthandle.h"
+#include "base/bittorrent/torrent.h"
 #include "base/global.h"
 #include "base/unicodestrings.h"
 #include "ui_torrentoptionsdialog.h"
@@ -53,7 +53,7 @@ namespace
     }
 }
 
-TorrentOptionsDialog::TorrentOptionsDialog(QWidget *parent, const QVector<BitTorrent::TorrentHandle *> &torrents)
+TorrentOptionsDialog::TorrentOptionsDialog(QWidget *parent, const QVector<BitTorrent::Torrent *> &torrents)
     : QDialog {parent}
     , m_ui {new Ui::TorrentOptionsDialog}
     , m_storeDialogSize {SETTINGS_KEY("Size")}
@@ -76,7 +76,7 @@ TorrentOptionsDialog::TorrentOptionsDialog(QWidget *parent, const QVector<BitTor
     const bool isFirstTorrentLSDDisabled = torrents[0]->isLSDDisabled();
 
     m_torrentHashes.reserve(torrents.size());
-    for (const BitTorrent::TorrentHandle *torrent : torrents)
+    for (const BitTorrent::Torrent *torrent : torrents)
     {
         m_torrentHashes << torrent->hash();
         if (allSameUpLimit)
@@ -180,8 +180,8 @@ TorrentOptionsDialog::TorrentOptionsDialog(QWidget *parent, const QVector<BitTor
     }
 
     const bool useGlobalValue = allSameRatio && allSameSeedingTime
-        && (firstTorrentRatio == BitTorrent::TorrentHandle::USE_GLOBAL_RATIO)
-        && (firstTorrentSeedingTime == BitTorrent::TorrentHandle::USE_GLOBAL_SEEDING_TIME);
+        && (firstTorrentRatio == BitTorrent::Torrent::USE_GLOBAL_RATIO)
+        && (firstTorrentSeedingTime == BitTorrent::Torrent::USE_GLOBAL_SEEDING_TIME);
 
     if (!allSameRatio || !allSameSeedingTime)
     {
@@ -193,8 +193,8 @@ TorrentOptionsDialog::TorrentOptionsDialog(QWidget *parent, const QVector<BitTor
     {
         m_ui->radioUseGlobalShareLimits->setChecked(true);
     }
-    else if ((firstTorrentRatio == BitTorrent::TorrentHandle::NO_RATIO_LIMIT)
-             && (firstTorrentSeedingTime == BitTorrent::TorrentHandle::NO_SEEDING_TIME_LIMIT))
+    else if ((firstTorrentRatio == BitTorrent::Torrent::NO_RATIO_LIMIT)
+             && (firstTorrentSeedingTime == BitTorrent::Torrent::NO_SEEDING_TIME_LIMIT))
     {
         m_ui->radioNoLimit->setChecked(true);
     }
@@ -288,7 +288,7 @@ void TorrentOptionsDialog::accept()
     const auto *session = BitTorrent::Session::instance();
     for (const BitTorrent::InfoHash &hash : asConst(m_torrentHashes))
     {
-        BitTorrent::TorrentHandle *torrent = session->findTorrent(hash);
+        BitTorrent::Torrent *torrent = session->findTorrent(hash);
         if (!torrent) continue;
 
         if (m_initialValues.upSpeedLimit != m_ui->spinUploadLimit->value())
@@ -324,10 +324,10 @@ qreal TorrentOptionsDialog::getRatio() const
         return MIXED_SHARE_LIMITS;
 
     if (m_ui->radioUseGlobalShareLimits->isChecked())
-        return BitTorrent::TorrentHandle::USE_GLOBAL_RATIO;
+        return BitTorrent::Torrent::USE_GLOBAL_RATIO;
 
     if (m_ui->radioNoLimit->isChecked() || !m_ui->checkMaxRatio->isChecked())
-        return BitTorrent::TorrentHandle::NO_RATIO_LIMIT;
+        return BitTorrent::Torrent::NO_RATIO_LIMIT;
 
     return m_ui->spinRatioLimit->value();
 }
@@ -338,10 +338,10 @@ int TorrentOptionsDialog::getSeedingTime() const
         return MIXED_SHARE_LIMITS;
 
     if (m_ui->radioUseGlobalShareLimits->isChecked())
-        return BitTorrent::TorrentHandle::USE_GLOBAL_SEEDING_TIME;
+        return BitTorrent::Torrent::USE_GLOBAL_SEEDING_TIME;
 
     if (m_ui->radioNoLimit->isChecked() || !m_ui->checkMaxTime->isChecked())
-        return  BitTorrent::TorrentHandle::NO_SEEDING_TIME_LIMIT;
+        return  BitTorrent::Torrent::NO_SEEDING_TIME_LIMIT;
 
     return m_ui->spinTimeLimit->value();
 }

--- a/src/gui/torrentoptionsdialog.h
+++ b/src/gui/torrentoptionsdialog.h
@@ -35,7 +35,7 @@
 namespace BitTorrent
 {
     class InfoHash;
-    class TorrentHandle;
+    class Torrent;
 }
 
 namespace Ui
@@ -49,7 +49,7 @@ class TorrentOptionsDialog final : public QDialog
     Q_DISABLE_COPY(TorrentOptionsDialog)
 
 public:
-    explicit TorrentOptionsDialog(QWidget *parent, const QVector<BitTorrent::TorrentHandle *> &torrents);
+    explicit TorrentOptionsDialog(QWidget *parent, const QVector<BitTorrent::Torrent *> &torrents);
     ~TorrentOptionsDialog() override;
 
 public slots:

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -40,7 +40,7 @@
 
 #include "base/bittorrent/infohash.h"
 #include "base/bittorrent/session.h"
-#include "base/bittorrent/torrenthandle.h"
+#include "base/bittorrent/torrent.h"
 #include "base/bittorrent/trackerentry.h"
 #include "base/global.h"
 #include "base/logger.h"
@@ -240,8 +240,8 @@ void StatusFilterWidget::updateTorrentNumbers()
     int nbStalledDownloading = 0;
     int nbErrored = 0;
 
-    const QVector<BitTorrent::TorrentHandle *> torrents = BitTorrent::Session::instance()->torrents();
-    for (const BitTorrent::TorrentHandle *torrent : torrents)
+    const QVector<BitTorrent::Torrent *> torrents = BitTorrent::Session::instance()->torrents();
+    for (const BitTorrent::Torrent *torrent : torrents)
     {
         if (torrent->isDownloading())
             ++nbDownloading;
@@ -288,9 +288,9 @@ void StatusFilterWidget::applyFilter(int row)
     transferList->applyStatusFilter(row);
 }
 
-void StatusFilterWidget::handleNewTorrent(BitTorrent::TorrentHandle *const) {}
+void StatusFilterWidget::handleNewTorrent(BitTorrent::Torrent *const) {}
 
-void StatusFilterWidget::torrentAboutToBeDeleted(BitTorrent::TorrentHandle *const) {}
+void StatusFilterWidget::torrentAboutToBeDeleted(BitTorrent::Torrent *const) {}
 
 TrackerFiltersList::TrackerFiltersList(QWidget *parent, TransferListWidget *transferList, const bool downloadFavicon)
     : BaseFilterWidget(parent, transferList)
@@ -577,7 +577,7 @@ void TrackerFiltersList::applyFilter(const int row)
         transferList->applyTrackerFilter(getInfoHashes(row));
 }
 
-void TrackerFiltersList::handleNewTorrent(BitTorrent::TorrentHandle *const torrent)
+void TrackerFiltersList::handleNewTorrent(BitTorrent::Torrent *const torrent)
 {
     const BitTorrent::InfoHash hash {torrent->hash()};
     const QVector<BitTorrent::TrackerEntry> trackers {torrent->trackers()};
@@ -591,7 +591,7 @@ void TrackerFiltersList::handleNewTorrent(BitTorrent::TorrentHandle *const torre
     item(ALL_ROW)->setText(tr("All (%1)", "this is for the tracker filter").arg(++m_totalTorrents));
 }
 
-void TrackerFiltersList::torrentAboutToBeDeleted(BitTorrent::TorrentHandle *const torrent)
+void TrackerFiltersList::torrentAboutToBeDeleted(BitTorrent::Torrent *const torrent)
 {
     const BitTorrent::InfoHash hash {torrent->hash()};
     const QVector<BitTorrent::TrackerEntry> trackers {torrent->trackers()};
@@ -742,34 +742,34 @@ void TransferListFiltersWidget::setDownloadTrackerFavicon(bool value)
     m_trackerFilters->setDownloadTrackerFavicon(value);
 }
 
-void TransferListFiltersWidget::addTrackers(const BitTorrent::TorrentHandle *torrent, const QVector<BitTorrent::TrackerEntry> &trackers)
+void TransferListFiltersWidget::addTrackers(const BitTorrent::Torrent *torrent, const QVector<BitTorrent::TrackerEntry> &trackers)
 {
     for (const BitTorrent::TrackerEntry &tracker : trackers)
         m_trackerFilters->addItem(tracker.url(), torrent->hash());
 }
 
-void TransferListFiltersWidget::removeTrackers(const BitTorrent::TorrentHandle *torrent, const QVector<BitTorrent::TrackerEntry> &trackers)
+void TransferListFiltersWidget::removeTrackers(const BitTorrent::Torrent *torrent, const QVector<BitTorrent::TrackerEntry> &trackers)
 {
     for (const BitTorrent::TrackerEntry &tracker : trackers)
         m_trackerFilters->removeItem(tracker.url(), torrent->hash());
 }
 
-void TransferListFiltersWidget::changeTrackerless(const BitTorrent::TorrentHandle *torrent, const bool trackerless)
+void TransferListFiltersWidget::changeTrackerless(const BitTorrent::Torrent *torrent, const bool trackerless)
 {
     m_trackerFilters->changeTrackerless(trackerless, torrent->hash());
 }
 
-void TransferListFiltersWidget::trackerSuccess(const BitTorrent::TorrentHandle *torrent, const QString &tracker)
+void TransferListFiltersWidget::trackerSuccess(const BitTorrent::Torrent *torrent, const QString &tracker)
 {
     emit trackerSuccess(torrent->hash(), tracker);
 }
 
-void TransferListFiltersWidget::trackerWarning(const BitTorrent::TorrentHandle *torrent, const QString &tracker)
+void TransferListFiltersWidget::trackerWarning(const BitTorrent::Torrent *torrent, const QString &tracker)
 {
     emit trackerWarning(torrent->hash(), tracker);
 }
 
-void TransferListFiltersWidget::trackerError(const BitTorrent::TorrentHandle *torrent, const QString &tracker)
+void TransferListFiltersWidget::trackerError(const BitTorrent::Torrent *torrent, const QString &tracker)
 {
     emit trackerError(torrent->hash(), tracker);
 }

--- a/src/gui/transferlistfilterswidget.h
+++ b/src/gui/transferlistfilterswidget.h
@@ -40,7 +40,7 @@ class TransferListWidget;
 namespace BitTorrent
 {
     class InfoHash;
-    class TorrentHandle;
+    class Torrent;
     class TrackerEntry;
 }
 
@@ -69,8 +69,8 @@ protected:
 private slots:
     virtual void showMenu(const QPoint &) = 0;
     virtual void applyFilter(int row) = 0;
-    virtual void handleNewTorrent(BitTorrent::TorrentHandle *const) = 0;
-    virtual void torrentAboutToBeDeleted(BitTorrent::TorrentHandle *const) = 0;
+    virtual void handleNewTorrent(BitTorrent::Torrent *const) = 0;
+    virtual void torrentAboutToBeDeleted(BitTorrent::Torrent *const) = 0;
 };
 
 class StatusFilterWidget final : public BaseFilterWidget
@@ -90,8 +90,8 @@ private:
     // No need to redeclare them here as slots.
     void showMenu(const QPoint &) override;
     void applyFilter(int row) override;
-    void handleNewTorrent(BitTorrent::TorrentHandle *const) override;
-    void torrentAboutToBeDeleted(BitTorrent::TorrentHandle *const) override;
+    void handleNewTorrent(BitTorrent::Torrent *const) override;
+    void torrentAboutToBeDeleted(BitTorrent::Torrent *const) override;
 };
 
 class TrackerFiltersList final : public BaseFilterWidget
@@ -122,8 +122,8 @@ private:
     // No need to redeclare them here as slots.
     void showMenu(const QPoint &) override;
     void applyFilter(int row) override;
-    void handleNewTorrent(BitTorrent::TorrentHandle *const torrent) override;
-    void torrentAboutToBeDeleted(BitTorrent::TorrentHandle *const torrent) override;
+    void handleNewTorrent(BitTorrent::Torrent *const torrent) override;
+    void torrentAboutToBeDeleted(BitTorrent::Torrent *const torrent) override;
     QString trackerFromRow(int row) const;
     int rowFromTracker(const QString &tracker) const;
     QSet<BitTorrent::InfoHash> getInfoHashes(int row) const;
@@ -150,12 +150,12 @@ public:
     void setDownloadTrackerFavicon(bool value);
 
 public slots:
-    void addTrackers(const BitTorrent::TorrentHandle *torrent, const QVector<BitTorrent::TrackerEntry> &trackers);
-    void removeTrackers(const BitTorrent::TorrentHandle *torrent, const QVector<BitTorrent::TrackerEntry> &trackers);
-    void changeTrackerless(const BitTorrent::TorrentHandle *torrent, bool trackerless);
-    void trackerSuccess(const BitTorrent::TorrentHandle *torrent, const QString &tracker);
-    void trackerWarning(const BitTorrent::TorrentHandle *torrent, const QString &tracker);
-    void trackerError(const BitTorrent::TorrentHandle *torrent, const QString &tracker);
+    void addTrackers(const BitTorrent::Torrent *torrent, const QVector<BitTorrent::TrackerEntry> &trackers);
+    void removeTrackers(const BitTorrent::Torrent *torrent, const QVector<BitTorrent::TrackerEntry> &trackers);
+    void changeTrackerless(const BitTorrent::Torrent *torrent, bool trackerless);
+    void trackerSuccess(const BitTorrent::Torrent *torrent, const QString &tracker);
+    void trackerWarning(const BitTorrent::Torrent *torrent, const QString &tracker);
+    void trackerError(const BitTorrent::Torrent *torrent, const QString &tracker);
 
 signals:
     void trackerSuccess(const BitTorrent::InfoHash &hash, const QString &tracker);

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -36,7 +36,7 @@
 #include <QPalette>
 
 #include "base/bittorrent/session.h"
-#include "base/bittorrent/torrenthandle.h"
+#include "base/bittorrent/torrent.h"
 #include "base/global.h"
 #include "base/preferences.h"
 #include "base/unicodestrings.h"
@@ -133,7 +133,7 @@ TransferListModel::TransferListModel(QObject *parent)
 
     // Load the torrents
     using namespace BitTorrent;
-    for (TorrentHandle *const torrent : asConst(Session::instance()->torrents()))
+    for (Torrent *const torrent : asConst(Session::instance()->torrents()))
         addTorrent(torrent);
 
     // Listen for torrent changes
@@ -234,7 +234,7 @@ QVariant TransferListModel::headerData(int section, Qt::Orientation orientation,
     return {};
 }
 
-QString TransferListModel::displayValue(const BitTorrent::TorrentHandle *torrent, const int column) const
+QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, const int column) const
 {
     bool hideValues = false;
     if (m_hideZeroValuesMode == HideZeroValuesMode::Always)
@@ -276,7 +276,7 @@ QString TransferListModel::displayValue(const BitTorrent::TorrentHandle *torrent
         if (hideValues && (value <= 0))
             return {};
 
-         return ((static_cast<int>(value) == -1) || (value > BitTorrent::TorrentHandle::MAX_RATIO))
+         return ((static_cast<int>(value) == -1) || (value > BitTorrent::Torrent::MAX_RATIO))
                   ? QString::fromUtf8(C_INFINITY) : Utils::String::fromDouble(value, 2);
     };
 
@@ -399,7 +399,7 @@ QString TransferListModel::displayValue(const BitTorrent::TorrentHandle *torrent
     return {};
 }
 
-QVariant TransferListModel::internalValue(const BitTorrent::TorrentHandle *torrent, const int column, const bool alt) const
+QVariant TransferListModel::internalValue(const BitTorrent::Torrent *torrent, const int column, const bool alt) const
 {
     switch (column)
     {
@@ -474,7 +474,7 @@ QVariant TransferListModel::data(const QModelIndex &index, const int role) const
 {
     if (!index.isValid()) return {};
 
-    const BitTorrent::TorrentHandle *torrent = m_torrentList.value(index.row());
+    const BitTorrent::Torrent *torrent = m_torrentList.value(index.row());
     if (!torrent) return {};
 
     switch (role)
@@ -537,7 +537,7 @@ bool TransferListModel::setData(const QModelIndex &index, const QVariant &value,
 {
     if (!index.isValid() || (role != Qt::DisplayRole)) return false;
 
-    BitTorrent::TorrentHandle *const torrent = m_torrentList.value(index.row());
+    BitTorrent::Torrent *const torrent = m_torrentList.value(index.row());
     if (!torrent) return false;
 
     // Category and Name columns can be edited
@@ -556,7 +556,7 @@ bool TransferListModel::setData(const QModelIndex &index, const QVariant &value,
     return true;
 }
 
-void TransferListModel::addTorrent(BitTorrent::TorrentHandle *const torrent)
+void TransferListModel::addTorrent(BitTorrent::Torrent *const torrent)
 {
     Q_ASSERT(!m_torrentMap.contains(torrent));
 
@@ -576,14 +576,14 @@ Qt::ItemFlags TransferListModel::flags(const QModelIndex &index) const
     return QAbstractListModel::flags(index) | Qt::ItemIsEditable;
 }
 
-BitTorrent::TorrentHandle *TransferListModel::torrentHandle(const QModelIndex &index) const
+BitTorrent::Torrent *TransferListModel::torrentHandle(const QModelIndex &index) const
 {
     if (!index.isValid()) return nullptr;
 
     return m_torrentList.value(index.row());
 }
 
-void TransferListModel::handleTorrentAboutToBeRemoved(BitTorrent::TorrentHandle *const torrent)
+void TransferListModel::handleTorrentAboutToBeRemoved(BitTorrent::Torrent *const torrent)
 {
     const int row = m_torrentMap.value(torrent, -1);
     Q_ASSERT(row >= 0);
@@ -599,7 +599,7 @@ void TransferListModel::handleTorrentAboutToBeRemoved(BitTorrent::TorrentHandle 
     endRemoveRows();
 }
 
-void TransferListModel::handleTorrentStatusUpdated(BitTorrent::TorrentHandle *const torrent)
+void TransferListModel::handleTorrentStatusUpdated(BitTorrent::Torrent *const torrent)
 {
     const int row = m_torrentMap.value(torrent, -1);
     Q_ASSERT(row >= 0);
@@ -607,13 +607,13 @@ void TransferListModel::handleTorrentStatusUpdated(BitTorrent::TorrentHandle *co
     emit dataChanged(index(row, 0), index(row, columnCount() - 1));
 }
 
-void TransferListModel::handleTorrentsUpdated(const QVector<BitTorrent::TorrentHandle *> &torrents)
+void TransferListModel::handleTorrentsUpdated(const QVector<BitTorrent::Torrent *> &torrents)
 {
     const int columns = (columnCount() - 1);
 
     if (torrents.size() <= (m_torrentList.size() * 0.5))
     {
-        for (BitTorrent::TorrentHandle *const torrent : torrents)
+        for (BitTorrent::Torrent *const torrent : torrents)
         {
             const int row = m_torrentMap.value(torrent, -1);
             Q_ASSERT(row >= 0);

--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -34,7 +34,7 @@
 #include <QHash>
 #include <QList>
 
-#include "base/bittorrent/torrenthandle.h"
+#include "base/bittorrent/torrent.h"
 
 namespace BitTorrent
 {
@@ -99,21 +99,21 @@ public:
     QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
     Qt::ItemFlags flags(const QModelIndex &index) const override;
 
-    BitTorrent::TorrentHandle *torrentHandle(const QModelIndex &index) const;
+    BitTorrent::Torrent *torrentHandle(const QModelIndex &index) const;
 
 private slots:
-    void addTorrent(BitTorrent::TorrentHandle *const torrent);
-    void handleTorrentAboutToBeRemoved(BitTorrent::TorrentHandle *const torrent);
-    void handleTorrentStatusUpdated(BitTorrent::TorrentHandle *const torrent);
-    void handleTorrentsUpdated(const QVector<BitTorrent::TorrentHandle *> &torrents);
+    void addTorrent(BitTorrent::Torrent *const torrent);
+    void handleTorrentAboutToBeRemoved(BitTorrent::Torrent *const torrent);
+    void handleTorrentStatusUpdated(BitTorrent::Torrent *const torrent);
+    void handleTorrentsUpdated(const QVector<BitTorrent::Torrent *> &torrents);
 
 private:
     void configure();
-    QString displayValue(const BitTorrent::TorrentHandle *torrent, int column) const;
-    QVariant internalValue(const BitTorrent::TorrentHandle *torrent, int column, bool alt = false) const;
+    QString displayValue(const BitTorrent::Torrent *torrent, int column) const;
+    QVariant internalValue(const BitTorrent::Torrent *torrent, int column, bool alt = false) const;
 
-    QList<BitTorrent::TorrentHandle *> m_torrentList;  // maps row number to torrent handle
-    QHash<BitTorrent::TorrentHandle *, int> m_torrentMap;  // maps torrent handle to row number
+    QList<BitTorrent::Torrent *> m_torrentList;  // maps row number to torrent handle
+    QHash<BitTorrent::Torrent *, int> m_torrentMap;  // maps torrent handle to row number
     const QHash<BitTorrent::TorrentState, QString> m_statusStrings;
     // row text colors
     const QHash<BitTorrent::TorrentState, QColor> m_stateThemeColors;

--- a/src/gui/transferlistsortmodel.cpp
+++ b/src/gui/transferlistsortmodel.cpp
@@ -31,7 +31,7 @@
 #include <QDateTime>
 
 #include "base/bittorrent/infohash.h"
-#include "base/bittorrent/torrenthandle.h"
+#include "base/bittorrent/torrent.h"
 #include "base/global.h"
 #include "base/types.h"
 #include "base/utils/string.h"
@@ -292,7 +292,7 @@ bool TransferListSortModel::matchFilter(const int sourceRow, const QModelIndex &
     const auto *model = qobject_cast<TransferListModel *>(sourceModel());
     if (!model) return false;
 
-    const BitTorrent::TorrentHandle *torrent = model->torrentHandle(model->index(sourceRow, 0, sourceParent));
+    const BitTorrent::Torrent *torrent = model->torrentHandle(model->index(sourceRow, 0, sourceParent));
     if (!torrent) return false;
 
     return m_filter.match(torrent);

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -40,7 +40,7 @@ class TransferListSortModel;
 namespace BitTorrent
 {
     class InfoHash;
-    class TorrentHandle;
+    class Torrent;
 }
 
 class TransferListWidget final : public QTreeView
@@ -96,7 +96,7 @@ protected:
     QModelIndex mapToSource(const QModelIndex &index) const;
     QModelIndex mapFromSource(const QModelIndex &index) const;
     bool loadSettings();
-    QVector<BitTorrent::TorrentHandle *> getSelectedTorrents() const;
+    QVector<BitTorrent::Torrent *> getSelectedTorrents() const;
 
 protected slots:
     void torrentDoubleClicked();
@@ -110,7 +110,7 @@ protected slots:
     void saveSettings();
 
 signals:
-    void currentTorrentChanged(BitTorrent::TorrentHandle *const torrent);
+    void currentTorrentChanged(BitTorrent::Torrent *const torrent);
 
 private:
     void wheelEvent(QWheelEvent *event) override;
@@ -118,8 +118,8 @@ private:
     void editTorrentTrackers();
     void confirmRemoveAllTagsForSelection();
     QStringList askTagsForSelection(const QString &dialogTitle);
-    void applyToSelectedTorrents(const std::function<void (BitTorrent::TorrentHandle *const)> &fn);
-    QVector<BitTorrent::TorrentHandle *> getVisibleTorrents() const;
+    void applyToSelectedTorrents(const std::function<void (BitTorrent::Torrent *const)> &fn);
+    QVector<BitTorrent::Torrent *> getVisibleTorrents() const;
 
     TransferListDelegate *m_listDelegate;
     TransferListModel *m_listModel;

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -33,7 +33,7 @@
 #include <QVector>
 
 #include "base/bittorrent/infohash.h"
-#include "base/bittorrent/torrenthandle.h"
+#include "base/bittorrent/torrent.h"
 #include "base/bittorrent/trackerentry.h"
 #include "base/utils/fs.h"
 
@@ -83,7 +83,7 @@ namespace
     }
 }
 
-QVariantMap serialize(const BitTorrent::TorrentHandle &torrent)
+QVariantMap serialize(const BitTorrent::Torrent &torrent)
 {
     QVariantMap ret =
     {
@@ -136,7 +136,7 @@ QVariantMap serialize(const BitTorrent::TorrentHandle &torrent)
     };
 
     const qreal ratio = torrent.realRatio();
-    ret[KEY_TORRENT_RATIO] = (ratio > BitTorrent::TorrentHandle::MAX_RATIO) ? -1 : ratio;
+    ret[KEY_TORRENT_RATIO] = (ratio > BitTorrent::Torrent::MAX_RATIO) ? -1 : ratio;
 
     if (torrent.isPaused() || torrent.isChecking())
     {

--- a/src/webui/api/serialize/serialize_torrent.h
+++ b/src/webui/api/serialize/serialize_torrent.h
@@ -32,7 +32,7 @@
 
 namespace BitTorrent
 {
-    class TorrentHandle;
+    class Torrent;
 }
 
 // Torrent keys
@@ -82,4 +82,4 @@ const char KEY_TORRENT_AUTO_TORRENT_MANAGEMENT[] = "auto_tmm";
 const char KEY_TORRENT_TIME_ACTIVE[] = "time_active";
 const char KEY_TORRENT_AVAILABILITY[] = "availability";
 
-QVariantMap serialize(const BitTorrent::TorrentHandle &torrent);
+QVariantMap serialize(const BitTorrent::Torrent &torrent);

--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -38,7 +38,7 @@
 #include "base/bittorrent/peeraddress.h"
 #include "base/bittorrent/peerinfo.h"
 #include "base/bittorrent/session.h"
-#include "base/bittorrent/torrenthandle.h"
+#include "base/bittorrent/torrent.h"
 #include "base/bittorrent/trackerentry.h"
 #include "base/global.h"
 #include "base/net/geoipmanager.h"
@@ -458,7 +458,7 @@ void SyncController::maindataAction()
 
     QVariantHash torrents;
     QHash<QString, QStringList> trackers;
-    for (const BitTorrent::TorrentHandle *torrent : asConst(session->torrents()))
+    for (const BitTorrent::Torrent *torrent : asConst(session->torrents()))
     {
         const BitTorrent::InfoHash torrentHash = torrent->hash();
 
@@ -542,7 +542,7 @@ void SyncController::torrentPeersAction()
     auto lastAcceptedResponse = sessionManager()->session()->getData(QLatin1String("syncTorrentPeersLastAcceptedResponse")).toMap();
 
     const QString hash {params()["hash"]};
-    const BitTorrent::TorrentHandle *torrent = BitTorrent::Session::instance()->findTorrent(hash);
+    const BitTorrent::Torrent *torrent = BitTorrent::Session::instance()->findTorrent(hash);
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 


### PR DESCRIPTION
Originally, it was just a wrapper for `libtorrent::torrent_handle` class, so it mimicked its name.
It was then transformed into a more complex aggregate, but the name was retained (just by inertia).
Unlike `libtorrent::torrent_handle` class in whose name "handle" means the pattern used, it does not matter for qBittorrent classes and just eats up space in the source code.