### PR TITLE
Use stable sorting in transfer list

### DIFF
--- a/src/gui/transferlistsortmodel.h
+++ b/src/gui/transferlistsortmodel.h
@@ -56,7 +56,6 @@ private:
     bool lessThan(const QModelIndex &left, const QModelIndex &right) const override;
     bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const override;
     bool matchFilter(int sourceRow, const QModelIndex &sourceParent) const;
-    bool lessThan_impl(const QModelIndex &left, const QModelIndex &right) const;
 
     TorrentFilter m_filter;
 };


### PR DESCRIPTION
This drops all sub-sorting code paths and maintain the stable sorting property instead.
For example, user click on one column to sort it first and then click on a second column to sort it again, the values that are compared equal in the second column will preserve the order the previous sorting result.