### PR TITLE
Don't miss to store metadata of new torrent

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -5216,6 +5216,8 @@ TorrentImpl *SessionImpl::createTorrent(const lt::torrent_handle &nativeHandle, 
 
     if (isRestored())
     {
+        torrent->saveResumeData(lt::torrent_handle::save_info_dict);
+
         // The following is useless for newly added magnet
         if (torrent->hasMetadata())
         {

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -690,9 +690,9 @@ bool TorrentImpl::needSaveResumeData() const
     return m_nativeStatus.need_save_resume;
 }
 
-void TorrentImpl::saveResumeData()
+void TorrentImpl::saveResumeData(lt::resume_data_flags_t flags)
 {
-    m_nativeHandle.save_resume_data();
+    m_nativeHandle.save_resume_data(flags);
     m_session->handleTorrentSaveResumeDataRequested(this);
 }
 

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -245,7 +245,7 @@ namespace BitTorrent
         void handleStateUpdate(const lt::torrent_status &nativeStatus);
         void handleCategoryOptionsChanged();
         void handleAppendExtensionToggled();
-        void saveResumeData();
+        void saveResumeData(lt::resume_data_flags_t flags = {});
         void handleMoveStorageJobFinished(const Path &path, bool hasOutstandingJob);
         void fileSearchFinished(const Path &savePath, const PathList &fileNames);
         void updatePeerCount(const QString &trackerURL, const TrackerEntry::Endpoint &endpoint, int count);


### PR DESCRIPTION
Fixes regression since b68c4e21065fb6b1c84b53f8bfc0d0761cb08e74.
Closes #18030.

It seems that this tangle with saving resume data for a new torrent twice has finally unraveled. Previous attempts have resulted in one of the following:
1. Metadata is saved but resume data is incorrect
2. Correct resume data is saved but metadata is missing