### PR TITLE
Add timeouts to network requests

### DIFF
--- a/src/base/net/downloadmanager.cpp
+++ b/src/base/net/downloadmanager.cpp
@@ -299,6 +299,8 @@ void Net::DownloadManager::processRequest(DownloadHandlerImpl *downloadHandler)
     // Qt doesn't support Magnet protocol so we need to handle redirections manually
     request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::ManualRedirectPolicy);
 
+    request.setTransferTimeout();
+
     QNetworkReply *reply = m_networkManager->get(request);
     connect(reply, &QNetworkReply::finished, this, [this, downloadHandler]
     {


### PR DESCRIPTION
Otherwise, network requests may be in a pending state indefinitely if for some reason they cannot be executed (i.e. data cannot be transferred).