### PR TITLE
Fix various typos

### DIFF
--- a/dist/docker/Readme.md
+++ b/dist/docker/Readme.md
@@ -2,7 +2,7 @@
 
 This Dockerfile allows you to build a docker image containing qBittorrent-nox
 
-## Prerequisities
+## Prerequisites
 
 In order to build/run this image you'll need `docker` installed: https://docs.docker.com/get-docker/
 
@@ -21,7 +21,7 @@ It is also recommended to install `docker-compose` as it can significantly ease 
   ```
 
 * If you are using docker-compose then you should edit `.env` file first.
-  You can find an explaination of the variables in the following [Parameters](#parameters) section. \
+  You can find an explanation of the variables in the following [Parameters](#parameters) section. \
   Then run the following commands in this folder:
   ```shell
   docker compose build \

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-# CMAKE_AUTO_UI causes unncessary rebuilds
+# CMAKE_AUTO_UI causes unnecessary rebuilds
 qt_wrap_ui(UI_HEADERS
     aboutdialog.ui
     addnewtorrentdialog.ui

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -99,7 +99,7 @@ SearchWidget::SearchWidget(MainWindow *mainWindow)
         + u"<br>"
         + tr("<b>foo bar</b>: search for <b>foo</b> and <b>bar</b>",
                  "Search phrase example, illustrates quotes usage, a pair of "
-                 "space delimited words, individal words are highlighted")
+                 "space delimited words, individual words are highlighted")
         + u"<br>"
         + tr("<b>&quot;foo bar&quot;</b>: search for <b>foo bar</b>",
                  "Search phrase example, illustrates quotes usage, double quoted"

--- a/src/gui/torrentoptionsdialog.cpp
+++ b/src/gui/torrentoptionsdialog.cpp
@@ -590,7 +590,7 @@ void TorrentOptionsDialog::handleRatioTypeChanged()
         QAbstractButton *currentRadio = m_ui->buttonGroup->checkedButton();
         if (currentRadio && (currentRadio == m_previousRadio))
         {
-            // Hack to deselect the currently selected radio button programatically because Qt doesn't allow it in exclusive mode
+            // Hack to deselect the currently selected radio button programmatically because Qt doesn't allow it in exclusive mode
             m_ui->buttonGroup->setExclusive(false);
             currentRadio->setChecked(false);
             m_ui->buttonGroup->setExclusive(true);

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -804,7 +804,7 @@ void TransferListWidget::exportTorrent()
         if (hasError)
         {
             QMessageBox::warning(this, tr("Export .torrent file error")
-                , tr("Errors occured when exporting .torrent files. Check execution log for details."));
+                , tr("Errors occurred when exporting .torrent files. Check execution log for details."));
         }
     });
 

--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -500,7 +500,7 @@ void SyncController::maindataAction()
     {
         const BitTorrent::CategoryOptions categoryOptions = session->categoryOptions(categoryName);
         QJsonObject category = categoryOptions.toJSON();
-        // adjust it to be compatible with exisitng WebAPI
+        // adjust it to be compatible with existing WebAPI
         category[u"savePath"_qs] = category.take(u"save_path"_qs);
         category.insert(u"name"_qs, categoryName);
         categories[categoryName] = category.toVariantMap();

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -1280,7 +1280,7 @@ void TorrentsController::categoriesAction()
     {
         const BitTorrent::CategoryOptions categoryOptions = session->categoryOptions(categoryName);
         QJsonObject category = categoryOptions.toJSON();
-        // adjust it to be compatible with exisitng WebAPI
+        // adjust it to be compatible with existing WebAPI
         category[u"savePath"_qs] = category.take(u"save_path"_qs);
         category.insert(u"name"_qs, categoryName);
         categories[categoryName] = category;


### PR DESCRIPTION
Found via `codespell -q 3 -S *.ts,*.desktop,./src/base/3rdparty,./dist/windows/installer-translations -L ba,doas,ist,ro,ths`