### PR TITLE
Fix wrong dialog sizes on first start up

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -45,7 +45,6 @@
 #include <QLocale>
 #include <QNetworkCookie>
 #include <QSettings>
-#include <QSize>
 #include <QTime>
 
 #ifdef Q_OS_WIN
@@ -1368,34 +1367,6 @@ void Preferences::setPropTrackerListState(const QByteArray &state)
     setValue(u"GUI/Qt6/TorrentProperties/TrackerListState"_qs, state);
 #else
     setValue(u"TorrentProperties/Trackers/qt5/TrackerListState"_qs, state);
-#endif
-}
-
-QSize Preferences::getRssGeometrySize() const
-{
-    return value<QSize>(u"RssFeedDownloader/geometrySize"_qs);
-}
-
-void Preferences::setRssGeometrySize(const QSize &geometry)
-{
-    setValue(u"RssFeedDownloader/geometrySize"_qs, geometry);
-}
-
-QByteArray Preferences::getRssHSplitterSizes() const
-{
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-    return value<QByteArray>(u"GUI/Qt6/RSSFeedDownloader/HSplitterSizes"_qs);
-#else
-    return value<QByteArray>(u"RssFeedDownloader/qt5/hsplitterSizes"_qs);
-#endif
-}
-
-void Preferences::setRssHSplitterSizes(const QByteArray &sizes)
-{
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-    setValue(u"GUI/Qt6/RSSFeedDownloader/HSplitterSizes"_qs, sizes);
-#else
-    setValue(u"RssFeedDownloader/qt5/hsplitterSizes"_qs, sizes);
 #endif
 }
 

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -38,7 +38,6 @@
 
 class QDateTime;
 class QNetworkCookie;
-class QSize;
 class QTime;
 
 namespace Scheduler
@@ -353,10 +352,6 @@ public:
     void setPropVisible(bool visible);
     QByteArray getPropTrackerListState() const;
     void setPropTrackerListState(const QByteArray &state);
-    QSize getRssGeometrySize() const;
-    void setRssGeometrySize(const QSize &geometry);
-    QByteArray getRssHSplitterSizes() const;
-    void setRssHSplitterSizes(const QByteArray &sizes);
     QStringList getRssOpenFolders() const;
     void setRssOpenFolders(const QStringList &folders);
     QByteArray getRssSideSplitterState() const;

--- a/src/gui/aboutdialog.cpp
+++ b/src/gui/aboutdialog.cpp
@@ -47,7 +47,6 @@ AboutDialog::AboutDialog(QWidget *parent)
     , m_storeDialogSize(SETTINGS_KEY(u"Size"_qs))
 {
     m_ui->setupUi(this);
-    setAttribute(Qt::WA_DeleteOnClose);
 
     // Title
     m_ui->labelName->setText(QStringLiteral("<b><h2>qBittorrent " QBT_VERSION " (%1-bit)</h2></b>").arg(QT_POINTER_SIZE * 8));
@@ -114,7 +113,6 @@ AboutDialog::AboutDialog(QWidget *parent)
     m_ui->labelDBIP->setText(DBIPText);
 
     resize(m_storeDialogSize);
-    show();
 }
 
 AboutDialog::~AboutDialog()

--- a/src/gui/aboutdialog.cpp
+++ b/src/gui/aboutdialog.cpp
@@ -112,7 +112,8 @@ AboutDialog::AboutDialog(QWidget *parent)
                                      "The database is licensed under the Creative Commons Attribution 4.0 International License"));
     m_ui->labelDBIP->setText(DBIPText);
 
-    resize(m_storeDialogSize);
+    if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())
+        resize(dialogSize);
 }
 
 AboutDialog::~AboutDialog()

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -183,7 +183,6 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::AddTorrentParams &inP
 {
     // TODO: set dialog file properties using m_torrentParams.filePriorities
     m_ui->setupUi(this);
-    setAttribute(Qt::WA_DeleteOnClose);
 
     m_ui->lblMetaLoading->setVisible(false);
     m_ui->progMetaLoading->setVisible(false);
@@ -352,6 +351,7 @@ void AddNewTorrentDialog::saveState()
 void AddNewTorrentDialog::show(const QString &source, const BitTorrent::AddTorrentParams &inParams, QWidget *parent)
 {
     auto *dlg = new AddNewTorrentDialog(inParams, parent);
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
 
     if (Net::DownloadManager::hasSupportedScheme(source))
     {

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -336,7 +336,9 @@ void AddNewTorrentDialog::setSavePathHistoryLength(const int value)
 
 void AddNewTorrentDialog::loadState()
 {
-    resize(m_storeDialogSize);
+    if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())
+        resize(dialogSize);
+
     m_ui->splitter->restoreState(m_storeSplitterState);;
 }
 

--- a/src/gui/banlistoptionsdialog.cpp
+++ b/src/gui/banlistoptionsdialog.cpp
@@ -56,7 +56,8 @@ BanListOptionsDialog::BanListOptionsDialog(QWidget *parent)
     m_ui->bannedIPList->sortByColumn(0, Qt::AscendingOrder);
     m_ui->buttonBanIP->setEnabled(false);
 
-    resize(m_storeDialogSize);
+    if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())
+        resize(dialogSize);
 }
 
 BanListOptionsDialog::~BanListOptionsDialog()

--- a/src/gui/cookiesdialog.cpp
+++ b/src/gui/cookiesdialog.cpp
@@ -64,7 +64,9 @@ CookiesDialog::CookiesDialog(QWidget *parent)
                     m_cookiesModel->index(0, 0),
                     QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
 
-    resize(m_storeDialogSize);
+    if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())
+        resize(dialogSize);
+
     m_ui->treeView->header()->restoreState(m_storeViewState);
 }
 

--- a/src/gui/downloadfromurldialog.cpp
+++ b/src/gui/downloadfromurldialog.cpp
@@ -92,7 +92,8 @@ DownloadFromURLDialog::DownloadFromURLDialog(QWidget *parent)
     m_ui->textUrls->setText(text);
     m_ui->textUrls->moveCursor(QTextCursor::End);
 
-    resize(m_storeDialogSize);
+    if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())
+        resize(dialogSize);
 }
 
 DownloadFromURLDialog::~DownloadFromURLDialog()

--- a/src/gui/downloadfromurldialog.cpp
+++ b/src/gui/downloadfromurldialog.cpp
@@ -64,8 +64,6 @@ DownloadFromURLDialog::DownloadFromURLDialog(QWidget *parent)
     , m_storeDialogSize(SETTINGS_KEY(u"Size"_qs))
 {
     m_ui->setupUi(this);
-    setAttribute(Qt::WA_DeleteOnClose);
-    setModal(true);
 
     m_ui->buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Download"));
     connect(m_ui->buttonBox, &QDialogButtonBox::accepted, this, &DownloadFromURLDialog::downloadButtonClicked);
@@ -95,7 +93,6 @@ DownloadFromURLDialog::DownloadFromURLDialog(QWidget *parent)
     m_ui->textUrls->moveCursor(QTextCursor::End);
 
     resize(m_storeDialogSize);
-    show();
 }
 
 DownloadFromURLDialog::~DownloadFromURLDialog()

--- a/src/gui/ipsubnetwhitelistoptionsdialog.cpp
+++ b/src/gui/ipsubnetwhitelistoptionsdialog.cpp
@@ -60,7 +60,8 @@ IPSubnetWhitelistOptionsDialog::IPSubnetWhitelistOptionsDialog(QWidget *parent)
     m_ui->whitelistedIPSubnetList->sortByColumn(0, Qt::AscendingOrder);
     m_ui->buttonWhitelistIPSubnet->setEnabled(false);
 
-    resize(m_storeDialogSize);
+    if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())
+        resize(dialogSize);
 }
 
 IPSubnetWhitelistOptionsDialog::~IPSubnetWhitelistOptionsDialog()

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1124,17 +1124,29 @@ void MainWindow::on_actionAbout_triggered()
 {
     // About dialog
     if (m_aboutDlg)
+    {
         m_aboutDlg->activateWindow();
+    }
     else
+    {
         m_aboutDlg = new AboutDialog(this);
+        m_aboutDlg->setAttribute(Qt::WA_DeleteOnClose);
+        m_aboutDlg->show();
+    }
 }
 
 void MainWindow::on_actionStatistics_triggered()
 {
     if (m_statsDlg)
+    {
         m_statsDlg->activateWindow();
+    }
     else
+    {
         m_statsDlg = new StatsDialog(this);
+        m_statsDlg->setAttribute(Qt::WA_DeleteOnClose);
+        m_statsDlg->show();
+    }
 }
 
 void MainWindow::showEvent(QShowEvent *e)
@@ -1279,6 +1291,8 @@ void MainWindow::createTorrentTriggered(const Path &path)
     else
     {
         m_createTorrentDlg = new TorrentCreatorDialog(this, path);
+        m_createTorrentDlg->setAttribute(Qt::WA_DeleteOnClose);
+        m_createTorrentDlg->show();
     }
 }
 
@@ -1814,9 +1828,15 @@ PropertiesWidget *MainWindow::propertiesWidget() const
 void MainWindow::on_actionOptions_triggered()
 {
     if (m_options)
+    {
         m_options->activateWindow();
+    }
     else
+    {
         m_options = new OptionsDialog(this);
+        m_options->setAttribute(Qt::WA_DeleteOnClose);
+        m_options->open();
+    }
 }
 
 void MainWindow::on_actionTopToolBar_triggered()
@@ -1923,7 +1943,9 @@ void MainWindow::on_actionDownloadFromURL_triggered()
     if (!m_downloadFromURLDialog)
     {
         m_downloadFromURLDialog = new DownloadFromURLDialog(this);
+        m_downloadFromURLDialog->setAttribute(Qt::WA_DeleteOnClose);
         connect(m_downloadFromURLDialog.data(), &DownloadFromURLDialog::urlsReadyToBeDownloaded, this, &MainWindow::downloadFromURLList);
+        m_downloadFromURLDialog->open();
     }
 }
 

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -32,7 +32,6 @@
 #include <limits>
 
 #include <QApplication>
-#include <QCloseEvent>
 #include <QDebug>
 #include <QDesktopServices>
 #include <QDialogButtonBox>
@@ -185,8 +184,6 @@ OptionsDialog::OptionsDialog(QWidget *parent)
 {
     qDebug("-> Constructing Options");
     m_ui->setupUi(this);
-    setAttribute(Qt::WA_DeleteOnClose);
-    setModal(true);
 
 #if (defined(Q_OS_UNIX))
     setWindowTitle(tr("Preferences"));
@@ -576,7 +573,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     m_ui->tabSelection->setCurrentRow(m_storeLastViewedPage);
 
     resize(m_storeDialogSize);
-    show();
+
     // Have to be called after show(), because splitter width needed
     loadSplitterState();
 }
@@ -1477,15 +1474,8 @@ void OptionsDialog::applySettings()
     saveOptions();
 }
 
-void OptionsDialog::closeEvent(QCloseEvent *e)
-{
-    setAttribute(Qt::WA_DeleteOnClose);
-    e->accept();
-}
-
 void OptionsDialog::on_buttonBox_rejected()
 {
-    setAttribute(Qt::WA_DeleteOnClose);
     reject();
 }
 
@@ -1667,7 +1657,6 @@ void OptionsDialog::on_addWatchedFolderButton_clicked()
         return;
 
     auto dialog = new WatchedFolderOptionsDialog({}, this);
-    dialog->setModal(true);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     connect(dialog, &QDialog::accepted, this, [this, dialog, dir, pref]()
     {
@@ -1723,7 +1712,6 @@ void OptionsDialog::editWatchedFolderOptions(const QModelIndex &index)
 
     auto watchedFoldersModel = static_cast<WatchedFoldersModel *>(m_ui->scanFoldersView->model());
     auto dialog = new WatchedFolderOptionsDialog(watchedFoldersModel->folderOptions(index.row()), this);
-    dialog->setModal(true);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     connect(dialog, &QDialog::accepted, this, [this, dialog, index, watchedFoldersModel]()
     {

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -572,10 +572,8 @@ OptionsDialog::OptionsDialog(QWidget *parent)
 
     m_ui->tabSelection->setCurrentRow(m_storeLastViewedPage);
 
-    resize(m_storeDialogSize);
-
-    // Have to be called after show(), because splitter width needed
-    loadSplitterState();
+    if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())
+        resize(dialogSize);
 }
 
 void OptionsDialog::initializeLanguageCombo()
@@ -644,6 +642,13 @@ void OptionsDialog::loadSplitterState()
         splitterSizes.append(string.toInt());
 
     m_ui->hsplitter->setSizes(splitterSizes);
+}
+
+void OptionsDialog::showEvent(QShowEvent *e)
+{
+    QDialog::showEvent(e);
+
+    loadSplitterState();
 }
 
 void OptionsDialog::saveOptions()

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -33,7 +33,6 @@
 #include "base/pathfwd.h"
 #include "base/settingvalue.h"
 
-class QCloseEvent;
 class QListWidgetItem;
 
 class AdvancedSettings;
@@ -94,7 +93,6 @@ public slots:
 private slots:
     void enableProxy(int index);
     void on_buttonBox_accepted();
-    void closeEvent(QCloseEvent *e) override;
     void on_buttonBox_rejected();
     void applySettings();
     void enableApplyButton();

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -115,6 +115,8 @@ private slots:
     void webUIHttpsKeyChanged(const Path &path, ShowError showError);
 
 private:
+    void showEvent(QShowEvent *e) override;
+
     // Methods
     void saveOptions();
     void loadOptions();

--- a/src/gui/previewselectdialog.cpp
+++ b/src/gui/previewselectdialog.cpp
@@ -173,13 +173,12 @@ void PreviewSelectDialog::saveWindowState()
 void PreviewSelectDialog::loadWindowState()
 {
     // Restore dialog size
-    resize(m_storeDialogSize);
+    if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())
+        resize(dialogSize);
 
     // Restore TreeView Header state
-    if (!m_storeTreeHeaderState.get().isEmpty())
-    {
-        m_headerStateInitialized = m_ui->previewList->header()->restoreState(m_storeTreeHeaderState);
-    }
+    if (const QByteArray treeHeaderState = m_storeTreeHeaderState; !treeHeaderState.isEmpty())
+        m_headerStateInitialized = m_ui->previewList->header()->restoreState(treeHeaderState);
 }
 
 void PreviewSelectDialog::showEvent(QShowEvent *event)

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -36,6 +36,7 @@
 #include <QSet>
 
 #include "base/rss/rss_autodownloadrule.h"
+#include "base/settingvalue.h"
 
 class QListWidgetItem;
 class QRegularExpression;
@@ -106,4 +107,7 @@ private:
     RSS::AutoDownloadRule m_currentRule;
     QHash<QString, QListWidgetItem *> m_itemsByRuleName;
     QRegularExpression *m_episodeRegex;
+
+    SettingValue<QSize> m_storeDialogSize;
+    SettingValue<QByteArray> m_storeHSplitterSize;
 };

--- a/src/gui/search/pluginselectdialog.cpp
+++ b/src/gui/search/pluginselectdialog.cpp
@@ -87,7 +87,8 @@ PluginSelectDialog::PluginSelectDialog(SearchPluginManager *pluginManager, QWidg
     connect(m_pluginManager, &SearchPluginManager::checkForUpdatesFinished, this, &PluginSelectDialog::checkForUpdatesFinished);
     connect(m_pluginManager, &SearchPluginManager::checkForUpdatesFailed, this, &PluginSelectDialog::checkForUpdatesFailed);
 
-    resize(m_storeDialogSize);
+    if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())
+        resize(dialogSize);
 }
 
 PluginSelectDialog::~PluginSelectDialog()

--- a/src/gui/search/pluginselectdialog.cpp
+++ b/src/gui/search/pluginselectdialog.cpp
@@ -66,7 +66,6 @@ PluginSelectDialog::PluginSelectDialog(SearchPluginManager *pluginManager, QWidg
     , m_pluginManager(pluginManager)
 {
     m_ui->setupUi(this);
-    setAttribute(Qt::WA_DeleteOnClose);
 
     m_ui->pluginsTree->setRootIsDecorated(false);
     m_ui->pluginsTree->hideColumn(PLUGIN_ID);
@@ -89,7 +88,6 @@ PluginSelectDialog::PluginSelectDialog(SearchPluginManager *pluginManager, QWidg
     connect(m_pluginManager, &SearchPluginManager::checkForUpdatesFailed, this, &PluginSelectDialog::checkForUpdatesFailed);
 
     resize(m_storeDialogSize);
-    show();
 }
 
 PluginSelectDialog::~PluginSelectDialog()
@@ -346,8 +344,10 @@ void PluginSelectDialog::finishPluginUpdate()
 void PluginSelectDialog::on_installButton_clicked()
 {
     auto *dlg = new PluginSourceDialog(this);
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
     connect(dlg, &PluginSourceDialog::askForLocalFile, this, &PluginSelectDialog::askForLocalPlugin);
     connect(dlg, &PluginSourceDialog::askForUrl, this, &PluginSelectDialog::askForPluginUrl);
+    dlg->show();
 }
 
 void PluginSelectDialog::askForPluginUrl()

--- a/src/gui/search/pluginsourcedialog.cpp
+++ b/src/gui/search/pluginsourcedialog.cpp
@@ -40,7 +40,8 @@ PluginSourceDialog::PluginSourceDialog(QWidget *parent)
 {
     m_ui->setupUi(this);
 
-    resize(m_storeDialogSize);
+    if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())
+        resize(dialogSize);
 }
 
 PluginSourceDialog::~PluginSourceDialog()

--- a/src/gui/search/pluginsourcedialog.cpp
+++ b/src/gui/search/pluginsourcedialog.cpp
@@ -39,10 +39,8 @@ PluginSourceDialog::PluginSourceDialog(QWidget *parent)
     , m_storeDialogSize(SETTINGS_KEY(u"Size"_qs))
 {
     m_ui->setupUi(this);
-    setAttribute(Qt::WA_DeleteOnClose);
 
     resize(m_storeDialogSize);
-    show();
 }
 
 PluginSourceDialog::~PluginSourceDialog()

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -286,7 +286,9 @@ void SearchWidget::toggleFocusBetweenLineEdits()
 
 void SearchWidget::on_pluginsButton_clicked()
 {
-    new PluginSelectDialog(SearchPluginManager::instance(), this);
+    auto *dlg = new PluginSelectDialog(SearchPluginManager::instance(), this);
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
+    dlg->show();
 }
 
 void SearchWidget::searchTextEdited(const QString &)

--- a/src/gui/speedlimitdialog.cpp
+++ b/src/gui/speedlimitdialog.cpp
@@ -108,7 +108,8 @@ SpeedLimitDialog::SpeedLimitDialog(QWidget *parent)
     connect(m_ui->spinAltDownloadLimit, qOverload<int>(&QSpinBox::valueChanged)
             , this, [this](const int value) { updateSliderValue(m_ui->sliderAltDownloadLimit, value); });
 
-    resize(m_storeDialogSize);
+    if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())
+        resize(dialogSize);
 }
 
 SpeedLimitDialog::~SpeedLimitDialog()

--- a/src/gui/statsdialog.cpp
+++ b/src/gui/statsdialog.cpp
@@ -60,7 +60,8 @@ StatsDialog::StatsDialog(QWidget *parent)
     m_ui->labelCacheHits->hide();
 #endif
 
-    resize(m_storeDialogSize);
+    if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())
+        resize(dialogSize);
 }
 
 StatsDialog::~StatsDialog()

--- a/src/gui/statsdialog.cpp
+++ b/src/gui/statsdialog.cpp
@@ -48,7 +48,7 @@ StatsDialog::StatsDialog(QWidget *parent)
     , m_storeDialogSize(SETTINGS_KEY(u"Size"_qs))
 {
     m_ui->setupUi(this);
-    setAttribute(Qt::WA_DeleteOnClose);
+
     connect(m_ui->buttonBox, &QDialogButtonBox::accepted, this, &StatsDialog::close);
 
     update();
@@ -61,7 +61,6 @@ StatsDialog::StatsDialog(QWidget *parent)
 #endif
 
     resize(m_storeDialogSize);
-    show();
 }
 
 StatsDialog::~StatsDialog()

--- a/src/gui/torrentcreatordialog.cpp
+++ b/src/gui/torrentcreatordialog.cpp
@@ -340,5 +340,6 @@ void TorrentCreatorDialog::loadSettings()
     m_ui->txtComment->setPlainText(m_storeComments);
     m_ui->lineEditSource->setText(m_storeSource);
 
-    resize(m_storeDialogSize);
+    if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())
+        resize(dialogSize);
 }

--- a/src/gui/torrentcreatordialog.cpp
+++ b/src/gui/torrentcreatordialog.cpp
@@ -67,8 +67,6 @@ TorrentCreatorDialog::TorrentCreatorDialog(QWidget *parent, const Path &defaultP
     , m_storeSource(SETTINGS_KEY(u"Source"_qs))
 {
     m_ui->setupUi(this);
-    setAttribute(Qt::WA_DeleteOnClose);
-    setModal(false);
 
     m_ui->buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Create Torrent"));
 
@@ -89,8 +87,6 @@ TorrentCreatorDialog::TorrentCreatorDialog(QWidget *parent, const Path &defaultP
 #else
     m_ui->widgetTorrentFormat->hide();
 #endif
-
-    show();
 }
 
 TorrentCreatorDialog::~TorrentCreatorDialog()

--- a/src/gui/torrentoptionsdialog.cpp
+++ b/src/gui/torrentoptionsdialog.cpp
@@ -390,7 +390,8 @@ TorrentOptionsDialog::TorrentOptionsDialog(QWidget *parent, const QVector<BitTor
 
     connect(m_ui->buttonGroup, &QButtonGroup::idClicked, this, &TorrentOptionsDialog::handleRatioTypeChanged);
 
-    resize(m_storeDialogSize);
+    if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())
+        resize(dialogSize);
 }
 
 TorrentOptionsDialog::~TorrentOptionsDialog()

--- a/src/gui/trackerentriesdialog.cpp
+++ b/src/gui/trackerentriesdialog.cpp
@@ -110,5 +110,6 @@ void TrackerEntriesDialog::saveSettings()
 
 void TrackerEntriesDialog::loadSettings()
 {
-    resize(m_storeDialogSize);
+    if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())
+        resize(dialogSize);
 }

--- a/src/gui/watchedfolderoptionsdialog.cpp
+++ b/src/gui/watchedfolderoptionsdialog.cpp
@@ -125,7 +125,8 @@ TorrentFilesWatcher::WatchedFolderOptions WatchedFolderOptionsDialog::watchedFol
 
 void WatchedFolderOptionsDialog::loadState()
 {
-    resize(m_storeDialogSize);
+    if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())
+        resize(dialogSize);
 }
 
 void WatchedFolderOptionsDialog::saveState()


### PR DESCRIPTION
* Set dialog properties at the caller site
  Redundant `setModal(true)` are removed since the dialog is already opened via `open()`.
* Don't resize dialog with invalid sizes
  This fixes wrong dialog sizes on first startup.