### PR TITLE
Use proper color for highlighted text in log widget 

### DIFF
--- a/src/gui/log/loglistview.cpp
+++ b/src/gui/log/loglistview.cpp
@@ -29,6 +29,7 @@
 
 #include "loglistview.h"
 
+#include <QtGlobal>
 #include <QApplication>
 #include <QClipboard>
 #include <QFontMetrics>
@@ -38,8 +39,11 @@
 #include <QStyledItemDelegate>
 
 #include "base/global.h"
-#include "gui/uithememanager.h"
 #include "logmodel.h"
+
+#ifdef Q_OS_WIN
+#include "base/preferences.h"
+#endif
 
 namespace
 {
@@ -60,7 +64,13 @@ namespace
     class LogItemDelegate final : public QStyledItemDelegate
     {
     public:
-        using QStyledItemDelegate::QStyledItemDelegate;
+        explicit LogItemDelegate(QObject *parent = nullptr)
+            : QStyledItemDelegate(parent)
+#ifdef Q_OS_WIN
+            , m_useCustomUITheme(Preferences::instance()->useCustomUITheme())
+#endif
+        {
+        }
 
     private:
         void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override
@@ -70,6 +80,16 @@ namespace
 
             const QStyle *style = option.widget ? option.widget->style() : QApplication::style();
             const QRect textRect = option.rect.adjusted(1, 0, 0, 0); // shift 1 to avoid text being too close to focus rect
+            const bool isEnabled = option.state.testFlag(QStyle::State_Enabled);
+
+#ifdef Q_OS_WIN
+            // Windows default theme do not use highlighted text color
+            const QPalette::ColorRole textRole = m_useCustomUITheme
+                ? (option.state.testFlag(QStyle::State_Selected) ? QPalette::HighlightedText : QPalette::WindowText)
+                : QPalette::WindowText;
+#else
+            const QPalette::ColorRole textRole = option.state.testFlag(QStyle::State_Selected) ? QPalette::HighlightedText : QPalette::WindowText;
+#endif
 
             // for unknown reasons (fixme) painter won't accept some font properties
             // until they are set explicitly, and we have to manually set some font properties
@@ -79,24 +99,23 @@ namespace
                 font.setPointSizeF(option.font.pointSizeF());
             painter->setFont(font);
 
-            const QPen originalPen = painter->pen();
-            QPen coloredPen = originalPen;
-            coloredPen.setColor(index.data(BaseLogModel::TimeForegroundRole).value<QColor>());
-            painter->setPen(coloredPen);
-            const QString time = index.data(BaseLogModel::TimeRole).toString();
-            style->drawItemText(painter, textRect, option.displayAlignment, option.palette, (option.state & QStyle::State_Enabled), time);
+            QPalette palette = option.palette;
 
-            painter->setPen(originalPen);
+            const QString time = index.data(BaseLogModel::TimeRole).toString();
+            palette.setColor(QPalette::Active, QPalette::WindowText, index.data(BaseLogModel::TimeForegroundRole).value<QColor>());
+            style->drawItemText(painter, textRect, option.displayAlignment, palette, isEnabled, time, textRole);
+
             const QFontMetrics fontMetrics = painter->fontMetrics(); // option.fontMetrics adds extra padding to QFontMetrics::width
             const int separatorCoordinateX = horizontalAdvance(fontMetrics, time);
             style->drawItemText(painter, textRect.adjusted(separatorCoordinateX, 0, 0, 0), option.displayAlignment, option.palette
-                                , (option.state & QStyle::State_Enabled), SEPARATOR);
+                                , isEnabled, SEPARATOR, textRole);
 
-            coloredPen.setColor(index.data(BaseLogModel::MessageForegroundRole).value<QColor>());
-            painter->setPen(coloredPen);
             const int messageCoordinateX = separatorCoordinateX + horizontalAdvance(fontMetrics, SEPARATOR);
-            style->drawItemText(painter, textRect.adjusted(messageCoordinateX, 0, 0, 0), option.displayAlignment, option.palette
-                                , (option.state & QStyle::State_Enabled), index.data(BaseLogModel::MessageRole).toString());
+            const QString message = index.data(BaseLogModel::MessageRole).toString();
+            palette.setColor(QPalette::Active, QPalette::WindowText, index.data(BaseLogModel::MessageForegroundRole).value<QColor>());
+            style->drawItemText(painter, textRect.adjusted(messageCoordinateX, 0, 0, 0), option.displayAlignment, palette
+                                , isEnabled, message, textRole);
+
             painter->restore();
         }
 
@@ -108,6 +127,10 @@ namespace
             const QSize margins = (defaultSize - fontSize).expandedTo({0, 0});
             return fontSize + margins;
         }
+
+#ifdef Q_OS_WIN
+        const bool m_useCustomUITheme = false;
+#endif
     };
 }
 
@@ -117,7 +140,7 @@ LogListView::LogListView(QWidget *parent)
     setSelectionMode(QAbstractItemView::ExtendedSelection);
     setItemDelegate(new LogItemDelegate(this));
 
-#if defined(Q_OS_MAC)
+#ifdef Q_OS_MAC
     setAttribute(Qt::WA_MacShowFocusRect, false);
 #endif
 }

--- a/src/gui/log/loglistview.cpp
+++ b/src/gui/log/loglistview.cpp
@@ -52,8 +52,9 @@ namespace
 
     QString logText(const QModelIndex &index)
     {
-        return u"%1%2%3"_qs.arg(index.data(BaseLogModel::TimeRole).toString(), SEPARATOR
-                                , index.data(BaseLogModel::MessageRole).toString());
+        return index.data(BaseLogModel::TimeRole).toString()
+            + SEPARATOR
+            + index.data(BaseLogModel::MessageRole).toString();
     }
 
     class LogItemDelegate final : public QStyledItemDelegate

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -34,8 +34,10 @@
 #endif
 
 #include <QApplication>
+#include <QColor>
 #include <QDesktopServices>
 #include <QIcon>
+#include <QPalette>
 #include <QPixmap>
 #include <QPixmapCache>
 #include <QPoint>
@@ -53,6 +55,13 @@
 #include "base/path.h"
 #include "base/utils/fs.h"
 #include "base/utils/version.h"
+
+bool Utils::Gui::isDarkTheme()
+{
+    const QPalette palette = qApp->palette();
+    const QColor &color = palette.color(QPalette::Active, QPalette::Base);
+    return (color.lightness() < 127);
+}
 
 QPixmap Utils::Gui::scaledPixmap(const QIcon &icon, const QWidget *widget, const int height)
 {

--- a/src/gui/utils.h
+++ b/src/gui/utils.h
@@ -38,6 +38,8 @@ class QWidget;
 
 namespace Utils::Gui
 {
+    bool isDarkTheme();
+
     QPixmap scaledPixmap(const QIcon &icon, const QWidget *widget, int height);
     QPixmap scaledPixmap(const Path &path, const QWidget *widget, int height = 0);
     QPixmap scaledPixmapSvg(const Path &path, const QWidget *widget, int height);


### PR DESCRIPTION
* Revive dark theme detection
  The code was removed in 199d770 and now revived.
  I reckon this function would be useful in the future despite it isn't in use currently.
* Simplify code
  Don't use replacement placeholder and use string append which is faster.
* Use proper color for highlighted text in log widget
  The color is either from qbt theme pack or desktop environment.
  Before:
  ![before](https://user-images.githubusercontent.com/9395168/190708038-a3fee518-b145-4ba8-a661-5a389d1c726c.png)
  After:
  ![after](https://user-images.githubusercontent.com/9395168/190708055-44ade9c7-8660-467e-ba05-d3fb59ac3e0f.png)
