### PR TITLE
Fill in initial data in `add_torrent_alert` handler

### DIFF
--- a/src/base/bittorrent/nativesessionextension.cpp
+++ b/src/base/bittorrent/nativesessionextension.cpp
@@ -35,6 +35,26 @@
 
 namespace
 {
+    void handleAddTorrentAlert(const lt::add_torrent_alert *alert)
+    {
+#ifndef QBT_USES_LIBTORRENT2
+        if (alert->error)
+            return;
+
+        // libtorrent < 2.0.7 has a bug that add_torrent_alert is posted too early
+        // (before torrent is fully initialized and torrent extensions are created)
+        // so we have to fill "extension data" in add_torrent_alert handler
+
+        // NOTE: `data` may not exist if a torrent is added behind the scenes to download metadata
+        auto *data = static_cast<ExtensionData *>(alert->params.userdata);
+        if (data)
+        {
+            data->status = alert->handle.status({});
+            data->trackers = alert->handle.trackers();
+        }
+#endif
+    }
+
     void handleFastresumeRejectedAlert(const lt::fastresume_rejected_alert *alert)
     {
         alert->handle.unset_flags(lt::torrent_flags::auto_managed);
@@ -56,8 +76,13 @@ void NativeSessionExtension::on_alert(const lt::alert *alert)
 {
     switch (alert->type())
     {
+    case lt::add_torrent_alert::alert_type:
+        handleAddTorrentAlert(static_cast<const lt::add_torrent_alert *>(alert));
+        break;
     case lt::fastresume_rejected_alert::alert_type:
         handleFastresumeRejectedAlert(static_cast<const lt::fastresume_rejected_alert *>(alert));
+        break;
+    default:
         break;
     }
 }

--- a/src/base/bittorrent/nativetorrentextension.cpp
+++ b/src/base/bittorrent/nativetorrentextension.cpp
@@ -42,14 +42,22 @@ NativeTorrentExtension::NativeTorrentExtension(const lt::torrent_handle &torrent
     : m_torrentHandle {torrentHandle}
     , m_data {data}
 {
-    lt::torrent_status torrentStatus = m_torrentHandle.status({});
-    on_state(torrentStatus.state);
+    // NOTE: `data` may not exist if a torrent is added behind the scenes to download metadata
+
+#ifdef QBT_USES_LIBTORRENT2
+    // libtorrent < 2.0.7 has a bug that add_torrent_alert is posted too early
+    // (before torrent is fully initialized and torrent extensions are created)
+    // so we have to fill "extension data" in add_torrent_alert handler and
+    // we have it already filled at this point
 
     if (m_data)
     {
-        m_data->status = std::move(torrentStatus);
+        m_data->status = m_torrentHandle.status({});
         m_data->trackers = m_torrentHandle.trackers();
     }
+#endif
+
+    on_state(m_data ? m_data->status.state : m_torrentHandle.status({}).state);
 }
 
 NativeTorrentExtension::~NativeTorrentExtension()


### PR DESCRIPTION
libtorrent < 2.0.7 has a bug that `add_torrent_alert` is posted too early (before torrent is fully initialized and torrent extensions are created) so we have to fill initial torrent data in `add_torrent_alert` handler.
