### PR TITLE
Stop installing app icon in pixmaps location

### DIFF
--- a/unixconf.pri
+++ b/unixconf.pri
@@ -51,10 +51,6 @@ nogui:systemd {
     INSTALLS += \
         menuicons \
         statusIconScalable
-
-    pixmap.files = $$DIST_PATH/menuicons/128x128/apps/qbittorrent.png
-    pixmap.path = $$DATADIR/pixmaps
-    INSTALLS += pixmap
 }
 
 # INSTALL


### PR DESCRIPTION
The `/usr/share/pixmaps` location is considered a legacy location for
application icons; since the application icons are already installed in
the global XDG hicolor theme, then simply stop installing the 128px one
in the legacy pixmaps location.