### PR TITLE
Make strings translatable

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -842,7 +842,7 @@ catch (const RuntimeError &err)
 #else
     QMessageBox msgBox;
     msgBox.setIcon(QMessageBox::Critical);
-    msgBox.setText(tr("Application failed to start."));
+    msgBox.setText(QCoreApplication::translate("Application", "Application failed to start."));
     msgBox.setInformativeText(err.message());
     msgBox.show(); // Need to be shown or to moveToCenter does not work
     msgBox.move(Utils::Gui::screenCenter(&msgBox));

--- a/src/webui/www/private/download.html
+++ b/src/webui/www/private/download.html
@@ -28,8 +28,8 @@
                         </td>
                         <td>
                             <select id="autoTMM" name="autoTMM" onchange="qBittorrent.Download.changeTMM(this)">
-                                <option selected value="false">Manual</option>
-                                <option value="true">Automatic</option>
+                                <option selected value="false">QBT_TR(Manual)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
+                                <option value="true">QBT_TR(Automatic)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
                             </select>
                         </td>
                     </tr>

--- a/src/webui/www/private/upload.html
+++ b/src/webui/www/private/upload.html
@@ -24,8 +24,8 @@
                     </td>
                     <td>
                         <select id="autoTMM" name="autoTMM" onchange="qBittorrent.Download.changeTMM(this)">
-                            <option selected value="false">Manual</option>
-                            <option value="true">Automatic</option>
+                            <option selected value="false">QBT_TR(Manual)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
+                            <option value="true">QBT_TR(Automatic)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
                         </select>
                     </td>
                 </tr>

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -413,7 +413,8 @@
             </legend>
             <div class="formRow">
                 QBT_TR(From:)QBT_TR[CONTEXT=OptionsDialog]
-                <input type="text" id="schedule_from_hour" style="width: 1.5em;" />:<input type="text" id="schedule_from_min" style="width: 1.5em;" /> QBT_TR(To:)QBT_TR[CONTEXT=OptionsDialog]
+                <input type="text" id="schedule_from_hour" style="width: 1.5em;" />:<input type="text" id="schedule_from_min" style="width: 1.5em;" />
+                QBT_TR(To:)QBT_TR[CONTEXT=OptionsDialog]
                 <input type="text" id="schedule_to_hour" style="width: 1.5em;" />:<input type="text" id="schedule_to_min" style="width: 1.5em;" />
             </div>
             <div class="formRow">

--- a/src/webui/www/private/views/search.html
+++ b/src/webui/www/private/views/search.html
@@ -92,7 +92,9 @@
             <tbody>
                 <tr>
                     <td>
-                        There aren't any search plugins installed.<br />Click the &quot;Search plugins...&quot; button at the bottom right of the window to install some.
+                        QBT_TR(There aren't any search plugins installed.)QBT_TR[CONTEXT=SearchEngineWidget]
+                        <br />
+                        QBT_TR(Click the "Search plugins..." button at the bottom right of the window to install some.)QBT_TR[CONTEXT=SearchEngineWidget]
                     </td>
                 </tr>
             </tbody>


### PR DESCRIPTION
* Make strings translatable
* Suppress warning
  Seems `lupdate` tool cannot correctly recognize the class/context of `tr()` here, so specify the
class/context manually.