### PR TITLE
Improve docker script

### DIFF
--- a/dist/docker/Dockerfile
+++ b/dist/docker/Dockerfile
@@ -40,9 +40,17 @@ FROM alpine:latest
 
 RUN \
   apk --no-cache add \
+    doas \
     libtorrent-rasterbar \
     qt6-qtbase \
-    tini
+    tini && \
+  adduser \
+    -D \
+    -H \
+    -s /sbin/nologin \
+    -u 1000 \
+    qbtUser && \
+  echo "permit nopass :root" >> "/etc/doas.d/doas.conf"
 
 COPY --from=builder /usr/local/bin/qbittorrent-nox /usr/bin/qbittorrent-nox
 

--- a/dist/docker/Readme.md
+++ b/dist/docker/Readme.md
@@ -35,6 +35,7 @@ docker build \
     QBT_WEBUI_PORT=8080
   docker run \
     -it \
+    --read-only \
     --rm \
     --name qbittorrent-nox \
     -e QBT_EULA \

--- a/dist/docker/Readme.md
+++ b/dist/docker/Readme.md
@@ -42,8 +42,8 @@ docker build \
     -p "$QBT_WEBUI_PORT":"$QBT_WEBUI_PORT" \
     -p 6881:6881/tcp \
     -p 6881:6881/udp \
-    -v /your_path/config:/config \
-    -v /your_path/downloads:/downloads \
+    -v <your_path>/config:/config \
+    -v <your_path>/downloads:/downloads \
     qbittorrent-nox:"$QBT_VERSION"
   ```
   Then you can login at: `http://127.0.0.1:8080`
@@ -67,5 +67,5 @@ docker build \
 ### Volumes
 
 There are some paths involved:
-* `/your_path/config` on your host machine will contain qBittorrent configurations
-* `/your_path/downloads` on your host machine will contain the files downloaded by qBittorrent
+* `<your_path>/config` on your host machine will contain qBittorrent configurations
+* `<your_path>/downloads` on your host machine will contain the files downloaded by qBittorrent

--- a/dist/docker/entrypoint.sh
+++ b/dist/docker/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+downloadsPath="/downloads"
 profilePath="/config"
 qbtConfigFile="$profilePath/qBittorrent/config/qBittorrent.conf"
 
@@ -22,7 +23,13 @@ EOF
     fi
 fi
 
-qbittorrent-nox \
-    --profile="$profilePath" \
-    --webui-port="$QBT_WEBUI_PORT" \
-    "$@"
+# those are owned by root by default
+# don't change existing files owner in `$downloadsPath`
+chown qbtUser:qbtUser "$downloadsPath"
+chown qbtUser:qbtUser -R "$profilePath"
+
+doas -u qbtUser \
+    qbittorrent-nox \
+        --profile="$profilePath" \
+        --webui-port="$QBT_WEBUI_PORT" \
+        "$@"


### PR DESCRIPTION
* Avoid using valid path for illustrative purpose
  Otherwise docker will really create this example path on host machine which is bad.
* Make the container filesystem read-only
  It is not expected to modify the filesystem of the container. 
  Mounted volumes (-v) are not affected.
* Run qbt-nox as non-root
  This is mainly to avoid downloaded files being owned by root which requires another one or two commands to change the file ownership.