### PR TITLE
Disable stdout buffering for qbt-nox

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -104,6 +104,10 @@ void adjustFileDescriptorLimit();
 // Main
 int main(int argc, char *argv[])
 {
+#ifdef DISABLE_GUI
+    setvbuf(stdout, nullptr, _IONBF, 0);
+#endif
+
 #ifdef Q_OS_UNIX
     adjustFileDescriptorLimit();
 #endif


### PR DESCRIPTION
The messages printed out via stdout is usually important and short so there is no reason to buffer them.

Closes #19984.
