### PR TITLE
Implement gateway for adding new torrents

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -837,27 +837,22 @@ try
                     , tr("An I/O error occurred for torrent '%1'.\n Reason: %2"
                             , "e.g: An error occurred for torrent 'xxx.avi'.\n Reason: disk is full.").arg(torrent->name(), msg));
         });
-        connect(btSession, &BitTorrent::Session::loadTorrentFailed, this
-                , [this](const QString &error)
-        {
-            m_desktopIntegration->showNotification(tr("Error"), tr("Failed to add torrent: %1").arg(error));
-        });
-        connect(btSession, &BitTorrent::Session::torrentAdded, this
-                , [this](const BitTorrent::Torrent *torrent)
-        {
-            if (isTorrentAddedNotificationsEnabled())
-                m_desktopIntegration->showNotification(tr("Torrent added"), tr("'%1' was added.", "e.g: xxx.avi was added.").arg(torrent->name()));
-        });
         connect(btSession, &BitTorrent::Session::torrentFinished, this
                 , [this](const BitTorrent::Torrent *torrent)
         {
             m_desktopIntegration->showNotification(tr("Download completed"), tr("'%1' has finished downloading.", "e.g: xxx.avi has finished downloading.").arg(torrent->name()));
         });
-        connect(m_addTorrentManager, &GUIAddTorrentManager::downloadFromUrlFailed, this
-                , [this](const QString &url, const QString &reason)
+        connect(m_addTorrentManager, &AddTorrentManager::torrentAdded, this
+                , [this]([[maybe_unused]] const QString &source, const BitTorrent::Torrent *torrent)
         {
-            m_desktopIntegration->showNotification(tr("URL download error")
-                    , tr("Couldn't download file at URL '%1', reason: %2.").arg(url, reason));
+            if (isTorrentAddedNotificationsEnabled())
+                m_desktopIntegration->showNotification(tr("Torrent added"), tr("'%1' was added.", "e.g: xxx.avi was added.").arg(torrent->name()));
+        });
+        connect(m_addTorrentManager, &AddTorrentManager::addTorrentFailed, this
+                , [this](const QString &source, const QString &reason)
+        {
+            m_desktopIntegration->showNotification(tr("Add torrent failed")
+                    , tr("Couldn't add torrent '%1', reason: %2.").arg(source, reason));
         });
 
         disconnect(m_desktopIntegration, &DesktopIntegration::activationRequested, this, &Application::createStartupProgressDialog);

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -172,6 +172,8 @@ private:
 #ifdef Q_OS_MACOS
     bool event(QEvent *) override;
 #endif
+    void askRecursiveTorrentDownloadConfirmation(const BitTorrent::Torrent *torrent);
+    void recursiveTorrentDownload(const BitTorrent::TorrentID &torrentID);
 #endif
 
     ApplicationInstanceManager *m_instanceManager = nullptr;

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -72,6 +72,7 @@ class QProgressDialog;
 class DesktopIntegration;
 class MainWindow;
 
+using AddTorrentManagerImpl = GUIAddTorrentManager;
 using BaseApplication = QApplication;
 using BaseIApplication = IGUIApplication;
 
@@ -79,6 +80,7 @@ using BaseIApplication = IGUIApplication;
 class QSessionManager;
 #endif
 #else // DISABLE_GUI
+using AddTorrentManagerImpl = AddTorrentManager;
 using BaseApplication = QCoreApplication;
 using BaseIApplication = IApplication;
 #endif // DISABLE_GUI
@@ -149,6 +151,8 @@ private slots:
 #endif
 
 private:
+    AddTorrentManagerImpl *addTorrentManager() const override;
+
     void initializeTranslation();
     void processParams(const QBtCommandLineParameters &params);
     void runExternalProgram(const QString &programTemplate, const BitTorrent::Torrent *torrent) const;
@@ -196,6 +200,8 @@ private:
 #ifdef Q_OS_WIN
     SettingValue<MemoryPriority> m_processMemoryPriority;
 #endif
+
+    AddTorrentManagerImpl *m_addTorrentManager = nullptr;
 
 #ifndef DISABLE_GUI
     SettingValue<WindowState> m_startUpWindowState;

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(qbt_base STATIC
     # headers
     3rdparty/expected.hpp
+    addtorrentmanager.h
     algorithm.h
     applicationcomponent.h
     asyncfilestorage.h
@@ -106,6 +107,7 @@ add_library(qbt_base STATIC
     version.h
 
     # sources
+    addtorrentmanager.cpp
     applicationcomponent.cpp
     asyncfilestorage.cpp
     bittorrent/abstractfilestorage.cpp

--- a/src/base/addtorrentmanager.cpp
+++ b/src/base/addtorrentmanager.cpp
@@ -1,0 +1,164 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2015-2023  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "addtorrentmanager.h"
+
+#include "base/bittorrent/infohash.h"
+#include "base/bittorrent/session.h"
+#include "base/bittorrent/torrentdescriptor.h"
+#include "base/logger.h"
+#include "base/net/downloadmanager.h"
+#include "base/preferences.h"
+#include "base/torrentfileguard.h"
+
+AddTorrentManager::AddTorrentManager(IApplication *app, BitTorrent::Session *btSession, QObject *parent)
+    : ApplicationComponent(app, parent)
+    , m_btSession {btSession}
+{
+    Q_ASSERT(m_btSession);
+}
+
+BitTorrent::Session *AddTorrentManager::btSession() const
+{
+    return m_btSession;
+}
+
+bool AddTorrentManager::addTorrent(const QString &source, const BitTorrent::AddTorrentParams &params)
+{
+    // `source`: .torrent file path,  magnet URI or URL
+
+    if (source.isEmpty())
+        return false;
+
+    if (Net::DownloadManager::hasSupportedScheme(source))
+    {
+        LogMsg(tr("Downloading torrent... Source: \"%1\"").arg(source));
+        const auto *pref = Preferences::instance();
+        // Launch downloader
+        Net::DownloadManager::instance()->download(Net::DownloadRequest(source).limit(pref->getTorrentFileSizeLimit())
+                , pref->useProxyForGeneralPurposes(), this, &AddTorrentManager::onDownloadFinished);
+        m_downloadedTorrents[source] = params;
+        return true;
+    }
+
+    if (const auto parseResult = BitTorrent::TorrentDescriptor::parse(source))
+    {
+        return processTorrent(parseResult.value(), params);
+    }
+    else if (source.startsWith(u"magnet:", Qt::CaseInsensitive))
+    {
+        handleError(source, parseResult.error());
+        return false;
+    }
+
+    const Path decodedPath {source.startsWith(u"file://", Qt::CaseInsensitive)
+            ? QUrl::fromEncoded(source.toLocal8Bit()).toLocalFile() : source};
+    TorrentFileGuard guard {decodedPath};
+    if (const auto loadResult = BitTorrent::TorrentDescriptor::loadFromFile(decodedPath))
+    {
+        guard.markAsAddedToSession();
+        return processTorrent(loadResult.value(), params);
+    }
+    else
+    {
+       handleError(source, loadResult.error());
+       return false;
+    }
+
+    return false;
+}
+
+void AddTorrentManager::onDownloadFinished(const Net::DownloadResult &result)
+{
+    const QString &source = result.url;
+    const BitTorrent::AddTorrentParams addTorrentParams = m_downloadedTorrents.take(source);
+
+    switch (result.status)
+    {
+    case Net::DownloadStatus::Success:
+        emit downloadFromUrlFinished(result.url);
+        if (const auto loadResult = BitTorrent::TorrentDescriptor::load(result.data))
+            processTorrent(loadResult.value(), addTorrentParams);
+        else
+            handleError(source, loadResult.error());
+        break;
+    case Net::DownloadStatus::RedirectedToMagnet:
+        emit downloadFromUrlFinished(result.url);
+        if (const auto parseResult = BitTorrent::TorrentDescriptor::parse(result.magnetURI))
+            processTorrent(parseResult.value(), addTorrentParams);
+        else
+            handleError(source, parseResult.error());
+        break;
+    default:
+        emit downloadFromUrlFailed(result.url, result.errorString);
+    }
+}
+
+void AddTorrentManager::handleError(const QString &source, const QString &reason)
+{
+    LogMsg(tr("Failed to load torrent. Source: \"%1\". Reason: \"%2\"").arg(source, reason), Log::WARNING);
+}
+
+bool AddTorrentManager::processTorrent(const BitTorrent::TorrentDescriptor &torrentDescr, const BitTorrent::AddTorrentParams &addTorrentParams)
+{
+    const bool hasMetadata = torrentDescr.info().has_value();
+    const BitTorrent::InfoHash infoHash = torrentDescr.infoHash();
+
+    if (BitTorrent::Torrent *torrent = btSession()->findTorrent(infoHash))
+    {
+        // a duplicate torrent is being added
+        if (hasMetadata)
+        {
+            // Trying to set metadata to existing torrent in case if it has none
+            torrent->setMetadata(*torrentDescr.info());
+        }
+
+        if (!btSession()->isMergeTrackersEnabled())
+        {
+            LogMsg(tr("Detected an attempt to add a duplicate torrent. Merging of trackers is disabled. Torrent: %1").arg(torrent->name()));
+            return false;
+        }
+
+        const bool isPrivate = torrent->isPrivate() || (hasMetadata && torrentDescr.info()->isPrivate());
+        if (isPrivate)
+        {
+            LogMsg(tr("Detected an attempt to add a duplicate torrent. Trackers cannot be merged because it is a private torrent. Torrent: %1").arg(torrent->name()));
+            return false;
+        }
+
+        // merge trackers and web seeds
+        torrent->addTrackers(torrentDescr.trackers());
+        torrent->addUrlSeeds(torrentDescr.urlSeeds());
+
+        LogMsg(tr("Detected an attempt to add a duplicate torrent. Trackers are merged from new source. Torrent: %1").arg(torrent->name()));
+        return false;
+    }
+
+    return btSession()->addTorrent(torrentDescr, addTorrentParams);
+}

--- a/src/base/applicationcomponent.cpp
+++ b/src/base/applicationcomponent.cpp
@@ -28,12 +28,12 @@
 
 #include "applicationcomponent.h"
 
-ApplicationComponent::ApplicationComponent(IApplication *app)
+ApplicationComponentBase::ApplicationComponentBase(IApplication *app)
     : m_app {app}
 {
 }
 
-IApplication *ApplicationComponent::app() const
+IApplication *ApplicationComponentBase::app() const
 {
     return m_app;
 }

--- a/src/base/applicationcomponent.h
+++ b/src/base/applicationcomponent.h
@@ -28,9 +28,12 @@
 
 #pragma once
 
+#include <concepts>
+#include <utility>
+
 #include <QtClassHelperMacros>
 
-#include "interfaces/iapplication.h"
+class IApplication;
 
 class ApplicationComponentBase
 {
@@ -39,7 +42,7 @@ class ApplicationComponentBase
 public:
     virtual ~ApplicationComponentBase() = default;
 
-    virtual IApplication *app() const;
+    IApplication *app() const;
 
 protected:
     explicit ApplicationComponentBase(IApplication *app);
@@ -48,7 +51,11 @@ private:
     IApplication *m_app = nullptr;
 };
 
+template <typename T>
+concept IsApplicationComponent = std::derived_from<T, ApplicationComponentBase>;
+
 template <typename Base>
+requires (!IsApplicationComponent<Base>)
 class ApplicationComponent : public Base, public ApplicationComponentBase
 {
 public:

--- a/src/base/applicationcomponent.h
+++ b/src/base/applicationcomponent.h
@@ -32,16 +32,30 @@
 
 #include "interfaces/iapplication.h"
 
-class ApplicationComponent
+class ApplicationComponentBase
 {
-    Q_DISABLE_COPY_MOVE(ApplicationComponent)
+    Q_DISABLE_COPY_MOVE(ApplicationComponentBase)
 
 public:
-    explicit ApplicationComponent(IApplication *app);
-    virtual ~ApplicationComponent() = default;
+    virtual ~ApplicationComponentBase() = default;
 
     virtual IApplication *app() const;
 
+protected:
+    explicit ApplicationComponentBase(IApplication *app);
+
 private:
     IApplication *m_app = nullptr;
+};
+
+template <typename Base>
+class ApplicationComponent : public Base, public ApplicationComponentBase
+{
+public:
+    template <typename... Args>
+    explicit ApplicationComponent(IApplication *app, Args&&... args)
+        : Base(std::forward<Args>(args)...)
+        , ApplicationComponentBase(app)
+    {
+    }
 };

--- a/src/base/bittorrent/infohash.cpp
+++ b/src/base/bittorrent/infohash.cpp
@@ -116,6 +116,11 @@ std::size_t BitTorrent::qHash(const BitTorrent::TorrentID &key, const std::size_
     return ::qHash(static_cast<TorrentID::BaseType>(key), seed);
 }
 
+std::size_t BitTorrent::qHash(const InfoHash &key, const std::size_t seed)
+{
+    return qHashMulti(seed, key.v1(), key.v2());
+}
+
 bool BitTorrent::operator==(const BitTorrent::InfoHash &left, const BitTorrent::InfoHash &right)
 {
     return (static_cast<InfoHash::WrappedType>(left) == static_cast<InfoHash::WrappedType>(right));

--- a/src/base/bittorrent/infohash.h
+++ b/src/base/bittorrent/infohash.h
@@ -87,6 +87,7 @@ namespace BitTorrent
     };
 
     std::size_t qHash(const TorrentID &key, std::size_t seed = 0);
+    std::size_t qHash(const InfoHash &key, std::size_t seed = 0);
 
     bool operator==(const InfoHash &left, const InfoHash &right);
 }

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -453,6 +453,7 @@ namespace BitTorrent
 
     signals:
         void startupProgressUpdated(int progress);
+        void addTorrentFailed(const InfoHash &infoHash, const QString &reason);
         void allTorrentsFinished();
         void categoryAdded(const QString &categoryName);
         void categoryRemoved(const QString &categoryName);

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -440,7 +440,6 @@ namespace BitTorrent
         virtual void banIP(const QString &ip) = 0;
 
         virtual bool isKnownTorrent(const InfoHash &infoHash) const = 0;
-        virtual bool addTorrent(const QString &source, const AddTorrentParams &params = {}) = 0;
         virtual bool addTorrent(const TorrentDescriptor &torrentDescr, const AddTorrentParams &params = {}) = 0;
         virtual bool deleteTorrent(const TorrentID &id, DeleteOption deleteOption = DeleteOption::DeleteTorrent) = 0;
         virtual bool downloadMetadata(const TorrentDescriptor &torrentDescr) = 0;
@@ -458,8 +457,6 @@ namespace BitTorrent
         void categoryAdded(const QString &categoryName);
         void categoryRemoved(const QString &categoryName);
         void categoryOptionsChanged(const QString &categoryName);
-        void downloadFromUrlFailed(const QString &url, const QString &reason);
-        void downloadFromUrlFinished(const QString &url);
         void fullDiskError(Torrent *torrent, const QString &msg);
         void IPFilterParsed(bool error, int ruleCount);
         void loadTorrentFailed(const QString &error);

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -445,7 +445,6 @@ namespace BitTorrent
         virtual bool downloadMetadata(const TorrentDescriptor &torrentDescr) = 0;
         virtual bool cancelDownloadMetadata(const TorrentID &id) = 0;
 
-        virtual void recursiveTorrentDownload(const TorrentID &id) = 0;
         virtual void increaseTorrentsQueuePos(const QVector<TorrentID> &ids) = 0;
         virtual void decreaseTorrentsQueuePos(const QVector<TorrentID> &ids) = 0;
         virtual void topTorrentsQueuePos(const QVector<TorrentID> &ids) = 0;
@@ -462,7 +461,6 @@ namespace BitTorrent
         void IPFilterParsed(bool error, int ruleCount);
         void loadTorrentFailed(const QString &error);
         void metadataDownloaded(const TorrentInfo &info);
-        void recursiveTorrentDownloadPossible(Torrent *torrent);
         void restored();
         void speedLimitModeChanged(bool alternative);
         void statsUpdated();

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -5306,6 +5306,7 @@ void SessionImpl::handleAddTorrentAlerts(const std::vector<lt::alert *> &alerts)
             if (const auto loadingTorrentsIter = m_loadingTorrents.find(TorrentID::fromInfoHash(infoHash))
                     ; loadingTorrentsIter != m_loadingTorrents.end())
             {
+                emit addTorrentFailed(infoHash, msg);
                 m_loadingTorrents.erase(loadingTorrentsIter);
             }
             else if (const auto downloadedMetadataIter = m_downloadedMetadata.find(TorrentID::fromInfoHash(infoHash))

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -67,11 +67,6 @@ class FileSearcher;
 class FilterParserThread;
 class NativeSessionExtension;
 
-namespace Net
-{
-    struct DownloadResult;
-}
-
 namespace BitTorrent
 {
     class InfoHash;
@@ -414,7 +409,6 @@ namespace BitTorrent
         void banIP(const QString &ip) override;
 
         bool isKnownTorrent(const InfoHash &infoHash) const override;
-        bool addTorrent(const QString &source, const AddTorrentParams &params = {}) override;
         bool addTorrent(const TorrentDescriptor &torrentDescr, const AddTorrentParams &params = {}) override;
         bool deleteTorrent(const TorrentID &id, DeleteOption deleteOption = DeleteTorrent) override;
         bool downloadMetadata(const TorrentDescriptor &torrentDescr) override;
@@ -477,7 +471,6 @@ namespace BitTorrent
         void generateResumeData();
         void handleIPFilterParsed(int ruleCount);
         void handleIPFilterError();
-        void handleDownloadFinished(const Net::DownloadResult &result);
         void fileSearchFinished(const TorrentID &id, const Path &savePath, const PathList &fileNames);
 
     private:
@@ -746,7 +739,6 @@ namespace BitTorrent
         QHash<TorrentID, TorrentImpl *> m_torrents;
         QHash<TorrentID, TorrentImpl *> m_hybridTorrentsByAltID;
         QHash<TorrentID, LoadTorrentParams> m_loadingTorrents;
-        QHash<QString, AddTorrentParams> m_downloadedTorrents;
         QHash<TorrentID, RemovingTorrentData> m_removingTorrents;
         QSet<TorrentID> m_needSaveResumeDataTorrents;
         QHash<TorrentID, TorrentID> m_changedTorrentIDs;

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -414,7 +414,6 @@ namespace BitTorrent
         bool downloadMetadata(const TorrentDescriptor &torrentDescr) override;
         bool cancelDownloadMetadata(const TorrentID &id) override;
 
-        void recursiveTorrentDownload(const TorrentID &id) override;
         void increaseTorrentsQueuePos(const QVector<TorrentID> &ids) override;
         void decreaseTorrentsQueuePos(const QVector<TorrentID> &ids) override;
         void topTorrentsQueuePos(const QVector<TorrentID> &ids) override;

--- a/src/base/interfaces/iapplication.h
+++ b/src/base/interfaces/iapplication.h
@@ -33,6 +33,8 @@
 #include <QtSystemDetection>
 #include <QMetaObject>
 
+#include "base/addtorrentmanager.h"
+
 class QString;
 
 class Path;
@@ -83,4 +85,6 @@ public:
     virtual MemoryPriority processMemoryPriority() const = 0;
     virtual void setProcessMemoryPriority(MemoryPriority priority) = 0;
 #endif
+
+    virtual AddTorrentManager *addTorrentManager() const = 0;
 };

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -2080,6 +2080,50 @@ void Preferences::setSpeedWidgetGraphEnable(const int id, const bool enable)
     setValue(u"SpeedWidget/graph_enable_%1"_s.arg(id), enable);
 }
 
+bool Preferences::isAddNewTorrentDialogEnabled() const
+{
+    return value(u"AddNewTorrentDialog/Enabled"_s, true);
+}
+
+void Preferences::setAddNewTorrentDialogEnabled(const bool value)
+{
+    if (value == isAddNewTorrentDialogEnabled())
+        return;
+
+    setValue(u"AddNewTorrentDialog/Enabled"_s, value);
+}
+
+bool Preferences::isAddNewTorrentDialogTopLevel() const
+{
+    return value(u"AddNewTorrentDialog/TopLevel"_s, true);
+}
+
+void Preferences::setAddNewTorrentDialogTopLevel(const bool value)
+{
+    if (value == isAddNewTorrentDialogTopLevel())
+        return;
+
+    setValue(u"AddNewTorrentDialog/TopLevel"_s, value);
+}
+
+int Preferences::addNewTorrentDialogSavePathHistoryLength() const
+{
+    const int defaultHistoryLength = 8;
+
+    const int val = value(u"AddNewTorrentDialog/SavePathHistoryLength"_s, defaultHistoryLength);
+    return std::clamp(val, 0, 99);
+}
+
+void Preferences::setAddNewTorrentDialogSavePathHistoryLength(const int value)
+{
+    const int clampedValue = qBound(0, value, 99);
+    const int oldValue = addNewTorrentDialogSavePathHistoryLength();
+    if (clampedValue == oldValue)
+        return;
+
+    setValue(u"AddNewTorrentDialog/SavePathHistoryLength"_s, clampedValue);
+}
+
 void Preferences::apply()
 {
     if (SettingsStorage::instance()->save())

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -424,6 +424,14 @@ public:
     bool getSpeedWidgetGraphEnable(int id) const;
     void setSpeedWidgetGraphEnable(int id, bool enable);
 
+    // AddNewTorrentDialog
+    bool isAddNewTorrentDialogEnabled() const;
+    void setAddNewTorrentDialogEnabled(bool value);
+    bool isAddNewTorrentDialogTopLevel() const;
+    void setAddNewTorrentDialogTopLevel(bool value);
+    int addNewTorrentDialogSavePathHistoryLength() const;
+    void setAddNewTorrentDialogSavePathHistoryLength(int value);
+
 public slots:
     void setStatusFilterState(bool checked);
     void setCategoryFilterState(bool checked);

--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -125,10 +125,10 @@ AutoDownloader::AutoDownloader(IApplication *app)
 
     m_ioThread->start();
 
-    connect(app->addTorrentManager(), &AddTorrentManager::downloadFromUrlFinished
-            , this, &AutoDownloader::handleTorrentDownloadFinished);
-    connect(app->addTorrentManager(), &AddTorrentManager::downloadFromUrlFailed
-            , this, &AutoDownloader::handleTorrentDownloadFailed);
+    connect(app->addTorrentManager(), &AddTorrentManager::torrentAdded
+            , this, &AutoDownloader::handleTorrentAdded);
+    connect(app->addTorrentManager(), &AddTorrentManager::addTorrentFailed
+            , this, &AutoDownloader::handleAddTorrentFailed);
 
     // initialise the smart episode regex
     const QString regex = computeSmartFilterRegex(smartEpisodeFilters());
@@ -361,9 +361,9 @@ void AutoDownloader::process()
     }
 }
 
-void AutoDownloader::handleTorrentDownloadFinished(const QString &url)
+void AutoDownloader::handleTorrentAdded(const QString &source)
 {
-    const auto job = m_waitingJobs.take(url);
+    const auto job = m_waitingJobs.take(source);
     if (!job)
         return;
 
@@ -374,9 +374,9 @@ void AutoDownloader::handleTorrentDownloadFinished(const QString &url)
     }
 }
 
-void AutoDownloader::handleTorrentDownloadFailed(const QString &url)
+void AutoDownloader::handleAddTorrentFailed(const QString &source)
 {
-    m_waitingJobs.remove(url);
+    m_waitingJobs.remove(source);
     // TODO: Re-schedule job here.
 }
 

--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -41,14 +41,16 @@
 #include <QVariant>
 #include <QVector>
 
-#include "../bittorrent/session.h"
-#include "../bittorrent/torrentdescriptor.h"
-#include "../asyncfilestorage.h"
-#include "../global.h"
-#include "../logger.h"
-#include "../profile.h"
-#include "../utils/fs.h"
-#include "../utils/io.h"
+#include "base/addtorrentmanager.h"
+#include "base/asyncfilestorage.h"
+#include "base/bittorrent/session.h"
+#include "base/bittorrent/torrentdescriptor.h"
+#include "base/global.h"
+#include "base/interfaces/iapplication.h"
+#include "base/logger.h"
+#include "base/profile.h"
+#include "base/utils/fs.h"
+#include "base/utils/io.h"
 #include "rss_article.h"
 #include "rss_autodownloadrule.h"
 #include "rss_feed.h"
@@ -100,12 +102,13 @@ QString computeSmartFilterRegex(const QStringList &filters)
     return u"(?:_|\\b)(?:%1)(?:_|\\b)"_s.arg(filters.join(u")|(?:"));
 }
 
-AutoDownloader::AutoDownloader()
-    : m_storeProcessingEnabled(u"RSS/AutoDownloader/EnableProcessing"_s, false)
-    , m_storeSmartEpisodeFilter(u"RSS/AutoDownloader/SmartEpisodeFilter"_s)
-    , m_storeDownloadRepacks(u"RSS/AutoDownloader/DownloadRepacks"_s)
-    , m_processingTimer(new QTimer(this))
-    , m_ioThread(new QThread)
+AutoDownloader::AutoDownloader(IApplication *app)
+    : ApplicationComponent(app)
+    , m_storeProcessingEnabled {u"RSS/AutoDownloader/EnableProcessing"_s, false}
+    , m_storeSmartEpisodeFilter {u"RSS/AutoDownloader/SmartEpisodeFilter"_s}
+    , m_storeDownloadRepacks {u"RSS/AutoDownloader/DownloadRepacks"_s}
+    , m_processingTimer {new QTimer(this)}
+    , m_ioThread {new QThread}
 {
     Q_ASSERT(!m_instance); // only one instance is allowed
     m_instance = this;
@@ -122,17 +125,17 @@ AutoDownloader::AutoDownloader()
 
     m_ioThread->start();
 
-    connect(BitTorrent::Session::instance(), &BitTorrent::Session::downloadFromUrlFinished
+    connect(app->addTorrentManager(), &AddTorrentManager::downloadFromUrlFinished
             , this, &AutoDownloader::handleTorrentDownloadFinished);
-    connect(BitTorrent::Session::instance(), &BitTorrent::Session::downloadFromUrlFailed
+    connect(app->addTorrentManager(), &AddTorrentManager::downloadFromUrlFailed
             , this, &AutoDownloader::handleTorrentDownloadFailed);
 
     // initialise the smart episode regex
     const QString regex = computeSmartFilterRegex(smartEpisodeFilters());
-    m_smartEpisodeRegex = QRegularExpression(regex,
-                                             QRegularExpression::CaseInsensitiveOption
-                                             | QRegularExpression::ExtendedPatternSyntaxOption
-                                             | QRegularExpression::UseUnicodePropertiesOption);
+    m_smartEpisodeRegex = QRegularExpression(regex
+            , QRegularExpression::CaseInsensitiveOption
+                    | QRegularExpression::ExtendedPatternSyntaxOption
+                    | QRegularExpression::UseUnicodePropertiesOption);
 
     load();
 
@@ -472,7 +475,7 @@ void AutoDownloader::processJob(const QSharedPointer<ProcessingJob> &job)
                 .arg(job->articleData.value(Article::KeyTitle).toString(), rule.name()));
 
         const auto torrentURL = job->articleData.value(Article::KeyTorrentURL).toString();
-        BitTorrent::Session::instance()->addTorrent(torrentURL, rule.addTorrentParams());
+        app()->addTorrentManager()->addTorrent(torrentURL, rule.addTorrentParams());
 
         if (BitTorrent::TorrentDescriptor::parse(torrentURL))
         {

--- a/src/base/rss/rss_autodownloader.h
+++ b/src/base/rss/rss_autodownloader.h
@@ -111,8 +111,8 @@ namespace RSS
 
     private slots:
         void process();
-        void handleTorrentDownloadFinished(const QString &url);
-        void handleTorrentDownloadFailed(const QString &url);
+        void handleTorrentAdded(const QString &source);
+        void handleAddTorrentFailed(const QString &url);
         void handleNewArticle(const Article *article);
         void handleFeedURLChanged(Feed *feed, const QString &oldURL);
 

--- a/src/base/rss/rss_autodownloader.h
+++ b/src/base/rss/rss_autodownloader.h
@@ -36,6 +36,7 @@
 #include <QRegularExpression>
 #include <QSharedPointer>
 
+#include "base/applicationcomponent.h"
 #include "base/exceptions.h"
 #include "base/settingvalue.h"
 #include "base/utils/thread.h"
@@ -61,14 +62,14 @@ namespace RSS
         using RuntimeError::RuntimeError;
     };
 
-    class AutoDownloader final : public QObject
+    class AutoDownloader final : public ApplicationComponent<QObject>
     {
         Q_OBJECT
         Q_DISABLE_COPY_MOVE(AutoDownloader)
 
         friend class ::Application;
 
-        AutoDownloader();
+        explicit AutoDownloader(IApplication *app);
         ~AutoDownloader() override;
 
     public:

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -54,6 +54,7 @@ add_library(qbt_gui STATIC
     flowlayout.h
     fspathedit.h
     fspathedit_p.h
+    guiaddtorrentmanager.h
     guiapplicationcomponent.h
     hidabletabwidget.h
     interfaces/iguiapplication.h
@@ -148,7 +149,7 @@ add_library(qbt_gui STATIC
     flowlayout.cpp
     fspathedit.cpp
     fspathedit_p.cpp
-    guiapplicationcomponent.cpp
+    guiaddtorrentmanager.cpp
     hidabletabwidget.cpp
     ipsubnetwhitelistoptionsdialog.cpp
     lineedit.cpp

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -471,7 +471,7 @@ void AddNewTorrentDialog::saveState()
 void AddNewTorrentDialog::showEvent(QShowEvent *event)
 {
     QDialog::showEvent(event);
-    if (!isTopLevel())
+    if (!Preferences::instance()->isAddNewTorrentDialogTopLevel())
         return;
 
     activateWindow();

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -37,6 +37,7 @@
 #include <QDir>
 #include <QFileDialog>
 #include <QMenu>
+#include <QMessageBox>
 #include <QPushButton>
 #include <QShortcut>
 #include <QString>
@@ -50,7 +51,6 @@
 #include "base/bittorrent/torrentcontenthandler.h"
 #include "base/bittorrent/torrentcontentlayout.h"
 #include "base/global.h"
-#include "base/net/downloadmanager.h"
 #include "base/preferences.h"
 #include "base/settingsstorage.h"
 #include "base/torrentfileguard.h"
@@ -58,19 +58,16 @@
 #include "base/utils/fs.h"
 #include "base/utils/misc.h"
 #include "lineedit.h"
-#include "raisedmessagebox.h"
 #include "torrenttagsdialog.h"
-#include "ui_addnewtorrentdialog.h"
 #include "uithememanager.h"
+
+#include "ui_addnewtorrentdialog.h"
 
 namespace
 {
 #define SETTINGS_KEY(name) u"AddNewTorrentDialog/" name
-    const QString KEY_ENABLED = SETTINGS_KEY(u"Enabled"_s);
-    const QString KEY_TOPLEVEL = SETTINGS_KEY(u"TopLevel"_s);
     const QString KEY_SAVEPATHHISTORY = SETTINGS_KEY(u"SavePathHistory"_s);
     const QString KEY_DOWNLOADPATHHISTORY = SETTINGS_KEY(u"DownloadPathHistory"_s);
-    const QString KEY_SAVEPATHHISTORYLENGTH = SETTINGS_KEY(u"SavePathHistoryLength"_s);
 
     // just a shortcut
     inline SettingsStorage *settings()
@@ -267,19 +264,18 @@ private:
     BitTorrent::TorrentContentLayout m_currentContentLayout;
 };
 
-const int AddNewTorrentDialog::minPathHistoryLength;
-const int AddNewTorrentDialog::maxPathHistoryLength;
-
-AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::AddTorrentParams &inParams, QWidget *parent)
+AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::TorrentDescriptor &torrentDescr
+        , const BitTorrent::AddTorrentParams &inParams, QWidget *parent)
     : QDialog(parent)
-    , m_ui(new Ui::AddNewTorrentDialog)
-    , m_filterLine(new LineEdit(this))
-    , m_torrentParams(inParams)
-    , m_storeDialogSize(SETTINGS_KEY(u"DialogSize"_s))
-    , m_storeDefaultCategory(SETTINGS_KEY(u"DefaultCategory"_s))
-    , m_storeRememberLastSavePath(SETTINGS_KEY(u"RememberLastSavePath"_s))
-    , m_storeTreeHeaderState(u"GUI/Qt6/" SETTINGS_KEY(u"TreeHeaderState"_s))
-    , m_storeSplitterState(u"GUI/Qt6/" SETTINGS_KEY(u"SplitterState"_s))
+    , m_ui {new Ui::AddNewTorrentDialog}
+    , m_torrentDescr {torrentDescr}
+    , m_torrentParams {inParams}
+    , m_filterLine {new LineEdit(this)}
+    , m_storeDialogSize {SETTINGS_KEY(u"DialogSize"_s)}
+    , m_storeDefaultCategory {SETTINGS_KEY(u"DefaultCategory"_s)}
+    , m_storeRememberLastSavePath {SETTINGS_KEY(u"RememberLastSavePath"_s)}
+    , m_storeTreeHeaderState {u"GUI/Qt6/" SETTINGS_KEY(u"TreeHeaderState"_s)}
+    , m_storeSplitterState {u"GUI/Qt6/" SETTINGS_KEY(u"SplitterState"_s)}
 {
     // TODO: set dialog file properties using m_torrentParams.filePriorities
     m_ui->setupUi(this);
@@ -384,8 +380,6 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::AddTorrentParams &inP
 
     loadState();
 
-    connect(m_ui->doNotDeleteTorrentCheckBox, &QCheckBox::clicked, this, &AddNewTorrentDialog::doNotDeleteTorrentClicked);
-
     connect(m_ui->buttonSelectAll, &QPushButton::clicked, m_ui->contentTreeView, &TorrentContentWidget::checkAll);
     connect(m_ui->buttonSelectNone, &QPushButton::clicked, m_ui->contentTreeView, &TorrentContentWidget::checkNone);
 
@@ -408,6 +402,33 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::AddTorrentParams &inP
         m_ui->savePath->setFocus();
     else
         m_ui->categoryComboBox->setFocus();
+
+    connect(Preferences::instance(), &Preferences::changed, []
+    {
+        const int length = Preferences::instance()->addNewTorrentDialogSavePathHistoryLength();
+        settings()->storeValue(KEY_SAVEPATHHISTORY
+                , QStringList(settings()->loadValue<QStringList>(KEY_SAVEPATHHISTORY).mid(0, length)));
+    });
+
+    const BitTorrent::InfoHash infoHash = m_torrentDescr.infoHash();
+
+    m_ui->labelInfohash1Data->setText(infoHash.v1().isValid() ? infoHash.v1().toString() : tr("N/A"));
+    m_ui->labelInfohash2Data->setText(infoHash.v2().isValid() ? infoHash.v2().toString() : tr("N/A"));
+
+    if (hasMetadata())
+    {
+        setupTreeview();
+    }
+    else
+    {
+        // Set dialog title
+        const QString torrentName = m_torrentDescr.name();
+        setWindowTitle(torrentName.isEmpty() ? tr("Magnet link") : torrentName);
+        updateDiskSpaceLabel();
+        setMetadataProgressIndicator(true, tr("Retrieving metadata..."));
+    }
+
+    TMMChanged(m_ui->comboTTM->currentIndex());
 }
 
 AddNewTorrentDialog::~AddNewTorrentDialog()
@@ -416,43 +437,19 @@ AddNewTorrentDialog::~AddNewTorrentDialog()
     delete m_ui;
 }
 
-bool AddNewTorrentDialog::isEnabled()
+BitTorrent::TorrentDescriptor AddNewTorrentDialog::torrentDescriptor() const
 {
-    return settings()->loadValue(KEY_ENABLED, true);
+    return m_torrentDescr;
 }
 
-void AddNewTorrentDialog::setEnabled(const bool value)
+BitTorrent::AddTorrentParams AddNewTorrentDialog::addTorrentParams() const
 {
-    settings()->storeValue(KEY_ENABLED, value);
+    return m_torrentParams;
 }
 
-bool AddNewTorrentDialog::isTopLevel()
+bool AddNewTorrentDialog::isDoNotDeleteTorrentChecked() const
 {
-    return settings()->loadValue(KEY_TOPLEVEL, true);
-}
-
-void AddNewTorrentDialog::setTopLevel(const bool value)
-{
-    settings()->storeValue(KEY_TOPLEVEL, value);
-}
-
-int AddNewTorrentDialog::savePathHistoryLength()
-{
-    const int defaultHistoryLength = 8;
-    const int value = settings()->loadValue(KEY_SAVEPATHHISTORYLENGTH, defaultHistoryLength);
-    return std::clamp(value, minPathHistoryLength, maxPathHistoryLength);
-}
-
-void AddNewTorrentDialog::setSavePathHistoryLength(const int value)
-{
-    const int clampedValue = qBound(minPathHistoryLength, value, maxPathHistoryLength);
-    const int oldValue = savePathHistoryLength();
-    if (clampedValue == oldValue)
-        return;
-
-    settings()->storeValue(KEY_SAVEPATHHISTORYLENGTH, clampedValue);
-    settings()->storeValue(KEY_SAVEPATHHISTORY
-        , QStringList(settings()->loadValue<QStringList>(KEY_SAVEPATHHISTORY).mid(0, clampedValue)));
+    return m_ui->doNotDeleteTorrentCheckBox->isChecked();
 }
 
 void AddNewTorrentDialog::loadState()
@@ -469,136 +466,6 @@ void AddNewTorrentDialog::saveState()
     m_storeSplitterState = m_ui->splitter->saveState();
     if (hasMetadata())
         m_storeTreeHeaderState = m_ui->contentTreeView->header()->saveState();
-}
-
-void AddNewTorrentDialog::show(const QString &source, const BitTorrent::AddTorrentParams &inParams, QWidget *parent)
-{
-    auto *dlg = new AddNewTorrentDialog(inParams, parent);
-    dlg->setAttribute(Qt::WA_DeleteOnClose);
-
-    if (Net::DownloadManager::hasSupportedScheme(source))
-    {
-        const auto *pref = Preferences::instance();
-        // Launch downloader
-        Net::DownloadManager::instance()->download(
-                Net::DownloadRequest(source).limit(pref->getTorrentFileSizeLimit())
-                , pref->useProxyForGeneralPurposes()
-                , dlg, &AddNewTorrentDialog::handleDownloadFinished);
-        return;
-    }
-
-    if (dlg->loadTorrent(source))
-        dlg->QDialog::show();
-    else
-        delete dlg;
-}
-
-void AddNewTorrentDialog::show(const QString &source, QWidget *parent)
-{
-    show(source, BitTorrent::AddTorrentParams(), parent);
-}
-
-bool AddNewTorrentDialog::loadTorrent(const QString &source)
-{
-    if (const auto parseResult = BitTorrent::TorrentDescriptor::parse(source))
-    {
-        m_torrentDescr = parseResult.value();
-        return loadTorrentImpl();
-    }
-    else if (source.startsWith(u"magnet:", Qt::CaseInsensitive))
-    {
-        RaisedMessageBox::critical(this, tr("Invalid torrent")
-                , tr("Failed to load the torrent: %1.\nError: %2").arg(source, parseResult.error()));
-        return false;
-    }
-
-    const Path decodedPath {source.startsWith(u"file://", Qt::CaseInsensitive)
-            ? QUrl::fromEncoded(source.toLocal8Bit()).toLocalFile() : source};
-
-    if (const auto loadResult = BitTorrent::TorrentDescriptor::loadFromFile(decodedPath))
-    {
-        m_torrentDescr = loadResult.value();
-        m_torrentGuard = std::make_unique<TorrentFileGuard>(decodedPath);
-
-        return loadTorrentImpl();
-    }
-    else
-    {
-        RaisedMessageBox::critical(this, tr("Invalid torrent")
-                , tr("Failed to load the torrent: %1.\nError: %2", "Don't remove the '\n' characters. They insert a newline.")
-                        .arg(decodedPath.toString(), loadResult.error()));
-        return false;
-    }
-}
-
-bool AddNewTorrentDialog::loadTorrentImpl()
-{
-    const BitTorrent::InfoHash infoHash = m_torrentDescr.infoHash();
-
-    // Prevent showing the dialog if download is already present
-    const auto *btSession = BitTorrent::Session::instance();
-    if (btSession->isKnownTorrent(infoHash))
-    {
-        if (BitTorrent::Torrent *torrent = btSession->findTorrent(infoHash))
-        {
-            if (hasMetadata())
-            {
-                // Trying to set metadata to existing torrent in case if it has none
-                torrent->setMetadata(*m_torrentDescr.info());
-            }
-
-            if (torrent->isPrivate() || (hasMetadata() && m_torrentDescr.info()->isPrivate()))
-            {
-                RaisedMessageBox::warning(this, tr("Torrent is already present"), tr("Torrent '%1' is already in the transfer list. Trackers cannot be merged because it is a private torrent.").arg(torrent->name()), QMessageBox::Ok);
-            }
-            else
-            {
-                bool mergeTrackers = btSession->isMergeTrackersEnabled();
-                if (Preferences::instance()->confirmMergeTrackers())
-                {
-                    const QMessageBox::StandardButton btn = RaisedMessageBox::question(this, tr("Torrent is already present")
-                            , tr("Torrent '%1' is already in the transfer list. Do you want to merge trackers from new source?").arg(torrent->name())
-                            , (QMessageBox::Yes | QMessageBox::No), QMessageBox::Yes);
-                    mergeTrackers = (btn == QMessageBox::Yes);
-                }
-
-                if (mergeTrackers)
-                {
-                    torrent->addTrackers(m_torrentDescr.trackers());
-                    torrent->addUrlSeeds(m_torrentDescr.urlSeeds());
-                }
-            }
-        }
-        else
-        {
-            RaisedMessageBox::information(this, tr("Torrent is already present"), tr("Torrent is already queued for processing."), QMessageBox::Ok);
-        }
-
-        return false;
-    }
-
-    m_ui->labelInfohash1Data->setText(infoHash.v1().isValid() ? infoHash.v1().toString() : tr("N/A"));
-    m_ui->labelInfohash2Data->setText(infoHash.v2().isValid() ? infoHash.v2().toString() : tr("N/A"));
-
-    if (hasMetadata())
-    {
-        setupTreeview();
-    }
-    else
-    {
-        connect(BitTorrent::Session::instance(), &BitTorrent::Session::metadataDownloaded, this, &AddNewTorrentDialog::updateMetadata);
-
-        // Set dialog title
-        const QString torrentName = m_torrentDescr.name();
-        setWindowTitle(torrentName.isEmpty() ? tr("Magnet link") : torrentName);
-        updateDiskSpaceLabel();
-        BitTorrent::Session::instance()->downloadMetadata(m_torrentDescr);
-        setMetadataProgressIndicator(true, tr("Retrieving metadata..."));
-    }
-
-    TMMChanged(m_ui->comboTTM->currentIndex());
-
-    return true;
 }
 
 void AddNewTorrentDialog::showEvent(QShowEvent *event)
@@ -818,16 +685,17 @@ void AddNewTorrentDialog::accept()
     m_torrentParams.useAutoTMM = useAutoTMM;
     if (!useAutoTMM)
     {
+        const int savePathHistoryLength = Preferences::instance()->addNewTorrentDialogSavePathHistoryLength();
         const Path savePath = m_ui->savePath->selectedPath();
         m_torrentParams.savePath = savePath;
-        updatePathHistory(KEY_SAVEPATHHISTORY, savePath, savePathHistoryLength());
+        updatePathHistory(KEY_SAVEPATHHISTORY, savePath, savePathHistoryLength);
 
         m_torrentParams.useDownloadPath = m_ui->groupBoxDownloadPath->isChecked();
         if (m_torrentParams.useDownloadPath)
         {
             const Path downloadPath = m_ui->downloadPath->selectedPath();
             m_torrentParams.downloadPath = downloadPath;
-            updatePathHistory(KEY_DOWNLOADPATHHISTORY, downloadPath, savePathHistoryLength());
+            updatePathHistory(KEY_DOWNLOADPATHHISTORY, downloadPath, savePathHistoryLength);
         }
         else
         {
@@ -843,11 +711,6 @@ void AddNewTorrentDialog::accept()
 
     setEnabled(!m_ui->checkBoxNeverShow->isChecked());
 
-    // Add torrent
-    BitTorrent::Session::instance()->addTorrent(m_torrentDescr, m_torrentParams);
-
-    if (m_torrentGuard)
-        m_torrentGuard->markAsAddedToSession();
     QDialog::accept();
 }
 
@@ -865,13 +728,13 @@ void AddNewTorrentDialog::reject()
 void AddNewTorrentDialog::updateMetadata(const BitTorrent::TorrentInfo &metadata)
 {
     Q_ASSERT(metadata.isValid());
-
-    if (!metadata.matchesInfoHash(m_torrentDescr.infoHash()))
+    if (!metadata.isValid()) [[unlikely]]
         return;
 
-    disconnect(BitTorrent::Session::instance(), &BitTorrent::Session::metadataDownloaded, this, &AddNewTorrentDialog::updateMetadata);
+    Q_ASSERT(!metadata.matchesInfoHash(m_torrentDescr.infoHash()));
+    if (!metadata.matchesInfoHash(m_torrentDescr.infoHash())) [[unlikely]]
+        return;
 
-    // Good to go
     m_torrentDescr.setTorrentInfo(metadata);
     setMetadataProgressIndicator(true, tr("Parsing metadata..."));
 
@@ -941,50 +804,6 @@ void AddNewTorrentDialog::setupTreeview()
     updateDiskSpaceLabel();
 }
 
-void AddNewTorrentDialog::handleDownloadFinished(const Net::DownloadResult &downloadResult)
-{
-    switch (downloadResult.status)
-    {
-    case Net::DownloadStatus::Success:
-        if (const auto loadResult = BitTorrent::TorrentDescriptor::load(downloadResult.data))
-        {
-            m_torrentDescr = loadResult.value();
-        }
-        else
-        {
-            RaisedMessageBox::critical(this, tr("Invalid torrent")
-                    , tr("Failed to load from URL: %1.\nError: %2").arg(downloadResult.url, loadResult.error()));
-            deleteLater();
-            return;
-        }
-        break;
-    case Net::DownloadStatus::RedirectedToMagnet:
-        if (const auto parseResult = BitTorrent::TorrentDescriptor::parse(downloadResult.magnetURI))
-        {
-            m_torrentDescr = parseResult.value();
-        }
-        else
-        {
-            RaisedMessageBox::critical(this, tr("Invalid torrent")
-                    , tr("Failed to load torrent. The request was redirected to invalid Magnet URI.\nError: %1")
-                            .arg(parseResult.error()));
-            deleteLater();
-            return;
-        }
-        break;
-    default:
-        RaisedMessageBox::critical(this, tr("Download Error")
-                , tr("Cannot download '%1': %2").arg(downloadResult.url, downloadResult.errorString));
-        deleteLater();
-        return;
-    }
-
-    if (loadTorrentImpl())
-        open();
-    else
-        deleteLater();
-}
-
 void AddNewTorrentDialog::TMMChanged(int index)
 {
     if (index != 1)
@@ -1013,10 +832,4 @@ void AddNewTorrentDialog::TMMChanged(int index)
     }
 
     updateDiskSpaceLabel();
-}
-
-void AddNewTorrentDialog::doNotDeleteTorrentClicked(bool checked)
-{
-    if (m_torrentGuard)
-        m_torrentGuard->setAutoRemove(!checked);
 }

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -731,7 +731,7 @@ void AddNewTorrentDialog::updateMetadata(const BitTorrent::TorrentInfo &metadata
     if (!metadata.isValid()) [[unlikely]]
         return;
 
-    Q_ASSERT(!metadata.matchesInfoHash(m_torrentDescr.infoHash()));
+    Q_ASSERT(metadata.matchesInfoHash(m_torrentDescr.infoHash()));
     if (!metadata.matchesInfoHash(m_torrentDescr.infoHash())) [[unlikely]]
         return;
 

--- a/src/gui/addnewtorrentdialog.h
+++ b/src/gui/addnewtorrentdialog.h
@@ -29,8 +29,6 @@
 
 #pragma once
 
-#include <memory>
-
 #include <QDialog>
 
 #include "base/bittorrent/addtorrentparams.h"
@@ -38,23 +36,12 @@
 #include "base/path.h"
 #include "base/settingvalue.h"
 
-namespace BitTorrent
-{
-    class InfoHash;
-}
-
-namespace Net
-{
-    struct DownloadResult;
-}
-
 namespace Ui
 {
     class AddNewTorrentDialog;
 }
 
 class LineEdit;
-class TorrentFileGuard;
 
 class AddNewTorrentDialog final : public QDialog
 {
@@ -62,32 +49,24 @@ class AddNewTorrentDialog final : public QDialog
     Q_DISABLE_COPY_MOVE(AddNewTorrentDialog)
 
 public:
-    static const int minPathHistoryLength = 0;
-    static const int maxPathHistoryLength = 99;
-
+    explicit AddNewTorrentDialog(const BitTorrent::TorrentDescriptor &torrentDescr
+            , const BitTorrent::AddTorrentParams &inParams, QWidget *parent);
     ~AddNewTorrentDialog() override;
 
-    static bool isEnabled();
-    static void setEnabled(bool value);
-    static bool isTopLevel();
-    static void setTopLevel(bool value);
-    static int savePathHistoryLength();
-    static void setSavePathHistoryLength(int value);
+    BitTorrent::TorrentDescriptor torrentDescriptor() const;
+    BitTorrent::AddTorrentParams addTorrentParams() const;
+    bool isDoNotDeleteTorrentChecked() const;
 
-    static void show(const QString &source, const BitTorrent::AddTorrentParams &inParams, QWidget *parent);
-    static void show(const QString &source, QWidget *parent);
+    void updateMetadata(const BitTorrent::TorrentInfo &metadata);
 
 private slots:
     void updateDiskSpaceLabel();
     void onSavePathChanged(const Path &newPath);
     void onDownloadPathChanged(const Path &newPath);
     void onUseDownloadPathChanged(bool checked);
-    void updateMetadata(const BitTorrent::TorrentInfo &metadata);
-    void handleDownloadFinished(const Net::DownloadResult &downloadResult);
     void TMMChanged(int index);
     void categoryChanged(int index);
     void contentLayoutChanged();
-    void doNotDeleteTorrentClicked(bool checked);
 
     void accept() override;
     void reject() override;
@@ -95,10 +74,6 @@ private slots:
 private:
     class TorrentContentAdaptor;
 
-    explicit AddNewTorrentDialog(const BitTorrent::AddTorrentParams &inParams, QWidget *parent);
-
-    bool loadTorrent(const QString &source);
-    bool loadTorrentImpl();
     void populateSavePaths();
     void loadState();
     void saveState();
@@ -112,12 +87,11 @@ private:
     Ui::AddNewTorrentDialog *m_ui = nullptr;
     TorrentContentAdaptor *m_contentAdaptor = nullptr;
     BitTorrent::TorrentDescriptor m_torrentDescr;
+    BitTorrent::AddTorrentParams m_torrentParams;
     int m_savePathIndex = -1;
     int m_downloadPathIndex = -1;
     bool m_useDownloadPath = false;
     LineEdit *m_filterLine = nullptr;
-    std::unique_ptr<TorrentFileGuard> m_torrentGuard;
-    BitTorrent::AddTorrentParams m_torrentParams;
 
     SettingValue<QSize> m_storeDialogSize;
     SettingValue<QString> m_storeDefaultCategory;

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -305,7 +305,7 @@ void AdvancedSettings::saveAdvancedSettings() const
     session->setReannounceWhenAddressChangedEnabled(m_checkBoxReannounceWhenAddressChanged.isChecked());
     // Misc GUI properties
     app()->mainWindow()->setDownloadTrackerFavicon(m_checkBoxTrackerFavicon.isChecked());
-    AddNewTorrentDialog::setSavePathHistoryLength(m_spinBoxSavePathHistoryLength.value());
+    pref->setAddNewTorrentDialogSavePathHistoryLength(m_spinBoxSavePathHistoryLength.value());
     pref->setSpeedWidgetEnabled(m_checkBoxSpeedWidgetEnabled.isChecked());
 #ifndef Q_OS_MACOS
     pref->setIconsInMenusEnabled(m_checkBoxIconsInMenusEnabled.isChecked());
@@ -785,8 +785,8 @@ void AdvancedSettings::loadAdvancedSettings()
     m_checkBoxTrackerFavicon.setChecked(app()->mainWindow()->isDownloadTrackerFavicon());
     addRow(DOWNLOAD_TRACKER_FAVICON, tr("Download tracker's favicon"), &m_checkBoxTrackerFavicon);
     // Save path history length
-    m_spinBoxSavePathHistoryLength.setRange(AddNewTorrentDialog::minPathHistoryLength, AddNewTorrentDialog::maxPathHistoryLength);
-    m_spinBoxSavePathHistoryLength.setValue(AddNewTorrentDialog::savePathHistoryLength());
+    m_spinBoxSavePathHistoryLength.setRange(0, 99);
+    m_spinBoxSavePathHistoryLength.setValue(pref->addNewTorrentDialogSavePathHistoryLength());
     addRow(SAVE_PATH_HISTORY_LENGTH, tr("Save path history length"), &m_spinBoxSavePathHistoryLength);
     // Enable speed graphs
     m_checkBoxSpeedWidgetEnabled.setChecked(pref->isSpeedWidgetEnabled());

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -168,8 +168,7 @@ namespace
 }
 
 AdvancedSettings::AdvancedSettings(IGUIApplication *app, QWidget *parent)
-    : QTableWidget(parent)
-    , GUIApplicationComponent(app)
+    : GUIApplicationComponent(app, parent)
 {
     // column
     setColumnCount(COL_COUNT);

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -38,7 +38,7 @@
 
 #include "guiapplicationcomponent.h"
 
-class AdvancedSettings final : public QTableWidget, public GUIApplicationComponent
+class AdvancedSettings final : public GUIApplicationComponent<QTableWidget>
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(AdvancedSettings)

--- a/src/gui/guiaddtorrentmanager.cpp
+++ b/src/gui/guiaddtorrentmanager.cpp
@@ -1,0 +1,212 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2015-2023  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "guiaddtorrentmanager.h"
+
+#include "base/bittorrent/session.h"
+#include "base/bittorrent/torrentdescriptor.h"
+#include "base/logger.h"
+#include "base/net/downloadmanager.h"
+#include "base/preferences.h"
+#include "addnewtorrentdialog.h"
+#include "interfaces/iguiapplication.h"
+#include "mainwindow.h"
+#include "raisedmessagebox.h"
+
+GUIAddTorrentManager::GUIAddTorrentManager(IGUIApplication *app, BitTorrent::Session *session, QObject *parent)
+    : GUIApplicationComponent(app, session, parent)
+{
+    connect(btSession(), &BitTorrent::Session::metadataDownloaded, this, &GUIAddTorrentManager::onMetadataDownloaded);
+}
+
+bool GUIAddTorrentManager::addTorrent(const QString &source, const BitTorrent::AddTorrentParams &params, const AddTorrentOption option)
+{
+    // `source`: .torrent file path,  magnet URI or URL
+
+    if (source.isEmpty())
+        return false;
+
+    const auto *pref = Preferences::instance();
+
+    if ((option == AddTorrentOption::SkipDialog)
+            || ((option == AddTorrentOption::Default) && !pref->isAddNewTorrentDialogEnabled()))
+    {
+        return AddTorrentManager::addTorrent(source, params);
+    }
+
+    if (Net::DownloadManager::hasSupportedScheme(source))
+    {
+        LogMsg(tr("Downloading torrent... Source: \"%1\"").arg(source));
+        // Launch downloader
+        Net::DownloadManager::instance()->download(Net::DownloadRequest(source).limit(pref->getTorrentFileSizeLimit())
+                , pref->useProxyForGeneralPurposes(), this, &GUIAddTorrentManager::onDownloadFinished);
+        m_downloadedTorrents[source] = params;
+
+        return true;
+    }
+
+    if (const auto parseResult = BitTorrent::TorrentDescriptor::parse(source))
+    {
+        return processTorrent(parseResult.value(), params);
+    }
+    else if (source.startsWith(u"magnet:", Qt::CaseInsensitive))
+    {
+        handleError(source, parseResult.error());
+        return false;
+    }
+
+    const Path decodedPath {source.startsWith(u"file://", Qt::CaseInsensitive)
+            ? QUrl::fromEncoded(source.toLocal8Bit()).toLocalFile() : source};
+    auto torrentFileGuard = std::make_shared<TorrentFileGuard>(decodedPath);
+    if (const auto loadResult = BitTorrent::TorrentDescriptor::loadFromFile(decodedPath))
+    {
+        const BitTorrent::TorrentDescriptor &torrentDescriptor = loadResult.value();
+        const bool isProcessing = processTorrent(torrentDescriptor, params);
+        if (isProcessing)
+            m_processingFiles.emplace(torrentDescriptor.infoHash(), std::move(torrentFileGuard));
+        return isProcessing;
+    }
+    else
+    {
+        handleError(decodedPath.toString(), loadResult.error());
+        return false;
+    }
+
+    return false;
+}
+
+void GUIAddTorrentManager::onDownloadFinished(const Net::DownloadResult &result)
+{
+    const QString &source = result.url;
+    const BitTorrent::AddTorrentParams addTorrentParams = m_downloadedTorrents.take(source);
+
+    switch (result.status)
+    {
+    case Net::DownloadStatus::Success:
+        emit downloadFromUrlFinished(result.url);
+        if (const auto loadResult = BitTorrent::TorrentDescriptor::load(result.data))
+            processTorrent(loadResult.value(), addTorrentParams);
+        else
+            handleError(source, loadResult.error());
+        break;
+    case Net::DownloadStatus::RedirectedToMagnet:
+        emit downloadFromUrlFinished(result.url);
+        if (const auto parseResult = BitTorrent::TorrentDescriptor::parse(result.magnetURI))
+            processTorrent(parseResult.value(), addTorrentParams);
+        else
+            handleError(source, parseResult.error());
+        break;
+    default:
+        emit downloadFromUrlFailed(result.url, result.errorString);
+    }
+}
+
+void GUIAddTorrentManager::onMetadataDownloaded(const BitTorrent::TorrentInfo &metadata)
+{
+    Q_ASSERT(metadata.isValid());
+    if (!metadata.isValid()) [[unlikely]]
+        return;
+
+    for (const auto &[infoHash, dialog] : m_dialogs.asKeyValueRange())
+    {
+        if (metadata.matchesInfoHash(infoHash))
+            dialog->updateMetadata(metadata);
+    }
+}
+
+void GUIAddTorrentManager::handleError(const QString &source, const QString &reason)
+{
+    RaisedMessageBox::critical(app()->mainWindow(), tr("Invalid torrent")
+            , tr("Failed to load torrent.\nSource: %1\nReason: %2").arg(source, reason));
+}
+
+bool GUIAddTorrentManager::processTorrent(const BitTorrent::TorrentDescriptor &torrentDescr, const BitTorrent::AddTorrentParams &params)
+{
+    const bool hasMetadata = torrentDescr.info().has_value();
+    const BitTorrent::InfoHash infoHash = torrentDescr.infoHash();
+
+    // Prevent showing the dialog if download is already present
+    if (BitTorrent::Torrent *torrent = btSession()->findTorrent(infoHash))
+    {
+        if (hasMetadata)
+        {
+            // Trying to set metadata to existing torrent in case if it has none
+            torrent->setMetadata(*torrentDescr.info());
+        }
+
+        if (torrent->isPrivate() || (hasMetadata && torrentDescr.info()->isPrivate()))
+        {
+            RaisedMessageBox::warning(app()->mainWindow(), tr("Torrent is already present")
+                    , tr("Torrent '%1' is already in the transfer list. Trackers cannot be merged because it is a private torrent.")
+                            .arg(torrent->name()), QMessageBox::Ok);
+        }
+        else
+        {
+            bool mergeTrackers = btSession()->isMergeTrackersEnabled();
+            if (Preferences::instance()->confirmMergeTrackers())
+            {
+                const QMessageBox::StandardButton btn = RaisedMessageBox::question(app()->mainWindow(), tr("Torrent is already present")
+                        , tr("Torrent '%1' is already in the transfer list. Do you want to merge trackers from new source?").arg(torrent->name())
+                        , (QMessageBox::Yes | QMessageBox::No), QMessageBox::Yes);
+                mergeTrackers = (btn == QMessageBox::Yes);
+            }
+
+            if (mergeTrackers)
+            {
+                torrent->addTrackers(torrentDescr.trackers());
+                torrent->addUrlSeeds(torrentDescr.urlSeeds());
+            }
+        }
+
+        return false;
+    }
+
+    if (!hasMetadata)
+        btSession()->downloadMetadata(torrentDescr);
+
+    auto *dlg = new AddNewTorrentDialog(torrentDescr, params, app()->mainWindow());
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
+    m_dialogs[infoHash] = dlg;
+    connect(dlg, &QDialog::finished, this, [this, infoHash, dlg](int result)
+    {
+        auto torrentFileGuard = m_processingFiles.take(infoHash);
+        torrentFileGuard->setAutoRemove(!dlg->isDoNotDeleteTorrentChecked());
+
+        if (result == QDialog::Accepted)
+        {
+            if (btSession()->addTorrent(dlg->torrentDescriptor(), dlg->addTorrentParams()))
+                torrentFileGuard->markAsAddedToSession();
+        }
+
+        m_dialogs.remove(infoHash);
+    });
+    dlg->show();
+
+    return true;
+}

--- a/src/gui/guiaddtorrentmanager.h
+++ b/src/gui/guiaddtorrentmanager.h
@@ -29,11 +29,8 @@
 
 #pragma once
 
-#include <memory>
-
 #include "base/addtorrentmanager.h"
 #include "base/bittorrent/infohash.h"
-#include "base/torrentfileguard.h"
 #include "guiapplicationcomponent.h"
 
 #include <QHash>
@@ -70,10 +67,8 @@ public:
 private:
     void onDownloadFinished(const Net::DownloadResult &result);
     void onMetadataDownloaded(const BitTorrent::TorrentInfo &metadata);
-    void handleError(const QString &source, const QString &reason);
-    bool processTorrent(const BitTorrent::TorrentDescriptor &torrentDescr, const BitTorrent::AddTorrentParams &params);
+    bool processTorrent(const QString &source, const BitTorrent::TorrentDescriptor &torrentDescr, const BitTorrent::AddTorrentParams &params);
 
     QHash<QString, BitTorrent::AddTorrentParams> m_downloadedTorrents;
     QHash<BitTorrent::InfoHash, AddNewTorrentDialog *> m_dialogs;
-    QHash<BitTorrent::InfoHash, std::shared_ptr<TorrentFileGuard>> m_processingFiles;
 };

--- a/src/gui/guiapplicationcomponent.cpp
+++ b/src/gui/guiapplicationcomponent.cpp
@@ -28,12 +28,12 @@
 
 #include "guiapplicationcomponent.h"
 
-GUIApplicationComponent::GUIApplicationComponent(IGUIApplication *app)
-    : ApplicationComponent(app)
+GUIApplicationComponentBase::GUIApplicationComponentBase(IGUIApplication *app)
+    : ApplicationComponentBase(app)
 {
 }
 
-IGUIApplication *GUIApplicationComponent::app() const
+IGUIApplication *GUIApplicationComponentBase::app() const
 {
-    return static_cast<IGUIApplication *>(ApplicationComponent::app());
+    return static_cast<IGUIApplication *>(ApplicationComponentBase::app());
 }

--- a/src/gui/guiapplicationcomponent.h
+++ b/src/gui/guiapplicationcomponent.h
@@ -31,12 +31,25 @@
 #include "base/applicationcomponent.h"
 #include "interfaces/iguiapplication.h"
 
-class GUIApplicationComponent : public ApplicationComponent
+class GUIApplicationComponentBase : public ApplicationComponentBase
 {
-    Q_DISABLE_COPY_MOVE(GUIApplicationComponent)
+    Q_DISABLE_COPY_MOVE(GUIApplicationComponentBase)
 
 public:
-    explicit GUIApplicationComponent(IGUIApplication *app);
-
     IGUIApplication *app() const override;
+
+protected:
+    explicit GUIApplicationComponentBase(IGUIApplication *app);
+};
+
+template <typename Base>
+class GUIApplicationComponent : public Base, public GUIApplicationComponentBase
+{
+public:
+    template <typename... Args>
+    explicit GUIApplicationComponent(IGUIApplication *app, Args&&... args)
+        : Base(std::forward<Args>(args)...)
+        , GUIApplicationComponentBase(app)
+    {
+    }
 };

--- a/src/gui/guiapplicationcomponent.h
+++ b/src/gui/guiapplicationcomponent.h
@@ -29,27 +29,38 @@
 #pragma once
 
 #include "base/applicationcomponent.h"
-#include "interfaces/iguiapplication.h"
 
-class GUIApplicationComponentBase : public ApplicationComponentBase
-{
-    Q_DISABLE_COPY_MOVE(GUIApplicationComponentBase)
-
-public:
-    IGUIApplication *app() const override;
-
-protected:
-    explicit GUIApplicationComponentBase(IGUIApplication *app);
-};
+class IGUIApplication;
 
 template <typename Base>
-class GUIApplicationComponent : public Base, public GUIApplicationComponentBase
+class GUIApplicationComponent : public Base, public ApplicationComponentBase
 {
 public:
     template <typename... Args>
     explicit GUIApplicationComponent(IGUIApplication *app, Args&&... args)
         : Base(std::forward<Args>(args)...)
-        , GUIApplicationComponentBase(app)
+        , ApplicationComponentBase(reinterpret_cast<IApplication *>(app))
     {
+    }
+
+    IGUIApplication *app() const
+    {
+        return reinterpret_cast<IGUIApplication *>(ApplicationComponentBase::app());
+    }
+};
+
+template <IsApplicationComponent Base>
+class GUIApplicationComponent<Base> : public Base
+{
+public:
+    template <typename... Args>
+    explicit GUIApplicationComponent(IGUIApplication *app, Args&&... args)
+        : Base(reinterpret_cast<IApplication *>(app), std::forward<Args>(args)...)
+    {
+    }
+
+    IGUIApplication *app() const
+    {
+        return reinterpret_cast<IGUIApplication *>(ApplicationComponentBase::app());
     }
 };

--- a/src/gui/interfaces/iguiapplication.h
+++ b/src/gui/interfaces/iguiapplication.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "base/interfaces/iapplication.h"
+#include "gui/guiaddtorrentmanager.h"
 #include "gui/windowstate.h"
 
 class DesktopIntegration;
@@ -40,6 +41,8 @@ class IGUIApplication : public IApplication
 {
 public:
     ~IGUIApplication() override = default;
+
+    GUIAddTorrentManager *addTorrentManager() const override = 0;
 
     virtual DesktopIntegration *desktopIntegration() = 0;
     virtual MainWindow *mainWindow() = 0;

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -184,7 +184,6 @@ MainWindow::MainWindow(IGUIApplication *app, WindowState initialState)
     updateAltSpeedsBtn(BitTorrent::Session::instance()->isAltGlobalSpeedLimitEnabled());
 
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::speedLimitModeChanged, this, &MainWindow::updateAltSpeedsBtn);
-    connect(BitTorrent::Session::instance(), &BitTorrent::Session::recursiveTorrentDownloadPossible, this, &MainWindow::askRecursiveTorrentDownloadConfirmation);
 
     qDebug("create tabWidget");
     m_tabs = new HidableTabWidget(this);
@@ -918,37 +917,6 @@ void MainWindow::displayExecutionLogTab()
 }
 
 // End of keyboard shortcuts slots
-
-void MainWindow::askRecursiveTorrentDownloadConfirmation(const BitTorrent::Torrent *torrent)
-{
-    if (!Preferences::instance()->isRecursiveDownloadEnabled())
-        return;
-
-    const auto torrentID = torrent->id();
-
-    QMessageBox *confirmBox = new QMessageBox(QMessageBox::Question, tr("Recursive download confirmation")
-        , tr("The torrent '%1' contains .torrent files, do you want to proceed with their downloads?").arg(torrent->name())
-        , (QMessageBox::Yes | QMessageBox::No | QMessageBox::NoToAll), this);
-    confirmBox->setAttribute(Qt::WA_DeleteOnClose);
-
-    const QAbstractButton *yesButton = confirmBox->button(QMessageBox::Yes);
-    QAbstractButton *neverButton = confirmBox->button(QMessageBox::NoToAll);
-    neverButton->setText(tr("Never"));
-
-    connect(confirmBox, &QMessageBox::buttonClicked, this
-        , [torrentID, yesButton, neverButton](const QAbstractButton *button)
-    {
-        if (button == yesButton)
-        {
-            BitTorrent::Session::instance()->recursiveTorrentDownload(torrentID);
-        }
-        else if (button == neverButton)
-        {
-            Preferences::instance()->setRecursiveDownloadEnabled(false);
-        }
-    });
-    confirmBox->open();
-}
 
 void MainWindow::on_actionSetGlobalSpeedLimits_triggered()
 {

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -70,8 +70,8 @@ namespace Ui
 {
     class MainWindow;
 }
-
-class MainWindow final : public QMainWindow, public GUIApplicationComponent
+    
+    class MainWindow final : public GUIApplicationComponent<QMainWindow>
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(MainWindow)

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -70,8 +70,8 @@ namespace Ui
 {
     class MainWindow;
 }
-    
-    class MainWindow final : public GUIApplicationComponent<QMainWindow>
+
+class MainWindow final : public GUIApplicationComponent<QMainWindow>
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(MainWindow)

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -122,7 +122,6 @@ private slots:
     void reloadSessionStats();
     void reloadTorrentStats(const QVector<BitTorrent::Torrent *> &torrents);
     void loadPreferences();
-    void askRecursiveTorrentDownloadConfirmation(const BitTorrent::Torrent *torrent);
     void optionsSaved();
     void toggleAlternativeSpeeds();
 

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -483,8 +483,8 @@ void OptionsDialog::loadDownloadsTabOptions()
     const auto *pref = Preferences::instance();
     const auto *session = BitTorrent::Session::instance();
 
-    m_ui->checkAdditionDialog->setChecked(AddNewTorrentDialog::isEnabled());
-    m_ui->checkAdditionDialogFront->setChecked(AddNewTorrentDialog::isTopLevel());
+    m_ui->checkAdditionDialog->setChecked(pref->isAddNewTorrentDialogEnabled());
+    m_ui->checkAdditionDialogFront->setChecked(pref->isAddNewTorrentDialogTopLevel());
 
     m_ui->contentLayoutComboBox->setCurrentIndex(static_cast<int>(session->torrentContentLayout()));
     m_ui->checkAddToQueueTop->setChecked(session->isAddTorrentToQueueTop());
@@ -685,8 +685,8 @@ void OptionsDialog::saveDownloadsTabOptions() const
     auto *pref = Preferences::instance();
     auto *session = BitTorrent::Session::instance();
 
-    AddNewTorrentDialog::setEnabled(useAdditionDialog());
-    AddNewTorrentDialog::setTopLevel(m_ui->checkAdditionDialogFront->isChecked());
+    pref->setAddNewTorrentDialogEnabled(useAdditionDialog());
+    pref->setAddNewTorrentDialogTopLevel(m_ui->checkAdditionDialogFront->isChecked());
 
     session->setTorrentContentLayout(static_cast<BitTorrent::TorrentContentLayout>(m_ui->contentLayoutComboBox->currentIndex()));
 

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -110,8 +110,7 @@ namespace
 
 // Constructor
 OptionsDialog::OptionsDialog(IGUIApplication *app, QWidget *parent)
-    : QDialog(parent)
-    , GUIApplicationComponent(app)
+    : GUIApplicationComponent(app, parent)
     , m_ui {new Ui::OptionsDialog}
     , m_storeDialogSize {SETTINGS_KEY(u"Size"_s)}
     , m_storeHSplitterSize {SETTINGS_KEY(u"HorizontalSplitterSizes"_s)}

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -57,8 +57,8 @@ namespace Ui
 {
     class OptionsDialog;
 }
-
-class OptionsDialog final : public QDialog, public GUIApplicationComponent
+    
+    class OptionsDialog final : public GUIApplicationComponent<QDialog>
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(OptionsDialog)

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -57,8 +57,8 @@ namespace Ui
 {
     class OptionsDialog;
 }
-    
-    class OptionsDialog final : public GUIApplicationComponent<QDialog>
+
+class OptionsDialog final : public GUIApplicationComponent<QDialog>
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(OptionsDialog)

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -39,7 +39,6 @@
 #include <QShortcut>
 #include <QString>
 
-#include "base/bittorrent/session.h"
 #include "base/global.h"
 #include "base/net/downloadmanager.h"
 #include "base/preferences.h"
@@ -47,17 +46,17 @@
 #include "base/rss/rss_feed.h"
 #include "base/rss/rss_folder.h"
 #include "base/rss/rss_session.h"
-#include "gui/addnewtorrentdialog.h"
 #include "gui/autoexpandabledialog.h"
+#include "gui/interfaces/iguiapplication.h"
 #include "gui/uithememanager.h"
 #include "articlelistwidget.h"
 #include "automatedrssdownloader.h"
 #include "feedlistwidget.h"
 #include "ui_rsswidget.h"
 
-RSSWidget::RSSWidget(QWidget *parent)
-    : QWidget(parent)
-    , m_ui(new Ui::RSSWidget)
+RSSWidget::RSSWidget(IGUIApplication *app, QWidget *parent)
+    : GUIApplicationComponent(app, parent)
+    , m_ui {new Ui::RSSWidget}
 {
     m_ui->setupUi(this);
 
@@ -370,13 +369,7 @@ void RSSWidget::downloadSelectedTorrents()
         // Mark as read
         article->markAsRead();
 
-        if (!article->torrentUrl().isEmpty())
-        {
-            if (AddNewTorrentDialog::isEnabled())
-                AddNewTorrentDialog::show(article->torrentUrl(), window());
-            else
-                BitTorrent::Session::instance()->addTorrent(article->torrentUrl());
-        }
+        app()->addTorrentManager()->addTorrent(article->torrentUrl());
     }
 }
 

--- a/src/gui/rss/rsswidget.h
+++ b/src/gui/rss/rsswidget.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2017  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2017-2023  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2006  Christophe Dumez <chris@qbittorrent.org>
  * Copyright (C) 2006  Arnaud Demaiziere <arnaud@qbittorrent.org>
  *
@@ -32,6 +32,8 @@
 
 #include <QWidget>
 
+#include "gui/guiapplicationcomponent.h"
+
 class QListWidgetItem;
 class QTreeWidgetItem;
 
@@ -43,14 +45,14 @@ namespace Ui
     class RSSWidget;
 }
 
-class RSSWidget : public QWidget
+class RSSWidget final : public GUIApplicationComponent<QWidget>
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(RSSWidget)
 
 public:
-    RSSWidget(QWidget *parent);
-    ~RSSWidget();
+    explicit RSSWidget(IGUIApplication *app, QWidget *parent = nullptr);
+    ~RSSWidget() override;
 
 public slots:
     void deleteSelectedItems();

--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -39,24 +39,22 @@
 #include <QStandardItemModel>
 #include <QUrl>
 
-#include "base/bittorrent/session.h"
 #include "base/preferences.h"
 #include "base/search/searchdownloadhandler.h"
 #include "base/search/searchhandler.h"
 #include "base/search/searchpluginmanager.h"
 #include "base/utils/misc.h"
-#include "gui/addnewtorrentdialog.h"
+#include "gui/interfaces/iguiapplication.h"
 #include "gui/lineedit.h"
 #include "gui/uithememanager.h"
-#include "gui/utils.h"
 #include "searchsortmodel.h"
 #include "ui_searchjobwidget.h"
 
-SearchJobWidget::SearchJobWidget(SearchHandler *searchHandler, QWidget *parent)
-    : QWidget(parent)
-    , m_ui(new Ui::SearchJobWidget)
-    , m_searchHandler(searchHandler)
-    , m_nameFilteringMode(u"Search/FilteringMode"_s)
+SearchJobWidget::SearchJobWidget(SearchHandler *searchHandler, IGUIApplication *app, QWidget *parent)
+    : GUIApplicationComponent(app, parent)
+    , m_ui {new Ui::SearchJobWidget}
+    , m_searchHandler {searchHandler}
+    , m_nameFilteringMode {u"Search/FilteringMode"_s}
 {
     m_ui->setupUi(this);
 
@@ -289,12 +287,7 @@ void SearchJobWidget::downloadTorrent(const QModelIndex &rowIndex, const AddTorr
 
 void SearchJobWidget::addTorrentToSession(const QString &source, const AddTorrentOption option)
 {
-    if (source.isEmpty()) return;
-
-    if ((option == AddTorrentOption::ShowDialog) || ((option == AddTorrentOption::Default) && AddNewTorrentDialog::isEnabled()))
-        AddNewTorrentDialog::show(source, this);
-    else
-        BitTorrent::Session::instance()->addTorrent(source);
+    app()->addTorrentManager()->addTorrent(source, {}, option);
 }
 
 void SearchJobWidget::updateResultsCount()

--- a/src/gui/search/searchjobwidget.h
+++ b/src/gui/search/searchjobwidget.h
@@ -32,6 +32,8 @@
 #include <QWidget>
 
 #include "base/settingvalue.h"
+#include "gui/guiaddtorrentmanager.h"
+#include "gui/guiapplicationcomponent.h"
 
 #define ENGINE_URL_COLUMN 4
 #define URL_COLUMN 5
@@ -52,7 +54,7 @@ namespace Ui
     class SearchJobWidget;
 }
 
-class SearchJobWidget final : public QWidget
+class SearchJobWidget final : public GUIApplicationComponent<QWidget>
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(SearchJobWidget)
@@ -74,7 +76,7 @@ public:
         NoResults
     };
 
-    explicit SearchJobWidget(SearchHandler *searchHandler, QWidget *parent = nullptr);
+    SearchJobWidget(SearchHandler *searchHandler, IGUIApplication *app, QWidget *parent = nullptr);
     ~SearchJobWidget() override;
 
     Status status() const;
@@ -94,13 +96,6 @@ private slots:
     void displayColumnHeaderMenu();
 
 private:
-    enum class AddTorrentOption
-    {
-        Default,
-        ShowDialog,
-        SkipDialog,
-    };
-
     void loadSettings();
     void saveSettings() const;
     void updateFilter();

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -84,8 +84,7 @@ namespace
 }
 
 SearchWidget::SearchWidget(IGUIApplication *app, MainWindow *mainWindow)
-    : QWidget(mainWindow)
-    , GUIApplicationComponent(app)
+    : GUIApplicationComponent(app, mainWindow)
     , m_ui {new Ui::SearchWidget()}
     , m_mainWindow {mainWindow}
 {

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -53,6 +53,7 @@
 #include "base/search/searchpluginmanager.h"
 #include "base/utils/foreignapps.h"
 #include "gui/desktopintegration.h"
+#include "gui/interfaces/iguiapplication.h"
 #include "gui/mainwindow.h"
 #include "gui/uithememanager.h"
 #include "pluginselectdialog.h"
@@ -346,7 +347,7 @@ void SearchWidget::on_searchButton_clicked()
     auto *searchHandler = SearchPluginManager::instance()->startSearch(pattern, selectedCategory(), plugins);
 
     // Tab Addition
-    auto *newTab = new SearchJobWidget(searchHandler, this);
+    auto *newTab = new SearchJobWidget(searchHandler, app(), this);
     m_allTabs.append(newTab);
 
     QString tabName = pattern;

--- a/src/gui/search/searchwidget.h
+++ b/src/gui/search/searchwidget.h
@@ -47,8 +47,8 @@ namespace Ui
 {
     class SearchWidget;
 }
-
-class SearchWidget : public QWidget, public GUIApplicationComponent
+    
+    class SearchWidget : public GUIApplicationComponent<QWidget>
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(SearchWidget)

--- a/src/webui/api/apicontroller.cpp
+++ b/src/webui/api/apicontroller.cpp
@@ -38,8 +38,7 @@
 #include "apierror.h"
 
 APIController::APIController(IApplication *app, QObject *parent)
-    : QObject(parent)
-    , ApplicationComponent(app)
+    : ApplicationComponent(app, parent)
 {
 }
 

--- a/src/webui/api/apicontroller.h
+++ b/src/webui/api/apicontroller.h
@@ -39,7 +39,7 @@ class QString;
 using DataMap = QHash<QString, QByteArray>;
 using StringMap = QHash<QString, QString>;
 
-class APIController : public QObject, public ApplicationComponent
+class APIController : public ApplicationComponent<QObject>
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(APIController)

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -47,6 +47,7 @@
 #include "base/bittorrent/torrent.h"
 #include "base/bittorrent/torrentdescriptor.h"
 #include "base/bittorrent/trackerentry.h"
+#include "base/interfaces/iapplication.h"
 #include "base/global.h"
 #include "base/logger.h"
 #include "base/net/downloadmanager.h"
@@ -732,7 +733,7 @@ void TorrentsController::addAction()
         if (!url.isEmpty())
         {
             Net::DownloadManager::instance()->setCookiesFromUrl(cookies, QUrl::fromEncoded(url.toUtf8()));
-            partialSuccess |= BitTorrent::Session::instance()->addTorrent(url, addTorrentParams);
+            partialSuccess |= app()->addTorrentManager()->addTorrent(url, addTorrentParams);
         }
     }
 

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -143,8 +143,7 @@ namespace
 }
 
 WebApplication::WebApplication(IApplication *app, QObject *parent)
-    : QObject(parent)
-    , ApplicationComponent(app)
+    : ApplicationComponent(app, parent)
     , m_cacheID {QString::number(Utils::Random::rand(), 36)}
     , m_authController {new AuthController(this, app, this)}
 {

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -58,7 +58,7 @@ class APIController;
 class AuthController;
 class WebApplication;
 
-class WebSession final : public QObject, public ApplicationComponent, public ISession
+class WebSession final : public ApplicationComponent<QObject>, public ISession
 {
 public:
     explicit WebSession(const QString &sid, IApplication *app);
@@ -83,8 +83,7 @@ private:
     QMap<QString, APIController *> m_apiControllers;
 };
 
-class WebApplication final
-        : public QObject, public ApplicationComponent
+class WebApplication final : public ApplicationComponent<QObject>
         , public Http::IRequestHandler, public ISessionManager
         , private Http::ResponseBuilder
 {

--- a/src/webui/webui.h
+++ b/src/webui/webui.h
@@ -45,7 +45,7 @@ namespace Net
 
 class WebApplication;
 
-class WebUI : public QObject, public ApplicationComponent
+class WebUI final : public ApplicationComponent<QObject>
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(WebUI)


### PR DESCRIPTION
This PR contains mainly a structural redesign of the code to serve as a basis for subsequent improvements. The idea is to concentrate the logic of adding torrents from various sources in a single place (providing a so-called gateway for added torrents) in order to have more control over them. This will allow to implement the following features:
1. Prevent opening multiple dialogs for the same torrent file (magnet link) simultaneously
2. Prevent conflicts when some torrent is being added non-interactively while dialog is already opened for the same torrent
3. Implement queueing and asynchronous processing of multiple added torrents