### PR TITLE
Revise partially filled checkbox logic on content folder

### DIFF
--- a/src/base/bittorrent/downloadpriority.cpp
+++ b/src/base/bittorrent/downloadpriority.cpp
@@ -39,6 +39,7 @@ namespace BitTorrent
         case DownloadPriority::High:
         case DownloadPriority::Maximum:
         case DownloadPriority::Mixed:
+        case DownloadPriority::MixedChecked:
             return true;
         default:
             return false;

--- a/src/base/bittorrent/downloadpriority.h
+++ b/src/base/bittorrent/downloadpriority.h
@@ -37,7 +37,8 @@ namespace BitTorrent
         High = 6,
         Maximum = 7,
 
-        Mixed = -1
+        Mixed = -1, // Checkbox shows as partial
+        MixedChecked = -2 // Checkbox shows as normal
     };
 
     bool isValidDownloadPriority(DownloadPriority priority);

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -342,6 +342,8 @@ void PropertiesWidget::loadTorrentInfos(BitTorrent::Torrent *const torrent)
         }
 
         // Load file priorities
+        // Download priority depends on files progress
+        m_propListModel->model()->updateFilesProgress(m_torrent->filesProgress());
         m_propListModel->model()->updateFilesPriorities(m_torrent->filePriorities());
     }
     // Load dynamic data

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -343,7 +343,7 @@ QVariant TorrentContentModel::data(const QModelIndex &index, int role) const
     switch (role)
     {
     case Qt::DecorationRole:
-    {
+        {
             if (index.column() != TorrentContentModelItem::COL_NAME)
                 return {};
 
@@ -352,7 +352,7 @@ QVariant TorrentContentModel::data(const QModelIndex &index, int role) const
             return m_fileIconProvider->icon(QFileInfo(item->name()));
         }
     case Qt::CheckStateRole:
-    {
+        {
             if (index.column() != TorrentContentModelItem::COL_NAME)
                 return {};
 

--- a/src/gui/torrentcontentmodelitem.cpp
+++ b/src/gui/torrentcontentmodelitem.cpp
@@ -115,6 +115,7 @@ QString TorrentContentModelItem::displayData(const int column) const
         switch (m_priority)
         {
         case BitTorrent::DownloadPriority::Mixed:
+        case BitTorrent::DownloadPriority::MixedChecked:
             return tr("Mixed", "Mixed (priorities");
         case BitTorrent::DownloadPriority::Ignored:
             return tr("Not downloaded");


### PR DESCRIPTION
The old logic for determining if a folder's download priority doesn't take account of `Fast` and `Maximum` statuses. That's why #14329 bug occurs, but I think the fact that you can toggle on/off already downloaded files is misleading.

In this PR I revise the logic to be as such:

1. If all files are set to be `not downloading`, then the folder's download priority should also be `not downloading`.

<img width="553" alt="nd" src="https://user-images.githubusercontent.com/26905303/107449516-8cb46b80-6af8-11eb-99f1-5016e149966c.png">

2. If all files are set to be downloading, then the folder's download priority should reflect the **lowest** download priority of the files.

- If all files are set to be downloading at **maximum** speed, then folder's download priority should also be **maximum**

<img width="546" alt="max" src="https://user-images.githubusercontent.com/26905303/107449583-ab1a6700-6af8-11eb-965a-7c81ec215a24.png">

- If there is a single file with download priority of **normal**, then folder's download priority is **normal**

<img width="606" alt="lowest" src="https://user-images.githubusercontent.com/26905303/107449236-0d269c80-6af8-11eb-9e72-5202e0d7cfec.png">

3. Otherwise, the folder's download priority is set to **mixed**.

<img width="544" alt="mixed" src="https://user-images.githubusercontent.com/26905303/107449410-5d056380-6af8-11eb-9ebe-be2c7b3544b5.png">