### PR TITLE
Present torrent peer stats as ranges reported by all endpoints

### DIFF
--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -138,10 +138,6 @@ namespace
                     trackerEndpoint.message = (!trackerMessage.isEmpty() ? trackerMessage : errorMessage);
 
                     trackerEntry.stats[endpoint.local_endpoint][(protocolVersion == lt::protocol_version::V1) ? 1 : 2] = trackerEndpoint;
-                    trackerEntry.numPeers = std::max(trackerEntry.numPeers, trackerEndpoint.numPeers);
-                    trackerEntry.numSeeds = std::max(trackerEntry.numSeeds, trackerEndpoint.numSeeds);
-                    trackerEntry.numLeeches = std::max(trackerEntry.numLeeches, trackerEndpoint.numLeeches);
-                    trackerEntry.numDownloaded = std::max(trackerEntry.numDownloaded, trackerEndpoint.numDownloaded);
 
                     if (firstTrackerMessage.isEmpty())
                         firstTrackerMessage = trackerMessage;
@@ -185,10 +181,6 @@ namespace
             trackerEndpoint.message = (!trackerMessage.isEmpty() ? trackerMessage : errorMessage);
 
             trackerEntry.stats[endpoint.local_endpoint][1] = trackerEndpoint;
-            trackerEntry.numPeers = std::max(trackerEntry.numPeers, trackerEndpoint.numPeers);
-            trackerEntry.numSeeds = std::max(trackerEntry.numSeeds, trackerEndpoint.numSeeds);
-            trackerEntry.numLeeches = std::max(trackerEntry.numLeeches, trackerEndpoint.numLeeches);
-            trackerEntry.numDownloaded = std::max(trackerEntry.numDownloaded, trackerEndpoint.numDownloaded);
 
             if (firstTrackerMessage.isEmpty())
                 firstTrackerMessage = trackerMessage;

--- a/src/base/bittorrent/trackerentry.h
+++ b/src/base/bittorrent/trackerentry.h
@@ -61,16 +61,12 @@ namespace BitTorrent
 
         QString url {};
         int tier = 0;
+        Status status = NotContacted;
 
         // TODO: Use QHash<TrackerEntry::Endpoint, QHash<int, EndpointStats>> once Qt5 is dropped.
         QMap<Endpoint, QHash<int, EndpointStats>> stats {};
 
         // Deprecated fields
-        Status status = NotContacted;
-        int numPeers = -1;
-        int numSeeds = -1;
-        int numLeeches = -1;
-        int numDownloaded = -1;
         QString message {};
     };
 

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -474,16 +474,31 @@ void TorrentsController::trackersAction()
 
     for (const BitTorrent::TrackerEntry &tracker : asConst(torrent->trackers()))
     {
+        int numPeers = -1;
+        int numSeeds = -1;
+        int numLeeches = -1;
+        int numDownloaded = -1;
+        for (const auto &endpoint : tracker.stats)
+        {
+            for (const auto &protocolStats : endpoint)
+            {
+                numPeers = std::max(numPeers, protocolStats.numPeers);
+                numSeeds = std::max(numSeeds, protocolStats.numSeeds);
+                numLeeches = std::max(numLeeches, protocolStats.numLeeches);
+                numDownloaded = std::max(numDownloaded, protocolStats.numDownloaded);
+            }
+        }
+
         trackerList << QJsonObject
         {
             {KEY_TRACKER_URL, tracker.url},
             {KEY_TRACKER_TIER, tracker.tier},
             {KEY_TRACKER_STATUS, static_cast<int>(tracker.status)},
             {KEY_TRACKER_MSG, tracker.message},
-            {KEY_TRACKER_PEERS_COUNT, tracker.numPeers},
-            {KEY_TRACKER_SEEDS_COUNT, tracker.numSeeds},
-            {KEY_TRACKER_LEECHES_COUNT, tracker.numLeeches},
-            {KEY_TRACKER_DOWNLOADED_COUNT, tracker.numDownloaded}
+            {KEY_TRACKER_PEERS_COUNT, numPeers},
+            {KEY_TRACKER_SEEDS_COUNT, numSeeds},
+            {KEY_TRACKER_LEECHES_COUNT, numLeeches},
+            {KEY_TRACKER_DOWNLOADED_COUNT, numDownloaded}
         };
     }
 


### PR DESCRIPTION
If endpoints reports different values show number of peers as `min ~ max` or just a value if all reported same.