### PR TITLE
Don't use executable name as CFBundleName value (v4_3_x backport)

### DIFF
--- a/dist/mac/Info.plist
+++ b/dist/mac/Info.plist
@@ -47,7 +47,7 @@
 		</dict>
 	</array>
 	<key>CFBundleName</key>
-	<string>@EXECUTABLE@</string>
+	<string>qBittorrent</string>
 	<key>CFBundleIconFile</key>
 	<string>qbittorrent_mac.icns</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -93,7 +93,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     )
     set_target_properties(qbt_app PROPERTIES
         MACOSX_BUNDLE ON
-        MACOSX_BUNDLE_BUNDLE_NAME "${EXECUTABLE}"
+        MACOSX_BUNDLE_BUNDLE_NAME "qBittorrent"
         MACOSX_BUNDLE_INFO_PLIST ${qBittorrent_BINARY_DIR}/dist/mac/Info.plist
     )
     target_sources(qbt_app PRIVATE


### PR DESCRIPTION
backport https://github.com/qbittorrent/qBittorrent/pull/14811 to v4_3_x
just cherry-picked 29e6b229ac7b5f717202cd9ed3e824c7ba7328bf