### PR TITLE
Use CMake to update translation files

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -51,8 +51,14 @@ before_build:
 
 build_script:
   - cd "%REPO_DIR%"
-  # scan only as lupdate is prone to hang
-  - lupdate -extensions c,cpp,h,hpp,ui .
+  # lupdate chokes when it parses headers from system inludes, especially Boost
+  # it also chokes with the sources from src/app/qtlocalpeer (formerly qtsingleapplication)
+  # Workaround: temporarily rename them to run lupdate with the .pro file
+  - RENAME conf.pri conf.pri.temp
+  - RENAME src\app\qtlocalpeer qtlocalpeer.temp
+  - lupdate qbittorrent.pro
+  - RENAME conf.pri.temp conf.pri
+  - RENAME src\app\qtlocalpeer.temp qtlocalpeer
   - qmake qbittorrent.pro && cd src && qmake src.pro
   - jom -j2 -f Makefile.Release
 

--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -80,7 +80,6 @@ jobs:
       - name: Build qBittorrent (Qt5)
         if: ${{ startsWith(matrix.qt_version, 5) }}
         run: |
-          lupdate -extensions c,cpp,h,hpp,ui ./
           cmake \
             -B build \
             -G "Ninja" \
@@ -90,12 +89,12 @@ jobs:
             -DOPENSSL_ROOT_DIR="${{ env.openssl_root }}" \
             -DVERBOSE_CONFIGURE=ON \
             -D${{ matrix.qbt_gui }}
+          cmake --build build --target qbt_update_translations
           cmake --build build
 
       - name: Build qBittorrent (Qt6)
         if: ${{ startsWith(matrix.qt_version, 6) }}
         run: |
-          lupdate -extensions c,cpp,h,hpp,ui ./
           cmake \
             -B build \
             -G "Ninja" \
@@ -106,6 +105,7 @@ jobs:
             -DQT6=ON \
             -DVERBOSE_CONFIGURE=ON \
             -D${{ matrix.qbt_gui }}
+          cmake --build build --target qbt_update_translations
           cmake --build build
 
       - name: Prepare build artifacts

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -64,7 +64,6 @@ jobs:
       - name: Build qBittorrent (Qt5)
         if: ${{ startsWith(matrix.qt_version, 5) }}
         run: |
-          lupdate -extensions c,cpp,h,hpp,ui ./
           cmake \
             -B build \
             -G "Ninja" \
@@ -73,13 +72,13 @@ jobs:
             -DCMAKE_INSTALL_PREFIX="/usr" \
             -DVERBOSE_CONFIGURE=ON \
             -D${{ matrix.qbt_gui }}
+          cmake --build build --target qbt_update_translations
           cmake --build build
           DESTDIR="qbittorrent" cmake --install build
 
       - name: Build qBittorrent (Qt6)
         if: ${{ startsWith(matrix.qt_version, 6) }}
         run: |
-          lupdate -extensions c,cpp,h,hpp,ui ./
           cmake \
             -B build \
             -G "Ninja" \
@@ -89,6 +88,7 @@ jobs:
             -DQT6=ON \
             -DVERBOSE_CONFIGURE=ON \
             -D${{ matrix.qbt_gui }}
+          cmake --build build --target qbt_update_translations
           cmake --build build
           DESTDIR="qbittorrent" cmake --install build
 

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -105,7 +105,6 @@ jobs:
 
       - name: Build qBittorrent
         run: |
-          lupdate -extensions c,cpp,h,hpp,ui .
           cmake `
             -B build `
             -G "Ninja" `
@@ -119,6 +118,7 @@ jobs:
             -DVCPKG_TARGET_TRIPLET=x64-windows-static-release `
             -DVERBOSE_CONFIGURE=ON `
             --graphviz=build/target_graph.dot
+          cmake --build build --target qbt_update_translations
           cmake --build build
 
       - name: Prepare build artifacts

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -1,8 +1,19 @@
+file(GLOB QBT_TS_FILES "${qBittorrent_SOURCE_DIR}/src/lang/*.ts")
+# Custom target to update .ts files and include new strings from source files
+# Depends on Qt's LinguistTools
+get_target_property(QT_LUPDATE_EXECUTABLE Qt::lupdate IMPORTED_LOCATION)
+add_custom_target(qbt_update_translations
+                    COMMAND ${QT_LUPDATE_EXECUTABLE} -extensions ui,c,c++,cc,cpp,cxx,ch,h,h++,hh,hpp,hxx
+                                                     ${qBittorrent_SOURCE_DIR}
+                                                     -ts ${QBT_TS_FILES}
+                    WORKING_DIRECTORY "${qBittorrent_SOURCE_DIR}"
+                    VERBATIM
+                    COMMAND_EXPAND_LISTS)
+
 # Generate and configure translation files
 # -----------------------------------------------------------------------------
 # -----------------------------------------------------------------------------
 # Based on https://gist.github.com/giraldeau/546ba5512a74dfe9d8ea0862d66db412
-file(GLOB QBT_TS_FILES "${qBittorrent_SOURCE_DIR}/src/lang/*.ts")
 set_source_files_properties(${QBT_TS_FILES} PROPERTIES OUTPUT_LOCATION "${qBittorrent_BINARY_DIR}/src/lang")
 qt_add_translation(QBT_QM_FILES ${QBT_TS_FILES} OPTIONS -silent)
 configure_file("${qBittorrent_SOURCE_DIR}/src/lang/lang.qrc" "${qBittorrent_BINARY_DIR}/src/lang/lang.qrc" COPYONLY)


### PR DESCRIPTION
It uses lupdate directly.
Qt's `qt_add_lupdate()` cmake function doesn't help much.
First of all it is Qt6 only.
Secondly, our project is split into multiple targets but we need all
strings into a single .ts file per language.
Thirdly, it looks like it will skip source files that are added conditionally into the build
via cmake condition checking (eg DBUS source files). We need to gather all strings present
in the source files regardless of the build configuration.

On another note, this is a step towards reducing dependency on qmake/autoconf.