### PR TITLE
Fix Help > Documentation leading to a potentially problematic redirect

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -746,7 +746,7 @@ void MainWindow::updateNbTorrents()
 
 void MainWindow::on_actionDocumentation_triggered() const
 {
-    QDesktopServices::openUrl(QUrl(u"https://doc.qbittorrent.org"_s));
+    QDesktopServices::openUrl(QUrl(u"https://github.com/qbittorrent/qBittorrent/wiki"_s));
 }
 
 void MainWindow::tabChanged([[maybe_unused]] const int newTab)


### PR DESCRIPTION
Closes #18113

Pressing Help > Documentation or F1 would open https://doc.qbittorrent.org, which would redirect to https://github.com/qbittorrent/qBittorrent/wiki/.