### PR TITLE
Add support for quarantine on macOS

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -205,9 +205,9 @@ target_link_libraries(qbt_base
 )
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    find_library(IOKit_LIBRARY IOKit)
-    find_library(Carbon_LIBRARY Carbon)
     find_library(AppKit_LIBRARY AppKit)
+    find_library(Carbon_LIBRARY Carbon)
+    find_library(IOKit_LIBRARY IOKit)
 
     target_link_libraries(qbt_base PRIVATE
         ${AppKit_LIBRARY}

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -68,9 +68,9 @@
 #include "peerinfo.h"
 #include "sessionimpl.h"
 
-#ifdef Q_OS_WIN
+#if defined(Q_OS_MACOS) || defined(Q_OS_WIN)
 #include "base/utils/misc.h"
-#endif
+#endif // Q_OS_MACOS || Q_OS_WIN
 
 using namespace BitTorrent;
 
@@ -2200,14 +2200,14 @@ void TorrentImpl::handleFileCompletedAlert(const lt::file_completed_alert *p)
 
     const Path actualPath = actualFilePath(fileIndex);
 
-#ifdef Q_OS_WIN
+#if defined(Q_OS_MACOS) || defined(Q_OS_WIN)
     // only apply Mark-of-the-Web to new download files
     if (isDownloading())
     {
         const Path fullpath = actualStorageLocation() / actualPath;
         Utils::Misc::applyMarkOfTheWeb(fullpath);
     }
-#endif
+#endif // Q_OS_MACOS || Q_OS_WIN
 
     if (m_session->isAppendExtensionEnabled())
     {

--- a/src/base/net/downloadhandlerimpl.cpp
+++ b/src/base/net/downloadhandlerimpl.cpp
@@ -150,9 +150,9 @@ void Net::DownloadHandlerImpl::processFinishedDownload()
             {
                 m_result.filePath = result.value();
 
-#ifdef Q_OS_WIN
+#if defined(Q_OS_MACOS) || defined(Q_OS_WIN)
                 Utils::Misc::applyMarkOfTheWeb(m_result.filePath, m_result.url);
-#endif
+#endif // Q_OS_MACOS || Q_OS_WIN
             }
             else
             {
@@ -166,9 +166,9 @@ void Net::DownloadHandlerImpl::processFinishedDownload()
             {
                 m_result.filePath = destinationPath;
 
-#ifdef Q_OS_WIN
+#if defined(Q_OS_MACOS) || defined(Q_OS_WIN)
                 Utils::Misc::applyMarkOfTheWeb(m_result.filePath, m_result.url);
-#endif
+#endif // Q_OS_MACOS || Q_OS_WIN
             }
             else
             {

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -622,6 +622,8 @@ QString Utils::Misc::zlibVersionString()
 #ifdef Q_OS_WIN
 bool Utils::Misc::applyMarkOfTheWeb(const Path &file, const QString &url)
 {
+    Q_ASSERT(url.isEmpty() || url.startsWith(u"http:") || url.startsWith(u"https:"));
+
     const QString zoneIDStream = file.toString() + u":Zone.Identifier";
     HANDLE handle = ::CreateFileW(zoneIDStream.toStdWString().c_str(), GENERIC_WRITE
         , (FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE)
@@ -631,8 +633,9 @@ bool Utils::Misc::applyMarkOfTheWeb(const Path &file, const QString &url)
 
     // 5.6.1 Zone.Identifier Stream Name
     // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/6e3f7352-d11c-4d76-8c39-2516a9df36e8
+    const QString hostURL = !url.isEmpty() ? url : u"about:internet"_s;
     const QByteArray zoneID = QByteArrayLiteral("[ZoneTransfer]\r\nZoneId=3\r\n")
-        + (!url.isEmpty() ? u"HostUrl=%1\r\n"_s.arg(url).toUtf8() : QByteArray());
+        + u"HostUrl=%1\r\n"_s.arg(hostURL).toUtf8();
 
     DWORD written = 0;
     const BOOL writeResult = ::WriteFile(handle, zoneID.constData(), zoneID.size(), &written, nullptr);

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -95,7 +95,6 @@ namespace Utils::Misc
     QString languageToLocalizedString(const QString &localeStr);
 
 #ifdef Q_OS_WIN
-    bool applyMarkOfTheWeb(const Path &file, const QString &url = {});
     Path windowsSystemPath();
 
     template <typename T>
@@ -105,4 +104,8 @@ namespace Utils::Misc
         return reinterpret_cast<T>(::GetProcAddress(::LoadLibraryW(path.c_str()), funcName));
     }
 #endif // Q_OS_WIN
+
+#if defined(Q_OS_MACOS) || defined(Q_OS_WIN)
+    bool applyMarkOfTheWeb(const Path &file, const QString &url = {});
+#endif // Q_OS_MACOS || Q_OS_WIN
 }


### PR DESCRIPTION
* Use proper fallback value for Mark-of-the-Web URL
  References:
  https://chromium.googlesource.com/chromium/src.git/+/refs/heads/main/components/services/quarantine/quarantine_win.cc#211
  https://hg.mozilla.org/mozilla-central/file/bd568ad893882d37f094d43cba3f62c78982cd05/toolkit/components/downloads/DownloadIntegration.sys.mjs#l537
* Add support for quarantine on macOS

['Quarantine'](https://iboysoft.com/news/com-apple-quarantine.html) is macOS terminology for [mark-of-the-web](https://textslashplain.com/2016/04/04/downloads-and-the-mark-of-the-web/).

ps. I have tested it and verify that it works.
pps. I plan to provide ui options to enable/disable it in a later PR.