### PR TITLE
Correctly handle share limits in torrent options dialog

### DIFF
--- a/src/gui/addtorrentparamswidget.cpp
+++ b/src/gui/addtorrentparamswidget.cpp
@@ -144,9 +144,9 @@ void AddTorrentParamsWidget::setAddTorrentParams(BitTorrent::AddTorrentParams ad
 BitTorrent::AddTorrentParams AddTorrentParamsWidget::addTorrentParams() const
 {
     BitTorrent::AddTorrentParams addTorrentParams = cleanParams(m_addTorrentParams);
-    addTorrentParams.ratioLimit = m_ui->torrentShareLimitsWidget->ratioLimit();
-    addTorrentParams.seedingTimeLimit = m_ui->torrentShareLimitsWidget->seedingTimeLimit();
-    addTorrentParams.inactiveSeedingTimeLimit = m_ui->torrentShareLimitsWidget->inactiveSeedingTimeLimit();
+    addTorrentParams.ratioLimit = m_ui->torrentShareLimitsWidget->ratioLimit().value();
+    addTorrentParams.seedingTimeLimit = m_ui->torrentShareLimitsWidget->seedingTimeLimit().value();
+    addTorrentParams.inactiveSeedingTimeLimit = m_ui->torrentShareLimitsWidget->inactiveSeedingTimeLimit().value();
 
     return addTorrentParams;
 }
@@ -269,8 +269,9 @@ void AddTorrentParamsWidget::populate()
             m_addTorrentParams.addToQueueTop = data.toBool();
     });
 
-    m_ui->torrentShareLimitsWidget->setTorrentShareLimits(m_addTorrentParams.ratioLimit
-            , m_addTorrentParams.seedingTimeLimit, m_addTorrentParams.inactiveSeedingTimeLimit);
+    m_ui->torrentShareLimitsWidget->setRatioLimit(m_addTorrentParams.ratioLimit);
+    m_ui->torrentShareLimitsWidget->setSeedingTimeLimit(m_addTorrentParams.seedingTimeLimit);
+    m_ui->torrentShareLimitsWidget->setInactiveSeedingTimeLimit(m_addTorrentParams.inactiveSeedingTimeLimit);
 }
 
 void AddTorrentParamsWidget::loadCustomSavePathOptions()

--- a/src/gui/torrentoptionsdialog.cpp
+++ b/src/gui/torrentoptionsdialog.cpp
@@ -282,6 +282,7 @@ TorrentOptionsDialog::TorrentOptionsDialog(QWidget *parent, const QVector<BitTor
                            , this, &TorrentOptionsDialog::handleDownSpeedLimitChanged);
     }
 
+    m_ui->torrentShareLimitsWidget->setDefaultLimits(session->globalMaxRatio(), session->globalMaxSeedingMinutes(), session->globalMaxInactiveSeedingMinutes());
     if (allSameRatio)
         m_ui->torrentShareLimitsWidget->setRatioLimit(firstTorrentRatio);
     if (allSameSeedingTime)

--- a/src/gui/torrentoptionsdialog.cpp
+++ b/src/gui/torrentoptionsdialog.cpp
@@ -1,5 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2024  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2020  thalieht
  * Copyright (C) 2011  Christian Kandeler
  * Copyright (C) 2011  Christophe Dumez <chris@qbittorrent.org>
@@ -49,8 +50,6 @@
 
 namespace
 {
-    const int MIXED_SHARE_LIMITS = -9;
-
     void updateSliderValue(QSlider *slider, const int value)
     {
         if (value > slider->maximum())
@@ -283,47 +282,12 @@ TorrentOptionsDialog::TorrentOptionsDialog(QWidget *parent, const QVector<BitTor
                            , this, &TorrentOptionsDialog::handleDownSpeedLimitChanged);
     }
 
-    const bool useGlobalValue = allSameRatio && allSameSeedingTime
-        && (firstTorrentRatio == BitTorrent::Torrent::USE_GLOBAL_RATIO)
-        && (firstTorrentSeedingTime == BitTorrent::Torrent::USE_GLOBAL_SEEDING_TIME)
-        && (firstTorrentInactiveSeedingTime == BitTorrent::Torrent::USE_GLOBAL_INACTIVE_SEEDING_TIME);
-
-    if (!allSameRatio || !allSameSeedingTime || !allSameInactiveSeedingTime)
-    {
-        m_ui->radioUseGlobalShareLimits->setChecked(false);
-        m_ui->radioNoLimit->setChecked(false);
-        m_ui->radioTorrentLimit->setChecked(false);
-    }
-    else if (useGlobalValue)
-    {
-        m_ui->radioUseGlobalShareLimits->setChecked(true);
-    }
-    else if ((firstTorrentRatio == BitTorrent::Torrent::NO_RATIO_LIMIT)
-             && (firstTorrentSeedingTime == BitTorrent::Torrent::NO_SEEDING_TIME_LIMIT)
-             && (firstTorrentInactiveSeedingTime == BitTorrent::Torrent::NO_INACTIVE_SEEDING_TIME_LIMIT))
-    {
-        m_ui->radioNoLimit->setChecked(true);
-    }
-    else
-    {
-        m_ui->radioTorrentLimit->setChecked(true);
-        if (firstTorrentRatio >= 0)
-            m_ui->checkMaxRatio->setChecked(true);
-        if (firstTorrentSeedingTime >= 0)
-            m_ui->checkMaxTime->setChecked(true);
-        if (firstTorrentInactiveSeedingTime >= 0)
-            m_ui->checkMaxInactiveTime->setChecked(true);
-    }
-
-    const qreal maxRatio = (allSameRatio && (firstTorrentRatio >= 0))
-            ? firstTorrentRatio : session->globalMaxRatio();
-    const int maxSeedingTime = (allSameSeedingTime && (firstTorrentSeedingTime >= 0))
-            ? firstTorrentSeedingTime : session->globalMaxSeedingMinutes();
-    const int maxInactiveSeedingTime = (allSameInactiveSeedingTime && (firstTorrentInactiveSeedingTime >= 0))
-            ? firstTorrentInactiveSeedingTime : session->globalMaxInactiveSeedingMinutes();
-    m_ui->spinRatioLimit->setValue(maxRatio);
-    m_ui->spinTimeLimit->setValue(maxSeedingTime);
-    m_ui->spinInactiveTimeLimit->setValue(maxInactiveSeedingTime);
+    if (allSameRatio)
+        m_ui->torrentShareLimitsWidget->setRatioLimit(firstTorrentRatio);
+    if (allSameSeedingTime)
+        m_ui->torrentShareLimitsWidget->setSeedingTimeLimit(firstTorrentSeedingTime);
+    if (allSameInactiveSeedingTime)
+        m_ui->torrentShareLimitsWidget->setInactiveSeedingTimeLimit(firstTorrentInactiveSeedingTime);
 
     if (!allTorrentsArePrivate)
     {
@@ -369,27 +333,26 @@ TorrentOptionsDialog::TorrentOptionsDialog(QWidget *parent, const QVector<BitTor
 
     m_initialValues =
     {
-        m_ui->savePath->selectedPath(),
-        m_ui->downloadPath->selectedPath(),
-        m_ui->comboCategory->currentText(),
-        getRatio(),
-        getSeedingTime(),
-        getInactiveSeedingTime(),
-        m_ui->spinUploadLimit->value(),
-        m_ui->spinDownloadLimit->value(),
-        m_ui->checkAutoTMM->checkState(),
-        m_ui->checkUseDownloadPath->checkState(),
-        m_ui->checkDisableDHT->checkState(),
-        m_ui->checkDisablePEX->checkState(),
-        m_ui->checkDisableLSD->checkState(),
-        m_ui->checkSequential->checkState(),
-        m_ui->checkFirstLastPieces->checkState()
+        .savePath = m_ui->savePath->selectedPath(),
+        .downloadPath = m_ui->downloadPath->selectedPath(),
+        .category = m_ui->comboCategory->currentText(),
+        .ratio = m_ui->torrentShareLimitsWidget->ratioLimit(),
+        .seedingTime = m_ui->torrentShareLimitsWidget->seedingTimeLimit(),
+        .inactiveSeedingTime = m_ui->torrentShareLimitsWidget->inactiveSeedingTimeLimit(),
+        .upSpeedLimit = m_ui->spinUploadLimit->value(),
+        .downSpeedLimit = m_ui->spinDownloadLimit->value(),
+        .autoTMM = m_ui->checkAutoTMM->checkState(),
+        .useDownloadPath = m_ui->checkUseDownloadPath->checkState(),
+        .disableDHT = m_ui->checkDisableDHT->checkState(),
+        .disablePEX = m_ui->checkDisablePEX->checkState(),
+        .disableLSD = m_ui->checkDisableLSD->checkState(),
+        .sequential = m_ui->checkSequential->checkState(),
+        .firstLastPieces = m_ui->checkFirstLastPieces->checkState()
     };
 
     // Needs to be called after the initial values struct is initialized
     handleTMMChanged();
     handleUseDownloadPathChanged();
-    handleRatioTypeChanged();
 
     connect(m_ui->checkAutoTMM, &QCheckBox::clicked, this, &TorrentOptionsDialog::handleTMMChanged);
     connect(m_ui->checkUseDownloadPath, &QCheckBox::clicked, this, &TorrentOptionsDialog::handleUseDownloadPathChanged);
@@ -403,12 +366,6 @@ TorrentOptionsDialog::TorrentOptionsDialog(QWidget *parent, const QVector<BitTor
     connect(m_ui->spinDownloadLimit, qOverload<int>(&QSpinBox::valueChanged)
             , this, [this](const int value) { updateSliderValue(m_ui->sliderDownloadLimit, value); });
 
-    connect(m_ui->checkMaxRatio, &QCheckBox::toggled, m_ui->spinRatioLimit, &QWidget::setEnabled);
-    connect(m_ui->checkMaxTime, &QCheckBox::toggled, m_ui->spinTimeLimit, &QWidget::setEnabled);
-    connect(m_ui->checkMaxInactiveTime, &QCheckBox::toggled, m_ui->spinInactiveTimeLimit, &QSpinBox::setEnabled);
-
-    connect(m_ui->buttonGroup, &QButtonGroup::idClicked, this, &TorrentOptionsDialog::handleRatioTypeChanged);
-
     if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())
         resize(dialogSize);
 }
@@ -421,13 +378,6 @@ TorrentOptionsDialog::~TorrentOptionsDialog()
 
 void TorrentOptionsDialog::accept()
 {
-    if (m_ui->radioTorrentLimit->isChecked() && !m_ui->checkMaxRatio->isChecked()
-        && !m_ui->checkMaxTime->isChecked() && !m_ui->checkMaxInactiveTime->isChecked())
-    {
-        QMessageBox::critical(this, tr("No share limit method selected"), tr("Please select a limit method first"));
-        return;
-    }
-
     auto *session = BitTorrent::Session::instance();
     for (const BitTorrent::TorrentID &id : asConst(m_torrentIDs))
     {
@@ -471,17 +421,23 @@ void TorrentOptionsDialog::accept()
         if (m_initialValues.downSpeedLimit != m_ui->spinDownloadLimit->value())
             torrent->setDownloadLimit(m_ui->spinDownloadLimit->value() * 1024);
 
-        const qreal ratioLimit = getRatio();
-        if (m_initialValues.ratio != ratioLimit)
-            torrent->setRatioLimit(ratioLimit);
+        if (const std::optional<qreal> ratioLimit = m_ui->torrentShareLimitsWidget->ratioLimit();
+                m_initialValues.ratio != ratioLimit)
+        {
+            torrent->setRatioLimit(ratioLimit.value());
+        }
 
-        const int seedingTimeLimit = getSeedingTime();
-        if (m_initialValues.seedingTime != seedingTimeLimit)
-            torrent->setSeedingTimeLimit(seedingTimeLimit);
+        if (const std::optional<int> seedingTimeLimit = m_ui->torrentShareLimitsWidget->seedingTimeLimit();
+                m_initialValues.seedingTime != seedingTimeLimit)
+        {
+            torrent->setSeedingTimeLimit(seedingTimeLimit.value());
+        }
 
-        const int inactiveSeedingTimeLimit = getInactiveSeedingTime();
-        if (m_initialValues.inactiveSeedingTime != inactiveSeedingTimeLimit)
-            torrent->setInactiveSeedingTimeLimit(inactiveSeedingTimeLimit);
+        if (const std::optional<int> inactiveSeedingTimeLimit = m_ui->torrentShareLimitsWidget->inactiveSeedingTimeLimit();
+                m_initialValues.inactiveSeedingTime != inactiveSeedingTimeLimit)
+        {
+            torrent->setInactiveSeedingTimeLimit(inactiveSeedingTimeLimit.value());
+        }
 
         if (!torrent->isPrivate())
         {
@@ -500,48 +456,6 @@ void TorrentOptionsDialog::accept()
     }
 
     QDialog::accept();
-}
-
-qreal TorrentOptionsDialog::getRatio() const
-{
-    if (m_ui->buttonGroup->checkedId() == -1) // No radio button is selected
-        return MIXED_SHARE_LIMITS;
-
-    if (m_ui->radioUseGlobalShareLimits->isChecked())
-        return BitTorrent::Torrent::USE_GLOBAL_RATIO;
-
-    if (m_ui->radioNoLimit->isChecked() || !m_ui->checkMaxRatio->isChecked())
-        return BitTorrent::Torrent::NO_RATIO_LIMIT;
-
-    return m_ui->spinRatioLimit->value();
-}
-
-int TorrentOptionsDialog::getSeedingTime() const
-{
-    if (m_ui->buttonGroup->checkedId() == -1) // No radio button is selected
-        return MIXED_SHARE_LIMITS;
-
-    if (m_ui->radioUseGlobalShareLimits->isChecked())
-        return BitTorrent::Torrent::USE_GLOBAL_SEEDING_TIME;
-
-    if (m_ui->radioNoLimit->isChecked() || !m_ui->checkMaxTime->isChecked())
-        return  BitTorrent::Torrent::NO_SEEDING_TIME_LIMIT;
-
-    return m_ui->spinTimeLimit->value();
-}
-
-int TorrentOptionsDialog::getInactiveSeedingTime() const
-{
-    if (m_ui->buttonGroup->checkedId() == -1) // No radio button is selected
-        return MIXED_SHARE_LIMITS;
-
-    if (m_ui->radioUseGlobalShareLimits->isChecked())
-        return BitTorrent::Torrent::USE_GLOBAL_INACTIVE_SEEDING_TIME;
-
-    if (m_ui->radioNoLimit->isChecked() || !m_ui->checkMaxInactiveTime->isChecked())
-        return  BitTorrent::Torrent::NO_INACTIVE_SEEDING_TIME_LIMIT;
-
-    return m_ui->spinInactiveTimeLimit->value();
 }
 
 void TorrentOptionsDialog::handleCategoryChanged([[maybe_unused]] const int index)
@@ -617,31 +531,6 @@ void TorrentOptionsDialog::handleUseDownloadPathChanged()
     m_ui->downloadPath->setEnabled(isChecked);
     if (isChecked && m_ui->downloadPath->selectedPath().isEmpty())
         m_ui->downloadPath->setSelectedPath(BitTorrent::Session::instance()->downloadPath());
-}
-
-void TorrentOptionsDialog::handleRatioTypeChanged()
-{
-    if ((m_initialValues.ratio == MIXED_SHARE_LIMITS) || (m_initialValues.seedingTime == MIXED_SHARE_LIMITS)
-        || (m_initialValues.inactiveSeedingTime == MIXED_SHARE_LIMITS))
-    {
-        QAbstractButton *currentRadio = m_ui->buttonGroup->checkedButton();
-        if (currentRadio && (currentRadio == m_previousRadio))
-        {
-            // Hack to deselect the currently selected radio button programmatically because Qt doesn't allow it in exclusive mode
-            m_ui->buttonGroup->setExclusive(false);
-            currentRadio->setChecked(false);
-            m_ui->buttonGroup->setExclusive(true);
-        }
-        m_previousRadio = m_ui->buttonGroup->checkedButton();
-    }
-
-    m_ui->checkMaxRatio->setEnabled(m_ui->radioTorrentLimit->isChecked());
-    m_ui->checkMaxTime->setEnabled(m_ui->radioTorrentLimit->isChecked());
-    m_ui->checkMaxInactiveTime->setEnabled(m_ui->radioTorrentLimit->isChecked());
-
-    m_ui->spinRatioLimit->setEnabled(m_ui->radioTorrentLimit->isChecked() && m_ui->checkMaxRatio->isChecked());
-    m_ui->spinTimeLimit->setEnabled(m_ui->radioTorrentLimit->isChecked() && m_ui->checkMaxTime->isChecked());
-    m_ui->spinInactiveTimeLimit->setEnabled(m_ui->radioTorrentLimit->isChecked() && m_ui->checkMaxInactiveTime->isChecked());
 }
 
 void TorrentOptionsDialog::handleUpSpeedLimitChanged()

--- a/src/gui/torrentoptionsdialog.h
+++ b/src/gui/torrentoptionsdialog.h
@@ -1,5 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2024  Vladimir Golovnev <glassez@yandex.ru>
  * Copyright (C) 2020  thalieht
  * Copyright (C) 2011  Christian Kandeler
  * Copyright (C) 2011  Christophe Dumez <chris@qbittorrent.org>
@@ -29,6 +30,8 @@
  */
 
 #pragma once
+
+#include <optional>
 
 #include <QDialog>
 
@@ -68,13 +71,7 @@ private slots:
     void handleUpSpeedLimitChanged();
     void handleDownSpeedLimitChanged();
 
-    void handleRatioTypeChanged();
-
 private:
-    qreal getRatio() const;
-    int getSeedingTime() const;
-    int getInactiveSeedingTime() const;
-
     QVector<BitTorrent::TorrentID> m_torrentIDs;
     Ui::TorrentOptionsDialog *m_ui = nullptr;
     SettingValue<QSize> m_storeDialogSize;
@@ -87,9 +84,9 @@ private:
         Path savePath;
         Path downloadPath;
         QString category;
-        qreal ratio;
-        int seedingTime;
-        int inactiveSeedingTime;
+        std::optional<qreal> ratio;
+        std::optional<int> seedingTime;
+        std::optional<int> inactiveSeedingTime;
         int upSpeedLimit;
         int downSpeedLimit;
         Qt::CheckState autoTMM;

--- a/src/gui/torrentoptionsdialog.ui
+++ b/src/gui/torrentoptionsdialog.ui
@@ -151,111 +151,13 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox_2">
+    <widget class="QGroupBox" name="torrentShareLimitsBox">
      <property name="title">
       <string>Torrent share limits</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
+     <layout class="QVBoxLayout" name="torrentShareLimitsBoxLayout">
       <item>
-       <widget class="QRadioButton" name="radioUseGlobalShareLimits">
-        <property name="text">
-         <string>Use global share limit</string>
-        </property>
-        <attribute name="buttonGroup">
-         <string notr="true">buttonGroup</string>
-        </attribute>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="radioNoLimit">
-        <property name="text">
-         <string>Set no share limit</string>
-        </property>
-        <attribute name="buttonGroup">
-         <string notr="true">buttonGroup</string>
-        </attribute>
-       </widget>
-      </item>
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QRadioButton" name="radioTorrentLimit">
-          <property name="text">
-           <string>Set share limit to</string>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">buttonGroup</string>
-          </attribute>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QCheckBox" name="checkMaxRatio">
-          <property name="text">
-           <string>ratio</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="QDoubleSpinBox" name="spinRatioLimit">
-          <property name="maximum">
-           <double>9999.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>0.050000000000000</double>
-          </property>
-          <property name="value">
-           <double>1.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QCheckBox" name="checkMaxTime">
-          <property name="text">
-           <string>total minutes</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="2">
-         <widget class="QSpinBox" name="spinTimeLimit">
-          <property name="maximum">
-           <number>525600</number>
-          </property>
-          <property name="value">
-           <number>1440</number>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="3">
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="2" column="1">
-         <widget class="QCheckBox" name="checkMaxInactiveTime">
-          <property name="text">
-           <string>inactive minutes</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="QSpinBox" name="spinInactiveTimeLimit">
-          <property name="maximum">
-           <number>525600</number>
-          </property>
-          <property name="value">
-           <number>1440</number>
-          </property>
-         </widget>
-        </item>
-       </layout>
+       <widget class="TorrentShareLimitsWidget" name="torrentShareLimitsWidget" native="true"/>
       </item>
      </layout>
     </widget>
@@ -339,6 +241,12 @@
    <class>FileSystemPathComboEdit</class>
    <extends>QWidget</extends>
    <header>gui/fspathedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>TorrentShareLimitsWidget</class>
+   <extends>QWidget</extends>
+   <header>gui/torrentsharelimitswidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/gui/torrentsharelimitswidget.cpp
+++ b/src/gui/torrentsharelimitswidget.cpp
@@ -34,18 +34,28 @@ namespace
 {
     enum ShareLimitModeIndex
     {
+        UninitializedModeIndex = -1,
         DefaultModeIndex,
         UnlimitedModeIndex,
         AssignedModeIndex
     };
 }
 
-TorrentShareLimitsWidget::TorrentShareLimitsWidget(QWidget *parent, const qreal ratioLimit
-        , const int seedingTimeLimit, const int inactiveSeedingTimeLimit)
+TorrentShareLimitsWidget::TorrentShareLimitsWidget(QWidget *parent)
     : QWidget(parent)
     , m_ui {new Ui::TorrentShareLimitsWidget}
 {
     m_ui->setupUi(this);
+
+    m_ui->spinBoxRatioValue->setEnabled(false);
+    m_ui->spinBoxRatioValue->setSuffix({});
+    m_ui->spinBoxRatioValue->clear();
+    m_ui->spinBoxSeedingTimeValue->setEnabled(false);
+    m_ui->spinBoxSeedingTimeValue->setSuffix({});
+    m_ui->spinBoxSeedingTimeValue->clear();
+    m_ui->spinBoxInactiveSeedingTimeValue->setEnabled(false);
+    m_ui->spinBoxInactiveSeedingTimeValue->setSuffix({});
+    m_ui->spinBoxInactiveSeedingTimeValue->clear();
 
     connect(m_ui->comboBoxRatioMode, &QComboBox::currentIndexChanged, this, [this](const int index)
     {
@@ -90,8 +100,6 @@ TorrentShareLimitsWidget::TorrentShareLimitsWidget(QWidget *parent, const qreal 
             m_ui->spinBoxInactiveSeedingTimeValue->clear();
         }
     });
-
-    setTorrentShareLimits(ratioLimit, seedingTimeLimit, inactiveSeedingTimeLimit);
 }
 
 TorrentShareLimitsWidget::~TorrentShareLimitsWidget()
@@ -99,7 +107,7 @@ TorrentShareLimitsWidget::~TorrentShareLimitsWidget()
     delete m_ui;
 }
 
-void TorrentShareLimitsWidget::setTorrentShareLimits(const qreal ratioLimit, const int seedingTimeLimit, const int inactiveSeedingTimeLimit)
+void TorrentShareLimitsWidget::setRatioLimit(const qreal ratioLimit)
 {
     if (ratioLimit == BitTorrent::Torrent::USE_GLOBAL_RATIO)
     {
@@ -114,7 +122,10 @@ void TorrentShareLimitsWidget::setTorrentShareLimits(const qreal ratioLimit, con
         m_ui->comboBoxRatioMode->setCurrentIndex(AssignedModeIndex);
         m_ui->spinBoxRatioValue->setValue(ratioLimit);
     }
+}
 
+void TorrentShareLimitsWidget::setSeedingTimeLimit(const int seedingTimeLimit)
+{
     if (seedingTimeLimit == BitTorrent::Torrent::USE_GLOBAL_SEEDING_TIME)
     {
         m_ui->comboBoxSeedingTimeMode->setCurrentIndex(DefaultModeIndex);
@@ -128,7 +139,10 @@ void TorrentShareLimitsWidget::setTorrentShareLimits(const qreal ratioLimit, con
         m_ui->comboBoxSeedingTimeMode->setCurrentIndex(AssignedModeIndex);
         m_ui->spinBoxSeedingTimeValue->setValue(seedingTimeLimit);
     }
+}
 
+void TorrentShareLimitsWidget::setInactiveSeedingTimeLimit(const int inactiveSeedingTimeLimit)
+{
     if (inactiveSeedingTimeLimit == BitTorrent::Torrent::USE_GLOBAL_INACTIVE_SEEDING_TIME)
     {
         m_ui->comboBoxInactiveSeedingTimeMode->setCurrentIndex(DefaultModeIndex);
@@ -144,44 +158,47 @@ void TorrentShareLimitsWidget::setTorrentShareLimits(const qreal ratioLimit, con
     }
 }
 
-qreal TorrentShareLimitsWidget::ratioLimit() const
+std::optional<qreal> TorrentShareLimitsWidget::ratioLimit() const
 {
     switch (m_ui->comboBoxRatioMode->currentIndex())
     {
     case DefaultModeIndex:
-    default:
         return BitTorrent::Torrent::USE_GLOBAL_RATIO;
     case UnlimitedModeIndex:
         return BitTorrent::Torrent::NO_RATIO_LIMIT;
     case AssignedModeIndex:
         return m_ui->spinBoxRatioValue->value();
+    default:
+        return std::nullopt;
     }
 }
 
-int TorrentShareLimitsWidget::seedingTimeLimit() const
+std::optional<int> TorrentShareLimitsWidget::seedingTimeLimit() const
 {
     switch (m_ui->comboBoxSeedingTimeMode->currentIndex())
     {
     case DefaultModeIndex:
-    default:
         return BitTorrent::Torrent::USE_GLOBAL_SEEDING_TIME;
     case UnlimitedModeIndex:
         return BitTorrent::Torrent::NO_SEEDING_TIME_LIMIT;
     case AssignedModeIndex:
         return m_ui->spinBoxSeedingTimeValue->value();
+    default:
+        return std::nullopt;
     }
 }
 
-int TorrentShareLimitsWidget::inactiveSeedingTimeLimit() const
+std::optional<int> TorrentShareLimitsWidget::inactiveSeedingTimeLimit() const
 {
     switch (m_ui->comboBoxInactiveSeedingTimeMode->currentIndex())
     {
     case DefaultModeIndex:
-    default:
         return BitTorrent::Torrent::USE_GLOBAL_INACTIVE_SEEDING_TIME;
     case UnlimitedModeIndex:
         return BitTorrent::Torrent::NO_INACTIVE_SEEDING_TIME_LIMIT;
     case AssignedModeIndex:
         return m_ui->spinBoxInactiveSeedingTimeValue->value();
+    default:
+        return std::nullopt;
     }
 }

--- a/src/gui/torrentsharelimitswidget.h
+++ b/src/gui/torrentsharelimitswidget.h
@@ -28,6 +28,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include <QWidget>
 
 #include "base/bittorrent/torrent.h"
@@ -43,21 +45,20 @@ class TorrentShareLimitsWidget final : public QWidget
     Q_DISABLE_COPY_MOVE(TorrentShareLimitsWidget)
 
 public:
-    explicit TorrentShareLimitsWidget(QWidget *parent = nullptr
-            , qreal ratioLimit = BitTorrent::Torrent::USE_GLOBAL_RATIO
-            , int seedingTimeLimit = BitTorrent::Torrent::USE_GLOBAL_SEEDING_TIME
-            , int inactiveSeedingTimeLimit = BitTorrent::Torrent::USE_GLOBAL_INACTIVE_SEEDING_TIME);
+    explicit TorrentShareLimitsWidget(QWidget *parent = nullptr);
     ~TorrentShareLimitsWidget() override;
 
-    void setTorrentShareLimits(qreal ratioLimit, int seedingTimeLimit, int inactiveSeedingTimeLimit);
+    void setRatioLimit(qreal ratioLimit);
+    void setSeedingTimeLimit(int seedingTimeLimit);
+    void setInactiveSeedingTimeLimit(int inactiveSeedingTimeLimit);
 
-    qreal ratioLimit() const;
-    int seedingTimeLimit() const;
-    int inactiveSeedingTimeLimit() const;
+    std::optional<qreal> ratioLimit() const;
+    std::optional<int> seedingTimeLimit() const;
+    std::optional<int> inactiveSeedingTimeLimit() const;
 
 private:
     Ui::TorrentShareLimitsWidget *m_ui = nullptr;
-    int m_seedingTimeLimit = 0;
-    int m_inactiveSeedingTimeLimit = 0;
-    qreal m_ratioLimit = 0;
+    int m_seedingTimeLimit = 1440;
+    int m_inactiveSeedingTimeLimit = 1440;
+    qreal m_ratioLimit = 1;
 };

--- a/src/gui/torrentsharelimitswidget.h
+++ b/src/gui/torrentsharelimitswidget.h
@@ -32,8 +32,6 @@
 
 #include <QWidget>
 
-#include "base/bittorrent/torrent.h"
-
 namespace Ui
 {
     class TorrentShareLimitsWidget;
@@ -52,13 +50,24 @@ public:
     void setSeedingTimeLimit(int seedingTimeLimit);
     void setInactiveSeedingTimeLimit(int inactiveSeedingTimeLimit);
 
+    void setDefaultLimits(qreal ratioLimit, int seedingTimeLimit, int inactiveSeedingTimeLimit);
+
     std::optional<qreal> ratioLimit() const;
     std::optional<int> seedingTimeLimit() const;
     std::optional<int> inactiveSeedingTimeLimit() const;
 
 private:
+    void refreshRatioLimitControls();
+    void refreshSeedingTimeLimitControls();
+    void refreshInactiveSeedingTimeLimitControls();
+
     Ui::TorrentShareLimitsWidget *m_ui = nullptr;
+
     int m_seedingTimeLimit = 1440;
     int m_inactiveSeedingTimeLimit = 1440;
     qreal m_ratioLimit = 1;
+
+    int m_defaultSeedingTimeLimit = -1;
+    int m_defaultInactiveSeedingTimeLimit = -1;
+    qreal m_defaultRatioLimit = -1;
 };


### PR DESCRIPTION
Now it handles share limits in a consistent manner with the underlying model.