### PR TITLE
Revert "Change clamping of update interval of SpeedPlotView::Averager"

### DIFF
--- a/src/gui/properties/speedplotview.cpp
+++ b/src/gui/properties/speedplotview.cpp
@@ -120,7 +120,8 @@ bool SpeedPlotView::Averager::push(const SampleData &sampleData)
 
     // system may go to sleep, that can cause very big elapsed interval
     const milliseconds updateInterval {static_cast<int64_t>(BitTorrent::Session::instance()->refreshInterval() * 1.25)};
-    const milliseconds elapsed {std::min(milliseconds {m_lastSampleTime.elapsed()}, updateInterval)};
+    const milliseconds maxElapsed {std::max(updateInterval, m_resolution)};
+    const milliseconds elapsed {std::min(milliseconds {m_lastSampleTime.elapsed()}, maxElapsed)};
     if (elapsed < m_resolution)
         return false; // still accumulating
 


### PR DESCRIPTION
This reverts commit 435bb3443507dd224b3579dbb4ba5657dc5cc8fa.

To achieve what the reverted commit wants, the timing
would need to be taken iteratively rather that cumulatively

fixes #14735