### PR TITLE
Deny remote user login with default credentials

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -98,6 +98,8 @@
 #include "gui/uithememanager.h"
 #include "gui/utils.h"
 #include "gui/windowstate.h"
+#else
+#include "base/utils/password.h"
 #endif // DISABLE_GUI
 
 #ifndef DISABLE_WEBUI
@@ -898,7 +900,7 @@ try
                 + tr("To control qBittorrent, access the WebUI at: %1").arg(url);
         printf("%s\n", qUtf8Printable(mesg));
 
-        if (pref->getWebUIPassword() == QByteArrayLiteral("ARQ77eY1NUZaQsuDHbIMCA==:0WMRkYTUWVT9wVvdDtHAjU9b3b7uB8NR1Gur2hmQCvCDpm39Q+PsJRJPaCU51dEiz+dTzh8qbPsL8WkFljQYFQ=="))
+        if (pref->getWebUIPassword() == Utils::Password::defaultPassword)
         {
             const QString warning = tr("The Web UI administrator username is: %1").arg(pref->getWebUiUsername()) + u'\n'
                     + tr("The Web UI administrator password has not been changed from the default: %1").arg(u"adminadmin"_qs) + u'\n'

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -57,6 +57,7 @@
 #include "profile.h"
 #include "settingsstorage.h"
 #include "utils/fs.h"
+#include "utils/password.h"
 
 namespace
 {
@@ -613,9 +614,7 @@ void Preferences::setWebUiUsername(const QString &username)
 
 QByteArray Preferences::getWebUIPassword() const
 {
-    // default: adminadmin
-    const auto defaultValue = QByteArrayLiteral("ARQ77eY1NUZaQsuDHbIMCA==:0WMRkYTUWVT9wVvdDtHAjU9b3b7uB8NR1Gur2hmQCvCDpm39Q+PsJRJPaCU51dEiz+dTzh8qbPsL8WkFljQYFQ==");
-    return value(u"Preferences/WebUI/Password_PBKDF2"_qs, defaultValue);
+    return value(u"Preferences/WebUI/Password_PBKDF2"_qs, Utils::Password::defaultPassword);
 }
 
 void Preferences::setWebUIPassword(const QByteArray &password)

--- a/src/base/utils/password.h
+++ b/src/base/utils/password.h
@@ -28,11 +28,13 @@
 
 #pragma once
 
-class QByteArray;
+#include  <QByteArray>
+
 class QString;
 
 namespace Utils::Password
 {
+    inline const QByteArray defaultPassword = QByteArrayLiteral("ARQ77eY1NUZaQsuDHbIMCA==:0WMRkYTUWVT9wVvdDtHAjU9b3b7uB8NR1Gur2hmQCvCDpm39Q+PsJRJPaCU51dEiz+dTzh8qbPsL8WkFljQYFQ==");
     // Implements constant-time comparison to protect against timing attacks
     // Taken from https://crackstation.net/hashing-security.htm
     bool slowEquals(const QByteArray &a, const QByteArray &b);

--- a/src/webui/api/authcontroller.cpp
+++ b/src/webui/api/authcontroller.cpp
@@ -70,7 +70,7 @@ void AuthController::loginAction()
     const QByteArray secret {pref->getWebUIPassword()};
     if (!m_sessionManager->isLocalClient()
         && (username == u"admin"_qs)
-        && (secret == QByteArrayLiteral("ARQ77eY1NUZaQsuDHbIMCA==:0WMRkYTUWVT9wVvdDtHAjU9b3b7uB8NR1Gur2hmQCvCDpm39Q+PsJRJPaCU51dEiz+dTzh8qbPsL8WkFljQYFQ==")))
+        && (secret == Utils::Password::defaultPassword))
     {
         if (Preferences::instance()->getWebUIMaxAuthFailCount() > 0)
             increaseFailedAttempts();

--- a/src/webui/api/authcontroller.cpp
+++ b/src/webui/api/authcontroller.cpp
@@ -68,6 +68,20 @@ void AuthController::loginAction()
 
     const QString username {pref->getWebUiUsername()};
     const QByteArray secret {pref->getWebUIPassword()};
+    if (!m_sessionManager->isLocalClient()
+        && (username == u"admin"_qs)
+        && (secret == QByteArrayLiteral("ARQ77eY1NUZaQsuDHbIMCA==:0WMRkYTUWVT9wVvdDtHAjU9b3b7uB8NR1Gur2hmQCvCDpm39Q+PsJRJPaCU51dEiz+dTzh8qbPsL8WkFljQYFQ==")))
+    {
+        if (Preferences::instance()->getWebUIMaxAuthFailCount() > 0)
+            increaseFailedAttempts();
+        LogMsg(tr("WebAPI login failure. Reason: Remote connection with the default credentials is prohibited.")
+               , Log::WARNING);
+        throw APIError(APIErrorType::AccessDenied
+                       , tr("Remote connection with the default credentials is prohibited. Change the default credentials by connecting from %1."
+                          , "Remote connection with the default credentials is prohibited. Change the default credentials by connecting from localhost.")
+                           .arg(u"localhost"_qs));
+    }
+
     const bool usernameEqual = Utils::Password::slowEquals(usernameFromWeb.toUtf8(), username.toUtf8());
     const bool passwordEqual = Utils::Password::PBKDF2::verify(secret, passwordFromWeb);
 

--- a/src/webui/api/isessionmanager.h
+++ b/src/webui/api/isessionmanager.h
@@ -42,6 +42,7 @@ struct ISessionManager
 {
     virtual ~ISessionManager() = default;
     virtual QString clientId() const = 0;
+    virtual bool isLocalClient() const = 0;
     virtual ISession *session() = 0;
     virtual void sessionStart() = 0;
     virtual void sessionEnd() = 0;

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -586,6 +586,11 @@ QString WebApplication::clientId() const
     return m_clientAddress.toString();
 }
 
+bool WebApplication::isLocalClient() const
+{
+    return Utils::Net::isLoopbackAddress(m_clientAddress);
+}
+
 void WebApplication::sessionInitialize()
 {
     Q_ASSERT(!m_currentSession);
@@ -638,7 +643,7 @@ QString WebApplication::generateSid() const
 
 bool WebApplication::isAuthNeeded()
 {
-    if (!m_isLocalAuthEnabled && Utils::Net::isLoopbackAddress(m_clientAddress))
+    if (!m_isLocalAuthEnabled && isLocalClient())
         return false;
     if (m_isAuthSubnetWhitelistEnabled && Utils::Net::isIPInSubnets(m_clientAddress, m_authSubnetWhitelist))
         return false;

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -98,6 +98,7 @@ public:
     Http::Response processRequest(const Http::Request &request, const Http::Environment &env) override;
 
     QString clientId() const override;
+    bool isLocalClient() const override;
     WebSession *session() override;
     void sessionStart() override;
     void sessionEnd() override;

--- a/src/webui/www/public/index.html
+++ b/src/webui/www/public/index.html
@@ -23,14 +23,14 @@
             <img src="images/qbittorrent-tray.svg" alt="qBittorrent logo" />
         </div>
         <div id="formplace" class="col">
-            <form id="loginform" method="post" onsubmit="submitLoginForm();">
+            <form id="loginform" method="post" onsubmit="submitLoginForm(event);">
                 <div class="row">
                     <label for="username">QBT_TR(Username)QBT_TR[CONTEXT=HttpServer]</label><br />
-                    <input type="text" id="username" name="username" autocomplete="username" />
+                    <input type="text" id="username" name="username" autocomplete="username" required />
                 </div>
                 <div class="row">
                     <label for="password">QBT_TR(Password)QBT_TR[CONTEXT=HttpServer]</label><br />
-                    <input type="password" id="password" name="password" autocomplete="current-password" />
+                    <input type="password" id="password" name="password" autocomplete="current-password" required />
                 </div>
                 <div class="row">
                     <input type="submit" id="login" value="QBT_TR(Login)QBT_TR[CONTEXT=HttpServer]" />

--- a/src/webui/www/public/scripts/login.js
+++ b/src/webui/www/public/scripts/login.js
@@ -39,16 +39,25 @@ document.addEventListener('DOMContentLoaded', function() {
 
 function submitLoginForm() {
     const errorMsgElement = document.getElementById('error_msg');
+    errorMsgElement.textContent = "";
 
     const xhr = new XMLHttpRequest();
     xhr.open('POST', 'api/v2/auth/login', true);
     xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded; charset=UTF-8');
     xhr.addEventListener('readystatechange', function() {
         if (xhr.readyState === 4) { // DONE state
-            if ((xhr.status === 200) && (xhr.responseText === "Ok."))
-                location.reload(true);
-            else
-                errorMsgElement.textContent = 'QBT_TR(Invalid Username or Password.)QBT_TR[CONTEXT=HttpServer]';
+            if (xhr.status === 200) {
+                if (xhr.responseText === "Ok.")
+                    location.reload(true);
+                else
+                    errorMsgElement.textContent = 'QBT_TR(Invalid Username or Password.)QBT_TR[CONTEXT=HttpServer]';
+            }
+            else if ((xhr.status === 403) && xhr.responseText) {
+                errorMsgElement.textContent = xhr.responseText;
+            }
+            else {
+                errorMsgElement.textContent = 'QBT_TR(Generic login error.)QBT_TR[CONTEXT=HttpServer]';
+            }
         }
     });
     xhr.addEventListener('error', function() {

--- a/src/webui/www/public/scripts/login.js
+++ b/src/webui/www/public/scripts/login.js
@@ -31,13 +31,10 @@
 document.addEventListener('DOMContentLoaded', function() {
     document.getElementById('username').focus();
     document.getElementById('username').select();
-
-    document.getElementById('loginform').addEventListener('submit', function(e) {
-        e.preventDefault();
-    });
 });
 
-function submitLoginForm() {
+function submitLoginForm(event) {
+    event.preventDefault();
     const errorMsgElement = document.getElementById('error_msg');
     errorMsgElement.textContent = "";
 


### PR DESCRIPTION
Apparently there are users exposing the webui client to the internet without changing the default credentials. And apparently there are attackers out there scanning for exposed clients and then logging in with the default credentials and running code (crypto miners).

With this PR users will be able to connect with default credentials only from localhost.
If connecting remotely, they login page will show them the reason the login failed and ask them to login locally to change the credentials (or manually set them in the configuration file).

Closes #13833
Closes #16529
Closes #18731