### PR TITLE
Revise constraint for `join` function

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -522,10 +522,7 @@ void Application::runExternalProgram(const QString &programTemplate, const BitTo
                 str.replace(i, 2, torrent->contentPath().toString());
                 break;
             case u'G':
-                {
-                    const TagSet &tags = torrent->tags();
-                    str.replace(i, 2, QStringList(tags.cbegin(), tags.cend()).join(u","_s));
-                }
+                str.replace(i, 2, torrent->tags().join(u","_s));
                 break;
             case u'I':
                 str.replace(i, 2, (torrent->infoHash().v1().isValid() ? torrent->infoHash().v1().toString() : u"-"_s));

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(qbt_base STATIC
     bittorrent/torrentinfo.h
     bittorrent/tracker.h
     bittorrent/trackerentry.h
+    concepts/explicitlyconvertibleto.h
     concepts/stringable.h
     digest32.h
     exceptions.h

--- a/src/base/bittorrent/dbresumedatastorage.cpp
+++ b/src/base/bittorrent/dbresumedatastorage.cpp
@@ -854,7 +854,7 @@ namespace
             query.bindValue(DB_COLUMN_NAME.placeholder, m_resumeData.name);
             query.bindValue(DB_COLUMN_CATEGORY.placeholder, m_resumeData.category);
             query.bindValue(DB_COLUMN_TAGS.placeholder, (m_resumeData.tags.isEmpty()
-                    ? QString() : QStringList(m_resumeData.tags.cbegin(), m_resumeData.tags.cend()).join(u","_s)));
+                    ? QString() : m_resumeData.tags.join(u","_s)));
             query.bindValue(DB_COLUMN_CONTENT_LAYOUT.placeholder, Utils::String::fromEnum(m_resumeData.contentLayout));
             query.bindValue(DB_COLUMN_RATIO_LIMIT.placeholder, static_cast<int>(m_resumeData.ratioLimit * 1000));
             query.bindValue(DB_COLUMN_SEEDING_TIME_LIMIT.placeholder, m_resumeData.seedingTimeLimit);

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -552,8 +552,11 @@ SessionImpl::SessionImpl(QObject *parent)
     }
 
     const QStringList storedTags = m_storedTags.get();
-    m_tags.insert(storedTags.cbegin(), storedTags.cend());
-    std::erase_if(m_tags, [](const Tag &tag) { return !tag.isValid(); });
+    for (const QString &tagStr : storedTags)
+    {
+        if (const Tag tag {tagStr}; tag.isValid())
+            m_tags.insert(tag);
+    }
 
     updateSeedingLimitTimer();
     populateAdditionalTrackers();

--- a/src/base/concepts/explicitlyconvertibleto.h
+++ b/src/base/concepts/explicitlyconvertibleto.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2023  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2023  Mike Tzou (Chocobo1)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -26,66 +26,12 @@
  * exception statement from your version.
  */
 
-#include "tag.h"
+#pragma once
 
-#include <QDataStream>
+#include <concepts>
 
-#include "base/concepts/stringable.h"
-
-namespace
+template <typename From, typename To>
+concept ExplicitlyConvertibleTo = requires (From f)
 {
-    QString cleanTag(const QString &tag)
-    {
-        return tag.trimmed();
-    }
-}
-
-// `Tag` should satisfy `Stringable` concept in order to be stored in settings as string
-static_assert(Stringable<Tag>);
-
-Tag::Tag(const QString &tagStr)
-    : m_tagStr {cleanTag(tagStr)}
-{
-}
-
-Tag::Tag(const std::string &tagStr)
-    : Tag(QString::fromStdString(tagStr))
-{
-}
-
-bool Tag::isValid() const
-{
-    if (isEmpty())
-        return false;
-
-    return !m_tagStr.contains(u',');
-}
-
-bool Tag::isEmpty() const
-{
-    return m_tagStr.isEmpty();
-}
-
-QString Tag::toString() const noexcept
-{
-    return m_tagStr;
-}
-
-Tag::operator QString() const noexcept
-{
-    return toString();
-}
-
-QDataStream &operator<<(QDataStream &out, const Tag &tag)
-{
-    out << tag.toString();
-    return out;
-}
-
-QDataStream &operator>>(QDataStream &in, Tag &tag)
-{
-    QString tagStr;
-    in >> tagStr;
-    tag = Tag(tagStr);
-    return in;
-}
+    static_cast<To>(f);
+};

--- a/src/base/orderedset.h
+++ b/src/base/orderedset.h
@@ -34,6 +34,7 @@
 #include <set>
 
 #include "algorithm.h"
+#include "concepts/explicitlyconvertibleto.h"
 
 template <typename T, typename Compare = std::less<T>>
 class OrderedSet : public std::set<T, Compare>
@@ -71,18 +72,19 @@ public:
     }
 
     QString join(const QString &separator) const
-        requires std::same_as<value_type, QString>
+        requires ExplicitlyConvertibleTo<value_type, QString>
     {
         auto iter = BaseType::cbegin();
         if (iter == BaseType::cend())
             return {};
 
-        QString ret = *iter;
+        auto ret = QString(*iter);
+        ret.reserve((ret.size() + separator.size()) * BaseType::size());  // crude estimate
         ++iter;
 
         while (iter != BaseType::cend())
         {
-            ret.push_back(separator + *iter);
+            ret.append(separator + QString(*iter));
             ++iter;
         }
 

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -363,7 +363,7 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::TorrentDescriptor &to
 
     connect(m_ui->categoryComboBox, &QComboBox::currentIndexChanged, this, &AddNewTorrentDialog::categoryChanged);
 
-    m_ui->tagsLineEdit->setText(QStringList(m_torrentParams.tags.cbegin(), m_torrentParams.tags.cend()).join(u", "_s));
+    m_ui->tagsLineEdit->setText(m_torrentParams.tags.join(u", "_s));
     connect(m_ui->tagsEditButton, &QAbstractButton::clicked, this, [this]
     {
         auto *dlg = new TorrentTagsDialog(m_torrentParams.tags, this);
@@ -371,7 +371,7 @@ AddNewTorrentDialog::AddNewTorrentDialog(const BitTorrent::TorrentDescriptor &to
         connect(dlg, &TorrentTagsDialog::accepted, this, [this, dlg]
         {
             m_torrentParams.tags = dlg->tags();
-            m_ui->tagsLineEdit->setText(QStringList(m_torrentParams.tags.cbegin(), m_torrentParams.tags.cend()).join(u", "_s));
+            m_ui->tagsLineEdit->setText(m_torrentParams.tags.join(u", "_s));
         });
         dlg->open();
     });

--- a/src/gui/addtorrentparamswidget.cpp
+++ b/src/gui/addtorrentparamswidget.cpp
@@ -112,7 +112,7 @@ AddTorrentParamsWidget::AddTorrentParamsWidget(BitTorrent::AddTorrentParams addT
         connect(dlg, &TorrentTagsDialog::accepted, this, [this, dlg]
         {
             m_addTorrentParams.tags = dlg->tags();
-            m_ui->tagsLineEdit->setText(QStringList(m_addTorrentParams.tags.cbegin(), m_addTorrentParams.tags.cend()).join(u", "_s));
+            m_ui->tagsLineEdit->setText(m_addTorrentParams.tags.join(u", "_s));
         });
         dlg->open();
     });
@@ -230,7 +230,7 @@ void AddTorrentParamsWidget::populate()
             m_addTorrentParams.stopCondition = data.value<BitTorrent::Torrent::StopCondition>();
     });
 
-    m_ui->tagsLineEdit->setText(QStringList(m_addTorrentParams.tags.cbegin(), m_addTorrentParams.tags.cend()).join(u", "_s));
+    m_ui->tagsLineEdit->setText(m_addTorrentParams.tags.join(u", "_s));
 
     m_ui->startTorrentComboBox->disconnect(this);
     m_ui->startTorrentComboBox->setCurrentIndex(m_addTorrentParams.addPaused

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -380,10 +380,7 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
     case TR_CATEGORY:
         return torrent->category();
     case TR_TAGS:
-        {
-            const TagSet &tags = torrent->tags();
-            return QStringList(tags.cbegin(), tags.cend()).join(u", "_s);
-        }
+        return torrent->tags().join(u", "_s);
     case TR_ADD_DATE:
         return QLocale().toString(torrent->addedTime().toLocalTime(), QLocale::ShortFormat);
     case TR_SEED_DATE:

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -29,7 +29,6 @@
 #include "serialize_torrent.h"
 
 #include <QDateTime>
-#include <QStringList>
 #include <QVector>
 
 #include "base/bittorrent/infohash.h"
@@ -106,8 +105,6 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
             : (QDateTime::currentDateTime().toSecsSinceEpoch() - timeSinceActivity);
     };
 
-    const TagSet &tags = torrent.tags();
-
     return {
         {KEY_TORRENT_ID, torrent.id().toString()},
         {KEY_TORRENT_INFOHASHV1, torrent.infoHash().v1().toString()},
@@ -130,7 +127,7 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         {KEY_TORRENT_FIRST_LAST_PIECE_PRIO, torrent.hasFirstLastPiecePriority()},
 
         {KEY_TORRENT_CATEGORY, torrent.category()},
-        {KEY_TORRENT_TAGS, QStringList(tags.cbegin(), tags.cend()).join(u", "_s)},
+        {KEY_TORRENT_TAGS, torrent.tags().join(u", "_s)},
         {KEY_TORRENT_SUPER_SEEDING, torrent.superSeeding()},
         {KEY_TORRENT_FORCE_START, torrent.isForced()},
         {KEY_TORRENT_SAVE_PATH, torrent.savePath().toString()},

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,7 @@ include_directories("../src")
 set(testFiles
     testalgorithm.cpp
     testbittorrenttrackerentry.cpp
+    testconceptsexplicitlyconvertibleto.cpp
     testconceptsstringable.cpp
     testglobal.cpp
     testorderedset.cpp

--- a/test/testconceptsexplicitlyconvertibleto.cpp
+++ b/test/testconceptsexplicitlyconvertibleto.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2023  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2023  Mike Tzou (Chocobo1)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -26,66 +26,29 @@
  * exception statement from your version.
  */
 
-#include "tag.h"
+#include <string>
 
-#include <QDataStream>
+#include <QObject>
+#include <QString>
+#include <QTest>
 
-#include "base/concepts/stringable.h"
+#include "base/concepts/explicitlyconvertibleto.h"
 
-namespace
+class TestExplicitlyConvertibleTo final : public QObject
 {
-    QString cleanTag(const QString &tag)
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(TestExplicitlyConvertibleTo)
+
+public:
+    TestExplicitlyConvertibleTo() = default;
+
+private slots:
+    void testExplicitlyConvertibleTo() const
     {
-        return tag.trimmed();
+        static_assert(ExplicitlyConvertibleTo<const char *, std::string>);
+        static_assert(!ExplicitlyConvertibleTo<std::string, const char *>);
     }
-}
+};
 
-// `Tag` should satisfy `Stringable` concept in order to be stored in settings as string
-static_assert(Stringable<Tag>);
-
-Tag::Tag(const QString &tagStr)
-    : m_tagStr {cleanTag(tagStr)}
-{
-}
-
-Tag::Tag(const std::string &tagStr)
-    : Tag(QString::fromStdString(tagStr))
-{
-}
-
-bool Tag::isValid() const
-{
-    if (isEmpty())
-        return false;
-
-    return !m_tagStr.contains(u',');
-}
-
-bool Tag::isEmpty() const
-{
-    return m_tagStr.isEmpty();
-}
-
-QString Tag::toString() const noexcept
-{
-    return m_tagStr;
-}
-
-Tag::operator QString() const noexcept
-{
-    return toString();
-}
-
-QDataStream &operator<<(QDataStream &out, const Tag &tag)
-{
-    out << tag.toString();
-    return out;
-}
-
-QDataStream &operator>>(QDataStream &in, Tag &tag)
-{
-    QString tagStr;
-    in >> tagStr;
-    tag = Tag(tagStr);
-    return in;
-}
+QTEST_APPLESS_MAIN(TestExplicitlyConvertibleTo)
+#include "testconceptsexplicitlyconvertibleto.moc"

--- a/test/testorderedset.cpp
+++ b/test/testorderedset.cpp
@@ -34,6 +34,31 @@
 #include "base/global.h"
 #include "base/orderedset.h"
 
+namespace
+{
+    class MyString
+    {
+    public:
+        MyString(const QString &str)
+            : m_str {str}
+        {
+        }
+
+        explicit operator QString() const
+        {
+            return m_str;
+        }
+
+        friend bool operator<(const MyString &left, const MyString &right)
+        {
+            return left.m_str < right.m_str;
+        }
+
+    private:
+        QString m_str;
+    };
+}
+
 class TestOrderedSet final : public QObject
 {
     Q_OBJECT
@@ -80,6 +105,9 @@ private slots:
 
         const OrderedSet<QString> emptySet;
         QCOMPARE(emptySet.join(u","_s), u""_s);
+
+        const OrderedSet<MyString> set2 {u"a"_s, u"b"_s, u"c"_s};
+        QCOMPARE(set2.join(u"+"_s), u"a+b+c"_s);
     }
 
     void testRemove() const


### PR DESCRIPTION
This enable `OrderedSet::join()` to be available when the value type is convertible to `QString`. And fix the performance regression introduced along with the new `Tag` type.
