### PR TITLE
Change IRC channel to Libera.Chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,8 @@ http://forum.qbittorrent.org
 Please report any bug (or feature request) to:
 http://bugs.qbittorrent.org
 
+Official IRC channel:
+`#qbittorrent on irc.libera.chat`
+
 ------------------------------------------
 sledgehammer999 <sledgehammer999@qbittorrent.org>


### PR DESCRIPTION
Unfortunately Freenode, after a takeover, decided to purge all their databases, thus
deleting all channel and user registrations, without a warning.
So if we're forced to re-register our stuff why not go where the cool kids are at?