### PR TITLE
Change Downloaded to Times Downloaded in trackers tab

### DIFF
--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -114,16 +114,16 @@ TrackerListWidget::TrackerListWidget(PropertiesWidget *properties)
     m_DHTItem->setTextAlignment(COL_LEECHES, alignment);
     m_PEXItem->setTextAlignment(COL_LEECHES, alignment);
     m_LSDItem->setTextAlignment(COL_LEECHES, alignment);
-    m_DHTItem->setTextAlignment(COL_DOWNLOADED, alignment);
-    m_PEXItem->setTextAlignment(COL_DOWNLOADED, alignment);
-    m_LSDItem->setTextAlignment(COL_DOWNLOADED, alignment);
+    m_DHTItem->setTextAlignment(COL_TIMES_DOWNLOADED, alignment);
+    m_PEXItem->setTextAlignment(COL_TIMES_DOWNLOADED, alignment);
+    m_LSDItem->setTextAlignment(COL_TIMES_DOWNLOADED, alignment);
 
     // Set header alignment
     headerItem()->setTextAlignment(COL_TIER, alignment);
     headerItem()->setTextAlignment(COL_PEERS, alignment);
     headerItem()->setTextAlignment(COL_SEEDS, alignment);
     headerItem()->setTextAlignment(COL_LEECHES, alignment);
-    headerItem()->setTextAlignment(COL_DOWNLOADED, alignment);
+    headerItem()->setTextAlignment(COL_TIMES_DOWNLOADED, alignment);
 
     // Set hotkeys
     const auto *editHotkey = new QShortcut(Qt::Key_F2, this, nullptr, nullptr, Qt::WidgetShortcut);
@@ -406,7 +406,7 @@ void TrackerListWidget::loadTrackers()
         item->setText(COL_LEECHES, ((entry.numLeeches > -1)
             ? QString::number(entry.numLeeches)
             : tr("N/A")));
-        item->setText(COL_DOWNLOADED, ((entry.numDownloaded > -1)
+        item->setText(COL_TIMES_DOWNLOADED, ((entry.numDownloaded > -1)
             ? QString::number(entry.numDownloaded)
             : tr("N/A")));
 
@@ -415,7 +415,7 @@ void TrackerListWidget::loadTrackers()
         item->setTextAlignment(COL_PEERS, alignment);
         item->setTextAlignment(COL_SEEDS, alignment);
         item->setTextAlignment(COL_LEECHES, alignment);
-        item->setTextAlignment(COL_DOWNLOADED, alignment);
+        item->setTextAlignment(COL_TIMES_DOWNLOADED, alignment);
     }
 
     // Remove old trackers
@@ -628,7 +628,7 @@ QStringList TrackerListWidget::headerLabels()
         , tr("Peers")
         , tr("Seeds")
         , tr("Leeches")
-        , tr("Downloaded")
+        , tr("Times Downloaded")
         , tr("Message")
     };
 }

--- a/src/gui/properties/trackerlistwidget.h
+++ b/src/gui/properties/trackerlistwidget.h
@@ -52,7 +52,7 @@ public:
         COL_PEERS,
         COL_SEEDS,
         COL_LEECHES,
-        COL_DOWNLOADED,
+        COL_TIMES_DOWNLOADED,
         COL_MSG,
 
         COL_COUNT

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1742,7 +1742,7 @@ window.qBittorrent.DynamicTable = (function() {
             this.newColumn('peers', '', 'QBT_TR(Peers)QBT_TR[CONTEXT=TrackerListWidget]', 75, true);
             this.newColumn('seeds', '', 'QBT_TR(Seeds)QBT_TR[CONTEXT=TrackerListWidget]', 75, true);
             this.newColumn('leeches', '', 'QBT_TR(Leeches)QBT_TR[CONTEXT=TrackerListWidget]', 75, true);
-            this.newColumn('downloaded', '', 'QBT_TR(Downloaded)QBT_TR[CONTEXT=TrackerListWidget]', 100, true);
+            this.newColumn('downloaded', '', 'QBT_TR(Times Downloaded)QBT_TR[CONTEXT=TrackerListWidget]', 100, true);
             this.newColumn('message', '', 'QBT_TR(Message)QBT_TR[CONTEXT=TrackerListWidget]', 250, true);
         },
     });


### PR DESCRIPTION
Change the confusing `Downloaded` column name in trackers tab.
Closes https://github.com/qbittorrent/qBittorrent/issues/14918
