### PR TITLE
Add an option to disable icons in menus

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -251,6 +251,9 @@ int main(int argc, char *argv[])
 
         // On OS X the standard is to not show icons in the menus
         app->setAttribute(Qt::AA_DontShowIconsInMenus);
+#else
+        if (!Preferences::instance()->iconsInMenusEnabled())
+            app->setAttribute(Qt::AA_DontShowIconsInMenus);
 #endif
 
         if (!firstTimeUser)

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -234,6 +234,16 @@ void Preferences::setCloseToTrayNotified(const bool b)
 {
     setValue("Preferences/General/CloseToTrayNotified", b);
 }
+
+bool Preferences::iconsInMenusEnabled() const
+{
+    return value("Preferences/Advanced/EnableIconsInMenus", true).toBool();
+}
+
+void Preferences::setIconsInMenusEnabled(const bool enable)
+{
+    setValue("Preferences/Advanced/EnableIconsInMenus", enable);
+}
 #endif // Q_OS_MACOS
 
 bool Preferences::isToolbarDisplayed() const

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -313,6 +313,8 @@ public:
     void setCloseToTrayNotified(bool b);
     TrayIcon::Style trayIconStyle() const;
     void setTrayIconStyle(TrayIcon::Style style);
+    bool iconsInMenusEnabled() const;
+    void setIconsInMenusEnabled(bool enable);
 #endif // Q_OS_MACOS
 
     // Stuff that don't appear in the Options GUI but are saved

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -82,6 +82,9 @@ namespace
         DOWNLOAD_TRACKER_FAVICON,
         SAVE_PATH_HISTORY_LENGTH,
         ENABLE_SPEED_WIDGET,
+#ifndef Q_OS_MACOS
+        ENABLE_ICONS_IN_MENUS,
+#endif
         // embedded tracker
         TRACKER_STATUS,
         TRACKER_PORT,
@@ -279,6 +282,9 @@ void AdvancedSettings::saveAdvancedSettings()
     mainWindow->setDownloadTrackerFavicon(m_checkBoxTrackerFavicon.isChecked());
     AddNewTorrentDialog::setSavePathHistoryLength(m_spinBoxSavePathHistoryLength.value());
     pref->setSpeedWidgetEnabled(m_checkBoxSpeedWidgetEnabled.isChecked());
+#ifndef Q_OS_MACOS
+    pref->setIconsInMenusEnabled(m_checkBoxIconsInMenusEnabled.isChecked());
+#endif
 
     // Tracker
     pref->setTrackerPort(m_spinBoxTrackerPort.value());
@@ -647,6 +653,11 @@ void AdvancedSettings::loadAdvancedSettings()
     // Enable speed graphs
     m_checkBoxSpeedWidgetEnabled.setChecked(pref->isSpeedWidgetEnabled());
     addRow(ENABLE_SPEED_WIDGET, tr("Enable speed graphs"), &m_checkBoxSpeedWidgetEnabled);
+#ifndef Q_OS_MACOS
+    // Enable icons in menus
+    m_checkBoxIconsInMenusEnabled.setChecked(pref->iconsInMenusEnabled());
+    addRow(ENABLE_ICONS_IN_MENUS, tr("Enable icons in menus"), &m_checkBoxIconsInMenusEnabled);
+#endif
     // Tracker State
     m_checkBoxTrackerStatus.setChecked(session->isTrackerEnabled());
     addRow(TRACKER_STATUS, tr("Enable embedded tracker"), &m_checkBoxTrackerStatus);

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -84,4 +84,8 @@ private:
 #if defined(Q_OS_WIN)
     QComboBox m_comboBoxOSMemoryPriority;
 #endif
+
+#ifndef Q_OS_MACOS
+    QCheckBox m_checkBoxIconsInMenusEnabled;
+#endif
 };


### PR DESCRIPTION
Add an advanced setting for enabling or disabling icons in context menus. Defaults to enabled.
This makes it possible to better integrate qBittorrent in GTK based DEs on Linux.

Here's what it looks like with the adwaita-qt theme:
![Comparison](https://user-images.githubusercontent.com/3678707/108600153-c6f1f880-7395-11eb-9785-4cda74d9a588.png)
Left: Menu icons enabled, Right: Menu icons disabled.

Closes #3297.
