### PR TITLE
Update german.nsi

### DIFF
--- a/dist/windows/installer-translations/german.nsi
+++ b/dist/windows/installer-translations/german.nsi
@@ -29,7 +29,7 @@ LangString launch_qbt ${LANG_GERMAN} "Starte qBittorrent."
 ;LangString inst_requires_64bit ${LANG_ENGLISH} "This installer works only in 64-bit Windows versions."
 LangString inst_requires_64bit ${LANG_GERMAN} "Diese Installation funktioniert nur mit einer 64-bit Version von Windows."
 ;LangString inst_requires_win7 ${LANG_ENGLISH} "This qBittorrent version requires at least Windows 7."
-LangString inst_requires_win7 ${LANG_GERMAN} "Diese Version von qBittorrent erfordert zumindest Windows 7."
+LangString inst_requires_win7 ${LANG_GERMAN} "Diese Version von qBittorrent erfordert mindestens Windows 7."
 
 
 ;------------------------------------


### PR DESCRIPTION
Line 32
Changing "zumindest" to "mindestens".
I even would go further to change the line into "[...] Windows 7 oder höher." ("[...] Windows 7 or higher."), as this seems to make more sense and we wouldn't have the hassle of discussing whether "zumindest" or "mindestens" fits better.

If you insist on a comment:
It is quite a cosmetic change, and a personal opinion as well. Imo "mindestens" fits more to the theme of general use - "zumindest" can be used in special places, as it isn't that common in e.g. regular conversations. What comes to my mind is "Best before", which is "Mindestens haltbar bis". It would be unusual to use "Zumindest haltbar bis". 😄


Finally it is up to you what to change.

CC: @schnurlos