### PR TITLE
Fix Docker legal notice when using existing config

### DIFF
--- a/dist/docker/entrypoint.sh
+++ b/dist/docker/entrypoint.sh
@@ -10,12 +10,12 @@ Session\TempPath=/downloads/temp
 [LegalNotice]
 Accepted=false
 EOF
-fi
 
-if [ "$LEGAL" = "accept" ] ; then
-    sed -i '/^\[LegalNotice\]$/{$!{N;s|\(\[LegalNotice\]\nAccepted=\).*|\1true|}}' /config/qBittorrent/qBittorrent.conf
-else
-    sed -i '/^\[LegalNotice\]$/{$!{N;s|\(\[LegalNotice\]\nAccepted=\).*|\1false|}}' /config/qBittorrent/qBittorrent.conf
+    if [ "$LEGAL" = "accept" ] ; then
+        sed -i '/^\[LegalNotice\]$/{$!{N;s|\(\[LegalNotice\]\nAccepted=\).*|\1true|}}' /config/qBittorrent/qBittorrent.conf
+    else
+        sed -i '/^\[LegalNotice\]$/{$!{N;s|\(\[LegalNotice\]\nAccepted=\).*|\1false|}}' /config/qBittorrent/qBittorrent.conf
+    fi
 fi
 
 HOME="/config" XDG_CONFIG_HOME="/config" XDG_DATA_HOME="/config" qbittorrent-nox --webui-port=$WEBUI_PORT


### PR DESCRIPTION
If the user is using a pre-existing config, don't update the legal notice.
