### PR TITLE
Fix reply data can't be decompressed correctly

### DIFF
--- a/src/base/net/downloadhandlerimpl.cpp
+++ b/src/base/net/downloadhandlerimpl.cpp
@@ -37,7 +37,7 @@
 #include "base/utils/io.h"
 #include "base/utils/misc.h"
 
-#if (QT_VERSION < QT_VERSION_CHECK(6, 3, 0))
+#ifdef QT_NO_COMPRESS
 #include "base/utils/gzip.h"
 #endif
 
@@ -124,12 +124,12 @@ void DownloadHandlerImpl::processFinishedDownload()
     }
 
     // Success
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 3, 0))
-    m_result.data = m_reply->readAll();
-#else
+#ifdef QT_NO_COMPRESS
     m_result.data = (m_reply->rawHeader("Content-Encoding") == "gzip")
                     ? Utils::Gzip::decompress(m_reply->readAll())
                     : m_reply->readAll();
+#else
+    m_result.data = m_reply->readAll();
 #endif
 
     if (m_downloadRequest.saveToFile())

--- a/src/base/net/downloadmanager.cpp
+++ b/src/base/net/downloadmanager.cpp
@@ -123,8 +123,12 @@ namespace
 
         // Spoof HTTP Referer to allow adding torrent link from Torcache/KickAssTorrents
         request.setRawHeader("Referer", request.url().toEncoded().data());
-        // Accept gzip
+#ifdef QT_NO_COMPRESS
+        // The macro "QT_NO_COMPRESS" defined in QT will disable the zlib releated features
+        // and reply data auto-decompression in QT will also be disabled. But we can support
+        // gzip encoding and manually decompress the reply data.
         request.setRawHeader("Accept-Encoding", "gzip");
+#endif
         // Qt doesn't support Magnet protocol so we need to handle redirections manually
         request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::ManualRedirectPolicy);
 


### PR DESCRIPTION
Fix #17420
Relate to #17120

Let QT handle the reply data if compression/decompression is support.

Test with QT 6.3.1 and 5.15.5. ~~May need some tests if `-no-zlib` is set when QT is complied.~~