### PR TITLE
GHA CI: build libtorrent with `/guard:cf` flag

### DIFF
--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -86,6 +86,7 @@ jobs:
             -B build `
             -G "Ninja" `
             -DCMAKE_BUILD_TYPE=RelWithDebInfo `
+            -DCMAKE_CXX_FLAGS=/guard:cf `
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON `
             -DCMAKE_INSTALL_PREFIX="${{ env.libtorrent_path }}" `
             -DCMAKE_TOOLCHAIN_FILE="${{ env.RUNVCPKG_VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake" `


### PR DESCRIPTION
qbt cmake script enables that flag already, so it make sense to build dependencies with it too.