### PR TITLE
CMake: Add a custom target to strip executable

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -155,6 +155,16 @@ if (WEBUI)
     target_link_libraries(qbt_app PRIVATE qbt_webui)
 endif()
 
+if ((UNIX AND (NOT APPLE)) OR MINGW OR MSYS)
+    add_custom_target(strip_build
+        COMMAND "${CMAKE_COMMAND}" -E "$<IF:$<BOOL:${STACKTRACE}>,echo,echo_append>"
+            "$<IF:$<BOOL:${STACKTRACE}>,WARNING: the STACKTRACE feature is enabled$<COMMA> but stripping the executable will make stacktraces useless.,>"
+        COMMAND "strip" "--strip-all" "$<TARGET_FILE:qbt_app>"
+        COMMENT "Stripping executable..."
+        VERBATIM
+    )
+endif()
+
 # Installation
 # -----------------------------------------------------------------------------
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
The new custom target, `strip_build`, depends on the main executable
target and can optionally be used via `cmake
--build build_dir --target strip_build` to strip the executable in the
build folder.

The only other "native" way to strip the executable would be to run
either `cmake --install --strip build_dir` or `cmake --build build_dir
--target install/strip`, both of which require actually performing the
install step, which might not be desired.

Currently, this is only implemented for non-Apple UNIX-like systems.

---

Extracted from https://github.com/qbittorrent/qBittorrent/pull/14995, ping @userdocs.