### PR TITLE
GHA CI: Don't upload built artifacts for dynamic linking builds

### DIFF
--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -90,7 +90,6 @@ jobs:
       - name: Prepare build artifacts
         run: |
           mkdir upload
-          mv qbittorrent upload
           mkdir upload/cmake
           cp build/compile_commands.json upload/cmake
           mkdir upload/cmake/libtorrent
@@ -99,5 +98,5 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: qBittorrent-CI_ubuntu-20.04-x64_${{ matrix.qbt_gui }}_libtorrent-${{ matrix.libt_version }}_Qt-${{ matrix.qt_version }}
+          name: build-info_ubuntu-20.04-x64_${{ matrix.qbt_gui }}_libtorrent-${{ matrix.libt_version }}_Qt-${{ matrix.qt_version }}
           path: upload


### PR DESCRIPTION
As those won't work on testers system unless they install *all* and same version of the dependent libraries too.

Another way is making it to link statically but that will require rebuilds of *all* libraries which will increase CI run time unnecessarily, i.e. this way isn't practical for CI.