### PR TITLE
Use the URI's setData to set query data

### DIFF
--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -119,18 +119,17 @@ const initializeWindows = function() {
 
     showDownloadPage = function(urls) {
         const id = 'downloadPage';
-        let contentUrl = 'download.html';
+        let contentUri = new URI('download.html');
+
         if (urls && (urls.length > 0)) {
-            contentUrl += ('?urls=' + encodeURIComponent(urls.map(function(url) {
-                return encodeURIComponent(url);
-            }).join("|")));
+            contentUri.setData("urls", urls.map(encodeURIComponent).join("|"));
         }
 
         new MochaUI.Window({
             id: id,
             title: "QBT_TR(Download from URLs)QBT_TR[CONTEXT=downloadFromURL]",
             loadMethod: 'iframe',
-            contentURL: contentUrl,
+            contentURL: contentUri.toString(),
             addClass: 'windowFrame', // fixes iframe scrolling on iOS Safari
             scrollbars: true,
             maximizable: false,
@@ -154,7 +153,7 @@ const initializeWindows = function() {
             title: "QBT_TR(Options)QBT_TR[CONTEXT=OptionsDialog]",
             loadMethod: 'xhr',
             toolbar: true,
-            contentURL: 'views/preferences.html',
+            contentURL: new URI("views/preferences.html").toString(),
             require: {
                 css: ['css/Tabs.css']
             },
@@ -178,7 +177,7 @@ const initializeWindows = function() {
             id: id,
             title: "QBT_TR(Upload local torrent)QBT_TR[CONTEXT=HttpServer]",
             loadMethod: 'iframe',
-            contentURL: 'upload.html',
+            contentURL: new URI("upload.html").toString(),
             addClass: 'windowFrame', // fixes iframe scrolling on iOS Safari
             scrollbars: true,
             maximizable: false,
@@ -198,7 +197,7 @@ const initializeWindows = function() {
             id: 'uploadLimitPage',
             title: "QBT_TR(Global Upload Speed Limit)QBT_TR[CONTEXT=MainWindow]",
             loadMethod: 'iframe',
-            contentURL: 'uploadlimit.html?hashes=global',
+            contentURL: new URI("uploadlimit.html").setData("hashes", "global").toString(),
             scrollbars: false,
             resizable: false,
             maximizable: false,
@@ -216,7 +215,7 @@ const initializeWindows = function() {
                 id: 'uploadLimitPage',
                 title: "QBT_TR(Torrent Upload Speed Limiting)QBT_TR[CONTEXT=TransferListWidget]",
                 loadMethod: 'iframe',
-                contentURL: 'uploadlimit.html?hashes=' + hashes.join("|"),
+                contentURL: new URI("uploadlimit.html").setData("hashes", hashes.join("|")).toString(),
                 scrollbars: false,
                 resizable: false,
                 maximizable: false,
@@ -256,7 +255,7 @@ const initializeWindows = function() {
                 id: 'shareRatioPage',
                 title: "QBT_TR(Torrent Upload/Download Ratio Limiting)QBT_TR[CONTEXT=UpDownRatioDialog]",
                 loadMethod: 'iframe',
-                contentURL: 'shareratio.html?hashes=' + hashes.join("|") + '&orig=' + orig,
+                contentURL: new URI("shareratio.html").setData("hashes", hashes.join("|")).setData("orig", orig).toString(),
                 scrollbars: false,
                 maximizable: false,
                 paddingVertical: 0,
@@ -330,7 +329,7 @@ const initializeWindows = function() {
             id: 'downloadLimitPage',
             title: "QBT_TR(Global Download Speed Limit)QBT_TR[CONTEXT=MainWindow]",
             loadMethod: 'iframe',
-            contentURL: 'downloadlimit.html?hashes=global',
+            contentURL: new URI("downloadlimit.html").setData("hashes", "global").toString(),
             scrollbars: false,
             resizable: false,
             maximizable: false,
@@ -347,7 +346,7 @@ const initializeWindows = function() {
             id: id,
             title: 'QBT_TR(Statistics)QBT_TR[CONTEXT=StatsDialog]',
             loadMethod: 'xhr',
-            contentURL: 'views/statistics.html',
+            contentURL: new URI("views/statistics.html").toString(),
             maximizable: false,
             padding: 10,
             width: loadWindowWidth(id, 275),
@@ -365,7 +364,7 @@ const initializeWindows = function() {
                 id: 'downloadLimitPage',
                 title: "QBT_TR(Torrent Download Speed Limiting)QBT_TR[CONTEXT=TransferListWidget]",
                 loadMethod: 'iframe',
-                contentURL: 'downloadlimit.html?hashes=' + hashes.join("|"),
+                contentURL: new URI("downloadlimit.html").setData("hashes", hashes.join("|")).toString(),
                 scrollbars: false,
                 resizable: false,
                 maximizable: false,
@@ -384,7 +383,7 @@ const initializeWindows = function() {
                 id: 'confirmDeletionPage',
                 title: "QBT_TR(Deletion confirmation)QBT_TR[CONTEXT=confirmDeletionDlg]",
                 loadMethod: 'iframe',
-                contentURL: ('confirmdeletion.html?hashes=' + hashes.join("|") + '&deleteFiles=' + deleteFiles),
+                contentURL: new URI("confirmdeletion.html").setData("hashes", hashes.join("|")).setData("deleteFiles", deleteFiles).toString(),
                 scrollbars: false,
                 resizable: false,
                 maximizable: false,
@@ -483,12 +482,12 @@ const initializeWindows = function() {
         if (hashes.length) {
             const hash = hashes[0];
             const row = torrentsTable.rows[hash];
-            const path = encodeURIComponent(row.full_data.save_path);
+
             new MochaUI.Window({
                 id: 'setLocationPage',
                 title: "QBT_TR(Set location)QBT_TR[CONTEXT=TransferListWidget]",
                 loadMethod: 'iframe',
-                contentURL: 'setlocation.html?hashes=' + hashes.join('|') + '&path=' + path,
+                contentURL: new URI("setlocation.html").setData("hashes", hashes.join('|')).setData("path", row.full_data.save_path).toString(),
                 scrollbars: false,
                 resizable: false,
                 maximizable: false,
@@ -510,7 +509,7 @@ const initializeWindows = function() {
                     id: 'renamePage',
                     title: "QBT_TR(Rename)QBT_TR[CONTEXT=TransferListWidget]",
                     loadMethod: 'iframe',
-                    contentURL: 'rename.html?hash=' + hash + '&name=' + encodeURIComponent(row.full_data.name),
+                    contentURL: new URI("rename.html").setData("hash", hash).setData("name", row.full_data.name).toString(),
                     scrollbars: false,
                     resizable: false,
                     maximizable: false,
@@ -531,7 +530,7 @@ const initializeWindows = function() {
                 id: 'newCategoryPage',
                 title: "QBT_TR(New Category)QBT_TR[CONTEXT=TransferListWidget]",
                 loadMethod: 'iframe',
-                contentURL: 'newcategory.html?action=' + action + '&hashes=' + hashes.join('|'),
+                contentURL: new URI("newcategory.html").setData("action", action).setData("hashes", hashes.join('|')).toString(),
                 scrollbars: false,
                 resizable: false,
                 maximizable: false,
@@ -566,7 +565,7 @@ const initializeWindows = function() {
             id: 'newCategoryPage',
             title: "QBT_TR(New Category)QBT_TR[CONTEXT=CategoryFilterWidget]",
             loadMethod: 'iframe',
-            contentURL: 'newcategory.html?action=' + action,
+            contentURL: new URI("newcategory.html").setData("action", action).toString(),
             scrollbars: false,
             resizable: false,
             maximizable: false,
@@ -586,7 +585,7 @@ const initializeWindows = function() {
             id: 'editCategoryPage',
             title: "QBT_TR(Edit Category)QBT_TR[CONTEXT=TransferListWidget]",
             loadMethod: 'iframe',
-            contentURL: 'newcategory.html?action=' + action + '&categoryName=' + categoryName + '&savePath=' + savePath,
+            contentURL: new URI('newcategory.html').setData("action", action).setData("categoryName", categoryName).setData("savePath", savePath).toString(),
             scrollbars: false,
             resizable: false,
             maximizable: false,
@@ -661,7 +660,7 @@ const initializeWindows = function() {
                 id: 'confirmDeletionPage',
                 title: "QBT_TR(Deletion confirmation)QBT_TR[CONTEXT=confirmDeletionDlg]",
                 loadMethod: 'iframe',
-                contentURL: 'confirmdeletion.html?hashes=' + hashes.join("|"),
+                contentURL: new URI("confirmdeletion.html").setData("hashes", hashes.join("|")).toString(),
                 scrollbars: false,
                 resizable: false,
                 maximizable: false,
@@ -681,7 +680,7 @@ const initializeWindows = function() {
                 id: 'newTagPage',
                 title: "QBT_TR(Add Tags)QBT_TR[CONTEXT=TransferListWidget]",
                 loadMethod: 'iframe',
-                contentURL: 'newtag.html?action=' + action + '&hashes=' + hashes.join('|'),
+                contentURL: new URI("newtag.html").setData("action", action).setData("hashes", hashes.join("|")).toString(),
                 scrollbars: false,
                 resizable: false,
                 maximizable: false,
@@ -727,7 +726,7 @@ const initializeWindows = function() {
             id: 'newTagPage',
             title: "QBT_TR(New Tag)QBT_TR[CONTEXT=TagFilterWidget]",
             loadMethod: 'iframe',
-            contentURL: 'newtag.html?action=' + action,
+            contentURL: new URI("newtag.html").setData("action", action).toString(),
             scrollbars: false,
             resizable: false,
             maximizable: false,
@@ -802,7 +801,7 @@ const initializeWindows = function() {
                 id: 'confirmDeletionPage',
                 title: "QBT_TR(Deletion confirmation)QBT_TR[CONTEXT=confirmDeletionDlg]",
                 loadMethod: 'iframe',
-                contentURL: 'confirmdeletion.html?hashes=' + hashes.join("|"),
+                contentURL: new URI("confirmdeletion.html").setData("hashes", hashes.join("|")).toString(),
                 scrollbars: false,
                 resizable: false,
                 maximizable: false,
@@ -888,7 +887,7 @@ const initializeWindows = function() {
                 id: 'confirmDeletionPage',
                 title: "QBT_TR(Deletion confirmation)QBT_TR[CONTEXT=confirmDeletionDlg]",
                 loadMethod: 'iframe',
-                contentURL: 'confirmdeletion.html?hashes=' + hashes.join("|"),
+                contentURL: new URI("confirmdeletion.html").setData("hashes", hashes.join("|")).toString(),
                 scrollbars: false,
                 resizable: false,
                 maximizable: false,
@@ -1019,7 +1018,7 @@ const initializeWindows = function() {
             id: id,
             title: 'QBT_TR(About qBittorrent)QBT_TR[CONTEXT=AboutDialog]',
             loadMethod: 'xhr',
-            contentURL: 'views/about.html',
+            contentURL: new URI("views/about.html").toString(),
             require: {
                 css: ['css/Tabs.css']
             },


### PR DESCRIPTION
This allows the system to properly encode the '|', instead of passing the '|' on in the URL, which is not allowed and breaks proxies such as Authelia.

Then, for the purpose of generalization, I pushed this pattern through to all places where we join items with a '|'.

This comes with the caveat that when we have individual components which contain a '|' or any other character that is not allowed per the HTTP standard, we still like to encode the individual components, for example in the case of 3 strings, separated by a '|'. If we don't do this we run into the risk that upon decoding URI finds '|' in our original strings, which is something we don't want.

For example:
Sender:
````javascript
const arr = ["foo|1", "bar|2"];
const uri = new URI("test.html").setData(arr.join("|"));
````
Then on the receiving window, when it receives the uri and splits it, it looks like this:
````javascript
const arr = new URI().getData('hashes').split('|');
// arr is now ["foo", "1", "bar", "2"]
````

This is why when we want to send a literal "|" we need to do `encodeURIComponent` and `decodeURIComponent` manually on each item, and THEN we join.

For example:
Sender:
````javascript
const arr = ["foo|1", "bar|2"];
const uri = new URI("test.html").setData(arr.map(encodeURIComponent).join("|"));
````

Receiver:
````javascript
const arr = new URI().getData('hashes').split('|').map(decodeURIComponent);
// arr is now ["foo|1", "bar|2"]
````

We don't need to with hashes as they are HEX, so no risk of any weird characters in there.