### PR TITLE
Allow to create RSS rule based on selected item

### DIFF
--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -166,13 +166,14 @@ AutomatedRssDownloader::~AutomatedRssDownloader()
 }
 
 // Selects a row by name
-void AutomatedRssDownloader::selectItem(const QString nameToSelect)
+void AutomatedRssDownloader::selectRule(const QString &ruleName)
 {
     m_ui->listRules->clearSelection();
     for (int i = 0; i < m_ui->listRules->count(); ++i)
     {
         const QString current_element_text = m_ui->listRules->item(i)->text();
-        if (nameToSelect == current_element_text) {
+        if (ruleName == current_element_text)
+        {
             m_ui->listRules->setCurrentRow(i);
             return;
         }

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -165,6 +165,20 @@ AutomatedRssDownloader::~AutomatedRssDownloader()
     delete m_episodeRegex;
 }
 
+// Selects a row by name
+void AutomatedRssDownloader::selectItem(const QString nameToSelect)
+{
+    m_ui->listRules->clearSelection();
+    for (int i = 0; i < m_ui->listRules->count(); ++i)
+    {
+        const QString current_element_text = m_ui->listRules->item(i)->text();
+        if (nameToSelect == current_element_text) {
+            m_ui->listRules->setCurrentRow(i);
+            return;
+        }
+    }
+}
+
 void AutomatedRssDownloader::loadSettings()
 {
     if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -179,6 +179,12 @@ void AutomatedRssDownloader::selectItem(const QString nameToSelect)
     }
 }
 
+// Returns 0 if there are no matches for selected rule
+int AutomatedRssDownloader::getTreeMatchingArticlesCount()
+{
+    return m_ui->treeMatchingArticles->topLevelItemCount();
+}
+
 void AutomatedRssDownloader::loadSettings()
 {
     if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -60,7 +60,8 @@ public:
     explicit AutomatedRssDownloader(QWidget *parent = nullptr);
     ~AutomatedRssDownloader() override;
 
-    void selectItem(const QString nameToSelect);
+    void selectItem(const QString nameToSelect); // used for right-click new rule
+    int getTreeMatchingArticlesCount(); // used for right-click new rule
 
 private slots:
     void on_addRuleBtn_clicked();

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -60,7 +60,7 @@ public:
     explicit AutomatedRssDownloader(QWidget *parent = nullptr);
     ~AutomatedRssDownloader() override;
 
-    void selectItem(const QString nameToSelect); // used for right-click new rule
+    void selectRule(const QString &ruleName); // used for right-click new rule
     int getTreeMatchingArticlesCount(); // used for right-click new rule
 
 private slots:

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -60,6 +60,8 @@ public:
     explicit AutomatedRssDownloader(QWidget *parent = nullptr);
     ~AutomatedRssDownloader() override;
 
+    void selectItem(const QString nameToSelect);
+
 private slots:
     void on_addRuleBtn_clicked();
     void on_removeRuleBtn_clicked();

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -421,7 +421,7 @@ void RSSWidget::on_newRssRuleBtn_clicked() {
     // If sanitizer returns empty, we don't add anything
     if (sanitizedRssRuleArticleTitle.isEmpty()) {
         QMessageBox::warning(
-            this, tr("Rule problem"),
+            this, tr("Issue with rule name"),
             tr("Torrent name could not be extracted, add failed."));
         return;
     }
@@ -466,6 +466,11 @@ void RSSWidget::on_newRssRuleBtn_clicked() {
 
     // Using the newly implemented selectItem(), we select the new item
     downloader->selectItem(sanitizedRssRuleArticleTitle);
+
+    if (downloader->getTreeMatchingArticlesCount() == 0) {
+        QMessageBox::warning(downloader, tr("No matches found"),
+                             tr("Please check the new rule's Must Contain field."));
+    }
 }
 
 // open the url of the selected RSS articles in the Web browser

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -383,7 +383,7 @@ void RSSWidget::downloadSelectedTorrents()
 }
 
 // Provides a way to filter a torrent's name. Used for Right-Click -> Add new RSS Rule.
-const QString RSSWidget::sanitizeNewRssRuleName(const QString &ruleName)
+const QString RSSWidget::sanitizeRSSRuleName(const QString &ruleName)
 {
     QString name;
 
@@ -407,7 +407,7 @@ void RSSWidget::newRSSRuleBtn() {
         return;
 
     // Retrieve article from selected items
-    QListWidgetItem *selectedRssRule = asConst(m_articleListWidget->selectedItems()[0]);
+    QListWidgetItem *selectedItem = m_articleListWidget->selectedItems()[0];
     RSS::Article *selectedRssRuleArticle = selectedRssRule->data(Qt::UserRole).value<RSS::Article *>();
     Q_ASSERT(selectedRssRuleArticle);
 

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -398,8 +398,7 @@ const QString RSSWidget::sanitizeNewRssRuleName(const QString name_to_filter)
     return name.simplified(); // return without multiple whitespace
 }
 
-void RSSWidget::on_newRssRuleBtn_clicked()
-{
+void RSSWidget::on_newRssRuleBtn_clicked() {
 
     // Safety:
     // The feature only appears if there is only 1 article selected,
@@ -408,41 +407,48 @@ void RSSWidget::on_newRssRuleBtn_clicked()
         return;
 
     // Retrieve article from selected items
-    auto selectedRssRule = asConst(m_articleListWidget->selectedItems()[0]);
-    auto selectedRssRuleArticle = selectedRssRule->data(Qt::UserRole).value<RSS::Article *>();
+    QListWidgetItem *selectedRssRule =
+        asConst(m_articleListWidget->selectedItems()[0]);
+    RSS::Article *selectedRssRuleArticle =
+        selectedRssRule->data(Qt::UserRole).value<RSS::Article *>();
     Q_ASSERT(selectedRssRuleArticle);
 
     // Get the title and also sanitize it
-    auto selectedRssRuleArticleTitle = selectedRssRuleArticle->title();
-    auto sanitizedRssRuleArticleTitle = sanitizeNewRssRuleName(selectedRssRuleArticleTitle);
+    QString selectedRssRuleArticleTitle = selectedRssRuleArticle->title();
+    QString sanitizedRssRuleArticleTitle =
+        sanitizeNewRssRuleName(selectedRssRuleArticleTitle);
 
     // If sanitizer returns empty, we don't add anything
-    if (sanitizedRssRuleArticleTitle.isEmpty())
-    {
-        QMessageBox::warning(this, tr("Rule problem")
-                             , tr("Torrent name could not be extracted, add failed."));
+    if (sanitizedRssRuleArticleTitle.isEmpty()) {
+        QMessageBox::warning(
+            this, tr("Rule problem"),
+            tr("Torrent name could not be extracted, add failed."));
         return;
     }
 
     // Check if this rule name already exists
-    if (RSS::AutoDownloader::instance()->hasRule(sanitizedRssRuleArticleTitle))
-    {
-        QMessageBox::warning(this, tr("Rule name conflict")
-                             , tr("No new rule has been added."));
+    if (RSS::AutoDownloader::instance()->hasRule(
+            sanitizedRssRuleArticleTitle)) {
+        QMessageBox::warning(this, tr("Rule name conflict"),
+                             tr("No new rule has been added."));
         return;
     }
 
     // Insert new rule to prepare it for further edit
-    RSS::AutoDownloader::instance()->insertRule(RSS::AutoDownloadRule(sanitizedRssRuleArticleTitle));
+    RSS::AutoDownloader::instance()->insertRule(
+        RSS::AutoDownloadRule(sanitizedRssRuleArticleTitle));
 
     // We retrieve the newly inserted blank rule
-    auto insertedRule = RSS::AutoDownloader::instance()->ruleByName(sanitizedRssRuleArticleTitle);
+    RSS::AutoDownloadRule insertedRule =
+        RSS::AutoDownloader::instance()->ruleByName(
+            sanitizedRssRuleArticleTitle);
 
     // Remove the inserted new rule for now (there is no change method)
     RSS::AutoDownloader::instance()->removeRule(insertedRule.name());
 
     // Set up our rule-in-works
-    insertedRule.setMustContain(selectedRssRuleArticleTitle); // must match 1:1 without sanitization
+    insertedRule.setMustContain(
+        selectedRssRuleArticleTitle); // must match 1:1 without sanitization
 
     // Feed match: we pass a 1 string QStringList as feed list
     QStringList feedURL;
@@ -452,9 +458,9 @@ void RSSWidget::on_newRssRuleBtn_clicked()
     // Insert set-up rule
     RSS::AutoDownloader::instance()->insertRule(insertedRule);
 
-    // Open the downloader and open this new rule so user can finish setting it up
-    // Taken from on_rssDownloaderBtn_clicked()
-    auto *downloader = new AutomatedRssDownloader(this);
+    // Open the downloader and open this new rule so user can finish setting it
+    // up Taken from on_rssDownloaderBtn_clicked()
+    AutomatedRssDownloader *downloader = new AutomatedRssDownloader(this);
     downloader->setAttribute(Qt::WA_DeleteOnClose);
     downloader->open();
 

--- a/src/gui/rss/rsswidget.h
+++ b/src/gui/rss/rsswidget.h
@@ -72,6 +72,7 @@ private slots:
     void handleCurrentArticleItemChanged(QListWidgetItem *currentItem, QListWidgetItem *previousItem);
     void openSelectedArticlesUrls();
     void downloadSelectedTorrents();
+    void on_newRssRuleBtn_clicked();
     void saveSlidersPosition();
     void restoreSlidersPosition();
     void askNewFolder();
@@ -85,4 +86,5 @@ private:
     Ui::RSSWidget *m_ui = nullptr;
     ArticleListWidget *m_articleListWidget = nullptr;
     FeedListWidget *m_feedListWidget = nullptr;
+    const QString filterNewRssRuleBtnNameFilter(const QString name_to_filter);
 };

--- a/src/gui/rss/rsswidget.h
+++ b/src/gui/rss/rsswidget.h
@@ -72,7 +72,7 @@ private slots:
     void handleCurrentArticleItemChanged(QListWidgetItem *currentItem, QListWidgetItem *previousItem);
     void openSelectedArticlesUrls();
     void downloadSelectedTorrents();
-    void on_newRssRuleBtn_clicked();
+    void newRSSRuleBtn();
     void saveSlidersPosition();
     void restoreSlidersPosition();
     void askNewFolder();
@@ -86,5 +86,5 @@ private:
     Ui::RSSWidget *m_ui = nullptr;
     ArticleListWidget *m_articleListWidget = nullptr;
     FeedListWidget *m_feedListWidget = nullptr;
-    const QString sanitizeNewRssRuleName(const QString name_to_filter);
+    const QString sanitizeNewRssRuleName(const QString &ruleName);
 };

--- a/src/gui/rss/rsswidget.h
+++ b/src/gui/rss/rsswidget.h
@@ -86,5 +86,5 @@ private:
     Ui::RSSWidget *m_ui = nullptr;
     ArticleListWidget *m_articleListWidget = nullptr;
     FeedListWidget *m_feedListWidget = nullptr;
-    const QString filterNewRssRuleBtnNameFilter(const QString name_to_filter);
+    const QString sanitizeNewRssRuleName(const QString name_to_filter);
 };

--- a/src/gui/rss/rsswidget.ui
+++ b/src/gui/rss/rsswidget.ui
@@ -197,6 +197,14 @@
     <string>New folder...</string>
    </property>
   </action>
+  <action name="actionRightClickAddRssRule">
+   <property name="text">
+    <string>Add new RSS rule</string>
+   </property>
+   <property name="toolTip">
+    <string>Add new RSS Rule based on the selected item</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/gui/rss/rsswidget.ui
+++ b/src/gui/rss/rsswidget.ui
@@ -100,7 +100,6 @@
         <widget class="QLabel" name="news_lbl">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -197,7 +196,7 @@
     <string>New folder...</string>
    </property>
   </action>
-  <action name="actionRightClickAddRssRule">
+  <action name="actionAddRSSRule">
    <property name="text">
     <string>Add new RSS rule</string>
    </property>


### PR DESCRIPTION
Fixes #17865

Since my previous one-liner PRs took me a century to make them pass code review, I feel really confident. This newly-gained confidence made me cook up this monstrosity. Jokes aside, thank you guys for your patience.

What it does:
In the RSS downloader, you can right-click to start a download, or open a new URL. Well, now you can make a new rule too! But wait, there is more!

What it can do:
- Auto-create new RSS rule using data from the feed
- Opens newly added rule
- Checks if new rule has any match (see note below), and warns user if there are no matches

**Note about Must Contain field:** The current title match is kinda tricky now.
- If the name contains at least two brackets (ie.: [group][1080p], it completely breaks title match. If I were to escape them with `\` AND set regex mode then the newly added title will 100% work each time. But then, user might get confused about why it's like that.
- For normal torrents, this auto-add creates a perfectly fine Must Contain.

**Title sanitization**
It is highly subjective how one would "sanitize" a title. I tried to pick something that looks OK. Please, let me know if you'd like to change this behavior to more aggressive for example. Like I could also chop very long titles. Could. But should I?