### PR TITLE
Destroy desktop integration at correct place

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -706,7 +706,7 @@ try
 #ifndef DISABLE_GUI
     UIThemeManager::initInstance();
 
-    m_desktopIntegration = new DesktopIntegration(this);
+    m_desktopIntegration = new DesktopIntegration;
     m_desktopIntegration->setToolTip(tr("Loading torrents..."));
 #ifndef Q_OS_MACOS
     auto *desktopIntegrationMenu = new QMenu;
@@ -1201,6 +1201,7 @@ void Application::cleanup()
         ::ShutdownBlockReasonDestroy(reinterpret_cast<HWND>(m_window->effectiveWinId()));
 #endif // Q_OS_WIN
         delete m_window;
+        delete m_desktopIntegration;
         UIThemeManager::freeInstance();
     }
 #endif // DISABLE_GUI


### PR DESCRIPTION
Otherwise it is destructed in QObject destructor, i.e. after GUI application is already destructed.
This can be related to some problems with system tray icon.

PR #18108.
Closes #18093.