### PR TITLE
Add support for boost 1.66

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(qBittorrent
 )
 
 # version requirements - older versions may work, but you are on your own
-set(minBoostVersion 1.71)
+set(minBoostVersion 1.66)
 set(minQt5Version 5.15.2)
 set(minQt6Version 6.2)
 set(minOpenSSLVersion 1.1.1)

--- a/cmake/Modules/CheckPackages.cmake
+++ b/cmake/Modules/CheckPackages.cmake
@@ -43,10 +43,9 @@ endif()
 
 # force variable type so that it always shows up in ccmake/cmake-gui frontends
 set_property(CACHE LibtorrentRasterbar_DIR PROPERTY TYPE PATH)
-find_package(Boost ${minBoostVersion} REQUIRED)
+find_package(Boost ${minBoostVersion} REQUIRED COMPONENTS system)
 find_package(OpenSSL ${minOpenSSLVersion} REQUIRED)
 find_package(ZLIB ${minZlibVersion} REQUIRED)
-find_package(Boost ${minBoostVersion} REQUIRED COMPONENTS system)
 
 if (QT6)
     find_package(Qt6 ${minQt6Version} REQUIRED COMPONENTS Core Network Sql Xml LinguistTools)

--- a/cmake/Modules/CheckPackages.cmake
+++ b/cmake/Modules/CheckPackages.cmake
@@ -46,6 +46,8 @@ set_property(CACHE LibtorrentRasterbar_DIR PROPERTY TYPE PATH)
 find_package(Boost ${minBoostVersion} REQUIRED)
 find_package(OpenSSL ${minOpenSSLVersion} REQUIRED)
 find_package(ZLIB ${minZlibVersion} REQUIRED)
+find_package(Boost ${minBoostVersion} REQUIRED COMPONENTS system)
+
 if (QT6)
     find_package(Qt6 ${minQt6Version} REQUIRED COMPONENTS Core Network Sql Xml LinguistTools)
     if (DBUS)

--- a/cmake/Modules/CheckPackages.cmake
+++ b/cmake/Modules/CheckPackages.cmake
@@ -43,7 +43,7 @@ endif()
 
 # force variable type so that it always shows up in ccmake/cmake-gui frontends
 set_property(CACHE LibtorrentRasterbar_DIR PROPERTY TYPE PATH)
-find_package(Boost ${minBoostVersion} REQUIRED COMPONENTS system)
+find_package(Boost ${minBoostVersion} REQUIRED OPTIONAL_COMPONENTS system)
 find_package(OpenSSL ${minOpenSSLVersion} REQUIRED)
 find_package(ZLIB ${minZlibVersion} REQUIRED)
 

--- a/src/app/stacktrace.cpp
+++ b/src/app/stacktrace.cpp
@@ -30,7 +30,14 @@
 
 #include <boost/stacktrace.hpp>
 
+#include <sstream>
+#include <boost/version.hpp>
+
 std::string getStacktrace()
 {
+#if BOOST_VERSION >= 107100
     return boost::stacktrace::to_string(boost::stacktrace::stacktrace());
+#else
+    return (std::ostringstream() << boost::stacktrace::stacktrace()).str();
+#endif
 }


### PR DESCRIPTION
openSUSE stable requires it and it most likely will in the 2023 release as well.
