### PR TITLE
Organizes ComboBox items in Behavior Preferences

### DIFF
--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -310,6 +310,11 @@
                     </item>
                     <item>
                      <property name="text">
+                      <string>Preview file, otherwise open destination folder</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
                       <string>No action</string>
                      </property>
                     </item>


### PR DESCRIPTION
Uses the correct case at transferlistwidget.cpp line 283.Closes #15422.

This comes from PR [15492](https://github.com/qbittorrent/qBittorrent/pull/15492).

> This PR solves issue 15422: Double-click opens torrent when set to No Action.
> The main problem is in file transferlistwidget.cpp , in line 283. Here the switch sentence is getting the action as input, which in the end is the index from one of the ComboBoxes at the Preferences window.
> As for the Downloading torrents ComboBox there are less options than for the Completed torrents the action to perform is incorrect, and it is entering in the wrong part of the switch sentence.
> To solve this I just added an entry to the Downloading torrents ComboBox, so now both ComboBoxes have the same options and we have the expected behavior.