### PR TITLE
Fix mismatched %I and %J in the translations

### DIFF
--- a/src/lang/qbittorrent_gl.ts
+++ b/src/lang/qbittorrent_gl.ts
@@ -7205,7 +7205,7 @@ readme[0-9].txt: filter &apos;readme1.txt&apos;, &apos;readme2.txt&apos; but not
     <message>
         <location filename="../gui/optionsdialog.cpp" line="613"/>
         <source>%J: Info hash v2 (or &apos;-&apos; if unavailable)</source>
-        <translation>%I: Info hash v2 (ou &apos;-&apos; se non está dispoñíbel)</translation>
+        <translation>%J: Info hash v2 (ou &apos;-&apos; se non está dispoñíbel)</translation>
     </message>
     <message>
         <location filename="../gui/optionsdialog.cpp" line="614"/>

--- a/src/lang/qbittorrent_it.ts
+++ b/src/lang/qbittorrent_it.ts
@@ -7368,7 +7368,7 @@ Questa modalità verrà applicato &lt;strong&gt;non solo&lt;/strong&gt; ai file 
     <message>
         <location filename="../gui/optionsdialog.cpp" line="613"/>
         <source>%J: Info hash v2 (or &apos;-&apos; if unavailable)</source>
-        <translation>%I: Info hash v2 (o &apos;-&apos; se non disponibile)</translation>
+        <translation>%J: Info hash v2 (o &apos;-&apos; se non disponibile)</translation>
     </message>
     <message>
         <location filename="../gui/optionsdialog.cpp" line="614"/>

--- a/src/webui/www/translations/webui_it.ts
+++ b/src/webui/www/translations/webui_it.ts
@@ -1452,7 +1452,7 @@
     </message>
     <message>
         <source>%I: Info hash v1</source>
-        <translation>%J: Info hash v1</translation>
+        <translation>%I: Info hash v1</translation>
     </message>
     <message>
         <source>IP address reported to trackers (requires restart):</source>


### PR DESCRIPTION
Some translations have mismatched `%I` being called info hash v2 and `%J` being called info hash v1.