### PR TITLE
GHA CI: Use macOS 11 runner image

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -4,7 +4,7 @@ on: [pull_request, push]
 jobs:
   ci:
     name: Build
-    runs-on: macos-10.15
+    runs-on: macos-11
 
     strategy:
       matrix:


### PR DESCRIPTION
Use macOS 11 (Big Sur) runner image.

It has now been made generally available.

Ref.: https://github.blog/changelog/2021-08-16-github-actions-macos-11-big-sur-is-generally-available-on-github-hosted-runners/

Supersedes https://github.com/qbittorrent/qBittorrent/pull/15195