### PR TITLE
Allow to use another icons in dark mode

### DIFF
--- a/src/gui/log/logmodel.cpp
+++ b/src/gui/log/logmodel.cpp
@@ -32,12 +32,9 @@
 #include <QApplication>
 #include <QDateTime>
 #include <QColor>
-#include <QPalette>
 
 #include "base/global.h"
-#include "gui/color.h"
 #include "gui/uithememanager.h"
-#include "gui/utils.h"
 
 namespace
 {
@@ -45,38 +42,32 @@ namespace
 
     QColor getTimestampColor()
     {
-        return UIThemeManager::instance()->getColor(u"Log.TimeStamp"_qs
-            , (Utils::Gui::isDarkTheme() ? Color::Primer::Dark::fgSubtle : Color::Primer::Light::fgSubtle));
+        return UIThemeManager::instance()->getColor(u"Log.TimeStamp"_qs);
     }
 
     QColor getLogNormalColor()
     {
-        return UIThemeManager::instance()->getColor(u"Log.Normal"_qs
-            , QApplication::palette().color(QPalette::Active, QPalette::WindowText));
+        return UIThemeManager::instance()->getColor(u"Log.Normal"_qs);
     }
 
     QColor getLogInfoColor()
     {
-        return UIThemeManager::instance()->getColor(u"Log.Info"_qs
-            , (Utils::Gui::isDarkTheme() ? Color::Primer::Dark::accentFg : Color::Primer::Light::accentFg));
+        return UIThemeManager::instance()->getColor(u"Log.Info"_qs);
     }
 
     QColor getLogWarningColor()
     {
-        return UIThemeManager::instance()->getColor(u"Log.Warning"_qs
-            , (Utils::Gui::isDarkTheme() ? Color::Primer::Dark::severeFg : Color::Primer::Light::severeFg));
+        return UIThemeManager::instance()->getColor(u"Log.Warning"_qs);
     }
 
     QColor getLogCriticalColor()
     {
-        return UIThemeManager::instance()->getColor(u"Log.Critical"_qs
-            , (Utils::Gui::isDarkTheme() ? Color::Primer::Dark::dangerFg : Color::Primer::Light::dangerFg));
+        return UIThemeManager::instance()->getColor(u"Log.Critical"_qs);
     }
 
     QColor getPeerBannedColor()
     {
-        return UIThemeManager::instance()->getColor(u"Log.BannedPeer"_qs
-            , (Utils::Gui::isDarkTheme() ? Color::Primer::Dark::dangerFg : Color::Primer::Light::dangerFg));
+        return UIThemeManager::instance()->getColor(u"Log.BannedPeer"_qs);
     }
 }
 

--- a/src/gui/rss/articlelistwidget.cpp
+++ b/src/gui/rss/articlelistwidget.cpp
@@ -102,8 +102,7 @@ void ArticleListWidget::handleArticleRead(RSS::Article *rssArticle)
     auto item = mapRSSArticle(rssArticle);
     if (!item) return;
 
-    const QColor defaultColor {palette().color(QPalette::Inactive, QPalette::WindowText)};
-    const QBrush foregroundBrush {UIThemeManager::instance()->getColor(u"RSS.ReadArticle"_qs, defaultColor)};
+    const QBrush foregroundBrush {UIThemeManager::instance()->getColor(u"RSS.ReadArticle"_qs)};
     item->setData(Qt::ForegroundRole, foregroundBrush);
     item->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"loading"_qs, u"sphere"_qs));
 
@@ -130,15 +129,13 @@ QListWidgetItem *ArticleListWidget::createItem(RSS::Article *article) const
     item->setData(Qt::UserRole, QVariant::fromValue(article));
     if (article->isRead())
     {
-        const QColor defaultColor {palette().color(QPalette::Inactive, QPalette::WindowText)};
-        const QBrush foregroundBrush {UIThemeManager::instance()->getColor(u"RSS.ReadArticle"_qs, defaultColor)};
+        const QBrush foregroundBrush {UIThemeManager::instance()->getColor(u"RSS.ReadArticle"_qs)};
         item->setData(Qt::ForegroundRole, foregroundBrush);
         item->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"loading"_qs, u"sphere"_qs));
     }
     else
     {
-        const QColor defaultColor {palette().color(QPalette::Active, QPalette::Link)};
-        const QBrush foregroundBrush {UIThemeManager::instance()->getColor(u"RSS.UnreadArticle"_qs, defaultColor)};
+        const QBrush foregroundBrush {UIThemeManager::instance()->getColor(u"RSS.UnreadArticle"_qs)};
         item->setData(Qt::ForegroundRole, foregroundBrush);
         item->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"loading"_qs, u"sphere"_qs));
     }

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -43,54 +43,10 @@
 #include "base/utils/fs.h"
 #include "base/utils/misc.h"
 #include "base/utils/string.h"
-#include "color.h"
 #include "uithememanager.h"
-#include "utils.h"
 
 namespace
 {
-    QColor getDefaultColorByState(const BitTorrent::TorrentState state)
-    {
-        const bool isDarkTheme = Utils::Gui::isDarkTheme();
-
-        switch (state)
-        {
-        case BitTorrent::TorrentState::Downloading:
-        case BitTorrent::TorrentState::ForcedDownloading:
-        case BitTorrent::TorrentState::DownloadingMetadata:
-        case BitTorrent::TorrentState::ForcedDownloadingMetadata:
-            return (isDarkTheme ? Color::Primer::Dark::successFg : Color::Primer::Light::successFg);
-        case BitTorrent::TorrentState::StalledDownloading:
-            return (isDarkTheme ? Color::Primer::Dark::successEmphasis : Color::Primer::Light::successEmphasis);
-        case BitTorrent::TorrentState::StalledUploading:
-            return (isDarkTheme ? Color::Primer::Dark::accentEmphasis : Color::Primer::Light::accentEmphasis);
-        case BitTorrent::TorrentState::Uploading:
-        case BitTorrent::TorrentState::ForcedUploading:
-            return (isDarkTheme ? Color::Primer::Dark::accentFg : Color::Primer::Light::accentFg);
-        case BitTorrent::TorrentState::PausedDownloading:
-            return (isDarkTheme ? Color::Primer::Dark::fgMuted : Color::Primer::Light::fgMuted);
-        case BitTorrent::TorrentState::PausedUploading:
-            return (isDarkTheme ? Color::Primer::Dark::doneFg : Color::Primer::Light::doneFg);
-        case BitTorrent::TorrentState::QueuedDownloading:
-        case BitTorrent::TorrentState::QueuedUploading:
-            return (isDarkTheme ? Color::Primer::Dark::scaleYellow6 : Color::Primer::Light::scaleYellow6);
-        case BitTorrent::TorrentState::CheckingDownloading:
-        case BitTorrent::TorrentState::CheckingUploading:
-        case BitTorrent::TorrentState::CheckingResumeData:
-        case BitTorrent::TorrentState::Moving:
-            return (isDarkTheme ? Color::Primer::Dark::successFg : Color::Primer::Light::successFg);
-        case BitTorrent::TorrentState::Error:
-        case BitTorrent::TorrentState::MissingFiles:
-        case BitTorrent::TorrentState::Unknown:
-            return (isDarkTheme ? Color::Primer::Dark::dangerFg : Color::Primer::Light::dangerFg);
-        default:
-            Q_ASSERT(false);
-            break;
-        }
-
-        return {};
-    }
-
     QHash<BitTorrent::TorrentState, QColor> torrentStateColorsFromUITheme()
     {
         struct TorrentStateColorDescriptor
@@ -124,9 +80,8 @@ namespace
         QHash<BitTorrent::TorrentState, QColor> colors;
         for (const TorrentStateColorDescriptor &colorDescriptor : colorDescriptors)
         {
-            const QColor themeColor = UIThemeManager::instance()->getColor(colorDescriptor.id, QColor());
-            if (themeColor.isValid())
-                colors.insert(colorDescriptor.state, themeColor);
+            const QColor themeColor = UIThemeManager::instance()->getColor(colorDescriptor.id);
+            colors.insert(colorDescriptor.state, themeColor);
         }
         return colors;
     }
@@ -548,7 +503,7 @@ QVariant TransferListModel::data(const QModelIndex &index, const int role) const
     switch (role)
     {
     case Qt::ForegroundRole:
-        return m_stateThemeColors.value(torrent->state(), getDefaultColorByState(torrent->state()));
+        return m_stateThemeColors.value(torrent->state());
     case Qt::DisplayRole:
         return displayValue(torrent, index.column());
     case UnderlyingDataRole:

--- a/src/gui/uithememanager.h
+++ b/src/gui/uithememanager.h
@@ -1,5 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2023  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2019  Prince Gupta <jagannatharjun11@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
@@ -39,17 +40,23 @@
 
 #include "base/pathfwd.h"
 
+enum class ColorMode
+{
+    Light,
+    Dark
+};
+
 class UIThemeSource
 {
 public:
     virtual ~UIThemeSource() = default;
 
+    virtual QColor getColor(const QString &colorId, const ColorMode colorMode) const = 0;
+    virtual Path getIconPath(const QString &iconId, const ColorMode colorMode) const = 0;
     virtual QByteArray readStyleSheet() = 0;
-    virtual QByteArray readConfig() = 0;
-    virtual Path iconPath(const QString &iconId) const = 0;
 };
 
-class UIThemeManager : public QObject
+class UIThemeManager final : public QObject
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(UIThemeManager)
@@ -63,7 +70,7 @@ public:
     QIcon getFlagIcon(const QString &countryIsoCode) const;
     QPixmap getScaledPixmap(const QString &iconId, int height) const;
 
-    QColor getColor(const QString &id, const QColor &defaultColor) const;
+    QColor getColor(const QString &id) const;
 
 #ifndef Q_OS_MACOS
     QIcon getSystrayIcon() const;
@@ -71,8 +78,7 @@ public:
 
 private:
     UIThemeManager(); // singleton class
-    Path getIconPathFromResources(const QString &iconId) const;
-    void loadColorsFromJSONConfig();
+
     void applyPalette() const;
     void applyStyleSheet() const;
 
@@ -82,7 +88,7 @@ private:
     const bool m_useSystemIcons;
 #endif
     std::unique_ptr<UIThemeSource> m_themeSource;
-    QHash<QString, QColor> m_colors;
-    mutable QHash<QString, QIcon> m_iconCache;
-    mutable QHash<QString, QIcon> m_flagCache;
+    mutable QHash<QString, QIcon> m_icons;
+    mutable QHash<QString, QIcon> m_darkModeIcons;
+    mutable QHash<QString, QIcon> m_flags;
 };

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -35,10 +35,8 @@
 #endif
 
 #include <QApplication>
-#include <QColor>
 #include <QDesktopServices>
 #include <QIcon>
-#include <QPalette>
 #include <QPixmap>
 #include <QPixmapCache>
 #include <QPoint>
@@ -56,13 +54,6 @@
 #include "base/path.h"
 #include "base/utils/fs.h"
 #include "base/utils/version.h"
-
-bool Utils::Gui::isDarkTheme()
-{
-    const QPalette palette = qApp->palette();
-    const QColor &color = palette.color(QPalette::Active, QPalette::Base);
-    return (color.lightness() < 127);
-}
 
 QPixmap Utils::Gui::scaledPixmap(const QIcon &icon, const QWidget *widget, const int height)
 {

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -551,7 +551,7 @@ Http::Response WebApplication::processRequest(const Http::Request &request, cons
         // block suspicious requests
         if ((m_isCSRFProtectionEnabled && isCrossSiteRequest(m_request))
             || (m_isHostHeaderValidationEnabled && !validateHostHeader(m_domainList)))
-            {
+        {
             throw UnauthorizedHTTPError();
         }
 


### PR DESCRIPTION
Allows to use another icons in dark mode. You can put them to `<config>/themes/default/icons/dark` folder (restart is required). Once some icon set was ready and approved we'll build it into executable alongside with default one.
Also allows to override default colors for dark mode via `<config>/themes/default/config.json` (using "colors.dark" dictionary).