### PR TITLE
Correctly handle "not enough disk space" error (v4_3_x backport)

### DIFF
--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -947,7 +947,7 @@ bool TorrentImpl::hasMissingFiles() const
 
 bool TorrentImpl::hasError() const
 {
-    return static_cast<bool>(m_nativeStatus.errc);
+    return (m_nativeStatus.errc || (m_nativeStatus.flags & lt::torrent_flags::upload_mode));
 }
 
 bool TorrentImpl::hasFilteredPieces() const
@@ -966,7 +966,13 @@ int TorrentImpl::queuePosition() const
 
 QString TorrentImpl::error() const
 {
-    return QString::fromStdString(m_nativeStatus.errc.message());
+    if (m_nativeStatus.errc)
+        return QString::fromStdString(m_nativeStatus.errc.message());
+
+    if (m_nativeStatus.flags & lt::torrent_flags::upload_mode)
+        return tr("There's not enough space on disk. Torrent is currently in \"upload only\" mode.");
+
+    return {};
 }
 
 qlonglong TorrentImpl::totalDownload() const
@@ -1525,7 +1531,10 @@ void TorrentImpl::pause()
 void TorrentImpl::resume(const TorrentOperatingMode mode)
 {
     if (hasError())
+    {
         m_nativeHandle.clear_error();
+        m_nativeHandle.unset_flags(lt::torrent_flags::upload_mode);
+    }
 
     m_operatingMode = mode;
 
@@ -1747,6 +1756,9 @@ void TorrentImpl::handleSaveResumeDataAlert(const lt::save_resume_data_alert *p)
     }
 
     m_ltAddTorrentParams.added_time = addedTime().toSecsSinceEpoch();
+
+    // We shouldn't save upload_mode flag to allow torrent operate normally on next run
+    m_ltAddTorrentParams.flags &= ~lt::torrent_flags::upload_mode;
 
     if (m_maintenanceJob == MaintenanceJob::HandleMetadata)
     {


### PR DESCRIPTION
If torrent failed to write, it stops downloading and goes to "upload mode" instead of errored state so it just keeps seeding.
Now qBittorrent indicates this state as "errored" and allows the user to manually bring the torrent out of this state.