### PR TITLE
Add the Popularity metric

### DIFF
--- a/src/base/bittorrent/torrent.h
+++ b/src/base/bittorrent/torrent.h
@@ -271,6 +271,7 @@ namespace BitTorrent
         virtual int maxSeedingTime() const = 0;
         virtual int maxInactiveSeedingTime() const = 0;
         virtual qreal realRatio() const = 0;
+        virtual qreal popularity() const = 0;
         virtual int uploadPayloadRate() const = 0;
         virtual int downloadPayloadRate() const = 0;
         virtual qlonglong totalPayloadUpload() const = 0;

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -1533,6 +1533,15 @@ qlonglong TorrentImpl::nextAnnounce() const
     return lt::total_seconds(m_nativeStatus.next_announce);
 }
 
+qreal TorrentImpl::popularity() const
+{
+    // in order to produce floating-point numbers using `std::chrono::duration_cast`,
+    // we should use `qreal` as `Rep` to define the `months` duration
+    using months = std::chrono::duration<qreal, std::chrono::months::period>;
+    const auto activeMonths = std::chrono::duration_cast<months>(m_nativeStatus.active_duration).count();
+    return (activeMonths > 0) ? (realRatio() / activeMonths) : 0;
+}
+
 void TorrentImpl::setName(const QString &name)
 {
     if (m_name != name)

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -204,6 +204,7 @@ namespace BitTorrent
         int maxSeedingTime() const override;
         int maxInactiveSeedingTime() const override;
         qreal realRatio() const override;
+        qreal popularity() const override;
         int uploadPayloadRate() const override;
         int downloadPayloadRate() const override;
         qlonglong totalPayloadUpload() const override;

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -220,6 +220,7 @@ void PropertiesWidget::clear()
     m_ui->labelConnectionsVal->clear();
     m_ui->labelReannounceInVal->clear();
     m_ui->labelShareRatioVal->clear();
+    m_ui->labelPopularityVal->clear();
     m_ui->listWebSeeds->clear();
     m_ui->labelETAVal->clear();
     m_ui->labelSeedsVal->clear();
@@ -406,6 +407,9 @@ void PropertiesWidget::loadDynamicData()
             // Update ratio info
             const qreal ratio = m_torrent->realRatio();
             m_ui->labelShareRatioVal->setText(ratio > BitTorrent::Torrent::MAX_RATIO ? C_INFINITY : Utils::String::fromDouble(ratio, 2));
+
+            const qreal popularity = m_torrent->popularity();
+            m_ui->labelPopularityVal->setText(popularity > BitTorrent::Torrent::MAX_RATIO ? C_INFINITY : Utils::String::fromDouble(popularity, 2));
 
             m_ui->labelSeedsVal->setText(tr("%1 (%2 total)", "%1 and %2 are numbers, e.g. 3 (10 total)")
                 .arg(QString::number(m_torrent->seedsCount())

--- a/src/gui/properties/propertieswidget.ui
+++ b/src/gui/properties/propertieswidget.ui
@@ -295,6 +295,25 @@
                 </property>
                </widget>
               </item>
+              <item row="5" column="0">
+               <widget class="QLabel" name="labelPopularity">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="toolTip">
+                 <string>Ratio / Time Active (in months), indicates how popular the torrent is</string>
+                </property>
+                <property name="text">
+                 <string>Popularity:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
               <item row="0" column="5">
                <widget class="QLabel" name="labelConnectionsVal">
                 <property name="sizePolicy">
@@ -489,6 +508,22 @@
                   <horstretch>0</horstretch>
                   <verstretch>0</verstretch>
                  </sizepolicy>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::PlainText</enum>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="1">
+               <widget class="QLabel" name="labelPopularityVal">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="toolTip">
+                 <string>Ratio / Time Active (in months), indicates how popular the torrent is</string>
                 </property>
                 <property name="textFormat">
                  <enum>Qt::PlainText</enum>

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -171,6 +171,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_DLSPEED: return tr("Down Speed", "i.e: Download speed");
             case TR_UPSPEED: return tr("Up Speed", "i.e: Upload speed");
             case TR_RATIO: return tr("Ratio", "Share ratio");
+            case TR_POPULARITY: return tr("Popularity");
             case TR_ETA: return tr("ETA", "i.e: Estimated Time of Arrival / Time left");
             case TR_CATEGORY: return tr("Category");
             case TR_TAGS: return tr("Tags");
@@ -199,6 +200,14 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             default: return {};
             }
         }
+        else if (role == Qt::ToolTipRole)
+        {
+            switch (section)
+            {
+            case TR_POPULARITY: return tr("Ratio / Time Active (in months), indicates how popular the torrent is");
+            default: return {};
+            }
+        }
         else if (role == Qt::TextAlignmentRole)
         {
             switch (section)
@@ -220,6 +229,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_DLLIMIT:
             case TR_RATIO_LIMIT:
             case TR_RATIO:
+            case TR_POPULARITY:
             case TR_QUEUE_POSITION:
             case TR_LAST_ACTIVITY:
             case TR_AVAILABILITY:
@@ -377,6 +387,8 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
         return ratioString(torrent->realRatio());
     case TR_RATIO_LIMIT:
         return ratioString(torrent->maxRatio());
+    case TR_POPULARITY:
+        return ratioString(torrent->popularity());
     case TR_CATEGORY:
         return torrent->category();
     case TR_TAGS:
@@ -454,6 +466,8 @@ QVariant TransferListModel::internalValue(const BitTorrent::Torrent *torrent, co
         return torrent->eta();
     case TR_RATIO:
         return torrent->realRatio();
+    case TR_POPULARITY:
+        return torrent->popularity();
     case TR_CATEGORY:
         return torrent->category();
     case TR_TAGS:
@@ -563,6 +577,7 @@ QVariant TransferListModel::data(const QModelIndex &index, const int role) const
         case TR_DLLIMIT:
         case TR_RATIO_LIMIT:
         case TR_RATIO:
+        case TR_POPULARITY:
         case TR_QUEUE_POSITION:
         case TR_LAST_ACTIVITY:
         case TR_AVAILABILITY:

--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -62,6 +62,7 @@ public:
         TR_UPSPEED,
         TR_ETA,
         TR_RATIO,
+        TR_POPULARITY,
         TR_CATEGORY,
         TR_TAGS,
         TR_ADD_DATE,

--- a/src/gui/transferlistsortmodel.cpp
+++ b/src/gui/transferlistsortmodel.cpp
@@ -196,6 +196,7 @@ int TransferListSortModel::compare(const QModelIndex &left, const QModelIndex &r
     case TransferListModel::TR_PROGRESS:
     case TransferListModel::TR_RATIO:
     case TransferListModel::TR_RATIO_LIMIT:
+    case TransferListModel::TR_POPULARITY:
         return customCompare(leftValue.toReal(), rightValue.toReal());
 
     case TransferListModel::TR_STATUS:

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -178,6 +178,7 @@ TransferListWidget::TransferListWidget(QWidget *parent, MainWindow *mainWindow)
         setColumnHidden(TransferListModel::TR_INFOHASH_V2, true);
         setColumnHidden(TransferListModel::TR_COMPLETED, true);
         setColumnHidden(TransferListModel::TR_RATIO_LIMIT, true);
+        setColumnHidden(TransferListModel::TR_POPULARITY, true);
         setColumnHidden(TransferListModel::TR_SEEN_COMPLETE_DATE, true);
         setColumnHidden(TransferListModel::TR_LAST_ACTIVITY, true);
         setColumnHidden(TransferListModel::TR_TOTAL_SIZE, true);
@@ -696,6 +697,7 @@ void TransferListWidget::displayColumnHeaderMenu()
             continue;
 
         const auto columnName = m_listModel->headerData(i, Qt::Horizontal, Qt::DisplayRole).toString();
+        const QVariant columnToolTip = m_listModel->headerData(i, Qt::Horizontal, Qt::ToolTipRole);
         QAction *action = menu->addAction(columnName, this, [this, i](const bool checked)
         {
             if (!checked && (visibleColumnsCount() <= 1))
@@ -710,6 +712,8 @@ void TransferListWidget::displayColumnHeaderMenu()
         });
         action->setCheckable(true);
         action->setChecked(!isColumnHidden(i));
+        if (!columnToolTip.isNull())
+            action->setToolTip(columnToolTip.toString());
     }
 
     menu->addSeparator();

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -152,6 +152,7 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         {KEY_TORRENT_MAX_INACTIVE_SEEDING_TIME, torrent.maxInactiveSeedingTime()},
         {KEY_TORRENT_RATIO, adjustRatio(torrent.realRatio())},
         {KEY_TORRENT_RATIO_LIMIT, torrent.ratioLimit()},
+        {KEY_TORRENT_POPULARITY, torrent.popularity()},
         {KEY_TORRENT_SEEDING_TIME_LIMIT, torrent.seedingTimeLimit()},
         {KEY_TORRENT_INACTIVE_SEEDING_TIME_LIMIT, torrent.inactiveSeedingTimeLimit()},
         {KEY_TORRENT_LAST_SEEN_COMPLETE_TIME, Utils::DateTime::toSecsSinceEpoch(torrent.lastSeenComplete())},

--- a/src/webui/api/serialize/serialize_torrent.h
+++ b/src/webui/api/serialize/serialize_torrent.h
@@ -54,6 +54,7 @@ inline const QString KEY_TORRENT_NUM_COMPLETE = u"num_complete"_s;
 inline const QString KEY_TORRENT_LEECHS = u"num_leechs"_s;
 inline const QString KEY_TORRENT_NUM_INCOMPLETE = u"num_incomplete"_s;
 inline const QString KEY_TORRENT_RATIO = u"ratio"_s;
+inline const QString KEY_TORRENT_POPULARITY = u"popularity"_s;
 inline const QString KEY_TORRENT_ETA = u"eta"_s;
 inline const QString KEY_TORRENT_STATE = u"state"_s;
 inline const QString KEY_TORRENT_SEQUENTIAL_DOWNLOAD = u"seq_dl"_s;

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -96,6 +96,7 @@ const QString KEY_PROP_SEEDS_TOTAL = u"seeds_total"_s;
 const QString KEY_PROP_PEERS = u"peers"_s;
 const QString KEY_PROP_PEERS_TOTAL = u"peers_total"_s;
 const QString KEY_PROP_RATIO = u"share_ratio"_s;
+const QString KEY_PROP_POPULARITY = u"popularity"_s;
 const QString KEY_PROP_REANNOUNCE = u"reannounce"_s;
 const QString KEY_PROP_TOTAL_SIZE = u"total_size"_s;
 const QString KEY_PROP_PIECES_NUM = u"pieces_num"_s;
@@ -397,6 +398,7 @@ void TorrentsController::infoAction()
 //   - "peers": Torrent connected peers
 //   - "peers_total": Torrent total number of peers
 //   - "share_ratio": Torrent share ratio
+//   - "popularity": Torrent popularity
 //   - "reannounce": Torrent next reannounce time
 //   - "total_size": Torrent total size
 //   - "pieces_num": Torrent pieces count
@@ -431,6 +433,7 @@ void TorrentsController::propertiesAction()
     const int downloadLimit = torrent->downloadLimit();
     const int uploadLimit = torrent->uploadLimit();
     const qreal ratio = torrent->realRatio();
+    const qreal popularity = torrent->popularity();
 
     const QJsonObject ret
     {
@@ -459,6 +462,7 @@ void TorrentsController::propertiesAction()
         {KEY_PROP_PEERS, torrent->leechsCount()},
         {KEY_PROP_PEERS_TOTAL, torrent->totalLeechersCount()},
         {KEY_PROP_RATIO, ((ratio > BitTorrent::Torrent::MAX_RATIO) ? -1 : ratio)},
+        {KEY_PROP_POPULARITY, ((popularity > BitTorrent::Torrent::MAX_RATIO) ? -1 : popularity)},
         {KEY_PROP_REANNOUNCE, torrent->nextAnnounce()},
         {KEY_PROP_TOTAL_SIZE, torrent->totalSize()},
         {KEY_PROP_PIECES_NUM, torrent->piecesCount()},

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -922,6 +922,7 @@ window.qBittorrent.DynamicTable = (function() {
             this.newColumn('upspeed', '', 'QBT_TR(Up Speed)QBT_TR[CONTEXT=TransferListModel]', 100, true);
             this.newColumn('eta', '', 'QBT_TR(ETA)QBT_TR[CONTEXT=TransferListModel]', 100, true);
             this.newColumn('ratio', '', 'QBT_TR(Ratio)QBT_TR[CONTEXT=TransferListModel]', 100, true);
+            this.newColumn('popularity', '', 'QBT_TR(Popularity)QBT_TR[CONTEXT=TransferListModel]', 100, true);
             this.newColumn('category', '', 'QBT_TR(Category)QBT_TR[CONTEXT=TransferListModel]', 100, true);
             this.newColumn('tags', '', 'QBT_TR(Tags)QBT_TR[CONTEXT=TransferListModel]', 100, true);
             this.newColumn('added_on', '', 'QBT_TR(Added On)QBT_TR[CONTEXT=TransferListModel]', 100, true);
@@ -1222,6 +1223,14 @@ window.qBittorrent.DynamicTable = (function() {
                 const string = (ratio === -1) ? '∞' : window.qBittorrent.Misc.toFixedPointString(ratio, 2);
                 td.set('text', string);
                 td.set('title', string);
+            };
+
+            // popularity
+            this.columns['popularity'].updateTd = function(td, row) {
+                const value = this.getRowValue(row);
+                const popularity = (value === -1) ? '∞' : window.qBittorrent.Misc.toFixedPointString(value, 2);
+                td.set('text', popularity);
+                td.set('title', popularity);
             };
 
             // added on

--- a/src/webui/www/private/scripts/prop-general.js
+++ b/src/webui/www/private/scripts/prop-general.js
@@ -58,6 +58,7 @@ window.qBittorrent.PropGeneral = (function() {
         $('seeds').set('html', '');
         $('peers').set('html', '');
         $('share_ratio').set('html', '');
+        $('popularity').set('html', '');
         $('reannounce').set('html', '');
         $('last_seen').set('html', '');
         $('total_size').set('html', '');
@@ -159,6 +160,8 @@ window.qBittorrent.PropGeneral = (function() {
                     $('peers').set('html', peers);
 
                     $('share_ratio').set('html', data.share_ratio.toFixed(2));
+
+                    $('popularity').set('html', data.popularity.toFixed(2));
 
                     $('reannounce').set('html', window.qBittorrent.Misc.friendlyDuration(data.reannounce));
 

--- a/src/webui/www/private/views/properties.html
+++ b/src/webui/www/private/views/properties.html
@@ -49,6 +49,10 @@
                 <td class="generalLabel">QBT_TR(Last Seen Complete:)QBT_TR[CONTEXT=PropertiesWidget]</td>
                 <td id="last_seen"></td>
             </tr>
+            <tr>
+                <td class="generalLabel" title="QBT_TR(Ratio / Time Active (in months), indicates how popular the torrent is)QBT_TR[CONTEXT=PropertiesWidget]">QBT_TR(Popularity:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td id="popularity" title="QBT_TR(Ratio / Time Active (in months), indicates how popular the torrent is)QBT_TR[CONTEXT=PropertiesWidget]"></td>
+            </tr>
         </table>
     </fieldset>
     <fieldset>


### PR DESCRIPTION
Hello,

Thank you for this amazing torrent client! 🙇🏻‍♂️

I believe it would be nice to have a metric that shows how popular a torrent is.
It's especially helpful for clean up purposes if you want to delete the least popular torrents.
So I'd like to suggest an implementation of the `Popularity` metric.

##  Popularity
_A new metric is inspired by the [Interest Rate](https://en.wikipedia.org/wiki/Interest_rate) from the finance world.
An implementation is adapted to the use-case and has nothing to do with money._

`Popularity` is an average number that represents how many times a torrent is seeded back on a monthly basis calculated as `all_time_upload / all_time_download / (activeTime() / MONTHS_SECONDS)`, translated to `realRatio() / activeMonths` for simplicity. The resulting values are reasonably small and easy to comprehend, just as for the classic `Ratio` metric.

~Metric's name might be different, but I've kept it due to lack of creativity 🤷🏻‍♂️~
Thanks to @Mazino-Urek and @LordNyriox for suggesting a better name!

## Screenshots
### Native UI
![Native UI](https://github.com/qbittorrent/qBittorrent/assets/5607572/b7dae3e8-4c14-43aa-956b-b5f379bfc077)

### Web UI
![Web UI](https://github.com/qbittorrent/qBittorrent/assets/5607572/4bb30001-f549-4439-9028-746684498124)

Best regards!
