### PR TITLE
Move state icon to "Status" column

### DIFF
--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -556,7 +556,7 @@ QVariant TransferListModel::data(const QModelIndex &index, const int role) const
     case AdditionalUnderlyingDataRole:
         return internalValue(torrent, index.column(), true);
     case Qt::DecorationRole:
-        if (index.column() == TR_NAME)
+        if (index.column() == TR_STATUS)
             return getIconByState(torrent->state());
         break;
     case Qt::ToolTipRole:


### PR DESCRIPTION
- closes #18193 as requested, I moved icon from name column to status column.

<h2>Screenshot </h2>

![Screenshot from 2022-12-17 13-11-06](https://user-images.githubusercontent.com/39624400/208238212-790d1e26-16ff-49a4-a262-a3c556f173ad.png)

