### PR TITLE
Improve startup window state handling

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -96,6 +96,7 @@
 #include "gui/shutdownconfirmdialog.h"
 #include "gui/uithememanager.h"
 #include "gui/utils.h"
+#include "gui/windowstate.h"
 #endif // DISABLE_GUI
 
 #ifndef DISABLE_WEBUI
@@ -138,6 +139,7 @@ Application::Application(int &argc, char **argv)
     , m_processMemoryPriority(SETTINGS_KEY(u"ProcessMemoryPriority"_qs))
 #endif
 #ifndef DISABLE_GUI
+    , m_startUpWindowState(u"GUI/StartUpWindowState"_qs)
     , m_storeNotificationTorrentAdded(NOTIFICATIONS_SETTINGS_KEY(u"TorrentAdded"_qs))
 #endif
 {
@@ -220,6 +222,16 @@ DesktopIntegration *Application::desktopIntegration()
 MainWindow *Application::mainWindow()
 {
     return m_window;
+}
+
+WindowState Application::startUpWindowState() const
+{
+    return m_startUpWindowState;
+}
+
+void Application::setStartUpWindowState(const WindowState windowState)
+{
+    m_startUpWindowState = windowState;
 }
 
 bool Application::isTorrentAddedNotificationsEnabled() const
@@ -721,11 +733,8 @@ try
     desktopIntegrationMenu->addAction(actionExit);
 
     m_desktopIntegration->setMenu(desktopIntegrationMenu);
-#endif
 
-    const auto *pref = Preferences::instance();
-#ifndef Q_OS_MACOS
-    const bool isHidden = m_desktopIntegration->isActive() && pref->startMinimized() && pref->minimizeToTray();
+    const bool isHidden = m_desktopIntegration->isActive() && (startUpWindowState() == WindowState::Hidden);
 #else
     const bool isHidden = false;
 #endif
@@ -735,7 +744,7 @@ try
         createStartupProgressDialog();
         // Add a small delay to avoid "flashing" the progress dialog in case there are not many torrents to restore.
         m_startupProgressDialog->setMinimumDuration(1000);
-        if (pref->startMinimized())
+        if (startUpWindowState() != WindowState::Normal)
             m_startupProgressDialog->setWindowState(Qt::WindowMinimized);
     }
     else
@@ -790,8 +799,14 @@ try
         disconnect(m_desktopIntegration, &DesktopIntegration::activationRequested, this, &Application::createStartupProgressDialog);
         // we must not delete menu while it is used by DesktopIntegration
         auto *oldMenu = m_desktopIntegration->menu();
-        const MainWindow::State windowState = (!m_startupProgressDialog || (m_startupProgressDialog->windowState() & Qt::WindowMinimized))
-                ? MainWindow::Minimized : MainWindow::Normal;
+#ifndef Q_OS_MACOS
+        const WindowState windowState = !m_startupProgressDialog ? WindowState::Hidden
+                : (m_startupProgressDialog->windowState() & Qt::WindowMinimized) ? WindowState::Minimized
+                        : WindowState::Normal;
+#else
+        const WindowState windowState = (m_startupProgressDialog->windowState() & Qt::WindowMinimized)
+                ? WindowState::Minimized : WindowState::Normal;
+#endif
         m_window = new MainWindow(this, windowState);
         delete oldMenu;
         delete m_startupProgressDialog;

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -130,6 +130,9 @@ public:
     DesktopIntegration *desktopIntegration() override;
     MainWindow *mainWindow() override;
 
+    WindowState startUpWindowState() const override;
+    void setStartUpWindowState(WindowState windowState) override;
+
     bool isTorrentAddedNotificationsEnabled() const override;
     void setTorrentAddedNotificationsEnabled(bool value) override;
 #endif
@@ -203,6 +206,7 @@ private:
 #endif
 
 #ifndef DISABLE_GUI
+    SettingValue<WindowState> m_startUpWindowState;
     SettingValue<bool> m_storeNotificationTorrentAdded;
 
     DesktopIntegration *m_desktopIntegration = nullptr;

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -279,16 +279,6 @@ void Preferences::setStatusbarDisplayed(const bool displayed)
     setValue(u"Preferences/General/StatusbarDisplayed"_qs, displayed);
 }
 
-bool Preferences::startMinimized() const
-{
-    return value(u"Preferences/General/StartMinimized"_qs, false);
-}
-
-void Preferences::setStartMinimized(const bool b)
-{
-    setValue(u"Preferences/General/StartMinimized"_qs, b);
-}
-
 bool Preferences::isSplashScreenDisabled() const
 {
     return value(u"Preferences/General/NoSplashScreen"_qs, true);

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -121,8 +121,6 @@ public:
     void setStatusbarDisplayed(bool displayed);
     bool isToolbarDisplayed() const;
     void setToolbarDisplayed(bool displayed);
-    bool startMinimized() const;
-    void setStartMinimized(bool b);
     bool isSplashScreenDisabled() const;
     void setSplashScreenDisabled(bool b);
     bool preventFromSuspendWhenDownloading() const;

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -125,6 +125,7 @@ add_library(qbt_gui STATIC
     utils.h
     watchedfolderoptionsdialog.h
     watchedfoldersmodel.h
+    windowstate.h
 
     # sources
     aboutdialog.cpp

--- a/src/gui/desktopintegration.cpp
+++ b/src/gui/desktopintegration.cpp
@@ -104,7 +104,7 @@ bool DesktopIntegration::isActive() const
 #ifdef Q_OS_MACOS
     return true;
 #else
-    return QSystemTrayIcon::isSystemTrayAvailable();
+    return m_systrayIcon && QSystemTrayIcon::isSystemTrayAvailable();
 #endif
 }
 

--- a/src/gui/gui.pri
+++ b/src/gui/gui.pri
@@ -83,7 +83,8 @@ HEADERS += \
     $$PWD/uithememanager.h \
     $$PWD/utils.h \
     $$PWD/watchedfolderoptionsdialog.h \
-    $$PWD/watchedfoldersmodel.h
+    $$PWD/watchedfoldersmodel.h \
+    $$PWD/windowstate.h
 
 SOURCES += \
     $$PWD/aboutdialog.cpp \

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1,5 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2022  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
@@ -115,7 +116,7 @@ namespace
     }
 }
 
-MainWindow::MainWindow(IGUIApplication *app, const State initialState)
+MainWindow::MainWindow(IGUIApplication *app, WindowState initialState)
     : GUIApplicationComponent(app)
     , m_ui(new Ui::MainWindow)
     , m_storeExecutionLogEnabled(EXECUTIONLOG_SETTINGS_KEY(u"Enabled"_qs))
@@ -375,27 +376,27 @@ MainWindow::MainWindow(IGUIApplication *app, const State initialState)
     });
 
 #ifdef Q_OS_MACOS
-    // Make sure the Window is visible if we don't have a tray icon
-    if (initialState == Minimized)
-    {
-        showMinimized();
-    }
-    else
+    if (initialState == WindowState::Normal)
     {
         show();
         activateWindow();
         raise();
     }
+    else
+    {
+        // Make sure the Window is visible if we don't have a tray icon
+        showMinimized();
+    }
 #else
     if (app->desktopIntegration()->isActive())
     {
-        if ((initialState != Minimized) && !m_uiLocked)
+        if ((initialState == WindowState::Normal) && !m_uiLocked)
         {
             show();
             activateWindow();
             raise();
         }
-        else if (initialState == Minimized)
+        else if (initialState == WindowState::Minimized)
         {
             showMinimized();
             if (pref->minimizeToTray())
@@ -412,7 +413,7 @@ MainWindow::MainWindow(IGUIApplication *app, const State initialState)
     else
     {
         // Make sure the Window is visible if we don't have a tray icon
-        if (initialState == Minimized)
+        if (initialState != WindowState::Normal)
         {
             showMinimized();
         }

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -1,5 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2022  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
@@ -35,6 +36,7 @@
 #include "base/logger.h"
 #include "base/settingvalue.h"
 #include "guiapplicationcomponent.h"
+#include "windowstate.h"
 
 class QCloseEvent;
 class QFileSystemWatcher;
@@ -74,13 +76,7 @@ class MainWindow final : public QMainWindow, public GUIApplicationComponent
     Q_DISABLE_COPY_MOVE(MainWindow)
 
 public:
-    enum State
-    {
-        Normal,
-        Minimized
-    };
-
-    explicit MainWindow(IGUIApplication *app, State initialState = Normal);
+    explicit MainWindow(IGUIApplication *app, WindowState initialState = WindowState::Normal);
     ~MainWindow() override;
 
     QWidget *currentTabWidget() const;

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -319,9 +319,15 @@ void OptionsDialog::loadBehaviorTabOptions()
     m_ui->checkStartup->setVisible(false);
 #endif
     m_ui->checkShowSplash->setChecked(!pref->isSplashScreenDisabled());
-    m_ui->checkStartMinimized->setChecked(pref->startMinimized());
     m_ui->checkProgramExitConfirm->setChecked(pref->confirmOnExit());
     m_ui->checkProgramAutoExitConfirm->setChecked(!pref->dontConfirmAutoExit());
+
+    m_ui->windowStateComboBox->addItem(tr("Normal"), QVariant::fromValue(WindowState::Normal));
+    m_ui->windowStateComboBox->addItem(tr("Minimized"), QVariant::fromValue(WindowState::Minimized));
+#ifndef Q_OS_MACOS
+    m_ui->windowStateComboBox->addItem(tr("Hidden"), QVariant::fromValue(WindowState::Hidden));
+#endif
+    m_ui->windowStateComboBox->setCurrentIndex(m_ui->windowStateComboBox->findData(QVariant::fromValue(app()->startUpWindowState())));
 
 #if !(defined(Q_OS_WIN) || defined(Q_OS_MACOS))
     m_ui->groupFileAssociation->setVisible(false);
@@ -397,13 +403,13 @@ void OptionsDialog::loadBehaviorTabOptions()
     connect(m_ui->checkStartup, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
 #endif
     connect(m_ui->checkShowSplash, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
-    connect(m_ui->checkStartMinimized, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkProgramExitConfirm, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkProgramAutoExitConfirm, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkShowSystray, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkMinimizeToSysTray, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkCloseToSystray, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->comboTrayIcon, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
+    connect(m_ui->windowStateComboBox, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
 
     connect(m_ui->checkPreventFromSuspendWhenDownloading, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkPreventFromSuspendWhenSeeding, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
@@ -463,7 +469,6 @@ void OptionsDialog::saveBehaviorTabOptions() const
     pref->setActionOnDblClOnTorrentFn(m_ui->actionTorrentFnOnDblClBox->currentData().toInt());
 
     pref->setSplashScreenDisabled(isSplashScreenDisabled());
-    pref->setStartMinimized(startMinimized());
     pref->setConfirmOnExit(m_ui->checkProgramExitConfirm->isChecked());
     pref->setDontConfirmAutoExit(!m_ui->checkProgramAutoExitConfirm->isChecked());
 
@@ -510,6 +515,8 @@ void OptionsDialog::saveBehaviorTabOptions() const
     app()->setFileLoggerAgeType(m_ui->comboFileLogAgeType->currentIndex());
     app()->setFileLoggerDeleteOld(m_ui->checkFileLogDelete->isChecked());
     app()->setFileLoggerEnabled(m_ui->checkFileLog->isChecked());
+
+    app()->setStartUpWindowState(m_ui->windowStateComboBox->currentData().value<WindowState>());
 
     session->setPerformanceWarningEnabled(m_ui->checkBoxPerformanceWarning->isChecked());
 }
@@ -1458,11 +1465,6 @@ bool OptionsDialog::isLSDEnabled() const
 bool OptionsDialog::isUPnPEnabled() const
 {
     return m_ui->checkUPnP->isChecked();
-}
-
-bool OptionsDialog::startMinimized() const
-{
-    return m_ui->checkStartMinimized->isChecked();
 }
 
 // Return Share ratio

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -143,7 +143,6 @@ private:
     // General options
     void initializeLanguageCombo();
     QString getLocale() const;
-    bool startMinimized() const;
     bool isSplashScreenDisabled() const;
 #ifdef Q_OS_WIN
     bool WinStartup() const;

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -397,14 +397,35 @@
                 </widget>
                </item>
                <item>
-                <widget class="QCheckBox" name="checkStartMinimized">
-                 <property name="toolTip">
-                  <string>When qBittorrent is started, the main window will be minimized</string>
-                 </property>
-                 <property name="text">
-                  <string>Start qBittorrent minimized</string>
-                 </property>
-                </widget>
+                <layout class="QHBoxLayout" name="windowStateLayout">
+                 <item>
+                  <widget class="QLabel" name="windowStateLabel">
+                   <property name="text">
+                    <string>Window state on start up:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="windowStateComboBox">
+                   <property name="toolTip">
+                    <string>qBittorrent window state on start up</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="windowStateSpacer">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
                </item>
                <item>
                 <widget class="QCheckBox" name="checkProgramExitConfirm">
@@ -3633,7 +3654,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
   <tabstop>actionTorrentFnOnDblClBox</tabstop>
   <tabstop>checkStartup</tabstop>
   <tabstop>checkShowSplash</tabstop>
-  <tabstop>checkStartMinimized</tabstop>
+  <tabstop>windowStateComboBox</tabstop>
   <tabstop>checkProgramExitConfirm</tabstop>
   <tabstop>checkShowSystray</tabstop>
   <tabstop>checkMinimizeToSysTray</tabstop>

--- a/src/gui/windowstate.h
+++ b/src/gui/windowstate.h
@@ -1,8 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2022  Mike Tzou (Chocobo1)
- * Copyright (C) 2015-2022  Vladimir Golovnev <glassez@yandex.ru>
- * Copyright (C) 2006  Christophe Dumez
+ * Copyright (C) 2022  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -30,23 +28,19 @@
 
 #pragma once
 
-#include "base/interfaces/iapplication.h"
-#include "gui/windowstate.h"
+#include <QMetaObject>
 
-class DesktopIntegration;
-class MainWindow;
-
-class IGUIApplication : public IApplication
+inline namespace WindowStateNS
 {
-public:
-    virtual ~IGUIApplication() = default;
+    Q_NAMESPACE
 
-    virtual DesktopIntegration *desktopIntegration() = 0;
-    virtual MainWindow *mainWindow() = 0;
-
-    virtual WindowState startUpWindowState() const = 0;
-    virtual void setStartUpWindowState(WindowState windowState) = 0;
-
-    virtual bool isTorrentAddedNotificationsEnabled() const = 0;
-    virtual void setTorrentAddedNotificationsEnabled(bool value) = 0;
-};
+    enum class WindowState
+    {
+        Normal,
+        Minimized,
+#ifndef Q_OS_MACOS
+        Hidden
+#endif
+    };
+    Q_ENUM_NS(WindowState);
+}


### PR DESCRIPTION
Replace current "Start qBittorrent minimized" option with "Initial window state" that allows to start qBittorrent as "hidden in system tray" while retaining regular "minimize to panel" functionality.

![windowstate](https://user-images.githubusercontent.com/5063477/208372277-e3cf7ba9-3851-45b7-8c76-9f470830917b.png)


Closes #487.
