### PR TITLE
Use spinbox special value to represent "Use any available port"

### DIFF
--- a/src/app/upgrade.cpp
+++ b/src/app/upgrade.cpp
@@ -102,12 +102,28 @@ namespace
         settingsStorage->storeValue(newKey, Utils::String::fromEnum(torrentContentLayout));
         settingsStorage->removeValue(oldKey);
     }
+
+    void upgradeListenPortSettings()
+    {
+        const auto oldKey = QString::fromLatin1("BitTorrent/Session/UseRandomPort");
+        const auto newKey = QString::fromLatin1("Preferences/Connection/PortRangeMin");
+        auto *settingsStorage = SettingsStorage::instance();
+
+        if (settingsStorage->hasKey(oldKey))
+        {
+            if (settingsStorage->loadValue<bool>(oldKey))
+                settingsStorage->storeValue(newKey, 0);
+
+            settingsStorage->removeValue(oldKey);
+        }
+    }
 }
 
 bool upgrade(const bool /*ask*/)
 {
     exportWebUIHttpsFiles();
     upgradeTorrentContentLayout();
+    upgradeListenPortSettings();
     return true;
 }
 

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -407,7 +407,6 @@ Session::Session(QObject *parent)
     , m_isBandwidthSchedulerEnabled(BITTORRENT_SESSION_KEY("BandwidthSchedulerEnabled"), false)
     , m_saveResumeDataInterval(BITTORRENT_SESSION_KEY("SaveResumeDataInterval"), 60)
     , m_port(BITTORRENT_SESSION_KEY("Port"), -1)
-    , m_useAnyAvailablePort(BITTORRENT_SESSION_KEY("UseRandomPort"), false)
     , m_networkInterface(BITTORRENT_SESSION_KEY("Interface"))
     , m_networkInterfaceName(BITTORRENT_SESSION_KEY("InterfaceName"))
     , m_networkInterfaceAddress(BITTORRENT_SESSION_KEY("InterfaceAddress"))
@@ -1421,13 +1420,12 @@ void Session::configureNetworkInterfaces(lt::settings_pack &settingsPack)
     if (m_listenInterfaceConfigured)
         return;
 
-    const int port = useAnyAvailablePort() ? 0 : this->port();
-    if (port > 0)  // user specified port
+    if (port() > 0)  // user has specified port number
         settingsPack.set_int(lt::settings_pack::max_retry_port_bind, 0);
 
     QStringList endpoints;
     QStringList outgoingInterfaces;
-    const QString portString = ':' + QString::number(port);
+    const QString portString = ':' + QString::number(port());
 
     for (const QString &ip : asConst(getListeningIPs()))
     {
@@ -2749,16 +2747,6 @@ void Session::setPort(const int port)
         if (isReannounceWhenAddressChangedEnabled())
             reannounceToAllTrackers();
     }
-}
-
-bool Session::useAnyAvailablePort() const
-{
-    return m_useAnyAvailablePort;
-}
-
-void Session::setUseAnyAvailablePort(const bool value)
-{
-    m_useAnyAvailablePort = value;
 }
 
 QString Session::networkInterface() const

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -407,7 +407,7 @@ Session::Session(QObject *parent)
     , m_isBandwidthSchedulerEnabled(BITTORRENT_SESSION_KEY("BandwidthSchedulerEnabled"), false)
     , m_saveResumeDataInterval(BITTORRENT_SESSION_KEY("SaveResumeDataInterval"), 60)
     , m_port(BITTORRENT_SESSION_KEY("Port"), -1)
-    , m_useRandomPort(BITTORRENT_SESSION_KEY("UseRandomPort"), false)
+    , m_useAnyAvailablePort(BITTORRENT_SESSION_KEY("UseRandomPort"), false)
     , m_networkInterface(BITTORRENT_SESSION_KEY("Interface"))
     , m_networkInterfaceName(BITTORRENT_SESSION_KEY("InterfaceName"))
     , m_networkInterfaceAddress(BITTORRENT_SESSION_KEY("InterfaceAddress"))
@@ -1421,7 +1421,7 @@ void Session::configureNetworkInterfaces(lt::settings_pack &settingsPack)
     if (m_listenInterfaceConfigured)
         return;
 
-    const int port = useRandomPort() ? 0 : this->port();
+    const int port = useAnyAvailablePort() ? 0 : this->port();
     if (port > 0)  // user specified port
         settingsPack.set_int(lt::settings_pack::max_retry_port_bind, 0);
 
@@ -2751,14 +2751,14 @@ void Session::setPort(const int port)
     }
 }
 
-bool Session::useRandomPort() const
+bool Session::useAnyAvailablePort() const
 {
-    return m_useRandomPort;
+    return m_useAnyAvailablePort;
 }
 
-void Session::setUseRandomPort(const bool value)
+void Session::setUseAnyAvailablePort(const bool value)
 {
-    m_useRandomPort = value;
+    m_useAnyAvailablePort = value;
 }
 
 QString Session::networkInterface() const

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -306,8 +306,8 @@ namespace BitTorrent
         void setSaveResumeDataInterval(int value);
         int port() const;
         void setPort(int port);
-        bool useRandomPort() const;
-        void setUseRandomPort(bool value);
+        bool useAnyAvailablePort() const;
+        void setUseAnyAvailablePort(bool value);
         QString networkInterface() const;
         void setNetworkInterface(const QString &iface);
         QString networkInterfaceName() const;
@@ -722,7 +722,7 @@ namespace BitTorrent
         CachedSettingValue<bool> m_isBandwidthSchedulerEnabled;
         CachedSettingValue<int> m_saveResumeDataInterval;
         CachedSettingValue<int> m_port;
-        CachedSettingValue<bool> m_useRandomPort;
+        CachedSettingValue<bool> m_useAnyAvailablePort;
         CachedSettingValue<QString> m_networkInterface;
         CachedSettingValue<QString> m_networkInterfaceName;
         CachedSettingValue<QString> m_networkInterfaceAddress;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -306,8 +306,6 @@ namespace BitTorrent
         void setSaveResumeDataInterval(int value);
         int port() const;
         void setPort(int port);
-        bool useAnyAvailablePort() const;
-        void setUseAnyAvailablePort(bool value);
         QString networkInterface() const;
         void setNetworkInterface(const QString &iface);
         QString networkInterfaceName() const;
@@ -722,7 +720,6 @@ namespace BitTorrent
         CachedSettingValue<bool> m_isBandwidthSchedulerEnabled;
         CachedSettingValue<int> m_saveResumeDataInterval;
         CachedSettingValue<int> m_port;
-        CachedSettingValue<bool> m_useAnyAvailablePort;
         CachedSettingValue<QString> m_networkInterface;
         CachedSettingValue<QString> m_networkInterfaceName;
         CachedSettingValue<QString> m_networkInterfaceAddress;

--- a/src/base/settingsstorage.cpp
+++ b/src/base/settingsstorage.cpp
@@ -234,6 +234,13 @@ void SettingsStorage::removeValue(const QString &key)
     }
 }
 
+bool SettingsStorage::hasKey(const QString &key) const
+{
+    const QString realKey = mapKey(key);
+    const QReadLocker locker {&m_lock};
+    return m_data.contains(realKey);
+}
+
 QVariantHash TransactionalSettings::read() const
 {
     QVariantHash res;

--- a/src/base/settingsstorage.h
+++ b/src/base/settingsstorage.h
@@ -79,6 +79,7 @@ public:
     }
 
     void removeValue(const QString &key);
+    bool hasKey(const QString &key) const;
 
 public slots:
     bool save();

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -300,7 +300,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     void (QSpinBox::*qSpinBoxValueChanged)(int) = &QSpinBox::valueChanged;
 
     connect(m_ui->comboProxyType, qComboBoxCurrentIndexChanged, this, &ThisType::enableProxy);
-    connect(m_ui->checkRandomPort, &QAbstractButton::toggled, m_ui->spinPort, &ThisType::setDisabled);
+    connect(m_ui->useAnyPort, &QAbstractButton::toggled, m_ui->spinPort, &ThisType::setDisabled);
 
     // Apply button is activated when a value is changed
     // Behavior tab
@@ -408,7 +408,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     // Connection tab
     connect(m_ui->comboProtocol, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->spinPort, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
-    connect(m_ui->checkRandomPort, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->useAnyPort, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkUPnP, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->spinUploadLimit, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->spinDownloadLimit, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
@@ -770,7 +770,7 @@ void OptionsDialog::saveOptions()
     // Connection preferences
     session->setBTProtocol(static_cast<BitTorrent::BTProtocol>(m_ui->comboProtocol->currentIndex()));
     session->setPort(getPort());
-    session->setUseRandomPort(m_ui->checkRandomPort->isChecked());
+    session->setUseAnyAvailablePort(m_ui->useAnyPort->isChecked());
     Net::PortForwarder::instance()->setEnabled(isUPnPEnabled());
     session->setGlobalDownloadSpeedLimit(m_ui->spinDownloadLimit->value() * 1024);
     session->setGlobalUploadSpeedLimit(m_ui->spinUploadLimit->value() * 1024);
@@ -1068,9 +1068,9 @@ void OptionsDialog::loadOptions()
     // Connection preferences
     m_ui->comboProtocol->setCurrentIndex(static_cast<int>(session->btProtocol()));
     m_ui->checkUPnP->setChecked(Net::PortForwarder::instance()->isEnabled());
-    m_ui->checkRandomPort->setChecked(session->useRandomPort());
+    m_ui->useAnyPort->setChecked(session->useAnyAvailablePort());
     m_ui->spinPort->setValue(session->port());
-    m_ui->spinPort->setDisabled(m_ui->checkRandomPort->isChecked());
+    m_ui->spinPort->setDisabled(m_ui->useAnyPort->isChecked());
 
     intValue = session->maxConnections();
     if (intValue > 0)

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -300,7 +300,6 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     void (QSpinBox::*qSpinBoxValueChanged)(int) = &QSpinBox::valueChanged;
 
     connect(m_ui->comboProxyType, qComboBoxCurrentIndexChanged, this, &ThisType::enableProxy);
-    connect(m_ui->useAnyPort, &QAbstractButton::toggled, m_ui->spinPort, &ThisType::setDisabled);
 
     // Apply button is activated when a value is changed
     // Behavior tab
@@ -408,7 +407,6 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     // Connection tab
     connect(m_ui->comboProtocol, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->spinPort, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
-    connect(m_ui->useAnyPort, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkUPnP, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->spinUploadLimit, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->spinDownloadLimit, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
@@ -770,7 +768,6 @@ void OptionsDialog::saveOptions()
     // Connection preferences
     session->setBTProtocol(static_cast<BitTorrent::BTProtocol>(m_ui->comboProtocol->currentIndex()));
     session->setPort(getPort());
-    session->setUseAnyAvailablePort(m_ui->useAnyPort->isChecked());
     Net::PortForwarder::instance()->setEnabled(isUPnPEnabled());
     session->setGlobalDownloadSpeedLimit(m_ui->spinDownloadLimit->value() * 1024);
     session->setGlobalUploadSpeedLimit(m_ui->spinUploadLimit->value() * 1024);
@@ -1067,10 +1064,8 @@ void OptionsDialog::loadOptions()
 
     // Connection preferences
     m_ui->comboProtocol->setCurrentIndex(static_cast<int>(session->btProtocol()));
-    m_ui->checkUPnP->setChecked(Net::PortForwarder::instance()->isEnabled());
-    m_ui->useAnyPort->setChecked(session->useAnyAvailablePort());
     m_ui->spinPort->setValue(session->port());
-    m_ui->spinPort->setDisabled(m_ui->useAnyPort->isChecked());
+    m_ui->checkUPnP->setChecked(Net::PortForwarder::instance()->isEnabled());
 
     intValue = session->maxConnections();
     if (intValue > 0)

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -2673,14 +2673,7 @@ Disable encryption: Only connect to peers without protocol encryption</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_16">
                <item row="0" column="0">
-                <widget class="QPlainTextEdit" name="textTrackers">
-                 <property name="enabled">
-                  <bool>true</bool>
-                 </property>
-                 <property name="focusPolicy">
-                  <enum>Qt::StrongFocus</enum>
-                 </property>
-                </widget>
+                <widget class="QPlainTextEdit" name="textTrackers"/>
                </item>
               </layout>
              </widget>

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -1457,14 +1457,11 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
                  </item>
                  <item>
                   <widget class="QSpinBox" name="spinPort">
-                   <property name="minimum">
-                    <number>1</number>
+                   <property name="specialValueText">
+                    <string>Any</string>
                    </property>
                    <property name="maximum">
                     <number>65535</number>
-                   </property>
-                   <property name="value">
-                    <number>8999</number>
                    </property>
                   </widget>
                  </item>
@@ -1489,13 +1486,6 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
                   </spacer>
                  </item>
                 </layout>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="useAnyPort">
-                 <property name="text">
-                  <string>Use any available port</string>
-                 </property>
-                </widget>
                </item>
                <item>
                 <widget class="QCheckBox" name="checkUPnP">
@@ -3469,7 +3459,6 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
   <tabstop>customThemeFilePath</tabstop>
   <tabstop>checkStartPaused</tabstop>
   <tabstop>spinPort</tabstop>
-  <tabstop>useAnyPort</tabstop>
   <tabstop>checkUPnP</tabstop>
   <tabstop>textWebUiUsername</tabstop>
   <tabstop>checkWebUi</tabstop>

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -1491,19 +1491,19 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
                 </layout>
                </item>
                <item>
+                <widget class="QCheckBox" name="useAnyPort">
+                 <property name="text">
+                  <string>Use any available port</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <widget class="QCheckBox" name="checkUPnP">
                  <property name="text">
                   <string>Use UPnP / NAT-PMP port forwarding from my router</string>
                  </property>
                  <property name="checked">
                   <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="checkRandomPort">
-                 <property name="text">
-                  <string>Use different port on each startup</string>
                  </property>
                 </widget>
                </item>
@@ -3281,7 +3281,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
                  </layout>
                 </widget>
                </item>
-			   <item>
+               <item>
                 <widget class="QGroupBox" name="groupEnableReverseProxySupport">
                  <property name="title">
                   <string>Enable reverse proxy support</string>
@@ -3469,6 +3469,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
   <tabstop>customThemeFilePath</tabstop>
   <tabstop>checkStartPaused</tabstop>
   <tabstop>spinPort</tabstop>
+  <tabstop>useAnyPort</tabstop>
   <tabstop>checkUPnP</tabstop>
   <tabstop>textWebUiUsername</tabstop>
   <tabstop>checkWebUi</tabstop>
@@ -3520,7 +3521,6 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
   <tabstop>lineEditAutoRun</tabstop>
   <tabstop>scrollArea_3</tabstop>
   <tabstop>randomButton</tabstop>
-  <tabstop>checkRandomPort</tabstop>
   <tabstop>checkMaxConnecs</tabstop>
   <tabstop>spinMaxConnec</tabstop>
   <tabstop>checkMaxConnecsPerTorrent</tabstop>

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -153,8 +153,8 @@ void AppController::preferencesAction()
     // Connection
     // Listening Port
     data["listen_port"] = session->port();
+    data["random_port"] = (session->port() == 0);  // deprecated
     data["upnp"] = Net::PortForwarder::instance()->isEnabled();
-    data["random_port"] = session->useAnyAvailablePort();
     // Connections Limits
     data["max_connec"] = session->maxConnections();
     data["max_connec_per_torrent"] = session->maxConnectionsPerTorrent();
@@ -482,12 +482,16 @@ void AppController::setPreferencesAction()
 
     // Connection
     // Listening Port
-    if (hasKey("listen_port"))
+    if (hasKey("random_port") && it.value().toBool())  // deprecated
+    {
+        session->setPort(0);
+    }
+    else if (hasKey("listen_port"))
+    {
         session->setPort(it.value().toInt());
+    }
     if (hasKey("upnp"))
         Net::PortForwarder::instance()->setEnabled(it.value().toBool());
-    if (hasKey("random_port"))
-        session->setUseAnyAvailablePort(it.value().toBool());
     // Connections Limits
     if (hasKey("max_connec"))
         session->setMaxConnections(it.value().toInt());

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -154,7 +154,7 @@ void AppController::preferencesAction()
     // Listening Port
     data["listen_port"] = session->port();
     data["upnp"] = Net::PortForwarder::instance()->isEnabled();
-    data["random_port"] = session->useRandomPort();
+    data["random_port"] = session->useAnyAvailablePort();
     // Connections Limits
     data["max_connec"] = session->maxConnections();
     data["max_connec_per_torrent"] = session->maxConnectionsPerTorrent();
@@ -487,7 +487,7 @@ void AppController::setPreferencesAction()
     if (hasKey("upnp"))
         Net::PortForwarder::instance()->setEnabled(it.value().toBool());
     if (hasKey("random_port"))
-        session->setUseRandomPort(it.value().toBool());
+        session->setUseAnyAvailablePort(it.value().toBool());
     // Connections Limits
     if (hasKey("max_connec"))
         session->setMaxConnections(it.value().toInt());

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -235,12 +235,12 @@
             <button style="margin-left: 1em;" onclick="qBittorrent.Preferences.generateRandomPort();">QBT_TR(Random)QBT_TR[CONTEXT=OptionsDialog]</button>
         </div>
         <div class="formRow">
-            <input type="checkbox" id="upnp_checkbox" />
-            <label for="upnp_checkbox">QBT_TR(Use UPnP / NAT-PMP port forwarding from my router)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <input type="checkbox" id="useAnyPortCheckbox" onclick="qBittorrent.Preferences.updatePortValueEnabled();" />
+            <label for="useAnyPortCheckbox">QBT_TR(Use any available port)QBT_TR[CONTEXT=OptionsDialog]</label>
         </div>
         <div class="formRow">
-            <input type="checkbox" id="random_port_checkbox" onclick="qBittorrent.Preferences.updatePortValueEnabled();" />
-            <label for="random_port_checkbox">QBT_TR(Use different port on each startup)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <input type="checkbox" id="upnp_checkbox" />
+            <label for="upnp_checkbox">QBT_TR(Use UPnP / NAT-PMP port forwarding from my router)QBT_TR[CONTEXT=OptionsDialog]</label>
         </div>
     </fieldset>
 
@@ -1405,7 +1405,7 @@
 
         // Connection tab
         const updatePortValueEnabled = function() {
-            const checked = $('random_port_checkbox').getProperty('checked');
+            const checked = $('useAnyPortCheckbox').getProperty('checked');
             $('port_value').setProperty('disabled', checked);
         };
 
@@ -1708,7 +1708,7 @@
                         // Listening Port
                         $('port_value').setProperty('value', pref.listen_port.toInt());
                         $('upnp_checkbox').setProperty('checked', pref.upnp);
-                        $('random_port_checkbox').setProperty('checked', pref.random_port);
+                        $('useAnyPortCheckbox').setProperty('checked', pref.random_port);
                         updatePortValueEnabled();
 
                         // Connections Limits
@@ -2024,7 +2024,7 @@
             }
             settings.set('listen_port', listen_port);
             settings.set('upnp', $('upnp_checkbox').getProperty('checked'));
-            settings.set('random_port', $('random_port_checkbox').getProperty('checked'));
+            settings.set('random_port', $('useAnyPortCheckbox').getProperty('checked'));
 
             // Connections Limits
             let max_connec = -1;

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -235,10 +235,6 @@
             <button style="margin-left: 1em;" onclick="qBittorrent.Preferences.generateRandomPort();">QBT_TR(Random)QBT_TR[CONTEXT=OptionsDialog]</button>
         </div>
         <div class="formRow">
-            <input type="checkbox" id="useAnyPortCheckbox" onclick="qBittorrent.Preferences.updatePortValueEnabled();" />
-            <label for="useAnyPortCheckbox">QBT_TR(Use any available port)QBT_TR[CONTEXT=OptionsDialog]</label>
-        </div>
-        <div class="formRow">
             <input type="checkbox" id="upnp_checkbox" />
             <label for="upnp_checkbox">QBT_TR(Use UPnP / NAT-PMP port forwarding from my router)QBT_TR[CONTEXT=OptionsDialog]</label>
         </div>
@@ -1275,7 +1271,6 @@
                 updateMailAuthSettings: updateMailAuthSettings,
                 updateAutoRun: updateAutoRun,
                 generateRandomPort: generateRandomPort,
-                updatePortValueEnabled: updatePortValueEnabled,
                 updateMaxConnecEnabled: updateMaxConnecEnabled,
                 updateMaxConnecPerTorrentEnabled: updateMaxConnecPerTorrentEnabled,
                 updateMaxUploadsEnabled: updateMaxUploadsEnabled,
@@ -1404,10 +1399,6 @@
         };
 
         // Connection tab
-        const updatePortValueEnabled = function() {
-            const checked = $('useAnyPortCheckbox').getProperty('checked');
-            $('port_value').setProperty('disabled', checked);
-        };
 
         const updateMaxConnecEnabled = function() {
             const isMaxConnecEnabled = $('max_connec_checkbox').getProperty('checked');
@@ -1708,8 +1699,6 @@
                         // Listening Port
                         $('port_value').setProperty('value', pref.listen_port.toInt());
                         $('upnp_checkbox').setProperty('checked', pref.upnp);
-                        $('useAnyPortCheckbox').setProperty('checked', pref.random_port);
-                        updatePortValueEnabled();
 
                         // Connections Limits
                         const max_connec = pref.max_connec.toInt();
@@ -2018,13 +2007,12 @@
             // Connection tab
             // Listening Port
             const listen_port = $('port_value').getProperty('value').toInt();
-            if (isNaN(listen_port) || listen_port < 1 || listen_port > 65535) {
-                alert("QBT_TR(The port used for incoming connections must be between 1 and 65535.)QBT_TR[CONTEXT=HttpServer]");
+            if (isNaN(listen_port) || (listen_port < 0) || (listen_port > 65535)) {
+                alert("QBT_TR(The port used for incoming connections must be between 0 and 65535.)QBT_TR[CONTEXT=HttpServer]");
                 return;
             }
             settings.set('listen_port', listen_port);
             settings.set('upnp', $('upnp_checkbox').getProperty('checked'));
-            settings.set('random_port', $('useAnyPortCheckbox').getProperty('checked'));
 
             // Connections Limits
             let max_connec = -1;


### PR DESCRIPTION
* Use default property for widgets
* Revise checkbox label for "Use any available port" functionality
  Also reorder the checkboxes a bit.
  [screenshot](https://user-images.githubusercontent.com/9395168/126934588-88a99f1d-d1b2-41aa-bd0a-0ea1e9bf100d.png)
* Use spinbox special value to represent "Use any available port"
  WebAPI functionality is preserved (deprecated) for now and should be removed in the future.
  [screenshot](https://user-images.githubusercontent.com/9395168/127268378-fcfb4013-7a08-4fca-94bb-3ddb75130a23.png)
