### PR TITLE
Migrate away from unsigned integer types

### DIFF
--- a/src/app/stacktrace.h
+++ b/src/app/stacktrace.h
@@ -12,7 +12,7 @@
 #include <vector>
 
 /** Print a demangled stack backtrace of the caller function to FILE* out. */
-static inline void print_stacktrace(FILE *out = stderr, unsigned int max_frames = 63)
+static inline void print_stacktrace(FILE *out = stderr, const int max_frames = 63)
 {
     fprintf(out, "Stack trace:\n");
 

--- a/src/base/bittorrent/cachestatus.h
+++ b/src/base/bittorrent/cachestatus.h
@@ -34,10 +34,10 @@ namespace BitTorrent
 {
     struct CacheStatus
     {
-        quint64 totalUsedBuffers = 0;
-        quint64 jobQueueLength = 0;
-        quint64 averageJobTime = 0;
-        quint64 queuedBytes = 0;
+        qint64 totalUsedBuffers = 0;
+        qint64 jobQueueLength = 0;
+        qint64 averageJobTime = 0;
+        qint64 queuedBytes = 0;
         qreal readRatio = 0;  // TODO: remove when LIBTORRENT_VERSION_NUM >= 20000
     };
 }

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -4702,12 +4702,12 @@ void Session::startUpTorrents()
     }
 }
 
-quint64 Session::getAlltimeDL() const
+qint64 Session::getAlltimeDL() const
 {
     return m_statistics->getAlltimeDL();
 }
 
-quint64 Session::getAlltimeUL() const
+qint64 Session::getAlltimeUL() const
 {
     return m_statistics->getAlltimeUL();
 }
@@ -5201,10 +5201,10 @@ void Session::handleSessionStatsAlert(const lt::session_stats_alert *p)
     const int64_t dhtDownload = stats[m_metricIndices.dht.dhtBytesIn];
     const int64_t dhtUpload = stats[m_metricIndices.dht.dhtBytesOut];
 
-    auto calcRate = [interval](const quint64 previous, const quint64 current)
+    const auto calcRate = [interval](const qint64 previous, const qint64 current) -> qint64
     {
         Q_ASSERT(current >= previous);
-        return static_cast<quint64>((current - previous) / interval);
+        return ((current - previous) / interval);
     };
 
     m_status.payloadDownloadRate = calcRate(m_status.totalPayloadDownload, totalPayloadDownload);

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -469,8 +469,8 @@ namespace BitTorrent
         bool hasRunningSeed() const;
         const SessionStatus &status() const;
         const CacheStatus &cacheStatus() const;
-        quint64 getAlltimeDL() const;
-        quint64 getAlltimeUL() const;
+        qint64 getAlltimeDL() const;
+        qint64 getAlltimeUL() const;
         bool isListening() const;
 
         MaxRatioAction maxRatioAction() const;

--- a/src/base/bittorrent/sessionstatus.h
+++ b/src/base/bittorrent/sessionstatus.h
@@ -39,37 +39,37 @@ namespace BitTorrent
         // Current download rate for the BT
         // session. Payload means that it only take into
         // account "useful" part of the rate
-        quint64 payloadDownloadRate = 0;
+        qint64 payloadDownloadRate = 0;
 
         // Current upload rate for the BT
         // session. Payload means that it only take into
         // account "useful" part of the rate
-        quint64 payloadUploadRate = 0;
+        qint64 payloadUploadRate = 0;
 
         // Additional download/upload rates
-        quint64 uploadRate = 0;
-        quint64 downloadRate = 0;
-        quint64 ipOverheadUploadRate = 0;
-        quint64 ipOverheadDownloadRate = 0;
-        quint64 dhtUploadRate = 0;
-        quint64 dhtDownloadRate = 0;
-        quint64 trackerUploadRate = 0;
-        quint64 trackerDownloadRate = 0;
+        qint64 uploadRate = 0;
+        qint64 downloadRate = 0;
+        qint64 ipOverheadUploadRate = 0;
+        qint64 ipOverheadDownloadRate = 0;
+        qint64 dhtUploadRate = 0;
+        qint64 dhtDownloadRate = 0;
+        qint64 trackerUploadRate = 0;
+        qint64 trackerDownloadRate = 0;
 
-        quint64 totalDownload = 0;
-        quint64 totalUpload = 0;
-        quint64 totalPayloadDownload = 0;
-        quint64 totalPayloadUpload = 0;
-        quint64 ipOverheadUpload = 0;
-        quint64 ipOverheadDownload = 0;
-        quint64 dhtUpload = 0;
-        quint64 dhtDownload = 0;
-        quint64 trackerUpload = 0;
-        quint64 trackerDownload = 0;
-        quint64 totalWasted = 0;
-        quint64 diskReadQueue = 0;
-        quint64 diskWriteQueue = 0;
-        quint64 dhtNodes = 0;
-        quint64 peersCount = 0;
+        qint64 totalDownload = 0;
+        qint64 totalUpload = 0;
+        qint64 totalPayloadDownload = 0;
+        qint64 totalPayloadUpload = 0;
+        qint64 ipOverheadUpload = 0;
+        qint64 ipOverheadDownload = 0;
+        qint64 dhtUpload = 0;
+        qint64 dhtDownload = 0;
+        qint64 trackerUpload = 0;
+        qint64 trackerDownload = 0;
+        qint64 totalWasted = 0;
+        qint64 diskReadQueue = 0;
+        qint64 diskWriteQueue = 0;
+        qint64 dhtNodes = 0;
+        qint64 peersCount = 0;
     };
 }

--- a/src/base/bittorrent/statistics.cpp
+++ b/src/base/bittorrent/statistics.cpp
@@ -42,10 +42,6 @@ using namespace BitTorrent;
 Statistics::Statistics(Session *session)
     : QObject(session)
     , m_session(session)
-    , m_sessionUL(0)
-    , m_sessionDL(0)
-    , m_lastWrite(0)
-    , m_dirty(false)
 {
     load();
     connect(&m_timer, &QTimer::timeout, this, &Statistics::gather);
@@ -59,12 +55,12 @@ Statistics::~Statistics()
     save();
 }
 
-quint64 Statistics::getAlltimeDL() const
+qint64 Statistics::getAlltimeDL() const
 {
     return m_alltimeDL + m_sessionDL;
 }
 
-quint64 Statistics::getAlltimeUL() const
+qint64 Statistics::getAlltimeUL() const
 {
     return m_alltimeUL + m_sessionUL;
 }
@@ -95,8 +91,8 @@ void Statistics::save() const
 
     SettingsPtr s = Profile::instance()->applicationSettings(u"qBittorrent-data"_qs);
     QVariantHash v;
-    v.insert(u"AlltimeDL"_qs, m_alltimeDL + m_sessionDL);
-    v.insert(u"AlltimeUL"_qs, m_alltimeUL + m_sessionUL);
+    v.insert(u"AlltimeDL"_qs, (m_alltimeDL + m_sessionDL));
+    v.insert(u"AlltimeUL"_qs, (m_alltimeUL + m_sessionUL));
     s->setValue(u"Stats/AllStats"_qs, v);
     m_dirty = false;
     m_lastWrite = now;

--- a/src/base/bittorrent/statistics.h
+++ b/src/base/bittorrent/statistics.h
@@ -45,8 +45,8 @@ public:
     explicit Statistics(BitTorrent::Session *session);
     ~Statistics();
 
-    quint64 getAlltimeDL() const;
-    quint64 getAlltimeUL() const;
+    qint64 getAlltimeDL() const;
+    qint64 getAlltimeUL() const;
 
 private slots:
     void gather();
@@ -56,13 +56,12 @@ private:
     void load();
 
     BitTorrent::Session *m_session;
-    // Will overflow at 15.9 EiB
-    quint64 m_alltimeUL;
-    quint64 m_alltimeDL;
-    quint64 m_sessionUL;
-    quint64 m_sessionDL;
-    mutable qint64 m_lastWrite;
-    mutable bool m_dirty;
+    qint64 m_alltimeUL = 0;
+    qint64 m_alltimeDL = 0;
+    qint64 m_sessionUL = 0;
+    qint64 m_sessionDL = 0;
+    mutable qint64 m_lastWrite = 0;
+    mutable bool m_dirty = false;
 
     QTimer m_timer;
 };

--- a/src/base/search/searchpluginmanager.h
+++ b/src/base/search/searchpluginmanager.h
@@ -36,7 +36,7 @@
 #include "base/path.h"
 #include "base/utils/version.h"
 
-using PluginVersion = Utils::Version<unsigned short, 2>;
+using PluginVersion = Utils::Version<short, 2>;
 Q_DECLARE_METATYPE(PluginVersion)
 
 namespace Net

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -1638,7 +1638,7 @@ void OptionsDialog::setLocale(const QString &localeStr)
     if (index < 0)
     {
         // Unrecognized, use US English
-        index = m_ui->comboI18n->findData(u"en", Qt::UserRole);
+        index = m_ui->comboI18n->findData(u"en"_qs, Qt::UserRole);
         Q_ASSERT(index >= 0);
     }
     m_ui->comboI18n->setCurrentIndex(index);

--- a/src/gui/rss/articlelistwidget.cpp
+++ b/src/gui/rss/articlelistwidget.cpp
@@ -47,7 +47,7 @@ ArticleListWidget::ArticleListWidget(QWidget *parent)
 RSS::Article *ArticleListWidget::getRSSArticle(QListWidgetItem *item) const
 {
     Q_ASSERT(item);
-    return reinterpret_cast<RSS::Article *>(item->data(Qt::UserRole).value<quintptr>());
+    return item->data(Qt::UserRole).value<RSS::Article *>();
 }
 
 QListWidgetItem *ArticleListWidget::mapRSSArticle(RSS::Article *rssArticle) const
@@ -127,7 +127,7 @@ QListWidgetItem *ArticleListWidget::createItem(RSS::Article *article) const
     auto *item = new QListWidgetItem;
 
     item->setData(Qt::DisplayRole, article->title());
-    item->setData(Qt::UserRole, reinterpret_cast<quintptr>(article));
+    item->setData(Qt::UserRole, QVariant::fromValue(article));
     if (article->isRead())
     {
         const QColor defaultColor {palette().color(QPalette::Inactive, QPalette::WindowText)};

--- a/src/gui/rss/feedlistwidget.cpp
+++ b/src/gui/rss/feedlistwidget.cpp
@@ -105,7 +105,7 @@ FeedListWidget::FeedListWidget(QWidget *parent)
     m_rssToTreeItemMapping[RSS::Session::instance()->rootFolder()] = invisibleRootItem();
 
     m_unreadStickyItem = new FeedListItem(this);
-    m_unreadStickyItem->setData(0, Qt::UserRole, reinterpret_cast<quintptr>(RSS::Session::instance()->rootFolder()));
+    m_unreadStickyItem->setData(0, Qt::UserRole, QVariant::fromValue(RSS::Session::instance()->rootFolder()));
     m_unreadStickyItem->setText(0, tr("Unread  (%1)").arg(RSS::Session::instance()->rootFolder()->unreadCount()));
     m_unreadStickyItem->setData(0, Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"mail-folder-inbox"_qs));
     m_unreadStickyItem->setData(0, StickyItemTagRole, true);
@@ -213,7 +213,7 @@ RSS::Item *FeedListWidget::getRSSItem(QTreeWidgetItem *item) const
 {
     if (!item) return nullptr;
 
-    return reinterpret_cast<RSS::Item *>(item->data(0, Qt::UserRole).value<quintptr>());
+    return item->data(0, Qt::UserRole).value<RSS::Item *>();
 }
 
 QTreeWidgetItem *FeedListWidget::mapRSSItem(RSS::Item *rssItem) const
@@ -275,7 +275,7 @@ QTreeWidgetItem *FeedListWidget::createItem(RSS::Item *rssItem, QTreeWidgetItem 
 {
     auto *item = new FeedListItem;
     item->setData(0, Qt::DisplayRole, u"%1  (%2)"_qs.arg(rssItem->name(), QString::number(rssItem->unreadCount())));
-    item->setData(0, Qt::UserRole, reinterpret_cast<quintptr>(rssItem));
+    item->setData(0, Qt::UserRole, QVariant::fromValue(rssItem));
     m_rssToTreeItemMapping[rssItem] = item;
 
     QIcon icon;

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -198,7 +198,7 @@ void RSSWidget::displayItemsListMenu()
     bool hasLink = false;
     for (const QListWidgetItem *item : asConst(m_articleListWidget->selectedItems()))
     {
-        auto article = reinterpret_cast<RSS::Article *>(item->data(Qt::UserRole).value<quintptr>());
+        auto article = item->data(Qt::UserRole).value<RSS::Article *>();
         Q_ASSERT(article);
 
         if (!article->torrentUrl().isEmpty())
@@ -359,7 +359,7 @@ void RSSWidget::downloadSelectedTorrents()
 {
     for (QListWidgetItem *item : asConst(m_articleListWidget->selectedItems()))
     {
-        auto article = reinterpret_cast<RSS::Article *>(item->data(Qt::UserRole).value<quintptr>());
+        auto article = item->data(Qt::UserRole).value<RSS::Article *>();
         Q_ASSERT(article);
 
         // Mark as read
@@ -380,7 +380,7 @@ void RSSWidget::openSelectedArticlesUrls()
 {
     for (QListWidgetItem *item : asConst(m_articleListWidget->selectedItems()))
     {
-        auto article = reinterpret_cast<RSS::Article *>(item->data(Qt::UserRole).value<quintptr>());
+        auto article = item->data(Qt::UserRole).value<RSS::Article *>();
         Q_ASSERT(article);
 
         // Mark as read

--- a/src/gui/statsdialog.cpp
+++ b/src/gui/statsdialog.cpp
@@ -76,8 +76,8 @@ void StatsDialog::update()
     const BitTorrent::CacheStatus &cs = BitTorrent::Session::instance()->cacheStatus();
 
     // All-time DL/UL
-    quint64 atd = BitTorrent::Session::instance()->getAlltimeDL();
-    quint64 atu = BitTorrent::Session::instance()->getAlltimeUL();
+    const qint64 atd = BitTorrent::Session::instance()->getAlltimeDL();
+    const qint64 atu = BitTorrent::Session::instance()->getAlltimeUL();
     m_ui->labelAlltimeDL->setText(Utils::Misc::friendlyUnit(atd));
     m_ui->labelAlltimeUL->setText(Utils::Misc::friendlyUnit(atu));
     // Total waste (this session)

--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -126,8 +126,8 @@ namespace
         map[KEY_TRANSFER_DLRATELIMIT] = session->downloadSpeedLimit();
         map[KEY_TRANSFER_UPRATELIMIT] = session->uploadSpeedLimit();
 
-        const quint64 atd = session->getAlltimeDL();
-        const quint64 atu = session->getAlltimeUL();
+        const qint64 atd = session->getAlltimeDL();
+        const qint64 atu = session->getAlltimeUL();
         map[KEY_TRANSFER_ALLTIME_DL] = atd;
         map[KEY_TRANSFER_ALLTIME_UL] = atu;
         map[KEY_TRANSFER_TOTAL_WASTE_SESSION] = sessionStatus.totalWasted;


### PR DESCRIPTION
* Omit redundant cast
* Use signed integer type for counters
* Migrate away from unsigned integer types
  Signed integers should be preferred in these cases.
* Fix wrong conversion to QVariant
  It was converted to bool-like type which is wrong.

>Migrate away from unsigned integer types 

It is actually more like unify integer types, since we reserve unsigned integers for bitwise operations (and few other very specific use cases like IP port numbers) and use signed integer for everything else.