### PR TITLE
Improve performance when scrolling large torrents

### DIFF
--- a/src/gui/torrentcontentwidget.cpp
+++ b/src/gui/torrentcontentwidget.cpp
@@ -61,6 +61,7 @@ TorrentContentWidget::TorrentContentWidget(QWidget *parent)
 {
     setExpandsOnDoubleClick(false);
     setSortingEnabled(true);
+    setUniformRowHeights(true);
     header()->setSortIndicator(0, Qt::AscendingOrder);
     header()->setFirstSectionMovable(true);
     header()->setContextMenuPolicy(Qt::CustomContextMenu);


### PR DESCRIPTION
When scrolling large torrent files (torrent with 100k files in one level) in the TorrentContentWidget, the application freezes.
This PR fixes this problem by specifying that the all TorrentContentWidget's items have the same height 