### PR TITLE
WebUI: fix missing error icon

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1006,6 +1006,7 @@ window.qBittorrent.DynamicTable = (function() {
                         state = "force-recheck";
                         img_path = "images/force-recheck.svg";
                         break;
+                    case "error":
                     case "unknown":
                     case "missingFiles":
                         state = "error";


### PR DESCRIPTION
Closes #18737.


tested locally, working as expected

![image](https://github.com/qbittorrent/qBittorrent/assets/13553903/10265f8c-9a19-4667-abc9-b4873b0d62b2)
