### PR TITLE
Force terminate libtorrent session after saving resume data

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -256,6 +256,8 @@ namespace BitTorrent
         virtual void setPerformanceWarningEnabled(bool enable) = 0;
         virtual int saveResumeDataInterval() const = 0;
         virtual void setSaveResumeDataInterval(int value) = 0;
+        virtual int shutdownTimeout() const = 0;
+        virtual void setShutdownTimeout(int value) = 0;
         virtual int port() const = 0;
         virtual void setPort(int port) = 0;
         virtual bool isSSLEnabled() const = 0;

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -58,6 +58,7 @@
 #include <libtorrent/session_status.hpp>
 #include <libtorrent/torrent_info.hpp>
 
+#include <QDeadlineTimer>
 #include <QDebug>
 #include <QDir>
 #include <QHostAddress>
@@ -480,6 +481,7 @@ SessionImpl::SessionImpl(QObject *parent)
     , m_isBandwidthSchedulerEnabled(BITTORRENT_SESSION_KEY(u"BandwidthSchedulerEnabled"_s), false)
     , m_isPerformanceWarningEnabled(BITTORRENT_SESSION_KEY(u"PerformanceWarning"_s), false)
     , m_saveResumeDataInterval(BITTORRENT_SESSION_KEY(u"SaveResumeDataInterval"_s), 60)
+    , m_shutdownTimeout(BITTORRENT_SESSION_KEY(u"ShutdownTimeout"_s), -1)
     , m_port(BITTORRENT_SESSION_KEY(u"Port"_s), -1)
     , m_sslEnabled(BITTORRENT_SESSION_KEY(u"SSL/Enabled"_s), false)
     , m_sslPort(BITTORRENT_SESSION_KEY(u"SSL/Port"_s), -1)
@@ -602,6 +604,9 @@ SessionImpl::~SessionImpl()
 {
     m_nativeSession->pause();
 
+    const qint64 timeout = (m_shutdownTimeout >= 0) ? (m_shutdownTimeout * 1000) : -1;
+    QDeadlineTimer shutdownDeadlineTimer {timeout};
+
     if (m_torrentsQueueChanged)
     {
         m_nativeSession->post_torrent_updates({});
@@ -628,8 +633,22 @@ SessionImpl::~SessionImpl()
     m_asyncWorker->clear();
     m_asyncWorker->waitForDone();
 
-    qDebug("Deleting libtorrent session...");
+    auto *nativeSessionProxy = new lt::session_proxy(m_nativeSession->abort());
     delete m_nativeSession;
+
+    qDebug("Deleting resume data storage...");
+    delete m_resumeDataStorage;
+    LogMsg(tr("Saving resume data completed."));
+
+    auto *sessionTerminateThread = QThread::create([nativeSessionProxy]()
+    {
+        qDebug("Deleting libtorrent session...");
+        delete nativeSessionProxy;
+    });
+    connect(sessionTerminateThread, &QThread::finished, sessionTerminateThread, &QObject::deleteLater);
+    sessionTerminateThread->start();
+    if (sessionTerminateThread->wait(shutdownDeadlineTimer))
+        LogMsg(tr("BitTorrent session finished."));
 }
 
 QString SessionImpl::getDHTBootstrapNodes() const
@@ -3474,6 +3493,16 @@ void SessionImpl::setSaveResumeDataInterval(const int value)
     {
         m_resumeDataTimer->stop();
     }
+}
+
+int SessionImpl::shutdownTimeout() const
+{
+    return m_shutdownTimeout;
+}
+
+void SessionImpl::setShutdownTimeout(const int value)
+{
+    m_shutdownTimeout = value;
 }
 
 int SessionImpl::port() const

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -233,6 +233,8 @@ namespace BitTorrent
         void setPerformanceWarningEnabled(bool enable) override;
         int saveResumeDataInterval() const override;
         void setSaveResumeDataInterval(int value) override;
+        int shutdownTimeout() const override;
+        void setShutdownTimeout(int value) override;
         int port() const override;
         void setPort(int port) override;
         bool isSSLEnabled() const override;
@@ -688,6 +690,7 @@ namespace BitTorrent
         CachedSettingValue<bool> m_isBandwidthSchedulerEnabled;
         CachedSettingValue<bool> m_isPerformanceWarningEnabled;
         CachedSettingValue<int> m_saveResumeDataInterval;
+        CachedSettingValue<int> m_shutdownTimeout;
         CachedSettingValue<int> m_port;
         CachedSettingValue<bool> m_sslEnabled;
         CachedSettingValue<int> m_sslPort;

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -106,6 +106,7 @@ namespace
 #endif // Q_OS_MACOS || Q_OS_WIN
         PYTHON_EXECUTABLE_PATH,
         START_SESSION_PAUSED,
+        SESSION_SHUTDOWN_TIMEOUT,
 
         // libtorrent section
         LIBTORRENT_HEADER,
@@ -334,6 +335,8 @@ void AdvancedSettings::saveAdvancedSettings() const
     pref->setPythonExecutablePath(Path(m_pythonExecutablePath.text().trimmed()));
     // Start session paused
     session->setStartPaused(m_checkBoxStartSessionPaused.isChecked());
+    // Session shutdown timeout
+    session->setShutdownTimeout(m_spinBoxSessionShutdownTimeout.value());
     // Choking algorithm
     session->setChokingAlgorithm(m_comboBoxChokingAlgorithm.currentData().value<BitTorrent::ChokingAlgorithm>());
     // Seed choking algorithm
@@ -848,7 +851,16 @@ void AdvancedSettings::loadAdvancedSettings()
     addRow(PYTHON_EXECUTABLE_PATH, tr("Python executable path (may require restart)"), &m_pythonExecutablePath);
     // Start session paused
     m_checkBoxStartSessionPaused.setChecked(session->isStartPaused());
-    addRow(START_SESSION_PAUSED, tr("Start session in paused state"), &m_checkBoxStartSessionPaused);
+    addRow(START_SESSION_PAUSED, tr("Start BitTorrent session in paused state"), &m_checkBoxStartSessionPaused);
+    // Session shutdown timeout
+    m_spinBoxSessionShutdownTimeout.setMinimum(-1);
+    m_spinBoxSessionShutdownTimeout.setMaximum(std::numeric_limits<int>::max());
+    m_spinBoxSessionShutdownTimeout.setValue(session->shutdownTimeout());
+    m_spinBoxSessionShutdownTimeout.setSuffix(tr(" sec", " seconds"));
+    m_spinBoxSessionShutdownTimeout.setSpecialValueText(tr("-1 (unlimited)"));
+    m_spinBoxSessionShutdownTimeout.setToolTip(u"Sets the timeout for the session to be shut down gracefully, at which it will be force terminated.<br>Note that this does not apply to the saving resume data time."_s);
+    addRow(SESSION_SHUTDOWN_TIMEOUT, tr("BitTorrent session shutdown timeout [-1: unlimited]"), &m_spinBoxSessionShutdownTimeout);
+
     // Choking algorithm
     m_comboBoxChokingAlgorithm.addItem(tr("Fixed slots"), QVariant::fromValue(BitTorrent::ChokingAlgorithm::FixedSlots));
     m_comboBoxChokingAlgorithm.addItem(tr("Upload rate based"), QVariant::fromValue(BitTorrent::ChokingAlgorithm::RateBased));
@@ -946,6 +958,7 @@ void AdvancedSettings::addRow(const int row, const QString &text, T *widget)
 {
     auto *label = new QLabel(text);
     label->setOpenExternalLinks(true);
+    label->setToolTip(widget->toolTip());
 
     setCellWidget(row, PROPERTY, label);
     setCellWidget(row, VALUE, widget);

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -73,7 +73,7 @@ private:
              m_spinBoxOutgoingPortsMin, m_spinBoxOutgoingPortsMax, m_spinBoxUPnPLeaseDuration, m_spinBoxPeerToS,
              m_spinBoxListRefresh, m_spinBoxTrackerPort, m_spinBoxSendBufferWatermark, m_spinBoxSendBufferLowWatermark,
              m_spinBoxSendBufferWatermarkFactor, m_spinBoxConnectionSpeed, m_spinBoxSocketSendBufferSize, m_spinBoxSocketReceiveBufferSize, m_spinBoxSocketBacklogSize,
-             m_spinBoxMaxConcurrentHTTPAnnounces, m_spinBoxStopTrackerTimeout,
+             m_spinBoxMaxConcurrentHTTPAnnounces, m_spinBoxStopTrackerTimeout, m_spinBoxSessionShutdownTimeout,
              m_spinBoxSavePathHistoryLength, m_spinBoxPeerTurnover, m_spinBoxPeerTurnoverCutoff, m_spinBoxPeerTurnoverInterval, m_spinBoxRequestQueueSize;
     QCheckBox m_checkBoxOsCache, m_checkBoxRecheckCompleted, m_checkBoxResolveCountries, m_checkBoxResolveHosts,
               m_checkBoxProgramNotifications, m_checkBoxTorrentAddedNotifications, m_checkBoxReannounceWhenAddressChanged, m_checkBoxTrackerFavicon, m_checkBoxTrackerStatus,


### PR DESCRIPTION
The problem is that at the end of the session, `libtorrent` pedantically follows the protocol and tries to correctly de-announce torrents on all connected trackers. For various reasons, this may take a very long time, which causes dissatisfaction of users. qBittorrent is usually constantly running and exits when logging out or shutting down the computer, so if such problems occur, it prevents the system from shutting down, which is extremely unacceptable. Given that such graceful session shutdown is unimportant to the user, this patch modifies qBittorrent in such a way as to terminate the `libtorrent` session after resume data saving is completed. Since the network interaction takes place in parallel with the resume data saving, I added a small timeout that should be respected before the session is interrupted if the resume data is saved too quickly.

Closes #18697.