### PR TITLE
Make it possible to translate derivative alt web UIs

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -935,6 +935,19 @@ void Preferences::setAltWebUIEnabled(const bool enabled)
     setValue(u"Preferences/WebUI/AlternativeUIEnabled"_s, enabled);
 }
 
+bool Preferences::isAltWebUIDerivative() const
+{
+    return value(u"Preferences/WebUI/AlternativeUIDerivativeFork"_s, false);
+}
+
+void Preferences::setAltWebUIDerivativeStatus(const bool derivative)
+{
+    if (derivative == isAltWebUIDerivative())
+        return;
+
+    setValue(u"Preferences/WebUI/AlternativeUIDerivativeFork"_s, derivative);
+}
+
 Path Preferences::getWebUIRootFolder() const
 {
     return value<Path>(u"Preferences/WebUI/RootFolder"_s);

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -219,6 +219,8 @@ public:
     void setWebUIHttpsKeyPath(const Path &path);
     bool isAltWebUIEnabled() const;
     void setAltWebUIEnabled(bool enabled);
+    bool isAltWebUIDerivative() const;
+    void setAltWebUIDerivativeStatus(bool derivative);
     Path getWebUIRootFolder() const;
     void setWebUIRootFolder(const Path &path);
 

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -1266,6 +1266,7 @@ void OptionsDialog::loadWebUITabOptions()
     m_ui->spinSessionTimeout->setValue(pref->getWebUISessionTimeout());
     // Alternative UI
     m_ui->groupAltWebUI->setChecked(pref->isAltWebUIEnabled());
+    m_ui->checkAltWebUIDerivative->setChecked(pref->isAltWebUIDerivative());
     m_ui->textWebUIRootFolder->setSelectedPath(pref->getWebUIRootFolder());
     // Security
     m_ui->checkClickjacking->setChecked(pref->isWebUIClickjackingProtectionEnabled());
@@ -1309,6 +1310,7 @@ void OptionsDialog::loadWebUITabOptions()
 
     connect(m_ui->groupAltWebUI, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->textWebUIRootFolder, &FileSystemPathLineEdit::selectedPathChanged, this, &ThisType::enableApplyButton);
+    connect(m_ui->checkAltWebUIDerivative, &QCheckBox::toggled, this, &ThisType::enableApplyButton);
 
     connect(m_ui->checkClickjacking, &QCheckBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkCSRFProtection, &QCheckBox::toggled, this, &ThisType::enableApplyButton);
@@ -1355,6 +1357,7 @@ void OptionsDialog::saveWebUITabOptions() const
     pref->setWebUIAuthSubnetWhitelistEnabled(m_ui->checkBypassAuthSubnetWhitelist->isChecked());
     // Alternative UI
     pref->setAltWebUIEnabled(m_ui->groupAltWebUI->isChecked());
+    pref->setAltWebUIDerivativeStatus(m_ui->checkAltWebUIDerivative->isChecked());
     pref->setWebUIRootFolder(m_ui->textWebUIRootFolder->selectedPath());
     // Security
     pref->setWebUIClickjackingProtectionEnabled(m_ui->checkClickjacking->isChecked());

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -122,8 +122,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>504</width>
-             <height>1064</height>
+             <width>526</width>
+             <height>1342</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -835,8 +835,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>539</width>
-             <height>1457</height>
+             <width>601</width>
+             <height>1833</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout">
@@ -1658,8 +1658,8 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>504</width>
-             <height>848</height>
+             <width>420</width>
+             <height>1028</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -2234,8 +2234,8 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>302</width>
-             <height>408</height>
+             <width>326</width>
+             <height>494</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -2571,8 +2571,8 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>413</width>
-             <height>693</height>
+             <width>511</width>
+             <height>895</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -3114,8 +3114,8 @@ Disable encryption: Only connect to peers without protocol encryption</string>
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>336</width>
-             <height>391</height>
+             <width>398</width>
+             <height>495</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_27">
@@ -3303,9 +3303,9 @@ Disable encryption: Only connect to peers without protocol encryption</string>
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>0</y>
-             <width>382</width>
-             <height>1045</height>
+             <y>-349</y>
+             <width>526</width>
+             <height>1323</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -3606,16 +3606,30 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                  <property name="checked">
                   <bool>false</bool>
                  </property>
-                 <layout class="QHBoxLayout" name="horizontalLayout_5">
+                 <layout class="QVBoxLayout" name="verticalLayout_altWebUI">
                   <item>
-                   <widget class="QLabel" name="labelWebUIRootFolder">
-                    <property name="text">
-                     <string>Files location:</string>
-                    </property>
-                   </widget>
+                   <layout class="QHBoxLayout" name="horizontalLayout_altWebUI_RootFolder">
+                    <item>
+                     <widget class="QLabel" name="labelWebUIRootFolder">
+                      <property name="text">
+                       <string>Files location:</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="FileSystemPathLineEdit" name="textWebUIRootFolder" native="true"/>
+                    </item>
+                   </layout>
                   </item>
                   <item>
-                   <widget class="FileSystemPathLineEdit" name="textWebUIRootFolder" native="true"/>
+                   <widget class="QCheckBox" name="checkAltWebUIDerivative">
+                    <property name="toolTip">
+                     <string>Enables built-in translations and HTTPS security options. Indicates that the alternative Web UI is a derivative work of the original Web UI.</string>
+                    </property>
+                    <property name="text">
+                     <string>Derived from original qBittorrent Web UI code base</string>
+                    </property>
+                   </widget>
                   </item>
                  </layout>
                 </widget>

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -316,6 +316,7 @@ void AppController::preferencesAction()
     // Use alternative WebUI
     data[u"alternative_webui_enabled"_s] = pref->isAltWebUIEnabled();
     data[u"alternative_webui_path"_s] = pref->getWebUIRootFolder().toString();
+    data[u"alternative_webui_derivative"_s] = pref->isAltWebUIDerivative();
     // Security
     data[u"web_ui_clickjacking_protection_enabled"_s] = pref->isWebUIClickjackingProtectionEnabled();
     data[u"web_ui_csrf_protection_enabled"_s] = pref->isWebUICSRFProtectionEnabled();

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -217,6 +217,7 @@ private:
         {{u"transfer"_s, u"toggleSpeedLimitsMode"_s}, Http::METHOD_POST},
     };
     bool m_isAltUIUsed = false;
+    bool m_isAltUIDerivative = false;
     Path m_rootFolder;
 
     struct TranslatedFile

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -879,6 +879,10 @@
                 <label for="webui_files_location_textarea">QBT_TR(Files location:)QBT_TR[CONTEXT=OptionsDialog]</label>
                 <input type="text" id="webui_files_location_textarea" />
             </div>
+            <div class="formRow">
+                <input type="checkbox" id="webui_derivative_checkbox" />
+                <label for="webui_derivative_checkbox">QBT_TR(Derived from original qBittorrent Web UI code base)QBT_TR[CONTEXT=OptionsDialog]</label>
+            </div>
         </fieldset>
 
         <fieldset class="settings">
@@ -1849,6 +1853,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
         const updateAlternativeWebUISettings = function() {
             const isUseAlternativeWebUIEnabled = $('use_alt_webui_checkbox').getProperty('checked');
             $('webui_files_location_textarea').setProperty('disabled', !isUseAlternativeWebUIEnabled);
+            $('webui_derivative_checkbox').setProperty('disabled', !isUseAlternativeWebUIEnabled);
         };
 
         const updateHostHeaderValidationSettings = function() {
@@ -2273,6 +2278,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     // Use alternative WebUI
                     $('use_alt_webui_checkbox').setProperty('checked', pref.alternative_webui_enabled);
                     $('webui_files_location_textarea').setProperty('value', pref.alternative_webui_path);
+                    $('webui_derivative_checkbox').setProperty('checked', pref.alternative_webui_derivative);
                     updateAlternativeWebUISettings();
 
                     // Security
@@ -2724,6 +2730,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             }
             settings['alternative_webui_enabled'] = alternative_webui_enabled;
             settings['alternative_webui_path'] = webui_files_location_textarea;
+            settings['alternative_webui_derivative'] = $('webui_derivative_checkbox').getProperty('checked');
 
             // Security
             settings['web_ui_clickjacking_protection_enabled'] = $('clickjacking_protection_checkbox').getProperty('checked');


### PR DESCRIPTION
Make it possible to translate and add same HTTP headers and CSP for alternative web UIs derived from original qBittorrent Web UI code base. For example see my project qbt-honeywell, which is basically just a styled version of the original Web UI.

Related: #19631