### PR TITLE
Allow to use Category paths in "Manual" mode

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -232,6 +232,8 @@ namespace BitTorrent
         bool removeCategory(const QString &name);
         bool isSubcategoriesEnabled() const;
         void setSubcategoriesEnabled(bool value);
+        bool useCategoryPathsInManualMode() const;
+        void setUseCategoryPathsInManualMode(bool value);
 
         static bool isValidTag(const QString &tag);
         QSet<QString> tags() const;
@@ -740,8 +742,9 @@ namespace BitTorrent
         CachedSettingValue<int> m_maxRatioAction;
         CachedSettingValue<QString> m_savePath;
         CachedSettingValue<QString> m_downloadPath;
-        CachedSettingValue<bool> m_isSubcategoriesEnabled;
         CachedSettingValue<bool> m_isDownloadPathEnabled;
+        CachedSettingValue<bool> m_isSubcategoriesEnabled;
+        CachedSettingValue<bool> m_useCategoryPathsInManualMode;
         CachedSettingValue<bool> m_isAutoTMMDisabledByDefault;
         CachedSettingValue<bool> m_isDisableAutoTMMWhenCategoryChanged;
         CachedSettingValue<bool> m_isDisableAutoTMMWhenDefaultSavePathChanged;

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -402,7 +402,9 @@ void TorrentImpl::setSavePath(const QString &path)
 {
     Q_ASSERT(!isAutoTMMEnabled());
 
-    const QString resolvedPath = (QDir::isAbsolutePath(path) ? path : Utils::Fs::resolvePath(path, m_session->savePath()));
+    const QString basePath = m_session->useCategoryPathsInManualMode()
+            ? m_session->categorySavePath(category()) : m_session->savePath();
+    const QString resolvedPath = (QDir::isAbsolutePath(path) ? path : Utils::Fs::resolvePath(path, basePath));
     if (resolvedPath == savePath())
         return;
 
@@ -424,8 +426,9 @@ void TorrentImpl::setDownloadPath(const QString &path)
 {
     Q_ASSERT(!isAutoTMMEnabled());
 
-    const QString resolvedPath = ((path.isEmpty() || QDir::isAbsolutePath(path))
-                                  ? path : Utils::Fs::resolvePath(path, m_session->downloadPath()));
+    const QString basePath = m_session->useCategoryPathsInManualMode()
+            ? m_session->categoryDownloadPath(category()) : m_session->downloadPath();
+    const QString resolvedPath = ((path.isEmpty() || QDir::isAbsolutePath(path)) ? path : Utils::Fs::resolvePath(path, basePath));
     if (resolvedPath == m_downloadPath)
         return;
 

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -350,6 +350,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     // Downloads tab
     connect(m_ui->textSavePath, &FileSystemPathEdit::selectedPathChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->checkUseSubcategories, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->checkUseCategoryPaths, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->comboSavingMode, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->comboTorrentCategoryChanged, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->comboCategoryDefaultPathChanged, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
@@ -733,6 +734,7 @@ void OptionsDialog::saveOptions()
     // Downloads preferences
     session->setSavePath(Utils::Fs::expandPathAbs(m_ui->textSavePath->selectedPath()));
     session->setSubcategoriesEnabled(m_ui->checkUseSubcategories->isChecked());
+    session->setUseCategoryPathsInManualMode(m_ui->checkUseCategoryPaths->isChecked());
     session->setAutoTMMDisabledByDefault(m_ui->comboSavingMode->currentIndex() == 0);
     session->setDisableAutoTMMWhenCategoryChanged(m_ui->comboTorrentCategoryChanged->currentIndex() == 1);
     session->setDisableAutoTMMWhenCategorySavePathChanged(m_ui->comboCategoryChanged->currentIndex() == 1);
@@ -999,6 +1001,7 @@ void OptionsDialog::loadOptions()
 
     m_ui->textSavePath->setSelectedPath(session->savePath());
     m_ui->checkUseSubcategories->setChecked(session->isSubcategoriesEnabled());
+    m_ui->checkUseCategoryPaths->setChecked(session->useCategoryPathsInManualMode());
     m_ui->comboSavingMode->setCurrentIndex(!session->isAutoTMMDisabledByDefault());
     m_ui->comboTorrentCategoryChanged->setCurrentIndex(session->isDisableAutoTMMWhenCategoryChanged());
     m_ui->comboCategoryChanged->setCurrentIndex(session->isDisableAutoTMMWhenCategorySavePathChanged());

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -1104,6 +1104,16 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
                 </widget>
                </item>
                <item>
+                <widget class="QCheckBox" name="checkUseCategoryPaths">
+                 <property name="text">
+                  <string>Use Category paths in Manual Mode</string>
+                 </property>
+                 <property name="toolTip">
+                  <string>Resolve relative Save Path against appropriate Category path instead of Default one</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <layout class="QGridLayout" name="gridLayout_4">
                  <item row="0" column="0">
                   <widget class="QLabel" name="labelSavePath">

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -115,6 +115,7 @@ void AppController::preferencesAction()
     data["save_path"] = Utils::Fs::toNativePath(session->savePath());
     data["temp_path_enabled"] = session->isDownloadPathEnabled();
     data["temp_path"] = Utils::Fs::toNativePath(session->downloadPath());
+    data["use_category_paths_in_manual_mode"] = session->useCategoryPathsInManualMode();
     data["export_dir"] = Utils::Fs::toNativePath(session->torrentExportDirectory());
     data["export_dir_fin"] = Utils::Fs::toNativePath(session->finishedTorrentExportDirectory());
 
@@ -404,6 +405,8 @@ void AppController::setPreferencesAction()
         session->setDownloadPathEnabled(it.value().toBool());
     if (hasKey("temp_path"))
         session->setDownloadPath(it.value().toString());
+    if (hasKey("use_category_paths_in_manual_mode"))
+        session->setUseCategoryPathsInManualMode(it.value().toBool());
     if (hasKey("export_dir"))
         session->setTorrentExportDirectory(it.value().toString());
     if (hasKey("export_dir_fin"))

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -43,7 +43,7 @@
 #include "base/utils/net.h"
 #include "base/utils/version.h"
 
-inline const Utils::Version<int, 3, 2> API_VERSION {2, 8, 5};
+inline const Utils::Version<int, 3, 2> API_VERSION {2, 8, 6};
 
 class APIController;
 class WebApplication;


### PR DESCRIPTION
If the option is enabled any relative save path will be resolved against an appropriate Category path instead of Global default one.

Closes #16209.