### PR TITLE
Code clean ups

### DIFF
--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -77,11 +77,12 @@ jobs:
             --recurse-submodules `
             https://github.com/arvidn/libtorrent.git
           cd libtorrent
+          $env:CXXFLAGS+=" /guard:cf"
+          $env:LDFLAGS+=" /guard:cf"
           cmake `
             -B build `
             -G "Ninja" `
             -DCMAKE_BUILD_TYPE=RelWithDebInfo `
-            -DCMAKE_CXX_FLAGS=/guard:cf `
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON `
             -DCMAKE_INSTALL_PREFIX="${{ env.libtorrent_path }}" `
             -DCMAKE_TOOLCHAIN_FILE="${{ env.RUNVCPKG_VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake" `
@@ -95,11 +96,11 @@ jobs:
 
       - name: Build qBittorrent
         run: |
+          $env:CXXFLAGS+=" /WX"
           cmake `
             -B build `
             -G "Ninja" `
             -DCMAKE_BUILD_TYPE=RelWithDebInfo `
-            -DCMAKE_CXX_FLAGS="/WX" `
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON `
             -DCMAKE_TOOLCHAIN_FILE="${{ env.RUNVCPKG_VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake" `
             -DBOOST_ROOT="${{ env.boost_path }}" `

--- a/cmake/Modules/CommonConfig.cmake
+++ b/cmake/Modules/CommonConfig.cmake
@@ -38,9 +38,9 @@ endif()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     target_compile_definitions(qbt_common_cfg INTERFACE
-        NTDDI_VERSION=0x06010000
-        _WIN32_WINNT=0x0601
-        _WIN32_IE=0x0601
+        NTDDI_VERSION=0x0A000006
+        _WIN32_WINNT=0x0A00
+        _WIN32_IE=0x0A00
         WIN32_LEAN_AND_MEAN
         NOMINMAX
         UNICODE

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -451,7 +451,7 @@ QString Utils::Misc::languageToLocalizedString(const QString &localeStr)
     case QLocale::Byelorussian: return C_LOCALE_BYELORUSSIAN;
     case QLocale::Catalan: return C_LOCALE_CATALAN;
     case QLocale::Chinese:
-        switch (locale.country())
+        switch (locale.territory())
         {
         case QLocale::China: return C_LOCALE_CHINESE_SIMPLIFIED;
         case QLocale::HongKong: return C_LOCALE_CHINESE_TRADITIONAL_HK;
@@ -462,7 +462,7 @@ QString Utils::Misc::languageToLocalizedString(const QString &localeStr)
     case QLocale::Danish: return C_LOCALE_DANISH;
     case QLocale::Dutch: return C_LOCALE_DUTCH;
     case QLocale::English:
-        switch (locale.country())
+        switch (locale.territory())
         {
         case QLocale::Australia: return C_LOCALE_ENGLISH_AUSTRALIA;
         case QLocale::UnitedKingdom: return C_LOCALE_ENGLISH_UNITEDKINGDOM;
@@ -492,7 +492,7 @@ QString Utils::Misc::languageToLocalizedString(const QString &localeStr)
     case QLocale::Persian: return C_LOCALE_PERSIAN;
     case QLocale::Polish: return C_LOCALE_POLISH;
     case QLocale::Portuguese:
-        if (locale.country() == QLocale::Brazil)
+        if (locale.territory() == QLocale::Brazil)
             return C_LOCALE_PORTUGUESE_BRAZIL;
         return C_LOCALE_PORTUGUESE;
     case QLocale::Romanian: return C_LOCALE_ROMANIAN;

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1914,9 +1914,7 @@ void MainWindow::installPython()
     setCursor(QCursor(Qt::WaitCursor));
     // Download python
 #ifdef QBT_APP_64BIT
-    const auto installerURL = ::IsWindows8OrGreater()
-        ? u"https://www.python.org/ftp/python/3.10.11/python-3.10.11-amd64.exe"_s
-        : u"https://www.python.org/ftp/python/3.8.10/python-3.8.10-amd64.exe"_s;
+    const auto installerURL = u"https://www.python.org/ftp/python/3.10.11/python-3.10.11-amd64.exe"_s;
 #else
     const auto installerURL = ::IsWindows8OrGreater()
         ? u"https://www.python.org/ftp/python/3.10.11/python-3.10.11.exe"_s

--- a/src/gui/programupdater.cpp
+++ b/src/gui/programupdater.cpp
@@ -30,20 +30,10 @@
 #include "programupdater.h"
 
 #include <QtSystemDetection>
-
-#if defined(Q_OS_WIN)
-#include <windows.h>
-#include <versionhelpers.h>  // must follow after windows.h
-#endif
-
 #include <QDebug>
 #include <QDesktopServices>
 #include <QRegularExpression>
 #include <QXmlStreamReader>
-
-#if defined(Q_OS_WIN)
-#include <QSysInfo>
-#endif
 
 #include "base/global.h"
 #include "base/net/downloadmanager.h"
@@ -110,9 +100,7 @@ void ProgramUpdater::rssDownloadFinished(const Net::DownloadResult &result)
 #ifdef Q_OS_MACOS
     const QString OS_TYPE = u"Mac OS X"_s;
 #elif defined(Q_OS_WIN)
-    const QString OS_TYPE = (::IsWindows7OrGreater() && QSysInfo::currentCpuArchitecture().endsWith(u"64"))
-        ? u"Windows x64"_s
-        : u"Windows"_s;
+    const QString OS_TYPE = u"Windows x64"_s;
 #endif
 
     bool inItem = false;

--- a/src/qbittorrent.exe.manifest
+++ b/src/qbittorrent.exe.manifest
@@ -24,13 +24,7 @@
   <!-- Declare support for various versions of Windows -->
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
       <application>
-          <!-- Windows 7 -->
-          <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
-          <!-- Windows 8 -->
-          <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
-          <!-- Windows 8.1 -->
-          <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
-          <!-- Windows 10 -->
+          <!-- Windows 10 and Windows 11 -->
           <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
       </application>
   </compatibility>


### PR DESCRIPTION
* Migrate away from deprecated functions
* Drop unsupported keys
* Bump Windows macro versions
* GHA CI: don't override cmake default CXXFLAGS
