### PR TITLE
WebUI: disable "auto complete" for torrent search input

### DIFF
--- a/src/webui/www/private/views/search.html
+++ b/src/webui/www/private/views/search.html
@@ -80,7 +80,7 @@
 <div id="searchResults">
     <div style="overflow: hidden; height: 70px;">
         <div style="margin: 20px 0; height: 30px;">
-            <input type="text" id="searchPattern" class="searchInputField" placeholder="QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]" autocorrect="off" autocapitalize="none" />
+            <input type="text" id="searchPattern" class="searchInputField" placeholder="QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]" autocorrect="off" autocomplete="off" autocapitalize="none" />
             <select id="categorySelect" class="searchInputField" onchange="qBittorrent.Search.categorySelected()"></select>
             <select id="pluginsSelect" class="searchInputField" onchange="qBittorrent.Search.pluginSelected()"></select>
             <button id="startSearchButton" class="searchInputField" onclick="qBittorrent.Search.startStopSearch()">QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]</button>


### PR DESCRIPTION
Added autocomplete="off"  for the search input box. 
Don't want torrent search history to pop up next time you try to search for torrents.. right? 
There are people who would search for 18+ content and what they searched would load up next time they are about to search.