### PR TITLE
Update AppVeyor CI image to Visual Studio 2022

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,7 +3,7 @@ version: '{branch}-{build}'
 # Do not build on tags (GitHub only)
 skip_tags: true
 
-image: Visual Studio 2019
+image: Visual Studio 2022
 
 branches:
   except:  # blacklist
@@ -42,7 +42,7 @@ install:
 
 before_build:
   # setup env
-  - CALL "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - CALL "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
   - SET PATH=%PATH%;C:\Qt\5.15.2\msvc2019_64\bin;%CACHE_DIR%\jom
   # setup project
   - COPY /Y "%CACHE_DIR%\conf.pri" "%REPO_DIR%"


### PR DESCRIPTION
- Visual Studio 2022 is now 64-bit
- [Visual Studio 2022 reached GA November 8, 2021](https://devblogs.microsoft.com/visualstudio/visual-studio-2022-now-available/)
- [Appveyor released a Visual Studio 2022 image on November 9, 2021](https://www.appveyor.com/updates/)
