### PR TITLE
Add copy comment functionality to the torrent list's context menu

### DIFF
--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -574,6 +574,18 @@ void TransferListWidget::copySelectedIDs() const
     qApp->clipboard()->setText(torrentIDs.join(u'\n'));
 }
 
+void TransferListWidget::copySelectedComments() const
+{
+    QStringList torrentComments;
+    for (const BitTorrent::Torrent *torrent : asConst(getSelectedTorrents()))
+    {
+        if (!torrent->comment().isEmpty())
+            torrentComments << torrent->comment();
+    }
+
+    qApp->clipboard()->setText(torrentComments.join(u"\n---------\n"_s));
+}
+
 void TransferListWidget::hideQueuePosColumn(bool hide)
 {
     setColumnHidden(TransferListModel::TR_QUEUE_POSITION, hide);
@@ -986,6 +998,8 @@ void TransferListWidget::displayListMenu()
     connect(actionCopyMagnetLink, &QAction::triggered, this, &TransferListWidget::copySelectedMagnetURIs);
     auto *actionCopyID = new QAction(UIThemeManager::instance()->getIcon(u"help-about"_s, u"edit-copy"_s), tr("Torrent &ID"), listMenu);
     connect(actionCopyID, &QAction::triggered, this, &TransferListWidget::copySelectedIDs);
+    auto *actionCopyComment = new QAction(UIThemeManager::instance()->getIcon(u"edit-copy"_s), tr("&Comment"), listMenu);
+    connect(actionCopyComment, &QAction::triggered, this, &TransferListWidget::copySelectedComments);
     auto *actionCopyName = new QAction(UIThemeManager::instance()->getIcon(u"name"_s, u"edit-copy"_s), tr("&Name"), listMenu);
     connect(actionCopyName, &QAction::triggered, this, &TransferListWidget::copySelectedNames);
     auto *actionCopyHash1 = new QAction(UIThemeManager::instance()->getIcon(u"hash"_s, u"edit-copy"_s), tr("Info &hash v1"), listMenu);
@@ -1277,6 +1291,7 @@ void TransferListWidget::displayListMenu()
     actionCopyHash2->setEnabled(hasInfohashV2);
     copySubMenu->addAction(actionCopyMagnetLink);
     copySubMenu->addAction(actionCopyID);
+    copySubMenu->addAction(actionCopyComment);
 
     actionExportTorrent->setToolTip(tr("Exported torrent is not necessarily the same as the imported"));
     listMenu->addAction(actionExportTorrent);

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -86,6 +86,7 @@ public slots:
     void copySelectedNames() const;
     void copySelectedInfohashes(CopyInfohashPolicy policy) const;
     void copySelectedIDs() const;
+    void copySelectedComments() const;
     void openSelectedTorrentsFolder() const;
     void recheckSelectedTorrents();
     void reannounceSelectedTorrents();

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -160,6 +160,7 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         {KEY_TORRENT_LAST_ACTIVITY_TIME, getLastActivityTime()},
         {KEY_TORRENT_AVAILABILITY, torrent.distributedCopies()},
         {KEY_TORRENT_REANNOUNCE, torrent.nextAnnounce()},
+        {KEY_TORRENT_COMMENT, torrent.comment()},
 
         {KEY_TORRENT_TOTAL_SIZE, torrent.totalSize()}
     };

--- a/src/webui/api/serialize/serialize_torrent.h
+++ b/src/webui/api/serialize/serialize_torrent.h
@@ -91,5 +91,6 @@ inline const QString KEY_TORRENT_TIME_ACTIVE = u"time_active"_s;
 inline const QString KEY_TORRENT_SEEDING_TIME = u"seeding_time"_s;
 inline const QString KEY_TORRENT_AVAILABILITY = u"availability"_s;
 inline const QString KEY_TORRENT_REANNOUNCE = u"reannounce"_s;
+inline const QString KEY_TORRENT_COMMENT = u"comment"_s;
 
 QVariantMap serialize(const BitTorrent::Torrent &torrent);

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -52,7 +52,7 @@
 #include "base/utils/version.h"
 #include "api/isessionmanager.h"
 
-inline const Utils::Version<3, 2> API_VERSION {2, 10, 0};
+inline const Utils::Version<3, 2> API_VERSION {2, 10, 1};
 
 class APIController;
 class AuthController;

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -180,6 +180,7 @@
                 <li><a href="#" id="copyInfohash2" class="copyToClipboard"><img src="images/hash.svg" alt="QBT_TR(Info hash v2)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Info hash v2)QBT_TR[CONTEXT=TransferListWidget]</a></li>
                 <li><a href="#" id="copyMagnetLink" class="copyToClipboard"><img src="images/torrent-magnet.svg" alt="QBT_TR(Magnet link)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Magnet link)QBT_TR[CONTEXT=TransferListWidget]</a></li>
                 <li><a href="#" id="copyID" class="copyToClipboard"><img src="images/help-about.svg" alt="QBT_TR(Torrent ID)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Torrent ID)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+                <li><a href="#" id="copyComment" class="copyToClipboard"><img src="images/edit-copy.svg" alt="QBT_TR(Comment)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Comment)QBT_TR[CONTEXT=TransferListWidget]</a></li>
             </ul>
         </li>
         <li>

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -1526,6 +1526,8 @@ function setupCopyEventHandler() {
                     return copyMagnetLinkFN();
                 case "copyID":
                     return copyIdFN();
+                case "copyComment":
+                    return copyCommentFN();
                 default:
                     return "";
             }

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -89,6 +89,7 @@ let copyNameFN = function() {};
 let copyInfohashFN = function(policy) {};
 let copyMagnetLinkFN = function() {};
 let copyIdFN = function() {};
+let copyCommentFN = function() {};
 let setQueuePositionFN = function() {};
 let exportTorrentFN = function() {};
 
@@ -1003,6 +1004,21 @@ const initializeWindows = function() {
 
     copyIdFN = function() {
         return torrentsTable.selectedRowsIds().join("\n");
+    };
+
+    copyCommentFN = function() {
+        const selectedRows = torrentsTable.selectedRowsIds();
+        const comments = [];
+        if (selectedRows.length > 0) {
+            const rows = torrentsTable.getFilteredAndSortedRows();
+            for (let i = 0; i < selectedRows.length; ++i) {
+                const hash = selectedRows[i];
+                const comment = rows[hash].full_data.comment;
+                if (comment && (comment !== ""))
+                    comments.push(comment);
+            }
+        }
+        return comments.join("\n---------\n");
     };
 
     exportTorrentFN = async function() {


### PR DESCRIPTION
- Didn't know which icon to use so i used the same as the one for "Copy" menu item.
- Not sure what to do about WeAPI version.
- In WebUI i suppose it would be desirable to clear the clipboard before the copy in case there is something else there and no selected torrent has a comment but i couldn't figure out how to do that.

Closes #18890.

