### PR TITLE
Separate docker image `data` and `config` dirs

### DIFF
--- a/dist/docker/Dockerfile
+++ b/dist/docker/Dockerfile
@@ -32,6 +32,6 @@ ENV WEBUI_PORT="8080"
 
 EXPOSE 6881 6881/udp 8080
 
-VOLUME /config /downloads
+VOLUME /config /data /downloads
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/dist/docker/Readme.md
+++ b/dist/docker/Readme.md
@@ -39,10 +39,11 @@ there is one important variable to run the container:
 
 #### Volumes
 
-there are two main locations:
+there are three main locations:
 
-* `downloads` contains the files downloaded by qBittorrent
 * `config` contains qBittorrent configurations
+* `data` contains qBittorrent application data
+* `downloads` contains the files downloaded by qBittorrent
 
 ```shell
 docker run give.example.org/of/your/container:v0.2.1 parameters
@@ -57,7 +58,7 @@ on the port `8080` the webinterface is run
 To start the the docker image simply run
 
 ```shell
-docker run --env LEGAL=accept -p 8080:8080 -v /your/path/config:/config -v /your/path/download:/downloads --name qBittorrent qbittorrent-nox:4.2.0
+docker run --env LEGAL=accept -p 8080:8080 -v /your/path/config:/config -v /your/path/data:/data -v /your/path/download:/downloads --name qBittorrent qbittorrent-nox:4.2.0
 ```
 
 to stop the container

--- a/dist/docker/entrypoint.sh
+++ b/dist/docker/entrypoint.sh
@@ -18,4 +18,4 @@ else
     sed -i '/^\[LegalNotice\]$/{$!{N;s|\(\[LegalNotice\]\nAccepted=\).*|\1false|}}' /config/qBittorrent/qBittorrent.conf
 fi
 
-HOME="/config" XDG_CONFIG_HOME="/config" XDG_DATA_HOME="/config" qbittorrent-nox --webui-port=$WEBUI_PORT
+HOME="/config" XDG_CONFIG_HOME="/config" XDG_DATA_HOME="/data" qbittorrent-nox --webui-port=$WEBUI_PORT


### PR DESCRIPTION
This PR separates these directories to prevent their contents from clobbering each other. For ex, on initial run, both directories create an `rss` directory. There are no guarantees future files won't conflict.

```sh
/ $ ls -l /config/qBittorrent/
total 20
-rw-r--r--    1 root     root             4 May  2 05:13 categories.json
srwx------    1 root     root             0 May  2 05:13 ipc-socket
-rw-r--r--    1 root     root             0 May  2 05:13 lockfile
-rw-r--r--    1 root     root           185 May  2 05:14 qBittorrent-data.conf
-rw-r--r--    1 root     root          1702 May  2 05:13 qBittorrent.conf
drwxr-xr-x    2 root     root          4096 May  2 05:13 rss
-rw-r--r--    1 root     root             4 May  2 05:13 watched_folders.json
/ $ ls -l /data/qBittorrent/
total 16
drwxr-xr-x    2 root     root          4096 May  2 05:13 BT_backup
drwxr-xr-x    2 root     root          4096 May  2 05:13 GeoDB
drwxr-xr-x    2 root     root          4096 May  2 05:13 logs
drwxr-xr-x    3 root     root          4096 May  2 05:13 rss
```

(cc @Amanuense-del-diavolo)
