### PR TITLE
Fix max outgoing port setting incorrectly

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1354,7 +1354,7 @@ void Session::loadLTSettings(lt::settings_pack &settingsPack)
 
     // Outgoing ports
     settingsPack.set_int(lt::settings_pack::outgoing_port, outgoingPortsMin());
-    settingsPack.set_int(lt::settings_pack::num_outgoing_ports, outgoingPortsMax() - outgoingPortsMin() + 1);
+    settingsPack.set_int(lt::settings_pack::num_outgoing_ports, outgoingPortsMax() - outgoingPortsMin());
     // UPnP lease duration
     settingsPack.set_int(lt::settings_pack::upnp_lease_duration, UPnPLeaseDuration());
     // Type of service

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1354,7 +1354,7 @@ void Session::loadLTSettings(lt::settings_pack &settingsPack)
 
     // Outgoing ports
     settingsPack.set_int(lt::settings_pack::outgoing_port, outgoingPortsMin());
-    settingsPack.set_int(lt::settings_pack::num_outgoing_ports, outgoingPortsMax() - outgoingPortsMin());
+    settingsPack.set_int(lt::settings_pack::num_outgoing_ports, (outgoingPortsMax() - outgoingPortsMin()));
     // UPnP lease duration
     settingsPack.set_int(lt::settings_pack::upnp_lease_duration, UPnPLeaseDuration());
     // Type of service


### PR DESCRIPTION
In Tools / Options / Advanced, set the outgoing ports to [min, max], but the actual outgoing ports used is [min, max+1].

libtorrent uses `outgoing_port` and `num_outgoing_ports` to set outgoing ports, the min and max outgoing ports are [outgoing_port, outgoing_port + num_outgoing_ports], see:
https://www.libtorrent.org/reference-Settings.html#outgoing_port
https://github.com/arvidn/libtorrent/blob/master/src/session_impl.cpp#L3138-L3153

qBittorrent set outgoing_port to min, num_outgoing_ports to max - min + 1, causes the actual max outgoing port is max+1.