### PR TITLE
GHA CI improvements

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -46,6 +46,7 @@ jobs:
       - name: Setup ccache
         uses: Chocobo1/setup-ccache-action@v1
         with:
+          store_cache: ${{ startsWith(github.ref, 'refs/heads/') }}
           update_packager_index: false
 
       - name: Install boost

--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -63,6 +63,7 @@ jobs:
           version: ${{ matrix.qt_version }}
           archives: qtbase qtdeclarative qtsvg qttools
           # Not sure why Qt made a hard dependency on qtdeclarative, try removing it when Qt > 6.4.0
+          cache: true
 
       - name: Install libtorrent
         run: |

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -40,6 +40,7 @@ jobs:
       - name: Setup ccache
         uses: Chocobo1/setup-ccache-action@v1
         with:
+          store_cache: ${{ startsWith(github.ref, 'refs/heads/') }}
           update_packager_index: false
           ccache_options: |
             max_size=2G

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -58,6 +58,7 @@ jobs:
         with:
           version: ${{ matrix.qt_version }}
           archives: icu qtbase qtdeclarative qtsvg qttools
+          cache: true
 
       - name: Install libtorrent
         run: |

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -22,6 +22,7 @@ jobs:
     env:
       boost_path: "${{ github.workspace }}/../boost"
       libtorrent_path: "${{ github.workspace }}/libtorrent"
+      vpkg_triplet_path: "${{ github.workspace }}/../triplets_overlay"
 
     steps:
       - name: Checkout repository
@@ -47,16 +48,32 @@ jobs:
           vcpkgDirectory: C:/vcpkg
           doNotUpdateVcpkg: true  # the preinstalled vcpkg is updated regularly
 
-      - name: Install dependencies from vcpkg
+      - name: Install dependencies with vcpkg
         run: |
+          # create our own triplet
+          New-Item `
+            -Force `
+            -ItemType File `
+            -Path "${{ env.vpkg_triplet_path }}/x64-windows-static-md-release.cmake"
+          Add-Content `
+            -Path "${{ env.vpkg_triplet_path }}/x64-windows-static-md-release.cmake" `
+            -Value @("set(VCPKG_TARGET_ARCHITECTURE x64)",
+              "set(VCPKG_LIBRARY_LINKAGE static)",
+              "set(VCPKG_CRT_LINKAGE dynamic)",
+              "set(VCPKG_BUILD_TYPE release)",
+              "set(VCPKG_C_FLAGS /guard:cf)",
+              "set(VCPKG_CXX_FLAGS /guard:cf)",
+              "set(VCPKG_LINKER_FLAGS /guard:cf)")
           # clear buildtrees after each package installation to reduce disk space requirements
           $packages = `
-            "openssl:x64-windows-static-release",
-            "zlib:x64-windows-static-release"
+            "openssl:x64-windows-static-md-release",
+            "zlib:x64-windows-static-md-release"
           ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg.exe upgrade `
-            --no-dry-run
+            --no-dry-run `
+            --overlay-triplets="${{ env.vpkg_triplet_path }}"
           ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg.exe install `
             --clean-after-build `
+            --overlay-triplets="${{ env.vpkg_triplet_path }}" `
             $packages
 
       - name: Install boost
@@ -96,7 +113,7 @@ jobs:
             -DBUILD_SHARED_LIBS=OFF `
             -Ddeprecated-functions=OFF `
             -Dstatic_runtime=OFF `
-            -DVCPKG_TARGET_TRIPLET=x64-windows-static-release
+            -DVCPKG_TARGET_TRIPLET=x64-windows-static-md-release
           cmake --build build
           cmake --install build
 
@@ -113,7 +130,7 @@ jobs:
             -DLibtorrentRasterbar_DIR="${{ env.libtorrent_path }}/lib/cmake/LibtorrentRasterbar" `
             -DMSVC_RUNTIME_DYNAMIC=ON `
             -DTESTING=ON `
-            -DVCPKG_TARGET_TRIPLET=x64-windows-static-release `
+            -DVCPKG_TARGET_TRIPLET=x64-windows-static-md-release `
             -DVERBOSE_CONFIGURE=ON `
             --graphviz=build/target_graph.dot
           cmake --build build --target qbt_update_translations

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -32,7 +32,12 @@ jobs:
 
       - name: Install build tools
         run: |
-          choco install ninja
+          if ((Get-Command "ninja.exe" -ErrorAction SilentlyContinue) -eq $null)
+          {
+             choco install ninja
+          }
+          where.exe ninja
+          ninja --version
 
       # use the preinstalled vcpkg from image
       # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md#package-management

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -68,6 +68,7 @@ jobs:
         with:
           version: "6.5.2"
           archives: qtbase qtsvg qttools
+          cache: true
 
       - name: Install libtorrent
         run: |


### PR DESCRIPTION
* GHA CI: enable caching for Qt library
* GHA CI: only store compile cache on stable branches
  Given the amount of PR and compile matrix, the CI cache size limit is easy to hit. So for now on, only store compile cache for stable branches to avoid cache thrashing.
* GHA CI: use built-in ninja
  `choco install` is slow: A basically simple download and extract operation takes 20sec compared to ~3sec when done manually. So we add a conditional for it.
* GHA CI: link to C libraries dynamically
  The C libraries is now updated by the OS and therefore there is no reason to bundle static versions which might be outdated later. Also enable Control Flow Guard for 3rd party libraries.