### PR TITLE
Don't let "program update" dialog steal focus

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1916,7 +1916,7 @@ void MainWindow::handleUpdateCheckFinished(bool updateAvailable, QString newVers
     }
     else if (invokedByUser)
     {
-        QMessageBox::information(this, tr("qBittorrent"),
+        QMessageBox::information(this, QLatin1String("qBittorrent"),
                                  tr("No updates available.\nYou are already using the latest version."));
     }
     sender()->deleteLater();

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -135,7 +135,7 @@ private slots:
     void askRecursiveTorrentDownloadConfirmation(BitTorrent::Torrent *const torrent);
     void optionsSaved();
 #if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
-    void handleUpdateCheckFinished(bool updateAvailable, QString newVersion, bool invokedByUser);
+    void handleUpdateCheckFinished(bool updateAvailable, const QString &newVersion, bool invokedByUser);
 #endif
     void toggleAlternativeSpeeds();
 

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -211,8 +211,8 @@ OptionsDialog::OptionsDialog(QWidget *parent)
 
     m_ui->IpFilterRefreshBtn->setIcon(UIThemeManager::instance()->getIcon("view-refresh"));
 
-    m_ui->labelGlobalRate->setPixmap(Utils::Gui::scaledPixmap(UIThemeManager::instance()->getIcon(QLatin1String("slow_off")), this, 16));
-    m_ui->labelAltRate->setPixmap(Utils::Gui::scaledPixmap(UIThemeManager::instance()->getIcon(QLatin1String("slow")), this, 16));
+    m_ui->labelGlobalRate->setPixmap(Utils::Gui::scaledPixmap(UIThemeManager::instance()->getIcon(QLatin1String("slow_off")), this, 24));
+    m_ui->labelAltRate->setPixmap(Utils::Gui::scaledPixmap(UIThemeManager::instance()->getIcon(QLatin1String("slow")), this, 24));
 
     m_ui->deleteTorrentWarningIcon->setPixmap(QApplication::style()->standardIcon(QStyle::SP_MessageBoxCritical).pixmap(16, 16));
     m_ui->deleteTorrentWarningIcon->hide();

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -800,7 +800,7 @@ void PropertiesWidget::editWebSeed()
 
     if (!m_ui->listWebSeeds->findItems(newSeed, Qt::MatchFixedString).empty())
     {
-        QMessageBox::warning(this, tr("qBittorrent"),
+        QMessageBox::warning(this, QLatin1String("qBittorrent"),
                              tr("This URL seed is already in the list."),
                              QMessageBox::Ok);
         return;


### PR DESCRIPTION
* Disable translation of program name
* Don't let "program update" dialog steal focus
  And also avoid creating an unnecessary event loop.
  Closes #14250.
* Enlarge "speed limit" icon slightly
  [screenshot](https://user-images.githubusercontent.com/9395168/105131305-a24efa80-5b23-11eb-8525-00ca02070e21.png)
