### PR TITLE
Fix crash when shutting down and clicked on system tray icon

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1236,6 +1236,7 @@ void MainWindow::closeEvent(QCloseEvent *e)
 #ifndef Q_OS_MACOS
     if (m_systrayIcon)
     {
+        m_systrayIcon->disconnect();
         m_systrayIcon->setToolTip(tr("qBittorrent is shutting down..."));
         m_trayIconMenu->setEnabled(false);
     }


### PR DESCRIPTION
Closes #16324.
Will backport to v4.4.x.