### PR TITLE
Improve AppStream metadata

### DIFF
--- a/dist/unix/CMakeLists.txt
+++ b/dist/unix/CMakeLists.txt
@@ -38,7 +38,7 @@ if (GUI)
         COMPONENT data
     )
 
-    install(FILES org.qbittorrent.qBittorrent.appdata.xml
+    install(FILES org.qbittorrent.qBittorrent.metainfo.xml
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/metainfo/
         COMPONENT data
     )

--- a/dist/unix/org.qbittorrent.qBittorrent.metainfo.xml
+++ b/dist/unix/org.qbittorrent.qBittorrent.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2014 sledgehammer999 <sledgehammer999@qbittorrent.org> -->
-<component type="desktop">
+<component type="desktop-application">
   <id>org.qbittorrent.qBittorrent</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later and OpenSSL</project_license>
@@ -14,33 +14,12 @@
     </p>
     <ul>
       <li>Polished µTorrent-like User Interface</li>
-      <li>
-        Well-integrated and extensible Search Engine
-        <ul>
-          <li>Simultaneous search in many Torrent search sites</li>
-          <li>Category-specific search requests (e.g. Books, Music, Software)</li>
-        </ul>
-      </li>
+      <li>Well-integrated and extensible Search Engine</li>
       <li>RSS feed support with advanced download filters (incl. regex)</li>
-      <li>
-        Many Bittorrent extensions supported:
-        <ul>
-          <li>Magnet links</li>
-          <li>Distributed hash table (DHT), peer exchange protocol (PEX), local peer discovery (LSD)</li>
-          <li>Private torrents</li>
-          <li>Encrypted connections</li>
-          <li>and many more...</li>
-        </ul>
-      </li>
+      <li>Many Bittorrent extensions supported</li>
       <li>Remote control through Web user interface, written with AJAX</li>
       <li>Sequential downloading (Download in order)</li>
-      <li>
-        Advanced control over torrents, trackers and peers
-        <ul>
-          <li>Torrents queueing and prioritizing</li>
-          <li>Torrent content selection and prioritizing</li>
-        </ul>
-      </li>
+      <li>Advanced control over torrents, trackers and peers</li>
       <li>Bandwidth scheduler</li>
       <li>Torrent creation tool</li>
       <li>IP Filtering (eMule &amp; PeerGuardian format compatible)</li>
@@ -53,25 +32,34 @@
   <launchable type="desktop-id">org.qbittorrent.qBittorrent.desktop</launchable>
   <screenshots>
     <screenshot type="default">
+      <caption>Main window (General tab collapsed)</caption>
       <image height="675" width="1200">https://alexpl.fedorapeople.org/AppData/qbittorrent/screens/qbittorrent_01.png</image>
     </screenshot>
     <screenshot>
-      <image height="675" width="1200">https://alexpl.fedorapeople.org/AppData/qbittorrent/screens/qbittorrent_02.png</image>
-    </screenshot>
-    <screenshot>
+      <caption>Main window (General tab expanded)</caption>
       <image height="675" width="1200">https://alexpl.fedorapeople.org/AppData/qbittorrent/screens/qbittorrent_03.png</image>
     </screenshot>
     <screenshot>
+      <caption>Options dialog</caption>
       <image height="675" width="1200">https://alexpl.fedorapeople.org/AppData/qbittorrent/screens/qbittorrent_04.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Search engine</caption>
+      <image height="675" width="1200">https://alexpl.fedorapeople.org/AppData/qbittorrent/screens/qbittorrent_02.png</image>
     </screenshot>
   </screenshots>
   <update_contact>sledgehammer999@qbittorrent.org</update_contact>
-  <developer_name>The qBittorrent Project</developer_name>
+  <developer id="org.qbittorrent">
+    <name>The qBittorrent Project</name>
+  </developer>
   <url type="homepage">https://www.qbittorrent.org/</url>
   <url type="bugtracker">https://bugs.qbittorrent.org/</url>
-  <url type="donation">https://www.qbittorrent.org/donate</url>
+  <url type="faq">https://wiki.qbittorrent.org/Frequently-Asked-Questions</url>
   <url type="help">https://forum.qbittorrent.org/</url>
-  <url type="translate">https://github.com/qbittorrent/qBittorrent/wiki/How-to-translate-qBittorrent</url>
+  <url type="donation">https://www.qbittorrent.org/donate</url>
+  <url type="translate">https://wiki.qbittorrent.org/How-to-translate-qBittorrent</url>
+  <url type="vcs-browser">https://github.com/qbittorrent/qBittorrent</url>
+  <url type="contribute">https://github.com/qbittorrent/qBittorrent/blob/master/CONTRIBUTING.md</url>
   <content_rating type="oars-1.1"/>
   <releases>
     <release version="5.0.0~beta1" date="2024-03-19"/>


### PR DESCRIPTION
Releasing v4.6.4 on Flathub was failing due to invalid AppStream metadata and this PR will fix it.
https://github.com/flathub/org.qbittorrent.qBittorrent/pull/148

This PR should be backported to v4.6.