### PR TITLE
Explicitly look for libboost_system or it won't be found on 1.66

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,7 +40,7 @@ endif()
 
 # force variable type so that it always shows up in ccmake/cmake-gui frontends
 set_property(CACHE LibtorrentRasterbar_DIR PROPERTY TYPE PATH)
-find_package(Boost ${minBoostVersion} REQUIRED)
+find_package(Boost ${minBoostVersion} REQUIRED COMPONENTS system)
 find_package(OpenSSL ${minOpenSSLVersion} REQUIRED)
 find_package(ZLIB ${minZlibVersion} REQUIRED)
 if (QT6)


### PR DESCRIPTION
Had to add this to the package for openSUSE Leap 15.4, which is stuck at boost 1.66. Boost started including the cmake config script only from 1.70, so we are stuck with the plain FindBoost here.
