### PR TITLE
Remove option of using icons from system theme

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -979,18 +979,6 @@ void Preferences::resolvePeerHostNames(const bool resolve)
     setValue(u"Preferences/Connection/ResolvePeerHostNames"_qs, resolve);
 }
 
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
-bool Preferences::useSystemIconTheme() const
-{
-    return value(u"Preferences/Advanced/useSystemIconTheme"_qs, false);
-}
-
-void Preferences::useSystemIconTheme(const bool enabled)
-{
-    setValue(u"Preferences/Advanced/useSystemIconTheme"_qs, enabled);
-}
-#endif
-
 bool Preferences::recursiveDownloadDisabled() const
 {
     return value(u"Preferences/Advanced/DisableRecursiveDownload"_qs, false);

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -275,10 +275,6 @@ public:
     void resolvePeerCountries(bool resolve);
     bool resolvePeerHostNames() const;
     void resolvePeerHostNames(bool resolve);
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
-    bool useSystemIconTheme() const;
-    void useSystemIconTheme(bool enabled);
-#endif
     bool recursiveDownloadDisabled() const;
     void disableRecursiveDownload(bool disable = true);
 #ifdef Q_OS_WIN

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -257,12 +257,6 @@ OptionsDialog::OptionsDialog(IGUIApplication *app, QWidget *parent)
     m_ui->customThemeFilePath->setDialogCaption(tr("Select qBittorrent UI Theme file"));
     m_ui->customThemeFilePath->setFileNameFilter(tr("qBittorrent UI Theme file (*.qbtheme config.json)"));
 
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
-    m_ui->checkUseSystemIcon->setChecked(Preferences::instance()->useSystemIconTheme());
-#else
-    m_ui->checkUseSystemIcon->setVisible(false);
-#endif
-
     // Load week days (scheduler)
     m_ui->comboBoxScheduleDays->addItems(translatedWeekdayNames());
 
@@ -306,9 +300,6 @@ OptionsDialog::OptionsDialog(IGUIApplication *app, QWidget *parent)
     connect(m_ui->comboI18n, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->checkUseCustomTheme, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->customThemeFilePath, &FileSystemPathEdit::selectedPathChanged, this, &ThisType::enableApplyButton);
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
-    connect(m_ui->checkUseSystemIcon, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
-#endif
     connect(m_ui->confirmDeletion, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkAltRowColors, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkHideZero, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
@@ -678,10 +669,6 @@ void OptionsDialog::saveOptions()
 
     pref->setUseCustomUITheme(m_ui->checkUseCustomTheme->isChecked());
     pref->setCustomUIThemePath(m_ui->customThemeFilePath->selectedPath());
-
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
-    pref->useSystemIconTheme(m_ui->checkUseSystemIcon->isChecked());
-#endif
 
     pref->setConfirmTorrentDeletion(m_ui->confirmDeletion->isChecked());
     pref->setAlternatingRowColors(m_ui->checkAltRowColors->isChecked());

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -175,13 +175,6 @@
                  </property>
                 </widget>
                </item>
-               <item row="2" column="0" colspan="2">
-                <widget class="QCheckBox" name="checkUseSystemIcon">
-                 <property name="text">
-                  <string>Use system icon theme</string>
-                 </property>
-                </widget>
-               </item>
                <item row="1" column="1">
                 <widget class="QComboBox" name="comboI18n">
                  <property name="minimumSize">
@@ -3532,7 +3525,6 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
  <tabstops>
   <tabstop>tabOption</tabstop>
   <tabstop>comboI18n</tabstop>
-  <tabstop>checkUseSystemIcon</tabstop>
   <tabstop>checkUseCustomTheme</tabstop>
   <tabstop>customThemeFilePath</tabstop>
   <tabstop>checkStartPaused</tabstop>

--- a/src/gui/uithememanager.cpp
+++ b/src/gui/uithememanager.cpp
@@ -168,9 +168,6 @@ void UIThemeManager::initInstance()
 
 UIThemeManager::UIThemeManager()
     : m_useCustomTheme(Preferences::instance()->useCustomUITheme())
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
-    , m_useSystemTheme(Preferences::instance()->useSystemIconTheme())
-#endif
 {
     if (m_useCustomTheme)
     {
@@ -205,17 +202,6 @@ QIcon UIThemeManager::getIcon(const QString &iconId, const QString &fallback) co
     const auto iter = m_iconCache.find(iconId);
     if (iter != m_iconCache.end())
         return *iter;
-
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
-    // Don't cache system icons because users might change them at run time
-    if (m_useSystemTheme)
-    {
-        QIcon icon = QIcon::fromTheme(iconId);
-        if (icon.name() != iconId)
-            icon = QIcon::fromTheme(fallback, QIcon(getIconPathFromResources(iconId, fallback).toString()));
-        return icon;
-    }
-#endif
 
     const QIcon icon {getIconPathFromResources(iconId, fallback).data()};
     m_iconCache[iconId] = icon;
@@ -273,22 +259,6 @@ QIcon UIThemeManager::getSystrayIcon() const
 
 Path UIThemeManager::getIconPath(const QString &iconId) const
 {
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
-    if (m_useSystemTheme)
-    {
-        Path path = Utils::Fs::tempPath() / Path(iconId + u".png");
-        if (!path.exists())
-        {
-            const QIcon icon = QIcon::fromTheme(iconId);
-            if (!icon.isNull())
-                icon.pixmap(32).save(path.toString());
-            else
-                path = getIconPathFromResources(iconId);
-        }
-
-        return path;
-    }
-#endif
     return getIconPathFromResources(iconId, {});
 }
 

--- a/src/gui/uithememanager.h
+++ b/src/gui/uithememanager.h
@@ -81,7 +81,4 @@ private:
     QHash<QString, QColor> m_colors;
     mutable QHash<QString, QIcon> m_iconCache;
     mutable QHash<QString, QIcon> m_flagCache;
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
-    const bool m_useSystemTheme;
-#endif
 };


### PR DESCRIPTION
As discussed in #15769, Linux support for System theme is getting removed.

Closes: #17150

