### PR TITLE
Add one line gaps between trackers in TrackersAdditionalDialog when fetched from URL

### DIFF
--- a/src/gui/properties/trackersadditiondialog.cpp
+++ b/src/gui/properties/trackersadditiondialog.cpp
@@ -116,6 +116,8 @@ void TrackersAdditionDialog::torrentListDownloadFinished(const Net::DownloadResu
         BitTorrent::TrackerEntry newTracker {line};
         if (!existingTrackers.contains(newTracker))
         {
+            if(nb != 0)
+                m_ui->textEditTrackersList->insertPlainText(u"\n"_qs);
             m_ui->textEditTrackersList->insertPlainText(line + u'\n');
             ++nb;
         }

--- a/src/gui/properties/trackersadditiondialog.cpp
+++ b/src/gui/properties/trackersadditiondialog.cpp
@@ -116,7 +116,7 @@ void TrackersAdditionDialog::torrentListDownloadFinished(const Net::DownloadResu
         BitTorrent::TrackerEntry newTracker {line};
         if (!existingTrackers.contains(newTracker))
         {
-            if(nb != 0)
+            if (nb != 0)
                 m_ui->textEditTrackersList->insertPlainText(u"\n"_qs);
             m_ui->textEditTrackersList->insertPlainText(line + u'\n');
             ++nb;


### PR DESCRIPTION
This fixes the issue addressed in #17692.