### PR TITLE
Restart qbittorrent-nox daemon on failure

### DIFF
--- a/dist/unix/systemd/qbittorrent-nox@.service.in
+++ b/dist/unix/systemd/qbittorrent-nox@.service.in
@@ -10,6 +10,8 @@ PrivateTmp=false
 User=%i
 ExecStart=@EXPAND_BINDIR@/qbittorrent-nox
 TimeoutStopSec=1800
+Restart=on-failure
+RestartSec=1
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The download and seeding will pause whenever qbittorrent-nox crashes sometimes and users cannot be aware of that. It would be useful to restart the daemon whenever it crashes.