### PR TITLE
Revise behavior of initializing checkboxes

### DIFF
--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -650,8 +650,6 @@ void OptionsDialog::saveOptions()
     auto *pref = Preferences::instance();
     auto *session = BitTorrent::Session::instance();
 
-    m_applyButton->setEnabled(false);
-
     // Load the translation
     QString locale = getLocale();
     if (pref->getLocale() != locale)
@@ -1419,8 +1417,8 @@ void OptionsDialog::on_buttonBox_accepted()
             m_ui->tabSelection->setCurrentRow(TAB_WEBUI);
             return;
         }
+
         m_applyButton->setEnabled(false);
-        this->hide();
         saveOptions();
     }
 
@@ -1444,6 +1442,8 @@ void OptionsDialog::applySettings()
         m_ui->tabSelection->setCurrentRow(TAB_WEBUI);
         return;
     }
+
+    m_applyButton->setEnabled(false);
     saveOptions();
 }
 

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -675,10 +675,10 @@ void OptionsDialog::saveOptions()
     pref->setHideZeroValues(m_ui->checkHideZero->isChecked());
     pref->setHideZeroComboValues(m_ui->comboHideZero->currentIndex());
 #ifndef Q_OS_MACOS
-    pref->setSystemTrayEnabled(systemTrayEnabled());
+    pref->setSystemTrayEnabled(m_ui->checkShowSystray->isChecked());
     pref->setTrayIconStyle(TrayIcon::Style(m_ui->comboTrayIcon->currentIndex()));
-    pref->setCloseToTray(closeToTray());
-    pref->setMinimizeToTray(minimizeToTray());
+    pref->setCloseToTray(m_ui->checkCloseToSystray->isChecked());
+    pref->setMinimizeToTray(m_ui->checkMinimizeToSysTray->isChecked());
 #endif
     pref->setStartMinimized(startMinimized());
     pref->setSplashScreenDisabled(isSplashScreenDisabled());
@@ -935,12 +935,9 @@ void OptionsDialog::loadOptions()
 
 #ifndef Q_OS_MACOS
     m_ui->checkShowSystray->setChecked(pref->systemTrayEnabled());
-    if (m_ui->checkShowSystray->isChecked())
-    {
-        m_ui->checkMinimizeToSysTray->setChecked(pref->minimizeToTray());
-        m_ui->checkCloseToSystray->setChecked(pref->closeToTray());
-        m_ui->comboTrayIcon->setCurrentIndex(static_cast<int>(pref->trayIconStyle()));
-    }
+    m_ui->checkMinimizeToSysTray->setChecked(pref->minimizeToTray());
+    m_ui->checkCloseToSystray->setChecked(pref->closeToTray());
+    m_ui->comboTrayIcon->setCurrentIndex(static_cast<int>(pref->trayIconStyle()));
 #endif
 
     m_ui->checkPreventFromSuspendWhenDownloading->setChecked(pref->preventFromSuspendWhenDownloading());
@@ -1353,27 +1350,6 @@ bool OptionsDialog::startMinimized() const
 {
     return m_ui->checkStartMinimized->isChecked();
 }
-
-#ifndef Q_OS_MACOS
-bool OptionsDialog::systemTrayEnabled() const
-{
-    return QSystemTrayIcon::isSystemTrayAvailable()
-        ? m_ui->checkShowSystray->isChecked()
-        : false;
-}
-
-bool OptionsDialog::minimizeToTray() const
-{
-    if (!m_ui->checkShowSystray->isChecked()) return false;
-    return m_ui->checkMinimizeToSysTray->isChecked();
-}
-
-bool OptionsDialog::closeToTray() const
-{
-    if (!m_ui->checkShowSystray->isChecked()) return false;
-    return m_ui->checkCloseToSystray->isChecked();
-}
-#endif // Q_OS_MACOS
 
 // Return Share ratio
 qreal OptionsDialog::getMaxRatio() const

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -262,6 +262,7 @@ OptionsDialog::OptionsDialog(IGUIApplication *app, QWidget *parent)
 
     // Load options
     loadOptions();
+
 #ifdef Q_OS_MACOS
     m_ui->checkShowSystray->setVisible(false);
 #else
@@ -270,8 +271,7 @@ OptionsDialog::OptionsDialog(IGUIApplication *app, QWidget *parent)
     {
         m_ui->checkShowSystray->setChecked(false);
         m_ui->checkShowSystray->setEnabled(false);
-        m_ui->labelTrayIconStyle->setVisible(false);
-        m_ui->comboTrayIcon->setVisible(false);
+        m_ui->checkShowSystray->setToolTip(tr("Disabled due to failed to detect system tray presence"));
     }
 #endif
 

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -123,11 +123,6 @@ private:
     void initializeLanguageCombo();
     // General options
     QString getLocale() const;
-#ifndef Q_OS_MACOS
-    bool systemTrayEnabled() const;
-    bool minimizeToTray() const;
-    bool closeToTray() const;
-#endif
     bool startMinimized() const;
     bool isSplashScreenDisabled() const;
 #ifdef Q_OS_WIN


### PR DESCRIPTION
* Revise behavior of initializing checkboxes
  The checkboxes initial value should not depend on parent state and should be restored anyway.
* Add tooltip message when system tray icon isn't available
  Also don't hide the sub-options as they are already in disabled state.
* Don't needlessly hide Options dialog
  The dialog should only close after all operations are done, not before.
