### PR TITLE
Remove meaningless checking for nullptr

### DIFF
--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -108,8 +108,6 @@ AutoDownloader::AutoDownloader()
     m_instance = this;
 
     m_fileStorage = new AsyncFileStorage(specialFolderLocation(SpecialFolder::Config) / Path(CONF_FOLDER_NAME));
-    if (!m_fileStorage)
-        throw RuntimeError(tr("Directory for RSS AutoDownloader data is unavailable."));
 
     m_fileStorage->moveToThread(m_ioThread);
     connect(m_ioThread, &QThread::finished, m_fileStorage, &AsyncFileStorage::deleteLater);


### PR DESCRIPTION
Fix PVS-Studio issue "rss_autodownloader.cpp:111: warning: V668
There is no sense in testing the 'm_fileStorage' pointer against null,
as the memory was allocated using the 'new' operator.
The exception will be generated in the case of memory allocation error".

<!--
MANDATORY Before submitting your work, make sure you have:
1. Read https://github.com/qbittorrent/qBittorrent/blob/master/CONTRIBUTING.md#opening-a-pull-request
2. Delete this comment block
-->
