### PR TITLE
Fix parent widget of "Lock qBittorrent" submenu

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -173,7 +173,7 @@ MainWindow::MainWindow(IGUIApplication *app, WindowState initialState)
     m_ui->menuLog->setIcon(UIThemeManager::instance()->getIcon(u"help-contents"_s));
     m_ui->actionCheckForUpdates->setIcon(UIThemeManager::instance()->getIcon(u"view-refresh"_s));
 
-    auto *lockMenu = new QMenu(this);
+    auto *lockMenu = new QMenu(m_ui->menuView);
     lockMenu->addAction(tr("&Set Password"), this, &MainWindow::defineUILockPassword);
     lockMenu->addAction(tr("&Clear Password"), this, &MainWindow::clearUILockPassword);
     m_ui->actionLock->setMenu(lockMenu);


### PR DESCRIPTION
The parent widget of lockMenu is going to be used to derive the transient parent window. Currently the parent widget of lockMenu is the main window, therefore the main window is also going to be the transient parent for lockMenu's window handle.

In other words, the "View" menu and "Lock qBittorrent" menu are going to be considered as siblings by the window manager even though the latter is nested inside the former.

On platforms like wayland, such popup hierarchies are illegal, popups must be properly nested. qtwayland works around it, but it also prints warning messages.

This change makes lockMenu a child of the view menu so they are properly nested from the window manager point of view.

Closes https://github.com/qbittorrent/qBittorrent/issues/19955.