### PR TITLE
Use tray icon from system theme only if option is set

### DIFF
--- a/src/gui/desktopintegration.cpp
+++ b/src/gui/desktopintegration.cpp
@@ -38,7 +38,6 @@
 #include <QSystemTrayIcon>
 #endif
 
-#include "base/logger.h"
 #include "base/preferences.h"
 #include "uithememanager.h"
 
@@ -243,7 +242,7 @@ void DesktopIntegration::onPreferencesChanged()
         if (m_systrayIcon)
         {
             // Reload systray icon
-            m_systrayIcon->setIcon(UIThemeManager::instance()->getSystrayIcon());
+            m_systrayIcon->setIcon(getSystrayIcon());
         }
         else
         {
@@ -264,7 +263,7 @@ void DesktopIntegration::createTrayIcon()
 {
     Q_ASSERT(!m_systrayIcon);
 
-    m_systrayIcon = new QSystemTrayIcon(UIThemeManager::instance()->getSystrayIcon(), this);
+    m_systrayIcon = new QSystemTrayIcon(getSystrayIcon(), this);
 
     m_systrayIcon->setToolTip(m_toolTip);
 
@@ -283,5 +282,22 @@ void DesktopIntegration::createTrayIcon()
 
     m_systrayIcon->show();
     emit stateChanged();
+}
+
+QIcon DesktopIntegration::getSystrayIcon() const
+{
+    const TrayIcon::Style style = Preferences::instance()->trayIconStyle();
+    switch (style)
+    {
+    default:
+    case TrayIcon::Style::Normal:
+        return UIThemeManager::instance()->getIcon(u"qbittorrent-tray"_qs);
+
+    case TrayIcon::Style::MonoDark:
+        return UIThemeManager::instance()->getIcon(u"qbittorrent-tray-dark"_qs);
+
+    case TrayIcon::Style::MonoLight:
+        return UIThemeManager::instance()->getIcon(u"qbittorrent-tray-light"_qs);
+    }
 }
 #endif // Q_OS_MACOS

--- a/src/gui/desktopintegration.h
+++ b/src/gui/desktopintegration.h
@@ -78,6 +78,7 @@ private:
     void onPreferencesChanged();
 #ifndef Q_OS_MACOS
     void createTrayIcon();
+    QIcon getSystrayIcon() const;
 #endif // Q_OS_MACOS
 
     CachedSettingValue<bool> m_storeNotificationEnabled;

--- a/src/gui/uithememanager.cpp
+++ b/src/gui/uithememanager.cpp
@@ -121,7 +121,7 @@ QIcon UIThemeManager::getIcon(const QString &iconId, [[maybe_unused]] const QStr
     if (m_useSystemIcons)
     {
         auto icon = QIcon::fromTheme(iconId);
-        if (icon.name() != iconId)
+        if (icon.isNull() || icon.availableSizes().isEmpty())
             icon = QIcon::fromTheme(fallback, QIcon(m_themeSource->getIconPath(iconId, colorMode).data()));
         return icon;
     }
@@ -173,36 +173,6 @@ QColor UIThemeManager::getColor(const QString &id) const
 
     return color;
 }
-
-#ifndef Q_OS_MACOS
-QIcon UIThemeManager::getSystrayIcon() const
-{
-    const TrayIcon::Style style = Preferences::instance()->trayIconStyle();
-    switch (style)
-    {
-#if defined(Q_OS_UNIX)
-    case TrayIcon::Style::Normal:
-        return QIcon::fromTheme(u"qbittorrent-tray"_qs);
-    case TrayIcon::Style::MonoDark:
-        return QIcon::fromTheme(u"qbittorrent-tray-dark"_qs);
-    case TrayIcon::Style::MonoLight:
-        return QIcon::fromTheme(u"qbittorrent-tray-light"_qs);
-#else
-    case TrayIcon::Style::Normal:
-        return getIcon(u"qbittorrent-tray"_qs);
-    case TrayIcon::Style::MonoDark:
-        return getIcon(u"qbittorrent-tray-dark"_qs);
-    case TrayIcon::Style::MonoLight:
-        return getIcon(u"qbittorrent-tray-light"_qs);
-#endif
-    default:
-        break;
-    }
-
-    // As a failsafe in case the enum is invalid
-    return getIcon(u"qbittorrent-tray"_qs);
-}
-#endif
 
 void UIThemeManager::applyPalette() const
 {

--- a/src/gui/uithememanager.h
+++ b/src/gui/uithememanager.h
@@ -57,10 +57,6 @@ public:
 
     QColor getColor(const QString &id) const;
 
-#ifndef Q_OS_MACOS
-    QIcon getSystrayIcon() const;
-#endif
-
 private:
     UIThemeManager(); // singleton class
 


### PR DESCRIPTION
Currently qBittorrent uses system tray icon from the Linux system theme regardless of whether the corresponding option is enabled. It looks inconsistent/incorrect to me and I believe this should be fixed.