### PR TITLE
WebUI: Add meta application name

### DIFF
--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=10" />
+    <meta name="application-name" content="qBittorrent" />
     <title>qBittorrent Web UI</title>
     <link rel="icon" type="image/png" href="images/qbittorrent32.png" />
     <link rel="icon" type="image/svg+xml" href="icons/qbittorrent-tray.svg" />


### PR DESCRIPTION
Used for installable/pinned app installs. E.g. when pinning to Android home screen or Windows Start.
