### PR TITLE
Use proper type to represent a path

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -403,14 +403,13 @@ void Application::runExternalProgram(const BitTorrent::Torrent *torrent) const
     LogMsg(tr("Torrent: %1, running external program, command: %2").arg(torrent->name(), program));
 
 #if defined(Q_OS_WIN)
-    auto programWchar = std::make_unique<wchar_t[]>(program.length() + 1);
-    program.toWCharArray(programWchar.get());
+    const std::wstring programWStr = program.toStdWString();
 
     // Need to split arguments manually because QProcess::startDetached(QString)
     // will strip off empty parameters.
     // E.g. `python.exe "1" "" "3"` will become `python.exe "1" "3"`
     int argCount = 0;
-    std::unique_ptr<LPWSTR[], decltype(&::LocalFree)> args {::CommandLineToArgvW(programWchar.get(), &argCount), ::LocalFree};
+    std::unique_ptr<LPWSTR[], decltype(&::LocalFree)> args {::CommandLineToArgvW(programWStr.c_str(), &argCount), ::LocalFree};
 
     QStringList argList;
     for (int i = 1; i < argCount; ++i)
@@ -836,8 +835,9 @@ void Application::cleanup()
         m_window->hide();
 
 #ifdef Q_OS_WIN
+        const std::wstring msg = tr("Saving torrent progress...").toStdWString();
         ::ShutdownBlockReasonCreate(reinterpret_cast<HWND>(m_window->effectiveWinId())
-            , tr("Saving torrent progress...").toStdWString().c_str());
+            , msg.c_str());
 #endif // Q_OS_WIN
 
         // Do manual cleanup in MainWindow to force widgets

--- a/src/app/qtlocalpeer/qtlockedfile_win.cpp
+++ b/src/app/qtlocalpeer/qtlockedfile_win.cpp
@@ -87,9 +87,11 @@ Qt::HANDLE QtLockedFile::getMutexHandle(const int idx, const bool doCreate)
     if (idx >= 0)
         mname += QString::number(idx);
 
+    const std::wstring mnameWStr = mname.toStdWString();
+
     if (doCreate)
     {
-        const Qt::HANDLE mutex = ::CreateMutexW(NULL, FALSE, reinterpret_cast<const TCHAR *>(mname.utf16()));
+        const Qt::HANDLE mutex = ::CreateMutexW(NULL, FALSE, mnameWStr.c_str());
         if (!mutex)
         {
             qErrnoWarning("QtLockedFile::lock(): CreateMutex failed");
@@ -100,7 +102,7 @@ Qt::HANDLE QtLockedFile::getMutexHandle(const int idx, const bool doCreate)
     }
     else
     {
-        const Qt::HANDLE mutex = ::OpenMutexW((SYNCHRONIZE | MUTEX_MODIFY_STATE), FALSE, reinterpret_cast<const TCHAR *>(mname.utf16()));
+        const Qt::HANDLE mutex = ::OpenMutexW((SYNCHRONIZE | MUTEX_MODIFY_STATE), FALSE, mnameWStr.c_str());
         if (!mutex)
         {
             if (GetLastError() != ERROR_FILE_NOT_FOUND)

--- a/src/app/stacktrace_win.h
+++ b/src/app/stacktrace_win.h
@@ -257,9 +257,10 @@ const QString straceWin::getBacktrace()
     QTextStream logStream(&log);
     logStream << "```\n";
 
+    const std::wstring appPath = QCoreApplication::applicationDirPath().toStdWString();
     HANDLE hProcess = GetCurrentProcess();
     HANDLE hThread = GetCurrentThread();
-    SymInitializeW(hProcess, QCoreApplication::applicationDirPath().toStdWString().c_str(), TRUE);
+    SymInitializeW(hProcess, appPath.c_str(), TRUE);
 
     DWORD64 dwDisplacement;
 

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -279,8 +279,9 @@ namespace
         if (!uuid.isNull())
             return uuid.toString().toUpper(); // Libtorrent expects the GUID in uppercase
 
+        const std::wstring nameWStr = name.toStdWString();
         NET_LUID luid {};
-        const LONG res = ::ConvertInterfaceNameToLuidW(name.toStdWString().c_str(), &luid);
+        const LONG res = ::ConvertInterfaceNameToLuidW(nameWStr.c_str(), &luid);
         if (res == 0)
         {
             GUID guid;

--- a/src/base/utils/foreignapps.cpp
+++ b/src/base/utils/foreignapps.cpp
@@ -128,26 +128,17 @@ namespace
 
     QString getRegValue(const HKEY handle, const QString &name = {})
     {
-        QString result;
-
+        const std::wstring nameWStr = name.toStdWString();
         DWORD type = 0;
         DWORD cbData = 0;
-        LPWSTR lpValueName = NULL;
-        if (!name.isEmpty())
-        {
-            lpValueName = new WCHAR[name.size() + 1];
-            name.toWCharArray(lpValueName);
-            lpValueName[name.size()] = 0;
-        }
 
         // Discover the size of the value
-        ::RegQueryValueExW(handle, lpValueName, NULL, &type, NULL, &cbData);
+        ::RegQueryValueExW(handle, nameWStr.c_str(), NULL, &type, NULL, &cbData);
         DWORD cBuffer = (cbData / sizeof(WCHAR)) + 1;
         LPWSTR lpData = new WCHAR[cBuffer];
-        LONG res = ::RegQueryValueExW(handle, lpValueName, NULL, &type, (LPBYTE)lpData, &cbData);
-        if (lpValueName)
-            delete[] lpValueName;
+        LONG res = ::RegQueryValueExW(handle, nameWStr.c_str(), NULL, &type, (LPBYTE)lpData, &cbData);
 
+        QString result;
         if (res == ERROR_SUCCESS)
         {
             lpData[cBuffer - 1] = 0;
@@ -186,18 +177,14 @@ namespace
             bool found = false;
             while (!found && !versions.empty())
             {
-                const QString version = versions.takeLast() + u"\\InstallPath";
-                LPWSTR lpSubkey = new WCHAR[version.size() + 1];
-                version.toWCharArray(lpSubkey);
-                lpSubkey[version.size()] = 0;
+                const std::wstring version = QString(versions.takeLast() + u"\\InstallPath").toStdWString();
 
                 HKEY hkInstallPath;
-                res = ::RegOpenKeyExW(hkPythonCore, lpSubkey, 0, samDesired, &hkInstallPath);
-                delete[] lpSubkey;
+                res = ::RegOpenKeyExW(hkPythonCore, version.c_str(), 0, samDesired, &hkInstallPath);
 
                 if (res == ERROR_SUCCESS)
                 {
-                    qDebug("Detected possible Python v%s location", qUtf8Printable(version));
+                    qDebug("Detected possible Python v%ls location", version.c_str());
                     path = getRegValue(hkInstallPath);
                     ::RegCloseKey(hkInstallPath);
 

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -31,6 +31,8 @@
 #include <optional>
 
 #ifdef Q_OS_WIN
+#include <memory>
+
 #include <windows.h>
 #include <powrprof.h>
 #include <Shlobj.h>
@@ -393,7 +395,7 @@ QString Utils::Misc::getUserIDString()
     const int UNLEN = 256;
     WCHAR buffer[UNLEN + 1] = {0};
     DWORD buffer_len = sizeof(buffer) / sizeof(*buffer);
-    if (GetUserNameW(buffer, &buffer_len))
+    if (::GetUserNameW(buffer, &buffer_len))
         uid = QString::fromWCharArray(buffer);
 #else
     uid = QString::number(getuid());

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -61,7 +61,6 @@
 #include <QDBusInterface>
 #endif
 
-#include "base/path.h"
 #include "base/types.h"
 #include "base/unicodestrings.h"
 #include "base/utils/fs.h"
@@ -510,13 +509,13 @@ QString Utils::Misc::zlibVersionString()
 }
 
 #ifdef Q_OS_WIN
-QString Utils::Misc::windowsSystemPath()
+Path Utils::Misc::windowsSystemPath()
 {
-    static const QString path = []() -> QString
+    static const Path path = []() -> Path
     {
         WCHAR systemPath[MAX_PATH] = {0};
         GetSystemDirectoryW(systemPath, sizeof(systemPath) / sizeof(WCHAR));
-        return QString::fromWCharArray(systemPath);
+        return Path(QString::fromWCharArray(systemPath));
     }();
     return path;
 }

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -31,7 +31,6 @@
 #include <QtGlobal>
 
 #ifdef Q_OS_WIN
-#include <memory>
 #include <Windows.h>
 #endif
 
@@ -92,9 +91,8 @@ namespace Utils::Misc
     template <typename T>
     T loadWinAPI(const QString &source, const char *funcName)
     {
-        const QString path = (windowsSystemPath() / Path(source)).toString();
-        return reinterpret_cast<T>(::GetProcAddress(::LoadLibraryW(
-            path.toStdWString().c_str()), funcName));
+        const std::wstring path = (windowsSystemPath() / Path(source)).toString().toStdWString();
+        return reinterpret_cast<T>(::GetProcAddress(::LoadLibraryW(path.c_str()), funcName));
     }
 #endif // Q_OS_WIN
 }

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -37,7 +37,7 @@
 
 #include <QString>
 
-#include "base/pathfwd.h"
+#include "base/path.h"
 
 enum class ShutdownDialogAction;
 
@@ -87,22 +87,14 @@ namespace Utils::Misc
     QString getUserIDString();
 
 #ifdef Q_OS_WIN
-    QString windowsSystemPath();
+    Path windowsSystemPath();
 
     template <typename T>
     T loadWinAPI(const QString &source, const char *funcName)
     {
-        QString path = windowsSystemPath();
-        if (!path.endsWith(u'\\'))
-            path += u'\\';
-
-        path += source;
-
-        auto pathWchar = std::make_unique<wchar_t[]>(path.length() + 1);
-        path.toWCharArray(pathWchar.get());
-
-        return reinterpret_cast<T>(
-            ::GetProcAddress(::LoadLibraryW(pathWchar.get()), funcName));
+        const QString path = (windowsSystemPath() / Path(source)).toString();
+        return reinterpret_cast<T>(::GetProcAddress(::LoadLibraryW(
+            path.toStdWString().c_str()), funcName));
     }
 #endif // Q_OS_WIN
 }

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -114,9 +114,9 @@ namespace
     {
         QPixmap pixmapForExtension(const QString &ext) const override
         {
-            const QString extWithDot = QLatin1Char('.') + ext;
+            const std::wstring extWStr = QString(u'.' + ext).toStdWString();
             SHFILEINFO sfi {};
-            HRESULT hr = ::SHGetFileInfoW(extWithDot.toStdWString().c_str(),
+            HRESULT hr = ::SHGetFileInfoW(extWStr.c_str(),
                 FILE_ATTRIBUTE_NORMAL, &sfi, sizeof(sfi), SHGFI_ICON | SHGFI_USEFILEATTRIBUTES);
             if (FAILED(hr))
                 return {};

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -164,7 +164,8 @@ void Utils::Gui::openFolderSelect(const Path &path)
     {
         if (SUCCEEDED(::CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE)))
         {
-            PIDLIST_ABSOLUTE pidl = ::ILCreateFromPathW(reinterpret_cast<const wchar_t *>(path.toString().utf16()));
+            const std::wstring pathWStr = path.toString().toStdWString();
+            PIDLIST_ABSOLUTE pidl = ::ILCreateFromPathW(pathWStr.c_str());
             if (pidl)
             {
                 ::SHOpenFolderAndSelectItems(pidl, 0, nullptr, 0);


### PR DESCRIPTION
* Use proper type to represent a path
* Don't use explicit memory management