### PR TITLE
Disable clang-tidy for 3rd-party code

### DIFF
--- a/src/base/3rdparty/.clang-tidy
+++ b/src/base/3rdparty/.clang-tidy
@@ -1,0 +1,2 @@
+# We don't care about fixing 3rd-party code, so we disable all checks here.
+Checks: -*


### PR DESCRIPTION
Discussed in #19458.