### PR TITLE
Improve tracker entries handling

### DIFF
--- a/src/base/bittorrent/magneturi.cpp
+++ b/src/base/bittorrent/magneturi.cpp
@@ -78,7 +78,7 @@ MagnetUri::MagnetUri(const QString &source)
 
     m_trackers.reserve(m_addTorrentParams.trackers.size());
     for (const std::string &tracker : m_addTorrentParams.trackers)
-        m_trackers.append(lt::announce_entry {tracker});
+        m_trackers.append({QString::fromStdString(tracker)});
 
     m_urlSeeds.reserve(m_addTorrentParams.url_seeds.size());
     for (const std::string &urlSeed : m_addTorrentParams.url_seeds)

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1604,7 +1604,7 @@ void Session::populateAdditionalTrackers()
     {
         tracker = tracker.trimmed();
         if (!tracker.isEmpty())
-            m_additionalTrackerList << tracker.toString();
+            m_additionalTrackerList.append({tracker.toString()});
     }
 }
 
@@ -3809,7 +3809,7 @@ void Session::handleTorrentTrackersAdded(TorrentImpl *const torrent, const QVect
     torrent->saveResumeData();
 
     for (const TrackerEntry &newTracker : newTrackers)
-        LogMsg(tr("Tracker '%1' was added to torrent '%2'").arg(newTracker.url(), torrent->name()));
+        LogMsg(tr("Tracker '%1' was added to torrent '%2'").arg(newTracker.url, torrent->name()));
     emit trackersAdded(torrent, newTrackers);
     if (torrent->trackers().size() == newTrackers.size())
         emit trackerlessStateChanged(torrent, false);
@@ -3821,7 +3821,7 @@ void Session::handleTorrentTrackersRemoved(TorrentImpl *const torrent, const QVe
     torrent->saveResumeData();
 
     for (const TrackerEntry &deletedTracker : deletedTrackers)
-        LogMsg(tr("Tracker '%1' was deleted from torrent '%2'").arg(deletedTracker.url(), torrent->name()));
+        LogMsg(tr("Tracker '%1' was deleted from torrent '%2'").arg(deletedTracker.url, torrent->name()));
     emit trackersRemoved(torrent, deletedTrackers);
     if (torrent->trackers().empty())
         emit trackerlessStateChanged(torrent, true);

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -99,8 +99,8 @@ namespace BitTorrent
     class Torrent;
     class TorrentImpl;
     class Tracker;
-    class TrackerEntry;
     struct LoadTorrentParams;
+    struct TrackerEntry;
 
     enum class MoveStorageMode;
 

--- a/src/base/bittorrent/torrent.h
+++ b/src/base/bittorrent/torrent.h
@@ -45,8 +45,8 @@ namespace BitTorrent
     class InfoHash;
     class PeerInfo;
     class TorrentInfo;
-    class TrackerEntry;
     struct PeerAddress;
+    struct TrackerEntry;
 
     enum class TorrentOperatingMode
     {

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -302,7 +302,7 @@ QVector<TrackerEntry> TorrentInfo::trackers() const
     ret.reserve(trackers.size());
 
     for (const lt::announce_entry &tracker : trackers)
-        ret.append(tracker);
+        ret.append({QString::fromStdString(tracker.url)});
     return ret;
 }
 

--- a/src/base/bittorrent/torrentinfo.h
+++ b/src/base/bittorrent/torrentinfo.h
@@ -45,7 +45,7 @@ class QUrl;
 namespace BitTorrent
 {
     class InfoHash;
-    class TrackerEntry;
+    struct TrackerEntry;
 
     class TorrentInfo final : public AbstractFileStorage
     {

--- a/src/base/bittorrent/trackerentry.cpp
+++ b/src/base/bittorrent/trackerentry.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2015, 2021  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -28,139 +28,15 @@
 
 #include "trackerentry.h"
 
-#include <algorithm>
-
-#include <libtorrent/version.hpp>
-
-#include <QString>
 #include <QUrl>
-
-using namespace BitTorrent;
-
-TrackerEntry::TrackerEntry(const QString &url)
-    : m_nativeEntry(url.toStdString())
-{
-}
-
-TrackerEntry::TrackerEntry(const lt::announce_entry &nativeEntry)
-    : m_nativeEntry(nativeEntry)
-{
-}
-
-QString TrackerEntry::url() const
-{
-    return QString::fromStdString(nativeEntry().url);
-}
-
-int TrackerEntry::tier() const
-{
-    return nativeEntry().tier;
-}
-
-TrackerEntry::Status TrackerEntry::status() const
-{
-    const auto &endpoints = nativeEntry().endpoints;
-
-    const bool allFailed = !endpoints.empty() && std::all_of(endpoints.begin(), endpoints.end()
-        , [](const lt::announce_endpoint &endpoint)
-    {
-#if (LIBTORRENT_VERSION_NUM >= 20000)
-        return std::all_of(endpoint.info_hashes.begin(), endpoint.info_hashes.end()
-            , [](const lt::announce_infohash &infohash)
-            {
-                return (infohash.fails > 0);
-            });
-#else
-        return (endpoint.fails > 0);
-#endif
-    });
-    if (allFailed)
-        return NotWorking;
-
-    const bool isUpdating = std::any_of(endpoints.begin(), endpoints.end()
-        , [](const lt::announce_endpoint &endpoint)
-    {
-#if (LIBTORRENT_VERSION_NUM >= 20000)
-        return std::any_of(endpoint.info_hashes.begin(), endpoint.info_hashes.end()
-            , [](const lt::announce_infohash &infohash)
-            {
-                return infohash.updating;
-            });
-#else
-        return endpoint.updating;
-#endif
-    });
-    if (isUpdating)
-        return Updating;
-
-    if (!nativeEntry().verified)
-        return NotContacted;
-
-    return Working;
-}
-
-void TrackerEntry::setTier(const int value)
-{
-    m_nativeEntry.tier = value;
-}
-
-int TrackerEntry::numSeeds() const
-{
-    int value = -1;
-    for (const lt::announce_endpoint &endpoint : nativeEntry().endpoints)
-    {
-#if (LIBTORRENT_VERSION_NUM >= 20000)
-        for (const lt::announce_infohash &infoHash : endpoint.info_hashes)
-            value = std::max(value, infoHash.scrape_complete);
-#else
-        value = std::max(value, endpoint.scrape_complete);
-#endif
-    }
-    return value;
-}
-
-int TrackerEntry::numLeeches() const
-{
-    int value = -1;
-    for (const lt::announce_endpoint &endpoint : nativeEntry().endpoints)
-    {
-#if (LIBTORRENT_VERSION_NUM >= 20000)
-        for (const lt::announce_infohash &infoHash : endpoint.info_hashes)
-            value = std::max(value, infoHash.scrape_incomplete);
-#else
-        value = std::max(value, endpoint.scrape_incomplete);
-#endif
-    }
-    return value;
-}
-
-int TrackerEntry::numDownloaded() const
-{
-    int value = -1;
-    for (const lt::announce_endpoint &endpoint : nativeEntry().endpoints)
-    {
-#if (LIBTORRENT_VERSION_NUM >= 20000)
-        for (const lt::announce_infohash &infoHash : endpoint.info_hashes)
-            value = std::max(value, infoHash.scrape_downloaded);
-#else
-        value = std::max(value, endpoint.scrape_downloaded);
-#endif
-    }
-    return value;
-}
-
-const lt::announce_entry &TrackerEntry::nativeEntry() const
-{
-    return m_nativeEntry;
-}
 
 bool BitTorrent::operator==(const TrackerEntry &left, const TrackerEntry &right)
 {
-    return ((left.tier() == right.tier())
-        && QUrl(left.url()) == QUrl(right.url()));
+    return ((left.tier == right.tier)
+        && QUrl(left.url) == QUrl(right.url));
 }
 
 uint BitTorrent::qHash(const TrackerEntry &key, const uint seed)
 {
-    return (::qHash(key.url(), seed) ^ ::qHash(key.tier()));
+    return (::qHash(key.url, seed) ^ ::qHash(key.tier));
 }

--- a/src/base/bittorrent/trackerentry.h
+++ b/src/base/bittorrent/trackerentry.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2015, 2021  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -28,17 +28,14 @@
 
 #pragma once
 
-#include <libtorrent/announce_entry.hpp>
-
 #include <QtGlobal>
-
-class QString;
+#include <QString>
+#include <QVector>
 
 namespace BitTorrent
 {
-    class TrackerEntry
+    struct TrackerEntry
     {
-    public:
         enum Status
         {
             NotContacted = 1,
@@ -47,26 +44,26 @@ namespace BitTorrent
             NotWorking = 4
         };
 
-        TrackerEntry() = default;
-        TrackerEntry(const QString &url);
-        TrackerEntry(const lt::announce_entry &nativeEntry);
-        TrackerEntry(const TrackerEntry &other) = default;
-        TrackerEntry &operator=(const TrackerEntry &other) = default;
+        struct EndpointStats
+        {
+            int protocolVersion = 1;
 
-        QString url() const;
-        Status status() const;
+            Status status = NotContacted;
+            int numSeeds = -1;
+            int numLeeches = -1;
+            int numDownloaded = -1;
+        };
 
-        int tier() const;
-        void setTier(int value);
+        QString url;
+        int tier = 0;
 
-        int numSeeds() const;
-        int numLeeches() const;
-        int numDownloaded() const;
+        QVector<EndpointStats> endpoints {};
 
-        const lt::announce_entry &nativeEntry() const;
-
-    private:
-        lt::announce_entry m_nativeEntry;
+        // Deprecated fields
+        Status status = NotContacted;
+        int numSeeds = -1;
+        int numLeeches = -1;
+        int numDownloaded = -1;
     };
 
     bool operator==(const TrackerEntry &left, const TrackerEntry &right);

--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -205,9 +205,7 @@ void TrackerListWidget::moveSelectionUp()
     for (int i = NB_STICKY_ITEM; i < topLevelItemCount(); ++i)
     {
         const QString trackerURL = topLevelItem(i)->data(COL_URL, Qt::DisplayRole).toString();
-        BitTorrent::TrackerEntry e(trackerURL);
-        e.setTier(i - NB_STICKY_ITEM);
-        trackers.append(e);
+        trackers.append({trackerURL, (i - NB_STICKY_ITEM)});
     }
 
     torrent->replaceTrackers(trackers);
@@ -251,9 +249,7 @@ void TrackerListWidget::moveSelectionDown()
     for (int i = NB_STICKY_ITEM; i < topLevelItemCount(); ++i)
     {
         const QString trackerURL = topLevelItem(i)->data(COL_URL, Qt::DisplayRole).toString();
-        BitTorrent::TrackerEntry e(trackerURL);
-        e.setTier(i - NB_STICKY_ITEM);
-        trackers.append(e);
+        trackers.append({trackerURL, (i - NB_STICKY_ITEM)});
     }
 
     torrent->replaceTrackers(trackers);
@@ -372,7 +368,7 @@ void TrackerListWidget::loadTrackers()
 
     for (const BitTorrent::TrackerEntry &entry : asConst(torrent->trackers()))
     {
-        const QString trackerURL = entry.url();
+        const QString trackerURL = entry.url;
 
         QTreeWidgetItem *item = m_trackerItems.value(trackerURL, nullptr);
         if (!item)
@@ -387,11 +383,11 @@ void TrackerListWidget::loadTrackers()
             oldTrackerURLs.removeOne(trackerURL);
         }
 
-        item->setText(COL_TIER, QString::number(entry.tier()));
+        item->setText(COL_TIER, QString::number(entry.tier));
 
         const BitTorrent::TrackerInfo data = trackerData.value(trackerURL);
 
-        switch (entry.status())
+        switch (entry.status)
         {
         case BitTorrent::TrackerEntry::Working:
             item->setText(COL_STATUS, tr("Working"));
@@ -412,14 +408,14 @@ void TrackerListWidget::loadTrackers()
         }
 
         item->setText(COL_PEERS, QString::number(data.numPeers));
-        item->setText(COL_SEEDS, ((entry.numSeeds() > -1)
-            ? QString::number(entry.numSeeds())
+        item->setText(COL_SEEDS, ((entry.numSeeds > -1)
+            ? QString::number(entry.numSeeds)
             : tr("N/A")));
-        item->setText(COL_LEECHES, ((entry.numLeeches() > -1)
-            ? QString::number(entry.numLeeches())
+        item->setText(COL_LEECHES, ((entry.numLeeches > -1)
+            ? QString::number(entry.numLeeches)
             : tr("N/A")));
-        item->setText(COL_DOWNLOADED, ((entry.numDownloaded() > -1)
-            ? QString::number(entry.numDownloaded())
+        item->setText(COL_DOWNLOADED, ((entry.numDownloaded > -1)
+            ? QString::number(entry.numDownloaded)
             : tr("N/A")));
 
         const Qt::Alignment alignment = (Qt::AlignRight | Qt::AlignVCenter);
@@ -443,7 +439,7 @@ void TrackerListWidget::askForTrackers()
 
     QVector<BitTorrent::TrackerEntry> trackers;
     for (const QString &tracker : asConst(TrackersAdditionDialog::askForTrackers(this, torrent)))
-        trackers << tracker;
+        trackers.append({tracker});
 
     torrent->addTrackers(trackers);
 }
@@ -492,7 +488,7 @@ void TrackerListWidget::deleteSelectedTrackers()
 
     for (const BitTorrent::TrackerEntry &entry : trackers)
     {
-        if (!urlsToRemove.contains(entry.url()))
+        if (!urlsToRemove.contains(entry.url))
             remainingTrackers.push_back(entry);
     }
 
@@ -529,18 +525,16 @@ void TrackerListWidget::editSelectedTracker()
     bool match = false;
     for (BitTorrent::TrackerEntry &entry : trackers)
     {
-        if (newTrackerURL == QUrl(entry.url()))
+        if (newTrackerURL == QUrl(entry.url))
         {
             QMessageBox::warning(this, tr("Tracker editing failed"), tr("The tracker URL already exists."));
             return;
         }
 
-        if (!match && (trackerURL == QUrl(entry.url())))
+        if (!match && (trackerURL == QUrl(entry.url)))
         {
             match = true;
-            BitTorrent::TrackerEntry newEntry(newTrackerURL.toString());
-            newEntry.setTier(entry.tier());
-            entry = newEntry;
+            entry.url = newTrackerURL.toString();
         }
     }
 
@@ -572,7 +566,7 @@ void TrackerListWidget::reannounceSelected()
         // Trackers case
         for (int i = 0; i < trackers.size(); ++i)
         {
-            if (item->text(COL_URL) == trackers[i].url())
+            if (item->text(COL_URL) == trackers[i].url)
             {
                 torrent->forceReannounce(i);
                 break;

--- a/src/gui/properties/trackersadditiondialog.cpp
+++ b/src/gui/properties/trackersadditiondialog.cpp
@@ -96,7 +96,7 @@ void TrackersAdditionDialog::torrentListDownloadFinished(const Net::DownloadResu
     existingTrackers.reserve(trackersFromUser.size());
     for (const QString &userURL : trackersFromUser)
     {
-        const BitTorrent::TrackerEntry userTracker(userURL);
+        const BitTorrent::TrackerEntry userTracker {userURL};
         if (!existingTrackers.contains(userTracker))
             existingTrackers << userTracker;
     }
@@ -113,7 +113,7 @@ void TrackersAdditionDialog::torrentListDownloadFinished(const Net::DownloadResu
         const QString line = buffer.readLine().trimmed();
         if (line.isEmpty()) continue;
 
-        BitTorrent::TrackerEntry newTracker(line);
+        BitTorrent::TrackerEntry newTracker {line};
         if (!existingTrackers.contains(newTracker))
         {
             m_ui->textEditTrackersList->insertPlainText(line + '\n');

--- a/src/gui/trackerentriesdialog.cpp
+++ b/src/gui/trackerentriesdialog.cpp
@@ -66,8 +66,8 @@ void TrackerEntriesDialog::setTrackers(const QVector<BitTorrent::TrackerEntry> &
 
     for (const BitTorrent::TrackerEntry &entry : trackers)
     {
-        tiers[entry.tier()] += (entry.url() + '\n');
-        maxTier = std::max(maxTier, entry.tier());
+        tiers[entry.tier] += (entry.url + '\n');
+        maxTier = std::max(maxTier, entry.tier);
     }
 
     QString text = tiers.value(0);
@@ -97,9 +97,7 @@ QVector<BitTorrent::TrackerEntry> TrackerEntriesDialog::trackers() const
             continue;
         }
 
-        BitTorrent::TrackerEntry entry {line.toString()};
-        entry.setTier(tier);
-        entries.append(entry);
+        entries.append({line.toString(), tier});
     }
 
     return entries;

--- a/src/gui/trackerentriesdialog.h
+++ b/src/gui/trackerentriesdialog.h
@@ -35,7 +35,7 @@
 
 namespace BitTorrent
 {
-    class TrackerEntry;
+    struct TrackerEntry;
 }
 
 namespace Ui

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -580,7 +580,7 @@ void TrackerFiltersList::handleNewTorrent(BitTorrent::Torrent *const torrent)
     const BitTorrent::InfoHash hash {torrent->hash()};
     const QVector<BitTorrent::TrackerEntry> trackers {torrent->trackers()};
     for (const BitTorrent::TrackerEntry &tracker : trackers)
-        addItem(tracker.url(), hash);
+        addItem(tracker.url, hash);
 
     // Check for trackerless torrent
     if (trackers.isEmpty())
@@ -594,7 +594,7 @@ void TrackerFiltersList::torrentAboutToBeDeleted(BitTorrent::Torrent *const torr
     const BitTorrent::InfoHash hash {torrent->hash()};
     const QVector<BitTorrent::TrackerEntry> trackers {torrent->trackers()};
     for (const BitTorrent::TrackerEntry &tracker : trackers)
-        removeItem(tracker.url(), hash);
+        removeItem(tracker.url, hash);
 
     // Check for trackerless torrent
     if (trackers.isEmpty())
@@ -743,13 +743,13 @@ void TransferListFiltersWidget::setDownloadTrackerFavicon(bool value)
 void TransferListFiltersWidget::addTrackers(const BitTorrent::Torrent *torrent, const QVector<BitTorrent::TrackerEntry> &trackers)
 {
     for (const BitTorrent::TrackerEntry &tracker : trackers)
-        m_trackerFilters->addItem(tracker.url(), torrent->hash());
+        m_trackerFilters->addItem(tracker.url, torrent->hash());
 }
 
 void TransferListFiltersWidget::removeTrackers(const BitTorrent::Torrent *torrent, const QVector<BitTorrent::TrackerEntry> &trackers)
 {
     for (const BitTorrent::TrackerEntry &tracker : trackers)
-        m_trackerFilters->removeItem(tracker.url(), torrent->hash());
+        m_trackerFilters->removeItem(tracker.url, torrent->hash());
 }
 
 void TransferListFiltersWidget::changeTrackerless(const BitTorrent::Torrent *torrent, const bool trackerless)

--- a/src/gui/transferlistfilterswidget.h
+++ b/src/gui/transferlistfilterswidget.h
@@ -41,7 +41,7 @@ namespace BitTorrent
 {
     class InfoHash;
     class Torrent;
-    class TrackerEntry;
+    struct TrackerEntry;
 }
 
 namespace Net

--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -488,7 +488,7 @@ void SyncController::maindataAction()
         }
 
         for (const BitTorrent::TrackerEntry &tracker : asConst(torrent->trackers()))
-            trackers[tracker.url()] << torrentHash.toString();
+            trackers[tracker.url] << torrentHash.toString();
 
         torrents[torrentHash.toString()] = map;
     }

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -453,18 +453,18 @@ void TorrentsController::trackersAction()
     QHash<QString, BitTorrent::TrackerInfo> trackersData = torrent->trackerInfos();
     for (const BitTorrent::TrackerEntry &tracker : asConst(torrent->trackers()))
     {
-        const BitTorrent::TrackerInfo data = trackersData.value(tracker.url());
+        const BitTorrent::TrackerInfo data = trackersData.value(tracker.url);
 
         trackerList << QJsonObject
         {
-            {KEY_TRACKER_URL, tracker.url()},
-            {KEY_TRACKER_TIER, tracker.tier()},
-            {KEY_TRACKER_STATUS, static_cast<int>(tracker.status())},
+            {KEY_TRACKER_URL, tracker.url},
+            {KEY_TRACKER_TIER, tracker.tier},
+            {KEY_TRACKER_STATUS, static_cast<int>(tracker.status)},
             {KEY_TRACKER_PEERS_COUNT, data.numPeers},
             {KEY_TRACKER_MSG, data.lastMessage.trimmed()},
-            {KEY_TRACKER_SEEDS_COUNT, tracker.numSeeds()},
-            {KEY_TRACKER_LEECHES_COUNT, tracker.numLeeches()},
-            {KEY_TRACKER_DOWNLOADED_COUNT, tracker.numDownloaded()}
+            {KEY_TRACKER_SEEDS_COUNT, tracker.numSeeds},
+            {KEY_TRACKER_LEECHES_COUNT, tracker.numLeeches},
+            {KEY_TRACKER_DOWNLOADED_COUNT, tracker.numDownloaded}
         };
     }
 
@@ -694,7 +694,7 @@ void TorrentsController::addTrackersAction()
     {
         const QUrl url {urlStr.trimmed()};
         if (url.isValid())
-            trackers << url.toString();
+            trackers.append({url.toString()});
     }
     torrent->addTrackers(trackers);
 }
@@ -722,15 +722,13 @@ void TorrentsController::editTrackerAction()
     bool match = false;
     for (BitTorrent::TrackerEntry &tracker : trackers)
     {
-        const QUrl trackerUrl(tracker.url());
+        const QUrl trackerUrl(tracker.url);
         if (trackerUrl == newTrackerUrl)
             throw APIError(APIErrorType::Conflict, "New tracker URL already exists");
         if (trackerUrl == origTrackerUrl)
         {
             match = true;
-            BitTorrent::TrackerEntry newTracker(newTrackerUrl.toString());
-            newTracker.setTier(tracker.tier());
-            tracker = newTracker;
+            tracker.url = newTrackerUrl.toString();
         }
     }
     if (!match)
@@ -758,7 +756,7 @@ void TorrentsController::removeTrackersAction()
     remainingTrackers.reserve(trackers.size());
     for (const BitTorrent::TrackerEntry &entry : trackers)
     {
-        if (!urls.contains(entry.url()))
+        if (!urls.contains(entry.url))
             remainingTrackers.push_back(entry);
     }
 


### PR DESCRIPTION
Make TrackerEntry a regular structure that serves to provide data about the current state of interaction with some tracker. It's still used also for some other jobs where just tracker URL (and probably tier) is enough so it's better to change this logic in future.
Move all the data conversion (i.e. filling TorrentEntry structure) to TorrentImpl class, and make all conversion only once when creating an instance of TrackerEntry.
Provide data for each local endpoint separately. For now, keep the summary data inside the TrackerEntry structure, but intend to remove it from here so that the caller summarises it itself if it needs to (or just displays it separately for each endpoint).