### PR TITLE
Correct the order of the migrated settings' mappings

### DIFF
--- a/src/app/upgrade.cpp
+++ b/src/app/upgrade.cpp
@@ -322,7 +322,7 @@ namespace
             {
                 const auto value = settingsStorage->loadValue<QVariant>(mapping.oldKey);
                 settingsStorage->storeValue(mapping.newKey, value);
-                settingsStorage->removeValue(mapping.oldKey);
+                // TODO: Remove oldKey after ~v4.4.3 and bump migration version
             }
         }
     }

--- a/src/app/upgrade.cpp
+++ b/src/app/upgrade.cpp
@@ -233,8 +233,8 @@ namespace
     {
         struct KeyMapping
         {
-            QString oldKey;
             QString newKey;
+            QString oldKey;
         };
 
         const KeyMapping mappings[] =


### PR DESCRIPTION
A rather silly bug.


**People who have run the recent nightlies:** Delete from your config the `Meta/MigrationVersion` you the migration code will run again and correctly after this PR is merged.

Bug introduced with 39f054eef628b199c5c3d2d37fa62dd98a4a48f2
