### PR TITLE
Improve torrent content handling

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -116,6 +116,7 @@ add_library(qbt_base STATIC
     bittorrent/speedmonitor.cpp
     bittorrent/statistics.cpp
     bittorrent/torrent.cpp
+    bittorrent/torrentcontentlayout.cpp
     bittorrent/torrentcreatorthread.cpp
     bittorrent/torrentimpl.cpp
     bittorrent/torrentinfo.cpp

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -116,6 +116,7 @@ SOURCES += \
     $$PWD/bittorrent/speedmonitor.cpp \
     $$PWD/bittorrent/statistics.cpp \
     $$PWD/bittorrent/torrent.cpp \
+    $$PWD/bittorrent/torrentcontentlayout.cpp \
     $$PWD/bittorrent/torrentcreatorthread.cpp \
     $$PWD/bittorrent/torrentimpl.cpp \
     $$PWD/bittorrent/torrentinfo.cpp \

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -499,7 +499,7 @@ namespace BitTorrent
 
         bool addMoveTorrentStorageJob(TorrentImpl *torrent, const QString &newPath, MoveStorageMode mode);
 
-        void findIncompleteFiles(const TorrentInfo &torrentInfo, const QString &savePath) const;
+        void findIncompleteFiles(const TorrentInfo &torrentInfo, const QString &savePath, const QStringList &filePaths = {}) const;
 
     signals:
         void allTorrentsFinished();

--- a/src/base/bittorrent/torrentcontentlayout.h
+++ b/src/base/bittorrent/torrentcontentlayout.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2020  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2020-2021  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -48,4 +48,7 @@ namespace BitTorrent
 
         Q_ENUM_NS(TorrentContentLayout)
     }
+
+    TorrentContentLayout detectContentLayout(const QStringList &filePaths);
+    void applyContentLayout(QStringList &filePaths, TorrentContentLayout contentLayout, const QString &rootFolder = {});
 }

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -289,6 +289,7 @@ namespace BitTorrent
         lt::torrent_status m_nativeStatus;
         TorrentState m_state = TorrentState::Unknown;
         TorrentInfo m_torrentInfo;
+        QStringList m_filePaths;
         SpeedMonitor m_speedMonitor;
 
         InfoHash m_infoHash;
@@ -300,12 +301,6 @@ namespace BitTorrent
         bool m_storageIsMoving = false;
 
         MaintenanceJob m_maintenanceJob = MaintenanceJob::None;
-
-#ifndef QBT_USES_LIBTORRENT2
-        // Until libtorrent provided an "old_name" field in `file_renamed_alert`
-        // we relied on this workaround to remove empty leftover folders
-        QHash<int, QVector<QString>> m_oldPath;
-#endif
 
         QHash<QString, QMap<lt::tcp::endpoint, int>> m_trackerPeerCounts;
         FileErrorInfo m_lastFileError;

--- a/src/base/bittorrent/torrentinfo.h
+++ b/src/base/bittorrent/torrentinfo.h
@@ -35,7 +35,6 @@
 
 #include "base/3rdparty/expected.hpp"
 #include "base/indexrange.h"
-#include "abstractfilestorage.h"
 #include "torrentcontentlayout.h"
 
 class QByteArray;
@@ -48,13 +47,15 @@ namespace BitTorrent
     class InfoHash;
     struct TrackerEntry;
 
-    class TorrentInfo final : public AbstractFileStorage
+    class TorrentInfo
     {
         Q_DECLARE_TR_FUNCTIONS(TorrentInfo)
 
     public:
-        explicit TorrentInfo(std::shared_ptr<const lt::torrent_info> nativeInfo = {});
+        TorrentInfo() = default;
         TorrentInfo(const TorrentInfo &other);
+
+        explicit TorrentInfo(const lt::torrent_info &nativeInfo);
 
         static nonstd::expected<TorrentInfo, QString> load(const QByteArray &data) noexcept;
         static nonstd::expected<TorrentInfo, QString> loadFromFile(const QString &path) noexcept;
@@ -70,14 +71,13 @@ namespace BitTorrent
         QString comment() const;
         bool isPrivate() const;
         qlonglong totalSize() const;
-        int filesCount() const override;
+        int filesCount() const;
         int pieceLength() const;
         int pieceLength(int index) const;
         int piecesCount() const;
-        QString filePath(int index) const override;
+        QString filePath(int index) const;
         QStringList filePaths() const;
-        QString origFilePath(int index) const;
-        qlonglong fileSize(int index) const override;
+        qlonglong fileSize(int index) const;
         qlonglong fileOffset(int index) const;
         QVector<TrackerEntry> trackers() const;
         QVector<QUrl> urlSeeds() const;
@@ -92,11 +92,8 @@ namespace BitTorrent
         PieceRange filePieces(const QString &file) const;
         PieceRange filePieces(int fileIndex) const;
 
-        void renameFile(int index, const QString &newPath) override;
-
         QString rootFolder() const;
         bool hasRootFolder() const;
-        void setContentLayout(TorrentContentLayout layout);
 
         std::shared_ptr<lt::torrent_info> nativeInfo() const;
         QVector<lt::file_index_t> nativeIndexes() const;
@@ -104,11 +101,9 @@ namespace BitTorrent
     private:
         // returns file index or -1 if fileName is not found
         int fileIndex(const QString &fileName) const;
-        void stripRootFolder();
-        void addRootFolder();
-        TorrentContentLayout defaultContentLayout() const;
+        TorrentContentLayout contentLayout() const;
 
-        std::shared_ptr<lt::torrent_info> m_nativeInfo;
+        std::shared_ptr<const lt::torrent_info> m_nativeInfo;
 
         // internal indexes of files (payload only, excluding any .pad files)
         // by which they are addressed in libtorrent

--- a/src/base/utils/fs.cpp
+++ b/src/base/utils/fs.cpp
@@ -398,3 +398,40 @@ bool Utils::Fs::isNetworkFileSystem(const QString &path)
 #endif
 }
 #endif // Q_OS_HAIKU
+
+QString Utils::Fs::findRootFolder(const QStringList &filePaths)
+{
+    QString rootFolder;
+    for (const QString &filePath : filePaths)
+    {
+        const auto filePathElements = QStringView(filePath).split(u'/');
+        // if at least one file has no root folder, no common root folder exists
+        if (filePathElements.count() <= 1)
+            return {};
+
+        if (rootFolder.isEmpty())
+            rootFolder = filePathElements.at(0).toString();
+        else if (rootFolder != filePathElements.at(0))
+            return {};
+    }
+
+    return rootFolder;
+}
+
+void Utils::Fs::stripRootFolder(QStringList &filePaths)
+{
+    const QString commonRootFolder = findRootFolder(filePaths);
+    if (commonRootFolder.isEmpty())
+        return;
+
+    for (QString &filePath : filePaths)
+        filePath = filePath.mid(commonRootFolder.size() + 1);
+}
+
+void Utils::Fs::addRootFolder(QStringList &filePaths, const QString &rootFolder)
+{
+    Q_ASSERT(!rootFolder.isEmpty());
+
+    for (QString &filePath : filePaths)
+        filePath = rootFolder + QLatin1Char('/') + filePath;
+}

--- a/src/base/utils/fs.h
+++ b/src/base/utils/fs.h
@@ -71,6 +71,10 @@ namespace Utils::Fs
 
     QString tempPath();
 
+    QString findRootFolder(const QStringList &filePaths);
+    void stripRootFolder(QStringList &filePaths);
+    void addRootFolder(QStringList &filePaths, const QString &name);
+
 #if !defined Q_OS_HAIKU
     bool isNetworkFileSystem(const QString &path);
 #endif

--- a/src/gui/addnewtorrentdialog.h
+++ b/src/gui/addnewtorrentdialog.h
@@ -86,6 +86,7 @@ private slots:
     void TMMChanged(int index);
     void categoryChanged(int index);
     void doNotDeleteTorrentClicked(bool checked);
+    void renameSelectedFile();
 
     void accept() override;
     void reject() override;
@@ -104,13 +105,13 @@ private:
     void setupTreeview();
     void setSavePath(const QString &newPath);
     void saveTorrentFile();
+    bool hasMetadata() const;
 
     void showEvent(QShowEvent *event) override;
 
     Ui::AddNewTorrentDialog *m_ui;
     TorrentContentFilterModel *m_contentModel = nullptr;
     PropListDelegate *m_contentDelegate = nullptr;
-    bool m_hasMetadata = false;
     BitTorrent::MagnetUri m_magnetURI;
     BitTorrent::TorrentInfo m_torrentInfo;
     int m_oldIndex = 0;

--- a/src/gui/addnewtorrentdialog.h
+++ b/src/gui/addnewtorrentdialog.h
@@ -85,6 +85,7 @@ private slots:
     void handleDownloadFinished(const Net::DownloadResult &downloadResult);
     void TMMChanged(int index);
     void categoryChanged(int index);
+    void contentLayoutChanged(int index);
     void doNotDeleteTorrentClicked(bool checked);
     void renameSelectedFile();
 

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -471,7 +471,9 @@ void PeerListWidget::updatePeer(const BitTorrent::Torrent *torrent, const BitTor
     setModelData(row, PeerListColumns::TOT_UP, totalUp, peer.totalUpload(), intDataTextAlignment);
     setModelData(row, PeerListColumns::RELEVANCE, (Utils::String::fromDouble(peer.relevance() * 100, 1) + '%'), peer.relevance(), intDataTextAlignment);
 
-    const QStringList downloadingFiles {torrent->info().filesForPiece(peer.downloadingPieceIndex())};
+    const QStringList downloadingFiles {torrent->hasMetadata()
+                ? torrent->info().filesForPiece(peer.downloadingPieceIndex())
+                : QStringList()};
     const QString downloadingFilesDisplayValue = downloadingFiles.join(';');
     setModelData(row, PeerListColumns::DOWNLOADING_PIECE, downloadingFilesDisplayValue, downloadingFilesDisplayValue, {}, downloadingFiles.join(QLatin1Char('\n')));
 

--- a/src/gui/properties/piecesbar.cpp
+++ b/src/gui/properties/piecesbar.cpp
@@ -256,13 +256,14 @@ void PiecesBar::showToolTip(const QHelpEvent *e)
     const bool showDetailedInformation = QApplication::keyboardModifiers().testFlag(Qt::ShiftModifier);
     if (showDetailedInformation && m_torrent->hasMetadata())
     {
+        const BitTorrent::TorrentInfo torrentInfo = m_torrent->info();
         const int imagePos = e->pos().x() - borderWidth;
         if ((imagePos >=0) && (imagePos < m_image.width()))
         {
             stream << "<html><body>";
-            PieceIndexToImagePos transform {m_torrent->info(), m_image};
+            PieceIndexToImagePos transform {torrentInfo, m_image};
             int pieceIndex = transform.pieceIndex(imagePos);
-            const QVector<int> files {m_torrent->info().fileIndicesForPiece(pieceIndex)};
+            const QVector<int> files {torrentInfo.fileIndicesForPiece(pieceIndex)};
 
             QString tooltipTitle;
             if (files.count() > 1)
@@ -271,7 +272,7 @@ void PiecesBar::showToolTip(const QHelpEvent *e)
             }
             else
             {
-                if (m_torrent->info().fileSize(files.front()) == m_torrent->info().pieceLength(pieceIndex))
+                if (torrentInfo.fileSize(files.front()) == torrentInfo.pieceLength(pieceIndex))
                     tooltipTitle = tr("File in this piece");
                 else
                     tooltipTitle = tr("File in these pieces");
@@ -281,8 +282,8 @@ void PiecesBar::showToolTip(const QHelpEvent *e)
 
             for (int f : files)
             {
-                const QString filePath {m_torrent->info().filePath(f)};
-                renderer(Utils::Misc::friendlyUnit(m_torrent->info().fileSize(f)), filePath);
+                const QString filePath {torrentInfo.filePath(f)};
+                renderer(Utils::Misc::friendlyUnit(torrentInfo.fileSize(f)), filePath);
             }
             stream << "</body></html>";
         }
@@ -306,13 +307,14 @@ void PiecesBar::highlightFile(int imagePos)
     if (!m_torrent || !m_torrent->hasMetadata() || (imagePos < 0) || (imagePos >= m_image.width()))
         return;
 
-    PieceIndexToImagePos transform {m_torrent->info(), m_image};
+    const BitTorrent::TorrentInfo torrentInfo = m_torrent->info();
+    PieceIndexToImagePos transform {torrentInfo, m_image};
 
     int pieceIndex = transform.pieceIndex(imagePos);
-    QVector<int> fileIndices {m_torrent->info().fileIndicesForPiece(pieceIndex)};
+    QVector<int> fileIndices {torrentInfo.fileIndicesForPiece(pieceIndex)};
     if (fileIndices.count() == 1)
     {
-        BitTorrent::TorrentInfo::PieceRange filePieces = m_torrent->info().filePieces(fileIndices.first());
+        BitTorrent::TorrentInfo::PieceRange filePieces = torrentInfo.filePieces(fileIndices.first());
 
         ImageRange imageRange = transform.imagePos(filePieces);
         QRect newHighlightedRegion {imageRange.first(), 0, imageRange.size(), m_image.height()};

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -528,7 +528,7 @@ void PropertiesWidget::loadDynamicData()
             if (!isContentInitialized)
             {
                 // List files in torrent
-                m_propListModel->model()->setupModelData(m_torrent->info());
+                m_propListModel->model()->setupModelData(*m_torrent);
                 // Load file priorities
                 m_propListModel->model()->updateFilesPriorities(m_torrent->filePriorities());
                 // Update file progress/availability

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -50,8 +50,8 @@
 #include <QPixmapCache>
 #endif
 
+#include "base/bittorrent/abstractfilestorage.h"
 #include "base/bittorrent/downloadpriority.h"
-#include "base/bittorrent/torrentinfo.h"
 #include "base/global.h"
 #include "base/utils/fs.h"
 #include "torrentcontentmodelfile.h"
@@ -485,7 +485,7 @@ void TorrentContentModel::clear()
     endResetModel();
 }
 
-void TorrentContentModel::setupModelData(const BitTorrent::TorrentInfo &info)
+void TorrentContentModel::setupModelData(const BitTorrent::AbstractFileStorage &info)
 {
     qDebug("setup model data called");
     const int filesCount = info.filesCount();

--- a/src/gui/torrentcontentmodel.h
+++ b/src/gui/torrentcontentmodel.h
@@ -41,7 +41,7 @@ class TorrentContentModelFile;
 
 namespace BitTorrent
 {
-    class TorrentInfo;
+    class AbstractFileStorage;
 }
 
 class TorrentContentModel final : public QAbstractItemModel
@@ -74,7 +74,7 @@ public:
     QModelIndex parent(const QModelIndex &index) const override;
     int rowCount(const QModelIndex &parent = {}) const override;
     void clear();
-    void setupModelData(const BitTorrent::TorrentInfo &info);
+    void setupModelData(const BitTorrent::AbstractFileStorage &info);
 
 signals:
     void filteredFilesChanged();

--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -573,9 +573,11 @@ void SyncController::torrentPeersAction()
             {KEY_PEER_CONNECTION_TYPE, pi.connectionType()},
             {KEY_PEER_FLAGS, pi.flags()},
             {KEY_PEER_FLAGS_DESCRIPTION, pi.flagsDescription()},
-            {KEY_PEER_RELEVANCE, pi.relevance()},
-            {KEY_PEER_FILES, torrent->info().filesForPiece(pi.downloadingPieceIndex()).join('\n')}
+            {KEY_PEER_RELEVANCE, pi.relevance()}
         };
+
+        if (torrent->hasMetadata())
+            peer.insert(KEY_PEER_FILES, torrent->info().filesForPiece(pi.downloadingPieceIndex()).join('\n'));
 
         if (resolvePeerCountries)
         {

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -594,9 +594,12 @@ void TorrentsController::pieceHashesAction()
         throw APIError(APIErrorType::NotFound);
 
     QJsonArray pieceHashes;
-    const QVector<QByteArray> hashes = torrent->info().pieceHashes();
-    for (const QByteArray &hash : hashes)
-        pieceHashes.append(QString(hash.toHex()));
+    if (torrent->hasMetadata())
+    {
+        const QVector<QByteArray> hashes = torrent->info().pieceHashes();
+        for (const QByteArray &hash : hashes)
+            pieceHashes.append(QString(hash.toHex()));
+    }
 
     setResult(pieceHashes);
 }


### PR DESCRIPTION
First commit provides core changes that make clear distinction between original torrent layout (including file names) and currently used local mapping of it (so TorrentInfo instance becomes immutable since then).
The second commit makes "Add new torrent dialog" to follow selected "Content layout" in files view.

![001](https://user-images.githubusercontent.com/5063477/146557845-304a725c-b99b-4437-b14e-d2fc2be2ac70.png)   

![002](https://user-images.githubusercontent.com/5063477/146557855-77c44319-b3b0-4f81-ae18-fb1a9bec66fc.png)

