### PR TITLE
Set default file priorities when not specified

### DIFF
--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -1512,6 +1512,10 @@ void TorrentImpl::endReceivedMetadataHandling(const QString &savePath, const QSt
         p.renamed_files[lt::file_index_t {i}] = fileNames[i].toStdString();
     p.save_path = Utils::Fs::toNativePath(savePath).toStdString();
 
+    // Use qBittorrent default priority rather than libtorrent's (4)
+    p.file_priorities = std::vector(fileNames.size(), static_cast<lt::download_priority_t>(
+            static_cast<lt::download_priority_t::underlying_type>(DownloadPriority::Normal)));
+
     reload();
 
     // If first/last piece priority was specified when adding this torrent,


### PR DESCRIPTION
Fixes #11450.

To repro the problem or test this PR you can:
1. Add a magnet link (don't wait for metadata, close the dialog and return to the transfer list)
2. Wait for metadata
3. Query `api/v2/torrents/files?hash=64a980abe6e448226bb930ba061592e44c3781a1` and check `priority` field

You can use this link:
`magnet:?xt=urn:btih:64a980abe6e448226bb930ba061592e44c3781a1&dn=ubuntu-21.04-desktop-amd64.iso&tr=https%3a%2f%2ftorrent.ubuntu.com%2fannounce&tr=https%3a%2f%2fipv6.torrent.ubuntu.com%2fannounce`
