### PR TITLE
Show progress bar in disabled state for paused torrents

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -11,7 +11,7 @@ qBittorrent - A BitTorrent client in C++ / Qt
 
   - OpenSSL >= 1.1.1
 
-  - Qt >= 5.9.5
+  - Qt >= 5.12
 
   - zlib >= 1.2.11
 

--- a/src/gui/transferlistdelegate.cpp
+++ b/src/gui/transferlistdelegate.cpp
@@ -68,9 +68,30 @@ void TransferListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     {
     case TransferListModel::TR_PROGRESS:
         {
+            using namespace BitTorrent;
+
+            const auto isEnableState = [](const TorrentState state) -> bool
+            {
+                switch (state)
+                {
+                case TorrentState::Error:
+                case TorrentState::PausedDownloading:
+                case TorrentState::Unknown:
+                    return false;
+                default:
+                    return true;
+                }
+            };
+
             const int progress = static_cast<int>(index.data(TransferListModel::UnderlyingDataRole).toReal());
 
-            m_progressBarPainter.paint(painter, option, index.data().toString(), progress);
+            const QModelIndex statusIndex = index.siblingAtColumn(TransferListModel::TR_STATUS);
+            const auto torrentState = statusIndex.data(TransferListModel::UnderlyingDataRole).value<TorrentState>();
+
+            QStyleOptionViewItem customOption {option};
+            customOption.state.setFlag(QStyle::State_Enabled, isEnableState(torrentState));
+
+            m_progressBarPainter.paint(painter, customOption, index.data().toString(), progress);
         }
         break;
     default:

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -498,7 +498,7 @@ QVariant TransferListModel::data(const QModelIndex &index, const int role) const
     case Qt::DisplayRole:
         return displayValue(torrent, index.column());
     case UnderlyingDataRole:
-        return internalValue(torrent, index.column());
+        return internalValue(torrent, index.column(), false);
     case AdditionalUnderlyingDataRole:
         return internalValue(torrent, index.column(), true);
     case Qt::DecorationRole:

--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -110,7 +110,7 @@ private slots:
 private:
     void configure();
     QString displayValue(const BitTorrent::Torrent *torrent, int column) const;
-    QVariant internalValue(const BitTorrent::Torrent *torrent, int column, bool alt = false) const;
+    QVariant internalValue(const BitTorrent::Torrent *torrent, int column, bool alt) const;
 
     QList<BitTorrent::Torrent *> m_torrentList;  // maps row number to torrent handle
     QHash<BitTorrent::Torrent *, int> m_torrentMap;  // maps torrent handle to row number


### PR DESCRIPTION
Transfer list screenshot:
![screenshot](https://user-images.githubusercontent.com/9395168/111571960-a83f2000-87e2-11eb-8caf-ce4a3a4a5696.png)

@qbittorrent/bug-handlers 
Any comment on this visual change?