### PR TITLE
TorrentState: Distinguish forced stalled/active down/up for later use

### DIFF
--- a/src/base/bittorrent/torrent.h
+++ b/src/base/bittorrent/torrent.h
@@ -75,12 +75,14 @@ namespace BitTorrent
         Unknown = -1,
 
         ForcedDownloading,
+        ForcedStalledDownloading,
         Downloading,
         ForcedDownloadingMetadata,
         DownloadingMetadata,
         StalledDownloading,
 
         ForcedUploading,
+        ForcedStalledUploading,
         Uploading,
         StalledUploading,
 

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -878,7 +878,7 @@ bool TorrentImpl::isUploading() const
     case TorrentState::CheckingUploading:
     case TorrentState::QueuedUploading:
     case TorrentState::ForcedUploading:
-    case TorrentState::ForcedStalledUploading;
+    case TorrentState::ForcedStalledUploading:
         return true;
     default:
         break;
@@ -897,7 +897,7 @@ bool TorrentImpl::isCompleted() const
     case TorrentState::PausedUploading:
     case TorrentState::QueuedUploading:
     case TorrentState::ForcedUploading:
-    case TorrentState::ForcedStalledUploading;
+    case TorrentState::ForcedStalledUploading:
         return true;
     default:
         break;
@@ -920,7 +920,7 @@ bool TorrentImpl::isActive() const
     case TorrentState::ForcedStalledDownloading:
     case TorrentState::Uploading:
     case TorrentState::ForcedUploading:
-    case TorrentState::ForcedStalledUploading;
+    case TorrentState::ForcedStalledUploading:
     case TorrentState::Moving:
         return true;
 

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -53,6 +53,7 @@ namespace
         {
         case BitTorrent::TorrentState::Downloading:
         case BitTorrent::TorrentState::ForcedDownloading:
+        case BitTorrent::TorrentState::ForcedStalledDownloading:
         case BitTorrent::TorrentState::DownloadingMetadata:
         case BitTorrent::TorrentState::ForcedDownloadingMetadata:
             return QColorConstants::Svg::green;
@@ -62,6 +63,7 @@ namespace
             return QColorConstants::Svg::cornflowerblue;
         case BitTorrent::TorrentState::Uploading:
         case BitTorrent::TorrentState::ForcedUploading:
+        case BitTorrent::TorrentState::ForcedStalledUploading:
             return QColorConstants::Svg::royalblue;
         case BitTorrent::TorrentState::PausedDownloading:
             return QColorConstants::Svg::grey;
@@ -100,9 +102,11 @@ namespace
             {BitTorrent::TorrentState::DownloadingMetadata, u"TransferList.DownloadingMetadata"_qs},
             {BitTorrent::TorrentState::ForcedDownloadingMetadata, u"TransferList.ForcedDownloadingMetadata"_qs},
             {BitTorrent::TorrentState::ForcedDownloading, u"TransferList.ForcedDownloading"_qs},
+            {BitTorrent::TorrentState::ForcedStalledDownloading, u"TransferList.ForcedStalledDownloading"_qs},
             {BitTorrent::TorrentState::Uploading, u"TransferList.Uploading"_qs},
             {BitTorrent::TorrentState::StalledUploading, u"TransferList.StalledUploading"_qs},
             {BitTorrent::TorrentState::ForcedUploading, u"TransferList.ForcedUploading"_qs},
+            {BitTorrent::TorrentState::ForcedStalledUploading, u"TransferList.ForcedStalledUploading"_qs},
             {BitTorrent::TorrentState::QueuedDownloading, u"TransferList.QueuedDownloading"_qs},
             {BitTorrent::TorrentState::QueuedUploading, u"TransferList.QueuedUploading"_qs},
             {BitTorrent::TorrentState::CheckingDownloading, u"TransferList.CheckingDownloading"_qs},
@@ -137,9 +141,11 @@ TransferListModel::TransferListModel(QObject *parent)
           {BitTorrent::TorrentState::DownloadingMetadata, tr("Downloading metadata", "Used when loading a magnet link")},
           {BitTorrent::TorrentState::ForcedDownloadingMetadata, tr("[F] Downloading metadata", "Used when forced to load a magnet link. You probably shouldn't translate the F.")},
           {BitTorrent::TorrentState::ForcedDownloading, tr("[F] Downloading", "Used when the torrent is forced started. You probably shouldn't translate the F.")},
+          {BitTorrent::TorrentState::ForcedStalledDownloading, tr("[F] Stalled", "Used when the torrent is forced started. You probably shouldn't translate the F.")},
           {BitTorrent::TorrentState::Uploading, tr("Seeding", "Torrent is complete and in upload-only mode")},
-          {BitTorrent::TorrentState::StalledUploading, tr("Seeding", "Torrent is complete and in upload-only mode")},
+          {BitTorrent::TorrentState::StalledUploading, tr("Seeding (waiting)", "Torrent is complete and in upload-only mode")},
           {BitTorrent::TorrentState::ForcedUploading, tr("[F] Seeding", "Used when the torrent is forced started. You probably shouldn't translate the F.")},
+          {BitTorrent::TorrentState::ForcedStalledUploading, tr("[F] Seeding (waiting)", "Used when the torrent is forced started. You probably shouldn't translate the F.")},
           {BitTorrent::TorrentState::QueuedDownloading, tr("Queued", "Torrent is queued")},
           {BitTorrent::TorrentState::QueuedUploading, tr("Queued", "Torrent is queued")},
           {BitTorrent::TorrentState::CheckingDownloading, tr("Checking", "Torrent local data is being checked")},
@@ -701,6 +707,7 @@ QIcon TransferListModel::getIconByState(const BitTorrent::TorrentState state) co
     {
     case BitTorrent::TorrentState::Downloading:
     case BitTorrent::TorrentState::ForcedDownloading:
+    case BitTorrent::TorrentState::ForcedStalledDownloading:
     case BitTorrent::TorrentState::DownloadingMetadata:
     case BitTorrent::TorrentState::ForcedDownloadingMetadata:
         return m_downloadingIcon;
@@ -710,6 +717,7 @@ QIcon TransferListModel::getIconByState(const BitTorrent::TorrentState state) co
         return m_stalledUPIcon;
     case BitTorrent::TorrentState::Uploading:
     case BitTorrent::TorrentState::ForcedUploading:
+    case BitTorrent::TorrentState::ForcedStalledUploading:
         return m_uploadingIcon;
     case BitTorrent::TorrentState::PausedDownloading:
         return m_pausedIcon;

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -59,8 +59,9 @@ namespace
         case BitTorrent::TorrentState::CheckingUploading:
             return u"checkingUP"_qs;
         case BitTorrent::TorrentState::ForcedUploading:
-        case BitTorrent::TorrentState::ForcedStalledUploading:
             return u"forcedUP"_qs;
+        case BitTorrent::TorrentState::ForcedStalledUploading:
+            return u"forcedStalledUP"_qs;
         case BitTorrent::TorrentState::Downloading:
             return u"downloading"_qs;
         case BitTorrent::TorrentState::DownloadingMetadata:
@@ -76,8 +77,9 @@ namespace
         case BitTorrent::TorrentState::CheckingDownloading:
             return u"checkingDL"_qs;
         case BitTorrent::TorrentState::ForcedDownloading:
-        case BitTorrent::TorrentState::ForcedStalledDownloading:
             return u"forcedDL"_qs;
+        case BitTorrent::TorrentState::ForcedStalledDownloading:
+            return u"forcedStalledDL"_qs;
         case BitTorrent::TorrentState::CheckingResumeData:
             return u"checkingResumeData"_qs;
         case BitTorrent::TorrentState::Moving:

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -59,6 +59,7 @@ namespace
         case BitTorrent::TorrentState::CheckingUploading:
             return u"checkingUP"_qs;
         case BitTorrent::TorrentState::ForcedUploading:
+        case BitTorrent::TorrentState::ForcedStalledUploading:
             return u"forcedUP"_qs;
         case BitTorrent::TorrentState::Downloading:
             return u"downloading"_qs;
@@ -75,6 +76,7 @@ namespace
         case BitTorrent::TorrentState::CheckingDownloading:
             return u"checkingDL"_qs;
         case BitTorrent::TorrentState::ForcedDownloading:
+        case BitTorrent::TorrentState::ForcedStalledDownloading:
             return u"forcedDL"_qs;
         case BitTorrent::TorrentState::CheckingResumeData:
             return u"checkingResumeData"_qs;

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1355,7 +1355,7 @@ window.qBittorrent.DynamicTable = (function() {
                     inactive = true;
                     // fallthrough
                 case 'active':
-                    if ((state == 'stalledDL') && (state == 'forcedStalledDL'))
+                    if ((state == 'stalledDL') || (state == 'forcedStalledDL'))
                         r = (row['full_data'].upspeed > 0);
                     else
                         r = state == 'metaDL' || state == 'forcedMetaDL' || state == 'downloading' || state == 'forcedDL' || state == 'forcedStalledDL' || state == 'uploading' || state == 'forcedUP' || state == 'forcedStalledUP';

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -954,8 +954,16 @@ window.qBittorrent.DynamicTable = (function() {
                         state = "stalledUP";
                         img_path = "images/stalledUP.svg";
                         break;
+                    case "forcedStalledUP":
+                        state = "forcedStalledUP";
+                        img_path = "images/stalledUP.svg";
+                        break;
                     case "stalledDL":
                         state = "stalledDL";
+                        img_path = "images/stalledDL.svg";
+                        break;
+                    case "forcedStalledDL":
+                        state = "forcedStalledDL";
                         img_path = "images/stalledDL.svg";
                         break;
                     case "pausedDL":
@@ -1027,12 +1035,20 @@ window.qBittorrent.DynamicTable = (function() {
                     case "forcedDL":
                         status = "QBT_TR([F] Downloading)QBT_TR[CONTEXT=TransferListDelegate]";
                         break;
+                    case "forcedStalledDL":
+                        status = "QBT_TR([F] Stalled)QBT_TR[CONTEXT=TransferListDelegate]";
+                        break;
                     case "uploading":
-                    case "stalledUP":
                         status = "QBT_TR(Seeding)QBT_TR[CONTEXT=TransferListDelegate]";
+                        break;
+                    case "stalledUP":
+                        status = "QBT_TR(Seeding (waiting))QBT_TR[CONTEXT=TransferListDelegate]";
                         break;
                     case "forcedUP":
                         status = "QBT_TR([F] Seeding)QBT_TR[CONTEXT=TransferListDelegate]";
+                        break;
+                    case "forcedStalledUP":
+                        status = "QBT_TR([F] Seeding (waiting))QBT_TR[CONTEXT=TransferListDelegate]";
                         break;
                     case "queuedDL":
                     case "queuedUP":
@@ -1308,7 +1324,7 @@ window.qBittorrent.DynamicTable = (function() {
                         return false;
                     break;
                 case 'seeding':
-                    if (state != 'uploading' && state != 'forcedUP' && state != 'stalledUP' && state != 'queuedUP' && state != 'checkingUP')
+                    if (state != 'uploading' && state != 'forcedUP' && state != 'stalledUP' && state != 'forcedStalledUP' && state != 'queuedUP' && state != 'checkingUP')
                         return false;
                     break;
                 case 'completed':
@@ -1324,25 +1340,25 @@ window.qBittorrent.DynamicTable = (function() {
                         return false;
                     break;
                 case 'stalled':
-                    if ((state != 'stalledUP') && (state != 'stalledDL'))
+                    if ((state != 'stalledUP') && (state != 'forcedStalledUP') && (state != 'stalledDL') && (state != 'forcedStalledDL'))
                         return false;
                     break;
                 case 'stalled_uploading':
-                    if (state != 'stalledUP')
+                    if ((state != 'stalledUP') && (state != 'forcedStalledUP'))
                         return false;
                     break;
                 case 'stalled_downloading':
-                    if (state != 'stalledDL')
+                    if ((state != 'stalledDL') && (state != 'forcedStalledDL'))
                         return false;
                     break;
                 case 'inactive':
                     inactive = true;
                     // fallthrough
                 case 'active':
-                    if (state == 'stalledDL')
+                    if ((state == 'stalledDL') && (state == 'forcedStalledDL'))
                         r = (row['full_data'].upspeed > 0);
                     else
-                        r = state == 'metaDL' || state == 'forcedMetaDL' || state == 'downloading' || state == 'forcedDL' || state == 'uploading' || state == 'forcedUP';
+                        r = state == 'metaDL' || state == 'forcedMetaDL' || state == 'downloading' || state == 'forcedDL' || state == 'forcedStalledDL' || state == 'uploading' || state == 'forcedUP' || state == 'forcedStalledUP';
                     if (r == inactive)
                         return false;
                     break;


### PR DESCRIPTION
Non-forced down/up torrents already distinguish active and inactive state; `Uploading`/`StalledUploading`, for example

This way, a status filter can be added to see the actually "bandwidth" active torrents: the one really downloading or uploading data.