### PR TITLE
WebUI: Properly decode strings

### DIFF
--- a/src/webui/www/private/confirmfeeddeletion.html
+++ b/src/webui/www/private/confirmfeeddeletion.html
@@ -11,7 +11,7 @@
         'use strict';
 
         window.addEvent('domready', () => {
-            const paths = decodeURIComponent(new URI().getData('paths')).split('|');
+            const paths = new URI().getData('paths').split('|');
             $('cancelBtn').focus();
             $('cancelBtn').addEvent('click', (e) => {
                 new Event(e).stop();

--- a/src/webui/www/private/confirmruleclear.html
+++ b/src/webui/www/private/confirmruleclear.html
@@ -11,7 +11,7 @@
         'use strict';
 
         window.addEvent('domready', () => {
-            const rules = decodeURIComponent(new URI().getData('rules')).split('|');
+            const rules = new URI().getData('rules').split('|');
 
             $('cancelBtn').focus();
             $('cancelBtn').addEvent('click', (e) => {

--- a/src/webui/www/private/confirmruledeletion.html
+++ b/src/webui/www/private/confirmruledeletion.html
@@ -11,7 +11,7 @@
         'use strict';
 
         window.addEvent('domready', () => {
-            const rules = decodeURIComponent(new URI().getData('rules')).split('|');
+            const rules = new URI().getData('rules').split('|');
 
             $('cancelBtn').focus();
             $('cancelBtn').addEvent('click', (e) => {

--- a/src/webui/www/private/newfeed.html
+++ b/src/webui/www/private/newfeed.html
@@ -30,7 +30,7 @@
         }).activate();
         window.addEvent('domready', () => {
             $('feedURL').focus();
-            const path = decodeURIComponent(new URI().getData('path'));
+            const path = new URI().getData('path');
             $('submitButton').addEvent('click', (e) => {
                 new Event(e).stop();
                 // check field

--- a/src/webui/www/private/newfolder.html
+++ b/src/webui/www/private/newfolder.html
@@ -30,7 +30,7 @@
         }).activate();
         window.addEvent('domready', () => {
             $('folderName').focus();
-            const path = decodeURIComponent(new URI().getData('path'));
+            const path = new URI().getData('path');
             $('submitButton').addEvent('click', (e) => {
                 new Event(e).stop();
                 // check field

--- a/src/webui/www/private/rename_feed.html
+++ b/src/webui/www/private/rename_feed.html
@@ -29,7 +29,7 @@
             }
         }).activate();
         window.addEvent('domready', () => {
-            const oldPath = decodeURIComponent(new URI().getData('oldPath'));
+            const oldPath = new URI().getData('oldPath');
 
             $('rename').value = oldPath;
             $('rename').focus();

--- a/src/webui/www/private/rename_rule.html
+++ b/src/webui/www/private/rename_rule.html
@@ -29,7 +29,7 @@
             }
         }).activate();
         window.addEvent('domready', () => {
-            const oldName = decodeURIComponent(new URI().getData('rule'));
+            const oldName = new URI().getData('rule');
 
             $('rename').value = oldName;
             $('rename').focus();


### PR DESCRIPTION
It can be reproduced if we rename the RSS feed names to encoded string by the WebUI, such as `%D1%82%D0%B5%D1%81%D1%82` (`тест` in Russian). Then the renamed feeds can't been deleted/renamed again.

This is because the URL has been decoded once by the function `getdata()`. It will make something wrong if the original encoded strings are encoded once and decoded twice.
