### PR TITLE
Add file name filter/blacklist

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -455,6 +455,9 @@ namespace BitTorrent
         void setBlockPeersOnPrivilegedPorts(bool enabled);
         bool isTrackerFilteringEnabled() const;
         void setTrackerFilteringEnabled(bool enabled);
+        QStringList excludedFileNames() const;
+        void setExcludedFileNames(const QStringList &newList);
+        bool isFilenameExcluded(const QString &fileName) const;
         QStringList bannedIPs() const;
         void setBannedIPs(const QStringList &newList);
         ResumeDataStorageType resumeDataStorageType() const;
@@ -624,6 +627,7 @@ namespace BitTorrent
         void applyOSMemoryPriority() const;
 #endif
         void processTrackerStatuses();
+        void populateExcludedFileNamesRegExpList();
 
         bool loadTorrent(LoadTorrentParams params);
         LoadTorrentParams initLoadTorrentParams(const AddTorrentParams &addTorrentParams);
@@ -778,6 +782,7 @@ namespace BitTorrent
         CachedSettingValue<int> m_peerTurnoverCutoff;
         CachedSettingValue<int> m_peerTurnoverInterval;
         CachedSettingValue<int> m_requestQueueSize;
+        CachedSettingValue<QStringList> m_excludedFileNames;
         CachedSettingValue<QStringList> m_bannedIPs;
         CachedSettingValue<ResumeDataStorageType> m_resumeDataStorageType;
 #if defined(Q_OS_WIN)
@@ -792,6 +797,7 @@ namespace BitTorrent
         int m_numResumeData = 0;
         int m_extraLimit = 0;
         QVector<TrackerEntry> m_additionalTrackerList;
+        QVector<QRegularExpression> m_excludedFileNamesRegExpList;
 
         bool m_refreshEnqueued = false;
         QTimer *m_seedingLimitTimer = nullptr;

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -961,6 +961,21 @@ void AddNewTorrentDialog::setupTreeview()
             currentIndex = m_contentModel->index(0, 0, currentIndex);
             m_ui->contentTreeView->setExpanded(currentIndex, true);
         }
+
+        // Check file name blacklist for torrents that are manually added
+        QVector<BitTorrent::DownloadPriority> priorities = m_contentModel->model()->getFilePriorities();
+        Q_ASSERT(priorities.size() == m_torrentInfo.filesCount());
+
+        for (int i = 0; i < priorities.size(); ++i)
+        {
+            if (priorities[i] == BitTorrent::DownloadPriority::Ignored)
+                continue;
+
+            if (BitTorrent::Session::instance()->isFilenameExcluded(m_torrentInfo.filePath(i).filename()))
+                priorities[i] = BitTorrent::DownloadPriority::Ignored;
+        }
+
+        m_contentModel->model()->updateFilesPriorities(priorities);
     }
 
     updateDiskSpaceLabel();

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -378,6 +378,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     connect(m_ui->checkUseDownloadPath, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkUseDownloadPath, &QAbstractButton::toggled, m_ui->textDownloadPath, &QWidget::setEnabled);
     connect(m_ui->addWatchedFolderButton, &QAbstractButton::clicked, this, &ThisType::enableApplyButton);
+    connect(m_ui->textExcludedFileNames, &QPlainTextEdit::textChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->removeWatchedFolderButton, &QAbstractButton::clicked, this, &ThisType::enableApplyButton);
     connect(m_ui->groupMailNotification, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->senderEmailTxt, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
@@ -755,6 +756,7 @@ void OptionsDialog::saveOptions()
     session->setTorrentContentLayout(static_cast<BitTorrent::TorrentContentLayout>(m_ui->contentLayoutComboBox->currentIndex()));
     auto watchedFoldersModel = static_cast<WatchedFoldersModel *>(m_ui->scanFoldersView->model());
     watchedFoldersModel->apply();
+    session->setExcludedFileNames(m_ui->textExcludedFileNames->toPlainText().split(u'\n', Qt::SkipEmptyParts));
     session->setTorrentExportDirectory(getTorrentExportDir());
     session->setFinishedTorrentExportDirectory(getFinishedTorrentExportDir());
     pref->setMailNotificationEnabled(m_ui->groupMailNotification->isChecked());
@@ -1014,6 +1016,7 @@ void OptionsDialog::loadOptions()
     m_ui->checkAppendqB->setChecked(session->isAppendExtensionEnabled());
     m_ui->checkPreallocateAll->setChecked(session->isPreallocationEnabled());
     m_ui->checkRecursiveDownload->setChecked(!pref->recursiveDownloadDisabled());
+    m_ui->textExcludedFileNames->setPlainText(session->excludedFileNames().join(u'\n'));
 
     if (session->torrentExportDirectory().isEmpty())
     {

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -1262,6 +1262,44 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
              </widget>
             </item>
             <item>
+             <widget class="QGroupBox" name="groupExcludedFileNames">
+              <property name="title">
+               <string>Excluded file names</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_311">
+               <item>
+                <widget class="QLabel" name="label_1">
+                 <property name="text">
+                  <string>Filters:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPlainTextEdit" name="textExcludedFileNames">
+                 <property name="toolTip">
+                  <string>Blacklist filtered file names from being downloaded from torrent(s).
+Files matching any of the filters in this list will have their priority automatically set to &quot;Do not download&quot;.
+
+Use newlines to separate multiple entries. Can use wildcards as outlined below.
+*: matches zero or more of any characters.
+?: matches any single character.
+[...]: sets of characters can be represented in square brackets.
+
+Examples
+*.exe: filter '.exe' file extension.
+readme.txt: filter exact file name.
+?.txt: filter 'a.txt', 'b.txt' but not 'aa.txt'.
+readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</string>
+                 </property>
+                 <property name="lineWrapMode">
+                  <enum>QPlainTextEdit::NoWrap</enum>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
              <widget class="QGroupBox" name="groupMailNotification">
               <property name="title">
                <string>Email notification &amp;upon download completion</string>

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -141,6 +141,8 @@ void AppController::preferencesAction()
     data[u"scan_dirs"_qs] = nativeDirs;
     // === END DEPRECATED CODE === //
 
+    data[u"excluded_file_names"_qs] = session->excludedFileNames().join(u'\n');
+
     // Email notification upon download completion
     data[u"mail_notification_enabled"_qs] = pref->isMailNotificationEnabled();
     data[u"mail_notification_sender"_qs] = pref->getMailNotificationSender();
@@ -475,6 +477,9 @@ void AppController::setPreferencesAction()
         }
     }
     // === END DEPRECATED CODE === //
+
+    if (hasKey(u"excluded_file_names"_qs))
+        session->setExcludedFileNames(it.value().toString().split(u'\n'));
 
     // Email notification upon download completion
     if (hasKey(u"mail_notification_enabled"_qs))

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -48,7 +48,7 @@
 #include "base/utils/version.h"
 #include "api/isessionmanager.h"
 
-inline const Utils::Version<int, 3, 2> API_VERSION {2, 8, 11};
+inline const Utils::Version<int, 3, 2> API_VERSION {2, 8, 12};
 
 class APIController;
 class AuthController;

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -131,6 +131,12 @@
     </fieldset>
 
     <fieldset class="settings">
+        <legend>QBT_TR(Excluded file names)QBT_TR[CONTEXT=OptionsDialog]</legend>
+        <label for="excludedFileNamesTextarea">QBT_TR(Filters:)QBT_TR[CONTEXT=OptionsDialog]</label><br>
+        <textarea id="excludedFileNamesTextarea" rows="6" cols="70"></textarea>
+    </fieldset>
+
+    <fieldset class="settings">
         <legend>
             <input type="checkbox" id="mail_notification_checkbox" onclick="qBittorrent.Preferences.updateMailNotification();" />
             <label for="mail_notification_checkbox">QBT_TR(Email notification upon download completion)QBT_TR[CONTEXT=OptionsDialog]</label>
@@ -1733,6 +1739,7 @@
                             addWatchFolder(folder, sel, other);
                         }
                         addWatchFolder();
+                        $('excludedFileNamesTextarea').setProperty('value', pref.excluded_file_names);
 
                         // Email notification upon download completion
                         $('mail_notification_checkbox').setProperty('checked', pref.mail_notification_enabled);
@@ -2053,6 +2060,7 @@
 
             // Automatically add torrents from
             settings.set('scan_dirs', getWatchedFolders());
+            settings.set('excluded_file_names', $('excludedFileNamesTextarea').getProperty('value'));
 
             // Email notification upon download completion
             settings.set('mail_notification_enabled', $('mail_notification_checkbox').getProperty('checked'));


### PR DESCRIPTION
Blacklist filtered file names from being downloaded from torrent(s).

See Options > Downloads >Do not download.

Files matching any of the filters in this list will have their priority automatically set to "Do not download".

Closes #3369.

![file_name_filter_blacklist-ui](https://user-images.githubusercontent.com/58796811/170532300-1d92bc50-8188-4397-b6c4-1a8fd607fae2.png)

