### PR TITLE
Keep sub-sorting order

### DIFF
--- a/src/gui/transferlistsortmodel.cpp
+++ b/src/gui/transferlistsortmodel.cpp
@@ -96,8 +96,22 @@ namespace
 TransferListSortModel::TransferListSortModel(QObject *parent)
     : QSortFilterProxyModel {parent}
     , m_subSortColumn {"TransferList/SubSortColumn", TransferListModel::TR_NAME, adjustSubSortColumn}
+    , m_subSortOrder {"TransferList/SubSortOrder", 0}
 {
     setSortRole(TransferListModel::UnderlyingDataRole);
+}
+
+void TransferListSortModel::sort(const int column, const Qt::SortOrder order)
+{
+    if ((m_lastSortColumn != column) && (m_lastSortColumn != -1))
+    {
+        m_subSortColumn = m_lastSortColumn;
+        m_subSortOrder = m_lastSortOrder;
+    }
+    m_lastSortColumn = column;
+    m_lastSortOrder = ((order == Qt::AscendingOrder) ? 0 : 1);
+
+    QSortFilterProxyModel::sort(column, order);
 }
 
 void TransferListSortModel::setStatusFilter(TorrentFilter::Type filter)
@@ -219,16 +233,16 @@ bool TransferListSortModel::lessThan(const QModelIndex &left, const QModelIndex 
 {
     Q_ASSERT(left.column() == right.column());
 
-    if (m_lastSortColumn != left.column())
-    {
-        if (m_lastSortColumn != -1)
-            m_subSortColumn = m_lastSortColumn;
-        m_lastSortColumn = left.column();
-    }
-
     const int result = compare(left, right);
     if (result == 0)
-        return compare(left.sibling(left.row(), m_subSortColumn), right.sibling(right.row(), m_subSortColumn)) < 0;
+    {
+        const int subResult = compare(left.sibling(left.row(), m_subSortColumn), right.sibling(right.row(), m_subSortColumn));
+        // Qt inverses lessThan() result when ordered descending.
+        // For sub-sorting we have to do it manually.
+        // When both are ordered descending subResult must be double-inversed, which is the same as no inversion.
+        const bool inverseSubResult = (m_lastSortOrder != m_subSortOrder); // exactly one is descending
+        return (inverseSubResult ? (subResult > 0) : (subResult < 0));
+    }
 
     return result < 0;
 }

--- a/src/gui/transferlistsortmodel.h
+++ b/src/gui/transferlistsortmodel.h
@@ -47,6 +47,8 @@ class TransferListSortModel final : public QSortFilterProxyModel
 public:
     explicit TransferListSortModel(QObject *parent = nullptr);
 
+    void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override;
+
     void setStatusFilter(TorrentFilter::Type filter);
     void setCategoryFilter(const QString &category);
     void disableCategoryFilter();
@@ -63,8 +65,10 @@ private:
     bool matchFilter(int sourceRow, const QModelIndex &sourceParent) const;
 
     TorrentFilter m_filter;
-    mutable CachedSettingValue<int> m_subSortColumn;
-    mutable int m_lastSortColumn = -1;
+    CachedSettingValue<int> m_subSortColumn;
+    CachedSettingValue<int> m_subSortOrder;
+    int m_lastSortColumn = -1;
+    int m_lastSortOrder = 0;
 
     Utils::Compare::NaturalCompare<Qt::CaseInsensitive> m_naturalCompare;
 };


### PR DESCRIPTION
Fixes #15073

Sub-sorting now works like in most grids where sub-sorting is a thing (except there is still no indication in UI).
Sub-sorting column tracked from `sort()` method that is called exactly once per view sort unlike `lessThan()` so it is a bit cleaner now too.

This complements earlier work done in https://github.com/qbittorrent/qBittorrent/pull/14423