### PR TITLE
Add pieces progress bar to General tab in the WebUI

### DIFF
--- a/src/webui/www/private/css/style.css
+++ b/src/webui/www/private/css/style.css
@@ -517,6 +517,21 @@ td.generalLabel {
     padding: 2px;
 }
 
+#progress {
+    border: 1px solid #999;
+    padding: 0;
+    position: relative;
+    width: 100%;
+}
+
+#progress canvas {
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+}
+
 #watched_folders_tab {
     border-collapse: collapse;
 }

--- a/src/webui/www/private/views/properties.html
+++ b/src/webui/www/private/views/properties.html
@@ -1,4 +1,13 @@
 <div id="prop_general" class="propertiesTabContent">
+    <table style="width: 100%; padding: 0 3px">
+        <tr>
+            <td style="text-align: right">QBT_TR(Progress:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+            <td id="progress">
+                <canvas width="0" height="1"></canvas>
+            </td>
+        </tr>
+    </table>
+    <hr>
     <fieldset>
         <legend><b>QBT_TR(Transfer)QBT_TR[CONTEXT=PropertiesWidget]</b></legend>
         <table style="width: 100%">


### PR DESCRIPTION
I use the WebUI mostly and I miss having the pieces progress bar show the status of each piece like in the GUI. I wanted the feature so I implemented it just on a local clone of this repo. Then I searched the current issues and found #15292 so I thought I'd submit a PR.

I initially used a bunch of `<div>`s for each piece but the quality of that was poor and it often looked like there were more pieces completed than in reality. So I changed it to use a `<canvas>` and it looks nicer and is more accurate.

I don't know much about the translations, so I'm not sure if there is anything else I need to do for that. I ran the `tstool.py` script, but it added several changes besides just my new addition. Not sure if all those changes should be submitted in this PR or not, just let me know and I can update the PR.

Here are some screenshots of different torrents at different stages of completion.

![pieces-blank](https://user-images.githubusercontent.com/1645882/132106987-f15cef28-866d-437c-aae5-0621b7784a09.png)
![pieces-init](https://user-images.githubusercontent.com/1645882/132107001-c7cb7036-b940-4f1a-8bd0-57fc56fa7912.png)

![pieces-in-order-05](https://user-images.githubusercontent.com/1645882/132107000-8ba6140b-34e7-4ec7-899d-7138490cd15e.png)
![pieces-in-order-50](https://user-images.githubusercontent.com/1645882/132106997-ff0d2093-086d-464e-8ba9-4c73e6b37a8c.png)
![pieces-in-order-75](https://user-images.githubusercontent.com/1645882/132106995-14d39ad7-e1d9-4e4f-8e61-5ad834d6054f.png)
![pieces-in-order-98](https://user-images.githubusercontent.com/1645882/132106994-32fb187b-36e6-4799-87d3-b8d31ffc79f4.png)

![pieces-mixed-10](https://user-images.githubusercontent.com/1645882/132106999-05c5aecf-3a34-4761-b1fa-f962f352c935.png)
![pieces-mixed-25](https://user-images.githubusercontent.com/1645882/132106992-a25d2215-c5dd-457b-9399-85cfae0a4e66.png)
![pieces-mixed-50](https://user-images.githubusercontent.com/1645882/132106990-2382fc71-945e-4f03-aff4-89439a145425.png)
![pieces-mixed-54](https://user-images.githubusercontent.com/1645882/132106986-0f3bb250-221f-4bcb-aaf0-52dcd8790e89.png)
![pieces-mixed-75](https://user-images.githubusercontent.com/1645882/132106989-a7905f15-803a-4aae-8154-3f5adb00465f.png)
![pieces-mixed-98](https://user-images.githubusercontent.com/1645882/132106988-5016ba58-0a7f-41d4-90db-3090080d1dce.png)

![pieces-full](https://user-images.githubusercontent.com/1645882/132106993-07e21b47-06fd-4d0a-95c4-e35f71b26133.png)

One thing I noticed when there are lots of spread out pieces completed and resizing the window, it is not a very smooth transition. I tired a few things to see if I could improve that, but nothing helped much. In any case, I don't think it is much of an issue because resizing is a relatively rare event anyway.

![resizing](https://user-images.githubusercontent.com/1645882/132107346-7b43e6fb-1b39-4111-a909-c2d733f4ed7a.gif)

Closes #15292