### PR TITLE
Add option to enable previous Add new torrent dialog behavior

### DIFF
--- a/src/gui/addnewtorrentdialog.h
+++ b/src/gui/addnewtorrentdialog.h
@@ -74,6 +74,10 @@ public:
     static void setTopLevel(bool value);
     static int savePathHistoryLength();
     static void setSavePathHistoryLength(int value);
+#ifndef Q_OS_MACOS
+    static bool isAttached();
+    static void setAttached(bool value);
+#endif
 
     static void show(const QString &source, const BitTorrent::AddTorrentParams &inParams, QWidget *parent);
     static void show(const QString &source, QWidget *parent);

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -94,6 +94,7 @@ namespace
         ENABLE_SPEED_WIDGET,
 #ifndef Q_OS_MACOS
         ENABLE_ICONS_IN_MENUS,
+        USE_ATTACHED_ADD_NEW_TORRENT_DIALOG,
 #endif
         // embedded tracker
         TRACKER_STATUS,
@@ -310,6 +311,7 @@ void AdvancedSettings::saveAdvancedSettings() const
     pref->setSpeedWidgetEnabled(m_checkBoxSpeedWidgetEnabled.isChecked());
 #ifndef Q_OS_MACOS
     pref->setIconsInMenusEnabled(m_checkBoxIconsInMenusEnabled.isChecked());
+    AddNewTorrentDialog::setAttached(m_checkBoxAttachedAddNewTorrentDialog.isChecked());
 #endif
 
     // Tracker
@@ -796,6 +798,9 @@ void AdvancedSettings::loadAdvancedSettings()
     // Enable icons in menus
     m_checkBoxIconsInMenusEnabled.setChecked(pref->iconsInMenusEnabled());
     addRow(ENABLE_ICONS_IN_MENUS, tr("Enable icons in menus"), &m_checkBoxIconsInMenusEnabled);
+
+    m_checkBoxAttachedAddNewTorrentDialog.setChecked(AddNewTorrentDialog::isAttached());
+    addRow(USE_ATTACHED_ADD_NEW_TORRENT_DIALOG, tr("Attach \"Add new torrent\" dialog to main window"), &m_checkBoxAttachedAddNewTorrentDialog);
 #endif
     // Tracker State
     m_checkBoxTrackerStatus.setChecked(session->isTrackerEnabled());

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -102,6 +102,7 @@ private:
 
 #ifndef Q_OS_MACOS
     QCheckBox m_checkBoxIconsInMenusEnabled;
+    QCheckBox m_checkBoxAttachedAddNewTorrentDialog;
 #endif
 
 #ifdef QBT_USES_DBUS


### PR DESCRIPTION
Closes #19774.


![000](https://github.com/qbittorrent/qBittorrent/assets/5063477/a22f9adb-d79d-4cdf-8f40-a6a90e8532b6)

