### PR TITLE
Restrict Web API usage on default credentials

### DIFF
--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -747,9 +747,19 @@ void AppController::setPreferencesAction()
         pref->setWebUIHttpsKeyPath(Path(it.value().toString()));
     // Authentication
     if (hasKey(u"web_ui_username"_qs))
-        pref->setWebUiUsername(it.value().toString());
+    {
+        const QString username = it.value().toString();
+        pref->setWebUiUsername(username);
+        if (!username.isEmpty() && (username != u"admin"_qs))
+            static_cast<WebSession*>(parent())->setRestricted(false);
+    }
     if (hasKey(u"web_ui_password"_qs))
+    {
+        const QString password = it.value().toString();
         pref->setWebUIPassword(Utils::Password::PBKDF2::generate(it.value().toByteArray()));
+        if (const QString password = it.value().toString(); !password.isEmpty() && (password != u"adminadmin"_qs))
+            static_cast<WebSession*>(parent())->setRestricted(false);
+    }
     if (hasKey(u"bypass_local_auth"_qs))
         pref->setWebUiLocalAuthEnabled(!it.value().toBool());
     if (hasKey(u"bypass_auth_subnet_whitelist_enabled"_qs))

--- a/src/webui/api/authcontroller.cpp
+++ b/src/webui/api/authcontroller.cpp
@@ -75,7 +75,9 @@ void AuthController::loginAction()
     {
         m_clientFailedLogins.remove(clientAddr);
 
-        m_sessionManager->sessionStart();
+        const bool restricted = (Utils::Password::slowEquals(usernameFromWeb.toUtf8(), u"admin"_qs.toUtf8())
+                                 && Utils::Password::slowEquals(passwordFromWeb.toUtf8(), u"adminadmin"_qs.toUtf8()));
+        m_sessionManager->sessionStart(restricted);
         setResult(u"Ok."_qs);
         LogMsg(tr("WebAPI login success. IP: %1").arg(clientAddr));
     }

--- a/src/webui/api/isessionmanager.h
+++ b/src/webui/api/isessionmanager.h
@@ -43,6 +43,6 @@ struct ISessionManager
     virtual ~ISessionManager() = default;
     virtual QString clientId() const = 0;
     virtual ISession *session() = 0;
-    virtual void sessionStart() = 0;
+    virtual void sessionStart(bool restrictedAccess) = 0;
     virtual void sessionEnd() = 0;
 };

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -67,6 +67,8 @@ public:
 
     bool hasExpired(qint64 seconds) const;
     void updateTimestamp();
+    bool isRestricted() const;
+    void setRestricted(bool restricted);
 
     template <typename T>
     void registerAPIController(const QString &scope)
@@ -78,6 +80,7 @@ public:
     APIController *getAPIController(const QString &scope) const;
 
 private:
+    bool m_restricted = true;
     const QString m_sid;
     QElapsedTimer m_timer;  // timestamp
     QMap<QString, APIController *> m_apiControllers;
@@ -99,7 +102,7 @@ public:
 
     QString clientId() const override;
     WebSession *session() override;
-    void sessionStart() override;
+    void sessionStart(bool restrictedAccess) override;
     void sessionEnd() override;
 
     const Http::Request &request() const;
@@ -121,6 +124,7 @@ private:
     void sessionInitialize();
     bool isAuthNeeded();
     bool isPublicAPI(const QString &scope, const QString &action) const;
+    bool isRestrictedAPI(const QString &scope, const QString &action) const;
 
     bool isCrossSiteRequest(const Http::Request &request) const;
     bool validateHostHeader(const QStringList &domains) const;


### PR DESCRIPTION
This more of a proof-of-concept. It isn't fully fleshed out.
I want to hear input first.
It is an alternative approach to PR #18735.

The HTML part would look like this:
Assume a new API endpoint `/api/v2/auth/Level` which returns `Restricted` on default credentials.
`private/index.html` ->onLoad check if  `Restricted`. On yes, display form to change credentials. On no, load the UI.