### PR TITLE
Use library provided `erase_if()`

### DIFF
--- a/src/base/algorithm.h
+++ b/src/base/algorithm.h
@@ -54,16 +54,6 @@ namespace Algorithm
             it = (p(it.key(), it.value()) ? dict.erase(it) : ++it);
     }
 
-    // To be used with set types, such as QSet, std::set
-    template <typename T, typename UnaryPredicate
-        , typename std::enable_if_t<!HasMappedType<T>::value, int> = 0>
-    void removeIf(T &set, UnaryPredicate &&p)
-    {
-        auto it = set.begin();
-        while (it != set.end())
-            it = (p(*it) ? set.erase(it) : ++it);
-    }
-
     template <typename List>
     List sorted(List list)
     {

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -1382,7 +1382,7 @@ void SessionImpl::processNextResumeData(ResumeSessionContext *context)
         }
     }
 
-    Algorithm::removeIf(resumeData.tags, [this, &torrentID](const QString &tag)
+    erase_if(resumeData.tags, [this, &torrentID](const QString &tag)
     {
         if (hasTag(tag))
             return false;

--- a/src/base/http/server.cpp
+++ b/src/base/http/server.cpp
@@ -148,7 +148,7 @@ void Server::removeConnection(Connection *connection)
 
 void Server::dropTimedOutConnection()
 {
-    Algorithm::removeIf(m_connections, [](Connection *connection)
+    erase_if(m_connections, [](Connection *connection)
     {
         if (!connection->hasExpired(KEEP_ALIVE_DURATION))
             return false;

--- a/src/base/orderedset.h
+++ b/src/base/orderedset.h
@@ -58,7 +58,7 @@ public:
 
     ThisType &intersect(const ThisType &other)
     {
-        Algorithm::removeIf(*this, [&other](const value_type &value) -> bool
+        std::erase_if(*this, [&other](const value_type &value) -> bool
         {
             return !other.contains(value);
         });

--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -957,8 +957,7 @@ void SyncController::onTorrentTrackersChanged(BitTorrent::Torrent *torrent)
 
     const TorrentID torrentID = torrent->id();
     Algorithm::removeIf(m_knownTrackers
-            , [this, torrentID, currentTrackers]
-                    (const QString &knownTracker, QSet<TorrentID> &torrentIDs)
+        , [this, torrentID, currentTrackers](const QString &knownTracker, QSet<TorrentID> &torrentIDs)
     {
         if (auto idIter = torrentIDs.find(torrentID)
                 ; (idIter != torrentIDs.end()) && !currentTrackers.contains(knownTracker))

--- a/test/testalgorithm.cpp
+++ b/test/testalgorithm.cpp
@@ -91,34 +91,11 @@ private slots:
         }
     }
 
-    void testNonMappedTypeRemoveIf() const
+    void testSorted() const
     {
-        {
-            QSet<char> data =
-            {
-                'a',
-                'b',
-                'c',
-                'b',
-                'd'
-            };
-            Algorithm::removeIf(data, [](const char value)
-            {
-                return (value == 'b');
-            });
-            QCOMPARE(data.size(), 3);
-            QVERIFY(data.contains('a'));
-            QVERIFY(data.contains('c'));
-            QVERIFY(data.contains('d'));
-        }
-        {
-            std::set<char> data;
-            Algorithm::removeIf(data, [](const char value)
-            {
-                return (value == 'b');
-            });
-            QVERIFY(data.empty());
-        }
+        const QStringList list = {u"c"_s, u"b"_s, u"a"_s};
+        const QStringList sortedList = {u"a"_s, u"b"_s, u"c"_s};
+        QCOMPARE(Algorithm::sorted(list), sortedList);
     }
 };
 


### PR DESCRIPTION
`Algorithm::removeIf()` is still valuable as `QHash::removeIf()` predicate require an iterator or a `std::pair`, which both require more code to unpack the parameter and therefore makes it unwieldy.
