### PR TITLE
Raise priority of the main "event loop" thread

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -601,6 +601,10 @@ int Application::exec(const QStringList &params)
     applyMemoryWorkingSetLimit();
 #endif
 
+#ifdef Q_OS_WIN
+    adjustThreadPriority();
+#endif
+
     Net::ProxyConfigurationManager::initInstance();
     Net::DownloadManager::initInstance();
     IconProvider::initInstance();
@@ -771,7 +775,7 @@ void Application::shutdownCleanup(QSessionManager &manager)
 #endif
 
 #ifdef QBT_USES_LIBTORRENT2
-void Application::applyMemoryWorkingSetLimit()
+void Application::applyMemoryWorkingSetLimit() const
 {
     const size_t MiB = 1024 * 1024;
     const QString logMessage = tr("Failed to set physical memory (RAM) usage limit. Error code: %1. Error message: \"%2\"");
@@ -807,6 +811,18 @@ void Application::applyMemoryWorkingSetLimit()
         LogMsg(logMessage.arg(QString::number(errno), message), Log::WARNING);
     }
 #endif
+}
+#endif
+
+#ifdef Q_OS_WIN
+void Application::adjustThreadPriority() const
+{
+    // Workaround for improving responsiveness of qbt when CPU resources are scarce.
+    // Raise main event loop thread to be just one level higher than libtorrent threads.
+    // Also note that on *nix platforms there is no easy way to achieve it,
+    // so implementation is omitted.
+
+    ::SetThreadPriority(::GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL);
 }
 #endif
 

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -136,8 +136,13 @@ private:
     void processParams(const QStringList &params);
     void runExternalProgram(const BitTorrent::Torrent *torrent) const;
     void sendNotificationEmail(const BitTorrent::Torrent *torrent);
+
 #ifdef QBT_USES_LIBTORRENT2
-    void applyMemoryWorkingSetLimit();
+    void applyMemoryWorkingSetLimit() const;
+#endif
+
+#ifdef Q_OS_WIN
+    void adjustThreadPriority() const;
 #endif
 
 #ifndef DISABLE_GUI


### PR DESCRIPTION
The goal is to improve responsiveness of qbt when CPU resources are scarce.

Instead of lowering libtorrent threads priority, it is chosen to raise main event loop thread priority to avoid getting messy with libtorrent internals.

Also on Windows, threads doesn't inherit thread priority from the parent thread and it always use the default (normal) priority.