### PR TITLE
Fix typo in preferences.html

### DIFF
--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -2235,7 +2235,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                         // RSS Tab
                         $('enable_fetching_rss_feeds_checkbox').setProperty('checked', pref.rss_processing_enabled);
                         $('feed_refresh_interval').setProperty('value', pref.rss_refresh_interval);
-                        $('feedFetchDelay').setProperty('value', perf.rss_fetch_delay);
+                        $('feedFetchDelay').setProperty('value', pref.rss_fetch_delay);
                         $('maximum_article_number').setProperty('value', pref.rss_max_articles_per_feed);
                         $('enable_auto_downloading_rss_torrents_checkbox').setProperty('checked', pref.rss_auto_downloading_enabled);
                         $('downlock_repack_proper_episodes').setProperty('checked', pref.rss_download_repack_proper_episodes);


### PR DESCRIPTION
Fix a typo caused by merged PR #19801 
The typo causes the Web UI options window to break.
[Link to code-review](https://github.com/qbittorrent/qBittorrent/pull/19801#pullrequestreview-1834730250)