### PR TITLE
Speed up piece relevance calculation

### DIFF
--- a/src/base/bittorrent/peerinfo.cpp
+++ b/src/base/bittorrent/peerinfo.cpp
@@ -229,25 +229,16 @@ QString PeerInfo::connectionType() const
 void PeerInfo::calcRelevance(const Torrent *torrent)
 {
     const QBitArray allPieces = torrent->pieces();
-    const QBitArray peerPieces = pieces();
-
-    int localMissing = 0;
-    int remoteHaves = 0;
-
-    for (int i = 0; i < allPieces.size(); ++i)
+    const int localMissing = allPieces.count(false);
+    if (localMissing <= 0)
     {
-        if (!allPieces[i])
-        {
-            ++localMissing;
-            if (peerPieces[i])
-                ++remoteHaves;
-        }
+        m_relevance = 0;
+        return;
     }
 
-    if (localMissing == 0)
-        m_relevance = 0.0;
-    else
-        m_relevance = static_cast<qreal>(remoteHaves) / localMissing;
+    const QBitArray peerPieces = pieces();
+    const int remoteHaves = (peerPieces & (~allPieces)).count(true);
+    m_relevance = static_cast<qreal>(remoteHaves) / localMissing;
 }
 
 qreal PeerInfo::relevance() const

--- a/src/base/bittorrent/peerinfo.cpp
+++ b/src/base/bittorrent/peerinfo.cpp
@@ -39,8 +39,8 @@ using namespace BitTorrent;
 
 PeerInfo::PeerInfo(const Torrent *torrent, const lt::peer_info &nativeInfo)
     : m_nativeInfo(nativeInfo)
+    , m_relevance(calcRelevance(torrent))
 {
-    calcRelevance(torrent);
     determineFlags();
 }
 
@@ -226,19 +226,16 @@ QString PeerInfo::connectionType() const
         : QLatin1String {"Web"};
 }
 
-void PeerInfo::calcRelevance(const Torrent *torrent)
+qreal PeerInfo::calcRelevance(const Torrent *torrent) const
 {
     const QBitArray allPieces = torrent->pieces();
     const int localMissing = allPieces.count(false);
     if (localMissing <= 0)
-    {
-        m_relevance = 0;
-        return;
-    }
+        return 0;
 
     const QBitArray peerPieces = pieces();
     const int remoteHaves = (peerPieces & (~allPieces)).count(true);
-    m_relevance = static_cast<qreal>(remoteHaves) / localMissing;
+    return static_cast<qreal>(remoteHaves) / localMissing;
 }
 
 qreal PeerInfo::relevance() const

--- a/src/base/bittorrent/peerinfo.h
+++ b/src/base/bittorrent/peerinfo.h
@@ -92,7 +92,7 @@ namespace BitTorrent
         int downloadingPieceIndex() const;
 
     private:
-        void calcRelevance(const Torrent *torrent);
+        qreal calcRelevance(const Torrent *torrent) const;
         void determineFlags();
 
         lt::peer_info m_nativeInfo = {};


### PR DESCRIPTION
For ~800 pieces, this roughly cuts the run time (of this function) in half.