### PR TITLE
Expose stop_when_ready flag

### DIFF
--- a/src/base/bittorrent/addtorrentparams.h
+++ b/src/base/bittorrent/addtorrentparams.h
@@ -52,6 +52,7 @@ namespace BitTorrent
         std::optional<bool> useDownloadPath;
         Path downloadPath;
         bool sequential = false;
+        bool stopWhenReady = false;
         bool firstLastPiecePriority = false;
         bool addForced = false;
         std::optional<bool> addPaused;

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -2319,6 +2319,11 @@ bool Session::addTorrent_impl(const std::variant<MagnetUri, TorrentInfo> &source
     else
         p.flags &= ~lt::torrent_flags::seed_mode;
 
+    if (addTorrentParams.stopWhenReady)
+        p.flags |= lt::torrent_flags::stop_when_ready;
+    else
+        p.flags &= ~lt::torrent_flags::stop_when_ready;
+
     if (loadTorrentParams.stopped || (loadTorrentParams.operatingMode == TorrentOperatingMode::AutoManaged))
         p.flags |= lt::torrent_flags::paused;
     else

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -651,6 +651,7 @@ void TorrentsController::addAction()
 
     const bool skipChecking = parseBool(params()[u"skip_checking"_qs]).value_or(false);
     const bool seqDownload = parseBool(params()[u"sequentialDownload"_qs]).value_or(false);
+    const bool stopWhenReady = parseBool(params()[u"stopWhenReady"_qs]).value_or(false);
     const bool firstLastPiece = parseBool(params()[u"firstLastPiecePrio"_qs]).value_or(false);
     const std::optional<bool> addPaused = parseBool(params()[u"paused"_qs]);
     const QString savepath = params()[u"savepath"_qs].trimmed();
@@ -691,6 +692,7 @@ void TorrentsController::addAction()
     // TODO: Check if destination actually exists
     addTorrentParams.skipChecking = skipChecking;
     addTorrentParams.sequential = seqDownload;
+    addTorrentParams.stopWhenReady = stopWhenReady;
     addTorrentParams.firstLastPiecePriority = firstLastPiece;
     addTorrentParams.addPaused = addPaused;
     addTorrentParams.contentLayout = contentLayout;


### PR DESCRIPTION
This PR allows to set `torrent_flags_t.stop_when_ready` flag using `addTorrentParams` in `addTorrent` and expose in webapi.