### PR TITLE
Drop I2P support with libtorrent 1.2

### DIFF
--- a/src/base/bittorrent/peerinfo.cpp
+++ b/src/base/bittorrent/peerinfo.cpp
@@ -184,7 +184,7 @@ QString PeerInfo::I2PAddress() const
     if (!useI2PSocket())
         return {};
 
-#ifdef QBT_USES_LIBTORRENT2
+#if defined(QBT_USES_LIBTORRENT2) && TORRENT_USE_I2P
     if (m_I2PAddress.isEmpty())
     {
         const lt::sha256_hash destHash = m_nativeInfo.i2p_destination();

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -1668,6 +1668,7 @@ lt::settings_pack SessionImpl::loadLTSettings() const
     settingsPack.set_int(lt::settings_pack::active_checking, maxActiveCheckingTorrents());
 
     // I2P
+#if defined(QBT_USES_LIBTORRENT2) && TORRENT_USE_I2P
     if (isI2PEnabled())
     {
         settingsPack.set_str(lt::settings_pack::i2p_hostname, I2PAddress().toStdString());
@@ -1681,7 +1682,6 @@ lt::settings_pack SessionImpl::loadLTSettings() const
         settingsPack.set_bool(lt::settings_pack::allow_i2p_mixed, false);
     }
 
-#ifdef QBT_USES_LIBTORRENT2
     // I2P session options
     settingsPack.set_int(lt::settings_pack::i2p_inbound_quantity, I2PInboundQuantity());
     settingsPack.set_int(lt::settings_pack::i2p_outbound_quantity, I2POutboundQuantity());

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -153,7 +153,7 @@ namespace
         PEER_TURNOVER_CUTOFF,
         PEER_TURNOVER_INTERVAL,
         REQUEST_QUEUE_SIZE,
-#ifdef QBT_USES_LIBTORRENT2
+#if defined(QBT_USES_LIBTORRENT2) && TORRENT_USE_I2P
         I2P_INBOUND_QUANTITY,
         I2P_OUTBOUND_QUANTITY,
         I2P_INBOUND_LENGTH,
@@ -325,7 +325,7 @@ void AdvancedSettings::saveAdvancedSettings() const
     session->setPeerTurnoverInterval(m_spinBoxPeerTurnoverInterval.value());
     // Maximum outstanding requests to a single peer
     session->setRequestQueueSize(m_spinBoxRequestQueueSize.value());
-#ifdef QBT_USES_LIBTORRENT2
+#if defined(QBT_USES_LIBTORRENT2) && TORRENT_USE_I2P
     // I2P session options
     session->setI2PInboundQuantity(m_spinBoxI2PInboundQuantity.value());
     session->setI2POutboundQuantity(m_spinBoxI2POutboundQuantity.value());
@@ -839,7 +839,7 @@ void AdvancedSettings::loadAdvancedSettings()
     m_spinBoxRequestQueueSize.setValue(session->requestQueueSize());
     addRow(REQUEST_QUEUE_SIZE, (tr("Maximum outstanding requests to a single peer") + u' ' + makeLink(u"https://www.libtorrent.org/reference-Settings.html#max_out_request_queue", u"(?)"))
             , &m_spinBoxRequestQueueSize);
-#ifdef QBT_USES_LIBTORRENT2
+#if defined(QBT_USES_LIBTORRENT2) && TORRENT_USE_I2P
     m_spinBoxI2PInboundQuantity.setMinimum(1);
     m_spinBoxI2PInboundQuantity.setMaximum(16);
     m_spinBoxI2PInboundQuantity.setValue(session->I2PInboundQuantity());

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -28,6 +28,8 @@
 
 #pragma once
 
+#include <libtorrent/config.hpp>
+
 #include <QCheckBox>
 #include <QComboBox>
 #include <QLineEdit>
@@ -85,8 +87,11 @@ private:
     QCheckBox m_checkBoxCoalesceRW;
 #else
     QComboBox m_comboBoxDiskIOType;
-    QSpinBox m_spinBoxMemoryWorkingSetLimit, m_spinBoxHashingThreads,
-             m_spinBoxI2PInboundQuantity, m_spinBoxI2POutboundQuantity, m_spinBoxI2PInboundLength, m_spinBoxI2POutboundLength;
+    QSpinBox m_spinBoxMemoryWorkingSetLimit, m_spinBoxHashingThreads;
+#endif
+
+#if defined(QBT_USES_LIBTORRENT2) && TORRENT_USE_I2P
+    QSpinBox m_spinBoxI2PInboundQuantity, m_spinBoxI2POutboundQuantity, m_spinBoxI2PInboundLength, m_spinBoxI2POutboundLength;
 #endif
 
     // OS dependent settings

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -791,10 +791,14 @@ void OptionsDialog::loadConnectionTabOptions()
         m_ui->spinMaxUploadsPerTorrent->setEnabled(false);
     }
 
+#if defined(QBT_USES_LIBTORRENT2) && TORRENT_USE_I2P
     m_ui->textI2PHost->setText(session->I2PAddress());
     m_ui->spinI2PPort->setValue(session->I2PPort());
     m_ui->checkI2PMixed->setChecked(session->I2PMixedMode());
     m_ui->groupI2P->setChecked(session->isI2PEnabled());
+#else
+    m_ui->groupI2P->hide();
+#endif
 
     const auto *proxyConfigManager = Net::ProxyConfigurationManager::instance();
     const Net::ProxyConfiguration proxyConf = proxyConfigManager->proxyConfiguration();
@@ -845,10 +849,12 @@ void OptionsDialog::loadConnectionTabOptions()
     connect(m_ui->textProxyIP, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->spinProxyPort, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
 
+#if defined(QBT_USES_LIBTORRENT2) && TORRENT_USE_I2P
     connect(m_ui->textI2PHost, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->spinI2PPort, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->checkI2PMixed, &QCheckBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->groupI2P, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
+#endif
 
     connect(m_ui->checkProxyBitTorrent, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkProxyBitTorrent, &QGroupBox::toggled, this, &ThisType::adjustProxyOptions);
@@ -881,10 +887,12 @@ void OptionsDialog::saveConnectionTabOptions() const
     session->setMaxUploads(getMaxUploads());
     session->setMaxUploadsPerTorrent(getMaxUploadsPerTorrent());
 
+#if defined(QBT_USES_LIBTORRENT2) && TORRENT_USE_I2P
     session->setI2PEnabled(m_ui->groupI2P->isChecked());
     session->setI2PAddress(m_ui->textI2PHost->text().trimmed());
     session->setI2PPort(m_ui->spinI2PPort->value());
     session->setI2PMixedMode(m_ui->checkI2PMixed->isChecked());
+#endif
 
     auto *proxyConfigManager = Net::ProxyConfigurationManager::instance();
     Net::ProxyConfiguration proxyConf;


### PR DESCRIPTION
libtorrent 1.2 does not contain a lot of I2P related fixes made recently, and I2P is almost completely unusable there (according to the feedbacks of the users involved).

Also fixes build when libtorrent is compiled with I2P support disabled.
Closes #19152.