### PR TITLE
Make `Peers` fields actually show peers

### DIFF
--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -475,8 +475,8 @@ void PropertiesWidget::loadDynamicData()
                     , QString::number(m_torrent->totalSeedsCount())));
 
             m_ui->labelPeersVal->setText(tr("%1 (%2 total)", "%1 and %2 are numbers, e.g. 3 (10 total)")
-                .arg(QString::number(m_torrent->leechsCount())
-                    , QString::number(m_torrent->totalLeechersCount())));
+                .arg(QString::number(m_torrent->peersCount())
+                    , QString::number(m_torrent->totalPeersCount())));
 
             const qlonglong dlDuration = m_torrent->activeTime() - m_torrent->finishedTime();
             const QString dlAvg = Utils::Misc::friendlyUnit((m_torrent->totalDownload() / ((dlDuration == 0) ? -1 : dlDuration)), true);

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -385,7 +385,7 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
     case TR_SEEDS:
         return amountString(torrent->seedsCount(), torrent->totalSeedsCount());
     case TR_PEERS:
-        return amountString(torrent->leechsCount(), torrent->totalLeechersCount());
+        return amountString(torrent->peersCount(), torrent->totalPeersCount());
     case TR_DLSPEED:
         return unitString(torrent->downloadPayloadRate(), true);
     case TR_UPSPEED:
@@ -456,7 +456,7 @@ QVariant TransferListModel::internalValue(const BitTorrent::Torrent *torrent, co
     case TR_SEEDS:
         return !alt ? torrent->seedsCount() : torrent->totalSeedsCount();
     case TR_PEERS:
-        return !alt ? torrent->leechsCount() : torrent->totalLeechersCount();
+        return !alt ? torrent->peersCount() : torrent->totalPeersCount();
     case TR_DLSPEED:
         return torrent->downloadPayloadRate();
     case TR_UPSPEED:

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -421,7 +421,7 @@ void TorrentsController::propertiesAction()
     dataDict[KEY_PROP_SEEDS] = torrent->seedsCount();
     dataDict[KEY_PROP_SEEDS_TOTAL] = torrent->totalSeedsCount();
     dataDict[KEY_PROP_PEERS] = torrent->leechsCount();
-    dataDict[KEY_PROP_PEERS_TOTAL] = torrent->totalLeechersCount();
+    dataDict[KEY_PROP_PEERS_TOTAL] = torrent->totalPeersCount();
     const qreal ratio = torrent->realRatio();
     dataDict[KEY_PROP_RATIO] = ratio > BitTorrent::Torrent::MAX_RATIO ? -1 : ratio;
     dataDict[KEY_PROP_REANNOUNCE] = torrent->nextAnnounce();


### PR DESCRIPTION
Some `Peers` fields and columns show the leeches count instead for some reason. This contradiction can even be seen in the code itself.

Its actually was noticed quite a while ago: https://github.com/qbittorrent/qBittorrent/issues/13619#issuecomment-733818365

So the patch is trying to fix this confusing behavior. The real `Leeches` fields may be implemented later, if we want so.