### PR TITLE
Don't use deprecated statfs64() on macOS

### DIFF
--- a/src/base/utils/fs.cpp
+++ b/src/base/utils/fs.cpp
@@ -347,15 +347,9 @@ bool Utils::Fs::isNetworkFileSystem(const QString &path)
         file += '/';
     file += '.';
 
-#if defined(Q_OS_MACOS)
-    struct statfs64 buf {};
-    if (statfs64(file.toLocal8Bit().constData(), &buf) != 0)
-        return false;
-#else
     struct statfs buf {};
     if (statfs(file.toLocal8Bit().constData(), &buf) != 0)
         return false;
-#endif
 
 #if defined(Q_OS_OPENBSD)
     return ((strncmp(buf.f_fstypename, "cifs", sizeof(buf.f_fstypename)) == 0)


### PR DESCRIPTION
`statfs64()` is deprecated even in macOS 10.14 Mojave https://www.unix.com/man-page/mojave/2/statfs64/
moreover, the presence of this call causes build issues on Apple M1 (tried to build with Xcode 13.1 doing cross-compilation), very likely it just doesn't exist anymore (who knows) in new SDK (but built was successful for x86_64)

this call is appeared as part of commit 5cf39a297004a1330af4a039fba99d0c286d48e9 , but there are no any comments why, and according to commit message (and how changes looks) this commit is just refactoring