### PR TITLE
Fix qBittorrent.conf overwrite on close

### DIFF
--- a/src/base/settingsstorage.cpp
+++ b/src/base/settingsstorage.cpp
@@ -57,7 +57,7 @@ SettingsStorage::SettingsStorage()
 
 SettingsStorage::~SettingsStorage()
 {
-    save();
+
 }
 
 void SettingsStorage::initInstance()


### PR DESCRIPTION
Currently, qBittorrent rewrites the config on close, which is unexpected behaviour for a linux daemon (qbittorrent-nox).
When modifying the config and then restarting the qbit systemd service, your changes would be rolled back, as the daemon is stopped. So one would have to make a nonstandard workaround which is to stop the service first, then modify the config, and finally start it.

This PR removes the call to SettingsStorage::save() on the SettingsStorage destructor (line 60 of src/base/settingsstorage.cpp), fixing this unexpected behaviour.