### PR TITLE
Look for qbittorrent.pdb in installation directory

### DIFF
--- a/src/app/stacktrace_win.h
+++ b/src/app/stacktrace_win.h
@@ -24,6 +24,7 @@
 #include <dbghelp.h>
 #include <stdio.h>
 
+#include <QCoreApplication>
 #include <QDir>
 #include <QTextStream>
 #ifdef __MINGW32__
@@ -256,7 +257,7 @@ const QString straceWin::getBacktrace()
 
     HANDLE hProcess = GetCurrentProcess();
     HANDLE hThread = GetCurrentThread();
-    SymInitialize(hProcess, NULL, TRUE);
+    SymInitializeW(hProcess, QCoreApplication::applicationDirPath().toStdWString().c_str(), TRUE);
 
     DWORD64 dwDisplacement;
 


### PR DESCRIPTION
Pass application directory as PDB search path in SymInitialize.
Otherwise it searches in application working directory so when you run qBittorrent with working directory other than its installation one it can't find qbittorent.pdb file and produces broken stacktrace.