### PR TITLE
GHA CI: build dependencies manually

### DIFF
--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -18,24 +18,18 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal
           sudo apt update
           sudo apt install \
             build-essential cmake ninja-build pkg-config \
-            libboost-dev libssl-dev zlib1g-dev
-        # sudo apt install libqt5svg5-dev qtbase5-dev qttools5-dev # the Qt version in the standard repositories is too old...
+            libboost-dev libssl-dev qt515base qt515svg qt515tools zlib1g-dev
 
       - name: Setup ccache
         uses: Chocobo1/setup-ccache-action@v1
         with:
           update_packager_index: false
-
-      # this will be installed under /opt/qt515. CMake will still find it automatically without additional hints
-      # to speed up the process, only the required components are installed rather than the full qt515-meta-full metapackage
-      - name: Install Qt
-        run: |
-          sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal
-          sudo apt install \
-            qt515base qt515svg qt515tools
+          ccache_options: |
+            max_size=2G
 
       - name: Install libtorrent
         run: |
@@ -63,9 +57,7 @@ jobs:
             -DVERBOSE_CONFIGURE=ON \
             --graphviz=build/target_graph.dot
           cmake --build build
-
-      - name: Install qBittorrent
-        run: sudo cmake --install build
+          sudo cmake --install build
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -4,11 +4,23 @@ on: [pull_request, push]
 jobs:
   ci:
     name: Build
-    runs-on: windows-2019
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        libt_version: ["v2.0.4", "v1.2.14"]
+      fail-fast: false
+
+    env:
+      boost_path: "${{ github.workspace }}/boost"
+      libtorrent_path: "${{ github.workspace }}/libtorrent"
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+
+      - name: Setup devcmd
+        uses: ilammy/msvc-dev-cmd@v1
 
       - name: Install build tools
         run: |
@@ -41,12 +53,12 @@ jobs:
       - name: Install dependencies
         run: |
           $packages = `
-            "boost-circular-buffer:x64-windows-static-release",
-            "libtorrent:x64-windows-static-release",
+            "openssl:x64-windows-static-release",
             "qt5-base:x64-windows-static-release",
             "qt5-svg:x64-windows-static-release",
             "qt5-tools:x64-windows-static-release",
-            "qt5-winextras:x64-windows-static-release"
+            "qt5-winextras:x64-windows-static-release",
+            "zlib:x64-windows-static-release"
           ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg.exe upgrade `
             --overlay-triplets="${{ github.workspace }}/triplets_overlay" `
             --no-dry-run
@@ -55,9 +67,33 @@ jobs:
             --clean-after-build `
             $packages
 
-      # this is necessary to correctly find and use cl.exe with the Ninja generator for now
-      - name: Setup devcmd
-        uses: ilammy/msvc-dev-cmd@v1
+      - name: Install boost
+        run: |
+          aria2c `
+            "https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.7z" `
+            -d "${{ runner.temp }}" `
+            -o "boost.7z"
+          7z x "${{ runner.temp }}/boost.7z" -o"${{ github.workspace }}/.."
+          move "${{ github.workspace }}/../boost_*" "${{ env.boost_path }}"
+
+      - name: Install libtorrent
+        run: |
+          git clone --branch ${{ matrix.libt_version }} --depth 1 https://github.com/arvidn/libtorrent.git
+          cd libtorrent
+          git submodule update --init --recursive
+          cmake `
+            -B build `
+            -G "Ninja" `
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo `
+            -DCMAKE_INSTALL_PREFIX="${{ env.libtorrent_path }}" `
+            -DCMAKE_TOOLCHAIN_FILE="${{ env.RUNVCPKG_VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake" `
+            -DBOOST_ROOT="${{ env.boost_path }}" `
+            -DBUILD_SHARED_LIBS=OFF `
+            -Ddeprecated-functions=OFF `
+            -Dstatic_runtime=ON `
+            -DVCPKG_TARGET_TRIPLET=x64-windows-static-release
+          cmake --build build
+          cmake --install build
 
       - name: Build qBittorrent
         run: |
@@ -67,19 +103,26 @@ jobs:
             -DCMAKE_BUILD_TYPE=RelWithDebInfo `
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON `
             -DCMAKE_TOOLCHAIN_FILE="${{ env.RUNVCPKG_VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake" `
+            -DBOOST_ROOT="${{ env.boost_path }}" `
+            -DLibtorrentRasterbar_DIR="${{ env.libtorrent_path }}/lib/cmake/LibtorrentRasterbar" `
             -DMSVC_RUNTIME_DYNAMIC=OFF `
             -DVCPKG_TARGET_TRIPLET=x64-windows-static-release `
             -DVERBOSE_CONFIGURE=ON `
             --graphviz=build/target_graph.dot
           cmake --build build
 
+      - name: Prepare build artifacts
+        run: |
+          mkdir upload
+          copy build/qbittorrent.exe upload
+          copy build/qbittorrent.pdb upload
+          copy dist/windows/qt.conf upload
+          mkdir upload/cmake
+          copy build/compile_commands.json upload/cmake
+          copy build/target_graph.dot upload/cmake
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: qBittorrent-CI_Windows-x64
-          path: |
-            build/compile_commands.json
-            build/qbittorrent.exe
-            build/qbittorrent.pdb
-            build/target_graph.dot
-            dist/windows/qt.conf
+          name: qBittorrent-CI_Windows-x64_libtorrent-${{ matrix.libt_version }}
+          path: upload

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -15,19 +15,11 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal
           sudo apt update
           sudo apt install \
             build-essential cmake ninja-build pkg-config \
-            libboost-dev libssl-dev zlib1g-dev
-        # sudo apt install libqt5svg5-dev qtbase5-dev qttools5-dev # the Qt version in the standard repositories is too old...
-
-      # this will be installed under /opt/qt515. CMake will still find it automatically without additional hints
-      # to speed up the process, only the required components are installed rather than the full qt515-meta-full metapackage
-      - name: Install Qt
-        run: |
-          sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal
-          sudo apt install \
-            qt515base qt515svg qt515tools
+            libboost-dev libssl-dev qt515base qt515svg qt515tools zlib1g-dev
 
       - name: Install libtorrent
         run: |
@@ -52,7 +44,7 @@ jobs:
           mkdir coverity_tool
           tar xzf coverity_tool.tgz --strip 1 -C coverity_tool
 
-      - name: Configure qBittorrent
+      - name: Build qBittorrent
         run: |
           cmake \
             -B build \
@@ -60,9 +52,6 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DGUI=ON \
             -DVERBOSE_CONFIGURE=ON
-
-      - name: Build qBittorrent
-        run: |
           export PATH="$(pwd)/coverity_tool/bin:$PATH"
           cov-build --dir cov-int cmake --build build
 


### PR DESCRIPTION
* GHA CI: build dependencies manually
  Now it builds boost, libtorrent manually and we have control over its version.
  Enable build matrix for libtorrent versions.
  Reorganized the folder/file layout in built artifact.
* GHA CI: use larger cache for compiling
  Previous default was 500MB and it couldn't fit all compile results in it, enlarge it to 2GB. Note that 2GB isn't the actual size stored on the server, it will be compressed again by zstd and will be a lot smaller.



