### PR TITLE
Fix various typos

### DIFF
--- a/src/base/bittorrent/dbresumedatastorage.cpp
+++ b/src/base/bittorrent/dbresumedatastorage.cpp
@@ -661,7 +661,7 @@ void BitTorrent::DBResumeDataStorage::Worker::run()
                     db.commit();
                     m_dbLock.unlock();
 
-                    qDebug() << "Resume data changes are commited. Transacted jobs:" << transactedJobsCount;
+                    qDebug() << "Resume data changes are committed. Transacted jobs:" << transactedJobsCount;
                     transactedJobsCount = 0;
                 }
 

--- a/src/base/rss/rss_parser.cpp
+++ b/src/base/rss/rss_parser.cpp
@@ -206,7 +206,7 @@ namespace
                 {u"Theta"_s,    u"&#920;"_s}, // greek capital letter theta, U+0398 ISOgrk3
                 {u"Iota"_s,     u"&#921;"_s}, // greek capital letter iota, U+0399
                 {u"Kappa"_s,    u"&#922;"_s}, // greek capital letter kappa, U+039A
-                {u"Lambda"_s,   u"&#923;"_s}, // greek capital letter lamda, U+039B ISOgrk3
+                {u"Lambda"_s,   u"&#923;"_s}, // greek capital letter lambda, U+039B ISOgrk3
                 {u"Mu"_s,       u"&#924;"_s}, // greek capital letter mu, U+039C
                 {u"Nu"_s,       u"&#925;"_s}, // greek capital letter nu, U+039D
                 {u"Xi"_s,       u"&#926;"_s}, // greek capital letter xi, U+039E ISOgrk3
@@ -230,7 +230,7 @@ namespace
                 {u"theta"_s,    u"&#952;"_s}, // greek small letter theta, U+03B8 ISOgrk3
                 {u"iota"_s,     u"&#953;"_s}, // greek small letter iota, U+03B9 ISOgrk3
                 {u"kappa"_s,    u"&#954;"_s}, // greek small letter kappa, U+03BA ISOgrk3
-                {u"lambda"_s,   u"&#955;"_s}, // greek small letter lamda, U+03BB ISOgrk3
+                {u"lambda"_s,   u"&#955;"_s}, // greek small letter lambda, U+03BB ISOgrk3
                 {u"mu"_s,       u"&#956;"_s}, // greek small letter mu, U+03BC ISOgrk3
                 {u"nu"_s,       u"&#957;"_s}, // greek small letter nu, U+03BD ISOgrk3
                 {u"xi"_s,       u"&#958;"_s}, // greek small letter xi, U+03BE ISOgrk3

--- a/src/gui/notifications/dbusnotifier.cpp
+++ b/src/gui/notifications/dbusnotifier.cpp
@@ -81,7 +81,7 @@ void DBusNotifier::onActionInvoked(const uint messageID, const QString &action)
     Q_UNUSED(action);
 
     // Check whether the notification is sent by qBittorrent
-    // to avoid reacting to unrelated notifictions
+    // to avoid reacting to unrelated notifications
     if (m_activeMessages.contains(messageID))
         emit messageClicked();
 }

--- a/src/webui/www/private/rename_files.html
+++ b/src/webui/www/private/rename_files.html
@@ -428,7 +428,7 @@
             </div>
             <div class="formRow">
                 <input type="checkbox" id="match_all_occurences" />
-                <label for="match_all_occurences">QBT_TR(Match all occurences)QBT_TR[CONTEXT=PropertiesWidget]</label>
+                <label for="match_all_occurences">QBT_TR(Match all occurrences)QBT_TR[CONTEXT=PropertiesWidget]</label>
             </div>
             <div class="formRow">
                 <input type="checkbox" id="case_sensitive" />

--- a/src/webui/www/private/scripts/rename-files.js
+++ b/src/webui/www/private/scripts/rename-files.js
@@ -110,7 +110,7 @@ window.qBittorrent.MultiRename = (function() {
                     else if (input.substring(i, i + search.length) === search) {
                         result += replacement;
                         i += search.length;
-                        // Append characters that didn't meet the previous critera
+                        // Append characters that didn't meet the previous criteria
                     }
                     else {
                         result += input[i];
@@ -200,7 +200,7 @@ window.qBittorrent.MultiRename = (function() {
                     for (let namedGroup in match.groups) {
                         replacement = replaceGroup(replacement, `$${namedGroup}`, match.groups[namedGroup], '\\', false);
                     }
-                    // Replace auxillary variables
+                    // Replace auxiliary variables
                     for (let v = 'dddddddd'; v !== ''; v = v.substring(1)) {
                         let fileCount = fileEnumeration.toString().padStart(v.length, '0');
                         replacement = replaceGroup(replacement, `$${v}`, fileCount, '\\', false);


### PR DESCRIPTION
Found via `codespell -q 3 -S *.ts,*.desktop,./src/base/3rdparty,./dist/windows/installer-translations -L ba,doas,ist,ro,superseeding,ths`