### PR TITLE
WebUI: Preserve the network interfaces when down

### DIFF
--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -845,7 +845,8 @@ void AppController::setPreferencesAction()
         const QString ifaceName = (ifacesIter != ifaces.cend()) ? ifacesIter->humanReadableName() : QString {};
 
         session->setNetworkInterface(ifaceValue);
-        session->setNetworkInterfaceName(ifaceName);
+        if (!ifaceName.isEmpty() || ifaceValue.isEmpty())
+            session->setNetworkInterfaceName(ifaceName);
     }
     // Current network interface address
     if (hasKey(u"current_interface_address"_s))

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -320,8 +320,10 @@ void AppController::preferencesAction()
     data[u"memory_working_set_limit"_s] = app()->memoryWorkingSetLimit();
     // Current network interface
     data[u"current_network_interface"_s] = session->networkInterface();
+    // Current network interface name
+    data[u"current_interface_name"_s] = session->networkInterfaceName();
     // Current network interface address
-    data[u"current_interface_address"_s] = BitTorrent::Session::instance()->networkInterfaceAddress();
+    data[u"current_interface_address"_s] = session->networkInterfaceAddress();
     // Save resume data interval
     data[u"save_resume_data_interval"_s] = session->saveResumeDataInterval();
     // Recheck completed torrents

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1749,7 +1749,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
         };
 
         // Advanced Tab
-        const updateNetworkInterfaces = function(default_iface) {
+        const updateNetworkInterfaces = function(default_iface, default_iface_name) {
             const url = 'api/v2/app/networkInterfaceList';
             $('networkInterface').empty();
             new Request.JSON({
@@ -2148,7 +2148,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                         // qBittorrent section
                         $('resumeDataStorageType').setProperty('value', pref.resume_data_storage_type);
                         $('memoryWorkingSetLimit').setProperty('value', pref.memory_working_set_limit);
-                        updateNetworkInterfaces(pref.current_network_interface);
+                        updateNetworkInterfaces(pref.current_network_interface, pref.current_interface_name);
                         updateInterfaceAddresses(pref.current_network_interface, pref.current_interface_address);
                         $('saveResumeDataInterval').setProperty('value', pref.save_resume_data_interval);
                         $('recheckTorrentsOnCompletion').setProperty('checked', pref.recheck_completed_torrents);

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1760,8 +1760,12 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     alert("Could not contact qBittorrent");
                 },
                 onSuccess: function(ifaces) {
-                    if (!ifaces)
+                    if (!Array.isArray(ifaces))
                         return;
+
+                    // add the current network interface to the options if needed
+                    if (default_iface && !ifaces.some((item) => item.value === default_iface))
+                        ifaces.push({ name: default_iface_name || default_iface, value: default_iface });
 
                     $('networkInterface').options.add(new Option('QBT_TR(Any interface)QBT_TR[CONTEXT=OptionsDialog]', ''));
                     ifaces.forEach(function(item, index) {


### PR DESCRIPTION
If the current network interface is down (eg: wg0) the endpoint used to construct the dropdown with available values for network interfaces will not return it.

For this reason the value "Any intercace" will be pre-selected, and by calling the Save (without the user change the network interfaces) it undesirable update the current network interface to "Any intercace".

This fix is to add the current interface to the dropdown when needed, this way the current network interface will be always present and selected.

--


This issue have been previous mentioned on the GUI app #17031 and #17058, but still present on WebUI.

I belive the fix for GUI was read the interface value from settings/Session and merge it when needed: [advancedsettings.cpp](https://github.com/qbittorrent/qBittorrent/pull/17031/files#diff-5eab49ac0cfd60ccf86481eb0b873358b0f9988837204592e6dfb70fe6ba7969R637-R649)
I also belive the same logic would be needed around here: [appcontroller.cpp](https://github.com/qbittorrent/qBittorrent/blob/master/src/webui/api/appcontroller.cpp#L1003-L1018)
But due lack of knowledge I could not do it. Instead Im proposing a different fix, and by my tests it works.
