### PR TITLE
Allow setting priority for partially downloaded multi-file torrent

### DIFF
--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -655,77 +655,74 @@ void PropertiesWidget::displayFilesListMenu()
         menu->addSeparator();
     }
 
-    if (!m_torrent->isSeed())
+    const auto applyPriorities = [this](const BitTorrent::DownloadPriority prio)
     {
-        const auto applyPriorities = [this](const BitTorrent::DownloadPriority prio)
+        const QModelIndexList selectedRows = m_ui->filesList->selectionModel()->selectedRows(0);
+        for (const QModelIndex &index : selectedRows)
         {
-            const QModelIndexList selectedRows = m_ui->filesList->selectionModel()->selectedRows(0);
-            for (const QModelIndex &index : selectedRows)
+            m_propListModel->setData(index.sibling(index.row(), PRIORITY)
+                , static_cast<int>(prio));
+        }
+
+        // Save changes
+        this->applyPriorities();
+    };
+
+    QMenu *subMenu = menu->addMenu(tr("Priority"));
+
+    subMenu->addAction(tr("Do not download"), subMenu, [applyPriorities]()
+    {
+        applyPriorities(BitTorrent::DownloadPriority::Ignored);
+    });
+    subMenu->addAction(tr("Normal"), subMenu, [applyPriorities]()
+    {
+        applyPriorities(BitTorrent::DownloadPriority::Normal);
+    });
+    subMenu->addAction(tr("High"), subMenu, [applyPriorities]()
+    {
+        applyPriorities(BitTorrent::DownloadPriority::High);
+    });
+    subMenu->addAction(tr("Maximum"), subMenu, [applyPriorities]()
+    {
+        applyPriorities(BitTorrent::DownloadPriority::Maximum);
+    });
+    subMenu->addSeparator();
+    subMenu->addAction(tr("By shown file order"), subMenu, [this]()
+    {
+        // Equally distribute the selected items into groups and for each group assign
+        // a download priority that will apply to each item. The number of groups depends on how
+        // many "download priority" are available to be assigned
+
+        const QModelIndexList selectedRows = m_ui->filesList->selectionModel()->selectedRows(0);
+
+        const qsizetype priorityGroups = 3;
+        const auto priorityGroupSize = std::max<qsizetype>((selectedRows.length() / priorityGroups), 1);
+
+        for (qsizetype i = 0; i < selectedRows.length(); ++i)
+        {
+            auto priority = BitTorrent::DownloadPriority::Ignored;
+            switch (i / priorityGroupSize)
             {
-                m_propListModel->setData(index.sibling(index.row(), PRIORITY)
-                    , static_cast<int>(prio));
+            case 0:
+                priority = BitTorrent::DownloadPriority::Maximum;
+                break;
+            case 1:
+                priority = BitTorrent::DownloadPriority::High;
+                break;
+            default:
+            case 2:
+                priority = BitTorrent::DownloadPriority::Normal;
+                break;
             }
+
+            const QModelIndex &index = selectedRows[i];
+            m_propListModel->setData(index.sibling(index.row(), PRIORITY)
+                , static_cast<int>(priority));
 
             // Save changes
             this->applyPriorities();
-        };
-
-        QMenu *subMenu = menu->addMenu(tr("Priority"));
-
-        subMenu->addAction(tr("Do not download"), subMenu, [applyPriorities]()
-        {
-            applyPriorities(BitTorrent::DownloadPriority::Ignored);
-        });
-        subMenu->addAction(tr("Normal"), subMenu, [applyPriorities]()
-        {
-            applyPriorities(BitTorrent::DownloadPriority::Normal);
-        });
-        subMenu->addAction(tr("High"), subMenu, [applyPriorities]()
-        {
-            applyPriorities(BitTorrent::DownloadPriority::High);
-        });
-        subMenu->addAction(tr("Maximum"), subMenu, [applyPriorities]()
-        {
-            applyPriorities(BitTorrent::DownloadPriority::Maximum);
-        });
-        subMenu->addSeparator();
-        subMenu->addAction(tr("By shown file order"), subMenu, [this]()
-        {
-            // Equally distribute the selected items into groups and for each group assign
-            // a download priority that will apply to each item. The number of groups depends on how
-            // many "download priority" are available to be assigned
-
-            const QModelIndexList selectedRows = m_ui->filesList->selectionModel()->selectedRows(0);
-
-            const qsizetype priorityGroups = 3;
-            const auto priorityGroupSize = std::max<qsizetype>((selectedRows.length() / priorityGroups), 1);
-
-            for (qsizetype i = 0; i < selectedRows.length(); ++i)
-            {
-                auto priority = BitTorrent::DownloadPriority::Ignored;
-                switch (i / priorityGroupSize)
-                {
-                case 0:
-                    priority = BitTorrent::DownloadPriority::Maximum;
-                    break;
-                case 1:
-                    priority = BitTorrent::DownloadPriority::High;
-                    break;
-                default:
-                case 2:
-                    priority = BitTorrent::DownloadPriority::Normal;
-                    break;
-                }
-
-                const QModelIndex &index = selectedRows[i];
-                m_propListModel->setData(index.sibling(index.row(), PRIORITY)
-                    , static_cast<int>(priority));
-
-                // Save changes
-                this->applyPriorities();
-            }
-        });
-    }
+        }
+    });
 
     // The selected torrent might have disappeared during exec()
     // so we just close menu when an appropriate model is reset

--- a/src/gui/properties/proplistdelegate.cpp
+++ b/src/gui/properties/proplistdelegate.cpp
@@ -77,7 +77,7 @@ QWidget *PropListDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
     if (m_properties)
     {
         const BitTorrent::Torrent *torrent = m_properties->getCurrentTorrent();
-        if (!torrent || !torrent->hasMetadata() || torrent->isSeed())
+        if (!torrent || !torrent->hasMetadata())
             return nullptr;
     }
 


### PR DESCRIPTION
Currently you can't directly change the priority of a partially completed multi file torrent. You'll have to start downloading those files and then change their priority. Closes #10994, closes  #8673
