### PR TITLE
Set correct minimum macOS version with CMake

### DIFF
--- a/dist/mac/Info.plist
+++ b/dist/mac/Info.plist
@@ -57,7 +57,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>4.4.0</string>
 	<key>CFBundleExecutable</key>
-	<string>@EXECUTABLE@</string>
+	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
 	<string>org.qbittorrent.qBittorrent</string>
 	<key>LSMinimumSystemVersion</key>

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -75,18 +75,14 @@ set_source_files_properties(
 )
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    # substitute @EXECUTABLE@ in dist/mac/Info.plist
-    get_target_property(EXECUTABLE qbt_app OUTPUT_NAME)
-    configure_file(${qBittorrent_SOURCE_DIR}/dist/mac/Info.plist
-        ${qBittorrent_BINARY_DIR}/dist/mac/pregen.plist @ONLY)
-    file(GENERATE
-        OUTPUT ${qBittorrent_BINARY_DIR}/dist/mac/Info.plist
-        INPUT ${qBittorrent_BINARY_DIR}/dist/mac/pregen.plist
-    )
+    # provide variables for substitution in dist/mac/Info.plist
+    get_target_property(EXECUTABLE_NAME qbt_app OUTPUT_NAME)
+    # This variable name should be changed once qmake is no longer used. Refer to the discussion in PR #14813
+    set(MACOSX_DEPLOYMENT_TARGET ${CMAKE_OSX_DEPLOYMENT_TARGET})
     set_target_properties(qbt_app PROPERTIES
         MACOSX_BUNDLE ON
         MACOSX_BUNDLE_BUNDLE_NAME "qBittorrent"
-        MACOSX_BUNDLE_INFO_PLIST ${qBittorrent_BINARY_DIR}/dist/mac/Info.plist
+        MACOSX_BUNDLE_INFO_PLIST ${qBittorrent_SOURCE_DIR}/dist/mac/Info.plist
     )
     target_sources(qbt_app PRIVATE
         ${QT_TRANSLATIONS}


### PR DESCRIPTION
Info.plist has ${MACOSX_DEPLOYMENT_TARGET} placeholder which is filled
by qmake, but not CMake. And as result, when building with CMake value
of LSMinimumSystemVersion field is '.0'. This happens because CMake has
possibility to substitute placeholders with values from corresponding
variables, and as so as there is no such variable, empty value is used.

So, to fix this, just set CMake variable MACOSX_DEPLOYMENT_TARGET to
CMAKE_OSX_DEPLOYMENT_TARGET value.

no fix, master as is:
<img width="499" alt="Screen Shot 2021-04-18 at 15 44 09" src="https://user-images.githubusercontent.com/947647/115150356-9fa36900-a070-11eb-9790-aaa25a5f874c.png">

with fix, this branch:
<img width="495" alt="Screen Shot 2021-04-18 at 17 30 09" src="https://user-images.githubusercontent.com/947647/115150371-afbb4880-a070-11eb-92f0-86a8bf5d016c.png">

P.S> maybe it is worth to set `CMAKE_OSX_DEPLOYMENT_TARGET` explicitly in root CMakeLists.txt instead of passing it to command line each time (especially when 10.14 is **required**)? similar thing is done for qmake:
https://github.com/qbittorrent/qBittorrent/blob/c7c7924d37f225f1be345037cf757cf9f70a57ca/macxconf.pri#L10