### PR TITLE
Restructure content tab columns

### DIFF
--- a/src/gui/properties/proplistdelegate.h
+++ b/src/gui/properties/proplistdelegate.h
@@ -44,6 +44,8 @@ enum PropColumn
     PCSIZE,
     PROGRESS,
     PRIORITY,
+    WANTED,
+    DONE,
     REMAINING,
     AVAILABILITY
 };

--- a/src/gui/properties/proplistdelegate.h
+++ b/src/gui/properties/proplistdelegate.h
@@ -41,9 +41,9 @@ class PropertiesWidget;
 enum PropColumn
 {
     NAME,
-    PCSIZE,
     PROGRESS,
     PRIORITY,
+    PCSIZE,
     WANTED,
     DONE,
     REMAINING,

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -184,7 +184,7 @@ namespace
 
 TorrentContentModel::TorrentContentModel(QObject *parent)
     : QAbstractItemModel(parent)
-    , m_rootItem(new TorrentContentModelFolder(QVector<QString>({ tr("Name"), tr("Size"), tr("Progress"), tr("Download Priority"), tr("Remaining"), tr("Availability") })))
+    , m_rootItem(new TorrentContentModelFolder(QVector<QString>({ tr("Name"), tr("Total"), tr("Progress"), tr("Download Priority"), tr("Wanted"), tr("Done"), tr("Remaining"), tr("Availability") })))
 {
 #if defined(Q_OS_WIN)
     m_fileIconProvider = new WinShellFileIconProvider();
@@ -364,6 +364,8 @@ QVariant TorrentContentModel::data(const QModelIndex &index, int role) const
         }
     case Qt::TextAlignmentRole:
         if ((index.column() == TorrentContentModelItem::COL_SIZE)
+            || (index.column() == TorrentContentModelItem::COL_WANTED)
+            || (index.column() == TorrentContentModelItem::COL_DONE)
             || (index.column() == TorrentContentModelItem::COL_REMAINING))
             return QVariant {Qt::AlignRight | Qt::AlignVCenter};
         return {};
@@ -405,6 +407,8 @@ QVariant TorrentContentModel::headerData(int section, Qt::Orientation orientatio
 
     case Qt::TextAlignmentRole:
         if ((section == TorrentContentModelItem::COL_SIZE)
+            || (section == TorrentContentModelItem::COL_WANTED)
+            || (section == TorrentContentModelItem::COL_DONE)
             || (section == TorrentContentModelItem::COL_REMAINING))
             return QVariant {Qt::AlignRight | Qt::AlignVCenter};
         return {};

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -184,7 +184,7 @@ namespace
 
 TorrentContentModel::TorrentContentModel(QObject *parent)
     : QAbstractItemModel(parent)
-    , m_rootItem(new TorrentContentModelFolder(QVector<QString>({ tr("Name"), tr("Total"), tr("Progress"), tr("Download Priority"), tr("Wanted"), tr("Done"), tr("Remaining"), tr("Availability") })))
+    , m_rootItem(new TorrentContentModelFolder(QVector<QString>({ tr("Name"), tr("Progress"), tr("Download Priority"), tr("Total"), tr("Wanted"), tr("Done"), tr("Remaining"), tr("Availability") })))
 {
 #if defined(Q_OS_WIN)
     m_fileIconProvider = new WinShellFileIconProvider();

--- a/src/gui/torrentcontentmodelfile.cpp
+++ b/src/gui/torrentcontentmodelfile.cpp
@@ -44,7 +44,7 @@ TorrentContentModelFile::TorrentContentModelFile(const QString &fileName, qulong
     if (m_name.endsWith(QB_EXT))
         m_name.chop(4);
 
-    m_size = fileSize;
+    m_wanted = m_size = fileSize;
 }
 
 int TorrentContentModelFile::fileIndex() const
@@ -59,7 +59,13 @@ void TorrentContentModelFile::setPriority(BitTorrent::DownloadPriority newPriori
     if (m_priority == newPriority)
         return;
 
+    if (m_priority != BitTorrent::DownloadPriority::Ignored && newPriority == BitTorrent::DownloadPriority::Ignored)
+      m_parentItem->updateWanted(-m_size);
+    else if (m_priority == BitTorrent::DownloadPriority::Ignored && newPriority != BitTorrent::DownloadPriority::Ignored)
+      m_parentItem->updateWanted(m_size);
+
     m_priority = newPriority;
+    m_wanted = m_priority == BitTorrent::DownloadPriority::Ignored ? 0 : m_size;
 
     // Update parent
     if (updateParent)

--- a/src/gui/torrentcontentmodelfolder.h
+++ b/src/gui/torrentcontentmodelfolder.h
@@ -49,6 +49,7 @@ public:
     ItemType itemType() const override;
 
     void increaseSize(qulonglong delta);
+    void updateWanted(qulonglong delta);
     void recalculateProgress();
     void recalculateAvailability();
     void updatePriority();

--- a/src/gui/torrentcontentmodelitem.cpp
+++ b/src/gui/torrentcontentmodelitem.cpp
@@ -37,6 +37,7 @@
 
 TorrentContentModelItem::TorrentContentModelItem(TorrentContentModelFolder *parent)
     : m_parentItem(parent)
+    , m_wanted(0)
     , m_size(0)
     , m_remaining(0)
     , m_priority(BitTorrent::DownloadPriority::Normal)
@@ -71,11 +72,24 @@ qulonglong TorrentContentModelItem::size() const
     return m_size;
 }
 
+qulonglong TorrentContentModelItem::wanted() const
+{
+    Q_ASSERT(!isRootItem());
+
+    return m_wanted;
+}
+
 qreal TorrentContentModelItem::progress() const
 {
     Q_ASSERT(!isRootItem());
 
     return (m_size > 0) ? m_progress : 1;
+}
+
+qulonglong TorrentContentModelItem::done() const
+{
+    Q_ASSERT(!isRootItem());
+    return (m_priority == BitTorrent::DownloadPriority::Ignored) ? 0 : m_wanted - m_remaining;
 }
 
 qulonglong TorrentContentModelItem::remaining() const
@@ -129,8 +143,12 @@ QString TorrentContentModelItem::displayData(const int column) const
         return (m_progress >= 1)
                ? QString::fromLatin1("100%")
                : (Utils::String::fromDouble((m_progress * 100), 1) + QLatin1Char('%'));
+    case COL_WANTED:
+        return Utils::Misc::friendlyUnit(m_wanted);
     case COL_SIZE:
         return Utils::Misc::friendlyUnit(m_size);
+    case COL_DONE:
+        return Utils::Misc::friendlyUnit(done());
     case COL_REMAINING:
         return Utils::Misc::friendlyUnit(remaining());
     case COL_AVAILABILITY:
@@ -163,8 +181,12 @@ QVariant TorrentContentModelItem::underlyingData(const int column) const
         return static_cast<int>(m_priority);
     case COL_PROGRESS:
         return progress() * 100;
+    case COL_WANTED:
+        return m_wanted;
     case COL_SIZE:
         return m_size;
+    case COL_DONE:
+        return done();
     case COL_REMAINING:
         return remaining();
     case COL_AVAILABILITY:

--- a/src/gui/torrentcontentmodelitem.h
+++ b/src/gui/torrentcontentmodelitem.h
@@ -48,6 +48,8 @@ public:
         COL_SIZE,
         COL_PROGRESS,
         COL_PRIO,
+        COL_WANTED,
+        COL_DONE,
         COL_REMAINING,
         COL_AVAILABILITY,
         NB_COL
@@ -69,8 +71,10 @@ public:
     QString name() const;
     void setName(const QString &name);
 
+    qulonglong wanted() const;
     qulonglong size() const;
     qreal progress() const;
+    qulonglong done() const;
     qulonglong remaining() const;
 
     qreal availability() const;
@@ -89,6 +93,7 @@ protected:
     QVector<QString> m_itemData;
     // Non-root item members
     QString m_name;
+    qulonglong m_wanted;
     qulonglong m_size;
     qulonglong m_remaining;
     BitTorrent::DownloadPriority m_priority;

--- a/src/gui/torrentcontentmodelitem.h
+++ b/src/gui/torrentcontentmodelitem.h
@@ -45,9 +45,9 @@ public:
     enum TreeItemColumns
     {
         COL_NAME,
-        COL_SIZE,
         COL_PROGRESS,
         COL_PRIO,
+        COL_SIZE,
         COL_WANTED,
         COL_DONE,
         COL_REMAINING,


### PR DESCRIPTION
#7348 addresses an issue where `size` column displays total size of all files in the folder, not only the selected files. This PR provides a quick fix to update folder's size from `recalculateProgress` and `recalculateAvailability`. I intentionally left out `increaseSize` function (originally used to calculate total size) in case we want to add a new column for `total size`.