### PR TITLE
Add a filter to identify torrents with no working trackers

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -5444,6 +5444,8 @@ void Session::handleTrackerAlert(const lt::tracker_alert *a)
     if (!torrent)
         return;
 
+    torrent->setHasNoWorkingTracker(torrent->hasWorkingTracker());
+
     const auto trackerURL = QString::fromUtf8(a->tracker_url());
     m_updatedTrackerEntries[torrent].insert(trackerURL);
 

--- a/src/base/bittorrent/torrent.h
+++ b/src/base/bittorrent/torrent.h
@@ -97,6 +97,7 @@ namespace BitTorrent
         Moving,
 
         MissingFiles,
+        NoWorkingTracker,
         Error
     };
 
@@ -223,6 +224,8 @@ namespace BitTorrent
         virtual bool hasMetadata() const = 0;
         virtual bool hasMissingFiles() const = 0;
         virtual bool hasError() const = 0;
+        virtual bool hasNoWorkingTracker() const = 0;
+        virtual void setHasNoWorkingTracker(bool enabled) = 0;
         virtual int queuePosition() const = 0;
         virtual QVector<TrackerEntry> trackers() const = 0;
         virtual QVector<QUrl> urlSeeds() const = 0;

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -514,6 +514,27 @@ QVector<TrackerEntry> TorrentImpl::trackers() const
     return m_trackerEntries;
 }
 
+void TorrentImpl::setHasNoWorkingTracker(const bool enabled)
+{
+    m_hasWorkingTracker = enabled;
+}
+
+bool TorrentImpl::hasNoWorkingTracker() const
+{
+    return !m_hasWorkingTracker;
+}
+
+bool TorrentImpl::hasWorkingTracker() const
+{
+    const QVector<TrackerEntry> currentTrackers = trackers();
+    if (currentTrackers.empty())
+        return true;
+    return std::any_of(currentTrackers.cbegin(), currentTrackers.cend(), [](const TrackerEntry &entry)
+    {
+        return entry.status == TrackerEntry::Working;
+    });
+}
+
 void TorrentImpl::addTrackers(QVector<TrackerEntry> trackers)
 {
     // TODO: use std::erase_if() in C++20

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -155,6 +155,9 @@ namespace BitTorrent
         bool hasMetadata() const override;
         bool hasMissingFiles() const override;
         bool hasError() const override;
+        void setHasNoWorkingTracker(bool enabled) override;
+        bool hasNoWorkingTracker() const override;
+        bool hasWorkingTracker() const;
         int queuePosition() const override;
         QVector<TrackerEntry> trackers() const override;
         QVector<QUrl> urlSeeds() const override;
@@ -333,6 +336,7 @@ namespace BitTorrent
         bool m_hasFirstLastPiecePriority = false;
         bool m_useAutoTMM;
         bool m_isStopped;
+        bool m_hasWorkingTracker = true;
 
         bool m_unchecked = false;
 

--- a/src/base/torrentfilter.cpp
+++ b/src/base/torrentfilter.cpp
@@ -46,6 +46,7 @@ const TorrentFilter TorrentFilter::StalledTorrent(TorrentFilter::Stalled);
 const TorrentFilter TorrentFilter::StalledUploadingTorrent(TorrentFilter::StalledUploading);
 const TorrentFilter TorrentFilter::StalledDownloadingTorrent(TorrentFilter::StalledDownloading);
 const TorrentFilter TorrentFilter::CheckingTorrent(TorrentFilter::Checking);
+const TorrentFilter TorrentFilter::NoWorkingTrackerTorrent(TorrentFilter::NoWorkingTracker);
 const TorrentFilter TorrentFilter::ErroredTorrent(TorrentFilter::Errored);
 
 using BitTorrent::Torrent;
@@ -106,6 +107,8 @@ bool TorrentFilter::setTypeByName(const QString &filter)
         type = StalledDownloading;
     else if (filter == u"checking")
         type = Checking;
+    else if (filter == u"no_working_tracker")
+        type = NoWorkingTracker;
     else if (filter == u"errored")
         type = Errored;
 
@@ -184,6 +187,8 @@ bool TorrentFilter::matchState(const BitTorrent::Torrent *const torrent) const
         return (torrent->state() == BitTorrent::TorrentState::CheckingUploading)
                 || (torrent->state() == BitTorrent::TorrentState::CheckingDownloading)
                 || (torrent->state() == BitTorrent::TorrentState::CheckingResumeData);
+    case NoWorkingTracker:
+        return torrent->hasNoWorkingTracker();
     case Errored:
         return torrent->isErrored();
     }

--- a/src/base/torrentfilter.h
+++ b/src/base/torrentfilter.h
@@ -59,6 +59,7 @@ public:
         StalledUploading,
         StalledDownloading,
         Checking,
+        NoWorkingTracker,
         Errored
     };
 
@@ -78,6 +79,7 @@ public:
     static const TorrentFilter StalledUploadingTorrent;
     static const TorrentFilter StalledDownloadingTorrent;
     static const TorrentFilter CheckingTorrent;
+    static const TorrentFilter NoWorkingTrackerTorrent;
     static const TorrentFilter ErroredTorrent;
 
     TorrentFilter() = default;

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -207,6 +207,9 @@ StatusFilterWidget::StatusFilterWidget(QWidget *parent, TransferListWidget *tran
     auto *checking = new QListWidgetItem(this);
     checking->setData(Qt::DisplayRole, tr("Checking (0)"));
     checking->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"force-recheck"_qs));
+    auto *noWorkingTracker = new QListWidgetItem(this);
+    noWorkingTracker->setData(Qt::DisplayRole, tr("No Working Tracker (0)"));
+    noWorkingTracker->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"error"_qs));
     auto *errored = new QListWidgetItem(this);
     errored->setData(Qt::DisplayRole, tr("Errored (0)"));
     errored->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"error"_qs));
@@ -267,6 +270,7 @@ void StatusFilterWidget::updateTorrentStatus(const BitTorrent::Torrent *torrent)
     update(TorrentFilter::StalledUploading, m_nbStalledUploading);
     update(TorrentFilter::StalledDownloading, m_nbStalledDownloading);
     update(TorrentFilter::Checking, m_nbChecking);
+    update(TorrentFilter::NoWorkingTracker, m_nbNoWorkingTracker);
     update(TorrentFilter::Errored, m_nbErrored);
 
     m_nbStalled = m_nbStalledUploading + m_nbStalledDownloading;
@@ -287,6 +291,7 @@ void StatusFilterWidget::updateTexts()
     item(TorrentFilter::StalledUploading)->setData(Qt::DisplayRole, tr("Stalled Uploading (%1)").arg(m_nbStalledUploading));
     item(TorrentFilter::StalledDownloading)->setData(Qt::DisplayRole, tr("Stalled Downloading (%1)").arg(m_nbStalledDownloading));
     item(TorrentFilter::Checking)->setData(Qt::DisplayRole, tr("Checking (%1)").arg(m_nbChecking));
+    item(TorrentFilter::NoWorkingTracker)->setData(Qt::DisplayRole, tr("No Working Tracker (%1)").arg(m_nbNoWorkingTracker));
     item(TorrentFilter::Errored)->setData(Qt::DisplayRole, tr("Errored (%1)").arg(m_nbErrored));
 }
 
@@ -350,6 +355,8 @@ void StatusFilterWidget::torrentAboutToBeDeleted(BitTorrent::Torrent *const torr
         --m_nbStalledDownloading;
     if (status[TorrentFilter::Checking])
         --m_nbChecking;
+    if (status[TorrentFilter::NoWorkingTracker])
+        --m_nbNoWorkingTracker;
     if (status[TorrentFilter::Errored])
         --m_nbErrored;
 

--- a/src/gui/transferlistfilterswidget.h
+++ b/src/gui/transferlistfilterswidget.h
@@ -112,6 +112,7 @@ private:
     int m_nbStalledUploading = 0;
     int m_nbStalledDownloading = 0;
     int m_nbChecking = 0;
+    int m_nbNoWorkingTracker = 0;
     int m_nbErrored = 0;
 };
 


### PR DESCRIPTION
closes https://github.com/qbittorrent/qBittorrent/issues/9849
my previous PR https://github.com/qbittorrent/qBittorrent/pull/12697

This PR just adds a status filter to find torrents with no working trackers.
This feature is specially useful to private tracker users where torrents can be deleted/banned and there's no easy way to find such torrents currently in the GUI/WebUI.

I'll implement the WebUI parts later once the GUI parts are sorted out.
<s>Currently there's one bug with the count in the filter, i.e filter shows torrent with no working tracker but the count is incorrect.</s>

Screenshot (updated):
![asdxxxzaaa](https://user-images.githubusercontent.com/79678786/162605924-5687070f-e74a-4349-9d76-5a6358d11764.png)

