### PR TITLE
Escape name string when applying filter

### DIFF
--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -1327,7 +1327,7 @@ void TransferListWidget::applyFilter(const QString &name, const TransferListMode
 {
     m_sortFilterModel->setFilterKeyColumn(type);
     const QString pattern = (Preferences::instance()->getRegexAsFilteringPatternForTransferList()
-                ? name : Utils::String::wildcardToRegexPattern(name));
+                ? name : QRegularExpression::escape(Utils::String::wildcardToRegexPattern(name)));
     m_sortFilterModel->setFilterRegularExpression(QRegularExpression(pattern, QRegularExpression::CaseInsensitiveOption));
 }
 


### PR DESCRIPTION
Escape name string when applying the filter on non-regular expressions mode.

Closes #19623.
Closes #17969.