### PR TITLE
Add missing Window icon

### DIFF
--- a/src/icons/icons.qrc
+++ b/src/icons/icons.qrc
@@ -327,6 +327,7 @@
         <file>qbittorrent-tray-dark.svg</file>
         <file>qbittorrent-tray-light.svg</file>
         <file>qbittorrent-tray.svg</file>
+        <file alias="qbittorrent.svg">qbittorrent-tray.svg</file>
         <file>queued.svg</file>
         <file>ratio.svg</file>
         <file>reannounce.svg</file>


### PR DESCRIPTION
Window icon isn't showing if "Use icons from system theme" setting is disabled.
This is how it looks in Lubuntu 22.04 / 23.10 for qBittorrent from sources/repo/AppImage:

![1](https://github.com/qbittorrent/qBittorrent/assets/9927685/cfee55f0-7cbc-4451-96a6-6d0474084324)

![2](https://github.com/qbittorrent/qBittorrent/assets/9927685/6d301e2f-5f6d-4089-9995-07a3ce194f5c)

~~The proposed patch uses "qbittorrent-tray" icon because there is no "qbittorrent" icon in the UI Theme.~~
Perhaps a better solution is possible.