### PR TITLE
Convert Windows header names to lowercase

### DIFF
--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -342,7 +342,7 @@ Example:
 
 // System headers
 #ifdef Q_OS_WIN
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 // Boost library headers

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -37,8 +37,8 @@
 
 #ifdef Q_OS_WIN
 #include <memory>
-#include <Windows.h>
-#include <Shellapi.h>
+#include <windows.h>
+#include <shellapi.h>
 #elif defined(Q_OS_UNIX)
 #include <sys/resource.h>
 #endif

--- a/src/app/qtlocalpeer/qtlocalpeer.cpp
+++ b/src/app/qtlocalpeer/qtlocalpeer.cpp
@@ -71,7 +71,7 @@
 #include <QtGlobal>
 
 #if defined(Q_OS_WIN)
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #include <QDataStream>

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -37,7 +37,7 @@
 #include <string>
 
 #ifdef Q_OS_WIN
-#include <Windows.h>
+#include <windows.h>
 #include <wincrypt.h>
 #include <iphlpapi.h>
 #endif

--- a/src/base/utils/fs.cpp
+++ b/src/base/utils/fs.cpp
@@ -41,7 +41,7 @@
 #include <sys/types.h>
 
 #if defined(Q_OS_WIN)
-#include <Windows.h>
+#include <windows.h>
 #elif defined(Q_OS_MACOS) || defined(Q_OS_FREEBSD) || defined(Q_OS_OPENBSD)
 #include <sys/param.h>
 #include <sys/mount.h>

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -35,7 +35,7 @@
 
 #include <windows.h>
 #include <powrprof.h>
-#include <Shlobj.h>
+#include <shlobj.h>
 #else
 #include <sys/types.h>
 #include <unistd.h>

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -31,7 +31,7 @@
 #include <QtGlobal>
 
 #ifdef Q_OS_WIN
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #include <QString>

--- a/src/base/utils/random.cpp
+++ b/src/base/utils/random.cpp
@@ -33,8 +33,8 @@
 #include <QtGlobal>
 
 #ifdef Q_OS_WIN
-#include <Windows.h>
-#include <Ntsecapi.h>
+#include <windows.h>
+#include <ntsecapi.h>
 #else  // Q_OS_WIN
 #include <cerrno>
 #include <cstdio>

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -35,8 +35,8 @@
 #include <chrono>
 
 #if defined(Q_OS_WIN)
-#include <Windows.h>
-#include <versionhelpers.h>  // must follow after Windows.h
+#include <windows.h>
+#include <versionhelpers.h>  // must follow after windows.h
 #endif
 
 #include <QAction>
@@ -59,7 +59,6 @@
 #include <QShortcut>
 #include <QSplitter>
 #include <QStatusBar>
-#include <QtGlobal>
 #include <QTimer>
 
 #include "base/bittorrent/session.h"

--- a/src/gui/programupdater.cpp
+++ b/src/gui/programupdater.cpp
@@ -32,8 +32,8 @@
 #include <QtGlobal>
 
 #if defined(Q_OS_WIN)
-#include <Windows.h>
-#include <versionhelpers.h>  // must follow after Windows.h
+#include <windows.h>
+#include <versionhelpers.h>  // must follow after windows.h
 #endif
 
 #include <QDebug>

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -38,8 +38,8 @@
 #include <QScopeGuard>
 
 #if defined(Q_OS_WIN)
-#include <Windows.h>
-#include <Shellapi.h>
+#include <windows.h>
+#include <shellapi.h>
 #else
 #include <QMimeDatabase>
 #include <QMimeType>

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -31,9 +31,9 @@
 #include <QtGlobal>
 
 #ifdef Q_OS_WIN
-#include <Objbase.h>
-#include <Shlobj.h>
-#include <Shellapi.h>
+#include <objbase.h>
+#include <shlobj.h>
+#include <shellapi.h>
 #endif
 
 #include <QApplication>


### PR DESCRIPTION
This was partially done in PR #4505, and this PR converts the rest of the headers.

Also removes a duplicate header include in `mainwindow.cpp`.
