### PR TITLE
GHA CI: work around error when installing Qt (backport)

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -48,6 +48,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v2
         with:
+          setup-python: false
           version: ${{ matrix.qt_version }}
 
       - name: Install libtorrent


### PR DESCRIPTION
Original PR #16767.