### PR TITLE
Don't start separate event loop for QFileDialog

### DIFF
--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -331,19 +331,35 @@ QVector<BitTorrent::Torrent *> TransferListWidget::getVisibleTorrents() const
 void TransferListWidget::setSelectedTorrentsLocation()
 {
     const QVector<BitTorrent::Torrent *> torrents = getSelectedTorrents();
-    if (torrents.isEmpty()) return;
+    if (torrents.isEmpty())
+        return;
 
     const QString oldLocation = torrents[0]->savePath();
-    const QString newLocation = QFileDialog::getExistingDirectory(this, tr("Choose save path"), oldLocation,
-                                            (QFileDialog::DontConfirmOverwrite | QFileDialog::ShowDirsOnly | QFileDialog::HideNameFilterDetails));
-    if (newLocation.isEmpty() || !QDir(newLocation).exists()) return;
 
-    // Actually move storage
-    for (BitTorrent::Torrent *const torrent : torrents)
+    auto fileDialog = new QFileDialog(this, tr("Choose save path"), oldLocation);
+    fileDialog->setAttribute(Qt::WA_DeleteOnClose);
+    fileDialog->setFileMode(QFileDialog::Directory);
+    fileDialog->setModal(true);
+    fileDialog->setOptions(QFileDialog::DontConfirmOverwrite | QFileDialog::ShowDirsOnly | QFileDialog::HideNameFilterDetails);
+    connect(fileDialog, &QDialog::accepted, this, [this, fileDialog]()
     {
-        torrent->setAutoTMMEnabled(false);
-        torrent->setSavePath(Utils::Fs::expandPathAbs(newLocation));
-    }
+        const QVector<BitTorrent::Torrent *> torrents = getSelectedTorrents();
+        if (torrents.isEmpty())
+            return;
+
+        const QString newLocation = fileDialog->selectedFiles().constFirst();
+        if (newLocation.isEmpty() || !QDir(newLocation).exists())
+            return;
+
+        // Actually move storage
+        for (BitTorrent::Torrent *const torrent : torrents)
+        {
+            torrent->setAutoTMMEnabled(false);
+            torrent->setSavePath(newLocation);
+        }
+    });
+
+    fileDialog->show();
 }
 
 void TransferListWidget::pauseAllTorrents()


### PR DESCRIPTION
It conflicts with QMenu on Qt6 that causes the crash.

Closes #15779.
