### PR TITLE
Enable browsing to shortcut folders

### DIFF
--- a/src/gui/fspathedit.cpp
+++ b/src/gui/fspathedit.cpp
@@ -130,7 +130,7 @@ void FileSystemPathEdit::FileSystemPathEditPrivate::browseActionTriggered()
     case FileSystemPathEdit::Mode::DirectoryOpen:
     case FileSystemPathEdit::Mode::DirectorySave:
         newPath = QFileDialog::getExistingDirectory(q, dialogCaptionOrDefault(),
-                                initialDirectory.data(), QFileDialog::DontResolveSymlinks | QFileDialog::ShowDirsOnly);
+                                initialDirectory.data(), QFileDialog::ShowDirsOnly);
         break;
     default:
         throw std::logic_error("Unknown FileSystemPathEdit mode");


### PR DESCRIPTION
Enable shortcut folders for the Open and Save directory file dialogs on the Add New Torrent File dialog to allow browsing to shortcut folders on Windows OS.
Fixes #7900