### PR TITLE
Improve GUI behavior when adding multiple torrents

### DIFF
--- a/src/gui/guiaddtorrentmanager.cpp
+++ b/src/gui/guiaddtorrentmanager.cpp
@@ -181,15 +181,12 @@ bool GUIAddTorrentManager::processTorrent(const QString &source, const BitTorren
     if (!hasMetadata)
         btSession()->downloadMetadata(torrentDescr);
 
-#ifndef Q_OS_MACOS
-    auto *dlg = new AddNewTorrentDialog(torrentDescr, params, app()->mainWindow());
-#else
     // By not setting a parent to the "AddNewTorrentDialog", all those dialogs
     // will be displayed on top and will not overlap with the main window.
     auto *dlg = new AddNewTorrentDialog(torrentDescr, params, nullptr);
     // Qt::Window is required to avoid showing only two dialog on top (see #12852).
+    // Also improves the general convenience of adding multiple torrents.
     dlg->setWindowFlags(Qt::Window);
-#endif
 
     dlg->setAttribute(Qt::WA_DeleteOnClose);
     m_dialogs[infoHash] = dlg;


### PR DESCRIPTION
Allows you to bring the main window to the front when one or more "Add new torrent" dialogs are open.
Also allows you to minimize/maximize the "Add new torrent" dialog.

Closes #17919.