### PR TITLE
Correctly track the root folder name change

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -2148,24 +2148,24 @@ bool Session::addTorrent_impl(const std::variant<MagnetUri, TorrentInfo> &source
     {
         const TorrentInfo &torrentInfo = std::get<TorrentInfo>(source);
 
-        // if torrent name wasn't explicitly set we handle the case of
-        // initial renaming of torrent content and rename torrent accordingly
-        if (loadTorrentParams.name.isEmpty())
-        {
-            QString contentName = torrentInfo.rootFolder();
-            if (contentName.isEmpty() && (torrentInfo.filesCount() == 1))
-                contentName = Utils::Fs::fileName(torrentInfo.filePath(0));
-
-            if (!contentName.isEmpty() && (contentName != torrentInfo.name()))
-                loadTorrentParams.name = contentName;
-        }
-
         Q_ASSERT(addTorrentParams.filePaths.isEmpty() || (addTorrentParams.filePaths.size() == torrentInfo.filesCount()));
 
         const TorrentContentLayout contentLayout = ((loadTorrentParams.contentLayout == TorrentContentLayout::Original)
                                                     ? detectContentLayout(torrentInfo.filePaths()) : loadTorrentParams.contentLayout);
         QStringList filePaths = (!addTorrentParams.filePaths.isEmpty() ? addTorrentParams.filePaths : torrentInfo.filePaths());
         applyContentLayout(filePaths, contentLayout, Utils::Fs::findRootFolder(torrentInfo.filePaths()));
+
+        // if torrent name wasn't explicitly set we handle the case of
+        // initial renaming of torrent content and rename torrent accordingly
+        if (loadTorrentParams.name.isEmpty())
+        {
+            QString contentName = Utils::Fs::findRootFolder(filePaths);
+            if (contentName.isEmpty() && (filePaths.size() == 1))
+                contentName = Utils::Fs::fileName(filePaths.at(0));
+
+            if (!contentName.isEmpty() && (contentName != torrentInfo.name()))
+                loadTorrentParams.name = contentName;
+        }
 
         if (!loadTorrentParams.hasSeedStatus)
         {

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -443,7 +443,7 @@ QString TorrentImpl::rootPath() const
     if (!hasMetadata())
         return {};
 
-    const QString relativeRootPath = m_torrentInfo.rootFolder();
+    const QString relativeRootPath = Utils::Fs::findRootFolder(filePaths());
     if (relativeRootPath.isEmpty())
         return {};
 

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -409,19 +409,6 @@ int TorrentInfo::fileIndex(const QString &fileName) const
     return -1;
 }
 
-QString TorrentInfo::rootFolder() const
-{
-    if (!isValid())
-        return {};
-
-    return Utils::Fs::findRootFolder(filePaths());
-}
-
-bool TorrentInfo::hasRootFolder() const
-{
-    return !rootFolder().isEmpty();
-}
-
 TorrentContentLayout TorrentInfo::contentLayout() const
 {
     if (!isValid())

--- a/src/base/bittorrent/torrentinfo.h
+++ b/src/base/bittorrent/torrentinfo.h
@@ -92,9 +92,6 @@ namespace BitTorrent
         PieceRange filePieces(const QString &file) const;
         PieceRange filePieces(int fileIndex) const;
 
-        QString rootFolder() const;
-        bool hasRootFolder() const;
-
         std::shared_ptr<lt::torrent_info> nativeInfo() const;
         QVector<lt::file_index_t> nativeIndexes() const;
 


### PR DESCRIPTION
We shouldn't use original file names for this to do.

Closes  #15962.