### PR TITLE
Turn on /Qspectre (Spectre Variant 1 Mitigations) for MSVC builds.

### DIFF
--- a/cmake/Modules/MacroQbtCommonConfig.cmake
+++ b/cmake/Modules/MacroQbtCommonConfig.cmake
@@ -84,6 +84,7 @@ macro(qbt_common_config)
     if (MSVC)
         target_compile_options(qbt_common_cfg INTERFACE
             /guard:cf
+            /Qspectre
             /utf-8
             # https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
             /Zc:__cplusplus

--- a/conf.pri.windows
+++ b/conf.pri.windows
@@ -52,7 +52,7 @@ DEFINES += BOOST_SYSTEM_STATIC_LINK
 CONFIG += stacktrace
 
 win32-msvc* {
-    QMAKE_CXXFLAGS += "/guard:cf"
+    QMAKE_CXXFLAGS += "/guard:cf /Qspectre"
     QMAKE_LFLAGS += "/guard:cf"
     QMAKE_LFLAGS_RELEASE += "/OPT:REF /OPT:ICF"
 }


### PR DESCRIPTION
>The effect of `/Qspectre` on performance appeared to be negligible in several sizable code bases.

Add `/Qspectre` compiler flag to mitigate against [CVE-2017-5753](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5753) (Spectre Variant 1)

Documentation:
https://docs.microsoft.com/en-us/cpp/build/reference/qspectre?view=msvc-170