### PR TITLE
Remove unnecessary UI properties from "Ip Filter Refresh" button

### DIFF
--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -1822,12 +1822,6 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
                  </item>
                  <item>
                   <widget class="QToolButton" name="IpFilterRefreshBtn">
-                   <property name="minimumSize">
-                    <size>
-                     <width>0</width>
-                     <height>25</height>
-                    </size>
-                   </property>
                    <property name="toolTip">
                     <string>Reload the filter</string>
                    </property>


### PR DESCRIPTION
* It's now in keeping visually with `browse` button next to it.

![IP Filtering Refresh Button](https://user-images.githubusercontent.com/42386382/156451222-e6674bf7-d3ca-4465-b51c-ebd989cb5e2e.png)
