### PR TITLE
Display error message when unrecoverable error occured

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -759,7 +759,6 @@ void Application::processParams(const QBtCommandLineParameters &params)
 }
 
 int Application::exec()
-try
 {
 #if !defined(DISABLE_WEBUI) && defined(DISABLE_GUI)
     const QString loadingStr = tr("WebUI will be started shortly after internal preparations. Please wait...");
@@ -927,21 +926,6 @@ try
         m_paramsQueue.append(params);
 
     return BaseApplication::exec();
-}
-catch (const RuntimeError &err)
-{
-#ifdef DISABLE_GUI
-    fprintf(stderr, "%s", qPrintable(err.message()));
-#else
-    QMessageBox msgBox;
-    msgBox.setIcon(QMessageBox::Critical);
-    msgBox.setText(QCoreApplication::translate("Application", "Application failed to start."));
-    msgBox.setInformativeText(err.message());
-    msgBox.show(); // Need to be shown or to moveToCenter does not work
-    msgBox.move(Utils::Gui::screenCenter(&msgBox));
-    msgBox.exec();
-#endif
-    return EXIT_FAILURE;
 }
 
 bool Application::isRunning()

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -3103,8 +3103,16 @@ void SessionImpl::generateResumeData()
 void SessionImpl::saveResumeData()
 {
     for (const TorrentImpl *torrent : asConst(m_torrents))
-        torrent->nativeHandle().save_resume_data(lt::torrent_handle::only_if_modified);
-    m_numResumeData += m_torrents.size();
+    {
+        // When the session is terminated due to unrecoverable error
+        // some of the torrent handles can be corrupted
+        try
+        {
+            torrent->nativeHandle().save_resume_data(lt::torrent_handle::only_if_modified);
+            ++m_numResumeData;
+        }
+        catch (const std::exception &) {}
+    }
 
     // clear queued storage move jobs except the current ongoing one
     if (m_moveStorageQueue.size() > 1)

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -50,6 +50,7 @@
 #include <QStringList>
 #include <QUrl>
 
+#include "base/exceptions.h"
 #include "base/global.h"
 #include "base/logger.h"
 #include "base/preferences.h"
@@ -1689,6 +1690,7 @@ void TorrentImpl::endReceivedMetadataHandling(const Path &savePath, const PathLi
 }
 
 void TorrentImpl::reload()
+try
 {
     m_completedFiles.fill(false);
     m_filesProgress.fill(0);
@@ -1730,6 +1732,11 @@ void TorrentImpl::reload()
     m_nativeStatus.queue_position = queuePos;
 
     updateState();
+}
+catch (const lt::system_error &err)
+{
+    throw RuntimeError(tr("Failed to reload torrent. Torrent: %1. Reason: %2")
+            .arg(id().toString(), QString::fromLocal8Bit(err.what())));
 }
 
 void TorrentImpl::pause()


### PR DESCRIPTION
The idea is that in the case of a known unrecoverable error (in which we deliberately throw an unhandled exception to abort the program), not to show the stack trace, but some more useful message instead (if possible). This can help in fixing confusing issues like #19436, where it is difficult to figure out how to reproduce it.