### PR TITLE
Add context menu to toggle content tab columns

### DIFF
--- a/src/gui/properties/propertieswidget.h
+++ b/src/gui/properties/propertieswidget.h
@@ -81,6 +81,7 @@ public slots:
     void readSettings();
     void saveSettings();
     void reloadPreferences();
+    void displayFileListHeaderMenu();
     void openItem(const QModelIndex &index) const;
     void loadTrackers(BitTorrent::Torrent *const torrent);
 


### PR DESCRIPTION
Addresses #5848.

- Implementation derived from [peer list widget](https://github.com/qbittorrent/qBittorrent/blob/9bfc74a1bcf1420ea0393ffbafe5057cae4f37e4/src/gui/properties/peerlistwidget.cpp#L178-L221)
- WebUI already has this functionality
- The cols >= 1 check is removed because "Name" column cannot be hidden

![image](https://user-images.githubusercontent.com/634710/124468983-11e73800-dd9a-11eb-94f5-16bbe9d46b5e.png)
