### PR TITLE
Follow the parent category options

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(qbt_base STATIC
     bittorrent/common.h
     bittorrent/customstorage.h
     bittorrent/dbresumedatastorage.h
+    bittorrent/downloadpathoption.h
     bittorrent/downloadpriority.h
     bittorrent/extensiondata.h
     bittorrent/filesearcher.h
@@ -118,6 +119,7 @@ add_library(qbt_base STATIC
     bittorrent/categoryoptions.cpp
     bittorrent/customstorage.cpp
     bittorrent/dbresumedatastorage.cpp
+    bittorrent/downloadpathoption.cpp
     bittorrent/downloadpriority.cpp
     bittorrent/filesearcher.cpp
     bittorrent/filterparserthread.cpp

--- a/src/base/bittorrent/categoryoptions.cpp
+++ b/src/base/bittorrent/categoryoptions.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2021  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2021-2023  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -65,12 +65,6 @@ QJsonObject BitTorrent::CategoryOptions::toJSON() const
         {OPTION_SAVEPATH, savePath.data()},
         {OPTION_DOWNLOADPATH, downloadPathValue}
     };
-}
-
-bool BitTorrent::operator==(const BitTorrent::CategoryOptions::DownloadPathOption &left, const BitTorrent::CategoryOptions::DownloadPathOption &right)
-{
-    return ((left.enabled == right.enabled)
-            && (left.path == right.path));
 }
 
 bool BitTorrent::operator==(const BitTorrent::CategoryOptions &left, const BitTorrent::CategoryOptions &right)

--- a/src/base/bittorrent/downloadpathoption.cpp
+++ b/src/base/bittorrent/downloadpathoption.cpp
@@ -26,27 +26,9 @@
  * exception statement from your version.
  */
 
-#pragma once
-
-#include <optional>
-
-#include <QString>
-
-#include "base/path.h"
 #include "downloadpathoption.h"
 
-class QJsonObject;
-
-namespace BitTorrent
+bool BitTorrent::operator==(const DownloadPathOption &left, const DownloadPathOption &right)
 {
-    struct CategoryOptions
-    {
-        Path savePath;
-        std::optional<DownloadPathOption> downloadPath;
-
-        static CategoryOptions fromJSON(const QJsonObject &jsonObj);
-        QJsonObject toJSON() const;
-    };
-
-    bool operator==(const CategoryOptions &left, const CategoryOptions &right);
+    return ((left.enabled == right.enabled) && (left.path == right.path));
 }

--- a/src/base/bittorrent/downloadpathoption.h
+++ b/src/base/bittorrent/downloadpathoption.h
@@ -28,25 +28,15 @@
 
 #pragma once
 
-#include <optional>
-
-#include <QString>
-
 #include "base/path.h"
-#include "downloadpathoption.h"
-
-class QJsonObject;
 
 namespace BitTorrent
 {
-    struct CategoryOptions
+    struct DownloadPathOption
     {
-        Path savePath;
-        std::optional<DownloadPathOption> downloadPath;
-
-        static CategoryOptions fromJSON(const QJsonObject &jsonObj);
-        QJsonObject toJSON() const;
+        bool enabled = false;
+        Path path;
     };
 
-    bool operator==(const CategoryOptions &left, const CategoryOptions &right);
+    bool operator==(const DownloadPathOption &left, const DownloadPathOption &right);
 }

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -155,13 +155,17 @@ namespace BitTorrent
         virtual void setDownloadPathEnabled(bool enabled) = 0;
 
         static bool isValidCategoryName(const QString &name);
+        static QString subcategoryName(const QString &category);
+        static QString parentCategoryName(const QString &category);
         // returns category itself and all top level categories
         static QStringList expandCategory(const QString &category);
 
         virtual QStringList categories() const = 0;
         virtual CategoryOptions categoryOptions(const QString &categoryName) const = 0;
         virtual Path categorySavePath(const QString &categoryName) const = 0;
+        virtual Path categorySavePath(const QString &categoryName, const CategoryOptions &options) const = 0;
         virtual Path categoryDownloadPath(const QString &categoryName) const = 0;
+        virtual Path categoryDownloadPath(const QString &categoryName, const CategoryOptions &options) const = 0;
         virtual bool addCategory(const QString &name, const CategoryOptions &options = {}) = 0;
         virtual bool editCategory(const QString &name, const CategoryOptions &options) = 0;
         virtual bool removeCategory(const QString &name) = 0;

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -142,7 +142,9 @@ namespace BitTorrent
         QStringList categories() const override;
         CategoryOptions categoryOptions(const QString &categoryName) const override;
         Path categorySavePath(const QString &categoryName) const override;
+        Path categorySavePath(const QString &categoryName, const CategoryOptions &options) const override;
         Path categoryDownloadPath(const QString &categoryName) const override;
+        Path categoryDownloadPath(const QString &categoryName, const CategoryOptions &options) const override;
         bool addCategory(const QString &name, const CategoryOptions &options = {}) override;
         bool editCategory(const QString &name, const CategoryOptions &options) override;
         bool removeCategory(const QString &name) override;
@@ -574,6 +576,7 @@ namespace BitTorrent
         void loadCategories();
         void storeCategories() const;
         void upgradeCategories();
+        DownloadPathOption resolveCategoryDownloadPathOption(const QString &categoryName, const std::optional<DownloadPathOption> &option) const;
 
         void saveStatistics() const;
         void loadStatistics();

--- a/src/gui/torrentcategorydialog.cpp
+++ b/src/gui/torrentcategorydialog.cpp
@@ -169,14 +169,13 @@ void TorrentCategoryDialog::setCategoryOptions(const BitTorrent::CategoryOptions
 
 void TorrentCategoryDialog::categoryNameChanged(const QString &categoryName)
 {
-    const Path categoryPath = Utils::Fs::toValidPath(categoryName);
     const auto *btSession = BitTorrent::Session::instance();
-    m_ui->comboSavePath->setPlaceholder(btSession->savePath() / categoryPath);
+    m_ui->comboSavePath->setPlaceholder(btSession->categorySavePath(categoryName, categoryOptions()));
 
     const int index = m_ui->comboUseDownloadPath->currentIndex();
-    const bool useDownloadPath = (index == 1) || ((index == 0) && BitTorrent::Session::instance()->isDownloadPathEnabled());
+    const bool useDownloadPath = (index == 1) || ((index == 0) && btSession->isDownloadPathEnabled());
     if (useDownloadPath)
-        m_ui->comboDownloadPath->setPlaceholder(btSession->downloadPath() / categoryPath);
+        m_ui->comboDownloadPath->setPlaceholder(btSession->categoryDownloadPath(categoryName, categoryOptions()));
 
     m_ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(!categoryName.isEmpty());
 }
@@ -190,8 +189,9 @@ void TorrentCategoryDialog::useDownloadPathChanged(const int index)
     m_ui->comboDownloadPath->setEnabled(index == 1);
     m_ui->comboDownloadPath->setSelectedPath((index == 1) ? m_lastEnteredDownloadPath : Path());
 
+    const auto *btSession = BitTorrent::Session::instance();
     const QString categoryName = m_ui->textCategoryName->text();
-    const Path categoryPath = BitTorrent::Session::instance()->downloadPath() / Utils::Fs::toValidPath(categoryName);
-    const bool useDownloadPath = (index == 1) || ((index == 0) && BitTorrent::Session::instance()->isDownloadPathEnabled());
+    const bool useDownloadPath = (index == 1) || ((index == 0) && btSession->isDownloadPathEnabled());
+    const Path categoryPath = btSession->categoryDownloadPath(categoryName, categoryOptions());
     m_ui->comboDownloadPath->setPlaceholder(useDownloadPath ? categoryPath : Path());
 }


### PR DESCRIPTION
Now (finally) subcategories are supposed to follow the options of parent categories when constructing implicitly defined save paths, etc.
Previously category `Music/Rock` used `<DefaultSavePath>/Music/Rock` (e.g. `D:\Torrents\Music\Rock`) path unless another one was explicitly set in its options.
Now it will use `<ParentSavePath>/Rock`, i.e. if `Music` has redefined save path, e.g. `D:\Music`, then `Music/Rock` will use `D:\Music\Rock`.

Closes #19941.