### PR TITLE
Fix wrong 'tracker error' count

### DIFF
--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -66,11 +66,8 @@ namespace
 
     QString getScheme(const QString &tracker)
     {
-        const QUrl url {tracker};
-        QString scheme = url.scheme();
-        if (scheme.isEmpty())
-            scheme = u"http"_qs;
-        return scheme;
+        const QString scheme = QUrl(tracker).scheme();
+        return !scheme.isEmpty() ? scheme : u"http"_qs;
     }
 
     QString getHost(const QString &tracker)
@@ -360,7 +357,6 @@ void StatusFilterWidget::torrentAboutToBeDeleted(BitTorrent::Torrent *const torr
 
 TrackerFiltersList::TrackerFiltersList(QWidget *parent, TransferListWidget *transferList, const bool downloadFavicon)
     : BaseFilterWidget(parent, transferList)
-    , m_totalTorrents(0)
     , m_downloadTrackerFavicon(downloadFavicon)
 {
     auto *allTrackers = new QListWidgetItem(this);

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -70,11 +70,14 @@ namespace
         return !scheme.isEmpty() ? scheme : u"http"_qs;
     }
 
-    QString getHost(const QString &tracker)
+    QString getHost(const QString &url)
     {
         // We want the domain + tld. Subdomains should be disregarded
-        const QUrl url {tracker};
-        const QString host {url.host()};
+        // If failed to parse the domain or IP address, original input should be returned
+
+        const QString host = QUrl(url).host();
+        if (host.isEmpty())
+            return url;
 
         // host is in IP format
         if (!QHostAddress(host).isNull())
@@ -505,10 +508,8 @@ void TrackerFiltersList::addItems(const QString &trackerURL, const QVector<BitTo
 void TrackerFiltersList::removeItem(const QString &trackerURL, const BitTorrent::TorrentID &id)
 {
     const QString host = getHost(trackerURL);
-    QSet<BitTorrent::TorrentID> torrentIDs = m_trackers.value(host).torrents;
-    if (torrentIDs.empty())
-        return;
 
+    QSet<BitTorrent::TorrentID> torrentIDs = m_trackers.value(host).torrents;
     torrentIDs.remove(id);
 
     QListWidgetItem *trackerItem = nullptr;

--- a/src/gui/transferlistfilterswidget.h
+++ b/src/gui/transferlistfilterswidget.h
@@ -157,12 +157,12 @@ private:
         QListWidgetItem *item = nullptr;
     };
 
-    QHash<QString, TrackerData> m_trackers;
+    QHash<QString, TrackerData> m_trackers;   // <tracker host, tracker data>
     QHash<BitTorrent::TorrentID, QSet<QString>> m_errors;  // <torrent ID, tracker hosts>
     QHash<BitTorrent::TorrentID, QSet<QString>> m_warnings;  // <torrent ID, tracker hosts>
     PathList m_iconPaths;
-    int m_totalTorrents;
-    bool m_downloadTrackerFavicon;
+    int m_totalTorrents = 0;
+    bool m_downloadTrackerFavicon = false;
 };
 
 class TransferListFiltersWidget final : public QFrame


### PR DESCRIPTION
* Clean up code
* Fix wrong 'tracker error' count
  This happens when a torrent contains some tracker URLs that share the same domain.
  Closes #17808.