### PR TITLE
Fix .torrent file upload on iPadOS

### DIFF
--- a/src/webui/www/private/upload.html
+++ b/src/webui/www/private/upload.html
@@ -167,7 +167,7 @@
                 window.parent.closeWindows();
         });
 
-        if (Browser.platform === 'ios') {
+        if (Browser.platform === 'ios' || (Browser.platform === 'mac' && navigator.maxTouchPoints > 1)) {
             $('fileselect').accept = ".torrent";
         }
     </script>

--- a/src/webui/www/private/upload.html
+++ b/src/webui/www/private/upload.html
@@ -167,7 +167,7 @@
                 window.parent.closeWindows();
         });
 
-        if (Browser.platform === 'ios' || (Browser.platform === 'mac' && navigator.maxTouchPoints > 1)) {
+        if ((Browser.platform === 'ios') || ((Browser.platform === 'mac') && (navigator.maxTouchPoints > 1))) {
             $('fileselect').accept = ".torrent";
         }
     </script>


### PR DESCRIPTION
Mobile Safari on iOS does report `ios` platform, but iPadOS reports `mac` instead. It is common sense to check for touch points when this happens to differentiate Mac and iPad.

Closes #19057.