### PR TITLE
Fix wrong file names displayed in tooltip

### DIFF
--- a/src/app/filelogger.cpp
+++ b/src/app/filelogger.cpp
@@ -134,19 +134,19 @@ void FileLogger::addLogMessage(const Log::Msg &msg)
     switch (msg.type)
     {
     case Log::INFO:
-        stream << "(I) ";
+        stream << u"(I) ";
         break;
     case Log::WARNING:
-        stream << "(W) ";
+        stream << u"(W) ";
         break;
     case Log::CRITICAL:
-        stream << "(C) ";
+        stream << u"(C) ";
         break;
     default:
-        stream << "(N) ";
+        stream << u"(N) ";
     }
 
-    stream << QDateTime::fromMSecsSinceEpoch(msg.timestamp).toString(Qt::ISODate) << " - " << msg.message << '\n';
+    stream << QDateTime::fromMSecsSinceEpoch(msg.timestamp).toString(Qt::ISODate) << u" - " << msg.message << u'\n';
 
     if (m_backup && (m_logFile.size() >= m_maxSize))
     {

--- a/src/gui/properties/piecesbar.cpp
+++ b/src/gui/properties/piecesbar.cpp
@@ -265,30 +265,25 @@ void PiecesBar::showToolTip(const QHelpEvent *e)
         {
             const PieceIndexToImagePos transform {torrentInfo, m_image};
             const int pieceIndex = transform.pieceIndex(imagePos);
-            const QVector<int> files {torrentInfo.fileIndicesForPiece(pieceIndex)};
+            const QVector<int> fileIndexes = torrentInfo.fileIndicesForPiece(pieceIndex);
 
             QString tooltipTitle;
-            if (files.count() > 1)
-            {
+            if (fileIndexes.count() > 1)
                 tooltipTitle = tr("Files in this piece:");
-            }
+            else if (torrentInfo.fileSize(fileIndexes.front()) == torrentInfo.pieceLength(pieceIndex))
+                tooltipTitle = tr("File in this piece:");
             else
-            {
-                if (torrentInfo.fileSize(files.front()) == torrentInfo.pieceLength(pieceIndex))
-                    tooltipTitle = tr("File in this piece");
-                else
-                    tooltipTitle = tr("File in these pieces");
-            }
+                tooltipTitle = tr("File in these pieces:");
 
-            toolTipText.reserve(files.size() * 128);
+            toolTipText.reserve(fileIndexes.size() * 128);
             toolTipText += u"<html><body>";
 
             DetailedTooltipRenderer renderer {toolTipText, tooltipTitle};
 
-            for (const int f : files)
+            for (const int index : fileIndexes)
             {
-                const Path filePath = torrentInfo.filePath(f);
-                renderer(Utils::Misc::friendlyUnit(torrentInfo.fileSize(f)), filePath);
+                const Path filePath = m_torrent->filePath(index);
+                renderer(Utils::Misc::friendlyUnit(torrentInfo.fileSize(index)), filePath);
             }
             toolTipText += u"</body></html>";
         }


### PR DESCRIPTION
* Fix wrong file names displayed in tooltip
  Also rename variable.
  Closes https://github.com/qbittorrent/qBittorrent/issues/17179.
* Avoid string encoding conversion
  Use UTF-16 string literals to match QTextStream internal buffer encoding.

I'll backport the fix to v4.4.x.