### PR TITLE
GHA CI: Bump libtorrent version(s)

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -14,11 +14,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libt_version: ["2.0.7", "1.2.17"]
+        libt_version: ["2.0.8", "1.2.18"]
         qbt_gui: ["GUI=ON", "GUI=OFF"]
         qt_version: ["5.15.2", "6.4.0"]
         exclude:
-          - libt_version: "1.2.17"
+          - libt_version: "1.2.18"
             qt_version: "6.4.0"
 
     env:

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -14,11 +14,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libt_version: ["2.0.7", "1.2.17"]
+        libt_version: ["2.0.8", "1.2.18"]
         qbt_gui: ["GUI=ON", "GUI=OFF"]
         qt_version: ["5.15.2", "6.2.0"]
         exclude:
-          - libt_version: "1.2.17"
+          - libt_version: "1.2.18"
             qt_version: "6.2.0"
 
     steps:

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libt_version: ["2.0.7", "1.2.17"]
+        libt_version: ["2.0.8", "1.2.18"]
 
     env:
       boost_path: "${{ github.workspace }}/../boost"

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install libtorrent
         run: |
           git clone \
-            --branch "v2.0.7" \
+            --branch "v2.0.8" \
             --depth 1 \
             --recurse-submodules \
             https://github.com/arvidn/libtorrent.git


### PR DESCRIPTION
* https://github.com/arvidn/libtorrent/releases/tag/v2.0.8
* https://github.com/arvidn/libtorrent/releases/tag/v1.2.18

NOTE:
Will create separate PR after this is merged raising minimum libtorrent requirements (if no objections).
