### PR TITLE
Avoid race conditions between dialogs on startup

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -758,6 +758,24 @@ try
         const MainWindow::State windowState = (!m_startupProgressDialog || (m_startupProgressDialog->windowState() & Qt::WindowMinimized))
                 ? MainWindow::Minimized : MainWindow::Normal;
         m_window = new MainWindow(this, windowState);
+        delete m_startupProgressDialog;
+#ifdef Q_OS_WIN
+        auto *pref = Preferences::instance();
+        if (!pref->neverCheckFileAssoc() && (!Preferences::isTorrentFileAssocSet() || !Preferences::isMagnetLinkAssocSet()))
+        {
+            if (QMessageBox::question(m_window, tr("Torrent file association")
+                                      , tr("qBittorrent is not the default application for opening torrent files or Magnet links.\nDo you want to make qBittorrent the default application for these?")
+                                      , QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes) == QMessageBox::Yes)
+            {
+                pref->setTorrentFileAssoc(true);
+                pref->setMagnetLinkAssoc(true);
+            }
+            else
+            {
+                pref->setNeverCheckFileAssoc();
+            }
+        }
+#endif // Q_OS_WIN
 #endif // DISABLE_GUI
 
 #ifndef DISABLE_WEBUI
@@ -838,7 +856,6 @@ void Application::createStartupProgressDialog()
     });
 
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::startupProgressUpdated, m_startupProgressDialog, &QProgressDialog::setValue);
-    connect(BitTorrent::Session::instance(), &BitTorrent::Session::restored, m_startupProgressDialog, &QObject::deleteLater);
 
     connect(m_desktopIntegration, &DesktopIntegration::activationRequested, m_startupProgressDialog, [this]()
     {

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -754,10 +754,12 @@ try
         });
 
         disconnect(m_desktopIntegration, &DesktopIntegration::activationRequested, this, &Application::createStartupProgressDialog);
-        delete m_desktopIntegration->menu();
+        // we must not delete menu while it is used by DesktopIntegration
+        auto *oldMenu = m_desktopIntegration->menu();
         const MainWindow::State windowState = (!m_startupProgressDialog || (m_startupProgressDialog->windowState() & Qt::WindowMinimized))
                 ? MainWindow::Minimized : MainWindow::Normal;
         m_window = new MainWindow(this, windowState);
+        delete oldMenu;
         delete m_startupProgressDialog;
 #ifdef Q_OS_WIN
         auto *pref = Preferences::instance();

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -460,22 +460,6 @@ MainWindow::MainWindow(IGUIApplication *app, const State initialState)
     connect(pref, &Preferences::changed, this, &MainWindow::optionsSaved);
 
     qDebug("GUI Built");
-#ifdef Q_OS_WIN
-    if (!pref->neverCheckFileAssoc() && (!Preferences::isTorrentFileAssocSet() || !Preferences::isMagnetLinkAssocSet()))
-    {
-        if (QMessageBox::question(this, tr("Torrent file association"),
-                                  tr("qBittorrent is not the default application for opening torrent files or Magnet links.\nDo you want to make qBittorrent the default application for these?"),
-                                  QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes) == QMessageBox::Yes)
-                                  {
-            Preferences::setTorrentFileAssoc(true);
-            Preferences::setMagnetLinkAssoc(true);
-        }
-        else
-        {
-            pref->setNeverCheckFileAssoc();
-        }
-    }
-#endif
 }
 
 MainWindow::~MainWindow()


### PR DESCRIPTION
Fix possible crash during first run on Windows.
Also fix bug of incorrectly replaced desktop integration menu (reported in https://github.com/qbittorrent/qBittorrent/pull/17389#issuecomment-1207136347).