### PR TITLE
CMake: link atomic lib for RISC-V architecture

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -100,6 +100,15 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     target_sources(qbt_app PRIVATE ${qBittorrent_SOURCE_DIR}/src/qbittorrent.exe.manifest)
 endif()
 
+# Add RISC-V support
+# -----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
+if (CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv64")
+    target_link_libraries(qbt_app PUBLIC
+        atomic
+    )
+endif()
+
 # Additional feature dependent configuration
 # -----------------------------------------------------------------------------
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Currently qBittorrent cannot be compiled for `risc-v` architecture, `gcc` compiler raises an error:  
```
/usr/bin/ld: libtorrent-rasterbar.so undefined reference to `__atomic_exchange_1'
```
This is because the `risc-v` architecture does not support 1-byte and 2-byte lock-free atomic operations.  
By linking the atomic lib, `gcc` will statically link the `libatomic` library. Inside that library, the `std::atomic<bool>` used in the project will fallback to the mutex implementation, which is allowed by C++ standard.