### PR TITLE
Remove Windows Vista support from manifest

### DIFF
--- a/src/qbittorrent.exe.manifest
+++ b/src/qbittorrent.exe.manifest
@@ -24,8 +24,6 @@
   <!-- Declare support for various versions of Windows -->
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
       <application>
-          <!-- Windows Vista -->
-          <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />
           <!-- Windows 7 -->
           <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
           <!-- Windows 8 -->


### PR DESCRIPTION
We no longer support Windows Vista, so removed it's GUID from the manifest file.