### PR TITLE
Add right click menu for status filters to allow bulk pause/resume/delete action

### DIFF
--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -286,7 +286,20 @@ void StatusFilterWidget::updateTorrentNumbers()
     item(TorrentFilter::Errored)->setData(Qt::DisplayRole, tr("Errored (%1)").arg(nbErrored));
 }
 
-void StatusFilterWidget::showMenu() {}
+void StatusFilterWidget::showMenu()
+{
+    QMenu *menu = new QMenu(this);
+    menu->setAttribute(Qt::WA_DeleteOnClose);
+
+    menu->addAction(UIThemeManager::instance()->getIcon("media-playback-start"), tr("Resume torrents")
+        , transferList, &TransferListWidget::startVisibleTorrents);
+    menu->addAction(UIThemeManager::instance()->getIcon("media-playback-pause"), tr("Pause torrents")
+        , transferList, &TransferListWidget::pauseVisibleTorrents);
+    menu->addAction(UIThemeManager::instance()->getIcon("edit-delete"), tr("Delete torrents")
+        , transferList, &TransferListWidget::deleteVisibleTorrents);
+
+    menu->popup(QCursor::pos());
+}
 
 void StatusFilterWidget::applyFilter(int row)
 {


### PR DESCRIPTION
This will allow users to perform action on all torrents with a single click instead of having to select all with ctrl+A or other cumbersome ways. Basically it copies the function found in tracker/category filters.
Closes #13398
