### PR TITLE
GHA CI: Update dependencies

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -14,12 +14,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libt_version: ["2.0.5", "1.2.15"]
+        libt_version: ["2.0.6", "1.2.16"]
         qbt_gui: ["GUI=ON", "GUI=OFF"]
-        qt_version: ["5.15.2", "6.2.0"]
+        qt_version: ["5.15.2", "6.3.0"]
         exclude:
-          - libt_version: "1.2.15"
-            qt_version: "6.2.0"
+          - libt_version: "1.2.16"
+            qt_version: "6.3.0"
 
     env:
       boost_path: "${{ github.workspace }}/../boost"
@@ -46,13 +46,14 @@ jobs:
           curl \
             -L \
             -o "${{ runner.temp }}/boost.tar.bz2" \
-            "https://boostorg.jfrog.io/artifactory/main/release/1.77.0/source/boost_1_77_0.tar.bz2"
+            "https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.bz2"
           tar -xf "${{ runner.temp }}/boost.tar.bz2" -C "${{ github.workspace }}/.."
           mv "${{ github.workspace }}/.."/boost_* "${{ env.boost_path }}"
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v2
         with:
+          aqtversion: '==2.1.0'
           setup-python: false
           version: ${{ matrix.qt_version }}
 

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -14,11 +14,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libt_version: ["2.0.5", "1.2.15"]
+        libt_version: ["2.0.6", "1.2.16"]
         qbt_gui: ["GUI=ON", "GUI=OFF"]
         qt_version: ["5.15.2", "6.2.0"]
         exclude:
-          - libt_version: "1.2.15"
+          - libt_version: "1.2.16"
             qt_version: "6.2.0"
 
     steps:

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libt_version: ["2.0.5", "1.2.15"]
+        libt_version: ["2.0.6", "1.2.16"]
 
     env:
       boost_path: "${{ github.workspace }}/../boost"
@@ -67,7 +67,7 @@ jobs:
       - name: Install boost
         run: |
           aria2c `
-            "https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.7z" `
+            "https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.7z" `
             -d "${{ runner.temp }}" `
             -o "boost.7z"
           7z x "${{ runner.temp }}/boost.7z" -o"${{ github.workspace }}/.."
@@ -76,7 +76,8 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v2
         with:
-          version: "6.2.0"
+          aqtversion: '==2.1.0'
+          version: "6.3.0"
 
       - name: Install libtorrent
         run: |

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install libtorrent
         run: |
           git clone \
-            --branch "v2.0.5" \
+            --branch "v2.0.6" \
             --depth 1 \
             --recurse-submodules \
             https://github.com/arvidn/libtorrent.git

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
           - ts
 
   - repo: https://github.com/pre-commit/pre-commit-hooks.git
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
     - id: check-json
       name: Check JSON files


### PR DESCRIPTION
Update `libtorrent` version(s) to `2.0.6` & `1.2.16` in `GHA CI`
- https://github.com/arvidn/libtorrent/releases/tag/v2.0.6
- https://github.com/arvidn/libtorrent/releases/tag/v1.2.16

Update `Boost` version to `1.79.0`
- https://www.boost.org/users/history/version_1_79_0.html

Bump `pre-commit-hooks` version to `4.2.0`
- https://github.com/pre-commit/pre-commit-hooks/releases/tag/v4.2.0

Update `Qt6` version to `6.3.0`
- https://www.qt.io/blog/qt-6.3-released
- https://code.qt.io/cgit/qt/qtreleasenotes.git/about/qt/6.3.0/release-note.md

Note: used `aqtinstall 2.1.0` with `jurplel
/
install-qt-action` for support of `Qt 6.2.1+`
(this requirement can be removed on official release of `jurplel
/
install-qt-action v3`)