### PR TITLE
Bundle recalculating progress and availability for content folder

### DIFF
--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -212,8 +212,7 @@ void TorrentContentModel::updateFilesProgress(const QVector<qreal> &fp)
     for (int i = 0; i < fp.size(); ++i)
         m_filesIndex[i]->setProgress(fp[i]);
     // Update folders progress in the tree
-    m_rootItem->recalculateProgress();
-    m_rootItem->recalculateAvailability();
+    m_rootItem->recalculateProperties(true, true);
     emit dataChanged(index(0, 0), index((rowCount() - 1), (columnCount() - 1)));
 }
 
@@ -240,7 +239,7 @@ void TorrentContentModel::updateFilesAvailability(const QVector<qreal> &fa)
     for (int i = 0; i < m_filesIndex.size(); ++i)
         m_filesIndex[i]->setAvailability(fa[i]);
     // Update folders progress in the tree
-    m_rootItem->recalculateProgress();
+    m_rootItem->recalculateProperties(true, false);
     emit dataChanged(index(0, 0), index((rowCount() - 1), (columnCount() - 1)));
 }
 
@@ -288,8 +287,7 @@ bool TorrentContentModel::setData(const QModelIndex &index, const QVariant &valu
 
             item->setPriority(prio);
             // Update folders progress in the tree
-            m_rootItem->recalculateProgress();
-            m_rootItem->recalculateAvailability();
+            m_rootItem->recalculateProperties(true, true);
             emit dataChanged(this->index(0, 0), this->index((rowCount() - 1), (columnCount() - 1)));
             emit filteredFilesChanged();
         }

--- a/src/gui/torrentcontentmodelfolder.h
+++ b/src/gui/torrentcontentmodelfolder.h
@@ -49,8 +49,7 @@ public:
     ItemType itemType() const override;
 
     void increaseSize(qulonglong delta);
-    void recalculateProgress();
-    void recalculateAvailability();
+    void recalculateProperties(bool progress, bool availability);
     void updatePriority();
 
     void setPriority(BitTorrent::DownloadPriority newPriority, bool updateParent = true) override;


### PR DESCRIPTION
While working on #7348, I noticed that `recalculateProgress` and `recalculateAvailability` traverse through all sub-folders recursively independently. Given how frequently content tab changes, I think bundling these functions into one can improve performance quite a bit. I wasn't certain why `updateFilesAvailability` (line 243) only calls `recalculateProgress`, so I gave two input params on the bundled function to selectively update progress and availability. 

I think this PR might be controversial, so I'll just close it if that case. Let me know what you guys think.