### PR TITLE
Revert "Set symbol visibility to hidden"

### DIFF
--- a/cmake/Modules/CommonConfig.cmake
+++ b/cmake/Modules/CommonConfig.cmake
@@ -19,9 +19,6 @@ target_compile_features(qbt_common_cfg INTERFACE
     cxx_std_20
 )
 
-set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
-
 target_compile_definitions(qbt_common_cfg INTERFACE
     QT_DISABLE_DEPRECATED_UP_TO=0x060500
     QT_NO_CAST_FROM_ASCII


### PR DESCRIPTION
This negatively affect stacktrace functionality.
This reverts commit 50680a3d9b2242b83e38094cefb6377dbfb4fd52.

Sorry about the noise.