### PR TITLE
WebUI: Set Connection status and Speed limits tooltips

### DIFF
--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -244,9 +244,9 @@
                     <td class="statusBarSeparator"></td>
                     <td id="DHTNodes"></td>
                     <td class="statusBarSeparator"></td>
-                    <td><img id="connectionStatus" alt="QBT_TR(Connection status)QBT_TR[CONTEXT=MainWindow]" title="QBT_TR(Connection status)QBT_TR[CONTEXT=MainWindow]" src="images/firewalled.svg" style="height: 1.5em;" /></td>
+                    <td><img id="connectionStatus" alt="QBT_TR(Connection status: Firewalled)QBT_TR[CONTEXT=MainWindow]" title="QBT_TR(Connection status: Firewalled)QBT_TR[CONTEXT=MainWindow]" src="images/firewalled.svg" style="height: 1.5em;" /></td>
                     <td class="statusBarSeparator"></td>
-                    <td style="cursor:pointer;"><img id="alternativeSpeedLimits" alt="QBT_TR(Alternative speed limits)QBT_TR[CONTEXT=MainWindow]" title="QBT_TR(Alternative speed limits)QBT_TR[CONTEXT=MainWindow]" src="images/slow_off.svg" style="height: 1.5em;" /></td>
+                    <td style="cursor:pointer;"><img id="alternativeSpeedLimits" alt="QBT_TR(Alternative speed limits: Off)QBT_TR[CONTEXT=MainWindow]" title="QBT_TR(Alternative speed limits: Off)QBT_TR[CONTEXT=MainWindow]" src="images/slow_off.svg" style="height: 1.5em;" /></td>
                     <td class="statusBarSeparator"></td>
                     <td class="speedLabel"><img src="images/downloading.svg" alt="QBT_TR(Download speed icon)QBT_TR[CONTEXT=MainWindow]" style="height: 1.5em; padding-right: 5px; margin-bottom: -4px;"><span id="DlInfos"></span></td>
                     <td class="statusBarSeparator"></td>

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -801,14 +801,17 @@ window.addEvent('load', function() {
             case 'connected':
                 $('connectionStatus').src = 'images/connected.svg';
                 $('connectionStatus').alt = 'QBT_TR(Connection status: Connected)QBT_TR[CONTEXT=MainWindow]';
+                $('connectionStatus').title = 'QBT_TR(Connection status: Connected)QBT_TR[CONTEXT=MainWindow]';
                 break;
             case 'firewalled':
                 $('connectionStatus').src = 'images/firewalled.svg';
                 $('connectionStatus').alt = 'QBT_TR(Connection status: Firewalled)QBT_TR[CONTEXT=MainWindow]';
+                $('connectionStatus').title = 'QBT_TR(Connection status: Firewalled)QBT_TR[CONTEXT=MainWindow]';
                 break;
             default:
                 $('connectionStatus').src = 'images/disconnected.svg';
                 $('connectionStatus').alt = 'QBT_TR(Connection status: Disconnected)QBT_TR[CONTEXT=MainWindow]';
+                $('connectionStatus').title = 'QBT_TR(Connection status: Disconnected)QBT_TR[CONTEXT=MainWindow]';
                 break;
         }
 
@@ -851,10 +854,12 @@ window.addEvent('load', function() {
         if (enabled) {
             $('alternativeSpeedLimits').src = 'images/slow.svg';
             $('alternativeSpeedLimits').alt = 'QBT_TR(Alternative speed limits: On)QBT_TR[CONTEXT=MainWindow]';
+            $('alternativeSpeedLimits').title = 'QBT_TR(Alternative speed limits: On)QBT_TR[CONTEXT=MainWindow]';
         }
         else {
             $('alternativeSpeedLimits').src = 'images/slow_off.svg';
             $('alternativeSpeedLimits').alt = 'QBT_TR(Alternative speed limits: Off)QBT_TR[CONTEXT=MainWindow]';
+            $('alternativeSpeedLimits').title = 'QBT_TR(Alternative speed limits: Off)QBT_TR[CONTEXT=MainWindow]';
         }
     };
 


### PR DESCRIPTION
Sets the title on the connection status and speed limits icons so that the tooltip matches.

Before|After
------|-----
![Screenshot 2023-05-31 at 11 32 54 AM](https://github.com/qbittorrent/qBittorrent/assets/371507/141ffd50-7844-4c69-9d21-772569ed0250)|![Screenshot 2023-05-31 at 11 32 33 AM](https://github.com/qbittorrent/qBittorrent/assets/371507/1fd20f68-f35d-4c2b-88cc-440e04520546)
![Screenshot 2023-05-31 at 11 33 02 AM](https://github.com/qbittorrent/qBittorrent/assets/371507/1f9bae70-1545-432a-b7be-7dcd458a0abf)|![Screenshot 2023-05-31 at 11 44 32 AM](https://github.com/qbittorrent/qBittorrent/assets/371507/6f41797a-9272-4572-8c77-ff1caf00df34)

Fixes #18958