### PR TITLE
Bump OpenSSL requirement to 3.0.2

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -23,7 +23,7 @@ jobs:
 
     env:
       boost_path: "${{ github.workspace }}/../boost"
-      openssl_root: /usr/local/opt/openssl@1.1
+      openssl_root: /usr/local/opt/openssl@3
 
     steps:
       - name: Checkout repository
@@ -41,7 +41,7 @@ jobs:
             brew update > /dev/null
             brew install \
               cmake ninja \
-              openssl@1.1 zlib
+              openssl@3 zlib
 
       - name: Setup ccache
         uses: Chocobo1/setup-ccache-action@v1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project(qBittorrent
 # version requirements - older versions may work, but you are on your own
 set(minBoostVersion 1.76)
 set(minQt6Version 6.5.0)
-set(minOpenSSLVersion 1.1.1)
+set(minOpenSSLVersion 3.0.2)
 set(minLibtorrent1Version 1.2.19)
 set(minLibtorrentVersion 2.0.9)
 set(minZlibVersion 1.2.11)

--- a/INSTALL
+++ b/INSTALL
@@ -9,7 +9,7 @@ qBittorrent - A BitTorrent client in C++ / Qt
       * By Arvid Norberg, https://www.libtorrent.org/
       * Be careful: another library (the one used by rTorrent) uses a similar name
 
-  - OpenSSL >= 1.1.1
+  - OpenSSL >= 3.0.2
 
   - Qt 6.5.0 - 6.x
 


### PR DESCRIPTION
Addresses:
* [CVE-2022-0778](https://github.com/advisories/GHSA-x3mh-jvjw-3xwx)
* [OpenSSL 1.1.1 End of Life](https://www.openssl.org/blog/blog/2023/09/11/eol-111/)