### PR TITLE
WebUI: set Cross Origin Opener Policy to `same-origin`

### DIFF
--- a/src/base/http/types.h
+++ b/src/base/http/types.h
@@ -47,6 +47,7 @@ namespace Http
     inline const QString HEADER_CONTENT_LENGTH = u"content-length"_qs;
     inline const QString HEADER_CONTENT_SECURITY_POLICY = u"content-security-policy"_qs;
     inline const QString HEADER_CONTENT_TYPE = u"content-type"_qs;
+    inline const QString HEADER_CROSS_ORIGIN_OPENER_POLICY  = u"cross-origin-opener-policy"_qs;
     inline const QString HEADER_DATE = u"date"_qs;
     inline const QString HEADER_HOST = u"host"_qs;
     inline const QString HEADER_ORIGIN = u"origin"_qs;

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -406,7 +406,10 @@ void WebApplication::configure()
     m_prebuiltHeaders.push_back({Http::HEADER_X_CONTENT_TYPE_OPTIONS, u"nosniff"_qs});
 
     if (!m_isAltUIUsed)
+    {
+        m_prebuiltHeaders.push_back({Http::HEADER_CROSS_ORIGIN_OPENER_POLICY, u"same-origin"_qs});
         m_prebuiltHeaders.push_back({Http::HEADER_REFERRER_POLICY, u"same-origin"_qs});
+    }
 
     const bool isClickjackingProtectionEnabled = pref->isWebUiClickjackingProtectionEnabled();
     if (isClickjackingProtectionEnabled)


### PR DESCRIPTION
This separates browsing context for different origin sites and prevents leaking data from it.
This header is only present when using built-in WebUI. Alternative WebUI is not affected.
https://web.dev/why-coop-coep/#coop