### PR TITLE
Create separate GHA CI - OS workflow badge URL's

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@ qBittorrent - A BitTorrent client in Qt
 ------------------------------------------
 
 [![AppVeyor Status](https://ci.appveyor.com/api/projects/status/github/qbittorrent/qBittorrent?branch=master&svg=true)](https://ci.appveyor.com/project/qbittorrent/qBittorrent)
-[![GitHub Actions CI Status](https://github.com/qbittorrent/qBittorrent/workflows/GitHub%20Actions%20CI/badge.svg)](https://github.com/qbittorrent/qBittorrent/actions)
+[![GitHub Actions CI Ubuntu Status](https://github.com/qbittorrent/qBittorrent/actions/workflows/ci_ubuntu.yaml/badge.svg)](https://github.com/qbittorrent/qBittorrent/actions/workflows/ci_ubuntu.yaml)
+[![GitHub Actions CI Windows Status](https://github.com/qbittorrent/qBittorrent/actions/workflows/ci_windows.yaml/badge.svg)](https://github.com/qbittorrent/qBittorrent/actions/workflows/ci_windows.yaml)
+[![GitHub Actions CI macOS Status](https://github.com/qbittorrent/qBittorrent/actions/workflows/ci_macos.yaml/badge.svg)](https://github.com/qbittorrent/qBittorrent/actions/workflows/ci_macos.yaml)
 [![Coverity Status](https://scan.coverity.com/projects/5494/badge.svg)](https://scan.coverity.com/projects/5494)
 ********************************
 ### Description:


### PR DESCRIPTION
As of PR https://github.com/qbittorrent/qBittorrent/pull/15342 we now use separate workflows for each OS.
This PR updates/adds GHA CI badge URL's for each OS.

Screenshot:
![Screenshot 2021-10-22 105639](https://user-images.githubusercontent.com/42386382/138434844-38b3eb30-c520-4b6c-b77c-5a1dec74c130.png)

README.md:
https://github.com/xavier2k6/qBittorrent/tree/GHA_CI_BADGES#readme