### PR TITLE
Consider explicitly specified parameters when resolving optional ones

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -2596,50 +2596,30 @@ LoadTorrentParams SessionImpl::initLoadTorrentParams(const AddTorrentParams &add
     const auto defaultSavePath = suggestedSavePath(loadTorrentParams.category, addTorrentParams.useAutoTMM);
     const auto defaultDownloadPath = suggestedDownloadPath(loadTorrentParams.category, addTorrentParams.useAutoTMM);
 
-    loadTorrentParams.useAutoTMM = addTorrentParams.useAutoTMM.value_or(!isAutoTMMDisabledByDefault());
+    loadTorrentParams.useAutoTMM = addTorrentParams.useAutoTMM.value_or(
+            addTorrentParams.savePath.isEmpty() && addTorrentParams.downloadPath.isEmpty() && !isAutoTMMDisabledByDefault());
 
-    if (!addTorrentParams.useAutoTMM.has_value())
+    if (!loadTorrentParams.useAutoTMM)
     {
-        // Default TMM settings
+        if (addTorrentParams.savePath.isAbsolute())
+            loadTorrentParams.savePath = addTorrentParams.savePath;
+        else
+            loadTorrentParams.savePath = defaultSavePath / addTorrentParams.savePath;
 
-        if (!loadTorrentParams.useAutoTMM)
+        // if useDownloadPath isn't specified but downloadPath is explicitly set we prefer to use it
+        const bool useDownloadPath = addTorrentParams.useDownloadPath.value_or(!addTorrentParams.downloadPath.isEmpty() || isDownloadPathEnabled());
+        if (useDownloadPath)
         {
-            loadTorrentParams.savePath = defaultSavePath;
-            if (isDownloadPathEnabled())
-                loadTorrentParams.downloadPath = (!defaultDownloadPath.isEmpty() ? defaultDownloadPath : downloadPath());
-        }
-    }
-    else
-    {
-        // Overridden TMM settings
+            // Overridden "Download path" settings
 
-        if (!loadTorrentParams.useAutoTMM)
-        {
-            if (addTorrentParams.savePath.isAbsolute())
-                loadTorrentParams.savePath = addTorrentParams.savePath;
-            else
-                loadTorrentParams.savePath = defaultSavePath / addTorrentParams.savePath;
-
-            if (!addTorrentParams.useDownloadPath.has_value())
+            if (addTorrentParams.downloadPath.isAbsolute())
             {
-                // Default "Download path" settings
-
-                if (isDownloadPathEnabled())
-                    loadTorrentParams.downloadPath = (!defaultDownloadPath.isEmpty() ? defaultDownloadPath : downloadPath());
+                loadTorrentParams.downloadPath = addTorrentParams.downloadPath;
             }
-            else if (addTorrentParams.useDownloadPath.value())
+            else
             {
-                // Overridden "Download path" settings
-
-                if (addTorrentParams.downloadPath.isAbsolute())
-                {
-                    loadTorrentParams.downloadPath = addTorrentParams.downloadPath;
-                }
-                else
-                {
-                    const Path basePath = (!defaultDownloadPath.isEmpty() ? defaultDownloadPath : downloadPath());
-                    loadTorrentParams.downloadPath = basePath / addTorrentParams.downloadPath;
-                }
+                const Path basePath = (!defaultDownloadPath.isEmpty() ? defaultDownloadPath : downloadPath());
+                loadTorrentParams.downloadPath = basePath / addTorrentParams.downloadPath;
             }
         }
     }

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -860,6 +860,16 @@ void AddNewTorrentDialog::accept()
             m_torrentParams.downloadPath = downloadPath;
             updatePathHistory(KEY_DOWNLOADPATHHISTORY, downloadPath, savePathHistoryLength());
         }
+        else
+        {
+            m_torrentParams.downloadPath = Path();
+        }
+    }
+    else
+    {
+        m_torrentParams.savePath = Path();
+        m_torrentParams.downloadPath = Path();
+        m_torrentParams.useDownloadPath = std::nullopt;
     }
 
     setEnabled(!m_ui->checkBoxNeverShow->isChecked());

--- a/src/gui/addtorrentparamswidget.cpp
+++ b/src/gui/addtorrentparamswidget.cpp
@@ -48,12 +48,28 @@ namespace
         Q_ASSERT(data.userType() == QMetaType::Bool);
         return data.toBool();
     }
+
+    BitTorrent::AddTorrentParams cleanParams(BitTorrent::AddTorrentParams params)
+    {
+        if (!params.useAutoTMM.has_value() || params.useAutoTMM.value())
+        {
+            params.savePath = Path();
+            params.downloadPath = Path();
+            params.useDownloadPath = std::nullopt;
+        }
+
+        if (!params.useDownloadPath.has_value() || !params.useDownloadPath.value())
+        {
+            params.downloadPath = Path();
+        }
+
+        return params;
+    }
 }
 
 AddTorrentParamsWidget::AddTorrentParamsWidget(BitTorrent::AddTorrentParams addTorrentParams, QWidget *parent)
     : QWidget(parent)
     , m_ui {new Ui::AddTorrentParamsWidget}
-    , m_addTorrentParams {std::move(addTorrentParams)}
 {
     m_ui->setupUi(this);
 
@@ -110,7 +126,7 @@ AddTorrentParamsWidget::AddTorrentParamsWidget(BitTorrent::AddTorrentParams addT
     miscParamsLayout->addWidget(m_ui->stopConditionWidget);
     miscParamsLayout->addWidget(m_ui->addToQueueTopWidget);
 
-    populate();
+    setAddTorrentParams(std::move(addTorrentParams));
 }
 
 AddTorrentParamsWidget::~AddTorrentParamsWidget()
@@ -126,7 +142,7 @@ void AddTorrentParamsWidget::setAddTorrentParams(BitTorrent::AddTorrentParams ad
 
 BitTorrent::AddTorrentParams AddTorrentParamsWidget::addTorrentParams() const
 {
-    return m_addTorrentParams;
+    return cleanParams(m_addTorrentParams);
 }
 
 void AddTorrentParamsWidget::populate()


### PR DESCRIPTION
In #18824 I lost my way, trying to unify the work of interfaces of different levels.
This patch should make the behavior of the low-level interface more logical when resolving effective values of omitted parameters considering explicitly specified ones.
E.g. when user specifies "download path" it's more obvious that he/she wants to use it even if "use download path" is omitted.
These changes do not affect the parameters editing UI, since there is supposed to be a somewhat different way of perception (which was actually the problem), i.e. if the user explicitly sets "Use download path" as "Default" there, then he/she really wants to use the default value instead of specifying any path.

Closes #18951.