### PR TITLE
Fix last_activity calculation on torrents with 0 xfer

### DIFF
--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -97,7 +97,7 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         return (ratio > BitTorrent::Torrent::MAX_RATIO) ? -1 : ratio;
     };
 
-    const auto getLastActivityTime = [](const qlonglong timeSinceActivity) -> qlonglong
+    const auto adjustActivityTime = [](const qlonglong timeSinceActivity) -> qlonglong
     {
         return (timeSinceActivity < 0)
             ? torrent.addedTime().toSecsSinceEpoch()
@@ -152,7 +152,7 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         {KEY_TORRENT_AUTO_TORRENT_MANAGEMENT, torrent.isAutoTMMEnabled()},
         {KEY_TORRENT_TIME_ACTIVE, torrent.activeTime()},
         {KEY_TORRENT_SEEDING_TIME, torrent.seedingTime()},
-        {KEY_TORRENT_LAST_ACTIVITY_TIME, getLastActivityTime()},
+        {KEY_TORRENT_LAST_ACTIVITY_TIME, adjustActivityTime(torrent.timeSinceActivity())},
         {KEY_TORRENT_AVAILABILITY, torrent.distributedCopies()},
 
         {KEY_TORRENT_TOTAL_SIZE, torrent.totalSize()}

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -102,7 +102,7 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         return (timeSinceActivity < 0)
             ? torrent.addedTime().toSecsSinceEpoch()
             : (QDateTime::currentDateTime().toSecsSinceEpoch() - timeSinceActivity);
-    }
+    };
 
     return {
         {KEY_TORRENT_ID, torrent.id().toString()},

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -97,7 +97,7 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         return (ratio > BitTorrent::Torrent::MAX_RATIO) ? -1 : ratio;
     };
 
-    const auto getLastActivityTime = [&torrent](const qlonglong timeSinceActivity) -> qlonglong
+    const auto getLastActivityTime = [](const qlonglong timeSinceActivity) -> qlonglong
     {
         return (timeSinceActivity < 0)
             ? torrent.addedTime().toSecsSinceEpoch()

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -97,7 +97,13 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         return (ratio > BitTorrent::Torrent::MAX_RATIO) ? -1 : ratio;
     };
 
-    const auto adjustLastActivity = [](const qlonglong sinceActivity) -> qlonglong
+    const auto getLastActivityTime = [&torrent]() -> qlonglong
+    {
+        const qlonglong timeSinceActivity = torrent.timeSinceActivity();
+        return (timeSinceActivity < 0)
+            ? torrent.added_time
+            : (QDateTime::currentDateTime().toSecsSinceEpoch() - timeSinceActivity);
+    }
     {
         if (sinceActivity < 0)
             return m_nativeStatus.added_time;
@@ -152,7 +158,7 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         {KEY_TORRENT_AUTO_TORRENT_MANAGEMENT, torrent.isAutoTMMEnabled()},
         {KEY_TORRENT_TIME_ACTIVE, torrent.activeTime()},
         {KEY_TORRENT_SEEDING_TIME, torrent.seedingTime()},
-        {KEY_TORRENT_LAST_ACTIVITY_TIME, adjustLastActivity(torrent.timeSinceActivity())},
+        {KEY_TORRENT_LAST_ACTIVITY_TIME, getLastActivityTime()},
         {KEY_TORRENT_AVAILABILITY, torrent.distributedCopies()},
 
         {KEY_TORRENT_TOTAL_SIZE, torrent.totalSize()}

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -99,15 +99,9 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
 
     const auto getLastActivityTime = [&torrent]() -> qlonglong
     {
-        const qlonglong timeSinceActivity = torrent.timeSinceActivity();
         return (timeSinceActivity < 0)
             ? torrent.addedTime().toSecsSinceEpoch()
             : (QDateTime::currentDateTime().toSecsSinceEpoch() - timeSinceActivity);
-    }
-    {
-        if (sinceActivity < 0)
-            return m_nativeStatus.added_time;
-        return QDateTime::currentDateTime().toSecsSinceEpoch() - sinceActivity;
     }
 
     return {

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -97,6 +97,13 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         return (ratio > BitTorrent::Torrent::MAX_RATIO) ? -1 : ratio;
     };
 
+    const auto adjustLastActivity = [](const qlonglong sinceActivity) -> qlonglong
+    {
+        if (sinceActivity < 0)
+            return m_nativeStatus.added_time;
+        return QDateTime::currentDateTime().toSecsSinceEpoch() - sinceActivity;
+    }
+
     return {
         {KEY_TORRENT_ID, torrent.id().toString()},
         {KEY_TORRENT_INFOHASHV1, torrent.infoHash().v1().toString()},
@@ -145,7 +152,7 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         {KEY_TORRENT_AUTO_TORRENT_MANAGEMENT, torrent.isAutoTMMEnabled()},
         {KEY_TORRENT_TIME_ACTIVE, torrent.activeTime()},
         {KEY_TORRENT_SEEDING_TIME, torrent.seedingTime()},
-        {KEY_TORRENT_LAST_ACTIVITY_TIME, (QDateTime::currentDateTime().toSecsSinceEpoch() - torrent.timeSinceActivity())},
+        {KEY_TORRENT_LAST_ACTIVITY_TIME, adjustLastActivity(torrent.timeSinceActivity())},
         {KEY_TORRENT_AVAILABILITY, torrent.distributedCopies()},
 
         {KEY_TORRENT_TOTAL_SIZE, torrent.totalSize()}

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -101,7 +101,7 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
     {
         const qlonglong timeSinceActivity = torrent.timeSinceActivity();
         return (timeSinceActivity < 0)
-            ? torrent.added_time
+            ? torrent.addedTime().toSecsSinceEpoch()
             : (QDateTime::currentDateTime().toSecsSinceEpoch() - timeSinceActivity);
     }
     {

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -97,7 +97,7 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         return (ratio > BitTorrent::Torrent::MAX_RATIO) ? -1 : ratio;
     };
 
-    const auto adjustActivityTime = [](const qlonglong timeSinceActivity) -> qlonglong
+    const auto adjustActivityTime = [&torrent](const qlonglong timeSinceActivity) -> qlonglong
     {
         return (timeSinceActivity < 0)
             ? torrent.addedTime().toSecsSinceEpoch()

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -97,7 +97,7 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         return (ratio > BitTorrent::Torrent::MAX_RATIO) ? -1 : ratio;
     };
 
-    const auto getLastActivityTime = [&torrent]() -> qlonglong
+    const auto getLastActivityTime = [&torrent](const qlonglong timeSinceActivity) -> qlonglong
     {
         return (timeSinceActivity < 0)
             ? torrent.addedTime().toSecsSinceEpoch()


### PR DESCRIPTION
I notice qb API could report the correct last_activity and it's causing a huge update each 15 seconds for massive idling torrents.

Currently qb is using `now - timeSinceActivity` to calculate last_activity, however `timeSinceActivity` returns -1 for some idling torrents, and API will returns `now - (-1)`.

This will render incorrect last_activity values in webui, and causing lags every 15 seconds.
![image](https://user-images.githubusercontent.com/822628/128473764-8d2e855a-bcce-41ab-ad35-61da4b54f283.png)
![image](https://user-images.githubusercontent.com/822628/128473674-5e4fbd79-93eb-4259-ab94-916759bd3e96.png)

