### PR TITLE
Allow sorting in trackerslistwidget (Trackers tab)

### DIFF
--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -82,6 +82,9 @@ TrackerListWidget::TrackerListWidget(PropertiesWidget *properties)
     for (int i = 0; i < COL_COUNT; ++i)
         if ((columnWidth(i) <= 0) && !isColumnHidden(i))
             resizeColumnToContents(i);
+    // Allow sort by column
+    for (int i = 0; i < COL_COUNT; ++i)
+        setSortingEnabled(i);
     // Context menu
     setContextMenuPolicy(Qt::CustomContextMenu);
     connect(this, &QWidget::customContextMenuRequested, this, &TrackerListWidget::showTrackerListMenu);


### PR DESCRIPTION
Please don't shoot me.
Very simple change, to allow sorting via columns.

This PR simply enables sorting for columns in the Tracker view. When you click a torrent, and then Tracker on bottom. That's it. I tested it, it works totally fine. To me it feels fine, but let me know what you think.

Inspired by https://qbforums.shiki.hu/viewtopic.php?p=40061
