### PR TITLE
Prevent tray menu from being accessed after destruction

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -50,6 +50,7 @@
 #include <QProcess>
 
 #ifndef DISABLE_GUI
+#include <QMenu>
 #include <QMessageBox>
 #include <QPixmapCache>
 #ifdef Q_OS_WIN
@@ -973,6 +974,14 @@ void Application::cleanup()
     LogMsg(tr("qBittorrent termination initiated"));
 
 #ifndef DISABLE_GUI
+    if (m_desktopIntegration)
+    {
+        m_desktopIntegration->disconnect();
+        m_desktopIntegration->setToolTip(tr("qBittorrent is shutting down..."));
+        if (m_desktopIntegration->menu())
+            m_desktopIntegration->menu()->setEnabled(false);
+    }
+
     if (m_window)
     {
         // Hide the window and don't leave it on screen as

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -481,6 +481,7 @@ MainWindow::MainWindow(IGUIApplication *app, QWidget *parent)
 
 MainWindow::~MainWindow()
 {
+    app()->desktopIntegration()->setMenu(nullptr);
     delete m_ui;
 }
 
@@ -1170,11 +1171,6 @@ void MainWindow::closeEvent(QCloseEvent *e)
                 Preferences::instance()->setConfirmOnExit(false);
         }
     }
-
-    // Disable some UI to prevent user interactions
-    app()->desktopIntegration()->disconnect();
-    app()->desktopIntegration()->setToolTip(tr("qBittorrent is shutting down..."));
-    app()->desktopIntegration()->menu()->setEnabled(false);
 
     // Accept exit
     e->accept();


### PR DESCRIPTION
Fixes regression of #17313.
Also moves some logic to appropriate place.
