### PR TITLE
Improve Torrent content tree structure creation

### DIFF
--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -498,6 +498,7 @@ void TorrentContentModel::setupModelData(const BitTorrent::AbstractFileStorage &
     m_filesIndex.reserve(filesCount);
 
     TorrentContentModelFolder *currentParent;
+    QHash<TorrentContentModelFolder *, QHash<QString, TorrentContentModelFolder *>> folderMap;
     // Iterate over files
     for (int i = 0; i < filesCount; ++i)
     {
@@ -510,13 +511,14 @@ void TorrentContentModel::setupModelData(const BitTorrent::AbstractFileStorage &
 
         for (const QStringView pathPart : asConst(pathFolders))
         {
-            const QString folderPath = pathPart.toString();
-            TorrentContentModelFolder *newParent = currentParent->childFolderWithName(folderPath);
+            const QString folderName = pathPart.toString();
+            TorrentContentModelFolder *&newParent = folderMap[currentParent][folderName];
             if (!newParent)
             {
-                newParent = new TorrentContentModelFolder(folderPath, currentParent);
+                newParent = new TorrentContentModelFolder(folderName, currentParent);
                 currentParent->appendChild(newParent);
             }
+
             currentParent = newParent;
         }
         // Actually create the file

--- a/src/gui/torrentcontentmodelfolder.cpp
+++ b/src/gui/torrentcontentmodelfolder.cpp
@@ -81,17 +81,6 @@ TorrentContentModelItem *TorrentContentModelFolder::child(int row) const
 {
     return m_childItems.value(row, nullptr);
 }
-
-TorrentContentModelFolder *TorrentContentModelFolder::childFolderWithName(const QString &name) const
-{
-    for (TorrentContentModelItem *child : asConst(m_childItems))
-    {
-        if ((child->itemType() == FolderType) && (child->name() == name))
-            return static_cast<TorrentContentModelFolder *>(child);
-    }
-    return nullptr;
-}
-
 int TorrentContentModelFolder::childCount() const
 {
     return m_childItems.count();

--- a/src/gui/torrentcontentmodelfolder.h
+++ b/src/gui/torrentcontentmodelfolder.h
@@ -59,7 +59,6 @@ public:
     const QVector<TorrentContentModelItem*> &children() const;
     void appendChild(TorrentContentModelItem *item);
     TorrentContentModelItem *child(int row) const;
-    TorrentContentModelFolder *childFolderWithName(const QString &name) const;
     int childCount() const;
 
 private:


### PR DESCRIPTION
Use QHash to cache folder items to improve
TorrentContentModelFolder::childFolderWithName

