### PR TITLE
Set specific exit codes when NSIS installer failed in silent mode 

### DIFF
--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -187,7 +187,7 @@ jobs:
       - name: Create installer
         run: |
           7z x -o"dist/windows/" "dist/windows/NSISPlugins.zip"
-          makensis /DQBT_DIST_DIR="../../upload/qBittorrent" dist/windows/qbittorrent.nsi
+          makensis /DQBT_DIST_DIR="../../upload/qBittorrent" /WX dist/windows/qbittorrent.nsi
 
       - name: Upload installer
         uses: actions/upload-artifact@v4

--- a/dist/windows/installer.nsh
+++ b/dist/windows/installer.nsh
@@ -117,12 +117,14 @@ Function .onInit
   !insertmacro MUI_LANGDLL_DISPLAY
 
   ${IfNot} ${AtLeastWaaS} 1809 ; Windows 10 (1809) / Windows Server 2019. Min supported version by Qt6
-    MessageBox MB_OK|MB_ICONEXCLAMATION $(inst_requires_win10)
+    MessageBox MB_OK|MB_ICONEXCLAMATION $(inst_requires_win10) /SD IDOK
+    SetErrorLevel 1654 # WinError.h: `ERROR_INSTALL_REJECTED`
     Abort
   ${EndIf}
 
   ${IfNot} ${RunningX64}
-    MessageBox MB_OK|MB_ICONEXCLAMATION $(inst_requires_64bit)
+    MessageBox MB_OK|MB_ICONEXCLAMATION $(inst_requires_64bit) /SD IDOK
+    SetErrorLevel 1654 # WinError.h: `ERROR_INSTALL_REJECTED`
     Abort
   ${EndIf}
 
@@ -147,9 +149,10 @@ Function check_instance
   check:
   FindProcDLL::FindProc "qbittorrent.exe"
   StrCmp $R0 "1" 0 notfound
-  MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION $(inst_warning) IDRETRY check IDCANCEL done
+  MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION $(inst_warning) /SD IDCANCEL IDRETRY check IDCANCEL canceled
 
-  done:
+  canceled:
+  SetErrorLevel 15618 # WinError.h: `ERROR_PACKAGES_IN_USE`
   Abort
 
   notfound:

--- a/dist/windows/uninstaller.nsh
+++ b/dist/windows/uninstaller.nsh
@@ -75,15 +75,16 @@ FunctionEnd
 
 Function un.check_instance
 
-    check:
-    FindProcDLL::FindProc "qbittorrent.exe"
-    StrCmp $R0 "1" 0 notfound
-    MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION $(uninst_warning) IDRETRY check IDCANCEL done
+  check:
+  FindProcDLL::FindProc "qbittorrent.exe"
+  StrCmp $R0 "1" 0 notfound
+  MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION $(uninst_warning) /SD IDCANCEL IDRETRY check IDCANCEL canceled
 
-    done:
-    Abort
+  canceled:
+  SetErrorLevel 15618 # WinError.h: `ERROR_PACKAGES_IN_USE`
+  Abort
 
-    notfound:
+  notfound:
 
 FunctionEnd
 


### PR DESCRIPTION
* Set specific exit codes when NSIS installer failed in silent mode
  Related: https://github.com/qbittorrent/qBittorrent/issues/18115#issuecomment-1789404780
* GHA CI: treat NSIS warnings as errors