### PR TITLE
Revamp handling of getting resume data from libtorrent

### DIFF
--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -426,9 +426,7 @@ namespace BitTorrent
         void bottomTorrentsQueuePos(const QVector<TorrentID> &ids) override;
 
         // Torrent interface
-        void handleTorrentNeedSaveResumeData(const TorrentImpl *torrent);
-        void handleTorrentSaveResumeDataRequested(const TorrentImpl *torrent);
-        void handleTorrentSaveResumeDataFailed(const TorrentImpl *torrent);
+        void handleTorrentResumeDataRequested(const TorrentImpl *torrent);
         void handleTorrentShareLimitChanged(TorrentImpl *torrent);
         void handleTorrentNameChanged(TorrentImpl *torrent);
         void handleTorrentSavePathChanged(TorrentImpl *torrent);
@@ -755,7 +753,6 @@ namespace BitTorrent
         QHash<TorrentID, TorrentImpl *> m_hybridTorrentsByAltID;
         QHash<TorrentID, LoadTorrentParams> m_loadingTorrents;
         QHash<TorrentID, RemovingTorrentData> m_removingTorrents;
-        QSet<TorrentID> m_needSaveResumeDataTorrents;
         QHash<TorrentID, TorrentID> m_changedTorrentIDs;
         QMap<QString, CategoryOptions> m_categories;
         TagSet m_tags;

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -264,7 +264,8 @@ namespace BitTorrent
         void handleCategoryOptionsChanged();
         void handleAppendExtensionToggled();
         void handleUnwantedFolderToggled();
-        void saveResumeData(lt::resume_data_flags_t flags = {});
+        void requestResumeData(lt::resume_data_flags_t flags = {});
+        void deferredRequestResumeData();
         void handleMoveStorageJobFinished(const Path &path, MoveStorageContext context, bool hasOutstandingJob);
         void fileSearchFinished(const Path &savePath, const PathList &fileNames);
         TrackerEntry updateTrackerEntry(const lt::announce_entry &announceEntry, const QHash<lt::tcp::endpoint, QMap<int, int>> &updateInfo);
@@ -372,5 +373,7 @@ namespace BitTorrent
 
         QBitArray m_pieces;
         QVector<std::int64_t> m_filesProgress;
+
+        bool m_deferredRequestResumeDataInvoked = false;
     };
 }


### PR DESCRIPTION
The code is restructured to more closely track the number of outstanding resume data requests. Otherwise, it could, under certain conditions, lead to unnecessary waiting at shutdown and adding an error message to the log.