### PR TITLE
Add button to copy library versions to clipboard

### DIFF
--- a/src/gui/aboutdialog.cpp
+++ b/src/gui/aboutdialog.cpp
@@ -28,6 +28,8 @@
 
 #include "aboutdialog.h"
 
+#include <QClipboard>
+
 #include "base/global.h"
 #include "base/path.h"
 #include "base/unicodestrings.h"
@@ -101,6 +103,8 @@ AboutDialog::AboutDialog(QWidget *parent)
     m_ui->labelOpensslVer->setText(Utils::Misc::opensslVersionString());
     m_ui->labelZlibVer->setText(Utils::Misc::zlibVersionString());
 
+    connect(m_ui->btnCopyToClipboard, &QAbstractButton::clicked, this, &AboutDialog::copyVersionsToClipboard);
+
     const QString DBIPText = u"<html><head/><body><p>"
                              u"%1 (<a href=\"https://db-ip.com/\">https://db-ip.com/</a>)"
                              u"</p></body></html>"_s
@@ -116,4 +120,15 @@ AboutDialog::~AboutDialog()
 {
     m_storeDialogSize = size();
     delete m_ui;
+}
+
+void AboutDialog::copyVersionsToClipboard() const
+{
+    const QString versions = u"%1 %2\n%3 %4\n%5 %6\n%7 %8\n%9 %10\n"_s
+        .arg(m_ui->labelQt->text(), m_ui->labelQtVer->text()
+            , m_ui->labelLibt->text(), m_ui->labelLibtVer->text()
+            , m_ui->labelBoost->text(), m_ui->labelBoostVer->text()
+            , m_ui->labelOpenssl->text(), m_ui->labelOpensslVer->text()
+            , m_ui->labelZlib->text(), m_ui->labelZlibVer->text());
+    qApp->clipboard()->setText(versions);
 }

--- a/src/gui/aboutdialog.h
+++ b/src/gui/aboutdialog.h
@@ -47,6 +47,8 @@ public:
     ~AboutDialog() override;
 
 private:
+    void copyVersionsToClipboard() const;
+
     Ui::AboutDialog *m_ui = nullptr;
     SettingValue<QSize> m_storeDialogSize;
 };

--- a/src/gui/aboutdialog.ui
+++ b/src/gui/aboutdialog.ui
@@ -25,6 +25,9 @@
        <property name="text">
         <string notr="true">qBittorrent</string>
        </property>
+       <property name="textInteractionFlags">
+        <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+       </property>
       </widget>
      </item>
      <item>

--- a/src/gui/aboutdialog.ui
+++ b/src/gui/aboutdialog.ui
@@ -281,11 +281,11 @@
        </property>
        <item>
         <widget class="QTextBrowser" name="textBrowserTranslation">
-         <property name="openExternalLinks">
-          <bool>true</bool>
-         </property>
          <property name="lineWrapMode">
           <enum>QTextEdit::NoWrap</enum>
+         </property>
+         <property name="openExternalLinks">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -323,11 +323,35 @@
       </attribute>
       <layout class="QVBoxLayout" name="SoftwareUsedTabLayout">
        <item>
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>qBittorrent was built with the following libraries:</string>
-         </property>
-        </widget>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>qBittorrent was built with the following libraries:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_5">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="btnCopyToClipboard">
+           <property name="text">
+            <string>Copy to clipboard</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
         <widget class="Line" name="line_2">
@@ -359,7 +383,7 @@
           </spacer>
          </item>
          <item row="0" column="1">
-          <widget class="QLabel" name="label_8">
+          <widget class="QLabel" name="labelQt">
            <property name="text">
             <string notr="true">Qt:</string>
            </property>
@@ -372,7 +396,7 @@
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="QLabel" name="label_9">
+          <widget class="QLabel" name="labelLibt">
            <property name="text">
             <string notr="true">Libtorrent:</string>
            </property>
@@ -385,7 +409,7 @@
           </widget>
          </item>
          <item row="2" column="1">
-          <widget class="QLabel" name="label_10">
+          <widget class="QLabel" name="labelBoost">
            <property name="text">
             <string notr="true">Boost:</string>
            </property>
@@ -425,7 +449,7 @@
           </spacer>
          </item>
          <item row="3" column="1">
-          <widget class="QLabel" name="label_11">
+          <widget class="QLabel" name="labelOpenssl">
            <property name="text">
             <string notr="true">OpenSSL:</string>
            </property>
@@ -445,7 +469,7 @@
           </widget>
          </item>
          <item row="4" column="1">
-          <widget class="QLabel" name="label_12">
+          <widget class="QLabel" name="labelZlib">
            <property name="text">
             <string notr="true">zlib:</string>
            </property>


### PR DESCRIPTION
* Add button to copy library versions to clipboard
  Closes #18702.
  ![screenshot](https://github.com/qbittorrent/qBittorrent/assets/9395168/47a765c4-f082-4ce3-85dd-442b7c1c8a96)

* Make the title label selectable
  And therefore its text is copyable.
