### PR TITLE
Properly check if file priority changes

### DIFF
--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -284,14 +284,15 @@ bool TorrentContentModel::setData(const QModelIndex &index, const QVariant &valu
     {
         auto *item = static_cast<TorrentContentModelItem*>(index.internalPointer());
         qDebug("setData(%s, %d)", qUtf8Printable(item->name()), value.toInt());
-        if (static_cast<int>(item->priority()) != value.toInt())
-        {
-            BitTorrent::DownloadPriority prio = BitTorrent::DownloadPriority::Normal;
-            if (value.toInt() == Qt::PartiallyChecked)
-                prio = BitTorrent::DownloadPriority::Mixed;
-            else if (value.toInt() == Qt::Unchecked)
-                prio = BitTorrent::DownloadPriority::Ignored;
 
+        BitTorrent::DownloadPriority prio = BitTorrent::DownloadPriority::Normal;
+        if (value.toInt() == Qt::PartiallyChecked)
+            prio = BitTorrent::DownloadPriority::Mixed;
+        else if (value.toInt() == Qt::Unchecked)
+            prio = BitTorrent::DownloadPriority::Ignored;
+
+        if (item->priority() != prio)
+        {
             item->setPriority(prio);
             // Update folders progress in the tree
             m_rootItem->recalculateProgress();


### PR DESCRIPTION
Small fix.

In TorrentContentModel::setData there is this piece of code for handling Qt::CheckStateRole
https://github.com/qbittorrent/qBittorrent/blob/b45248bf99ef00ce314d210c1cb9ebe5fe247cc0/src/gui/torrentcontentmodel.cpp#L283-L303

This fragment is invalid:
```cpp
if (static_cast<int>(item->priority()) != value.toInt()) 
```
Current item priority is compared against new checkbox state. I believe the intention was to check if the priority changes before performing further actions. This PR fixes the issue - compare priority against new value that is about to be set rather then the checkbox state.