### PR TITLE
WebAPI: Allow to set read-only directory as torrent location

### DIFF
--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -1101,10 +1101,6 @@ void TorrentsController::setLocationAction()
     if (!Utils::Fs::mkpath(newLocation))
         throw APIError(APIErrorType::Conflict, tr("Cannot make save path"));
 
-    // check permissions
-    if (!Utils::Fs::isWritable(newLocation))
-        throw APIError(APIErrorType::AccessDenied, tr("Cannot write to directory"));
-
     applyToTorrents(hashes, [newLocation](BitTorrent::Torrent *const torrent)
     {
         LogMsg(tr("WebUI Set location: moving \"%1\", from \"%2\" to \"%3\"")


### PR DESCRIPTION
Closes #18480.