### PR TITLE
Fix code defects

### DIFF
--- a/src/base/bittorrent/customstorage.cpp
+++ b/src/base/bittorrent/customstorage.cpp
@@ -92,7 +92,7 @@ bool CustomDiskIOThread::async_write(lt::storage_index_t storage, const lt::peer
                                      , const char *buf, std::shared_ptr<lt::disk_observer> diskObserver
                                      , std::function<void (const lt::storage_error &)> handler, lt::disk_job_flags_t flags)
 {
-    return m_nativeDiskIO->async_write(storage, peerRequest, buf, diskObserver, std::move(handler), flags);
+    return m_nativeDiskIO->async_write(storage, peerRequest, buf, std::move(diskObserver), std::move(handler), flags);
 }
 
 void CustomDiskIOThread::async_hash(lt::storage_index_t storage, lt::piece_index_t piece

--- a/src/base/bittorrent/customstorage.cpp
+++ b/src/base/bittorrent/customstorage.cpp
@@ -141,7 +141,7 @@ void CustomDiskIOThread::async_check_files(lt::storage_index_t storage, const lt
                                            , std::function<void (lt::status_t, const lt::storage_error &)> handler)
 {
     handleCompleteFiles(storage, m_storageData[storage].savePath);
-    m_nativeDiskIO->async_check_files(storage, resume_data, links, std::move(handler));
+    m_nativeDiskIO->async_check_files(storage, resume_data, std::move(links), std::move(handler));
 }
 
 void CustomDiskIOThread::async_stop_torrent(lt::storage_index_t storage, std::function<void ()> handler)
@@ -170,7 +170,7 @@ void CustomDiskIOThread::async_delete_files(lt::storage_index_t storage, lt::rem
 void CustomDiskIOThread::async_set_file_priority(lt::storage_index_t storage, lt::aux::vector<lt::download_priority_t, lt::file_index_t> priorities
                                                  , std::function<void (const lt::storage_error &, lt::aux::vector<lt::download_priority_t, lt::file_index_t>)> handler)
 {
-    m_nativeDiskIO->async_set_file_priority(storage, priorities
+    m_nativeDiskIO->async_set_file_priority(storage, std::move(priorities)
                                             , [=, handler = std::move(handler)](const lt::storage_error &error, const lt::aux::vector<lt::download_priority_t, lt::file_index_t> &priorities)
     {
         m_storageData[storage].filePriorities = priorities;

--- a/src/base/bittorrent/portforwarderimpl.cpp
+++ b/src/base/bittorrent/portforwarderimpl.cpp
@@ -67,7 +67,7 @@ void PortForwarderImpl::setPorts(const QString &profile, QSet<quint16> ports)
 {
     const QSet<quint16> oldForwardedPorts = std::accumulate(m_portProfiles.cbegin(), m_portProfiles.cend(), QSet<quint16>());
 
-    m_portProfiles[profile] = ports;
+    m_portProfiles[profile] = std::move(ports);
     const QSet<quint16> newForwardedPorts = std::accumulate(m_portProfiles.cbegin(), m_portProfiles.cend(), QSet<quint16>());
 
     m_provider->removeMappedPorts(oldForwardedPorts - newForwardedPorts);

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -6091,7 +6091,8 @@ void SessionImpl::processTrackerStatuses()
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
                         updatedTrackerEntries[trackerEntry.url] = std::move(trackerEntry);
 #else
-                        updatedTrackerEntries.emplace(trackerEntry.url, std::move(trackerEntry));
+                        const QString url = trackerEntry.url;
+                        updatedTrackerEntries.emplace(url, std::move(trackerEntry));
 #endif
                     }
 

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -1318,7 +1318,7 @@ void SessionImpl::processNextResumeData(ResumeSessionContext *context)
                 std::shared_ptr<lt::torrent_info> ti = resumeData.ltAddTorrentParams.ti;
                 resumeData = *loadPreferredResumeDataResult;
                 if (!resumeData.ltAddTorrentParams.ti)
-                    resumeData.ltAddTorrentParams.ti = ti;
+                    resumeData.ltAddTorrentParams.ti = std::move(ti);
             }
         }
     }

--- a/src/base/digest32.h
+++ b/src/base/digest32.h
@@ -84,7 +84,7 @@ private:
     class Data;
 
     explicit Digest32(QSharedDataPointer<Data> dataPtr)
-        : m_dataPtr {dataPtr}
+        : m_dataPtr {std::move(dataPtr)}
     {
     }
 


### PR DESCRIPTION
* Fix potential use-after-move
  The evaluation order for function parameters is unspecified in C++.
  https://stackoverflow.com/questions/2934904/order-of-evaluation-in-c-function-parameters
  Fix up https://github.com/qbittorrent/qBittorrent/commit/1b2ff0f6f8f93c4e3d3aff38359b1b2037a13378.
* Use move construct for shared pointers
* Use move construct for large data 
