### PR TITLE
Fix transfer list tab hotkey

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -878,7 +878,7 @@ void MainWindow::createKeyboardShortcuts()
 // Keyboard shortcuts slots
 void MainWindow::displayTransferTab() const
 {
-    m_tabs->setCurrentWidget(m_transferListWidget);
+    m_tabs->setCurrentWidget(m_splitter);
 }
 
 void MainWindow::displaySearchTab()


### PR DESCRIPTION
Not sure whether this is the best way to fix it. `Alt + 1` wouldn't change to transfer list tab.
