### PR TITLE
GitHub Actions CI: update workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ name: GitHub Actions CI
 on: [pull_request, push]
 
 env:
-  VCPKG_COMMIT: c5ac711fefa6cacbd6bb6335349e36a765babf87
+  VCPKG_COMMIT: 8dddc6c899ce6fdbeab38b525a31e7f23cb2d5bb
   VCPKG_DEST_MACOS: /Users/runner/qbt_tools/vcpkg
   VCPKG_DEST_WIN: C:\qbt_tools\vcpkg
   LIBTORRENT_VERSION_TAG: v1.2.14


### PR DESCRIPTION
- update vcpkg to latest commit (includes Boost 1.76)

Closes #15244.