### PR TITLE
Clean up 'recursive download' related code

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -4549,31 +4549,26 @@ void SessionImpl::handleTorrentFinished(TorrentImpl *const torrent)
     LogMsg(tr("Torrent download finished. Torrent: \"%1\"").arg(torrent->name()));
     emit torrentFinished(torrent);
 
-    qDebug("Checking if the torrent contains torrent files to download");
+    if (const Path exportPath = finishedTorrentExportDirectory(); !exportPath.isEmpty())
+        exportTorrentFile(torrent, exportPath);
+
     // Check if there are torrent files inside
     for (const Path &torrentRelpath : asConst(torrent->filePaths()))
     {
         if (torrentRelpath.hasExtension(u".torrent"_qs))
         {
-            qDebug("Found possible recursive torrent download.");
             const Path torrentFullpath = torrent->actualStorageLocation() / torrentRelpath;
-            qDebug("Full subtorrent path is %s", qUtf8Printable(torrentFullpath.toString()));
             if (TorrentInfo::loadFromFile(torrentFullpath))
             {
-                qDebug("emitting recursiveTorrentDownloadPossible()");
                 emit recursiveTorrentDownloadPossible(torrent);
                 break;
             }
             else
             {
-                qDebug("Caught error loading torrent");
                 LogMsg(tr("Unable to load torrent. File: \"%1\"").arg(torrentFullpath.toString()), Log::CRITICAL);
             }
         }
     }
-
-    if (!finishedTorrentExportDirectory().isEmpty())
-        exportTorrentFile(torrent, finishedTorrentExportDirectory());
 
     if (!hasUnfinishedTorrents())
         emit allTorrentsFinished();

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -1769,10 +1769,10 @@ void TorrentImpl::handleTorrentCheckedAlert(const lt::torrent_checked_alert *p)
 void TorrentImpl::handleTorrentFinishedAlert(const lt::torrent_finished_alert *p)
 {
     Q_UNUSED(p);
-    qDebug("Got a torrent finished alert for \"%s\"", qUtf8Printable(name()));
-    qDebug("Torrent has seed status: %s", m_hasSeedStatus ? "yes" : "no");
+
     m_hasMissingFiles = false;
-    if (m_hasSeedStatus) return;
+    if (m_hasSeedStatus)
+        return;
 
     m_statusUpdatedTriggers.enqueue([this]()
     {

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -996,14 +996,14 @@ void Preferences::resolvePeerHostNames(const bool resolve)
     setValue(u"Preferences/Connection/ResolvePeerHostNames"_qs, resolve);
 }
 
-bool Preferences::recursiveDownloadDisabled() const
+bool Preferences::isRecursiveDownloadEnabled() const
 {
-    return value(u"Preferences/Advanced/DisableRecursiveDownload"_qs, false);
+    return !value(u"Preferences/Advanced/DisableRecursiveDownload"_qs, false);
 }
 
-void Preferences::disableRecursiveDownload(const bool disable)
+void Preferences::setRecursiveDownloadEnabled(const bool enable)
 {
-    setValue(u"Preferences/Advanced/DisableRecursiveDownload"_qs, disable);
+    setValue(u"Preferences/Advanced/DisableRecursiveDownload"_qs, !enable);
 }
 
 #ifdef Q_OS_WIN

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -281,8 +281,8 @@ public:
     void resolvePeerCountries(bool resolve);
     bool resolvePeerHostNames() const;
     void resolvePeerHostNames(bool resolve);
-    bool recursiveDownloadDisabled() const;
-    void disableRecursiveDownload(bool disable = true);
+    bool isRecursiveDownloadEnabled() const;
+    void setRecursiveDownloadEnabled(bool enable);
 #ifdef Q_OS_WIN
     bool neverCheckFileAssoc() const;
     void setNeverCheckFileAssoc(bool check = true);

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -130,7 +130,7 @@ private slots:
     void reloadSessionStats();
     void reloadTorrentStats(const QVector<BitTorrent::Torrent *> &torrents);
     void loadPreferences();
-    void askRecursiveTorrentDownloadConfirmation(BitTorrent::Torrent *const torrent);
+    void askRecursiveTorrentDownloadConfirmation(const BitTorrent::Torrent *torrent);
     void optionsSaved();
     void toggleAlternativeSpeeds();
 

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -546,7 +546,7 @@ void OptionsDialog::loadDownloadsTabOptions()
 
     m_ui->checkPreallocateAll->setChecked(session->isPreallocationEnabled());
     m_ui->checkAppendqB->setChecked(session->isAppendExtensionEnabled());
-    m_ui->checkRecursiveDownload->setChecked(!pref->recursiveDownloadDisabled());
+    m_ui->checkRecursiveDownload->setChecked(pref->isRecursiveDownloadEnabled());
 
     m_ui->comboSavingMode->setCurrentIndex(!session->isAutoTMMDisabledByDefault());
     m_ui->comboTorrentCategoryChanged->setCurrentIndex(session->isDisableAutoTMMWhenCategoryChanged());
@@ -698,7 +698,7 @@ void OptionsDialog::saveDownloadsTabOptions() const
 
     session->setPreallocationEnabled(preAllocateAllFiles());
     session->setAppendExtensionEnabled(m_ui->checkAppendqB->isChecked());
-    pref->disableRecursiveDownload(!m_ui->checkRecursiveDownload->isChecked());
+    pref->setRecursiveDownloadEnabled(m_ui->checkRecursiveDownload->isChecked());
 
     session->setAutoTMMDisabledByDefault(m_ui->comboSavingMode->currentIndex() == 0);
     session->setDisableAutoTMMWhenCategoryChanged(m_ui->comboTorrentCategoryChanged->currentIndex() == 1);


### PR DESCRIPTION
* Reorder operations in 'torrent finished' handler
  Avoid redundant data fetch.
  Remove debug messages.
* Clean up 'recursive download' related code
  Don't load .torrent files too early, otherwise qbt might emit a dubious error log message if the .torrent file is invalid.