### PR TITLE
Don't inhibit system sleep if all active torrents are errored

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1764,7 +1764,7 @@ bool Session::hasUnfinishedTorrents() const
 {
     return std::any_of(m_torrents.begin(), m_torrents.end(), [](const TorrentImpl *torrent)
     {
-        return (!torrent->isSeed() && !torrent->isPaused());
+        return (!torrent->isSeed() && !torrent->isPaused() && !torrent->isErrored());
     });
 }
 


### PR DESCRIPTION
Currently if there are torrents with MissingFiles state, qBittorrent will prevent system from sleeping draining battery to zero even though nothing is actually downloading.