### PR TITLE
Introduce color palettes for both dark, light themes

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library(qbt_gui STATIC
     categoryfiltermodel.h
     categoryfilterproxymodel.h
     categoryfilterwidget.h
+    color.h
     cookiesdialog.h
     cookiesmodel.h
     deletionconfirmationdialog.h

--- a/src/gui/color.h
+++ b/src/gui/color.h
@@ -1,0 +1,72 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2022  Mike Tzou (Chocobo1)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+namespace Color
+{
+    /*
+     * Documentation: https://primer.style/primitives/colors
+     * Repository: https://github.com/primer/primitives
+     * Primer Primitives v7.9
+     */
+    namespace Primer
+    {
+        namespace Dark
+        {
+            // Functional variables
+            inline const QColor accentEmphasis = 0x1f6feb;
+            inline const QColor accentFg = 0x58a6ff;
+            inline const QColor dangerFg = 0xf85149;
+            inline const QColor fgMuted = 0x8b949e;
+            inline const QColor fgSubtle = 0x6e7681;
+            inline const QColor severeFg = 0xdb6d28;
+            inline const QColor successEmphasis = 0x238636;
+            inline const QColor successFg = 0x1a7f37;
+            // Scale variables
+            inline const QColor scaleBlue4 = 0x388bfd;
+            inline const QColor scaleYellow6 = 0x845306;
+        }
+
+        namespace Light
+        {
+            // Functional variables
+            inline const QColor accentEmphasis = 0x0969da;
+            inline const QColor accentFg = 0x0969da;
+            inline const QColor dangerFg = 0xcf222e;
+            inline const QColor fgMuted = 0x57606a;
+            inline const QColor fgSubtle = 0x6e7781;
+            inline const QColor severeFg = 0xbc4c00;
+            inline const QColor successEmphasis = 0x2da44e;
+            inline const QColor successFg = 0x1a7f37;
+            // Scale variables
+            inline const QColor scaleBlue4 = 0x218bff;
+            inline const QColor scaleYellow6 = 0x7d4e00;
+        }
+    }
+}

--- a/src/gui/gui.pri
+++ b/src/gui/gui.pri
@@ -9,6 +9,7 @@ HEADERS += \
     $$PWD/categoryfiltermodel.h \
     $$PWD/categoryfilterproxymodel.h \
     $$PWD/categoryfilterwidget.h \
+    $$PWD/color.h \
     $$PWD/cookiesdialog.h \
     $$PWD/cookiesmodel.h \
     $$PWD/deletionconfirmationdialog.h \

--- a/src/gui/log/logmodel.cpp
+++ b/src/gui/log/logmodel.cpp
@@ -35,11 +35,49 @@
 #include <QPalette>
 
 #include "base/global.h"
+#include "gui/color.h"
 #include "gui/uithememanager.h"
+#include "gui/utils.h"
 
 namespace
 {
     const int MAX_VISIBLE_MESSAGES = 20000;
+
+    QColor getTimestampColor()
+    {
+        return UIThemeManager::instance()->getColor(u"Log.TimeStamp"_qs
+            , (Utils::Gui::isDarkTheme() ? Color::Primer::Dark::fgSubtle : Color::Primer::Light::fgSubtle));
+    }
+
+    QColor getLogNormalColor()
+    {
+        return UIThemeManager::instance()->getColor(u"Log.Normal"_qs
+            , QApplication::palette().color(QPalette::Active, QPalette::WindowText));
+    }
+
+    QColor getLogInfoColor()
+    {
+        return UIThemeManager::instance()->getColor(u"Log.Info"_qs
+            , (Utils::Gui::isDarkTheme() ? Color::Primer::Dark::accentFg : Color::Primer::Light::accentFg));
+    }
+
+    QColor getLogWarningColor()
+    {
+        return UIThemeManager::instance()->getColor(u"Log.Warning"_qs
+            , (Utils::Gui::isDarkTheme() ? Color::Primer::Dark::severeFg : Color::Primer::Light::severeFg));
+    }
+
+    QColor getLogCriticalColor()
+    {
+        return UIThemeManager::instance()->getColor(u"Log.Critical"_qs
+            , (Utils::Gui::isDarkTheme() ? Color::Primer::Dark::dangerFg : Color::Primer::Light::dangerFg));
+    }
+
+    QColor getPeerBannedColor()
+    {
+        return UIThemeManager::instance()->getColor(u"Log.BannedPeer"_qs
+            , (Utils::Gui::isDarkTheme() ? Color::Primer::Dark::dangerFg : Color::Primer::Light::dangerFg));
+    }
 }
 
 BaseLogModel::Message::Message(const QString &time, const QString &message, const QColor &foreground, const Log::MsgType type)
@@ -73,7 +111,7 @@ QVariant BaseLogModel::Message::type() const
 BaseLogModel::BaseLogModel(QObject *parent)
     : QAbstractListModel(parent)
     , m_messages(MAX_VISIBLE_MESSAGES)
-    , m_timeForeground(UIThemeManager::instance()->getColor(u"Log.TimeStamp"_qs, Qt::darkGray))
+    , m_timeForeground(getTimestampColor())
 {
 }
 
@@ -142,10 +180,10 @@ LogMessageModel::LogMessageModel(QObject *parent)
     : BaseLogModel(parent)
     , m_foregroundForMessageTypes
     {
-        {Log::NORMAL, UIThemeManager::instance()->getColor(u"Log.Normal"_qs, QApplication::palette().color(QPalette::WindowText))},
-        {Log::INFO, UIThemeManager::instance()->getColor(u"Log.Info"_qs, Qt::blue)},
-        {Log::WARNING, UIThemeManager::instance()->getColor(u"Log.Warning"_qs, QColor {255, 165, 0})}, // orange
-        {Log::CRITICAL, UIThemeManager::instance()->getColor(u"Log.Critical"_qs, Qt::red)}
+        {Log::NORMAL, getLogNormalColor()},
+        {Log::INFO, getLogInfoColor()},
+        {Log::WARNING, getLogWarningColor()},
+        {Log::CRITICAL, getLogCriticalColor()}
     }
 {
     for (const Log::Msg &msg : asConst(Logger::instance()->getMessages()))
@@ -164,7 +202,7 @@ void LogMessageModel::handleNewMessage(const Log::Msg &message)
 
 LogPeerModel::LogPeerModel(QObject *parent)
     : BaseLogModel(parent)
-    , m_bannedPeerForeground(UIThemeManager::instance()->getColor(u"Log.BannedPeer"_qs, Qt::red))
+    , m_bannedPeerForeground(getPeerBannedColor())
 {
     for (const Log::Peer &peer : asConst(Logger::instance()->getPeers()))
         handleNewMessage(peer);

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -32,7 +32,6 @@
 #include <QApplication>
 #include <QDateTime>
 #include <QDebug>
-#include <QPalette>
 
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/torrent.h"
@@ -43,46 +42,52 @@
 #include "base/utils/fs.h"
 #include "base/utils/misc.h"
 #include "base/utils/string.h"
+#include "color.h"
 #include "uithememanager.h"
+#include "utils.h"
 
 namespace
 {
     QColor getDefaultColorByState(const BitTorrent::TorrentState state)
     {
+        const bool isDarkTheme = Utils::Gui::isDarkTheme();
+
         switch (state)
         {
         case BitTorrent::TorrentState::Downloading:
         case BitTorrent::TorrentState::ForcedDownloading:
         case BitTorrent::TorrentState::DownloadingMetadata:
         case BitTorrent::TorrentState::ForcedDownloadingMetadata:
-            return QColorConstants::Svg::green;
+            return (isDarkTheme ? Color::Primer::Dark::successFg : Color::Primer::Light::successFg);
         case BitTorrent::TorrentState::StalledDownloading:
-            return QColorConstants::Svg::mediumseagreen;
+            return (isDarkTheme ? Color::Primer::Dark::successEmphasis : Color::Primer::Light::successEmphasis);
         case BitTorrent::TorrentState::StalledUploading:
-            return QColorConstants::Svg::cornflowerblue;
+            return (isDarkTheme ? Color::Primer::Dark::accentEmphasis : Color::Primer::Light::accentEmphasis);
         case BitTorrent::TorrentState::Uploading:
         case BitTorrent::TorrentState::ForcedUploading:
-            return QColorConstants::Svg::royalblue;
+            return (isDarkTheme ? Color::Primer::Dark::accentFg : Color::Primer::Light::accentFg);
         case BitTorrent::TorrentState::PausedDownloading:
-            return QColorConstants::Svg::grey;
+            return (isDarkTheme ? Color::Primer::Dark::fgMuted : Color::Primer::Light::fgMuted);
         case BitTorrent::TorrentState::PausedUploading:
-            return QColorConstants::Svg::darkslateblue;
+            return (isDarkTheme ? Color::Primer::Dark::scaleBlue4 : Color::Primer::Light::scaleBlue4);
         case BitTorrent::TorrentState::QueuedDownloading:
         case BitTorrent::TorrentState::QueuedUploading:
-            return QColorConstants::Svg::peru;
+            return (isDarkTheme ? Color::Primer::Dark::scaleYellow6 : Color::Primer::Light::scaleYellow6);
         case BitTorrent::TorrentState::CheckingDownloading:
         case BitTorrent::TorrentState::CheckingUploading:
         case BitTorrent::TorrentState::CheckingResumeData:
         case BitTorrent::TorrentState::Moving:
-            return QColorConstants::Svg::teal;
+            return (isDarkTheme ? Color::Primer::Dark::successFg : Color::Primer::Light::successFg);
         case BitTorrent::TorrentState::Error:
         case BitTorrent::TorrentState::MissingFiles:
         case BitTorrent::TorrentState::Unknown:
-            return QColorConstants::Svg::red;
+            return (isDarkTheme ? Color::Primer::Dark::dangerFg : Color::Primer::Light::dangerFg);
         default:
             Q_ASSERT(false);
-            return QColorConstants::Svg::red;
+            break;
         }
+
+        return {};
     }
 
     QHash<BitTorrent::TorrentState, QColor> torrentStateColorsFromUITheme()


### PR DESCRIPTION
This commit introduce color palettes from Primer and make use of it in various widgets.
Primer system is chosen due to well designed and is highly rated on Github (in terms of Github stars).
https://primer.style/primitives/colors

Screenshots:
[Transfer List light](https://user-images.githubusercontent.com/9395168/193185017-6841d796-fd21-4388-be0f-c527c6224f15.png)
[Transfer List dark](https://user-images.githubusercontent.com/9395168/193185024-fe2a7a9f-8aa5-4eb1-aa7c-eab7369c8fa6.png)
[Log light](https://user-images.githubusercontent.com/9395168/193185023-df4e3406-1ab5-4f46-92a4-0951f0b0a8f2.png)
[Log dark](https://user-images.githubusercontent.com/9395168/193185020-b69b21db-1ed1-4f56-a505-8efd21945beb.png)

I'm open to suggestions on the colors from Primer.. note that I didn't radically revamped the colors and just picked what is similar to the current ones.
