### PR TITLE
Prevent multiple copying the resume data where possible

### DIFF
--- a/src/base/bittorrent/bencoderesumedatastorage.cpp
+++ b/src/base/bittorrent/bencoderesumedatastorage.cpp
@@ -60,7 +60,7 @@ namespace BitTorrent
     public:
         explicit Worker(const Path &resumeDataDir);
 
-        void store(const TorrentID &id, const LoadTorrentParams &resumeData) const;
+        void store(const TorrentID &id, LoadTorrentParams resumeData) const;
         void remove(const TorrentID &id) const;
         void storeQueue(const QVector<TorrentID> &queue) const;
 
@@ -252,11 +252,11 @@ std::optional<BitTorrent::LoadTorrentParams> BitTorrent::BencodeResumeDataStorag
     return torrentParams;
 }
 
-void BitTorrent::BencodeResumeDataStorage::store(const TorrentID &id, const LoadTorrentParams &resumeData) const
+void BitTorrent::BencodeResumeDataStorage::store(const TorrentID &id, LoadTorrentParams resumeData) const
 {
-    QMetaObject::invokeMethod(m_asyncWorker, [this, id, resumeData]()
+    QMetaObject::invokeMethod(m_asyncWorker, [this, id, resumeData = std::move(resumeData)]() mutable
     {
-        m_asyncWorker->store(id, resumeData);
+        m_asyncWorker->store(id, std::move(resumeData));
     });
 }
 
@@ -314,10 +314,10 @@ BitTorrent::BencodeResumeDataStorage::Worker::Worker(const Path &resumeDataDir)
 {
 }
 
-void BitTorrent::BencodeResumeDataStorage::Worker::store(const TorrentID &id, const LoadTorrentParams &resumeData) const
+void BitTorrent::BencodeResumeDataStorage::Worker::store(const TorrentID &id, LoadTorrentParams resumeData) const
 {
     // We need to adjust native libtorrent resume data
-    lt::add_torrent_params p = resumeData.ltAddTorrentParams;
+    lt::add_torrent_params &p = resumeData.ltAddTorrentParams;
     p.save_path = Profile::instance()->toPortablePath(Path(p.save_path))
             .toString().toStdString();
     if (resumeData.stopped)

--- a/src/base/bittorrent/bencoderesumedatastorage.h
+++ b/src/base/bittorrent/bencoderesumedatastorage.h
@@ -50,7 +50,7 @@ namespace BitTorrent
 
         QVector<TorrentID> registeredTorrents() const override;
         std::optional<LoadTorrentParams> load(const TorrentID &id) const override;
-        void store(const TorrentID &id, const LoadTorrentParams &resumeData) const override;
+        void store(const TorrentID &id, LoadTorrentParams resumeData) const override;
         void remove(const TorrentID &id) const override;
         void storeQueue(const QVector<TorrentID> &queue) const override;
 

--- a/src/base/bittorrent/dbresumedatastorage.h
+++ b/src/base/bittorrent/dbresumedatastorage.h
@@ -46,7 +46,7 @@ namespace BitTorrent
 
         QVector<TorrentID> registeredTorrents() const override;
         std::optional<LoadTorrentParams> load(const TorrentID &id) const override;
-        void store(const TorrentID &id, const LoadTorrentParams &resumeData) const override;
+        void store(const TorrentID &id, LoadTorrentParams resumeData) const override;
         void remove(const TorrentID &id) const override;
         void storeQueue(const QVector<TorrentID> &queue) const override;
 

--- a/src/base/bittorrent/resumedatastorage.h
+++ b/src/base/bittorrent/resumedatastorage.h
@@ -48,7 +48,7 @@ namespace BitTorrent
 
         virtual QVector<TorrentID> registeredTorrents() const = 0;
         virtual std::optional<LoadTorrentParams> load(const TorrentID &id) const = 0;
-        virtual void store(const TorrentID &id, const LoadTorrentParams &resumeData) const = 0;
+        virtual void store(const TorrentID &id, LoadTorrentParams resumeData) const = 0;
         virtual void remove(const TorrentID &id) const = 0;
         virtual void storeQueue(const QVector<TorrentID> &queue) const = 0;
     };

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -516,7 +516,7 @@ namespace BitTorrent
         void handleTorrentTrackersChanged(TorrentImpl *const torrent);
         void handleTorrentUrlSeedsAdded(TorrentImpl *const torrent, const QVector<QUrl> &newUrlSeeds);
         void handleTorrentUrlSeedsRemoved(TorrentImpl *const torrent, const QVector<QUrl> &urlSeeds);
-        void handleTorrentResumeDataReady(TorrentImpl *const torrent, const LoadTorrentParams &data);
+        void handleTorrentResumeDataReady(TorrentImpl *const torrent, LoadTorrentParams data);
 
         bool addMoveTorrentStorageJob(TorrentImpl *torrent, const Path &newPath, MoveStorageMode mode);
 

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -228,7 +228,7 @@ namespace
 // TorrentImpl
 
 TorrentImpl::TorrentImpl(Session *session, lt::session *nativeSession
-                                     , const lt::torrent_handle &nativeHandle, const LoadTorrentParams &params)
+                                     , const lt::torrent_handle &nativeHandle, LoadTorrentParams params)
     : QObject(session)
     , m_session(session)
     , m_nativeSession(nativeSession)
@@ -251,7 +251,7 @@ TorrentImpl::TorrentImpl(Session *session, lt::session *nativeSession
     , m_hasFirstLastPiecePriority(params.firstLastPiecePriority)
     , m_useAutoTMM(params.useAutoTMM)
     , m_isStopped(params.stopped)
-    , m_ltAddTorrentParams(params.ltAddTorrentParams)
+    , m_ltAddTorrentParams(std::move(params.ltAddTorrentParams))
 {
     if (m_ltAddTorrentParams.ti)
     {
@@ -1874,7 +1874,7 @@ void TorrentImpl::prepareResumeData(const lt::add_torrent_params &params)
         resumeData.downloadPath = m_downloadPath;
     }
 
-    m_session->handleTorrentResumeDataReady(this, resumeData);
+    m_session->handleTorrentResumeDataReady(this, std::move(resumeData));
 }
 
 void TorrentImpl::handleSaveResumeDataFailedAlert(const lt::save_resume_data_failed_alert *p)

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -86,7 +86,7 @@ namespace BitTorrent
 
     public:
         TorrentImpl(Session *session, lt::session *nativeSession
-                          , const lt::torrent_handle &nativeHandle, const LoadTorrentParams &params);
+                          , const lt::torrent_handle &nativeHandle, LoadTorrentParams params);
         ~TorrentImpl() override;
 
         bool isValid() const;


### PR DESCRIPTION
This is one more standalone part of #16840.

Now it recklessly copies LoadTorrentParams many times during one logical subprocess - restoring an existing torrent, adding a new torrent, or saving resume data. It is a fairly large data structure, most of which are not Qt shared data compliant.
