### PR TITLE
GHA CI: build libtorrent as a static library

### DIFF
--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -60,6 +60,7 @@ jobs:
           cmake \
             -B build \
             -G "Ninja" \
+            -DBUILD_SHARED_LIBS=OFF \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -Ddeprecated-functions=OFF


### PR DESCRIPTION
Since appimage is bundling the libraries it make sense to embed libtorrent statically into qbt binary.
Another side effect is now qbt binary includes debug symbols from libtorrent too (which I consider a good thing for debugging). Previously appimage seems to (unnecessarily) strip the libtorrent debug symbols.
ps. this only affects linux appimages.