### PR TITLE
WebUI: Prevent incorrect line breaking in properties panel

### DIFF
--- a/src/webui/www/private/views/properties.html
+++ b/src/webui/www/private/views/properties.html
@@ -1,7 +1,7 @@
 <div id="prop_general" class="propertiesTabContent">
     <table style="width: 100%; padding: 0 3px">
         <tr>
-            <td style="text-align: right">QBT_TR(Progress:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+            <td style="text-align: right; white-space: nowrap">QBT_TR(Progress:)QBT_TR[CONTEXT=PropertiesWidget]</td>
             <td id="progress" style="width: 100%"></td>
         </tr>
     </table>


### PR DESCRIPTION
This addresses an issue that the "Progress:" hint text is broken into several lines when using certain languages (e.g. `ja`, `zh-CN`, `zh-HK` and `zh-TW`).

* Current as in `en`
  ![图片](https://user-images.githubusercontent.com/24728204/208156245-775d5e62-8c04-441a-b01e-5f4f2f02249a.png)
* Current as in `zh-CN`
![图片](https://user-images.githubusercontent.com/24728204/208155968-d4576084-44e6-4cad-ac1e-c1938117e1d6.png)
* Expected as in `zh-CN`
![图片](https://user-images.githubusercontent.com/24728204/208156074-d226376c-ebbb-47a0-83d3-1de85611f435.png)
