### PR TITLE
Use `std::pair` instead of `QPair`

### DIFF
--- a/src/base/http/requestparser.cpp
+++ b/src/base/http/requestparser.cpp
@@ -31,6 +31,7 @@
 #include "requestparser.h"
 
 #include <algorithm>
+#include <utility>
 
 #include <QByteArrayView>
 #include <QDebug>
@@ -45,7 +46,7 @@
 
 using namespace Http;
 using namespace Utils::ByteArray;
-using QStringPair = QPair<QString, QString>;
+using QStringPair = std::pair<QString, QString>;
 
 namespace
 {

--- a/src/base/utils/net.cpp
+++ b/src/base/utils/net.cpp
@@ -30,7 +30,6 @@
 
 #include <QList>
 #include <QNetworkInterface>
-#include <QPair>
 #include <QSslCertificate>
 #include <QSslKey>
 #include <QString>

--- a/src/base/utils/net.h
+++ b/src/base/utils/net.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include <optional>
+#include <utility>
 
 #include <QtContainerFwd>
 #include <QHostAddress>
@@ -40,7 +41,7 @@ class QString;
 namespace Utils::Net
 {
     // alias for `QHostAddress::parseSubnet()` return type
-    using Subnet = QPair<QHostAddress, int>;
+    using Subnet = std::pair<QHostAddress, int>;
 
     bool isValidIP(const QString &ip);
     std::optional<Subnet> parseSubnet(const QString &subnetStr);


### PR DESCRIPTION
The codebase already prefers `std::pair` to `QPair` (~11 occurrences v.s. ~2).