### PR TITLE
Add more download options to torrent search result right-click menu

### DIFF
--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -296,7 +296,7 @@ void SearchJobWidget::addTorrentToSession(const QString &source, AddTorrentOptio
 {
     if (source.isEmpty()) return;
 
-    if (option == AddTorrentOption::ShowDialog || (option == AddTorrentOption::Default && AddNewTorrentDialog::isEnabled()))
+    if ((option == AddTorrentOption::ShowDialog) || ((option == AddTorrentOption::Default) && AddNewTorrentDialog::isEnabled()))
         AddNewTorrentDialog::show(source, this);
     else
         BitTorrent::Session::instance()->addTorrent(source);

--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -211,7 +211,7 @@ void SearchJobWidget::cancelSearch()
     m_searchHandler->cancelSearch();
 }
 
-void SearchJobWidget::downloadTorrents(AddTorrentOption option)
+void SearchJobWidget::downloadTorrents(const AddTorrentOption option)
 {
     const QModelIndexList rows {m_ui->resultsBrowser->selectionModel()->selectedRows()};
     for (const QModelIndex &rowIndex : rows)
@@ -271,7 +271,7 @@ void SearchJobWidget::setStatus(Status value)
     emit statusChanged();
 }
 
-void SearchJobWidget::downloadTorrent(const QModelIndex &rowIndex, AddTorrentOption option)
+void SearchJobWidget::downloadTorrent(const QModelIndex &rowIndex, const AddTorrentOption option)
 {
     const QString torrentUrl = m_proxyModel->data(
                 m_proxyModel->index(rowIndex.row(), SearchSortModel::DL_LINK)).toString();
@@ -292,7 +292,7 @@ void SearchJobWidget::downloadTorrent(const QModelIndex &rowIndex, AddTorrentOpt
     setRowColor(rowIndex.row(), QApplication::palette().color(QPalette::LinkVisited));
 }
 
-void SearchJobWidget::addTorrentToSession(const QString &source, AddTorrentOption option)
+void SearchJobWidget::addTorrentToSession(const QString &source, const AddTorrentOption option)
 {
     if (source.isEmpty()) return;
 

--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -397,7 +397,7 @@ void SearchJobWidget::contextMenuEvent(QContextMenuEvent *event)
 
     menu->addAction(UIThemeManager::instance()->getIcon("download"), tr("Open download window")
         , this, [this]() { downloadTorrents(AddTorrentOption::ShowDialog); });
-    menu->addAction(UIThemeManager::instance()->getIcon("downloading"), tr("Start downloading")
+    menu->addAction(UIThemeManager::instance()->getIcon("download"), tr("Download")
         , this, [this]() { downloadTorrents(AddTorrentOption::SkipDialog); });
     menu->addSeparator();
     menu->addAction(UIThemeManager::instance()->getIcon("application-x-mswinurl"), tr("Open description page")

--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -211,11 +211,11 @@ void SearchJobWidget::cancelSearch()
     m_searchHandler->cancelSearch();
 }
 
-void SearchJobWidget::downloadTorrents(ShowAddNewTorrentDialog showDialog)
+void SearchJobWidget::downloadTorrents(AddTorrentOption option)
 {
     const QModelIndexList rows {m_ui->resultsBrowser->selectionModel()->selectedRows()};
     for (const QModelIndex &rowIndex : rows)
-        downloadTorrent(rowIndex, showDialog);
+        downloadTorrent(rowIndex, option);
 }
 
 void SearchJobWidget::openTorrentPages() const
@@ -271,7 +271,7 @@ void SearchJobWidget::setStatus(Status value)
     emit statusChanged();
 }
 
-void SearchJobWidget::downloadTorrent(const QModelIndex &rowIndex, ShowAddNewTorrentDialog showDialog)
+void SearchJobWidget::downloadTorrent(const QModelIndex &rowIndex, AddTorrentOption option)
 {
     const QString torrentUrl = m_proxyModel->data(
                 m_proxyModel->index(rowIndex.row(), SearchSortModel::DL_LINK)).toString();
@@ -280,23 +280,23 @@ void SearchJobWidget::downloadTorrent(const QModelIndex &rowIndex, ShowAddNewTor
 
     if (torrentUrl.startsWith("magnet:", Qt::CaseInsensitive))
     {
-        addTorrentToSession(torrentUrl, showDialog);
+        addTorrentToSession(torrentUrl, option);
     }
     else
     {
         SearchDownloadHandler *downloadHandler = m_searchHandler->manager()->downloadTorrent(siteUrl, torrentUrl);
         connect(downloadHandler, &SearchDownloadHandler::downloadFinished
-            , this, [this, showDialog](const QString &source) { addTorrentToSession(source, showDialog); });
+            , this, [this, option](const QString &source) { addTorrentToSession(source, option); });
         connect(downloadHandler, &SearchDownloadHandler::downloadFinished, downloadHandler, &SearchDownloadHandler::deleteLater);
     }
     setRowColor(rowIndex.row(), QApplication::palette().color(QPalette::LinkVisited));
 }
 
-void SearchJobWidget::addTorrentToSession(const QString &source, ShowAddNewTorrentDialog showDialog)
+void SearchJobWidget::addTorrentToSession(const QString &source, AddTorrentOption option)
 {
     if (source.isEmpty()) return;
 
-    if (showDialog == ShowAddNewTorrentDialog::Yes || (showDialog == ShowAddNewTorrentDialog::FromSettings && AddNewTorrentDialog::isEnabled()))
+    if (option == AddTorrentOption::ShowDialog || (option == AddTorrentOption::Default && AddNewTorrentDialog::isEnabled()))
         AddNewTorrentDialog::show(source, this);
     else
         BitTorrent::Session::instance()->addTorrent(source);
@@ -396,9 +396,9 @@ void SearchJobWidget::contextMenuEvent(QContextMenuEvent *event)
     menu->setAttribute(Qt::WA_DeleteOnClose);
 
     menu->addAction(UIThemeManager::instance()->getIcon("download"), tr("Open download window")
-        , this, [this]() { downloadTorrents(ShowAddNewTorrentDialog::Yes); });
+        , this, [this]() { downloadTorrents(AddTorrentOption::ShowDialog); });
     menu->addAction(UIThemeManager::instance()->getIcon("downloading"), tr("Start downloading")
-        , this, [this]() { downloadTorrents(ShowAddNewTorrentDialog::No); });
+        , this, [this]() { downloadTorrents(AddTorrentOption::SkipDialog); });
     menu->addSeparator();
     menu->addAction(UIThemeManager::instance()->getIcon("application-x-mswinurl"), tr("Open description page")
         , this, &SearchJobWidget::openTorrentPages);

--- a/src/gui/search/searchjobwidget.h
+++ b/src/gui/search/searchjobwidget.h
@@ -89,11 +89,11 @@ protected:
     void keyPressEvent(QKeyEvent *event) override;
 
 private:
-    enum class ShowAddNewTorrentDialog
+    enum class AddTorrentOption
     {
-        No,
-        Yes,
-        FromSettings,
+        Default,
+        ShowDialog,
+        SkipDialog,
     };
 
     void loadSettings();
@@ -109,14 +109,14 @@ private:
     void appendSearchResults(const QVector<SearchResult> &results);
     void updateResultsCount();
     void setStatus(Status value);
-    void downloadTorrent(const QModelIndex &rowIndex, ShowAddNewTorrentDialog showDialog = ShowAddNewTorrentDialog::FromSettings);
-    void addTorrentToSession(const QString &source, ShowAddNewTorrentDialog showDialog = ShowAddNewTorrentDialog::FromSettings);
+    void downloadTorrent(const QModelIndex &rowIndex, AddTorrentOption option = AddTorrentOption::Default);
+    void addTorrentToSession(const QString &source, AddTorrentOption option = AddTorrentOption::Default);
     void fillFilterComboBoxes();
     NameFilteringMode filteringMode() const;
     QHeaderView *header() const;
     void setRowColor(int row, const QColor &color);
 
-    void downloadTorrents(ShowAddNewTorrentDialog showDialog = ShowAddNewTorrentDialog::FromSettings);
+    void downloadTorrents(AddTorrentOption option = AddTorrentOption::Default);
     void openTorrentPages() const;
     void copyTorrentURLs() const;
     void copyTorrentDownloadLinks() const;

--- a/src/gui/search/searchjobwidget.h
+++ b/src/gui/search/searchjobwidget.h
@@ -89,6 +89,12 @@ protected:
     void keyPressEvent(QKeyEvent *event) override;
 
 private:
+    enum class ShowAddNewTorrentDialog {
+        No,
+        Yes,
+        FromSettings,
+    };
+
     void loadSettings();
     void saveSettings() const;
     void updateFilter();
@@ -102,14 +108,14 @@ private:
     void appendSearchResults(const QVector<SearchResult> &results);
     void updateResultsCount();
     void setStatus(Status value);
-    void downloadTorrent(const QModelIndex &rowIndex);
-    void addTorrentToSession(const QString &source);
+    void downloadTorrent(const QModelIndex &rowIndex, ShowAddNewTorrentDialog showDialog = ShowAddNewTorrentDialog::FromSettings);
+    void addTorrentToSession(const QString &source, ShowAddNewTorrentDialog showDialog = ShowAddNewTorrentDialog::FromSettings);
     void fillFilterComboBoxes();
     NameFilteringMode filteringMode() const;
     QHeaderView *header() const;
     void setRowColor(int row, const QColor &color);
 
-    void downloadTorrents();
+    void downloadTorrents(ShowAddNewTorrentDialog showDialog = ShowAddNewTorrentDialog::FromSettings);
     void openTorrentPages() const;
     void copyTorrentURLs() const;
     void copyTorrentDownloadLinks() const;

--- a/src/gui/search/searchjobwidget.h
+++ b/src/gui/search/searchjobwidget.h
@@ -89,7 +89,8 @@ protected:
     void keyPressEvent(QKeyEvent *event) override;
 
 private:
-    enum class ShowAddNewTorrentDialog {
+    enum class ShowAddNewTorrentDialog
+    {
         No,
         Yes,
         FromSettings,


### PR DESCRIPTION
New feature (QT GUI).

![qb](https://user-images.githubusercontent.com/68896601/139592790-058c4e2d-2d8e-49db-8361-2e8161ac393b.png)

In the "search" tab, when right-clicking a search result, a menu pops up. The menu contains "download" item - clicking it causes either immediate adding of the torrent to the download session or showing the download window where torrent content can be viewed and some download options can be selected. Whether the one or the other action is used is controlled by "Display torrent content and some options" setting.

![qb1](https://user-images.githubusercontent.com/68896601/139592799-3fbe0d17-5e94-41c7-933c-1630cbdc1060.png)

This PR is about splitting the "download" item into two separate items - one for each of the two mentioned actions.

Rationale: In general I have "Display torrent content and some options" setting turned off so torrents are added immediately. However, sometimes I want to see what's in the torrent or adjust some download options before starting the download. I must open preferences, navigate and select the option. Do the viewing/downloading. Then again go to preferences and turn off the option. It's tedious.