### PR TITLE
WebUI: Stricter SSL configuration

### DIFF
--- a/src/base/http/server.cpp
+++ b/src/base/http/server.cpp
@@ -56,13 +56,14 @@ namespace
     QList<QSslCipher> safeCipherList()
     {
         const QStringList badCiphers {u"idea"_qs, u"rc4"_qs};
+        const QString dhePrefix = u"dhe"_qs;
         const QList<QSslCipher> allCiphers {QSslConfiguration::supportedCiphers()};
         QList<QSslCipher> safeCiphers;
         std::copy_if(allCiphers.cbegin(), allCiphers.cend(), std::back_inserter(safeCiphers), [&badCiphers](const QSslCipher &cipher)
         {
             return std::none_of(badCiphers.cbegin(), badCiphers.cend(), [&cipher](const QString &badCipher)
             {
-                return cipher.name().contains(badCipher, Qt::CaseInsensitive);
+                return cipher.name().contains(badCipher, Qt::CaseInsensitive) || cipher.name().startsWith(dhePrefix);
             });
         });
         return safeCiphers;
@@ -79,6 +80,7 @@ Server::Server(IRequestHandler *requestHandler, QObject *parent)
 
     QSslConfiguration sslConf {QSslConfiguration::defaultConfiguration()};
     sslConf.setCiphers(safeCipherList());
+    sslConf.setProtocol(QSsl::TlsV1_2OrLater);
     QSslConfiguration::setDefaultConfiguration(sslConf);
 
     auto *dropConnectionTimer = new QTimer(this);

--- a/src/base/http/server.cpp
+++ b/src/base/http/server.cpp
@@ -56,14 +56,13 @@ namespace
     QList<QSslCipher> safeCipherList()
     {
         const QStringList badCiphers {u"idea"_qs, u"rc4"_qs};
-        const QString dhePrefix = u"dhe"_qs;
         const QList<QSslCipher> allCiphers {QSslConfiguration::supportedCiphers()};
         QList<QSslCipher> safeCiphers;
         std::copy_if(allCiphers.cbegin(), allCiphers.cend(), std::back_inserter(safeCiphers), [&badCiphers](const QSslCipher &cipher)
         {
             return std::none_of(badCiphers.cbegin(), badCiphers.cend(), [&cipher](const QString &badCipher)
             {
-                return cipher.name().contains(badCipher, Qt::CaseInsensitive) || cipher.name().startsWith(dhePrefix);
+                return cipher.name().contains(badCipher, Qt::CaseInsensitive) || cipher.name().startsWith(u"dhe"_qs);
             });
         });
         return safeCiphers;

--- a/src/base/http/server.cpp
+++ b/src/base/http/server.cpp
@@ -62,7 +62,7 @@ namespace
         {
             return std::none_of(badCiphers.cbegin(), badCiphers.cend(), [&cipher](const QString &badCipher)
             {
-                return cipher.name().contains(badCipher, Qt::CaseInsensitive));
+                return cipher.name().contains(badCipher, Qt::CaseInsensitive);
             });
         });
         return safeCiphers;

--- a/src/base/http/server.cpp
+++ b/src/base/http/server.cpp
@@ -55,14 +55,14 @@ namespace
 
     QList<QSslCipher> safeCipherList()
     {
-        const QStringList badCiphers {u"idea"_qs, u"rc4"_qs, u"rsa"_qs};
+        const QStringList badCiphers {u"idea"_qs, u"rc4"_qs, u"rsa"_qs, u"adh"_qs};
         const QList<QSslCipher> allCiphers {QSslConfiguration::supportedCiphers()};
         QList<QSslCipher> safeCiphers;
         std::copy_if(allCiphers.cbegin(), allCiphers.cend(), std::back_inserter(safeCiphers), [&badCiphers](const QSslCipher &cipher)
         {
             return std::none_of(badCiphers.cbegin(), badCiphers.cend(), [&cipher](const QString &badCipher)
             {
-                return cipher.name().contains(badCipher, Qt::CaseInsensitive) || cipher.name().startsWith(u"dhe"_qs);
+                return cipher.name().contains(badCipher, Qt::CaseInsensitive));
             });
         });
         return safeCiphers;

--- a/src/base/http/server.cpp
+++ b/src/base/http/server.cpp
@@ -55,7 +55,7 @@ namespace
 
     QList<QSslCipher> safeCipherList()
     {
-        const QStringList badCiphers {u"idea"_qs, u"rc4"_qs};
+        const QStringList badCiphers {u"idea"_qs, u"rc4"_qs, u"rsa"_qs};
         const QList<QSslCipher> allCiphers {QSslConfiguration::supportedCiphers()};
         QList<QSslCipher> safeCiphers;
         std::copy_if(allCiphers.cbegin(), allCiphers.cend(), std::back_inserter(safeCiphers), [&badCiphers](const QSslCipher &cipher)


### PR DESCRIPTION
This hardens the default configuration for hosting the WebUI by restricting the SSL protocols to TLSv1.2 and later, and disables ciphers beginning with DHE_ to prevent weaker DH key sizes from being used.

Closes #18483, #18122