### PR TITLE
Fix newly added trackers being incorrectly all tier 0

### DIFF
--- a/src/base/bittorrent/trackerentry.cpp
+++ b/src/base/bittorrent/trackerentry.cpp
@@ -30,21 +30,23 @@
 
 #include <QList>
 
-QList<BitTorrent::TrackerEntry> BitTorrent::parseTrackerEntries(const QStringView str)
+QList<BitTorrent::TrackerEntry> BitTorrent::parseTrackerEntries(const QStringView str, const int defaultTier)
 {
+    Q_ASSERT(defaultTier >= 0);
+    
     const QList<QStringView> trackers = str.split(u'\n');  // keep the empty parts to track tracker tier
 
     QList<BitTorrent::TrackerEntry> entries;
     entries.reserve(trackers.size());
 
-    int trackerTier = 0;
+    int trackerTier = defaultTier;
     for (QStringView tracker : trackers)
     {
         tracker = tracker.trimmed();
 
         if (tracker.isEmpty())
         {
-            if (trackerTier < std::numeric_limits<decltype(trackerTier)>::max())  // prevent overflow
+            if (defaultTier <= 0 && trackerTier < std::numeric_limits<decltype(trackerTier)>::max())  // prevent overflow
                 ++trackerTier;
             continue;
         }

--- a/src/base/bittorrent/trackerentry.h
+++ b/src/base/bittorrent/trackerentry.h
@@ -81,7 +81,7 @@ namespace BitTorrent
         QHash<std::pair<QString, int>, TrackerEndpointEntry> endpointEntries {};
     };
 
-    QList<TrackerEntry> parseTrackerEntries(QStringView str);
+    QList<TrackerEntry> parseTrackerEntries(QStringView str, int defaultTier = 0);
 
     bool operator==(const TrackerEntry &left, const TrackerEntry &right);
     std::size_t qHash(const TrackerEntry &key, std::size_t seed = 0);

--- a/src/gui/trackerentriesdialog.cpp
+++ b/src/gui/trackerentriesdialog.cpp
@@ -78,9 +78,9 @@ void TrackerEntriesDialog::setTrackers(const QVector<BitTorrent::TrackerEntry> &
     m_ui->plainTextEdit->setPlainText(text);
 }
 
-QVector<BitTorrent::TrackerEntry> TrackerEntriesDialog::trackers() const
+QVector<BitTorrent::TrackerEntry> TrackerEntriesDialog::trackers(const int &tierGroupOverride) const
 {
-    return BitTorrent::parseTrackerEntries(m_ui->plainTextEdit->toPlainText());
+    return BitTorrent::parseTrackerEntries(m_ui->plainTextEdit->toPlainText(), tierGroupOverride);
 }
 
 void TrackerEntriesDialog::saveSettings()

--- a/src/gui/trackerentriesdialog.h
+++ b/src/gui/trackerentriesdialog.h
@@ -53,7 +53,7 @@ public:
     ~TrackerEntriesDialog() override;
 
     void setTrackers(const QVector<BitTorrent::TrackerEntry> &trackers);
-    QVector<BitTorrent::TrackerEntry> trackers() const;
+    QVector<BitTorrent::TrackerEntry> trackers(const int &tierGroupOverride = -1) const;
 
 private:
     void saveSettings();

--- a/src/gui/trackersadditiondialog.cpp
+++ b/src/gui/trackersadditiondialog.cpp
@@ -74,7 +74,9 @@ TrackersAdditionDialog::~TrackersAdditionDialog()
 
 void TrackersAdditionDialog::onAccepted() const
 {
-    const QVector<BitTorrent::TrackerEntry> entries = BitTorrent::parseTrackerEntries(m_ui->textEditTrackersList->toPlainText());
+    const QVector<BitTorrent::TrackerEntry> trackers = m_torrent->trackers();
+    int maxTier = (trackers.size() > 0 ? trackers.back().tier : -1);  // get maximum tier of current torrent
+    const QVector<BitTorrent::TrackerEntry> entries = BitTorrent::parseTrackerEntries(m_ui->textEditTrackersList->toPlainText(), maxTier + 1);
     m_torrent->addTrackers(entries);
 }
 

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -782,7 +782,9 @@ void TorrentsController::addTrackersAction()
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 
-    const QVector<BitTorrent::TrackerEntry> entries = BitTorrent::parseTrackerEntries(params()[u"urls"_s]);
+    const QVector<BitTorrent::TrackerEntry> trackers = torrent->trackers();
+    int maxTier = (trackers.size() > 0 ? trackers.back().tier : -1);  // get maximum tier of current torrent
+    const QVector<BitTorrent::TrackerEntry> entries = BitTorrent::parseTrackerEntries(params()[u"urls"_s], maxTier + 1);
     torrent->addTrackers(entries);
 }
 

--- a/test/testbittorrenttrackerentry.cpp
+++ b/test/testbittorrenttrackerentry.cpp
@@ -137,6 +137,28 @@ private slots:
             };
             QVERIFY(isEqual(BitTorrent::parseTrackerEntries(input), output));
         }
+
+        {
+            const int overrideValue = 0;
+            const QString input = u"\n \n \n http://localhost:1234 \n \n \n \n http://[::1]:4567 \n \n \n"_s;
+            const Entries output =
+            {
+                {u"http://localhost:1234"_s, 3},
+                {u"http://[::1]:4567"_s, 6}
+            };
+            QVERIFY(isEqual(BitTorrent::parseTrackerEntries(input, overrideValue), output));
+        }
+
+        {
+            const int overrideValue = INT_MAX;
+            const QString input = u"\n \n \n http://localhost:1234 \n \n \n \n http://[::1]:4567 \n \n \n"_s;
+            const Entries output =
+            {
+                {u"http://localhost:1234"_s, overrideValue},
+                {u"http://[::1]:4567"_s, overrideValue}
+            };
+            QVERIFY(isEqual(BitTorrent::parseTrackerEntries(input, overrideValue), output));
+        }
     }
 };
 


### PR DESCRIPTION
This PR changes tier of the automatically added trackers to start with `existing_max_tier + 1`.

In current implementation, tier of additional trackers are initialized with default value 0.
To address this, on adding additional trackers, the max tier of existing trackers is looked up and +1 for every additional tracker added.

Closes #20102 

Putting 3 testing trackers in "automatically added list"
<img width="300" alt="image" src="https://github.com/qbittorrent/qBittorrent/assets/26112431/7e6d1a4a-cd31-4edf-873a-7a937684e58a">
Before: Additional trackers are added with all tier = 0
<img width="1275" alt="image" src="https://github.com/qbittorrent/qBittorrent/assets/26112431/f9487c09-42db-455c-b0b9-d2425f9ce457">

After: Additional trackers are added with tier after the existing trackers in sequential order.
<img width="1396" alt="image" src="https://github.com/qbittorrent/qBittorrent/assets/26112431/b8409add-c416-405f-a390-2bb59084e52b">
