### PR TITLE
Improve the initialization process

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -143,11 +143,7 @@ Application::Application(int &argc, char **argv)
     QPixmapCache::setCacheLimit(PIXMAP_CACHE_SIZE);
 #endif
 
-#if !defined(Q_OS_WIN) || defined(DISABLE_GUI)
     const bool endInit = (m_commandLineArgs.showVersion || m_commandLineArgs.showHelp || !m_commandLineArgs.unknownParameter.isEmpty());
-#else
-    const bool endInit = (m_commandLineArgs.showHelp || !m_commandLineArgs.unknownParameter.isEmpty());
-#endif
 
     if (endInit)
         return;

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -134,9 +134,6 @@ Application::Application(int &argc, char **argv)
     , m_shutdownAct(ShutdownDialogAction::Exit)
     , m_commandLineArgs(parseCommandLine(this->arguments()))
 {
-    qRegisterMetaType<Log::Msg>("Log::Msg");
-    qRegisterMetaType<Log::Peer>("Log::Peer");
-
     setApplicationName("qBittorrent");
     setOrganizationDomain("qbittorrent.org");
 #if !defined(DISABLE_GUI)
@@ -145,6 +142,18 @@ Application::Application(int &argc, char **argv)
     setQuitOnLastWindowClosed(false);
     QPixmapCache::setCacheLimit(PIXMAP_CACHE_SIZE);
 #endif
+
+#if !defined(Q_OS_WIN) || defined(DISABLE_GUI)
+    const bool endInit = (m_commandLineArgs.showVersion || m_commandLineArgs.showHelp || !m_commandLineArgs.unknownParameter.isEmpty());
+#else
+    const bool endInit = (m_commandLineArgs.showHelp || !m_commandLineArgs.unknownParameter.isEmpty());
+#endif
+
+    if (endInit)
+        return;
+
+    qRegisterMetaType<Log::Msg>("Log::Msg");
+    qRegisterMetaType<Log::Peer>("Log::Peer");
 
     const bool portableModeEnabled = m_commandLineArgs.profileDir.isEmpty()
             && QDir(QCoreApplication::applicationDirPath()).exists(DEFAULT_PORTABLE_MODE_PROFILE_DIR);

--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -342,9 +342,7 @@ QBtCommandLineParameters::QBtCommandLineParameters(const QProcessEnvironment &en
     , skipChecking(SKIP_HASH_CHECK_OPTION.value(env))
     , sequential(SEQUENTIAL_OPTION.value(env))
     , firstLastPiecePriority(FIRST_AND_LAST_OPTION.value(env))
-#if !defined(Q_OS_WIN) || defined(DISABLE_GUI)
     , showVersion(false)
-#endif
 #ifndef DISABLE_GUI
     , noSplash(NO_SPLASH_OPTION.value(env))
 #elif !defined(Q_OS_WIN)
@@ -412,12 +410,10 @@ QBtCommandLineParameters parseCommandLine(const QStringList &args)
             {
                 result.showHelp = true;
             }
-#if !defined(Q_OS_WIN) || defined(DISABLE_GUI)
             else if (arg == SHOW_VERSION_OPTION)
             {
                 result.showVersion = true;
             }
-#endif
             else if (arg == WEBUI_PORT_OPTION)
             {
                 result.webUiPort = WEBUI_PORT_OPTION.value(arg);
@@ -541,9 +537,7 @@ QString makeUsage(const QString &prgName)
     stream << indentation << prgName << QLatin1String(" [options] [(<filename> | <url>)...]") << '\n';
 
     stream << QObject::tr("Options:") << '\n';
-#if !defined(Q_OS_WIN) || defined(DISABLE_GUI)
     stream << SHOW_VERSION_OPTION.usage() << wrapText(QObject::tr("Display program version and exit")) << '\n';
-#endif
     stream << SHOW_HELP_OPTION.usage() << wrapText(QObject::tr("Display this help message and exit")) << '\n';
     stream << WEBUI_PORT_OPTION.usage(QObject::tr("port"))
            << wrapText(QObject::tr("Change the Web UI port"))

--- a/src/app/cmdoptions.h
+++ b/src/app/cmdoptions.h
@@ -45,9 +45,7 @@ struct QBtCommandLineParameters
     bool skipChecking;
     bool sequential;
     bool firstLastPiecePriority;
-#if !defined(Q_OS_WIN) || defined(DISABLE_GUI)
     bool showVersion;
-#endif
 #ifndef DISABLE_GUI
     bool noSplash;
 #elif !defined(Q_OS_WIN)

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
                                                         "--random-parameter is an unknown command line parameter.")
                                                         .arg(params.unknownParameter));
         }
-#if !defined(Q_OS_WIN) || defined(DISABLE_GUI)
+
         if (params.showVersion)
         {
             if (isOneArg)
@@ -166,7 +166,7 @@ int main(int argc, char *argv[])
             throw CommandLineParameterError(QObject::tr("%1 must be the single command line parameter.")
                                      .arg(QLatin1String("-v (or --version)")));
         }
-#endif
+
         if (params.showHelp)
         {
             if (isOneArg)


### PR DESCRIPTION
Perform some initializations of qApplication after parsing -v and -h, which will avoid generating unnecessary files in some cases.