### PR TITLE
Open "Save path" if torrent has no metadata

### DIFF
--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -587,7 +587,11 @@ void TransferListWidget::openSelectedTorrentsFolder() const
     for (BitTorrent::Torrent *const torrent : asConst(getSelectedTorrents()))
     {
         const Path contentPath = torrent->contentPath();
-        paths.insert(contentPath);
+        if(contentPath.isEmpty()){
+            paths.insert(torrent->savePath());
+        }else{
+            paths.insert(contentPath);
+        }
     }
     MacUtils::openFiles(PathList(paths.cbegin(), paths.cend()));
 #else

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -100,13 +100,15 @@ namespace
 
     void openDestinationFolder(const BitTorrent::Torrent *const torrent)
     {
+        const Path contentPath = torrent->contentPath();
+        const Path openedPath = (!contentPath.isEmpty() ? contentPath : torrent->savePath());
 #ifdef Q_OS_MACOS
-        MacUtils::openFiles({torrent->contentPath()});
+        MacUtils::openFiles({openedPath});
 #else
         if (torrent->filesCount() == 1)
-            Utils::Gui::openFolderSelect(torrent->contentPath());
+            Utils::Gui::openFolderSelect(openedPath);
         else
-            Utils::Gui::openPath(torrent->contentPath());
+            Utils::Gui::openPath(openedPath);
 #endif
     }
 
@@ -594,14 +596,15 @@ void TransferListWidget::openSelectedTorrentsFolder() const
     for (BitTorrent::Torrent *const torrent : asConst(getSelectedTorrents()))
     {
         const Path contentPath = torrent->contentPath();
-        if (!paths.contains(contentPath))
+        const Path openedPath = (!contentPath.isEmpty() ? contentPath : torrent->savePath());
+        if (!paths.contains(openedPath))
         {
             if (torrent->filesCount() == 1)
-                Utils::Gui::openFolderSelect(contentPath);
+                Utils::Gui::openFolderSelect(openedPath);
             else
-                Utils::Gui::openPath(contentPath);
+                Utils::Gui::openPath(openedPath);
         }
-        paths.insert(contentPath);
+        paths.insert(openedPath);
     }
 #endif // Q_OS_MACOS
 }

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -587,9 +587,12 @@ void TransferListWidget::openSelectedTorrentsFolder() const
     for (BitTorrent::Torrent *const torrent : asConst(getSelectedTorrents()))
     {
         const Path contentPath = torrent->contentPath();
-        if(contentPath.isEmpty()){
+        if(contentPath.isEmpty())
+        {
             paths.insert(torrent->savePath());
-        }else{
+        }
+        else
+        {
             paths.insert(contentPath);
         }
     }

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -587,7 +587,7 @@ void TransferListWidget::openSelectedTorrentsFolder() const
     for (BitTorrent::Torrent *const torrent : asConst(getSelectedTorrents()))
     {
         const Path contentPath = torrent->contentPath();
-        if(contentPath.isEmpty())
+        if (contentPath.isEmpty())
         {
             paths.insert(torrent->savePath());
         }

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -587,14 +587,7 @@ void TransferListWidget::openSelectedTorrentsFolder() const
     for (BitTorrent::Torrent *const torrent : asConst(getSelectedTorrents()))
     {
         const Path contentPath = torrent->contentPath();
-        if (contentPath.isEmpty())
-        {
-            paths.insert(torrent->savePath());
-        }
-        else
-        {
-            paths.insert(contentPath);
-        }
+        paths.insert(!contentPath.isEmpty() ? contentPath : torrent->savePath());
     }
     MacUtils::openFiles(PathList(paths.cbegin(), paths.cend()));
 #else


### PR DESCRIPTION
This problem caused by attempting to open the destination folder before it has been created. Add a check before open folder could solve it.
Closes #18738