### PR TITLE
Add category button on AutomatedRSSDownloader

### DIFF
--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -50,6 +50,7 @@
 #include "base/utils/fs.h"
 #include "base/utils/string.h"
 #include "gui/autoexpandabledialog.h"
+#include "gui/torrentcategorydialog.h"
 #include "gui/uithememanager.h"
 #include "gui/utils.h"
 #include "ui_automatedrssdownloader.h"
@@ -68,6 +69,7 @@ AutomatedRssDownloader::AutomatedRssDownloader(QWidget *parent)
     // Icons
     m_ui->removeRuleBtn->setIcon(UIThemeManager::instance()->getIcon("list-remove"));
     m_ui->addRuleBtn->setIcon(UIThemeManager::instance()->getIcon("list-add"));
+    m_ui->addCategoryBtn->setIcon(UIThemeManager::instance()->getIcon("list-add"));
 
     // Ui Settings
     m_ui->listRules->setSortingEnabled(true);
@@ -403,6 +405,17 @@ void AutomatedRssDownloader::on_removeRuleBtn_clicked()
 
     for (const QListWidgetItem *item : selection)
         RSS::AutoDownloader::instance()->removeRule(item->text());
+}
+
+void AutomatedRssDownloader::on_addCategoryBtn_clicked()
+{
+    const QString newCategoryName = TorrentCategoryDialog::createCategory(this);
+
+    if (!newCategoryName.isEmpty())
+    {
+        m_ui->comboCategory->addItem(newCategoryName);
+        m_ui->comboCategory->setCurrentText(newCategoryName);
+    }
 }
 
 void AutomatedRssDownloader::on_exportBtn_clicked()

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -61,6 +61,7 @@ public:
 private slots:
     void on_addRuleBtn_clicked();
     void on_removeRuleBtn_clicked();
+    void on_addCategoryBtn_clicked();
     void on_exportBtn_clicked();
     void on_importBtn_clicked();
 

--- a/src/gui/rss/automatedrssdownloader.ui
+++ b/src/gui/rss/automatedrssdownloader.ui
@@ -209,7 +209,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                </sizepolicy>
               </property>
               <property name="text">
-               <string>Assign Category:</string>
+               <string>Category:</string>
               </property>
              </widget>
             </item>
@@ -219,6 +219,9 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                <bool>false</bool>
               </property>
              </widget>
+            </item>
+            <item>
+             <widget class="QToolButton" name="addCategoryBtn" />
             </item>
            </layout>
           </item>

--- a/src/gui/torrentcategorydialog.cpp
+++ b/src/gui/torrentcategorydialog.cpp
@@ -29,6 +29,7 @@
 #include "torrentcategorydialog.h"
 
 #include <QMessageBox>
+#include <QPushButton>
 
 #include "base/bittorrent/session.h"
 #include "ui_torrentcategorydialog.h"
@@ -40,6 +41,13 @@ TorrentCategoryDialog::TorrentCategoryDialog(QWidget *parent)
     m_ui->setupUi(this);
     m_ui->comboSavePath->setMode(FileSystemPathEdit::Mode::DirectorySave);
     m_ui->comboSavePath->setDialogCaption(tr("Choose save path"));
+
+    // disable save button
+    m_ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
+    connect(m_ui->textCategoryName, &QLineEdit::textChanged, this, [this](const QString &text)
+    {
+        m_ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(!text.isEmpty());
+    });
 }
 
 TorrentCategoryDialog::~TorrentCategoryDialog()


### PR DESCRIPTION
#7629 suggests adding a button to add new category when creating a new automated RSS downloader rule. I think it's a pretty nice idea and straightforward to implement. When a new category is added, the rule's category is auto-selected to the created category. `TorrentCategoryDialog` class is reused to handle the logic.

I'm planning to make the same update on the WebUI in a following PR.

<img width="614" alt="Untitled" src="https://user-images.githubusercontent.com/26905303/106663482-9ff39400-6558-11eb-828a-e7f3e546b615.png">

<img width="614" alt="Untitled" src="https://user-images.githubusercontent.com/26905303/106663694-ee089780-6558-11eb-90c8-c7bef7771995.png">