### PR TITLE
WebUI: Remove extra ')' in QBT_TR macro

### DIFF
--- a/src/webui/www/private/rename_files.html
+++ b/src/webui/www/private/rename_files.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(Renaming))QBT_TR[CONTEXT=TorrentContentTreeView]</title>
+    <title>QBT_TR(Renaming)QBT_TR[CONTEXT=TorrentContentTreeView]</title>
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
     <script src="scripts/filesystem.js?v=${CACHEID}"></script>


### PR DESCRIPTION
Removed an extra `)` for `QBT_TR`