### PR TITLE
Fix empty string parameter was omitted

### DIFF
--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -527,7 +527,7 @@ QString makeUsage(const QString &prgName)
     const QString indentation {USAGE_INDENTATION, u' '};
 
     const QString text = QObject::tr("Usage:") + u'\n'
-        + indentation + prgName + u" [options] [(<filename> | <url>)...]" + u'\n'
+        + indentation + prgName + u' ' + QObject::tr("[options] [(<filename> | <url>)...]") + u'\n'
 
         + QObject::tr("Options:") + u'\n'
 #if !defined(Q_OS_WIN) || defined(DISABLE_GUI)

--- a/src/base/utils/string.cpp
+++ b/src/base/utils/string.cpp
@@ -33,6 +33,7 @@
 
 #include <QLocale>
 #include <QRegularExpression>
+#include <QStringList>
 #include <QVector>
 
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
@@ -75,6 +76,42 @@ QString Utils::String::wildcardToRegexPattern(const QString &pattern)
     return qt_regexp_toCanonical(escapedPattern, QRegExp::Wildcard);
 }
 #endif
+
+QStringList Utils::String::splitCommand(const QString &command)
+{
+    QStringList ret;
+    ret.reserve(32);
+
+    bool inQuotes = false;
+    QString tmp;
+    for (const QChar c : command)
+    {
+        if (c == u' ')
+        {
+            if (!inQuotes)
+            {
+                if (!tmp.isEmpty())
+                {
+                    ret.append(tmp);
+                    tmp.clear();
+                }
+
+                continue;
+            }
+        }
+        else if (c == u'"')
+        {
+            inQuotes = !inQuotes;
+        }
+
+        tmp.append(c);
+    }
+
+    if (!tmp.isEmpty())
+        ret.append(tmp);
+
+    return ret;
+}
 
 std::optional<bool> Utils::String::parseBool(const QString &string)
 {

--- a/src/base/utils/string.h
+++ b/src/base/utils/string.h
@@ -61,6 +61,8 @@ namespace Utils::String
     std::optional<int> parseInt(const QString &string);
     std::optional<double> parseDouble(const QString &string);
 
+    QStringList splitCommand(const QString &command);
+
     QString join(const QList<QStringView> &strings, QStringView separator);
 
     QString fromDouble(double n, int precision);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ set(testFiles
     testorderedset.cpp
     testutilscompare.cpp
     testutilsgzip.cpp
+    testutilsstring.cpp
 )
 foreach(testFile ${testFiles})
     get_filename_component(testFilename "${testFile}" NAME_WLE)

--- a/test/testutilsstring.cpp
+++ b/test/testutilsstring.cpp
@@ -1,0 +1,59 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2022  Mike Tzou (Chocobo1)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include <QTest>
+
+#include "base/global.h"
+#include "base/utils/string.h"
+
+class TestUtilsString final : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(TestUtilsString)
+
+public:
+    TestUtilsString() = default;
+
+private slots:
+    void testSplitCommand() const
+    {
+        QCOMPARE(Utils::String::splitCommand({}), {});
+        QCOMPARE(Utils::String::splitCommand(u""_qs), {});
+        QCOMPARE(Utils::String::splitCommand(u"  "_qs), {});
+        QCOMPARE(Utils::String::splitCommand(uR"("")"_qs), {uR"("")"_qs});
+        QCOMPARE(Utils::String::splitCommand(uR"(" ")"_qs), {uR"(" ")"_qs});
+        QCOMPARE(Utils::String::splitCommand(u"\"\"\""_qs), {u"\"\"\""_qs});
+        QCOMPARE(Utils::String::splitCommand(uR"(" """)"_qs), {uR"(" """)"_qs});
+        QCOMPARE(Utils::String::splitCommand(u" app a b c  "_qs), QStringList({u"app"_qs, u"a"_qs, u"b"_qs, u"c"_qs}));
+        QCOMPARE(Utils::String::splitCommand(u"   cmd.exe /d --arg2 \"arg3\" \"\" arg5 \"\"arg6 \"arg7 "_qs)
+            , QStringList({u"cmd.exe"_qs, u"/d"_qs, u"--arg2"_qs, u"\"arg3\""_qs, u"\"\""_qs, u"arg5"_qs, u"\"\"arg6"_qs, u"\"arg7 "_qs}));
+    }
+};
+
+QTEST_APPLESS_MAIN(TestUtilsString)
+#include "testutilsstring.moc"


### PR DESCRIPTION
* Translate app help text
* Fix empty string parameter was omitted
  `QProcess::splitCommand()` will omit empty strings like `""` so provide
our own replacement.
  Closes #13124.