### PR TITLE
Add "Forced metadata downloading" state

### DIFF
--- a/src/base/bittorrent/torrent.h
+++ b/src/base/bittorrent/torrent.h
@@ -72,6 +72,7 @@ namespace BitTorrent
 
         ForcedDownloading,
         Downloading,
+        ForcedDownloadingMetadata,
         DownloadingMetadata,
         StalledDownloading,
 

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -833,6 +833,7 @@ bool TorrentImpl::isDownloading() const
 {
     return m_state == TorrentState::Downloading
             || m_state == TorrentState::DownloadingMetadata
+            || m_state == TorrentState::ForcedDownloadingMetadata
             || m_state == TorrentState::StalledDownloading
             || m_state == TorrentState::CheckingDownloading
             || m_state == TorrentState::PausedDownloading
@@ -865,6 +866,7 @@ bool TorrentImpl::isActive() const
         return (uploadPayloadRate() > 0);
 
     return m_state == TorrentState::DownloadingMetadata
+            || m_state == TorrentState::ForcedDownloadingMetadata
             || m_state == TorrentState::Downloading
             || m_state == TorrentState::ForcedDownloading
             || m_state == TorrentState::Uploading
@@ -934,7 +936,7 @@ void TorrentImpl::updateState()
         else if (m_session->isQueueingSystemEnabled() && isQueued())
             m_state = TorrentState::QueuedDownloading;
         else
-            m_state = TorrentState::DownloadingMetadata;
+            m_state = isForced() ? TorrentState::ForcedDownloadingMetadata : TorrentState::DownloadingMetadata;
     }
     else if ((m_nativeStatus.state == lt::torrent_status::checking_files)
              && (!isPaused() || (m_nativeStatus.flags & lt::torrent_flags::auto_managed)

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -75,6 +75,7 @@ namespace
             {BitTorrent::TorrentState::Downloading, QLatin1String("TransferList.Downloading")},
             {BitTorrent::TorrentState::StalledDownloading, QLatin1String("TransferList.StalledDownloading")},
             {BitTorrent::TorrentState::DownloadingMetadata, QLatin1String("TransferList.DownloadingMetadata")},
+            {BitTorrent::TorrentState::ForcedDownloadingMetadata, QLatin1String("TransferList.ForcedDownloadingMetadata")},
             {BitTorrent::TorrentState::ForcedDownloading, QLatin1String("TransferList.ForcedDownloading")},
             {BitTorrent::TorrentState::Uploading, QLatin1String("TransferList.Uploading")},
             {BitTorrent::TorrentState::StalledUploading, QLatin1String("TransferList.StalledUploading")},
@@ -111,6 +112,7 @@ TransferListModel::TransferListModel(QObject *parent)
           {BitTorrent::TorrentState::Downloading, tr("Downloading")},
           {BitTorrent::TorrentState::StalledDownloading, tr("Stalled", "Torrent is waiting for download to begin")},
           {BitTorrent::TorrentState::DownloadingMetadata, tr("Downloading metadata", "Used when loading a magnet link")},
+          {BitTorrent::TorrentState::ForcedDownloadingMetadata, tr("[F] Downloading metadata", "Used when forced to load a magnet link. You probably shouldn't translate the F.")},
           {BitTorrent::TorrentState::ForcedDownloading, tr("[F] Downloading", "Used when the torrent is forced started. You probably shouldn't translate the F.")},
           {BitTorrent::TorrentState::Uploading, tr("Seeding", "Torrent is complete and in upload-only mode")},
           {BitTorrent::TorrentState::StalledUploading, tr("Seeding", "Torrent is complete and in upload-only mode")},
@@ -664,6 +666,7 @@ QIcon getIconByState(const BitTorrent::TorrentState state)
     case BitTorrent::TorrentState::Downloading:
     case BitTorrent::TorrentState::ForcedDownloading:
     case BitTorrent::TorrentState::DownloadingMetadata:
+    case BitTorrent::TorrentState::ForcedDownloadingMetadata:
         return getDownloadingIcon();
     case BitTorrent::TorrentState::StalledDownloading:
         return getStalledDownloadingIcon();
@@ -704,6 +707,7 @@ QColor getDefaultColorByState(const BitTorrent::TorrentState state)
     case BitTorrent::TorrentState::Downloading:
     case BitTorrent::TorrentState::ForcedDownloading:
     case BitTorrent::TorrentState::DownloadingMetadata:
+    case BitTorrent::TorrentState::ForcedDownloadingMetadata:
         if (!dark)
             return {34, 139, 34}; // Forest Green
         else

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -63,6 +63,8 @@ namespace
             return QLatin1String("downloading");
         case BitTorrent::TorrentState::DownloadingMetadata:
             return QLatin1String("metaDL");
+        case BitTorrent::TorrentState::ForcedDownloadingMetadata:
+            return QLatin1String("forcedMetaDL");
         case BitTorrent::TorrentState::PausedDownloading:
             return QLatin1String("pausedDL");
         case BitTorrent::TorrentState::QueuedDownloading:

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -870,6 +870,7 @@ window.qBittorrent.DynamicTable = (function() {
                 switch (state) {
                     case "forcedDL":
                     case "metaDL":
+                    case "forcedMetaDL":
                         state = "downloading";
                         break;
                     case "forcedUP":
@@ -933,6 +934,9 @@ window.qBittorrent.DynamicTable = (function() {
                         break;
                     case "metaDL":
                         status = "QBT_TR(Downloading metadata)QBT_TR[CONTEXT=TransferListDelegate]";
+                        break;
+                    case "forcedMetaDL":
+                        status = "QBT_TR([F] Downloading metadata)QBT_TR[CONTEXT=TransferListDelegate]";
                         break;
                     case "forcedDL":
                         status = "QBT_TR([F] Downloading)QBT_TR[CONTEXT=TransferListDelegate]";
@@ -1250,7 +1254,7 @@ window.qBittorrent.DynamicTable = (function() {
                     if (state == 'stalledDL')
                         r = (row['full_data'].upspeed > 0);
                     else
-                        r = state == 'metaDL' || state == 'downloading' || state == 'forcedDL' || state == 'uploading' || state == 'forcedUP';
+                        r = state == 'metaDL' || state == 'forcedMetaDL' || state == 'downloading' || state == 'forcedDL' || state == 'uploading' || state == 'forcedUP';
                     if (r == inactive)
                         return false;
                     break;


### PR DESCRIPTION
ATM there is no distinction between `downloading metadata` forced or not.

This PR introduces the new state `ForcedDownloadingMetadata`, completing the forced states: `ForcedDownloading` and `ForcedUploading`.

TODO:
- [ ] Update wiki