### PR TITLE
WebUI: Conditionally show filters sidebar

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -1147,8 +1147,11 @@ window.addEventListener("DOMContentLoaded", function() {
     // main window tabs
 
     const showTransfersTab = function() {
-        $("filtersColumn").removeClass("invisible");
-        $("filtersColumn_handle").removeClass("invisible");
+        const showFiltersSidebar = LocalPreferences.get("show_filters_sidebar", "true") === "true";
+        if (showFiltersSidebar) {
+            $("filtersColumn").removeClass("invisible");
+            $("filtersColumn_handle").removeClass("invisible");
+        }
         $("mainColumn").removeClass("invisible");
         $('torrentsFilterToolbar').removeClass("invisible");
 


### PR DESCRIPTION
This fixes a bug where the filters sidebar would always be displayed when switching back to the Transfers tab. Closes #19257.
