### PR TITLE
Add an advanced "add torrent" option

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -545,7 +545,8 @@ void Application::processParams(const QStringList &params)
 
         if (param.startsWith(u"@addPaused="))
         {
-            torrentParams.addPaused = (QStringView(param).mid(11).toInt() != 0);
+            torrentParams.addTorrentOption = ((QStringView(param).mid(11).toInt() != 0)
+                                              ? BitTorrent::AddTorrentOption::DontStart : BitTorrent::AddTorrentOption::Start);
             continue;
         }
 

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(qbt_base STATIC
     algorithm.h
     asyncfilestorage.h
     bittorrent/abstractfilestorage.h
+    bittorrent/addtorrentoption.h
     bittorrent/addtorrentparams.h
     bittorrent/bandwidthscheduler.h
     bittorrent/bencoderesumedatastorage.h

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -3,6 +3,7 @@ HEADERS += \
     $$PWD/algorithm.h \
     $$PWD/asyncfilestorage.h \
     $$PWD/bittorrent/abstractfilestorage.h \
+    $$PWD/bittorrent/addtorrentoption.h \
     $$PWD/bittorrent/addtorrentparams.h \
     $$PWD/bittorrent/bandwidthscheduler.h \
     $$PWD/bittorrent/bencoderesumedatastorage.h \

--- a/src/base/bittorrent/addtorrentoption.h
+++ b/src/base/bittorrent/addtorrentoption.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2022  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -28,43 +28,25 @@
 
 #pragma once
 
-#include <optional>
-
-#include <QMetaType>
-#include <QString>
-#include <QVector>
-
-#include "base/path.h"
-#include "base/tagset.h"
-#include "addtorrentoption.h"
-#include "torrent.h"
-#include "torrentcontentlayout.h"
+#include <QMetaEnum>
 
 namespace BitTorrent
 {
-    enum class DownloadPriority;
-
-    struct AddTorrentParams
+    // Using `Q_ENUM_NS()` without a wrapper namespace in our case is not advised
+    // since `Q_NAMESPACE` cannot be used when the same namespace resides at different files.
+    // https://www.kdab.com/new-qt-5-8-meta-object-support-namespaces/#comment-143779
+    inline namespace AddTorrentOptionNS
     {
-        QString name;
-        QString category;
-        TagSet tags;
-        Path savePath;
-        std::optional<bool> useDownloadPath;
-        Path downloadPath;
-        bool sequential = false;
-        bool firstLastPiecePriority = false;
-        std::optional<AddTorrentOption> addTorrentOption;
-        PathList filePaths; // used if TorrentInfo is set
-        QVector<DownloadPriority> filePriorities; // used if TorrentInfo is set
-        bool skipChecking = false;
-        std::optional<BitTorrent::TorrentContentLayout> contentLayout;
-        std::optional<bool> useAutoTMM;
-        int uploadLimit = -1;
-        int downloadLimit = -1;
-        int seedingTimeLimit = Torrent::USE_GLOBAL_SEEDING_TIME;
-        qreal ratioLimit = Torrent::USE_GLOBAL_RATIO;
-    };
-}
+        Q_NAMESPACE
 
-Q_DECLARE_METATYPE(BitTorrent::AddTorrentParams)
+        enum class AddTorrentOption
+        {
+            DontStart = 0,
+            CheckOnly = 1,
+            Start = 2,
+            StartForced = 3
+        };
+
+        Q_ENUM_NS(AddTorrentOption)
+    }
+}

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -280,8 +280,8 @@ namespace BitTorrent
         void setLSDEnabled(bool enabled);
         bool isPeXEnabled() const;
         void setPeXEnabled(bool enabled);
-        bool isAddTorrentPaused() const;
-        void setAddTorrentPaused(bool value);
+        AddTorrentOption addTorrentOption() const;
+        void setAddTorrentOption(AddTorrentOption value);
         TorrentContentLayout torrentContentLayout() const;
         void setTorrentContentLayout(TorrentContentLayout value);
         bool isTrackerEnabled() const;
@@ -738,7 +738,7 @@ namespace BitTorrent
         CachedSettingValue<QString> m_additionalTrackers;
         CachedSettingValue<qreal> m_globalMaxRatio;
         CachedSettingValue<int> m_globalMaxSeedingMinutes;
-        CachedSettingValue<bool> m_isAddTorrentPaused;
+        CachedSettingValue<AddTorrentOption> m_addTorrentOption;
         CachedSettingValue<TorrentContentLayout> m_torrentContentLayout;
         CachedSettingValue<bool> m_isAppendExtensionEnabled;
         CachedSettingValue<int> m_refreshInterval;

--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -386,7 +386,7 @@ void AutoDownloader::processJob(const QSharedPointer<ProcessingJob> &job)
         BitTorrent::AddTorrentParams params;
         params.savePath = rule.savePath();
         params.category = rule.assignedCategory();
-        params.addPaused = rule.addPaused();
+        params.addTorrentOption = rule.addTorrentOption();
         params.contentLayout = rule.torrentContentLayout();
         if (!rule.savePath().isEmpty())
             params.useAutoTMM = false;

--- a/src/base/rss/rss_autodownloadrule.h
+++ b/src/base/rss/rss_autodownloadrule.h
@@ -35,6 +35,7 @@
 #include <QVariant>
 
 #include "base/global.h"
+#include "base/bittorrent/addtorrentoption.h"
 #include "base/bittorrent/torrentcontentlayout.h"
 #include "base/pathfwd.h"
 
@@ -83,8 +84,8 @@ namespace RSS
 
         Path savePath() const;
         void setSavePath(const Path &savePath);
-        std::optional<bool> addPaused() const;
-        void setAddPaused(std::optional<bool> addPaused);
+        std::optional<BitTorrent::AddTorrentOption> addTorrentOption() const;
+        void setAddTorrentOption(std::optional<BitTorrent::AddTorrentOption> addTorrentOption);
         std::optional<BitTorrent::TorrentContentLayout> torrentContentLayout() const;
         void setTorrentContentLayout(std::optional<BitTorrent::TorrentContentLayout> contentLayout);
         QString assignedCategory() const;

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -200,7 +200,12 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::AddTorrentParams &inP
     m_ui->downloadPath->setDialogCaption(tr("Choose save path"));
     m_ui->downloadPath->setMaxVisibleItems(20);
 
-    m_ui->startTorrentCheckBox->setChecked(!m_torrentParams.addPaused.value_or(session->isAddTorrentPaused()));
+    m_ui->addTorrentOptionComboBox->addItem(tr("Don't start it"), QVariant::fromValue(BitTorrent::AddTorrentOption::DontStart));
+    m_ui->addTorrentOptionComboBox->addItem(tr("Only check it"), QVariant::fromValue(BitTorrent::AddTorrentOption::CheckOnly));
+    m_ui->addTorrentOptionComboBox->addItem(tr("Start it"), QVariant::fromValue(BitTorrent::AddTorrentOption::Start));
+    m_ui->addTorrentOptionComboBox->addItem(tr("Force start it"), QVariant::fromValue(BitTorrent::AddTorrentOption::StartForced));
+    m_ui->addTorrentOptionComboBox->setCurrentIndex(
+                m_ui->addTorrentOptionComboBox->findData(QVariant::fromValue(m_torrentParams.addTorrentOption.value_or(session->addTorrentOption()))));
 
     m_ui->comboTTM->blockSignals(true); // the TreeView size isn't correct if the slot does its job at this point
     m_ui->comboTTM->setCurrentIndex(session->isAutoTMMDisabledByDefault() ? 0 : 1);
@@ -828,7 +833,7 @@ void AddNewTorrentDialog::accept()
     if (m_contentModel)
         m_torrentParams.filePriorities = m_contentModel->model()->getFilePriorities();
 
-    m_torrentParams.addPaused = !m_ui->startTorrentCheckBox->isChecked();
+    m_torrentParams.addTorrentOption = m_ui->addTorrentOptionComboBox->currentData().value<BitTorrent::AddTorrentOption>();
     m_torrentParams.contentLayout = static_cast<BitTorrent::TorrentContentLayout>(m_ui->contentLayoutComboBox->currentIndex());
 
     m_torrentParams.sequential = m_ui->sequentialCheckBox->isChecked();

--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -187,7 +187,7 @@
               </property>
              </widget>
             </item>
-            <item row="1" column="0">
+            <item row="0" column="0">
              <widget class="QCheckBox" name="skipCheckingCheckBox">
               <property name="text">
                <string>Skip hash check</string>
@@ -201,15 +201,36 @@
               </property>
              </widget>
             </item>
-            <item row="0" column="0">
-             <widget class="QCheckBox" name="startTorrentCheckBox">
+            <item row="0" column="2">
+             <spacer name="horizontalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="addTorrentOptionLayout">
+            <item>
+             <widget class="QLabel" name="addTorrentOptionLabel">
               <property name="text">
-               <string>Start torrent</string>
+               <string>When torrent is added:</string>
               </property>
              </widget>
             </item>
-            <item row="0" column="2">
-             <spacer name="horizontalSpacer_3">
+            <item>
+             <widget class="QComboBox" name="addTorrentOptionComboBox">
+             </widget>
+            </item>
+            <item>
+             <spacer name="addTorrentOptionSpacer">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -136,7 +136,6 @@ private:
     // Downloads
     bool preAllocateAllFiles() const;
     bool useAdditionDialog() const;
-    bool addTorrentsInPause() const;
     Path getTorrentExportDir() const;
     Path getFinishedTorrentExportDir() const;
     // Connection options

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -837,14 +837,32 @@
                 </layout>
                </item>
                <item>
-                <widget class="QCheckBox" name="checkStartPaused">
-                 <property name="toolTip">
-                  <string>The torrent will be added to download list in a paused state</string>
-                 </property>
-                 <property name="text">
-                  <string extracomment="The torrent will be added to download list in a paused state">Do not start the download automatically</string>
-                 </property>
-                </widget>
+                <layout class="QHBoxLayout" name="horizontalLayout_29">
+                 <item>
+                  <widget class="QLabel" name="addTorrentOptionLabel">
+                   <property name="text">
+                    <string>When new torrent is added:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="addTorrentOptionComboBox">
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="addTorrentOptionSpacer">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
                </item>
                <item>
                 <widget class="QGroupBox" name="deleteTorrentBox">
@@ -3498,7 +3516,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
   <tabstop>checkUseSystemIcon</tabstop>
   <tabstop>checkUseCustomTheme</tabstop>
   <tabstop>customThemeFilePath</tabstop>
-  <tabstop>checkStartPaused</tabstop>
+  <tabstop>addTorrentOptionComboBox</tabstop>
   <tabstop>spinPort</tabstop>
   <tabstop>checkUPnP</tabstop>
   <tabstop>textWebUiUsername</tabstop>

--- a/src/gui/rss/automatedrssdownloader.ui
+++ b/src/gui/rss/automatedrssdownloader.ui
@@ -290,9 +290,9 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
            </widget>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_9">
+           <layout class="QHBoxLayout" name="addTorrentOptionLayout">
             <item>
-             <widget class="QLabel" name="lblAddPaused">
+             <widget class="QLabel" name="lblAddTorrentOption">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
                 <horstretch>0</horstretch>
@@ -300,27 +300,12 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                </sizepolicy>
               </property>
               <property name="text">
-               <string>Add Paused:</string>
+               <string>When new torrent is added:</string>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QComboBox" name="comboAddPaused">
-              <item>
-               <property name="text">
-                <string>Use global settings</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Always</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Never</string>
-               </property>
-              </item>
+             <widget class="QComboBox" name="comboAddTorrentOption">
              </widget>
             </item>
            </layout>
@@ -478,7 +463,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
   <tabstop>checkBoxSaveDiffDir</tabstop>
   <tabstop>lineSavePath</tabstop>
   <tabstop>spinIgnorePeriod</tabstop>
-  <tabstop>comboAddPaused</tabstop>
+  <tabstop>comboAddTorrentOption</tabstop>
   <tabstop>comboContentLayout</tabstop>
   <tabstop>listFeeds</tabstop>
   <tabstop>treeMatchingArticles</tabstop>

--- a/src/gui/watchedfolderoptionsdialog.cpp
+++ b/src/gui/watchedfolderoptionsdialog.cpp
@@ -30,6 +30,7 @@
 
 #include <QDir>
 #include <QPushButton>
+#include <QVariant>
 
 #include "base/bittorrent/session.h"
 #include "base/global.h"
@@ -65,11 +66,17 @@ WatchedFolderOptionsDialog::WatchedFolderOptionsDialog(
     populateSavePaths();
 
     const BitTorrent::AddTorrentParams &torrentParams = watchedFolderOptions.addTorrentParams;
-    m_ui->startTorrentCheckBox->setChecked(!torrentParams.addPaused.value_or(session->isAddTorrentPaused()));
     m_ui->skipCheckingCheckBox->setChecked(torrentParams.skipChecking);
     m_ui->comboTTM->setCurrentIndex(torrentParams.useAutoTMM.value_or(!session->isAutoTMMDisabledByDefault()));
     m_ui->contentLayoutComboBox->setCurrentIndex(
         static_cast<int>(torrentParams.contentLayout.value_or(session->torrentContentLayout())));
+
+    m_ui->addTorrentOptionComboBox->addItem(tr("Don't start it"), QVariant::fromValue(BitTorrent::AddTorrentOption::DontStart));
+    m_ui->addTorrentOptionComboBox->addItem(tr("Only check it"), QVariant::fromValue(BitTorrent::AddTorrentOption::CheckOnly));
+    m_ui->addTorrentOptionComboBox->addItem(tr("Start it"), QVariant::fromValue(BitTorrent::AddTorrentOption::Start));
+    m_ui->addTorrentOptionComboBox->addItem(tr("Force start it"), QVariant::fromValue(BitTorrent::AddTorrentOption::StartForced));
+    m_ui->addTorrentOptionComboBox->setCurrentIndex(
+                m_ui->addTorrentOptionComboBox->findData(QVariant::fromValue(torrentParams.addTorrentOption.value_or(session->addTorrentOption()))));
 
     // Load categories
     QStringList categories = session->categories();
@@ -116,7 +123,7 @@ TorrentFilesWatcher::WatchedFolderOptions WatchedFolderOptionsDialog::watchedFol
     }
     params.useAutoTMM = useAutoTMM;
     params.category = m_ui->categoryComboBox->currentText();
-    params.addPaused = !m_ui->startTorrentCheckBox->isChecked();
+    params.addTorrentOption = m_ui->addTorrentOptionComboBox->currentData().value<BitTorrent::AddTorrentOption>();
     params.skipChecking = m_ui->skipCheckingCheckBox->isChecked();
     params.contentLayout = static_cast<BitTorrent::TorrentContentLayout>(m_ui->contentLayoutComboBox->currentIndex());
 

--- a/src/gui/watchedfolderoptionsdialog.ui
+++ b/src/gui/watchedfolderoptionsdialog.ui
@@ -181,16 +181,20 @@
            </layout>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <layout class="QHBoxLayout" name="addTorrentOptionLayout">
             <item>
-             <widget class="QCheckBox" name="startTorrentCheckBox">
+             <widget class="QLabel" name="addTorrentOptionLabel">
               <property name="text">
-               <string>Start torrent</string>
+               <string>When new torrent is added:</string>
               </property>
              </widget>
             </item>
             <item>
-             <spacer name="horizontalSpacer_3">
+             <widget class="QComboBox" name="addTorrentOptionComboBox">
+             </widget>
+            </item>
+            <item>
+             <spacer name="addTorrentOptionSpacer">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -106,7 +106,7 @@ void AppController::preferencesAction()
     // Downloads
     // When adding a torrent
     data[u"torrent_content_layout"_qs] = Utils::String::fromEnum(session->torrentContentLayout());
-    data[u"start_paused_enabled"_qs] = session->isAddTorrentPaused();
+    data[u"add_torrent_option"_qs] = Utils::String::fromEnum(session->addTorrentOption());
     data[u"auto_delete_mode"_qs] = static_cast<int>(TorrentFileGuard::autoDeleteMode());
     data[u"preallocate_all"_qs] = session->isPreallocationEnabled();
     data[u"incomplete_files_ext"_qs] = session->isAppendExtensionEnabled();
@@ -394,8 +394,8 @@ void AppController::setPreferencesAction()
     // When adding a torrent
     if (hasKey(u"torrent_content_layout"_qs))
         session->setTorrentContentLayout(Utils::String::toEnum(it.value().toString(), BitTorrent::TorrentContentLayout::Original));
-    if (hasKey(u"start_paused_enabled"_qs))
-        session->setAddTorrentPaused(it.value().toBool());
+    if (hasKey(u"add_torrent_option"_qs))
+        session->setAddTorrentOption(Utils::String::toEnum(it.value().toString(), BitTorrent::AddTorrentOption::Start));
     if (hasKey(u"auto_delete_mode"_qs))
         TorrentFileGuard::setAutoDeleteMode(static_cast<TorrentFileGuard::AutoDeleteMode>(it.value().toInt()));
 

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -652,7 +652,6 @@ void TorrentsController::addAction()
     const bool skipChecking = parseBool(params()[u"skip_checking"_qs]).value_or(false);
     const bool seqDownload = parseBool(params()[u"sequentialDownload"_qs]).value_or(false);
     const bool firstLastPiece = parseBool(params()[u"firstLastPiecePrio"_qs]).value_or(false);
-    const std::optional<bool> addPaused = parseBool(params()[u"paused"_qs]);
     const QString savepath = params()[u"savepath"_qs].trimmed();
     const QString downloadPath = params()[u"downloadPath"_qs].trimmed();
     const std::optional<bool> useDownloadPath = parseBool(params()[u"useDownloadPath"_qs]);
@@ -669,6 +668,11 @@ void TorrentsController::addAction()
     const std::optional<BitTorrent::TorrentContentLayout> contentLayout = (!contentLayoutParam.isEmpty()
             ? Utils::String::toEnum(contentLayoutParam, BitTorrent::TorrentContentLayout::Original)
             : std::optional<BitTorrent::TorrentContentLayout> {});
+
+    const QString addTorrentOptionParam = params()[u"addTorrentOption"_qs];
+    const std::optional<BitTorrent::AddTorrentOption> addTorrentOption = (!addTorrentOptionParam.isEmpty()
+            ? Utils::String::toEnum(addTorrentOptionParam, BitTorrent::AddTorrentOption::Start)
+            : std::optional<BitTorrent::AddTorrentOption> {});
 
     QList<QNetworkCookie> cookies;
     if (!cookie.isEmpty())
@@ -692,7 +696,7 @@ void TorrentsController::addAction()
     addTorrentParams.skipChecking = skipChecking;
     addTorrentParams.sequential = seqDownload;
     addTorrentParams.firstLastPiecePriority = firstLastPiece;
-    addTorrentParams.addPaused = addPaused;
+    addTorrentParams.addTorrentOption = addTorrentOption;
     addTorrentParams.contentLayout = contentLayout;
     addTorrentParams.savePath = Path(savepath);
     addTorrentParams.downloadPath = Path(downloadPath);

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -48,7 +48,7 @@
 #include "base/utils/version.h"
 #include "api/isessionmanager.h"
 
-inline const Utils::Version<int, 3, 2> API_VERSION {2, 8, 11};
+inline const Utils::Version<int, 3, 2> API_VERSION {2, 9, 0};
 
 class APIController;
 class AuthController;

--- a/src/webui/www/private/download.html
+++ b/src/webui/www/private/download.html
@@ -72,19 +72,23 @@
                     </tr>
                     <tr>
                         <td>
-                            <label for="startTorrent">QBT_TR(Start torrent)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
-                        </td>
-                        <td>
-                            <input type="hidden" id="startTorrentHidden" name="paused" />
-                            <input type="checkbox" id="startTorrent" />
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
                             <label for="skip_checking">QBT_TR(Skip hash check)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
                         </td>
                         <td>
                             <input type="checkbox" id="skip_checking" name="skip_checking" value="true" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <label for="addTorrentOption">QBT_TR(When torrent is added:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                        </td>
+                        <td>
+                            <select id="addTorrentOption" name="addTorrentOption">
+                                <option selected value="DontStart">QBT_TR(Don't start it)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
+                                <option value="CheckOnly">QBT_TR(Only check it)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
+                                <option value="Start">QBT_TR(Start it)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
+                                <option value="StartForced">QBT_TR(Force start it)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
+                            </select>
                         </td>
                     </tr>
                     <tr>

--- a/src/webui/www/private/upload.html
+++ b/src/webui/www/private/upload.html
@@ -60,19 +60,23 @@
                 </tr>
                 <tr>
                     <td>
-                        <label for="startTorrent">QBT_TR(Start torrent)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
-                    </td>
-                    <td>
-                        <input type="hidden" id="startTorrentHidden" name="paused" />
-                        <input type="checkbox" id="startTorrent" />
-                    </td>
-                </tr>
-                <tr>
-                    <td>
                         <label for="skip_checking">QBT_TR(Skip hash check)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
                     </td>
                     <td>
                         <input type="checkbox" id="skip_checking" name="skip_checking" value="true" />
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="addTorrentOption">QBT_TR(When torrent is added:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                    </td>
+                    <td>
+                        <select id="addTorrentOption" name="addTorrentOption">
+                            <option selected value="DontStart">QBT_TR(Don't start it)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
+                            <option value="CheckOnly">QBT_TR(Only check it)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
+                            <option value="Start">QBT_TR(Start it)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
+                            <option value="StartForced">QBT_TR(Force start it)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
+                        </select>
                     </td>
                 </tr>
                 <tr>

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -10,8 +10,13 @@
             </select>
         </div>
         <div class="formRow">
-            <input type="checkbox" id="dontstartdownloads_checkbox" />
-            <label for="dontstartdownloads_checkbox">QBT_TR(Do not start the download automatically)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="addtorrentoption_select">QBT_TR(When new torrent is added)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <select id="addtorrentoption_select">
+                <option value="DontStart">QBT_TR(Start it)QBT_TR[CONTEXT=OptionsDialog]</option>
+                <option value="CheckOnly">QBT_TR(Only check it)QBT_TR[CONTEXT=OptionsDialog]</option>
+                <option value="Start">QBT_TR(Start it)QBT_TR[CONTEXT=OptionsDialog]</option>
+                <option value="StartForced">QBT_TR(Force start it)QBT_TR[CONTEXT=OptionsDialog]</option>
+            </select>
         </div>
         <div class="formRow">
             <input type="checkbox" id="deletetorrentfileafter_checkbox" />
@@ -1685,9 +1690,25 @@
                                 break;
                         }
                         $('contentlayout_select').getChildren('option')[index].setAttribute('selected', '');
-                        $('dontstartdownloads_checkbox').setProperty('checked', pref.start_paused_enabled);
-                        $('deletetorrentfileafter_checkbox').setProperty('checked', pref.auto_delete_mode);
 
+                        index = 0;
+                        switch (pref.add_torrent_option) {
+                            case "DontStart":
+                                index = 0;
+                                break;
+                            case "CheckOnly":
+                                index = 1;
+                                break;
+                            case "Start":
+                                index = 2;
+                                break;
+                            case "StartForced":
+                                index = 3;
+                                break;
+                        }
+                        $('addtorrentoption_select').getChildren('option')[index].setAttribute('selected', '');
+
+                        $('deletetorrentfileafter_checkbox').setProperty('checked', pref.auto_delete_mode);
                         $('preallocateall_checkbox').setProperty('checked', pref.preallocate_all);
                         $('appendext_checkbox').setProperty('checked', pref.incomplete_files_ext);
 
@@ -2028,7 +2049,7 @@
             // Downloads tab
             // When adding a torrent
             settings.set('torrent_content_layout', $('contentlayout_select').getSelected()[0].getProperty('value'));
-            settings.set('start_paused_enabled', $('dontstartdownloads_checkbox').getProperty('checked'));
+            settings.set('add_torrent_option', $('addtorrentoption_select').getSelected()[0].getProperty('value'));
             settings.set('auto_delete_mode', $('deletetorrentfileafter_checkbox').getProperty('checked'));
 
             settings.set('preallocate_all', $('preallocateall_checkbox').getProperty('checked'));

--- a/src/webui/www/private/views/rssDownloader.html
+++ b/src/webui/www/private/views/rssDownloader.html
@@ -238,13 +238,15 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
             <table class="fullWidth">
                 <tr>
                     <td>
-                        <label class="noWrap">QBT_TR(Add Paused:)QBT_TR[CONTEXT=AutomatedRssDownloader]</label>
+                        <label class="noWrap">QBT_TR(When new torrent is added:)QBT_TR[CONTEXT=AutomatedRssDownloader]</label>
                     </td>
                     <td class="fullWidth">
-                        <select disabled id="addPausedCombobox" class="fullWidth">
-                            <option value="default">QBT_TR(Use global settings)QBT_TR[CONTEXT=AutomatedRssDownloader]</option>
-                            <option value="always">QBT_TR(Always)QBT_TR[CONTEXT=AutomatedRssDownloader]</option>
-                            <option value="never">QBT_TR(Never)QBT_TR[CONTEXT=AutomatedRssDownloader]</option>
+                        <select disabled id="addTorrentOptionCombobox" class="fullWidth">
+                            <option value="Default">QBT_TR(Use global settings)QBT_TR[CONTEXT=AutomatedRssDownloader]</option>
+                            <option value="DontStart">QBT_TR(Don't start it)QBT_TR[CONTEXT=AutomatedRssDownloader]</option>
+                            <option value="CheckOnly">QBT_TR(Only check it)QBT_TR[CONTEXT=AutomatedRssDownloader]</option>
+                            <option value="Start">QBT_TR(Start it)QBT_TR[CONTEXT=AutomatedRssDownloader]</option>
+                            <option value="StartForced">QBT_TR(Force start it)QBT_TR[CONTEXT=AutomatedRssDownloader]</option>
                         </select>
                     </td>
                 </tr>
@@ -581,15 +583,21 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
             rulesList[rule].savePath = $('savetoDifferentDir').checked ? $('saveToText').value : '';
             rulesList[rule].ignoreDays = parseInt($('ignoreDaysValue').value);
 
-            switch ($('addPausedCombobox').value) {
-                case 'default':
-                    rulesList[rule].addPaused = null;
+            switch ($('addTorrentOptionCombobox').value) {
+                case 'Default':
+                    rulesList[rule].addTorrentOption = null;
                     break;
-                case 'always':
-                    rulesList[rule].addPaused = true;
+                case 'DontStart':
+                    rulesList[rule].addTorrentOption = 'DontStart';
                     break;
-                case 'never':
-                    rulesList[rule].addPaused = false;
+                case 'CheckOnly':
+                    rulesList[rule].addTorrentOption = 'CheckOnly';
+                    break;
+                case 'Start':
+                    rulesList[rule].addTorrentOption = 'Start';
+                    break;
+                case 'StartForced':
+                    rulesList[rule].addTorrentOption = 'StartForced';
                     break;
             }
 
@@ -669,7 +677,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                 $('savetoDifferentDir').disabled = true;
                 $('saveToText').disabled = true;
                 $('ignoreDaysValue').disabled = true;
-                $('addPausedCombobox').disabled = true;
+                $('addTorrentOptionCombobox').disabled = true;
                 $('contentLayoutCombobox').disabled = true;
 
                 // reset all boxes
@@ -683,7 +691,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                 $('saveToText').value = '';
                 $('ignoreDaysValue').value = 0;
                 $('lastMatchText').innerHTML = 'QBT_TR(Last Match: Unknown)QBT_TR[CONTEXT=AutomatedRssDownloader]';
-                $('addPausedCombobox').value = 'default';
+                $('addTorrentOptionCombobox').value = 'Default';
                 $('contentLayoutCombobox').value = 'Default';
                 rssDownloaderFeedSelectionTable.clear();
                 rssDownloaderArticlesTable.clear();
@@ -705,7 +713,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                 $('savetoDifferentDir').checked = rulesList[ruleName].savePath ? false : true;
                 $('saveToText').disabled = rulesList[ruleName].savePath ? false : true;
                 $('ignoreDaysValue').disabled = false;
-                $('addPausedCombobox').disabled = false;
+                $('addTorrentOptionCombobox').disabled = false;
                 $('contentLayoutCombobox').disabled = false;
 
                 // load rule settings
@@ -731,9 +739,9 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                 }
 
                 if (rulesList[ruleName].addPaused === null)
-                    $('addPausedCombobox').value = 'default';
+                    $('addTorrentOptionCombobox').value = 'Default';
                 else
-                    $('addPausedCombobox').value = rulesList[ruleName].addPaused ? 'always' : 'never';
+                    $('addTorrentOptionCombobox').value = rulesList[ruleName].addTorrentOption;
 
                 if (rulesList[ruleName].torrentContentLayout === null)
                     $('contentLayoutCombobox').value = 'Default';


### PR DESCRIPTION
It allows to add new torrent not only as started/stopped but also as force started or as checking only.

Closes #13890.