### PR TITLE
Add Select All/None buttons in new torrent dialog

### DIFF
--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -201,7 +201,7 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::AddTorrentParams &inP
 
     m_ui->startTorrentCheckBox->setChecked(!m_torrentParams.addPaused.value_or(session->isAddTorrentPaused()));
 
-    m_ui->comboTTM->blockSignals(true); // the TreeView size isn't correct if the slot does it job at this point
+    m_ui->comboTTM->blockSignals(true); // the TreeView size isn't correct if the slot does its job at this point
     m_ui->comboTTM->setCurrentIndex(session->isAutoTMMDisabledByDefault() ? 0 : 1);
     m_ui->comboTTM->blockSignals(false);
 
@@ -899,6 +899,8 @@ void AddNewTorrentDialog::setupTreeview()
         connect(m_ui->contentTreeView, &QAbstractItemView::clicked, m_ui->contentTreeView
                 , qOverload<const QModelIndex &>(&QAbstractItemView::edit));
         connect(m_ui->contentTreeView, &QWidget::customContextMenuRequested, this, &AddNewTorrentDialog::displayContentTreeMenu);
+        connect(m_ui->buttonSelectAll, &QPushButton::clicked, m_contentModel, &TorrentContentFilterModel::selectAll);
+        connect(m_ui->buttonSelectNone, &QPushButton::clicked, m_contentModel, &TorrentContentFilterModel::selectNone);
 
         const auto contentLayout = ((m_ui->contentLayoutComboBox->currentIndex() == 0)
                                     ? BitTorrent::detectContentLayout(m_torrentInfo.filePaths())

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -991,9 +991,9 @@ void AddNewTorrentDialog::TMMChanged(int index)
 
         m_ui->groupBoxDownloadPath->blockSignals(true);
         m_ui->groupBoxDownloadPath->setChecked(!downloadPath.isEmpty());
-
-        updateDiskSpaceLabel();
     }
+
+    updateDiskSpaceLabel();
 }
 
 void AddNewTorrentDialog::doNotDeleteTorrentClicked(bool checked)

--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -392,22 +392,59 @@
        </item>
       </layout>
      </widget>
-     <widget class="TorrentContentTreeView" name="contentTreeView">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-        <horstretch>1</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="contextMenuPolicy">
-       <enum>Qt::CustomContextMenu</enum>
-      </property>
-      <property name="selectionMode">
-       <enum>QAbstractItemView::ExtendedSelection</enum>
-      </property>
-      <property name="sortingEnabled">
-       <bool>true</bool>
-      </property>
+     <widget class="QWidget" name="layoutWidget">
+      <layout class="QVBoxLayout" name="verticalLayout_5">
+       <item>
+        <layout class="QHBoxLayout" name="contentFilterLayout">
+         <item>
+          <widget class="QPushButton" name="buttonSelectAll">
+           <property name="text">
+            <string>Select All</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonSelectNone">
+           <property name="text">
+            <string>Select None</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_6">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>168</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="TorrentContentTreeView" name="contentTreeView">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>1</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::ExtendedSelection</enum>
+         </property>
+         <property name="sortingEnabled">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
     </widget>
    </item>


### PR DESCRIPTION
![Screenshot 2022-01-30 164930](https://user-images.githubusercontent.com/6451685/151708157-b2e1b773-af71-4e00-b0f1-6f9edc9877b7.png)

1. Not sure if we should enable/disable the buttons at all.
2. Not sure if where i currently do them are the best places (or in `setupTreeview()` maybe?)

closes #16308, closes #15963
closes #16012

/off topic
After this i want to add a filter like in Content tab. It will be copy-paste, i have no interest in finding out how to somehow make them shared. If anyone has a problem with that, let me know so i don't open the PR.

While i'm in this file, anyone knows if #16012 has a simple solution or i should leave it alone?