### PR TITLE
Add confirmation for enabling Auto TMM from context menu

### DIFF
--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -847,6 +847,7 @@ void TransferListWidget::displayListMenu(const QPoint &)
 
     auto *listMenu = new QMenu(this);
     listMenu->setAttribute(Qt::WA_DeleteOnClose);
+    listMenu->setToolTipsVisible(true);
 
     // Create actions
 
@@ -897,6 +898,7 @@ void TransferListWidget::displayListMenu(const QPoint &)
     auto *actionFirstLastPiecePrio = new TriStateAction(tr("Download first and last pieces first"), listMenu);
     connect(actionFirstLastPiecePrio, &QAction::triggered, this, &TransferListWidget::setSelectedFirstLastPiecePrio);
     auto *actionAutoTMM = new TriStateAction(tr("Automatic Torrent Management"), listMenu);
+    actionAutoTMM->setToolTip(tr("Automatic mode means that various torrent properties (e.g. save path) will be decided by the associated category"));
     connect(actionAutoTMM, &QAction::triggered, this, &TransferListWidget::setSelectedAutoTMMEnabled);
     auto *actionEditTracker = new QAction(UIThemeManager::instance()->getIcon("edit-rename"), tr("Edit trackers..."), listMenu);
     connect(actionEditTracker, &QAction::triggered, this, &TransferListWidget::editTorrentTrackers);

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -690,8 +690,16 @@ void TransferListWidget::setSelectedFirstLastPiecePrio(const bool enabled) const
         torrent->setFirstLastPiecePriority(enabled);
 }
 
-void TransferListWidget::setSelectedAutoTMMEnabled(const bool enabled) const
+void TransferListWidget::setSelectedAutoTMMEnabled(const bool enabled)
 {
+    if (enabled)
+    {
+        const QMessageBox::StandardButton btn = QMessageBox::question(this, tr("Enable automatic torrent management")
+                , tr("Are you sure you want to enable Automatic Torrent Management for the selected torrent(s)? They may be relocated.")
+                , (QMessageBox::Yes | QMessageBox::No), QMessageBox::Yes);
+        if (btn != QMessageBox::Yes) return;
+    }
+
     for (BitTorrent::Torrent *const torrent : asConst(getSelectedTorrents()))
         torrent->setAutoTMMEnabled(enabled);
 }

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -111,7 +111,7 @@ private slots:
     void setSelectedTorrentsSuperSeeding(bool enabled) const;
     void setSelectedTorrentsSequentialDownload(bool enabled) const;
     void setSelectedFirstLastPiecePrio(bool enabled) const;
-    void setSelectedAutoTMMEnabled(bool enabled) const;
+    void setSelectedAutoTMMEnabled(bool enabled);
     void askNewCategoryForSelection();
     void saveSettings();
 


### PR DESCRIPTION
>Add tooltip to Automatic Torrent Management context menu action

It's "restore" actually (from #15452) but in the eyes of the users, this option never had a tooltip i.e. it never worked thanks to the stupid Qt default option `menu->setToolTipsVisible` being false. The same checkbox in Torrent options has the same tooltip so if you think it's too much, i'll drop that commit.

Closes #16046