### PR TITLE
Mark as single window app in .desktop file

### DIFF
--- a/dist/unix/org.qbittorrent.qBittorrent.desktop
+++ b/dist/unix/org.qbittorrent.qBittorrent.desktop
@@ -11,6 +11,7 @@ Type=Application
 StartupNotify=false
 StartupWMClass=qbittorrent
 Keywords=bittorrent;torrent;magnet;download;p2p;
+SingleMainWindow=true
 
 # Translations
 


### PR DESCRIPTION
qBittorrent is a single-window application.

By marking it as such desktop environments know to not offer to open
a new window for it.

This is a new standard key intruduced in
https://gitlab.freedesktop.org/xdg/xdg-specs/-/commit/3ea3bc26e24f252eb96f4bfdd525cf4f314330c4