### PR TITLE
Fix parenthesis on peformance warning log message

### DIFF
--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -1925,7 +1925,7 @@ void TorrentImpl::handleMetadataReceivedAlert(const lt::metadata_received_alert 
 
 void TorrentImpl::handlePerformanceAlert(const lt::performance_alert *p) const
 {
-    LogMsg((tr("Performance alert: %1. More info: %2").arg(QString::fromStdString(p->message())), u"https://libtorrent.org/reference-Alerts.html#enum-performance-warning-t"_qs)
+    LogMsg((tr("Performance alert: %1. More info: %2").arg(QString::fromStdString(p->message()), u"https://libtorrent.org/reference-Alerts.html#enum-performance-warning-t"_qs))
            , Log::INFO);
 }
 


### PR DESCRIPTION
Before:
`(I) 2022-03-08T20:59:49 - https://libtorrent.org/reference-Alerts.html#enum-performance-warning-t`

After:
`(I) 2022-03-08T21:13:17 - Performance alert: Sing.2.2021.1080p.WEB-DL.DD+5.1.Atmos.H.264.HuN-No1: performance warning: max outstanding piece requests reached. More info: https://libtorrent.org/reference-Alerts.html#enum-performance-warning-t`