### PR TITLE
Store minimal metadata for "restore torrent" purposes

### DIFF
--- a/src/base/bittorrent/bencoderesumedatastorage.h
+++ b/src/base/bittorrent/bencoderesumedatastorage.h
@@ -38,8 +38,6 @@ class QThread;
 
 namespace BitTorrent
 {
-    class TorrentInfo;
-
     class BencodeResumeDataStorage final : public ResumeDataStorage
     {
         Q_OBJECT
@@ -57,7 +55,7 @@ namespace BitTorrent
 
     private:
         void loadQueue(const QString &queueFilename);
-        std::optional<LoadTorrentParams> loadTorrentResumeData(const QByteArray &data, const TorrentInfo &metadata) const;
+        std::optional<LoadTorrentParams> loadTorrentResumeData(const QByteArray &data, const QByteArray &metadata) const;
 
         const QDir m_resumeDataDir;
         QVector<TorrentID> m_registeredTorrents;


### PR DESCRIPTION
We can no longer save valid torrent files in the general case, because for torrents of version 2, we need a full merkle tree to do it, but if a torrent is added from magnet link, full merkle tree may not be available even before the end of downloading all the data.
Actually, we don't need the full torrent file for the purposes of resuming the torrent, so we can allow libtorrent to produce only a minimal part of the metadata as part complete resume data, but we still want to store it in a separate file, so we extract the resulting metadata from the complete resume data before saving and merge it together before loading.