### PR TITLE
Migrate away from deprecated function

### DIFF
--- a/src/gui/statusbar.cpp
+++ b/src/gui/statusbar.cpp
@@ -158,12 +158,14 @@ void StatusBar::showRestartRequired()
 {
     // Restart required notification
     const QString restartText = tr("qBittorrent needs to be restarted!");
-    QLabel *restartIconLbl = new QLabel(this);
-    restartIconLbl->setPixmap(style()->standardPixmap(QStyle::SP_MessageBoxWarning));
+
+    const QPixmap pixmap = style()->standardIcon(QStyle::SP_MessageBoxWarning).pixmap(Utils::Gui::smallIconSize());
+    auto *restartIconLbl = new QLabel(this);
+    restartIconLbl->setPixmap(pixmap);
     restartIconLbl->setToolTip(restartText);
     insertWidget(0, restartIconLbl);
 
-    QLabel *restartLbl = new QLabel(this);
+    auto *restartLbl = new QLabel(this);
     restartLbl->setText(restartText);
     insertWidget(1, restartLbl);
 }

--- a/src/gui/statusbar.h
+++ b/src/gui/statusbar.h
@@ -38,7 +38,7 @@ namespace BitTorrent
     struct SessionStatus;
 }
 
-class StatusBar : public QStatusBar
+class StatusBar final : public QStatusBar
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(StatusBar)


### PR DESCRIPTION
`QStyle::standardPixmap()` is deprecated.
