### PR TITLE
Always confirm exit

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1146,8 +1146,7 @@ void MainWindow::closeEvent(QCloseEvent *e)
             if (!isVisible())
                 show();
             QMessageBox confirmBox(QMessageBox::Question, tr("Exiting qBittorrent"),
-                                   // Split it because the last sentence is used in the Web UI
-                                   tr("Some files are currently transferring.") + u'\n' + tr("Are you sure you want to quit qBittorrent?"),
+                                   tr("Are you sure you want to quit qBittorrent?"),
                                    QMessageBox::NoButton, this);
             QPushButton *noBtn = confirmBox.addButton(tr("&No"), QMessageBox::NoRole);
             confirmBox.addButton(tr("&Yes"), QMessageBox::YesRole);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1139,7 +1139,7 @@ void MainWindow::closeEvent(QCloseEvent *e)
     }
 #endif // Q_OS_MACOS
 
-    if (pref->confirmOnExit() && BitTorrent::Session::instance()->hasActiveTorrents())
+    if (pref->confirmOnExit())
     {
         if (e->spontaneous() || m_forceExit)
         {

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -409,10 +409,10 @@
                <item>
                 <widget class="QCheckBox" name="checkProgramExitConfirm">
                  <property name="toolTip">
-                  <string>Shows a confirmation dialog when exiting with active torrents</string>
+                  <string>Shows a confirmation dialog when exiting</string>
                  </property>
                  <property name="text">
-                  <string>Confirmation on exit when torrents are active</string>
+                  <string>Confirmation on exit</string>
                  </property>
                  <property name="checked">
                   <bool>true</bool>


### PR DESCRIPTION
Closes #18018

Super simple change.
Always ask for confirmation on exit, regardless if there are "active torrents" or not.

**This is an "up-for-debate" kind of PR.**
**Seriously feel free to close it right away, if you don't agree with it!**

Rationale:
Currently, qBittorrent only asks for confirmation on exit if there are active torrents. This was introduced many many years ago. Just a few days ago a user asked on the forums if it'd be possible to add a "confirm always". And I read it, and I was like, hmm, why is that not the default behavior?

I checked the source, and I only found one extra `if` condition at exit. And the related strings (2). Could not find any other occurrence. I compiled it then, tested it, and it worked. 

Now, this change does affect a lot of people, because Confirm on Exit **is default**.
**But**, people on the first exit can already disable this option, if they are bothered by it.
(There is a "Never ask" button which disables the pop-up right away.)

**Web-UI**: I checked, it always asks and the desktop GUI confirmation is not exposed in Preferences, as far as I can tell.

Ps.: I swear I am not trying to make you guys mad and I mean it 100%, just close it if it makes no sense to change the behavior.



