### PR TITLE
Show proper string when torrent availability is not available

### DIFF
--- a/src/base/bittorrent/torrent.cpp
+++ b/src/base/bittorrent/torrent.cpp
@@ -29,8 +29,6 @@
 
 #include "torrent.h"
 
-#include <type_traits>
-
 #include <QHash>
 
 namespace BitTorrent
@@ -42,13 +40,13 @@ namespace BitTorrent
 
     // Torrent
 
-    const qreal Torrent::USE_GLOBAL_RATIO = -2.;
-    const qreal Torrent::NO_RATIO_LIMIT = -1.;
+    const qreal Torrent::USE_GLOBAL_RATIO = -2;
+    const qreal Torrent::NO_RATIO_LIMIT = -1;
 
     const int Torrent::USE_GLOBAL_SEEDING_TIME = -2;
     const int Torrent::NO_SEEDING_TIME_LIMIT = -1;
 
-    const qreal Torrent::MAX_RATIO = 9999.;
+    const qreal Torrent::MAX_RATIO = 9999;
     const int Torrent::MAX_SEEDING_TIME = 525600;
 
     bool Torrent::isResumed() const

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -239,7 +239,7 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
     bool hideValues = false;
     if (m_hideZeroValuesMode == HideZeroValuesMode::Always)
         hideValues = true;
-    else if (m_hideZeroValuesMode != HideZeroValuesMode::Never)
+    else if (m_hideZeroValuesMode == HideZeroValuesMode::Paused)
         hideValues = (torrent->state() == BitTorrent::TorrentState::PausedDownloading);
 
     const auto availabilityString = [hideValues](const qreal value) -> QString
@@ -269,9 +269,9 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
 
     const auto amountString = [hideValues](const qint64 value, const qint64 total) -> QString
     {
-        return (hideValues && (value == 0) && (total == 0))
-                ? QString {}
-                : QString::number(value) + " (" + QString::number(total) + ')';
+        if (hideValues && (value == 0) && (total == 0))
+            return {};
+        return QString::fromLatin1("%1 (%2)").arg(QString::number(value), QString::number(total));
     };
 
     const auto ratioString = [hideValues](const qreal value) -> QString
@@ -285,13 +285,13 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
 
     const auto queuePositionString = [](const qint64 value) -> QString
     {
-        return (value > 0) ? QString::number(value) : "*";
+        return (value > 0) ? QString::number(value) : QLatin1String("*");
     };
 
     const auto lastActivityString = [hideValues](qint64 value) -> QString
     {
         if (hideValues && ((value < 0) || (value >= MAX_ETA)))
-            return QString {};
+            return {};
 
         // Show '< 1m ago' when elapsed time is 0
         if (value == 0)

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -259,7 +259,7 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
 
     const auto limitString = [hideValues](const qint64 value) -> QString
     {
-        if (hideValues && (value == 0))
+        if (hideValues && (value <= 0))
             return {};
 
         return (value > 0)

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -274,6 +274,13 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
         return QString::fromLatin1("%1 (%2)").arg(QString::number(value), QString::number(total));
     };
 
+    const auto etaString = [hideValues](const qlonglong value) -> QString
+    {
+        if (hideValues && (value >= MAX_ETA))
+            return {};
+        return Utils::Misc::userFriendlyDuration(value, MAX_ETA);
+    };
+
     const auto ratioString = [hideValues](const qreal value) -> QString
     {
         if (hideValues && (value <= 0))
@@ -358,7 +365,7 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
     case TR_UPSPEED:
         return unitString(torrent->uploadPayloadRate(), true);
     case TR_ETA:
-        return Utils::Misc::userFriendlyDuration(torrent->eta(), MAX_ETA);
+        return etaString(torrent->eta());
     case TR_RATIO:
         return ratioString(torrent->realRatio());
     case TR_RATIO_LIMIT:

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -302,10 +302,14 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
             : Utils::Misc::userFriendlyDuration(value);
     };
 
-    const auto timeElapsedString = [](const qint64 elapsedTime, const qint64 seedingTime) -> QString
+    const auto timeElapsedString = [hideValues](const qint64 elapsedTime, const qint64 seedingTime) -> QString
     {
         if (seedingTime <= 0)
+        {
+            if (hideValues && (elapsedTime == 0))
+                return {};
             return Utils::Misc::userFriendlyDuration(elapsedTime);
+        }
 
         return tr("%1 (seeded for %2)", "e.g. 4m39s (seeded for 3m10s)")
                 .arg(Utils::Misc::userFriendlyDuration(elapsedTime)

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -244,8 +244,11 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
 
     const auto availabilityString = [hideValues](const qreal value) -> QString
     {
-        return (hideValues && (value <= 0))
-                ? QString {} : Utils::String::fromDouble(value, 3);
+        if (hideValues && (value == 0))
+            return {};
+        return (value >= 0)
+            ? Utils::String::fromDouble(value, 3)
+            : tr("N/A");
     };
 
     const auto unitString = [hideValues](const qint64 value, const bool isSpeedUnit = false) -> QString


### PR DESCRIPTION
* Show proper string when torrent availability is not available
* Clean up coding style
* Apply "Hide zero values" to "Time Active" column
* Apply "Hide infinity values" to "Down/Up Limit" columns
* Apply "Hide infinity values" to ETA column 