### PR TITLE
Revise 'Add trackers' dialog

### DIFF
--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -540,6 +540,7 @@ void TorrentImpl::addTrackers(QVector<TrackerEntry> trackers)
     m_trackerEntries.append(trackers);
     std::sort(m_trackerEntries.begin(), m_trackerEntries.end()
         , [](const TrackerEntry &lhs, const TrackerEntry &rhs) { return lhs.tier < rhs.tier; });
+
     m_session->handleTorrentNeedSaveResumeData(this);
     m_session->handleTorrentTrackersAdded(this, trackers);
 }
@@ -561,6 +562,7 @@ void TorrentImpl::removeTrackers(const QStringList &trackers)
     if (!removedTrackers.isEmpty())
     {
         m_nativeHandle.replace_trackers(nativeTrackers);
+
         m_session->handleTorrentNeedSaveResumeData(this);
         m_session->handleTorrentTrackersRemoved(this, removedTrackers);
     }
@@ -579,12 +581,13 @@ void TorrentImpl::replaceTrackers(QVector<TrackerEntry> trackers)
         nativeTrackers.emplace_back(makeNativeAnnounceEntry(tracker.url, tracker.tier));
 
     m_nativeHandle.replace_trackers(nativeTrackers);
+    m_trackerEntries = trackers;
+
     // Clear the peer list if it's a private torrent since
     // we do not want to keep connecting with peers from old tracker.
     if (isPrivate())
         clearPeers();
 
-    m_trackerEntries = trackers;
     m_session->handleTorrentNeedSaveResumeData(this);
     m_session->handleTorrentTrackersChanged(this);
 }

--- a/src/base/bittorrent/trackerentry.cpp
+++ b/src/base/bittorrent/trackerentry.cpp
@@ -28,6 +28,34 @@
 
 #include "trackerentry.h"
 
+#include <QList>
+#include <QVector>
+
+QVector<BitTorrent::TrackerEntry> BitTorrent::parseTrackerEntries(const QStringView str)
+{
+    const QList<QStringView> trackers = str.split(u'\n');  // keep the empty parts to track tracker tier
+
+    QVector<BitTorrent::TrackerEntry> entries;
+    entries.reserve(trackers.size());
+
+    int trackerTier = 0;
+    for (QStringView tracker : trackers)
+    {
+        tracker = tracker.trimmed();
+
+        if (tracker.isEmpty())
+        {
+            if (trackerTier < std::numeric_limits<decltype(trackerTier)>::max())  // prevent overflow
+                ++trackerTier;
+            continue;
+        }
+
+        entries.append({tracker.toString(), trackerTier});
+    }
+
+    return entries;
+}
+
 bool BitTorrent::operator==(const TrackerEntry &left, const TrackerEntry &right)
 {
     return (left.url == right.url);

--- a/src/base/bittorrent/trackerentry.h
+++ b/src/base/bittorrent/trackerentry.h
@@ -30,10 +30,12 @@
 
 #include <libtorrent/socket.hpp>
 
+#include <QtContainerFwd>
 #include <QtGlobal>
 #include <QHash>
 #include <QMap>
 #include <QString>
+#include <QStringView>
 
 namespace BitTorrent
 {
@@ -73,6 +75,8 @@ namespace BitTorrent
         int numDownloaded = -1;
         QString message {};
     };
+
+    QVector<TrackerEntry> parseTrackerEntries(QStringView str);
 
     bool operator==(const TrackerEntry &left, const TrackerEntry &right);
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))

--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -423,17 +423,15 @@ void TrackerListWidget::loadTrackers()
         delete m_trackerItems.take(tracker);
 }
 
-// Ask the user for new trackers and add them to the torrent
-void TrackerListWidget::askForTrackers()
+void TrackerListWidget::openAddTrackersDialog()
 {
-    BitTorrent::Torrent *const torrent = m_properties->getCurrentTorrent();
-    if (!torrent) return;
+    BitTorrent::Torrent *torrent = m_properties->getCurrentTorrent();
+    if (!torrent)
+        return;
 
-    QVector<BitTorrent::TrackerEntry> trackers;
-    for (const QString &tracker : asConst(TrackersAdditionDialog::askForTrackers(this, torrent)))
-        trackers.append({tracker});
-
-    torrent->addTrackers(trackers);
+    const auto dialog = new TrackersAdditionDialog(this, torrent);
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+    dialog->open();
 }
 
 void TrackerListWidget::copyTrackerUrl()
@@ -568,7 +566,7 @@ void TrackerListWidget::showTrackerListMenu()
 
     // Add actions
     menu->addAction(UIThemeManager::instance()->getIcon(u"list-add"_qs), tr("Add trackers...")
-        , this, &TrackerListWidget::askForTrackers);
+        , this, &TrackerListWidget::openAddTrackersDialog);
 
     if (!getSelectedTrackerItems().isEmpty())
     {

--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -567,7 +567,7 @@ void TrackerListWidget::showTrackerListMenu()
     menu->setAttribute(Qt::WA_DeleteOnClose);
 
     // Add actions
-    menu->addAction(UIThemeManager::instance()->getIcon(u"list-add"_qs), tr("Add a new tracker...")
+    menu->addAction(UIThemeManager::instance()->getIcon(u"list-add"_qs), tr("Add trackers...")
         , this, &TrackerListWidget::askForTrackers);
 
     if (!getSelectedTrackerItems().isEmpty())

--- a/src/gui/properties/trackerlistwidget.h
+++ b/src/gui/properties/trackerlistwidget.h
@@ -70,7 +70,6 @@ public slots:
     void clear();
     void loadStickyItems(const BitTorrent::Torrent *torrent);
     void loadTrackers();
-    void askForTrackers();
     void copyTrackerUrl();
     void reannounceSelected();
     void deleteSelectedTrackers();
@@ -83,6 +82,7 @@ protected:
     QVector<QTreeWidgetItem *> getSelectedTrackerItems() const;
 
 private slots:
+    void openAddTrackersDialog();
     void displayColumnHeaderMenu();
 
 private:

--- a/src/gui/properties/trackersadditiondialog.cpp
+++ b/src/gui/properties/trackersadditiondialog.cpp
@@ -1,5 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2022  Mike Tzou (Chocobo1)
  * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
@@ -28,9 +29,10 @@
 
 #include "trackersadditiondialog.h"
 
-#include <QBuffer>
 #include <QMessageBox>
-#include <QStringList>
+#include <QSize>
+#include <QStringView>
+#include <QVector>
 
 #include "base/bittorrent/torrent.h"
 #include "base/bittorrent/trackerentry.h"
@@ -39,102 +41,87 @@
 #include "gui/uithememanager.h"
 #include "ui_trackersadditiondialog.h"
 
+#define SETTINGS_KEY(name) u"AddTrackersDialog/" name
+
 TrackersAdditionDialog::TrackersAdditionDialog(QWidget *parent, BitTorrent::Torrent *const torrent)
     : QDialog(parent)
-    , m_ui(new Ui::TrackersAdditionDialog())
+    , m_ui(new Ui::TrackersAdditionDialog)
     , m_torrent(torrent)
+    , m_storeDialogSize(SETTINGS_KEY(u"Size"_qs))
+    , m_storeTrackersListURL(SETTINGS_KEY(u"TrackersListURL"_qs))
 {
     m_ui->setupUi(this);
-    // Icons
-    m_ui->uTorrentListButton->setIcon(UIThemeManager::instance()->getIcon(u"downloading"_qs));
+
+    m_ui->downloadButton->setIcon(UIThemeManager::instance()->getIcon(u"downloading"_qs));
+    m_ui->buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Add"));
+
+    connect(m_ui->downloadButton, &QAbstractButton::clicked, this, &TrackersAdditionDialog::onDownloadButtonClicked);
+    connect(this, &QDialog::accepted, this, &TrackersAdditionDialog::onAccepted);
+
+    loadSettings();
 }
 
 TrackersAdditionDialog::~TrackersAdditionDialog()
 {
+    saveSettings();
+
     delete m_ui;
 }
 
-QStringList TrackersAdditionDialog::newTrackers() const
+void TrackersAdditionDialog::onAccepted() const
 {
-    const QString plainText = m_ui->textEditTrackersList->toPlainText();
-
-    QStringList cleanTrackers;
-    for (QStringView url : asConst(QStringView(plainText).split(u'\n')))
-    {
-        url = url.trimmed();
-        if (!url.isEmpty())
-            cleanTrackers << url.toString();
-    }
-    return cleanTrackers;
+    const QVector<BitTorrent::TrackerEntry> entries = BitTorrent::parseTrackerEntries(m_ui->textEditTrackersList->toPlainText());
+    m_torrent->addTrackers(entries);
 }
 
-void TrackersAdditionDialog::on_uTorrentListButton_clicked()
+void TrackersAdditionDialog::onDownloadButtonClicked()
 {
-    m_ui->uTorrentListButton->setEnabled(false);
-    Net::DownloadManager::instance()->download(m_ui->lineEditListURL->text()
-                                               , this, &TrackersAdditionDialog::torrentListDownloadFinished);
-    // Just to show that it takes times
-    setCursor(Qt::WaitCursor);
-}
-
-void TrackersAdditionDialog::torrentListDownloadFinished(const Net::DownloadResult &result)
-{
-    if (result.status != Net::DownloadStatus::Success)
+    const QString url = m_ui->lineEditListURL->text();
+    if (url.isEmpty())
     {
-        // To restore the cursor ...
-        setCursor(Qt::ArrowCursor);
-        m_ui->uTorrentListButton->setEnabled(true);
-        QMessageBox::warning(
-                    this, tr("Download error")
-                    , tr("The trackers list could not be downloaded, reason: %1")
-                    .arg(result.errorString), QMessageBox::Ok);
+        QMessageBox::warning(this, tr("Trackers list URL error"), tr("The trackers list URL cannot be empty"));
         return;
     }
 
-    const QStringList trackersFromUser = m_ui->textEditTrackersList->toPlainText().split(u'\n');
-    QVector<BitTorrent::TrackerEntry> existingTrackers = m_torrent->trackers();
-    existingTrackers.reserve(trackersFromUser.size());
-    for (const QString &userURL : trackersFromUser)
-    {
-        const BitTorrent::TrackerEntry userTracker {userURL};
-        if (!existingTrackers.contains(userTracker))
-            existingTrackers << userTracker;
-    }
+    // Just to show that it takes times
+    m_ui->downloadButton->setEnabled(false);
+    setCursor(Qt::WaitCursor);
 
-    // Add new trackers to the list
-    if (!m_ui->textEditTrackersList->toPlainText().isEmpty() && !m_ui->textEditTrackersList->toPlainText().endsWith(u'\n'))
-        m_ui->textEditTrackersList->insertPlainText(u"\n"_qs);
-    int nb = 0;
-    QBuffer buffer;
-    buffer.setData(result.data);
-    buffer.open(QBuffer::ReadOnly);
-    while (!buffer.atEnd())
-    {
-        const auto line = QString::fromUtf8(buffer.readLine().trimmed());
-        if (line.isEmpty()) continue;
-
-        BitTorrent::TrackerEntry newTracker {line};
-        if (!existingTrackers.contains(newTracker))
-        {
-            m_ui->textEditTrackersList->insertPlainText(line + u'\n');
-            ++nb;
-        }
-    }
-
-    // To restore the cursor ...
-    setCursor(Qt::ArrowCursor);
-    m_ui->uTorrentListButton->setEnabled(true);
-    // Display information message if necessary
-    if (nb == 0)
-        QMessageBox::information(this, tr("No change"), tr("No additional trackers were found."), QMessageBox::Ok);
+    Net::DownloadManager::instance()->download(url, this, &TrackersAdditionDialog::onTorrentListDownloadFinished);
 }
 
-QStringList TrackersAdditionDialog::askForTrackers(QWidget *parent, BitTorrent::Torrent *const torrent)
+void TrackersAdditionDialog::onTorrentListDownloadFinished(const Net::DownloadResult &result)
 {
-    QStringList trackers;
-    TrackersAdditionDialog dlg(parent, torrent);
-    if (dlg.exec() == QDialog::Accepted)
-        return dlg.newTrackers();
+    // Restore the cursor, buttons...
+    m_ui->downloadButton->setEnabled(true);
+    setCursor(Qt::ArrowCursor);
 
-    return trackers;
+    if (result.status != Net::DownloadStatus::Success)
+    {
+        QMessageBox::warning(this, tr("Download trackers list error")
+            , tr("Error occurred when downloading the trackers list. Reason: \"%1\"").arg(result.errorString));
+        return;
+    }
+
+    // Add fetched trackers to the list
+    const QString existingText = m_ui->textEditTrackersList->toPlainText();
+    if (!existingText.isEmpty() && !existingText.endsWith(u'\n'))
+        m_ui->textEditTrackersList->insertPlainText(u"\n"_qs);
+
+    // append the data as-is
+    const auto trackers = QString::fromUtf8(result.data).trimmed();
+    m_ui->textEditTrackersList->insertPlainText(trackers);
+}
+
+void TrackersAdditionDialog::saveSettings()
+{
+    m_storeDialogSize = size();
+    m_storeTrackersListURL = m_ui->lineEditListURL->text();
+}
+
+void TrackersAdditionDialog::loadSettings()
+{
+    if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())
+        resize(dialogSize);
+    m_ui->lineEditListURL->setText(m_storeTrackersListURL);
 }

--- a/src/gui/properties/trackersadditiondialog.h
+++ b/src/gui/properties/trackersadditiondialog.h
@@ -1,5 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2022  Mike Tzou (Chocobo1)
  * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
@@ -29,9 +30,8 @@
 #pragma once
 
 #include <QDialog>
-#include <QtContainerFwd>
 
-class QString;
+#include "base/settingvalue.h"
 
 namespace BitTorrent
 {
@@ -57,14 +57,18 @@ public:
     TrackersAdditionDialog(QWidget *parent, BitTorrent::Torrent *const torrent);
     ~TrackersAdditionDialog();
 
-    QStringList newTrackers() const;
-    static QStringList askForTrackers(QWidget *parent, BitTorrent::Torrent *const torrent);
-
-public slots:
-    void on_uTorrentListButton_clicked();
-    void torrentListDownloadFinished(const Net::DownloadResult &result);
+private slots:
+    void onAccepted() const;
+    void onDownloadButtonClicked();
+    void onTorrentListDownloadFinished(const Net::DownloadResult &result);
 
 private:
+    void saveSettings();
+    void loadSettings();
+
     Ui::TrackersAdditionDialog *m_ui = nullptr;
     BitTorrent::Torrent *const m_torrent = nullptr;
+
+    SettingValue<QSize> m_storeDialogSize;
+    SettingValue<QString> m_storeTrackersListURL;
 };

--- a/src/gui/properties/trackersadditiondialog.ui
+++ b/src/gui/properties/trackersadditiondialog.ui
@@ -44,7 +44,11 @@
       <widget class="QLineEdit" name="lineEditListURL"/>
      </item>
      <item>
-      <widget class="QPushButton" name="uTorrentListButton"/>
+      <widget class="QPushButton" name="downloadButton">
+       <property name="toolTip">
+        <string>Download trackers list</string>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/src/gui/properties/trackersadditiondialog.ui
+++ b/src/gui/properties/trackersadditiondialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Trackers addition dialog</string>
+   <string>Add trackers</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/src/gui/trackerentriesdialog.cpp
+++ b/src/gui/trackerentriesdialog.cpp
@@ -80,27 +80,7 @@ void TrackerEntriesDialog::setTrackers(const QVector<BitTorrent::TrackerEntry> &
 
 QVector<BitTorrent::TrackerEntry> TrackerEntriesDialog::trackers() const
 {
-    const QString plainText = m_ui->plainTextEdit->toPlainText();
-    const QList<QStringView> lines = QStringView(plainText).split(u'\n');
-
-    QVector<BitTorrent::TrackerEntry> entries;
-    entries.reserve(lines.size());
-
-    int tier = 0;
-    for (QStringView line : lines)
-    {
-        line = line.trimmed();
-
-        if (line.isEmpty())
-        {
-            ++tier;
-            continue;
-        }
-
-        entries.append({line.toString(), tier});
-    }
-
-    return entries;
+    return BitTorrent::parseTrackerEntries(m_ui->plainTextEdit->toPlainText());
 }
 
 void TrackerEntriesDialog::saveSettings()

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -745,14 +745,8 @@ void TorrentsController::addTrackersAction()
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 
-    QVector<BitTorrent::TrackerEntry> trackers;
-    for (const QString &urlStr : asConst(params()[u"urls"_qs].split(u'\n')))
-    {
-        const QUrl url {urlStr.trimmed()};
-        if (url.isValid())
-            trackers.append({url.toString()});
-    }
-    torrent->addTrackers(trackers);
+    const QVector<BitTorrent::TrackerEntry> entries = BitTorrent::parseTrackerEntries(params()[u"urls"_qs]);
+    torrent->addTrackers(entries);
 }
 
 void TorrentsController::editTrackerAction()

--- a/src/webui/www/private/addtrackers.html
+++ b/src/webui/www/private/addtrackers.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(Trackers addition dialog)QBT_TR[CONTEXT=TrackersAdditionDialog]</title>
+    <title>QBT_TR(Add trackers)QBT_TR[CONTEXT=TrackersAdditionDialog]</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -201,7 +201,7 @@
         <li><a href="#deleteTorrentsByTracker"><img src="images/list-remove.svg" alt="QBT_TR(Remove torrents)QBT_TR[CONTEXT=TrackerFiltersList]" /> QBT_TR(Remove torrents)QBT_TR[CONTEXT=TrackerFiltersList]</a></li>
     </ul>
     <ul id="torrentTrackersMenu" class="contextMenu">
-        <li><a href="#AddTracker"><img src="images/list-add.svg" alt="QBT_TR(Add a new tracker...)QBT_TR[CONTEXT=TrackerListWidget]" /> QBT_TR(Add a new tracker...)QBT_TR[CONTEXT=TrackerListWidget]</a></li>
+        <li><a href="#AddTracker"><img src="images/list-add.svg" alt="QBT_TR(Add trackers...)QBT_TR[CONTEXT=TrackerListWidget]" /> QBT_TR(Add trackers...)QBT_TR[CONTEXT=TrackerListWidget]</a></li>
         <li class="separator"><a href="#EditTracker"><img src="images/edit-rename.svg" alt="QBT_TR(Edit tracker URL...)QBT_TR[CONTEXT=TrackerListWidget]" /> QBT_TR(Edit tracker URL...)QBT_TR[CONTEXT=TrackerListWidget]</a></li>
         <li><a href="#RemoveTracker"><img src="images/list-remove.svg" alt="QBT_TR(Remove tracker)QBT_TR[CONTEXT=TrackerListWidget]" /> QBT_TR(Remove tracker)QBT_TR[CONTEXT=TrackerListWidget]</a></li>
         <li><a href="#CopyTrackerUrl" id="CopyTrackerUrl"><img src="images/edit-copy.svg" alt="QBT_TR(Copy tracker URL)QBT_TR[CONTEXT=TrackerListWidget]" /> QBT_TR(Copy tracker URL)QBT_TR[CONTEXT=TrackerListWidget]</a></li>

--- a/src/webui/www/private/scripts/prop-trackers.js
+++ b/src/webui/www/private/scripts/prop-trackers.js
@@ -169,7 +169,7 @@ window.qBittorrent.PropTrackers = (function() {
             return;
         new MochaUI.Window({
             id: 'trackersPage',
-            title: "QBT_TR(Trackers addition dialog)QBT_TR[CONTEXT=TrackersAdditionDialog]",
+            title: "QBT_TR(Add trackers)QBT_TR[CONTEXT=TrackersAdditionDialog]",
             loadMethod: 'iframe',
             contentURL: 'addtrackers.html?hash=' + current_hash,
             scrollbars: true,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ include_directories("../src")
 
 set(testFiles
     testalgorithm.cpp
+    testbittorrenttrackerentry.cpp
     testorderedset.cpp
     testpath.cpp
     testutilscompare.cpp

--- a/test/testbittorrenttrackerentry.cpp
+++ b/test/testbittorrenttrackerentry.cpp
@@ -1,0 +1,143 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2022  Mike Tzou (Chocobo1)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include <algorithm>
+
+#include <QTest>
+#include <QVector>
+
+#include "base/bittorrent/trackerentry.h"
+#include "base/global.h"
+
+class TestBittorrentTrackerEntry final : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(TestBittorrentTrackerEntry)
+
+public:
+    TestBittorrentTrackerEntry() = default;
+
+private slots:
+    void testParseTrackerEntries() const
+    {
+        using Entries = QVector<BitTorrent::TrackerEntry>;
+
+        const auto isEqual = [](const Entries &left, const Entries &right) -> bool
+        {
+            return std::equal(left.begin(), left.end(), right.begin(), right.end()
+                , [](const BitTorrent::TrackerEntry &leftEntry, const BitTorrent::TrackerEntry &rightEntry)
+            {
+                return (leftEntry.url == rightEntry.url)
+                    && (leftEntry.tier == rightEntry.tier);
+            });
+        };
+
+        {
+            const QString input;
+            const Entries output;
+            QVERIFY(isEqual(BitTorrent::parseTrackerEntries(input), output));
+        }
+
+        {
+            const QString input = u"http://localhost:1234"_qs;
+            const Entries output = {{u"http://localhost:1234"_qs, 0}};
+            QVERIFY(isEqual(BitTorrent::parseTrackerEntries(input), output));
+        }
+
+        {
+            const QString input = u"  http://localhost:1234     "_qs;
+            const Entries output = {{u"http://localhost:1234"_qs, 0}};
+            QVERIFY(isEqual(BitTorrent::parseTrackerEntries(input), output));
+        }
+
+        {
+            const QString input = u"\nhttp://localhost:1234"_qs;
+            const Entries output = {{u"http://localhost:1234"_qs, 1}};
+            QVERIFY(isEqual(BitTorrent::parseTrackerEntries(input), output));
+        }
+
+        {
+            const QString input = u"http://localhost:1234\n"_qs;
+            const Entries output = {{u"http://localhost:1234"_qs, 0}};
+            QVERIFY(isEqual(BitTorrent::parseTrackerEntries(input), output));
+        }
+
+        {
+            const QString input = u"http://localhost:1234 \n http://[::1]:4567"_qs;
+            const Entries output =
+            {
+                {u"http://localhost:1234"_qs, 0},
+                {u"http://[::1]:4567"_qs, 0}
+            };
+            QVERIFY(isEqual(BitTorrent::parseTrackerEntries(input), output));
+        }
+
+        {
+            const QString input = u"\n http://localhost:1234 \n http://[::1]:4567"_qs;
+            const Entries output =
+            {
+                {u"http://localhost:1234"_qs, 1},
+                {u"http://[::1]:4567"_qs, 1}
+            };
+            QVERIFY(isEqual(BitTorrent::parseTrackerEntries(input), output));
+        }
+
+        {
+            const QString input = u"http://localhost:1234 \n http://[::1]:4567 \n \n \n"_qs;
+            const Entries output =
+            {
+                {u"http://localhost:1234"_qs, 0},
+                {u"http://[::1]:4567"_qs, 0}
+            };
+            QVERIFY(isEqual(BitTorrent::parseTrackerEntries(input), output));
+        }
+
+        {
+            const QString input = u"http://localhost:1234 \n \n http://[::1]:4567"_qs;
+            const Entries output =
+            {
+                {u"http://localhost:1234"_qs, 0},
+                {u"http://[::1]:4567"_qs, 1}
+            };
+            QVERIFY(isEqual(BitTorrent::parseTrackerEntries(input), output));
+        }
+
+        {
+            const QString input = u"\n \n \n http://localhost:1234 \n \n \n \n http://[::1]:4567 \n \n \n"_qs;
+            const Entries output =
+            {
+                {u"http://localhost:1234"_qs, 3},
+                {u"http://[::1]:4567"_qs, 6}
+            };
+            QVERIFY(isEqual(BitTorrent::parseTrackerEntries(input), output));
+        }
+    }
+};
+
+QTEST_APPLESS_MAIN(TestBittorrentTrackerEntry)
+#include "testbittorrenttrackerentry.moc"


### PR DESCRIPTION
* Rename action
* Revise 'Add trackers' dialog 
  * Now it allow user to add tracker to different tier.
  * The downloaded trackers are now displayed as is (without modifying).
  * Now the dialog remember dialog size and last used URL.
  
  Closes #17692.

[screenshot](https://user-images.githubusercontent.com/9395168/189814358-289550c6-e23b-4a2f-98d4-7909bcf76005.png)