### PR TITLE
GHA CI: only install required Qt components

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -54,6 +54,8 @@ jobs:
         uses: jurplel/install-qt-action@v3
         with:
           version: ${{ matrix.qt_version }}
+          archives: qtbase qtdeclarative qtsvg qttools
+          # Not sure why Qt made a hard dependency on qtdeclarative, try removing it when Qt > 6.4.0
 
       - name: Install libtorrent
         run: |

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -43,6 +43,7 @@ jobs:
         uses: jurplel/install-qt-action@v3
         with:
           version: ${{ matrix.qt_version }}
+          archives: icu qtbase qtsvg qttools
 
       - name: Install libtorrent
         run: |

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -77,6 +77,7 @@ jobs:
         uses: jurplel/install-qt-action@v3
         with:
           version: "6.4.0"
+          archives: qtbase qtsvg qttools
 
       - name: Install libtorrent
         run: |

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
         with:
-          version: "6.3.0"
+          version: "6.4.0"
           archives: qtbase qtsvg qttools
 
       - name: Install libtorrent

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -25,6 +25,7 @@ jobs:
         uses: jurplel/install-qt-action@v3
         with:
           version: "6.3.0"
+          archives: qtbase qtsvg qttools
 
       - name: Install libtorrent
         run: |


### PR DESCRIPTION
* GHA CI: only install required Qt components
  So it won't waste time download/install unused Qt components.
* GHA CI: bump Qt version to 6.4.0 