### PR TITLE
GHA CI: Bump Qt version to 6.5.2

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -19,10 +19,10 @@ jobs:
       matrix:
         libt_version: ["2.0.9", "1.2.19"]
         qbt_gui: ["GUI=ON", "GUI=OFF"]
-        qt_version: ["6.5.0"]
+        qt_version: ["6.5.2"]
         exclude:
           - libt_version: "1.2.19"
-            qt_version: "6.5.0"
+            qt_version: "6.5.2"
 
     env:
       boost_path: "${{ github.workspace }}/../boost"

--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -20,9 +20,6 @@ jobs:
         libt_version: ["2.0.9", "1.2.19"]
         qbt_gui: ["GUI=ON", "GUI=OFF"]
         qt_version: ["6.5.2"]
-        exclude:
-          - libt_version: "1.2.19"
-            qt_version: "6.5.2"
 
     env:
       boost_path: "${{ github.workspace }}/../boost"

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -21,9 +21,6 @@ jobs:
         libt_version: ["2.0.9", "1.2.19"]
         qbt_gui: ["GUI=ON", "GUI=OFF"]
         qt_version: ["6.5.2"]
-        exclude:
-          - libt_version: "1.2.19"
-            qt_version: "6.5.2"
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -34,7 +34,7 @@ jobs:
           sudo apt update
           sudo apt install \
             build-essential cmake ninja-build pkg-config \
-            libboost-dev libssl-dev libxkbcommon-x11-dev zlib1g-dev
+            libboost-dev libssl-dev libxkbcommon-x11-dev libxcb-cursor-dev zlib1g-dev
 
       - name: Setup ccache
         uses: Chocobo1/setup-ccache-action@v1
@@ -47,7 +47,7 @@ jobs:
         uses: jurplel/install-qt-action@v3
         with:
           version: ${{ matrix.qt_version }}
-          archives: icu qtbase qtsvg qttools
+          archives: icu qtbase qtdeclarative qtsvg qttools
 
       - name: Install libtorrent
         run: |

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -20,10 +20,10 @@ jobs:
       matrix:
         libt_version: ["2.0.9", "1.2.19"]
         qbt_gui: ["GUI=ON", "GUI=OFF"]
-        qt_version: ["6.2.0"]
+        qt_version: ["6.5.2"]
         exclude:
           - libt_version: "1.2.19"
-            qt_version: "6.2.0"
+            qt_version: "6.5.2"
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
         with:
-          version: "6.5.0"
+          version: "6.5.2"
           archives: qtbase qtsvg qttools
 
       - name: Install libtorrent

--- a/.github/workflows/coverity-scan.yaml
+++ b/.github/workflows/coverity-scan.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
         with:
-          version: "6.5.0"
+          version: "6.5.2"
           archives: icu qtbase qtsvg qttools
 
       - name: Install libtorrent


### PR DESCRIPTION
* Use Qt 6.5.2 across all CI
* Add required dependencies (Linux)
* Re-enabled libtorrent1 builds (Linux & macOS)