### PR TITLE
Move new line character out of translation string

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -650,8 +650,8 @@ int Application::exec(const QStringList &params)
     const auto scheme = QString::fromLatin1(pref->isWebUiHttpsEnabled() ? "https" : "http");
     const auto url = QString::fromLatin1("%1://localhost:%2\n").arg(scheme, QString::number(pref->getWebUiPort()));
     const QString mesg = QString::fromLatin1("\n******** %1 ********\n").arg(tr("Information"))
-        + tr("To control qBittorrent, access the WebUI at: %1\n").arg(url);
-    printf("%s", qUtf8Printable(mesg));
+        + tr("To control qBittorrent, access the WebUI at: %1").arg(url);
+    printf("%s\n", qUtf8Printable(mesg));
 
     if (pref->getWebUIPassword() == "ARQ77eY1NUZaQsuDHbIMCA==:0WMRkYTUWVT9wVvdDtHAjU9b3b7uB8NR1Gur2hmQCvCDpm39Q+PsJRJPaCU51dEiz+dTzh8qbPsL8WkFljQYFQ==")
     {


### PR DESCRIPTION
This will resolve the recent "File health" error: https://github.com/qbittorrent/qBittorrent/runs/4733244476?check_suite_focus=true (after resync with Transifex)