### PR TITLE
Update dyndns register url

### DIFF
--- a/src/base/net/dnsupdater.cpp
+++ b/src/base/net/dnsupdater.cpp
@@ -300,7 +300,7 @@ QUrl DNSUpdater::getRegistrationUrl(const int service)
     switch (service)
     {
     case DNS::DYNDNS:
-        return {"https://www.dyndns.com/account/services/hosts/add.html"};
+        return {"https://account.dyn.com/entrance/"};
     case DNS::NOIP:
         return {"https://www.noip.com/remote-access"};
     default:


### PR DESCRIPTION
The old register url for dyndns (`https://account.dyn.com/dns/dyndns/add.html`) is broken.
Replace with [a new link](https://account.dyn.com/dns/dyndns/add.html).