### PR TITLE
Improve Web UI progress bar rendering

### DIFF
--- a/src/webui/www/private/css/style.css
+++ b/src/webui/www/private/css/style.css
@@ -521,6 +521,7 @@ td.generalLabel {
     position: absolute;
     top: 0;
     width: 100%;
+    image-rendering: pixelated;
 }
 
 #watched_folders_tab {

--- a/src/webui/www/private/css/style.css
+++ b/src/webui/www/private/css/style.css
@@ -517,11 +517,11 @@ td.generalLabel {
 
 #progress canvas {
     height: 100%;
+    image-rendering: pixelated;
     left: 0;
     position: absolute;
     top: 0;
     width: 100%;
-    image-rendering: pixelated;
 }
 
 #watched_folders_tab {


### PR DESCRIPTION
The progress bar of the Web UI often looks blurry on edges of coloured bars, especially for torrents with large files. This is due to the fact that the default image scaling algorithm was optimized for photos and drawings, not pixelated images like a progress bar (with sharp edges).

This PR will fix the problem by specifying the [image scaling algorithm](https://developer.mozilla.org/en-US/docs/Web/CSS/image-rendering#pixelated) for the canvas element of the progress bar. Please see the attached images for comparison (notice the edges of coloured bars):

Before (no `image-rendering` property specified):
![qbt-webui-progressbar-rendering-before](https://user-images.githubusercontent.com/9620335/175170210-f0528e9d-29c5-4490-b097-33360a1b5ee6.png)
After (`image-rendering: pixelated`):
![qbt-webui-progressbar-rendering-after](https://user-images.githubusercontent.com/9620335/175170253-33333db3-ad15-46c7-a3c8-578a43151417.png)