### PR TITLE
Bump python version minimum requirement

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -18,7 +18,7 @@ qBittorrent - A BitTorrent client in C++ / Qt
   - pkg-config *
       * Compile-time only on *nix systems
 
-  - Python >= 3.5.0
+  - Python >= 3.7.0
       * Optional, run-time only
       * Used by the bundled search engine
 

--- a/src/base/utils/foreignapps.cpp
+++ b/src/base/utils/foreignapps.cpp
@@ -248,7 +248,7 @@ bool Utils::ForeignApps::PythonInfo::isValid() const
 
 bool Utils::ForeignApps::PythonInfo::isSupportedVersion() const
 {
-    return (version >= Version {3, 5, 0});
+    return (version >= Version {3, 7, 0});
 }
 
 PythonInfo Utils::ForeignApps::pythonInfo()

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -29,8 +29,15 @@
 
 #include "mainwindow.h"
 
+#include <QtGlobal>
+
 #include <algorithm>
 #include <chrono>
+
+#if defined(Q_OS_WIN)
+#include <Windows.h>
+#include <versionhelpers.h>  // must follow after Windows.h
+#endif
 
 #include <QActionGroup>
 #include <QClipboard>
@@ -1962,9 +1969,13 @@ void MainWindow::installPython()
     setCursor(QCursor(Qt::WaitCursor));
     // Download python
 #ifdef QBT_APP_64BIT
-    const auto installerURL = u"https://www.python.org/ftp/python/3.8.10/python-3.8.10-amd64.exe"_qs;
+    const auto installerURL = ::IsWindows8OrGreater()
+        ? u"https://www.python.org/ftp/python/3.10.11/python-3.10.11-amd64.exe"_qs
+        : u"https://www.python.org/ftp/python/3.8.10/python-3.8.10-amd64.exe"_qs;
 #else
-    const auto installerURL = u"https://www.python.org/ftp/python/3.8.10/python-3.8.10.exe"_qs;
+    const auto installerURL = ::IsWindows8OrGreater()
+        ? u"https://www.python.org/ftp/python/3.10.11/python-3.10.11.exe"_qs
+        : u"https://www.python.org/ftp/python/3.8.10/python-3.8.10.exe"_qs;
 #endif
     Net::DownloadManager::instance()->download(
             Net::DownloadRequest(installerURL).saveToFile(true)

--- a/src/gui/programupdater.cpp
+++ b/src/gui/programupdater.cpp
@@ -29,6 +29,8 @@
 
 #include "programupdater.h"
 
+#include <QtGlobal>
+
 #if defined(Q_OS_WIN)
 #include <Windows.h>
 #include <versionhelpers.h>  // must follow after Windows.h


### PR DESCRIPTION
How was the `3.7.0` decided? I took a look at https://repology.org/project/python/versions and look at the relic `debian 10` and used that.
For the Windows installer: I looked at https://devguide.python.org/versions/#python-release-cycle and took the latest branch/version that is in the `security` phase.

ps. The deciding process should probably be formalized and recorded in INSTALL file...