### PR TITLE
Add support for SSL torrents

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(qbt_base STATIC
     bittorrent/sessionimpl.h
     bittorrent/sessionstatus.h
     bittorrent/speedmonitor.h
+    bittorrent/sslparameters.h
     bittorrent/torrent.h
     bittorrent/torrentcontenthandler.h
     bittorrent/torrentcontentlayout.h
@@ -105,6 +106,7 @@ add_library(qbt_base STATIC
     utils/os.h
     utils/password.h
     utils/random.h
+    utils/sslkey.h
     utils/string.h
     utils/thread.h
     utils/version.h
@@ -135,6 +137,7 @@ add_library(qbt_base STATIC
     bittorrent/resumedatastorage.cpp
     bittorrent/sessionimpl.cpp
     bittorrent/speedmonitor.cpp
+    bittorrent/sslparameters.cpp
     bittorrent/torrent.cpp
     bittorrent/torrentcontenthandler.cpp
     bittorrent/torrentcreator.cpp
@@ -194,6 +197,7 @@ add_library(qbt_base STATIC
     utils/os.cpp
     utils/password.cpp
     utils/random.cpp
+    utils/sslkey.cpp
     utils/string.cpp
     utils/thread.cpp
     utils/version.cpp

--- a/src/base/bittorrent/addtorrentparams.h
+++ b/src/base/bittorrent/addtorrentparams.h
@@ -36,6 +36,7 @@
 
 #include "base/path.h"
 #include "base/tagset.h"
+#include "sslparameters.h"
 #include "torrent.h"
 #include "torrentcontentlayout.h"
 
@@ -69,6 +70,7 @@ namespace BitTorrent
         int seedingTimeLimit = Torrent::USE_GLOBAL_SEEDING_TIME;
         int inactiveSeedingTimeLimit = Torrent::USE_GLOBAL_INACTIVE_SEEDING_TIME;
         qreal ratioLimit = Torrent::USE_GLOBAL_RATIO;
+        SSLParameters sslParameters;
 
         friend bool operator==(const AddTorrentParams &lhs, const AddTorrentParams &rhs) = default;
     };

--- a/src/base/bittorrent/loadtorrentparams.h
+++ b/src/base/bittorrent/loadtorrentparams.h
@@ -34,6 +34,7 @@
 
 #include "base/path.h"
 #include "base/tagset.h"
+#include "sslparameters.h"
 #include "torrent.h"
 #include "torrentcontentlayout.h"
 
@@ -61,5 +62,6 @@ namespace BitTorrent
         qreal ratioLimit = Torrent::USE_GLOBAL_RATIO;
         int seedingTimeLimit = Torrent::USE_GLOBAL_SEEDING_TIME;
         int inactiveSeedingTimeLimit = Torrent::USE_GLOBAL_INACTIVE_SEEDING_TIME;
+        SSLParameters sslParameters;
     };
 }

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -267,8 +267,6 @@ namespace BitTorrent
         virtual void setSSLEnabled(bool enabled) = 0;
         virtual int sslPort() const = 0;
         virtual void setSSLPort(int port) = 0;
-        virtual Path sslCertificatesDirectory() const = 0;
-        virtual void setSSLCertificatesDirectory(const Path &path) = 0;
         virtual QString networkInterface() const = 0;
         virtual void setNetworkInterface(const QString &iface) = 0;
         virtual QString networkInterfaceName() const = 0;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -263,6 +263,12 @@ namespace BitTorrent
         virtual void setSaveResumeDataInterval(int value) = 0;
         virtual int port() const = 0;
         virtual void setPort(int port) = 0;
+        virtual bool isSSLEnabled() const = 0;
+        virtual void setSSLEnabled(bool enabled) = 0;
+        virtual int sslPort() const = 0;
+        virtual void setSSLPort(int port) = 0;
+        virtual Path sslCertificatesDirectory() const = 0;
+        virtual void setSSLCertificatesDirectory(const Path &path) = 0;
         virtual QString networkInterface() const = 0;
         virtual void setNetworkInterface(const QString &iface) = 0;
         virtual QString networkInterfaceName() const = 0;

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -234,8 +234,6 @@ namespace BitTorrent
         void setSSLEnabled(bool enabled) override;
         int sslPort() const override;
         void setSSLPort(int port) override;
-        Path sslCertificatesDirectory() const override;
-        void setSSLCertificatesDirectory(const Path &path) override;
         QString networkInterface() const override;
         void setNetworkInterface(const QString &iface) override;
         QString networkInterfaceName() const override;
@@ -458,7 +456,6 @@ namespace BitTorrent
 
         void findIncompleteFiles(const TorrentInfo &torrentInfo, const Path &savePath
                                  , const Path &downloadPath, const PathList &filePaths = {}) const;
-        std::tuple<Path, Path, Path> sslCertificatesPathsForTorrent(const TorrentID &torrentId) const;
 
         void enablePortMapping();
         void disablePortMapping();
@@ -550,7 +547,7 @@ namespace BitTorrent
         void handleTorrentRemovedAlert(const lt::torrent_removed_alert *p);
         void handleTorrentDeletedAlert(const lt::torrent_deleted_alert *p);
         void handleTorrentDeleteFailedAlert(const lt::torrent_delete_failed_alert *p);
-        void handleTorrentNeedCertAlert(const lt::torrent_need_cert_alert *p);
+        void handleTorrentNeedCertAlert(const lt::torrent_need_cert_alert *a);
         void handlePortmapWarningAlert(const lt::portmap_error_alert *p);
         void handlePortmapAlert(const lt::portmap_alert *p);
         void handlePeerBlockedAlert(const lt::peer_blocked_alert *p);
@@ -686,7 +683,6 @@ namespace BitTorrent
         CachedSettingValue<int> m_port;
         CachedSettingValue<bool> m_sslEnabled;
         CachedSettingValue<int> m_sslPort;
-        CachedSettingValue<Path> m_sslCertificatesDirectory;
         CachedSettingValue<QString> m_networkInterface;
         CachedSettingValue<QString> m_networkInterfaceName;
         CachedSettingValue<QString> m_networkInterfaceAddress;

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -230,6 +230,12 @@ namespace BitTorrent
         void setSaveResumeDataInterval(int value) override;
         int port() const override;
         void setPort(int port) override;
+        bool isSSLEnabled() const override;
+        void setSSLEnabled(bool enabled) override;
+        int sslPort() const override;
+        void setSSLPort(int port) override;
+        Path sslCertificatesDirectory() const override;
+        void setSSLCertificatesDirectory(const Path &path) override;
         QString networkInterface() const override;
         void setNetworkInterface(const QString &iface) override;
         QString networkInterfaceName() const override;
@@ -452,6 +458,7 @@ namespace BitTorrent
 
         void findIncompleteFiles(const TorrentInfo &torrentInfo, const Path &savePath
                                  , const Path &downloadPath, const PathList &filePaths = {}) const;
+        std::tuple<Path, Path, Path> sslCertificatesPathsForTorrent(const TorrentID &torrentId) const;
 
         void enablePortMapping();
         void disablePortMapping();
@@ -543,6 +550,7 @@ namespace BitTorrent
         void handleTorrentRemovedAlert(const lt::torrent_removed_alert *p);
         void handleTorrentDeletedAlert(const lt::torrent_deleted_alert *p);
         void handleTorrentDeleteFailedAlert(const lt::torrent_delete_failed_alert *p);
+        void handleTorrentNeedCertAlert(const lt::torrent_need_cert_alert *p);
         void handlePortmapWarningAlert(const lt::portmap_error_alert *p);
         void handlePortmapAlert(const lt::portmap_alert *p);
         void handlePeerBlockedAlert(const lt::peer_blocked_alert *p);
@@ -676,6 +684,9 @@ namespace BitTorrent
         CachedSettingValue<bool> m_isPerformanceWarningEnabled;
         CachedSettingValue<int> m_saveResumeDataInterval;
         CachedSettingValue<int> m_port;
+        CachedSettingValue<bool> m_sslEnabled;
+        CachedSettingValue<int> m_sslPort;
+        CachedSettingValue<Path> m_sslCertificatesDirectory;
         CachedSettingValue<QString> m_networkInterface;
         CachedSettingValue<QString> m_networkInterfaceName;
         CachedSettingValue<QString> m_networkInterfaceAddress;

--- a/src/base/bittorrent/sslparameters.cpp
+++ b/src/base/bittorrent/sslparameters.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2016  Alexandr Milovantsev <dzmat@yandex.ru>
+ * Copyright (C) 2024  Mike Tzou (Chocobo1)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -26,31 +26,9 @@
  * exception statement from your version.
  */
 
-#pragma once
+#include "sslparameters.h"
 
-#include <optional>
-#include <utility>
-
-#include <QtContainerFwd>
-#include <QHostAddress>
-
-class QSslCertificate;
-class QSslKey;
-class QString;
-
-namespace Utils::Net
+bool BitTorrent::SSLParameters::isValid() const
 {
-    // alias for `QHostAddress::parseSubnet()` return type
-    using Subnet = std::pair<QHostAddress, int>;
-
-    bool isValidIP(const QString &ip);
-    std::optional<Subnet> parseSubnet(const QString &subnetStr);
-    bool isLoopbackAddress(const QHostAddress &addr);
-    bool isIPInSubnets(const QHostAddress &addr, const QVector<Subnet> &subnets);
-    QString subnetToString(const Subnet &subnet);
-    QHostAddress canonicalIPv6Addr(const QHostAddress &addr);
-
-    inline const int MAX_SSL_FILE_SIZE = 1024 * 1024;
-    QList<QSslCertificate> loadSSLCertificate(const QByteArray &data);
-    bool isSSLCertificatesValid(const QByteArray &data);
+    return (!certificate.isNull() && !privateKey.isNull() && !dhParams.isEmpty());
 }

--- a/src/base/bittorrent/sslparameters.h
+++ b/src/base/bittorrent/sslparameters.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2016  Alexandr Milovantsev <dzmat@yandex.ru>
+ * Copyright (C) 2024  Mike Tzou (Chocobo1)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -28,29 +28,20 @@
 
 #pragma once
 
-#include <optional>
-#include <utility>
+#include <QByteArray>
+#include <QSslCertificate>
+#include <QSslKey>
 
-#include <QtContainerFwd>
-#include <QHostAddress>
-
-class QSslCertificate;
-class QSslKey;
-class QString;
-
-namespace Utils::Net
+namespace BitTorrent
 {
-    // alias for `QHostAddress::parseSubnet()` return type
-    using Subnet = std::pair<QHostAddress, int>;
+    struct SSLParameters
+    {
+        QSslCertificate certificate {{}};
+        QSslKey privateKey;
+        QByteArray dhParams;
 
-    bool isValidIP(const QString &ip);
-    std::optional<Subnet> parseSubnet(const QString &subnetStr);
-    bool isLoopbackAddress(const QHostAddress &addr);
-    bool isIPInSubnets(const QHostAddress &addr, const QVector<Subnet> &subnets);
-    QString subnetToString(const Subnet &subnet);
-    QHostAddress canonicalIPv6Addr(const QHostAddress &addr);
+        bool isValid() const;
 
-    inline const int MAX_SSL_FILE_SIZE = 1024 * 1024;
-    QList<QSslCertificate> loadSSLCertificate(const QByteArray &data);
-    bool isSSLCertificatesValid(const QByteArray &data);
+        friend bool operator==(const SSLParameters &left, const SSLParameters &right) = default;
+    };
 }

--- a/src/base/bittorrent/torrent.h
+++ b/src/base/bittorrent/torrent.h
@@ -303,6 +303,7 @@ namespace BitTorrent
         virtual bool connectPeer(const PeerAddress &peerAddress) = 0;
         virtual void clearPeers() = 0;
         virtual void setMetadata(const TorrentInfo &torrentInfo) = 0;
+        virtual void setSSLCertificate(const QByteArray &certificate, const QByteArray &privateKey, const QByteArray &dhParams) = 0;
 
         virtual StopCondition stopCondition() const = 0;
         virtual void setStopCondition(StopCondition stopCondition) = 0;

--- a/src/base/bittorrent/torrent.h
+++ b/src/base/bittorrent/torrent.h
@@ -53,6 +53,7 @@ namespace BitTorrent
     class TorrentID;
     class TorrentInfo;
     struct PeerAddress;
+    struct SSLParameters;
     struct TrackerEntry;
 
     // Using `Q_ENUM_NS()` without a wrapper namespace in our case is not advised
@@ -303,10 +304,11 @@ namespace BitTorrent
         virtual bool connectPeer(const PeerAddress &peerAddress) = 0;
         virtual void clearPeers() = 0;
         virtual void setMetadata(const TorrentInfo &torrentInfo) = 0;
-        virtual void setSSLCertificate(const QByteArray &certificate, const QByteArray &privateKey, const QByteArray &dhParams) = 0;
 
         virtual StopCondition stopCondition() const = 0;
         virtual void setStopCondition(StopCondition stopCondition) = 0;
+        virtual SSLParameters getSSLParameters() const = 0;
+        virtual void setSSLParameters(const SSLParameters &sslParams) = 0;
 
         virtual QString createMagnetURI() const = 0;
         virtual nonstd::expected<QByteArray, QString> exportToBuffer() const = 0;

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -240,6 +240,7 @@ namespace BitTorrent
         bool connectPeer(const PeerAddress &peerAddress) override;
         void clearPeers() override;
         void setMetadata(const TorrentInfo &torrentInfo) override;
+        void setSSLCertificate(const QByteArray &certificate, const QByteArray &privateKey, const QByteArray &dhParams) override;
 
         StopCondition stopCondition() const override;
         void setStopCondition(StopCondition stopCondition) override;

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -51,6 +51,7 @@
 #include "base/tagset.h"
 #include "infohash.h"
 #include "speedmonitor.h"
+#include "sslparameters.h"
 #include "torrent.h"
 #include "torrentcontentlayout.h"
 #include "torrentinfo.h"
@@ -240,10 +241,12 @@ namespace BitTorrent
         bool connectPeer(const PeerAddress &peerAddress) override;
         void clearPeers() override;
         void setMetadata(const TorrentInfo &torrentInfo) override;
-        void setSSLCertificate(const QByteArray &certificate, const QByteArray &privateKey, const QByteArray &dhParams) override;
 
         StopCondition stopCondition() const override;
         void setStopCondition(StopCondition stopCondition) override;
+        SSLParameters getSSLParameters() const override;
+        void setSSLParameters(const SSLParameters &sslParams) override;
+        bool applySSLParameters();
 
         QString createMagnetURI() const override;
         nonstd::expected<QByteArray, QString> exportToBuffer() const override;
@@ -364,6 +367,7 @@ namespace BitTorrent
         bool m_useAutoTMM;
         bool m_isStopped;
         StopCondition m_stopCondition = StopCondition::None;
+        SSLParameters m_sslParams;
 
         bool m_unchecked = false;
 

--- a/src/base/http/server.cpp
+++ b/src/base/http/server.cpp
@@ -43,6 +43,7 @@
 #include "base/algorithm.h"
 #include "base/global.h"
 #include "base/utils/net.h"
+#include "base/utils/sslkey.h"
 #include "connection.h"
 
 using namespace std::chrono_literals;
@@ -161,7 +162,7 @@ void Server::dropTimedOutConnection()
 bool Server::setupHttps(const QByteArray &certificates, const QByteArray &privateKey)
 {
     const QList<QSslCertificate> certs {Utils::Net::loadSSLCertificate(certificates)};
-    const QSslKey key {Utils::Net::loadSSLKey(privateKey)};
+    const QSslKey key {Utils::SSLKey::load(privateKey)};
 
     if (certs.isEmpty() || key.isNull())
     {

--- a/src/base/utils/net.cpp
+++ b/src/base/utils/net.cpp
@@ -136,19 +136,5 @@ namespace Utils
         {
             return !loadSSLCertificate(data).isEmpty();
         }
-
-        QSslKey loadSSLKey(const QByteArray &data)
-        {
-            // try different formats
-            const QSslKey key {data, QSsl::Rsa};
-            if (!key.isNull())
-                return key;
-            return {data, QSsl::Ec};
-        }
-
-        bool isSSLKeyValid(const QByteArray &data)
-        {
-            return !loadSSLKey(data).isNull();
-        }
     }
 }

--- a/src/base/utils/sslkey.cpp
+++ b/src/base/utils/sslkey.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2016  Alexandr Milovantsev <dzmat@yandex.ru>
+ * Copyright (C) 2024  Mike Tzou (Chocobo1)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -26,31 +26,15 @@
  * exception statement from your version.
  */
 
-#pragma once
+#include "sslkey.h"
 
-#include <optional>
-#include <utility>
+#include <QByteArray>
+#include <QSslKey>
 
-#include <QtContainerFwd>
-#include <QHostAddress>
-
-class QSslCertificate;
-class QSslKey;
-class QString;
-
-namespace Utils::Net
+QSslKey Utils::SSLKey::load(const QByteArray &data)
 {
-    // alias for `QHostAddress::parseSubnet()` return type
-    using Subnet = std::pair<QHostAddress, int>;
-
-    bool isValidIP(const QString &ip);
-    std::optional<Subnet> parseSubnet(const QString &subnetStr);
-    bool isLoopbackAddress(const QHostAddress &addr);
-    bool isIPInSubnets(const QHostAddress &addr, const QVector<Subnet> &subnets);
-    QString subnetToString(const Subnet &subnet);
-    QHostAddress canonicalIPv6Addr(const QHostAddress &addr);
-
-    inline const int MAX_SSL_FILE_SIZE = 1024 * 1024;
-    QList<QSslCertificate> loadSSLCertificate(const QByteArray &data);
-    bool isSSLCertificatesValid(const QByteArray &data);
+    // try different formats
+    if (const QSslKey key {data, QSsl::Ec}; !key.isNull())
+        return key;
+    return {data, QSsl::Rsa};
 }

--- a/src/base/utils/sslkey.h
+++ b/src/base/utils/sslkey.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2016  Alexandr Milovantsev <dzmat@yandex.ru>
+ * Copyright (C) 2024  Mike Tzou (Chocobo1)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -28,29 +28,10 @@
 
 #pragma once
 
-#include <optional>
-#include <utility>
-
-#include <QtContainerFwd>
-#include <QHostAddress>
-
-class QSslCertificate;
+class QByteArray;
 class QSslKey;
-class QString;
 
-namespace Utils::Net
+namespace Utils::SSLKey
 {
-    // alias for `QHostAddress::parseSubnet()` return type
-    using Subnet = std::pair<QHostAddress, int>;
-
-    bool isValidIP(const QString &ip);
-    std::optional<Subnet> parseSubnet(const QString &subnetStr);
-    bool isLoopbackAddress(const QHostAddress &addr);
-    bool isIPInSubnets(const QHostAddress &addr, const QVector<Subnet> &subnets);
-    QString subnetToString(const Subnet &subnet);
-    QHostAddress canonicalIPv6Addr(const QHostAddress &addr);
-
-    inline const int MAX_SSL_FILE_SIZE = 1024 * 1024;
-    QList<QSslCertificate> loadSSLCertificate(const QByteArray &data);
-    bool isSSLCertificatesValid(const QByteArray &data);
+    QSslKey load(const QByteArray &data);
 }

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -783,6 +783,9 @@ void OptionsDialog::loadConnectionTabOptions()
 
     m_ui->comboProtocol->setCurrentIndex(static_cast<int>(session->btProtocol()));
     m_ui->spinPort->setValue(session->port());
+    m_ui->spinSSLPort->setEnabled(session->isSSLEnabled());
+    m_ui->spinSSLPort->setValue(session->sslPort());
+    m_ui->groupSSL->setChecked(session->isSSLEnabled());
     m_ui->checkUPnP->setChecked(Net::PortForwarder::instance()->isEnabled());
 
     int intValue = session->maxConnections();
@@ -885,6 +888,8 @@ void OptionsDialog::loadConnectionTabOptions()
 
     connect(m_ui->comboProtocol, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->spinPort, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
+    connect(m_ui->spinSSLPort, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
+    connect(m_ui->groupSSL, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkUPnP, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
 
     connect(m_ui->checkMaxConnections, &QAbstractButton::toggled, m_ui->spinMaxConnec, &QWidget::setEnabled);
@@ -936,6 +941,8 @@ void OptionsDialog::saveConnectionTabOptions() const
 
     session->setBTProtocol(static_cast<BitTorrent::BTProtocol>(m_ui->comboProtocol->currentIndex()));
     session->setPort(getPort());
+    session->setSSLEnabled(m_ui->groupSSL->isChecked());
+    session->setSSLPort(m_ui->spinSSLPort->value());
     Net::PortForwarder::instance()->setEnabled(isUPnPEnabled());
 
     session->setMaxConnections(getMaxConnections());
@@ -1455,6 +1462,14 @@ void OptionsDialog::on_randomButton_clicked()
 {
     // Range [1024: 65535]
     m_ui->spinPort->setValue(Utils::Random::rand(1024, 65535));
+}
+
+void OptionsDialog::on_randomSSLButton_clicked()
+{
+    int sslPort = 0;
+    while ((sslPort == getPort()) || (sslPort <= 0))
+        sslPort = Utils::Random::rand(1024, 65535);
+    m_ui->spinSSLPort->setValue(sslPort);
 }
 
 int OptionsDialog::getEncryptionSetting() const

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -100,6 +100,7 @@ private slots:
     void on_banListButton_clicked();
     void on_IPSubnetWhitelistButton_clicked();
     void on_randomButton_clicked();
+    void on_randomSSLButton_clicked();
     void on_addWatchedFolderButton_clicked();
     void on_editWatchedFolderButton_clicked();
     void on_removeWatchedFolderButton_clicked();

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -100,7 +100,6 @@ private slots:
     void on_banListButton_clicked();
     void on_IPSubnetWhitelistButton_clicked();
     void on_randomButton_clicked();
-    void on_randomSSLButton_clicked();
     void on_addWatchedFolderButton_clicked();
     void on_editWatchedFolderButton_clicked();
     void on_removeWatchedFolderButton_clicked();

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -1779,58 +1779,6 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                  </property>
                 </widget>
                </item>
-               <item>
-                <widget class="QGroupBox" name="groupSSL">
-                 <property name="title">
-                  <string>SSL Torrents</string>
-                 </property>
-                 <property name="checkable">
-                  <bool>true</bool>
-                 </property>
-                 <property name="checked">
-                  <bool>false</bool>
-                 </property>
-                 <layout class="QHBoxLayout" name="horizontalLayout_21">
-                  <item>
-                   <widget class="QLabel" name="lblSSLPort">
-                    <property name="text">
-                     <string>Port used for incoming SSL connections:</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QSpinBox" name="spinSSLPort">
-                    <property name="specialValueText">
-                     <string>Any</string>
-                    </property>
-                    <property name="maximum">
-                     <number>65535</number>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QPushButton" name="randomSSLButton">
-                    <property name="text">
-                     <string>Random</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <spacer name="horizontalSpacer_25">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
               </layout>
              </widget>
             </item>
@@ -4060,8 +4008,6 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
   <tabstop>domainNameTxt</tabstop>
   <tabstop>DNSUsernameTxt</tabstop>
   <tabstop>DNSPasswordTxt</tabstop>
-  <tabstop>randomSSLButton</tabstop>
-  <tabstop>spinSSLPort</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -1779,6 +1779,58 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                  </property>
                 </widget>
                </item>
+               <item>
+                <widget class="QGroupBox" name="groupSSL">
+                 <property name="title">
+                  <string>SSL Torrents</string>
+                 </property>
+                 <property name="checkable">
+                  <bool>true</bool>
+                 </property>
+                 <property name="checked">
+                  <bool>false</bool>
+                 </property>
+                 <layout class="QHBoxLayout" name="horizontalLayout_21">
+                  <item>
+                   <widget class="QLabel" name="lblSSLPort">
+                    <property name="text">
+                     <string>Port used for incoming SSL connections:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QSpinBox" name="spinSSLPort">
+                    <property name="specialValueText">
+                     <string>Any</string>
+                    </property>
+                    <property name="maximum">
+                     <number>65535</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QPushButton" name="randomSSLButton">
+                    <property name="text">
+                     <string>Random</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="horizontalSpacer_25">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
               </layout>
              </widget>
             </item>
@@ -4008,6 +4060,8 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
   <tabstop>domainNameTxt</tabstop>
   <tabstop>DNSUsernameTxt</tabstop>
   <tabstop>DNSPasswordTxt</tabstop>
+  <tabstop>randomSSLButton</tabstop>
+  <tabstop>spinSSLPort</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -189,6 +189,8 @@ void AppController::preferencesAction()
     // Connection
     // Listening Port
     data[u"listen_port"_s] = session->port();
+    data[u"ssl_enabled"_s] = session->isSSLEnabled();
+    data[u"ssl_listen_port"_s] = session->sslPort();
     data[u"random_port"_s] = (session->port() == 0);  // deprecated
     data[u"upnp"_s] = Net::PortForwarder::instance()->isEnabled();
     // Connections Limits
@@ -642,6 +644,11 @@ void AppController::setPreferencesAction()
     {
         session->setPort(it.value().toInt());
     }
+    // SSL Torrents
+    if (hasKey(u"ssl_enabled"_s))
+        session->setSSLEnabled(it.value().toBool());
+    if (hasKey(u"ssl_listen_port"_s))
+        session->setSSLPort(it.value().toInt());
     if (hasKey(u"upnp"_s))
         Net::PortForwarder::instance()->setEnabled(it.value().toBool());
     // Connections Limits

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -45,6 +45,7 @@
 #include "base/bittorrent/peeraddress.h"
 #include "base/bittorrent/peerinfo.h"
 #include "base/bittorrent/session.h"
+#include "base/bittorrent/sslparameters.h"
 #include "base/bittorrent/torrent.h"
 #include "base/bittorrent/torrentdescriptor.h"
 #include "base/bittorrent/trackerentry.h"
@@ -55,6 +56,7 @@
 #include "base/torrentfilter.h"
 #include "base/utils/datetime.h"
 #include "base/utils/fs.h"
+#include "base/utils/sslkey.h"
 #include "base/utils/string.h"
 #include "apierror.h"
 #include "serialize/serialize_torrent.h"
@@ -108,6 +110,9 @@ const QString KEY_PROP_SAVE_PATH = u"save_path"_s;
 const QString KEY_PROP_DOWNLOAD_PATH = u"download_path"_s;
 const QString KEY_PROP_COMMENT = u"comment"_s;
 const QString KEY_PROP_ISPRIVATE = u"is_private"_s;
+const QString KEY_PROP_SSL_CERTIFICATE = u"ssl_certificate"_s;
+const QString KEY_PROP_SSL_PRIVATEKEY = u"ssl_private_key"_s;
+const QString KEY_PROP_SSL_DHPARAMS = u"ssl_dh_params"_s;
 
 // File keys
 const QString KEY_FILE_INDEX = u"index"_s;
@@ -721,27 +726,38 @@ void TorrentsController::addAction()
         }
     }
 
-    BitTorrent::AddTorrentParams addTorrentParams;
-    // TODO: Check if destination actually exists
-    addTorrentParams.skipChecking = skipChecking;
-    addTorrentParams.sequential = seqDownload;
-    addTorrentParams.firstLastPiecePriority = firstLastPiece;
-    addTorrentParams.addToQueueTop = addToQueueTop;
-    addTorrentParams.addPaused = addPaused;
-    addTorrentParams.stopCondition = stopCondition;
-    addTorrentParams.contentLayout = contentLayout;
-    addTorrentParams.savePath = Path(savepath);
-    addTorrentParams.downloadPath = Path(downloadPath);
-    addTorrentParams.useDownloadPath = useDownloadPath;
-    addTorrentParams.category = category;
-    addTorrentParams.tags.insert(tags.cbegin(), tags.cend());
-    addTorrentParams.name = torrentName;
-    addTorrentParams.uploadLimit = upLimit;
-    addTorrentParams.downloadLimit = dlLimit;
-    addTorrentParams.seedingTimeLimit = seedingTimeLimit;
-    addTorrentParams.inactiveSeedingTimeLimit = inactiveSeedingTimeLimit;
-    addTorrentParams.ratioLimit = ratioLimit;
-    addTorrentParams.useAutoTMM = autoTMM;
+    const BitTorrent::AddTorrentParams addTorrentParams
+    {
+        // TODO: Check if destination actually exists
+        .name = torrentName,
+        .category = category,
+        .tags = {tags.cbegin(), tags.cend()},
+        .savePath = Path(savepath),
+        .useDownloadPath = useDownloadPath,
+        .downloadPath = Path(downloadPath),
+        .sequential = seqDownload,
+        .firstLastPiecePriority = firstLastPiece,
+        .addForced = false,
+        .addToQueueTop = addToQueueTop,
+        .addPaused = addPaused,
+        .stopCondition = stopCondition,
+        .filePaths = {},
+        .filePriorities = {},
+        .skipChecking = skipChecking,
+        .contentLayout = contentLayout,
+        .useAutoTMM = autoTMM,
+        .uploadLimit = upLimit,
+        .downloadLimit = dlLimit,
+        .seedingTimeLimit = seedingTimeLimit,
+        .inactiveSeedingTimeLimit = inactiveSeedingTimeLimit,
+        .ratioLimit = ratioLimit,
+        .sslParameters =
+        {
+            .certificate = QSslCertificate(params()[KEY_PROP_SSL_CERTIFICATE].toLatin1()),
+            .privateKey = Utils::SSLKey::load(params()[KEY_PROP_SSL_PRIVATEKEY].toLatin1()),
+            .dhParams = params()[KEY_PROP_SSL_DHPARAMS].toLatin1()
+        }
+    };
 
     bool partialSuccess = false;
     for (QString url : asConst(urls.split(u'\n')))
@@ -1213,27 +1229,6 @@ void TorrentsController::setAutoManagementAction()
     });
 }
 
-void TorrentsController::setSSLCertificateAction()
-{
-    requireParams({u"hash"_s});
-    const auto id = BitTorrent::TorrentID::fromString(params()[u"hash"_s]);
-    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(id);
-    if (!torrent)
-        throw APIError(APIErrorType::NotFound);
-
-    for (const auto &file: {u"certificate"_s, u"privateKey"_s, u"dhParams"_s})
-    {
-        if (!data().contains(file))
-            throw APIError(APIErrorType::BadData);
-    }
-
-    const QByteArray certificate = data()[u"certificate"_s];
-    const QByteArray privateKey = data()[u"privateKey"_s];
-    const QByteArray dhParams = data()[u"dhParams"_s];
-
-    torrent->setSSLCertificate(certificate, privateKey, dhParams);
-}
-
 void TorrentsController::recheckAction()
 {
     requireParams({u"hashes"_s});
@@ -1464,4 +1459,44 @@ void TorrentsController::exportAction()
         throw APIError(APIErrorType::Conflict, tr("Unable to export torrent file. Error: %1").arg(result.error()));
 
     setResult(result.value());
+}
+
+void TorrentsController::SSLParametersAction()
+{
+    requireParams({u"hash"_s});
+
+    const auto id = BitTorrent::TorrentID::fromString(params()[u"hash"_s]);
+    const BitTorrent::Torrent *torrent = BitTorrent::Session::instance()->getTorrent(id);
+    if (!torrent)
+        throw APIError(APIErrorType::NotFound);
+
+    const BitTorrent::SSLParameters sslParams = torrent->getSSLParameters();
+    const QJsonObject ret
+    {
+        {KEY_PROP_SSL_CERTIFICATE, QString::fromLatin1(sslParams.certificate.toPem())},
+        {KEY_PROP_SSL_PRIVATEKEY, QString::fromLatin1(sslParams.privateKey.toPem())},
+        {KEY_PROP_SSL_DHPARAMS, QString::fromLatin1(sslParams.dhParams)}
+    };
+    setResult(ret);
+}
+
+void TorrentsController::setSSLParametersAction()
+{
+    requireParams({u"hash"_s, KEY_PROP_SSL_CERTIFICATE, KEY_PROP_SSL_PRIVATEKEY, KEY_PROP_SSL_DHPARAMS});
+
+    const auto id = BitTorrent::TorrentID::fromString(params()[u"hash"_s]);
+    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(id);
+    if (!torrent)
+        throw APIError(APIErrorType::NotFound);
+
+    const BitTorrent::SSLParameters sslParams
+    {
+        .certificate = QSslCertificate(params()[KEY_PROP_SSL_CERTIFICATE].toLatin1()),
+        .privateKey = Utils::SSLKey::load(params()[KEY_PROP_SSL_PRIVATEKEY].toLatin1()),
+        .dhParams = params()[KEY_PROP_SSL_DHPARAMS].toLatin1()
+    };
+    if (!sslParams.isValid())
+        throw APIError(APIErrorType::BadData);
+
+    torrent->setSSLParameters(sslParams);
 }

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -1213,6 +1213,27 @@ void TorrentsController::setAutoManagementAction()
     });
 }
 
+void TorrentsController::setSSLCertificateAction()
+{
+    requireParams({u"hash"_s});
+    const auto id = BitTorrent::TorrentID::fromString(params()[u"hash"_s]);
+    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(id);
+    if (!torrent)
+        throw APIError(APIErrorType::NotFound);
+
+    for (const auto &file: {u"certificate"_s, u"privateKey"_s, u"dhParams"_s})
+    {
+        if (!data().contains(file))
+            throw APIError(APIErrorType::BadData);
+    }
+
+    const QByteArray certificate = data()[u"certificate"_s];
+    const QByteArray privateKey = data()[u"privateKey"_s];
+    const QByteArray dhParams = data()[u"dhParams"_s];
+
+    torrent->setSSLCertificate(certificate, privateKey, dhParams);
+}
+
 void TorrentsController::recheckAction()
 {
     requireParams({u"hashes"_s});

--- a/src/webui/api/torrentscontroller.h
+++ b/src/webui/api/torrentscontroller.h
@@ -84,6 +84,7 @@ private slots:
     void setAutoManagementAction();
     void setSuperSeedingAction();
     void setForceStartAction();
+    void setSSLCertificateAction();
     void toggleSequentialDownloadAction();
     void toggleFirstLastPiecePrioAction();
     void renameFileAction();

--- a/src/webui/api/torrentscontroller.h
+++ b/src/webui/api/torrentscontroller.h
@@ -84,10 +84,11 @@ private slots:
     void setAutoManagementAction();
     void setSuperSeedingAction();
     void setForceStartAction();
-    void setSSLCertificateAction();
     void toggleSequentialDownloadAction();
     void toggleFirstLastPiecePrioAction();
     void renameFileAction();
     void renameFolderAction();
     void exportAction();
+    void SSLParametersAction();
+    void setSSLParametersAction();
 };

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -53,7 +53,7 @@
 #include "base/utils/version.h"
 #include "api/isessionmanager.h"
 
-inline const Utils::Version<3, 2> API_VERSION {2, 10, 2};
+inline const Utils::Version<3, 2> API_VERSION {2, 10, 3};
 
 class QTimer;
 
@@ -204,6 +204,7 @@ private:
         {{u"torrents"_s, u"setLocation"_s}, Http::METHOD_POST},
         {{u"torrents"_s, u"setSavePath"_s}, Http::METHOD_POST},
         {{u"torrents"_s, u"setShareLimits"_s}, Http::METHOD_POST},
+        {{u"torrents"_s, u"setSSLParameters"_s}, Http::METHOD_POST},
         {{u"torrents"_s, u"setSuperSeeding"_s}, Http::METHOD_POST},
         {{u"torrents"_s, u"setUploadLimit"_s}, Http::METHOD_POST},
         {{u"torrents"_s, u"toggleFirstLastPiecePrio"_s}, Http::METHOD_POST},

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -319,17 +319,6 @@
             <input type="checkbox" id="upnp_checkbox" />
             <label for="upnp_checkbox">QBT_TR(Use UPnP / NAT-PMP port forwarding from my router)QBT_TR[CONTEXT=OptionsDialog]</label>
         </div>
-        <fieldset class="settings">
-            <legend>
-                <input type="checkbox" id="sslEnabledCheckbox" onclick="qBittorrent.Preferences.updateSslSettings();" />
-                <label for="sslEnabledCheckbox">QBT_TR(Enable SSL torrents)QBT_TR[CONTEXT=OptionsDialog]</label>
-            </legend>
-            <div class="formRow">
-                <label for="sslPortValue">QBT_TR(Port used for incoming SSL connections:)QBT_TR[CONTEXT=OptionsDialog]</label>
-                <input type="text" id="sslPortValue" style="width: 4em;" title="QBT_TR(Set to 0 to let your system pick an unused port)QBT_TR[CONTEXT=OptionsDialog]" />
-                <button type="button" id="sslRandomPortButton" style="margin-left: 1em;" onclick="qBittorrent.Preferences.generateRandomSSLPort();">QBT_TR(Random)QBT_TR[CONTEXT=OptionsDialog]</button>
-            </div>
-        </fieldset>
     </fieldset>
 
     <fieldset class="settings">
@@ -1559,8 +1548,6 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 updateAutoRun: updateAutoRun,
                 updateAutoRunOnTorrentAdded: updateAutoRunOnTorrentAdded,
                 generateRandomPort: generateRandomPort,
-                generateRandomSSLPort: generateRandomSSLPort,
-                updateSslSettings: updateSslSettings,
                 updateMaxConnecEnabled: updateMaxConnecEnabled,
                 updateMaxConnecPerTorrentEnabled: updateMaxConnecPerTorrentEnabled,
                 updateMaxUploadsEnabled: updateMaxUploadsEnabled,
@@ -1895,19 +1882,6 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             $('port_value').setProperty('value', port);
         };
 
-        const generateRandomSSLPort = function() {
-            const min = 1024;
-            const max = 65535;
-            const port = Math.floor(Math.random() * (max - min + 1) + min);
-            $('sslPortValue').setProperty('value', port);
-        };
-
-        const updateSslSettings = function() {
-            const isSSLEnabled = $('sslEnabledCheckbox').getProperty('checked');
-            $('sslRandomPortButton').setProperty('disabled', !isSSLEnabled);
-            $('sslPortValue').setProperty('disabled', !isSSLEnabled);
-        };
-
         const time_padding = function(val) {
             let ret = val.toString();
             if (ret.length == 1)
@@ -2116,9 +2090,6 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                         // Listening Port
                         $('port_value').setProperty('value', pref.listen_port.toInt());
                         $('upnp_checkbox').setProperty('checked', pref.upnp);
-                        $('sslEnabledCheckbox').setProperty('checked', pref.ssl_enabled);
-                        $('sslPortValue').setProperty('value', pref.ssl_listen_port.toInt()).setProperty('disabled', !pref.ssl_enabled);
-                        $('sslRandomPortButton').setProperty('disabled', !pref.ssl_enabled);
 
                         // Connections Limits
                         const max_connec = pref.max_connec.toInt();
@@ -2475,16 +2446,6 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 return;
             }
             settings.set('listen_port', listen_port);
-            const sslEnabled = $('sslEnabledCheckbox').getProperty('checked');
-            if (sslEnabled) {
-                const sslListenPort = $('sslPortValue').getProperty('value').toInt();
-                if (isNaN(sslListenPort) || (sslListenPort < 0) || (sslListenPort > 65535)) {
-                    alert("QBT_TR(The port used for incoming connections must be between 0 and 65535.)QBT_TR[CONTEXT=HttpServer]");
-                    return;
-                }
-                settings.set('ssl_listen_port', sslListenPort);
-            }
-            settings.set('ssl_enabled', sslEnabled);
             settings.set('upnp', $('upnp_checkbox').getProperty('checked'));
 
             // Connections Limits

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -319,6 +319,17 @@
             <input type="checkbox" id="upnp_checkbox" />
             <label for="upnp_checkbox">QBT_TR(Use UPnP / NAT-PMP port forwarding from my router)QBT_TR[CONTEXT=OptionsDialog]</label>
         </div>
+        <fieldset class="settings">
+            <legend>
+                <input type="checkbox" id="sslEnabledCheckbox" onclick="qBittorrent.Preferences.updateSslSettings();" />
+                <label for="sslEnabledCheckbox">QBT_TR(Enable SSL torrents)QBT_TR[CONTEXT=OptionsDialog]</label>
+            </legend>
+            <div class="formRow">
+                <label for="sslPortValue">QBT_TR(Port used for incoming SSL connections:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                <input type="text" id="sslPortValue" style="width: 4em;" title="QBT_TR(Set to 0 to let your system pick an unused port)QBT_TR[CONTEXT=OptionsDialog]" />
+                <button type="button" id="sslRandomPortButton" style="margin-left: 1em;" onclick="qBittorrent.Preferences.generateRandomSSLPort();">QBT_TR(Random)QBT_TR[CONTEXT=OptionsDialog]</button>
+            </div>
+        </fieldset>
     </fieldset>
 
     <fieldset class="settings">
@@ -1548,6 +1559,8 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 updateAutoRun: updateAutoRun,
                 updateAutoRunOnTorrentAdded: updateAutoRunOnTorrentAdded,
                 generateRandomPort: generateRandomPort,
+                generateRandomSSLPort: generateRandomSSLPort,
+                updateSslSettings: updateSslSettings,
                 updateMaxConnecEnabled: updateMaxConnecEnabled,
                 updateMaxConnecPerTorrentEnabled: updateMaxConnecPerTorrentEnabled,
                 updateMaxUploadsEnabled: updateMaxUploadsEnabled,
@@ -1882,6 +1895,19 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             $('port_value').setProperty('value', port);
         };
 
+        const generateRandomSSLPort = function() {
+            const min = 1024;
+            const max = 65535;
+            const port = Math.floor(Math.random() * (max - min + 1) + min);
+            $('sslPortValue').setProperty('value', port);
+        };
+
+        const updateSslSettings = function() {
+            const isSSLEnabled = $('sslEnabledCheckbox').getProperty('checked');
+            $('sslRandomPortButton').setProperty('disabled', !isSSLEnabled);
+            $('sslPortValue').setProperty('disabled', !isSSLEnabled);
+        };
+
         const time_padding = function(val) {
             let ret = val.toString();
             if (ret.length == 1)
@@ -2090,6 +2116,9 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                         // Listening Port
                         $('port_value').setProperty('value', pref.listen_port.toInt());
                         $('upnp_checkbox').setProperty('checked', pref.upnp);
+                        $('sslEnabledCheckbox').setProperty('checked', pref.ssl_enabled);
+                        $('sslPortValue').setProperty('value', pref.ssl_listen_port.toInt()).setProperty('disabled', !pref.ssl_enabled);
+                        $('sslRandomPortButton').setProperty('disabled', !pref.ssl_enabled);
 
                         // Connections Limits
                         const max_connec = pref.max_connec.toInt();
@@ -2446,6 +2475,16 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 return;
             }
             settings.set('listen_port', listen_port);
+            const sslEnabled = $('sslEnabledCheckbox').getProperty('checked');
+            if (sslEnabled) {
+                const sslListenPort = $('sslPortValue').getProperty('value').toInt();
+                if (isNaN(sslListenPort) || (sslListenPort < 0) || (sslListenPort > 65535)) {
+                    alert("QBT_TR(The port used for incoming connections must be between 0 and 65535.)QBT_TR[CONTEXT=HttpServer]");
+                    return;
+                }
+                settings.set('ssl_listen_port', sslListenPort);
+            }
+            settings.set('ssl_enabled', sslEnabled);
             settings.set('upnp', $('upnp_checkbox').getProperty('checked'));
 
             // Connections Limits


### PR DESCRIPTION
This is a revise of PR #19542.
The 'SSL torrent' feature is not standardized. I.e. there are no BEP (BitTorrent Enhancement Proposals) associated with it, so we do not greatly encourage its usage as it will only work with libtorrent clients and derivatives. It will not work with other torrent clients that do not support the libtorrent specific implementation.
This PR aims to provide minimal support for those who need SSL torrents. Furthermore, it is intended that there will be no UI support (nor indication) of adding/creating SSL torrents.

* Prerequisites:
  I omit the instructions of creating those files as the intended audience (experts & advanced users) should have no problem with it. All files are as follow:
  1. Root (torrent publisher) certificate
  2. Root private key
  3. A .torrent file created with root certificate 
  5. Peer certificate (signed by the root certificate)
  6. Peer private key
  7. Diffie-Hellman parameters file
  
  All files are stored in .pem format.

* Enable SSL torrent protocol in qbt
  There are 2 hidden keys to put in qbt config file, under `[BitTorrent]` section:
  1. `Session\SSL\Enabled`: set it to `true`.
  2. `Session\SSL\Port`: set it to some unused port or omit the key entirely to let qbt pick one for you.
* Add an SSL torrent to qbt
  The only way of adding an SSL torrent is via WebAPI. The `/api/v2/torrents/add` endpoint will support 3 additional parameters. You must provide them for an SSL torrent.
  1. `ssl_certificate`: Contents of the peer certificate file (in PEM format).
  2. `ssl_private_key`: Contents of the peer private key file.
  3. `ssl_dh_params`: Contents of the Diffie-Hellman parameters file.

* Change the SSL parameters to a torrent
  In case you provided wrong SSL parameters when adding a torrent, there is a new endpoint `/api/v2/torrents/setSSLParameters` that you can update the SSL parameters. The parameters (`ssl_*`) are the same as `/api/v2/torrents/add` endpoint.

* Query the SSL parameters of a torrent
  There is a new endpoint `/api/v2/torrents/SSLParameters` that you can query the SSL parameters of a torrent.

References:
* https://www.libtorrent.org/manual-ref.html#ssl-torrents
* https://blog.libtorrent.org/2012/01/bittorrent-over-ssl/

ps. I intend to use 'squash and merge' for merging.