### PR TITLE
Add a "Use proxy for hostname lookup" option

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -260,6 +260,8 @@ namespace BitTorrent
         virtual void setMaxActiveCheckingTorrents(int val) = 0;
         virtual bool isProxyPeerConnectionsEnabled() const = 0;
         virtual void setProxyPeerConnectionsEnabled(bool enabled) = 0;
+        virtual bool isProxyHostnameLookupEnabled() const = 0;
+        virtual void setProxyHostnameLookupEnabled(bool enabled) = 0;
         virtual ChokingAlgorithm chokingAlgorithm() const = 0;
         virtual void setChokingAlgorithm(ChokingAlgorithm mode) = 0;
         virtual SeedChokingAlgorithm seedChokingAlgorithm() const = 0;

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -475,6 +475,7 @@ SessionImpl::SessionImpl(QObject *parent)
     , m_encryption(BITTORRENT_SESSION_KEY(u"Encryption"_qs), 0)
     , m_maxActiveCheckingTorrents(BITTORRENT_SESSION_KEY(u"MaxActiveCheckingTorrents"_qs), 1)
     , m_isProxyPeerConnectionsEnabled(BITTORRENT_SESSION_KEY(u"ProxyPeerConnections"_qs), false)
+    , m_isProxyHostnameLookupEnabled(BITTORRENT_SESSION_KEY(u"ProxyHostnameLookup"_qs), true)
     , m_chokingAlgorithm(BITTORRENT_SESSION_KEY(u"ChokingAlgorithm"_qs), ChokingAlgorithm::FixedSlots
         , clampValue(ChokingAlgorithm::FixedSlots, ChokingAlgorithm::RateBased))
     , m_seedChokingAlgorithm(BITTORRENT_SESSION_KEY(u"SeedChokingAlgorithm"_qs), SeedChokingAlgorithm::FastestUpload
@@ -1644,6 +1645,7 @@ void SessionImpl::loadLTSettings(lt::settings_pack &settingsPack)
         }
 
         settingsPack.set_bool(lt::settings_pack::proxy_peer_connections, isProxyPeerConnectionsEnabled());
+        settingsPack.set_bool(lt::settings_pack::proxy_hostnames, isProxyHostnameLookupEnabled());
     }
 
     settingsPack.set_bool(lt::settings_pack::announce_to_all_trackers, announceToAllTrackers());
@@ -3438,6 +3440,20 @@ void SessionImpl::setProxyPeerConnectionsEnabled(const bool enabled)
     if (enabled != isProxyPeerConnectionsEnabled())
     {
         m_isProxyPeerConnectionsEnabled = enabled;
+        configureDeferred();
+    }
+}
+
+bool SessionImpl::isProxyHostnameLookupEnabled() const
+{
+    return m_isProxyHostnameLookupEnabled;
+}
+
+void SessionImpl::setProxyHostnameLookupEnabled(const bool enabled)
+{
+    if (enabled != isProxyHostnameLookupEnabled())
+    {
+        m_isProxyHostnameLookupEnabled = enabled;
         configureDeferred();
     }
 }

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -240,6 +240,8 @@ namespace BitTorrent
         void setMaxActiveCheckingTorrents(int val) override;
         bool isProxyPeerConnectionsEnabled() const override;
         void setProxyPeerConnectionsEnabled(bool enabled) override;
+        bool isProxyHostnameLookupEnabled() const override;
+        void setProxyHostnameLookupEnabled(bool enabled) override;
         ChokingAlgorithm chokingAlgorithm() const override;
         void setChokingAlgorithm(ChokingAlgorithm mode) override;
         SeedChokingAlgorithm seedChokingAlgorithm() const override;
@@ -645,6 +647,7 @@ namespace BitTorrent
         CachedSettingValue<int> m_encryption;
         CachedSettingValue<int> m_maxActiveCheckingTorrents;
         CachedSettingValue<bool> m_isProxyPeerConnectionsEnabled;
+        CachedSettingValue<bool> m_isProxyHostnameLookupEnabled;
         CachedSettingValue<ChokingAlgorithm> m_chokingAlgorithm;
         CachedSettingValue<SeedChokingAlgorithm> m_seedChokingAlgorithm;
         CachedSettingValue<QStringList> m_storedTags;

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -858,6 +858,7 @@ void OptionsDialog::loadConnectionTabOptions()
 
     m_ui->checkProxyPeerConnections->setChecked(session->isProxyPeerConnectionsEnabled());
     m_ui->isProxyOnlyForTorrents->setChecked(proxyConfigManager->isProxyOnlyForTorrents());
+    m_ui->checkProxyHostnameLookup->setChecked(session->isProxyHostnameLookupEnabled());
     enableProxy(m_ui->comboProxyType->currentIndex());
 
     m_ui->checkIPFilter->setChecked(session->isIPFilteringEnabled());
@@ -887,8 +888,11 @@ void OptionsDialog::loadConnectionTabOptions()
     connect(m_ui->comboProxyType, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->textProxyIP, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->spinProxyPort, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
+
     connect(m_ui->checkProxyPeerConnections, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->isProxyOnlyForTorrents, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->checkProxyHostnameLookup, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
+
     connect(m_ui->checkProxyAuth, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->textProxyUsername, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->textProxyPassword, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
@@ -922,7 +926,9 @@ void OptionsDialog::saveConnectionTabOptions() const
     proxyConf.password = getProxyPassword();
     proxyConfigManager->setProxyOnlyForTorrents(m_ui->isProxyOnlyForTorrents->isChecked());
     proxyConfigManager->setProxyConfiguration(proxyConf);
+
     session->setProxyPeerConnectionsEnabled(m_ui->checkProxyPeerConnections->isChecked());
+    session->setProxyHostnameLookupEnabled(m_ui->checkProxyHostnameLookup->isChecked());
 
     // IPFilter
     session->setIPFilteringEnabled(isIPFilteringEnabled());
@@ -1596,12 +1602,14 @@ void OptionsDialog::enableProxy(const int index)
         { // SOCKS5 or HTTP
             m_ui->checkProxyAuth->setEnabled(true);
             m_ui->isProxyOnlyForTorrents->setEnabled(true);
+            m_ui->checkProxyHostnameLookup->setEnabled(true);
         }
         else
         {
             m_ui->checkProxyAuth->setEnabled(false);
             m_ui->isProxyOnlyForTorrents->setEnabled(false);
             m_ui->isProxyOnlyForTorrents->setChecked(true);
+            m_ui->checkProxyHostnameLookup->setEnabled(false);
         }
     }
     else
@@ -1613,6 +1621,7 @@ void OptionsDialog::enableProxy(const int index)
         m_ui->spinProxyPort->setEnabled(false);
         m_ui->checkProxyPeerConnections->setEnabled(false);
         m_ui->isProxyOnlyForTorrents->setEnabled(false);
+        m_ui->checkProxyHostnameLookup->setEnabled(false);
         m_ui->checkProxyAuth->setEnabled(false);
     }
 }

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -1857,6 +1857,19 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                 </widget>
                </item>
                <item>
+                <widget class="QCheckBox" name="checkProxyHostnameLookup">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="toolTip">
+                  <string>If checked, hostname lookups are done via the proxy.</string>
+                 </property>
+                 <property name="text">
+                  <string>Use proxy for hostname lookups</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <widget class="QGroupBox" name="checkProxyAuth">
                  <property name="enabled">
                   <bool>false</bool>
@@ -3667,6 +3680,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
   <tabstop>spinProxyPort</tabstop>
   <tabstop>checkProxyPeerConnections</tabstop>
   <tabstop>isProxyOnlyForTorrents</tabstop>
+  <tabstop>checkProxyHostnameLookup</tabstop>
   <tabstop>checkProxyAuth</tabstop>
   <tabstop>textProxyUsername</tabstop>
   <tabstop>textProxyPassword</tabstop>

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -189,6 +189,7 @@ void AppController::preferencesAction()
 
     data[u"proxy_peer_connections"_qs] = session->isProxyPeerConnectionsEnabled();
     data[u"proxy_torrents_only"_qs] = proxyManager->isProxyOnlyForTorrents();
+    data[u"proxy_hostname_lookup"_qs] = session->isProxyHostnameLookupEnabled();
 
     // IP Filtering
     data[u"ip_filter_enabled"_qs] = session->isIPFilteringEnabled();
@@ -569,6 +570,8 @@ void AppController::setPreferencesAction()
         session->setProxyPeerConnectionsEnabled(it.value().toBool());
     if (hasKey(u"proxy_torrents_only"_qs))
         proxyManager->setProxyOnlyForTorrents(it.value().toBool());
+    if (hasKey(u"proxy_hostname_lookup"_qs))
+        session->setProxyHostnameLookupEnabled(it.value().toBool());
 
     // IP Filtering
     if (hasKey(u"ip_filter_enabled"_qs))

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -52,7 +52,7 @@
 #include "base/utils/version.h"
 #include "api/isessionmanager.h"
 
-inline const Utils::Version<3, 2> API_VERSION {2, 8, 15};
+inline const Utils::Version<3, 2> API_VERSION {2, 8, 16};
 
 class APIController;
 class AuthController;

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -333,6 +333,10 @@
             <input type="checkbox" id="proxy_only_for_torrents_checkbox" />
             <label for="proxy_only_for_torrents_checkbox">QBT_TR(Use proxy only for torrents)QBT_TR[CONTEXT=OptionsDialog]</label>
         </div>
+        <div class="formRow">
+            <input type="checkbox" id="proxyHostnameLookupCheckbox" title="QBT_TR(If checked, hostname lookups are done via the proxy.)QBT_TR[CONTEXT=OptionsDialog]" />
+            <label for="proxyHostnameLookupCheckbox">QBT_TR(Use proxy for hostname lookup)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </div>
         <fieldset class="settings">
             <legend>
                 <input type="checkbox" id="peer_proxy_auth_checkbox" onclick="qBittorrent.Preferences.updatePeerProxyAuthSettings();" />
@@ -1541,11 +1545,15 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             $('peer_proxy_host_text').setProperty('disabled', !isPeerProxyTypeSelected);
             $('peer_proxy_port_value').setProperty('disabled', !isPeerProxyTypeSelected);
             $('use_peer_proxy_checkbox').setProperty('disabled', !isPeerProxyTypeSelected);
-            const isPeerProxyAuthenticatable = ($('peer_proxy_type_select').getProperty('value') === "socks5" || $('peer_proxy_type_select').getProperty('value') === "http");
+            const proxyType = $('peer_proxy_type_select').getProperty('value');
+            const isPeerProxyAuthenticatable = (proxyType === "socks5") || (proxyType === "http");
             $('proxy_only_for_torrents_checkbox').setProperty('disabled', !isPeerProxyAuthenticatable);
 
             if ($('peer_proxy_type_select').getProperty('value') === "socks4")
                 $('proxy_only_for_torrents_checkbox').setProperty('checked', true);
+
+            const canPeerProxyResolveHostnames = (proxyType === "socks5") || (proxyType === "http");
+            $('proxyHostnameLookupCheckbox').setProperty('disabled', !canPeerProxyResolveHostnames);
 
             $('peer_proxy_auth_checkbox').setProperty('disabled', !isPeerProxyAuthenticatable);
 
@@ -1901,6 +1909,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                         $('peer_proxy_port_value').setProperty('value', pref.proxy_port);
                         $('use_peer_proxy_checkbox').setProperty('checked', pref.proxy_peer_connections);
                         $('proxy_only_for_torrents_checkbox').setProperty('checked', pref.proxy_torrents_only);
+                        $('proxyHostnameLookupCheckbox').setProperty('checked', pref.proxy_hostname_lookup);
                         $('peer_proxy_auth_checkbox').setProperty('checked', pref.proxy_auth_enabled);
                         updatePeerProxyAuthSettings();
                         $('peer_proxy_username_text').setProperty('value', pref.proxy_username);
@@ -2243,6 +2252,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             settings.set('proxy_port', $('peer_proxy_port_value').getProperty('value').toInt());
             settings.set('proxy_peer_connections', $('use_peer_proxy_checkbox').getProperty('checked'));
             settings.set('proxy_torrents_only', $('proxy_only_for_torrents_checkbox').getProperty('checked'));
+            settings.set('proxy_hostname_lookup', $('proxyHostnameLookupCheckbox').getProperty('checked'));
             settings.set('proxy_username', $('peer_proxy_username_text').getProperty('value'));
             settings.set('proxy_password', $('peer_proxy_password_text').getProperty('value'));
 


### PR DESCRIPTION
Add a UI option for "Use proxy for hostname lookup" option and plumb it into libtorrent's settings_pack.proxy_hostnames option.  This is available for SOCKS5 and HTTP proxies, and defaults to true, which is the previous functionality.  Hostname lookups can be forced to be local by unchecking this option, which can aid compatibility with certain non-compliant proxy servers.

UI changes:
![image](https://user-images.githubusercontent.com/1743553/196524465-687ad76d-bfa5-488f-afaa-925215fa1b4e.png)
![image](https://user-images.githubusercontent.com/1743553/196524841-686ae71b-238a-44ae-b980-10f2dc896a59.png)


Closes #17902
