### PR TITLE
Update translator tab on About

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -119,7 +119,7 @@ Translations authors:
   - German: Niels Hoffmann (zentralmaschine@users.sourceforge.net)
   - Greek: Tsvetan Bankov (emerge_life@users.sourceforge.net), Stephanos Antaris (santaris@csd.auth.gr), sledgehammer999(hammered999@gmail.com) and Γιάννης Ανθυμίδης Evropi(Transifex)
   - Hebrew: David Deutsch (d.deffo@gmail.com)
-  - Hungarian: Majoros Péter (majoros.j.p@t-online.hu)
+  - Hungarian: Majoros Péter
   - Italian: bovirus (bovirus@live.it) and Matteo Sechi (bu17714@gmail.com)
   - Japanese: Masato Hashimoto (cabezon.hashimoto@gmail.com)
   - Korean: Jin Woo Sin (jin828sin@users.sourceforge.net)

--- a/src/gui/aboutdialog.ui
+++ b/src/gui/aboutdialog.ui
@@ -281,6 +281,9 @@
        </property>
        <item>
         <widget class="QTextBrowser" name="textBrowserTranslation">
+         <property name="openExternalLinks">
+          <bool>true</bool>
+         </property>
          <property name="lineWrapMode">
           <enum>QTextEdit::NoWrap</enum>
          </property>

--- a/src/gui/translators.html
+++ b/src/gui/translators.html
@@ -6,7 +6,7 @@
 </head>
 <body>
     <p>I would like to thank the people who volunteered to translate qBittorrent.<br>
-    Most of them translated via Transifex and some of them are mentioned below:<br>
+    Most of them translated via <a href="https://www.transifex.com/sledgehammer999/qbittorrent">Transifex</a> and some of them are mentioned below:<br>
     (the list might not be up to date)
     </p>
     <ul>

--- a/src/gui/translators.html
+++ b/src/gui/translators.html
@@ -30,7 +30,7 @@
         <li><u>German:</u> Niels Hoffmann (zentralmaschine@users.sourceforge.net), schnurlos (schnurlos@gmail.com)</li>
         <li><u>Greek:</u> Tsvetan Bankov (emerge_life@users.sourceforge.net), Stephanos Antaris (santaris@csd.auth.gr), sledgehammer999(hammered999@gmail.com), Γιάννης Ανθυμίδης Evropi(Transifex) and Panagiotis Tabakis(tabakisp@gmail.com)</li>
         <li><u>Hebrew:</u> David Deutsch (d.deffo@gmail.com)</li>
-        <li><u>Hungarian:</u> Majoros Péter (majoros.peterj@gmail.com)</li>
+        <li><u>Hungarian:</u> Majoros Péter</li>
         <li><u>Italian:</u> bovirus (bovirus@live.it) and Matteo Sechi (bu17714@gmail.com)</li>
         <li><u>Japanese:</u> Masato Hashimoto (cabezon.hashimoto@gmail.com)</li>
         <li><u>Korean:</u> Jin Woo Sin (jin828sin@users.sourceforge.net)</li>

--- a/src/webui/www/private/views/about.html
+++ b/src/webui/www/private/views/about.html
@@ -104,7 +104,7 @@
         <li><u>German:</u> Niels Hoffmann (zentralmaschine@users.sourceforge.net), schnurlos (schnurlos@gmail.com)</li>
         <li><u>Greek:</u> Tsvetan Bankov (emerge_life@users.sourceforge.net), Stephanos Antaris (santaris@csd.auth.gr), sledgehammer999(hammered999@gmail.com), Γιάννης Ανθυμίδης Evropi(Transifex) and Panagiotis Tabakis(tabakisp@gmail.com)</li>
         <li><u>Hebrew:</u> David Deutsch (d.deffo@gmail.com)</li>
-        <li><u>Hungarian:</u> Majoros Péter (majoros.peterj@gmail.com)</li>
+        <li><u>Hungarian:</u> Majoros Péter</li>
         <li><u>Italian:</u> bovirus (bovirus@live.it) and Matteo Sechi (bu17714@gmail.com)</li>
         <li><u>Japanese:</u> Masato Hashimoto (cabezon.hashimoto@gmail.com)</li>
         <li><u>Korean:</u> Jin Woo Sin (jin828sin@users.sourceforge.net)</li>

--- a/src/webui/www/private/views/about.html
+++ b/src/webui/www/private/views/about.html
@@ -82,7 +82,10 @@
 </div>
 
 <div id="aboutTranslatorsContent" class="aboutTabContent invisible">
-    <p>I would like to thank the following people who volunteered to translate qBittorrent:</p>
+    <p>I would like to thank the people who volunteered to translate qBittorrent.<br>
+    Most of them translated via <a target="_blank" href="https://www.transifex.com/sledgehammer999/qbittorrent/">Transifex</a> and some of them are mentioned below:<br>
+    (the list might not be up to date)
+    </p>
     <ul>
         <li><u>Arabic:</u> SDERAWI (abz8868@msn.com), sn51234 (nesseyan@gmail.com) and Ibrahim Saed ibraheem_alex(Transifex)</li>
         <li><u>Armenian:</u> Hrant Ohanyan (hrantohanyan@mail.am)</li>


### PR DESCRIPTION
### Description

#12609 addresses an issue where the Hungarian translator desires to be removed from list. The author also suggests linking Transifex team to each language, but upon research unless you join the language team you cannot get access to information regarding team members. 

Instead, I decided to add hyperlink to Transifex word on the introduction, which would redirect the user to the link to the qBittorrent Transifex dashboard (https://www.transifex.com/sledgehammer999/qbittorrent/) on both GUI and WebUI.

<img width="1195" alt="Untitled" src="https://user-images.githubusercontent.com/26905303/106245220-fbbcc680-61c0-11eb-874f-2329b8765db5.png">