### PR TITLE
Revise interface of port forwarder

### DIFF
--- a/src/base/bittorrent/portforwarderimpl.h
+++ b/src/base/bittorrent/portforwarderimpl.h
@@ -34,6 +34,7 @@
 #include <libtorrent/portmap.hpp>
 
 #include <QHash>
+#include <QSet>
 
 #include "base/net/portforwarder.h"
 #include "base/settingvalue.h"
@@ -50,8 +51,8 @@ public:
     bool isEnabled() const override;
     void setEnabled(bool enabled) override;
 
-    void addPort(quint16 port) override;
-    void deletePort(quint16 port) override;
+    void setPorts(const QString &profile, QSet<quint16> ports) override;
+    void removePorts(const QString &profile) override;
 
 private:
     void start();
@@ -59,5 +60,8 @@ private:
 
     CachedSettingValue<bool> m_storeActive;
     lt::session *const m_provider = nullptr;
-    QHash<quint16, std::vector<lt::port_mapping_t>> m_mappedPorts;
+
+    using PortMapping = QHash<quint16, std::vector<lt::port_mapping_t>>;  // <port, handles>
+    QHash<QString, PortMapping> m_portProfiles;
+    QSet<quint16> m_forwardedPorts;
 };

--- a/src/base/net/portforwarder.h
+++ b/src/base/net/portforwarder.h
@@ -29,6 +29,9 @@
 #pragma once
 
 #include <QObject>
+#include <QSet>
+
+class QString;
 
 namespace Net
 {
@@ -45,8 +48,8 @@ namespace Net
         virtual bool isEnabled() const = 0;
         virtual void setEnabled(bool enabled) = 0;
 
-        virtual void addPort(quint16 port) = 0;
-        virtual void deletePort(quint16 port) = 0;
+        virtual void setPorts(const QString &profile, QSet<quint16> ports) = 0;
+        virtual void removePorts(const QString &profile) = 0;
 
     private:
         static PortForwarder *m_instance;

--- a/src/webui/webui.h
+++ b/src/webui/webui.h
@@ -66,5 +66,4 @@ private:
     QPointer<Http::Server> m_httpServer;
     QPointer<Net::DNSUpdater> m_dnsUpdater;
     QPointer<WebApplication> m_webapp;
-    quint16 m_port = 0;
 };


### PR DESCRIPTION
This eases the usage of port forwarder as the caller code doesn't need to store previous used port and now can rely on port forwarder doing all the hard work.
