### PR TITLE
Add horizontal scrolling for tracker list and torrent content

### DIFF
--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -530,9 +530,9 @@ void PeerListWidget::wheelEvent(QWheelEvent *event)
     {
         // Shift + scroll = horizontal scroll
         event->accept();
-        QWheelEvent scrollHEvent(event->position(), event->globalPosition()
+        QWheelEvent scrollHEvent {event->position(), event->globalPosition()
             , event->pixelDelta(), event->angleDelta().transposed(), event->buttons()
-            , event->modifiers(), event->phase(), event->inverted(), event->source());
+            , event->modifiers(), event->phase(), event->inverted(), event->source()};
         QTreeView::wheelEvent(&scrollHEvent);
         return;
     }

--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -41,6 +41,7 @@
 #include <QTreeWidgetItem>
 #include <QUrl>
 #include <QVector>
+#include <QWheelEvent>
 
 #include "base/bittorrent/peerinfo.h"
 #include "base/bittorrent/session.h"
@@ -682,4 +683,20 @@ void TrackerListWidget::displayColumnHeaderMenu()
     resizeAction->setToolTip(tr("Resize all non-hidden columns to the size of their contents"));
 
     menu->popup(QCursor::pos());
+}
+
+void TrackerListWidget::wheelEvent(QWheelEvent *event)
+{
+    if (event->modifiers() & Qt::ShiftModifier)
+    {
+        // Shift + scroll = horizontal scroll
+        event->accept();
+        QWheelEvent scrollHEvent {event->position(), event->globalPosition()
+            , event->pixelDelta(), event->angleDelta().transposed(), event->buttons()
+            , event->modifiers(), event->phase(), event->inverted(), event->source()};
+        QTreeView::wheelEvent(&scrollHEvent);
+        return;
+    }
+
+    QTreeView::wheelEvent(event);  // event delegated to base class
 }

--- a/src/gui/properties/trackerlistwidget.h
+++ b/src/gui/properties/trackerlistwidget.h
@@ -87,6 +87,7 @@ private slots:
 
 private:
     int visibleColumnsCount() const;
+    void wheelEvent(QWheelEvent *event) override;
 
     static QStringList headerLabels();
 

--- a/src/gui/torrentcontenttreeview.cpp
+++ b/src/gui/torrentcontenttreeview.cpp
@@ -35,6 +35,7 @@
 #include <QMessageBox>
 #include <QModelIndexList>
 #include <QThread>
+#include <QWheelEvent>
 
 #include "base/bittorrent/abstractfilestorage.h"
 #include "base/bittorrent/common.h"
@@ -151,4 +152,20 @@ QModelIndex TorrentContentTreeView::currentNameCell()
     }
 
     return model()->index(current.row(), TorrentContentModelItem::COL_NAME, current.parent());
+}
+
+void TorrentContentTreeView::wheelEvent(QWheelEvent *event)
+{
+    if (event->modifiers() & Qt::ShiftModifier)
+    {
+        // Shift + scroll = horizontal scroll
+        event->accept();
+        QWheelEvent scrollHEvent {event->position(), event->globalPosition()
+            , event->pixelDelta(), event->angleDelta().transposed(), event->buttons()
+            , event->modifiers(), event->phase(), event->inverted(), event->source()};
+        QTreeView::wheelEvent(&scrollHEvent);
+        return;
+    }
+
+    QTreeView::wheelEvent(event);  // event delegated to base class
 }

--- a/src/gui/torrentcontenttreeview.h
+++ b/src/gui/torrentcontenttreeview.h
@@ -50,4 +50,5 @@ public:
 
 private:
     QModelIndex currentNameCell();
+    void wheelEvent(QWheelEvent *event) override;
 };

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -1248,9 +1248,9 @@ void TransferListWidget::wheelEvent(QWheelEvent *event)
     {
         // Shift + scroll = horizontal scroll
         event->accept();
-        QWheelEvent scrollHEvent(event->position(), event->globalPosition()
+        QWheelEvent scrollHEvent {event->position(), event->globalPosition()
             , event->pixelDelta(), event->angleDelta().transposed(), event->buttons()
-            , event->modifiers(), event->phase(), event->inverted(), event->source());
+            , event->modifiers(), event->phase(), event->inverted(), event->source()};
         QTreeView::wheelEvent(&scrollHEvent);
         return;
     }


### PR DESCRIPTION
Horizontal scrolling was added to the peer list and torrent list, but I see no reason why it should not also be applied to the tracker list and especially the torrent content list. Tested on Windows 10.