### PR TITLE
Set symbol visibility to hidden

### DIFF
--- a/cmake/Modules/CommonConfig.cmake
+++ b/cmake/Modules/CommonConfig.cmake
@@ -19,6 +19,9 @@ target_compile_features(qbt_common_cfg INTERFACE
     cxx_std_20
 )
 
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+
 target_compile_definitions(qbt_common_cfg INTERFACE
     QT_DISABLE_DEPRECATED_UP_TO=0x060500
     QT_NO_CAST_FROM_ASCII


### PR DESCRIPTION
This suppresses compiler warnings in GHA CI:
>ld: warning: direct access in function 'std::__1::__function::__func<libtorrent::storage_interface* (*)(libtorrent::storage_params const&, libtorrent::file_pool&), std::__1::allocator<libtorrent::storage_interface* (*)(libtorrent::storage_params const&, libtorrent::file_pool&)>, libtorrent::storage_interface* (libtorrent::storage_params const&, libtorrent::file_pool&)>::target(std::type_info const&) const' from file '/usr/local/lib/libtorrent-rasterbar.a(create_torrent.cpp.o)' to global weak symbol 'typeinfo name for libtorrent::storage_interface* (*)(libtorrent::storage_params const&, libtorrent::file_pool&)' from file 'src/base/libqbt_base.a(mocs_compilation.cpp.o)' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.

And also makes the binary a bit smaller.

https://gcc.gnu.org/onlinedocs/gcc-13.2.0/gcc/Code-Gen-Options.html#index-fvisibility

<!--
MANDATORY Before submitting your work, make sure you have:
1. Read https://github.com/qbittorrent/qBittorrent/blob/master/CONTRIBUTING.md#opening-a-pull-request
2. Delete this comment block
-->
