### PR TITLE
Improve torrent searching in handling of torrent alerts

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -804,6 +804,7 @@ namespace BitTorrent
 
         QSet<TorrentID> m_downloadedMetadata;
 
+        QHash<lt::torrent_handle, TorrentImpl *> m_torrentsByNativeHandle;
         QHash<TorrentID, TorrentImpl *> m_torrents;
         QHash<TorrentID, LoadTorrentParams> m_loadingTorrents;
         QHash<QString, AddTorrentParams> m_downloadedTorrents;


### PR DESCRIPTION
InfoHash is expensive to hash, use torrent_handle based Hash to improve

