### PR TITLE
Don't use executable name as CFBundleName value

### DIFF
--- a/dist/mac/Info.plist
+++ b/dist/mac/Info.plist
@@ -47,7 +47,7 @@
 		</dict>
 	</array>
 	<key>CFBundleName</key>
-	<string>@EXECUTABLE@</string>
+	<string>qBittorrent</string>
 	<key>CFBundleIconFile</key>
 	<string>qbittorrent_mac.icns</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -85,7 +85,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     )
     set_target_properties(qbt_app PROPERTIES
         MACOSX_BUNDLE ON
-        MACOSX_BUNDLE_BUNDLE_NAME "${EXECUTABLE}"
+        MACOSX_BUNDLE_BUNDLE_NAME "qBittorrent"
         MACOSX_BUNDLE_INFO_PLIST ${qBittorrent_BINARY_DIR}/dist/mac/Info.plist
     )
     target_sources(qbt_app PRIVATE


### PR DESCRIPTION
display 'q**B**ittorrent' (uppercase 'B') instead of 'q**b**ittorrent' (lowercase 'b') in application menu

before fix:
<img width="370" alt="Screen Shot 2021-04-18 at 11 19 43" src="https://user-images.githubusercontent.com/947647/115140220-dfe9f380-a03e-11eb-9be0-b9e303ef0bc6.png">
after fix:
<img width="370" alt="Screen Shot 2021-04-18 at 11 20 38" src="https://user-images.githubusercontent.com/947647/115140229-e9735b80-a03e-11eb-8823-2f3c16244af5.png">
