### PR TITLE
Restrict window dimensions to current window size

### DIFF
--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -97,11 +97,11 @@ const initializeWindows = function() {
     };
 
     loadWindowWidth = function(windowId, defaultValue) {
-        return LocalPreferences.get('window_' + windowId + '_width', defaultValue);
+        return Math.min(window.innerWidth, LocalPreferences.get('window_' + windowId + '_width', defaultValue));
     };
 
     loadWindowHeight = function(windowId, defaultValue) {
-        return LocalPreferences.get('window_' + windowId + '_height', defaultValue);
+        return Math.min(window.innerHeight, LocalPreferences.get('window_' + windowId + '_height', defaultValue));
     };
 
     function addClickEvent(el, fn) {


### PR DESCRIPTION
You can’t reach the edge to resize dialogs that are wider than the viewport. Ensure dialogs open to fit within the available viewport. Prevents issues that arise when switching between different displays of varying sizes (e.g. using the same web UI on a big desktop monitor and then later on a smaller laptop).
