### PR TITLE
WebUI: handle drag and drop events 

### DIFF
--- a/src/webui/www/private/upload.html
+++ b/src/webui/www/private/upload.html
@@ -14,7 +14,7 @@
     <iframe id="upload_frame" name="upload_frame" class="invisible" src="about:blank"></iframe>
     <form action="api/v2/torrents/add" enctype="multipart/form-data" method="post" id="uploadForm" style="text-align: center;" target="upload_frame" autocorrect="off" autocapitalize="none">
         <div style="margin-top: 25px; display: inline-block; border: 1px solid lightgrey; border-radius: 4px;">
-            <input type="file" id="fileselect" name="fileselect[]" multiple="multiple" />
+            <input type="file" id="fileselect" name="fileselect[]" multiple />
         </div>
         <fieldset class="settings" style="border: 0; text-align: left; margin-top: 12px;">
             <table style="margin: auto;">

--- a/src/webui/www/private/upload.html
+++ b/src/webui/www/private/upload.html
@@ -14,7 +14,7 @@
     <iframe id="upload_frame" name="upload_frame" class="invisible" src="about:blank"></iframe>
     <form action="api/v2/torrents/add" enctype="multipart/form-data" method="post" id="uploadForm" style="text-align: center;" target="upload_frame" autocorrect="off" autocapitalize="none">
         <div style="margin-top: 25px; display: inline-block; border: 1px solid lightgrey; border-radius: 4px;">
-            <input type="file" id="fileselect" name="fileselect[]" multiple />
+            <input type="file" id="fileselect" accept="application/x-bittorrent, .torrent" name="fileselect[]" multiple />
         </div>
         <fieldset class="settings" style="border: 0; text-align: left; margin-top: 12px;">
             <table style="margin: auto;">


### PR DESCRIPTION
* WebUI: simplify attribute usage
  The `multiple` attribute is a boolean value and its presence equals to `true`.
* WebUI: filter file selection to bittorrent files
  Note that the user can still overwrite the selection filter and select other files.
* WebUI: handle drag and drop events
  This allows user to drag and drop .torrent files and URL links onto the main window and will open the respective dialog.
  Dropping folders are not supported due to technical reasons.
  Closes #6038.