### PR TITLE
Migrate away from unsafe function

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -1387,11 +1387,11 @@ function registerMagnetHandler() {
         return;
     }
 
-    const hashParams = getHashParamsFromUrl();
-    hashParams.download = '';
+    const hashString = location.hash ? location.hash.replace(/^#/, '') : '';
+    const hashParams = new URLSearchParams(hashString);
+    hashParams.set('download', '');
 
-    const templateHashString = Object.toQueryString(hashParams).replace('download=', 'download=%s');
-
+    const templateHashString = hashParams.toString().replace('download=', 'download=%s');
     const templateUrl = location.origin + location.pathname
         + location.search + '#' + templateHashString;
 
@@ -1409,11 +1409,6 @@ function handleDownloadParam() {
     // Remove the processed hash from the URL
     history.replaceState('', document.title, (location.pathname + location.search));
     showDownloadPage([url]);
-}
-
-function getHashParamsFromUrl() {
-    const hashString = location.hash ? location.hash.replace(/^#/, '') : '';
-    return (hashString.length > 0) ? String.parseQueryString(hashString) : {};
 }
 
 function closeWindows() {


### PR DESCRIPTION
MooTools More has CVE-2021-20088 and qbt is affected by it by using the unsafe function call `String.parseQueryString()`, so migrate away from it.
