### PR TITLE
Don't use hack to make the first column movable

### DIFF
--- a/src/gui/previewselectdialog.cpp
+++ b/src/gui/previewselectdialog.cpp
@@ -37,7 +37,6 @@
 #include <QPushButton>
 #include <QShowEvent>
 #include <QStandardItemModel>
-#include <QTableView>
 
 #include "base/bittorrent/torrent.h"
 #include "base/preferences.h"
@@ -77,13 +76,6 @@ PreviewSelectDialog::PreviewSelectDialog(QWidget *parent, const BitTorrent::Torr
     m_previewListModel->setHeaderData(SIZE, Qt::Horizontal, tr("Size"));
     m_previewListModel->setHeaderData(PROGRESS, Qt::Horizontal, tr("Progress"));
 
-    // This hack fixes reordering of first column with Qt5.
-    // https://github.com/qtproject/qtbase/commit/e0fc088c0c8bc61dbcaf5928b24986cd61a22777
-    QTableView unused;
-    unused.setVerticalHeader(m_ui->previewList->header());
-    m_ui->previewList->header()->setParent(m_ui->previewList);
-    unused.setVerticalHeader(new QHeaderView(Qt::Horizontal));
-
     m_ui->previewList->setAlternatingRowColors(pref->useAlternatingRowColors());
     m_ui->previewList->setModel(m_previewListModel);
     m_ui->previewList->hideColumn(FILE_INDEX);
@@ -107,6 +99,7 @@ PreviewSelectDialog::PreviewSelectDialog(QWidget *parent, const BitTorrent::Torr
 
     m_previewListModel->sort(NAME);
     m_ui->previewList->header()->setContextMenuPolicy(Qt::CustomContextMenu);
+    m_ui->previewList->header()->setFirstSectionMovable(true);
     m_ui->previewList->header()->setSortIndicator(0, Qt::AscendingOrder);
     m_ui->previewList->selectionModel()->select(m_previewListModel->index(0, NAME), QItemSelectionModel::Select | QItemSelectionModel::Rows);
 

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -40,7 +40,6 @@
 #include <QShortcut>
 #include <QSortFilterProxyModel>
 #include <QStandardItemModel>
-#include <QTableView>
 #include <QVector>
 #include <QWheelEvent>
 
@@ -89,6 +88,7 @@ PeerListWidget::PeerListWidget(PropertiesWidget *parent)
     setAllColumnsShowFocus(true);
     setEditTriggers(QAbstractItemView::NoEditTriggers);
     setSelectionMode(QAbstractItemView::ExtendedSelection);
+    header()->setFirstSectionMovable(true);
     header()->setStretchLastSection(false);
     header()->setTextElideMode(Qt::ElideRight);
 
@@ -163,13 +163,6 @@ PeerListWidget::PeerListWidget(PropertiesWidget *parent)
     handleSortColumnChanged(header()->sortIndicatorSection());
     const auto *copyHotkey = new QShortcut(QKeySequence::Copy, this, nullptr, nullptr, Qt::WidgetShortcut);
     connect(copyHotkey, &QShortcut::activated, this, &PeerListWidget::copySelectedPeers);
-
-    // This hack fixes reordering of first column with Qt5.
-    // https://github.com/qtproject/qtbase/commit/e0fc088c0c8bc61dbcaf5928b24986cd61a22777
-    QTableView unused;
-    unused.setVerticalHeader(this->header());
-    this->header()->setParent(this);
-    unused.setVerticalHeader(new QHeaderView(Qt::Horizontal));
 }
 
 PeerListWidget::~PeerListWidget()

--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -38,7 +38,6 @@
 #include <QMessageBox>
 #include <QShortcut>
 #include <QStringList>
-#include <QTableView>
 #include <QTreeWidgetItem>
 #include <QUrl>
 #include <QVector>
@@ -70,6 +69,7 @@ TrackerListWidget::TrackerListWidget(PropertiesWidget *properties)
     setAllColumnsShowFocus(true);
     setItemsExpandable(false);
     setSelectionMode(QAbstractItemView::ExtendedSelection);
+    header()->setFirstSectionMovable(true);
     header()->setStretchLastSection(false); // Must be set after loadSettings() in order to work
     header()->setTextElideMode(Qt::ElideRight);
     // Ensure that at least one column is visible at all times
@@ -133,13 +133,6 @@ TrackerListWidget::TrackerListWidget(PropertiesWidget *properties)
     connect(copyHotkey, &QShortcut::activated, this, &TrackerListWidget::copyTrackerUrl);
 
     connect(this, &QAbstractItemView::doubleClicked, this, &TrackerListWidget::editSelectedTracker);
-
-    // This hack fixes reordering of first column with Qt5.
-    // https://github.com/qtproject/qtbase/commit/e0fc088c0c8bc61dbcaf5928b24986cd61a22777
-    QTableView unused;
-    unused.setVerticalHeader(header());
-    header()->setParent(this);
-    unused.setVerticalHeader(new QHeaderView(Qt::Horizontal));
 }
 
 TrackerListWidget::~TrackerListWidget()

--- a/src/gui/search/pluginselectdialog.cpp
+++ b/src/gui/search/pluginselectdialog.cpp
@@ -37,7 +37,6 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QMimeData>
-#include <QTableView>
 
 #include "base/global.h"
 #include "base/net/downloadmanager.h"
@@ -69,15 +68,9 @@ PluginSelectDialog::PluginSelectDialog(SearchPluginManager *pluginManager, QWidg
     m_ui->setupUi(this);
     setAttribute(Qt::WA_DeleteOnClose);
 
-    // This hack fixes reordering of first column with Qt5.
-    // https://github.com/qtproject/qtbase/commit/e0fc088c0c8bc61dbcaf5928b24986cd61a22777
-    QTableView unused;
-    unused.setVerticalHeader(m_ui->pluginsTree->header());
-    m_ui->pluginsTree->header()->setParent(m_ui->pluginsTree);
-    unused.setVerticalHeader(new QHeaderView(Qt::Horizontal));
-
     m_ui->pluginsTree->setRootIsDecorated(false);
     m_ui->pluginsTree->hideColumn(PLUGIN_ID);
+    m_ui->pluginsTree->header()->setFirstSectionMovable(true);
     m_ui->pluginsTree->header()->setSortIndicator(0, Qt::AscendingOrder);
 
     m_ui->actionUninstall->setIcon(UIThemeManager::instance()->getIcon("list-remove"));

--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -37,7 +37,6 @@
 #include <QMenu>
 #include <QPalette>
 #include <QStandardItemModel>
-#include <QTableView>
 #include <QUrl>
 
 #include "base/bittorrent/session.h"
@@ -61,15 +60,9 @@ SearchJobWidget::SearchJobWidget(SearchHandler *searchHandler, QWidget *parent)
 {
     m_ui->setupUi(this);
 
-    // This hack fixes reordering of first column with Qt5.
-    // https://github.com/qtproject/qtbase/commit/e0fc088c0c8bc61dbcaf5928b24986cd61a22777
-    QTableView unused;
-    unused.setVerticalHeader(m_ui->resultsBrowser->header());
-    m_ui->resultsBrowser->header()->setParent(m_ui->resultsBrowser);
-    unused.setVerticalHeader(new QHeaderView(Qt::Horizontal));
-
     loadSettings();
 
+    header()->setFirstSectionMovable(true);
     header()->setStretchLastSection(false);
     header()->setTextElideMode(Qt::ElideRight);
 

--- a/src/gui/torrentcontenttreeview.cpp
+++ b/src/gui/torrentcontenttreeview.cpp
@@ -34,7 +34,6 @@
 #include <QLineEdit>
 #include <QMessageBox>
 #include <QModelIndexList>
-#include <QTableView>
 #include <QThread>
 
 #include "base/bittorrent/abstractfilestorage.h"
@@ -66,15 +65,7 @@ TorrentContentTreeView::TorrentContentTreeView(QWidget *parent)
     : QTreeView(parent)
 {
     setExpandsOnDoubleClick(false);
-
-    // This hack fixes reordering of first column with Qt5.
-    // https://github.com/qtproject/qtbase/commit/e0fc088c0c8bc61dbcaf5928b24986cd61a22777
-    QTableView unused;
-    unused.setVerticalHeader(header());
-    header()->setParent(this);
-    header()->setStretchLastSection(false);
-    header()->setTextElideMode(Qt::ElideRight);
-    unused.setVerticalHeader(new QHeaderView(Qt::Horizontal));
+    header()->setFirstSectionMovable(true);
 }
 
 void TorrentContentTreeView::keyPressEvent(QKeyEvent *event)

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -39,7 +39,6 @@
 #include <QRegularExpression>
 #include <QSet>
 #include <QShortcut>
-#include <QTableView>
 #include <QVector>
 #include <QWheelEvent>
 
@@ -152,6 +151,7 @@ TransferListWidget::TransferListWidget(QWidget *parent, MainWindow *mainWindow)
 #if defined(Q_OS_MACOS)
     setAttribute(Qt::WA_MacShowFocusRect, false);
 #endif
+    header()->setFirstSectionMovable(true);
     header()->setStretchLastSection(false);
     header()->setTextElideMode(Qt::ElideRight);
 
@@ -222,13 +222,6 @@ TransferListWidget::TransferListWidget(QWidget *parent, MainWindow *mainWindow)
     connect(doubleClickHotkeyEnter, &QShortcut::activated, this, &TransferListWidget::torrentDoubleClicked);
     const auto *recheckHotkey = new QShortcut(Qt::CTRL + Qt::Key_R, this, nullptr, nullptr, Qt::WidgetShortcut);
     connect(recheckHotkey, &QShortcut::activated, this, &TransferListWidget::recheckSelectedTorrents);
-
-    // This hack fixes reordering of first column with Qt5.
-    // https://github.com/qtproject/qtbase/commit/e0fc088c0c8bc61dbcaf5928b24986cd61a22777
-    QTableView unused;
-    unused.setVerticalHeader(header());
-    header()->setParent(this);
-    unused.setVerticalHeader(new QHeaderView(Qt::Horizontal));
 }
 
 TransferListWidget::~TransferListWidget()


### PR DESCRIPTION
`QHeaderView::setFirstSectionMovable()` was introduced in Qt 5.11. 

The first column in transfer list is movable without any of these but i included it anyway to be safe. I don't know if something is broken for me, maybe corrupt savestate of header in config file, i mention this because it happens sometimes when going from Qt6 to Qt5.