### PR TITLE
Improve command line parameters dispatching

### DIFF
--- a/src/app/application.h
+++ b/src/app/application.h
@@ -96,10 +96,10 @@ public:
     Application(int &argc, char **argv);
     ~Application() override;
 
-    int exec(const QStringList &params);
+    int exec();
 
     bool isRunning();
-    bool sendParams(const QStringList &params);
+    bool callMainInstance();
     const QBtCommandLineParameters &commandLineArgs() const;
 
     // FileLogger properties
@@ -149,16 +149,8 @@ private slots:
 #endif
 
 private:
-    struct AddTorrentParams
-    {
-        QStringList torrentSources;
-        BitTorrent::AddTorrentParams torrentParams;
-        std::optional<bool> skipTorrentDialog;
-    };
-
     void initializeTranslation();
-    AddTorrentParams parseParams(const QStringList &params) const;
-    void processParams(const AddTorrentParams &params);
+    void processParams(const QBtCommandLineParameters &params);
     void runExternalProgram(const QString &programTemplate, const BitTorrent::Torrent *torrent) const;
     void sendNotificationEmail(const BitTorrent::Torrent *torrent);
 
@@ -190,7 +182,7 @@ private:
     QTranslator m_qtTranslator;
     QTranslator m_translator;
 
-    QList<AddTorrentParams> m_paramsQueue;
+    QList<QBtCommandLineParameters> m_paramsQueue;
 
     SettingValue<bool> m_storeFileLoggerEnabled;
     SettingValue<bool> m_storeFileLoggerBackup;

--- a/src/app/cmdoptions.h
+++ b/src/app/cmdoptions.h
@@ -35,6 +35,7 @@
 #include <QString>
 #include <QStringList>
 
+#include "base/bittorrent/addtorrentparams.h"
 #include "base/exceptions.h"
 #include "base/path.h"
 
@@ -42,32 +43,29 @@ class QProcessEnvironment;
 
 struct QBtCommandLineParameters
 {
-    bool showHelp;
-    bool relativeFastresumePaths;
-    bool skipChecking;
-    bool sequential;
-    bool firstLastPiecePriority;
+    bool showHelp = false;
+    bool relativeFastresumePaths = false;
 #if !defined(Q_OS_WIN) || defined(DISABLE_GUI)
-    bool showVersion;
+    bool showVersion = false;
 #endif
 #ifndef DISABLE_GUI
-    bool noSplash;
+    bool noSplash = false;
 #elif !defined(Q_OS_WIN)
-    bool shouldDaemonize;
+    bool shouldDaemonize = false;
 #endif
-    int webUiPort;
-    int torrentingPort;
-    std::optional<bool> addPaused;
+    int webUiPort = -1;
+    int torrentingPort = -1;
     std::optional<bool> skipDialog;
-    QStringList torrents;
     Path profileDir;
     QString configurationName;
-    Path savePath;
-    QString category;
+
+    QStringList torrentSources;
+    BitTorrent::AddTorrentParams addTorrentParams;
+
     QString unknownParameter;
 
+    QBtCommandLineParameters() = default;
     explicit QBtCommandLineParameters(const QProcessEnvironment &);
-    QStringList paramList() const;
 };
 
 class CommandLineParameterError : public RuntimeError

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -193,7 +193,7 @@ int main(int argc, char *argv[])
 #endif
 
             QThread::msleep(300);
-            app->sendParams(params.paramList());
+            app->callMainInstance();
 
             return EXIT_SUCCESS;
         }
@@ -258,7 +258,7 @@ int main(int argc, char *argv[])
 
         registerSignalHandlers();
 
-        return app->exec(params.paramList());
+        return app->exec();
     }
     catch (const CommandLineParameterError &er)
     {


### PR DESCRIPTION
Encapsulate parameters dispatching in Application class.
Avoid serializing parameters when it is not necessary.
