### PR TITLE
Add button for sending test email

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -662,6 +662,24 @@ void Application::sendNotificationEmail(const BitTorrent::Torrent *torrent)
                      content);
 }
 
+void Application::sendTestEmail() const
+{
+    const Preferences *pref = Preferences::instance();
+    if (pref->isMailNotificationEnabled())
+    {
+        // Prepare mail content
+        const QString content = tr("This is a test email.") + u'\n'
+            + tr("Thank you for using qBittorrent.") + u'\n';
+
+        // Send the notification email
+        auto *smtp = new Net::Smtp();
+        smtp->sendMail(pref->getMailNotificationSender(),
+                        pref->getMailNotificationEmail(),
+                        tr("Test email"),
+                        content);
+    }
+}
+
 void Application::torrentAdded(const BitTorrent::Torrent *torrent) const
 {
     const Preferences *pref = Preferences::instance();

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -124,6 +124,8 @@ public:
     int memoryWorkingSetLimit() const override;
     void setMemoryWorkingSetLimit(int size) override;
 
+    void sendTestEmail() const override;
+
 #ifdef Q_OS_WIN
     MemoryPriority processMemoryPriority() const override;
     void setProcessMemoryPriority(MemoryPriority priority) override;

--- a/src/base/interfaces/iapplication.h
+++ b/src/base/interfaces/iapplication.h
@@ -80,6 +80,8 @@ public:
     virtual int memoryWorkingSetLimit() const = 0;
     virtual void setMemoryWorkingSetLimit(int size) = 0;
 
+    virtual void sendTestEmail() const = 0;
+
 #ifdef Q_OS_WIN
     virtual MemoryPriority processMemoryPriority() const = 0;
     virtual void setProcessMemoryPriority(MemoryPriority priority) = 0;

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -704,6 +704,11 @@ void OptionsDialog::loadDownloadsTabOptions()
     connect(m_ui->groupMailNotifAuth, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->mailNotifUsername, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->mailNotifPassword, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
+    connect(m_ui->sendTestEmail, &QPushButton::clicked, this, [this]
+    {
+        app()->sendTestEmail();
+        QMessageBox::information(this, tr("Test email"), tr("Attempted to send email. Check your inbox to confirm success"));
+    });
 
     connect(m_ui->groupBoxRunOnAdded, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->lineEditRunOnAdded, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -1579,6 +1579,19 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                  </layout>
                 </widget>
                </item>
+               <item>
+                <widget class="QPushButton" name="sendTestEmail">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="text">
+                   <string>Send test email</string>
+                 </property>
+                </widget>
+               </item>
               </layout>
              </widget>
             </item>
@@ -3928,6 +3941,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
   <tabstop>groupMailNotifAuth</tabstop>
   <tabstop>mailNotifUsername</tabstop>
   <tabstop>mailNotifPassword</tabstop>
+  <tabstop>sendTestEmail</tabstop>
   <tabstop>checkSmtpSSL</tabstop>
   <tabstop>lineEditRunOnAdded</tabstop>
   <tabstop>lineEditRunOnFinished</tabstop>

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -1074,6 +1074,11 @@ void AppController::defaultSavePathAction()
     setResult(BitTorrent::Session::instance()->savePath().toString());
 }
 
+void AppController::sendTestEmailAction()
+{
+    app()->sendTestEmail();
+}
+
 void AppController::networkInterfaceListAction()
 {
     QJsonArray ifaceList;

--- a/src/webui/api/appcontroller.h
+++ b/src/webui/api/appcontroller.h
@@ -48,6 +48,7 @@ private slots:
     void preferencesAction();
     void setPreferencesAction();
     void defaultSavePathAction();
+    void sendTestEmailAction();
 
     void networkInterfaceListAction();
     void networkInterfaceAddressListAction();

--- a/src/webui/www/private/scripts/download.js
+++ b/src/webui/www/private/scripts/download.js
@@ -64,7 +64,7 @@ window.qBittorrent.Download = (function() {
             method: 'get',
             noCache: true,
             onFailure: function() {
-                alert("Could not contact qBittorrent");
+                alert("QBT_TR(Could not contact qBittorrent)QBT_TR[CONTEXT=HttpServer]");
             },
             onSuccess: function(pref) {
                 if (!pref)

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1908,7 +1908,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 method: 'get',
                 noCache: true,
                 onFailure: function() {
-                    alert("Could not contact qBittorrent");
+                    alert("QBT_TR(Could not contact qBittorrent)QBT_TR[CONTEXT=HttpServer]");
                 },
                 onSuccess: function(ifaces) {
                     if (!Array.isArray(ifaces))
@@ -1938,7 +1938,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     'iface': iface
                 },
                 onFailure: function() {
-                    alert("Could not contact qBittorrent");
+                    alert("QBT_TR(Could not contact qBittorrent)QBT_TR[CONTEXT=HttpServer]");
                 },
                 onSuccess: function(addresses) {
                     if (!addresses)
@@ -1974,7 +1974,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 method: 'get',
                 noCache: true,
                 onFailure: function() {
-                    alert("Could not contact qBittorrent");
+                    alert("QBT_TR(Could not contact qBittorrent)QBT_TR[CONTEXT=HttpServer]");
                 },
                 onSuccess: function(pref) {
                     if (pref) {

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -263,6 +263,9 @@
                 </tr>
             </table>
         </fieldset>
+        <div class="formRow">
+            <input type="button" id="mail_test_button" value="QBT_TR(Send test email)QBT_TR[CONTEXT=OptionsDialog]" onclick="qBittorrent.Preferences.sendTestEmail();" />
+        </div>
     </fieldset>
 
     <fieldset class="settings">
@@ -1537,6 +1540,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 changeWatchFolderSelect: changeWatchFolderSelect,
                 updateMailNotification: updateMailNotification,
                 updateMailAuthSettings: updateMailAuthSettings,
+                sendTestEmail: sendTestEmail,
                 updateAutoRun: updateAutoRun,
                 updateAutoRunOnTorrentAdded: updateAutoRunOnTorrentAdded,
                 generateRandomPort: generateRandomPort,
@@ -1689,6 +1693,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             $('smtp_server_txt').setProperty('disabled', !isMailNotificationEnabled);
             $('mail_ssl_checkbox').setProperty('disabled', !isMailNotificationEnabled);
             $('mail_auth_checkbox').setProperty('disabled', !isMailNotificationEnabled);
+            $('mail_test_button').setProperty('disabled', !isMailNotificationEnabled);
 
             if (!isMailNotificationEnabled) {
                 $('mail_auth_checkbox').setProperty('checked', !isMailNotificationEnabled);
@@ -1700,6 +1705,19 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             const isMailAuthEnabled = $('mail_auth_checkbox').getProperty('checked');
             $('mail_username_text').setProperty('disabled', !isMailAuthEnabled);
             $('mail_password_text').setProperty('disabled', !isMailAuthEnabled);
+        };
+
+        const sendTestEmail = function() {
+            new Request({
+                url: 'api/v2/app/sendTestEmail',
+                method: 'post',
+                onFailure: function() {
+                    alert("QBT_TR(Could not contact qBittorrent)QBT_TR[CONTEXT=HttpServer]");
+                },
+                onSuccess: function() {
+                    alert("QBT_TR(Attempted to send email. Check your inbox to confirm success)QBT_TR[CONTEXT=OptionsDialog]");
+                }
+            }).send();
         };
 
         const updateAutoRunOnTorrentAdded = function() {

--- a/src/webui/www/private/views/rss.html
+++ b/src/webui/www/private/views/rss.html
@@ -194,7 +194,7 @@
                 method: 'get',
                 noCache: true,
                 onFailure: () => {
-                    alert('Could not contact qBittorrent');
+                    alert("QBT_TR(Could not contact qBittorrent)QBT_TR[CONTEXT=HttpServer]");
                 },
                 onSuccess: (pref) => {
                     if (!pref.rss_processing_enabled)

--- a/src/webui/www/private/views/rssDownloader.html
+++ b/src/webui/www/private/views/rssDownloader.html
@@ -363,7 +363,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                 method: 'get',
                 noCache: true,
                 onFailure: () => {
-                    alert('Could not contact qBittorrent');
+                    alert("QBT_TR(Could not contact qBittorrent)QBT_TR[CONTEXT=HttpServer]");
                 },
                 onSuccess: (pref) => {
                     if (!pref.rss_auto_downloading_enabled)


### PR DESCRIPTION
This allows for easily testing whether the provided email configuration is correct. Testing otherwise requires downloading a torrent until completion.

Note that the email is sent using the values currently saved to the config file; NOT necessarily the information currently entered into the options dialog. I'm open to ideas on how to make this more apparent to the user.

<img src="https://github.com/qbittorrent/qBittorrent/assets/8296030/60733163-26de-4ecd-86f5-e3d73b3dd07a" width="600" />
<img src="https://github.com/qbittorrent/qBittorrent/assets/8296030/171cd8cd-ecc2-4dd2-8da1-2c08e99887ea" width="600" />
