### PR TITLE
Show filtered port numbers in logs

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -5529,13 +5529,13 @@ void SessionImpl::handlePeerBlockedAlert(const lt::peer_blocked_alert *p)
         reason = tr("IP filter", "this peer was blocked. Reason: IP filter.");
         break;
     case lt::peer_blocked_alert::port_filter:
-        reason = tr("port %1 is filtered", "this peer was blocked. Reason: port 8899 is filtered.").arg(QString::number(p->endpoint.port()));
+        reason = tr("filtered port (%1)", "this peer was blocked. Reason: filtered port (8899).").arg(QString::number(p->endpoint.port()));
         break;
     case lt::peer_blocked_alert::i2p_mixed:
         reason = tr("%1 mixed mode restrictions", "this peer was blocked. Reason: I2P mixed mode restrictions.").arg(u"I2P"_qs); // don't translate I2P
         break;
     case lt::peer_blocked_alert::privileged_ports:
-        reason = tr("use of privileged port %1", "this peer was blocked. Reason: use of privileged port 80.").arg(QString::number(p->endpoint.port()));
+        reason = tr("privileged port (%1)", "this peer was blocked. Reason: privileged port (80).").arg(QString::number(p->endpoint.port()));
         break;
     case lt::peer_blocked_alert::utp_disabled:
         reason = tr("%1 is disabled", "this peer was blocked. Reason: uTP is disabled.").arg(C_UTP); // don't translate μTP

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -5529,15 +5529,13 @@ void SessionImpl::handlePeerBlockedAlert(const lt::peer_blocked_alert *p)
         reason = tr("IP filter", "this peer was blocked. Reason: IP filter.");
         break;
     case lt::peer_blocked_alert::port_filter:
-        reason = tr("port filter", "this peer was blocked. Reason: port filter.");
-        reason.append(u" (%1)"_qs.arg(QString::number(p->endpoint.port())));
+        reason = tr("port %1 is filtered", "this peer was blocked. Reason: port 8899 is filtered.").arg(QString::number(p->endpoint.port()));
         break;
     case lt::peer_blocked_alert::i2p_mixed:
         reason = tr("%1 mixed mode restrictions", "this peer was blocked. Reason: I2P mixed mode restrictions.").arg(u"I2P"_qs); // don't translate I2P
         break;
     case lt::peer_blocked_alert::privileged_ports:
-        reason = tr("use of privileged port", "this peer was blocked. Reason: use of privileged port.");
-        reason.append(u" (%1)"_qs.arg(QString::number(p->endpoint.port())));
+        reason = tr("use of privileged port %1", "this peer was blocked. Reason: use of privileged port 80.").arg(QString::number(p->endpoint.port()));
         break;
     case lt::peer_blocked_alert::utp_disabled:
         reason = tr("%1 is disabled", "this peer was blocked. Reason: uTP is disabled.").arg(C_UTP); // don't translate μTP

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -5530,12 +5530,14 @@ void SessionImpl::handlePeerBlockedAlert(const lt::peer_blocked_alert *p)
         break;
     case lt::peer_blocked_alert::port_filter:
         reason = tr("port filter", "this peer was blocked. Reason: port filter.");
+        reason.append(u" (%1)"_qs.arg(QString::number(p->endpoint.port())));
         break;
     case lt::peer_blocked_alert::i2p_mixed:
         reason = tr("%1 mixed mode restrictions", "this peer was blocked. Reason: I2P mixed mode restrictions.").arg(u"I2P"_qs); // don't translate I2P
         break;
     case lt::peer_blocked_alert::privileged_ports:
         reason = tr("use of privileged port", "this peer was blocked. Reason: use of privileged port.");
+        reason.append(u" (%1)"_qs.arg(QString::number(p->endpoint.port())));
         break;
     case lt::peer_blocked_alert::utp_disabled:
         reason = tr("%1 is disabled", "this peer was blocked. Reason: uTP is disabled.").arg(C_UTP); // don't translate μTP


### PR DESCRIPTION
As the name implies, this PR adds filtered port numbers in logs.

![Screenshot](https://user-images.githubusercontent.com/13597663/218223553-fd95e939-9abc-434b-a6cf-f45f8e37ed67.png)

I am not sure about implementation here, so it needs a review.