### PR TITLE
Improve handling the case when torrent enters/leaves trackerless state

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -484,7 +484,6 @@ namespace BitTorrent
         void torrentTagAdded(Torrent *torrent, const QString &tag);
         void torrentTagRemoved(Torrent *torrent, const QString &tag);
         void trackerError(Torrent *torrent, const QString &tracker);
-        void trackerlessStateChanged(Torrent *torrent, bool trackerless);
         void trackersAdded(Torrent *torrent, const QVector<TrackerEntry> &trackers);
         void trackersChanged(Torrent *torrent);
         void trackersRemoved(Torrent *torrent, const QStringList &trackers);

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -4815,8 +4815,6 @@ void SessionImpl::handleTorrentTrackersAdded(TorrentImpl *const torrent, const Q
     for (const TrackerEntry &newTracker : newTrackers)
         LogMsg(tr("Added tracker to torrent. Torrent: \"%1\". Tracker: \"%2\"").arg(torrent->name(), newTracker.url));
     emit trackersAdded(torrent, newTrackers);
-    if (torrent->trackers().size() == newTrackers.size())
-        emit trackerlessStateChanged(torrent, false);
     emit trackersChanged(torrent);
 }
 
@@ -4825,8 +4823,6 @@ void SessionImpl::handleTorrentTrackersRemoved(TorrentImpl *const torrent, const
     for (const QString &deletedTracker : deletedTrackers)
         LogMsg(tr("Removed tracker from torrent. Torrent: \"%1\". Tracker: \"%2\"").arg(torrent->name(), deletedTracker));
     emit trackersRemoved(torrent, deletedTrackers);
-    if (torrent->trackers().isEmpty())
-        emit trackerlessStateChanged(torrent, true);
     emit trackersChanged(torrent);
 }
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1377,7 +1377,6 @@ void MainWindow::showFiltersSidebar(const bool show)
         connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackersAdded, m_transferListFiltersWidget, &TransferListFiltersWidget::addTrackers);
         connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackersRemoved, m_transferListFiltersWidget, &TransferListFiltersWidget::removeTrackers);
         connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackersChanged, m_transferListFiltersWidget, &TransferListFiltersWidget::refreshTrackers);
-        connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackerlessStateChanged, m_transferListFiltersWidget, &TransferListFiltersWidget::changeTrackerless);
         connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackerEntriesUpdated, m_transferListFiltersWidget, &TransferListFiltersWidget::trackerEntriesUpdated);
 
         m_splitter->insertWidget(0, m_transferListFiltersWidget);

--- a/src/gui/transferlistfilters/trackersfilterwidget.cpp
+++ b/src/gui/transferlistfilters/trackersfilterwidget.cpp
@@ -117,15 +117,22 @@ TrackersFilterWidget::~TrackersFilterWidget()
 void TrackersFilterWidget::addTrackers(const BitTorrent::Torrent *torrent, const QVector<BitTorrent::TrackerEntry> &trackers)
 {
     const BitTorrent::TorrentID torrentID = torrent->id();
+
     for (const BitTorrent::TrackerEntry &tracker : trackers)
         addItems(tracker.url, {torrentID});
+
+    removeItem(NULL_HOST, torrentID);
 }
 
 void TrackersFilterWidget::removeTrackers(const BitTorrent::Torrent *torrent, const QStringList &trackers)
 {
     const BitTorrent::TorrentID torrentID = torrent->id();
+
     for (const QString &tracker : trackers)
         removeItem(tracker, torrentID);
+
+    if (torrent->trackers().isEmpty())
+        addItems(NULL_HOST, {torrentID});
 }
 
 void TrackersFilterWidget::refreshTrackers(const BitTorrent::Torrent *torrent)
@@ -167,15 +174,15 @@ void TrackersFilterWidget::refreshTrackers(const BitTorrent::Torrent *torrent)
             addItems(trackerEntry.url, {torrentID});
     }
 
-    updateGeometry();
-}
+    item(ERROR_ROW)->setText(tr("Error (%1)").arg(m_errors.size()));
+    item(WARNING_ROW)->setText(tr("Warning (%1)").arg(m_warnings.size()));
 
-void TrackersFilterWidget::changeTrackerless(const BitTorrent::Torrent *torrent, const bool trackerless)
-{
-    if (trackerless)
-        addItems(NULL_HOST, {torrent->id()});
-    else
-        removeItem(NULL_HOST, torrent->id());
+    if (currentRow() == ERROR_ROW)
+        applyFilter(ERROR_ROW);
+    else if (currentRow() == WARNING_ROW)
+        applyFilter(WARNING_ROW);
+
+    updateGeometry();
 }
 
 void TrackersFilterWidget::addItems(const QString &trackerURL, const QVector<BitTorrent::TorrentID> &torrents)

--- a/src/gui/transferlistfilters/trackersfilterwidget.h
+++ b/src/gui/transferlistfilters/trackersfilterwidget.h
@@ -55,7 +55,6 @@ public:
     void addTrackers(const BitTorrent::Torrent *torrent, const QVector<BitTorrent::TrackerEntry> &trackers);
     void removeTrackers(const BitTorrent::Torrent *torrent, const QStringList &trackers);
     void refreshTrackers(const BitTorrent::Torrent *torrent);
-    void changeTrackerless(const BitTorrent::Torrent *torrent, bool trackerless);
     void handleTrackerEntriesUpdated(const BitTorrent::Torrent *torrent
             , const QHash<QString, BitTorrent::TrackerEntry> &updatedTrackerEntries);
     void setDownloadTrackerFavicon(bool value);

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -191,11 +191,6 @@ void TransferListFiltersWidget::refreshTrackers(const BitTorrent::Torrent *torre
     m_trackersFilterWidget->refreshTrackers(torrent);
 }
 
-void TransferListFiltersWidget::changeTrackerless(const BitTorrent::Torrent *torrent, const bool trackerless)
-{
-    m_trackersFilterWidget->changeTrackerless(torrent, trackerless);
-}
-
 void TransferListFiltersWidget::trackerEntriesUpdated(const BitTorrent::Torrent *torrent
         , const QHash<QString, BitTorrent::TrackerEntry> &updatedTrackerEntries)
 {

--- a/src/gui/transferlistfilterswidget.h
+++ b/src/gui/transferlistfilterswidget.h
@@ -55,7 +55,6 @@ public slots:
     void addTrackers(const BitTorrent::Torrent *torrent, const QVector<BitTorrent::TrackerEntry> &trackers);
     void removeTrackers(const BitTorrent::Torrent *torrent, const QStringList &trackers);
     void refreshTrackers(const BitTorrent::Torrent *torrent);
-    void changeTrackerless(const BitTorrent::Torrent *torrent, bool trackerless);
     void trackerEntriesUpdated(const BitTorrent::Torrent *torrent
             , const QHash<QString, BitTorrent::TrackerEntry> &updatedTrackerEntries);
 


### PR DESCRIPTION
Previously, it could leave the error/warning counters not updated if you deleted the corresponding trackers via "Edit Trackers..." dialog.