### PR TITLE
Remove TODO and NEWS files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 core.eol=lf
 * text eol=lf
-*.zip binary
-*.png binary
-*.ico binary
-*.qm binary
 *.icns binary
+*.ico binary
+*.png binary
+*.qm binary
+*.zip binary

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,0 @@
-See Changelog
-
-*******************************************
-Christophe dumez - chris@qbittorrent.org

--- a/TODO
+++ b/TODO
@@ -1,1 +1,0 @@
-See https://blueprints.launchpad.net/qbittorrent/

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_PROG_CXX
 AC_PROG_SED
 AC_LANG(C++)
 AC_CANONICAL_HOST
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([foreign])
 
 # use compiler from env variables if available
 QBT_CC="$CC"


### PR DESCRIPTION
The contents are outdated and the files are not in use.
`configure.ac` is adjusted to suppress automake errors.
https://www.gnu.org/software/automake/manual/html_node/Strictness.html#index-Strictness_002c-foreign