### PR TITLE
Upload_only clients are NOT seeds

### DIFF
--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -341,9 +341,9 @@ void TrackerListWidget::loadStickyItems(const BitTorrent::Torrent *torrent)
             else
                 ++peersPeX;
         }
-        if (peer.fromLSD() && !peer.isUploadOnly)
+        if (peer.fromLSD())
         {
-            if (peer.isSeed())
+            if (peer.isSeed() && !peer.isUploadOnly)
                 ++seedsLSD;
             else
                 ++peersLSD;

--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -336,14 +336,14 @@ void TrackerListWidget::loadStickyItems(const BitTorrent::Torrent *torrent)
         }
         if (peer.fromPeX())
         {
-            if (peer.isSeed() && !(bool)peer.isUploadOnly)
+            if (peer.isSeed() && !(bool)(peer.isUploadOnly))
                 ++seedsPeX;
             else
                 ++peersPeX;
         }
         if (peer.fromLSD())
         {
-            if (peer.isSeed() && !(bool)peer.isUploadOnly)
+            if (peer.isSeed() && !(bool)(peer.isUploadOnly))
                 ++seedsLSD;
             else
                 ++peersLSD;

--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -329,19 +329,19 @@ void TrackerListWidget::loadStickyItems(const BitTorrent::Torrent *torrent)
 
         if (peer.fromDHT())
         {
-            if (peer.isSeed())
+            if (peer.isSeed() && !peer.isUploadOnly)
                 ++seedsDHT;
             else
                 ++peersDHT;
         }
         if (peer.fromPeX())
         {
-            if (peer.isSeed())
+            if (peer.isSeed() && !peer.isUploadOnly)
                 ++seedsPeX;
             else
                 ++peersPeX;
         }
-        if (peer.fromLSD())
+        if (peer.fromLSD() && !peer.isUploadOnly)
         {
             if (peer.isSeed())
                 ++seedsLSD;

--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -329,21 +329,21 @@ void TrackerListWidget::loadStickyItems(const BitTorrent::Torrent *torrent)
 
         if (peer.fromDHT())
         {
-            if (peer.isSeed() && !peer.isUploadOnly)
+            if (peer.isSeed() && !(bool)peer.isUploadOnly)
                 ++seedsDHT;
             else
                 ++peersDHT;
         }
         if (peer.fromPeX())
         {
-            if (peer.isSeed() && !peer.isUploadOnly)
+            if (peer.isSeed() && !(bool)peer.isUploadOnly)
                 ++seedsPeX;
             else
                 ++peersPeX;
         }
         if (peer.fromLSD())
         {
-            if (peer.isSeed() && !peer.isUploadOnly)
+            if (peer.isSeed() && !(bool)peer.isUploadOnly)
                 ++seedsLSD;
             else
                 ++peersLSD;

--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -329,7 +329,7 @@ void TrackerListWidget::loadStickyItems(const BitTorrent::Torrent *torrent)
 
         if (peer.fromDHT())
         {
-            if (peer.isSeed() && !(bool)peer.isUploadOnly)
+            if (peer.isSeed() && !(bool)(peer.isUploadOnly))
                 ++seedsDHT;
             else
                 ++peersDHT;

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -144,7 +144,7 @@ namespace
         {
             if (peer.isConnecting()) continue;
 
-            if (peer.isSeed())
+            if (peer.isSeed() && !peer.isUploadOnly)
             {
                 if (peer.fromDHT())
                     ++seedsDHT;

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -144,7 +144,7 @@ namespace
         {
             if (peer.isConnecting()) continue;
 
-            if (peer.isSeed() && !(bool)peer.isUploadOnly)
+            if (peer.isSeed() && !peer.isUploadOnly())
             {
                 if (peer.fromDHT())
                     ++seedsDHT;

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -144,7 +144,7 @@ namespace
         {
             if (peer.isConnecting()) continue;
 
-            if (peer.isSeed() && !peer.isUploadOnly)
+            if (peer.isSeed() && !(bool)peer.isUploadOnly)
             {
                 if (peer.fromDHT())
                     ++seedsDHT;


### PR DESCRIPTION
I quite often try to download torrents which have multiple "seeds" only to find that these peers do not have the complete torrent - and indeed that there are no peers that have a complete torrent. This is caused by these peers being upload_only.

See [BEP21](https://www.bittorrent.org/beps/bep_0021.html) .

This change counts seeds which are upload_only as leechers rather than seeds.