### PR TITLE
GHA CI: fix environment variable not being used

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -34,13 +34,13 @@ jobs:
 
       - name: Install dependencies
         uses: Wandalen/wretry.action@v1
+        env:
+           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
+           HOMEBREW_NO_INSTALL_CLEANUP: 1
         with:
           attempt_delay: 20000
           attempt_limit: 6
           command: |
-            export \
-              HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 \
-              HOMEBREW_NO_INSTALL_CLEANUP=1
             brew update > /dev/null
             brew install \
               cmake ninja \


### PR DESCRIPTION
Related issue: https://github.com/Wandalen/wretry.action/issues/106
A workaround was suggested in https://github.com/Wandalen/wretry.action/issues/106#issuecomment-1631860467
