### PR TITLE
Add support for Mark-of-the-Web

### DIFF
--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -43,6 +43,7 @@
 #include <libtorrent/info_hash.hpp>
 #endif
 
+#include <QtSystemDetection>
 #include <QByteArray>
 #include <QDebug>
 #include <QPointer>
@@ -66,6 +67,10 @@
 #include "peeraddress.h"
 #include "peerinfo.h"
 #include "sessionimpl.h"
+
+#ifdef Q_OS_WIN
+#include "base/utils/misc.h"
+#endif
 
 using namespace BitTorrent;
 
@@ -2205,10 +2210,20 @@ void TorrentImpl::handleFileCompletedAlert(const lt::file_completed_alert *p)
 
     m_completedFiles.setBit(fileIndex);
 
+    const Path actualPath = actualFilePath(fileIndex);
+
+#ifdef Q_OS_WIN
+    // only apply Mark-of-the-Web to new download files
+    if (isDownloading())
+    {
+        const Path fullpath = actualStorageLocation() / actualPath;
+        Utils::Misc::applyMarkOfTheWeb(fullpath);
+    }
+#endif
+
     if (m_session->isAppendExtensionEnabled())
     {
         const Path path = filePath(fileIndex);
-        const Path actualPath = actualFilePath(fileIndex);
         if (actualPath != path)
         {
             qDebug("Renaming %s to %s", qUtf8Printable(actualPath.toString()), qUtf8Printable(path.toString()));
@@ -2343,7 +2358,7 @@ void TorrentImpl::adjustStorageLocation()
         moveStorage(targetPath, MoveStorageContext::AdjustCurrentLocation);
 }
 
-void TorrentImpl::doRenameFile(int index, const Path &path)
+void TorrentImpl::doRenameFile(const int index, const Path &path)
 {
     const QVector<lt::file_index_t> nativeIndexes = m_torrentInfo.nativeIndexes();
 

--- a/src/base/net/downloadhandlerimpl.cpp
+++ b/src/base/net/downloadhandlerimpl.cpp
@@ -29,6 +29,7 @@
 
 #include "downloadhandlerimpl.h"
 
+#include <QtSystemDetection>
 #include <QTemporaryFile>
 #include <QUrl>
 
@@ -146,17 +147,33 @@ void Net::DownloadHandlerImpl::processFinishedDownload()
         {
             const nonstd::expected<Path, QString> result = saveToTempFile(m_result.data);
             if (result)
+            {
                 m_result.filePath = result.value();
+
+#ifdef Q_OS_WIN
+                Utils::Misc::applyMarkOfTheWeb(m_result.filePath, m_result.url);
+#endif
+            }
             else
+            {
                 setError(tr("I/O Error: %1").arg(result.error()));
+            }
         }
         else
         {
             const nonstd::expected<void, QString> result = Utils::IO::saveToFile(destinationPath, m_result.data);
             if (result)
+            {
                 m_result.filePath = destinationPath;
+
+#ifdef Q_OS_WIN
+                Utils::Misc::applyMarkOfTheWeb(m_result.filePath, m_result.url);
+#endif
+            }
             else
+            {
                 setError(tr("I/O Error: %1").arg(result.error()));
+            }
         }
     }
 

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -94,6 +94,7 @@ enum class TimeResolution
     QString languageToLocalizedString(const QString &localeStr);
 
 #ifdef Q_OS_WIN
+    bool applyMarkOfTheWeb(const Path &file, const QString &url = {});
     Path windowsSystemPath();
 
     template <typename T>


### PR DESCRIPTION
In short, now Windows can identify newly downloaded files (from bittorrent) and possibly prevent novice users from executing dangerous file extensions.

https://redcanary.com/threat-detection-report/techniques/mark-of-the-web-bypass/
https://mikehadlow.blogspot.com/2011/07/detecting-and-changing-files-internet.html
https://textslashplain.com/2016/04/04/downloads-and-the-mark-of-the-web/

Closes #19648.
