### PR TITLE
Fix TravisCI macOS builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,8 +106,8 @@ install:
 
       brew update > /dev/null
       brew upgrade cmake
-      brew install ccache colormake boost openssl qt zlib
-      brew link --force qt zlib
+      brew install ccache colormake boost openssl qt@5 zlib
+      brew link --force qt@5 zlib
 
       if [ "$build_system" = "cmake" ]; then
         sudo ln -s /usr/local/opt/qt/mkspecs /usr/local/mkspecs

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1926,7 +1926,7 @@ void MainWindow::handleUpdateCheckFinished(ProgramUpdater *updater, const bool i
         msgBox->setAttribute(Qt::WA_DeleteOnClose);
         msgBox->setAttribute(Qt::WA_ShowWithoutActivating);
         msgBox->setDefaultButton(QMessageBox::Yes);
-        connect(msgBox, &QMessageBox::buttonClicked, this, [this, msgBox, updater](QAbstractButton *button)
+        connect(msgBox, &QMessageBox::buttonClicked, this, [msgBox, updater](QAbstractButton *button)
         {
             if (msgBox->buttonRole(button) == QMessageBox::YesRole)
             {


### PR DESCRIPTION
In homebrew `qt` package is referring to Qt6 instead of Qt5.