### PR TITLE
Clarify that the license is GPLv2+

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,19 +17,23 @@ Contributors:
 * Nick Tiskov <daymansmail@gmail.com>
 
 Code from other projects:
-* files src/qtsingleapplication/* src/lineedit/*
+* files src/app/qtlocalpeer/*
   copyright: Nokia Corporation
-  license: LGPL
+  license: mixed
 
-* files src/ico.cpp src/ico.h
-  copyright: Malte Starostik <malte@kde.org>
-  license: LGPL
+* files src/gui/lineedit.*
+  copyright: Trolltech ASA <info@trolltech.com>
+  license: custom
 
 * files src/search_engine/socks.py
   copyright: Dan Haim <negativeiq@users.sourceforge.net>
   license: BSD
 
-* file src/stacktrace_win.h
+* file src/app/stacktrace.h
+  copyright: Timo Bingmann from http://idlebox.net/
+  license: WTFPL v2.0
+
+* file src/app/stacktrace_win.h
   copyright: Quassel Project
   license: GPLv2/3
 

--- a/COPYING
+++ b/COPYING
@@ -1,5 +1,6 @@
-qBittorrent is licensed under the GNU General Public License version 2 with the
-addition of the following special exception:
+qBittorrent is licensed under the GNU General Public License either version 2,
+or (at your option) any later version with the addition of the following
+special exception:
 
 In addition, as a special exception, the copyright holders give permission to
 link this program with the OpenSSL project's "OpenSSL" library (or with
@@ -9,6 +10,8 @@ License in all respects for all of the code used other than "OpenSSL".  If you
 modify file(s), you may extend this exception to your version of the file(s),
 but you are not obligated to do so. If you do not wish to do so, delete this
 exception statement from your version.
+
+See also the AUTHORS file
 
 ----------
 

--- a/src/gui/gpl.html
+++ b/src/gui/gpl.html
@@ -5,8 +5,8 @@
     <title>License</title>
 </head>
 <body>
-<p>qBittorrent is licensed under the GNU General Public License version 2 with the
-addition of the following special exception:</p>
+<p>qBittorrent is licensed under the GNU General Public License either version 2,
+or (at your option) any later version with the addition of the following special exception:</p>
 <p>
 In addition, as a special exception, the copyright holders give permission to
 link this program with the OpenSSL project's "OpenSSL" library (or with

--- a/src/webui/www/private/views/about.html
+++ b/src/webui/www/private/views/about.html
@@ -130,8 +130,8 @@
 </div>
 
 <div id="aboutLicenseContent" class="aboutTabContent invisible">
-    <p>qBittorrent is licensed under the GNU General Public License version 2 with the
-        addition of the following special exception:</p>
+    <p>qBittorrent is licensed under the GNU General Public License either version 2,
+        or (at your option) any later version with the addition of the following special exception:</p>
     <p>
         In addition, as a special exception, the copyright holders give permission to
         link this program with the OpenSSL project's "OpenSSL" library (or with


### PR DESCRIPTION
Regarding this license clarification there are 3 commits of interest
(commits A, B, C). Before commit A the COPYING file contained only the
text of the GPLv2 license, while all source files had a license block
at the top saying that they are under the terms of "GPLv2 or later". With
commit A there was a temporary change to GPLv3. The COPYING file contained
only the text of the GPLv3 license, while all source files had a license
block at the top saying that they are under the terms of "GPLv3 or later".
Then with commit B the COPYING file and the license block of the source
files was reverted to their state before commit A. Afterwards, with
commit C a license summary(or clarification) block was put at the top of
the COPYING file. This block indicated that the license was GPLv2 without
having the "or later" clause and it also included the OpenSSL exception.
However, the license block of each source file continued to contain the
"or later" clause which was not removed. The same license block continues
to exist in all current source files. Thus it is concluded that the ommision
of the "or later" clause with commit C in the COPYING file was accidental.
~OR ALTERNATIVELY (OR IN ADDITION)
Maybe with commits B and C it was decided that the license of the
project(qBittorrent) as a whole/bundle was indeed GPLv2 only, while the
individual source files were to remain as GPLv2+ so any 3rd party could
use them under the more relaxed GPLv2+ terms. It should be noted that new
code and source files also have had the GPLv2+ terms. So from this point
on we exercise the same rights the 3rd parties have and choose GPLv2+ terms
for the project too.~
OR ALTERNATIVELY (OR IN ADDITION)
At the time commit C was made Christophe Dumez was not the sole contributor.
There is no record that the other contributors agreed with the supposed
GPLv2 only change or that there was a Contributor License Agreement,
transfering their rights to him. Thus making his license change decision
invalid/void/illegal.

Commit A: 54f9375b325cc03f8d5da9abbf6c4e25e8ee698f
Commit B: 8df61db644a7fcb19170d60da3b7b5297215439c
Commit C: 9835af49627e65d314668387b6ec9d029707c186