### PR TITLE
Allow to set torrent stop condition

### DIFF
--- a/src/base/bittorrent/addtorrentparams.h
+++ b/src/base/bittorrent/addtorrentparams.h
@@ -55,6 +55,7 @@ namespace BitTorrent
         bool firstLastPiecePriority = false;
         bool addForced = false;
         std::optional<bool> addPaused;
+        std::optional<Torrent::StopCondition> stopCondition;
         PathList filePaths; // used if TorrentInfo is set
         QVector<DownloadPriority> filePriorities; // used if TorrentInfo is set
         bool skipChecking = false;

--- a/src/base/bittorrent/bencoderesumedatastorage.cpp
+++ b/src/base/bittorrent/bencoderesumedatastorage.cpp
@@ -245,6 +245,9 @@ BitTorrent::LoadResumeDataResult BitTorrent::BencodeResumeDataStorage::loadTorre
     //                fromLTString(root.dict_find_string_value("qBt-contentLayout")), TorrentContentLayout::Default);
     // === END REPLACEMENT CODE === //
 
+    torrentParams.stopCondition = Utils::String::toEnum(
+                fromLTString(resumeDataRoot.dict_find_string_value("qBt-stopCondition")), Torrent::StopCondition::None);
+
     const lt::string_view ratioLimitString = resumeDataRoot.dict_find_string_value("qBt-ratioLimit");
     if (ratioLimitString.empty())
         torrentParams.ratioLimit = resumeDataRoot.dict_find_int_value("qBt-ratioLimit", Torrent::USE_GLOBAL_RATIO * 1000) / 1000.0;
@@ -284,20 +287,14 @@ BitTorrent::LoadResumeDataResult BitTorrent::BencodeResumeDataStorage::loadTorre
     p.save_path = Profile::instance()->fromPortablePath(
                 Path(fromLTString(p.save_path))).toString().toStdString();
 
+    torrentParams.stopped = (p.flags & lt::torrent_flags::paused) && !(p.flags & lt::torrent_flags::auto_managed);
+    torrentParams.operatingMode = (p.flags & lt::torrent_flags::paused) || (p.flags & lt::torrent_flags::auto_managed)
+            ? TorrentOperatingMode::AutoManaged : TorrentOperatingMode::Forced;
+
     if (p.flags & lt::torrent_flags::stop_when_ready)
     {
-        // If torrent has "stop_when_ready" flag set then it is actually "stopped"
-        torrentParams.stopped = true;
-        torrentParams.operatingMode = TorrentOperatingMode::AutoManaged;
-        // ...but temporarily "resumed" to perform some service jobs (e.g. checking)
-        p.flags &= ~lt::torrent_flags::paused;
-        p.flags |= lt::torrent_flags::auto_managed;
-    }
-    else
-    {
-        torrentParams.stopped = (p.flags & lt::torrent_flags::paused) && !(p.flags & lt::torrent_flags::auto_managed);
-        torrentParams.operatingMode = (p.flags & lt::torrent_flags::paused) || (p.flags & lt::torrent_flags::auto_managed)
-                ? TorrentOperatingMode::AutoManaged : TorrentOperatingMode::Forced;
+        p.flags &= ~lt::torrent_flags::stop_when_ready;
+        torrentParams.stopCondition = Torrent::StopCondition::FilesChecked;
     }
 
     const bool hasMetadata = (p.ti && p.ti->is_valid());
@@ -393,6 +390,7 @@ void BitTorrent::BencodeResumeDataStorage::Worker::store(const TorrentID &id, co
     data["qBt-seedStatus"] = resumeData.hasSeedStatus;
     data["qBt-contentLayout"] = Utils::String::fromEnum(resumeData.contentLayout).toStdString();
     data["qBt-firstLastPiecePriority"] = resumeData.firstLastPiecePriority;
+    data["qBt-stopCondition"] = Utils::String::fromEnum(resumeData.stopCondition).toStdString();
 
     if (!resumeData.useAutoTMM)
     {

--- a/src/base/bittorrent/dbresumedatastorage.h
+++ b/src/base/bittorrent/dbresumedatastorage.h
@@ -57,7 +57,7 @@ namespace BitTorrent
         void doLoadAll() const override;
         int currentDBVersion() const;
         void createDB() const;
-        void updateDBFromVersion1() const;
+        void updateDB(int fromVersion) const;
 
         QThread *m_ioThread = nullptr;
 

--- a/src/base/bittorrent/loadtorrentparams.h
+++ b/src/base/bittorrent/loadtorrentparams.h
@@ -54,6 +54,7 @@ namespace BitTorrent
         bool firstLastPiecePriority = false;
         bool hasSeedStatus = false;
         bool stopped = false;
+        Torrent::StopCondition stopCondition;
 
         qreal ratioLimit = Torrent::USE_GLOBAL_RATIO;
         int seedingTimeLimit = Torrent::USE_GLOBAL_SEEDING_TIME;

--- a/src/base/bittorrent/nativetorrentextension.cpp
+++ b/src/base/bittorrent/nativetorrentextension.cpp
@@ -30,14 +30,6 @@
 
 #include <libtorrent/torrent_status.hpp>
 
-namespace
-{
-    bool isAutoManaged(const lt::torrent_status &torrentStatus)
-    {
-        return static_cast<bool>(torrentStatus.flags & lt::torrent_flags::auto_managed);
-    }
-}
-
 NativeTorrentExtension::NativeTorrentExtension(const lt::torrent_handle &torrentHandle, ExtensionData *data)
     : m_torrentHandle {torrentHandle}
     , m_data {data}
@@ -65,19 +57,10 @@ NativeTorrentExtension::~NativeTorrentExtension()
     delete m_data;
 }
 
-bool NativeTorrentExtension::on_pause()
-{
-    if (!isAutoManaged(m_torrentHandle.status({})))
-        m_torrentHandle.unset_flags(lt::torrent_flags::stop_when_ready);
-
-    // return `false` to allow standard handler
-    // and other extensions to be also invoked.
-    return false;
-}
-
 void NativeTorrentExtension::on_state(const lt::torrent_status::state_t state)
 {
-    if (m_state == lt::torrent_status::downloading_metadata)
+    if ((m_state == lt::torrent_status::downloading_metadata)
+            || (m_state == lt::torrent_status::checking_files))
     {
         m_torrentHandle.unset_flags(lt::torrent_flags::auto_managed);
         m_torrentHandle.pause();

--- a/src/base/bittorrent/nativetorrentextension.h
+++ b/src/base/bittorrent/nativetorrentextension.h
@@ -40,7 +40,6 @@ public:
     ~NativeTorrentExtension();
 
 private:
-    bool on_pause() override;
     void on_state(lt::torrent_status::state_t state) override;
 
     lt::torrent_handle m_torrentHandle;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -208,6 +208,8 @@ namespace BitTorrent
         virtual void setPeXEnabled(bool enabled) = 0;
         virtual bool isAddTorrentPaused() const = 0;
         virtual void setAddTorrentPaused(bool value) = 0;
+        virtual Torrent::StopCondition torrentStopCondition() const = 0;
+        virtual void setTorrentStopCondition(Torrent::StopCondition stopCondition) = 0;
         virtual TorrentContentLayout torrentContentLayout() const = 0;
         virtual void setTorrentContentLayout(TorrentContentLayout value) = 0;
         virtual bool isTrackerEnabled() const = 0;

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -438,6 +438,7 @@ SessionImpl::SessionImpl(QObject *parent)
     , m_globalMaxRatio(BITTORRENT_SESSION_KEY(u"GlobalMaxRatio"_qs), -1, [](qreal r) { return r < 0 ? -1. : r;})
     , m_globalMaxSeedingMinutes(BITTORRENT_SESSION_KEY(u"GlobalMaxSeedingMinutes"_qs), -1, lowerLimited(-1))
     , m_isAddTorrentPaused(BITTORRENT_SESSION_KEY(u"AddTorrentPaused"_qs), false)
+    , m_torrentStopCondition(BITTORRENT_SESSION_KEY(u"TorrentStopCondition"_qs), Torrent::StopCondition::None)
     , m_torrentContentLayout(BITTORRENT_SESSION_KEY(u"TorrentContentLayout"_qs), TorrentContentLayout::Original)
     , m_isAppendExtensionEnabled(BITTORRENT_SESSION_KEY(u"AddExtensionToIncompleteFiles"_qs), false)
     , m_refreshInterval(BITTORRENT_SESSION_KEY(u"RefreshInterval"_qs), 1500)
@@ -948,6 +949,16 @@ bool SessionImpl::isAddTorrentPaused() const
 void SessionImpl::setAddTorrentPaused(const bool value)
 {
     m_isAddTorrentPaused = value;
+}
+
+Torrent::StopCondition SessionImpl::torrentStopCondition() const
+{
+    return m_torrentStopCondition;
+}
+
+void SessionImpl::setTorrentStopCondition(const Torrent::StopCondition stopCondition)
+{
+    m_torrentStopCondition = stopCondition;
 }
 
 bool SessionImpl::isTrackerEnabled() const
@@ -2497,6 +2508,7 @@ LoadTorrentParams SessionImpl::initLoadTorrentParams(const AddTorrentParams &add
     loadTorrentParams.contentLayout = addTorrentParams.contentLayout.value_or(torrentContentLayout());
     loadTorrentParams.operatingMode = (addTorrentParams.addForced ? TorrentOperatingMode::Forced : TorrentOperatingMode::AutoManaged);
     loadTorrentParams.stopped = addTorrentParams.addPaused.value_or(isAddTorrentPaused());
+    loadTorrentParams.stopCondition = addTorrentParams.stopCondition.value_or(torrentStopCondition());
     loadTorrentParams.ratioLimit = addTorrentParams.ratioLimit;
     loadTorrentParams.seedingTimeLimit = addTorrentParams.seedingTimeLimit;
 

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -188,6 +188,8 @@ namespace BitTorrent
         void setPeXEnabled(bool enabled) override;
         bool isAddTorrentPaused() const override;
         void setAddTorrentPaused(bool value) override;
+        Torrent::StopCondition torrentStopCondition() const override;
+        void setTorrentStopCondition(Torrent::StopCondition stopCondition) override;
         TorrentContentLayout torrentContentLayout() const override;
         void setTorrentContentLayout(TorrentContentLayout value) override;
         bool isTrackerEnabled() const override;
@@ -620,6 +622,7 @@ namespace BitTorrent
         CachedSettingValue<qreal> m_globalMaxRatio;
         CachedSettingValue<int> m_globalMaxSeedingMinutes;
         CachedSettingValue<bool> m_isAddTorrentPaused;
+        CachedSettingValue<Torrent::StopCondition> m_torrentStopCondition;
         CachedSettingValue<TorrentContentLayout> m_torrentContentLayout;
         CachedSettingValue<bool> m_isAppendExtensionEnabled;
         CachedSettingValue<int> m_refreshInterval;

--- a/src/base/bittorrent/torrent.h
+++ b/src/base/bittorrent/torrent.h
@@ -108,7 +108,17 @@ namespace BitTorrent
 
     class Torrent : public AbstractFileStorage
     {
+        Q_GADGET
+
     public:
+        enum class StopCondition
+        {
+            None = 0,
+            MetadataReceived = 1,
+            FilesChecked = 2
+        };
+        Q_ENUM(StopCondition)
+
         static const qreal USE_GLOBAL_RATIO;
         static const qreal NO_RATIO_LIMIT;
 
@@ -299,6 +309,9 @@ namespace BitTorrent
         virtual bool connectPeer(const PeerAddress &peerAddress) = 0;
         virtual void clearPeers() = 0;
         virtual bool setMetadata(const TorrentInfo &torrentInfo) = 0;
+
+        virtual StopCondition stopCondition() const = 0;
+        virtual void setStopCondition(StopCondition stopCondition) = 0;
 
         virtual QString createMagnetURI() const = 0;
         virtual nonstd::expected<QByteArray, QString> exportToBuffer() const = 0;

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -227,6 +227,9 @@ namespace BitTorrent
         void clearPeers() override;
         bool setMetadata(const TorrentInfo &torrentInfo) override;
 
+        StopCondition stopCondition() const override;
+        void setStopCondition(StopCondition stopCondition) override;
+
         QString createMagnetURI() const override;
         nonstd::expected<QByteArray, QString> exportToBuffer() const override;
         nonstd::expected<void, QString> exportToFile(const Path &path) const override;
@@ -332,6 +335,7 @@ namespace BitTorrent
         bool m_hasFirstLastPiecePriority = false;
         bool m_useAutoTMM;
         bool m_isStopped;
+        StopCondition m_stopCondition;
 
         bool m_unchecked = false;
 

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -218,6 +218,24 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::AddTorrentParams &inP
     m_ui->downloadPath->setMaxVisibleItems(20);
 
     m_ui->startTorrentCheckBox->setChecked(!m_torrentParams.addPaused.value_or(session->isAddTorrentPaused()));
+    m_ui->stopConditionComboBox->setToolTip(
+                u"<html><body><p><b>" + tr("None") + u"</b> - " + tr("No stop condition is set.") + u"</p><p><b>" +
+                tr("Metadata received") + u"</b> - " + tr("Torrent will stop after metadata is received.") +
+                u" <em>" + tr("Torrents that have metadata initially aren't affected.") + u"</em></p><p><b>" +
+                tr("Files checked") + u"</b> - " + tr("Torrent will stop after files are initially checked.") +
+                u" <em>" + tr("This will also download metadata if it wasn't there initially.") + u"</em></p></body></html>");
+    m_ui->stopConditionComboBox->setItemData(0, QVariant::fromValue(BitTorrent::Torrent::StopCondition::None));
+    m_ui->stopConditionComboBox->setItemData(1, QVariant::fromValue(BitTorrent::Torrent::StopCondition::MetadataReceived));
+    m_ui->stopConditionComboBox->setItemData(2, QVariant::fromValue(BitTorrent::Torrent::StopCondition::FilesChecked));
+    m_ui->stopConditionComboBox->setCurrentIndex(m_ui->stopConditionComboBox->findData(
+                                                     QVariant::fromValue(m_torrentParams.stopCondition.value_or(session->torrentStopCondition()))));
+    m_ui->stopConditionLabel->setEnabled(m_ui->startTorrentCheckBox->isChecked());
+    m_ui->stopConditionComboBox->setEnabled(m_ui->startTorrentCheckBox->isChecked());
+    connect(m_ui->startTorrentCheckBox, &QCheckBox::toggled, this, [this](const bool checked)
+    {
+        m_ui->stopConditionLabel->setEnabled(checked);
+        m_ui->stopConditionComboBox->setEnabled(checked);
+    });
 
     m_ui->comboTTM->blockSignals(true); // the TreeView size isn't correct if the slot does its job at this point
     m_ui->comboTTM->setCurrentIndex(session->isAutoTMMDisabledByDefault() ? 0 : 1);
@@ -872,6 +890,7 @@ void AddNewTorrentDialog::accept()
         m_torrentParams.filePriorities = m_contentModel->model()->getFilePriorities();
 
     m_torrentParams.addPaused = !m_ui->startTorrentCheckBox->isChecked();
+    m_torrentParams.stopCondition = m_ui->stopConditionComboBox->currentData().value<BitTorrent::Torrent::StopCondition>();
     m_torrentParams.contentLayout = static_cast<BitTorrent::TorrentContentLayout>(m_ui->contentLayoutComboBox->currentIndex());
 
     m_torrentParams.sequential = m_ui->sequentialCheckBox->isChecked();

--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -203,43 +203,45 @@
               </item>
               <item>
                <layout class="QGridLayout" name="gridLayout">
-                <item row="2" column="0">
-                 <widget class="QCheckBox" name="doNotDeleteTorrentCheckBox">
-                  <property name="toolTip">
-                   <string>When checked, the .torrent file will not be deleted regardless of the settings at the &quot;Download&quot; page of the Options dialog</string>
-                  </property>
-                  <property name="text">
-                   <string>Do not delete .torrent file</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="1" column="1">
-                 <widget class="QCheckBox" name="firstLastCheckBox">
-                  <property name="text">
-                   <string>Download first and last pieces first</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="1" column="0">
-                 <widget class="QCheckBox" name="skipCheckingCheckBox">
-                  <property name="text">
-                   <string>Skip hash check</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="0" column="1">
-                 <widget class="QCheckBox" name="sequentialCheckBox">
-                  <property name="text">
-                   <string>Download in sequential order</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="0" column="0">
+               <item row="0" column="0">
                  <widget class="QCheckBox" name="startTorrentCheckBox">
                   <property name="text">
                    <string>Start torrent</string>
                   </property>
                  </widget>
+                </item>
+                <item row="0" column="1">
+                 <layout class="QHBoxLayout" name="stopConditionLayout">
+                 <item>
+                 <widget class="QLabel" name="stopConditionLabel">
+                  <property name="text">
+                   <string>Stop condition:</string>
+                  </property>
+                 </widget>
+                 </item>
+                 <item>
+                 <widget class="QComboBox" name="stopConditionComboBox">
+                  <property name="currentIndex">
+                   <number>0</number>
+                  </property>
+                  <item>
+                   <property name="text">
+                    <string>None</string>
+                   </property>
+                  </item>
+                  <item>
+                   <property name="text">
+                    <string>Metadata received</string>
+                   </property>
+                  </item>
+                  <item>
+                   <property name="text">
+                    <string>Files checked</string>
+                   </property>
+                  </item>
+                 </widget>
+                 </item>
+                 </layout>
                 </item>
                 <item row="0" column="2">
                  <spacer name="horizontalSpacer_3">
@@ -253,6 +255,37 @@
                    </size>
                   </property>
                  </spacer>
+                </item>
+                <item row="1" column="0">
+                 <widget class="QCheckBox" name="skipCheckingCheckBox">
+                  <property name="text">
+                   <string>Skip hash check</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="0">
+                 <widget class="QCheckBox" name="sequentialCheckBox">
+                  <property name="text">
+                   <string>Download in sequential order</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="1">
+                 <widget class="QCheckBox" name="firstLastCheckBox">
+                  <property name="text">
+                   <string>Download first and last pieces first</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="3" column="0">
+                 <widget class="QCheckBox" name="doNotDeleteTorrentCheckBox">
+                  <property name="toolTip">
+                   <string>When checked, the .torrent file will not be deleted regardless of the settings at the &quot;Download&quot; page of the Options dialog</string>
+                  </property>
+                  <property name="text">
+                   <string>Do not delete .torrent file</string>
+                  </property>
+                 </widget>
                 </item>
                </layout>
               </item>

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -840,6 +840,52 @@
                 </widget>
                </item>
                <item>
+                <layout class="QHBoxLayout" name="stopConditionLayout">
+                 <item>
+                  <widget class="QLabel" name="stopConditionLabel">
+                   <property name="text">
+                    <string>Torrent stop condition:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="stopConditionComboBox">
+                   <property name="currentIndex">
+                    <number>0</number>
+                   </property>
+                   <item>
+                    <property name="text">
+                     <string>None</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Metadata received</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Files checked</string>
+                    </property>
+                   </item>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="stopConditionSpacer">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+               <item>
                 <widget class="QGroupBox" name="deleteTorrentBox">
                  <property name="toolTip">
                   <string>Whether the .torrent file should be deleted after adding it</string>
@@ -3555,6 +3601,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
   <tabstop>checkUseCustomTheme</tabstop>
   <tabstop>customThemeFilePath</tabstop>
   <tabstop>checkStartPaused</tabstop>
+  <tabstop>stopConditionComboBox</tabstop>
   <tabstop>spinPort</tabstop>
   <tabstop>checkUPnP</tabstop>
   <tabstop>textWebUiUsername</tabstop>

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -665,6 +665,11 @@ void TorrentsController::addAction()
     const int seedingTimeLimit = parseInt(params()[u"seedingTimeLimit"_qs]).value_or(BitTorrent::Torrent::USE_GLOBAL_SEEDING_TIME);
     const std::optional<bool> autoTMM = parseBool(params()[u"autoTMM"_qs]);
 
+    const QString stopConditionParam = params()[u"stopCondition"_qs];
+    const std::optional<BitTorrent::Torrent::StopCondition> stopCondition = (!stopConditionParam.isEmpty()
+            ? Utils::String::toEnum(stopConditionParam, BitTorrent::Torrent::StopCondition::None)
+            : std::optional<BitTorrent::Torrent::StopCondition> {});
+
     const QString contentLayoutParam = params()[u"contentLayout"_qs];
     const std::optional<BitTorrent::TorrentContentLayout> contentLayout = (!contentLayoutParam.isEmpty()
             ? Utils::String::toEnum(contentLayoutParam, BitTorrent::TorrentContentLayout::Original)
@@ -693,6 +698,7 @@ void TorrentsController::addAction()
     addTorrentParams.sequential = seqDownload;
     addTorrentParams.firstLastPiecePriority = firstLastPiece;
     addTorrentParams.addPaused = addPaused;
+    addTorrentParams.stopCondition = stopCondition;
     addTorrentParams.contentLayout = contentLayout;
     addTorrentParams.savePath = Path(savepath);
     addTorrentParams.downloadPath = Path(downloadPath);

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -52,7 +52,7 @@
 #include "base/utils/version.h"
 #include "api/isessionmanager.h"
 
-inline const Utils::Version<3, 2> API_VERSION {2, 8, 14};
+inline const Utils::Version<3, 2> API_VERSION {2, 8, 15};
 
 class APIController;
 class AuthController;


### PR DESCRIPTION
Closes #17792.
Closes #929.

_(Actually it should close all issues about lack of ability to stop torrent after metadata downloaded or after files are initially checked.)_

Also makes explicit the temporary start of the torrent in the case when recheck of the stopped torrent is performed.

Preferences:
![001](https://user-images.githubusercontent.com/5063477/193600325-32395aa8-5c64-4e4b-b29b-17f9aa43e0cc.png)

Add new torrent dialog:
![002](https://user-images.githubusercontent.com/5063477/193600368-f2adc739-249d-4811-a24a-3bb8bb8e4629.png)
