### PR TITLE
Change emit to Q_EMIT

### DIFF
--- a/src/app/qtlocalpeer/qtlocalpeer.cpp
+++ b/src/app/qtlocalpeer/qtlocalpeer.cpp
@@ -259,5 +259,5 @@ void QtLocalPeer::receiveConnection()
     socket->waitForBytesWritten(1000);
     socket->waitForDisconnected(1000); // make sure client reads ack
     delete socket;
-    emit messageReceived(message); //### (might take a long time to return)
+    Q_EMIT messageReceived(message); //### (might take a long time to return)
 }

--- a/src/base/asyncfilestorage.cpp
+++ b/src/base/asyncfilestorage.cpp
@@ -74,6 +74,6 @@ void AsyncFileStorage::store_impl(const QString &fileName, const QByteArray &dat
     if (!result)
     {
         qDebug() << "AsyncFileStorage: Failed to save data";
-        emit failed(filePath, result.error());
+        Q_EMIT failed(filePath, result.error());
     }
 }

--- a/src/base/bittorrent/bandwidthscheduler.cpp
+++ b/src/base/bittorrent/bandwidthscheduler.cpp
@@ -47,7 +47,7 @@ BandwidthScheduler::BandwidthScheduler(QObject *parent)
 void BandwidthScheduler::start()
 {
     m_lastAlternative = isTimeForAlternative();
-    emit bandwidthLimitRequested(m_lastAlternative);
+    Q_EMIT bandwidthLimitRequested(m_lastAlternative);
 
     // Timeout regularly to accommodate for external system clock changes
     // eg from the user or from a timesync utility
@@ -102,6 +102,6 @@ void BandwidthScheduler::onTimeout()
     if (alternative != m_lastAlternative)
     {
         m_lastAlternative = alternative;
-        emit bandwidthLimitRequested(alternative);
+        Q_EMIT bandwidthLimitRequested(alternative);
     }
 }

--- a/src/base/bittorrent/filesearcher.cpp
+++ b/src/base/bittorrent/filesearcher.cpp
@@ -65,5 +65,5 @@ void FileSearcher::search(const BitTorrent::TorrentID &id, const QStringList &or
         findInDir(savePath, adjustedFileNames);
     }
 
-    emit searchFinished(id, savePath, adjustedFileNames);
+    Q_EMIT searchFinished(id, savePath, adjustedFileNames);
 }

--- a/src/base/bittorrent/filterparserthread.cpp
+++ b/src/base/bittorrent/filterparserthread.cpp
@@ -637,11 +637,11 @@ void FilterParserThread::run()
 
     try
     {
-        emit IPFilterParsed(ruleCount);
+        Q_EMIT IPFilterParsed(ruleCount);
     }
     catch (const std::exception &)
     {
-        emit IPFilterError();
+        Q_EMIT IPFilterError();
     }
 
     qDebug("IP Filter thread: finished parsing, filter applied");

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -725,14 +725,14 @@ bool Session::addCategory(const QString &name, const QString &savePath)
             if ((parent != name) && !m_categories.contains(parent))
             {
                 m_categories[parent] = "";
-                emit categoryAdded(parent);
+                Q_EMIT categoryAdded(parent);
             }
         }
     }
 
     m_categories[name] = savePath;
     m_storedCategories = map_cast(m_categories);
-    emit categoryAdded(name);
+    Q_EMIT categoryAdded(name);
 
     return true;
 }
@@ -777,7 +777,7 @@ bool Session::removeCategory(const QString &name)
             if (category.startsWith(test))
             {
                 result = true;
-                emit categoryRemoved(category);
+                Q_EMIT categoryRemoved(category);
                 return true;
             }
             return false;
@@ -790,7 +790,7 @@ bool Session::removeCategory(const QString &name)
     {
         // update stored categories
         m_storedCategories = map_cast(m_categories);
-        emit categoryRemoved(name);
+        Q_EMIT categoryRemoved(name);
     }
 
     return result;
@@ -819,7 +819,7 @@ void Session::setSubcategoriesEnabled(const bool value)
     }
 
     m_isSubcategoriesEnabled = value;
-    emit subcategoriesSupportChanged();
+    Q_EMIT subcategoriesSupportChanged();
 }
 
 QSet<QString> Session::tags() const
@@ -844,7 +844,7 @@ bool Session::addTag(const QString &tag)
 
     m_tags.insert(tag);
     m_storedTags = m_tags.values();
-    emit tagAdded(tag);
+    Q_EMIT tagAdded(tag);
     return true;
 }
 
@@ -855,7 +855,7 @@ bool Session::removeTag(const QString &tag)
         for (TorrentImpl *const torrent : asConst(m_torrents))
             torrent->removeTag(tag);
         m_storedTags = m_tags.values();
-        emit tagRemoved(tag);
+        Q_EMIT tagRemoved(tag);
         return true;
     }
     return false;
@@ -1697,15 +1697,15 @@ void Session::handleDownloadFinished(const Net::DownloadResult &result)
     switch (result.status)
     {
     case Net::DownloadStatus::Success:
-        emit downloadFromUrlFinished(result.url);
+        Q_EMIT downloadFromUrlFinished(result.url);
         addTorrent(TorrentInfo::load(result.data), m_downloadedTorrents.take(result.url));
         break;
     case Net::DownloadStatus::RedirectedToMagnet:
-        emit downloadFromUrlFinished(result.url);
+        Q_EMIT downloadFromUrlFinished(result.url);
         addTorrent(MagnetUri {result.magnet}, m_downloadedTorrents.take(result.url));
         break;
     default:
-        emit downloadFromUrlFailed(result.url, result.errorString);
+        Q_EMIT downloadFromUrlFailed(result.url, result.errorString);
     }
 }
 
@@ -1793,7 +1793,7 @@ bool Session::deleteTorrent(const TorrentID &id, const DeleteOption deleteOption
     if (!torrent) return false;
 
     qDebug("Deleting torrent with ID: %s", qUtf8Printable(torrent->id().toString()));
-    emit torrentAboutToBeRemoved(torrent);
+    Q_EMIT torrentAboutToBeRemoved(torrent);
 
     // Remove it from session
     if (deleteOption == DeleteTorrent)
@@ -2696,7 +2696,7 @@ void Session::setAltGlobalSpeedLimitEnabled(const bool enabled)
     m_isAltGlobalSpeedLimitEnabled = enabled;
     applyBandwidthLimits();
     // Notify
-    emit speedLimitModeChanged(m_isAltGlobalSpeedLimitEnabled);
+    Q_EMIT speedLimitModeChanged(m_isAltGlobalSpeedLimitEnabled);
 }
 
 bool Session::isBandwidthSchedulerEnabled() const
@@ -3834,52 +3834,52 @@ void Session::handleTorrentNameChanged(TorrentImpl *const)
 
 void Session::handleTorrentSavePathChanged(TorrentImpl *const torrent)
 {
-    emit torrentSavePathChanged(torrent);
+    Q_EMIT torrentSavePathChanged(torrent);
 }
 
 void Session::handleTorrentCategoryChanged(TorrentImpl *const torrent, const QString &oldCategory)
 {
-    emit torrentCategoryChanged(torrent, oldCategory);
+    Q_EMIT torrentCategoryChanged(torrent, oldCategory);
 }
 
 void Session::handleTorrentTagAdded(TorrentImpl *const torrent, const QString &tag)
 {
-    emit torrentTagAdded(torrent, tag);
+    Q_EMIT torrentTagAdded(torrent, tag);
 }
 
 void Session::handleTorrentTagRemoved(TorrentImpl *const torrent, const QString &tag)
 {
-    emit torrentTagRemoved(torrent, tag);
+    Q_EMIT torrentTagRemoved(torrent, tag);
 }
 
 void Session::handleTorrentSavingModeChanged(TorrentImpl *const torrent)
 {
-    emit torrentSavingModeChanged(torrent);
+    Q_EMIT torrentSavingModeChanged(torrent);
 }
 
 void Session::handleTorrentTrackersAdded(TorrentImpl *const torrent, const QVector<TrackerEntry> &newTrackers)
 {
     for (const TrackerEntry &newTracker : newTrackers)
         LogMsg(tr("Tracker '%1' was added to torrent '%2'").arg(newTracker.url, torrent->name()));
-    emit trackersAdded(torrent, newTrackers);
+    Q_EMIT trackersAdded(torrent, newTrackers);
     if (torrent->trackers().size() == newTrackers.size())
-        emit trackerlessStateChanged(torrent, false);
-    emit trackersChanged(torrent);
+        Q_EMIT trackerlessStateChanged(torrent, false);
+    Q_EMIT trackersChanged(torrent);
 }
 
 void Session::handleTorrentTrackersRemoved(TorrentImpl *const torrent, const QVector<TrackerEntry> &deletedTrackers)
 {
     for (const TrackerEntry &deletedTracker : deletedTrackers)
         LogMsg(tr("Tracker '%1' was deleted from torrent '%2'").arg(deletedTracker.url, torrent->name()));
-    emit trackersRemoved(torrent, deletedTrackers);
+    Q_EMIT trackersRemoved(torrent, deletedTrackers);
     if (torrent->trackers().empty())
-        emit trackerlessStateChanged(torrent, true);
-    emit trackersChanged(torrent);
+        Q_EMIT trackerlessStateChanged(torrent, true);
+    Q_EMIT trackersChanged(torrent);
 }
 
 void Session::handleTorrentTrackersChanged(TorrentImpl *const torrent)
 {
-    emit trackersChanged(torrent);
+    Q_EMIT trackersChanged(torrent);
 }
 
 void Session::handleTorrentUrlSeedsAdded(TorrentImpl *const torrent, const QVector<QUrl> &newUrlSeeds)
@@ -3907,27 +3907,27 @@ void Session::handleTorrentMetadataReceived(TorrentImpl *const torrent)
         exportTorrentFile(torrentInfo, torrentExportDirectory(), torrent->name());
     }
 
-    emit torrentMetadataReceived(torrent);
+    Q_EMIT torrentMetadataReceived(torrent);
 }
 
 void Session::handleTorrentPaused(TorrentImpl *const torrent)
 {
-    emit torrentPaused(torrent);
+    Q_EMIT torrentPaused(torrent);
 }
 
 void Session::handleTorrentResumed(TorrentImpl *const torrent)
 {
-    emit torrentResumed(torrent);
+    Q_EMIT torrentResumed(torrent);
 }
 
 void Session::handleTorrentChecked(TorrentImpl *const torrent)
 {
-    emit torrentFinishedChecking(torrent);
+    Q_EMIT torrentFinishedChecking(torrent);
 }
 
 void Session::handleTorrentFinished(TorrentImpl *const torrent)
 {
-    emit torrentFinished(torrent);
+    Q_EMIT torrentFinished(torrent);
 
     qDebug("Checking if the torrent contains torrent files to download");
     // Check if there are torrent files inside
@@ -3942,7 +3942,7 @@ void Session::handleTorrentFinished(TorrentImpl *const torrent)
             if (torrentInfo.isValid())
             {
                 qDebug("emitting recursiveTorrentDownloadPossible()");
-                emit recursiveTorrentDownloadPossible(torrent);
+                Q_EMIT recursiveTorrentDownloadPossible(torrent);
                 break;
             }
             else
@@ -3965,7 +3965,7 @@ void Session::handleTorrentFinished(TorrentImpl *const torrent)
     }
 
     if (!hasUnfinishedTorrents())
-        emit allTorrentsFinished();
+        Q_EMIT allTorrentsFinished();
 }
 
 void Session::handleTorrentResumeDataReady(TorrentImpl *const torrent, const LoadTorrentParams &data)
@@ -3977,12 +3977,12 @@ void Session::handleTorrentResumeDataReady(TorrentImpl *const torrent, const Loa
 
 void Session::handleTorrentTrackerReply(TorrentImpl *const torrent, const QString &trackerUrl)
 {
-    emit trackerSuccess(torrent, trackerUrl);
+    Q_EMIT trackerSuccess(torrent, trackerUrl);
 }
 
 void Session::handleTorrentTrackerError(TorrentImpl *const torrent, const QString &trackerUrl)
 {
-    emit trackerError(torrent, trackerUrl);
+    Q_EMIT trackerError(torrent, trackerUrl);
 }
 
 bool Session::addMoveTorrentStorageJob(TorrentImpl *torrent, const QString &newPath, const MoveStorageMode mode)
@@ -4086,7 +4086,7 @@ void Session::handleMoveTorrentStorageJobFinished()
 
 void Session::handleTorrentTrackerWarning(TorrentImpl *const torrent, const QString &trackerUrl)
 {
-    emit trackerWarning(torrent, trackerUrl);
+    Q_EMIT trackerWarning(torrent, trackerUrl);
 }
 
 bool Session::hasPerTorrentRatioLimit() const
@@ -4292,7 +4292,7 @@ void Session::handleIPFilterParsed(const int ruleCount)
         m_nativeSession->set_ip_filter(filter);
     }
     LogMsg(tr("Successfully parsed the provided IP filter: %1 rules were applied.", "%1 is a number").arg(ruleCount));
-    emit IPFilterParsed(false, ruleCount);
+    Q_EMIT IPFilterParsed(false, ruleCount);
 }
 
 void Session::handleIPFilterError()
@@ -4302,7 +4302,7 @@ void Session::handleIPFilterError()
     m_nativeSession->set_ip_filter(filter);
 
     LogMsg(tr("Error: Failed to parse the provided IP filter."), Log::CRITICAL);
-    emit IPFilterParsed(true, 0);
+    Q_EMIT IPFilterParsed(true, 0);
 }
 
 std::vector<lt::alert *> Session::getPendingAlerts(const lt::time_duration time) const
@@ -4487,10 +4487,10 @@ void Session::createTorrent(const lt::torrent_handle &nativeHandle)
         m_seedingLimitTimer->start();
 
     // Send torrent addition signal
-    emit torrentLoaded(torrent);
+    Q_EMIT torrentLoaded(torrent);
     // Send new torrent signal
     if (!params.restored)
-        emit torrentAdded(torrent);
+        Q_EMIT torrentAdded(torrent);
 
     // Torrent could have error just after adding to libtorrent
     if (torrent->hasError())
@@ -4503,7 +4503,7 @@ void Session::handleAddTorrentAlert(const lt::add_torrent_alert *p)
     {
         const QString msg = QString::fromStdString(p->message());
         LogMsg(tr("Couldn't load torrent. Reason: %1.").arg(msg), Log::WARNING);
-        emit loadTorrentFailed(msg);
+        Q_EMIT loadTorrentFailed(msg);
 
         const lt::add_torrent_params &params = p->params;
         const bool hasMetadata = (params.ti && params.ti->is_valid());
@@ -4606,7 +4606,7 @@ void Session::handleMetadataReceivedAlert(const lt::metadata_received_alert *p)
         adjustLimits();
         m_nativeSession->remove_torrent(p->handle, lt::session::delete_files);
 
-        emit metadataDownloaded(metadata);
+        Q_EMIT metadataDownloaded(metadata);
     }
 }
 
@@ -4627,7 +4627,7 @@ void Session::handleFileErrorAlert(const lt::file_error_alert *p)
         LogMsg(tr("File error alert. Torrent: \"%1\". File: \"%2\". Reason: %3")
                 .arg(torrent->name(), p->filename(), msg)
             , Log::WARNING);
-        emit fullDiskError(torrent, msg);
+        Q_EMIT fullDiskError(torrent, msg);
     }
 
     m_recentErroredTorrentsTimer->start();
@@ -4803,7 +4803,7 @@ void Session::handleSessionStatsAlert(const lt::session_stats_alert *p)
     m_cacheStatus.averageJobTime = (totalJobs > 0)
                                    ? (stats[m_metricIndices.disk.diskJobTime] / totalJobs) : 0;
 
-    emit statsUpdated();
+    Q_EMIT statsUpdated();
 
     if (m_refreshEnqueued)
         m_refreshEnqueued = false;
@@ -4884,7 +4884,7 @@ void Session::handleStateUpdateAlert(const lt::state_update_alert *p)
     }
 
     if (!updatedTorrents.isEmpty())
-        emit torrentsUpdated(updatedTorrents);
+        Q_EMIT torrentsUpdated(updatedTorrents);
 
     if (m_refreshEnqueued)
         m_refreshEnqueued = false;

--- a/src/base/bittorrent/torrentcreatorthread.cpp
+++ b/src/base/bittorrent/torrentcreatorthread.cpp
@@ -93,7 +93,7 @@ void TorrentCreatorThread::create(const TorrentCreatorParams &params)
 
 void TorrentCreatorThread::sendProgressSignal(int currentPieceIdx, int totalPieces)
 {
-    emit updateProgress(static_cast<int>((currentPieceIdx * 100.) / totalPieces));
+    Q_EMIT updateProgress(static_cast<int>((currentPieceIdx * 100.) / totalPieces));
 }
 
 void TorrentCreatorThread::checkInterruptionRequested() const
@@ -104,7 +104,7 @@ void TorrentCreatorThread::checkInterruptionRequested() const
 
 void TorrentCreatorThread::run()
 {
-    emit updateProgress(0);
+    Q_EMIT updateProgress(0);
 
     try
     {
@@ -211,16 +211,16 @@ void TorrentCreatorThread::run()
         if (!result)
             throw RuntimeError(result.error());
 
-        emit updateProgress(100);
-        emit creationSuccess(m_params.savePath, parentPath);
+        Q_EMIT updateProgress(100);
+        Q_EMIT creationSuccess(m_params.savePath, parentPath);
     }
     catch (const RuntimeError &err)
     {
-        emit creationFailure(tr("Create new torrent file failed. Reason: %1.").arg(err.message()));
+        Q_EMIT creationFailure(tr("Create new torrent file failed. Reason: %1.").arg(err.message()));
     }
     catch (const std::exception &err)
     {
-        emit creationFailure(tr("Create new torrent file failed. Reason: %1.").arg(QString::fromLocal8Bit(err.what())));
+        Q_EMIT creationFailure(tr("Create new torrent file failed. Reason: %1.").arg(QString::fromLocal8Bit(err.what())));
     }
 }
 

--- a/src/base/logger.cpp
+++ b/src/base/logger.cpp
@@ -77,7 +77,7 @@ void Logger::addMessage(const QString &message, const Log::MsgType &type)
     m_messages.push_back(msg);
     locker.unlock();
 
-    emit newLogMessage(msg);
+    Q_EMIT newLogMessage(msg);
 }
 
 void Logger::addPeer(const QString &ip, const bool blocked, const QString &reason)
@@ -87,7 +87,7 @@ void Logger::addPeer(const QString &ip, const bool blocked, const QString &reaso
     m_peers.push_back(msg);
     locker.unlock();
 
-    emit newLogPeer(msg);
+    Q_EMIT newLogPeer(msg);
 }
 
 QVector<Log::Msg> Logger::getMessages(const int lastKnownId) const

--- a/src/base/net/downloadhandlerimpl.cpp
+++ b/src/base/net/downloadhandlerimpl.cpp
@@ -213,7 +213,7 @@ void DownloadHandlerImpl::setError(const QString &error)
 
 void DownloadHandlerImpl::finish()
 {
-    emit finished(m_result);
+    Q_EMIT finished(m_result);
 }
 
 QString DownloadHandlerImpl::errorCodeToString(const QNetworkReply::NetworkError status)

--- a/src/base/net/proxyconfigurationmanager.cpp
+++ b/src/base/net/proxyconfigurationmanager.cpp
@@ -110,7 +110,7 @@ void ProxyConfigurationManager::setProxyConfiguration(const ProxyConfiguration &
         settings()->storeValue(KEY_PASSWORD, config.password);
         configureProxy();
 
-        emit proxyConfigurationChanged();
+        Q_EMIT proxyConfigurationChanged();
     }
 }
 

--- a/src/base/net/reverseresolution.cpp
+++ b/src/base/net/reverseresolution.cpp
@@ -61,7 +61,7 @@ void ReverseResolution::resolve(const QHostAddress &ip)
     const QString *hostname = m_cache.object(ip);
     if (hostname)
     {
-        emit ipResolved(ip, *hostname);
+        Q_EMIT ipResolved(ip, *hostname);
         return;
     }
 
@@ -76,7 +76,7 @@ void ReverseResolution::hostResolved(const QHostInfo &host)
 
     if (host.error() != QHostInfo::NoError)
     {
-        emit ipResolved(ip, {});
+        Q_EMIT ipResolved(ip, {});
         return;
     }
 
@@ -84,5 +84,5 @@ void ReverseResolution::hostResolved(const QHostInfo &host)
         ? host.hostName()
         : QString();
     m_cache.insert(ip, new QString(hostname));
-    emit ipResolved(ip, hostname);
+    Q_EMIT ipResolved(ip, hostname);
 }

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -1587,5 +1587,5 @@ void Preferences::setSpeedWidgetGraphEnable(const int id, const bool enable)
 void Preferences::apply()
 {
     if (SettingsStorage::instance()->save())
-        emit changed();
+        Q_EMIT changed();
 }

--- a/src/base/rss/rss_article.cpp
+++ b/src/base/rss/rss_article.cpp
@@ -130,7 +130,7 @@ void Article::markAsRead()
     {
         m_isRead = true;
         m_data[KeyIsRead] = m_isRead;
-        emit read(this);
+        Q_EMIT read(this);
     }
 }
 

--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -182,7 +182,7 @@ void AutoDownloader::insertRule(const AutoDownloadRule &rule)
         setRule_impl(rule);
         m_dirty = true;
         store();
-        emit ruleAdded(rule.name());
+        Q_EMIT ruleAdded(rule.name());
         resetProcessingQueue();
     }
     else if (ruleByName(rule.name()) != rule)
@@ -191,7 +191,7 @@ void AutoDownloader::insertRule(const AutoDownloadRule &rule)
         setRule_impl(rule);
         m_dirty = true;
         storeDeferred();
-        emit ruleChanged(rule.name());
+        Q_EMIT ruleChanged(rule.name());
         resetProcessingQueue();
     }
 }
@@ -206,7 +206,7 @@ bool AutoDownloader::renameRule(const QString &ruleName, const QString &newRuleN
     m_rules.insert(newRuleName, rule);
     m_dirty = true;
     store();
-    emit ruleRenamed(newRuleName, ruleName);
+    Q_EMIT ruleRenamed(newRuleName, ruleName);
     return true;
 }
 
@@ -214,7 +214,7 @@ void AutoDownloader::removeRule(const QString &ruleName)
 {
     if (m_rules.contains(ruleName))
     {
-        emit ruleAboutToBeRemoved(ruleName);
+        Q_EMIT ruleAboutToBeRemoved(ruleName);
         m_rules.remove(ruleName);
         m_dirty = true;
         store();
@@ -517,7 +517,7 @@ void AutoDownloader::setProcessingEnabled(const bool enabled)
             disconnect(Session::instance()->rootFolder(), &Folder::newArticle, this, &AutoDownloader::handleNewArticle);
         }
 
-        emit processingStateChanged(m_processingEnabled);
+        Q_EMIT processingStateChanged(m_processingEnabled);
     }
 }
 

--- a/src/base/rss/rss_feed.cpp
+++ b/src/base/rss/rss_feed.cpp
@@ -98,7 +98,7 @@ Feed::Feed(const QUuid &uid, const QString &url, const QString &path, Session *s
 
 Feed::~Feed()
 {
-    emit aboutToBeDestroyed(this);
+    Q_EMIT aboutToBeDestroyed(this);
 }
 
 QList<Article *> Feed::articles() const
@@ -116,7 +116,7 @@ void Feed::markAsRead()
             article->disconnect(this);
             article->markAsRead();
             --m_unreadCount;
-            emit articleRead(article);
+            Q_EMIT articleRead(article);
         }
     }
 
@@ -124,7 +124,7 @@ void Feed::markAsRead()
     {
         m_dirty = true;
         store();
-        emit unreadCountChanged(this);
+        Q_EMIT unreadCountChanged(this);
     }
 }
 
@@ -142,7 +142,7 @@ void Feed::refresh()
         downloadIcon();
 
     m_isLoading = true;
-    emit stateChanged(this);
+    Q_EMIT stateChanged(this);
 }
 
 QUuid Feed::uid() const
@@ -191,7 +191,7 @@ void Feed::handleIconDownloadFinished(const Net::DownloadResult &result)
 {
     if (result.status == Net::DownloadStatus::Success)
     {
-        emit iconLoaded(this);
+        Q_EMIT iconLoaded(this);
     }
 }
 
@@ -219,7 +219,7 @@ void Feed::handleDownloadFinished(const Net::DownloadResult &result)
         LogMsg(tr("Failed to download RSS feed at '%1'. Reason: %2")
                .arg(result.url, result.errorString), Log::WARNING);
 
-        emit stateChanged(this);
+        Q_EMIT stateChanged(this);
     }
 }
 
@@ -231,7 +231,7 @@ void Feed::handleParsingFinished(const RSS::Private::ParsingResult &result)
     {
         m_title = result.title;
         m_dirty = true;
-        emit titleChanged(this);
+        Q_EMIT titleChanged(this);
     }
 
     if (!result.lastBuildDate.isEmpty())
@@ -256,7 +256,7 @@ void Feed::handleParsingFinished(const RSS::Private::ParsingResult &result)
            .arg(url(), QString::number(newArticlesCount)));
 
     m_isLoading = false;
-    emit stateChanged(this);
+    Q_EMIT stateChanged(this);
 }
 
 void Feed::load()
@@ -384,7 +384,7 @@ bool Feed::addArticle(Article *article)
     }
 
     m_dirty = true;
-    emit newArticle(article);
+    Q_EMIT newArticle(article);
 
     if (m_articlesByDate.size() > maxArticles)
         removeOldestArticle();
@@ -395,7 +395,7 @@ bool Feed::addArticle(Article *article)
 void Feed::removeOldestArticle()
 {
     auto oldestArticle = m_articlesByDate.last();
-    emit articleAboutToBeRemoved(oldestArticle);
+    Q_EMIT articleAboutToBeRemoved(oldestArticle);
 
     m_articles.remove(oldestArticle->guid());
     m_articlesByDate.removeLast();
@@ -409,7 +409,7 @@ void Feed::removeOldestArticle()
 void Feed::increaseUnreadCount()
 {
     ++m_unreadCount;
-    emit unreadCountChanged(this);
+    Q_EMIT unreadCountChanged(this);
 }
 
 void Feed::decreaseUnreadCount()
@@ -417,7 +417,7 @@ void Feed::decreaseUnreadCount()
     Q_ASSERT(m_unreadCount > 0);
 
     --m_unreadCount;
-    emit unreadCountChanged(this);
+    Q_EMIT unreadCountChanged(this);
 }
 
 void Feed::downloadIcon()
@@ -540,7 +540,7 @@ void Feed::handleArticleRead(Article *article)
 {
     article->disconnect(this);
     decreaseUnreadCount();
-    emit articleRead(article);
+    Q_EMIT articleRead(article);
     // will be stored deferred
     m_dirty = true;
     storeDeferred();

--- a/src/base/rss/rss_folder.cpp
+++ b/src/base/rss/rss_folder.cpp
@@ -47,7 +47,7 @@ Folder::Folder(const QString &path)
 
 Folder::~Folder()
 {
-    emit aboutToBeDestroyed(this);
+    Q_EMIT aboutToBeDestroyed(this);
 
     for (auto item : asConst(items()))
         delete item;
@@ -107,7 +107,7 @@ QJsonValue Folder::toJsonValue(bool withData) const
 
 void Folder::handleItemUnreadCountChanged()
 {
-    emit unreadCountChanged(this);
+    Q_EMIT unreadCountChanged(this);
 }
 
 void Folder::cleanup()
@@ -128,10 +128,10 @@ void Folder::addItem(Item *item)
     connect(item, &Item::unreadCountChanged, this, &Folder::handleItemUnreadCountChanged);
 
     for (auto article : asConst(item->articles()))
-        emit newArticle(article);
+        Q_EMIT newArticle(article);
 
     if (item->unreadCount() > 0)
-        emit unreadCountChanged(this);
+        Q_EMIT unreadCountChanged(this);
 }
 
 void Folder::removeItem(Item *item)
@@ -139,10 +139,10 @@ void Folder::removeItem(Item *item)
     Q_ASSERT(m_items.contains(item));
 
     for (auto article : asConst(item->articles()))
-        emit articleAboutToBeRemoved(article);
+        Q_EMIT articleAboutToBeRemoved(article);
 
     item->disconnect(this);
     m_items.removeOne(item);
     if (item->unreadCount() > 0)
-        emit unreadCountChanged(this);
+        Q_EMIT unreadCountChanged(this);
 }

--- a/src/base/rss/rss_item.cpp
+++ b/src/base/rss/rss_item.cpp
@@ -50,7 +50,7 @@ void Item::setPath(const QString &path)
     if (path != m_path)
     {
         m_path = path;
-        emit pathChanged(this);
+        Q_EMIT pathChanged(this);
     }
 }
 

--- a/src/base/rss/rss_parser.cpp
+++ b/src/base/rss/rss_parser.cpp
@@ -602,7 +602,7 @@ void Parser::parse_impl(const QByteArray &feedData)
                 .arg(xml.columnNumber()).arg(xml.characterOffset());
     }
 
-    emit finished(m_result);
+    Q_EMIT finished(m_result);
     m_result.articles.clear(); // clear articles only
     m_articleIDs.clear();
 }

--- a/src/base/rss/rss_session.cpp
+++ b/src/base/rss/rss_session.cpp
@@ -231,7 +231,7 @@ bool Session::removeItem(const QString &itemPath, QString *error)
         return false;
     }
 
-    emit itemAboutToBeRemoved(item);
+    Q_EMIT itemAboutToBeRemoved(item);
     item->cleanup();
 
     auto folder = static_cast<Folder *>(m_itemsByPath.value(Item::parentPath(item->path())));
@@ -452,7 +452,7 @@ void Session::addItem(Item *item, Folder *destFolder)
     connect(item, &Item::aboutToBeDestroyed, this, &Session::handleItemAboutToBeDestroyed);
     m_itemsByPath[item->path()] = item;
     destFolder->addItem(item);
-    emit itemAdded(item);
+    Q_EMIT itemAdded(item);
 }
 
 bool Session::isProcessingEnabled() const
@@ -476,7 +476,7 @@ void Session::setProcessingEnabled(bool enabled)
             m_refreshTimer.stop();
         }
 
-        emit processingStateChanged(m_processingEnabled);
+        Q_EMIT processingStateChanged(m_processingEnabled);
     }
 }
 
@@ -564,7 +564,7 @@ void Session::setMaxArticlesPerFeed(const int n)
     {
         m_maxArticlesPerFeed = n;
         SettingsStorage::instance()->storeValue(SettingsKey_MaxArticlesPerFeed, n);
-        emit maxArticlesPerFeedChanged(n);
+        Q_EMIT maxArticlesPerFeedChanged(n);
     }
 }
 

--- a/src/base/search/searchdownloadhandler.cpp
+++ b/src/base/search/searchdownloadhandler.cpp
@@ -64,5 +64,5 @@ void SearchDownloadHandler::downloadProcessFinished(int exitcode)
             path = parts[0].toString();
     }
 
-    emit downloadFinished(path);
+    Q_EMIT downloadFinished(path);
 }

--- a/src/base/search/searchhandler.cpp
+++ b/src/base/search/searchhandler.cpp
@@ -116,11 +116,11 @@ void SearchHandler::processFinished(const int exitcode)
     m_searchTimeout->stop();
 
     if (m_searchCancelled)
-        emit searchFinished(true);
+        Q_EMIT searchFinished(true);
     else if ((m_searchProcess->exitStatus() == QProcess::NormalExit) && (exitcode == 0))
-        emit searchFinished(false);
+        Q_EMIT searchFinished(false);
     else
-        emit searchFailed();
+        Q_EMIT searchFailed();
 }
 
 // search QProcess return output as soon as it gets new
@@ -150,14 +150,14 @@ void SearchHandler::readSearchOutput()
     {
         for (const SearchResult &result : searchResultList)
             m_results.append(result);
-        emit newSearchResults(searchResultList);
+        Q_EMIT newSearchResults(searchResultList);
     }
 }
 
 void SearchHandler::processFailed()
 {
     if (!m_searchCancelled)
-        emit searchFailed();
+        Q_EMIT searchFailed();
 }
 
 // Parse one line of search results list

--- a/src/base/search/searchpluginmanager.cpp
+++ b/src/base/search/searchpluginmanager.cpp
@@ -187,7 +187,7 @@ void SearchPluginManager::enablePlugin(const QString &name, const bool enabled)
             disabledPlugins.append(name);
         pref->setSearchEngDisabled(disabledPlugins);
 
-        emit pluginEnabled(name, enabled);
+        Q_EMIT pluginEnabled(name, enabled);
     }
 }
 
@@ -218,7 +218,7 @@ void SearchPluginManager::installPlugin(const QString &source)
         pluginName.chop(pluginName.size() - pluginName.lastIndexOf('.'));
 
         if (!path.endsWith(".py", Qt::CaseInsensitive))
-            emit pluginInstallationFailed(pluginName, tr("Unknown search engine plugin file format."));
+            Q_EMIT pluginInstallationFailed(pluginName, tr("Unknown search engine plugin file format."));
         else
             installPlugin_impl(pluginName, path);
     }
@@ -231,7 +231,7 @@ void SearchPluginManager::installPlugin_impl(const QString &name, const QString 
     if (plugin && !(plugin->version < newVersion))
     {
         LogMsg(tr("Plugin already at version %1, which is greater than %2").arg(plugin->version, newVersion), Log::INFO);
-        emit pluginUpdateFailed(name, tr("A more recent version of this plugin is already installed."));
+        Q_EMIT pluginUpdateFailed(name, tr("A more recent version of this plugin is already installed."));
         return;
     }
 
@@ -262,11 +262,11 @@ void SearchPluginManager::installPlugin_impl(const QString &name, const QString 
             Utils::Fs::forceRemove(destPath + ".bak");
             // Update supported plugins
             update();
-            emit pluginUpdateFailed(name, tr("Plugin is not supported."));
+            Q_EMIT pluginUpdateFailed(name, tr("Plugin is not supported."));
         }
         else
         {
-            emit pluginInstallationFailed(name, tr("Plugin is not supported."));
+            Q_EMIT pluginInstallationFailed(name, tr("Plugin is not supported."));
         }
     }
     else
@@ -294,7 +294,7 @@ bool SearchPluginManager::uninstallPlugin(const QString &name)
     // Remove it from supported engines
     delete m_plugins.take(name);
 
-    emit pluginUninstalled(name);
+    Q_EMIT pluginUninstalled(name);
     return true;
 }
 
@@ -381,7 +381,7 @@ void SearchPluginManager::versionInfoDownloadFinished(const Net::DownloadResult 
     if (result.status == Net::DownloadStatus::Success)
         parseVersionInfo(result.data);
     else
-        emit checkForUpdatesFailed(tr("Update server is temporarily unavailable. %1").arg(result.errorString));
+        Q_EMIT checkForUpdatesFailed(tr("Update server is temporarily unavailable. %1").arg(result.errorString));
 }
 
 void SearchPluginManager::pluginDownloadFinished(const Net::DownloadResult &result)
@@ -402,9 +402,9 @@ void SearchPluginManager::pluginDownloadFinished(const Net::DownloadResult &resu
         pluginName.replace(".py", "", Qt::CaseInsensitive);
 
         if (pluginInfo(pluginName))
-            emit pluginUpdateFailed(pluginName, tr("Failed to download the plugin file. %1").arg(result.errorString));
+            Q_EMIT pluginUpdateFailed(pluginName, tr("Failed to download the plugin file. %1").arg(result.errorString));
         else
-            emit pluginInstallationFailed(pluginName, tr("Failed to download the plugin file. %1").arg(result.errorString));
+            Q_EMIT pluginInstallationFailed(pluginName, tr("Failed to download the plugin file. %1").arg(result.errorString));
     }
 }
 
@@ -499,13 +499,13 @@ void SearchPluginManager::update()
             if (!m_plugins.contains(pluginName))
             {
                 m_plugins[pluginName] = plugin.release();
-                emit pluginInstalled(pluginName);
+                Q_EMIT pluginInstalled(pluginName);
             }
             else if (m_plugins[pluginName]->version != plugin->version)
             {
                 delete m_plugins.take(pluginName);
                 m_plugins[pluginName] = plugin.release();
-                emit pluginUpdated(pluginName);
+                Q_EMIT pluginUpdated(pluginName);
             }
         }
     }
@@ -541,12 +541,12 @@ void SearchPluginManager::parseVersionInfo(const QByteArray &info)
 
     if (numCorrectData < lines.size())
     {
-        emit checkForUpdatesFailed(tr("Incorrect update info received for %1 out of %2 plugins.")
+        Q_EMIT checkForUpdatesFailed(tr("Incorrect update info received for %1 out of %2 plugins.")
             .arg(QString::number(lines.size() - numCorrectData), QString::number(lines.size())));
     }
     else
     {
-        emit checkForUpdatesFinished(updateInfo);
+        Q_EMIT checkForUpdatesFinished(updateInfo);
     }
 }
 

--- a/src/base/torrentfileswatcher.cpp
+++ b/src/base/torrentfileswatcher.cpp
@@ -404,7 +404,7 @@ void TorrentFilesWatcher::doSetWatchedFolder(const QString &path, const WatchedF
         m_asyncWorker->setWatchedFolder(path, options);
     });
 
-    emit watchedFolderSet(cleanPath, options);
+    Q_EMIT watchedFolderSet(cleanPath, options);
 }
 
 void TorrentFilesWatcher::removeWatchedFolder(const QString &path)
@@ -417,7 +417,7 @@ void TorrentFilesWatcher::removeWatchedFolder(const QString &path)
             m_asyncWorker->removeWatchedFolder(cleanPath);
         });
 
-        emit watchedFolderRemoved(cleanPath);
+        Q_EMIT watchedFolderRemoved(cleanPath);
 
         store();
     }
@@ -514,7 +514,7 @@ void TorrentFilesWatcher::Worker::processFolder(const QString &path, const QStri
             {
                 QTextStream str {&file};
                 while (!str.atEnd())
-                    emit magnetFound(BitTorrent::MagnetUri(str.readLine()), addTorrentParams);
+                    Q_EMIT magnetFound(BitTorrent::MagnetUri(str.readLine()), addTorrentParams);
 
                 file.close();
                 Utils::Fs::forceRemove(filePath);
@@ -529,7 +529,7 @@ void TorrentFilesWatcher::Worker::processFolder(const QString &path, const QStri
             const auto torrentInfo = BitTorrent::TorrentInfo::loadFromFile(filePath);
             if (torrentInfo.isValid())
             {
-                emit torrentFound(torrentInfo, addTorrentParams);
+                Q_EMIT torrentFound(torrentInfo, addTorrentParams);
                 Utils::Fs::forceRemove(filePath);
             }
             else
@@ -578,7 +578,7 @@ void TorrentFilesWatcher::Worker::processFailedTorrents()
                     addTorrentParams.savePath = QDir(addTorrentParams.savePath).filePath(subdirPath);
                 }
 
-                emit torrentFound(torrentInfo, addTorrentParams);
+                Q_EMIT torrentFound(torrentInfo, addTorrentParams);
                 Utils::Fs::forceRemove(torrentPath);
 
                 return true;

--- a/src/gui/categoryfiltermodel.cpp
+++ b/src/gui/categoryfiltermodel.cpp
@@ -365,7 +365,7 @@ void CategoryFilterModel::torrentCategoryChanged(BitTorrent::Torrent *const torr
     i = index(item);
     while (i.isValid())
     {
-        emit dataChanged(i, i);
+        Q_EMIT dataChanged(i, i);
         i = parent(i);
     }
 
@@ -376,7 +376,7 @@ void CategoryFilterModel::torrentCategoryChanged(BitTorrent::Torrent *const torr
     i = index(item);
     while (i.isValid())
     {
-        emit dataChanged(i, i);
+        Q_EMIT dataChanged(i, i);
         i = parent(i);
     }
 }

--- a/src/gui/categoryfilterwidget.cpp
+++ b/src/gui/categoryfilterwidget.cpp
@@ -101,7 +101,7 @@ void CategoryFilterWidget::onCurrentRowChanged(const QModelIndex &current, const
 {
     Q_UNUSED(previous);
 
-    emit categoryChanged(getCategoryFilter(static_cast<CategoryFilterProxyModel *>(model()), current));
+    Q_EMIT categoryChanged(getCategoryFilter(static_cast<CategoryFilterProxyModel *>(model()), current));
 }
 
 void CategoryFilterWidget::showMenu(const QPoint &)

--- a/src/gui/cookiesmodel.cpp
+++ b/src/gui/cookiesmodel.cpp
@@ -140,7 +140,7 @@ bool CookiesModel::setData(const QModelIndex &index, const QVariant &value, int 
         return false;
     }
 
-    emit dataChanged(index, index);
+    Q_EMIT dataChanged(index, index);
     return true;
 }
 

--- a/src/gui/downloadfromurldialog.cpp
+++ b/src/gui/downloadfromurldialog.cpp
@@ -124,6 +124,6 @@ void DownloadFromURLDialog::downloadButtonClicked()
         return;
     }
 
-    emit urlsReadyToBeDownloaded(uniqueURLs.values());
+    Q_EMIT urlsReadyToBeDownloaded(uniqueURLs.values());
     accept();
 }

--- a/src/gui/fspathedit.cpp
+++ b/src/gui/fspathedit.cpp
@@ -265,7 +265,7 @@ void FileSystemPathEdit::onPathEdited()
     QString newPath = selectedPath();
     if (newPath != d->m_lastSignaledPath)
     {
-        emit selectedPathChanged(newPath);
+        Q_EMIT selectedPathChanged(newPath);
         d->m_lastSignaledPath = newPath;
         d->m_editor->widget()->setToolTip(editWidgetText());
     }

--- a/src/gui/previewselectdialog.cpp
+++ b/src/gui/previewselectdialog.cpp
@@ -139,7 +139,7 @@ void PreviewSelectDialog::previewButtonClicked()
         return;
     }
 
-    emit readyToPreviewFile(path);
+    Q_EMIT readyToPreviewFile(path);
     accept();
 }
 

--- a/src/gui/programupdater.cpp
+++ b/src/gui/programupdater.cpp
@@ -93,7 +93,7 @@ void ProgramUpdater::rssDownloadFinished(const Net::DownloadResult &result)
     if (result.status != Net::DownloadStatus::Success)
     {
         qDebug() << "Downloading the new qBittorrent updates RSS failed:" << result.errorString;
-        emit updateCheckFinished();
+        Q_EMIT updateCheckFinished();
         return;
     }
 
@@ -163,7 +163,7 @@ void ProgramUpdater::rssDownloadFinished(const Net::DownloadResult &result)
         }
     }
 
-    emit updateCheckFinished();
+    Q_EMIT updateCheckFinished();
 }
 
 bool ProgramUpdater::updateProgram() const

--- a/src/gui/properties/proplistdelegate.cpp
+++ b/src/gui/properties/proplistdelegate.cpp
@@ -110,7 +110,7 @@ void PropListDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, 
     }
 
     model->setData(index, static_cast<int>(prio));
-    emit filteredFilesChanged();
+    Q_EMIT filteredFilesChanged();
 }
 
 void PropListDelegate::updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &) const

--- a/src/gui/properties/proptabbar.cpp
+++ b/src/gui/properties/proptabbar.cpp
@@ -123,7 +123,7 @@ void PropTabBar::setCurrentIndex(int index)
         {
           m_btnGroup->button(m_currentIndex)->setDown(false);
           m_currentIndex = -1;
-          emit visibilityToggled(false);
+          Q_EMIT visibilityToggled(false);
         }
         return;
     }
@@ -135,11 +135,11 @@ void PropTabBar::setCurrentIndex(int index)
     else
     {
         // Nothing was selected, show!
-        emit visibilityToggled(true);
+        Q_EMIT visibilityToggled(true);
     }
     // Select the new button
     m_btnGroup->button(index)->setDown(true);
     m_currentIndex = index;
     // Emit the signal
-    emit tabChanged(index);
+    Q_EMIT tabChanged(index);
 }

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -565,5 +565,5 @@ void RSSWidget::handleSessionProcessingStateChanged(bool enabled)
 
 void RSSWidget::handleUnreadCountChanged()
 {
-    emit unreadCountUpdated(RSS::Session::instance()->rootFolder()->unreadCount());
+    Q_EMIT unreadCountUpdated(RSS::Session::instance()->rootFolder()->unreadCount());
 }

--- a/src/gui/search/pluginsourcedialog.cpp
+++ b/src/gui/search/pluginsourcedialog.cpp
@@ -53,12 +53,12 @@ PluginSourceDialog::~PluginSourceDialog()
 
 void PluginSourceDialog::on_localButton_clicked()
 {
-    emit askForLocalFile();
+    Q_EMIT askForLocalFile();
     close();
 }
 
 void PluginSourceDialog::on_urlButton_clicked()
 {
-    emit askForUrl();
+    Q_EMIT askForUrl();
     close();
 }

--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -268,7 +268,7 @@ void SearchJobWidget::setStatus(Status value)
 
     m_status = value;
     setStatusTip(statusText(value));
-    emit statusChanged();
+    Q_EMIT statusChanged();
 }
 
 void SearchJobWidget::downloadTorrent(const QModelIndex &rowIndex)
@@ -309,7 +309,7 @@ void SearchJobWidget::updateResultsCount()
                               .arg(filteredResults).arg(totalResults));
 
     m_noSearchResults = (totalResults == 0);
-    emit resultsCountUpdated();
+    Q_EMIT resultsCountUpdated();
 }
 
 void SearchJobWidget::updateFilter()

--- a/src/gui/tagfiltermodel.cpp
+++ b/src/gui/tagfiltermodel.cpp
@@ -213,7 +213,7 @@ void TagFilterModel::torrentTagAdded(BitTorrent::Torrent *const torrent, const Q
 
     item.increaseTorrentsCount();
     const QModelIndex i = index(row, 0, QModelIndex());
-    emit dataChanged(i, i);
+    Q_EMIT dataChanged(i, i);
 }
 
 void TagFilterModel::torrentTagRemoved(BitTorrent::Torrent *const torrent, const QString &tag)
@@ -228,7 +228,7 @@ void TagFilterModel::torrentTagRemoved(BitTorrent::Torrent *const torrent, const
     m_tagItems[row].decreaseTorrentsCount();
 
     const QModelIndex i = index(row, 0, QModelIndex());
-    emit dataChanged(i, i);
+    Q_EMIT dataChanged(i, i);
 }
 
 void TagFilterModel::torrentAdded(BitTorrent::Torrent *const torrent)

--- a/src/gui/tagfilterwidget.cpp
+++ b/src/gui/tagfilterwidget.cpp
@@ -99,7 +99,7 @@ void TagFilterWidget::onCurrentRowChanged(const QModelIndex &current, const QMod
 {
     Q_UNUSED(previous);
 
-    emit tagChanged(getTagFilter(static_cast<TagFilterProxyModel *>(model()), current));
+    Q_EMIT tagChanged(getTagFilter(static_cast<TagFilterProxyModel *>(model()), current));
 }
 
 void TagFilterWidget::showMenu(QPoint)

--- a/src/gui/torrentcontentfiltermodel.cpp
+++ b/src/gui/torrentcontentfiltermodel.cpp
@@ -112,7 +112,7 @@ void TorrentContentFilterModel::selectAll()
     for (int i = 0; i < rowCount(); ++i)
         setData(index(i, 0), Qt::Checked, Qt::CheckStateRole);
 
-    emit dataChanged(index(0, 0), index((rowCount() - 1), (columnCount() - 1)));
+    Q_EMIT dataChanged(index(0, 0), index((rowCount() - 1), (columnCount() - 1)));
 }
 
 void TorrentContentFilterModel::selectNone()
@@ -120,7 +120,7 @@ void TorrentContentFilterModel::selectNone()
     for (int i = 0; i < rowCount(); ++i)
         setData(index(i, 0), Qt::Unchecked, Qt::CheckStateRole);
 
-    emit dataChanged(index(0, 0), index((rowCount() - 1), (columnCount() - 1)));
+    Q_EMIT dataChanged(index(0, 0), index((rowCount() - 1), (columnCount() - 1)));
 }
 
 bool TorrentContentFilterModel::hasFiltered(const QModelIndex &folder) const

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -214,13 +214,13 @@ void TorrentContentModel::updateFilesProgress(const QVector<qreal> &fp)
     // XXX: Why is this necessary?
     if (m_filesIndex.size() != fp.size()) return;
 
-    emit layoutAboutToBeChanged();
+    Q_EMIT layoutAboutToBeChanged();
     for (int i = 0; i < fp.size(); ++i)
         m_filesIndex[i]->setProgress(fp[i]);
     // Update folders progress in the tree
     m_rootItem->recalculateProgress();
     m_rootItem->recalculateAvailability();
-    emit dataChanged(index(0, 0), index((rowCount() - 1), (columnCount() - 1)));
+    Q_EMIT dataChanged(index(0, 0), index((rowCount() - 1), (columnCount() - 1)));
 }
 
 void TorrentContentModel::updateFilesPriorities(const QVector<BitTorrent::DownloadPriority> &fprio)
@@ -230,10 +230,10 @@ void TorrentContentModel::updateFilesPriorities(const QVector<BitTorrent::Downlo
     if (m_filesIndex.size() != fprio.size())
         return;
 
-    emit layoutAboutToBeChanged();
+    Q_EMIT layoutAboutToBeChanged();
     for (int i = 0; i < fprio.size(); ++i)
         m_filesIndex[i]->setPriority(static_cast<BitTorrent::DownloadPriority>(fprio[i]));
-    emit dataChanged(index(0, 0), index((rowCount() - 1), (columnCount() - 1)));
+    Q_EMIT dataChanged(index(0, 0), index((rowCount() - 1), (columnCount() - 1)));
 }
 
 void TorrentContentModel::updateFilesAvailability(const QVector<qreal> &fa)
@@ -242,12 +242,12 @@ void TorrentContentModel::updateFilesAvailability(const QVector<qreal> &fa)
     // XXX: Why is this necessary?
     if (m_filesIndex.size() != fa.size()) return;
 
-    emit layoutAboutToBeChanged();
+    Q_EMIT layoutAboutToBeChanged();
     for (int i = 0; i < m_filesIndex.size(); ++i)
         m_filesIndex[i]->setAvailability(fa[i]);
     // Update folders progress in the tree
     m_rootItem->recalculateProgress();
-    emit dataChanged(index(0, 0), index((rowCount() - 1), (columnCount() - 1)));
+    Q_EMIT dataChanged(index(0, 0), index((rowCount() - 1), (columnCount() - 1)));
 }
 
 QVector<BitTorrent::DownloadPriority> TorrentContentModel::getFilePriorities() const
@@ -296,8 +296,8 @@ bool TorrentContentModel::setData(const QModelIndex &index, const QVariant &valu
             // Update folders progress in the tree
             m_rootItem->recalculateProgress();
             m_rootItem->recalculateAvailability();
-            emit dataChanged(this->index(0, 0), this->index((rowCount() - 1), (columnCount() - 1)));
-            emit filteredFilesChanged();
+            Q_EMIT dataChanged(this->index(0, 0), this->index((rowCount() - 1), (columnCount() - 1)));
+            Q_EMIT filteredFilesChanged();
         }
         return true;
     }
@@ -317,7 +317,7 @@ bool TorrentContentModel::setData(const QModelIndex &index, const QVariant &valu
         default:
             return false;
         }
-        emit dataChanged(index, index);
+        Q_EMIT dataChanged(index, index);
         return true;
     }
 
@@ -491,7 +491,7 @@ void TorrentContentModel::setupModelData(const BitTorrent::TorrentInfo &info)
     if (filesCount <= 0)
         return;
 
-    emit layoutAboutToBeChanged();
+    Q_EMIT layoutAboutToBeChanged();
     // Initialize files_index array
     qDebug("Torrent contains %d files", filesCount);
     m_filesIndex.reserve(filesCount);
@@ -524,7 +524,7 @@ void TorrentContentModel::setupModelData(const BitTorrent::TorrentInfo &info)
         currentParent->appendChild(fileItem);
         m_filesIndex.push_back(fileItem);
     }
-    emit layoutChanged();
+    Q_EMIT layoutChanged();
 }
 
 void TorrentContentModel::selectAll()
@@ -535,12 +535,12 @@ void TorrentContentModel::selectAll()
         if (child->priority() == BitTorrent::DownloadPriority::Ignored)
             child->setPriority(BitTorrent::DownloadPriority::Normal);
     }
-    emit dataChanged(index(0, 0), index((rowCount() - 1), (columnCount() - 1)));
+    Q_EMIT dataChanged(index(0, 0), index((rowCount() - 1), (columnCount() - 1)));
 }
 
 void TorrentContentModel::selectNone()
 {
     for (int i = 0; i < m_rootItem->childCount(); ++i)
         m_rootItem->child(i)->setPriority(BitTorrent::DownloadPriority::Ignored);
-    emit dataChanged(index(0, 0), index((rowCount() - 1), (columnCount() - 1)));
+    Q_EMIT dataChanged(index(0, 0), index((rowCount() - 1), (columnCount() - 1)));
 }

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -765,17 +765,17 @@ void TransferListFiltersWidget::changeTrackerless(const BitTorrent::Torrent *tor
 
 void TransferListFiltersWidget::trackerSuccess(const BitTorrent::Torrent *torrent, const QString &tracker)
 {
-    emit trackerSuccess(torrent->id(), tracker);
+    Q_EMIT trackerSuccess(torrent->id(), tracker);
 }
 
 void TransferListFiltersWidget::trackerWarning(const BitTorrent::Torrent *torrent, const QString &tracker)
 {
-    emit trackerWarning(torrent->id(), tracker);
+    Q_EMIT trackerWarning(torrent->id(), tracker);
 }
 
 void TransferListFiltersWidget::trackerError(const BitTorrent::Torrent *torrent, const QString &tracker)
 {
-    emit trackerError(torrent->id(), tracker);
+    Q_EMIT trackerError(torrent->id(), tracker);
 }
 
 void TransferListFiltersWidget::onCategoryFilterStateChanged(bool enabled)

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -613,7 +613,7 @@ void TransferListModel::handleTorrentStatusUpdated(BitTorrent::Torrent *const to
     const int row = m_torrentMap.value(torrent, -1);
     Q_ASSERT(row >= 0);
 
-    emit dataChanged(index(row, 0), index(row, columnCount() - 1));
+    Q_EMIT dataChanged(index(row, 0), index(row, columnCount() - 1));
 }
 
 void TransferListModel::handleTorrentsUpdated(const QVector<BitTorrent::Torrent *> &torrents)
@@ -627,13 +627,13 @@ void TransferListModel::handleTorrentsUpdated(const QVector<BitTorrent::Torrent 
             const int row = m_torrentMap.value(torrent, -1);
             Q_ASSERT(row >= 0);
 
-            emit dataChanged(index(row, 0), index(row, columns));
+            Q_EMIT dataChanged(index(row, 0), index(row, columns));
         }
     }
     else
     {
         // save the overhead when more than half of the torrent list needs update
-        emit dataChanged(index(0, 0), index((rowCount() - 1), columns));
+        Q_EMIT dataChanged(index(0, 0), index((rowCount() - 1), columns));
     }
 }
 
@@ -653,7 +653,7 @@ void TransferListModel::configure()
     if (m_hideZeroValuesMode != hideZeroValuesMode)
     {
         m_hideZeroValuesMode = hideZeroValuesMode;
-        emit dataChanged(index(0, 0), index((rowCount() - 1), (columnCount() - 1)));
+        Q_EMIT dataChanged(index(0, 0), index((rowCount() - 1), (columnCount() - 1)));
     }
 }
 

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -1141,7 +1141,7 @@ void TransferListWidget::currentChanged(const QModelIndex &current, const QModel
         // Scroll Fix
         scrollTo(current);
     }
-    emit currentTorrentChanged(torrent);
+    Q_EMIT currentTorrentChanged(torrent);
 }
 
 void TransferListWidget::applyCategoryFilter(const QString &category)

--- a/src/gui/tristatewidget.cpp
+++ b/src/gui/tristatewidget.cpp
@@ -113,7 +113,7 @@ void TriStateWidget::mouseReleaseEvent(QMouseEvent *event)
     {
         update();
         // need to emit `triggered` signal manually
-        emit triggered(m_checkState == Qt::Checked);
+        Q_EMIT triggered(m_checkState == Qt::Checked);
     }
 }
 
@@ -128,7 +128,7 @@ void TriStateWidget::keyPressEvent(QKeyEvent *event)
         {
             update();
             // need to emit parent `triggered` signal manually
-            emit triggered(m_checkState == Qt::Checked);
+            Q_EMIT triggered(m_checkState == Qt::Checked);
             return;
         }
     }

--- a/src/webui/api/freediskspacechecker.cpp
+++ b/src/webui/api/freediskspacechecker.cpp
@@ -34,5 +34,5 @@
 void FreeDiskSpaceChecker::check()
 {
     const qint64 freeDiskSpace = Utils::Fs::freeDiskSpaceOnPath(BitTorrent::Session::instance()->defaultSavePath());
-    emit checked(freeDiskSpace);
+    Q_EMIT checked(freeDiskSpace);
 }

--- a/src/webui/webui.cpp
+++ b/src/webui/webui.cpp
@@ -126,7 +126,7 @@ void WebUI::configure()
                 qCritical() << errorMsg;
 
                 m_isErrored = true;
-                emit fatalError();
+                Q_EMIT fatalError();
             }
         }
 


### PR DESCRIPTION
Keyword 'emit' will not be recognized in MSVC when using vcpkg.
The head file include order is not recognized by MSVC compiler. 

Provide a related page. But this pull request has nothing to do with OpenCV:
[OpenCV & QT: 'emit' undeclared identifier error | Qt Forum](https://forum.qt.io/topic/67949/opencv-qt-emit-undeclared-identifier-error)

I've tested out in VS2019. Changing emit to Q_EMIT fixed all the compiling issue using MSVC and vcpkg.
I've also avoid all the comment changes in this pull request.