### PR TITLE
Don't set parent of "Add new torrent dialog" on macOS

### DIFF
--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -431,8 +431,9 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::TorrentDescriptor &to
     TMMChanged(m_ui->comboTTM->currentIndex());
 
 #if defined(Q_OS_MACOS)
-    // Always show this dialog on top
-    setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
+    //By not setting a parent to the "addnewtorrentdialog",
+    //all those dialogs will be displayed on top and will not overlap with the main window.
+    setParent(nullptr);
 #endif
 }
 

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -429,6 +429,11 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::TorrentDescriptor &to
     }
 
     TMMChanged(m_ui->comboTTM->currentIndex());
+
+#if defined(Q_OS_MACOS)
+    // Always show this dialog on top
+    setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
+#endif
 }
 
 AddNewTorrentDialog::~AddNewTorrentDialog()

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -429,12 +429,6 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::TorrentDescriptor &to
     }
 
     TMMChanged(m_ui->comboTTM->currentIndex());
-
-#if defined(Q_OS_MACOS)
-    //By not setting a parent to the "addnewtorrentdialog",
-    //all those dialogs will be displayed on top and will not overlap with the main window.
-    setParent(nullptr);
-#endif
 }
 
 AddNewTorrentDialog::~AddNewTorrentDialog()

--- a/src/gui/guiaddtorrentmanager.cpp
+++ b/src/gui/guiaddtorrentmanager.cpp
@@ -184,8 +184,8 @@ bool GUIAddTorrentManager::processTorrent(const QString &source, const BitTorren
 #ifndef Q_OS_MACOS
     auto *dlg = new AddNewTorrentDialog(torrentDescr, params, app()->mainWindow());
 #else
-    //By not setting a parent to the "addnewtorrentdialog",
-    //all those dialogs will be displayed on top and will not overlap with the main window.
+    // By not setting a parent to the "AddNewTorrentDialog", all those dialogs
+    // will be displayed on top and will not overlap with the main window.
     auto *dlg = new AddNewTorrentDialog(torrentDescr, params, nullptr);
     //required Qt::Window to avoid only show two dialog on top, see #12852.
     dlg->setWindowFlags(Qt::Window);

--- a/src/gui/guiaddtorrentmanager.cpp
+++ b/src/gui/guiaddtorrentmanager.cpp
@@ -187,7 +187,7 @@ bool GUIAddTorrentManager::processTorrent(const QString &source, const BitTorren
     // By not setting a parent to the "AddNewTorrentDialog", all those dialogs
     // will be displayed on top and will not overlap with the main window.
     auto *dlg = new AddNewTorrentDialog(torrentDescr, params, nullptr);
-    //required Qt::Window to avoid only show two dialog on top, see #12852.
+    // Qt::Window is required to avoid showing only two dialog on top (see #12852).
     dlg->setWindowFlags(Qt::Window);
 #endif
 

--- a/src/gui/guiaddtorrentmanager.cpp
+++ b/src/gui/guiaddtorrentmanager.cpp
@@ -181,7 +181,16 @@ bool GUIAddTorrentManager::processTorrent(const QString &source, const BitTorren
     if (!hasMetadata)
         btSession()->downloadMetadata(torrentDescr);
 
+#ifndef Q_OS_MACOS
     auto *dlg = new AddNewTorrentDialog(torrentDescr, params, app()->mainWindow());
+#else
+    //By not setting a parent to the "addnewtorrentdialog",
+    //all those dialogs will be displayed on top and will not overlap with the main window.
+    auto *dlg = new AddNewTorrentDialog(torrentDescr, params, nullptr);
+    //required Qt::Window to avoid only show two dialog on top, see #12852.
+    dlg->setWindowFlags(Qt::Window);
+#endif
+
     dlg->setAttribute(Qt::WA_DeleteOnClose);
     m_dialogs[infoHash] = dlg;
     connect(dlg, &QDialog::finished, this, [this, source, infoHash, dlg](int result)


### PR DESCRIPTION
Closes #12849.
Closes #12852.
Closes #19072.