### PR TITLE
Delegate string hashing to standard library

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -125,7 +125,7 @@ namespace std
 {
     uint qHash(const std::string &key, uint seed = 0)
     {
-        return qHash(QByteArray::fromRawData(key.data(), static_cast<int>(key.length())), seed);
+        return ::qHash(std::hash<std::string> {}(key), seed);
     }
 }
 

--- a/src/base/digest32.h
+++ b/src/base/digest32.h
@@ -167,6 +167,6 @@ std::size_t qHash(const Digest32<N> &key, const std::size_t seed = 0)
 template <int N>
 uint qHash(const Digest32<N> &key, const uint seed = 0)
 {
-    return static_cast<uint>((std::hash<typename Digest32<N>::UnderlyingType> {})(key)) ^ seed;
+    return ::qHash(std::hash<typename Digest32<N>::UnderlyingType> {}(key), seed);
 }
 #endif


### PR DESCRIPTION
Since standard library could have platform dependent specialized hashing functions.
Also the main idea is to let `qHash` handle whatever integer type `std::hash` returns and mix it with `seed` accordingly.

ps. this should be backported once merged.