### PR TITLE
WebUI Improvements

### DIFF
--- a/src/webui/www/.eslintrc.json
+++ b/src/webui/www/.eslintrc.json
@@ -1,7 +1,7 @@
 {
     "env": {
         "browser": true,
-        "es2021": true
+        "es2022": true
     },
     "extends": "eslint:recommended",
     "plugins": [

--- a/src/webui/www/private/confirmdeletion.html
+++ b/src/webui/www/private/confirmdeletion.html
@@ -37,38 +37,25 @@
             const isDeletingFiles = (new URI().getData('deleteFiles') === "true");
             $('deleteFromDiskCB').checked = isDeletingFiles;
 
-            let prefDeleteContentFiles = false;
-            new Request.JSON({
-                url: 'api/v2/app/preferences',
-                method: 'get',
-                noCache: true,
-                onSuccess: function(pref) {
-                    if (!pref)
-                        return;
+            const prefCache = window.parent.qBittorrent.Cache.preferences.get();
+            let prefDeleteContentFiles = prefCache.delete_torrent_content_files;
 
-                    prefDeleteContentFiles = pref.delete_torrent_content_files;
-                    $('deleteFromDiskCB').checked ||= prefDeleteContentFiles;
-                }
-            }).send();
+            $('deleteFromDiskCB').checked ||= prefDeleteContentFiles;
             $('deleteFromDiskCB').addEvent('click', function(e) {
                 setRememberBtnEnabled($('deleteFromDiskCB').checked !== prefDeleteContentFiles);
             });
 
             // Set current "Delete files" choice as the default
             $('rememberBtn').addEvent('click', function(e) {
-                new Request({
-                    url: 'api/v2/app/setPreferences',
-                    method: 'post',
+                window.parent.qBittorrent.Cache.preferences.set({
                     data: {
-                        'json': JSON.encode({
-                            'delete_torrent_content_files': $('deleteFromDiskCB').checked
-                        })
+                        'delete_torrent_content_files': $('deleteFromDiskCB').checked
                     },
                     onSuccess: function() {
                         prefDeleteContentFiles = $('deleteFromDiskCB').checked;
                         setRememberBtnEnabled(false);
                     }
-                }).send();
+                });
             });
 
             const hashes = new URI().getData('hashes').split('|');

--- a/src/webui/www/private/download.html
+++ b/src/webui/www/private/download.html
@@ -160,6 +160,8 @@
             </fieldset>
         </div>
     </form>
+    <div id="download_spinner" class="mochaSpinner"></div>
+
     <script>
         'use strict';
 
@@ -190,7 +192,6 @@
                 window.parent.qBittorrent.Client.closeWindows();
         });
     </script>
-    <div id="download_spinner" class="mochaSpinner"></div>
 </body>
 
 </html>

--- a/src/webui/www/private/downloadlimit.html
+++ b/src/webui/www/private/downloadlimit.html
@@ -21,44 +21,43 @@
             </div>
             <div class="clear"></div>
         </div>
-        <script>
-            'use strict';
-
-            const hashes = new URI().getData('hashes').split('|');
-            const setDlLimit = function() {
-                const limit = $("dllimitUpdatevalue").value.toInt() * 1024;
-                if (hashes[0] == "global") {
-                    new Request({
-                        url: 'api/v2/transfer/setDownloadLimit',
-                        method: 'post',
-                        data: {
-                            'limit': limit
-                        },
-                        onComplete: function() {
-                            window.parent.updateMainData();
-                            window.parent.qBittorrent.Client.closeWindows();
-                        }
-                    }).send();
-                }
-                else {
-                    new Request({
-                        url: 'api/v2/torrents/setDownloadLimit',
-                        method: 'post',
-                        data: {
-                            'hashes': hashes.join('|'),
-                            'limit': limit
-                        },
-                        onComplete: function() {
-                            window.parent.qBittorrent.Client.closeWindows();
-                        }
-                    }).send();
-                }
-            };
-        </script>
         <input type="button" id="applyButton" value="QBT_TR(Apply)QBT_TR[CONTEXT=HttpServer]" onclick="setDlLimit()" />
     </div>
 
     <script>
+        'use strict';
+
+        const hashes = new URI().getData('hashes').split('|');
+        const setDlLimit = function() {
+            const limit = $("dllimitUpdatevalue").value.toInt() * 1024;
+            if (hashes[0] == "global") {
+                new Request({
+                    url: 'api/v2/transfer/setDownloadLimit',
+                    method: 'post',
+                    data: {
+                        'limit': limit
+                    },
+                    onComplete: function() {
+                        window.parent.updateMainData();
+                        window.parent.qBittorrent.Client.closeWindows();
+                    }
+                }).send();
+            }
+            else {
+                new Request({
+                    url: 'api/v2/torrents/setDownloadLimit',
+                    method: 'post',
+                    data: {
+                        'hashes': hashes.join('|'),
+                        'limit': limit
+                    },
+                    onComplete: function() {
+                        window.parent.qBittorrent.Client.closeWindows();
+                    }
+                }).send();
+            }
+        };
+
         new Keyboard({
             defaultEventType: 'keydown',
             events: {
@@ -81,7 +80,6 @@
 
         MochaUI.addDlLimitSlider(hashes);
     </script>
-
 </body>
 
 </html>

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -18,22 +18,22 @@
     <noscript>
         <link rel="stylesheet" type="text/css" href="css/noscript.css?v=${CACHEID}" />
     </noscript>
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/mocha.min.js"></script>
-    <script src="scripts/cache.js?v=${CACHEID}"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/mocha-init.js?locale=${LANG}&v=${CACHEID}"></script>
-    <script src="scripts/lib/clipboard.min.js"></script>
-    <script src="scripts/filesystem.js?v=${CACHEID}"></script>
-    <script src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
-    <script src="scripts/progressbar.js?v=${CACHEID}"></script>
-    <script src="scripts/piecesbar.js?v=${CACHEID}"></script>
-    <script src="scripts/file-tree.js?v=${CACHEID}"></script>
-    <script src="scripts/dynamicTable.js?locale=${LANG}&v=${CACHEID}"></script>
-    <script src="scripts/rename-files.js?v=${CACHEID}"></script>
-    <script src="scripts/client.js?locale=${LANG}&v=${CACHEID}"></script>
-    <script src="scripts/contextmenu.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script defer src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script defer src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script defer src="scripts/lib/mocha.min.js"></script>
+    <script defer src="scripts/cache.js?v=${CACHEID}"></script>
+    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="scripts/mocha-init.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script defer src="scripts/lib/clipboard.min.js"></script>
+    <script defer src="scripts/filesystem.js?v=${CACHEID}"></script>
+    <script defer src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script defer src="scripts/progressbar.js?v=${CACHEID}"></script>
+    <script defer src="scripts/piecesbar.js?v=${CACHEID}"></script>
+    <script defer src="scripts/file-tree.js?v=${CACHEID}"></script>
+    <script defer src="scripts/dynamicTable.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script defer src="scripts/rename-files.js?v=${CACHEID}"></script>
+    <script defer src="scripts/client.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script defer src="scripts/contextmenu.js?locale=${LANG}&v=${CACHEID}"></script>
 </head>
 
 <body>

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -21,7 +21,8 @@
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/mocha.min.js"></script>
-    <script src="scripts/localpreferences.js"></script>
+    <script src="scripts/cache.js?v=${CACHEID}"></script>
+    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
     <script src="scripts/mocha-init.js?locale=${LANG}&v=${CACHEID}"></script>
     <script src="scripts/lib/clipboard.min.js"></script>
     <script src="scripts/filesystem.js?v=${CACHEID}"></script>

--- a/src/webui/www/private/scripts/cache.js
+++ b/src/webui/www/private/scripts/cache.js
@@ -34,9 +34,32 @@ if (window.qBittorrent === undefined)
 window.qBittorrent.Cache = (() => {
     const exports = () => {
         return {
-            preferences: new PreferencesCache()
+            buildInfo: new BuildInfoCache(),
+            preferences: new PreferencesCache(),
+            qbtVersion: new QbtVersionCache()
         };
     };
+
+    class BuildInfoCache {
+        #m_store = {};
+
+        init() {
+            new Request.JSON({
+                url: 'api/v2/app/buildInfo',
+                method: 'get',
+                noCache: true,
+                onSuccess: (responseJSON) => {
+                    if (!responseJSON)
+                        return;
+                    this.#m_store = responseJSON;
+                }
+            }).send();
+        }
+
+        get() {
+            return structuredClone(this.#m_store);
+        }
+    }
 
     class PreferencesCache {
         #m_store = {};
@@ -103,6 +126,27 @@ window.qBittorrent.Cache = (() => {
                         obj.onSuccess(responseText, responseXML);
                 }
             }).send();
+        }
+    }
+
+    class QbtVersionCache {
+        #m_store = '';
+
+        init() {
+            new Request({
+                url: 'api/v2/app/version',
+                method: 'get',
+                noCache: true,
+                onSuccess: (responseText) => {
+                    if (!responseText)
+                        return;
+                    this.#m_store = responseText;
+                }
+            }).send();
+        }
+
+        get() {
+            return this.#m_store;
         }
     }
 

--- a/src/webui/www/private/scripts/cache.js
+++ b/src/webui/www/private/scripts/cache.js
@@ -1,0 +1,112 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2024  Mike Tzou (Chocobo1)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+'use strict';
+
+if (window.qBittorrent === undefined)
+    window.qBittorrent = {};
+
+window.qBittorrent.Cache = (() => {
+    const exports = () => {
+        return {
+            preferences: new PreferencesCache()
+        };
+    };
+
+    class PreferencesCache {
+        #m_store = {};
+
+        // obj: {
+        //   onFailure: () => {},
+        //   onSuccess: () => {}
+        // }
+        init(obj = {}) {
+            new Request.JSON({
+                url: 'api/v2/app/preferences',
+                method: 'get',
+                noCache: true,
+                onFailure: (xhr) => {
+                    if (typeof obj.onFailure === 'function')
+                        obj.onFailure(xhr);
+                },
+                onSuccess: (responseJSON, responseText) => {
+                    if (!responseJSON)
+                        return;
+                    this.#m_store = structuredClone(responseJSON);
+
+                    if (typeof obj.onSuccess === 'function')
+                        obj.onSuccess(responseJSON, responseText);
+                }
+            }).send();
+        }
+
+        get() {
+            return structuredClone(this.#m_store);
+        }
+
+        // obj: {
+        //   data: {},
+        //   onFailure: () => {},
+        //   onSuccess: () => {}
+        // }
+        set(obj) {
+            if (typeof obj !== 'object')
+                throw new Error('`obj` is not an object.');
+            if (typeof obj.data !== 'object')
+                throw new Error('`data` is not an object.');
+
+            new Request({
+                url: 'api/v2/app/setPreferences',
+                method: 'post',
+                data: {
+                    'json': JSON.stringify(obj.data)
+                },
+                onFailure: (xhr) => {
+                    if (typeof obj.onFailure === 'function')
+                        obj.onFailure(xhr);
+                },
+                onSuccess: (responseText, responseXML) => {
+                    for (const key in obj.data) {
+                        if (!Object.hasOwn(obj.data, key))
+                            continue;
+
+                        const value = obj.data[key];
+                        this.#m_store[key] = value;
+                    }
+
+                    if (typeof obj.onSuccess === 'function')
+                        obj.onSuccess(responseText, responseXML);
+                }
+            }).send();
+        }
+    }
+
+    return exports();
+})();
+
+Object.freeze(window.qBittorrent.Cache);

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -34,8 +34,7 @@ window.qBittorrent.Client = (() => {
         return {
             closeWindows: closeWindows,
             genHash: genHash,
-            getSyncMainDataInterval: getSyncMainDataInterval,
-            qbtVersion: qbtVersion
+            getSyncMainDataInterval: getSyncMainDataInterval
         };
     };
 
@@ -55,10 +54,6 @@ window.qBittorrent.Client = (() => {
 
     const getSyncMainDataInterval = function() {
         return customSyncMainDataInterval ? customSyncMainDataInterval : serverSyncMainDataInterval;
-    };
-
-    const qbtVersion = function() {
-        return LocalPreferences.get('qbtVersion', '');
     };
 
     return exports();
@@ -110,7 +105,7 @@ let selected_filter = LocalPreferences.get('selected_filter', 'all');
 let setFilter = function() {};
 let toggleFilterDisplay = function() {};
 
-window.addEvent('load', function() {
+window.addEventListener("DOMContentLoaded", function() {
     const saveColumnSizes = function() {
         const filters_width = $('Filters').getSize().x;
         const properties_height_rel = $('propertiesPanel').getSize().y / Window.getSize().y;
@@ -869,12 +864,15 @@ window.addEvent('load', function() {
             transfer_info += " [" + window.qBittorrent.Misc.friendlyUnit(serverState.up_rate_limit, true) + "]";
         transfer_info += " (" + window.qBittorrent.Misc.friendlyUnit(serverState.up_info_data, false) + ")";
         $("UpInfos").set('html', transfer_info);
+
+        const qbtVersion = window.qBittorrent.Cache.qbtVersion.get();
+
         if (speedInTitle) {
-            document.title = "QBT_TR([D: %1, U: %2] qBittorrent %3)QBT_TR[CONTEXT=MainWindow]".replace("%1", window.qBittorrent.Misc.friendlyUnit(serverState.dl_info_speed, true)).replace("%2", window.qBittorrent.Misc.friendlyUnit(serverState.up_info_speed, true)).replace("%3", window.qBittorrent.Client.qbtVersion());
+            document.title = "QBT_TR([D: %1, U: %2] qBittorrent %3)QBT_TR[CONTEXT=MainWindow]".replace("%1", window.qBittorrent.Misc.friendlyUnit(serverState.dl_info_speed, true)).replace("%2", window.qBittorrent.Misc.friendlyUnit(serverState.up_info_speed, true)).replace("%3", qbtVersion);
             document.title += " QBT_TR(Web UI)QBT_TR[CONTEXT=OptionsDialog]";
         }
         else
-            document.title = ("qBittorrent " + window.qBittorrent.Client.qbtVersion() + " QBT_TR(Web UI)QBT_TR[CONTEXT=OptionsDialog]");
+            document.title = ("qBittorrent " + qbtVersion + " QBT_TR(Web UI)QBT_TR[CONTEXT=OptionsDialog]");
         $('freeSpaceOnDisk').set('html', 'QBT_TR(Free space: %1)QBT_TR[CONTEXT=HttpServer]'.replace("%1", window.qBittorrent.Misc.friendlyUnit(serverState.free_space_on_disk)));
         $('DHTNodes').set('html', 'QBT_TR(DHT: %1 nodes)QBT_TR[CONTEXT=StatusBar]'.replace("%1", serverState.dht_nodes));
 
@@ -1575,38 +1573,11 @@ window.addEvent('load', function() {
             }
         }
     }).activate();
+});
 
-    window.parent.qBittorrent.Cache.preferences.init();
-
-    // fetch qbt version and store it locally
-    new Request({
-        url: 'api/v2/app/version',
-        method: 'get',
-        noCache: true,
-        onSuccess: (info) => {
-            if (!info)
-                return;
-
-            LocalPreferences.set('qbtVersion', info);
-        }
-    }).send();
-
-    // fetch build info and store it locally
-    new Request.JSON({
-        url: 'api/v2/app/buildInfo',
-        method: 'get',
-        noCache: true,
-        onSuccess: (info) => {
-            if (!info)
-                return;
-
-            LocalPreferences.set('buildInfo.qtVersion', info.qt);
-            LocalPreferences.set('buildInfo.libtorrentVersion', info.libtorrent);
-            LocalPreferences.set('buildInfo.boostVersion', info.boost);
-            LocalPreferences.set('buildInfo.opensslVersion', info.openssl);
-            LocalPreferences.set('buildInfo.zlibVersion', info.zlib);
-            LocalPreferences.set('buildInfo.bitness', info.bitness);
-            LocalPreferences.set('buildInfo.platform', info.platform);
-        }
-    }).send();
+window.addEventListener("load", () => {
+    // fetch various data and store it in memory
+    window.qBittorrent.Cache.buildInfo.init();
+    window.qBittorrent.Cache.preferences.init();
+    window.qBittorrent.Cache.qbtVersion.init();
 });

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -1576,6 +1576,8 @@ window.addEvent('load', function() {
         }
     }).activate();
 
+    window.parent.qBittorrent.Cache.preferences.init();
+
     // fetch qbt version and store it locally
     new Request({
         url: 'api/v2/app/version',

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -264,29 +264,21 @@ window.addEventListener("DOMContentLoaded", function() {
     initializeWindows();
 
     // Show Top Toolbar is enabled by default
-    let showTopToolbar = true;
-    if (LocalPreferences.get('show_top_toolbar') !== null)
-        showTopToolbar = LocalPreferences.get('show_top_toolbar') == "true";
+    let showTopToolbar = LocalPreferences.get('show_top_toolbar', 'true') == "true";
     if (!showTopToolbar) {
         $('showTopToolbarLink').firstChild.style.opacity = '0';
         $('mochaToolbar').addClass('invisible');
     }
 
     // Show Status Bar is enabled by default
-    let showStatusBar = true;
-    if (LocalPreferences.get('show_status_bar') !== null)
-        showStatusBar = LocalPreferences.get('show_status_bar') === "true";
+    let showStatusBar = LocalPreferences.get('show_status_bar', 'true') === "true";
     if (!showStatusBar) {
         $('showStatusBarLink').firstChild.style.opacity = '0';
         $('desktopFooterWrapper').addClass('invisible');
     }
 
-    const getShowFiltersSidebar = function() {
-        // Show Filters Sidebar is enabled by default
-        const show = LocalPreferences.get('show_filters_sidebar');
-        return (show === null) || (show === 'true');
-    };
-    const showFiltersSidebar = getShowFiltersSidebar();
+    // Show Filters Sidebar is enabled by default
+    let showFiltersSidebar = LocalPreferences.get('show_filters_sidebar', 'true') === "true";
     if (!showFiltersSidebar) {
         $('showFiltersSidebarLink').firstChild.style.opacity = '0';
         $('filtersColumn').addClass('invisible');
@@ -1032,7 +1024,7 @@ window.addEventListener("DOMContentLoaded", function() {
     });
 
     $('showFiltersSidebarLink').addEvent('click', function(e) {
-        const showFiltersSidebar = !getShowFiltersSidebar();
+        showFiltersSidebar = !showFiltersSidebar;
         LocalPreferences.set('show_filters_sidebar', showFiltersSidebar.toString());
         if (showFiltersSidebar) {
             $('showFiltersSidebarLink').firstChild.style.opacity = '1';

--- a/src/webui/www/private/scripts/download.js
+++ b/src/webui/www/private/scripts/download.js
@@ -59,51 +59,40 @@ window.qBittorrent.Download = (function() {
     };
 
     const getPreferences = function() {
-        new Request.JSON({
-            url: 'api/v2/app/preferences',
-            method: 'get',
-            noCache: true,
-            onFailure: function() {
-                alert("Could not contact qBittorrent");
-            },
-            onSuccess: function(pref) {
-                if (!pref)
-                    return;
+        const pref = window.parent.qBittorrent.Cache.preferences.get();
 
-                defaultSavePath = pref.save_path;
-                $('savepath').setProperty('value', defaultSavePath);
-                $('startTorrent').checked = !pref.start_paused_enabled;
-                $('addToTopOfQueue').checked = pref.add_to_top_of_queue;
+        defaultSavePath = pref.save_path;
+        $('savepath').setProperty('value', defaultSavePath);
+        $('startTorrent').checked = !pref.start_paused_enabled;
+        $('addToTopOfQueue').checked = pref.add_to_top_of_queue;
 
-                if (pref.auto_tmm_enabled == 1) {
-                    $('autoTMM').selectedIndex = 1;
-                    $('savepath').disabled = true;
-                }
-                else {
-                    $('autoTMM').selectedIndex = 0;
-                }
+        if (pref.auto_tmm_enabled == 1) {
+            $('autoTMM').selectedIndex = 1;
+            $('savepath').disabled = true;
+        }
+        else {
+            $('autoTMM').selectedIndex = 0;
+        }
 
-                if (pref.torrent_stop_condition === "MetadataReceived") {
-                    $('stopCondition').selectedIndex = 1;
-                }
-                else if (pref.torrent_stop_condition === "FilesChecked") {
-                    $('stopCondition').selectedIndex = 2;
-                }
-                else {
-                    $('stopCondition').selectedIndex = 0;
-                }
+        if (pref.torrent_stop_condition === "MetadataReceived") {
+            $('stopCondition').selectedIndex = 1;
+        }
+        else if (pref.torrent_stop_condition === "FilesChecked") {
+            $('stopCondition').selectedIndex = 2;
+        }
+        else {
+            $('stopCondition').selectedIndex = 0;
+        }
 
-                if (pref.torrent_content_layout === "Subfolder") {
-                    $('contentLayout').selectedIndex = 1;
-                }
-                else if (pref.torrent_content_layout === "NoSubfolder") {
-                    $('contentLayout').selectedIndex = 2;
-                }
-                else {
-                    $('contentLayout').selectedIndex = 0;
-                }
-            }
-        }).send();
+        if (pref.torrent_content_layout === "Subfolder") {
+            $('contentLayout').selectedIndex = 1;
+        }
+        else if (pref.torrent_content_layout === "NoSubfolder") {
+            $('contentLayout').selectedIndex = 2;
+        }
+        else {
+            $('contentLayout').selectedIndex = 0;
+        }
     };
 
     const changeCategorySelect = function(item) {

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -1159,7 +1159,8 @@ const initializeWindows = function() {
                 onSuccess: function() {
                     document.write('<!doctype html><html lang="${LANG}"><head> <meta charset="UTF-8"> <meta name="color-scheme" content="light dark" /> <title>QBT_TR(qBittorrent has been shutdown)QBT_TR[CONTEXT=HttpServer]</title></head><body> <h1 style="text-align: center;">QBT_TR(qBittorrent has been shutdown)QBT_TR[CONTEXT=HttpServer]</h1></body></html>');
                     document.close();
-                    stop();
+                    window.stop();
+                    window.qBittorrent.Client.stop();
                 }
             }).send();
         }

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -1157,7 +1157,7 @@ const initializeWindows = function() {
                 url: 'api/v2/app/shutdown',
                 method: 'post',
                 onSuccess: function() {
-                    document.write('<!doctype html><html lang="${LANG}"><head> <meta charset="UTF-8"> <title>QBT_TR(qBittorrent has been shutdown)QBT_TR[CONTEXT=HttpServer]</title></head><body> <h1 style="text-align: center;">QBT_TR(qBittorrent has been shutdown)QBT_TR[CONTEXT=HttpServer]</h1></body></html>');
+                    document.write('<!doctype html><html lang="${LANG}"><head> <meta charset="UTF-8"> <meta name="color-scheme" content="light dark" /> <title>QBT_TR(qBittorrent has been shutdown)QBT_TR[CONTEXT=HttpServer]</title></head><body> <h1 style="text-align: center;">QBT_TR(qBittorrent has been shutdown)QBT_TR[CONTEXT=HttpServer]</h1></body></html>');
                     document.close();
                     stop();
                 }

--- a/src/webui/www/private/scripts/prop-general.js
+++ b/src/webui/www/private/scripts/prop-general.js
@@ -100,113 +100,110 @@ window.qBittorrent.PropGeneral = (function() {
             onSuccess: function(data) {
                 $('error_div').set('html', '');
                 if (data) {
-                    let temp;
                     // Update Torrent data
-                    if (data.seeding_time > 0)
-                        temp = "QBT_TR(%1 (seeded for %2))QBT_TR[CONTEXT=PropertiesWidget]"
+
+                    const timeElapsed = (data.seeding_time > 0)
+                        ? "QBT_TR(%1 (seeded for %2))QBT_TR[CONTEXT=PropertiesWidget]"
                         .replace("%1", window.qBittorrent.Misc.friendlyDuration(data.time_elapsed))
-                        .replace("%2", window.qBittorrent.Misc.friendlyDuration(data.seeding_time));
-                    else
-                        temp = window.qBittorrent.Misc.friendlyDuration(data.time_elapsed);
-                    $('time_elapsed').set('html', temp);
+                        .replace("%2", window.qBittorrent.Misc.friendlyDuration(data.seeding_time))
+                        : window.qBittorrent.Misc.friendlyDuration(data.time_elapsed);
+                    $('time_elapsed').set('html', timeElapsed);
 
                     $('eta').set('html', window.qBittorrent.Misc.friendlyDuration(data.eta, window.qBittorrent.Misc.MAX_ETA));
 
-                    temp = "QBT_TR(%1 (%2 max))QBT_TR[CONTEXT=PropertiesWidget]"
+                    const nbConnections = "QBT_TR(%1 (%2 max))QBT_TR[CONTEXT=PropertiesWidget]"
                         .replace("%1", data.nb_connections)
-                        .replace("%2", data.nb_connections_limit < 0 ? "∞" : data.nb_connections_limit);
-                    $('nb_connections').set('html', temp);
+                        .replace("%2", ((data.nb_connections_limit < 0) ? "∞" : data.nb_connections_limit));
+                    $('nb_connections').set('html', nbConnections);
 
-                    temp = "QBT_TR(%1 (%2 this session))QBT_TR[CONTEXT=PropertiesWidget]"
+                    const totalDownloaded = "QBT_TR(%1 (%2 this session))QBT_TR[CONTEXT=PropertiesWidget]"
                         .replace("%1", window.qBittorrent.Misc.friendlyUnit(data.total_downloaded))
                         .replace("%2", window.qBittorrent.Misc.friendlyUnit(data.total_downloaded_session));
-                    $('total_downloaded').set('html', temp);
+                    $('total_downloaded').set('html', totalDownloaded);
 
-                    temp = "QBT_TR(%1 (%2 this session))QBT_TR[CONTEXT=PropertiesWidget]"
+                    const totalUploaded = "QBT_TR(%1 (%2 this session))QBT_TR[CONTEXT=PropertiesWidget]"
                         .replace("%1", window.qBittorrent.Misc.friendlyUnit(data.total_uploaded))
                         .replace("%2", window.qBittorrent.Misc.friendlyUnit(data.total_uploaded_session));
-                    $('total_uploaded').set('html', temp);
+                    $('total_uploaded').set('html', totalUploaded);
 
-                    temp = "QBT_TR(%1 (%2 avg.))QBT_TR[CONTEXT=PropertiesWidget]"
+                    const dlSpeed = "QBT_TR(%1 (%2 avg.))QBT_TR[CONTEXT=PropertiesWidget]"
                         .replace("%1", window.qBittorrent.Misc.friendlyUnit(data.dl_speed, true))
                         .replace("%2", window.qBittorrent.Misc.friendlyUnit(data.dl_speed_avg, true));
-                    $('dl_speed').set('html', temp);
+                    $('dl_speed').set('html', dlSpeed);
 
-                    temp = "QBT_TR(%1 (%2 avg.))QBT_TR[CONTEXT=PropertiesWidget]"
+                    const upSpeed = "QBT_TR(%1 (%2 avg.))QBT_TR[CONTEXT=PropertiesWidget]"
                         .replace("%1", window.qBittorrent.Misc.friendlyUnit(data.up_speed, true))
                         .replace("%2", window.qBittorrent.Misc.friendlyUnit(data.up_speed_avg, true));
-                    $('up_speed').set('html', temp);
+                    $('up_speed').set('html', upSpeed);
 
-                    temp = (data.dl_limit == -1 ? "∞" : window.qBittorrent.Misc.friendlyUnit(data.dl_limit, true));
-                    $('dl_limit').set('html', temp);
+                    const dlLimit = (data.dl_limit === -1)
+                        ? "∞"
+                        : window.qBittorrent.Misc.friendlyUnit(data.dl_limit, true);
+                    $('dl_limit').set('html', dlLimit);
 
-                    temp = (data.up_limit == -1 ? "∞" : window.qBittorrent.Misc.friendlyUnit(data.up_limit, true));
-                    $('up_limit').set('html', temp);
+                    const upLimit = (data.up_limit === -1)
+                        ? "∞"
+                        : window.qBittorrent.Misc.friendlyUnit(data.up_limit, true);
+                    $('up_limit').set('html', upLimit);
 
                     $('total_wasted').set('html', window.qBittorrent.Misc.friendlyUnit(data.total_wasted));
 
-                    temp = "QBT_TR(%1 (%2 total))QBT_TR[CONTEXT=PropertiesWidget]"
+                    const seeds = "QBT_TR(%1 (%2 total))QBT_TR[CONTEXT=PropertiesWidget]"
                         .replace("%1", data.seeds)
                         .replace("%2", data.seeds_total);
-                    $('seeds').set('html', temp);
+                    $('seeds').set('html', seeds);
 
-                    temp = "QBT_TR(%1 (%2 total))QBT_TR[CONTEXT=PropertiesWidget]"
+                    const peers = "QBT_TR(%1 (%2 total))QBT_TR[CONTEXT=PropertiesWidget]"
                         .replace("%1", data.peers)
                         .replace("%2", data.peers_total);
-                    $('peers').set('html', temp);
+                    $('peers').set('html', peers);
 
                     $('share_ratio').set('html', data.share_ratio.toFixed(2));
 
                     $('reannounce').set('html', window.qBittorrent.Misc.friendlyDuration(data.reannounce));
 
-                    if (data.last_seen != -1)
-                        temp = new Date(data.last_seen * 1000).toLocaleString();
-                    else
-                        temp = "QBT_TR(Never)QBT_TR[CONTEXT=PropertiesWidget]";
-                    $('last_seen').set('html', temp);
+                    const lastSeen = (data.last_seen >= 0)
+                        ? new Date(data.last_seen * 1000).toLocaleString()
+                        : "QBT_TR(Never)QBT_TR[CONTEXT=PropertiesWidget]";
+                    $('last_seen').set('html', lastSeen);
 
-                    temp = (data.total_size >= 0) ? window.qBittorrent.Misc.friendlyUnit(data.total_size) : "";
-                    $('total_size').set('html', temp);
+                    const totalSize = (data.total_size >= 0) ? window.qBittorrent.Misc.friendlyUnit(data.total_size) : "";
+                    $('total_size').set('html', totalSize);
 
-                    if (data.pieces_num >= 0) {
-                        temp = "QBT_TR(%1 x %2 (have %3))QBT_TR[CONTEXT=PropertiesWidget]"
-                            .replace("%1", data.pieces_num)
-                            .replace("%2", window.qBittorrent.Misc.friendlyUnit(data.piece_size))
-                            .replace("%3", data.pieces_have);
-                    }
-                    else {
-                        temp = "";
-                    }
-                    $('pieces').set('html', temp);
+                    const pieces = (data.pieces_num >= 0)
+                        ? "QBT_TR(%1 x %2 (have %3))QBT_TR[CONTEXT=PropertiesWidget]"
+                        .replace("%1", data.pieces_num)
+                        .replace("%2", window.qBittorrent.Misc.friendlyUnit(data.piece_size))
+                        .replace("%3", data.pieces_have)
+                        : '';
+                    $('pieces').set('html', pieces);
 
                     $('created_by').set('text', data.created_by);
 
-                    if (data.addition_date != -1)
-                        temp = new Date(data.addition_date * 1000).toLocaleString();
-                    else
-                        temp = "QBT_TR(Unknown)QBT_TR[CONTEXT=HttpServer]";
-                    $('addition_date').set('html', temp);
+                    const additionDate = (data.addition_date >= 0)
+                        ? new Date(data.addition_date * 1000).toLocaleString()
+                        : "QBT_TR(Unknown)QBT_TR[CONTEXT=HttpServer]";
+                    $('addition_date').set('html', additionDate);
 
-                    if (data.completion_date != -1)
-                        temp = new Date(data.completion_date * 1000).toLocaleString();
-                    else
-                        temp = "";
-                    $('completion_date').set('html', temp);
+                    const completionDate = (data.completion_date >= 0)
+                        ? new Date(data.completion_date * 1000).toLocaleString()
+                        : "";
+                    $('completion_date').set('html', completionDate);
 
-                    temp = (data.creation_date >= 0) ? (new Date(data.creation_date * 1000).toLocaleString()) : "";
-                    $('creation_date').set('html', temp);
+                    const creationDate = (data.creation_date >= 0)
+                        ? new Date(data.creation_date * 1000).toLocaleString()
+                        : "";
+                    $('creation_date').set('html', creationDate);
 
-                    if (data.infohash_v1 === "")
-                        temp = "QBT_TR(N/A)QBT_TR[CONTEXT=PropertiesWidget]";
-                    else
-                        temp = data.infohash_v1;
-                    $('torrent_hash_v1').set('html', temp);
+                    const torrentHashV1 = (data.infohash_v1 !== "")
+                        ? data.infohash_v1
+                        : "QBT_TR(N/A)QBT_TR[CONTEXT=PropertiesWidget]";
+                    $('torrent_hash_v1').set('html', torrentHashV1);
 
-                    if (data.infohash_v2 === "")
-                        temp = "QBT_TR(N/A)QBT_TR[CONTEXT=PropertiesWidget]";
-                    else
-                        temp = data.infohash_v2;
-                    $('torrent_hash_v2').set('html', temp);
+                    const torrentHashV2 = (data.infohash_v2 !== "")
+                        ? data.infohash_v2
+                        : "QBT_TR(N/A)QBT_TR[CONTEXT=PropertiesWidget]";
+                    $('torrent_hash_v2').set('html', torrentHashV2);
 
                     $('save_path').set('html', data.save_path);
 

--- a/src/webui/www/private/upload.html
+++ b/src/webui/www/private/upload.html
@@ -147,6 +147,8 @@
             </div>
         </fieldset>
     </form>
+    <div id="upload_spinner" class="mochaSpinner"></div>
+
     <script>
         'use strict';
 
@@ -171,7 +173,6 @@
             $('fileselect').accept = ".torrent";
         }
     </script>
-    <div id="upload_spinner" class="mochaSpinner"></div>
 </body>
 
 </html>

--- a/src/webui/www/private/uploadlimit.html
+++ b/src/webui/www/private/uploadlimit.html
@@ -21,44 +21,43 @@
             </div>
             <div class="clear"></div>
         </div>
-        <script>
-            'use strict';
-
-            const hashes = new URI().getData('hashes').split('|');
-            const setUpLimit = function() {
-                const limit = $("uplimitUpdatevalue").value.toInt() * 1024;
-                if (hashes[0] == "global") {
-                    new Request({
-                        url: 'api/v2/transfer/setUploadLimit',
-                        method: 'post',
-                        data: {
-                            'limit': limit
-                        },
-                        onComplete: function() {
-                            window.parent.updateMainData();
-                            window.parent.qBittorrent.Client.closeWindows();
-                        }
-                    }).send();
-                }
-                else {
-                    new Request({
-                        url: 'api/v2/torrents/setUploadLimit',
-                        method: 'post',
-                        data: {
-                            'hashes': hashes.join('|'),
-                            'limit': limit
-                        },
-                        onComplete: function() {
-                            window.parent.qBittorrent.Client.closeWindows();
-                        }
-                    }).send();
-                }
-            };
-        </script>
         <input type="button" id="applyButton" value="QBT_TR(Apply)QBT_TR[CONTEXT=HttpServer]" onclick="setUpLimit()" />
     </div>
 
     <script>
+        'use strict';
+
+        const hashes = new URI().getData('hashes').split('|');
+        const setUpLimit = function() {
+            const limit = $("uplimitUpdatevalue").value.toInt() * 1024;
+            if (hashes[0] == "global") {
+                new Request({
+                    url: 'api/v2/transfer/setUploadLimit',
+                    method: 'post',
+                    data: {
+                        'limit': limit
+                    },
+                    onComplete: function() {
+                        window.parent.updateMainData();
+                        window.parent.qBittorrent.Client.closeWindows();
+                    }
+                }).send();
+            }
+            else {
+                new Request({
+                    url: 'api/v2/torrents/setUploadLimit',
+                    method: 'post',
+                    data: {
+                        'hashes': hashes.join('|'),
+                        'limit': limit
+                    },
+                    onComplete: function() {
+                        window.parent.qBittorrent.Client.closeWindows();
+                    }
+                }).send();
+            }
+        };
+
         new Keyboard({
             defaultEventType: 'keydown',
             events: {
@@ -81,7 +80,6 @@
 
         MochaUI.addUpLimitSlider(hashes);
     </script>
-
 </body>
 
 </html>

--- a/src/webui/www/private/views/about.html
+++ b/src/webui/www/private/views/about.html
@@ -843,11 +843,14 @@
 <script>
     'use strict';
 
-    $('qbittorrentVersion').innerText = `qBittorrent ${window.qBittorrent.Client.qbtVersion()} QBT_TR(Web UI)QBT_TR[CONTEXT=OptionsDialog]`;
-    $('qtVersion').textContent = LocalPreferences.get('buildInfo.qtVersion');
-    $('libtorrentVersion').textContent = LocalPreferences.get('buildInfo.libtorrentVersion');
-    $('boostVersion').textContent = LocalPreferences.get('buildInfo.boostVersion');
-    $('opensslVersion').textContent = LocalPreferences.get('buildInfo.opensslVersion');
-    $('zlibVersion').textContent = LocalPreferences.get('buildInfo.zlibVersion');
-    $('qbittorrentVersion').textContent += ` (${LocalPreferences.get('buildInfo.bitness')}-bit)`;
+    const qbtVersion = window.parent.qBittorrent.Cache.qbtVersion.get();
+    const buildInfo = window.parent.qBittorrent.Cache.buildInfo.get();
+
+    $('qbittorrentVersion').innerText = `qBittorrent ${qbtVersion} QBT_TR(Web UI)QBT_TR[CONTEXT=OptionsDialog]`;
+    $('qtVersion').textContent = buildInfo.qt;
+    $('libtorrentVersion').textContent = buildInfo.libtorrent;
+    $('boostVersion').textContent = buildInfo.boost;
+    $('opensslVersion').textContent = buildInfo.openssl;
+    $('zlibVersion').textContent = buildInfo.zlib;
+    $('qbittorrentVersion').textContent += ` (${buildInfo.bitness}-bit)`;
 </script>

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1574,34 +1574,6 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             };
         };
 
-        // hide entries
-        const buildInfo = window.qBittorrent.Cache.buildInfo.get();
-
-        const libtorrentVersion = window.qBittorrent.Misc.parseVersion(buildInfo.libtorrent);
-        if (libtorrentVersion.valid) {
-            if (libtorrentVersion.major >= 2) {
-                $('rowDiskCache').style.display = 'none';
-                $('rowDiskCacheExpiryInterval').style.display = 'none';
-                $('rowCoalesceReadsAndWrites').style.display = 'none';
-            }
-            else {
-                $('fieldsetI2p').style.display = 'none';
-                $('rowMemoryWorkingSetLimit').style.display = 'none';
-                $('rowHashingThreads').style.display = 'none';
-                $('rowDiskIOType').style.display = 'none';
-                $('rowI2pInboundQuantity').style.display = 'none';
-                $('rowI2pOutboundQuantity').style.display = 'none';
-                $('rowI2pInboundLength').style.display = 'none';
-                $('rowI2pOutboundLength').style.display = 'none';
-            }
-
-            if (!((libtorrentVersion.major >= 2) && (libtorrentVersion.minor >= 0) && (libtorrentVersion.fix >= 6)))
-                $('diskIOWriteModeWriteThrough').style.display = 'none';
-        }
-
-        if ((buildInfo.platform !== 'macos') && (buildInfo.platform !== 'windows'))
-            $('rowMarkOfTheWeb').style.display = 'none';
-
         // Behavior tab
         const numberInputLimiter = (input) => {
             const min = input.getAttribute("min");
@@ -2847,6 +2819,34 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 }
             });
         };
+
+        // hide entries
+        const buildInfo = window.qBittorrent.Cache.buildInfo.get();
+
+        const libtorrentVersion = window.qBittorrent.Misc.parseVersion(buildInfo.libtorrent);
+        if (libtorrentVersion.valid) {
+            if (libtorrentVersion.major >= 2) {
+                $('rowDiskCache').style.display = 'none';
+                $('rowDiskCacheExpiryInterval').style.display = 'none';
+                $('rowCoalesceReadsAndWrites').style.display = 'none';
+            }
+            else {
+                $('fieldsetI2p').style.display = 'none';
+                $('rowMemoryWorkingSetLimit').style.display = 'none';
+                $('rowHashingThreads').style.display = 'none';
+                $('rowDiskIOType').style.display = 'none';
+                $('rowI2pInboundQuantity').style.display = 'none';
+                $('rowI2pOutboundQuantity').style.display = 'none';
+                $('rowI2pInboundLength').style.display = 'none';
+                $('rowI2pOutboundLength').style.display = 'none';
+            }
+
+            if (!((libtorrentVersion.major >= 2) && (libtorrentVersion.minor >= 0) && (libtorrentVersion.fix >= 6)))
+                $('diskIOWriteModeWriteThrough').style.display = 'none';
+        }
+
+        if ((buildInfo.platform !== 'macos') && (buildInfo.platform !== 'windows'))
+            $('rowMarkOfTheWeb').style.display = 'none';
 
         $('networkInterface').addEvent('change', function() {
             updateInterfaceAddresses($(this).getProperty('value'), '');

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1575,7 +1575,9 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
         };
 
         // hide entries
-        const libtorrentVersion = window.qBittorrent.Misc.parseVersion(LocalPreferences.get('buildInfo.libtorrentVersion', ''));
+        const buildInfo = window.qBittorrent.Cache.buildInfo.get();
+
+        const libtorrentVersion = window.qBittorrent.Misc.parseVersion(buildInfo.libtorrent);
         if (libtorrentVersion.valid) {
             if (libtorrentVersion.major >= 2) {
                 $('rowDiskCache').style.display = 'none';
@@ -1597,8 +1599,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 $('diskIOWriteModeWriteThrough').style.display = 'none';
         }
 
-        const serverPlatform = LocalPreferences.get('buildInfo.platform', '');
-        if ((serverPlatform !== 'macos') && (serverPlatform !== 'windows'))
+        if ((buildInfo.platform !== 'macos') && (buildInfo.platform !== 'windows'))
             $('rowMarkOfTheWeb').style.display = 'none';
 
         // Behavior tab

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1985,17 +1985,8 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
         };
 
         const loadPreferences = function() {
-            new Request.JSON({
-                url: 'api/v2/app/preferences',
-                method: 'get',
-                noCache: true,
-                onFailure: function() {
-                    alert("Could not contact qBittorrent");
-                },
-                onSuccess: function(pref) {
-                    if (!pref)
-                        return;
-
+            window.parent.qBittorrent.Cache.preferences.init({
+                onSuccess: (pref) => {
                     // Behavior tab
                     $('filelog_checkbox').setProperty('checked', pref.file_log_enabled);
                     $('filelog_save_path_input').setProperty('value', pref.file_log_path);
@@ -2395,75 +2386,75 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     $('i2pInboundLength').setProperty('value', pref.i2p_inbound_length);
                     $('i2pOutboundLength').setProperty('value', pref.i2p_outbound_length);
                 }
-            }).send();
+            });
         };
 
         const applyPreferences = function() {
-            const settings = new Hash();
+            const settings = {};
             // Validate form data
 
             // Behavior tab
-            settings.set('file_log_enabled', $('filelog_checkbox').getProperty('checked'));
-            settings.set('file_log_path', $('filelog_save_path_input').getProperty('value'));
-            settings.set('file_log_backup_enabled', $('filelog_backup_checkbox').getProperty('checked'));
-            settings.set('file_log_max_size', Number($('filelog_max_size_input').getProperty('value')));
-            settings.set('file_log_delete_old', $('filelog_delete_old_checkbox').getProperty('checked'));
-            settings.set('file_log_age', Number($('filelog_age_input').getProperty('value')));
-            settings.set('file_log_age_type', Number($('filelog_age_type_select').getProperty('value')));
+            settings['file_log_enabled'] = $('filelog_checkbox').getProperty('checked');
+            settings['file_log_path'] = $('filelog_save_path_input').getProperty('value');
+            settings['file_log_backup_enabled'] = $('filelog_backup_checkbox').getProperty('checked');
+            settings['file_log_max_size'] = Number($('filelog_max_size_input').getProperty('value'));
+            settings['file_log_delete_old'] = $('filelog_delete_old_checkbox').getProperty('checked');
+            settings['file_log_age'] = Number($('filelog_age_input').getProperty('value'));
+            settings['file_log_age_type'] = Number($('filelog_age_type_select').getProperty('value'));
 
             // Downloads tab
             // When adding a torrent
-            settings.set('torrent_content_layout', $('contentlayout_select').getSelected()[0].getProperty('value'));
-            settings.set('add_to_top_of_queue', $('addToTopOfQueueCheckbox').getProperty('checked'));
-            settings.set('start_paused_enabled', $('dontstartdownloads_checkbox').getProperty('checked'));
-            settings.set('torrent_stop_condition', $('stopConditionSelect').getSelected()[0].getProperty('value'));
-            settings.set('auto_delete_mode', Number($('deletetorrentfileafter_checkbox').getProperty('checked')));
+            settings['torrent_content_layout'] = $('contentlayout_select').getSelected()[0].getProperty('value');
+            settings['add_to_top_of_queue'] = $('addToTopOfQueueCheckbox').getProperty('checked');
+            settings['start_paused_enabled'] = $('dontstartdownloads_checkbox').getProperty('checked');
+            settings['torrent_stop_condition'] = $('stopConditionSelect').getSelected()[0].getProperty('value');
+            settings['auto_delete_mode'] = Number($('deletetorrentfileafter_checkbox').getProperty('checked'));
 
-            settings.set('preallocate_all', $('preallocateall_checkbox').getProperty('checked'));
-            settings.set('incomplete_files_ext', $('appendext_checkbox').getProperty('checked'));
-            settings.set('use_unwanted_folder', $('unwantedfolder_checkbox').getProperty('checked'));
+            settings['preallocate_all'] = $('preallocateall_checkbox').getProperty('checked');
+            settings['incomplete_files_ext'] = $('appendext_checkbox').getProperty('checked');
+            settings['use_unwanted_folder'] = $('unwantedfolder_checkbox').getProperty('checked');
 
             // Saving Management
-            settings.set('auto_tmm_enabled', ($('default_tmm_combobox').getProperty('value') === 'true'));
-            settings.set('torrent_changed_tmm_enabled', ($('torrent_changed_tmm_combobox').getProperty('value') === 'true'));
-            settings.set('save_path_changed_tmm_enabled', ($('save_path_changed_tmm_combobox').getProperty('value') === 'true'));
-            settings.set('category_changed_tmm_enabled', ($('category_changed_tmm_combobox').getProperty('value') === 'true'));
-            settings.set('use_subcategories', $('use_subcategories_checkbox').getProperty('checked'));
-            settings.set('save_path', $('savepath_text').getProperty('value'));
-            settings.set('temp_path_enabled', $('temppath_checkbox').getProperty('checked'));
-            settings.set('temp_path', $('temppath_text').getProperty('value'));
+            settings['auto_tmm_enabled'] = ($('default_tmm_combobox').getProperty('value') === 'true');
+            settings['torrent_changed_tmm_enabled'] = ($('torrent_changed_tmm_combobox').getProperty('value') === 'true');
+            settings['save_path_changed_tmm_enabled'] = ($('save_path_changed_tmm_combobox').getProperty('value') === 'true');
+            settings['category_changed_tmm_enabled'] = ($('category_changed_tmm_combobox').getProperty('value') === 'true');
+            settings['use_subcategories'] = $('use_subcategories_checkbox').getProperty('checked');
+            settings['save_path'] = $('savepath_text').getProperty('value');
+            settings['temp_path_enabled'] = $('temppath_checkbox').getProperty('checked');
+            settings['temp_path'] = $('temppath_text').getProperty('value');
             if ($('exportdir_checkbox').getProperty('checked'))
-                settings.set('export_dir', $('exportdir_text').getProperty('value'));
+                settings['export_dir'] = $('exportdir_text').getProperty('value');
             else
-                settings.set('export_dir', '');
+                settings['export_dir'] = '';
             if ($('exportdirfin_checkbox').getProperty('checked'))
-                settings.set('export_dir_fin', $('exportdirfin_text').getProperty('value'));
+                settings['export_dir_fin'] = $('exportdirfin_text').getProperty('value');
             else
-                settings.set('export_dir_fin', '');
+                settings['export_dir_fin'] = '';
 
             // Automatically add torrents from
-            settings.set('scan_dirs', getWatchedFolders());
+            settings['scan_dirs'] = getWatchedFolders();
 
             // Excluded file names
-            settings.set('excluded_file_names_enabled', $('excludedFileNamesCheckbox').getProperty('checked'));
-            settings.set('excluded_file_names', $('excludedFileNamesTextarea').getProperty('value'));
+            settings['excluded_file_names_enabled'] = $('excludedFileNamesCheckbox').getProperty('checked');
+            settings['excluded_file_names'] = $('excludedFileNamesTextarea').getProperty('value');
 
             // Email notification upon download completion
-            settings.set('mail_notification_enabled', $('mail_notification_checkbox').getProperty('checked'));
-            settings.set('mail_notification_sender', $('src_email_txt').getProperty('value'));
-            settings.set('mail_notification_email', $('dest_email_txt').getProperty('value'));
-            settings.set('mail_notification_smtp', $('smtp_server_txt').getProperty('value'));
-            settings.set('mail_notification_ssl_enabled', $('mail_ssl_checkbox').getProperty('checked'));
-            settings.set('mail_notification_auth_enabled', $('mail_auth_checkbox').getProperty('checked'));
-            settings.set('mail_notification_username', $('mail_username_text').getProperty('value'));
-            settings.set('mail_notification_password', $('mail_password_text').getProperty('value'));
+            settings['mail_notification_enabled'] = $('mail_notification_checkbox').getProperty('checked');
+            settings['mail_notification_sender'] = $('src_email_txt').getProperty('value');
+            settings['mail_notification_email'] = $('dest_email_txt').getProperty('value');
+            settings['mail_notification_smtp'] = $('smtp_server_txt').getProperty('value');
+            settings['mail_notification_ssl_enabled'] = $('mail_ssl_checkbox').getProperty('checked');
+            settings['mail_notification_auth_enabled'] = $('mail_auth_checkbox').getProperty('checked');
+            settings['mail_notification_username'] = $('mail_username_text').getProperty('value');
+            settings['mail_notification_password'] = $('mail_password_text').getProperty('value');
 
             // Run an external program on torrent added
-            settings.set('autorun_on_torrent_added_enabled', $('autorunOnTorrentAddedCheckbox').getProperty('checked'));
-            settings.set('autorun_on_torrent_added_program', $('autorunOnTorrentAddedProgram').getProperty('value'));
+            settings['autorun_on_torrent_added_enabled'] = $('autorunOnTorrentAddedCheckbox').getProperty('checked');
+            settings['autorun_on_torrent_added_program'] = $('autorunOnTorrentAddedProgram').getProperty('value');
             // Run an external program on torrent finished
-            settings.set('autorun_enabled', $('autorun_checkbox').getProperty('checked'));
-            settings.set('autorun_program', $('autorunProg_txt').getProperty('value'));
+            settings['autorun_enabled'] = $('autorun_checkbox').getProperty('checked');
+            settings['autorun_program'] = $('autorunProg_txt').getProperty('value');
 
             // Connection tab
             // Listening Port
@@ -2472,8 +2463,8 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 alert("QBT_TR(The port used for incoming connections must be between 0 and 65535.)QBT_TR[CONTEXT=HttpServer]");
                 return;
             }
-            settings.set('listen_port', listen_port);
-            settings.set('upnp', $('upnp_checkbox').getProperty('checked'));
+            settings['listen_port'] = listen_port;
+            settings['upnp'] = $('upnp_checkbox').getProperty('checked');
 
             // Connections Limits
             let max_connec = -1;
@@ -2484,7 +2475,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     return;
                 }
             }
-            settings.set('max_connec', max_connec);
+            settings['max_connec'] = max_connec;
             let max_connec_per_torrent = -1;
             if ($('max_connec_per_torrent_checkbox').getProperty('checked')) {
                 max_connec_per_torrent = $('max_connec_per_torrent_value').getProperty('value').toInt();
@@ -2493,7 +2484,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     return;
                 }
             }
-            settings.set('max_connec_per_torrent', max_connec_per_torrent);
+            settings['max_connec_per_torrent'] = max_connec_per_torrent;
             let max_uploads = -1;
             if ($('max_uploads_checkbox').getProperty('checked')) {
                 max_uploads = $('max_uploads_value').getProperty('value').toInt();
@@ -2502,7 +2493,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     return;
                 }
             }
-            settings.set('max_uploads', max_uploads);
+            settings['max_uploads'] = max_uploads;
             let max_uploads_per_torrent = -1;
             if ($('max_uploads_per_torrent_checkbox').getProperty('checked')) {
                 max_uploads_per_torrent = $('max_uploads_per_torrent_value').getProperty('value').toInt();
@@ -2511,32 +2502,32 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     return;
                 }
             }
-            settings.set('max_uploads_per_torrent', max_uploads_per_torrent);
+            settings['max_uploads_per_torrent'] = max_uploads_per_torrent;
 
             // I2P
-            settings.set('i2p_enabled', $('i2pEnabledCheckbox').getProperty('checked'));
-            settings.set('i2p_address', $('i2pAddress').getProperty('value'));
-            settings.set('i2p_port', $('i2pPort').getProperty('value').toInt());
-            settings.set('i2p_mixed_mode', $('i2pMixedMode').getProperty('checked'));
+            settings['i2p_enabled'] = $('i2pEnabledCheckbox').getProperty('checked');
+            settings['i2p_address'] = $('i2pAddress').getProperty('value');
+            settings['i2p_port'] = $('i2pPort').getProperty('value').toInt();
+            settings['i2p_mixed_mode'] = $('i2pMixedMode').getProperty('checked');
 
             // Proxy Server
-            settings.set('proxy_type', $('peer_proxy_type_select').getProperty('value'));
-            settings.set('proxy_ip', $('peer_proxy_host_text').getProperty('value'));
-            settings.set('proxy_port', $('peer_proxy_port_value').getProperty('value').toInt());
-            settings.set('proxy_auth_enabled', $('peer_proxy_auth_checkbox').getProperty('checked'));
-            settings.set('proxy_username', $('peer_proxy_username_text').getProperty('value'));
-            settings.set('proxy_password', $('peer_proxy_password_text').getProperty('value'));
-            settings.set('proxy_hostname_lookup', $('proxyHostnameLookupCheckbox').getProperty('checked'));
-            settings.set('proxy_bittorrent', $('proxy_bittorrent_checkbox').getProperty('checked'));
-            settings.set('proxy_peer_connections', $('use_peer_proxy_checkbox').getProperty('checked'));
-            settings.set('proxy_rss', $('proxy_rss_checkbox').getProperty('checked'));
-            settings.set('proxy_misc', $('proxy_misc_checkbox').getProperty('checked'));
+            settings['proxy_type'] = $('peer_proxy_type_select').getProperty('value');
+            settings['proxy_ip'] = $('peer_proxy_host_text').getProperty('value');
+            settings['proxy_port'] = $('peer_proxy_port_value').getProperty('value').toInt();
+            settings['proxy_auth_enabled'] = $('peer_proxy_auth_checkbox').getProperty('checked');
+            settings['proxy_username'] = $('peer_proxy_username_text').getProperty('value');
+            settings['proxy_password'] = $('peer_proxy_password_text').getProperty('value');
+            settings['proxy_hostname_lookup'] = $('proxyHostnameLookupCheckbox').getProperty('checked');
+            settings['proxy_bittorrent'] = $('proxy_bittorrent_checkbox').getProperty('checked');
+            settings['proxy_peer_connections'] = $('use_peer_proxy_checkbox').getProperty('checked');
+            settings['proxy_rss'] = $('proxy_rss_checkbox').getProperty('checked');
+            settings['proxy_misc'] = $('proxy_misc_checkbox').getProperty('checked');
 
             // IP Filtering
-            settings.set('ip_filter_enabled', $('ipfilter_text_checkbox').getProperty('checked'));
-            settings.set('ip_filter_path', $('ipfilter_text').getProperty('value'));
-            settings.set('ip_filter_trackers', $('ipfilter_trackers_checkbox').getProperty('checked'));
-            settings.set('banned_IPs', $('banned_IPs_textarea').getProperty('value'));
+            settings['ip_filter_enabled'] = $('ipfilter_text_checkbox').getProperty('checked');
+            settings['ip_filter_path'] = $('ipfilter_text').getProperty('value');
+            settings['ip_filter_trackers'] = $('ipfilter_trackers_checkbox').getProperty('checked');
+            settings['banned_IPs'] = $('banned_IPs_textarea').getProperty('value');
 
             // Speed tab
             // Global Rate Limits
@@ -2545,14 +2536,14 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 alert("QBT_TR(Global upload rate limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
                 return;
             }
-            settings.set('up_limit', up_limit);
+            settings['up_limit'] = up_limit;
 
             const dl_limit = $('dl_limit_value').getProperty('value').toInt() * 1024;
             if (isNaN(dl_limit) || dl_limit < 0) {
                 alert("QBT_TR(Global download rate limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
                 return;
             }
-            settings.set('dl_limit', dl_limit);
+            settings['dl_limit'] = dl_limit;
 
             // Alternative Global Rate Limits
             const alt_up_limit = $('alt_up_limit_value').getProperty('value').toInt() * 1024;
@@ -2560,81 +2551,81 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 alert("QBT_TR(Alternative upload rate limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
                 return;
             }
-            settings.set('alt_up_limit', alt_up_limit);
+            settings['alt_up_limit'] = alt_up_limit;
 
             const alt_dl_limit = $('alt_dl_limit_value').getProperty('value').toInt() * 1024;
             if (isNaN(alt_dl_limit) || alt_dl_limit < 0) {
                 alert("QBT_TR(Alternative download rate limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
                 return;
             }
-            settings.set('alt_dl_limit', alt_dl_limit);
+            settings['alt_dl_limit'] = alt_dl_limit;
 
-            settings.set('bittorrent_protocol', Number($('enable_protocol_combobox').getProperty('value')));
-            settings.set('limit_utp_rate', $('limit_utp_rate_checkbox').getProperty('checked'));
-            settings.set('limit_tcp_overhead', $('limit_tcp_overhead_checkbox').getProperty('checked'));
-            settings.set('limit_lan_peers', $('limit_lan_peers_checkbox').getProperty('checked'));
+            settings['bittorrent_protocol'] = Number($('enable_protocol_combobox').getProperty('value'));
+            settings['limit_utp_rate'] = $('limit_utp_rate_checkbox').getProperty('checked');
+            settings['limit_tcp_overhead'] = $('limit_tcp_overhead_checkbox').getProperty('checked');
+            settings['limit_lan_peers'] = $('limit_lan_peers_checkbox').getProperty('checked');
 
             // Scheduler
             const scheduling_enabled = $('limitSchedulingCheckbox').getProperty('checked');
-            settings.set('scheduler_enabled', scheduling_enabled);
+            settings['scheduler_enabled'] = scheduling_enabled;
             if (scheduling_enabled) {
-                settings.set('schedule_from_hour', $('schedule_from_hour').getProperty('value').toInt());
-                settings.set('schedule_from_min', $('schedule_from_min').getProperty('value').toInt());
-                settings.set('schedule_to_hour', $('schedule_to_hour').getProperty('value').toInt());
-                settings.set('schedule_to_min', $('schedule_to_min').getProperty('value').toInt());
-                settings.set('scheduler_days', $('schedule_freq_select').getProperty('value').toInt());
+                settings['schedule_from_hour'] = $('schedule_from_hour').getProperty('value').toInt();
+                settings['schedule_from_min'] = $('schedule_from_min').getProperty('value').toInt();
+                settings['schedule_to_hour'] = $('schedule_to_hour').getProperty('value').toInt();
+                settings['schedule_to_min'] = $('schedule_to_min').getProperty('value').toInt();
+                settings['scheduler_days'] = $('schedule_freq_select').getProperty('value').toInt();
             }
 
             // Bittorrent tab
             // Privacy
-            settings.set('dht', $('dht_checkbox').getProperty('checked'));
-            settings.set('pex', $('pex_checkbox').getProperty('checked'));
-            settings.set('lsd', $('lsd_checkbox').getProperty('checked'));
-            settings.set('encryption', Number($('encryption_select').getSelected()[0].getProperty('value')));
-            settings.set('anonymous_mode', $('anonymous_mode_checkbox').getProperty('checked'));
+            settings['dht'] = $('dht_checkbox').getProperty('checked');
+            settings['pex'] = $('pex_checkbox').getProperty('checked');
+            settings['lsd'] = $('lsd_checkbox').getProperty('checked');
+            settings['encryption'] = Number($('encryption_select').getSelected()[0].getProperty('value'));
+            settings['anonymous_mode'] = $('anonymous_mode_checkbox').getProperty('checked');
 
-            settings.set('max_active_checking_torrents', Number($('maxActiveCheckingTorrents').getProperty('value')));
+            settings['max_active_checking_torrents'] = Number($('maxActiveCheckingTorrents').getProperty('value'));
 
             // Torrent Queueing
-            settings.set('queueing_enabled', $('queueing_checkbox').getProperty('checked'));
+            settings['queueing_enabled'] = $('queueing_checkbox').getProperty('checked');
             if ($('queueing_checkbox').getProperty('checked')) {
                 const max_active_downloads = $('max_active_dl_value').getProperty('value').toInt();
                 if (isNaN(max_active_downloads) || max_active_downloads < -1) {
                     alert("QBT_TR(Maximum active downloads must be greater than -1.)QBT_TR[CONTEXT=HttpServer]");
                     return;
                 }
-                settings.set('max_active_downloads', max_active_downloads);
+                settings['max_active_downloads'] = max_active_downloads;
                 const max_active_uploads = $('max_active_up_value').getProperty('value').toInt();
                 if (isNaN(max_active_uploads) || max_active_uploads < -1) {
                     alert("QBT_TR(Maximum active uploads must be greater than -1.)QBT_TR[CONTEXT=HttpServer]");
                     return;
                 }
-                settings.set('max_active_uploads', max_active_uploads);
+                settings['max_active_uploads'] = max_active_uploads;
                 const max_active_torrents = $('max_active_to_value').getProperty('value').toInt();
                 if (isNaN(max_active_torrents) || max_active_torrents < -1) {
                     alert("QBT_TR(Maximum active torrents must be greater than -1.)QBT_TR[CONTEXT=HttpServer]");
                     return;
                 }
-                settings.set('max_active_torrents', max_active_torrents);
-                settings.set('dont_count_slow_torrents', $('dont_count_slow_torrents_checkbox').getProperty('checked'));
+                settings['max_active_torrents'] = max_active_torrents;
+                settings['dont_count_slow_torrents'] = $('dont_count_slow_torrents_checkbox').getProperty('checked');
                 const dl_rate_threshold = $('dl_rate_threshold').getProperty('value').toInt();
                 if (isNaN(dl_rate_threshold) || (dl_rate_threshold < 1)) {
                     alert("QBT_TR(Download rate threshold must be greater than 0.)QBT_TR[CONTEXT=HttpServer]");
                     return;
                 }
-                settings.set('slow_torrent_dl_rate_threshold', dl_rate_threshold);
+                settings['slow_torrent_dl_rate_threshold'] = dl_rate_threshold;
                 const ul_rate_threshold = $('ul_rate_threshold').getProperty('value').toInt();
                 if (isNaN(ul_rate_threshold) || (ul_rate_threshold < 1)) {
                     alert("QBT_TR(Upload rate threshold must be greater than 0.)QBT_TR[CONTEXT=HttpServer]");
                     return;
                 }
-                settings.set('slow_torrent_ul_rate_threshold', ul_rate_threshold);
+                settings['slow_torrent_ul_rate_threshold'] = ul_rate_threshold;
                 const torrent_inactive_timer = $('torrent_inactive_timer').getProperty('value').toInt();
                 if (isNaN(torrent_inactive_timer) || (torrent_inactive_timer < 1)) {
                     alert("QBT_TR(Torrent inactivity timer must be greater than 0.)QBT_TR[CONTEXT=HttpServer]");
                     return;
                 }
-                settings.set('slow_torrent_inactive_timer', torrent_inactive_timer);
+                settings['slow_torrent_inactive_timer'] = torrent_inactive_timer;
             }
 
             // Share Ratio Limiting
@@ -2646,8 +2637,8 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     return;
                 }
             }
-            settings.set('max_ratio_enabled', $('max_ratio_checkbox').getProperty('checked'));
-            settings.set('max_ratio', max_ratio);
+            settings['max_ratio_enabled'] = $('max_ratio_checkbox').getProperty('checked');
+            settings['max_ratio'] = max_ratio;
 
             let max_seeding_time = -1;
             if ($('max_seeding_time_checkbox').getProperty('checked')) {
@@ -2657,9 +2648,9 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     return;
                 }
             }
-            settings.set('max_seeding_time_enabled', $('max_seeding_time_checkbox').getProperty('checked'));
-            settings.set('max_seeding_time', max_seeding_time);
-            settings.set('max_ratio_act', $('max_ratio_act').getProperty('value').toInt());
+            settings['max_seeding_time_enabled'] = $('max_seeding_time_checkbox').getProperty('checked');
+            settings['max_seeding_time'] = max_seeding_time;
+            settings['max_ratio_act'] = $('max_ratio_act').getProperty('value').toInt();
 
             let max_inactive_seeding_time = -1;
             if ($('max_inactive_seeding_time_checkbox').getProperty('checked')) {
@@ -2669,52 +2660,52 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     return;
                 }
             }
-            settings.set('max_inactive_seeding_time_enabled', $('max_inactive_seeding_time_checkbox').getProperty('checked'));
-            settings.set('max_inactive_seeding_time', max_inactive_seeding_time);
-            settings.set('max_ratio_act', $('max_ratio_act').getProperty('value').toInt());
+            settings['max_inactive_seeding_time_enabled'] = $('max_inactive_seeding_time_checkbox').getProperty('checked');
+            settings['max_inactive_seeding_time'] = max_inactive_seeding_time;
+            settings['max_ratio_act'] = $('max_ratio_act').getProperty('value').toInt();
 
             // Add trackers
-            settings.set('add_trackers_enabled', $('add_trackers_checkbox').getProperty('checked'));
-            settings.set('add_trackers', $('add_trackers_textarea').getProperty('value'));
+            settings['add_trackers_enabled'] = $('add_trackers_checkbox').getProperty('checked');
+            settings['add_trackers'] = $('add_trackers_textarea').getProperty('value');
 
             // RSS Tab
-            settings.set('rss_processing_enabled', $('enable_fetching_rss_feeds_checkbox').getProperty('checked'));
-            settings.set('rss_refresh_interval', Number($('feed_refresh_interval').getProperty('value')));
-            settings.set('rss_fetch_delay', Number($('feedFetchDelay').getProperty('value')));
-            settings.set('rss_max_articles_per_feed', Number($('maximum_article_number').getProperty('value')));
-            settings.set('rss_auto_downloading_enabled', $('enable_auto_downloading_rss_torrents_checkbox').getProperty('checked'));
-            settings.set('rss_download_repack_proper_episodes', $('downlock_repack_proper_episodes').getProperty('checked'));
-            settings.set('rss_smart_episode_filters', $('rss_filter_textarea').getProperty('value'));
+            settings['rss_processing_enabled'] = $('enable_fetching_rss_feeds_checkbox').getProperty('checked');
+            settings['rss_refresh_interval'] = Number($('feed_refresh_interval').getProperty('value'));
+            settings['rss_fetch_delay'] = Number($('feedFetchDelay').getProperty('value'));
+            settings['rss_max_articles_per_feed'] = Number($('maximum_article_number').getProperty('value'));
+            settings['rss_auto_downloading_enabled'] = $('enable_auto_downloading_rss_torrents_checkbox').getProperty('checked');
+            settings['rss_download_repack_proper_episodes'] = $('downlock_repack_proper_episodes').getProperty('checked');
+            settings['rss_smart_episode_filters'] = $('rss_filter_textarea').getProperty('value');
 
             // Web UI tab
             // Language
-            settings.set('locale', $('locale_select').getProperty('value'));
-            settings.set('performance_warning', $('performanceWarning').getProperty('checked'));
+            settings['locale'] = $('locale_select').getProperty('value');
+            settings['performance_warning'] = $('performanceWarning').getProperty('checked');
 
             // HTTP Server
-            settings.set('web_ui_domain_list', $('webui_domain_textarea').getProperty('value'));
+            settings['web_ui_domain_list'] = $('webui_domain_textarea').getProperty('value');
             const web_ui_address = $('webui_address_value').getProperty('value').toString();
             const web_ui_port = $('webui_port_value').getProperty('value').toInt();
             if (isNaN(web_ui_port) || web_ui_port < 1 || web_ui_port > 65535) {
                 alert("QBT_TR(The port used for the Web UI must be between 1 and 65535.)QBT_TR[CONTEXT=HttpServer]");
                 return;
             }
-            settings.set('web_ui_address', web_ui_address);
-            settings.set('web_ui_port', web_ui_port);
-            settings.set('web_ui_upnp', $('webui_upnp_checkbox').getProperty('checked'));
+            settings['web_ui_address'] = web_ui_address;
+            settings['web_ui_port'] = web_ui_port;
+            settings['web_ui_upnp'] = $('webui_upnp_checkbox').getProperty('checked');
 
             const useHTTPS = $('use_https_checkbox').getProperty('checked');
-            settings.set('use_https', useHTTPS);
+            settings['use_https'] = useHTTPS;
 
             const httpsCertificate = $('ssl_cert_text').getProperty('value');
-            settings.set('web_ui_https_cert_path', httpsCertificate);
+            settings['web_ui_https_cert_path'] = httpsCertificate;
             if (useHTTPS && (httpsCertificate.length === 0)) {
                 alert("QBT_TR(HTTPS certificate should not be empty)QBT_TR[CONTEXT=OptionsDialog]");
                 return;
             }
 
             const httpsKey = $('ssl_key_text').getProperty('value');
-            settings.set('web_ui_https_key_path', httpsKey);
+            settings['web_ui_https_key_path'] = httpsKey;
             if (useHTTPS && (httpsKey.length === 0)) {
                 alert("QBT_TR(HTTPS key should not be empty)QBT_TR[CONTEXT=OptionsDialog]");
                 return;
@@ -2732,15 +2723,15 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 return;
             }
 
-            settings.set('web_ui_username', web_ui_username);
+            settings['web_ui_username'] = web_ui_username;
             if (web_ui_password.length > 0)
-                settings.set('web_ui_password', web_ui_password);
-            settings.set('bypass_local_auth', $('bypass_local_auth_checkbox').getProperty('checked'));
-            settings.set('bypass_auth_subnet_whitelist_enabled', $('bypass_auth_subnet_whitelist_checkbox').getProperty('checked'));
-            settings.set('bypass_auth_subnet_whitelist', $('bypass_auth_subnet_whitelist_textarea').getProperty('value'));
-            settings.set('web_ui_max_auth_fail_count', Number($('webUIMaxAuthFailCountInput').getProperty('value')));
-            settings.set('web_ui_ban_duration', Number($('webUIBanDurationInput').getProperty('value')));
-            settings.set('web_ui_session_timeout', Number($('webUISessionTimeoutInput').getProperty('value')));
+                settings['web_ui_password'] = web_ui_password;
+            settings['bypass_local_auth'] = $('bypass_local_auth_checkbox').getProperty('checked');
+            settings['bypass_auth_subnet_whitelist_enabled'] = $('bypass_auth_subnet_whitelist_checkbox').getProperty('checked');
+            settings['bypass_auth_subnet_whitelist'] = $('bypass_auth_subnet_whitelist_textarea').getProperty('value');
+            settings['web_ui_max_auth_fail_count'] = Number($('webUIMaxAuthFailCountInput').getProperty('value'));
+            settings['web_ui_ban_duration'] = Number($('webUIBanDurationInput').getProperty('value'));
+            settings['web_ui_session_timeout'] = Number($('webUISessionTimeoutInput').getProperty('value'));
 
             // Use alternative Web UI
             const alternative_webui_enabled = $('use_alt_webui_checkbox').getProperty('checked');
@@ -2749,105 +2740,101 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 alert("QBT_TR(The alternative Web UI files location cannot be blank.)QBT_TR[CONTEXT=OptionsDialog]");
                 return;
             }
-            settings.set('alternative_webui_enabled', alternative_webui_enabled);
-            settings.set('alternative_webui_path', webui_files_location_textarea);
+            settings['alternative_webui_enabled'] = alternative_webui_enabled;
+            settings['alternative_webui_path'] = webui_files_location_textarea;
 
             // Security
-            settings.set('web_ui_clickjacking_protection_enabled', $('clickjacking_protection_checkbox').getProperty('checked'));
-            settings.set('web_ui_csrf_protection_enabled', $('csrf_protection_checkbox').getProperty('checked'));
-            settings.set('web_ui_secure_cookie_enabled', $('secureCookieCheckbox').getProperty('checked'));
-            settings.set('web_ui_host_header_validation_enabled', $('host_header_validation_checkbox').getProperty('checked'));
+            settings['web_ui_clickjacking_protection_enabled'] = $('clickjacking_protection_checkbox').getProperty('checked');
+            settings['web_ui_csrf_protection_enabled'] = $('csrf_protection_checkbox').getProperty('checked');
+            settings['web_ui_secure_cookie_enabled'] = $('secureCookieCheckbox').getProperty('checked');
+            settings['web_ui_host_header_validation_enabled'] = $('host_header_validation_checkbox').getProperty('checked');
 
             // Custom HTTP headers
-            settings.set('web_ui_use_custom_http_headers_enabled', $('webUIUseCustomHTTPHeadersCheckbox').getProperty('checked'));
-            settings.set('web_ui_custom_http_headers', $('webUICustomHTTPHeadersTextarea').getProperty('value'));
+            settings['web_ui_use_custom_http_headers_enabled'] = $('webUIUseCustomHTTPHeadersCheckbox').getProperty('checked');
+            settings['web_ui_custom_http_headers'] = $('webUICustomHTTPHeadersTextarea').getProperty('value');
 
             // Reverse Proxy
-            settings.set('web_ui_reverse_proxy_enabled', $('webUIReverseProxySupportCheckbox').getProperty('checked'));
-            settings.set('web_ui_reverse_proxies_list', $('webUIReverseProxiesListTextarea').getProperty('value'));
+            settings['web_ui_reverse_proxy_enabled'] = $('webUIReverseProxySupportCheckbox').getProperty('checked');
+            settings['web_ui_reverse_proxies_list'] = $('webUIReverseProxiesListTextarea').getProperty('value');
 
             // Update my dynamic domain name
-            settings.set('dyndns_enabled', $('use_dyndns_checkbox').getProperty('checked'));
-            settings.set('dyndns_service', Number($('dyndns_select').getProperty('value')));
-            settings.set('dyndns_domain', $('dyndns_domain_text').getProperty('value'));
-            settings.set('dyndns_username', $('dyndns_username_text').getProperty('value'));
-            settings.set('dyndns_password', $('dyndns_password_text').getProperty('value'));
+            settings['dyndns_enabled'] = $('use_dyndns_checkbox').getProperty('checked');
+            settings['dyndns_service'] = Number($('dyndns_select').getProperty('value'));
+            settings['dyndns_domain'] = $('dyndns_domain_text').getProperty('value');
+            settings['dyndns_username'] = $('dyndns_username_text').getProperty('value');
+            settings['dyndns_password'] = $('dyndns_password_text').getProperty('value');
 
             // Update advanced settings
             // qBittorrent section
-            settings.set('resume_data_storage_type', $('resumeDataStorageType').getProperty('value'));
-            settings.set('memory_working_set_limit', Number($('memoryWorkingSetLimit').getProperty('value')));
-            settings.set('current_network_interface', $('networkInterface').getProperty('value'));
-            settings.set('current_interface_address', $('optionalIPAddressToBind').getProperty('value'));
-            settings.set('save_resume_data_interval', Number($('saveResumeDataInterval').getProperty('value')));
-            settings.set('torrent_file_size_limit', ($('torrentFileSizeLimit').getProperty('value') * 1024 * 1024));
-            settings.set('recheck_completed_torrents', $('recheckTorrentsOnCompletion').getProperty('checked'));
-            settings.set('refresh_interval', Number($('refreshInterval').getProperty('value')));
-            settings.set('resolve_peer_countries', $('resolvePeerCountries').getProperty('checked'));
-            settings.set('reannounce_when_address_changed', $('reannounceWhenAddressChanged').getProperty('checked'));
+            settings['resume_data_storage_type'] = $('resumeDataStorageType').getProperty('value');
+            settings['memory_working_set_limit'] = Number($('memoryWorkingSetLimit').getProperty('value'));
+            settings['current_network_interface'] = $('networkInterface').getProperty('value');
+            settings['current_interface_address'] = $('optionalIPAddressToBind').getProperty('value');
+            settings['save_resume_data_interval'] = Number($('saveResumeDataInterval').getProperty('value'));
+            settings['torrent_file_size_limit'] = ($('torrentFileSizeLimit').getProperty('value') * 1024 * 1024);
+            settings['recheck_completed_torrents'] = $('recheckTorrentsOnCompletion').getProperty('checked');
+            settings['refresh_interval'] = Number($('refreshInterval').getProperty('value'));
+            settings['resolve_peer_countries'] = $('resolvePeerCountries').getProperty('checked');
+            settings['reannounce_when_address_changed'] = $('reannounceWhenAddressChanged').getProperty('checked');
 
             // libtorrent section
-            settings.set('bdecode_depth_limit', Number($('bdecodeDepthLimit').getProperty('value')));
-            settings.set('bdecode_token_limit', Number($('bdecodeTokenLimit').getProperty('value')));
-            settings.set('async_io_threads', Number($('asyncIOThreads').getProperty('value')));
-            settings.set('hashing_threads', Number($('hashingThreads').getProperty('value')));
-            settings.set('file_pool_size', Number($('filePoolSize').getProperty('value')));
-            settings.set('checking_memory_use', Number($('outstandMemoryWhenCheckingTorrents').getProperty('value')));
-            settings.set('disk_cache', Number($('diskCache').getProperty('value')));
-            settings.set('disk_cache_ttl', Number($('diskCacheExpiryInterval').getProperty('value')));
-            settings.set('disk_queue_size', (Number($('diskQueueSize').getProperty('value')) * 1024));
-            settings.set('disk_io_type', Number($('diskIOType').getProperty('value')));
-            settings.set('disk_io_read_mode', Number($('diskIOReadMode').getProperty('value')));
-            settings.set('disk_io_write_mode', Number($('diskIOWriteMode').getProperty('value')));
-            settings.set('enable_coalesce_read_write', $('coalesceReadsAndWrites').getProperty('checked'));
-            settings.set('enable_piece_extent_affinity', $('pieceExtentAffinity').getProperty('checked'));
-            settings.set('enable_upload_suggestions', $('sendUploadPieceSuggestions').getProperty('checked'));
-            settings.set('send_buffer_watermark', Number($('sendBufferWatermark').getProperty('value')));
-            settings.set('send_buffer_low_watermark', Number($('sendBufferLowWatermark').getProperty('value')));
-            settings.set('send_buffer_watermark_factor', Number($('sendBufferWatermarkFactor').getProperty('value')));
-            settings.set('connection_speed', Number($('connectionSpeed').getProperty('value')));
-            settings.set('socket_send_buffer_size', ($('socketSendBufferSize').getProperty('value') * 1024));
-            settings.set('socket_receive_buffer_size', ($('socketReceiveBufferSize').getProperty('value') * 1024));
-            settings.set('socket_backlog_size', Number($('socketBacklogSize').getProperty('value')));
-            settings.set('outgoing_ports_min', Number($('outgoingPortsMin').getProperty('value')));
-            settings.set('outgoing_ports_max', Number($('outgoingPortsMax').getProperty('value')));
-            settings.set('upnp_lease_duration', Number($('UPnPLeaseDuration').getProperty('value')));
-            settings.set('peer_tos', Number($('peerToS').getProperty('value')));
-            settings.set('utp_tcp_mixed_mode', Number($('utpTCPMixedModeAlgorithm').getProperty('value')));
-            settings.set('idn_support_enabled', $('IDNSupportCheckbox').getProperty('checked'));
-            settings.set('enable_multi_connections_from_same_ip', $('allowMultipleConnectionsFromTheSameIPAddress').getProperty('checked'));
-            settings.set('validate_https_tracker_certificate', $('validateHTTPSTrackerCertificate').getProperty('checked'));
-            settings.set('ssrf_mitigation', $('mitigateSSRF').getProperty('checked'));
-            settings.set('block_peers_on_privileged_ports', $('blockPeersOnPrivilegedPorts').getProperty('checked'));
-            settings.set('enable_embedded_tracker', $('enableEmbeddedTracker').getProperty('checked'));
-            settings.set('embedded_tracker_port', Number($('embeddedTrackerPort').getProperty('value')));
-            settings.set('embedded_tracker_port_forwarding', $('embeddedTrackerPortForwarding').getProperty('checked'));
-            settings.set('mark_of_the_web', $('markOfTheWeb').getProperty('checked'));
-            settings.set('python_executable_path', $('pythonExecutablePath').getProperty('value'));
-            settings.set('upload_slots_behavior', Number($('uploadSlotsBehavior').getProperty('value')));
-            settings.set('upload_choking_algorithm', Number($('uploadChokingAlgorithm').getProperty('value')));
-            settings.set('announce_to_all_trackers', $('announceAllTrackers').getProperty('checked'));
-            settings.set('announce_to_all_tiers', $('announceAllTiers').getProperty('checked'));
-            settings.set('announce_ip', $('announceIP').getProperty('value'));
-            settings.set('max_concurrent_http_announces', Number($('maxConcurrentHTTPAnnounces').getProperty('value')));
-            settings.set('stop_tracker_timeout', Number($('stopTrackerTimeout').getProperty('value')));
-            settings.set('peer_turnover', Number($('peerTurnover').getProperty('value')));
-            settings.set('peer_turnover_cutoff', Number($('peerTurnoverCutoff').getProperty('value')));
-            settings.set('peer_turnover_interval', Number($('peerTurnoverInterval').getProperty('value')));
-            settings.set('request_queue_size', Number($('requestQueueSize').getProperty('value')));
-            settings.set('dht_bootstrap_nodes', $('dhtBootstrapNodes').getProperty('value'));
-            settings.set('i2p_inbound_quantity', Number($('i2pInboundQuantity').getProperty('value')));
-            settings.set('i2p_outbound_quantity', Number($('i2pOutboundQuantity').getProperty('value')));
-            settings.set('i2p_inbound_length', Number($('i2pInboundLength').getProperty('value')));
-            settings.set('i2p_outbound_length', Number($('i2pOutboundLength').getProperty('value')));
+            settings['bdecode_depth_limit'] = Number($('bdecodeDepthLimit').getProperty('value'));
+            settings['bdecode_token_limit'] = Number($('bdecodeTokenLimit').getProperty('value'));
+            settings['async_io_threads'] = Number($('asyncIOThreads').getProperty('value'));
+            settings['hashing_threads'] = Number($('hashingThreads').getProperty('value'));
+            settings['file_pool_size'] = Number($('filePoolSize').getProperty('value'));
+            settings['checking_memory_use'] = Number($('outstandMemoryWhenCheckingTorrents').getProperty('value'));
+            settings['disk_cache'] = Number($('diskCache').getProperty('value'));
+            settings['disk_cache_ttl'] = Number($('diskCacheExpiryInterval').getProperty('value'));
+            settings['disk_queue_size'] = (Number($('diskQueueSize').getProperty('value')) * 1024);
+            settings['disk_io_type'] = Number($('diskIOType').getProperty('value'));
+            settings['disk_io_read_mode'] = Number($('diskIOReadMode').getProperty('value'));
+            settings['disk_io_write_mode'] = Number($('diskIOWriteMode').getProperty('value'));
+            settings['enable_coalesce_read_write'] = $('coalesceReadsAndWrites').getProperty('checked');
+            settings['enable_piece_extent_affinity'] = $('pieceExtentAffinity').getProperty('checked');
+            settings['enable_upload_suggestions'] = $('sendUploadPieceSuggestions').getProperty('checked');
+            settings['send_buffer_watermark'] = Number($('sendBufferWatermark').getProperty('value'));
+            settings['send_buffer_low_watermark'] = Number($('sendBufferLowWatermark').getProperty('value'));
+            settings['send_buffer_watermark_factor'] = Number($('sendBufferWatermarkFactor').getProperty('value'));
+            settings['connection_speed'] = Number($('connectionSpeed').getProperty('value'));
+            settings['socket_send_buffer_size'] = ($('socketSendBufferSize').getProperty('value') * 1024);
+            settings['socket_receive_buffer_size'] = ($('socketReceiveBufferSize').getProperty('value') * 1024);
+            settings['socket_backlog_size'] = Number($('socketBacklogSize').getProperty('value'));
+            settings['outgoing_ports_min'] = Number($('outgoingPortsMin').getProperty('value'));
+            settings['outgoing_ports_max'] = Number($('outgoingPortsMax').getProperty('value'));
+            settings['upnp_lease_duration'] = Number($('UPnPLeaseDuration').getProperty('value'));
+            settings['peer_tos'] = Number($('peerToS').getProperty('value'));
+            settings['utp_tcp_mixed_mode'] = Number($('utpTCPMixedModeAlgorithm').getProperty('value'));
+            settings['idn_support_enabled'] = $('IDNSupportCheckbox').getProperty('checked');
+            settings['enable_multi_connections_from_same_ip'] = $('allowMultipleConnectionsFromTheSameIPAddress').getProperty('checked');
+            settings['validate_https_tracker_certificate'] = $('validateHTTPSTrackerCertificate').getProperty('checked');
+            settings['ssrf_mitigation'] = $('mitigateSSRF').getProperty('checked');
+            settings['block_peers_on_privileged_ports'] = $('blockPeersOnPrivilegedPorts').getProperty('checked');
+            settings['enable_embedded_tracker'] = $('enableEmbeddedTracker').getProperty('checked');
+            settings['embedded_tracker_port'] = Number($('embeddedTrackerPort').getProperty('value'));
+            settings['embedded_tracker_port_forwarding'] = $('embeddedTrackerPortForwarding').getProperty('checked');
+            settings['mark_of_the_web'] = $('markOfTheWeb').getProperty('checked');
+            settings['python_executable_path'] = $('pythonExecutablePath').getProperty('value');
+            settings['upload_slots_behavior'] = Number($('uploadSlotsBehavior').getProperty('value'));
+            settings['upload_choking_algorithm'] = Number($('uploadChokingAlgorithm').getProperty('value'));
+            settings['announce_to_all_trackers'] = $('announceAllTrackers').getProperty('checked');
+            settings['announce_to_all_tiers'] = $('announceAllTiers').getProperty('checked');
+            settings['announce_ip'] = $('announceIP').getProperty('value');
+            settings['max_concurrent_http_announces'] = Number($('maxConcurrentHTTPAnnounces').getProperty('value'));
+            settings['stop_tracker_timeout'] = Number($('stopTrackerTimeout').getProperty('value'));
+            settings['peer_turnover'] = Number($('peerTurnover').getProperty('value'));
+            settings['peer_turnover_cutoff'] = Number($('peerTurnoverCutoff').getProperty('value'));
+            settings['peer_turnover_interval'] = Number($('peerTurnoverInterval').getProperty('value'));
+            settings['request_queue_size'] = Number($('requestQueueSize').getProperty('value'));
+            settings['dht_bootstrap_nodes'] = $('dhtBootstrapNodes').getProperty('value');
+            settings['i2p_inbound_quantity'] = Number($('i2pInboundQuantity').getProperty('value'));
+            settings['i2p_outbound_quantity'] = Number($('i2pOutboundQuantity').getProperty('value'));
+            settings['i2p_inbound_length'] = Number($('i2pInboundLength').getProperty('value'));
+            settings['i2p_outbound_length'] = Number($('i2pOutboundLength').getProperty('value'));
 
             // Send it to qBT
-            new Request({
-                url: 'api/v2/app/setPreferences',
-                method: 'post',
-                data: {
-                    'json': JSON.encode(settings),
-                },
+            window.parent.qBittorrent.Cache.preferences.set({
+                data: settings,
                 onFailure: function() {
                     alert("QBT_TR(Unable to save program preferences, qBittorrent is probably unreachable.)QBT_TR[CONTEXT=HttpServer]");
                     window.parent.qBittorrent.Client.closeWindows();
@@ -2857,7 +2844,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     window.parent.location.reload();
                     window.parent.qBittorrent.Client.closeWindows();
                 }
-            }).send();
+            });
         };
 
         $('networkInterface').addEvent('change', function() {

--- a/src/webui/www/private/views/rss.html
+++ b/src/webui/www/private/views/rss.html
@@ -189,31 +189,22 @@
         let rssArticleTable = new window.qBittorrent.DynamicTable.RssArticleTable();
 
         const init = () => {
-            new Request.JSON({
-                url: 'api/v2/app/preferences',
-                method: 'get',
-                noCache: true,
-                onFailure: () => {
-                    alert('Could not contact qBittorrent');
-                },
-                onSuccess: (pref) => {
-                    if (!pref.rss_processing_enabled)
-                        $('rssFetchingDisabled').removeClass('invisible');
+            const pref = window.parent.qBittorrent.Cache.preferences.get();
 
-                    // recalculate heights
-                    let nonPageHeight = $('rssTopBar').getBoundingClientRect().height
-                        + $('desktopHeader').getBoundingClientRect().height
-                        + $('desktopFooterWrapper').getBoundingClientRect().height + 20;
-                    $('rssDetailsView').style.height = 'calc(100vh - ' + nonPageHeight + 'px)';
+            if (!pref.rss_processing_enabled)
+                $('rssFetchingDisabled').removeClass('invisible');
 
-                    let nonTableHeight = nonPageHeight + $('rssFeedFixedHeaderDiv').getBoundingClientRect().height;
+            // recalculate heights
+            const nonPageHeight = $('rssTopBar').getBoundingClientRect().height
+                + $('desktopHeader').getBoundingClientRect().height
+                + $('desktopFooterWrapper').getBoundingClientRect().height + 20;
+            $('rssDetailsView').style.height = 'calc(100vh - ' + nonPageHeight + 'px)';
 
-                    $('rssFeedTableDiv').style.height = 'calc(100vh - ' + nonTableHeight + 'px)';
-                    $('rssArticleTableDiv').style.height = 'calc(100vh - ' + nonTableHeight + 'px)';
+            const nonTableHeight = nonPageHeight + $('rssFeedFixedHeaderDiv').getBoundingClientRect().height;
+            $('rssFeedTableDiv').style.height = 'calc(100vh - ' + nonTableHeight + 'px)';
+            $('rssArticleTableDiv').style.height = 'calc(100vh - ' + nonTableHeight + 'px)';
 
-                    $('rssContentView').style.height = 'calc(100% - ' + $('rssTopBar').getBoundingClientRect().height + 'px)';
-                }
-            }).send();
+            $('rssContentView').style.height = 'calc(100% - ' + $('rssTopBar').getBoundingClientRect().height + 'px)';
 
             const rssFeedContextMenu = new window.qBittorrent.ContextMenu.RssFeedContextMenu({
                 targets: '.rssFeedContextMenuTarget',

--- a/src/webui/www/private/views/rssDownloader.html
+++ b/src/webui/www/private/views/rssDownloader.html
@@ -358,42 +358,34 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
         let feedList = [];
 
         const initRssDownloader = () => {
-            new Request.JSON({
-                url: 'api/v2/app/preferences',
-                method: 'get',
-                noCache: true,
-                onFailure: () => {
-                    alert('Could not contact qBittorrent');
-                },
-                onSuccess: (pref) => {
-                    if (!pref.rss_auto_downloading_enabled)
-                        $('rssDownloaderDisabled').removeClass('invisible');
+            const pref = window.parent.qBittorrent.Cache.preferences.get();
 
-                    // recalculate height
-                    let warningHeight = $('rssDownloaderDisabled').getBoundingClientRect().height;
+            if (!pref.rss_auto_downloading_enabled)
+                $('rssDownloaderDisabled').removeClass('invisible');
 
-                    $('leftRssDownloaderColumn').style.height = 'calc(100% - ' + warningHeight + 'px)';
-                    $('centerRssDownloaderColumn').style.height = 'calc(100% - ' + warningHeight + 'px)';
-                    $('rightRssDownloaderColumn').style.height = 'calc(100% - ' + warningHeight + 'px)';
+            // recalculate height
+            const warningHeight = $('rssDownloaderDisabled').getBoundingClientRect().height;
 
-                    $('rulesTable').style.height = 'calc(100% - ' + $('rulesTableDesc').getBoundingClientRect().height + 'px)';
-                    $('rssDownloaderArticlesTable').style.height = 'calc(100% - ' + $('articleTableDesc').getBoundingClientRect().height + 'px)';
+            $('leftRssDownloaderColumn').style.height = 'calc(100% - ' + warningHeight + 'px)';
+            $('centerRssDownloaderColumn').style.height = 'calc(100% - ' + warningHeight + 'px)';
+            $('rightRssDownloaderColumn').style.height = 'calc(100% - ' + warningHeight + 'px)';
 
-                    let centerRowNotTableHeight = $('saveButton').getBoundingClientRect().height
-                        + $('ruleSettings').getBoundingClientRect().height + 15;
+            $('rulesTable').style.height = 'calc(100% - ' + $('rulesTableDesc').getBoundingClientRect().height + 'px)';
+            $('rssDownloaderArticlesTable').style.height = 'calc(100% - ' + $('articleTableDesc').getBoundingClientRect().height + 'px)';
 
-                    $('rssDownloaderFeeds').style.height = 'calc(100% - ' + centerRowNotTableHeight + 'px)';
+            const centerRowNotTableHeight = $('saveButton').getBoundingClientRect().height
+                + $('ruleSettings').getBoundingClientRect().height + 15;
 
-                    // firefox calculates the height of the table inside fieldset differently and thus doesn't need the offset
-                    if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
-                        $('rssDownloaderFeedsTable').style.height = '100%';
-                    }
-                    else {
-                        let outsideTableHeight = ($('rssDownloaderFeedsTable').getBoundingClientRect().top - $('rssDownloaderFeeds').getBoundingClientRect().top) - 10;
-                        $('rssDownloaderFeedsTable').style.height = 'calc(100% - ' + outsideTableHeight + 'px)';
-                    }
-                }
-            }).send();
+            $('rssDownloaderFeeds').style.height = 'calc(100% - ' + centerRowNotTableHeight + 'px)';
+
+            // firefox calculates the height of the table inside fieldset differently and thus doesn't need the offset
+            if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
+                $('rssDownloaderFeedsTable').style.height = '100%';
+            }
+            else {
+                let outsideTableHeight = ($('rssDownloaderFeedsTable').getBoundingClientRect().top - $('rssDownloaderFeeds').getBoundingClientRect().top) - 10;
+                $('rssDownloaderFeedsTable').style.height = 'calc(100% - ' + outsideTableHeight + 'px)';
+            }
 
             const rssDownloaderRuleContextMenu = new window.qBittorrent.ContextMenu.RssDownloaderRuleContextMenu({
                 targets: '',

--- a/src/webui/www/public/index.html
+++ b/src/webui/www/public/index.html
@@ -11,7 +11,7 @@
     <noscript>
         <link rel="stylesheet" type="text/css" href="css/noscript.css?v=${CACHEID}" />
     </noscript>
-    <script src="scripts/login.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script defer src="scripts/login.js?locale=${LANG}&v=${CACHEID}"></script>
 </head>
 
 <body>

--- a/src/webui/www/webui.qrc
+++ b/src/webui/www/webui.qrc
@@ -374,6 +374,7 @@
         <file>private/rename_file.html</file>
         <file>private/rename_files.html</file>
         <file>private/rename_rule.html</file>
+        <file>private/scripts/cache.js</file>
         <file>private/scripts/client.js</file>
         <file>private/scripts/contextmenu.js</file>
         <file>private/scripts/download.js</file>


### PR DESCRIPTION
* Cache program preferences
  So that qbt can just use the data from memory which is vastly faster than waiting for a response over the net.
* Migrate to Cache for commonly used data
  Previously it was abusing the `localStorage` and now it is storing data in memory (per session).
* Simplify code
* Add support for dark theme
* Combine script tags
* Defer loading of js code on landing pages
  So that DOM tree can be processed earlier.
* Stop sync requests after qbt has been shutdown

This is the last batch for now.