### PR TITLE
GHA CI: Bump libtorrent version(s)

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -17,11 +17,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libt_version: ["2.0.8", "1.2.18"]
+        libt_version: ["2.0.9", "1.2.19"]
         qbt_gui: ["GUI=ON", "GUI=OFF"]
         qt_version: ["5.15.2", "6.5.0"]
         exclude:
-          - libt_version: "1.2.18"
+          - libt_version: "1.2.19"
             qt_version: "6.5.0"
 
     env:

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -18,11 +18,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libt_version: ["2.0.8", "1.2.18"]
+        libt_version: ["2.0.9", "1.2.19"]
         qbt_gui: ["GUI=ON", "GUI=OFF"]
         qt_version: ["5.15.2", "6.2.0"]
         exclude:
-          - libt_version: "1.2.18"
+          - libt_version: "1.2.19"
             qt_version: "6.2.0"
 
     steps:

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libt_version: ["2.0.8", "1.2.18"]
+        libt_version: ["2.0.9", "1.2.19"]
 
     env:
       boost_path: "${{ github.workspace }}/../boost"

--- a/.github/workflows/coverity-scan.yaml
+++ b/.github/workflows/coverity-scan.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Install libtorrent
         run: |
           git clone \
-            --branch "v2.0.8" \
+            --branch "v2.0.9" \
             --depth 1 \
             --recurse-submodules \
             https://github.com/arvidn/libtorrent.git


### PR DESCRIPTION
* https://github.com/arvidn/libtorrent/releases/tag/v2.0.9
* https://github.com/arvidn/libtorrent/releases/tag/v1.2.19