### PR TITLE
Use Qt built-in non-breaking space variable

### DIFF
--- a/src/base/unicodestrings.h
+++ b/src/base/unicodestrings.h
@@ -37,7 +37,6 @@
 inline const QString C_COPYRIGHT = u"©"_s;
 inline const QString C_INEQUALITY = u"≠"_s;
 inline const QString C_INFINITY = u"∞"_s;
-inline const QString C_THIN_SPACE = u" "_s;
 inline const QString C_UTP = u"μTP"_s;
 
 inline const QString C_LOCALE_ARABIC = u"عربي"_s;

--- a/src/base/unicodestrings.h
+++ b/src/base/unicodestrings.h
@@ -37,7 +37,6 @@
 inline const QString C_COPYRIGHT = u"©"_s;
 inline const QString C_INEQUALITY = u"≠"_s;
 inline const QString C_INFINITY = u"∞"_s;
-inline const QString C_NON_BREAKING_SPACE = u" "_s;
 inline const QString C_THIN_SPACE = u" "_s;
 inline const QString C_UTP = u"μTP"_s;
 

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -267,8 +267,7 @@ QString Utils::Misc::friendlyUnit(const qint64 bytes, const bool isSpeed, const 
 
     const int digitPrecision = (precision >= 0) ? precision : friendlyUnitPrecision(result->unit);
     return Utils::String::fromDouble(result->value, digitPrecision)
-           + C_NON_BREAKING_SPACE
-           + unitString(result->unit, isSpeed);
+           + QChar::Nbsp + unitString(result->unit, isSpeed);
 }
 
 int Utils::Misc::friendlyUnitPrecision(const SizeUnit unit)

--- a/src/gui/properties/speedplotview.cpp
+++ b/src/gui/properties/speedplotview.cpp
@@ -94,8 +94,7 @@ namespace
         // check is there need for digits after decimal separator
         const int precision = (argValue < 10) ? friendlyUnitPrecision(unit) : 0;
         return QLocale::system().toString(argValue, 'f', precision)
-               + C_NON_BREAKING_SPACE
-               + unitString(unit, true);
+               + QChar::Nbsp + unitString(unit, true);
     }
 }
 

--- a/src/gui/torrentcontentmodelitem.cpp
+++ b/src/gui/torrentcontentmodelitem.cpp
@@ -137,7 +137,7 @@ QString TorrentContentModelItem::displayData(const int column) const
             const QString value = (avail >= 1)
                                   ? u"100"_s
                                   : Utils::String::fromDouble((avail * 100), 1);
-            return (value + C_THIN_SPACE + u'%');
+            return (value + u'%');
         }
     default:
         Q_ASSERT(false);


### PR DESCRIPTION
* Use Qt built-in non-breaking space variable
* Remove thin space
  Generally qbt doesn't put a space before percentage symbol.
  This change makes the UI elements consistent.
