### PR TITLE
Fix code defects

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -77,7 +77,7 @@ jobs:
           curl \
             --form token=$TOKEN \
             --form email=sledgehammer999@qbittorrent.org \
-            --form file=@qbittorrent.tgz \
+            --form file=@qbittorrent.xz \
             --form version="$(git rev-parse --short HEAD)" \
             --form description="master" \
             https://scan.coverity.com/builds?project=qbittorrent%2FqBittorrent

--- a/src/base/utils/gzip.cpp
+++ b/src/base/utils/gzip.cpp
@@ -48,7 +48,7 @@ QByteArray Utils::Gzip::compress(const QByteArray &data, const int level, bool *
     const int BUFSIZE = 128 * 1024;
     std::vector<char> tmpBuf(BUFSIZE);
 
-    z_stream strm;
+    z_stream strm {};
     strm.zalloc = Z_NULL;
     strm.zfree = Z_NULL;
     strm.opaque = Z_NULL;
@@ -109,7 +109,7 @@ QByteArray Utils::Gzip::decompress(const QByteArray &data, bool *ok)
     const int BUFSIZE = 1024 * 1024;
     std::vector<char> tmpBuf(BUFSIZE);
 
-    z_stream strm;
+    z_stream strm {};
     strm.zalloc = Z_NULL;
     strm.zfree = Z_NULL;
     strm.opaque = Z_NULL;

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -551,6 +551,9 @@ void PropertiesWidget::loadDynamicData()
 
 void PropertiesWidget::loadUrlSeeds()
 {
+    if (!m_torrent)
+        return;
+
     m_ui->listWebSeeds->clear();
     qDebug("Loading URL seeds");
     const QVector<QUrl> hcSeeds = m_torrent->urlSeeds();


### PR DESCRIPTION
* Initialize member fields
* Guard for null pointer
  Although pointed out in https://github.com/qbittorrent/qBittorrent/pull/15303#discussion_r688377164, not all of them are actually trigger-able when nullptr is present. Therefore this commit only patches the report from coverity scan.
* Fix typo

Supersedes #15303.