### PR TITLE
Fix wrong time stamp values in WebAPI

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -95,6 +95,7 @@ add_library(qbt_base STATIC
     unicodestrings.h
     utils/bytearray.h
     utils/compare.h
+    utils/datetime.h
     utils/foreignapps.h
     utils/fs.h
     utils/gzip.h
@@ -183,6 +184,7 @@ add_library(qbt_base STATIC
     torrentfilter.cpp
     utils/bytearray.cpp
     utils/compare.cpp
+    utils/datetime.cpp
     utils/foreignapps.cpp
     utils/fs.cpp
     utils/gzip.cpp

--- a/src/base/utils/datetime.cpp
+++ b/src/base/utils/datetime.cpp
@@ -1,0 +1,36 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2024  Mike Tzou (Chocobo1)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "datetime.h"
+
+#include <QDateTime>
+
+qint64 Utils::DateTime::toSecsSinceEpoch(const QDateTime &dateTime)
+{
+    return dateTime.isValid() ? dateTime.toSecsSinceEpoch() : -1;
+}

--- a/src/base/utils/datetime.h
+++ b/src/base/utils/datetime.h
@@ -1,0 +1,38 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2024  Mike Tzou (Chocobo1)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+#include <QtTypes>
+
+class QDateTime;
+
+namespace Utils::DateTime
+{
+    qint64 toSecsSinceEpoch(const QDateTime &dateTime);
+}

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -98,11 +98,16 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         return (ratio > BitTorrent::Torrent::MAX_RATIO) ? -1 : ratio;
     };
 
-    const auto getLastActivityTime = [&torrent]() -> qlonglong
+    const auto toTimeStamp = [](const QDateTime &dateTime) -> qint64
+    {
+        return dateTime.isValid() ? dateTime.toSecsSinceEpoch() : -1;
+    };
+
+    const auto getLastActivityTime = [&torrent, &toTimeStamp]() -> qlonglong
     {
         const qlonglong timeSinceActivity = torrent.timeSinceActivity();
         return (timeSinceActivity < 0)
-            ? torrent.addedTime().toSecsSinceEpoch()
+            ? toTimeStamp(torrent.addedTime())
             : (QDateTime::currentDateTime().toSecsSinceEpoch() - timeSinceActivity);
     };
 
@@ -134,8 +139,8 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         {KEY_TORRENT_SAVE_PATH, torrent.savePath().toString()},
         {KEY_TORRENT_DOWNLOAD_PATH, torrent.downloadPath().toString()},
         {KEY_TORRENT_CONTENT_PATH, torrent.contentPath().toString()},
-        {KEY_TORRENT_ADDED_ON, torrent.addedTime().toSecsSinceEpoch()},
-        {KEY_TORRENT_COMPLETION_ON, torrent.completedTime().toSecsSinceEpoch()},
+        {KEY_TORRENT_ADDED_ON, toTimeStamp(torrent.addedTime())},
+        {KEY_TORRENT_COMPLETION_ON, toTimeStamp(torrent.completedTime())},
         {KEY_TORRENT_TRACKER, torrent.currentTracker()},
         {KEY_TORRENT_TRACKERS_COUNT, torrent.trackers().size()},
         {KEY_TORRENT_DL_LIMIT, torrent.downloadLimit()},
@@ -153,7 +158,7 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         {KEY_TORRENT_RATIO_LIMIT, torrent.ratioLimit()},
         {KEY_TORRENT_SEEDING_TIME_LIMIT, torrent.seedingTimeLimit()},
         {KEY_TORRENT_INACTIVE_SEEDING_TIME_LIMIT, torrent.inactiveSeedingTimeLimit()},
-        {KEY_TORRENT_LAST_SEEN_COMPLETE_TIME, torrent.lastSeenComplete().toSecsSinceEpoch()},
+        {KEY_TORRENT_LAST_SEEN_COMPLETE_TIME, toTimeStamp(torrent.lastSeenComplete())},
         {KEY_TORRENT_AUTO_TORRENT_MANAGEMENT, torrent.isAutoTMMEnabled()},
         {KEY_TORRENT_TIME_ACTIVE, torrent.activeTime()},
         {KEY_TORRENT_SEEDING_TIME, torrent.finishedTime()},

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -36,6 +36,7 @@
 #include "base/bittorrent/trackerentry.h"
 #include "base/path.h"
 #include "base/tagset.h"
+#include "base/utils/datetime.h"
 #include "base/utils/string.h"
 
 namespace
@@ -98,16 +99,11 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         return (ratio > BitTorrent::Torrent::MAX_RATIO) ? -1 : ratio;
     };
 
-    const auto toTimeStamp = [](const QDateTime &dateTime) -> qint64
-    {
-        return dateTime.isValid() ? dateTime.toSecsSinceEpoch() : -1;
-    };
-
-    const auto getLastActivityTime = [&torrent, &toTimeStamp]() -> qlonglong
+    const auto getLastActivityTime = [&torrent]() -> qlonglong
     {
         const qlonglong timeSinceActivity = torrent.timeSinceActivity();
         return (timeSinceActivity < 0)
-            ? toTimeStamp(torrent.addedTime())
+            ? Utils::DateTime::toSecsSinceEpoch(torrent.addedTime())
             : (QDateTime::currentDateTime().toSecsSinceEpoch() - timeSinceActivity);
     };
 
@@ -139,8 +135,8 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         {KEY_TORRENT_SAVE_PATH, torrent.savePath().toString()},
         {KEY_TORRENT_DOWNLOAD_PATH, torrent.downloadPath().toString()},
         {KEY_TORRENT_CONTENT_PATH, torrent.contentPath().toString()},
-        {KEY_TORRENT_ADDED_ON, toTimeStamp(torrent.addedTime())},
-        {KEY_TORRENT_COMPLETION_ON, toTimeStamp(torrent.completedTime())},
+        {KEY_TORRENT_ADDED_ON, Utils::DateTime::toSecsSinceEpoch(torrent.addedTime())},
+        {KEY_TORRENT_COMPLETION_ON, Utils::DateTime::toSecsSinceEpoch(torrent.completedTime())},
         {KEY_TORRENT_TRACKER, torrent.currentTracker()},
         {KEY_TORRENT_TRACKERS_COUNT, torrent.trackers().size()},
         {KEY_TORRENT_DL_LIMIT, torrent.downloadLimit()},
@@ -158,7 +154,7 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         {KEY_TORRENT_RATIO_LIMIT, torrent.ratioLimit()},
         {KEY_TORRENT_SEEDING_TIME_LIMIT, torrent.seedingTimeLimit()},
         {KEY_TORRENT_INACTIVE_SEEDING_TIME_LIMIT, torrent.inactiveSeedingTimeLimit()},
-        {KEY_TORRENT_LAST_SEEN_COMPLETE_TIME, toTimeStamp(torrent.lastSeenComplete())},
+        {KEY_TORRENT_LAST_SEEN_COMPLETE_TIME, Utils::DateTime::toSecsSinceEpoch(torrent.lastSeenComplete())},
         {KEY_TORRENT_AUTO_TORRENT_MANAGEMENT, torrent.isAutoTMMEnabled()},
         {KEY_TORRENT_TIME_ACTIVE, torrent.activeTime()},
         {KEY_TORRENT_SEEDING_TIME, torrent.finishedTime()},

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -417,6 +417,11 @@ void TorrentsController::propertiesAction()
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 
+    const auto toTimeStamp = [](const QDateTime &dateTime) -> qint64
+    {
+        return dateTime.isValid() ? dateTime.toSecsSinceEpoch() : -1;
+    };
+
     QJsonObject dataDict;
 
     dataDict[KEY_TORRENT_INFOHASHV1] = torrent->infoHash().v1().toString();
@@ -425,7 +430,7 @@ void TorrentsController::propertiesAction()
     dataDict[KEY_TORRENT_ID] = torrent->id().toString();
     dataDict[KEY_PROP_TIME_ELAPSED] = torrent->activeTime();
     dataDict[KEY_PROP_SEEDING_TIME] = torrent->finishedTime();
-    dataDict[KEY_PROP_ETA] = static_cast<double>(torrent->eta());
+    dataDict[KEY_PROP_ETA] = torrent->eta();
     dataDict[KEY_PROP_CONNECT_COUNT] = torrent->connectionsCount();
     dataDict[KEY_PROP_CONNECT_COUNT_LIMIT] = torrent->connectionsLimit();
     dataDict[KEY_PROP_DOWNLOADED] = torrent->totalDownload();
@@ -454,12 +459,12 @@ void TorrentsController::propertiesAction()
     dataDict[KEY_PROP_PIECES_HAVE] = torrent->piecesHave();
     dataDict[KEY_PROP_CREATED_BY] = torrent->creator();
     dataDict[KEY_PROP_ISPRIVATE] = torrent->isPrivate();
-    dataDict[KEY_PROP_ADDITION_DATE] = static_cast<double>(torrent->addedTime().toSecsSinceEpoch());
+    dataDict[KEY_PROP_ADDITION_DATE] = toTimeStamp(torrent->addedTime());
     if (torrent->hasMetadata())
     {
-        dataDict[KEY_PROP_LAST_SEEN] = torrent->lastSeenComplete().isValid() ? torrent->lastSeenComplete().toSecsSinceEpoch() : -1;
-        dataDict[KEY_PROP_COMPLETION_DATE] = torrent->completedTime().isValid() ? torrent->completedTime().toSecsSinceEpoch() : -1;
-        dataDict[KEY_PROP_CREATION_DATE] = static_cast<double>(torrent->creationDate().toSecsSinceEpoch());
+        dataDict[KEY_PROP_LAST_SEEN] = toTimeStamp(torrent->lastSeenComplete());
+        dataDict[KEY_PROP_COMPLETION_DATE] = toTimeStamp(torrent->completedTime());
+        dataDict[KEY_PROP_CREATION_DATE] = toTimeStamp(torrent->creationDate());
     }
     else
     {

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -413,7 +413,7 @@ void TorrentsController::propertiesAction()
     requireParams({u"hash"_s});
 
     const auto id = BitTorrent::TorrentID::fromString(params()[u"hash"_s]);
-    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(id);
+    const BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(id);
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 
@@ -422,61 +422,59 @@ void TorrentsController::propertiesAction()
         return dateTime.isValid() ? dateTime.toSecsSinceEpoch() : -1;
     };
 
-    QJsonObject dataDict;
-
-    dataDict[KEY_TORRENT_INFOHASHV1] = torrent->infoHash().v1().toString();
-    dataDict[KEY_TORRENT_INFOHASHV2] = torrent->infoHash().v2().toString();
-    dataDict[KEY_TORRENT_NAME] = torrent->name();
-    dataDict[KEY_TORRENT_ID] = torrent->id().toString();
-    dataDict[KEY_PROP_TIME_ELAPSED] = torrent->activeTime();
-    dataDict[KEY_PROP_SEEDING_TIME] = torrent->finishedTime();
-    dataDict[KEY_PROP_ETA] = torrent->eta();
-    dataDict[KEY_PROP_CONNECT_COUNT] = torrent->connectionsCount();
-    dataDict[KEY_PROP_CONNECT_COUNT_LIMIT] = torrent->connectionsLimit();
-    dataDict[KEY_PROP_DOWNLOADED] = torrent->totalDownload();
-    dataDict[KEY_PROP_DOWNLOADED_SESSION] = torrent->totalPayloadDownload();
-    dataDict[KEY_PROP_UPLOADED] = torrent->totalUpload();
-    dataDict[KEY_PROP_UPLOADED_SESSION] = torrent->totalPayloadUpload();
-    dataDict[KEY_PROP_DL_SPEED] = torrent->downloadPayloadRate();
+    const BitTorrent::InfoHash infoHash = torrent->infoHash();
+    const qlonglong totalDownload = torrent->totalDownload();
+    const qlonglong totalUpload = torrent->totalUpload();
     const qlonglong dlDuration = torrent->activeTime() - torrent->finishedTime();
-    dataDict[KEY_PROP_DL_SPEED_AVG] = torrent->totalDownload() / ((dlDuration == 0) ? -1 : dlDuration);
-    dataDict[KEY_PROP_UP_SPEED] = torrent->uploadPayloadRate();
     const qlonglong ulDuration = torrent->activeTime();
-    dataDict[KEY_PROP_UP_SPEED_AVG] = torrent->totalUpload() / ((ulDuration == 0) ? -1 : ulDuration);
-    dataDict[KEY_PROP_DL_LIMIT] = torrent->downloadLimit() <= 0 ? -1 : torrent->downloadLimit();
-    dataDict[KEY_PROP_UP_LIMIT] = torrent->uploadLimit() <= 0 ? -1 : torrent->uploadLimit();
-    dataDict[KEY_PROP_WASTED] = torrent->wastedSize();
-    dataDict[KEY_PROP_SEEDS] = torrent->seedsCount();
-    dataDict[KEY_PROP_SEEDS_TOTAL] = torrent->totalSeedsCount();
-    dataDict[KEY_PROP_PEERS] = torrent->leechsCount();
-    dataDict[KEY_PROP_PEERS_TOTAL] = torrent->totalLeechersCount();
+    const int downloadLimit = torrent->downloadLimit();
+    const int uploadLimit = torrent->uploadLimit();
     const qreal ratio = torrent->realRatio();
-    dataDict[KEY_PROP_RATIO] = ratio > BitTorrent::Torrent::MAX_RATIO ? -1 : ratio;
-    dataDict[KEY_PROP_REANNOUNCE] = torrent->nextAnnounce();
-    dataDict[KEY_PROP_TOTAL_SIZE] = torrent->totalSize();
-    dataDict[KEY_PROP_PIECES_NUM] = torrent->piecesCount();
-    dataDict[KEY_PROP_PIECE_SIZE] = torrent->pieceLength();
-    dataDict[KEY_PROP_PIECES_HAVE] = torrent->piecesHave();
-    dataDict[KEY_PROP_CREATED_BY] = torrent->creator();
-    dataDict[KEY_PROP_ISPRIVATE] = torrent->isPrivate();
-    dataDict[KEY_PROP_ADDITION_DATE] = toTimeStamp(torrent->addedTime());
-    if (torrent->hasMetadata())
-    {
-        dataDict[KEY_PROP_LAST_SEEN] = toTimeStamp(torrent->lastSeenComplete());
-        dataDict[KEY_PROP_COMPLETION_DATE] = toTimeStamp(torrent->completedTime());
-        dataDict[KEY_PROP_CREATION_DATE] = toTimeStamp(torrent->creationDate());
-    }
-    else
-    {
-        dataDict[KEY_PROP_LAST_SEEN] = -1;
-        dataDict[KEY_PROP_COMPLETION_DATE] = -1;
-        dataDict[KEY_PROP_CREATION_DATE] = -1;
-    }
-    dataDict[KEY_PROP_SAVE_PATH] = torrent->savePath().toString();
-    dataDict[KEY_PROP_DOWNLOAD_PATH] = torrent->downloadPath().toString();
-    dataDict[KEY_PROP_COMMENT] = torrent->comment();
 
-    setResult(dataDict);
+    const QJsonObject ret
+    {
+        {KEY_TORRENT_INFOHASHV1, infoHash.v1().toString()},
+        {KEY_TORRENT_INFOHASHV2, infoHash.v2().toString()},
+        {KEY_TORRENT_NAME, torrent->name()},
+        {KEY_TORRENT_ID, torrent->id().toString()},
+        {KEY_PROP_TIME_ELAPSED, torrent->activeTime()},
+        {KEY_PROP_SEEDING_TIME, torrent->finishedTime()},
+        {KEY_PROP_ETA, torrent->eta()},
+        {KEY_PROP_CONNECT_COUNT, torrent->connectionsCount()},
+        {KEY_PROP_CONNECT_COUNT_LIMIT, torrent->connectionsLimit()},
+        {KEY_PROP_DOWNLOADED, totalDownload},
+        {KEY_PROP_DOWNLOADED_SESSION, torrent->totalPayloadDownload()},
+        {KEY_PROP_UPLOADED, totalUpload},
+        {KEY_PROP_UPLOADED_SESSION, torrent->totalPayloadUpload()},
+        {KEY_PROP_DL_SPEED, torrent->downloadPayloadRate()},
+        {KEY_PROP_DL_SPEED_AVG, ((dlDuration > 0) ? (totalDownload / dlDuration) : -1)},
+        {KEY_PROP_UP_SPEED, torrent->uploadPayloadRate()},
+        {KEY_PROP_UP_SPEED_AVG, ((ulDuration > 0) ? (totalUpload / ulDuration) : -1)},
+        {KEY_PROP_DL_LIMIT, ((downloadLimit > 0) ? downloadLimit : -1)},
+        {KEY_PROP_UP_LIMIT, ((uploadLimit > 0) ? uploadLimit : -1)},
+        {KEY_PROP_WASTED, torrent->wastedSize()},
+        {KEY_PROP_SEEDS, torrent->seedsCount()},
+        {KEY_PROP_SEEDS_TOTAL, torrent->totalSeedsCount()},
+        {KEY_PROP_PEERS, torrent->leechsCount()},
+        {KEY_PROP_PEERS_TOTAL, torrent->totalLeechersCount()},
+        {KEY_PROP_RATIO, ((ratio > BitTorrent::Torrent::MAX_RATIO) ? -1 : ratio)},
+        {KEY_PROP_REANNOUNCE, torrent->nextAnnounce()},
+        {KEY_PROP_TOTAL_SIZE, torrent->totalSize()},
+        {KEY_PROP_PIECES_NUM, torrent->piecesCount()},
+        {KEY_PROP_PIECE_SIZE, torrent->pieceLength()},
+        {KEY_PROP_PIECES_HAVE, torrent->piecesHave()},
+        {KEY_PROP_CREATED_BY, torrent->creator()},
+        {KEY_PROP_ISPRIVATE, torrent->isPrivate()},
+        {KEY_PROP_ADDITION_DATE, toTimeStamp(torrent->addedTime())},
+        {KEY_PROP_LAST_SEEN, toTimeStamp(torrent->lastSeenComplete())},
+        {KEY_PROP_COMPLETION_DATE, toTimeStamp(torrent->completedTime())},
+        {KEY_PROP_CREATION_DATE, toTimeStamp(torrent->creationDate())},
+        {KEY_PROP_SAVE_PATH, torrent->savePath().toString()},
+        {KEY_PROP_DOWNLOAD_PATH, torrent->downloadPath().toString()},
+        {KEY_PROP_COMMENT, torrent->comment()}
+    };
+
+    setResult(ret);
 }
 
 // Returns the trackers for a torrent in JSON format.

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -53,6 +53,7 @@
 #include "base/logger.h"
 #include "base/net/downloadmanager.h"
 #include "base/torrentfilter.h"
+#include "base/utils/datetime.h"
 #include "base/utils/fs.h"
 #include "base/utils/string.h"
 #include "apierror.h"
@@ -417,11 +418,6 @@ void TorrentsController::propertiesAction()
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 
-    const auto toTimeStamp = [](const QDateTime &dateTime) -> qint64
-    {
-        return dateTime.isValid() ? dateTime.toSecsSinceEpoch() : -1;
-    };
-
     const BitTorrent::InfoHash infoHash = torrent->infoHash();
     const qlonglong totalDownload = torrent->totalDownload();
     const qlonglong totalUpload = torrent->totalUpload();
@@ -465,10 +461,10 @@ void TorrentsController::propertiesAction()
         {KEY_PROP_PIECES_HAVE, torrent->piecesHave()},
         {KEY_PROP_CREATED_BY, torrent->creator()},
         {KEY_PROP_ISPRIVATE, torrent->isPrivate()},
-        {KEY_PROP_ADDITION_DATE, toTimeStamp(torrent->addedTime())},
-        {KEY_PROP_LAST_SEEN, toTimeStamp(torrent->lastSeenComplete())},
-        {KEY_PROP_COMPLETION_DATE, toTimeStamp(torrent->completedTime())},
-        {KEY_PROP_CREATION_DATE, toTimeStamp(torrent->creationDate())},
+        {KEY_PROP_ADDITION_DATE, Utils::DateTime::toSecsSinceEpoch(torrent->addedTime())},
+        {KEY_PROP_LAST_SEEN, Utils::DateTime::toSecsSinceEpoch(torrent->lastSeenComplete())},
+        {KEY_PROP_COMPLETION_DATE, Utils::DateTime::toSecsSinceEpoch(torrent->completedTime())},
+        {KEY_PROP_CREATION_DATE, Utils::DateTime::toSecsSinceEpoch(torrent->creationDate())},
         {KEY_PROP_SAVE_PATH, torrent->savePath().toString()},
         {KEY_PROP_DOWNLOAD_PATH, torrent->downloadPath().toString()},
         {KEY_PROP_COMMENT, torrent->comment()}

--- a/src/webui/www/private/scripts/prop-general.js
+++ b/src/webui/www/private/scripts/prop-general.js
@@ -165,35 +165,35 @@ window.qBittorrent.PropGeneral = (function() {
                         temp = "QBT_TR(Never)QBT_TR[CONTEXT=PropertiesWidget]";
                     $('last_seen').set('html', temp);
 
-                    $('total_size').set('html', window.qBittorrent.Misc.friendlyUnit(data.total_size));
+                    temp = (data.total_size >= 0) ? window.qBittorrent.Misc.friendlyUnit(data.total_size) : "";
+                    $('total_size').set('html', temp);
 
-                    if (data.pieces_num != -1)
+                    if (data.pieces_num >= 0) {
                         temp = "QBT_TR(%1 x %2 (have %3))QBT_TR[CONTEXT=PropertiesWidget]"
-                        .replace("%1", data.pieces_num)
-                        .replace("%2", window.qBittorrent.Misc.friendlyUnit(data.piece_size))
-                        .replace("%3", data.pieces_have);
-                    else
-                        temp = "QBT_TR(Unknown)QBT_TR[CONTEXT=HttpServer]";
+                            .replace("%1", data.pieces_num)
+                            .replace("%2", window.qBittorrent.Misc.friendlyUnit(data.piece_size))
+                            .replace("%3", data.pieces_have);
+                    }
+                    else {
+                        temp = "";
+                    }
                     $('pieces').set('html', temp);
 
                     $('created_by').set('text', data.created_by);
+
                     if (data.addition_date != -1)
                         temp = new Date(data.addition_date * 1000).toLocaleString();
                     else
                         temp = "QBT_TR(Unknown)QBT_TR[CONTEXT=HttpServer]";
-
                     $('addition_date').set('html', temp);
+
                     if (data.completion_date != -1)
                         temp = new Date(data.completion_date * 1000).toLocaleString();
                     else
                         temp = "";
-
                     $('completion_date').set('html', temp);
 
-                    if (data.creation_date != -1)
-                        temp = new Date(data.creation_date * 1000).toLocaleString();
-                    else
-                        temp = "QBT_TR(Unknown)QBT_TR[CONTEXT=HttpServer]";
+                    temp = (data.creation_date >= 0) ? (new Date(data.creation_date * 1000).toLocaleString()) : "";
                     $('creation_date').set('html', temp);
 
                     if (data.infohash_v1 === "")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,8 +13,9 @@ set(testFiles
     testglobal.cpp
     testorderedset.cpp
     testpath.cpp
-    testutilscompare.cpp
     testutilsbytearray.cpp
+    testutilscompare.cpp
+    testutilsdatetime.cpp
     testutilsgzip.cpp
     testutilsio.cpp
     testutilsstring.cpp

--- a/test/testutilsdatetime.cpp
+++ b/test/testutilsdatetime.cpp
@@ -1,0 +1,52 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2024  Mike Tzou (Chocobo1)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include <QDateTime>
+#include <QTest>
+
+#include "base/utils/datetime.h"
+
+class TestUtilsDateTime final : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(TestUtilsDateTime)
+
+public:
+    TestUtilsDateTime() = default;
+
+private slots:
+    void testToSecsSinceEpoch() const
+    {
+        QCOMPARE(Utils::DateTime::toSecsSinceEpoch(QDateTime()), -1);
+        QCOMPARE(Utils::DateTime::toSecsSinceEpoch(QDateTime::fromSecsSinceEpoch(0)), 0);
+        QCOMPARE(Utils::DateTime::toSecsSinceEpoch(QDateTime::fromSecsSinceEpoch(1)), 1);
+    }
+};
+
+QTEST_APPLESS_MAIN(TestUtilsDateTime)
+#include "testutilsdatetime.moc"


### PR DESCRIPTION
* Fix wrong time stamp values in WebAPI
  The wrong values are observed when encountered an invalid QDateTime data.
* Leave the fields empty when value is invalid
  This follows GUI behavior.
* Use initialization form for variable
* Provide safe helper for converting to 'seconds since epoch'

ps. I intend to use 'rebase and merge' strategy.