### PR TITLE
Revise "save resume data" handling on shutdown

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -1030,10 +1030,11 @@ void SessionImpl::setGlobalMaxSeedingMinutes(int minutes)
 // Main destructor
 SessionImpl::~SessionImpl()
 {
-    saveStatistics();
-
-    // Do some BT related saving
+    // Do some bittorrent related saving
+    // After this, (ideally) no more important alerts will be generated/handled
     saveResumeData();
+
+    saveStatistics();
 
     // We must delete FilterParserThread
     // before we delete lt::session

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -2444,6 +2444,12 @@ void SessionImpl::handleTorrentSaveResumeDataRequested(const TorrentImpl *torren
     ++m_numResumeData;
 }
 
+void SessionImpl::handleTorrentSaveResumeDataFailed(const TorrentImpl *torrent)
+{
+    Q_UNUSED(torrent);
+    --m_numResumeData;
+}
+
 QVector<Torrent *> SessionImpl::torrents() const
 {
     QVector<Torrent *> result;
@@ -2904,16 +2910,12 @@ void SessionImpl::saveResumeData()
         bool hasWantedAlert = false;
         for (const lt::alert *a : alerts)
         {
-            switch (a->type())
+            if (const int alertType = a->type();
+                (alertType == lt::save_resume_data_alert::alert_type)
+                || (alertType == lt::save_resume_data_failed_alert::alert_type))
             {
-            case lt::save_resume_data_failed_alert::alert_type:
                 hasWantedAlert = true;
-                --m_numResumeData;
-                break;
-            case lt::save_resume_data_alert::alert_type:
-                hasWantedAlert = true;
-                dispatchTorrentAlert(static_cast<const lt::torrent_alert *>(a));
-                break;
+                handleAlert(a);
             }
         }
 

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -410,6 +410,7 @@ namespace BitTorrent
         // Torrent interface
         void handleTorrentNeedSaveResumeData(const TorrentImpl *torrent);
         void handleTorrentSaveResumeDataRequested(const TorrentImpl *torrent);
+        void handleTorrentSaveResumeDataFailed(const TorrentImpl *torrent);
         void handleTorrentShareLimitChanged(TorrentImpl *const torrent);
         void handleTorrentNameChanged(TorrentImpl *const torrent);
         void handleTorrentSavePathChanged(TorrentImpl *const torrent);

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -1949,8 +1949,13 @@ void TorrentImpl::prepareResumeData(const lt::add_torrent_params &params)
 
 void TorrentImpl::handleSaveResumeDataFailedAlert(const lt::save_resume_data_failed_alert *p)
 {
-    Q_UNUSED(p);
-    Q_ASSERT_X(false, Q_FUNC_INFO, "This point should be unreachable since libtorrent 1.2.11");
+    if (p->error != lt::errors::resume_data_not_modified)
+    {
+        LogMsg(tr("Generate resume data failed. Torrent: \"%1\". Reason: \"%2\"")
+            .arg(name(), QString::fromLocal8Bit(p->error.message().c_str())), Log::CRITICAL);
+    }
+
+    m_session->handleTorrentSaveResumeDataFailed(this);
 }
 
 void TorrentImpl::handleFastResumeRejectedAlert(const lt::fastresume_rejected_alert *p)


### PR DESCRIPTION
When shutting down, instead of waiting for all types of alert from libtorrent, now it only waits for specific alert types. This potentially help shorten the shutdown waiting time.
