### PR TITLE
Correctly draw the background of progress bar

### DIFF
--- a/src/gui/progressbardelegate.cpp
+++ b/src/gui/progressbardelegate.cpp
@@ -53,7 +53,6 @@ void ProgressBarDelegate::initProgressStyleOption(QStyleOptionProgressBar &optio
     option.progress = static_cast<int>(index.data(m_dataRole).toReal());
     option.maximum = 100;
     option.minimum = 0;
-    option.state |= (QStyle::State_Enabled | QStyle::State_Horizontal);
     option.textVisible = true;
 }
 
@@ -65,9 +64,11 @@ void ProgressBarDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
     QStyleOptionProgressBar newopt;
     newopt.initFrom(&m_dummyProgressBar);
     newopt.rect = option.rect;
+    newopt.state = option.state;
     initProgressStyleOption(newopt, index);
 
     painter->save();
+    m_dummyProgressBar.style()->drawPrimitive(QStyle::PE_PanelItemViewItem, &option, painter);
     m_dummyProgressBar.style()->drawControl(QStyle::CE_ProgressBar, &newopt, painter, &m_dummyProgressBar);
     painter->restore();
 }


### PR DESCRIPTION
Now the background of progress bar is drawn correctly:
![screenshot](https://user-images.githubusercontent.com/9395168/109612575-e4c81600-7b6a-11eb-90ee-4bf3ca6dd060.png)
Before this PR:
![screenshot](https://user-images.githubusercontent.com/52258748/77545052-84d4e400-6eb2-11ea-9bc5-21aabb36736c.png) (image from https://github.com/qbittorrent/qBittorrent/issues/12271#issue-587723714)

Closes #12271.
Addresses #14464 partially.