### PR TITLE
Fix wrong version conditional

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -3891,7 +3891,7 @@ void Session::handleTorrentMetadataReceived(TorrentImpl *const torrent)
     // Copy the torrent file to the export folder
     if (!torrentExportDirectory().isEmpty())
     {
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#if (LIBTORRENT_VERSION_NUM >= 20003)
         const TorrentInfo torrentInfo {torrent->nativeHandle().torrent_file_with_hashes()};
 #else
         const TorrentInfo torrentInfo {torrent->nativeHandle().torrent_file()};
@@ -3949,7 +3949,7 @@ void Session::handleTorrentFinished(TorrentImpl *const torrent)
     // Move .torrent file to another folder
     if (!finishedTorrentExportDirectory().isEmpty())
     {
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#if (LIBTORRENT_VERSION_NUM >= 20003)
         const TorrentInfo torrentInfo {torrent->nativeHandle().torrent_file_with_hashes()};
 #else
         const TorrentInfo torrentInfo {torrent->nativeHandle().torrent_file()};


### PR DESCRIPTION
* Fix wrong version conditional 
  `torrent_file_with_hashes()` was introduced in libtorrent v2.0.3.
  https://github.com/arvidn/libtorrent/releases/tag/v2.0.3
* ~~Don't use old style cast~~
  Moved to #15242.
