### PR TITLE
Improve RSS subsystem initialization

### DIFF
--- a/src/base/rss/feed_serializer.cpp
+++ b/src/base/rss/feed_serializer.cpp
@@ -42,6 +42,8 @@
 #include "base/utils/io.h"
 #include "rss_article.h"
 
+const int ARTICLEDATALIST_TYPEID = qRegisterMetaType<QVector<QVariantHash>>();
+
 void RSS::Private::FeedSerializer::load(const Path &dataFileName, const QString &url)
 {
     QFile file {dataFileName.data()};
@@ -121,6 +123,11 @@ QVector<QVariantHash> RSS::Private::FeedSerializer::loadArticles(const QByteArra
 
         result.push_back(varHash);
     }
+
+    std::sort(result.begin(), result.end(), [](const QVariantHash &left, const QVariantHash &right)
+    {
+        return (left.value(Article::KeyDate).toDateTime() > right.value(Article::KeyDate).toDateTime());
+    });
 
     return result;
 }

--- a/src/base/rss/rss_article.cpp
+++ b/src/base/rss/rss_article.cpp
@@ -30,26 +30,12 @@
 
 #include "rss_article.h"
 
-#include <QJsonObject>
 #include <QVariant>
 
 #include "base/global.h"
 #include "rss_feed.h"
 
 using namespace RSS;
-
-namespace
-{
-    QVariantHash articleDataFromJSON(const QJsonObject &jsonObj)
-    {
-        auto varHash = jsonObj.toVariantHash();
-        // JSON object store DateTime as string so we need to convert it
-        varHash[Article::KeyDate] =
-                QDateTime::fromString(jsonObj.value(Article::KeyDate).toString(), Qt::RFC2822Date);
-
-        return varHash;
-    }
-}
 
 const QString Article::KeyId = u"id"_qs;
 const QString Article::KeyDate = u"date"_qs;
@@ -72,11 +58,6 @@ Article::Article(Feed *feed, const QVariantHash &varHash)
     , m_link(varHash.value(KeyLink).toString())
     , m_isRead(varHash.value(KeyIsRead, false).toBool())
     , m_data(varHash)
-{
-}
-
-Article::Article(Feed *feed, const QJsonObject &jsonObj)
-    : Article(feed, articleDataFromJSON(jsonObj))
 {
 }
 
@@ -133,15 +114,6 @@ void Article::markAsRead()
         m_data[KeyIsRead] = m_isRead;
         emit read(this);
     }
-}
-
-QJsonObject Article::toJsonObject() const
-{
-    auto jsonObj = QJsonObject::fromVariantHash(m_data);
-    // JSON object doesn't support DateTime so we need to convert it
-    jsonObj[KeyDate] = m_date.toString(Qt::RFC2822Date);
-
-    return jsonObj;
 }
 
 bool Article::articleDateRecentThan(const Article *article, const QDateTime &date)

--- a/src/base/rss/rss_article.h
+++ b/src/base/rss/rss_article.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2017  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2017-2022  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2010  Christophe Dumez <chris@qbittorrent.org>
  * Copyright (C) 2010  Arnaud Demaiziere <arnaud@qbittorrent.org>
  *
@@ -39,7 +39,7 @@ namespace RSS
 {
     class Feed;
 
-    class Article : public QObject
+    class Article final : public QObject
     {
         Q_OBJECT
         Q_DISABLE_COPY_MOVE(Article)
@@ -47,7 +47,6 @@ namespace RSS
         friend class Feed;
 
         Article(Feed *feed, const QVariantHash &varHash);
-        Article(Feed *feed, const QJsonObject &jsonObj);
 
     public:
         static const QString KeyId;
@@ -71,8 +70,6 @@ namespace RSS
         QVariantHash data() const;
 
         void markAsRead();
-
-        QJsonObject toJsonObject() const;
 
         static bool articleDateRecentThan(const Article *article, const QDateTime &date);
 

--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -491,7 +491,12 @@ void AutoDownloader::resetProcessingQueue()
 void AutoDownloader::startProcessing()
 {
     resetProcessingQueue();
-    connect(Session::instance()->rootFolder(), &Folder::newArticle, this, &AutoDownloader::handleNewArticle);
+
+    const RSS::Folder *rootFolder = Session::instance()->rootFolder();
+    for (const Article *article : asConst(rootFolder->articles()))
+        handleNewArticle(article);
+
+    connect(rootFolder, &Folder::newArticle, this, &AutoDownloader::handleNewArticle);
 }
 
 void AutoDownloader::setProcessingEnabled(const bool enabled)

--- a/src/base/rss/rss_feed.h
+++ b/src/base/rss/rss_feed.h
@@ -99,7 +99,7 @@ namespace RSS
         void handleDownloadFinished(const Net::DownloadResult &result);
         void handleParsingFinished(const Private::ParsingResult &result);
         void handleArticleRead(Article *article);
-        void handleArticleLoadFinished(const QVector<QVariantHash> &articles);
+        void handleArticleLoadFinished(QVector<QVariantHash> articles);
 
     private:
         void timerEvent(QTimerEvent *event) override;
@@ -107,7 +107,7 @@ namespace RSS
         void load();
         void store();
         void storeDeferred();
-        bool addArticle(Article *article);
+        bool addArticle(const QVariantHash &articleData);
         void removeOldestArticle();
         void increaseUnreadCount();
         void decreaseUnreadCount();

--- a/src/base/rss/rss_parser.cpp
+++ b/src/base/rss/rss_parser.cpp
@@ -539,23 +539,15 @@ namespace
     }
 }
 
-using namespace RSS::Private;
+const int PARSINGRESULT_TYPEID = qRegisterMetaType<RSS::Private::ParsingResult>();
 
-const int ParsingResultTypeId = qRegisterMetaType<ParsingResult>();
-
-Parser::Parser(const QString lastBuildDate)
+RSS::Private::Parser::Parser(const QString lastBuildDate)
 {
     m_result.lastBuildDate = lastBuildDate;
 }
 
-void Parser::parse(const QByteArray &feedData)
-{
-    QMetaObject::invokeMethod(this, [this, feedData]() { parse_impl(feedData); }
-                              , Qt::QueuedConnection);
-}
-
 // read and create items from a rss document
-void Parser::parse_impl(const QByteArray &feedData)
+void RSS::Private::Parser::parse(const QByteArray &feedData)
 {
     QXmlStreamReader xml(feedData);
     XmlStreamEntityResolver resolver;
@@ -608,7 +600,7 @@ void Parser::parse_impl(const QByteArray &feedData)
     m_articleIDs.clear();
 }
 
-void Parser::parseRssArticle(QXmlStreamReader &xml)
+void RSS::Private::Parser::parseRssArticle(QXmlStreamReader &xml)
 {
     QVariantHash article;
     QString altTorrentUrl;
@@ -671,7 +663,7 @@ void Parser::parseRssArticle(QXmlStreamReader &xml)
     addArticle(article);
 }
 
-void Parser::parseRSSChannel(QXmlStreamReader &xml)
+void RSS::Private::Parser::parseRSSChannel(QXmlStreamReader &xml)
 {
     while (!xml.atEnd())
     {
@@ -704,7 +696,7 @@ void Parser::parseRSSChannel(QXmlStreamReader &xml)
     }
 }
 
-void Parser::parseAtomArticle(QXmlStreamReader &xml)
+void RSS::Private::Parser::parseAtomArticle(QXmlStreamReader &xml)
 {
     QVariantHash article;
     bool doubleContent = false;
@@ -785,7 +777,7 @@ void Parser::parseAtomArticle(QXmlStreamReader &xml)
     addArticle(article);
 }
 
-void Parser::parseAtomChannel(QXmlStreamReader &xml)
+void RSS::Private::Parser::parseAtomChannel(QXmlStreamReader &xml)
 {
     m_baseUrl = xml.attributes().value(u"xml:base"_qs).toString();
 
@@ -820,7 +812,7 @@ void Parser::parseAtomChannel(QXmlStreamReader &xml)
     }
 }
 
-void Parser::addArticle(QVariantHash article)
+void RSS::Private::Parser::addArticle(QVariantHash article)
 {
     QVariant &torrentURL = article[Article::KeyTorrentURL];
     if (torrentURL.toString().isEmpty())

--- a/src/base/rss/rss_parser.h
+++ b/src/base/rss/rss_parser.h
@@ -37,43 +37,39 @@
 
 class QXmlStreamReader;
 
-namespace RSS
+namespace RSS::Private
 {
-    namespace Private
+    struct ParsingResult
     {
-        struct ParsingResult
-        {
-            QString error;
-            QString lastBuildDate;
-            QString title;
-            QList<QVariantHash> articles;
-        };
+        QString error;
+        QString lastBuildDate;
+        QString title;
+        QList<QVariantHash> articles;
+    };
 
-        class Parser : public QObject
-        {
-            Q_OBJECT
-            Q_DISABLE_COPY_MOVE(Parser)
+    class Parser final : public QObject
+    {
+        Q_OBJECT
+        Q_DISABLE_COPY_MOVE(Parser)
 
-        public:
-            explicit Parser(QString lastBuildDate);
-            void parse(const QByteArray &feedData);
+    public:
+        explicit Parser(QString lastBuildDate);
+        void parse(const QByteArray &feedData);
 
-        signals:
-            void finished(const RSS::Private::ParsingResult &result);
+    signals:
+        void finished(const RSS::Private::ParsingResult &result);
 
-        private:
-            Q_INVOKABLE void parse_impl(const QByteArray &feedData);
-            void parseRssArticle(QXmlStreamReader &xml);
-            void parseRSSChannel(QXmlStreamReader &xml);
-            void parseAtomArticle(QXmlStreamReader &xml);
-            void parseAtomChannel(QXmlStreamReader &xml);
-            void addArticle(QVariantHash article);
+    private:
+        void parseRssArticle(QXmlStreamReader &xml);
+        void parseRSSChannel(QXmlStreamReader &xml);
+        void parseAtomArticle(QXmlStreamReader &xml);
+        void parseAtomChannel(QXmlStreamReader &xml);
+        void addArticle(QVariantHash article);
 
-            QString m_baseUrl;
-            ParsingResult m_result;
-            QSet<QString> m_articleIDs;
-        };
-    }
+        QString m_baseUrl;
+        ParsingResult m_result;
+        QSet<QString> m_articleIDs;
+    };
 }
 
 Q_DECLARE_METATYPE(RSS::Private::ParsingResult)


### PR DESCRIPTION
1. Disunify the logic of adding new and saved articles to avoid some redundant work during startup.
2. Apply several code cleanups.
3. Fix regression of previous changes that prevents Qt5 based build from being working correctly.

As a further improvement, it would be nice to get rid of emitting `newArticle()` signals at startup altogether, and instead handle the event of the end of loading saved articles.