### PR TITLE
GHA CI: cancel outdated in-progress workflow runs

### DIFF
--- a/.github/workflows/ci_file_health.yaml
+++ b/.github/workflows/ci_file_health.yaml
@@ -2,6 +2,10 @@ name: CI - File health
 
 on: [pull_request, push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: ${{ github.head_ref != '' }}
+
 jobs:
   ci:
     name: Check

--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -1,5 +1,10 @@
 name: CI - macOS
+
 on: [pull_request, push]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: ${{ github.head_ref != '' }}
 
 jobs:
   ci:

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -1,5 +1,10 @@
 name: CI - Ubuntu
+
 on: [pull_request, push]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: ${{ github.head_ref != '' }}
 
 jobs:
   ci:

--- a/.github/workflows/ci_webui.yaml
+++ b/.github/workflows/ci_webui.yaml
@@ -2,6 +2,10 @@ name: CI - WebUI
 
 on: [pull_request, push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: ${{ github.head_ref != '' }}
+
 jobs:
   ci:
     name: Check

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -1,5 +1,10 @@
 name: CI - Windows
+
 on: [pull_request, push]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: ${{ github.head_ref != '' }}
 
 jobs:
   ci:


### PR DESCRIPTION
This will only cancel outdated workflow runs on PR branches and won't affect other normal repo branches.
