### PR TITLE
Remove obsoleted functions from Utils::Gui namespace

### DIFF
--- a/src/gui/aboutdialog.cpp
+++ b/src/gui/aboutdialog.cpp
@@ -113,7 +113,7 @@ AboutDialog::AboutDialog(QWidget *parent)
                                      "The database is licensed under the Creative Commons Attribution 4.0 International License"));
     m_ui->labelDBIP->setText(DBIPText);
 
-    Utils::Gui::resize(this, m_storeDialogSize);
+    resize(m_storeDialogSize);
     show();
 }
 

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -305,7 +305,7 @@ void AddNewTorrentDialog::setSavePathHistoryLength(const int value)
 
 void AddNewTorrentDialog::loadState()
 {
-    Utils::Gui::resize(this, m_storeDialogSize);
+    resize(m_storeDialogSize);
     m_ui->splitter->restoreState(m_storeSplitterState);;
 }
 

--- a/src/gui/autoexpandabledialog.cpp
+++ b/src/gui/autoexpandabledialog.cpp
@@ -101,6 +101,6 @@ void AutoExpandableDialog::showEvent(QShowEvent *e)
     if (wd > width())
     {
         QSize size = {width() - m_ui->verticalLayout->sizeHint().width() + wd, height()};
-        Utils::Gui::resize(this, size);
+        resize(size);
     }
 }

--- a/src/gui/banlistoptionsdialog.cpp
+++ b/src/gui/banlistoptionsdialog.cpp
@@ -56,7 +56,7 @@ BanListOptionsDialog::BanListOptionsDialog(QWidget *parent)
     m_ui->bannedIPList->sortByColumn(0, Qt::AscendingOrder);
     m_ui->buttonBanIP->setEnabled(false);
 
-    Utils::Gui::resize(this, m_storeDialogSize);
+    resize(m_storeDialogSize);
 }
 
 BanListOptionsDialog::~BanListOptionsDialog()

--- a/src/gui/cookiesdialog.cpp
+++ b/src/gui/cookiesdialog.cpp
@@ -64,7 +64,7 @@ CookiesDialog::CookiesDialog(QWidget *parent)
                     m_cookiesModel->index(0, 0),
                     QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
 
-    Utils::Gui::resize(this, m_storeDialogSize);
+    resize(m_storeDialogSize);
     m_ui->treeView->header()->restoreState(m_storeViewState);
 }
 

--- a/src/gui/deletionconfirmationdialog.cpp
+++ b/src/gui/deletionconfirmationdialog.cpp
@@ -55,8 +55,6 @@ DeletionConfirmationDialog::DeletionConfirmationDialog(QWidget *parent, const in
     m_ui->checkPermDelete->setChecked(defaultDeleteFiles || Preferences::instance()->deleteTorrentFilesAsDefault());
     connect(m_ui->checkPermDelete, &QCheckBox::clicked, this, &DeletionConfirmationDialog::updateRememberButtonState);
     m_ui->buttonBox->button(QDialogButtonBox::Cancel)->setFocus();
-
-    Utils::Gui::resize(this);
 }
 
 DeletionConfirmationDialog::~DeletionConfirmationDialog()

--- a/src/gui/downloadfromurldialog.cpp
+++ b/src/gui/downloadfromurldialog.cpp
@@ -94,7 +94,7 @@ DownloadFromURLDialog::DownloadFromURLDialog(QWidget *parent)
     m_ui->textUrls->setText(text);
     m_ui->textUrls->moveCursor(QTextCursor::End);
 
-    Utils::Gui::resize(this, m_storeDialogSize);
+    resize(m_storeDialogSize);
     show();
 }
 

--- a/src/gui/ipsubnetwhitelistoptionsdialog.cpp
+++ b/src/gui/ipsubnetwhitelistoptionsdialog.cpp
@@ -60,7 +60,7 @@ IPSubnetWhitelistOptionsDialog::IPSubnetWhitelistOptionsDialog(QWidget *parent)
     m_ui->whitelistedIPSubnetList->sortByColumn(0, Qt::AscendingOrder);
     m_ui->buttonWhitelistIPSubnet->setEnabled(false);
 
-    Utils::Gui::resize(this, m_storeDialogSize);
+    resize(m_storeDialogSize);
 }
 
 IPSubnetWhitelistOptionsDialog::~IPSubnetWhitelistOptionsDialog()

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -209,7 +209,7 @@ MainWindow::MainWindow(QWidget *parent)
     // Name filter
     m_searchFilter = new LineEdit(this);
     m_searchFilter->setPlaceholderText(tr("Filter torrent names..."));
-    m_searchFilter->setFixedWidth(Utils::Gui::scaledSize(this, 200));
+    m_searchFilter->setFixedWidth(200);
     m_searchFilter->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(m_searchFilter, &QWidget::customContextMenuRequested, this, &MainWindow::showFilterContextMenu);
     m_searchFilterAction = m_ui->toolBar->insertWidget(m_ui->actionLock, m_searchFilter);

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -575,7 +575,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
 
     m_ui->tabSelection->setCurrentRow(m_storeLastViewedPage);
 
-    Utils::Gui::resize(this, m_storeDialogSize);
+    resize(m_storeDialogSize);
     show();
     // Have to be called after show(), because splitter width needed
     loadSplitterState();
@@ -639,8 +639,7 @@ void OptionsDialog::changePage(QListWidgetItem *current, QListWidgetItem *previo
 void OptionsDialog::loadSplitterState()
 {
     // width has been modified, use height as width reference instead
-    const int width = Utils::Gui::scaledSize(this
-        , (m_ui->tabSelection->item(TAB_UI)->sizeHint().height() * 2));
+    const int width = m_ui->tabSelection->item(TAB_UI)->sizeHint().height() * 2;
     const QStringList defaultSizes = {QString::number(width), QString::number(m_ui->hsplitter->width() - width)};
 
     QList<int> splitterSizes;

--- a/src/gui/previewselectdialog.cpp
+++ b/src/gui/previewselectdialog.cpp
@@ -173,7 +173,7 @@ void PreviewSelectDialog::saveWindowState()
 void PreviewSelectDialog::loadWindowState()
 {
     // Restore dialog size
-    Utils::Gui::resize(this, m_storeDialogSize);
+    resize(m_storeDialogSize);
 
     // Restore TreeView Header state
     if (!m_storeTreeHeaderState.get().isEmpty())

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -94,7 +94,7 @@ PropertiesWidget::PropertiesWidget(QWidget *parent)
     // Torrent content filtering
     m_contentFilterLine = new LineEdit(this);
     m_contentFilterLine->setPlaceholderText(tr("Filter files..."));
-    m_contentFilterLine->setFixedWidth(Utils::Gui::scaledSize(this, 300));
+    m_contentFilterLine->setFixedWidth(300);
     connect(m_contentFilterLine, &LineEdit::textChanged, this, &PropertiesWidget::filterText);
     m_ui->contentFilterLayout->insertWidget(3, m_contentFilterLine);
 
@@ -117,7 +117,7 @@ PropertiesWidget::PropertiesWidget(QWidget *parent)
     connect(m_ui->filesList->header(), &QHeaderView::sortIndicatorChanged, this, &PropertiesWidget::saveSettings);
 
     // set bar height relative to screen dpi
-    const int barHeight = Utils::Gui::scaledSize(this, 18);
+    const int barHeight = 18;
 
     // Downloaded pieces progress bar
     m_ui->tempProgressBarArea->setVisible(false);

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -160,8 +160,8 @@ AutomatedRssDownloader::~AutomatedRssDownloader()
 
 void AutomatedRssDownloader::loadSettings()
 {
-    const Preferences *const pref = Preferences::instance();
-    Utils::Gui::resize(this, pref->getRssGeometrySize());
+    const auto *pref = Preferences::instance();
+    resize(pref->getRssGeometrySize());
     m_ui->hsplitter->restoreState(pref->getRssHSplitterSizes());
 }
 

--- a/src/gui/search/pluginselectdialog.cpp
+++ b/src/gui/search/pluginselectdialog.cpp
@@ -88,7 +88,7 @@ PluginSelectDialog::PluginSelectDialog(SearchPluginManager *pluginManager, QWidg
     connect(m_pluginManager, &SearchPluginManager::checkForUpdatesFinished, this, &PluginSelectDialog::checkForUpdatesFinished);
     connect(m_pluginManager, &SearchPluginManager::checkForUpdatesFailed, this, &PluginSelectDialog::checkForUpdatesFailed);
 
-    Utils::Gui::resize(this, m_storeDialogSize);
+    resize(m_storeDialogSize);
     show();
 }
 

--- a/src/gui/search/pluginsourcedialog.cpp
+++ b/src/gui/search/pluginsourcedialog.cpp
@@ -41,7 +41,7 @@ PluginSourceDialog::PluginSourceDialog(QWidget *parent)
     m_ui->setupUi(this);
     setAttribute(Qt::WA_DeleteOnClose);
 
-    Utils::Gui::resize(this, m_storeDialogSize);
+    resize(m_storeDialogSize);
     show();
 }
 

--- a/src/gui/shutdownconfirmdialog.cpp
+++ b/src/gui/shutdownconfirmdialog.cpp
@@ -66,8 +66,6 @@ ShutdownConfirmDialog::ShutdownConfirmDialog(QWidget *parent, const ShutdownDial
 
     m_timer.setInterval(1000); // 1sec
     connect(&m_timer, &QTimer::timeout, this, &ShutdownConfirmDialog::updateSeconds);
-
-    Utils::Gui::resize(this);
 }
 
 ShutdownConfirmDialog::~ShutdownConfirmDialog()

--- a/src/gui/speedlimitdialog.cpp
+++ b/src/gui/speedlimitdialog.cpp
@@ -108,7 +108,7 @@ SpeedLimitDialog::SpeedLimitDialog(QWidget *parent)
     connect(m_ui->spinAltDownloadLimit, qOverload<int>(&QSpinBox::valueChanged)
             , this, [this](const int value) { updateSliderValue(m_ui->sliderAltDownloadLimit, value); });
 
-    Utils::Gui::resize(this, m_storeDialogSize);
+    resize(m_storeDialogSize);
 }
 
 SpeedLimitDialog::~SpeedLimitDialog()

--- a/src/gui/statsdialog.cpp
+++ b/src/gui/statsdialog.cpp
@@ -60,7 +60,7 @@ StatsDialog::StatsDialog(QWidget *parent)
     m_ui->labelCacheHits->hide();
 #endif
 
-    Utils::Gui::resize(this, m_storeDialogSize);
+    resize(m_storeDialogSize);
     show();
 }
 

--- a/src/gui/torrentcreatordialog.cpp
+++ b/src/gui/torrentcreatordialog.cpp
@@ -344,5 +344,5 @@ void TorrentCreatorDialog::loadSettings()
     m_ui->txtComment->setPlainText(m_storeComments);
     m_ui->lineEditSource->setText(m_storeSource);
 
-    Utils::Gui::resize(this, m_storeDialogSize);
+    resize(m_storeDialogSize);
 }

--- a/src/gui/torrentoptionsdialog.cpp
+++ b/src/gui/torrentoptionsdialog.cpp
@@ -390,7 +390,7 @@ TorrentOptionsDialog::TorrentOptionsDialog(QWidget *parent, const QVector<BitTor
 
     connect(m_ui->buttonGroup, &QButtonGroup::idClicked, this, &TorrentOptionsDialog::handleRatioTypeChanged);
 
-    Utils::Gui::resize(this, m_storeDialogSize);
+    resize(m_storeDialogSize);
 }
 
 TorrentOptionsDialog::~TorrentOptionsDialog()

--- a/src/gui/trackerentriesdialog.cpp
+++ b/src/gui/trackerentriesdialog.cpp
@@ -110,5 +110,5 @@ void TrackerEntriesDialog::saveSettings()
 
 void TrackerEntriesDialog::loadSettings()
 {
-    Utils::Gui::resize(this, m_storeDialogSize);
+    resize(m_storeDialogSize);
 }

--- a/src/gui/utils.h
+++ b/src/gui/utils.h
@@ -39,18 +39,10 @@ class QWidget;
 
 namespace Utils::Gui
 {
-    void resize(QWidget *widget, const QSize &newSize = {});
-    qreal screenScalingFactor(const QWidget *widget);
-
-    template <typename T>
-    T scaledSize(const QWidget *widget, const T &size)
-    {
-        return (size * screenScalingFactor(widget));
-    }
-
     QPixmap scaledPixmap(const QIcon &icon, const QWidget *widget, int height);
     QPixmap scaledPixmap(const Path &path, const QWidget *widget, int height = 0);
-    QPixmap scaledPixmapSvg(const Path &path, const QWidget *widget, int baseHeight);
+    QPixmap scaledPixmapSvg(const Path &path, const QWidget *widget, int height);
+
     QSize smallIconSize(const QWidget *widget = nullptr);
     QSize mediumIconSize(const QWidget *widget = nullptr);
     QSize largeIconSize(const QWidget *widget = nullptr);

--- a/src/gui/watchedfolderoptionsdialog.cpp
+++ b/src/gui/watchedfolderoptionsdialog.cpp
@@ -125,7 +125,7 @@ TorrentFilesWatcher::WatchedFolderOptions WatchedFolderOptionsDialog::watchedFol
 
 void WatchedFolderOptionsDialog::loadState()
 {
-    Utils::Gui::resize(this, m_storeDialogSize);
+    resize(m_storeDialogSize);
 }
 
 void WatchedFolderOptionsDialog::saveState()


### PR DESCRIPTION
`widget` parameter is kept for now to avoid major disruption for other PR.
Also add comments for loading svg images.

