### PR TITLE
WebAPI: fix wrong key used for categories

### DIFF
--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -503,6 +503,8 @@ void SyncController::maindataAction()
     {
         const BitTorrent::CategoryOptions categoryOptions = session->categoryOptions(categoryName);
         QJsonObject category = categoryOptions.toJSON();
+        // adjust it to be compatible with exisitng WebAPI
+        category[QLatin1String("savePath")] = category.take(QLatin1String("save_path"));
         category.insert(QLatin1String("name"), categoryName);
         categories[categoryName] = category.toVariantMap();
     }

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -1285,6 +1285,8 @@ void TorrentsController::categoriesAction()
     {
         const BitTorrent::CategoryOptions categoryOptions = session->categoryOptions(categoryName);
         QJsonObject category = categoryOptions.toJSON();
+        // adjust it to be compatible with exisitng WebAPI
+        category[QLatin1String("savePath")] = category.take(QLatin1String("save_path"));
         category.insert(QLatin1String("name"), categoryName);
         categories[categoryName] = category;
     }

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -43,7 +43,7 @@
 #include "base/utils/net.h"
 #include "base/utils/version.h"
 
-inline const Utils::Version<int, 3, 2> API_VERSION {2, 8, 4};
+inline const Utils::Version<int, 3, 2> API_VERSION {2, 8, 5};
 
 class APIController;
 class WebApplication;


### PR DESCRIPTION
Regression from 1c0f8b4289b8d298041fe195cdc24f793dce4df5.
Closes #15969.

