### PR TITLE
Show N/A when there is no hash

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -25,7 +25,7 @@ jobs:
         uses: jurplel/install-qt-action@v3
         with:
           version: "6.4.0"
-          archives: qtbase qtsvg qttools
+          archives: icu qtbase qtsvg qttools
 
       - name: Install libtorrent
         run: |

--- a/src/gui/downloadfromurldialog.cpp
+++ b/src/gui/downloadfromurldialog.cpp
@@ -38,6 +38,7 @@
 #include <QStringList>
 #include <QStringView>
 
+#include "base/net/downloadmanager.h"
 #include "ui_downloadfromurldialog.h"
 #include "utils.h"
 
@@ -47,16 +48,13 @@ namespace
 {
     bool isDownloadable(const QString &str)
     {
-        return (str.startsWith(u"http://", Qt::CaseInsensitive)
-            || str.startsWith(u"https://", Qt::CaseInsensitive)
-            || str.startsWith(u"ftp://", Qt::CaseInsensitive)
+        return (Net::DownloadManager::hasSupportedScheme(str)
             || str.startsWith(u"magnet:", Qt::CaseInsensitive)
-            || ((str.size() == 40) && !str.contains(QRegularExpression(u"[^0-9A-Fa-f]"_qs))) // v1 hex-encoded SHA-1 info-hash
 #ifdef QBT_USES_LIBTORRENT2
             || ((str.size() == 64) && !str.contains(QRegularExpression(u"[^0-9A-Fa-f]"_qs))) // v2 hex-encoded SHA-256 info-hash
 #endif
+            || ((str.size() == 40) && !str.contains(QRegularExpression(u"[^0-9A-Fa-f]"_qs))) // v1 hex-encoded SHA-1 info-hash
             || ((str.size() == 32) && !str.contains(QRegularExpression(u"[^2-7A-Za-z]"_qs)))); // v1 Base32 encoded SHA-1 info-hash
-
     }
 }
 

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -511,7 +511,7 @@ QVariant TransferListModel::internalValue(const BitTorrent::Torrent *torrent, co
     case TR_DOWNLOAD_PATH:
         return torrent->downloadPath().data();
     case TR_SAVE_PATH:
-        return torrent->savePath().toString();
+        return torrent->savePath().data();
     case TR_COMPLETED:
         return torrent->completedSize();
     case TR_RATIO_LIMIT:

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -224,7 +224,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_AMOUNT_UPLOADED_SESSION: return tr("Session Upload", "Amount of data uploaded since program open (e.g. in MB)");
             case TR_AMOUNT_LEFT: return tr("Remaining", "Amount of data left to download (e.g. in MB)");
             case TR_TIME_ELAPSED: return tr("Time Active", "Time (duration) the torrent is active (not paused)");
-            case TR_SAVE_PATH: return tr("Save path", "Torrent save path");
+            case TR_SAVE_PATH: return tr("Save Path", "Torrent save path");
             case TR_DOWNLOAD_PATH: return tr("Incomplete Save Path", "Torrent incomplete save path");
             case TR_COMPLETED: return tr("Completed", "Amount of data completed (e.g. in MB)");
             case TR_RATIO_LIMIT: return tr("Ratio Limit", "Upload share ratio limit");

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -374,6 +374,13 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
                    : m_statusStrings[state];
     };
 
+    const auto hashString = [hideValues](const auto &hash) -> QString
+    {
+        if (hideValues && !hash.isValid())
+            return {};
+        return hash.isValid() ? hash.toString() : tr("N/A");
+    };
+
     switch (column)
     {
     case TR_NAME:
@@ -441,9 +448,9 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
     case TR_TOTAL_SIZE:
         return unitString(torrent->totalSize());
     case TR_INFOHASH_V1:
-        return torrent->infoHash().v1().toString();
+        return hashString(torrent->infoHash().v1());
     case TR_INFOHASH_V2:
-        return torrent->infoHash().v2().toString();
+        return hashString(torrent->infoHash().v2());
     }
 
     return {};


### PR DESCRIPTION
* Show 'N/A' when there is no hash
  This is to follow 'General' tab which show 'N/A' when there is no hash.
* Use Path internal representation for internal value in model
  The internal value is used for sorting comparisons and not displayed to the user, so make a shortcut.
* Capitalize header title
  This is the only one not properly capitalized.
* Don't use hardcoded URL scheme list
  This is to avoid the list being outdated.
* GHA CI: add missing Qt module