### PR TITLE
Handle some torrent conflicts

### DIFF
--- a/src/base/bittorrent/infohash.cpp
+++ b/src/base/bittorrent/infohash.cpp
@@ -50,6 +50,15 @@ bool BitTorrent::InfoHash::isValid() const
     return m_valid;
 }
 
+bool BitTorrent::InfoHash::isHybrid() const
+{
+#ifdef QBT_USES_LIBTORRENT2
+    return (m_nativeHash.has_v1() && m_nativeHash.has_v2());
+#else
+    return false;
+#endif
+}
+
 SHA1Hash BitTorrent::InfoHash::v1() const
 {
 #ifdef QBT_USES_LIBTORRENT2
@@ -84,12 +93,22 @@ BitTorrent::InfoHash::operator WrappedType() const
 
 BitTorrent::TorrentID BitTorrent::TorrentID::fromString(const QString &hashString)
 {
-    return {BaseType::fromString(hashString)};
+    return TorrentID(BaseType::fromString(hashString));
 }
 
 BitTorrent::TorrentID BitTorrent::TorrentID::fromInfoHash(const BitTorrent::InfoHash &infoHash)
 {
     return infoHash.toTorrentID();
+}
+
+BitTorrent::TorrentID BitTorrent::TorrentID::fromSHA1Hash(const SHA1Hash &hash)
+{
+    return TorrentID(hash);
+}
+
+BitTorrent::TorrentID BitTorrent::TorrentID::fromSHA256Hash(const SHA256Hash &hash)
+{
+    return BaseType::UnderlyingType(static_cast<typename SHA256Hash::UnderlyingType>(hash).data());
 }
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))

--- a/src/base/bittorrent/infohash.h
+++ b/src/base/bittorrent/infohash.h
@@ -52,6 +52,8 @@ namespace BitTorrent
 
         static TorrentID fromString(const QString &hashString);
         static TorrentID fromInfoHash(const InfoHash &infoHash);
+        static TorrentID fromSHA1Hash(const SHA1Hash &hash);
+        static TorrentID fromSHA256Hash(const SHA256Hash &hash);
     };
 
     class InfoHash
@@ -70,6 +72,7 @@ namespace BitTorrent
 #endif
 
         bool isValid() const;
+        bool isHybrid() const;
         SHA1Hash v1() const;
         SHA256Hash v2() const;
         TorrentID toTorrentID() const;

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -2004,6 +2004,13 @@ void TorrentImpl::handleMetadataReceivedAlert(const lt::metadata_received_alert 
     Q_UNUSED(p);
     qDebug("Metadata received for torrent %s.", qUtf8Printable(name()));
 
+#ifdef QBT_USES_LIBTORRENT2
+    const TorrentID prevTorrentID = id();
+    m_infoHash = InfoHash(m_nativeHandle.info_hashes());
+    if (prevTorrentID != id())
+        m_session->handleTorrentIDChanged(this, prevTorrentID);
+#endif
+
     m_maintenanceJob = MaintenanceJob::HandleMetadata;
     m_session->handleTorrentNeedSaveResumeData(this);
 }

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -427,12 +427,12 @@ bool AddNewTorrentDialog::loadTorrentFile(const QString &source)
 
 bool AddNewTorrentDialog::loadTorrentImpl()
 {
-    const auto torrentID = BitTorrent::TorrentID::fromInfoHash(m_torrentInfo.infoHash());
+    const BitTorrent::InfoHash infoHash = m_torrentInfo.infoHash();
 
     // Prevent showing the dialog if download is already present
-    if (BitTorrent::Session::instance()->isKnownTorrent(torrentID))
+    if (BitTorrent::Session::instance()->isKnownTorrent(infoHash))
     {
-        BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->findTorrent(torrentID);
+        BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->findTorrent(infoHash);
         if (torrent)
         {
             // Trying to set metadata to existing torrent in case if it has none
@@ -480,11 +480,12 @@ bool AddNewTorrentDialog::loadMagnet(const BitTorrent::MagnetUri &magnetUri)
 
     m_torrentGuard = std::make_unique<TorrentFileGuard>();
 
-    const auto torrentID = BitTorrent::TorrentID::fromInfoHash(magnetUri.infoHash());
+    const BitTorrent::InfoHash infoHash = magnetUri.infoHash();
+
     // Prevent showing the dialog if download is already present
-    if (BitTorrent::Session::instance()->isKnownTorrent(torrentID))
+    if (BitTorrent::Session::instance()->isKnownTorrent(infoHash))
     {
-        BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->findTorrent(torrentID);
+        BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->findTorrent(infoHash);
         if (torrent)
         {
             if (torrent->isPrivate())

--- a/src/gui/torrentoptionsdialog.cpp
+++ b/src/gui/torrentoptionsdialog.cpp
@@ -411,7 +411,7 @@ void TorrentOptionsDialog::accept()
     auto *session = BitTorrent::Session::instance();
     for (const BitTorrent::TorrentID &id : asConst(m_torrentIDs))
     {
-        BitTorrent::Torrent *torrent = session->findTorrent(id);
+        BitTorrent::Torrent *torrent = session->getTorrent(id);
         if (!torrent) continue;
 
         if (m_initialValues.autoTMM != m_ui->checkAutoTMM->checkState())

--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -536,7 +536,7 @@ void SyncController::maindataAction()
 void SyncController::torrentPeersAction()
 {
     const auto id = BitTorrent::TorrentID::fromString(params()[u"hash"_qs]);
-    const BitTorrent::Torrent *torrent = BitTorrent::Session::instance()->findTorrent(id);
+    const BitTorrent::Torrent *torrent = BitTorrent::Session::instance()->getTorrent(id);
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -133,7 +133,7 @@ namespace
             for (const QString &idString : idList)
             {
                 const auto hash = BitTorrent::TorrentID::fromString(idString);
-                BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->findTorrent(hash);
+                BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(hash);
                 if (torrent)
                     func(torrent);
             }
@@ -392,7 +392,7 @@ void TorrentsController::propertiesAction()
     requireParams({u"hash"_qs});
 
     const auto id = BitTorrent::TorrentID::fromString(params()[u"hash"_qs]);
-    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->findTorrent(id);
+    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(id);
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 
@@ -466,7 +466,7 @@ void TorrentsController::trackersAction()
     requireParams({u"hash"_qs});
 
     const auto id = BitTorrent::TorrentID::fromString(params()[u"hash"_qs]);
-    const BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->findTorrent(id);
+    const BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(id);
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 
@@ -499,7 +499,7 @@ void TorrentsController::webseedsAction()
     requireParams({u"hash"_qs});
 
     const auto id = BitTorrent::TorrentID::fromString(params()[u"hash"_qs]);
-    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->findTorrent(id);
+    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(id);
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 
@@ -531,7 +531,7 @@ void TorrentsController::filesAction()
     requireParams({u"hash"_qs});
 
     const auto id = BitTorrent::TorrentID::fromString(params()[u"hash"_qs]);
-    const BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->findTorrent(id);
+    const BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(id);
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 
@@ -600,7 +600,7 @@ void TorrentsController::pieceHashesAction()
     requireParams({u"hash"_qs});
 
     const auto id = BitTorrent::TorrentID::fromString(params()[u"hash"_qs]);
-    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->findTorrent(id);
+    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(id);
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 
@@ -625,7 +625,7 @@ void TorrentsController::pieceStatesAction()
     requireParams({u"hash"_qs});
 
     const auto id = BitTorrent::TorrentID::fromString(params()[u"hash"_qs]);
-    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->findTorrent(id);
+    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(id);
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 
@@ -741,7 +741,7 @@ void TorrentsController::addTrackersAction()
     requireParams({u"hash"_qs, u"urls"_qs});
 
     const auto id = BitTorrent::TorrentID::fromString(params()[u"hash"_qs]);
-    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->findTorrent(id);
+    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(id);
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 
@@ -763,7 +763,7 @@ void TorrentsController::editTrackerAction()
     const QString origUrl = params()[u"origUrl"_qs];
     const QString newUrl = params()[u"newUrl"_qs];
 
-    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->findTorrent(id);
+    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(id);
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 
@@ -801,7 +801,7 @@ void TorrentsController::removeTrackersAction()
     requireParams({u"hash"_qs, u"urls"_qs});
 
     const auto id = BitTorrent::TorrentID::fromString(params()[u"hash"_qs]);
-    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->findTorrent(id);
+    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(id);
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 
@@ -879,7 +879,7 @@ void TorrentsController::filePrioAction()
     if (!BitTorrent::isValidDownloadPriority(priority))
         throw APIError(APIErrorType::BadParams, tr("Priority is not valid"));
 
-    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->findTorrent(id);
+    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(id);
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
     if (!torrent->hasMetadata())
@@ -916,7 +916,7 @@ void TorrentsController::uploadLimitAction()
     for (const QString &id : idList)
     {
         int limit = -1;
-        const BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->findTorrent(BitTorrent::TorrentID::fromString(id));
+        const BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(BitTorrent::TorrentID::fromString(id));
         if (torrent)
             limit = torrent->uploadLimit();
         map[id] = limit;
@@ -934,7 +934,7 @@ void TorrentsController::downloadLimitAction()
     for (const QString &id : idList)
     {
         int limit = -1;
-        const BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->findTorrent(BitTorrent::TorrentID::fromString(id));
+        const BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(BitTorrent::TorrentID::fromString(id));
         if (torrent)
             limit = torrent->downloadLimit();
         map[id] = limit;
@@ -1163,7 +1163,7 @@ void TorrentsController::renameAction()
     if (name.isEmpty())
         throw APIError(APIErrorType::Conflict, tr("Incorrect torrent name"));
 
-    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->findTorrent(id);
+    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(id);
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 
@@ -1363,7 +1363,7 @@ void TorrentsController::renameFileAction()
     requireParams({u"hash"_qs, u"oldPath"_qs, u"newPath"_qs});
 
     const auto id = BitTorrent::TorrentID::fromString(params()[u"hash"_qs]);
-    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->findTorrent(id);
+    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(id);
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 
@@ -1385,7 +1385,7 @@ void TorrentsController::renameFolderAction()
     requireParams({u"hash"_qs, u"oldPath"_qs, u"newPath"_qs});
 
     const auto id = BitTorrent::TorrentID::fromString(params()[u"hash"_qs]);
-    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->findTorrent(id);
+    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(id);
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 
@@ -1407,7 +1407,7 @@ void TorrentsController::exportAction()
     requireParams({u"hash"_qs});
 
     const auto id = BitTorrent::TorrentID::fromString(params()[u"hash"_qs]);
-    const BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->findTorrent(id);
+    const BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(id);
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 


### PR DESCRIPTION
Handle conflict when the same hybrid torrent is added twice by v1 and v2 info hashes (magnet links) separately (in fact, we cannot know that these hashes refer to the same torrent until the metadata is received).
Allow to find hybrid torrent previously added using v1 info hash (magnet link).
Update info hashes and torrent ID of hybrid torrent previously added using v1-only or v2-only info hash once metadata received.

P.S. Because of this mess that hybrid torrents have made, some more conflicts are possible. I'll try to deal with them next time (I'm tired of it now).