### PR TITLE
GHA CI: Update some dependencies

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -19,10 +19,10 @@ jobs:
       matrix:
         libt_version: ["2.0.8", "1.2.18"]
         qbt_gui: ["GUI=ON", "GUI=OFF"]
-        qt_version: ["5.15.2", "6.4.0"]
+        qt_version: ["5.15.2", "6.5.0"]
         exclude:
           - libt_version: "1.2.18"
-            qt_version: "6.4.0"
+            qt_version: "6.5.0"
 
     env:
       boost_path: "${{ github.workspace }}/../boost"
@@ -52,7 +52,7 @@ jobs:
           curl \
             -L \
             -o "${{ runner.temp }}/boost.tar.bz2" \
-            "https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0.tar.bz2"
+            "https://boostorg.jfrog.io/artifactory/main/release/1.82.0/source/boost_1_82_0.tar.bz2"
           tar -xf "${{ runner.temp }}/boost.tar.bz2" -C "${{ github.workspace }}/.."
           mv "${{ github.workspace }}/.."/boost_* "${{ env.boost_path }}"
 

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Install boost
         run: |
           aria2c `
-            "https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0.7z" `
+            "https://boostorg.jfrog.io/artifactory/main/release/1.82.0/source/boost_1_82_0.7z" `
             -d "${{ runner.temp }}" `
             -o "boost.7z"
           7z x "${{ runner.temp }}/boost.7z" -o"${{ github.workspace }}/.."
@@ -79,7 +79,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
         with:
-          version: "6.4.0"
+          version: "6.5.0"
           archives: qtbase qtsvg qttools
 
       - name: Install libtorrent

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
         with:
-          version: "6.4.0"
+          version: "6.5.0"
           archives: icu qtbase qtsvg qttools
 
       - name: Install libtorrent


### PR DESCRIPTION
Updated some Windows/macOS dependencies
* Qt 6.5.0
* Boost 1.82.0

Note:
I left Qt 6.2.0 on `linux`, didn't try to remove `qtdeclarative` dependency on `macOS`
Updated `Coverityscan` with Qt 6.5.0