### PR TITLE
Clean up workflow files coding style

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,10 +29,10 @@ jobs:
         shell: bash
 
     steps:
-      - name: checkout repository
+      - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: install all build dependencies except libtorrent from Ubuntu repos
+      - name: Install all build dependencies except libtorrent from Ubuntu repos
         run: |
           sudo apt update
           sudo apt install \
@@ -43,13 +43,13 @@ jobs:
 
       # this will be installed under /opt/qt515. CMake will still find it automatically without additional hints
       # to speed up the process, only the required components are installed rather than the full qt515-meta-full metapackage
-      - name: install Qt 5.15.2 from an external PPA
+      - name: Install Qt 5.15.2 from an external PPA
         run: |
           sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal
           sudo apt install \
             qt515base qt515svg qt515tools
 
-      - name: install libtorrent from source
+      - name: Install libtorrent from source
         run: |
           git clone https://github.com/arvidn/libtorrent
           cd libtorrent
@@ -64,7 +64,7 @@ jobs:
           cmake --build build
           sudo cmake --install build --prefix /usr/local
 
-      - name: build qBittorrent
+      - name: Build qBittorrent
         run: |
           cmake \
             -B build \
@@ -76,10 +76,10 @@ jobs:
             --graphviz=build/target_graph.dot
           cmake --build build
 
-      - name: install qBittorrent
+      - name: Install qBittorrent
         run: sudo cmake --install build --prefix /usr/local
 
-      - name: upload artifact as zip
+      - name: Upload artifact as zip
         uses: actions/upload-artifact@v2
         with:
           name: qBittorrent-CI_${{ matrix.os }}-x64_${{ matrix.qbt_gui }}
@@ -101,15 +101,15 @@ jobs:
         shell: pwsh
 
     steps:
-      - name: checkout repository
+      - name: Checkout repository
         uses: actions/checkout@v2
 
       # - ninja is needed for building qBittorrent (because it's preferable, not a hard requirement)
-      - name: install additional required packages with chocolatey
+      - name: Install additional required packages with chocolatey
         run: |
           choco install ninja
 
-      - name: setup vcpkg (cached, if possible)
+      - name: Setup vcpkg (cached, if possible)
         uses: lukka/run-vcpkg@v7
         with:
           vcpkgDirectory: ${{ env.VCPKG_DEST_WIN }}
@@ -117,7 +117,7 @@ jobs:
           setupOnly: true
 
       # Tell vcpkg to only build Release variants of the dependencies
-      - name: configure vcpkg triplet overlay for release builds only
+      - name: Configure vcpkg triplet overlay for release builds only
         run: |
           New-Item `
             -Path ${{ github.workspace }} `
@@ -131,7 +131,7 @@ jobs:
             -Value "set(VCPKG_BUILD_TYPE release)"
 
       # clear buildtrees after each package installation to reduce disk space requirements
-      - name: install dependencies via vcpkg
+      - name: Install dependencies via vcpkg
         run: |
           $packages = `
             "boost-circular-buffer:x64-windows-static-release",
@@ -151,10 +151,10 @@ jobs:
           }
 
       # NOTE: this is necessary to correctly find and use cl.exe with the Ninja generator for now
-      - name: setup devcmd
+      - name: Setup devcmd
         uses: ilammy/msvc-dev-cmd@v1
 
-      - name: build qBittorrent
+      - name: Build qBittorrent
         shell: cmd
         run: |
           cmake ^
@@ -169,7 +169,7 @@ jobs:
             --graphviz=build\target_graph.dot
           cmake --build build
 
-      - name: upload artifact as zip
+      - name: Upload artifact as zip
         uses: actions/upload-artifact@v2
         with:
           name: qBittorrent-CI_Windows-x64
@@ -194,24 +194,24 @@ jobs:
         shell: pwsh
 
     steps:
-      - name: checkout repository
+      - name: Checkout repository
         uses: actions/checkout@v2
 
       # - ninja is needed for building qBittorrent (because it's preferable, not a hard requirement)
       # - automake is needed for the installation the vcpkg installation of fontconfig, a dependency of qt5-base
-      - name: install additional required packages with homebrew
+      - name: Install additional required packages with homebrew
         shell: bash
         run: |
           brew install automake ninja
 
-      - name: setup vcpkg (cached, if possible)
+      - name: Setup vcpkg (cached, if possible)
         uses: lukka/run-vcpkg@v7
         with:
           vcpkgDirectory: ${{ env.VCPKG_DEST_MACOS }}
           vcpkgGitCommitId: ${{ env.VCPKG_COMMIT }}
           setupOnly: true
 
-      - name: configure vcpkg triplet overlay for release builds only
+      - name: Configure vcpkg triplet overlay for release builds only
         run: |
           New-Item `
             -Path ${{ github.workspace }} `
@@ -225,14 +225,14 @@ jobs:
             -Value "set(VCPKG_BUILD_TYPE release)","set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)"
 
       # NOTE: Avoids a libtorrent ABI issue. See https://github.com/arvidn/libtorrent/issues/4965
-      - name: force AppleClang to compile libtorrent with the same C++ standard as qBittorrent
+      - name: Force AppleClang to compile libtorrent with the same C++ standard as qBittorrent
         run: |
           (Get-Content `
             -path ${{ env.RUNVCPKG_VCPKG_ROOT }}/ports/libtorrent/portfile.cmake).Replace( `
               '${FEATURE_OPTIONS}', '${FEATURE_OPTIONS} -DCMAKE_CXX_STANDARD=17') `
             | Set-Content -Path ${{ env.RUNVCPKG_VCPKG_ROOT }}/ports/libtorrent/portfile.cmake
 
-      - name: install dependencies via vcpkg
+      - name: Install dependencies via vcpkg
         run: |
           $packages = `
             "boost-circular-buffer:x64-osx-release",
@@ -251,7 +251,7 @@ jobs:
               --clean-after-build
           }
 
-      - name: build qBittorrent
+      - name: Build qBittorrent
         shell: bash
         run: |
           cmake \
@@ -266,7 +266,7 @@ jobs:
             --graphviz=build/target_graph.dot
           cmake --build build
 
-      - name: upload artifact as zip
+      - name: Upload artifact as zip
         uses: actions/upload-artifact@v2
         with:
           name: qBittorrent-CI_macOS_${{ matrix.qbt_gui }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,8 +13,7 @@ env:
   LIBTORRENT_VERSION_TAG: v1.2.14
 
 jobs:
-
-  ci_ubuntu:
+  ubuntu:
     name: Ubuntu
 
     strategy:
@@ -47,23 +46,31 @@ jobs:
       - name: install Qt 5.15.2 from an external PPA
         run: |
           sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal
-          sudo apt install qt515base qt515svg qt515tools
+          sudo apt install \
+            qt515base qt515svg qt515tools
 
       - name: install libtorrent from source
         run: |
-          git clone https://github.com/arvidn/libtorrent && cd libtorrent
+          git clone https://github.com/arvidn/libtorrent
+          cd libtorrent
           git checkout ${{ env.LIBTORRENT_VERSION_TAG }}
-          cmake -B cmake-build-dir -G "Ninja" \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          cmake \
+            -B build \
+            -G "Ninja" \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -Ddeprecated-functions=OFF \
             --graphviz=cmake-build-dir/target_graph.dot
-          cmake --build cmake-build-dir
-          sudo cmake --install cmake-build-dir --prefix /usr/local
+          cmake --build build
+          sudo cmake --install build --prefix /usr/local
 
       - name: build qBittorrent
         run: |
-          cmake -B build -G "Ninja" \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          cmake \
+            -B build \
+            -G "Ninja" \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -D${{ matrix.qbt_gui }} \
             -DVERBOSE_CONFIGURE=ON \
             --graphviz=build/target_graph.dot
@@ -85,9 +92,8 @@ jobs:
             libtorrent/cmake-build-dir/compile_commands.json
             libtorrent/cmake-build-dir/target_graph.dot
 
-  ci_windows:
+  windows:
     name: Windows + vcpkg
-
     runs-on: windows-2019
 
     defaults:
@@ -113,10 +119,15 @@ jobs:
       # Tell vcpkg to only build Release variants of the dependencies
       - name: configure vcpkg triplet overlay for release builds only
         run: |
-          New-Item -Path ${{ github.workspace }} -Name "triplets_overlay" -ItemType Directory
-          Copy-Item ${{ env.RUNVCPKG_VCPKG_ROOT }}/triplets/x64-windows-static.cmake `
+          New-Item `
+            -Path ${{ github.workspace }} `
+            -Name "triplets_overlay" `
+            -ItemType Directory
+          Copy-Item `
+            ${{ env.RUNVCPKG_VCPKG_ROOT }}/triplets/x64-windows-static.cmake `
             ${{ github.workspace }}/triplets_overlay/x64-windows-static-release.cmake
-          Add-Content ${{ github.workspace }}/triplets_overlay/x64-windows-static-release.cmake `
+          Add-Content `
+            ${{ github.workspace }}/triplets_overlay/x64-windows-static-release.cmake `
             -Value "set(VCPKG_BUILD_TYPE release)"
 
       # clear buildtrees after each package installation to reduce disk space requirements
@@ -130,8 +141,8 @@ jobs:
             "qt5-tools:x64-windows-static-release",
             "qt5-winextras:x64-windows-static-release"
           ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg.exe upgrade `
-              --overlay-triplets=${{ github.workspace }}/triplets_overlay `
-              --no-dry-run
+            --overlay-triplets=${{ github.workspace }}/triplets_overlay `
+            --no-dry-run
           foreach($package in $packages)
           {
             ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg.exe install $package `
@@ -146,8 +157,11 @@ jobs:
       - name: build qBittorrent
         shell: cmd
         run: |
-          cmake -B build -G "Ninja" ^
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
+          cmake ^
+            -B build ^
+            -G "Ninja" ^
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ^
             -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_DEST_WIN }}\scripts\buildsystems\vcpkg.cmake ^
             -DVCPKG_TARGET_TRIPLET=x64-windows-static-release ^
             -DVERBOSE_CONFIGURE=ON ^
@@ -166,15 +180,14 @@ jobs:
             build/qbittorrent.pdb
             dist/windows/qt.conf
 
-  ci_macos:
+  macos:
     name: macOS + vcpkg
+    runs-on: macos-10.15
 
     strategy:
       matrix:
         qbt_gui: ["GUI=ON", "GUI=OFF"]
       fail-fast: false
-
-    runs-on: macos-10.15
 
     defaults:
       run:
@@ -200,17 +213,23 @@ jobs:
 
       - name: configure vcpkg triplet overlay for release builds only
         run: |
-          New-Item -Path ${{ github.workspace }} -Name "triplets_overlay" -ItemType Directory
-          Copy-Item ${{ env.RUNVCPKG_VCPKG_ROOT }}/triplets/x64-osx.cmake `
+          New-Item `
+            -Path ${{ github.workspace }} `
+            -Name "triplets_overlay" `
+            -ItemType Directory
+          Copy-Item `
+            ${{ env.RUNVCPKG_VCPKG_ROOT }}/triplets/x64-osx.cmake `
             ${{ github.workspace }}/triplets_overlay/x64-osx-release.cmake
-          Add-Content ${{ github.workspace }}/triplets_overlay/x64-osx-release.cmake `
+          Add-Content `
+            ${{ github.workspace }}/triplets_overlay/x64-osx-release.cmake `
             -Value "set(VCPKG_BUILD_TYPE release)","set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)"
 
       # NOTE: Avoids a libtorrent ABI issue. See https://github.com/arvidn/libtorrent/issues/4965
       - name: force AppleClang to compile libtorrent with the same C++ standard as qBittorrent
         run: |
-          (Get-Content -path ${{ env.RUNVCPKG_VCPKG_ROOT }}/ports/libtorrent/portfile.cmake).Replace( `
-            '${FEATURE_OPTIONS}', '${FEATURE_OPTIONS} -DCMAKE_CXX_STANDARD=17') `
+          (Get-Content `
+            -path ${{ env.RUNVCPKG_VCPKG_ROOT }}/ports/libtorrent/portfile.cmake).Replace( `
+              '${FEATURE_OPTIONS}', '${FEATURE_OPTIONS} -DCMAKE_CXX_STANDARD=17') `
             | Set-Content -Path ${{ env.RUNVCPKG_VCPKG_ROOT }}/ports/libtorrent/portfile.cmake
 
       - name: install dependencies via vcpkg
@@ -223,8 +242,8 @@ jobs:
             "qt5-tools:x64-osx-release",
             "qt5-macextras:x64-osx-release"
           ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg upgrade `
-              --overlay-triplets=${{ github.workspace }}/triplets_overlay `
-              --no-dry-run
+            --overlay-triplets=${{ github.workspace }}/triplets_overlay `
+            --no-dry-run
           foreach($package in $packages)
           {
             ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg install $package `
@@ -235,7 +254,11 @@ jobs:
       - name: build qBittorrent
         shell: bash
         run: |
-          cmake -B build -G "Ninja" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          cmake \
+            -B build \
+            -G "Ninja" \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_DEST_MACOS }}/scripts/buildsystems/vcpkg.cmake \
             -DVCPKG_TARGET_TRIPLET=x64-osx-release \
             -D${{ matrix.qbt_gui }} \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,7 +93,7 @@ jobs:
             libtorrent/cmake-build-dir/target_graph.dot
 
   windows:
-    name: Windows + vcpkg
+    name: Windows
     runs-on: windows-2019
 
     defaults:
@@ -181,7 +181,7 @@ jobs:
             dist/windows/qt.conf
 
   macos:
-    name: macOS + vcpkg
+    name: macOS
     runs-on: macos-10.15
 
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: GitHub Actions CI
+name: CI - Main
 
 # Cache is used for all Windows and macOS dependencies (size approx. 1230 * 2 + 1850 = 4310 MiB)
 # Cache is not used for Ubuntu builds, because it already has all dependencies except

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install all build dependencies except libtorrent from Ubuntu repos
+      - name: Install dependencies
         run: |
           sudo apt update
           sudo apt install \
@@ -43,13 +43,13 @@ jobs:
 
       # this will be installed under /opt/qt515. CMake will still find it automatically without additional hints
       # to speed up the process, only the required components are installed rather than the full qt515-meta-full metapackage
-      - name: Install Qt 5.15.2 from an external PPA
+      - name: Install Qt
         run: |
           sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal
           sudo apt install \
             qt515base qt515svg qt515tools
 
-      - name: Install libtorrent from source
+      - name: Install libtorrent
         run: |
           git clone https://github.com/arvidn/libtorrent
           cd libtorrent
@@ -79,7 +79,7 @@ jobs:
       - name: Install qBittorrent
         run: sudo cmake --install build --prefix /usr/local
 
-      - name: Upload artifact as zip
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v2
         with:
           name: qBittorrent-CI_${{ matrix.os }}-x64_${{ matrix.qbt_gui }}
@@ -105,11 +105,11 @@ jobs:
         uses: actions/checkout@v2
 
       # - ninja is needed for building qBittorrent (because it's preferable, not a hard requirement)
-      - name: Install additional required packages with chocolatey
+      - name: Install build tools
         run: |
           choco install ninja
 
-      - name: Setup vcpkg (cached, if possible)
+      - name: Setup vcpkg
         uses: lukka/run-vcpkg@v7
         with:
           vcpkgDirectory: ${{ env.VCPKG_DEST_WIN }}
@@ -117,7 +117,7 @@ jobs:
           setupOnly: true
 
       # Tell vcpkg to only build Release variants of the dependencies
-      - name: Configure vcpkg triplet overlay for release builds only
+      - name: Configure vcpkg triplet overlay
         run: |
           New-Item `
             -Path ${{ github.workspace }} `
@@ -131,7 +131,7 @@ jobs:
             -Value "set(VCPKG_BUILD_TYPE release)"
 
       # clear buildtrees after each package installation to reduce disk space requirements
-      - name: Install dependencies via vcpkg
+      - name: Install dependencies
         run: |
           $packages = `
             "boost-circular-buffer:x64-windows-static-release",
@@ -169,7 +169,7 @@ jobs:
             --graphviz=build\target_graph.dot
           cmake --build build
 
-      - name: Upload artifact as zip
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v2
         with:
           name: qBittorrent-CI_Windows-x64
@@ -199,19 +199,19 @@ jobs:
 
       # - ninja is needed for building qBittorrent (because it's preferable, not a hard requirement)
       # - automake is needed for the installation the vcpkg installation of fontconfig, a dependency of qt5-base
-      - name: Install additional required packages with homebrew
+      - name: Install build tools
         shell: bash
         run: |
           brew install automake ninja
 
-      - name: Setup vcpkg (cached, if possible)
+      - name: Setup vcpkg
         uses: lukka/run-vcpkg@v7
         with:
           vcpkgDirectory: ${{ env.VCPKG_DEST_MACOS }}
           vcpkgGitCommitId: ${{ env.VCPKG_COMMIT }}
           setupOnly: true
 
-      - name: Configure vcpkg triplet overlay for release builds only
+      - name: Configure vcpkg triplet overlay
         run: |
           New-Item `
             -Path ${{ github.workspace }} `
@@ -225,14 +225,14 @@ jobs:
             -Value "set(VCPKG_BUILD_TYPE release)","set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)"
 
       # NOTE: Avoids a libtorrent ABI issue. See https://github.com/arvidn/libtorrent/issues/4965
-      - name: Force AppleClang to compile libtorrent with the same C++ standard as qBittorrent
+      - name: Adjust "C++ standard" cmake flag
         run: |
           (Get-Content `
             -path ${{ env.RUNVCPKG_VCPKG_ROOT }}/ports/libtorrent/portfile.cmake).Replace( `
               '${FEATURE_OPTIONS}', '${FEATURE_OPTIONS} -DCMAKE_CXX_STANDARD=17') `
             | Set-Content -Path ${{ env.RUNVCPKG_VCPKG_ROOT }}/ports/libtorrent/portfile.cmake
 
-      - name: Install dependencies via vcpkg
+      - name: Install dependencies
         run: |
           $packages = `
             "boost-circular-buffer:x64-osx-release",
@@ -266,7 +266,7 @@ jobs:
             --graphviz=build/target_graph.dot
           cmake --build build
 
-      - name: Upload artifact as zip
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v2
         with:
           name: qBittorrent-CI_macOS_${{ matrix.qbt_gui }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,60 +30,60 @@ jobs:
         shell: bash
 
     steps:
-    - name: checkout repository
-      uses: actions/checkout@v2
+      - name: checkout repository
+        uses: actions/checkout@v2
 
-    - name: install all build dependencies except libtorrent from Ubuntu repos
-      run: |
-        sudo apt update
-        sudo apt install \
-          build-essential cmake git ninja-build pkg-config \
-          libssl-dev libgeoip-dev zlib1g-dev \
-          libboost-dev libboost-chrono-dev libboost-random-dev libboost-system-dev
-      # sudo apt install libqt5svg5-dev qtbase5-dev qttools5-dev # the Qt version in the standard repositories is too old...
+      - name: install all build dependencies except libtorrent from Ubuntu repos
+        run: |
+          sudo apt update
+          sudo apt install \
+            build-essential cmake git ninja-build pkg-config \
+            libssl-dev libgeoip-dev zlib1g-dev \
+            libboost-dev libboost-chrono-dev libboost-random-dev libboost-system-dev
+        # sudo apt install libqt5svg5-dev qtbase5-dev qttools5-dev # the Qt version in the standard repositories is too old...
 
-    # this will be installed under /opt/qt515. CMake will still find it automatically without additional hints
-    # to speed up the process, only the required components are installed rather than the full qt515-meta-full metapackage
-    - name: install Qt 5.15.2 from an external PPA
-      run: |
-        sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal
-        sudo apt install qt515base qt515svg qt515tools
+      # this will be installed under /opt/qt515. CMake will still find it automatically without additional hints
+      # to speed up the process, only the required components are installed rather than the full qt515-meta-full metapackage
+      - name: install Qt 5.15.2 from an external PPA
+        run: |
+          sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal
+          sudo apt install qt515base qt515svg qt515tools
 
-    - name: install libtorrent from source
-      run: |
-        git clone https://github.com/arvidn/libtorrent && cd libtorrent
-        git checkout ${{ env.LIBTORRENT_VERSION_TAG }}
-        cmake -B cmake-build-dir -G "Ninja" \
-          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-          -Ddeprecated-functions=OFF \
-          --graphviz=cmake-build-dir/target_graph.dot
-        cmake --build cmake-build-dir
-        sudo cmake --install cmake-build-dir --prefix /usr/local
+      - name: install libtorrent from source
+        run: |
+          git clone https://github.com/arvidn/libtorrent && cd libtorrent
+          git checkout ${{ env.LIBTORRENT_VERSION_TAG }}
+          cmake -B cmake-build-dir -G "Ninja" \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -Ddeprecated-functions=OFF \
+            --graphviz=cmake-build-dir/target_graph.dot
+          cmake --build cmake-build-dir
+          sudo cmake --install cmake-build-dir --prefix /usr/local
 
-    - name: build qBittorrent
-      run: |
-        cmake -B build -G "Ninja" \
-          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-          -D${{ matrix.qbt_gui }} \
-          -DVERBOSE_CONFIGURE=ON \
-          --graphviz=build/target_graph.dot
-        cmake --build build
+      - name: build qBittorrent
+        run: |
+          cmake -B build -G "Ninja" \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -D${{ matrix.qbt_gui }} \
+            -DVERBOSE_CONFIGURE=ON \
+            --graphviz=build/target_graph.dot
+          cmake --build build
 
-    - name: install qBittorrent
-      run: sudo cmake --install build --prefix /usr/local
+      - name: install qBittorrent
+        run: sudo cmake --install build --prefix /usr/local
 
-    - name: upload artifact as zip
-      uses: actions/upload-artifact@v2
-      with:
-        name: qBittorrent-CI_${{ matrix.os }}-x64_${{ matrix.qbt_gui }}
-        path: |
-          build/compile_commands.json
-          build/install_manifest.txt
-          build/target_graph.dot
-          build/qbittorrent
-          build/qbittorrent-nox
-          libtorrent/cmake-build-dir/compile_commands.json
-          libtorrent/cmake-build-dir/target_graph.dot
+      - name: upload artifact as zip
+        uses: actions/upload-artifact@v2
+        with:
+          name: qBittorrent-CI_${{ matrix.os }}-x64_${{ matrix.qbt_gui }}
+          path: |
+            build/compile_commands.json
+            build/install_manifest.txt
+            build/target_graph.dot
+            build/qbittorrent
+            build/qbittorrent-nox
+            libtorrent/cmake-build-dir/compile_commands.json
+            libtorrent/cmake-build-dir/target_graph.dot
 
   ci_windows:
     name: Windows + vcpkg
@@ -95,76 +95,76 @@ jobs:
         shell: pwsh
 
     steps:
-    - name: checkout repository
-      uses: actions/checkout@v2
+      - name: checkout repository
+        uses: actions/checkout@v2
 
-    # - ninja is needed for building qBittorrent (because it's preferable, not a hard requirement)
-    - name: install additional required packages with chocolatey
-      run: |
-        choco install ninja
+      # - ninja is needed for building qBittorrent (because it's preferable, not a hard requirement)
+      - name: install additional required packages with chocolatey
+        run: |
+          choco install ninja
 
-    - name: setup vcpkg (cached, if possible)
-      uses: lukka/run-vcpkg@v7
-      with:
-        vcpkgDirectory: ${{ env.VCPKG_DEST_WIN }}
-        vcpkgGitCommitId: ${{ env.VCPKG_COMMIT }}
-        setupOnly: true
+      - name: setup vcpkg (cached, if possible)
+        uses: lukka/run-vcpkg@v7
+        with:
+          vcpkgDirectory: ${{ env.VCPKG_DEST_WIN }}
+          vcpkgGitCommitId: ${{ env.VCPKG_COMMIT }}
+          setupOnly: true
 
-    # Tell vcpkg to only build Release variants of the dependencies
-    - name: configure vcpkg triplet overlay for release builds only
-      run: |
-        New-Item -Path ${{ github.workspace }} -Name "triplets_overlay" -ItemType Directory
-        Copy-Item ${{ env.RUNVCPKG_VCPKG_ROOT }}/triplets/x64-windows-static.cmake `
-          ${{ github.workspace }}/triplets_overlay/x64-windows-static-release.cmake
-        Add-Content ${{ github.workspace }}/triplets_overlay/x64-windows-static-release.cmake `
-          -Value "set(VCPKG_BUILD_TYPE release)"
+      # Tell vcpkg to only build Release variants of the dependencies
+      - name: configure vcpkg triplet overlay for release builds only
+        run: |
+          New-Item -Path ${{ github.workspace }} -Name "triplets_overlay" -ItemType Directory
+          Copy-Item ${{ env.RUNVCPKG_VCPKG_ROOT }}/triplets/x64-windows-static.cmake `
+            ${{ github.workspace }}/triplets_overlay/x64-windows-static-release.cmake
+          Add-Content ${{ github.workspace }}/triplets_overlay/x64-windows-static-release.cmake `
+            -Value "set(VCPKG_BUILD_TYPE release)"
 
-    # clear buildtrees after each package installation to reduce disk space requirements
-    - name: install dependencies via vcpkg
-      run: |
-        $packages = `
-          "boost-circular-buffer:x64-windows-static-release",
-          "libtorrent:x64-windows-static-release",
-          "qt5-base:x64-windows-static-release",
-          "qt5-svg:x64-windows-static-release",
-          "qt5-tools:x64-windows-static-release",
-          "qt5-winextras:x64-windows-static-release"
-        ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg.exe upgrade `
-            --overlay-triplets=${{ github.workspace }}/triplets_overlay `
-            --no-dry-run
-        foreach($package in $packages)
-        {
-          ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg.exe install $package `
-            --overlay-triplets=${{ github.workspace }}/triplets_overlay `
-            --clean-after-build
-        }
+      # clear buildtrees after each package installation to reduce disk space requirements
+      - name: install dependencies via vcpkg
+        run: |
+          $packages = `
+            "boost-circular-buffer:x64-windows-static-release",
+            "libtorrent:x64-windows-static-release",
+            "qt5-base:x64-windows-static-release",
+            "qt5-svg:x64-windows-static-release",
+            "qt5-tools:x64-windows-static-release",
+            "qt5-winextras:x64-windows-static-release"
+          ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg.exe upgrade `
+              --overlay-triplets=${{ github.workspace }}/triplets_overlay `
+              --no-dry-run
+          foreach($package in $packages)
+          {
+            ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg.exe install $package `
+              --overlay-triplets=${{ github.workspace }}/triplets_overlay `
+              --clean-after-build
+          }
 
-    # NOTE: this is necessary to correctly find and use cl.exe with the Ninja generator for now
-    - name: setup devcmd
-      uses: ilammy/msvc-dev-cmd@v1
+      # NOTE: this is necessary to correctly find and use cl.exe with the Ninja generator for now
+      - name: setup devcmd
+        uses: ilammy/msvc-dev-cmd@v1
 
-    - name: build qBittorrent
-      shell: cmd
-      run: |
-        cmake -B build -G "Ninja" ^
-          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
-          -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_DEST_WIN }}\scripts\buildsystems\vcpkg.cmake ^
-          -DVCPKG_TARGET_TRIPLET=x64-windows-static-release ^
-          -DVERBOSE_CONFIGURE=ON ^
-          -DMSVC_RUNTIME_DYNAMIC=OFF ^
-          --graphviz=build\target_graph.dot
-        cmake --build build
+      - name: build qBittorrent
+        shell: cmd
+        run: |
+          cmake -B build -G "Ninja" ^
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
+            -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_DEST_WIN }}\scripts\buildsystems\vcpkg.cmake ^
+            -DVCPKG_TARGET_TRIPLET=x64-windows-static-release ^
+            -DVERBOSE_CONFIGURE=ON ^
+            -DMSVC_RUNTIME_DYNAMIC=OFF ^
+            --graphviz=build\target_graph.dot
+          cmake --build build
 
-    - name: upload artifact as zip
-      uses: actions/upload-artifact@v2
-      with:
-        name: qBittorrent-CI_Windows-x64
-        path: |
-          build/compile_commands.json
-          build/target_graph.dot
-          build/qbittorrent.exe
-          build/qbittorrent.pdb
-          dist/windows/qt.conf
+      - name: upload artifact as zip
+        uses: actions/upload-artifact@v2
+        with:
+          name: qBittorrent-CI_Windows-x64
+          path: |
+            build/compile_commands.json
+            build/target_graph.dot
+            build/qbittorrent.exe
+            build/qbittorrent.pdb
+            dist/windows/qt.conf
 
   ci_macos:
     name: macOS + vcpkg
@@ -181,74 +181,74 @@ jobs:
         shell: pwsh
 
     steps:
-    - name: checkout repository
-      uses: actions/checkout@v2
+      - name: checkout repository
+        uses: actions/checkout@v2
 
-    # - ninja is needed for building qBittorrent (because it's preferable, not a hard requirement)
-    # - automake is needed for the installation the vcpkg installation of fontconfig, a dependency of qt5-base
-    - name: install additional required packages with homebrew
-      shell: bash
-      run: |
-        brew install automake ninja
+      # - ninja is needed for building qBittorrent (because it's preferable, not a hard requirement)
+      # - automake is needed for the installation the vcpkg installation of fontconfig, a dependency of qt5-base
+      - name: install additional required packages with homebrew
+        shell: bash
+        run: |
+          brew install automake ninja
 
-    - name: setup vcpkg (cached, if possible)
-      uses: lukka/run-vcpkg@v7
-      with:
-        vcpkgDirectory: ${{ env.VCPKG_DEST_MACOS }}
-        vcpkgGitCommitId: ${{ env.VCPKG_COMMIT }}
-        setupOnly: true
+      - name: setup vcpkg (cached, if possible)
+        uses: lukka/run-vcpkg@v7
+        with:
+          vcpkgDirectory: ${{ env.VCPKG_DEST_MACOS }}
+          vcpkgGitCommitId: ${{ env.VCPKG_COMMIT }}
+          setupOnly: true
 
-    - name: configure vcpkg triplet overlay for release builds only
-      run: |
-        New-Item -Path ${{ github.workspace }} -Name "triplets_overlay" -ItemType Directory
-        Copy-Item ${{ env.RUNVCPKG_VCPKG_ROOT }}/triplets/x64-osx.cmake `
-          ${{ github.workspace }}/triplets_overlay/x64-osx-release.cmake
-        Add-Content ${{ github.workspace }}/triplets_overlay/x64-osx-release.cmake `
-          -Value "set(VCPKG_BUILD_TYPE release)","set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)"
+      - name: configure vcpkg triplet overlay for release builds only
+        run: |
+          New-Item -Path ${{ github.workspace }} -Name "triplets_overlay" -ItemType Directory
+          Copy-Item ${{ env.RUNVCPKG_VCPKG_ROOT }}/triplets/x64-osx.cmake `
+            ${{ github.workspace }}/triplets_overlay/x64-osx-release.cmake
+          Add-Content ${{ github.workspace }}/triplets_overlay/x64-osx-release.cmake `
+            -Value "set(VCPKG_BUILD_TYPE release)","set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)"
 
-    # NOTE: Avoids a libtorrent ABI issue. See https://github.com/arvidn/libtorrent/issues/4965
-    - name: force AppleClang to compile libtorrent with the same C++ standard as qBittorrent
-      run: |
-        (Get-Content -path ${{ env.RUNVCPKG_VCPKG_ROOT }}/ports/libtorrent/portfile.cmake).Replace( `
-          '${FEATURE_OPTIONS}', '${FEATURE_OPTIONS} -DCMAKE_CXX_STANDARD=17') `
-          | Set-Content -Path ${{ env.RUNVCPKG_VCPKG_ROOT }}/ports/libtorrent/portfile.cmake
+      # NOTE: Avoids a libtorrent ABI issue. See https://github.com/arvidn/libtorrent/issues/4965
+      - name: force AppleClang to compile libtorrent with the same C++ standard as qBittorrent
+        run: |
+          (Get-Content -path ${{ env.RUNVCPKG_VCPKG_ROOT }}/ports/libtorrent/portfile.cmake).Replace( `
+            '${FEATURE_OPTIONS}', '${FEATURE_OPTIONS} -DCMAKE_CXX_STANDARD=17') `
+            | Set-Content -Path ${{ env.RUNVCPKG_VCPKG_ROOT }}/ports/libtorrent/portfile.cmake
 
-    - name: install dependencies via vcpkg
-      run: |
-        $packages = `
-          "boost-circular-buffer:x64-osx-release",
-          "libtorrent:x64-osx-release",
-          "qt5-base:x64-osx-release",
-          "qt5-svg:x64-osx-release",
-          "qt5-tools:x64-osx-release",
-          "qt5-macextras:x64-osx-release"
-        ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg upgrade `
-            --overlay-triplets=${{ github.workspace }}/triplets_overlay `
-            --no-dry-run
-        foreach($package in $packages)
-        {
-          ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg install $package `
-            --overlay-triplets=${{ github.workspace }}/triplets_overlay `
-            --clean-after-build
-        }
+      - name: install dependencies via vcpkg
+        run: |
+          $packages = `
+            "boost-circular-buffer:x64-osx-release",
+            "libtorrent:x64-osx-release",
+            "qt5-base:x64-osx-release",
+            "qt5-svg:x64-osx-release",
+            "qt5-tools:x64-osx-release",
+            "qt5-macextras:x64-osx-release"
+          ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg upgrade `
+              --overlay-triplets=${{ github.workspace }}/triplets_overlay `
+              --no-dry-run
+          foreach($package in $packages)
+          {
+            ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg install $package `
+              --overlay-triplets=${{ github.workspace }}/triplets_overlay `
+              --clean-after-build
+          }
 
-    - name: build qBittorrent
-      shell: bash
-      run: |
-        cmake -B build -G "Ninja" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-          -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_DEST_MACOS }}/scripts/buildsystems/vcpkg.cmake \
-          -DVCPKG_TARGET_TRIPLET=x64-osx-release \
-          -D${{ matrix.qbt_gui }} \
-          -DVERBOSE_CONFIGURE=ON \
-          --graphviz=build/target_graph.dot
-        cmake --build build
+      - name: build qBittorrent
+        shell: bash
+        run: |
+          cmake -B build -G "Ninja" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_DEST_MACOS }}/scripts/buildsystems/vcpkg.cmake \
+            -DVCPKG_TARGET_TRIPLET=x64-osx-release \
+            -D${{ matrix.qbt_gui }} \
+            -DVERBOSE_CONFIGURE=ON \
+            --graphviz=build/target_graph.dot
+          cmake --build build
 
-    - name: upload artifact as zip
-      uses: actions/upload-artifact@v2
-      with:
-        name: qBittorrent-CI_macOS_${{ matrix.qbt_gui }}
-        path: |
-          build/compile_commands.json
-          build/target_graph.dot
-          build/qbittorrent.app
-          build/qbittorrent-nox.app
+      - name: upload artifact as zip
+        uses: actions/upload-artifact@v2
+        with:
+          name: qBittorrent-CI_macOS_${{ matrix.qbt_gui }}
+          path: |
+            build/compile_commands.json
+            build/target_graph.dot
+            build/qbittorrent.app
+            build/qbittorrent-nox.app

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -13,10 +13,10 @@ jobs:
     name: Scan
     runs-on: ubuntu-20.04
     steps:
-      - name: checkout repository
+      - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: install all build dependencies except libtorrent from Ubuntu repos
+      - name: Install all build dependencies except libtorrent from Ubuntu repos
         run: |
           sudo apt update
           sudo apt install \
@@ -26,13 +26,13 @@ jobs:
 
       # this will be installed under /opt/qt515. CMake will still find it automatically without additional hints
       # to speed up the process, only the required components are installed rather than the full qt515-meta-full metapackage
-      - name: install Qt 5.15.2 from an external PPA
+      - name: Install Qt 5.15.2 from an external PPA
         run: |
           sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal
           sudo apt install \
             qt515base qt515svg qt515tools
 
-      - name: install libtorrent from source
+      - name: Install libtorrent from source
         run: |
           git clone https://github.com/arvidn/libtorrent
           cd libtorrent

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install all build dependencies except libtorrent from Ubuntu repos
+      - name: Install dependencies
         run: |
           sudo apt update
           sudo apt install \
@@ -26,13 +26,13 @@ jobs:
 
       # this will be installed under /opt/qt515. CMake will still find it automatically without additional hints
       # to speed up the process, only the required components are installed rather than the full qt515-meta-full metapackage
-      - name: Install Qt 5.15.2 from an external PPA
+      - name: Install Qt
         run: |
           sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal
           sudo apt install \
             qt515base qt515svg qt515tools
 
-      - name: Install libtorrent from source
+      - name: Install libtorrent
         run: |
           git clone https://github.com/arvidn/libtorrent
           cd libtorrent
@@ -66,7 +66,7 @@ jobs:
             -DGUI=ON \
             -DVERBOSE_CONFIGURE=ON
 
-      - name: Build with cov-build
+      - name: Build qBittorrent
         run: |
           export PATH="$(pwd)/coverity_tool/bin:$PATH"
           cov-build --dir cov-int cmake --build build

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -1,78 +1,75 @@
 name: Coverity Scan
+
 on:
   schedule:
     - cron: '0 0 1 * *' # Monthly (1st day of month at midnight)
-
   workflow_dispatch: # Mainly for testing. Don't forget the Coverity usage limits.
 
 env:
   LIBTORRENT_VERSION_TAG: v1.2.14
 
 jobs:
-
   coverity_scan:
     name: Scan
-
     runs-on: ubuntu-20.04
-
     steps:
-    - name: checkout repository
-      uses: actions/checkout@v2
+      - name: checkout repository
+        uses: actions/checkout@v2
 
-    - name: install all build dependencies except libtorrent from Ubuntu repos
-      run: |
-        sudo apt update
-        sudo apt install \
-          build-essential cmake git ninja-build pkg-config \
-          libssl-dev zlib1g-dev libboost-dev libboost-system-dev
-      # sudo apt install libqt5svg5-dev qtbase5-dev qttools5-dev # the Qt version in the standard repositories is too old...
+      - name: install all build dependencies except libtorrent from Ubuntu repos
+        run: |
+          sudo apt update
+          sudo apt install \
+            build-essential cmake git ninja-build pkg-config \
+            libssl-dev zlib1g-dev libboost-dev libboost-system-dev
+        # sudo apt install libqt5svg5-dev qtbase5-dev qttools5-dev # the Qt version in the standard repositories is too old...
 
-    # this will be installed under /opt/qt515. CMake will still find it automatically without additional hints
-    # to speed up the process, only the required components are installed rather than the full qt515-meta-full metapackage
-    - name: install Qt 5.15.2 from an external PPA
-      run: |
-        sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal
-        sudo apt install qt515base qt515svg qt515tools
+      # this will be installed under /opt/qt515. CMake will still find it automatically without additional hints
+      # to speed up the process, only the required components are installed rather than the full qt515-meta-full metapackage
+      - name: install Qt 5.15.2 from an external PPA
+        run: |
+          sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal
+          sudo apt install qt515base qt515svg qt515tools
 
-    - name: install libtorrent from source
-      run: |
-        git clone https://github.com/arvidn/libtorrent && cd libtorrent
-        git checkout ${{ env.LIBTORRENT_VERSION_TAG }}
-        cmake -B cmake-build-dir -G "Ninja" \
-          -DCMAKE_BUILD_TYPE=Release \
-          -Ddeprecated-functions=OFF
-        cmake --build cmake-build-dir
-        sudo cmake --install cmake-build-dir --prefix /usr/local
+      - name: install libtorrent from source
+        run: |
+          git clone https://github.com/arvidn/libtorrent && cd libtorrent
+          git checkout ${{ env.LIBTORRENT_VERSION_TAG }}
+          cmake -B cmake-build-dir -G "Ninja" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -Ddeprecated-functions=OFF
+          cmake --build cmake-build-dir
+          sudo cmake --install cmake-build-dir --prefix /usr/local
 
-    - name: Download Coverity Build Tool
-      run: |
-        wget -q https://scan.coverity.com/download/linux64 --post-data "token=$TOKEN&project=qbittorrent%2FqBittorrent" -O coverity_tool.tgz
-        mkdir coverity_tool
-        tar xzf coverity_tool.tgz --strip 1 -C coverity_tool
-      env:
-        TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+      - name: Download Coverity Build Tool
+        run: |
+          wget -q https://scan.coverity.com/download/linux64 --post-data "token=$TOKEN&project=qbittorrent%2FqBittorrent" -O coverity_tool.tgz
+          mkdir coverity_tool
+          tar xzf coverity_tool.tgz --strip 1 -C coverity_tool
+        env:
+          TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
 
-    - name: Configure qBittorrent
-      run: |
-        cmake -B build -G "Ninja" \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DGUI=ON \
-          -DVERBOSE_CONFIGURE=ON
+      - name: Configure qBittorrent
+        run: |
+          cmake -B build -G "Ninja" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DGUI=ON \
+            -DVERBOSE_CONFIGURE=ON
 
-    - name: Build with cov-build
-      run: |
-        export PATH=`pwd`/coverity_tool/bin:$PATH
-        cov-build --dir cov-int cmake --build build
+      - name: Build with cov-build
+        run: |
+          export PATH=`pwd`/coverity_tool/bin:$PATH
+          cov-build --dir cov-int cmake --build build
 
-    - name: Submit the result to Coverity Scan
-      run: |
-        tar caf qbittorrent.xz cov-int
-        curl \
-          --form token=$TOKEN \
-          --form email=sledgehammer999@qbittorrent.org \
-          --form file=@qbittorrent.tgz \
-          --form version="`git rev-parse --short HEAD`" \
-          --form description="master" \
-          https://scan.coverity.com/builds?project=qbittorrent%2FqBittorrent
-      env:
-        TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+      - name: Submit the result to Coverity Scan
+        run: |
+          tar caf qbittorrent.xz cov-int
+          curl \
+            --form token=$TOKEN \
+            --form email=sledgehammer999@qbittorrent.org \
+            --form file=@qbittorrent.tgz \
+            --form version="`git rev-parse --short HEAD`" \
+            --form description="master" \
+            https://scan.coverity.com/builds?project=qbittorrent%2FqBittorrent
+        env:
+          TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build with cov-build
         run: |
-          export PATH=`pwd`/coverity_tool/bin:$PATH
+          export PATH="$(pwd)/coverity_tool/bin:$PATH"
           cov-build --dir cov-int cmake --build build
 
       - name: Submit the result to Coverity Scan
@@ -78,7 +78,7 @@ jobs:
             --form token=$TOKEN \
             --form email=sledgehammer999@qbittorrent.org \
             --form file=@qbittorrent.tgz \
-            --form version="`git rev-parse --short HEAD`" \
+            --form version="$(git rev-parse --short HEAD)" \
             --form description="master" \
             https://scan.coverity.com/builds?project=qbittorrent%2FqBittorrent
         env:

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -29,21 +29,29 @@ jobs:
       - name: install Qt 5.15.2 from an external PPA
         run: |
           sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal
-          sudo apt install qt515base qt515svg qt515tools
+          sudo apt install \
+            qt515base qt515svg qt515tools
 
       - name: install libtorrent from source
         run: |
-          git clone https://github.com/arvidn/libtorrent && cd libtorrent
+          git clone https://github.com/arvidn/libtorrent
+          cd libtorrent
           git checkout ${{ env.LIBTORRENT_VERSION_TAG }}
-          cmake -B cmake-build-dir -G "Ninja" \
+          cmake \
+            -B build \
+            -G "Ninja" \
             -DCMAKE_BUILD_TYPE=Release \
             -Ddeprecated-functions=OFF
-          cmake --build cmake-build-dir
-          sudo cmake --install cmake-build-dir --prefix /usr/local
+          cmake --build build
+          sudo cmake --install build --prefix /usr/local
 
       - name: Download Coverity Build Tool
         run: |
-          wget -q https://scan.coverity.com/download/linux64 --post-data "token=$TOKEN&project=qbittorrent%2FqBittorrent" -O coverity_tool.tgz
+          wget \
+            -q \
+            https://scan.coverity.com/download/linux64 \
+            --post-data "token=$TOKEN&project=qbittorrent%2FqBittorrent" \
+            -O coverity_tool.tgz
           mkdir coverity_tool
           tar xzf coverity_tool.tgz --strip 1 -C coverity_tool
         env:
@@ -51,7 +59,9 @@ jobs:
 
       - name: Configure qBittorrent
         run: |
-          cmake -B build -G "Ninja" \
+          cmake \
+            -B build \
+            -G "Ninja" \
             -DCMAKE_BUILD_TYPE=Release \
             -DGUI=ON \
             -DVERBOSE_CONFIGURE=ON

--- a/.github/workflows/file_health.yaml
+++ b/.github/workflows/file_health.yaml
@@ -10,11 +10,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install zsh
+      - name: Install tools
         run: |
           sudo apt update
           sudo apt install zsh
 
-      - name: Run check file health script
+      - name: Run script
         run: |
           ./.github/workflows/file_health.sh

--- a/.github/workflows/file_health.yaml
+++ b/.github/workflows/file_health.yaml
@@ -5,7 +5,7 @@ on: [pull_request, push]
 jobs:
   check_file_health:
     name: Check file health
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/file_health.yaml
+++ b/.github/workflows/file_health.yaml
@@ -5,18 +5,16 @@ on: [pull_request, push]
 jobs:
   check_file_health:
     name: Check file health
-
     runs-on: ubuntu-20.04
-
     steps:
-    - name: checkout repository
-      uses: actions/checkout@v2
+      - name: checkout repository
+        uses: actions/checkout@v2
 
-    - name: install zsh
-      run: |
-        sudo apt update
-        sudo apt install zsh
+      - name: install zsh
+        run: |
+          sudo apt update
+          sudo apt install zsh
 
-    - name: run check file health script
-      run: |
-        ./.github/workflows/file_health.sh
+      - name: run check file health script
+        run: |
+          ./.github/workflows/file_health.sh

--- a/.github/workflows/file_health.yaml
+++ b/.github/workflows/file_health.yaml
@@ -1,4 +1,4 @@
-name: GitHub Actions file health check
+name: CI - File health
 
 on: [pull_request, push]
 

--- a/.github/workflows/file_health.yaml
+++ b/.github/workflows/file_health.yaml
@@ -7,14 +7,14 @@ jobs:
     name: Check file health
     runs-on: ubuntu-latest
     steps:
-      - name: checkout repository
+      - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: install zsh
+      - name: Install zsh
         run: |
           sudo apt update
           sudo apt install zsh
 
-      - name: run check file health script
+      - name: Run check file health script
         run: |
           ./.github/workflows/file_health.sh

--- a/.github/workflows/webui_ci.yaml
+++ b/.github/workflows/webui_ci.yaml
@@ -1,4 +1,4 @@
-name: WebUI CI
+name: CI - WebUI
 
 on: [pull_request, push]
 

--- a/.github/workflows/webui_ci.yaml
+++ b/.github/workflows/webui_ci.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: setup nodejs
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: 'lts/*'
 
       - name: install tools
         run: npm install

--- a/.github/workflows/webui_ci.yaml
+++ b/.github/workflows/webui_ci.yaml
@@ -11,21 +11,21 @@ jobs:
         working-directory: src/webui/www
 
     steps:
-    - name: checkout repository
-      uses: actions/checkout@v2
+      - name: checkout repository
+        uses: actions/checkout@v2
 
-    - name: setup nodejs
-      uses: actions/setup-node@v2
-      with:
-        node-version: '14'
+      - name: setup nodejs
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
 
-    - name: install tools
-      run: npm install
+      - name: install tools
+        run: npm install
 
-    - name: lint code
-      run: npm run lint
+      - name: lint code
+        run: npm run lint
 
-    - name: format code
-      run: |
-        npm run format
-        git diff --exit-code
+      - name: format code
+        run: |
+          npm run format
+          git diff --exit-code

--- a/.github/workflows/webui_ci.yaml
+++ b/.github/workflows/webui_ci.yaml
@@ -11,21 +11,21 @@ jobs:
         working-directory: src/webui/www
 
     steps:
-      - name: checkout repository
+      - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: setup nodejs
+      - name: Setup nodejs
         uses: actions/setup-node@v2
         with:
           node-version: 'lts/*'
 
-      - name: install tools
+      - name: Install tools
         run: npm install
 
-      - name: lint code
+      - name: Lint code
         run: npm run lint
 
-      - name: format code
+      - name: Format code
         run: |
           npm run format
           git diff --exit-code

--- a/.github/workflows/webui_ci.yaml
+++ b/.github/workflows/webui_ci.yaml
@@ -5,7 +5,7 @@ on: [pull_request, push]
 jobs:
   check_webui:
     name: Check WebUI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: src/webui/www


### PR DESCRIPTION
* Clean up Github workflows' name
* Add proper indention to steps section
  Following the style from the examples in https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idsteps
* Use latest Ubuntu images
  Jobs in those workflows has little to do with specific OS version, so just use the latest.
* Split commands to multiple lines properly
* Avoid using legacy backticks
  https://github.com/koalaman/shellcheck/wiki/SC2006
* Rename jobs 
* Use nodejs lts version for CI
  The exact nodejs version isn't critical here, just make sure it isn't too outdated.

----

Screenshot:
![screenshot](https://user-images.githubusercontent.com/9395168/129252430-b55cd403-8e54-40bc-a650-cc92fa84cd8f.png)
(Ignore the Qt6 branch, it was from other PR)