### PR TITLE
GHA CI: Use preinstalled vcpkg

### DIFF
--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -6,42 +6,35 @@ jobs:
     name: Build
     runs-on: windows-2019
 
-    env:
-      VCPKG_COMMIT: 8dddc6c899ce6fdbeab38b525a31e7f23cb2d5bb
-      VCPKG_DEST_WIN: C:\qbt_tools\vcpkg
-
-    defaults:
-      run:
-        shell: pwsh
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      # - ninja is needed for building qBittorrent (because it's preferable, not a hard requirement)
       - name: Install build tools
         run: |
           choco install ninja
 
+      # use the preinstalled vcpkg from image
+      # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md#package-management
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v7
         with:
-          vcpkgDirectory: ${{ env.VCPKG_DEST_WIN }}
-          vcpkgGitCommitId: ${{ env.VCPKG_COMMIT }}
+          vcpkgDirectory: C:/vcpkg
+          doNotUpdateVcpkg: true  # the preinstalled vcpkg is updated regularly
           setupOnly: true
 
-      # Tell vcpkg to only build Release variants of the dependencies
+      # tell vcpkg to only build Release variants of the dependencies
       - name: Configure vcpkg triplet overlay
         run: |
           New-Item `
-            -Path ${{ github.workspace }} `
+            -Path "${{ github.workspace }}" `
             -Name "triplets_overlay" `
             -ItemType Directory
           Copy-Item `
-            ${{ env.RUNVCPKG_VCPKG_ROOT }}/triplets/x64-windows-static.cmake `
-            ${{ github.workspace }}/triplets_overlay/x64-windows-static-release.cmake
+            "${{ env.RUNVCPKG_VCPKG_ROOT }}/triplets/x64-windows-static.cmake" `
+            "${{ github.workspace }}/triplets_overlay/x64-windows-static-release.cmake"
           Add-Content `
-            ${{ github.workspace }}/triplets_overlay/x64-windows-static-release.cmake `
+            "${{ github.workspace }}/triplets_overlay/x64-windows-static-release.cmake" `
             -Value "set(VCPKG_BUILD_TYPE release)"
 
       # clear buildtrees after each package installation to reduce disk space requirements
@@ -55,32 +48,29 @@ jobs:
             "qt5-tools:x64-windows-static-release",
             "qt5-winextras:x64-windows-static-release"
           ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg.exe upgrade `
-            --overlay-triplets=${{ github.workspace }}/triplets_overlay `
+            --overlay-triplets="${{ github.workspace }}/triplets_overlay" `
             --no-dry-run
-          foreach($package in $packages)
-          {
-            ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg.exe install $package `
-              --overlay-triplets=${{ github.workspace }}/triplets_overlay `
-              --clean-after-build
-          }
+          ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg.exe install `
+            --overlay-triplets="${{ github.workspace }}/triplets_overlay" `
+            --clean-after-build `
+            $packages
 
-      # NOTE: this is necessary to correctly find and use cl.exe with the Ninja generator for now
+      # this is necessary to correctly find and use cl.exe with the Ninja generator for now
       - name: Setup devcmd
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Build qBittorrent
-        shell: cmd
         run: |
-          cmake ^
-            -B build ^
-            -G "Ninja" ^
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ^
-            -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_DEST_WIN }}\scripts\buildsystems\vcpkg.cmake ^
-            -DVCPKG_TARGET_TRIPLET=x64-windows-static-release ^
-            -DVERBOSE_CONFIGURE=ON ^
-            -DMSVC_RUNTIME_DYNAMIC=OFF ^
-            --graphviz=build\target_graph.dot
+          cmake `
+            -B build `
+            -G "Ninja" `
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo `
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON `
+            -DCMAKE_TOOLCHAIN_FILE="${{ env.RUNVCPKG_VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake" `
+            -DMSVC_RUNTIME_DYNAMIC=OFF `
+            -DVCPKG_TARGET_TRIPLET=x64-windows-static-release `
+            -DVERBOSE_CONFIGURE=ON `
+            --graphviz=build/target_graph.dot
           cmake --build build
 
       - name: Upload build artifacts
@@ -89,7 +79,7 @@ jobs:
           name: qBittorrent-CI_Windows-x64
           path: |
             build/compile_commands.json
-            build/target_graph.dot
             build/qbittorrent.exe
             build/qbittorrent.pdb
+            build/target_graph.dot
             dist/windows/qt.conf


### PR DESCRIPTION
This will save maintenance work on the vcpkg version.

Also a few other improvements:
  * Add quotes to path
  * Sort command flags
  * Avoid switching shell, always use powershell (the default shell)
