### PR TITLE
Change some default values

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -378,11 +378,15 @@ SessionImpl::SessionImpl(QObject *parent)
     , m_IPFilterFile(BITTORRENT_SESSION_KEY(u"IPFilter"_qs))
     , m_announceToAllTrackers(BITTORRENT_SESSION_KEY(u"AnnounceToAllTrackers"_qs), false)
     , m_announceToAllTiers(BITTORRENT_SESSION_KEY(u"AnnounceToAllTiers"_qs), true)
-    , m_asyncIOThreads(BITTORRENT_SESSION_KEY(u"AsyncIOThreadsCount"_qs), 10)
+    , m_asyncIOThreads(BITTORRENT_SESSION_KEY(u"AsyncIOThreadsCount"_qs), 4)
     , m_hashingThreads(BITTORRENT_SESSION_KEY(u"HashingThreadsCount"_qs), 1)
+#ifdef QBT_USES_LIBTORRENT2
+    , m_filePoolSize(BITTORRENT_SESSION_KEY(u"FilePoolSize"_qs), 40)
+#else
     , m_filePoolSize(BITTORRENT_SESSION_KEY(u"FilePoolSize"_qs), 5000)
+#endif
     , m_checkingMemUsage(BITTORRENT_SESSION_KEY(u"CheckingMemUsageSize"_qs), 32)
-    , m_diskCacheSize(BITTORRENT_SESSION_KEY(u"DiskCacheSize"_qs), -1)
+    , m_diskCacheSize(BITTORRENT_SESSION_KEY(u"DiskCacheSize"_qs), 512)
     , m_diskCacheTTL(BITTORRENT_SESSION_KEY(u"DiskCacheTTL"_qs), 60)
     , m_diskQueueSize(BITTORRENT_SESSION_KEY(u"DiskQueueSize"_qs), (1024 * 1024))
     , m_diskIOType(BITTORRENT_SESSION_KEY(u"DiskIOType"_qs), DiskIOType::Default)


### PR DESCRIPTION
The default `disk cache` size has been set to `512 MiB` to match the working set limit on RC_2_0 builds. It's been causing confusions among users as the default build has been switched to RC_1_2 and they are expecting the RAM usage to be like previous versions.

async I/O thread was bumped in hopes that it would increase performance on SSDs.
But setting this to 10 spawns two hashing threads(in RC_1_2) and results in decreased I/O performance for HDD users.
And since the `hashing thread` default was changed to `1`, it makes no sense to keep the AIO threads at 10.
So this has been set to 4 by default.

File pool size seem to have been causing issues in RC_2_0 builds as too many files are being kept open and the OS is not closing them in a timely manner. So this has been set to 500.


