### PR TITLE
Allow to hide individual Status filter items

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -143,7 +143,13 @@ Application::Application(int &argc, char **argv)
 {
     qRegisterMetaType<Log::Msg>("Log::Msg");
     qRegisterMetaType<Log::Peer>("Log::Peer");
+#ifndef DISABLE_GUI
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     qRegisterMetaTypeStreamOperators<QList<Qt::CheckState>>("QList<Qt::CheckState>");
+#else
+    qRegisterMetaType<QList<Qt::CheckState>>("QList<Qt::CheckState>");
+#endif
+#endif
     setApplicationName(u"qBittorrent"_qs);
     setOrganizationDomain(u"qbittorrent.org"_qs);
 #if !defined(DISABLE_GUI)

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -143,7 +143,7 @@ Application::Application(int &argc, char **argv)
 {
     qRegisterMetaType<Log::Msg>("Log::Msg");
     qRegisterMetaType<Log::Peer>("Log::Peer");
-
+    qRegisterMetaTypeStreamOperators<QList<Qt::CheckState>>("QList<Qt::CheckState>");
     setApplicationName(u"qBittorrent"_qs);
     setOrganizationDomain(u"qbittorrent.org"_qs);
 #if !defined(DISABLE_GUI)

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -1643,3 +1643,14 @@ void Preferences::apply()
     if (SettingsStorage::instance()->save())
         emit changed();
 }
+
+QList<Qt::CheckState> Preferences::getIndividualStatusFilterState() const
+{   
+    QList<Qt::CheckState> individualStates{Qt::Checked,Qt::Checked,Qt::Checked,Qt::Checked,Qt::Checked,Qt::Checked,Qt::Checked,Qt::Checked,Qt::Checked,Qt::Checked,Qt::Checked,Qt::Checked,Qt::Checked,Qt::Checked};
+    return value(u"TransferListFilters/individualStatusFilterState"_qs, individualStates);
+}
+
+void Preferences::setIndividualStatusFilterState( QList<Qt::CheckState> &individualStates) 
+{
+    setValue(u"TransferListFilters/individualStatusFilterState"_qs, individualStates);
+}

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -1650,7 +1650,7 @@ QList<Qt::CheckState> Preferences::getIndividualStatusFilterState() const
     return value(u"TransferListFilters/individualStatusFilterState"_qs, individualStates);
 }
 
-void Preferences::setIndividualStatusFilterState( QList<Qt::CheckState> &individualStates) 
+void Preferences::setIndividualStatusFilterState( QList<Qt::CheckState> &individualStates)
 {
     setValue(u"TransferListFilters/individualStatusFilterState"_qs, individualStates);
 }

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -1645,7 +1645,7 @@ void Preferences::apply()
 }
 
 QList<Qt::CheckState> Preferences::getIndividualStatusFilterState() const
-{   
+{
     QList<Qt::CheckState> individualStates{Qt::Checked,Qt::Checked,Qt::Checked,Qt::Checked,Qt::Checked,Qt::Checked,Qt::Checked,Qt::Checked,Qt::Checked,Qt::Checked,Qt::Checked,Qt::Checked,Qt::Checked,Qt::Checked};
     return value(u"TransferListFilters/individualStatusFilterState"_qs, individualStates);
 }

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -373,6 +373,8 @@ public:
     QByteArray getTorImportGeometry() const;
     void setTorImportGeometry(const QByteArray &geometry);
     bool getStatusFilterState() const;
+    QList<Qt::CheckState> getIndividualStatusFilterState() const;
+    void setIndividualStatusFilterState( QList<Qt::CheckState> &individialStates);
     bool getCategoryFilterState() const;
     bool getTagFilterState() const;
     bool getTrackerFilterState() const;

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -389,7 +389,7 @@ void StatusFilterWidget::torrentAboutToBeDeleted(BitTorrent::Torrent *const torr
 }
 
 QSize StatusFilterWidget::sizeHint() const
-{   
+{
     return QSize(m_nbIndividualStatusNotHidden*INDIVIDUAL_STATUS_HEIGHT, m_nbIndividualStatusNotHidden*INDIVIDUAL_STATUS_HEIGHT);
 }
 
@@ -972,7 +972,7 @@ void TransferListFiltersWidget::toggleTagFilter(bool enabled)
 }
 
 void TransferListFiltersWidget::showMenu()
-{   
+{
     QMenu *menu = new QMenu(this);
 
     QCheckBox *checkBoxAll = new QCheckBox(menu);
@@ -1082,7 +1082,7 @@ void TransferListFiltersWidget::showMenu()
 }
 
 void TransferListFiltersWidget::updateStatus(int state)
-{   
+{
     Preferences *const pref = Preferences::instance();
     QList<Qt::CheckState> individualStatusFilter = pref->getIndividualStatusFilterState();
     auto checkBox = static_cast<QCheckBox*>(sender());
@@ -1090,15 +1090,14 @@ void TransferListFiltersWidget::updateStatus(int state)
     if(state == Qt::Unchecked)
     {
          m_statusFilters->setIndividualStatusNotHidden(m_statusFilters->getIndividualStatusNotHidden() - 1 );
-        items.first()->setHidden(true);  
-    }  
+        items.first()->setHidden(true);
+    }
     else
     {
         m_statusFilters->setIndividualStatusNotHidden(m_statusFilters->getIndividualStatusNotHidden() + 1);
         items.first()->setHidden(false);
-    }        
+    }
     m_statusFilters->updateGeometry();
     individualStatusFilter[m_statusFilters->row(items.first())] = (static_cast<Qt::CheckState>(state));
     pref->setIndividualStatusFilterState(individualStatusFilter);
 }
-

--- a/src/gui/transferlistfilterswidget.h
+++ b/src/gui/transferlistfilterswidget.h
@@ -85,6 +85,16 @@ class StatusFilterWidget final : public BaseFilterWidget
 public:
     StatusFilterWidget(QWidget *parent, TransferListWidget *transferList);
     ~StatusFilterWidget() override;
+    QSize sizeHint() const override;
+    int getIndividualStatusNotHidden() const
+    {
+        return m_nbIndividualStatusNotHidden;
+    }
+
+    void setIndividualStatusNotHidden(int individualStatusNotHidden)
+    {
+        m_nbIndividualStatusNotHidden = individualStatusNotHidden;
+    }
 
 private slots:
     void handleTorrentsUpdated(const QVector<BitTorrent::Torrent *> torrents);
@@ -100,6 +110,7 @@ private:
     void populate();
     void updateTorrentStatus(const BitTorrent::Torrent *torrent);
     void updateTexts();
+    void updateVisibility();
 
     using TorrentFilterBitset = std::bitset<32>;  // approximated size, this should be the number of TorrentFilter::Type elements
     QHash<const BitTorrent::Torrent *, TorrentFilterBitset> m_torrentsStatus;
@@ -116,6 +127,7 @@ private:
     int m_nbChecking = 0;
     int m_nbMoving = 0;
     int m_nbErrored = 0;
+    int m_nbIndividualStatusNotHidden;
 };
 
 class TrackerFiltersList final : public BaseFilterWidget
@@ -187,6 +199,8 @@ public slots:
 private slots:
     void onCategoryFilterStateChanged(bool enabled);
     void onTagFilterStateChanged(bool enabled);
+    void showMenu();
+    void updateStatus(int state);
 
 private:
     void toggleCategoryFilter(bool enabled);
@@ -196,4 +210,5 @@ private:
     TrackerFiltersList *m_trackerFilters = nullptr;
     CategoryFilterWidget *m_categoryFilterWidget = nullptr;
     TagFilterWidget *m_tagFilterWidget = nullptr;
+    StatusFilterWidget *m_statusFilters = nullptr;
 };


### PR DESCRIPTION
Closes #18082
Qwidget-> UpdateGeometry does not work on hidden widgets, so sizeHint method of QWidget is overrided in StatusFilterWidget. In sizeHint method, constant 20 is used because QWidgetListItem->sizeHint().height returns -1.

## Screnshot
![Screenshot from 2022-12-22 21-32-25](https://user-images.githubusercontent.com/39624400/209203152-e99341b8-d290-437b-ab8c-2792062b6400.png)
