### PR TITLE
TorrentCreator: Add new line before each protocol prefix

### DIFF
--- a/src/gui/torrentcreatordialog.cpp
+++ b/src/gui/torrentcreatordialog.cpp
@@ -195,8 +195,14 @@ void TorrentCreatorDialog::onCreateButtonClicked()
     // Disable dialog & set busy cursor
     setInteractionEnabled(false);
     setCursor(QCursor(Qt::WaitCursor));
-
-    const QStringList trackers = m_ui->trackersList->toPlainText().trimmed()
+    
+    // Add new line before each protocol prefix
+    QString trackerString = m_ui->trackersList->toPlainText();
+    trackerString.replace(QString("udp://"), QString("\nudp://"));
+    trackerString.replace(QString("http://"), QString("\nhttp://"));
+    trackerString.replace(QString("https://"), QString("\nhttps://"));
+    
+    const QStringList trackers = trackerString.trimmed()
         .replace(QRegularExpression("\n\n[\n]+"), "\n\n").split('\n');
     const BitTorrent::TorrentCreatorParams params
     {


### PR DESCRIPTION
This pull request resolves a bug with qBittorrent caused by users adding Tracker URLs in the Torrent Creator Dialog box like this:
```
udp://tracker.internetwarriors.net:1337/announce
udp://tracker.opentrackr.org:1337/announce
udp://tracker.openbittorrent.com:6969/announce
```

When the user does this, each tracker is added to tier 0 and only the first tracker works properly. qBittorrent currently requires a new line in between each Tracker URL like this:
```
udp://tracker.internetwarriors.net:1337/announce

udp://tracker.opentrackr.org:1337/announce

udp://tracker.openbittorrent.com:6969/announce
```

My approach to resolving this bug is to automatically add a new line before each protocol prefix in the tracker string.  This way, the user doesn't have to add a new line in between each Tracker URL in the Torrent Creator Dialog box anymore. 