### PR TITLE
Fix UI crash when torrent is in non-existent category.

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -320,7 +320,7 @@ window.addEvent('load', function() {
             return true;
         }
         const categoryHash = genHash(category);
-        if (category_list[categoryHash] === null) // This should not happen
+        if (!category_list[categoryHash]) // This should not happen
             category_list[categoryHash] = {
                 name: category,
                 torrents: []


### PR DESCRIPTION
This checks that `category_list[categoryHash].torrents` is truthy before dereferencing it. In some cases the API response will have a torrent in a category that doesn't exist resulting in the check to return `undefined` which is not `null`. This broadens the check so that it will create the category even if null.