### PR TITLE
GHA CI: work around error when installing Qt 

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -53,6 +53,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v2
         with:
+          setup-python: false
           version: ${{ matrix.qt_version }}
 
       - name: Install libtorrent

--- a/src/gui/properties/downloadedpiecesbar.cpp
+++ b/src/gui/properties/downloadedpiecesbar.cpp
@@ -34,6 +34,8 @@
 #include <QDebug>
 #include <QVector>
 
+#include "base/global.h"
+
 namespace
 {
     QColor dlPieceColor(const QColor &pieceColor)

--- a/src/gui/properties/pieceavailabilitybar.cpp
+++ b/src/gui/properties/pieceavailabilitybar.cpp
@@ -33,6 +33,8 @@
 
 #include <QDebug>
 
+#include "base/global.h"
+
 PieceAvailabilityBar::PieceAvailabilityBar(QWidget *parent)
     : base {parent}
 {


### PR DESCRIPTION
* Add missing header
  Fix up https://github.com/qbittorrent/qBittorrent/commit/75c93d72be7a31f29d6c14aa6f3eefa8ec9f9ea1.
* GHA CI: work around error when installing Qt
  This is to (temporarily) work around CI errors at jurplel/install-qt-action.
  Upstream issue: https://github.com/jurplel/install-qt-action/issues/130