### PR TITLE
Allow to assign priority to RSS download rule

### DIFF
--- a/src/base/rss/rss_autodownloader.h
+++ b/src/base/rss/rss_autodownloader.h
@@ -94,7 +94,7 @@ namespace RSS
         AutoDownloadRule ruleByName(const QString &ruleName) const;
         QList<AutoDownloadRule> rules() const;
 
-        void insertRule(const AutoDownloadRule &rule);
+        void setRule(const AutoDownloadRule &rule);
         bool renameRule(const QString &ruleName, const QString &newRuleName);
         void removeRule(const QString &ruleName);
 
@@ -118,6 +118,7 @@ namespace RSS
     private:
         void timerEvent(QTimerEvent *event) override;
         void setRule_impl(const AutoDownloadRule &rule);
+        void sortRules();
         void resetProcessingQueue();
         void startProcessing();
         void addJobForArticle(const Article *article);
@@ -141,7 +142,8 @@ namespace RSS
         QTimer *m_processingTimer = nullptr;
         Utils::Thread::UniquePtr m_ioThread;
         AsyncFileStorage *m_fileStorage = nullptr;
-        QHash<QString, AutoDownloadRule> m_rules;
+        QList<AutoDownloadRule> m_rules;
+        QHash<QString, qsizetype> m_rulesByName;
         QList<QSharedPointer<ProcessingJob>> m_processingQueue;
         QHash<QString, QSharedPointer<ProcessingJob>> m_waitingJobs;
         bool m_dirty = false;

--- a/src/base/rss/rss_autodownloadrule.cpp
+++ b/src/base/rss/rss_autodownloadrule.cpp
@@ -103,6 +103,7 @@ namespace
 
 const QString S_NAME = u"name"_qs;
 const QString S_ENABLED = u"enabled"_qs;
+const QString S_PRIORITY = u"priority"_qs;
 const QString S_USE_REGEX = u"useRegex"_qs;
 const QString S_MUST_CONTAIN = u"mustContain"_qs;
 const QString S_MUST_NOT_CONTAIN = u"mustNotContain"_qs;
@@ -126,6 +127,7 @@ namespace RSS
     {
         QString name;
         bool enabled = true;
+        int priority = 0;
 
         QStringList mustContain;
         QStringList mustNotContain;
@@ -147,6 +149,7 @@ namespace RSS
         {
             return (left.name == right.name)
                     && (left.enabled == right.enabled)
+                    && (left.priority == right.priority)
                     && (left.mustContain == right.mustContain)
                     && (left.mustNotContain == right.mustNotContain)
                     && (left.episodeFilter == right.episodeFilter)
@@ -457,6 +460,7 @@ QJsonObject AutoDownloadRule::toJsonObject() const
     const BitTorrent::AddTorrentParams &addTorrentParams = m_dataPtr->addTorrentParams;
 
     return {{S_ENABLED, isEnabled()}
+        , {S_PRIORITY, priority()}
         , {S_USE_REGEX, useRegex()}
         , {S_MUST_CONTAIN, mustContain()}
         , {S_MUST_NOT_CONTAIN, mustNotContain()}
@@ -483,11 +487,13 @@ AutoDownloadRule AutoDownloadRule::fromJsonObject(const QJsonObject &jsonObj, co
 {
     AutoDownloadRule rule {(name.isEmpty() ? jsonObj.value(S_NAME).toString() : name)};
 
+    rule.setEnabled(jsonObj.value(S_ENABLED).toBool(true));
+    rule.setPriority(jsonObj.value(S_PRIORITY).toInt(0));
+
     rule.setUseRegex(jsonObj.value(S_USE_REGEX).toBool(false));
     rule.setMustContain(jsonObj.value(S_MUST_CONTAIN).toString());
     rule.setMustNotContain(jsonObj.value(S_MUST_NOT_CONTAIN).toString());
     rule.setEpisodeFilter(jsonObj.value(S_EPISODE_FILTER).toString());
-    rule.setEnabled(jsonObj.value(S_ENABLED).toBool(true));
     rule.setLastMatch(QDateTime::fromString(jsonObj.value(S_LAST_MATCH).toString(), Qt::RFC2822Date));
     rule.setIgnoreDays(jsonObj.value(S_IGNORE_DAYS).toInt());
     rule.setUseSmartFilter(jsonObj.value(S_SMART_FILTER).toBool(false));
@@ -663,6 +669,16 @@ bool AutoDownloadRule::isEnabled() const
 void AutoDownloadRule::setEnabled(const bool enable)
 {
     m_dataPtr->enabled = enable;
+}
+
+int AutoDownloadRule::priority() const
+{
+    return m_dataPtr->priority;
+}
+
+void AutoDownloadRule::setPriority(const int value)
+{
+    m_dataPtr->priority = value;
 }
 
 QDateTime AutoDownloadRule::lastMatch() const

--- a/src/base/rss/rss_autodownloadrule.h
+++ b/src/base/rss/rss_autodownloadrule.h
@@ -61,6 +61,9 @@ namespace RSS
         bool isEnabled() const;
         void setEnabled(bool enable);
 
+        int priority() const;
+        void setPriority(int value);
+
         QString mustContain() const;
         void setMustContain(const QString &tokens);
         QString mustNotContain() const;

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -222,7 +222,6 @@ MainWindow::MainWindow(IGUIApplication *app, WindowState initialState)
 
     // Transfer List tab
     m_transferListWidget = new TransferListWidget(hSplitter, this);
-    // m_transferListWidget->setStyleSheet("QTreeView {border: none;}");  // borderless
     m_propertiesWidget = new PropertiesWidget(hSplitter);
     connect(m_transferListWidget, &TransferListWidget::currentTorrentChanged, m_propertiesWidget, &PropertiesWidget::loadTorrentInfos);
     hSplitter->addWidget(m_transferListWidget);

--- a/src/gui/rss/automatedrssdownloader.ui
+++ b/src/gui/rss/automatedrssdownloader.ui
@@ -134,11 +134,38 @@
          <rect>
           <x>0</x>
           <y>0</y>
-          <width>329</width>
-          <height>243</height>
+          <width>370</width>
+          <height>277</height>
          </rect>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout_8" stretch="0,0,0,0,0,0,1">
+        <layout class="QVBoxLayout" name="verticalLayout_8" stretch="0,0,0,0,0,0,0,1">
+         <item>
+          <layout class="QHBoxLayout" name="priorityLayout">
+           <item>
+            <widget class="QLabel" name="priorityLabel">
+             <property name="text">
+              <string>Priority:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="prioritySpinBox"/>
+           </item>
+           <item>
+            <spacer name="prioritySpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
          <item>
           <widget class="QCheckBox" name="checkRegex">
            <property name="text">

--- a/src/webui/api/rsscontroller.cpp
+++ b/src/webui/api/rsscontroller.cpp
@@ -150,7 +150,7 @@ void RSSController::setRuleAction()
     const QByteArray ruleDef {params()[u"ruleDef"_qs].trimmed().toUtf8()};
 
     const auto jsonObj = QJsonDocument::fromJson(ruleDef).object();
-    RSS::AutoDownloader::instance()->insertRule(RSS::AutoDownloadRule::fromJsonObject(jsonObj, ruleName));
+    RSS::AutoDownloader::instance()->setRule(RSS::AutoDownloadRule::fromJsonObject(jsonObj, ruleName));
 }
 
 void RSSController::renameRuleAction()


### PR DESCRIPTION
When an article matches to several rules, it is processed by the first of them. Previously, rules were applied in an arbitrary order, but it may be useful to be able to affect their order.