### PR TITLE
GHA CI: speed up boost installation

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -52,9 +52,9 @@ jobs:
         run: |
           curl \
             -L \
-            -o "${{ runner.temp }}/boost.tar.bz2" \
-            "https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.bz2"
-          tar -xf "${{ runner.temp }}/boost.tar.bz2" -C "${{ github.workspace }}/.."
+            -o "${{ runner.temp }}/boost.tar.gz" \
+            "https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.gz"
+          tar -xf "${{ runner.temp }}/boost.tar.gz" -C "${{ github.workspace }}/.."
           mv "${{ github.workspace }}/.."/boost_* "${{ env.boost_path }}"
 
       - name: Install Qt

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -48,9 +48,9 @@ jobs:
         run: |
           curl \
             -L \
-            -o "${{ runner.temp }}/boost.tar.bz2" \
-            "https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2"
-          tar -xf "${{ runner.temp }}/boost.tar.bz2" -C "${{ github.workspace }}/.."
+            -o "${{ runner.temp }}/boost.tar.gz" \
+            "https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz"
+          tar -xf "${{ runner.temp }}/boost.tar.gz" -C "${{ github.workspace }}/.."
           mv "${{ github.workspace }}/.."/boost_* "${{ env.boost_path }}"
 
       - name: Install Qt

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -56,11 +56,11 @@ jobs:
 
       - name: Install boost
         run: |
-          aria2c `
-            "https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.7z" `
-            -d "${{ runner.temp }}" `
-            -o "boost.7z"
-          7z x "${{ runner.temp }}/boost.7z" -o"${{ github.workspace }}/.."
+          curl `
+            -L `
+            -o "${{ runner.temp }}/boost.tar.gz" `
+            "https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.gz"
+          tar -xf "${{ runner.temp }}/boost.tar.gz" -C "${{ github.workspace }}/.."
           move "${{ github.workspace }}/../boost_*" "${{ env.boost_path }}"
 
       - name: Install Qt


### PR DESCRIPTION
Here is some benchmark for various archive formats:
```
gz
  0m11.384s
  0m11.495s
  0m11.193s

zip
  0m14.159s
  0m14.416s
  0m13.917s

7z
  0m17.569s
  0m17.295s
  0m18.496s

bz2
  0m31.519s
  0m28.885s
  0m29.510s
```

Looking by compressed size, bz2 is the best. However its decompressing speed is the slowest. bz2 and gz file size only differs by ~20MB and this difference is neglectable given the network speed on Github. So switch to gz format to speed up CI build time.

<!--
MANDATORY Before submitting your work, make sure you have:
1. Read https://github.com/qbittorrent/qBittorrent/blob/master/CONTRIBUTING.md#opening-a-pull-request
2. Delete this comment block
-->
