### PR TITLE
Allow to filter torrent list by save path

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1934,7 +1934,8 @@ void MainWindow::updatePowerManagementState()
     m_pwr->setActivityState(inhibitSuspend);
 }
 
-void MainWindow::applyTransferListFilter() {
+void MainWindow::applyTransferListFilter()
+{
     m_transferListWidget->applyFilter(m_searchFilter->text(), m_filterColumnComboBox->currentData().value<TransferListModel::Column>());
 }
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -35,6 +35,7 @@
 #include <QActionGroup>
 #include <QClipboard>
 #include <QCloseEvent>
+#include <QComboBox>
 #include <QDebug>
 #include <QDesktopServices>
 #include <QFileDialog>
@@ -196,8 +197,8 @@ MainWindow::MainWindow(IGUIApplication *app, WindowState initialState)
     m_searchFilterAction = m_ui->toolBar->insertWidget(m_ui->actionLock, m_searchFilter);
     // Filter by type
     m_filterBy = new QComboBox(this);
-    m_filterBy->addItem(tr("Torrent names"), TransferListModel::Column::TR_NAME);
-    m_filterBy->addItem(tr("Torrent save paths"), TransferListModel::Column::TR_SAVE_PATH);
+    m_filterBy->addItem(tr("Torrent name"), TransferListModel::Column::TR_NAME);
+    m_filterBy->addItem(tr("Torrent save path"), TransferListModel::Column::TR_SAVE_PATH);
     m_filterBy->setFixedWidth(200);
     m_ui->toolBar->insertWidget(m_ui->actionLock, m_filterBy);
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -189,11 +189,17 @@ MainWindow::MainWindow(IGUIApplication *app, WindowState initialState)
 
     // Name filter
     m_searchFilter = new LineEdit(this);
-    m_searchFilter->setPlaceholderText(tr("Filter torrent names..."));
+    m_searchFilter->setPlaceholderText(tr("Filter torrent ..."));
     m_searchFilter->setFixedWidth(200);
     m_searchFilter->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(m_searchFilter, &QWidget::customContextMenuRequested, this, &MainWindow::showFilterContextMenu);
     m_searchFilterAction = m_ui->toolBar->insertWidget(m_ui->actionLock, m_searchFilter);
+    // Filter by type
+    m_filterBy = new QComboBox(this);
+    m_filterBy->addItem(tr("Torrent names"),TransferListModel::Column::TR_NAME);
+    m_filterBy->addItem(tr("Torrent save paths"),TransferListModel::Column::TR_SAVE_PATH);
+    m_filterBy->setFixedWidth(200);
+    m_ui->toolBar->insertWidget(m_ui->actionLock,m_filterBy);
 
     QWidget *spacer = new QWidget(this);
     spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
@@ -213,8 +219,11 @@ MainWindow::MainWindow(IGUIApplication *app, WindowState initialState)
         UIThemeManager::instance()->getIcon(u"folder-remote"_qs),
 #endif
         tr("Transfers"));
-
-    connect(m_searchFilter, &LineEdit::textChanged, m_transferListWidget, &TransferListWidget::applyNameFilter);
+    auto emitFilterChanged = [this](){ emit filterChanged(m_searchFilter->text(),
+                                       m_filterBy->currentData().value<TransferListModel::Column>());};
+    connect(m_filterBy, &QComboBox::currentIndexChanged, this, emitFilterChanged);
+    connect(m_searchFilter, &LineEdit::textChanged, this, emitFilterChanged);
+    connect(this, &MainWindow::filterChanged, m_transferListWidget, &TransferListWidget::applyFilter);
     connect(hSplitter, &QSplitter::splitterMoved, this, &MainWindow::saveSettings);
     connect(m_splitter, &QSplitter::splitterMoved, this, &MainWindow::saveSplitterSettings);
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackersChanged, m_propertiesWidget, &PropertiesWidget::loadTrackers);
@@ -670,7 +679,9 @@ void MainWindow::showFilterContextMenu()
     useRegexAct->setCheckable(true);
     useRegexAct->setChecked(pref->getRegexAsFilteringPatternForTransferList());
     connect(useRegexAct, &QAction::toggled, pref, &Preferences::setRegexAsFilteringPatternForTransferList);
-    connect(useRegexAct, &QAction::toggled, this, [this]() { m_transferListWidget->applyNameFilter(m_searchFilter->text()); });
+    connect(useRegexAct, &QAction::toggled, this, [this]() {
+        m_transferListWidget->applyFilter(m_searchFilter->text(),
+                                          m_filterBy->currentData().value<TransferListModel::Column>()); });
 
     menu->popup(QCursor::pos());
 }

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -189,17 +189,17 @@ MainWindow::MainWindow(IGUIApplication *app, WindowState initialState)
 
     // Name filter
     m_searchFilter = new LineEdit(this);
-    m_searchFilter->setPlaceholderText(tr("Filter torrent ..."));
+    m_searchFilter->setPlaceholderText(tr("Filter torrents..."));
     m_searchFilter->setFixedWidth(200);
     m_searchFilter->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(m_searchFilter, &QWidget::customContextMenuRequested, this, &MainWindow::showFilterContextMenu);
     m_searchFilterAction = m_ui->toolBar->insertWidget(m_ui->actionLock, m_searchFilter);
     // Filter by type
     m_filterBy = new QComboBox(this);
-    m_filterBy->addItem(tr("Torrent names"),TransferListModel::Column::TR_NAME);
-    m_filterBy->addItem(tr("Torrent save paths"),TransferListModel::Column::TR_SAVE_PATH);
+    m_filterBy->addItem(tr("Torrent names"), TransferListModel::Column::TR_NAME);
+    m_filterBy->addItem(tr("Torrent save paths"), TransferListModel::Column::TR_SAVE_PATH);
     m_filterBy->setFixedWidth(200);
-    m_ui->toolBar->insertWidget(m_ui->actionLock,m_filterBy);
+    m_ui->toolBar->insertWidget(m_ui->actionLock, m_filterBy);
 
     QWidget *spacer = new QWidget(this);
     spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
@@ -219,11 +219,12 @@ MainWindow::MainWindow(IGUIApplication *app, WindowState initialState)
         UIThemeManager::instance()->getIcon(u"folder-remote"_qs),
 #endif
         tr("Transfers"));
-    auto emitFilterChanged = [this](){ emit filterChanged(m_searchFilter->text(),
-                                       m_filterBy->currentData().value<TransferListModel::Column>());};
-    connect(m_filterBy, &QComboBox::currentIndexChanged, this, emitFilterChanged);
-    connect(m_searchFilter, &LineEdit::textChanged, this, emitFilterChanged);
-    connect(this, &MainWindow::filterChanged, m_transferListWidget, &TransferListWidget::applyFilter);
+    auto applyFilter = [this]()
+    {
+        m_transferListWidget->applyFilter(m_searchFilter->text(), m_filterBy->currentData().value<TransferListModel::Column>());
+    };
+    connect(m_filterBy, &QComboBox::currentIndexChanged, this, applyFilter);
+    connect(m_searchFilter, &LineEdit::textChanged, this, applyFilter);
     connect(hSplitter, &QSplitter::splitterMoved, this, &MainWindow::saveSettings);
     connect(m_splitter, &QSplitter::splitterMoved, this, &MainWindow::saveSplitterSettings);
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackersChanged, m_propertiesWidget, &PropertiesWidget::loadTrackers);
@@ -679,9 +680,10 @@ void MainWindow::showFilterContextMenu()
     useRegexAct->setCheckable(true);
     useRegexAct->setChecked(pref->getRegexAsFilteringPatternForTransferList());
     connect(useRegexAct, &QAction::toggled, pref, &Preferences::setRegexAsFilteringPatternForTransferList);
-    connect(useRegexAct, &QAction::toggled, this, [this]() {
-        m_transferListWidget->applyFilter(m_searchFilter->text(),
-                                          m_filterBy->currentData().value<TransferListModel::Column>()); });
+    connect(useRegexAct, &QAction::toggled, this, [this]()
+    {
+        m_transferListWidget->applyFilter(m_searchFilter->text(), m_filterBy->currentData().value<TransferListModel::Column>());
+    });
 
     menu->popup(QCursor::pos());
 }

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -199,7 +199,6 @@ MainWindow::MainWindow(IGUIApplication *app, WindowState initialState)
     m_filterBy = new QComboBox(this);
     m_filterBy->addItem(tr("Torrent name"), TransferListModel::Column::TR_NAME);
     m_filterBy->addItem(tr("Torrent save path"), TransferListModel::Column::TR_SAVE_PATH);
-    m_filterBy->setFixedWidth(200);
     m_ui->toolBar->insertWidget(m_ui->actionLock, m_filterBy);
 
     QWidget *spacer = new QWidget(this);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -41,6 +41,7 @@
 #include <QFileDialog>
 #include <QFileSystemWatcher>
 #include <QKeyEvent>
+#include <QLabel>
 #include <QMessageBox>
 #include <QMetaObject>
 #include <QMimeData>
@@ -188,7 +189,7 @@ MainWindow::MainWindow(IGUIApplication *app, WindowState initialState)
     hSplitter->setChildrenCollapsible(false);
     hSplitter->setFrameShape(QFrame::NoFrame);
 
-    // Name filter
+    // Torrent filter
     m_searchFilter = new LineEdit(this);
     m_searchFilter->setPlaceholderText(tr("Filter torrents..."));
     m_searchFilter->setFixedWidth(200);
@@ -196,10 +197,15 @@ MainWindow::MainWindow(IGUIApplication *app, WindowState initialState)
     connect(m_searchFilter, &QWidget::customContextMenuRequested, this, &MainWindow::showFilterContextMenu);
     m_searchFilterAction = m_ui->toolBar->insertWidget(m_ui->actionLock, m_searchFilter);
     // Filter by type
+    QWidget *filterByWidget = new QWidget(this);
+    QLabel *filterLabel = new QLabel(tr("Filter by:"));
+    filterLabel->setMargin(7);
     m_filterBy = new QComboBox(this);
-    m_filterBy->addItem(tr("Torrent name"), TransferListModel::Column::TR_NAME);
-    m_filterBy->addItem(tr("Torrent save path"), TransferListModel::Column::TR_SAVE_PATH);
-    m_ui->toolBar->insertWidget(m_ui->actionLock, m_filterBy);
+    QHBoxLayout *filterByLayout = new QHBoxLayout(this);
+    filterByLayout->addWidget(filterLabel);
+    filterByLayout->addWidget(m_filterBy);
+    filterByWidget->setLayout(filterByLayout);
+    m_ui->toolBar->insertWidget(m_ui->actionLock, filterByWidget);
 
     QWidget *spacer = new QWidget(this);
     spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
@@ -219,6 +225,13 @@ MainWindow::MainWindow(IGUIApplication *app, WindowState initialState)
         UIThemeManager::instance()->getIcon(u"folder-remote"_qs),
 #endif
         tr("Transfers"));
+    // Filter types
+    QVector<TransferListModel::Column> filterTypes = {TransferListModel::Column::TR_NAME, TransferListModel::Column::TR_SAVE_PATH};
+    for (TransferListModel::Column type : filterTypes)
+    {
+        QString typeName = m_transferListWidget->getSourceModel()->headerData(type, Qt::Horizontal, Qt::DisplayRole).value<QString>();
+        m_filterBy->addItem(typeName, type);
+    }
     auto applyFilter = [this]()
     {
         m_transferListWidget->applyFilter(m_searchFilter->text(), m_filterBy->currentData().value<TransferListModel::Column>());

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -29,7 +29,6 @@
 
 #pragma once
 
-#include <QComboBox>
 #include <QMainWindow>
 #include <QPointer>
 
@@ -38,9 +37,9 @@
 #include "base/settingvalue.h"
 #include "guiapplicationcomponent.h"
 #include "windowstate.h"
-#include "transferlistmodel.h"
 
 class QCloseEvent;
+class QComboBox;
 class QFileSystemWatcher;
 class QSplitter;
 class QTabWidget;

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -31,12 +31,14 @@
 
 #include <QMainWindow>
 #include <QPointer>
+#include <QComboBox>
 
 #include "base/bittorrent/torrent.h"
 #include "base/logger.h"
 #include "base/settingvalue.h"
 #include "guiapplicationcomponent.h"
 #include "windowstate.h"
+#include "transferlistmodel.h"
 
 class QCloseEvent;
 class QFileSystemWatcher;
@@ -97,6 +99,8 @@ public:
 
     void activate();
     void cleanup();
+signals:
+    void filterChanged(const QString &name, const TransferListModel::Column &type);
 
 private slots:
     void showFilterContextMenu();
@@ -219,6 +223,7 @@ private:
     bool m_unlockDlgShowing = false;
     LineEdit *m_searchFilter = nullptr;
     QAction *m_searchFilterAction = nullptr;
+    QComboBox *m_filterBy = nullptr;
     // Widgets
     QAction *m_queueSeparator = nullptr;
     QAction *m_queueSeparatorMenu = nullptr;

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -195,6 +195,7 @@ private:
     void createTorrentTriggered(const Path &path);
     void showStatusBar(bool show);
     void showFiltersSidebar(bool show);
+    void applyTransferListFilter();
 
     Ui::MainWindow *m_ui = nullptr;
 
@@ -220,7 +221,7 @@ private:
     bool m_unlockDlgShowing = false;
     LineEdit *m_searchFilter = nullptr;
     QAction *m_searchFilterAction = nullptr;
-    QComboBox *m_filterBy = nullptr;
+    QComboBox *m_filterColumnComboBox = nullptr;
     // Widgets
     QAction *m_queueSeparator = nullptr;
     QAction *m_queueSeparatorMenu = nullptr;

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -29,9 +29,9 @@
 
 #pragma once
 
+#include <QComboBox>
 #include <QMainWindow>
 #include <QPointer>
-#include <QComboBox>
 
 #include "base/bittorrent/torrent.h"
 #include "base/logger.h"
@@ -99,8 +99,6 @@ public:
 
     void activate();
     void cleanup();
-signals:
-    void filterChanged(const QString &name, const TransferListModel::Column &type);
 
 private slots:
     void showFilterContextMenu();

--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -143,3 +143,5 @@ private:
     QIcon m_stalledUPIcon;
     QIcon m_uploadingIcon;
 };
+
+Q_DECLARE_METATYPE(TransferListModel::Column)

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -64,7 +64,6 @@
 #include "torrentoptionsdialog.h"
 #include "trackerentriesdialog.h"
 #include "transferlistdelegate.h"
-#include "transferlistmodel.h"
 #include "transferlistsortmodel.h"
 #include "tristateaction.h"
 #include "uithememanager.h"
@@ -1299,8 +1298,9 @@ void TransferListWidget::applyTrackerFilter(const QSet<BitTorrent::TorrentID> &t
     m_sortFilterModel->setTrackerFilter(torrentIDs);
 }
 
-void TransferListWidget::applyNameFilter(const QString &name)
+void TransferListWidget::applyFilter(const QString &name, const TransferListModel::Column &type)
 {
+    m_sortFilterModel->setFilterKeyColumn(type);
     const QString pattern = (Preferences::instance()->getRegexAsFilteringPatternForTransferList()
                 ? name : Utils::String::wildcardToRegexPattern(name));
     m_sortFilterModel->setFilterRegularExpression(QRegularExpression(pattern, QRegularExpression::CaseInsensitiveOption));

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -34,6 +34,7 @@
 #include <QTreeView>
 
 #include "base/bittorrent/infohash.h"
+#include "transferlistmodel.h"
 
 class MainWindow;
 class Path;
@@ -92,7 +93,7 @@ public slots:
     void setTorrentOptions();
     void previewSelectedTorrents();
     void hideQueuePosColumn(bool hide);
-    void applyNameFilter(const QString &name);
+    void applyFilter(const QString &name, const TransferListModel::Column &type);
     void applyStatusFilter(int f);
     void applyCategoryFilter(const QString &category);
     void applyTagFilter(const QString &tag);

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -38,7 +38,6 @@
 
 class MainWindow;
 class Path;
-class TransferListModel;
 class TransferListSortModel;
 
 namespace BitTorrent


### PR DESCRIPTION
Responding to #16335

**Add a combobox to select to filter by name or save path** 

![Capture d’écran du 2023-02-19 21-20-02](https://user-images.githubusercontent.com/38819112/219973514-a6607253-8126-4c3d-9468-0b838e192c4e.png)
![Capture d’écran du 2023-02-19 21-29-24](https://user-images.githubusercontent.com/38819112/219973569-ada20735-c803-4f49-88f7-cd0f069541b0.png)

Easily expandable to include other filters as the combobox item just need to have a `TransferListModel::Column`  data

ps : this is my first pull request, sorry for mistakes