### PR TITLE
Append trailing slash to URL if missing

### DIFF
--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -2,6 +2,14 @@
 <html lang="${LANG}">
 
 <head>
+    <script>
+        let path = window.location.pathname;
+        if (path) {
+            let lastChar = path.substr(path.length - 1);
+            if (lastChar != '/')
+                window.location.replace(window.location.href + '/');
+        }
+    </script>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=10" />
     <title>qBittorrent Web UI</title>

--- a/src/webui/www/public/index.html
+++ b/src/webui/www/public/index.html
@@ -2,6 +2,14 @@
 <html lang="${LANG}">
 
 <head>
+    <script>
+        let path = window.location.pathname;
+        if (path) {
+            let lastChar = path.substr(path.length - 1);
+            if (lastChar != '/')
+                window.location.replace(window.location.href + '/');
+        }
+    </script>
     <meta charset="UTF-8" />
     <title>qBittorrent QBT_TR(Web UI)QBT_TR[CONTEXT=OptionsDialog]</title>
     <link rel="icon" type="image/png" href="images/qbittorrent32.png" />


### PR DESCRIPTION
Closes #5693
Index pages now automatically redirect to a path with a trailing"/". If the site was accessed through a proxy with a modified path, a missing trailing "/" would break the relative paths.