### PR TITLE
Cache download/upload limit values

### DIFF
--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -337,6 +337,9 @@ namespace BitTorrent
 
         lt::add_torrent_params m_ltAddTorrentParams;
 
+        int m_downloadLimit = 0;
+        int m_uploadLimit = 0;
+
         mutable QBitArray m_pieces;
     };
 }


### PR DESCRIPTION
A little more caching to prevent blocking calls to libtorrent.
It seems that what remains after this PR cannot be cached, since it is updated in the process, so I will have to use other methods to avoid blocking on them.