### PR TITLE
Correctly destroy startup resume data storage

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -1388,7 +1388,7 @@ void SessionImpl::endStartup(ResumeSessionContext *context)
             saveTorrentsQueue();
 
         const Path dbPath = context->startupStorage->path();
-        delete context->startupStorage;
+        context->startupStorage->deleteLater();
 
         if (context->currentStorageType == ResumeDataStorageType::Legacy)
             Utils::Fs::removeFile(dbPath);


### PR DESCRIPTION
Otherwise it can crash after converting resume data storage.