### PR TITLE
Initialize struct members by default

### DIFF
--- a/src/base/bittorrent/trackerentry.h
+++ b/src/base/bittorrent/trackerentry.h
@@ -53,10 +53,10 @@ namespace BitTorrent
             int numSeeds = -1;
             int numLeeches = -1;
             int numDownloaded = -1;
-            QString message;
+            QString message {};
         };
 
-        QString url;
+        QString url {};
         int tier = 0;
 
         QVector<EndpointStats> endpoints {};
@@ -67,7 +67,7 @@ namespace BitTorrent
         int numSeeds = -1;
         int numLeeches = -1;
         int numDownloaded = -1;
-        QString message;
+        QString message {};
     };
 
     bool operator==(const TrackerEntry &left, const TrackerEntry &right);


### PR DESCRIPTION
This is to suppress the following compilation warnings:
```
base/bittorrent/magneturi.cpp: In constructor ‘BitTorrent::MagnetUri::MagnetUri(const QString&)’:
base/bittorrent/magneturi.cpp:87:60: warning: missing initializer for member ‘BitTorrent::TrackerEntry::message’ [-Wmissing-field-initializers]
   87 |         m_trackers.append({QString::fromStdString(tracker)});
```
https://travis-ci.org/github/qbittorrent/qBittorrent/jobs/768355867#L5519