### PR TITLE
Don't increase limits when prefetching metadata for added magnets

### DIFF
--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -492,9 +492,7 @@ namespace BitTorrent
         lt::settings_pack loadLTSettings() const;
         void applyNetworkInterfacesSettings(lt::settings_pack &settingsPack) const;
         void configurePeerClasses();
-        int adjustLimit(int limit) const;
         void initMetrics();
-        void adjustLimits();
         void applyBandwidthLimits();
         void processBannedIPs(lt::ip_filter &filter);
         QStringList getListeningIPs() const;
@@ -686,7 +684,6 @@ namespace BitTorrent
         const bool m_wasPexEnabled = m_isPeXEnabled;
 
         int m_numResumeData = 0;
-        int m_extraLimit = 0;
         QVector<TrackerEntry> m_additionalTrackerList;
         QVector<QRegularExpression> m_excludedFileNamesRegExpList;
 


### PR DESCRIPTION
Adjusting limits was made based on the belief that "forced" torrents (internally used for prefetching metadata) are still under limits, but ignore only the queue. This is not really the case. "Forced" torrents ignore the limits like "maximum active torrents/downloads", so adjusting limits is not required, and what's more, it really causes the problem of unexpectedly activated previously queued torrents when adding some magnet using "Add new torrent" dialog.

Fixes #18490.
