### PR TITLE
Remove 'DownloadRequest::saveToFile'

### DIFF
--- a/src/base/net/downloadhandlerimpl.cpp
+++ b/src/base/net/downloadhandlerimpl.cpp
@@ -38,23 +38,6 @@
 
 const int MAX_REDIRECTIONS = 20;  // the common value for web browsers
 
-namespace
-{
-    bool saveToFile(const QByteArray &replyData, QString &filePath)
-    {
-        QTemporaryFile tmpfile {Utils::Fs::tempPath() + "XXXXXX"};
-        tmpfile.setAutoRemove(false);
-
-        if (!tmpfile.open())
-            return false;
-
-        filePath = tmpfile.fileName();
-
-        tmpfile.write(replyData);
-        return true;
-    }
-}
-
 DownloadHandlerImpl::DownloadHandlerImpl(Net::DownloadManager *manager, const Net::DownloadRequest &downloadRequest)
     : DownloadHandler {manager}
     , m_manager {manager}
@@ -126,15 +109,6 @@ void DownloadHandlerImpl::processFinishedDownload()
     m_result.data = (m_reply->rawHeader("Content-Encoding") == "gzip")
                     ? Utils::Gzip::decompress(m_reply->readAll())
                     : m_reply->readAll();
-
-    if (m_downloadRequest.saveToFile())
-    {
-        QString filePath;
-        if (saveToFile(m_result.data, filePath))
-            m_result.filePath = filePath;
-        else
-            setError(tr("I/O Error"));
-    }
 
     finish();
 }

--- a/src/base/net/downloadmanager.cpp
+++ b/src/base/net/downloadmanager.cpp
@@ -337,17 +337,6 @@ Net::DownloadRequest &Net::DownloadRequest::limit(const qint64 value)
     return *this;
 }
 
-bool Net::DownloadRequest::saveToFile() const
-{
-    return m_saveToFile;
-}
-
-Net::DownloadRequest &Net::DownloadRequest::saveToFile(const bool value)
-{
-    m_saveToFile = value;
-    return *this;
-}
-
 Net::ServiceID Net::ServiceID::fromURL(const QUrl &url)
 {
     return {url.host(), url.port(80)};

--- a/src/base/net/downloadmanager.h
+++ b/src/base/net/downloadmanager.h
@@ -75,14 +75,10 @@ namespace Net
         qint64 limit() const;
         DownloadRequest &limit(qint64 value);
 
-        bool saveToFile() const;
-        DownloadRequest &saveToFile(bool value);
-
     private:
         QString m_url;
         QString m_userAgent;
         qint64 m_limit = 0;
-        bool m_saveToFile = false;
     };
 
     struct DownloadResult
@@ -91,7 +87,6 @@ namespace Net
         DownloadStatus status;
         QString errorString;
         QByteArray data;
-        QString filePath;
         QString magnet;
     };
 

--- a/src/base/rss/rss_feed.cpp
+++ b/src/base/rss/rss_feed.cpp
@@ -136,6 +136,9 @@ void Feed::refresh()
     m_downloadHandler = Net::DownloadManager::instance()->download(m_url);
     connect(m_downloadHandler, &Net::DownloadHandler::finished, this, &Feed::handleDownloadFinished);
 
+    if (!m_icon || !m_icon->exists()) // icon not available, try to redownload it
+        downloadIcon();
+
     m_isLoading = true;
     emit stateChanged(this);
 }

--- a/src/base/rss/rss_feed.h
+++ b/src/base/rss/rss_feed.h
@@ -38,6 +38,7 @@
 #include "rss_item.h"
 
 class AsyncFileStorage;
+class QTemporaryFile;
 
 namespace Net
 {
@@ -122,10 +123,10 @@ namespace RSS
         QHash<QString, Article *> m_articles;
         QList<Article *> m_articlesByDate;
         int m_unreadCount = 0;
-        QString m_iconPath;
         QString m_dataFileName;
         QBasicTimer m_savingTimer;
         bool m_dirty = false;
         Net::DownloadHandler *m_downloadHandler = nullptr;
+        QTemporaryFile *m_icon = nullptr;
     };
 }

--- a/src/base/utils/fs.cpp
+++ b/src/base/utils/fs.cpp
@@ -56,8 +56,9 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QMimeDatabase>
-#include <QStorageInfo>
 #include <QRegularExpression>
+#include <QStorageInfo>
+#include <QTemporaryFile>
 
 #include "base/bittorrent/common.h"
 #include "base/global.h"
@@ -382,3 +383,14 @@ bool Utils::Fs::isNetworkFileSystem(const QString &path)
 #endif // Q_OS_WIN
 }
 #endif // Q_OS_HAIKU
+
+std::unique_ptr<QTemporaryFile> Utils::Fs::tempFile(const QByteArray &data)
+{
+    auto tmpFile = std::make_unique<QTemporaryFile>(tempPath());
+    if (!tmpFile->open())
+        return nullptr;
+
+    tmpFile->write(data);
+    tmpFile->close(); // flush data
+    return tmpFile;
+}

--- a/src/base/utils/fs.h
+++ b/src/base/utils/fs.h
@@ -32,7 +32,12 @@
  * Utility functions related to file system.
  */
 
+#include <memory>
+
 #include <QString>
+
+class QByteArray;
+class QTemporaryFile;
 
 namespace Utils::Fs
 {
@@ -70,6 +75,7 @@ namespace Utils::Fs
     void removeDirRecursive(const QString &path);
 
     QString tempPath();
+    std::unique_ptr<QTemporaryFile> tempFile(const QByteArray &data);
 
 #if !defined Q_OS_HAIKU
     bool isNetworkFileSystem(const QString &path);

--- a/src/gui/transferlistfilterswidget.h
+++ b/src/gui/transferlistfilterswidget.h
@@ -101,7 +101,6 @@ class TrackerFiltersList final : public BaseFilterWidget
 
 public:
     TrackerFiltersList(QWidget *parent, TransferListWidget *transferList, bool downloadFavicon);
-    ~TrackerFiltersList() override;
 
     // Redefine addItem() to make sure the list stays sorted
     void addItem(const QString &tracker, const BitTorrent::TorrentID &id);
@@ -132,7 +131,6 @@ private:
     QHash<QString, QSet<BitTorrent::TorrentID>> m_trackers;  // <tracker host, torrent IDs>
     QHash<BitTorrent::TorrentID, QSet<QString>> m_errors;  // <torrent ID, tracker hosts>
     QHash<BitTorrent::TorrentID, QSet<QString>> m_warnings;  // <torrent ID, tracker hosts>
-    QStringList m_iconPaths;
     int m_totalTorrents;
     bool m_downloadTrackerFavicon;
 };


### PR DESCRIPTION
`DownloadRequest::saveToFile` instantiates `QTemporaryFile` as temporarily objects. `QTemporaryFile` make sure the temporary file is accessible during it's lifetime by always keeping open the file, even `QTemporaryFile::close` don't actually close the file. Accessing `DownloadResult::filePath` after source QTemporaryFile is destroyed is dangling. 

Remove 'DownloadRequest::saveToFile' and instantiate QTemporaryFile at the place of usage.

Fixes RSS icons not visible after some time.