### PR TITLE
Refactor apply button logics on options dialog

### DIFF
--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -233,15 +233,8 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     m_ui->hsplitter->setCollapsible(0, false);
     m_ui->hsplitter->setCollapsible(1, false);
     // Get apply button in button box
-    const QList<QAbstractButton *> buttons = m_ui->buttonBox->buttons();
-    for (QAbstractButton *button : buttons)
-    {
-        if (m_ui->buttonBox->buttonRole(button) == QDialogButtonBox::ApplyRole)
-        {
-            m_applyButton = button;
-            break;
-        }
-    }
+    m_applyButton = m_ui->buttonBox->button(QDialogButtonBox::Apply);
+    connect(m_applyButton, &QPushButton::clicked, this, &OptionsDialog::applySettings);
 
     m_ui->scanFoldersView->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
     m_ui->scanFoldersView->setModel(ScanFoldersModel::instance());
@@ -249,7 +242,6 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     connect(ScanFoldersModel::instance(), &QAbstractListModel::dataChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->scanFoldersView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &ThisType::handleScanFolderViewSelectionChanged);
 
-    connect(m_ui->buttonBox, &QDialogButtonBox::clicked, this, &OptionsDialog::applySettings);
     // Languages supported
     initializeLanguageCombo();
 
@@ -1439,27 +1431,24 @@ void OptionsDialog::on_buttonBox_accepted()
     accept();
 }
 
-void OptionsDialog::applySettings(QAbstractButton *button)
+void OptionsDialog::applySettings()
 {
-    if (button == m_applyButton)
+    if (!schedTimesOk())
     {
-        if (!schedTimesOk())
-        {
-            m_ui->tabSelection->setCurrentRow(TAB_SPEED);
-            return;
-        }
-        if (!webUIAuthenticationOk())
-        {
-            m_ui->tabSelection->setCurrentRow(TAB_WEBUI);
-            return;
-        }
-        if (!isAlternativeWebUIPathValid())
-        {
-            m_ui->tabSelection->setCurrentRow(TAB_WEBUI);
-            return;
-        }
-        saveOptions();
+        m_ui->tabSelection->setCurrentRow(TAB_SPEED);
+        return;
     }
+    if (!webUIAuthenticationOk())
+    {
+        m_ui->tabSelection->setCurrentRow(TAB_WEBUI);
+        return;
+    }
+    if (!isAlternativeWebUIPathValid())
+    {
+        m_ui->tabSelection->setCurrentRow(TAB_WEBUI);
+        return;
+    }
+    saveOptions();
 }
 
 void OptionsDialog::closeEvent(QCloseEvent *e)

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -32,7 +32,6 @@
 
 #include "base/settingvalue.h"
 
-class QAbstractButton;
 class QCloseEvent;
 class QListWidgetItem;
 
@@ -95,7 +94,7 @@ private slots:
     void on_buttonBox_accepted();
     void closeEvent(QCloseEvent *e) override;
     void on_buttonBox_rejected();
-    void applySettings(QAbstractButton *button);
+    void applySettings();
     void enableApplyButton();
     void toggleComboRatioLimitAct();
     void changePage(QListWidgetItem *, QListWidgetItem *);
@@ -181,7 +180,7 @@ private:
     SettingValue<QSize> m_storeDialogSize;
     SettingValue<QStringList> m_storeHSplitterSize;
 
-    QAbstractButton *m_applyButton;
+    QPushButton *m_applyButton;
 
     AdvancedSettings *m_advancedSettings;
 


### PR DESCRIPTION
I found these while finding a way to disable save button if input field is empty for #14327. 

1. Rather than using a `for-loop` on the button box to find the apply button, we can directly find it using `button` method. 

2. Likewise, `applySettings` method can directly have signal on the apply button rather than on the button box, then using an `if` conditional to match the clicked button to be the apply button. I am not certain if there will be a side-effect on directly attaching the signal on the button, so please let me know.

3. It is clearer to define the type of the `m_applyButton` to be `QPushButton` than `QAbstractButton`. `QAbstractButton` is the abstact base class for numerous button types, including `QCheckBox`, `QPushButton`, `QRadioButton`, and `QToolButton`. I think there is no risk for specifying the type of the apply button.