### PR TITLE
Extract desktop integration stuff into separate class

### DIFF
--- a/src/app/application.h
+++ b/src/app/application.h
@@ -67,6 +67,7 @@ namespace RSS
 }
 
 #ifndef DISABLE_GUI
+class DesktopIntegration;
 class MainWindow;
 
 using BaseApplication = QApplication;
@@ -124,7 +125,11 @@ public:
 #endif
 
 #ifndef DISABLE_GUI
+    DesktopIntegration *desktopIntegration() override;
     MainWindow *mainWindow() override;
+
+    bool isTorrentAddedNotificationsEnabled() const override;
+    void setTorrentAddedNotificationsEnabled(bool value) override;
 #endif
 
 private slots:
@@ -194,6 +199,9 @@ private:
 #endif
 
 #ifndef DISABLE_GUI
+    SettingValue<bool> m_storeNotificationTorrentAdded;
+
+    DesktopIntegration *m_desktopIntegration = nullptr;
     MainWindow *m_window = nullptr;
 #endif
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(qbt_gui STATIC
     cookiesdialog.h
     cookiesmodel.h
     deletionconfirmationdialog.h
+    desktopintegration.h
     downloadfromurldialog.h
     executionlogwidget.h
     fspathedit.h
@@ -128,6 +129,7 @@ add_library(qbt_gui STATIC
     cookiesdialog.cpp
     cookiesmodel.cpp
     deletionconfirmationdialog.cpp
+    desktopintegration.cpp
     downloadfromurldialog.cpp
     executionlogwidget.cpp
     fspathedit.cpp

--- a/src/gui/desktopintegration.cpp
+++ b/src/gui/desktopintegration.cpp
@@ -1,0 +1,273 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2022  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "desktopintegration.h"
+
+#include <chrono>
+
+#include <QMenu>
+#include <QTimer>
+
+#ifndef Q_OS_MACOS
+#include <QSystemTrayIcon>
+#endif
+
+#include "base/logger.h"
+#include "base/preferences.h"
+#include "uithememanager.h"
+
+#ifdef Q_OS_MACOS
+#include "macutilities.h"
+#endif
+
+#ifdef QBT_USES_CUSTOMDBUSNOTIFICATIONS
+#include "notifications/dbusnotifier.h"
+#endif
+
+namespace
+{
+#ifdef Q_OS_MACOS
+    DesktopIntegration *desktopIntegrationInstance = nullptr;
+
+    bool handleDockClicked(id self, SEL cmd, ...)
+    {
+        Q_UNUSED(self);
+        Q_UNUSED(cmd);
+
+        Q_ASSERT(desktopIntegrationInstance);
+        emit desktopIntegrationInstance->activationRequested();
+
+        return true;
+    }
+#endif
+}
+
+using namespace std::chrono_literals;
+
+#define SETTINGS_KEY(name) u"GUI/" name
+#define NOTIFICATIONS_SETTINGS_KEY(name) (SETTINGS_KEY(u"Notifications/"_qs) name)
+
+DesktopIntegration::DesktopIntegration(QObject *parent)
+    : QObject(parent)
+    , m_storeNotificationEnabled {NOTIFICATIONS_SETTINGS_KEY(u"Enabled"_qs), true}
+#ifdef QBT_USES_CUSTOMDBUSNOTIFICATIONS
+    , m_storeNotificationTimeOut {NOTIFICATIONS_SETTINGS_KEY(u"Timeout"_qs), -1}
+#endif
+{
+#ifdef Q_OS_MACOS
+    desktopIntegrationInstance = this;
+    MacUtils::overrideDockClickHandler(handleDockClicked);
+#else
+    if (Preferences::instance()->systemTrayEnabled())
+        createTrayIcon(20);
+
+#ifdef QBT_USES_CUSTOMDBUSNOTIFICATIONS
+    if (isNotificationsEnabled())
+    {
+        m_notifier = new DBusNotifier(this);
+        connect(m_notifier, &DBusNotifier::messageClicked, this, &DesktopIntegration::notificationClicked);
+    }
+#endif
+#endif
+
+    connect(Preferences::instance(), &Preferences::changed, this, &DesktopIntegration::onPreferencesChanged);
+}
+
+bool DesktopIntegration::isActive() const
+{
+#ifdef Q_OS_MACOS
+    return true;
+#else
+    return (m_systrayIcon != nullptr);
+#endif
+}
+
+QString DesktopIntegration::toolTip() const
+{
+    return m_toolTip;
+}
+
+void DesktopIntegration::setToolTip(const QString &toolTip)
+{
+    if (m_toolTip == toolTip)
+        return;
+
+#ifndef Q_OS_MACOS
+    if (m_systrayIcon)
+        m_systrayIcon->setToolTip(toolTip);
+#endif
+}
+
+QMenu *DesktopIntegration::menu() const
+{
+    return m_menu;
+}
+
+void DesktopIntegration::setMenu(QMenu *menu)
+{
+    if (menu == m_menu)
+        return;
+
+    m_menu = menu;
+
+#ifdef Q_OS_MACOS
+    if (m_menu)
+        m_menu->setAsDockMenu();
+#else
+    if (m_systrayIcon)
+        m_systrayIcon->setContextMenu(m_menu);
+#endif
+}
+
+bool DesktopIntegration::isNotificationsEnabled() const
+{
+    return m_storeNotificationEnabled;
+}
+
+void DesktopIntegration::setNotificationsEnabled(const bool value)
+{
+    if (m_storeNotificationEnabled == value)
+        return;
+
+    m_storeNotificationEnabled = value;
+
+#ifdef QBT_USES_CUSTOMDBUSNOTIFICATIONS
+    if (value)
+    {
+        m_notifier = new DBusNotifier(this);
+        connect(m_notifier, &DBusNotifier::messageClicked, this, &DesktopIntegration::notificationClicked);
+    }
+    else
+    {
+        delete m_notifier;
+        m_notifier = nullptr;
+    }
+#endif
+}
+
+int DesktopIntegration::notificationTimeout() const
+{
+#ifdef QBT_USES_CUSTOMDBUSNOTIFICATIONS
+    return m_storeNotificationTimeOut;
+#else
+    return 5000;
+#endif
+}
+
+#ifdef QBT_USES_CUSTOMDBUSNOTIFICATIONS
+void DesktopIntegration::setNotificationTimeout(const int value)
+{
+    m_storeNotificationTimeOut = value;
+}
+#endif
+
+void DesktopIntegration::showNotification(const QString &title, const QString &msg) const
+{
+    if (!isNotificationsEnabled())
+        return;
+
+#ifdef Q_OS_MACOS
+    MacUtils::displayNotification(title, msg);
+#else
+#ifdef QBT_USES_CUSTOMDBUSNOTIFICATIONS
+    m_notifier->showMessage(title, msg, notificationTimeout());
+#else
+    if (m_systrayIcon && QSystemTrayIcon::supportsMessages())
+        m_systrayIcon->showMessage(title, msg, QSystemTrayIcon::Information, notificationTimeout());
+#endif
+#endif
+}
+
+void DesktopIntegration::onPreferencesChanged()
+{
+#ifndef Q_OS_MACOS
+    if (Preferences::instance()->systemTrayEnabled())
+    {
+        if (m_systrayIcon)
+        {
+            // Reload systray icon
+            m_systrayIcon->setIcon(UIThemeManager::instance()->getSystrayIcon());
+        }
+        else
+        {
+            createTrayIcon(20);
+        }
+    }
+    else
+    {
+        delete m_systrayIcon;
+        m_systrayIcon = nullptr;
+        emit stateChanged();
+    }
+#endif
+}
+
+#ifndef Q_OS_MACOS
+void DesktopIntegration::createTrayIcon(const int retries)
+{
+    Q_ASSERT(!m_systrayIcon);
+
+    if (QSystemTrayIcon::isSystemTrayAvailable())
+    {
+        m_systrayIcon = new QSystemTrayIcon(UIThemeManager::instance()->getSystrayIcon(), this);
+
+        m_systrayIcon->setToolTip(m_toolTip);
+
+        if (m_menu)
+            m_systrayIcon->setContextMenu(m_menu);
+
+        connect(m_systrayIcon, &QSystemTrayIcon::activated, this
+                , [this](const QSystemTrayIcon::ActivationReason reason)
+        {
+            if (reason == QSystemTrayIcon::Trigger)
+                emit activationRequested();
+        });
+#ifndef QBT_USES_CUSTOMDBUSNOTIFICATIONS
+        connect(m_systrayIcon, &QSystemTrayIcon::messageClicked, this, &DesktopIntegration::notificationClicked);
+#endif
+
+        m_systrayIcon->show();
+        emit stateChanged();
+    }
+    else if (retries > 0)
+    {
+        LogMsg(tr("System tray icon is not available, retrying..."), Log::WARNING);
+        QTimer::singleShot(2s, this, [this, retries]()
+        {
+            if (Preferences::instance()->systemTrayEnabled())
+                createTrayIcon(retries - 1);
+        });
+    }
+    else
+    {
+        LogMsg(tr("System tray icon is still not available after retries. Disabling it."), Log::WARNING);
+        Preferences::instance()->setSystemTrayEnabled(false);
+    }
+}
+#endif // Q_OS_MACOS

--- a/src/gui/gui.pri
+++ b/src/gui/gui.pri
@@ -12,6 +12,7 @@ HEADERS += \
     $$PWD/cookiesdialog.h \
     $$PWD/cookiesmodel.h \
     $$PWD/deletionconfirmationdialog.h \
+    $$PWD/desktopintegration.h \
     $$PWD/downloadfromurldialog.h \
     $$PWD/executionlogwidget.h \
     $$PWD/fspathedit.h \
@@ -95,6 +96,7 @@ SOURCES += \
     $$PWD/cookiesdialog.cpp \
     $$PWD/cookiesmodel.cpp \
     $$PWD/deletionconfirmationdialog.cpp \
+    $$PWD/desktopintegration.cpp \
     $$PWD/downloadfromurldialog.cpp \
     $$PWD/executionlogwidget.cpp \
     $$PWD/fspathedit.cpp \

--- a/src/gui/interfaces/iguiapplication.h
+++ b/src/gui/interfaces/iguiapplication.h
@@ -32,6 +32,7 @@
 
 #include "base/interfaces/iapplication.h"
 
+class DesktopIntegration;
 class MainWindow;
 
 class IGUIApplication : public IApplication
@@ -39,5 +40,9 @@ class IGUIApplication : public IApplication
 public:
     virtual ~IGUIApplication() = default;
 
+    virtual DesktopIntegration *desktopIntegration() = 0;
     virtual MainWindow *mainWindow() = 0;
+
+    virtual bool isTorrentAddedNotificationsEnabled() const = 0;
+    virtual void setTorrentAddedNotificationsEnabled(bool value) = 0;
 };

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -31,10 +31,6 @@
 #include <QMainWindow>
 #include <QPointer>
 
-#ifndef Q_OS_MACOS
-#include <QSystemTrayIcon>
-#endif
-
 #include "base/bittorrent/torrent.h"
 #include "base/logger.h"
 #include "base/settingvalue.h"
@@ -97,14 +93,6 @@ public:
     void setExecutionLogMsgTypes(Log::MsgTypes value);
 
     // Notifications properties
-    bool isNotificationsEnabled() const;
-    void setNotificationsEnabled(bool value);
-    bool isTorrentAddedNotificationsEnabled() const;
-    void setTorrentAddedNotificationsEnabled(bool value);
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)) && defined(QT_DBUS_LIB)
-    int getNotificationTimeout() const;
-    void setNotificationTimeout(int value);
-#endif
 
     // Misc properties
     bool isDownloadTrackerFavicon() const;
@@ -113,19 +101,12 @@ public:
     void activate();
     void cleanup();
 
-    void showNotificationBalloon(const QString &title, const QString &msg) const;
-
-signals:
-    void systemTrayIconCreated();
-
 private slots:
     void showFilterContextMenu();
-    void balloonClicked();
+    void desktopNotificationClicked();
     void writeSettings();
     void writeSplitterSettings();
     void readSettings();
-    void fullDiskError(BitTorrent::Torrent *const torrent, const QString &msg) const;
-    void handleDownloadFromUrlFailure(const QString &, const QString &) const;
     void tabChanged(int newTab);
     bool defineUILockPassword();
     void clearUILockPassword();
@@ -143,9 +124,6 @@ private slots:
     void reloadSessionStats();
     void reloadTorrentStats(const QVector<BitTorrent::Torrent *> &torrents);
     void loadPreferences();
-    void addTorrentFailed(const QString &error) const;
-    void torrentNew(BitTorrent::Torrent *const torrent) const;
-    void finishedTorrent(BitTorrent::Torrent *const torrent) const;
     void askRecursiveTorrentDownloadConfirmation(BitTorrent::Torrent *const torrent);
     void optionsSaved();
     void toggleAlternativeSpeeds();
@@ -199,16 +177,11 @@ private slots:
 #ifdef Q_OS_MACOS
     void on_actionCloseWindow_triggered();
 #else
-    void toggleVisibility(const QSystemTrayIcon::ActivationReason reason = QSystemTrayIcon::Trigger);
+    void toggleVisibility();
 #endif
 
 private:
-    void createTrayIconMenu();
-#ifdef Q_OS_MACOS
-    void setupDockClickHandler();
-#else
-    void createTrayIcon(int retries);
-#endif
+    QMenu *createDesktopIntegrationMenu();
 #ifdef Q_OS_WIN
     void installPython();
 #endif
@@ -238,9 +211,6 @@ private:
     QPointer<TorrentCreatorDialog> m_createTorrentDlg;
     QPointer<DownloadFromURLDialog> m_downloadFromURLDialog;
 
-#ifndef Q_OS_MACOS
-    QPointer<QSystemTrayIcon> m_systrayIcon;
-#endif
     QPointer<QMenu> m_trayIconMenu;
 
     TransferListWidget *m_transferListWidget = nullptr;
@@ -267,14 +237,7 @@ private:
 
     SettingValue<bool> m_storeExecutionLogEnabled;
     SettingValue<bool> m_storeDownloadTrackerFavicon;
-    SettingValue<bool> m_storeNotificationEnabled;
-    SettingValue<bool> m_storeNotificationTorrentAdded;
     CachedSettingValue<Log::MsgTypes> m_storeExecutionLogTypes;
-
-#ifdef QBT_USES_CUSTOMDBUSNOTIFICATIONS
-    SettingValue<int> m_storeNotificationTimeOut;
-    DBusNotifier *m_notifier = nullptr;
-#endif
 
 #if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
     void checkProgramUpdate(bool invokedByUser);

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -52,6 +52,7 @@
 #include "base/search/searchhandler.h"
 #include "base/search/searchpluginmanager.h"
 #include "base/utils/foreignapps.h"
+#include "gui/desktopintegration.h"
 #include "gui/mainwindow.h"
 #include "gui/uithememanager.h"
 #include "pluginselectdialog.h"
@@ -83,10 +84,11 @@ namespace
     }
 }
 
-SearchWidget::SearchWidget(MainWindow *mainWindow)
+SearchWidget::SearchWidget(IGUIApplication *app, MainWindow *mainWindow)
     : QWidget(mainWindow)
-    , m_ui(new Ui::SearchWidget())
-    , m_mainWindow(mainWindow)
+    , GUIApplicationComponent(app)
+    , m_ui {new Ui::SearchWidget()}
+    , m_mainWindow {mainWindow}
 {
     m_ui->setupUi(this);
     m_ui->tabWidget->tabBar()->installEventFilter(this);
@@ -304,7 +306,7 @@ void SearchWidget::on_searchButton_clicked()
 {
     if (!Utils::ForeignApps::pythonInfo().isValid())
     {
-        m_mainWindow->showNotificationBalloon(tr("Search Engine"), tr("Please install Python to use the Search Engine."));
+        app()->desktopIntegration()->showNotification(tr("Search Engine"), tr("Please install Python to use the Search Engine."));
         return;
     }
 
@@ -370,12 +372,12 @@ void SearchWidget::tabStatusChanged(QWidget *tab)
     {
         Q_ASSERT(m_activeSearchTab->status() != SearchJobWidget::Status::Ongoing);
 
-        if (m_mainWindow->isNotificationsEnabled() && (m_mainWindow->currentTabWidget() != this))
+        if (app()->desktopIntegration()->isNotificationsEnabled() && (m_mainWindow->currentTabWidget() != this))
         {
             if (m_activeSearchTab->status() == SearchJobWidget::Status::Error)
-                m_mainWindow->showNotificationBalloon(tr("Search Engine"), tr("Search has failed"));
+                app()->desktopIntegration()->showNotification(tr("Search Engine"), tr("Search has failed"));
             else
-                m_mainWindow->showNotificationBalloon(tr("Search Engine"), tr("Search has finished"));
+                app()->desktopIntegration()->showNotification(tr("Search Engine"), tr("Search has finished"));
         }
 
         m_activeSearchTab = nullptr;


### PR DESCRIPTION
This PR is prerequisite for making possible to indicate only application loading progress until the BitTorrent session is fully restored.
It extracts desktop integration stuff (like tray icon, macOS dock and desktop notifications support) into separate class.
