### PR TITLE
Don't check files when restoring torrents

### DIFF
--- a/src/base/bittorrent/nativesessionextension.cpp
+++ b/src/base/bittorrent/nativesessionextension.cpp
@@ -27,39 +27,9 @@
  */
 
 #include "nativesessionextension.h"
-
-#include <libtorrent/alert_types.hpp>
-
 #include "nativetorrentextension.h"
-
-namespace
-{
-    void handleFastresumeRejectedAlert(const lt::fastresume_rejected_alert *alert)
-    {
-        if (alert->error.value() == lt::errors::mismatching_file_size)
-        {
-            alert->handle.unset_flags(lt::torrent_flags::auto_managed);
-            alert->handle.pause();
-        }
-    }
-}
-
-lt::feature_flags_t NativeSessionExtension::implemented_features()
-{
-    return alert_feature;
-}
 
 std::shared_ptr<lt::torrent_plugin> NativeSessionExtension::new_torrent(const lt::torrent_handle &torrentHandle, ClientData)
 {
     return std::make_shared<NativeTorrentExtension>(torrentHandle);
-}
-
-void NativeSessionExtension::on_alert(const lt::alert *alert)
-{
-    switch (alert->type())
-    {
-    case lt::fastresume_rejected_alert::alert_type:
-        handleFastresumeRejectedAlert(static_cast<const lt::fastresume_rejected_alert *>(alert));
-        break;
-    }
 }

--- a/src/base/bittorrent/nativesessionextension.h
+++ b/src/base/bittorrent/nativesessionextension.h
@@ -38,7 +38,5 @@ class NativeSessionExtension final : public lt::plugin
     using ClientData = void *;
 #endif
 
-    lt::feature_flags_t implemented_features() override;
     std::shared_ptr<lt::torrent_plugin> new_torrent(const lt::torrent_handle &torrentHandle, ClientData) override;
-    void on_alert(const lt::alert *alert) override;
 };

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -4619,6 +4619,7 @@ void Session::startUpTorrents()
         }
 
         qDebug() << "Starting up torrent" << torrentID.toString() << "...";
+        resumeData.ltAddTorrentParams.flags |= lt::torrent_flags::no_verify_files;
         if (!loadTorrent(resumeData))
             LogMsg(tr("Failed to resume torrent. Torrent: \"%1\"").arg(torrentID.toString()), Log::CRITICAL);
 
@@ -4731,7 +4732,6 @@ void Session::handleAlert(const lt::alert *a)
         case lt::save_resume_data_failed_alert::alert_type:
         case lt::torrent_paused_alert::alert_type:
         case lt::torrent_resumed_alert::alert_type:
-        case lt::fastresume_rejected_alert::alert_type:
         case lt::torrent_checked_alert::alert_type:
         case lt::metadata_received_alert::alert_type:
         case lt::performance_alert::alert_type:

--- a/src/base/bittorrent/torrent.h
+++ b/src/base/bittorrent/torrent.h
@@ -214,7 +214,6 @@ namespace BitTorrent
         virtual bool hasFirstLastPiecePriority() const = 0;
         virtual TorrentState state() const = 0;
         virtual bool hasMetadata() const = 0;
-        virtual bool hasMissingFiles() const = 0;
         virtual bool hasError() const = 0;
         virtual int queuePosition() const = 0;
         virtual QVector<TrackerEntry> trackers() const = 0;

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -150,7 +150,6 @@ namespace BitTorrent
         bool hasFirstLastPiecePriority() const override;
         TorrentState state() const override;
         bool hasMetadata() const override;
-        bool hasMissingFiles() const override;
         bool hasError() const override;
         int queuePosition() const override;
         QVector<TrackerEntry> trackers() const override;
@@ -247,7 +246,6 @@ namespace BitTorrent
         void updateStatus(const lt::torrent_status &nativeStatus);
         void updateState();
 
-        void handleFastResumeRejectedAlert(const lt::fastresume_rejected_alert *p);
         void handleFileCompletedAlert(const lt::file_completed_alert *p);
         void handleFileErrorAlert(const lt::file_error_alert *p);
 #ifdef QBT_USES_LIBTORRENT2
@@ -312,8 +310,6 @@ namespace BitTorrent
         TorrentOperatingMode m_operatingMode;
         TorrentContentLayout m_contentLayout;
         bool m_hasSeedStatus;
-        bool m_fastresumeDataRejected = false;
-        bool m_hasMissingFiles = false;
         bool m_hasFirstLastPiecePriority = false;
         bool m_useAutoTMM;
         bool m_isStopped;

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -992,7 +992,7 @@ void TransferListWidget::displayListMenu()
         else
             needsPause = true;
 
-        if (torrent->isErrored() || torrent->hasMissingFiles())
+        if (torrent->isErrored())
         {
             // If torrent is in "errored" or "missing files" state
             // it cannot keep further processing until you restart it.


### PR DESCRIPTION
It redesigns the session restoring process, using a feature previously added to libtorrent from my submission, so as not to check files of torrents. Now errors with files (for example, missing files) will be detected only "on demand" (when you really need to read/write a file). This kind of emulates the continuity of the session, so there is no difference whether the file is corrupted while the application is running, or between its launches.
This should save us from the old-fashioned problem with handling "missing files" state.
It should also appeal to fans of so-called "archived" torrents, so that they can (temporarily) delete or move files of completed (downloaded and stopped) torrents without causing any problems.
Since this may seem like a rather drastic change (which made me hesitate to implement it), I would like it to be thoroughly tested in advance before the next "feature" update (v4.5).