### PR TITLE
Fix qtbase_zh_CN.qm not loaded

### DIFF
--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -1297,6 +1297,12 @@ void OptionsDialog::initializeLanguageCombo()
             // QLocale doesn't work with that locale.
             languageName = C_LOCALE_LATGALIAN;
         }
+        else if (localeStr == "zh")
+        {
+            // Map zh to zh_CN so that qtbase_zh_CN.qm can be paired
+            localeStr = "zh_CN"
+            languageName = C_LOCALE_CHINESE_SIMPLIFIED;
+        }
         else
         {
             QLocale locale(localeStr);

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -1300,7 +1300,7 @@ void OptionsDialog::initializeLanguageCombo()
         else if (localeStr == "zh")
         {
             // Map zh to zh_CN so that qtbase_zh_CN.qm can be paired
-            localeStr = "zh_CN"
+            localeStr = "zh_CN";
             languageName = C_LOCALE_CHINESE_SIMPLIFIED;
         }
         else


### PR DESCRIPTION
Map `zh` to `zh_CN` when populating the combo box, so that `qtbase_zh_CN.qm` can be paired and loaded correctly on next run.

You can either rename the language `zh` to `zh_CN` on transifex, and update the translation file name to `qbittorrent_zh_CN.ts`. That will resolve the issue as well.

Closes #17506.