### PR TITLE
Correctly forward declare file_prio_alert

### DIFF
--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -53,10 +53,9 @@
 // file_prio_alert is missing to be forward declared in "libtorrent/fwd.hpp"
 namespace libtorrent
 {
-    inline namespace v2
-    {
-        struct file_prio_alert;
-    }
+    TORRENT_VERSION_NAMESPACE_3
+    struct file_prio_alert;
+    TORRENT_VERSION_NAMESPACE_3_END
 }
 #endif
 


### PR DESCRIPTION
Otherwise it won't compile if libtorrent uses deprecated features since there are different namespaces declared.