### PR TITLE
Consider brackets within wildcard as regular characters

### DIFF
--- a/src/base/utils/string.cpp
+++ b/src/base/utils/string.cpp
@@ -51,7 +51,16 @@ QString Utils::String::fromDouble(const double n, const int precision)
 
 QString Utils::String::wildcardToRegexPattern(const QString &pattern)
 {
-    return QRegularExpression::wildcardToRegularExpression(pattern, QRegularExpression::UnanchoredWildcardConversion);
+    QString wildcard = QRegularExpression::escape(pattern);
+
+    // Replace "\?" (which has been regex-escaped above) with "."
+    wildcard.replace(u"\\?"_s, u"."_s);
+
+    // Replace "\*" (which has been regex-escaped above) with ".*"
+    // Consecutive wildcards are merged to avoid catastrophic backtracking
+    wildcard.replace(QRegularExpression(u"(?:\\\\\\*)+"_s), u".*"_s);
+
+    return wildcard;
 }
 
 QStringList Utils::String::splitCommand(const QString &command)


### PR DESCRIPTION
For context, in #4170 we added support for « ? » and « * » glob wildcards in search patterns. But a side-effect is that « [ » and « ] » also become special characters, which is rather unexcepted and undesirable.

This PR is a new attempt at #16965, which was broken and had to be reverted in #17820. I still don't know why #16965 was failing…

Here I'm taking a new approach: we fully regex-escape the provided pattern, then we replace `\?` and `\*` with `.` and `.*` respectively. This approach should be more robust, and is even simpler actually. See [this question on SO](https://stackoverflow.com/questions/77005094/escaping-characters-before-converting-a-wildcard-pattern-to-a-regular-expression) that led me to this approach.

I'm taking the opportunity to point out that at the time of #4170 (2015), only plaintext search was available, hence the need for these wildcards. In 2018 the powerful regex search has been added: #9255. Ideally, we should be able to choose between plaintext, wildcard and regex searches, see [this draft](https://github.com/qbittorrent/qBittorrent/pull/9255#issuecomment-1263081969).