### PR TITLE
Add LTO for Unix release builds

### DIFF
--- a/configure
+++ b/configure
@@ -3458,7 +3458,7 @@ elif test $ac_cv_prog_cc_g = yes; then
   fi
 else
   if test "$GCC" = yes; then
-    CFLAGS="-O2"
+    CFLAGS="-O2 -flto"
   else
     CFLAGS=
   fi
@@ -3945,7 +3945,7 @@ elif test $ac_cv_prog_cxx_g = yes; then
   fi
 else
   if test "$GXX" = yes; then
-    CXXFLAGS="-O2"
+    CXXFLAGS="-O2 -flto"
   else
     CXXFLAGS=
   fi

--- a/configure
+++ b/configure
@@ -3458,7 +3458,7 @@ elif test $ac_cv_prog_cc_g = yes; then
   fi
 else
   if test "$GCC" = yes; then
-    CFLAGS="-O2 -flto"
+    CFLAGS="-O2"
   else
     CFLAGS=
   fi
@@ -3945,7 +3945,7 @@ elif test $ac_cv_prog_cxx_g = yes; then
   fi
 else
   if test "$GXX" = yes; then
-    CXXFLAGS="-O2 -flto"
+    CXXFLAGS="-O2"
   else
     CXXFLAGS=
   fi

--- a/unixconf.pri
+++ b/unixconf.pri
@@ -11,6 +11,7 @@ else {
 !nogui:dbus: QT += dbus
 
 QMAKE_CXXFLAGS += -Wall -Wextra -Wpedantic -Wformat-security
+QMAKE_CXXFLAGS_RELEASE += -flto
 !haiku: QMAKE_LFLAGS_APP += -rdynamic
 
 # Man page


### PR DESCRIPTION
This commit adds Link Time Optimizations when building qBittorrent on Linux. These are proven to improve performance and reduce binary sizes. The disadvantages are that it takes longer to build, reduces debugging information and may require additional changes to be compatible with source code.