### PR TITLE
CMake: prefer `-pthread` flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ project(qBittorrent
 
 # use CONFIG mode first in find_package
 set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
 # version requirements - older versions may work, but you are on your own
 set(minBoostVersion 1.65)
 set(minQt5Version 5.15.2)


### PR DESCRIPTION
ref: https://cmake.org/cmake/help/latest/module/FindThreads.html#variable:THREADS_PREFER_PTHREAD_FLAG

> Use of both the imported target as well as this switch is highly recommended for new code.

Note that this change also fixes build on RISC-V architecture, which needs `-pthread` flag for libpthread to function correctly.

See also: [Stack Overflow: Difference between -pthread and -lpthread](https://stackoverflow.com/questions/23250863/difference-between-pthread-and-lpthread-while-compiling)
