### PR TITLE
Improve tracker status handling

### DIFF
--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -239,6 +239,7 @@ namespace BitTorrent
         void saveResumeData();
         void handleMoveStorageJobFinished(bool hasOutstandingJob);
         void fileSearchFinished(const Path &savePath, const PathList &fileNames);
+        void updatePeerCount(const QString &trackerUrl, const lt::tcp::endpoint &endpoint, int count);
 
     private:
         using EventTrigger = std::function<void ()>;
@@ -263,9 +264,6 @@ namespace BitTorrent
         void handleTorrentFinishedAlert(const lt::torrent_finished_alert *p);
         void handleTorrentPausedAlert(const lt::torrent_paused_alert *p);
         void handleTorrentResumedAlert(const lt::torrent_resumed_alert *p);
-        void handleTrackerErrorAlert(const lt::tracker_error_alert *p);
-        void handleTrackerReplyAlert(const lt::tracker_reply_alert *p);
-        void handleTrackerWarningAlert(const lt::tracker_warning_alert *p);
 
         bool isMoveInProgress() const;
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -243,13 +243,7 @@ MainWindow::MainWindow(QWidget *parent)
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackersAdded, m_transferListFiltersWidget, &TransferListFiltersWidget::addTrackers);
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackersRemoved, m_transferListFiltersWidget, &TransferListFiltersWidget::removeTrackers);
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackerlessStateChanged, m_transferListFiltersWidget, &TransferListFiltersWidget::changeTrackerless);
-
-    connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackerSuccess
-        , m_transferListFiltersWidget, qOverload<const BitTorrent::Torrent *, const QString &>(&TransferListFiltersWidget::trackerSuccess));
-    connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackerError
-        , m_transferListFiltersWidget, qOverload<const BitTorrent::Torrent *, const QString &>(&TransferListFiltersWidget::trackerError));
-    connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackerWarning
-        , m_transferListFiltersWidget, qOverload<const BitTorrent::Torrent *, const QString &>(&TransferListFiltersWidget::trackerWarning));
+    connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackerEntriesUpdated, m_transferListFiltersWidget, &TransferListFiltersWidget::trackerEntriesUpdated);
 
 #ifdef Q_OS_MACOS
     // Increase top spacing to avoid tab overlapping

--- a/src/gui/transferlistfilterswidget.h
+++ b/src/gui/transferlistfilterswidget.h
@@ -33,6 +33,7 @@
 #include <QtContainerFwd>
 
 #include "base/bittorrent/infohash.h"
+#include "base/bittorrent/session.h"
 #include "base/bittorrent/trackerentry.h"
 #include "base/path.h"
 
@@ -40,11 +41,6 @@ class QCheckBox;
 class QResizeEvent;
 
 class TransferListWidget;
-
-namespace BitTorrent
-{
-    class Torrent;
-}
 
 namespace Net
 {
@@ -107,14 +103,10 @@ public:
 
     // Redefine addItem() to make sure the list stays sorted
     void addItem(const QString &tracker, const BitTorrent::TorrentID &id);
-    void removeItem(const QString &tracker, const BitTorrent::TorrentID &id);
+    void removeItem(const QString &trackerURL, const BitTorrent::TorrentID &id);
     void changeTrackerless(bool trackerless, const BitTorrent::TorrentID &id);
     void setDownloadTrackerFavicon(bool value);
-
-public slots:
-    void trackerSuccess(const BitTorrent::TorrentID &id, const QString &tracker);
-    void trackerError(const BitTorrent::TorrentID &id, const QString &tracker);
-    void trackerWarning(const BitTorrent::TorrentID &id, const QString &tracker);
+    void handleTrackerEntriesUpdated(const QHash<BitTorrent::Torrent *, QHash<QString, BitTorrent::TrackerEntryUpdateInfo>> &updateInfos);
 
 private slots:
     void handleFavicoDownloadFinished(const Net::DownloadResult &result);
@@ -155,14 +147,7 @@ public slots:
     void addTrackers(const BitTorrent::Torrent *torrent, const QVector<BitTorrent::TrackerEntry> &trackers);
     void removeTrackers(const BitTorrent::Torrent *torrent, const QVector<BitTorrent::TrackerEntry> &trackers);
     void changeTrackerless(const BitTorrent::Torrent *torrent, bool trackerless);
-    void trackerSuccess(const BitTorrent::Torrent *torrent, const QString &tracker);
-    void trackerWarning(const BitTorrent::Torrent *torrent, const QString &tracker);
-    void trackerError(const BitTorrent::Torrent *torrent, const QString &tracker);
-
-signals:
-    void trackerSuccess(const BitTorrent::TorrentID &id, const QString &tracker);
-    void trackerError(const BitTorrent::TorrentID &id, const QString &tracker);
-    void trackerWarning(const BitTorrent::TorrentID &id, const QString &tracker);
+    void trackerEntriesUpdated(const QHash<BitTorrent::Torrent *, QHash<QString, BitTorrent::TrackerEntryUpdateInfo>> &updateInfos);
 
 private slots:
     void onCategoryFilterStateChanged(bool enabled);


### PR DESCRIPTION
The idea is that we shouldn't pollute upper level components with all the atomic events in libtorrent. In some cases it's better to preprocess them and then report it as a compound events.

It should improve GUI performance (especially during startup with many torrents and tracker entries in them).