### PR TITLE
Fix startup performance on Qt5

### DIFF
--- a/src/base/bittorrent/resumedatastorage.cpp
+++ b/src/base/bittorrent/resumedatastorage.cpp
@@ -33,6 +33,7 @@
 #include <QMetaObject>
 #include <QMutexLocker>
 #include <QThread>
+#include <QVector>
 
 const int TORRENTIDLIST_TYPEID = qRegisterMetaType<QVector<BitTorrent::TorrentID>>();
 
@@ -59,11 +60,11 @@ void BitTorrent::ResumeDataStorage::loadAll() const
     loadingThread->start();
 }
 
-QVector<BitTorrent::LoadedResumeData> BitTorrent::ResumeDataStorage::fetchLoadedResumeData() const
+QList<BitTorrent::LoadedResumeData> BitTorrent::ResumeDataStorage::fetchLoadedResumeData() const
 {
     const QMutexLocker locker {&m_loadedResumeDataMutex};
 
-    const QVector<BitTorrent::LoadedResumeData> loadedResumeData = m_loadedResumeData;
+    const QList<BitTorrent::LoadedResumeData> loadedResumeData = m_loadedResumeData;
     m_loadedResumeData.clear();
 
     return loadedResumeData;

--- a/src/base/bittorrent/resumedatastorage.h
+++ b/src/base/bittorrent/resumedatastorage.h
@@ -29,9 +29,9 @@
 #pragma once
 
 #include <QtContainerFwd>
+#include <QList>
 #include <QMutex>
 #include <QObject>
-#include <QVector>
 
 #include "base/3rdparty/expected.hpp"
 #include "base/path.h"
@@ -65,7 +65,7 @@ namespace BitTorrent
         virtual void storeQueue(const QVector<TorrentID> &queue) const = 0;
 
         void loadAll() const;
-        QVector<LoadedResumeData> fetchLoadedResumeData() const;
+        QList<LoadedResumeData> fetchLoadedResumeData() const;
 
     signals:
         void loadStarted(const QVector<BitTorrent::TorrentID> &torrents);
@@ -78,7 +78,7 @@ namespace BitTorrent
         virtual void doLoadAll() const = 0;
 
         const Path m_path;
-        mutable QVector<LoadedResumeData> m_loadedResumeData;
+        mutable QList<LoadedResumeData> m_loadedResumeData;
         mutable QMutex m_loadedResumeDataMutex;
     };
 }

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -340,7 +340,7 @@ struct BitTorrent::SessionImpl::ResumeSessionContext final : public QObject
 
     ResumeDataStorage *startupStorage = nullptr;
     ResumeDataStorageType currentStorageType = ResumeDataStorageType::Legacy;
-    QVector<LoadedResumeData> loadedResumeData;
+    QList<LoadedResumeData> loadedResumeData;
     int processingResumeDataCount = 0;
     int64_t totalResumeDataCount = 0;
     int64_t finishedResumeDataCount = 0;


### PR DESCRIPTION
Use more appropriate container (`QList`) for resume data queue buffer. `QVector` in Qt5 has poor performance of the first element taking operation, which is used to process the resume data queue. In Qt6, `QVector` is just an alias for `QList`, so there was no problem there.

Fixes #18341.