### PR TITLE
Fix overwriting feeds.json with an incomplete load of it

### DIFF
--- a/src/base/rss/rss_session.cpp
+++ b/src/base/rss/rss_session.cpp
@@ -294,7 +294,7 @@ void Session::load()
             .arg(path.toString()), Log::WARNING);
         return;
     }
-    
+
     if (loadFolder(jsonDoc.object(), rootFolder()))
         store(); // convert to updated format
 }

--- a/src/base/rss/rss_session.cpp
+++ b/src/base/rss/rss_session.cpp
@@ -355,7 +355,8 @@ bool Session::loadFolder(const QJsonObject &jsonObj, Folder *folder)
             }
             else
             {
-                update = update || loadFolder(valObj, addSubfolder(key, folder));
+                if (loadFolder(valObj, addSubfolder(key, folder)))
+                    updated = true;
             }
         }
         else
@@ -365,7 +366,7 @@ bool Session::loadFolder(const QJsonObject &jsonObj, Folder *folder)
         }
     }
 
-    return updated; // to update root after loading everything
+    return updated;
 }
 
 void Session::loadLegacy()

--- a/src/base/rss/rss_session.h
+++ b/src/base/rss/rss_session.h
@@ -149,7 +149,7 @@ namespace RSS
     private:
         QUuid generateUID() const;
         void load();
-        void loadFolder(const QJsonObject &jsonObj, Folder *folder);
+        bool loadFolder(const QJsonObject &jsonObj, Folder *folder);
         void loadLegacy();
         void store();
         nonstd::expected<Folder *, QString> prepareItemDest(const QString &path);


### PR DESCRIPTION
Related to issue #19439

What it does:
1. Changed `loadFolder()`'s return type to `bool` to be able to return `updated` from inside recursive calls.
2. Made `loadFolder()` change `updated` based on changes in feeds **AND** subfolders. previously only based on changes in feeds.
3. `loadFolder()` returns `updated` instead of calling `store()` then after returning to `load()` it checks the returned value to find out whether to call `store()` or not.
4. Changed `loadLegacy()` to not call `store()` but call it after returning to `load()`. (for consistancy)

Points to note outside the bugfix:
1. `rss_session::loadLegacy()` and `rss_session::loadFolder()` no longer call `store()`
2. `rss_session::loadFolder()` now returns `bool` instead of `void`
