### PR TITLE
Drop extension from generated content folder name

### DIFF
--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -481,9 +481,17 @@ void TorrentInfo::stripRootFolder()
 
 void TorrentInfo::addRootFolder()
 {
-    const QString rootFolder = name();
-    Q_ASSERT(!rootFolder.isEmpty());
+    const QString originalName = name();
+    Q_ASSERT(!originalName.isEmpty());
 
+    const QString extension = Utils::Fs::fileExtension(originalName);
+    const QString rootFolder = extension.isEmpty()
+            ? originalName
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+            : originalName.chopped(extension.size() + 1);
+#else
+            : originalName.left(originalName.size() - (extension.size() + 1));
+#endif
     const std::string rootPrefix = Utils::Fs::toNativePath(rootFolder + QLatin1Char {'/'}).toStdString();
     lt::file_storage files = m_nativeInfo->files();
     files.set_name(rootFolder.toStdString());


### PR DESCRIPTION
Try to detect whether generated content folder name contains extension
and drop it to avoid possible conflicts between file/folder names.

Closes #14193.