### PR TITLE
Use QVarLengthArray whenever applicable

### DIFF
--- a/src/base/bittorrent/ltqbitarray.cpp
+++ b/src/base/bittorrent/ltqbitarray.cpp
@@ -28,11 +28,10 @@
 
 #include "ltqbitarray.h"
 
-#include <memory>
-
 #include <libtorrent/bitfield.hpp>
 
 #include <QBitArray>
+#include <QVarLengthArray>
 
 namespace
 {
@@ -52,21 +51,10 @@ namespace BitTorrent::LT
         const char *bitsData = bits.data();
         const int dataLength = (bits.size() + 7) / 8;
 
-        if (dataLength <= STACK_ALLOC_SIZE)
-        {
-            // fast path for small bitfields
-            char tmp[STACK_ALLOC_SIZE];  // uninitialized for faster allocation
-            for (int i = 0; i < dataLength; ++i)
-                tmp[i] = reverseByte(bitsData[i]);
-
-            return QBitArray::fromBits(tmp, bits.size());
-        }
-
-        // slow path for big bitfields
-        auto tmp = std::make_unique<char []>(dataLength);
+        QVarLengthArray<char, STACK_ALLOC_SIZE> tmp(dataLength);
         for (int i = 0; i < dataLength; ++i)
             tmp[i] = reverseByte(bitsData[i]);
 
-        return QBitArray::fromBits(tmp.get(), bits.size());
+        return QBitArray::fromBits(tmp.data(), tmp.size());
     }
 }

--- a/src/base/bittorrent/ltqbitarray.cpp
+++ b/src/base/bittorrent/ltqbitarray.cpp
@@ -37,8 +37,18 @@ namespace
 {
     unsigned char reverseByte(const unsigned char byte)
     {
-        // https://graphics.stanford.edu/~seander/bithacks.html#ReverseByteWith64Bits
-        return (((byte * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL) >> 32;
+        // https://graphics.stanford.edu/~seander/bithacks.html#BitReverseTable
+        static const unsigned char table[] =
+        {
+#define R2(n) n, (n + (2 * 64)), (n + 64), (n + (3 * 64))
+#define R4(n) R2(n), R2(n + (2 * 16)), R2(n + 16), R2(n + (3 * 16))
+#define R6(n) R4(n), R4(n + (2 * 4)), R4(n + 4), R4(n + (3 * 4))
+            R6(0), R6(2), R6(1), R6(3)
+#undef R6
+#undef R4
+#undef R2
+        };
+        return table[byte];
     }
 }
 

--- a/src/base/path.cpp
+++ b/src/base/path.cpp
@@ -272,7 +272,7 @@ Path Path::createUnchecked(const QString &pathStr)
 
 bool operator==(const Path &lhs, const Path &rhs)
 {
-    return (lhs.m_pathStr.compare(rhs.m_pathStr, CASE_SENSITIVITY) == 0);
+    return (lhs.data().compare(rhs.data(), CASE_SENSITIVITY) == 0);
 }
 
 bool operator!=(const Path &lhs, const Path &rhs)

--- a/src/base/path.h
+++ b/src/base/path.h
@@ -76,7 +76,6 @@ public:
     static void stripRootFolder(PathList &filePaths);
     static void addRootFolder(PathList &filePaths, const Path &rootFolder);
 
-    friend bool operator==(const Path &lhs, const Path &rhs);
     friend Path operator/(const Path &lhs, const Path &rhs);
     friend Path operator+(const Path &lhs, const QString &rhs);
 
@@ -90,6 +89,7 @@ private:
 
 Q_DECLARE_METATYPE(Path)
 
+bool operator==(const Path &lhs, const Path &rhs);
 bool operator!=(const Path &lhs, const Path &rhs);
 Path operator+(const Path &lhs, const char rhs[]);
 Path operator+(const Path &lhs, const std::string &rhs);

--- a/src/webui/www/private/css/Window.css
+++ b/src/webui/www/private/css/Window.css
@@ -192,7 +192,7 @@ div.mochaToolbarWrapper.bottom {
 .zIndexFix {
     border: 1px solid transparent;
     display: block;
-    filter: mask();
+    /*filter: mask();*/
     height: 100px;
     left: 0;
     position: absolute;


### PR DESCRIPTION
* Use QVarLengthArray whenever applicable
* Use "table look-up" method for reversing byte
  This method takes constant time and is less prone to (CPU) pipeline stalling due to less computation. Also it is slightly faster than the previous method.
* Make Path::operator== a free function
* Remove hack for outdated IE 6 browser
  The `mask()` isn't valid in CSS.