### PR TITLE
Revamp tracker entries handling

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(qbt_base STATIC
     bittorrent/customstorage.h
     bittorrent/dbresumedatastorage.h
     bittorrent/downloadpriority.h
+    bittorrent/extensiondata.h
     bittorrent/filesearcher.h
     bittorrent/filterparserthread.h
     bittorrent/infohash.h

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -12,6 +12,7 @@ HEADERS += \
     $$PWD/bittorrent/customstorage.h \
     $$PWD/bittorrent/downloadpriority.h \
     $$PWD/bittorrent/dbresumedatastorage.h \
+    $$PWD/bittorrent/extensiondata.h \
     $$PWD/bittorrent/filesearcher.h \
     $$PWD/bittorrent/filterparserthread.h \
     $$PWD/bittorrent/infohash.h \

--- a/src/base/bittorrent/extensiondata.h
+++ b/src/base/bittorrent/extensiondata.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015-2022  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2022  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -28,56 +28,18 @@
 
 #pragma once
 
-#include <libtorrent/socket.hpp>
+#include <vector>
 
-#include <QtGlobal>
-#include <QHash>
-#include <QMap>
-#include <QString>
+#include <libtorrent/announce_entry.hpp>
 
-namespace BitTorrent
-{
-    struct TrackerEntry
-    {
-        using Endpoint = lt::tcp::endpoint;
-
-        enum Status
-        {
-            NotContacted = 1,
-            Working = 2,
-            Updating = 3,
-            NotWorking = 4
-        };
-
-        struct EndpointStats
-        {
-            Status status = NotContacted;
-            int numPeers = -1;
-            int numSeeds = -1;
-            int numLeeches = -1;
-            int numDownloaded = -1;
-            QString message {};
-        };
-
-        QString url {};
-        int tier = 0;
-
-        // TODO: Use QHash<TrackerEntry::Endpoint, QHash<int, EndpointStats>> once Qt5 is dropped.
-        QMap<Endpoint, QHash<int, EndpointStats>> stats {};
-
-        // Deprecated fields
-        Status status = NotContacted;
-        int numPeers = -1;
-        int numSeeds = -1;
-        int numLeeches = -1;
-        int numDownloaded = -1;
-        QString message {};
-    };
-
-    bool operator==(const TrackerEntry &left, const TrackerEntry &right);
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-    std::size_t qHash(const TrackerEntry &key, std::size_t seed = 0);
+#ifdef QBT_USES_LIBTORRENT2
+#include <libtorrent/client_data.hpp>
+using LTClientData = lt::client_data_t;
 #else
-    uint qHash(const TrackerEntry &key, uint seed = 0);
+using LTClientData = void *;
 #endif
-}
+
+struct ExtensionData
+{
+    std::vector<lt::announce_entry> trackers;
+};

--- a/src/base/bittorrent/magneturi.cpp
+++ b/src/base/bittorrent/magneturi.cpp
@@ -100,8 +100,15 @@ MagnetUri::MagnetUri(const QString &source)
     m_name = QString::fromStdString(m_addTorrentParams.name);
 
     m_trackers.reserve(static_cast<decltype(m_trackers)::size_type>(m_addTorrentParams.trackers.size()));
-    for (const std::string &tracker : m_addTorrentParams.trackers)
-        m_trackers.append({QString::fromStdString(tracker)});
+    int tier = 0;
+    auto tierIter = m_addTorrentParams.tracker_tiers.cbegin();
+    for (const std::string &url : m_addTorrentParams.trackers)
+    {
+        if (tierIter != m_addTorrentParams.tracker_tiers.cend())
+            tier = *tierIter++;
+
+        m_trackers.append({QString::fromStdString(url), tier});
+    }
 
     m_urlSeeds.reserve(static_cast<decltype(m_urlSeeds)::size_type>(m_addTorrentParams.url_seeds.size()));
     for (const std::string &urlSeed : m_addTorrentParams.url_seeds)

--- a/src/base/bittorrent/nativesessionextension.cpp
+++ b/src/base/bittorrent/nativesessionextension.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2020  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2020-2022  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -30,6 +30,7 @@
 
 #include <libtorrent/alert_types.hpp>
 
+#include "extensiondata.h"
 #include "nativetorrentextension.h"
 
 namespace
@@ -49,9 +50,9 @@ lt::feature_flags_t NativeSessionExtension::implemented_features()
     return alert_feature;
 }
 
-std::shared_ptr<lt::torrent_plugin> NativeSessionExtension::new_torrent(const lt::torrent_handle &torrentHandle, ClientData)
+std::shared_ptr<lt::torrent_plugin> NativeSessionExtension::new_torrent(const lt::torrent_handle &torrentHandle, LTClientData clientData)
 {
-    return std::make_shared<NativeTorrentExtension>(torrentHandle);
+    return std::make_shared<NativeTorrentExtension>(torrentHandle, static_cast<ExtensionData *>(clientData));
 }
 
 void NativeSessionExtension::on_alert(const lt::alert *alert)

--- a/src/base/bittorrent/nativesessionextension.h
+++ b/src/base/bittorrent/nativesessionextension.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2020  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2020-2022  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -30,15 +30,11 @@
 
 #include <libtorrent/extensions.hpp>
 
+#include "extensiondata.h"
+
 class NativeSessionExtension final : public lt::plugin
 {
-#ifdef QBT_USES_LIBTORRENT2
-    using ClientData = lt::client_data_t;
-#else
-    using ClientData = void *;
-#endif
-
     lt::feature_flags_t implemented_features() override;
-    std::shared_ptr<lt::torrent_plugin> new_torrent(const lt::torrent_handle &torrentHandle, ClientData) override;
+    std::shared_ptr<lt::torrent_plugin> new_torrent(const lt::torrent_handle &torrentHandle, LTClientData clientData) override;
     void on_alert(const lt::alert *alert) override;
 };

--- a/src/base/bittorrent/nativetorrentextension.cpp
+++ b/src/base/bittorrent/nativetorrentextension.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2020  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2020-2022  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -38,10 +38,19 @@ namespace
     }
 }
 
-NativeTorrentExtension::NativeTorrentExtension(const lt::torrent_handle &torrentHandle)
+NativeTorrentExtension::NativeTorrentExtension(const lt::torrent_handle &torrentHandle, ExtensionData *data)
     : m_torrentHandle {torrentHandle}
+    , m_data {data}
 {
     on_state(m_torrentHandle.status({}).state);
+
+    if (m_data)
+        m_data->trackers = m_torrentHandle.trackers();
+}
+
+NativeTorrentExtension::~NativeTorrentExtension()
+{
+    delete m_data;
 }
 
 bool NativeTorrentExtension::on_pause()

--- a/src/base/bittorrent/nativetorrentextension.h
+++ b/src/base/bittorrent/nativetorrentextension.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2020  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2020-2022  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -31,10 +31,13 @@
 #include <libtorrent/extensions.hpp>
 #include <libtorrent/torrent_handle.hpp>
 
+#include "extensiondata.h"
+
 class NativeTorrentExtension final : public lt::torrent_plugin
 {
 public:
-    explicit NativeTorrentExtension(const lt::torrent_handle &torrentHandle);
+    NativeTorrentExtension(const lt::torrent_handle &torrentHandle, ExtensionData *data);
+    ~NativeTorrentExtension();
 
 private:
     bool on_pause() override;
@@ -42,4 +45,5 @@ private:
 
     lt::torrent_handle m_torrentHandle;
     lt::torrent_status::state_t m_state = lt::torrent_status::checking_resume_data;
+    ExtensionData *m_data = nullptr;
 };

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -211,12 +211,6 @@ namespace BitTorrent
         } disk;
     };
 
-    struct TrackerEntryUpdateInfo
-    {
-        TrackerEntry::Status status = TrackerEntry::NotContacted;
-        bool hasMessages = false;
-    };
-
     class Session final : public QObject
     {
         Q_OBJECT
@@ -518,7 +512,7 @@ namespace BitTorrent
         void handleTorrentChecked(TorrentImpl *const torrent);
         void handleTorrentFinished(TorrentImpl *const torrent);
         void handleTorrentTrackersAdded(TorrentImpl *const torrent, const QVector<TrackerEntry> &newTrackers);
-        void handleTorrentTrackersRemoved(TorrentImpl *const torrent, const QVector<TrackerEntry> &deletedTrackers);
+        void handleTorrentTrackersRemoved(TorrentImpl *const torrent, const QStringList &deletedTrackers);
         void handleTorrentTrackersChanged(TorrentImpl *const torrent);
         void handleTorrentUrlSeedsAdded(TorrentImpl *const torrent, const QVector<QUrl> &newUrlSeeds);
         void handleTorrentUrlSeedsRemoved(TorrentImpl *const torrent, const QVector<QUrl> &urlSeeds);
@@ -563,10 +557,10 @@ namespace BitTorrent
         void trackerlessStateChanged(Torrent *torrent, bool trackerless);
         void trackersAdded(Torrent *torrent, const QVector<TrackerEntry> &trackers);
         void trackersChanged(Torrent *torrent);
-        void trackersRemoved(Torrent *torrent, const QVector<TrackerEntry> &trackers);
+        void trackersRemoved(Torrent *torrent, const QStringList &trackers);
         void trackerSuccess(Torrent *torrent, const QString &tracker);
         void trackerWarning(Torrent *torrent, const QString &tracker);
-        void trackerEntriesUpdated(const QHash<Torrent *, QHash<QString, TrackerEntryUpdateInfo>> &updateInfos);
+        void trackerEntriesUpdated(const QHash<Torrent *, QSet<QString>> &updateInfos);
 
     private slots:
         void configureDeferred();
@@ -823,7 +817,7 @@ namespace BitTorrent
         QMap<QString, CategoryOptions> m_categories;
         QSet<QString> m_tags;
 
-        QHash<TorrentImpl *, QSet<QByteArray>> m_updatedTrackerEntries;
+        QHash<Torrent *, QSet<QString>> m_updatedTrackerEntries;
 
         // I/O errored torrents
         QSet<TorrentID> m_recentErroredTorrents;

--- a/src/base/bittorrent/torrent.h
+++ b/src/base/bittorrent/torrent.h
@@ -224,7 +224,6 @@ namespace BitTorrent
         virtual bool hasMissingFiles() const = 0;
         virtual bool hasError() const = 0;
         virtual int queuePosition() const = 0;
-        virtual QVector<QString> trackerURLs() const = 0;
         virtual QVector<TrackerEntry> trackers() const = 0;
         virtual QVector<QUrl> urlSeeds() const = 0;
         virtual QString error() const = 0;
@@ -294,8 +293,9 @@ namespace BitTorrent
         virtual void setPEXDisabled(bool disable) = 0;
         virtual void setLSDDisabled(bool disable) = 0;
         virtual void flushCache() const = 0;
-        virtual void addTrackers(const QVector<TrackerEntry> &trackers) = 0;
-        virtual void replaceTrackers(const QVector<TrackerEntry> &trackers) = 0;
+        virtual void addTrackers(QVector<TrackerEntry> trackers) = 0;
+        virtual void removeTrackers(const QStringList &trackers) = 0;
+        virtual void replaceTrackers(QVector<TrackerEntry> trackers) = 0;
         virtual void addUrlSeeds(const QVector<QUrl> &urlSeeds) = 0;
         virtual void removeUrlSeeds(const QVector<QUrl> &urlSeeds) = 0;
         virtual bool connectPeer(const PeerAddress &peerAddress) = 0;

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -275,9 +275,8 @@ QVector<TrackerEntry> TorrentInfo::trackers() const
 
     QVector<TrackerEntry> ret;
     ret.reserve(static_cast<decltype(ret)::size_type>(trackers.size()));
-
     for (const lt::announce_entry &tracker : trackers)
-        ret.append({QString::fromStdString(tracker.url)});
+        ret.append({QString::fromStdString(tracker.url), tracker.tier});
 
     return ret;
 }

--- a/src/base/bittorrent/torrentinfo.h
+++ b/src/base/bittorrent/torrentinfo.h
@@ -30,8 +30,8 @@
 
 #include <libtorrent/torrent_info.hpp>
 
-#include <QCoreApplication>
 #include <QtContainerFwd>
+#include <QCoreApplication>
 #include <QVector>
 
 #include "base/3rdparty/expected.hpp"

--- a/src/base/bittorrent/trackerentry.cpp
+++ b/src/base/bittorrent/trackerentry.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015, 2021  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2015-2022  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -28,22 +28,16 @@
 
 #include "trackerentry.h"
 
-#include <QUrl>
-
 bool BitTorrent::operator==(const TrackerEntry &left, const TrackerEntry &right)
 {
-    return ((left.tier == right.tier)
-        && QUrl(left.url) == QUrl(right.url));
+    return (left.url == right.url);
 }
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 std::size_t BitTorrent::qHash(const TrackerEntry &key, const std::size_t seed)
-{
-    return qHashMulti(seed, key.url, key.tier);
-}
 #else
 uint BitTorrent::qHash(const TrackerEntry &key, const uint seed)
-{
-    return (::qHash(key.url, seed) ^ ::qHash(key.tier));
-}
 #endif
+{
+    return ::qHash(key.url, seed);
+}

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1495,6 +1495,7 @@ void MainWindow::showFiltersSidebar(const bool show)
 
         connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackersAdded, m_transferListFiltersWidget, &TransferListFiltersWidget::addTrackers);
         connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackersRemoved, m_transferListFiltersWidget, &TransferListFiltersWidget::removeTrackers);
+        connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackersChanged, m_transferListFiltersWidget, &TransferListFiltersWidget::refreshTrackers);
         connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackerlessStateChanged, m_transferListFiltersWidget, &TransferListFiltersWidget::changeTrackerless);
         connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackerEntriesUpdated, m_transferListFiltersWidget, &TransferListFiltersWidget::trackerEntriesUpdated);
     }

--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -473,18 +473,7 @@ void TrackerListWidget::deleteSelectedTrackers()
         delete item;
     }
 
-    // Iterate over the trackers and remove the selected ones
-    const QVector<BitTorrent::TrackerEntry> trackers = torrent->trackers();
-    QVector<BitTorrent::TrackerEntry> remainingTrackers;
-    remainingTrackers.reserve(trackers.size());
-
-    for (const BitTorrent::TrackerEntry &entry : trackers)
-    {
-        if (!urlsToRemove.contains(entry.url))
-            remainingTrackers.push_back(entry);
-    }
-
-    torrent->replaceTrackers(remainingTrackers);
+    torrent->removeTrackers(urlsToRemove);
 
     if (!torrent->isPaused())
         torrent->forceReannounce();

--- a/src/gui/transferlistfilterswidget.h
+++ b/src/gui/transferlistfilterswidget.h
@@ -124,12 +124,12 @@ public:
     TrackerFiltersList(QWidget *parent, TransferListWidget *transferList, bool downloadFavicon);
     ~TrackerFiltersList() override;
 
-    // Redefine addItem() to make sure the list stays sorted
-    void addItem(const QString &tracker, const BitTorrent::TorrentID &id);
-    void removeItem(const QString &trackerURL, const BitTorrent::TorrentID &id);
-    void changeTrackerless(bool trackerless, const BitTorrent::TorrentID &id);
+    void addTrackers(const BitTorrent::Torrent *torrent, const QVector<BitTorrent::TrackerEntry> &trackers);
+    void removeTrackers(const BitTorrent::Torrent *torrent, const QStringList &trackers);
+    void refreshTrackers(const BitTorrent::Torrent *torrent);
+    void changeTrackerless(const BitTorrent::Torrent *torrent, bool trackerless);
+    void handleTrackerEntriesUpdated(const QHash<BitTorrent::Torrent *, QSet<QString>> &updateInfos);
     void setDownloadTrackerFavicon(bool value);
-    void handleTrackerEntriesUpdated(const QHash<BitTorrent::Torrent *, QHash<QString, BitTorrent::TrackerEntryUpdateInfo>> &updateInfos);
 
 private slots:
     void handleFavicoDownloadFinished(const Net::DownloadResult &result);
@@ -141,6 +141,9 @@ private:
     void applyFilter(int row) override;
     void handleNewTorrent(BitTorrent::Torrent *const torrent) override;
     void torrentAboutToBeDeleted(BitTorrent::Torrent *const torrent) override;
+
+    void addItem(const QString &tracker, const BitTorrent::TorrentID &id);
+    void removeItem(const QString &trackerURL, const BitTorrent::TorrentID &id);
     QString trackerFromRow(int row) const;
     int rowFromTracker(const QString &tracker) const;
     QSet<BitTorrent::TorrentID> getTorrentIDs(int row) const;
@@ -174,9 +177,10 @@ public:
 
 public slots:
     void addTrackers(const BitTorrent::Torrent *torrent, const QVector<BitTorrent::TrackerEntry> &trackers);
-    void removeTrackers(const BitTorrent::Torrent *torrent, const QVector<BitTorrent::TrackerEntry> &trackers);
+    void removeTrackers(const BitTorrent::Torrent *torrent, const QStringList &trackers);
+    void refreshTrackers(const BitTorrent::Torrent *torrent);
     void changeTrackerless(const BitTorrent::Torrent *torrent, bool trackerless);
-    void trackerEntriesUpdated(const QHash<BitTorrent::Torrent *, QHash<QString, BitTorrent::TrackerEntryUpdateInfo>> &updateInfos);
+    void trackerEntriesUpdated(const QHash<BitTorrent::Torrent *, QSet<QString>> &updateInfos);
 
 private slots:
     void onCategoryFilterStateChanged(bool enabled);

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -767,8 +767,8 @@ void TorrentsController::editTrackerAction()
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 
-    const QUrl origTrackerUrl(origUrl);
-    const QUrl newTrackerUrl(newUrl);
+    const QUrl origTrackerUrl {origUrl};
+    const QUrl newTrackerUrl {newUrl};
     if (origTrackerUrl == newTrackerUrl)
         return;
     if (!newTrackerUrl.isValid())
@@ -778,7 +778,7 @@ void TorrentsController::editTrackerAction()
     bool match = false;
     for (BitTorrent::TrackerEntry &tracker : trackers)
     {
-        const QUrl trackerUrl(tracker.url);
+        const QUrl trackerUrl {tracker.url};
         if (trackerUrl == newTrackerUrl)
             throw APIError(APIErrorType::Conflict, u"New tracker URL already exists"_qs);
         if (trackerUrl == origTrackerUrl)
@@ -806,20 +806,7 @@ void TorrentsController::removeTrackersAction()
         throw APIError(APIErrorType::NotFound);
 
     const QStringList urls = params()[u"urls"_qs].split(u'|');
-
-    const QVector<BitTorrent::TrackerEntry> trackers = torrent->trackers();
-    QVector<BitTorrent::TrackerEntry> remainingTrackers;
-    remainingTrackers.reserve(trackers.size());
-    for (const BitTorrent::TrackerEntry &entry : trackers)
-    {
-        if (!urls.contains(entry.url))
-            remainingTrackers.push_back(entry);
-    }
-
-    if (remainingTrackers.size() == trackers.size())
-        throw APIError(APIErrorType::Conflict, u"No trackers were removed"_qs);
-
-    torrent->replaceTrackers(remainingTrackers);
+    torrent->removeTrackers(urls);
 
     if (!torrent->isPaused())
         torrent->forceReannounce();


### PR DESCRIPTION
This should significantly reduce the amount of blocking calls to libtorrent for retrieving announce entries (no such call at all in case of stopped torrents):
1. Tracker entries are cached at qBittorrent level so libtorrent is touched only when trackers info is updated.
2. Moreover cached tracker entries are initialized from resume data so libtorrent keeps untouched until trackers info is first time updated. This should have significant performance impact at startup time, especially within the context of #16840.

Tracker entries are also changed to be considered unique only based on the tracker URL, since allowing duplicates does not make sense and it isn't really supported by libtorrent. See https://github.com/arvidn/libtorrent/issues/6846 for reference.

This PR is most likely the last preparation step before finishing #16840.