### PR TITLE
GHA CI: Revise artifact folder layout

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -50,6 +50,7 @@ jobs:
             -G "Ninja" \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_CXX_STANDARD=17 \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -Ddeprecated-functions=OFF \
             -DOPENSSL_ROOT_DIR="${{ env.openssl_root }}"
           cmake --build build
@@ -62,6 +63,7 @@ jobs:
             -B build \
             -G "Ninja" \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DOPENSSL_ROOT_DIR="${{ env.openssl_root }}" \
             -DQt5_DIR="$Qt5_DIR" \
             -DVERBOSE_CONFIGURE=ON \
@@ -75,6 +77,7 @@ jobs:
             -B build \
             -G "Ninja" \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DOPENSSL_ROOT_DIR="${{ env.openssl_root }}" \
             -DQT6=ON \
             -DQt6_DIR="$Qt6_DIR" \
@@ -82,10 +85,17 @@ jobs:
             -D${{ matrix.qbt_gui }}
           cmake --build build
 
+      - name: Prepare build artifacts
+        run: |
+          mkdir upload
+          mv build/qbittorrent*.app upload
+          mkdir upload/cmake
+          cp build/compile_commands.json upload/cmake
+          mkdir upload/cmake/libtorrent
+          cp libtorrent/build/compile_commands.json upload/cmake/libtorrent
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v2
         with:
           name: qBittorrent-CI_macOS_${{ matrix.qbt_gui }}_libtorrent-${{ matrix.libt_version }}_Qt-${{ matrix.qt_version }}
-          path: |
-            build/qbittorrent.app
-            build/qbittorrent-nox.app
+          path: upload

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -49,8 +49,7 @@ jobs:
             -G "Ninja" \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            -Ddeprecated-functions=OFF \
-            --graphviz=cmake-build-dir/target_graph.dot
+            -Ddeprecated-functions=OFF
           cmake --build build
           sudo cmake --install build
 
@@ -62,12 +61,12 @@ jobs:
             -G "Ninja" \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DCMAKE_INSTALL_PREFIX="/usr" \
             -DQt5_DIR="$Qt5_DIR" \
-            -D${{ matrix.qbt_gui }} \
             -DVERBOSE_CONFIGURE=ON \
-            --graphviz=build/target_graph.dot
+            -D${{ matrix.qbt_gui }}
           cmake --build build
-          sudo cmake --install build
+          DESTDIR="qbittorrent" cmake --install build
 
       - name: Build qBittorrent (Qt6)
         if: ${{ startsWith(matrix.qt_version, 6) }}
@@ -77,23 +76,25 @@ jobs:
             -G "Ninja" \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            -DQt6_DIR="$Qt6_DIR" \
+            -DCMAKE_INSTALL_PREFIX="/usr" \
             -DQT6=ON \
-            -D${{ matrix.qbt_gui }} \
+            -DQt6_DIR="$Qt6_DIR" \
             -DVERBOSE_CONFIGURE=ON \
-            --graphviz=build/target_graph.dot
+            -D${{ matrix.qbt_gui }}
           cmake --build build
-          sudo cmake --install build
+          DESTDIR="qbittorrent" cmake --install build
+
+      - name: Prepare build artifacts
+        run: |
+          mkdir upload
+          mv qbittorrent upload
+          mkdir upload/cmake
+          cp build/compile_commands.json upload/cmake
+          mkdir upload/cmake/libtorrent
+          cp libtorrent/build/compile_commands.json upload/cmake/libtorrent
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v2
         with:
           name: qBittorrent-CI_ubuntu-20.04-x64_${{ matrix.qbt_gui }}_libtorrent-${{ matrix.libt_version }}_Qt-${{ matrix.qt_version }}
-          path: |
-            build/compile_commands.json
-            build/install_manifest.txt
-            build/target_graph.dot
-            build/qbittorrent
-            build/qbittorrent-nox
-            libtorrent/cmake-build-dir/compile_commands.json
-            libtorrent/cmake-build-dir/target_graph.dot
+          path: upload

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -7,9 +7,9 @@ jobs:
     runs-on: windows-latest
 
     strategy:
-      matrix:
-        libt_version: ["v2.0.4", "v1.2.14"]
       fail-fast: false
+      matrix:
+        libt_version: ["2.0.4", "1.2.14"]
 
     env:
       boost_path: "${{ github.workspace }}/boost"
@@ -78,13 +78,14 @@ jobs:
 
       - name: Install libtorrent
         run: |
-          git clone --branch ${{ matrix.libt_version }} --depth 1 https://github.com/arvidn/libtorrent.git
+          git clone --branch v${{ matrix.libt_version }} --depth 1 https://github.com/arvidn/libtorrent.git
           cd libtorrent
           git submodule update --init --recursive
           cmake `
             -B build `
             -G "Ninja" `
             -DCMAKE_BUILD_TYPE=RelWithDebInfo `
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON `
             -DCMAKE_INSTALL_PREFIX="${{ env.libtorrent_path }}" `
             -DCMAKE_TOOLCHAIN_FILE="${{ env.RUNVCPKG_VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake" `
             -DBOOST_ROOT="${{ env.boost_path }}" `
@@ -120,6 +121,8 @@ jobs:
           mkdir upload/cmake
           copy build/compile_commands.json upload/cmake
           copy build/target_graph.dot upload/cmake
+          mkdir upload/cmake/libtorrent
+          copy libtorrent/build/compile_commands.json upload/cmake/libtorrent
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Now qbittorrent binaries will be placed in its own folder and cmake related artifacts will be in another.
