### PR TITLE
Stale bot: Handle more PR per run

### DIFF
--- a/.github/workflows/stale_bot.yaml
+++ b/.github/workflows/stale_bot.yaml
@@ -19,3 +19,4 @@ jobs:
           days-before-pr-close: 7
           exempt-all-pr-assignees: true  # avoid stale for all PR with assignees
           exempt-all-pr-milestones: true # avoid stale for all PR with milestones
+          operations-per-run: 200


### PR DESCRIPTION
Previously only [28 PR are scanned per run](https://github.com/qbittorrent/qBittorrent/runs/3286243181?check_suite_focus=true#step:2:9922), this commit attempt to handle all open PR at once.

Another repo that has similar count of issues/PR utilize a larger number than this PR:
https://github.com/Automattic/wp-calypso/blob/trunk/.github/workflows/mark-issue-stale.yml#L34
However the proposed value (`200`) is already sufficient for handling all PR, see my previous "debug-only" run results: 
https://github.com/qbittorrent/qBittorrent/runs/3287536111?check_suite_focus=true#step:2:44016