### PR TITLE
Add compile definition to indicate using of libtorrent 2.0

### DIFF
--- a/conf.pri.windows
+++ b/conf.pri.windows
@@ -45,6 +45,9 @@ DEFINES += BOOST_SYSTEM_STATIC_LINK
 # Enable if linking dynamically against libtorrent
 #DEFINES += TORRENT_LINKING_SHARED
 
+# Enable this if compiling with libtorrent 2.x
+#DEFINES += QBT_USES_LIBTORRENT2
+
 # Enable stack trace support
 CONFIG += stacktrace
 

--- a/configure
+++ b/configure
@@ -6279,7 +6279,7 @@ else
 	libtorrent_LIBS=$pkg_cv_libtorrent_LIBS
         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
-	CXXFLAGS="$libtorrent_CFLAGS $CXXFLAGS" LIBS="$libtorrent_LIBS $LIBS"
+	CXXFLAGS="$libtorrent_CFLAGS $CXXFLAGS" LIBS="$libtorrent_LIBS $LIBS" QBT_ADD_DEFINES="$QBT_ADD_DEFINES QBT_USES_LIBTORRENT2"
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -178,7 +178,7 @@ AC_COMPILE_IFELSE([DETECT_BOOST_VERSION_PROGRAM(106000)], [],
 
 PKG_CHECK_MODULES(libtorrent,
                   [libtorrent-rasterbar >= 2.0.4],
-                  [CXXFLAGS="$libtorrent_CFLAGS $CXXFLAGS" LIBS="$libtorrent_LIBS $LIBS"],
+                  [CXXFLAGS="$libtorrent_CFLAGS $CXXFLAGS" LIBS="$libtorrent_LIBS $LIBS" QBT_ADD_DEFINES="$QBT_ADD_DEFINES QBT_USES_LIBTORRENT2"],
                   [PKG_CHECK_MODULES(libtorrent,
                                      [libtorrent-rasterbar >= 1.2.14 libtorrent-rasterbar < 2],
                                      [CXXFLAGS="$libtorrent_CFLAGS $CXXFLAGS" LIBS="$libtorrent_LIBS $LIBS"])])

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,7 @@ endmacro()
 find_libtorrent(${minLibtorrent1Version})
 if (LibtorrentRasterbar_FOUND AND (LibtorrentRasterbar_VERSION VERSION_GREATER_EQUAL 2.0))
     find_libtorrent(${minLibtorrentVersion})
+    target_compile_definitions(qbt_common_cfg PUBLIC QBT_USES_LIBTORRENT2)
 endif()
 
 # force variable type so that it always shows up in ccmake/cmake-gui frontends

--- a/src/base/bittorrent/customstorage.cpp
+++ b/src/base/bittorrent/customstorage.cpp
@@ -35,7 +35,7 @@
 #include "base/utils/fs.h"
 #include "common.h"
 
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
 #include <libtorrent/session.hpp>
 
 std::unique_ptr<lt::disk_interface> customDiskIOConstructor(

--- a/src/base/bittorrent/customstorage.h
+++ b/src/base/bittorrent/customstorage.h
@@ -30,11 +30,10 @@
 
 #include <libtorrent/aux_/vector.hpp>
 #include <libtorrent/fwd.hpp>
-#include <libtorrent/version.hpp>
 
 #include <QString>
 
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
 #include <libtorrent/disk_interface.hpp>
 #include <libtorrent/file_storage.hpp>
 #include <libtorrent/io_context.hpp>
@@ -46,7 +45,7 @@
 #include <libtorrent/storage.hpp>
 #endif
 
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
 std::unique_ptr<lt::disk_interface> customDiskIOConstructor(
         lt::io_context &ioContext, lt::settings_interface const &settings, lt::counters &counters);
 

--- a/src/base/bittorrent/infohash.cpp
+++ b/src/base/bittorrent/infohash.cpp
@@ -43,7 +43,7 @@ bool BitTorrent::InfoHash::isValid() const
 
 SHA1Hash BitTorrent::InfoHash::v1() const
 {
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
     return (m_nativeHash.has_v1() ? SHA1Hash(m_nativeHash.v1) : SHA1Hash());
 #else
     return {m_nativeHash};
@@ -52,7 +52,7 @@ SHA1Hash BitTorrent::InfoHash::v1() const
 
 SHA256Hash BitTorrent::InfoHash::v2() const
 {
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
     return (m_nativeHash.has_v2() ? SHA256Hash(m_nativeHash.v2) : SHA256Hash());
 #else
     return {};
@@ -61,7 +61,7 @@ SHA256Hash BitTorrent::InfoHash::v2() const
 
 BitTorrent::TorrentID BitTorrent::InfoHash::toTorrentID() const
 {
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
     return m_nativeHash.get_best();
 #else
     return {m_nativeHash};

--- a/src/base/bittorrent/infohash.h
+++ b/src/base/bittorrent/infohash.h
@@ -28,8 +28,7 @@
 
 #pragma once
 
-#include <libtorrent/version.hpp>
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
 #include <libtorrent/info_hash.hpp>
 #endif
 
@@ -58,7 +57,7 @@ namespace BitTorrent
     class InfoHash
     {
     public:
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
         using WrappedType = lt::info_hash_t;
 #else
         using WrappedType = lt::sha1_hash;

--- a/src/base/bittorrent/magneturi.cpp
+++ b/src/base/bittorrent/magneturi.cpp
@@ -90,7 +90,7 @@ MagnetUri::MagnetUri(const QString &source)
 
     m_valid = true;
 
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
     m_infoHash = m_addTorrentParams.info_hashes;
 #else
     m_infoHash = m_addTorrentParams.info_hash;

--- a/src/base/bittorrent/nativesessionextension.h
+++ b/src/base/bittorrent/nativesessionextension.h
@@ -29,11 +29,10 @@
 #pragma once
 
 #include <libtorrent/extensions.hpp>
-#include <libtorrent/version.hpp>
 
 class NativeSessionExtension final : public lt::plugin
 {
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
     using ClientData = lt::client_data_t;
 #else
     using ClientData = void *;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -36,7 +36,6 @@
 #include <libtorrent/add_torrent_params.hpp>
 #include <libtorrent/fwd.hpp>
 #include <libtorrent/torrent_handle.hpp>
-#include <libtorrent/version.hpp>
 
 #include <QHash>
 #include <QPointer>
@@ -191,7 +190,7 @@ namespace BitTorrent
         {
             int diskBlocksInUse = -1;
             int numBlocksRead = -1;
-#if (LIBTORRENT_VERSION_NUM < 20000)
+#ifndef QBT_USES_LIBTORRENT2
             int numBlocksCacheHits = -1;
 #endif
             int writeJobs = -1;

--- a/src/base/bittorrent/torrentcreatorthread.cpp
+++ b/src/base/bittorrent/torrentcreatorthread.cpp
@@ -57,7 +57,7 @@ namespace
         return !Utils::Fs::fileName(QString::fromStdString(f)).startsWith('.');
     }
 
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
     lt::create_flags_t toNativeTorrentFormatFlag(const BitTorrent::TorrentFormat torrentFormat)
     {
         switch (torrentFormat)
@@ -159,7 +159,7 @@ void TorrentCreatorThread::run()
 
         checkInterruptionRequested();
 
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
         lt::create_torrent newTorrent {fs, m_params.pieceSize, toNativeTorrentFormatFlag(m_params.torrentFormat)};
 #else
         lt::create_torrent newTorrent(fs, m_params.pieceSize, m_params.paddedFileSizeLimit
@@ -233,7 +233,7 @@ void TorrentCreatorThread::run()
     }
 }
 
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
 int TorrentCreatorThread::calculateTotalPieces(const QString &inputPath, const int pieceSize, const TorrentFormat torrentFormat)
 #else
 int TorrentCreatorThread::calculateTotalPieces(const QString &inputPath, const int pieceSize, const bool isAlignmentOptimized, const int paddedFileSizeLimit)
@@ -245,7 +245,7 @@ int TorrentCreatorThread::calculateTotalPieces(const QString &inputPath, const i
     lt::file_storage fs;
     lt::add_files(fs, Utils::Fs::toNativePath(inputPath).toStdString(), fileFilter);
 
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
     return lt::create_torrent {fs, pieceSize, toNativeTorrentFormatFlag(torrentFormat)}.num_pieces();
 #else
     return lt::create_torrent(fs, pieceSize, paddedFileSizeLimit

--- a/src/base/bittorrent/torrentcreatorthread.h
+++ b/src/base/bittorrent/torrentcreatorthread.h
@@ -28,14 +28,12 @@
 
 #pragma once
 
-#include <libtorrent/version.hpp>
-
 #include <QStringList>
 #include <QThread>
 
 namespace BitTorrent
 {
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
     enum class TorrentFormat
     {
         V1,
@@ -47,7 +45,7 @@ namespace BitTorrent
     struct TorrentCreatorParams
     {
         bool isPrivate;
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
         TorrentFormat torrentFormat;
 #else
         bool isAlignmentOptimized;
@@ -73,7 +71,7 @@ namespace BitTorrent
 
         void create(const TorrentCreatorParams &params);
 
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
         static int calculateTotalPieces(const QString &inputPath, const int pieceSize, const TorrentFormat torrentFormat);
 #else
         static int calculateTotalPieces(const QString &inputPath

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -43,9 +43,8 @@
 #include <libtorrent/session.hpp>
 #include <libtorrent/storage_defs.hpp>
 #include <libtorrent/time.hpp>
-#include <libtorrent/version.hpp>
 
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
 #include <libtorrent/info_hash.hpp>
 #endif
 
@@ -96,7 +95,7 @@ namespace
         return entry;
     }
 
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
     TrackerEntry fromNativeAnnouncerEntry(const lt::announce_entry &nativeEntry
         , const lt::info_hash_t &hashes, const QMap<lt::tcp::endpoint, int> &trackerPeerCounts)
 #else
@@ -111,7 +110,7 @@ namespace
         int numNotWorking = 0;
         QString firstTrackerMessage;
         QString firstErrorMessage;
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
         const auto numEndpoints = static_cast<qsizetype>(nativeEntry.endpoints.size() * ((hashes.has_v1() && hashes.has_v2()) ? 2 : 1));
         trackerEntry.endpoints.reserve(static_cast<decltype(trackerEntry.endpoints)::size_type>(numEndpoints));
         for (const lt::announce_endpoint &endpoint : nativeEntry.endpoints)
@@ -265,7 +264,7 @@ TorrentImpl::TorrentImpl(Session *session, lt::session *nativeSession
     , m_session(session)
     , m_nativeSession(nativeSession)
     , m_nativeHandle(nativeHandle)
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
     , m_infoHash(m_nativeHandle.info_hashes())
 #else
     , m_infoHash(m_nativeHandle.info_hash())
@@ -478,7 +477,7 @@ QVector<TrackerEntry> TorrentImpl::trackers() const
     for (const lt::announce_entry &tracker : nativeTrackers)
     {
         const QString trackerURL = QString::fromStdString(tracker.url);
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
         entries << fromNativeAnnouncerEntry(tracker, m_nativeHandle.info_hashes(), m_trackerPeerCounts[trackerURL]);
 #else
         entries << fromNativeAnnouncerEntry(tracker, m_trackerPeerCounts[trackerURL]);
@@ -1942,7 +1941,7 @@ void TorrentImpl::handleFileErrorAlert(const lt::file_error_alert *p)
     m_lastFileError = {p->error, p->op};
 }
 
-#if (LIBTORRENT_VERSION_NUM >= 20003)
+#ifdef QBT_USES_LIBTORRENT2
 void TorrentImpl::handleFilePrioAlert(const lt::file_prio_alert *)
 {
     if (m_nativeHandle.need_save_resume_data())
@@ -1987,7 +1986,7 @@ void TorrentImpl::handleAlert(const lt::alert *a)
 {
     switch (a->type())
     {
-#if (LIBTORRENT_VERSION_NUM >= 20003)
+#ifdef QBT_USES_LIBTORRENT2
     case lt::file_prio_alert::alert_type:
         handleFilePrioAlert(static_cast<const lt::file_prio_alert*>(a));
         break;

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -252,7 +252,7 @@ namespace BitTorrent
         void handleFastResumeRejectedAlert(const lt::fastresume_rejected_alert *p);
         void handleFileCompletedAlert(const lt::file_completed_alert *p);
         void handleFileErrorAlert(const lt::file_error_alert *p);
-#if (LIBTORRENT_VERSION_NUM >= 20003)
+#ifdef QBT_USES_LIBTORRENT2
         void handleFilePrioAlert(const lt::file_prio_alert *p);
 #endif
         void handleFileRenamedAlert(const lt::file_renamed_alert *p);

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -31,7 +31,6 @@
 #include <libtorrent/bencode.hpp>
 #include <libtorrent/create_torrent.hpp>
 #include <libtorrent/error_code.hpp>
-#include <libtorrent/version.hpp>
 
 #include <QByteArray>
 #include <QDateTime>
@@ -197,7 +196,7 @@ InfoHash TorrentInfo::infoHash() const
 {
     if (!isValid()) return {};
 
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
     return m_nativeInfo->info_hashes();
 #else
     return m_nativeInfo->info_hash();
@@ -342,7 +341,7 @@ QVector<QUrl> TorrentInfo::urlSeeds() const
 QByteArray TorrentInfo::metadata() const
 {
     if (!isValid()) return {};
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
     const lt::span<const char> infoSection {m_nativeInfo->info_section()};
     return {infoSection.data(), static_cast<int>(infoSection.size())};
 #else

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -96,18 +96,18 @@ namespace
         // libtorrent section
         LIBTORRENT_HEADER,
         ASYNC_IO_THREADS,
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
         HASHING_THREADS,
 #endif
         FILE_POOL_SIZE,
         CHECKING_MEM_USAGE,
-#if (LIBTORRENT_VERSION_NUM < 20000)
+#ifndef QBT_USES_LIBTORRENT2
         // cache
         DISK_CACHE,
         DISK_CACHE_TTL,
 #endif
         OS_CACHE,
-#if (LIBTORRENT_VERSION_NUM < 20000)
+#ifndef QBT_USES_LIBTORRENT2
         COALESCE_RW,
 #endif
         PIECE_EXTENT_AFFINITY,
@@ -199,7 +199,7 @@ void AdvancedSettings::saveAdvancedSettings()
 #endif
     // Async IO threads
     session->setAsyncIOThreads(m_spinBoxAsyncIOThreads.value());
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
     // Hashing threads
     session->setHashingThreads(m_spinBoxHashingThreads.value());
 #endif
@@ -207,14 +207,14 @@ void AdvancedSettings::saveAdvancedSettings()
     session->setFilePoolSize(m_spinBoxFilePoolSize.value());
     // Checking Memory Usage
     session->setCheckingMemUsage(m_spinBoxCheckingMemUsage.value());
-#if (LIBTORRENT_VERSION_NUM < 20000)
+#ifndef QBT_USES_LIBTORRENT2
     // Disk write cache
     session->setDiskCacheSize(m_spinBoxCache.value());
     session->setDiskCacheTTL(m_spinBoxCacheTTL.value());
 #endif
     // Enable OS cache
     session->setUseOSCache(m_checkBoxOsCache.isChecked());
-#if (LIBTORRENT_VERSION_NUM < 20000)
+#ifndef QBT_USES_LIBTORRENT2
     // Coalesce reads & writes
     session->setCoalesceReadWriteEnabled(m_checkBoxCoalesceRW.isChecked());
 #endif
@@ -321,7 +321,7 @@ void AdvancedSettings::saveAdvancedSettings()
     session->setPeerTurnoverInterval(m_spinBoxPeerTurnoverInterval.value());
 }
 
-#if (LIBTORRENT_VERSION_NUM < 20000)
+#ifndef QBT_USES_LIBTORRENT2
 void AdvancedSettings::updateCacheSpinSuffix(int value)
 {
     if (value == 0)
@@ -445,7 +445,7 @@ void AdvancedSettings::loadAdvancedSettings()
     addRow(ASYNC_IO_THREADS, (tr("Asynchronous I/O threads") + ' ' + makeLink("https://www.libtorrent.org/reference-Settings.html#aio_threads", "(?)"))
             , &m_spinBoxAsyncIOThreads);
 
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
     // Hashing threads
     m_spinBoxHashingThreads.setMinimum(1);
     m_spinBoxHashingThreads.setMaximum(1024);
@@ -474,7 +474,7 @@ void AdvancedSettings::loadAdvancedSettings()
     m_spinBoxCheckingMemUsage.setSuffix(tr(" MiB"));
     addRow(CHECKING_MEM_USAGE, (tr("Outstanding memory when checking torrents") + ' ' + makeLink("https://www.libtorrent.org/reference-Settings.html#checking_mem_usage", "(?)"))
             , &m_spinBoxCheckingMemUsage);
-#if (LIBTORRENT_VERSION_NUM < 20000)
+#ifndef QBT_USES_LIBTORRENT2
     // Disk write cache
     m_spinBoxCache.setMinimum(-1);
     // When build as 32bit binary, set the maximum at less than 2GB to prevent crashes.
@@ -502,7 +502,7 @@ void AdvancedSettings::loadAdvancedSettings()
     m_checkBoxOsCache.setChecked(session->useOSCache());
     addRow(OS_CACHE, (tr("Enable OS cache") + ' ' + makeLink("https://www.libtorrent.org/reference-Settings.html#disk_io_write_mode", "(?)"))
             , &m_checkBoxOsCache);
-#if (LIBTORRENT_VERSION_NUM < 20000)
+#ifndef QBT_USES_LIBTORRENT2
     // Coalesce reads & writes
     m_checkBoxCoalesceRW.setChecked(session->isCoalesceReadWriteEnabled());
     addRow(COALESCE_RW, (tr("Coalesce reads & writes") + ' ' + makeLink("https://www.libtorrent.org/reference-Settings.html#coalesce_reads", "(?)"))

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -28,8 +28,6 @@
 
 #pragma once
 
-#include <libtorrent/version.hpp>
-
 #include <QCheckBox>
 #include <QComboBox>
 #include <QLineEdit>
@@ -50,7 +48,7 @@ signals:
     void settingsChanged();
 
 private slots:
-#if (LIBTORRENT_VERSION_NUM < 20000)
+#ifndef QBT_USES_LIBTORRENT2
     void updateCacheSpinSuffix(int value);
 #endif
     void updateSaveResumeDataIntervalSuffix(int value);
@@ -74,7 +72,7 @@ private:
               m_comboBoxSeedChokingAlgorithm, m_comboBoxResumeDataStorage;
     QLineEdit m_lineEditAnnounceIP;
 
-#if (LIBTORRENT_VERSION_NUM < 20000)
+#ifndef QBT_USES_LIBTORRENT2
     QSpinBox m_spinBoxCache, m_spinBoxCacheTTL;
     QCheckBox m_checkBoxCoalesceRW;
 #else

--- a/src/gui/downloadfromurldialog.cpp
+++ b/src/gui/downloadfromurldialog.cpp
@@ -50,7 +50,7 @@ namespace
             || str.startsWith("ftp://", Qt::CaseInsensitive)
             || str.startsWith("magnet:", Qt::CaseInsensitive)
             || ((str.size() == 40) && !str.contains(QRegularExpression("[^0-9A-Fa-f]"))) // v1 hex-encoded SHA-1 info-hash
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
             || ((str.size() == 64) && !str.contains(QRegularExpression("[^0-9A-Fa-f]"))) // v2 hex-encoded SHA-256 info-hash
 #endif
             || ((str.size() == 32) && !str.contains(QRegularExpression("[^2-7A-Za-z]")))); // v1 Base32 encoded SHA-1 info-hash

--- a/src/gui/statsdialog.cpp
+++ b/src/gui/statsdialog.cpp
@@ -55,7 +55,7 @@ StatsDialog::StatsDialog(QWidget *parent)
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::statsUpdated
             , this, &StatsDialog::update);
 
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
     m_ui->labelCacheHitsText->hide();
     m_ui->labelCacheHits->hide();
 #endif
@@ -87,7 +87,7 @@ void StatsDialog::update()
                 ((atd > 0) && (atu > 0))
                 ? Utils::String::fromDouble(static_cast<qreal>(atu) / atd, 2)
                 : "-");
-#if (LIBTORRENT_VERSION_NUM < 20000)
+#ifndef QBT_USES_LIBTORRENT2
     // Cache hits
     const qreal readRatio = cs.readRatio;
     m_ui->labelCacheHits->setText(QString::fromLatin1("%1%").arg((readRatio > 0)

--- a/src/gui/torrentcreatordialog.cpp
+++ b/src/gui/torrentcreatordialog.cpp
@@ -53,7 +53,7 @@ TorrentCreatorDialog::TorrentCreatorDialog(QWidget *parent, const QString &defau
     , m_storePrivateTorrent(SETTINGS_KEY("PrivateTorrent"))
     , m_storeStartSeeding(SETTINGS_KEY("StartSeeding"))
     , m_storeIgnoreRatio(SETTINGS_KEY("IgnoreRatio"))
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
     , m_storeTorrentFormat(SETTINGS_KEY("TorrentFormat"))
 #else
     , m_storeOptimizeAlignment(SETTINGS_KEY("OptimizeAlignment"))
@@ -84,7 +84,7 @@ TorrentCreatorDialog::TorrentCreatorDialog(QWidget *parent, const QString &defau
     loadSettings();
     updateInputPath(defaultPath);
 
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
     m_ui->checkOptimizeAlignment->hide();
 #else
     m_ui->widgetTorrentFormat->hide();
@@ -127,7 +127,7 @@ int TorrentCreatorDialog::getPieceSize() const
     return pieceSizes[m_ui->comboPieceSize->currentIndex()] * 1024;
 }
 
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
 BitTorrent::TorrentFormat TorrentCreatorDialog::getTorrentFormat() const
 {
     switch (m_ui->comboTorrentFormat->currentIndex())
@@ -201,7 +201,7 @@ void TorrentCreatorDialog::onCreateButtonClicked()
     const BitTorrent::TorrentCreatorParams params
     {
         m_ui->checkPrivate->isChecked()
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
         , getTorrentFormat()
 #else
         , m_ui->checkOptimizeAlignment->isChecked()
@@ -266,7 +266,7 @@ void TorrentCreatorDialog::updateProgressBar(int progress)
 void TorrentCreatorDialog::updatePiecesCount()
 {
     const QString path = m_ui->textInputPath->text().trimmed();
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
     const int count = BitTorrent::TorrentCreatorThread::calculateTotalPieces(
         path, getPieceSize(), getTorrentFormat());
 #else
@@ -291,7 +291,7 @@ void TorrentCreatorDialog::setInteractionEnabled(const bool enabled) const
     m_ui->checkStartSeeding->setEnabled(enabled);
     m_ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(enabled);
     m_ui->checkIgnoreShareLimits->setEnabled(enabled && m_ui->checkStartSeeding->isChecked());
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
     m_ui->widgetTorrentFormat->setEnabled(enabled);
 #else
     m_ui->checkOptimizeAlignment->setEnabled(enabled);
@@ -307,7 +307,7 @@ void TorrentCreatorDialog::saveSettings()
     m_storePrivateTorrent = m_ui->checkPrivate->isChecked();
     m_storeStartSeeding = m_ui->checkStartSeeding->isChecked();
     m_storeIgnoreRatio = m_ui->checkIgnoreShareLimits->isChecked();
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
     m_storeTorrentFormat = m_ui->comboTorrentFormat->currentIndex();
 #else
     m_storeOptimizeAlignment = m_ui->checkOptimizeAlignment->isChecked();
@@ -331,7 +331,7 @@ void TorrentCreatorDialog::loadSettings()
     m_ui->checkStartSeeding->setChecked(m_storeStartSeeding);
     m_ui->checkIgnoreShareLimits->setChecked(m_storeIgnoreRatio);
     m_ui->checkIgnoreShareLimits->setEnabled(m_ui->checkStartSeeding->isChecked());
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
     m_ui->comboTorrentFormat->setCurrentIndex(m_storeTorrentFormat.get(1));
 #else
     m_ui->checkOptimizeAlignment->setChecked(m_storeOptimizeAlignment.get(true));

--- a/src/gui/torrentcreatordialog.h
+++ b/src/gui/torrentcreatordialog.h
@@ -29,8 +29,6 @@
 
 #pragma once
 
-#include <libtorrent/version.hpp>
-
 #include <QDialog>
 
 #include "base/bittorrent/torrentcreatorthread.h"
@@ -68,7 +66,7 @@ private:
     void setInteractionEnabled(bool enabled) const;
 
     int getPieceSize() const;
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
     BitTorrent::TorrentFormat getTorrentFormat() const;
 #else
     int getPaddedFileSizeLimit() const;
@@ -83,7 +81,7 @@ private:
     SettingValue<bool> m_storePrivateTorrent;
     SettingValue<bool> m_storeStartSeeding;
     SettingValue<bool> m_storeIgnoreRatio;
-#if (LIBTORRENT_VERSION_NUM >= 20000)
+#ifdef QBT_USES_LIBTORRENT2
     SettingValue<int> m_storeTorrentFormat;
 #else
     SettingValue<bool> m_storeOptimizeAlignment;


### PR DESCRIPTION
* Add compile definition to indicate using of libtorrent 2.0
  The compile definition is temporary which will be removed when qbt ditches libtorrent 1.x.

Part of code is adopted from https://github.com/qbittorrent/qBittorrent/pull/15242#issuecomment-889026909.