### PR TITLE
Revise error message

### DIFF
--- a/conf.pri.windows
+++ b/conf.pri.windows
@@ -37,8 +37,6 @@ DEFINES += BOOST_ALL_NO_LIB
 # Use one of the following options
 DEFINES += BOOST_SYSTEM_STATIC_LINK
 #DEFINES += BOOST_SYSTEM_DYN_LINK
-# Enable if encountered build error with boost version <= 1.59
-#DEFINES += BOOST_NO_CXX11_RVALUE_REFERENCES
 
 # Enable if libtorrent was built with this flag defined
 #DEFINES += TORRENT_NO_DEPRECATE

--- a/conf.pri.windows
+++ b/conf.pri.windows
@@ -37,6 +37,8 @@ DEFINES += BOOST_ALL_NO_LIB
 # Use one of the following options
 DEFINES += BOOST_SYSTEM_STATIC_LINK
 #DEFINES += BOOST_SYSTEM_DYN_LINK
+# Enable it if compiling with libtorrent 3.x
+#DEFINES += BOOST_SYSTEM_USE_UTF8
 
 # Enable if libtorrent was built with this flag defined
 #DEFINES += TORRENT_NO_DEPRECATE

--- a/configure
+++ b/configure
@@ -6020,25 +6020,6 @@ LDFLAGS="$BOOST_LDFLAGS $LDFLAGS"
 # taken from ax_boost_base.m4
 
 
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <boost/version.hpp>
-int
-main (void)
-{
-(void) ((void)sizeof(char[1 - 2*!!((BOOST_VERSION) < (106000))]));
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_compile "$LINENO"
-then :
-
-else $as_nop
-  QBT_ADD_DEFINES="$QBT_ADD_DEFINES BOOST_NO_CXX11_RVALUE_REFERENCES"
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-
 
 pkg_failed=no
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for libtorrent-rasterbar >= 2.0.4" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -187,9 +187,6 @@ m4_define([DETECT_BOOST_VERSION_PROGRAM],
     [AC_LANG_PROGRAM([[#include <boost/version.hpp>]],
                      [[(void) ((void)sizeof(char[1 - 2*!!((BOOST_VERSION) < ($1))]));]])])
 
-AC_COMPILE_IFELSE([DETECT_BOOST_VERSION_PROGRAM(106000)], [],
-    [QBT_ADD_DEFINES="$QBT_ADD_DEFINES BOOST_NO_CXX11_RVALUE_REFERENCES"])
-
 PKG_CHECK_MODULES(libtorrent,
                   [libtorrent-rasterbar >= 2.0.4],
                   [CXXFLAGS="$libtorrent_CFLAGS $CXXFLAGS" LIBS="$libtorrent_LIBS $LIBS" QBT_ADD_DEFINES="$QBT_ADD_DEFINES QBT_USES_LIBTORRENT2"],

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -1028,10 +1028,9 @@ QString TorrentImpl::error() const
     if (m_nativeStatus.flags & lt::torrent_flags::upload_mode)
     {
         const QString writeErrorStr = tr("Couldn't write to file.");
-        const QString uploadModeStr = tr("Torrent is currently in \"upload only\" mode.");
-        const QString errorMessage = QString::fromLocal8Bit(m_lastFileError.error.message().c_str());
-
-        return writeErrorStr + QLatin1Char(' ') + errorMessage + QLatin1String(". ") + uploadModeStr;
+        const QString uploadModeStr = tr("Torrent is now in \"upload only\" mode.");
+        const QString errorMessage = tr("Reason:") + QLatin1Char(' ') + QString::fromLocal8Bit(m_lastFileError.error.message().c_str());
+        return QString::fromLatin1("%1 %2 %3").arg(writeErrorStr, errorMessage, uploadModeStr);
     }
 
     return {};


### PR DESCRIPTION
* Revise error message
  Remove the period mark at the end of error message since `errc.message()` already contains one.
* Remove outdated build configuration
* Add comment for new libtorrent build flag
  Upstream change: [arvidn/libtorrent@66def89](https://github.com/arvidn/libtorrent/commit/66def8908909232b15f02a97c9671785bd019736)

Will back port "Revise error message" commit to v4.4.x.