### PR TITLE
Don't close tags menu when toggling items. Closes #13492

### DIFF
--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -1009,13 +1009,13 @@ void TransferListWidget::displayListMenu(const QPoint &)
     for (const QString &tag : asConst(tags))
     {
         auto *action = new TriStateAction(tag, tagsMenu);
-        action->setCloseOnTriggered(false);
+        action->setCloseOnInteraction(false);
 
         const Qt::CheckState initialState = tagsInAll.contains(tag) ? Qt::Checked
                                             : tagsInAny.contains(tag) ? Qt::PartiallyChecked : Qt::Unchecked;
         action->setCheckState(initialState);
 
-        connect(action, &QAction::triggered, this, [this, tag](const bool checked)
+        connect(action, &QAction::toggled, this, [this, tag](const bool checked)
         {
             if (checked)
                 addSelectionTag(tag);

--- a/src/gui/tristateaction.cpp
+++ b/src/gui/tristateaction.cpp
@@ -45,8 +45,7 @@ TriStateAction::TriStateAction(const QString &text, QWidget *parent)
         m_triStateWidget->setCheckState(checked ? Qt::Checked : Qt::Unchecked);
     });
 
-    connect(m_triStateWidget, &TriStateWidget::triggered, this, &QAction::setChecked);
-    connect(m_triStateWidget, &TriStateWidget::triggered, this, &QAction::triggered);
+    connect(m_triStateWidget, &TriStateWidget::triggered, this, &QAction::toggled);
     setDefaultWidget(m_triStateWidget);
 }
 
@@ -56,7 +55,7 @@ void TriStateAction::setCheckState(const Qt::CheckState checkState)
     m_triStateWidget->setCheckState(checkState);
 }
 
-void TriStateAction::setCloseOnTriggered(const bool enabled)
+void TriStateAction::setCloseOnInteraction(const bool enabled)
 {
-    m_triStateWidget->setCloseOnTriggered(enabled);
+    m_triStateWidget->setCloseOnInteraction(enabled);
 }

--- a/src/gui/tristateaction.h
+++ b/src/gui/tristateaction.h
@@ -37,7 +37,7 @@ class TriStateWidget;
 
 // TriStateWidget is responsible for checkbox state (tri-state) and paint events while
 // TriStateAction will keep in sync with it. This allows connecting with the usual
-// QAction::triggered slot.
+// QAction::triggered or QAction::toggled slots.
 class TriStateAction : public QWidgetAction
 {
 public:
@@ -46,7 +46,12 @@ public:
     // should use this function instead of QAction::setChecked(bool)
     void setCheckState(Qt::CheckState checkState);
 
-    void setCloseOnTriggered(bool enabled);
+    // When set to 'true' toggling the checkbox will emit a signal on
+    // QAction::triggered. When placed in a QMenu, this causes the menu to close.
+    // When set to 'false' emits a signal on QAction::toggled instead, leaving the
+    // menu open.
+    // Default value: 'true'.
+    void setCloseOnInteraction(bool enabled);
 
 private:
     TriStateWidget *m_triStateWidget;

--- a/src/gui/tristatewidget.cpp
+++ b/src/gui/tristatewidget.cpp
@@ -38,7 +38,7 @@
 
 TriStateWidget::TriStateWidget(const QString &text, QWidget *parent)
     : QWidget {parent}
-    , m_closeOnTriggered {true}
+    , m_closeOnInteraction {true}
     , m_checkState {Qt::Unchecked}
     , m_text {text}
 {
@@ -51,9 +51,9 @@ void TriStateWidget::setCheckState(const Qt::CheckState checkState)
     m_checkState = checkState;
 }
 
-void TriStateWidget::setCloseOnTriggered(const bool enabled)
+void TriStateWidget::setCloseOnInteraction(const bool enabled)
 {
-    m_closeOnTriggered = enabled;
+    m_closeOnInteraction = enabled;
 }
 
 QSize TriStateWidget::minimumSizeHint() const
@@ -104,7 +104,7 @@ void TriStateWidget::mouseReleaseEvent(QMouseEvent *event)
 {
     toggleCheckState();
 
-    if (m_closeOnTriggered)
+    if (m_closeOnInteraction)
     {
         // parent `triggered` signal will be emitted
         QWidget::mouseReleaseEvent(event);
@@ -112,7 +112,7 @@ void TriStateWidget::mouseReleaseEvent(QMouseEvent *event)
     else
     {
         update();
-        // need to emit parent `triggered` signal manually
+        // need to emit `triggered` signal manually
         emit triggered(m_checkState == Qt::Checked);
     }
 }
@@ -124,7 +124,7 @@ void TriStateWidget::keyPressEvent(QKeyEvent *event)
         {
         toggleCheckState();
 
-        if (!m_closeOnTriggered)
+        if (!m_closeOnInteraction)
         {
             update();
             // need to emit parent `triggered` signal manually

--- a/src/gui/tristatewidget.h
+++ b/src/gui/tristatewidget.h
@@ -41,7 +41,7 @@ public:
     TriStateWidget(const QString &text, QWidget *parent);
 
     void setCheckState(Qt::CheckState checkState);
-    void setCloseOnTriggered(bool enabled);
+    void setCloseOnInteraction(bool enabled);
 
 signals:
     void triggered(bool checked) const;
@@ -55,7 +55,7 @@ private:
 
     void toggleCheckState();
 
-    bool m_closeOnTriggered;
+    bool m_closeOnInteraction;
     Qt::CheckState m_checkState;
     const QString m_text;
 };


### PR DESCRIPTION
The issue was resolved by using QAction::toggled signal instead of QAction::triggered. The latter is documented to cause QMenus to close. Per [the manual](https://doc.qt.io/qt-5/qmenu.html):

> Widgets can be inserted into menus with the QWidgetAction class. Instances of this class are used to hold widgets, and are inserted into menus with the addAction() overload that takes a QAction. If the QWidgetAction fires the triggered() signal, the menu will close.

Verified working with qtbase 5.15.2.