### PR TITLE
Correctly concatenate paths

### DIFF
--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -1892,9 +1892,10 @@ void TorrentImpl::handleFileRenamedAlert(const lt::file_renamed_alert *p)
         ++pathIdx;
     }
 
+    QDir storageDir {actualStorageLocation()};
     for (int i = (oldPathParts.size() - 1); i >= pathIdx; --i)
     {
-        QDir().rmdir(savePath() + Utils::String::join(oldPathParts, QString::fromLatin1("/")));
+        storageDir.rmdir(Utils::String::join(oldPathParts, QString::fromLatin1("/")));
         oldPathParts.removeLast();
     }
 


### PR DESCRIPTION
Closes #16058.

Note: this PR is for v4.4.x branch only. In v4.5 all similar problems should gone when #15915 is merged.