### PR TITLE
Fix torrent content sorting

### DIFF
--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -524,8 +524,8 @@ void PropertiesWidget::loadDynamicData()
             m_ui->filesList->setUpdatesEnabled(false);
 
             // Load torrent content if not yet done so
-            const bool isContentInitialized = !m_propListModel->model()->hasIndex(0, 0);
-            if (isContentInitialized)
+            const bool isContentInitialized = m_propListModel->model()->hasIndex(0, 0);
+            if (!isContentInitialized)
             {
                 // List files in torrent
                 m_propListModel->model()->setupModelData(m_torrent->info());
@@ -539,7 +539,7 @@ void PropertiesWidget::loadDynamicData()
             m_propListModel->model()->updateFilesProgress(m_torrent->filesProgress());
             m_propListModel->model()->updateFilesAvailability(m_torrent->availableFileFractions());
 
-            if (isContentInitialized)
+            if (!isContentInitialized)
             {
                 // Expand single-item folders recursively.
                 // This will trigger sorting and filtering so do it after all relevant data is loaded.

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -368,6 +368,14 @@ void PropertiesWidget::loadTorrentInfos(BitTorrent::Torrent *const torrent)
 
         // Load file priorities
         m_propListModel->model()->updateFilesPriorities(m_torrent->filePriorities());
+
+        // Load progress and availability. loadDynamicData() will take care of it if "content" tab is
+        // visible and selected. Always load all data so that the files list can be sorted properly.
+        if (m_state != VISIBLE || m_ui->stackedProperties->currentIndex() != PropTabBar::FilesTab)
+        {
+            m_propListModel->model()->updateFilesProgress(m_torrent->filesProgress());
+            m_propListModel->model()->updateFilesAvailability(m_torrent->availableFileFractions());
+        }
     }
     // Load dynamic data
     loadDynamicData();

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -543,7 +543,9 @@ void PropertiesWidget::loadDynamicData()
                     currentIndex = m_propListModel->index(0, 0, currentIndex);
                     m_ui->filesList->setExpanded(currentIndex, true);
                 }
-            } else {
+            }
+            else
+            {
                 // Torrent content was loaded already, only make some updates
 
                 m_propListModel->model()->updateFilesProgress(m_torrent->filesProgress());

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -530,17 +530,11 @@ void PropertiesWidget::loadDynamicData()
                 // List files in torrent
                 m_propListModel->model()->setupModelData(m_torrent->info());
                 // Load file priorities
-                // XXX: We don't update file priorities regularly for performance
-                // reasons. This means that priorities will not be updated if
-                // set from the Web UI.
                 m_propListModel->model()->updateFilesPriorities(m_torrent->filePriorities());
-            }
+                // Update file progress/availability
+                m_propListModel->model()->updateFilesProgress(m_torrent->filesProgress());
+                m_propListModel->model()->updateFilesAvailability(m_torrent->availableFileFractions());
 
-            m_propListModel->model()->updateFilesProgress(m_torrent->filesProgress());
-            m_propListModel->model()->updateFilesAvailability(m_torrent->availableFileFractions());
-
-            if (!isContentInitialized)
-            {
                 // Expand single-item folders recursively.
                 // This will trigger sorting and filtering so do it after all relevant data is loaded.
                 QModelIndex currentIndex;
@@ -549,6 +543,15 @@ void PropertiesWidget::loadDynamicData()
                     currentIndex = m_propListModel->index(0, 0, currentIndex);
                     m_ui->filesList->setExpanded(currentIndex, true);
                 }
+            } else {
+                // Torrent content was loaded already, only make some updates
+
+                m_propListModel->model()->updateFilesProgress(m_torrent->filesProgress());
+                m_propListModel->model()->updateFilesAvailability(m_torrent->availableFileFractions());
+                // XXX: We don't update file priorities regularly for performance
+                // reasons. This means that priorities will not be updated if
+                // set from the Web UI.
+                // m_propListModel->model()->updateFilesPriorities(m_torrent->filePriorities());
             }
 
             m_ui->filesList->setUpdatesEnabled(true);

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -366,19 +366,20 @@ void PropertiesWidget::loadTorrentInfos(BitTorrent::Torrent *const torrent)
         // List files in torrent
         m_propListModel->model()->setupModelData(m_torrent->info());
 
-        // Expand single-item folders recursively
-        QModelIndex currentIndex;
-        while (m_propListModel->rowCount(currentIndex) == 1)
-        {
-            currentIndex = m_propListModel->index(0, 0, currentIndex);
-            m_ui->filesList->setExpanded(currentIndex, true);
-        }
-
         // Load file priorities
         m_propListModel->model()->updateFilesPriorities(m_torrent->filePriorities());
     }
     // Load dynamic data
     loadDynamicData();
+
+    // Expand single-item folders recursively.
+    // This will trigger sorting and filtering so do it after all relevant data is loaded.
+    QModelIndex currentIndex;
+    while (m_propListModel->rowCount(currentIndex) == 1)
+    {
+        currentIndex = m_propListModel->index(0, 0, currentIndex);
+        m_ui->filesList->setExpanded(currentIndex, true);
+    }
 }
 
 void PropertiesWidget::readSettings()

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -524,8 +524,8 @@ void PropertiesWidget::loadDynamicData()
             m_ui->filesList->setUpdatesEnabled(false);
 
             // Load torrent content if not yet done so
-            const bool loadTorrentContent = !m_propListModel->model()->hasIndex(0, 0);
-            if (loadTorrentContent)
+            const bool isContentInitialized = !m_propListModel->model()->hasIndex(0, 0);
+            if (isContentInitialized)
             {
                 // List files in torrent
                 m_propListModel->model()->setupModelData(m_torrent->info());
@@ -539,7 +539,7 @@ void PropertiesWidget::loadDynamicData()
             m_propListModel->model()->updateFilesProgress(m_torrent->filesProgress());
             m_propListModel->model()->updateFilesAvailability(m_torrent->availableFileFractions());
 
-            if (loadTorrentContent)
+            if (isContentInitialized)
             {
                 // Expand single-item folders recursively.
                 // This will trigger sorting and filtering so do it after all relevant data is loaded.


### PR DESCRIPTION
The list of files contained by a torrent (the "content" tab on the bottom of the main window) is not always sorted properly. If current sort column is "priority", "progress", "remaining" or "availability" and you select another torrent on the main download list, the sorting is improper. This PR changes the behavior in a way that the list is always sorted accordingly to currently selected sort column after selecting a torrent on the main download list and also after showing the "content" tab (it's not about sorting in real-time).

**Steps to reproduce**
1. Select the "content" tab on the bottom of the main window.
2. Click on the header of one of the mentioned columns i.e. "progress", the list of files should get resorted accordingly
3. Select another torrent on the main download list
4. Observe that the list of files is not properly sorted

**Cause**
When sorting occurs, not all relevant data is loaded already. Everything happens in `PropertiesWidget::loadTorrentInfos` https://github.com/qbittorrent/qBittorrent/blob/cd3635985e0ba0354c76e329e2c5637800e56fd7/src/gui/properties/propertieswidget.cpp#L366-L381 Some relevant code is also in `PropertiesWidget::loadDynamicData` https://github.com/qbittorrent/qBittorrent/blob/cd3635985e0ba0354c76e329e2c5637800e56fd7/src/gui/properties/propertieswidget.cpp#L539-L540 Sorting and filtering of the list is triggered by "Expand single-item folders recursively" - at that point only file names and sizes are loaded. Other relevant data is loaded afterwards or not loaded at all.

**Solution**
"Expand single-item folders recursively" can be moved below "Load file priorities", this would take care of the "priority" column. Furthermore it can be moved below "Load dynamic data", this would take care of other columns. And this is exactly what my first commit does (https://github.com/a-sum-duma/qBittorrent/commit/e846a6d9f63bb87471f3d26592e6dc941ac72de5).

However, there is still an issue regarding "progress/remaining/availability" columns. `loadDynamicData` loads progress/availability, but only if the "content" tab is visible and selected. If not, that data won't be loaded and sorting against mentioned columns will not be proper (sorting occurs even if the "content" tab is not visible/selected). Steps to trigger invalid sorting would be:
1. Select "content" tab
2. Sort by "progress/remaining/availability"
3. Select other tab i.e. "peers"
4. Select another torrent
5. Select "content" tab
6. Observe improper order

Simple fix is to always load all data, independently of the "content" tab state. That's what my second commit does (https://github.com/a-sum-duma/qBittorrent/commit/5922d1d2d596ac74eb3d36ec1f98b983bb35a455).

But this solution is not the best thing we can do, the code gets less DRY. We could postpone the sorting until the moment when all data is loaded. Let's say we do the "Expand single-item folders recursively" inside `loadDynamicData`, after loading the progress and the availability. Expending must be done exactly once so we would need a `bool` variable somewhere that would tell whether we did the expanding yet or not. Moreover, there is no guarantee that something else won't trigger sorting. So maybe postpone not only sorting but entire loading of the torrent content? When "content" tab is not visible/selected we don't need it to be loaded. We can load it "on demand", inside `loadDynamicData`. No extra `bool` is needed - we can simply check if the files tree is empty. That's my third commit (https://github.com/a-sum-duma/qBittorrent/commit/34acd9e4a6658973124f9063ae7f07bd97e12d39). As a bonus we get a small performance boost. My tests shows that if you have a huge torrent with thousand's of files and you select it on the main download list you may experience a tiny but noticeable lag caused by loading of the content. With my solution, the lag occurs only when the "content" tab is visible/selected, otherwise it's gone.

I did test the changes by myself. I've been using them for something like a month and didn't notice any undesirable effects.

Note: I've seen #13169 which is about "real-time" sorting. Are you sure that this is the way to go? It might be impractical - files will be "jumping" up and down making it harder to click the one we are interested in. What's your opinion on the subject?