### PR TITLE
Prevent self-assignment in assignment operator

### DIFF
--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -88,7 +88,10 @@ TorrentInfo::TorrentInfo(const TorrentInfo &other)
 
 TorrentInfo &TorrentInfo::operator=(const TorrentInfo &other)
 {
-    m_nativeInfo = other.m_nativeInfo;
+    if (this != &other)
+    {
+        m_nativeInfo = other.m_nativeInfo;
+    }
     return *this;
 }
 

--- a/src/base/rss/rss_autodownloadrule.cpp
+++ b/src/base/rss/rss_autodownloadrule.cpp
@@ -440,7 +440,10 @@ bool AutoDownloadRule::accepts(const QVariantHash &articleData)
 
 AutoDownloadRule &AutoDownloadRule::operator=(const AutoDownloadRule &other)
 {
-    m_dataPtr = other.m_dataPtr;
+    if (this != &other)
+    {
+        m_dataPtr = other.m_dataPtr;
+    }
     return *this;
 }
 

--- a/src/gui/raisedmessagebox.h
+++ b/src/gui/raisedmessagebox.h
@@ -32,7 +32,8 @@
 
 class RaisedMessageBox final : public QMessageBox
 {
-  Q_OBJECT
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(RaisedMessageBox)
 
 public:
     static QMessageBox::StandardButton critical(QWidget *parent, const QString &title, const QString &text, QMessageBox::StandardButtons buttons = QMessageBox::Ok, QMessageBox::StandardButton defaultButton = QMessageBox::NoButton);
@@ -45,9 +46,6 @@ protected:
 
 private:
     RaisedMessageBox(QMessageBox::Icon icon, const QString &title, const QString &text, QMessageBox::StandardButtons buttons = NoButton, QWidget *parent = nullptr, Qt::WindowFlags f = Qt::Dialog|Qt::MSWindowsFixedSizeDialogHint);
-    RaisedMessageBox();
-    RaisedMessageBox(RaisedMessageBox const&);
-    void operator=(RaisedMessageBox const&);
 
     static QMessageBox::StandardButton impl(const QMessageBox::Icon &icon, QWidget *parent, const QString &title, const QString &text, QMessageBox::StandardButtons buttons = QMessageBox::Ok, QMessageBox::StandardButton defaultButton = QMessageBox::NoButton);
 };


### PR DESCRIPTION
* Prevent self-assignment in assignment operator
* Use Qt macro to disable various constructors 