### PR TITLE
Allow WebAPI to specify filename and mime type for result data

### DIFF
--- a/src/webui/api/apicontroller.cpp
+++ b/src/webui/api/apicontroller.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2018, 2022  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2018-2024  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -37,12 +37,19 @@
 
 #include "apierror.h"
 
+void APIResult::clear()
+{
+    data.clear();
+    mimeType.clear();
+    filename.clear();
+}
+
 APIController::APIController(IApplication *app, QObject *parent)
     : ApplicationComponent(app, parent)
 {
 }
 
-QVariant APIController::run(const QString &action, const StringMap &params, const DataMap &data)
+APIResult APIController::run(const QString &action, const StringMap &params, const DataMap &data)
 {
     m_result.clear(); // clear result
     m_params = params;
@@ -79,20 +86,22 @@ void APIController::requireParams(const QVector<QString> &requiredParams) const
 
 void APIController::setResult(const QString &result)
 {
-    m_result = result;
+    m_result.data = result;
 }
 
 void APIController::setResult(const QJsonArray &result)
 {
-    m_result = QJsonDocument(result);
+    m_result.data = QJsonDocument(result);
 }
 
 void APIController::setResult(const QJsonObject &result)
 {
-    m_result = QJsonDocument(result);
+    m_result.data = QJsonDocument(result);
 }
 
-void APIController::setResult(const QByteArray &result)
+void APIController::setResult(const QByteArray &result, const QString &mimeType, const QString &filename)
 {
-    m_result = result;
+    m_result.data = result;
+    m_result.mimeType = mimeType;
+    m_result.filename = filename;
 }

--- a/src/webui/api/apicontroller.h
+++ b/src/webui/api/apicontroller.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2018, 2022  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2018-2024  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -30,14 +30,22 @@
 
 #include <QtContainerFwd>
 #include <QObject>
+#include <QString>
 #include <QVariant>
 
 #include "base/applicationcomponent.h"
 
-class QString;
-
 using DataMap = QHash<QString, QByteArray>;
 using StringMap = QHash<QString, QString>;
+
+struct APIResult
+{
+    QVariant data;
+    QString mimeType;
+    QString filename;
+
+    void clear();
+};
 
 class APIController : public ApplicationComponent<QObject>
 {
@@ -47,7 +55,7 @@ class APIController : public ApplicationComponent<QObject>
 public:
     explicit APIController(IApplication *app, QObject *parent = nullptr);
 
-    QVariant run(const QString &action, const StringMap &params, const DataMap &data = {});
+    APIResult run(const QString &action, const StringMap &params, const DataMap &data = {});
 
 protected:
     const StringMap &params() const;
@@ -57,10 +65,10 @@ protected:
     void setResult(const QString &result);
     void setResult(const QJsonArray &result);
     void setResult(const QJsonObject &result);
-    void setResult(const QByteArray &result);
+    void setResult(const QByteArray &result, const QString &mimeType = {}, const QString &filename = {});
 
 private:
     StringMap m_params;
     DataMap m_data;
-    QVariant m_result;
+    APIResult m_result;
 };

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -1442,5 +1442,5 @@ void TorrentsController::exportAction()
     if (!result)
         throw APIError(APIErrorType::Conflict, tr("Unable to export torrent file. Error: %1").arg(result.error()));
 
-    setResult(result.value());
+    setResult(result.value(), u"application/x-bittorrent"_s, (id.toString() + u".torrent"));
 }


### PR DESCRIPTION
Some WebAPI endpoints produce a result that is essentially data in some format (e.g. `torrents/export` actually produces `.torrent` file data). Now they can specify the MIME type of this data and the suggested filename.