### PR TITLE
Fix skipping levels of parent folders for the content layout Combobox

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -2236,7 +2236,7 @@ bool Session::addTorrent_impl(const std::variant<MagnetUri, TorrentInfo> &source
         const TorrentContentLayout contentLayout = ((loadTorrentParams.contentLayout == TorrentContentLayout::Original)
                                                     ? detectContentLayout(torrentInfo.filePaths()) : loadTorrentParams.contentLayout);
         PathList filePaths = (!addTorrentParams.filePaths.isEmpty() ? addTorrentParams.filePaths : torrentInfo.filePaths());
-        applyContentLayout(filePaths, contentLayout, Path::findRootFolder(torrentInfo.filePaths()));
+        applyContentLayout(filePaths, contentLayout, torrentInfo.filePaths());
 
         // if torrent name wasn't explicitly set we handle the case of
         // initial renaming of torrent content and rename torrent accordingly

--- a/src/base/bittorrent/torrentcontentlayout.cpp
+++ b/src/base/bittorrent/torrentcontentlayout.cpp
@@ -48,17 +48,27 @@ BitTorrent::TorrentContentLayout BitTorrent::detectContentLayout(const PathList 
             : TorrentContentLayout::Subfolder);
 }
 
-void BitTorrent::applyContentLayout(PathList &filePaths, const BitTorrent::TorrentContentLayout contentLayout, const Path &rootFolder)
+void BitTorrent::applyContentLayout(PathList &filePaths, const BitTorrent::TorrentContentLayout contentLayout, const PathList &infoFilePaths)
 {
     Q_ASSERT(!filePaths.isEmpty());
 
     switch (contentLayout)
     {
     case TorrentContentLayout::Subfolder:
-        if (Path::findRootFolder(filePaths).isEmpty())
-            Path::addRootFolder(filePaths, !rootFolder.isEmpty() ? rootFolder : removeExtension(filePaths.at(0)));
-        break;
+    {
+        const Path paramsRootFolder = Path::findRootFolder(filePaths);
+        const Path infoRootFolder = Path::findRootFolder(infoFilePaths);
 
+        if (paramsRootFolder.isEmpty())
+        {
+            Path::addRootFolder(filePaths, !infoRootFolder.isEmpty() ? infoRootFolder : removeExtension(filePaths.at(0)));
+        }
+        else if (Path::depth(filePaths) != Path::depth(infoFilePaths))
+        {
+            Path::addRootFolder(filePaths, infoRootFolder);
+        }
+        break;
+    }
     case TorrentContentLayout::NoSubfolder:
         Path::stripRootFolder(filePaths);
         break;

--- a/src/base/bittorrent/torrentcontentlayout.h
+++ b/src/base/bittorrent/torrentcontentlayout.h
@@ -53,5 +53,5 @@ namespace BitTorrent
     }
 
     TorrentContentLayout detectContentLayout(const PathList &filePaths);
-    void applyContentLayout(PathList &filePaths, TorrentContentLayout contentLayout, const Path &rootFolder = {});
+    void applyContentLayout(PathList &filePaths, TorrentContentLayout contentLayout, const PathList &infoFilePaths = {});
 }

--- a/src/base/path.cpp
+++ b/src/base/path.cpp
@@ -199,6 +199,12 @@ QString Path::toString() const
     return QDir::toNativeSeparators(m_pathStr);
 }
 
+const int Path::depth() const
+{
+    const QList<QStringView> pathItems = QStringView(m_pathStr).split(u'/', Qt::SkipEmptyParts);
+    return pathItems.count();
+}
+
 Path &Path::operator/=(const Path &other)
 {
     *this = *this / other;
@@ -282,6 +288,18 @@ void Path::addRootFolder(PathList &filePaths, const Path &rootFolder)
 
     for (Path &filePath : filePaths)
         filePath = rootFolder / filePath;
+}
+
+const int Path::depth(const PathList &filePaths)
+{
+    int maxDepth = 0;
+    for (const Path &filePath : filePaths)
+    {
+        int depth = filePath.depth();
+        if (depth > maxDepth)
+            maxDepth = depth;
+    }
+    return maxDepth;
 }
 
 Path Path::createUnchecked(const QString &pathStr)

--- a/src/base/path.h
+++ b/src/base/path.h
@@ -62,6 +62,7 @@ public:
 
     bool hasAncestor(const Path &other) const;
     Path relativePathOf(const Path &childPath) const;
+    const int depth() const;
 
     QString data() const;
     QString toString() const;
@@ -76,6 +77,7 @@ public:
     static Path findRootFolder(const PathList &filePaths);
     static void stripRootFolder(PathList &filePaths);
     static void addRootFolder(PathList &filePaths, const Path &rootFolder);
+    static const int depth(const PathList &filePaths);
 
     friend Path operator/(const Path &lhs, const Path &rhs);
     friend Path operator+(const Path &lhs, const QString &rhs);

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -546,7 +546,7 @@ void AddNewTorrentDialog::contentLayoutChanged(const int index)
     const auto contentLayout = ((index == 0)
                                 ? BitTorrent::detectContentLayout(m_torrentInfo.filePaths())
                                 : static_cast<BitTorrent::TorrentContentLayout>(index));
-    BitTorrent::applyContentLayout(m_torrentParams.filePaths, contentLayout, Path::findRootFolder(m_torrentInfo.filePaths()));
+    BitTorrent::applyContentLayout(m_torrentParams.filePaths, contentLayout, m_torrentInfo.filePaths());
     m_contentModel->model()->setupModelData(FileStorageAdaptor(m_torrentInfo, m_torrentParams.filePaths));
     m_contentModel->model()->updateFilesPriorities(filePriorities);
 
@@ -908,7 +908,7 @@ void AddNewTorrentDialog::setupTreeview()
                                     : static_cast<BitTorrent::TorrentContentLayout>(m_ui->contentLayoutComboBox->currentIndex()));
         if (m_torrentParams.filePaths.isEmpty())
             m_torrentParams.filePaths = m_torrentInfo.filePaths();
-        BitTorrent::applyContentLayout(m_torrentParams.filePaths, contentLayout, Path::findRootFolder(m_torrentInfo.filePaths()));
+        BitTorrent::applyContentLayout(m_torrentParams.filePaths, contentLayout, m_torrentInfo.filePaths());
         // List files in torrent
         m_contentModel->model()->setupModelData(FileStorageAdaptor(m_torrentInfo, m_torrentParams.filePaths));
         if (const QByteArray state = m_storeTreeHeaderState; !state.isEmpty())


### PR DESCRIPTION
This is in response to #16259. May also address #15250, and #14426 and possibly some other tickets related to content layout selection ComboBox on the Add New Torrent Dialog which is known to break the file paths with several levels of depth so that after a few clicks between the available options: "Original", "Create Subfolder", "Don't create subfolder" the root folders get stripped completely for all options.

The root folder finder has been modified to account for the full common path rather than only the top level folder.

Ex.:

Folder1/Folder2/Folder3/File1
Folder1/Folder2/Folder32/File2
Folder1/Folder2/Folder33/File1

will have a root folder of 'Folder1/Folder2', and not 'Folder1' as they have now.

This makes the "Don't create subfolder" option actually create no subfolders for those folders that have no root folder and will result in the following path list:

Folder3/File1
Folder32/File2
Folder33/File1

Fixes #16259