### PR TITLE
Support CORS request

### DIFF
--- a/src/base/bittorrent/tracker.cpp
+++ b/src/base/bittorrent/tracker.cpp
@@ -248,7 +248,7 @@ Http::Response Tracker::processRequest(const Http::Request &request, const Http:
     try
     {
         // Is it a GET request?
-        if (request.method != Http::HEADER_REQUEST_METHOD_GET)
+        if (request.method != Http::METHOD_GET)
             throw MethodNotAllowedHTTPError();
 
         if (request.path.startsWith(ANNOUNCE_REQUEST_PATH, Qt::CaseInsensitive))

--- a/src/base/http/requestparser.cpp
+++ b/src/base/http/requestparser.cpp
@@ -105,9 +105,11 @@ RequestParser::ParseResult RequestParser::doParse(const QByteArray &data)
     const int headerLength = headerEnd + EOH.length();
 
     // handle supported methods
-    if ((m_request.method == HEADER_REQUEST_METHOD_GET) || (m_request.method == HEADER_REQUEST_METHOD_HEAD))
+    if ((m_request.method == Http::METHOD_GET)
+        || (m_request.method == Http::METHOD_HEAD)
+        || (m_request.method == Http::METHOD_OPTIONS))
         return {ParseStatus::OK, m_request, headerLength};
-    if (m_request.method == HEADER_REQUEST_METHOD_POST)
+    if (m_request.method == Http::METHOD_POST)
     {
         const auto parseContentLength = [this]() -> int
         {

--- a/src/base/http/types.h
+++ b/src/base/http/types.h
@@ -38,7 +38,9 @@
 namespace Http
 {
     inline const QString METHOD_GET = u"GET"_qs;
+    inline const QString METHOD_HEAD = u"HEAD"_qs;
     inline const QString METHOD_POST = u"POST"_qs;
+    inline const QString METHOD_OPTIONS = u"OPTIONS"_qs;
 
     inline const QString HEADER_AUTHORIZATION = u"authorization"_qs;
     inline const QString HEADER_CACHE_CONTROL = u"cache-control"_qs;
@@ -60,10 +62,6 @@ namespace Http
     inline const QString HEADER_X_FRAME_OPTIONS = u"x-frame-options"_qs;
     inline const QString HEADER_X_XSS_PROTECTION = u"x-xss-protection"_qs;
 
-    inline const QString HEADER_REQUEST_METHOD_GET = u"GET"_qs;
-    inline const QString HEADER_REQUEST_METHOD_HEAD = u"HEAD"_qs;
-    inline const QString HEADER_REQUEST_METHOD_POST = u"POST"_qs;
-
     inline const QString CONTENT_TYPE_HTML = u"text/html"_qs;
     inline const QString CONTENT_TYPE_CSS = u"text/css"_qs;
     inline const QString CONTENT_TYPE_TXT = u"text/plain; charset=UTF-8"_qs;
@@ -73,6 +71,10 @@ namespace Http
     inline const QString CONTENT_TYPE_PNG = u"image/png"_qs;
     inline const QString CONTENT_TYPE_FORM_ENCODED = u"application/x-www-form-urlencoded"_qs;
     inline const QString CONTENT_TYPE_FORM_DATA = u"multipart/form-data"_qs;
+
+    inline const uint STATUS_NO_CONTENT = 204;
+
+    inline const QString STATUS_TEXT_NO_CONTENT = u"No Content"_qs;
 
     // portability: "\r\n" doesn't guarantee mapping to the correct symbol
     inline const char CRLF[] = {0x0D, 0x0A, '\0'};

--- a/src/base/http/types.h
+++ b/src/base/http/types.h
@@ -40,6 +40,7 @@ namespace Http
     inline const QString METHOD_GET = u"GET"_qs;
     inline const QString METHOD_POST = u"POST"_qs;
 
+    inline const QString HEADER_AUTHORIZATION = u"authorization"_qs;
     inline const QString HEADER_CACHE_CONTROL = u"cache-control"_qs;
     inline const QString HEADER_CONNECTION = u"connection"_qs;
     inline const QString HEADER_CONTENT_DISPOSITION = u"content-disposition"_qs;

--- a/src/webui/api/isessionmanager.h
+++ b/src/webui/api/isessionmanager.h
@@ -43,6 +43,6 @@ struct ISessionManager
     virtual ~ISessionManager() = default;
     virtual QString clientId() const = 0;
     virtual ISession *session() = 0;
-    virtual void sessionStart() = 0;
+    virtual void sessionStart(bool updateCookie) = 0;
     virtual void sessionEnd() = 0;
 };

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -491,6 +491,10 @@ Http::Response WebApplication::processRequest(const Http::Request &request, cons
         for (auto iter = m_request.query.cbegin(); iter != m_request.query.cend(); ++iter)
             m_params[iter.key()] = QString::fromUtf8(iter.value());
     }
+    else if (m_request.method == Http::METHOD_OPTIONS)
+    {
+        // pass
+    }
     else
     {
         m_params = m_request.posts;
@@ -511,8 +515,15 @@ Http::Response WebApplication::processRequest(const Http::Request &request, cons
         // reverse proxy resolve client address
         m_clientAddress = resolveClientAddress();
 
-        sessionInitialize();
-        doProcessRequest();
+        if (m_request.method == Http::METHOD_OPTIONS)
+        {
+            status(Http::STATUS_NO_CONTENT, Http::STATUS_TEXT_NO_CONTENT);
+        }
+        else
+        {
+            sessionInitialize();
+            doProcessRequest();
+        }
     }
     catch (const HTTPError &error)
     {

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -94,7 +94,7 @@ public:
 
     QString clientId() const override;
     WebSession *session() override;
-    void sessionStart() override;
+    void sessionStart(bool updateCookie) override;
     void sessionEnd() override;
 
     const Http::Request &request() const;


### PR DESCRIPTION
This patch allows authentication information to be passed via the http header, which is the session id.

It is mainly for allow CORS request, so [my WebUI](https://github.com/CzBiX/qb-web/wiki/How-to-use) can be used by the user online without locally installation. But cookies have security restrictions that cannot be bypassed in CORS(See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite). There may also be new security restrictions on cookies in the future, so I tend to change the http header. This mechanism may also be used for the next generation API architecture.

This patch also can simplifying the writing of scripts without handling of cookies. Since not all HTTP libraries support handle cookies(such as `urllib` in python).

This PR can be tested with:
```sh
# get token
curl -X POST -F 'username=admin' -F 'password=adminadmin' -F 'token_mode=1' http://localhost:8080/api/v2/auth/login
# check the token works
curl -H 'Authorization: Bearer foobar' http://localhost:8080/api/v2/app/versioin
```