### PR TITLE
WebUI: Fix category save path

### DIFF
--- a/src/webui/www/private/scripts/download.js
+++ b/src/webui/www/private/scripts/download.js
@@ -125,7 +125,7 @@ window.qBittorrent.Download = (function() {
                 const category = categories[categoryName];
                 let savePath = defaultSavePath;
                 if (category !== undefined)
-                    savePath = (category['savePath'] !== "") ? category['savePath'] : (defaultSavePath + categoryName);
+                    savePath = (category['savePath'] !== "") ? category['savePath'] : `${defaultSavePath}/${categoryName}`;
                 $('savepath').value = savePath;
             }
         }


### PR DESCRIPTION
Fixes the displayed default category save path. The default save path does not contain a trailing slash so there was a missing slash in between the default save path and the category name.

Before|After
-------|-----
![before](https://github.com/qbittorrent/qBittorrent/assets/371507/0e39bb71-63d5-4087-abc4-c0f68226690d)|![after](https://github.com/qbittorrent/qBittorrent/assets/371507/60ae0644-c325-4a1c-8f7a-0e57438463dc)
