### PR TITLE
WebUI: Fix duplicate scrollbar on Transfer List

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -112,7 +112,7 @@ window.qBittorrent.DynamicTable = (function() {
                     let n = 2;
 
                     // is panel vertical scrollbar visible or does panel content not fit?
-                    while ((panel.clientWidth != panel.offsetWidth || panel.clientHeight != panel.scrollHeight) && n > 0) {
+                    while (((panel.clientWidth != panel.offsetWidth) || (panel.clientHeight != panel.scrollHeight)) && (n > 0)) {
                         --n;
                         h -= 0.5;
                         $(this.dynamicTableDivId).style.height = h + 'px';

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -111,7 +111,8 @@ window.qBittorrent.DynamicTable = (function() {
 
                     let n = 2;
 
-                    while (panel.clientWidth != panel.offsetWidth && n > 0) { // is panel vertical scrollbar visible ?
+                    // is panel vertical scrollbar visible or does panel content not fit?
+                    while ((panel.clientWidth != panel.offsetWidth || panel.clientHeight != panel.scrollHeight) && n > 0) {
                         --n;
                         h -= 0.5;
                         $(this.dynamicTableDivId).style.height = h + 'px';


### PR DESCRIPTION
The overlay scrollbars [introduced](https://www.mozilla.org/en-US/firefox/100.0/releasenotes/#note-789043) in Firefox 100 take up no space, breaking the existing overflow detection. This may result in a second, defunct vertical scrollbar inside the Transfer List Panel with a travel of only 1px.
Add an extra check for scrollHeight != clientHeight which is able to detect an overflow independent of scrollbar style ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight)).

Before:
![master_scrollbar](https://github.com/qbittorrent/qBittorrent/assets/27744962/b307d34b-d840-4e9e-9678-607c5fa13805)

After:
![patch-1_no-scrollbar](https://github.com/qbittorrent/qBittorrent/assets/27744962/f839b879-d42f-42e8-9b10-b6253f3b69cf)
