### PR TITLE
Apply correct tab order to Category options dialog

### DIFF
--- a/src/gui/torrentcategorydialog.cpp
+++ b/src/gui/torrentcategorydialog.cpp
@@ -133,6 +133,9 @@ QString TorrentCategoryDialog::categoryName() const
 void TorrentCategoryDialog::setCategoryName(const QString &categoryName)
 {
     m_ui->textCategoryName->setText(categoryName);
+
+    const int subcategoryNameStart = categoryName.lastIndexOf(u"/") + 1;
+    m_ui->textCategoryName->setSelection(subcategoryNameStart, (categoryName.size() - subcategoryNameStart));
 }
 
 BitTorrent::CategoryOptions TorrentCategoryDialog::categoryOptions() const

--- a/src/gui/torrentcategorydialog.ui
+++ b/src/gui/torrentcategorydialog.ui
@@ -29,13 +29,10 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="1" column="1">
-      <widget class="FileSystemPathComboEdit" name="comboSavePath" native="true">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
+     <item row="0" column="0">
+      <widget class="QLabel" name="labelCategoryName">
+       <property name="text">
+        <string>Name:</string>
        </property>
       </widget>
      </item>
@@ -49,10 +46,13 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="labelCategoryName">
-       <property name="text">
-        <string>Name:</string>
+     <item row="1" column="1">
+      <widget class="FileSystemPathComboEdit" name="comboSavePath" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
       </widget>
      </item>
@@ -173,6 +173,12 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>textCategoryName</tabstop>
+  <tabstop>comboSavePath</tabstop>
+  <tabstop>comboUseDownloadPath</tabstop>
+  <tabstop>comboDownloadPath</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
Also pre-select (sub)category name for editing when dialog is opened for creating new (sub)category.

Closes #18265.