### PR TITLE
Fix empty selection in WebUI language combobox

### DIFF
--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1900,7 +1900,7 @@
 
                         // Web UI tab
                         // Language
-                        $('locale_select').setProperty('value', pref.locale);
+                        $('locale_select').setProperty('value', ((pref.locale === "en_US") ? "en" : pref.locale));
                         $('performanceWarning').setProperty('checked', pref.performance_warning);
 
                         // HTTP Server


### PR DESCRIPTION
This mostly happens with a clean install.
