### PR TITLE
Unify log messages format

### DIFF
--- a/src/base/bittorrent/portforwarderimpl.cpp
+++ b/src/base/bittorrent/portforwarderimpl.cpp
@@ -101,7 +101,7 @@ void PortForwarderImpl::start()
         // quint16 port = i.key();
         i.value() = {m_provider->add_port_mapping(lt::session::tcp, i.key(), i.key())};
     }
-    LogMsg(tr("UPnP / NAT-PMP support [ON]"), Log::INFO);
+    LogMsg(tr("UPnP/NAT-PMP support: ON"), Log::INFO);
 }
 
 void PortForwarderImpl::stop()
@@ -111,5 +111,5 @@ void PortForwarderImpl::stop()
     settingsPack.set_bool(lt::settings_pack::enable_upnp, false);
     settingsPack.set_bool(lt::settings_pack::enable_natpmp, false);
     m_provider->apply_settings(settingsPack);
-    LogMsg(tr("UPnP / NAT-PMP support [OFF]"), Log::INFO);
+    LogMsg(tr("UPnP/NAT-PMP support: OFF"), Log::INFO);
 }


### PR DESCRIPTION
This improves readability and may allow users to match log message with better accuracy.
Now log message is consisted of 2 parts:
The first part is a short sentence describing the event. It should avoid writing out the specifics of the event as it will be described in the next part of the message. The sentence should use correct tense of the event.
The second part consist of `Name: Value` pairs which will provide sufficient info for the event.

Note that none of the message parts is mandatory, one of them can be omitted when the resulting log message is clear enough.

Note: this PR mainly apply to `Session` class and other classes can be applied later (gradually).