### PR TITLE
Change default power management to Gnome Session Manager

### DIFF
--- a/src/gui/powermanagement/powermanagement.h
+++ b/src/gui/powermanagement/powermanagement.h
@@ -61,6 +61,6 @@ private:
   PowerManagementInhibitor *m_inhibitor = nullptr;
 #endif
 #ifdef Q_OS_MACOS
-  IOPMAssertionID m_assertionID;
+  IOPMAssertionID m_assertionID {};
 #endif
 };

--- a/src/gui/powermanagement/powermanagement_x11.cpp
+++ b/src/gui/powermanagement/powermanagement_x11.cpp
@@ -86,7 +86,7 @@ void PowerManagementInhibitor::requestBusy()
     m_state = RequestBusy;
     qDebug("D-Bus: PowerManagementInhibitor: Requesting busy");
 
-    const QString message = u"Active torrents are presented"_s;
+    const QString message = u"Active torrents are currently present"_s;
     const auto args = (m_manager == ManagerType::Gnome)
         ? QList<QVariant> {u"qBittorrent"_s, 0u, message, 4u}
         : QList<QVariant> {u"qBittorrent"_s, message};

--- a/src/gui/powermanagement/powermanagement_x11.cpp
+++ b/src/gui/powermanagement/powermanagement_x11.cpp
@@ -48,7 +48,7 @@ PowerManagementInhibitor::PowerManagementInhibitor(QObject *parent)
 
     m_intendedState = Idle;
     m_cookie = 0;
-    m_useGSM = false;
+    m_useGSM = true;
 }
 
 void PowerManagementInhibitor::requestIdle()
@@ -135,9 +135,9 @@ void PowerManagementInhibitor::onAsyncReply(QDBusPendingCallWatcher *call)
         if (reply.isError()) {
             qDebug("D-Bus: Reply: Error: %s", qUtf8Printable(reply.error().message()));
 
-            if (!m_useGSM) {
-                qDebug("D-Bus: Falling back to org.gnome.SessionManager");
-                m_useGSM = true;
+            if (m_useGSM) {
+                qDebug("D-Bus: Falling back to org.freedesktop.PowerManagement");
+                m_useGSM = false;
                 m_state = Idle;
                 if (m_intendedState == Busy)
                     requestBusy();

--- a/src/gui/powermanagement/powermanagement_x11.h
+++ b/src/gui/powermanagement/powermanagement_x11.h
@@ -30,6 +30,7 @@
 
 #include <QObject>
 
+class QDBusInterface;
 class QDBusPendingCallWatcher;
 
 class PowerManagementInhibitor final : public QObject
@@ -57,9 +58,16 @@ private:
         RequestIdle
     };
 
+    enum class ManagerType
+    {
+        Freedesktop,  // https://www.freedesktop.org/wiki/Specifications/power-management-spec/
+        Gnome  // https://github.com/GNOME/gnome-settings-daemon/blob/master/gnome-settings-daemon/org.gnome.SessionManager.xml
+    };
+
+    QDBusInterface *m_busInterface = nullptr;
+    ManagerType m_manager = ManagerType::Gnome;
+
     enum State m_state = Error;
     enum State m_intendedState = Idle;
     quint32 m_cookie = 0;
-
-    bool m_useGSM = true;
 };

--- a/src/gui/powermanagement/powermanagement_x11.h
+++ b/src/gui/powermanagement/powermanagement_x11.h
@@ -32,7 +32,7 @@
 
 class QDBusPendingCallWatcher;
 
-class PowerManagementInhibitor : public QObject
+class PowerManagementInhibitor final : public QObject
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(PowerManagementInhibitor)
@@ -57,9 +57,9 @@ private:
         RequestIdle
     };
 
-    enum State m_state;
-    enum State m_intendedState;
-    unsigned int m_cookie;
+    enum State m_state = Error;
+    enum State m_intendedState = Idle;
+    quint32 m_cookie = 0;
 
-    bool m_useGSM;
+    bool m_useGSM = true;
 };


### PR DESCRIPTION
* Change default power management to Gnome Session Manager
  As seen on https://www.freedesktop.org/wiki/Specifications/power-management-spec/, the `org.freedesktop.PowerManagement` is obsolete.
* Clean up coding style
* Detect D-Bus interface
* Revise message
