### PR TITLE
Simplify natural sort classes interface

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -78,9 +78,9 @@
 #include "base/scanfoldersmodel.h"
 #include "base/search/searchpluginmanager.h"
 #include "base/settingsstorage.h"
+#include "base/utils/compare.h"
 #include "base/utils/fs.h"
 #include "base/utils/misc.h"
-#include "base/utils/string.h"
 #include "base/version.h"
 #include "applicationinstancemanager.h"
 #include "filelogger.h"
@@ -352,7 +352,7 @@ void Application::runExternalProgram(const BitTorrent::Torrent *torrent) const
         case u'G':
             {
                 QStringList tags = torrent->tags().values();
-                std::sort(tags.begin(), tags.end(), Utils::String::naturalLessThan<Qt::CaseInsensitive>);
+                std::sort(tags.begin(), tags.end(), Utils::Compare::NaturalLessThan<Qt::CaseInsensitive>());
                 program.replace(i, 2, tags.join(','));
             }
             break;

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -79,6 +79,7 @@ add_library(qbt_base STATIC
     types.h
     unicodestrings.h
     utils/bytearray.h
+    utils/compare.h
     utils/foreignapps.h
     utils/fs.h
     utils/gzip.h
@@ -154,6 +155,7 @@ add_library(qbt_base STATIC
     torrentfileguard.cpp
     torrentfilter.cpp
     utils/bytearray.cpp
+    utils/compare.cpp
     utils/foreignapps.cpp
     utils/fs.cpp
     utils/gzip.cpp

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -79,6 +79,7 @@ HEADERS += \
     $$PWD/types.h \
     $$PWD/unicodestrings.h \
     $$PWD/utils/bytearray.h \
+    $$PWD/utils/compare.h \
     $$PWD/utils/foreignapps.h \
     $$PWD/utils/fs.h \
     $$PWD/utils/gzip.h \
@@ -154,6 +155,7 @@ SOURCES += \
     $$PWD/torrentfileguard.cpp \
     $$PWD/torrentfilter.cpp \
     $$PWD/utils/bytearray.cpp \
+    $$PWD/utils/compare.cpp \
     $$PWD/utils/foreignapps.cpp \
     $$PWD/utils/fs.cpp \
     $$PWD/utils/gzip.cpp \

--- a/src/base/bittorrent/torrentcreatorthread.cpp
+++ b/src/base/bittorrent/torrentcreatorthread.cpp
@@ -42,9 +42,9 @@
 
 #include "base/exceptions.h"
 #include "base/global.h"
+#include "base/utils/compare.h"
 #include "base/utils/fs.h"
 #include "base/utils/io.h"
-#include "base/utils/string.h"
 #include "base/version.h"
 #include "ltunderlyingtype.h"
 
@@ -105,6 +105,7 @@ void TorrentCreatorThread::run()
     try
     {
         const QString parentPath = Utils::Fs::branchPath(m_params.inputPath) + '/';
+        const Utils::Compare::NaturalLessThan<Qt::CaseInsensitive> naturalLessThan {};
 
         // Adding files to the torrent
         lt::file_storage fs;
@@ -123,7 +124,7 @@ void TorrentCreatorThread::run()
                 dirIter.next();
                 dirs += dirIter.filePath();
             }
-            std::sort(dirs.begin(), dirs.end(), Utils::String::naturalLessThan<Qt::CaseInsensitive>);
+            std::sort(dirs.begin(), dirs.end(), naturalLessThan);
 
             QStringList fileNames;
             QHash<QString, qint64> fileSizeMap;
@@ -142,7 +143,7 @@ void TorrentCreatorThread::run()
                     fileSizeMap[relFilePath] = fileIter.fileInfo().size();
                 }
 
-                std::sort(tmpNames.begin(), tmpNames.end(), Utils::String::naturalLessThan<Qt::CaseInsensitive>);
+                std::sort(tmpNames.begin(), tmpNames.end(), naturalLessThan);
                 fileNames += tmpNames;
             }
 

--- a/src/base/utils/compare.cpp
+++ b/src/base/utils/compare.cpp
@@ -1,0 +1,96 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2021  Mike Tzou (Chocobo1)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "compare.h"
+
+#include <QChar>
+#include <QString>
+
+#ifndef QBT_USE_QCOLLATOR
+int Utils::Compare::naturalCompare(const QString &left, const QString &right, const Qt::CaseSensitivity caseSensitivity)
+{
+    // Return value <0: `left` is smaller than `right`
+    // Return value >0: `left` is greater than `right`
+    // Return value =0: both strings are equal
+
+    int posL = 0;
+    int posR = 0;
+    while (true)
+    {
+        if ((posL == left.size()) || (posR == right.size()))
+            return (left.size() - right.size());  // when a shorter string is another string's prefix, shorter string place before longer string
+
+        const QChar leftChar = (caseSensitivity == Qt::CaseSensitive) ? left[posL] : left[posL].toLower();
+        const QChar rightChar = (caseSensitivity == Qt::CaseSensitive) ? right[posR] : right[posR].toLower();
+        // Compare only non-digits.
+        // Numbers should be compared as a whole
+        // otherwise the string->int conversion can yield a wrong value
+        if ((leftChar == rightChar) && !leftChar.isDigit())
+        {
+            // compare next character
+            ++posL;
+            ++posR;
+        }
+        else if (leftChar.isDigit() && rightChar.isDigit())
+        {
+            // Both are digits, compare the numbers
+
+            const auto numberView = [](const QString &str, int &pos) -> QStringRef
+            {
+                const int start = pos;
+                while ((pos < str.size()) && str[pos].isDigit())
+                    ++pos;
+                return str.midRef(start, (pos - start));
+            };
+
+            const QStringRef numViewL = numberView(left, posL);
+            const QStringRef numViewR = numberView(right, posR);
+
+            if (numViewL.length() != numViewR.length())
+                return (numViewL.length() - numViewR.length());
+
+            // both string/view has the same length
+            for (int i = 0; i < numViewL.length(); ++i)
+            {
+                const QChar numL = numViewL[i];
+                const QChar numR = numViewR[i];
+
+                if (numL != numR)
+                    return (numL.unicode() - numR.unicode());
+            }
+
+            // String + digits do match and we haven't hit the end of both strings
+            // then continue to consume the remainings
+        }
+        else
+        {
+            return (leftChar.unicode() - rightChar.unicode());
+        }
+    }
+}
+#endif

--- a/src/base/utils/string.cpp
+++ b/src/base/utils/string.cpp
@@ -31,9 +31,7 @@
 
 #include <cmath>
 
-#include <QCollator>
 #include <QLocale>
-#include <QtGlobal>
 #include <QVector>
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
@@ -41,137 +39,6 @@
 #else
 #include <QRegExp>
 #endif
-
-#if defined(Q_OS_MACOS) || defined(__MINGW32__)
-#define QBT_USES_QTHREADSTORAGE
-#include <QThreadStorage>
-#endif
-
-namespace
-{
-    class NaturalCompare
-    {
-    public:
-        explicit NaturalCompare(const Qt::CaseSensitivity caseSensitivity = Qt::CaseSensitive)
-            : m_caseSensitivity(caseSensitivity)
-        {
-#ifdef Q_OS_WIN
-            // Without ICU library, QCollator uses the native API on Windows 7+. But that API
-            // sorts older versions of μTorrent differently than the newer ones because the
-            // 'μ' character is encoded differently and the native API can't cope with that.
-            // So default to using our custom natural sorting algorithm instead.
-            // See #5238 and #5240
-            // Without ICU library, QCollator doesn't support `setNumericMode(true)` on an OS older than Win7
-#else
-            m_collator.setNumericMode(true);
-            m_collator.setCaseSensitivity(caseSensitivity);
-#endif
-        }
-
-        int operator()(const QString &left, const QString &right) const
-        {
-#ifdef Q_OS_WIN
-            return compare(left, right);
-#else
-            return m_collator.compare(left, right);
-#endif
-        }
-
-    private:
-        int compare(const QString &left, const QString &right) const
-        {
-            // Return value <0: `left` is smaller than `right`
-            // Return value >0: `left` is greater than `right`
-            // Return value =0: both strings are equal
-
-            int posL = 0;
-            int posR = 0;
-            while (true)
-            {
-                if ((posL == left.size()) || (posR == right.size()))
-                    return (left.size() - right.size());  // when a shorter string is another string's prefix, shorter string place before longer string
-
-                const QChar leftChar = (m_caseSensitivity == Qt::CaseSensitive) ? left[posL] : left[posL].toLower();
-                const QChar rightChar = (m_caseSensitivity == Qt::CaseSensitive) ? right[posR] : right[posR].toLower();
-                // Compare only non-digits.
-                // Numbers should be compared as a whole
-                // otherwise the string->int conversion can yield a wrong value
-                if ((leftChar == rightChar) && !leftChar.isDigit())
-                {
-                    // compare next character
-                    ++posL;
-                    ++posR;
-                }
-                else if (leftChar.isDigit() && rightChar.isDigit())
-                {
-                    // Both are digits, compare the numbers
-
-                    const auto numberView = [](const QString &str, int &pos) -> QStringRef
-                    {
-                        const int start = pos;
-                        while ((pos < str.size()) && str[pos].isDigit())
-                            ++pos;
-                        return str.midRef(start, (pos - start));
-                    };
-
-                    const QStringRef numViewL = numberView(left, posL);
-                    const QStringRef numViewR = numberView(right, posR);
-
-                    if (numViewL.length() != numViewR.length())
-                        return (numViewL.length() - numViewR.length());
-
-                    // both string/view has the same length
-                    for (int i = 0; i < numViewL.length(); ++i)
-                    {
-                        const QChar numL = numViewL[i];
-                        const QChar numR = numViewR[i];
-
-                        if (numL != numR)
-                            return (numL.unicode() - numR.unicode());
-                    }
-
-                    // String + digits do match and we haven't hit the end of both strings
-                    // then continue to consume the remainings
-                }
-                else
-                {
-                    return (leftChar.unicode() - rightChar.unicode());
-                }
-            }
-        }
-
-        QCollator m_collator;
-        const Qt::CaseSensitivity m_caseSensitivity;
-    };
-}
-
-int Utils::String::naturalCompare(const QString &left, const QString &right, const Qt::CaseSensitivity caseSensitivity)
-{
-    // provide a single `NaturalCompare` instance for easy use
-    // https://doc.qt.io/qt-5/threads-reentrancy.html
-    if (caseSensitivity == Qt::CaseSensitive)
-    {
-#ifdef QBT_USES_QTHREADSTORAGE
-        static QThreadStorage<NaturalCompare> nCmp;
-        if (!nCmp.hasLocalData())
-            nCmp.setLocalData(NaturalCompare(Qt::CaseSensitive));
-        return (nCmp.localData())(left, right);
-#else
-        thread_local NaturalCompare nCmp(Qt::CaseSensitive);
-        return nCmp(left, right);
-#endif
-    }
-
-#ifdef QBT_USES_QTHREADSTORAGE
-    static QThreadStorage<NaturalCompare> nCmp;
-    if (!nCmp.hasLocalData())
-        nCmp.setLocalData(NaturalCompare(Qt::CaseInsensitive));
-    return (nCmp.localData())(left, right);
-#else
-    thread_local NaturalCompare nCmp(Qt::CaseInsensitive);
-    return nCmp(left, right);
-#endif
-}
 
 // to send numbers instead of strings with suffixes
 QString Utils::String::fromDouble(const double n, const int precision)

--- a/src/base/utils/string.h
+++ b/src/base/utils/string.h
@@ -41,15 +41,6 @@ class QStringRef;
 
 namespace Utils::String
 {
-    QString fromDouble(double n, int precision);
-
-    int naturalCompare(const QString &left, const QString &right, const Qt::CaseSensitivity caseSensitivity);
-    template <Qt::CaseSensitivity caseSensitivity>
-    bool naturalLessThan(const QString &left, const QString &right)
-    {
-        return (naturalCompare(left, right, caseSensitivity) < 0);
-    }
-
     QString wildcardToRegexPattern(const QString &pattern);
 
     template <typename T>
@@ -71,6 +62,8 @@ namespace Utils::String
     std::optional<double> parseDouble(const QString &string);
 
     QString join(const QVector<QStringRef> &strings, const QString &separator);
+
+    QString fromDouble(double n, int precision);
 
     template <typename T, typename std::enable_if_t<std::is_enum_v<T>, int> = 0>
     QString fromEnum(const T &value)

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -48,9 +48,9 @@
 #include "base/net/downloadmanager.h"
 #include "base/settingsstorage.h"
 #include "base/torrentfileguard.h"
+#include "base/utils/compare.h"
 #include "base/utils/fs.h"
 #include "base/utils/misc.h"
-#include "base/utils/string.h"
 #include "autoexpandabledialog.h"
 #include "properties/proplistdelegate.h"
 #include "raisedmessagebox.h"
@@ -129,7 +129,7 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::AddTorrentParams &inP
 
     // Load categories
     QStringList categories = session->categories().keys();
-    std::sort(categories.begin(), categories.end(), Utils::String::naturalLessThan<Qt::CaseInsensitive>);
+    std::sort(categories.begin(), categories.end(), Utils::Compare::NaturalLessThan<Qt::CaseInsensitive>());
     auto defaultCategory = settings()->loadValue<QString>(KEY_DEFAULTCATEGORY);
 
     if (!m_torrentParams.category.isEmpty())

--- a/src/gui/categoryfilterproxymodel.cpp
+++ b/src/gui/categoryfilterproxymodel.cpp
@@ -28,7 +28,6 @@
 
 #include "categoryfilterproxymodel.h"
 
-#include "base/utils/string.h"
 #include "categoryfiltermodel.h"
 
 CategoryFilterProxyModel::CategoryFilterProxyModel(QObject *parent)
@@ -51,9 +50,5 @@ bool CategoryFilterProxyModel::lessThan(const QModelIndex &left, const QModelInd
     // "All" and "Uncategorized" must be left in place
     if (CategoryFilterModel::isSpecialItem(left) || CategoryFilterModel::isSpecialItem(right))
         return (left < right);
-
-    int result = Utils::String::naturalCompare(left.data().toString(), right.data().toString()
-        , Qt::CaseInsensitive);
-
-    return (result < 0);
+    return m_naturalLessThan(left.data().toString(), right.data().toString());
 }

--- a/src/gui/categoryfilterproxymodel.h
+++ b/src/gui/categoryfilterproxymodel.h
@@ -30,6 +30,8 @@
 
 #include <QSortFilterProxyModel>
 
+#include "base/utils/compare.h"
+
 class QString;
 
 class CategoryFilterProxyModel final : public QSortFilterProxyModel
@@ -47,4 +49,6 @@ protected:
 private:
     // we added another overload of index(), hence this using directive:
     using QSortFilterProxyModel::index;
+
+    Utils::Compare::NaturalLessThan<Qt::CaseInsensitive> m_naturalLessThan;
 };

--- a/src/gui/properties/peerlistsortmodel.h
+++ b/src/gui/properties/peerlistsortmodel.h
@@ -30,6 +30,8 @@
 
 #include <QSortFilterProxyModel>
 
+#include "base/utils/compare.h"
+
 class PeerListSortModel final : public QSortFilterProxyModel
 {
     Q_OBJECT
@@ -45,4 +47,6 @@ public:
 
 private:
     bool lessThan(const QModelIndex &left, const QModelIndex &right) const override;
+
+    Utils::Compare::NaturalLessThan<Qt::CaseInsensitive> m_naturalLessThan;
 };

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -47,6 +47,7 @@
 #include "base/rss/rss_feed.h"
 #include "base/rss/rss_folder.h"
 #include "base/rss/rss_session.h"
+#include "base/utils/compare.h"
 #include "base/utils/fs.h"
 #include "base/utils/string.h"
 #include "gui/autoexpandabledialog.h"
@@ -330,7 +331,7 @@ void AutomatedRssDownloader::initCategoryCombobox()
 {
     // Load torrent categories
     QStringList categories = BitTorrent::Session::instance()->categories().keys();
-    std::sort(categories.begin(), categories.end(), Utils::String::naturalLessThan<Qt::CaseInsensitive>);
+    std::sort(categories.begin(), categories.end(), Utils::Compare::NaturalLessThan<Qt::CaseInsensitive>());
     m_ui->comboCategory->addItem("");
     m_ui->comboCategory->addItems(categories);
 }

--- a/src/gui/search/searchsortmodel.cpp
+++ b/src/gui/search/searchsortmodel.cpp
@@ -29,7 +29,6 @@
 #include "searchsortmodel.h"
 
 #include "base/global.h"
-#include "base/utils/string.h"
 
 SearchSortModel::SearchSortModel(QObject *parent)
     : base(parent)
@@ -118,11 +117,10 @@ bool SearchSortModel::lessThan(const QModelIndex &left, const QModelIndex &right
     {
     case NAME:
     case ENGINE_URL:
-    {
+        {
             const QString strL = left.data().toString();
             const QString strR = right.data().toString();
-            const int result = Utils::String::naturalCompare(strL, strR, Qt::CaseInsensitive);
-            return (result < 0);
+            return m_naturalLessThan(strL, strR);
         }
         break;
     default:

--- a/src/gui/search/searchsortmodel.h
+++ b/src/gui/search/searchsortmodel.h
@@ -31,6 +31,8 @@
 #include <QSortFilterProxyModel>
 #include <QStringList>
 
+#include "base/utils/compare.h"
+
 class SearchSortModel final : public QSortFilterProxyModel
 {
     using base = QSortFilterProxyModel;
@@ -94,4 +96,6 @@ private:
     int m_minSeeds, m_maxSeeds;
     int m_minLeeches, m_maxLeeches;
     qint64 m_minSize, m_maxSize;
+
+    Utils::Compare::NaturalLessThan<Qt::CaseInsensitive> m_naturalLessThan;
 };

--- a/src/gui/tagfilterproxymodel.cpp
+++ b/src/gui/tagfilterproxymodel.cpp
@@ -28,7 +28,6 @@
 
 #include "tagfilterproxymodel.h"
 
-#include "base/utils/string.h"
 #include "tagfiltermodel.h"
 
 TagFilterProxyModel::TagFilterProxyModel(QObject *parent)
@@ -51,8 +50,5 @@ bool TagFilterProxyModel::lessThan(const QModelIndex &left, const QModelIndex &r
     // "All" and "Untagged" must be left in place
     if (TagFilterModel::isSpecialItem(left) || TagFilterModel::isSpecialItem(right))
         return (left < right);
-
-    int result = Utils::String::naturalCompare(left.data().toString(), right.data().toString()
-        , Qt::CaseInsensitive);
-    return (result < 0);
+    return m_naturalLessThan(left.data().toString(), right.data().toString());
 }

--- a/src/gui/tagfilterproxymodel.h
+++ b/src/gui/tagfilterproxymodel.h
@@ -30,6 +30,8 @@
 
 #include <QSortFilterProxyModel>
 
+#include "base/utils/compare.h"
+
 class QString;
 
 class TagFilterProxyModel final : public QSortFilterProxyModel
@@ -47,4 +49,6 @@ protected:
 private:
     // we added another overload of index(), hence this using directive:
     using QSortFilterProxyModel::index;
+
+    Utils::Compare::NaturalLessThan<Qt::CaseInsensitive> m_naturalLessThan;
 };

--- a/src/gui/torrentcontentfiltermodel.cpp
+++ b/src/gui/torrentcontentfiltermodel.cpp
@@ -28,7 +28,6 @@
 
 #include "torrentcontentfiltermodel.h"
 
-#include "base/utils/string.h"
 #include "torrentcontentmodel.h"
 
 TorrentContentFilterModel::TorrentContentFilterModel(QObject *parent)
@@ -94,7 +93,7 @@ bool TorrentContentFilterModel::lessThan(const QModelIndex &left, const QModelIn
             {
                 const QString strL = left.data().toString();
                 const QString strR = right.data().toString();
-                return Utils::String::naturalLessThan<Qt::CaseInsensitive>(strL, strR);
+                return m_naturalLessThan(strL, strR);
             }
             if ((leftType == TorrentContentModelItem::FolderType) && (sortOrder() == Qt::AscendingOrder))
             {

--- a/src/gui/torrentcontentfiltermodel.h
+++ b/src/gui/torrentcontentfiltermodel.h
@@ -30,6 +30,7 @@
 
 #include <QSortFilterProxyModel>
 
+#include "base/utils/compare.h"
 #include "torrentcontentmodelitem.h"
 
 class TorrentContentModel;
@@ -61,4 +62,5 @@ private:
     bool hasFiltered(const QModelIndex &folder) const;
 
     TorrentContentModel *m_model;
+    Utils::Compare::NaturalLessThan<Qt::CaseInsensitive> m_naturalLessThan;
 };

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -47,8 +47,8 @@
 #include "base/net/downloadmanager.h"
 #include "base/preferences.h"
 #include "base/torrentfilter.h"
+#include "base/utils/compare.h"
 #include "base/utils/fs.h"
-#include "base/utils/string.h"
 #include "categoryfilterwidget.h"
 #include "tagfilterwidget.h"
 #include "transferlistwidget.h"
@@ -366,10 +366,11 @@ void TrackerFiltersList::addItem(const QString &tracker, const BitTorrent::Torre
     }
 
     Q_ASSERT(count() >= 4);
+    const Utils::Compare::NaturalLessThan<Qt::CaseSensitive> naturalLessThan {};
     int insPos = count();
     for (int i = 4; i < count(); ++i)
     {
-        if (Utils::String::naturalLessThan<Qt::CaseSensitive>(host, item(i)->text()))
+        if (naturalLessThan(host, item(i)->text()))
         {
             insPos = i;
             break;

--- a/src/gui/transferlistsortmodel.cpp
+++ b/src/gui/transferlistsortmodel.cpp
@@ -34,7 +34,6 @@
 
 #include "base/bittorrent/infohash.h"
 #include "base/bittorrent/torrent.h"
-#include "base/utils/string.h"
 #include "transferlistmodel.h"
 
 namespace
@@ -143,7 +142,7 @@ int TransferListSortModel::compare(const QModelIndex &left, const QModelIndex &r
     case TransferListModel::TR_SAVE_PATH:
     case TransferListModel::TR_TAGS:
     case TransferListModel::TR_TRACKER:
-        return Utils::String::naturalCompare(leftValue.toString(), rightValue.toString(), Qt::CaseInsensitive);
+        return m_naturalCompare(leftValue.toString(), rightValue.toString());
 
     case TransferListModel::TR_AMOUNT_DOWNLOADED:
     case TransferListModel::TR_AMOUNT_DOWNLOADED_SESSION:

--- a/src/gui/transferlistsortmodel.h
+++ b/src/gui/transferlistsortmodel.h
@@ -32,6 +32,7 @@
 
 #include "base/settingvalue.h"
 #include "base/torrentfilter.h"
+#include "base/utils/compare.h"
 
 namespace BitTorrent
 {
@@ -64,4 +65,6 @@ private:
     TorrentFilter m_filter;
     mutable CachedSettingValue<int> m_subSortColumn;
     mutable int m_lastSortColumn = -1;
+
+    Utils::Compare::NaturalCompare<Qt::CaseInsensitive> m_naturalCompare;
 };

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -52,6 +52,7 @@
 #include "base/logger.h"
 #include "base/preferences.h"
 #include "base/torrentfilter.h"
+#include "base/utils/compare.h"
 #include "base/utils/fs.h"
 #include "base/utils/misc.h"
 #include "base/utils/string.h"
@@ -963,7 +964,7 @@ void TransferListWidget::displayListMenu(const QPoint &)
 
     // Category Menu
     QStringList categories = BitTorrent::Session::instance()->categories().keys();
-    std::sort(categories.begin(), categories.end(), Utils::String::naturalLessThan<Qt::CaseInsensitive>);
+    std::sort(categories.begin(), categories.end(), Utils::Compare::NaturalLessThan<Qt::CaseInsensitive>());
 
     QMenu *categoryMenu = listMenu->addMenu(UIThemeManager::instance()->getIcon("view-categories"), tr("Category"));
 
@@ -988,7 +989,7 @@ void TransferListWidget::displayListMenu(const QPoint &)
 
     // Tag Menu
     QStringList tags(BitTorrent::Session::instance()->tags().values());
-    std::sort(tags.begin(), tags.end(), Utils::String::naturalLessThan<Qt::CaseInsensitive>);
+    std::sort(tags.begin(), tags.end(), Utils::Compare::NaturalLessThan<Qt::CaseInsensitive>());
 
     QMenu *tagsMenu = listMenu->addMenu(UIThemeManager::instance()->getIcon("view-categories"), tr("Tags"));
 


### PR DESCRIPTION
Now the comparison function/class should be constructed before usage.
This change also make it easier to plug in into various containers which will require a compare function type (such as std::set).