### PR TITLE
WebUI: Remove IRC in about page

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Please report any bug (or feature request) to:
 http://bugs.qbittorrent.org
 
 Official IRC channel:
-`#qbittorrent on irc.libera.chat`
+[#qbittorrent on irc.libera.chat](ircs://irc.libera.chat:6697/qbittorrent)
 
 ------------------------------------------
-sledgehammer999 <sledgehammer999@qbittorrent.org>
+sledgehammer999 \<sledgehammer999@qbittorrent.org\>

--- a/src/webui/www/private/views/about.html
+++ b/src/webui/www/private/views/about.html
@@ -6,7 +6,6 @@
     <p>QBT_TR(Home Page:)QBT_TR[CONTEXT=AboutDialog] <a target="_blank" href="https://www.qbittorrent.org"> https://www.qbittorrent.org</a></p>
     <p>QBT_TR(Bug Tracker:)QBT_TR[CONTEXT=AboutDialog] <a target="_blank" href="http://bugs.qbittorrent.org"> http://bugs.qbittorrent.org</a></p>
     <p>QBT_TR(Forum:)QBT_TR[CONTEXT=AboutDialog] <a target="_blank" href="http://forum.qbittorrent.org"> http://forum.qbittorrent.org</a></p>
-    <p>QBT_TR(IRC: #qbittorrent on Freenode)QBT_TR[CONTEXT=HttpServer]</p>
 </div>
 
 <div id="aboutAuthorContent" class="aboutTabContent invisible">

--- a/src/webui/www/private/views/about.html
+++ b/src/webui/www/private/views/about.html
@@ -1,11 +1,25 @@
 <div id="aboutAboutContent" class="aboutTabContent">
-    <img src="icons/mascot.png" style="float: right;" alt="qBittorrent Mascot" />
-    <h3 id="qbittorrentVersion"></h3>
+    <img src="icons/mascot.png" style="float: left;" alt="QBT_TR(qBittorrent Mascot)QBT_TR[CONTEXT=AboutDialog]" />
+    <div>
+        <img src="icons/qbittorrent-tray.svg" style="float: left; height: 1.5em;" alt="QBT_TR(qBittorrent icon)QBT_TR[CONTEXT=AboutDialog]" />
+        <h3 id="qbittorrentVersion"></h3>
+    </div>
     <p>QBT_TR(An advanced BitTorrent client programmed in C++, based on Qt toolkit and libtorrent-rasterbar.)QBT_TR[CONTEXT=AboutDialog]</p>
-    <p>Copyright (c) 2011-2021 The qBittorrent project</p>
-    <p>QBT_TR(Home Page:)QBT_TR[CONTEXT=AboutDialog] <a target="_blank" href="https://www.qbittorrent.org"> https://www.qbittorrent.org</a></p>
-    <p>QBT_TR(Bug Tracker:)QBT_TR[CONTEXT=AboutDialog] <a target="_blank" href="http://bugs.qbittorrent.org"> http://bugs.qbittorrent.org</a></p>
-    <p>QBT_TR(Forum:)QBT_TR[CONTEXT=AboutDialog] <a target="_blank" href="http://forum.qbittorrent.org"> http://forum.qbittorrent.org</a></p>
+    <p>Copyright © 2006-2021 The qBittorrent project</p>
+    <table>
+        <tr>
+            <td>QBT_TR(Home Page:)QBT_TR[CONTEXT=AboutDialog]</td>
+            <td><a href="https://www.qbittorrent.org" target="_blank">https://www.qbittorrent.org</a></td>
+        </tr>
+        <tr>
+            <td>QBT_TR(Bug Tracker:)QBT_TR[CONTEXT=AboutDialog]</td>
+            <td><a href="http://bugs.qbittorrent.org" target="_blank">http://bugs.qbittorrent.org</a></td>
+        </tr>
+        <tr>
+            <td>QBT_TR(Forum:)QBT_TR[CONTEXT=AboutDialog]</td>
+            <td><a href="http://forum.qbittorrent.org" target="_blank">http://forum.qbittorrent.org</a></td>
+        </tr>
+    </table>
 </div>
 
 <div id="aboutAuthorContent" class="aboutTabContent invisible">


### PR DESCRIPTION
* Add IRC link
  https://en.wikipedia.org/wiki/Internet_Relay_Chat#URI_scheme
  And also show the angle brackets in rendered markdown.
* WebUI: Remove IRC in about page
  This follows the GUI change in 65a30ba.
* WebUI: Revise about page
  Follow GUI more closely.
  Screenshot:
  ![screenshot](https://user-images.githubusercontent.com/9395168/140867047-b8643d42-6380-48a2-91b6-d6bbd361bae5.png)

