### PR TITLE
WebUI: Make rename file dialog resizable

### DIFF
--- a/src/webui/www/private/rename_file.html
+++ b/src/webui/www/private/rename_file.html
@@ -85,7 +85,7 @@
 <body>
     <div style="padding: 10px 10px 0px 10px;">
         <p style="font-weight: bold;">QBT_TR(New name:)QBT_TR[CONTEXT=TorrentContentTreeView]</p>
-        <input type="text" id="rename" style="width: 220px;" />
+        <input type="text" id="rename" style="width: 99%;" />
         <div style="text-align: center; padding-top: 10px;">
             <input type="button" value="QBT_TR(Save)QBT_TR[CONTEXT=HttpServer]" id="renameButton" />
         </div>

--- a/src/webui/www/private/scripts/prop-files.js
+++ b/src/webui/www/private/scripts/prop-files.js
@@ -561,11 +561,11 @@ window.qBittorrent.PropFiles = (function() {
                     contentURL: 'rename_file.html?hash=' + hash + '&isFolder=' + node.isFolder
                         + '&path=' + encodeURIComponent(path),
                     scrollbars: false,
-                    resizable: false,
+                    resizable: true,
                     maximizable: false,
                     paddingVertical: 0,
                     paddingHorizontal: 0,
-                    width: 250,
+                    width: 400,
                     height: 100
                 });
             },


### PR DESCRIPTION
* WebUI: Make rename file dialog resizable
  And enlarge dialog default width.

inline with https://github.com/qbittorrent/qBittorrent/pull/16784