### PR TITLE
Set "SameSite=None" if CSRF Protection is disabled

### DIFF
--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -683,7 +683,7 @@ void WebApplication::sessionStart()
     QByteArray cookieRawForm = cookie.toRawForm();
     if (m_isCSRFProtectionEnabled)
         cookieRawForm.append("; SameSite=Strict");
-    else
+    else if (cookie.isSecure())
         cookieRawForm.append("; SameSite=None");
     setHeader({Http::HEADER_SET_COOKIE, QString::fromLatin1(cookieRawForm)});
 }

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -683,6 +683,8 @@ void WebApplication::sessionStart()
     QByteArray cookieRawForm = cookie.toRawForm();
     if (m_isCSRFProtectionEnabled)
         cookieRawForm.append("; SameSite=Strict");
+    else
+        cookieRawForm.append("; SameSite=None");
     setHeader({Http::HEADER_SET_COOKIE, QString::fromLatin1(cookieRawForm)});
 }
 


### PR DESCRIPTION
TL;DR: Make CORS works by only little change.

Google Chrome changed cross-site cookie policy on 2020 https://developers.google.com/search/blog/2020/01/get-ready-for-new-samesitenone-secure When no `SameSite` set, default value changes from `None` to `Lax`, which will prevent CORS access. This PR set `SameSite` to `None` when CSRFProtection is Disabled by user.

ref #16993 #9884

Tip: to make cors really works, https and `Secure` flag shoule be enabled,  `access-control` headers should be set.