### PR TITLE
Add confirmation to resume/pause all

### DIFF
--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -367,7 +367,7 @@ void TransferListWidget::pauseAllTorrents()
     const QMessageBox::StandardButton ret =
             QMessageBox::question(this, tr("Confirm pause"),
                                   tr("Would you like to pause all torrents?"),
-                                  (QMessageBox::Yes | QMessageBox::No), QMessageBox::Yes);
+                                  (QMessageBox::Yes | QMessageBox::No));
 
     if (ret != QMessageBox::Yes)
         return;
@@ -383,7 +383,7 @@ void TransferListWidget::resumeAllTorrents()
     const QMessageBox::StandardButton ret =
             QMessageBox::question(this, tr("Confirm resume"),
                                   tr("Would you like to resume all torrents?"),
-                                  (QMessageBox::Yes | QMessageBox::No), QMessageBox::Yes);
+                                  (QMessageBox::Yes | QMessageBox::No));
 
     if (ret != QMessageBox::Yes)
         return;

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -363,14 +363,32 @@ void TransferListWidget::setSelectedTorrentsLocation()
 
 void TransferListWidget::pauseAllTorrents()
 {
+    // Show confirmation if user would really like to Pause All
+    QMessageBox::StandardButton ret =
+            QMessageBox::question(this, tr("Confirm pause"),
+                                  tr("Would you like to pause all torrents?"),
+                                  QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+
+    if (ret != QMessageBox::Yes) return;
+
     for (BitTorrent::Torrent *const torrent : asConst(BitTorrent::Session::instance()->torrents()))
         torrent->pause();
+
 }
 
 void TransferListWidget::resumeAllTorrents()
 {
+    // Show confirmation if user would really like to Resume All
+    QMessageBox::StandardButton ret =
+            QMessageBox::question(this, tr("Confirm resume"),
+                                  tr("Would you like to resume all torrents?"),
+                                  QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+
+    if (ret != QMessageBox::Yes) return;
+
     for (BitTorrent::Torrent *const torrent : asConst(BitTorrent::Session::instance()->torrents()))
         torrent->resume();
+
 }
 
 void TransferListWidget::startSelectedTorrents()

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -364,12 +364,13 @@ void TransferListWidget::setSelectedTorrentsLocation()
 void TransferListWidget::pauseAllTorrents()
 {
     // Show confirmation if user would really like to Pause All
-    QMessageBox::StandardButton ret =
+    const QMessageBox::StandardButton ret =
             QMessageBox::question(this, tr("Confirm pause"),
                                   tr("Would you like to pause all torrents?"),
-                                  QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+                                  (QMessageBox::Yes | QMessageBox::No), QMessageBox::Yes);
 
-    if (ret != QMessageBox::Yes) return;
+    if (ret != QMessageBox::Yes)
+        return;
 
     for (BitTorrent::Torrent *const torrent : asConst(BitTorrent::Session::instance()->torrents()))
         torrent->pause();
@@ -379,12 +380,13 @@ void TransferListWidget::pauseAllTorrents()
 void TransferListWidget::resumeAllTorrents()
 {
     // Show confirmation if user would really like to Resume All
-    QMessageBox::StandardButton ret =
+    const QMessageBox::StandardButton ret =
             QMessageBox::question(this, tr("Confirm resume"),
                                   tr("Would you like to resume all torrents?"),
-                                  QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+                                  (QMessageBox::Yes | QMessageBox::No), QMessageBox::Yes);
 
-    if (ret != QMessageBox::Yes) return;
+    if (ret != QMessageBox::Yes)
+        return;
 
     for (BitTorrent::Torrent *const torrent : asConst(BitTorrent::Session::instance()->torrents()))
         torrent->resume();

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -365,32 +365,30 @@ void TransferListWidget::pauseAllTorrents()
 {
     // Show confirmation if user would really like to Pause All
     const QMessageBox::StandardButton ret =
-            QMessageBox::question(this, tr("Confirm pause"),
-                                  tr("Would you like to pause all torrents?"),
-                                  (QMessageBox::Yes | QMessageBox::No));
+            QMessageBox::question(this, tr("Confirm pause")
+                                  , tr("Would you like to pause all torrents?")
+                                  , (QMessageBox::Yes | QMessageBox::No));
 
     if (ret != QMessageBox::Yes)
         return;
 
     for (BitTorrent::Torrent *const torrent : asConst(BitTorrent::Session::instance()->torrents()))
         torrent->pause();
-
 }
 
 void TransferListWidget::resumeAllTorrents()
 {
     // Show confirmation if user would really like to Resume All
     const QMessageBox::StandardButton ret =
-            QMessageBox::question(this, tr("Confirm resume"),
-                                  tr("Would you like to resume all torrents?"),
-                                  (QMessageBox::Yes | QMessageBox::No));
+            QMessageBox::question(this, tr("Confirm resume")
+                                  , tr("Would you like to resume all torrents?")
+                                  , (QMessageBox::Yes | QMessageBox::No));
 
     if (ret != QMessageBox::Yes)
         return;
 
     for (BitTorrent::Torrent *const torrent : asConst(BitTorrent::Session::instance()->torrents()))
         torrent->resume();
-
 }
 
 void TransferListWidget::startSelectedTorrents()

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -980,7 +980,7 @@ const initializeWindows = function() {
     };
 
     addClickEvent('pauseAll', function(e) {
-        if (confirm('QBT_TR(Are you sure you want to pause all your torrents?)QBT_TR[CONTEXT=MainWindow]')) {
+        if (confirm('QBT_TR(Would you like to pause all torrents?)QBT_TR[CONTEXT=MainWindow]')) {
             new Event(e).stop();
             new Request({
                 url: 'api/v2/torrents/pause',
@@ -994,7 +994,7 @@ const initializeWindows = function() {
     });
 
     addClickEvent('resumeAll', function(e) {
-        if (confirm('QBT_TR(Are you sure you want to resume all your torrents?)QBT_TR[CONTEXT=MainWindow]')) {
+        if (confirm('QBT_TR(Would you like to resume all torrents?)QBT_TR[CONTEXT=MainWindow]')) {
             new Event(e).stop();
             new Request({
                 url: 'api/v2/torrents/resume',

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -980,8 +980,9 @@ const initializeWindows = function() {
     };
 
     addClickEvent('pauseAll', (e) => {
+		new Event(e).stop();
+		
         if (confirm('QBT_TR(Would you like to pause all torrents?)QBT_TR[CONTEXT=MainWindow]')) {
-            new Event(e).stop();
             new Request({
                 url: 'api/v2/torrents/pause',
                 method: 'post',
@@ -994,8 +995,9 @@ const initializeWindows = function() {
     });
 
     addClickEvent('resumeAll', (e) => {
+		new Event(e).stop();
+		
         if (confirm('QBT_TR(Would you like to resume all torrents?)QBT_TR[CONTEXT=MainWindow]')) {
-            new Event(e).stop();
             new Request({
                 url: 'api/v2/torrents/resume',
                 method: 'post',

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -979,18 +979,32 @@ const initializeWindows = function() {
         }
     };
 
-    ['pause', 'resume'].each(function(item) {
-        addClickEvent(item + 'All', function(e) {
+    addClickEvent('pauseAll', function(e) {
+        if (confirm('QBT_TR(Are you sure you want to pause all your torrents?)QBT_TR[CONTEXT=MainWindow]')) {
             new Event(e).stop();
             new Request({
-                url: 'api/v2/torrents/' + item,
+                url: 'api/v2/torrents/pause',
                 method: 'post',
                 data: {
                     hashes: "all"
                 }
             }).send();
             updateMainData();
-        });
+        }
+    });
+
+    addClickEvent('resumeAll', function(e) {
+        if (confirm('QBT_TR(Are you sure you want to resume all your torrents?)QBT_TR[CONTEXT=MainWindow]')) {
+            new Event(e).stop();
+            new Request({
+                url: 'api/v2/torrents/resume',
+                method: 'post',
+                data: {
+                    hashes: "all"
+                }
+            }).send();
+            updateMainData();
+        }
     });
 
     ['pause', 'resume', 'recheck'].each(function(item) {

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -980,8 +980,8 @@ const initializeWindows = function() {
     };
 
     addClickEvent('pauseAll', (e) => {
-		new Event(e).stop();
-		
+        new Event(e).stop();
+
         if (confirm('QBT_TR(Would you like to pause all torrents?)QBT_TR[CONTEXT=MainWindow]')) {
             new Request({
                 url: 'api/v2/torrents/pause',
@@ -995,8 +995,8 @@ const initializeWindows = function() {
     });
 
     addClickEvent('resumeAll', (e) => {
-		new Event(e).stop();
-		
+        new Event(e).stop();
+
         if (confirm('QBT_TR(Would you like to resume all torrents?)QBT_TR[CONTEXT=MainWindow]')) {
             new Request({
                 url: 'api/v2/torrents/resume',

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -979,7 +979,7 @@ const initializeWindows = function() {
         }
     };
 
-    addClickEvent('pauseAll', function(e) {
+    addClickEvent('pauseAll', (e) => {
         if (confirm('QBT_TR(Would you like to pause all torrents?)QBT_TR[CONTEXT=MainWindow]')) {
             new Event(e).stop();
             new Request({
@@ -993,7 +993,7 @@ const initializeWindows = function() {
         }
     });
 
-    addClickEvent('resumeAll', function(e) {
+    addClickEvent('resumeAll', (e) => {
         if (confirm('QBT_TR(Would you like to resume all torrents?)QBT_TR[CONTEXT=MainWindow]')) {
             new Event(e).stop();
             new Request({


### PR DESCRIPTION
Closes #17683

This adds a confirmation dialog to Pause All and Resume All. First I wanted to only add it in Tray, but honestly, clicking around in the menu, using hotkeys might trigger it just as easy.

This introduces new strings (please check) for the confirm/resume, so it adds 4 new translations.

It uses an existing confirmation dialog, taken from `recheckSelectedTorrents()`.

Feel free to reject it, I just "felt" the user's pain. Some people run 1000+ torrents and this might ease their pain.