### PR TITLE
Use QRegularExpression instead of deprecated QRegExp

### DIFF
--- a/src/app/qtlocalpeer/qtlocalpeer.cpp
+++ b/src/app/qtlocalpeer/qtlocalpeer.cpp
@@ -79,6 +79,7 @@
 #include <QDir>
 #include <QLocalServer>
 #include <QLocalSocket>
+#include <QRegularExpression>
 
 #include "base/utils/misc.h"
 
@@ -108,7 +109,7 @@ QtLocalPeer::QtLocalPeer(QObject* parent, const QString &appId)
 #endif
         prefix = id.section(QLatin1Char('/'), -1);
     }
-    prefix.remove(QRegExp("[^a-zA-Z]"));
+    prefix.remove(QRegularExpression("[^a-zA-Z]"));
     prefix.truncate(6);
 
     QByteArray idc = id.toUtf8();

--- a/src/base/rss/rss_autodownloadrule.cpp
+++ b/src/base/rss/rss_autodownloadrule.cpp
@@ -213,10 +213,8 @@ QRegularExpression AutoDownloadRule::cachedRegex(const QString &expression, cons
     QRegularExpression &regex = m_dataPtr->cachedRegexes[expression];
     if (regex.pattern().isEmpty())
     {
-        regex = QRegularExpression
-        {
-                (isRegex ? expression : Utils::String::wildcardToRegex(expression))
-                , QRegularExpression::CaseInsensitiveOption};
+        const QString pattern = (isRegex ? expression : Utils::String::wildcardToRegexPattern(expression));
+        regex = QRegularExpression {pattern, QRegularExpression::CaseInsensitiveOption};
     }
 
     return regex;

--- a/src/base/utils/string.cpp
+++ b/src/base/utils/string.cpp
@@ -33,9 +33,14 @@
 
 #include <QCollator>
 #include <QLocale>
-#include <QRegExp>
 #include <QtGlobal>
 #include <QVector>
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#include <QRegularExpression>
+#else
+#include <QRegExp>
+#endif
 
 #if defined(Q_OS_MACOS) || defined(__MINGW32__)
 #define QBT_USES_QTHREADSTORAGE
@@ -181,14 +186,21 @@ QString Utils::String::fromDouble(const double n, const int precision)
     return QLocale::system().toString(std::floor(n * prec) / prec, 'f', precision);
 }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+QString Utils::String::wildcardToRegexPattern(const QString &pattern)
+{
+    return QRegularExpression::wildcardToRegularExpression(pattern, QRegularExpression::UnanchoredWildcardConversion);
+}
+#else
 // This is marked as internal in QRegExp.cpp, but is exported. The alternative would be to
 // copy the code from QRegExp::wc2rx().
 QString qt_regexp_toCanonical(const QString &pattern, QRegExp::PatternSyntax patternSyntax);
 
-QString Utils::String::wildcardToRegex(const QString &pattern)
+QString Utils::String::wildcardToRegexPattern(const QString &pattern)
 {
     return qt_regexp_toCanonical(pattern, QRegExp::Wildcard);
 }
+#endif
 
 std::optional<bool> Utils::String::parseBool(const QString &string)
 {

--- a/src/base/utils/string.h
+++ b/src/base/utils/string.h
@@ -50,7 +50,7 @@ namespace Utils::String
         return (naturalCompare(left, right, caseSensitivity) < 0);
     }
 
-    QString wildcardToRegex(const QString &pattern);
+    QString wildcardToRegexPattern(const QString &pattern);
 
     template <typename T>
     T unquote(const T &str, const QString &quotes = QChar('"'))

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -825,7 +825,8 @@ void PropertiesWidget::filteredFilesChanged()
 
 void PropertiesWidget::filterText(const QString &filter)
 {
-    m_propListModel->setFilterRegExp(QRegExp(filter, Qt::CaseInsensitive, QRegExp::WildcardUnix));
+    const QString pattern = Utils::String::wildcardToRegexPattern(filter);
+    m_propListModel->setFilterRegularExpression(QRegularExpression(pattern, QRegularExpression::CaseInsensitiveOption));
     if (filter.isEmpty())
     {
         m_ui->filesList->collapseAll();

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -719,10 +719,14 @@ void AutomatedRssDownloader::updateMustLineValidity()
     {
         QStringList tokens;
         if (isRegex)
+        {
             tokens << text;
+        }
         else
+        {
             for (const QString &token : asConst(text.split('|')))
-                tokens << Utils::String::wildcardToRegex(token);
+                tokens << Utils::String::wildcardToRegexPattern(token);
+        }
 
         for (const QString &token : asConst(tokens))
         {
@@ -762,10 +766,14 @@ void AutomatedRssDownloader::updateMustNotLineValidity()
     {
         QStringList tokens;
         if (isRegex)
+        {
             tokens << text;
+        }
         else
+        {
             for (const QString &token : asConst(text.split('|')))
-                tokens << Utils::String::wildcardToRegex(token);
+                tokens << Utils::String::wildcardToRegexPattern(token);
+        }
 
         for (const QString &token : asConst(tokens))
         {

--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -365,9 +365,9 @@ void SearchJobWidget::fillFilterComboBoxes()
 
 void SearchJobWidget::filterSearchResults(const QString &name)
 {
-    const QRegExp::PatternSyntax patternSyntax = Preferences::instance()->getRegexAsFilteringPatternForSearchJob()
-                    ? QRegExp::RegExp : QRegExp::WildcardUnix;
-    m_proxyModel->setFilterRegExp(QRegExp(name, Qt::CaseInsensitive, patternSyntax));
+    const QString pattern = (Preferences::instance()->getRegexAsFilteringPatternForSearchJob()
+                    ? name : Utils::String::wildcardToRegexPattern(name));
+    m_proxyModel->setFilterRegularExpression(QRegularExpression(pattern, QRegularExpression::CaseInsensitiveOption));
     updateResultsCount();
 }
 

--- a/src/gui/torrentcontentfiltermodel.cpp
+++ b/src/gui/torrentcontentfiltermodel.cpp
@@ -129,7 +129,7 @@ bool TorrentContentFilterModel::hasFiltered(const QModelIndex &folder) const
     // this should be called only with folders
     // check if the folder name itself matches the filter string
     QString name = folder.data().toString();
-    if (name.contains(filterRegExp()))
+    if (name.contains(filterRegularExpression()))
         return true;
     for (int child = 0; child < m_model->rowCount(folder); ++child)
     {
@@ -141,7 +141,7 @@ bool TorrentContentFilterModel::hasFiltered(const QModelIndex &folder) const
             continue;
         }
         name = childIndex.data().toString();
-        if (name.contains(filterRegExp()))
+        if (name.contains(filterRegularExpression()))
             return true;
     }
 

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -36,7 +36,6 @@
 #include <QHeaderView>
 #include <QMenu>
 #include <QMessageBox>
-#include <QRegExp>
 #include <QRegularExpression>
 #include <QSet>
 #include <QShortcut>
@@ -1131,9 +1130,9 @@ void TransferListWidget::applyTrackerFilter(const QSet<BitTorrent::TorrentID> &t
 
 void TransferListWidget::applyNameFilter(const QString &name)
 {
-    const QRegExp::PatternSyntax patternSyntax = Preferences::instance()->getRegexAsFilteringPatternForTransferList()
-                ? QRegExp::RegExp : QRegExp::WildcardUnix;
-    m_sortFilterModel->setFilterRegExp(QRegExp(name, Qt::CaseInsensitive, patternSyntax));
+    const QString pattern = (Preferences::instance()->getRegexAsFilteringPatternForTransferList()
+                ? name : Utils::String::wildcardToRegexPattern(name));
+    m_sortFilterModel->setFilterRegularExpression(QRegularExpression(pattern, QRegularExpression::CaseInsensitiveOption));
 }
 
 void TransferListWidget::applyStatusFilter(int f)

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -38,7 +38,7 @@
 #include <QMimeDatabase>
 #include <QMimeType>
 #include <QNetworkCookie>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QUrl>
 
 #include "base/algorithm.h"
@@ -693,7 +693,7 @@ bool WebApplication::validateHostHeader(const QStringList &domains) const
     // try matching host header with domain list
     for (const auto &domain : domains)
     {
-        QRegExp domainRegex(domain, Qt::CaseInsensitive, QRegExp::Wildcard);
+        const QRegularExpression domainRegex {Utils::String::wildcardToRegexPattern(domain), QRegularExpression::CaseInsensitiveOption};
         if (requestHost.contains(domainRegex))
             return true;
     }


### PR DESCRIPTION
Now wildcard filters follow closely the definition of wildcard for glob patterns. The backslash (\) character is not an escape char in this context. In order to match one of the special characters, place it in square brackets (for example, [?]). So it should be mentioned in release notes.

P.S. This makes current codebase more compatible with Qt 6.