### PR TITLE
Fix tabChangesFocus attribute in "Edit trackers" dialog

### DIFF
--- a/src/gui/trackerentriesdialog.ui
+++ b/src/gui/trackerentriesdialog.ui
@@ -28,9 +28,9 @@
    </item>
    <item>
     <widget class="QPlainTextEdit" name="plainTextEdit">
-     <attribute name="tabChangesFocus">
+     <property name="tabChangesFocus">
       <bool>true</bool>
-     </attribute>
+     </property>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
I'm terribly sorry. I must have been asleep while pushing commits for my last pull request.

The XML of the "Edit trackers" dialog should say `<property...` but it said `<attribute...`

This is to fix that.