### PR TITLE
Disconnect comment links fom the WebUI

### DIFF
--- a/src/webui/www/private/scripts/misc.js
+++ b/src/webui/www/private/scripts/misc.js
@@ -163,7 +163,7 @@ window.qBittorrent.Misc = (function() {
      */
     const parseHtmlLinks = function(text) {
         const exp = /(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#/%?=~_|!:,.;]*[-A-Z0-9+&@#/%=~_|])/ig;
-        return text.replace(exp, "<a target='_blank' href='$1'>$1</a>");
+        return text.replace(exp, "<a target='_blank' rel='noopener noreferrer' href='$1'>$1</a>");
     }
 
     const escapeHtml = function(str) {


### PR DESCRIPTION
`rel=noopener` results in [better performance](https://jakearchibald.com/2016/performance-benefits-of-rel-noopener/) and [security for untrusted links](https://mathiasbynens.github.io/rel-noopener/). Implicit in very-up-to-date browsers, but people still use older browsers through embedded webviews in apps and devices. `rel=noreferrer` ever so slightly enhances user privacy.