### PR TITLE
Handle more torrent conflicts

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -60,6 +60,7 @@ namespace BitTorrent
     class InfoHash;
     class MagnetUri;
     class Torrent;
+    class TorrentID;
     class TorrentInfo;
     struct CacheStatus;
     struct SessionStatus;

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -428,7 +428,7 @@ namespace BitTorrent
         void handleTorrentUrlSeedsAdded(TorrentImpl *const torrent, const QVector<QUrl> &newUrlSeeds);
         void handleTorrentUrlSeedsRemoved(TorrentImpl *const torrent, const QVector<QUrl> &urlSeeds);
         void handleTorrentResumeDataReady(TorrentImpl *const torrent, const LoadTorrentParams &data);
-        void handleTorrentIDChanged(const TorrentImpl *torrent, const TorrentID &prevID);
+        void handleTorrentInfoHashChanged(TorrentImpl *torrent, const InfoHash &prevInfoHash);
 
         bool addMoveTorrentStorageJob(TorrentImpl *torrent, const Path &newPath, MoveStorageMode mode);
 
@@ -692,6 +692,7 @@ namespace BitTorrent
         QSet<TorrentID> m_downloadedMetadata;
 
         QHash<TorrentID, TorrentImpl *> m_torrents;
+        QHash<TorrentID, TorrentImpl *> m_hybridTorrentsByAltID;
         QHash<TorrentID, LoadTorrentParams> m_loadingTorrents;
         QHash<QString, AddTorrentParams> m_downloadedTorrents;
         QHash<TorrentID, RemovingTorrentData> m_removingTorrents;

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -2014,10 +2014,10 @@ void TorrentImpl::handleMetadataReceivedAlert(const lt::metadata_received_alert 
     qDebug("Metadata received for torrent %s.", qUtf8Printable(name()));
 
 #ifdef QBT_USES_LIBTORRENT2
-    const TorrentID prevTorrentID = id();
+    const InfoHash prevInfoHash = infoHash();
     m_infoHash = InfoHash(m_nativeHandle.info_hashes());
-    if (prevTorrentID != id())
-        m_session->handleTorrentIDChanged(this, prevTorrentID);
+    if (prevInfoHash != infoHash())
+        m_session->handleTorrentInfoHashChanged(this, prevInfoHash);
 #endif
 
     m_maintenanceJob = MaintenanceJob::HandleMetadata;


### PR DESCRIPTION
This is a continuation of #17576.
Handles the case when you add hybrid torrent by v1-only magnet link and this torrent is already known by its full hybrid info hash (i.e. by both v1 and v2 info hashes).