### PR TITLE
Store WebUI port setting in human readable number

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -592,12 +592,13 @@ void Preferences::setWebUiAddress(const QString &addr)
 
 quint16 Preferences::getWebUiPort() const
 {
-    return value<int>(u"Preferences/WebUI/Port"_qs, 8080);
+    return value<quint16>(u"Preferences/WebUI/Port"_qs, 8080);
 }
 
 void Preferences::setWebUiPort(const quint16 port)
 {
-    setValue(u"Preferences/WebUI/Port"_qs, port);
+    // cast to `int` type so it will show human readable unit in configuration file
+    setValue(u"Preferences/WebUI/Port"_qs, static_cast<int>(port));
 }
 
 bool Preferences::useUPnPForWebUIPort() const

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -661,7 +661,7 @@ void AppController::setPreferencesAction()
     if (hasKey(u"web_ui_address"_qs))
         pref->setWebUiAddress(it.value().toString());
     if (hasKey(u"web_ui_port"_qs))
-        pref->setWebUiPort(it.value().toUInt());
+        pref->setWebUiPort(it.value().value<quint16>());
     if (hasKey(u"web_ui_upnp"_qs))
         pref->setUPnPForWebUIPort(it.value().toBool());
     if (hasKey(u"use_https"_qs))


### PR DESCRIPTION
Previously it was wrapped in QVariant type.