### PR TITLE
Cache the network interface GUID on Windows

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -82,6 +82,10 @@ enum DeleteOption
     DeleteTorrentAndFiles
 };
 
+#ifdef Q_OS_WIN
+QString m_interfaceGUID;
+#endif
+
 namespace Net
 {
     struct DownloadResult;


### PR DESCRIPTION
qBt may start earlier than the VPN/Network interface and some interfaces(WAN miniports, IKEv2 VPN etc) do not have a GUID when they're disconnected. So we attempt to cache this value to restore network connection when the interface is available again.
Closes https://github.com/qbittorrent/qBittorrent/issues/13154