### PR TITLE
Create lock file in config folder instead of temp folder

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -154,16 +154,10 @@ Application::Application(int &argc, char **argv)
     const QString profileDir = portableModeEnabled
         ? QDir(QCoreApplication::applicationDirPath()).absoluteFilePath(DEFAULT_PORTABLE_MODE_PROFILE_DIR)
         : m_commandLineArgs.profileDir;
-#ifdef Q_OS_WIN
-    const QString instanceId = (profileDir + (m_commandLineArgs.configurationName.isEmpty() ? QString {} : ('/' + m_commandLineArgs.configurationName))).toLower();
-#else
-    const QString instanceId = profileDir + (m_commandLineArgs.configurationName.isEmpty() ? QString {} : ('/' + m_commandLineArgs.configurationName));
-#endif
-    const QString appId = QLatin1String("qBittorrent-") + Utils::Misc::getUserIDString() + '@' + instanceId;
-    m_instanceManager = new ApplicationInstanceManager {appId, this};
-
     Profile::initInstance(profileDir, m_commandLineArgs.configurationName,
                         (m_commandLineArgs.relativeFastresumePaths || portableModeEnabled));
+
+    m_instanceManager = new ApplicationInstanceManager {Profile::instance()->location(SpecialFolder::Config), this};
 
     Logger::initInstance();
     SettingsStorage::initInstance();

--- a/src/app/applicationinstancemanager.h
+++ b/src/app/applicationinstancemanager.h
@@ -32,16 +32,15 @@
 
 class QtLocalPeer;
 
-class ApplicationInstanceManager : public QObject
+class ApplicationInstanceManager final : public QObject
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(ApplicationInstanceManager)
 
 public:
-    explicit ApplicationInstanceManager(const QString &appId, QObject *parent = nullptr);
+    explicit ApplicationInstanceManager(const QString &instancePath, QObject *parent = nullptr);
 
     bool isFirstInstance() const;
-    QString appId() const;
 
 public slots:
     bool sendMessage(const QString &message, int timeout = 5000);

--- a/src/app/qtlocalpeer/qtlocalpeer.h
+++ b/src/app/qtlocalpeer/qtlocalpeer.h
@@ -68,21 +68,23 @@
 
 #pragma once
 
+#include <QString>
+
 #include "qtlockedfile.h"
 
 class QLocalServer;
 
-class QtLocalPeer : public QObject
+class QtLocalPeer final : public QObject
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(QtLocalPeer)
 
 public:
-    QtLocalPeer(QObject *parent = nullptr, const QString &appId = QString());
+    QtLocalPeer(const QString &path, QObject *parent = nullptr);
     ~QtLocalPeer() override;
 
     bool isClient();
     bool sendMessage(const QString &message, int timeout);
-    QString applicationId() const;
 
 signals:
     void messageReceived(const QString &message);

--- a/src/app/qtlocalpeer/qtlockedfile.h
+++ b/src/app/qtlocalpeer/qtlockedfile.h
@@ -71,6 +71,7 @@
 #include <QFile>
 
 #ifdef Q_OS_WIN
+#include <QString>
 #include <QVector>
 #endif
 

--- a/src/base/profile_p.cpp
+++ b/src/base/profile_p.cpp
@@ -169,9 +169,9 @@ SettingsPtr Private::CustomProfile::applicationSettings(const QString &name) con
 {
     // here we force QSettings::IniFormat format always because we need it to be portable across platforms
 #if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
-    constexpr const char *CONF_FILE_EXTENSION = ".ini";
+    const char CONF_FILE_EXTENSION[] = ".ini";
 #else
-    constexpr const char *CONF_FILE_EXTENSION = ".conf";
+    const char CONF_FILE_EXTENSION[] = ".conf";
 #endif
     const QString settingsFileName {QDir(configLocation()).absoluteFilePath(name + QLatin1String(CONF_FILE_EXTENSION))};
     return SettingsPtr(new QSettings(settingsFileName, QSettings::IniFormat));


### PR DESCRIPTION
* Create lock file in config folder instead of temp folder 
  Some linux distros seem to alter TMPDIR environment variable and therefore hamper qbt ability to find the lock files. So use config folder instead of TMPDIR folder to create/locate the lock files.
  Note that this change will also make qbt become one instance per-user instead of one instance per-system.
  Closes #15646.
* Use char array directly
  This eliminates the possibility of reassigning the pointer to another address.

For testers: This is related to qbt multi-instances detection and it should work as before, that is, only one instance is allowed. Please look for regressions.