### PR TITLE
GHA CI improvements

### DIFF
--- a/.github/workflows/ci_file_health.yaml
+++ b/.github/workflows/ci_file_health.yaml
@@ -2,6 +2,8 @@ name: CI - File health
 
 on: [pull_request, push]
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: ${{ github.head_ref != '' }}

--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -86,11 +86,11 @@ jobs:
       - name: Build qBittorrent (Qt5)
         if: ${{ startsWith(matrix.qt_version, 5) }}
         run: |
+          CXXFLAGS="$CXXFLAGS -Werror -Wno-error=deprecated-declarations" \
           cmake \
             -B build \
             -G "Ninja" \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_CXX_FLAGS="-Werror -Wno-error=deprecated-declarations" \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DBOOST_ROOT="${{ env.boost_path }}" \
             -DOPENSSL_ROOT_DIR="${{ env.openssl_root }}" \
@@ -104,11 +104,11 @@ jobs:
       - name: Build qBittorrent (Qt6)
         if: ${{ startsWith(matrix.qt_version, 6) }}
         run: |
+          CXXFLAGS="$CXXFLAGS -Wno-gnu-zero-variadic-macro-arguments -Werror -Wno-error=deprecated-declarations" \
           cmake \
             -B build \
             -G "Ninja" \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_CXX_FLAGS="-Wno-gnu-zero-variadic-macro-arguments -Werror -Wno-error=deprecated-declarations" \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DBOOST_ROOT="${{ env.boost_path }}" \
             -DOPENSSL_ROOT_DIR="${{ env.openssl_root }}" \

--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -2,6 +2,9 @@ name: CI - macOS
 
 on: [pull_request, push]
 
+permissions:
+  actions: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: ${{ github.head_ref != '' }}

--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -87,6 +87,7 @@ jobs:
         if: ${{ startsWith(matrix.qt_version, 5) }}
         run: |
           CXXFLAGS="$CXXFLAGS -Werror -Wno-error=deprecated-declarations" \
+          LDFLAGS="$LDFLAGS -gz" \
           cmake \
             -B build \
             -G "Ninja" \
@@ -105,6 +106,7 @@ jobs:
         if: ${{ startsWith(matrix.qt_version, 6) }}
         run: |
           CXXFLAGS="$CXXFLAGS -Wno-gnu-zero-variadic-macro-arguments -Werror -Wno-error=deprecated-declarations" \
+          LDFLAGS="$LDFLAGS -gz" \
           cmake \
             -B build \
             -G "Ninja" \

--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -31,6 +31,9 @@ jobs:
 
       - name: Install dependencies
         run: |
+          export \
+            HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 \
+            HOMEBREW_NO_INSTALL_CLEANUP=1
           brew update > /dev/null
           brew install \
             cmake ninja \

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -2,6 +2,9 @@ name: CI - Ubuntu
 
 on: [pull_request, push]
 
+permissions:
+  actions: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: ${{ github.head_ref != '' }}

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -69,6 +69,7 @@ jobs:
         if: ${{ startsWith(matrix.qt_version, 5) }}
         run: |
           CXXFLAGS="$CXXFLAGS -Werror -Wno-error=deprecated-declarations" \
+          LDFLAGS="$LDFLAGS -gz" \
           cmake \
             -B build \
             -G "Ninja" \
@@ -87,6 +88,7 @@ jobs:
         if: ${{ startsWith(matrix.qt_version, 6) }}
         run: |
           CXXFLAGS="$CXXFLAGS -Werror" \
+          LDFLAGS="$LDFLAGS -gz" \
           cmake \
             -B build \
             -G "Ninja" \

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -81,7 +81,7 @@ jobs:
           cmake --build build --target qbt_update_translations
           cmake --build build
           cmake --build build --target check
-          DESTDIR="qbittorrent" cmake --install build --strip
+          DESTDIR="qbittorrent" cmake --install build
 
       - name: Build qBittorrent (Qt6)
         if: ${{ startsWith(matrix.qt_version, 6) }}
@@ -100,7 +100,7 @@ jobs:
           cmake --build build --target qbt_update_translations
           cmake --build build
           cmake --build build --target check
-          DESTDIR="qbittorrent" cmake --install build --strip
+          DESTDIR="qbittorrent" cmake --install build
 
       - name: Prepare build artifacts
         run: |

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -68,11 +68,11 @@ jobs:
       - name: Build qBittorrent (Qt5)
         if: ${{ startsWith(matrix.qt_version, 5) }}
         run: |
+          CXXFLAGS="$CXXFLAGS -Werror -Wno-error=deprecated-declarations" \
           cmake \
             -B build \
             -G "Ninja" \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_CXX_FLAGS="-Werror -Wno-error=deprecated-declarations" \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DCMAKE_INSTALL_PREFIX="/usr" \
             -DTESTING=ON \
@@ -86,11 +86,11 @@ jobs:
       - name: Build qBittorrent (Qt6)
         if: ${{ startsWith(matrix.qt_version, 6) }}
         run: |
+          CXXFLAGS="$CXXFLAGS -Werror" \
           cmake \
             -B build \
             -G "Ninja" \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_CXX_FLAGS="-Werror" \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DCMAKE_INSTALL_PREFIX="/usr" \
             -DQT6=ON \

--- a/.github/workflows/ci_webui.yaml
+++ b/.github/workflows/ci_webui.yaml
@@ -2,6 +2,8 @@ name: CI - WebUI
 
 on: [pull_request, push]
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: ${{ github.head_ref != '' }}

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -2,6 +2,9 @@ name: CI - Windows
 
 on: [pull_request, push]
 
+permissions:
+  actions: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: ${{ github.head_ref != '' }}

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -5,6 +5,8 @@ on:
     - cron: '0 0 1 * *' # Monthly (1st day of month at midnight)
   workflow_dispatch: # Mainly for testing. Don't forget the Coverity usage limits.
 
+permissions: {}
+
 jobs:
   coverity_scan:
     name: Scan

--- a/.github/workflows/stale_bot.yaml
+++ b/.github/workflows/stale_bot.yaml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
* GHA CI: speed up package installation on macOS
  Setup time is shortened by cutting down unnecessary operations.
  https://docs.brew.sh/Manpage#environment


* GHA CI: use least permission level
  `actions: write` is required by Chocobo1/setup-ccache-action.
  `pull-requests: write` is required by actions/stale.
  https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions


* GHA CI: revert "[CI Ubuntu] Strip installed components"
  For tester convenience, the binaries should ship with debug symbols.
  This reverts commit b8aa9e5.

* GHA CI: don't overwrite system default compile flags
  System might have some default compile flags which are crucial for security hardening so we should append our flags instead of overwriting them.

* GHA CI: compress debug symbols
  The result binary is smaller.