### PR TITLE
Visually validate input path in torrent creator dialog

### DIFF
--- a/src/gui/fspathedit.cpp
+++ b/src/gui/fspathedit.cpp
@@ -135,6 +135,8 @@ void FileSystemPathEdit::FileSystemPathEditPrivate::browseActionTriggered()
         newPath = QFileDialog::getExistingDirectory(q, dialogCaptionOrDefault(),
                                 initialDirectory.data(), QFileDialog::ShowDirsOnly);
         break;
+    case FileSystemPathEdit::Mode::ReadOnly:
+        throw std::logic_error("Not supported");
     default:
         throw std::logic_error("Unknown FileSystemPathEdit mode");
     }
@@ -156,6 +158,8 @@ QString FileSystemPathEdit::FileSystemPathEditPrivate::dialogCaptionOrDefault() 
     case FileSystemPathEdit::Mode::DirectoryOpen:
     case FileSystemPathEdit::Mode::DirectorySave:
         return defaultDialogCaptionForDirectory.tr();
+    case FileSystemPathEdit::Mode::ReadOnly:
+        throw std::logic_error("Not supported");
     default:
         throw std::logic_error("Unknown FileSystemPathEdit mode");
     }
@@ -163,11 +167,13 @@ QString FileSystemPathEdit::FileSystemPathEditPrivate::dialogCaptionOrDefault() 
 
 void FileSystemPathEdit::FileSystemPathEditPrivate::modeChanged()
 {
+    m_browseBtn->setVisible(m_mode != FileSystemPathEdit::Mode::ReadOnly);
     m_editor->completeDirectoriesOnly((m_mode == FileSystemPathEdit::Mode::DirectoryOpen) || (m_mode == FileSystemPathEdit::Mode::DirectorySave));
 
-    m_validator->setExistingOnly((m_mode == FileSystemPathEdit::Mode::FileOpen) || (m_mode == FileSystemPathEdit::Mode::DirectoryOpen));
+    m_validator->setExistingOnly((m_mode == FileSystemPathEdit::Mode::FileOpen) || (m_mode == FileSystemPathEdit::Mode::DirectoryOpen) || (m_mode == FileSystemPathEdit::Mode::ReadOnly));
+    m_validator->setFilesOnly((m_mode == FileSystemPathEdit::Mode::FileOpen) || (m_mode == FileSystemPathEdit::Mode::FileSave));
     m_validator->setDirectoriesOnly((m_mode == FileSystemPathEdit::Mode::DirectoryOpen) || (m_mode == FileSystemPathEdit::Mode::DirectorySave));
-    m_validator->setCheckReadPermission((m_mode == FileSystemPathEdit::Mode::FileOpen) || (m_mode == FileSystemPathEdit::Mode::DirectoryOpen));
+    m_validator->setCheckReadPermission((m_mode == FileSystemPathEdit::Mode::FileOpen) || (m_mode == FileSystemPathEdit::Mode::DirectoryOpen) || (m_mode == FileSystemPathEdit::Mode::ReadOnly));
     m_validator->setCheckWritePermission((m_mode == FileSystemPathEdit::Mode::FileSave) || (m_mode == FileSystemPathEdit::Mode::DirectorySave));
 }
 

--- a/src/gui/fspathedit.h
+++ b/src/gui/fspathedit.h
@@ -63,7 +63,8 @@ public:
         FileOpen,        //!< opening files, shows open file dialog
         FileSave,        //!< saving files, shows save file dialog
         DirectoryOpen,   //!< selecting existing directories
-        DirectorySave    //!< selecting directories for saving
+        DirectorySave,   //!< selecting directories for saving
+        ReadOnly         //!< no browse button and no dialog, only validate path and check read permission
     };
     Q_ENUM(Mode)
 

--- a/src/gui/fspathedit_p.cpp
+++ b/src/gui/fspathedit_p.cpp
@@ -66,6 +66,16 @@ void Private::FileSystemPathValidator::setExistingOnly(const bool value)
     m_existingOnly = value;
 }
 
+bool Private::FileSystemPathValidator::filesOnly() const
+{
+    return m_filesOnly;
+}
+
+void Private::FileSystemPathValidator::setFilesOnly(const bool value)
+{
+    m_filesOnly = value;
+}
+
 bool Private::FileSystemPathValidator::directoriesOnly() const
 {
     return m_directoriesOnly;
@@ -105,15 +115,16 @@ Private::FileSystemPathValidator::testPath(const Path &path) const
     if (!info.exists())
         return existingOnly() ? TestResult::DoesNotExist : TestResult::OK;
 
+    if (filesOnly())
+    {
+        if (!info.isFile())
+            return TestResult::NotAFile;
+    }
+
     if (directoriesOnly())
     {
         if (!info.isDir())
             return TestResult::NotADir;
-    }
-    else
-    {
-        if (!info.isFile())
-            return TestResult::NotAFile;
     }
 
     if (checkReadPermission() && !info.isReadable())

--- a/src/gui/fspathedit_p.h
+++ b/src/gui/fspathedit_p.h
@@ -68,6 +68,9 @@ namespace Private
         bool existingOnly() const;
         void setExistingOnly(bool value);
 
+        bool filesOnly() const;
+        void setFilesOnly(bool value);
+
         bool directoriesOnly() const;
         void setDirectoriesOnly(bool value);
 
@@ -87,6 +90,7 @@ namespace Private
 
         bool m_strictMode = false;
         bool m_existingOnly = false;
+        bool m_filesOnly = false;
         bool m_directoriesOnly = false;
         bool m_checkReadPermission = false;
         bool m_checkWritePermission = false;

--- a/src/gui/torrentcreatordialog.ui
+++ b/src/gui/torrentcreatordialog.ui
@@ -66,7 +66,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QLineEdit" name="textInputPath">
+             <widget class="FileSystemPathLineEdit" name="textInputPath">
               <property name="acceptDrops">
                <bool>false</bool>
               </property>
@@ -470,6 +470,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>FileSystemPathLineEdit</class>
+   <extends>QWidget</extends>
+   <header>gui/fspathedit.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>textInputPath</tabstop>
   <tabstop>addFileButton</tabstop>


### PR DESCRIPTION
* Visually validate input path in torrent creator dialog
  ![screenshot](https://github.com/qbittorrent/qBittorrent/assets/9395168/5616aae5-4380-44db-ba36-35d43e8397bd)