### PR TITLE
GHA CI: Bump Windows/macOS Boost version to 1.83.0

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -53,7 +53,7 @@ jobs:
           curl \
             -L \
             -o "${{ runner.temp }}/boost.tar.bz2" \
-            "https://boostorg.jfrog.io/artifactory/main/release/1.82.0/source/boost_1_82_0.tar.bz2"
+            "https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.bz2"
           tar -xf "${{ runner.temp }}/boost.tar.bz2" -C "${{ github.workspace }}/.."
           mv "${{ github.workspace }}/.."/boost_* "${{ env.boost_path }}"
 

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Install boost
         run: |
           aria2c `
-            "https://boostorg.jfrog.io/artifactory/main/release/1.82.0/source/boost_1_82_0.7z" `
+            "https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.7z" `
             -d "${{ runner.temp }}" `
             -o "boost.7z"
           7z x "${{ runner.temp }}/boost.7z" -o"${{ github.workspace }}/.."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,7 +83,7 @@ repos:
         - ts
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.15.5
+    rev: v1.16.4
     hooks:
     - id: typos
       name: Check spelling (typos)


### PR DESCRIPTION
* GHA CI: Bump Windows/macOS Boost version to 1.83.0
(Left Linux at 1.76.0 as per https://github.com/qbittorrent/qBittorrent/pull/19428)

* GHA CI: Bump `typos` action revision to 1.16.4
(Bumped this along the way)