### PR TITLE
Set new torrent dialog to always on top on macOS

### DIFF
--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -429,6 +429,11 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::TorrentDescriptor &to
     }
 
     TMMChanged(m_ui->comboTTM->currentIndex());
+
+#if defined(Q_OS_MACOS)
+    // Always show this dialog on top
+    setWindowFlags(Qt::Window | Qt::WindowStaysOnTopHint);
+#endif
 }
 
 AddNewTorrentDialog::~AddNewTorrentDialog()


### PR DESCRIPTION
Closes #19072.
