### PR TITLE
Avoid excessive power management updates

### DIFF
--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -164,7 +164,7 @@ private slots:
     void on_actionExit_triggered();
     void on_actionLock_triggered();
     // Check for unpaused downloading or seeding torrents and prevent system suspend/sleep according to preferences
-    void updatePowerManagementState();
+    void updatePowerManagementState() const;
 
     void toolbarMenuRequested();
     void toolbarIconsOnly();

--- a/src/gui/powermanagement/powermanagement.h
+++ b/src/gui/powermanagement/powermanagement.h
@@ -36,31 +36,30 @@
 #endif
 
 #ifdef QBT_USES_DBUS
-// Require DBus
 class PowerManagementInhibitor;
 #endif
 
 class PowerManagement final : public QObject
 {
-  Q_OBJECT
-  Q_DISABLE_COPY_MOVE(PowerManagement)
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(PowerManagement)
 
 public:
-  PowerManagement(QObject *parent = nullptr);
-  ~PowerManagement() override;
+    PowerManagement(QObject *parent = nullptr);
+    ~PowerManagement() override;
 
-  void setActivityState(bool busy);
+    void setActivityState(bool busy);
 
 private:
-  void setBusy();
-  void setIdle();
+    void setBusy();
+    void setIdle();
 
-  bool m_busy = false;
+    bool m_busy = false;
 
 #ifdef QBT_USES_DBUS
-  PowerManagementInhibitor *m_inhibitor = nullptr;
+    PowerManagementInhibitor *m_inhibitor = nullptr;
 #endif
 #ifdef Q_OS_MACOS
-  IOPMAssertionID m_assertionID {};
+    IOPMAssertionID m_assertionID {};
 #endif
 };

--- a/src/gui/powermanagement/powermanagement.h
+++ b/src/gui/powermanagement/powermanagement.h
@@ -40,14 +40,14 @@
 class PowerManagementInhibitor;
 #endif
 
-class PowerManagement : public QObject
+class PowerManagement final : public QObject
 {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(PowerManagement)
 
 public:
   PowerManagement(QObject *parent = nullptr);
-  virtual ~PowerManagement() = default;
+  ~PowerManagement() override;
 
   void setActivityState(bool busy);
 

--- a/src/gui/powermanagement/powermanagement_x11.cpp
+++ b/src/gui/powermanagement/powermanagement_x11.cpp
@@ -80,14 +80,14 @@ void PowerManagementInhibitor::requestIdle()
     if ((m_state == Error) || (m_state == Idle) || (m_state == RequestIdle) || (m_state == RequestBusy))
         return;
 
-    m_state = RequestIdle;
-
     if (m_manager == ManagerType::Systemd)
     {
-        QDBusUnixFileDescriptor dummy;
-        m_fd.swap(dummy);
+        m_fd = {};
+        m_state = Idle;
         return;
     }
+
+    m_state = RequestIdle;
 
     const QString method = (m_manager == ManagerType::Gnome)
         ? u"Uninhibit"_s


### PR DESCRIPTION
* Set power state to idle when deconstructing class
* Avoid excessive power management updates
* Fix indentation
* Fix incorrect state
  Fix up f3f9cfe44ed49d5bf3de0e318fa9c8ec48645ca4.