### PR TITLE
Handle all types of alerts on shutdown

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -2916,8 +2916,9 @@ void SessionImpl::saveResumeData()
                 || (alertType == lt::save_resume_data_failed_alert::alert_type))
             {
                 hasWantedAlert = true;
-                handleAlert(a);
             }
+
+            handleAlert(a);
         }
 
         if (hasWantedAlert)


### PR DESCRIPTION
There might be alerts already queued in buffer waiting to be handled at the time of pausing the session, so don't skip over them.

Discussed in https://github.com/qbittorrent/qBittorrent/pull/17885#issuecomment-1279917556