### PR TITLE
Index peers by PeerID

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(qbt_base STATIC
     bittorrent/nativesessionextension.h
     bittorrent/nativetorrentextension.h
     bittorrent/peeraddress.h
+    bittorrent/peerid.h
     bittorrent/peerinfo.h
     bittorrent/portforwarderimpl.h
     bittorrent/resumedatastorage.h

--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -25,6 +25,7 @@ HEADERS += \
     $$PWD/bittorrent/nativesessionextension.h \
     $$PWD/bittorrent/nativetorrentextension.h \
     $$PWD/bittorrent/peeraddress.h \
+    $$PWD/bittorrent/peerid.h \
     $$PWD/bittorrent/peerinfo.h \
     $$PWD/bittorrent/portforwarderimpl.h \
     $$PWD/bittorrent/resumedatastorage.h \

--- a/src/base/bittorrent/infohash.h
+++ b/src/base/bittorrent/infohash.h
@@ -33,15 +33,8 @@
 #endif
 
 #include <QtGlobal>
-#include <QMetaType>
 
 #include "base/digest32.h"
-
-using SHA1Hash = Digest32<160>;
-using SHA256Hash = Digest32<256>;
-
-Q_DECLARE_METATYPE(SHA1Hash)
-Q_DECLARE_METATYPE(SHA256Hash)
 
 namespace BitTorrent
 {

--- a/src/base/bittorrent/peerid.h
+++ b/src/base/bittorrent/peerid.h
@@ -1,0 +1,36 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2023  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+#include "base/digest32.h"
+
+namespace BitTorrent
+{
+    using PeerID = SHA1Hash;
+}

--- a/src/base/bittorrent/peerinfo.cpp
+++ b/src/base/bittorrent/peerinfo.cpp
@@ -61,7 +61,7 @@ bool PeerInfo::fromLSD() const
 
 QString PeerInfo::country() const
 {
-    if (m_country.isEmpty())
+    if (m_country.isEmpty() && !useI2PSocket())
         m_country = Net::GeoIPManager::instance()->lookup(address().ip);
     return m_country;
 }
@@ -164,6 +164,11 @@ bool PeerInfo::isRC4Encrypted() const
 bool PeerInfo::isPlaintextEncrypted() const
 {
     return static_cast<bool>(m_nativeInfo.flags & lt::peer_info::plaintext_encrypted);
+}
+
+PeerID PeerInfo::id() const
+{
+    return m_nativeInfo.pid;
 }
 
 PeerAddress PeerInfo::address() const

--- a/src/base/bittorrent/peerinfo.h
+++ b/src/base/bittorrent/peerinfo.h
@@ -32,6 +32,8 @@
 
 #include <QCoreApplication>
 
+#include "peerid.h"
+
 class QBitArray;
 
 namespace BitTorrent
@@ -75,6 +77,7 @@ namespace BitTorrent
         bool isRC4Encrypted() const;
         bool isPlaintextEncrypted() const;
 
+        PeerID id() const;
         PeerAddress address() const;
         QString client() const;
         QString peerIdClient() const;

--- a/src/base/digest32.h
+++ b/src/base/digest32.h
@@ -33,6 +33,7 @@
 #include <QtGlobal>
 #include <QByteArray>
 #include <QHash>
+#include <QMetaType>
 #include <QSharedData>
 #include <QSharedDataPointer>
 #include <QString>
@@ -136,6 +137,12 @@ private:
     UnderlyingType m_nativeDigest;
     mutable QString m_hashString;
 };
+
+using SHA1Hash = Digest32<160>;
+using SHA256Hash = Digest32<256>;
+
+Q_DECLARE_METATYPE(SHA1Hash)
+Q_DECLARE_METATYPE(SHA256Hash)
 
 template <int N>
 bool operator==(const Digest32<N> &left, const Digest32<N> &right)

--- a/src/gui/properties/peerlistwidget.h
+++ b/src/gui/properties/peerlistwidget.h
@@ -1,5 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2023  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  *
  * This program is free software; you can redistribute it and/or
@@ -29,10 +30,12 @@
 #pragma once
 
 #include <QHash>
+#include <QHostAddress>
 #include <QSet>
 #include <QTreeView>
 
-class QHostAddress;
+#include "base/bittorrent/peerid.h"
+
 class QStandardItem;
 class QStandardItemModel;
 
@@ -74,7 +77,6 @@ public:
         TOT_UP,
         RELEVANCE,
         DOWNLOADING_PIECE,
-        IP_HIDDEN,
 
         COL_COUNT
     };
@@ -107,8 +109,14 @@ private:
     PeerListSortModel *m_proxyModel = nullptr;
     PropertiesWidget *m_properties = nullptr;
     Net::ReverseResolution *m_resolver = nullptr;
-    QHash<PeerEndpoint, QStandardItem *> m_peerItems;
-    QList<QStandardItem *> m_I2PPeerItems;
-    QHash<QHostAddress, QSet<QStandardItem *>> m_itemsByIP;  // must be kept in sync with `m_peerItems`
+
+    struct PeerItemWrapper
+    {
+        QStandardItem *item;
+        QHostAddress ip;
+    };
+
+    QHash<BitTorrent::PeerID, PeerItemWrapper> m_peerItems;
+    QHash<QHostAddress, QSet<QStandardItem *>> m_peerItemsByIP;
     bool m_resolveCountries;
 };


### PR DESCRIPTION
Index the peers by the same identifier as used in libtorrent to avoid inconsistencies and better support I2P peers that have no IP/port by which peers were indexed before.

Fixes #18741.