### PR TITLE
Try to recover missing tags

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1306,6 +1306,24 @@ void Session::processNextResumeData(ResumeSessionContext *context)
         }
     }
 
+    Algorithm::removeIf(resumeData.tags, [this, &torrentID](const QString &tag)
+    {
+        if (hasTag(tag))
+            return false;
+
+        if (addTag(tag))
+        {
+            LogMsg(tr("Detected inconsistent data: tag is missing from the configuration file."
+                      " Tag will be recovered."
+                      " Torrent: \"%1\". Tag: \"%2\"").arg(torrentID.toString(), tag), Log::WARNING);
+            return false;
+        }
+
+        LogMsg(tr("Detected inconsistent data: invalid tag. Torrent: \"%1\". Tag: \"%2\"")
+               .arg(torrentID.toString(), tag), Log::WARNING);
+        return true;
+    });
+
     resumeData.ltAddTorrentParams.userdata = LTClientData(new ExtensionData);
 #ifndef QBT_USES_LIBTORRENT2
     resumeData.ltAddTorrentParams.storage = customStorageConstructor;
@@ -4823,7 +4841,6 @@ const CacheStatus &Session::cacheStatus() const
 {
     return m_cacheStatus;
 }
-
 
 qint64 Session::getAlltimeDL() const
 {


### PR DESCRIPTION
Tags can go missing from config/resume data. Try to recover them to avoid inconsistent behavior.

Inspiration taken from https://github.com/qbittorrent/qBittorrent/pull/16430 with due thanks to @glassez 

Closes https://github.com/qbittorrent/qBittorrent/issues/17289.
Closes https://github.com/qbittorrent/qBittorrent/issues/16710.
