### PR TITLE
Allow to hide connecting peers in Peers list

### DIFF
--- a/src/base/bittorrent/peerinfo.cpp
+++ b/src/base/bittorrent/peerinfo.cpp
@@ -246,6 +246,10 @@ void PeerInfo::determineFlags()
         m_flagsDescription += u"%1 = %2\n"_qs.arg(specifier, explanation);
     };
 
+    // C = is peer in connecting state
+    if (isConnecting())
+        updateFlags(u'C', tr("Connecting"));
+
     if (isInteresting())
     {
         if (isRemoteChocked())

--- a/src/gui/properties/peerlistsortmodel.cpp
+++ b/src/gui/properties/peerlistsortmodel.cpp
@@ -32,8 +32,23 @@
 
 PeerListSortModel::PeerListSortModel(QObject *parent)
     : QSortFilterProxyModel(parent)
+    , m_showConnectingPeers(u"PeerList/ShowConnectingPeers"_qs, false)
 {
     setSortRole(UnderlyingDataRole);
+}
+
+bool PeerListSortModel::showConnectingPeers() const
+{
+    return m_showConnectingPeers.get();
+}
+
+void PeerListSortModel::setShowConnectingPeers(const bool show)
+{
+    if (showConnectingPeers() == show)
+        return;
+
+    m_showConnectingPeers = show;
+    invalidateFilter(); // TODO: use invalidateRowFilters
 }
 
 bool PeerListSortModel::lessThan(const QModelIndex &left, const QModelIndex &right) const
@@ -51,4 +66,15 @@ bool PeerListSortModel::lessThan(const QModelIndex &left, const QModelIndex &rig
     default:
         return QSortFilterProxyModel::lessThan(left, right);
     };
+}
+
+bool PeerListSortModel::filterAcceptsRow(const int sourceRow, const QModelIndex &sourceParent) const
+{
+    if (!m_showConnectingPeers)
+    {
+        const QModelIndex sourceIndex = sourceModel()->index(sourceRow, 0, sourceParent);
+        return !sourceIndex.data(IsConnectingRole).toBool();
+    }
+
+    return QSortFilterProxyModel::filterAcceptsRow(sourceRow, sourceParent);
 }

--- a/src/gui/properties/peerlistsortmodel.h
+++ b/src/gui/properties/peerlistsortmodel.h
@@ -30,6 +30,7 @@
 
 #include <QSortFilterProxyModel>
 
+#include "base/settingvalue.h"
 #include "base/utils/compare.h"
 
 class PeerListSortModel final : public QSortFilterProxyModel
@@ -40,13 +41,19 @@ class PeerListSortModel final : public QSortFilterProxyModel
 public:
     enum
     {
-        UnderlyingDataRole = Qt::UserRole
+        UnderlyingDataRole = Qt::UserRole,
+        IsConnectingRole // only set on index(row, 0)
     };
 
     explicit PeerListSortModel(QObject *parent = nullptr);
 
+    bool showConnectingPeers() const;
+    void setShowConnectingPeers(bool show);
+
 private:
     bool lessThan(const QModelIndex &left, const QModelIndex &right) const override;
+    bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const override;
 
     Utils::Compare::NaturalLessThan<Qt::CaseInsensitive> m_naturalLessThan;
+    CachedSettingValue<bool> m_showConnectingPeers;
 };

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -288,6 +288,14 @@ void PeerListWidget::showPeerListMenu()
     QAction *banPeers = menu->addAction(UIThemeManager::instance()->getIcon(u"user-group-delete"_qs), tr("Ban peer permanently")
         , this, &PeerListWidget::banSelectedPeers);
 
+    menu->addSeparator();
+    QAction *showConnectingPeers = menu->addAction(tr("Show Connecting Peers")
+                                                   , m_proxyModel
+                                                   , &PeerListSortModel::setShowConnectingPeers);
+
+    showConnectingPeers->setCheckable(true);
+    showConnectingPeers->setChecked(m_proxyModel->showConnectingPeers());
+
     // disable actions
     const auto disableAction = [](QAction *action, const QString &tooltip)
     {
@@ -478,6 +486,8 @@ void PeerListWidget::updatePeer(const BitTorrent::Torrent *torrent, const BitTor
         downloadingFiles.append(filePath.toString());
     const QString downloadingFilesDisplayValue = downloadingFiles.join(u';');
     setModelData(row, PeerListColumns::DOWNLOADING_PIECE, downloadingFilesDisplayValue, downloadingFilesDisplayValue, {}, downloadingFiles.join(u'\n'));
+
+    m_listModel->setData(m_listModel->index(row, 0), peer.isConnecting(), PeerListSortModel::IsConnectingRole);
 
     if (m_resolver)
         m_resolver->resolve(peerEndpoint.address.ip);


### PR DESCRIPTION
TorrentImpl::leechesCount() (shown in Transfer list under Peers Tab) doesn't include connecting peers but is shown in the peer's list tab causing confusion. Add a flag for connecting peers, also allow hiding these peers (by default such peers are not shown anymore)