### PR TITLE
Revert "Use another workaround to update files tree view"

### DIFF
--- a/src/gui/torrentcontentmodel.h
+++ b/src/gui/torrentcontentmodel.h
@@ -81,6 +81,10 @@ signals:
     void filteredFilesChanged();
 
 private:
+    using ColumnInterval = IndexInterval<int>;
+
+    void notifySubtreeUpdated(const QModelIndex &index, const QVector<ColumnInterval> &columns);
+
     TorrentContentModelFolder *m_rootItem = nullptr;
     QVector<TorrentContentModelFile *> m_filesIndex;
     QFileIconProvider *m_fileIconProvider = nullptr;


### PR DESCRIPTION
This reverts commit 0f82c169362cd2e26c053725d3b8fae3889f1655.

There were some non-obvious defects, so it seems it would be better to return to a more reliable (although possibly more expensive) method of notifying the View about data changed.

Closes #18036.