### PR TITLE
GHA CI: disable security hardening flag

### DIFF
--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -55,15 +55,13 @@ jobs:
             -Force `
             -ItemType File `
             -Path "${{ env.vcpkg_path }}/triplets_overlay/x64-windows-static-md-release.cmake"
+          # OpenSSL isn't compatible with `/guard:cf` flag so we omit it for now, see: https://github.com/openssl/openssl/issues/22554
           Add-Content `
             -Path "${{ env.vcpkg_path }}/triplets_overlay/x64-windows-static-md-release.cmake" `
             -Value @("set(VCPKG_TARGET_ARCHITECTURE x64)",
               "set(VCPKG_LIBRARY_LINKAGE static)",
               "set(VCPKG_CRT_LINKAGE dynamic)",
-              "set(VCPKG_BUILD_TYPE release)",
-              "set(VCPKG_C_FLAGS /guard:cf)",
-              "set(VCPKG_CXX_FLAGS /guard:cf)",
-              "set(VCPKG_LINKER_FLAGS /guard:cf)")
+              "set(VCPKG_BUILD_TYPE release)")
           # clear buildtrees after each package installation to reduce disk space requirements
           $packages = `
             "openssl:x64-windows-static-md-release",


### PR DESCRIPTION
OpenSSL isn't compatible with `/guard:cf` flag so we omit it for now. Related: https://github.com/openssl/openssl/issues/22554
Closes #20479.

