### PR TITLE
Fix wrong tracker status (with libtorrent >= 2.0)

### DIFF
--- a/src/base/bittorrent/infohash.h
+++ b/src/base/bittorrent/infohash.h
@@ -29,12 +29,23 @@
 #pragma once
 
 #include <libtorrent/sha1_hash.hpp>
+#include <libtorrent/version.hpp>
 
+#include <QFlags>
 #include <QMetaType>
 #include <QString>
 
 namespace BitTorrent
 {
+    enum class InfoHashFormat
+    {
+        V1,
+#if (LIBTORRENT_VERSION_NUM >= 20000)
+        V2,
+#endif
+    };
+    Q_DECLARE_FLAGS(InfoHashFormats, InfoHashFormat)
+
     class InfoHash
     {
     public:
@@ -65,4 +76,5 @@ namespace BitTorrent
     uint qHash(const InfoHash &key, uint seed);
 }
 
+Q_DECLARE_OPERATORS_FOR_FLAGS(BitTorrent::InfoHashFormats)
 Q_DECLARE_METATYPE(BitTorrent::InfoHash)

--- a/src/base/bittorrent/magneturi.cpp
+++ b/src/base/bittorrent/magneturi.cpp
@@ -36,8 +36,6 @@
 #include <QRegularExpression>
 #include <QUrl>
 
-#include "infohash.h"
-
 namespace
 {
     bool isBitTorrentInfoHash(const QString &string)
@@ -60,13 +58,12 @@ namespace
 using namespace BitTorrent;
 
 MagnetUri::MagnetUri(const QString &source)
-    : m_valid(false)
-    , m_url(source)
 {
     if (source.isEmpty()) return;
 
-    if (isBitTorrentInfoHash(source))
-        m_url = QLatin1String("magnet:?xt=urn:btih:") + source;
+    m_url = isBitTorrentInfoHash(source)
+        ? (QLatin1String("magnet:?xt=urn:btih:") + source)
+        : source;
 
     lt::error_code ec;
     lt::parse_magnet_uri(m_url.toStdString(), m_addTorrentParams, ec);

--- a/src/base/bittorrent/magneturi.h
+++ b/src/base/bittorrent/magneturi.h
@@ -55,10 +55,10 @@ namespace BitTorrent
         lt::add_torrent_params addTorrentParams() const;
 
     private:
-        bool m_valid;
+        bool m_valid = false;
         QString m_url;
-        InfoHash m_hash;
         QString m_name;
+        InfoHash m_hash;
         QVector<TrackerEntry> m_trackers;
         QVector<QUrl> m_urlSeeds;
         lt::add_torrent_params m_addTorrentParams;

--- a/src/base/bittorrent/trackerentry.h
+++ b/src/base/bittorrent/trackerentry.h
@@ -30,7 +30,7 @@
 
 #include <libtorrent/announce_entry.hpp>
 
-#include <QtGlobal>
+#include "infohash.h"
 
 class QString;
 
@@ -54,14 +54,14 @@ namespace BitTorrent
         TrackerEntry &operator=(const TrackerEntry &other) = default;
 
         QString url() const;
-        Status status() const;
+        Status status(InfoHashFormats hashVersions = InfoHashFormat::V1) const;
 
         int tier() const;
         void setTier(int value);
 
-        int numSeeds() const;
-        int numLeeches() const;
-        int numDownloaded() const;
+        int numSeeds(InfoHashFormats hashVersions = InfoHashFormat::V1) const;
+        int numLeeches(InfoHashFormats hashVersions = InfoHashFormat::V1) const;
+        int numDownloaded(InfoHashFormats hashVersions = InfoHashFormat::V1) const;
 
         const lt::announce_entry &nativeEntry() const;
 


### PR DESCRIPTION
* Clean up coding style
* Fix wrong tracker status
  For the time being, the parameter in TrackerEntry class functions still default to V1 format. We will change/fix it when the support of bittorrent 2.0 is complete.
  Note that the wrong status is only present when using libtorrent >= 2.0.
  Closes #14087.

Related thread: https://github.com/arvidn/libtorrent/issues/5335
