### PR TITLE
GHA CI: Bump libtorrent 2 version to 2.0.10

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libt_version: ["2.0.9", "1.2.19"]
+        libt_version: ["2.0.10", "1.2.19"]
         qbt_gui: ["GUI=ON", "GUI=OFF"]
         qt_version: ["6.5.2"]
 

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libt_version: ["2.0.9", "1.2.19"]
+        libt_version: ["2.0.10", "1.2.19"]
         qbt_gui: ["GUI=ON", "GUI=OFF"]
         qt_version: ["6.5.2"]
 

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libt_version: ["2.0.9", "1.2.19"]
+        libt_version: ["2.0.10", "1.2.19"]
 
     env:
       boost_path: "${{ github.workspace }}/../boost"

--- a/.github/workflows/coverity-scan.yaml
+++ b/.github/workflows/coverity-scan.yaml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        libt_version: ["2.0.9"]
+        libt_version: ["2.0.10"]
         qbt_gui: ["GUI=ON"]
         qt_version: ["6.5.2"]
 


### PR DESCRIPTION
* Libtorrent 2.0.10 released
https://github.com/arvidn/libtorrent/releases/tag/v2.0.10