### PR TITLE
WebUI: show correct location path 

### DIFF
--- a/src/webui/www/private/newcategory.html
+++ b/src/webui/www/private/newcategory.html
@@ -132,9 +132,9 @@
 <body>
     <div style="padding: 10px 10px 0px 10px;">
         <p style="font-weight: bold;">QBT_TR(Category)QBT_TR[CONTEXT=TransferListWidget]:</p>
-        <input type="text" id="categoryName" style="width: 220px;" />
+        <input type="text" id="categoryName" style="width: 99%;" />
         <p style="font-weight: bold;">QBT_TR(Save path)QBT_TR[CONTEXT=TransferListWidget]:</p>
-        <input type="text" id="savePath" style="width: 220px;" />
+        <input type="text" id="savePath" style="width: 99%;" />
         <div style="text-align: center; padding-top: 10px;">
             <input type="button" value="QBT_TR(Add)QBT_TR[CONTEXT=HttpServer]" id="categoryNameButton" />
         </div>

--- a/src/webui/www/private/newtag.html
+++ b/src/webui/www/private/newtag.html
@@ -95,7 +95,7 @@
 <body>
     <div style="padding: 10px 10px 0px 10px;">
         <p id="legendText" style="font-weight: bold;">QBT_TR(Comma-separated tags:)QBT_TR[CONTEXT=TransferListWidget]</p>
-        <input type="text" id="tagName" style="width: 220px;" />
+        <input type="text" id="tagName" style="width: 99%;" />
         <div style="text-align: center; padding-top: 10px;">
             <input type="button" value="QBT_TR(Add)QBT_TR[CONTEXT=HttpServer]" id="tagNameButton" />
         </div>

--- a/src/webui/www/private/rename.html
+++ b/src/webui/www/private/rename.html
@@ -65,7 +65,7 @@
 <body>
     <div style="padding: 10px 10px 0px 10px;">
         <p style="font-weight: bold;">QBT_TR(New name)QBT_TR[CONTEXT=TransferListWidget]:</p>
-        <input type="text" id="rename" style="width: 220px;" />
+        <input type="text" id="rename" style="width: 99%;" />
         <div style="text-align: center; padding-top: 10px;">
             <input type="button" value="QBT_TR(Save)QBT_TR[CONTEXT=HttpServer]" id="renameButton" />
         </div>

--- a/src/webui/www/private/scripts/misc.js
+++ b/src/webui/www/private/scripts/misc.js
@@ -169,7 +169,9 @@ window.qBittorrent.Misc = (function() {
     const escapeHtml = function(str) {
         const div = document.createElement('div');
         div.appendChild(document.createTextNode(str));
-        return div.innerHTML;
+        const escapedString = div.innerHTML;
+        div.remove();
+        return escapedString;
     }
 
     const safeTrim = function(value) {

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -487,7 +487,7 @@ const initializeWindows = function() {
                 id: 'setLocationPage',
                 title: "QBT_TR(Set location)QBT_TR[CONTEXT=TransferListWidget]",
                 loadMethod: 'iframe',
-                contentURL: new URI("setlocation.html").setData("hashes", hashes.join('|')).setData("path", row.full_data.save_path).toString(),
+                contentURL: new URI("setlocation.html").setData("hashes", hashes.join('|')).setData("path", encodeURIComponent(row.full_data.save_path)).toString(),
                 scrollbars: false,
                 resizable: true,
                 maximizable: false,

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -489,7 +489,7 @@ const initializeWindows = function() {
                 loadMethod: 'iframe',
                 contentURL: new URI("setlocation.html").setData("hashes", hashes.join('|')).setData("path", row.full_data.save_path).toString(),
                 scrollbars: false,
-                resizable: false,
+                resizable: true,
                 maximizable: false,
                 paddingVertical: 0,
                 paddingHorizontal: 0,
@@ -511,11 +511,11 @@ const initializeWindows = function() {
                     loadMethod: 'iframe',
                     contentURL: new URI("rename.html").setData("hash", hash).setData("name", row.full_data.name).toString(),
                     scrollbars: false,
-                    resizable: false,
+                    resizable: true,
                     maximizable: false,
                     paddingVertical: 0,
                     paddingHorizontal: 0,
-                    width: 250,
+                    width: 400,
                     height: 100
                 });
             }
@@ -532,11 +532,11 @@ const initializeWindows = function() {
                 loadMethod: 'iframe',
                 contentURL: new URI("newcategory.html").setData("action", action).setData("hashes", hashes.join('|')).toString(),
                 scrollbars: false,
-                resizable: false,
+                resizable: true,
                 maximizable: false,
                 paddingVertical: 0,
                 paddingHorizontal: 0,
-                width: 250,
+                width: 400,
                 height: 150
             });
         }
@@ -567,11 +567,11 @@ const initializeWindows = function() {
             loadMethod: 'iframe',
             contentURL: new URI("newcategory.html").setData("action", action).toString(),
             scrollbars: false,
-            resizable: false,
+            resizable: true,
             maximizable: false,
             paddingVertical: 0,
             paddingHorizontal: 0,
-            width: 250,
+            width: 400,
             height: 150
         });
         updateMainData();
@@ -587,11 +587,11 @@ const initializeWindows = function() {
             loadMethod: 'iframe',
             contentURL: new URI('newcategory.html').setData("action", action).setData("categoryName", categoryName).setData("savePath", savePath).toString(),
             scrollbars: false,
-            resizable: false,
+            resizable: true,
             maximizable: false,
             paddingVertical: 0,
             paddingHorizontal: 0,
-            width: 250,
+            width: 400,
             height: 150
         });
         updateMainData();
@@ -682,7 +682,7 @@ const initializeWindows = function() {
                 loadMethod: 'iframe',
                 contentURL: new URI("newtag.html").setData("action", action).setData("hashes", hashes.join("|")).toString(),
                 scrollbars: false,
-                resizable: false,
+                resizable: true,
                 maximizable: false,
                 paddingVertical: 0,
                 paddingHorizontal: 0,
@@ -728,7 +728,7 @@ const initializeWindows = function() {
             loadMethod: 'iframe',
             contentURL: new URI("newtag.html").setData("action", action).toString(),
             scrollbars: false,
-            resizable: false,
+            resizable: true,
             maximizable: false,
             paddingVertical: 0,
             paddingHorizontal: 0,

--- a/src/webui/www/private/setlocation.html
+++ b/src/webui/www/private/setlocation.html
@@ -31,16 +31,17 @@
 
         window.addEvent('domready', function() {
             const path = new URI().getData('path');
+
             // set text field to current value
             if (path)
-                $('setLocation').value = window.qBittorrent.Misc.escapeHtml(path);
+                $('setLocation').value = decodeURIComponent(path);
 
             $('setLocation').focus();
             $('setLocationButton').addEvent('click', function(e) {
                 new Event(e).stop();
                 // check field
                 const location = $('setLocation').value.trim();
-                if (location === null || location === "") {
+                if ((location === null) || (location === "")) {
                     $('error_div').set('text', 'QBT_TR(Save path is empty)QBT_TR[CONTEXT=TorrentsController]');
                     return false;
                 }

--- a/src/webui/www/private/setlocation.html
+++ b/src/webui/www/private/setlocation.html
@@ -68,8 +68,8 @@
 <body>
     <div style="padding: 10px 10px 0px 10px;">
         <p style="font-weight: bold;">QBT_TR(Location)QBT_TR[CONTEXT=TransferListWidget]:</p>
-        <input type="text" id="setLocation" autocorrect="off" autocapitalize="none" style="width: 370px;" />
-        <div style="float: none; width: 370px;" id="error_div">&nbsp;</div>
+        <input type="text" id="setLocation" autocorrect="off" autocapitalize="none" style="width: 99%;" />
+        <div style="float: none; width: 99%;" id="error_div">&nbsp;</div>
         <div style="text-align: center; padding-top: 10px;">
             <input type="button" value="QBT_TR(Save)QBT_TR[CONTEXT=HttpServer]" id="setLocationButton" />
         </div>


### PR DESCRIPTION
* WebUI: make various dialog resizable
  And enlarge dialog default width.
* WebUI: show correct location path
  The `path` might contains '&' (delimit character) so it must be encoded.
  Closes https://github.com/qbittorrent/qBittorrent/issues/15976.
* WebUI: remove temporary element

Before:  [screenshot](https://user-images.githubusercontent.com/9395168/161377883-f14507f4-f964-4946-8acb-89c331659082.png)
After: [screenshot](https://user-images.githubusercontent.com/9395168/161377886-a83c5f2e-df7b-46e7-8ed2-e8803fe46b7b.png)

UPDATE, change verified: https://github.com/qbittorrent/qBittorrent/issues/15976#issuecomment-1085506109