### PR TITLE
Don't use variable after it is moved

### DIFF
--- a/src/base/bittorrent/torrentdescriptor.cpp
+++ b/src/base/bittorrent/torrentdescriptor.cpp
@@ -195,7 +195,7 @@ void BitTorrent::TorrentDescriptor::setTorrentInfo(TorrentInfo torrentInfo)
     else
     {
         m_info = std::move(torrentInfo);
-        m_ltAddTorrentParams.ti = torrentInfo.nativeInfo();
+        m_ltAddTorrentParams.ti = m_info->nativeInfo();
 #ifdef QBT_USES_LIBTORRENT2
         m_ltAddTorrentParams.info_hashes = m_ltAddTorrentParams.ti->info_hashes();
 #else


### PR DESCRIPTION
Fixes regression of #19301.
Ref.: https://github.com/qbittorrent/qBittorrent/pull/19301#discussion_r1280154593.
