### PR TITLE
Fix invisible tray icon on Plasma 6 in Linux

### DIFF
--- a/src/gui/desktopintegration.cpp
+++ b/src/gui/desktopintegration.cpp
@@ -283,17 +283,25 @@ void DesktopIntegration::createTrayIcon()
 QIcon DesktopIntegration::getSystrayIcon() const
 {
     const TrayIcon::Style style = Preferences::instance()->trayIconStyle();
+    QIcon icon;
     switch (style)
     {
     default:
     case TrayIcon::Style::Normal:
-        return UIThemeManager::instance()->getIcon(u"qbittorrent-tray"_s);
-
+        icon = UIThemeManager::instance()->getIcon(u"qbittorrent-tray"_s);
+        break;
     case TrayIcon::Style::MonoDark:
-        return UIThemeManager::instance()->getIcon(u"qbittorrent-tray-dark"_s);
-
+        icon = UIThemeManager::instance()->getIcon(u"qbittorrent-tray-dark"_s);
+        break;
     case TrayIcon::Style::MonoLight:
-        return UIThemeManager::instance()->getIcon(u"qbittorrent-tray-light"_s);
+        icon = UIThemeManager::instance()->getIcon(u"qbittorrent-tray-light"_s);
+        break;
     }
+#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
+    // Workaround for invisible tray icon in KDE, https://bugreports.qt.io/browse/QTBUG-53550
+    return {icon.pixmap(32)};
+#else
+    return icon;
+#endif
 }
 #endif // Q_OS_MACOS

--- a/src/gui/desktopintegration.cpp
+++ b/src/gui/desktopintegration.cpp
@@ -31,6 +31,7 @@
 
 #include <chrono>
 
+#include <QtEnvironmentVariables>
 #include <QMenu>
 #include <QTimer>
 
@@ -297,11 +298,11 @@ QIcon DesktopIntegration::getSystrayIcon() const
         icon = UIThemeManager::instance()->getIcon(u"qbittorrent-tray-light"_s);
         break;
     }
-#if (defined(Q_OS_UNIX) && !defined(Q_OS_MACOS))
+#ifdef Q_OS_UNIX
     // Workaround for invisible tray icon in KDE, https://bugreports.qt.io/browse/QTBUG-53550
-    return {icon.pixmap(32)};
-#else
-    return icon;
+    if (qEnvironmentVariable(u"XDG_CURRENT_DESKTOP").compare(u"KDE", Qt::CaseInsensitive) == 0)
+        return icon.pixmap(32);
 #endif
+    return icon;
 }
 #endif // Q_OS_MACOS

--- a/src/gui/desktopintegration.cpp
+++ b/src/gui/desktopintegration.cpp
@@ -300,7 +300,7 @@ QIcon DesktopIntegration::getSystrayIcon() const
     }
 #ifdef Q_OS_UNIX
     // Workaround for invisible tray icon in KDE, https://bugreports.qt.io/browse/QTBUG-53550
-    if (qEnvironmentVariable(u"XDG_CURRENT_DESKTOP").compare(u"KDE", Qt::CaseInsensitive) == 0)
+    if (qEnvironmentVariable("XDG_CURRENT_DESKTOP").compare(u"KDE", Qt::CaseInsensitive) == 0)
         return icon.pixmap(32);
 #endif
     return icon;


### PR DESCRIPTION
Closes #20367.

Adapted from #19814, removed Qt version check.
