### PR TITLE
Specify Unicode for resource block

### DIFF
--- a/src/qbittorrent.rc
+++ b/src/qbittorrent.rc
@@ -29,7 +29,7 @@ FILESUBTYPE    	VFT2_UNKNOWN
 BEGIN
     BLOCK "StringFileInfo"
     BEGIN
-        BLOCK "040904E4"
+        BLOCK "040904B0"
         BEGIN
             VALUE "CompanyName",      "The qBittorrent Project"
             VALUE "FileDescription",  "qBittorrent - A Bittorrent Client"


### PR DESCRIPTION
The StringFileInfo block was using "1252 Multilingual", change it to "1200 Unicode" for consistency.
https://docs.microsoft.com/en-us/windows/win32/menurc/stringfileinfo-block

Closes #15364.