### PR TITLE
Cache file priorities

### DIFF
--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -272,7 +272,7 @@ namespace BitTorrent
         void adjustStorageLocation();
         void moveStorage(const Path &newPath, MoveStorageMode mode);
         void manageIncompleteFiles();
-        void applyFirstLastPiecePriority(bool enabled, const QVector<DownloadPriority> &updatedFilePrio = {});
+        void applyFirstLastPiecePriority(bool enabled);
 
         void prepareResumeData(const lt::add_torrent_params &params);
         void endReceivedMetadataHandling(const Path &savePath, const PathList &fileNames);
@@ -286,6 +286,7 @@ namespace BitTorrent
         TorrentInfo m_torrentInfo;
         PathList m_filePaths;
         QHash<lt::file_index_t, int> m_indexMap;
+        QVector<DownloadPriority> m_filePriorities;
         SpeedMonitor m_speedMonitor;
 
         InfoHash m_infoHash;


### PR DESCRIPTION
Speedup access to file priorities by avoiding extra blocking call to libtorrent thread.
Improve the Torrent interface by hiding the asynchrony of file priority changes behind the scenes.