### PR TITLE
Systemd: wait for mounting of local filesystems

### DIFF
--- a/dist/unix/systemd/qbittorrent-nox@.service.in
+++ b/dist/unix/systemd/qbittorrent-nox@.service.in
@@ -2,7 +2,7 @@
 Description=qBittorrent-nox service for user %I
 Documentation=man:qbittorrent-nox(1)
 Wants=network-online.target
-After=network-online.target nss-lookup.target
+After=local-fs.target network-online.target nss-lookup.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
My torrents reside on a USB HDD. qbittorrent sometimes starts before the HDD completes mounting, so qbittorrent errors out thinking the files are missing.

This change to the bundled qbittorrent systemd service file makes systemd wait until fstab filesystems are finished mounting before starting qbittorrent.

`local-fs.target` is a [special systemd target](https://www.freedesktop.org/software/systemd/man/systemd.special.html#local-fs.target) which is marked finished when fstab filesystems are mounted.