### PR TITLE
CS Translation correction

### DIFF
--- a/src/lang/qbittorrent_cs.ts
+++ b/src/lang/qbittorrent_cs.ts
@@ -2860,12 +2860,12 @@ Podporuje formáty: S01E01, 1x1, 2017.12.31 a 31.12.2017 (Formáty dat také pod
     <message>
         <location filename="../gui/mainwindow.ui" line="369"/>
         <source>&amp;Suspend System</source>
-        <translation>U&amp;spat počítač</translation>
+        <translation>&amp;Režim spánku</translation>
     </message>
     <message>
         <location filename="../gui/mainwindow.ui" line="377"/>
         <source>&amp;Hibernate System</source>
-        <translation>&amp;Režim spánku</translation>
+        <translation>&amp;Režim hibernace</translation>
     </message>
     <message>
         <location filename="../gui/mainwindow.ui" line="385"/>


### PR DESCRIPTION
The translation here was poor.

Basically both meant sleep -  in CS, it wasn't sleep mode and hibernate mode, but sleep and sleep, fixed now.

**Note**: I did read the "How to translate qBittorrent" and I do apologize if I am doing it the wrong way, honestly I prefer Github, also, this is probably a one-time thing, so there is no need to use Transifex. I mean, you can always reject it, but that would be a shame, I believe.
