### PR TITLE
Improve Docker build

### DIFF
--- a/dist/docker/Dockerfile
+++ b/dist/docker/Dockerfile
@@ -1,37 +1,51 @@
-
+# image for building
 FROM alpine:latest AS builder
 
-ARG BUILD_TYPE
-ARG RELEASE
+ARG QBT_VERSION
 
-RUN if [ $RELEASE = "master" ] ; \
-    then \
-      wget https://github.com/qbittorrent/qBittorrent/archive/refs/heads/master.zip && \
-      unzip master.zip && \
-      cd qBittorrent-master ; \
-    else \
-      wget https://github.com/qbittorrent/qBittorrent/archive/refs/tags/release-${RELEASE}.tar.gz && \
-      tar xf release-${RELEASE}.tar.gz && \
-      cd qBittorrent-release-${RELEASE} ; \
-    fi && \
-    apk add --no-cache qt6-qttools-dev g++ libtorrent-rasterbar-dev cmake boost-dev ninja && \
-    cmake -B build-nox -G "Ninja" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DGUI=OFF -DQT6=ON -DSTACKTRACE=OFF && \
-    cmake --build build-nox && \
-    cmake --build build-nox --target install/strip
+# alpine linux qbittorrent package: https://git.alpinelinux.org/aports/tree/community/qbittorrent/APKBUILD
 
+RUN \
+  apk --update-cache add \
+    boost-dev \
+    cmake \
+    g++ \
+    libtorrent-rasterbar-dev \
+    ninja \
+    qt6-qtbase-dev \
+    qt6-qttools-dev
+
+RUN \
+  if [ "$QBT_VERSION" = "devel" ]; then \
+    wget https://github.com/qbittorrent/qBittorrent/archive/refs/heads/master.zip && \
+    unzip master.zip && \
+    cd qBittorrent-master ; \
+  else \
+    wget "https://github.com/qbittorrent/qBittorrent/archive/refs/tags/release-${QBT_VERSION}.tar.gz" && \
+    tar -xf "release-${QBT_VERSION}.tar.gz" && \
+    cd "qBittorrent-release-${QBT_VERSION}" ; \
+  fi && \
+  cmake \
+    -B build \
+    -G Ninja \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DGUI=OFF \
+    -DQT6=ON \
+    -DSTACKTRACE=OFF && \
+  cmake --build build && \
+  cmake --install build
+
+# image for running
 FROM alpine:latest
+
+RUN \
+  apk --no-cache add \
+    libtorrent-rasterbar \
+    qt6-qtbase \
+    tini
 
 COPY --from=builder /usr/local/bin/qbittorrent-nox /usr/bin/qbittorrent-nox
 
 COPY entrypoint.sh /entrypoint.sh
 
-RUN chmod +x /entrypoint.sh && \
-    apk add --no-cache qt6-qtbase libtorrent-rasterbar
-
-ENV WEBUI_PORT="8080"
-
-EXPOSE 6881 6881/udp 8080
-
-VOLUME /config /data /downloads
-
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "-g", "--", "/entrypoint.sh"]

--- a/dist/docker/Readme.md
+++ b/dist/docker/Readme.md
@@ -1,68 +1,71 @@
-# Docker Container Name
+# qBittorrent-nox Docker Image
 
-This Dockerfile allows you to build a qBittorrent-nox container
+This Dockerfile allows you to build a docker image containing qBittorrent-nox
 
-## Getting Started
+## Prerequisities
 
-### Prerequisities
+In order to build/run this image you'll need docker installed: https://docs.docker.com/get-docker/
 
+## Building docker image
 
-In order to run this container you'll need docker installed.
-
-* [Windows](https://docs.docker.com/windows/started)
-* [OS X](https://docs.docker.com/mac/started/)
-* [Linux](https://docs.docker.com/linux/started/)
-
-
-## Built
-
-in the docker folder run
-
+In this docker folder run:
 ```shell
-release="4.2.0" ; sudo docker build --build-arg BUILD_TYPE=Release --build-arg RELEASE=$release -t qbittorrent-nox:$release --rm  .
+export \
+  QBT_VERSION=devel
+docker build \
+  --build-arg QBT_VERSION \
+  -t qbittorrent-nox:"$QBT_VERSION" \
+  .
 ```
 
-where:
+### Parameters
 
-* the `release` variable is the specific tagged version you want to build
-* the `BUILD_TYPE` argument is the build you want to create `Debug` or `Release`
-* the `RELEASE` argument works as the but is the actual argument given to docker, in the above script is defined by the `release` variable
+* `QBT_VERSION`
+  This environment variable specifies the version of qBittorrent-nox to be built. \
+  For example, `4.4.0` is a valid entry. You can find all tagged versions [here](https://github.com/qbittorrent/qBittorrent/tags). \
+  Or you can put `devel` to build the latest development version.
 
+## Running docker image
 
-### Usage
+* To start the the docker image simply run:
+  ```shell
+  export \
+    QBT_VERSION=devel \
+    QBT_EULA=accept \
+    QBT_WEBUI_PORT=8080
+  docker run \
+    -it \
+    --rm \
+    --name qbittorrent-nox \
+    -e QBT_EULA \
+    -e QBT_WEBUI_PORT \
+    -p "$QBT_WEBUI_PORT":"$QBT_WEBUI_PORT" \
+    -p 6881:6881/tcp \
+    -p 6881:6881/udp \
+    -v /your_path/config:/config \
+    -v /your_path/downloads:/downloads \
+    qbittorrent-nox:"$QBT_VERSION"
+  ```
+  Then you can login at: `http://127.0.0.1:8080`
 
-#### Container Variables
+* To stop the container:
+  ```shell
+  docker stop -t 1800 qbittorrent-nox
+  ```
 
-there is one important variable to run the container:
+### Parameters
 
-* the `LEGAL` varible defines if you accept the Legal Notice, put accept as a value only if you understand and accept the Legal Notice
+* `QBT_VERSION` \
+  The same as [above](#variables).
+* `QBT_EULA` \
+  This environment variable defines whether you accept the end-user license agreement (EULA) of qBittorrent. \
+  Put `accept` only if you understand and accepted the EULA. You can find
+  the EULA [here](https://github.com/qbittorrent/qBittorrent/blob/56667e717b82c79433ecb8a5ff6cc2d7b315d773/src/app/main.cpp#L320-L323).
+* `QBT_WEBUI_PORT` \
+  This environment variable sets the port number which qBittorrent WebUI will be binded to.
 
-#### Volumes
+### Volumes
 
-there are three main locations:
-
-* `config` contains qBittorrent configurations
-* `data` contains qBittorrent application data
-* `downloads` contains the files downloaded by qBittorrent
-
-```shell
-docker run give.example.org/of/your/container:v0.2.1 parameters
-```
-
-#### Network
-
-on the port `8080` the webinterface is run
-
-#### RUN
-
-To start the the docker image simply run
-
-```shell
-docker run --env LEGAL=accept -p 8080:8080 -v /your/path/config:/config -v /your/path/data:/data -v /your/path/download:/downloads --name qBittorrent qbittorrent-nox:4.2.0
-```
-
-to stop the container
-
-```shell
-docker stop qBittorrent
-```
+There are some paths involved:
+* `/your_path/config` on your host machine will contain qBittorrent configurations
+* `/your_path/downloads` on your host machine will contain the files downloaded by qBittorrent

--- a/dist/docker/entrypoint.sh
+++ b/dist/docker/entrypoint.sh
@@ -1,21 +1,28 @@
 #!/bin/sh
 
-if [ ! -f /config/qBittorrent/qBittorrent.conf ]; then
-    mkdir -p /config/qBittorrent/
-    cat << EOF > /config/qBittorrent/qBittorrent.conf
+profilePath="/config"
+qbtConfigFile="$profilePath/qBittorrent/config/qBittorrent.conf"
+
+if [ ! -f "$qbtConfigFile" ]; then
+    mkdir -p "$(dirname $qbtConfigFile)"
+    cat << EOF > "$qbtConfigFile"
 [BitTorrent]
 Session\DefaultSavePath=/downloads
+Session\Port=6881
 Session\TempPath=/downloads/temp
 
 [LegalNotice]
 Accepted=false
 EOF
 
-    if [ "$LEGAL" = "accept" ] ; then
-        sed -i '/^\[LegalNotice\]$/{$!{N;s|\(\[LegalNotice\]\nAccepted=\).*|\1true|}}' /config/qBittorrent/qBittorrent.conf
+    if [ "$QBT_EULA" = "accept" ]; then
+        sed -i '/^\[LegalNotice\]$/{$!{N;s|\(\[LegalNotice\]\nAccepted=\).*|\1true|}}' "$qbtConfigFile"
     else
-        sed -i '/^\[LegalNotice\]$/{$!{N;s|\(\[LegalNotice\]\nAccepted=\).*|\1false|}}' /config/qBittorrent/qBittorrent.conf
+        sed -i '/^\[LegalNotice\]$/{$!{N;s|\(\[LegalNotice\]\nAccepted=\).*|\1false|}}' "$qbtConfigFile"
     fi
 fi
 
-HOME="/config" XDG_CONFIG_HOME="/config" XDG_DATA_HOME="/data" qbittorrent-nox --webui-port=$WEBUI_PORT
+qbittorrent-nox \
+    --profile="$profilePath" \
+    --webui-port="$QBT_WEBUI_PORT" \
+    "$@"


### PR DESCRIPTION
* Improves code readability.
* Improve documentation.
* Fix "docker stop" doesn't terminate qbt gracefully which could lead to data corruption.
* Provide correct/working bittorrent listening port by default.
* Make use of qbt profile option instead of hacking environment variables.
* Simplify build steps.

~~Note that this PR already incorporate changes from #16974. I'll rebase it again after #16974 is merged.~~ Done.