### PR TITLE
Prolong wait time for shutdown

### DIFF
--- a/dist/unix/systemd/qbittorrent-nox@.service.in
+++ b/dist/unix/systemd/qbittorrent-nox@.service.in
@@ -9,6 +9,7 @@ Type=simple
 PrivateTmp=false
 User=%i
 ExecStart=@EXPAND_BINDIR@/qbittorrent-nox
+TimeoutStopSec=1800
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The default was [90s](https://www.freedesktop.org/software/systemd/man/systemd-system.conf.html#DefaultTimeoutStartSec=), prolong to 30 mins. 
From the discussion in https://github.com/qbittorrent/qBittorrent/issues/15381#issuecomment-912080617, ~2k torrents took 5 mins to completely shutdown. Here we wait at most 30 mins which scales to about 12k torrents which should cover most use case (also note that 4.3.x series is mentioned to have even shorter shutdown time).

Setting it to `infinity` isn't a good idea since that would potentially stall the system if anything go wrong.