### PR TITLE
Specify standards conformance mode to MSVC

### DIFF
--- a/cmake/Modules/CommonConfig.cmake
+++ b/cmake/Modules/CommonConfig.cmake
@@ -83,6 +83,7 @@ endif()
 if (MSVC)
     target_compile_options(qbt_common_cfg INTERFACE
         /guard:cf
+        /permissive-
         /utf-8
         # https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
         /Zc:__cplusplus


### PR DESCRIPTION
From https://learn.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance?view=msvc-170:
>Specify standards conformance mode to the compiler. Use this option to help you identify and fix conformance issues in your code, to make it both more correct and more portable.
