### PR TITLE
Remove unnecessary force reannounce on interface alerts

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -5184,9 +5184,6 @@ void Session::handleListenSucceededAlert(const lt::listen_succeeded_alert *p)
     const QString proto {toString(p->socket_type)};
     LogMsg(tr("Successfully listening on IP. IP: \"%1\". Port: \"%2/%3\"")
             .arg(toString(p->address), proto, QString::number(p->port)), Log::INFO);
-
-    // Force reannounce on all torrents because some trackers blacklist some ports
-    reannounceToAllTrackers();
 }
 
 void Session::handleListenFailedAlert(const lt::listen_failed_alert *p)


### PR DESCRIPTION
This force reannounce isn't necessary since it can cause issues by doing unnecessary reannounce during startup and network address refresh.
The impact of this unnecessary call can be great if it happens on a regular basis and if someone has a lot of torrents.

If someone changes their port because it was a blacklisted one(by a pvt tracker), it's required only once, and such a thing can't warrant a force reannounce for all users just on receiveing this alert. This alert can be posted many times during session startup and due to interface/IP refresh.
If strictly necessary, they may enable the option of "Reannounce to all trackers when IP or port changed" from advanced settings.