### PR TITLE
Implement `Reannounce In` column

### DIFF
--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -194,6 +194,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_AVAILABILITY: return tr("Availability", "The number of distributed copies of the torrent");
             case TR_INFOHASH_V1: return tr("Info Hash v1", "i.e: torrent info hash v1");
             case TR_INFOHASH_V2: return tr("Info Hash v2", "i.e: torrent info hash v2");
+            case TR_REANNOUNCE: return tr("Reannounce In", "Indicates the time until next trackers reannounce");
             default: return {};
             }
         }
@@ -221,6 +222,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_QUEUE_POSITION:
             case TR_LAST_ACTIVITY:
             case TR_AVAILABILITY:
+            case TR_REANNOUNCE:
                 return QVariant(Qt::AlignRight | Qt::AlignVCenter);
             default:
                 return QAbstractListModel::headerData(section, orientation, role);
@@ -341,6 +343,13 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
         return hash.isValid() ? hash.toString() : tr("N/A");
     };
 
+    const auto reannounceString = [hideValues](const qint64 time) -> QString
+    {
+        if (hideValues && (time == 0))
+            return {};
+        return Utils::Misc::userFriendlyDuration(time);
+    };
+
     switch (column)
     {
     case TR_NAME:
@@ -411,6 +420,8 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
         return hashString(torrent->infoHash().v1());
     case TR_INFOHASH_V2:
         return hashString(torrent->infoHash().v2());
+    case TR_REANNOUNCE:
+        return reannounceString(torrent->nextAnnounce());
     }
 
     return {};
@@ -488,6 +499,8 @@ QVariant TransferListModel::internalValue(const BitTorrent::Torrent *torrent, co
         return QVariant::fromValue(torrent->infoHash().v1());
     case TR_INFOHASH_V2:
         return QVariant::fromValue(torrent->infoHash().v2());
+    case TR_REANNOUNCE:
+        return torrent->nextAnnounce();
     }
 
     return {};
@@ -552,6 +565,7 @@ QVariant TransferListModel::data(const QModelIndex &index, const int role) const
         case TR_QUEUE_POSITION:
         case TR_LAST_ACTIVITY:
         case TR_AVAILABILITY:
+        case TR_REANNOUNCE:
             return QVariant(Qt::AlignRight | Qt::AlignVCenter);
         }
         break;

--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -84,6 +84,7 @@ public:
         TR_DOWNLOAD_PATH,
         TR_INFOHASH_V1,
         TR_INFOHASH_V2,
+        TR_REANNOUNCE,
 
         NB_COLUMNS
     };

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -180,6 +180,7 @@ TransferListWidget::TransferListWidget(QWidget *parent, MainWindow *mainWindow)
         setColumnHidden(TransferListModel::TR_SEEN_COMPLETE_DATE, true);
         setColumnHidden(TransferListModel::TR_LAST_ACTIVITY, true);
         setColumnHidden(TransferListModel::TR_TOTAL_SIZE, true);
+        setColumnHidden(TransferListModel::TR_REANNOUNCE, true);
     }
 
     //Ensure that at least one column is visible at all times

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -159,6 +159,7 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         {KEY_TORRENT_SEEDING_TIME, torrent.finishedTime()},
         {KEY_TORRENT_LAST_ACTIVITY_TIME, getLastActivityTime()},
         {KEY_TORRENT_AVAILABILITY, torrent.distributedCopies()},
+        {KEY_TORRENT_REANNOUNCE, torrent.nextAnnounce()},
 
         {KEY_TORRENT_TOTAL_SIZE, torrent.totalSize()}
     };

--- a/src/webui/api/serialize/serialize_torrent.h
+++ b/src/webui/api/serialize/serialize_torrent.h
@@ -90,5 +90,6 @@ inline const QString KEY_TORRENT_AUTO_TORRENT_MANAGEMENT = u"auto_tmm"_s;
 inline const QString KEY_TORRENT_TIME_ACTIVE = u"time_active"_s;
 inline const QString KEY_TORRENT_SEEDING_TIME = u"seeding_time"_s;
 inline const QString KEY_TORRENT_AVAILABILITY = u"availability"_s;
+inline const QString KEY_TORRENT_REANNOUNCE = u"reannounce"_s;
 
 QVariantMap serialize(const BitTorrent::Torrent &torrent);

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -52,7 +52,7 @@
 #include "base/utils/version.h"
 #include "api/isessionmanager.h"
 
-inline const Utils::Version<3, 2> API_VERSION {2, 9, 2};
+inline const Utils::Version<3, 2> API_VERSION {2, 9, 3};
 
 class APIController;
 class AuthController;

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -945,6 +945,7 @@ window.qBittorrent.DynamicTable = (function() {
             this.newColumn('seen_complete', '', 'QBT_TR(Last Seen Complete)QBT_TR[CONTEXT=TransferListModel]', 100, false);
             this.newColumn('last_activity', '', 'QBT_TR(Last Activity)QBT_TR[CONTEXT=TransferListModel]', 100, false);
             this.newColumn('availability', '', 'QBT_TR(Availability)QBT_TR[CONTEXT=TransferListModel]', 100, false);
+            this.newColumn('reannounce', '', 'QBT_TR(Reannounce In)QBT_TR[CONTEXT=TransferListModel]', 100, false);
 
             this.columns['state_icon'].onclick = '';
             this.columns['state_icon'].dataProperties[0] = 'state';
@@ -1308,6 +1309,13 @@ window.qBittorrent.DynamicTable = (function() {
                 const value = window.qBittorrent.Misc.toFixedPointString(this.getRowValue(row), 3);
                 td.set('text', value);
                 td.set('title', value);
+            };
+
+            // reannounce
+            this.columns['reannounce'].updateTd = function(td, row) {
+                const time = window.qBittorrent.Misc.friendlyDuration(this.getRowValue(row));
+                td.set('text', time);
+                td.set('title', time);
             };
         },
 


### PR DESCRIPTION
This PR adds new `Reannounce In` column into main transfer list. Same thing as in torrent info `General` tab.
The column is hidden by default.

### Screenshot

![Screenshot](https://github.com/qbittorrent/qBittorrent/assets/13597663/c5443bc5-0fea-4b11-ac9e-9555149dbe63)