### PR TITLE
Manually specify UIC headers in CMake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,11 +63,10 @@ else()
     endif()
 endif()
 
-# automatically call Qt moc, rcc and uic as needed for all targets by default
+# automatically call Qt moc and rcc as needed for all targets by default
 set(CMAKE_AUTORCC_OPTIONS --compress 9 --threshold 5)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
-set(CMAKE_AUTOUIC ON)
 
 # create interface-only target libraries with common compile options/definitions to link to
 include(MacroQbtCommonConfig)

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -110,10 +110,17 @@ if (STACKTRACE)
         target_sources(qbt_app PRIVATE stacktrace_win.h)
 
         if (GUI)
+            qt_wrap_ui(STACKTRACE_UI_HEADERS stacktracedialog.ui)
+
             target_sources(qbt_app PRIVATE
                 stacktracedialog.h
                 stacktracedialog.cpp
-                stacktracedialog.ui
+                ${STACKTRACE_UI_HEADERS}
+            )
+
+            # UI headers will be generated in ${CMAKE_CURRENT_BINARY_DIR}
+            target_include_directories(qbt_app PRIVATE
+                ${CMAKE_CURRENT_BINARY_DIR}
             )
         endif()
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,3 +1,37 @@
+
+# CMAKE_AUTO_UI causes unncessary rebuilds
+qt_wrap_ui(UI_HEADERS
+    aboutdialog.ui
+    addnewtorrentdialog.ui
+    autoexpandabledialog.ui
+    banlistoptionsdialog.ui
+    cookiesdialog.ui
+    deletionconfirmationdialog.ui
+    downloadfromurldialog.ui
+    executionlogwidget.ui
+    ipsubnetwhitelistoptionsdialog.ui
+    mainwindow.ui
+    optionsdialog.ui
+    previewselectdialog.ui
+    properties/peersadditiondialog.ui
+    properties/propertieswidget.ui
+    properties/trackersadditiondialog.ui
+    rss/automatedrssdownloader.ui
+    rss/rsswidget.ui
+    search/pluginselectdialog.ui
+    search/pluginsourcedialog.ui
+    search/searchjobwidget.ui
+    search/searchwidget.ui
+    shutdownconfirmdialog.ui
+    speedlimitdialog.ui
+    statsdialog.ui
+    torrentcategorydialog.ui
+    torrentcreatordialog.ui
+    torrentoptionsdialog.ui
+    trackerentriesdialog.ui
+    watchedfolderoptionsdialog.ui
+)
+
 add_library(qbt_gui STATIC
     # headers
     aboutdialog.h
@@ -161,39 +195,14 @@ add_library(qbt_gui STATIC
     watchedfolderoptionsdialog.cpp
     watchedfoldersmodel.cpp
 
-    # forms
-    aboutdialog.ui
-    addnewtorrentdialog.ui
-    autoexpandabledialog.ui
-    banlistoptionsdialog.ui
-    cookiesdialog.ui
-    deletionconfirmationdialog.ui
-    downloadfromurldialog.ui
-    executionlogwidget.ui
-    ipsubnetwhitelistoptionsdialog.ui
-    mainwindow.ui
-    optionsdialog.ui
-    previewselectdialog.ui
-    properties/peersadditiondialog.ui
-    properties/propertieswidget.ui
-    properties/trackersadditiondialog.ui
-    rss/automatedrssdownloader.ui
-    rss/rsswidget.ui
-    search/pluginselectdialog.ui
-    search/pluginsourcedialog.ui
-    search/searchjobwidget.ui
-    search/searchwidget.ui
-    shutdownconfirmdialog.ui
-    speedlimitdialog.ui
-    statsdialog.ui
-    torrentcategorydialog.ui
-    torrentcreatordialog.ui
-    torrentoptionsdialog.ui
-    trackerentriesdialog.ui
-    watchedfolderoptionsdialog.ui
+    # generated .ui headers
+    ${UI_HEADERS}
 )
 
 target_sources(qbt_gui INTERFACE about.qrc)
+
+# UI headers will be generated in ${CMAKE_CURRENT_BINARY_DIR}
+target_include_directories(qbt_gui PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 target_link_libraries(qbt_gui
     PRIVATE


### PR DESCRIPTION
fixes unnecessary recompilation when editing GUI files
cuts down recompilation times from the 20s to 4s for GUI lib (when only one file is changed, tested with "uithememanager.cpp")

