### PR TITLE
Delete worker in appropriate thread

### DIFF
--- a/src/base/torrentfileswatcher.cpp
+++ b/src/base/torrentfileswatcher.cpp
@@ -159,7 +159,7 @@ void TorrentFilesWatcher::initWorker()
     connect(m_asyncWorker, &TorrentFilesWatcher::Worker::torrentFound, this, &TorrentFilesWatcher::onTorrentFound);
 
     m_asyncWorker->moveToThread(m_ioThread.get());
-    connect(m_ioThread.get(), &QObject::destroyed, this, [this] { delete m_asyncWorker; });
+    connect(m_ioThread.get(), &QThread::finished, m_asyncWorker, [this] { delete m_asyncWorker; });
     m_ioThread->start();
 
     for (auto it = m_watchedFolders.cbegin(); it != m_watchedFolders.cend(); ++it)


### PR DESCRIPTION
Fixes regression of #19650.
>QObject::~QObject: Timers cannot be stopped from another thread