### PR TITLE
Display long durations as months

### DIFF
--- a/dist/windows/gather_qt_translations.py
+++ b/dist/windows/gather_qt_translations.py
@@ -19,7 +19,7 @@ def main() -> int:
     tmp_translations: List[str] = glob.glob(f'{args.qt_translations_folder}/qt_??.qm')
     tmp_translations += glob.glob(f'{args.qt_translations_folder}/qt_??_??.qm')
     tmp_translations += glob.glob(f'{args.qt_translations_folder}/qtbase_??.qm')
-    tmp_translations += glob.glob(f'{args.qt_translations_folder}qtbase_??_??.qm')
+    tmp_translations += glob.glob(f'{args.qt_translations_folder}/qtbase_??_??.qm')
 
     filtered = filter(isNotStub, tmp_translations)
     for file in filtered:

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -390,14 +390,14 @@ QString Utils::Misc::userFriendlyDuration(const qlonglong seconds, const qlonglo
     {
         qlonglong months = (days / 30);
         days -= (months * 30);
-        return QCoreApplication::translate("misc", "%1m %2d", "e.g.: 3months 4days").arg(QString::number(months), QString::number(days));
+        return QCoreApplication::translate("misc", "%1M %2d", "e.g.: 3months 4days").arg(QString::number(months), QString::number(days));
     }
 
     qlonglong years = (days / 365);
     days -= (years * 365);
     months = (days / 30);
     days -= (months * 30);
-    return QCoreApplication::translate("misc", "%1y %2m %3d", "e.g: 2years 7 months 10days").arg(QString::number(years), QString::number(months), QString::number(days));
+    return QCoreApplication::translate("misc", "%1y %2M %3d", "e.g: 2years 7 months 10days").arg(QString::number(years), QString::number(months), QString::number(days));
 }
 
 QString Utils::Misc::getUserIDString()

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -379,7 +379,7 @@ QString Utils::Misc::userFriendlyDuration(const qlonglong seconds, const qlonglo
     }
 
     qlonglong days = (hours / 24);
-    if (days < 7)
+    if (days < 30)
     {
         hours -= (days * 24);
         return QCoreApplication::translate("misc", "%1d %2h", "e.g: 2days 10hours").arg(QString::number(days), QString::number(hours));

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -382,14 +382,14 @@ QString Utils::Misc::userFriendlyDuration(const qlonglong seconds, const qlonglo
     if (days < 31)
     {
         hours -= (days * 24);
-        return QCoreApplication::translate("misc", "%1d %2h", "e.g: 2days 10hours").arg(QString::number(days), QString::number(hours));
+        return QCoreApplication::translate("misc", "%1D %2h", "e.g: 2days 10hours").arg(QString::number(days), QString::number(hours));
     }
 
     if (days < 365)
     {
         qlonglong months = (days / 31);
         days -= (months * 31);
-        return QCoreApplication::translate("misc", "%1M %2d", "e.g.: 3months 4days").arg(QString::number(months), QString::number(days));
+        return QCoreApplication::translate("misc", "%1M %2D", "e.g.: 3months 4days").arg(QString::number(months), QString::number(days));
     }
 
     qlonglong years = (days / 365);
@@ -397,7 +397,7 @@ QString Utils::Misc::userFriendlyDuration(const qlonglong seconds, const qlonglo
     days -= (years * 365);
     months = (days / 31);
     days -= (months * 31);
-    return QCoreApplication::translate("misc", "%1y %2M %3d", "e.g: 2years 7 months 10days").arg(QString::number(years), QString::number(months), QString::number(days));
+    return QCoreApplication::translate("misc", "%1Y %2M %3D", "e.g: 2years 7 months 10days").arg(QString::number(years), QString::number(months), QString::number(days));
 }
 
 QString Utils::Misc::getUserIDString()

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -379,10 +379,17 @@ QString Utils::Misc::userFriendlyDuration(const qlonglong seconds, const qlonglo
     }
 
     qlonglong days = (hours / 24);
-    if (days < 365)
+    if (days < 7)
     {
         hours -= (days * 24);
         return QCoreApplication::translate("misc", "%1d %2h", "e.g: 2days 10hours").arg(QString::number(days), QString::number(hours));
+    }
+
+    qlonglong weeks = (days / 7);
+    if (days < 365)
+    {
+        days -= (weeks * 7);
+        return QCoreApplication::translate("misc", "%1w %2d", "e.g.: 3weeks 4days").arg(QString::number(weeks), QString::number(days));
     }
 
     qlonglong years = (days / 365);

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -385,16 +385,19 @@ QString Utils::Misc::userFriendlyDuration(const qlonglong seconds, const qlonglo
         return QCoreApplication::translate("misc", "%1d %2h", "e.g: 2days 10hours").arg(QString::number(days), QString::number(hours));
     }
 
-    qlonglong weeks = (days / 7);
+    qlonglong months = (days / 30);
     if (days < 365)
     {
-        days -= (weeks * 7);
-        return QCoreApplication::translate("misc", "%1w %2d", "e.g.: 3weeks 4days").arg(QString::number(weeks), QString::number(days));
+        qlonglong months = (days / 30);
+        days -= (months * 30);
+        return QCoreApplication::translate("misc", "%1m %2d", "e.g.: 3months 4days").arg(QString::number(months), QString::number(days));
     }
 
     qlonglong years = (days / 365);
     days -= (years * 365);
-    return QCoreApplication::translate("misc", "%1y %2d", "e.g: 2years 10days").arg(QString::number(years), QString::number(days));
+    months = (days / 30);
+    days -= (months * 30);
+    return QCoreApplication::translate("misc", "%1y %2m %3d", "e.g: 2years 7 months 10days").arg(QString::number(years), QString::number(months), QString::number(days));
 }
 
 QString Utils::Misc::getUserIDString()


### PR DESCRIPTION
Currently durations are formated as minutes, hours, days or years. Add support to also format durations as weeks.
Closes #19230
