### PR TITLE
Fix nogui compilation for Windows

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -32,6 +32,7 @@
 #include <csignal>
 #include <cstdlib>
 #include <memory>
+#include <tuple>
 
 #if defined(Q_OS_UNIX)
 #include <sys/resource.h>
@@ -318,17 +319,13 @@ int main(int argc, char *argv[])
 void reportToUser(const char *str)
 {
     const size_t strLen = strlen(str);
-#ifndef Q_OS_WIN
-    if (write(STDERR_FILENO, str, strLen) < static_cast<ssize_t>(strLen))
-    {
-        const auto dummy = write(STDOUT_FILENO, str, strLen);
+#ifdef Q_OS_WIN
+    if (_write(_fileno(stderr), str, strLen) < static_cast<int>(strLen))
+        std::ignore = _write(_fileno(stdout), str, strLen);
 #else
-    if (_write(STDERR_FILENO, str, strLen) < static_cast<ssize_t>(strLen))
-    {
-        const auto dummy = _write(STDOUT_FILENO, str, strLen);
+    if (write(STDERR_FILENO, str, strLen) < static_cast<ssize_t>(strLen))
+        std::ignore = write(STDOUT_FILENO, str, strLen);
 #endif
-        Q_UNUSED(dummy);
-    }
 }
 #endif
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -352,7 +352,9 @@ void sigAbnormalHandler(int signum)
     reportToUser(msg);
     reportToUser(sigName);
     reportToUser("\n");
+#if !defined Q_OS_WIN
     print_stacktrace();  // unsafe
+#endif
 #endif
 
 #if defined Q_OS_WIN && !defined DISABLE_GUI

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -211,9 +211,7 @@ int main(int argc, char *argv[])
                 throw CommandLineParameterError(QObject::tr("You cannot use %1: qBittorrent is already running for this user.")
                                      .arg(u"-d (or --daemon)"_qs));
             }
-            else
 #endif
-            qDebug("qBittorrent is already running for this user.");
 
             QThread::msleep(300);
             app->sendParams(params.paramList());


### PR DESCRIPTION
* Use correct type for comparisons
  `_write()` actually returns `int` type.
  And fix wrong function parameters.
  Closes https://github.com/qbittorrent/qBittorrent/issues/16938.
  Closes https://github.com/qbittorrent/qBittorrent/issues/16944.
* Avoid splitting code over ifdef boundary
  By removing unimportant debug message.
* Disable Linux-specific function when compiling for Windows

I should backport it to v4.4.x since it resolves severe compilation issue.