### PR TITLE
Improve Profile handling

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -55,8 +55,19 @@
 
 #include "algorithm.h"
 #include "global.h"
+#include "profile.h"
 #include "settingsstorage.h"
 #include "utils/fs.h"
+
+namespace
+{
+    QString makeProfileID(const QString &profilePath, const QString &profileName)
+    {
+        return profilePath.isEmpty()
+                ? profileName
+                : profileName + QLatin1Char('@') + Utils::Fs::toValidFileSystemName(profilePath, false, {});
+    }
+}
 
 Preferences *Preferences::m_instance = nullptr;
 
@@ -310,21 +321,31 @@ void Preferences::setPreventFromSuspendWhenSeeding(const bool b)
 #ifdef Q_OS_WIN
 bool Preferences::WinStartup() const
 {
-    QSettings settings("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Run", QSettings::NativeFormat);
-    return settings.contains("qBittorrent");
+    const QString profileName = Profile::instance()->profileName();
+    const QString profilePath = Profile::instance()->rootPath();
+    const QString profileID = makeProfileID(profilePath, profileName);
+    const QSettings settings {"HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Run", QSettings::NativeFormat};
+
+    return settings.contains(profileID);
 }
 
 void Preferences::setWinStartup(const bool b)
 {
-    QSettings settings("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Run", QSettings::NativeFormat);
+    const QString profileName = Profile::instance()->profileName();
+    const QString profilePath = Profile::instance()->rootPath();
+    const QString profileID = makeProfileID(profilePath, profileName);
+    QSettings settings {"HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Run", QSettings::NativeFormat};
     if (b)
     {
-        const QString binPath = '"' + Utils::Fs::toNativePath(qApp->applicationFilePath()) + '"';
-        settings.setValue("qBittorrent", binPath);
+        const QString configuration = Profile::instance()->configurationName();
+
+        const auto cmd = QString::fromLatin1(R"("%1" "--profile=%2" "--configuration=%3")")
+                .arg(Utils::Fs::toNativePath(qApp->applicationFilePath()), profilePath, configuration);
+        settings.setValue(profileID, cmd);
     }
     else
     {
-        settings.remove("qBittorrent");
+        settings.remove(profileID);
     }
 }
 #endif // Q_OS_WIN

--- a/src/base/profile.cpp
+++ b/src/base/profile.cpp
@@ -45,7 +45,7 @@ Profile::Profile(const QString &rootProfilePath, const QString &configurationNam
     ensureDirectoryExists(SpecialFolder::Data);
 
     if (convertPathsToProfileRelative)
-        m_pathConverterImpl = std::make_unique<Private::Converter>(m_profileImpl->baseDirectory());
+        m_pathConverterImpl = std::make_unique<Private::Converter>(m_profileImpl->basePath());
     else
         m_pathConverterImpl = std::make_unique<Private::NoConvertConverter>();
 }
@@ -91,6 +91,16 @@ QString Profile::location(const SpecialFolder folder) const
     if (!result.endsWith(QLatin1Char('/')))
         result += QLatin1Char('/');
     return result;
+}
+
+QString Profile::rootPath() const
+{
+    return m_profileImpl->rootPath();
+}
+
+QString Profile::configurationName() const
+{
+    return m_profileImpl->configurationName();
 }
 
 QString Profile::profileName() const

--- a/src/base/profile.h
+++ b/src/base/profile.h
@@ -62,6 +62,9 @@ public:
     QString location(SpecialFolder folder) const;
     SettingsPtr applicationSettings(const QString &name) const;
 
+    QString rootPath() const;
+    QString configurationName() const;
+
     /// Returns either default name for configuration file (QCoreApplication::applicationName())
     /// or the value, supplied via parameters
     QString profileName() const;

--- a/src/base/profile_p.cpp
+++ b/src/base/profile_p.cpp
@@ -32,13 +32,18 @@
 #include <QCoreApplication>
 
 Private::Profile::Profile(const QString &configurationName)
-    : m_configurationSuffix {configurationName.isEmpty() ? QString() : QLatin1Char('_') + configurationName}
+    : m_configurationName {configurationName}
 {
+}
+
+QString Private::Profile::configurationName() const
+{
+    return m_configurationName;
 }
 
 QString Private::Profile::configurationSuffix() const
 {
-    return m_configurationSuffix;
+    return (m_configurationName.isEmpty() ? QString() : QLatin1Char('_') + m_configurationName);
 }
 
 QString Private::Profile::profileName() const
@@ -47,11 +52,16 @@ QString Private::Profile::profileName() const
 }
 
 Private::DefaultProfile::DefaultProfile(const QString &configurationName)
-    : Profile(configurationName)
+    : Profile {configurationName}
 {
 }
 
-QString Private::DefaultProfile::baseDirectory() const
+QString Private::DefaultProfile::rootPath() const
+{
+    return {};
+}
+
+QString Private::DefaultProfile::basePath() const
 {
     return QDir::homePath();
 }
@@ -116,33 +126,43 @@ QString Private::DefaultProfile::locationWithConfigurationName(const QStandardPa
 
 Private::CustomProfile::CustomProfile(const QString &rootPath, const QString &configurationName)
     : Profile {configurationName}
-    , m_rootDirectory {QDir(rootPath).absoluteFilePath(this->profileName())}
+    , m_rootDir {rootPath}
+    , m_baseDir {m_rootDir.absoluteFilePath(profileName())}
+    , m_cacheLocation {m_baseDir.absoluteFilePath(QLatin1String("cache"))}
+    , m_configLocation {m_baseDir.absoluteFilePath(QLatin1String("config"))}
+    , m_dataLocation {m_baseDir.absoluteFilePath(QLatin1String("data"))}
+    , m_downloadLocation {m_baseDir.absoluteFilePath(QLatin1String("downloads"))}
 {
 }
 
-QString Private::CustomProfile::baseDirectory() const
+QString Private::CustomProfile::rootPath() const
 {
-    return m_rootDirectory.canonicalPath();
+    return m_rootDir.absolutePath();
+}
+
+QString Private::CustomProfile::basePath() const
+{
+    return m_baseDir.absolutePath();
 }
 
 QString Private::CustomProfile::cacheLocation() const
 {
-    return m_rootDirectory.absoluteFilePath(QLatin1String(cacheDirName));
+    return m_cacheLocation;
 }
 
 QString Private::CustomProfile::configLocation() const
 {
-    return m_rootDirectory.absoluteFilePath(QLatin1String(configDirName));
+    return m_configLocation;
 }
 
 QString Private::CustomProfile::dataLocation() const
 {
-    return m_rootDirectory.absoluteFilePath(QLatin1String(dataDirName));
+    return m_dataLocation;
 }
 
 QString Private::CustomProfile::downloadLocation() const
 {
-    return m_rootDirectory.absoluteFilePath(QLatin1String(downloadsDirName));
+    return m_downloadLocation;
 }
 
 SettingsPtr Private::CustomProfile::applicationSettings(const QString &name) const

--- a/src/base/profile_p.h
+++ b/src/base/profile_p.h
@@ -39,14 +39,23 @@ namespace Private
     class Profile
     {
     public:
-        virtual QString baseDirectory() const = 0;
+        virtual ~Profile() = default;
+
+        virtual QString rootPath() const = 0;
+
+        /**
+         * @brief The base path against to which portable (relative) paths are resolved
+         */
+        virtual QString basePath() const = 0;
+
         virtual QString cacheLocation() const = 0;
         virtual QString configLocation() const = 0;
         virtual QString dataLocation() const = 0;
         virtual QString downloadLocation() const = 0;
+
         virtual SettingsPtr applicationSettings(const QString &name) const = 0;
 
-        virtual ~Profile() = default;
+        QString configurationName() const;
 
         /**
          * @brief QCoreApplication::applicationName() with optional configuration name appended
@@ -57,8 +66,9 @@ namespace Private
         explicit Profile(const QString &configurationName);
 
         QString configurationSuffix() const;
+
     private:
-        QString m_configurationSuffix;
+        QString m_configurationName;
     };
 
     /// Default implementation. Takes paths from system
@@ -67,7 +77,8 @@ namespace Private
     public:
         explicit DefaultProfile(const QString &configurationName);
 
-        QString baseDirectory() const override;
+        QString rootPath() const override;
+        QString basePath() const override;
         QString cacheLocation() const override;
         QString configLocation() const override;
         QString dataLocation() const override;
@@ -90,7 +101,8 @@ namespace Private
     public:
         CustomProfile(const QString &rootPath, const QString &configurationName);
 
-        QString baseDirectory() const override;
+        QString rootPath() const override;
+        QString basePath() const override;
         QString cacheLocation() const override;
         QString configLocation() const override;
         QString dataLocation() const override;
@@ -98,11 +110,12 @@ namespace Private
         SettingsPtr applicationSettings(const QString &name) const override;
 
     private:
-        QDir m_rootDirectory;
-        static constexpr const char *cacheDirName = "cache";
-        static constexpr const char *configDirName = "config";
-        static constexpr const char *dataDirName = "data";
-        static constexpr const char *downloadsDirName = "downloads";
+        const QDir m_rootDir;
+        const QDir m_baseDir;
+        const QString m_cacheLocation;
+        const QString m_configLocation;
+        const QString m_dataLocation;
+        const QString m_downloadLocation;
     };
 
     class PathConverter


### PR DESCRIPTION
Add `Profile::rootPath` and `Profile::configurationName` properties.
Fix startup with different profiles.
Supercedes #15400.