### PR TITLE
Fetch data asynchronously

### DIFF
--- a/src/base/bittorrent/peerinfo.cpp
+++ b/src/base/bittorrent/peerinfo.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2015-2022  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -31,16 +31,15 @@
 #include <QBitArray>
 
 #include "base/bittorrent/ltqbitarray.h"
-#include "base/bittorrent/torrent.h"
 #include "base/net/geoipmanager.h"
 #include "base/unicodestrings.h"
 #include "peeraddress.h"
 
 using namespace BitTorrent;
 
-PeerInfo::PeerInfo(const Torrent *torrent, const lt::peer_info &nativeInfo)
+PeerInfo::PeerInfo(const lt::peer_info &nativeInfo, const QBitArray &allPieces)
     : m_nativeInfo(nativeInfo)
-    , m_relevance(calcRelevance(torrent))
+    , m_relevance(calcRelevance(allPieces))
 {
     determineFlags();
 }
@@ -246,9 +245,8 @@ QString PeerInfo::connectionType() const
         : u"Web"_qs;
 }
 
-qreal PeerInfo::calcRelevance(const Torrent *torrent) const
+qreal PeerInfo::calcRelevance(const QBitArray &allPieces) const
 {
-    const QBitArray allPieces = torrent->pieces();
     const int localMissing = allPieces.count(false);
     if (localMissing <= 0)
         return 0;

--- a/src/base/bittorrent/peerinfo.h
+++ b/src/base/bittorrent/peerinfo.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2015-2022  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -36,7 +36,6 @@ class QBitArray;
 
 namespace BitTorrent
 {
-    class Torrent;
     struct PeerAddress;
 
     class PeerInfo
@@ -45,7 +44,7 @@ namespace BitTorrent
 
     public:
         PeerInfo() = default;
-        PeerInfo(const Torrent *torrent, const lt::peer_info &nativeInfo);
+        PeerInfo(const lt::peer_info &nativeInfo, const QBitArray &allPieces);
 
         bool fromDHT() const;
         bool fromPeX() const;
@@ -93,7 +92,7 @@ namespace BitTorrent
         int downloadingPieceIndex() const;
 
     private:
-        qreal calcRelevance(const Torrent *torrent) const;
+        qreal calcRelevance(const QBitArray &allPieces) const;
         void determineFlags();
 
         lt::peer_info m_nativeInfo = {};

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -627,6 +627,8 @@ SessionImpl::~SessionImpl()
     // we delete lt::session
     delete Net::PortForwarder::instance();
 
+    // We must stop "async worker" only after deletion
+    // of all the components that could potentially use it
     m_asyncWorker->clear();
     m_asyncWorker->waitForDone();
 

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -443,7 +443,7 @@ namespace BitTorrent
         template <typename Func>
         void invoke(Func &&func)
         {
-            QMetaObject::invokeMethod(this, std::forward<Func>(func));
+            QMetaObject::invokeMethod(this, std::forward<Func>(func), Qt::QueuedConnection);
         }
 
         void invokeAsync(std::function<void ()> func);

--- a/src/base/bittorrent/torrent.h
+++ b/src/base/bittorrent/torrent.h
@@ -310,7 +310,7 @@ namespace BitTorrent
         virtual void removeUrlSeeds(const QVector<QUrl> &urlSeeds) = 0;
         virtual bool connectPeer(const PeerAddress &peerAddress) = 0;
         virtual void clearPeers() = 0;
-        virtual bool setMetadata(const TorrentInfo &torrentInfo) = 0;
+        virtual void setMetadata(const TorrentInfo &torrentInfo) = 0;
 
         virtual StopCondition stopCondition() const = 0;
         virtual void setStopCondition(StopCondition stopCondition) = 0;

--- a/src/base/bittorrent/torrent.h
+++ b/src/base/bittorrent/torrent.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2015-2022  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
@@ -106,9 +106,10 @@ namespace BitTorrent
     uint qHash(TorrentState key, uint seed = 0);
 #endif
 
-    class Torrent : public AbstractFileStorage
+    class Torrent : public QObject, public AbstractFileStorage
     {
-        Q_GADGET
+        Q_OBJECT
+        Q_DISABLE_COPY_MOVE(Torrent)
 
     public:
         enum class StopCondition
@@ -128,7 +129,7 @@ namespace BitTorrent
         static const qreal MAX_RATIO;
         static const int MAX_SEEDING_TIME;
 
-        virtual ~Torrent() = default;
+        using QObject::QObject;
 
         virtual InfoHash infoHash() const = 0;
         virtual QString name() const = 0;
@@ -317,6 +318,19 @@ namespace BitTorrent
         virtual QString createMagnetURI() const = 0;
         virtual nonstd::expected<QByteArray, QString> exportToBuffer() const = 0;
         virtual nonstd::expected<void, QString> exportToFile(const Path &path) const = 0;
+
+        virtual void fetchPeerInfo(std::function<void (QVector<PeerInfo>)> resultHandler) const = 0;
+        virtual void fetchURLSeeds(std::function<void (QVector<QUrl>)> resultHandler) const = 0;
+        virtual void fetchFilesProgress(std::function<void (QVector<qreal>)> resultHandler) const = 0;
+        virtual void fetchPieceAvailability(std::function<void (QVector<int>)> resultHandler) const = 0;
+        virtual void fetchDownloadingPieces(std::function<void (QBitArray)> resultHandler) const = 0;
+        /**
+         * @brief fraction of file pieces that are available at least from one peer
+         *
+         * This is not the same as torrrent availability, it is just a fraction of pieces
+         * that can be downloaded right now. It varies between 0 to 1.
+         */
+        virtual void fetchAvailableFileFractions(std::function<void (QVector<qreal>)> resultHandler) const = 0;
 
         TorrentID id() const;
         bool isResumed() const;

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -2055,7 +2055,7 @@ void TorrentImpl::handleFileCompletedAlert(const lt::file_completed_alert *p)
     const int fileIndex = m_indexMap.value(p->index, -1);
     Q_ASSERT(fileIndex >= 0);
 
-    m_completedFiles[fileIndex] = true;
+    m_completedFiles.setBit(fileIndex);
 
     if (m_session->isAppendExtensionEnabled())
     {

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -227,7 +227,7 @@ namespace BitTorrent
         void removeUrlSeeds(const QVector<QUrl> &urlSeeds) override;
         bool connectPeer(const PeerAddress &peerAddress) override;
         void clearPeers() override;
-        bool setMetadata(const TorrentInfo &torrentInfo) override;
+        void setMetadata(const TorrentInfo &torrentInfo) override;
 
         StopCondition stopCondition() const override;
         void setStopCondition(StopCondition stopCondition) override;

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -80,10 +80,10 @@ namespace BitTorrent
         lt::operation_t operation;
     };
 
-    class TorrentImpl final : public QObject, public Torrent
+    class TorrentImpl final : public Torrent
     {
+        Q_OBJECT
         Q_DISABLE_COPY_MOVE(TorrentImpl)
-        Q_DECLARE_TR_FUNCTIONS(BitTorrent::TorrentImpl)
 
     public:
         TorrentImpl(SessionImpl *session, lt::session *nativeSession
@@ -236,6 +236,13 @@ namespace BitTorrent
         nonstd::expected<QByteArray, QString> exportToBuffer() const override;
         nonstd::expected<void, QString> exportToFile(const Path &path) const override;
 
+        void fetchPeerInfo(std::function<void (QVector<PeerInfo>)> resultHandler) const override;
+        void fetchURLSeeds(std::function<void (QVector<QUrl>)> resultHandler) const override;
+        void fetchFilesProgress(std::function<void (QVector<qreal>)> resultHandler) const override;
+        void fetchPieceAvailability(std::function<void (QVector<int>)> resultHandler) const override;
+        void fetchDownloadingPieces(std::function<void (QBitArray)> resultHandler) const override;
+        void fetchAvailableFileFractions(std::function<void (QVector<qreal>)> resultHandler) const override;
+
         bool needSaveResumeData() const;
 
         // Session interface
@@ -289,6 +296,9 @@ namespace BitTorrent
         void reload();
 
         nonstd::expected<lt::entry, QString> exportTorrent() const;
+
+        template <typename Func, typename Callback>
+        void invokeAsync(Func func, Callback resultHandler) const;
 
         SessionImpl *const m_session = nullptr;
         lt::session *m_nativeSession = nullptr;


### PR DESCRIPTION
This (together with #18010) should prevent UI from being freezed when updates some data fetching from libtorrent when it does some hard work.
I tried to touch on all cases when it comes to regular auto-updates. There are still untouched cases when data is fetched on demand, for example, exporting a .torrent file or magnet link, etc. The Web API requires additional refactoring so that a similar approach can be applied there. This will follow further.