### PR TITLE
Prevent torrent from being started unexpectedly

### DIFF
--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -310,7 +310,7 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::TorrentDescriptor &to
     m_ui->stopConditionComboBox->setItemData(1, QVariant::fromValue(BitTorrent::Torrent::StopCondition::MetadataReceived));
     m_ui->stopConditionComboBox->setItemData(2, QVariant::fromValue(BitTorrent::Torrent::StopCondition::FilesChecked));
     m_ui->stopConditionComboBox->setCurrentIndex(m_ui->stopConditionComboBox->findData(
-                                                     QVariant::fromValue(m_torrentParams.stopCondition.value_or(session->torrentStopCondition()))));
+            QVariant::fromValue(m_torrentParams.stopCondition.value_or(session->torrentStopCondition()))));
     m_ui->stopConditionLabel->setEnabled(m_ui->startTorrentCheckBox->isChecked());
     m_ui->stopConditionComboBox->setEnabled(m_ui->startTorrentCheckBox->isChecked());
     connect(m_ui->startTorrentCheckBox, &QCheckBox::toggled, this, [this](const bool checked)
@@ -331,7 +331,7 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::TorrentDescriptor &to
     m_ui->checkBoxRememberLastSavePath->setChecked(m_storeRememberLastSavePath);
 
     m_ui->contentLayoutComboBox->setCurrentIndex(
-                static_cast<int>(m_torrentParams.contentLayout.value_or(session->torrentContentLayout())));
+            static_cast<int>(m_torrentParams.contentLayout.value_or(session->torrentContentLayout())));
     connect(m_ui->contentLayoutComboBox, &QComboBox::currentIndexChanged, this, &AddNewTorrentDialog::contentLayoutChanged);
 
     m_ui->sequentialCheckBox->setChecked(m_torrentParams.sequential);
@@ -733,6 +733,9 @@ void AddNewTorrentDialog::updateMetadata(const BitTorrent::TorrentInfo &metadata
 
     m_torrentDescr.setTorrentInfo(metadata);
     setMetadataProgressIndicator(true, tr("Parsing metadata..."));
+    const auto stopCondition = m_ui->stopConditionComboBox->currentData().value<BitTorrent::Torrent::StopCondition>();
+    if (stopCondition == BitTorrent::Torrent::StopCondition::MetadataReceived)
+        m_ui->startTorrentCheckBox->setChecked(false);
 
     // Update UI
     setupTreeview();


### PR DESCRIPTION
Improves "Metadata received" stop condition handling by "Add new torrent" dialog.
The problem is when "Metadata received" stop condition is set the metadata can still be received 0.1 sec before clicking the "OK" button so torrent is actually added with metadata and therefore it cannot respect "Metadata received" stop condition.
The solution is to uncheck "Start torrent" checkbox once metadata is received.

Closes #19583.