### PR TITLE
Split the OS cache settings into Disk IO read/write modes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(minQt5Version 5.15.2)
 set(minQt6Version 6.2)
 set(minOpenSSLVersion 1.1.1)
 set(minLibtorrent1Version 1.2.14)
-set(minLibtorrentVersion 2.0.4)
+set(minLibtorrentVersion 2.0.6)
 set(minZlibVersion 1.2.11)
 
 include(CheckCXXSourceCompiles) # TODO: migrate to CheckSourceCompiles in CMake >= 3.19

--- a/INSTALL
+++ b/INSTALL
@@ -5,7 +5,7 @@ qBittorrent - A BitTorrent client in C++ / Qt
 
   - Boost >= 1.71
 
-  - libtorrent-rasterbar 1.2.14 - 1.2.x || 2.0.4 - 2.0.x
+  - libtorrent-rasterbar 1.2.14 - 1.2.x || 2.0.6 - 2.0.x
       * By Arvid Norberg, https://www.libtorrent.org/
       * Be careful: another library (the one used by rTorrent) uses a similar name
 

--- a/configure
+++ b/configure
@@ -6022,19 +6022,19 @@ LDFLAGS="$BOOST_LDFLAGS $LDFLAGS"
 
 
 pkg_failed=no
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for libtorrent-rasterbar >= 2.0.4" >&5
-printf %s "checking for libtorrent-rasterbar >= 2.0.4... " >&6; }
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for libtorrent-rasterbar >= 2.0.6" >&5
+printf %s "checking for libtorrent-rasterbar >= 2.0.6... " >&6; }
 
 if test -n "$libtorrent_CFLAGS"; then
     pkg_cv_libtorrent_CFLAGS="$libtorrent_CFLAGS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libtorrent-rasterbar >= 2.0.4\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libtorrent-rasterbar >= 2.0.4") 2>&5
+    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libtorrent-rasterbar >= 2.0.6\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libtorrent-rasterbar >= 2.0.6") 2>&5
   ac_status=$?
   printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_libtorrent_CFLAGS=`$PKG_CONFIG --cflags "libtorrent-rasterbar >= 2.0.4" 2>/dev/null`
+  pkg_cv_libtorrent_CFLAGS=`$PKG_CONFIG --cflags "libtorrent-rasterbar >= 2.0.6" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -6046,12 +6046,12 @@ if test -n "$libtorrent_LIBS"; then
     pkg_cv_libtorrent_LIBS="$libtorrent_LIBS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libtorrent-rasterbar >= 2.0.4\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libtorrent-rasterbar >= 2.0.4") 2>&5
+    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libtorrent-rasterbar >= 2.0.6\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libtorrent-rasterbar >= 2.0.6") 2>&5
   ac_status=$?
   printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_libtorrent_LIBS=`$PKG_CONFIG --libs "libtorrent-rasterbar >= 2.0.4" 2>/dev/null`
+  pkg_cv_libtorrent_LIBS=`$PKG_CONFIG --libs "libtorrent-rasterbar >= 2.0.6" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -6072,9 +6072,9 @@ else
         _pkg_short_errors_supported=no
 fi
         if test $_pkg_short_errors_supported = yes; then
-	        libtorrent_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libtorrent-rasterbar >= 2.0.4" 2>&1`
+	        libtorrent_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libtorrent-rasterbar >= 2.0.6" 2>&1`
         else
-	        libtorrent_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libtorrent-rasterbar >= 2.0.4" 2>&1`
+	        libtorrent_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libtorrent-rasterbar >= 2.0.6" 2>&1`
         fi
 	# Put the nasty error message in config.log where it belongs
 	echo "$libtorrent_PKG_ERRORS" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -188,7 +188,7 @@ m4_define([DETECT_BOOST_VERSION_PROGRAM],
                      [[(void) ((void)sizeof(char[1 - 2*!!((BOOST_VERSION) < ($1))]));]])])
 
 PKG_CHECK_MODULES(libtorrent,
-                  [libtorrent-rasterbar >= 2.0.4],
+                  [libtorrent-rasterbar >= 2.0.6],
                   [CXXFLAGS="$libtorrent_CFLAGS $CXXFLAGS" LIBS="$libtorrent_LIBS $LIBS" QBT_ADD_DEFINES="$QBT_ADD_DEFINES QBT_USES_LIBTORRENT2"],
                   [PKG_CHECK_MODULES(libtorrent,
                                      [libtorrent-rasterbar >= 1.2.14 libtorrent-rasterbar < 2],

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -343,7 +343,8 @@ Session::Session(QObject *parent)
     , m_diskCacheTTL(BITTORRENT_SESSION_KEY(u"DiskCacheTTL"_qs), 60)
     , m_diskQueueSize(BITTORRENT_SESSION_KEY(u"DiskQueueSize"_qs), (1024 * 1024))
     , m_diskIOType(BITTORRENT_SESSION_KEY(u"DiskIOType"_qs), DiskIOType::Default)
-    , m_useOSCache(BITTORRENT_SESSION_KEY(u"UseOSCache"_qs), true)
+    , m_diskIOReadMode(BITTORRENT_SESSION_KEY(u"DiskIOReadMode"_qs), DiskIOReadMode::EnableOSCache)
+    , m_diskIOWriteMode(BITTORRENT_SESSION_KEY(u"DiskIOWriteMode"_qs), DiskIOWriteMode::EnableOSCache)
 #ifdef Q_OS_WIN
     , m_coalesceReadWriteEnabled(BITTORRENT_SESSION_KEY(u"CoalesceReadWrite"_qs), true)
 #else
@@ -1612,10 +1613,32 @@ void Session::loadLTSettings(lt::settings_pack &settingsPack)
 
     settingsPack.set_int(lt::settings_pack::max_queued_disk_bytes, diskQueueSize());
 
-    lt::settings_pack::io_buffer_mode_t mode = useOSCache() ? lt::settings_pack::enable_os_cache
-                                                              : lt::settings_pack::disable_os_cache;
-    settingsPack.set_int(lt::settings_pack::disk_io_read_mode, mode);
-    settingsPack.set_int(lt::settings_pack::disk_io_write_mode, mode);
+    switch (diskIOReadMode())
+    {
+    case DiskIOReadMode::DisableOSCache:
+        settingsPack.set_int(lt::settings_pack::disk_io_read_mode, lt::settings_pack::disable_os_cache);
+        break;
+    case DiskIOReadMode::EnableOSCache:
+    default:
+        settingsPack.set_int(lt::settings_pack::disk_io_read_mode, lt::settings_pack::enable_os_cache);
+        break;
+    }
+
+    switch (diskIOWriteMode())
+    {
+    case DiskIOWriteMode::DisableOSCache:
+        settingsPack.set_int(lt::settings_pack::disk_io_write_mode, lt::settings_pack::disable_os_cache);
+        break;
+    case DiskIOWriteMode::EnableOSCache:
+    default:
+        settingsPack.set_int(lt::settings_pack::disk_io_write_mode, lt::settings_pack::enable_os_cache);
+        break;
+#ifdef QBT_USES_LIBTORRENT2
+    case DiskIOWriteMode::WriteThrough:
+        settingsPack.set_int(lt::settings_pack::disk_io_write_mode, lt::settings_pack::write_through);
+        break;
+#endif
+    }
 
 #ifndef QBT_USES_LIBTORRENT2
     settingsPack.set_bool(lt::settings_pack::coalesce_reads, isCoalesceReadWriteEnabled());
@@ -3762,18 +3785,32 @@ void Session::setDiskQueueSize(const qint64 size)
     configureDeferred();
 }
 
-bool Session::useOSCache() const
+DiskIOReadMode Session::diskIOReadMode() const
 {
-    return m_useOSCache;
+    return m_diskIOReadMode;
 }
 
-void Session::setUseOSCache(const bool use)
+void Session::setDiskIOReadMode(const DiskIOReadMode mode)
 {
-    if (use != m_useOSCache)
-    {
-        m_useOSCache = use;
-        configureDeferred();
-    }
+    if (mode == m_diskIOReadMode)
+        return;
+
+    m_diskIOReadMode = mode;
+    configureDeferred();
+}
+
+DiskIOWriteMode Session::diskIOWriteMode() const
+{
+    return m_diskIOWriteMode;
+}
+
+void Session::setDiskIOWriteMode(const DiskIOWriteMode mode)
+{
+    if (mode == m_diskIOWriteMode)
+        return;
+
+    m_diskIOWriteMode = mode;
+    configureDeferred();
 }
 
 bool Session::isCoalesceReadWriteEnabled() const

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -121,6 +121,13 @@ namespace BitTorrent
         };
         Q_ENUM_NS(ChokingAlgorithm)
 
+        enum class DiskIOReadMode : int
+        {
+            DisableOSCache = 0,
+            EnableOSCache = 1
+        };
+        Q_ENUM_NS(DiskIOReadMode)
+
         enum class DiskIOType : int
         {
             Default = 0,
@@ -128,6 +135,16 @@ namespace BitTorrent
             Posix = 2
         };
         Q_ENUM_NS(DiskIOType)
+
+        enum class DiskIOWriteMode : int
+        {
+            DisableOSCache = 0,
+            EnableOSCache = 1,
+#ifdef QBT_USES_LIBTORRENT2
+            WriteThrough = 2
+#endif
+        };
+        Q_ENUM_NS(DiskIOWriteMode)
 
         enum class MixedModeAlgorithm : int
         {
@@ -359,8 +376,10 @@ namespace BitTorrent
         void setDiskQueueSize(qint64 size);
         DiskIOType diskIOType() const;
         void setDiskIOType(DiskIOType type);
-        bool useOSCache() const;
-        void setUseOSCache(bool use);
+        DiskIOReadMode diskIOReadMode() const;
+        void setDiskIOReadMode(DiskIOReadMode mode);
+        DiskIOWriteMode diskIOWriteMode() const;
+        void setDiskIOWriteMode(DiskIOWriteMode mode);
         bool isCoalesceReadWriteEnabled() const;
         void setCoalesceReadWriteEnabled(bool enabled);
         bool usePieceExtentAffinity() const;
@@ -687,7 +706,8 @@ namespace BitTorrent
         CachedSettingValue<int> m_diskCacheTTL;
         CachedSettingValue<qint64> m_diskQueueSize;
         CachedSettingValue<DiskIOType> m_diskIOType;
-        CachedSettingValue<bool> m_useOSCache;
+        CachedSettingValue<DiskIOReadMode> m_diskIOReadMode;
+        CachedSettingValue<DiskIOWriteMode> m_diskIOWriteMode;
         CachedSettingValue<bool> m_coalesceReadWriteEnabled;
         CachedSettingValue<bool> m_usePieceExtentAffinity;
         CachedSettingValue<bool> m_isSuggestMode;

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -114,7 +114,8 @@ namespace
 #ifdef QBT_USES_LIBTORRENT2
         DISK_IO_TYPE,
 #endif
-        OS_CACHE,
+        DISK_IO_READ_MODE,
+        DISK_IO_WRITE_MODE,
 #ifndef QBT_USES_LIBTORRENT2
         COALESCE_RW,
 #endif
@@ -208,8 +209,10 @@ void AdvancedSettings::saveAdvancedSettings() const
 #ifdef QBT_USES_LIBTORRENT2
     session->setDiskIOType(m_comboBoxDiskIOType.currentData().value<BitTorrent::DiskIOType>());
 #endif
-    // Enable OS cache
-    session->setUseOSCache(m_checkBoxOsCache.isChecked());
+    // Disk IO read mode
+    session->setDiskIOReadMode(m_comboBoxDiskIOReadMode.currentData().value<BitTorrent::DiskIOReadMode>());
+    // Disk IO write mode
+    session->setDiskIOWriteMode(m_comboBoxDiskIOWriteMode.currentData().value<BitTorrent::DiskIOWriteMode>());
 #ifndef QBT_USES_LIBTORRENT2
     // Coalesce reads & writes
     session->setCoalesceReadWriteEnabled(m_checkBoxCoalesceRW.isChecked());
@@ -508,10 +511,21 @@ void AdvancedSettings::loadAdvancedSettings()
     addRow(DISK_IO_TYPE, tr("Disk IO type (requires restart)") + u' ' + makeLink(u"https://www.libtorrent.org/single-page-ref.html#default-disk-io-constructor", u"(?)")
            , &m_comboBoxDiskIOType);
 #endif
-    // Enable OS cache
-    m_checkBoxOsCache.setChecked(session->useOSCache());
-    addRow(OS_CACHE, (tr("Enable OS cache") + u' ' + makeLink(u"https://www.libtorrent.org/reference-Settings.html#disk_io_write_mode", u"(?)"))
-            , &m_checkBoxOsCache);
+    // Disk IO read mode
+    m_comboBoxDiskIOReadMode.addItem(tr("Disable OS cache"), QVariant::fromValue(BitTorrent::DiskIOReadMode::DisableOSCache));
+    m_comboBoxDiskIOReadMode.addItem(tr("Enable OS cache"), QVariant::fromValue(BitTorrent::DiskIOReadMode::EnableOSCache));
+    m_comboBoxDiskIOReadMode.setCurrentIndex(m_comboBoxDiskIOReadMode.findData(QVariant::fromValue(session->diskIOReadMode())));
+    addRow(DISK_IO_READ_MODE, (tr("Disk IO read mode") + u' ' + makeLink(u"https://www.libtorrent.org/reference-Settings.html#disk_io_read_mode", u"(?)"))
+            , &m_comboBoxDiskIOReadMode);
+    // Disk IO write mode
+    m_comboBoxDiskIOWriteMode.addItem(tr("Disable OS cache"), QVariant::fromValue(BitTorrent::DiskIOWriteMode::DisableOSCache));
+    m_comboBoxDiskIOWriteMode.addItem(tr("Enable OS cache"), QVariant::fromValue(BitTorrent::DiskIOWriteMode::EnableOSCache));
+#ifdef QBT_USES_LIBTORRENT2
+    m_comboBoxDiskIOWriteMode.addItem(tr("Write-through"), QVariant::fromValue(BitTorrent::DiskIOWriteMode::WriteThrough));
+#endif
+    m_comboBoxDiskIOWriteMode.setCurrentIndex(m_comboBoxDiskIOWriteMode.findData(QVariant::fromValue(session->diskIOWriteMode())));
+    addRow(DISK_IO_WRITE_MODE, (tr("Disk IO write mode") + u' ' + makeLink(u"https://www.libtorrent.org/reference-Settings.html#disk_io_write_mode", u"(?)"))
+            , &m_comboBoxDiskIOWriteMode);
 #ifndef QBT_USES_LIBTORRENT2
     // Coalesce reads & writes
     m_checkBoxCoalesceRW.setChecked(session->isCoalesceReadWriteEnabled());

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -71,7 +71,7 @@ private:
               m_checkBoxConfirmTorrentRecheck, m_checkBoxConfirmRemoveAllTags, m_checkBoxAnnounceAllTrackers, m_checkBoxAnnounceAllTiers,
               m_checkBoxMultiConnectionsPerIp, m_checkBoxValidateHTTPSTrackerCertificate, m_checkBoxSSRFMitigation, m_checkBoxBlockPeersOnPrivilegedPorts, m_checkBoxPieceExtentAffinity,
               m_checkBoxSuggestMode, m_checkBoxSpeedWidgetEnabled, m_checkBoxIDNSupport;
-    QComboBox m_comboBoxInterface, m_comboBoxInterfaceAddress, m_comboBoxUtpMixedMode, m_comboBoxChokingAlgorithm,
+    QComboBox m_comboBoxInterface, m_comboBoxInterfaceAddress, m_comboBoxDiskIOReadMode, m_comboBoxDiskIOWriteMode, m_comboBoxUtpMixedMode, m_comboBoxChokingAlgorithm,
               m_comboBoxSeedChokingAlgorithm, m_comboBoxResumeDataStorage;
     QLineEdit m_lineEditAnnounceIP;
 

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -324,8 +324,10 @@ void AppController::preferencesAction()
     data[u"disk_queue_size"_qs] = session->diskQueueSize();
     // Disk IO Type
     data[u"disk_io_type"_qs] = static_cast<int>(session->diskIOType());
-    // Enable OS cache
-    data[u"enable_os_cache"_qs] = session->useOSCache();
+    // Disk IO read mode
+    data[u"disk_io_read_mode"_qs] = static_cast<int>(session->diskIOReadMode());
+    // Disk IO write mode
+    data[u"disk_io_write_mode"_qs] = static_cast<int>(session->diskIOWriteMode());
     // Coalesce reads & writes
     data[u"enable_coalesce_read_write"_qs] = session->isCoalesceReadWriteEnabled();
     // Piece Extent Affinity
@@ -817,9 +819,12 @@ void AppController::setPreferencesAction()
     // Disk IO Type
     if (hasKey(u"disk_io_type"_qs))
         session->setDiskIOType(static_cast<BitTorrent::DiskIOType>(it.value().toInt()));
-    // Enable OS cache
-    if (hasKey(u"enable_os_cache"_qs))
-        session->setUseOSCache(it.value().toBool());
+    // Disk IO read mode
+    if (hasKey(u"disk_io_read_mode"_qs))
+        session->setDiskIOReadMode(static_cast<BitTorrent::DiskIOReadMode>(it.value().toInt()));
+    // Disk IO write mode
+    if (hasKey(u"disk_io_write_mode"_qs))
+        session->setDiskIOWriteMode(static_cast<BitTorrent::DiskIOWriteMode>(it.value().toInt()));
     // Coalesce reads & writes
     if (hasKey(u"enable_coalesce_read_write"_qs))
         session->setCoalesceReadWriteEnabled(it.value().toBool());

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1060,10 +1060,25 @@
             </tr>
             <tr>
                 <td>
-                    <label for="enableOSCache">QBT_TR(Enable OS cache:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#disk_io_write_mode" target="_blank">(?)</a></label>
+                    <label for="diskIOReadMode">QBT_TR(Disk IO read mode:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#disk_io_read_mode" target="_blank">(?)</a></label>
                 </td>
                 <td>
-                    <input type="checkbox" id="enableOSCache" />
+                    <select id="diskIOReadMode" style="width: 15em;">
+                        <option value="0">QBT_TR(Disable OS cache)QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="1">QBT_TR(Enable OS cache)QBT_TR[CONTEXT=OptionsDialog]</option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <label for="diskIOWriteMode">QBT_TR(Disk IO write mode:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#disk_io_write_mode" target="_blank">(?)</a></label>
+                </td>
+                <td>
+                    <select id="diskIOWriteMode" style="width: 15em;">
+                        <option value="0">QBT_TR(Disable OS cache)QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="1">QBT_TR(Enable OS cache)QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="2">QBT_TR(Write-through (requires libtorrent >= 2.0.6))QBT_TR[CONTEXT=OptionsDialog]</option>
+                    </select>
                 </td>
             </tr>
             <tr>
@@ -2003,7 +2018,8 @@
                         $('diskCacheExpiryInterval').setProperty('value', pref.disk_cache_ttl);
                         $('diskQueueSize').setProperty('value', (pref.disk_queue_size / 1024));
                         $('diskIOType').setProperty('value', pref.disk_io_type);
-                        $('enableOSCache').setProperty('checked', pref.enable_os_cache);
+                        $('diskIOReadMode').setProperty('value', pref.disk_io_read_mode);
+                        $('diskIOWriteMode').setProperty('value', pref.disk_io_write_mode);
                         $('coalesceReadsAndWrites').setProperty('checked', pref.enable_coalesce_read_write);
                         $('pieceExtentAffinity').setProperty('checked', pref.enable_piece_extent_affinity);
                         $('sendUploadPieceSuggestions').setProperty('checked', pref.enable_upload_suggestions);
@@ -2409,7 +2425,8 @@
             settings.set('disk_cache_ttl', $('diskCacheExpiryInterval').getProperty('value'));
             settings.set('disk_queue_size', ($('diskQueueSize').getProperty('value') * 1024));
             settings.set('disk_io_type', $('diskIOType').getProperty('value'));
-            settings.set('enable_os_cache', $('enableOSCache').getProperty('checked'));
+            settings.set('disk_io_read_mode', $('diskIOReadMode').getProperty('value'));
+            settings.set('disk_io_write_mode', $('diskIOWriteMode').getProperty('value'));
             settings.set('enable_coalesce_read_write', $('coalesceReadsAndWrites').getProperty('checked'));
             settings.set('enable_piece_extent_affinity', $('pieceExtentAffinity').getProperty('checked'));
             settings.set('enable_upload_suggestions', $('sendUploadPieceSuggestions').getProperty('checked'));


### PR DESCRIPTION
* Bump libtorrent requirements to 2.0.6
* Split the OS cache settings into Disk IO read/write modes