### PR TITLE
WebAPI: return correct status

### DIFF
--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -252,6 +252,9 @@ void WebApplication::doProcessRequest()
     const QString action = match.captured(u"action"_qs);
     const QString scope = match.captured(u"scope"_qs);
 
+    if (!session() && !isPublicAPI(scope, action))
+        throw ForbiddenHTTPError();
+
     APIController *controller = nullptr;
     if (session())
         controller = session()->getAPIController(scope);
@@ -262,9 +265,6 @@ void WebApplication::doProcessRequest()
         else
             throw NotFoundHTTPError();
     }
-
-    if (!session() && !isPublicAPI(scope, action))
-        throw ForbiddenHTTPError();
 
     DataMap data;
     for (const Http::UploadedFile &torrent : request().files)


### PR DESCRIPTION
Since https://github.com/qbittorrent/qBittorrent/commit/4471a6377ee7446cfbcf0314654a41de8bb4a9f3 when not having a session the API would return "Not Found" instead of "Forbidden" when trying to access a non-public endpoint.

This also broke other software like Radarr/Sonarr which expected a 403 and not a 404 to detect the web API version.
