### PR TITLE
Correctly register PathList alias

### DIFF
--- a/src/base/path.cpp
+++ b/src/base/path.cpp
@@ -42,7 +42,7 @@ const Qt::CaseSensitivity CASE_SENSITIVITY = Qt::CaseInsensitive;
 const Qt::CaseSensitivity CASE_SENSITIVITY = Qt::CaseSensitive;
 #endif
 
-const int PATHLIST_TYPEID = qRegisterMetaType<PathList>();
+const int PATHLIST_TYPEID = qRegisterMetaType<PathList>("PathList");
 
 Path::Path(const QString &pathStr)
     : m_pathStr {QDir::cleanPath(pathStr)}


### PR DESCRIPTION
Otherwise `PathList` (aka` QList<Path>`) cannot be used in queued connections with Qt5.