### PR TITLE
Introduce stale bot for PR

### DIFF
--- a/.github/workflows/stale_bot.yaml
+++ b/.github/workflows/stale_bot.yaml
@@ -1,0 +1,21 @@
+name: Stale bot
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark and close stale PRs
+        uses: actions/stale@v4
+        with:
+          stale-pr-message: "This PR is stale because it has been 60 days with no activity. This PR will be automatically closed within 7 days if there is no further activity."
+          close-pr-message: "This PR was closed because it has been stalled for some time with no activity."
+          days-before-stale: -1 # avoid marking issues
+          days-before-pr-stale: 60
+          days-before-close: -1 # avoid closing issues
+          days-before-pr-close: 7
+          exempt-all-pr-assignees: true  # avoid stale for all PR with assignees
+          exempt-all-pr-milestones: true # avoid stale for all PR with milestones


### PR DESCRIPTION
Stale bot will mark stale PR with a tag and close them after a specified interval of time.
Draft PRs are not subject to this marking.