### PR TITLE
Support relative profile paths

### DIFF
--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -42,6 +42,7 @@
 #endif
 
 #include "base/global.h"
+#include "base/utils/fs.h"
 #include "base/utils/misc.h"
 #include "base/utils/string.h"
 
@@ -332,7 +333,7 @@ QBtCommandLineParameters::QBtCommandLineParameters(const QProcessEnvironment &en
     , webUiPort(WEBUI_PORT_OPTION.value(env, -1))
     , torrentingPort(TORRENTING_PORT_OPTION.value(env, -1))
     , skipDialog(SKIP_DIALOG_OPTION.value(env))
-    , profileDir(PROFILE_OPTION.value(env))
+    , profileDir(Utils::Fs::toAbsolutePath(Path(PROFILE_OPTION.value(env))))
     , configurationName(CONFIGURATION_OPTION.value(env))
 {
     addTorrentParams.savePath = Path(SAVE_PATH_OPTION.value(env));
@@ -394,7 +395,7 @@ QBtCommandLineParameters parseCommandLine(const QStringList &args)
 #endif
             else if (arg == PROFILE_OPTION)
             {
-                result.profileDir = Path(PROFILE_OPTION.value(arg));
+                result.profileDir = Utils::Fs::toAbsolutePath(Path(PROFILE_OPTION.value(arg)));
             }
             else if (arg == RELATIVE_FASTRESUME)
             {

--- a/src/base/utils/fs.cpp
+++ b/src/base/utils/fs.cpp
@@ -345,6 +345,11 @@ bool Utils::Fs::isDir(const Path &path)
     return QFileInfo(path.data()).isDir();
 }
 
+Path Utils::Fs::toAbsolutePath(const Path &path)
+{
+    return Path(QFileInfo(path.data()).absoluteFilePath());
+}
+
 Path Utils::Fs::toCanonicalPath(const Path &path)
 {
     return Path(QFileInfo(path.data()).canonicalFilePath());

--- a/src/base/utils/fs.h
+++ b/src/base/utils/fs.h
@@ -55,6 +55,7 @@ namespace Utils::Fs
 
     QString toValidFileName(const QString &name, const QString &pad = u" "_s);
     Path toValidPath(const QString &name, const QString &pad = u" "_s);
+    Path toAbsolutePath(const Path &path);
     Path toCanonicalPath(const Path &path);
 
     bool copyFile(const Path &from, const Path &to);


### PR DESCRIPTION
Currently, if you try something like: `qbittorrent --profile=foo`, the program simply crashes because it requires an absolute path (`BitTorrent::BencodeResumeDataStorage::BencodeResumeDataStorage()` has this check: `Q_ASSERT(path.isAbsolute());`.

This PR makes the command line argument parser convert the given profile path to an absolute one.
