### PR TITLE
Enable sponsor button on Github

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: "https://www.qbittorrent.org/donate.php"


### PR DESCRIPTION
Closes  #14355.

See: [screenshot](https://user-images.githubusercontent.com/9395168/107869759-74fc2f00-6ecc-11eb-87da-a5005f650d1e.png)
The repository name in the screenshot is just an example, it will be the current repo name once merged.
And note that although the sponsor button will appear, we won't really be participating in Github Sponsors program due to reasons (e.g. org registration/taxes, Sponsors program not available in some countries).