### PR TITLE
Change title of "version update" dialog box

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1923,7 +1923,7 @@ void MainWindow::handleUpdateCheckFinished(bool updateAvailable, QString newVers
     }
     else if (invokedByUser)
     {
-        QMessageBox::information(this, tr("Already Using the Latest qBittorrent Version"),
+        QMessageBox::information(this, tr("qBittorrent"),
                                  tr("No updates available.\nYou are already using the latest version."));
     }
     sender()->deleteLater();


### PR DESCRIPTION
Closes #14217

Previous:
`"Already Using the Latest qBittorrent Version"`

![image](https://user-images.githubusercontent.com/1579587/104528454-31fc3100-566c-11eb-8b29-60d189630848.jpg)

ref: https://github.com/qbittorrent/qBittorrent/issues/14217#issue-785556411

This PR:
`"qBittorrent"`

![qBittorrent update window title](https://user-images.githubusercontent.com/42386382/104924822-e0b6af00-5995-11eb-9079-203505d2d8e7.png)

> From Qt docs (https://doc.qt.io/qt-5/qmessagebox.html#details):
> 
> > The _Microsoft Windows User Interface Guidelines_ recommend using the **application name** as the **window's title**.