### PR TITLE
Use python isolate mode

### DIFF
--- a/src/base/search/searchdownloadhandler.cpp
+++ b/src/base/search/searchdownloadhandler.cpp
@@ -46,6 +46,7 @@ SearchDownloadHandler::SearchDownloadHandler(const QString &siteUrl, const QStri
             , this, &SearchDownloadHandler::downloadProcessFinished);
     const QStringList params
     {
+        Utils::ForeignApps::PYTHON_ISOLATE_MODE_FLAG,
         (SearchPluginManager::engineLocation() / Path(u"nova2dl.py"_qs)).toString(),
         siteUrl,
         url

--- a/src/base/search/searchhandler.cpp
+++ b/src/base/search/searchhandler.cpp
@@ -73,6 +73,7 @@ SearchHandler::SearchHandler(const QString &pattern, const QString &category, co
 
     const QStringList params
     {
+        Utils::ForeignApps::PYTHON_ISOLATE_MODE_FLAG,
         (SearchPluginManager::engineLocation() / Path(u"nova2.py"_qs)).toString(),
         m_usedPlugins.join(u','),
         m_category

--- a/src/base/search/searchpluginmanager.cpp
+++ b/src/base/search/searchpluginmanager.cpp
@@ -509,7 +509,12 @@ void SearchPluginManager::update()
     QProcess nova;
     nova.setProcessEnvironment(QProcessEnvironment::systemEnvironment());
 
-    const QStringList params {(engineLocation() / Path(u"/nova2.py"_qs)).toString(), u"--capabilities"_qs};
+    const QStringList params
+    {
+        Utils::ForeignApps::PYTHON_ISOLATE_MODE_FLAG,
+        (engineLocation() / Path(u"/nova2.py"_qs)).toString(),
+        u"--capabilities"_qs
+    };
     nova.start(Utils::ForeignApps::pythonInfo().executableName, params, QIODevice::ReadOnly);
     nova.waitForFinished();
 

--- a/src/base/utils/foreignapps.h
+++ b/src/base/utils/foreignapps.h
@@ -31,10 +31,13 @@
 
 #include <QString>
 
+#include "base/global.h"
 #include "base/utils/version.h"
 
 namespace Utils::ForeignApps
 {
+    inline const QString PYTHON_ISOLATE_MODE_FLAG = u"-I"_qs;
+
     struct PythonInfo
     {
         using Version = Utils::Version<3, 1>;

--- a/src/searchengine/nova3/nova2.py
+++ b/src/searchengine/nova3/nova2.py
@@ -1,4 +1,4 @@
-#VERSION: 1.43
+#VERSION: 1.44
 
 # Author:
 #  Fabien Devaux <fab AT gnux DOT info>
@@ -33,11 +33,13 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import importlib
+import pathlib
+import sys
 import urllib.parse
-from os import path
 from glob import glob
-from sys import argv
 from multiprocessing import Pool, cpu_count
+from os import path
 
 THREADED = True
 try:
@@ -70,9 +72,7 @@ def initialize_engines():
             continue
         try:
             # import engines.[engine]
-            engine_module = __import__(".".join(("engines", engi)))
-            # get low-level module
-            engine_module = getattr(engine_module, engi)
+            engine_module = importlib.import_module("engines." + engi)
             # bind class name
             globals()[engi] = getattr(engine_module, engi)
             supported_engines.append(engi)
@@ -143,6 +143,11 @@ def run_search(engine_list):
 
 
 def main(args):
+    # qbt tend to run this script in 'isolate mode' so append the current path manually
+    current_path = str(pathlib.Path(__file__).parent.resolve())
+    if current_path not in sys.path:
+        sys.path.append(current_path)
+
     supported_engines = initialize_engines()
 
     if not args:
@@ -187,4 +192,4 @@ def main(args):
 
 
 if __name__ == "__main__":
-    main(argv[1:])
+    main(sys.argv[1:])


### PR DESCRIPTION
This (more or less) avoids user's environment variables tampering the search process.
I'm not sure it will solve all 'plugins unworkable' issues but at least it should shrink the problem surface.