### PR TITLE
Revise text color for completed status

### DIFF
--- a/src/gui/color.h
+++ b/src/gui/color.h
@@ -43,13 +43,13 @@ namespace Color
             inline const QColor accentEmphasis = 0x1f6feb;
             inline const QColor accentFg = 0x58a6ff;
             inline const QColor dangerFg = 0xf85149;
+            inline const QColor doneFg = 0xa371f7;
             inline const QColor fgMuted = 0x8b949e;
             inline const QColor fgSubtle = 0x6e7681;
             inline const QColor severeFg = 0xdb6d28;
             inline const QColor successEmphasis = 0x238636;
             inline const QColor successFg = 0x1a7f37;
             // Scale variables
-            inline const QColor scaleBlue4 = 0x388bfd;
             inline const QColor scaleYellow6 = 0x845306;
         }
 
@@ -59,13 +59,13 @@ namespace Color
             inline const QColor accentEmphasis = 0x0969da;
             inline const QColor accentFg = 0x0969da;
             inline const QColor dangerFg = 0xcf222e;
+            inline const QColor doneFg = 0x8250df;
             inline const QColor fgMuted = 0x57606a;
             inline const QColor fgSubtle = 0x6e7781;
             inline const QColor severeFg = 0xbc4c00;
             inline const QColor successEmphasis = 0x2da44e;
             inline const QColor successFg = 0x1a7f37;
             // Scale variables
-            inline const QColor scaleBlue4 = 0x218bff;
             inline const QColor scaleYellow6 = 0x7d4e00;
         }
     }

--- a/src/gui/color.h
+++ b/src/gui/color.h
@@ -48,7 +48,7 @@ namespace Color
             inline const QColor fgSubtle = 0x6e7681;
             inline const QColor severeFg = 0xdb6d28;
             inline const QColor successEmphasis = 0x238636;
-            inline const QColor successFg = 0x1a7f37;
+            inline const QColor successFg = 0x3fb950;
             // Scale variables
             inline const QColor scaleYellow6 = 0x845306;
         }

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -70,7 +70,7 @@ namespace
         case BitTorrent::TorrentState::PausedDownloading:
             return (isDarkTheme ? Color::Primer::Dark::fgMuted : Color::Primer::Light::fgMuted);
         case BitTorrent::TorrentState::PausedUploading:
-            return (isDarkTheme ? Color::Primer::Dark::scaleBlue4 : Color::Primer::Light::scaleBlue4);
+            return (isDarkTheme ? Color::Primer::Dark::doneFg : Color::Primer::Light::doneFg);
         case BitTorrent::TorrentState::QueuedDownloading:
         case BitTorrent::TorrentState::QueuedUploading:
             return (isDarkTheme ? Color::Primer::Dark::scaleYellow6 : Color::Primer::Light::scaleYellow6);


### PR DESCRIPTION
Now it uses the purple color which matches the completed status icon color.
[screenshot](https://user-images.githubusercontent.com/9395168/204402401-7c3700ff-102f-49a3-adfc-11d193df3488.png)

Related: #18078.
