### PR TITLE
Apply download priority immediately after picking it via drop-down menu

### DIFF
--- a/src/gui/properties/proplistdelegate.cpp
+++ b/src/gui/properties/proplistdelegate.cpp
@@ -87,6 +87,13 @@ QWidget *PropListDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
     editor->addItem(tr("Normal", "Normal (priority)"));
     editor->addItem(tr("High", "High (priority)"));
     editor->addItem(tr("Maximum", "Maximum (priority)"));
+
+    // Apply newly selected priority right away, don't wait until editor is closed.
+    connect(editor, qOverload<int>(&QComboBox::activated), this, [this, editor]()
+    {
+        emit const_cast<PropListDelegate* >(this)->commitData(editor);
+    });
+
     return editor;
 }
 

--- a/src/gui/properties/proplistdelegate.cpp
+++ b/src/gui/properties/proplistdelegate.cpp
@@ -91,7 +91,7 @@ QWidget *PropListDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
     // Apply newly selected priority right away, don't wait until editor is closed.
     connect(editor, qOverload<int>(&QComboBox::activated), this, [this, editor]()
     {
-        emit const_cast<PropListDelegate* >(this)->commitData(editor);
+        emit const_cast<PropListDelegate *>(this)->commitData(editor);
     });
 
     return editor;

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -310,15 +310,15 @@ bool TorrentContentModel::setData(const QModelIndex &index, const QVariant &valu
         {
         case TorrentContentModelItem::COL_NAME:
             item->setName(value.toString());
-            break;
+            emit dataChanged(index, index);
+            return true;
         case TorrentContentModelItem::COL_PRIO:
             item->setPriority(static_cast<BitTorrent::DownloadPriority>(value.toInt()));
-            break;
+            emit dataChanged(this->index(0, 0), this->index(rowCount() - 1, columnCount() - 1));
+            return true;
         default:
             return false;
         }
-        emit dataChanged(index, index);
-        return true;
     }
 
     return false;

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -314,7 +314,7 @@ bool TorrentContentModel::setData(const QModelIndex &index, const QVariant &valu
             return true;
         case TorrentContentModelItem::COL_PRIO:
             item->setPriority(static_cast<BitTorrent::DownloadPriority>(value.toInt()));
-            emit dataChanged(this->index(0, 0), this->index(rowCount() - 1, columnCount() - 1));
+            emit dataChanged(this->index(0, 0), this->index((rowCount() - 1), (columnCount() - 1)));
             return true;
         default:
             return false;


### PR DESCRIPTION
Fixes #15238 #14667

When changing download priority of a file contained by a torrent via drop-down menu, the change doesn't take place right after clicking on a given priority, the drop-down menu must loose focus (i.e. we must click somewhere else) for this to happen. See https://github.com/qbittorrent/qBittorrent/issues/14667#issuecomment-877391474.

This PR fixes the issue by making the changes to happen immediately, right after clicking on a priority menu item.

Implementation details:
When editing data view (QTreeView) via so called "editor" (QComboBox), new value is reported to underlying data model when editor finishes editing. This happens after editor widget is closed. Closing of the widget is automatically triggered when it looses focus. This is all built-in QT behavior. If we want to report the value earlier, we must do it by ourselves - we shell emit [QAbstractItemDelegate::commitData](https://doc.qt.io/qt-5/qabstractitemdelegate.html#commitData) in response to [QComboBox::activated](https://doc.qt.io/qt-5/qcombobox.html#activated) signal.
Another thing that happens automatically after editor is closed and that we must take care of is refreshing of the view. After download priority of a file is changed, values in other cells may change too - parent and ancestor folders priority, state of check-boxes, color of progress bars etc. We shell force sending new values from data model to data view by emitting [QAbstractItemModel::dataChanged](https://doc.qt.io/qt-5/qabstractitemmodel.html#dataChanged).