### PR TITLE
Improve "save resume data" handling

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -465,6 +465,7 @@ namespace BitTorrent
         void bottomTorrentsQueuePos(const QVector<TorrentID> &ids);
 
         // Torrent interface
+        void handleTorrentNeedSaveResumeData(const TorrentImpl *torrent);
         void handleTorrentSaveResumeDataRequested(const TorrentImpl *torrent);
         void handleTorrentShareLimitChanged(TorrentImpl *const torrent);
         void handleTorrentNameChanged(TorrentImpl *const torrent);
@@ -770,6 +771,7 @@ namespace BitTorrent
         QHash<TorrentID, LoadTorrentParams> m_loadingTorrents;
         QHash<QString, AddTorrentParams> m_downloadedTorrents;
         QHash<TorrentID, RemovingTorrentData> m_removingTorrents;
+        QSet<TorrentID> m_needSaveResumeDataTorrents;
         QStringMap m_categories;
         QSet<QString> m_tags;
 


### PR DESCRIPTION
Eliminate cases of multiple resume data overwrites, where multiple properties of the same torrent are changed sequentially in a single event. 
Plus, I don't filter out stopped torrents explicitly when saving regularly, but rely on their `need_save_resume_data` property, so if we missed something, it will have a chance to be saved.