### PR TITLE
Add advanced options for piece control defaults

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -1178,6 +1178,26 @@ void Preferences::setTrayIconStyle(const TrayIcon::Style style)
 }
 #endif
 
+bool Preferences::sequentialDownloadDefault() const
+{
+    return value("Preferences/Advanced/sequentialDownloadDefault", false).toBool();
+}
+
+void Preferences::setSequentialDownloadDefault(const bool enabled)
+{
+    setValue("Preferences/Advanced/sequentialDownloadDefault", enabled);
+}
+
+bool Preferences::firstLastPiecePriorityDefault() const
+{
+    return value("Preferences/Advanced/firstLastPiecePriorityDefault", false).toBool();
+}
+
+void Preferences::setFirstLastPiecePriorityDefault(const bool enabled)
+{
+    setValue("Preferences/Advanced/firstLastPiecePriorityDefault", enabled);
+}
+
 // Stuff that don't appear in the Options GUI but are saved
 // in the same file.
 

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -314,6 +314,10 @@ public:
     TrayIcon::Style trayIconStyle() const;
     void setTrayIconStyle(TrayIcon::Style style);
 #endif // Q_OS_MACOS
+    bool sequentialDownloadDefault() const;
+    void setSequentialDownloadDefault(const bool enabled);
+    bool firstLastPiecePriorityDefault() const;
+    void setFirstLastPiecePriorityDefault(const bool enabled);
 
     // Stuff that don't appear in the Options GUI but are saved
     // in the same file.

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -46,6 +46,7 @@
 #include "base/exceptions.h"
 #include "base/global.h"
 #include "base/net/downloadmanager.h"
+#include "base/preferences.h"
 #include "base/settingsstorage.h"
 #include "base/torrentfileguard.h"
 #include "base/utils/fs.h"
@@ -121,8 +122,8 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::AddTorrentParams &inP
     m_ui->contentLayoutComboBox->setCurrentIndex(
                 static_cast<int>(m_torrentParams.contentLayout.value_or(session->torrentContentLayout())));
 
-    m_ui->sequentialCheckBox->setChecked(m_torrentParams.sequential);
-    m_ui->firstLastCheckBox->setChecked(m_torrentParams.firstLastPiecePriority);
+    m_ui->sequentialCheckBox->setChecked(Preferences::instance()->sequentialDownloadDefault());
+    m_ui->firstLastCheckBox->setChecked(Preferences::instance()->firstLastPiecePriorityDefault());
 
     m_ui->skipCheckingCheckBox->setChecked(m_torrentParams.skipChecking);
     m_ui->doNotDeleteTorrentCheckBox->setVisible(TorrentFileGuard::autoDeleteMode() != TorrentFileGuard::Never);

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -133,6 +133,8 @@ namespace
         PEER_TURNOVER,
         PEER_TURNOVER_CUTOFF,
         PEER_TURNOVER_INTERVAL,
+        SEQUENTIAL_DOWNLOAD_DEFAULT,
+        FIRST_LAST_PIECE_PRIORITY_DEFAULT,
 
         ROW_COUNT
     };
@@ -291,6 +293,9 @@ void AdvancedSettings::saveAdvancedSettings()
     pref->setConfirmTorrentRecheck(m_checkBoxConfirmTorrentRecheck.isChecked());
 
     pref->setConfirmRemoveAllTags(m_checkBoxConfirmRemoveAllTags.isChecked());
+
+    pref->setSequentialDownloadDefault(m_checkBoxSequentialDownloadDefault.isChecked());
+    pref->setFirstLastPiecePriorityDefault(m_checkBoxFirstLastPiecePriorityDefault.isChecked());
 
     session->setAnnounceToAllTrackers(m_checkBoxAnnounceAllTrackers.isChecked());
     session->setAnnounceToAllTiers(m_checkBoxAnnounceAllTiers.isChecked());
@@ -704,6 +709,12 @@ void AdvancedSettings::loadAdvancedSettings()
     m_spinBoxPeerTurnoverInterval.setValue(session->peerTurnoverInterval());
     addRow(PEER_TURNOVER_INTERVAL, (tr("Peer turnover disconnect interval") + ' ' + makeLink("https://www.libtorrent.org/reference-Settings.html#peer_turnover", "(?)"))
             , &m_spinBoxPeerTurnoverInterval);
+
+    m_checkBoxSequentialDownloadDefault.setChecked(pref->sequentialDownloadDefault());
+    addRow(SEQUENTIAL_DOWNLOAD_DEFAULT, tr("Download in sequential order by default"), &m_checkBoxSequentialDownloadDefault);
+
+    m_checkBoxFirstLastPiecePriorityDefault.setChecked(pref->firstLastPiecePriorityDefault());
+    addRow(FIRST_LAST_PIECE_PRIORITY_DEFAULT, tr("Download first and last pieces first by default"), &m_checkBoxFirstLastPiecePriorityDefault);
 }
 
 template <typename T>

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -69,7 +69,8 @@ private:
               m_checkBoxProgramNotifications, m_checkBoxTorrentAddedNotifications, m_checkBoxTrackerFavicon, m_checkBoxTrackerStatus,
               m_checkBoxConfirmTorrentRecheck, m_checkBoxConfirmRemoveAllTags, m_checkBoxAnnounceAllTrackers, m_checkBoxAnnounceAllTiers,
               m_checkBoxMultiConnectionsPerIp, m_checkBoxValidateHTTPSTrackerCertificate, m_checkBoxBlockPeersOnPrivilegedPorts, m_checkBoxPieceExtentAffinity,
-              m_checkBoxSuggestMode, m_checkBoxSpeedWidgetEnabled, m_checkBoxIDNSupport;
+              m_checkBoxSuggestMode, m_checkBoxSpeedWidgetEnabled, m_checkBoxIDNSupport, m_checkBoxSequentialDownloadDefault,
+              m_checkBoxFirstLastPiecePriorityDefault;
     QComboBox m_comboBoxInterface, m_comboBoxInterfaceAddress, m_comboBoxUtpMixedMode, m_comboBoxChokingAlgorithm, m_comboBoxSeedChokingAlgorithm;
     QLineEdit m_lineEditAnnounceIP;
 


### PR DESCRIPTION
Adds advanced options to change defaults for downloading first and last pieces first and for downloading pieces sequentially.

These options (particularly the sequential downloading one) are somewhat controversial, so I've added them to the advanced options.

FWIW IMO there is no reason these settings shouldn't exist. Either the options shouldn't exist at all, or people should be able to change the default values for them.

Closes #164.