### PR TITLE
Avoid redundant hashing 

### DIFF
--- a/src/base/bittorrent/infohash.cpp
+++ b/src/base/bittorrent/infohash.cpp
@@ -90,7 +90,11 @@ BitTorrent::TorrentID BitTorrent::TorrentID::fromInfoHash(const BitTorrent::Info
     return infoHash.toTorrentID();
 }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+std::size_t BitTorrent::qHash(const BitTorrent::TorrentID &key, const std::size_t seed)
+#else
 uint BitTorrent::qHash(const BitTorrent::TorrentID &key, const uint seed)
+#endif
 {
     return ::qHash(std::hash<TorrentID::UnderlyingType>()(key), seed);
 }

--- a/src/base/bittorrent/infohash.cpp
+++ b/src/base/bittorrent/infohash.cpp
@@ -96,7 +96,7 @@ std::size_t BitTorrent::qHash(const BitTorrent::TorrentID &key, const std::size_
 uint BitTorrent::qHash(const BitTorrent::TorrentID &key, const uint seed)
 #endif
 {
-    return ::qHash(std::hash<TorrentID::UnderlyingType>()(key), seed);
+    return ::qHash(static_cast<TorrentID::BaseType>(key), seed);
 }
 
 bool BitTorrent::operator==(const BitTorrent::InfoHash &left, const BitTorrent::InfoHash &right)

--- a/src/base/bittorrent/infohash.h
+++ b/src/base/bittorrent/infohash.h
@@ -32,6 +32,7 @@
 #include <libtorrent/info_hash.hpp>
 #endif
 
+#include <QtGlobal>
 #include <QHash>
 #include <QMetaType>
 
@@ -81,7 +82,11 @@ namespace BitTorrent
         WrappedType m_nativeHash;
     };
 
-    uint qHash(const TorrentID &key, uint seed);
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    std::size_t qHash(const TorrentID &key, std::size_t seed = 0);
+#else
+    uint qHash(const TorrentID &key, uint seed = 0);
+#endif
 
     bool operator==(const InfoHash &left, const InfoHash &right);
     bool operator!=(const InfoHash &left, const InfoHash &right);

--- a/src/base/bittorrent/ltqhash.h
+++ b/src/base/bittorrent/ltqhash.h
@@ -28,28 +28,24 @@
 
 #pragma once
 
+#include <QtGlobal>
+
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 #include <functional>
 
 #include <libtorrent/units.hpp>
 
-#include <QtGlobal>
 #include <QHash>
 
-// From https://doc.qt.io/qt-6/qhash.html#the-hashing-function:
-// A hashing function for a key type K may be provided in two different ways.
-// The first way is by having an overload of qHash() in K's namespace.
 namespace libtorrent
 {
     namespace aux
     {
         template <typename T, typename Tag>
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-        std::size_t qHash(const strong_typedef<T, Tag> &key, const std::size_t seed = 0)
-#else
         uint qHash(const strong_typedef<T, Tag> &key, const uint seed = 0)
-#endif
         {
             return ::qHash((std::hash<strong_typedef<T, Tag>> {})(key), seed);
         }
     }
 }
+#endif

--- a/src/base/bittorrent/ltqhash.h
+++ b/src/base/bittorrent/ltqhash.h
@@ -32,6 +32,7 @@
 
 #include <libtorrent/units.hpp>
 
+#include <QtGlobal>
 #include <QHash>
 
 // From https://doc.qt.io/qt-6/qhash.html#the-hashing-function:
@@ -42,7 +43,11 @@ namespace libtorrent
     namespace aux
     {
         template <typename T, typename Tag>
-        uint qHash(const strong_typedef<T, Tag> &key, const uint seed)
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        std::size_t qHash(const strong_typedef<T, Tag> &key, const std::size_t seed = 0)
+#else
+        uint qHash(const strong_typedef<T, Tag> &key, const uint seed = 0)
+#endif
         {
             return ::qHash((std::hash<strong_typedef<T, Tag>> {})(key), seed);
         }

--- a/src/base/bittorrent/peeraddress.cpp
+++ b/src/base/bittorrent/peeraddress.cpp
@@ -77,7 +77,11 @@ bool BitTorrent::operator==(const BitTorrent::PeerAddress &left, const BitTorren
     return (left.ip == right.ip) && (left.port == right.port);
 }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+std::size_t BitTorrent::qHash(const BitTorrent::PeerAddress &addr, const std::size_t seed)
+#else
 uint BitTorrent::qHash(const BitTorrent::PeerAddress &addr, const uint seed)
+#endif
 {
     return (::qHash(addr.ip, seed) ^ ::qHash(addr.port));
 }

--- a/src/base/bittorrent/peeraddress.cpp
+++ b/src/base/bittorrent/peeraddress.cpp
@@ -79,9 +79,12 @@ bool BitTorrent::operator==(const BitTorrent::PeerAddress &left, const BitTorren
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 std::size_t BitTorrent::qHash(const BitTorrent::PeerAddress &addr, const std::size_t seed)
+{
+    return qHashMulti(seed, addr.ip, addr.port);
+}
 #else
 uint BitTorrent::qHash(const BitTorrent::PeerAddress &addr, const uint seed)
-#endif
 {
     return (::qHash(addr.ip, seed) ^ ::qHash(addr.port));
 }
+#endif

--- a/src/base/bittorrent/peeraddress.h
+++ b/src/base/bittorrent/peeraddress.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <QtGlobal>
 #include <QHostAddress>
 
 class QString;
@@ -44,5 +45,9 @@ namespace BitTorrent
     };
 
     bool operator==(const PeerAddress &left, const PeerAddress &right);
-    uint qHash(const PeerAddress &addr, uint seed);
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    std::size_t qHash(const PeerAddress &addr, std::size_t seed = 0);
+#else
+    uint qHash(const PeerAddress &addr, uint seed = 0);
+#endif
 }

--- a/src/base/bittorrent/torrent.cpp
+++ b/src/base/bittorrent/torrent.cpp
@@ -35,7 +35,11 @@
 
 namespace BitTorrent
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    std::size_t qHash(const TorrentState key, const std::size_t seed)
+#else
     uint qHash(const TorrentState key, const uint seed)
+#endif
     {
         return ::qHash(static_cast<std::underlying_type_t<TorrentState>>(key), seed);
     }

--- a/src/base/bittorrent/torrent.h
+++ b/src/base/bittorrent/torrent.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include <QtGlobal>
 #include <QtContainerFwd>
 #include <QMetaType>
 #include <QString>
@@ -97,7 +98,11 @@ namespace BitTorrent
         Error
     };
 
-    uint qHash(TorrentState key, uint seed);
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    std::size_t qHash(TorrentState key, std::size_t seed = 0);
+#else
+    uint qHash(TorrentState key, uint seed = 0);
+#endif
 
     class Torrent : public AbstractFileStorage
     {

--- a/src/base/bittorrent/tracker.cpp
+++ b/src/base/bittorrent/tracker.cpp
@@ -140,7 +140,11 @@ namespace BitTorrent
         return !(left == right);
     }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    std::size_t qHash(const Peer &key, const std::size_t seed)
+#else
     uint qHash(const Peer &key, const uint seed)
+#endif
     {
         return qHash(key.uniqueID(), seed);
     }

--- a/src/base/bittorrent/tracker.h
+++ b/src/base/bittorrent/tracker.h
@@ -34,6 +34,7 @@
 
 #include <libtorrent/entry.hpp>
 
+#include <QtGlobal>
 #include <QHash>
 #include <QObject>
 #include <QSet>
@@ -64,7 +65,11 @@ namespace BitTorrent
 
     bool operator==(const Peer &left, const Peer &right);
     bool operator!=(const Peer &left, const Peer &right);
-    uint qHash(const Peer &key, uint seed);
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    std::size_t qHash(const Peer &key, std::size_t seed = 0);
+#else
+    uint qHash(const Peer &key, uint seed = 0);
+#endif
 
     // *Basic* Bittorrent tracker implementation
     // [BEP-3] The BitTorrent Protocol Specification

--- a/src/base/bittorrent/trackerentry.cpp
+++ b/src/base/bittorrent/trackerentry.cpp
@@ -38,9 +38,12 @@ bool BitTorrent::operator==(const TrackerEntry &left, const TrackerEntry &right)
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 std::size_t BitTorrent::qHash(const TrackerEntry &key, const std::size_t seed)
+{
+    return qHashMulti(seed, key.url, key.tier);
+}
 #else
 uint BitTorrent::qHash(const TrackerEntry &key, const uint seed)
-#endif
 {
     return (::qHash(key.url, seed) ^ ::qHash(key.tier));
 }
+#endif

--- a/src/base/bittorrent/trackerentry.cpp
+++ b/src/base/bittorrent/trackerentry.cpp
@@ -36,7 +36,11 @@ bool BitTorrent::operator==(const TrackerEntry &left, const TrackerEntry &right)
         && QUrl(left.url) == QUrl(right.url));
 }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+std::size_t BitTorrent::qHash(const TrackerEntry &key, const std::size_t seed)
+#else
 uint BitTorrent::qHash(const TrackerEntry &key, const uint seed)
+#endif
 {
     return (::qHash(key.url, seed) ^ ::qHash(key.tier));
 }

--- a/src/base/bittorrent/trackerentry.h
+++ b/src/base/bittorrent/trackerentry.h
@@ -71,5 +71,9 @@ namespace BitTorrent
     };
 
     bool operator==(const TrackerEntry &left, const TrackerEntry &right);
-    uint qHash(const TrackerEntry &key, uint seed);
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    std::size_t qHash(const TrackerEntry &key, std::size_t seed = 0);
+#else
+    uint qHash(const TrackerEntry &key, uint seed = 0);
+#endif
 }

--- a/src/base/digest32.h
+++ b/src/base/digest32.h
@@ -131,12 +131,16 @@ bool operator<(const Digest32<N> &left, const Digest32<N> &right)
             < static_cast<typename Digest32<N>::UnderlyingType>(right);
 }
 
-template <int N>
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+template <int N>
 std::size_t qHash(const Digest32<N> &key, const std::size_t seed = 0)
-#else
-uint qHash(const Digest32<N> &key, const uint seed = 0)
-#endif
 {
-    return ::qHash(std::hash<typename Digest32<N>::UnderlyingType>()(key), seed);
+    return ::qHash(static_cast<typename Digest32<N>::UnderlyingType>(key), seed);
 }
+#else
+template <int N>
+uint qHash(const Digest32<N> &key, const uint seed = 0)
+{
+    return static_cast<uint>((std::hash<typename Digest32<N>::UnderlyingType> {})(key)) ^ seed;
+}
+#endif

--- a/src/base/digest32.h
+++ b/src/base/digest32.h
@@ -30,6 +30,7 @@
 
 #include <libtorrent/sha1_hash.hpp>
 
+#include <QtGlobal>
 #include <QByteArray>
 #include <QHash>
 #include <QSharedData>
@@ -131,7 +132,11 @@ bool operator<(const Digest32<N> &left, const Digest32<N> &right)
 }
 
 template <int N>
-uint qHash(const Digest32<N> &key, const uint seed)
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+std::size_t qHash(const Digest32<N> &key, const std::size_t seed = 0)
+#else
+uint qHash(const Digest32<N> &key, const uint seed = 0)
+#endif
 {
     return ::qHash(std::hash<typename Digest32<N>::UnderlyingType>()(key), seed);
 }

--- a/src/base/net/downloadmanager.cpp
+++ b/src/base/net/downloadmanager.cpp
@@ -364,7 +364,11 @@ Net::ServiceID Net::ServiceID::fromURL(const QUrl &url)
     return {url.host(), url.port(80)};
 }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+std::size_t Net::qHash(const ServiceID &serviceID, const std::size_t seed)
+#else
 uint Net::qHash(const ServiceID &serviceID, const uint seed)
+#endif
 {
     return ::qHash(serviceID.hostName, seed) ^ ::qHash(serviceID.port);
 }

--- a/src/base/net/downloadmanager.cpp
+++ b/src/base/net/downloadmanager.cpp
@@ -366,12 +366,15 @@ Net::ServiceID Net::ServiceID::fromURL(const QUrl &url)
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 std::size_t Net::qHash(const ServiceID &serviceID, const std::size_t seed)
+{
+    return qHashMulti(seed, serviceID.hostName, serviceID.port);
+}
 #else
 uint Net::qHash(const ServiceID &serviceID, const uint seed)
-#endif
 {
     return ::qHash(serviceID.hostName, seed) ^ ::qHash(serviceID.port);
 }
+#endif
 
 bool Net::operator==(const ServiceID &lhs, const ServiceID &rhs)
 {

--- a/src/base/net/downloadmanager.h
+++ b/src/base/net/downloadmanager.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include <QtGlobal>
 #include <QHash>
 #include <QNetworkAccessManager>
 #include <QObject>
@@ -52,7 +53,11 @@ namespace Net
         static ServiceID fromURL(const QUrl &url);
     };
 
-    uint qHash(const ServiceID &serviceID, uint seed);
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    std::size_t qHash(const ServiceID &serviceID, std::size_t seed = 0);
+#else
+    uint qHash(const ServiceID &serviceID, uint seed = 0);
+#endif
     bool operator==(const ServiceID &lhs, const ServiceID &rhs);
 
     enum class DownloadStatus

--- a/src/base/path.cpp
+++ b/src/base/path.cpp
@@ -332,7 +332,11 @@ QDataStream &operator>>(QDataStream &in, Path &path)
     return in;
 }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+std::size_t qHash(const Path &key, const std::size_t seed)
+#else
 uint qHash(const Path &key, const uint seed)
+#endif
 {
     return ::qHash(key.data(), seed);
 }

--- a/src/base/path.h
+++ b/src/base/path.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include <QtGlobal>
 #include <QMetaType>
 #include <QString>
 
@@ -96,4 +97,8 @@ Path operator+(const Path &lhs, const std::string &rhs);
 QDataStream &operator<<(QDataStream &out, const Path &path);
 QDataStream &operator>>(QDataStream &in, Path &path);
 
-uint qHash(const Path &key, uint seed);
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+std::size_t qHash(const Path &key, std::size_t seed = 0);
+#else
+uint qHash(const Path &key, uint seed = 0);
+#endif

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -30,6 +30,7 @@
 
 #include <algorithm>
 
+#include <QtGlobal>
 #include <QApplication>
 #include <QClipboard>
 #include <QHeaderView>
@@ -70,7 +71,11 @@ bool operator==(const PeerEndpoint &left, const PeerEndpoint &right)
     return (left.address == right.address) && (left.connectionType == right.connectionType);
 }
 
-uint qHash(const PeerEndpoint &peerEndpoint, const uint seed)
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+std::size_t qHash(const PeerEndpoint &peerEndpoint, const std::size_t seed = 0)
+#else
+uint qHash(const PeerEndpoint &peerEndpoint, const uint seed = 0)
+#endif
 {
     return (qHash(peerEndpoint.address, seed) ^ ::qHash(peerEndpoint.connectionType));
 }

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -73,12 +73,15 @@ bool operator==(const PeerEndpoint &left, const PeerEndpoint &right)
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 std::size_t qHash(const PeerEndpoint &peerEndpoint, const std::size_t seed = 0)
+{
+    return qHashMulti(seed, peerEndpoint.address, peerEndpoint.connectionType);
+}
 #else
 uint qHash(const PeerEndpoint &peerEndpoint, const uint seed = 0)
-#endif
 {
     return (qHash(peerEndpoint.address, seed) ^ ::qHash(peerEndpoint.connectionType));
 }
+#endif
 
 PeerListWidget::PeerListWidget(PropertiesWidget *parent)
     : QTreeView(parent)


### PR DESCRIPTION
* Update function signature for Qt6 qHash()
  Since the `qhash()` signature has changed in Qt6.
* Avoid redundant hashing
  The return type of `std::hash()` is larger (or equal) than what `qHash()` requires so we can omit hashing it again.
* Use hashing helpers provided by Qt6
