### PR TITLE
Have separate API controller instances per session

### DIFF
--- a/src/webui/api/apicontroller.cpp
+++ b/src/webui/api/apicontroller.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2018  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2018, 2022  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -37,9 +37,8 @@
 
 #include "apierror.h"
 
-APIController::APIController(ISessionManager *sessionManager, QObject *parent)
+APIController::APIController(QObject *parent)
     : QObject {parent}
-    , m_sessionManager {sessionManager}
 {
 }
 
@@ -54,11 +53,6 @@ QVariant APIController::run(const QString &action, const StringMap &params, cons
         throw APIError(APIErrorType::NotFound);
 
     return m_result;
-}
-
-ISessionManager *APIController::sessionManager() const
-{
-    return m_sessionManager;
 }
 
 const StringMap &APIController::params() const

--- a/src/webui/api/apicontroller.h
+++ b/src/webui/api/apicontroller.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2018  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2018, 2022  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -28,13 +28,11 @@
 
 #pragma once
 
+#include <QtContainerFwd>
 #include <QObject>
 #include <QVariant>
-#include <QtContainerFwd>
 
 class QString;
-
-struct ISessionManager;
 
 using DataMap = QHash<QString, QByteArray>;
 using StringMap = QHash<QString, QString>;
@@ -44,17 +42,10 @@ class APIController : public QObject
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(APIController)
 
-#ifndef Q_MOC_RUN
-#define WEBAPI_PUBLIC
-#define WEBAPI_PRIVATE
-#endif
-
 public:
-    explicit APIController(ISessionManager *sessionManager, QObject *parent = nullptr);
+    explicit APIController(QObject *parent = nullptr);
 
     QVariant run(const QString &action, const StringMap &params, const DataMap &data = {});
-
-    ISessionManager *sessionManager() const;
 
 protected:
     const StringMap &params() const;
@@ -66,7 +57,6 @@ protected:
     void setResult(const QJsonObject &result);
 
 private:
-    ISessionManager *m_sessionManager;
     StringMap m_params;
     DataMap m_data;
     QVariant m_result;

--- a/src/webui/api/authcontroller.h
+++ b/src/webui/api/authcontroller.h
@@ -35,13 +35,15 @@
 
 class QString;
 
+struct ISessionManager;
+
 class AuthController : public APIController
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(AuthController)
 
 public:
-    using APIController::APIController;
+    explicit AuthController(ISessionManager *sessionManager, QObject *parent = nullptr);
 
 private slots:
     void loginAction();
@@ -51,6 +53,8 @@ private:
     bool isBanned() const;
     int failedAttemptsCount() const;
     void increaseFailedAttempts();
+
+    ISessionManager *m_sessionManager = nullptr;
 
     struct FailedLogin
     {

--- a/src/webui/api/isessionmanager.h
+++ b/src/webui/api/isessionmanager.h
@@ -36,14 +36,6 @@ struct ISession
 {
     virtual ~ISession() = default;
     virtual QString id() const = 0;
-    virtual QVariant getData(const QString &id) const = 0;
-    virtual void setData(const QString &id, const QVariant &data) = 0;
-
-    template <class T>
-    T getData(const QString &id) const
-    {
-        return this->getData(id).value<T>();
-    }
 };
 
 struct ISessionManager

--- a/src/webui/api/searchcontroller.h
+++ b/src/webui/api/searchcontroller.h
@@ -28,7 +28,11 @@
 
 #pragma once
 
+#include <memory>
+
 #include <QtContainerFwd>
+#include <QHash>
+#include <QSet>
 
 #include "base/search/searchpluginmanager.h"
 #include "apicontroller.h"
@@ -36,7 +40,6 @@
 class QJsonArray;
 class QJsonObject;
 
-struct ISession;
 struct SearchResult;
 
 class SearchController : public APIController
@@ -64,9 +67,10 @@ private:
 
     void checkForUpdatesFinished(const QHash<QString, PluginVersion> &updateInfo);
     void checkForUpdatesFailed(const QString &reason);
-    void searchFinished(ISession *session, int id);
-    void searchFailed(ISession *session, int id);
     int generateSearchId() const;
     QJsonObject getResults(const QList<SearchResult> &searchResults, bool isSearchActive, int totalResults) const;
     QJsonArray getPluginsInfo(const QStringList &plugins) const;
+
+    QSet<int> m_activeSearches;
+    QHash<int, std::shared_ptr<SearchHandler>> m_searchHandlers;
 };

--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -366,8 +366,8 @@ namespace
     }
 }
 
-SyncController::SyncController(ISessionManager *sessionManager, QObject *parent)
-    : APIController(sessionManager, parent)
+SyncController::SyncController(QObject *parent)
+    : APIController(parent)
 {
     m_freeDiskSpaceThread = new QThread(this);
     m_freeDiskSpaceChecker = new FreeDiskSpaceChecker();
@@ -456,9 +456,6 @@ void SyncController::maindataAction()
 
     QVariantMap data;
 
-    QVariantMap lastResponse = sessionManager()->session()->getData(u"syncMainDataLastResponse"_qs).toMap();
-    QVariantMap lastAcceptedResponse = sessionManager()->session()->getData(u"syncMainDataLastAcceptedResponse"_qs).toMap();
-
     QVariantHash torrents;
     QHash<QString, QStringList> trackers;
     for (const BitTorrent::Torrent *torrent : asConst(session->torrents()))
@@ -470,8 +467,8 @@ void SyncController::maindataAction()
 
         // Calculated last activity time can differ from actual value by up to 10 seconds (this is a libtorrent issue).
         // So we don't need unnecessary updates of last activity time in response.
-        const auto iterTorrents = lastResponse.find(u"torrents"_qs);
-        if (iterTorrents != lastResponse.end())
+        const auto iterTorrents = m_lastMaindataResponse.find(u"torrents"_qs);
+        if (iterTorrents != m_lastMaindataResponse.end())
         {
             const QVariantHash lastResponseTorrents = iterTorrents->toHash();
             const auto iterID = lastResponseTorrents.find(torrentID.toString());
@@ -529,11 +526,8 @@ void SyncController::maindataAction()
     serverState[KEY_SYNC_MAINDATA_REFRESH_INTERVAL] = session->refreshInterval();
     data[u"server_state"_qs] = serverState;
 
-    const int acceptedResponseId {params()[u"rid"_qs].toInt()};
-    setResult(QJsonObject::fromVariantMap(generateSyncData(acceptedResponseId, data, lastAcceptedResponse, lastResponse)));
-
-    sessionManager()->session()->setData(u"syncMainDataLastResponse"_qs, lastResponse);
-    sessionManager()->session()->setData(u"syncMainDataLastAcceptedResponse"_qs, lastAcceptedResponse);
+    const int acceptedResponseId = params()[u"rid"_qs].toInt();
+    setResult(QJsonObject::fromVariantMap(generateSyncData(acceptedResponseId, data, m_lastAcceptedMaindataResponse, m_lastMaindataResponse)));
 }
 
 // GET param:
@@ -541,9 +535,6 @@ void SyncController::maindataAction()
 //   - rid (int): last response id
 void SyncController::torrentPeersAction()
 {
-    auto lastResponse = sessionManager()->session()->getData(u"syncTorrentPeersLastResponse"_qs).toMap();
-    auto lastAcceptedResponse = sessionManager()->session()->getData(u"syncTorrentPeersLastAcceptedResponse"_qs).toMap();
-
     const auto id = BitTorrent::TorrentID::fromString(params()[u"hash"_qs]);
     const BitTorrent::Torrent *torrent = BitTorrent::Session::instance()->findTorrent(id);
     if (!torrent)
@@ -598,11 +589,8 @@ void SyncController::torrentPeersAction()
     }
     data[u"peers"_qs] = peers;
 
-    const int acceptedResponseId {params()[u"rid"_qs].toInt()};
-    setResult(QJsonObject::fromVariantMap(generateSyncData(acceptedResponseId, data, lastAcceptedResponse, lastResponse)));
-
-    sessionManager()->session()->setData(u"syncTorrentPeersLastResponse"_qs, lastResponse);
-    sessionManager()->session()->setData(u"syncTorrentPeersLastAcceptedResponse"_qs, lastAcceptedResponse);
+    const int acceptedResponseId = params()[u"rid"_qs].toInt();
+    setResult(QJsonObject::fromVariantMap(generateSyncData(acceptedResponseId, data, m_lastAcceptedPeersResponse, m_lastPeersResponse)));
 }
 
 qint64 SyncController::getFreeDiskSpace()

--- a/src/webui/api/synccontroller.h
+++ b/src/webui/api/synccontroller.h
@@ -29,10 +29,9 @@
 #pragma once
 
 #include <QElapsedTimer>
+#include <QVariantMap>
 
 #include "apicontroller.h"
-
-struct ISessionManager;
 
 class QThread;
 
@@ -46,7 +45,7 @@ class SyncController : public APIController
 public:
     using APIController::APIController;
 
-    explicit SyncController(ISessionManager *sessionManager, QObject *parent = nullptr);
+    explicit SyncController(QObject *parent = nullptr);
     ~SyncController() override;
 
 private slots:
@@ -62,4 +61,9 @@ private:
     FreeDiskSpaceChecker *m_freeDiskSpaceChecker = nullptr;
     QThread *m_freeDiskSpaceThread = nullptr;
     QElapsedTimer m_freeDiskSpaceElapsedTimer;
+
+    QVariantMap m_lastMaindataResponse;
+    QVariantMap m_lastAcceptedMaindataResponse;
+    QVariantMap m_lastPeersResponse;
+    QVariantMap m_lastAcceptedPeersResponse;
 };

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2014  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2014, 2022  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -119,16 +119,8 @@ namespace
 WebApplication::WebApplication(QObject *parent)
     : QObject(parent)
     , m_cacheID {QString::number(Utils::Random::rand(), 36)}
+    , m_authController {new AuthController(this, this)}
 {
-    registerAPIController(u"app"_qs, new AppController(this, this));
-    registerAPIController(u"auth"_qs, new AuthController(this, this));
-    registerAPIController(u"log"_qs, new LogController(this, this));
-    registerAPIController(u"rss"_qs, new RSSController(this, this));
-    registerAPIController(u"search"_qs, new SearchController(this, this));
-    registerAPIController(u"sync"_qs, new SyncController(this, this));
-    registerAPIController(u"torrents"_qs, new TorrentsController(this, this));
-    registerAPIController(u"transfer"_qs, new TransferController(this, this));
-
     declarePublicAPI(u"auth/login"_qs);
 
     configure();
@@ -260,9 +252,16 @@ void WebApplication::doProcessRequest()
     const QString action = match.captured(u"action"_qs);
     const QString scope = match.captured(u"scope"_qs);
 
-    APIController *controller = m_apiControllers.value(scope);
+    APIController *controller = nullptr;
+    if (session())
+        controller = session()->getAPIController(scope);
     if (!controller)
-        throw NotFoundHTTPError();
+    {
+        if (scope == u"auth")
+            controller = m_authController;
+        else
+            throw NotFoundHTTPError();
+    }
 
     if (!session() && !isPublicAPI(scope, action))
         throw ForbiddenHTTPError();
@@ -412,14 +411,6 @@ void WebApplication::configure()
         if (m_trustedReverseProxyList.isEmpty())
             m_isReverseProxySupportEnabled = false;
     }
-}
-
-void WebApplication::registerAPIController(const QString &scope, APIController *controller)
-{
-    Q_ASSERT(controller);
-    Q_ASSERT(!m_apiControllers.value(scope));
-
-    m_apiControllers[scope] = controller;
 }
 
 void WebApplication::declarePublicAPI(const QString &apiPath)
@@ -607,6 +598,13 @@ void WebApplication::sessionStart()
     });
 
     m_currentSession = new WebSession(generateSid());
+    m_currentSession->registerAPIController<AppController>(u"app"_qs);
+    m_currentSession->registerAPIController<LogController>(u"log"_qs);
+    m_currentSession->registerAPIController<RSSController>(u"rss"_qs);
+    m_currentSession->registerAPIController<SearchController>(u"search"_qs);
+    m_currentSession->registerAPIController<SyncController>(u"sync"_qs);
+    m_currentSession->registerAPIController<TorrentsController>(u"torrents"_qs);
+    m_currentSession->registerAPIController<TransferController>(u"transfer"_qs);
     m_sessions[m_currentSession->id()] = m_currentSession;
 
     QNetworkCookie cookie(C_SID, m_currentSession->id().toUtf8());
@@ -775,12 +773,7 @@ void WebSession::updateTimestamp()
     m_timer.start();
 }
 
-QVariant WebSession::getData(const QString &id) const
+APIController *WebSession::getAPIController(const QString &scope) const
 {
-    return m_data.value(id);
-}
-
-void WebSession::setData(const QString &id, const QVariant &data)
-{
-    m_data[id] = data;
+    return m_apiControllers.value(scope);
 }

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2014, 2017  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2014, 2017, 2022  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -28,9 +28,12 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include <QDateTime>
 #include <QElapsedTimer>
 #include <QHash>
+#include <QMap>
 #include <QObject>
 #include <QRegularExpression>
 #include <QSet>
@@ -48,9 +51,10 @@
 inline const Utils::Version<int, 3, 2> API_VERSION {2, 8, 9};
 
 class APIController;
+class AuthController;
 class WebApplication;
 
-class WebSession final : public ISession
+class WebSession final : public QObject, public ISession
 {
 public:
     explicit WebSession(const QString &sid);
@@ -60,13 +64,19 @@ public:
     bool hasExpired(qint64 seconds) const;
     void updateTimestamp();
 
-    QVariant getData(const QString &id) const override;
-    void setData(const QString &id, const QVariant &data) override;
+    template <typename T>
+    void registerAPIController(const QString &scope)
+    {
+        static_assert(std::is_base_of_v<APIController, T>, "Class should be derived from APIController.");
+        m_apiControllers[scope] = new T(this);
+    }
+
+    APIController *getAPIController(const QString &scope) const;
 
 private:
     const QString m_sid;
     QElapsedTimer m_timer;  // timestamp
-    QVariantHash m_data;
+    QMap<QString, APIController *> m_apiControllers;
 };
 
 class WebApplication final
@@ -75,11 +85,6 @@ class WebApplication final
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(WebApplication)
-
-#ifndef Q_MOC_RUN
-#define WEBAPI_PUBLIC
-#define WEBAPI_PRIVATE
-#endif
 
 public:
     explicit WebApplication(QObject *parent = nullptr);
@@ -99,7 +104,6 @@ private:
     void doProcessRequest();
     void configure();
 
-    void registerAPIController(const QString &scope, APIController *controller);
     void declarePublicAPI(const QString &apiPath);
 
     void sendFile(const Path &path);
@@ -130,7 +134,6 @@ private:
 
     const QRegularExpression m_apiPathPattern {u"^/api/v2/(?<scope>[A-Za-z_][A-Za-z_0-9]*)/(?<action>[A-Za-z_][A-Za-z_0-9]*)$"_qs};
 
-    QHash<QString, APIController *> m_apiControllers;
     QSet<QString> m_publicAPIs;
     bool m_isAltUIUsed = false;
     Path m_rootFolder;
@@ -146,6 +149,7 @@ private:
     QTranslator m_translator;
     bool m_translationFileLoaded = false;
 
+    AuthController *m_authController = nullptr;
     bool m_isLocalAuthEnabled;
     bool m_isAuthSubnetWhitelistEnabled;
     QVector<Utils::Net::Subnet> m_authSubnetWhitelist;


### PR DESCRIPTION
This will allow further to subscribe to BitTorrent session notifications in order to synchronize data more efficiently (only those torrents that have been updated since the last time).
It should also slightly improve performance by using direct data access instead of repetitive reading/rewriting of data in the abstract session storage.