### PR TITLE
WebUI: Report last activity as "< 1m ago" while torrent is active

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1257,8 +1257,8 @@ window.qBittorrent.DynamicTable = (function() {
             this.columns['last_activity'].updateTd = function(td, row) {
                 const val = this.getRowValue(row);
                 if (val < 1) {
-                    td.set('text', '∞');
-                    td.set('title', '∞');
+                    td.set('text', '< 1m');
+                    td.set('title', '< 1m');
                 }
                 else {
                     const formattedVal = 'QBT_TR(%1 ago)QBT_TR[CONTEXT=TransferListDelegate]'.replace('%1', window.qBittorrent.Misc.friendlyDuration((new Date()) / 1000 - val));


### PR DESCRIPTION
The desktop UI already does this as far as I can tell (I don't use it) [here](https://github.com/qbittorrent/qBittorrent/blob/75c93d72be7a31f29d6c14aa6f3eefa8ec9f9ea1/src/gui/transferlistmodel.cpp#L305)

I've made what I think are the necessary changes to have this reflect on the WebUI too. "∞ ago" doesn't make sense when the torrent is currently active (in my humble opinion), and consistency across the desktop app and web UI is a bonus.

I'm not massively familiar with the codebase so not sure if there's a better way I could make this change, but as far as I can gather this should be all that's needed. I've not tested the change as it's just a string change, but if it doesn't work as I'm expecting let me know and I can look into it further