### PR TITLE
Don't pollute move queue by torrents w/o metadata

### DIFF
--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -501,6 +501,9 @@ void TorrentImpl::setAutoTMMEnabled(bool enabled)
 
 QString TorrentImpl::actualStorageLocation() const
 {
+    if (!hasMetadata())
+        return {};
+
     return Utils::Fs::toUniformPath(QString::fromStdString(m_nativeStatus.save_path));
 }
 
@@ -1634,6 +1637,12 @@ void TorrentImpl::resume(const TorrentOperatingMode mode)
 
 void TorrentImpl::moveStorage(const QString &newPath, const MoveStorageMode mode)
 {
+    if (!hasMetadata())
+    {
+        m_session->handleTorrentSavePathChanged(this);
+        return;
+    }
+
     if (m_session->addMoveTorrentStorageJob(this, Utils::Fs::toNativePath(newPath), mode))
     {
         m_storageIsMoving = true;


### PR DESCRIPTION
There's really nothing to move if the torrent still doesn't have metadata. Additionally, such torrents in the queue can lead to unexpected behavior when reloading the torrent after metadata is received.

Original PR #17823.