### PR TITLE
Fix wrong v2 hash string displayed in WebUI

### DIFF
--- a/src/base/digest32.h
+++ b/src/base/digest32.h
@@ -122,7 +122,7 @@ public:
 
     QString hashString() const
     {
-        if (m_hashString.isEmpty())
+        if (m_hashString.isEmpty() && isValid())
         {
             const QByteArray raw = QByteArray::fromRawData(m_nativeDigest.data(), length());
             m_hashString = QString::fromLatin1(raw.toHex());


### PR DESCRIPTION
Previously `0000...` was erroneously displayed when v2 hash is absent, now it correctly shows the `N/A`.
