### PR TITLE
Support libtorrent v2.0.4 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,6 @@ env:
   VCPKG_COMMIT: 8dddc6c899ce6fdbeab38b525a31e7f23cb2d5bb
   VCPKG_DEST_MACOS: /Users/runner/qbt_tools/vcpkg
   VCPKG_DEST_WIN: C:\qbt_tools\vcpkg
-  LIBTORRENT_VERSION_TAG: v1.2.14
 
 jobs:
   ubuntu:
@@ -20,6 +19,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         qbt_gui: ["GUI=ON", "GUI=OFF"]
+        libt_version: ["v2.0.4", "v1.2.14"]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -51,9 +51,9 @@ jobs:
 
       - name: Install libtorrent
         run: |
-          git clone https://github.com/arvidn/libtorrent
+          git clone --branch ${{ matrix.libt_version }} --depth 1 https://github.com/arvidn/libtorrent.git
           cd libtorrent
-          git checkout ${{ env.LIBTORRENT_VERSION_TAG }}
+          git submodule update --init --recursive
           cmake \
             -B build \
             -G "Ninja" \
@@ -82,7 +82,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: qBittorrent-CI_${{ matrix.os }}-x64_${{ matrix.qbt_gui }}
+          name: qBittorrent-CI_${{ matrix.os }}-x64_${{ matrix.qbt_gui }}_libtorrent-${{ matrix.libt_version }}
           path: |
             build/compile_commands.json
             build/install_manifest.txt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1
+
       - name: Install dependencies
         run: |
           sudo apt update
@@ -46,6 +49,7 @@ jobs:
           git clone --branch ${{ matrix.libt_version }} --depth 1 https://github.com/arvidn/libtorrent.git
           cd libtorrent
           git submodule update --init --recursive
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           cmake \
             -B build \
             -G "Ninja" \
@@ -58,6 +62,7 @@ jobs:
 
       - name: Build qBittorrent
         run: |
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           cmake \
             -B build \
             -G "Ninja" \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,19 +14,13 @@ env:
 jobs:
   ubuntu:
     name: Ubuntu
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
-        os: [ubuntu-20.04]
         qbt_gui: ["GUI=ON", "GUI=OFF"]
         libt_version: ["v2.0.4", "v1.2.14"]
       fail-fast: false
-
-    runs-on: ${{ matrix.os }}
-
-    defaults:
-      run:
-        shell: bash
 
     steps:
       - name: Checkout repository
@@ -82,7 +76,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: qBittorrent-CI_${{ matrix.os }}-x64_${{ matrix.qbt_gui }}_libtorrent-${{ matrix.libt_version }}
+          name: qBittorrent-CI_ubuntu-20.04-x64_${{ matrix.qbt_gui }}_libtorrent-${{ matrix.libt_version }}
           path: |
             build/compile_commands.json
             build/install_manifest.txt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,8 +8,6 @@ on: [pull_request, push]
 
 env:
   VCPKG_COMMIT: 8dddc6c899ce6fdbeab38b525a31e7f23cb2d5bb
-  VCPKG_DEST_MACOS: /Users/runner/qbt_tools/vcpkg
-  VCPKG_DEST_WIN: C:\qbt_tools\vcpkg
 
 jobs:
   ubuntu:
@@ -89,6 +87,9 @@ jobs:
   windows:
     name: Windows
     runs-on: windows-2019
+
+    env:
+      VCPKG_DEST_WIN: C:\qbt_tools\vcpkg
 
     defaults:
       run:
@@ -182,6 +183,9 @@ jobs:
       matrix:
         qbt_gui: ["GUI=ON", "GUI=OFF"]
       fail-fast: false
+
+    env:
+      VCPKG_DEST_MACOS: /Users/runner/qbt_tools/vcpkg
 
     defaults:
       run:


### PR DESCRIPTION
* Support libtorrent v2.0.4 in CI
* Remove OS variable from build matrix
  It is meaningless to build on multiple linux versions as we only depend on library versions, not OS versions.
 Also remove redundant "shell default" section.
* Move global environment variables out
* Use ccache in CI 