### PR TITLE
Use QThreadPool for torrent creation

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -35,7 +35,7 @@ add_library(qbt_base STATIC
     bittorrent/torrent.h
     bittorrent/torrentcontenthandler.h
     bittorrent/torrentcontentlayout.h
-    bittorrent/torrentcreatorthread.h
+    bittorrent/torrentcreator.h
     bittorrent/torrentdescriptor.h
     bittorrent/torrentimpl.h
     bittorrent/torrentinfo.h
@@ -132,7 +132,7 @@ add_library(qbt_base STATIC
     bittorrent/speedmonitor.cpp
     bittorrent/torrent.cpp
     bittorrent/torrentcontenthandler.cpp
-    bittorrent/torrentcreatorthread.cpp
+    bittorrent/torrentcreator.cpp
     bittorrent/torrentdescriptor.cpp
     bittorrent/torrentimpl.cpp
     bittorrent/torrentinfo.cpp

--- a/src/base/bittorrent/torrentcreator.h
+++ b/src/base/bittorrent/torrentcreator.h
@@ -28,8 +28,10 @@
 
 #pragma once
 
+#include <QAtomicInt>
+#include <QObject>
+#include <QRunnable>
 #include <QStringList>
-#include <QThread>
 
 #include "base/path.h"
 
@@ -62,16 +64,20 @@ namespace BitTorrent
         QStringList urlSeeds;
     };
 
-    class TorrentCreatorThread final : public QThread
+    class TorrentCreator final : public QObject, public QRunnable
     {
         Q_OBJECT
-        Q_DISABLE_COPY_MOVE(TorrentCreatorThread)
+        Q_DISABLE_COPY_MOVE(TorrentCreator)
 
     public:
-        explicit TorrentCreatorThread(QObject *parent = nullptr);
-        ~TorrentCreatorThread() override;
+        explicit TorrentCreator(const TorrentCreatorParams &params, QObject *parent = nullptr);
 
-        void create(const TorrentCreatorParams &params);
+        void run() override;
+
+        bool isInterruptionRequested() const;
+
+    public slots:
+        void requestInterruption();
 
 #ifdef QBT_USES_LIBTORRENT2
         static int calculateTotalPieces(const Path &inputPath, int pieceSize, TorrentFormat torrentFormat);
@@ -86,10 +92,10 @@ namespace BitTorrent
         void updateProgress(int progress);
 
     private:
-        void run() override;
         void sendProgressSignal(int currentPieceIdx, int totalPieces);
         void checkInterruptionRequested() const;
 
         TorrentCreatorParams m_params;
+        QAtomicInt m_interruptionRequested;
     };
 }

--- a/src/gui/torrentcreatordialog.cpp
+++ b/src/gui/torrentcreatordialog.cpp
@@ -59,7 +59,7 @@ namespace
 TorrentCreatorDialog::TorrentCreatorDialog(QWidget *parent, const Path &defaultPath)
     : QDialog(parent)
     , m_ui(new Ui::TorrentCreatorDialog)
-    , m_creatorThread(new BitTorrent::TorrentCreatorThread(this))
+    , m_threadPool(this)
     , m_storeDialogSize(SETTINGS_KEY(u"Size"_s))
     , m_storePieceSize(SETTINGS_KEY(u"PieceSize"_s))
     , m_storePrivateTorrent(SETTINGS_KEY(u"PrivateTorrent"_s))
@@ -90,12 +90,10 @@ TorrentCreatorDialog::TorrentCreatorDialog(QWidget *parent, const Path &defaultP
     connect(m_ui->buttonCalcTotalPieces, &QPushButton::clicked, this, &TorrentCreatorDialog::updatePiecesCount);
     connect(m_ui->checkStartSeeding, &QCheckBox::clicked, m_ui->checkIgnoreShareLimits, &QWidget::setEnabled);
 
-    connect(m_creatorThread, &BitTorrent::TorrentCreatorThread::creationSuccess, this, &TorrentCreatorDialog::handleCreationSuccess);
-    connect(m_creatorThread, &BitTorrent::TorrentCreatorThread::creationFailure, this, &TorrentCreatorDialog::handleCreationFailure);
-    connect(m_creatorThread, &BitTorrent::TorrentCreatorThread::updateProgress, this, &TorrentCreatorDialog::updateProgressBar);
-
     loadSettings();
     updateInputPath(defaultPath);
+
+    m_threadPool.setMaxThreadCount(1);
 
 #ifdef QBT_USES_LIBTORRENT2
     m_ui->checkOptimizeAlignment->hide();
@@ -233,8 +231,14 @@ void TorrentCreatorDialog::onCreateButtonClicked()
         , m_ui->URLSeedsList->toPlainText().split(u'\n', Qt::SkipEmptyParts)
     };
 
-    // run the creator thread
-    m_creatorThread->create(params);
+    auto *torrentCreator = new BitTorrent::TorrentCreator(params);
+    connect(this, &QDialog::rejected, torrentCreator, &BitTorrent::TorrentCreator::requestInterruption);
+    connect(torrentCreator, &BitTorrent::TorrentCreator::creationSuccess, this, &TorrentCreatorDialog::handleCreationSuccess);
+    connect(torrentCreator, &BitTorrent::TorrentCreator::creationFailure, this, &TorrentCreatorDialog::handleCreationFailure);
+    connect(torrentCreator, &BitTorrent::TorrentCreator::updateProgress, this, &TorrentCreatorDialog::updateProgressBar);
+
+    // run the torrentCreator in a thread
+    m_threadPool.start(torrentCreator);
 }
 
 void TorrentCreatorDialog::handleCreationFailure(const QString &msg)
@@ -286,11 +290,11 @@ void TorrentCreatorDialog::updatePiecesCount()
 {
     const Path path = m_ui->textInputPath->selectedPath();
 #ifdef QBT_USES_LIBTORRENT2
-    const int count = BitTorrent::TorrentCreatorThread::calculateTotalPieces(
+    const int count = BitTorrent::TorrentCreator::calculateTotalPieces(
         path, getPieceSize(), getTorrentFormat());
 #else
     const bool isAlignmentOptimized = m_ui->checkOptimizeAlignment->isChecked();
-    const int count = BitTorrent::TorrentCreatorThread::calculateTotalPieces(path
+    const int count = BitTorrent::TorrentCreator::calculateTotalPieces(path
         , getPieceSize(), isAlignmentOptimized, getPaddedFileSizeLimit());
 #endif
     m_ui->labelTotalPieces->setText(QString::number(count));

--- a/src/gui/torrentcreatordialog.h
+++ b/src/gui/torrentcreatordialog.h
@@ -30,8 +30,9 @@
 #pragma once
 
 #include <QDialog>
+#include <QThreadPool>
 
-#include "base/bittorrent/torrentcreatorthread.h"
+#include "base/bittorrent/torrentcreator.h"
 #include "base/path.h"
 #include "base/settingvalue.h"
 
@@ -75,7 +76,7 @@ private:
 #endif
 
     Ui::TorrentCreatorDialog *m_ui = nullptr;
-    BitTorrent::TorrentCreatorThread *m_creatorThread = nullptr;
+    QThreadPool m_threadPool;
 
     // settings
     SettingValue<QSize> m_storeDialogSize;


### PR DESCRIPTION
The change is in preparation for adding the possibility to create torrent files via the API.

Rework TorrentCreatorThread to be a more lightweight QRunnable class. The parameters are now defined on construction time and are fixed throughout the lifecycle of the TorrentCreator. The lifecycle of the object is not bound to the one of QDialog anymore; it is now handled by the QThreadPool. This will enable easier queueing of multiple torrent creation jobs without risk of spawning many threads.