### PR TITLE
Handle .txt URL in tracker list

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -298,6 +298,11 @@ namespace BitTorrent
         virtual void setAddTrackersEnabled(bool enabled) = 0;
         virtual QString additionalTrackers() const = 0;
         virtual void setAdditionalTrackers(const QString &trackers) = 0;
+        virtual bool isAutoUpdateTrackersEnabled() const = 0;
+        virtual void setAutoUpdateTrackersEnabled(bool enabled) = 0;
+        virtual QString publicTrackers() const = 0;
+        virtual void setPublicTrackers(const QString &trackers) = 0;
+        virtual void updatePublicTracker() = 0;
         virtual bool isIPFilteringEnabled() const = 0;
         virtual void setIPFilteringEnabled(bool enabled) = 0;
         virtual Path IPFilterFile() const = 0;

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -2265,18 +2265,19 @@ void SessionImpl::setPublicTrackers(const QString &trackers)
 void SessionImpl::updatePublicTracker()
 {
     Preferences *const pref = Preferences::instance();
-    Net::DownloadManager::instance()->download(Net::DownloadRequest(pref->customizeTrackersListUrl()).userAgent(QStringLiteral("qBittorrent Enhanced/" QBT_VERSION_2)), Preferences::instance()->useProxyForGeneralPurposes(), this, &SessionImpl::handlePublicTrackerTxtDownloadFinished);
+    Net::DownloadManager::instance()->download(Net::DownloadRequest(pref->customizeTrackersListUrl()).userAgent(QStringLiteral("qBittorrent/" QBT_VERSION_2)), Preferences::instance()->useProxyForGeneralPurposes(), this, &SessionImpl::handlePublicTrackerTxtDownloadFinished);
 }
 
 void SessionImpl::handlePublicTrackerTxtDownloadFinished(const Net::DownloadResult &result)
 {
-    switch (result.status) {
-        case Net::DownloadStatus::Success:
-            setPublicTrackers(QString::fromUtf8(result.data.data()));
-            LogMsg(tr("The public tracker list updated."), Log::INFO);
-            break;
-        default:
-            LogMsg(tr("Updating the public tracker list failed: %1").arg(result.errorString, Log::WARNING));
+    if (result.status == Net::DownloadStatus::Success)
+    {
+        setPublicTrackers(QString::fromUtf8(result.data.data()));
+        LogMsg(tr("The public tracker list updated."), Log::INFO);
+    }
+    else
+    {
+        LogMsg(tr("Updating the public tracker list failed: %1").arg(result.errorString, Log::WARNING));
     }
 }
 

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -73,6 +73,9 @@
 #include <QThreadPool>
 #include <QTimer>
 #include <QUuid>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
 
 #include "base/algorithm.h"
 #include "base/global.h"

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -1845,6 +1845,16 @@ void Preferences::setToolbarTextPosition(const int position)
     setValue(u"Toolbar/textPosition"_s, position);
 }
 
+QString Preferences::customizeTrackersListUrl() const
+{
+    return value(u"Preferences/Bittorrent/CustomizeTrackersListUrl"_s, u"https://cdn.jsdelivr.net/gh/ngosang/trackerslist/trackers_best.txt"_s);
+}
+
+void Preferences::setCustomizeTrackersListUrl(const QString &trackersUrl)
+{
+    setValue(u"Preferences/Bittorrent/CustomizeTrackersListUrl"_s, trackersUrl);
+}
+
 QList<QNetworkCookie> Preferences::getNetworkCookies() const
 {
     const auto rawCookies = value<QStringList>(u"Network/Cookies"_s);

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -1847,7 +1847,7 @@ void Preferences::setToolbarTextPosition(const int position)
 
 QString Preferences::customizeTrackersListUrl() const
 {
-    return value(u"Preferences/Bittorrent/CustomizeTrackersListUrl"_s, u"https://cdn.jsdelivr.net/gh/ngosang/trackerslist/trackers_best.txt"_s);
+    return value(u"Preferences/Bittorrent/CustomizeTrackersListUrl"_s, u"https://raw.githubusercontent.com/ngosang/trackerslist/master/trackers_best.txt"_s);
 }
 
 void Preferences::setCustomizeTrackersListUrl(const QString &trackersUrl)

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -390,6 +390,8 @@ public:
     void setRegexAsFilteringPatternForTransferList(bool checked);
     int getToolbarTextPosition() const;
     void setToolbarTextPosition(int position);
+    QString customizeTrackersListUrl() const;
+    void setCustomizeTrackersListUrl(const QString &trackersUrl);
 
     // From old RssSettings class
     bool isRSSWidgetEnabled() const;

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -2012,14 +2012,13 @@ void OptionsDialog::on_fetchButton_clicked()
 
 void OptionsDialog::handlePublicTrackersListChanged(const Net::DownloadResult &result)
 {
-    switch (result.status) {
-        case Net::DownloadStatus::Success:
-            BitTorrent::Session::instance()->setPublicTrackers(QString::fromUtf8(result.data.data()));
-            m_ui->textPublicTrackers->setPlainText(QString::fromUtf8(result.data.data()));
-            m_ui->fetchButton->setEnabled(false);
-            m_ui->fetchButton->setText(u"Fetched!"_s);
-            break;
-        default:
-            m_ui->textPublicTrackers->setPlainText(u"Refetch failed. Reason: "_s + result.errorString);
+    if (result.status == Net::DownloadStatus::Success) {
+        BitTorrent::Session::instance()->setPublicTrackers(QString::fromUtf8(result.data.data()));
+        m_ui->textPublicTrackers->setPlainText(QString::fromUtf8(result.data.data()));
+        m_ui->fetchButton->setEnabled(false);
+        m_ui->fetchButton->setText(u"Fetched!"_s);
+    }
+    else {
+        m_ui->textPublicTrackers->setPlainText(u"Refetch failed. Reason: "_s + result.errorString);
     }
 }

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -110,8 +110,9 @@ private slots:
     void webUIHttpsCertChanged(const Path &path);
     void webUIHttpsKeyChanged(const Path &path);
     void on_registerDNSBtn_clicked();
-    void on_fetchButton_clicked();
+    void on_fetchButton_clicked(const QString &trackersUrl) const;
     void handlePublicTrackersListChanged(const Net::DownloadResult &result);
+    void on_textCustomizeTrackersListURL_textChanged(const QString &text);
 #endif
 
 private:

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -33,6 +33,7 @@
 
 #include "base/pathfwd.h"
 #include "base/settingvalue.h"
+#include "base/net/downloadmanager.h"
 #include "guiapplicationcomponent.h"
 
 class QListWidgetItem;
@@ -109,6 +110,8 @@ private slots:
     void webUIHttpsCertChanged(const Path &path);
     void webUIHttpsKeyChanged(const Path &path);
     void on_registerDNSBtn_clicked();
+    void on_fetchButton_clicked();
+    void handlePublicTrackersListChanged(const Net::DownloadResult &result);
 #endif
 
 private:

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -3085,6 +3085,72 @@ Disable encryption: Only connect to peers without protocol encryption</string>
              </widget>
             </item>
             <item>
+             <widget class="QGroupBox" name="checkAutoUpdateTrackers">
+              <property name="title">
+               <string>Automatically update public trackers list:</string>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_999">
+               <property name="leftMargin">
+                <number>9</number>
+               </property>
+               <property name="topMargin">
+                <number>9</number>
+               </property>
+               <property name="rightMargin">
+                <number>9</number>
+               </property>
+               <property name="bottomMargin">
+                <number>9</number>
+               </property>
+               <item row="0" column="0">
+                <widget class="QLineEdit" name="textCustomizeTrackersListUrl">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="text">
+                  <string>https://raw.githubusercontent.com/ngosang/trackerslist/master/trackers_best.txt</string>
+                 </property>
+                 <property name="readOnly">
+                  <bool>false</bool>
+                 </property>
+                 <property name="cursorMoveStyle">
+                  <enum>Qt::LogicalMoveStyle</enum>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QPushButton" name="fetchButton">
+                 <property name="text">
+                  <string>Refetch</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0" colspan="2">
+                <widget class="QPlainTextEdit" name="textPublicTrackers">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>0</width>
+                   <height>153</height>
+                  </size>
+                 </property>
+                 <property name="readOnly">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
              <spacer name="verticalSpacer_8">
               <property name="orientation">
                <enum>Qt::Vertical</enum>


### PR DESCRIPTION
This commit adds the ability to parse .txt URL in the automatic tracker add list, as requested by https://github.com/qbittorrent/qBittorrent/issues/6865
