### PR TITLE
Drop extra semicolon

### DIFF
--- a/src/gui/windowstate.h
+++ b/src/gui/windowstate.h
@@ -42,5 +42,5 @@ inline namespace WindowStateNS
         Hidden
 #endif
     };
-    Q_ENUM_NS(WindowState);
+    Q_ENUM_NS(WindowState)
 }


### PR DESCRIPTION
Fixes build with '-pedantic' flag.

GCC 10 on Debian 11 seems to be more stricter than GCC 12 regarding '-pedantic -pedantic-errors' compiler flags, so extra ';' (because another one is hidden in macro) leads to build error.

```
[  473s] ../src/gui/windowstate.h:45:27: error: extra ‘;’ [-Wpedantic]
[  473s]    45 |     Q_ENUM_NS(WindowState);
[  473s]       |                           ^
```

Strange, GCC 12 with the same options set doesn't produce even warning.

fixup 32e437120823120e233ea589c3901cfc9b528f82

detected on ci building nightly packages for Debian, all builds for Debian 11 failed regardless of target architecture.

full command line:
```
[  473s] FAILED: src/gui/CMakeFiles/qbt_gui.dir/advancedsettings.cpp.o 
[  473s] /usr/bin/c++ -DBOOST_ALL_NO_LIB -DBOOST_ASIO_ENABLE_CANCELIO -DBOOST_ASIO_NO_DEPRECATED -DOPENSSL_NO_SSL2 -DQBT_USES_LIBTORRENT2 -DQT_CORE_LIB -DQT_DBUS_LIB -DQT_DISABLE_DEPRECATED_BEFORE=0x050f02 -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_FROM_BYTEARRAY -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_NO_DEBUG_OUTPUT -DQT_NO_NARROWING_CONVERSIONS_IN_CONNECT -DQT_SQL_LIB -DQT_STRICT_ITERATORS -DQT_USE_QSTRINGBUILDER -DQT_WIDGETS_LIB -DQT_XML_LIB -DTORRENT_LINKING_SHARED -DTORRENT_NO_DEPRECATE -DTORRENT_SSL_PEERS -DTORRENT_USE_LIBCRYPTO -DTORRENT_USE_OPENSSL -Isrc/gui/qbt_gui_autogen/include -I../src -Isrc/gui -isystem /usr/include/x86_64-linux-gnu/qt5 -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore -isystem /usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -isystem /usr/include/x86_64-linux-gnu/qt5/QtNetwork -isystem /usr/include/x86_64-linux-gnu/qt5/QtSql -isystem /usr/include/x86_64-linux-gnu/qt5/QtXml -isystem /usr/include/x86_64-linux-gnu/qt5/QtDBus -isystem /usr/include/x86_64-linux-gnu/qt5/QtGui -isystem /usr/include/x86_64-linux-gnu/qt5/QtWidgets -g -O2 -ffile-prefix-map=/usr/src/packages/BUILD=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fexceptions -fPIC -Wall -Wextra -Wcast-qual -Wcast-align -Winvalid-pch -Woverloaded-virtual -Wold-style-cast -Wnon-virtual-dtor -pedantic -pedantic-errors -Wstrict-null-sentinel -std=c++17 -MD -MT src/gui/CMakeFiles/qbt_gui.dir/advancedsettings.cpp.o -MF src/gui/CMakeFiles/qbt_gui.dir/advancedsettings.cpp.o.d -o src/gui/CMakeFiles/qbt_gui.dir/advancedsettings.cpp.o -c ../src/gui/advancedsettings.cpp
[  473s] In file included from ../src/gui/interfaces/iguiapplication.h:34,
[  473s]                  from ../src/gui/guiapplicationcomponent.h:32,
[  473s]                  from ../src/gui/advancedsettings.h:37,
[  473s]                  from ../src/gui/advancedsettings.cpp:29:
[  473s] ../src/gui/windowstate.h:45:27: error: extra ‘;’ [-Wpedantic]
[  473s]    45 |     Q_ENUM_NS(WindowState);
[  473s]       |                           ^
```
