### PR TITLE
CMake: improve Windows build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,16 +148,19 @@ jobs:
           --graphviz=build\target_graph.dot
         cmake --build build
 
+    - name: install qBittorrent
+      run: |
+        cmake --install build --prefix qBittorrent-CI_Windows-x64
+
     - name: upload artifact as zip
       uses: actions/upload-artifact@v2
       with:
         name: qBittorrent-CI_Windows-x64
         path: |
           build/compile_commands.json
+          build/install_manifest.txt
           build/target_graph.dot
-          build/qbittorrent.exe
-          build/qbittorrent.pdb
-          dist/windows/qt.conf
+          qBittorrent-CI_Windows-x64
 
   ci_macos:
     name: macOS + vcpkg

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16 FATAL_ERROR) # Policies <= CMP0097 default to NEW
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR) # Configurable policies: up to and including CMP0120
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR) # Configurable policies: up to and including CMP0120
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 
 project(qBittorrent
     DESCRIPTION "The qBittorrent BitTorrent client"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     endif()
 elseif (MSVC)
     feature_option(MSVC_RUNTIME_DYNAMIC "Use MSVC dynamic runtime library (-MD) instead of static (-MT)" ON)
+    feature_option(COPY_RUNTIME_DEPS_TO_BUILDIR "Copy dynamic build runtime dependencies to the build directory (e.g. DLLs), so that fully dynamic builds can be executed from there directly without requiring PATH setup or installing first." OFF)
 endif()
 
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(minLibtorrentVersion 1.2.13)
 set(minZlibVersion 1.2.11)
 
 # features (some are platform-specific)
-include(CheckCXXSourceCompiles) # TODO: migrate to CheckSourceCompiles in CMake >= 3.19
+include(CheckSourceCompiles)
 include(FeatureSummary)
 include(FeatureOptionsSetup)
 feature_option(STACKTRACE "Enable stacktraces" ON)
@@ -35,7 +35,8 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
         OFF "NOT GUI" OFF
     )
     if (STACKTRACE)
-        check_cxx_source_compiles(
+        check_source_compiles(
+            CXX
             "#include <execinfo.h>
             int main(){return 0;}"
             QBITTORRENT_HAS_EXECINFO_H

--- a/cmake/Modules/MacroQbtFindDependentDLLs.cmake
+++ b/cmake/Modules/MacroQbtFindDependentDLLs.cmake
@@ -1,0 +1,52 @@
+# Find the paths to the dependent DLLs of qBittorrent that are not accessible in another way;
+# Currently, they are the DLLs corresponding to the OpenSSL and ZLIB packages.
+# Variables this macro defines: OPENSSL_LIBCRYPTO_DLL, OPENSSL_LIBSSL_DLL,
+# and one or both of ZLIB_DLL_DBG, ZLIB_DLL_REL
+# TODO: works for MSVC, what about MinGW?
+# TODO: This can probably be entirely removed (or at least greatly simplified and made more robust)
+# by using TARGET_RUNTIME_DLLS instead, in CMake >= 3.21, which even resolves and handles
+# transitive dependencies automatically
+
+macro(qbt_find_dependent_dlls)
+    # Must manually find these DLLs, because the target names for these libs point at the .lib files, not the .dll files
+    # Handling zlib is trickier than OpenSSL because FindZLIB sucks
+    cmake_path(SET OPENSSL_DLLS_PATH "${OPENSSL_CRYPTO_LIBRARY}")
+    cmake_path(GET OPENSSL_DLLS_PATH PARENT_PATH OPENSSL_DLLS_PATH)
+    cmake_path(SET OPENSSL_DLLS_PATH NORMALIZE "${OPENSSL_DLLS_PATH}/../bin")
+    find_file(OPENSSL_LIBSSL_DLL "libssl-1_1-x64.dll" PATHS "${OPENSSL_DLLS_PATH}" DOC "OpenSSL::SSL DLL path" REQUIRED
+        NO_DEFAULT_PATH NO_PACKAGE_ROOT_PATH NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH NO_CMAKE_FIND_ROOT_PATH
+    )
+    find_file(OPENSSL_LIBCRYPTO_DLL "libcrypto-1_1-x64.dll" PATHS "${OPENSSL_DLLS_PATH}" DOC "OpenSSL::Crypto DLL path" REQUIRED
+        NO_DEFAULT_PATH NO_PACKAGE_ROOT_PATH NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH NO_CMAKE_FIND_ROOT_PATH
+    )
+    list(APPEND ZLIB_NAMES_LIST "z.dll" "zlib.dll" "zdll.dll" "zlib1.dll" "zd.dll" "zlibd.dll" "zdlld.dll" "zlibd1.dll" "zlib1d.dll")
+    get_target_property(ZLIB_RELEASE_LOCATION ZLIB::ZLIB IMPORTED_LOCATION_RELEASE)
+    get_target_property(ZLIB_DEBUG_LOCATION ZLIB::ZLIB IMPORTED_LOCATION_DEBUG)
+    get_target_property(ZLIB_ANY_LOCATION ZLIB::ZLIB IMPORTED_LOCATION)
+    if (ZLIB_RELEASE_LOCATION)
+        cmake_path(SET ZLIB_RELEASE_LOCATION "${ZLIB_RELEASE_LOCATION}")
+        cmake_path(GET ZLIB_RELEASE_LOCATION PARENT_PATH ZLIB_RELEASE_LOCATION)
+        cmake_path(SET ZLIB_RELEASE_LOCATION NORMALIZE "${ZLIB_RELEASE_LOCATION}/../bin")
+        find_file(ZLIB_DLL_REL ${ZLIB_NAMES_LIST} PATHS "${ZLIB_RELEASE_LOCATION}" DOC "ZLIB::ZLIB DLL path (Release)" REQUIRED
+            NO_DEFAULT_PATH NO_PACKAGE_ROOT_PATH NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH NO_CMAKE_FIND_ROOT_PATH
+        )
+    endif()
+    if (ZLIB_DEBUG_LOCATION)
+        cmake_path(SET ZLIB_DEBUG_LOCATION "${ZLIB_DEBUG_LOCATION}")
+        cmake_path(GET ZLIB_DEBUG_LOCATION PARENT_PATH ZLIB_DEBUG_LOCATION)
+        cmake_path(SET ZLIB_DEBUG_LOCATION NORMALIZE "${ZLIB_DEBUG_LOCATION}/../bin")
+        find_file(ZLIB_DLL_DBG ${ZLIB_NAMES_LIST} PATHS "${ZLIB_DEBUG_LOCATION}" DOC "ZLIB::ZLIB DLL path (Debug)" REQUIRED
+            NO_DEFAULT_PATH NO_PACKAGE_ROOT_PATH NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH NO_CMAKE_FIND_ROOT_PATH
+        )
+    endif()
+    if (ZLIB_ANY_LOCATION)
+        cmake_path(SET ZLIB_ANY_LOCATION "${ZLIB_ANY_LOCATION}")
+        cmake_path(GET ZLIB_ANY_LOCATION PARENT_PATH ZLIB_ANY_LOCATION)
+        cmake_path(SET ZLIB_ANY_LOCATION NORMALIZE "${ZLIB_ANY_LOCATION}/../bin")
+        find_file(ZLIB_DLL_ANY ${ZLIB_NAMES_LIST} PATHS "${ZLIB_ANY_LOCATION}" DOC "ZLIB::ZLIB DLL path (any)" REQUIRED
+            NO_DEFAULT_PATH NO_PACKAGE_ROOT_PATH NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH NO_CMAKE_FIND_ROOT_PATH
+        )
+        set(ZLIB_DLL_REL "${ZLIB_DLL_ANY}")
+        set(ZLIB_DLL_DBG "${ZLIB_DLL_ANY}")
+    endif()
+endmacro(qbt_find_dependent_dlls)

--- a/dist/unix/CMakeLists.txt
+++ b/dist/unix/CMakeLists.txt
@@ -10,46 +10,46 @@ if (SYSTEMD)
             )
         endif()
     endif()
-    set(EXPAND_BINDIR ${CMAKE_INSTALL_FULL_BINDIR})
-    configure_file(systemd/qbittorrent-nox@.service.in ${CMAKE_CURRENT_BINARY_DIR}/qbittorrent-nox@.service @ONLY)
+    set(EXPAND_BINDIR "${CMAKE_INSTALL_FULL_BINDIR}")
+    configure_file(systemd/qbittorrent-nox@.service.in "${CMAKE_CURRENT_BINARY_DIR}/qbittorrent-nox@.service" @ONLY)
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/qbittorrent-nox@.service"
-        DESTINATION ${SYSTEMD_SERVICES_INSTALL_DIR}
+        DESTINATION "${SYSTEMD_SERVICES_INSTALL_DIR}"
         COMPONENT data
     )
 endif()
 
 if (GUI)
-    list(APPEND MAN_FILES ${PROJECT_SOURCE_DIR}/doc/qbittorrent.1)
+    list(APPEND MAN_FILES_LIST "${PROJECT_SOURCE_DIR}/doc/qbittorrent.1")
 else()
-    list(APPEND MAN_FILES ${PROJECT_SOURCE_DIR}/doc/qbittorrent-nox.1)
+    list(APPEND MAN_FILES_LIST "${PROJECT_SOURCE_DIR}/doc/qbittorrent-nox.1")
 endif()
 
-install(FILES ${MAN_FILES}
-    DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
+install(FILES ${MAN_FILES_LIST}
+    DESTINATION "${CMAKE_INSTALL_MANDIR}/man1"
     COMPONENT doc
 )
 
 if (GUI)
     install(FILES org.qbittorrent.qBittorrent.desktop
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications/
+        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications"
         COMPONENT data
     )
 
     install(FILES org.qbittorrent.qBittorrent.appdata.xml
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/metainfo/
+        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/metainfo"
         COMPONENT data
     )
 
     install(DIRECTORY menuicons/
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor
+        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor"
         COMPONENT data
     )
 
     install(FILES
-        ${PROJECT_SOURCE_DIR}/src/icons/qbittorrent-tray.svg
-        ${PROJECT_SOURCE_DIR}/src/icons/qbittorrent-tray-dark.svg
-        ${PROJECT_SOURCE_DIR}/src/icons/qbittorrent-tray-light.svg
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/status
+        "${PROJECT_SOURCE_DIR}/src/icons/qbittorrent-tray.svg"
+        "${PROJECT_SOURCE_DIR}/src/icons/qbittorrent-tray-dark.svg"
+        "${PROJECT_SOURCE_DIR}/src/icons/qbittorrent-tray-light.svg"
+        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/status"
         COMPONENT data
     )
 endif()

--- a/dist/windows/CMakeLists.txt
+++ b/dist/windows/CMakeLists.txt
@@ -1,4 +1,4 @@
 install(FILES qt.conf
-    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    DESTINATION "."
     COMPONENT runtime
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (UNIX AND (NOT APPLE) AND (NOT CYGWIN))
-    find_package(LibtorrentRasterbar QUIET ${minLibtorrentVersion} COMPONENTS torrent-rasterbar)
+    find_package(LibtorrentRasterbar QUIET "${minLibtorrentVersion}" COMPONENTS torrent-rasterbar)
     if (NOT LibtorrentRasterbar_FOUND)
         include(FindPkgConfig)
         pkg_check_modules(LIBTORRENT_RASTERBAR IMPORTED_TARGET GLOBAL "libtorrent-rasterbar>=${minLibtorrentVersion}")
@@ -28,16 +28,16 @@ if (UNIX AND (NOT APPLE) AND (NOT CYGWIN))
         set_package_properties(LibtorrentRasterbar PROPERTIES TYPE REQUIRED)
     endif()
 else()
-    find_package(LibtorrentRasterbar ${minLibtorrentVersion} REQUIRED COMPONENTS torrent-rasterbar)
+    find_package(LibtorrentRasterbar "${minLibtorrentVersion}" REQUIRED COMPONENTS torrent-rasterbar)
 endif()
 # force variable type so that it always shows up in ccmake/cmake-gui frontends
 set_property(CACHE LibtorrentRasterbar_DIR PROPERTY TYPE PATH)
-find_package(Boost ${minBoostVersion} REQUIRED)
-find_package(OpenSSL ${minOpenSSLVersion} REQUIRED)
-find_package(ZLIB ${minZlibVersion} REQUIRED)
-find_package(Qt5 ${minQtVersion} REQUIRED COMPONENTS Core Network Sql Xml LinguistTools)
+find_package(Boost "${minBoostVersion}" REQUIRED)
+find_package(OpenSSL "${minOpenSSLVersion}" REQUIRED)
+find_package(ZLIB "${minZlibVersion}" REQUIRED)
+find_package(Qt5 "${minQtVersion}" REQUIRED COMPONENTS Core LinguistTools Network Sql Xml)
 if (DBUS)
-    find_package(Qt5 ${minQtVersion} REQUIRED COMPONENTS DBus)
+    find_package(Qt5 "${minQtVersion}" REQUIRED COMPONENTS DBus)
     set_package_properties(Qt5DBus PROPERTIES
         DESCRIPTION "Qt5 module for inter-process communication over the D-Bus protocol"
         PURPOSE "Required by the DBUS feature"
@@ -55,14 +55,14 @@ include(MacroQbtCommonConfig)
 qbt_common_config()
 
 # include directories - ideally, would be done per target instead of global directory scope
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
 
 add_subdirectory(base)
 
 if (GUI)
-    find_package(Qt5 ${minQtVersion} REQUIRED COMPONENTS Widgets Svg)
+    find_package(Qt5 "${minQtVersion}" REQUIRED COMPONENTS Widgets Svg)
     if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
-        find_package(Qt5 ${minQtVersion} REQUIRED COMPONENTS WinExtras)
+        find_package(Qt5 "${minQtVersion}" REQUIRED COMPONENTS WinExtras)
     endif()
     add_subdirectory(gui)
 endif()

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -98,6 +98,40 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
         target_sources(qbt_app PRIVATE "${qBittorrent_SOURCE_DIR}/src/qbittorrent.rc")
     endif()
     target_sources(qbt_app PRIVATE "${qBittorrent_SOURCE_DIR}/src/qbittorrent.exe.manifest")
+
+    # Find and copy dependent DLLs to the build folder after the build,
+    # so that the executable can be run from there with no additional setup.
+    # When using vcpkg, everything is automatically copied except for some stuff handled by windeployqt;
+    # this is no problem because the `copy_if_different` command is idempotent in this case
+    if (COPY_RUNTIME_DEPS_TO_BUILDIR)
+        # Variables this macro defines: OPENSSL_LIBCRYPTO_DLL, OPENSSL_LIBSSL_DLL,
+        # and one or both of ZLIB_DLL_DBG, ZLIB_DLL_REL
+        include(MacroQbtFindDependentDLLs)
+        qbt_find_dependent_dlls()
+
+        # TODO: remove this target definition after migrating to Qt6, since it provides a Qt6::windeployqt target natively
+        if (NOT TARGET Qt5::windeployqt)
+            get_target_property(_qt5_qmake_location Qt5::qmake IMPORTED_LOCATION)
+            cmake_path(GET _qt5_qmake_location PARENT_PATH _qt5_bin_dir)
+            cmake_path(APPEND _qt5_bin_dir "windeployqt.exe" OUTPUT_VARIABLE qt5_windeployqt_imported_location)
+            add_executable(Qt5::windeployqt IMPORTED)
+            set_target_properties(Qt5::windeployqt PROPERTIES
+                IMPORTED_LOCATION "${qt5_windeployqt_imported_location}"
+            )
+        endif()
+
+        list(APPEND WINDEPLOYQT_OPTIONS_LIST "--verbose" "0")
+        list(APPEND WINDEPLOYQT_OPTIONS_LIST "--no-angle") # TODO: remove when migrating to Qt6.
+        add_custom_command(TARGET qbt_app POST_BUILD
+            COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+            "$<IF:$<CONFIG:Debug>,${ZLIB_DLL_DBG},${ZLIB_DLL_REL}>"
+            "${OPENSSL_LIBCRYPTO_DLL}"
+            "${OPENSSL_LIBSSL_DLL}"
+            "$<TARGET_FILE:LibtorrentRasterbar::torrent-rasterbar>"
+            "$<TARGET_FILE_DIR:qbt_app>"
+            COMMAND Qt5::windeployqt ${WINDEPLOYQT_OPTIONS_LIST} "$<TARGET_FILE:qbt_app>"
+        )
+    endif()
 endif()
 
 # Additional feature dependent configuration
@@ -158,15 +192,30 @@ endif()
 # Installation
 # -----------------------------------------------------------------------------
 # -----------------------------------------------------------------------------
+# On Windows, everything goes in the base install location
+
 install(TARGETS qbt_app
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    BUNDLE  DESTINATION .
+    RUNTIME DESTINATION "$<IF:$<BOOL:${WIN32}>,.,${CMAKE_INSTALL_BINDIR}>"
+    BUNDLE  DESTINATION "."
     COMPONENT runtime
 )
 
+# TODO: works for MSVC, what about MinGW?
 if (MSVC)
     install(FILES $<TARGET_PDB_FILE:qbt_app>
-        DESTINATION ${CMAKE_INSTALL_BINDIR}
+        DESTINATION "."
+        COMPONENT runtime
         OPTIONAL
     )
+    if (COPY_RUNTIME_DEPS_TO_BUILDIR)
+        install(
+            DIRECTORY "${CMAKE_BINARY_DIR}/" # trailing slash is required here to copy only the contents
+            DESTINATION "."
+            COMPONENT runtime
+            FILES_MATCHING REGEX ".*.dll|.*.qm"
+            # the exclusion below is required to prevent creation of empty directories at the destination
+            # see https://gitlab.kitware.com/cmake/cmake/-/issues/19189
+            REGEX "CMakeFiles.*|dist.*|src.*" EXCLUDE
+        )
+    endif()
 endif()

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -2,23 +2,23 @@
 # -----------------------------------------------------------------------------
 # -----------------------------------------------------------------------------
 # Based on https://gist.github.com/giraldeau/546ba5512a74dfe9d8ea0862d66db412
-file(GLOB QBT_TS_FILES "${qBittorrent_SOURCE_DIR}/src/lang/*.ts")
-set_source_files_properties(${QBT_TS_FILES} PROPERTIES OUTPUT_LOCATION "${qBittorrent_BINARY_DIR}/src/lang")
-qt5_add_translation(QBT_QM_FILES ${QBT_TS_FILES} OPTIONS -silent)
+file(GLOB QBT_TS_FILES_LIST "${qBittorrent_SOURCE_DIR}/src/lang/*.ts")
+set_source_files_properties(${QBT_TS_FILES_LIST} PROPERTIES OUTPUT_LOCATION "${qBittorrent_BINARY_DIR}/src/lang")
+qt5_add_translation(QBT_QM_FILES_LIST ${QBT_TS_FILES_LIST} OPTIONS -silent)
 configure_file("${qBittorrent_SOURCE_DIR}/src/lang/lang.qrc" "${qBittorrent_BINARY_DIR}/src/lang/lang.qrc" COPYONLY)
 
 if (WEBUI)
-    file(GLOB QBT_WEBUI_TS_FILES "${qBittorrent_SOURCE_DIR}/src/webui/www/translations/*.ts")
-    set_source_files_properties(${QBT_WEBUI_TS_FILES}
+    file(GLOB QBT_WEBUI_TS_FILES_LIST "${qBittorrent_SOURCE_DIR}/src/webui/www/translations/*.ts")
+    set_source_files_properties(${QBT_WEBUI_TS_FILES_LIST}
         PROPERTIES OUTPUT_LOCATION "${qBittorrent_BINARY_DIR}/src/webui/www/translations")
-    qt5_add_translation(QBT_WEBUI_QM_FILES ${QBT_WEBUI_TS_FILES} OPTIONS -silent)
+    qt5_add_translation(QBT_WEBUI_QM_FILES_LIST ${QBT_WEBUI_TS_FILES_LIST} OPTIONS -silent)
     configure_file("${qBittorrent_SOURCE_DIR}/src/webui/www/translations/webui_translations.qrc"
         "${qBittorrent_BINARY_DIR}/src/webui/www/translations/webui_translations.qrc" COPYONLY)
 endif()
 
-FILE(GLOB QT_TRANSLATIONS "${qBittorrent_SOURCE_DIR}/dist/qt-translations/qtbase_*.qm")
+FILE(GLOB QT_TRANSLATIONS_LIST "${qBittorrent_SOURCE_DIR}/dist/qt-translations/qtbase_*.qm")
 foreach(EXTRA_TRANSLATION IN ITEMS "fa" "gl" "lt" "pt" "sl" "sv" "zh_CN")
-    list(APPEND QT_TRANSLATIONS "${qBittorrent_SOURCE_DIR}/dist/qt-translations/qt_${EXTRA_TRANSLATION}.qm")
+    list(APPEND QT_TRANSLATIONS_LIST "${qBittorrent_SOURCE_DIR}/dist/qt-translations/qt_${EXTRA_TRANSLATION}.qm")
 endforeach()
 
 # Executable target configuration
@@ -47,7 +47,7 @@ target_sources(qbt_app PRIVATE
     # resources
     "${qBittorrent_SOURCE_DIR}/src/icons/icons.qrc"
     "${qBittorrent_SOURCE_DIR}/src/searchengine/searchengine.qrc"
-    ${QBT_QM_FILES}
+    ${QBT_QM_FILES_LIST}
     "${qBittorrent_BINARY_DIR}/src/lang/lang.qrc" # yes, it's supposed to be "*_BINARY_DIR"
 )
 
@@ -65,7 +65,7 @@ endif()
 # Additional platform specific configuration
 # -----------------------------------------------------------------------------
 # -----------------------------------------------------------------------------
-set_source_files_properties(${QT_TRANSLATIONS} PROPERTIES MACOSX_PACKAGE_LOCATION translations)
+set_source_files_properties(${QT_TRANSLATIONS_LIST} PROPERTIES MACOSX_PACKAGE_LOCATION translations)
 set_source_files_properties(
     "${qBittorrent_SOURCE_DIR}/dist/mac/qt.conf"
     "${qBittorrent_SOURCE_DIR}/dist/mac/qBitTorrentDocument.icns"
@@ -78,26 +78,26 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     # provide variables for substitution in dist/mac/Info.plist
     get_target_property(EXECUTABLE_NAME qbt_app OUTPUT_NAME)
     # This variable name should be changed once qmake is no longer used. Refer to the discussion in PR #14813
-    set(MACOSX_DEPLOYMENT_TARGET ${CMAKE_OSX_DEPLOYMENT_TARGET})
+    set(MACOSX_DEPLOYMENT_TARGET "${CMAKE_OSX_DEPLOYMENT_TARGET}")
     set_target_properties(qbt_app PROPERTIES
         MACOSX_BUNDLE ON
         MACOSX_BUNDLE_BUNDLE_NAME "qBittorrent"
-        MACOSX_BUNDLE_INFO_PLIST ${qBittorrent_SOURCE_DIR}/dist/mac/Info.plist
+        MACOSX_BUNDLE_INFO_PLIST "${qBittorrent_SOURCE_DIR}/dist/mac/Info.plist"
     )
     target_sources(qbt_app PRIVATE
-        ${QT_TRANSLATIONS}
-        ${qBittorrent_SOURCE_DIR}/dist/mac/qt.conf
-        ${qBittorrent_SOURCE_DIR}/dist/mac/qBitTorrentDocument.icns
-        ${qBittorrent_SOURCE_DIR}/dist/mac/qbittorrent_mac.icns
+        ${QT_TRANSLATIONS_LIST}
+        "${qBittorrent_SOURCE_DIR}/dist/mac/qt.conf"
+        "${qBittorrent_SOURCE_DIR}/dist/mac/qBitTorrentDocument.icns"
+        "${qBittorrent_SOURCE_DIR}/dist/mac/qbittorrent_mac.icns"
     )
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set_target_properties(qbt_app PROPERTIES WIN32_EXECUTABLE ON)
     if (MINGW)
-        target_sources(qbt_app PRIVATE ${qBittorrent_SOURCE_DIR}/src/qbittorrent_mingw.rc)
+        target_sources(qbt_app PRIVATE "${qBittorrent_SOURCE_DIR}/src/qbittorrent_mingw.rc")
     else()
-        target_sources(qbt_app PRIVATE ${qBittorrent_SOURCE_DIR}/src/qbittorrent.rc)
+        target_sources(qbt_app PRIVATE "${qBittorrent_SOURCE_DIR}/src/qbittorrent.rc")
     endif()
-    target_sources(qbt_app PRIVATE ${qBittorrent_SOURCE_DIR}/src/qbittorrent.exe.manifest)
+    target_sources(qbt_app PRIVATE "${qBittorrent_SOURCE_DIR}/src/qbittorrent.exe.manifest")
 endif()
 
 # Additional feature dependent configuration
@@ -149,8 +149,8 @@ endif()
 
 if (WEBUI)
     target_sources(qbt_app PRIVATE
-        ${QBT_WEBUI_QM_FILES}
-        ${qBittorrent_BINARY_DIR}/src/webui/www/translations/webui_translations.qrc # yes, it's supposed to be "*_BINARY_DIR"
+        ${QBT_WEBUI_QM_FILES_LIST}
+        "${qBittorrent_BINARY_DIR}/src/webui/www/translations/webui_translations.qrc" # yes, it's supposed to be "*_BINARY_DIR"
     )
     target_link_libraries(qbt_app PRIVATE qbt_webui)
 endif()

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -186,9 +186,9 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     find_library(AppKit_LIBRARY AppKit)
 
     target_link_libraries(qbt_base PRIVATE
-        ${AppKit_LIBRARY}
-        ${Carbon_LIBRARY}
-        ${IOKit_LIBRARY}
+        "${AppKit_LIBRARY}"
+        "${Carbon_LIBRARY}"
+        "${IOKit_LIBRARY}"
     )
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     target_link_libraries(qbt_base PRIVATE Iphlpapi)


### PR DESCRIPTION
#### CI: Run installation for Windows static builds

#### CMake: improve Windows build

- All necessary runtime components for dynamic builds are now copied to
the build directory as a post-build step, improving the
edit/compile/debug cycle experience for these builds, as no PATH setup
is necessary.

- Windows installation was revamped and fixed for both static
and dynamic builds. The default behavior is less surprising: all
necessary files are installed to `C:\Program Files\qBittorrent` by
default.

#### CMake: clarify variable purpose and expansion

- Enquote all dereferencing of variables that are not meant to be expanded
as separate parameters.
- Add the `_LIST` suffix to all variables that are meant to be lists.

#### CMake: Migrate to CheckSourceCompiles

#### CMake: bump minimum version to 3.20
---

This a "Qt5 backport" of the efforts posted in https://github.com/glassez/qBittorrent/pull/1. CI for dynamic builds is purposefully not included here, that is to be discussed and maybe implemented in another PR.

The bump to CMake 3.20 is perhaps a bit unfortunate, but `vcpkg` already works with it, GitHub Actions supports it, and we've been dropping support for older OS's in master, so I don't think the fact that its not in many repos yet is a big deal (not that installing the latest version of CMake is hard... https://youtu.be/_yFPO1ofyF0?t=45)