### PR TITLE
Use 'fail if exist' strategy on automatic move

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -298,6 +298,21 @@ namespace
         return {};
     }
 #endif
+
+    constexpr lt::move_flags_t toNative(const MoveStorageMode mode)
+    {
+        switch (mode)
+        {
+        default:
+            Q_ASSERT(false);
+        case MoveStorageMode::FailIfExist:
+            return lt::move_flags_t::fail_if_exist;
+        case MoveStorageMode::KeepExistingFiles:
+            return lt::move_flags_t::dont_replace;
+        case MoveStorageMode::Overwrite:
+            return lt::move_flags_t::always_replace_files;
+        }
+    }
 }
 
 struct BitTorrent::SessionImpl::ResumeSessionContext final : public QObject
@@ -4678,9 +4693,7 @@ void SessionImpl::moveTorrentStorage(const MoveStorageJob &job) const
     const QString torrentName = (torrent ? torrent->name() : id.toString());
     LogMsg(tr("Start moving torrent. Torrent: \"%1\". Destination: \"%2\"").arg(torrentName, job.path.toString()));
 
-    job.torrentHandle.move_storage(job.path.toString().toStdString()
-                            , ((job.mode == MoveStorageMode::Overwrite)
-                            ? lt::move_flags_t::always_replace_files : lt::move_flags_t::dont_replace));
+    job.torrentHandle.move_storage(job.path.toString().toStdString(), toNative(job.mode));
 }
 
 void SessionImpl::handleMoveTorrentStorageJobFinished(const Path &newPath)

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -2145,7 +2145,7 @@ void TorrentImpl::adjustStorageLocation()
     const Path targetPath = ((isFinished || downloadPath.isEmpty()) ? savePath() : downloadPath);
 
     if ((targetPath != actualStorageLocation()) || isMoveInProgress())
-        moveStorage(targetPath, MoveStorageMode::Overwrite);
+        moveStorage(targetPath, MoveStorageMode::FailIfExist);
 }
 
 lt::torrent_handle TorrentImpl::nativeHandle() const

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -63,6 +63,7 @@ namespace BitTorrent
 
     enum class MoveStorageMode
     {
+        FailIfExist,
         KeepExistingFiles,
         Overwrite
     };


### PR DESCRIPTION
Prevent existing files overwriting when torrent is moved automatically (e.g. when moved from incomplete to final save path).
