### PR TITLE
Add support for exporting .torrent data to buffer

### DIFF
--- a/src/base/bittorrent/torrent.h
+++ b/src/base/bittorrent/torrent.h
@@ -40,6 +40,7 @@
 #include "abstractfilestorage.h"
 
 class QBitArray;
+class QByteArray;
 class QDateTime;
 class QUrl;
 
@@ -301,6 +302,7 @@ namespace BitTorrent
         virtual void clearPeers() = 0;
 
         virtual QString createMagnetURI() const = 0;
+        virtual nonstd::expected<QByteArray, QString> exportToBuffer() const = 0;
         virtual nonstd::expected<void, QString> exportToFile(const Path &path) const = 0;
 
         TorrentID id() const;

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -227,7 +227,8 @@ namespace BitTorrent
         void clearPeers() override;
 
         QString createMagnetURI() const override;
-        nonstd::expected<void, QString> exportToFile(const Path &path) const;
+        nonstd::expected<QByteArray, QString> exportToBuffer() const override;
+        nonstd::expected<void, QString> exportToFile(const Path &path) const override;
 
         bool needSaveResumeData() const;
 
@@ -279,6 +280,8 @@ namespace BitTorrent
         void prepareResumeData(const lt::add_torrent_params &params);
         void endReceivedMetadataHandling(const Path &savePath, const PathList &fileNames);
         void reload();
+
+        nonstd::expected<lt::entry, QString> exportTorrent() const;
 
         Session *const m_session;
         lt::session *m_nativeSession;


### PR DESCRIPTION
Related: https://github.com/qbittorrent/qBittorrent/pull/16886#discussion_r855882018

@Piccirello
Now you can use it from webapi:
```c++
const nonstd::expected<QByteArray, QString> result = someTorrentHandle.exportToBuffer();
if (result) // no error occurred, provides data
    const QByteArray &data = result.value();
else  // has error, provides error string
    const QString &errorMsg = result.error();
```