### PR TITLE
Apply i18n to percent values

### DIFF
--- a/src/gui/progressbarpainter.h
+++ b/src/gui/progressbarpainter.h
@@ -38,6 +38,8 @@ public:
     ProgressBarPainter();
 
     void paint(QPainter *painter, const QStyleOptionViewItem &option, const QString &text, int progress) const;
+    //: TRANSLATORS: %p is the progress value, % is the percent sign
+    m_dummyProgressBar->setFormat(tr("%p%"));
 
 private:
     // for painting progressbar with stylesheet option, a dummy progress bar is required

--- a/src/gui/torrentcreatordialog.ui
+++ b/src/gui/torrentcreatordialog.ui
@@ -454,6 +454,9 @@
        <property name="value">
         <number>0</number>
        </property>
+       <property name="format">
+        <string>%p%</string>
+       </property>
       </widget>
      </item>
     </layout>


### PR DESCRIPTION
Some languages use a different percent formatting style, such as %100 or 100 %. This commit enables i18n, so that translators can apply the needed format for their respective languages.