### PR TITLE
Revert changes of conflict resolution strategy on automatic move

### DIFF
--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -2201,7 +2201,7 @@ void TorrentImpl::adjustStorageLocation()
     const Path targetPath = ((isFinished || downloadPath.isEmpty()) ? savePath() : downloadPath);
 
     if ((targetPath != actualStorageLocation()) || isMoveInProgress())
-        moveStorage(targetPath, MoveStorageMode::FailIfExist);
+        moveStorage(targetPath, MoveStorageMode::Overwrite);
 }
 
 void TorrentImpl::doRenameFile(int index, const Path &path)


### PR DESCRIPTION
I believe it's better to revert this changes until complex  solution is available. IIRC, "fail if exists" strategy can make the life hard for much many users (after all, files with the same name but different content are unlikely to occur more often than really matching files).

Closes #18297.
Closes #18495.