### PR TITLE
Set proper focus on widget

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -60,6 +60,7 @@ jobs:
             -G "Ninja" \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DGUI=ON \
+            -DQT6=ON \
             -DVERBOSE_CONFIGURE=ON
           export PATH="$(pwd)/coverity_tool/bin:$PATH"
           cov-build --dir cov-int cmake --build build

--- a/src/gui/fspathedit.cpp
+++ b/src/gui/fspathedit.cpp
@@ -178,6 +178,10 @@ FileSystemPathEdit::FileSystemPathEdit(Private::IFileEditorWithCompletion *edito
     Q_D(FileSystemPathEdit);
     editor->widget()->setParent(this);
 
+    setFocusProxy(editor->widget());
+    // required, otherwise the button cannot be selected via keyboard tab
+    setTabOrder(editor->widget(), d_ptr->m_browseBtn);
+
     auto *layout = new QHBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
     layout->addWidget(editor->widget());


### PR DESCRIPTION
* Set proper focus on widget
  And also allow keyboard tabbing to the Browse button.
  Fix up 6ab3551.
* GHA CI: add missing cmake flag for Qt6 