### PR TITLE
Update grunt dependency

### DIFF
--- a/src/icons/build-icons/package.json
+++ b/src/icons/build-icons/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {},
   "devDependencies": {
-    "grunt": "^0.4.5",
+    "grunt": ">=1.3.0",
     "grunt-svg2png": "git+https://git@github.com/bertyhell/grunt-svg2png.git"
   },
   "author": "Bert Verhelst",


### PR DESCRIPTION
This fixes CVE-2020-7729

Github link to the CVE: https://github.com/advisories/GHSA-m5pj-vjjf-4m3h

This was alerted by github's "dependabot" autoscan of the repo.