### PR TITLE
Fix response for HTTP HEAD method

### DIFF
--- a/src/base/http/connection.cpp
+++ b/src/base/http/connection.cpp
@@ -32,7 +32,6 @@
 
 #include <QTcpSocket>
 
-#include "base/logger.h"
 #include "irequesthandler.h"
 #include "requestparser.h"
 #include "responsegenerator.h"
@@ -94,8 +93,8 @@ void Connection::read()
                 const long bufferLimit = RequestParser::MAX_CONTENT_SIZE * 1.1;  // some margin for headers
                 if (m_receivedData.size() > bufferLimit)
                 {
-                    LogMsg(tr("Http request size exceeds limitation, closing socket. Limit: %1, IP: %2")
-                        .arg(bufferLimit).arg(m_socket->peerAddress().toString()), Log::WARNING);
+                    qWarning("%s", qUtf8Printable(tr("Http request size exceeds limitation, closing socket. Limit: %1, IP: %2")
+                        .arg(QString::number(bufferLimit), m_socket->peerAddress().toString())));
 
                     Response resp(413, u"Payload Too Large"_s);
                     resp.headers[HEADER_CONNECTION] = u"close"_s;
@@ -108,8 +107,8 @@ void Connection::read()
 
         case RequestParser::ParseStatus::BadMethod:
             {
-                LogMsg(tr("Bad Http request method, closing socket. IP: %1. Method: \"%2\"")
-                    .arg(m_socket->peerAddress().toString(), result.request.method), Log::WARNING);
+                qWarning("%s", qUtf8Printable(tr("Bad Http request method, closing socket. IP: %1. Method: \"%2\"")
+                    .arg(m_socket->peerAddress().toString(), result.request.method)));
 
                 Response resp(501, u"Not Implemented"_s);
                 resp.headers[HEADER_CONNECTION] = u"close"_s;
@@ -121,8 +120,8 @@ void Connection::read()
 
         case RequestParser::ParseStatus::BadRequest:
             {
-                LogMsg(tr("Bad Http request, closing socket. IP: %1")
-                    .arg(m_socket->peerAddress().toString()), Log::WARNING);
+                qWarning("%s", qUtf8Printable(tr("Bad Http request, closing socket. IP: %1")
+                    .arg(m_socket->peerAddress().toString())));
 
                 Response resp(400, u"Bad Request"_s);
                 resp.headers[HEADER_CONNECTION] = u"close"_s;

--- a/src/base/http/connection.cpp
+++ b/src/base/http/connection.cpp
@@ -106,6 +106,19 @@ void Connection::read()
             }
             return;
 
+        case RequestParser::ParseStatus::BadMethod:
+            {
+                LogMsg(tr("Bad Http request method, closing socket. IP: %1. Method: \"%2\"")
+                    .arg(m_socket->peerAddress().toString(), result.request.method), Log::WARNING);
+
+                Response resp(501, u"Not Implemented"_s);
+                resp.headers[HEADER_CONNECTION] = u"close"_s;
+
+                sendResponse(resp);
+                m_socket->close();
+            }
+            return;
+
         case RequestParser::ParseStatus::BadRequest:
             {
                 LogMsg(tr("Bad Http request, closing socket. IP: %1")

--- a/src/base/http/requestparser.cpp
+++ b/src/base/http/requestparser.cpp
@@ -103,6 +103,7 @@ RequestParser::ParseResult RequestParser::doParse(const QByteArray &data)
     // handle supported methods
     if ((m_request.method == HEADER_REQUEST_METHOD_GET) || (m_request.method == HEADER_REQUEST_METHOD_HEAD))
         return {ParseStatus::OK, m_request, headerLength};
+
     if (m_request.method == HEADER_REQUEST_METHOD_POST)
     {
         const auto parseContentLength = [this]() -> int
@@ -146,8 +147,7 @@ RequestParser::ParseResult RequestParser::doParse(const QByteArray &data)
         return {ParseStatus::OK, m_request, (headerLength + contentLength)};
     }
 
-    qWarning() << Q_FUNC_INFO << "unsupported request method: " << m_request.method;
-    return {ParseStatus::BadRequest, Request(), 0};  // TODO: SHOULD respond "501 Not Implemented"
+    return {ParseStatus::BadMethod, m_request, 0};
 }
 
 bool RequestParser::parseStartLines(const QStringView data)

--- a/src/base/http/requestparser.h
+++ b/src/base/http/requestparser.h
@@ -41,6 +41,7 @@ namespace Http
         {
             OK,
             Incomplete,
+            BadMethod,
             BadRequest
         };
 

--- a/src/base/http/responsegenerator.cpp
+++ b/src/base/http/responsegenerator.cpp
@@ -38,8 +38,9 @@ QByteArray Http::toByteArray(Response response)
 {
     compressContent(response);
 
-    response.headers[HEADER_CONTENT_LENGTH] = QString::number(response.content.length());
     response.headers[HEADER_DATE] = httpDate();
+    if (QString &value = response.headers[HEADER_CONTENT_LENGTH]; value.isEmpty())
+        value = QString::number(response.content.length());
 
     QByteArray buf;
     buf.reserve(1024 + response.content.length());
@@ -63,7 +64,7 @@ QByteArray Http::toByteArray(Response response)
     // the first empty line
     buf += CRLF;
 
-    // message body  // TODO: support HEAD request
+    // message body
     buf += response.content;
 
     return buf;


### PR DESCRIPTION
* Fix response for HTTP HEAD method
  Closes #19288.
* Response proper error status for invalid request methods
* Avoid stuffing the log via junk requests