### PR TITLE
Peerlist improvements

### DIFF
--- a/src/base/bittorrent/peerinfo.cpp
+++ b/src/base/bittorrent/peerinfo.cpp
@@ -263,6 +263,10 @@ void PeerInfo::determineFlags()
         m_flagsDescription += QString::fromLatin1("%1 = %2\n").arg(specifier, explanation);
     };
 
+    // C = is peer in connecting state, such peer don't get counted in Torrent::leechsCount
+    if (isConnecting())
+        updateFlags(QLatin1Char('C'), tr("Connecting"));
+
     if (isInteresting())
     {
         if (isRemoteChocked())

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -1108,7 +1108,7 @@ int TorrentImpl::leechsCount() const
 
 int TorrentImpl::totalSeedsCount() const
 {
-    return (m_nativeStatus.num_complete > 0) ? m_nativeStatus.num_complete : m_nativeStatus.list_seeds;
+    return qMax(m_nativeStatus.list_seeds, m_nativeStatus.num_complete);
 }
 
 int TorrentImpl::totalPeersCount() const
@@ -1119,7 +1119,7 @@ int TorrentImpl::totalPeersCount() const
 
 int TorrentImpl::totalLeechersCount() const
 {
-    return (m_nativeStatus.num_incomplete > 0) ? m_nativeStatus.num_incomplete : (m_nativeStatus.list_peers - m_nativeStatus.list_seeds);
+    return qMax(m_nativeStatus.list_peers - m_nativeStatus.list_seeds, m_nativeStatus.num_incomplete);
 }
 
 int TorrentImpl::completeCount() const

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -478,6 +478,12 @@ void PeerListWidget::updatePeer(const BitTorrent::Torrent *torrent, const BitTor
             m_listModel->setData(m_listModel->index(row, PeerListColumns::COUNTRY), countryName, Qt::ToolTipRole);
         }
     }
+
+    for (int col = 0; col < PeerListColumns::COL_COUNT; ++col)
+    {
+        if (auto item = m_listModel->item(row, col))
+            item->setEnabled(!peer.isConnecting());
+    }
 }
 
 void PeerListWidget::handleResolved(const QHostAddress &ip, const QString &hostname) const


### PR DESCRIPTION
- Revise peer statistics 
  num_* doesn't include peers from DHT and other likewise peer sources, so
also take list_* variable to calculate peer based stats

- Add 'connecting' flag to Peers

- Show connecting peer disabled in Peer list in GUI
  This is to avoid confusion as these peers don't get counted in
  Torrent::leechsCount but appear in the Peer list

reference https://github.com/qbittorrent/qBittorrent/issues/12575