### PR TITLE
Fix issue #14419, column header truncation

### DIFF
--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -90,6 +90,8 @@ PeerListWidget::PeerListWidget(PropertiesWidget *parent)
     setEditTriggers(QAbstractItemView::NoEditTriggers);
     setSelectionMode(QAbstractItemView::ExtendedSelection);
     header()->setStretchLastSection(false);
+    header()->setTextElideMode(Qt::ElideRight);
+
     // List Model
     m_listModel = new QStandardItemModel(0, PeerListColumns::COL_COUNT, this);
     m_listModel->setHeaderData(PeerListColumns::COUNTRY, Qt::Horizontal, tr("Country/Region")); // Country flag column

--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -71,6 +71,7 @@ TrackerListWidget::TrackerListWidget(PropertiesWidget *properties)
     setItemsExpandable(false);
     setSelectionMode(QAbstractItemView::ExtendedSelection);
     header()->setStretchLastSection(false); // Must be set after loadSettings() in order to work
+    header()->setTextElideMode(Qt::ElideRight);
     // Ensure that at least one column is visible at all times
     if (visibleColumnsCount() == 0)
         setColumnHidden(COL_URL, false);

--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -71,6 +71,7 @@ SearchJobWidget::SearchJobWidget(SearchHandler *searchHandler, QWidget *parent)
     loadSettings();
 
     header()->setStretchLastSection(false);
+    header()->setTextElideMode(Qt::ElideRight);
 
     // Set Search results list model
     m_searchListModel = new QStandardItemModel(0, SearchSortModel::NB_SEARCH_COLUMNS, this);

--- a/src/gui/torrentcontenttreeview.cpp
+++ b/src/gui/torrentcontenttreeview.cpp
@@ -72,6 +72,7 @@ TorrentContentTreeView::TorrentContentTreeView(QWidget *parent)
     unused.setVerticalHeader(header());
     header()->setParent(this);
     header()->setStretchLastSection(false);
+    header()->setTextElideMode(Qt::ElideRight);
     unused.setVerticalHeader(new QHeaderView(Qt::Horizontal));
 }
 

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -158,6 +158,7 @@ TransferListWidget::TransferListWidget(QWidget *parent, MainWindow *mainWindow)
     setAttribute(Qt::WA_MacShowFocusRect, false);
 #endif
     header()->setStretchLastSection(false);
+    header()->setTextElideMode(Qt::ElideRight);
 
     // Default hidden columns
     if (!columnLoaded)


### PR DESCRIPTION
Minimizing columns no longer truncates text from the left, now elides
text from the right for better readability. Done by setting
textElideMode to Qt::TextElideRight for header (and columns, for
consistency).

Closes #14419.

Untruncated
![before](https://user-images.githubusercontent.com/62163458/130522959-6ff31688-e15f-4223-8094-3e8e941a9c97.png)

Before
![before2](https://user-images.githubusercontent.com/62163458/130522968-a3f2c285-08bc-46f8-b7b7-09f7a7b4bb2c.png)

After
![after](https://user-images.githubusercontent.com/62163458/130522978-1ea5ee5f-dae2-4f6d-9360-14c451fd8d5e.png)

