### PR TITLE
Fixes "Open destination folder" delay on Windows

### DIFF
--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -152,15 +152,7 @@ void Utils::Gui::openPath(const Path &path)
     {
         if (SUCCEEDED(::CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE)))
         {
-            const std::wstring pathWStr = path.toString().toStdWString();
-            PIDLIST_ABSOLUTE pidl = ::ILCreateFromPathW(pathWStr.c_str());
-            ITEMIDLIST idNull = {};
-            LPCITEMIDLIST pidlNull[1] = {&idNull};
-            if (pidl)
-            {
-                ::SHOpenFolderAndSelectItems(pidl, 1, pidlNull, 0);
-                ::ILFree(pidl);
-            }
+            ShellExecute(nullptr, nullptr, path.toString().toStdWString().c_str(), nullptr, nullptr, SW_SHOWNORMAL);
 
             ::CoUninitialize();
         }

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -150,7 +150,7 @@ void Utils::Gui::openPath(const Path &path)
 #ifdef Q_OS_WIN
     auto *thread = QThread::create([path]()
     {
-        if (SUCCEEDED(::CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE)))
+        if (SUCCEEDED(::CoInitializeEx(NULL, (COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE))))
         {
             ::ShellExecuteW(nullptr, nullptr, path.toString().toStdWString().c_str(), nullptr, nullptr, SW_SHOWNORMAL);
 

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -152,7 +152,9 @@ void Utils::Gui::openPath(const Path &path)
     {
         if (SUCCEEDED(::CoInitializeEx(NULL, (COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE))))
         {
-            ::ShellExecuteW(nullptr, nullptr, path.toString().toStdWString().c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+            const std::wstring pathWStr = path.toString().toStdWString();
+
+            ::ShellExecuteW(nullptr, nullptr, pathWStr.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
 
             ::CoUninitialize();
         }

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -152,7 +152,7 @@ void Utils::Gui::openPath(const Path &path)
     {
         if (SUCCEEDED(::CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE)))
         {
-            ShellExecute(nullptr, nullptr, path.toString().toStdWString().c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+            ::ShellExecuteW(nullptr, nullptr, path.toString().toStdWString().c_str(), nullptr, nullptr, SW_SHOWNORMAL);
 
             ::CoUninitialize();
         }

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -154,11 +154,11 @@ void Utils::Gui::openPath(const Path &path)
         {
             const std::wstring pathWStr = path.toString().toStdWString();
             PIDLIST_ABSOLUTE pidl = ::ILCreateFromPathW(pathWStr.c_str());
-            ITEMIDLIST idNull = {0};
+            ITEMIDLIST idNull = {};
             LPCITEMIDLIST pidlNull[1] = {&idNull};
             if (pidl)
             {
-                ::SHOpenFolderAndSelectItems(pidl, 0, pidlNull, 0);
+                ::SHOpenFolderAndSelectItems(pidl, 1, pidlNull, 0);
                 ::ILFree(pidl);
             }
 

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -31,6 +31,7 @@
 #ifdef Q_OS_WIN
 #include <Objbase.h>
 #include <Shlobj.h>
+#include <Shellapi.h>
 #endif
 
 #include <QApplication>


### PR DESCRIPTION
Replaced QDesktopServices by native Windows function to open destination folder due to QDesktopServices issues on Windows
Closes #17482.

The specific kinda "black box" function is QDesktopServices::openUrl.

The issues are described in #17482 and even more detailed in https://github.com/qbittorrent/qBittorrent/discussions/17025
