### PR TITLE
Prevent precise timers from being used when unnecessary

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -283,7 +283,7 @@ void showSplashScreen()
     painter.drawText(224 - painter.fontMetrics().horizontalAdvance(version), 270, version);
     QSplashScreen *splash = new QSplashScreen(splashImg);
     splash->show();
-    QTimer::singleShot(1500ms, splash, &QObject::deleteLater);
+    QTimer::singleShot(1500ms, Qt::CoarseTimer, splash, &QObject::deleteLater);
     qApp->processEvents();
 }
 #endif  // DISABLE_GUI

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -5064,7 +5064,7 @@ void SessionImpl::enqueueRefresh()
 {
     Q_ASSERT(!m_refreshEnqueued);
 
-    QTimer::singleShot(refreshInterval(), this, [this] ()
+    QTimer::singleShot(refreshInterval(), Qt::CoarseTimer, this, [this]
     {
         m_nativeSession->post_torrent_updates();
         m_nativeSession->post_session_stats();

--- a/src/base/torrentfileswatcher.cpp
+++ b/src/base/torrentfileswatcher.cpp
@@ -502,7 +502,7 @@ void TorrentFilesWatcher::Worker::removeWatchedFolder(const Path &path)
 
 void TorrentFilesWatcher::Worker::scheduleWatchedFolderProcessing(const Path &path)
 {
-    QTimer::singleShot(2s, this, [this, path]()
+    QTimer::singleShot(2s, Qt::CoarseTimer, this, [this, path]
     {
         processWatchedFolder(path);
     });

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -94,7 +94,7 @@ void AppController::shutdownAction()
     // Special handling for shutdown, we
     // need to reply to the Web UI before
     // actually shutting down.
-    QTimer::singleShot(100ms, qApp, []()
+    QTimer::singleShot(100ms, Qt::CoarseTimer, qApp, []
     {
         QCoreApplication::exit();
     });


### PR DESCRIPTION
The implementation of QTimer::singleShot() uses Qt::PreciseTimer if interval is less than 2 seconds. This isn't mentioned in the docs.
Qt::PreciseTimer increases the system's timer resolution which negatively affects power consumption.

Closes #18350.
Supercedes #18475.
