### PR TITLE
Don't use QCollator when it works on posix mode

### DIFF
--- a/src/base/utils/compare.h
+++ b/src/base/utils/compare.h
@@ -31,7 +31,7 @@
 #include <Qt>
 #include <QtGlobal>
 
-#ifndef Q_OS_WIN
+#if !defined(Q_OS_WIN) && (!defined(Q_OS_UNIX) || defined(Q_OS_MACOS) || defined(QT_FEATURE_icu))
 #define QBT_USE_QCOLLATOR
 #include <QCollator>
 #endif


### PR DESCRIPTION
The QCollator will work on posix mode if not MacOS and also no ICU. From https://github.com/qt/qtbase/blob/8a665ba9a660a09e5e6ac7cce2272118e303c220/src/corelib/CMakeLists.txt#L799-L802 and https://github.com/qt/qtbase/blob/ffdd372c7bbda62e9d937f406319f38e3e982774/src/corelib/text/text.pri#L63-L74.

If the Qt is built without ICU, the qbittorrent-nox with numericMode enabled will generate a lot of warning messages in the CMD. From https://github.com/qt/qtbase/blob/8a665ba9a660a09e5e6ac7cce2272118e303c220/src/corelib/CMakeLists.txt#L799-L802.

Othes' report:
https://www.reddit.com/r/qBittorrent/comments/s9z2ys/no_detailed_text_info/
https://dietpi.com/forum/t/how-to-install-qbittorrent-4-3-9-vesrion/6092/4