### PR TITLE
Add "minimum seeders" option to share ratio limiting.

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -261,6 +261,8 @@ namespace BitTorrent
         void setGlobalMaxRatio(qreal ratio);
         int globalMaxSeedingMinutes() const;
         void setGlobalMaxSeedingMinutes(int minutes);
+        int globalMinSeeders() const;
+        void setGlobalMinSeeders(int seeders);
         bool isDHTEnabled() const;
         void setDHTEnabled(bool enabled);
         bool isLSDEnabled() const;
@@ -606,6 +608,7 @@ namespace BitTorrent
         bool addTorrent_impl(const std::variant<MagnetUri, TorrentInfo> &source, const AddTorrentParams &addTorrentParams);
 
         void updateSeedingLimitTimer();
+        bool performMaxRatioAction(TorrentImpl &torrent, MaxRatioAction action);
         void exportTorrentFile(const TorrentInfo &torrentInfo, const QString &folderPath, const QString &baseName);
 
         void handleAlert(const lt::alert *a);
@@ -707,6 +710,7 @@ namespace BitTorrent
         CachedSettingValue<QString> m_additionalTrackers;
         CachedSettingValue<qreal> m_globalMaxRatio;
         CachedSettingValue<int> m_globalMaxSeedingMinutes;
+        CachedSettingValue<int> m_globalMinSeeders;
         CachedSettingValue<bool> m_isAddTorrentPaused;
         CachedSettingValue<TorrentContentLayout> m_torrentContentLayout;
         CachedSettingValue<bool> m_isAppendExtensionEnabled;

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -96,7 +96,7 @@ private slots:
     void on_buttonBox_rejected();
     void applySettings();
     void enableApplyButton();
-    void toggleComboRatioLimitAct();
+    void toggleRatioLimitFields();
     void changePage(QListWidgetItem *, QListWidgetItem *);
     void loadSplitterState();
     void handleWatchedFolderViewSelectionChanged();
@@ -153,6 +153,7 @@ private:
     int getEncryptionSetting() const;
     qreal getMaxRatio() const;
     int getMaxSeedingMinutes() const;
+    int getMinSeeders() const;
     // Proxy options
     bool isProxyEnabled() const;
     bool isProxyAuthEnabled() const;

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -2568,7 +2568,7 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                  </property>
                 </widget>
                </item>
-               <item row="3" column="0">
+               <item row="4" column="0">
                 <widget class="QLabel" name="label">
                  <property name="text">
                   <string>then</string>
@@ -2578,7 +2578,7 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                  </property>
                 </widget>
                </item>
-               <item row="3" column="1">
+               <item row="4" column="1">
                 <widget class="QComboBox" name="comboRatioLimitAct">
                  <property name="enabled">
                   <bool>false</bool>
@@ -2625,6 +2625,26 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                  </property>
                  <property name="value">
                   <double>1.000000000000000</double>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QCheckBox" name="checkMinSeeders">
+                 <property name="text">
+                  <string>And seeded by at least</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QSpinBox" name="spinMinSeeders">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="suffix">
+                  <string> seeders</string>
+                 </property>
+                 <property name="maximum">
+                  <number>9999999</number>
                  </property>
                 </widget>
                </item>
@@ -3645,6 +3665,22 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
     <hint type="destinationlabel">
      <x>496</x>
      <y>171</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>checkMinSeeders</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>spinMinSeeders</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>353</x>
+     <y>369</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>572</x>
+     <y>369</y>
     </hint>
    </hints>
   </connection>

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -221,6 +221,8 @@ void AppController::preferencesAction()
     data["max_ratio"] = session->globalMaxRatio();
     data["max_seeding_time_enabled"] = (session->globalMaxSeedingMinutes() >= 0.);
     data["max_seeding_time"] = session->globalMaxSeedingMinutes();
+    data["min_seeders_enabled"] = (session->globalMinSeeders() > 0);
+    data["min_seeders"] = session->globalMinSeeders();
     data["max_ratio_act"] = session->maxRatioAction();
     // Add trackers
     data["add_trackers_enabled"] = session->isAddTrackersEnabled();
@@ -605,6 +607,13 @@ void AppController::setPreferencesAction()
             session->setGlobalMaxSeedingMinutes(m["max_seeding_time"].toInt());
         else
             session->setGlobalMaxSeedingMinutes(-1);
+    }
+    if (hasKey("min_seeders_enabled"))
+    {
+        if (it.value().toBool())
+            session->setGlobalMinSeeders(m["min_seeders"].toInt());
+        else
+            session->setGlobalMinSeeders(0);
     }
     if (hasKey("max_ratio_act"))
         session->setMaxRatioAction(static_cast<MaxRatioAction>(it.value().toInt()));

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -559,6 +559,15 @@
                 </td>
             </tr>
             <tr>
+                <td>
+                    <input type="checkbox" id="min_seeders_checkbox" onclick="qBittorrent.Preferences.updateMaxRatioTimeEnabled();" />
+                    <label for="min_seeders_checkbox">QBT_TR(And seeded by at least)QBT_TR[CONTEXT=OptionsDialog]</label>
+                </td>
+                <td>
+                    <input type="text" id="min_seeders_value" style="width: 4em;" />QBT_TR(seeders)QBT_TR[CONTEXT=OptionsDialog]
+                </td>
+            </tr>
+            <tr>
                 <td style="text-align: right;"><label for="max_ratio_act">QBT_TR(then)QBT_TR[CONTEXT=OptionsDialog]</label></td>
                 <td>
                     <select id="max_ratio_act">
@@ -1489,7 +1498,13 @@
             const isMaxSeedingTimeEnabled = $('max_seeding_time_checkbox').getProperty('checked');
             $('max_seeding_time_value').setProperty('disabled', !isMaxSeedingTimeEnabled);
 
-            $('max_ratio_act').setProperty('disabled', !(isMaxRatioEnabled || isMaxSeedingTimeEnabled));
+            const isMinSeedersEnabled = $('min_seeders_checkbox').getProperty('checked');
+
+            const isShareLimitEnabled = isMaxRatioEnabled || isMaxSeedingTimeEnabled;
+
+            $('max_ratio_act').setProperty('disabled', !(isShareLimitEnabled));
+            $('min_seeders_checkbox').setProperty('disabled', !(isShareLimitEnabled));
+            $('min_seeders_value').setProperty('disabled', !(isShareLimitEnabled && isMinSeedersEnabled));
         };
 
         const updateAddTrackersEnabled = function() {
@@ -1830,6 +1845,8 @@
                         $('max_ratio_value').setProperty('value', (pref.max_ratio_enabled ? pref.max_ratio : 1));
                         $('max_seeding_time_checkbox').setProperty('checked', pref.max_seeding_time_enabled);
                         $('max_seeding_time_value').setProperty('value', (pref.max_seeding_time_enabled ? pref.max_seeding_time.toInt() : 1440));
+                        $('min_seeders_checkbox').setProperty('checked', pref.min_seeders_enabled);
+                        $('min_seeders_value').setProperty('value', (pref.min_seeders_enabled ? pref.min_seeders.toInt() : 0));
                         let maxRatioAct = 0;
                         switch (pref.max_ratio_act.toInt()) {
                             case 0: // Pause
@@ -2224,6 +2241,18 @@
             }
             settings.set('max_seeding_time_enabled', $('max_seeding_time_checkbox').getProperty('checked'));
             settings.set('max_seeding_time', max_seeding_time);
+
+            let min_seeders = 0;
+            if ($('min_seeders_checkbox').getProperty('checked')) {
+                min_seeders = $('min_seeders_value').getProperty('value').toInt();
+                if (isNaN(min_seeders) || min_seeders < 0 || min_seeders > 9999999) {
+                    alert("QBT_TR(Minimum seeders must be between 0 and 9999999.)QBT_TR[CONTEXT=HttpServer]");
+                    return;
+                }
+            }
+            settings.set('min_seeders_enabled', $('min_seeders_checkbox').getProperty('checked'));
+            settings.set('min_seeders', min_seeders);
+
             settings.set('max_ratio_act', $('max_ratio_act').getProperty('value').toInt());
 
             // Add trackers


### PR DESCRIPTION
Specifically, the global share ratio limits do not apply when a torrent has fewer than the minimum number of seeders. This allows one to enforce share ratio limits only on highly seeded torrents.

Closes #6788.

The min seeders option is global only -- I did not add a per-torrent minimum seeders option. This is because I figure that the main purpose of the min seeders option is to prevent less popular torrents from being paused. If you are manually setting ratio limits, you probably know whether the torrent is popular or not and will set the limits accordingly. I can add a per-torrent option if someone thinks it's valuable.

I also refactored the code that processes the share limits to reduce code duplication.

This is my first substantial pull request to QB so let me know if there's anything I can improve!

![Screenshot_20210816_120737](https://user-images.githubusercontent.com/44627085/129616679-ac4d5e72-299e-46c4-b504-63ef80719eb3.png)
