### PR TITLE
Fix "Open destination folder" on macOS

### DIFF
--- a/src/gui/macutilities.mm
+++ b/src/gui/macutilities.mm
@@ -106,7 +106,15 @@ namespace MacUtils
             for (const auto &path : pathList)
                 [pathURLs addObject:[NSURL fileURLWithPath:path.toString().toNSString()]];
 
-            [[NSWorkspace sharedWorkspace] activateFileViewerSelectingURLs:pathURLs];
+            // In some unknown way, the next line affects Qt's main loop causing the crash
+            // in QApplication::exec() on processing next event after this call.
+            // Even crash doesn't happen exactly after this call, it will happen on
+            // application exit. Call stack and disassembly are the same in all cases.
+            // But running it in another thread (aka in background) solves the issue.
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^
+            {
+                [[NSWorkspace sharedWorkspace] activateFileViewerSelectingURLs:pathURLs];
+            });
         }
     }
 

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -552,7 +552,7 @@ void TransferListWidget::openSelectedTorrentsFolder() const
     // folders prehilighted for opening, so we use a custom method.
     for (BitTorrent::Torrent *const torrent : asConst(getSelectedTorrents()))
     {
-        const Path contentPath = torrent->actualStorageLocation() / torrent->contentPath();
+        const Path contentPath = torrent->contentPath();
         paths.insert(contentPath);
     }
     MacUtils::openFiles(PathList(paths.cbegin(), paths.cend()));


### PR DESCRIPTION
actually 2 issues where fixed (see commit messages for details):
- the issue caused crash (the second commit)
- incorrect path was passed to openFiles()

`Torrent::contentPath()` already returns correct abolute path to the torrent content, it considers any possible situations

existing code tried to append some "prefix" and that lead to not existing "slightly duplicated" path like
```txt
"/Users/nickkorotysh/Downloads/Users/nickkorotysh/Downloads/ubuntu-22.04-desktop-amd64.iso"
```
so destination folder was not opened in any case (but no crash happens in such case)

crash was not actually fixed, its source somewhere deep in Qt, just some workaround added, see corresponding comment in the code.

[build](https://www.dropbox.com/s/ugjelspx01ewefk/qBittorrent-master-macOS-universal.dmg?dl=0) was tested on both MacBooks: Intel-based (Core i9, 2019) and M1-based (M1 Pro, 2021)

Fixes #17273 