### PR TITLE
Avoid integer overflow when calculating working set size

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -799,7 +799,7 @@ void Application::shutdownCleanup(QSessionManager &manager)
 #ifdef Q_OS_WIN
 void Application::applyMemoryWorkingSetLimit()
 {
-    const int UNIT_SIZE = 1024 * 1024; // MiB
+    const SIZE_T UNIT_SIZE = 1024 * 1024; // MiB
     const SIZE_T maxSize = memoryWorkingSetLimit() * UNIT_SIZE;
     const SIZE_T minSize = std::min<SIZE_T>((64 * UNIT_SIZE), (maxSize / 2));
     if (!::SetProcessWorkingSetSizeEx(::GetCurrentProcess(), minSize, maxSize, QUOTA_LIMITS_HARDWS_MAX_ENABLE))


### PR DESCRIPTION
Otherwise it is impossible to apply working set size larger than 4095 MiB.