### PR TITLE
Revise conditional for when to use QCollator

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -199,11 +199,16 @@ add_library(qbt_base STATIC
 
 target_link_libraries(qbt_base
     PRIVATE
-        OpenSSL::Crypto OpenSSL::SSL
+        OpenSSL::Crypto
+        OpenSSL::SSL
         ZLIB::ZLIB
     PUBLIC
         LibtorrentRasterbar::torrent-rasterbar
-        Qt::Core Qt::Network Qt::Sql Qt::Xml
+        Qt::Core
+        Qt::CorePrivate
+        Qt::Network
+        Qt::Sql
+        Qt::Xml
         qbt_common_cfg
 )
 

--- a/src/base/utils/compare.h
+++ b/src/base/utils/compare.h
@@ -31,6 +31,9 @@
 #include <Qt>
 #include <QtSystemDetection>
 
+// for QT_FEATURE_xxx, see: https://wiki.qt.io/Qt5_Build_System#How_to
+#include <QtCore/private/qtcore-config_p.h>
+
 #if !defined(Q_OS_WIN) && (!defined(Q_OS_UNIX) || defined(Q_OS_MACOS) || defined(QT_FEATURE_icu))
 #define QBT_USE_QCOLLATOR
 #include <QCollator>

--- a/src/base/utils/compare.h
+++ b/src/base/utils/compare.h
@@ -34,7 +34,11 @@
 // for QT_FEATURE_xxx, see: https://wiki.qt.io/Qt5_Build_System#How_to
 #include <QtCore/private/qtcore-config_p.h>
 
-#if !defined(Q_OS_WIN) && (!defined(Q_OS_UNIX) || defined(Q_OS_MACOS) || defined(QT_FEATURE_icu))
+// macOS and Windows support 'case sensitivity' and 'numeric mode' natively
+// https://github.com/qt/qtbase/blob/6.0/src/corelib/CMakeLists.txt#L777-L793
+// https://github.com/qt/qtbase/blob/6.0/src/corelib/text/qcollator_macx.cpp#L74-L77
+// https://github.com/qt/qtbase/blob/6.0/src/corelib/text/qcollator_win.cpp#L72-L78
+#if ((QT_FEATURE_icu == 1) || defined(Q_OS_MACOS) || defined(Q_OS_WIN))
 #define QBT_USE_QCOLLATOR
 #include <QCollator>
 #endif


### PR DESCRIPTION
According to https://doc.qt.io/qt-6/qcollator.html#posix-fallback-implementation
The 'POSIX fallback implementation' is only used when ICU is not available. So the correct way is to detect ICU directly and not depend on the OS. The exceptions are macOS and Windows since they support the required functionalities natively.
Closes #20205.

ps. I can reproduce the issue and confirm the fix.
pps. this is eligible to be backported to v4.6.x