### PR TITLE
Fix some file renaming woes (probably)

### DIFF
--- a/src/base/bittorrent/abstractfilestorage.cpp
+++ b/src/base/bittorrent/abstractfilestorage.cpp
@@ -72,6 +72,7 @@ void BitTorrent::AbstractFileStorage::renameFolder(const Path &oldFolderPath, co
         throw RuntimeError(tr("The new path is invalid: '%1'.").arg(newFolderPath.toString()));
     if (newFolderPath.isAbsolute())
         throw RuntimeError(tr("Absolute path isn't allowed: '%1'.").arg(newFolderPath.toString()));
+    
 
     QVector<int> renamingFileIndexes;
     renamingFileIndexes.reserve(filesCount());
@@ -83,7 +84,7 @@ void BitTorrent::AbstractFileStorage::renameFolder(const Path &oldFolderPath, co
         if (path.hasAncestor(oldFolderPath))
             renamingFileIndexes.append(i);
         else if (path.hasAncestor(newFolderPath))
-            throw RuntimeError(tr("The folder already exists: '%1'.").arg(newFolderPath.toString()));
+            throw RuntimeError(tr("The folder already exists in this torrent: '%1'.").arg(newFolderPath.toString()));
     }
 
     if (renamingFileIndexes.isEmpty())
@@ -92,6 +93,6 @@ void BitTorrent::AbstractFileStorage::renameFolder(const Path &oldFolderPath, co
     for (const int index : renamingFileIndexes)
     {
         const Path newFilePath = newFolderPath / oldFolderPath.relativePathOf(filePath(index));
-        renameFile(index, newFilePath);
+        renameFile(index, newFilePath); // note; if file would be overwritten, we note that is true here
     }
 }

--- a/src/base/bittorrent/abstractfilestorage.cpp
+++ b/src/base/bittorrent/abstractfilestorage.cpp
@@ -44,7 +44,9 @@ void BitTorrent::AbstractFileStorage::renameFile(const Path &oldPath, const Path
         throw RuntimeError(tr("The new path is invalid: '%1'.").arg(newPath.toString()));
     if (newPath.isAbsolute())
         throw RuntimeError(tr("Absolute path isn't allowed: '%1'.").arg(newPath.toString()));
-
+    if (newPath.exists())
+        throw RuntimeError(tr("Another file exists at new path: '%1'.").arg(newPath.toString()));
+    
     int renamingFileIndex = -1;
     for (int i = 0; i < filesCount(); ++i)
     {
@@ -53,7 +55,7 @@ void BitTorrent::AbstractFileStorage::renameFile(const Path &oldPath, const Path
         if ((renamingFileIndex < 0) && (path == oldPath))
             renamingFileIndex = i;
         else if (path == newPath)
-            throw RuntimeError(tr("The file already exists: '%1'.").arg(newPath.toString()));
+            throw RuntimeError(tr("The file already exists in this torrent: '%1'.").arg(newPath.toString()));
     }
 
     if (renamingFileIndex < 0)

--- a/src/base/path.cpp
+++ b/src/base/path.cpp
@@ -130,7 +130,7 @@ bool Path::isRelative() const
 
 bool Path::exists() const
 {
-    return !isEmpty() && QFileInfo::exists(m_pathStr);
+    return !isValid() && QFileInfo::exists(m_pathStr);
 }
 
 Path Path::rootItem() const


### PR DESCRIPTION
Hullo, new contributer, wanted to avoid others losing data the way I just did!

I added a few new checks that, to my knowlege, will prevent users from renaming files on top of files that exist.  While this can be useful for reseeding, it causes instant data loss if qbittorrent has downloaded any part of the existing file.

I also do some cleanup on messages and exists() function.

Reject the PR if you'd prefer to move the functionality to a different place, but I had the itch to hack something up to fix this, and I couldn't resist.

Probably closes a few issues, but I wasn't sure which, and I should get back to final projects.