### PR TITLE
WebAPI: fix wrong behavior for shutdown action

### DIFF
--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -91,12 +91,13 @@ void AppController::buildInfoAction()
 
 void AppController::shutdownAction()
 {
-    qDebug() << "Shutdown request from Web UI";
-
-    // Special case handling for shutdown, we
+    // Special handling for shutdown, we
     // need to reply to the Web UI before
     // actually shutting down.
-    QTimer::singleShot(100ms, qApp, &QCoreApplication::quit);
+    QTimer::singleShot(100ms, qApp, []()
+    {
+        QCoreApplication::exit();
+    });
 }
 
 void AppController::preferencesAction()


### PR DESCRIPTION
Qt6 has changed implementation for `QCoreApplication::quit` and therefore it is not suitable anymore.

Closes #17709.

