### PR TITLE
Don't trigger Github Actions CI builds after editing a PR's opening post

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    types: [edited, opened, reopened, synchronize]
     branches: [ master ]
 
 env:

--- a/.github/workflows/file_health.yaml
+++ b/.github/workflows/file_health.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ '**' ]
   pull_request:
-    types: [edited, opened, reopened, synchronize]
     branches: [ '**' ]
 
 jobs:

--- a/.github/workflows/file_health.yaml
+++ b/.github/workflows/file_health.yaml
@@ -1,10 +1,6 @@
 name: GitHub Actions file health check
 
-on:
-  push:
-    branches: [ '**' ]
-  pull_request:
-    branches: [ '**' ]
+on: [pull_request, push]
 
 jobs:
   check_file_health:


### PR DESCRIPTION
After dropping "edited" keyword, it is the same as the default.

https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request
