### PR TITLE
Initialize completer for file system path widget on demand

### DIFF
--- a/src/gui/fspathedit_p.cpp
+++ b/src/gui/fspathedit_p.cpp
@@ -1,7 +1,8 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2022 Mike Tzou (Chocobo1)
- * Copyright (C) 2016 Eugene Shalygin
+ * Copyright (C) 2024  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2022  Mike Tzou (Chocobo1)
+ * Copyright (C) 2016  Eugene Shalygin
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -32,6 +33,7 @@
 #include <QCompleter>
 #include <QContextMenuEvent>
 #include <QDir>
+#include <QFileIconProvider>
 #include <QFileInfo>
 #include <QFileSystemModel>
 #include <QMenu>
@@ -159,36 +161,33 @@ QValidator::State Private::FileSystemPathValidator::validate(QString &input, [[m
 }
 
 Private::FileLineEdit::FileLineEdit(QWidget *parent)
-    : QLineEdit {parent}
-    , m_completerModel {new QFileSystemModel(this)}
-    , m_completer {new QCompleter(this)}
+    : QLineEdit(parent)
 {
-    m_iconProvider.setOptions(QFileIconProvider::DontUseCustomDirectoryIcons);
-
-    m_completerModel->setIconProvider(&m_iconProvider);
-    m_completerModel->setOptions(QFileSystemModel::DontWatchForChanges);
-
-    m_completer->setModel(m_completerModel);
-    setCompleter(m_completer);
-
     connect(this, &QLineEdit::textChanged, this, &FileLineEdit::validateText);
 }
 
 Private::FileLineEdit::~FileLineEdit()
 {
     delete m_completerModel; // has to be deleted before deleting the m_iconProvider object
+    delete m_iconProvider;
 }
 
 void Private::FileLineEdit::completeDirectoriesOnly(const bool completeDirsOnly)
 {
-    const QDir::Filters filters = QDir::NoDotAndDotDot
-        | (completeDirsOnly ? QDir::Dirs : QDir::AllEntries);
-    m_completerModel->setFilter(filters);
+    m_completeDirectoriesOnly = completeDirsOnly;
+    if (m_completerModel)
+    {
+        const QDir::Filters filters = QDir::NoDotAndDotDot
+                | (completeDirsOnly ? QDir::Dirs : QDir::AllEntries);
+        m_completerModel->setFilter(filters);
+    }
 }
 
 void Private::FileLineEdit::setFilenameFilters(const QStringList &filters)
 {
-    m_completerModel->setNameFilters(filters);
+    m_filenameFilters = filters;
+    if (m_completerModel)
+        m_completerModel->setNameFilters(m_filenameFilters);
 }
 
 void Private::FileLineEdit::setBrowseAction(QAction *action)
@@ -222,6 +221,24 @@ void Private::FileLineEdit::keyPressEvent(QKeyEvent *e)
 
     if ((e->key() == Qt::Key_Space) && (e->modifiers() == Qt::CTRL))
     {
+        if (!m_completer)
+        {
+            m_iconProvider = new QFileIconProvider;
+            m_iconProvider->setOptions(QFileIconProvider::DontUseCustomDirectoryIcons);
+
+            m_completerModel = new QFileSystemModel(this);
+            m_completerModel->setIconProvider(m_iconProvider);
+            m_completerModel->setOptions(QFileSystemModel::DontWatchForChanges);
+            m_completerModel->setNameFilters(m_filenameFilters);
+            const QDir::Filters filters = QDir::NoDotAndDotDot
+                    | (m_completeDirectoriesOnly ? QDir::Dirs : QDir::AllEntries);
+            m_completerModel->setFilter(filters);
+
+            m_completer = new QCompleter(this);
+            m_completer->setModel(m_completerModel);
+            setCompleter(m_completer);
+        }
+
         m_completerModel->setRootPath(Path(text()).data());
         showCompletionPopup();
     }

--- a/src/gui/fspathedit_p.h
+++ b/src/gui/fspathedit_p.h
@@ -1,6 +1,7 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2016 Eugene Shalygin
+ * Copyright (C) 2024  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2016  Eugene Shalygin
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -29,7 +30,6 @@
 #pragma once
 
 #include <QComboBox>
-#include <QFileIconProvider>
 #include <QLineEdit>
 #include <QtContainerFwd>
 #include <QValidator>
@@ -39,6 +39,7 @@
 class QAction;
 class QCompleter;
 class QContextMenuEvent;
+class QFileIconProvider;
 class QFileSystemModel;
 class QKeyEvent;
 
@@ -143,7 +144,9 @@ namespace Private
         QCompleter *m_completer = nullptr;
         QAction *m_browseAction = nullptr;
         QAction *m_warningAction = nullptr;
-        QFileIconProvider m_iconProvider;
+        QFileIconProvider *m_iconProvider = nullptr;
+        bool m_completeDirectoriesOnly = false;
+        QStringList m_filenameFilters;
     };
 
     class FileComboEdit final : public QComboBox, public IFileEditorWithCompletion


### PR DESCRIPTION
This should save some resources and prevent unnecessary access to the file system.
