### PR TITLE
WebUI: Improve accuracy of trackers list

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1431,8 +1431,17 @@ window.qBittorrent.DynamicTable = (function() {
                     break;
                 default: {
                     const tracker = trackerList.get(trackerHashInt);
-                    if (tracker && !tracker.torrents.includes(row['full_data'].rowId))
-                        return false;
+                    if (tracker) {
+                        let found = false;
+                        for (const torrents of tracker.trackerTorrentMap.values()) {
+                            if (torrents.includes(row['full_data'].rowId)) {
+                                found = true;
+                                break;
+                            }
+                        }
+                        if (!found)
+                            return false;
+                    }
                     break;
                 }
             }

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -874,9 +874,16 @@ const initializeWindows = function() {
             case TRACKERS_TRACKERLESS:
                 hashes = torrentsTable.getFilteredTorrentsHashes('all', CATEGORIES_ALL, TAGS_ALL, TRACKERS_TRACKERLESS);
                 break;
-            default:
-                hashes = trackerList.get(trackerHashInt).torrents;
+            default: {
+                const uniqueTorrents = new Set();
+                for (const torrents of trackerList.get(trackerHashInt).trackerTorrentMap.values()) {
+                    for (const torrent of torrents) {
+                        uniqueTorrents.add(torrent);
+                    }
+                }
+                hashes = [...uniqueTorrents];
                 break;
+            }
         }
 
         if (hashes.length > 0) {
@@ -901,9 +908,16 @@ const initializeWindows = function() {
             case TRACKERS_TRACKERLESS:
                 hashes = torrentsTable.getFilteredTorrentsHashes('all', CATEGORIES_ALL, TAGS_ALL, TRACKERS_TRACKERLESS);
                 break;
-            default:
-                hashes = trackerList.get(trackerHashInt).torrents;
+            default: {
+                const uniqueTorrents = new Set();
+                for (const torrents of trackerList.get(trackerHashInt).trackerTorrentMap.values()) {
+                    for (const torrent of torrents) {
+                        uniqueTorrents.add(torrent);
+                    }
+                }
+                hashes = [...uniqueTorrents];
                 break;
+            }
         }
 
         if (hashes.length) {
@@ -928,9 +942,16 @@ const initializeWindows = function() {
             case TRACKERS_TRACKERLESS:
                 hashes = torrentsTable.getFilteredTorrentsHashes('all', CATEGORIES_ALL, TAGS_ALL, TRACKERS_TRACKERLESS);
                 break;
-            default:
-                hashes = trackerList.get(trackerHashInt).torrents;
+            default: {
+                const uniqueTorrents = new Set();
+                for (const torrents of trackerList.get(trackerHashInt).trackerTorrentMap.values()) {
+                    for (const torrent of torrents) {
+                        uniqueTorrents.add(torrent);
+                    }
+                }
+                hashes = [...uniqueTorrents];
                 break;
+            }
         }
 
         if (hashes.length) {


### PR DESCRIPTION
This PR fixes various accounting issues with the trackers list. Removing a torrent would not update the trackers list, nor would removing a tracker from a torrent. And removing a tracker with a shared host but unique url (e.g. example.com/1 and example.com/2) would erroneously remove the tracker's host from the list, despite trackers with that host still remaining.

Closes #20054, closes #20053.
