### PR TITLE
Use atomic primitives from standard library

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -1274,7 +1274,7 @@ void Application::adjustThreadPriority() const
 void Application::cleanup()
 {
     // cleanup() can be called multiple times during shutdown. We only need it once.
-    if (!m_isCleanupRun.testAndSetAcquire(0, 1))
+    if (m_isCleanupRun.exchange(true, std::memory_order_acquire))
         return;
 
     LogMsg(tr("qBittorrent termination initiated"));

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -30,8 +30,9 @@
 
 #pragma once
 
+#include <atomic>
+
 #include <QtSystemDetection>
-#include <QAtomicInt>
 #include <QCoreApplication>
 #include <QPointer>
 #include <QStringList>
@@ -177,7 +178,7 @@ private:
 #endif
 
     ApplicationInstanceManager *m_instanceManager = nullptr;
-    QAtomicInt m_isCleanupRun;
+    std::atomic_bool m_isCleanupRun;
     bool m_isProcessingParamsAllowed = false;
     ShutdownDialogAction m_shutdownAct = ShutdownDialogAction::Exit;
     QBtCommandLineParameters m_commandLineArgs;

--- a/src/base/bittorrent/torrentcreator.cpp
+++ b/src/base/bittorrent/torrentcreator.cpp
@@ -93,12 +93,12 @@ void TorrentCreator::checkInterruptionRequested() const
 
 void TorrentCreator::requestInterruption()
 {
-    m_interruptionRequested.storeRelaxed(1);
+    m_interruptionRequested.store(true, std::memory_order_relaxed);
 }
 
 bool TorrentCreator::isInterruptionRequested() const
 {
-    return m_interruptionRequested.loadRelaxed() != 0;
+    return m_interruptionRequested.load(std::memory_order_relaxed);
 }
 
 void TorrentCreator::run()

--- a/src/base/bittorrent/torrentcreator.h
+++ b/src/base/bittorrent/torrentcreator.h
@@ -28,7 +28,8 @@
 
 #pragma once
 
-#include <QAtomicInt>
+#include <atomic>
+
 #include <QObject>
 #include <QRunnable>
 #include <QStringList>
@@ -96,6 +97,6 @@ namespace BitTorrent
         void checkInterruptionRequested() const;
 
         TorrentCreatorParams m_params;
-        QAtomicInt m_interruptionRequested;
+        std::atomic_bool m_interruptionRequested;
     };
 }


### PR DESCRIPTION
QAtomicInteger underlying is using std::atomic structures, so using std::atomic directly should not be a problem for us.
