### PR TITLE
Revise Tracker related classes

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(qbt_base STATIC
     bittorrent/torrentinfo.h
     bittorrent/tracker.h
     bittorrent/trackerentry.h
+    bittorrent/trackerentrystatus.h
     concepts/explicitlyconvertibleto.h
     concepts/stringable.h
     digest32.h
@@ -151,6 +152,7 @@ add_library(qbt_base STATIC
     bittorrent/torrentinfo.cpp
     bittorrent/tracker.cpp
     bittorrent/trackerentry.cpp
+    bittorrent/trackerentrystatus.cpp
     exceptions.cpp
     http/connection.cpp
     http/httperror.cpp

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -38,6 +38,7 @@
 #include "categoryoptions.h"
 #include "sharelimitaction.h"
 #include "trackerentry.h"
+#include "trackerentrystatus.h"
 
 class QString;
 
@@ -490,6 +491,6 @@ namespace BitTorrent
         void trackersRemoved(Torrent *torrent, const QStringList &trackers);
         void trackerSuccess(Torrent *torrent, const QString &tracker);
         void trackerWarning(Torrent *torrent, const QString &tracker);
-        void trackerEntriesUpdated(Torrent *torrent, const QHash<QString, TrackerEntry> &updatedTrackerEntries);
+        void trackerEntryStatusesUpdated(Torrent *torrent, const QHash<QString, TrackerEntryStatus> &updatedTrackers);
     };
 }

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -102,6 +102,7 @@
 #include "torrentdescriptor.h"
 #include "torrentimpl.h"
 #include "tracker.h"
+#include "trackerentry.h"
 
 using namespace std::chrono_literals;
 using namespace BitTorrent;
@@ -2214,7 +2215,7 @@ void SessionImpl::populateAdditionalTrackers()
     {
         tracker = tracker.trimmed();
         if (!tracker.isEmpty())
-            m_additionalTrackerList.append({tracker.toString()});
+            m_additionalTrackerList.append({.url = tracker.toString(), .tier = 0});
     }
 }
 
@@ -4898,14 +4899,15 @@ void SessionImpl::handleTorrentMetadataReceived(TorrentImpl *const torrent)
 
 void SessionImpl::handleTorrentPaused(TorrentImpl *const torrent)
 {
-    torrent->resetTrackerEntries();
+    torrent->resetTrackerEntryStatuses();
 
-    const auto &trackerEntries = torrent->trackers();
-    QHash<QString, TrackerEntry> updatedTrackerEntries;
-    updatedTrackerEntries.reserve(trackerEntries.size());
-    for (const auto &trackerEntry : trackerEntries)
-        updatedTrackerEntries.emplace(trackerEntry.url, trackerEntry);
-    emit trackerEntriesUpdated(torrent, updatedTrackerEntries);
+    const QVector<TrackerEntryStatus> trackers = torrent->trackers();
+    QHash<QString, TrackerEntryStatus> updatedTrackers;
+    updatedTrackers.reserve(trackers.size());
+
+    for (const TrackerEntryStatus &status : trackers)
+        updatedTrackers.emplace(status.url, status);
+    emit trackerEntryStatusesUpdated(torrent, updatedTrackers);
 
     LogMsg(tr("Torrent paused. Torrent: \"%1\"").arg(torrent->name()));
     emit torrentPaused(torrent);
@@ -6041,7 +6043,7 @@ void SessionImpl::handleTrackerAlert(const lt::tracker_alert *a)
     if (!torrent)
         return;
 
-    QMap<int, int> &updateInfo = m_updatedTrackerEntries[torrent->nativeHandle()][std::string(a->tracker_url())][a->local_endpoint];
+    QMap<int, int> &updateInfo = m_updatedTrackerStatuses[torrent->nativeHandle()][std::string(a->tracker_url())][a->local_endpoint];
 
     if (a->type() == lt::tracker_reply_alert::alert_type)
     {
@@ -6105,15 +6107,13 @@ void SessionImpl::handleTorrentConflictAlert(const lt::torrent_conflict_alert *a
 
 void SessionImpl::processTrackerStatuses()
 {
-    if (m_updatedTrackerEntries.isEmpty())
+    if (m_updatedTrackerStatuses.isEmpty())
         return;
 
-    for (auto it = m_updatedTrackerEntries.cbegin(); it != m_updatedTrackerEntries.cend(); ++it)
-    {
-        updateTrackerEntries(it.key(), it.value());
-    }
+    for (auto it = m_updatedTrackerStatuses.cbegin(); it != m_updatedTrackerStatuses.cend(); ++it)
+        updateTrackerEntryStatuses(it.key(), it.value());
 
-    m_updatedTrackerEntries.clear();
+    m_updatedTrackerStatuses.clear();
 }
 
 void SessionImpl::saveStatistics() const
@@ -6140,7 +6140,7 @@ void SessionImpl::loadStatistics()
     m_previouslyUploaded = value[u"AlltimeUL"_s].toLongLong();
 }
 
-void SessionImpl::updateTrackerEntries(lt::torrent_handle torrentHandle, QHash<std::string, QHash<lt::tcp::endpoint, QMap<int, int>>> updatedTrackers)
+void SessionImpl::updateTrackerEntryStatuses(lt::torrent_handle torrentHandle, QHash<std::string, QHash<lt::tcp::endpoint, QMap<int, int>>> updatedTrackers)
 {
     invokeAsync([this, torrentHandle = std::move(torrentHandle), updatedTrackers = std::move(updatedTrackers)]() mutable
     {
@@ -6154,8 +6154,8 @@ void SessionImpl::updateTrackerEntries(lt::torrent_handle torrentHandle, QHash<s
                 if (!torrent || torrent->isPaused())
                     return;
 
-                QHash<QString, TrackerEntry> updatedTrackerEntries;
-                updatedTrackerEntries.reserve(updatedTrackers.size());
+                QHash<QString, TrackerEntryStatus> trackers;
+                trackers.reserve(updatedTrackers.size());
                 for (const lt::announce_entry &announceEntry : nativeTrackers)
                 {
                     const auto updatedTrackersIter = updatedTrackers.find(announceEntry.url);
@@ -6163,12 +6163,12 @@ void SessionImpl::updateTrackerEntries(lt::torrent_handle torrentHandle, QHash<s
                         continue;
 
                     const auto &updateInfo = updatedTrackersIter.value();
-                    TrackerEntry trackerEntry = torrent->updateTrackerEntry(announceEntry, updateInfo);
-                    const QString url = trackerEntry.url;
-                    updatedTrackerEntries.emplace(url, std::move(trackerEntry));
+                    TrackerEntryStatus status = torrent->updateTrackerEntryStatus(announceEntry, updateInfo);
+                    const QString url = status.url;
+                    trackers.emplace(url, std::move(status));
                 }
 
-                emit trackerEntriesUpdated(torrent, updatedTrackerEntries);
+                emit trackerEntryStatusesUpdated(torrent, trackers);
             });
         }
         catch (const std::exception &)

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -54,7 +54,7 @@
 #include "session.h"
 #include "sessionstatus.h"
 #include "torrentinfo.h"
-#include "trackerentry.h"
+#include "trackerentrystatus.h"
 
 class QString;
 class QThread;
@@ -69,16 +69,18 @@ class NativeSessionExtension;
 
 namespace BitTorrent
 {
+    enum class MoveStorageMode;
+    enum class MoveStorageContext;
+
     class InfoHash;
     class ResumeDataStorage;
     class Torrent;
     class TorrentDescriptor;
     class TorrentImpl;
     class Tracker;
-    struct LoadTorrentParams;
 
-    enum class MoveStorageMode;
-    enum class MoveStorageContext;
+    struct LoadTorrentParams;
+    struct TrackerEntry;
 
     struct SessionMetricIndices
     {
@@ -587,7 +589,7 @@ namespace BitTorrent
         void saveStatistics() const;
         void loadStatistics();
 
-        void updateTrackerEntries(lt::torrent_handle torrentHandle, QHash<std::string, QHash<lt::tcp::endpoint, QMap<int, int>>> updatedTrackers);
+        void updateTrackerEntryStatuses(lt::torrent_handle torrentHandle, QHash<std::string, QHash<lt::tcp::endpoint, QMap<int, int>>> updatedTrackers);
 
         // BitTorrent
         lt::session *m_nativeSession = nullptr;
@@ -766,7 +768,7 @@ namespace BitTorrent
 
         // This field holds amounts of peers reported by trackers in their responses to announces
         // (torrent.tracker_name.tracker_local_endpoint.protocol_version.num_peers)
-        QHash<lt::torrent_handle, QHash<std::string, QHash<lt::tcp::endpoint, QMap<int, int>>>> m_updatedTrackerEntries;
+        QHash<lt::torrent_handle, QHash<std::string, QHash<lt::tcp::endpoint, QMap<int, int>>>> m_updatedTrackerStatuses;
 
         // I/O errored torrents
         QSet<TorrentID> m_recentErroredTorrents;

--- a/src/base/bittorrent/torrent.h
+++ b/src/base/bittorrent/torrent.h
@@ -48,14 +48,17 @@ class QUrl;
 namespace BitTorrent
 {
     enum class DownloadPriority;
+
     class InfoHash;
     class PeerInfo;
     class Session;
     class TorrentID;
     class TorrentInfo;
+
     struct PeerAddress;
     struct SSLParameters;
     struct TrackerEntry;
+    struct TrackerEntryStatus;
 
     // Using `Q_ENUM_NS()` without a wrapper namespace in our case is not advised
     // since `Q_NAMESPACE` cannot be used when the same namespace resides at different files.
@@ -245,7 +248,7 @@ namespace BitTorrent
         virtual bool hasMissingFiles() const = 0;
         virtual bool hasError() const = 0;
         virtual int queuePosition() const = 0;
-        virtual QVector<TrackerEntry> trackers() const = 0;
+        virtual QVector<TrackerEntryStatus> trackers() const = 0;
         virtual QVector<QUrl> urlSeeds() const = 0;
         virtual QString error() const = 0;
         virtual qlonglong totalDownload() const = 0;

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -55,7 +55,7 @@
 #include "torrent.h"
 #include "torrentcontentlayout.h"
 #include "torrentinfo.h"
-#include "trackerentry.h"
+#include "trackerentrystatus.h"
 
 namespace BitTorrent
 {
@@ -175,7 +175,7 @@ namespace BitTorrent
         bool hasMissingFiles() const override;
         bool hasError() const override;
         int queuePosition() const override;
-        QVector<TrackerEntry> trackers() const override;
+        QVector<TrackerEntryStatus> trackers() const override;
         QVector<QUrl> urlSeeds() const override;
         QString error() const override;
         qlonglong totalDownload() const override;
@@ -275,8 +275,8 @@ namespace BitTorrent
         void deferredRequestResumeData();
         void handleMoveStorageJobFinished(const Path &path, MoveStorageContext context, bool hasOutstandingJob);
         void fileSearchFinished(const Path &savePath, const PathList &fileNames);
-        TrackerEntry updateTrackerEntry(const lt::announce_entry &announceEntry, const QHash<lt::tcp::endpoint, QMap<int, int>> &updateInfo);
-        void resetTrackerEntries();
+        TrackerEntryStatus updateTrackerEntryStatus(const lt::announce_entry &announceEntry, const QHash<lt::tcp::endpoint, QMap<int, int>> &updateInfo);
+        void resetTrackerEntryStatuses();
 
     private:
         using EventTrigger = std::function<void ()>;
@@ -349,7 +349,7 @@ namespace BitTorrent
 
         MaintenanceJob m_maintenanceJob = MaintenanceJob::None;
 
-        QVector<TrackerEntry> m_trackerEntries;
+        QVector<TrackerEntryStatus> m_trackerEntryStatuses;
         QVector<QUrl> m_urlSeeds;
         FileErrorInfo m_lastFileError;
 

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -279,7 +279,7 @@ QVector<TrackerEntry> TorrentInfo::trackers() const
     QVector<TrackerEntry> ret;
     ret.reserve(static_cast<decltype(ret)::size_type>(trackers.size()));
     for (const lt::announce_entry &tracker : trackers)
-        ret.append({QString::fromStdString(tracker.url), tracker.tier});
+        ret.append({.url = QString::fromStdString(tracker.url), .tier = tracker.tier});
 
     return ret;
 }

--- a/src/base/bittorrent/trackerentry.h
+++ b/src/base/bittorrent/trackerentry.h
@@ -1,5 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2024  Mike Tzou (Chocobo1)
  * Copyright (C) 2015-2023  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
@@ -29,56 +30,16 @@
 #pragma once
 
 #include <QtContainerFwd>
-#include <QDateTime>
-#include <QHash>
 #include <QString>
-#include <QStringView>
+
+class QStringView;
 
 namespace BitTorrent
 {
-    enum class TrackerEntryStatus
-    {
-        NotContacted = 1,
-        Working = 2,
-        Updating = 3,
-        NotWorking = 4,
-        TrackerError = 5,
-        Unreachable = 6
-    };
-    struct TrackerEndpointEntry
-    {
-        QString name {};
-        int btVersion = 1;
-
-        TrackerEntryStatus status = TrackerEntryStatus::NotContacted;
-        QString message {};
-
-        int numPeers = -1;
-        int numSeeds = -1;
-        int numLeeches = -1;
-        int numDownloaded = -1;
-
-        QDateTime nextAnnounceTime {};
-        QDateTime minAnnounceTime {};
-    };
-
     struct TrackerEntry
     {
         QString url {};
         int tier = 0;
-
-        TrackerEntryStatus status = TrackerEntryStatus::NotContacted;
-        QString message {};
-
-        int numPeers = -1;
-        int numSeeds = -1;
-        int numLeeches = -1;
-        int numDownloaded = -1;
-
-        QDateTime nextAnnounceTime {};
-        QDateTime minAnnounceTime {};
-
-        QHash<std::pair<QString, int>, TrackerEndpointEntry> endpointEntries {};
     };
 
     QList<TrackerEntry> parseTrackerEntries(QStringView str);

--- a/src/base/bittorrent/trackerentrystatus.cpp
+++ b/src/base/bittorrent/trackerentrystatus.cpp
@@ -1,6 +1,5 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2024  Mike Tzou (Chocobo1)
  * Copyright (C) 2015-2023  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
@@ -27,43 +26,29 @@
  * exception statement from your version.
  */
 
-#include "trackerentry.h"
+#include "trackerentrystatus.h"
 
-#include <QHash>
-#include <QList>
-#include <QStringView>
-
-QList<BitTorrent::TrackerEntry> BitTorrent::parseTrackerEntries(const QStringView str)
+void BitTorrent::TrackerEntryStatus::clear()
 {
-    const QList<QStringView> trackers = str.split(u'\n');  // keep the empty parts to track tracker tier
-
-    QList<BitTorrent::TrackerEntry> entries;
-    entries.reserve(trackers.size());
-
-    int trackerTier = 0;
-    for (QStringView tracker : trackers)
-    {
-        tracker = tracker.trimmed();
-
-        if (tracker.isEmpty())
-        {
-            if (trackerTier < std::numeric_limits<decltype(trackerTier)>::max())  // prevent overflow
-                ++trackerTier;
-            continue;
-        }
-
-        entries.append({tracker.toString(), trackerTier});
-    }
-
-    return entries;
+    url.clear();
+    tier = 0;
+    state = TrackerEndpointState::NotContacted;
+    message.clear();
+    numPeers = -1;
+    numSeeds = -1;
+    numLeeches = -1;
+    numDownloaded = -1;
+    nextAnnounceTime = {};
+    minAnnounceTime = {};
+    endpoints.clear();
 }
 
-bool BitTorrent::operator==(const TrackerEntry &left, const TrackerEntry &right)
+bool BitTorrent::operator==(const TrackerEntryStatus &left, const TrackerEntryStatus &right)
 {
     return (left.url == right.url);
 }
 
-std::size_t BitTorrent::qHash(const TrackerEntry &key, const std::size_t seed)
+std::size_t BitTorrent::qHash(const TrackerEntryStatus &key, const std::size_t seed)
 {
     return ::qHash(key.url, seed);
 }

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1395,7 +1395,7 @@ void MainWindow::showFiltersSidebar(const bool show)
         connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackersAdded, m_transferListFiltersWidget, &TransferListFiltersWidget::addTrackers);
         connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackersRemoved, m_transferListFiltersWidget, &TransferListFiltersWidget::removeTrackers);
         connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackersChanged, m_transferListFiltersWidget, &TransferListFiltersWidget::refreshTrackers);
-        connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackerEntriesUpdated, m_transferListFiltersWidget, &TransferListFiltersWidget::trackerEntriesUpdated);
+        connect(BitTorrent::Session::instance(), &BitTorrent::Session::trackerEntryStatusesUpdated, m_transferListFiltersWidget, &TransferListFiltersWidget::trackerEntryStatusesUpdated);
 
         m_splitter->insertWidget(0, m_transferListFiltersWidget);
         m_splitter->setCollapsible(0, true);

--- a/src/gui/trackerlist/trackerlistmodel.h
+++ b/src/gui/trackerlist/trackerlistmodel.h
@@ -35,7 +35,7 @@
 #include <QAbstractItemModel>
 #include <QDateTime>
 
-#include "base/bittorrent/trackerentry.h"
+#include "base/bittorrent/trackerentrystatus.h"
 
 class QTimer;
 
@@ -43,6 +43,7 @@ namespace BitTorrent
 {
     class Session;
     class Torrent;
+    struct TrackerEntry;
 }
 
 class TrackerListModel final : public QAbstractItemModel
@@ -99,14 +100,14 @@ private:
     struct Item;
 
     void populate();
-    std::shared_ptr<Item> createTrackerItem(const BitTorrent::TrackerEntry &trackerEntry);
-    void addTrackerItem(const BitTorrent::TrackerEntry &trackerEntry);
-    void updateTrackerItem(const std::shared_ptr<Item> &item, const BitTorrent::TrackerEntry &trackerEntry);
+    std::shared_ptr<Item> createTrackerItem(const BitTorrent::TrackerEntryStatus &trackerEntryStatus);
+    void addTrackerItem(const BitTorrent::TrackerEntryStatus &trackerEntryStatus);
+    void updateTrackerItem(const std::shared_ptr<Item> &item, const BitTorrent::TrackerEntryStatus &trackerEntryStatus);
     void refreshAnnounceTimes();
     void onTrackersAdded(const QList<BitTorrent::TrackerEntry> &newTrackers);
     void onTrackersRemoved(const QStringList &deletedTrackers);
     void onTrackersChanged();
-    void onTrackersUpdated(const QHash<QString, BitTorrent::TrackerEntry> &updatedTrackers);
+    void onTrackersUpdated(const QHash<QString, BitTorrent::TrackerEntryStatus> &updatedTrackers);
 
     BitTorrent::Session *m_btSession = nullptr;
     BitTorrent::Torrent *m_torrent = nullptr;

--- a/src/gui/transferlistfilters/trackersfilterwidget.h
+++ b/src/gui/transferlistfilters/trackersfilterwidget.h
@@ -32,11 +32,16 @@
 #include <QtContainerFwd>
 #include <QHash>
 
-#include "base/bittorrent/trackerentry.h"
 #include "base/path.h"
 #include "basefilterwidget.h"
 
 class TransferListWidget;
+
+namespace BitTorrent
+{
+    struct TrackerEntry;
+    struct TrackerEntryStatus;
+}
 
 namespace Net
 {
@@ -55,8 +60,8 @@ public:
     void addTrackers(const BitTorrent::Torrent *torrent, const QVector<BitTorrent::TrackerEntry> &trackers);
     void removeTrackers(const BitTorrent::Torrent *torrent, const QStringList &trackers);
     void refreshTrackers(const BitTorrent::Torrent *torrent);
-    void handleTrackerEntriesUpdated(const BitTorrent::Torrent *torrent
-            , const QHash<QString, BitTorrent::TrackerEntry> &updatedTrackerEntries);
+    void handleTrackerStatusesUpdated(const BitTorrent::Torrent *torrent
+            , const QHash<QString, BitTorrent::TrackerEntryStatus> &updatedTrackers);
     void setDownloadTrackerFavicon(bool value);
 
 private slots:

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -42,6 +42,7 @@
 #include "base/algorithm.h"
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/torrent.h"
+#include "base/bittorrent/trackerentrystatus.h"
 #include "base/global.h"
 #include "base/logger.h"
 #include "base/net/downloadmanager.h"
@@ -191,10 +192,10 @@ void TransferListFiltersWidget::refreshTrackers(const BitTorrent::Torrent *torre
     m_trackersFilterWidget->refreshTrackers(torrent);
 }
 
-void TransferListFiltersWidget::trackerEntriesUpdated(const BitTorrent::Torrent *torrent
-        , const QHash<QString, BitTorrent::TrackerEntry> &updatedTrackerEntries)
+void TransferListFiltersWidget::trackerEntryStatusesUpdated(const BitTorrent::Torrent *torrent
+        , const QHash<QString, BitTorrent::TrackerEntryStatus> &updatedTrackers)
 {
-    m_trackersFilterWidget->handleTrackerEntriesUpdated(torrent, updatedTrackerEntries);
+    m_trackersFilterWidget->handleTrackerStatusesUpdated(torrent, updatedTrackers);
 }
 
 void TransferListFiltersWidget::onCategoryFilterStateChanged(bool enabled)

--- a/src/gui/transferlistfilterswidget.h
+++ b/src/gui/transferlistfilterswidget.h
@@ -30,10 +30,8 @@
 #pragma once
 
 #include <QtContainerFwd>
-#include <QHash>
 #include <QWidget>
 
-#include "base/bittorrent/torrent.h"
 #include "base/bittorrent/trackerentry.h"
 
 class CategoryFilterWidget;
@@ -41,6 +39,12 @@ class StatusFilterWidget;
 class TagFilterWidget;
 class TrackersFilterWidget;
 class TransferListWidget;
+
+namespace BitTorrent
+{
+    class Torrent;
+    struct TrackerEntryStatus;
+}
 
 class TransferListFiltersWidget final : public QWidget
 {
@@ -55,8 +59,8 @@ public slots:
     void addTrackers(const BitTorrent::Torrent *torrent, const QVector<BitTorrent::TrackerEntry> &trackers);
     void removeTrackers(const BitTorrent::Torrent *torrent, const QStringList &trackers);
     void refreshTrackers(const BitTorrent::Torrent *torrent);
-    void trackerEntriesUpdated(const BitTorrent::Torrent *torrent
-            , const QHash<QString, BitTorrent::TrackerEntry> &updatedTrackerEntries);
+    void trackerEntryStatusesUpdated(const BitTorrent::Torrent *torrent
+            , const QHash<QString, BitTorrent::TrackerEntryStatus> &updatedTrackers);
 
 private slots:
     void onCategoryFilterStateChanged(bool enabled);

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -45,7 +45,7 @@
 
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/torrent.h"
-#include "base/bittorrent/trackerentry.h"
+#include "base/bittorrent/trackerentrystatus.h"
 #include "base/global.h"
 #include "base/logger.h"
 #include "base/path.h"
@@ -783,14 +783,14 @@ void TransferListWidget::editTorrentTrackers()
 
     if (!torrents.empty())
     {
-        commonTrackers = torrents[0]->trackers();
+        for (const BitTorrent::TrackerEntryStatus &status : asConst(torrents[0]->trackers()))
+            commonTrackers.append({.url = status.url, .tier = status.tier});
 
         for (const BitTorrent::Torrent *torrent : torrents)
         {
             QSet<BitTorrent::TrackerEntry> trackerSet;
-
-            for (const BitTorrent::TrackerEntry &entry : asConst(torrent->trackers()))
-                trackerSet.insert(entry);
+            for (const BitTorrent::TrackerEntryStatus &status : asConst(torrent->trackers()))
+                trackerSet.insert({.url = status.url, .tier = status.tier});
 
             commonTrackers.erase(std::remove_if(commonTrackers.begin(), commonTrackers.end()
                 , [&trackerSet](const BitTorrent::TrackerEntry &entry) { return !trackerSet.contains(entry); })

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -33,7 +33,7 @@
 
 #include "base/bittorrent/infohash.h"
 #include "base/bittorrent/torrent.h"
-#include "base/bittorrent/trackerentry.h"
+#include "base/bittorrent/trackerentrystatus.h"
 #include "base/path.h"
 #include "base/tagset.h"
 #include "base/utils/datetime.h"

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -49,6 +49,7 @@
 #include "base/bittorrent/torrent.h"
 #include "base/bittorrent/torrentdescriptor.h"
 #include "base/bittorrent/trackerentry.h"
+#include "base/bittorrent/trackerentrystatus.h"
 #include "base/interfaces/iapplication.h"
 #include "base/global.h"
 #include "base/logger.h"
@@ -194,7 +195,7 @@ namespace
             }
         }
 
-        const int working = static_cast<int>(BitTorrent::TrackerEntryStatus::Working);
+        const int working = static_cast<int>(BitTorrent::TrackerEndpointState::Working);
         const int disabled = 0;
 
         const QString privateMsg {QCoreApplication::translate("TrackerListWidget", "This torrent is private")};
@@ -500,16 +501,16 @@ void TorrentsController::trackersAction()
 
     QJsonArray trackerList = getStickyTrackers(torrent);
 
-    for (const BitTorrent::TrackerEntry &tracker : asConst(torrent->trackers()))
+    for (const BitTorrent::TrackerEntryStatus &tracker : asConst(torrent->trackers()))
     {
-        const bool isNotWorking = (tracker.status == BitTorrent::TrackerEntryStatus::NotWorking)
-                || (tracker.status == BitTorrent::TrackerEntryStatus::TrackerError)
-                || (tracker.status == BitTorrent::TrackerEntryStatus::Unreachable);
+        const bool isNotWorking = (tracker.state == BitTorrent::TrackerEndpointState::NotWorking)
+                || (tracker.state == BitTorrent::TrackerEndpointState::TrackerError)
+                || (tracker.state == BitTorrent::TrackerEndpointState::Unreachable);
         trackerList << QJsonObject
         {
             {KEY_TRACKER_URL, tracker.url},
             {KEY_TRACKER_TIER, tracker.tier},
-            {KEY_TRACKER_STATUS, static_cast<int>((isNotWorking ? BitTorrent::TrackerEntryStatus::NotWorking : tracker.status))},
+            {KEY_TRACKER_STATUS, static_cast<int>((isNotWorking ? BitTorrent::TrackerEndpointState::NotWorking : tracker.state))},
             {KEY_TRACKER_MSG, tracker.message},
             {KEY_TRACKER_PEERS_COUNT, tracker.numPeers},
             {KEY_TRACKER_SEEDS_COUNT, tracker.numSeeds},
@@ -800,7 +801,7 @@ void TorrentsController::addTrackersAction()
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 
-    const QVector<BitTorrent::TrackerEntry> entries = BitTorrent::parseTrackerEntries(params()[u"urls"_s]);
+    const QList<BitTorrent::TrackerEntry> entries = BitTorrent::parseTrackerEntries(params()[u"urls"_s]);
     torrent->addTrackers(entries);
 }
 
@@ -823,23 +824,35 @@ void TorrentsController::editTrackerAction()
     if (!newTrackerUrl.isValid())
         throw APIError(APIErrorType::BadParams, u"New tracker URL is invalid"_s);
 
-    QVector<BitTorrent::TrackerEntry> trackers = torrent->trackers();
+    const QList<BitTorrent::TrackerEntryStatus> currentTrackers = torrent->trackers();
+    QList<BitTorrent::TrackerEntry> entries;
+    entries.reserve(currentTrackers.size());
+
     bool match = false;
-    for (BitTorrent::TrackerEntry &tracker : trackers)
+    for (const BitTorrent::TrackerEntryStatus &tracker : currentTrackers)
     {
         const QUrl trackerUrl {tracker.url};
+
         if (trackerUrl == newTrackerUrl)
             throw APIError(APIErrorType::Conflict, u"New tracker URL already exists"_s);
+
+        BitTorrent::TrackerEntry entry
+        {
+            .url = tracker.url,
+            .tier = tracker.tier
+        };
+
         if (trackerUrl == origTrackerUrl)
         {
             match = true;
-            tracker.url = newTrackerUrl.toString();
+            entry.url = newTrackerUrl.toString();
         }
+        entries.append(entry);
     }
     if (!match)
         throw APIError(APIErrorType::Conflict, u"Tracker not found"_s);
 
-    torrent->replaceTrackers(trackers);
+    torrent->replaceTrackers(entries);
 
     if (!torrent->isPaused())
         torrent->forceReannounce();


### PR DESCRIPTION
The main motivation is that, in a future PR I would like to create a simple struct to pass/parse information from the GUI (without all the additional unused fields as it is now currently):
```c++
struct TrackerEntry
{
    QString url {};
    int tier = 0;
};  
```
The current `TrackerEntry` has a lot of fields and IMO it is more like providing some info instead of a simple 'entry'.