### PR TITLE
Fix potential data race

### DIFF
--- a/src/base/bittorrent/dbresumedatastorage.cpp
+++ b/src/base/bittorrent/dbresumedatastorage.cpp
@@ -389,7 +389,7 @@ void BitTorrent::DBResumeDataStorage::createDB() const
     catch (const RuntimeError &err)
     {
         db.rollback();
-        throw err;
+        throw;
     }
 }
 
@@ -566,7 +566,7 @@ void BitTorrent::DBResumeDataStorage::Worker::storeQueue(const QVector<TorrentID
         catch (const RuntimeError &err)
         {
             db.rollback();
-            throw err;
+            throw;
         }
     }
     catch (const RuntimeError &err)

--- a/src/base/settingsstorage.cpp
+++ b/src/base/settingsstorage.cpp
@@ -184,9 +184,8 @@ SettingsStorage *SettingsStorage::instance()
 
 bool SettingsStorage::save()
 {
-    if (!m_dirty) return true; // Obtaining the lock is expensive, let's check early
-    const QWriteLocker locker(&m_lock);  // to guard for `m_dirty`
-    if (!m_dirty) return true; // something might have changed while we were getting the lock
+    const QWriteLocker locker(&m_lock);  // guard for `m_dirty` too
+    if (!m_dirty) return true;
 
     const TransactionalSettings settings(QLatin1String("qBittorrent"));
     if (!settings.write(m_data))

--- a/src/gui/properties/piecesbar.cpp
+++ b/src/gui/properties/piecesbar.cpp
@@ -154,7 +154,7 @@ void PiecesBar::enterEvent(QEvent *e)
 void PiecesBar::leaveEvent(QEvent *e)
 {
     m_hovered = false;
-    m_highlitedRegion = QRect();
+    m_highlightedRegion = {};
     requestImageUpdate();
     base::leaveEvent(e);
 }
@@ -183,11 +183,11 @@ void PiecesBar::paintEvent(QPaintEvent *)
         painter.drawImage(imageRect, m_image);
     }
 
-    if (!m_highlitedRegion.isNull())
+    if (!m_highlightedRegion.isNull())
     {
         QColor highlightColor {this->palette().color(QPalette::Active, QPalette::Highlight)};
         highlightColor.setAlphaF(0.35);
-        QRect targetHighlightRect {m_highlitedRegion.adjusted(borderWidth, borderWidth, borderWidth, height() - 2 * borderWidth)};
+        QRect targetHighlightRect {m_highlightedRegion.adjusted(borderWidth, borderWidth, borderWidth, height() - 2 * borderWidth)};
         painter.fillRect(targetHighlightRect, highlightColor);
     }
 
@@ -316,15 +316,15 @@ void PiecesBar::highlightFile(int imagePos)
 
         ImageRange imageRange = transform.imagePos(filePieces);
         QRect newHighlitedRegion {imageRange.first(), 0, imageRange.size(), m_image.height()};
-        if (newHighlitedRegion != m_highlitedRegion)
+        if (newHighlitedRegion != m_highlightedRegion)
         {
-            m_highlitedRegion = newHighlitedRegion;
+            m_highlightedRegion = newHighlitedRegion;
             update();
         }
     }
-    else if (!m_highlitedRegion.isEmpty())
+    else if (!m_highlightedRegion.isEmpty())
     {
-        m_highlitedRegion = QRect();
+        m_highlightedRegion = {};
         update();
     }
 }

--- a/src/gui/properties/piecesbar.cpp
+++ b/src/gui/properties/piecesbar.cpp
@@ -112,8 +112,6 @@ namespace
 
 PiecesBar::PiecesBar(QWidget *parent)
     : QWidget {parent}
-    , m_torrent {nullptr}
-    , m_hovered {false}
 {
     updatePieceColors();
     setMouseTracking(true);

--- a/src/gui/properties/piecesbar.h
+++ b/src/gui/properties/piecesbar.h
@@ -91,10 +91,10 @@ private:
     virtual bool updateImage(QImage &image) = 0;
     void updatePieceColors();
 
-    const BitTorrent::Torrent *m_torrent;
+    const BitTorrent::Torrent *m_torrent = nullptr;
     QImage m_image;
     // buffered 256 levels gradient from bg_color to piece_color
     QVector<QRgb> m_pieceColors;
-    bool m_hovered;
+    bool m_hovered = false;
     QRect m_highlitedRegion; //!< part of the bar can be highlighted; this rectangle is in the same frame as m_image
 };

--- a/src/gui/properties/piecesbar.h
+++ b/src/gui/properties/piecesbar.h
@@ -96,5 +96,5 @@ private:
     // buffered 256 levels gradient from bg_color to piece_color
     QVector<QRgb> m_pieceColors;
     bool m_hovered = false;
-    QRect m_highlitedRegion; //!< part of the bar can be highlighted; this rectangle is in the same frame as m_image
+    QRect m_highlightedRegion; // part of the bar can be highlighted; this rectangle is in the same frame as m_image
 };


### PR DESCRIPTION
* Move initial values to header
* Fix typo
* Throw the exact (same) exception
* Fix potential data race
  This case could be considered benign however it could still be an undefined behavior to the compiler, so remove it.
  Ref:
  https://hacks.mozilla.org/2021/04/eliminating-data-races-in-firefox-a-technical-report/

