### PR TITLE
Move comparison operator out of class

### DIFF
--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -111,12 +111,6 @@ namespace
         {
         }
 
-        bool operator==(const QString &arg) const
-        {
-            return (hasShortcut() && ((arg.size() == 2) && (arg == shortcutParameter())))
-                   || (arg == fullParameter());
-        }
-
         bool value(const QProcessEnvironment &env) const
         {
             QString val = env.value(envVarName());
@@ -132,11 +126,17 @@ namespace
             res += fullParameter();
             return padUsageText(res);
         }
+
+        friend bool operator==(const BoolOption &option, const QString &arg)
+        {
+            return (option.hasShortcut() && ((arg.size() == 2) && (option.shortcutParameter() == arg)))
+                   || (option.fullParameter() == arg);
+        }
     };
 
-    bool operator==(const QString &s, const BoolOption &o)
+    bool operator==(const QString &arg, const BoolOption &option)
     {
-        return o == s;
+        return (option == arg);
     }
 
     // Option with string value. May not have a shortcut
@@ -146,11 +146,6 @@ namespace
         explicit constexpr StringOption(const char *name)
             : Option {name, 0}
         {
-        }
-
-        bool operator==(const QString &arg) const
-        {
-            return arg.startsWith(parameterAssignment());
         }
 
         QString value(const QString &arg) const
@@ -174,6 +169,11 @@ namespace
             return padUsageText(parameterAssignment() + u'<' + valueName + u'>');
         }
 
+        friend bool operator==(const StringOption &option, const QString &arg)
+        {
+            return arg.startsWith(option.parameterAssignment());
+        }
+
     private:
         QString parameterAssignment() const
         {
@@ -181,9 +181,9 @@ namespace
         }
     };
 
-    bool operator==(const QString &s, const StringOption &o)
+    bool operator==(const QString &arg, const StringOption &option)
     {
-        return o == s;
+        return (option == arg);
     }
 
     // Option with integer value. May not have a shortcut
@@ -195,7 +195,6 @@ namespace
         {
         }
 
-        using StringOption::operator==;
         using StringOption::usage;
 
         int value(const QString &arg) const
@@ -225,11 +224,16 @@ namespace
             }
             return res;
         }
+
+        friend bool operator==(const IntOption &option, const QString &arg)
+        {
+            return (static_cast<StringOption>(option) == arg);
+        }
     };
 
-    bool operator==(const QString &s, const IntOption &o)
+    bool operator==(const QString &arg, const IntOption &option)
     {
-        return o == s;
+        return (option == arg);
     }
 
     // Option that is explicitly set to true or false, and whose value is undefined when unspecified.
@@ -241,12 +245,6 @@ namespace
             : Option {name, 0}
             , m_defaultValue(defaultValue)
         {
-        }
-
-        bool operator==(const QString &arg) const
-        {
-            QStringList parts = arg.split(u'=');
-            return parts[0] == fullParameter();
         }
 
         QString usage() const
@@ -308,12 +306,18 @@ namespace
             return std::nullopt;
         }
 
+        friend bool operator==(const TriStateBoolOption &option, const QString &arg)
+        {
+            const QStringList parts = arg.split(u'=');
+            return parts[0] == option.fullParameter();
+        }
+
         bool m_defaultValue;
     };
 
-    bool operator==(const QString &s, const TriStateBoolOption &o)
+    bool operator==(const QString &arg, const TriStateBoolOption &option)
     {
-        return o == s;
+        return (option == arg);
     }
 
     constexpr const BoolOption SHOW_HELP_OPTION {"help", 'h'};

--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -308,8 +308,7 @@ namespace
 
         friend bool operator==(const TriStateBoolOption &option, const QString &arg)
         {
-            const QStringList parts = arg.split(u'=');
-            return parts[0] == option.fullParameter();
+            return arg.section(u'=', 0, 0) == option.fullParameter();
         }
 
         bool m_defaultValue;

--- a/src/base/indexrange.h
+++ b/src/base/indexrange.h
@@ -101,14 +101,15 @@ public:
             return iter;
         }
 
-        constexpr bool operator==(const Iterator &other) const
+        // comparing iterators from different containers is undefined behavior in C++ standard library
+        friend constexpr bool operator==(const Iterator &left, const Iterator &right)
         {
-            return (*(*this) == *other);
+            return (*left == *right);
         }
 
-        constexpr bool operator!=(const Iterator &other) const
+        friend constexpr bool operator!=(const Iterator &left, const Iterator &right)
         {
-            return !(*this == other);
+            return !(left == right);
         }
 
     private:

--- a/src/base/rss/rss_autodownloadrule.cpp
+++ b/src/base/rss/rss_autodownloadrule.cpp
@@ -144,24 +144,35 @@ namespace RSS
         mutable QStringList lastComputedEpisodes;
         mutable QHash<QString, QRegularExpression> cachedRegexes;
 
-        bool operator==(const AutoDownloadRuleData &other) const
+        friend bool operator==(const AutoDownloadRuleData &left, const AutoDownloadRuleData &right)
         {
-            return (name == other.name)
-                    && (enabled == other.enabled)
-                    && (mustContain == other.mustContain)
-                    && (mustNotContain == other.mustNotContain)
-                    && (episodeFilter == other.episodeFilter)
-                    && (feedURLs == other.feedURLs)
-                    && (useRegex == other.useRegex)
-                    && (ignoreDays == other.ignoreDays)
-                    && (lastMatch == other.lastMatch)
-                    && (savePath == other.savePath)
-                    && (category == other.category)
-                    && (addPaused == other.addPaused)
-                    && (contentLayout == other.contentLayout)
-                    && (smartFilter == other.smartFilter);
+            return (left.name == right.name)
+                    && (left.enabled == right.enabled)
+                    && (left.mustContain == right.mustContain)
+                    && (left.mustNotContain == right.mustNotContain)
+                    && (left.episodeFilter == right.episodeFilter)
+                    && (left.feedURLs == right.feedURLs)
+                    && (left.useRegex == right.useRegex)
+                    && (left.ignoreDays == right.ignoreDays)
+                    && (left.lastMatch == right.lastMatch)
+                    && (left.savePath == right.savePath)
+                    && (left.category == right.category)
+                    && (left.addPaused == right.addPaused)
+                    && (left.contentLayout == right.contentLayout)
+                    && (left.smartFilter == right.smartFilter);
         }
     };
+
+    bool operator==(const AutoDownloadRule &left, const AutoDownloadRule &right)
+    {
+        return (left.m_dataPtr == right.m_dataPtr) // optimization
+                || (*(left.m_dataPtr) == *(right.m_dataPtr));
+    }
+
+    bool operator!=(const AutoDownloadRule &left, const AutoDownloadRule &right)
+    {
+        return !(left == right);
+    }
 }
 
 using namespace RSS;
@@ -446,17 +457,6 @@ AutoDownloadRule &AutoDownloadRule::operator=(const AutoDownloadRule &other)
         m_dataPtr = other.m_dataPtr;
     }
     return *this;
-}
-
-bool AutoDownloadRule::operator==(const AutoDownloadRule &other) const
-{
-    return (m_dataPtr == other.m_dataPtr) // optimization
-            || (*m_dataPtr == *other.m_dataPtr);
-}
-
-bool AutoDownloadRule::operator!=(const AutoDownloadRule &other) const
-{
-    return !operator==(other);
 }
 
 QJsonObject AutoDownloadRule::toJsonObject() const

--- a/src/base/rss/rss_autodownloadrule.h
+++ b/src/base/rss/rss_autodownloadrule.h
@@ -53,6 +53,8 @@ namespace RSS
         AutoDownloadRule(const AutoDownloadRule &other);
         ~AutoDownloadRule();
 
+        AutoDownloadRule &operator=(const AutoDownloadRule &other);
+
         QString name() const;
         void setName(const QString &name);
 
@@ -91,9 +93,7 @@ namespace RSS
         bool matches(const QVariantHash &articleData) const;
         bool accepts(const QVariantHash &articleData);
 
-        AutoDownloadRule &operator=(const AutoDownloadRule &other);
-        bool operator==(const AutoDownloadRule &other) const;
-        bool operator!=(const AutoDownloadRule &other) const;
+        friend bool operator==(const AutoDownloadRule &left, const AutoDownloadRule &right);
 
         QJsonObject toJsonObject() const;
         static AutoDownloadRule fromJsonObject(const QJsonObject &jsonObj, const QString &name = u""_qs);
@@ -111,4 +111,6 @@ namespace RSS
 
         QSharedDataPointer<AutoDownloadRuleData> m_dataPtr;
     };
+
+    bool operator!=(const AutoDownloadRule &left, const AutoDownloadRule &right);
 }

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -142,10 +142,10 @@ QPoint Utils::Gui::screenCenter(const QWidget *w)
 void Utils::Gui::openPath(const Path &path)
 {
     // Hack to access samba shares with QDesktopServices::openUrl
-    if (path.data().startsWith(u"//"))
-        QDesktopServices::openUrl(QUrl(u"file:" + path.toString()));
-    else
-        QDesktopServices::openUrl(QUrl::fromLocalFile(path.data()));
+    const QUrl url = path.data().startsWith(u"//")
+        ? QUrl(u"file:" + path.data())
+        : QUrl::fromLocalFile(path.data());
+    QDesktopServices::openUrl(url);
 }
 
 // Open the parent directory of the given path with a file manager and select

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -717,7 +717,8 @@ void TorrentsController::addAction()
         }
     }
 
-    for (auto it = data().constBegin(); it != data().constEnd(); ++it)
+    const DataMap torrents = data();
+    for (auto it = torrents.constBegin(); it != torrents.constEnd(); ++it)
     {
         const nonstd::expected<BitTorrent::TorrentInfo, QString> result = BitTorrent::TorrentInfo::load(it.value());
         if (!result)


### PR DESCRIPTION
* Move comparison operator out of class
* Simplify code
* Assign temporary data to a variable
  This is mainly to avoid dangerous code pattern: getting an iterator on a temporary object. Previously `data()` returns a const reference so the code wasn't doing any harm.

I think those are worth cleaning up when I was experimenting with C++20.