### PR TITLE
Add tooltip for more widgets

### DIFF
--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -797,7 +797,7 @@ QVector<DownloadPriority> TorrentImpl::filePriorities() const
     const std::vector<lt::download_priority_t> fp = m_nativeHandle.get_file_priorities();
 
     QVector<DownloadPriority> ret;
-    ret.reserve(fp.size());
+    ret.reserve(static_cast<decltype(ret)::size_type>(fp.size()));
     std::transform(fp.cbegin(), fp.cend(), std::back_inserter(ret), [](const lt::download_priority_t priority)
     {
         return static_cast<DownloadPriority>(toLTUnderlyingType(priority));

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -447,7 +447,7 @@ void PeerListWidget::updatePeer(const BitTorrent::Torrent *torrent, const BitTor
     setModelData(row, PeerListColumns::CONNECTION, peer.connectionType(), peer.connectionType());
     setModelData(row, PeerListColumns::FLAGS, peer.flags(), peer.flags(), {}, peer.flagsDescription());
     const QString client = peer.client().toHtmlEscaped();
-    setModelData(row, PeerListColumns::CLIENT, client, client);
+    setModelData(row, PeerListColumns::CLIENT, client, client, {}, client);
     setModelData(row, PeerListColumns::PROGRESS, (Utils::String::fromDouble(peer.progress() * 100, 1) + '%'), peer.progress(), intDataTextAlignment);
     const QString downSpeed = (hideValues && (peer.payloadDownSpeed() <= 0)) ? QString {} : Utils::Misc::friendlyUnit(peer.payloadDownSpeed(), true);
     setModelData(row, PeerListColumns::DOWN_SPEED, downSpeed, peer.payloadDownSpeed(), intDataTextAlignment);
@@ -461,7 +461,7 @@ void PeerListWidget::updatePeer(const BitTorrent::Torrent *torrent, const BitTor
 
     const QStringList downloadingFiles {torrent->info().filesForPiece(peer.downloadingPieceIndex())};
     const QString downloadingFilesDisplayValue = downloadingFiles.join(';');
-    setModelData(row, PeerListColumns::DOWNLOADING_PIECE, downloadingFilesDisplayValue, downloadingFilesDisplayValue, {}, downloadingFiles.join('\n'));
+    setModelData(row, PeerListColumns::DOWNLOADING_PIECE, downloadingFilesDisplayValue, downloadingFilesDisplayValue, {}, downloadingFiles.join(QLatin1Char('\n')));
 
     if (m_resolver)
         m_resolver->resolve(peerEndpoint.address.ip);

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -339,7 +339,7 @@ int TorrentContentModel::getFileIndex(const QModelIndex &index)
     return -1;
 }
 
-QVariant TorrentContentModel::data(const QModelIndex &index, int role) const
+QVariant TorrentContentModel::data(const QModelIndex &index, const int role) const
 {
     if (!index.isValid())
         return {};
@@ -375,6 +375,7 @@ QVariant TorrentContentModel::data(const QModelIndex &index, int role) const
         return {};
 
     case Qt::DisplayRole:
+    case Qt::ToolTipRole:
         return item->displayData(index.column());
 
     case Roles::UnderlyingDataRole:


### PR DESCRIPTION
* Add tooltip for "client ID" column
  Sometimes the client ID could be quite long and this patch helps showing it.
* Display tooltip for all columns in torrent content widget
  It is primary useful for showing long file names.
* Suppress type narrowing warning on MSVC
  Fix up 45e31a1.
