### PR TITLE
Keep "torrent info" alive while generating .torrent file

### DIFF
--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -140,7 +140,7 @@ nonstd::expected<void, QString> TorrentInfo::saveToFile(const QString &path) con
 
     try
     {
-        const auto torrentCreator = lt::create_torrent(*nativeInfo());
+        const auto torrentCreator = lt::create_torrent(*m_nativeInfo);
         const lt::entry torrentEntry = torrentCreator.generate();
         const nonstd::expected<void, QString> result = Utils::IO::saveToFile(path, torrentEntry);
         if (!result)


### PR DESCRIPTION
Closes #15959.
