### PR TITLE
Destroy object within appropriate thread

### DIFF
--- a/src/base/torrentfileswatcher.cpp
+++ b/src/base/torrentfileswatcher.cpp
@@ -269,7 +269,6 @@ TorrentFilesWatcher::~TorrentFilesWatcher()
 {
     m_ioThread->quit();
     m_ioThread->wait();
-    delete m_asyncWorker;
 }
 
 void TorrentFilesWatcher::initWorker()
@@ -282,6 +281,7 @@ void TorrentFilesWatcher::initWorker()
     connect(m_asyncWorker, &TorrentFilesWatcher::Worker::torrentFound, this, &TorrentFilesWatcher::onTorrentFound);
 
     m_asyncWorker->moveToThread(m_ioThread);
+    connect(m_ioThread, &QThread::finished, m_asyncWorker, &QObject::deleteLater);
     m_ioThread->start();
 
     for (auto it = m_watchedFolders.cbegin(); it != m_watchedFolders.cend(); ++it)


### PR DESCRIPTION
Otherwise there are the following debug messages:
>QObject::killTimer: Timers cannot be stopped from another thread
QObject::~QObject: Timers cannot be stopped from another thread