### PR TITLE
cmake: Fix redefinition of _WIN32_WINNT with Qt6

### DIFF
--- a/cmake/Modules/MacroQbtCommonConfig.cmake
+++ b/cmake/Modules/MacroQbtCommonConfig.cmake
@@ -33,14 +33,18 @@ macro(qbt_common_config)
 
     if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
         target_compile_definitions(qbt_common_cfg INTERFACE
-            NTDDI_VERSION=0x06010000
-            _WIN32_WINNT=0x0601
-            _WIN32_IE=0x0601
             WIN32_LEAN_AND_MEAN
             NOMINMAX
             UNICODE
             _UNICODE
         )
+        if (NOT QT6)
+            target_compile_definitions(qbt_common_cfg INTERFACE
+                NTDDI_VERSION=0x06010000
+                _WIN32_WINNT=0x0601
+                _WIN32_IE=0x0601
+            )
+        endif()
     endif()
 
     if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang") OR (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"))


### PR DESCRIPTION
This fixes building with Qt6 in Windows using CMake. _WIN32_WINNT is
defined in Qt6Targets.cmake as _WIN32_WINNT=0x0A00. Without the change,
these errors are shown:

FAILED: src/base/CMakeFiles/qbt_base.dir/asyncfilestorage.cpp.obj
<command-line>: error: _WIN32_WINNT redefined
<command-line>: note: this is the location of the previous definition

Also Qt6 is supported for Windows 10 (1809 or later).
