### PR TITLE
Unify download priority right-click context menu in torrent content tab and in add new torrent dialog

### DIFF
--- a/src/gui/torrentcontenttreeview.cpp
+++ b/src/gui/torrentcontenttreeview.cpp
@@ -120,9 +120,8 @@ void TorrentContentTreeView::setupDownloadPriorityMenu(QMenu *menu, const bool c
         return [model, getSelectedRows, priority]()
         {
             for (const QModelIndex &index : asConst(getSelectedRows()))
-            {
                 model->setData(index, static_cast<int>(priority));
-            }
+
             emit model->filteredFilesChanged();
         };
     };
@@ -134,7 +133,7 @@ void TorrentContentTreeView::setupDownloadPriorityMenu(QMenu *menu, const bool c
 
         const QModelIndexList selectedRows = getSelectedRows();
         const qsizetype priorityGroups = 3;
-        const auto priorityGroupSize = std::max<qsizetype>(selectedRows.length() / priorityGroups, 1);
+        const auto priorityGroupSize = std::max<qsizetype>((selectedRows.length() / priorityGroups), 1);
 
         for (qsizetype i = 0; i < selectedRows.length(); ++i)
         {

--- a/src/gui/torrentcontenttreeview.cpp
+++ b/src/gui/torrentcontenttreeview.cpp
@@ -113,11 +113,14 @@ void TorrentContentTreeView::setupDownloadPriorityMenu(QMenu *menu, const bool c
     const auto model = qobject_cast<TorrentContentFilterModel *>(this->model());
     Q_ASSERT(model);
 
-    const auto getSelectedRows = [this]() { return selectionModel()->selectedRows(TorrentContentModelItem::COL_PRIO); };
-
-    const auto applyPriorities = [&](const BitTorrent::DownloadPriority priority)
+    const auto getSelectedRows = [this]() -> QModelIndexList
     {
-        return [model, getSelectedRows, priority]()
+        return selectionModel()->selectedRows(TorrentContentModelItem::COL_PRIO);
+    };
+
+    const auto applyPriorities = [getSelectedRows, model](const BitTorrent::DownloadPriority priority) -> auto
+    {
+        return [getSelectedRows, model, priority]() -> void
         {
             for (const QModelIndex &index : asConst(getSelectedRows()))
                 model->setData(index, static_cast<int>(priority));
@@ -125,7 +128,7 @@ void TorrentContentTreeView::setupDownloadPriorityMenu(QMenu *menu, const bool c
             emit model->filteredFilesChanged();
         };
     };
-    const auto applyPrioritiesByOrder = [model, getSelectedRows]()
+    const auto applyPrioritiesByOrder = [getSelectedRows, model]() -> void
     {
         // Equally distribute the selected items into groups and for each group assign
         // a download priority that will apply to each item. The number of groups depends on how

--- a/src/gui/torrentcontenttreeview.cpp
+++ b/src/gui/torrentcontenttreeview.cpp
@@ -108,7 +108,7 @@ void TorrentContentTreeView::keyPressEvent(QKeyEvent *event)
     }
 }
 
-void TorrentContentTreeView::setupDownloadPriorityMenu(QMenu *menu, const bool createSubMenu) const
+void TorrentContentTreeView::setupDownloadPriorityMenu(QMenu *const menu, const bool createSubMenu) const
 {
     const auto model = qobject_cast<TorrentContentFilterModel *>(this->model());
     Q_ASSERT(model);
@@ -163,13 +163,13 @@ void TorrentContentTreeView::setupDownloadPriorityMenu(QMenu *menu, const bool c
 
     if (createSubMenu)
     {
-        menu = menu->addMenu(tr("Priority"));
-        menu->addAction(tr("Do not download"), menu, applyPriorities(BitTorrent::DownloadPriority::Ignored));
-        menu->addAction(tr("Normal"),          menu, applyPriorities(BitTorrent::DownloadPriority::Normal));
-        menu->addAction(tr("High"),            menu, applyPriorities(BitTorrent::DownloadPriority::High));
-        menu->addAction(tr("Maximum"),         menu, applyPriorities(BitTorrent::DownloadPriority::Maximum));
-        menu->addSeparator();
-        menu->addAction(tr("By shown file order"), menu, applyPrioritiesByOrder);
+        QMenu *const priorityMenu = menu->addMenu(tr("Priority"));
+        priorityMenu->addAction(tr("Do not download"), priorityMenu, applyPriorities(BitTorrent::DownloadPriority::Ignored));
+        priorityMenu->addAction(tr("Normal"),          priorityMenu, applyPriorities(BitTorrent::DownloadPriority::Normal));
+        priorityMenu->addAction(tr("High"),            priorityMenu, applyPriorities(BitTorrent::DownloadPriority::High));
+        priorityMenu->addAction(tr("Maximum"),         priorityMenu, applyPriorities(BitTorrent::DownloadPriority::Maximum));
+        priorityMenu->addSeparator();
+        priorityMenu->addAction(tr("By shown file order"), priorityMenu, applyPrioritiesByOrder);
     }
     else
     {

--- a/src/gui/torrentcontenttreeview.h
+++ b/src/gui/torrentcontenttreeview.h
@@ -46,6 +46,7 @@ public:
     explicit TorrentContentTreeView(QWidget *parent = nullptr);
     void keyPressEvent(QKeyEvent *event) override;
 
+    void setupDownloadPriorityMenu(QMenu *menu, bool createSubMenu) const;
     void renameSelectedFile(BitTorrent::AbstractFileStorage &fileStorage);
 
 private:

--- a/src/gui/torrentcontenttreeview.h
+++ b/src/gui/torrentcontenttreeview.h
@@ -30,6 +30,8 @@
 
 #include <QTreeView>
 
+class QMenu;
+
 namespace BitTorrent
 {
     class AbstractFileStorage;


### PR DESCRIPTION

![qb2](https://user-images.githubusercontent.com/68896601/140642281-9644161d-6498-4dfc-9c86-5259b98b5f6c.png)

Some time ago #14714 was merged. It was about the "add new torrent" dialog. This PR does the same thing but to the torrent content tab. It also deduplicates the code.