### PR TITLE
Bump WebAPI version

### DIFF
--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -43,7 +43,7 @@
 #include "base/utils/net.h"
 #include "base/utils/version.h"
 
-constexpr Utils::Version<int, 3, 2> API_VERSION {2, 7, 0};
+constexpr Utils::Version<int, 3, 2> API_VERSION {2, 8, 0};
 
 class APIController;
 class WebApplication;


### PR DESCRIPTION
#13995 was supposed to be included in the release along with other API changes, so both PRs had a version change to 2.7.0. However, it ended up in another release, and I forgot to upgrade the version again.

Unfortunately, it is unlikely to fix a problem like #14266, but at least it will fix it for users of intermediate/test builds.
@qbittorrent/bug-handlers, what do you think?