### PR TITLE
Improvements for WebAPI server

### DIFF
--- a/src/base/http/connection.cpp
+++ b/src/base/http/connection.cpp
@@ -45,8 +45,18 @@ Connection::Connection(QTcpSocket *socket, IRequestHandler *requestHandler, QObj
     , m_requestHandler(requestHandler)
 {
     m_socket->setParent(this);
+
+    // reset timer when there are activity
     m_idleTimer.start();
-    connect(m_socket, &QTcpSocket::readyRead, this, &Connection::read);
+    connect(m_socket, &QIODevice::readyRead, this, [this]()
+    {
+        m_idleTimer.start();
+        read();
+    });
+    connect(m_socket, &QIODevice::bytesWritten, this, [this]()
+    {
+        m_idleTimer.start();
+    });
 }
 
 Connection::~Connection()
@@ -56,7 +66,6 @@ Connection::~Connection()
 
 void Connection::read()
 {
-    m_idleTimer.restart();
     m_receivedData.append(m_socket->readAll());
 
     while (!m_receivedData.isEmpty())
@@ -66,7 +75,7 @@ void Connection::read()
         switch (result.status)
         {
         case RequestParser::ParseStatus::Incomplete:
-        {
+            {
                 const long bufferLimit = RequestParser::MAX_CONTENT_SIZE * 1.1;  // some margin for headers
                 if (m_receivedData.size() > bufferLimit)
                 {
@@ -83,7 +92,7 @@ void Connection::read()
             return;
 
         case RequestParser::ParseStatus::BadRequest:
-        {
+            {
                 Logger::instance()->addMessage(tr("Bad Http request, closing socket. IP: %1")
                     .arg(m_socket->peerAddress().toString()), Log::WARNING);
 
@@ -96,7 +105,7 @@ void Connection::read()
             return;
 
         case RequestParser::ParseStatus::OK:
-        {
+            {
                 const Environment env {m_socket->localAddress(), m_socket->localPort(), m_socket->peerAddress(), m_socket->peerPort()};
 
                 Response resp = m_requestHandler->processRequest(result.request, env);

--- a/src/base/http/connection.h
+++ b/src/base/http/connection.h
@@ -52,11 +52,9 @@ namespace Http
         bool hasExpired(qint64 timeout) const;
         bool isClosed() const;
 
-    private slots:
-        void read();
-
     private:
         static bool acceptsGzipEncoding(QString codings);
+        void read();
         void sendResponse(const Response &response) const;
 
         QTcpSocket *m_socket;

--- a/src/base/http/responsegenerator.cpp
+++ b/src/base/http/responsegenerator.cpp
@@ -42,7 +42,7 @@ QByteArray Http::toByteArray(Response response)
     response.headers[HEADER_DATE] = httpDate();
 
     QByteArray buf;
-    buf.reserve(10 * 1024);
+    buf.reserve(1024 + response.content.length());
 
     // Status Line
     buf += QString("HTTP/%1 %2 %3")

--- a/src/base/http/responsegenerator.cpp
+++ b/src/base/http/responsegenerator.cpp
@@ -45,16 +45,20 @@ QByteArray Http::toByteArray(Response response)
     buf.reserve(1024 + response.content.length());
 
     // Status Line
-    buf += QString("HTTP/%1 %2 %3")
-        .arg("1.1",  // TODO: depends on request
-            QString::number(response.status.code),
-            response.status.text)
-        .toLatin1()
+    buf.append("HTTP/1.1 ")  // TODO: depends on request
+        .append(QByteArray::number(response.status.code))
+        .append(' ')
+        .append(response.status.text.toLatin1())
         .append(CRLF);
 
     // Header Fields
     for (auto i = response.headers.constBegin(); i != response.headers.constEnd(); ++i)
-        buf += QString::fromLatin1("%1: %2").arg(i.key(), i.value()).toLatin1().append(CRLF);
+    {
+        buf.append(i.key().toLatin1())
+            .append(": ")
+            .append(i.value().toLatin1())
+            .append(CRLF);
+    }
 
     // the first empty line
     buf += CRLF;


### PR DESCRIPTION
* Restart idle timer on sending network response
* Reserve enough buffer space according to response content size
* Avoid needless string-bytes conversion
  This saves a few microseconds.
