### PR TITLE
Improve startup

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -309,10 +309,18 @@ void Application::setFileLoggerAgeType(const int value)
 
 void Application::processMessage(const QString &message)
 {
-    const QStringList params = message.split(PARAMS_SEPARATOR, Qt::SkipEmptyParts);
-    // If Application is not running (i.e., other
-    // components are not ready) store params
-    if (m_running)
+#ifndef DISABLE_GUI
+    if (message.isEmpty())
+    {
+        m_window->activate(); // show UI
+        return;
+    }
+#endif
+
+    const AddTorrentParams params = parseParams(message.split(PARAMS_SEPARATOR, Qt::SkipEmptyParts));
+    // If Application is not allowed to process params immediately
+    // (i.e., other components are not ready) store params
+    if (m_isProcessingParamsAllowed)
         processParams(params);
     else
         m_paramsQueue.append(params);
@@ -516,21 +524,10 @@ bool Application::sendParams(const QStringList &params)
     return m_instanceManager->sendMessage(params.join(PARAMS_SEPARATOR));
 }
 
-// As program parameters, we can get paths or urls.
-// This function parse the parameters and call
-// the right addTorrent function, considering
-// the parameter type.
-void Application::processParams(const QStringList &params)
+Application::AddTorrentParams Application::parseParams(const QStringList &params) const
 {
-#ifndef DISABLE_GUI
-    if (params.isEmpty())
-    {
-        m_window->activate(); // show UI
-        return;
-    }
-#endif
-    BitTorrent::AddTorrentParams torrentParams;
-    std::optional<bool> skipTorrentDialog;
+    AddTorrentParams parsedParams;
+    BitTorrent::AddTorrentParams &torrentParams = parsedParams.torrentParams;
 
     for (QString param : params)
     {
@@ -576,23 +573,31 @@ void Application::processParams(const QStringList &params)
 
         if (param.startsWith(u"@skipDialog="))
         {
-            skipTorrentDialog = (QStringView(param).mid(12).toInt() != 0);
+            parsedParams.skipTorrentDialog = (QStringView(param).mid(12).toInt() != 0);
             continue;
         }
 
-#ifndef DISABLE_GUI
-        // There are two circumstances in which we want to show the torrent
-        // dialog. One is when the application settings specify that it should
-        // be shown and skipTorrentDialog is undefined. The other is when
-        // skipTorrentDialog is false, meaning that the application setting
-        // should be overridden.
-        const bool showDialogForThisTorrent = !skipTorrentDialog.value_or(!AddNewTorrentDialog::isEnabled());
-        if (showDialogForThisTorrent)
-            AddNewTorrentDialog::show(param, torrentParams, m_window);
-        else
-#endif
-            BitTorrent::Session::instance()->addTorrent(param, torrentParams);
+        parsedParams.torrentSource = param;
+        break;
     }
+
+    return parsedParams;
+}
+
+void Application::processParams(const AddTorrentParams &params)
+{
+#ifndef DISABLE_GUI
+    // There are two circumstances in which we want to show the torrent
+    // dialog. One is when the application settings specify that it should
+    // be shown and skipTorrentDialog is undefined. The other is when
+    // skipTorrentDialog is false, meaning that the application setting
+    // should be overridden.
+    const bool showDialogForThisTorrent = !params.skipTorrentDialog.value_or(!AddNewTorrentDialog::isEnabled());
+    if (showDialogForThisTorrent)
+        AddNewTorrentDialog::show(params.torrentSource, params.torrentParams, m_window);
+    else
+#endif
+        BitTorrent::Session::instance()->addTorrent(params.torrentSource, params.torrentParams);
 }
 
 int Application::exec(const QStringList &params)
@@ -608,20 +613,27 @@ int Application::exec(const QStringList &params)
     try
     {
         BitTorrent::Session::initInstance();
+        connect(BitTorrent::Session::instance(), &BitTorrent::Session::restored, this, [this]()
+        {
+#ifndef DISABLE_WEBUI
+            m_webui = new WebUI(this);
+#ifdef DISABLE_GUI
+            if (m_webui->isErrored())
+                QCoreApplication::exit(1);
+            connect(m_webui, &WebUI::fatalError, this, []() { QCoreApplication::exit(1); });
+#endif // DISABLE_GUI
+#endif // DISABLE_WEBUI
+
+            m_isProcessingParamsAllowed = true;
+            for (const AddTorrentParams &params : m_paramsQueue)
+                processParams(params);
+            m_paramsQueue.clear();
+        });
         connect(BitTorrent::Session::instance(), &BitTorrent::Session::torrentFinished, this, &Application::torrentFinished);
         connect(BitTorrent::Session::instance(), &BitTorrent::Session::allTorrentsFinished, this, &Application::allTorrentsFinished, Qt::QueuedConnection);
 
         Net::GeoIPManager::initInstance();
         TorrentFilesWatcher::initInstance();
-
-#ifndef DISABLE_WEBUI
-        m_webui = new WebUI(this);
-#ifdef DISABLE_GUI
-        if (m_webui->isErrored())
-            return 1;
-        connect(m_webui, &WebUI::fatalError, this, []() { QCoreApplication::exit(1); });
-#endif // DISABLE_GUI
-#endif // DISABLE_WEBUI
 
         new RSS::Session; // create RSS::Session singleton
         new RSS::AutoDownloader; // create RSS::AutoDownloader singleton
@@ -665,17 +677,9 @@ int Application::exec(const QStringList &params)
     m_window = new MainWindow(this);
 #endif // DISABLE_GUI
 
-    m_running = true;
+    if (!params.isEmpty())
+        m_paramsQueue.append(parseParams(params));
 
-    // Now UI is ready to process signals from Session
-    BitTorrent::Session::instance()->startUpTorrents();
-
-    m_paramsQueue = params + m_paramsQueue;
-    if (!m_paramsQueue.isEmpty())
-    {
-        processParams(m_paramsQueue);
-        m_paramsQueue.clear();
-    }
     return BaseApplication::exec();
 }
 
@@ -695,16 +699,19 @@ bool Application::event(QEvent *ev)
             // Get the url instead
             path = static_cast<QFileOpenEvent *>(ev)->url().toString();
         qDebug("Received a mac file open event: %s", qUtf8Printable(path));
-        if (m_running)
-            processParams(QStringList(path));
+
+        const AddTorrentParams params = parseParams({path});
+        // If Application is not allowed to process params immediately
+        // (i.e., other components are not ready) store params
+        if (m_isProcessingParamsAllowed)
+            processParams(params);
         else
-            m_paramsQueue.append(path);
+            m_paramsQueue.append(params);
+
         return true;
     }
-    else
-    {
-        return BaseApplication::event(ev);
-    }
+
+    return BaseApplication::event(ev);
 }
 #endif // Q_OS_MACOS
 #endif // DISABLE_GUI

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -41,6 +41,7 @@
 #include <QApplication>
 #endif
 
+#include "base/bittorrent/addtorrentparams.h"
 #include "base/interfaces/iapplication.h"
 #include "base/path.h"
 #include "base/settingvalue.h"
@@ -132,8 +133,16 @@ private slots:
 #endif
 
 private:
+    struct AddTorrentParams
+    {
+        QString torrentSource;
+        BitTorrent::AddTorrentParams torrentParams;
+        std::optional<bool> skipTorrentDialog;
+    };
+
     void initializeTranslation();
-    void processParams(const QStringList &params);
+    AddTorrentParams parseParams(const QStringList &params) const;
+    void processParams(const AddTorrentParams &params);
     void runExternalProgram(const BitTorrent::Torrent *torrent) const;
     void sendNotificationEmail(const BitTorrent::Torrent *torrent);
 #ifdef QBT_USES_LIBTORRENT2
@@ -147,8 +156,8 @@ private:
 #endif
 
     ApplicationInstanceManager *m_instanceManager = nullptr;
-    bool m_running = false;
     QAtomicInt m_isCleanupRun;
+    bool m_isProcessingParamsAllowed = false;
     ShutdownDialogAction m_shutdownAct;
     QBtCommandLineParameters m_commandLineArgs;
 
@@ -157,7 +166,8 @@ private:
 
     QTranslator m_qtTranslator;
     QTranslator m_translator;
-    QStringList m_paramsQueue;
+
+    QList<AddTorrentParams> m_paramsQueue;
 
     SettingValue<bool> m_storeFileLoggerEnabled;
     SettingValue<bool> m_storeFileLoggerBackup;

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -124,6 +124,7 @@ add_library(qbt_base STATIC
     bittorrent/peeraddress.cpp
     bittorrent/peerinfo.cpp
     bittorrent/portforwarderimpl.cpp
+    bittorrent/resumedatastorage.cpp
     bittorrent/session.cpp
     bittorrent/speedmonitor.cpp
     bittorrent/statistics.cpp

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -124,6 +124,7 @@ SOURCES += \
     $$PWD/bittorrent/peeraddress.cpp \
     $$PWD/bittorrent/peerinfo.cpp \
     $$PWD/bittorrent/portforwarderimpl.cpp \
+    $$PWD/bittorrent/resumedatastorage.cpp \
     $$PWD/bittorrent/session.cpp \
     $$PWD/bittorrent/speedmonitor.cpp \
     $$PWD/bittorrent/statistics.cpp \

--- a/src/base/bittorrent/bencoderesumedatastorage.h
+++ b/src/base/bittorrent/bencoderesumedatastorage.h
@@ -31,7 +31,7 @@
 #include <QDir>
 #include <QVector>
 
-#include "base/path.h"
+#include "base/pathfwd.h"
 #include "resumedatastorage.h"
 
 class QByteArray;
@@ -49,16 +49,16 @@ namespace BitTorrent
         ~BencodeResumeDataStorage() override;
 
         QVector<TorrentID> registeredTorrents() const override;
-        std::optional<LoadTorrentParams> load(const TorrentID &id) const override;
+        LoadResumeDataResult load(const TorrentID &id) const override;
         void store(const TorrentID &id, const LoadTorrentParams &resumeData) const override;
         void remove(const TorrentID &id) const override;
         void storeQueue(const QVector<TorrentID> &queue) const override;
 
     private:
+        void doLoadAll() const override;
         void loadQueue(const Path &queueFilename);
-        std::optional<LoadTorrentParams> loadTorrentResumeData(const QByteArray &data, const QByteArray &metadata) const;
+        LoadResumeDataResult loadTorrentResumeData(const QByteArray &data, const QByteArray &metadata) const;
 
-        const Path m_resumeDataPath;
         QVector<TorrentID> m_registeredTorrents;
         QThread *m_ioThread = nullptr;
 

--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -138,8 +138,20 @@ AutoDownloader::AutoDownloader()
     m_processingTimer->setSingleShot(true);
     connect(m_processingTimer, &QTimer::timeout, this, &AutoDownloader::process);
 
-    if (isProcessingEnabled())
-        startProcessing();
+    const auto *btSession = BitTorrent::Session::instance();
+    if (btSession->isRestored())
+    {
+        if (isProcessingEnabled())
+            startProcessing();
+    }
+    else
+    {
+        connect(btSession, &BitTorrent::Session::restored, this, [this]()
+        {
+            if (isProcessingEnabled())
+                startProcessing();
+        });
+    }
 }
 
 AutoDownloader::~AutoDownloader()
@@ -506,7 +518,8 @@ void AutoDownloader::setProcessingEnabled(const bool enabled)
         m_storeProcessingEnabled = enabled;
         if (enabled)
         {
-            startProcessing();
+            if (BitTorrent::Session::instance()->isRestored())
+                startProcessing();
         }
         else
         {

--- a/src/base/torrentfileswatcher.cpp
+++ b/src/base/torrentfileswatcher.cpp
@@ -255,13 +255,12 @@ TorrentFilesWatcher *TorrentFilesWatcher::instance()
 TorrentFilesWatcher::TorrentFilesWatcher(QObject *parent)
     : QObject {parent}
     , m_ioThread {new QThread(this)}
-    , m_asyncWorker {new TorrentFilesWatcher::Worker}
 {
-    connect(m_asyncWorker, &TorrentFilesWatcher::Worker::magnetFound, this, &TorrentFilesWatcher::onMagnetFound);
-    connect(m_asyncWorker, &TorrentFilesWatcher::Worker::torrentFound, this, &TorrentFilesWatcher::onTorrentFound);
-
-    m_asyncWorker->moveToThread(m_ioThread);
-    m_ioThread->start();
+    const auto *btSession = BitTorrent::Session::instance();
+    if (btSession->isRestored())
+        initWorker();
+    else
+        connect(btSession, &BitTorrent::Session::restored, this, &TorrentFilesWatcher::initWorker);
 
     load();
 }
@@ -271,6 +270,27 @@ TorrentFilesWatcher::~TorrentFilesWatcher()
     m_ioThread->quit();
     m_ioThread->wait();
     delete m_asyncWorker;
+}
+
+void TorrentFilesWatcher::initWorker()
+{
+    Q_ASSERT(!m_asyncWorker);
+
+    m_asyncWorker = new TorrentFilesWatcher::Worker;
+
+    connect(m_asyncWorker, &TorrentFilesWatcher::Worker::magnetFound, this, &TorrentFilesWatcher::onMagnetFound);
+    connect(m_asyncWorker, &TorrentFilesWatcher::Worker::torrentFound, this, &TorrentFilesWatcher::onTorrentFound);
+
+    m_asyncWorker->moveToThread(m_ioThread);
+    m_ioThread->start();
+
+    for (auto it = m_watchedFolders.cbegin(); it != m_watchedFolders.cend(); ++it)
+    {
+        QMetaObject::invokeMethod(m_asyncWorker, [this, path = it.key(), options = it.value()]()
+        {
+            m_asyncWorker->setWatchedFolder(path, options);
+        });
+    }
 }
 
 void TorrentFilesWatcher::load()
@@ -399,10 +419,13 @@ void TorrentFilesWatcher::doSetWatchedFolder(const Path &path, const WatchedFold
 
     m_watchedFolders[path] = options;
 
-    QMetaObject::invokeMethod(m_asyncWorker, [this, path, options]()
+    if (m_asyncWorker)
     {
-        m_asyncWorker->setWatchedFolder(path, options);
-    });
+        QMetaObject::invokeMethod(m_asyncWorker, [this, path, options]()
+        {
+            m_asyncWorker->setWatchedFolder(path, options);
+        });
+    }
 
     emit watchedFolderSet(path, options);
 }
@@ -411,10 +434,13 @@ void TorrentFilesWatcher::removeWatchedFolder(const Path &path)
 {
     if (m_watchedFolders.remove(path))
     {
-        QMetaObject::invokeMethod(m_asyncWorker, [this, path]()
+        if (m_asyncWorker)
         {
-            m_asyncWorker->removeWatchedFolder(path);
-        });
+            QMetaObject::invokeMethod(m_asyncWorker, [this, path]()
+            {
+                m_asyncWorker->removeWatchedFolder(path);
+            });
+        }
 
         emit watchedFolderRemoved(path);
 

--- a/src/base/torrentfileswatcher.h
+++ b/src/base/torrentfileswatcher.h
@@ -78,6 +78,7 @@ private:
     explicit TorrentFilesWatcher(QObject *parent = nullptr);
     ~TorrentFilesWatcher() override;
 
+    void initWorker();
     void load();
     void loadLegacy();
     void store() const;

--- a/src/gui/categoryfiltermodel.cpp
+++ b/src/gui/categoryfiltermodel.cpp
@@ -32,7 +32,6 @@
 #include <QIcon>
 
 #include "base/bittorrent/session.h"
-#include "base/bittorrent/torrent.h"
 #include "base/global.h"
 #include "uithememanager.h"
 
@@ -181,7 +180,7 @@ CategoryFilterModel::CategoryFilterModel(QObject *parent)
     connect(session, &Session::categoryRemoved, this, &CategoryFilterModel::categoryRemoved);
     connect(session, &Session::torrentCategoryChanged, this, &CategoryFilterModel::torrentCategoryChanged);
     connect(session, &Session::subcategoriesSupportChanged, this, &CategoryFilterModel::subcategoriesSupportChanged);
-    connect(session, &Session::torrentLoaded, this, &CategoryFilterModel::torrentAdded);
+    connect(session, &Session::torrentsLoaded, this, &CategoryFilterModel::torrentsLoaded);
     connect(session, &Session::torrentAboutToBeRemoved, this, &CategoryFilterModel::torrentAboutToBeRemoved);
 
     populate();
@@ -333,13 +332,16 @@ void CategoryFilterModel::categoryRemoved(const QString &categoryName)
     }
 }
 
-void CategoryFilterModel::torrentAdded(BitTorrent::Torrent *const torrent)
+void CategoryFilterModel::torrentsLoaded(const QVector<BitTorrent::Torrent *> &torrents)
 {
-    CategoryModelItem *item = findItem(torrent->category());
-    Q_ASSERT(item);
+    for (const BitTorrent::Torrent *torrent : torrents)
+    {
+        CategoryModelItem *item = findItem(torrent->category());
+        Q_ASSERT(item);
 
-    item->increaseTorrentsCount();
-    m_rootItem->childAt(0)->increaseTorrentsCount();
+        item->increaseTorrentsCount();
+        m_rootItem->childAt(0)->increaseTorrentsCount();
+    }
 }
 
 void CategoryFilterModel::torrentAboutToBeRemoved(BitTorrent::Torrent *const torrent)

--- a/src/gui/categoryfiltermodel.h
+++ b/src/gui/categoryfiltermodel.h
@@ -28,16 +28,14 @@
 
 #pragma once
 
+#include <QtContainerFwd>
 #include <QAbstractItemModel>
+
+#include "base/bittorrent/torrent.h"
 
 class QModelIndex;
 
 class CategoryModelItem;
-
-namespace BitTorrent
-{
-    class Torrent;
-}
 
 class CategoryFilterModel final : public QAbstractItemModel
 {
@@ -64,7 +62,7 @@ public:
 private slots:
     void categoryAdded(const QString &categoryName);
     void categoryRemoved(const QString &categoryName);
-    void torrentAdded(BitTorrent::Torrent *const torrent);
+    void torrentsLoaded(const QVector<BitTorrent::Torrent *> &torrents);
     void torrentAboutToBeRemoved(BitTorrent::Torrent *const torrent);
     void torrentCategoryChanged(BitTorrent::Torrent *const torrent, const QString &oldCategory);
     void subcategoriesSupportChanged();

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1205,12 +1205,12 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
 {
     if (event->matches(QKeySequence::Paste))
     {
-        const QMimeData *mimeData {QGuiApplication::clipboard()->mimeData()};
+        const QMimeData *mimeData = QGuiApplication::clipboard()->mimeData();
 
         if (mimeData->hasText())
         {
-            const bool useTorrentAdditionDialog {AddNewTorrentDialog::isEnabled()};
-            const QStringList lines {mimeData->text().split(u'\n', Qt::SkipEmptyParts)};
+            const bool useTorrentAdditionDialog = AddNewTorrentDialog::isEnabled();
+            const QStringList lines = mimeData->text().split(u'\n', Qt::SkipEmptyParts);
 
             for (QString line : lines)
             {
@@ -1438,6 +1438,7 @@ void MainWindow::dragEnterEvent(QDragEnterEvent *event)
 {
     for (const QString &mime : asConst(event->mimeData()->formats()))
         qDebug("mimeData: %s", mime.toLocal8Bit().data());
+
     if (event->mimeData()->hasFormat(u"text/plain"_qs) || event->mimeData()->hasFormat(u"text/uri-list"_qs))
         event->acceptProposedAction();
 }

--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -208,7 +208,7 @@ void SearchJobWidget::cancelSearch()
 
 void SearchJobWidget::downloadTorrents(const AddTorrentOption option)
 {
-    const QModelIndexList rows {m_ui->resultsBrowser->selectionModel()->selectedRows()};
+    const QModelIndexList rows = m_ui->resultsBrowser->selectionModel()->selectedRows();
     for (const QModelIndex &rowIndex : rows)
         downloadTorrent(rowIndex, option);
 }
@@ -390,10 +390,10 @@ void SearchJobWidget::contextMenuEvent(QContextMenuEvent *event)
     auto *menu = new QMenu(this);
     menu->setAttribute(Qt::WA_DeleteOnClose);
 
-    menu->addAction(UIThemeManager::instance()->getIcon(u"kt-set-max-download-speed"_qs), tr("Open download window")
-        , this, [this]() { downloadTorrents(AddTorrentOption::ShowDialog); });
-    menu->addAction(UIThemeManager::instance()->getIcon(u"downloading"_qs), tr("Download")
-        , this, [this]() { downloadTorrents(AddTorrentOption::SkipDialog); });
+    menu->addAction(UIThemeManager::instance()->getIcon(u"kt-set-max-download-speed"_qs)
+        , tr("Open download window"), this, [this]() { downloadTorrents(AddTorrentOption::ShowDialog); });
+    menu->addAction(UIThemeManager::instance()->getIcon(u"downloading"_qs)
+        , tr("Download"), this, [this]() { downloadTorrents(AddTorrentOption::SkipDialog); });
     menu->addSeparator();
     menu->addAction(UIThemeManager::instance()->getIcon(u"application-x-mswinurl"_qs), tr("Open description page")
         , this, &SearchJobWidget::openTorrentPages);

--- a/src/gui/tagfiltermodel.cpp
+++ b/src/gui/tagfiltermodel.cpp
@@ -33,7 +33,6 @@
 #include <QVector>
 
 #include "base/bittorrent/session.h"
-#include "base/bittorrent/torrent.h"
 #include "base/global.h"
 #include "uithememanager.h"
 
@@ -99,7 +98,7 @@ TagFilterModel::TagFilterModel(QObject *parent)
     connect(session, &Session::tagRemoved, this, &TagFilterModel::tagRemoved);
     connect(session, &Session::torrentTagAdded, this, &TagFilterModel::torrentTagAdded);
     connect(session, &Session::torrentTagRemoved, this, &TagFilterModel::torrentTagRemoved);
-    connect(session, &Session::torrentLoaded, this, &TagFilterModel::torrentAdded);
+    connect(session, &Session::torrentsLoaded, this, &TagFilterModel::torrentsLoaded);
     connect(session, &Session::torrentAboutToBeRemoved, this, &TagFilterModel::torrentAboutToBeRemoved);
     populate();
 }
@@ -230,16 +229,19 @@ void TagFilterModel::torrentTagRemoved(BitTorrent::Torrent *const torrent, const
     emit dataChanged(i, i);
 }
 
-void TagFilterModel::torrentAdded(BitTorrent::Torrent *const torrent)
+void TagFilterModel::torrentsLoaded(const QVector<BitTorrent::Torrent *> &torrents)
 {
-    allTagsItem()->increaseTorrentsCount();
+    for (const BitTorrent::Torrent *torrent : torrents)
+    {
+        allTagsItem()->increaseTorrentsCount();
 
-    const QVector<TagModelItem *> items = findItems(torrent->tags());
-    if (items.isEmpty())
-        untaggedItem()->increaseTorrentsCount();
+        const QVector<TagModelItem *> items = findItems(torrent->tags());
+        if (items.isEmpty())
+            untaggedItem()->increaseTorrentsCount();
 
-    for (TagModelItem *item : items)
-        item->increaseTorrentsCount();
+        for (TagModelItem *item : items)
+            item->increaseTorrentsCount();
+    }
 }
 
 void TagFilterModel::torrentAboutToBeRemoved(BitTorrent::Torrent *const torrent)

--- a/src/gui/tagfiltermodel.h
+++ b/src/gui/tagfiltermodel.h
@@ -28,19 +28,15 @@
 
 #pragma once
 
-#include <QAbstractListModel>
 #include <QtContainerFwd>
+#include <QAbstractItemModel>
 
+#include "base/bittorrent/torrent.h"
 #include "base/tagset.h"
 
 class QModelIndex;
 
 class TagModelItem;
-
-namespace BitTorrent
-{
-    class Torrent;
-}
 
 class TagFilterModel final : public QAbstractListModel
 {
@@ -67,7 +63,7 @@ private slots:
     void tagRemoved(const QString &tag);
     void torrentTagAdded(BitTorrent::Torrent *const torrent, const QString &tag);
     void torrentTagRemoved(BitTorrent::Torrent *const, const QString &tag);
-    void torrentAdded(BitTorrent::Torrent *const torrent);
+    void torrentsLoaded(const QVector<BitTorrent::Torrent *> &torrents);
     void torrentAboutToBeRemoved(BitTorrent::Torrent *const torrent);
 
 private:

--- a/src/gui/transferlistfilterswidget.h
+++ b/src/gui/transferlistfilterswidget.h
@@ -71,7 +71,7 @@ protected:
 private slots:
     virtual void showMenu() = 0;
     virtual void applyFilter(int row) = 0;
-    virtual void handleNewTorrent(BitTorrent::Torrent *const) = 0;
+    virtual void handleTorrentsLoaded(const QVector<BitTorrent::Torrent *> &torrents) = 0;
     virtual void torrentAboutToBeDeleted(BitTorrent::Torrent *const) = 0;
 };
 
@@ -92,7 +92,7 @@ private:
     // No need to redeclare them here as slots.
     void showMenu() override;
     void applyFilter(int row) override;
-    void handleNewTorrent(BitTorrent::Torrent *const) override;
+    void handleTorrentsLoaded(const QVector<BitTorrent::Torrent *> &torrents) override;
     void torrentAboutToBeDeleted(BitTorrent::Torrent *const) override;
 
     void populate();
@@ -139,10 +139,10 @@ private:
     // No need to redeclare them here as slots.
     void showMenu() override;
     void applyFilter(int row) override;
-    void handleNewTorrent(BitTorrent::Torrent *const torrent) override;
+    void handleTorrentsLoaded(const QVector<BitTorrent::Torrent *> &torrents) override;
     void torrentAboutToBeDeleted(BitTorrent::Torrent *const torrent) override;
 
-    void addItem(const QString &tracker, const BitTorrent::TorrentID &id);
+    void addItems(const QString &trackerURL, const QVector<BitTorrent::TorrentID> &torrents);
     void removeItem(const QString &trackerURL, const BitTorrent::TorrentID &id);
     QString trackerFromRow(int row) const;
     int rowFromTracker(const QString &tracker) const;

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -166,11 +166,10 @@ TransferListModel::TransferListModel(QObject *parent)
 
     // Load the torrents
     using namespace BitTorrent;
-    for (Torrent *const torrent : asConst(Session::instance()->torrents()))
-        addTorrent(torrent);
+    addTorrents(Session::instance()->torrents());
 
     // Listen for torrent changes
-    connect(Session::instance(), &Session::torrentLoaded, this, &TransferListModel::addTorrent);
+    connect(Session::instance(), &Session::torrentsLoaded, this, &TransferListModel::addTorrents);
     connect(Session::instance(), &Session::torrentAboutToBeRemoved, this, &TransferListModel::handleTorrentAboutToBeRemoved);
     connect(Session::instance(), &Session::torrentsUpdated, this, &TransferListModel::handleTorrentsUpdated);
 
@@ -599,15 +598,19 @@ bool TransferListModel::setData(const QModelIndex &index, const QVariant &value,
     return true;
 }
 
-void TransferListModel::addTorrent(BitTorrent::Torrent *const torrent)
+void TransferListModel::addTorrents(const QVector<BitTorrent::Torrent *> &torrents)
 {
-    Q_ASSERT(!m_torrentMap.contains(torrent));
+    int row = m_torrentList.size();
+    beginInsertRows({}, row, (row + torrents.size()));
 
-    const int row = m_torrentList.size();
+    for (BitTorrent::Torrent *torrent : torrents)
+    {
+        Q_ASSERT(!m_torrentMap.contains(torrent));
 
-    beginInsertRows({}, row, row);
-    m_torrentList << torrent;
-    m_torrentMap[torrent] = row;
+        m_torrentList.append(torrent);
+        m_torrentMap[torrent] = row++;
+    }
+
     endInsertRows();
 }
 

--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -103,7 +103,7 @@ public:
     BitTorrent::Torrent *torrentHandle(const QModelIndex &index) const;
 
 private slots:
-    void addTorrent(BitTorrent::Torrent *const torrent);
+    void addTorrents(const QVector<BitTorrent::Torrent *> &torrents);
     void handleTorrentAboutToBeRemoved(BitTorrent::Torrent *const torrent);
     void handleTorrentStatusUpdated(BitTorrent::Torrent *const torrent);
     void handleTorrentsUpdated(const QVector<BitTorrent::Torrent *> &torrents);


### PR DESCRIPTION
Reduce the total startup time of the application and maintain sufficient responsiveness of the UI during startup due to the following:
1. Load resume data from disk asynchronously in separate thread,
2. Split handling of loaded resume data in chunks,
3. Reduce the number of emitting signals.