### PR TITLE
Allow setting the maximum active checking torrents

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -375,6 +375,7 @@ Session::Session(QObject *parent)
     , m_announceToAllTiers(BITTORRENT_SESSION_KEY("AnnounceToAllTiers"), true)
     , m_asyncIOThreads(BITTORRENT_SESSION_KEY("AsyncIOThreadsCount"), 10)
     , m_hashingThreads(BITTORRENT_SESSION_KEY("HashingThreadsCount"), 2)
+    , m_maxActiveCheckingTorrents(BITTORRENT_SESSION_KEY("maxActiveCheckingTorrents"), 1)
     , m_filePoolSize(BITTORRENT_SESSION_KEY("FilePoolSize"), 5000)
     , m_checkingMemUsage(BITTORRENT_SESSION_KEY("CheckingMemUsageSize"), 32)
     , m_diskCacheSize(BITTORRENT_SESSION_KEY("DiskCacheSize"), -1)
@@ -1338,6 +1339,9 @@ void Session::loadLTSettings(lt::settings_pack &settingsPack)
 #ifdef QBT_USES_LIBTORRENT2
     settingsPack.set_int(lt::settings_pack::hashing_threads, hashingThreads());
 #endif
+    // Max active checking torrents
+    settingsPack.set_int(lt::settings_pack::active_checking, maxActiveCheckingTorrents());
+
     settingsPack.set_int(lt::settings_pack::file_pool_size, filePoolSize());
 
     const int checkingMemUsageSize = checkingMemUsage() * 64;
@@ -3304,6 +3308,20 @@ void Session::setHashingThreads(const int num)
         return;
 
     m_hashingThreads = num;
+    configureDeferred();
+}
+
+int Session::maxActiveCheckingTorrents() const
+{
+    return m_maxActiveCheckingTorrents;
+}
+
+void Session::setMaxActiveCheckingTorrents(const int val)
+{
+    if (val == m_maxActiveCheckingTorrents)
+        return;
+
+    m_maxActiveCheckingTorrents = val;
     configureDeferred();
 }
 

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -354,6 +354,8 @@ namespace BitTorrent
         void setAsyncIOThreads(int num);
         int hashingThreads() const;
         void setHashingThreads(int num);
+        int maxActiveCheckingTorrents() const;
+        void setMaxActiveCheckingTorrents(int val);
         int filePoolSize() const;
         void setFilePoolSize(int size);
         int checkingMemUsage() const;
@@ -679,6 +681,7 @@ namespace BitTorrent
         CachedSettingValue<bool> m_announceToAllTiers;
         CachedSettingValue<int> m_asyncIOThreads;
         CachedSettingValue<int> m_hashingThreads;
+        CachedSettingValue<int> m_maxActiveCheckingTorrents;
         CachedSettingValue<int> m_filePoolSize;
         CachedSettingValue<int> m_checkingMemUsage;
         CachedSettingValue<int> m_diskCacheSize;

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -99,6 +99,7 @@ namespace
 #ifdef QBT_USES_LIBTORRENT2
         HASHING_THREADS,
 #endif
+        MAX_ACTIVE_CHECKING_TORRENTS,
         FILE_POOL_SIZE,
         CHECKING_MEM_USAGE,
 #ifndef QBT_USES_LIBTORRENT2
@@ -205,6 +206,8 @@ void AdvancedSettings::saveAdvancedSettings()
     // Hashing threads
     session->setHashingThreads(m_spinBoxHashingThreads.value());
 #endif
+    // Max active rechecking torrents
+    session->setMaxActiveCheckingTorrents(m_spinBoxMaxActiveCheckingTorrents.value());
     // File pool size
     session->setFilePoolSize(m_spinBoxFilePoolSize.value());
     // Checking Memory Usage
@@ -459,7 +462,13 @@ void AdvancedSettings::loadAdvancedSettings()
     addRow(HASHING_THREADS, (tr("Hashing threads") + ' ' + makeLink("https://www.libtorrent.org/reference-Settings.html#hashing_threads", "(?)"))
             , &m_spinBoxHashingThreads);
 #endif
-
+    // Max active rechecking torrents
+    m_spinBoxMaxActiveCheckingTorrents.setMinimum(-1);
+    m_spinBoxMaxActiveCheckingTorrents.setMaximum(std::numeric_limits<int>::max());
+    m_spinBoxMaxActiveCheckingTorrents.setValue(session->maxActiveCheckingTorrents());
+    m_spinBoxMaxActiveCheckingTorrents.setSpecialValueText(QString::fromUtf8(C_INFINITY));
+    addRow(MAX_ACTIVE_CHECKING_TORRENTS, (tr("Maximum active checking torrents") + ' ' + makeLink("https://www.libtorrent.org/reference-Settings.html#active_checking", "(?)"))
+            , &m_spinBoxMaxActiveCheckingTorrents);
     // File pool size
     m_spinBoxFilePoolSize.setMinimum(1);
     m_spinBoxFilePoolSize.setMaximum(std::numeric_limits<int>::max());

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -58,7 +58,7 @@ private:
     void loadAdvancedSettings();
     template <typename T> void addRow(int row, const QString &text, T *widget);
 
-    QSpinBox m_spinBoxAsyncIOThreads, m_spinBoxFilePoolSize, m_spinBoxCheckingMemUsage, m_spinBoxDiskQueueSize,
+    QSpinBox m_spinBoxAsyncIOThreads, m_spinBoxMaxActiveCheckingTorrents, m_spinBoxFilePoolSize, m_spinBoxCheckingMemUsage, m_spinBoxDiskQueueSize,
              m_spinBoxSaveResumeDataInterval, m_spinBoxOutgoingPortsMin, m_spinBoxOutgoingPortsMax, m_spinBoxUPnPLeaseDuration, m_spinBoxPeerToS,
              m_spinBoxListRefresh, m_spinBoxTrackerPort, m_spinBoxSendBufferWatermark, m_spinBoxSendBufferLowWatermark,
              m_spinBoxSendBufferWatermarkFactor, m_spinBoxConnectionSpeed, m_spinBoxSocketBacklogSize, m_spinBoxMaxConcurrentHTTPAnnounces, m_spinBoxStopTrackerTimeout,

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -299,6 +299,8 @@ void AppController::preferencesAction()
     data["async_io_threads"] = session->asyncIOThreads();
     // Hashing threads
     data["hashing_threads"] = session->hashingThreads();
+    // Max active checking torrents
+    data["max_active_checking_torrents"] = session->maxActiveCheckingTorrents();
     // File pool size
     data["file_pool_size"] = session->filePoolSize();
     // Checking memory usage
@@ -770,6 +772,9 @@ void AppController::setPreferencesAction()
     // Hashing threads
     if (hasKey("hashing_threads"))
         session->setHashingThreads(it.value().toInt());
+    // Max active checking torrents
+    if (hasKey("max_active_checking_torrents"))
+        session->setMaxActiveCheckingTorrents(it.value().toInt());
     // File pool size
     if (hasKey("file_pool_size"))
         session->setFilePoolSize(it.value().toInt());

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -982,6 +982,14 @@
             </tr>
             <tr>
                 <td>
+                    <label for="maxActiveCheckingTorrents">QBT_TR(Max active checking torrents:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#active_checking" target="_blank">(?)</a></label>
+                </td>
+                <td>
+                    <input type="text" id="maxActiveCheckingTorrents" style="width: 15em;" />
+                </td>
+            </tr>
+            <tr>
+                <td>
                     <label for="filePoolSize">QBT_TR(File pool size:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#file_pool_size" target="_blank">(?)</a></label>
                 </td>
                 <td>
@@ -1943,6 +1951,7 @@
                         // libtorrent section
                         $('asyncIOThreads').setProperty('value', pref.async_io_threads);
                         $('hashingThreads').setProperty('value', pref.hashing_threads);
+                        $('maxActiveCheckingTorrents').setProperty('value', pref.max_active_checking_torrents);
                         $('filePoolSize').setProperty('value', pref.file_pool_size);
                         $('outstandMemoryWhenCheckingTorrents').setProperty('value', pref.checking_memory_use);
                         $('diskCache').setProperty('value', pref.disk_cache);
@@ -2340,6 +2349,7 @@
             // libtorrent section
             settings.set('async_io_threads', $('asyncIOThreads').getProperty('value'));
             settings.set('hashing_threads', $('hashingThreads').getProperty('value'));
+            settings.set('max_active_checking_torrents', $('maxActiveCheckingTorrents').getProperty('value'));
             settings.set('file_pool_size', $('filePoolSize').getProperty('value'));
             settings.set('checking_memory_use', $('outstandMemoryWhenCheckingTorrents').getProperty('value'));
             settings.set('disk_cache', $('diskCache').getProperty('value'));


### PR DESCRIPTION
This is to allow re-checking of multiple torrents simultaneously. This will benefit users who have multiple disks or SSD.
Closes #15296

