### PR TITLE
Update gitignore for vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode/
 src/gui/geoip/GeoIP.dat
 src/gui/geoip/GeoIP.dat.gz
 src/qbittorrent


### PR DESCRIPTION
Continuation of PR #20492, which was closed because I accidentally deleted the branch.

I have been using vscode for development for the past months. It saves its configuration (per project) in a `.vscode` subfolder in the root of the project. Currently my settings hold the necessary configuration environment for cmake to find my custom built packages.
It doesn't make much sense to share those.

I put it in the ignore list so I can finally have a clean `git status`.