### PR TITLE
Bump boost requirement to 1.71

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ project(qBittorrent
 # use CONFIG mode first in find_package
 set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 # version requirements - older versions may work, but you are on your own
-set(minBoostVersion 1.65)
+set(minBoostVersion 1.71)
 set(minQt5Version 5.15.2)
 set(minQt6Version 6.2)
 set(minOpenSSLVersion 1.1.1)

--- a/INSTALL
+++ b/INSTALL
@@ -3,7 +3,7 @@ qBittorrent - A BitTorrent client in C++ / Qt
 
 1) Install these dependencies:
 
-  - Boost >= 1.65
+  - Boost >= 1.71
 
   - libtorrent-rasterbar 1.2.14 - 1.2.x || 2.0.4 - 2.0.x
       * By Arvid Norberg, https://www.libtorrent.org/

--- a/configure
+++ b/configure
@@ -5707,11 +5707,11 @@ if test "x$want_boost" = "xyes"
 then :
 
 
-  if test "x1.65" = "x"
+  if test "x1.71" = "x"
 then :
   _AX_BOOST_BASE_TONUMERICVERSION_req="1.20.0"
 else $as_nop
-  _AX_BOOST_BASE_TONUMERICVERSION_req="1.65"
+  _AX_BOOST_BASE_TONUMERICVERSION_req="1.71"
 fi
   _AX_BOOST_BASE_TONUMERICVERSION_req_shorten=`expr $_AX_BOOST_BASE_TONUMERICVERSION_req : '\([0-9]*\.[0-9]*\)'`
   _AX_BOOST_BASE_TONUMERICVERSION_req_major=`expr $_AX_BOOST_BASE_TONUMERICVERSION_req : '\([0-9]*\)'`
@@ -5759,8 +5759,8 @@ esac
                 if test "x$_AX_BOOST_BASE_boost_path" != "x"
 then :
 
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for boostlib >= 1.65 ($WANT_BOOST_VERSION) includes in \"$_AX_BOOST_BASE_boost_path/include\"" >&5
-printf %s "checking for boostlib >= 1.65 ($WANT_BOOST_VERSION) includes in \"$_AX_BOOST_BASE_boost_path/include\"... " >&6; }
+        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for boostlib >= 1.71 ($WANT_BOOST_VERSION) includes in \"$_AX_BOOST_BASE_boost_path/include\"" >&5
+printf %s "checking for boostlib >= 1.71 ($WANT_BOOST_VERSION) includes in \"$_AX_BOOST_BASE_boost_path/include\"... " >&6; }
          if test -d "$_AX_BOOST_BASE_boost_path/include" && test -r "$_AX_BOOST_BASE_boost_path/include"
 then :
 
@@ -5768,8 +5768,8 @@ then :
 printf "%s\n" "yes" >&6; }
            BOOST_CPPFLAGS="-I$_AX_BOOST_BASE_boost_path/include"
            for _AX_BOOST_BASE_boost_path_tmp in $multiarch_libsubdir $libsubdirs; do
-                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for boostlib >= 1.65 ($WANT_BOOST_VERSION) lib path in \"$_AX_BOOST_BASE_boost_path/$_AX_BOOST_BASE_boost_path_tmp\"" >&5
-printf %s "checking for boostlib >= 1.65 ($WANT_BOOST_VERSION) lib path in \"$_AX_BOOST_BASE_boost_path/$_AX_BOOST_BASE_boost_path_tmp\"... " >&6; }
+                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for boostlib >= 1.71 ($WANT_BOOST_VERSION) lib path in \"$_AX_BOOST_BASE_boost_path/$_AX_BOOST_BASE_boost_path_tmp\"" >&5
+printf %s "checking for boostlib >= 1.71 ($WANT_BOOST_VERSION) lib path in \"$_AX_BOOST_BASE_boost_path/$_AX_BOOST_BASE_boost_path_tmp\"... " >&6; }
                 if test -d "$_AX_BOOST_BASE_boost_path/$_AX_BOOST_BASE_boost_path_tmp" && test -r "$_AX_BOOST_BASE_boost_path/$_AX_BOOST_BASE_boost_path_tmp"
 then :
 
@@ -5814,8 +5814,8 @@ then :
   BOOST_LDFLAGS="-L$_AX_BOOST_BASE_boost_lib_path"
 fi
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for boostlib >= 1.65 ($WANT_BOOST_VERSION)" >&5
-printf %s "checking for boostlib >= 1.65 ($WANT_BOOST_VERSION)... " >&6; }
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for boostlib >= 1.71 ($WANT_BOOST_VERSION)" >&5
+printf %s "checking for boostlib >= 1.71 ($WANT_BOOST_VERSION)... " >&6; }
     CPPFLAGS_SAVED="$CPPFLAGS"
     CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
     export CPPFLAGS
@@ -5986,8 +5986,8 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
     if test "x$succeeded" != "xyes" ; then
         if test "x$_version" = "x0" ; then
-            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: We could not detect the boost libraries (version 1.65 or higher). If you have a staged boost library (still not installed) please specify \$BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See http://randspringer.de/boost for more documentation." >&5
-printf "%s\n" "$as_me: We could not detect the boost libraries (version 1.65 or higher). If you have a staged boost library (still not installed) please specify \$BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See http://randspringer.de/boost for more documentation." >&6;}
+            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: We could not detect the boost libraries (version 1.71 or higher). If you have a staged boost library (still not installed) please specify \$BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See http://randspringer.de/boost for more documentation." >&5
+printf "%s\n" "$as_me: We could not detect the boost libraries (version 1.71 or higher). If you have a staged boost library (still not installed) please specify \$BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See http://randspringer.de/boost for more documentation." >&6;}
         else
             { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Your boost libraries seems to old (version $_version)." >&5
 printf "%s\n" "$as_me: Your boost libraries seems to old (version $_version)." >&6;}

--- a/configure.ac
+++ b/configure.ac
@@ -174,7 +174,7 @@ AS_CASE(["x$enable_qt_dbus"],
         AC_MSG_ERROR([Unknown option "$enable_qt_dbus". Use either "yes" or "no".])])
 
 
-AX_BOOST_BASE([1.65],
+AX_BOOST_BASE([1.71],
               [AC_MSG_NOTICE([Boost CXXFLAGS: "$BOOST_CPPFLAGS"])
                AC_MSG_NOTICE([Boost LDFLAGS: "$BOOST_LDFLAGS"])],
               [AC_MSG_ERROR([Could not find Boost])])


### PR DESCRIPTION
This is a prerequisite for using boost stacktrace.
Note that this is not the first version that introduces boost stacktrace but the version that should be stable enough.

Boost 1.71 is available on both debian, ubuntu:
https://packages.debian.org/bullseye/libboost-dev
https://packages.ubuntu.com/focal/libboost-dev