### PR TITLE
Implement custom "bit array" wrapper

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(qbt_base STATIC
     # headers
     algorithm.h
     asyncfilestorage.h
+    bitarray.h
     bittorrent/abstractfilestorage.h
     bittorrent/addtorrentparams.h
     bittorrent/bandwidthscheduler.h
@@ -91,6 +92,7 @@ add_library(qbt_base STATIC
 
     # sources
     asyncfilestorage.cpp
+    bitarray.cpp
     bittorrent/abstractfilestorage.cpp
     bittorrent/bandwidthscheduler.cpp
     bittorrent/customstorage.cpp

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -1,6 +1,7 @@
 HEADERS += \
     $$PWD/algorithm.h \
     $$PWD/asyncfilestorage.h \
+    $$PWD/bitarray.h \
     $$PWD/bittorrent/abstractfilestorage.h \
     $$PWD/bittorrent/addtorrentparams.h \
     $$PWD/bittorrent/bandwidthscheduler.h \
@@ -91,6 +92,7 @@ HEADERS += \
 
 SOURCES += \
     $$PWD/asyncfilestorage.cpp \
+    $$PWD/bitarray.cpp \
     $$PWD/bittorrent/abstractfilestorage.cpp \
     $$PWD/bittorrent/bandwidthscheduler.cpp \
     $$PWD/bittorrent/customstorage.cpp \

--- a/src/base/bitarray.cpp
+++ b/src/base/bitarray.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
+ * Copyright (C) 2021  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -26,39 +26,44 @@
  * exception statement from your version.
  */
 
-#pragma once
+#include "bitarray.h"
 
-#include <QtContainerFwd>
-
-#include "base/bitarray.h"
-#include "piecesbar.h"
-
-class QWidget;
-
-class DownloadedPiecesBar final : public PiecesBar
+BitArray::BitArray(const lt::bitfield &bitfield)
+    : m_bitfield {bitfield}
 {
-    using base = PiecesBar;
-    Q_OBJECT
-    Q_DISABLE_COPY(DownloadedPiecesBar)
+}
 
-public:
-    DownloadedPiecesBar(QWidget *parent);
+BitArray::BitArray(const int size, const bool val)
+    : m_bitfield {size, val}
+{
+}
 
-    void setProgress(const BitArray &pieces, const BitArray &downloadedPieces);
+int BitArray::size() const noexcept
+{
+    return m_bitfield.size();
+}
 
-    // PiecesBar interface
-    void clear() override;
+bool BitArray::isEmpty() const noexcept
+{
+    return m_bitfield.empty();
+}
 
-private:
-    // scale bitfield vector to float vector
-    QVector<float> bitfieldToFloatVector(const BitArray &vecin, int reqSize);
-    virtual bool updateImage(QImage &image) override;
-    QString simpleToolTipText() const override;
+void BitArray::setBit(const int index)
+{
+    m_bitfield.set_bit(index);
+}
 
-    // incomplete piece color
-    const QColor m_dlPieceColor;
-    // last used bitfields, uses to better resize redraw
-    // TODO: make a diff pieces to new pieces and update only changed pixels, speedup when update > 20x faster
-    BitArray m_pieces;
-    BitArray m_downloadedPieces;
-};
+void BitArray::clear() noexcept
+{
+    m_bitfield.clear();
+}
+
+bool BitArray::operator[](const int index) const noexcept
+{
+    return m_bitfield[index];
+}
+
+BitArray::operator lt::bitfield() noexcept
+{
+    return m_bitfield;
+}

--- a/src/base/bitarray.h
+++ b/src/base/bitarray.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
+ * Copyright (C) 2021  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -28,37 +28,36 @@
 
 #pragma once
 
-#include <QtContainerFwd>
+#include <libtorrent/bitfield.hpp>
 
-#include "base/bitarray.h"
-#include "piecesbar.h"
-
-class QWidget;
-
-class DownloadedPiecesBar final : public PiecesBar
+class BitArray
 {
-    using base = PiecesBar;
-    Q_OBJECT
-    Q_DISABLE_COPY(DownloadedPiecesBar)
-
 public:
-    DownloadedPiecesBar(QWidget *parent);
+    BitArray() noexcept = default;
+    BitArray(const BitArray &other) noexcept = default;
+    BitArray(BitArray &&other) noexcept = default;
 
-    void setProgress(const BitArray &pieces, const BitArray &downloadedPieces);
+    BitArray(const lt::bitfield &bitfield);
+    explicit BitArray(int size, bool val = false);
 
-    // PiecesBar interface
-    void clear() override;
+    template <typename IndexType>
+    BitArray(const typename lt::typed_bitfield<IndexType> &bitfield)
+        : BitArray {static_cast<const lt::bitfield &>(bitfield)}
+    {
+    }
+
+    BitArray &operator=(const BitArray &other) = default;
+    BitArray &operator=(BitArray &&other) noexcept = default;
+
+    int size() const noexcept;
+    bool isEmpty() const noexcept;
+
+    void setBit(int index);
+    void clear() noexcept;
+
+    operator lt::bitfield() noexcept;
+    bool operator[](int index) const noexcept;
 
 private:
-    // scale bitfield vector to float vector
-    QVector<float> bitfieldToFloatVector(const BitArray &vecin, int reqSize);
-    virtual bool updateImage(QImage &image) override;
-    QString simpleToolTipText() const override;
-
-    // incomplete piece color
-    const QColor m_dlPieceColor;
-    // last used bitfields, uses to better resize redraw
-    // TODO: make a diff pieces to new pieces and update only changed pixels, speedup when update > 20x faster
-    BitArray m_pieces;
-    BitArray m_downloadedPieces;
+    lt::bitfield m_bitfield;
 };

--- a/src/base/bittorrent/peerinfo.cpp
+++ b/src/base/bittorrent/peerinfo.cpp
@@ -28,8 +28,7 @@
 
 #include "peerinfo.h"
 
-#include <QBitArray>
-
+#include "base/bitarray.h"
 #include "base/bittorrent/torrent.h"
 #include "base/net/geoipmanager.h"
 #include "base/unicodestrings.h"
@@ -205,15 +204,9 @@ qlonglong PeerInfo::totalDownload() const
     return m_nativeInfo.total_download;
 }
 
-QBitArray PeerInfo::pieces() const
+BitArray PeerInfo::pieces() const
 {
-    QBitArray result(m_nativeInfo.pieces.size());
-    for (int i = 0; i < result.size(); ++i)
-    {
-        if (m_nativeInfo.pieces[lt::piece_index_t {i}])
-            result.setBit(i, true);
-    }
-    return result;
+    return m_nativeInfo.pieces;
 }
 
 QString PeerInfo::connectionType() const
@@ -228,8 +221,8 @@ QString PeerInfo::connectionType() const
 
 void PeerInfo::calcRelevance(const Torrent *torrent)
 {
-    const QBitArray allPieces = torrent->pieces();
-    const QBitArray peerPieces = pieces();
+    const BitArray allPieces = torrent->pieces();
+    const BitArray peerPieces = pieces();
 
     int localMissing = 0;
     int remoteHaves = 0;

--- a/src/base/bittorrent/peerinfo.h
+++ b/src/base/bittorrent/peerinfo.h
@@ -32,7 +32,7 @@
 
 #include <QCoreApplication>
 
-class QBitArray;
+class BitArray;
 
 namespace BitTorrent
 {
@@ -83,7 +83,7 @@ namespace BitTorrent
         int payloadDownSpeed() const;
         qlonglong totalUpload() const;
         qlonglong totalDownload() const;
-        QBitArray pieces() const;
+        BitArray pieces() const;
         QString connectionType() const;
         qreal relevance() const;
         QString flags() const;

--- a/src/base/bittorrent/torrent.h
+++ b/src/base/bittorrent/torrent.h
@@ -35,7 +35,7 @@
 
 #include "abstractfilestorage.h"
 
-class QBitArray;
+class BitArray;
 class QDateTime;
 class QUrl;
 
@@ -240,8 +240,8 @@ namespace BitTorrent
         virtual bool isPEXDisabled() const = 0;
         virtual bool isLSDDisabled() const = 0;
         virtual QVector<PeerInfo> peers() const = 0;
-        virtual QBitArray pieces() const = 0;
-        virtual QBitArray downloadingPieces() const = 0;
+        virtual BitArray pieces() const = 0;
+        virtual BitArray downloadingPieces() const = 0;
         virtual QVector<int> pieceAvailability() const = 0;
         virtual qreal distributedCopies() const = 0;
         virtual qreal maxRatio() const = 0;

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -51,13 +51,13 @@
 #include <libtorrent/info_hash.hpp>
 #endif
 
-#include <QBitArray>
 #include <QDebug>
 #include <QDir>
 #include <QFile>
 #include <QStringList>
 #include <QUrl>
 
+#include "base/bitarray.h"
 #include "base/global.h"
 #include "base/logger.h"
 #include "base/preferences.h"
@@ -1155,20 +1155,14 @@ QVector<PeerInfo> TorrentImpl::peers() const
     return peers;
 }
 
-QBitArray TorrentImpl::pieces() const
+BitArray TorrentImpl::pieces() const
 {
-    QBitArray result(m_nativeStatus.pieces.size());
-    for (int i = 0; i < result.size(); ++i)
-    {
-        if (m_nativeStatus.pieces[lt::piece_index_t {i}])
-            result.setBit(i, true);
-    }
-    return result;
+    return m_nativeStatus.pieces;
 }
 
-QBitArray TorrentImpl::downloadingPieces() const
+BitArray TorrentImpl::downloadingPieces() const
 {
-    QBitArray result(piecesCount());
+    BitArray result {piecesCount()};
 
     std::vector<lt::partial_piece_info> queue;
     m_nativeHandle.get_download_queue(queue);

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -195,8 +195,8 @@ namespace BitTorrent
         bool isPEXDisabled() const override;
         bool isLSDDisabled() const override;
         QVector<PeerInfo> peers() const override;
-        QBitArray pieces() const override;
-        QBitArray downloadingPieces() const override;
+        BitArray pieces() const override;
+        BitArray downloadingPieces() const override;
         QVector<int> pieceAvailability() const override;
         qreal distributedCopies() const override;
         qreal maxRatio() const override;

--- a/src/gui/properties/downloadedpiecesbar.cpp
+++ b/src/gui/properties/downloadedpiecesbar.cpp
@@ -48,7 +48,7 @@ DownloadedPiecesBar::DownloadedPiecesBar(QWidget *parent)
 {
 }
 
-QVector<float> DownloadedPiecesBar::bitfieldToFloatVector(const QBitArray &vecin, int reqSize)
+QVector<float> DownloadedPiecesBar::bitfieldToFloatVector(const BitArray &vecin, int reqSize)
 {
     QVector<float> result(reqSize, 0.0);
     if (vecin.isEmpty()) return result;
@@ -169,7 +169,7 @@ bool DownloadedPiecesBar::updateImage(QImage &image)
     return true;
 }
 
-void DownloadedPiecesBar::setProgress(const QBitArray &pieces, const QBitArray &downloadedPieces)
+void DownloadedPiecesBar::setProgress(const BitArray &pieces, const BitArray &downloadedPieces)
 {
     m_pieces = pieces;
     m_downloadedPieces = downloadedPieces;

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -30,7 +30,6 @@
 
 #include <functional>
 
-#include <QBitArray>
 #include <QDir>
 #include <QJsonArray>
 #include <QJsonObject>
@@ -39,6 +38,7 @@
 #include <QRegularExpression>
 #include <QUrl>
 
+#include "base/bitarray.h"
 #include "base/bittorrent/common.h"
 #include "base/bittorrent/downloadpriority.h"
 #include "base/bittorrent/infohash.h"
@@ -586,11 +586,11 @@ void TorrentsController::pieceStatesAction()
         throw APIError(APIErrorType::NotFound);
 
     QJsonArray pieceStates;
-    const QBitArray states = torrent->pieces();
+    const BitArray states = torrent->pieces();
     for (int i = 0; i < states.size(); ++i)
         pieceStates.append(static_cast<int>(states[i]) * 2);
 
-    const QBitArray dlstates = torrent->downloadingPieces();
+    const BitArray dlstates = torrent->downloadingPieces();
     for (int i = 0; i < states.size(); ++i)
     {
         if (dlstates[i])


### PR DESCRIPTION
We really don't require to use QBitArray.
Using wrapped libtorrent bitfield will save redundant memory writes.