### PR TITLE
Allow tab to escape the text box in "Edit trackers" dialog

### DIFF
--- a/src/gui/trackerentriesdialog.ui
+++ b/src/gui/trackerentriesdialog.ui
@@ -27,7 +27,11 @@
     </widget>
    </item>
    <item>
-    <widget class="QPlainTextEdit" name="plainTextEdit"/>
+    <widget class="QPlainTextEdit" name="plainTextEdit">
+     <attribute name="tabChangesFocus">
+      <bool>true</bool>
+     </attribute>
+    </widget>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">


### PR DESCRIPTION
it makes no sense to accept tab characters in that text field _and_ I'd like there to be a way to get out of that dialog purely using the keyboard.