### PR TITLE
Adds option to show subcategories as sub-menus in the torrent context menu.

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -423,6 +423,7 @@ Session::Session(QObject *parent)
     , m_defaultSavePath(BITTORRENT_SESSION_KEY("DefaultSavePath"), specialFolderLocation(SpecialFolder::Downloads), normalizePath)
     , m_tempPath(BITTORRENT_SESSION_KEY("TempPath"), defaultSavePath() + "temp/", normalizePath)
     , m_isSubcategoriesEnabled(BITTORRENT_SESSION_KEY("SubcategoriesEnabled"), false)
+    , m_isSubcategoriesAsSubMenusEnabled(BITTORRENT_SESSION_KEY("SubcategoriesAsSubMenusEnabled"), false)
     , m_isTempPathEnabled(BITTORRENT_SESSION_KEY("TempPathEnabled"), false)
     , m_isAutoTMMDisabledByDefault(BITTORRENT_SESSION_KEY("DisableAutoTMMByDefault"), true)
     , m_isDisableAutoTMMWhenCategoryChanged(BITTORRENT_SESSION_KEY("DisableAutoTMMTriggers/CategoryChanged"), false)
@@ -819,6 +820,16 @@ void Session::setSubcategoriesEnabled(const bool value)
 
     m_isSubcategoriesEnabled = value;
     emit subcategoriesSupportChanged();
+}
+
+bool Session::isSubcategoriesAsSubMenusEnabled() const
+{
+    return m_isSubcategoriesAsSubMenusEnabled;
+}
+
+void Session::setSubcategoriesAsSubMenusEnabled(const bool value)
+{
+    m_isSubcategoriesAsSubMenusEnabled = value;
 }
 
 QSet<QString> Session::tags() const

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -231,6 +231,8 @@ namespace BitTorrent
         bool removeCategory(const QString &name);
         bool isSubcategoriesEnabled() const;
         void setSubcategoriesEnabled(bool value);
+        bool isSubcategoriesAsSubMenusEnabled() const;
+        void setSubcategoriesAsSubMenusEnabled(bool balue);
 
         static bool isValidTag(const QString &tag);
         QSet<QString> tags() const;
@@ -736,6 +738,7 @@ namespace BitTorrent
         CachedSettingValue<QString> m_defaultSavePath;
         CachedSettingValue<QString> m_tempPath;
         CachedSettingValue<bool> m_isSubcategoriesEnabled;
+        CachedSettingValue<bool> m_isSubcategoriesAsSubMenusEnabled;
         CachedSettingValue<bool> m_isTempPathEnabled;
         CachedSettingValue<bool> m_isAutoTMMDisabledByDefault;
         CachedSettingValue<bool> m_isDisableAutoTMMWhenCategoryChanged;

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -350,6 +350,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     // Downloads tab
     connect(m_ui->textSavePath, &FileSystemPathEdit::selectedPathChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->checkUseSubcategories, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->checkSubcategoriesAsSubMenus, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->comboSavingMode, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->comboTorrentCategoryChanged, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->comboCategoryDefaultPathChanged, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
@@ -730,6 +731,7 @@ void OptionsDialog::saveOptions()
     // Downloads preferences
     session->setDefaultSavePath(Utils::Fs::expandPathAbs(m_ui->textSavePath->selectedPath()));
     session->setSubcategoriesEnabled(m_ui->checkUseSubcategories->isChecked());
+    session->setSubcategoriesAsSubMenusEnabled(m_ui->checkSubcategoriesAsSubMenus->isChecked());
     session->setAutoTMMDisabledByDefault(m_ui->comboSavingMode->currentIndex() == 0);
     session->setDisableAutoTMMWhenCategoryChanged(m_ui->comboTorrentCategoryChanged->currentIndex() == 1);
     session->setDisableAutoTMMWhenCategorySavePathChanged(m_ui->comboCategoryChanged->currentIndex() == 1);
@@ -997,6 +999,7 @@ void OptionsDialog::loadOptions()
 
     m_ui->textSavePath->setSelectedPath(session->defaultSavePath());
     m_ui->checkUseSubcategories->setChecked(session->isSubcategoriesEnabled());
+    m_ui->checkSubcategoriesAsSubMenus->setChecked(session->isSubcategoriesAsSubMenusEnabled());
     m_ui->comboSavingMode->setCurrentIndex(!session->isAutoTMMDisabledByDefault());
     m_ui->comboTorrentCategoryChanged->setCurrentIndex(session->isDisableAutoTMMWhenCategoryChanged());
     m_ui->comboCategoryChanged->setCurrentIndex(session->isDisableAutoTMMWhenCategorySavePathChanged());

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -1089,6 +1089,13 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
                 </widget>
                </item>
                <item>
+                <widget class="QCheckBox" name="checkSubcategoriesAsSubMenus">
+                 <property name="text">
+                  <string>Use Sub-Menus for Subcategories</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <layout class="QGridLayout" name="gridLayout_4">
                  <item row="1" column="1">
                   <widget class="FileSystemPathLineEdit" name="textTempPath" native="true"/>

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -125,6 +125,7 @@ private:
     QStringList askTagsForSelection(const QString &dialogTitle);
     void applyToSelectedTorrents(const std::function<void (BitTorrent::Torrent *const)> &fn);
     QVector<BitTorrent::Torrent *> getVisibleTorrents() const;
+    void createCatgorySubMenus(QMenu *parentMenu, const QString parentName, const QVariantMap &leafs);
 
     TransferListModel *m_listModel;
     TransferListSortModel *m_sortFilterModel;


### PR DESCRIPTION
Implements #6924

Screen shot:

![qBittorrent-Categories-Sub-Menus](https://user-images.githubusercontent.com/333840/116908415-8c38f600-ac4b-11eb-9dd5-9bd13db8650c.png)

I couldn't think of a way to show the current category. I'm open to suggestions.

Last time I did C++ was long time ago and I haven't kept up with the language changes so If there is something stupid please point it out :)
