### PR TITLE
Improve ResumeDataStorage

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(qbt_base STATIC
     bittorrent/abstractfilestorage.h
     bittorrent/addtorrentparams.h
     bittorrent/bandwidthscheduler.h
+    bittorrent/bencoderesumedatastorage.h
     bittorrent/cachestatus.h
     bittorrent/common.h
     bittorrent/customstorage.h
@@ -94,6 +95,7 @@ add_library(qbt_base STATIC
     asyncfilestorage.cpp
     bittorrent/abstractfilestorage.cpp
     bittorrent/bandwidthscheduler.cpp
+    bittorrent/bencoderesumedatastorage.cpp
     bittorrent/customstorage.cpp
     bittorrent/downloadpriority.cpp
     bittorrent/filesearcher.cpp
@@ -105,7 +107,6 @@ add_library(qbt_base STATIC
     bittorrent/peeraddress.cpp
     bittorrent/peerinfo.cpp
     bittorrent/portforwarderimpl.cpp
-    bittorrent/resumedatastorage.cpp
     bittorrent/session.cpp
     bittorrent/speedmonitor.cpp
     bittorrent/statistics.cpp

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -4,6 +4,7 @@ HEADERS += \
     $$PWD/bittorrent/abstractfilestorage.h \
     $$PWD/bittorrent/addtorrentparams.h \
     $$PWD/bittorrent/bandwidthscheduler.h \
+    $$PWD/bittorrent/bencoderesumedatastorage.h \
     $$PWD/bittorrent/cachestatus.h \
     $$PWD/bittorrent/common.h \
     $$PWD/bittorrent/customstorage.h \
@@ -94,6 +95,7 @@ SOURCES += \
     $$PWD/asyncfilestorage.cpp \
     $$PWD/bittorrent/abstractfilestorage.cpp \
     $$PWD/bittorrent/bandwidthscheduler.cpp \
+    $$PWD/bittorrent/bencoderesumedatastorage.cpp \
     $$PWD/bittorrent/customstorage.cpp \
     $$PWD/bittorrent/downloadpriority.cpp \
     $$PWD/bittorrent/filesearcher.cpp \
@@ -105,7 +107,6 @@ SOURCES += \
     $$PWD/bittorrent/peeraddress.cpp \
     $$PWD/bittorrent/peerinfo.cpp \
     $$PWD/bittorrent/portforwarderimpl.cpp \
-    $$PWD/bittorrent/resumedatastorage.cpp \
     $$PWD/bittorrent/session.cpp \
     $$PWD/bittorrent/speedmonitor.cpp \
     $$PWD/bittorrent/statistics.cpp \

--- a/src/base/bittorrent/resumedatastorage.h
+++ b/src/base/bittorrent/resumedatastorage.h
@@ -30,19 +30,14 @@
 
 #include <optional>
 
-#include <libtorrent/fwd.hpp>
-
-#include <QDir>
+#include <QtContainerFwd>
 #include <QObject>
-#include <QVector>
-
-#include "infohash.h"
-#include "loadtorrentparams.h"
-
-class QByteArray;
 
 namespace BitTorrent
 {
+    class TorrentID;
+    struct LoadTorrentParams;
+
     class ResumeDataStorage : public QObject
     {
         Q_OBJECT
@@ -56,26 +51,5 @@ namespace BitTorrent
         virtual void store(const TorrentID &id, const LoadTorrentParams &resumeData) const = 0;
         virtual void remove(const TorrentID &id) const = 0;
         virtual void storeQueue(const QVector<TorrentID> &queue) const = 0;
-    };
-
-    class BencodeResumeDataStorage final : public ResumeDataStorage
-    {
-        Q_OBJECT
-        Q_DISABLE_COPY(BencodeResumeDataStorage)
-
-    public:
-        explicit BencodeResumeDataStorage(const QString &resumeFolderPath);
-
-        QVector<TorrentID> registeredTorrents() const override;
-        std::optional<LoadTorrentParams> load(const TorrentID &id) const override;
-        void store(const TorrentID &id, const LoadTorrentParams &resumeData) const override;
-        void remove(const TorrentID &id) const override;
-        void storeQueue(const QVector<TorrentID> &queue) const override;
-
-    private:
-        std::optional<LoadTorrentParams> loadTorrentResumeData(const QByteArray &data, const TorrentInfo &metadata) const;
-
-        const QDir m_resumeDataDir;
-        QVector<TorrentID> m_registeredTorrents;
     };
 }

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -85,15 +85,16 @@
 #include "base/utils/random.h"
 #include "base/version.h"
 #include "bandwidthscheduler.h"
+#include "bencoderesumedatastorage.h"
 #include "common.h"
 #include "customstorage.h"
 #include "filesearcher.h"
 #include "filterparserthread.h"
+#include "loadtorrentparams.h"
 #include "ltunderlyingtype.h"
 #include "magneturi.h"
 #include "nativesessionextension.h"
 #include "portforwarderimpl.h"
-#include "resumedatastorage.h"
 #include "statistics.h"
 #include "torrentimpl.h"
 #include "tracker.h"
@@ -103,7 +104,6 @@ using namespace BitTorrent;
 namespace
 {
     const char PEER_ID[] = "qB";
-    const char RESUME_FOLDER[] = "BT_backup";
     const char USER_AGENT[] = "qBittorrent/" QBT_VERSION_2;
 
     void torrentQueuePositionUp(const lt::torrent_handle &handle)
@@ -439,7 +439,6 @@ Session::Session(QObject *parent)
 #if defined(Q_OS_WIN)
     , m_OSMemoryPriority(BITTORRENT_KEY("OSMemoryPriority"), OSMemoryPriority::BelowNormal)
 #endif
-    , m_resumeFolderLock {new QFile {this}}
     , m_seedingLimitTimer {new QTimer {this}}
     , m_resumeDataTimer {new QTimer {this}}
     , m_statistics {new Statistics {this}}
@@ -980,9 +979,6 @@ Session::~Session()
 
     m_ioThread->quit();
     m_ioThread->wait();
-
-    m_resumeFolderLock->close();
-    m_resumeFolderLock->remove();
 }
 
 void Session::initInstance()
@@ -1844,10 +1840,7 @@ bool Session::deleteTorrent(const TorrentID &id, const DeleteOption deleteOption
     }
 
     // Remove it from torrent resume directory
-    QMetaObject::invokeMethod(m_resumeDataStorage, [this, torrentID = torrent->id()]()
-    {
-        m_resumeDataStorage->remove(torrentID);
-    });
+    m_resumeDataStorage->remove(torrent->id());
 
     delete torrent;
     return true;
@@ -2061,8 +2054,8 @@ LoadTorrentParams Session::initLoadTorrentParams(const AddTorrentParams &addTorr
     loadTorrentParams.firstLastPiecePriority = addTorrentParams.firstLastPiecePriority;
     loadTorrentParams.hasSeedStatus = addTorrentParams.skipChecking; // do not react on 'torrent_finished_alert' when skipping
     loadTorrentParams.contentLayout = addTorrentParams.contentLayout.value_or(torrentContentLayout());
-    loadTorrentParams.forced = addTorrentParams.addForced;
-    loadTorrentParams.paused = addTorrentParams.addPaused.value_or(isAddTorrentPaused());
+    loadTorrentParams.operatingMode = (addTorrentParams.addForced ? TorrentOperatingMode::Forced : TorrentOperatingMode::AutoManaged);
+    loadTorrentParams.stopped = addTorrentParams.addPaused.value_or(isAddTorrentPaused());
     loadTorrentParams.ratioLimit = addTorrentParams.ratioLimit;
     loadTorrentParams.seedingTimeLimit = addTorrentParams.seedingTimeLimit;
 
@@ -2181,11 +2174,11 @@ bool Session::addTorrent_impl(const std::variant<MagnetUri, TorrentInfo> &source
     else
         p.flags &= ~lt::torrent_flags::seed_mode;
 
-    if (loadTorrentParams.paused || !loadTorrentParams.forced)
+    if (loadTorrentParams.stopped || (loadTorrentParams.operatingMode == TorrentOperatingMode::AutoManaged))
         p.flags |= lt::torrent_flags::paused;
     else
         p.flags &= ~lt::torrent_flags::paused;
-    if (loadTorrentParams.paused || loadTorrentParams.forced)
+    if (loadTorrentParams.stopped || (loadTorrentParams.operatingMode == TorrentOperatingMode::Forced))
         p.flags &= ~lt::torrent_flags::auto_managed;
     else
         p.flags |= lt::torrent_flags::auto_managed;
@@ -2300,23 +2293,28 @@ void Session::exportTorrentFile(const Torrent *torrent, TorrentExportFolder fold
              ((folder == TorrentExportFolder::Finished) && !finishedTorrentExportDirectory().isEmpty()));
 
     const QString validName = Utils::Fs::toValidFileSystemName(torrent->name());
-    const QString torrentFilename = QString::fromLatin1("%1.torrent").arg(torrent->id().toString());
     QString torrentExportFilename = QString::fromLatin1("%1.torrent").arg(validName);
-    const QString torrentPath = QDir(m_resumeFolderPath).absoluteFilePath(torrentFilename);
     const QDir exportPath(folder == TorrentExportFolder::Regular ? torrentExportDirectory() : finishedTorrentExportDirectory());
     if (exportPath.exists() || exportPath.mkpath(exportPath.absolutePath()))
     {
         QString newTorrentPath = exportPath.absoluteFilePath(torrentExportFilename);
         int counter = 0;
-        while (QFile::exists(newTorrentPath) && !Utils::Fs::sameFiles(torrentPath, newTorrentPath))
+        while (QFile::exists(newTorrentPath))
         {
             // Append number to torrent name to make it unique
             torrentExportFilename = QString::fromLatin1("%1 %2.torrent").arg(validName).arg(++counter);
             newTorrentPath = exportPath.absoluteFilePath(torrentExportFilename);
         }
 
-        if (!QFile::exists(newTorrentPath))
-            QFile::copy(torrentPath, newTorrentPath);
+        try
+        {
+            torrent->info().saveToFile(newTorrentPath);
+        }
+        catch (const RuntimeError &err)
+        {
+            LogMsg(tr("Couldn't export torrent metadata file '%1'. Reason: %2")
+                   .arg(newTorrentPath, err.message()), Log::WARNING);
+        }
     }
 }
 
@@ -2382,14 +2380,12 @@ void Session::saveTorrentsQueue() const
         }
     }
 
-    QMetaObject::invokeMethod(m_resumeDataStorage
-        , [this, queue]() { m_resumeDataStorage->storeQueue(queue); });
+    m_resumeDataStorage->storeQueue(queue);
 }
 
 void Session::removeTorrentsQueue() const
 {
-    QMetaObject::invokeMethod(m_resumeDataStorage
-        , [this]() { m_resumeDataStorage->storeQueue({}); });
+    m_resumeDataStorage->storeQueue({});
 }
 
 void Session::setDefaultSavePath(QString path)
@@ -3844,21 +3840,9 @@ void Session::handleTorrentUrlSeedsRemoved(TorrentImpl *const torrent, const QVe
 
 void Session::handleTorrentMetadataReceived(TorrentImpl *const torrent)
 {
-    // Save metadata
-    const QDir resumeDataDir {m_resumeFolderPath};
-    const QString torrentFileName {QString {"%1.torrent"}.arg(torrent->id().toString())};
-    try
-    {
-        torrent->info().saveToFile(resumeDataDir.absoluteFilePath(torrentFileName));
-        // Copy the torrent file to the export folder
-        if (!torrentExportDirectory().isEmpty())
-            exportTorrentFile(torrent);
-    }
-    catch (const RuntimeError &err)
-    {
-        LogMsg(tr("Couldn't save torrent metadata file '%1'. Reason: %2")
-               .arg(torrentFileName, err.message()), Log::CRITICAL);
-    }
+    // Copy the torrent file to the export folder
+    if (!torrentExportDirectory().isEmpty())
+        exportTorrentFile(torrent);
 
     emit torrentMetadataReceived(torrent);
 }
@@ -3919,8 +3903,7 @@ void Session::handleTorrentResumeDataReady(TorrentImpl *const torrent, const Loa
 {
     --m_numResumeData;
 
-    QMetaObject::invokeMethod(m_resumeDataStorage
-        , [this, torrentID = torrent->id(), data]() { m_resumeDataStorage->store(torrentID, data); });
+    m_resumeDataStorage->store(torrent->id(), data);
 }
 
 void Session::handleTorrentTrackerReply(TorrentImpl *const torrent, const QString &trackerUrl)
@@ -4055,26 +4038,7 @@ bool Session::hasPerTorrentSeedingTimeLimit() const
 
 void Session::initResumeDataStorage()
 {
-    m_resumeFolderPath = Utils::Fs::expandPathAbs(specialFolderLocation(SpecialFolder::Data) + RESUME_FOLDER);
-    const QDir resumeFolderDir(m_resumeFolderPath);
-    if (resumeFolderDir.exists() || resumeFolderDir.mkpath(resumeFolderDir.absolutePath()))
-    {
-        m_resumeFolderLock->setFileName(resumeFolderDir.absoluteFilePath("session.lock"));
-        if (!m_resumeFolderLock->open(QFile::WriteOnly))
-        {
-            throw RuntimeError {tr("Cannot write to torrent resume folder: \"%1\"")
-                        .arg(Utils::Fs::toNativePath(m_resumeFolderPath))};
-        }
-    }
-    else
-    {
-        throw RuntimeError {tr("Cannot create torrent resume folder: \"%1\"")
-                    .arg(Utils::Fs::toNativePath(m_resumeFolderPath))};
-    }
-
-    m_resumeDataStorage = new BencodeResumeDataStorage {m_resumeFolderPath};
-    m_resumeDataStorage->moveToThread(m_ioThread);
-    connect(m_ioThread, &QThread::finished, m_resumeDataStorage, &QObject::deleteLater);
+    m_resumeDataStorage = new BencodeResumeDataStorage(this);
 }
 
 void Session::configureDeferred()
@@ -4378,24 +4342,14 @@ void Session::createTorrent(const lt::torrent_handle &nativeHandle)
     }
     else
     {
+        m_resumeDataStorage->store(torrent->id(), params);
+
         // The following is useless for newly added magnet
         if (hasMetadata)
         {
-            // Backup torrent file
-            const QDir resumeDataDir {m_resumeFolderPath};
-            const QString torrentFileName {QString::fromLatin1("%1.torrent").arg(torrent->id().toString())};
-            try
-            {
-                torrent->info().saveToFile(resumeDataDir.absoluteFilePath(torrentFileName));
-                // Copy the torrent file to the export folder
-                if (!torrentExportDirectory().isEmpty())
-                    exportTorrentFile(torrent);
-            }
-            catch (const RuntimeError &err)
-            {
-                LogMsg(tr("Couldn't save torrent metadata file '%1'. Reason: %2")
-                       .arg(torrentFileName, err.message()), Log::CRITICAL);
-            }
+            // Copy the torrent file to the export folder
+            if (!torrentExportDirectory().isEmpty())
+                exportTorrentFile(torrent);
         }
 
         if (isAddTrackersEnabled() && !torrent->isPrivate())
@@ -4403,10 +4357,6 @@ void Session::createTorrent(const lt::torrent_handle &nativeHandle)
 
         LogMsg(tr("'%1' added to download list.", "'torrent name' was added to download list.")
             .arg(torrent->name()));
-
-        // In case of crash before the scheduled generation
-        // of the fastresumes.
-        torrent->saveResumeData();
     }
 
     if (((torrent->ratioLimit() >= 0) || (torrent->seedingTimeLimit() >= 0))

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -52,7 +52,6 @@
 #include "torrentinfo.h"
 #include "trackerentry.h"
 
-class QFile;
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 class QNetworkConfiguration;
 class QNetworkConfigurationManager;
@@ -751,8 +750,6 @@ namespace BitTorrent
         int m_numResumeData = 0;
         int m_extraLimit = 0;
         QVector<TrackerEntry> m_additionalTrackerList;
-        QString m_resumeFolderPath;
-        QFile *m_resumeFolderLock = nullptr;
 
         bool m_refreshEnqueued = false;
         QTimer *m_seedingLimitTimer = nullptr;
@@ -763,7 +760,7 @@ namespace BitTorrent
         QPointer<BandwidthScheduler> m_bwScheduler;
         // Tracker
         QPointer<Tracker> m_tracker;
-        // fastresume data writing thread
+
         QThread *m_ioThread = nullptr;
         ResumeDataStorage *m_resumeDataStorage = nullptr;
         FileSearcher *m_fileSearcher = nullptr;

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -240,12 +240,12 @@ TorrentImpl::TorrentImpl(Session *session, lt::session *nativeSession
     , m_tags(params.tags)
     , m_ratioLimit(params.ratioLimit)
     , m_seedingTimeLimit(params.seedingTimeLimit)
-    , m_operatingMode(params.forced ? TorrentOperatingMode::Forced : TorrentOperatingMode::AutoManaged)
+    , m_operatingMode(params.operatingMode)
     , m_contentLayout(params.contentLayout)
     , m_hasSeedStatus(params.hasSeedStatus)
     , m_hasFirstLastPiecePriority(params.firstLastPiecePriority)
     , m_useAutoTMM(params.savePath.isEmpty())
-    , m_isStopped(params.paused)
+    , m_isStopped(params.stopped)
     , m_ltAddTorrentParams(params.ltAddTorrentParams)
 {
     if (m_useAutoTMM)
@@ -1470,6 +1470,7 @@ void TorrentImpl::endReceivedMetadataHandling(const QString &savePath, const QSt
 
     m_maintenanceJob = MaintenanceJob::None;
     updateStatus();
+    prepareResumeData(p);
 
     m_session->handleTorrentMetadataReceived(this);
 }
@@ -1729,28 +1730,10 @@ void TorrentImpl::handleTorrentResumedAlert(const lt::torrent_resumed_alert *p)
 
 void TorrentImpl::handleSaveResumeDataAlert(const lt::save_resume_data_alert *p)
 {
-    if (m_hasMissingFiles)
-    {
-        const auto havePieces = m_ltAddTorrentParams.have_pieces;
-        const auto unfinishedPieces = m_ltAddTorrentParams.unfinished_pieces;
-        const auto verifiedPieces = m_ltAddTorrentParams.verified_pieces;
-
-        // Update recent resume data but preserve existing progress
-        m_ltAddTorrentParams = p->params;
-        m_ltAddTorrentParams.have_pieces = havePieces;
-        m_ltAddTorrentParams.unfinished_pieces = unfinishedPieces;
-        m_ltAddTorrentParams.verified_pieces = verifiedPieces;
-    }
-    else
-    {
-        // Update recent resume data
-        m_ltAddTorrentParams = p->params;
-    }
-
-    m_ltAddTorrentParams.added_time = addedTime().toSecsSinceEpoch();
-
     if (m_maintenanceJob == MaintenanceJob::HandleMetadata)
     {
+        m_ltAddTorrentParams = p->params;
+
         m_ltAddTorrentParams.have_pieces.clear();
         m_ltAddTorrentParams.verified_pieces.clear();
 
@@ -1759,6 +1742,33 @@ void TorrentImpl::handleSaveResumeDataAlert(const lt::save_resume_data_alert *p)
 
         m_session->findIncompleteFiles(metadata, m_savePath);
     }
+    else
+    {
+        prepareResumeData(p->params);
+    }
+}
+
+void TorrentImpl::prepareResumeData(const lt::add_torrent_params &params)
+{
+    if (m_hasMissingFiles)
+    {
+        const auto havePieces = m_ltAddTorrentParams.have_pieces;
+        const auto unfinishedPieces = m_ltAddTorrentParams.unfinished_pieces;
+        const auto verifiedPieces = m_ltAddTorrentParams.verified_pieces;
+
+        // Update recent resume data but preserve existing progress
+        m_ltAddTorrentParams = params;
+        m_ltAddTorrentParams.have_pieces = havePieces;
+        m_ltAddTorrentParams.unfinished_pieces = unfinishedPieces;
+        m_ltAddTorrentParams.verified_pieces = verifiedPieces;
+    }
+    else
+    {
+        // Update recent resume data
+        m_ltAddTorrentParams = params;
+    }
+
+    m_ltAddTorrentParams.added_time = addedTime().toSecsSinceEpoch();
 
     LoadTorrentParams resumeData;
     resumeData.name = m_name;
@@ -1770,8 +1780,8 @@ void TorrentImpl::handleSaveResumeDataAlert(const lt::save_resume_data_alert *p)
     resumeData.seedingTimeLimit = m_seedingTimeLimit;
     resumeData.firstLastPiecePriority = m_hasFirstLastPiecePriority;
     resumeData.hasSeedStatus = m_hasSeedStatus;
-    resumeData.paused = m_isStopped;
-    resumeData.forced = (m_operatingMode == TorrentOperatingMode::Forced);
+    resumeData.stopped = m_isStopped;
+    resumeData.operatingMode = m_operatingMode;
     resumeData.ltAddTorrentParams = m_ltAddTorrentParams;
 
     m_session->handleTorrentResumeDataReady(this, resumeData);

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -269,6 +269,7 @@ namespace BitTorrent
         void manageIncompleteFiles();
         void applyFirstLastPiecePriority(bool enabled, const QVector<DownloadPriority> &updatedFilePrio = {});
 
+        void prepareResumeData(const lt::add_torrent_params &params);
         void endReceivedMetadataHandling(const QString &savePath, const QStringList &fileNames);
         void reload();
 


### PR DESCRIPTION
Finish moving the "resume data" saving logic to "resume data storage":
1. Saving metadata
2. Managing IO thread

The logic itself keeps mostly unchanged.

Test cases are add/restore/remove torrent both from .torrent files and magnet links.