### PR TITLE
Don't use extra variable to distinguish restored torrents

### DIFF
--- a/src/base/bittorrent/bencoderesumedatastorage.cpp
+++ b/src/base/bittorrent/bencoderesumedatastorage.cpp
@@ -210,7 +210,6 @@ BitTorrent::LoadResumeDataResult BitTorrent::BencodeResumeDataStorage::loadTorre
         return nonstd::make_unexpected(tr("Cannot parse resume data: invalid format"));
 
     LoadTorrentParams torrentParams;
-    torrentParams.restored = true;
     torrentParams.category = fromLTString(resumeDataRoot.dict_find_string_value("qBt-category"));
     torrentParams.name = fromLTString(resumeDataRoot.dict_find_string_value("qBt-name"));
     torrentParams.hasSeedStatus = resumeDataRoot.dict_find_int_value("qBt-seedStatus");

--- a/src/base/bittorrent/dbresumedatastorage.cpp
+++ b/src/base/bittorrent/dbresumedatastorage.cpp
@@ -196,7 +196,6 @@ namespace BitTorrent
         LoadTorrentParams parseQueryResultRow(const QSqlQuery &query)
         {
             LoadTorrentParams resumeData;
-            resumeData.restored = true;
             resumeData.name = query.value(DB_COLUMN_NAME.name).toString();
             resumeData.category = query.value(DB_COLUMN_CATEGORY.name).toString();
             const QString tagsData = query.value(DB_COLUMN_TAGS.name).toString();

--- a/src/base/bittorrent/loadtorrentparams.h
+++ b/src/base/bittorrent/loadtorrentparams.h
@@ -58,7 +58,5 @@ namespace BitTorrent
 
         qreal ratioLimit = Torrent::USE_GLOBAL_RATIO;
         int seedingTimeLimit = Torrent::USE_GLOBAL_SEEDING_TIME;
-
-        bool restored = false;  // is existing torrent job?
     };
 }

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -5219,7 +5219,7 @@ TorrentImpl *SessionImpl::createTorrent(const lt::torrent_handle &nativeHandle, 
     if (const InfoHash infoHash = torrent->infoHash(); infoHash.isHybrid())
         m_hybridTorrentsByAltID.insert(TorrentID::fromSHA1Hash(infoHash.v1()), torrent);
 
-    if (!params.restored)
+    if (isRestored())
     {
         m_resumeDataStorage->store(torrent->id(), params);
 
@@ -5237,7 +5237,7 @@ TorrentImpl *SessionImpl::createTorrent(const lt::torrent_handle &nativeHandle, 
         m_seedingLimitTimer->start();
     }
 
-    if (params.restored)
+    if (!isRestored())
     {
         LogMsg(tr("Restored torrent. Torrent: \"%1\"").arg(torrent->name()));
     }


### PR DESCRIPTION
This is now known from the session stage.
