### PR TITLE
Add tooltip for various columns

### DIFF
--- a/src/gui/macutilities.mm
+++ b/src/gui/macutilities.mm
@@ -68,14 +68,14 @@ namespace MacUtils
 
         if (class_getInstanceMethod(delClass, shouldHandle))
         {
-            if (class_replaceMethod(delClass, shouldHandle, (IMP)dockClickHandler, "B@:"))
+            if (class_replaceMethod(delClass, shouldHandle, reinterpret_cast<IMP>(dockClickHandler), "B@:"))
                 qDebug("Registered dock click handler (replaced original method)");
             else
                 qWarning("Failed to replace method for dock click handler");
         }
         else
         {
-            if (class_addMethod(delClass, shouldHandle, (IMP)dockClickHandler, "B@:"))
+            if (class_addMethod(delClass, shouldHandle, reinterpret_cast<IMP>(dockClickHandler), "B@:"))
                 qDebug("Registered dock click handler");
             else
                 qWarning("Failed to register dock click handler");

--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -373,6 +373,7 @@ void TrackerListWidget::loadTrackers()
         {
             item = new QTreeWidgetItem();
             item->setText(COL_URL, trackerURL);
+            item->setToolTip(COL_URL, trackerURL);
             addTopLevelItem(item);
             m_trackerItems[trackerURL] = item;
         }
@@ -400,6 +401,7 @@ void TrackerListWidget::loadTrackers()
         }
 
         item->setText(COL_MSG, entry.message);
+        item->setToolTip(COL_MSG, entry.message);
         item->setText(COL_PEERS, ((entry.numPeers > -1)
             ? QString::number(entry.numPeers)
             : tr("N/A")));

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -621,16 +621,16 @@ window.qBittorrent.DynamicTable = (function() {
             let row;
 
             if (!this.rows.has(rowId)) {
-                row = {};
+                row = {
+                    'full_data': {},
+                    'rowId': rowId
+                };
                 this.rows.set(rowId, row);
-                row['full_data'] = {};
-                row['rowId'] = rowId;
             }
             else
                 row = this.rows.get(rowId);
 
             row['data'] = data;
-
             for (const x in data)
                 row['full_data'][x] = data[x];
         },


### PR DESCRIPTION
* Add tooltip for various columns
  Those strings sometimes are quite long and having a tooltip would save the action of resizing the column width to see the full message.
  The WebUI already has it done for all columns.
* Simplify initialization statement
* Don't use old style casts
  Ref: https://github.com/qbittorrent/qBittorrent/runs/2996702005?check_suite_focus=true#step:8:298
