### PR TITLE
Add support for custom SMTP ports

### DIFF
--- a/src/base/net/smtp.cpp
+++ b/src/base/net/smtp.cpp
@@ -163,16 +163,14 @@ void Smtp::sendMail(const QString &from, const QString &to, const QString &subje
     }
 
     // Connect to SMTP server
-    QStringList smtpServer;
-    quint16 smtpPort;
-    bool customPort;
+    bool customPort = false;
+    const QStringList smtpServer = pref->getMailNotificationSMTP().split(u":"_qs);;
+    quint16 smtpPort = smtpServer.value(1).toUShort(&customPort);
 
-    smtpServer = pref->getMailNotificationSMTP().split(u":"_qs);
-    smtpPort = smtpServer.value(1).toUShort(&customPort);
 #ifndef QT_NO_OPENSSL
     if (pref->getMailNotificationSMTPSSL())
     {
-        if(customPort == false)
+        if (customPort == false)
             smtpPort = DEFAULT_PORT_SSL;
         m_socket->connectToHostEncrypted(smtpServer.at(0), smtpPort);
         m_useSsl = true;
@@ -180,7 +178,7 @@ void Smtp::sendMail(const QString &from, const QString &to, const QString &subje
     else
     {
 #endif
-    if(customPort == false)
+    if (customPort == false)
         smtpPort = DEFAULT_PORT;
     m_socket->connectToHost(smtpServer.at(0), smtpPort);
     m_useSsl = false;

--- a/src/base/net/smtp.cpp
+++ b/src/base/net/smtp.cpp
@@ -163,16 +163,26 @@ void Smtp::sendMail(const QString &from, const QString &to, const QString &subje
     }
 
     // Connect to SMTP server
+    QStringList smtpServer;
+    quint16 smtpPort;
+    bool customPort;
+
+    smtpServer = pref->getMailNotificationSMTP().split(u":"_qs);
+    smtpPort = smtpServer.value(1).toUShort(&customPort);
 #ifndef QT_NO_OPENSSL
     if (pref->getMailNotificationSMTPSSL())
     {
-        m_socket->connectToHostEncrypted(pref->getMailNotificationSMTP(), DEFAULT_PORT_SSL);
+        if(customPort == false)
+            smtpPort = DEFAULT_PORT_SSL;
+        m_socket->connectToHostEncrypted(smtpServer.at(0), smtpPort);
         m_useSsl = true;
     }
     else
     {
 #endif
-    m_socket->connectToHost(pref->getMailNotificationSMTP(), DEFAULT_PORT);
+    if(customPort == false)
+        smtpPort = DEFAULT_PORT;
+    m_socket->connectToHost(smtpServer.at(0), smtpPort);
     m_useSsl = false;
 #ifndef QT_NO_OPENSSL
     }


### PR DESCRIPTION
This PR adds support for custom ports in SMTP settings used for email notifications.

The port can be optionally specified by appending `:<port>` to the existing `SMTP Server` field in settings. If no port is specified, then the default port (`25` for insecure or `465` for SSL) is used.

Closes #12212.