### PR TITLE
Drop WebUI default credentials

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -305,8 +305,8 @@ Application::Application(int &argc, char **argv)
     if (isFileLoggerEnabled())
         m_fileLogger = new FileLogger(fileLoggerPath(), isFileLoggerBackup(), fileLoggerMaxSize(), isFileLoggerDeleteOld(), fileLoggerAge(), static_cast<FileLogger::FileLogAgeType>(fileLoggerAgeType()));
 
-    if (m_commandLineArgs.webUiPort > 0) // it will be -1 when user did not set any value
-        Preferences::instance()->setWebUiPort(m_commandLineArgs.webUiPort);
+    if (m_commandLineArgs.webUIPort > 0) // it will be -1 when user did not set any value
+        Preferences::instance()->setWebUIPort(m_commandLineArgs.webUIPort);
 
     if (m_commandLineArgs.torrentingPort > 0) // it will be -1 when user did not set any value
     {
@@ -908,8 +908,8 @@ int Application::exec()
             const Preferences *pref = Preferences::instance();
             if (pref->getWebUIPassword() == QByteArrayLiteral("ARQ77eY1NUZaQsuDHbIMCA==:0WMRkYTUWVT9wVvdDtHAjU9b3b7uB8NR1Gur2hmQCvCDpm39Q+PsJRJPaCU51dEiz+dTzh8qbPsL8WkFljQYFQ=="))
             {
-                const QString warning = tr("The Web UI administrator username is: %1").arg(pref->getWebUiUsername()) + u'\n'
-                        + tr("The Web UI administrator password has not been changed from the default: %1").arg(u"adminadmin"_s) + u'\n'
+                const QString warning = tr("The WebUI administrator username is: %1").arg(pref->getWebUIUsername()) + u'\n'
+                        + tr("The WebUI administrator password has not been changed from the default: %1").arg(u"adminadmin"_s) + u'\n'
                         + tr("This is a security risk, please change your password in program preferences.") + u'\n';
                 printf("%s", qUtf8Printable(warning));
             }

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -98,12 +98,14 @@
 #include "gui/mainwindow.h"
 #include "gui/shutdownconfirmdialog.h"
 #include "gui/uithememanager.h"
-#include "gui/utils.h"
 #include "gui/windowstate.h"
 #endif // DISABLE_GUI
 
 #ifndef DISABLE_WEBUI
 #include "webui/webui.h"
+#ifdef DISABLE_GUI
+#include "base/utils/password.h"
+#endif
 #endif
 
 namespace
@@ -885,9 +887,18 @@ int Application::exec()
 #endif // DISABLE_GUI
 
 #ifndef DISABLE_WEBUI
+#ifndef DISABLE_GUI
         m_webui = new WebUI(this);
-#ifdef DISABLE_GUI
-        connect(m_webui, &WebUI::error, this, [](const QString &message) { fprintf(stderr, "%s\n", qUtf8Printable(message)); });
+#else
+        const auto *pref = Preferences::instance();
+
+        const QString tempPassword = pref->getWebUIPassword().isEmpty()
+                ? Utils::Password::generate() : QString();
+        m_webui = new WebUI(this, (!tempPassword.isEmpty() ? Utils::Password::PBKDF2::generate(tempPassword) : QByteArray()));
+        connect(m_webui, &WebUI::error, this, [](const QString &message)
+        {
+            fprintf(stderr, "WebUI configuration failed. Reason: %s\n", qUtf8Printable(message));
+        });
 
         printf("%s", qUtf8Printable(u"\n******** %1 ********\n"_s.arg(tr("Information"))));
 
@@ -905,12 +916,11 @@ int Application::exec()
                     , QString::number(m_webui->port()));
             printf("%s\n", qUtf8Printable(tr("To control qBittorrent, access the WebUI at: %1").arg(url)));
 
-            const Preferences *pref = Preferences::instance();
-            if (pref->getWebUIPassword() == QByteArrayLiteral("ARQ77eY1NUZaQsuDHbIMCA==:0WMRkYTUWVT9wVvdDtHAjU9b3b7uB8NR1Gur2hmQCvCDpm39Q+PsJRJPaCU51dEiz+dTzh8qbPsL8WkFljQYFQ=="))
+            if (!tempPassword.isEmpty())
             {
                 const QString warning = tr("The WebUI administrator username is: %1").arg(pref->getWebUIUsername()) + u'\n'
-                        + tr("The WebUI administrator password has not been changed from the default: %1").arg(u"adminadmin"_s) + u'\n'
-                        + tr("This is a security risk, please change your password in program preferences.") + u'\n';
+                        + tr("The WebUI administrator password was not set. A temporary password is provided for this session: %1").arg(tempPassword) + u'\n'
+                        + tr("You should set your own password in program preferences.") + u'\n';
                 printf("%s", qUtf8Printable(warning));
             }
         }
@@ -1357,3 +1367,10 @@ AddTorrentManagerImpl *Application::addTorrentManager() const
 {
     return m_addTorrentManager;
 }
+
+#ifndef DISABLE_WEBUI
+WebUI *Application::webUI() const
+{
+    return m_webui;
+}
+#endif

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -153,6 +153,9 @@ private slots:
 
 private:
     AddTorrentManagerImpl *addTorrentManager() const override;
+#ifndef DISABLE_WEBUI
+    WebUI *webUI() const override;
+#endif
 
     void initializeTranslation();
     void processParams(const QBtCommandLineParameters &params);

--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -329,7 +329,7 @@ QBtCommandLineParameters::QBtCommandLineParameters(const QProcessEnvironment &en
 #elif !defined(Q_OS_WIN)
     , shouldDaemonize(DAEMON_OPTION.value(env))
 #endif
-    , webUiPort(WEBUI_PORT_OPTION.value(env, -1))
+    , webUIPort(WEBUI_PORT_OPTION.value(env, -1))
     , torrentingPort(TORRENTING_PORT_OPTION.value(env, -1))
     , skipDialog(SKIP_DIALOG_OPTION.value(env))
     , profileDir(PROFILE_OPTION.value(env))
@@ -367,8 +367,8 @@ QBtCommandLineParameters parseCommandLine(const QStringList &args)
 #endif
             else if (arg == WEBUI_PORT_OPTION)
             {
-                result.webUiPort = WEBUI_PORT_OPTION.value(arg);
-                if ((result.webUiPort < 1) || (result.webUiPort > 65535))
+                result.webUIPort = WEBUI_PORT_OPTION.value(arg);
+                if ((result.webUIPort < 1) || (result.webUIPort > 65535))
                     throw CommandLineParameterError(QCoreApplication::translate("CMD Options", "%1 must specify a valid port (1 to 65535).")
                                                     .arg(u"--webui-port"_s));
             }
@@ -489,7 +489,7 @@ QString makeUsage(const QString &prgName)
 #endif
         + SHOW_HELP_OPTION.usage() + wrapText(QCoreApplication::translate("CMD Options", "Display this help message and exit")) + u'\n'
         + WEBUI_PORT_OPTION.usage(QCoreApplication::translate("CMD Options", "port"))
-        + wrapText(QCoreApplication::translate("CMD Options", "Change the Web UI port"))
+        + wrapText(QCoreApplication::translate("CMD Options", "Change the WebUI port"))
         + u'\n'
         + TORRENTING_PORT_OPTION.usage(QCoreApplication::translate("CMD Options", "port"))
         + wrapText(QCoreApplication::translate("CMD Options", "Change the torrenting port"))

--- a/src/app/cmdoptions.h
+++ b/src/app/cmdoptions.h
@@ -53,7 +53,7 @@ struct QBtCommandLineParameters
 #elif !defined(Q_OS_WIN)
     bool shouldDaemonize = false;
 #endif
-    int webUiPort = -1;
+    int webUIPort = -1;
     int torrentingPort = -1;
     std::optional<bool> skipDialog;
     Path profileDir;

--- a/src/base/interfaces/iapplication.h
+++ b/src/base/interfaces/iapplication.h
@@ -36,6 +36,7 @@
 #include "base/pathfwd.h"
 
 class AddTorrentManager;
+class WebUI;
 struct QBtCommandLineParameters;
 
 #ifdef Q_OS_WIN
@@ -85,4 +86,7 @@ public:
 #endif
 
     virtual AddTorrentManager *addTorrentManager() const = 0;
+#ifndef DISABLE_WEBUI
+    virtual WebUI *webUI() const = 0;
+#endif
 };

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -768,9 +768,7 @@ void Preferences::setWebUIUsername(const QString &username)
 
 QByteArray Preferences::getWebUIPassword() const
 {
-    // default: adminadmin
-    const auto defaultValue = QByteArrayLiteral("ARQ77eY1NUZaQsuDHbIMCA==:0WMRkYTUWVT9wVvdDtHAjU9b3b7uB8NR1Gur2hmQCvCDpm39Q+PsJRJPaCU51dEiz+dTzh8qbPsL8WkFljQYFQ==");
-    return value(u"Preferences/WebUI/Password_PBKDF2"_s, defaultValue);
+    return value<QByteArray>(u"Preferences/WebUI/Password_PBKDF2"_s);
 }
 
 void Preferences::setWebUIPassword(const QByteArray &password)

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -629,7 +629,7 @@ void Preferences::setSearchEnabled(const bool enabled)
     setValue(u"Preferences/Search/SearchEnabled"_s, enabled);
 }
 
-bool Preferences::isWebUiEnabled() const
+bool Preferences::isWebUIEnabled() const
 {
 #ifdef DISABLE_GUI
     const bool defaultValue = true;
@@ -639,41 +639,41 @@ bool Preferences::isWebUiEnabled() const
     return value(u"Preferences/WebUI/Enabled"_s, defaultValue);
 }
 
-void Preferences::setWebUiEnabled(const bool enabled)
+void Preferences::setWebUIEnabled(const bool enabled)
 {
-    if (enabled == isWebUiEnabled())
+    if (enabled == isWebUIEnabled())
         return;
 
     setValue(u"Preferences/WebUI/Enabled"_s, enabled);
 }
 
-bool Preferences::isWebUiLocalAuthEnabled() const
+bool Preferences::isWebUILocalAuthEnabled() const
 {
     return value(u"Preferences/WebUI/LocalHostAuth"_s, true);
 }
 
-void Preferences::setWebUiLocalAuthEnabled(const bool enabled)
+void Preferences::setWebUILocalAuthEnabled(const bool enabled)
 {
-    if (enabled == isWebUiLocalAuthEnabled())
+    if (enabled == isWebUILocalAuthEnabled())
         return;
 
     setValue(u"Preferences/WebUI/LocalHostAuth"_s, enabled);
 }
 
-bool Preferences::isWebUiAuthSubnetWhitelistEnabled() const
+bool Preferences::isWebUIAuthSubnetWhitelistEnabled() const
 {
     return value(u"Preferences/WebUI/AuthSubnetWhitelistEnabled"_s, false);
 }
 
-void Preferences::setWebUiAuthSubnetWhitelistEnabled(const bool enabled)
+void Preferences::setWebUIAuthSubnetWhitelistEnabled(const bool enabled)
 {
-    if (enabled == isWebUiAuthSubnetWhitelistEnabled())
+    if (enabled == isWebUIAuthSubnetWhitelistEnabled())
         return;
 
     setValue(u"Preferences/WebUI/AuthSubnetWhitelistEnabled"_s, enabled);
 }
 
-QVector<Utils::Net::Subnet> Preferences::getWebUiAuthSubnetWhitelist() const
+QVector<Utils::Net::Subnet> Preferences::getWebUIAuthSubnetWhitelist() const
 {
     const auto subnets = value<QStringList>(u"Preferences/WebUI/AuthSubnetWhitelist"_s);
 
@@ -690,7 +690,7 @@ QVector<Utils::Net::Subnet> Preferences::getWebUiAuthSubnetWhitelist() const
     return ret;
 }
 
-void Preferences::setWebUiAuthSubnetWhitelist(QStringList subnets)
+void Preferences::setWebUIAuthSubnetWhitelist(QStringList subnets)
 {
     subnets.removeIf([](const QString &subnet)
     {
@@ -713,27 +713,27 @@ void Preferences::setServerDomains(const QString &str)
     setValue(u"Preferences/WebUI/ServerDomains"_s, str);
 }
 
-QString Preferences::getWebUiAddress() const
+QString Preferences::getWebUIAddress() const
 {
     return value<QString>(u"Preferences/WebUI/Address"_s, u"*"_s).trimmed();
 }
 
-void Preferences::setWebUiAddress(const QString &addr)
+void Preferences::setWebUIAddress(const QString &addr)
 {
-    if (addr == getWebUiAddress())
+    if (addr == getWebUIAddress())
         return;
 
     setValue(u"Preferences/WebUI/Address"_s, addr.trimmed());
 }
 
-quint16 Preferences::getWebUiPort() const
+quint16 Preferences::getWebUIPort() const
 {
     return value<quint16>(u"Preferences/WebUI/Port"_s, 8080);
 }
 
-void Preferences::setWebUiPort(const quint16 port)
+void Preferences::setWebUIPort(const quint16 port)
 {
-    if (port == getWebUiPort())
+    if (port == getWebUIPort())
         return;
 
     // cast to `int` type so it will show human readable unit in configuration file
@@ -753,14 +753,14 @@ void Preferences::setUPnPForWebUIPort(const bool enabled)
     setValue(u"Preferences/WebUI/UseUPnP"_s, enabled);
 }
 
-QString Preferences::getWebUiUsername() const
+QString Preferences::getWebUIUsername() const
 {
     return value<QString>(u"Preferences/WebUI/Username"_s, u"admin"_s);
 }
 
-void Preferences::setWebUiUsername(const QString &username)
+void Preferences::setWebUIUsername(const QString &username)
 {
-    if (username == getWebUiUsername())
+    if (username == getWebUIUsername())
         return;
 
     setValue(u"Preferences/WebUI/Username"_s, username);
@@ -833,40 +833,40 @@ void Preferences::setWebAPISessionCookieName(const QString &cookieName)
     setValue(u"WebAPI/SessionCookieName"_s, cookieName);
 }
 
-bool Preferences::isWebUiClickjackingProtectionEnabled() const
+bool Preferences::isWebUIClickjackingProtectionEnabled() const
 {
     return value(u"Preferences/WebUI/ClickjackingProtection"_s, true);
 }
 
-void Preferences::setWebUiClickjackingProtectionEnabled(const bool enabled)
+void Preferences::setWebUIClickjackingProtectionEnabled(const bool enabled)
 {
-    if (enabled == isWebUiClickjackingProtectionEnabled())
+    if (enabled == isWebUIClickjackingProtectionEnabled())
         return;
 
     setValue(u"Preferences/WebUI/ClickjackingProtection"_s, enabled);
 }
 
-bool Preferences::isWebUiCSRFProtectionEnabled() const
+bool Preferences::isWebUICSRFProtectionEnabled() const
 {
     return value(u"Preferences/WebUI/CSRFProtection"_s, true);
 }
 
-void Preferences::setWebUiCSRFProtectionEnabled(const bool enabled)
+void Preferences::setWebUICSRFProtectionEnabled(const bool enabled)
 {
-    if (enabled == isWebUiCSRFProtectionEnabled())
+    if (enabled == isWebUICSRFProtectionEnabled())
         return;
 
     setValue(u"Preferences/WebUI/CSRFProtection"_s, enabled);
 }
 
-bool Preferences::isWebUiSecureCookieEnabled() const
+bool Preferences::isWebUISecureCookieEnabled() const
 {
     return value(u"Preferences/WebUI/SecureCookie"_s, true);
 }
 
-void Preferences::setWebUiSecureCookieEnabled(const bool enabled)
+void Preferences::setWebUISecureCookieEnabled(const bool enabled)
 {
-    if (enabled == isWebUiSecureCookieEnabled())
+    if (enabled == isWebUISecureCookieEnabled())
         return;
 
     setValue(u"Preferences/WebUI/SecureCookie"_s, enabled);
@@ -885,14 +885,14 @@ void Preferences::setWebUIHostHeaderValidationEnabled(const bool enabled)
     setValue(u"Preferences/WebUI/HostHeaderValidation"_s, enabled);
 }
 
-bool Preferences::isWebUiHttpsEnabled() const
+bool Preferences::isWebUIHttpsEnabled() const
 {
     return value(u"Preferences/WebUI/HTTPS/Enabled"_s, false);
 }
 
-void Preferences::setWebUiHttpsEnabled(const bool enabled)
+void Preferences::setWebUIHttpsEnabled(const bool enabled)
 {
-    if (enabled == isWebUiHttpsEnabled())
+    if (enabled == isWebUIHttpsEnabled())
         return;
 
     setValue(u"Preferences/WebUI/HTTPS/Enabled"_s, enabled);
@@ -924,27 +924,27 @@ void Preferences::setWebUIHttpsKeyPath(const Path &path)
     setValue(u"Preferences/WebUI/HTTPS/KeyPath"_s, path);
 }
 
-bool Preferences::isAltWebUiEnabled() const
+bool Preferences::isAltWebUIEnabled() const
 {
     return value(u"Preferences/WebUI/AlternativeUIEnabled"_s, false);
 }
 
-void Preferences::setAltWebUiEnabled(const bool enabled)
+void Preferences::setAltWebUIEnabled(const bool enabled)
 {
-    if (enabled == isAltWebUiEnabled())
+    if (enabled == isAltWebUIEnabled())
         return;
 
     setValue(u"Preferences/WebUI/AlternativeUIEnabled"_s, enabled);
 }
 
-Path Preferences::getWebUiRootFolder() const
+Path Preferences::getWebUIRootFolder() const
 {
     return value<Path>(u"Preferences/WebUI/RootFolder"_s);
 }
 
-void Preferences::setWebUiRootFolder(const Path &path)
+void Preferences::setWebUIRootFolder(const Path &path)
 {
-    if (path == getWebUiRootFolder())
+    if (path == getWebUIRootFolder())
         return;
 
     setValue(u"Preferences/WebUI/RootFolder"_s, path);

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -169,26 +169,26 @@ public:
     void setSearchEnabled(bool enabled);
 
     // HTTP Server
-    bool isWebUiEnabled() const;
-    void setWebUiEnabled(bool enabled);
+    bool isWebUIEnabled() const;
+    void setWebUIEnabled(bool enabled);
     QString getServerDomains() const;
     void setServerDomains(const QString &str);
-    QString getWebUiAddress() const;
-    void setWebUiAddress(const QString &addr);
-    quint16 getWebUiPort() const;
-    void setWebUiPort(quint16 port);
+    QString getWebUIAddress() const;
+    void setWebUIAddress(const QString &addr);
+    quint16 getWebUIPort() const;
+    void setWebUIPort(quint16 port);
     bool useUPnPForWebUIPort() const;
     void setUPnPForWebUIPort(bool enabled);
 
     // Authentication
-    bool isWebUiLocalAuthEnabled() const;
-    void setWebUiLocalAuthEnabled(bool enabled);
-    bool isWebUiAuthSubnetWhitelistEnabled() const;
-    void setWebUiAuthSubnetWhitelistEnabled(bool enabled);
-    QVector<Utils::Net::Subnet> getWebUiAuthSubnetWhitelist() const;
-    void setWebUiAuthSubnetWhitelist(QStringList subnets);
-    QString getWebUiUsername() const;
-    void setWebUiUsername(const QString &username);
+    bool isWebUILocalAuthEnabled() const;
+    void setWebUILocalAuthEnabled(bool enabled);
+    bool isWebUIAuthSubnetWhitelistEnabled() const;
+    void setWebUIAuthSubnetWhitelistEnabled(bool enabled);
+    QVector<Utils::Net::Subnet> getWebUIAuthSubnetWhitelist() const;
+    void setWebUIAuthSubnetWhitelist(QStringList subnets);
+    QString getWebUIUsername() const;
+    void setWebUIUsername(const QString &username);
     QByteArray getWebUIPassword() const;
     void setWebUIPassword(const QByteArray &password);
     int getWebUIMaxAuthFailCount() const;
@@ -201,26 +201,26 @@ public:
     void setWebAPISessionCookieName(const QString &cookieName);
 
     // WebUI security
-    bool isWebUiClickjackingProtectionEnabled() const;
-    void setWebUiClickjackingProtectionEnabled(bool enabled);
-    bool isWebUiCSRFProtectionEnabled() const;
-    void setWebUiCSRFProtectionEnabled(bool enabled);
-    bool isWebUiSecureCookieEnabled () const;
-    void setWebUiSecureCookieEnabled(bool enabled);
+    bool isWebUIClickjackingProtectionEnabled() const;
+    void setWebUIClickjackingProtectionEnabled(bool enabled);
+    bool isWebUICSRFProtectionEnabled() const;
+    void setWebUICSRFProtectionEnabled(bool enabled);
+    bool isWebUISecureCookieEnabled () const;
+    void setWebUISecureCookieEnabled(bool enabled);
     bool isWebUIHostHeaderValidationEnabled() const;
     void setWebUIHostHeaderValidationEnabled(bool enabled);
 
     // HTTPS
-    bool isWebUiHttpsEnabled() const;
-    void setWebUiHttpsEnabled(bool enabled);
+    bool isWebUIHttpsEnabled() const;
+    void setWebUIHttpsEnabled(bool enabled);
     Path getWebUIHttpsCertificatePath() const;
     void setWebUIHttpsCertificatePath(const Path &path);
     Path getWebUIHttpsKeyPath() const;
     void setWebUIHttpsKeyPath(const Path &path);
-    bool isAltWebUiEnabled() const;
-    void setAltWebUiEnabled(bool enabled);
-    Path getWebUiRootFolder() const;
-    void setWebUiRootFolder(const Path &path);
+    bool isAltWebUIEnabled() const;
+    void setAltWebUIEnabled(bool enabled);
+    Path getWebUIRootFolder() const;
+    void setWebUIRootFolder(const Path &path);
 
     // WebUI custom HTTP headers
     bool isWebUICustomHTTPHeadersEnabled() const;

--- a/src/base/utils/password.cpp
+++ b/src/base/utils/password.cpp
@@ -1,5 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2023  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2018  Mike Tzou (Chocobo1)
  *
  * This program is free software; you can redistribute it and/or
@@ -36,6 +37,7 @@
 #include <QString>
 #include <QVector>
 
+#include "base/global.h"
 #include "bytearray.h"
 #include "random.h"
 
@@ -65,6 +67,21 @@ bool Utils::Password::slowEquals(const QByteArray &a, const QByteArray &b)
     return (diff == 0);
 }
 
+QString Utils::Password::generate()
+{
+    const QString alphanum = u"23456789ABCDEFGHIJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz"_s;
+    const int passwordLength = 9;
+    QString pass;
+    pass.reserve(passwordLength);
+    while (pass.length() < passwordLength)
+    {
+        const auto num = Utils::Random::rand(0, (alphanum.size() - 1));
+        pass.append(alphanum[num]);
+    }
+
+    return pass;
+}
+
 QByteArray Utils::Password::PBKDF2::generate(const QString &password)
 {
     return generate(password.toUtf8());
@@ -72,9 +89,8 @@ QByteArray Utils::Password::PBKDF2::generate(const QString &password)
 
 QByteArray Utils::Password::PBKDF2::generate(const QByteArray &password)
 {
-    const std::array<uint32_t, 4> salt
-    {{Random::rand(), Random::rand()
-        , Random::rand(), Random::rand()}};
+    const std::array<uint32_t, 4> salt {
+        {Random::rand(), Random::rand(), Random::rand(), Random::rand()}};
 
     std::array<unsigned char, 64> outBuf {};
     const int hmacResult = PKCS5_PBKDF2_HMAC(password.constData(), password.size()

--- a/src/base/utils/password.h
+++ b/src/base/utils/password.h
@@ -1,5 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2023  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2018  Mike Tzou (Chocobo1)
  *
  * This program is free software; you can redistribute it and/or
@@ -36,6 +37,8 @@ namespace Utils::Password
     // Implements constant-time comparison to protect against timing attacks
     // Taken from https://crackstation.net/hashing-security.htm
     bool slowEquals(const QByteArray &a, const QByteArray &b);
+
+    QString generate();
 
     namespace PBKDF2
     {

--- a/src/gui/ipsubnetwhitelistoptionsdialog.cpp
+++ b/src/gui/ipsubnetwhitelistoptionsdialog.cpp
@@ -50,7 +50,7 @@ IPSubnetWhitelistOptionsDialog::IPSubnetWhitelistOptionsDialog(QWidget *parent)
     connect(m_ui->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
     QStringList authSubnetWhitelistStringList;
-    for (const Utils::Net::Subnet &subnet : asConst(Preferences::instance()->getWebUiAuthSubnetWhitelist()))
+    for (const Utils::Net::Subnet &subnet : asConst(Preferences::instance()->getWebUIAuthSubnetWhitelist()))
         authSubnetWhitelistStringList << Utils::Net::subnetToString(subnet);
     m_model = new QStringListModel(authSubnetWhitelistStringList, this);
 
@@ -81,7 +81,7 @@ void IPSubnetWhitelistOptionsDialog::on_buttonBox_accepted()
         // Operate on the m_sortFilter to grab the strings in sorted order
         for (int i = 0; i < m_sortFilter->rowCount(); ++i)
             subnets.append(m_sortFilter->index(i, 0).data().toString());
-        Preferences::instance()->setWebUiAuthSubnetWhitelist(subnets);
+        Preferences::instance()->setWebUIAuthSubnetWhitelist(subnets);
         QDialog::accept();
     }
     else

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1145,7 +1145,7 @@ void MainWindow::closeEvent(QCloseEvent *e)
             if (!isVisible())
                 show();
             QMessageBox confirmBox(QMessageBox::Question, tr("Exiting qBittorrent"),
-                                   // Split it because the last sentence is used in the Web UI
+                                   // Split it because the last sentence is used in the WebUI
                                    tr("Some files are currently transferring.") + u'\n' + tr("Are you sure you want to quit qBittorrent?"),
                                    QMessageBox::NoButton, this);
             QPushButton *noBtn = confirmBox.addButton(tr("&No"), QMessageBox::NoRole);

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -1218,28 +1218,28 @@ void OptionsDialog::loadWebUITabOptions()
     m_ui->textWebUIRootFolder->setMode(FileSystemPathEdit::Mode::DirectoryOpen);
     m_ui->textWebUIRootFolder->setDialogCaption(tr("Choose Alternative UI files location"));
 
-    m_ui->checkWebUi->setChecked(pref->isWebUiEnabled());
-    m_ui->textWebUiAddress->setText(pref->getWebUiAddress());
-    m_ui->spinWebUiPort->setValue(pref->getWebUiPort());
+    m_ui->checkWebUI->setChecked(pref->isWebUIEnabled());
+    m_ui->textWebUIAddress->setText(pref->getWebUIAddress());
+    m_ui->spinWebUIPort->setValue(pref->getWebUIPort());
     m_ui->checkWebUIUPnP->setChecked(pref->useUPnPForWebUIPort());
-    m_ui->checkWebUiHttps->setChecked(pref->isWebUiHttpsEnabled());
+    m_ui->checkWebUIHttps->setChecked(pref->isWebUIHttpsEnabled());
     webUIHttpsCertChanged(pref->getWebUIHttpsCertificatePath());
     webUIHttpsKeyChanged(pref->getWebUIHttpsKeyPath());
-    m_ui->textWebUiUsername->setText(pref->getWebUiUsername());
-    m_ui->checkBypassLocalAuth->setChecked(!pref->isWebUiLocalAuthEnabled());
-    m_ui->checkBypassAuthSubnetWhitelist->setChecked(pref->isWebUiAuthSubnetWhitelistEnabled());
+    m_ui->textWebUIUsername->setText(pref->getWebUIUsername());
+    m_ui->checkBypassLocalAuth->setChecked(!pref->isWebUILocalAuthEnabled());
+    m_ui->checkBypassAuthSubnetWhitelist->setChecked(pref->isWebUIAuthSubnetWhitelistEnabled());
     m_ui->IPSubnetWhitelistButton->setEnabled(m_ui->checkBypassAuthSubnetWhitelist->isChecked());
     m_ui->spinBanCounter->setValue(pref->getWebUIMaxAuthFailCount());
     m_ui->spinBanDuration->setValue(pref->getWebUIBanDuration().count());
     m_ui->spinSessionTimeout->setValue(pref->getWebUISessionTimeout());
     // Alternative UI
-    m_ui->groupAltWebUI->setChecked(pref->isAltWebUiEnabled());
-    m_ui->textWebUIRootFolder->setSelectedPath(pref->getWebUiRootFolder());
+    m_ui->groupAltWebUI->setChecked(pref->isAltWebUIEnabled());
+    m_ui->textWebUIRootFolder->setSelectedPath(pref->getWebUIRootFolder());
     // Security
-    m_ui->checkClickjacking->setChecked(pref->isWebUiClickjackingProtectionEnabled());
-    m_ui->checkCSRFProtection->setChecked(pref->isWebUiCSRFProtectionEnabled());
-    m_ui->checkSecureCookie->setEnabled(pref->isWebUiHttpsEnabled());
-    m_ui->checkSecureCookie->setChecked(pref->isWebUiSecureCookieEnabled());
+    m_ui->checkClickjacking->setChecked(pref->isWebUIClickjackingProtectionEnabled());
+    m_ui->checkCSRFProtection->setChecked(pref->isWebUICSRFProtectionEnabled());
+    m_ui->checkSecureCookie->setEnabled(pref->isWebUIHttpsEnabled());
+    m_ui->checkSecureCookie->setChecked(pref->isWebUISecureCookieEnabled());
     m_ui->groupHostHeaderValidation->setChecked(pref->isWebUIHostHeaderValidationEnabled());
     m_ui->textServerDomains->setText(pref->getServerDomains());
     // Custom HTTP headers
@@ -1255,18 +1255,18 @@ void OptionsDialog::loadWebUITabOptions()
     m_ui->DNSUsernameTxt->setText(pref->getDynDNSUsername());
     m_ui->DNSPasswordTxt->setText(pref->getDynDNSPassword());
 
-    connect(m_ui->checkWebUi, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
-    connect(m_ui->textWebUiAddress, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
-    connect(m_ui->spinWebUiPort, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
+    connect(m_ui->checkWebUI, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->textWebUIAddress, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
+    connect(m_ui->spinWebUIPort, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->checkWebUIUPnP, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
-    connect(m_ui->checkWebUiHttps, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->checkWebUIHttps, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->textWebUIHttpsCert, &FileSystemPathLineEdit::selectedPathChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->textWebUIHttpsCert, &FileSystemPathLineEdit::selectedPathChanged, this, &OptionsDialog::webUIHttpsCertChanged);
     connect(m_ui->textWebUIHttpsKey, &FileSystemPathLineEdit::selectedPathChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->textWebUIHttpsKey, &FileSystemPathLineEdit::selectedPathChanged, this, &OptionsDialog::webUIHttpsKeyChanged);
 
-    connect(m_ui->textWebUiUsername, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
-    connect(m_ui->textWebUiPassword, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
+    connect(m_ui->textWebUIUsername, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
+    connect(m_ui->textWebUIPassword, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
 
     connect(m_ui->checkBypassLocalAuth, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkBypassAuthSubnetWhitelist, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
@@ -1280,7 +1280,7 @@ void OptionsDialog::loadWebUITabOptions()
 
     connect(m_ui->checkClickjacking, &QCheckBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkCSRFProtection, &QCheckBox::toggled, this, &ThisType::enableApplyButton);
-    connect(m_ui->checkWebUiHttps, &QGroupBox::toggled, m_ui->checkSecureCookie, &QWidget::setEnabled);
+    connect(m_ui->checkWebUIHttps, &QGroupBox::toggled, m_ui->checkSecureCookie, &QWidget::setEnabled);
     connect(m_ui->checkSecureCookie, &QCheckBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->groupHostHeaderValidation, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->textServerDomains, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
@@ -1302,29 +1302,29 @@ void OptionsDialog::saveWebUITabOptions() const
 {
     auto *pref = Preferences::instance();
 
-    pref->setWebUiEnabled(isWebUiEnabled());
-    pref->setWebUiAddress(m_ui->textWebUiAddress->text());
-    pref->setWebUiPort(m_ui->spinWebUiPort->value());
+    pref->setWebUIEnabled(isWebUIEnabled());
+    pref->setWebUIAddress(m_ui->textWebUIAddress->text());
+    pref->setWebUIPort(m_ui->spinWebUIPort->value());
     pref->setUPnPForWebUIPort(m_ui->checkWebUIUPnP->isChecked());
-    pref->setWebUiHttpsEnabled(m_ui->checkWebUiHttps->isChecked());
+    pref->setWebUIHttpsEnabled(m_ui->checkWebUIHttps->isChecked());
     pref->setWebUIHttpsCertificatePath(m_ui->textWebUIHttpsCert->selectedPath());
     pref->setWebUIHttpsKeyPath(m_ui->textWebUIHttpsKey->selectedPath());
     pref->setWebUIMaxAuthFailCount(m_ui->spinBanCounter->value());
     pref->setWebUIBanDuration(std::chrono::seconds {m_ui->spinBanDuration->value()});
     pref->setWebUISessionTimeout(m_ui->spinSessionTimeout->value());
     // Authentication
-    pref->setWebUiUsername(webUiUsername());
-    if (!webUiPassword().isEmpty())
-        pref->setWebUIPassword(Utils::Password::PBKDF2::generate(webUiPassword()));
-    pref->setWebUiLocalAuthEnabled(!m_ui->checkBypassLocalAuth->isChecked());
-    pref->setWebUiAuthSubnetWhitelistEnabled(m_ui->checkBypassAuthSubnetWhitelist->isChecked());
+    pref->setWebUIUsername(webUIUsername());
+    if (!webUIPassword().isEmpty())
+        pref->setWebUIPassword(Utils::Password::PBKDF2::generate(webUIPassword()));
+    pref->setWebUILocalAuthEnabled(!m_ui->checkBypassLocalAuth->isChecked());
+    pref->setWebUIAuthSubnetWhitelistEnabled(m_ui->checkBypassAuthSubnetWhitelist->isChecked());
     // Alternative UI
-    pref->setAltWebUiEnabled(m_ui->groupAltWebUI->isChecked());
-    pref->setWebUiRootFolder(m_ui->textWebUIRootFolder->selectedPath());
+    pref->setAltWebUIEnabled(m_ui->groupAltWebUI->isChecked());
+    pref->setWebUIRootFolder(m_ui->textWebUIRootFolder->selectedPath());
     // Security
-    pref->setWebUiClickjackingProtectionEnabled(m_ui->checkClickjacking->isChecked());
-    pref->setWebUiCSRFProtectionEnabled(m_ui->checkCSRFProtection->isChecked());
-    pref->setWebUiSecureCookieEnabled(m_ui->checkSecureCookie->isChecked());
+    pref->setWebUIClickjackingProtectionEnabled(m_ui->checkClickjacking->isChecked());
+    pref->setWebUICSRFProtectionEnabled(m_ui->checkCSRFProtection->isChecked());
+    pref->setWebUISecureCookieEnabled(m_ui->checkSecureCookie->isChecked());
     pref->setWebUIHostHeaderValidationEnabled(m_ui->groupHostHeaderValidation->isChecked());
     pref->setServerDomains(m_ui->textServerDomains->text());
     // Custom HTTP headers
@@ -1866,31 +1866,31 @@ void OptionsDialog::webUIHttpsKeyChanged(const Path &path)
         (isKeyValid ? u"security-high"_s : u"security-low"_s), 24));
 }
 
-bool OptionsDialog::isWebUiEnabled() const
+bool OptionsDialog::isWebUIEnabled() const
 {
-    return m_ui->checkWebUi->isChecked();
+    return m_ui->checkWebUI->isChecked();
 }
 
-QString OptionsDialog::webUiUsername() const
+QString OptionsDialog::webUIUsername() const
 {
-    return m_ui->textWebUiUsername->text();
+    return m_ui->textWebUIUsername->text();
 }
 
-QString OptionsDialog::webUiPassword() const
+QString OptionsDialog::webUIPassword() const
 {
-    return m_ui->textWebUiPassword->text();
+    return m_ui->textWebUIPassword->text();
 }
 
 bool OptionsDialog::webUIAuthenticationOk()
 {
-    if (webUiUsername().length() < 3)
+    if (webUIUsername().length() < 3)
     {
-        QMessageBox::warning(this, tr("Length Error"), tr("The Web UI username must be at least 3 characters long."));
+        QMessageBox::warning(this, tr("Length Error"), tr("The WebUI username must be at least 3 characters long."));
         return false;
     }
-    if (!webUiPassword().isEmpty() && (webUiPassword().length() < 6))
+    if (!webUIPassword().isEmpty() && (webUIPassword().length() < 6))
     {
-        QMessageBox::warning(this, tr("Length Error"), tr("The Web UI password must be at least 6 characters long."));
+        QMessageBox::warning(this, tr("Length Error"), tr("The WebUI password must be at least 6 characters long."));
         return false;
     }
     return true;
@@ -1900,7 +1900,7 @@ bool OptionsDialog::isAlternativeWebUIPathValid()
 {
     if (m_ui->groupAltWebUI->isChecked() && m_ui->textWebUIRootFolder->selectedPath().isEmpty())
     {
-        QMessageBox::warning(this, tr("Location Error"), tr("The alternative Web UI files location cannot be blank."));
+        QMessageBox::warning(this, tr("Location Error"), tr("The alternative WebUI files location cannot be blank."));
         return false;
     }
     return true;

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -89,7 +89,6 @@ private slots:
     void adjustProxyOptions();
     void on_buttonBox_accepted();
     void on_buttonBox_rejected();
-    void applySettings();
     void enableApplyButton();
     void toggleComboRatioLimitAct();
     void changePage(QListWidgetItem *, QListWidgetItem *);
@@ -116,6 +115,7 @@ private:
     void showEvent(QShowEvent *e) override;
 
     // Methods
+    bool applySettings();
     void saveOptions() const;
 
     void loadBehaviorTabOptions();

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -185,9 +185,9 @@ private:
     int getMaxActiveTorrents() const;
     // WebUI
 #ifndef DISABLE_WEBUI
-    bool isWebUiEnabled() const;
-    QString webUiUsername() const;
-    QString webUiPassword() const;
+    bool isWebUIEnabled() const;
+    QString webUIUsername() const;
+    QString webUIPassword() const;
     bool webUIAuthenticationOk();
     bool isAlternativeWebUIPathValid();
 #endif

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -3266,8 +3266,8 @@ Disable encryption: Only connect to peers without protocol encryption</string>
         </item>
        </layout>
       </widget>
-      <widget class="QWidget" name="tabWebuiPage">
-       <layout class="QVBoxLayout" name="tabWebuiPageLayout">
+      <widget class="QWidget" name="tabWebUIPage">
+       <layout class="QVBoxLayout" name="tabWebUIPageLayout">
         <property name="leftMargin">
          <number>0</number>
         </property>
@@ -3296,7 +3296,7 @@ Disable encryption: Only connect to peers without protocol encryption</string>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_23">
             <item>
-             <widget class="QGroupBox" name="checkWebUi">
+             <widget class="QGroupBox" name="checkWebUI">
               <property name="title">
                <string>Web User Interface (Remote control)</string>
               </property>
@@ -3310,14 +3310,14 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                <item>
                 <layout class="QHBoxLayout" name="horizontalLayout_2">
                  <item>
-                  <widget class="QLabel" name="lblWebUiAddress">
+                  <widget class="QLabel" name="lblWebUIAddress">
                    <property name="text">
                     <string>IP address:</string>
                    </property>
                   </widget>
                  </item>
                  <item>
-                  <widget class="QLineEdit" name="textWebUiAddress">
+                  <widget class="QLineEdit" name="textWebUIAddress">
                    <property name="toolTip">
                     <string>IP address that the Web UI will bind to.
 Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv4 address,
@@ -3326,14 +3326,14 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                   </widget>
                  </item>
                  <item>
-                  <widget class="QLabel" name="lblWebUiPort">
+                  <widget class="QLabel" name="lblWebUIPort">
                    <property name="text">
                     <string>Port:</string>
                    </property>
                   </widget>
                  </item>
                  <item>
-                  <widget class="QSpinBox" name="spinWebUiPort">
+                  <widget class="QSpinBox" name="spinWebUIPort">
                    <property name="minimum">
                     <number>1</number>
                    </property>
@@ -3358,7 +3358,7 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="checkWebUiHttps">
+                <widget class="QGroupBox" name="checkWebUIHttps">
                  <property name="title">
                   <string>&amp;Use HTTPS instead of HTTP</string>
                  </property>
@@ -3370,14 +3370,14 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                  </property>
                  <layout class="QGridLayout" name="gridLayout_11">
                   <item row="1" column="1">
-                   <widget class="QLabel" name="lblWebUiKey">
+                   <widget class="QLabel" name="lblWebUIKey">
                     <property name="text">
                      <string>Key:</string>
                     </property>
                    </widget>
                   </item>
                   <item row="0" column="1">
-                   <widget class="QLabel" name="lblWebUiCrt">
+                   <widget class="QLabel" name="lblWebUICrt">
                     <property name="text">
                      <string>Certificate:</string>
                     </property>
@@ -3409,7 +3409,7 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="groupWebUiAuth">
+                <widget class="QGroupBox" name="groupWebUIAuth">
                  <property name="title">
                   <string>Authentication</string>
                  </property>
@@ -3417,24 +3417,24 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                   <item>
                    <layout class="QGridLayout" name="gridLayout_8">
                     <item row="0" column="0">
-                     <widget class="QLabel" name="lblWebUiUsername">
+                     <widget class="QLabel" name="lblWebUIUsername">
                       <property name="text">
                        <string>Username:</string>
                       </property>
                      </widget>
                     </item>
                     <item row="0" column="1">
-                     <widget class="QLineEdit" name="textWebUiUsername"/>
+                     <widget class="QLineEdit" name="textWebUIUsername"/>
                     </item>
                     <item row="1" column="0">
-                     <widget class="QLabel" name="lblWebUiPassword">
+                     <widget class="QLabel" name="lblWebUIPassword">
                       <property name="text">
                        <string>Password:</string>
                       </property>
                      </widget>
                     </item>
                     <item row="1" column="1">
-                     <widget class="QLineEdit" name="textWebUiPassword">
+                     <widget class="QLineEdit" name="textWebUIPassword">
                       <property name="echoMode">
                        <enum>QLineEdit::Password</enum>
                       </property>
@@ -3862,13 +3862,13 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
   <tabstop>stopConditionComboBox</tabstop>
   <tabstop>spinPort</tabstop>
   <tabstop>checkUPnP</tabstop>
-  <tabstop>textWebUiUsername</tabstop>
-  <tabstop>checkWebUi</tabstop>
+  <tabstop>textWebUIUsername</tabstop>
+  <tabstop>checkWebUI</tabstop>
   <tabstop>textSavePath</tabstop>
   <tabstop>scrollArea_7</tabstop>
   <tabstop>scrollArea_2</tabstop>
-  <tabstop>spinWebUiPort</tabstop>
-  <tabstop>textWebUiPassword</tabstop>
+  <tabstop>spinWebUIPort</tabstop>
+  <tabstop>textWebUIPassword</tabstop>
   <tabstop>buttonBox</tabstop>
   <tabstop>tabSelection</tabstop>
   <tabstop>scrollArea</tabstop>
@@ -3958,7 +3958,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
   <tabstop>spinMaxActiveUploads</tabstop>
   <tabstop>spinMaxActiveTorrents</tabstop>
   <tabstop>checkWebUIUPnP</tabstop>
-  <tabstop>checkWebUiHttps</tabstop>
+  <tabstop>checkWebUIHttps</tabstop>
   <tabstop>checkBypassLocalAuth</tabstop>
   <tabstop>checkBypassAuthSubnetWhitelist</tabstop>
   <tabstop>IPSubnetWhitelistButton</tabstop>

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -3308,6 +3308,18 @@ Disable encryption: Only connect to peers without protocol encryption</string>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_2">
                <item>
+                <widget class="QLabel" name="labelWebUIError">
+                 <property name="font">
+                  <font>
+                   <italic>true</italic>
+                  </font>
+                 </property>
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <layout class="QHBoxLayout" name="horizontalLayout_2">
                  <item>
                   <widget class="QLabel" name="lblWebUIAddress">

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -92,7 +92,7 @@ void AppController::buildInfoAction()
 void AppController::shutdownAction()
 {
     // Special handling for shutdown, we
-    // need to reply to the Web UI before
+    // need to reply to the WebUI before
     // actually shutting down.
     QTimer::singleShot(100ms, Qt::CoarseTimer, qApp, []
     {
@@ -275,33 +275,33 @@ void AppController::preferencesAction()
     data[u"add_trackers_enabled"_s] = session->isAddTrackersEnabled();
     data[u"add_trackers"_s] = session->additionalTrackers();
 
-    // Web UI
+    // WebUI
     // HTTP Server
     data[u"web_ui_domain_list"_s] = pref->getServerDomains();
-    data[u"web_ui_address"_s] = pref->getWebUiAddress();
-    data[u"web_ui_port"_s] = pref->getWebUiPort();
+    data[u"web_ui_address"_s] = pref->getWebUIAddress();
+    data[u"web_ui_port"_s] = pref->getWebUIPort();
     data[u"web_ui_upnp"_s] = pref->useUPnPForWebUIPort();
-    data[u"use_https"_s] = pref->isWebUiHttpsEnabled();
+    data[u"use_https"_s] = pref->isWebUIHttpsEnabled();
     data[u"web_ui_https_cert_path"_s] = pref->getWebUIHttpsCertificatePath().toString();
     data[u"web_ui_https_key_path"_s] = pref->getWebUIHttpsKeyPath().toString();
     // Authentication
-    data[u"web_ui_username"_s] = pref->getWebUiUsername();
-    data[u"bypass_local_auth"_s] = !pref->isWebUiLocalAuthEnabled();
-    data[u"bypass_auth_subnet_whitelist_enabled"_s] = pref->isWebUiAuthSubnetWhitelistEnabled();
+    data[u"web_ui_username"_s] = pref->getWebUIUsername();
+    data[u"bypass_local_auth"_s] = !pref->isWebUILocalAuthEnabled();
+    data[u"bypass_auth_subnet_whitelist_enabled"_s] = pref->isWebUIAuthSubnetWhitelistEnabled();
     QStringList authSubnetWhitelistStringList;
-    for (const Utils::Net::Subnet &subnet : asConst(pref->getWebUiAuthSubnetWhitelist()))
+    for (const Utils::Net::Subnet &subnet : asConst(pref->getWebUIAuthSubnetWhitelist()))
         authSubnetWhitelistStringList << Utils::Net::subnetToString(subnet);
     data[u"bypass_auth_subnet_whitelist"_s] = authSubnetWhitelistStringList.join(u'\n');
     data[u"web_ui_max_auth_fail_count"_s] = pref->getWebUIMaxAuthFailCount();
     data[u"web_ui_ban_duration"_s] = static_cast<int>(pref->getWebUIBanDuration().count());
     data[u"web_ui_session_timeout"_s] = pref->getWebUISessionTimeout();
-    // Use alternative Web UI
-    data[u"alternative_webui_enabled"_s] = pref->isAltWebUiEnabled();
-    data[u"alternative_webui_path"_s] = pref->getWebUiRootFolder().toString();
+    // Use alternative WebUI
+    data[u"alternative_webui_enabled"_s] = pref->isAltWebUIEnabled();
+    data[u"alternative_webui_path"_s] = pref->getWebUIRootFolder().toString();
     // Security
-    data[u"web_ui_clickjacking_protection_enabled"_s] = pref->isWebUiClickjackingProtectionEnabled();
-    data[u"web_ui_csrf_protection_enabled"_s] = pref->isWebUiCSRFProtectionEnabled();
-    data[u"web_ui_secure_cookie_enabled"_s] = pref->isWebUiSecureCookieEnabled();
+    data[u"web_ui_clickjacking_protection_enabled"_s] = pref->isWebUIClickjackingProtectionEnabled();
+    data[u"web_ui_csrf_protection_enabled"_s] = pref->isWebUICSRFProtectionEnabled();
+    data[u"web_ui_secure_cookie_enabled"_s] = pref->isWebUISecureCookieEnabled();
     data[u"web_ui_host_header_validation_enabled"_s] = pref->isWebUIHostHeaderValidationEnabled();
     // Custom HTTP headers
     data[u"web_ui_use_custom_http_headers_enabled"_s] = pref->isWebUICustomHTTPHeadersEnabled();
@@ -788,35 +788,35 @@ void AppController::setPreferencesAction()
     if (hasKey(u"add_trackers"_s))
         session->setAdditionalTrackers(it.value().toString());
 
-    // Web UI
+    // WebUI
     // HTTP Server
     if (hasKey(u"web_ui_domain_list"_s))
         pref->setServerDomains(it.value().toString());
     if (hasKey(u"web_ui_address"_s))
-        pref->setWebUiAddress(it.value().toString());
+        pref->setWebUIAddress(it.value().toString());
     if (hasKey(u"web_ui_port"_s))
-        pref->setWebUiPort(it.value().value<quint16>());
+        pref->setWebUIPort(it.value().value<quint16>());
     if (hasKey(u"web_ui_upnp"_s))
         pref->setUPnPForWebUIPort(it.value().toBool());
     if (hasKey(u"use_https"_s))
-        pref->setWebUiHttpsEnabled(it.value().toBool());
+        pref->setWebUIHttpsEnabled(it.value().toBool());
     if (hasKey(u"web_ui_https_cert_path"_s))
         pref->setWebUIHttpsCertificatePath(Path(it.value().toString()));
     if (hasKey(u"web_ui_https_key_path"_s))
         pref->setWebUIHttpsKeyPath(Path(it.value().toString()));
     // Authentication
     if (hasKey(u"web_ui_username"_s))
-        pref->setWebUiUsername(it.value().toString());
+        pref->setWebUIUsername(it.value().toString());
     if (hasKey(u"web_ui_password"_s))
         pref->setWebUIPassword(Utils::Password::PBKDF2::generate(it.value().toByteArray()));
     if (hasKey(u"bypass_local_auth"_s))
-        pref->setWebUiLocalAuthEnabled(!it.value().toBool());
+        pref->setWebUILocalAuthEnabled(!it.value().toBool());
     if (hasKey(u"bypass_auth_subnet_whitelist_enabled"_s))
-        pref->setWebUiAuthSubnetWhitelistEnabled(it.value().toBool());
+        pref->setWebUIAuthSubnetWhitelistEnabled(it.value().toBool());
     if (hasKey(u"bypass_auth_subnet_whitelist"_s))
     {
         // recognize new lines and commas as delimiters
-        pref->setWebUiAuthSubnetWhitelist(it.value().toString().split(QRegularExpression(u"\n|,"_s), Qt::SkipEmptyParts));
+        pref->setWebUIAuthSubnetWhitelist(it.value().toString().split(QRegularExpression(u"\n|,"_s), Qt::SkipEmptyParts));
     }
     if (hasKey(u"web_ui_max_auth_fail_count"_s))
         pref->setWebUIMaxAuthFailCount(it.value().toInt());
@@ -824,18 +824,18 @@ void AppController::setPreferencesAction()
         pref->setWebUIBanDuration(std::chrono::seconds {it.value().toInt()});
     if (hasKey(u"web_ui_session_timeout"_s))
         pref->setWebUISessionTimeout(it.value().toInt());
-    // Use alternative Web UI
+    // Use alternative WebUI
     if (hasKey(u"alternative_webui_enabled"_s))
-        pref->setAltWebUiEnabled(it.value().toBool());
+        pref->setAltWebUIEnabled(it.value().toBool());
     if (hasKey(u"alternative_webui_path"_s))
-        pref->setWebUiRootFolder(Path(it.value().toString()));
+        pref->setWebUIRootFolder(Path(it.value().toString()));
     // Security
     if (hasKey(u"web_ui_clickjacking_protection_enabled"_s))
-        pref->setWebUiClickjackingProtectionEnabled(it.value().toBool());
+        pref->setWebUIClickjackingProtectionEnabled(it.value().toBool());
     if (hasKey(u"web_ui_csrf_protection_enabled"_s))
-        pref->setWebUiCSRFProtectionEnabled(it.value().toBool());
+        pref->setWebUICSRFProtectionEnabled(it.value().toBool());
     if (hasKey(u"web_ui_secure_cookie_enabled"_s))
-        pref->setWebUiSecureCookieEnabled(it.value().toBool());
+        pref->setWebUISecureCookieEnabled(it.value().toBool());
     if (hasKey(u"web_ui_host_header_validation_enabled"_s))
         pref->setWebUIHostHeaderValidationEnabled(it.value().toBool());
     // Custom HTTP headers

--- a/src/webui/api/authcontroller.cpp
+++ b/src/webui/api/authcontroller.cpp
@@ -66,7 +66,7 @@ void AuthController::loginAction()
 
     const Preferences *pref = Preferences::instance();
 
-    const QString username {pref->getWebUiUsername()};
+    const QString username {pref->getWebUIUsername()};
     const QByteArray secret {pref->getWebUIPassword()};
     const bool usernameEqual = Utils::Password::slowEquals(usernameFromWeb.toUtf8(), username.toUtf8());
     const bool passwordEqual = Utils::Password::PBKDF2::verify(secret, passwordFromWeb);

--- a/src/webui/api/authcontroller.cpp
+++ b/src/webui/api/authcontroller.cpp
@@ -43,6 +43,16 @@ AuthController::AuthController(ISessionManager *sessionManager, IApplication *ap
 {
 }
 
+void AuthController::setUsername(const QString &username)
+{
+    m_username = username;
+}
+
+void AuthController::setPasswordHash(const QByteArray &passwordHash)
+{
+    m_passwordHash = passwordHash;
+}
+
 void AuthController::loginAction()
 {
     if (m_sessionManager->session())
@@ -51,9 +61,9 @@ void AuthController::loginAction()
         return;
     }
 
-    const QString clientAddr {m_sessionManager->clientId()};
-    const QString usernameFromWeb {params()[u"username"_s]};
-    const QString passwordFromWeb {params()[u"password"_s]};
+    const QString clientAddr = m_sessionManager->clientId();
+    const QString usernameFromWeb = params()[u"username"_s];
+    const QString passwordFromWeb = params()[u"password"_s];
 
     if (isBanned())
     {
@@ -61,15 +71,11 @@ void AuthController::loginAction()
                 .arg(clientAddr, usernameFromWeb)
             , Log::WARNING);
         throw APIError(APIErrorType::AccessDenied
-                       , tr("Your IP address has been banned after too many failed authentication attempts."));
+            , tr("Your IP address has been banned after too many failed authentication attempts."));
     }
 
-    const Preferences *pref = Preferences::instance();
-
-    const QString username {pref->getWebUIUsername()};
-    const QByteArray secret {pref->getWebUIPassword()};
-    const bool usernameEqual = Utils::Password::slowEquals(usernameFromWeb.toUtf8(), username.toUtf8());
-    const bool passwordEqual = Utils::Password::PBKDF2::verify(secret, passwordFromWeb);
+    const bool usernameEqual = Utils::Password::slowEquals(usernameFromWeb.toUtf8(), m_username.toUtf8());
+    const bool passwordEqual = Utils::Password::PBKDF2::verify(m_passwordHash, passwordFromWeb);
 
     if (usernameEqual && passwordEqual)
     {

--- a/src/webui/api/authcontroller.h
+++ b/src/webui/api/authcontroller.h
@@ -28,8 +28,10 @@
 
 #pragma once
 
+#include <QByteArray>
 #include <QDeadlineTimer>
 #include <QHash>
+#include <QString>
 
 #include "apicontroller.h"
 
@@ -45,6 +47,9 @@ class AuthController : public APIController
 public:
     explicit AuthController(ISessionManager *sessionManager, IApplication *app, QObject *parent = nullptr);
 
+    void setUsername(const QString &username);
+    void setPasswordHash(const QByteArray &passwordHash);
+
 private slots:
     void loginAction();
     void logoutAction() const;
@@ -55,6 +60,9 @@ private:
     void increaseFailedAttempts();
 
     ISessionManager *m_sessionManager = nullptr;
+
+    QString m_username;
+    QByteArray m_passwordHash;
 
     struct FailedLogin
     {

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -378,17 +378,17 @@ void WebApplication::configure()
 {
     const auto *pref = Preferences::instance();
 
-    const bool isAltUIUsed = pref->isAltWebUiEnabled();
-    const Path rootFolder = (!isAltUIUsed ? Path(WWW_FOLDER) : pref->getWebUiRootFolder());
+    const bool isAltUIUsed = pref->isAltWebUIEnabled();
+    const Path rootFolder = (!isAltUIUsed ? Path(WWW_FOLDER) : pref->getWebUIRootFolder());
     if ((isAltUIUsed != m_isAltUIUsed) || (rootFolder != m_rootFolder))
     {
         m_isAltUIUsed = isAltUIUsed;
         m_rootFolder = rootFolder;
         m_translatedFiles.clear();
         if (!m_isAltUIUsed)
-            LogMsg(tr("Using built-in Web UI."));
+            LogMsg(tr("Using built-in WebUI."));
         else
-            LogMsg(tr("Using custom Web UI. Location: \"%1\".").arg(m_rootFolder.toString()));
+            LogMsg(tr("Using custom WebUI. Location: \"%1\".").arg(m_rootFolder.toString()));
     }
 
     const QString newLocale = pref->getLocale();
@@ -400,27 +400,27 @@ void WebApplication::configure()
         m_translationFileLoaded = m_translator.load((m_rootFolder / Path(u"translations/webui_"_s) + newLocale).data());
         if (m_translationFileLoaded)
         {
-            LogMsg(tr("Web UI translation for selected locale (%1) has been successfully loaded.")
+            LogMsg(tr("WebUI translation for selected locale (%1) has been successfully loaded.")
                    .arg(newLocale));
         }
         else
         {
-            LogMsg(tr("Couldn't load Web UI translation for selected locale (%1).").arg(newLocale), Log::WARNING);
+            LogMsg(tr("Couldn't load WebUI translation for selected locale (%1).").arg(newLocale), Log::WARNING);
         }
     }
 
-    m_isLocalAuthEnabled = pref->isWebUiLocalAuthEnabled();
-    m_isAuthSubnetWhitelistEnabled = pref->isWebUiAuthSubnetWhitelistEnabled();
-    m_authSubnetWhitelist = pref->getWebUiAuthSubnetWhitelist();
+    m_isLocalAuthEnabled = pref->isWebUILocalAuthEnabled();
+    m_isAuthSubnetWhitelistEnabled = pref->isWebUIAuthSubnetWhitelistEnabled();
+    m_authSubnetWhitelist = pref->getWebUIAuthSubnetWhitelist();
     m_sessionTimeout = pref->getWebUISessionTimeout();
 
     m_domainList = pref->getServerDomains().split(u';', Qt::SkipEmptyParts);
     std::for_each(m_domainList.begin(), m_domainList.end(), [](QString &entry) { entry = entry.trimmed(); });
 
-    m_isCSRFProtectionEnabled = pref->isWebUiCSRFProtectionEnabled();
-    m_isSecureCookieEnabled = pref->isWebUiSecureCookieEnabled();
+    m_isCSRFProtectionEnabled = pref->isWebUICSRFProtectionEnabled();
+    m_isSecureCookieEnabled = pref->isWebUISecureCookieEnabled();
     m_isHostHeaderValidationEnabled = pref->isWebUIHostHeaderValidationEnabled();
-    m_isHttpsEnabled = pref->isWebUiHttpsEnabled();
+    m_isHttpsEnabled = pref->isWebUIHttpsEnabled();
 
     m_prebuiltHeaders.clear();
     m_prebuiltHeaders.push_back({Http::HEADER_X_XSS_PROTECTION, u"1; mode=block"_s});
@@ -432,7 +432,7 @@ void WebApplication::configure()
         m_prebuiltHeaders.push_back({Http::HEADER_REFERRER_POLICY, u"same-origin"_s});
     }
 
-    const bool isClickjackingProtectionEnabled = pref->isWebUiClickjackingProtectionEnabled();
+    const bool isClickjackingProtectionEnabled = pref->isWebUIClickjackingProtectionEnabled();
     if (isClickjackingProtectionEnabled)
         m_prebuiltHeaders.push_back({Http::HEADER_X_FRAME_OPTIONS, u"SAMEORIGIN"_s});
 

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -290,6 +290,16 @@ const Http::Environment &WebApplication::env() const
     return m_env;
 }
 
+void WebApplication::setUsername(const QString &username)
+{
+    m_authController->setUsername(username);
+}
+
+void WebApplication::setPasswordHash(const QByteArray &passwordHash)
+{
+    m_authController->setPasswordHash(passwordHash);
+}
+
 void WebApplication::doProcessRequest()
 {
     const QRegularExpressionMatch match = m_apiPathPattern.match(request().path);

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -105,6 +105,9 @@ public:
     const Http::Request &request() const;
     const Http::Environment &env() const;
 
+    void setUsername(const QString &username);
+    void setPasswordHash(const QByteArray &passwordHash);
+
 private:
     QString clientId() const override;
     WebSession *session() override;

--- a/src/webui/webui.cpp
+++ b/src/webui/webui.cpp
@@ -52,8 +52,8 @@ void WebUI::configure()
 
     const QString portForwardingProfile = u"webui"_s;
     const Preferences *pref = Preferences::instance();
-    const quint16 port = pref->getWebUiPort();
-    m_isEnabled = pref->isWebUiEnabled();
+    const quint16 port = pref->getWebUIPort();
+    m_isEnabled = pref->isWebUIEnabled();
 
     if (m_isEnabled)
     {
@@ -69,7 +69,7 @@ void WebUI::configure()
         }
 
         // http server
-        const QString serverAddressString = pref->getWebUiAddress();
+        const QString serverAddressString = pref->getWebUIAddress();
         const auto serverAddress = ((serverAddressString == u"*") || serverAddressString.isEmpty())
             ? QHostAddress::Any : QHostAddress(serverAddressString);
 
@@ -84,7 +84,7 @@ void WebUI::configure()
                 m_httpServer->close();
         }
 
-        if (pref->isWebUiHttpsEnabled())
+        if (pref->isWebUIHttpsEnabled())
         {
             const auto readData = [](const Path &path) -> QByteArray
             {
@@ -96,9 +96,9 @@ void WebUI::configure()
 
             const bool success = m_httpServer->setupHttps(cert, key);
             if (success)
-                LogMsg(tr("Web UI: HTTPS setup successful"));
+                LogMsg(tr("WebUI: HTTPS setup successful"));
             else
-                LogMsg(tr("Web UI: HTTPS setup failed, fallback to HTTP"), Log::CRITICAL);
+                LogMsg(tr("WebUI: HTTPS setup failed, fallback to HTTP"), Log::CRITICAL);
         }
         else
         {
@@ -110,11 +110,11 @@ void WebUI::configure()
             const bool success = m_httpServer->listen(serverAddress, port);
             if (success)
             {
-                LogMsg(tr("Web UI: Now listening on IP: %1, port: %2").arg(serverAddressString).arg(port));
+                LogMsg(tr("WebUI: Now listening on IP: %1, port: %2").arg(serverAddressString).arg(port));
             }
             else
             {
-                m_errorMsg = tr("Web UI: Unable to bind to IP: %1, port: %2. Reason: %3")
+                m_errorMsg = tr("WebUI: Unable to bind to IP: %1, port: %2. Reason: %3")
                     .arg(serverAddressString).arg(port).arg(m_httpServer->errorString());
                 LogMsg(m_errorMsg, Log::CRITICAL);
                 qCritical() << m_errorMsg;

--- a/src/webui/webui.h
+++ b/src/webui/webui.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2015, 2023  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -52,7 +52,7 @@ class WebUI final : public ApplicationComponent<QObject>
     Q_DISABLE_COPY_MOVE(WebUI)
 
 public:
-    explicit WebUI(IApplication *app);
+    explicit WebUI(IApplication *app, const QByteArray &tempPasswordHash = {});
 
     bool isEnabled() const;
     bool isErrored() const;
@@ -68,10 +68,14 @@ private slots:
     void configure();
 
 private:
+    void setError(const QString &message);
+
     bool m_isEnabled = false;
     bool m_isErrored = false;
     QString m_errorMsg;
     QPointer<Http::Server> m_httpServer;
     QPointer<Net::DNSUpdater> m_dnsUpdater;
     QPointer<WebApplication> m_webapp;
+
+    QByteArray m_passwordHash;
 };


### PR DESCRIPTION
This is how it is supposed to behave:
1. WebUI is still disabled by default for regular build and enabled for no-GUI one.
2. There are no default credentials for now (default username "admin" is still supported). no-GUI build uses temporary auto generated password until user sets custom one. Existing regular installations that had enabled WebUI with default credentials will fail to start WebUI until user sets custom password.

Note that credentials explicitly set to "admin:adminadmin" are considered as valid.