### PR TITLE
Make resume data storage backups

### DIFF
--- a/src/base/bittorrent/bencoderesumedatastorage.cpp
+++ b/src/base/bittorrent/bencoderesumedatastorage.cpp
@@ -328,6 +328,11 @@ void BitTorrent::BencodeResumeDataStorage::storeQueue(const QVector<TorrentID> &
     });
 }
 
+void BitTorrent::BencodeResumeDataStorage::makeBackup() const
+{
+    // NOTE: Making backups isn't implemented by this type of resume data storage.
+}
+
 BitTorrent::BencodeResumeDataStorage::Worker::Worker(const Path &resumeDataDir)
     : m_resumeDataDir {resumeDataDir}
 {

--- a/src/base/bittorrent/bencoderesumedatastorage.h
+++ b/src/base/bittorrent/bencoderesumedatastorage.h
@@ -53,6 +53,7 @@ namespace BitTorrent
         void store(const TorrentID &id, const LoadTorrentParams &resumeData) const override;
         void remove(const TorrentID &id) const override;
         void storeQueue(const QVector<TorrentID> &queue) const override;
+        void makeBackup() const override;
 
     private:
         void doLoadAll() const override;

--- a/src/base/bittorrent/dbresumedatastorage.h
+++ b/src/base/bittorrent/dbresumedatastorage.h
@@ -52,6 +52,7 @@ namespace BitTorrent
         void store(const TorrentID &id, const LoadTorrentParams &resumeData) const override;
         void remove(const TorrentID &id) const override;
         void storeQueue(const QVector<TorrentID> &queue) const override;
+        void makeBackup() const override;
 
     private:
         void doLoadAll() const override;

--- a/src/base/bittorrent/resumedatastorage.h
+++ b/src/base/bittorrent/resumedatastorage.h
@@ -63,6 +63,7 @@ namespace BitTorrent
         virtual void store(const TorrentID &id, const LoadTorrentParams &resumeData) const = 0;
         virtual void remove(const TorrentID &id) const = 0;
         virtual void storeQueue(const QVector<TorrentID> &queue) const = 0;
+        virtual void makeBackup() const = 0;
 
         void loadAll() const;
         QVector<LoadedResumeData> fetchLoadedResumeData() const;

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -1391,6 +1391,12 @@ void SessionImpl::endStartup(ResumeSessionContext *context)
 
         if (context->currentStorageType == ResumeDataStorageType::Legacy)
             Utils::Fs::removeFile(dbPath);
+
+        if (m_torrents.count() > 0)
+        {
+            // make initial backup if there are imported torrents
+            m_resumeDataStorage->makeBackup();
+        }
     }
 
     context->deleteLater();
@@ -4646,6 +4652,9 @@ void SessionImpl::handleTorrentResumeDataReady(TorrentImpl *const torrent, const
         m_resumeDataStorage->remove(iter.value());
         m_changedTorrentIDs.erase(iter);
     }
+
+    if (m_numResumeData == 0)
+        m_resumeDataStorage->makeBackup();
 }
 
 void SessionImpl::handleTorrentInfoHashChanged(TorrentImpl *torrent, const InfoHash &prevInfoHash)


### PR DESCRIPTION
Makes backup of resume data  from time to time (only SQLite based storage is supported).
It is intended to protect against corruption of the main resume data, so it does not create a new copy every time, but simply overwrites the single one.