### PR TITLE
Allow to disable dedicated hashing threads

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -3393,7 +3393,7 @@ void Session::setAsyncIOThreads(const int num)
 
 int Session::hashingThreads() const
 {
-    return std::clamp(m_hashingThreads.get(), 1, 1024);
+    return std::clamp(m_hashingThreads.get(), 0, 1024);
 }
 
 void Session::setHashingThreads(const int num)

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -463,7 +463,7 @@ void AdvancedSettings::loadAdvancedSettings()
 
 #ifdef QBT_USES_LIBTORRENT2
     // Hashing threads
-    m_spinBoxHashingThreads.setMinimum(1);
+    m_spinBoxHashingThreads.setMinimum(0);
     m_spinBoxHashingThreads.setMaximum(1024);
     m_spinBoxHashingThreads.setValue(session->hashingThreads());
     addRow(HASHING_THREADS, (tr("Hashing threads") + u' ' + makeLink(u"https://www.libtorrent.org/reference-Settings.html#hashing_threads", u"(?)"))


### PR DESCRIPTION
by setting Hashing threads to zero. The hashing will be done by generic threads in that case.
