### PR TITLE
Don't merge trackers by default

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -2502,32 +2502,7 @@ bool Session::addTorrent_impl(const std::variant<MagnetUri, TorrentInfo> &source
 
     TorrentImpl *const torrent = m_torrents.value(id);
     if (torrent)
-    {  // a duplicate torrent is added
-        if (torrent->isPrivate())
-            return false;
-
-        if (hasMetadata)
-        {
-            const TorrentInfo &torrentInfo = std::get<TorrentInfo>(source);
-
-            if (torrentInfo.isPrivate())
-                return false;
-
-            // merge trackers and web seeds
-            torrent->addTrackers(torrentInfo.trackers());
-            torrent->addUrlSeeds(torrentInfo.urlSeeds());
-        }
-        else
-        {
-            const MagnetUri &magnetUri = std::get<MagnetUri>(source);
-
-            // merge trackers and web seeds
-            torrent->addTrackers(magnetUri.trackers());
-            torrent->addUrlSeeds(magnetUri.urlSeeds());
-        }
-
-        return true;
-    }
+        return false;
 
     LoadTorrentParams loadTorrentParams = initLoadTorrentParams(addTorrentParams);
     lt::add_torrent_params &p = loadTorrentParams.ltAddTorrentParams;

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -437,19 +437,25 @@ bool AddNewTorrentDialog::loadTorrentImpl()
         {
             if (torrent->isPrivate() || m_torrentInfo.isPrivate())
             {
-                RaisedMessageBox::warning(this, tr("Torrent is already present"), tr("Torrent '%1' is already in the transfer list. Trackers haven't been merged because it is a private torrent.").arg(torrent->name()), QMessageBox::Ok);
+                RaisedMessageBox::warning(this, tr("Torrent is already present"), tr("Torrent '%1' is already in the transfer list. Trackers cannot be merged because it is a private torrent.").arg(torrent->name()), QMessageBox::Ok);
             }
             else
             {
-                torrent->addTrackers(m_torrentInfo.trackers());
-                torrent->addUrlSeeds(m_torrentInfo.urlSeeds());
-                RaisedMessageBox::information(this, tr("Torrent is already present"), tr("Torrent '%1' is already in the transfer list. Trackers have been merged.").arg(torrent->name()), QMessageBox::Ok);
+                const QMessageBox::StandardButton btn = RaisedMessageBox::question(this, tr("Torrent is already present")
+                        , tr("Torrent '%1' is already in the transfer list. Do you want to merge trackers from new source?").arg(torrent->name())
+                        , (QMessageBox::Yes | QMessageBox::No), QMessageBox::Yes);
+                if (btn == QMessageBox::Yes)
+                {
+                    torrent->addTrackers(m_torrentInfo.trackers());
+                    torrent->addUrlSeeds(m_torrentInfo.urlSeeds());
+                }
             }
         }
         else
         {
             RaisedMessageBox::information(this, tr("Torrent is already present"), tr("Torrent is already queued for processing."), QMessageBox::Ok);
         }
+
         return false;
     }
 
@@ -484,15 +490,21 @@ bool AddNewTorrentDialog::loadMagnet(const BitTorrent::MagnetUri &magnetUri)
             }
             else
             {
-                torrent->addTrackers(magnetUri.trackers());
-                torrent->addUrlSeeds(magnetUri.urlSeeds());
-                RaisedMessageBox::information(this, tr("Torrent is already present"), tr("Magnet link '%1' is already in the transfer list. Trackers have been merged.").arg(torrent->name()), QMessageBox::Ok);
+                const QMessageBox::StandardButton btn = RaisedMessageBox::question(this, tr("Torrent is already present")
+                        , tr("Torrent '%1' is already in the transfer list. Do you want to merge trackers from new source?").arg(torrent->name())
+                        , (QMessageBox::Yes | QMessageBox::No), QMessageBox::Yes);
+                if (btn == QMessageBox::Yes)
+                {
+                    torrent->addTrackers(magnetUri.trackers());
+                    torrent->addUrlSeeds(magnetUri.urlSeeds());
+                }
             }
         }
         else
         {
             RaisedMessageBox::information(this, tr("Torrent is already present"), tr("Magnet link is already queued for processing."), QMessageBox::Ok);
         }
+
         return false;
     }
 


### PR DESCRIPTION
When duplicate torrent is added don't merge trackers by default.
It doesn't seem like a good idea to perform such an action behind the scenes since the user can have deleted some trackers previously and then add the duplicated torrent by mistake.
<del>The GUI has been left untouched for now, because</del> it would be better not just to remove it from GUI, but to add some advanced tracker merge dialog, as requested by some users (a task for a separate PR). Currently simple confirmation dialog is shown to the user.