### PR TITLE
Don't expire connection when there are data in buffer

### DIFF
--- a/src/base/http/connection.cpp
+++ b/src/base/http/connection.cpp
@@ -134,7 +134,9 @@ void Connection::sendResponse(const Response &response) const
 
 bool Connection::hasExpired(const qint64 timeout) const
 {
-    return m_idleTimer.hasExpired(timeout);
+    return (m_socket->bytesAvailable() == 0)
+        && (m_socket->bytesToWrite() == 0)
+        && m_idleTimer.hasExpired(timeout);
 }
 
 bool Connection::isClosed() const


### PR DESCRIPTION
For writing, this ensures expire handler won't be executed in a small time window, that is after `m_socket->write()` and before `QIODevice::bytesWritten()` signal.
For reading, this let the socket to have the chance to process the received data instead of dropping it.

This is a supplement to ece92a886ab1c7f5a44906f43cdeea58d2872944.