### PR TITLE
Inhibit system sleep while torrents are moving

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1927,7 +1927,7 @@ void MainWindow::updatePowerManagementState()
     const QVector<BitTorrent::Torrent *> allTorrents = BitTorrent::Session::instance()->torrents();
     const bool hasUnfinishedTorrents = std::any_of(allTorrents.cbegin(), allTorrents.cend(), [](const BitTorrent::Torrent *torrent)
     {
-        return (!torrent->isFinished() && !torrent->isMoving() && !torrent->isPaused() && !torrent->isErrored() && torrent->hasMetadata());
+        return (!torrent->isFinished() && !torrent->isPaused() && !torrent->isErrored() && torrent->hasMetadata()) || torrent->isMoving();
     });
     const bool hasRunningSeed = std::any_of(allTorrents.cbegin(), allTorrents.cend(), [](const BitTorrent::Torrent *torrent)
     {

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1927,7 +1927,7 @@ void MainWindow::updatePowerManagementState()
     const QVector<BitTorrent::Torrent *> allTorrents = BitTorrent::Session::instance()->torrents();
     const bool hasUnfinishedTorrents = std::any_of(allTorrents.cbegin(), allTorrents.cend(), [](const BitTorrent::Torrent *torrent)
     {
-        return (!torrent->isFinished() && !torrent->isPaused() && !torrent->isErrored() && torrent->hasMetadata());
+        return (!torrent->isFinished() && !torrent->isMoving() && !torrent->isPaused() && !torrent->isErrored() && torrent->hasMetadata());
     });
     const bool hasRunningSeed = std::any_of(allTorrents.cbegin(), allTorrents.cend(), [](const BitTorrent::Torrent *torrent)
     {

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1918,7 +1918,7 @@ void MainWindow::updatePowerManagementState()
     const bool preventFromSuspendWhenSeeding = Preferences::instance()->preventFromSuspendWhenSeeding();
 
     const QVector<BitTorrent::Torrent *> allTorrents = BitTorrent::Session::instance()->torrents();
-   const bool inhibitSuspend = std::any_of(allTorrents.cbegin(), allTorrents.cend(), [&](const BitTorrent::Torrent *torrent)
+    const bool inhibitSuspend = std::any_of(allTorrents.cbegin(), allTorrents.cend(), [&](const BitTorrent::Torrent *torrent)
     {
         if (preventFromSuspendWhenDownloading && (!torrent->isFinished() && !torrent->isPaused() && !torrent->isErrored() && torrent->hasMetadata()))
             return true;

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -311,9 +311,11 @@ MainWindow::MainWindow(IGUIApplication *app, WindowState initialState)
 
     connect(m_ui->actionManageCookies, &QAction::triggered, this, &MainWindow::manageCookies);
 
+    // Initialise system sleep inhibition timer
     m_pwr = new PowerManagement(this);
     m_preventTimer = new QTimer(this);
     connect(m_preventTimer, &QTimer::timeout, this, &MainWindow::updatePowerManagementState);
+    m_preventTimer->start(PREVENT_SUSPEND_INTERVAL);
 
     // Configure BT session according to options
     loadPreferences();
@@ -1448,19 +1450,7 @@ void MainWindow::loadPreferences()
 
     showStatusBar(pref->isStatusbarDisplayed());
 
-    if (pref->preventFromSuspendWhenDownloading() || pref->preventFromSuspendWhenSeeding())
-    {
-        if (!m_preventTimer->isActive())
-        {
-            updatePowerManagementState();
-            m_preventTimer->start(PREVENT_SUSPEND_INTERVAL);
-        }
-    }
-    else
-    {
-        m_preventTimer->stop();
-        m_pwr->setActivityState(false);
-    }
+    updatePowerManagementState();
 
     m_transferListWidget->setAlternatingRowColors(pref->useAlternatingRowColors());
     m_propertiesWidget->getFilesList()->setAlternatingRowColors(pref->useAlternatingRowColors());
@@ -1924,17 +1914,20 @@ void MainWindow::on_actionAutoShutdown_toggled(bool enabled)
 
 void MainWindow::updatePowerManagementState()
 {
+    const bool preventFromSuspendWhenDownloading = Preferences::instance()->preventFromSuspendWhenDownloading();
+    const bool preventFromSuspendWhenSeeding = Preferences::instance()->preventFromSuspendWhenSeeding();
+
     const QVector<BitTorrent::Torrent *> allTorrents = BitTorrent::Session::instance()->torrents();
-    const bool hasUnfinishedTorrents = std::any_of(allTorrents.cbegin(), allTorrents.cend(), [](const BitTorrent::Torrent *torrent)
+    const bool inhibitSuspend = std::any_of(allTorrents.cbegin(), allTorrents.cend(), [&](const BitTorrent::Torrent* torrent)
     {
-        return (!torrent->isFinished() && !torrent->isPaused() && !torrent->isErrored() && torrent->hasMetadata()) || torrent->isMoving();
+        if (preventFromSuspendWhenDownloading && (!torrent->isFinished() && !torrent->isPaused() && !torrent->isErrored() && torrent->hasMetadata()))
+            return true;
+
+        if (preventFromSuspendWhenSeeding && (torrent->isFinished() && !torrent->isPaused()))
+            return true;
+
+        return torrent->isMoving();
     });
-    const bool hasRunningSeed = std::any_of(allTorrents.cbegin(), allTorrents.cend(), [](const BitTorrent::Torrent *torrent)
-    {
-        return (torrent->isFinished() && !torrent->isPaused());
-    });
-    const bool inhibitSuspend = (Preferences::instance()->preventFromSuspendWhenDownloading() && hasUnfinishedTorrents)
-                             || (Preferences::instance()->preventFromSuspendWhenSeeding() && hasRunningSeed);
     m_pwr->setActivityState(inhibitSuspend);
 }
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1918,7 +1918,7 @@ void MainWindow::updatePowerManagementState()
     const bool preventFromSuspendWhenSeeding = Preferences::instance()->preventFromSuspendWhenSeeding();
 
     const QVector<BitTorrent::Torrent *> allTorrents = BitTorrent::Session::instance()->torrents();
-    const bool inhibitSuspend = std::any_of(allTorrents.cbegin(), allTorrents.cend(), [&](const BitTorrent::Torrent* torrent)
+   const bool inhibitSuspend = std::any_of(allTorrents.cbegin(), allTorrents.cend(), [&](const BitTorrent::Torrent *torrent)
     {
         if (preventFromSuspendWhenDownloading && (!torrent->isFinished() && !torrent->isPaused() && !torrent->isErrored() && torrent->hasMetadata()))
             return true;


### PR DESCRIPTION
While a torrent is considered "finished" upon download completion, a session's handleTorrentFinished() event is only queued after any relevant move event is completed. So if a user chooses a post-download action such as system shutdown, torrents will finish, move, and then shutdown occurs.

However, inhibit system sleep behaviour is managed by an independent timer than checks the native status of torrents. This leads to a particular scenario where the user may expect sleep to be inhibited until downloads complete, followed by the system hibernating/shutting down/etc. But since sleep inhibition lapses as soon as torrents are downloaded, a move operation of sufficient duration may allow the system to suspend, meaning the expected post-download action is not executed.

I'm not sure this solution is ideal - for one, it may lead to a user-initiated location change inhibiting sleep unexpectedly. However, any other solutions would seem to require some architectural changes to how updatePowerManagement() works (i.e. transitioning from a timer to being event-driven) or a rethink of what constitutes "finished". Feedback appreciated.