### PR TITLE
Revise Docker document

### DIFF
--- a/dist/docker/Readme.md
+++ b/dist/docker/Readme.md
@@ -4,9 +4,9 @@ This Dockerfile allows you to build a docker image containing qBittorrent-nox
 
 ## Prerequisites
 
-In order to build/run this image you'll need `docker` installed: https://docs.docker.com/get-docker/
+In order to build/run this image you'll need `docker` installed: https://docs.docker.com/engine/install/
 
-It is also recommended to install `docker-compose` as it can significantly ease the process: https://docs.docker.com/compose/install/
+It is also recommended to install `docker-compose-plugin` as it can significantly ease the process: https://docs.docker.com/compose/install/compose-plugin/
 
 ## Building docker image
 
@@ -51,7 +51,7 @@ There are some paths involved:
 
 ## Running container
 
-* Using docker (not docker-compose), simply run:
+* Using docker (not docker-compose-plugin), simply run:
   ```shell
   export \
     QBT_EULA=accept \
@@ -75,7 +75,7 @@ There are some paths involved:
     qbittorrent-nox:"$QBT_VERSION"
   ```
 
-* Using docker-compose:
+* Using docker-compose-plugin:
   ```shell
   docker compose up
   ```

--- a/dist/docker/Readme.md
+++ b/dist/docker/Readme.md
@@ -51,7 +51,7 @@ There are some paths involved:
 
 ## Running container
 
-* Using docker (not docker-compose-plugin), simply run:
+* Using docker (not Docker Compose), simply run:
   ```shell
   export \
     QBT_EULA=accept \
@@ -75,7 +75,7 @@ There are some paths involved:
     qbittorrent-nox:"$QBT_VERSION"
   ```
 
-* Using docker-compose-plugin:
+* Using Docker Compose:
   ```shell
   docker compose up
   ```

--- a/dist/docker/Readme.md
+++ b/dist/docker/Readme.md
@@ -4,11 +4,11 @@ This Dockerfile allows you to build a docker image containing qBittorrent-nox
 
 ## Prerequisites
 
-In order to build/run this image you'll need `docker` installed: https://docs.docker.com/get-docker/
+In order to build/run this image you'll need Docker installed: https://docs.docker.com/get-docker/
 
 If you don't need the GUI, you can just install Docker Engine: https://docs.docker.com/engine/install/
 
-It is also recommended to install `docker-compose-plugin` as it can significantly ease the process: https://docs.docker.com/compose/install/
+It is also recommended to install Docker Compose as it can significantly ease the process: https://docs.docker.com/compose/install/
 
 ## Building docker image
 

--- a/dist/docker/Readme.md
+++ b/dist/docker/Readme.md
@@ -84,12 +84,12 @@ Then you can login at: `http://127.0.0.1:8080`
 
 ## Stopping container
 
-* Using docker (not docker-compose):
+* Using docker (not Docker Compose):
   ```shell
   docker stop -t 1800 qbittorrent-nox
   ```
 
-* Using docker-compose:
+* Using Docker Compose:
   ```shell
   docker compose down
   ```

--- a/dist/docker/Readme.md
+++ b/dist/docker/Readme.md
@@ -1,6 +1,6 @@
 # qBittorrent-nox Docker Image
 
-This Dockerfile allows you to build a docker image containing qBittorrent-nox
+This Dockerfile allows you to build a Docker Image containing qBittorrent-nox
 
 ## Prerequisites
 
@@ -10,9 +10,9 @@ If you don't need the GUI, you can just install Docker Engine: https://docs.dock
 
 It is also recommended to install Docker Compose as it can significantly ease the process: https://docs.docker.com/compose/install/
 
-## Building docker image
+## Building Docker Image
 
-* If you are using docker (not docker-compose) then run the following commands in this folder:
+* If you are using Docker (not Docker Compose) then run the following commands in this folder:
   ```shell
   export \
     QBT_VERSION=devel
@@ -22,7 +22,7 @@ It is also recommended to install Docker Compose as it can significantly ease th
     .
   ```
 
-* If you are using docker-compose then you should edit `.env` file first.
+* If you are using Docker Compose then you should edit `.env` file first.
   You can find an explanation of the variables in the following [Parameters](#parameters) section. \
   Then run the following commands in this folder:
   ```shell
@@ -53,7 +53,7 @@ There are some paths involved:
 
 ## Running container
 
-* Using docker (not Docker Compose), simply run:
+* Using Docker (not Docker Compose), simply run:
   ```shell
   export \
     QBT_EULA=accept \
@@ -86,7 +86,7 @@ Then you can login at: `http://127.0.0.1:8080`
 
 ## Stopping container
 
-* Using docker (not Docker Compose):
+* Using Docker (not Docker Compose):
   ```shell
   docker stop -t 1800 qbittorrent-nox
   ```

--- a/dist/docker/Readme.md
+++ b/dist/docker/Readme.md
@@ -4,9 +4,11 @@ This Dockerfile allows you to build a docker image containing qBittorrent-nox
 
 ## Prerequisites
 
-In order to build/run this image you'll need `docker` installed: https://docs.docker.com/engine/install/
+In order to build/run this image you'll need `docker` installed: https://docs.docker.com/get-docker/
 
-It is also recommended to install `docker-compose-plugin` as it can significantly ease the process: https://docs.docker.com/compose/install/compose-plugin/
+If you don't need the GUI, you can just install Docker Engine: https://docs.docker.com/engine/install/
+
+It is also recommended to install `docker-compose-plugin` as it can significantly ease the process: https://docs.docker.com/compose/install/
 
 ## Building docker image
 


### PR DESCRIPTION
Currently Docker Inc. recommends installing Docker Desktop instead of the CLI.

`docker-compose` has been deprecated, replaced by `docker compose`.