### PR TITLE
Revert "Consider brackets within wildcard as regular characters"

### DIFF
--- a/src/base/utils/string.cpp
+++ b/src/base/utils/string.cpp
@@ -32,11 +32,12 @@
 #include <cmath>
 
 #include <QLocale>
-#include <QRegularExpression>
 #include <QStringList>
 #include <QVector>
 
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#include <QRegularExpression>
+#else
 #include <QRegExp>
 #endif
 
@@ -56,11 +57,7 @@ QString Utils::String::fromDouble(const double n, const int precision)
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 QString Utils::String::wildcardToRegexPattern(const QString &pattern)
 {
-    // replace [ and ] with [[] and []], respectively
-    QString escapedPattern = pattern;
-    escapedPattern.replace(QRegularExpression(u"\\[|\\]"_qs), u"[\\0]"_qs);
-
-    return QRegularExpression::wildcardToRegularExpression(escapedPattern, QRegularExpression::UnanchoredWildcardConversion);
+    return QRegularExpression::wildcardToRegularExpression(pattern, QRegularExpression::UnanchoredWildcardConversion);
 }
 #else
 // This is marked as internal in QRegExp.cpp, but is exported. The alternative would be to
@@ -69,11 +66,7 @@ QString qt_regexp_toCanonical(const QString &pattern, QRegExp::PatternSyntax pat
 
 QString Utils::String::wildcardToRegexPattern(const QString &pattern)
 {
-    // replace [ and ] with [[] and []], respectively
-    QString escapedPattern = pattern;
-    escapedPattern.replace(QRegularExpression(u"\\[|\\]"_qs), u"[\\0]"_qs);
-
-    return qt_regexp_toCanonical(escapedPattern, QRegExp::Wildcard);
+    return qt_regexp_toCanonical(pattern, QRegExp::Wildcard);
 }
 #endif
 


### PR DESCRIPTION
I'm opening this PR to make sure the broken #16965 doesn't land into 4.5.0 release.

As spotted by @tristanleboss, and as I confirmed too, the implementation appeared to be broken. See https://github.com/qbittorrent/qBittorrent/pull/16965#issuecomment-1263084823 and following.

Until the implementation is fixed, or better, an UI letting optionally use the wildcards is implemented (see https://github.com/qbittorrent/qBittorrent/pull/9255#issuecomment-1263081969 and following), it should be reverted.