### PR TITLE
Disable symlink resolving in Torrent creator

### DIFF
--- a/src/gui/torrentcreatordialog.cpp
+++ b/src/gui/torrentcreatordialog.cpp
@@ -48,11 +48,11 @@ namespace
 {
 #ifndef Q_OS_WIN
     // When the root file/directory of the created torrent is a symlink, we want to keep the symlink name in the torrent.
-    const QFileDialog::Options fileDialogOptions {QFileDialog::DontResolveSymlinks};
+    const QFileDialog::Options FILE_DIALOG_OPTIONS {QFileDialog::DontResolveSymlinks};
 #else
-    // On Windows, however, this option disables shortcuts (.lnk files) expansion, making it impossible to pick a file if its path contains a shortcut.
+    // On Windows, however, QFileDialog::DontResolveSymlinks disables shortcuts (.lnk files) expansion, making it impossible to pick a file if its path contains a shortcut.
     // As of NTFS symlinks, they don't seem to be resolved anyways.
-    const QFileDialog::Options fileDialogOptions {};
+    const QFileDialog::Options FILE_DIALOG_OPTIONS {};
 #endif
 }
 
@@ -119,7 +119,7 @@ void TorrentCreatorDialog::onAddFolderButtonClicked()
 {
     const QString oldPath = m_ui->textInputPath->text();
     const Path path {QFileDialog::getExistingDirectory(this, tr("Select folder"), oldPath,
-                                                       QFileDialog::ShowDirsOnly | fileDialogOptions)};
+                                                       QFileDialog::ShowDirsOnly | FILE_DIALOG_OPTIONS)};
     updateInputPath(path);
 }
 
@@ -185,7 +185,7 @@ void TorrentCreatorDialog::onCreateButtonClicked()
 {
     auto inputPath = Path(m_ui->textInputPath->text().trimmed());
 #ifdef Q_OS_WIN
-    // We don't want .lnk to be the root of the created torrent
+    // Resolve the path in case it contains a shortcut (otherwise, the following usages will consider it invalid)
     inputPath = Utils::Fs::toCanonicalPath(inputPath);
 #endif
 

--- a/src/gui/torrentcreatordialog.cpp
+++ b/src/gui/torrentcreatordialog.cpp
@@ -187,7 +187,7 @@ void TorrentCreatorDialog::onCreateButtonClicked()
     // Resolve the path in case it contains a shortcut (otherwise, the following usages will consider it invalid)
     const auto inputPath = Utils::Fs::toCanonicalPath(Path(m_ui->textInputPath->text().trimmed()));
 #else
-    const auto inputPath = Path(m_ui->textInputPath->text().trimmed()); 
+    const auto inputPath = Path(m_ui->textInputPath->text().trimmed());
 #endif
 
     // test if readable

--- a/src/gui/torrentcreatordialog.cpp
+++ b/src/gui/torrentcreatordialog.cpp
@@ -44,6 +44,18 @@
 
 #define SETTINGS_KEY(name) u"TorrentCreator/" name
 
+namespace
+{
+#ifndef Q_OS_WIN
+    // When the root file/directory of the created torrent is a symlink, we want to keep the symlink name in the torrent.
+    const QFileDialog::Options fileDialogOptions {QFileDialog::DontResolveSymlinks};
+#else
+    // On Windows, however, this option disables shortcuts (.lnk files) expansion, making it impossible to pick a file if its path contains a shortcut.
+    // As of NTFS symlinks, they don't seem to be resolved anyways.
+    const QFileDialog::Options fileDialogOptions {};
+#endif
+}
+
 TorrentCreatorDialog::TorrentCreatorDialog(QWidget *parent, const Path &defaultPath)
     : QDialog(parent)
     , m_ui(new Ui::TorrentCreatorDialog)
@@ -102,15 +114,6 @@ void TorrentCreatorDialog::updateInputPath(const Path &path)
     m_ui->textInputPath->setText(path.toString());
     updateProgressBar(0);
 }
-
-#ifndef Q_OS_WIN
-// When the root file/directory of the created torrent is a symlink, we want to keep the symlink name in the torrent.
-constexpr QFileDialog::Options fileDialogOptions{QFileDialog::DontResolveSymlinks};
-#else
-// On Windows, however, this option disables shortcuts (.lnk files) expansion, making it impossible to pick a file if its path contains a shortcut.
-// As of NTFS symlinks, they don't seem to be resolved anyways.
-constexpr QFileDialog::Options fileDialogOptions{};
-#endif
 
 void TorrentCreatorDialog::onAddFolderButtonClicked()
 {

--- a/src/gui/torrentcreatordialog.cpp
+++ b/src/gui/torrentcreatordialog.cpp
@@ -103,19 +103,27 @@ void TorrentCreatorDialog::updateInputPath(const Path &path)
     updateProgressBar(0);
 }
 
+#ifndef Q_OS_WIN
+// When the root file/directory of the created torrent is a symlink, we want to keep the symlink name in the torrent.
+constexpr QFileDialog::Options fileDialogOptions{QFileDialog::DontResolveSymlinks};
+#else
+// On Windows, however, this option disables shortcuts (.lnk files) expansion, making it impossible to pick a file if its path contains a shortcut.
+// As of NTFS symlinks, they don't seem to be resolved anyways.
+constexpr QFileDialog::Options fileDialogOptions{};
+#endif
+
 void TorrentCreatorDialog::onAddFolderButtonClicked()
 {
     const QString oldPath = m_ui->textInputPath->text();
     const Path path {QFileDialog::getExistingDirectory(this, tr("Select folder"), oldPath,
-                                                       QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks)};
+                                                       QFileDialog::ShowDirsOnly | fileDialogOptions)};
     updateInputPath(path);
 }
 
 void TorrentCreatorDialog::onAddFileButtonClicked()
 {
     const QString oldPath = m_ui->textInputPath->text();
-    const Path path {QFileDialog::getOpenFileName(this, tr("Select file"), oldPath, QString(), nullptr,
-                                                  QFileDialog::DontResolveSymlinks)};
+    const Path path {QFileDialog::getOpenFileName(this, tr("Select file"), oldPath, QString(), nullptr, fileDialogOptions)};
     updateInputPath(path);
 }
 

--- a/src/gui/torrentcreatordialog.cpp
+++ b/src/gui/torrentcreatordialog.cpp
@@ -46,12 +46,12 @@
 
 namespace
 {
-#ifndef Q_OS_WIN
     // When the root file/directory of the created torrent is a symlink, we want to keep the symlink name in the torrent.
-    const QFileDialog::Options FILE_DIALOG_OPTIONS {QFileDialog::DontResolveSymlinks};
-#else
     // On Windows, however, QFileDialog::DontResolveSymlinks disables shortcuts (.lnk files) expansion, making it impossible to pick a file if its path contains a shortcut.
     // As of NTFS symlinks, they don't seem to be resolved anyways.
+#ifndef Q_OS_WIN
+    const QFileDialog::Options FILE_DIALOG_OPTIONS {QFileDialog::DontResolveSymlinks};
+#else
     const QFileDialog::Options FILE_DIALOG_OPTIONS {};
 #endif
 }
@@ -118,8 +118,8 @@ void TorrentCreatorDialog::updateInputPath(const Path &path)
 void TorrentCreatorDialog::onAddFolderButtonClicked()
 {
     const QString oldPath = m_ui->textInputPath->text();
-    const Path path {QFileDialog::getExistingDirectory(this, tr("Select folder"), oldPath,
-                                                       QFileDialog::ShowDirsOnly | FILE_DIALOG_OPTIONS)};
+    const Path path {QFileDialog::getExistingDirectory(this, tr("Select folder")
+            , oldPath, (QFileDialog::ShowDirsOnly | FILE_DIALOG_OPTIONS))};
     updateInputPath(path);
 }
 
@@ -183,10 +183,11 @@ void TorrentCreatorDialog::dragEnterEvent(QDragEnterEvent *event)
 // Main function that create a .torrent file
 void TorrentCreatorDialog::onCreateButtonClicked()
 {
-    auto inputPath = Path(m_ui->textInputPath->text().trimmed());
 #ifdef Q_OS_WIN
     // Resolve the path in case it contains a shortcut (otherwise, the following usages will consider it invalid)
-    inputPath = Utils::Fs::toCanonicalPath(inputPath);
+    const auto inputPath = Utils::Fs::toCanonicalPath(Path(m_ui->textInputPath->text().trimmed()));
+#else
+    const auto inputPath = Path(m_ui->textInputPath->text().trimmed()); 
 #endif
 
     // test if readable

--- a/src/gui/torrentcreatordialog.cpp
+++ b/src/gui/torrentcreatordialog.cpp
@@ -106,14 +106,16 @@ void TorrentCreatorDialog::updateInputPath(const Path &path)
 void TorrentCreatorDialog::onAddFolderButtonClicked()
 {
     const QString oldPath = m_ui->textInputPath->text();
-    const Path path {QFileDialog::getExistingDirectory(this, tr("Select folder"), oldPath)};
+    const Path path {QFileDialog::getExistingDirectory(this, tr("Select folder"), oldPath,
+                                                       QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks)};
     updateInputPath(path);
 }
 
 void TorrentCreatorDialog::onAddFileButtonClicked()
 {
     const QString oldPath = m_ui->textInputPath->text();
-    const Path path {QFileDialog::getOpenFileName(this, tr("Select file"), oldPath)};
+    const Path path {QFileDialog::getOpenFileName(this, tr("Select file"), oldPath, QString(), nullptr,
+                                                  QFileDialog::DontResolveSymlinks)};
     updateInputPath(path);
 }
 
@@ -170,7 +172,7 @@ void TorrentCreatorDialog::dragEnterEvent(QDragEnterEvent *event)
 // Main function that create a .torrent file
 void TorrentCreatorDialog::onCreateButtonClicked()
 {
-    const auto inputPath = Utils::Fs::toCanonicalPath(Path(m_ui->textInputPath->text().trimmed()));
+    const auto inputPath = Path(m_ui->textInputPath->text().trimmed());
 
     // test if readable
     if (!Utils::Fs::isReadable(inputPath))

--- a/src/gui/torrentcreatordialog.cpp
+++ b/src/gui/torrentcreatordialog.cpp
@@ -126,7 +126,7 @@ void TorrentCreatorDialog::onAddFolderButtonClicked()
 void TorrentCreatorDialog::onAddFileButtonClicked()
 {
     const QString oldPath = m_ui->textInputPath->text();
-    const Path path {QFileDialog::getOpenFileName(this, tr("Select file"), oldPath, QString(), nullptr, fileDialogOptions)};
+    const Path path {QFileDialog::getOpenFileName(this, tr("Select file"), oldPath, QString(), nullptr, FILE_DIALOG_OPTIONS)};
     updateInputPath(path);
 }
 

--- a/src/gui/torrentcreatordialog.cpp
+++ b/src/gui/torrentcreatordialog.cpp
@@ -183,7 +183,11 @@ void TorrentCreatorDialog::dragEnterEvent(QDragEnterEvent *event)
 // Main function that create a .torrent file
 void TorrentCreatorDialog::onCreateButtonClicked()
 {
-    const auto inputPath = Path(m_ui->textInputPath->text().trimmed());
+    auto inputPath = Path(m_ui->textInputPath->text().trimmed());
+#ifdef Q_OS_WIN
+    // We don't want .lnk to be the root of the created torrent
+    inputPath = Utils::Fs::toCanonicalPath(inputPath);
+#endif
 
     // test if readable
     if (!Utils::Fs::isReadable(inputPath))


### PR DESCRIPTION
If the last level of the added path is a symlink, the user probably expects it to appear in the torrent under the symlink name, not under the resolved one.