### PR TITLE
Implement SSL peer support

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -257,6 +257,12 @@ namespace BitTorrent
         virtual void setSaveResumeDataInterval(int value) = 0;
         virtual int port() const = 0;
         virtual void setPort(int port) = 0;
+        virtual bool isSSLEnabled() const = 0;
+        virtual void setSSLEnabled(bool enabled) = 0;
+        virtual int sslPort() const = 0;
+        virtual void setSSLPort(int port) = 0;
+        virtual Path sslCertificatesDirectory() const = 0;
+        virtual void setSSLCertificatesDirectory(const Path &path) = 0;
         virtual QString networkInterface() const = 0;
         virtual void setNetworkInterface(const QString &iface) = 0;
         virtual QString networkInterfaceName() const = 0;

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -468,6 +468,10 @@ SessionImpl::SessionImpl(QObject *parent)
     , m_isPerformanceWarningEnabled(BITTORRENT_SESSION_KEY(u"PerformanceWarning"_s), false)
     , m_saveResumeDataInterval(BITTORRENT_SESSION_KEY(u"SaveResumeDataInterval"_s), 60)
     , m_port(BITTORRENT_SESSION_KEY(u"Port"_s), -1)
+    , m_sslEnabled(BITTORRENT_SESSION_KEY(u"SSL/Enabled"_s), false)
+    , m_sslPort(BITTORRENT_SESSION_KEY(u"SSL/Port"_s), -1)
+    , m_sslCertificatesDirectory(BITTORRENT_SESSION_KEY(u"SSL/CertificatesDir"_s)
+        , specialFolderLocation(SpecialFolder::Config) / Path(u"SSLTorrentsCertificates"_s))
     , m_networkInterface(BITTORRENT_SESSION_KEY(u"Interface"_s))
     , m_networkInterfaceName(BITTORRENT_SESSION_KEY(u"InterfaceName"_s))
     , m_networkInterfaceAddress(BITTORRENT_SESSION_KEY(u"InterfaceAddress"_s))
@@ -518,6 +522,8 @@ SessionImpl::SessionImpl(QObject *parent)
 
     if (port() < 0)
         m_port = Utils::Random::rand(1024, 65535);
+    while ((sslPort() < 0) || (port() == sslPort()))
+        m_sslPort = Utils::Random::rand(1024, 65535);
 
     m_recentErroredTorrentsTimer->setSingleShot(true);
     m_recentErroredTorrentsTimer->setInterval(1s);
@@ -1944,7 +1950,9 @@ void SessionImpl::applyNetworkInterfacesSettings(lt::settings_pack &settingsPack
 
     QStringList endpoints;
     QStringList outgoingInterfaces;
-    const QString portString = u':' + QString::number(port());
+    QStringList portStrings = {u':' + QString::number(port())};
+    if (m_sslEnabled)
+        portStrings.append(u':' + QString::number(sslPort()) + u's');
 
     for (const QString &ip : asConst(getListeningIPs()))
     {
@@ -1956,7 +1964,8 @@ void SessionImpl::applyNetworkInterfacesSettings(lt::settings_pack &settingsPack
                           ? Utils::Net::canonicalIPv6Addr(addr).toString()
                           : addr.toString();
 
-            endpoints << ((isIPv6 ? (u'[' + ip + u']') : ip) + portString);
+            for (const QString &portString : asConst(portStrings))
+                endpoints << ((isIPv6 ? (u'[' + ip + u']') : ip) + portString);
 
             if ((ip != u"0.0.0.0") && (ip != u"::"))
                 outgoingInterfaces << ip;
@@ -1971,7 +1980,8 @@ void SessionImpl::applyNetworkInterfacesSettings(lt::settings_pack &settingsPack
             const QString guid = convertIfaceNameToGuid(ip);
             if (!guid.isEmpty())
             {
-                endpoints << (guid + portString);
+                for (const QString &portString : asConst(portStrings))
+                    endpoints << (guid + portString);
                 outgoingInterfaces << guid;
             }
             else
@@ -1979,11 +1989,13 @@ void SessionImpl::applyNetworkInterfacesSettings(lt::settings_pack &settingsPack
                 LogMsg(tr("Could not find GUID of network interface. Interface: \"%1\"").arg(ip), Log::WARNING);
                 // Since we can't get the GUID, we'll pass the interface name instead.
                 // Otherwise an empty string will be passed to outgoing_interface which will cause IP leak.
-                endpoints << (ip + portString);
+                for (const QString &portString : asConst(portStrings))
+                    endpoints << (ip + portString);
                 outgoingInterfaces << ip;
             }
 #else
-            endpoints << (ip + portString);
+            for (const QString &portString : asConst(portStrings))
+                endpoints << (ip + portString);
             outgoingInterfaces << ip;
 #endif
         }
@@ -2345,6 +2357,10 @@ bool SessionImpl::deleteTorrent(const TorrentID &id, const DeleteOption deleteOp
 
     if (const InfoHash infoHash = torrent->infoHash(); infoHash.isHybrid())
         m_hybridTorrentsByAltID.remove(TorrentID::fromSHA1Hash(infoHash.v1()));
+
+    const auto [certPath, keyPath, dhPath] = sslCertificatesPathsForTorrent(id);
+    for (const Path &path : {certPath, keyPath, dhPath})
+        Utils::Fs::removeFile(path);
 
     // Remove it from session
     if (deleteOption == DeleteTorrent)
@@ -3481,6 +3497,60 @@ void SessionImpl::setPort(const int port)
         if (isReannounceWhenAddressChangedEnabled())
             reannounceToAllTrackers();
     }
+}
+
+bool SessionImpl::isSSLEnabled() const
+{
+    return m_sslEnabled;
+}
+
+void SessionImpl::setSSLEnabled(const bool enabled)
+{
+    if (m_sslEnabled != enabled)
+    {
+        m_sslEnabled = enabled;
+        configureListeningInterface();
+
+        if (isReannounceWhenAddressChangedEnabled())
+            reannounceToAllTrackers();
+    }
+}
+
+int SessionImpl::sslPort() const
+{
+    return m_sslPort;
+}
+
+void SessionImpl::setSSLPort(const int port)
+{
+    if (port != m_sslPort)
+    {
+        m_sslPort = port;
+        configureListeningInterface();
+
+        if (isReannounceWhenAddressChangedEnabled())
+            reannounceToAllTrackers();
+    }
+}
+
+Path SessionImpl::sslCertificatesDirectory() const
+{
+    return m_sslCertificatesDirectory;
+}
+
+void SessionImpl::setSSLCertificatesDirectory(const Path &path)
+{
+    if (path != m_sslCertificatesDirectory)
+        m_sslCertificatesDirectory = path;
+}
+
+std::tuple<Path, Path, Path> SessionImpl::sslCertificatesPathsForTorrent(const TorrentID &torrentId) const
+{
+    const Path basePath = sslCertificatesDirectory() / Path(torrentId.toString());
+    const Path certPath = basePath + u".crt.pem"_s;
+    const Path keyPath = basePath + u".key.pem"_s;
+    const Path dhPath = basePath + u".dh.pem"_s;
+    return {certPath, keyPath, dhPath};
 }
 
 QString SessionImpl::networkInterface() const
@@ -5401,6 +5471,9 @@ void SessionImpl::handleAlert(const lt::alert *a)
         case lt::torrent_delete_failed_alert::alert_type:
             handleTorrentDeleteFailedAlert(static_cast<const lt::torrent_delete_failed_alert *>(a));
             break;
+        case lt::torrent_need_cert_alert::alert_type:
+            handleTorrentNeedCertAlert(static_cast<const lt::torrent_need_cert_alert*>(a));
+            break;
         case lt::portmap_error_alert::alert_type:
             handlePortmapWarningAlert(static_cast<const lt::portmap_error_alert *>(a));
             break;
@@ -5593,6 +5666,40 @@ void SessionImpl::handleTorrentDeleteFailedAlert(const lt::torrent_delete_failed
     }
 
     m_removingTorrents.erase(removingTorrentDataIter);
+}
+
+void SessionImpl::handleTorrentNeedCertAlert(const lt::torrent_need_cert_alert *p)
+{
+    const TorrentID torrentID {p->handle.info_hash()};
+
+    TorrentImpl *const torrent = m_torrents.value(torrentID);
+    if (!torrent) [[unlikely]]
+        return;
+
+    if (const Path baseDir = sslCertificatesDirectory(); baseDir.exists())
+    {
+        auto [certPath, keyPath, dhPath] = sslCertificatesPathsForTorrent(torrentID);
+
+        if (!certPath.exists() || !keyPath.exists())
+        {
+            certPath = baseDir / Path(u"default.crt.pem"_s);
+            keyPath = baseDir / Path(u"default.key.pem"_s);
+        }
+        if (!dhPath.exists())
+        {
+            dhPath = baseDir / Path(u"default.dh.pem"_s);
+        }
+
+        if (certPath.exists() && keyPath.exists() && dhPath.exists())
+        {
+            torrent->nativeHandle().set_ssl_certificate(certPath.toString().toStdString()
+                , keyPath.toString().toStdString()
+                , dhPath.toString().toStdString());
+            return;
+        }
+    }
+
+    LogMsg(tr("Unable to set SSL certificates for torrent. Torrent: \"%1\"").arg(torrent->name()), Log::WARNING);
 }
 
 void SessionImpl::handleMetadataReceivedAlert(const lt::metadata_received_alert *p)

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -226,6 +226,12 @@ namespace BitTorrent
         void setSaveResumeDataInterval(int value) override;
         int port() const override;
         void setPort(int port) override;
+        bool isSSLEnabled() const override;
+        void setSSLEnabled(bool enabled) override;
+        int sslPort() const override;
+        void setSSLPort(int port) override;
+        Path sslCertificatesDirectory() const override;
+        void setSSLCertificatesDirectory(const Path &path) override;
         QString networkInterface() const override;
         void setNetworkInterface(const QString &iface) override;
         QString networkInterfaceName() const override;
@@ -450,6 +456,7 @@ namespace BitTorrent
 
         void findIncompleteFiles(const TorrentInfo &torrentInfo, const Path &savePath
                                  , const Path &downloadPath, const PathList &filePaths = {}) const;
+        std::tuple<Path, Path, Path> sslCertificatesPathsForTorrent(const TorrentID &torrentId) const;
 
         void enablePortMapping();
         void disablePortMapping();
@@ -538,6 +545,7 @@ namespace BitTorrent
         void handleTorrentRemovedAlert(const lt::torrent_removed_alert *p);
         void handleTorrentDeletedAlert(const lt::torrent_deleted_alert *p);
         void handleTorrentDeleteFailedAlert(const lt::torrent_delete_failed_alert *p);
+        void handleTorrentNeedCertAlert(const lt::torrent_need_cert_alert *p);
         void handlePortmapWarningAlert(const lt::portmap_error_alert *p);
         void handlePortmapAlert(const lt::portmap_alert *p);
         void handlePeerBlockedAlert(const lt::peer_blocked_alert *p);
@@ -669,6 +677,9 @@ namespace BitTorrent
         CachedSettingValue<bool> m_isPerformanceWarningEnabled;
         CachedSettingValue<int> m_saveResumeDataInterval;
         CachedSettingValue<int> m_port;
+        CachedSettingValue<bool> m_sslEnabled;
+        CachedSettingValue<int> m_sslPort;
+        CachedSettingValue<Path> m_sslCertificatesDirectory;
         CachedSettingValue<QString> m_networkInterface;
         CachedSettingValue<QString> m_networkInterfaceName;
         CachedSettingValue<QString> m_networkInterfaceAddress;

--- a/src/base/bittorrent/torrent.h
+++ b/src/base/bittorrent/torrent.h
@@ -303,6 +303,7 @@ namespace BitTorrent
         virtual bool connectPeer(const PeerAddress &peerAddress) = 0;
         virtual void clearPeers() = 0;
         virtual void setMetadata(const TorrentInfo &torrentInfo) = 0;
+        virtual void setSSLCertificate(const QByteArray &certificate, const QByteArray &privateKey, const QByteArray &dhParams) = 0;
 
         virtual StopCondition stopCondition() const = 0;
         virtual void setStopCondition(StopCondition stopCondition) = 0;

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -50,6 +50,7 @@
 #include <QtSystemDetection>
 #include <QByteArray>
 #include <QDebug>
+#include <QFile>
 #include <QPointer>
 #include <QSet>
 #include <QStringList>
@@ -2425,6 +2426,29 @@ void TorrentImpl::setMetadata(const TorrentInfo &torrentInfo)
         }
         catch (const std::exception &) {}
     });
+}
+
+void TorrentImpl::setSSLCertificate(const QByteArray &certificate, const QByteArray &privateKey, const QByteArray &dhParams)
+{
+    const Path baseDir = m_session->sslCertificatesDirectory();
+    const auto [certPath, keyPath, dhPath] = m_session->sslCertificatesPathsForTorrent(id());
+
+    if (!baseDir.exists())
+    {
+        Utils::Fs::mkpath(baseDir);
+        QFile(baseDir.data()).setPermissions(QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner | QFile::ReadUser | QFile::WriteUser | QFile::ExeUser);
+    }
+
+    for (const auto &[path, content] : {std::pair {certPath, certificate}, {keyPath, privateKey}, {dhPath, dhParams}})
+    {
+        const nonstd::expected<void, QString> result = Utils::IO::saveToFile(path, content);
+        if (!result)
+            LogMsg(tr("Cannot save SSL certificates. Torrent: \"%1\". Reason: \"%2\"").arg(name(), result.error()), Log::WARNING);
+    }
+
+    QFile(keyPath.data()).setPermissions(QFile::ReadOwner | QFile::WriteOwner | QFile::ReadUser | QFile::WriteUser);
+
+    m_nativeHandle.set_ssl_certificate(certPath.toStdFsPath().string(), keyPath.toStdFsPath().string(), dhPath.toStdFsPath().string());
 }
 
 Torrent::StopCondition TorrentImpl::stopCondition() const

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -240,6 +240,7 @@ namespace BitTorrent
         bool connectPeer(const PeerAddress &peerAddress) override;
         void clearPeers() override;
         void setMetadata(const TorrentInfo &torrentInfo) override;
+        void setSSLCertificate(const QByteArray &certificate, const QByteArray &privateKey, const QByteArray &dhParams) override;
 
         StopCondition stopCondition() const override;
         void setStopCondition(StopCondition stopCondition) override;

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -760,6 +760,9 @@ void OptionsDialog::loadConnectionTabOptions()
 
     m_ui->comboProtocol->setCurrentIndex(static_cast<int>(session->btProtocol()));
     m_ui->spinPort->setValue(session->port());
+    m_ui->spinSSLPort->setEnabled(session->isSSLEnabled());
+    m_ui->spinSSLPort->setValue(session->sslPort());
+    m_ui->groupSSL->setChecked(session->isSSLEnabled());
     m_ui->checkUPnP->setChecked(Net::PortForwarder::instance()->isEnabled());
 
     int intValue = session->maxConnections();
@@ -862,6 +865,8 @@ void OptionsDialog::loadConnectionTabOptions()
 
     connect(m_ui->comboProtocol, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->spinPort, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
+    connect(m_ui->spinSSLPort, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
+    connect(m_ui->groupSSL, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkUPnP, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
 
     connect(m_ui->checkMaxConnections, &QAbstractButton::toggled, m_ui->spinMaxConnec, &QWidget::setEnabled);
@@ -913,6 +918,8 @@ void OptionsDialog::saveConnectionTabOptions() const
 
     session->setBTProtocol(static_cast<BitTorrent::BTProtocol>(m_ui->comboProtocol->currentIndex()));
     session->setPort(getPort());
+    session->setSSLEnabled(m_ui->groupSSL->isChecked());
+    session->setSSLPort(m_ui->spinSSLPort->value());
     Net::PortForwarder::instance()->setEnabled(isUPnPEnabled());
 
     session->setMaxConnections(getMaxConnections());
@@ -1421,6 +1428,14 @@ void OptionsDialog::on_randomButton_clicked()
 {
     // Range [1024: 65535]
     m_ui->spinPort->setValue(Utils::Random::rand(1024, 65535));
+}
+
+void OptionsDialog::on_randomSSLButton_clicked()
+{
+    int sslPort = 0;
+    while ((sslPort == getPort()) || (sslPort <= 0))
+        sslPort = Utils::Random::rand(1024, 65535);
+    m_ui->spinSSLPort->setValue(sslPort);
 }
 
 int OptionsDialog::getEncryptionSetting() const

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -101,6 +101,7 @@ private slots:
     void on_banListButton_clicked();
     void on_IPSubnetWhitelistButton_clicked();
     void on_randomButton_clicked();
+    void on_randomSSLButton_clicked();
     void on_addWatchedFolderButton_clicked();
     void on_editWatchedFolderButton_clicked();
     void on_removeWatchedFolderButton_clicked();

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -1772,6 +1772,58 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                  </property>
                 </widget>
                </item>
+               <item>
+                <widget class="QGroupBox" name="groupSSL">
+                 <property name="title">
+                  <string>SSL Torrents</string>
+                 </property>
+                 <property name="checkable">
+                  <bool>true</bool>
+                 </property>
+                 <property name="checked">
+                  <bool>false</bool>
+                 </property>
+                 <layout class="QHBoxLayout" name="horizontalLayout_21">
+                  <item>
+                   <widget class="QLabel" name="lblSSLPort">
+                    <property name="text">
+                     <string>Port used for incoming SSL connections:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QSpinBox" name="spinSSLPort">
+                    <property name="specialValueText">
+                     <string>Any</string>
+                    </property>
+                    <property name="maximum">
+                     <number>65535</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QPushButton" name="randomSSLButton">
+                    <property name="text">
+                     <string>Random</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="horizontalSpacer_25">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
               </layout>
              </widget>
             </item>
@@ -3968,6 +4020,8 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
   <tabstop>domainNameTxt</tabstop>
   <tabstop>DNSUsernameTxt</tabstop>
   <tabstop>DNSPasswordTxt</tabstop>
+  <tabstop>randomSSLButton</tabstop>
+  <tabstop>spinSSLPort</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -185,6 +185,8 @@ void AppController::preferencesAction()
     // Connection
     // Listening Port
     data[u"listen_port"_s] = session->port();
+    data[u"ssl_enabled"_s] = session->isSSLEnabled();
+    data[u"ssl_listen_port"_s] = session->sslPort();
     data[u"random_port"_s] = (session->port() == 0);  // deprecated
     data[u"upnp"_s] = Net::PortForwarder::instance()->isEnabled();
     // Connections Limits
@@ -632,6 +634,11 @@ void AppController::setPreferencesAction()
     {
         session->setPort(it.value().toInt());
     }
+    // SSL Torrents
+    if (hasKey(u"ssl_enabled"_s))
+        session->setSSLEnabled(it.value().toBool());
+    if (hasKey(u"ssl_listen_port"_s))
+        session->setSSLPort(it.value().toInt());
     if (hasKey(u"upnp"_s))
         Net::PortForwarder::instance()->setEnabled(it.value().toBool());
     // Connections Limits

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -1205,6 +1205,27 @@ void TorrentsController::setAutoManagementAction()
     });
 }
 
+void TorrentsController::setSSLCertificateAction()
+{
+    requireParams({u"hash"_s});
+    const auto id = BitTorrent::TorrentID::fromString(params()[u"hash"_s]);
+    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(id);
+    if (!torrent)
+        throw APIError(APIErrorType::NotFound);
+
+    for (const auto &file: {u"certificate"_s, u"privateKey"_s, u"dhParams"_s})
+    {
+        if (!data().contains(file))
+            throw APIError(APIErrorType::BadData);
+    }
+
+    const QByteArray certificate = data()[u"certificate"_s];
+    const QByteArray privateKey = data()[u"privateKey"_s];
+    const QByteArray dhParams = data()[u"dhParams"_s];
+
+    torrent->setSSLCertificate(certificate, privateKey, dhParams);
+}
+
 void TorrentsController::recheckAction()
 {
     requireParams({u"hashes"_s});

--- a/src/webui/api/torrentscontroller.h
+++ b/src/webui/api/torrentscontroller.h
@@ -84,6 +84,7 @@ private slots:
     void setAutoManagementAction();
     void setSuperSeedingAction();
     void setForceStartAction();
+    void setSSLCertificateAction();
     void toggleSequentialDownloadAction();
     void toggleFirstLastPiecePrioAction();
     void renameFileAction();

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -313,6 +313,17 @@
             <input type="checkbox" id="upnp_checkbox" />
             <label for="upnp_checkbox">QBT_TR(Use UPnP / NAT-PMP port forwarding from my router)QBT_TR[CONTEXT=OptionsDialog]</label>
         </div>
+        <fieldset class="settings">
+            <legend>
+                <input type="checkbox" id="sslEnabledCheckbox" onclick="qBittorrent.Preferences.updateSslSettings();" />
+                <label for="sslEnabledCheckbox">QBT_TR(Enable SSL torrents)QBT_TR[CONTEXT=OptionsDialog]</label>
+            </legend>
+            <div class="formRow">
+                <label for="sslPortValue">QBT_TR(Port used for incoming SSL connections:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                <input type="text" id="sslPortValue" style="width: 4em;" title="QBT_TR(Set to 0 to let your system pick an unused port)QBT_TR[CONTEXT=OptionsDialog]" />
+                <button type="button" id="sslRandomPortButton" style="margin-left: 1em;" onclick="qBittorrent.Preferences.generateRandomSSLPort();">QBT_TR(Random)QBT_TR[CONTEXT=OptionsDialog]</button>
+            </div>
+        </fieldset>
     </fieldset>
 
     <fieldset class="settings">
@@ -1534,6 +1545,8 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 updateAutoRun: updateAutoRun,
                 updateAutoRunOnTorrentAdded: updateAutoRunOnTorrentAdded,
                 generateRandomPort: generateRandomPort,
+                generateRandomSSLPort: generateRandomSSLPort,
+                updateSslSettings: updateSslSettings,
                 updateMaxConnecEnabled: updateMaxConnecEnabled,
                 updateMaxConnecPerTorrentEnabled: updateMaxConnecPerTorrentEnabled,
                 updateMaxUploadsEnabled: updateMaxUploadsEnabled,
@@ -1868,6 +1881,19 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             $('port_value').setProperty('value', port);
         };
 
+        const generateRandomSSLPort = function() {
+            const min = 1024;
+            const max = 65535;
+            const port = Math.floor(Math.random() * (max - min + 1) + min);
+            $('sslPortValue').setProperty('value', port);
+        };
+
+        const updateSslSettings = function() {
+            const isSSLEnabled = $('sslEnabledCheckbox').getProperty('checked');
+            $('sslRandomPortButton').setProperty('disabled', !isSSLEnabled);
+            $('sslPortValue').setProperty('disabled', !isSSLEnabled);
+        };
+
         const time_padding = function(val) {
             let ret = val.toString();
             if (ret.length == 1)
@@ -2071,6 +2097,9 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                         // Listening Port
                         $('port_value').setProperty('value', pref.listen_port.toInt());
                         $('upnp_checkbox').setProperty('checked', pref.upnp);
+                        $('sslEnabledCheckbox').setProperty('checked', pref.ssl_enabled);
+                        $('sslPortValue').setProperty('value', pref.ssl_listen_port.toInt()).setProperty('disabled', !pref.ssl_enabled);
+                        $('sslRandomPortButton').setProperty('disabled', !pref.ssl_enabled);
 
                         // Connections Limits
                         const max_connec = pref.max_connec.toInt();
@@ -2425,6 +2454,16 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 return;
             }
             settings.set('listen_port', listen_port);
+            const sslEnabled = $('sslEnabledCheckbox').getProperty('checked');
+            if (sslEnabled) {
+                const sslListenPort = $('sslPortValue').getProperty('value').toInt();
+                if (isNaN(sslListenPort) || (sslListenPort < 0) || (sslListenPort > 65535)) {
+                    alert("QBT_TR(The port used for incoming connections must be between 0 and 65535.)QBT_TR[CONTEXT=HttpServer]");
+                    return;
+                }
+                settings.set('ssl_listen_port', sslListenPort);
+            }
+            settings.set('ssl_enabled', sslEnabled);
             settings.set('upnp', $('upnp_checkbox').getProperty('checked'));
 
             // Connections Limits


### PR DESCRIPTION
This feature is interesting when multiple qBittorent instances are managed by the same administrator who uses it to transfer private data across a non-secure network.

Implement the two missing functionalities:
- allow to configure and listen on an SSL port
- allow to set the SSL certificate on a torrent via the API

More details about these two functionalities:

A separate port has to be allocated for incoming SSL connections from peers. Libtorrent already supports this. It's enough to add the suffix 's' when configuring libtorrent's listen_interfaces. Implement all the gui and core changes to allow setting an SSL port on top of the currently existing normal port.

Configuring an SSL port is not enough to allow SSL connection. x509 certificate, private_key and diffie-hellman parameters have to be configured for each torrent. This is achieved by calling libtorrent's handle->set_ssl_certificate. The certificates are only kept in-memory, so they have to be explicitly re-added after each restart.

Because of the constraints listed previously, some automation on top of qBittorent's API is strongly desired to make full use of this new feature. An alternative way to set those certificates is to put them in a directory. The certificates from that path will be automatically added to affected torrents when torrent_need_cert_alert is raised. Certificates have to be stored in that path with pre-defined file names.

More details on this feature: https://libtorrent.org/manual-ref.html#ssl-torrents

<!--
MANDATORY Before submitting your work, make sure you have:
1. Read https://github.com/qbittorrent/qBittorrent/blob/master/CONTRIBUTING.md#opening-a-pull-request
2. Delete this comment block
-->
