### PR TITLE
WebUI: Use setProperty() for selecting an option

### DIFF
--- a/src/webui/www/private/scripts/prop-files.js
+++ b/src/webui/www/private/scripts/prop-files.js
@@ -173,7 +173,7 @@ window.qBittorrent.PropFiles = (function() {
         elem.set('value', priority.toString());
         elem.set('html', html);
         if (selected)
-            elem.setProperty('selected', true);
+            elem.selected = true;
         return elem;
     };
 
@@ -210,9 +210,9 @@ window.qBittorrent.PropFiles = (function() {
         for (let i = 0; i < options.length; ++i) {
             const option = options[i];
             if (parseInt(option.value) === priority)
-                option.setProperty('selected', true);
+                option.selected = true;
             else
-                option.removeProperty('selected');
+                option.selected = false;
         }
 
         combobox.value = priority;

--- a/src/webui/www/private/scripts/prop-files.js
+++ b/src/webui/www/private/scripts/prop-files.js
@@ -173,7 +173,7 @@ window.qBittorrent.PropFiles = (function() {
         elem.set('value', priority.toString());
         elem.set('html', html);
         if (selected)
-            elem.setAttribute('selected', '');
+            elem.setProperty('selected', true);
         return elem;
     };
 
@@ -210,9 +210,9 @@ window.qBittorrent.PropFiles = (function() {
         for (let i = 0; i < options.length; ++i) {
             const option = options[i];
             if (parseInt(option.value) === priority)
-                option.setAttribute('selected', '');
+                option.setProperty('selected', true);
             else
-                option.removeAttribute('selected');
+                option.removeProperty('selected');
         }
 
         combobox.value = priority;

--- a/src/webui/www/private/views/log.html
+++ b/src/webui/www/private/views/log.html
@@ -191,10 +191,10 @@
         const init = () => {
             $('logLevelSelect').getElements('option').each((x) => {
                 if (selectedLogLevels.indexOf(x.value.toString()) !== -1) {
-                    x.setAttribute('selected', '');
+                    x.setProperty('selected', true);
                 }
                 else {
-                    x.removeAttribute('selected');
+                    x.removeProperty('selected');
                 }
             });
 

--- a/src/webui/www/private/views/log.html
+++ b/src/webui/www/private/views/log.html
@@ -191,10 +191,10 @@
         const init = () => {
             $('logLevelSelect').getElements('option').each((x) => {
                 if (selectedLogLevels.indexOf(x.value.toString()) !== -1) {
-                    x.setProperty('selected', true);
+                    x.selected = true;
                 }
                 else {
-                    x.removeProperty('selected');
+                    x.selected = false;
                 }
             });
 

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1839,7 +1839,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                                 index = 2;
                                 break;
                         }
-                        $('contentlayout_select').getChildren('option')[index].setProperty('selected', true);
+                        $('contentlayout_select').getChildren('option')[index].selected = true;
                         $('addToTopOfQueueCheckbox').setProperty('checked', pref.add_to_top_of_queue);
                         $('dontstartdownloads_checkbox').setProperty('checked', pref.start_paused_enabled);
                         switch (pref.torrent_stop_condition) {
@@ -1853,7 +1853,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                                 index = 2;
                                 break;
                         }
-                        $('stopConditionSelect').getChildren('option')[index].setProperty('selected', true);
+                        $('stopConditionSelect').getChildren('option')[index].selected = true;
                         $('deletetorrentfileafter_checkbox').setProperty('checked', pref.auto_delete_mode);
 
                         $('preallocateall_checkbox').setProperty('checked', pref.preallocate_all);
@@ -2024,7 +2024,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                         $('pex_checkbox').setProperty('checked', pref.pex);
                         $('lsd_checkbox').setProperty('checked', pref.lsd);
                         const encryption = pref.encryption.toInt();
-                        $('encryption_select').getChildren('option')[encryption].setProperty('selected', true);
+                        $('encryption_select').getChildren('option')[encryption].selected = true;
                         $('anonymous_mode_checkbox').setProperty('checked', pref.anonymous_mode);
 
                         $('maxActiveCheckingTorrents').setProperty('value', pref.max_active_checking_torrents);
@@ -2061,7 +2061,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                                 maxRatioAct = 2;
                                 break;
                         }
-                        $('max_ratio_act').getChildren('option')[maxRatioAct].setProperty('selected', true);
+                        $('max_ratio_act').getChildren('option')[maxRatioAct].selected = true;
                         updateMaxRatioTimeEnabled();
 
                         // Add trackers

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1839,7 +1839,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                                 index = 2;
                                 break;
                         }
-                        $('contentlayout_select').getChildren('option')[index].setAttribute('selected', '');
+                        $('contentlayout_select').getChildren('option')[index].setProperty('selected', true);
                         $('addToTopOfQueueCheckbox').setProperty('checked', pref.add_to_top_of_queue);
                         $('dontstartdownloads_checkbox').setProperty('checked', pref.start_paused_enabled);
                         switch (pref.torrent_stop_condition) {
@@ -1853,7 +1853,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                                 index = 2;
                                 break;
                         }
-                        $('stopConditionSelect').getChildren('option')[index].setAttribute('selected', '');
+                        $('stopConditionSelect').getChildren('option')[index].setProperty('selected', true);
                         $('deletetorrentfileafter_checkbox').setProperty('checked', pref.auto_delete_mode);
 
                         $('preallocateall_checkbox').setProperty('checked', pref.preallocate_all);
@@ -2024,7 +2024,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                         $('pex_checkbox').setProperty('checked', pref.pex);
                         $('lsd_checkbox').setProperty('checked', pref.lsd);
                         const encryption = pref.encryption.toInt();
-                        $('encryption_select').getChildren('option')[encryption].setAttribute('selected', '');
+                        $('encryption_select').getChildren('option')[encryption].setProperty('selected', true);
                         $('anonymous_mode_checkbox').setProperty('checked', pref.anonymous_mode);
 
                         $('maxActiveCheckingTorrents').setProperty('value', pref.max_active_checking_torrents);
@@ -2061,7 +2061,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                                 maxRatioAct = 2;
                                 break;
                         }
-                        $('max_ratio_act').getChildren('option')[maxRatioAct].setAttribute('selected', '');
+                        $('max_ratio_act').getChildren('option')[maxRatioAct].setProperty('selected', true);
                         updateMaxRatioTimeEnabled();
 
                         // Add trackers


### PR DESCRIPTION
This pull request resolves an issue with Safari not properly selecting an `<option>`.  Unlike other browsers Safari does select an `<option>` when the `selected` attribute is set using `setAttribute()`. Using `setProperty()` solves this issue.

I have tested it by patching qBittorrent version 4.5.2. That means I have not tested the log view as it is not present in that version.
Tested with Safari version 16.4 on macOS. I have also verified that it is still working in Firefox 113.0.2.

Closes #17866.
