### PR TITLE
Compress log backup files by gzip

### DIFF
--- a/src/app/application.h
+++ b/src/app/application.h
@@ -120,6 +120,8 @@ public:
     void setFileLoggerAge(int value) override;
     int fileLoggerAgeType() const override;
     void setFileLoggerAgeType(int value) override;
+    bool isFileLoggerCompressBackups() const override;
+    void setFileLoggerCompressBackups(bool value) override;
 
     int memoryWorkingSetLimit() const override;
     void setMemoryWorkingSetLimit(int size) override;
@@ -198,6 +200,7 @@ private:
     SettingValue<int> m_storeFileLoggerAge;
     SettingValue<int> m_storeFileLoggerAgeType;
     SettingValue<Path> m_storeFileLoggerPath;
+    SettingValue<bool> m_storeFileLoggerCompressBackups;
     SettingValue<int> m_storeMemoryWorkingSetLimit;
 
 #ifdef Q_OS_WIN

--- a/src/app/filelogger.h
+++ b/src/app/filelogger.h
@@ -34,6 +34,8 @@
 
 #include "base/path.h"
 
+class QThread;
+
 namespace Log
 {
     struct Msg;
@@ -66,6 +68,7 @@ public:
 private slots:
     void addLogMessage(const Log::Msg &msg);
     void flushLog();
+    Path handleResults(const Path &renameFrom, const QString &msg, const bool compressed) const;
 
 private:
     void makeBackup();

--- a/src/app/filelogger.h
+++ b/src/app/filelogger.h
@@ -52,12 +52,15 @@ public:
         YEARS
     };
 
-    FileLogger(const Path &path, bool backup, int maxSize, bool deleteOld, int age, FileLogAgeType ageType);
+    FileLogger(const Path &path, bool backup, int maxSize, bool deleteOld, int age, FileLogAgeType ageType, bool compressBackups);
     ~FileLogger();
 
     void changePath(const Path &newPath);
-    void deleteOld(int age, FileLogAgeType ageType);
+    void setAge(int value);
+    void setAgeType(FileLogAgeType value);
     void setBackup(bool value);
+    void setCompressBackups(bool value);
+    void setDeleteOld(bool value);
     void setMaxSize(int value);
 
 private slots:
@@ -65,11 +68,17 @@ private slots:
     void flushLog();
 
 private:
+    void makeBackup();
+    void deleteOld();
     void openLogFile();
     void closeLogFile();
 
+    int m_age;
+    FileLogAgeType m_ageType;
     Path m_path;
     bool m_backup;
+    bool m_compressBackups;
+    bool m_deleteOld;
     int m_maxSize;
     QFile m_logFile;
     QTimer m_flusher;

--- a/src/base/interfaces/iapplication.h
+++ b/src/base/interfaces/iapplication.h
@@ -77,6 +77,8 @@ public:
     virtual void setFileLoggerAge(int value) = 0;
     virtual int fileLoggerAgeType() const = 0;
     virtual void setFileLoggerAgeType(int value) = 0;
+    virtual bool isFileLoggerCompressBackups() const = 0;
+    virtual void setFileLoggerCompressBackups(bool value) = 0;
 
     virtual int memoryWorkingSetLimit() const = 0;
     virtual void setMemoryWorkingSetLimit(int size) = 0;

--- a/src/base/utils/gzip.cpp
+++ b/src/base/utils/gzip.cpp
@@ -32,12 +32,70 @@
 #include <vector>
 
 #include <QtAssert>
+#include <QBuffer>
 #include <QByteArray>
+#include <QIODevice>
 
 #ifndef ZLIB_CONST
 #define ZLIB_CONST  // make z_stream.next_in const
 #endif
 #include <zlib.h>
+
+bool Utils::Gzip::compress(QIODevice &source, QIODevice &dest, const int level)
+{
+    const unsigned int chunkSize = 128 * 1024;
+
+    z_stream strm {};
+    strm.zalloc = Z_NULL;
+    strm.zfree = Z_NULL;
+    strm.opaque = Z_NULL;
+
+    std::vector<char> in(chunkSize);
+    std::vector<char> out(chunkSize);
+
+    // windowBits = 15 + 16 to enable gzip
+    // From the zlib manual: windowBits can also be greater than 15 for optional gzip encoding. Add 16 to windowBits
+    // to write a simple gzip header and trailer around the compressed data instead of a zlib wrapper.
+    int ret = deflateInit2(&strm, level, Z_DEFLATED, (15 + 16), 9, Z_DEFAULT_STRATEGY);
+    if (ret != Z_OK)
+        return false;
+
+    int flush = Z_NO_FLUSH;
+    do
+    {
+        const qsizetype readBytes = source.read(in.data(), chunkSize);
+        if (readBytes == -1)
+        {
+            deflateEnd(&strm);
+            return false;
+        }
+
+        flush = source.atEnd() ? Z_FINISH : Z_NO_FLUSH;
+        strm.avail_in = readBytes;
+        strm.next_in = reinterpret_cast<const Bytef *>(in.data());
+
+        do
+        {
+            strm.avail_out = chunkSize;
+            strm.next_out = reinterpret_cast<Bytef *>(out.data());
+
+            ret = deflate(&strm, flush);
+            Q_ASSERT(ret != Z_STREAM_ERROR);
+
+            const qsizetype have = chunkSize - strm.avail_out;
+            if (dest.write(out.data(), have) == -1)
+            {
+                deflateEnd(&strm);
+                return false;
+            }
+        } while (strm.avail_out == 0);
+        Q_ASSERT(strm.avail_in == 0);
+    } while (flush != Z_FINISH);
+    Q_ASSERT(ret == Z_STREAM_END);
+
+    deflateEnd(&strm);
+    return true;
+}
 
 QByteArray Utils::Gzip::compress(const QByteArray &data, const int level, bool *ok)
 {
@@ -79,59 +137,96 @@ QByteArray Utils::Gzip::compress(const QByteArray &data, const int level, bool *
     return ret;
 }
 
-QByteArray Utils::Gzip::decompress(const QByteArray &data, bool *ok)
+bool Utils::Gzip::decompress(QIODevice &source, QIODevice &dest)
 {
-    if (ok) *ok = false;
-
-    if (data.isEmpty())
-        return {};
-
-    const int BUFSIZE = 1024 * 1024;
-    std::vector<char> tmpBuf(BUFSIZE);
+    const unsigned int chunkSize = 128 * 1024;
 
     z_stream strm {};
     strm.zalloc = Z_NULL;
     strm.zfree = Z_NULL;
     strm.opaque = Z_NULL;
-    strm.next_in = reinterpret_cast<const Bytef *>(data.constData());
-    strm.avail_in = uInt(data.size());
-    strm.next_out = reinterpret_cast<Bytef *>(tmpBuf.data());
-    strm.avail_out = BUFSIZE;
+    strm.avail_in = 0;
+    strm.next_in = Z_NULL;
+
+    std::vector<char> in(chunkSize);
+    std::vector<char> out(chunkSize);
 
     // windowBits must be greater than or equal to the windowBits value provided to deflateInit2() while compressing
     // Add 32 to windowBits to enable zlib and gzip decoding with automatic header detection
-    int result = inflateInit2(&strm, (15 + 32));
-    if (result != Z_OK)
+    int ret = inflateInit2(&strm, (15 + 32));
+    if (ret != Z_OK)
+        return false;
+
+    do
+    {
+        const qsizetype readBytes = source.read(in.data(), chunkSize);
+        if (readBytes == -1)
+        {
+            inflateEnd(&strm);
+            return false;
+        }
+
+        if (readBytes == 0)
+        {
+            break;
+        }
+
+        strm.avail_in = readBytes;
+        strm.next_in = reinterpret_cast<const Bytef *>(in.data());
+
+        do
+        {
+            strm.avail_out = chunkSize;
+            strm.next_out = reinterpret_cast<Bytef *>(out.data());
+
+            ret = inflate(&strm, Z_NO_FLUSH);
+            Q_ASSERT(ret != Z_STREAM_ERROR);
+
+            switch (ret)
+            {
+            case Z_NEED_DICT:
+                ret = Z_DATA_ERROR;
+                break;
+            case Z_DATA_ERROR:
+            case Z_MEM_ERROR:
+                inflateEnd(&strm);
+                return false;
+            }
+
+            const qsizetype have = chunkSize - strm.avail_out;
+            if (dest.write(out.data(), have) == -1)
+            {
+                inflateEnd(&strm);
+                return false;
+            }
+        } while (strm.avail_out == 0);
+        Q_ASSERT(strm.avail_in == 0);
+    } while (ret != Z_STREAM_END);
+
+    inflateEnd(&strm);
+    return ret == Z_STREAM_END;
+}
+
+QByteArray Utils::Gzip::decompress(const QByteArray &data, bool *ok)
+{
+    if (ok)
+        *ok = false;
+
+    if (data.isEmpty())
         return {};
 
     QByteArray output;
     // from lzbench, level 9 average compression ratio is: 31.92%, which decompression ratio is: 1 / 0.3192 = 3.13
     output.reserve(data.size() * 3);
+    QBuffer source {const_cast<QByteArray *>(&data)};
+    source.open(QIODevice::ReadOnly);
+    QBuffer dest {&output};
+    dest.open(QIODevice::WriteOnly);
 
-    // run inflate
-    while (true)
-    {
-        result = inflate(&strm, Z_NO_FLUSH);
+    if (Utils::Gzip::decompress(source, dest) && ok)
+        *ok = true;
 
-        if (result == Z_STREAM_END)
-        {
-            output.append(tmpBuf.data(), (BUFSIZE - strm.avail_out));
-            break;
-        }
-
-        if (result != Z_OK)
-        {
-            inflateEnd(&strm);
-            return {};
-        }
-
-        output.append(tmpBuf.data(), (BUFSIZE - strm.avail_out));
-        strm.next_out = reinterpret_cast<Bytef *>(tmpBuf.data());
-        strm.avail_out = BUFSIZE;
-    }
-
-    inflateEnd(&strm);
-
-    if (ok) *ok = true;
+    source.close();
+    dest.close();
     return output;
 }

--- a/src/base/utils/gzip.cpp
+++ b/src/base/utils/gzip.cpp
@@ -63,6 +63,7 @@ bool Utils::Gzip::compress(QIODevice &source, QIODevice &dest, const int level)
     int flush = Z_NO_FLUSH;
     do
     {
+        Q_ASSERT(source.isReadable());
         const qsizetype readBytes = source.read(in.data(), chunkSize);
         if (readBytes == -1)
         {
@@ -82,6 +83,7 @@ bool Utils::Gzip::compress(QIODevice &source, QIODevice &dest, const int level)
             ret = deflate(&strm, flush);
             Q_ASSERT(ret != Z_STREAM_ERROR);
 
+            Q_ASSERT(dest.isWritable());
             const qsizetype have = chunkSize - strm.avail_out;
             if (dest.write(out.data(), have) == -1)
             {
@@ -159,6 +161,7 @@ bool Utils::Gzip::decompress(QIODevice &source, QIODevice &dest)
 
     do
     {
+        Q_ASSERT(source.isReadable());
         const qsizetype readBytes = source.read(in.data(), chunkSize);
         if (readBytes == -1)
         {
@@ -193,6 +196,7 @@ bool Utils::Gzip::decompress(QIODevice &source, QIODevice &dest)
                 return false;
             }
 
+            Q_ASSERT(dest.isWritable());
             const qsizetype have = chunkSize - strm.avail_out;
             if (dest.write(out.data(), have) == -1)
             {

--- a/src/base/utils/gzip.h
+++ b/src/base/utils/gzip.h
@@ -30,9 +30,12 @@
 #pragma once
 
 class QByteArray;
+class QIODevice;
 
 namespace Utils::Gzip
 {
+    bool compress(QIODevice &source, QIODevice &dest, int level = 6);
     QByteArray compress(const QByteArray &data, int level = 6, bool *ok = nullptr);
+    bool decompress(QIODevice &source, QIODevice &dest);
     QByteArray decompress(const QByteArray &data, bool *ok = nullptr);
 }

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -315,6 +315,7 @@ void OptionsDialog::loadBehaviorTabOptions()
     m_ui->spinFileLogSize->setValue(app()->fileLoggerMaxSize() / 1024);
     m_ui->spinFileLogAge->setValue(app()->fileLoggerAge());
     m_ui->comboFileLogAgeType->setCurrentIndex(app()->fileLoggerAgeType());
+    m_ui->checkFileLogCompressBackups->setChecked(app()->isFileLoggerCompressBackups());
     // Groupbox's check state  must be initialized after some of its children if they are manually enabled/disabled
     m_ui->checkFileLog->setChecked(app()->isFileLoggerEnabled());
 
@@ -386,6 +387,7 @@ void OptionsDialog::loadBehaviorTabOptions()
     connect(m_ui->spinFileLogSize, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->spinFileLogAge, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->comboFileLogAgeType, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
+    connect(m_ui->checkFileLogCompressBackups, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
 
     connect(m_ui->checkBoxPerformanceWarning, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
 }
@@ -472,6 +474,7 @@ void OptionsDialog::saveBehaviorTabOptions() const
     app()->setFileLoggerAgeType(m_ui->comboFileLogAgeType->currentIndex());
     app()->setFileLoggerDeleteOld(m_ui->checkFileLogDelete->isChecked());
     app()->setFileLoggerEnabled(m_ui->checkFileLog->isChecked());
+    app()->setFileLoggerCompressBackups(m_ui->checkFileLogCompressBackups->isChecked());
 
     app()->setStartUpWindowState(m_ui->windowStateComboBox->currentData().value<WindowState>());
 

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -752,6 +752,16 @@
                  </item>
                 </layout>
                </item>
+               <item>
+                <widget class="QCheckBox" name="checkFileLogCompressBackups">
+                 <property name="text">
+                  <string>Compress log backups with gzip</string>
+                 </property>
+                 <property name="toolTip">
+                  <string>Be careful enabling this option. Files compressed with gzip can't be opened directly on Windows OS without 3rd-party tools.</string>
+                 </property>
+                </widget>
+               </item>
               </layout>
              </widget>
             </item>

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -119,6 +119,7 @@ void AppController::preferencesAction()
     data[u"file_log_delete_old"_s] = app()->isFileLoggerDeleteOld();
     data[u"file_log_age"_s] = app()->fileLoggerAge();
     data[u"file_log_age_type"_s] = app()->fileLoggerAgeType();
+    data[u"file_log_compress_backups"_s] = app()->isFileLoggerCompressBackups();
 
     // Downloads
     // When adding a torrent
@@ -481,6 +482,8 @@ void AppController::setPreferencesAction()
         app()->setFileLoggerAge(it.value().toInt());
     if (hasKey(u"file_log_age_type"_s))
         app()->setFileLoggerAgeType(it.value().toInt());
+    if (hasKey(u"file_log_compress_backups"_s))
+        app()->setFileLoggerCompressBackups(it.value().toBool());
 
     // Downloads
     // When adding a torrent

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -34,6 +34,10 @@
                     </select>
                 </td>
             </tr>
+            <tr title="QBT_TR(Be careful enabling this option. Files compressed with gzip can't be opened directly on Windows OS without 3rd-party tools.)QBT_TR[CONTEXT=OptionsDialog]">
+                <td><input type="checkbox" id="filelog_compress_backups_checkbox" /></td>
+                <td><label for="filelog_compress_backups_checkbox">QBT_TR(Compress log backups with gzip)QBT_TR[CONTEXT=OptionsDialog]</label></td>
+            </tr>
         </table>
     </fieldset>
 
@@ -1509,6 +1513,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             $('filelog_save_path_input').setProperty('disabled', !isFileLogEnabled);
             $('filelog_backup_checkbox').setProperty('disabled', !isFileLogEnabled);
             $('filelog_delete_old_checkbox').setProperty('disabled', !isFileLogEnabled);
+            $('filelog_compress_backups_checkbox').setProperty('disabled', !isFileLogEnabled);
 
             updateFileLogBackupEnabled();
             updateFileLogDeleteEnabled();
@@ -1887,6 +1892,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                         $('filelog_delete_old_checkbox').setProperty('checked', pref.file_log_delete_old);
                         $('filelog_age_input').setProperty('value', pref.file_log_age);
                         $('filelog_age_type_select').setProperty('value', pref.file_log_age_type);
+                        $('filelog_compress_backups_checkbox').setProperty('checked', pref.file_log_compress_backups);
                         updateFileLogEnabled();
 
                         // Downloads tab
@@ -2276,6 +2282,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             settings.set('file_log_delete_old', $('filelog_delete_old_checkbox').getProperty('checked'));
             settings.set('file_log_age', $('filelog_age_input').getProperty('value'));
             settings.set('file_log_age_type', $('filelog_age_type_select').getProperty('value'));
+            settings.set('file_log_compress_backups', $('filelog_compress_backups_checkbox').getProperty('checked'));
 
             // Downloads tab
             // When adding a torrent

--- a/test/testutilsgzip.cpp
+++ b/test/testutilsgzip.cpp
@@ -26,6 +26,7 @@
  * exception statement from your version.
  */
 
+#include <QBuffer>
 #include <QObject>
 #include <QTest>
 
@@ -46,9 +47,16 @@ private slots:
         // compressed data is not reproducible, see: https://stackoverflow.com/questions/30150972/are-there-test-vectors-available-for-gzip
         const QByteArray data = QByteArrayLiteral("abc");
 
-        bool ok = false;
-        const QByteArray compressedData = Utils::Gzip::compress(data, 6, &ok);
-        QVERIFY(ok);
+        {
+            bool ok = false;
+            const QByteArray compressedData = Utils::Gzip::compress(data, 6, &ok);
+            QVERIFY(ok);
+        }
+
+        {
+            const QByteArray compressedData = Utils::Gzip::compress(data, 6);
+            QVERIFY(!compressedData.isEmpty());
+        }
     }
 
     void testDecompress() const
@@ -60,10 +68,88 @@ private slots:
         QVERIFY(ok);
         QVERIFY(compressedData != data);
 
-        ok = false;
-        const QByteArray decompressedData = Utils::Gzip::decompress(compressedData, &ok);
+        {
+            ok = false;
+            const QByteArray decompressedData = Utils::Gzip::decompress(compressedData, &ok);
+            QVERIFY(ok);
+            QCOMPARE(decompressedData, data);
+        }
+
+        {
+            const QByteArray decompressedData = Utils::Gzip::decompress(compressedData);
+            QCOMPARE(decompressedData, data);
+        }
+    }
+
+    void testCompressQIODevice() const
+    {
+        const QByteArray data = QByteArrayLiteral("abc");
+        bool ok = false;
+
+        QBuffer inBuff;
+        inBuff.setData(data);
+        inBuff.open(QIODevice::ReadOnly);
+        QBuffer outBuff;
+        outBuff.open(QIODevice::WriteOnly);
+        ok = Utils::Gzip::compress(inBuff, outBuff, 6);
+        inBuff.close();
+        outBuff.close();
         QVERIFY(ok);
-        QCOMPARE(decompressedData, data);
+
+        QFile file {};
+        outBuff.open(QIODevice::WriteOnly);
+        ok = Utils::Gzip::compress(file, outBuff, 6);
+        outBuff.close();
+        QVERIFY(!ok);
+
+        inBuff.open(QIODevice::ReadOnly);
+        ok = Utils::Gzip::compress(inBuff, file, 6);
+        inBuff.close();
+        QVERIFY(!ok);
+
+        ok = Utils::Gzip::compress(file, file, 6);
+        QVERIFY(!ok);
+    }
+
+    void testDecompressQIODevice() const
+    {
+        const QByteArray data = QByteArrayLiteral("abc");
+        bool ok = false;
+
+        QBuffer inBuff;
+        inBuff.setData(data);
+        inBuff.open(QIODevice::ReadOnly);
+        QBuffer outBuff;
+        outBuff.open(QIODevice::WriteOnly);
+        ok = Utils::Gzip::compress(inBuff, outBuff, 6);
+        const QByteArray compressedData = outBuff.data();
+        inBuff.close();
+        outBuff.close();
+        QVERIFY(ok);
+
+        inBuff.setData(compressedData);
+        inBuff.open(QIODevice::ReadOnly);
+        outBuff.buffer().clear();
+        outBuff.open(QIODevice::WriteOnly);
+        ok = Utils::Gzip::decompress(inBuff, outBuff);
+        inBuff.close();
+        outBuff.close();
+        QVERIFY(ok);
+        QCOMPARE(data, outBuff.data());
+
+        QFile file {};
+        outBuff.open(QIODevice::WriteOnly);
+        ok = Utils::Gzip::decompress(file, outBuff);
+        outBuff.close();
+        QVERIFY(!ok);
+
+        inBuff.open(QIODevice::ReadOnly);
+        ok = Utils::Gzip::decompress(inBuff, file);
+        inBuff.close();
+        QVERIFY(!ok);
+
+        ok = Utils::Gzip::decompress(file, file);
+        QVERIFY(!ok);
     }
 };
 


### PR DESCRIPTION
Some operations (such as updating RSS schedulely) will make qbittorrent generate a lot of messages. But the qbittorrent will delete old backups only at startup previously. If qbittorrent is running for a long time, log backups will pile up over time.

The main changes in this PR are:
1. Delete obsolete backups when a new backup is generated (previously only at startup). The backups will also be sorted.
2. Allow to compress the log backups by gzip (disabled by default).

~84143d487031282669c5a40eb3022747c6ff030c is a little hacking way to implement log compression with streams. I hesitate to add this because I find that the max allowed log file size is 1000MiB.~
