### PR TITLE
Clean up usage of `static` keyword

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -43,7 +43,6 @@
 #include <sys/resource.h>
 #endif
 
-#include <QAtomicInt>
 #include <QByteArray>
 #include <QDebug>
 #include <QLibraryInfo>
@@ -808,8 +807,7 @@ void Application::applyMemoryWorkingSetLimit()
 void Application::cleanup()
 {
     // cleanup() can be called multiple times during shutdown. We only need it once.
-    static QAtomicInt alreadyDone;
-    if (!alreadyDone.testAndSetAcquire(0, 1))
+    if (!m_isCleanupRun.testAndSetAcquire(0, 1))
         return;
 
 #ifndef DISABLE_GUI

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <QtGlobal>
+#include <QAtomicInt>
 #include <QCoreApplication>
 #include <QPointer>
 #include <QStringList>
@@ -145,6 +146,7 @@ private:
 
     ApplicationInstanceManager *m_instanceManager = nullptr;
     bool m_running = false;
+    QAtomicInt m_isCleanupRun;
     ShutdownDialogAction m_shutdownAct;
     QBtCommandLineParameters m_commandLineArgs;
 

--- a/src/app/signalhandler.cpp
+++ b/src/app/signalhandler.cpp
@@ -76,8 +76,8 @@ namespace
     {
         const size_t strLen = strlen(str);
 #ifdef Q_OS_WIN
-        if (_write(_fileno(stderr), str, strLen) < static_cast<int>(strLen))
-            std::ignore = _write(_fileno(stdout), str, strLen);
+        if (_write(_fileno(stderr), str, static_cast<unsigned int>(strLen)) < static_cast<int>(strLen))
+            std::ignore = _write(_fileno(stdout), str, static_cast<unsigned int>(strLen));
 #else
         if (write(STDERR_FILENO, str, strLen) < static_cast<ssize_t>(strLen))
             std::ignore = write(STDOUT_FILENO, str, strLen);

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -635,7 +635,7 @@ Path Session::downloadPath() const
 
 bool Session::isValidCategoryName(const QString &name)
 {
-    static const QRegularExpression re(uR"(^([^\\\/]|[^\\\/]([^\\\/]|\/(?=[^\/]))*[^\\\/])$)"_qs);
+    const QRegularExpression re(uR"(^([^\\\/]|[^\\\/]([^\\\/]|\/(?=[^\/]))*[^\\\/])$)"_qs);
     if (!name.isEmpty() && (name.indexOf(re) != 0))
     {
         qDebug() << "Incorrect category name:" << name;

--- a/src/base/bittorrent/statistics.cpp
+++ b/src/base/bittorrent/statistics.cpp
@@ -35,7 +35,7 @@
 #include "base/bittorrent/sessionstatus.h"
 #include "base/profile.h"
 
-static const qint64 SAVE_INTERVAL = 15 * 60 * 1000;
+const qint64 SAVE_INTERVAL = 15 * 60 * 1000;
 
 using namespace BitTorrent;
 

--- a/src/base/rss/rss_item.cpp
+++ b/src/base/rss/rss_item.cpp
@@ -68,7 +68,7 @@ QString Item::name() const
 
 bool Item::isValidPath(const QString &path)
 {
-    static const QRegularExpression re(
+    const QRegularExpression re(
                 uR"(\A[^\%1]+(\%1[^\%1]+)*\z)"_qs.arg(Item::PathSeparator)
                 , QRegularExpression::DontCaptureOption);
 

--- a/src/base/torrentfileguard.cpp
+++ b/src/base/torrentfileguard.cpp
@@ -31,6 +31,14 @@
 #include "settingvalue.h"
 #include "utils/fs.h"
 
+namespace
+{
+    SettingValue<TorrentFileGuard::AutoDeleteMode> autoDeleteModeSetting()
+    {
+        return SettingValue<TorrentFileGuard::AutoDeleteMode> {u"Core/AutoDeleteAddedTorrentFile"_qs};
+    }
+}
+
 FileGuard::FileGuard(const Path &path)
     : m_path {path}
     , m_remove {true}
@@ -76,13 +84,7 @@ TorrentFileGuard::AutoDeleteMode TorrentFileGuard::autoDeleteMode()
     return autoDeleteModeSetting().get(AutoDeleteMode::Never);
 }
 
-void TorrentFileGuard::setAutoDeleteMode(TorrentFileGuard::AutoDeleteMode mode)
+void TorrentFileGuard::setAutoDeleteMode(const TorrentFileGuard::AutoDeleteMode mode)
 {
     autoDeleteModeSetting() = mode;
-}
-
-SettingValue<TorrentFileGuard::AutoDeleteMode> &TorrentFileGuard::autoDeleteModeSetting()
-{
-    static SettingValue<AutoDeleteMode> setting {u"Core/AutoDeleteAddedTorrentFile"_qs};
-    return setting;
 }

--- a/src/base/torrentfileguard.h
+++ b/src/base/torrentfileguard.h
@@ -33,8 +33,6 @@
 
 #include "base/path.h"
 
-template <typename T> class SettingValue;
-
 /// Utility class to defer file deletion
 class FileGuard
 {
@@ -47,7 +45,7 @@ public:
 
 private:
     Path m_path;
-    bool m_remove;
+    bool m_remove = false;
 };
 
 /// Reads settings for .torrent files from preferences
@@ -64,7 +62,7 @@ public:
     void markAsAddedToSession();
     using FileGuard::setAutoRemove;
 
-    enum AutoDeleteMode: int     // do not change these names: they are stored in config file
+    enum AutoDeleteMode : int     // do not change these names: they are stored in config file
     {
         Never,
         IfAdded,
@@ -77,9 +75,8 @@ public:
 
 private:
     TorrentFileGuard(const Path &path, AutoDeleteMode mode);
-    static SettingValue<AutoDeleteMode> &autoDeleteModeSetting();
 
     Q_ENUM(AutoDeleteMode)
     AutoDeleteMode m_mode;
-    bool m_wasAdded;
+    bool m_wasAdded = false;
 };

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -500,7 +500,7 @@ QString Utils::Misc::opensslVersionString()
 #else
     static const auto version {QString::fromLatin1(SSLeay_version(SSLEAY_VERSION))};
 #endif
-    return QStringView(version).split(u' ', Qt::SkipEmptyParts).at(1).toString();
+    return version.section(u' ', 1, 1);
 }
 
 QString Utils::Misc::zlibVersionString()

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -457,7 +457,7 @@ QString Utils::Misc::parseHtmlLinks(const QString &rawText)
     result.replace(reURL, u"\\1<a href=\"\\2\">\\2</a>"_qs);
 
     // Capture links without scheme
-    static const QRegularExpression reNoScheme(u"<a\\s+href=\"(?!https?)([a-zA-Z0-9\\?%=&/_\\.-:#]+)\\s*\">"_qs);
+    const QRegularExpression reNoScheme(u"<a\\s+href=\"(?!https?)([a-zA-Z0-9\\?%=&/_\\.-:#]+)\\s*\">"_qs);
     result.replace(reNoScheme, u"<a href=\"http://\\1\">"_qs);
 
     // to preserve plain text formatting

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -121,6 +121,21 @@ namespace
             || (!str.startsWith(u"file:", Qt::CaseInsensitive)
                 && Net::DownloadManager::hasSupportedScheme(str));
     }
+
+#ifdef Q_OS_MACOS
+    MainWindow *dockMainWindowHandle = nullptr;
+
+    bool dockClickHandler(id self, SEL cmd, ...)
+    {
+        Q_UNUSED(self)
+        Q_UNUSED(cmd)
+
+        if (dockMainWindowHandle && !dockMainWindowHandle->isVisible())
+            dockMainWindowHandle->activate();
+
+        return true;
+    }
+#endif
 }
 
 MainWindow::MainWindow(QWidget *parent)
@@ -1388,28 +1403,11 @@ void MainWindow::dragEnterEvent(QDragEnterEvent *event)
 }
 
 #ifdef Q_OS_MACOS
-
-static MainWindow *dockMainWindowHandle;
-
-static bool dockClickHandler(id self, SEL cmd, ...)
-{
-    Q_UNUSED(self)
-    Q_UNUSED(cmd)
-
-    if (dockMainWindowHandle && !dockMainWindowHandle->isVisible())
-    {
-        dockMainWindowHandle->activate();
-    }
-
-    return true;
-}
-
 void MainWindow::setupDockClickHandler()
 {
     dockMainWindowHandle = this;
     MacUtils::overrideDockClickHandler(dockClickHandler);
 }
-
 #endif // Q_OS_MACOS
 
 /*****************************************************

--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -44,7 +44,6 @@
 #include "base/search/searchdownloadhandler.h"
 #include "base/search/searchhandler.h"
 #include "base/search/searchpluginmanager.h"
-#include "base/settingvalue.h"
 #include "base/utils/misc.h"
 #include "gui/addnewtorrentdialog.h"
 #include "gui/lineedit.h"
@@ -57,6 +56,7 @@ SearchJobWidget::SearchJobWidget(SearchHandler *searchHandler, QWidget *parent)
     : QWidget(parent)
     , m_ui(new Ui::SearchJobWidget)
     , m_searchHandler(searchHandler)
+    , m_nameFilteringMode(u"Search/FilteringMode"_qs)
 {
     m_ui->setupUi(this);
 
@@ -319,7 +319,7 @@ void SearchJobWidget::updateFilter()
         sizeInBytes(m_ui->minSize->value(), static_cast<SizeUnit>(m_ui->minSizeUnit->currentIndex())),
         sizeInBytes(m_ui->maxSize->value(), static_cast<SizeUnit>(m_ui->maxSizeUnit->currentIndex())));
 
-    nameFilteringModeSetting() = filteringMode();
+    m_nameFilteringMode = filteringMode();
 
     m_proxyModel->invalidate();
     updateResultsCount();
@@ -355,8 +355,8 @@ void SearchJobWidget::fillFilterComboBoxes()
     m_ui->filterMode->addItem(tr("Torrent names only"), static_cast<int>(NameFilteringMode::OnlyNames));
     m_ui->filterMode->addItem(tr("Everywhere"), static_cast<int>(NameFilteringMode::Everywhere));
 
-    QVariant selectedMode = static_cast<int>(nameFilteringModeSetting().get(NameFilteringMode::OnlyNames));
-    int index = m_ui->filterMode->findData(selectedMode);
+    const QVariant selectedMode = static_cast<int>(m_nameFilteringMode.get(NameFilteringMode::OnlyNames));
+    const int index = m_ui->filterMode->findData(selectedMode);
     m_ui->filterMode->setCurrentIndex((index == -1) ? 0 : index);
 }
 
@@ -543,12 +543,6 @@ void SearchJobWidget::appendSearchResults(const QVector<SearchResult> &results)
     }
 
     updateResultsCount();
-}
-
-SettingValue<SearchJobWidget::NameFilteringMode> &SearchJobWidget::nameFilteringModeSetting()
-{
-    static SettingValue<NameFilteringMode> setting {u"Search/FilteringMode"_qs};
-    return setting;
 }
 
 void SearchJobWidget::keyPressEvent(QKeyEvent *event)

--- a/src/gui/search/searchjobwidget.h
+++ b/src/gui/search/searchjobwidget.h
@@ -31,6 +31,8 @@
 
 #include <QWidget>
 
+#include "base/settingvalue.h"
+
 #define ENGINE_URL_COLUMN 4
 #define URL_COLUMN 5
 
@@ -127,7 +129,6 @@ private:
     void copyField(int column) const;
 
     static QString statusText(Status st);
-    static SettingValue<NameFilteringMode> &nameFilteringModeSetting();
 
     Ui::SearchJobWidget *m_ui;
     SearchHandler *m_searchHandler;
@@ -136,6 +137,8 @@ private:
     LineEdit *m_lineEditSearchResultsFilter;
     Status m_status = Status::Ongoing;
     bool m_noSearchResults = true;
+
+    SettingValue<NameFilteringMode> m_nameFilteringMode;
 };
 
 Q_DECLARE_METATYPE(SearchJobWidget::NameFilteringMode)

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -69,14 +69,20 @@ namespace
     class UnifiedFileIconProvider : public QFileIconProvider
     {
     public:
+        UnifiedFileIconProvider()
+            : m_textPlainIcon {UIThemeManager::instance()->getIcon(u"text-plain"_qs)}
+        {
+        }
+
         using QFileIconProvider::icon;
 
-        QIcon icon(const QFileInfo &info) const override
+        QIcon icon(const QFileInfo &) const override
         {
-            Q_UNUSED(info);
-            static QIcon cached = UIThemeManager::instance()->getIcon(u"text-plain"_qs);
-            return cached;
+            return m_textPlainIcon;
         }
+
+    private:
+        QIcon m_textPlainIcon;
     };
 
 #ifdef QBT_PIXMAP_CACHE_FOR_FILE_ICONS
@@ -185,15 +191,14 @@ namespace
 TorrentContentModel::TorrentContentModel(QObject *parent)
     : QAbstractItemModel(parent)
     , m_rootItem(new TorrentContentModelFolder(QVector<QString>({ tr("Name"), tr("Total Size"), tr("Progress"), tr("Download Priority"), tr("Remaining"), tr("Availability") })))
-{
 #if defined(Q_OS_WIN)
-    m_fileIconProvider = new WinShellFileIconProvider();
+    , m_fileIconProvider {new WinShellFileIconProvider}
 #elif defined(Q_OS_MACOS)
-    m_fileIconProvider = new MacFileIconProvider();
+    , m_fileIconProvider {new MacFileIconProvider}
 #else
-    static bool doesBuiltInProviderWork = doesQFileIconProviderWork();
-    m_fileIconProvider = doesBuiltInProviderWork ? new QFileIconProvider() : new MimeFileIconProvider();
+    , m_fileIconProvider {doesQFileIconProviderWork() ? new QFileIconProvider : new MimeFileIconProvider}
 #endif
+{
 }
 
 TorrentContentModel::~TorrentContentModel()

--- a/src/gui/torrentcontentmodel.h
+++ b/src/gui/torrentcontentmodel.h
@@ -84,7 +84,7 @@ public slots:
     void selectNone();
 
 private:
-    TorrentContentModelFolder *m_rootItem;
+    TorrentContentModelFolder *m_rootItem = nullptr;
     QVector<TorrentContentModelFile *> m_filesIndex;
-    QFileIconProvider *m_fileIconProvider;
+    QFileIconProvider *m_fileIconProvider = nullptr;
 };

--- a/src/gui/transferlistdelegate.cpp
+++ b/src/gui/transferlistdelegate.cpp
@@ -50,15 +50,14 @@ QSize TransferListDelegate::sizeHint(const QStyleOptionViewItem &option, const Q
     // the rows shrink if the text's height is smaller than the icon's height.
     // This happens because icon from the 'name' column is no longer drawn.
 
-    static int nameColHeight = -1;
-    if (nameColHeight == -1)
+    if (m_nameColHeight == -1)
     {
         const QModelIndex nameColumn = index.sibling(index.row(), TransferListModel::TR_NAME);
-        nameColHeight = QStyledItemDelegate::sizeHint(option, nameColumn).height();
+        m_nameColHeight = QStyledItemDelegate::sizeHint(option, nameColumn).height();
     }
 
     QSize size = QStyledItemDelegate::sizeHint(option, index);
-    size.setHeight(std::max(nameColHeight, size.height()));
+    size.setHeight(std::max(m_nameColHeight, size.height()));
     return size;
 }
 

--- a/src/gui/transferlistdelegate.h
+++ b/src/gui/transferlistdelegate.h
@@ -46,4 +46,5 @@ public:
 
 private:
     ProgressBarPainter m_progressBarPainter;
+    mutable int m_nameColHeight = -1;
 };

--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -32,6 +32,7 @@
 #include <QAbstractListModel>
 #include <QColor>
 #include <QHash>
+#include <QIcon>
 #include <QList>
 
 #include "base/bittorrent/torrent.h"
@@ -111,6 +112,7 @@ private:
     void configure();
     QString displayValue(const BitTorrent::Torrent *torrent, int column) const;
     QVariant internalValue(const BitTorrent::Torrent *torrent, int column, bool alt) const;
+    QIcon getIconByState(const BitTorrent::TorrentState state) const;
 
     QList<BitTorrent::Torrent *> m_torrentList;  // maps row number to torrent handle
     QHash<BitTorrent::Torrent *, int> m_torrentMap;  // maps torrent handle to row number
@@ -126,4 +128,15 @@ private:
     };
 
     HideZeroValuesMode m_hideZeroValuesMode = HideZeroValuesMode::Never;
+
+    // cached icons
+    QIcon m_checkingIcon;
+    QIcon m_completedIcon;
+    QIcon m_downloadingIcon;
+    QIcon m_errorIcon;
+    QIcon m_pausedIcon;
+    QIcon m_queuedIcon;
+    QIcon m_stalledDLIcon;
+    QIcon m_stalledUPIcon;
+    QIcon m_uploadingIcon;
 };

--- a/src/gui/uithememanager.cpp
+++ b/src/gui/uithememanager.cpp
@@ -201,7 +201,13 @@ void UIThemeManager::applyStyleSheet() const
 
 QIcon UIThemeManager::getIcon(const QString &iconId, const QString &fallback) const
 {
+    // Cache to avoid rescaling svg icons
+    const auto iter = m_iconCache.find(iconId);
+    if (iter != m_iconCache.end())
+        return *iter;
+
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
+    // Don't cache system icons because users might change them at run time
     if (m_useSystemTheme)
     {
         QIcon icon = QIcon::fromTheme(iconId);
@@ -210,12 +216,6 @@ QIcon UIThemeManager::getIcon(const QString &iconId, const QString &fallback) co
         return icon;
     }
 #endif
-
-    // Cache to avoid rescaling svg icons
-    // And don't cache system icons because users might change them at run time
-    const auto iter = m_iconCache.find(iconId);
-    if (iter != m_iconCache.end())
-        return *iter;
 
     const QIcon icon {getIconPathFromResources(iconId, fallback).data()};
     m_iconCache[iconId] = icon;


### PR DESCRIPTION
* Suppress type narrowing warnings
* Turn static variable into class member
* Revise code
* Move function into anonymous namespace
* Revise icon cache look up
  Find in `m_iconCache` first because it is cheaper than calling `QIcon::fromTheme()`.
* Clean up usage of static keyword
  They are either misused or redundant, so remove it.