### PR TITLE
Raise minimum libtorrent 2 version to 2.0.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(minBoostVersion 1.76)
 set(minQt6Version 6.5.0)
 set(minOpenSSLVersion 3.0.2)
 set(minLibtorrent1Version 1.2.19)
-set(minLibtorrentVersion 2.0.9)
+set(minLibtorrentVersion 2.0.10)
 set(minZlibVersion 1.2.11)
 
 include(GNUInstallDirs)

--- a/INSTALL
+++ b/INSTALL
@@ -5,7 +5,7 @@ qBittorrent - A BitTorrent client in C++ / Qt
 
   - Boost >= 1.76
 
-  - libtorrent-rasterbar 1.2.19 - 1.2.x || 2.0.9 - 2.0.x
+  - libtorrent-rasterbar 1.2.19 - 1.2.x || 2.0.10 - 2.0.x
       * By Arvid Norberg, https://www.libtorrent.org/
       * Be careful: another library (the one used by rTorrent) uses a similar name
 


### PR DESCRIPTION
* Libtorrent 2.0.10 released
https://github.com/arvidn/libtorrent/releases/tag/v2.0.10