### PR TITLE
Wrap "resume data" in LoadTorrentParams

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -44,6 +44,7 @@
 #include <libtorrent/alert_types.hpp>
 #include <libtorrent/bdecode.hpp>
 #include <libtorrent/bencode.hpp>
+#include <libtorrent/entry.hpp>
 #include <libtorrent/error_code.hpp>
 #include <libtorrent/extensions/smart_ban.hpp>
 #include <libtorrent/extensions/ut_metadata.hpp>
@@ -55,6 +56,7 @@
 #include <libtorrent/session_stats.hpp>
 #include <libtorrent/session_status.hpp>
 #include <libtorrent/torrent_info.hpp>
+#include <libtorrent/write_resume_data.hpp>
 
 #include <QDebug>
 #include <QDir>
@@ -301,6 +303,17 @@ namespace
                 return upper;
             return value;
         };
+    }
+
+    using ListType = lt::entry::list_type;
+
+    ListType setToEntryList(const QSet<QString> &input)
+    {
+        ListType entryList;
+        entryList.reserve(input.size());
+        for (const QString &setValue : input)
+            entryList.emplace_back(setValue.toStdString());
+        return entryList;
     }
 
 #ifdef Q_OS_WIN
@@ -3926,16 +3939,52 @@ void Session::handleTorrentFinished(TorrentImpl *const torrent)
         emit allTorrentsFinished();
 }
 
-void Session::handleTorrentResumeDataReady(TorrentImpl *const torrent, const std::shared_ptr<lt::entry> &data)
+void Session::handleTorrentResumeDataReady(TorrentImpl *const torrent, const LoadTorrentParams &data)
 {
     --m_numResumeData;
+
+    // We need to adjust native libtorrent resume data
+    lt::add_torrent_params p = data.ltAddTorrentParams;
+    p.save_path = Profile::instance()->toPortablePath(QString::fromStdString(p.save_path)).toStdString();
+    if (data.paused)
+    {
+        p.flags |= lt::torrent_flags::paused;
+        p.flags &= ~lt::torrent_flags::auto_managed;
+    }
+    else
+    {
+        // Torrent can be actually "running" but temporarily "paused" to perform some
+        // service jobs behind the scenes so we need to restore it as "running"
+        if (!data.forced)
+        {
+            p.flags |= lt::torrent_flags::auto_managed;
+        }
+        else
+        {
+            p.flags &= ~lt::torrent_flags::paused;
+            p.flags &= ~lt::torrent_flags::auto_managed;
+        }
+    }
 
     // Separated thread is used for the blocking IO which results in slow processing of many torrents.
     // Copying lt::entry objects around isn't cheap.
 
+    auto resumeDataPtr = std::make_shared<lt::entry>(lt::write_resume_data(p));
+    lt::entry &resumeData = *resumeDataPtr;
+
+    resumeData["qBt-savePath"] = Profile::instance()->toPortablePath(data.savePath).toStdString();
+    resumeData["qBt-ratioLimit"] = static_cast<int>(data.ratioLimit * 1000);
+    resumeData["qBt-seedingTimeLimit"] = data.seedingTimeLimit;
+    resumeData["qBt-category"] = data.category.toStdString();
+    resumeData["qBt-tags"] = setToEntryList(data.tags);
+    resumeData["qBt-name"] = data.name.toStdString();
+    resumeData["qBt-seedStatus"] = data.hasSeedStatus;
+    resumeData["qBt-contentLayout"] = Utils::String::fromEnum(data.contentLayout).toStdString();
+    resumeData["qBt-firstLastPiecePriority"] = data.firstLastPiecePriority;
+
     const QString filename = QString::fromLatin1("%1.fastresume").arg(torrent->id().toString());
     QMetaObject::invokeMethod(m_resumeDataSavingManager
-        , [this, filename, data]() { m_resumeDataSavingManager->save(filename, data); });
+        , [this, filename, resumeDataPtr]() { m_resumeDataSavingManager->save(filename, resumeDataPtr); });
 }
 
 void Session::handleTorrentTrackerReply(TorrentImpl *const torrent, const QString &trackerUrl)

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -4253,51 +4253,7 @@ bool Session::loadTorrentResumeData(const QByteArray &data, const TorrentInfo &m
 
     const bool hasMetadata = (p.ti && p.ti->is_valid());
     if (!hasMetadata && !root.dict_find("info-hash"))
-    {
-        // TODO: The following code is deprecated. Remove after several releases in 4.3.x.
-        // === BEGIN DEPRECATED CODE === //
-        // Try to load from legacy data used in older versions for torrents w/o metadata
-        const lt::bdecode_node magnetURINode = root.dict_find("qBt-magnetUri");
-        if (magnetURINode.type() == lt::bdecode_node::string_t)
-        {
-            lt::parse_magnet_uri(magnetURINode.string_value(), p, ec);
-
-            if (isTempPathEnabled())
-            {
-                p.save_path = Utils::Fs::toNativePath(tempPath()).toStdString();
-            }
-            else
-            {
-                // If empty then Automatic mode, otherwise Manual mode
-                const QString savePath = torrentParams.savePath.isEmpty() ? categorySavePath(torrentParams.category) : torrentParams.savePath;
-                p.save_path = Utils::Fs::toNativePath(savePath).toStdString();
-            }
-
-            // Preallocation mode
-            p.storage_mode = (isPreallocationEnabled() ? lt::storage_mode_allocate : lt::storage_mode_sparse);
-
-            const lt::bdecode_node addedTimeNode = root.dict_find("qBt-addedTime");
-            if (addedTimeNode.type() == lt::bdecode_node::int_t)
-                p.added_time = addedTimeNode.int_value();
-
-            const lt::bdecode_node sequentialNode = root.dict_find("qBt-sequential");
-            if (sequentialNode.type() == lt::bdecode_node::int_t)
-            {
-                if (static_cast<bool>(sequentialNode.int_value()))
-                    p.flags |= lt::torrent_flags::sequential_download;
-                else
-                    p.flags &= ~lt::torrent_flags::sequential_download;
-            }
-
-            if (torrentParams.name.isEmpty() && !p.name.empty())
-                torrentParams.name = QString::fromStdString(p.name);
-        }
-        // === END DEPRECATED CODE === //
-        else
-        {
-            return false;
-        }
-    }
+        return false;
 
     return true;
 }

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -484,7 +484,7 @@ namespace BitTorrent
         void handleTorrentTrackersChanged(TorrentImpl *const torrent);
         void handleTorrentUrlSeedsAdded(TorrentImpl *const torrent, const QVector<QUrl> &newUrlSeeds);
         void handleTorrentUrlSeedsRemoved(TorrentImpl *const torrent, const QVector<QUrl> &urlSeeds);
-        void handleTorrentResumeDataReady(TorrentImpl *const torrent, const std::shared_ptr<lt::entry> &data);
+        void handleTorrentResumeDataReady(TorrentImpl *const torrent, const LoadTorrentParams &data);
         void handleTorrentTrackerReply(TorrentImpl *const torrent, const QString &trackerUrl);
         void handleTorrentTrackerWarning(TorrentImpl *const torrent, const QString &trackerUrl);
         void handleTorrentTrackerError(TorrentImpl *const torrent, const QString &trackerUrl);

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -1676,6 +1676,9 @@ void TorrentImpl::handleTorrentCheckedAlert(const lt::torrent_checked_alert *p)
         return;
     }
 
+    if (m_nativeHandle.need_save_resume_data())
+        m_session->handleTorrentNeedSaveResumeData(this);
+
     if (m_fastresumeDataRejected && !m_hasMissingFiles)
         m_fastresumeDataRejected = false;
 

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -1797,23 +1797,6 @@ void TorrentImpl::handleSaveResumeDataAlert(const lt::save_resume_data_alert *p)
     auto resumeDataPtr = std::make_shared<lt::entry>(lt::write_resume_data(m_ltAddTorrentParams));
     lt::entry &resumeData = *resumeDataPtr;
 
-    // TODO: The following code is deprecated. Remove after several releases in 4.3.x.
-    // === BEGIN DEPRECATED CODE === //
-    const bool useDummyResumeData = !hasMetadata();
-    if (useDummyResumeData)
-    {
-        updateStatus();
-
-        resumeData["qBt-magnetUri"] = createMagnetURI().toStdString();
-        // sequentialDownload needs to be stored in the
-        // resume data if there is no metadata, otherwise they won't be
-        // restored if qBittorrent quits before the metadata are retrieved:
-        resumeData["qBt-sequential"] = isSequentialDownload();
-
-        resumeData["qBt-addedTime"] = addedTime().toSecsSinceEpoch();
-    }
-    // === END DEPRECATED CODE === //
-
     resumeData["qBt-savePath"] = m_useAutoTMM ? "" : Profile::instance()->toPortablePath(m_savePath).toStdString();
     resumeData["qBt-ratioLimit"] = static_cast<int>(m_ratioLimit * 1000);
     resumeData["qBt-seedingTimeLimit"] = m_seedingTimeLimit;

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -39,13 +39,11 @@
 
 #include <libtorrent/address.hpp>
 #include <libtorrent/alert_types.hpp>
-#include <libtorrent/entry.hpp>
 #include <libtorrent/magnet_uri.hpp>
 #include <libtorrent/session.hpp>
 #include <libtorrent/storage_defs.hpp>
 #include <libtorrent/time.hpp>
 #include <libtorrent/version.hpp>
-#include <libtorrent/write_resume_data.hpp>
 
 #if (LIBTORRENT_VERSION_NUM >= 20000)
 #include <libtorrent/info_hash.hpp>
@@ -61,7 +59,6 @@
 #include "base/global.h"
 #include "base/logger.h"
 #include "base/preferences.h"
-#include "base/profile.h"
 #include "base/utils/fs.h"
 #include "base/utils/string.h"
 #include "common.h"
@@ -89,16 +86,6 @@ namespace
                         static_cast<LTUnderlyingType<lt::download_priority_t>>(priority));
         });
         return out;
-    }
-
-    using ListType = lt::entry::list_type;
-
-    ListType setToEntryList(const QSet<QString> &input)
-    {
-        ListType entryList;
-        for (const QString &setValue : input)
-            entryList.emplace_back(setValue.toStdString());
-        return entryList;
     }
 
     lt::announce_entry makeNativeAnnouncerEntry(const QString &url, const int tier)
@@ -1759,29 +1746,7 @@ void TorrentImpl::handleSaveResumeDataAlert(const lt::save_resume_data_alert *p)
         m_ltAddTorrentParams = p->params;
     }
 
-    if (m_isStopped)
-    {
-        m_ltAddTorrentParams.flags |= lt::torrent_flags::paused;
-        m_ltAddTorrentParams.flags &= ~lt::torrent_flags::auto_managed;
-    }
-    else
-    {
-        // Torrent can be actually "running" but temporarily "paused" to perform some
-        // service jobs behind the scenes so we need to restore it as "running"
-        if (m_operatingMode == TorrentOperatingMode::AutoManaged)
-        {
-            m_ltAddTorrentParams.flags |= lt::torrent_flags::auto_managed;
-        }
-        else
-        {
-            m_ltAddTorrentParams.flags &= ~lt::torrent_flags::paused;
-            m_ltAddTorrentParams.flags &= ~lt::torrent_flags::auto_managed;
-        }
-    }
-
     m_ltAddTorrentParams.added_time = addedTime().toSecsSinceEpoch();
-    m_ltAddTorrentParams.save_path = Profile::instance()->toPortablePath(
-                QString::fromStdString(m_ltAddTorrentParams.save_path)).toStdString();
 
     if (m_maintenanceJob == MaintenanceJob::HandleMetadata)
     {
@@ -1794,20 +1759,21 @@ void TorrentImpl::handleSaveResumeDataAlert(const lt::save_resume_data_alert *p)
         m_session->findIncompleteFiles(metadata, m_savePath);
     }
 
-    auto resumeDataPtr = std::make_shared<lt::entry>(lt::write_resume_data(m_ltAddTorrentParams));
-    lt::entry &resumeData = *resumeDataPtr;
+    LoadTorrentParams resumeData;
+    resumeData.name = m_name;
+    resumeData.category = m_category;
+    resumeData.savePath = m_useAutoTMM ? "" : m_savePath;
+    resumeData.tags = m_tags;
+    resumeData.contentLayout = m_contentLayout;
+    resumeData.ratioLimit = m_ratioLimit;
+    resumeData.seedingTimeLimit = m_seedingTimeLimit;
+    resumeData.firstLastPiecePriority = m_hasFirstLastPiecePriority;
+    resumeData.hasSeedStatus = m_hasSeedStatus;
+    resumeData.paused = m_isStopped;
+    resumeData.forced = (m_operatingMode == TorrentOperatingMode::Forced);
+    resumeData.ltAddTorrentParams = m_ltAddTorrentParams;
 
-    resumeData["qBt-savePath"] = m_useAutoTMM ? "" : Profile::instance()->toPortablePath(m_savePath).toStdString();
-    resumeData["qBt-ratioLimit"] = static_cast<int>(m_ratioLimit * 1000);
-    resumeData["qBt-seedingTimeLimit"] = m_seedingTimeLimit;
-    resumeData["qBt-category"] = m_category.toStdString();
-    resumeData["qBt-tags"] = setToEntryList(m_tags);
-    resumeData["qBt-name"] = m_name.toStdString();
-    resumeData["qBt-seedStatus"] = m_hasSeedStatus;
-    resumeData["qBt-contentLayout"] = Utils::String::fromEnum(m_contentLayout).toStdString();
-    resumeData["qBt-firstLastPiecePriority"] = m_hasFirstLastPiecePriority;
-
-    m_session->handleTorrentResumeDataReady(this, resumeDataPtr);
+    m_session->handleTorrentResumeDataReady(this, resumeData);
 }
 
 void TorrentImpl::handleSaveResumeDataFailedAlert(const lt::save_resume_data_failed_alert *p)

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -68,7 +68,6 @@ namespace BitTorrent
         bool forced = false;
         bool paused = false;
 
-
         qreal ratioLimit = Torrent::USE_GLOBAL_RATIO;
         int seedingTimeLimit = Torrent::USE_GLOBAL_SEEDING_TIME;
 


### PR DESCRIPTION
Provide all the "resume data" in raw form, which will allow to save it in different ways in the future, for example, in SQLite database driven storage (WIP).