### PR TITLE
Implement class for handling filesystem paths

### DIFF
--- a/src/app/application.h
+++ b/src/app/application.h
@@ -47,6 +47,7 @@ class QSessionManager;
 using BaseApplication = QCoreApplication;
 #endif // DISABLE_GUI
 
+#include "base/path.h"
 #include "base/settingvalue.h"
 #include "base/types.h"
 #include "cmdoptions.h"
@@ -91,8 +92,8 @@ public:
     // FileLogger properties
     bool isFileLoggerEnabled() const;
     void setFileLoggerEnabled(bool value);
-    QString fileLoggerPath() const;
-    void setFileLoggerPath(const QString &path);
+    Path fileLoggerPath() const;
+    void setFileLoggerPath(const Path &path);
     bool isFileLoggerBackup() const;
     void setFileLoggerBackup(bool value);
     bool isFileLoggerDeleteOld() const;
@@ -152,5 +153,5 @@ private:
     SettingValue<int> m_storeFileLoggerMaxSize;
     SettingValue<int> m_storeFileLoggerAge;
     SettingValue<int> m_storeFileLoggerAgeType;
-    SettingValue<QString> m_storeFileLoggerPath;
+    SettingValue<Path> m_storeFileLoggerPath;
 };

--- a/src/app/applicationinstancemanager.cpp
+++ b/src/app/applicationinstancemanager.cpp
@@ -37,18 +37,19 @@
 #include <QSharedMemory>
 #endif
 
+#include "base/path.h"
 #include "qtlocalpeer/qtlocalpeer.h"
 
-ApplicationInstanceManager::ApplicationInstanceManager(const QString &instancePath, QObject *parent)
+ApplicationInstanceManager::ApplicationInstanceManager(const Path &instancePath, QObject *parent)
     : QObject {parent}
-    , m_peer {new QtLocalPeer {instancePath, this}}
+    , m_peer {new QtLocalPeer(instancePath.data(), this)}
     , m_isFirstInstance {!m_peer->isClient()}
 {
     connect(m_peer, &QtLocalPeer::messageReceived, this, &ApplicationInstanceManager::messageReceived);
 
 #ifdef Q_OS_WIN
-    const QString sharedMemoryKey = instancePath + QLatin1String {"/shared-memory"};
-    auto sharedMem = new QSharedMemory {sharedMemoryKey, this};
+    const QString sharedMemoryKey = instancePath.data() + QLatin1String("/shared-memory");
+    auto sharedMem = new QSharedMemory(sharedMemoryKey, this);
     if (m_isFirstInstance)
     {
         // First instance creates shared memory and store PID

--- a/src/app/applicationinstancemanager.h
+++ b/src/app/applicationinstancemanager.h
@@ -30,6 +30,8 @@
 
 #include <QObject>
 
+#include "base/pathfwd.h"
+
 class QtLocalPeer;
 
 class ApplicationInstanceManager final : public QObject
@@ -38,7 +40,7 @@ class ApplicationInstanceManager final : public QObject
     Q_DISABLE_COPY_MOVE(ApplicationInstanceManager)
 
 public:
-    explicit ApplicationInstanceManager(const QString &instancePath, QObject *parent = nullptr);
+    explicit ApplicationInstanceManager(const Path &instancePath, QObject *parent = nullptr);
 
     bool isFirstInstance() const;
 

--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -372,7 +372,7 @@ QStringList QBtCommandLineParameters::paramList() const
     // torrent paths or URLs.
 
     if (!savePath.isEmpty())
-        result.append(QLatin1String("@savePath=") + savePath);
+        result.append(QLatin1String("@savePath=") + savePath.data());
 
     if (addPaused.has_value())
         result.append(*addPaused ? QLatin1String {"@addPaused=1"} : QLatin1String {"@addPaused=0"});
@@ -438,7 +438,7 @@ QBtCommandLineParameters parseCommandLine(const QStringList &args)
 #endif
             else if (arg == PROFILE_OPTION)
             {
-                result.profileDir = PROFILE_OPTION.value(arg);
+                result.profileDir = Path(PROFILE_OPTION.value(arg));
             }
             else if (arg == RELATIVE_FASTRESUME)
             {
@@ -450,7 +450,7 @@ QBtCommandLineParameters parseCommandLine(const QStringList &args)
             }
             else if (arg == SAVE_PATH_OPTION)
             {
-                result.savePath = SAVE_PATH_OPTION.value(arg);
+                result.savePath = Path(SAVE_PATH_OPTION.value(arg));
             }
             else if (arg == PAUSED_OPTION)
             {

--- a/src/app/cmdoptions.h
+++ b/src/app/cmdoptions.h
@@ -36,6 +36,7 @@
 #include <QStringList>
 
 #include "base/exceptions.h"
+#include "base/path.h"
 
 class QProcessEnvironment;
 
@@ -58,9 +59,9 @@ struct QBtCommandLineParameters
     std::optional<bool> addPaused;
     std::optional<bool> skipDialog;
     QStringList torrents;
-    QString profileDir;
+    Path profileDir;
     QString configurationName;
-    QString savePath;
+    Path savePath;
     QString category;
     QString unknownParameter;
 

--- a/src/app/filelogger.h
+++ b/src/app/filelogger.h
@@ -32,6 +32,8 @@
 #include <QObject>
 #include <QTimer>
 
+#include "base/path.h"
+
 namespace Log
 {
     struct Msg;
@@ -50,10 +52,10 @@ public:
         YEARS
     };
 
-    FileLogger(const QString &path, bool backup, int maxSize, bool deleteOld, int age, FileLogAgeType ageType);
+    FileLogger(const Path &path, bool backup, int maxSize, bool deleteOld, int age, FileLogAgeType ageType);
     ~FileLogger();
 
-    void changePath(const QString &newPath);
+    void changePath(const Path &newPath);
     void deleteOld(int age, FileLogAgeType ageType);
     void setBackup(bool value);
     void setMaxSize(int value);
@@ -66,7 +68,7 @@ private:
     void openLogFile();
     void closeLogFile();
 
-    QString m_path;
+    Path m_path;
     bool m_backup;
     int m_maxSize;
     QFile m_logFile;

--- a/src/app/upgrade.cpp
+++ b/src/app/upgrade.cpp
@@ -48,7 +48,7 @@ namespace
 
     void exportWebUIHttpsFiles()
     {
-        const auto migrate = [](const QString &oldKey, const QString &newKey, const QString &savePath)
+        const auto migrate = [](const QString &oldKey, const QString &newKey, const Path &savePath)
         {
             SettingsStorage *settingsStorage {SettingsStorage::instance()};
             const auto oldData {settingsStorage->loadValue<QByteArray>(oldKey)};
@@ -61,24 +61,24 @@ namespace
             const nonstd::expected<void, QString> result = Utils::IO::saveToFile(savePath, oldData);
             if (!result)
             {
-                LogMsg(errorMsgFormat.arg(savePath, result.error()) , Log::WARNING);
+                LogMsg(errorMsgFormat.arg(savePath.toString(), result.error()) , Log::WARNING);
                 return;
             }
 
             settingsStorage->storeValue(newKey, savePath);
             settingsStorage->removeValue(oldKey);
 
-            LogMsg(QObject::tr("Migrated preferences: WebUI https, exported data to file: \"%1\"").arg(savePath)
+            LogMsg(QObject::tr("Migrated preferences: WebUI https, exported data to file: \"%1\"").arg(savePath.toString())
                 , Log::INFO);
         };
 
-        const QString configPath {specialFolderLocation(SpecialFolder::Config)};
+        const Path configPath = specialFolderLocation(SpecialFolder::Config);
         migrate(QLatin1String("Preferences/WebUI/HTTPS/Certificate")
             , QLatin1String("Preferences/WebUI/HTTPS/CertificatePath")
-            , Utils::Fs::toNativePath(configPath + QLatin1String("/WebUICertificate.crt")));
+            , (configPath / Path("WebUICertificate.crt")));
         migrate(QLatin1String("Preferences/WebUI/HTTPS/Key")
             , QLatin1String("Preferences/WebUI/HTTPS/KeyPath")
-            , Utils::Fs::toNativePath(configPath + QLatin1String("/WebUIPrivateKey.pem")));
+            , (configPath / Path("WebUIPrivateKey.pem")));
     }
 
     void upgradeTorrentContentLayout()

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -62,6 +62,8 @@ add_library(qbt_base STATIC
     net/reverseresolution.h
     net/smtp.h
     orderedset.h
+    path.h
+    pathfwd.h
     preferences.h
     profile.h
     profile_p.h
@@ -144,6 +146,7 @@ add_library(qbt_base STATIC
     net/proxyconfigurationmanager.cpp
     net/reverseresolution.cpp
     net/smtp.cpp
+    path.cpp
     preferences.cpp
     profile.cpp
     profile_p.cpp

--- a/src/base/asyncfilestorage.cpp
+++ b/src/base/asyncfilestorage.cpp
@@ -31,21 +31,22 @@
 #include <QDebug>
 #include <QMetaObject>
 
+#include "base/utils/fs.h"
 #include "base/utils/io.h"
 
-AsyncFileStorage::AsyncFileStorage(const QString &storageFolderPath, QObject *parent)
+AsyncFileStorage::AsyncFileStorage(const Path &storageFolderPath, QObject *parent)
     : QObject(parent)
     , m_storageDir(storageFolderPath)
-    , m_lockFile(m_storageDir.absoluteFilePath(QStringLiteral("storage.lock")))
+    , m_lockFile((m_storageDir / Path(QStringLiteral("storage.lock"))).data())
 {
-    if (!m_storageDir.mkpath(m_storageDir.absolutePath()))
-        throw AsyncFileStorageError
-        {tr("Could not create directory '%1'.")
-                .arg(m_storageDir.absolutePath())};
+    Q_ASSERT(m_storageDir.isAbsolute());
+
+    if (!Utils::Fs::mkpath(m_storageDir))
+        throw AsyncFileStorageError(tr("Could not create directory '%1'.").arg(m_storageDir.toString()));
 
     // TODO: This folder locking approach does not work for UNIX systems. Implement it.
     if (!m_lockFile.open(QFile::WriteOnly))
-        throw AsyncFileStorageError {m_lockFile.errorString()};
+        throw AsyncFileStorageError(m_lockFile.errorString());
 }
 
 AsyncFileStorage::~AsyncFileStorage()
@@ -54,21 +55,21 @@ AsyncFileStorage::~AsyncFileStorage()
     m_lockFile.remove();
 }
 
-void AsyncFileStorage::store(const QString &fileName, const QByteArray &data)
+void AsyncFileStorage::store(const Path &filePath, const QByteArray &data)
 {
-    QMetaObject::invokeMethod(this, [this, data, fileName]() { store_impl(fileName, data); }
+    QMetaObject::invokeMethod(this, [this, data, filePath]() { store_impl(filePath, data); }
                               , Qt::QueuedConnection);
 }
 
-QDir AsyncFileStorage::storageDir() const
+Path AsyncFileStorage::storageDir() const
 {
     return m_storageDir;
 }
 
-void AsyncFileStorage::store_impl(const QString &fileName, const QByteArray &data)
+void AsyncFileStorage::store_impl(const Path &fileName, const QByteArray &data)
 {
-    const QString filePath = m_storageDir.absoluteFilePath(fileName);
-    qDebug() << "AsyncFileStorage: Saving data to" << filePath;
+    const Path filePath = m_storageDir / fileName;
+    qDebug() << "AsyncFileStorage: Saving data to" << filePath.toString();
 
     const nonstd::expected<void, QString> result = Utils::IO::saveToFile(filePath, data);
     if (!result)

--- a/src/base/asyncfilestorage.h
+++ b/src/base/asyncfilestorage.h
@@ -28,11 +28,11 @@
 
 #pragma once
 
-#include <QDir>
 #include <QFile>
 #include <QObject>
 
 #include "base/exceptions.h"
+#include "base/path.h"
 
 class AsyncFileStorageError : public RuntimeError
 {
@@ -46,19 +46,19 @@ class AsyncFileStorage : public QObject
     Q_DISABLE_COPY_MOVE(AsyncFileStorage)
 
 public:
-    explicit AsyncFileStorage(const QString &storageFolderPath, QObject *parent = nullptr);
+    explicit AsyncFileStorage(const Path &storageFolderPath, QObject *parent = nullptr);
     ~AsyncFileStorage() override;
 
-    void store(const QString &fileName, const QByteArray &data);
+    void store(const Path &filePath, const QByteArray &data);
 
-    QDir storageDir() const;
+    Path storageDir() const;
 
 signals:
-    void failed(const QString &fileName, const QString &errorString);
+    void failed(const Path &filePath, const QString &errorString);
 
 private:
-    Q_INVOKABLE void store_impl(const QString &fileName, const QByteArray &data);
+    Q_INVOKABLE void store_impl(const Path &fileName, const QByteArray &data);
 
-    QDir m_storageDir;
+    Path m_storageDir;
     QFile m_lockFile;
 };

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -61,6 +61,8 @@ HEADERS += \
     $$PWD/net/reverseresolution.h \
     $$PWD/net/smtp.h \
     $$PWD/orderedset.h \
+    $$PWD/path.h \
+    $$PWD/pathfwd.h \
     $$PWD/preferences.h \
     $$PWD/profile.h \
     $$PWD/profile_p.h \
@@ -144,6 +146,7 @@ SOURCES += \
     $$PWD/net/proxyconfigurationmanager.cpp \
     $$PWD/net/reverseresolution.cpp \
     $$PWD/net/smtp.cpp \
+    $$PWD/path.cpp \
     $$PWD/preferences.cpp \
     $$PWD/profile.cpp \
     $$PWD/profile_p.cpp \

--- a/src/base/bittorrent/abstractfilestorage.h
+++ b/src/base/bittorrent/abstractfilestorage.h
@@ -31,6 +31,8 @@
 #include <QtGlobal>
 #include <QCoreApplication>
 
+#include "base/pathfwd.h"
+
 class QString;
 
 namespace BitTorrent
@@ -43,12 +45,12 @@ namespace BitTorrent
         virtual ~AbstractFileStorage() = default;
 
         virtual int filesCount() const = 0;
-        virtual QString filePath(int index) const = 0;
+        virtual Path filePath(int index) const = 0;
         virtual qlonglong fileSize(int index) const = 0;
 
-        virtual void renameFile(int index, const QString &name) = 0;
+        virtual void renameFile(int index, const Path &newPath) = 0;
 
-        void renameFile(const QString &oldPath, const QString &newPath);
-        void renameFolder(const QString &oldPath, const QString &newPath);
+        void renameFile(const Path &oldPath, const Path &newPath);
+        void renameFolder(const Path &oldFolderPath, const Path &newFolderPath);
     };
 }

--- a/src/base/bittorrent/addtorrentparams.h
+++ b/src/base/bittorrent/addtorrentparams.h
@@ -34,6 +34,7 @@
 #include <QString>
 #include <QVector>
 
+#include "base/path.h"
 #include "base/tagset.h"
 #include "torrent.h"
 #include "torrentcontentlayout.h"
@@ -47,14 +48,14 @@ namespace BitTorrent
         QString name;
         QString category;
         TagSet tags;
-        QString savePath;
+        Path savePath;
         std::optional<bool> useDownloadPath;
-        QString downloadPath;
+        Path downloadPath;
         bool sequential = false;
         bool firstLastPiecePriority = false;
         bool addForced = false;
         std::optional<bool> addPaused;
-        QStringList filePaths; // used if TorrentInfo is set
+        PathList filePaths; // used if TorrentInfo is set
         QVector<DownloadPriority> filePriorities; // used if TorrentInfo is set
         bool skipChecking = false;
         std::optional<BitTorrent::TorrentContentLayout> contentLayout;

--- a/src/base/bittorrent/bencoderesumedatastorage.h
+++ b/src/base/bittorrent/bencoderesumedatastorage.h
@@ -31,6 +31,7 @@
 #include <QDir>
 #include <QVector>
 
+#include "base/path.h"
 #include "resumedatastorage.h"
 
 class QByteArray;
@@ -44,7 +45,7 @@ namespace BitTorrent
         Q_DISABLE_COPY_MOVE(BencodeResumeDataStorage)
 
     public:
-        explicit BencodeResumeDataStorage(const QString &path, QObject *parent = nullptr);
+        explicit BencodeResumeDataStorage(const Path &path, QObject *parent = nullptr);
         ~BencodeResumeDataStorage() override;
 
         QVector<TorrentID> registeredTorrents() const override;
@@ -54,10 +55,10 @@ namespace BitTorrent
         void storeQueue(const QVector<TorrentID> &queue) const override;
 
     private:
-        void loadQueue(const QString &queueFilename);
+        void loadQueue(const Path &queueFilename);
         std::optional<LoadTorrentParams> loadTorrentResumeData(const QByteArray &data, const QByteArray &metadata) const;
 
-        const QDir m_resumeDataDir;
+        const Path m_resumeDataPath;
         QVector<TorrentID> m_registeredTorrents;
         QThread *m_ioThread = nullptr;
 

--- a/src/base/bittorrent/categoryoptions.cpp
+++ b/src/base/bittorrent/categoryoptions.cpp
@@ -37,13 +37,13 @@ const QString OPTION_DOWNLOADPATH {QStringLiteral("download_path")};
 BitTorrent::CategoryOptions BitTorrent::CategoryOptions::fromJSON(const QJsonObject &jsonObj)
 {
     CategoryOptions options;
-    options.savePath = jsonObj.value(OPTION_SAVEPATH).toString();
+    options.savePath = Path(jsonObj.value(OPTION_SAVEPATH).toString());
 
     const QJsonValue downloadPathValue = jsonObj.value(OPTION_DOWNLOADPATH);
     if (downloadPathValue.isBool())
         options.downloadPath = {downloadPathValue.toBool(), {}};
     else if (downloadPathValue.isString())
-        options.downloadPath = {true, downloadPathValue.toString()};
+        options.downloadPath = {true, Path(downloadPathValue.toString())};
 
     return options;
 }
@@ -54,13 +54,13 @@ QJsonObject BitTorrent::CategoryOptions::toJSON() const
     if (downloadPath)
     {
         if (downloadPath->enabled)
-            downloadPathValue = downloadPath->path;
+            downloadPathValue = downloadPath->path.data();
         else
             downloadPathValue = false;
     }
 
     return {
-        {OPTION_SAVEPATH, savePath},
+        {OPTION_SAVEPATH, savePath.data()},
         {OPTION_DOWNLOADPATH, downloadPathValue}
     };
 }

--- a/src/base/bittorrent/categoryoptions.h
+++ b/src/base/bittorrent/categoryoptions.h
@@ -32,6 +32,8 @@
 
 #include <QString>
 
+#include "base/path.h"
+
 class QJsonObject;
 
 namespace BitTorrent
@@ -41,10 +43,10 @@ namespace BitTorrent
         struct DownloadPathOption
         {
             bool enabled;
-            QString path;
+            Path path;
         };
 
-        QString savePath;
+        Path savePath;
         std::optional<DownloadPathOption> downloadPath;
 
         static CategoryOptions fromJSON(const QJsonObject &jsonObj);

--- a/src/base/bittorrent/customstorage.cpp
+++ b/src/base/bittorrent/customstorage.cpp
@@ -30,8 +30,6 @@
 
 #include <libtorrent/download_priority.hpp>
 
-#include <QDir>
-
 #include "base/utils/fs.h"
 #include "common.h"
 
@@ -53,12 +51,13 @@ lt::storage_holder CustomDiskIOThread::new_torrent(const lt::storage_params &sto
 {
     lt::storage_holder storageHolder = m_nativeDiskIO->new_torrent(storageParams, torrent);
 
-    const QString savePath = Utils::Fs::expandPathAbs(QString::fromStdString(storageParams.path));
+    const Path savePath {storageParams.path};
     m_storageData[storageHolder] =
     {
-            savePath
-            , storageParams.mapped_files ? *storageParams.mapped_files : storageParams.files
-            , storageParams.priorities};
+        savePath,
+        storageParams.mapped_files ? *storageParams.mapped_files : storageParams.files,
+        storageParams.priorities
+    };
 
     return storageHolder;
 }
@@ -99,7 +98,7 @@ void CustomDiskIOThread::async_hash2(lt::storage_index_t storage, lt::piece_inde
 void CustomDiskIOThread::async_move_storage(lt::storage_index_t storage, std::string path, lt::move_flags_t flags
                                             , std::function<void (lt::status_t, const std::string &, const lt::storage_error &)> handler)
 {
-    const QString newSavePath {Utils::Fs::expandPathAbs(QString::fromStdString(path))};
+    const Path newSavePath {path};
 
     if (flags == lt::move_flags_t::dont_replace)
         handleCompleteFiles(storage, newSavePath);
@@ -192,9 +191,8 @@ void CustomDiskIOThread::settings_updated()
     m_nativeDiskIO->settings_updated();
 }
 
-void CustomDiskIOThread::handleCompleteFiles(lt::storage_index_t storage, const QString &savePath)
+void CustomDiskIOThread::handleCompleteFiles(lt::storage_index_t storage, const Path &savePath)
 {
-    const QDir saveDir {savePath};
     const StorageData storageData = m_storageData[storage];
     const lt::file_storage &fileStorage = storageData.files;
     for (const lt::file_index_t fileIndex : fileStorage.file_range())
@@ -206,16 +204,16 @@ void CustomDiskIOThread::handleCompleteFiles(lt::storage_index_t storage, const 
         // ignore pad files
         if (fileStorage.pad_file_at(fileIndex)) continue;
 
-        const QString filePath = QString::fromStdString(fileStorage.file_path(fileIndex));
-        if (filePath.endsWith(QB_EXT))
+        const Path filePath {fileStorage.file_path(fileIndex)};
+        if (filePath.hasExtension(QB_EXT))
         {
-            const QString completeFilePath = filePath.left(filePath.size() - QB_EXT.size());
-            QFile completeFile {saveDir.absoluteFilePath(completeFilePath)};
-            if (completeFile.exists())
+            const Path incompleteFilePath = savePath / filePath;
+            Path completeFilePath = incompleteFilePath;
+            completeFilePath.removeExtension();
+            if (completeFilePath.exists())
             {
-                QFile incompleteFile {saveDir.absoluteFilePath(filePath)};
-                incompleteFile.remove();
-                completeFile.rename(incompleteFile.fileName());
+                Utils::Fs::removeFile(incompleteFilePath);
+                Utils::Fs::renameFile(completeFilePath, incompleteFilePath);
             }
         }
     }
@@ -230,7 +228,7 @@ lt::storage_interface *customStorageConstructor(const lt::storage_params &params
 
 CustomStorage::CustomStorage(const lt::storage_params &params, lt::file_pool &filePool)
     : lt::default_storage {params, filePool}
-    , m_savePath {Utils::Fs::expandPathAbs(QString::fromStdString(params.path))}
+    , m_savePath {params.path}
 {
 }
 
@@ -248,7 +246,7 @@ void CustomStorage::set_file_priority(lt::aux::vector<lt::download_priority_t, l
 
 lt::status_t CustomStorage::move_storage(const std::string &savePath, lt::move_flags_t flags, lt::storage_error &ec)
 {
-    const QString newSavePath {Utils::Fs::expandPathAbs(QString::fromStdString(savePath))};
+    const Path newSavePath {savePath};
 
     if (flags == lt::move_flags_t::dont_replace)
         handleCompleteFiles(newSavePath);
@@ -260,10 +258,8 @@ lt::status_t CustomStorage::move_storage(const std::string &savePath, lt::move_f
     return ret;
 }
 
-void CustomStorage::handleCompleteFiles(const QString &savePath)
+void CustomStorage::handleCompleteFiles(const Path &savePath)
 {
-    const QDir saveDir {savePath};
-
     const lt::file_storage &fileStorage = files();
     for (const lt::file_index_t fileIndex : fileStorage.file_range())
     {
@@ -274,16 +270,16 @@ void CustomStorage::handleCompleteFiles(const QString &savePath)
         // ignore pad files
         if (fileStorage.pad_file_at(fileIndex)) continue;
 
-        const QString filePath = QString::fromStdString(fileStorage.file_path(fileIndex));
-        if (filePath.endsWith(QB_EXT))
+        const Path filePath {fileStorage.file_path(fileIndex)};
+        if (filePath.hasExtension(QB_EXT))
         {
-            const QString completeFilePath = filePath.left(filePath.size() - QB_EXT.size());
-            QFile completeFile {saveDir.absoluteFilePath(completeFilePath)};
-            if (completeFile.exists())
+            const Path incompleteFilePath = savePath / filePath;
+            Path completeFilePath = incompleteFilePath;
+            completeFilePath.removeExtension();
+            if (completeFilePath.exists())
             {
-                QFile incompleteFile {saveDir.absoluteFilePath(filePath)};
-                incompleteFile.remove();
-                completeFile.rename(incompleteFile.fileName());
+                Utils::Fs::removeFile(incompleteFilePath);
+                Utils::Fs::renameFile(completeFilePath, incompleteFilePath);
             }
         }
     }

--- a/src/base/bittorrent/customstorage.h
+++ b/src/base/bittorrent/customstorage.h
@@ -33,6 +33,8 @@
 
 #include <QString>
 
+#include "base/path.h"
+
 #ifdef QBT_USES_LIBTORRENT2
 #include <libtorrent/disk_interface.hpp>
 #include <libtorrent/file_storage.hpp>
@@ -86,13 +88,13 @@ public:
     void settings_updated() override;
 
 private:
-    void handleCompleteFiles(libtorrent::storage_index_t storage, const QString &savePath);
+    void handleCompleteFiles(libtorrent::storage_index_t storage, const Path &savePath);
 
     std::unique_ptr<lt::disk_interface> m_nativeDiskIO;
 
     struct StorageData
     {
-        QString savePath;
+        Path savePath;
         lt::file_storage files;
         lt::aux::vector<lt::download_priority_t, lt::file_index_t> filePriorities;
     };
@@ -113,9 +115,9 @@ public:
     lt::status_t move_storage(const std::string &savePath, lt::move_flags_t flags, lt::storage_error &ec) override;
 
 private:
-    void handleCompleteFiles(const QString &savePath);
+    void handleCompleteFiles(const Path &savePath);
 
     lt::aux::vector<lt::download_priority_t, lt::file_index_t> m_filePriorities;
-    QString m_savePath;
+    Path m_savePath;
 };
 #endif

--- a/src/base/bittorrent/dbresumedatastorage.h
+++ b/src/base/bittorrent/dbresumedatastorage.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include "base/pathfwd.h"
 #include "resumedatastorage.h"
 
 class QThread;
@@ -40,7 +41,7 @@ namespace BitTorrent
         Q_DISABLE_COPY_MOVE(DBResumeDataStorage)
 
     public:
-        explicit DBResumeDataStorage(const QString &dbPath, QObject *parent = nullptr);
+        explicit DBResumeDataStorage(const Path &dbPath, QObject *parent = nullptr);
         ~DBResumeDataStorage() override;
 
         QVector<TorrentID> registeredTorrents() const override;

--- a/src/base/bittorrent/filesearcher.cpp
+++ b/src/base/bittorrent/filesearcher.cpp
@@ -27,37 +27,33 @@
  */
 
 #include "filesearcher.h"
-
-#include <QDir>
-
 #include "base/bittorrent/common.h"
 #include "base/bittorrent/infohash.h"
 
-void FileSearcher::search(const BitTorrent::TorrentID &id, const QStringList &originalFileNames
-                          , const QString &savePath, const QString &downloadPath)
+void FileSearcher::search(const BitTorrent::TorrentID &id, const PathList &originalFileNames
+                          , const Path &savePath, const Path &downloadPath)
 {
-    const auto findInDir = [](const QString &dirPath, QStringList &fileNames) -> bool
+    const auto findInDir = [](const Path &dirPath, PathList &fileNames) -> bool
     {
-        const QDir dir {dirPath};
         bool found = false;
-        for (QString &fileName : fileNames)
+        for (Path &fileName : fileNames)
         {
-            if (dir.exists(fileName))
+            if ((dirPath / fileName).exists())
             {
                 found = true;
             }
-            else if (dir.exists(fileName + QB_EXT))
+            else if ((dirPath / fileName + QB_EXT).exists())
             {
                 found = true;
-                fileName += QB_EXT;
+                fileName = fileName + QB_EXT;
             }
         }
 
         return found;
     };
 
-    QString usedPath = savePath;
-    QStringList adjustedFileNames = originalFileNames;
+    Path usedPath = savePath;
+    PathList adjustedFileNames = originalFileNames;
     const bool found = findInDir(usedPath, adjustedFileNames);
     if (!found && !downloadPath.isEmpty())
     {

--- a/src/base/bittorrent/filesearcher.h
+++ b/src/base/bittorrent/filesearcher.h
@@ -30,6 +30,8 @@
 
 #include <QObject>
 
+#include "base/path.h"
+
 namespace BitTorrent
 {
     class TorrentID;
@@ -44,9 +46,9 @@ public:
     FileSearcher() = default;
 
 public slots:
-    void search(const BitTorrent::TorrentID &id, const QStringList &originalFileNames
-                , const QString &savePath, const QString &downloadPath);
+    void search(const BitTorrent::TorrentID &id, const PathList &originalFileNames
+                , const Path &savePath, const Path &downloadPath);
 
 signals:
-    void searchFinished(const BitTorrent::TorrentID &id, const QString &savePath, const QStringList &fileNames);
+    void searchFinished(const BitTorrent::TorrentID &id, const Path &savePath, const PathList &fileNames);
 };

--- a/src/base/bittorrent/filterparserthread.cpp
+++ b/src/base/bittorrent/filterparserthread.cpp
@@ -124,7 +124,7 @@ FilterParserThread::~FilterParserThread()
 int FilterParserThread::parseDATFilterFile()
 {
     int ruleCount = 0;
-    QFile file(m_filePath);
+    QFile file {m_filePath.data()};
     if (!file.exists()) return ruleCount;
 
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
@@ -288,7 +288,7 @@ int FilterParserThread::parseDATFilterFile()
 int FilterParserThread::parseP2PFilterFile()
 {
     int ruleCount = 0;
-    QFile file(m_filePath);
+    QFile file {m_filePath.data()};
     if (!file.exists()) return ruleCount;
 
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
@@ -469,7 +469,7 @@ int FilterParserThread::getlineInStream(QDataStream &stream, std::string &name, 
 int FilterParserThread::parseP2BFilterFile()
 {
     int ruleCount = 0;
-    QFile file(m_filePath);
+    QFile file {m_filePath.data()};
     if (!file.exists()) return ruleCount;
 
     if (!file.open(QIODevice::ReadOnly))
@@ -592,7 +592,7 @@ int FilterParserThread::parseP2BFilterFile()
 //  * eMule IP list (DAT): http://wiki.phoenixlabs.org/wiki/DAT_Format
 //  * PeerGuardian Text (P2P): http://wiki.phoenixlabs.org/wiki/P2P_Format
 //  * PeerGuardian Binary (P2B): http://wiki.phoenixlabs.org/wiki/P2B_Format
-void FilterParserThread::processFilterFile(const QString &filePath)
+void FilterParserThread::processFilterFile(const Path &filePath)
 {
     if (isRunning())
     {
@@ -617,17 +617,17 @@ void FilterParserThread::run()
 {
     qDebug("Processing filter file");
     int ruleCount = 0;
-    if (m_filePath.endsWith(".p2p", Qt::CaseInsensitive))
+    if (m_filePath.hasExtension(QLatin1String(".p2p")))
     {
         // PeerGuardian p2p file
         ruleCount = parseP2PFilterFile();
     }
-    else if (m_filePath.endsWith(".p2b", Qt::CaseInsensitive))
+    else if (m_filePath.hasExtension(QLatin1String(".p2b")))
     {
         // PeerGuardian p2b file
         ruleCount = parseP2BFilterFile();
     }
-    else if (m_filePath.endsWith(".dat", Qt::CaseInsensitive))
+    else if (m_filePath.hasExtension(QLatin1String(".dat")))
     {
         // eMule DAT format
         ruleCount = parseDATFilterFile();

--- a/src/base/bittorrent/filterparserthread.h
+++ b/src/base/bittorrent/filterparserthread.h
@@ -32,16 +32,19 @@
 
 #include <QThread>
 
+#include "base/path.h"
+
 class QDataStream;
 
 class FilterParserThread final : public QThread
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(FilterParserThread)
 
 public:
     FilterParserThread(QObject *parent = nullptr);
     ~FilterParserThread();
-    void processFilterFile(const QString &filePath);
+    void processFilterFile(const Path &filePath);
     lt::ip_filter IPfilter();
 
 signals:
@@ -60,6 +63,6 @@ private:
     int parseP2BFilterFile();
 
     bool m_abort;
-    QString m_filePath;
+    Path m_filePath;
     lt::ip_filter m_filter;
 };

--- a/src/base/bittorrent/loadtorrentparams.h
+++ b/src/base/bittorrent/loadtorrentparams.h
@@ -32,6 +32,7 @@
 
 #include <QString>
 
+#include "base/path.h"
 #include "base/tagset.h"
 #include "torrent.h"
 #include "torrentcontentlayout.h"
@@ -45,8 +46,8 @@ namespace BitTorrent
         QString name;
         QString category;
         TagSet tags;
-        QString savePath;
-        QString downloadPath;
+        Path savePath;
+        Path downloadPath;
         TorrentContentLayout contentLayout = TorrentContentLayout::Original;
         TorrentOperatingMode operatingMode = TorrentOperatingMode::AutoManaged;
         bool useAutoTMM = false;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -43,6 +43,7 @@
 #include <QtContainerFwd>
 #include <QVector>
 
+#include "base/path.h"
 #include "base/settingvalue.h"
 #include "base/types.h"
 #include "addtorrentparams.h"
@@ -202,7 +203,7 @@ namespace BitTorrent
         } disk;
     };
 
-    class Session : public QObject
+    class Session final : public QObject
     {
         Q_OBJECT
         Q_DISABLE_COPY_MOVE(Session)
@@ -212,10 +213,10 @@ namespace BitTorrent
         static void freeInstance();
         static Session *instance();
 
-        QString savePath() const;
-        void setSavePath(const QString &path);
-        QString downloadPath() const;
-        void setDownloadPath(const QString &path);
+        Path savePath() const;
+        void setSavePath(const Path &path);
+        Path downloadPath() const;
+        void setDownloadPath(const Path &path);
         bool isDownloadPathEnabled() const;
         void setDownloadPathEnabled(bool enabled);
 
@@ -225,8 +226,8 @@ namespace BitTorrent
 
         QStringList categories() const;
         CategoryOptions categoryOptions(const QString &categoryName) const;
-        QString categorySavePath(const QString &categoryName) const;
-        QString categoryDownloadPath(const QString &categoryName) const;
+        Path categorySavePath(const QString &categoryName) const;
+        Path categoryDownloadPath(const QString &categoryName) const;
         bool addCategory(const QString &name, const CategoryOptions &options = {});
         bool editCategory(const QString &name, const CategoryOptions &options);
         bool removeCategory(const QString &name);
@@ -283,10 +284,10 @@ namespace BitTorrent
         void setRefreshInterval(int value);
         bool isPreallocationEnabled() const;
         void setPreallocationEnabled(bool enabled);
-        QString torrentExportDirectory() const;
-        void setTorrentExportDirectory(QString path);
-        QString finishedTorrentExportDirectory() const;
-        void setFinishedTorrentExportDirectory(QString path);
+        Path torrentExportDirectory() const;
+        void setTorrentExportDirectory(const Path &path);
+        Path finishedTorrentExportDirectory() const;
+        void setFinishedTorrentExportDirectory(const Path &path);
 
         int globalDownloadSpeedLimit() const;
         void setGlobalDownloadSpeedLimit(int limit);
@@ -329,8 +330,8 @@ namespace BitTorrent
         void setAdditionalTrackers(const QString &trackers);
         bool isIPFilteringEnabled() const;
         void setIPFilteringEnabled(bool enabled);
-        QString IPFilterFile() const;
-        void setIPFilterFile(QString path);
+        Path IPFilterFile() const;
+        void setIPFilterFile(const Path &path);
         bool announceToAllTrackers() const;
         void setAnnounceToAllTrackers(bool val);
         bool announceToAllTiers() const;
@@ -501,10 +502,10 @@ namespace BitTorrent
         void handleTorrentTrackerWarning(TorrentImpl *const torrent, const QString &trackerUrl);
         void handleTorrentTrackerError(TorrentImpl *const torrent, const QString &trackerUrl);
 
-        bool addMoveTorrentStorageJob(TorrentImpl *torrent, const QString &newPath, MoveStorageMode mode);
+        bool addMoveTorrentStorageJob(TorrentImpl *torrent, const Path &newPath, MoveStorageMode mode);
 
-        void findIncompleteFiles(const TorrentInfo &torrentInfo, const QString &savePath
-                                 , const QString &downloadPath, const QStringList &filePaths = {}) const;
+        void findIncompleteFiles(const TorrentInfo &torrentInfo, const Path &savePath
+                                 , const Path &downloadPath, const PathList &filePaths = {}) const;
 
     signals:
         void allTorrentsFinished();
@@ -553,7 +554,7 @@ namespace BitTorrent
         void handleIPFilterParsed(int ruleCount);
         void handleIPFilterError();
         void handleDownloadFinished(const Net::DownloadResult &result);
-        void fileSearchFinished(const TorrentID &id, const QString &savePath, const QStringList &fileNames);
+        void fileSearchFinished(const TorrentID &id, const Path &savePath, const PathList &fileNames);
 
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
         // Session reconfiguration triggers
@@ -565,14 +566,14 @@ namespace BitTorrent
         struct MoveStorageJob
         {
             lt::torrent_handle torrentHandle;
-            QString path;
+            Path path;
             MoveStorageMode mode;
         };
 
         struct RemovingTorrentData
         {
             QString name;
-            QString pathToRemove;
+            Path pathToRemove;
             DeleteOption deleteOption;
         };
 
@@ -611,7 +612,7 @@ namespace BitTorrent
         bool addTorrent_impl(const std::variant<MagnetUri, TorrentInfo> &source, const AddTorrentParams &addTorrentParams);
 
         void updateSeedingLimitTimer();
-        void exportTorrentFile(const TorrentInfo &torrentInfo, const QString &folderPath, const QString &baseName);
+        void exportTorrentFile(const TorrentInfo &torrentInfo, const Path &folderPath, const QString &baseName);
 
         void handleAlert(const lt::alert *a);
         void dispatchTorrentAlert(const lt::alert *a);
@@ -663,7 +664,7 @@ namespace BitTorrent
         CachedSettingValue<bool> m_isPeXEnabled;
         CachedSettingValue<bool> m_isIPFilteringEnabled;
         CachedSettingValue<bool> m_isTrackerFilteringEnabled;
-        CachedSettingValue<QString> m_IPFilterFile;
+        CachedSettingValue<Path> m_IPFilterFile;
         CachedSettingValue<bool> m_announceToAllTrackers;
         CachedSettingValue<bool> m_announceToAllTiers;
         CachedSettingValue<int> m_asyncIOThreads;
@@ -721,8 +722,8 @@ namespace BitTorrent
         CachedSettingValue<bool> m_isAppendExtensionEnabled;
         CachedSettingValue<int> m_refreshInterval;
         CachedSettingValue<bool> m_isPreallocationEnabled;
-        CachedSettingValue<QString> m_torrentExportDirectory;
-        CachedSettingValue<QString> m_finishedTorrentExportDirectory;
+        CachedSettingValue<Path> m_torrentExportDirectory;
+        CachedSettingValue<Path> m_finishedTorrentExportDirectory;
         CachedSettingValue<int> m_globalDownloadSpeedLimit;
         CachedSettingValue<int> m_globalUploadSpeedLimit;
         CachedSettingValue<int> m_altGlobalDownloadSpeedLimit;
@@ -740,8 +741,8 @@ namespace BitTorrent
         CachedSettingValue<SeedChokingAlgorithm> m_seedChokingAlgorithm;
         CachedSettingValue<QStringList> m_storedTags;
         CachedSettingValue<int> m_maxRatioAction;
-        CachedSettingValue<QString> m_savePath;
-        CachedSettingValue<QString> m_downloadPath;
+        CachedSettingValue<Path> m_savePath;
+        CachedSettingValue<Path> m_downloadPath;
         CachedSettingValue<bool> m_isDownloadPathEnabled;
         CachedSettingValue<bool> m_isSubcategoriesEnabled;
         CachedSettingValue<bool> m_useCategoryPathsInManualMode;

--- a/src/base/bittorrent/torrent.h
+++ b/src/base/bittorrent/torrent.h
@@ -29,10 +29,11 @@
 
 #pragma once
 
+#include <QtContainerFwd>
 #include <QMetaType>
 #include <QString>
-#include <QtContainerFwd>
 
+#include "base/pathfwd.h"
 #include "base/tagset.h"
 #include "abstractfilestorage.h"
 
@@ -169,13 +170,13 @@ namespace BitTorrent
 
         virtual bool isAutoTMMEnabled() const = 0;
         virtual void setAutoTMMEnabled(bool enabled) = 0;
-        virtual QString savePath() const = 0;
-        virtual void setSavePath(const QString &savePath) = 0;
-        virtual QString downloadPath() const = 0;
-        virtual void setDownloadPath(const QString &downloadPath) = 0;
-        virtual QString actualStorageLocation() const = 0;
-        virtual QString rootPath() const = 0;
-        virtual QString contentPath() const = 0;
+        virtual Path savePath() const = 0;
+        virtual void setSavePath(const Path &savePath) = 0;
+        virtual Path downloadPath() const = 0;
+        virtual void setDownloadPath(const Path &downloadPath) = 0;
+        virtual Path actualStorageLocation() const = 0;
+        virtual Path rootPath() const = 0;
+        virtual Path contentPath() const = 0;
         virtual QString category() const = 0;
         virtual bool belongsToCategory(const QString &category) const = 0;
         virtual bool setCategory(const QString &category) = 0;
@@ -193,8 +194,8 @@ namespace BitTorrent
         virtual qreal ratioLimit() const = 0;
         virtual int seedingTimeLimit() const = 0;
 
-        virtual QString actualFilePath(int index) const = 0;
-        virtual QStringList filePaths() const = 0;
+        virtual Path actualFilePath(int index) const = 0;
+        virtual PathList filePaths() const = 0;
         virtual QVector<DownloadPriority> filePriorities() const = 0;
 
         virtual TorrentInfo info() const = 0;

--- a/src/base/bittorrent/torrentcontentlayout.cpp
+++ b/src/base/bittorrent/torrentcontentlayout.cpp
@@ -32,36 +32,35 @@
 
 namespace
 {
-    QString removeExtension(const QString &fileName)
+    Path removeExtension(const Path &fileName)
     {
-        const QString extension = Utils::Fs::fileExtension(fileName);
-        return extension.isEmpty()
-                ? fileName
-                : fileName.chopped(extension.size() + 1);
+        Path result = fileName;
+        result.removeExtension();
+        return result;
     }
 }
 
-BitTorrent::TorrentContentLayout BitTorrent::detectContentLayout(const QStringList &filePaths)
+BitTorrent::TorrentContentLayout BitTorrent::detectContentLayout(const PathList &filePaths)
 {
-    const QString rootFolder = Utils::Fs::findRootFolder(filePaths);
+    const Path rootFolder = Path::findRootFolder(filePaths);
     return (rootFolder.isEmpty()
             ? TorrentContentLayout::NoSubfolder
             : TorrentContentLayout::Subfolder);
 }
 
-void BitTorrent::applyContentLayout(QStringList &filePaths, const BitTorrent::TorrentContentLayout contentLayout, const QString &rootFolder)
+void BitTorrent::applyContentLayout(PathList &filePaths, const BitTorrent::TorrentContentLayout contentLayout, const Path &rootFolder)
 {
     Q_ASSERT(!filePaths.isEmpty());
 
     switch (contentLayout)
     {
     case TorrentContentLayout::Subfolder:
-        if (Utils::Fs::findRootFolder(filePaths).isEmpty())
-            Utils::Fs::addRootFolder(filePaths, !rootFolder.isEmpty() ? rootFolder : removeExtension(filePaths.at(0)));
+        if (Path::findRootFolder(filePaths).isEmpty())
+            Path::addRootFolder(filePaths, !rootFolder.isEmpty() ? rootFolder : removeExtension(filePaths.at(0)));
         break;
 
     case TorrentContentLayout::NoSubfolder:
-        Utils::Fs::stripRootFolder(filePaths);
+        Path::stripRootFolder(filePaths);
         break;
 
     default:

--- a/src/base/bittorrent/torrentcontentlayout.h
+++ b/src/base/bittorrent/torrentcontentlayout.h
@@ -28,7 +28,10 @@
 
 #pragma once
 
+#include <QtContainerFwd>
 #include <QMetaEnum>
+
+#include "base/path.h"
 
 namespace BitTorrent
 {
@@ -49,6 +52,6 @@ namespace BitTorrent
         Q_ENUM_NS(TorrentContentLayout)
     }
 
-    TorrentContentLayout detectContentLayout(const QStringList &filePaths);
-    void applyContentLayout(QStringList &filePaths, TorrentContentLayout contentLayout, const QString &rootFolder = {});
+    TorrentContentLayout detectContentLayout(const PathList &filePaths);
+    void applyContentLayout(PathList &filePaths, TorrentContentLayout contentLayout, const Path &rootFolder = {});
 }

--- a/src/base/bittorrent/torrentcreatorthread.h
+++ b/src/base/bittorrent/torrentcreatorthread.h
@@ -31,6 +31,8 @@
 #include <QStringList>
 #include <QThread>
 
+#include "base/path.h"
+
 namespace BitTorrent
 {
 #ifdef QBT_USES_LIBTORRENT2
@@ -52,8 +54,8 @@ namespace BitTorrent
         int paddedFileSizeLimit;
 #endif
         int pieceSize;
-        QString inputPath;
-        QString savePath;
+        Path inputPath;
+        Path savePath;
         QString comment;
         QString source;
         QStringList trackers;
@@ -72,15 +74,15 @@ namespace BitTorrent
         void create(const TorrentCreatorParams &params);
 
 #ifdef QBT_USES_LIBTORRENT2
-        static int calculateTotalPieces(const QString &inputPath, const int pieceSize, const TorrentFormat torrentFormat);
+        static int calculateTotalPieces(const Path &inputPath, const int pieceSize, const TorrentFormat torrentFormat);
 #else
-        static int calculateTotalPieces(const QString &inputPath
+        static int calculateTotalPieces(const Path &inputPath
             , const int pieceSize, const bool isAlignmentOptimized, int paddedFileSizeLimit);
 #endif
 
     signals:
         void creationFailure(const QString &msg);
-        void creationSuccess(const QString &path, const QString &branchPath);
+        void creationSuccess(const Path &path, const Path &branchPath);
         void updateProgress(int progress);
 
     private:

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -45,7 +45,6 @@
 #endif
 
 #include <QDebug>
-#include <QDir>
 #include <QFile>
 #include <QStringList>
 #include <QUrl>
@@ -282,8 +281,10 @@ TorrentImpl::TorrentImpl(Session *session, lt::session *nativeSession
         {
             const lt::file_index_t nativeIndex = m_torrentInfo.nativeIndexes().at(i);
             m_indexMap[nativeIndex] = i;
-            const QString filePath = Utils::Fs::toUniformPath(QString::fromStdString(fileStorage.file_path(nativeIndex)));
-            m_filePaths.append(filePath.endsWith(QB_EXT, Qt::CaseInsensitive) ? filePath.chopped(QB_EXT.size()) : filePath);
+            Path filePath {fileStorage.file_path(nativeIndex)};
+            if (filePath.hasExtension(QB_EXT))
+                filePath.removeExtension();
+            m_filePaths.append(filePath);
         }
     }
 
@@ -295,24 +296,22 @@ TorrentImpl::TorrentImpl(Session *session, lt::session *nativeSession
 
     // TODO: Remove the following upgrade code in v4.4
     // == BEGIN UPGRADE CODE ==
-    const QString spath = actualStorageLocation();
+    const Path spath = actualStorageLocation();
     for (int i = 0; i < filesCount(); ++i)
     {
-        const QString filepath = filePath(i);
+        const Path filepath = filePath(i);
         // Move "unwanted" files back to their original folder
-        const QString parentRelPath = Utils::Fs::branchPath(filepath);
-        if (QDir(parentRelPath).dirName() == ".unwanted")
+        const Path parentRelPath = filepath.parentPath();
+        if (parentRelPath.filename() == QLatin1String(".unwanted"))
         {
-            const QString oldName = Utils::Fs::fileName(filepath);
-            const QString newRelPath = Utils::Fs::branchPath(parentRelPath);
-            if (newRelPath.isEmpty())
-                renameFile(i, oldName);
-            else
-                renameFile(i, QDir(newRelPath).filePath(oldName));
+            const QString oldName = filepath.filename();
+            const Path newRelPath = parentRelPath.parentPath();
+            renameFile(i, (newRelPath / Path(oldName)));
 
             // Remove .unwanted directory if empty
-            qDebug() << "Attempting to remove \".unwanted\" folder at " << QDir(spath + '/' + newRelPath).absoluteFilePath(".unwanted");
-            QDir(spath + '/' + newRelPath).rmdir(".unwanted");
+            const Path newPath = spath / newRelPath;
+            qDebug() << "Attempting to remove \".unwanted\" folder at " << (newPath / Path(".unwanted")).toString();
+            Utils::Fs::rmdir(newPath / Path(".unwanted"));
         }
     }
     // == END UPGRADE CODE ==
@@ -396,18 +395,18 @@ QString TorrentImpl::currentTracker() const
     return QString::fromStdString(m_nativeStatus.current_tracker);
 }
 
-QString TorrentImpl::savePath() const
+Path TorrentImpl::savePath() const
 {
     return isAutoTMMEnabled() ? m_session->categorySavePath(category()) : m_savePath;
 }
 
-void TorrentImpl::setSavePath(const QString &path)
+void TorrentImpl::setSavePath(const Path &path)
 {
     Q_ASSERT(!isAutoTMMEnabled());
 
-    const QString basePath = m_session->useCategoryPathsInManualMode()
+    const Path basePath = m_session->useCategoryPathsInManualMode()
             ? m_session->categorySavePath(category()) : m_session->savePath();
-    const QString resolvedPath = (QDir::isAbsolutePath(path) ? path : Utils::Fs::resolvePath(path, basePath));
+    const Path resolvedPath = (path.isAbsolute() ? path : (basePath / path));
     if (resolvedPath == savePath())
         return;
 
@@ -420,18 +419,18 @@ void TorrentImpl::setSavePath(const QString &path)
         moveStorage(savePath(), MoveStorageMode::KeepExistingFiles);
 }
 
-QString TorrentImpl::downloadPath() const
+Path TorrentImpl::downloadPath() const
 {
     return isAutoTMMEnabled() ? m_session->categoryDownloadPath(category()) : m_downloadPath;
 }
 
-void TorrentImpl::setDownloadPath(const QString &path)
+void TorrentImpl::setDownloadPath(const Path &path)
 {
     Q_ASSERT(!isAutoTMMEnabled());
 
-    const QString basePath = m_session->useCategoryPathsInManualMode()
+    const Path basePath = m_session->useCategoryPathsInManualMode()
             ? m_session->categoryDownloadPath(category()) : m_session->downloadPath();
-    const QString resolvedPath = ((path.isEmpty() || QDir::isAbsolutePath(path)) ? path : Utils::Fs::resolvePath(path, basePath));
+    const Path resolvedPath = (path.isEmpty() || path.isAbsolute()) ? path : (basePath / path);
     if (resolvedPath == m_downloadPath)
         return;
 
@@ -444,27 +443,27 @@ void TorrentImpl::setDownloadPath(const QString &path)
         moveStorage((m_downloadPath.isEmpty() ? savePath() : m_downloadPath), MoveStorageMode::KeepExistingFiles);
 }
 
-QString TorrentImpl::rootPath() const
+Path TorrentImpl::rootPath() const
 {
     if (!hasMetadata())
         return {};
 
-    const QString relativeRootPath = Utils::Fs::findRootFolder(filePaths());
+    const Path relativeRootPath = Path::findRootFolder(filePaths());
     if (relativeRootPath.isEmpty())
         return {};
 
-    return QDir(actualStorageLocation()).absoluteFilePath(relativeRootPath);
+    return (actualStorageLocation() / relativeRootPath);
 }
 
-QString TorrentImpl::contentPath() const
+Path TorrentImpl::contentPath() const
 {
     if (!hasMetadata())
         return {};
 
     if (filesCount() == 1)
-        return QDir(actualStorageLocation()).absoluteFilePath(filePath(0));
+        return (actualStorageLocation() / filePath(0));
 
-    const QString rootPath = this->rootPath();
+    const Path rootPath = this->rootPath();
     return (rootPath.isEmpty() ? actualStorageLocation() : rootPath);
 }
 
@@ -491,9 +490,9 @@ void TorrentImpl::setAutoTMMEnabled(bool enabled)
     adjustStorageLocation();
 }
 
-QString TorrentImpl::actualStorageLocation() const
+Path TorrentImpl::actualStorageLocation() const
 {
-    return Utils::Fs::toUniformPath(QString::fromStdString(m_nativeStatus.save_path));
+    return Path(m_nativeStatus.save_path);
 }
 
 void TorrentImpl::setAutoManaged(const bool enable)
@@ -799,16 +798,15 @@ int TorrentImpl::seedingTimeLimit() const
     return m_seedingTimeLimit;
 }
 
-QString TorrentImpl::filePath(const int index) const
+Path TorrentImpl::filePath(const int index) const
 {
     return m_filePaths.at(index);
 }
 
-QString TorrentImpl::actualFilePath(const int index) const
+Path TorrentImpl::actualFilePath(const int index) const
 {
     const auto nativeIndex = m_torrentInfo.nativeIndexes().at(index);
-    const std::string filePath = m_nativeHandle.torrent_file()->files().file_path(nativeIndex);
-    return Utils::Fs::toUniformPath(QString::fromStdString(filePath));
+    return Path(m_nativeHandle.torrent_file()->files().file_path(nativeIndex));
 }
 
 qlonglong TorrentImpl::fileSize(const int index) const
@@ -816,7 +814,7 @@ qlonglong TorrentImpl::fileSize(const int index) const
     return m_torrentInfo.fileSize(index);
 }
 
-QStringList TorrentImpl::filePaths() const
+PathList TorrentImpl::filePaths() const
 {
     return m_filePaths;
 }
@@ -1481,12 +1479,12 @@ void TorrentImpl::applyFirstLastPiecePriority(const bool enabled, const QVector<
     m_nativeHandle.prioritize_pieces(piecePriorities);
 }
 
-void TorrentImpl::fileSearchFinished(const QString &savePath, const QStringList &fileNames)
+void TorrentImpl::fileSearchFinished(const Path &savePath, const PathList &fileNames)
 {
     endReceivedMetadataHandling(savePath, fileNames);
 }
 
-void TorrentImpl::endReceivedMetadataHandling(const QString &savePath, const QStringList &fileNames)
+void TorrentImpl::endReceivedMetadataHandling(const Path &savePath, const PathList &fileNames)
 {
     Q_ASSERT(m_filePaths.isEmpty());
     Q_ASSERT(m_indexMap.isEmpty());
@@ -1502,11 +1500,14 @@ void TorrentImpl::endReceivedMetadataHandling(const QString &savePath, const QSt
         const auto nativeIndex = nativeIndexes.at(i);
         m_indexMap[nativeIndex] = i;
 
-        const QString filePath = fileNames.at(i);
-        m_filePaths.append(filePath.endsWith(QB_EXT, Qt::CaseInsensitive) ? filePath.chopped(QB_EXT.size()) : filePath);
-        p.renamed_files[nativeIndex] = filePath.toStdString();
+        Path filePath = fileNames.at(i);
+        p.renamed_files[nativeIndex] = filePath.toString().toStdString();
+
+        if (filePath.hasExtension(QB_EXT))
+            filePath.removeExtension();
+        m_filePaths.append(filePath);
     }
-    p.save_path = Utils::Fs::toNativePath(savePath).toStdString();
+    p.save_path = savePath.toString().toStdString();
     p.ti = metadata;
 
     const int internalFilesCount = p.ti->files().num_files(); // including .pad files
@@ -1613,19 +1614,20 @@ void TorrentImpl::resume(const TorrentOperatingMode mode)
     }
 }
 
-void TorrentImpl::moveStorage(const QString &newPath, const MoveStorageMode mode)
+void TorrentImpl::moveStorage(const Path &newPath, const MoveStorageMode mode)
 {
-    if (m_session->addMoveTorrentStorageJob(this, Utils::Fs::toNativePath(newPath), mode))
+    if (m_session->addMoveTorrentStorageJob(this, newPath, mode))
     {
         m_storageIsMoving = true;
         updateStatus();
     }
 }
 
-void TorrentImpl::renameFile(const int index, const QString &path)
+void TorrentImpl::renameFile(const int index, const Path &path)
 {
     ++m_renameCount;
-    m_nativeHandle.rename_file(m_torrentInfo.nativeIndexes().at(index), Utils::Fs::toNativePath(path).toStdString());
+    m_nativeHandle.rename_file(m_torrentInfo.nativeIndexes().at(index)
+                               , path.toString().toStdString());
 }
 
 void TorrentImpl::handleStateUpdate(const lt::torrent_status &nativeStatus)
@@ -1790,7 +1792,7 @@ void TorrentImpl::handleSaveResumeDataAlert(const lt::save_resume_data_alert *p)
 
         TorrentInfo metadata = TorrentInfo(*m_nativeHandle.torrent_file());
 
-        QStringList filePaths = metadata.filePaths();
+        PathList filePaths = metadata.filePaths();
         applyContentLayout(filePaths, m_contentLayout);
         m_session->findIncompleteFiles(metadata, savePath(), downloadPath(), filePaths);
     }
@@ -1876,37 +1878,23 @@ void TorrentImpl::handleFileRenamedAlert(const lt::file_renamed_alert *p)
     // Remove empty leftover folders
     // For example renaming "a/b/c" to "d/b/c", then folders "a/b" and "a" will
     // be removed if they are empty
-    const QString oldFilePath = m_filePaths.at(fileIndex);
-    const QString newFilePath = Utils::Fs::toUniformPath(p->new_name());
+    const Path oldFilePath = m_filePaths.at(fileIndex);
+    const Path newFilePath {QString(p->new_name())};
 
     // Check if ".!qB" extension was just added or removed
-    if ((oldFilePath != newFilePath) && (oldFilePath != newFilePath.chopped(QB_EXT.size())))
+    // We should compare path in a case sensitive manner even on case insensitive
+    // platforms since it can be renamed by only changing case of some character(s)
+    if ((oldFilePath.data() != newFilePath.data())
+            && ((oldFilePath + QB_EXT) != newFilePath))
     {
         m_filePaths[fileIndex] = newFilePath;
 
-        QList<QStringView> oldPathParts = QStringView(oldFilePath).split('/', Qt::SkipEmptyParts);
-        oldPathParts.removeLast();  // drop file name part
-        QList<QStringView> newPathParts = QStringView(newFilePath).split('/', Qt::SkipEmptyParts);
-        newPathParts.removeLast();  // drop file name part
-
-#if defined(Q_OS_WIN)
-        const Qt::CaseSensitivity caseSensitivity = Qt::CaseInsensitive;
-#else
-        const Qt::CaseSensitivity caseSensitivity = Qt::CaseSensitive;
-#endif
-
-        int pathIdx = 0;
-        while ((pathIdx < oldPathParts.size()) && (pathIdx < newPathParts.size()))
+        Path oldParentPath = oldFilePath.parentPath();
+        const Path commonBasePath = Path::commonPath(oldParentPath, newFilePath.parentPath());
+        while (oldParentPath != commonBasePath)
         {
-            if (oldPathParts[pathIdx].compare(newPathParts[pathIdx], caseSensitivity) != 0)
-                break;
-            ++pathIdx;
-        }
-
-        for (int i = (oldPathParts.size() - 1); i >= pathIdx; --i)
-        {
-            QDir().rmdir(savePath() + Utils::String::join(oldPathParts, QString::fromLatin1("/")));
-            oldPathParts.removeLast();
+            Utils::Fs::rmdir(actualStorageLocation() / oldParentPath);
+            oldParentPath = oldParentPath.parentPath();
         }
     }
 
@@ -1923,7 +1911,7 @@ void TorrentImpl::handleFileRenameFailedAlert(const lt::file_rename_failed_alert
     Q_ASSERT(fileIndex >= 0);
 
     LogMsg(tr("File rename failed. Torrent: \"%1\", file: \"%2\", reason: \"%3\"")
-        .arg(name(), filePath(fileIndex), QString::fromLocal8Bit(p->error.message().c_str())), Log::WARNING);
+        .arg(name(), filePath(fileIndex).toString(), QString::fromLocal8Bit(p->error.message().c_str())), Log::WARNING);
 
     --m_renameCount;
     while (!isMoveInProgress() && (m_renameCount == 0) && !m_moveFinishedTriggers.isEmpty())
@@ -1939,11 +1927,11 @@ void TorrentImpl::handleFileCompletedAlert(const lt::file_completed_alert *p)
         const int fileIndex = m_indexMap.value(p->index, -1);
         Q_ASSERT(fileIndex >= 0);
 
-        const QString path = filePath(fileIndex);
-        const QString actualPath = actualFilePath(fileIndex);
+        const Path path = filePath(fileIndex);
+        const Path actualPath = actualFilePath(fileIndex);
         if (actualPath != path)
         {
-            qDebug("Renaming %s to %s", qUtf8Printable(actualPath), qUtf8Printable(path));
+            qDebug("Renaming %s to %s", qUtf8Printable(actualPath.toString()), qUtf8Printable(path.toString()));
             renameFile(fileIndex, path);
         }
     }
@@ -2064,18 +2052,17 @@ void TorrentImpl::manageIncompleteFiles()
 
     for (int i = 0; i < filesCount(); ++i)
     {
-        const QString path = filePath(i);
+        const Path path = filePath(i);
 
         const auto nativeIndex = m_torrentInfo.nativeIndexes().at(i);
-        const QString actualPath = Utils::Fs::toUniformPath(
-                    QString::fromStdString(nativeFiles.file_path(nativeIndex)));
+        const Path actualPath {nativeFiles.file_path(nativeIndex)};
 
         if (isAppendExtensionEnabled && (fileSize(i) > 0) && (fp[i] < 1))
         {
-            const QString wantedPath = path + QB_EXT;
+            const Path wantedPath = path + QB_EXT;
             if (actualPath != wantedPath)
             {
-                qDebug() << "Renaming" << actualPath << "to" << wantedPath;
+                qDebug() << "Renaming" << actualPath.toString() << "to" << wantedPath.toString();
                 renameFile(i, wantedPath);
             }
         }
@@ -2083,7 +2070,7 @@ void TorrentImpl::manageIncompleteFiles()
         {
             if (actualPath != path)
             {
-                qDebug() << "Renaming" << actualPath << "to" << path;
+                qDebug() << "Renaming" << actualPath.toString() << "to" << path.toString();
                 renameFile(i, path);
             }
         }
@@ -2092,12 +2079,12 @@ void TorrentImpl::manageIncompleteFiles()
 
 void TorrentImpl::adjustStorageLocation()
 {
-    const QString downloadPath = this->downloadPath();
+    const Path downloadPath = this->downloadPath();
     const bool isFinished = isSeed() || m_hasSeedStatus;
-    const QDir targetDir {((isFinished || downloadPath.isEmpty()) ? savePath() : downloadPath)};
+    const Path targetPath = ((isFinished || downloadPath.isEmpty()) ? savePath() : downloadPath);
 
-    if ((targetDir != QDir(actualStorageLocation())) || isMoveInProgress())
-        moveStorage(targetDir.absolutePath(), MoveStorageMode::Overwrite);
+    if ((targetPath != actualStorageLocation()) || isMoveInProgress())
+        moveStorage(targetPath, MoveStorageMode::Overwrite);
 }
 
 lt::torrent_handle TorrentImpl::nativeHandle() const

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -46,6 +46,7 @@
 #include <QString>
 #include <QVector>
 
+#include "base/path.h"
 #include "base/tagset.h"
 #include "infohash.h"
 #include "speedmonitor.h"
@@ -102,13 +103,13 @@ namespace BitTorrent
 
         bool isAutoTMMEnabled() const override;
         void setAutoTMMEnabled(bool enabled) override;
-        QString savePath() const override;
-        void setSavePath(const QString &path) override;
-        QString downloadPath() const override;
-        void setDownloadPath(const QString &path) override;
-        QString actualStorageLocation() const override;
-        QString rootPath() const override;
-        QString contentPath() const override;
+        Path savePath() const override;
+        void setSavePath(const Path &path) override;
+        Path downloadPath() const override;
+        void setDownloadPath(const Path &path) override;
+        Path actualStorageLocation() const override;
+        Path rootPath() const override;
+        Path contentPath() const override;
         QString category() const override;
         bool belongsToCategory(const QString &category) const override;
         bool setCategory(const QString &category) override;
@@ -127,10 +128,10 @@ namespace BitTorrent
         qreal ratioLimit() const override;
         int seedingTimeLimit() const override;
 
-        QString filePath(int index) const override;
-        QString actualFilePath(int index) const override;
+        Path filePath(int index) const override;
+        Path actualFilePath(int index) const override;
         qlonglong fileSize(int index) const override;
-        QStringList filePaths() const override;
+        PathList filePaths() const override;
         QVector<DownloadPriority> filePriorities() const override;
 
         TorrentInfo info() const override;
@@ -205,7 +206,7 @@ namespace BitTorrent
         void forceReannounce(int index = -1) override;
         void forceDHTAnnounce() override;
         void forceRecheck() override;
-        void renameFile(int index, const QString &path) override;
+        void renameFile(int index, const Path &path) override;
         void prioritizeFiles(const QVector<DownloadPriority> &priorities) override;
         void setRatioLimit(qreal limit) override;
         void setSeedingTimeLimit(int limit) override;
@@ -237,7 +238,7 @@ namespace BitTorrent
         void handleAppendExtensionToggled();
         void saveResumeData();
         void handleMoveStorageJobFinished(bool hasOutstandingJob);
-        void fileSearchFinished(const QString &savePath, const QStringList &fileNames);
+        void fileSearchFinished(const Path &savePath, const PathList &fileNames);
 
     private:
         using EventTrigger = std::function<void ()>;
@@ -271,12 +272,12 @@ namespace BitTorrent
         void setAutoManaged(bool enable);
 
         void adjustStorageLocation();
-        void moveStorage(const QString &newPath, MoveStorageMode mode);
+        void moveStorage(const Path &newPath, MoveStorageMode mode);
         void manageIncompleteFiles();
         void applyFirstLastPiecePriority(bool enabled, const QVector<DownloadPriority> &updatedFilePrio = {});
 
         void prepareResumeData(const lt::add_torrent_params &params);
-        void endReceivedMetadataHandling(const QString &savePath, const QStringList &fileNames);
+        void endReceivedMetadataHandling(const Path &savePath, const PathList &fileNames);
         void reload();
 
         Session *const m_session;
@@ -285,7 +286,7 @@ namespace BitTorrent
         lt::torrent_status m_nativeStatus;
         TorrentState m_state = TorrentState::Unknown;
         TorrentInfo m_torrentInfo;
-        QStringList m_filePaths;
+        PathList m_filePaths;
         QHash<lt::file_index_t, int> m_indexMap;
         SpeedMonitor m_speedMonitor;
 
@@ -304,8 +305,8 @@ namespace BitTorrent
 
         // Persistent data
         QString m_name;
-        QString m_savePath;
-        QString m_downloadPath;
+        Path m_savePath;
+        Path m_downloadPath;
         QString m_category;
         TagSet m_tags;
         qreal m_ratioLimit;

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -99,16 +99,16 @@ nonstd::expected<TorrentInfo, QString> TorrentInfo::load(const QByteArray &data)
     if (ec)
         return nonstd::make_unexpected(QString::fromStdString(ec.message()));
 
-    lt::torrent_info nativeInfo {node, ec};
+    const lt::torrent_info nativeInfo {node, ec};
     if (ec)
         return nonstd::make_unexpected(QString::fromStdString(ec.message()));
 
     return TorrentInfo(nativeInfo);
 }
 
-nonstd::expected<TorrentInfo, QString> TorrentInfo::loadFromFile(const QString &path) noexcept
+nonstd::expected<TorrentInfo, QString> TorrentInfo::loadFromFile(const Path &path) noexcept
 {
-    QFile file {path};
+    QFile file {path.data()};
     if (!file.open(QIODevice::ReadOnly))
         return nonstd::make_unexpected(file.errorString());
 
@@ -133,7 +133,7 @@ nonstd::expected<TorrentInfo, QString> TorrentInfo::loadFromFile(const QString &
     return load(data);
 }
 
-nonstd::expected<void, QString> TorrentInfo::saveToFile(const QString &path) const
+nonstd::expected<void, QString> TorrentInfo::saveToFile(const Path &path) const
 {
     if (!isValid())
         return nonstd::make_unexpected(tr("Invalid metadata"));
@@ -236,17 +236,16 @@ int TorrentInfo::piecesCount() const
     return m_nativeInfo->num_pieces();
 }
 
-QString TorrentInfo::filePath(const int index) const
+Path TorrentInfo::filePath(const int index) const
 {
     if (!isValid()) return {};
 
-    return Utils::Fs::toUniformPath(
-                QString::fromStdString(m_nativeInfo->orig_files().file_path(m_nativeIndexes[index])));
+    return Path(m_nativeInfo->orig_files().file_path(m_nativeIndexes[index]));
 }
 
-QStringList TorrentInfo::filePaths() const
+PathList TorrentInfo::filePaths() const
 {
-    QStringList list;
+    PathList list;
     list.reserve(filesCount());
     for (int i = 0; i < filesCount(); ++i)
         list << filePath(i);
@@ -312,15 +311,15 @@ QByteArray TorrentInfo::metadata() const
 #endif
 }
 
-QStringList TorrentInfo::filesForPiece(const int pieceIndex) const
+PathList TorrentInfo::filesForPiece(const int pieceIndex) const
 {
     // no checks here because fileIndicesForPiece() will return an empty list
     const QVector<int> fileIndices = fileIndicesForPiece(pieceIndex);
 
-    QStringList res;
+    PathList res;
     res.reserve(fileIndices.size());
-    std::transform(fileIndices.begin(), fileIndices.end(), std::back_inserter(res),
-        [this](int i) { return filePath(i); });
+    std::transform(fileIndices.begin(), fileIndices.end(), std::back_inserter(res)
+                   , [this](int i) { return filePath(i); });
 
     return res;
 }
@@ -359,15 +358,15 @@ QVector<QByteArray> TorrentInfo::pieceHashes() const
     return hashes;
 }
 
-TorrentInfo::PieceRange TorrentInfo::filePieces(const QString &file) const
+TorrentInfo::PieceRange TorrentInfo::filePieces(const Path &filePath) const
 {
     if (!isValid()) // if we do not check here the debug message will be printed, which would be not correct
         return {};
 
-    const int index = fileIndex(file);
+    const int index = fileIndex(filePath);
     if (index == -1)
     {
-        qDebug() << "Filename" << file << "was not found in torrent" << name();
+        qDebug() << "Filename" << filePath.toString() << "was not found in torrent" << name();
         return {};
     }
     return filePieces(index);
@@ -396,13 +395,13 @@ TorrentInfo::PieceRange TorrentInfo::filePieces(const int fileIndex) const
     return makeInterval(beginIdx, endIdx);
 }
 
-int TorrentInfo::fileIndex(const QString &fileName) const
+int TorrentInfo::fileIndex(const Path &filePath) const
 {
     // the check whether the object is valid is not needed here
     // because if filesCount() returns -1 the loop exits immediately
     for (int i = 0; i < filesCount(); ++i)
     {
-        if (fileName == filePath(i))
+        if (filePath == this->filePath(i))
             return i;
     }
 

--- a/src/base/bittorrent/torrentinfo.h
+++ b/src/base/bittorrent/torrentinfo.h
@@ -35,6 +35,7 @@
 
 #include "base/3rdparty/expected.hpp"
 #include "base/indexrange.h"
+#include "base/pathfwd.h"
 #include "torrentcontentlayout.h"
 
 class QByteArray;
@@ -58,8 +59,8 @@ namespace BitTorrent
         explicit TorrentInfo(const lt::torrent_info &nativeInfo);
 
         static nonstd::expected<TorrentInfo, QString> load(const QByteArray &data) noexcept;
-        static nonstd::expected<TorrentInfo, QString> loadFromFile(const QString &path) noexcept;
-        nonstd::expected<void, QString> saveToFile(const QString &path) const;
+        static nonstd::expected<TorrentInfo, QString> loadFromFile(const Path &path) noexcept;
+        nonstd::expected<void, QString> saveToFile(const Path &path) const;
 
         TorrentInfo &operator=(const TorrentInfo &other);
 
@@ -75,21 +76,21 @@ namespace BitTorrent
         int pieceLength() const;
         int pieceLength(int index) const;
         int piecesCount() const;
-        QString filePath(int index) const;
-        QStringList filePaths() const;
+        Path filePath(int index) const;
+        PathList filePaths() const;
         qlonglong fileSize(int index) const;
         qlonglong fileOffset(int index) const;
         QVector<TrackerEntry> trackers() const;
         QVector<QUrl> urlSeeds() const;
         QByteArray metadata() const;
-        QStringList filesForPiece(int pieceIndex) const;
+        PathList filesForPiece(int pieceIndex) const;
         QVector<int> fileIndicesForPiece(int pieceIndex) const;
         QVector<QByteArray> pieceHashes() const;
 
         using PieceRange = IndexRange<int>;
         // returns pair of the first and the last pieces into which
         // the given file extends (maybe partially).
-        PieceRange filePieces(const QString &file) const;
+        PieceRange filePieces(const Path &filePath) const;
         PieceRange filePieces(int fileIndex) const;
 
         std::shared_ptr<lt::torrent_info> nativeInfo() const;
@@ -97,7 +98,7 @@ namespace BitTorrent
 
     private:
         // returns file index or -1 if fileName is not found
-        int fileIndex(const QString &fileName) const;
+        int fileIndex(const Path &filePath) const;
         TorrentContentLayout contentLayout() const;
 
         std::shared_ptr<const lt::torrent_info> m_nativeInfo;

--- a/src/base/iconprovider.cpp
+++ b/src/base/iconprovider.cpp
@@ -29,7 +29,7 @@
 
 #include "iconprovider.h"
 
-#include <QFileInfo>
+#include "base/path.h"
 
 IconProvider::IconProvider(QObject *parent)
     : QObject(parent)
@@ -55,14 +55,14 @@ IconProvider *IconProvider::instance()
     return m_instance;
 }
 
-QString IconProvider::getIconPath(const QString &iconId) const
+Path IconProvider::getIconPath(const QString &iconId) const
 {
     // there are a few icons not available in svg
-    const QString pathSvg = ":/icons/" + iconId + ".svg";
-    if (QFileInfo::exists(pathSvg))
+    const Path pathSvg {":/icons/" + iconId + ".svg"};
+    if (pathSvg.exists())
         return pathSvg;
 
-    const QString pathPng = ":/icons/" + iconId + ".png";
+    const Path pathPng {":/icons/" + iconId + ".png"};
     return pathPng;
 }
 

--- a/src/base/iconprovider.h
+++ b/src/base/iconprovider.h
@@ -31,6 +31,8 @@
 
 #include <QObject>
 
+#include "base/pathfwd.h"
+
 class QString;
 
 class IconProvider : public QObject
@@ -42,7 +44,7 @@ public:
     static void freeInstance();
     static IconProvider *instance();
 
-    virtual QString getIconPath(const QString &iconId) const;
+    virtual Path getIconPath(const QString &iconId) const;
 
 protected:
     explicit IconProvider(QObject *parent = nullptr);

--- a/src/base/net/downloadhandlerimpl.cpp
+++ b/src/base/net/downloadhandlerimpl.cpp
@@ -42,14 +42,14 @@ const int MAX_REDIRECTIONS = 20;  // the common value for web browsers
 
 namespace
 {
-    nonstd::expected<QString, QString> saveToTempFile(const QByteArray &data)
+    nonstd::expected<Path, QString> saveToTempFile(const QByteArray &data)
     {
-        QTemporaryFile file {Utils::Fs::tempPath()};
+        QTemporaryFile file {Utils::Fs::tempPath().data()};
         if (!file.open() || (file.write(data) != data.length()) || !file.flush())
             return nonstd::make_unexpected(file.errorString());
 
         file.setAutoRemove(false);
-        return file.fileName();
+        return Path(file.fileName());
     }
 }
 
@@ -127,10 +127,10 @@ void DownloadHandlerImpl::processFinishedDownload()
 
     if (m_downloadRequest.saveToFile())
     {
-        const QString destinationPath = m_downloadRequest.destFileName();
+        const Path destinationPath = m_downloadRequest.destFileName();
         if (destinationPath.isEmpty())
         {
-            const nonstd::expected<QString, QString> result = saveToTempFile(m_result.data);
+            const nonstd::expected<Path, QString> result = saveToTempFile(m_result.data);
             if (result)
                 m_result.filePath = result.value();
             else

--- a/src/base/net/downloadmanager.cpp
+++ b/src/base/net/downloadmanager.cpp
@@ -348,12 +348,12 @@ Net::DownloadRequest &Net::DownloadRequest::saveToFile(const bool value)
     return *this;
 }
 
-QString Net::DownloadRequest::destFileName() const
+Path Net::DownloadRequest::destFileName() const
 {
     return m_destFileName;
 }
 
-Net::DownloadRequest &Net::DownloadRequest::destFileName(const QString &value)
+Net::DownloadRequest &Net::DownloadRequest::destFileName(const Path &value)
 {
     m_destFileName = value;
     return *this;

--- a/src/base/net/downloadmanager.h
+++ b/src/base/net/downloadmanager.h
@@ -35,6 +35,8 @@
 #include <QQueue>
 #include <QSet>
 
+#include "base/path.h"
+
 class QNetworkCookie;
 class QNetworkReply;
 class QSslError;
@@ -81,15 +83,15 @@ namespace Net
         // if saveToFile is set, the file is saved in destFileName
         // (deprecated) if destFileName is not provided, the file will be saved
         // in a temporary file, the name of file is set in DownloadResult::filePath
-        QString destFileName() const;
-        DownloadRequest &destFileName(const QString &value);
+        Path destFileName() const;
+        DownloadRequest &destFileName(const Path &value);
 
     private:
         QString m_url;
         QString m_userAgent;
         qint64 m_limit = 0;
         bool m_saveToFile = false;
-        QString m_destFileName;
+        Path m_destFileName;
     };
 
     struct DownloadResult
@@ -98,7 +100,7 @@ namespace Net
         DownloadStatus status;
         QString errorString;
         QByteArray data;
-        QString filePath;
+        Path filePath;
         QString magnet;
     };
 

--- a/src/base/net/geoipdatabase.cpp
+++ b/src/base/net/geoipdatabase.cpp
@@ -26,13 +26,15 @@
  * exception statement from your version.
  */
 
+#include "geoipdatabase.h"
+
 #include <QDateTime>
 #include <QDebug>
 #include <QFile>
 #include <QHostAddress>
 #include <QVariant>
 
-#include "geoipdatabase.h"
+#include "base/path.h"
 
 namespace
 {
@@ -84,10 +86,10 @@ GeoIPDatabase::GeoIPDatabase(const quint32 size)
 {
 }
 
-GeoIPDatabase *GeoIPDatabase::load(const QString &filename, QString &error)
+GeoIPDatabase *GeoIPDatabase::load(const Path &filename, QString &error)
 {
     GeoIPDatabase *db = nullptr;
-    QFile file(filename);
+    QFile file {filename.data()};
     if (file.size() > MAX_FILE_SIZE)
     {
         error = tr("Unsupported database file size.");

--- a/src/base/net/geoipdatabase.h
+++ b/src/base/net/geoipdatabase.h
@@ -28,11 +28,15 @@
 
 #pragma once
 
-#include <QCoreApplication>
 #include <QtGlobal>
+#include <QCoreApplication>
+#include <QDateTime>
+#include <QHash>
+#include <QVariant>
+
+#include "base/pathfwd.h"
 
 class QByteArray;
-class QDateTime;
 class QHostAddress;
 class QString;
 
@@ -43,7 +47,7 @@ class GeoIPDatabase
     Q_DECLARE_TR_FUNCTIONS(GeoIPDatabase)
 
 public:
-    static GeoIPDatabase *load(const QString &filename, QString &error);
+    static GeoIPDatabase *load(const Path &filename, QString &error);
     static GeoIPDatabase *load(const QByteArray &data, QString &error);
 
     ~GeoIPDatabase();

--- a/src/base/path.cpp
+++ b/src/base/path.cpp
@@ -1,0 +1,326 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2022  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2012  Christophe Dumez <chris@qbittorrent.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "path.h"
+
+#include <QDataStream>
+#include <QDir>
+#include <QFileInfo>
+#include <QList>
+#include <QMimeDatabase>
+#include <QRegularExpression>
+
+#if defined(Q_OS_WIN)
+const Qt::CaseSensitivity CASE_SENSITIVITY = Qt::CaseInsensitive;
+#else
+const Qt::CaseSensitivity CASE_SENSITIVITY = Qt::CaseSensitive;
+#endif
+
+const int PATHLIST_TYPEID = qRegisterMetaType<PathList>();
+
+Path::Path(const QString &pathStr)
+    : m_pathStr {QDir::cleanPath(pathStr)}
+{
+}
+
+Path::Path(const std::string &pathStr)
+    : Path(QString::fromStdString(pathStr))
+{
+}
+
+Path::Path(const char pathStr[])
+    : Path(QString::fromLatin1(pathStr))
+{
+}
+
+bool Path::isValid() const
+{
+    if (isEmpty())
+        return false;
+
+#if defined(Q_OS_WIN)
+    const QRegularExpression regex {QLatin1String("[:?\"*<>|]")};
+#elif defined(Q_OS_MACOS)
+    const QRegularExpression regex {QLatin1String("[\\0:]")};
+#else
+    const QRegularExpression regex {QLatin1String("[\\0]")};
+#endif
+    return !m_pathStr.contains(regex);
+}
+
+bool Path::isEmpty() const
+{
+    return m_pathStr.isEmpty();
+}
+
+bool Path::isAbsolute() const
+{
+    return QDir::isAbsolutePath(m_pathStr);
+}
+
+bool Path::isRelative() const
+{
+    return QDir::isRelativePath(m_pathStr);
+}
+
+bool Path::exists() const
+{
+    return !isEmpty() && QFileInfo::exists(m_pathStr);
+}
+
+Path Path::rootItem() const
+{
+    const int slashIndex = m_pathStr.indexOf(QLatin1Char('/'));
+    if (slashIndex < 0)
+        return *this;
+
+    if (slashIndex == 0) // *nix absolute path
+        return createUnchecked(QLatin1String("/"));
+
+    return createUnchecked(m_pathStr.left(slashIndex));
+}
+
+Path Path::parentPath() const
+{
+    const int slashIndex = m_pathStr.lastIndexOf(QLatin1Char('/'));
+    if (slashIndex == -1)
+        return {};
+
+    if (slashIndex == 0) // *nix absolute path
+        return (m_pathStr.size() == 1) ? Path() : createUnchecked(QLatin1String("/"));
+
+    return createUnchecked(m_pathStr.left(slashIndex));
+}
+
+QString Path::filename() const
+{
+    const int slashIndex = m_pathStr.lastIndexOf('/');
+    if (slashIndex == -1)
+        return m_pathStr;
+
+    return m_pathStr.mid(slashIndex + 1);
+}
+
+QString Path::extension() const
+{
+    const QString suffix = QMimeDatabase().suffixForFileName(m_pathStr);
+    if (!suffix.isEmpty())
+        return (QLatin1String(".") + suffix);
+
+    const int slashIndex = m_pathStr.lastIndexOf(QLatin1Char('/'));
+    const auto filename = QStringView(m_pathStr).mid(slashIndex + 1);
+    const int dotIndex = filename.lastIndexOf(QLatin1Char('.'));
+    return ((dotIndex == -1) ? QString() : filename.mid(dotIndex).toString());
+}
+
+bool Path::hasExtension(const QString &ext) const
+{
+    return (extension().compare(ext, Qt::CaseInsensitive) == 0);
+}
+
+bool Path::hasAncestor(const Path &other) const
+{
+    if (other.isEmpty() || (m_pathStr.size() <= other.m_pathStr.size()))
+        return false;
+
+    return (m_pathStr[other.m_pathStr.size()] == QLatin1Char('/'))
+            && m_pathStr.startsWith(other.m_pathStr, CASE_SENSITIVITY);
+}
+
+Path Path::relativePathOf(const Path &childPath) const
+{
+    // If both paths are relative, we assume that they have the same base path
+    if (isRelative() && childPath.isRelative())
+        return Path(QDir(QDir::home().absoluteFilePath(m_pathStr)).relativeFilePath(QDir::home().absoluteFilePath(childPath.data())));
+
+    return Path(QDir(m_pathStr).relativeFilePath(childPath.data()));
+}
+
+void Path::removeExtension()
+{
+    m_pathStr.chop(extension().size());
+}
+
+QString Path::data() const
+{
+    return m_pathStr;
+}
+
+QString Path::toString() const
+{
+    return QDir::toNativeSeparators(m_pathStr);
+}
+
+Path &Path::operator/=(const Path &other)
+{
+    *this = *this / other;
+    return *this;
+}
+
+Path &Path::operator+=(const QString &str)
+{
+    *this = *this + str;
+    return *this;
+}
+
+Path &Path::operator+=(const char str[])
+{
+    return (*this += QString::fromLatin1(str));
+}
+
+Path &Path::operator+=(const std::string &str)
+{
+    return (*this += QString::fromStdString(str));
+}
+
+Path Path::commonPath(const Path &left, const Path &right)
+{
+    if (left.isEmpty() || right.isEmpty())
+        return {};
+
+    const QList<QStringView> leftPathItems = QStringView(left.m_pathStr).split(u'/');
+    const QList<QStringView> rightPathItems = QStringView(right.m_pathStr).split(u'/');
+    int commonItemsCount = 0;
+    qsizetype commonPathSize = 0;
+    while ((commonItemsCount < leftPathItems.size()) && (commonItemsCount < rightPathItems.size()))
+    {
+        const QStringView leftPathItem = leftPathItems[commonItemsCount];
+        const QStringView rightPathItem = rightPathItems[commonItemsCount];
+        if (leftPathItem.compare(rightPathItem, CASE_SENSITIVITY) != 0)
+            break;
+
+        ++commonItemsCount;
+        commonPathSize += leftPathItem.size();
+    }
+
+    if (commonItemsCount > 0)
+        commonPathSize += (commonItemsCount - 1); // size of intermediate separators
+
+    return Path::createUnchecked(left.m_pathStr.left(commonPathSize));
+}
+
+Path Path::findRootFolder(const PathList &filePaths)
+{
+    Path rootFolder;
+    for (const Path &filePath : filePaths)
+    {
+        const auto filePathElements = QStringView(filePath.m_pathStr).split(u'/');
+        // if at least one file has no root folder, no common root folder exists
+        if (filePathElements.count() <= 1)
+            return {};
+
+        if (rootFolder.isEmpty())
+            rootFolder.m_pathStr = filePathElements.at(0).toString();
+        else if (rootFolder.m_pathStr != filePathElements.at(0))
+            return {};
+    }
+
+    return rootFolder;
+}
+
+void Path::stripRootFolder(PathList &filePaths)
+{
+    const Path commonRootFolder = findRootFolder(filePaths);
+    if (commonRootFolder.isEmpty())
+        return;
+
+    for (Path &filePath : filePaths)
+        filePath.m_pathStr = filePath.m_pathStr.mid(commonRootFolder.m_pathStr.size() + 1);
+}
+
+void Path::addRootFolder(PathList &filePaths, const Path &rootFolder)
+{
+    Q_ASSERT(!rootFolder.isEmpty());
+
+    for (Path &filePath : filePaths)
+        filePath = rootFolder / filePath;
+}
+
+Path Path::createUnchecked(const QString &pathStr)
+{
+    Path path;
+    path.m_pathStr = pathStr;
+
+    return path;
+}
+
+bool operator==(const Path &lhs, const Path &rhs)
+{
+    return (lhs.m_pathStr.compare(rhs.m_pathStr, CASE_SENSITIVITY) == 0);
+}
+
+bool operator!=(const Path &lhs, const Path &rhs)
+{
+    return !(lhs == rhs);
+}
+
+Path operator/(const Path &lhs, const Path &rhs)
+{
+    if (rhs.isEmpty())
+        return lhs;
+
+    if (lhs.isEmpty())
+        return rhs;
+
+    return Path(lhs.m_pathStr + QLatin1Char('/') + rhs.m_pathStr);
+}
+
+Path operator+(const Path &lhs, const QString &rhs)
+{
+    return Path(lhs.m_pathStr + rhs);
+}
+
+Path operator+(const Path &lhs, const char rhs[])
+{
+    return lhs + QString::fromLatin1(rhs);
+}
+
+Path operator+(const Path &lhs, const std::string &rhs)
+{
+    return lhs + QString::fromStdString(rhs);
+}
+
+QDataStream &operator<<(QDataStream &out, const Path &path)
+{
+    out << path.data();
+    return out;
+}
+
+QDataStream &operator>>(QDataStream &in, Path &path)
+{
+    QString pathStr;
+    in >> pathStr;
+    path = Path(pathStr);
+    return in;
+}
+
+uint qHash(const Path &key, const uint seed)
+{
+    return ::qHash(key.data(), seed);
+}

--- a/src/base/path.h
+++ b/src/base/path.h
@@ -1,0 +1,100 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2022  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2012  Christophe Dumez <chris@qbittorrent.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+#include <QMetaType>
+#include <QString>
+
+#include "pathfwd.h"
+
+class Path final
+{
+public:
+    Path() = default;
+
+    explicit Path(const QString &pathStr);
+    explicit Path(const char pathStr[]);
+    explicit Path(const std::string &pathStr);
+
+    bool isValid() const;
+    bool isEmpty() const;
+    bool isAbsolute() const;
+    bool isRelative() const;
+
+    bool exists() const;
+
+    Path rootItem() const;
+    Path parentPath() const;
+
+    QString filename() const;
+
+    QString extension() const;
+    bool hasExtension(const QString &ext) const;
+    void removeExtension();
+
+    bool hasAncestor(const Path &other) const;
+    Path relativePathOf(const Path &childPath) const;
+
+    QString data() const;
+    QString toString() const;
+
+    Path &operator/=(const Path &other);
+    Path &operator+=(const QString &str);
+    Path &operator+=(const char str[]);
+    Path &operator+=(const std::string &str);
+
+    static Path commonPath(const Path &left, const Path &right);
+
+    static Path findRootFolder(const PathList &filePaths);
+    static void stripRootFolder(PathList &filePaths);
+    static void addRootFolder(PathList &filePaths, const Path &rootFolder);
+
+    friend bool operator==(const Path &lhs, const Path &rhs);
+    friend Path operator/(const Path &lhs, const Path &rhs);
+    friend Path operator+(const Path &lhs, const QString &rhs);
+
+private:
+    // this constructor doesn't perform any checks
+    // so it's intended for internal use only
+    static Path createUnchecked(const QString &pathStr);
+
+    QString m_pathStr;
+};
+
+Q_DECLARE_METATYPE(Path)
+
+bool operator!=(const Path &lhs, const Path &rhs);
+Path operator+(const Path &lhs, const char rhs[]);
+Path operator+(const Path &lhs, const std::string &rhs);
+
+QDataStream &operator<<(QDataStream &out, const Path &path);
+QDataStream &operator>>(QDataStream &in, Path &path);
+
+uint qHash(const Path &key, uint seed);

--- a/src/base/pathfwd.h
+++ b/src/base/pathfwd.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2011  Christophe Dumez <chris@qbittorrent.org>
+ * Copyright (C) 2022  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -28,63 +28,8 @@
 
 #pragma once
 
-#include <QDialog>
+#include <QtContainerFwd>
 
-#include "base/path.h"
-#include "base/settingvalue.h"
+class Path;
 
-class QStandardItemModel;
-
-namespace BitTorrent
-{
-    class Torrent;
-}
-
-namespace Ui
-{
-    class PreviewSelectDialog;
-}
-class PreviewListDelegate;
-
-class PreviewSelectDialog final : public QDialog
-{
-    Q_OBJECT
-    Q_DISABLE_COPY_MOVE(PreviewSelectDialog)
-
-public:
-    enum PreviewColumn
-    {
-        NAME,
-        SIZE,
-        PROGRESS,
-        FILE_INDEX,
-
-        NB_COLUMNS
-    };
-
-    PreviewSelectDialog(QWidget *parent, const BitTorrent::Torrent *torrent);
-    ~PreviewSelectDialog();
-
-signals:
-    void readyToPreviewFile(const Path &filePath) const;
-
-private slots:
-    void previewButtonClicked();
-    void displayColumnHeaderMenu();
-
-private:
-    void showEvent(QShowEvent *event) override;
-
-    void loadWindowState();
-    void saveWindowState();
-
-    Ui::PreviewSelectDialog *m_ui;
-    QStandardItemModel *m_previewListModel;
-    PreviewListDelegate *m_listDelegate;
-    const BitTorrent::Torrent *m_torrent;
-    bool m_headerStateInitialized = false;
-
-    // Settings
-    SettingValue<QSize> m_storeDialogSize;
-    SettingValue<QByteArray> m_storeTreeHeaderState;
-};
+using PathList = QList<Path>;

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -29,10 +29,11 @@
 
 #pragma once
 
-#include <QObject>
 #include <QtContainerFwd>
 #include <QtGlobal>
+#include <QObject>
 
+#include "base/pathfwd.h"
 #include "base/utils/net.h"
 
 class QDateTime;
@@ -108,8 +109,8 @@ public:
     void setLocale(const QString &locale);
     bool useCustomUITheme() const;
     void setUseCustomUITheme(bool use);
-    QString customUIThemePath() const;
-    void setCustomUIThemePath(const QString &path);
+    Path customUIThemePath() const;
+    void setCustomUIThemePath(const Path &path);
     bool deleteTorrentFilesAsDefault() const;
     void setDeleteTorrentFilesAsDefault(bool del);
     bool confirmOnExit() const;
@@ -140,10 +141,8 @@ public:
 #endif
 
     // Downloads
-    QString lastLocationPath() const;
-    void setLastLocationPath(const QString &path);
-    QString getScanDirsLastPath() const;
-    void setScanDirsLastPath(const QString &path);
+    Path getScanDirsLastPath() const;
+    void setScanDirsLastPath(const Path &path);
     bool isMailNotificationEnabled() const;
     void setMailNotificationEnabled(bool enabled);
     QString getMailNotificationSender() const;
@@ -220,14 +219,14 @@ public:
     // HTTPS
     bool isWebUiHttpsEnabled() const;
     void setWebUiHttpsEnabled(bool enabled);
-    QString getWebUIHttpsCertificatePath() const;
-    void setWebUIHttpsCertificatePath(const QString &path);
-    QString getWebUIHttpsKeyPath() const;
-    void setWebUIHttpsKeyPath(const QString &path);
+    Path getWebUIHttpsCertificatePath() const;
+    void setWebUIHttpsCertificatePath(const Path &path);
+    Path getWebUIHttpsKeyPath() const;
+    void setWebUIHttpsKeyPath(const Path &path);
     bool isAltWebUiEnabled() const;
     void setAltWebUiEnabled(bool enabled);
-    QString getWebUiRootFolder() const;
-    void setWebUiRootFolder(const QString &path);
+    Path getWebUiRootFolder() const;
+    void setWebUiRootFolder(const Path &path);
 
     // WebUI custom HTTP headers
     bool isWebUICustomHTTPHeadersEnabled() const;
@@ -343,8 +342,8 @@ public:
     void setMainGeometry(const QByteArray &geometry);
     QByteArray getMainVSplitterState() const;
     void setMainVSplitterState(const QByteArray &state);
-    QString getMainLastDir() const;
-    void setMainLastDir(const QString &path);
+    Path getMainLastDir() const;
+    void setMainLastDir(const Path &path);
     QByteArray getPeerListState() const;
     void setPeerListState(const QByteArray &state);
     QString getPropSplitterSizes() const;

--- a/src/base/profile.h
+++ b/src/base/profile.h
@@ -33,6 +33,8 @@
 
 #include <QSettings>
 
+#include "base/pathfwd.h"
+
 class QString;
 
 namespace Private
@@ -54,26 +56,26 @@ enum class SpecialFolder
 class Profile
 {
 public:
-    static void initInstance(const QString &rootProfilePath, const QString &configurationName,
+    static void initInstance(const Path &rootProfilePath, const QString &configurationName,
         bool convertPathsToProfileRelative);
     static void freeInstance();
     static const Profile *instance();
 
-    QString location(SpecialFolder folder) const;
+    Path location(SpecialFolder folder) const;
     SettingsPtr applicationSettings(const QString &name) const;
 
-    QString rootPath() const;
+    Path rootPath() const;
     QString configurationName() const;
 
     /// Returns either default name for configuration file (QCoreApplication::applicationName())
     /// or the value, supplied via parameters
     QString profileName() const;
 
-    QString toPortablePath(const QString &absolutePath) const;
-    QString fromPortablePath(const QString &portablePath) const;
+    Path toPortablePath(const Path &absolutePath) const;
+    Path fromPortablePath(const Path &portablePath) const;
 
 private:
-    Profile(const QString &rootProfilePath, const QString &configurationName, bool convertPathsToProfileRelative);
+    Profile(const Path &rootProfilePath, const QString &configurationName, bool convertPathsToProfileRelative);
     ~Profile() = default;  // to generate correct call to ProfilePrivate::~ProfileImpl()
 
     void ensureDirectoryExists(SpecialFolder folder) const;
@@ -83,4 +85,4 @@ private:
     static Profile *m_instance;
 };
 
-QString specialFolderLocation(SpecialFolder folder);
+Path specialFolderLocation(SpecialFolder folder);

--- a/src/base/profile_p.h
+++ b/src/base/profile_p.h
@@ -29,10 +29,10 @@
 
 #pragma once
 
-#include <QDir>
 #include <QStandardPaths>
 
-#include "base/profile.h"
+#include "base/path.h"
+#include "profile.h"
 
 namespace Private
 {
@@ -41,17 +41,17 @@ namespace Private
     public:
         virtual ~Profile() = default;
 
-        virtual QString rootPath() const = 0;
+        virtual Path rootPath() const = 0;
 
         /**
          * @brief The base path against to which portable (relative) paths are resolved
          */
-        virtual QString basePath() const = 0;
+        virtual Path basePath() const = 0;
 
-        virtual QString cacheLocation() const = 0;
-        virtual QString configLocation() const = 0;
-        virtual QString dataLocation() const = 0;
-        virtual QString downloadLocation() const = 0;
+        virtual Path cacheLocation() const = 0;
+        virtual Path configLocation() const = 0;
+        virtual Path dataLocation() const = 0;
+        virtual Path downloadLocation() const = 0;
 
         virtual SettingsPtr applicationSettings(const QString &name) const = 0;
 
@@ -77,12 +77,12 @@ namespace Private
     public:
         explicit DefaultProfile(const QString &configurationName);
 
-        QString rootPath() const override;
-        QString basePath() const override;
-        QString cacheLocation() const override;
-        QString configLocation() const override;
-        QString dataLocation() const override;
-        QString downloadLocation() const override;
+        Path rootPath() const override;
+        Path basePath() const override;
+        Path cacheLocation() const override;
+        Path configLocation() const override;
+        Path dataLocation() const override;
+        Path downloadLocation() const override;
         SettingsPtr applicationSettings(const QString &name) const override;
 
     private:
@@ -92,55 +92,55 @@ namespace Private
          * @param location location kind
          * @return QStandardPaths::writableLocation(location) / configurationName()
          */
-        QString locationWithConfigurationName(QStandardPaths::StandardLocation location) const;
+        Path locationWithConfigurationName(QStandardPaths::StandardLocation location) const;
     };
 
     /// Custom tree: creates directories under the specified root directory
     class CustomProfile final : public Profile
     {
     public:
-        CustomProfile(const QString &rootPath, const QString &configurationName);
+        CustomProfile(const Path &rootPath, const QString &configurationName);
 
-        QString rootPath() const override;
-        QString basePath() const override;
-        QString cacheLocation() const override;
-        QString configLocation() const override;
-        QString dataLocation() const override;
-        QString downloadLocation() const override;
+        Path rootPath() const override;
+        Path basePath() const override;
+        Path cacheLocation() const override;
+        Path configLocation() const override;
+        Path dataLocation() const override;
+        Path downloadLocation() const override;
         SettingsPtr applicationSettings(const QString &name) const override;
 
     private:
-        const QDir m_rootDir;
-        const QDir m_baseDir;
-        const QString m_cacheLocation;
-        const QString m_configLocation;
-        const QString m_dataLocation;
-        const QString m_downloadLocation;
+        const Path m_rootPath;
+        const Path m_basePath;
+        const Path m_cacheLocation;
+        const Path m_configLocation;
+        const Path m_dataLocation;
+        const Path m_downloadLocation;
     };
 
     class PathConverter
     {
     public:
-        virtual QString toPortablePath(const QString &path) const = 0;
-        virtual QString fromPortablePath(const QString &portablePath) const = 0;
+        virtual Path toPortablePath(const Path &path) const = 0;
+        virtual Path fromPortablePath(const Path &portablePath) const = 0;
         virtual ~PathConverter() = default;
     };
 
     class NoConvertConverter final : public PathConverter
     {
     public:
-        QString toPortablePath(const QString &path) const override;
-        QString fromPortablePath(const QString &portablePath) const override;
+        Path toPortablePath(const Path &path) const override;
+        Path fromPortablePath(const Path &portablePath) const override;
     };
 
     class Converter final : public PathConverter
     {
     public:
-        explicit Converter(const QString &basePath);
-        QString toPortablePath(const QString &path) const override;
-        QString fromPortablePath(const QString &portablePath) const override;
+        explicit Converter(const Path &basePath);
+        Path toPortablePath(const Path &path) const override;
+        Path fromPortablePath(const Path &portablePath) const override;
 
     private:
-        QDir m_baseDir;
+        Path m_basePath;
     };
 }

--- a/src/base/rss/rss_autodownloadrule.cpp
+++ b/src/base/rss/rss_autodownloadrule.cpp
@@ -41,6 +41,7 @@
 #include <QStringList>
 
 #include "base/global.h"
+#include "base/path.h"
 #include "base/preferences.h"
 #include "base/utils/fs.h"
 #include "base/utils/string.h"
@@ -132,7 +133,7 @@ namespace RSS
         int ignoreDays = 0;
         QDateTime lastMatch;
 
-        QString savePath;
+        Path savePath;
         QString category;
         std::optional<bool> addPaused;
         std::optional<BitTorrent::TorrentContentLayout> contentLayout;
@@ -466,7 +467,7 @@ QJsonObject AutoDownloadRule::toJsonObject() const
         , {Str_MustNotContain, mustNotContain()}
         , {Str_EpisodeFilter, episodeFilter()}
         , {Str_AffectedFeeds, QJsonArray::fromStringList(feedURLs())}
-        , {Str_SavePath, savePath()}
+        , {Str_SavePath, savePath().toString()}
         , {Str_AssignedCategory, assignedCategory()}
         , {Str_LastMatch, lastMatch().toString(Qt::RFC2822Date)}
         , {Str_IgnoreDays, ignoreDays()}
@@ -485,7 +486,7 @@ AutoDownloadRule AutoDownloadRule::fromJsonObject(const QJsonObject &jsonObj, co
     rule.setMustNotContain(jsonObj.value(Str_MustNotContain).toString());
     rule.setEpisodeFilter(jsonObj.value(Str_EpisodeFilter).toString());
     rule.setEnabled(jsonObj.value(Str_Enabled).toBool(true));
-    rule.setSavePath(jsonObj.value(Str_SavePath).toString());
+    rule.setSavePath(Path(jsonObj.value(Str_SavePath).toString()));
     rule.setCategory(jsonObj.value(Str_AssignedCategory).toString());
     rule.setAddPaused(toOptionalBool(jsonObj.value(Str_AddPaused)));
 
@@ -546,7 +547,7 @@ QVariantHash AutoDownloadRule::toLegacyDict() const
     return {{"name", name()},
         {"must_contain", mustContain()},
         {"must_not_contain", mustNotContain()},
-        {"save_path", savePath()},
+        {"save_path", savePath().toString()},
         {"affected_feeds", feedURLs()},
         {"enabled", isEnabled()},
         {"category_assigned", assignedCategory()},
@@ -567,7 +568,7 @@ AutoDownloadRule AutoDownloadRule::fromLegacyDict(const QVariantHash &dict)
     rule.setEpisodeFilter(dict.value("episode_filter").toString());
     rule.setFeedURLs(dict.value("affected_feeds").toStringList());
     rule.setEnabled(dict.value("enabled", false).toBool());
-    rule.setSavePath(dict.value("save_path").toString());
+    rule.setSavePath(Path(dict.value("save_path").toString()));
     rule.setCategory(dict.value("category_assigned").toString());
     rule.setAddPaused(addPausedLegacyToOptionalBool(dict.value("add_paused").toInt()));
     rule.setLastMatch(dict.value("last_match").toDateTime());
@@ -624,14 +625,14 @@ void AutoDownloadRule::setName(const QString &name)
     m_dataPtr->name = name;
 }
 
-QString AutoDownloadRule::savePath() const
+Path AutoDownloadRule::savePath() const
 {
     return m_dataPtr->savePath;
 }
 
-void AutoDownloadRule::setSavePath(const QString &savePath)
+void AutoDownloadRule::setSavePath(const Path &savePath)
 {
-    m_dataPtr->savePath = Utils::Fs::toUniformPath(savePath);
+    m_dataPtr->savePath = savePath;
 }
 
 std::optional<bool> AutoDownloadRule::addPaused() const

--- a/src/base/rss/rss_autodownloadrule.h
+++ b/src/base/rss/rss_autodownloadrule.h
@@ -35,6 +35,7 @@
 #include <QVariant>
 
 #include "base/bittorrent/torrentcontentlayout.h"
+#include "base/pathfwd.h"
 
 class QDateTime;
 class QJsonObject;
@@ -77,8 +78,8 @@ namespace RSS
         QStringList previouslyMatchedEpisodes() const;
         void setPreviouslyMatchedEpisodes(const QStringList &previouslyMatchedEpisodes);
 
-        QString savePath() const;
-        void setSavePath(const QString &savePath);
+        Path savePath() const;
+        void setSavePath(const Path &savePath);
         std::optional<bool> addPaused() const;
         void setAddPaused(std::optional<bool> addPaused);
         std::optional<BitTorrent::TorrentContentLayout> torrentContentLayout() const;

--- a/src/base/rss/rss_feed.h
+++ b/src/base/rss/rss_feed.h
@@ -35,6 +35,7 @@
 #include <QList>
 #include <QUuid>
 
+#include "base/path.h"
 #include "rss_item.h"
 
 class AsyncFileStorage;
@@ -79,7 +80,7 @@ namespace RSS
         bool hasError() const;
         bool isLoading() const;
         Article *articleByGUID(const QString &guid) const;
-        QString iconPath() const;
+        Path iconPath() const;
 
         QJsonValue toJsonValue(bool withData = false) const override;
 
@@ -122,8 +123,8 @@ namespace RSS
         QHash<QString, Article *> m_articles;
         QList<Article *> m_articlesByDate;
         int m_unreadCount = 0;
-        QString m_iconPath;
-        QString m_dataFileName;
+        Path m_iconPath;
+        Path m_dataFileName;
         QBasicTimer m_savingTimer;
         bool m_dirty = false;
         Net::DownloadHandler *m_downloadHandler = nullptr;

--- a/src/base/search/searchdownloadhandler.cpp
+++ b/src/base/search/searchdownloadhandler.cpp
@@ -30,8 +30,9 @@
 
 #include <QProcess>
 
-#include "../utils/foreignapps.h"
-#include "../utils/fs.h"
+#include "base/path.h"
+#include "base/utils/foreignapps.h"
+#include "base/utils/fs.h"
 #include "searchpluginmanager.h"
 
 SearchDownloadHandler::SearchDownloadHandler(const QString &siteUrl, const QString &url, SearchPluginManager *manager)
@@ -44,7 +45,7 @@ SearchDownloadHandler::SearchDownloadHandler(const QString &siteUrl, const QStri
             , this, &SearchDownloadHandler::downloadProcessFinished);
     const QStringList params
     {
-        Utils::Fs::toNativePath(m_manager->engineLocation() + "/nova2dl.py"),
+        (m_manager->engineLocation() / Path("nova2dl.py")).toString(),
         siteUrl,
         url
     };

--- a/src/base/search/searchhandler.cpp
+++ b/src/base/search/searchhandler.cpp
@@ -34,6 +34,7 @@
 #include <QVector>
 
 #include "base/global.h"
+#include "base/path.h"
 #include "base/utils/foreignapps.h"
 #include "base/utils/fs.h"
 #include "searchpluginmanager.h"
@@ -67,7 +68,7 @@ SearchHandler::SearchHandler(const QString &pattern, const QString &category, co
 
     const QStringList params
     {
-        Utils::Fs::toNativePath(m_manager->engineLocation() + "/nova2.py"),
+        (m_manager->engineLocation() / Path("nova2.py")).toString(),
         m_usedPlugins.join(','),
         m_category
     };

--- a/src/base/search/searchpluginmanager.cpp
+++ b/src/base/search/searchpluginmanager.cpp
@@ -52,30 +52,31 @@
 
 namespace
 {
-    void clearPythonCache(const QString &path)
+    void clearPythonCache(const Path &path)
     {
         // remove python cache artifacts in `path` and subdirs
 
-        QStringList dirs = {path};
-        QDirIterator iter {path, (QDir::AllDirs | QDir::NoDotAndDotDot), QDirIterator::Subdirectories};
+        PathList dirs = {path};
+        QDirIterator iter {path.data(), (QDir::AllDirs | QDir::NoDotAndDotDot), QDirIterator::Subdirectories};
         while (iter.hasNext())
-            dirs += iter.next();
+            dirs += Path(iter.next());
 
-        for (const QString &dir : asConst(dirs))
+        for (const Path &dir : asConst(dirs))
         {
             // python 3: remove "__pycache__" folders
-            if (dir.endsWith("/__pycache__"))
+            if (dir.filename() == QLatin1String("__pycache__"))
             {
-                Utils::Fs::removeDirRecursive(dir);
+                Utils::Fs::removeDirRecursively(dir);
                 continue;
             }
 
             // python 2: remove "*.pyc" files
-            const QStringList files = QDir(dir).entryList(QDir::Files);
+            const QStringList files = QDir(dir.data()).entryList(QDir::Files);
             for (const QString &file : files)
             {
-                if (file.endsWith(".pyc"))
-                    Utils::Fs::forceRemove(file);
+                const Path path {file};
+                if (path.hasExtension(QLatin1String(".pyc")))
+                    Utils::Fs::removeFile(path);
             }
         }
     }
@@ -210,21 +211,22 @@ void SearchPluginManager::installPlugin(const QString &source)
     }
     else
     {
-        QString path = source;
-        if (path.startsWith("file:", Qt::CaseInsensitive))
-            path = QUrl(path).toLocalFile();
+        const Path path {source.startsWith("file:", Qt::CaseInsensitive) ? QUrl(source).toLocalFile() : source};
 
-        QString pluginName = Utils::Fs::fileName(path);
-        pluginName.chop(pluginName.size() - pluginName.lastIndexOf('.'));
-
-        if (!path.endsWith(".py", Qt::CaseInsensitive))
-            emit pluginInstallationFailed(pluginName, tr("Unknown search engine plugin file format."));
-        else
+        QString pluginName = path.filename();
+        if (pluginName.endsWith(".py", Qt::CaseInsensitive))
+        {
+            pluginName.chop(pluginName.size() - pluginName.lastIndexOf('.'));
             installPlugin_impl(pluginName, path);
+        }
+        else
+        {
+            emit pluginInstallationFailed(pluginName, tr("Unknown search engine plugin file format."));
+        }
     }
 }
 
-void SearchPluginManager::installPlugin_impl(const QString &name, const QString &path)
+void SearchPluginManager::installPlugin_impl(const QString &name, const Path &path)
 {
     const PluginVersion newVersion = getPluginVersion(path);
     const PluginInfo *plugin = pluginInfo(name);
@@ -236,30 +238,31 @@ void SearchPluginManager::installPlugin_impl(const QString &name, const QString 
     }
 
     // Process with install
-    const QString destPath = pluginPath(name);
+    const Path destPath = pluginPath(name);
+    const Path backupPath = destPath + ".bak";
     bool updated = false;
-    if (QFile::exists(destPath))
+    if (destPath.exists())
     {
         // Backup in case install fails
-        QFile::copy(destPath, destPath + ".bak");
-        Utils::Fs::forceRemove(destPath);
+        Utils::Fs::copyFile(destPath, backupPath);
+        Utils::Fs::removeFile(destPath);
         updated = true;
     }
     // Copy the plugin
-    QFile::copy(path, destPath);
+    Utils::Fs::copyFile(path, destPath);
     // Update supported plugins
     update();
     // Check if this was correctly installed
     if (!m_plugins.contains(name))
     {
         // Remove broken file
-        Utils::Fs::forceRemove(destPath);
+        Utils::Fs::removeFile(destPath);
         LogMsg(tr("Plugin %1 is not supported.").arg(name), Log::INFO);
         if (updated)
         {
             // restore backup
-            QFile::copy(destPath + ".bak", destPath);
-            Utils::Fs::forceRemove(destPath + ".bak");
+            Utils::Fs::copyFile(backupPath, destPath);
+            Utils::Fs::removeFile(backupPath);
             // Update supported plugins
             update();
             emit pluginUpdateFailed(name, tr("Plugin is not supported."));
@@ -275,7 +278,7 @@ void SearchPluginManager::installPlugin_impl(const QString &name, const QString 
         if (updated)
         {
             LogMsg(tr("Plugin %1 has been successfully updated.").arg(name), Log::INFO);
-            Utils::Fs::forceRemove(destPath + ".bak");
+            Utils::Fs::removeFile(backupPath);
         }
     }
 }
@@ -285,12 +288,11 @@ bool SearchPluginManager::uninstallPlugin(const QString &name)
     clearPythonCache(engineLocation());
 
     // remove it from hard drive
-    const QDir pluginsFolder(pluginsLocation());
-    QStringList filters;
-    filters << name + ".*";
-    const QStringList files = pluginsFolder.entryList(filters, QDir::Files, QDir::Unsorted);
+    const Path pluginsPath = pluginsLocation();
+    const QStringList filters {name + QLatin1String(".*")};
+    const QStringList files = QDir(pluginsPath.data()).entryList(filters, QDir::Files, QDir::Unsorted);
     for (const QString &file : files)
-        Utils::Fs::forceRemove(pluginsFolder.absoluteFilePath(file));
+        Utils::Fs::removeFile(pluginsPath / Path(file));
     // Remove it from supported engines
     delete m_plugins.take(name);
 
@@ -301,15 +303,17 @@ bool SearchPluginManager::uninstallPlugin(const QString &name)
 void SearchPluginManager::updateIconPath(PluginInfo *const plugin)
 {
     if (!plugin) return;
-    QString iconPath = QString::fromLatin1("%1/%2.png").arg(pluginsLocation(), plugin->name);
-    if (QFile::exists(iconPath))
+
+    const Path pluginsPath = pluginsLocation();
+    Path iconPath = pluginsPath / Path(plugin->name + QLatin1String(".png"));
+    if (iconPath.exists())
     {
         plugin->iconPath = iconPath;
     }
     else
     {
-        iconPath = QString::fromLatin1("%1/%2.ico").arg(pluginsLocation(), plugin->name);
-        if (QFile::exists(iconPath))
+        iconPath = pluginsPath / Path(plugin->name + QLatin1String(".ico"));
+        if (iconPath.exists())
             plugin->iconPath = iconPath;
     }
 }
@@ -357,20 +361,18 @@ QString SearchPluginManager::pluginFullName(const QString &pluginName)
     return pluginInfo(pluginName) ? pluginInfo(pluginName)->fullName : QString();
 }
 
-QString SearchPluginManager::pluginsLocation()
+Path SearchPluginManager::pluginsLocation()
 {
-    return QString::fromLatin1("%1/engines").arg(engineLocation());
+    return (engineLocation() / Path("engines"));
 }
 
-QString SearchPluginManager::engineLocation()
+Path SearchPluginManager::engineLocation()
 {
-    static QString location;
+    static Path location;
     if (location.isEmpty())
     {
-        location = Utils::Fs::expandPathAbs(specialFolderLocation(SpecialFolder::Data) + "/nova3");
-
-        const QDir locationDir(location);
-        locationDir.mkpath(locationDir.absolutePath());
+        location = specialFolderLocation(SpecialFolder::Data) / Path("nova3");
+        Utils::Fs::mkpath(location);
     }
 
     return location;
@@ -388,12 +390,12 @@ void SearchPluginManager::pluginDownloadFinished(const Net::DownloadResult &resu
 {
     if (result.status == Net::DownloadStatus::Success)
     {
-        const QString filePath = Utils::Fs::toUniformPath(result.filePath);
+        const Path filePath = result.filePath;
 
-        QString pluginName = Utils::Fs::fileName(result.url);
-        pluginName.chop(pluginName.size() - pluginName.lastIndexOf('.')); // Remove extension
-        installPlugin_impl(pluginName, filePath);
-        Utils::Fs::forceRemove(filePath);
+        Path pluginPath {QUrl(result.url).path()};
+        pluginPath.removeExtension(); // Remove extension
+        installPlugin_impl(pluginPath.filename(), filePath);
+        Utils::Fs::removeFile(filePath);
     }
     else
     {
@@ -412,37 +414,37 @@ void SearchPluginManager::pluginDownloadFinished(const Net::DownloadResult &resu
 void SearchPluginManager::updateNova()
 {
     // create nova directory if necessary
-    const QDir searchDir(engineLocation());
+    const Path enginePath = engineLocation();
 
-    QFile packageFile(searchDir.absoluteFilePath("__init__.py"));
+    QFile packageFile {(enginePath / Path("__init__.py")).data()};
     packageFile.open(QIODevice::WriteOnly);
     packageFile.close();
 
-    searchDir.mkdir("engines");
+    Utils::Fs::mkdir(enginePath / Path("engines"));
 
-    QFile packageFile2(searchDir.absolutePath() + "/engines/__init__.py");
+    QFile packageFile2 {(enginePath / Path("engines/__init__.py")).data()};
     packageFile2.open(QIODevice::WriteOnly);
     packageFile2.close();
 
     // Copy search plugin files (if necessary)
-    const auto updateFile = [](const QString &filename, const bool compareVersion)
+    const auto updateFile = [&enginePath](const Path &filename, const bool compareVersion)
     {
-        const QString filePathBundled = ":/searchengine/nova3/" + filename;
-        const QString filePathDisk = QDir(engineLocation()).absoluteFilePath(filename);
+        const Path filePathBundled = Path(":/searchengine/nova3") / filename;
+        const Path filePathDisk = enginePath / filename;
 
         if (compareVersion && (getPluginVersion(filePathBundled) <= getPluginVersion(filePathDisk)))
             return;
 
-        Utils::Fs::forceRemove(filePathDisk);
-        QFile::copy(filePathBundled, filePathDisk);
+        Utils::Fs::removeFile(filePathDisk);
+        Utils::Fs::copyFile(filePathBundled, filePathDisk);
     };
 
-    updateFile("helpers.py", true);
-    updateFile("nova2.py", true);
-    updateFile("nova2dl.py", true);
-    updateFile("novaprinter.py", true);
-    updateFile("sgmllib3.py", false);
-    updateFile("socks.py", false);
+    updateFile(Path("helpers.py"), true);
+    updateFile(Path("nova2.py"), true);
+    updateFile(Path("nova2dl.py"), true);
+    updateFile(Path("novaprinter.py"), true);
+    updateFile(Path("sgmllib3.py"), false);
+    updateFile(Path("socks.py"), false);
 }
 
 void SearchPluginManager::update()
@@ -450,7 +452,7 @@ void SearchPluginManager::update()
     QProcess nova;
     nova.setProcessEnvironment(QProcessEnvironment::systemEnvironment());
 
-    const QStringList params {Utils::Fs::toNativePath(engineLocation() + "/nova2.py"), "--capabilities"};
+    const QStringList params {(engineLocation() / Path("/nova2.py")).toString(), QLatin1String("--capabilities")};
     nova.start(Utils::ForeignApps::pythonInfo().executableName, params, QIODevice::ReadOnly);
     nova.waitForFinished();
 
@@ -559,14 +561,14 @@ bool SearchPluginManager::isUpdateNeeded(const QString &pluginName, const Plugin
     return (newVersion > oldVersion);
 }
 
-QString SearchPluginManager::pluginPath(const QString &name)
+Path SearchPluginManager::pluginPath(const QString &name)
 {
-    return QString::fromLatin1("%1/%2.py").arg(pluginsLocation(), name);
+    return (pluginsLocation() / Path(name + QLatin1String(".py")));
 }
 
-PluginVersion SearchPluginManager::getPluginVersion(const QString &filePath)
+PluginVersion SearchPluginManager::getPluginVersion(const Path &filePath)
 {
-    QFile pluginFile(filePath);
+    QFile pluginFile {filePath.data()};
     if (!pluginFile.open(QIODevice::ReadOnly | QIODevice::Text))
         return {};
 
@@ -581,7 +583,7 @@ PluginVersion SearchPluginManager::getPluginVersion(const QString &filePath)
             return version;
 
         LogMsg(tr("Search plugin '%1' contains invalid version string ('%2')")
-            .arg(Utils::Fs::fileName(filePath), versionStr), Log::MsgType::WARNING);
+            .arg(filePath.filename(), versionStr), Log::MsgType::WARNING);
         break;
     }
 

--- a/src/base/search/searchpluginmanager.h
+++ b/src/base/search/searchpluginmanager.h
@@ -33,6 +33,7 @@
 #include <QMetaType>
 #include <QObject>
 
+#include "base/path.h"
 #include "base/utils/version.h"
 
 using PluginVersion = Utils::Version<unsigned short, 2>;
@@ -50,7 +51,7 @@ struct PluginInfo
     QString fullName;
     QString url;
     QStringList supportedCategories;
-    QString iconPath;
+    Path iconPath;
     bool enabled;
 };
 
@@ -85,11 +86,11 @@ public:
     SearchHandler *startSearch(const QString &pattern, const QString &category, const QStringList &usedPlugins);
     SearchDownloadHandler *downloadTorrent(const QString &siteUrl, const QString &url);
 
-    static PluginVersion getPluginVersion(const QString &filePath);
+    static PluginVersion getPluginVersion(const Path &filePath);
     static QString categoryFullName(const QString &categoryName);
     QString pluginFullName(const QString &pluginName);
-    static QString pluginsLocation();
-    static QString engineLocation();
+    static Path pluginsLocation();
+    static Path engineLocation();
 
 signals:
     void pluginEnabled(const QString &name, bool enabled);
@@ -106,13 +107,13 @@ private:
     void update();
     void updateNova();
     void parseVersionInfo(const QByteArray &info);
-    void installPlugin_impl(const QString &name, const QString &path);
+    void installPlugin_impl(const QString &name, const Path &path);
     bool isUpdateNeeded(const QString &pluginName, PluginVersion newVersion) const;
 
     void versionInfoDownloadFinished(const Net::DownloadResult &result);
     void pluginDownloadFinished(const Net::DownloadResult &result);
 
-    static QString pluginPath(const QString &name);
+    static Path pluginPath(const QString &name);
 
     static QPointer<SearchPluginManager> m_instance;
 

--- a/src/base/settingsstorage.h
+++ b/src/base/settingsstorage.h
@@ -36,6 +36,7 @@
 #include <QTimer>
 #include <QVariantHash>
 
+#include "path.h"
 #include "utils/string.h"
 
 template <typename T>
@@ -68,6 +69,11 @@ public:
             const typename T::Int value = loadValue(key, static_cast<typename T::Int>(defaultValue));
             return T {value};
         }
+        else if constexpr (std::is_same_v<T, Path>)
+        {
+            const auto value = loadValue<QString>(key, defaultValue.toString());
+            return Path(value);
+        }
         else if constexpr (std::is_same_v<T, QVariant>)
         {
             // fast path for loading QVariant
@@ -88,8 +94,10 @@ public:
             storeValueImpl(key, Utils::String::fromEnum(value));
         else if constexpr (IsQFlags<T>::value)
             storeValueImpl(key, static_cast<typename T::Int>(value));
+        else if constexpr (std::is_same_v<T, Path>)
+            storeValueImpl(key, value.toString());
         else
-            storeValueImpl(key, value);
+            storeValueImpl(key, QVariant::fromValue(value));
     }
 
     void removeValue(const QString &key);

--- a/src/base/torrentfileguard.cpp
+++ b/src/base/torrentfileguard.cpp
@@ -31,7 +31,7 @@
 #include "settingvalue.h"
 #include "utils/fs.h"
 
-FileGuard::FileGuard(const QString &path)
+FileGuard::FileGuard(const Path &path)
     : m_path {path}
     , m_remove {true}
 {
@@ -45,17 +45,17 @@ void FileGuard::setAutoRemove(const bool remove) noexcept
 FileGuard::~FileGuard()
 {
     if (m_remove && !m_path.isEmpty())
-        Utils::Fs::forceRemove(m_path); // forceRemove() checks for file existence
+        Utils::Fs::removeFile(m_path); // removeFile() checks for file existence
 }
 
-TorrentFileGuard::TorrentFileGuard(const QString &path, const TorrentFileGuard::AutoDeleteMode mode)
-    : FileGuard {mode != Never ? path : QString()}
+TorrentFileGuard::TorrentFileGuard(const Path &path, const TorrentFileGuard::AutoDeleteMode mode)
+    : FileGuard {mode != Never ? path : Path()}
     , m_mode {mode}
     , m_wasAdded {false}
 {
 }
 
-TorrentFileGuard::TorrentFileGuard(const QString &path)
+TorrentFileGuard::TorrentFileGuard(const Path &path)
     : TorrentFileGuard {path, autoDeleteMode()}
 {
 }

--- a/src/base/torrentfileguard.h
+++ b/src/base/torrentfileguard.h
@@ -31,20 +31,22 @@
 #include <QObject>
 #include <QString>
 
+#include "base/path.h"
+
 template <typename T> class SettingValue;
 
 /// Utility class to defer file deletion
 class FileGuard
 {
 public:
-    explicit FileGuard(const QString &path = {});
+    explicit FileGuard(const Path &path = {});
     ~FileGuard();
 
     /// Cancels or re-enables deferred file deletion
     void setAutoRemove(bool remove) noexcept;
 
 private:
-    QString m_path;
+    Path m_path;
     bool m_remove;
 };
 
@@ -55,7 +57,7 @@ class TorrentFileGuard : private FileGuard
     Q_GADGET
 
 public:
-    explicit TorrentFileGuard(const QString &path = {});
+    explicit TorrentFileGuard(const Path &path = {});
     ~TorrentFileGuard();
 
     /// marks the torrent file as loaded (added) into the BitTorrent::Session
@@ -74,7 +76,7 @@ public:
     static void setAutoDeleteMode(AutoDeleteMode mode);
 
 private:
-    TorrentFileGuard(const QString &path, AutoDeleteMode mode);
+    TorrentFileGuard(const Path &path, AutoDeleteMode mode);
     static SettingValue<AutoDeleteMode> &autoDeleteModeSetting();
 
     Q_ENUM(AutoDeleteMode)

--- a/src/base/torrentfileswatcher.h
+++ b/src/base/torrentfileswatcher.h
@@ -32,6 +32,7 @@
 #include <QHash>
 
 #include "base/bittorrent/addtorrentparams.h"
+#include "base/path.h"
 
 class QThread;
 
@@ -61,15 +62,13 @@ public:
     static void freeInstance();
     static TorrentFilesWatcher *instance();
 
-    static QString makeCleanPath(const QString &path);
-
-    QHash<QString, WatchedFolderOptions> folders() const;
-    void setWatchedFolder(const QString &path, const WatchedFolderOptions &options);
-    void removeWatchedFolder(const QString &path);
+    QHash<Path, WatchedFolderOptions> folders() const;
+    void setWatchedFolder(const Path &path, const WatchedFolderOptions &options);
+    void removeWatchedFolder(const Path &path);
 
 signals:
-    void watchedFolderSet(const QString &path, const WatchedFolderOptions &options);
-    void watchedFolderRemoved(const QString &path);
+    void watchedFolderSet(const Path &path, const WatchedFolderOptions &options);
+    void watchedFolderRemoved(const Path &path);
 
 private slots:
     void onMagnetFound(const BitTorrent::MagnetUri &magnetURI, const BitTorrent::AddTorrentParams &addTorrentParams);
@@ -83,11 +82,11 @@ private:
     void loadLegacy();
     void store() const;
 
-    void doSetWatchedFolder(const QString &path, const WatchedFolderOptions &options);
+    void doSetWatchedFolder(const Path &path, const WatchedFolderOptions &options);
 
     static TorrentFilesWatcher *m_instance;
 
-    QHash<QString, WatchedFolderOptions> m_watchedFolders;
+    QHash<Path, WatchedFolderOptions> m_watchedFolders;
 
     QThread *m_ioThread = nullptr;
 

--- a/src/base/utils/fs.h
+++ b/src/base/utils/fs.h
@@ -1,5 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2022  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2012  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
@@ -34,58 +35,36 @@
 
 #include <QString>
 
+#include "base/pathfwd.h"
+
+class QDateTime;
+
 namespace Utils::Fs
 {
-    /**
-     * Converts a path to a string suitable for display.
-     * This function makes sure the directory separator used is consistent
-     * with the OS being run.
-     */
-    QString toNativePath(const QString &path);
+    qint64 computePathSize(const Path &path);
+    qint64 freeDiskSpaceOnPath(const Path &path);
 
-    /**
-     * Converts a path to a string suitable for processing.
-     * This function makes sure the directory separator used is independent
-     * from the OS being run so it is the same on all supported platforms.
-     * Slash ('/') is used as "uniform" directory separator.
-     */
-    QString toUniformPath(const QString &path);
+    bool isRegularFile(const Path &path);
+    bool isDir(const Path &path);
+    bool isReadable(const Path &path);
+    bool isWritable(const Path &path);
+    bool isNetworkFileSystem(const Path &path);
+    QDateTime lastModified(const Path &path);
+    bool sameFiles(const Path &path1, const Path &path2);
 
-    /**
-     * If `path is relative then resolves it against `basePath`, otherwise returns the `path` itself
-     */
-    QString resolvePath(const QString &relativePath, const QString &basePath);
+    QString toValidFileName(const QString &name, const QString &pad = QLatin1String(" "));
+    Path toValidPath(const QString &name, const QString &pad = QLatin1String(" "));
+    Path toCanonicalPath(const Path &path);
 
-    /**
-     * Returns the file extension part of a file name.
-     */
-    QString fileExtension(const QString &filename);
+    bool copyFile(const Path &from, const Path &to);
+    bool renameFile(const Path &from, const Path &to);
+    bool removeFile(const Path &path);
+    bool mkdir(const Path &dirPath);
+    bool mkpath(const Path &dirPath);
+    bool rmdir(const Path &dirPath);
+    void removeDirRecursively(const Path &path);
+    bool smartRemoveEmptyFolderTree(const Path &path);
 
-    QString fileName(const QString &filePath);
-    QString folderName(const QString &filePath);
-    qint64 computePathSize(const QString &path);
-    bool sameFiles(const QString &path1, const QString &path2);
-    QString toValidFileSystemName(const QString &name, bool allowSeparators = false
-            , const QString &pad = QLatin1String(" "));
-    bool isValidFileSystemName(const QString &name, bool allowSeparators = false);
-    qint64 freeDiskSpaceOnPath(const QString &path);
-    QString branchPath(const QString &filePath, QString *removed = nullptr);
-    bool sameFileNames(const QString &first, const QString &second);
-    QString expandPath(const QString &path);
-    QString expandPathAbs(const QString &path);
-    bool isRegularFile(const QString &path);
-
-    bool smartRemoveEmptyFolderTree(const QString &path);
-    bool forceRemove(const QString &filePath);
-    void removeDirRecursive(const QString &path);
-
-    QString tempPath();
-
-    QString findRootFolder(const QStringList &filePaths);
-    void stripRootFolder(QStringList &filePaths);
-    void addRootFolder(QStringList &filePaths, const QString &name);
-
-#if !defined Q_OS_HAIKU
-    bool isNetworkFileSystem(const QString &path);
-#endif
+    Path homePath();
+    Path tempPath();
 }

--- a/src/base/utils/io.cpp
+++ b/src/base/utils/io.cpp
@@ -36,6 +36,8 @@
 #include <QSaveFile>
 #include <QString>
 
+#include "base/path.h"
+
 Utils::IO::FileDeviceOutputIterator::FileDeviceOutputIterator(QFileDevice &device, const int bufferSize)
     : m_device {&device}
     , m_buffer {std::make_shared<QByteArray>()}
@@ -66,17 +68,17 @@ Utils::IO::FileDeviceOutputIterator &Utils::IO::FileDeviceOutputIterator::operat
     return *this;
 }
 
-nonstd::expected<void, QString> Utils::IO::saveToFile(const QString &path, const QByteArray &data)
+nonstd::expected<void, QString> Utils::IO::saveToFile(const Path &path, const QByteArray &data)
 {
-    QSaveFile file {path};
+    QSaveFile file {path.data()};
     if (!file.open(QIODevice::WriteOnly) || (file.write(data) != data.size()) || !file.flush() || !file.commit())
         return nonstd::make_unexpected(file.errorString());
     return {};
 }
 
-nonstd::expected<void, QString> Utils::IO::saveToFile(const QString &path, const lt::entry &data)
+nonstd::expected<void, QString> Utils::IO::saveToFile(const Path &path, const lt::entry &data)
 {
-    QSaveFile file {path};
+    QSaveFile file {path.data()};
     if (!file.open(QIODevice::WriteOnly))
         return nonstd::make_unexpected(file.errorString());
 

--- a/src/base/utils/io.h
+++ b/src/base/utils/io.h
@@ -34,6 +34,7 @@
 #include <libtorrent/fwd.hpp>
 
 #include "base/3rdparty/expected.hpp"
+#include "base/pathfwd.h"
 
 class QByteArray;
 class QFileDevice;
@@ -80,6 +81,6 @@ namespace Utils::IO
         int m_bufferSize;
     };
 
-    nonstd::expected<void, QString> saveToFile(const QString &path, const QByteArray &data);
-    nonstd::expected<void, QString> saveToFile(const QString &path, const lt::entry &data);
+    nonstd::expected<void, QString> saveToFile(const Path &path, const QByteArray &data);
+    nonstd::expected<void, QString> saveToFile(const Path &path, const lt::entry &data);
 }

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -61,6 +61,7 @@
 #include <QDBusInterface>
 #endif
 
+#include "base/path.h"
 #include "base/types.h"
 #include "base/unicodestrings.h"
 #include "base/utils/fs.h"
@@ -292,9 +293,9 @@ qlonglong Utils::Misc::sizeInBytes(qreal size, const Utils::Misc::SizeUnit unit)
     return size;
 }
 
-bool Utils::Misc::isPreviewable(const QString &filename)
+bool Utils::Misc::isPreviewable(const Path &filePath)
 {
-    const QString mime = QMimeDatabase().mimeTypeForFile(filename, QMimeDatabase::MatchExtension).name();
+    const QString mime = QMimeDatabase().mimeTypeForFile(filePath.data(), QMimeDatabase::MatchExtension).name();
 
     if (mime.startsWith(QLatin1String("audio"), Qt::CaseInsensitive)
         || mime.startsWith(QLatin1String("video"), Qt::CaseInsensitive))
@@ -304,50 +305,50 @@ bool Utils::Misc::isPreviewable(const QString &filename)
 
     const QSet<QString> multimediaExtensions =
     {
-        "3GP",
-        "AAC",
-        "AC3",
-        "AIF",
-        "AIFC",
-        "AIFF",
-        "ASF",
-        "AU",
-        "AVI",
-        "FLAC",
-        "FLV",
-        "M3U",
-        "M4A",
-        "M4P",
-        "M4V",
-        "MID",
-        "MKV",
-        "MOV",
-        "MP2",
-        "MP3",
-        "MP4",
-        "MPC",
-        "MPE",
-        "MPEG",
-        "MPG",
-        "MPP",
-        "OGG",
-        "OGM",
-        "OGV",
-        "QT",
-        "RA",
-        "RAM",
-        "RM",
-        "RMV",
-        "RMVB",
-        "SWA",
-        "SWF",
-        "TS",
-        "VOB",
-        "WAV",
-        "WMA",
-        "WMV"
+        ".3GP",
+        ".AAC",
+        ".AC3",
+        ".AIF",
+        ".AIFC",
+        ".AIFF",
+        ".ASF",
+        ".AU",
+        ".AVI",
+        ".FLAC",
+        ".FLV",
+        ".M3U",
+        ".M4A",
+        ".M4P",
+        ".M4V",
+        ".MID",
+        ".MKV",
+        ".MOV",
+        ".MP2",
+        ".MP3",
+        ".MP4",
+        ".MPC",
+        ".MPE",
+        ".MPEG",
+        ".MPG",
+        ".MPP",
+        ".OGG",
+        ".OGM",
+        ".OGV",
+        ".QT",
+        ".RA",
+        ".RAM",
+        ".RM",
+        ".RMV",
+        ".RMVB",
+        ".SWA",
+        ".SWF",
+        ".TS",
+        ".VOB",
+        ".WAV",
+        ".WMA",
+        ".WMV"
     };
-    return multimediaExtensions.contains(Utils::Fs::fileExtension(filename).toUpper());
+    return multimediaExtensions.contains(filePath.extension().toUpper());
 }
 
 QString Utils::Misc::userFriendlyDuration(const qlonglong seconds, const qlonglong maxCap)

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -37,6 +37,8 @@
 
 #include <QString>
 
+#include "base/pathfwd.h"
+
 enum class ShutdownDialogAction;
 
 /*  Miscellaneous functions that can be useful */
@@ -77,7 +79,7 @@ namespace Utils::Misc
     int friendlyUnitPrecision(SizeUnit unit);
     qint64 sizeInBytes(qreal size, SizeUnit unit);
 
-    bool isPreviewable(const QString &filename);
+    bool isPreviewable(const Path &filePath);
 
     // Take a number of seconds and return a user-friendly
     // time duration like "1d 2h 10m".

--- a/src/gui/aboutdialog.cpp
+++ b/src/gui/aboutdialog.cpp
@@ -30,6 +30,7 @@
 
 #include <QFile>
 
+#include "base/path.h"
 #include "base/unicodestrings.h"
 #include "base/utils/misc.h"
 #include "base/version.h"
@@ -70,7 +71,7 @@ AboutDialog::AboutDialog(QWidget *parent)
             , tr("Bug Tracker:"));
     m_ui->labelAbout->setText(aboutText);
 
-    m_ui->labelMascot->setPixmap(Utils::Gui::scaledPixmap(":/icons/mascot.png", this));
+    m_ui->labelMascot->setPixmap(Utils::Gui::scaledPixmap(Path(":/icons/mascot.png"), this));
 
     // Thanks
     QFile thanksfile(":/thanks.html");

--- a/src/gui/addnewtorrentdialog.h
+++ b/src/gui/addnewtorrentdialog.h
@@ -81,8 +81,8 @@ private slots:
     void displayContentTreeMenu();
     void displayColumnHeaderMenu();
     void updateDiskSpaceLabel();
-    void onSavePathChanged(const QString &newPath);
-    void onDownloadPathChanged(const QString &newPath);
+    void onSavePathChanged(const Path &newPath);
+    void onDownloadPathChanged(const Path &newPath);
     void onUseDownloadPathChanged(bool checked);
     void updateMetadata(const BitTorrent::TorrentInfo &metadata);
     void handleDownloadFinished(const Net::DownloadResult &downloadResult);
@@ -97,7 +97,7 @@ private slots:
 
 private:
     explicit AddNewTorrentDialog(const BitTorrent::AddTorrentParams &inParams, QWidget *parent);
-    bool loadTorrentFile(const QString &torrentPath);
+    bool loadTorrentFile(const QString &source);
     bool loadTorrentImpl();
     bool loadMagnet(const BitTorrent::MagnetUri &magnetUri);
     void populateSavePaths();

--- a/src/gui/autoexpandabledialog.cpp
+++ b/src/gui/autoexpandabledialog.cpp
@@ -28,7 +28,7 @@
 
 #include "autoexpandabledialog.h"
 
-#include "base/utils/fs.h"
+#include "base/path.h"
 #include "ui_autoexpandabledialog.h"
 #include "utils.h"
 
@@ -58,9 +58,9 @@ QString AutoExpandableDialog::getText(QWidget *parent, const QString &title, con
     d.m_ui->textEdit->selectAll();
     if (excludeExtension)
     {
-        const QString extension = Utils::Fs::fileExtension(text);
+        const QString extension = Path(text).extension();
         if (!extension.isEmpty())
-            d.m_ui->textEdit->setSelection(0, (text.length() - extension.length() - 1));
+            d.m_ui->textEdit->setSelection(0, (text.length() - extension.length()));
     }
 
     bool res = d.exec();

--- a/src/gui/fspathedit.cpp
+++ b/src/gui/fspathedit.cpp
@@ -82,7 +82,7 @@ class FileSystemPathEdit::FileSystemPathEditPrivate
     QToolButton *m_browseBtn;
     QString m_fileNameFilter;
     Mode m_mode;
-    QString m_lastSignaledPath;
+    Path m_lastSignaledPath;
     QString m_dialogCaption;
     Private::FileSystemPathValidator *m_validator;
 };
@@ -112,31 +112,32 @@ void FileSystemPathEdit::FileSystemPathEditPrivate::browseActionTriggered()
 {
     Q_Q(FileSystemPathEdit);
 
-    const QFileInfo fileInfo {q->selectedPath()};
-    const QString directory = (m_mode == FileSystemPathEdit::Mode::DirectoryOpen) || (m_mode == FileSystemPathEdit::Mode::DirectorySave)
-            ? fileInfo.absoluteFilePath()
-            : fileInfo.absolutePath();
-    QString filter = q->fileNameFilter();
+    const Path currentDirectory = (m_mode == FileSystemPathEdit::Mode::DirectoryOpen) || (m_mode == FileSystemPathEdit::Mode::DirectorySave)
+            ? q->selectedPath()
+            : q->selectedPath().parentPath();
+    const Path initialDirectory = currentDirectory.isAbsolute() ? currentDirectory : (Utils::Fs::homePath() / currentDirectory);
 
-    QString selectedPath;
+    QString filter = q->fileNameFilter();
+    QString newPath;
     switch (m_mode)
     {
     case FileSystemPathEdit::Mode::FileOpen:
-        selectedPath = QFileDialog::getOpenFileName(q, dialogCaptionOrDefault(), directory, filter);
+        newPath = QFileDialog::getOpenFileName(q, dialogCaptionOrDefault(), initialDirectory.data(), filter);
         break;
     case FileSystemPathEdit::Mode::FileSave:
-        selectedPath = QFileDialog::getSaveFileName(q, dialogCaptionOrDefault(), directory, filter, &filter);
+        newPath = QFileDialog::getSaveFileName(q, dialogCaptionOrDefault(), initialDirectory.data(), filter, &filter);
         break;
     case FileSystemPathEdit::Mode::DirectoryOpen:
     case FileSystemPathEdit::Mode::DirectorySave:
-        selectedPath = QFileDialog::getExistingDirectory(q, dialogCaptionOrDefault(),
-                                directory, QFileDialog::DontResolveSymlinks | QFileDialog::ShowDirsOnly);
+        newPath = QFileDialog::getExistingDirectory(q, dialogCaptionOrDefault(),
+                                initialDirectory.data(), QFileDialog::DontResolveSymlinks | QFileDialog::ShowDirsOnly);
         break;
     default:
         throw std::logic_error("Unknown FileSystemPathEdit mode");
     }
-    if (!selectedPath.isEmpty())
-        q->setEditWidgetText(Utils::Fs::toNativePath(selectedPath));
+
+    if (!newPath.isEmpty())
+        q->setSelectedPath(Path(newPath));
 }
 
 QString FileSystemPathEdit::FileSystemPathEditPrivate::dialogCaptionOrDefault() const
@@ -202,16 +203,18 @@ FileSystemPathEdit::~FileSystemPathEdit()
     delete d_ptr;
 }
 
-QString FileSystemPathEdit::selectedPath() const
+Path FileSystemPathEdit::selectedPath() const
 {
-    return Utils::Fs::toUniformPath(editWidgetText());
+    return Path(editWidgetText());
 }
 
-void FileSystemPathEdit::setSelectedPath(const QString &val)
+void FileSystemPathEdit::setSelectedPath(const Path &val)
 {
     Q_D(FileSystemPathEdit);
-    setEditWidgetText(Utils::Fs::toNativePath(val));
-    d->m_editor->widget()->setToolTip(val);
+
+    const QString nativePath = val.toString();
+    setEditWidgetText(nativePath);
+    d->m_editor->widget()->setToolTip(nativePath);
 }
 
 QString FileSystemPathEdit::fileNameFilter() const
@@ -251,13 +254,13 @@ void FileSystemPathEdit::setFileNameFilter(const QString &val)
 #endif
 }
 
-QString FileSystemPathEdit::placeholder() const
+Path FileSystemPathEdit::placeholder() const
 {
     Q_D(const FileSystemPathEdit);
     return d->m_editor->placeholder();
 }
 
-void FileSystemPathEdit::setPlaceholder(const QString &val)
+void FileSystemPathEdit::setPlaceholder(const Path &val)
 {
     Q_D(FileSystemPathEdit);
     d->m_editor->setPlaceholder(val);
@@ -278,7 +281,8 @@ void FileSystemPathEdit::setBriefBrowseButtonCaption(bool brief)
 void FileSystemPathEdit::onPathEdited()
 {
     Q_D(FileSystemPathEdit);
-    QString newPath = selectedPath();
+
+    const Path newPath = selectedPath();
     if (newPath != d->m_lastSignaledPath)
     {
         emit selectedPathChanged(newPath);
@@ -360,19 +364,19 @@ int FileSystemPathComboEdit::count() const
     return editWidget<WidgetType>()->count();
 }
 
-QString FileSystemPathComboEdit::item(int index) const
+Path FileSystemPathComboEdit::item(int index) const
 {
-    return Utils::Fs::toUniformPath(editWidget<WidgetType>()->itemText(index));
+    return Path(editWidget<WidgetType>()->itemText(index));
 }
 
-void FileSystemPathComboEdit::addItem(const QString &text)
+void FileSystemPathComboEdit::addItem(const Path &path)
 {
-    editWidget<WidgetType>()->addItem(Utils::Fs::toNativePath(text));
+    editWidget<WidgetType>()->addItem(path.toString());
 }
 
-void FileSystemPathComboEdit::insertItem(int index, const QString &text)
+void FileSystemPathComboEdit::insertItem(int index, const Path &path)
 {
-    editWidget<WidgetType>()->insertItem(index, Utils::Fs::toNativePath(text));
+    editWidget<WidgetType>()->insertItem(index, path.toString());
 }
 
 int FileSystemPathComboEdit::currentIndex() const

--- a/src/gui/fspathedit.h
+++ b/src/gui/fspathedit.h
@@ -30,6 +30,8 @@
 
 #include <QWidget>
 
+#include "base/path.h"
+
 namespace Private
 {
     class FileComboEdit;
@@ -45,7 +47,7 @@ class FileSystemPathEdit : public QWidget
 {
     Q_OBJECT
     Q_PROPERTY(Mode mode READ mode WRITE setMode)
-    Q_PROPERTY(QString selectedPath READ selectedPath WRITE setSelectedPath NOTIFY selectedPathChanged)
+    Q_PROPERTY(Path selectedPath READ selectedPath WRITE setSelectedPath NOTIFY selectedPathChanged)
     Q_PROPERTY(QString fileNameFilter READ fileNameFilter WRITE setFileNameFilter)
     Q_PROPERTY(QString dialogCaption READ dialogCaption WRITE setDialogCaption)
 
@@ -64,14 +66,14 @@ public:
     Mode mode() const;
     void setMode(Mode mode);
 
-    QString selectedPath() const;
-    void setSelectedPath(const QString &val);
+    Path selectedPath() const;
+    void setSelectedPath(const Path &val);
 
     QString fileNameFilter() const;
     void setFileNameFilter(const QString &val);
 
-    QString placeholder() const;
-    void setPlaceholder(const QString &val);
+    Path placeholder() const;
+    void setPlaceholder(const Path &val);
 
     /// The browse button caption is "..." if true, and "Browse" otherwise
     bool briefBrowseButtonCaption() const;
@@ -83,7 +85,7 @@ public:
     virtual void clear() = 0;
 
 signals:
-    void selectedPathChanged(const QString &path);
+    void selectedPathChanged(const Path &path);
 
 protected:
     explicit FileSystemPathEdit(Private::FileEditorWithCompletion *editor, QWidget *parent);
@@ -136,9 +138,9 @@ public:
     void clear() override;
 
     int count() const;
-    QString item(int index) const;
-    void addItem(const QString &text);
-    void insertItem(int index, const QString &text);
+    Path item(int index) const;
+    void addItem(const Path &path);
+    void insertItem(int index, const Path &path);
 
     int currentIndex() const;
     void setCurrentIndex(int index);

--- a/src/gui/fspathedit_p.cpp
+++ b/src/gui/fspathedit_p.cpp
@@ -37,6 +37,8 @@
 #include <QStringList>
 #include <QStyle>
 
+#include "base/path.h"
+
 // -------------------- FileSystemPathValidator ----------------------------------------
 Private::FileSystemPathValidator::FileSystemPathValidator(QObject *parent)
     : QValidator(parent)
@@ -149,7 +151,7 @@ QValidator::State Private::FileSystemPathValidator::validate(const QList<QString
         const QStringView componentPath = pathComponents[i];
         if (componentPath.isEmpty()) continue;
 
-        m_lastTestResult = testPath(pathComponents[i], isFinalPath);
+        m_lastTestResult = testPath(Path(pathComponents[i].toString()), isFinalPath);
         if (m_lastTestResult != TestResult::OK)
         {
             m_lastTestedPath = componentPath.toString();
@@ -161,9 +163,9 @@ QValidator::State Private::FileSystemPathValidator::validate(const QList<QString
 }
 
 Private::FileSystemPathValidator::TestResult
-Private::FileSystemPathValidator::testPath(const QStringView path, bool pathIsComplete) const
+Private::FileSystemPathValidator::testPath(const Path &path, bool pathIsComplete) const
 {
-    QFileInfo fi(path.toString());
+    QFileInfo fi {path.data()};
     if (m_existingOnly && !fi.exists())
         return TestResult::DoesNotExist;
 
@@ -240,14 +242,14 @@ void Private::FileLineEdit::setValidator(QValidator *validator)
     QLineEdit::setValidator(validator);
 }
 
-QString Private::FileLineEdit::placeholder() const
+Path Private::FileLineEdit::placeholder() const
 {
-    return placeholderText();
+    return Path(placeholderText());
 }
 
-void Private::FileLineEdit::setPlaceholder(const QString &val)
+void Private::FileLineEdit::setPlaceholder(const Path &val)
 {
-    setPlaceholderText(val);
+    setPlaceholderText(val.toString());
 }
 
 QWidget *Private::FileLineEdit::widget()
@@ -356,14 +358,14 @@ void Private::FileComboEdit::setValidator(QValidator *validator)
     lineEdit()->setValidator(validator);
 }
 
-QString Private::FileComboEdit::placeholder() const
+Path Private::FileComboEdit::placeholder() const
 {
-    return lineEdit()->placeholderText();
+    return Path(lineEdit()->placeholderText());
 }
 
-void Private::FileComboEdit::setPlaceholder(const QString &val)
+void Private::FileComboEdit::setPlaceholder(const Path &val)
 {
-    lineEdit()->setPlaceholderText(val);
+    lineEdit()->setPlaceholderText(val.toString());
 }
 
 void Private::FileComboEdit::setFilenameFilters(const QStringList &filters)

--- a/src/gui/fspathedit_p.h
+++ b/src/gui/fspathedit_p.h
@@ -34,6 +34,8 @@
 #include <QtContainerFwd>
 #include <QValidator>
 
+#include "base/pathfwd.h"
+
 class QAction;
 class QCompleter;
 class QContextMenuEvent;
@@ -84,7 +86,7 @@ namespace Private
         QValidator::State validate(const QList<QStringView> &pathComponents, bool strict,
                                    int firstComponentToTest, int lastComponentToTest) const;
 
-        TestResult testPath(QStringView path, bool pathIsComplete) const;
+        TestResult testPath(const Path &path, bool pathIsComplete) const;
 
         bool m_strictMode;
         bool m_existingOnly;
@@ -105,8 +107,8 @@ namespace Private
         virtual void setFilenameFilters(const QStringList &filters) = 0;
         virtual void setBrowseAction(QAction *action) = 0;
         virtual void setValidator(QValidator *validator) = 0;
-        virtual QString placeholder() const = 0;
-        virtual void setPlaceholder(const QString &val) = 0;
+        virtual Path placeholder() const = 0;
+        virtual void setPlaceholder(const Path &val) = 0;
         virtual QWidget *widget() = 0;
     };
 
@@ -123,8 +125,8 @@ namespace Private
         void setFilenameFilters(const QStringList &filters) override;
         void setBrowseAction(QAction *action) override;
         void setValidator(QValidator *validator) override;
-        QString placeholder() const override;
-        void setPlaceholder(const QString &val) override;
+        Path placeholder() const override;
+        void setPlaceholder(const Path &val) override;
         QWidget *widget() override;
 
     protected:
@@ -153,8 +155,8 @@ namespace Private
         void setFilenameFilters(const QStringList &filters) override;
         void setBrowseAction(QAction *action) override;
         void setValidator(QValidator *validator) override;
-        QString placeholder() const override;
-        void setPlaceholder(const QString &val) override;
+        Path placeholder() const override;
+        void setPlaceholder(const Path &val) override;
         QWidget *widget() override;
 
     protected:

--- a/src/gui/macutilities.h
+++ b/src/gui/macutilities.h
@@ -30,7 +30,7 @@
 
 #include <objc/objc.h>
 
-#include <QSet>
+#include "base/pathfwd.h"
 
 class QPixmap;
 class QSize;
@@ -41,7 +41,7 @@ namespace MacUtils
     QPixmap pixmapForExtension(const QString &ext, const QSize &size);
     void overrideDockClickHandler(bool (*dockClickHandler)(id, SEL, ...));
     void displayNotification(const QString &title, const QString &message);
-    void openFiles(const QSet<QString> &pathsList);
+    void openFiles(const PathList &pathList);
 
     QString badgeLabelText();
     void setBadgeLabelText(const QString &text);

--- a/src/gui/macutilities.mm
+++ b/src/gui/macutilities.mm
@@ -32,9 +32,11 @@
 #include <objc/message.h>
 
 #include <QPixmap>
-#include <QSet>
 #include <QSize>
 #include <QString>
+#include <QVector>
+
+#include "base/path.h"
 
 QImage qt_mac_toQImage(CGImageRef image);
 
@@ -95,14 +97,14 @@ namespace MacUtils
         }
     }
 
-    void openFiles(const QSet<QString> &pathsList)
+    void openFiles(const PathList &pathList)
     {
         @autoreleasepool
         {
-            NSMutableArray *pathURLs = [NSMutableArray arrayWithCapacity:pathsList.size()];
+            NSMutableArray *pathURLs = [NSMutableArray arrayWithCapacity:pathList.size()];
 
-            for (const auto &path : pathsList)
-                [pathURLs addObject:[NSURL fileURLWithPath:path.toNSString()]];
+            for (const auto &path : pathList)
+                [pathURLs addObject:[NSURL fileURLWithPath:path.toString().toNSString()]];
 
             [[NSWorkspace sharedWorkspace] activateFileViewerSelectingURLs:pathURLs];
         }

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -212,7 +212,7 @@ private:
     bool event(QEvent *e) override;
     void displayRSSTab(bool enable);
     void displaySearchTab(bool enable);
-    void createTorrentTriggered(const QString &path = {});
+    void createTorrentTriggered(const Path &path);
     void showStatusBar(bool show);
 
     Ui::MainWindow *m_ui;

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -30,6 +30,7 @@
 
 #include <QDialog>
 
+#include "base/pathfwd.h"
 #include "base/settingvalue.h"
 
 class QCloseEvent;
@@ -112,8 +113,8 @@ private slots:
     void on_removeWatchedFolderButton_clicked();
     void on_registerDNSBtn_clicked();
     void setLocale(const QString &localeStr);
-    void webUIHttpsCertChanged(const QString &path, ShowError showError);
-    void webUIHttpsKeyChanged(const QString &path, ShowError showError);
+    void webUIHttpsCertChanged(const Path &path, ShowError showError);
+    void webUIHttpsKeyChanged(const Path &path, ShowError showError);
 
 private:
     // Methods
@@ -136,9 +137,8 @@ private:
     bool preAllocateAllFiles() const;
     bool useAdditionDialog() const;
     bool addTorrentsInPause() const;
-    QString getTorrentExportDir() const;
-    QString getFinishedTorrentExportDir() const;
-    QString askForExportDir(const QString &currentExportPath);
+    Path getTorrentExportDir() const;
+    Path getFinishedTorrentExportDir() const;
     // Connection options
     int getPort() const;
     bool isUPnPEnabled() const;
@@ -162,7 +162,7 @@ private:
     Net::ProxyType getProxyType() const;
     // IP Filter
     bool isIPFilteringEnabled() const;
-    QString getFilter() const;
+    Path getFilter() const;
     // Queueing system
     bool isQueueingSystemEnabled() const;
     int getMaxActiveDownloads() const;

--- a/src/gui/previewselectdialog.cpp
+++ b/src/gui/previewselectdialog.cpp
@@ -93,12 +93,12 @@ PreviewSelectDialog::PreviewSelectDialog(QWidget *parent, const BitTorrent::Torr
     const QVector<qreal> fp = torrent->filesProgress();
     for (int i = 0; i < torrent->filesCount(); ++i)
     {
-        const QString fileName = Utils::Fs::fileName(torrent->filePath(i));
-        if (Utils::Misc::isPreviewable(fileName))
+        const Path filePath = torrent->filePath(i);
+        if (Utils::Misc::isPreviewable(filePath))
         {
             int row = m_previewListModel->rowCount();
             m_previewListModel->insertRow(row);
-            m_previewListModel->setData(m_previewListModel->index(row, NAME), fileName);
+            m_previewListModel->setData(m_previewListModel->index(row, NAME), filePath.filename());
             m_previewListModel->setData(m_previewListModel->index(row, SIZE), torrent->fileSize(i));
             m_previewListModel->setData(m_previewListModel->index(row, PROGRESS), fp[i]);
             m_previewListModel->setData(m_previewListModel->index(row, FILE_INDEX), i);
@@ -133,14 +133,14 @@ void PreviewSelectDialog::previewButtonClicked()
 
     // Only one file should be selected
     const int fileIndex = selectedIndexes.at(0).data().toInt();
-    const QString path = QDir(m_torrent->actualStorageLocation()).absoluteFilePath(m_torrent->actualFilePath(fileIndex));
+    const Path path = m_torrent->actualStorageLocation() / m_torrent->actualFilePath(fileIndex);
     // File
-    if (!QFile::exists(path))
+    if (!path.exists())
     {
         const bool isSingleFile = (m_previewListModel->rowCount() == 1);
         QWidget *parent = isSingleFile ? this->parentWidget() : this;
         QMessageBox::critical(parent, tr("Preview impossible")
-            , tr("Sorry, we can't preview this file: \"%1\".").arg(Utils::Fs::toNativePath(path)));
+            , tr("Sorry, we can't preview this file: \"%1\".").arg(path.toString()));
         if (isSingleFile)
             reject();
         return;

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -470,9 +470,11 @@ void PeerListWidget::updatePeer(const BitTorrent::Torrent *torrent, const BitTor
     setModelData(row, PeerListColumns::TOT_UP, totalUp, peer.totalUpload(), intDataTextAlignment);
     setModelData(row, PeerListColumns::RELEVANCE, (Utils::String::fromDouble(peer.relevance() * 100, 1) + '%'), peer.relevance(), intDataTextAlignment);
 
-    const QStringList downloadingFiles {torrent->hasMetadata()
-                ? torrent->info().filesForPiece(peer.downloadingPieceIndex())
-                : QStringList()};
+    const PathList filePaths = torrent->info().filesForPiece(peer.downloadingPieceIndex());
+    QStringList downloadingFiles;
+    downloadingFiles.reserve(filePaths.size());
+    for (const Path &filePath : filePaths)
+        downloadingFiles.append(filePath.toString());
     const QString downloadingFilesDisplayValue = downloadingFiles.join(';');
     setModelData(row, PeerListColumns::DOWNLOADING_PIECE, downloadingFilesDisplayValue, downloadingFilesDisplayValue, {}, downloadingFiles.join(QLatin1Char('\n')));
 

--- a/src/gui/properties/piecesbar.cpp
+++ b/src/gui/properties/piecesbar.cpp
@@ -37,9 +37,10 @@
 #include <QTextStream>
 #include <QToolTip>
 
-#include "base/indexrange.h"
 #include "base/bittorrent/torrent.h"
 #include "base/bittorrent/torrentinfo.h"
+#include "base/indexrange.h"
+#include "base/path.h"
 #include "base/utils/misc.h"
 
 namespace
@@ -53,9 +54,8 @@ namespace
     {
     public:
         PieceIndexToImagePos(const BitTorrent::TorrentInfo &torrentInfo, const QImage &image)
-            : m_bytesPerPixel
-            {((image.width() > 0) && (torrentInfo.totalSize() >= image.width()))
-                ? torrentInfo.totalSize() / image.width() : -1}
+            : m_bytesPerPixel {((image.width() > 0) && (torrentInfo.totalSize() >= image.width()))
+                               ? torrentInfo.totalSize() / image.width() : -1}
             , m_torrentInfo {torrentInfo}
         {
             if ((m_bytesPerPixel > 0) && (m_bytesPerPixel < 10))
@@ -100,9 +100,9 @@ namespace
             m_stream << "</table>";
         }
 
-        void operator()(const QString &size, const QString &path)
+        void operator()(const QString &size, const Path &path)
         {
-            m_stream << R"(<tr><td style="white-space:nowrap">)" << size << "</td><td>" << path << "</td></tr>";
+            m_stream << R"(<tr><td style="white-space:nowrap">)" << size << "</td><td>" << path.toString() << "</td></tr>";
         }
 
     private:
@@ -282,7 +282,7 @@ void PiecesBar::showToolTip(const QHelpEvent *e)
 
             for (int f : files)
             {
-                const QString filePath {torrentInfo.filePath(f)};
+                const Path filePath = torrentInfo.filePath(f);
                 renderer(Utils::Misc::friendlyUnit(torrentInfo.fileSize(f)), filePath);
             }
             stream << "</body></html>";

--- a/src/gui/properties/propertieswidget.h
+++ b/src/gui/properties/propertieswidget.h
@@ -31,6 +31,8 @@
 #include <QList>
 #include <QWidget>
 
+#include "base/pathfwd.h"
+
 class QPushButton;
 class QTreeView;
 
@@ -108,7 +110,7 @@ private:
     QPushButton *getButtonFromIndex(int index);
     void applyPriorities();
     void openParentFolder(const QModelIndex &index) const;
-    QString getFullPath(const QModelIndex &index) const;
+    Path getFullPath(const QModelIndex &index) const;
 
     Ui::PropertiesWidget *m_ui;
     BitTorrent::Torrent *m_torrent;

--- a/src/gui/rss/feedlistwidget.cpp
+++ b/src/gui/rss/feedlistwidget.cpp
@@ -67,9 +67,9 @@ namespace
         }
     };
 
-    QIcon loadIcon(const QString &path, const QString &fallbackId)
+    QIcon loadIcon(const Path &path, const QString &fallbackId)
     {
-        const QPixmap pixmap {path};
+        const QPixmap pixmap {path.data()};
         if (!pixmap.isNull())
             return {pixmap};
 

--- a/src/gui/rss/htmlbrowser.cpp
+++ b/src/gui/rss/htmlbrowser.cpp
@@ -30,7 +30,6 @@
 
 #include <QApplication>
 #include <QDateTime>
-#include <QDir>
 #include <QDebug>
 #include <QNetworkDiskCache>
 #include <QNetworkReply>
@@ -38,6 +37,7 @@
 #include <QScrollBar>
 #include <QStyle>
 
+#include "base/path.h"
 #include "base/profile.h"
 
 HtmlBrowser::HtmlBrowser(QWidget *parent)
@@ -45,7 +45,7 @@ HtmlBrowser::HtmlBrowser(QWidget *parent)
 {
     m_netManager = new QNetworkAccessManager(this);
     m_diskCache = new QNetworkDiskCache(this);
-    m_diskCache->setCacheDirectory(QDir::cleanPath(specialFolderLocation(SpecialFolder::Cache) + "/rss"));
+    m_diskCache->setCacheDirectory((specialFolderLocation(SpecialFolder::Cache) / Path("rss")).data());
     m_diskCache->setMaximumCacheSize(50 * 1024 * 1024);
     qDebug() << "HtmlBrowser  cache path:" << m_diskCache->cacheDirectory() << " max size:" << m_diskCache->maximumCacheSize() / 1024 / 1024 << "MB";
     m_netManager->setCache(m_diskCache);

--- a/src/gui/torrentcategorydialog.cpp
+++ b/src/gui/torrentcategorydialog.cpp
@@ -153,7 +153,7 @@ void TorrentCategoryDialog::setCategoryOptions(const BitTorrent::CategoryOptions
     if (categoryOptions.downloadPath)
     {
         m_ui->comboUseDownloadPath->setCurrentIndex(categoryOptions.downloadPath->enabled ? 1 : 2);
-        m_ui->comboDownloadPath->setSelectedPath(categoryOptions.downloadPath->enabled ? categoryOptions.downloadPath->path : QString());
+        m_ui->comboDownloadPath->setSelectedPath(categoryOptions.downloadPath->enabled ? categoryOptions.downloadPath->path : Path());
     }
     else
     {
@@ -164,30 +164,29 @@ void TorrentCategoryDialog::setCategoryOptions(const BitTorrent::CategoryOptions
 
 void TorrentCategoryDialog::categoryNameChanged(const QString &categoryName)
 {
-    const QString categoryPath = Utils::Fs::toValidFileSystemName(categoryName, true);
+    const Path categoryPath = Utils::Fs::toValidPath(categoryName);
     const auto *btSession = BitTorrent::Session::instance();
-    m_ui->comboSavePath->setPlaceholder(Utils::Fs::resolvePath(categoryPath, btSession->savePath()));
+    m_ui->comboSavePath->setPlaceholder(btSession->savePath() / categoryPath);
 
     const int index = m_ui->comboUseDownloadPath->currentIndex();
     const bool useDownloadPath = (index == 1) || ((index == 0) && BitTorrent::Session::instance()->isDownloadPathEnabled());
     if (useDownloadPath)
-        m_ui->comboDownloadPath->setPlaceholder(Utils::Fs::resolvePath(categoryPath, btSession->downloadPath()));
+        m_ui->comboDownloadPath->setPlaceholder(btSession->downloadPath() / categoryPath);
 
     m_ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(!categoryName.isEmpty());
 }
 
 void TorrentCategoryDialog::useDownloadPathChanged(const int index)
 {
-    if (const QString selectedPath = m_ui->comboDownloadPath->selectedPath(); !selectedPath.isEmpty())
+    if (const Path selectedPath = m_ui->comboDownloadPath->selectedPath(); !selectedPath.isEmpty())
         m_lastEnteredDownloadPath = selectedPath;
 
     m_ui->labelDownloadPath->setEnabled(index == 1);
     m_ui->comboDownloadPath->setEnabled(index == 1);
-    m_ui->comboDownloadPath->setSelectedPath((index == 1) ? m_lastEnteredDownloadPath : QString());
+    m_ui->comboDownloadPath->setSelectedPath((index == 1) ? m_lastEnteredDownloadPath : Path());
 
     const QString categoryName = m_ui->textCategoryName->text();
-    const QString categoryPath = Utils::Fs::resolvePath(Utils::Fs::toValidFileSystemName(categoryName, true)
-                                             , BitTorrent::Session::instance()->downloadPath());
+    const Path categoryPath = BitTorrent::Session::instance()->downloadPath() / Utils::Fs::toValidPath(categoryName);
     const bool useDownloadPath = (index == 1) || ((index == 0) && BitTorrent::Session::instance()->isDownloadPathEnabled());
-    m_ui->comboDownloadPath->setPlaceholder(useDownloadPath ? categoryPath : QString());
+    m_ui->comboDownloadPath->setPlaceholder(useDownloadPath ? categoryPath : Path());
 }

--- a/src/gui/torrentcategorydialog.h
+++ b/src/gui/torrentcategorydialog.h
@@ -30,6 +30,8 @@
 
 #include <QDialog>
 
+#include "base/path.h"
+
 namespace BitTorrent
 {
     struct CategoryOptions;
@@ -64,5 +66,5 @@ private slots:
 
 private:
     Ui::TorrentCategoryDialog *m_ui;
-    QString m_lastEnteredDownloadPath;
+    Path m_lastEnteredDownloadPath;
 };

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -53,6 +53,7 @@
 #include "base/bittorrent/abstractfilestorage.h"
 #include "base/bittorrent/downloadpriority.h"
 #include "base/global.h"
+#include "base/path.h"
 #include "base/utils/fs.h"
 #include "torrentcontentmodelfile.h"
 #include "torrentcontentmodelfolder.h"
@@ -503,7 +504,7 @@ void TorrentContentModel::setupModelData(const BitTorrent::AbstractFileStorage &
     for (int i = 0; i < filesCount; ++i)
     {
         currentParent = m_rootItem;
-        const QString path = Utils::Fs::toUniformPath(info.filePath(i));
+        const QString path = info.filePath(i).data();
 
         // Iterate of parts of the path to create necessary folders
         QList<QStringView> pathFolders = QStringView(path).split(u'/', Qt::SkipEmptyParts);
@@ -523,7 +524,7 @@ void TorrentContentModel::setupModelData(const BitTorrent::AbstractFileStorage &
         }
         // Actually create the file
         TorrentContentModelFile *fileItem = new TorrentContentModelFile(
-                    Utils::Fs::fileName(info.filePath(i)), info.fileSize(i), currentParent, i);
+                    info.filePath(i).filename(), info.fileSize(i), currentParent, i);
         currentParent->appendChild(fileItem);
         m_filesIndex.push_back(fileItem);
     }

--- a/src/gui/torrentcontenttreeview.cpp
+++ b/src/gui/torrentcontenttreeview.cpp
@@ -44,6 +44,7 @@
 #include "base/bittorrent/torrentinfo.h"
 #include "base/exceptions.h"
 #include "base/global.h"
+#include "base/path.h"
 #include "base/utils/fs.h"
 #include "autoexpandabledialog.h"
 #include "raisedmessagebox.h"
@@ -52,12 +53,12 @@
 
 namespace
 {
-    QString getFullPath(const QModelIndex &idx)
+    Path getFullPath(const QModelIndex &idx)
     {
-        QStringList paths;
+        Path path;
         for (QModelIndex i = idx; i.isValid(); i = i.parent())
-            paths.prepend(i.data().toString());
-        return paths.join(QLatin1Char {'/'});
+            path = Path(i.data().toString()) / path;
+        return path;
     }
 }
 
@@ -130,9 +131,9 @@ void TorrentContentTreeView::renameSelectedFile(BitTorrent::AbstractFileStorage 
     if (newName == oldName)
         return;  // Name did not change
 
-    const QString parentPath = getFullPath(modelIndex.parent());
-    const QString oldPath {parentPath.isEmpty() ? oldName : parentPath + QLatin1Char {'/'} + oldName};
-    const QString newPath {parentPath.isEmpty() ? newName : parentPath + QLatin1Char {'/'} + newName};
+    const Path parentPath = getFullPath(modelIndex.parent());
+    const Path oldPath = parentPath / Path(oldName);
+    const Path newPath = parentPath / Path(newName);
 
     try
     {

--- a/src/gui/torrentcreatordialog.h
+++ b/src/gui/torrentcreatordialog.h
@@ -32,6 +32,7 @@
 #include <QDialog>
 
 #include "base/bittorrent/torrentcreatorthread.h"
+#include "base/path.h"
 #include "base/settingvalue.h"
 
 namespace Ui
@@ -42,11 +43,12 @@ namespace Ui
 class TorrentCreatorDialog final : public QDialog
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(TorrentCreatorDialog)
 
 public:
-    TorrentCreatorDialog(QWidget *parent = nullptr, const QString &defaultPath = {});
+    TorrentCreatorDialog(QWidget *parent = nullptr, const Path &defaultPath = {});
     ~TorrentCreatorDialog() override;
-    void updateInputPath(const QString &path);
+    void updateInputPath(const Path &path);
 
 private slots:
     void updateProgressBar(int progress);
@@ -55,7 +57,7 @@ private slots:
     void onAddFileButtonClicked();
     void onAddFolderButtonClicked();
     void handleCreationFailure(const QString &msg);
-    void handleCreationSuccess(const QString &path, const QString &branchPath);
+    void handleCreationSuccess(const Path &path, const Path &branchPath);
 
 private:
     void dropEvent(QDropEvent *event) override;
@@ -87,10 +89,10 @@ private:
     SettingValue<bool> m_storeOptimizeAlignment;
     SettingValue<int> m_paddedFileSizeLimit;
 #endif
-    SettingValue<QString> m_storeLastAddPath;
+    SettingValue<Path> m_storeLastAddPath;
     SettingValue<QString> m_storeTrackerList;
     SettingValue<QString> m_storeWebSeedList;
     SettingValue<QString> m_storeComments;
-    SettingValue<QString> m_storeLastSavePath;
+    SettingValue<Path> m_storeLastSavePath;
     SettingValue<QString> m_storeSource;
 };

--- a/src/gui/torrentoptionsdialog.cpp
+++ b/src/gui/torrentoptionsdialog.cpp
@@ -90,8 +90,8 @@ TorrentOptionsDialog::TorrentOptionsDialog(QWidget *parent, const QVector<BitTor
     bool allSameDownloadPath = true;
 
     const bool isFirstTorrentAutoTMMEnabled = torrents[0]->isAutoTMMEnabled();
-    const QString firstTorrentSavePath = torrents[0]->savePath();
-    const QString firstTorrentDownloadPath = torrents[0]->downloadPath();
+    const Path firstTorrentSavePath = torrents[0]->savePath();
+    const Path firstTorrentDownloadPath = torrents[0]->downloadPath();
     const QString firstTorrentCategory = torrents[0]->category();
 
     const int firstTorrentUpLimit = std::max(0, torrents[0]->uploadLimit());
@@ -418,20 +418,20 @@ void TorrentOptionsDialog::accept()
 
         if (m_ui->checkAutoTMM->checkState() == Qt::Unchecked)
         {
-            const QString savePath = m_ui->savePath->selectedPath();
+            const Path savePath = m_ui->savePath->selectedPath();
             if (m_initialValues.savePath != savePath)
-                torrent->setSavePath(Utils::Fs::expandPathAbs(savePath));
+                torrent->setSavePath(savePath);
 
             const Qt::CheckState useDownloadPathState = m_ui->checkUseDownloadPath->checkState();
             if (useDownloadPathState == Qt::Checked)
             {
-                const QString downloadPath = m_ui->downloadPath->selectedPath();
+                const Path downloadPath = m_ui->downloadPath->selectedPath();
                 if (m_initialValues.downloadPath != downloadPath)
-                    torrent->setDownloadPath(Utils::Fs::expandPathAbs(downloadPath));
+                    torrent->setDownloadPath(downloadPath);
             }
             else if (useDownloadPathState == Qt::Unchecked)
             {
-                torrent->setDownloadPath(QString());
+                torrent->setDownloadPath({});
             }
         }
 
@@ -513,14 +513,14 @@ void TorrentOptionsDialog::handleCategoryChanged(const int index)
     {
         if (!m_allSameCategory && (m_ui->comboCategory->currentIndex() == 0))
         {
-            m_ui->savePath->setSelectedPath(QString());
+            m_ui->savePath->setSelectedPath({});
         }
         else
         {
-            const QString savePath = BitTorrent::Session::instance()->categorySavePath(m_ui->comboCategory->currentText());
-            m_ui->savePath->setSelectedPath(Utils::Fs::toNativePath(savePath));
-            const QString downloadPath = BitTorrent::Session::instance()->categoryDownloadPath(m_ui->comboCategory->currentText());
-            m_ui->downloadPath->setSelectedPath(Utils::Fs::toNativePath(downloadPath));
+            const Path savePath = BitTorrent::Session::instance()->categorySavePath(m_ui->comboCategory->currentText());
+            m_ui->savePath->setSelectedPath(savePath);
+            const Path downloadPath = BitTorrent::Session::instance()->categoryDownloadPath(m_ui->comboCategory->currentText());
+            m_ui->downloadPath->setSelectedPath(downloadPath);
             m_ui->checkUseDownloadPath->setChecked(!downloadPath.isEmpty());
         }
     }
@@ -541,8 +541,8 @@ void TorrentOptionsDialog::handleTMMChanged()
     if (m_ui->checkAutoTMM->checkState() == Qt::Unchecked)
     {
         m_ui->groupBoxSavePath->setEnabled(true);
-        m_ui->savePath->setSelectedPath(Utils::Fs::toNativePath(m_initialValues.savePath));
-        m_ui->downloadPath->setSelectedPath(Utils::Fs::toNativePath(m_initialValues.downloadPath));
+        m_ui->savePath->setSelectedPath(m_initialValues.savePath);
+        m_ui->downloadPath->setSelectedPath(m_initialValues.downloadPath);
         m_ui->checkUseDownloadPath->setCheckState(m_initialValues.useDownloadPath);
     }
     else
@@ -552,23 +552,23 @@ void TorrentOptionsDialog::handleTMMChanged()
         {
             if (!m_allSameCategory && (m_ui->comboCategory->currentIndex() == 0))
             {
-                m_ui->savePath->setSelectedPath(QString());
-                m_ui->downloadPath->setSelectedPath(QString());
+                m_ui->savePath->setSelectedPath({});
+                m_ui->downloadPath->setSelectedPath({});
                 m_ui->checkUseDownloadPath->setCheckState(Qt::PartiallyChecked);
             }
             else
             {
-                const QString savePath = BitTorrent::Session::instance()->categorySavePath(m_ui->comboCategory->currentText());
-                m_ui->savePath->setSelectedPath(Utils::Fs::toNativePath(savePath));
-                const QString downloadPath = BitTorrent::Session::instance()->categoryDownloadPath(m_ui->comboCategory->currentText());
-                m_ui->downloadPath->setSelectedPath(Utils::Fs::toNativePath(downloadPath));
+                const Path savePath = BitTorrent::Session::instance()->categorySavePath(m_ui->comboCategory->currentText());
+                m_ui->savePath->setSelectedPath(savePath);
+                const Path downloadPath = BitTorrent::Session::instance()->categoryDownloadPath(m_ui->comboCategory->currentText());
+                m_ui->downloadPath->setSelectedPath(downloadPath);
                 m_ui->checkUseDownloadPath->setChecked(!downloadPath.isEmpty());
             }
         }
         else // partially checked
         {
-            m_ui->savePath->setSelectedPath(QString());
-            m_ui->downloadPath->setSelectedPath(QString());
+            m_ui->savePath->setSelectedPath({});
+            m_ui->downloadPath->setSelectedPath({});
             m_ui->checkUseDownloadPath->setCheckState(Qt::PartiallyChecked);
         }
     }

--- a/src/gui/torrentoptionsdialog.h
+++ b/src/gui/torrentoptionsdialog.h
@@ -32,6 +32,7 @@
 
 #include <QDialog>
 
+#include "base/path.h"
 #include "base/settingvalue.h"
 
 class QAbstractButton;
@@ -82,8 +83,8 @@ private:
     QAbstractButton *m_previousRadio = nullptr;
     struct
     {
-        QString savePath;
-        QString downloadPath;
+        Path savePath;
+        Path downloadPath;
         QString category;
         qreal ratio;
         int seedingTime;

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -322,8 +322,8 @@ TrackerFiltersList::TrackerFiltersList(QWidget *parent, TransferListWidget *tran
 
 TrackerFiltersList::~TrackerFiltersList()
 {
-    for (const QString &iconPath : asConst(m_iconPaths))
-        Utils::Fs::forceRemove(iconPath);
+    for (const Path &iconPath : asConst(m_iconPaths))
+        Utils::Fs::removeFile(iconPath);
 }
 
 void TrackerFiltersList::addItem(const QString &tracker, const BitTorrent::TorrentID &id)
@@ -534,14 +534,14 @@ void TrackerFiltersList::handleFavicoDownloadFinished(const Net::DownloadResult 
 
     if (!m_trackers.contains(host))
     {
-        Utils::Fs::forceRemove(result.filePath);
+        Utils::Fs::removeFile(result.filePath);
         return;
     }
 
     QListWidgetItem *trackerItem = item(rowFromTracker(host));
     if (!trackerItem) return;
 
-    QIcon icon(result.filePath);
+    const QIcon icon {result.filePath.data()};
     //Detect a non-decodable icon
     QList<QSize> sizes = icon.availableSizes();
     bool invalid = (sizes.isEmpty() || icon.pixmap(sizes.first()).isNull());
@@ -549,11 +549,11 @@ void TrackerFiltersList::handleFavicoDownloadFinished(const Net::DownloadResult 
     {
         if (result.url.endsWith(".ico", Qt::CaseInsensitive))
             downloadFavicon(result.url.left(result.url.size() - 4) + ".png");
-        Utils::Fs::forceRemove(result.filePath);
+        Utils::Fs::removeFile(result.filePath);
     }
     else
     {
-        trackerItem->setData(Qt::DecorationRole, QIcon(result.filePath));
+        trackerItem->setData(Qt::DecorationRole, QIcon(result.filePath.data()));
         m_iconPaths.append(result.filePath);
     }
 }

--- a/src/gui/transferlistfilterswidget.h
+++ b/src/gui/transferlistfilterswidget.h
@@ -34,6 +34,7 @@
 
 #include "base/bittorrent/infohash.h"
 #include "base/bittorrent/trackerentry.h"
+#include "base/path.h"
 
 class QCheckBox;
 class QResizeEvent;
@@ -133,7 +134,7 @@ private:
     QHash<QString, QSet<BitTorrent::TorrentID>> m_trackers;  // <tracker host, torrent IDs>
     QHash<BitTorrent::TorrentID, QSet<QString>> m_errors;  // <torrent ID, tracker hosts>
     QHash<BitTorrent::TorrentID, QSet<QString>> m_warnings;  // <torrent ID, tracker hosts>
-    QStringList m_iconPaths;
+    PathList m_iconPaths;
     int m_totalTorrents;
     bool m_downloadTrackerFavicon;
 };

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -392,7 +392,7 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
     case TR_TIME_ELAPSED:
         return timeElapsedString(torrent->activeTime(), torrent->finishedTime());
     case TR_SAVE_PATH:
-        return Utils::Fs::toNativePath(torrent->savePath());
+        return torrent->savePath().toString();
     case TR_COMPLETED:
         return unitString(torrent->completedSize());
     case TR_SEEN_COMPLETE_DATE:
@@ -461,7 +461,7 @@ QVariant TransferListModel::internalValue(const BitTorrent::Torrent *torrent, co
     case TR_TIME_ELAPSED:
         return !alt ? torrent->activeTime() : torrent->finishedTime();
     case TR_SAVE_PATH:
-        return Utils::Fs::toNativePath(torrent->savePath());
+        return torrent->savePath().toString();
     case TR_COMPLETED:
         return torrent->completedSize();
     case TR_RATIO_LIMIT:

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -34,6 +34,7 @@
 #include <QTreeView>
 
 #include "base/bittorrent/infohash.h"
+#include "base/path.h"
 
 class MainWindow;
 class TransferListModel;
@@ -97,7 +98,7 @@ public slots:
     void applyTagFilter(const QString &tag);
     void applyTrackerFilterAll();
     void applyTrackerFilter(const QSet<BitTorrent::TorrentID> &torrentIDs);
-    void previewFile(const QString &filePath);
+    void previewFile(const Path &filePath);
     void renameSelectedTorrent();
 
 signals:

--- a/src/gui/uithememanager.h
+++ b/src/gui/uithememanager.h
@@ -36,6 +36,8 @@
 #include <QObject>
 #include <QString>
 
+#include "base/pathfwd.h"
+
 class UIThemeSource
 {
 public:
@@ -43,7 +45,7 @@ public:
 
     virtual QByteArray readStyleSheet() = 0;
     virtual QByteArray readConfig() = 0;
-    virtual QString iconPath(const QString &iconId) const = 0;
+    virtual Path iconPath(const QString &iconId) const = 0;
 };
 
 class UIThemeManager : public QObject
@@ -56,7 +58,7 @@ public:
     static void freeInstance();
     static UIThemeManager *instance();
 
-    QString getIconPath(const QString &iconId) const;
+    Path getIconPath(const QString &iconId) const;
     QIcon getIcon(const QString &iconId, const QString &fallback = {}) const;
     QIcon getFlagIcon(const QString &countryIsoCode) const;
 
@@ -68,7 +70,7 @@ public:
 
 private:
     UIThemeManager(); // singleton class
-    QString getIconPathFromResources(const QString &iconId, const QString &fallback = {}) const;
+    Path getIconPathFromResources(const QString &iconId, const QString &fallback = {}) const;
     void loadColorsFromJSONConfig();
     void applyPalette() const;
     void applyStyleSheet() const;

--- a/src/gui/utils.h
+++ b/src/gui/utils.h
@@ -30,34 +30,33 @@
 
 #include <QSize>
 
+#include "base/pathfwd.h"
+
 class QIcon;
 class QPixmap;
 class QPoint;
 class QWidget;
 
-namespace Utils
+namespace Utils::Gui
 {
-    namespace Gui
+    void resize(QWidget *widget, const QSize &newSize = {});
+    qreal screenScalingFactor(const QWidget *widget);
+
+    template <typename T>
+    T scaledSize(const QWidget *widget, const T &size)
     {
-        void resize(QWidget *widget, const QSize &newSize = {});
-        qreal screenScalingFactor(const QWidget *widget);
-
-        template <typename T>
-        T scaledSize(const QWidget *widget, const T &size)
-        {
-            return (size * screenScalingFactor(widget));
-        }
-
-        QPixmap scaledPixmap(const QIcon &icon, const QWidget *widget, int height);
-        QPixmap scaledPixmap(const QString &path, const QWidget *widget, int height = 0);
-        QPixmap scaledPixmapSvg(const QString &path, const QWidget *widget, int baseHeight);
-        QSize smallIconSize(const QWidget *widget = nullptr);
-        QSize mediumIconSize(const QWidget *widget = nullptr);
-        QSize largeIconSize(const QWidget *widget = nullptr);
-
-        QPoint screenCenter(const QWidget *w);
-
-        void openPath(const QString &absolutePath);
-        void openFolderSelect(const QString &absolutePath);
+        return (size * screenScalingFactor(widget));
     }
+
+    QPixmap scaledPixmap(const QIcon &icon, const QWidget *widget, int height);
+    QPixmap scaledPixmap(const Path &path, const QWidget *widget, int height = 0);
+    QPixmap scaledPixmapSvg(const Path &path, const QWidget *widget, int baseHeight);
+    QSize smallIconSize(const QWidget *widget = nullptr);
+    QSize mediumIconSize(const QWidget *widget = nullptr);
+    QSize largeIconSize(const QWidget *widget = nullptr);
+
+    QPoint screenCenter(const QWidget *w);
+
+    void openPath(const Path &path);
+    void openFolderSelect(const Path &path);
 }

--- a/src/gui/watchedfolderoptionsdialog.cpp
+++ b/src/gui/watchedfolderoptionsdialog.cpp
@@ -138,13 +138,13 @@ void WatchedFolderOptionsDialog::onCategoryChanged(const int index)
         const auto *btSession = BitTorrent::Session::instance();
         const QString categoryName = m_ui->categoryComboBox->currentText();
 
-        const QString savePath = btSession->categorySavePath(categoryName);
-        m_ui->savePath->setSelectedPath(Utils::Fs::toNativePath(savePath));
+        const Path savePath = btSession->categorySavePath(categoryName);
+        m_ui->savePath->setSelectedPath(savePath);
 
-        const QString finishedSavePath = btSession->categoryDownloadPath(categoryName);
-        m_ui->downloadPath->setSelectedPath(Utils::Fs::toNativePath(finishedSavePath));
+        const Path downloadPath = btSession->categoryDownloadPath(categoryName);
+        m_ui->downloadPath->setSelectedPath(downloadPath);
 
-        m_ui->groupBoxDownloadPath->setChecked(!finishedSavePath.isEmpty());
+        m_ui->groupBoxDownloadPath->setChecked(!downloadPath.isEmpty());
     }
 }
 
@@ -152,11 +152,11 @@ void WatchedFolderOptionsDialog::populateSavePaths()
 {
     const auto *btSession = BitTorrent::Session::instance();
 
-    const QString defaultSavePath {btSession->savePath()};
+    const Path defaultSavePath {btSession->savePath()};
     m_ui->savePath->setSelectedPath(!m_savePath.isEmpty() ? m_savePath : defaultSavePath);
 
-    const QString defaultFinishedSavePath {btSession->downloadPath()};
-    m_ui->downloadPath->setSelectedPath(!m_downloadPath.isEmpty() ? m_downloadPath : defaultFinishedSavePath);
+    const Path defaultDownloadPath {btSession->downloadPath()};
+    m_ui->downloadPath->setSelectedPath(!m_downloadPath.isEmpty() ? m_downloadPath : defaultDownloadPath);
 
     m_ui->groupBoxDownloadPath->setChecked(m_useDownloadPath);
 }
@@ -178,15 +178,15 @@ void WatchedFolderOptionsDialog::onTMMChanged(const int index)
 
         m_ui->savePath->blockSignals(true);
         m_savePath = m_ui->savePath->selectedPath();
-        const QString savePath = btSession->categorySavePath(m_ui->categoryComboBox->currentText());
+        const Path savePath = btSession->categorySavePath(m_ui->categoryComboBox->currentText());
         m_ui->savePath->setSelectedPath(savePath);
 
         m_ui->downloadPath->blockSignals(true);
         m_downloadPath = m_ui->downloadPath->selectedPath();
-        const QString finishedSavePath = btSession->categoryDownloadPath(m_ui->categoryComboBox->currentText());
-        m_ui->downloadPath->setSelectedPath(finishedSavePath);
+        const Path downloadPath = btSession->categoryDownloadPath(m_ui->categoryComboBox->currentText());
+        m_ui->downloadPath->setSelectedPath(downloadPath);
 
         m_useDownloadPath = m_ui->groupBoxDownloadPath->isChecked();
-        m_ui->groupBoxDownloadPath->setChecked(!finishedSavePath.isEmpty());
+        m_ui->groupBoxDownloadPath->setChecked(!downloadPath.isEmpty());
     }
 }

--- a/src/gui/watchedfolderoptionsdialog.h
+++ b/src/gui/watchedfolderoptionsdialog.h
@@ -30,6 +30,7 @@
 
 #include <QDialog>
 
+#include "base/path.h"
 #include "base/settingvalue.h"
 #include "base/torrentfileswatcher.h"
 
@@ -57,8 +58,8 @@ private:
     void onCategoryChanged(int index);
 
     Ui::WatchedFolderOptionsDialog *m_ui;
-    QString m_savePath;
-    QString m_downloadPath;
+    Path m_savePath;
+    Path m_downloadPath;
     bool m_useDownloadPath = false;
     SettingValue<QSize> m_storeDialogSize;
 };

--- a/src/gui/watchedfoldersmodel.h
+++ b/src/gui/watchedfoldersmodel.h
@@ -34,6 +34,7 @@
 #include <QSet>
 #include <QStringList>
 
+#include "base/path.h"
 #include "base/torrentfileswatcher.h"
 
 class WatchedFoldersModel final : public QAbstractListModel
@@ -50,7 +51,7 @@ public:
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
     bool removeRows(int row, int count, const QModelIndex &parent = QModelIndex()) override;
 
-    void addFolder(const QString &path, const TorrentFilesWatcher::WatchedFolderOptions &options);
+    void addFolder(const Path &path, const TorrentFilesWatcher::WatchedFolderOptions &options);
 
     TorrentFilesWatcher::WatchedFolderOptions folderOptions(int row) const;
     void setFolderOptions(int row, const TorrentFilesWatcher::WatchedFolderOptions &options);
@@ -58,11 +59,11 @@ public:
     void apply();
 
 private:
-    void onFolderSet(const QString &path, const TorrentFilesWatcher::WatchedFolderOptions &options);
-    void onFolderRemoved(const QString &path);
+    void onFolderSet(const Path &path, const TorrentFilesWatcher::WatchedFolderOptions &options);
+    void onFolderRemoved(const Path &path);
 
     TorrentFilesWatcher *m_fsWatcher;
-    QStringList m_watchedFolders;
-    QHash<QString, TorrentFilesWatcher::WatchedFolderOptions> m_watchedFoldersOptions;
-    QSet<QString> m_deletedFolders;
+    PathList m_watchedFolders;
+    QHash<Path, TorrentFilesWatcher::WatchedFolderOptions> m_watchedFoldersOptions;
+    QSet<Path> m_deletedFolders;
 };

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -34,6 +34,7 @@
 #include "base/bittorrent/infohash.h"
 #include "base/bittorrent/torrent.h"
 #include "base/bittorrent/trackerentry.h"
+#include "base/path.h"
 #include "base/tagset.h"
 #include "base/utils/fs.h"
 
@@ -130,9 +131,9 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         {KEY_TORRENT_TAGS, torrent.tags().join(QLatin1String(", "))},
         {KEY_TORRENT_SUPER_SEEDING, torrent.superSeeding()},
         {KEY_TORRENT_FORCE_START, torrent.isForced()},
-        {KEY_TORRENT_SAVE_PATH, Utils::Fs::toNativePath(torrent.savePath())},
-        {KEY_TORRENT_DOWNLOAD_PATH, Utils::Fs::toNativePath(torrent.downloadPath())},
-        {KEY_TORRENT_CONTENT_PATH, Utils::Fs::toNativePath(torrent.contentPath())},
+        {KEY_TORRENT_SAVE_PATH, torrent.savePath().toString()},
+        {KEY_TORRENT_DOWNLOAD_PATH, torrent.downloadPath().toString()},
+        {KEY_TORRENT_CONTENT_PATH, torrent.contentPath().toString()},
         {KEY_TORRENT_ADDED_ON, torrent.addedTime().toSecsSinceEpoch()},
         {KEY_TORRENT_COMPLETION_ON, torrent.completedTime().toSecsSinceEpoch()},
         {KEY_TORRENT_TRACKER, torrent.currentTracker()},

--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -579,7 +579,14 @@ void SyncController::torrentPeersAction()
         };
 
         if (torrent->hasMetadata())
-            peer.insert(KEY_PEER_FILES, torrent->info().filesForPiece(pi.downloadingPieceIndex()).join('\n'));
+        {
+            const PathList filePaths = torrent->info().filesForPiece(pi.downloadingPieceIndex());
+            QStringList filesForPiece;
+            filesForPiece.reserve(filePaths.size());
+            for (const Path &filePath : filePaths)
+                filesForPiece.append(filePath.toString());
+            peer.insert(KEY_PEER_FILES, filesForPiece.join(QLatin1Char('\n')));
+        }
 
         if (resolvePeerCountries)
         {

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -151,8 +151,8 @@ void WebApplication::sendWebUIFile()
     {
         if (request().path.startsWith(PATH_PREFIX_ICONS))
         {
-            const QString imageFilename {request().path.mid(PATH_PREFIX_ICONS.size())};
-            sendFile(QLatin1String(":/icons/") + imageFilename);
+            const Path imageFilename {request().path.mid(PATH_PREFIX_ICONS.size())};
+            sendFile(Path(":/icons") / imageFilename);
             return;
         }
     }
@@ -164,20 +164,13 @@ void WebApplication::sendWebUIFile()
                 : QLatin1String("/index.html"))
     };
 
-    QString localPath
-    {
-        m_rootFolder
-                + (session() ? PRIVATE_FOLDER : PUBLIC_FOLDER)
-                + path
-    };
-
-    QFileInfo fileInfo {localPath};
-
-    if (!fileInfo.exists() && session())
+    Path localPath = m_rootFolder
+                / Path(session() ? PRIVATE_FOLDER : PUBLIC_FOLDER)
+                / Path(path);
+    if (!localPath.exists() && session())
     {
         // try to send public file if there is no private one
-        localPath = m_rootFolder + PUBLIC_FOLDER + path;
-        fileInfo.setFile(localPath);
+        localPath = m_rootFolder / Path(PUBLIC_FOLDER) / Path(path);
     }
 
     if (m_isAltUIUsed)
@@ -191,7 +184,8 @@ void WebApplication::sendWebUIFile()
         }
 #endif
 
-        while (fileInfo.filePath() != m_rootFolder)
+        QFileInfo fileInfo {localPath.data()};
+        while (Path(fileInfo.filePath()) != m_rootFolder)
         {
             if (fileInfo.isSymLink())
                 throw InternalServerErrorHTTPError(tr("Symlinks inside alternative UI folder are forbidden."));
@@ -320,8 +314,7 @@ void WebApplication::configure()
     const auto *pref = Preferences::instance();
 
     const bool isAltUIUsed = pref->isAltWebUiEnabled();
-    const QString rootFolder = Utils::Fs::expandPathAbs(
-                !isAltUIUsed ? WWW_FOLDER : pref->getWebUiRootFolder());
+    const Path rootFolder = (!isAltUIUsed ? Path(WWW_FOLDER) : pref->getWebUiRootFolder());
     if ((isAltUIUsed != m_isAltUIUsed) || (rootFolder != m_rootFolder))
     {
         m_isAltUIUsed = isAltUIUsed;
@@ -330,7 +323,7 @@ void WebApplication::configure()
         if (!m_isAltUIUsed)
             LogMsg(tr("Using built-in Web UI."));
         else
-            LogMsg(tr("Using custom Web UI. Location: \"%1\".").arg(m_rootFolder));
+            LogMsg(tr("Using custom Web UI. Location: \"%1\".").arg(m_rootFolder.toString()));
     }
 
     const QString newLocale = pref->getLocale();
@@ -339,7 +332,7 @@ void WebApplication::configure()
         m_currentLocale = newLocale;
         m_translatedFiles.clear();
 
-        m_translationFileLoaded = m_translator.load(m_rootFolder + QLatin1String("/translations/webui_") + newLocale);
+        m_translationFileLoaded = m_translator.load((m_rootFolder / Path("translations/webui_") + newLocale).data());
         if (m_translationFileLoaded)
         {
             LogMsg(tr("Web UI translation for selected locale (%1) has been successfully loaded.")
@@ -437,9 +430,9 @@ void WebApplication::declarePublicAPI(const QString &apiPath)
     m_publicAPIs << apiPath;
 }
 
-void WebApplication::sendFile(const QString &path)
+void WebApplication::sendFile(const Path &path)
 {
-    const QDateTime lastModified {QFileInfo(path).lastModified()};
+    const QDateTime lastModified = Utils::Fs::lastModified(path);
 
     // find translated file in cache
     const auto it = m_translatedFiles.constFind(path);
@@ -450,16 +443,16 @@ void WebApplication::sendFile(const QString &path)
         return;
     }
 
-    QFile file {path};
+    QFile file {path.data()};
     if (!file.open(QIODevice::ReadOnly))
     {
-        qDebug("File %s was not found!", qUtf8Printable(path));
+        qDebug("File %s was not found!", qUtf8Printable(path.toString()));
         throw NotFoundHTTPError();
     }
 
     if (file.size() > MAX_ALLOWED_FILESIZE)
     {
-        qWarning("%s: exceeded the maximum allowed file size!", qUtf8Printable(path));
+        qWarning("%s: exceeded the maximum allowed file size!", qUtf8Printable(path.toString()));
         throw InternalServerErrorHTTPError(tr("Exceeded the maximum allowed file size (%1)!")
                                            .arg(Utils::Misc::friendlyUnit(MAX_ALLOWED_FILESIZE)));
     }
@@ -467,8 +460,8 @@ void WebApplication::sendFile(const QString &path)
     QByteArray data {file.readAll()};
     file.close();
 
-    const QMimeType mimeType {QMimeDatabase().mimeTypeForFileNameAndData(path, data)};
-    const bool isTranslatable {mimeType.inherits(QLatin1String("text/plain"))};
+    const QMimeType mimeType = QMimeDatabase().mimeTypeForFileNameAndData(path.data(), data);
+    const bool isTranslatable = mimeType.inherits(QLatin1String("text/plain"));
 
     // Translate the file
     if (isTranslatable)

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -40,6 +40,7 @@
 #include "base/http/irequesthandler.h"
 #include "base/http/responsebuilder.h"
 #include "base/http/types.h"
+#include "base/path.h"
 #include "base/utils/net.h"
 #include "base/utils/version.h"
 
@@ -100,7 +101,7 @@ private:
     void registerAPIController(const QString &scope, APIController *controller);
     void declarePublicAPI(const QString &apiPath);
 
-    void sendFile(const QString &path);
+    void sendFile(const Path &path);
     void sendWebUIFile();
 
     void translateDocument(QString &data) const;
@@ -131,7 +132,7 @@ private:
     QHash<QString, APIController *> m_apiControllers;
     QSet<QString> m_publicAPIs;
     bool m_isAltUIUsed = false;
-    QString m_rootFolder;
+    Path m_rootFolder;
 
     struct TranslatedFile
     {
@@ -139,7 +140,7 @@ private:
         QString mimeType;
         QDateTime lastModified;
     };
-    QHash<QString, TranslatedFile> m_translatedFiles;
+    QHash<Path, TranslatedFile> m_translatedFiles;
     QString m_currentLocale;
     QTranslator m_translator;
     bool m_translationFileLoaded = false;

--- a/src/webui/webui.cpp
+++ b/src/webui/webui.cpp
@@ -34,6 +34,7 @@
 #include "base/logger.h"
 #include "base/net/dnsupdater.h"
 #include "base/net/portforwarder.h"
+#include "base/path.h"
 #include "base/preferences.h"
 #include "base/utils/net.h"
 #include "webapplication.h"
@@ -88,9 +89,9 @@ void WebUI::configure()
 
         if (pref->isWebUiHttpsEnabled())
         {
-            const auto readData = [](const QString &path) -> QByteArray
+            const auto readData = [](const Path &path) -> QByteArray
             {
-                QFile file(path);
+                QFile file {path.data()};
                 if (!file.open(QIODevice::ReadOnly))
                     return {};
                 return file.read(Utils::Net::MAX_SSL_FILE_SIZE);


### PR DESCRIPTION
This incapsulates most of usual filesystem path handling logic into Path class.
It does not pretend to be general purpose solution. On the contrary, it embodies exactly those practices that are inherent in the qBittorrent (e.g. it deals with cleaned/normalized paths).
`Utils::Fs` functions are revamped to accept parameters of `Path` type.