### PR TITLE
GHA CI: enable run-time checks in C++ library

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Build qBittorrent
         run: |
-          CXXFLAGS="$CXXFLAGS -Wno-gnu-zero-variadic-macro-arguments -Werror -Wno-error=deprecated-declarations" \
+          CXXFLAGS="$CXXFLAGS -Werror -Wno-error=deprecated-declarations" \
           LDFLAGS="$LDFLAGS -gz" \
           cmake \
             -B build \

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -24,6 +24,7 @@ jobs:
 
     env:
       boost_path: "${{ github.workspace }}/../boost"
+      harden_flags: "-D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS"
 
     steps:
       - name: Checkout repository
@@ -66,6 +67,7 @@ jobs:
             --recurse-submodules \
             https://github.com/arvidn/libtorrent.git
           cd libtorrent
+          CXXFLAGS="$CXXFLAGS ${{ env.harden_flags }}" \
           cmake \
             -B build \
             -G "Ninja" \
@@ -87,7 +89,7 @@ jobs:
 
       - name: Build qBittorrent
         run: |
-          CXXFLAGS="$CXXFLAGS -Werror" \
+          CXXFLAGS="$CXXFLAGS ${{ env.harden_flags }} -Werror" \
           LDFLAGS="$LDFLAGS -gz" \
           cmake \
             -B build \


### PR DESCRIPTION
Those have minimal impact on run-time:
https://www.gnu.org/software/libc/manual/html_node/Source-Fortification.html
https://bugs.launchpad.net/kicad/+bug/1838448/comments/40
