### PR TITLE
WebUI: change order of accepted types of file input

### DIFF
--- a/src/webui/www/private/upload.html
+++ b/src/webui/www/private/upload.html
@@ -14,7 +14,7 @@
     <iframe id="upload_frame" name="upload_frame" class="invisible" src="about:blank"></iframe>
     <form action="api/v2/torrents/add" enctype="multipart/form-data" method="post" id="uploadForm" style="text-align: center;" target="upload_frame" autocorrect="off" autocapitalize="none">
         <div style="margin-top: 25px; display: inline-block; border: 1px solid lightgrey; border-radius: 4px;">
-            <input type="file" id="fileselect" accept="application/x-bittorrent, .torrent" name="fileselect[]" multiple />
+            <input type="file" id="fileselect" accept=".torrent, application/x-bittorrent" name="fileselect[]" multiple />
         </div>
         <fieldset class="settings" style="border: 0; text-align: left; margin-top: 12px;">
             <table style="margin: auto;">


### PR DESCRIPTION
On iOS (Chrome/Safari/Firefox) the existing file upload page uses a input file type with an `accept` attribute of `application/x-bittorrent, .torrent` does not allow the user to click any BitTorrent or `.torrent` files.  Swapping the order retains the existing functionality of selecting BitTorrent and .torrent files on other platforms but also allows iOS users to upload torrent files.