### PR TITLE
Add four new icons to the View menu

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -173,6 +173,10 @@ MainWindow::MainWindow(IGUIApplication *app, WindowState initialState)
     m_ui->actionManageCookies->setIcon(UIThemeManager::instance()->getIcon(u"browser-cookies"_s, u"preferences-web-browser-cookies"_s));
     m_ui->menuLog->setIcon(UIThemeManager::instance()->getIcon(u"help-contents"_s));
     m_ui->actionCheckForUpdates->setIcon(UIThemeManager::instance()->getIcon(u"view-refresh"_s));
+    m_ui->actionRSSReader->setIcon(UIThemeManager::instance()->getIcon(u"rss"_s));
+    m_ui->actionShowFiltersSidebar->setIcon(UIThemeManager::instance()->getIcon(u"view-sidetree"_s));
+    m_ui->actionSpeedInTitleBar->setIcon(UIThemeManager::instance()->getIcon(u"speedometer"_s));
+    m_ui->actionSearchWidget->setIcon(UIThemeManager::instance()->getIcon(u"search"_s));
 
     auto *lockMenu = new QMenu(m_ui->menuView);
     lockMenu->addAction(tr("&Set Password"), this, &MainWindow::defineUILockPassword);


### PR DESCRIPTION
This pull request adds four new icons to actions in the View menu that are currently missing icons:
- RSS Reader
- Filters Sidebar
- Speed in Title Bar
- Search Engine

Before:
![image](https://github.com/qbittorrent/qBittorrent/assets/43704682/91c9ce07-e8d2-4653-8a67-54354364ee96)

After:
![image](https://github.com/qbittorrent/qBittorrent/assets/43704682/0e09a67a-45d9-4088-b9c4-9028e12594c9)
