### PR TITLE
GHA CI: Update numerous pre-commit revisions and fixed typo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
           - ts
 
   - repo: https://github.com/pre-commit/pre-commit-hooks.git
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
     - id: check-json
       name: Check JSON files
@@ -62,7 +62,7 @@ repos:
         - ts
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.5
+    rev: v2.2.6
     hooks:
     - id: codespell
       name: Check spelling (codespell)
@@ -83,7 +83,7 @@ repos:
         - ts
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.16.10
+    rev: v1.16.18
     hooks:
     - id: typos
       name: Check spelling (typos)

--- a/dist/windows/config.nsi
+++ b/dist/windows/config.nsi
@@ -148,7 +148,7 @@ RequestExecutionLevel user
 !define MUI_LANGDLL_ALLLANGUAGES
 
 ;--------------------------------
-;Remember the unistaller/installer language
+;Remember the uninstaller/installer language
 !define MUI_LANGDLL_REGISTRY_ROOT "HKLM"
 !define MUI_LANGDLL_REGISTRY_KEY "Software\qbittorrent"
 !define MUI_LANGDLL_REGISTRY_VALUENAME "Installer Language"


### PR DESCRIPTION
Updated:

* pre-commit-hooks -> 4.5.0
* codespell -> 2.2.6
* typos -> 1.16.18

Note:
fixed a typo from previous "test run"  of codespell 2.2.6 (L151) `dist\windows\config.nsi` - `unistaller` -> `uninstaller`