### PR TITLE
Enable sorting of tracker entry list

### DIFF
--- a/src/gui/properties/trackerlistwidget.cpp
+++ b/src/gui/properties/trackerlistwidget.cpp
@@ -70,6 +70,7 @@ TrackerListWidget::TrackerListWidget(PropertiesWidget *properties)
     setAllColumnsShowFocus(true);
     setItemsExpandable(false);
     setSelectionMode(QAbstractItemView::ExtendedSelection);
+    setSortingEnabled(true);
     header()->setFirstSectionMovable(true);
     header()->setStretchLastSection(false); // Must be set after loadSettings() in order to work
     header()->setTextElideMode(Qt::ElideRight);


### PR DESCRIPTION
Closes #261.

This is the simplest way to provide a sorting the tracker list feature. Its only (possible) drawback is that "pseudo tracker entries" (such as DHT) are sorted on a general basis (personally, I would expect they to be "sticky", but that would require a much deeper code redesign).

![001](https://github.com/qbittorrent/qBittorrent/assets/5063477/5b8bf6f2-eb41-45c7-b2c4-7bc0ed969185)
