### PR TITLE
GHA CI: Update libtorrent version(s)

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -9,11 +9,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libt_version: ["2.0.4", "1.2.14"]
+        libt_version: ["2.0.5", "1.2.15"]
         qbt_gui: ["GUI=ON", "GUI=OFF"]
         qt_version: ["5.15.2", "6.2.0"]
         exclude:
-          - libt_version: "1.2.14"
+          - libt_version: "1.2.15"
             qt_version: "6.2.0"
 
     env:

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -9,11 +9,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libt_version: ["2.0.4", "1.2.14"]
+        libt_version: ["2.0.5", "1.2.15"]
         qbt_gui: ["GUI=ON", "GUI=OFF"]
         qt_version: ["5.15.2", "6.2.0"]
         exclude:
-          - libt_version: "1.2.14"
+          - libt_version: "1.2.15"
             qt_version: "6.2.0"
 
     steps:

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libt_version: ["2.0.4", "1.2.14"]
+        libt_version: ["2.0.5", "1.2.15"]
 
     env:
       boost_path: "${{ github.workspace }}/boost"

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install libtorrent
         run: |
           git clone \
-            --branch "v2.0.4" \
+            --branch "v2.0.5" \
             --depth 1 \
             --recurse-submodules \
             https://github.com/arvidn/libtorrent.git


### PR DESCRIPTION
Update `libtorrent` version(s) to `2.0.5` & `1.2.15` in `GHA CI`
- https://github.com/arvidn/libtorrent/releases/tag/v2.0.5
- https://github.com/arvidn/libtorrent/releases/tag/v1.2.15