### PR TITLE
Increase ETA time and fix seed time options max value

### DIFF
--- a/src/base/bittorrent/torrent.cpp
+++ b/src/base/bittorrent/torrent.cpp
@@ -53,7 +53,7 @@ namespace BitTorrent
     const int Torrent::NO_SEEDING_TIME_LIMIT = -1;
 
     const qreal Torrent::MAX_RATIO = 9999;
-    const int Torrent::MAX_SEEDING_TIME = 5259487;
+    const int Torrent::MAX_SEEDING_TIME = 99999990; // minutes ~ 190 years
 
     TorrentID Torrent::id() const
     {

--- a/src/base/bittorrent/torrent.cpp
+++ b/src/base/bittorrent/torrent.cpp
@@ -53,7 +53,7 @@ namespace BitTorrent
     const int Torrent::NO_SEEDING_TIME_LIMIT = -1;
 
     const qreal Torrent::MAX_RATIO = 9999;
-    const int Torrent::MAX_SEEDING_TIME = 525600;
+    const int Torrent::MAX_SEEDING_TIME = 5259487;
 
     TorrentID Torrent::id() const
     {

--- a/src/base/types.h
+++ b/src/base/types.h
@@ -30,7 +30,7 @@
 
 #include <QtContainerFwd>
 
-const qlonglong MAX_ETA = 8640000;
+const qlonglong MAX_ETA = 315569260;
 
 enum class ShutdownDialogAction
 {

--- a/src/base/types.h
+++ b/src/base/types.h
@@ -30,7 +30,11 @@
 
 #include <QtContainerFwd>
 
-const qlonglong MAX_ETA = 315569260;
+/*
+* used to limit ETA. ETA only shown if ETA is smaller than this.
+* it is set to 99,999,990 minutes in seconds; see torrent.cpp
+*/
+const qlonglong MAX_ETA = 5999999400; // seconds
 
 enum class ShutdownDialogAction
 {

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -2665,7 +2665,7 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                   <string extracomment="minutes"> min</string>
                  </property>
                  <property name="maximum">
-                  <number>9999999</number>
+                  <number>5259487</number>
                  </property>
                  <property name="value">
                   <number>1440</number>

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -2665,7 +2665,7 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                   <string extracomment="minutes"> min</string>
                  </property>
                  <property name="maximum">
-                  <number>5259487</number>
+                  <number>9999999</number>
                  </property>
                  <property name="value">
                   <number>1440</number>

--- a/src/webui/www/private/scripts/misc.js
+++ b/src/webui/www/private/scripts/misc.js
@@ -44,7 +44,7 @@ window.qBittorrent.Misc = (function() {
             safeTrim: safeTrim,
             toFixedPointString: toFixedPointString,
             containsAllTerms: containsAllTerms,
-            MAX_ETA: 315569260
+            MAX_ETA: 5999999400
         };
     };
 

--- a/src/webui/www/private/scripts/misc.js
+++ b/src/webui/www/private/scripts/misc.js
@@ -44,7 +44,7 @@ window.qBittorrent.Misc = (function() {
             safeTrim: safeTrim,
             toFixedPointString: toFixedPointString,
             containsAllTerms: containsAllTerms,
-            MAX_ETA: 8640000
+            MAX_ETA: 315569260
         };
     };
 


### PR DESCRIPTION
Closes #17854

Please be gentle, it's my first (horrible) PR.

The ETA currently is fixed to 1 year.
This PR changes that to 10 years.

- I compiled it, it ran fine, but please verify. (tested on Manjaro, x64)
- I could not figure out why there was a 1 year limit. Like I could not find any explanation at all. Maybe there is a good reason, and maybe a git wizard can find the reason with some black magic. Please do, if you can. Thank you.
- In some files the limit is expressed in seconds (qlonglong), while in "int", it is expressed in minutes.
- This PR "fixes" the global options seed time limit as well. Previously you were able to set 9999999 value, ignoring the hard-coded 1 year. Since it's a .ui file, I could not find a better way of fixing this. If you used the per-torrent, right-click torrent options dialogue, the set limit was followed.
- I could not find any other occurrence of this limit.

As for why 10 years? Well, "torrent.cpp" had a hard-coded 1 year const, as int. 10 years in minutes is still way below of any limit of an integer, so "it should be fine". Going 20, 30 makes no sense I believe.

Ps.: This is my "user" account, I am @Balls0fSteel. I made this account to avoid any possible "mistakes".