### PR TITLE
Implement base classes for application components

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -194,7 +194,7 @@ Application::~Application()
 }
 
 #ifndef DISABLE_GUI
-QPointer<MainWindow> Application::mainWindow()
+MainWindow *Application::mainWindow()
 {
     return m_window;
 }
@@ -611,7 +611,7 @@ int Application::exec(const QStringList &params)
         TorrentFilesWatcher::initInstance();
 
 #ifndef DISABLE_WEBUI
-        m_webui = new WebUI;
+        m_webui = new WebUI(this);
 #ifdef DISABLE_GUI
         if (m_webui->isErrored())
             return 1;
@@ -658,7 +658,7 @@ int Application::exec(const QStringList &params)
 #endif // DISABLE_WEBUI
 #else
     UIThemeManager::initInstance();
-    m_window = new MainWindow;
+    m_window = new MainWindow(this);
 #endif // DISABLE_GUI
 
     m_running = true;

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -118,7 +118,7 @@ public:
     void setMemoryWorkingSetLimit(int size) override;
 
 #ifndef DISABLE_GUI
-    QPointer<MainWindow> mainWindow() override;
+    MainWindow *mainWindow() override;
 #endif
 
 private slots:
@@ -167,7 +167,7 @@ private:
     SettingValue<int> m_storeMemoryWorkingSetLimit;
 
 #ifndef DISABLE_GUI
-    QPointer<MainWindow> m_window;
+    MainWindow *m_window = nullptr;
 #endif
 
 #ifndef DISABLE_WEBUI

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(qbt_base STATIC
     # headers
     3rdparty/expected.hpp
     algorithm.h
+    applicationcomponent.h
     asyncfilestorage.h
     bittorrent/abstractfilestorage.h
     bittorrent/addtorrentparams.h
@@ -104,6 +105,7 @@ add_library(qbt_base STATIC
     version.h
 
     # sources
+    applicationcomponent.cpp
     asyncfilestorage.cpp
     bittorrent/abstractfilestorage.cpp
     bittorrent/bandwidthscheduler.cpp

--- a/src/base/applicationcomponent.cpp
+++ b/src/base/applicationcomponent.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2018  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2022  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -26,40 +26,14 @@
  * exception statement from your version.
  */
 
-#pragma once
+#include "applicationcomponent.h"
 
-#include <QDeadlineTimer>
-#include <QHash>
-
-#include "apicontroller.h"
-
-class QString;
-
-struct ISessionManager;
-
-class AuthController : public APIController
+ApplicationComponent::ApplicationComponent(IApplication *app)
+    : m_app {app}
 {
-    Q_OBJECT
-    Q_DISABLE_COPY_MOVE(AuthController)
+}
 
-public:
-    explicit AuthController(ISessionManager *sessionManager, IApplication *app, QObject *parent = nullptr);
-
-private slots:
-    void loginAction();
-    void logoutAction() const;
-
-private:
-    bool isBanned() const;
-    int failedAttemptsCount() const;
-    void increaseFailedAttempts();
-
-    ISessionManager *m_sessionManager = nullptr;
-
-    struct FailedLogin
-    {
-        int failedAttemptsCount = 0;
-        QDeadlineTimer banTimer {-1};
-    };
-    mutable QHash<QString, FailedLogin> m_clientFailedLogins;
-};
+IApplication *ApplicationComponent::app() const
+{
+    return m_app;
+}

--- a/src/base/applicationcomponent.h
+++ b/src/base/applicationcomponent.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2018  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2022  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -28,38 +28,20 @@
 
 #pragma once
 
-#include <QDeadlineTimer>
-#include <QHash>
+#include <QtGlobal>
 
-#include "apicontroller.h"
+#include "interfaces/iapplication.h"
 
-class QString;
-
-struct ISessionManager;
-
-class AuthController : public APIController
+class ApplicationComponent
 {
-    Q_OBJECT
-    Q_DISABLE_COPY_MOVE(AuthController)
+    Q_DISABLE_COPY_MOVE(ApplicationComponent)
 
 public:
-    explicit AuthController(ISessionManager *sessionManager, IApplication *app, QObject *parent = nullptr);
+    explicit ApplicationComponent(IApplication *app);
+    virtual ~ApplicationComponent() = default;
 
-private slots:
-    void loginAction();
-    void logoutAction() const;
+    virtual IApplication *app() const;
 
 private:
-    bool isBanned() const;
-    int failedAttemptsCount() const;
-    void increaseFailedAttempts();
-
-    ISessionManager *m_sessionManager = nullptr;
-
-    struct FailedLogin
-    {
-        int failedAttemptsCount = 0;
-        QDeadlineTimer banTimer {-1};
-    };
-    mutable QHash<QString, FailedLogin> m_clientFailedLogins;
+    IApplication *m_app = nullptr;
 };

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -1,6 +1,7 @@
 HEADERS += \
     $$PWD/3rdparty/expected.hpp \
     $$PWD/algorithm.h \
+    $$PWD/applicationcomponent.h \
     $$PWD/asyncfilestorage.h \
     $$PWD/bittorrent/abstractfilestorage.h \
     $$PWD/bittorrent/addtorrentparams.h \
@@ -104,6 +105,7 @@ HEADERS += \
     $$PWD/version.h
 
 SOURCES += \
+    $$PWD/applicationcomponent.cpp \
     $$PWD/asyncfilestorage.cpp \
     $$PWD/bittorrent/abstractfilestorage.cpp \
     $$PWD/bittorrent/bandwidthscheduler.cpp \

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(qbt_gui STATIC
     executionlogwidget.h
     fspathedit.h
     fspathedit_p.h
+    guiapplicationcomponent.h
     hidabletabwidget.h
     interfaces/iguiapplication.h
     ipsubnetwhitelistoptionsdialog.h
@@ -131,6 +132,7 @@ add_library(qbt_gui STATIC
     executionlogwidget.cpp
     fspathedit.cpp
     fspathedit_p.cpp
+    guiapplicationcomponent.cpp
     hidabletabwidget.cpp
     ipsubnetwhitelistoptionsdialog.cpp
     lineedit.cpp

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -151,8 +151,9 @@ namespace
     };
 }
 
-AdvancedSettings::AdvancedSettings(QWidget *parent)
+AdvancedSettings::AdvancedSettings(IGUIApplication *app, QWidget *parent)
     : QTableWidget(parent)
+    , GUIApplicationComponent(app)
 {
     // column
     setColumnCount(COL_COUNT);
@@ -178,7 +179,7 @@ void AdvancedSettings::saveAdvancedSettings() const
 
     session->setResumeDataStorageType(m_comboBoxResumeDataStorage.currentData().value<BitTorrent::ResumeDataStorageType>());
     // Physical memory (RAM) usage limit
-    dynamic_cast<IApplication *>(QCoreApplication::instance())->setMemoryWorkingSetLimit(m_spinBoxMemoryWorkingSetLimit.value());
+    app()->setMemoryWorkingSetLimit(m_spinBoxMemoryWorkingSetLimit.value());
 #if defined(Q_OS_WIN)
     session->setOSMemoryPriority(m_comboBoxOSMemoryPriority.currentData().value<BitTorrent::OSMemoryPriority>());
 #endif
@@ -266,7 +267,7 @@ void AdvancedSettings::saveAdvancedSettings() const
     // Stop tracker timeout
     session->setStopTrackerTimeout(m_spinBoxStopTrackerTimeout.value());
     // Program notification
-    MainWindow *mainWindow = dynamic_cast<IGUIApplication *>(QCoreApplication::instance())->mainWindow();
+    MainWindow *mainWindow = app()->mainWindow();
     mainWindow->setNotificationsEnabled(m_checkBoxProgramNotifications.isChecked());
     mainWindow->setTorrentAddedNotificationsEnabled(m_checkBoxTorrentAddedNotifications.isChecked());
 #if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)) && defined(QT_DBUS_LIB)
@@ -411,7 +412,7 @@ void AdvancedSettings::loadAdvancedSettings()
     m_spinBoxMemoryWorkingSetLimit.setMaximum(std::numeric_limits<int>::max());
     m_spinBoxMemoryWorkingSetLimit.setSuffix(tr(" MiB"));
     m_spinBoxMemoryWorkingSetLimit.setToolTip(tr("This option is less effective on Linux"));
-    m_spinBoxMemoryWorkingSetLimit.setValue(dynamic_cast<IApplication *>(QCoreApplication::instance())->memoryWorkingSetLimit());
+    m_spinBoxMemoryWorkingSetLimit.setValue(app()->memoryWorkingSetLimit());
     addRow(MEMORY_WORKING_SET_LIMIT, (tr("Physical memory (RAM) usage limit") + u' ' + makeLink(u"https://wikipedia.org/wiki/Working_set", u"(?)"))
         , &m_spinBoxMemoryWorkingSetLimit);
 #if defined(Q_OS_WIN)
@@ -670,7 +671,7 @@ void AdvancedSettings::loadAdvancedSettings()
            , &m_spinBoxStopTrackerTimeout);
 
     // Program notifications
-    const MainWindow *mainWindow = dynamic_cast<IGUIApplication *>(QCoreApplication::instance())->mainWindow();
+    const MainWindow *mainWindow = app()->mainWindow();
     m_checkBoxProgramNotifications.setChecked(mainWindow->isNotificationsEnabled());
     addRow(PROGRAM_NOTIFICATIONS, tr("Display notifications"), &m_checkBoxProgramNotifications);
     // Torrent added notifications

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -34,13 +34,15 @@
 #include <QSpinBox>
 #include <QTableWidget>
 
-class AdvancedSettings final : public QTableWidget
+#include "guiapplicationcomponent.h"
+
+class AdvancedSettings final : public QTableWidget, public GUIApplicationComponent
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(AdvancedSettings)
 
 public:
-    AdvancedSettings(QWidget *parent);
+    explicit AdvancedSettings(IGUIApplication *app, QWidget *parent = nullptr);
 
 public slots:
     void saveAdvancedSettings() const;

--- a/src/gui/gui.pri
+++ b/src/gui/gui.pri
@@ -16,6 +16,7 @@ HEADERS += \
     $$PWD/executionlogwidget.h \
     $$PWD/fspathedit.h \
     $$PWD/fspathedit_p.h \
+    $$PWD/guiapplicationcomponent.h \
     $$PWD/hidabletabwidget.h \
     $$PWD/interfaces/iguiapplication.h \
     $$PWD/ipsubnetwhitelistoptionsdialog.h \
@@ -98,6 +99,7 @@ SOURCES += \
     $$PWD/executionlogwidget.cpp \
     $$PWD/fspathedit.cpp \
     $$PWD/fspathedit_p.cpp \
+    $$PWD/guiapplicationcomponent.cpp \
     $$PWD/hidabletabwidget.cpp \
     $$PWD/ipsubnetwhitelistoptionsdialog.cpp \
     $$PWD/lineedit.cpp \

--- a/src/gui/guiapplicationcomponent.cpp
+++ b/src/gui/guiapplicationcomponent.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2018  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2022  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -26,40 +26,14 @@
  * exception statement from your version.
  */
 
-#pragma once
+#include "guiapplicationcomponent.h"
 
-#include <QDeadlineTimer>
-#include <QHash>
-
-#include "apicontroller.h"
-
-class QString;
-
-struct ISessionManager;
-
-class AuthController : public APIController
+GUIApplicationComponent::GUIApplicationComponent(IGUIApplication *app)
+    : ApplicationComponent(app)
 {
-    Q_OBJECT
-    Q_DISABLE_COPY_MOVE(AuthController)
+}
 
-public:
-    explicit AuthController(ISessionManager *sessionManager, IApplication *app, QObject *parent = nullptr);
-
-private slots:
-    void loginAction();
-    void logoutAction() const;
-
-private:
-    bool isBanned() const;
-    int failedAttemptsCount() const;
-    void increaseFailedAttempts();
-
-    ISessionManager *m_sessionManager = nullptr;
-
-    struct FailedLogin
-    {
-        int failedAttemptsCount = 0;
-        QDeadlineTimer banTimer {-1};
-    };
-    mutable QHash<QString, FailedLogin> m_clientFailedLogins;
-};
+IGUIApplication *GUIApplicationComponent::app() const
+{
+    return static_cast<IGUIApplication *>(ApplicationComponent::app());
+}

--- a/src/gui/guiapplicationcomponent.h
+++ b/src/gui/guiapplicationcomponent.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2018  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2022  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -28,38 +28,15 @@
 
 #pragma once
 
-#include <QDeadlineTimer>
-#include <QHash>
+#include "base/applicationcomponent.h"
+#include "interfaces/iguiapplication.h"
 
-#include "apicontroller.h"
-
-class QString;
-
-struct ISessionManager;
-
-class AuthController : public APIController
+class GUIApplicationComponent : public ApplicationComponent
 {
-    Q_OBJECT
-    Q_DISABLE_COPY_MOVE(AuthController)
+    Q_DISABLE_COPY_MOVE(GUIApplicationComponent)
 
 public:
-    explicit AuthController(ISessionManager *sessionManager, IApplication *app, QObject *parent = nullptr);
+    explicit GUIApplicationComponent(IGUIApplication *app);
 
-private slots:
-    void loginAction();
-    void logoutAction() const;
-
-private:
-    bool isBanned() const;
-    int failedAttemptsCount() const;
-    void increaseFailedAttempts();
-
-    ISessionManager *m_sessionManager = nullptr;
-
-    struct FailedLogin
-    {
-        int failedAttemptsCount = 0;
-        QDeadlineTimer banTimer {-1};
-    };
-    mutable QHash<QString, FailedLogin> m_clientFailedLogins;
+    IGUIApplication *app() const override;
 };

--- a/src/gui/interfaces/iguiapplication.h
+++ b/src/gui/interfaces/iguiapplication.h
@@ -39,5 +39,5 @@ class IGUIApplication : public IApplication
 public:
     virtual ~IGUIApplication() = default;
 
-    virtual QPointer<MainWindow> mainWindow() = 0;
+    virtual MainWindow *mainWindow() = 0;
 };

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -138,8 +138,9 @@ namespace
 #endif
 }
 
-MainWindow::MainWindow(QWidget *parent)
+MainWindow::MainWindow(IGUIApplication *app, QWidget *parent)
     : QMainWindow(parent)
+    , GUIApplicationComponent(app)
     , m_ui(new Ui::MainWindow)
     , m_storeExecutionLogEnabled(EXECUTIONLOG_SETTINGS_KEY(u"Enabled"_qs))
     , m_storeDownloadTrackerFavicon(SETTINGS_KEY(u"DownloadTrackerFavicon"_qs))
@@ -1833,7 +1834,7 @@ void MainWindow::on_actionOptions_triggered()
     }
     else
     {
-        m_options = new OptionsDialog(this);
+        m_options = new OptionsDialog(app(), this);
         m_options->setAttribute(Qt::WA_DeleteOnClose);
         m_options->open();
     }

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -38,6 +38,7 @@
 #include "base/bittorrent/torrent.h"
 #include "base/logger.h"
 #include "base/settingvalue.h"
+#include "guiapplicationcomponent.h"
 
 class QCloseEvent;
 class QFileSystemWatcher;
@@ -71,13 +72,13 @@ namespace Ui
     class MainWindow;
 }
 
-class MainWindow final : public QMainWindow
+class MainWindow final : public QMainWindow, public GUIApplicationComponent
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(MainWindow)
 
 public:
-    explicit MainWindow(QWidget *parent = nullptr);
+    explicit MainWindow(IGUIApplication *app, QWidget *parent = nullptr);
     ~MainWindow() override;
 
     QWidget *currentTabWidget() const;

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -175,8 +175,9 @@ private:
 };
 
 // Constructor
-OptionsDialog::OptionsDialog(QWidget *parent)
-    : QDialog {parent}
+OptionsDialog::OptionsDialog(IGUIApplication *app, QWidget *parent)
+    : QDialog(parent)
+    , GUIApplicationComponent(app)
     , m_ui {new Ui::OptionsDialog}
     , m_storeDialogSize {SETTINGS_KEY(u"Size"_qs)}
     , m_storeHSplitterSize {SETTINGS_KEY(u"HorizontalSplitterSizes"_qs)}
@@ -542,7 +543,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     // Tab selection mechanism
     connect(m_ui->tabSelection, &QListWidget::currentItemChanged, this, &ThisType::changePage);
     // Load Advanced settings
-    m_advancedSettings = new AdvancedSettings(m_ui->tabAdvancedPage);
+    m_advancedSettings = new AdvancedSettings(app, m_ui->tabAdvancedPage);
     m_ui->advPageLayout->addWidget(m_advancedSettings);
     connect(m_advancedSettings, &AdvancedSettings::settingsChanged, this, &ThisType::enableApplyButton);
 
@@ -723,14 +724,13 @@ void OptionsDialog::saveOptions()
 #endif
     session->setPerformanceWarningEnabled(m_ui->checkBoxPerformanceWarning->isChecked());
 
-    auto *app = dynamic_cast<IApplication *>(QCoreApplication::instance());
-    app->setFileLoggerPath(m_ui->textFileLogPath->selectedPath());
-    app->setFileLoggerBackup(m_ui->checkFileLogBackup->isChecked());
-    app->setFileLoggerMaxSize(m_ui->spinFileLogSize->value() * 1024);
-    app->setFileLoggerAge(m_ui->spinFileLogAge->value());
-    app->setFileLoggerAgeType(m_ui->comboFileLogAgeType->currentIndex());
-    app->setFileLoggerDeleteOld(m_ui->checkFileLogDelete->isChecked());
-    app->setFileLoggerEnabled(m_ui->checkFileLog->isChecked());
+    app()->setFileLoggerPath(m_ui->textFileLogPath->selectedPath());
+    app()->setFileLoggerBackup(m_ui->checkFileLogBackup->isChecked());
+    app()->setFileLoggerMaxSize(m_ui->spinFileLogSize->value() * 1024);
+    app()->setFileLoggerAge(m_ui->spinFileLogAge->value());
+    app()->setFileLoggerAgeType(m_ui->comboFileLogAgeType->currentIndex());
+    app()->setFileLoggerDeleteOld(m_ui->checkFileLogDelete->isChecked());
+    app()->setFileLoggerEnabled(m_ui->checkFileLog->isChecked());
     // End Behavior preferences
 
     RSS::Session::instance()->setRefreshInterval(m_ui->spinRSSRefreshInterval->value());
@@ -975,19 +975,18 @@ void OptionsDialog::loadOptions()
 #endif
     m_ui->checkBoxPerformanceWarning->setChecked(session->isPerformanceWarningEnabled());
 
-    const auto *app = dynamic_cast<IApplication *>(QCoreApplication::instance());
-    m_ui->checkFileLog->setChecked(app->isFileLoggerEnabled());
-    m_ui->textFileLogPath->setSelectedPath(app->fileLoggerPath());
-    const bool fileLogBackup = app->isFileLoggerBackup();
+    m_ui->checkFileLog->setChecked(app()->isFileLoggerEnabled());
+    m_ui->textFileLogPath->setSelectedPath(app()->fileLoggerPath());
+    const bool fileLogBackup = app()->isFileLoggerBackup();
     m_ui->checkFileLogBackup->setChecked(fileLogBackup);
     m_ui->spinFileLogSize->setEnabled(fileLogBackup);
-    const bool fileLogDelete = app->isFileLoggerDeleteOld();
+    const bool fileLogDelete = app()->isFileLoggerDeleteOld();
     m_ui->checkFileLogDelete->setChecked(fileLogDelete);
     m_ui->spinFileLogAge->setEnabled(fileLogDelete);
     m_ui->comboFileLogAgeType->setEnabled(fileLogDelete);
-    m_ui->spinFileLogSize->setValue(app->fileLoggerMaxSize() / 1024);
-    m_ui->spinFileLogAge->setValue(app->fileLoggerAge());
-    m_ui->comboFileLogAgeType->setCurrentIndex(app->fileLoggerAgeType());
+    m_ui->spinFileLogSize->setValue(app()->fileLoggerMaxSize() / 1024);
+    m_ui->spinFileLogAge->setValue(app()->fileLoggerAge());
+    m_ui->comboFileLogAgeType->setCurrentIndex(app()->fileLoggerAgeType());
     // End Behavior preferences
 
     m_ui->checkRSSEnable->setChecked(RSS::Session::instance()->isProcessingEnabled());

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -32,6 +32,7 @@
 
 #include "base/pathfwd.h"
 #include "base/settingvalue.h"
+#include "guiapplicationcomponent.h"
 
 class QListWidgetItem;
 
@@ -57,7 +58,7 @@ namespace Ui
     class OptionsDialog;
 }
 
-class OptionsDialog final : public QDialog
+class OptionsDialog final : public QDialog, public GUIApplicationComponent
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(OptionsDialog)
@@ -83,8 +84,7 @@ class OptionsDialog final : public QDialog
     };
 
 public:
-    // Constructor / Destructor
-    OptionsDialog(QWidget *parent = nullptr);
+    explicit OptionsDialog(IGUIApplication *app, QWidget *parent = nullptr);
     ~OptionsDialog() override;
 
 public slots:

--- a/src/webui/api/apicontroller.cpp
+++ b/src/webui/api/apicontroller.cpp
@@ -37,8 +37,9 @@
 
 #include "apierror.h"
 
-APIController::APIController(QObject *parent)
-    : QObject {parent}
+APIController::APIController(IApplication *app, QObject *parent)
+    : QObject(parent)
+    , ApplicationComponent(app)
 {
 }
 

--- a/src/webui/api/apicontroller.h
+++ b/src/webui/api/apicontroller.h
@@ -32,18 +32,20 @@
 #include <QObject>
 #include <QVariant>
 
+#include "base/applicationcomponent.h"
+
 class QString;
 
 using DataMap = QHash<QString, QByteArray>;
 using StringMap = QHash<QString, QString>;
 
-class APIController : public QObject
+class APIController : public QObject, public ApplicationComponent
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(APIController)
 
 public:
-    explicit APIController(QObject *parent = nullptr);
+    explicit APIController(IApplication *app, QObject *parent = nullptr);
 
     QVariant run(const QString &action, const StringMap &params, const DataMap &data = {});
 

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -291,7 +291,7 @@ void AppController::preferencesAction()
     // Advanced settings
     // qBitorrent preferences
     // Physical memory (RAM) usage limit
-    data[u"memory_working_set_limit"_qs] = dynamic_cast<IApplication *>(QCoreApplication::instance())->memoryWorkingSetLimit();
+    data[u"memory_working_set_limit"_qs] = app()->memoryWorkingSetLimit();
     // Current network interface
     data[u"current_network_interface"_qs] = session->networkInterface();
     // Current network interface address
@@ -755,7 +755,7 @@ void AppController::setPreferencesAction()
     // qBittorrent preferences
     // Physical memory (RAM) usage limit
     if (hasKey(u"memory_working_set_limit"_qs))
-        dynamic_cast<IApplication *>(QCoreApplication::instance())->setMemoryWorkingSetLimit(it.value().toInt());
+        app()->setMemoryWorkingSetLimit(it.value().toInt());
     // Current network interface
     if (hasKey(u"current_network_interface"_qs))
     {

--- a/src/webui/api/authcontroller.cpp
+++ b/src/webui/api/authcontroller.cpp
@@ -37,8 +37,8 @@
 #include "apierror.h"
 #include "isessionmanager.h"
 
-AuthController::AuthController(ISessionManager *sessionManager, QObject *parent)
-    : APIController {parent}
+AuthController::AuthController(ISessionManager *sessionManager, IApplication *app, QObject *parent)
+    : APIController(app, parent)
     , m_sessionManager {sessionManager}
 {
 }

--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -366,8 +366,8 @@ namespace
     }
 }
 
-SyncController::SyncController(QObject *parent)
-    : APIController(parent)
+SyncController::SyncController(IApplication *app, QObject *parent)
+    : APIController(app, parent)
 {
     m_freeDiskSpaceThread = new QThread(this);
     m_freeDiskSpaceChecker = new FreeDiskSpaceChecker();

--- a/src/webui/api/synccontroller.h
+++ b/src/webui/api/synccontroller.h
@@ -45,7 +45,7 @@ class SyncController : public APIController
 public:
     using APIController::APIController;
 
-    explicit SyncController(QObject *parent = nullptr);
+    explicit SyncController(IApplication *app, QObject *parent = nullptr);
     ~SyncController() override;
 
 private slots:

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -116,10 +116,11 @@ namespace
     }
 }
 
-WebApplication::WebApplication(QObject *parent)
+WebApplication::WebApplication(IApplication *app, QObject *parent)
     : QObject(parent)
+    , ApplicationComponent(app)
     , m_cacheID {QString::number(Utils::Random::rand(), 36)}
-    , m_authController {new AuthController(this, this)}
+    , m_authController {new AuthController(this, app, this)}
 {
     declarePublicAPI(u"auth/login"_qs);
 
@@ -600,7 +601,7 @@ void WebApplication::sessionStart()
         return false;
     });
 
-    m_currentSession = new WebSession(generateSid());
+    m_currentSession = new WebSession(generateSid(), app());
     m_currentSession->registerAPIController<AppController>(u"app"_qs);
     m_currentSession->registerAPIController<LogController>(u"log"_qs);
     m_currentSession->registerAPIController<RSSController>(u"rss"_qs);
@@ -753,8 +754,9 @@ QHostAddress WebApplication::resolveClientAddress() const
 
 // WebSession
 
-WebSession::WebSession(const QString &sid)
-    : m_sid {sid}
+WebSession::WebSession(const QString &sid, IApplication *app)
+    : ApplicationComponent(app)
+    , m_sid {sid}
 {
     updateTimestamp();
 }

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -39,6 +39,7 @@
 #include <QSet>
 #include <QTranslator>
 
+#include "base/applicationcomponent.h"
 #include "base/global.h"
 #include "base/http/irequesthandler.h"
 #include "base/http/responsebuilder.h"
@@ -54,10 +55,10 @@ class APIController;
 class AuthController;
 class WebApplication;
 
-class WebSession final : public QObject, public ISession
+class WebSession final : public QObject, public ApplicationComponent, public ISession
 {
 public:
-    explicit WebSession(const QString &sid);
+    explicit WebSession(const QString &sid, IApplication *app);
 
     QString id() const override;
 
@@ -68,7 +69,7 @@ public:
     void registerAPIController(const QString &scope)
     {
         static_assert(std::is_base_of_v<APIController, T>, "Class should be derived from APIController.");
-        m_apiControllers[scope] = new T(this);
+        m_apiControllers[scope] = new T(app(), this);
     }
 
     APIController *getAPIController(const QString &scope) const;
@@ -80,14 +81,15 @@ private:
 };
 
 class WebApplication final
-        : public QObject, public Http::IRequestHandler, public ISessionManager
+        : public QObject, public ApplicationComponent
+        , public Http::IRequestHandler, public ISessionManager
         , private Http::ResponseBuilder
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(WebApplication)
 
 public:
-    explicit WebApplication(QObject *parent = nullptr);
+    explicit WebApplication(IApplication *app, QObject *parent = nullptr);
     ~WebApplication() override;
 
     Http::Response processRequest(const Http::Request &request, const Http::Environment &env) override;

--- a/src/webui/webui.cpp
+++ b/src/webui/webui.cpp
@@ -39,9 +39,8 @@
 #include "base/utils/net.h"
 #include "webapplication.h"
 
-WebUI::WebUI()
-    : m_isErrored(false)
-    , m_port(0)
+WebUI::WebUI(IApplication *app)
+    : ApplicationComponent(app)
 {
     configure();
     connect(Preferences::instance(), &Preferences::changed, this, &WebUI::configure);
@@ -77,7 +76,7 @@ void WebUI::configure()
         const QString serverAddressString = pref->getWebUiAddress();
         if (!m_httpServer)
         {
-            m_webapp = new WebApplication(this);
+            m_webapp = new WebApplication(app(), this);
             m_httpServer = new Http::Server(m_webapp, this);
         }
         else

--- a/src/webui/webui.h
+++ b/src/webui/webui.h
@@ -31,6 +31,8 @@
 #include <QObject>
 #include <QPointer>
 
+#include "base/applicationcomponent.h"
+
 namespace Http
 {
     class Server;
@@ -43,13 +45,13 @@ namespace Net
 
 class WebApplication;
 
-class WebUI : public QObject
+class WebUI : public QObject, public ApplicationComponent
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(WebUI)
 
 public:
-    WebUI();
+    explicit WebUI(IApplication *app);
 
     bool isErrored() const;
 
@@ -60,9 +62,9 @@ private slots:
     void configure();
 
 private:
-    bool m_isErrored;
+    bool m_isErrored = false;
     QPointer<Http::Server> m_httpServer;
     QPointer<Net::DNSUpdater> m_dnsUpdater;
     QPointer<WebApplication> m_webapp;
-    quint16 m_port;
+    quint16 m_port = 0;
 };


### PR DESCRIPTION
This PR starts to redesign application structure.
In the following steps this will: 
1. Allow the application components to access each other via application interface instead of using singletons. 
2. Allow to reduce some "noise" in the code that was due to access components using singletons. 
3. Allow to avoid some extra implementation details by hiding some service components behind helper methods.