### PR TITLE
Add "Rename rule" button to RSS Downloader

### DIFF
--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -427,6 +427,11 @@ void AutomatedRssDownloader::on_addCategoryBtn_clicked()
     }
 }
 
+void AutomatedRssDownloader::on_editTitleBtn_clicked()
+{
+    renameSelectedRule();
+}
+
 void AutomatedRssDownloader::on_exportBtn_clicked()
 {
     if (RSS::AutoDownloader::instance()->rules().isEmpty())

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -75,6 +75,7 @@ AutomatedRssDownloader::AutomatedRssDownloader(QWidget *parent)
 {
     m_ui->setupUi(this);
     // Icons
+    m_ui->renameRuleBtn->setIcon(UIThemeManager::instance()->getIcon(u"edit-rename"_qs));
     m_ui->removeRuleBtn->setIcon(UIThemeManager::instance()->getIcon(u"edit-clear"_qs));
     m_ui->addRuleBtn->setIcon(UIThemeManager::instance()->getIcon(u"list-add"_qs));
     m_ui->addCategoryBtn->setIcon(UIThemeManager::instance()->getIcon(u"list-add"_qs));
@@ -250,6 +251,13 @@ void AutomatedRssDownloader::updateRuleDefinitionBox()
 {
     const QList<QListWidgetItem *> selection = m_ui->listRules->selectedItems();
     QListWidgetItem *currentRuleItem = ((selection.count() == 1) ? selection.first() : nullptr);
+
+    // Enable the edit rule button but only if we have 1 rule selected
+    if (selection.count() == 1)
+        m_ui->renameRuleBtn->setEnabled(true);
+    else
+        m_ui->renameRuleBtn->setEnabled(false);
+
     if (m_currentRuleItem != currentRuleItem)
     {
         saveEditedRule(); // Save previous rule first
@@ -427,7 +435,7 @@ void AutomatedRssDownloader::on_addCategoryBtn_clicked()
     }
 }
 
-void AutomatedRssDownloader::on_editTitleBtn_clicked()
+void AutomatedRssDownloader::on_renameRuleBtn_clicked()
 {
     renameSelectedRule();
 }

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -66,7 +66,7 @@ private slots:
     void on_addCategoryBtn_clicked();
     void on_exportBtn_clicked();
     void on_importBtn_clicked();
-    void on_editTitleBtn_clicked();
+    void on_renameRuleBtn_clicked();
 
     void handleRuleCheckStateChange(QListWidgetItem *ruleItem);
     void handleFeedCheckStateChange(QListWidgetItem *feedItem);

--- a/src/gui/rss/automatedrssdownloader.h
+++ b/src/gui/rss/automatedrssdownloader.h
@@ -66,6 +66,7 @@ private slots:
     void on_addCategoryBtn_clicked();
     void on_exportBtn_clicked();
     void on_importBtn_clicked();
+    void on_editTitleBtn_clicked();
 
     void handleRuleCheckStateChange(QListWidgetItem *ruleItem);
     void handleFeedCheckStateChange(QListWidgetItem *feedItem);

--- a/src/gui/rss/automatedrssdownloader.ui
+++ b/src/gui/rss/automatedrssdownloader.ui
@@ -424,7 +424,17 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_4">
-     <item>
+      <item>
+      <widget class="QPushButton" name="editTitleBtn">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>&amp;Edit rule title</string>
+        </property>
+       </widget>
+      </item>
+      <item>
       <widget class="QPushButton" name="importBtn">
        <property name="enabled">
         <bool>true</bool>
@@ -482,6 +492,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
   <tabstop>comboContentLayout</tabstop>
   <tabstop>listFeeds</tabstop>
   <tabstop>treeMatchingArticles</tabstop>
+  <tabstop>editTitleBtn</tabstop>
   <tabstop>importBtn</tabstop>
   <tabstop>exportBtn</tabstop>
  </tabstops>

--- a/src/gui/rss/automatedrssdownloader.ui
+++ b/src/gui/rss/automatedrssdownloader.ui
@@ -61,6 +61,19 @@
           </widget>
          </item>
          <item>
+          <widget class="QToolButton" name="renameRuleBtn">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>24</width>
+             <height>20</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QToolButton" name="removeRuleBtn">
            <property name="iconSize">
             <size>
@@ -424,17 +437,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_4">
-      <item>
-      <widget class="QPushButton" name="editTitleBtn">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="text">
-         <string>&amp;Edit rule title</string>
-        </property>
-       </widget>
-      </item>
-      <item>
+     <item>
       <widget class="QPushButton" name="importBtn">
        <property name="enabled">
         <bool>true</bool>
@@ -476,6 +479,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>renameRuleBtn</tabstop>
   <tabstop>removeRuleBtn</tabstop>
   <tabstop>addRuleBtn</tabstop>
   <tabstop>listRules</tabstop>
@@ -492,7 +496,6 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
   <tabstop>comboContentLayout</tabstop>
   <tabstop>listFeeds</tabstop>
   <tabstop>treeMatchingArticles</tabstop>
-  <tabstop>editTitleBtn</tabstop>
   <tabstop>importBtn</tabstop>
   <tabstop>exportBtn</tabstop>
  </tabstops>

--- a/src/gui/rss/automatedrssdownloader.ui
+++ b/src/gui/rss/automatedrssdownloader.ui
@@ -65,6 +65,9 @@
            <property name="enabled">
             <bool>false</bool>
            </property>
+           <property name="toolTip">
+            <string>Rename selected rule. You can also use the F2 hotkey to rename.</string>
+           </property>
            <property name="iconSize">
             <size>
              <width>24</width>


### PR DESCRIPTION
This is quite the simple PR. It simply adds a new button to RSS Downloader so people are aware that they can rename. It's just usability, in my opinion.

At the moment, users can press F2 (only found this in source code) and double-click to rename a rule's title. But, there is no real hint about this. So I thought this button would be helpful, especially for the less techie people.

Feel free to reject it, if you don't agree.