### PR TITLE
Use proper verb when referring to torrent removal

### DIFF
--- a/src/gui/categoryfilterwidget.cpp
+++ b/src/gui/categoryfilterwidget.cpp
@@ -134,7 +134,7 @@ void CategoryFilterWidget::showMenu()
         , this, &CategoryFilterWidget::actionResumeTorrentsTriggered);
     menu->addAction(UIThemeManager::instance()->getIcon(u"torrent-stop"_qs), tr("Pause torrents")
         , this, &CategoryFilterWidget::actionPauseTorrentsTriggered);
-    menu->addAction(UIThemeManager::instance()->getIcon(u"list-remove"_qs), tr("Delete torrents")
+    menu->addAction(UIThemeManager::instance()->getIcon(u"list-remove"_qs), tr("Remove torrents")
         , this, &CategoryFilterWidget::actionDeleteTorrentsTriggered);
 
     menu->popup(QCursor::pos());

--- a/src/gui/deletionconfirmationdialog.ui
+++ b/src/gui/deletionconfirmationdialog.ui
@@ -17,7 +17,7 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>Deletion confirmation</string>
+   <string>Remove torrent(s)</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
@@ -44,7 +44,7 @@
         </sizepolicy>
        </property>
        <property name="text">
-        <string notr="true">deletion message goes here</string>
+        <string notr="true">message goes here</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -208,7 +208,7 @@
   </action>
   <action name="actionDelete">
    <property name="text">
-    <string>&amp;Delete</string>
+    <string>&amp;Remove</string>
    </property>
   </action>
   <action name="actionDownloadFromURL">

--- a/src/gui/tagfilterwidget.cpp
+++ b/src/gui/tagfilterwidget.cpp
@@ -124,7 +124,7 @@ void TagFilterWidget::showMenu()
         , this, &TagFilterWidget::actionResumeTorrentsTriggered);
     menu->addAction(UIThemeManager::instance()->getIcon(u"torrent-stop"_qs), tr("Pause torrents")
         , this, &TagFilterWidget::actionPauseTorrentsTriggered);
-    menu->addAction(UIThemeManager::instance()->getIcon(u"list-remove"_qs), tr("Delete torrents")
+    menu->addAction(UIThemeManager::instance()->getIcon(u"list-remove"_qs), tr("Remove torrents")
         , this, &TagFilterWidget::actionDeleteTorrentsTriggered);
 
     menu->popup(QCursor::pos());

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -307,7 +307,7 @@ void StatusFilterWidget::showMenu()
         , transferList, &TransferListWidget::startVisibleTorrents);
     menu->addAction(UIThemeManager::instance()->getIcon(u"torrent-stop"_qs), tr("Pause torrents")
         , transferList, &TransferListWidget::pauseVisibleTorrents);
-    menu->addAction(UIThemeManager::instance()->getIcon(u"list-remove"_qs), tr("Delete torrents")
+    menu->addAction(UIThemeManager::instance()->getIcon(u"list-remove"_qs), tr("Remove torrents")
         , transferList, &TransferListWidget::deleteVisibleTorrents);
 
     menu->popup(QCursor::pos());
@@ -712,7 +712,7 @@ void TrackerFiltersList::showMenu()
         , transferList, &TransferListWidget::startVisibleTorrents);
     menu->addAction(UIThemeManager::instance()->getIcon(u"torrent-stop"_qs), tr("Pause torrents")
         , transferList, &TransferListWidget::pauseVisibleTorrents);
-    menu->addAction(UIThemeManager::instance()->getIcon(u"list-remove"_qs), tr("Delete torrents")
+    menu->addAction(UIThemeManager::instance()->getIcon(u"list-remove"_qs), tr("Remove torrents")
         , transferList, &TransferListWidget::deleteVisibleTorrents);
 
     menu->popup(QCursor::pos());

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -915,7 +915,7 @@ void TransferListWidget::displayListMenu()
     connect(actionPause, &QAction::triggered, this, &TransferListWidget::pauseSelectedTorrents);
     auto *actionForceStart = new QAction(UIThemeManager::instance()->getIcon(u"torrent-start-forced"_qs), tr("Force Resu&me", "Force Resume/start the torrent"), listMenu);
     connect(actionForceStart, &QAction::triggered, this, &TransferListWidget::forceStartSelectedTorrents);
-    auto *actionDelete = new QAction(UIThemeManager::instance()->getIcon(u"list-remove"_qs), tr("&Delete", "Delete the torrent"), listMenu);
+    auto *actionDelete = new QAction(UIThemeManager::instance()->getIcon(u"list-remove"_qs), tr("&Remove", "Remove the torrent"), listMenu);
     connect(actionDelete, &QAction::triggered, this, &TransferListWidget::softDeleteSelectedTorrents);
     auto *actionPreviewFile = new QAction(UIThemeManager::instance()->getIcon(u"view-preview"_qs), tr("Pre&view file..."), listMenu);
     connect(actionPreviewFile, &QAction::triggered, this, &TransferListWidget::previewSelectedTorrents);

--- a/src/webui/www/private/confirmdeletion.html
+++ b/src/webui/www/private/confirmdeletion.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(Deletion confirmation - qBittorrent)QBT_TR[CONTEXT=confirmDeletionDlg]</title>
+    <title>QBT_TR(Remove torrent(s))QBT_TR[CONTEXT=confirmDeletionDlg]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -61,7 +61,7 @@
                             <li><a id="pauseAllLink"><img class="MyMenuIcon" alt="QBT_TR(Pause All)QBT_TR[CONTEXT=MainWindow]" src="icons/torrent-stop.svg" width="16" height="16" />QBT_TR(Pause All)QBT_TR[CONTEXT=MainWindow]</a></li>
                             <li class="divider"><a id="resumeLink"><img class="MyMenuIcon" alt="QBT_TR(Resume)QBT_TR[CONTEXT=MainWindow]" src="icons/torrent-start.svg" width="16" height="16" />QBT_TR(Resume)QBT_TR[CONTEXT=MainWindow]</a></li>
                             <li><a id="pauseLink"><img class="MyMenuIcon" src="icons/torrent-stop.svg" alt="QBT_TR(Pause)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Pause)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li class="divider"><a id="deleteLink"><img class="MyMenuIcon" src="icons/list-remove.svg" alt="QBT_TR(Delete)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Delete)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li class="divider"><a id="deleteLink"><img class="MyMenuIcon" src="icons/list-remove.svg" alt="QBT_TR(Remove)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Remove)QBT_TR[CONTEXT=MainWindow]</a></li>
                             <li id="topQueuePosItem" class="divider"><a id="topPrioLink"><img class="MyMenuIcon" src="icons/go-top.svg" alt="QBT_TR(Top of Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Top of Queue)QBT_TR[CONTEXT=MainWindow]</a></li>
                             <li id="increaseQueuePosItem"><a id="increasePrioLink"><img class="MyMenuIcon" src="icons/go-up.svg" alt="QBT_TR(Move Up Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Move Up Queue)QBT_TR[CONTEXT=MainWindow]</a></li>
                             <li id="decreaseQueuePosItem"><a id="decreasePrioLink"><img class="MyMenuIcon" src="icons/go-down.svg" alt="QBT_TR(Move Down Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Move Down Queue)QBT_TR[CONTEXT=MainWindow]</a></li>
@@ -102,7 +102,7 @@
                 &nbsp;&nbsp;
                 <a id="downloadButton"><img class="mochaToolButton" title="QBT_TR(Add Torrent Link...)QBT_TR[CONTEXT=MainWindow]" src="icons/insert-link.svg" alt="QBT_TR(Add Torrent Link...)QBT_TR[CONTEXT=MainWindow]" width="24" height="24" /></a>
                 <a id="uploadButton"><img class="mochaToolButton" title="QBT_TR(Add Torrent File...)QBT_TR[CONTEXT=MainWindow]" src="icons/list-add.svg" alt="QBT_TR(Add Torrent File...)QBT_TR[CONTEXT=MainWindow]" width="24" height="24" /></a>
-                <a id="deleteButton" class="divider"><img class="mochaToolButton" title="QBT_TR(Delete)QBT_TR[CONTEXT=TransferListWidget]" src="icons/list-remove.svg" alt="QBT_TR(Delete)QBT_TR[CONTEXT=TransferListWidget]" width="24" height="24" /></a>
+                <a id="deleteButton" class="divider"><img class="mochaToolButton" title="QBT_TR(Remove)QBT_TR[CONTEXT=TransferListWidget]" src="icons/list-remove.svg" alt="QBT_TR(Remove)QBT_TR[CONTEXT=TransferListWidget]" width="24" height="24" /></a>
                 <a id="resumeButton" class="divider"><img class="mochaToolButton" title="QBT_TR(Resume)QBT_TR[CONTEXT=TransferListWidget]" src="icons/torrent-start.svg" alt="QBT_TR(Resume)QBT_TR[CONTEXT=TransferListWidget]" width="24" height="24" /></a>
                 <a id="pauseButton"><img class="mochaToolButton" title="QBT_TR(Pause)QBT_TR[CONTEXT=TransferListWidget]" src="icons/torrent-stop.svg" alt="QBT_TR(Pause)QBT_TR[CONTEXT=TransferListWidget]" width="24" height="24" /></a>
                 <span id="queueingButtons">
@@ -132,7 +132,7 @@
         <li><a href="#start"><img src="icons/torrent-start.svg" alt="QBT_TR(Resume)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Resume)QBT_TR[CONTEXT=TransferListWidget]</a></li>
         <li><a href="#pause"><img src="icons/torrent-stop.svg" alt="QBT_TR(Pause)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Pause)QBT_TR[CONTEXT=TransferListWidget]</a></li>
         <li><a href="#forceStart"><img src="icons/torrent-start-forced.svg" alt="QBT_TR(Force Resume)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Force Resume)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-        <li class="separator"><a href="#delete"><img src="icons/list-remove.svg" alt="QBT_TR(Delete)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Delete)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li class="separator"><a href="#delete"><img src="icons/list-remove.svg" alt="QBT_TR(Remove)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Remove)QBT_TR[CONTEXT=TransferListWidget]</a></li>
         <li class="separator">
             <a href="#setLocation"><img src="icons/set-location.svg" alt="QBT_TR(Set location...)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Set location...)QBT_TR[CONTEXT=TransferListWidget]</a>
             <a href="#rename"><img src="icons/edit-rename.svg" alt="QBT_TR(Rename...)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Rename...)QBT_TR[CONTEXT=TransferListWidget]</a>
@@ -186,7 +186,7 @@
         <li><a href="#deleteUnusedCategories"><img src="icons/list-remove.svg" alt="QBT_TR(Remove unused categories)QBT_TR[CONTEXT=CategoryFilterWidget]" /> QBT_TR(Remove unused categories)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
         <li class="separator"><a href="#startTorrentsByCategory"><img src="icons/torrent-start.svg" alt="QBT_TR(Resume torrents)QBT_TR[CONTEXT=CategoryFilterWidget]" /> QBT_TR(Resume torrents)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
         <li><a href="#pauseTorrentsByCategory"><img src="icons/torrent-stop.svg" alt="QBT_TR(Pause torrents)QBT_TR[CONTEXT=CategoryFilterWidget]" /> QBT_TR(Pause torrents)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
-        <li><a href="#deleteTorrentsByCategory"><img src="icons/list-remove.svg" alt="QBT_TR(Delete torrents)QBT_TR[CONTEXT=CategoryFilterWidget]" /> QBT_TR(Delete torrents)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
+        <li><a href="#deleteTorrentsByCategory"><img src="icons/list-remove.svg" alt="QBT_TR(Remove torrents)QBT_TR[CONTEXT=CategoryFilterWidget]" /> QBT_TR(Remove torrents)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
     </ul>
     <ul id="tagsFilterMenu" class="contextMenu">
         <li><a href="#createTag"><img src="icons/list-add.svg" alt="QBT_TR(Add tag...)QBT_TR[CONTEXT=TagFilterWidget]" /> QBT_TR(Add tag...)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
@@ -194,12 +194,12 @@
         <li><a href="#deleteUnusedTags"><img src="icons/list-remove.svg" alt="QBT_TR(Remove unused tags)QBT_TR[CONTEXT=TagFilterWidget]" /> QBT_TR(Remove unused tags)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
         <li class="separator"><a href="#startTorrentsByTag"><img src="icons/torrent-start.svg" alt="QBT_TR(Resume torrents)QBT_TR[CONTEXT=TagFilterWidget]" /> QBT_TR(Resume torrents)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
         <li><a href="#pauseTorrentsByTag"><img src="icons/torrent-stop.svg" alt="QBT_TR(Pause torrents)QBT_TR[CONTEXT=TagFilterWidget]" /> QBT_TR(Pause torrents)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
-        <li><a href="#deleteTorrentsByTag"><img src="icons/list-remove.svg" alt="QBT_TR(Delete torrents)QBT_TR[CONTEXT=TagFilterWidget]" /> QBT_TR(Delete torrents)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
+        <li><a href="#deleteTorrentsByTag"><img src="icons/list-remove.svg" alt="QBT_TR(Remove torrents)QBT_TR[CONTEXT=TagFilterWidget]" /> QBT_TR(Remove torrents)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
     </ul>
     <ul id="trackersFilterMenu" class="contextMenu">
         <li><a href="#resumeTorrentsByTracker"><img src="icons/torrent-start.svg" alt="QBT_TR(Resume torrents)QBT_TR[CONTEXT=TrackerFiltersList]" /> QBT_TR(Resume torrents)QBT_TR[CONTEXT=TrackerFiltersList]</a></li>
         <li><a href="#pauseTorrentsByTracker"><img src="icons/torrent-stop.svg" alt="QBT_TR(Pause torrents)QBT_TR[CONTEXT=TrackerFiltersList]" /> QBT_TR(Pause torrents)QBT_TR[CONTEXT=TrackerFiltersList]</a></li>
-        <li><a href="#deleteTorrentsByTracker"><img src="icons/list-remove.svg" alt="QBT_TR(Delete torrents)QBT_TR[CONTEXT=TrackerFiltersList]" /> QBT_TR(Delete torrents)QBT_TR[CONTEXT=TrackerFiltersList]</a></li>
+        <li><a href="#deleteTorrentsByTracker"><img src="icons/list-remove.svg" alt="QBT_TR(Remove torrents)QBT_TR[CONTEXT=TrackerFiltersList]" /> QBT_TR(Remove torrents)QBT_TR[CONTEXT=TrackerFiltersList]</a></li>
     </ul>
     <ul id="torrentTrackersMenu" class="contextMenu">
         <li><a href="#AddTracker"><img src="icons/list-add.svg" alt="QBT_TR(Add a new tracker...)QBT_TR[CONTEXT=TrackerListWidget]" /> QBT_TR(Add a new tracker...)QBT_TR[CONTEXT=TrackerListWidget]</a></li>

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -57,16 +57,15 @@
                     <li>
                         <a class="returnFalse">QBT_TR(Edit)QBT_TR[CONTEXT=MainWindow]</a>
                         <ul>
+                            <li><a id="resumeLink"><img class="MyMenuIcon" alt="QBT_TR(Resume)QBT_TR[CONTEXT=MainWindow]" src="icons/torrent-start.svg" width="16" height="16" />QBT_TR(Resume)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li><a id="pauseLink"><img class="MyMenuIcon" src="icons/torrent-stop.svg" alt="QBT_TR(Pause)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Pause)QBT_TR[CONTEXT=MainWindow]</a></li>
                             <li><a id="resumeAllLink"><img class="MyMenuIcon" alt="QBT_TR(Resume All)QBT_TR[CONTEXT=MainWindow]" src="icons/torrent-start.svg" width="16" height="16" />QBT_TR(Resume All)QBT_TR[CONTEXT=MainWindow]</a></li>
                             <li><a id="pauseAllLink"><img class="MyMenuIcon" alt="QBT_TR(Pause All)QBT_TR[CONTEXT=MainWindow]" src="icons/torrent-stop.svg" width="16" height="16" />QBT_TR(Pause All)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li class="divider"><a id="resumeLink"><img class="MyMenuIcon" alt="QBT_TR(Resume)QBT_TR[CONTEXT=MainWindow]" src="icons/torrent-start.svg" width="16" height="16" />QBT_TR(Resume)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li><a id="pauseLink"><img class="MyMenuIcon" src="icons/torrent-stop.svg" alt="QBT_TR(Pause)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Pause)QBT_TR[CONTEXT=MainWindow]</a></li>
                             <li class="divider"><a id="deleteLink"><img class="MyMenuIcon" src="icons/list-remove.svg" alt="QBT_TR(Remove)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Remove)QBT_TR[CONTEXT=MainWindow]</a></li>
                             <li id="topQueuePosItem" class="divider"><a id="topPrioLink"><img class="MyMenuIcon" src="icons/go-top.svg" alt="QBT_TR(Top of Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Top of Queue)QBT_TR[CONTEXT=MainWindow]</a></li>
                             <li id="increaseQueuePosItem"><a id="increasePrioLink"><img class="MyMenuIcon" src="icons/go-up.svg" alt="QBT_TR(Move Up Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Move Up Queue)QBT_TR[CONTEXT=MainWindow]</a></li>
                             <li id="decreaseQueuePosItem"><a id="decreasePrioLink"><img class="MyMenuIcon" src="icons/go-down.svg" alt="QBT_TR(Move Down Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Move Down Queue)QBT_TR[CONTEXT=MainWindow]</a></li>
                             <li id="bottomQueuePosItem"><a id="bottomPrioLink"><img class="MyMenuIcon" src="icons/go-bottom.svg" alt="QBT_TR(Bottom of Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Bottom of Queue)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li class="divider"><a id="recheckLink"><img class="MyMenuIcon" src="icons/force-recheck.svg" alt="QBT_TR(Force Recheck)QBT_TR[CONTEXT=TransferListWidget]" width="16" height="16" />QBT_TR(Force recheck)QBT_TR[CONTEXT=TransferListWidget]</a></li>
                         </ul>
                     </li>
                     <li>

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -382,7 +382,7 @@ const initializeWindows = function() {
         if (hashes.length) {
             new MochaUI.Window({
                 id: 'confirmDeletionPage',
-                title: "QBT_TR(Deletion confirmation)QBT_TR[CONTEXT=confirmDeletionDlg]",
+                title: "QBT_TR(Remove torrent(s))QBT_TR[CONTEXT=confirmDeletionDlg]",
                 loadMethod: 'iframe',
                 contentURL: new URI("confirmdeletion.html").setData("hashes", hashes.join("|")).setData("deleteFiles", deleteFiles).toString(),
                 scrollbars: false,
@@ -659,7 +659,7 @@ const initializeWindows = function() {
         if (hashes.length) {
             new MochaUI.Window({
                 id: 'confirmDeletionPage',
-                title: "QBT_TR(Deletion confirmation)QBT_TR[CONTEXT=confirmDeletionDlg]",
+                title: "QBT_TR(Remove torrent(s))QBT_TR[CONTEXT=confirmDeletionDlg]",
                 loadMethod: 'iframe',
                 contentURL: new URI("confirmdeletion.html").setData("hashes", hashes.join("|")).toString(),
                 scrollbars: false,
@@ -800,7 +800,7 @@ const initializeWindows = function() {
         if (hashes.length) {
             new MochaUI.Window({
                 id: 'confirmDeletionPage',
-                title: "QBT_TR(Deletion confirmation)QBT_TR[CONTEXT=confirmDeletionDlg]",
+                title: "QBT_TR(Remove torrent(s))QBT_TR[CONTEXT=confirmDeletionDlg]",
                 loadMethod: 'iframe',
                 contentURL: new URI("confirmdeletion.html").setData("hashes", hashes.join("|")).toString(),
                 scrollbars: false,
@@ -886,7 +886,7 @@ const initializeWindows = function() {
         if (hashes.length) {
             new MochaUI.Window({
                 id: 'confirmDeletionPage',
-                title: "QBT_TR(Deletion confirmation)QBT_TR[CONTEXT=confirmDeletionDlg]",
+                title: "QBT_TR(Remove torrent(s))QBT_TR[CONTEXT=confirmDeletionDlg]",
                 loadMethod: 'iframe',
                 contentURL: new URI("confirmdeletion.html").setData("hashes", hashes.join("|")).toString(),
                 scrollbars: false,


### PR DESCRIPTION
After d28b5f7834c0573ba6ab60892294e95e3e73c9c2, it is a bit inconsistent: the rephrased dialog preferred using 'remove' over 'delete' (as it refers to remove it from the torrent list) so IMO the menu/UI should follow it.