### PR TITLE
Improve WebUI login behavior

### DIFF
--- a/src/webui/www/public/scripts/login.js
+++ b/src/webui/www/public/scripts/login.js
@@ -42,9 +42,10 @@ function submitLoginForm(event) {
     xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded; charset=UTF-8');
     xhr.addEventListener('readystatechange', function() {
         if (xhr.readyState === 4) { // DONE state
-            if ((xhr.status === 200) && (xhr.responseText === "Ok."))
+            if ((xhr.status === 200) && (xhr.responseText === "Ok.")) {
                 location.replace(location);
                 location.reload(true);
+            }
             else
                 errorMsgElement.textContent = 'QBT_TR(Invalid Username or Password.)QBT_TR[CONTEXT=HttpServer]';
         }

--- a/src/webui/www/public/scripts/login.js
+++ b/src/webui/www/public/scripts/login.js
@@ -42,10 +42,8 @@ function submitLoginForm(event) {
     xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded; charset=UTF-8');
     xhr.addEventListener('readystatechange', function() {
         if (xhr.readyState === 4) { // DONE state
-            if ((xhr.status === 200) && (xhr.responseText === "Ok.")) {
+            if ((xhr.status === 200) && (xhr.responseText === "Ok."))
                 location.replace(location);
-                location.reload(true);
-            }
             else
                 errorMsgElement.textContent = 'QBT_TR(Invalid Username or Password.)QBT_TR[CONTEXT=HttpServer]';
         }

--- a/src/webui/www/public/scripts/login.js
+++ b/src/webui/www/public/scripts/login.js
@@ -43,7 +43,7 @@ function submitLoginForm(event) {
     xhr.addEventListener('readystatechange', function() {
         if (xhr.readyState === 4) { // DONE state
             if ((xhr.status === 200) && (xhr.responseText === "Ok."))
-                location.assign(location);
+                location.replace(location);
                 location.reload(true);
             else
                 errorMsgElement.textContent = 'QBT_TR(Invalid Username or Password.)QBT_TR[CONTEXT=HttpServer]';

--- a/src/webui/www/public/scripts/login.js
+++ b/src/webui/www/public/scripts/login.js
@@ -43,6 +43,7 @@ function submitLoginForm(event) {
     xhr.addEventListener('readystatechange', function() {
         if (xhr.readyState === 4) { // DONE state
             if ((xhr.status === 200) && (xhr.responseText === "Ok."))
+                location.assign(location);
                 location.reload(true);
             else
                 errorMsgElement.textContent = 'QBT_TR(Invalid Username or Password.)QBT_TR[CONTEXT=HttpServer]';


### PR DESCRIPTION
Fixes reload bug in login.js for webgui on librewolf by adding
`location.assign(location);` before `location.reload(true);`.
left the latter for when `location.assign(location);` fails.
Closes #20441.
