### PR TITLE
[API] get endpoint returns same data as info, for a single torrent (closes #18185)

### DIFF
--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -1418,3 +1418,15 @@ void TorrentsController::exportAction()
 
     setResult(result.value());
 }
+
+void TorrentsController::getAction()
+{
+    requireParams({u"hash"_qs});
+
+    const auto id = BitTorrent::TorrentID::fromString(params()[u"hash"_qs]);
+    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(id);
+    if (!torrent)
+        throw APIError(APIErrorType::NotFound);
+
+    setResult(QJsonObject::fromVariantMap(serialize(*torrent)));
+}

--- a/src/webui/api/torrentscontroller.h
+++ b/src/webui/api/torrentscontroller.h
@@ -88,4 +88,5 @@ private slots:
     void renameFileAction();
     void renameFolderAction();
     void exportAction();
+    void getAction();
 };


### PR DESCRIPTION
This PR introduces a new endpoint which reuses torrent serialization code to serialize a single torrent. It returns the same data as info endpoint, but for a single torrent. Ideally, properties endpoint would do just that, but that would break backwards-compatibility. This may be reconsidered in an APIv3.

This is useful because without it, API clients need two different data models/structures to interact with API depending on if they call info or properties endpoint. This PR allows API clients to define a single data structure used for both info and get endpoints, where info returns a list of such structures.

The endpoint is called 'get' but we could be renamed to 'singleinfo' or something like that.

I did not run tests due to cmake shenanigans.