### PR TITLE
Use appropriate icon for "moving" torrents in transfer list

### DIFF
--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -117,6 +117,7 @@ TransferListModel::TransferListModel(QObject *parent)
     , m_completedIcon {UIThemeManager::instance()->getIcon(u"checked-completed"_s, u"completed"_s)}
     , m_downloadingIcon {UIThemeManager::instance()->getIcon(u"downloading"_s)}
     , m_errorIcon {UIThemeManager::instance()->getIcon(u"error"_s)}
+    , m_movingIcon {UIThemeManager::instance()->getIcon(u"set-location"_s)}
     , m_pausedIcon {UIThemeManager::instance()->getIcon(u"stopped"_s, u"media-playback-pause"_s)}
     , m_queuedIcon {UIThemeManager::instance()->getIcon(u"queued"_s)}
     , m_stalledDLIcon {UIThemeManager::instance()->getIcon(u"stalledDL"_s)}
@@ -724,8 +725,9 @@ QIcon TransferListModel::getIconByState(const BitTorrent::TorrentState state) co
     case BitTorrent::TorrentState::CheckingDownloading:
     case BitTorrent::TorrentState::CheckingUploading:
     case BitTorrent::TorrentState::CheckingResumeData:
-    case BitTorrent::TorrentState::Moving:
         return m_checkingIcon;
+    case BitTorrent::TorrentState::Moving:
+        return m_movingIcon;
     case BitTorrent::TorrentState::Unknown:
     case BitTorrent::TorrentState::MissingFiles:
     case BitTorrent::TorrentState::Error:

--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -138,6 +138,7 @@ private:
     QIcon m_completedIcon;
     QIcon m_downloadingIcon;
     QIcon m_errorIcon;
+    QIcon m_movingIcon;
     QIcon m_pausedIcon;
     QIcon m_queuedIcon;
     QIcon m_stalledDLIcon;

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1003,9 +1003,12 @@ window.qBittorrent.DynamicTable = (function() {
                     case "checkingUP":
                     case "queuedForChecking":
                     case "checkingResumeData":
-                    case "moving":
                         state = "force-recheck";
                         img_path = "images/force-recheck.svg";
+                        break;
+                    case "moving":
+                        state = "moving";
+                        img_path = "images/set-location.svg";
                         break;
                     case "error":
                     case "unknown":


### PR DESCRIPTION
Before this PR, "checking/moving" shared the same icon in `transferlist`.

#### GUI: Before
![Screenshot 2023-10-29 123634](https://github.com/qbittorrent/qBittorrent/assets/42386382/59fee4f3-d3cc-4222-ab8e-aa07771f739b)

#### GUI - After:
![Screenshot 2023-10-29 125925](https://github.com/qbittorrent/qBittorrent/assets/42386382/32886a0e-2ca2-48ac-8ca3-54ec9dc6581b)
____

#### WebUI - Before:
![Screenshot 2023-10-29 123737](https://github.com/qbittorrent/qBittorrent/assets/42386382/5410a547-71b4-4674-9586-0ff76712d906)

#### WebUI - After:
![Screenshot 2023-10-29 130010](https://github.com/qbittorrent/qBittorrent/assets/42386382/b0497497-3266-42fc-8a9c-899fdb80492b)