### PR TITLE
Minor UI revise

### DIFF
--- a/src/gui/fspathedit.cpp
+++ b/src/gui/fspathedit.cpp
@@ -155,26 +155,21 @@ QString FileSystemPathEdit::FileSystemPathEditPrivate::dialogCaptionOrDefault() 
 
 void FileSystemPathEdit::FileSystemPathEditPrivate::modeChanged()
 {
-    QStyle::StandardPixmap pixmap = QStyle::SP_DialogOpenButton;
     bool showDirsOnly = false;
     switch (m_mode)
     {
     case FileSystemPathEdit::Mode::FileOpen:
     case FileSystemPathEdit::Mode::FileSave:
-#ifdef Q_OS_WIN
-        pixmap = QStyle::SP_DirOpenIcon;
-#endif
         showDirsOnly = false;
         break;
     case FileSystemPathEdit::Mode::DirectoryOpen:
     case FileSystemPathEdit::Mode::DirectorySave:
-        pixmap = QStyle::SP_DirOpenIcon;
         showDirsOnly = true;
         break;
     default:
         throw std::logic_error("Unknown FileSystemPathEdit mode");
     }
-    m_browseAction->setIcon(QApplication::style()->standardIcon(pixmap));
+    m_browseAction->setIcon(QApplication::style()->standardIcon(QStyle::SP_DirOpenIcon));
     m_editor->completeDirectoriesOnly(showDirsOnly);
 
     m_validator->setExistingOnly(m_mode != FileSystemPathEdit::Mode::FileSave);

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -1570,18 +1570,12 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
                  <property name="text">
                   <string>Maximum number of upload slots per torrent:</string>
                  </property>
-                 <property name="checked">
-                  <bool>false</bool>
-                 </property>
                 </widget>
                </item>
                <item row="2" column="0">
                 <widget class="QCheckBox" name="checkMaxUploads">
                  <property name="text">
                   <string>Global maximum number of upload slots:</string>
-                 </property>
-                 <property name="checked">
-                  <bool>false</bool>
                  </property>
                 </widget>
                </item>
@@ -1667,9 +1661,6 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
                   <widget class="QLineEdit" name="textProxyIP">
                    <property name="enabled">
                     <bool>false</bool>
-                   </property>
-                   <property name="text">
-                    <string/>
                    </property>
                   </widget>
                  </item>

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -3367,11 +3367,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
                    </widget>
                   </item>
                   <item row="2" column="1">
-                   <widget class="QLineEdit" name="DNSUsernameTxt">
-                    <property name="maxLength">
-                     <number>50</number>
-                    </property>
-                   </widget>
+                   <widget class="QLineEdit" name="DNSUsernameTxt"/>
                   </item>
                   <item row="3" column="0">
                    <widget class="QLabel" name="label_22">
@@ -3382,9 +3378,6 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
                   </item>
                   <item row="3" column="1">
                    <widget class="QLineEdit" name="DNSPasswordTxt">
-                    <property name="maxLength">
-                     <number>50</number>
-                    </property>
                     <property name="echoMode">
                      <enum>QLineEdit::Password</enum>
                     </property>

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -1457,6 +1457,9 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
                  </item>
                  <item>
                   <widget class="QSpinBox" name="spinPort">
+                   <property name="toolTip">
+                    <string>Set to 0 to let your system pick an unused port</string>
+                   </property>
                    <property name="specialValueText">
                     <string>Any</string>
                    </property>

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -231,7 +231,7 @@
         <legend>QBT_TR(Listening Port)QBT_TR[CONTEXT=OptionsDialog]</legend>
         <div class="formRow">
             <label for="port_value">QBT_TR(Port used for incoming connections:)QBT_TR[CONTEXT=OptionsDialog]</label>
-            <input type="text" id="port_value" style="width: 4em;" />
+            <input type="text" id="port_value" style="width: 4em;" title="QBT_TR(Set to 0 to let your system pick an unused port)QBT_TR[CONTEXT=OptionsDialog]" />
             <button style="margin-left: 1em;" onclick="qBittorrent.Preferences.generateRandomPort();">QBT_TR(Random)QBT_TR[CONTEXT=OptionsDialog]</button>
         </div>
         <div class="formRow">


### PR DESCRIPTION
* Use the same icon for selecting folders/files
  As stated in Qt doc, the `QStyle::SP_DialogOpenButton` is only for a button within QDialogButtonBox which means it isn't suitable elsewhere.
* Use default upper limits for ddns entries
  The default is 32767 which is larger than the previous artificial limit.
* Use default values for inconsequential fields
  Or when the default value is actually what we want.
* Add tooltip to listening port spinbox 