### PR TITLE
Selectively convert http to https throughout repo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# EditorConfig is awesome: http://EditorConfig.org
+# EditorConfig is awesome: https://EditorConfig.org
 
 root = true
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,7 +9,7 @@ contact_links:
     about: "Please ask questions related to usage/setup/support/non-issue development discussion in the Discussions section"
 
   - name: Question
-    url: "http://forum.qbittorrent.org/"
+    url: "https://forum.qbittorrent.org/"
     about: "Alternatively, ask on the official forum"
 
   - name: Question

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -14,5 +14,5 @@ For such questions, use one of the following community support resources:
 * The [qBittorrent subreddit][subreddit-url]
 
 [discussions-url]: https://github.com/qbittorrent/qBittorrent/discussions
-[forum-url]: http://forum.qbittorrent.org/
+[forum-url]: https://forum.qbittorrent.org/
 [subreddit-url]: https://www.reddit.com/r/qBittorrent/

--- a/AUTHORS
+++ b/AUTHORS
@@ -30,7 +30,7 @@ Code from other projects:
   license: BSD
 
 * file src/app/stacktrace.h
-  copyright: Timo Bingmann from http://idlebox.net/
+  copyright: Timo Bingmann from https://idlebox.net/
   license: WTFPL v2.0
 
 * file src/app/stacktrace_win.h
@@ -49,12 +49,12 @@ Images Authors:
 * files: src/icons/*.png
   copyright: Gnome Icon Theme
   license: GPLv2
-  url: http://ftp.acc.umu.se/pub/GNOME/sources/gnome-icon-theme
+  url: https://ftp.acc.umu.se/pub/GNOME/sources/gnome-icon-theme
 
 * files: src/oxygen/*.png
   copyright: Oxygen Icon Theme (KDE)
   license: LGPL
-  url: http://www.oxygen-icons.org
+  url: https://www.oxygen-icons.org
 
 * files: src/icons/flags/*.svg
   copyright: lipis/flag-icons
@@ -95,7 +95,7 @@ Images Authors:
 * file: src/icons/skin/ratio.png
   copyright: Fatcow Web Hosting
   license: Creative Commons Attribution 3.0 License
-  url: http://www.fatcow.com/free-icons
+  url: https://www.fatcow.com/free-icons
 
 Translations authors:
 * files: src/lang/*.ts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,7 +200,7 @@ Following these guidelines helps maintainers and the community understand your s
 [coding-guidelines-url]: https://github.com/qbittorrent/qBittorrent/blob/master/CODING_GUIDELINES.md
 [coding-guidelines-git-commit-message-url]: https://github.com/qbittorrent/qBittorrent/blob/master/CODING_GUIDELINES.md#10-git-commit-message
 [commit-message-fix-issue-example-url]: https://github.com/qbittorrent/qBittorrent/commit/c07cd440cd46345297debb47cb260f8688975f50
-[forum-url]: http://forum.qbittorrent.org/
+[forum-url]: https://forum.qbittorrent.org/
 [howto-report-bugs-url]: https://www.chiark.greenend.org.uk/~sgtatham/bugs.html
 [how-to-translate-url]: https://github.com/qbittorrent/qBittorrent/wiki/How-to-translate-qBittorrent
 [merging-vs-rebasing-url]: https://www.atlassian.com/git/tutorials/merging-vs-rebasing

--- a/INSTALL
+++ b/INSTALL
@@ -43,7 +43,7 @@ Please ensure you are building with an officially supported configuration when r
   will install and execute qBittorrent.
 
 DOCUMENTATION:
-Please note that there is a "Compilation" section at http://wiki.qbittorrent.org.
+Please note that there is a "Compilation" section at https://wiki.qbittorrent.org.
 
 ------------------------------------------
 sledgehammer999 <sledgehammer999@qbittorrent.org>

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ For more information please visit:
 https://www.qbittorrent.org
 
 or our wiki here:
-http://wiki.qbittorrent.org
+https://wiki.qbittorrent.org
 
 Use the forum for troubleshooting before reporting bugs:
-http://forum.qbittorrent.org
+https://forum.qbittorrent.org
 
 Please report any bug (or feature request) to:
-http://bugs.qbittorrent.org
+https://bugs.qbittorrent.org
 
 Official IRC channel:
 [#qbittorrent on irc.libera.chat](ircs://irc.libera.chat:6697/qbittorrent)

--- a/configure
+++ b/configure
@@ -5099,7 +5099,7 @@ Oops!
 Your 'rm' program seems unable to run without file operands specified
 on the command line, even when the '-f' option is present.  This is contrary
 to the behaviour of most rm programs out there, and not conforming with
-the upcoming POSIX standard: <http://austingroupbugs.net/view.php?id=542>
+the upcoming POSIX standard: <https://austingroupbugs.net/view.php?id=542>
 
 Please tell bug-automake@gnu.org about your system, including the value
 of your $PATH and any error possibly output before this message.  This
@@ -5611,7 +5611,7 @@ Alternatively, you may set the environment variables Qt5Svg_CFLAGS
 and Qt5Svg_LIBS to avoid the need to call pkg-config.
 See the pkg-config man page for more details.
 
-To get pkg-config, see <http://pkg-config.freedesktop.org/>.
+To get pkg-config, see <https://pkg-config.freedesktop.org/>.
 See \`config.log' for more details" "$LINENO" 5; }
 else
 	Qt5Svg_CFLAGS=$pkg_cv_Qt5Svg_CFLAGS
@@ -5988,8 +5988,8 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
     if test "x$succeeded" != "xyes" ; then
         if test "x$_version" = "x0" ; then
-            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: We could not detect the boost libraries (version 1.71 or higher). If you have a staged boost library (still not installed) please specify \$BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See http://randspringer.de/boost for more documentation." >&5
-printf "%s\n" "$as_me: We could not detect the boost libraries (version 1.71 or higher). If you have a staged boost library (still not installed) please specify \$BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See http://randspringer.de/boost for more documentation." >&6;}
+            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: We could not detect the boost libraries (version 1.71 or higher). If you have a staged boost library (still not installed) please specify \$BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See https://randspringer.de/boost for more documentation." >&5
+printf "%s\n" "$as_me: We could not detect the boost libraries (version 1.71 or higher). If you have a staged boost library (still not installed) please specify \$BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See https://randspringer.de/boost for more documentation." >&6;}
         else
             { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Your boost libraries seems to old (version $_version)." >&5
 printf "%s\n" "$as_me: Your boost libraries seems to old (version $_version)." >&6;}
@@ -6163,7 +6163,7 @@ Alternatively, you may set the environment variables libtorrent_CFLAGS
 and libtorrent_LIBS to avoid the need to call pkg-config.
 See the pkg-config man page for more details.
 
-To get pkg-config, see <http://pkg-config.freedesktop.org/>.
+To get pkg-config, see <https://pkg-config.freedesktop.org/>.
 See \`config.log' for more details" "$LINENO" 5; }
 else
 	libtorrent_CFLAGS=$pkg_cv_libtorrent_CFLAGS
@@ -6257,7 +6257,7 @@ Alternatively, you may set the environment variables libtorrent_CFLAGS
 and libtorrent_LIBS to avoid the need to call pkg-config.
 See the pkg-config man page for more details.
 
-To get pkg-config, see <http://pkg-config.freedesktop.org/>.
+To get pkg-config, see <https://pkg-config.freedesktop.org/>.
 See \`config.log' for more details" "$LINENO" 5; }
 else
 	libtorrent_CFLAGS=$pkg_cv_libtorrent_CFLAGS
@@ -6356,7 +6356,7 @@ Alternatively, you may set the environment variables openssl_CFLAGS
 and openssl_LIBS to avoid the need to call pkg-config.
 See the pkg-config man page for more details.
 
-To get pkg-config, see <http://pkg-config.freedesktop.org/>.
+To get pkg-config, see <https://pkg-config.freedesktop.org/>.
 See \`config.log' for more details" "$LINENO" 5; }
 else
 	openssl_CFLAGS=$pkg_cv_openssl_CFLAGS
@@ -6449,7 +6449,7 @@ Alternatively, you may set the environment variables zlib_CFLAGS
 and zlib_LIBS to avoid the need to call pkg-config.
 See the pkg-config man page for more details.
 
-To get pkg-config, see <http://pkg-config.freedesktop.org/>.
+To get pkg-config, see <https://pkg-config.freedesktop.org/>.
 See \`config.log' for more details" "$LINENO" 5; }
 else
 	zlib_CFLAGS=$pkg_cv_zlib_CFLAGS

--- a/dist/mac/Info.plist
+++ b/dist/mac/Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>

--- a/dist/unix/org.qbittorrent.qBittorrent.appdata.xml
+++ b/dist/unix/org.qbittorrent.qBittorrent.appdata.xml
@@ -68,9 +68,9 @@
   <update_contact>sledgehammer999@qbittorrent.org</update_contact>
   <developer_name>The qBittorrent Project</developer_name>
   <url type="homepage">https://www.qbittorrent.org/</url>
-  <url type="bugtracker">http://bugs.qbittorrent.org/</url>
+  <url type="bugtracker">https://bugs.qbittorrent.org/</url>
   <url type="donation">https://www.qbittorrent.org/donate</url>
-  <url type="help">http://forum.qbittorrent.org/</url>
+  <url type="help">https://forum.qbittorrent.org/</url>
   <url type="translate">https://github.com/qbittorrent/qBittorrent/wiki/How-to-translate-qBittorrent</url>
   <content_rating type="oars-1.1"/>
   <releases>

--- a/doc/qbittorrent-nox.1
+++ b/doc/qbittorrent-nox.1
@@ -42,6 +42,6 @@ number.
 8080).
 .SH BUGS
 .PP
-If you find a bug, please report it at http://bugs.qbittorrent.org
+If you find a bug, please report it at https://bugs.qbittorrent.org
 .SH AUTHORS
 Christophe Dumez <chris@qbittorrent.org>.

--- a/doc/qbittorrent-nox.1.md
+++ b/doc/qbittorrent-nox.1.md
@@ -38,4 +38,4 @@ the default account user name is "admin" with "adminadmin" as a password.
 
 
 # BUGS
-If you find a bug, please report it at http://bugs.qbittorrent.org
+If you find a bug, please report it at https://bugs.qbittorrent.org

--- a/doc/qbittorrent.1
+++ b/doc/qbittorrent.1
@@ -36,6 +36,6 @@ number.
 8080).
 .SH BUGS
 .PP
-If you find a bug, please report it at http://bugs.qbittorrent.org
+If you find a bug, please report it at https://bugs.qbittorrent.org
 .SH AUTHORS
 Christophe Dumez <chris@qbittorrent.org>.

--- a/doc/qbittorrent.1.md
+++ b/doc/qbittorrent.1.md
@@ -33,4 +33,4 @@ FAST extension (mainline) and PeX support (utorrent compatible).
 
 
 # BUGS
-If you find a bug, please report it at http://bugs.qbittorrent.org
+If you find a bug, please report it at https://bugs.qbittorrent.org

--- a/m4/ax_boost_base.m4
+++ b/m4/ax_boost_base.m4
@@ -13,7 +13,7 @@
 #   If no path to the installed boost library is given the macro searchs
 #   under /usr, /usr/local, /opt and /opt/local and evaluates the
 #   $BOOST_ROOT environment variable. Further documentation is available at
-#   <http://randspringer.de/boost/index.html>.
+#   <https://randspringer.de/boost/index.html>.
 #
 #   This macro calls:
 #
@@ -285,7 +285,7 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
 
     if test "x$succeeded" != "xyes" ; then
         if test "x$_version" = "x0" ; then
-            AC_MSG_NOTICE([[We could not detect the boost libraries (version $1 or higher). If you have a staged boost library (still not installed) please specify \$BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See http://randspringer.de/boost for more documentation.]])
+            AC_MSG_NOTICE([[We could not detect the boost libraries (version $1 or higher). If you have a staged boost library (still not installed) please specify \$BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See https://randspringer.de/boost for more documentation.]])
         else
             AC_MSG_NOTICE([Your boost libraries seems to old (version $_version).])
         fi

--- a/m4/ax_define_dir.m4
+++ b/m4/ax_define_dir.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#       http://www.gnu.org/software/autoconf-archive/ax_define_dir.html
+#       https://www.gnu.org/software/autoconf-archive/ax_define_dir.html
 # ===========================================================================
 #
 # SYNOPSIS

--- a/m4/pkg.m4
+++ b/m4/pkg.m4
@@ -181,7 +181,7 @@ path to pkg-config.
 
 _PKG_TEXT
 
-To get pkg-config, see <http://pkg-config.freedesktop.org/>.])[]dnl
+To get pkg-config, see <https://pkg-config.freedesktop.org/>.])[]dnl
         ])
 else
 	$1[]_CFLAGS=$pkg_cv_[]$1[]_CFLAGS

--- a/src/app/qtlocalpeer/qtlocalpeer.cpp
+++ b/src/app/qtlocalpeer/qtlocalpeer.cpp
@@ -28,7 +28,7 @@
 ****************************************************************************
 **
 ** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
-** Contact: http://www.qt-project.org/legal
+** Contact: https://www.qt-project.org/legal
 **
 ** This file is part of the Qt Solutions component.
 **

--- a/src/app/qtlocalpeer/qtlocalpeer.h
+++ b/src/app/qtlocalpeer/qtlocalpeer.h
@@ -28,7 +28,7 @@
 ****************************************************************************
 **
 ** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
-** Contact: http://www.qt-project.org/legal
+** Contact: https://www.qt-project.org/legal
 **
 ** This file is part of the Qt Solutions component.
 **

--- a/src/app/qtlocalpeer/qtlockedfile.cpp
+++ b/src/app/qtlocalpeer/qtlockedfile.cpp
@@ -28,7 +28,7 @@
 ****************************************************************************
 **
 ** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
-** Contact: http://www.qt-project.org/legal
+** Contact: https://www.qt-project.org/legal
 **
 ** This file is part of the Qt Solutions component.
 **

--- a/src/app/qtlocalpeer/qtlockedfile.h
+++ b/src/app/qtlocalpeer/qtlockedfile.h
@@ -28,7 +28,7 @@
 ****************************************************************************
 **
 ** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
-** Contact: http://www.qt-project.org/legal
+** Contact: https://www.qt-project.org/legal
 **
 ** This file is part of the Qt Solutions component.
 **

--- a/src/app/qtlocalpeer/qtlockedfile_unix.cpp
+++ b/src/app/qtlocalpeer/qtlockedfile_unix.cpp
@@ -28,7 +28,7 @@
 ****************************************************************************
 **
 ** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
-** Contact: http://www.qt-project.org/legal
+** Contact: https://www.qt-project.org/legal
 **
 ** This file is part of the Qt Solutions component.
 **

--- a/src/app/qtlocalpeer/qtlockedfile_win.cpp
+++ b/src/app/qtlocalpeer/qtlockedfile_win.cpp
@@ -28,7 +28,7 @@
 ****************************************************************************
 **
 ** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
-** Contact: http://www.qt-project.org/legal
+** Contact: https://www.qt-project.org/legal
 **
 ** This file is part of the Qt Solutions component.
 **

--- a/src/app/signalhandler.cpp
+++ b/src/app/signalhandler.cpp
@@ -96,7 +96,7 @@ namespace
     void abnormalExitHandler(const int signum)
     {
         const char msg[] = "\n\n*************************************************************\n"
-            "Please file a bug report at http://bug.qbittorrent.org and provide the following information:\n\n"
+            "Please file a bug report at https://bug.qbittorrent.org and provide the following information:\n\n"
             "qBittorrent version: " QBT_VERSION "\n\n"
             "Caught signal: ";
         const char *sigName = sysSigName[signum];

--- a/src/base/3rdparty/expected.hpp
+++ b/src/base/3rdparty/expected.hpp
@@ -3,7 +3,7 @@
 // Copyright (C) 2016-2020 Martin Moene.
 //
 // Distributed under the Boost Software License, Version 1.0.
-// (See accompanying file LICENSE.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
 //
 // expected lite is based on:
 //   A proposal to add a utility class to represent expected monad
@@ -1034,7 +1034,7 @@ unexpected_type( E ) -> unexpected_type< E >;
 #if  nsel_P0323R <= 2
 
 // TODO: Should expected be specialized for particular E types such as exception_ptr and how?
-//       See p0323r7 2.1. Ergonomics, http://wg21.link/p0323
+//       See p0323r7 2.1. Ergonomics, https://wg21.link/p0323
 template<>
 class unexpected_type< std::exception_ptr >
 {

--- a/src/base/bittorrent/filterparserthread.cpp
+++ b/src/base/bittorrent/filterparserthread.cpp
@@ -590,9 +590,9 @@ int FilterParserThread::parseP2BFilterFile()
 
 // Process ip filter file
 // Supported formats:
-//  * eMule IP list (DAT): http://wiki.phoenixlabs.org/wiki/DAT_Format
-//  * PeerGuardian Text (P2P): http://wiki.phoenixlabs.org/wiki/P2P_Format
-//  * PeerGuardian Binary (P2B): http://wiki.phoenixlabs.org/wiki/P2B_Format
+//  * eMule IP list (DAT): https://wiki.phoenixlabs.org/wiki/DAT_Format
+//  * PeerGuardian Text (P2P): https://wiki.phoenixlabs.org/wiki/P2P_Format
+//  * PeerGuardian Binary (P2B): https://wiki.phoenixlabs.org/wiki/P2B_Format
 void FilterParserThread::processFilterFile(const Path &filePath)
 {
     if (isRunning())

--- a/src/base/net/dnsupdater.cpp
+++ b/src/base/net/dnsupdater.cpp
@@ -217,7 +217,7 @@ void DNSUpdater::processIPUpdateReply(const QString &reply)
 
     if (code == u"badagent")
     {
-        LogMsg(tr("Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org."),
+        LogMsg(tr("Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org."),
                            Log::CRITICAL);
         m_state = FATAL;
         return;
@@ -225,7 +225,7 @@ void DNSUpdater::processIPUpdateReply(const QString &reply)
 
     if (code == u"!donator")
     {
-        LogMsg(tr("Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.").arg(u"!donator"_qs),
+        LogMsg(tr("Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.").arg(u"!donator"_qs),
                            Log::CRITICAL);
         m_state = FATAL;
         return;

--- a/src/base/net/dnsupdater.h
+++ b/src/base/net/dnsupdater.h
@@ -39,7 +39,7 @@ namespace Net
 {
     struct DownloadResult;
 
-    // Based on http://www.dyndns.com/developers/specs/
+    // Based on https://www.dyndns.com/developers/specs/
     class DNSUpdater : public QObject
     {
         Q_OBJECT

--- a/src/base/net/geoipmanager.cpp
+++ b/src/base/net/geoipmanager.cpp
@@ -145,7 +145,7 @@ QString GeoIPManager::CountryName(const QString &countryISOCode)
     static const QHash<QString, QString> countries =
     {
         // ISO 3166-1 alpha-2 codes
-        // http://www.iso.org/iso/home/standards/country_codes/country_names_and_code_elements_txt-temp.htm
+        // https://www.iso.org/iso/home/standards/country_codes/country_names_and_code_elements_txt-temp.htm
 
         // Officially assigned
         {u"AD"_qs, tr("Andorra")},

--- a/src/base/net/smtp.cpp
+++ b/src/base/net/smtp.cpp
@@ -27,7 +27,7 @@
  */
 
 /*
- * This code is based on QxtSmtp from libqxt (http://libqxt.org)
+ * This code is based on QxtSmtp from libqxt (https://libqxt.org)
  */
 
 #include "smtp.h"
@@ -65,7 +65,7 @@ namespace
         QByteArray innerPadding(blockSize, char(0x36)); // initialize inner padding with char "6"
         QByteArray outerPadding(blockSize, char(0x5c)); // initialize outer padding with char "\"
         // ascii characters 0x36 ("6") and 0x5c ("\") are selected because they have large
-        // Hamming distance (http://en.wikipedia.org/wiki/Hamming_distance)
+        // Hamming distance (https://en.wikipedia.org/wiki/Hamming_distance)
 
         for (int i = 0; i < key.length(); ++i)
         {
@@ -122,7 +122,7 @@ Smtp::Smtp(QObject *parent)
     connect(m_socket, &QAbstractSocket::disconnected, this, &QObject::deleteLater);
     connect(m_socket, &QAbstractSocket::errorOccurred, this, &Smtp::error);
 
-    // Test hmacMD5 function (http://www.faqs.org/rfcs/rfc2202.html)
+    // Test hmacMD5 function (https://www.faqs.org/rfcs/rfc2202.html)
     Q_ASSERT(hmacMD5("Jefe", "what do ya want for nothing?").toHex()
              == "750c783e6ab0b503eaa86e310a5db738");
     Q_ASSERT(hmacMD5(QByteArray::fromHex("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"), "Hi There").toHex()

--- a/src/base/net/smtp.h
+++ b/src/base/net/smtp.h
@@ -27,7 +27,7 @@
  */
 
 /*
- * This code is based on QxtSmtp from libqxt (http://libqxt.org)
+ * This code is based on QxtSmtp from libqxt (https://libqxt.org)
  */
 
 #pragma once

--- a/src/base/rss/rss_parser.cpp
+++ b/src/base/rss/rss_parser.cpp
@@ -51,9 +51,9 @@ namespace
         QString resolveUndeclaredEntity(const QString &name) override
         {
             // (X)HTML entities declared in:
-            //     http://www.w3.org/TR/xhtml1/DTD/xhtml-lat1.ent
-            //     http://www.w3.org/TR/xhtml1/DTD/xhtml-symbol.ent
-            //     http://www.w3.org/TR/xhtml1/DTD/xhtml-special.ent
+            //     https://www.w3.org/TR/xhtml1/DTD/xhtml-lat1.ent
+            //     https://www.w3.org/TR/xhtml1/DTD/xhtml-symbol.ent
+            //     https://www.w3.org/TR/xhtml1/DTD/xhtml-special.ent
             static const QHash<QString, QString> HTMLEntities
             {
                 {u"nbsp"_qs,   u"&#160;"_qs}, // no-break space = non-breaking space, U+00A0 ISOnum

--- a/src/base/rss/rss_session.h
+++ b/src/base/rss/rss_session.h
@@ -43,19 +43,19 @@
  *             "Feed name 1 (Alias)":
  {
  *                 "uid": "feed unique identifier",
- *                 "url": "http://some-feed-url1"
+ *                 "url": "https://some-feed-url1"
  *             }
  *             "Feed name 2 (Alias)":
  {
  *                 "uid": "feed unique identifier",
- *                 "url": "http://some-feed-url2"
+ *                 "url": "https://some-feed-url2"
  *             }
  *         },
  *         "subfolder2": {},
  *         "Feed name 3 (Alias)":
  {
  *             "uid": "feed unique identifier",
- *             "url": "http://some-feed-url3"
+ *             "url": "https://some-feed-url3"
  *         }
  *     },
  *     "folder2": {},

--- a/src/base/search/searchpluginmanager.cpp
+++ b/src/base/search/searchpluginmanager.cpp
@@ -85,7 +85,7 @@ namespace
 QPointer<SearchPluginManager> SearchPluginManager::m_instance = nullptr;
 
 SearchPluginManager::SearchPluginManager()
-    : m_updateUrl(u"http://searchplugins.qbittorrent.org/nova3/engines/"_qs)
+    : m_updateUrl(u"https://searchplugins.qbittorrent.org/nova3/engines/"_qs)
 {
     Q_ASSERT(!m_instance); // only one instance is allowed
     m_instance = this;

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -83,7 +83,7 @@ namespace
 
     // return best userfriendly storage unit (B, KiB, MiB, GiB, TiB, ...)
     // use Binary prefix standards from IEC 60027-2
-    // see http://en.wikipedia.org/wiki/Kilobyte
+    // see https://en.wikipedia.org/wiki/Kilobyte
     // value must be given in bytes
     // to send numbers instead of strings with suffixes
     struct SplitToFriendlyUnitResult

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -45,7 +45,7 @@ enum class ShutdownDialogAction;
 namespace Utils::Misc
 {
     // use binary prefix standards from IEC 60027-2
-    // see http://en.wikipedia.org/wiki/Kilobyte
+    // see https://en.wikipedia.org/wiki/Kilobyte
     enum class SizeUnit
     {
         Byte,       // 1024^0,

--- a/src/gui/aboutdialog.cpp
+++ b/src/gui/aboutdialog.cpp
@@ -60,8 +60,8 @@ AboutDialog::AboutDialog(QWidget *parent)
         u"%2\n\n"
         u"<table>"
         u"<tr><td>%3</td><td><a href=\"https://www.qbittorrent.org\">https://www.qbittorrent.org</a></td></tr>"
-        u"<tr><td>%4</td><td><a href=\"http://forum.qbittorrent.org\">http://forum.qbittorrent.org</a></td></tr>"
-        u"<tr><td>%5</td><td><a href=\"http://bugs.qbittorrent.org\">http://bugs.qbittorrent.org</a></td></tr>"
+        u"<tr><td>%4</td><td><a href=\"https://forum.qbittorrent.org\">https://forum.qbittorrent.org</a></td></tr>"
+        u"<tr><td>%5</td><td><a href=\"https://bugs.qbittorrent.org\">https://bugs.qbittorrent.org</a></td></tr>"
         u"</table>"
         u"</p>"_qs
         .arg(tr("An advanced BitTorrent client programmed in C++, based on Qt toolkit and libtorrent-rasterbar.")

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -715,7 +715,7 @@ void MainWindow::updateNbTorrents()
 
 void MainWindow::on_actionDocumentation_triggered() const
 {
-    QDesktopServices::openUrl(QUrl(u"http://doc.qbittorrent.org"_qs));
+    QDesktopServices::openUrl(QUrl(u"https://doc.qbittorrent.org"_qs));
 }
 
 void MainWindow::tabChanged(int newTab)

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -810,7 +810,7 @@ void PropertiesWidget::askWebSeed()
     // Ask user for a new url seed
     const QString urlSeed = AutoExpandableDialog::getText(this, tr("New URL seed", "New HTTP source"),
                                                            tr("New URL seed:"), QLineEdit::Normal,
-                                                           u"http://www."_qs, &ok);
+                                                           u"https://www."_qs, &ok);
     if (!ok) return;
     qDebug("Adding %s web seed", qUtf8Printable(urlSeed));
     if (!m_ui->listWebSeeds->findItems(urlSeed, Qt::MatchFixedString).empty())

--- a/src/gui/search/pluginselectdialog.ui
+++ b/src/gui/search/pluginselectdialog.ui
@@ -93,7 +93,7 @@
       </font>
      </property>
      <property name="text">
-      <string>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</string>
+      <string>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</string>
      </property>
      <property name="openExternalLinks">
       <bool>true</bool>

--- a/src/gui/stacktracedialog.cpp
+++ b/src/gui/stacktracedialog.cpp
@@ -57,7 +57,7 @@ void StacktraceDialog::setText(const QString &signalName, const QString &stacktr
         "</font></b></p>"
         "<font size=4><p>"
         "Please file a bug report at "
-        "<a href=\"http://bugs.qbittorrent.org\">http://bugs.qbittorrent.org</a> "
+        "<a href=\"https://bugs.qbittorrent.org\">https://bugs.qbittorrent.org</a> "
         "and provide the following information:"
         "</p></font>"
         "<br/><hr><br/>"

--- a/src/lang/qbittorrent_ar.ts
+++ b/src/lang/qbittorrent_ar.ts
@@ -3517,13 +3517,13 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>خطأ DNS ديناميكي: تم وضع كيوبت‎تورنت في القائمة السوداء بواسطة الخدمة ، يرجى إرسال تقرير خطأ على http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>خطأ DNS ديناميكي: تم وضع كيوبت‎تورنت في القائمة السوداء بواسطة الخدمة ، يرجى إرسال تقرير خطأ على https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>خطأ DNS ديناميكي: تم إرجاع: %1 بواسطة الخدمة ، يرجى إرسال تقرير خطأ على http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>خطأ DNS ديناميكي: تم إرجاع: %1 بواسطة الخدمة ، يرجى إرسال تقرير خطأ على https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6789,8 +6789,8 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation> يمكنك الحصول على محركات بحث جديدة من هنا:&lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation> يمكنك الحصول على محركات بحث جديدة من هنا:&lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_az@latin.ts
+++ b/src/lang/qbittorrent_az@latin.ts
@@ -3517,13 +3517,13 @@ qBittorrenti bunlar üçün əsas tətbiq etmək istəyirsiniz?</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Dinamik DNS xətası: qBittorrent server tərəfindən qara siyahıya salındı, xəta hesabatını http://bugs.qbittorrent.org ünvanında yerləşdirin.</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Dinamik DNS xətası: qBittorrent server tərəfindən qara siyahıya salındı, xəta hesabatını https://bugs.qbittorrent.org ünvanında yerləşdirin.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Dinamik DNS xətası: %1 server tərəfindən qaytarıldı, xəta hesabatını http://bugs.qbittorrent.org ünvanında yerləşdirin.</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Dinamik DNS xətası: %1 server tərəfindən qaytarıldı, xəta hesabatını https://bugs.qbittorrent.org ünvanında yerləşdirin.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6787,8 +6787,8 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Yeni axtarış sistemi qoşmalarını buradan əldə edə bilərsiniz.: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Yeni axtarış sistemi qoşmalarını buradan əldə edə bilərsiniz.: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_be.ts
+++ b/src/lang/qbittorrent_be.ts
@@ -3512,12 +3512,12 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6777,7 +6777,7 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/lang/qbittorrent_bg.ts
+++ b/src/lang/qbittorrent_bg.ts
@@ -3517,13 +3517,13 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Динамичен DNS грешка: qBittorrent бе в черният списък от услугата, моля изпратете доклад за грешка при http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Динамичен DNS грешка: qBittorrent бе в черният списък от услугата, моля изпратете доклад за грешка при https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Динамичен DNS грешка: %1 бе върнат от услугата, моля изпратете доклад за грешка при http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Динамичен DNS грешка: %1 бе върнат от услугата, моля изпратете доклад за грешка при https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6784,8 +6784,8 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Може да вземете нови добавки за търсене оттук: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Може да вземете нови добавки за търсене оттук: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_ca.ts
+++ b/src/lang/qbittorrent_ca.ts
@@ -3517,13 +3517,13 @@ Voleu que l qBittorrent en sigui l&apos;aplicació predeterminada?</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Error de DNS dinàmic: qBittorrent era a la llista negra del servei. Envieu un informe d&apos;error a http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Error de DNS dinàmic: qBittorrent era a la llista negra del servei. Envieu un informe d&apos;error a https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Error de DNS dinàmic: %1 ha estat retornat pel servei. Envieu un informe d&apos;error a http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Error de DNS dinàmic: %1 ha estat retornat pel servei. Envieu un informe d&apos;error a https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6788,8 +6788,8 @@ Manual: s&apos;han d&apos;assignar manualment diverses propietats del torrent (p
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Podeu obtenir nous connectors de motors de cerca aquí: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Podeu obtenir nous connectors de motors de cerca aquí: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_cs.ts
+++ b/src/lang/qbittorrent_cs.ts
@@ -3517,13 +3517,13 @@ Chcete qBittorrent nastavit jako výchozí program?</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Chyba dynamické DNS: qBittorrent je na černé listině této služby, nahlašte prosím chybu na http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Chyba dynamické DNS: qBittorrent je na černé listině této služby, nahlašte prosím chybu na https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Chyba dynamické DNS: služba odpověděla %1, nahlašte prosím chybu na http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Chyba dynamické DNS: služba odpověděla %1, nahlašte prosím chybu na https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6788,8 +6788,8 @@ Ručně: Různé vlastnosti torrentu (např. cesta uložení) musí být přiřa
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Nové vyhledávací pluginy můžete získat zde: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Nové vyhledávací pluginy můžete získat zde: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_da.ts
+++ b/src/lang/qbittorrent_da.ts
@@ -3513,12 +3513,12 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6781,8 +6781,8 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Her kan du finde nye søgemotor-plugins: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Her kan du finde nye søgemotor-plugins: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_de.ts
+++ b/src/lang/qbittorrent_de.ts
@@ -3516,13 +3516,13 @@ Sollen Torrent-Dateien und Magnet-Links immer mit qBittorent geöffnet werden?</
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Dynamischer DNS Fehler: qBittorrent wurde durch den Dienst geblacklisted. Bitte melden sie einen Bug unter http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Dynamischer DNS Fehler: qBittorrent wurde durch den Dienst geblacklisted. Bitte melden sie einen Bug unter https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Dynamischer DNS Fehler: Der Dienst hat %1 zurückgegeben. Bitte diesen Bug unter http://bugs.qbittorrent.org melden.</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Dynamischer DNS Fehler: Der Dienst hat %1 zurückgegeben. Bitte diesen Bug unter https://bugs.qbittorrent.org melden.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6789,8 +6789,8 @@ Manuell: diverse Torrent-Eigenschaften (z.B. der Speicherpfad) müssen händisch
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Neue Suchmaschinen-Plugins können hier heruntergeladen werden: &lt;a href=&quot;http:plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Neue Suchmaschinen-Plugins können hier heruntergeladen werden: &lt;a href=&quot;http:plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_el.ts
+++ b/src/lang/qbittorrent_el.ts
@@ -3517,13 +3517,13 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Σφάλμα Dynamic DNS: το qBittorrent έχει καταχωρηθεί σε blocklist από την υπηρεσία, παρακαλώ υποβάλετε μια αναφορά σφαλμάτων στο http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Σφάλμα Dynamic DNS: το qBittorrent έχει καταχωρηθεί σε blocklist από την υπηρεσία, παρακαλώ υποβάλετε μια αναφορά σφαλμάτων στο https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Σφάλμα Dynamic DNS: επιστράφηκε %1 από την υπηρεσία, παρακαλώ υποβάλετε μια αναφορά σφάλματος στο http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Σφάλμα Dynamic DNS: επιστράφηκε %1 από την υπηρεσία, παρακαλώ υποβάλετε μια αναφορά σφάλματος στο https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6788,8 +6788,8 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Μπορείτε να βρείτε νέες προσθήκες μηχανών αναζήτησης εδώ: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Μπορείτε να βρείτε νέες προσθήκες μηχανών αναζήτησης εδώ: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_en.ts
+++ b/src/lang/qbittorrent_en.ts
@@ -3507,12 +3507,12 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6769,7 +6769,7 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/lang/qbittorrent_en_AU.ts
+++ b/src/lang/qbittorrent_en_AU.ts
@@ -3512,12 +3512,12 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6778,7 +6778,7 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/lang/qbittorrent_en_GB.ts
+++ b/src/lang/qbittorrent_en_GB.ts
@@ -3512,12 +3512,12 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6778,7 +6778,7 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/lang/qbittorrent_eo.ts
+++ b/src/lang/qbittorrent_eo.ts
@@ -3510,12 +3510,12 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6772,7 +6772,7 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/lang/qbittorrent_es.ts
+++ b/src/lang/qbittorrent_es.ts
@@ -3521,13 +3521,13 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Error de DNS dinámico: qBittorrent fue incluido en la lista negra por el servicio, envíe un informe de error en http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Error de DNS dinámico: qBittorrent fue incluido en la lista negra por el servicio, envíe un informe de error en https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Error de DNS dinámico: el servicio devolvió %1; envíe un informe de error en http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Error de DNS dinámico: el servicio devolvió %1; envíe un informe de error en https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6794,8 +6794,8 @@ Manual: Diversas características del torrent (p.e. ruta de guardado) deben ser 
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Puedes obtener nuevos motores de búsqueda aquí: &lt;a href=&quot;http:plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Puedes obtener nuevos motores de búsqueda aquí: &lt;a href=&quot;http:plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_et.ts
+++ b/src/lang/qbittorrent_et.ts
@@ -3517,12 +3517,12 @@ Soovite qBitorrenti määrata peamiseks programmiks, et neid avada?</translation
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6782,7 +6782,7 @@ Manuaalne: mitmed torrenti omadused (s.h. salvestamise asukoht) tuleb määrata 
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/lang/qbittorrent_eu.ts
+++ b/src/lang/qbittorrent_eu.ts
@@ -3514,12 +3514,12 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6785,8 +6785,8 @@ Eskuzkoa: Torrent ezaugarri ugari (adib. gordetze helburua) eskuz esleitu behar 
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Bilaketa gailu plugin berriak lortu ditzakezu hemen: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Bilaketa gailu plugin berriak lortu ditzakezu hemen: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_fa.ts
+++ b/src/lang/qbittorrent_fa.ts
@@ -3510,12 +3510,12 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6772,7 +6772,7 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/lang/qbittorrent_fi.ts
+++ b/src/lang/qbittorrent_fi.ts
@@ -3514,12 +3514,12 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6778,8 +6778,8 @@ Manuaalinen: Monet torrenttien määritykset, kuten tallennussijainti, on asetet
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Voit hakea uusia hakukoneliitännäisiä täältä: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Voit hakea uusia hakukoneliitännäisiä täältä: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_fr.ts
+++ b/src/lang/qbittorrent_fr.ts
@@ -3517,13 +3517,13 @@ Voulez-vous faire de qBittorrent l&apos;application par défaut pour ceux-ci ?</
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Erreur du DNS dynamique : qBittorrent a été mis sur liste noire par le service, veuillez soumettre un rapport de bogue sur http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Erreur du DNS dynamique : qBittorrent a été mis sur liste noire par le service, veuillez soumettre un rapport de bogue sur https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Erreur du DNS dynamique : %1 a été renvoyé par le service, veuillez soumettre un rapport de bogue sur http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Erreur du DNS dynamique : %1 a été renvoyé par le service, veuillez soumettre un rapport de bogue sur https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6787,8 +6787,8 @@ Manuel : Certaines propriétés du torrent (p. ex. le répertoire de destination
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Vous pouvez obtenir davantage de greffons de recherche ici : &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Vous pouvez obtenir davantage de greffons de recherche ici : &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_gl.ts
+++ b/src/lang/qbittorrent_gl.ts
@@ -3517,13 +3517,13 @@ Desexa facer do qBittorrent o aplicativo predeterminado para estes ficheiros?</t
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Erro do DNS dinámico: o qBittorrent está na lista negra deste servizo, por favor informe deste erro en http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Erro do DNS dinámico: o qBittorrent está na lista negra deste servizo, por favor informe deste erro en https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Erro de DNS dinámico: o servizo devolveu %1 , por favor envíe un informe de erro en http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Erro de DNS dinámico: o servizo devolveu %1 , por favor envíe un informe de erro en https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6789,8 +6789,8 @@ Manual: varias propiedades do torrent (p.e: a ruta de gardado) deben asignarse m
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Pode obter novos engadidos con motores de busca aquí: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Pode obter novos engadidos con motores de busca aquí: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_he.ts
+++ b/src/lang/qbittorrent_he.ts
@@ -3517,13 +3517,13 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>שגיאת DNS דינמי: qBittorrent הוכנס אל רשימה שחורה ע״י השירות, אנא הגש דוח תקלים בכתובת: http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>שגיאת DNS דינמי: qBittorrent הוכנס אל רשימה שחורה ע״י השירות, אנא הגש דוח תקלים בכתובת: https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>שגיאת DNS דינמי: %1 הוחזר ע״י השירות, אנא הגש דוח תקלים בכתובת: http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>שגיאת DNS דינמי: %1 הוחזר ע״י השירות, אנא הגש דוח תקלים בכתובת: https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6787,8 +6787,8 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>אתה יכול לקבל מתקעי מנוע חיפוש חדשים כאן: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>אתה יכול לקבל מתקעי מנוע חיפוש חדשים כאן: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_hi_IN.ts
+++ b/src/lang/qbittorrent_hi_IN.ts
@@ -3513,12 +3513,12 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6776,8 +6776,8 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>नए खोज साधन प्लगिन यहाँ से प्राप्त करें : &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>नए खोज साधन प्लगिन यहाँ से प्राप्त करें : &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_hr.ts
+++ b/src/lang/qbittorrent_hr.ts
@@ -3512,12 +3512,12 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6774,7 +6774,7 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/lang/qbittorrent_hu.ts
+++ b/src/lang/qbittorrent_hu.ts
@@ -3515,13 +3515,13 @@ Szeretnéd alapértelmezetté tenni?</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Dinamikus DNS hiba: a qBittorrent feketelistára került a szolgáltató által, kérem jelezze ezt a http://bugs.qbittorrent.org webcímen.</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Dinamikus DNS hiba: a qBittorrent feketelistára került a szolgáltató által, kérem jelezze ezt a https://bugs.qbittorrent.org webcímen.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Dinamikus DNS hiba: %1 választ küldött a kiszolgáló, kérem jelezze ezt a http://bugs.qbittorrent.org webcímen.</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Dinamikus DNS hiba: %1 választ küldött a kiszolgáló, kérem jelezze ezt a https://bugs.qbittorrent.org webcímen.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6786,8 +6786,8 @@ Kézi: A különböző torrenttulajdonságokat (például a mentési útvonalat)
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>További keresőmodulok tölthetőek le innen: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>További keresőmodulok tölthetőek le innen: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_hy.ts
+++ b/src/lang/qbittorrent_hy.ts
@@ -3510,12 +3510,12 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6772,8 +6772,8 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Որոնման նոր խրվակներ կարելի է ձեռք բերել այստեղ՝ &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Որոնման նոր խրվակներ կարելի է ձեռք բերել այստեղ՝ &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_id.ts
+++ b/src/lang/qbittorrent_id.ts
@@ -3513,12 +3513,12 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6783,8 +6783,8 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Anda dapat mendapatkan plugin mesin pencari baru disini: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Anda dapat mendapatkan plugin mesin pencari baru disini: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_is.ts
+++ b/src/lang/qbittorrent_is.ts
@@ -3896,12 +3896,12 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7189,7 +7189,7 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/lang/qbittorrent_it.ts
+++ b/src/lang/qbittorrent_it.ts
@@ -3624,15 +3624,15 @@ Vuoi rendere qBittorrent l&apos;applicazione predefinita per questi file?</trans
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation>Errore DNS dinamico: qBittorrent è stato inserito in elenco non autorizzati dal servizio.
-Invia una segnalazione di bug a http://bugs.qbittorrent.org.</translation>
+Invia una segnalazione di bug a https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation>Errore DNS dinamico: è stato restituito dal servizio %1 .
-Invia una segnalazione di bug a http://bugs.qbittorrent.org.</translation>
+Invia una segnalazione di bug a https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6905,8 +6905,8 @@ Per i dettagli controlla il registro eventi.</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>È possibile ottenere altri plugin di ricerca qui: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>È possibile ottenere altri plugin di ricerca qui: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_ja.ts
+++ b/src/lang/qbittorrent_ja.ts
@@ -3517,13 +3517,13 @@ qBittorrentをこれらの既定アプリケーションにしますか？</tran
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>ダイナミックDNSエラー: qBittorrentがサービスによってブラックリストに登録されました。 http://bugs.qbittorrent.org でバグ報告を送信してください。</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>ダイナミックDNSエラー: qBittorrentがサービスによってブラックリストに登録されました。 https://bugs.qbittorrent.org でバグ報告を送信してください。</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>ダイナミックDNSエラー: サービスから %1 が返されました。http://bugs.qbittorrent.org でバグ報告を送信してください。</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>ダイナミックDNSエラー: サービスから %1 が返されました。https://bugs.qbittorrent.org でバグ報告を送信してください。</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6790,8 +6790,8 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>次のURLから新しい検索プラグインを入手できます: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>次のURLから新しい検索プラグインを入手できます: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_ka.ts
+++ b/src/lang/qbittorrent_ka.ts
@@ -3510,12 +3510,12 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6774,8 +6774,8 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>თქვენ შეგიძლიათ არალი საძიებო მოდულების აქ მოძიება: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>თქვენ შეგიძლიათ არალი საძიებო მოდულების აქ მოძიება: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_ko.ts
+++ b/src/lang/qbittorrent_ko.ts
@@ -3516,13 +3516,13 @@ qBittorrent를 이에 대한 기본 응용 프로그램으로 설정하시겠습
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>동적 DNS 오류: qBittorrent가 서비스에 의해 차단되었습니다. http://bugs.qbittorrent.org 에서 버그 보고서를 제출하십시오.</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>동적 DNS 오류: qBittorrent가 서비스에 의해 차단되었습니다. https://bugs.qbittorrent.org 에서 버그 보고서를 제출하십시오.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>동적 DNS 오류: 서비스에서 %1을(를) 반환했습니다. http://bugs.qbittorrent.org 에서 버그 보고서를 제출하십시오.</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>동적 DNS 오류: 서비스에서 %1을(를) 반환했습니다. https://bugs.qbittorrent.org 에서 버그 보고서를 제출하십시오.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6787,8 +6787,8 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>새 검색 엔진 플러그인을 받을 사이트: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>새 검색 엔진 플러그인을 받을 사이트: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_lt.ts
+++ b/src/lang/qbittorrent_lt.ts
@@ -3514,12 +3514,12 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6784,8 +6784,8 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Naujų paieškos sistemų papildinių galite gauti čia: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Naujų paieškos sistemų papildinių galite gauti čia: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_ltg.ts
+++ b/src/lang/qbittorrent_ltg.ts
@@ -3510,12 +3510,12 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"/>
     </message>
     <message>
@@ -6772,7 +6772,7 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/lang/qbittorrent_lv_LV.ts
+++ b/src/lang/qbittorrent_lv_LV.ts
@@ -3517,13 +3517,13 @@ Vai vēlaties to uzstādīt kā noklusēto programmu tagad?</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Dinamiskā DNS kļūme: qBittorrent klients ir nobloķēts un iekļauts melnajā sarakstā. Lūdzu noziņojiet šo gadījumu http://bugs.qbittorrent.org</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Dinamiskā DNS kļūme: qBittorrent klients ir nobloķēts un iekļauts melnajā sarakstā. Lūdzu noziņojiet šo gadījumu https://bugs.qbittorrent.org</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Dinamiskā DNS kļūme: serviss atbildēja ar %1, lūdzu noziņojiet šo gadījumu http://bugs.qbittorrent.org</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Dinamiskā DNS kļūme: serviss atbildēja ar %1, lūdzu noziņojiet šo gadījumu https://bugs.qbittorrent.org</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6788,8 +6788,8 @@ Manuāli: Nozīmē, ka torrenta uzstādījumi (piem. saglabāšanas vieta) būs 
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Jūs varat atrast jaunus meklētāju spraudņus šeit: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Jūs varat atrast jaunus meklētāju spraudņus šeit: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_mn_MN.ts
+++ b/src/lang/qbittorrent_mn_MN.ts
@@ -3589,12 +3589,12 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6851,7 +6851,7 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/lang/qbittorrent_ms_MY.ts
+++ b/src/lang/qbittorrent_ms_MY.ts
@@ -3513,12 +3513,12 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6784,8 +6784,8 @@ Manual: Pelbagai sifat torrent (seperti laluan simpan) mesti diumpuk secara manu
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Anda boleh dapatkan pemalam enjin gelintar baharu di sini: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Anda boleh dapatkan pemalam enjin gelintar baharu di sini: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_nb.ts
+++ b/src/lang/qbittorrent_nb.ts
@@ -3517,13 +3517,13 @@ Vil du tilknytte qBittorrent med disse?</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Dynamisk DNS-feil: qBittorrent ble svartelistet av tjenesten. Rapporter som feil på http://bugs.qbittorrent.org</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Dynamisk DNS-feil: qBittorrent ble svartelistet av tjenesten. Rapporter som feil på https://bugs.qbittorrent.org</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Dynamisk DNS-feil: %1 ble returnert av tjenesten. Rapporter som feil hos http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Dynamisk DNS-feil: %1 ble returnert av tjenesten. Rapporter som feil hos https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6788,9 +6788,9 @@ Manuelt: Diverse torrent-egenskaper (f.eks. lagringssti) må tilordnes manuelt</
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Du kan få nye søkemotormoduler her: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;
-http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Du kan få nye søkemotormoduler her: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;
+https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_nl.ts
+++ b/src/lang/qbittorrent_nl.ts
@@ -3517,13 +3517,13 @@ Wilt u qBittorrent hiervoor het standaardprogramma maken?</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Dynamische DNS fout: qBittorrent werd geblacklist door deze dienst. Verzend een bugrapport op http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Dynamische DNS fout: qBittorrent werd geblacklist door deze dienst. Verzend een bugrapport op https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Dynamische DNS fout: %1 werd teruggegeven door de dienst. Verzend een bugrapport op http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Dynamische DNS fout: %1 werd teruggegeven door de dienst. Verzend een bugrapport op https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6788,8 +6788,8 @@ Handmatig: verschillende torrent-eigenschappen (bijvoorbeeld opslagpad) moeten h
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>U kunt hier nieuwe zoekmachineplugins vinden:&lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>U kunt hier nieuwe zoekmachineplugins vinden:&lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_oc.ts
+++ b/src/lang/qbittorrent_oc.ts
@@ -3512,12 +3512,12 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6774,7 +6774,7 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/lang/qbittorrent_pl.ts
+++ b/src/lang/qbittorrent_pl.ts
@@ -3517,13 +3517,13 @@ Czy chcesz, aby qBittorrent był dla nich domyślnym programem?</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Błąd dynamicznego DNS: usługa dodała program qBittorrent do czarnej listy; prześlij raport o błędzie na http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Błąd dynamicznego DNS: usługa dodała program qBittorrent do czarnej listy; prześlij raport o błędzie na https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Błąd dynamicznego DNS: %1 został zwrócony przez usługę, prześlij raport o błędzie na http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Błąd dynamicznego DNS: %1 został zwrócony przez usługę, prześlij raport o błędzie na https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6788,8 +6788,8 @@ Ręcznie: różne właściwości torrenta (np. ścieżka zapisu) muszą być prz
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Tutaj możesz pobrać nowe wtyczki wyszukiwania: &lt;/a&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Tutaj możesz pobrać nowe wtyczki wyszukiwania: &lt;/a&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_pt_BR.ts
+++ b/src/lang/qbittorrent_pt_BR.ts
@@ -3517,13 +3517,13 @@ Você quer tornar o qBittorrent o aplicativo padrão para estes?</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Erro do DNS dinâmico: o qBittorrent está na lista negra deste serviço. Por favor submeta um relatório do bug em http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Erro do DNS dinâmico: o qBittorrent está na lista negra deste serviço. Por favor submeta um relatório do bug em https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Erro do DNS dinâmico: %1 foi retornado pelo serviço. Por favor submeta um relatório do bug em http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Erro do DNS dinâmico: %1 foi retornado pelo serviço. Por favor submeta um relatório do bug em https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6788,8 +6788,8 @@ Manual: Várias propriedades do torrent (ex: o caminho do salvamento) devem ser 
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Você pode obter novos plugins de motores de busca aqui: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Você pode obter novos plugins de motores de busca aqui: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_pt_PT.ts
+++ b/src/lang/qbittorrent_pt_PT.ts
@@ -3517,13 +3517,13 @@ Quer tornar o qBittorrent a aplicação predefinida para estes?</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Erro do DNS dinâmico: o qBittorrent foi colocado na lista negra pelo serviço. Submeta um relatório do erro em http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Erro do DNS dinâmico: o qBittorrent foi colocado na lista negra pelo serviço. Submeta um relatório do erro em https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Erro de DNS dinâmico: %1 foi devolvido pelo serviço, submeta um relatório do erro em http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Erro de DNS dinâmico: %1 foi devolvido pelo serviço, submeta um relatório do erro em https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6788,8 +6788,8 @@ Manual: Várias propriedades do torrent (ex: caminho para guardar) deverão ser 
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Pode obter novos plugins para o motor de busca aqui: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Pode obter novos plugins para o motor de busca aqui: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_ro.ts
+++ b/src/lang/qbittorrent_ro.ts
@@ -3517,12 +3517,12 @@ Doriți să faceți qBittorrent programul implicit pentru acestea?</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6784,8 +6784,8 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Puteți obține noi module pentru motorul de căutare de căutare de aici: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Puteți obține noi module pentru motorul de căutare de căutare de aici: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_ru.ts
+++ b/src/lang/qbittorrent_ru.ts
@@ -3517,13 +3517,13 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Ошибка динамического DNS: qBittorrent внесён службой в чёрный список. Пожалуйста, сообщите об ошибке на  http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Ошибка динамического DNS: qBittorrent внесён службой в чёрный список. Пожалуйста, сообщите об ошибке на  https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Ошибка динамического DNS: Служба вернула %1. Пожалуйста, сообщите об ошибке на http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Ошибка динамического DNS: Служба вернула %1. Пожалуйста, сообщите об ошибке на https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6788,8 +6788,8 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Вы можете найти новые поисковые плагины здесь: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Вы можете найти новые поисковые плагины здесь: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_sk.ts
+++ b/src/lang/qbittorrent_sk.ts
@@ -3517,12 +3517,12 @@ Chcete qBittorrent nastaviť ako predvolenú aplikáciu?</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Dynamická chyba DNS: Služba qBittorrent zaradila na čiernu listinu, odošlite prosím hlásenie o chybe na http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Dynamická chyba DNS: Služba qBittorrent zaradila na čiernu listinu, odošlite prosím hlásenie o chybe na https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6788,8 +6788,8 @@ Ručne: Rôzne vlastnosti torrentu (napr. cesta uloženia) musia byť priradené
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Nové zásuvné moduly vyhľadávačov nájdete tu: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Nové zásuvné moduly vyhľadávačov nájdete tu: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_sl.ts
+++ b/src/lang/qbittorrent_sl.ts
@@ -3518,12 +3518,12 @@ Ali želite nastaviti qBittorrent kot privzeti program za te vrste?</translation
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6788,8 +6788,8 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Nove iskalne vtičnike najdete na : &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Nove iskalne vtičnike najdete na : &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_sr.ts
+++ b/src/lang/qbittorrent_sr.ts
@@ -3511,12 +3511,12 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6773,8 +6773,8 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Можете преузети још додатака за претраживање овде: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Можете преузети још додатака за претраживање овде: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_sv.ts
+++ b/src/lang/qbittorrent_sv.ts
@@ -3517,13 +3517,13 @@ Vill du göra qBittorrent till standardprogrammet för dessa?</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Dynamiskt DNS-fel: qBittorrent svartlistades av tjänsten, skicka en felrapport på http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Dynamiskt DNS-fel: qBittorrent svartlistades av tjänsten, skicka en felrapport på https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Dynamiskt DNS-fel: %1 returnerades av tjänsten, skicka en felrapport på http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Dynamiskt DNS-fel: %1 returnerades av tjänsten, skicka en felrapport på https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6788,8 +6788,8 @@ Manuell: Olika torrentegenskaper (t.ex. sparsökväg) måste tilldelas manuellt<
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Du kan skaffa nya sökmotorsinsticksmoduler här: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Du kan skaffa nya sökmotorsinsticksmoduler här: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_th.ts
+++ b/src/lang/qbittorrent_th.ts
@@ -3514,12 +3514,12 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6776,7 +6776,7 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/lang/qbittorrent_tr.ts
+++ b/src/lang/qbittorrent_tr.ts
@@ -3517,13 +3517,13 @@ qBittorrent&apos;i bunlar için varsayılan uygulama yapmak istiyor musunuz?</tr
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Değişken DNS hatası: qBittorrent, hizmet tarafından kara listeye alındı, lütfen http://bugs.qbittorrent.org adresinde bir hata bildirimi gönderin.</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Değişken DNS hatası: qBittorrent, hizmet tarafından kara listeye alındı, lütfen https://bugs.qbittorrent.org adresinde bir hata bildirimi gönderin.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Değişken DNS hatası: %1, hizmet tarafından geri döndürüldü, lütfen http://bugs.qbittorrent.org adresinde bir hata bildirimi gönderin.</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Değişken DNS hatası: %1, hizmet tarafından geri döndürüldü, lütfen https://bugs.qbittorrent.org adresinde bir hata bildirimi gönderin.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6788,8 +6788,8 @@ Elle: Çeşitli torrent özellikleri (örn. kaydetme yolu) el ile atanmak zorund
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Yeni arama motoru eklentilerini buradan alabilirsiniz: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Yeni arama motoru eklentilerini buradan alabilirsiniz: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_uk.ts
+++ b/src/lang/qbittorrent_uk.ts
@@ -3517,13 +3517,13 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Помилка динамічної DNS: qBittorrent потрапив у чорний список сервісу, надішліть звіт про помилку на http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Помилка динамічної DNS: qBittorrent потрапив у чорний список сервісу, надішліть звіт про помилку на https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Помилка динамічної DNS: %1 було повернуто службою, надішліть звіт про помилку на http://bugs.qbittorrent.org. </translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Помилка динамічної DNS: %1 було повернуто службою, надішліть звіт про помилку на https://bugs.qbittorrent.org. </translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6788,8 +6788,8 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Ви можете отримати нові пошукові додатки тут: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Ви можете отримати нові пошукові додатки тут: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_uz@Latn.ts
+++ b/src/lang/qbittorrent_uz@Latn.ts
@@ -3512,12 +3512,12 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6774,7 +6774,7 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/lang/qbittorrent_vi.ts
+++ b/src/lang/qbittorrent_vi.ts
@@ -3517,13 +3517,13 @@ Bạn có muốn đặt qBittorrent làm ứng dụng mặc định cho những 
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Lỗi DNS động: qBittorrent đã bị dịch vụ đưa vào danh sách đen, vui lòng gửi báo cáo lỗi tại http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Lỗi DNS động: qBittorrent đã bị dịch vụ đưa vào danh sách đen, vui lòng gửi báo cáo lỗi tại https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>Lỗi DNS động: %1 đã được dịch vụ trả lại, vui lòng gửi báo cáo lỗi tại http://bugs.qbittorrent.org.</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>Lỗi DNS động: %1 đã được dịch vụ trả lại, vui lòng gửi báo cáo lỗi tại https://bugs.qbittorrent.org.</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6788,8 +6788,8 @@ Thủ công: Các thuộc tính torrent khác nhau (ví dụ: đường dẫn l�
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>Bạn có thể tải các plugin công cụ tìm kiếm mới tại đây: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>Bạn có thể tải các plugin công cụ tìm kiếm mới tại đây: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_zh.ts
+++ b/src/lang/qbittorrent_zh.ts
@@ -3517,13 +3517,13 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>动态 DNS 错误：qBittorrent 被该服务列入黑名单，请在http://bugs.qbittorrent.org 提交错误报告。</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>动态 DNS 错误：qBittorrent 被该服务列入黑名单，请在https://bugs.qbittorrent.org 提交错误报告。</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>动态 DNS 错误：服务返回 %1，请在 http://bugs.qbittorrent.org 上提交错误报告。</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>动态 DNS 错误：服务返回 %1，请在 https://bugs.qbittorrent.org 上提交错误报告。</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6788,8 +6788,8 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>您可以在这里获得新的搜索引擎：&lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>您可以在这里获得新的搜索引擎：&lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_zh_HK.ts
+++ b/src/lang/qbittorrent_zh_HK.ts
@@ -3517,13 +3517,13 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>動態 DNS 錯誤：qBittorrent 被服務列入黑名單，請在 http://bugs.qbittorrent.org 遞交臭蟲回報。</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>動態 DNS 錯誤：qBittorrent 被服務列入黑名單，請在 https://bugs.qbittorrent.org 遞交臭蟲回報。</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>動態 DNS 錯誤：服務回傳了 %1，請在 http://bugs.qbittorrent.org 遞交臭蟲回報。</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>動態 DNS 錯誤：服務回傳了 %1，請在 https://bugs.qbittorrent.org 遞交臭蟲回報。</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6788,8 +6788,8 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>需要新的搜尋器附加元件，請到：&lt;a href=&quot;http:plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>需要新的搜尋器附加元件，請到：&lt;a href=&quot;http:plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/lang/qbittorrent_zh_TW.ts
+++ b/src/lang/qbittorrent_zh_TW.ts
@@ -3517,13 +3517,13 @@ Do you want to make qBittorrent the default application for these?</source>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="218"/>
-        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>動態 DNS 錯誤：qBittorrent 被服務列入黑名單，請在 http://bugs.qbittorrent.org 遞交臭蟲回報。</translation>
+        <source>Dynamic DNS error: qBittorrent was blacklisted by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>動態 DNS 錯誤：qBittorrent 被服務列入黑名單，請在 https://bugs.qbittorrent.org 遞交臭蟲回報。</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="226"/>
-        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at http://bugs.qbittorrent.org.</source>
-        <translation>動態 DNS 錯誤：服務回傳了 %1，請在 http://bugs.qbittorrent.org 遞交臭蟲回報。</translation>
+        <source>Dynamic DNS error: %1 was returned by the service, please submit a bug report at https://bugs.qbittorrent.org.</source>
+        <translation>動態 DNS 錯誤：服務回傳了 %1，請在 https://bugs.qbittorrent.org 遞交臭蟲回報。</translation>
     </message>
     <message>
         <location filename="../base/net/dnsupdater.cpp" line="234"/>
@@ -6788,8 +6788,8 @@ Manual: Various torrent properties (e.g. save path) must be assigned manually</s
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="96"/>
-        <source>You can get new search engine plugins here: &lt;a href=&quot;http://plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</source>
-        <translation>您可以在這裡取得新的搜尋引擎外掛：&lt;a href=&quot;http:plugins.qbittorrent.org&quot;&gt;http://plugins.qbittorrent.org&lt;/a&gt;</translation>
+        <source>You can get new search engine plugins here: &lt;a href=&quot;https://plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</source>
+        <translation>您可以在這裡取得新的搜尋引擎外掛：&lt;a href=&quot;http:plugins.qbittorrent.org&quot;&gt;https://plugins.qbittorrent.org&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../gui/search/pluginselectdialog.ui" line="108"/>

--- a/src/qbittorrent.exe.manifest
+++ b/src/qbittorrent.exe.manifest
@@ -36,7 +36,7 @@
   </compatibility>
   <!-- Enable long paths that exceed MAX_PATH in length -->
   <asmv3:application>
-    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+    <asmv3:windowsSettings xmlns="https://schemas.microsoft.com/SMI/2016/WindowsSettings">
       <longPathAware>true</longPathAware>
     </asmv3:windowsSettings>
   </asmv3:application>

--- a/src/searchengine/nova3/helpers.py
+++ b/src/searchengine/nova3/helpers.py
@@ -55,7 +55,7 @@ if "sock_proxy" in os.environ and len(os.environ["sock_proxy"].strip()) > 0:
 
 def htmlentitydecode(s):
     # First convert alpha entities (such as &eacute;)
-    # (Inspired from http://mail.python.org/pipermail/python-list/2007-June/443813.html)
+    # (Inspired from https://mail.python.org/pipermail/python-list/2007-June/443813.html)
     def entity2char(m):
         entity = m.group(1)
         if entity in html.entities.name2codepoint:

--- a/src/searchengine/nova3/nova2.py
+++ b/src/searchengine/nova3/nova2.py
@@ -108,7 +108,7 @@ def displayCapabilities(supported_engines):
     <capabilities>
       <engine_short_name>
         <name>long name</name>
-        <url>http://example.com</url>
+        <url>https://example.com</url>
         <categories>movies music games</categories>
       </engine_short_name>
     </capabilities>

--- a/src/webui/www/private/css/Core.css
+++ b/src/webui/www/private/css/Core.css
@@ -5,7 +5,7 @@ Core.css for Mocha UI
 Theme: Default
 
 Copyright:
-	Copyright (c) 2007-2009 Greg Houston, <http://greghoustondesign.com/>.
+	Copyright (c) 2007-2009 Greg Houston, <https://greghoustondesign.com/>.
 
 License:
 	MIT-style license.

--- a/src/webui/www/private/css/Layout.css
+++ b/src/webui/www/private/css/Layout.css
@@ -5,7 +5,7 @@ Core.css for Mocha UI
 Theme: Default
 
 Copyright:
-	Copyright (c) 2007-2009 Greg Houston, <http://greghoustondesign.com/>.
+	Copyright (c) 2007-2009 Greg Houston, <https://greghoustondesign.com/>.
 
 License:
 	MIT-style license.

--- a/src/webui/www/private/css/Tabs.css
+++ b/src/webui/www/private/css/Tabs.css
@@ -5,7 +5,7 @@ Tabs.css for Mocha UI
 Theme: Default
 
 Copyright:
-	Copyright (c) 2007-2009 Greg Houston, <http://greghoustondesign.com/>.
+	Copyright (c) 2007-2009 Greg Houston, <https://greghoustondesign.com/>.
 
 License:
 	MIT-style license.

--- a/src/webui/www/private/css/Window.css
+++ b/src/webui/www/private/css/Window.css
@@ -5,7 +5,7 @@ Window.css for Mocha UI
 Theme: Default
 
 Copyright:
-	Copyright (c) 2007-2009 Greg Houston, <http://greghoustondesign.com/>.
+	Copyright (c) 2007-2009 Greg Houston, <https://greghoustondesign.com/>.
 
 License:
 	MIT-style license.

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -90,7 +90,7 @@
                     <li>
                         <a class="returnFalse">QBT_TR(Help)QBT_TR[CONTEXT=MainWindow]</a>
                         <ul>
-                            <li><a id="docsLink" target="_blank" href="http://wiki.qbittorrent.org/"><img class="MyMenuIcon" src="icons/help-contents.svg" alt="QBT_TR(Documentation)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Documentation)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li><a id="docsLink" target="_blank" href="https://wiki.qbittorrent.org/"><img class="MyMenuIcon" src="icons/help-contents.svg" alt="QBT_TR(Documentation)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Documentation)QBT_TR[CONTEXT=MainWindow]</a></li>
                             <li class="divider"><a id="bugLink" target="_blank" href="https://www.qbittorrent.org/donate"><img class="MyMenuIcon" src="icons/wallet-open.svg" alt="QBT_TR(Donate!)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Donate!)QBT_TR[CONTEXT=MainWindow]</a></li>
                             <li><a id="aboutLink"><img class="MyMenuIcon" src="icons/help-about.svg" alt="QBT_TR(About)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(About)QBT_TR[CONTEXT=MainWindow]</a></li>
                         </ul>

--- a/src/webui/www/private/scripts/lib/mocha-0.9.6.js
+++ b/src/webui/www/private/scripts/lib/mocha-0.9.6.js
@@ -4,7 +4,7 @@ Script: Core.js
 	MUI - A Web Applications User Interface Framework.
 
 Copyright:
-	Copyright (c) 2007-2009 Greg Houston, <http://greghoustondesign.com/>.
+	Copyright (c) 2007-2009 Greg Houston, <https://greghoustondesign.com/>.
 
 License:
 	MIT-style license.
@@ -511,7 +511,7 @@ Element.implement({
 /*
 
 Shake effect by Uvumi Tools
-http://tools.uvumi.com/element-shake.html
+https://tools.uvumi.com/element-shake.html
 
 Function: shake
 
@@ -944,7 +944,7 @@ Script: Themes.js
 	Allows for switching themes dynamically.
 
 Copyright:
-	Copyright (c) 2007-2009 Greg Houston, <http://greghoustondesign.com/>.
+	Copyright (c) 2007-2009 Greg Houston, <https://greghoustondesign.com/>.
 
 License:
 	MIT-style license.
@@ -1140,7 +1140,7 @@ Script: Window.js
 	Build windows.
 
 Copyright:
-	Copyright (c) 2007-2009 Greg Houston, <http://greghoustondesign.com/>.
+	Copyright (c) 2007-2009 Greg Houston, <https://greghoustondesign.com/>.
 
 License:
 	MIT-style license.
@@ -3674,7 +3674,7 @@ Script: Modal.js
 	Create modal dialog windows.
 
 Copyright:
-	Copyright (c) 2007-2009 Greg Houston, <http://greghoustondesign.com/>.
+	Copyright (c) 2007-2009 Greg Houston, <https://greghoustondesign.com/>.
 
 License:
 	MIT-style license.
@@ -3769,7 +3769,7 @@ Script: Windows-from-html.js
 	Create windows from html markup in page.
 
 Copyright:
-	Copyright (c) 2007-2009 Greg Houston, <http://greghoustondesign.com/>.
+	Copyright (c) 2007-2009 Greg Houston, <https://greghoustondesign.com/>.
 
 License:
 	MIT-style license.
@@ -3833,7 +3833,7 @@ Script: Windows-from-json.js
 	Create one or more windows from JSON data. You can define all the same properties as you can for new MUI.Window(). Undefined properties are set to their defaults.
 
 Copyright:
-	Copyright (c) 2007-2009 Greg Houston, <http://greghoustondesign.com/>.
+	Copyright (c) 2007-2009 Greg Houston, <https://greghoustondesign.com/>.
 
 License:
 	MIT-style license.
@@ -3888,7 +3888,7 @@ Script: Arrange-cascade.js
 	Cascade windows.
 
 Copyright:
-	Copyright (c) 2007-2009 Greg Houston, <http://greghoustondesign.com/>.
+	Copyright (c) 2007-2009 Greg Houston, <https://greghoustondesign.com/>.
 
 License:
 	MIT-style license.
@@ -3970,7 +3970,7 @@ Script: Arrange-tile.js
 	Cascade windows.
 
 Copyright:
-	Copyright (c) 2007-2009 Greg Houston, <http://greghoustondesign.com/>.
+	Copyright (c) 2007-2009 Greg Houston, <https://greghoustondesign.com/>.
 
 Authors:
 	Harry Roberts and Greg Houston
@@ -4086,7 +4086,7 @@ Script: Tabs.js
 	Functionality for window tabs.
 
 Copyright:
-	Copyright (c) 2007-2009 Greg Houston, <http://greghoustondesign.com/>.
+	Copyright (c) 2007-2009 Greg Houston, <https://greghoustondesign.com/>.
 
 License:
 	MIT-style license.
@@ -4140,7 +4140,7 @@ Script: Layout.js
 	Create web application layouts. Enables window maximize.
 
 Copyright:
-	Copyright (c) 2007-2009 Greg Houston, <http://greghoustondesign.com/>.
+	Copyright (c) 2007-2009 Greg Houston, <https://greghoustondesign.com/>.
 
 License:
 	MIT-style license.
@@ -5640,7 +5640,7 @@ Script: Dock.js
 	Implements the dock/taskbar. Enables window minimize.
 
 Copyright:
-	Copyright (c) 2007-2009 Greg Houston, <http://greghoustondesign.com/>.
+	Copyright (c) 2007-2009 Greg Houston, <https://greghoustondesign.com/>.
 
 License:
 	MIT-style license.
@@ -6093,7 +6093,7 @@ Script: Workspaces.js
 	Save and load workspaces. The Workspaces emulate Adobe Illustrator functionality remembering what windows are open and where they are positioned.
 
 Copyright:
-	Copyright (c) 2007-2009 Greg Houston, <http://greghoustondesign.com/>.
+	Copyright (c) 2007-2009 Greg Houston, <https://greghoustondesign.com/>.
 
 License:
 	MIT-style license.

--- a/src/webui/www/private/views/about.html
+++ b/src/webui/www/private/views/about.html
@@ -13,11 +13,11 @@
         </tr>
         <tr>
             <td>QBT_TR(Bug Tracker:)QBT_TR[CONTEXT=AboutDialog]</td>
-            <td><a href="http://bugs.qbittorrent.org" target="_blank">http://bugs.qbittorrent.org</a></td>
+            <td><a href="https://bugs.qbittorrent.org" target="_blank">https://bugs.qbittorrent.org</a></td>
         </tr>
         <tr>
             <td>QBT_TR(Forum:)QBT_TR[CONTEXT=AboutDialog]</td>
-            <td><a href="http://forum.qbittorrent.org" target="_blank">http://forum.qbittorrent.org</a></td>
+            <td><a href="https://forum.qbittorrent.org" target="_blank">https://forum.qbittorrent.org</a></td>
         </tr>
     </table>
 </div>

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1623,7 +1623,7 @@
 
         const registerDynDns = function() {
             if ($('dyndns_select').getProperty('value').toInt() == 1) {
-                window.open("http://www.no-ip.com/services/managed_dns/free_dynamic_dns.html", "NO-IP Registration");
+                window.open("https://www.no-ip.com/services/managed_dns/free_dynamic_dns.html", "NO-IP Registration");
             }
             else {
                 window.open("https://www.dyndns.com/account/services/hosts/add.html", "DynDNS Registration");

--- a/src/webui/www/private/views/searchplugins.html
+++ b/src/webui/www/private/views/searchplugins.html
@@ -63,7 +63,7 @@
     </div>
 
     <span>QBT_TR(Warning: Be sure to comply with your country's copyright laws when downloading torrents from any of these search engines.)QBT_TR[CONTEXT=PluginSelectDlg]</span>
-    <span style="font-style: italic;">QBT_TR(You can get new search engine plugins here:)QBT_TR[CONTEXT=PluginSelectDlg] <a href="http://plugins.qbittorrent.org" target="_blank">http://plugins.qbittorrent.org</a></span>
+    <span style="font-style: italic;">QBT_TR(You can get new search engine plugins here:)QBT_TR[CONTEXT=PluginSelectDlg] <a href="https://plugins.qbittorrent.org" target="_blank">https://plugins.qbittorrent.org</a></span>
     <div style="width: 100%; margin-top: 10px;">
         <button style="width: 33%; line-height: 1.4em;" onclick="qBittorrent.SearchPlugins.installPlugin();">QBT_TR(Install new plugin)QBT_TR[CONTEXT=PluginSelectDlg]</button>
         <button style="width: 33%; line-height: 1.4em;" onclick="qBittorrent.SearchPlugins.checkForUpdates();">QBT_TR(Check for updates)QBT_TR[CONTEXT=PluginSelectDlg]</button>


### PR DESCRIPTION
Converted http:// to https:// links, wherever possible. All domains were tested to ensure that they are supported (e.g., http://checkip.dyndns.org was left unconverted, as it does not support https). 

HTTPS is important because it provides security, especially when users may be going to these websites to download updates to qBittorrent, download plugins, etc. By taking users to the http versions of the sites, this program is putting them at risk. 

Developers are also better protected now, as documentation-only links (i.e., links in comment blocks in C code, to wikipedia for example) are now also https.

Side note, consider switching to https://api.ipify.org, which supports https.