### PR TITLE
Fix WebUI greeting for `qbittorrent-nox`

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -907,20 +907,28 @@ int Application::exec()
             QCoreApplication::exit(EXIT_FAILURE);
         connect(m_webui, &WebUI::fatalError, this, []() { QCoreApplication::exit(EXIT_FAILURE); });
 
-        const Preferences *pref = Preferences::instance();
+        printf("%s", qUtf8Printable(u"\n******** %1 ********\n"_s.arg(tr("Information"))));
 
-        const auto scheme = pref->isWebUiHttpsEnabled() ? u"https"_s : u"http"_s;
-        const auto url = u"%1://localhost:%2\n"_s.arg(scheme, QString::number(pref->getWebUiPort()));
-        const QString mesg = u"\n******** %1 ********\n"_s.arg(tr("Information"))
-                + tr("To control qBittorrent, access the WebUI at: %1").arg(url);
-        printf("%s\n", qUtf8Printable(mesg));
-
-        if (pref->getWebUIPassword() == QByteArrayLiteral("ARQ77eY1NUZaQsuDHbIMCA==:0WMRkYTUWVT9wVvdDtHAjU9b3b7uB8NR1Gur2hmQCvCDpm39Q+PsJRJPaCU51dEiz+dTzh8qbPsL8WkFljQYFQ=="))
+        if (m_webui->isEnabled())
         {
-            const QString warning = tr("The Web UI administrator username is: %1").arg(pref->getWebUiUsername()) + u'\n'
-                    + tr("The Web UI administrator password has not been changed from the default: %1").arg(u"adminadmin"_s) + u'\n'
-                    + tr("This is a security risk, please change your password in program preferences.") + u'\n';
-            printf("%s", qUtf8Printable(warning));
+            const QHostAddress address = m_webui->hostAddress();
+            const QString url = u"%1://%2:%3"_s.arg((m_webui->isHttps() ? u"https"_s : u"http"_s)
+                    , (address.isEqual(QHostAddress::Any, QHostAddress::ConvertUnspecifiedAddress) ? u"localhost"_s : address.toString())
+                    , QString::number(m_webui->port()));
+            printf("%s\n", qUtf8Printable(tr("To control qBittorrent, access the WebUI at: %1").arg(url)));
+
+            const Preferences *pref = Preferences::instance();
+            if (pref->getWebUIPassword() == QByteArrayLiteral("ARQ77eY1NUZaQsuDHbIMCA==:0WMRkYTUWVT9wVvdDtHAjU9b3b7uB8NR1Gur2hmQCvCDpm39Q+PsJRJPaCU51dEiz+dTzh8qbPsL8WkFljQYFQ=="))
+            {
+                const QString warning = tr("The Web UI administrator username is: %1").arg(pref->getWebUiUsername()) + u'\n'
+                        + tr("The Web UI administrator password has not been changed from the default: %1").arg(u"adminadmin"_s) + u'\n'
+                        + tr("This is a security risk, please change your password in program preferences.") + u'\n';
+                printf("%s", qUtf8Printable(warning));
+            }
+        }
+        else
+        {
+            printf("%s\n", qUtf8Printable(tr("The WebUI is disabled! To enable the WebUI, edit the config file manually.")));
         }
 #endif // DISABLE_GUI
 #endif // DISABLE_WEBUI

--- a/src/base/http/server.cpp
+++ b/src/base/http/server.cpp
@@ -181,3 +181,8 @@ void Server::disableHttps()
     m_certificates.clear();
     m_key.clear();
 }
+
+bool Server::isHttps() const
+{
+    return m_https;
+}

--- a/src/base/http/server.h
+++ b/src/base/http/server.h
@@ -50,6 +50,7 @@ namespace Http
 
         bool setupHttps(const QByteArray &certificates, const QByteArray &privateKey);
         void disableHttps();
+        bool isHttps() const;
 
     private slots:
         void dropTimedOutConnection();

--- a/src/webui/webui.cpp
+++ b/src/webui/webui.cpp
@@ -52,8 +52,9 @@ void WebUI::configure()
     const QString portForwardingProfile = u"webui"_s;
     const Preferences *pref = Preferences::instance();
     const quint16 port = pref->getWebUiPort();
+    m_isEnabled = pref->isWebUiEnabled();
 
-    if (pref->isWebUiEnabled())
+    if (m_isEnabled)
     {
         // Port forwarding
         auto *portForwarder = Net::PortForwarder::instance();
@@ -145,7 +146,30 @@ void WebUI::configure()
     }
 }
 
+bool WebUI::isEnabled() const
+{
+    return m_isEnabled;
+}
+
 bool WebUI::isErrored() const
 {
     return m_isErrored;
+}
+
+bool WebUI::isHttps() const
+{
+    if (!m_httpServer) return false;
+    return m_httpServer->isHttps();
+}
+
+QHostAddress WebUI::hostAddress() const
+{
+    if (!m_httpServer) return {};
+    return m_httpServer->serverAddress();
+}
+
+quint16 WebUI::port() const
+{
+    if (!m_httpServer) return 0;
+    return m_httpServer->serverPort();
 }

--- a/src/webui/webui.h
+++ b/src/webui/webui.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <QHostAddress>
 #include <QObject>
 #include <QPointer>
 
@@ -53,7 +54,11 @@ class WebUI final : public ApplicationComponent<QObject>
 public:
     explicit WebUI(IApplication *app);
 
+    bool isEnabled() const;
     bool isErrored() const;
+    bool isHttps() const;
+    QHostAddress hostAddress() const;
+    quint16 port() const;
 
 signals:
     void fatalError();
@@ -62,6 +67,7 @@ private slots:
     void configure();
 
 private:
+    bool m_isEnabled = false;
     bool m_isErrored = false;
     QPointer<Http::Server> m_httpServer;
     QPointer<Net::DNSUpdater> m_dnsUpdater;


### PR DESCRIPTION
- Check if WebUI is enabled and print an appropriate message otherwise.
- Print an actual runtime server scheme, address and port.