### PR TITLE
[WIP] Convert private WebUI strings to i18next

### DIFF
--- a/src/webui/www/private/addpeers.html
+++ b/src/webui/www/private/addpeers.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(Add Peers)QBT_TR[CONTEXT=PeersAdditionDialog]</title>
+    <title class="qbt-translatable" data-i18n="Add Peers">Add Peers</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
@@ -59,11 +59,11 @@
 
 <body>
     <div style="padding: 10px 10px 0px 10px;">
-        <p>QBT_TR(List of peers to add (one IP per line):)QBT_TR[CONTEXT=PeersAdditionDialog]</p>
+        <p class="qbt-translatable" data-i18n="List of peers to add (one IP per line):">List of peers to add (one IP per line):</p>
         <textarea id="peers" rows="10" style="width: 100%;" placeholder="QBT_TR(Format: IPv4:port / [IPv6]:port)QBT_TR[CONTEXT=PeersAdditionDialog]"></textarea>
         <div style="margin-top: 10px; text-align: center;">
-            <button type="button" onclick="parent.qBittorrent.Client.closeWindows();">QBT_TR(Cancel)QBT_TR[CONTEXT=PeersAdditionDialog]</button>
-            <button type="button" id="addPeersOk">QBT_TR(Ok)QBT_TR[CONTEXT=PeersAdditionDialog]</button>
+            <button type="button" onclick="parent.qBittorrent.Client.closeWindows();" class="qbt-translatable" data-i18n="Cancel">Cancel</button>
+            <button type="button" id="addPeersOk" class="qbt-translatable" data-i18n="Ok">Ok</button>
         </div>
     </div>
 </body>

--- a/src/webui/www/private/addpeers.html
+++ b/src/webui/www/private/addpeers.html
@@ -60,7 +60,7 @@
 <body>
     <div style="padding: 10px 10px 0px 10px;">
         <p class="qbt-translatable" data-i18n="List of peers to add (one IP per line):">List of peers to add (one IP per line):</p>
-        <textarea id="peers" rows="10" style="width: 100%;" placeholder="QBT_TR(Format: IPv4:port / [IPv6]:port)QBT_TR[CONTEXT=PeersAdditionDialog]"></textarea>
+        <textarea id="peers" rows="10" style="width: 100%;" class="qbt-translatable" data-i18n="[placeholder]Format: IPv4:port / [IPv6]:port" placeholder="Format: IPv4:port / [IPv6]:port"></textarea>
         <div style="margin-top: 10px; text-align: center;">
             <button type="button" onclick="parent.qBittorrent.Client.closeWindows();" class="qbt-translatable" data-i18n="Cancel">Cancel</button>
             <button type="button" id="addPeersOk" class="qbt-translatable" data-i18n="Ok">Ok</button>

--- a/src/webui/www/private/addpeers.html
+++ b/src/webui/www/private/addpeers.html
@@ -46,7 +46,7 @@
                         peers: peers.join('|')
                     },
                     onFailure: function() {
-                        alert("QBT_TR(Unable to add peers. Please ensure you are adhering to the IP:port format.)QBT_TR[CONTEXT=HttpServer]");
+                        alert(i18next.t("Unable to add peers. Please ensure you are adhering to the IP:port format."));
                     },
                     onSuccess: function() {
                         window.parent.qBittorrent.Client.closeWindows();

--- a/src/webui/www/private/addtrackers.html
+++ b/src/webui/www/private/addtrackers.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(Add trackers)QBT_TR[CONTEXT=TrackersAdditionDialog]</title>
+    <title class="qbt-translatable" data-i18n="Add trackers">Add trackers</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>

--- a/src/webui/www/private/addtrackers.html
+++ b/src/webui/www/private/addtrackers.html
@@ -51,7 +51,7 @@
         <h2 class="vcenter qbt-translatable" data-i18n="List of trackers to add (one per line):">List of trackers to add (one per line):</h2>
         <textarea name="list" id="trackersUrls" rows="10" cols="1"></textarea>
         <br />
-        <input type="button" value="QBT_TR(Add)QBT_TR[CONTEXT=HttpServer]" id="addTrackersButton" />
+        <input type="button" class="qbt-translatable" data-i18n="[value]Add" value="Add" id="addTrackersButton" />
     </div>
 </body>
 

--- a/src/webui/www/private/addtrackers.html
+++ b/src/webui/www/private/addtrackers.html
@@ -48,7 +48,7 @@
 <body>
     <div style="text-align: center;">
         <br />
-        <h2 class="vcenter">QBT_TR(List of trackers to add (one per line):)QBT_TR[CONTEXT=TrackersAdditionDialog]</h2>
+        <h2 class="vcenter qbt-translatable" data-i18n="List of trackers to add (one per line):">List of trackers to add (one per line):</h2>
         <textarea name="list" id="trackersUrls" rows="10" cols="1"></textarea>
         <br />
         <input type="button" value="QBT_TR(Add)QBT_TR[CONTEXT=HttpServer]" id="addTrackersButton" />

--- a/src/webui/www/private/confirmdeletion.html
+++ b/src/webui/www/private/confirmdeletion.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(Remove torrent(s))QBT_TR[CONTEXT=confirmDeletionDlg]</title>
+    <title class="qbt-translatable" data-i18n="Remove torrent(s)">Remove torrent(s)</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
@@ -91,7 +91,7 @@
     <p>&nbsp;&nbsp;QBT_TR(Are you sure you want to remove the selected torrents from the transfer list?)QBT_TR[CONTEXT=HttpServer]</p>
     &nbsp;&nbsp;&nbsp;&nbsp;<button id="rememberBtn" type="button" title="Remember choice" style="vertical-align: middle; padding: 4px 6px;">
     </button>
-    <input type="checkbox" id="deleteFromDiskCB" /> <label for="deleteFromDiskCB"><i>QBT_TR(Also permanently delete the files)QBT_TR[CONTEXT=confirmDeletionDlg]</i></label><br /><br />
+    <input type="checkbox" id="deleteFromDiskCB" /> <label for="deleteFromDiskCB"><i class="qbt-translatable" data-i18n="Also permanently delete the files">Also permanently delete the files</i></label><br /><br />
     <div style="text-align: right;">
         <input type="button" id="cancelBtn" value="QBT_TR(Cancel)QBT_TR[CONTEXT=MainWindow]" />&nbsp;&nbsp;<input type="button" id="confirmBtn" value="QBT_TR(Remove)QBT_TR[CONTEXT=MainWindow]" />&nbsp;&nbsp;
     </div>

--- a/src/webui/www/private/confirmdeletion.html
+++ b/src/webui/www/private/confirmdeletion.html
@@ -93,7 +93,7 @@
     </button>
     <input type="checkbox" id="deleteFromDiskCB" /> <label for="deleteFromDiskCB"><i class="qbt-translatable" data-i18n="Also permanently delete the files">Also permanently delete the files</i></label><br /><br />
     <div style="text-align: right;">
-        <input type="button" id="cancelBtn" value="QBT_TR(Cancel)QBT_TR[CONTEXT=MainWindow]" />&nbsp;&nbsp;<input type="button" id="confirmBtn" value="QBT_TR(Remove)QBT_TR[CONTEXT=MainWindow]" />&nbsp;&nbsp;
+        <input type="button" id="cancelBtn" class="qbt-translatable" data-i18n="[value]Cancel" value="Cancel" />&nbsp;&nbsp;<input type="button" id="confirmBtn" class="qbt-translatable" data-i18n="[value]Remove" value="Remove" />&nbsp;&nbsp;
     </div>
 </body>
 

--- a/src/webui/www/private/confirmfeeddeletion.html
+++ b/src/webui/www/private/confirmfeeddeletion.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(Deletion confirmation)QBT_TR[CONTEXT=RSSWidget]</title>
+    <title class="qbt-translatable" data-i18n="Deletion confirmation">Deletion confirmation</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
@@ -43,7 +43,7 @@
 
 <body>
     <div style="padding: 10px 10px 0px 10px;">
-        <p>QBT_TR(Are you sure you want to delete the selected RSS feeds?)QBT_TR[CONTEXT=RSSWidget]</p>
+        <p class="qbt-translatable" data-i18n="Are you sure you want to delete the selected RSS feeds?">Are you sure you want to delete the selected RSS feeds?</p>
         <div style="text-align: right;">
             <input type="button" id="cancelBtn" value="QBT_TR(No)QBT_TR[CONTEXT=MainWindow]" />
             <input type="button" id="confirmBtn" value="QBT_TR(Yes)QBT_TR[CONTEXT=MainWindow]" />

--- a/src/webui/www/private/confirmfeeddeletion.html
+++ b/src/webui/www/private/confirmfeeddeletion.html
@@ -45,8 +45,8 @@
     <div style="padding: 10px 10px 0px 10px;">
         <p class="qbt-translatable" data-i18n="Are you sure you want to delete the selected RSS feeds?">Are you sure you want to delete the selected RSS feeds?</p>
         <div style="text-align: right;">
-            <input type="button" id="cancelBtn" value="QBT_TR(No)QBT_TR[CONTEXT=MainWindow]" />
-            <input type="button" id="confirmBtn" value="QBT_TR(Yes)QBT_TR[CONTEXT=MainWindow]" />
+            <input type="button" id="cancelBtn" class="qbt-translatable" data-i18n="[value]No" value="No" />
+            <input type="button" id="confirmBtn" class="qbt-translatable" data-i18n="[value]Yes" value="Yes" />
         </div>
     </div>
 </body>

--- a/src/webui/www/private/confirmruleclear.html
+++ b/src/webui/www/private/confirmruleclear.html
@@ -39,8 +39,8 @@
     <div style="padding: 10px 10px 0px 10px;">
         <p class="qbt-translatable" data-i18n="Are you sure you want to clear the list of downloaded episodes for the selected rule?">Are you sure you want to clear the list of downloaded episodes for the selected rule?</p>
         <div style="text-align: right;">
-            <input type="button" id="cancelBtn" value="QBT_TR(No)QBT_TR[CONTEXT=MainWindow]" />
-            <input type="button" id="confirmBtn" value="QBT_TR(Yes)QBT_TR[CONTEXT=MainWindow]" />
+            <input type="button" id="cancelBtn" class="qbt-translatable" data-i18n="[value]No" value="No" />
+            <input type="button" id="confirmBtn" class="qbt-translatable" data-i18n="[value]Yes" value="Yes" />
         </div>
     </div>
 </body>

--- a/src/webui/www/private/confirmruleclear.html
+++ b/src/webui/www/private/confirmruleclear.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(Clear downloaded episodes)QBT_TR[CONTEXT=AutomatedRssDownloader]</title>
+    <title class="qbt-translatable" data-i18n="Clear downloaded episodes">Clear downloaded episodes</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
@@ -37,7 +37,7 @@
 
 <body>
     <div style="padding: 10px 10px 0px 10px;">
-        <p>QBT_TR(Are you sure you want to clear the list of downloaded episodes for the selected rule?)QBT_TR[CONTEXT=AutomatedRssDownloader]</p>
+        <p class="qbt-translatable" data-i18n="Are you sure you want to clear the list of downloaded episodes for the selected rule?">Are you sure you want to clear the list of downloaded episodes for the selected rule?</p>
         <div style="text-align: right;">
             <input type="button" id="cancelBtn" value="QBT_TR(No)QBT_TR[CONTEXT=MainWindow]" />
             <input type="button" id="confirmBtn" value="QBT_TR(Yes)QBT_TR[CONTEXT=MainWindow]" />

--- a/src/webui/www/private/confirmruledeletion.html
+++ b/src/webui/www/private/confirmruledeletion.html
@@ -46,8 +46,8 @@
     <div style="padding: 10px 10px 0px 10px;">
         <p class="qbt-translatable" data-i18n="Are you sure you want to remove the selected download rules?">Are you sure you want to remove the selected download rules?</p>
         <div style="text-align: right;">
-            <input type="button" id="cancelBtn" value="QBT_TR(No)QBT_TR[CONTEXT=MainWindow]" />
-            <input type="button" id="confirmBtn" value="QBT_TR(Yes)QBT_TR[CONTEXT=MainWindow]" />
+            <input type="button" id="cancelBtn" class="qbt-translatable" data-i18n="[value]No" value="No" />
+            <input type="button" id="confirmBtn" class="qbt-translatable" data-i18n="[value]Yes" value="Yes" />
         </div>
     </div>
 </body>

--- a/src/webui/www/private/confirmruledeletion.html
+++ b/src/webui/www/private/confirmruledeletion.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(Rule deletion confirmation)QBT_TR[CONTEXT=AutomatedRssDownloader]</title>
+    <title class="qbt-translatable" data-i18n="Rule deletion confirmation">Rule deletion confirmation</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
@@ -44,7 +44,7 @@
 
 <body>
     <div style="padding: 10px 10px 0px 10px;">
-        <p>QBT_TR(Are you sure you want to remove the selected download rules?)QBT_TR[CONTEXT=AutomatedRssDownloader]</p>
+        <p class="qbt-translatable" data-i18n="Are you sure you want to remove the selected download rules?">Are you sure you want to remove the selected download rules?</p>
         <div style="text-align: right;">
             <input type="button" id="cancelBtn" value="QBT_TR(No)QBT_TR[CONTEXT=MainWindow]" />
             <input type="button" id="confirmBtn" value="QBT_TR(Yes)QBT_TR[CONTEXT=MainWindow]" />

--- a/src/webui/www/private/download.html
+++ b/src/webui/www/private/download.html
@@ -17,7 +17,7 @@
     <form action="api/v2/torrents/add" enctype="multipart/form-data" method="post" id="downloadForm" style="text-align: center;" target="download_frame" autocorrect="off" autocapitalize="none">
         <div style="text-align: center;">
             <br />
-            <h2 class="vcenter">QBT_TR(Download Torrents from their URLs or Magnet links)QBT_TR[CONTEXT=HttpServer]</h2>
+            <h2 class="vcenter qbt-translatable" data-i18n="Download Torrents from their URLs or Magnet links">Download Torrents from their URLs or Magnet links</h2>
             <textarea id="urls" rows="10" name="urls"></textarea>
             <p class="qbt-translatable" data-i18n="Only one link per line">Only one link per line</p>
             <fieldset class="settings" style="border: 0; text-align: left; margin-top: 6px;">

--- a/src/webui/www/private/download.html
+++ b/src/webui/www/private/download.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(Add Torrent Links)QBT_TR[CONTEXT=downloadFromURL]</title>
+    <title class="qbt-translatable" data-i18n="Add Torrent Links">Add Torrent Links</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
     <link rel="stylesheet" href="css/Window.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
@@ -19,23 +19,23 @@
             <br />
             <h2 class="vcenter">QBT_TR(Download Torrents from their URLs or Magnet links)QBT_TR[CONTEXT=HttpServer]</h2>
             <textarea id="urls" rows="10" name="urls"></textarea>
-            <p>QBT_TR(Only one link per line)QBT_TR[CONTEXT=HttpServer]</p>
+            <p class="qbt-translatable" data-i18n="Only one link per line">Only one link per line</p>
             <fieldset class="settings" style="border: 0; text-align: left; margin-top: 6px;">
                 <table style="margin: auto;">
                     <tr>
                         <td>
-                            <label for="autoTMM">QBT_TR(Torrent Management Mode:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                            <label for="autoTMM" class="qbt-translatable" data-i18n="Torrent Management Mode:">Torrent Management Mode:</label>
                         </td>
                         <td>
                             <select id="autoTMM" name="autoTMM" onchange="qBittorrent.Download.changeTMM(this)">
-                                <option selected value="false">QBT_TR(Manual)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
-                                <option value="true">QBT_TR(Automatic)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
+                                <option selected value="false" class="qbt-translatable" data-i18n="Manual">Manual</option>
+                                <option value="true" class="qbt-translatable" data-i18n="Automatic">Automatic</option>
                             </select>
                         </td>
                     </tr>
                     <tr>
                         <td>
-                            <label for="savepath">QBT_TR(Save files to location:)QBT_TR[CONTEXT=HttpServer]</label>
+                            <label for="savepath" class="qbt-translatable" data-i18n="Save files to location:">Save files to location:</label>
                         </td>
                         <td>
                             <input type="text" id="savepath" name="savepath" style="width: 16em;" />
@@ -43,7 +43,7 @@
                     </tr>
                     <tr>
                         <td>
-                            <label for="cookie">QBT_TR(Cookie:)QBT_TR[CONTEXT=HttpServer]</label>
+                            <label for="cookie" class="qbt-translatable" data-i18n="Cookie:">Cookie:</label>
                         </td>
                         <td>
                             <input type="text" id="cookie" name="cookie" style="width: 16em;" />
@@ -51,7 +51,7 @@
                     </tr>
                     <tr>
                         <td>
-                            <label for="rename">QBT_TR(Rename torrent)QBT_TR[CONTEXT=HttpServer]</label>
+                            <label for="rename" class="qbt-translatable" data-i18n="Rename torrent">Rename torrent</label>
                         </td>
                         <td>
                             <input type="text" id="rename" name="rename" style="width: 16em;" />
@@ -59,7 +59,7 @@
                     </tr>
                     <tr>
                         <td>
-                            <label for="category">QBT_TR(Category:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                            <label for="category" class="qbt-translatable" data-i18n="Category:">Category:</label>
                         </td>
                         <td>
                             <div class="select-watched-folder-editable">
@@ -72,7 +72,7 @@
                     </tr>
                     <tr>
                         <td>
-                            <label for="startTorrent">QBT_TR(Start torrent)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                            <label for="startTorrent" class="qbt-translatable" data-i18n="Start torrent">Start torrent</label>
                         </td>
                         <td>
                             <input type="hidden" id="startTorrentHidden" name="paused" />
@@ -81,7 +81,7 @@
                     </tr>
                     <tr>
                         <td>
-                            <label for="addToTopOfQueue">QBT_TR(Add to top of queue)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                            <label for="addToTopOfQueue" class="qbt-translatable" data-i18n="Add to top of queue">Add to top of queue</label>
                         </td>
                         <td>
                             <input type="checkbox" id="addToTopOfQueue" name="addToTopOfQueue" value="true" />
@@ -89,19 +89,19 @@
                     </tr>
                     <tr>
                         <td>
-                            <label for="stopCondition">QBT_TR(Stop condition:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                            <label for="stopCondition" class="qbt-translatable" data-i18n="Stop condition:">Stop condition:</label>
                         </td>
                         <td>
                             <select id="stopCondition" name="stopCondition">
-                                <option selected value="None">QBT_TR(None)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
-                                <option value="MetadataReceived">QBT_TR(Metadata received)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
-                                <option value="FilesChecked">QBT_TR(Files checked)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
+                                <option selected value="None" class="qbt-translatable" data-i18n="None">None</option>
+                                <option value="MetadataReceived" class="qbt-translatable" data-i18n="Metadata received">Metadata received</option>
+                                <option value="FilesChecked" class="qbt-translatable" data-i18n="Files checked">Files checked</option>
                             </select>
                         </td>
                     </tr>
                     <tr>
                         <td>
-                            <label for="skip_checking">QBT_TR(Skip hash check)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                            <label for="skip_checking" class="qbt-translatable" data-i18n="Skip hash check">Skip hash check</label>
                         </td>
                         <td>
                             <input type="checkbox" id="skip_checking" name="skip_checking" value="true" />
@@ -109,19 +109,19 @@
                     </tr>
                     <tr>
                         <td>
-                            <label for="contentLayout">QBT_TR(Content layout:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                            <label for="contentLayout" class="qbt-translatable" data-i18n="Content layout:">Content layout:</label>
                         </td>
                         <td>
                             <select id="contentLayout" name="contentLayout">
-                                <option selected value="Original">QBT_TR(Original)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
-                                <option value="Subfolder">QBT_TR(Create subfolder)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
-                                <option value="NoSubfolder">QBT_TR(Don't create subfolder)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
+                                <option selected value="Original" class="qbt-translatable" data-i18n="Original">Original</option>
+                                <option value="Subfolder" class="qbt-translatable" data-i18n="Create subfolder">Create subfolder</option>
+                                <option value="NoSubfolder" class="qbt-translatable" data-i18n="Don't create subfolder">Don't create subfolder</option>
                             </select>
                         </td>
                     </tr>
                     <tr>
                         <td>
-                            <label for="sequentialDownload">QBT_TR(Download in sequential order)QBT_TR[CONTEXT=TransferListWidget]</label>
+                            <label for="sequentialDownload" class="qbt-translatable" data-i18n="Download in sequential order">Download in sequential order</label>
                         </td>
                         <td>
                             <input type="checkbox" id="sequentialDownload" name="sequentialDownload" value="true" />
@@ -129,7 +129,7 @@
                     </tr>
                     <tr>
                         <td>
-                            <label for="firstLastPiecePrio">QBT_TR(Download first and last pieces first)QBT_TR[CONTEXT=TransferListWidget]</label>
+                            <label for="firstLastPiecePrio" class="qbt-translatable" data-i18n="Download first and last pieces first">Download first and last pieces first</label>
                         </td>
                         <td>
                             <input type="checkbox" id="firstLastPiecePrio" name="firstLastPiecePrio" value="true" />
@@ -137,7 +137,7 @@
                     </tr>
                     <tr>
                         <td>
-                            <label for="dlLimitText">QBT_TR(Limit download rate)QBT_TR[CONTEXT=HttpServer]</label>
+                            <label for="dlLimitText" class="qbt-translatable" data-i18n="Limit download rate">Limit download rate</label>
                         </td>
                         <td>
                             <input type="hidden" id="dlLimitHidden" name="dlLimit" />
@@ -146,7 +146,7 @@
                     </tr>
                     <tr>
                         <td>
-                            <label for="upLimitText">QBT_TR(Limit upload rate)QBT_TR[CONTEXT=HttpServer]</label>
+                            <label for="upLimitText" class="qbt-translatable" data-i18n="Limit upload rate">Limit upload rate</label>
                         </td>
                         <td>
                             <input type="hidden" id="upLimitHidden" name="upLimit" />
@@ -155,7 +155,7 @@
                     </tr>
                 </table>
                 <div id="submitbutton" style="margin-top: 12px; text-align: center;">
-                    <button type="submit" id="submitButton">QBT_TR(Download)QBT_TR[CONTEXT=downloadFromURL]</button>
+                    <button type="submit" id="submitButton" class="qbt-translatable" data-i18n="Download">Download</button>
                 </div>
             </fieldset>
         </div>

--- a/src/webui/www/private/downloadlimit.html
+++ b/src/webui/www/private/downloadlimit.html
@@ -21,7 +21,7 @@
             </div>
             <div class="clear"></div>
         </div>
-        <input type="button" id="applyButton" value="QBT_TR(Apply)QBT_TR[CONTEXT=HttpServer]" onclick="setDlLimit()" />
+        <input type="button" id="applyButton" class="qbt-translatable" data-i18n="[value]Apply" value="Apply" onclick="setDlLimit()" />
     </div>
 
     <script>

--- a/src/webui/www/private/downloadlimit.html
+++ b/src/webui/www/private/downloadlimit.html
@@ -14,7 +14,7 @@
 <body>
     <div style="width: 100%; text-align: center; margin: 0 auto; overflow: hidden">
         <div id="dllimitSlider" class="slider">
-            <div id="dllimitUpdate" class="update">QBT_TR(Download limit:)QBT_TR[CONTEXT=PropertiesWidget] <input type="text" id="dllimitUpdatevalue" size="6" placeholder="∞" style="text-align: center;"> <span id="dlLimitUnit" class="qbt-translatable" data-i18n="KiB/s">KiB/s</span></div>
+            <div id="dllimitUpdate" class="update qbt-translatable" data-i18n="Download limit:">Download limit: <input type="text" id="dllimitUpdatevalue" size="6" placeholder="∞" style="text-align: center;"> <span id="dlLimitUnit" class="qbt-translatable" data-i18n="KiB/s">KiB/s</span></div>
             <div class="sliderWrapper">
                 <div id="dllimitSliderknob" class="sliderknob"></div>
                 <div id="dllimitSliderarea" class="sliderarea"></div>

--- a/src/webui/www/private/downloadlimit.html
+++ b/src/webui/www/private/downloadlimit.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(Torrent Download Speed Limiting)QBT_TR[CONTEXT=TransferListWidget]</title>
+    <title class="qbt-translatable" data-i18n="Torrent Download Speed Limiting">Torrent Download Speed Limiting</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
@@ -14,7 +14,7 @@
 <body>
     <div style="width: 100%; text-align: center; margin: 0 auto; overflow: hidden">
         <div id="dllimitSlider" class="slider">
-            <div id="dllimitUpdate" class="update">QBT_TR(Download limit:)QBT_TR[CONTEXT=PropertiesWidget] <input type="text" id="dllimitUpdatevalue" size="6" placeholder="∞" style="text-align: center;"> <span id="dlLimitUnit">QBT_TR(KiB/s)QBT_TR[CONTEXT=SpeedLimitDialog]</span></div>
+            <div id="dllimitUpdate" class="update">QBT_TR(Download limit:)QBT_TR[CONTEXT=PropertiesWidget] <input type="text" id="dllimitUpdatevalue" size="6" placeholder="∞" style="text-align: center;"> <span id="dlLimitUnit" class="qbt-translatable" data-i18n="KiB/s">KiB/s</span></div>
             <div class="sliderWrapper">
                 <div id="dllimitSliderknob" class="sliderknob"></div>
                 <div id="dllimitSliderarea" class="sliderarea"></div>

--- a/src/webui/www/private/edittracker.html
+++ b/src/webui/www/private/edittracker.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(Tracker editing)QBT_TR[CONTEXT=TrackerListWidget]</title>
+    <title class="qbt-translatable" data-i18n="Tracker editing">Tracker editing</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>

--- a/src/webui/www/private/edittracker.html
+++ b/src/webui/www/private/edittracker.html
@@ -59,7 +59,7 @@
 <body>
     <div style="text-align: center;">
         <br />
-        <h2 class="vcenter">QBT_TR(Tracker URL:)QBT_TR[CONTEXT=TrackerListWidget]</h2>
+        <h2 class="vcenter qbt-translatable" data-i18n="Tracker URL:">Tracker URL:</h2>
         <div style="text-align: center; padding-top: 10px;">
             <input type="text" id="trackerUrl" style="width: 90%;" />
         </div>

--- a/src/webui/www/private/edittracker.html
+++ b/src/webui/www/private/edittracker.html
@@ -64,7 +64,7 @@
             <input type="text" id="trackerUrl" style="width: 90%;" />
         </div>
         <br />
-        <input type="button" value="QBT_TR(Edit)QBT_TR[CONTEXT=HttpServer]" id="editTrackerButton" />
+        <input type="button" class="qbt-translatable" data-i18n="[value]Edit" value="Edit" id="editTrackerButton" />
     </div>
 </body>
 

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -55,70 +55,70 @@
                     <li>
                         <a class="returnFalse qbt-translatable" data-i18n="File">File</a>
                         <ul>
-                            <li><a id="uploadLink"><img class="MyMenuIcon qbt-translatable" alt="QBT_TR(Add Torrent File...)QBT_TR[CONTEXT=MainWindow]" src="images/list-add.svg" width="16" height="16" / data-i18n="Add Torrent File...">Add Torrent File...</a></li>
-                            <li><a id="downloadLink"><img class="MyMenuIcon qbt-translatable" alt="QBT_TR(Add Torrent Link...)QBT_TR[CONTEXT=MainWindow]" src="images/insert-link.svg" width="16" height="16" / data-i18n="Add Torrent Link...">Add Torrent Link...</a></li>
-                            <li class="divider qbt-translatable"><a id="logoutLink"><img class="MyMenuIcon" alt="QBT_TR(Logout)QBT_TR[CONTEXT=HttpServer]" src="images/system-log-out.svg" width="16" height="16" / data-i18n="Logout">Logout</a></li>
-                            <li><a id="shutdownLink"><img class="MyMenuIcon qbt-translatable" alt="QBT_TR(Exit qBittorrent)QBT_TR[CONTEXT=HttpServer]" src="images/application-exit.svg" width="16" height="16" / data-i18n="Exit qBittorrent">Exit qBittorrent</a></li>
+                            <li><a id="uploadLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" data-i18n="[alt]Add Torrent File..." alt="Add Torrent File..." src="images/list-add.svg" width="16" height="16" / data-i18n="Add Torrent File...">Add Torrent File...</a></li>
+                            <li><a id="downloadLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" data-i18n="[alt]Add Torrent Link..." alt="Add Torrent Link..." src="images/insert-link.svg" width="16" height="16" / data-i18n="Add Torrent Link...">Add Torrent Link...</a></li>
+                            <li class="divider qbt-translatable qbt-translatable"><a id="logoutLink"><img class="MyMenuIcon" data-i18n="[alt]Logout" alt="Logout" src="images/system-log-out.svg" width="16" height="16" / data-i18n="Logout">Logout</a></li>
+                            <li><a id="shutdownLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" data-i18n="[alt]Exit qBittorrent" alt="Exit qBittorrent" src="images/application-exit.svg" width="16" height="16" / data-i18n="Exit qBittorrent">Exit qBittorrent</a></li>
                         </ul>
                     </li>
                     <li>
                         <a class="returnFalse qbt-translatable" data-i18n="Edit">Edit</a>
                         <ul>
-                            <li><a id="resumeLink"><img class="MyMenuIcon qbt-translatable" alt="QBT_TR(Resume)QBT_TR[CONTEXT=MainWindow]" src="images/torrent-start.svg" width="16" height="16" / data-i18n="Resume">Resume</a></li>
-                            <li><a id="pauseLink"><img class="MyMenuIcon qbt-translatable" src="images/torrent-stop.svg" alt="QBT_TR(Pause)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Pause">Pause</a></li>
-                            <li><a id="resumeAllLink"><img class="MyMenuIcon qbt-translatable" alt="QBT_TR(Resume All)QBT_TR[CONTEXT=MainWindow]" src="images/torrent-start.svg" width="16" height="16" / data-i18n="Resume All">Resume All</a></li>
-                            <li><a id="pauseAllLink"><img class="MyMenuIcon qbt-translatable" alt="QBT_TR(Pause All)QBT_TR[CONTEXT=MainWindow]" src="images/torrent-stop.svg" width="16" height="16" / data-i18n="Pause All">Pause All</a></li>
-                            <li class="divider qbt-translatable"><a id="deleteLink"><img class="MyMenuIcon" src="images/list-remove.svg" alt="QBT_TR(Remove)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Remove">Remove</a></li>
-                            <li id="topQueuePosItem" class="divider qbt-translatable"><a id="topPrioLink"><img class="MyMenuIcon" src="images/go-top.svg" alt="QBT_TR(Top of Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Top of Queue">Top of Queue</a></li>
-                            <li id="increaseQueuePosItem"><a id="increasePrioLink"><img class="MyMenuIcon qbt-translatable" src="images/go-up.svg" alt="QBT_TR(Move Up Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Move Up Queue">Move Up Queue</a></li>
-                            <li id="decreaseQueuePosItem"><a id="decreasePrioLink"><img class="MyMenuIcon qbt-translatable" src="images/go-down.svg" alt="QBT_TR(Move Down Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Move Down Queue">Move Down Queue</a></li>
-                            <li id="bottomQueuePosItem"><a id="bottomPrioLink"><img class="MyMenuIcon qbt-translatable" src="images/go-bottom.svg" alt="QBT_TR(Bottom of Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Bottom of Queue">Bottom of Queue</a></li>
+                            <li><a id="resumeLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" data-i18n="[alt]Resume" alt="Resume" src="images/torrent-start.svg" width="16" height="16" / data-i18n="Resume">Resume</a></li>
+                            <li><a id="pauseLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/torrent-stop.svg" data-i18n="[alt]Pause" alt="Pause" width="16" height="16" / data-i18n="Pause">Pause</a></li>
+                            <li><a id="resumeAllLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" data-i18n="[alt]Resume All" alt="Resume All" src="images/torrent-start.svg" width="16" height="16" / data-i18n="Resume All">Resume All</a></li>
+                            <li><a id="pauseAllLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" data-i18n="[alt]Pause All" alt="Pause All" src="images/torrent-stop.svg" width="16" height="16" / data-i18n="Pause All">Pause All</a></li>
+                            <li class="divider qbt-translatable qbt-translatable"><a id="deleteLink"><img class="MyMenuIcon" src="images/list-remove.svg" data-i18n="[alt]Remove" alt="Remove" width="16" height="16" / data-i18n="Remove">Remove</a></li>
+                            <li id="topQueuePosItem" class="divider qbt-translatable qbt-translatable"><a id="topPrioLink"><img class="MyMenuIcon" src="images/go-top.svg" data-i18n="[alt]Top of Queue" alt="Top of Queue" width="16" height="16" / data-i18n="Top of Queue">Top of Queue</a></li>
+                            <li id="increaseQueuePosItem"><a id="increasePrioLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/go-up.svg" data-i18n="[alt]Move Up Queue" alt="Move Up Queue" width="16" height="16" / data-i18n="Move Up Queue">Move Up Queue</a></li>
+                            <li id="decreaseQueuePosItem"><a id="decreasePrioLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/go-down.svg" data-i18n="[alt]Move Down Queue" alt="Move Down Queue" width="16" height="16" / data-i18n="Move Down Queue">Move Down Queue</a></li>
+                            <li id="bottomQueuePosItem"><a id="bottomPrioLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/go-bottom.svg" data-i18n="[alt]Bottom of Queue" alt="Bottom of Queue" width="16" height="16" / data-i18n="Bottom of Queue">Bottom of Queue</a></li>
                         </ul>
                     </li>
                     <li>
                         <a class="returnFalse qbt-translatable" data-i18n="View">View</a>
                         <ul>
-                            <li><a id="showTopToolbarLink"><img class="MyMenuIcon qbt-translatable" src="images/checked-completed.svg" alt="QBT_TR(Top Toolbar)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Top Toolbar">Top Toolbar</a></li>
-                            <li><a id="showStatusBarLink"><img class="MyMenuIcon qbt-translatable" src="images/checked-completed.svg" alt="QBT_TR(Status Bar)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Status Bar">Status Bar</a></li>
-                            <li><a id="showFiltersSidebarLink"><img class="MyMenuIcon qbt-translatable" src="images/checked-completed.svg" alt="QBT_TR(Filters Sidebar)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Filters Sidebar">Filters Sidebar</a></li>
-                            <li><a id="speedInBrowserTitleBarLink"><img class="MyMenuIcon qbt-translatable" src="images/checked-completed.svg" alt="QBT_TR(Speed in Title Bar)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Speed in Title Bar">Speed in Title Bar</a></li>
-                            <li class="divider qbt-translatable"><a id="showSearchEngineLink"><img class="MyMenuIcon" src="images/checked-completed.svg" alt="QBT_TR(Search Engine)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Search Engine">Search Engine</a></li>
-                            <li><a id="showRssReaderLink"><img class="MyMenuIcon qbt-translatable" src="images/checked-completed.svg" alt="QBT_TR(RSS)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="RSS Reader">RSS Reader</a></li>
-                            <li><a id="showLogViewerLink"><img class="MyMenuIcon qbt-translatable" src="images/checked-completed.svg" alt="QBT_TR(Log)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Log">Log</a></li>
-                            <li class="divider qbt-translatable"><a id="StatisticsLink"><img class="MyMenuIcon" src="images/view-statistics.svg" alt="QBT_TR(Statistics)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Statistics">Statistics</a></li>
+                            <li><a id="showTopToolbarLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/checked-completed.svg" data-i18n="[alt]Top Toolbar" alt="Top Toolbar" width="16" height="16" / data-i18n="Top Toolbar">Top Toolbar</a></li>
+                            <li><a id="showStatusBarLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/checked-completed.svg" data-i18n="[alt]Status Bar" alt="Status Bar" width="16" height="16" / data-i18n="Status Bar">Status Bar</a></li>
+                            <li><a id="showFiltersSidebarLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/checked-completed.svg" data-i18n="[alt]Filters Sidebar" alt="Filters Sidebar" width="16" height="16" / data-i18n="Filters Sidebar">Filters Sidebar</a></li>
+                            <li><a id="speedInBrowserTitleBarLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/checked-completed.svg" data-i18n="[alt]Speed in Title Bar" alt="Speed in Title Bar" width="16" height="16" / data-i18n="Speed in Title Bar">Speed in Title Bar</a></li>
+                            <li class="divider qbt-translatable qbt-translatable"><a id="showSearchEngineLink"><img class="MyMenuIcon" src="images/checked-completed.svg" data-i18n="[alt]Search Engine" alt="Search Engine" width="16" height="16" / data-i18n="Search Engine">Search Engine</a></li>
+                            <li><a id="showRssReaderLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/checked-completed.svg" data-i18n="[alt]RSS" alt="RSS" width="16" height="16" / data-i18n="RSS Reader">RSS Reader</a></li>
+                            <li><a id="showLogViewerLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/checked-completed.svg" data-i18n="[alt]Log" alt="Log" width="16" height="16" / data-i18n="Log">Log</a></li>
+                            <li class="divider qbt-translatable qbt-translatable"><a id="StatisticsLink"><img class="MyMenuIcon" src="images/view-statistics.svg" data-i18n="[alt]Statistics" alt="Statistics" width="16" height="16" / data-i18n="Statistics">Statistics</a></li>
                         </ul>
                     </li>
                     <li>
                         <a class="returnFalse qbt-translatable" data-i18n="Tools">Tools</a>
                         <ul>
-                            <li><a id="preferencesLink"><img class="MyMenuIcon qbt-translatable" src="images/configure.svg" alt="QBT_TR(Options...)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Options...">Options...</a></li>
-                            <li><a id="registerMagnetHandlerLink"><img class="MyMenuIcon qbt-translatable" src="images/torrent-magnet.svg" alt="QBT_TR(Register to handle magnet links...)QBT_TR[CONTEXT=HttpServer]" width="16" height="16" / data-i18n="Register to handle magnet links...">Register to handle magnet links...</a></li>
+                            <li><a id="preferencesLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/configure.svg" data-i18n="[alt]Options..." alt="Options..." width="16" height="16" / data-i18n="Options...">Options...</a></li>
+                            <li><a id="registerMagnetHandlerLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/torrent-magnet.svg" data-i18n="[alt]Register to handle magnet links..." alt="Register to handle magnet links..." width="16" height="16" / data-i18n="Register to handle magnet links...">Register to handle magnet links...</a></li>
                         </ul>
                     </li>
                     <li>
                         <a class="returnFalse qbt-translatable" data-i18n="Help">Help</a>
                         <ul>
-                            <li><a id="docsLink" target="_blank" href="https://wiki.qbittorrent.org/"><img class="MyMenuIcon qbt-translatable" src="images/help-contents.svg" alt="QBT_TR(Documentation)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Documentation">Documentation</a></li>
-                            <li class="divider qbt-translatable"><a id="bugLink" target="_blank" href="https://www.qbittorrent.org/donate"><img class="MyMenuIcon" src="images/wallet-open.svg" alt="QBT_TR(Donate!)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Donate!">Donate!</a></li>
-                            <li><a id="aboutLink"><img class="MyMenuIcon qbt-translatable" src="images/help-about.svg" alt="QBT_TR(About)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="About">About</a></li>
+                            <li><a id="docsLink" target="_blank" href="https://wiki.qbittorrent.org/"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/help-contents.svg" data-i18n="[alt]Documentation" alt="Documentation" width="16" height="16" / data-i18n="Documentation">Documentation</a></li>
+                            <li class="divider qbt-translatable qbt-translatable"><a id="bugLink" target="_blank" href="https://www.qbittorrent.org/donate"><img class="MyMenuIcon" src="images/wallet-open.svg" data-i18n="[alt]Donate!" alt="Donate!" width="16" height="16" / data-i18n="Donate!">Donate!</a></li>
+                            <li><a id="aboutLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/help-about.svg" data-i18n="[alt]About" alt="About" width="16" height="16" / data-i18n="About">About</a></li>
                         </ul>
                     </li>
                 </ul>
             </div>
             <div id="mochaToolbar">
                 &nbsp;&nbsp;
-                <a id="downloadButton"><img class="mochaToolButton" title="QBT_TR(Add Torrent Link...)QBT_TR[CONTEXT=MainWindow]" src="images/insert-link.svg" alt="QBT_TR(Add Torrent Link...)QBT_TR[CONTEXT=MainWindow]" width="24" height="24" /></a>
-                <a id="uploadButton"><img class="mochaToolButton" title="QBT_TR(Add Torrent File...)QBT_TR[CONTEXT=MainWindow]" src="images/list-add.svg" alt="QBT_TR(Add Torrent File...)QBT_TR[CONTEXT=MainWindow]" width="24" height="24" /></a>
-                <a id="deleteButton" class="divider"><img class="mochaToolButton" title="QBT_TR(Remove)QBT_TR[CONTEXT=TransferListWidget]" src="images/list-remove.svg" alt="QBT_TR(Remove)QBT_TR[CONTEXT=TransferListWidget]" width="24" height="24" /></a>
-                <a id="resumeButton" class="divider"><img class="mochaToolButton" title="QBT_TR(Resume)QBT_TR[CONTEXT=TransferListWidget]" src="images/torrent-start.svg" alt="QBT_TR(Resume)QBT_TR[CONTEXT=TransferListWidget]" width="24" height="24" /></a>
-                <a id="pauseButton"><img class="mochaToolButton" title="QBT_TR(Pause)QBT_TR[CONTEXT=TransferListWidget]" src="images/torrent-stop.svg" alt="QBT_TR(Pause)QBT_TR[CONTEXT=TransferListWidget]" width="24" height="24" /></a>
+                <a id="downloadButton"><img class="mochaToolButton qbt-translatable" data-i18n="[title]Add Torrent Link..." title="Add Torrent Link..." src="images/insert-link.svg" alt="QBT_TR(Add Torrent Link...)QBT_TR[CONTEXT=MainWindow]" width="24" height="24" /></a>
+                <a id="uploadButton"><img class="mochaToolButton qbt-translatable" data-i18n="[title]Add Torrent File..." title="Add Torrent File..." src="images/list-add.svg" alt="QBT_TR(Add Torrent File...)QBT_TR[CONTEXT=MainWindow]" width="24" height="24" /></a>
+                <a id="deleteButton" class="divider qbt-translatable"><img class="mochaToolButton" data-i18n="[title]Remove" title="Remove" src="images/list-remove.svg" alt="QBT_TR(Remove)QBT_TR[CONTEXT=TransferListWidget]" width="24" height="24" /></a>
+                <a id="resumeButton" class="divider qbt-translatable"><img class="mochaToolButton" data-i18n="[title]Resume" title="Resume" src="images/torrent-start.svg" alt="QBT_TR(Resume)QBT_TR[CONTEXT=TransferListWidget]" width="24" height="24" /></a>
+                <a id="pauseButton"><img class="mochaToolButton qbt-translatable" data-i18n="[title]Pause" title="Pause" src="images/torrent-stop.svg" alt="QBT_TR(Pause)QBT_TR[CONTEXT=TransferListWidget]" width="24" height="24" /></a>
                 <span id="queueingButtons">
-                    <a id="topPrioButton" class="divider"><img class="mochaToolButton" title="QBT_TR(Move to the top of the queue)QBT_TR[CONTEXT=MainWindow]" src="images/go-top.svg" alt="QBT_TR(Top of Queue)QBT_TR[CONTEXT=MainWindow]" width="24" height="24" /></a>
-                    <a id="increasePrioButton"><img class="mochaToolButton" title="QBT_TR(Move up in the queue)QBT_TR[CONTEXT=MainWindow]" src="images/go-up.svg" alt="QBT_TR(Move Up Queue)QBT_TR[CONTEXT=MainWindow]" width="24" height="24" /></a>
-                    <a id="decreasePrioButton"><img class="mochaToolButton" title="QBT_TR(Move down in the queue)QBT_TR[CONTEXT=MainWindow]" src="images/go-down.svg" alt="QBT_TR(Move Down Queue)QBT_TR[CONTEXT=MainWindow]" width="24" height="24" /></a>
-                    <a id="bottomPrioButton"><img class="mochaToolButton" title="QBT_TR(Move to the bottom of the queue)QBT_TR[CONTEXT=MainWindow]" src="images/go-bottom.svg" alt="QBT_TR(Bottom of Queue)QBT_TR[CONTEXT=MainWindow]" width="24" height="24" /></a>
+                    <a id="topPrioButton" class="divider qbt-translatable"><img class="mochaToolButton" data-i18n="[title]Move to the top of the queue" title="Move to the top of the queue" src="images/go-top.svg" alt="QBT_TR(Top of Queue)QBT_TR[CONTEXT=MainWindow]" width="24" height="24" /></a>
+                    <a id="increasePrioButton"><img class="mochaToolButton qbt-translatable" data-i18n="[title]Move up in the queue" title="Move up in the queue" src="images/go-up.svg" alt="QBT_TR(Move Up Queue)QBT_TR[CONTEXT=MainWindow]" width="24" height="24" /></a>
+                    <a id="decreasePrioButton"><img class="mochaToolButton qbt-translatable" data-i18n="[title]Move down in the queue" title="Move down in the queue" src="images/go-down.svg" alt="QBT_TR(Move Down Queue)QBT_TR[CONTEXT=MainWindow]" width="24" height="24" /></a>
+                    <a id="bottomPrioButton"><img class="mochaToolButton qbt-translatable" data-i18n="[title]Move to the bottom of the queue" title="Move to the bottom of the queue" src="images/go-bottom.svg" alt="QBT_TR(Bottom of Queue)QBT_TR[CONTEXT=MainWindow]" width="24" height="24" /></a>
                 </span>
-                <a id="preferencesButton" class="divider"><img class="mochaToolButton" title="QBT_TR(Options)QBT_TR[CONTEXT=OptionsDialog]" src="images/configure.svg" alt="QBT_TR(Options)QBT_TR[CONTEXT=OptionsDialog]" width="24" height="24" /></a>
+                <a id="preferencesButton" class="divider qbt-translatable"><img class="mochaToolButton" data-i18n="[title]Options" title="Options" src="images/configure.svg" alt="QBT_TR(Options)QBT_TR[CONTEXT=OptionsDialog]" width="24" height="24" /></a>
                 <div id="mainWindowTabs" class="toolbarTabs">
                     <ul id="mainWindowTabsList" class="tab-menu">
                         <li id="transfersTabLink" class="selected qbt-translatable"><a class="tab" data-i18n="Transfers">Transfers</a></li>
@@ -251,9 +251,9 @@
                     <td class="statusBarSeparator"></td>
                     <td id="DHTNodes"></td>
                     <td class="statusBarSeparator"></td>
-                    <td><img id="connectionStatus" class="qbt-translatable" data-i18n="[alt]Connection status: Firewalled" alt="Connection status: Firewalled" title="QBT_TR(Connection status: Firewalled)QBT_TR[CONTEXT=MainWindow]" src="images/firewalled.svg" style="height: 1.5em;" /></td>
+                    <td><img id="connectionStatus" class="qbt-translatable qbt-translatable" data-i18n="[alt]Connection status: Firewalled" alt="Connection status: Firewalled" data-i18n="[title]Connection status: Firewalled" title="Connection status: Firewalled" src="images/firewalled.svg" style="height: 1.5em;" /></td>
                     <td class="statusBarSeparator"></td>
-                    <td style="cursor:pointer;"><img id="alternativeSpeedLimits" class="qbt-translatable" data-i18n="[alt]Alternative speed limits: Off" alt="Alternative speed limits: Off" title="QBT_TR(Alternative speed limits: Off)QBT_TR[CONTEXT=MainWindow]" src="images/slow_off.svg" style="height: 1.5em;" /></td>
+                    <td style="cursor:pointer;"><img id="alternativeSpeedLimits" class="qbt-translatable qbt-translatable" data-i18n="[alt]Alternative speed limits: Off" alt="Alternative speed limits: Off" data-i18n="[title]Alternative speed limits: Off" title="Alternative speed limits: Off" src="images/slow_off.svg" style="height: 1.5em;" /></td>
                     <td class="statusBarSeparator"></td>
                     <td class="speedLabel"><img src="images/downloading.svg" class="qbt-translatable" data-i18n="[alt]Download speed icon" alt="Download speed icon" style="height: 1.5em; padding-right: 5px; margin-bottom: -4px;"><span id="DlInfos"></span></td>
                     <td class="statusBarSeparator"></td>

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -107,18 +107,18 @@
             </div>
             <div id="mochaToolbar">
                 &nbsp;&nbsp;
-                <a id="downloadButton"><img class="mochaToolButton qbt-translatable" data-i18n="[title]Add Torrent Link..." title="Add Torrent Link..." src="images/insert-link.svg" alt="QBT_TR(Add Torrent Link...)QBT_TR[CONTEXT=MainWindow]" width="24" height="24" /></a>
-                <a id="uploadButton"><img class="mochaToolButton qbt-translatable" data-i18n="[title]Add Torrent File..." title="Add Torrent File..." src="images/list-add.svg" alt="QBT_TR(Add Torrent File...)QBT_TR[CONTEXT=MainWindow]" width="24" height="24" /></a>
-                <a id="deleteButton" class="divider qbt-translatable"><img class="mochaToolButton" data-i18n="[title]Remove" title="Remove" src="images/list-remove.svg" alt="QBT_TR(Remove)QBT_TR[CONTEXT=TransferListWidget]" width="24" height="24" /></a>
-                <a id="resumeButton" class="divider qbt-translatable"><img class="mochaToolButton" data-i18n="[title]Resume" title="Resume" src="images/torrent-start.svg" alt="QBT_TR(Resume)QBT_TR[CONTEXT=TransferListWidget]" width="24" height="24" /></a>
-                <a id="pauseButton"><img class="mochaToolButton qbt-translatable" data-i18n="[title]Pause" title="Pause" src="images/torrent-stop.svg" alt="QBT_TR(Pause)QBT_TR[CONTEXT=TransferListWidget]" width="24" height="24" /></a>
+                <a id="downloadButton"><img class="mochaToolButton qbt-translatable" data-i18n="[title]Add Torrent Link...;[alt]Add Torrent Link..." title="Add Torrent Link..." src="images/insert-link.svg" alt="Add Torrent Link..." width="24" height="24" /></a>
+                <a id="uploadButton"><img class="mochaToolButton qbt-translatable" data-i18n="[title]Add Torrent File...;[alt]Add Torrent File..." title="Add Torrent File..." src="images/list-add.svg" alt="Add Torrent File..." width="24" height="24" /></a>
+                <a id="deleteButton" class="divider qbt-translatable"><img class="mochaToolButton" data-i18n="[title]Remove;[alt]Remove" title="Remove" src="images/list-remove.svg" alt="Remove" width="24" height="24" /></a>
+                <a id="resumeButton" class="divider qbt-translatable"><img class="mochaToolButton" data-i18n="[title]Resume;[alt]Resume" title="Resume" src="images/torrent-start.svg" alt="Resume" width="24" height="24" /></a>
+                <a id="pauseButton"><img class="mochaToolButton qbt-translatable" data-i18n="[title]Pause;[alt]Pause" title="Pause" src="images/torrent-stop.svg" alt="Pause" width="24" height="24" /></a>
                 <span id="queueingButtons">
-                    <a id="topPrioButton" class="divider qbt-translatable"><img class="mochaToolButton" data-i18n="[title]Move to the top of the queue" title="Move to the top of the queue" src="images/go-top.svg" alt="QBT_TR(Top of Queue)QBT_TR[CONTEXT=MainWindow]" width="24" height="24" /></a>
-                    <a id="increasePrioButton"><img class="mochaToolButton qbt-translatable" data-i18n="[title]Move up in the queue" title="Move up in the queue" src="images/go-up.svg" alt="QBT_TR(Move Up Queue)QBT_TR[CONTEXT=MainWindow]" width="24" height="24" /></a>
-                    <a id="decreasePrioButton"><img class="mochaToolButton qbt-translatable" data-i18n="[title]Move down in the queue" title="Move down in the queue" src="images/go-down.svg" alt="QBT_TR(Move Down Queue)QBT_TR[CONTEXT=MainWindow]" width="24" height="24" /></a>
-                    <a id="bottomPrioButton"><img class="mochaToolButton qbt-translatable" data-i18n="[title]Move to the bottom of the queue" title="Move to the bottom of the queue" src="images/go-bottom.svg" alt="QBT_TR(Bottom of Queue)QBT_TR[CONTEXT=MainWindow]" width="24" height="24" /></a>
+                    <a id="topPrioButton" class="divider qbt-translatable"><img class="mochaToolButton" data-i18n="[title]Move to the top of the queue;[alt]Top of Queue" title="Move to the top of the queue" src="images/go-top.svg" alt="Top of Queue" width="24" height="24" /></a>
+                    <a id="increasePrioButton"><img class="mochaToolButton qbt-translatable" data-i18n="[title]Move up in the queue;[alt]Move Up Queue" title="Move up in the queue" src="images/go-up.svg" alt="Move Up Queue" width="24" height="24" /></a>
+                    <a id="decreasePrioButton"><img class="mochaToolButton qbt-translatable" data-i18n="[title]Move down in the queue;[alt]Move Down Queue" title="Move down in the queue" src="images/go-down.svg" alt="Move Down Queue" width="24" height="24" /></a>
+                    <a id="bottomPrioButton"><img class="mochaToolButton qbt-translatable" data-i18n="[title]Move to the bottom of the queue;[alt]Bottom of Queue" title="Move to the bottom of the queue" src="images/go-bottom.svg" alt="Bottom of Queue" width="24" height="24" /></a>
                 </span>
-                <a id="preferencesButton" class="divider qbt-translatable"><img class="mochaToolButton" data-i18n="[title]Options" title="Options" src="images/configure.svg" alt="QBT_TR(Options)QBT_TR[CONTEXT=OptionsDialog]" width="24" height="24" /></a>
+                <a id="preferencesButton" class="divider qbt-translatable"><img class="mochaToolButton" data-i18n="[title]Options;[alt]Options" title="Options" src="images/configure.svg" alt="Options" width="24" height="24" /></a>
                 <div id="mainWindowTabs" class="toolbarTabs">
                     <ul id="mainWindowTabsList" class="tab-menu">
                         <li id="transfersTabLink" class="selected qbt-translatable"><a class="tab" data-i18n="Transfers">Transfers</a></li>

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -43,7 +43,7 @@
 
 <body>
     <noscript id="noscript">
-        <h1>QBT_TR(JavaScript Required! You must enable JavaScript for the WebUI to work properly)QBT_TR[CONTEXT=HttpServer]</h1>
+        <h1 class="qbt-translatable" data-i18n="JavaScript Required! You must enable JavaScript for the WebUI to work properly">JavaScript Required! You must enable JavaScript for the WebUI to work properly</h1>
     </noscript>
     <div id="desktop">
         <div id="desktopHeader">

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -55,52 +55,52 @@
                     <li>
                         <a class="returnFalse qbt-translatable" data-i18n="File">File</a>
                         <ul>
-                            <li><a id="uploadLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" data-i18n="[alt]Add Torrent File..." alt="Add Torrent File..." src="images/list-add.svg" width="16" height="16" / data-i18n="Add Torrent File...">Add Torrent File...</a></li>
-                            <li><a id="downloadLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" data-i18n="[alt]Add Torrent Link..." alt="Add Torrent Link..." src="images/insert-link.svg" width="16" height="16" / data-i18n="Add Torrent Link...">Add Torrent Link...</a></li>
-                            <li class="divider qbt-translatable qbt-translatable"><a id="logoutLink"><img class="MyMenuIcon" data-i18n="[alt]Logout" alt="Logout" src="images/system-log-out.svg" width="16" height="16" / data-i18n="Logout">Logout</a></li>
-                            <li><a id="shutdownLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" data-i18n="[alt]Exit qBittorrent" alt="Exit qBittorrent" src="images/application-exit.svg" width="16" height="16" / data-i18n="Exit qBittorrent">Exit qBittorrent</a></li>
+                            <li><a id="uploadLink"><img class="MyMenuIcon qbt-translatable" data-i18n="[alt]Add Torrent File..." alt="Add Torrent File..." src="images/list-add.svg" width="16" height="16" / data-i18n="Add Torrent File...">Add Torrent File...</a></li>
+                            <li><a id="downloadLink"><img class="MyMenuIcon qbt-translatable" data-i18n="[alt]Add Torrent Link..." alt="Add Torrent Link..." src="images/insert-link.svg" width="16" height="16" / data-i18n="Add Torrent Link...">Add Torrent Link...</a></li>
+                            <li class="divider qbt-translatable"><a id="logoutLink"><img class="MyMenuIcon" data-i18n="[alt]Logout" alt="Logout" src="images/system-log-out.svg" width="16" height="16" / data-i18n="Logout">Logout</a></li>
+                            <li><a id="shutdownLink"><img class="MyMenuIcon qbt-translatable" data-i18n="[alt]Exit qBittorrent" alt="Exit qBittorrent" src="images/application-exit.svg" width="16" height="16" / data-i18n="Exit qBittorrent">Exit qBittorrent</a></li>
                         </ul>
                     </li>
                     <li>
                         <a class="returnFalse qbt-translatable" data-i18n="Edit">Edit</a>
                         <ul>
-                            <li><a id="resumeLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" data-i18n="[alt]Resume" alt="Resume" src="images/torrent-start.svg" width="16" height="16" / data-i18n="Resume">Resume</a></li>
-                            <li><a id="pauseLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/torrent-stop.svg" data-i18n="[alt]Pause" alt="Pause" width="16" height="16" / data-i18n="Pause">Pause</a></li>
-                            <li><a id="resumeAllLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" data-i18n="[alt]Resume All" alt="Resume All" src="images/torrent-start.svg" width="16" height="16" / data-i18n="Resume All">Resume All</a></li>
-                            <li><a id="pauseAllLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" data-i18n="[alt]Pause All" alt="Pause All" src="images/torrent-stop.svg" width="16" height="16" / data-i18n="Pause All">Pause All</a></li>
-                            <li class="divider qbt-translatable qbt-translatable"><a id="deleteLink"><img class="MyMenuIcon" src="images/list-remove.svg" data-i18n="[alt]Remove" alt="Remove" width="16" height="16" / data-i18n="Remove">Remove</a></li>
-                            <li id="topQueuePosItem" class="divider qbt-translatable qbt-translatable"><a id="topPrioLink"><img class="MyMenuIcon" src="images/go-top.svg" data-i18n="[alt]Top of Queue" alt="Top of Queue" width="16" height="16" / data-i18n="Top of Queue">Top of Queue</a></li>
-                            <li id="increaseQueuePosItem"><a id="increasePrioLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/go-up.svg" data-i18n="[alt]Move Up Queue" alt="Move Up Queue" width="16" height="16" / data-i18n="Move Up Queue">Move Up Queue</a></li>
-                            <li id="decreaseQueuePosItem"><a id="decreasePrioLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/go-down.svg" data-i18n="[alt]Move Down Queue" alt="Move Down Queue" width="16" height="16" / data-i18n="Move Down Queue">Move Down Queue</a></li>
-                            <li id="bottomQueuePosItem"><a id="bottomPrioLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/go-bottom.svg" data-i18n="[alt]Bottom of Queue" alt="Bottom of Queue" width="16" height="16" / data-i18n="Bottom of Queue">Bottom of Queue</a></li>
+                            <li><a id="resumeLink"><img class="MyMenuIcon qbt-translatable" data-i18n="[alt]Resume" alt="Resume" src="images/torrent-start.svg" width="16" height="16" / data-i18n="Resume">Resume</a></li>
+                            <li><a id="pauseLink"><img class="MyMenuIcon qbt-translatable" src="images/torrent-stop.svg" data-i18n="[alt]Pause" alt="Pause" width="16" height="16" / data-i18n="Pause">Pause</a></li>
+                            <li><a id="resumeAllLink"><img class="MyMenuIcon qbt-translatable" data-i18n="[alt]Resume All" alt="Resume All" src="images/torrent-start.svg" width="16" height="16" / data-i18n="Resume All">Resume All</a></li>
+                            <li><a id="pauseAllLink"><img class="MyMenuIcon qbt-translatable" data-i18n="[alt]Pause All" alt="Pause All" src="images/torrent-stop.svg" width="16" height="16" / data-i18n="Pause All">Pause All</a></li>
+                            <li class="divider qbt-translatable"><a id="deleteLink"><img class="MyMenuIcon" src="images/list-remove.svg" data-i18n="[alt]Remove" alt="Remove" width="16" height="16" / data-i18n="Remove">Remove</a></li>
+                            <li id="topQueuePosItem" class="divider qbt-translatable"><a id="topPrioLink"><img class="MyMenuIcon" src="images/go-top.svg" data-i18n="[alt]Top of Queue" alt="Top of Queue" width="16" height="16" / data-i18n="Top of Queue">Top of Queue</a></li>
+                            <li id="increaseQueuePosItem"><a id="increasePrioLink"><img class="MyMenuIcon qbt-translatable" src="images/go-up.svg" data-i18n="[alt]Move Up Queue" alt="Move Up Queue" width="16" height="16" / data-i18n="Move Up Queue">Move Up Queue</a></li>
+                            <li id="decreaseQueuePosItem"><a id="decreasePrioLink"><img class="MyMenuIcon qbt-translatable" src="images/go-down.svg" data-i18n="[alt]Move Down Queue" alt="Move Down Queue" width="16" height="16" / data-i18n="Move Down Queue">Move Down Queue</a></li>
+                            <li id="bottomQueuePosItem"><a id="bottomPrioLink"><img class="MyMenuIcon qbt-translatable" src="images/go-bottom.svg" data-i18n="[alt]Bottom of Queue" alt="Bottom of Queue" width="16" height="16" / data-i18n="Bottom of Queue">Bottom of Queue</a></li>
                         </ul>
                     </li>
                     <li>
                         <a class="returnFalse qbt-translatable" data-i18n="View">View</a>
                         <ul>
-                            <li><a id="showTopToolbarLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/checked-completed.svg" data-i18n="[alt]Top Toolbar" alt="Top Toolbar" width="16" height="16" / data-i18n="Top Toolbar">Top Toolbar</a></li>
-                            <li><a id="showStatusBarLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/checked-completed.svg" data-i18n="[alt]Status Bar" alt="Status Bar" width="16" height="16" / data-i18n="Status Bar">Status Bar</a></li>
-                            <li><a id="showFiltersSidebarLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/checked-completed.svg" data-i18n="[alt]Filters Sidebar" alt="Filters Sidebar" width="16" height="16" / data-i18n="Filters Sidebar">Filters Sidebar</a></li>
-                            <li><a id="speedInBrowserTitleBarLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/checked-completed.svg" data-i18n="[alt]Speed in Title Bar" alt="Speed in Title Bar" width="16" height="16" / data-i18n="Speed in Title Bar">Speed in Title Bar</a></li>
-                            <li class="divider qbt-translatable qbt-translatable"><a id="showSearchEngineLink"><img class="MyMenuIcon" src="images/checked-completed.svg" data-i18n="[alt]Search Engine" alt="Search Engine" width="16" height="16" / data-i18n="Search Engine">Search Engine</a></li>
-                            <li><a id="showRssReaderLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/checked-completed.svg" data-i18n="[alt]RSS" alt="RSS" width="16" height="16" / data-i18n="RSS Reader">RSS Reader</a></li>
-                            <li><a id="showLogViewerLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/checked-completed.svg" data-i18n="[alt]Log" alt="Log" width="16" height="16" / data-i18n="Log">Log</a></li>
-                            <li class="divider qbt-translatable qbt-translatable"><a id="StatisticsLink"><img class="MyMenuIcon" src="images/view-statistics.svg" data-i18n="[alt]Statistics" alt="Statistics" width="16" height="16" / data-i18n="Statistics">Statistics</a></li>
+                            <li><a id="showTopToolbarLink"><img class="MyMenuIcon qbt-translatable" src="images/checked-completed.svg" data-i18n="[alt]Top Toolbar" alt="Top Toolbar" width="16" height="16" / data-i18n="Top Toolbar">Top Toolbar</a></li>
+                            <li><a id="showStatusBarLink"><img class="MyMenuIcon qbt-translatable" src="images/checked-completed.svg" data-i18n="[alt]Status Bar" alt="Status Bar" width="16" height="16" / data-i18n="Status Bar">Status Bar</a></li>
+                            <li><a id="showFiltersSidebarLink"><img class="MyMenuIcon qbt-translatable" src="images/checked-completed.svg" data-i18n="[alt]Filters Sidebar" alt="Filters Sidebar" width="16" height="16" / data-i18n="Filters Sidebar">Filters Sidebar</a></li>
+                            <li><a id="speedInBrowserTitleBarLink"><img class="MyMenuIcon qbt-translatable" src="images/checked-completed.svg" data-i18n="[alt]Speed in Title Bar" alt="Speed in Title Bar" width="16" height="16" / data-i18n="Speed in Title Bar">Speed in Title Bar</a></li>
+                            <li class="divider qbt-translatable"><a id="showSearchEngineLink"><img class="MyMenuIcon" src="images/checked-completed.svg" data-i18n="[alt]Search Engine" alt="Search Engine" width="16" height="16" / data-i18n="Search Engine">Search Engine</a></li>
+                            <li><a id="showRssReaderLink"><img class="MyMenuIcon qbt-translatable" src="images/checked-completed.svg" data-i18n="[alt]RSS" alt="RSS" width="16" height="16" / data-i18n="RSS Reader">RSS Reader</a></li>
+                            <li><a id="showLogViewerLink"><img class="MyMenuIcon qbt-translatable" src="images/checked-completed.svg" data-i18n="[alt]Log" alt="Log" width="16" height="16" / data-i18n="Log">Log</a></li>
+                            <li class="divider qbt-translatable"><a id="StatisticsLink"><img class="MyMenuIcon" src="images/view-statistics.svg" data-i18n="[alt]Statistics" alt="Statistics" width="16" height="16" / data-i18n="Statistics">Statistics</a></li>
                         </ul>
                     </li>
                     <li>
                         <a class="returnFalse qbt-translatable" data-i18n="Tools">Tools</a>
                         <ul>
-                            <li><a id="preferencesLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/configure.svg" data-i18n="[alt]Options..." alt="Options..." width="16" height="16" / data-i18n="Options...">Options...</a></li>
-                            <li><a id="registerMagnetHandlerLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/torrent-magnet.svg" data-i18n="[alt]Register to handle magnet links..." alt="Register to handle magnet links..." width="16" height="16" / data-i18n="Register to handle magnet links...">Register to handle magnet links...</a></li>
+                            <li><a id="preferencesLink"><img class="MyMenuIcon qbt-translatable" src="images/configure.svg" data-i18n="[alt]Options..." alt="Options..." width="16" height="16" / data-i18n="Options...">Options...</a></li>
+                            <li><a id="registerMagnetHandlerLink"><img class="MyMenuIcon qbt-translatable" src="images/torrent-magnet.svg" data-i18n="[alt]Register to handle magnet links..." alt="Register to handle magnet links..." width="16" height="16" / data-i18n="Register to handle magnet links...">Register to handle magnet links...</a></li>
                         </ul>
                     </li>
                     <li>
                         <a class="returnFalse qbt-translatable" data-i18n="Help">Help</a>
                         <ul>
-                            <li><a id="docsLink" target="_blank" href="https://wiki.qbittorrent.org/"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/help-contents.svg" data-i18n="[alt]Documentation" alt="Documentation" width="16" height="16" / data-i18n="Documentation">Documentation</a></li>
-                            <li class="divider qbt-translatable qbt-translatable"><a id="bugLink" target="_blank" href="https://www.qbittorrent.org/donate"><img class="MyMenuIcon" src="images/wallet-open.svg" data-i18n="[alt]Donate!" alt="Donate!" width="16" height="16" / data-i18n="Donate!">Donate!</a></li>
-                            <li><a id="aboutLink"><img class="MyMenuIcon qbt-translatable qbt-translatable" src="images/help-about.svg" data-i18n="[alt]About" alt="About" width="16" height="16" / data-i18n="About">About</a></li>
+                            <li><a id="docsLink" target="_blank" href="https://wiki.qbittorrent.org/"><img class="MyMenuIcon qbt-translatable" src="images/help-contents.svg" data-i18n="[alt]Documentation" alt="Documentation" width="16" height="16" / data-i18n="Documentation">Documentation</a></li>
+                            <li class="divider qbt-translatable"><a id="bugLink" target="_blank" href="https://www.qbittorrent.org/donate"><img class="MyMenuIcon" src="images/wallet-open.svg" data-i18n="[alt]Donate!" alt="Donate!" width="16" height="16" / data-i18n="Donate!">Donate!</a></li>
+                            <li><a id="aboutLink"><img class="MyMenuIcon qbt-translatable" src="images/help-about.svg" data-i18n="[alt]About" alt="About" width="16" height="16" / data-i18n="About">About</a></li>
                         </ul>
                     </li>
                 </ul>
@@ -251,9 +251,9 @@
                     <td class="statusBarSeparator"></td>
                     <td id="DHTNodes"></td>
                     <td class="statusBarSeparator"></td>
-                    <td><img id="connectionStatus" class="qbt-translatable qbt-translatable" data-i18n="[alt]Connection status: Firewalled" alt="Connection status: Firewalled" data-i18n="[title]Connection status: Firewalled" title="Connection status: Firewalled" src="images/firewalled.svg" style="height: 1.5em;" /></td>
+                    <td><img id="connectionStatus" class="qbt-translatable" data-i18n="[alt]Connection status: Firewalled" alt="Connection status: Firewalled" data-i18n="[title]Connection status: Firewalled" title="Connection status: Firewalled" src="images/firewalled.svg" style="height: 1.5em;" /></td>
                     <td class="statusBarSeparator"></td>
-                    <td style="cursor:pointer;"><img id="alternativeSpeedLimits" class="qbt-translatable qbt-translatable" data-i18n="[alt]Alternative speed limits: Off" alt="Alternative speed limits: Off" data-i18n="[title]Alternative speed limits: Off" title="Alternative speed limits: Off" src="images/slow_off.svg" style="height: 1.5em;" /></td>
+                    <td style="cursor:pointer;"><img id="alternativeSpeedLimits" class="qbt-translatable" data-i18n="[alt]Alternative speed limits: Off" alt="Alternative speed limits: Off" data-i18n="[title]Alternative speed limits: Off" title="Alternative speed limits: Off" src="images/slow_off.svg" style="height: 1.5em;" /></td>
                     <td class="statusBarSeparator"></td>
                     <td class="speedLabel"><img src="images/downloading.svg" class="qbt-translatable" data-i18n="[alt]Download speed icon" alt="Download speed icon" style="height: 1.5em; padding-right: 5px; margin-bottom: -4px;"><span id="DlInfos"></span></td>
                     <td class="statusBarSeparator"></td>

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -53,54 +53,54 @@
             <div id="desktopNavbar">
                 <ul>
                     <li>
-                        <a class="returnFalse">QBT_TR(File)QBT_TR[CONTEXT=MainWindow]</a>
+                        <a class="returnFalse qbt-translatable" data-i18n="File">File</a>
                         <ul>
-                            <li><a id="uploadLink"><img class="MyMenuIcon" alt="QBT_TR(Add Torrent File...)QBT_TR[CONTEXT=MainWindow]" src="images/list-add.svg" width="16" height="16" />QBT_TR(Add Torrent File...)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li><a id="downloadLink"><img class="MyMenuIcon" alt="QBT_TR(Add Torrent Link...)QBT_TR[CONTEXT=MainWindow]" src="images/insert-link.svg" width="16" height="16" />QBT_TR(Add Torrent Link...)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li class="divider"><a id="logoutLink"><img class="MyMenuIcon" alt="QBT_TR(Logout)QBT_TR[CONTEXT=HttpServer]" src="images/system-log-out.svg" width="16" height="16" />QBT_TR(Logout)QBT_TR[CONTEXT=HttpServer]</a></li>
-                            <li><a id="shutdownLink"><img class="MyMenuIcon" alt="QBT_TR(Exit qBittorrent)QBT_TR[CONTEXT=HttpServer]" src="images/application-exit.svg" width="16" height="16" />QBT_TR(Exit qBittorrent)QBT_TR[CONTEXT=HttpServer]</a></li>
+                            <li><a id="uploadLink"><img class="MyMenuIcon qbt-translatable" alt="QBT_TR(Add Torrent File...)QBT_TR[CONTEXT=MainWindow]" src="images/list-add.svg" width="16" height="16" / data-i18n="Add Torrent File...">Add Torrent File...</a></li>
+                            <li><a id="downloadLink"><img class="MyMenuIcon qbt-translatable" alt="QBT_TR(Add Torrent Link...)QBT_TR[CONTEXT=MainWindow]" src="images/insert-link.svg" width="16" height="16" / data-i18n="Add Torrent Link...">Add Torrent Link...</a></li>
+                            <li class="divider qbt-translatable"><a id="logoutLink"><img class="MyMenuIcon" alt="QBT_TR(Logout)QBT_TR[CONTEXT=HttpServer]" src="images/system-log-out.svg" width="16" height="16" / data-i18n="Logout">Logout</a></li>
+                            <li><a id="shutdownLink"><img class="MyMenuIcon qbt-translatable" alt="QBT_TR(Exit qBittorrent)QBT_TR[CONTEXT=HttpServer]" src="images/application-exit.svg" width="16" height="16" / data-i18n="Exit qBittorrent">Exit qBittorrent</a></li>
                         </ul>
                     </li>
                     <li>
-                        <a class="returnFalse">QBT_TR(Edit)QBT_TR[CONTEXT=MainWindow]</a>
+                        <a class="returnFalse qbt-translatable" data-i18n="Edit">Edit</a>
                         <ul>
-                            <li><a id="resumeLink"><img class="MyMenuIcon" alt="QBT_TR(Resume)QBT_TR[CONTEXT=MainWindow]" src="images/torrent-start.svg" width="16" height="16" />QBT_TR(Resume)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li><a id="pauseLink"><img class="MyMenuIcon" src="images/torrent-stop.svg" alt="QBT_TR(Pause)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Pause)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li><a id="resumeAllLink"><img class="MyMenuIcon" alt="QBT_TR(Resume All)QBT_TR[CONTEXT=MainWindow]" src="images/torrent-start.svg" width="16" height="16" />QBT_TR(Resume All)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li><a id="pauseAllLink"><img class="MyMenuIcon" alt="QBT_TR(Pause All)QBT_TR[CONTEXT=MainWindow]" src="images/torrent-stop.svg" width="16" height="16" />QBT_TR(Pause All)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li class="divider"><a id="deleteLink"><img class="MyMenuIcon" src="images/list-remove.svg" alt="QBT_TR(Remove)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Remove)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li id="topQueuePosItem" class="divider"><a id="topPrioLink"><img class="MyMenuIcon" src="images/go-top.svg" alt="QBT_TR(Top of Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Top of Queue)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li id="increaseQueuePosItem"><a id="increasePrioLink"><img class="MyMenuIcon" src="images/go-up.svg" alt="QBT_TR(Move Up Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Move Up Queue)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li id="decreaseQueuePosItem"><a id="decreasePrioLink"><img class="MyMenuIcon" src="images/go-down.svg" alt="QBT_TR(Move Down Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Move Down Queue)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li id="bottomQueuePosItem"><a id="bottomPrioLink"><img class="MyMenuIcon" src="images/go-bottom.svg" alt="QBT_TR(Bottom of Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Bottom of Queue)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li><a id="resumeLink"><img class="MyMenuIcon qbt-translatable" alt="QBT_TR(Resume)QBT_TR[CONTEXT=MainWindow]" src="images/torrent-start.svg" width="16" height="16" / data-i18n="Resume">Resume</a></li>
+                            <li><a id="pauseLink"><img class="MyMenuIcon qbt-translatable" src="images/torrent-stop.svg" alt="QBT_TR(Pause)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Pause">Pause</a></li>
+                            <li><a id="resumeAllLink"><img class="MyMenuIcon qbt-translatable" alt="QBT_TR(Resume All)QBT_TR[CONTEXT=MainWindow]" src="images/torrent-start.svg" width="16" height="16" / data-i18n="Resume All">Resume All</a></li>
+                            <li><a id="pauseAllLink"><img class="MyMenuIcon qbt-translatable" alt="QBT_TR(Pause All)QBT_TR[CONTEXT=MainWindow]" src="images/torrent-stop.svg" width="16" height="16" / data-i18n="Pause All">Pause All</a></li>
+                            <li class="divider qbt-translatable"><a id="deleteLink"><img class="MyMenuIcon" src="images/list-remove.svg" alt="QBT_TR(Remove)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Remove">Remove</a></li>
+                            <li id="topQueuePosItem" class="divider qbt-translatable"><a id="topPrioLink"><img class="MyMenuIcon" src="images/go-top.svg" alt="QBT_TR(Top of Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Top of Queue">Top of Queue</a></li>
+                            <li id="increaseQueuePosItem"><a id="increasePrioLink"><img class="MyMenuIcon qbt-translatable" src="images/go-up.svg" alt="QBT_TR(Move Up Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Move Up Queue">Move Up Queue</a></li>
+                            <li id="decreaseQueuePosItem"><a id="decreasePrioLink"><img class="MyMenuIcon qbt-translatable" src="images/go-down.svg" alt="QBT_TR(Move Down Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Move Down Queue">Move Down Queue</a></li>
+                            <li id="bottomQueuePosItem"><a id="bottomPrioLink"><img class="MyMenuIcon qbt-translatable" src="images/go-bottom.svg" alt="QBT_TR(Bottom of Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Bottom of Queue">Bottom of Queue</a></li>
                         </ul>
                     </li>
                     <li>
-                        <a class="returnFalse">QBT_TR(View)QBT_TR[CONTEXT=MainWindow]</a>
+                        <a class="returnFalse qbt-translatable" data-i18n="View">View</a>
                         <ul>
-                            <li><a id="showTopToolbarLink"><img class="MyMenuIcon" src="images/checked-completed.svg" alt="QBT_TR(Top Toolbar)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Top Toolbar)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li><a id="showStatusBarLink"><img class="MyMenuIcon" src="images/checked-completed.svg" alt="QBT_TR(Status Bar)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Status Bar)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li><a id="showFiltersSidebarLink"><img class="MyMenuIcon" src="images/checked-completed.svg" alt="QBT_TR(Filters Sidebar)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Filters Sidebar)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li><a id="speedInBrowserTitleBarLink"><img class="MyMenuIcon" src="images/checked-completed.svg" alt="QBT_TR(Speed in Title Bar)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Speed in Title Bar)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li class="divider"><a id="showSearchEngineLink"><img class="MyMenuIcon" src="images/checked-completed.svg" alt="QBT_TR(Search Engine)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Search Engine)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li><a id="showRssReaderLink"><img class="MyMenuIcon" src="images/checked-completed.svg" alt="QBT_TR(RSS)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(RSS Reader)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li><a id="showLogViewerLink"><img class="MyMenuIcon" src="images/checked-completed.svg" alt="QBT_TR(Log)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Log)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li class="divider"><a id="StatisticsLink"><img class="MyMenuIcon" src="images/view-statistics.svg" alt="QBT_TR(Statistics)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Statistics)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li><a id="showTopToolbarLink"><img class="MyMenuIcon qbt-translatable" src="images/checked-completed.svg" alt="QBT_TR(Top Toolbar)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Top Toolbar">Top Toolbar</a></li>
+                            <li><a id="showStatusBarLink"><img class="MyMenuIcon qbt-translatable" src="images/checked-completed.svg" alt="QBT_TR(Status Bar)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Status Bar">Status Bar</a></li>
+                            <li><a id="showFiltersSidebarLink"><img class="MyMenuIcon qbt-translatable" src="images/checked-completed.svg" alt="QBT_TR(Filters Sidebar)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Filters Sidebar">Filters Sidebar</a></li>
+                            <li><a id="speedInBrowserTitleBarLink"><img class="MyMenuIcon qbt-translatable" src="images/checked-completed.svg" alt="QBT_TR(Speed in Title Bar)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Speed in Title Bar">Speed in Title Bar</a></li>
+                            <li class="divider qbt-translatable"><a id="showSearchEngineLink"><img class="MyMenuIcon" src="images/checked-completed.svg" alt="QBT_TR(Search Engine)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Search Engine">Search Engine</a></li>
+                            <li><a id="showRssReaderLink"><img class="MyMenuIcon qbt-translatable" src="images/checked-completed.svg" alt="QBT_TR(RSS)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="RSS Reader">RSS Reader</a></li>
+                            <li><a id="showLogViewerLink"><img class="MyMenuIcon qbt-translatable" src="images/checked-completed.svg" alt="QBT_TR(Log)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Log">Log</a></li>
+                            <li class="divider qbt-translatable"><a id="StatisticsLink"><img class="MyMenuIcon" src="images/view-statistics.svg" alt="QBT_TR(Statistics)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Statistics">Statistics</a></li>
                         </ul>
                     </li>
                     <li>
-                        <a class="returnFalse">QBT_TR(Tools)QBT_TR[CONTEXT=MainWindow]</a>
+                        <a class="returnFalse qbt-translatable" data-i18n="Tools">Tools</a>
                         <ul>
-                            <li><a id="preferencesLink"><img class="MyMenuIcon" src="images/configure.svg" alt="QBT_TR(Options...)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Options...)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li><a id="registerMagnetHandlerLink"><img class="MyMenuIcon" src="images/torrent-magnet.svg" alt="QBT_TR(Register to handle magnet links...)QBT_TR[CONTEXT=HttpServer]" width="16" height="16" />QBT_TR(Register to handle magnet links...)QBT_TR[CONTEXT=HttpServer]</a></li>
+                            <li><a id="preferencesLink"><img class="MyMenuIcon qbt-translatable" src="images/configure.svg" alt="QBT_TR(Options...)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Options...">Options...</a></li>
+                            <li><a id="registerMagnetHandlerLink"><img class="MyMenuIcon qbt-translatable" src="images/torrent-magnet.svg" alt="QBT_TR(Register to handle magnet links...)QBT_TR[CONTEXT=HttpServer]" width="16" height="16" / data-i18n="Register to handle magnet links...">Register to handle magnet links...</a></li>
                         </ul>
                     </li>
                     <li>
-                        <a class="returnFalse">QBT_TR(Help)QBT_TR[CONTEXT=MainWindow]</a>
+                        <a class="returnFalse qbt-translatable" data-i18n="Help">Help</a>
                         <ul>
-                            <li><a id="docsLink" target="_blank" href="https://wiki.qbittorrent.org/"><img class="MyMenuIcon" src="images/help-contents.svg" alt="QBT_TR(Documentation)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Documentation)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li class="divider"><a id="bugLink" target="_blank" href="https://www.qbittorrent.org/donate"><img class="MyMenuIcon" src="images/wallet-open.svg" alt="QBT_TR(Donate!)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(Donate!)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li><a id="aboutLink"><img class="MyMenuIcon" src="images/help-about.svg" alt="QBT_TR(About)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" />QBT_TR(About)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li><a id="docsLink" target="_blank" href="https://wiki.qbittorrent.org/"><img class="MyMenuIcon qbt-translatable" src="images/help-contents.svg" alt="QBT_TR(Documentation)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Documentation">Documentation</a></li>
+                            <li class="divider qbt-translatable"><a id="bugLink" target="_blank" href="https://www.qbittorrent.org/donate"><img class="MyMenuIcon" src="images/wallet-open.svg" alt="QBT_TR(Donate!)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="Donate!">Donate!</a></li>
+                            <li><a id="aboutLink"><img class="MyMenuIcon qbt-translatable" src="images/help-about.svg" alt="QBT_TR(About)QBT_TR[CONTEXT=MainWindow]" width="16" height="16" / data-i18n="About">About</a></li>
                         </ul>
                     </li>
                 </ul>
@@ -121,10 +121,10 @@
                 <a id="preferencesButton" class="divider"><img class="mochaToolButton" title="QBT_TR(Options)QBT_TR[CONTEXT=OptionsDialog]" src="images/configure.svg" alt="QBT_TR(Options)QBT_TR[CONTEXT=OptionsDialog]" width="24" height="24" /></a>
                 <div id="mainWindowTabs" class="toolbarTabs">
                     <ul id="mainWindowTabsList" class="tab-menu">
-                        <li id="transfersTabLink" class="selected"><a class="tab">QBT_TR(Transfers)QBT_TR[CONTEXT=MainWindow]</a></li>
-                        <li id="searchTabLink"><a class="tab">QBT_TR(Search)QBT_TR[CONTEXT=MainWindow]</a></li>
-                        <li id="rssTabLink"><a class="tab">QBT_TR(RSS)QBT_TR[CONTEXT=MainWindow]</a></li>
-                        <li id="logTabLink"><a class="tab">QBT_TR(Execution Log)QBT_TR[CONTEXT=MainWindow]</a></li>
+                        <li id="transfersTabLink" class="selected qbt-translatable"><a class="tab" data-i18n="Transfers">Transfers</a></li>
+                        <li id="searchTabLink"><a class="tab qbt-translatable" data-i18n="Search">Search</a></li>
+                        <li id="rssTabLink"><a class="tab qbt-translatable" data-i18n="RSS">RSS</a></li>
+                        <li id="logTabLink"><a class="tab qbt-translatable" data-i18n="Execution Log">Execution Log</a></li>
                     </ul>
                     <div class="clear"></div>
                 </div>

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -129,7 +129,7 @@
                     <div class="clear"></div>
                 </div>
                 <div id="torrentsFilterToolbar">
-                    <input type="text" id="torrentsFilterInput" placeholder="QBT_TR(Filter torrent list...)QBT_TR[CONTEXT=MainWindow]" autocorrect="off" autocapitalize="none" />
+                    <input type="text" id="torrentsFilterInput" class="qbt-translatable" data-i18n="[placeholder]Filter torrent list..." placeholder="Filter torrent list..." autocorrect="off" autocapitalize="none" />
                 </div>
             </div>
         </div>
@@ -137,98 +137,98 @@
         </div>
     </div>
     <ul id="torrentsTableMenu" class="contextMenu">
-        <li><a href="#start"><img src="images/torrent-start.svg" alt="QBT_TR(Resume)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Resume)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-        <li><a href="#pause"><img src="images/torrent-stop.svg" alt="QBT_TR(Pause)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Pause)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-        <li><a href="#forceStart"><img src="images/torrent-start-forced.svg" alt="QBT_TR(Force Resume)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Force Resume)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-        <li class="separator"><a href="#delete"><img src="images/list-remove.svg" alt="QBT_TR(Remove)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Remove)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li><a href="#start"><img src="images/torrent-start.svg" class="qbt-translatable" data-i18n="[alt]Resume" alt="Resume" /> QBT_TR(Resume)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li><a href="#pause"><img src="images/torrent-stop.svg" class="qbt-translatable" data-i18n="[alt]Pause" alt="Pause" /> QBT_TR(Pause)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li><a href="#forceStart"><img src="images/torrent-start-forced.svg" class="qbt-translatable" data-i18n="[alt]Force Resume" alt="Force Resume" /> QBT_TR(Force Resume)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li class="separator"><a href="#delete"><img src="images/list-remove.svg" class="qbt-translatable" data-i18n="[alt]Remove" alt="Remove" /> QBT_TR(Remove)QBT_TR[CONTEXT=TransferListWidget]</a></li>
         <li class="separator">
-            <a href="#setLocation"><img src="images/set-location.svg" alt="QBT_TR(Set location...)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Set location...)QBT_TR[CONTEXT=TransferListWidget]</a>
+            <a href="#setLocation"><img src="images/set-location.svg" class="qbt-translatable" data-i18n="[alt]Set location..." alt="Set location..." /> QBT_TR(Set location...)QBT_TR[CONTEXT=TransferListWidget]</a>
         </li>
         <li>
-            <a href="#rename"><img src="images/edit-rename.svg" alt="QBT_TR(Rename...)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Rename...)QBT_TR[CONTEXT=TransferListWidget]</a>
+            <a href="#rename"><img src="images/edit-rename.svg" class="qbt-translatable" data-i18n="[alt]Rename..." alt="Rename..." /> QBT_TR(Rename...)QBT_TR[CONTEXT=TransferListWidget]</a>
         </li>
         <li>
-            <a href="#renameFiles"><img src="images/edit-rename.svg" alt="QBT_TR(Rename Files...)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Rename Files...)QBT_TR[CONTEXT=TransferListWidget]</a>
+            <a href="#renameFiles"><img src="images/edit-rename.svg" class="qbt-translatable" data-i18n="[alt]Rename Files..." alt="Rename Files..." /> QBT_TR(Rename Files...)QBT_TR[CONTEXT=TransferListWidget]</a>
         </li>
         <li>
-            <a href="#Category" class="arrow-right"><img src="images/view-categories.svg" alt="QBT_TR(Category)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Category)QBT_TR[CONTEXT=TransferListWidget]</a>
+            <a href="#Category" class="arrow-right"><img src="images/view-categories.svg" class="qbt-translatable" data-i18n="[alt]Category" alt="Category" /> QBT_TR(Category)QBT_TR[CONTEXT=TransferListWidget]</a>
             <ul id="contextCategoryList" class="scrollableMenu"></ul>
         </li>
         <li>
-            <a href="#Tags" class="arrow-right"><img src="images/tags.svg" alt="QBT_TR(Tags)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Tags)QBT_TR[CONTEXT=TransferListWidget]</a>
+            <a href="#Tags" class="arrow-right"><img src="images/tags.svg" class="qbt-translatable" data-i18n="[alt]Tags" alt="Tags" /> QBT_TR(Tags)QBT_TR[CONTEXT=TransferListWidget]</a>
             <ul id="contextTagList" class="scrollableMenu"></ul>
         </li>
         <li>
-            <a href="#autoTorrentManagement"><img src="images/checked-completed.svg" alt="QBT_TR(Automatic Torrent Management)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Automatic Torrent Management)QBT_TR[CONTEXT=TransferListWidget]</a>
+            <a href="#autoTorrentManagement"><img src="images/checked-completed.svg" class="qbt-translatable" data-i18n="[alt]Automatic Torrent Management" alt="Automatic Torrent Management" /> QBT_TR(Automatic Torrent Management)QBT_TR[CONTEXT=TransferListWidget]</a>
         </li>
-        <li class="separator"><a href="#downloadLimit"><img src="images/download.svg" alt="QBT_TR(Limit download rate...)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Limit download rate...)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-        <li><a href="#uploadLimit"><img src="images/upload.svg" alt="QBT_TR(Limit upload rate...)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Limit upload rate...)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-        <li><a href="#shareRatio"><img src="images/ratio.svg" alt="QBT_TR(Limit share ratio...)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Limit share ratio...)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-        <li><a href="#superSeeding"><img src="images/checked-completed.svg" alt="QBT_TR(Super seeding mode)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Super seeding mode)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-        <li class="separator"><a href="#sequentialDownload"><img src="images/checked-completed.svg" alt="QBT_TR(Download in sequential order)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Download in sequential order)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-        <li><a href="#firstLastPiecePrio"><img src="images/checked-completed.svg" alt="QBT_TR(Download first and last pieces first)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Download first and last pieces first)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-        <li class="separator"><a href="#forceRecheck"><img src="images/force-recheck.svg" alt="QBT_TR(Force recheck)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Force recheck)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-        <li><a href="#forceReannounce"><img src="images/reannounce.svg" alt="QBT_TR(Force reannounce)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Force reannounce)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li class="separator"><a href="#downloadLimit"><img src="images/download.svg" class="qbt-translatable" data-i18n="[alt]Limit download rate..." alt="Limit download rate..." /> QBT_TR(Limit download rate...)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li><a href="#uploadLimit"><img src="images/upload.svg" class="qbt-translatable" data-i18n="[alt]Limit upload rate..." alt="Limit upload rate..." /> QBT_TR(Limit upload rate...)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li><a href="#shareRatio"><img src="images/ratio.svg" class="qbt-translatable" data-i18n="[alt]Limit share ratio..." alt="Limit share ratio..." /> QBT_TR(Limit share ratio...)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li><a href="#superSeeding"><img src="images/checked-completed.svg" class="qbt-translatable" data-i18n="[alt]Super seeding mode" alt="Super seeding mode" /> QBT_TR(Super seeding mode)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li class="separator"><a href="#sequentialDownload"><img src="images/checked-completed.svg" class="qbt-translatable" data-i18n="[alt]Download in sequential order" alt="Download in sequential order" /> QBT_TR(Download in sequential order)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li><a href="#firstLastPiecePrio"><img src="images/checked-completed.svg" class="qbt-translatable" data-i18n="[alt]Download first and last pieces first" alt="Download first and last pieces first" /> QBT_TR(Download first and last pieces first)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li class="separator"><a href="#forceRecheck"><img src="images/force-recheck.svg" class="qbt-translatable" data-i18n="[alt]Force recheck" alt="Force recheck" /> QBT_TR(Force recheck)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li><a href="#forceReannounce"><img src="images/reannounce.svg" class="qbt-translatable" data-i18n="[alt]Force reannounce" alt="Force reannounce" /> QBT_TR(Force reannounce)QBT_TR[CONTEXT=TransferListWidget]</a></li>
         <li id="queueingMenuItems" class="separator">
             <a href="#queue" class="arrow-right"><span style="display: inline-block; width:16px"></span> QBT_TR(Queue)QBT_TR[CONTEXT=TransferListWidget]</a>
             <ul>
-                <li><a href="#queueTop"><img src="images/go-top.svg" alt="QBT_TR(Move to top)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Move to top)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-                <li><a href="#queueUp"><img src="images/go-up.svg" alt="QBT_TR(Move up)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Move up)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-                <li><a href="#queueDown"><img src="images/go-down.svg" alt="QBT_TR(Move down)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Move down)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-                <li><a href="#queueBottom"><img src="images/go-bottom.svg" alt="QBT_TR(Move to bottom)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Move to bottom)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+                <li><a href="#queueTop"><img src="images/go-top.svg" class="qbt-translatable" data-i18n="[alt]Move to top" alt="Move to top" /> QBT_TR(Move to top)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+                <li><a href="#queueUp"><img src="images/go-up.svg" class="qbt-translatable" data-i18n="[alt]Move up" alt="Move up" /> QBT_TR(Move up)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+                <li><a href="#queueDown"><img src="images/go-down.svg" class="qbt-translatable" data-i18n="[alt]Move down" alt="Move down" /> QBT_TR(Move down)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+                <li><a href="#queueBottom"><img src="images/go-bottom.svg" class="qbt-translatable" data-i18n="[alt]Move to bottom" alt="Move to bottom" /> QBT_TR(Move to bottom)QBT_TR[CONTEXT=TransferListWidget]</a></li>
             </ul>
         </li>
         <li>
-            <a href="#" class="arrow-right"><img src="images/edit-copy.svg" alt="QBT_TR(Copy)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Copy)QBT_TR[CONTEXT=TransferListWidget]</a>
+            <a href="#" class="arrow-right"><img src="images/edit-copy.svg" class="qbt-translatable" data-i18n="[alt]Copy" alt="Copy" /> QBT_TR(Copy)QBT_TR[CONTEXT=TransferListWidget]</a>
             <ul>
-                <li><a href="#" id="copyName" class="copyToClipboard"><img src="images/name.svg" alt="QBT_TR(Name)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Name)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-                <li><a href="#" id="copyInfohash1" class="copyToClipboard"><img src="images/hash.svg" alt="QBT_TR(Info hash v1)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Info hash v1)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-                <li><a href="#" id="copyInfohash2" class="copyToClipboard"><img src="images/hash.svg" alt="QBT_TR(Info hash v2)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Info hash v2)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-                <li><a href="#" id="copyMagnetLink" class="copyToClipboard"><img src="images/torrent-magnet.svg" alt="QBT_TR(Magnet link)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Magnet link)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-                <li><a href="#" id="copyID" class="copyToClipboard"><img src="images/help-about.svg" alt="QBT_TR(Torrent ID)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Torrent ID)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-                <li><a href="#" id="copyComment" class="copyToClipboard"><img src="images/edit-copy.svg" alt="QBT_TR(Comment)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Comment)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+                <li><a href="#" id="copyName" class="copyToClipboard"><img src="images/name.svg" class="qbt-translatable" data-i18n="[alt]Name" alt="Name" /> QBT_TR(Name)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+                <li><a href="#" id="copyInfohash1" class="copyToClipboard"><img src="images/hash.svg" class="qbt-translatable" data-i18n="[alt]Info hash v1" alt="Info hash v1" /> QBT_TR(Info hash v1)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+                <li><a href="#" id="copyInfohash2" class="copyToClipboard"><img src="images/hash.svg" class="qbt-translatable" data-i18n="[alt]Info hash v2" alt="Info hash v2" /> QBT_TR(Info hash v2)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+                <li><a href="#" id="copyMagnetLink" class="copyToClipboard"><img src="images/torrent-magnet.svg" class="qbt-translatable" data-i18n="[alt]Magnet link" alt="Magnet link" /> QBT_TR(Magnet link)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+                <li><a href="#" id="copyID" class="copyToClipboard"><img src="images/help-about.svg" class="qbt-translatable" data-i18n="[alt]Torrent ID" alt="Torrent ID" /> QBT_TR(Torrent ID)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+                <li><a href="#" id="copyComment" class="copyToClipboard"><img src="images/edit-copy.svg" class="qbt-translatable" data-i18n="[alt]Comment" alt="Comment" /> QBT_TR(Comment)QBT_TR[CONTEXT=TransferListWidget]</a></li>
             </ul>
         </li>
         <li>
-            <a href="#exportTorrent"><img src="images/edit-copy.svg" alt="QBT_TR(Export .torrent)QBT_TR[CONTEXT=TransferListWidget]" /> QBT_TR(Export .torrent)QBT_TR[CONTEXT=TransferListWidget]</a>
+            <a href="#exportTorrent"><img src="images/edit-copy.svg" class="qbt-translatable" data-i18n="[alt]Export .torrent" alt="Export .torrent" /> QBT_TR(Export .torrent)QBT_TR[CONTEXT=TransferListWidget]</a>
         </li>
     </ul>
     <ul id="categoriesFilterMenu" class="contextMenu">
-        <li><a href="#createCategory"><img src="images/list-add.svg" alt="QBT_TR(Add category...)QBT_TR[CONTEXT=CategoryFilterWidget]" /> QBT_TR(Add category...)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
-        <li><a href="#createSubcategory"><img src="images/list-add.svg" alt="QBT_TR(Add subcategory...)QBT_TR[CONTEXT=CategoryFilterWidget]" /> QBT_TR(Add subcategory...)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
-        <li><a href="#editCategory"><img src="images/edit-rename.svg" alt="QBT_TR(Edit category...)QBT_TR[CONTEXT=CategoryFilterWidget]" /> QBT_TR(Edit category...)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
-        <li><a href="#deleteCategory"><img src="images/list-remove.svg" alt="QBT_TR(Remove category)QBT_TR[CONTEXT=CategoryFilterWidget]" /> QBT_TR(Remove category)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
-        <li><a href="#deleteUnusedCategories"><img src="images/list-remove.svg" alt="QBT_TR(Remove unused categories)QBT_TR[CONTEXT=CategoryFilterWidget]" /> QBT_TR(Remove unused categories)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
-        <li class="separator"><a href="#startTorrentsByCategory"><img src="images/torrent-start.svg" alt="QBT_TR(Resume torrents)QBT_TR[CONTEXT=CategoryFilterWidget]" /> QBT_TR(Resume torrents)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
-        <li><a href="#pauseTorrentsByCategory"><img src="images/torrent-stop.svg" alt="QBT_TR(Pause torrents)QBT_TR[CONTEXT=CategoryFilterWidget]" /> QBT_TR(Pause torrents)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
-        <li><a href="#deleteTorrentsByCategory"><img src="images/list-remove.svg" alt="QBT_TR(Remove torrents)QBT_TR[CONTEXT=CategoryFilterWidget]" /> QBT_TR(Remove torrents)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
+        <li><a href="#createCategory"><img src="images/list-add.svg" class="qbt-translatable" data-i18n="[alt]Add category..." alt="Add category..." /> QBT_TR(Add category...)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
+        <li><a href="#createSubcategory"><img src="images/list-add.svg" class="qbt-translatable" data-i18n="[alt]Add subcategory..." alt="Add subcategory..." /> QBT_TR(Add subcategory...)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
+        <li><a href="#editCategory"><img src="images/edit-rename.svg" class="qbt-translatable" data-i18n="[alt]Edit category..." alt="Edit category..." /> QBT_TR(Edit category...)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
+        <li><a href="#deleteCategory"><img src="images/list-remove.svg" class="qbt-translatable" data-i18n="[alt]Remove category" alt="Remove category" /> QBT_TR(Remove category)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
+        <li><a href="#deleteUnusedCategories"><img src="images/list-remove.svg" class="qbt-translatable" data-i18n="[alt]Remove unused categories" alt="Remove unused categories" /> QBT_TR(Remove unused categories)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
+        <li class="separator"><a href="#startTorrentsByCategory"><img src="images/torrent-start.svg" class="qbt-translatable" data-i18n="[alt]Resume torrents" alt="Resume torrents" /> QBT_TR(Resume torrents)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
+        <li><a href="#pauseTorrentsByCategory"><img src="images/torrent-stop.svg" class="qbt-translatable" data-i18n="[alt]Pause torrents" alt="Pause torrents" /> QBT_TR(Pause torrents)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
+        <li><a href="#deleteTorrentsByCategory"><img src="images/list-remove.svg" class="qbt-translatable" data-i18n="[alt]Remove torrents" alt="Remove torrents" /> QBT_TR(Remove torrents)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
     </ul>
     <ul id="tagsFilterMenu" class="contextMenu">
-        <li><a href="#createTag"><img src="images/list-add.svg" alt="QBT_TR(Add tag...)QBT_TR[CONTEXT=TagFilterWidget]" /> QBT_TR(Add tag...)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
-        <li><a href="#deleteTag"><img src="images/list-remove.svg" alt="QBT_TR(Remove tag)QBT_TR[CONTEXT=TagFilterWidget]" /> QBT_TR(Remove tag)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
-        <li><a href="#deleteUnusedTags"><img src="images/list-remove.svg" alt="QBT_TR(Remove unused tags)QBT_TR[CONTEXT=TagFilterWidget]" /> QBT_TR(Remove unused tags)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
-        <li class="separator"><a href="#startTorrentsByTag"><img src="images/torrent-start.svg" alt="QBT_TR(Resume torrents)QBT_TR[CONTEXT=TagFilterWidget]" /> QBT_TR(Resume torrents)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
-        <li><a href="#pauseTorrentsByTag"><img src="images/torrent-stop.svg" alt="QBT_TR(Pause torrents)QBT_TR[CONTEXT=TagFilterWidget]" /> QBT_TR(Pause torrents)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
-        <li><a href="#deleteTorrentsByTag"><img src="images/list-remove.svg" alt="QBT_TR(Remove torrents)QBT_TR[CONTEXT=TagFilterWidget]" /> QBT_TR(Remove torrents)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
+        <li><a href="#createTag"><img src="images/list-add.svg" class="qbt-translatable" data-i18n="[alt]Add tag..." alt="Add tag..." /> QBT_TR(Add tag...)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
+        <li><a href="#deleteTag"><img src="images/list-remove.svg" class="qbt-translatable" data-i18n="[alt]Remove tag" alt="Remove tag" /> QBT_TR(Remove tag)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
+        <li><a href="#deleteUnusedTags"><img src="images/list-remove.svg" class="qbt-translatable" data-i18n="[alt]Remove unused tags" alt="Remove unused tags" /> QBT_TR(Remove unused tags)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
+        <li class="separator"><a href="#startTorrentsByTag"><img src="images/torrent-start.svg" class="qbt-translatable" data-i18n="[alt]Resume torrents" alt="Resume torrents" /> QBT_TR(Resume torrents)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
+        <li><a href="#pauseTorrentsByTag"><img src="images/torrent-stop.svg" class="qbt-translatable" data-i18n="[alt]Pause torrents" alt="Pause torrents" /> QBT_TR(Pause torrents)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
+        <li><a href="#deleteTorrentsByTag"><img src="images/list-remove.svg" class="qbt-translatable" data-i18n="[alt]Remove torrents" alt="Remove torrents" /> QBT_TR(Remove torrents)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
     </ul>
     <ul id="trackersFilterMenu" class="contextMenu">
-        <li><a href="#resumeTorrentsByTracker"><img src="images/torrent-start.svg" alt="QBT_TR(Resume torrents)QBT_TR[CONTEXT=TrackerFiltersList]" /> QBT_TR(Resume torrents)QBT_TR[CONTEXT=TrackerFiltersList]</a></li>
-        <li><a href="#pauseTorrentsByTracker"><img src="images/torrent-stop.svg" alt="QBT_TR(Pause torrents)QBT_TR[CONTEXT=TrackerFiltersList]" /> QBT_TR(Pause torrents)QBT_TR[CONTEXT=TrackerFiltersList]</a></li>
-        <li><a href="#deleteTorrentsByTracker"><img src="images/list-remove.svg" alt="QBT_TR(Remove torrents)QBT_TR[CONTEXT=TrackerFiltersList]" /> QBT_TR(Remove torrents)QBT_TR[CONTEXT=TrackerFiltersList]</a></li>
+        <li><a href="#resumeTorrentsByTracker"><img src="images/torrent-start.svg" class="qbt-translatable" data-i18n="[alt]Resume torrents" alt="Resume torrents" /> QBT_TR(Resume torrents)QBT_TR[CONTEXT=TrackerFiltersList]</a></li>
+        <li><a href="#pauseTorrentsByTracker"><img src="images/torrent-stop.svg" class="qbt-translatable" data-i18n="[alt]Pause torrents" alt="Pause torrents" /> QBT_TR(Pause torrents)QBT_TR[CONTEXT=TrackerFiltersList]</a></li>
+        <li><a href="#deleteTorrentsByTracker"><img src="images/list-remove.svg" class="qbt-translatable" data-i18n="[alt]Remove torrents" alt="Remove torrents" /> QBT_TR(Remove torrents)QBT_TR[CONTEXT=TrackerFiltersList]</a></li>
     </ul>
     <ul id="torrentTrackersMenu" class="contextMenu">
-        <li><a href="#AddTracker"><img src="images/list-add.svg" alt="QBT_TR(Add trackers...)QBT_TR[CONTEXT=TrackerListWidget]" /> QBT_TR(Add trackers...)QBT_TR[CONTEXT=TrackerListWidget]</a></li>
-        <li class="separator"><a href="#EditTracker"><img src="images/edit-rename.svg" alt="QBT_TR(Edit tracker URL...)QBT_TR[CONTEXT=TrackerListWidget]" /> QBT_TR(Edit tracker URL...)QBT_TR[CONTEXT=TrackerListWidget]</a></li>
-        <li><a href="#RemoveTracker"><img src="images/list-remove.svg" alt="QBT_TR(Remove tracker)QBT_TR[CONTEXT=TrackerListWidget]" /> QBT_TR(Remove tracker)QBT_TR[CONTEXT=TrackerListWidget]</a></li>
-        <li><a href="#CopyTrackerUrl" id="CopyTrackerUrl"><img src="images/edit-copy.svg" alt="QBT_TR(Copy tracker URL)QBT_TR[CONTEXT=TrackerListWidget]" /> QBT_TR(Copy tracker URL)QBT_TR[CONTEXT=TrackerListWidget]</a></li>
+        <li><a href="#AddTracker"><img src="images/list-add.svg" class="qbt-translatable" data-i18n="[alt]Add trackers..." alt="Add trackers..." /> QBT_TR(Add trackers...)QBT_TR[CONTEXT=TrackerListWidget]</a></li>
+        <li class="separator"><a href="#EditTracker"><img src="images/edit-rename.svg" class="qbt-translatable" data-i18n="[alt]Edit tracker URL..." alt="Edit tracker URL..." /> QBT_TR(Edit tracker URL...)QBT_TR[CONTEXT=TrackerListWidget]</a></li>
+        <li><a href="#RemoveTracker"><img src="images/list-remove.svg" class="qbt-translatable" data-i18n="[alt]Remove tracker" alt="Remove tracker" /> QBT_TR(Remove tracker)QBT_TR[CONTEXT=TrackerListWidget]</a></li>
+        <li><a href="#CopyTrackerUrl" id="CopyTrackerUrl"><img src="images/edit-copy.svg" class="qbt-translatable" data-i18n="[alt]Copy tracker URL" alt="Copy tracker URL" /> QBT_TR(Copy tracker URL)QBT_TR[CONTEXT=TrackerListWidget]</a></li>
     </ul>
     <ul id="torrentPeersMenu" class="contextMenu">
-        <li><a href="#addPeer"><img src="images/peers-add.svg" alt="QBT_TR(Add peers...)QBT_TR[CONTEXT=PeerListWidget]" /> QBT_TR(Add peers...)QBT_TR[CONTEXT=PeerListWidget]</a></li>
-        <li><a href="#copyPeer" id="CopyPeerInfo"><img src="images/edit-copy.svg" alt="QBT_TR(Copy IP:port)QBT_TR[CONTEXT=PeerListWidget]" /> QBT_TR(Copy IP:port)QBT_TR[CONTEXT=PeerListWidget]</a></li>
-        <li class="separator"><a href="#banPeer"><img src="images/peers-remove.svg" alt="QBT_TR(Ban peer permanently)QBT_TR[CONTEXT=PeerListWidget]" /> QBT_TR(Ban peer permanently)QBT_TR[CONTEXT=PeerListWidget]</a></li>
+        <li><a href="#addPeer"><img src="images/peers-add.svg" class="qbt-translatable" data-i18n="[alt]Add peers..." alt="Add peers..." /> QBT_TR(Add peers...)QBT_TR[CONTEXT=PeerListWidget]</a></li>
+        <li><a href="#copyPeer" id="CopyPeerInfo"><img src="images/edit-copy.svg" class="qbt-translatable" data-i18n="[alt]Copy IP:port" alt="Copy IP:port" /> QBT_TR(Copy IP:port)QBT_TR[CONTEXT=PeerListWidget]</a></li>
+        <li class="separator"><a href="#banPeer"><img src="images/peers-remove.svg" class="qbt-translatable" data-i18n="[alt]Ban peer permanently" alt="Ban peer permanently" /> QBT_TR(Ban peer permanently)QBT_TR[CONTEXT=PeerListWidget]</a></li>
     </ul>
     <ul id="torrentFilesMenu" class="contextMenu">
-        <li><a href="#Rename"><img src="images/edit-rename.svg" alt="QBT_TR(Rename...)QBT_TR[CONTEXT=PropertiesWidget]" /> QBT_TR(Rename...)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
+        <li><a href="#Rename"><img src="images/edit-rename.svg" class="qbt-translatable" data-i18n="[alt]Rename..." alt="Rename..." /> QBT_TR(Rename...)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
         <li class="separator">
             <a href="#FilePrio" class="arrow-right"><span style="display: inline-block; width: 16px;"></span> QBT_TR(Priority)QBT_TR[CONTEXT=PropertiesWidget]</a>
             <ul>
@@ -240,7 +240,7 @@
         </li>
     </ul>
     <ul id="multiRenameFilesMenu" class="contextMenu">
-        <li><a href="#ToggleSelection"><img src="images/edit-rename.svg" alt="QBT_TR(Toggle Selection)QBT_TR[CONTEXT=PropertiesWidget]" /> QBT_TR(Toggle Selection)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
+        <li><a href="#ToggleSelection"><img src="images/edit-rename.svg" class="qbt-translatable" data-i18n="[alt]Toggle Selection" alt="Toggle Selection" /> QBT_TR(Toggle Selection)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
     </ul>
     <div id="desktopFooterWrapper">
         <div id="desktopFooter">
@@ -251,13 +251,13 @@
                     <td class="statusBarSeparator"></td>
                     <td id="DHTNodes"></td>
                     <td class="statusBarSeparator"></td>
-                    <td><img id="connectionStatus" alt="QBT_TR(Connection status: Firewalled)QBT_TR[CONTEXT=MainWindow]" title="QBT_TR(Connection status: Firewalled)QBT_TR[CONTEXT=MainWindow]" src="images/firewalled.svg" style="height: 1.5em;" /></td>
+                    <td><img id="connectionStatus" class="qbt-translatable" data-i18n="[alt]Connection status: Firewalled" alt="Connection status: Firewalled" title="QBT_TR(Connection status: Firewalled)QBT_TR[CONTEXT=MainWindow]" src="images/firewalled.svg" style="height: 1.5em;" /></td>
                     <td class="statusBarSeparator"></td>
-                    <td style="cursor:pointer;"><img id="alternativeSpeedLimits" alt="QBT_TR(Alternative speed limits: Off)QBT_TR[CONTEXT=MainWindow]" title="QBT_TR(Alternative speed limits: Off)QBT_TR[CONTEXT=MainWindow]" src="images/slow_off.svg" style="height: 1.5em;" /></td>
+                    <td style="cursor:pointer;"><img id="alternativeSpeedLimits" class="qbt-translatable" data-i18n="[alt]Alternative speed limits: Off" alt="Alternative speed limits: Off" title="QBT_TR(Alternative speed limits: Off)QBT_TR[CONTEXT=MainWindow]" src="images/slow_off.svg" style="height: 1.5em;" /></td>
                     <td class="statusBarSeparator"></td>
-                    <td class="speedLabel"><img src="images/downloading.svg" alt="QBT_TR(Download speed icon)QBT_TR[CONTEXT=MainWindow]" style="height: 1.5em; padding-right: 5px; margin-bottom: -4px;"><span id="DlInfos"></span></td>
+                    <td class="speedLabel"><img src="images/downloading.svg" class="qbt-translatable" data-i18n="[alt]Download speed icon" alt="Download speed icon" style="height: 1.5em; padding-right: 5px; margin-bottom: -4px;"><span id="DlInfos"></span></td>
                     <td class="statusBarSeparator"></td>
-                    <td class="speedLabel"><img src="images/upload.svg" alt="QBT_TR(Upload speed icon)QBT_TR[CONTEXT=MainWindow]" style="height: 1.5em; padding-right: 5px; margin-bottom: -4px;"><span id="UpInfos"></span></td>
+                    <td class="speedLabel"><img src="images/upload.svg" class="qbt-translatable" data-i18n="[alt]Upload speed icon" alt="Upload speed icon" style="height: 1.5em; padding-right: 5px; margin-bottom: -4px;"><span id="UpInfos"></span></td>
                 </tr>
             </table>
         </div>

--- a/src/webui/www/private/newcategory.html
+++ b/src/webui/www/private/newcategory.html
@@ -94,7 +94,7 @@
                                 }).send();
                             },
                             onFailure: function() {
-                                alert("QBT_TR(Unable to create category)QBT_TR[CONTEXT=HttpServer] " + window.qBittorrent.Misc.escapeHtml(categoryName));
+                                alert(`${i18next.t("Unable to create category")} ${window.qBittorrent.Misc.escapeHtml(categoryName)}`);
                             }
                         }).send();
                         break;

--- a/src/webui/www/private/newcategory.html
+++ b/src/webui/www/private/newcategory.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(New Category)QBT_TR[CONTEXT=TransferListWidget]</title>
+    <title class="qbt-translatable" data-i18n="New Category">New Category</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
@@ -136,9 +136,9 @@
 
 <body>
     <div style="padding: 10px 10px 0px 10px;">
-        <p style="font-weight: bold;">QBT_TR(Category)QBT_TR[CONTEXT=TransferListWidget]:</p>
+        <p style="font-weight: bold;" class="qbt-translatable" data-i18n="Category">Category:</p>
         <input type="text" id="categoryName" style="width: 99%;" />
-        <p style="font-weight: bold;">QBT_TR(Save path)QBT_TR[CONTEXT=TransferListWidget]:</p>
+        <p style="font-weight: bold;" class="qbt-translatable" data-i18n="Save path">Save path:</p>
         <input type="text" id="savePath" style="width: 99%;" />
         <div style="text-align: center; padding-top: 10px;">
             <input type="button" value="QBT_TR(Add)QBT_TR[CONTEXT=HttpServer]" id="categoryNameButton" />

--- a/src/webui/www/private/newcategory.html
+++ b/src/webui/www/private/newcategory.html
@@ -141,7 +141,7 @@
         <p style="font-weight: bold;" class="qbt-translatable" data-i18n="Save path">Save path:</p>
         <input type="text" id="savePath" style="width: 99%;" />
         <div style="text-align: center; padding-top: 10px;">
-            <input type="button" value="QBT_TR(Add)QBT_TR[CONTEXT=HttpServer]" id="categoryNameButton" />
+            <input type="button" class="qbt-translatable" data-i18n="[value]Add" value="Add" id="categoryNameButton" />
         </div>
     </div>
 </body>

--- a/src/webui/www/private/newcategory.html
+++ b/src/webui/www/private/newcategory.html
@@ -62,7 +62,7 @@
                     if ((name === null) || (name === ""))
                         return false;
                     if (name.match("^([^\\\\\\/]|[^\\\\\\/]([^\\\\\\/]|\\/(?=[^\\/]))*[^\\\\\\/])$") === null) {
-                        alert("QBT_TR(Invalid category name:\nPlease do not use any special characters in the category name.)QBT_TR[CONTEXT=HttpServer]");
+                        alert(i18next.t("Invalid category name:\nPlease do not use any special characters in the category name."));
                         return false;
                     }
                     return true;

--- a/src/webui/www/private/newfeed.html
+++ b/src/webui/www/private/newfeed.html
@@ -36,7 +36,7 @@
                 // check field
                 const feedURL = $('feedURL').value.trim();
                 if (feedURL === '') {
-                    alert('QBT_TR(Name cannot be empty)QBT_TR[CONTEXT=HttpServer]');
+                    alert(i18next.t('Name cannot be empty'));
                     return;
                 }
 

--- a/src/webui/www/private/newfeed.html
+++ b/src/webui/www/private/newfeed.html
@@ -69,7 +69,7 @@
         <p style="font-weight: bold;" class="qbt-translatable" data-i18n="Feed URL:">Feed URL:</p>
         <input type="text" id="feedURL" style="width: 320px;" />
         <div style="text-align: center; padding-top: 10px;">
-            <input type="button" value="QBT_TR(OK)QBT_TR[CONTEXT=HttpServer]" id="submitButton" />
+            <input type="button" class="qbt-translatable" data-i18n="[value]OK" value="OK" id="submitButton" />
         </div>
     </div>
 </body>

--- a/src/webui/www/private/newfeed.html
+++ b/src/webui/www/private/newfeed.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(Please type a RSS feed URL)QBT_TR[CONTEXT=RSSWidget]</title>
+    <title class="qbt-translatable" data-i18n="Please type a RSS feed URL">Please type a RSS feed URL</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
@@ -66,7 +66,7 @@
 
 <body>
     <div style="padding: 10px 10px 0px 10px;">
-        <p style="font-weight: bold;">QBT_TR(Feed URL:)QBT_TR[CONTEXT=RSSWidget]</p>
+        <p style="font-weight: bold;" class="qbt-translatable" data-i18n="Feed URL:">Feed URL:</p>
         <input type="text" id="feedURL" style="width: 320px;" />
         <div style="text-align: center; padding-top: 10px;">
             <input type="button" value="QBT_TR(OK)QBT_TR[CONTEXT=HttpServer]" id="submitButton" />

--- a/src/webui/www/private/newfolder.html
+++ b/src/webui/www/private/newfolder.html
@@ -68,7 +68,7 @@
         <p style="font-weight: bold;" class="qbt-translatable" data-i18n="Folder name:">Folder name:</p>
         <input type="text" id="folderName" style="width: 320px;" />
         <div style="text-align: center; padding-top: 10px;">
-            <input type="button" value="QBT_TR(OK)QBT_TR[CONTEXT=HttpServer]" id="submitButton" />
+            <input type="button" class="qbt-translatable" data-i18n="[value]OK" value="OK" id="submitButton" />
         </div>
     </div>
 </body>

--- a/src/webui/www/private/newfolder.html
+++ b/src/webui/www/private/newfolder.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(Please choose a folder name)QBT_TR[CONTEXT=RSSWidget]</title>
+    <title class="qbt-translatable" data-i18n="Please choose a folder name">Please choose a folder name</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
@@ -65,7 +65,7 @@
 
 <body>
     <div style="padding: 10px 10px 0px 10px;">
-        <p style="font-weight: bold;">QBT_TR(Folder name:)QBT_TR[CONTEXT=RSSWidget]</p>
+        <p style="font-weight: bold;" class="qbt-translatable" data-i18n="Folder name:">Folder name:</p>
         <input type="text" id="folderName" style="width: 320px;" />
         <div style="text-align: center; padding-top: 10px;">
             <input type="button" value="QBT_TR(OK)QBT_TR[CONTEXT=HttpServer]" id="submitButton" />

--- a/src/webui/www/private/newfolder.html
+++ b/src/webui/www/private/newfolder.html
@@ -36,7 +36,7 @@
                 // check field
                 const folderName = $('folderName').value.trim();
                 if (folderName === '') {
-                    alert('QBT_TR(Name cannot be empty)QBT_TR[CONTEXT=HttpServer]');
+                    alert(i18next.t('Name cannot be empty'));
                     return;
                 }
 

--- a/src/webui/www/private/newrule.html
+++ b/src/webui/www/private/newrule.html
@@ -35,7 +35,7 @@
                 // check field
                 const name = $('name').value.trim();
                 if (name === '') {
-                    alert('QBT_TR(Name cannot be empty)QBT_TR[CONTEXT=HttpServer]');
+                    alert(i18next.t('Name cannot be empty'));
                     return;
                 }
                 $('submitButton').disabled = true;

--- a/src/webui/www/private/newrule.html
+++ b/src/webui/www/private/newrule.html
@@ -61,7 +61,7 @@
         <p class="qbt-translatable" data-i18n="Please type the name of the new download rule.">Please type the name of the new download rule.</p>
         <input type="text" id="name" style="width: 320px;" />
         <div style="text-align: center; padding-top: 10px;">
-            <input type="button" value="QBT_TR(OK)QBT_TR[CONTEXT=HttpServer]" id="submitButton" />
+            <input type="button" class="qbt-translatable" data-i18n="[value]OK" value="OK" id="submitButton" />
         </div>
     </div>
 </body>

--- a/src/webui/www/private/newrule.html
+++ b/src/webui/www/private/newrule.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(New rule name)QBT_TR[CONTEXT=AutomatedRssDownloader]</title>
+    <title class="qbt-translatable" data-i18n="New rule name">New rule name</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
@@ -58,7 +58,7 @@
 
 <body>
     <div style="padding: 10px 10px 0px 10px;">
-        <p>QBT_TR(Please type the name of the new download rule.)QBT_TR[CONTEXT=AutomatedRssDownloader]</p>
+        <p class="qbt-translatable" data-i18n="Please type the name of the new download rule.">Please type the name of the new download rule.</p>
         <input type="text" id="name" style="width: 320px;" />
         <div style="text-align: center; padding-top: 10px;">
             <input type="button" value="QBT_TR(OK)QBT_TR[CONTEXT=HttpServer]" id="submitButton" />

--- a/src/webui/www/private/newtag.html
+++ b/src/webui/www/private/newtag.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(Add Tags)QBT_TR[CONTEXT=TransferListWidget]</title>
+    <title class="qbt-translatable" data-i18n="Add Tags">Add Tags</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
@@ -94,7 +94,7 @@
 
 <body>
     <div style="padding: 10px 10px 0px 10px;">
-        <p id="legendText" style="font-weight: bold;">QBT_TR(Comma-separated tags:)QBT_TR[CONTEXT=TransferListWidget]</p>
+        <p id="legendText" style="font-weight: bold;" class="qbt-translatable" data-i18n="Comma-separated tags:">Comma-separated tags:</p>
         <input type="text" id="tagName" style="width: 99%;" />
         <div style="text-align: center; padding-top: 10px;">
             <input type="button" value="QBT_TR(Add)QBT_TR[CONTEXT=HttpServer]" id="tagNameButton" />

--- a/src/webui/www/private/newtag.html
+++ b/src/webui/www/private/newtag.html
@@ -34,7 +34,7 @@
             const uriHashes = window.qBittorrent.Misc.safeTrim(new URI().getData('hashes'));
 
             if (uriAction === 'create')
-                $('legendText').innerText = 'QBT_TR(Tag:)QBT_TR[CONTEXT=TagFilterWidget]';
+                $('legendText').innerText = i18next.t('Tag:');
 
             $('tagName').focus();
 
@@ -47,7 +47,7 @@
                     if ((name === null) || (name === ""))
                         return false;
                     if (name.indexOf(",") >= 0) {
-                        alert("QBT_TR(Invalid tag name)QBT_TR[CONTEXT=TagFilterWidget]");
+                        alert(i18next.t("Invalid tag name"));
                         return false;
                     }
                     return true;

--- a/src/webui/www/private/newtag.html
+++ b/src/webui/www/private/newtag.html
@@ -97,7 +97,7 @@
         <p id="legendText" style="font-weight: bold;" class="qbt-translatable" data-i18n="Comma-separated tags:">Comma-separated tags:</p>
         <input type="text" id="tagName" style="width: 99%;" />
         <div style="text-align: center; padding-top: 10px;">
-            <input type="button" value="QBT_TR(Add)QBT_TR[CONTEXT=HttpServer]" id="tagNameButton" />
+            <input type="button" class="qbt-translatable" data-i18n="[value]Add" value="Add" id="tagNameButton" />
         </div>
     </div>
 </body>

--- a/src/webui/www/private/rename.html
+++ b/src/webui/www/private/rename.html
@@ -67,7 +67,7 @@
         <p style="font-weight: bold;" class="qbt-translatable" data-i18n="New name">New name:</p>
         <input type="text" id="rename" style="width: 99%;" />
         <div style="text-align: center; padding-top: 10px;">
-            <input type="button" value="QBT_TR(Save)QBT_TR[CONTEXT=HttpServer]" id="renameButton" />
+            <input type="button" class="qbt-translatable" data-i18n="[value]Save" value="Save" id="renameButton" />
         </div>
     </div>
 </body>

--- a/src/webui/www/private/rename.html
+++ b/src/webui/www/private/rename.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(Rename)QBT_TR[CONTEXT=TransferListWidget]</title>
+    <title class="qbt-translatable" data-i18n="Rename">Rename</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
@@ -64,7 +64,7 @@
 
 <body>
     <div style="padding: 10px 10px 0px 10px;">
-        <p style="font-weight: bold;">QBT_TR(New name)QBT_TR[CONTEXT=TransferListWidget]:</p>
+        <p style="font-weight: bold;" class="qbt-translatable" data-i18n="New name">New name:</p>
         <input type="text" id="rename" style="width: 99%;" />
         <div style="text-align: center; padding-top: 10px;">
             <input type="button" value="QBT_TR(Save)QBT_TR[CONTEXT=HttpServer]" id="renameButton" />

--- a/src/webui/www/private/rename_feed.html
+++ b/src/webui/www/private/rename_feed.html
@@ -40,12 +40,12 @@
                 // check field
                 const newPath = $('rename').value.trim();
                 if (newPath === '') {
-                    alert('QBT_TR(Name cannot be empty)QBT_TR[CONTEXT=HttpServer]');
+                    alert(i18next.t('Name cannot be empty'));
                     return;
                 }
 
                 if (newPath === oldPath) {
-                    alert('QBT_TR(Name is unchanged)QBT_TR[CONTEXT=HttpServer]');
+                    alert(i18next.t('Name is unchanged'));
                     return;
                 }
 

--- a/src/webui/www/private/rename_feed.html
+++ b/src/webui/www/private/rename_feed.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(Please choose a new name for this RSS feed)QBT_TR[CONTEXT=RSSWidget]</title>
+    <title class="qbt-translatable" data-i18n="Please choose a new name for this RSS feed">Please choose a new name for this RSS feed</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
@@ -76,7 +76,7 @@
 
 <body>
     <div style="padding: 10px 10px 0px 10px;">
-        <p style="font-weight: bold;">QBT_TR(New feed name:)QBT_TR[CONTEXT=RSSWidget]</p>
+        <p style="font-weight: bold;" class="qbt-translatable" data-i18n="New feed name:">New feed name:</p>
         <input type="text" id="rename" style="width: 320px;" />
         <div style="text-align: center; padding-top: 10px;">
             <input type="button" value="QBT_TR(Save)QBT_TR[CONTEXT=HttpServer]" id="renameButton" />

--- a/src/webui/www/private/rename_feed.html
+++ b/src/webui/www/private/rename_feed.html
@@ -79,7 +79,7 @@
         <p style="font-weight: bold;" class="qbt-translatable" data-i18n="New feed name:">New feed name:</p>
         <input type="text" id="rename" style="width: 320px;" />
         <div style="text-align: center; padding-top: 10px;">
-            <input type="button" value="QBT_TR(Save)QBT_TR[CONTEXT=HttpServer]" id="renameButton" />
+            <input type="button" class="qbt-translatable" data-i18n="[value]Save" value="Save" id="renameButton" />
         </div>
     </div>
 </body>

--- a/src/webui/www/private/rename_file.html
+++ b/src/webui/www/private/rename_file.html
@@ -87,7 +87,7 @@
         <p style="font-weight: bold;" class="qbt-translatable" data-i18n="New name:">New name:</p>
         <input type="text" id="rename" style="width: 99%;" />
         <div style="text-align: center; padding-top: 10px;">
-            <input type="button" value="QBT_TR(Save)QBT_TR[CONTEXT=HttpServer]" id="renameButton" />
+            <input type="button" class="qbt-translatable" data-i18n="[value]Save" value="Save" id="renameButton" />
         </div>
     </div>
 </body>

--- a/src/webui/www/private/rename_file.html
+++ b/src/webui/www/private/rename_file.html
@@ -46,12 +46,12 @@
                 // check field
                 const newName = $('rename').value.trim();
                 if (newName === '') {
-                    alert('QBT_TR(Name cannot be empty)QBT_TR[CONTEXT=HttpServer]');
+                    alert(i18next.t('Name cannot be empty'));
                     return;
                 }
 
                 if (newName === oldName) {
-                    alert('QBT_TR(Name is unchanged)QBT_TR[CONTEXT=HttpServer]');
+                    alert(i18next.t('Name is unchanged'));
                     return;
                 }
 
@@ -73,7 +73,7 @@
                         window.parent.qBittorrent.Client.closeWindows();
                     },
                     onFailure: function() {
-                        alert('QBT_TR(Failed to update name)QBT_TR[CONTEXT=HttpServer]');
+                        alert(i18next.t('Failed to update name'));
                         $('renameButton').disabled = false;
                     }
                 }).send();

--- a/src/webui/www/private/rename_file.html
+++ b/src/webui/www/private/rename_file.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(Renaming)QBT_TR[CONTEXT=TorrentContentTreeView]</title>
+    <title class="qbt-translatable" data-i18n="Renaming">Renaming</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
@@ -84,7 +84,7 @@
 
 <body>
     <div style="padding: 10px 10px 0px 10px;">
-        <p style="font-weight: bold;">QBT_TR(New name:)QBT_TR[CONTEXT=TorrentContentTreeView]</p>
+        <p style="font-weight: bold;" class="qbt-translatable" data-i18n="New name:">New name:</p>
         <input type="text" id="rename" style="width: 99%;" />
         <div style="text-align: center; padding-top: 10px;">
             <input type="button" value="QBT_TR(Save)QBT_TR[CONTEXT=HttpServer]" id="renameButton" />

--- a/src/webui/www/private/rename_files.html
+++ b/src/webui/www/private/rename_files.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(Renaming)QBT_TR[CONTEXT=TorrentContentTreeView]</title>
+    <title class="qbt-translatable" data-i18n="Renaming">Renaming</title>
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
     <script src="scripts/filesystem.js?v=${CACHEID}"></script>
@@ -418,40 +418,40 @@
         <div style="float: left; height: 100%; width: 228px;">
             <div class="formRow">
                 <input type="checkbox" id="multirename_rememberprefs_checkbox" onchange="LocalPreferences.set('multirename_rememberPreferences', this.checked);" />
-                <label for="multirename_rememberprefs_checkbox">QBT_TR(Remember Multi-Rename settings)QBT_TR[CONTEXT=OptionsDialog]</label>
+                <label for="multirename_rememberprefs_checkbox" class="qbt-translatable" data-i18n="Remember Multi-Rename settings">Remember Multi-Rename settings</label>
             </div>
             <hr>
             <textarea id="multiRenameSearch" placeholder="QBT_TR(Search Files)QBT_TR[CONTEXT=PropertiesWidget]" style="width: calc(100% - 8px); resize: vertical; min-height: 30px;"></textarea>
             <div class="formRow">
                 <input type="checkbox" id="use_regex_search" />
-                <label for="use_regex_search">QBT_TR(Use regular expressions)QBT_TR[CONTEXT=PropertiesWidget]</label>
+                <label for="use_regex_search" class="qbt-translatable" data-i18n="Use regular expressions">Use regular expressions</label>
             </div>
             <div class="formRow">
                 <input type="checkbox" id="match_all_occurrences" />
-                <label for="match_all_occurrences">QBT_TR(Match all occurrences)QBT_TR[CONTEXT=PropertiesWidget]</label>
+                <label for="match_all_occurrences" class="qbt-translatable" data-i18n="Match all occurrences">Match all occurrences</label>
             </div>
             <div class="formRow">
                 <input type="checkbox" id="case_sensitive" />
-                <label for="case_sensitive">QBT_TR(Case sensitive)QBT_TR[CONTEXT=PropertiesWidget]</label>
+                <label for="case_sensitive" class="qbt-translatable" data-i18n="Case sensitive">Case sensitive</label>
             </div>
             <hr>
             <textarea id="multiRenameReplace" placeholder="QBT_TR(Replacement Input)QBT_TR[CONTEXT=PropertiesWidget]" style="width: calc(100% - 8px); resize: vertical; min-height: 30px;"></textarea>
             <select id="applies_to_option" name="applies_to_option" style="width: 100%; margin-bottom: 5px;">
-                <option selected value="FilenameExtension">QBT_TR(Filename + Extension)QBT_TR[CONTEXT=PropertiesWidget]</option>
-                <option value="Filename">QBT_TR(Filename)QBT_TR[CONTEXT=PropertiesWidget]</option>
-                <option value="Extension">QBT_TR(Extension)QBT_TR[CONTEXT=PropertiesWidget]</option>
+                <option selected value="FilenameExtension" class="qbt-translatable" data-i18n="Filename + Extension">Filename + Extension</option>
+                <option value="Filename" class="qbt-translatable" data-i18n="Filename">Filename</option>
+                <option value="Extension" class="qbt-translatable" data-i18n="Extension">Extension</option>
             </select>
             <div class="formRow">
                 <input type="checkbox" id="include_files" checked />
-                <label for="include_files">QBT_TR(Include files)QBT_TR[CONTEXT=PropertiesWidget]</label>
+                <label for="include_files" class="qbt-translatable" data-i18n="Include files">Include files</label>
             </div>
             <div class="formRow">
                 <input type="checkbox" id="include_folders" />
-                <label for="include_folders">QBT_TR(Include folders)QBT_TR[CONTEXT=PropertiesWidget]</label>
+                <label for="include_folders" class="qbt-translatable" data-i18n="Include folders">Include folders</label>
             </div>
             <div class="formRow">
                 <input type="number" min="0" max="99999999" value="0" id="file_counter" style="width: 80px;" />
-                <label for="file_counter">QBT_TR(Enumerate Files)QBT_TR[CONTEXT=PropertiesWidget]</label>
+                <label for="file_counter" class="qbt-translatable" data-i18n="Enumerate Files">Enumerate Files</label>
             </div>
         </div>
         <div id="operation_btns" style="position: absolute; left: 0; bottom: 0; margin: 0px 12px 36px 12px; width: 228px;background: #ffffff;padding: 0px 5px 10px 0px;">
@@ -462,8 +462,8 @@
             <div style="width: 60%; float: left;">
                 <input id="renameButton" type="button" value="Replace" style="float: left; width: 86px;">
                 <select id="renameOptions" name="renameOptions" style="width: 22px;">
-                    <option selected value="Replace">QBT_TR(Replace)QBT_TR[CONTEXT=PropertiesWidget]</option>
-                    <option value="Replace All">QBT_TR(Replace All)QBT_TR[CONTEXT=PropertiesWidget]</option>
+                    <option selected value="Replace" class="qbt-translatable" data-i18n="Replace">Replace</option>
+                    <option value="Replace All" class="qbt-translatable" data-i18n="Replace All">Replace All</option>
                 </select>
             </div>
             <input id="closeButton" type="button" value="Close" style="float: right; width: 30%;">

--- a/src/webui/www/private/rename_files.html
+++ b/src/webui/www/private/rename_files.html
@@ -421,7 +421,7 @@
                 <label for="multirename_rememberprefs_checkbox" class="qbt-translatable" data-i18n="Remember Multi-Rename settings">Remember Multi-Rename settings</label>
             </div>
             <hr>
-            <textarea id="multiRenameSearch" placeholder="QBT_TR(Search Files)QBT_TR[CONTEXT=PropertiesWidget]" style="width: calc(100% - 8px); resize: vertical; min-height: 30px;"></textarea>
+            <textarea id="multiRenameSearch" class="qbt-translatable" data-i18n="[placeholder]Search Files" placeholder="Search Files" style="width: calc(100% - 8px); resize: vertical; min-height: 30px;"></textarea>
             <div class="formRow">
                 <input type="checkbox" id="use_regex_search" />
                 <label for="use_regex_search" class="qbt-translatable" data-i18n="Use regular expressions">Use regular expressions</label>
@@ -435,7 +435,7 @@
                 <label for="case_sensitive" class="qbt-translatable" data-i18n="Case sensitive">Case sensitive</label>
             </div>
             <hr>
-            <textarea id="multiRenameReplace" placeholder="QBT_TR(Replacement Input)QBT_TR[CONTEXT=PropertiesWidget]" style="width: calc(100% - 8px); resize: vertical; min-height: 30px;"></textarea>
+            <textarea id="multiRenameReplace" class="qbt-translatable" data-i18n="[placeholder]Replacement Input" placeholder="Replacement Input" style="width: calc(100% - 8px); resize: vertical; min-height: 30px;"></textarea>
             <select id="applies_to_option" name="applies_to_option" style="width: 100%; margin-bottom: 5px;">
                 <option selected value="FilenameExtension" class="qbt-translatable" data-i18n="Filename + Extension">Filename + Extension</option>
                 <option value="Filename" class="qbt-translatable" data-i18n="Filename">Filename</option>

--- a/src/webui/www/private/rename_files.html
+++ b/src/webui/www/private/rename_files.html
@@ -279,7 +279,7 @@
         };
         fileRenamer.onRenameError = function(err, row) {
             if (err.xhr.status === 409) {
-                $('rename_error').set('text', `QBT_TR(Rename failed: file or folder already exists)QBT_TR[CONTEXT=PropertiesWidget] \`${row.renamed}\``);
+                $('rename_error').set('text', `\${i18next.t('Rename failed: file or folder already exists')} \`${row.renamed}\``);
             }
         };
         $('renameOptions').addEvent('change', function(e) {

--- a/src/webui/www/private/rename_rule.html
+++ b/src/webui/www/private/rename_rule.html
@@ -72,7 +72,7 @@
         <p class="qbt-translatable" data-i18n="Please type the new rule name">Please type the new rule name</p>
         <input type="text" id="rename" style="width: 320px;" />
         <div style="text-align: center; padding-top: 10px;">
-            <input type="button" value="QBT_TR(Save)QBT_TR[CONTEXT=HttpServer]" id="renameButton" />
+            <input type="button" class="qbt-translatable" data-i18n="[value]Save" value="Save" id="renameButton" />
         </div>
     </div>
 </body>

--- a/src/webui/www/private/rename_rule.html
+++ b/src/webui/www/private/rename_rule.html
@@ -40,12 +40,12 @@
                 // check field
                 const newName = $('rename').value.trim();
                 if (newName === '') {
-                    alert('QBT_TR(Name cannot be empty)QBT_TR[CONTEXT=HttpServer]');
+                    alert(i18next.t('Name cannot be empty'));
                     return;
                 }
 
                 if (newName === oldName) {
-                    alert('QBT_TR(Name is unchanged)QBT_TR[CONTEXT=HttpServer]');
+                    alert(i18next.t('Name is unchanged'));
                     return;
                 }
 

--- a/src/webui/www/private/rename_rule.html
+++ b/src/webui/www/private/rename_rule.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(Rule renaming)QBT_TR[CONTEXT=AutomatedRssDownloader]</title>
+    <title class="qbt-translatable" data-i18n="Rule renaming">Rule renaming</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
@@ -69,7 +69,7 @@
 
 <body>
     <div style="padding: 10px 10px 0px 10px;">
-        <p>QBT_TR(Please type the new rule name)QBT_TR[CONTEXT=AutomatedRssDownloader]</p>
+        <p class="qbt-translatable" data-i18n="Please type the new rule name">Please type the new rule name</p>
         <input type="text" id="rename" style="width: 320px;" />
         <div style="text-align: center; padding-top: 10px;">
             <input type="button" value="QBT_TR(Save)QBT_TR[CONTEXT=HttpServer]" id="renameButton" />

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -410,20 +410,20 @@ window.addEventListener("DOMContentLoaded", function() {
     };
 
     const updateFiltersList = function() {
-        updateFilter('all', 'QBT_TR(All (%1))QBT_TR[CONTEXT=StatusFilterWidget]');
-        updateFilter('downloading', 'QBT_TR(Downloading (%1))QBT_TR[CONTEXT=StatusFilterWidget]');
-        updateFilter('seeding', 'QBT_TR(Seeding (%1))QBT_TR[CONTEXT=StatusFilterWidget]');
-        updateFilter('completed', 'QBT_TR(Completed (%1))QBT_TR[CONTEXT=StatusFilterWidget]');
-        updateFilter('resumed', 'QBT_TR(Resumed (%1))QBT_TR[CONTEXT=StatusFilterWidget]');
-        updateFilter('paused', 'QBT_TR(Paused (%1))QBT_TR[CONTEXT=StatusFilterWidget]');
-        updateFilter('active', 'QBT_TR(Active (%1))QBT_TR[CONTEXT=StatusFilterWidget]');
-        updateFilter('inactive', 'QBT_TR(Inactive (%1))QBT_TR[CONTEXT=StatusFilterWidget]');
-        updateFilter('stalled', 'QBT_TR(Stalled (%1))QBT_TR[CONTEXT=StatusFilterWidget]');
-        updateFilter('stalled_uploading', 'QBT_TR(Stalled Uploading (%1))QBT_TR[CONTEXT=StatusFilterWidget]');
-        updateFilter('stalled_downloading', 'QBT_TR(Stalled Downloading (%1))QBT_TR[CONTEXT=StatusFilterWidget]');
-        updateFilter('checking', 'QBT_TR(Checking (%1))QBT_TR[CONTEXT=StatusFilterWidget]');
-        updateFilter('moving', 'QBT_TR(Moving (%1))QBT_TR[CONTEXT=StatusFilterWidget]');
-        updateFilter('errored', 'QBT_TR(Errored (%1))QBT_TR[CONTEXT=StatusFilterWidget]');
+        updateFilter('all', i18next.t('All (%1)'));
+        updateFilter('downloading', i18next.t('Downloading (%1)'));
+        updateFilter('seeding', i18next.t('Seeding (%1)'));
+        updateFilter('completed', i18next.t('Completed (%1)'));
+        updateFilter('resumed', i18next.t('Resumed (%1)'));
+        updateFilter('paused', i18next.t('Paused (%1)'));
+        updateFilter('active', i18next.t('Active (%1)'));
+        updateFilter('inactive', i18next.t('Inactive (%1)'));
+        updateFilter('stalled', i18next.t('Stalled (%1)'));
+        updateFilter('stalled_uploading', i18next.t('Stalled Uploading (%1)'));
+        updateFilter('stalled_downloading', i18next.t('Stalled Downloading (%1)'));
+        updateFilter('checking', i18next.t('Checking (%1)'));
+        updateFilter('moving', i18next.t('Moving (%1)'));
+        updateFilter('errored', i18next.t('Errored (%1)'));
     };
 
     const updateCategoryList = function() {
@@ -462,8 +462,8 @@ window.addEventListener("DOMContentLoaded", function() {
             if (row['full_data'].category.length === 0)
                 uncategorized += 1;
         }
-        categoryList.appendChild(create_link(CATEGORIES_ALL, 'QBT_TR(All)QBT_TR[CONTEXT=CategoryFilterModel]', all));
-        categoryList.appendChild(create_link(CATEGORIES_UNCATEGORIZED, 'QBT_TR(Uncategorized)QBT_TR[CONTEXT=CategoryFilterModel]', uncategorized));
+        categoryList.appendChild(create_link(CATEGORIES_ALL, i18next.t('All'), all));
+        categoryList.appendChild(create_link(CATEGORIES_UNCATEGORIZED, i18next.t('Uncategorized'), uncategorized));
 
         const sortedCategories = [];
         category_list.forEach((category, hash) => sortedCategories.push({
@@ -540,8 +540,8 @@ window.addEventListener("DOMContentLoaded", function() {
             if (Object.hasOwn(torrentsTable.rows, key) && (torrentsTable.rows[key]['full_data'].tags.length === 0))
                 untagged += 1;
         }
-        tagFilterList.appendChild(createLink(TAGS_ALL, 'QBT_TR(All)QBT_TR[CONTEXT=TagFilterModel]', torrentsCount));
-        tagFilterList.appendChild(createLink(TAGS_UNTAGGED, 'QBT_TR(Untagged)QBT_TR[CONTEXT=TagFilterModel]', untagged));
+        tagFilterList.appendChild(createLink(TAGS_ALL, i18next.t('All'), torrentsCount));
+        tagFilterList.appendChild(createLink(TAGS_UNTAGGED, i18next.t('Untagged'), untagged));
 
         const sortedTags = [];
         tagList.forEach((tag, hash) => sortedTags.push({
@@ -613,13 +613,13 @@ window.addEventListener("DOMContentLoaded", function() {
         };
 
         const torrentsCount = torrentsTable.getRowIds().length;
-        trackerFilterList.appendChild(createLink(TRACKERS_ALL, 'QBT_TR(All (%1))QBT_TR[CONTEXT=TrackerFiltersList]', torrentsCount));
+        trackerFilterList.appendChild(createLink(TRACKERS_ALL, i18next.t('All (%1)'), torrentsCount));
         let trackerlessTorrentsCount = 0;
         for (const key in torrentsTable.rows) {
             if (Object.hasOwn(torrentsTable.rows, key) && (torrentsTable.rows[key]['full_data'].trackers_count === 0))
                 trackerlessTorrentsCount += 1;
         }
-        trackerFilterList.appendChild(createLink(TRACKERS_TRACKERLESS, 'QBT_TR(Trackerless (%1))QBT_TR[CONTEXT=TrackerFiltersList]', trackerlessTorrentsCount));
+        trackerFilterList.appendChild(createLink(TRACKERS_TRACKERLESS, i18next.t('Trackerless (%1)'), trackerlessTorrentsCount));
 
         // Sort trackers by hostname
         const sortedList = [];
@@ -687,7 +687,7 @@ window.addEventListener("DOMContentLoaded", function() {
             onFailure: function() {
                 const errorDiv = $('error_div');
                 if (errorDiv)
-                    errorDiv.set('html', 'QBT_TR(qBittorrent client is not reachable)QBT_TR[CONTEXT=HttpServer]');
+                    errorDiv.set('html', i18next.t('qBittorrent client is not reachable'));
                 syncRequestInProgress = false;
                 syncData(2000);
             },
@@ -892,8 +892,8 @@ window.addEventListener("DOMContentLoaded", function() {
                 : '')
             + window.qBittorrent.Client.mainTitle();
 
-        $('freeSpaceOnDisk').set('html', 'QBT_TR(Free space: %1)QBT_TR[CONTEXT=HttpServer]'.replace("%1", window.qBittorrent.Misc.friendlyUnit(serverState.free_space_on_disk)));
-        $('DHTNodes').set('html', 'QBT_TR(DHT: %1 nodes)QBT_TR[CONTEXT=StatusBar]'.replace("%1", serverState.dht_nodes));
+        $('freeSpaceOnDisk').set('html', i18next.t('Free space: %1').replace("%1", window.qBittorrent.Misc.friendlyUnit(serverState.free_space_on_disk)));
+        $('DHTNodes').set('html', i18next.t('DHT: %1 nodes').replace("%1", serverState.dht_nodes));
 
         // Statistics dialog
         if (document.getElementById("statisticsContent")) {
@@ -914,18 +914,18 @@ window.addEventListener("DOMContentLoaded", function() {
         switch (serverState.connection_status) {
             case 'connected':
                 $('connectionStatus').src = 'images/connected.svg';
-                $('connectionStatus').alt = 'QBT_TR(Connection status: Connected)QBT_TR[CONTEXT=MainWindow]';
-                $('connectionStatus').title = 'QBT_TR(Connection status: Connected)QBT_TR[CONTEXT=MainWindow]';
+                $('connectionStatus').alt = i18next.t('Connection status: Connected');
+                $('connectionStatus').title = i18next.t('Connection status: Connected');
                 break;
             case 'firewalled':
                 $('connectionStatus').src = 'images/firewalled.svg';
-                $('connectionStatus').alt = 'QBT_TR(Connection status: Firewalled)QBT_TR[CONTEXT=MainWindow]';
-                $('connectionStatus').title = 'QBT_TR(Connection status: Firewalled)QBT_TR[CONTEXT=MainWindow]';
+                $('connectionStatus').alt = i18next.t('Connection status: Firewalled');
+                $('connectionStatus').title = i18next.t('Connection status: Firewalled');
                 break;
             default:
                 $('connectionStatus').src = 'images/disconnected.svg';
-                $('connectionStatus').alt = 'QBT_TR(Connection status: Disconnected)QBT_TR[CONTEXT=MainWindow]';
-                $('connectionStatus').title = 'QBT_TR(Connection status: Disconnected)QBT_TR[CONTEXT=MainWindow]';
+                $('connectionStatus').alt = i18next.t('Connection status: Disconnected');
+                $('connectionStatus').title = i18next.t('Connection status: Disconnected');
                 break;
         }
 
@@ -967,13 +967,13 @@ window.addEventListener("DOMContentLoaded", function() {
     const updateAltSpeedIcon = function(enabled) {
         if (enabled) {
             $('alternativeSpeedLimits').src = 'images/slow.svg';
-            $('alternativeSpeedLimits').alt = 'QBT_TR(Alternative speed limits: On)QBT_TR[CONTEXT=MainWindow]';
-            $('alternativeSpeedLimits').title = 'QBT_TR(Alternative speed limits: On)QBT_TR[CONTEXT=MainWindow]';
+            $('alternativeSpeedLimits').alt = i18next.t('Alternative speed limits: On');
+            $('alternativeSpeedLimits').title = i18next.t('Alternative speed limits: On');
         }
         else {
             $('alternativeSpeedLimits').src = 'images/slow_off.svg';
-            $('alternativeSpeedLimits').alt = 'QBT_TR(Alternative speed limits: Off)QBT_TR[CONTEXT=MainWindow]';
-            $('alternativeSpeedLimits').title = 'QBT_TR(Alternative speed limits: Off)QBT_TR[CONTEXT=MainWindow]';
+            $('alternativeSpeedLimits').alt = i18next.t('Alternative speed limits: Off');
+            $('alternativeSpeedLimits').title = i18next.t('Alternative speed limits: Off');
         }
     };
 
@@ -1029,9 +1029,9 @@ window.addEventListener("DOMContentLoaded", function() {
     const registerMagnetHandler = function() {
         if (typeof navigator.registerProtocolHandler !== 'function') {
             if (window.location.protocol !== 'https:')
-                alert("QBT_TR(To use this feature, the WebUI needs to be accessed over HTTPS)QBT_TR[CONTEXT=MainWindow]");
+                alert(i18next.t("To use this feature, the WebUI needs to be accessed over HTTPS"));
             else
-                alert("QBT_TR(Your browser does not support this feature)QBT_TR[CONTEXT=MainWindow]");
+                alert(i18next.t("Your browser does not support this feature"));
             return;
         }
 
@@ -1497,7 +1497,7 @@ window.addEventListener("DOMContentLoaded", function() {
                 const id = 'uploadPage';
                 new MochaUI.Window({
                     id: id,
-                    title: "QBT_TR(Upload local torrent)QBT_TR[CONTEXT=HttpServer]",
+                    title: i18next.t("Upload local torrent"),
                     loadMethod: 'iframe',
                     contentURL: new URI("upload.html").toString(),
                     addClass: 'windowFrame', // fixes iframe scrolling on iOS Safari
@@ -1539,7 +1539,7 @@ window.addEventListener("DOMContentLoaded", function() {
                 const contentURI = new URI('download.html').setData("urls", urls.map(encodeURIComponent).join("|"));
                 new MochaUI.Window({
                     id: id,
-                    title: "QBT_TR(Download from URLs)QBT_TR[CONTEXT=downloadFromURL]",
+                    title: i18next.t("Download from URLs"),
                     loadMethod: 'iframe',
                     contentURL: contentURI.toString(),
                     addClass: 'windowFrame', // fixes iframe scrolling on iOS Safari

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -72,7 +72,7 @@ window.qBittorrent.Client = (() => {
         const emDash = '\u2014';
         const qbtVersion = window.qBittorrent.Cache.qbtVersion.get();
         const suffix = window.qBittorrent.Cache.preferences.get()['app_instance_name'] || '';
-        const title = `qBittorrent ${qbtVersion} QBT_TR(WebUI)QBT_TR[CONTEXT=OptionsDialog]`
+        const title = `qBittorrent ${qbtVersion} ${i18next.t('WebUI')})`
             + ((suffix.length > 0) ? ` ${emDash} ${suffix}` : '');
         return title;
     };

--- a/src/webui/www/private/scripts/contextmenu.js
+++ b/src/webui/www/private/scripts/contextmenu.js
@@ -473,13 +473,13 @@ window.qBittorrent.ContextMenu = (function() {
             contextTagList.appendChild(new Element('li', {
                 html: '<a href="javascript:torrentAddTagsFN();">'
                     + '<img src="images/list-add.svg" alt=i18next.t("Add...")/>'
-                    + ' QBT_TR(Add...)QBT_TR[CONTEXT=TransferListWidget]'
+                    + ` ${i18next.t('Add...')}`
                     + '</a>'
             }));
             contextTagList.appendChild(new Element('li', {
                 html: '<a href="javascript:torrentRemoveAllTagsFN();">'
                     + '<img src="images/edit-clear.svg" alt=i18next.t("Remove All")/>'
-                    + ' QBT_TR(Remove All)QBT_TR[CONTEXT=TransferListWidget]'
+                    + ` ${i18next.t('Remove All')}`
                     + '</a>'
             }));
 

--- a/src/webui/www/private/scripts/contextmenu.js
+++ b/src/webui/www/private/scripts/contextmenu.js
@@ -438,10 +438,10 @@ window.qBittorrent.ContextMenu = (function() {
             const contextCategoryList = $('contextCategoryList');
             contextCategoryList.getChildren().each(c => c.destroy());
             contextCategoryList.appendChild(new Element('li', {
-                html: '<a href="javascript:torrentNewCategoryFN();"><img src="images/list-add.svg" alt="QBT_TR(New...)QBT_TR[CONTEXT=TransferListWidget]"/> QBT_TR(New...)QBT_TR[CONTEXT=TransferListWidget]</a>'
+                html: '<a href="javascript:torrentNewCategoryFN();"><img src="images/list-add.svg" alt=i18next.t("New...")/> QBT_TR(New...)QBT_TR[CONTEXT=TransferListWidget]</a>'
             }));
             contextCategoryList.appendChild(new Element('li', {
-                html: '<a href="javascript:torrentSetCategoryFN(0);"><img src="images/edit-clear.svg" alt="QBT_TR(Reset)QBT_TR[CONTEXT=TransferListWidget]"/> QBT_TR(Reset)QBT_TR[CONTEXT=TransferListWidget]</a>'
+                html: '<a href="javascript:torrentSetCategoryFN(0);"><img src="images/edit-clear.svg" alt=i18next.t("Reset")/> QBT_TR(Reset)QBT_TR[CONTEXT=TransferListWidget]</a>'
             }));
 
             const sortedCategories = [];
@@ -472,13 +472,13 @@ window.qBittorrent.ContextMenu = (function() {
 
             contextTagList.appendChild(new Element('li', {
                 html: '<a href="javascript:torrentAddTagsFN();">'
-                    + '<img src="images/list-add.svg" alt="QBT_TR(Add...)QBT_TR[CONTEXT=TransferListWidget]"/>'
+                    + '<img src="images/list-add.svg" alt=i18next.t("Add...")/>'
                     + ' QBT_TR(Add...)QBT_TR[CONTEXT=TransferListWidget]'
                     + '</a>'
             }));
             contextTagList.appendChild(new Element('li', {
                 html: '<a href="javascript:torrentRemoveAllTagsFN();">'
-                    + '<img src="images/edit-clear.svg" alt="QBT_TR(Remove All)QBT_TR[CONTEXT=TransferListWidget]"/>'
+                    + '<img src="images/edit-clear.svg" alt=i18next.t("Remove All")/>'
                     + ' QBT_TR(Remove All)QBT_TR[CONTEXT=TransferListWidget]'
                     + '</a>'
             }));

--- a/src/webui/www/private/scripts/contextmenu.js
+++ b/src/webui/www/private/scripts/contextmenu.js
@@ -438,10 +438,10 @@ window.qBittorrent.ContextMenu = (function() {
             const contextCategoryList = $('contextCategoryList');
             contextCategoryList.getChildren().each(c => c.destroy());
             contextCategoryList.appendChild(new Element('li', {
-                html: '<a href="javascript:torrentNewCategoryFN();"><img src="images/list-add.svg" alt=i18next.t("New...")/> QBT_TR(New...)QBT_TR[CONTEXT=TransferListWidget]</a>'
+                html: '<a href="javascript:torrentNewCategoryFN();"><img src="images/list-add.svg" class="qbt-translatable" data-i18n="[alt]New..." alt=i18next.t("New...")/> QBT_TR(New...)QBT_TR[CONTEXT=TransferListWidget]</a>'
             }));
             contextCategoryList.appendChild(new Element('li', {
-                html: '<a href="javascript:torrentSetCategoryFN(0);"><img src="images/edit-clear.svg" alt=i18next.t("Reset")/> QBT_TR(Reset)QBT_TR[CONTEXT=TransferListWidget]</a>'
+                html: '<a href="javascript:torrentSetCategoryFN(0);"><img src="images/edit-clear.svg" class="qbt-translatable" data-i18n="[alt]Reset" alt=i18next.t("Reset")/> QBT_TR(Reset)QBT_TR[CONTEXT=TransferListWidget]</a>'
             }));
 
             const sortedCategories = [];

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -911,37 +911,37 @@ window.qBittorrent.DynamicTable = (function() {
         initColumns: function() {
             this.newColumn('priority', '', '#', 30, true);
             this.newColumn('state_icon', 'cursor: default', '', 22, true);
-            this.newColumn('name', '', 'QBT_TR(Name)QBT_TR[CONTEXT=TransferListModel]', 200, true);
-            this.newColumn('size', '', 'QBT_TR(Size)QBT_TR[CONTEXT=TransferListModel]', 100, true);
-            this.newColumn('total_size', '', 'QBT_TR(Total Size)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-            this.newColumn('progress', '', 'QBT_TR(Done)QBT_TR[CONTEXT=TransferListModel]', 85, true);
-            this.newColumn('status', '', 'QBT_TR(Status)QBT_TR[CONTEXT=TransferListModel]', 100, true);
-            this.newColumn('num_seeds', '', 'QBT_TR(Seeds)QBT_TR[CONTEXT=TransferListModel]', 100, true);
-            this.newColumn('num_leechs', '', 'QBT_TR(Peers)QBT_TR[CONTEXT=TransferListModel]', 100, true);
-            this.newColumn('dlspeed', '', 'QBT_TR(Down Speed)QBT_TR[CONTEXT=TransferListModel]', 100, true);
-            this.newColumn('upspeed', '', 'QBT_TR(Up Speed)QBT_TR[CONTEXT=TransferListModel]', 100, true);
-            this.newColumn('eta', '', 'QBT_TR(ETA)QBT_TR[CONTEXT=TransferListModel]', 100, true);
-            this.newColumn('ratio', '', 'QBT_TR(Ratio)QBT_TR[CONTEXT=TransferListModel]', 100, true);
-            this.newColumn('category', '', 'QBT_TR(Category)QBT_TR[CONTEXT=TransferListModel]', 100, true);
-            this.newColumn('tags', '', 'QBT_TR(Tags)QBT_TR[CONTEXT=TransferListModel]', 100, true);
-            this.newColumn('added_on', '', 'QBT_TR(Added On)QBT_TR[CONTEXT=TransferListModel]', 100, true);
-            this.newColumn('completion_on', '', 'QBT_TR(Completed On)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-            this.newColumn('tracker', '', 'QBT_TR(Tracker)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-            this.newColumn('dl_limit', '', 'QBT_TR(Down Limit)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-            this.newColumn('up_limit', '', 'QBT_TR(Up Limit)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-            this.newColumn('downloaded', '', 'QBT_TR(Downloaded)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-            this.newColumn('uploaded', '', 'QBT_TR(Uploaded)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-            this.newColumn('downloaded_session', '', 'QBT_TR(Session Download)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-            this.newColumn('uploaded_session', '', 'QBT_TR(Session Upload)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-            this.newColumn('amount_left', '', 'QBT_TR(Remaining)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-            this.newColumn('time_active', '', 'QBT_TR(Time Active)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-            this.newColumn('save_path', '', 'QBT_TR(Save path)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-            this.newColumn('completed', '', 'QBT_TR(Completed)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-            this.newColumn('max_ratio', '', 'QBT_TR(Ratio Limit)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-            this.newColumn('seen_complete', '', 'QBT_TR(Last Seen Complete)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-            this.newColumn('last_activity', '', 'QBT_TR(Last Activity)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-            this.newColumn('availability', '', 'QBT_TR(Availability)QBT_TR[CONTEXT=TransferListModel]', 100, false);
-            this.newColumn('reannounce', '', 'QBT_TR(Reannounce In)QBT_TR[CONTEXT=TransferListModel]', 100, false);
+            this.newColumn('name', '', i18next.t('Name'), 200, true);
+            this.newColumn('size', '', i18next.t('Size'), 100, true);
+            this.newColumn('total_size', '', i18next.t('Total Size'), 100, false);
+            this.newColumn('progress', '', i18next.t('Done'), 85, true);
+            this.newColumn('status', '', i18next.t('Status'), 100, true);
+            this.newColumn('num_seeds', '', i18next.t('Seeds'), 100, true);
+            this.newColumn('num_leechs', '', i18next.t('Peers'), 100, true);
+            this.newColumn('dlspeed', '', i18next.t('Down Speed'), 100, true);
+            this.newColumn('upspeed', '', i18next.t('Up Speed'), 100, true);
+            this.newColumn('eta', '', i18next.t('ETA'), 100, true);
+            this.newColumn('ratio', '', i18next.t('Ratio'), 100, true);
+            this.newColumn('category', '', i18next.t('Category'), 100, true);
+            this.newColumn('tags', '', i18next.t('Tags'), 100, true);
+            this.newColumn('added_on', '', i18next.t('Added On'), 100, true);
+            this.newColumn('completion_on', '', i18next.t('Completed On'), 100, false);
+            this.newColumn('tracker', '', i18next.t('Tracker'), 100, false);
+            this.newColumn('dl_limit', '', i18next.t('Down Limit'), 100, false);
+            this.newColumn('up_limit', '', i18next.t('Up Limit'), 100, false);
+            this.newColumn('downloaded', '', i18next.t('Downloaded'), 100, false);
+            this.newColumn('uploaded', '', i18next.t('Uploaded'), 100, false);
+            this.newColumn('downloaded_session', '', i18next.t('Session Download'), 100, false);
+            this.newColumn('uploaded_session', '', i18next.t('Session Upload'), 100, false);
+            this.newColumn('amount_left', '', i18next.t('Remaining'), 100, false);
+            this.newColumn('time_active', '', i18next.t('Time Active'), 100, false);
+            this.newColumn('save_path', '', i18next.t('Save path'), 100, false);
+            this.newColumn('completed', '', i18next.t('Completed'), 100, false);
+            this.newColumn('max_ratio', '', i18next.t('Ratio Limit'), 100, false);
+            this.newColumn('seen_complete', '', i18next.t('Last Seen Complete'), 100, false);
+            this.newColumn('last_activity', '', i18next.t('Last Activity'), 100, false);
+            this.newColumn('availability', '', i18next.t('Availability'), 100, false);
+            this.newColumn('reannounce', '', i18next.t('Reannounce In'), 100, false);
 
             this.columns['state_icon'].onclick = '';
             this.columns['state_icon'].dataProperties[0] = 'state';
@@ -1040,58 +1040,58 @@ window.qBittorrent.DynamicTable = (function() {
                 let status;
                 switch (state) {
                     case "downloading":
-                        status = "QBT_TR(Downloading)QBT_TR[CONTEXT=TransferListDelegate]";
+                        status = i18next.t("Downloading");
                         break;
                     case "stalledDL":
-                        status = "QBT_TR(Stalled)QBT_TR[CONTEXT=TransferListDelegate]";
+                        status = i18next.t("Stalled");
                         break;
                     case "metaDL":
-                        status = "QBT_TR(Downloading metadata)QBT_TR[CONTEXT=TransferListDelegate]";
+                        status = i18next.t("Downloading metadata");
                         break;
                     case "forcedMetaDL":
-                        status = "QBT_TR([F] Downloading metadata)QBT_TR[CONTEXT=TransferListDelegate]";
+                        status = i18next.t("[F] Downloading metadata");
                         break;
                     case "forcedDL":
-                        status = "QBT_TR([F] Downloading)QBT_TR[CONTEXT=TransferListDelegate]";
+                        status = i18next.t("[F] Downloading");
                         break;
                     case "uploading":
                     case "stalledUP":
-                        status = "QBT_TR(Seeding)QBT_TR[CONTEXT=TransferListDelegate]";
+                        status = i18next.t("Seeding");
                         break;
                     case "forcedUP":
-                        status = "QBT_TR([F] Seeding)QBT_TR[CONTEXT=TransferListDelegate]";
+                        status = i18next.t("[F] Seeding");
                         break;
                     case "queuedDL":
                     case "queuedUP":
-                        status = "QBT_TR(Queued)QBT_TR[CONTEXT=TransferListDelegate]";
+                        status = i18next.t("Queued");
                         break;
                     case "checkingDL":
                     case "checkingUP":
-                        status = "QBT_TR(Checking)QBT_TR[CONTEXT=TransferListDelegate]";
+                        status = i18next.t("Checking");
                         break;
                     case "queuedForChecking":
-                        status = "QBT_TR(Queued for checking)QBT_TR[CONTEXT=TransferListDelegate]";
+                        status = i18next.t("Queued for checking");
                         break;
                     case "checkingResumeData":
-                        status = "QBT_TR(Checking resume data)QBT_TR[CONTEXT=TransferListDelegate]";
+                        status = i18next.t("Checking resume data");
                         break;
                     case "pausedDL":
-                        status = "QBT_TR(Paused)QBT_TR[CONTEXT=TransferListDelegate]";
+                        status = i18next.t("Paused");
                         break;
                     case "pausedUP":
-                        status = "QBT_TR(Completed)QBT_TR[CONTEXT=TransferListDelegate]";
+                        status = i18next.t("Completed");
                         break;
                     case "moving":
-                        status = "QBT_TR(Moving)QBT_TR[CONTEXT=TransferListDelegate]";
+                        status = i18next.t("Moving");
                         break;
                     case "missingFiles":
-                        status = "QBT_TR(Missing Files)QBT_TR[CONTEXT=TransferListDelegate]";
+                        status = i18next.t("Missing Files");
                         break;
                     case "error":
-                        status = "QBT_TR(Errored)QBT_TR[CONTEXT=TransferListDelegate]";
+                        status = i18next.t("Errored");
                         break;
                     default:
-                        status = "QBT_TR(Unknown)QBT_TR[CONTEXT=HttpServer]";
+                        status = i18next.t("Unknown");
                 }
 
                 td.set('text', status);
@@ -1273,7 +1273,7 @@ window.qBittorrent.DynamicTable = (function() {
                 const activeTime = this.getRowValue(row, 0);
                 const seedingTime = this.getRowValue(row, 1);
                 const time = (seedingTime > 0)
-                    ? ('QBT_TR(%1 (seeded for %2))QBT_TR[CONTEXT=TransferListDelegate]'
+                    ? (i18next.t('%1 (seeded for %2)')
                         .replace('%1', window.qBittorrent.Misc.friendlyDuration(activeTime))
                         .replace('%2', window.qBittorrent.Misc.friendlyDuration(seedingTime)))
                     : window.qBittorrent.Misc.friendlyDuration(activeTime);
@@ -1298,7 +1298,7 @@ window.qBittorrent.DynamicTable = (function() {
                     td.set('title', '∞');
                 }
                 else {
-                    const formattedVal = 'QBT_TR(%1 ago)QBT_TR[CONTEXT=TransferListDelegate]'.replace('%1', window.qBittorrent.Misc.friendlyDuration((new Date()) / 1000 - val));
+                    const formattedVal = i18next.t('%1 ago').replace('%1', window.qBittorrent.Misc.friendlyDuration((new Date()) / 1000 - val));
                     td.set('text', formattedVal);
                     td.set('title', formattedVal);
                 }
@@ -1521,20 +1521,20 @@ window.qBittorrent.DynamicTable = (function() {
         Extends: DynamicTable,
 
         initColumns: function() {
-            this.newColumn('country', '', 'QBT_TR(Country/Region)QBT_TR[CONTEXT=PeerListWidget]', 22, true);
-            this.newColumn('ip', '', 'QBT_TR(IP)QBT_TR[CONTEXT=PeerListWidget]', 80, true);
-            this.newColumn('port', '', 'QBT_TR(Port)QBT_TR[CONTEXT=PeerListWidget]', 35, true);
-            this.newColumn('connection', '', 'QBT_TR(Connection)QBT_TR[CONTEXT=PeerListWidget]', 50, true);
-            this.newColumn('flags', '', 'QBT_TR(Flags)QBT_TR[CONTEXT=PeerListWidget]', 50, true);
-            this.newColumn('client', '', 'QBT_TR(Client)QBT_TR[CONTEXT=PeerListWidget]', 140, true);
-            this.newColumn('peer_id_client', '', 'QBT_TR(Peer ID Client)QBT_TR[CONTEXT=PeerListWidget]', 60, false);
-            this.newColumn('progress', '', 'QBT_TR(Progress)QBT_TR[CONTEXT=PeerListWidget]', 50, true);
-            this.newColumn('dl_speed', '', 'QBT_TR(Down Speed)QBT_TR[CONTEXT=PeerListWidget]', 50, true);
-            this.newColumn('up_speed', '', 'QBT_TR(Up Speed)QBT_TR[CONTEXT=PeerListWidget]', 50, true);
-            this.newColumn('downloaded', '', 'QBT_TR(Downloaded)QBT_TR[CONTEXT=PeerListWidget]', 50, true);
-            this.newColumn('uploaded', '', 'QBT_TR(Uploaded)QBT_TR[CONTEXT=PeerListWidget]', 50, true);
-            this.newColumn('relevance', '', 'QBT_TR(Relevance)QBT_TR[CONTEXT=PeerListWidget]', 30, true);
-            this.newColumn('files', '', 'QBT_TR(Files)QBT_TR[CONTEXT=PeerListWidget]', 100, true);
+            this.newColumn('country', '', i18next.t('Country/Region'), 22, true);
+            this.newColumn('ip', '', i18next.t('IP'), 80, true);
+            this.newColumn('port', '', i18next.t('Port'), 35, true);
+            this.newColumn('connection', '', i18next.t('Connection'), 50, true);
+            this.newColumn('flags', '', i18next.t('Flags'), 50, true);
+            this.newColumn('client', '', i18next.t('Client'), 140, true);
+            this.newColumn('peer_id_client', '', i18next.t('Peer ID Client'), 60, false);
+            this.newColumn('progress', '', i18next.t('Progress'), 50, true);
+            this.newColumn('dl_speed', '', i18next.t('Down Speed'), 50, true);
+            this.newColumn('up_speed', '', i18next.t('Up Speed'), 50, true);
+            this.newColumn('downloaded', '', i18next.t('Downloaded'), 50, true);
+            this.newColumn('uploaded', '', i18next.t('Uploaded'), 50, true);
+            this.newColumn('relevance', '', i18next.t('Relevance'), 30, true);
+            this.newColumn('files', '', i18next.t('Files'), 100, true);
 
             this.columns['country'].dataProperties.push('country_code');
             this.columns['flags'].dataProperties.push('flags_desc');
@@ -1645,11 +1645,11 @@ window.qBittorrent.DynamicTable = (function() {
         Extends: DynamicTable,
 
         initColumns: function() {
-            this.newColumn('fileName', '', 'QBT_TR(Name)QBT_TR[CONTEXT=SearchResultsTable]', 500, true);
-            this.newColumn('fileSize', '', 'QBT_TR(Size)QBT_TR[CONTEXT=SearchResultsTable]', 100, true);
-            this.newColumn('nbSeeders', '', 'QBT_TR(Seeders)QBT_TR[CONTEXT=SearchResultsTable]', 100, true);
-            this.newColumn('nbLeechers', '', 'QBT_TR(Leechers)QBT_TR[CONTEXT=SearchResultsTable]', 100, true);
-            this.newColumn('siteUrl', '', 'QBT_TR(Search engine)QBT_TR[CONTEXT=SearchResultsTable]', 250, true);
+            this.newColumn('fileName', '', i18next.t('Name'), 500, true);
+            this.newColumn('fileSize', '', i18next.t('Size'), 100, true);
+            this.newColumn('nbSeeders', '', i18next.t('Seeders'), 100, true);
+            this.newColumn('nbLeechers', '', i18next.t('Leechers'), 100, true);
+            this.newColumn('siteUrl', '', i18next.t('Search engine'), 250, true);
 
             this.initColumnsFunctions();
         },
@@ -1758,10 +1758,10 @@ window.qBittorrent.DynamicTable = (function() {
         Extends: DynamicTable,
 
         initColumns: function() {
-            this.newColumn('fullName', '', 'QBT_TR(Name)QBT_TR[CONTEXT=SearchPluginsTable]', 175, true);
-            this.newColumn('version', '', 'QBT_TR(Version)QBT_TR[CONTEXT=SearchPluginsTable]', 100, true);
-            this.newColumn('url', '', 'QBT_TR(Url)QBT_TR[CONTEXT=SearchPluginsTable]', 175, true);
-            this.newColumn('enabled', '', 'QBT_TR(Enabled)QBT_TR[CONTEXT=SearchPluginsTable]', 100, true);
+            this.newColumn('fullName', '', i18next.t('Name'), 175, true);
+            this.newColumn('version', '', i18next.t('Version'), 100, true);
+            this.newColumn('url', '', i18next.t('Url'), 175, true);
+            this.newColumn('enabled', '', i18next.t('Enabled'), 100, true);
 
             this.initColumnsFunctions();
         },
@@ -1770,14 +1770,14 @@ window.qBittorrent.DynamicTable = (function() {
             this.columns['enabled'].updateTd = function(td, row) {
                 const value = this.getRowValue(row);
                 if (value) {
-                    td.set('text', 'QBT_TR(Yes)QBT_TR[CONTEXT=SearchPluginsTable]');
-                    td.set('title', 'QBT_TR(Yes)QBT_TR[CONTEXT=SearchPluginsTable]');
+                    td.set('text', i18next.t('Yes'));
+                    td.set('title', i18next.t('Yes'));
                     td.getParent("tr").addClass("green");
                     td.getParent("tr").removeClass("red");
                 }
                 else {
-                    td.set('text', 'QBT_TR(No)QBT_TR[CONTEXT=SearchPluginsTable]');
-                    td.set('title', 'QBT_TR(No)QBT_TR[CONTEXT=SearchPluginsTable]');
+                    td.set('text', i18next.t('No'));
+                    td.set('title', i18next.t('No'));
                     td.getParent("tr").addClass("red");
                     td.getParent("tr").removeClass("green");
                 }
@@ -1793,14 +1793,14 @@ window.qBittorrent.DynamicTable = (function() {
         Extends: DynamicTable,
 
         initColumns: function() {
-            this.newColumn('tier', '', 'QBT_TR(Tier)QBT_TR[CONTEXT=TrackerListWidget]', 35, true);
-            this.newColumn('url', '', 'QBT_TR(URL)QBT_TR[CONTEXT=TrackerListWidget]', 250, true);
-            this.newColumn('status', '', 'QBT_TR(Status)QBT_TR[CONTEXT=TrackerListWidget]', 125, true);
-            this.newColumn('peers', '', 'QBT_TR(Peers)QBT_TR[CONTEXT=TrackerListWidget]', 75, true);
-            this.newColumn('seeds', '', 'QBT_TR(Seeds)QBT_TR[CONTEXT=TrackerListWidget]', 75, true);
-            this.newColumn('leeches', '', 'QBT_TR(Leeches)QBT_TR[CONTEXT=TrackerListWidget]', 75, true);
-            this.newColumn('downloaded', '', 'QBT_TR(Times Downloaded)QBT_TR[CONTEXT=TrackerListWidget]', 100, true);
-            this.newColumn('message', '', 'QBT_TR(Message)QBT_TR[CONTEXT=TrackerListWidget]', 250, true);
+            this.newColumn('tier', '', i18next.t('Tier'), 35, true);
+            this.newColumn('url', '', i18next.t('URL'), 250, true);
+            this.newColumn('status', '', i18next.t('Status'), 125, true);
+            this.newColumn('peers', '', i18next.t('Peers'), 75, true);
+            this.newColumn('seeds', '', i18next.t('Seeds'), 75, true);
+            this.newColumn('leeches', '', i18next.t('Leeches'), 75, true);
+            this.newColumn('downloaded', '', i18next.t('Times Downloaded'), 100, true);
+            this.newColumn('message', '', i18next.t('Message'), 250, true);
         },
     });
 
@@ -1875,8 +1875,8 @@ window.qBittorrent.DynamicTable = (function() {
             LocalPreferences.remove('column_' + "original" + '_width_' + this.dynamicTableDivId);
             LocalPreferences.remove('column_' + "renamed" + '_width_' + this.dynamicTableDivId);
             this.newColumn('checked', '', '', 50, true);
-            this.newColumn('original', '', 'QBT_TR(Original)QBT_TR[CONTEXT=TrackerListWidget]', 270, true);
-            this.newColumn('renamed', '', 'QBT_TR(Renamed)QBT_TR[CONTEXT=TrackerListWidget]', 220, true);
+            this.newColumn('original', '', i18next.t('Original'), 270, true);
+            this.newColumn('renamed', '', i18next.t('Renamed'), 220, true);
 
             this.initColumnsFunctions();
         },
@@ -2293,12 +2293,12 @@ window.qBittorrent.DynamicTable = (function() {
 
         initColumns: function() {
             this.newColumn('checked', '', '', 50, true);
-            this.newColumn('name', '', 'QBT_TR(Name)QBT_TR[CONTEXT=TrackerListWidget]', 300, true);
-            this.newColumn('size', '', 'QBT_TR(Total Size)QBT_TR[CONTEXT=TrackerListWidget]', 75, true);
-            this.newColumn('progress', '', 'QBT_TR(Progress)QBT_TR[CONTEXT=TrackerListWidget]', 100, true);
-            this.newColumn('priority', '', 'QBT_TR(Download Priority)QBT_TR[CONTEXT=TrackerListWidget]', 150, true);
-            this.newColumn('remaining', '', 'QBT_TR(Remaining)QBT_TR[CONTEXT=TrackerListWidget]', 75, true);
-            this.newColumn('availability', '', 'QBT_TR(Availability)QBT_TR[CONTEXT=TrackerListWidget]', 75, true);
+            this.newColumn('name', '', i18next.t('Name'), 300, true);
+            this.newColumn('size', '', i18next.t('Total Size'), 75, true);
+            this.newColumn('progress', '', i18next.t('Progress'), 100, true);
+            this.newColumn('priority', '', i18next.t('Download Priority'), 150, true);
+            this.newColumn('remaining', '', i18next.t('Remaining'), 75, true);
+            this.newColumn('availability', '', i18next.t('Availability'), 75, true);
 
             this.initColumnsFunctions();
         },
@@ -2583,7 +2583,7 @@ window.qBittorrent.DynamicTable = (function() {
         Extends: DynamicTable,
         initColumns: function() {
             this.newColumn('state_icon', '', '', 30, true);
-            this.newColumn('name', '', 'QBT_TR(RSS feeds)QBT_TR[CONTEXT=FeedListWidget]', -1, true);
+            this.newColumn('name', '', i18next.t('RSS feeds'), -1, true);
 
             this.columns['state_icon'].dataProperties[0] = '';
 
@@ -2734,7 +2734,7 @@ window.qBittorrent.DynamicTable = (function() {
     const RssArticleTable = new Class({
         Extends: DynamicTable,
         initColumns: function() {
-            this.newColumn('name', '', 'QBT_TR(Torrents: (double-click to download))QBT_TR[CONTEXT=RSSWidget]', -1, true);
+            this.newColumn('name', '', i18next.t('Torrents: (double-click to download)'), -1, true);
         },
         setupHeaderMenu: function() {},
         setupHeaderEvents: function() {},
@@ -3074,10 +3074,10 @@ window.qBittorrent.DynamicTable = (function() {
         },
 
         initColumns: function() {
-            this.newColumn('rowId', '', 'QBT_TR(ID)QBT_TR[CONTEXT=ExecutionLogWidget]', 50, true);
-            this.newColumn('message', '', 'QBT_TR(Message)QBT_TR[CONTEXT=ExecutionLogWidget]', 350, true);
-            this.newColumn('timestamp', '', 'QBT_TR(Timestamp)QBT_TR[CONTEXT=ExecutionLogWidget]', 150, true);
-            this.newColumn('type', '', 'QBT_TR(Log Type)QBT_TR[CONTEXT=ExecutionLogWidget]', 100, true);
+            this.newColumn('rowId', '', i18next.t('ID'), 50, true);
+            this.newColumn('message', '', i18next.t('Message'), 350, true);
+            this.newColumn('timestamp', '', i18next.t('Timestamp'), 150, true);
+            this.newColumn('type', '', i18next.t('Log Type'), 100, true);
             this.initColumnsFunctions();
         },
 
@@ -3092,23 +3092,23 @@ window.qBittorrent.DynamicTable = (function() {
                 let logLevel, addClass;
                 switch (this.getRowValue(row).toInt()) {
                     case 1:
-                        logLevel = 'QBT_TR(Normal)QBT_TR[CONTEXT=ExecutionLogWidget]';
+                        logLevel = i18next.t('Normal');
                         addClass = 'logNormal';
                         break;
                     case 2:
-                        logLevel = 'QBT_TR(Info)QBT_TR[CONTEXT=ExecutionLogWidget]';
+                        logLevel = i18next.t('Info');
                         addClass = 'logInfo';
                         break;
                     case 4:
-                        logLevel = 'QBT_TR(Warning)QBT_TR[CONTEXT=ExecutionLogWidget]';
+                        logLevel = i18next.t('Warning');
                         addClass = 'logWarning';
                         break;
                     case 8:
-                        logLevel = 'QBT_TR(Critical)QBT_TR[CONTEXT=ExecutionLogWidget]';
+                        logLevel = i18next.t('Critical');
                         addClass = 'logCritical';
                         break;
                     default:
-                        logLevel = 'QBT_TR(Unknown)QBT_TR[CONTEXT=ExecutionLogWidget]';
+                        logLevel = i18next.t('Unknown');
                         addClass = 'logUnknown';
                         break;
                 }
@@ -3158,11 +3158,11 @@ window.qBittorrent.DynamicTable = (function() {
         Extends: LogMessageTable,
 
         initColumns: function() {
-            this.newColumn('rowId', '', 'QBT_TR(ID)QBT_TR[CONTEXT=ExecutionLogWidget]', 50, true);
-            this.newColumn('ip', '', 'QBT_TR(IP)QBT_TR[CONTEXT=ExecutionLogWidget]', 150, true);
-            this.newColumn('timestamp', '', 'QBT_TR(Timestamp)QBT_TR[CONTEXT=ExecutionLogWidget]', 150, true);
-            this.newColumn('blocked', '', 'QBT_TR(Status)QBT_TR[CONTEXT=ExecutionLogWidget]', 150, true);
-            this.newColumn('reason', '', 'QBT_TR(Reason)QBT_TR[CONTEXT=ExecutionLogWidget]', 150, true);
+            this.newColumn('rowId', '', i18next.t('ID'), 50, true);
+            this.newColumn('ip', '', i18next.t('IP'), 150, true);
+            this.newColumn('timestamp', '', i18next.t('Timestamp'), 150, true);
+            this.newColumn('blocked', '', i18next.t('Status'), 150, true);
+            this.newColumn('reason', '', i18next.t('Reason'), 150, true);
 
             this.columns['timestamp'].updateTd = function(td, row) {
                 const date = new Date(this.getRowValue(row) * 1000).toLocaleString();
@@ -3172,11 +3172,11 @@ window.qBittorrent.DynamicTable = (function() {
             this.columns['blocked'].updateTd = function(td, row) {
                 let status, addClass;
                 if (this.getRowValue(row)) {
-                    status = 'QBT_TR(Blocked)QBT_TR[CONTEXT=ExecutionLogWidget]';
+                    status = i18next.t('Blocked');
                     addClass = 'peerBlocked';
                 }
                 else {
-                    status = 'QBT_TR(Banned)QBT_TR[CONTEXT=ExecutionLogWidget]';
+                    status = i18next.t('Banned');
                     addClass = 'peerBanned';
                 }
                 td.set({ 'text': status, 'title': status });

--- a/src/webui/www/private/scripts/misc.js
+++ b/src/webui/www/private/scripts/misc.js
@@ -58,17 +58,17 @@ window.qBittorrent.Misc = (function() {
      */
     const friendlyUnit = function(value, isSpeed) {
         const units = [
-            "QBT_TR(B)QBT_TR[CONTEXT=misc]",
-            "QBT_TR(KiB)QBT_TR[CONTEXT=misc]",
-            "QBT_TR(MiB)QBT_TR[CONTEXT=misc]",
-            "QBT_TR(GiB)QBT_TR[CONTEXT=misc]",
-            "QBT_TR(TiB)QBT_TR[CONTEXT=misc]",
-            "QBT_TR(PiB)QBT_TR[CONTEXT=misc]",
-            "QBT_TR(EiB)QBT_TR[CONTEXT=misc]"
+            i18next.t("B"),
+            i18next.t("KiB"),
+            i18next.t("MiB"),
+            i18next.t("GiB"),
+            i18next.t("TiB"),
+            i18next.t("PiB"),
+            i18next.t("EiB")
         ];
 
         if ((value === undefined) || (value === null) || (value < 0))
-            return "QBT_TR(Unknown)QBT_TR[CONTEXT=misc]";
+            return i18next.t("Unknown");
 
         let i = 0;
         while (value >= 1024.0 && i < 6) {
@@ -96,7 +96,7 @@ window.qBittorrent.Misc = (function() {
         }
 
         if (isSpeed)
-            ret += "QBT_TR(/s)QBT_TR[CONTEXT=misc]";
+            ret += i18next.t("/s");
         return ret;
     };
 
@@ -109,21 +109,21 @@ window.qBittorrent.Misc = (function() {
         if (seconds === 0)
             return "0";
         if (seconds < 60)
-            return "QBT_TR(< 1m)QBT_TR[CONTEXT=misc]";
+            return i18next.t("< 1m");
         let minutes = seconds / 60;
         if (minutes < 60)
-            return "QBT_TR(%1m)QBT_TR[CONTEXT=misc]".replace("%1", parseInt(minutes));
+            return i18next.t("%1m").replace("%1", parseInt(minutes));
         let hours = minutes / 60;
         minutes = minutes % 60;
         if (hours < 24)
-            return "QBT_TR(%1h %2m)QBT_TR[CONTEXT=misc]".replace("%1", parseInt(hours)).replace("%2", parseInt(minutes));
+            return i18next.t("%1h %2m").replace("%1", parseInt(hours)).replace("%2", parseInt(minutes));
         let days = hours / 24;
         hours = hours % 24;
         if (days < 365)
-            return "QBT_TR(%1d %2h)QBT_TR[CONTEXT=misc]".replace("%1", parseInt(days)).replace("%2", parseInt(hours));
+            return i18next.t("%1d %2h").replace("%1", parseInt(days)).replace("%2", parseInt(hours));
         const years = days / 365;
         days = days % 365;
-        return "QBT_TR(%1y %2d)QBT_TR[CONTEXT=misc]".replace("%1", parseInt(years)).replace("%2", parseInt(days));
+        return i18next.t("%1y %2d").replace("%1", parseInt(years)).replace("%2", parseInt(days));
     };
 
     const friendlyPercentage = function(value) {

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -131,7 +131,7 @@ const initializeWindows = function() {
 
         new MochaUI.Window({
             id: id,
-            title: "QBT_TR(Download from URLs)QBT_TR[CONTEXT=downloadFromURL]",
+            title: i18next.t("Download from URLs"),
             loadMethod: 'iframe',
             contentURL: contentUri.toString(),
             addClass: 'windowFrame', // fixes iframe scrolling on iOS Safari
@@ -154,7 +154,7 @@ const initializeWindows = function() {
         const id = 'preferencesPage';
         new MochaUI.Window({
             id: id,
-            title: "QBT_TR(Options)QBT_TR[CONTEXT=OptionsDialog]",
+            title: i18next.t("Options"),
             loadMethod: 'xhr',
             toolbar: true,
             contentURL: new URI("views/preferences.html").toString(),
@@ -179,7 +179,7 @@ const initializeWindows = function() {
         const id = 'uploadPage';
         new MochaUI.Window({
             id: id,
-            title: "QBT_TR(Upload local torrent)QBT_TR[CONTEXT=HttpServer]",
+            title: i18next.t("Upload local torrent"),
             loadMethod: 'iframe',
             contentURL: new URI("upload.html").toString(),
             addClass: 'windowFrame', // fixes iframe scrolling on iOS Safari
@@ -199,7 +199,7 @@ const initializeWindows = function() {
     globalUploadLimitFN = function() {
         new MochaUI.Window({
             id: 'uploadLimitPage',
-            title: "QBT_TR(Global Upload Speed Limit)QBT_TR[CONTEXT=MainWindow]",
+            title: i18next.t("Global Upload Speed Limit"),
             loadMethod: 'iframe',
             contentURL: new URI("uploadlimit.html").setData("hashes", "global").toString(),
             scrollbars: false,
@@ -217,7 +217,7 @@ const initializeWindows = function() {
         if (hashes.length) {
             new MochaUI.Window({
                 id: 'uploadLimitPage',
-                title: "QBT_TR(Torrent Upload Speed Limiting)QBT_TR[CONTEXT=TransferListWidget]",
+                title: i18next.t("Torrent Upload Speed Limiting"),
                 loadMethod: 'iframe',
                 contentURL: new URI("uploadlimit.html").setData("hashes", hashes.join("|")).toString(),
                 scrollbars: false,
@@ -258,7 +258,7 @@ const initializeWindows = function() {
             const orig = torrentsHaveSameShareRatio ? shareRatio : "";
             new MochaUI.Window({
                 id: 'shareRatioPage',
-                title: "QBT_TR(Torrent Upload/Download Ratio Limiting)QBT_TR[CONTEXT=UpDownRatioDialog]",
+                title: i18next.t("Torrent Upload/Download Ratio Limiting"),
                 loadMethod: 'iframe',
                 contentURL: new URI("shareratio.html").setData("hashes", hashes.join("|")).setData("orig", orig).toString(),
                 scrollbars: false,
@@ -332,7 +332,7 @@ const initializeWindows = function() {
     globalDownloadLimitFN = function() {
         new MochaUI.Window({
             id: 'downloadLimitPage',
-            title: "QBT_TR(Global Download Speed Limit)QBT_TR[CONTEXT=MainWindow]",
+            title: i18next.t("Global Download Speed Limit"),
             loadMethod: 'iframe',
             contentURL: new URI("downloadlimit.html").setData("hashes", "global").toString(),
             scrollbars: false,
@@ -349,7 +349,7 @@ const initializeWindows = function() {
         const id = 'statisticspage';
         new MochaUI.Window({
             id: id,
-            title: 'QBT_TR(Statistics)QBT_TR[CONTEXT=StatsDialog]',
+            title: i18next.t('Statistics'),
             loadMethod: 'xhr',
             contentURL: new URI("views/statistics.html").toString(),
             maximizable: false,
@@ -367,7 +367,7 @@ const initializeWindows = function() {
         if (hashes.length) {
             new MochaUI.Window({
                 id: 'downloadLimitPage',
-                title: "QBT_TR(Torrent Download Speed Limiting)QBT_TR[CONTEXT=TransferListWidget]",
+                title: i18next.t("Torrent Download Speed Limiting"),
                 loadMethod: 'iframe',
                 contentURL: new URI("downloadlimit.html").setData("hashes", hashes.join("|")).toString(),
                 scrollbars: false,
@@ -386,7 +386,7 @@ const initializeWindows = function() {
         if (hashes.length) {
             new MochaUI.Window({
                 id: 'confirmDeletionPage',
-                title: "QBT_TR(Remove torrent(s))QBT_TR[CONTEXT=confirmDeletionDlg]",
+                title: i18next.t("Remove torrent(s)"),
                 loadMethod: 'iframe',
                 contentURL: new URI("confirmdeletion.html").setData("hashes", hashes.join("|")).setData("deleteFiles", deleteFiles).toString(),
                 scrollbars: false,
@@ -490,7 +490,7 @@ const initializeWindows = function() {
 
             new MochaUI.Window({
                 id: 'setLocationPage',
-                title: "QBT_TR(Set location)QBT_TR[CONTEXT=TransferListWidget]",
+                title: i18next.t("Set location"),
                 loadMethod: 'iframe',
                 contentURL: new URI("setlocation.html").setData("hashes", hashes.join('|')).setData("path", encodeURIComponent(row.full_data.save_path)).toString(),
                 scrollbars: false,
@@ -512,7 +512,7 @@ const initializeWindows = function() {
             if (row) {
                 new MochaUI.Window({
                     id: 'renamePage',
-                    title: "QBT_TR(Rename)QBT_TR[CONTEXT=TransferListWidget]",
+                    title: i18next.t("Rename"),
                     loadMethod: 'iframe',
                     contentURL: new URI("rename.html").setData("hash", hash).setData("name", row.full_data.name).toString(),
                     scrollbars: false,
@@ -535,7 +535,7 @@ const initializeWindows = function() {
             if (row) {
                 new MochaUI.Window({
                     id: 'multiRenamePage',
-                    title: "QBT_TR(Renaming)QBT_TR[CONTEXT=TransferListWidget]",
+                    title: i18next.t("Renaming"),
                     data: { hash: hash, selectedRows: [] },
                     loadMethod: 'xhr',
                     contentURL: 'rename_files.html',
@@ -558,7 +558,7 @@ const initializeWindows = function() {
         if (hashes.length) {
             new MochaUI.Window({
                 id: 'newCategoryPage',
-                title: "QBT_TR(New Category)QBT_TR[CONTEXT=TransferListWidget]",
+                title: i18next.t("New Category"),
                 loadMethod: 'iframe',
                 contentURL: new URI("newcategory.html").setData("action", action).setData("hashes", hashes.join('|')).toString(),
                 scrollbars: false,
@@ -594,7 +594,7 @@ const initializeWindows = function() {
         const action = "create";
         new MochaUI.Window({
             id: 'newCategoryPage',
-            title: "QBT_TR(New Category)QBT_TR[CONTEXT=CategoryFilterWidget]",
+            title: i18next.t("New Category"),
             loadMethod: 'iframe',
             contentURL: new URI("newcategory.html").setData("action", action).toString(),
             scrollbars: false,
@@ -613,7 +613,7 @@ const initializeWindows = function() {
         const categoryName = category_list.get(categoryHash).name + "/";
         new MochaUI.Window({
             id: 'newSubcategoryPage',
-            title: "QBT_TR(New Category)QBT_TR[CONTEXT=CategoryFilterWidget]",
+            title: i18next.t("New Category"),
             loadMethod: 'iframe',
             contentURL: new URI("newcategory.html").setData("action", action).setData("categoryName", categoryName).toString(),
             scrollbars: false,
@@ -632,7 +632,7 @@ const initializeWindows = function() {
         const category = category_list.get(categoryHash);
         new MochaUI.Window({
             id: 'editCategoryPage',
-            title: "QBT_TR(Edit Category)QBT_TR[CONTEXT=TransferListWidget]",
+            title: i18next.t("Edit Category"),
             loadMethod: 'iframe',
             contentURL: new URI('newcategory.html').setData("action", action).setData("categoryName", category.name).setData("savePath", category.savePath).toString(),
             scrollbars: false,
@@ -708,7 +708,7 @@ const initializeWindows = function() {
         if (hashes.length) {
             new MochaUI.Window({
                 id: 'confirmDeletionPage',
-                title: "QBT_TR(Remove torrent(s))QBT_TR[CONTEXT=confirmDeletionDlg]",
+                title: i18next.t("Remove torrent(s)"),
                 loadMethod: 'iframe',
                 contentURL: new URI("confirmdeletion.html").setData("hashes", hashes.join("|")).toString(),
                 scrollbars: false,
@@ -728,7 +728,7 @@ const initializeWindows = function() {
         if (hashes.length) {
             new MochaUI.Window({
                 id: 'newTagPage',
-                title: "QBT_TR(Add Tags)QBT_TR[CONTEXT=TransferListWidget]",
+                title: i18next.t("Add Tags"),
                 loadMethod: 'iframe',
                 contentURL: new URI("newtag.html").setData("action", action).setData("hashes", hashes.join("|")).toString(),
                 scrollbars: false,
@@ -775,7 +775,7 @@ const initializeWindows = function() {
         const action = "create";
         new MochaUI.Window({
             id: 'newTagPage',
-            title: "QBT_TR(New Tag)QBT_TR[CONTEXT=TagFilterWidget]",
+            title: i18next.t("New Tag"),
             loadMethod: 'iframe',
             contentURL: new URI("newtag.html").setData("action", action).toString(),
             scrollbars: false,
@@ -850,7 +850,7 @@ const initializeWindows = function() {
         if (hashes.length) {
             new MochaUI.Window({
                 id: 'confirmDeletionPage',
-                title: "QBT_TR(Remove torrent(s))QBT_TR[CONTEXT=confirmDeletionDlg]",
+                title: i18next.t("Remove torrent(s)"),
                 loadMethod: 'iframe',
                 contentURL: new URI("confirmdeletion.html").setData("hashes", hashes.join("|")).toString(),
                 scrollbars: false,
@@ -936,7 +936,7 @@ const initializeWindows = function() {
         if (hashes.length) {
             new MochaUI.Window({
                 id: 'confirmDeletionPage',
-                title: "QBT_TR(Remove torrent(s))QBT_TR[CONTEXT=confirmDeletionDlg]",
+                title: i18next.t("Remove torrent(s)"),
                 loadMethod: 'iframe',
                 contentURL: new URI("confirmdeletion.html").setData("hashes", hashes.join("|")).toString(),
                 scrollbars: false,
@@ -1050,7 +1050,7 @@ const initializeWindows = function() {
     addClickEvent('pauseAll', (e) => {
         new Event(e).stop();
 
-        if (confirm('QBT_TR(Would you like to pause all torrents?)QBT_TR[CONTEXT=MainWindow]')) {
+        if (confirm(i18next.t('Would you like to pause all torrents?'))) {
             new Request({
                 url: 'api/v2/torrents/pause',
                 method: 'post',
@@ -1065,7 +1065,7 @@ const initializeWindows = function() {
     addClickEvent('resumeAll', (e) => {
         new Event(e).stop();
 
-        if (confirm('QBT_TR(Would you like to resume all torrents?)QBT_TR[CONTEXT=MainWindow]')) {
+        if (confirm(i18next.t('Would you like to resume all torrents?'))) {
             new Request({
                 url: 'api/v2/torrents/resume',
                 method: 'post',
@@ -1122,7 +1122,7 @@ const initializeWindows = function() {
         const id = 'aboutpage';
         new MochaUI.Window({
             id: id,
-            title: 'QBT_TR(About qBittorrent)QBT_TR[CONTEXT=AboutDialog]',
+            title: i18next.t('About qBittorrent'),
             loadMethod: 'xhr',
             contentURL: new URI("views/about.html").toString(),
             require: {
@@ -1152,12 +1152,12 @@ const initializeWindows = function() {
 
     addClickEvent('shutdown', function(e) {
         new Event(e).stop();
-        if (confirm('QBT_TR(Are you sure you want to quit qBittorrent?)QBT_TR[CONTEXT=MainWindow]')) {
+        if (confirm(i18next.t('Are you sure you want to quit qBittorrent?'))) {
             new Request({
                 url: 'api/v2/app/shutdown',
                 method: 'post',
                 onSuccess: function() {
-                    const shutdownMessage = 'QBT_TR(%1 has been shutdown)QBT_TR[CONTEXT=HttpServer]'.replace("%1", window.qBittorrent.Client.mainTitle());
+                    const shutdownMessage = i18next.t('%1 has been shutdown').replace("%1", window.qBittorrent.Client.mainTitle());
                     document.write(`<!doctype html><html lang="${LANG}"><head> <meta charset="UTF-8"> <meta name="color-scheme" content="light dark"> <title>${shutdownMessage}</title> <style>* {font-family: Arial, Helvetica, sans-serif;}</style></head><body> <h1 style="text-align: center;">${shutdownMessage}</h1></body></html>`);
                     document.close();
                     window.stop();

--- a/src/webui/www/private/scripts/prop-files.js
+++ b/src/webui/www/private/scripts/prop-files.js
@@ -185,13 +185,13 @@ window.qBittorrent.PropFiles = (function() {
         select.addClass('combo_priority');
         select.addEvent('change', fileComboboxChanged);
 
-        createPriorityOptionElement(FilePriority.Ignored, (FilePriority.Ignored === selectedPriority), 'QBT_TR(Do not download)QBT_TR[CONTEXT=PropListDelegate]').injectInside(select);
-        createPriorityOptionElement(FilePriority.Normal, (FilePriority.Normal === selectedPriority), 'QBT_TR(Normal)QBT_TR[CONTEXT=PropListDelegate]').injectInside(select);
-        createPriorityOptionElement(FilePriority.High, (FilePriority.High === selectedPriority), 'QBT_TR(High)QBT_TR[CONTEXT=PropListDelegate]').injectInside(select);
-        createPriorityOptionElement(FilePriority.Maximum, (FilePriority.Maximum === selectedPriority), 'QBT_TR(Maximum)QBT_TR[CONTEXT=PropListDelegate]').injectInside(select);
+        createPriorityOptionElement(FilePriority.Ignored, (FilePriority.Ignored === selectedPriority), i18next.t('Do not download')).injectInside(select);
+        createPriorityOptionElement(FilePriority.Normal, (FilePriority.Normal === selectedPriority), i18next.t('Normal')).injectInside(select);
+        createPriorityOptionElement(FilePriority.High, (FilePriority.High === selectedPriority), i18next.t('High')).injectInside(select);
+        createPriorityOptionElement(FilePriority.Maximum, (FilePriority.Maximum === selectedPriority), i18next.t('Maximum')).injectInside(select);
 
         // "Mixed" priority is for display only; it shouldn't be selectable
-        const mixedPriorityOption = createPriorityOptionElement(FilePriority.Mixed, (FilePriority.Mixed === selectedPriority), 'QBT_TR(Mixed)QBT_TR[CONTEXT=PropListDelegate]');
+        const mixedPriorityOption = createPriorityOptionElement(FilePriority.Mixed, (FilePriority.Mixed === selectedPriority), i18next.t('Mixed'));
         mixedPriorityOption.set('disabled', true);
         mixedPriorityOption.injectInside(select);
 
@@ -550,7 +550,7 @@ window.qBittorrent.PropFiles = (function() {
 
         new MochaUI.Window({
             id: 'renamePage',
-            title: "QBT_TR(Renaming)QBT_TR[CONTEXT=TorrentContentTreeView]",
+            title: i18next.t("Renaming"),
             loadMethod: 'iframe',
             contentURL: 'rename_file.html?hash=' + hash + '&isFolder=' + node.isFolder
                 + '&path=' + encodeURIComponent(path),
@@ -567,7 +567,7 @@ window.qBittorrent.PropFiles = (function() {
     const multiFileRename = function(hash) {
         new MochaUI.Window({
             id: 'multiRenamePage',
-            title: "QBT_TR(Renaming)QBT_TR[CONTEXT=TorrentContentTreeView]",
+            title: i18next.t("Renaming"),
             data: { hash: hash, selectedRows: torrentFilesTable.selectedRows },
             loadMethod: 'xhr',
             contentURL: 'rename_files.html',

--- a/src/webui/www/private/scripts/prop-general.js
+++ b/src/webui/www/private/scripts/prop-general.js
@@ -93,7 +93,7 @@ window.qBittorrent.PropGeneral = (function() {
             method: 'get',
             noCache: true,
             onFailure: function() {
-                $('error_div').set('html', 'QBT_TR(qBittorrent client is not reachable)QBT_TR[CONTEXT=HttpServer]');
+                $('error_div').set('html', i18next.t('qBittorrent client is not reachable'));
                 clearTimeout(loadTorrentDataTimer);
                 loadTorrentDataTimer = loadTorrentData.delay(10000);
             },
@@ -103,7 +103,7 @@ window.qBittorrent.PropGeneral = (function() {
                     // Update Torrent data
 
                     const timeElapsed = (data.seeding_time > 0)
-                        ? "QBT_TR(%1 (seeded for %2))QBT_TR[CONTEXT=PropertiesWidget]"
+                        ? i18next.t("%1 (seeded for %2)")
                         .replace("%1", window.qBittorrent.Misc.friendlyDuration(data.time_elapsed))
                         .replace("%2", window.qBittorrent.Misc.friendlyDuration(data.seeding_time))
                         : window.qBittorrent.Misc.friendlyDuration(data.time_elapsed);
@@ -111,27 +111,27 @@ window.qBittorrent.PropGeneral = (function() {
 
                     $('eta').set('html', window.qBittorrent.Misc.friendlyDuration(data.eta, window.qBittorrent.Misc.MAX_ETA));
 
-                    const nbConnections = "QBT_TR(%1 (%2 max))QBT_TR[CONTEXT=PropertiesWidget]"
+                    const nbConnections = i18next.t("%1 (%2 max)")
                         .replace("%1", data.nb_connections)
                         .replace("%2", ((data.nb_connections_limit < 0) ? "∞" : data.nb_connections_limit));
                     $('nb_connections').set('html', nbConnections);
 
-                    const totalDownloaded = "QBT_TR(%1 (%2 this session))QBT_TR[CONTEXT=PropertiesWidget]"
+                    const totalDownloaded = i18next.t("%1 (%2 this session)")
                         .replace("%1", window.qBittorrent.Misc.friendlyUnit(data.total_downloaded))
                         .replace("%2", window.qBittorrent.Misc.friendlyUnit(data.total_downloaded_session));
                     $('total_downloaded').set('html', totalDownloaded);
 
-                    const totalUploaded = "QBT_TR(%1 (%2 this session))QBT_TR[CONTEXT=PropertiesWidget]"
+                    const totalUploaded = i18next.t("%1 (%2 this session)")
                         .replace("%1", window.qBittorrent.Misc.friendlyUnit(data.total_uploaded))
                         .replace("%2", window.qBittorrent.Misc.friendlyUnit(data.total_uploaded_session));
                     $('total_uploaded').set('html', totalUploaded);
 
-                    const dlSpeed = "QBT_TR(%1 (%2 avg.))QBT_TR[CONTEXT=PropertiesWidget]"
+                    const dlSpeed = i18next.t("%1 (%2 avg.)")
                         .replace("%1", window.qBittorrent.Misc.friendlyUnit(data.dl_speed, true))
                         .replace("%2", window.qBittorrent.Misc.friendlyUnit(data.dl_speed_avg, true));
                     $('dl_speed').set('html', dlSpeed);
 
-                    const upSpeed = "QBT_TR(%1 (%2 avg.))QBT_TR[CONTEXT=PropertiesWidget]"
+                    const upSpeed = i18next.t("%1 (%2 avg.)")
                         .replace("%1", window.qBittorrent.Misc.friendlyUnit(data.up_speed, true))
                         .replace("%2", window.qBittorrent.Misc.friendlyUnit(data.up_speed_avg, true));
                     $('up_speed').set('html', upSpeed);
@@ -148,12 +148,12 @@ window.qBittorrent.PropGeneral = (function() {
 
                     $('total_wasted').set('html', window.qBittorrent.Misc.friendlyUnit(data.total_wasted));
 
-                    const seeds = "QBT_TR(%1 (%2 total))QBT_TR[CONTEXT=PropertiesWidget]"
+                    const seeds = i18next.t("%1 (%2 total)")
                         .replace("%1", data.seeds)
                         .replace("%2", data.seeds_total);
                     $('seeds').set('html', seeds);
 
-                    const peers = "QBT_TR(%1 (%2 total))QBT_TR[CONTEXT=PropertiesWidget]"
+                    const peers = i18next.t("%1 (%2 total)")
                         .replace("%1", data.peers)
                         .replace("%2", data.peers_total);
                     $('peers').set('html', peers);
@@ -164,14 +164,14 @@ window.qBittorrent.PropGeneral = (function() {
 
                     const lastSeen = (data.last_seen >= 0)
                         ? new Date(data.last_seen * 1000).toLocaleString()
-                        : "QBT_TR(Never)QBT_TR[CONTEXT=PropertiesWidget]";
+                        : i18next.t("Never");
                     $('last_seen').set('html', lastSeen);
 
                     const totalSize = (data.total_size >= 0) ? window.qBittorrent.Misc.friendlyUnit(data.total_size) : "";
                     $('total_size').set('html', totalSize);
 
                     const pieces = (data.pieces_num >= 0)
-                        ? "QBT_TR(%1 x %2 (have %3))QBT_TR[CONTEXT=PropertiesWidget]"
+                        ? i18next.t("%1 x %2 (have %3)")
                         .replace("%1", data.pieces_num)
                         .replace("%2", window.qBittorrent.Misc.friendlyUnit(data.piece_size))
                         .replace("%3", data.pieces_have)
@@ -182,7 +182,7 @@ window.qBittorrent.PropGeneral = (function() {
 
                     const additionDate = (data.addition_date >= 0)
                         ? new Date(data.addition_date * 1000).toLocaleString()
-                        : "QBT_TR(Unknown)QBT_TR[CONTEXT=HttpServer]";
+                        : i18next.t("Unknown");
                     $('addition_date').set('html', additionDate);
 
                     const completionDate = (data.completion_date >= 0)
@@ -197,12 +197,12 @@ window.qBittorrent.PropGeneral = (function() {
 
                     const torrentHashV1 = (data.infohash_v1 !== "")
                         ? data.infohash_v1
-                        : "QBT_TR(N/A)QBT_TR[CONTEXT=PropertiesWidget]";
+                        : i18next.t("N/A");
                     $('torrent_hash_v1').set('html', torrentHashV1);
 
                     const torrentHashV2 = (data.infohash_v2 !== "")
                         ? data.infohash_v2
-                        : "QBT_TR(N/A)QBT_TR[CONTEXT=PropertiesWidget]";
+                        : i18next.t("N/A");
                     $('torrent_hash_v2').set('html', torrentHashV2);
 
                     $('save_path').set('html', data.save_path);
@@ -223,7 +223,7 @@ window.qBittorrent.PropGeneral = (function() {
             method: 'get',
             noCache: true,
             onFailure: function() {
-                $('error_div').set('html', 'QBT_TR(qBittorrent client is not reachable)QBT_TR[CONTEXT=HttpServer]');
+                $('error_div').set('html', i18next.t('qBittorrent client is not reachable'));
                 clearTimeout(loadTorrentDataTimer);
                 loadTorrentDataTimer = loadTorrentData.delay(10000);
             },

--- a/src/webui/www/private/scripts/prop-peers.js
+++ b/src/webui/www/private/scripts/prop-peers.js
@@ -124,7 +124,7 @@ window.qBittorrent.PropPeers = (function() {
 
                 new MochaUI.Window({
                     id: 'addPeersPage',
-                    title: "QBT_TR(Add Peers)QBT_TR[CONTEXT=PeersAdditionDialog]",
+                    title: i18next.t("Add Peers"),
                     loadMethod: 'iframe',
                     contentURL: 'addpeers.html?hash=' + hash,
                     scrollbars: false,
@@ -141,7 +141,7 @@ window.qBittorrent.PropPeers = (function() {
                 if (selectedPeers.length === 0)
                     return;
 
-                if (confirm('QBT_TR(Are you sure you want to permanently ban the selected peers?)QBT_TR[CONTEXT=PeerListWidget]')) {
+                if (confirm(i18next.t('Are you sure you want to permanently ban the selected peers?'))) {
                     new Request({
                         url: 'api/v2/transfer/banPeers',
                         method: 'post',

--- a/src/webui/www/private/scripts/prop-trackers.js
+++ b/src/webui/www/private/scripts/prop-trackers.js
@@ -79,19 +79,19 @@ window.qBittorrent.PropTrackers = (function() {
                         let status;
                         switch (tracker.status) {
                             case 0:
-                                status = "QBT_TR(Disabled)QBT_TR[CONTEXT=TrackerListWidget]";
+                                status = i18next.t("Disabled");
                                 break;
                             case 1:
-                                status = "QBT_TR(Not contacted yet)QBT_TR[CONTEXT=TrackerListWidget]";
+                                status = i18next.t("Not contacted yet");
                                 break;
                             case 2:
-                                status = "QBT_TR(Working)QBT_TR[CONTEXT=TrackerListWidget]";
+                                status = i18next.t("Working");
                                 break;
                             case 3:
-                                status = "QBT_TR(Updating...)QBT_TR[CONTEXT=TrackerListWidget]";
+                                status = i18next.t("Updating...");
                                 break;
                             case 4:
-                                status = "QBT_TR(Not working)QBT_TR[CONTEXT=TrackerListWidget]";
+                                status = i18next.t("Not working");
                                 break;
                         }
 
@@ -101,9 +101,9 @@ window.qBittorrent.PropTrackers = (function() {
                             url: tracker.url,
                             status: status,
                             peers: tracker.num_peers,
-                            seeds: (tracker.num_seeds >= 0) ? tracker.num_seeds : "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]",
-                            leeches: (tracker.num_leeches >= 0) ? tracker.num_leeches : "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]",
-                            downloaded: (tracker.num_downloaded >= 0) ? tracker.num_downloaded : "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]",
+                            seeds: (tracker.num_seeds >= 0) ? tracker.num_seeds : i18next.t("N/A"),
+                            leeches: (tracker.num_leeches >= 0) ? tracker.num_leeches : i18next.t("N/A"),
+                            downloaded: (tracker.num_downloaded >= 0) ? tracker.num_downloaded : i18next.t("N/A"),
                             message: tracker.msg
                         };
 
@@ -169,7 +169,7 @@ window.qBittorrent.PropTrackers = (function() {
             return;
         new MochaUI.Window({
             id: 'trackersPage',
-            title: "QBT_TR(Add trackers)QBT_TR[CONTEXT=TrackersAdditionDialog]",
+            title: i18next.t("Add trackers"),
             loadMethod: 'iframe',
             contentURL: 'addtrackers.html?hash=' + current_hash,
             scrollbars: true,
@@ -193,7 +193,7 @@ window.qBittorrent.PropTrackers = (function() {
         const trackerUrl = encodeURIComponent(element.childNodes[1].innerText);
         new MochaUI.Window({
             id: 'trackersPage',
-            title: "QBT_TR(Tracker editing)QBT_TR[CONTEXT=TrackerListWidget]",
+            title: i18next.t("Tracker editing"),
             loadMethod: 'iframe',
             contentURL: 'edittracker.html?hash=' + current_hash + '&url=' + trackerUrl,
             scrollbars: true,

--- a/src/webui/www/private/scripts/prop-webseeds.js
+++ b/src/webui/www/private/scripts/prop-webseeds.js
@@ -116,7 +116,7 @@ window.qBittorrent.PropWebseeds = (function() {
             method: 'get',
             noCache: true,
             onFailure: function() {
-                $('error_div').set('html', 'QBT_TR(qBittorrent client is not reachable)QBT_TR[CONTEXT=HttpServer]');
+                $('error_div').set('html', i18next.t('qBittorrent client is not reachable'));
                 clearTimeout(loadWebSeedsDataTimer);
                 loadWebSeedsDataTimer = loadWebSeedsData.delay(20000);
             },

--- a/src/webui/www/private/setlocation.html
+++ b/src/webui/www/private/setlocation.html
@@ -42,7 +42,7 @@
                 // check field
                 const location = $('setLocation').value.trim();
                 if ((location === null) || (location === "")) {
-                    $('error_div').set('text', 'QBT_TR(Save path is empty)QBT_TR[CONTEXT=TorrentsController]');
+                    $('error_div').set('text', i18next.t('Save path is empty'));
                     return false;
                 }
 

--- a/src/webui/www/private/setlocation.html
+++ b/src/webui/www/private/setlocation.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(Set location)QBT_TR[CONTEXT=HttpServer]</title>
+    <title class="qbt-translatable" data-i18n="Set location">Set location</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
@@ -68,7 +68,7 @@
 
 <body>
     <div style="padding: 10px 10px 0px 10px;">
-        <p style="font-weight: bold;">QBT_TR(Location)QBT_TR[CONTEXT=TransferListWidget]:</p>
+        <p style="font-weight: bold;" class="qbt-translatable" data-i18n="Location">Location:</p>
         <input type="text" id="setLocation" autocorrect="off" autocapitalize="none" style="width: 99%;" />
         <div style="float: none; width: 99%;" id="error_div">&nbsp;</div>
         <div style="text-align: center; padding-top: 10px;">

--- a/src/webui/www/private/setlocation.html
+++ b/src/webui/www/private/setlocation.html
@@ -72,7 +72,7 @@
         <input type="text" id="setLocation" autocorrect="off" autocapitalize="none" style="width: 99%;" />
         <div style="float: none; width: 99%;" id="error_div">&nbsp;</div>
         <div style="text-align: center; padding-top: 10px;">
-            <input type="button" value="QBT_TR(Save)QBT_TR[CONTEXT=HttpServer]" id="setLocationButton" />
+            <input type="button" class="qbt-translatable" data-i18n="[value]Save" value="Save" id="setLocationButton" />
         </div>
     </div>
 </body>

--- a/src/webui/www/private/shareratio.html
+++ b/src/webui/www/private/shareratio.html
@@ -186,7 +186,7 @@
             <input type="number" id="inactiveMinutes" value="0" step="1" min="0" max="525600" class="shareLimitInput" />
         </div>
         <div style="text-align: center; padding-top: 10px;">
-            <input type="button" value="QBT_TR(Save)QBT_TR[CONTEXT=HttpServer]" id="save" />
+            <input type="button" class="qbt-translatable" data-i18n="[value]Save" value="Save" id="save" />
         </div>
     </div>
 </body>

--- a/src/webui/www/private/shareratio.html
+++ b/src/webui/www/private/shareratio.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(Torrent Upload/Download Ratio Limiting)QBT_TR[CONTEXT=UpDownRatioDialog]</title>
+    <title class="qbt-translatable" data-i18n="Torrent Upload/Download Ratio Limiting">Torrent Upload/Download Ratio Limiting</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
@@ -166,23 +166,23 @@
 
 <body>
     <div style="padding: 10px 10px 0px 10px;">
-        <input type="radio" name="shareLimit" id="default" value="default" onchange="shareLimitChanged()" checked style="margin-bottom: 5px;" />QBT_TR(Use global share limit)QBT_TR[CONTEXT=UpDownRatioDialog]<br />
-        <input type="radio" name="shareLimit" value="none" onchange="shareLimitChanged()" style="margin-bottom: 5px;" />QBT_TR(Set no share limit)QBT_TR[CONTEXT=UpDownRatioDialog]<br />
-        <input type="radio" name="shareLimit" value="custom" onchange="shareLimitChanged()" style="margin-bottom: 5px;" />QBT_TR(Set share limit to)QBT_TR[CONTEXT=UpDownRatioDialog]<br />
+        <input type="radio" name="shareLimit" id="default" value="default" onchange="shareLimitChanged()" checked style="margin-bottom: 5px;" / class="qbt-translatable" data-i18n="Use global share limit">Use global share limit<br />
+        <input type="radio" name="shareLimit" value="none" onchange="shareLimitChanged()" style="margin-bottom: 5px;" / class="qbt-translatable" data-i18n="Set no share limit">Set no share limit<br />
+        <input type="radio" name="shareLimit" value="custom" onchange="shareLimitChanged()" style="margin-bottom: 5px;" / class="qbt-translatable" data-i18n="Set share limit to">Set share limit to<br />
 
         <div style="margin-left: 40px; margin-bottom: 5px;">
             <input type="checkbox" id="setRatio" class="shareLimitInput" onclick="enableInputBoxes()" />
-            <label for="setRatio">QBT_TR(ratio)QBT_TR[CONTEXT=UpDownRatioDialog]</label>
+            <label for="setRatio" class="qbt-translatable" data-i18n="ratio">ratio</label>
             <input type="number" id="ratio" value="0.00" step=".01" min="0" max="9999" class="shareLimitInput" />
         </div>
         <div style="margin-left: 40px; margin-bottom: 5px;">
             <input type="checkbox" id="setTotalMinutes" class="shareLimitInput" onclick="enableInputBoxes()" />
-            <label for="setTotalMinutes">QBT_TR(total minutes)QBT_TR[CONTEXT=UpDownRatioDialog]</label>
+            <label for="setTotalMinutes" class="qbt-translatable" data-i18n="total minutes">total minutes</label>
             <input type="number" id="totalMinutes" value="0" step="1" min="0" max="525600" class="shareLimitInput" />
         </div>
         <div style="margin-left: 40px; margin-bottom: 5px;">
             <input type="checkbox" id="setInactiveMinutes" class="shareLimitInput" onclick="enableInputBoxes()" />
-            <label for="setInactiveMinutes">QBT_TR(inactive minutes)QBT_TR[CONTEXT=UpDownRatioDialog]</label>
+            <label for="setInactiveMinutes" class="qbt-translatable" data-i18n="inactive minutes">inactive minutes</label>
             <input type="number" id="inactiveMinutes" value="0" step="1" min="0" max="525600" class="shareLimitInput" />
         </div>
         <div style="text-align: center; padding-top: 10px;">

--- a/src/webui/www/private/upload.html
+++ b/src/webui/www/private/upload.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(Upload local torrent)QBT_TR[CONTEXT=HttpServer]</title>
+    <title class="qbt-translatable" data-i18n="Upload local torrent">Upload local torrent</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
     <link rel="stylesheet" href="css/Window.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
@@ -20,18 +20,18 @@
             <table style="margin: auto;">
                 <tr>
                     <td>
-                        <label for="autoTMM">QBT_TR(Torrent Management Mode:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                        <label for="autoTMM" class="qbt-translatable" data-i18n="Torrent Management Mode:">Torrent Management Mode:</label>
                     </td>
                     <td>
                         <select id="autoTMM" name="autoTMM" onchange="qBittorrent.Download.changeTMM(this)">
-                            <option selected value="false">QBT_TR(Manual)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
-                            <option value="true">QBT_TR(Automatic)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
+                            <option selected value="false" class="qbt-translatable" data-i18n="Manual">Manual</option>
+                            <option value="true" class="qbt-translatable" data-i18n="Automatic">Automatic</option>
                         </select>
                     </td>
                 </tr>
                 <tr>
                     <td>
-                        <label for="savepath">QBT_TR(Save files to location:)QBT_TR[CONTEXT=HttpServer]</label>
+                        <label for="savepath" class="qbt-translatable" data-i18n="Save files to location:">Save files to location:</label>
                     </td>
                     <td>
                         <input type="text" id="savepath" name="savepath" style="width: 16em;" />
@@ -39,7 +39,7 @@
                 </tr>
                 <tr>
                     <td>
-                        <label for="rename">QBT_TR(Rename torrent)QBT_TR[CONTEXT=HttpServer]</label>
+                        <label for="rename" class="qbt-translatable" data-i18n="Rename torrent">Rename torrent</label>
                     </td>
                     <td>
                         <input type="text" id="rename" name="rename" style="width: 16em;" />
@@ -47,7 +47,7 @@
                 </tr>
                 <tr>
                     <td>
-                        <label for="category">QBT_TR(Category:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                        <label for="category" class="qbt-translatable" data-i18n="Category:">Category:</label>
                     </td>
                     <td>
                         <div class="select-watched-folder-editable">
@@ -60,7 +60,7 @@
                 </tr>
                 <tr>
                     <td>
-                        <label for="startTorrent">QBT_TR(Start torrent)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                        <label for="startTorrent" class="qbt-translatable" data-i18n="Start torrent">Start torrent</label>
                     </td>
                     <td>
                         <input type="hidden" id="startTorrentHidden" name="paused" />
@@ -69,7 +69,7 @@
                 </tr>
                 <tr>
                     <td>
-                        <label for="addToTopOfQueue">QBT_TR(Add to top of queue)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                        <label for="addToTopOfQueue" class="qbt-translatable" data-i18n="Add to top of queue">Add to top of queue</label>
                     </td>
                     <td>
                         <input type="checkbox" id="addToTopOfQueue" name="addToTopOfQueue" value="true" />
@@ -77,19 +77,19 @@
                 </tr>
                 <tr>
                     <td>
-                        <label for="stopCondition">QBT_TR(Stop condition:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                        <label for="stopCondition" class="qbt-translatable" data-i18n="Stop condition:">Stop condition:</label>
                     </td>
                     <td>
                         <select id="stopCondition" name="stopCondition">
-                            <option selected value="None">QBT_TR(None)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
-                            <option value="MetadataReceived">QBT_TR(Metadata received)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
-                            <option value="FilesChecked">QBT_TR(Files checked)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
+                            <option selected value="None" class="qbt-translatable" data-i18n="None">None</option>
+                            <option value="MetadataReceived" class="qbt-translatable" data-i18n="Metadata received">Metadata received</option>
+                            <option value="FilesChecked" class="qbt-translatable" data-i18n="Files checked">Files checked</option>
                         </select>
                     </td>
                 </tr>
                 <tr>
                     <td>
-                        <label for="skip_checking">QBT_TR(Skip hash check)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                        <label for="skip_checking" class="qbt-translatable" data-i18n="Skip hash check">Skip hash check</label>
                     </td>
                     <td>
                         <input type="checkbox" id="skip_checking" name="skip_checking" value="true" />
@@ -97,19 +97,19 @@
                 </tr>
                 <tr>
                     <td>
-                        <label for="contentLayout">QBT_TR(Content layout:)QBT_TR[CONTEXT=AddNewTorrentDialog]</label>
+                        <label for="contentLayout" class="qbt-translatable" data-i18n="Content layout:">Content layout:</label>
                     </td>
                     <td>
                         <select id="contentLayout" name="contentLayout">
-                            <option selected value="Original">QBT_TR(Original)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
-                            <option value="Subfolder">QBT_TR(Create subfolder)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
-                            <option value="NoSubfolder">QBT_TR(Don't create subfolder)QBT_TR[CONTEXT=AddNewTorrentDialog]</option>
+                            <option selected value="Original" class="qbt-translatable" data-i18n="Original">Original</option>
+                            <option value="Subfolder" class="qbt-translatable" data-i18n="Create subfolder">Create subfolder</option>
+                            <option value="NoSubfolder" class="qbt-translatable" data-i18n="Don't create subfolder">Don't create subfolder</option>
                         </select>
                     </td>
                 </tr>
                 <tr>
                     <td>
-                        <label for="sequentialDownload">QBT_TR(Download in sequential order)QBT_TR[CONTEXT=TransferListWidget]</label>
+                        <label for="sequentialDownload" class="qbt-translatable" data-i18n="Download in sequential order">Download in sequential order</label>
                     </td>
                     <td>
                         <input type="checkbox" id="sequentialDownload" name="sequentialDownload" value="true" />
@@ -117,7 +117,7 @@
                 </tr>
                 <tr>
                     <td>
-                        <label for="firstLastPiecePrio">QBT_TR(Download first and last pieces first)QBT_TR[CONTEXT=TransferListWidget]</label>
+                        <label for="firstLastPiecePrio" class="qbt-translatable" data-i18n="Download first and last pieces first">Download first and last pieces first</label>
                     </td>
                     <td>
                         <input type="checkbox" id="firstLastPiecePrio" name="firstLastPiecePrio" value="true" />
@@ -125,7 +125,7 @@
                 </tr>
                 <tr>
                     <td>
-                        <label for="dlLimitText">QBT_TR(Limit download rate)QBT_TR[CONTEXT=HttpServer]</label>
+                        <label for="dlLimitText" class="qbt-translatable" data-i18n="Limit download rate">Limit download rate</label>
                     </td>
                     <td>
                         <input type="hidden" id="dlLimitHidden" name="dlLimit" />
@@ -134,7 +134,7 @@
                 </tr>
                 <tr>
                     <td>
-                        <label for="upLimitText">QBT_TR(Limit upload rate)QBT_TR[CONTEXT=HttpServer]</label>
+                        <label for="upLimitText" class="qbt-translatable" data-i18n="Limit upload rate">Limit upload rate</label>
                     </td>
                     <td>
                         <input type="hidden" id="upLimitHidden" name="upLimit" />
@@ -143,7 +143,7 @@
                 </tr>
             </table>
             <div id="submitbutton" style="margin-top: 30px; text-align: center;">
-                <button type="submit" style="font-size: 1em;">QBT_TR(Upload Torrents)QBT_TR[CONTEXT=HttpServer]</button>
+                <button type="submit" style="font-size: 1em;" class="qbt-translatable" data-i18n="Upload Torrents">Upload Torrents</button>
             </div>
         </fieldset>
     </form>

--- a/src/webui/www/private/uploadlimit.html
+++ b/src/webui/www/private/uploadlimit.html
@@ -14,7 +14,7 @@
 <body>
     <div style="width: 100%; text-align: center; margin: 0 auto; overflow: hidden">
         <div id="uplimitSlider" class="slider">
-            <div id="uplimitUpdate" class="update">QBT_TR(Upload limit:)QBT_TR[CONTEXT=PropertiesWidget] <input type="text" id="uplimitUpdatevalue" size="6" placeholder="∞" style="text-align: center;"> <span id="upLimitUnit" class="qbt-translatable" data-i18n="KiB/s">KiB/s</span></div>
+            <div id="uplimitUpdate" class="update qbt-translatable" data-i18n="Upload limit:">Upload limit: <input type="text" id="uplimitUpdatevalue" size="6" placeholder="∞" style="text-align: center;"> <span id="upLimitUnit" class="qbt-translatable" data-i18n="KiB/s">KiB/s</span></div>
             <div class="sliderWrapper">
                 <div id="uplimitSliderknob" class="sliderknob"></div>
                 <div id="uplimitSliderarea" class="sliderarea"></div>

--- a/src/webui/www/private/uploadlimit.html
+++ b/src/webui/www/private/uploadlimit.html
@@ -21,7 +21,7 @@
             </div>
             <div class="clear"></div>
         </div>
-        <input type="button" id="applyButton" value="QBT_TR(Apply)QBT_TR[CONTEXT=HttpServer]" onclick="setUpLimit()" />
+        <input type="button" id="applyButton" class="qbt-translatable" data-i18n="[value]Apply" value="Apply" onclick="setUpLimit()" />
     </div>
 
     <script>

--- a/src/webui/www/private/uploadlimit.html
+++ b/src/webui/www/private/uploadlimit.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>QBT_TR(Torrent Upload Speed Limiting)QBT_TR[CONTEXT=TransferListWidget]</title>
+    <title class="qbt-translatable" data-i18n="Torrent Upload Speed Limiting">Torrent Upload Speed Limiting</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
@@ -14,7 +14,7 @@
 <body>
     <div style="width: 100%; text-align: center; margin: 0 auto; overflow: hidden">
         <div id="uplimitSlider" class="slider">
-            <div id="uplimitUpdate" class="update">QBT_TR(Upload limit:)QBT_TR[CONTEXT=PropertiesWidget] <input type="text" id="uplimitUpdatevalue" size="6" placeholder="∞" style="text-align: center;"> <span id="upLimitUnit">QBT_TR(KiB/s)QBT_TR[CONTEXT=SpeedLimitDialog]</span></div>
+            <div id="uplimitUpdate" class="update">QBT_TR(Upload limit:)QBT_TR[CONTEXT=PropertiesWidget] <input type="text" id="uplimitUpdatevalue" size="6" placeholder="∞" style="text-align: center;"> <span id="upLimitUnit" class="qbt-translatable" data-i18n="KiB/s">KiB/s</span></div>
             <div class="sliderWrapper">
                 <div id="uplimitSliderknob" class="sliderknob"></div>
                 <div id="uplimitSliderarea" class="sliderarea"></div>

--- a/src/webui/www/private/views/about.html
+++ b/src/webui/www/private/views/about.html
@@ -847,7 +847,7 @@
         const qbtVersion = window.parent.qBittorrent.Cache.qbtVersion.get();
         const buildInfo = window.parent.qBittorrent.Cache.buildInfo.get();
 
-        $('qbittorrentVersion').innerText = `qBittorrent ${qbtVersion} QBT_TR(WebUI)QBT_TR[CONTEXT=OptionsDialog]`;
+        $('qbittorrentVersion').innerText = `qBittorrent ${qbtVersion} \${i18next.t('WebUI')}`;
         $('qtVersion').textContent = buildInfo.qt;
         $('libtorrentVersion').textContent = buildInfo.libtorrent;
         $('boostVersion').textContent = buildInfo.boost;

--- a/src/webui/www/private/views/about.html
+++ b/src/webui/www/private/views/about.html
@@ -4,53 +4,53 @@
         <img src="images/qbittorrent-tray.svg" style="float: left; height: 1.5em;" alt="QBT_TR(qBittorrent icon)QBT_TR[CONTEXT=AboutDialog]" />
         <h3 id="qbittorrentVersion"></h3>
     </div>
-    <p>QBT_TR(An advanced BitTorrent client programmed in C++, based on Qt toolkit and libtorrent-rasterbar.)QBT_TR[CONTEXT=AboutDialog]</p>
+    <p class="qbt-translatable" data-i18n="An advanced BitTorrent client programmed in C++, based on Qt toolkit and libtorrent-rasterbar.">An advanced BitTorrent client programmed in C++, based on Qt toolkit and libtorrent-rasterbar.</p>
     <p>Copyright © 2006-2024 The qBittorrent project</p>
     <table>
         <tr>
-            <td>QBT_TR(Home Page:)QBT_TR[CONTEXT=AboutDialog]</td>
+            <td class="qbt-translatable" data-i18n="Home Page:">Home Page:</td>
             <td><a href="https://www.qbittorrent.org" target="_blank">https://www.qbittorrent.org</a></td>
         </tr>
         <tr>
-            <td>QBT_TR(Bug Tracker:)QBT_TR[CONTEXT=AboutDialog]</td>
+            <td class="qbt-translatable" data-i18n="Bug Tracker:">Bug Tracker:</td>
             <td><a href="https://bugs.qbittorrent.org" target="_blank">https://bugs.qbittorrent.org</a></td>
         </tr>
         <tr>
-            <td>QBT_TR(Forum:)QBT_TR[CONTEXT=AboutDialog]</td>
+            <td class="qbt-translatable" data-i18n="Forum:">Forum:</td>
             <td><a href="https://forum.qbittorrent.org" target="_blank">https://forum.qbittorrent.org</a></td>
         </tr>
     </table>
 </div>
 
 <div id="aboutAuthorContent" class="aboutTabContent invisible">
-    <h3>QBT_TR(Current maintainer)QBT_TR[CONTEXT=AboutDialog]</h3>
+    <h3 class="qbt-translatable" data-i18n="Current maintainer">Current maintainer</h3>
     <table>
         <tr>
-            <td>QBT_TR(Name:)QBT_TR[CONTEXT=AboutDialog]</td>
+            <td class="qbt-translatable" data-i18n="Name:">Name:</td>
             <td>Sledgehammer999</td>
         </tr>
         <tr>
-            <td>QBT_TR(Nationality:)QBT_TR[CONTEXT=AboutDialog]</td>
-            <td>QBT_TR(Greece)QBT_TR[CONTEXT=AboutDialog]</td>
+            <td class="qbt-translatable" data-i18n="Nationality:">Nationality:</td>
+            <td class="qbt-translatable" data-i18n="Greece">Greece</td>
         </tr>
         <tr>
-            <td>QBT_TR(E-mail:)QBT_TR[CONTEXT=AboutDialog]</td>
+            <td class="qbt-translatable" data-i18n="E-mail:">E-mail:</td>
             <td><a target="_blank" href="mailto:sledgehammer999@qbittorrent.org">sledgehammer999@qbittorrent.org</a></td>
         </tr>
     </table>
     <br />
-    <h3>QBT_TR(Original author)QBT_TR[CONTEXT=HttpServer]</h3>
+    <h3 class="qbt-translatable" data-i18n="Original author">Original author</h3>
     <table>
         <tr>
-            <td>QBT_TR(Name:)QBT_TR[CONTEXT=AboutDialog]</td>
+            <td class="qbt-translatable" data-i18n="Name:">Name:</td>
             <td>Christophe Dumez</td>
         </tr>
         <tr>
-            <td>QBT_TR(Nationality:)QBT_TR[CONTEXT=AboutDialog]</td>
-            <td>QBT_TR(France)QBT_TR[CONTEXT=AboutDialog]</td>
+            <td class="qbt-translatable" data-i18n="Nationality:">Nationality:</td>
+            <td class="qbt-translatable" data-i18n="France">France</td>
         </tr>
         <tr>
-            <td>QBT_TR(E-mail:)QBT_TR[CONTEXT=AboutDialog]</td>
+            <td class="qbt-translatable" data-i18n="E-mail:">E-mail:</td>
             <td><a target="_blank" href="mailto:chris@qbittorrent.org">chris@qbittorrent.org</a></td>
         </tr>
     </table>
@@ -814,7 +814,7 @@
 </div>
 
 <div id="aboutSoftwareUsedContent" class="aboutTabContent invisible">
-    <p>QBT_TR(qBittorrent was built with the following libraries:)QBT_TR[CONTEXT=AboutDialog]</p>
+    <p class="qbt-translatable" data-i18n="qBittorrent was built with the following libraries:">qBittorrent was built with the following libraries:</p>
     <table style="margin-left: 20px;">
         <tr>
             <td>Qt:</td>
@@ -837,7 +837,7 @@
             <td><span id="zlibVersion"></span></td>
         </tr>
     </table>
-    <p>QBT_TR(The free IP to Country Lite database by DB-IP is used for resolving the countries of peers. The database is licensed under the Creative Commons Attribution 4.0 International License)QBT_TR[CONTEXT=AboutDialog] (<a href="https://db-ip.com/" target="_blank" rel="noopener ">https://db-ip.com/</a>)</p>
+    <p class="qbt-translatable" data-i18n="The free IP to Country Lite database by DB-IP is used for resolving the countries of peers. The database is licensed under the Creative Commons Attribution 4.0 International License">The free IP to Country Lite database by DB-IP is used for resolving the countries of peers. The database is licensed under the Creative Commons Attribution 4.0 International License (<a href="https://db-ip.com/" target="_blank" rel="noopener ">https://db-ip.com/</a>)</p>
 </div>
 
 <script>

--- a/src/webui/www/private/views/about.html
+++ b/src/webui/www/private/views/about.html
@@ -1,7 +1,7 @@
 <div id="aboutAboutContent" class="aboutTabContent">
-    <img src="images/mascot.png" style="float: left;" alt="QBT_TR(qBittorrent Mascot)QBT_TR[CONTEXT=AboutDialog]" />
+    <img src="images/mascot.png" style="float: left;" class="qbt-translatable" data-i18n="[alt]qBittorrent Mascot" alt="qBittorrent Mascot" />
     <div>
-        <img src="images/qbittorrent-tray.svg" style="float: left; height: 1.5em;" alt="QBT_TR(qBittorrent icon)QBT_TR[CONTEXT=AboutDialog]" />
+        <img src="images/qbittorrent-tray.svg" style="float: left; height: 1.5em;" class="qbt-translatable" data-i18n="[alt]qBittorrent icon" alt="qBittorrent icon" />
         <h3 id="qbittorrentVersion"></h3>
     </div>
     <p class="qbt-translatable" data-i18n="An advanced BitTorrent client programmed in C++, based on Qt toolkit and libtorrent-rasterbar.">An advanced BitTorrent client programmed in C++, based on Qt toolkit and libtorrent-rasterbar.</p>

--- a/src/webui/www/private/views/aboutToolbar.html
+++ b/src/webui/www/private/views/aboutToolbar.html
@@ -1,11 +1,11 @@
 <div class="toolbarTabs">
     <ul id="aboutTabs" class="tab-menu">
-        <li id="aboutAboutLink" class="selected"><a>QBT_TR(About)QBT_TR[CONTEXT=AboutDialog]</a></li>
-        <li id="aboutAuthorLink"><a>QBT_TR(Authors)QBT_TR[CONTEXT=AboutDialog]</a></li>
-        <li id="aboutSpecialThanksLink"><a>QBT_TR(Special Thanks)QBT_TR[CONTEXT=AboutDialog]</a></li>
-        <li id="aboutTranslatorsLink"><a>QBT_TR(Translators)QBT_TR[CONTEXT=AboutDialog]</a></li>
-        <li id="aboutLicenseLink"><a>QBT_TR(License)QBT_TR[CONTEXT=AboutDialog]</a></li>
-        <li id="aboutSoftwareUsedLink"><a>QBT_TR(Software Used)QBT_TR[CONTEXT=AboutDialog]</a></li>
+        <li id="aboutAboutLink" class="selected"><a class="qbt-translatable" data-i18n="About">About</a></li>
+        <li id="aboutAuthorLink"><a class="qbt-translatable" data-i18n="Authors">Authors</a></li>
+        <li id="aboutSpecialThanksLink"><a class="qbt-translatable" data-i18n="Special Thanks">Special Thanks</a></li>
+        <li id="aboutTranslatorsLink"><a class="qbt-translatable" data-i18n="Translators">Translators</a></li>
+        <li id="aboutLicenseLink"><a class="qbt-translatable" data-i18n="License">License</a></li>
+        <li id="aboutSoftwareUsedLink"><a class="qbt-translatable" data-i18n="Software Used">Software Used</a></li>
     </ul>
     <div class="clear"></div>
 </div>

--- a/src/webui/www/private/views/filters.html
+++ b/src/webui/www/private/views/filters.html
@@ -1,41 +1,41 @@
 <div class="filterWrapper">
     <span class="filterTitle" onclick="toggleFilterDisplay('status');">
-        <img src="images/go-down.svg" alt="QBT_TR(Collapse/expand)QBT_TR[CONTEXT=TransferListFiltersWidget]">QBT_TR(Status)QBT_TR[CONTEXT=TransferListFiltersWidget]
+        <img src="images/go-down.svg" alt="QBT_TR(Collapse/expand)QBT_TR[CONTEXT=TransferListFiltersWidget]" class="qbt-translatable" data-i18n="Status">Status
     </span>
     <ul class="filterList" id="statusFilterList">
-        <li id="all_filter"><a href="#" onclick="setFilter('all');return false;"><img src="images/filter-all.svg" alt="All" />QBT_TR(All (0))QBT_TR[CONTEXT=StatusFilterWidget]</a></li>
-        <li id="downloading_filter"><a href="#" onclick="setFilter('downloading');return false;"><img src="images/downloading.svg" alt="Downloading" />QBT_TR(Downloading (0))QBT_TR[CONTEXT=StatusFilterWidget]</a></li>
-        <li id="seeding_filter"><a href="#" onclick="setFilter('seeding');return false;"><img src="images/upload.svg" alt="Seeding" />QBT_TR(Seeding (0))QBT_TR[CONTEXT=StatusFilterWidget]</a></li>
-        <li id="completed_filter"><a href="#" onclick="setFilter('completed');return false;"><img src="images/checked-completed.svg" alt="Completed" />QBT_TR(Completed (0))QBT_TR[CONTEXT=StatusFilterWidget]</a></li>
-        <li id="resumed_filter"><a href="#" onclick="setFilter('resumed');return false;"><img src="images/torrent-start.svg" alt="Resumed" />QBT_TR(Resumed (0))QBT_TR[CONTEXT=StatusFilterWidget]</a></li>
-        <li id="paused_filter"><a href="#" onclick="setFilter('paused');return false;"><img src="images/stopped.svg" alt="Paused" />QBT_TR(Paused (0))QBT_TR[CONTEXT=StatusFilterWidget]</a></li>
-        <li id="active_filter"><a href="#" onclick="setFilter('active');return false;"><img src="images/filter-active.svg" alt="Active" />QBT_TR(Active (0))QBT_TR[CONTEXT=StatusFilterWidget]</a></li>
-        <li id="inactive_filter"><a href="#" onclick="setFilter('inactive');return false;"><img src="images/filter-inactive.svg" alt="Inactive" />QBT_TR(Inactive (0))QBT_TR[CONTEXT=StatusFilterWidget]</a></li>
-        <li id="stalled_filter"><a href="#" onclick="setFilter('stalled');return false;"><img src="images/filter-stalled.svg" alt="Stalled" />QBT_TR(Stalled (0))QBT_TR[CONTEXT=StatusFilterWidget]</a></li>
-        <li id="stalled_uploading_filter"><a href="#" onclick="setFilter('stalled_uploading');return false;"><img src="images/stalledUP.svg" alt="Stalled Uploading" />QBT_TR(Stalled Uploading (0))QBT_TR[CONTEXT=StatusFilterWidget]</a></li>
-        <li id="stalled_downloading_filter"><a href="#" onclick="setFilter('stalled_downloading');return false;"><img src="images/stalledDL.svg" alt="Stalled Downloading" />QBT_TR(Stalled Downloading (0))QBT_TR[CONTEXT=StatusFilterWidget]</a></li>
-        <li id="checking_filter"><a href="#" onclick="setFilter('checking'); return false;"><img src="images/force-recheck.svg" alt="Checking" />QBT_TR(Checking (0))QBT_TR[CONTEXT=StatusFilterWidget]</a></li>
-        <li id="moving_filter"><a href="#" onclick="setFilter('moving'); return false;"><img src="images/set-location.svg" alt="Moving" />QBT_TR(Moving (0))QBT_TR[CONTEXT=StatusFilterWidget]</a></li>
-        <li id="errored_filter"><a href="#" onclick="setFilter('errored');return false;"><img src="images/error.svg" alt="Errored" />QBT_TR(Errored (0))QBT_TR[CONTEXT=StatusFilterWidget]</a></li>
+        <li id="all_filter"><a href="#" onclick="setFilter('all');return false;"><img src="images/filter-all.svg" alt="All" / class="qbt-translatable" data-i18n="All (0)">All (0)</a></li>
+        <li id="downloading_filter"><a href="#" onclick="setFilter('downloading');return false;"><img src="images/downloading.svg" alt="Downloading" / class="qbt-translatable" data-i18n="Downloading (0)">Downloading (0)</a></li>
+        <li id="seeding_filter"><a href="#" onclick="setFilter('seeding');return false;"><img src="images/upload.svg" alt="Seeding" / class="qbt-translatable" data-i18n="Seeding (0)">Seeding (0)</a></li>
+        <li id="completed_filter"><a href="#" onclick="setFilter('completed');return false;"><img src="images/checked-completed.svg" alt="Completed" / class="qbt-translatable" data-i18n="Completed (0)">Completed (0)</a></li>
+        <li id="resumed_filter"><a href="#" onclick="setFilter('resumed');return false;"><img src="images/torrent-start.svg" alt="Resumed" / class="qbt-translatable" data-i18n="Resumed (0)">Resumed (0)</a></li>
+        <li id="paused_filter"><a href="#" onclick="setFilter('paused');return false;"><img src="images/stopped.svg" alt="Paused" / class="qbt-translatable" data-i18n="Paused (0)">Paused (0)</a></li>
+        <li id="active_filter"><a href="#" onclick="setFilter('active');return false;"><img src="images/filter-active.svg" alt="Active" / class="qbt-translatable" data-i18n="Active (0)">Active (0)</a></li>
+        <li id="inactive_filter"><a href="#" onclick="setFilter('inactive');return false;"><img src="images/filter-inactive.svg" alt="Inactive" / class="qbt-translatable" data-i18n="Inactive (0)">Inactive (0)</a></li>
+        <li id="stalled_filter"><a href="#" onclick="setFilter('stalled');return false;"><img src="images/filter-stalled.svg" alt="Stalled" / class="qbt-translatable" data-i18n="Stalled (0)">Stalled (0)</a></li>
+        <li id="stalled_uploading_filter"><a href="#" onclick="setFilter('stalled_uploading');return false;"><img src="images/stalledUP.svg" alt="Stalled Uploading" / class="qbt-translatable" data-i18n="Stalled Uploading (0)">Stalled Uploading (0)</a></li>
+        <li id="stalled_downloading_filter"><a href="#" onclick="setFilter('stalled_downloading');return false;"><img src="images/stalledDL.svg" alt="Stalled Downloading" / class="qbt-translatable" data-i18n="Stalled Downloading (0)">Stalled Downloading (0)</a></li>
+        <li id="checking_filter"><a href="#" onclick="setFilter('checking'); return false;"><img src="images/force-recheck.svg" alt="Checking" / class="qbt-translatable" data-i18n="Checking (0)">Checking (0)</a></li>
+        <li id="moving_filter"><a href="#" onclick="setFilter('moving'); return false;"><img src="images/set-location.svg" alt="Moving" / class="qbt-translatable" data-i18n="Moving (0)">Moving (0)</a></li>
+        <li id="errored_filter"><a href="#" onclick="setFilter('errored');return false;"><img src="images/error.svg" alt="Errored" / class="qbt-translatable" data-i18n="Errored (0)">Errored (0)</a></li>
     </ul>
 </div>
 <div class="filterWrapper">
     <span class="filterTitle" onclick="toggleFilterDisplay('category');">
-        <img src="images/go-down.svg" alt="QBT_TR(Collapse/expand)QBT_TR[CONTEXT=TransferListFiltersWidget]">QBT_TR(Categories)QBT_TR[CONTEXT=TransferListFiltersWidget]
+        <img src="images/go-down.svg" alt="QBT_TR(Collapse/expand)QBT_TR[CONTEXT=TransferListFiltersWidget]" class="qbt-translatable" data-i18n="Categories">Categories
     </span>
     <ul class="filterList" id="categoryFilterList">
     </ul>
 </div>
 <div class="filterWrapper">
     <span class="filterTitle" onclick="toggleFilterDisplay('tag');">
-        <img src="images/go-down.svg" alt="QBT_TR(Collapse/expand)QBT_TR[CONTEXT=TransferListFiltersWidget]">QBT_TR(Tags)QBT_TR[CONTEXT=TransferListFiltersWidget]
+        <img src="images/go-down.svg" alt="QBT_TR(Collapse/expand)QBT_TR[CONTEXT=TransferListFiltersWidget]" class="qbt-translatable" data-i18n="Tags">Tags
     </span>
     <ul class="filterList" id="tagFilterList">
     </ul>
 </div>
 <div class="filterWrapper">
     <span class="filterTitle" onclick="toggleFilterDisplay('tracker');">
-        <img src="images/go-down.svg" alt="QBT_TR(Collapse/expand)QBT_TR[CONTEXT=TransferListFiltersWidget]">QBT_TR(Trackers)QBT_TR[CONTEXT=TransferListFiltersWidget]
+        <img src="images/go-down.svg" alt="QBT_TR(Collapse/expand)QBT_TR[CONTEXT=TransferListFiltersWidget]" class="qbt-translatable" data-i18n="Trackers">Trackers
     </span>
     <ul class="filterList" id="trackerFilterList">
     </ul>

--- a/src/webui/www/private/views/filters.html
+++ b/src/webui/www/private/views/filters.html
@@ -1,6 +1,6 @@
 <div class="filterWrapper">
     <span class="filterTitle" onclick="toggleFilterDisplay('status');">
-        <img src="images/go-down.svg" alt="QBT_TR(Collapse/expand)QBT_TR[CONTEXT=TransferListFiltersWidget]" class="qbt-translatable" data-i18n="Status">Status
+        <img src="images/go-down.svg" class="qbt-translatable" data-i18n="[alt]Collapse/expand" alt="Collapse/expand" class="qbt-translatable" data-i18n="Status">Status
     </span>
     <ul class="filterList" id="statusFilterList">
         <li id="all_filter"><a href="#" onclick="setFilter('all');return false;"><img src="images/filter-all.svg" alt="All" / class="qbt-translatable" data-i18n="All (0)">All (0)</a></li>
@@ -21,21 +21,21 @@
 </div>
 <div class="filterWrapper">
     <span class="filterTitle" onclick="toggleFilterDisplay('category');">
-        <img src="images/go-down.svg" alt="QBT_TR(Collapse/expand)QBT_TR[CONTEXT=TransferListFiltersWidget]" class="qbt-translatable" data-i18n="Categories">Categories
+        <img src="images/go-down.svg" class="qbt-translatable" data-i18n="[alt]Collapse/expand" alt="Collapse/expand" class="qbt-translatable" data-i18n="Categories">Categories
     </span>
     <ul class="filterList" id="categoryFilterList">
     </ul>
 </div>
 <div class="filterWrapper">
     <span class="filterTitle" onclick="toggleFilterDisplay('tag');">
-        <img src="images/go-down.svg" alt="QBT_TR(Collapse/expand)QBT_TR[CONTEXT=TransferListFiltersWidget]" class="qbt-translatable" data-i18n="Tags">Tags
+        <img src="images/go-down.svg" class="qbt-translatable" data-i18n="[alt]Collapse/expand" alt="Collapse/expand" class="qbt-translatable" data-i18n="Tags">Tags
     </span>
     <ul class="filterList" id="tagFilterList">
     </ul>
 </div>
 <div class="filterWrapper">
     <span class="filterTitle" onclick="toggleFilterDisplay('tracker');">
-        <img src="images/go-down.svg" alt="QBT_TR(Collapse/expand)QBT_TR[CONTEXT=TransferListFiltersWidget]" class="qbt-translatable" data-i18n="Trackers">Trackers
+        <img src="images/go-down.svg" class="qbt-translatable" data-i18n="[alt]Collapse/expand" alt="Collapse/expand" class="qbt-translatable" data-i18n="Trackers">Trackers
     </span>
     <ul class="filterList" id="trackerFilterList">
     </ul>

--- a/src/webui/www/private/views/installsearchplugin.html
+++ b/src/webui/www/private/views/installsearchplugin.html
@@ -15,13 +15,13 @@
 </style>
 
 <div id="installSearchPluginContainer">
-    <h2>QBT_TR(Plugin path:)QBT_TR[CONTEXT=PluginSourceDlg]</h2>
+    <h2 class="qbt-translatable" data-i18n="Plugin path:">Plugin path:</h2>
 
     <div>
         <input type="text" id="newPluginPath" placeholder="QBT_TR(URL or local directory)QBT_TR[CONTEXT=PluginSourceDlg]" autocorrect="off" autocapitalize="none" />
         <div style="margin-top: 10px; text-align: center;">
-            <button type="button" id="newPluginCancel" onclick="qBittorrent.SearchPlugins.closeSearchWindow('installSearchPlugin');">QBT_TR(Cancel)QBT_TR[CONTEXT=PluginSourceDlg]</button>
-            <button type="button" id="newPluginOk" onclick="qBittorrent.InstallSearchPlugin.newPluginOk();">QBT_TR(Ok)QBT_TR[CONTEXT=PluginSourceDlg]</button>
+            <button type="button" id="newPluginCancel" onclick="qBittorrent.SearchPlugins.closeSearchWindow('installSearchPlugin');" class="qbt-translatable" data-i18n="Cancel">Cancel</button>
+            <button type="button" id="newPluginOk" onclick="qBittorrent.InstallSearchPlugin.newPluginOk();" class="qbt-translatable" data-i18n="Ok">Ok</button>
         </div>
     </div>
 </div>

--- a/src/webui/www/private/views/installsearchplugin.html
+++ b/src/webui/www/private/views/installsearchplugin.html
@@ -18,7 +18,7 @@
     <h2 class="qbt-translatable" data-i18n="Plugin path:">Plugin path:</h2>
 
     <div>
-        <input type="text" id="newPluginPath" placeholder="QBT_TR(URL or local directory)QBT_TR[CONTEXT=PluginSourceDlg]" autocorrect="off" autocapitalize="none" />
+        <input type="text" id="newPluginPath" class="qbt-translatable" data-i18n="[placeholder]URL or local directory" placeholder="URL or local directory" autocorrect="off" autocapitalize="none" />
         <div style="margin-top: 10px; text-align: center;">
             <button type="button" id="newPluginCancel" onclick="qBittorrent.SearchPlugins.closeSearchWindow('installSearchPlugin');" class="qbt-translatable" data-i18n="Cancel">Cancel</button>
             <button type="button" id="newPluginOk" onclick="qBittorrent.InstallSearchPlugin.newPluginOk();" class="qbt-translatable" data-i18n="Ok">Ok</button>

--- a/src/webui/www/private/views/log.html
+++ b/src/webui/www/private/views/log.html
@@ -202,13 +202,13 @@
                 maxHeight: 200,
                 search: false,
                 translations: {
-                    all: 'QBT_TR(All)QBT_TR[CONTEXT=ExecutionLogWidget]',
-                    item: 'QBT_TR(item)QBT_TR[CONTEXT=ExecutionLogWidget]',
-                    items: 'QBT_TR(items)QBT_TR[CONTEXT=ExecutionLogWidget]',
-                    selectAll: 'QBT_TR(Select All)QBT_TR[CONTEXT=ExecutionLogWidget]',
-                    clearAll: 'QBT_TR(Clear All)QBT_TR[CONTEXT=ExecutionLogWidget]',
+                    all: i18next.t('All'),
+                    item: i18next.t('item'),
+                    items: i18next.t('items'),
+                    selectAll: i18next.t('Select All'),
+                    clearAll: i18next.t('Clear All'),
                 },
-                placeHolder: "QBT_TR(Choose a log level...)QBT_TR[CONTEXT=ExecutionLogWidget]",
+                placeHolder: i18next.t("Choose a log level..."),
                 keepInlineStyles: false
             });
 
@@ -369,7 +369,7 @@
                 onFailure: function(response) {
                     const errorDiv = $('error_div');
                     if (errorDiv)
-                        errorDiv.set('text', 'QBT_TR(qBittorrent client is not reachable)QBT_TR[CONTEXT=HttpServer]');
+                        errorDiv.set('text', i18next.t('qBittorrent client is not reachable'));
                     tableInfo[curTab].progress = false;
                     syncLogWithInterval(10000);
                 },

--- a/src/webui/www/private/views/log.html
+++ b/src/webui/www/private/views/log.html
@@ -85,20 +85,20 @@
 <div id="logView">
     <div id="logTopBar">
         <div id="logFilterBar">
-            <label for="logLevelSelect">QBT_TR(Log Levels:)QBT_TR[CONTEXT=ExecutionLogWidget]</label>
+            <label for="logLevelSelect" class="qbt-translatable" data-i18n="Log Levels:">Log Levels:</label>
             <select multiple size="1" id="logLevelSelect" class="logLevelSelect" onchange="window.qBittorrent.Log.logLevelChanged()">
-                <option value="1">QBT_TR(Normal Messages)QBT_TR[CONTEXT=ExecutionLogWidget]</option>
-                <option value="2">QBT_TR(Information Messages)QBT_TR[CONTEXT=ExecutionLogWidget]</option>
-                <option value="4">QBT_TR(Warning Messages)QBT_TR[CONTEXT=ExecutionLogWidget]</option>
-                <option value="8">QBT_TR(Critical Messages)QBT_TR[CONTEXT=ExecutionLogWidget]</option>
+                <option value="1" class="qbt-translatable" data-i18n="Normal Messages">Normal Messages</option>
+                <option value="2" class="qbt-translatable" data-i18n="Information Messages">Information Messages</option>
+                <option value="4" class="qbt-translatable" data-i18n="Warning Messages">Warning Messages</option>
+                <option value="8" class="qbt-translatable" data-i18n="Critical Messages">Critical Messages</option>
             </select>
 
             <input type="text" id="filterTextInput" onkeyup="window.qBittorrent.Log.filterTextChanged()" placeholder="QBT_TR(Filter logs)QBT_TR[CONTEXT=ExecutionLogWidget]" autocomplete="off" autocorrect="off" autocapitalize="none" />
-            <button type="button" title="Clear input" onclick="javascript:document.querySelector('#filterTextInput').value='';window.qBittorrent.Log.filterTextChanged();">QBT_TR(Clear)QBT_TR[CONTEXT=ExecutionLogWidget]</button>
+            <button type="button" title="Clear input" onclick="javascript:document.querySelector('#filterTextInput').value='';window.qBittorrent.Log.filterTextChanged();" class="qbt-translatable" data-i18n="Clear">Clear</button>
         </div>
 
         <div id="logFilterSummary">
-            <span>QBT_TR(Results)QBT_TR[CONTEXT=ExecutionLogWidget] (QBT_TR(showing)QBT_TR[CONTEXT=ExecutionLogWidget] <span id="numFilteredLogs">0</span> QBT_TR(out of)QBT_TR[CONTEXT=ExecutionLogWidget] <span id="numTotalLogs">0</span>):</span>
+            <span class="qbt-translatable" data-i18n="Results">Results (QBT_TR(showing)QBT_TR[CONTEXT=ExecutionLogWidget] <span id="numFilteredLogs">0</span> QBT_TR(out of)QBT_TR[CONTEXT=ExecutionLogWidget] <span id="numTotalLogs">0</span>):</span>
         </div>
     </div>
 
@@ -141,8 +141,8 @@
 </div>
 
 <ul id="logTableMenu" class="contextMenu">
-    <li><a href="#" class="copyLogDataToClipboard"><img src="images/edit-copy.svg" alt="QBT_TR(Copy)QBT_TR[CONTEXT=ExecutionLogWidget]" />QBT_TR(Copy)QBT_TR[CONTEXT=ExecutionLogWidget]</a></li>
-    <li><a href="#Clear"><img src="images/list-remove.svg" alt="QBT_TR(Clear)QBT_TR[CONTEXT=ExecutionLogWidget]" />QBT_TR(Clear)QBT_TR[CONTEXT=ExecutionLogWidget]</a></li>
+    <li><a href="#" class="copyLogDataToClipboard"><img src="images/edit-copy.svg" alt="QBT_TR(Copy)QBT_TR[CONTEXT=ExecutionLogWidget]" / class="qbt-translatable" data-i18n="Copy">Copy</a></li>
+    <li><a href="#Clear"><img src="images/list-remove.svg" alt="QBT_TR(Clear)QBT_TR[CONTEXT=ExecutionLogWidget]" / class="qbt-translatable" data-i18n="Clear">Clear</a></li>
 </ul>
 
 <script>

--- a/src/webui/www/private/views/log.html
+++ b/src/webui/www/private/views/log.html
@@ -93,7 +93,7 @@
                 <option value="8" class="qbt-translatable" data-i18n="Critical Messages">Critical Messages</option>
             </select>
 
-            <input type="text" id="filterTextInput" onkeyup="window.qBittorrent.Log.filterTextChanged()" placeholder="QBT_TR(Filter logs)QBT_TR[CONTEXT=ExecutionLogWidget]" autocomplete="off" autocorrect="off" autocapitalize="none" />
+            <input type="text" id="filterTextInput" onkeyup="window.qBittorrent.Log.filterTextChanged()" class="qbt-translatable" data-i18n="[placeholder]Filter logs" placeholder="Filter logs" autocomplete="off" autocorrect="off" autocapitalize="none" />
             <button type="button" title="Clear input" onclick="javascript:document.querySelector('#filterTextInput').value='';window.qBittorrent.Log.filterTextChanged();" class="qbt-translatable" data-i18n="Clear">Clear</button>
         </div>
 
@@ -141,8 +141,8 @@
 </div>
 
 <ul id="logTableMenu" class="contextMenu">
-    <li><a href="#" class="copyLogDataToClipboard"><img src="images/edit-copy.svg" alt="QBT_TR(Copy)QBT_TR[CONTEXT=ExecutionLogWidget]" / class="qbt-translatable" data-i18n="Copy">Copy</a></li>
-    <li><a href="#Clear"><img src="images/list-remove.svg" alt="QBT_TR(Clear)QBT_TR[CONTEXT=ExecutionLogWidget]" / class="qbt-translatable" data-i18n="Clear">Clear</a></li>
+    <li><a href="#" class="copyLogDataToClipboard"><img src="images/edit-copy.svg" class="qbt-translatable" data-i18n="[alt]Copy" alt="Copy" / class="qbt-translatable" data-i18n="Copy">Copy</a></li>
+    <li><a href="#Clear"><img src="images/list-remove.svg" class="qbt-translatable" data-i18n="[alt]Clear" alt="Clear" / class="qbt-translatable" data-i18n="Clear">Clear</a></li>
 </ul>
 
 <script>

--- a/src/webui/www/private/views/logTabs.html
+++ b/src/webui/www/private/views/logTabs.html
@@ -1,7 +1,7 @@
 <div class="toolbarTabs">
     <ul id="panelTabs" class="tab-menu">
-        <li id="logMessageLink" class="selected"><a title="QBT_TR(General)QBT_TR[CONTEXT=ExecutionLogWidget]">QBT_TR(General)QBT_TR[CONTEXT=ExecutionLogWidget]</a></li>
-        <li id="logPeerLink"><a title="QBT_TR(Blocked IPs)QBT_TR[CONTEXT=ExecutionLogWidget]">QBT_TR(Blocked IPs)QBT_TR[CONTEXT=ExecutionLogWidget]</a></li>
+        <li id="logMessageLink" class="selected"><a title="QBT_TR(General)QBT_TR[CONTEXT=ExecutionLogWidget]" class="qbt-translatable" data-i18n="General">General</a></li>
+        <li id="logPeerLink"><a title="QBT_TR(Blocked IPs)QBT_TR[CONTEXT=ExecutionLogWidget]" class="qbt-translatable" data-i18n="Blocked IPs">Blocked IPs</a></li>
     </ul>
     <div class="clear"></div>
 </div>

--- a/src/webui/www/private/views/logTabs.html
+++ b/src/webui/www/private/views/logTabs.html
@@ -1,7 +1,7 @@
 <div class="toolbarTabs">
     <ul id="panelTabs" class="tab-menu">
-        <li id="logMessageLink" class="selected"><a title="QBT_TR(General)QBT_TR[CONTEXT=ExecutionLogWidget]" class="qbt-translatable" data-i18n="General">General</a></li>
-        <li id="logPeerLink"><a title="QBT_TR(Blocked IPs)QBT_TR[CONTEXT=ExecutionLogWidget]" class="qbt-translatable" data-i18n="Blocked IPs">Blocked IPs</a></li>
+        <li id="logMessageLink" class="selected"><a class="qbt-translatable" data-i18n="[title]General" title="General" class="qbt-translatable" data-i18n="General">General</a></li>
+        <li id="logPeerLink"><a class="qbt-translatable" data-i18n="[title]Blocked IPs" title="Blocked IPs" class="qbt-translatable" data-i18n="Blocked IPs">Blocked IPs</a></li>
     </ul>
     <div class="clear"></div>
 </div>

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1630,7 +1630,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
         const changeWatchFolderSelect = (item) => {
             if (item.value === "other") {
                 item.nextElementSibling.hidden = false;
-                item.nextElementSibling.value = 'QBT_TR(Type folder here)QBT_TR[CONTEXT=ScanFoldersModel]';
+                item.nextElementSibling.value = i18next.t('Type folder here');
                 item.nextElementSibling.select();
             }
             else {
@@ -1728,10 +1728,10 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 url: 'api/v2/app/sendTestEmail',
                 method: 'post',
                 onFailure: function() {
-                    alert("QBT_TR(Could not contact qBittorrent)QBT_TR[CONTEXT=HttpServer]");
+                    alert(i18next.t("Could not contact qBittorrent"));
                 },
                 onSuccess: function() {
-                    alert("QBT_TR(Attempted to send email. Check your inbox to confirm success)QBT_TR[CONTEXT=OptionsDialog]");
+                    alert(i18next.t("Attempted to send email. Check your inbox to confirm success"));
                 }
             }).send();
         };
@@ -1934,7 +1934,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     if (default_iface && !ifaces.some((item) => item.value === default_iface))
                         ifaces.push({ name: default_iface_name || default_iface, value: default_iface });
 
-                    $('networkInterface').options.add(new Option('QBT_TR(Any interface)QBT_TR[CONTEXT=OptionsDialog]', ''));
+                    $('networkInterface').options.add(new Option(i18next.t('Any interface'), ''));
                     ifaces.forEach(function(item, index) {
                         $('networkInterface').options.add(new Option(item.name, item.value));
                     });
@@ -1960,9 +1960,9 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     if (!addresses)
                         return;
 
-                    $('optionalIPAddressToBind').options.add(new Option('QBT_TR(All addresses)QBT_TR[CONTEXT=OptionDialog]', ''));
-                    $('optionalIPAddressToBind').options.add(new Option('QBT_TR(All IPv4 addresses)QBT_TR[CONTEXT=OptionDialog]', '0.0.0.0'));
-                    $('optionalIPAddressToBind').options.add(new Option('QBT_TR(All IPv6 addresses)QBT_TR[CONTEXT=OptionDialog]', '::'));
+                    $('optionalIPAddressToBind').options.add(new Option(i18next.t('All addresses'), ''));
+                    $('optionalIPAddressToBind').options.add(new Option(i18next.t('All IPv4 addresses'), '0.0.0.0'));
+                    $('optionalIPAddressToBind').options.add(new Option(i18next.t('All IPv6 addresses'), '::'));
                     addresses.forEach(function(item, index) {
                         $('optionalIPAddressToBind').options.add(new Option(item, item));
                     });
@@ -2460,7 +2460,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             // Listening Port
             const listen_port = $('port_value').getProperty('value').toInt();
             if (isNaN(listen_port) || (listen_port < 0) || (listen_port > 65535)) {
-                alert("QBT_TR(The port used for incoming connections must be between 0 and 65535.)QBT_TR[CONTEXT=HttpServer]");
+                alert(i18next.t("The port used for incoming connections must be between 0 and 65535."));
                 return;
             }
             settings['listen_port'] = listen_port;
@@ -2471,7 +2471,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             if ($('max_connec_checkbox').getProperty('checked')) {
                 max_connec = $('max_connec_value').getProperty('value').toInt();
                 if (isNaN(max_connec) || max_connec <= 0) {
-                    alert("QBT_TR(Maximum number of connections limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
+                    alert(i18next.t("Maximum number of connections limit must be greater than 0 or disabled."));
                     return;
                 }
             }
@@ -2480,7 +2480,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             if ($('max_connec_per_torrent_checkbox').getProperty('checked')) {
                 max_connec_per_torrent = $('max_connec_per_torrent_value').getProperty('value').toInt();
                 if (isNaN(max_connec_per_torrent) || max_connec_per_torrent <= 0) {
-                    alert("QBT_TR(Maximum number of connections per torrent limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
+                    alert(i18next.t("Maximum number of connections per torrent limit must be greater than 0 or disabled."));
                     return;
                 }
             }
@@ -2489,7 +2489,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             if ($('max_uploads_checkbox').getProperty('checked')) {
                 max_uploads = $('max_uploads_value').getProperty('value').toInt();
                 if (isNaN(max_uploads) || max_uploads <= 0) {
-                    alert("QBT_TR(Global number of upload slots limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
+                    alert(i18next.t("Global number of upload slots limit must be greater than 0 or disabled."));
                     return;
                 }
             }
@@ -2498,7 +2498,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             if ($('max_uploads_per_torrent_checkbox').getProperty('checked')) {
                 max_uploads_per_torrent = $('max_uploads_per_torrent_value').getProperty('value').toInt();
                 if (isNaN(max_uploads_per_torrent) || max_uploads_per_torrent <= 0) {
-                    alert("QBT_TR(Maximum number of upload slots per torrent limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
+                    alert(i18next.t("Maximum number of upload slots per torrent limit must be greater than 0 or disabled."));
                     return;
                 }
             }
@@ -2533,14 +2533,14 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             // Global Rate Limits
             const up_limit = $('up_limit_value').getProperty('value').toInt() * 1024;
             if (isNaN(up_limit) || up_limit < 0) {
-                alert("QBT_TR(Global upload rate limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
+                alert(i18next.t("Global upload rate limit must be greater than 0 or disabled."));
                 return;
             }
             settings['up_limit'] = up_limit;
 
             const dl_limit = $('dl_limit_value').getProperty('value').toInt() * 1024;
             if (isNaN(dl_limit) || dl_limit < 0) {
-                alert("QBT_TR(Global download rate limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
+                alert(i18next.t("Global download rate limit must be greater than 0 or disabled."));
                 return;
             }
             settings['dl_limit'] = dl_limit;
@@ -2548,14 +2548,14 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             // Alternative Global Rate Limits
             const alt_up_limit = $('alt_up_limit_value').getProperty('value').toInt() * 1024;
             if (isNaN(alt_up_limit) || alt_up_limit < 0) {
-                alert("QBT_TR(Alternative upload rate limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
+                alert(i18next.t("Alternative upload rate limit must be greater than 0 or disabled."));
                 return;
             }
             settings['alt_up_limit'] = alt_up_limit;
 
             const alt_dl_limit = $('alt_dl_limit_value').getProperty('value').toInt() * 1024;
             if (isNaN(alt_dl_limit) || alt_dl_limit < 0) {
-                alert("QBT_TR(Alternative download rate limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
+                alert(i18next.t("Alternative download rate limit must be greater than 0 or disabled."));
                 return;
             }
             settings['alt_dl_limit'] = alt_dl_limit;
@@ -2591,38 +2591,38 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             if ($('queueing_checkbox').getProperty('checked')) {
                 const max_active_downloads = $('max_active_dl_value').getProperty('value').toInt();
                 if (isNaN(max_active_downloads) || max_active_downloads < -1) {
-                    alert("QBT_TR(Maximum active downloads must be greater than -1.)QBT_TR[CONTEXT=HttpServer]");
+                    alert(i18next.t("Maximum active downloads must be greater than -1."));
                     return;
                 }
                 settings['max_active_downloads'] = max_active_downloads;
                 const max_active_uploads = $('max_active_up_value').getProperty('value').toInt();
                 if (isNaN(max_active_uploads) || max_active_uploads < -1) {
-                    alert("QBT_TR(Maximum active uploads must be greater than -1.)QBT_TR[CONTEXT=HttpServer]");
+                    alert(i18next.t("Maximum active uploads must be greater than -1."));
                     return;
                 }
                 settings['max_active_uploads'] = max_active_uploads;
                 const max_active_torrents = $('max_active_to_value').getProperty('value').toInt();
                 if (isNaN(max_active_torrents) || max_active_torrents < -1) {
-                    alert("QBT_TR(Maximum active torrents must be greater than -1.)QBT_TR[CONTEXT=HttpServer]");
+                    alert(i18next.t("Maximum active torrents must be greater than -1."));
                     return;
                 }
                 settings['max_active_torrents'] = max_active_torrents;
                 settings['dont_count_slow_torrents'] = $('dont_count_slow_torrents_checkbox').getProperty('checked');
                 const dl_rate_threshold = $('dl_rate_threshold').getProperty('value').toInt();
                 if (isNaN(dl_rate_threshold) || (dl_rate_threshold < 1)) {
-                    alert("QBT_TR(Download rate threshold must be greater than 0.)QBT_TR[CONTEXT=HttpServer]");
+                    alert(i18next.t("Download rate threshold must be greater than 0."));
                     return;
                 }
                 settings['slow_torrent_dl_rate_threshold'] = dl_rate_threshold;
                 const ul_rate_threshold = $('ul_rate_threshold').getProperty('value').toInt();
                 if (isNaN(ul_rate_threshold) || (ul_rate_threshold < 1)) {
-                    alert("QBT_TR(Upload rate threshold must be greater than 0.)QBT_TR[CONTEXT=HttpServer]");
+                    alert(i18next.t("Upload rate threshold must be greater than 0."));
                     return;
                 }
                 settings['slow_torrent_ul_rate_threshold'] = ul_rate_threshold;
                 const torrent_inactive_timer = $('torrent_inactive_timer').getProperty('value').toInt();
                 if (isNaN(torrent_inactive_timer) || (torrent_inactive_timer < 1)) {
-                    alert("QBT_TR(Torrent inactivity timer must be greater than 0.)QBT_TR[CONTEXT=HttpServer]");
+                    alert(i18next.t("Torrent inactivity timer must be greater than 0."));
                     return;
                 }
                 settings['slow_torrent_inactive_timer'] = torrent_inactive_timer;
@@ -2633,7 +2633,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             if ($('max_ratio_checkbox').getProperty('checked')) {
                 max_ratio = $('max_ratio_value').getProperty('value').toFloat();
                 if (isNaN(max_ratio) || (max_ratio < 0) || (max_ratio > 9998)) {
-                    alert("QBT_TR(Share ratio limit must be between 0 and 9998.)QBT_TR[CONTEXT=HttpServer]");
+                    alert(i18next.t("Share ratio limit must be between 0 and 9998."));
                     return;
                 }
             }
@@ -2644,7 +2644,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             if ($('max_seeding_time_checkbox').getProperty('checked')) {
                 max_seeding_time = $('max_seeding_time_value').getProperty('value').toInt();
                 if (isNaN(max_seeding_time) || (max_seeding_time < 0) || (max_seeding_time > 525600)) {
-                    alert("QBT_TR(Seeding time limit must be between 0 and 525600 minutes.)QBT_TR[CONTEXT=HttpServer]");
+                    alert(i18next.t("Seeding time limit must be between 0 and 525600 minutes."));
                     return;
                 }
             }
@@ -2656,7 +2656,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             if ($('max_inactive_seeding_time_checkbox').getProperty('checked')) {
                 max_inactive_seeding_time = $('max_inactive_seeding_time_value').getProperty('value').toInt();
                 if (isNaN(max_inactive_seeding_time) || (max_inactive_seeding_time < 0) || (max_inactive_seeding_time > 525600)) {
-                    alert("QBT_TR(Seeding time limit must be between 0 and 525600 minutes.)QBT_TR[CONTEXT=HttpServer]");
+                    alert(i18next.t("Seeding time limit must be between 0 and 525600 minutes."));
                     return;
                 }
             }
@@ -2687,7 +2687,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             const web_ui_address = $('webui_address_value').getProperty('value').toString();
             const web_ui_port = $('webui_port_value').getProperty('value').toInt();
             if (isNaN(web_ui_port) || web_ui_port < 1 || web_ui_port > 65535) {
-                alert("QBT_TR(The port used for the WebUI must be between 1 and 65535.)QBT_TR[CONTEXT=HttpServer]");
+                alert(i18next.t("The port used for the WebUI must be between 1 and 65535."));
                 return;
             }
             settings['web_ui_address'] = web_ui_address;
@@ -2700,26 +2700,26 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             const httpsCertificate = $('ssl_cert_text').getProperty('value');
             settings['web_ui_https_cert_path'] = httpsCertificate;
             if (useHTTPS && (httpsCertificate.length === 0)) {
-                alert("QBT_TR(HTTPS certificate should not be empty)QBT_TR[CONTEXT=OptionsDialog]");
+                alert(i18next.t("HTTPS certificate should not be empty"));
                 return;
             }
 
             const httpsKey = $('ssl_key_text').getProperty('value');
             settings['web_ui_https_key_path'] = httpsKey;
             if (useHTTPS && (httpsKey.length === 0)) {
-                alert("QBT_TR(HTTPS key should not be empty)QBT_TR[CONTEXT=OptionsDialog]");
+                alert(i18next.t("HTTPS key should not be empty"));
                 return;
             }
 
             // Authentication
             const web_ui_username = $('webui_username_text').getProperty('value');
             if (web_ui_username.length < 3) {
-                alert("QBT_TR(The WebUI username must be at least 3 characters long.)QBT_TR[CONTEXT=OptionsDialog]");
+                alert(i18next.t("The WebUI username must be at least 3 characters long."));
                 return;
             }
             const web_ui_password = $('webui_password_text').getProperty('value');
             if ((0 < web_ui_password.length) && (web_ui_password.length < 6)) {
-                alert("QBT_TR(The WebUI password must be at least 6 characters long.)QBT_TR[CONTEXT=OptionsDialog]");
+                alert(i18next.t("The WebUI password must be at least 6 characters long."));
                 return;
             }
 
@@ -2737,7 +2737,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             const alternative_webui_enabled = $('use_alt_webui_checkbox').getProperty('checked');
             const webui_files_location_textarea = $('webui_files_location_textarea').getProperty('value');
             if (alternative_webui_enabled && (webui_files_location_textarea.trim() === "")) {
-                alert("QBT_TR(The alternative WebUI files location cannot be blank.)QBT_TR[CONTEXT=OptionsDialog]");
+                alert(i18next.t("The alternative WebUI files location cannot be blank."));
                 return;
             }
             settings['alternative_webui_enabled'] = alternative_webui_enabled;
@@ -2837,7 +2837,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             window.parent.qBittorrent.Cache.preferences.set({
                 data: settings,
                 onFailure: function() {
-                    alert("QBT_TR(Unable to save program preferences, qBittorrent is probably unreachable.)QBT_TR[CONTEXT=HttpServer]");
+                    alert(i18next.t("Unable to save program preferences, qBittorrent is probably unreachable."));
                     window.parent.qBittorrent.Client.closeWindows();
                 },
                 onSuccess: function() {

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -264,7 +264,7 @@
             </table>
         </fieldset>
         <div class="formRow">
-            <input type="button" id="mail_test_button" value="QBT_TR(Send test email)QBT_TR[CONTEXT=OptionsDialog]" onclick="qBittorrent.Preferences.sendTestEmail();" />
+            <input type="button" id="mail_test_button" class="qbt-translatable" data-i18n="[value]Send test email" value="Send test email" onclick="qBittorrent.Preferences.sendTestEmail();" />
         </div>
     </fieldset>
 
@@ -315,7 +315,7 @@
         <legend class="qbt-translatable" data-i18n="Listening Port">Listening Port</legend>
         <div class="formRow">
             <label for="port_value" class="qbt-translatable" data-i18n="Port used for incoming connections:">Port used for incoming connections:</label>
-            <input type="text" id="port_value" style="width: 4em;" title="QBT_TR(Set to 0 to let your system pick an unused port)QBT_TR[CONTEXT=OptionsDialog]" />
+            <input type="text" id="port_value" style="width: 4em;" class="qbt-translatable" data-i18n="[title]Set to 0 to let your system pick an unused port" title="Set to 0 to let your system pick an unused port" />
             <button type="button" style="margin-left: 1em;" onclick="qBittorrent.Preferences.generateRandomPort();" class="qbt-translatable" data-i18n="Random">Random</button>
         </div>
         <div class="formRow">
@@ -380,7 +380,7 @@
             </tr>
         </table>
         <div class="formRow">
-            <input type="checkbox" id="i2pMixedMode" title="QBT_TR(If &quot;mixed mode&quot; is enabled, I2P torrents are allowed to also get peers from other sources than the tracker, and connect to regular IPs, not providing any anonymization. This may be useful if the user is not interested in the anonymization of I2P, but still wants to be able to connect to I2P peers.)QBT_TR[CONTEXT=OptionsDialog]" />
+            <input type="checkbox" id="i2pMixedMode" class="qbt-translatable" data-i18n="[title]If &quot;mixed mode&quot; is enabled, I2P torrents are allowed to also get peers from other sources than the tracker, and connect to regular IPs, not providing any anonymization. This may be useful if the user is not interested in the anonymization of I2P, but still wants to be able to connect to I2P peers." title="If &quot;mixed mode&quot; is enabled, I2P torrents are allowed to also get peers from other sources than the tracker, and connect to regular IPs, not providing any anonymization. This may be useful if the user is not interested in the anonymization of I2P, but still wants to be able to connect to I2P peers." />
             <label for="i2pMixedMode" class="qbt-translatable" data-i18n="Mixed mode">Mixed mode</label>
         </div>
     </fieldset>
@@ -416,7 +416,7 @@
         </table>
 
         <div class="formRow">
-            <input type="checkbox" id="proxyHostnameLookupCheckbox" title="QBT_TR(If checked, hostname lookups are done via the proxy.)QBT_TR[CONTEXT=OptionsDialog]" />
+            <input type="checkbox" id="proxyHostnameLookupCheckbox" class="qbt-translatable" data-i18n="[title]If checked, hostname lookups are done via the proxy." title="If checked, hostname lookups are done via the proxy." />
             <label for="proxyHostnameLookupCheckbox" class="qbt-translatable" data-i18n="Perform hostname lookup via proxy">Perform hostname lookup via proxy</label>
         </div>
 
@@ -496,7 +496,7 @@
         <table>
             <tr>
                 <td rowspan="2">
-                    <img src="images/slow_off.svg" style="height: 1.5em;" alt="QBT_TR(Alternative speed limits)QBT_TR[CONTEXT=MainWindow]">
+                    <img src="images/slow_off.svg" style="height: 1.5em;" class="qbt-translatable" data-i18n="[alt]Alternative speed limits" alt="Alternative speed limits">
                 </td>
                 <td><label for="up_limit_value" class="qbt-translatable" data-i18n="Upload:">Upload:</label></td>
                 <td><input type="number" id="up_limit_value" style="width: 4em;" min="0" />&nbsp;&nbsp;QBT_TR(KiB/s)QBT_TR[CONTEXT=OptionsDialog]</td>
@@ -514,7 +514,7 @@
         <table>
             <tr>
                 <td rowspan="2">
-                    <img src="images/slow.svg" style="height: 1.5em;" alt="QBT_TR(Alternative speed limits)QBT_TR[CONTEXT=MainWindow]">
+                    <img src="images/slow.svg" style="height: 1.5em;" class="qbt-translatable" data-i18n="[alt]Alternative speed limits" alt="Alternative speed limits">
                 </td>
                 <td><label for="alt_up_limit_value" class="qbt-translatable" data-i18n="Upload:">Upload:</label></td>
                 <td><input type="number" id="alt_up_limit_value" style="width: 4em;" min="0" />&nbsp;&nbsp;QBT_TR(KiB/s)QBT_TR[CONTEXT=OptionsDialog]</td>
@@ -841,7 +841,7 @@
                         <label for="webui_password_text" class="qbt-translatable" data-i18n="Password:">Password:</label>
                     </td>
                     <td>
-                        <input type="password" id="webui_password_text" placeholder="QBT_TR(Change current password)QBT_TR[CONTEXT=OptionsDialog]" autocomplete="new-password" />
+                        <input type="password" id="webui_password_text" class="qbt-translatable" data-i18n="[placeholder]Change current password" placeholder="Change current password" autocomplete="new-password" />
                     </td>
                 </tr>
             </table>
@@ -854,7 +854,7 @@
                 <label for="bypass_auth_subnet_whitelist_checkbox" class="qbt-translatable" data-i18n="Bypass authentication for clients in whitelisted IP subnets">Bypass authentication for clients in whitelisted IP subnets</label>
             </div>
             <div class="formRow" style="padding-left: 30px; padding-top: 5px;">
-                <textarea id="bypass_auth_subnet_whitelist_textarea" rows="5" cols="48" placeholder="QBT_TR(Example: 172.17.32.0/24, fdff:ffff:c8::/40)QBT_TR[CONTEXT=OptionsDialog]"></textarea>
+                <textarea id="bypass_auth_subnet_whitelist_textarea" rows="5" cols="48" class="qbt-translatable" data-i18n="[placeholder]Example: 172.17.32.0/24, fdff:ffff:c8::/40" placeholder="Example: 172.17.32.0/24, fdff:ffff:c8::/40"></textarea>
             </div>
             <table>
                 <tr>
@@ -926,7 +926,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 <input type="checkbox" id="webUIUseCustomHTTPHeadersCheckbox" onclick="qBittorrent.Preferences.updateWebUICustomHTTPHeadersSettings();" />
                 <label for="webUIUseCustomHTTPHeadersCheckbox" class="qbt-translatable" data-i18n="Add custom HTTP headers">Add custom HTTP headers</label>
             </legend>
-            <textarea id="webUICustomHTTPHeadersTextarea" placeholder="QBT_TR(Header: value pairs, one per line)QBT_TR[CONTEXT=OptionsDialog]" style="width: 90%;"></textarea>
+            <textarea id="webUICustomHTTPHeadersTextarea" class="qbt-translatable" data-i18n="[placeholder]Header: value pairs, one per line" placeholder="Header: value pairs, one per line" style="width: 90%;"></textarea>
         </fieldset>
 
         <fieldset class="settings">
@@ -936,7 +936,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </legend>
             <div class="formRow">
                 <label for="webUIReverseProxiesListTextarea" class="qbt-translatable" data-i18n="Trusted proxies list:">Trusted proxies list:</label>
-                <input type="text" id="webUIReverseProxiesListTextarea" title="QBT_TR(Specify reverse proxy IPs (or subnets, e.g. 0.0.0.0/24) in order to use forwarded client address (X-Forwarded-For header). Use ';' to split multiple entries.)QBT_TR[CONTEXT=OptionsDialog]" />
+                <input type="text" id="webUIReverseProxiesListTextarea" class="qbt-translatable" data-i18n="[title]Specify reverse proxy IPs (or subnets, e.g. 0.0.0.0/24) in order to use forwarded client address (X-Forwarded-For header). Use ';' to split multiple entries." title="Specify reverse proxy IPs (or subnets, e.g. 0.0.0.0/24) in order to use forwarded client address (X-Forwarded-For header). Use ';' to split multiple entries." />
             </div>
         </fieldset>
 
@@ -951,7 +951,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             <option value="0">DynDNS</option>
             <option value="1">NO-IP</option>
         </select>
-        <input type="button" value="QBT_TR(Register)QBT_TR[CONTEXT=OptionsDialog]" onclick="qBittorrent.Preferences.registerDynDns();" />
+        <input type="button" class="qbt-translatable" data-i18n="[value]Register" value="Register" onclick="qBittorrent.Preferences.registerDynDns();" />
         <table style="margin-top: 10px;">
             <tr>
                 <td>
@@ -1001,7 +1001,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     <label for="memoryWorkingSetLimit" class="qbt-translatable" data-i18n="Physical memory (RAM) usage limit:">Physical memory (RAM) usage limit:&nbsp;<a href="https://wikipedia.org/wiki/Working_set" target="_blank">(?)</a></label>
                 </td>
                 <td>
-                    <input type="text" id="memoryWorkingSetLimit" style="width: 15em;" title="QBT_TR(This option is less effective on Linux)QBT_TR[CONTEXT=OptionsDialog]">&nbsp;&nbsp;QBT_TR(MiB)QBT_TR[CONTEXT=OptionsDialog]
+                    <input type="text" id="memoryWorkingSetLimit" style="width: 15em;" class="qbt-translatable" data-i18n="[title]This option is less effective on Linux" title="This option is less effective on Linux">&nbsp;&nbsp;QBT_TR(MiB)QBT_TR[CONTEXT=OptionsDialog]
                 </td>
             </tr>
             <tr>
@@ -1051,7 +1051,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     <label for="appInstanceName" class="qbt-translatable" data-i18n="Customize application instance name:">Customize application instance name:</label>
                 </td>
                 <td>
-                    <input type="text" id="appInstanceName" style="width: 15em;" title="QBT_TR(It appends the text to the window title to help distinguish qBittorent instances)QBT_TR[CONTEXT=OptionsDialog]" />
+                    <input type="text" id="appInstanceName" style="width: 15em;" class="qbt-translatable" data-i18n="[title]It appends the text to the window title to help distinguish qBittorent instances" title="It appends the text to the window title to help distinguish qBittorent instances" />
                 </td>
             </tr>
             <tr>
@@ -1059,7 +1059,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     <label for="refreshInterval" class="qbt-translatable" data-i18n="Refresh interval:">Refresh interval:</label>
                 </td>
                 <td>
-                    <input type="text" id="refreshInterval" style="width: 15em;" title="QBT_TR(It controls the internal state update interval which in turn will affect UI updates)QBT_TR[CONTEXT=OptionsDialog]">&nbsp;&nbsp;QBT_TR(ms)QBT_TR[CONTEXT=OptionsDialog]
+                    <input type="text" id="refreshInterval" style="width: 15em;" class="qbt-translatable" data-i18n="[title]It controls the internal state update interval which in turn will affect UI updates" title="It controls the internal state update interval which in turn will affect UI updates">&nbsp;&nbsp;QBT_TR(ms)QBT_TR[CONTEXT=OptionsDialog]
                 </td>
             </tr>
             <tr>
@@ -1115,7 +1115,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     <label for="pythonExecutablePath" class="qbt-translatable" data-i18n="Python executable path (may require restart):">Python executable path (may require restart):</label>
                 </td>
                 <td>
-                    <input type="text" id="pythonExecutablePath" placeholder="QBT_TR((Auto detect if empty))QBT_TR[CONTEXT=OptionsDialog]" style="width: 15em;" />
+                    <input type="text" id="pythonExecutablePath" class="qbt-translatable" data-i18n="[placeholder](Auto detect if empty)" placeholder="(Auto detect if empty)" style="width: 15em;" />
                 </td>
             </tr>
         </table>
@@ -1493,7 +1493,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     <label for="dhtBootstrapNodes" class="qbt-translatable" data-i18n="DHT bootstrap nodes:">DHT bootstrap nodes:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#dht_bootstrap_nodes" target="_blank">(?)</a></label>
                 </td>
                 <td>
-                    <input type="text" id="dhtBootstrapNodes" placeholder="QBT_TR(Resets to default if empty)QBT_TR[CONTEXT=OptionsDialog]" style="width: 15em;" />
+                    <input type="text" id="dhtBootstrapNodes" class="qbt-translatable" data-i18n="[placeholder]Resets to default if empty" placeholder="Resets to default if empty" style="width: 15em;" />
                 </td>
             </tr>
             <tr id="rowI2pInboundQuantity">
@@ -1532,7 +1532,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
     </fieldset>
 </div>
 
-<div style="text-align: center; margin-top: 1em;"><input type="button" value="QBT_TR(Save)QBT_TR[CONTEXT=HttpServer]" onclick="qBittorrent.Preferences.applyPreferences();" /></div>
+<div style="text-align: center; margin-top: 1em;"><input type="button" class="qbt-translatable" data-i18n="[value]Save" value="Save" onclick="qBittorrent.Preferences.applyPreferences();" /></div>
 
 <script>
     'use strict';

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1,7 +1,7 @@
 <div id="BehaviorTab" class="PrefTab">
     <fieldset class="settings">
-        <legend>QBT_TR(Language)QBT_TR[CONTEXT=OptionsDialog]</legend>
-        <label for="locale_select">QBT_TR(User Interface Language:)QBT_TR[CONTEXT=OptionsDialog]</label>
+        <legend class="qbt-translatable" data-i18n="Language">Language</legend>
+        <label for="locale_select" class="qbt-translatable" data-i18n="User Interface Language:">User Interface Language:</label>
         <select id="locale_select">
             ${LANGUAGE_OPTIONS}
         </select>
@@ -10,27 +10,27 @@
     <fieldset class="settings">
         <legend>
             <input type="checkbox" id="filelog_checkbox" onclick="qBittorrent.Preferences.updateFileLogEnabled();" />
-            <label for="filelog_checkbox">QBT_TR(Log file)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="filelog_checkbox" class="qbt-translatable" data-i18n="Log file">Log file</label>
         </legend>
         <div class="formRow">
-            <label for="filelog_save_path_input">QBT_TR(Save path:)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="filelog_save_path_input" class="qbt-translatable" data-i18n="Save path:">Save path:</label>
             <input type="text" id="filelog_save_path_input" />
         </div>
         <table>
             <tr>
                 <td><input type="checkbox" id="filelog_backup_checkbox" onclick="qBittorrent.Preferences.updateFileLogBackupEnabled();" /></td>
-                <td><label for="filelog_backup_checkbox">QBT_TR(Backup the log file after:)QBT_TR[CONTEXT=OptionsDialog]</label></td>
-                <td><input id="filelog_max_size_input" type="number" min="1" max="1024000" value="65" onchange="qBittorrent.Preferences.numberInputLimiter(this);" />QBT_TR(KiB)QBT_TR[CONTEXT=OptionsDialog]</td>
+                <td><label for="filelog_backup_checkbox" class="qbt-translatable" data-i18n="Backup the log file after:">Backup the log file after:</label></td>
+                <td><input id="filelog_max_size_input" type="number" min="1" max="1024000" value="65" onchange="qBittorrent.Preferences.numberInputLimiter(this);" / class="qbt-translatable" data-i18n="KiB">KiB</td>
             </tr>
             <tr>
                 <td><input type="checkbox" id="filelog_delete_old_checkbox" onclick="qBittorrent.Preferences.updateFileLogDeleteEnabled();" /></td>
-                <td><label for="filelog_delete_old_checkbox">QBT_TR(Delete backup logs older than:)QBT_TR[CONTEXT=OptionsDialog]</label></td>
+                <td><label for="filelog_delete_old_checkbox" class="qbt-translatable" data-i18n="Delete backup logs older than:">Delete backup logs older than:</label></td>
                 <td>
                     <input type="number" min="1" max="365" value="6" id="filelog_age_input" onchange="qBittorrent.Preferences.numberInputLimiter(this);" />
                     <select id="filelog_age_type_select">
-                        <option value="0">QBT_TR(days)QBT_TR[CONTEXT=OptionsDialog]</option>
-                        <option value="1" selected>QBT_TR(months)QBT_TR[CONTEXT=OptionsDialog]</option>
-                        <option value="2">QBT_TR(years)QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="0" class="qbt-translatable" data-i18n="days">days</option>
+                        <option value="1" selected class="qbt-translatable" data-i18n="months">months</option>
+                        <option value="2" class="qbt-translatable" data-i18n="years">years</option>
                     </select>
                 </td>
             </tr>
@@ -39,116 +39,116 @@
 
     <div class="formRow">
         <input type="checkbox" id="performanceWarning" />
-        <label for="performanceWarning">QBT_TR(Log performance warnings)QBT_TR[CONTEXT=OptionsDialog]</label>
+        <label for="performanceWarning" class="qbt-translatable" data-i18n="Log performance warnings">Log performance warnings</label>
     </div>
 </div>
 
 <div id="DownloadsTab" class="PrefTab invisible">
     <fieldset class="settings">
-        <legend>QBT_TR(When adding a torrent)QBT_TR[CONTEXT=OptionsDialog]</legend>
+        <legend class="qbt-translatable" data-i18n="When adding a torrent">When adding a torrent</legend>
         <div class="formRow">
-            <label for="contentlayout_select">QBT_TR(Torrent content layout:)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="contentlayout_select" class="qbt-translatable" data-i18n="Torrent content layout:">Torrent content layout:</label>
             <select id="contentlayout_select">
-                <option value="Original">QBT_TR(Original)QBT_TR[CONTEXT=OptionsDialog]</option>
-                <option value="Subfolder">QBT_TR(Create subfolder)QBT_TR[CONTEXT=OptionsDialog]</option>
-                <option value="NoSubfolder">QBT_TR(Don't create subfolder)QBT_TR[CONTEXT=OptionsDialog]</option>
+                <option value="Original" class="qbt-translatable" data-i18n="Original">Original</option>
+                <option value="Subfolder" class="qbt-translatable" data-i18n="Create subfolder">Create subfolder</option>
+                <option value="NoSubfolder" class="qbt-translatable" data-i18n="Don't create subfolder">Don't create subfolder</option>
             </select>
         </div>
         <div class="formRow">
             <input type="checkbox" id="addToTopOfQueueCheckbox" />
-            <label for="addToTopOfQueueCheckbox">QBT_TR(Add to top of queue)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="addToTopOfQueueCheckbox" class="qbt-translatable" data-i18n="Add to top of queue">Add to top of queue</label>
         </div>
         <div class="formRow">
             <input type="checkbox" id="dontstartdownloads_checkbox" />
-            <label for="dontstartdownloads_checkbox">QBT_TR(Do not start the download automatically)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="dontstartdownloads_checkbox" class="qbt-translatable" data-i18n="Do not start the download automatically">Do not start the download automatically</label>
         </div>
         <div class="formRow">
-            <label for="stopConditionSelect">QBT_TR(Torrent stop condition:)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="stopConditionSelect" class="qbt-translatable" data-i18n="Torrent stop condition:">Torrent stop condition:</label>
             <select id="stopConditionSelect">
-                <option value="None">QBT_TR(None)QBT_TR[CONTEXT=OptionsDialog]</option>
-                <option value="MetadataReceived">QBT_TR(Metadata received)QBT_TR[CONTEXT=OptionsDialog]</option>
-                <option value="FilesChecked">QBT_TR(Files checked)QBT_TR[CONTEXT=OptionsDialog]</option>
+                <option value="None" class="qbt-translatable" data-i18n="None">None</option>
+                <option value="MetadataReceived" class="qbt-translatable" data-i18n="Metadata received">Metadata received</option>
+                <option value="FilesChecked" class="qbt-translatable" data-i18n="Files checked">Files checked</option>
             </select>
         </div>
         <div class="formRow">
             <input type="checkbox" id="deletetorrentfileafter_checkbox" />
-            <label for="deletetorrentfileafter_checkbox">QBT_TR(Delete .torrent files afterwards)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="deletetorrentfileafter_checkbox" class="qbt-translatable" data-i18n="Delete .torrent files afterwards">Delete .torrent files afterwards</label>
         </div>
     </fieldset>
 
     <div class="formRow">
         <input type="checkbox" id="preallocateall_checkbox" />
-        <label for="preallocateall_checkbox">QBT_TR(Pre-allocate disk space for all files)QBT_TR[CONTEXT=OptionsDialog]</label>
+        <label for="preallocateall_checkbox" class="qbt-translatable" data-i18n="Pre-allocate disk space for all files">Pre-allocate disk space for all files</label>
     </div>
     <div class="formRow">
         <span id="appendexttr">
             <input type="checkbox" id="appendext_checkbox" />
-            <label for="appendext_checkbox">QBT_TR(Append .!qB extension to incomplete files)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="appendext_checkbox" class="qbt-translatable" data-i18n="Append .!qB extension to incomplete files">Append .!qB extension to incomplete files</label>
         </span>
     </div>
     <div class="formRow">
         <span id="unwantedfoldertr">
             <input type="checkbox" id="unwantedfolder_checkbox" />
-            <label for="unwantedfolder_checkbox">QBT_TR(Keep unselected files in ".unwanted" folder)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="unwantedfolder_checkbox" class="qbt-translatable" data-i18n="Keep unselected files in ".unwanted" folder">Keep unselected files in ".unwanted" folder</label>
         </span>
     </div>
 
     <fieldset class="settings">
-        <legend>QBT_TR(Saving Management)QBT_TR[CONTEXT=HttpServer]</legend>
+        <legend class="qbt-translatable" data-i18n="Saving Management">Saving Management</legend>
         <table>
             <tr>
                 <td>
-                    <label>QBT_TR(Default Torrent Management Mode:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label class="qbt-translatable" data-i18n="Default Torrent Management Mode:">Default Torrent Management Mode:</label>
                 </td>
                 <td>
                     <select id="default_tmm_combobox">
-                        <option value="false" selected>QBT_TR(Manual)QBT_TR[CONTEXT=OptionsDialog]</option>
-                        <option value="true">QBT_TR(Automatic)QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="false" selected class="qbt-translatable" data-i18n="Manual">Manual</option>
+                        <option value="true" class="qbt-translatable" data-i18n="Automatic">Automatic</option>
                     </select>
                 </td>
             </tr>
             <tr>
                 <td>
-                    <label>QBT_TR(When Torrent Category changed:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label class="qbt-translatable" data-i18n="When Torrent Category changed:">When Torrent Category changed:</label>
                 </td>
                 <td>
                     <select id="torrent_changed_tmm_combobox">
-                        <option value="true">QBT_TR(Relocate torrent)QBT_TR[CONTEXT=OptionsDialog]</option>
-                        <option value="false" selected>QBT_TR(Switch torrent to Manual Mode)QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="true" class="qbt-translatable" data-i18n="Relocate torrent">Relocate torrent</option>
+                        <option value="false" selected class="qbt-translatable" data-i18n="Switch torrent to Manual Mode">Switch torrent to Manual Mode</option>
                     </select>
                 </td>
             </tr>
             <tr>
                 <td>
-                    <label>QBT_TR(When Default Save Path changed:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label class="qbt-translatable" data-i18n="When Default Save Path changed:">When Default Save Path changed:</label>
                 </td>
                 <td>
                     <select id="save_path_changed_tmm_combobox">
-                        <option value="true">QBT_TR(Relocate affected torrents)QBT_TR[CONTEXT=OptionsDialog]</option>
-                        <option value="false" selected>QBT_TR(Switch affected torrents to Manual Mode)QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="true" class="qbt-translatable" data-i18n="Relocate affected torrents">Relocate affected torrents</option>
+                        <option value="false" selected class="qbt-translatable" data-i18n="Switch affected torrents to Manual Mode">Switch affected torrents to Manual Mode</option>
                     </select>
                 </td>
             </tr>
             <tr>
                 <td>
-                    <label>QBT_TR(When Category Save Path changed:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label class="qbt-translatable" data-i18n="When Category Save Path changed:">When Category Save Path changed:</label>
                 </td>
                 <td>
                     <select id="category_changed_tmm_combobox">
-                        <option value="true">QBT_TR(Relocate affected torrents)QBT_TR[CONTEXT=OptionsDialog]</option>
-                        <option value="false" selected>QBT_TR(Switch affected torrents to Manual Mode)QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="true" class="qbt-translatable" data-i18n="Relocate affected torrents">Relocate affected torrents</option>
+                        <option value="false" selected class="qbt-translatable" data-i18n="Switch affected torrents to Manual Mode">Switch affected torrents to Manual Mode</option>
                     </select>
                 </td>
             </tr>
         </table>
         <div class="formRow">
             <input type="checkbox" id="use_subcategories_checkbox" />
-            <label for="use_subcategories_checkbox">QBT_TR(Use Subcategories)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="use_subcategories_checkbox" class="qbt-translatable" data-i18n="Use Subcategories">Use Subcategories</label>
         </div>
         <table>
             <tr>
                 <td>
-                    <label for="savepath_text">QBT_TR(Default Save Path:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="savepath_text" class="qbt-translatable" data-i18n="Default Save Path:">Default Save Path:</label>
                 </td>
                 <td>
                     <input type="text" id="savepath_text" autocorrect="off" autocapitalize="none" />
@@ -157,7 +157,7 @@
             <tr>
                 <td>
                     <input type="checkbox" id="temppath_checkbox" onclick="qBittorrent.Preferences.updateTempDirEnabled();" />
-                    <label for="temppath_checkbox">QBT_TR(Keep incomplete torrents in:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="temppath_checkbox" class="qbt-translatable" data-i18n="Keep incomplete torrents in:">Keep incomplete torrents in:</label>
                 </td>
                 <td>
                     <input type="text" id="temppath_text" autocorrect="off" autocapitalize="none" />
@@ -166,7 +166,7 @@
             <tr>
                 <td>
                     <input type="checkbox" id="exportdir_checkbox" onclick="qBittorrent.Preferences.updateExportDirEnabled();" />
-                    <label for="exportdir_checkbox">QBT_TR(Copy .torrent files to:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="exportdir_checkbox" class="qbt-translatable" data-i18n="Copy .torrent files to:">Copy .torrent files to:</label>
                 </td>
                 <td>
                     <input type="text" id="exportdir_text" autocorrect="off" autocapitalize="none" />
@@ -175,7 +175,7 @@
             <tr>
                 <td>
                     <input type="checkbox" id="exportdirfin_checkbox" onclick="qBittorrent.Preferences.updateExportDirFinEnabled();" />
-                    <label for="exportdirfin_checkbox">QBT_TR(Copy .torrent files for finished downloads to:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="exportdirfin_checkbox" class="qbt-translatable" data-i18n="Copy .torrent files for finished downloads to:">Copy .torrent files for finished downloads to:</label>
                 </td>
                 <td>
                     <input type="text" id="exportdirfin_text" autocorrect="off" autocapitalize="none" />
@@ -185,12 +185,12 @@
     </fieldset>
 
     <fieldset class="settings">
-        <legend>QBT_TR(Automatically add torrents from:)QBT_TR[CONTEXT=OptionsDialog]</legend>
+        <legend class="qbt-translatable" data-i18n="Automatically add torrents from:">Automatically add torrents from:</legend>
         <table id="watched_folders_tab" style="border: 1px solid black;">
             <thead>
                 <tr>
-                    <th>QBT_TR(Monitored Folder)QBT_TR[CONTEXT=ScanFoldersModel]</th>
-                    <th>QBT_TR(Override Save Location)QBT_TR[CONTEXT=ScanFoldersModel]</th>
+                    <th class="qbt-translatable" data-i18n="Monitored Folder">Monitored Folder</th>
+                    <th class="qbt-translatable" data-i18n="Override Save Location">Override Save Location</th>
                 </tr>
             </thead>
             <tbody></tbody>
@@ -200,7 +200,7 @@
     <fieldset class="settings">
         <legend>
             <input type="checkbox" id="excludedFileNamesCheckbox" onclick="qBittorrent.Preferences.updateExcludedFileNamesEnabled();" />
-            <label for="excludedFileNamesCheckbox">QBT_TR(Excluded file names)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="excludedFileNamesCheckbox" class="qbt-translatable" data-i18n="Excluded file names">Excluded file names</label>
         </legend>
         <textarea id="excludedFileNamesTextarea" rows="6" cols="70"></textarea>
     </fieldset>
@@ -208,12 +208,12 @@
     <fieldset class="settings">
         <legend>
             <input type="checkbox" id="mail_notification_checkbox" onclick="qBittorrent.Preferences.updateMailNotification();" />
-            <label for="mail_notification_checkbox">QBT_TR(Email notification upon download completion)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="mail_notification_checkbox" class="qbt-translatable" data-i18n="Email notification upon download completion">Email notification upon download completion</label>
         </legend>
         <table>
             <tr>
                 <td>
-                    <label for="src_email_txt">QBT_TR(From:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="src_email_txt" class="qbt-translatable" data-i18n="From:">From:</label>
                 </td>
                 <td>
                     <input type="text" id="src_email_txt" />
@@ -221,7 +221,7 @@
             </tr>
             <tr>
                 <td>
-                    <label for="dest_email_txt">QBT_TR(To:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="dest_email_txt" class="qbt-translatable" data-i18n="To:">To:</label>
                 </td>
                 <td>
                     <input type="text" id="dest_email_txt" />
@@ -229,7 +229,7 @@
             </tr>
             <tr>
                 <td>
-                    <label for="smtp_server_txt">QBT_TR(SMTP server:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="smtp_server_txt" class="qbt-translatable" data-i18n="SMTP server:">SMTP server:</label>
                 </td>
                 <td>
                     <input type="text" id="smtp_server_txt" />
@@ -237,17 +237,17 @@
             </tr>
         </table>
         <div class="formRow">
-            <input type="checkbox" id="mail_ssl_checkbox" /><label for="mail_ssl_checkbox">QBT_TR(This server requires a secure connection (SSL))QBT_TR[CONTEXT=OptionsDialog]</label>
+            <input type="checkbox" id="mail_ssl_checkbox" /><label for="mail_ssl_checkbox" class="qbt-translatable" data-i18n="This server requires a secure connection (SSL)">This server requires a secure connection (SSL)</label>
         </div>
         <fieldset class="settings">
             <legend>
                 <input type="checkbox" id="mail_auth_checkbox" onclick="qBittorrent.Preferences.updateMailAuthSettings();" />
-                <label for="mail_auth_checkbox">QBT_TR(Authentication)QBT_TR[CONTEXT=OptionsDialog]</label>
+                <label for="mail_auth_checkbox" class="qbt-translatable" data-i18n="Authentication">Authentication</label>
             </legend>
             <table>
                 <tr>
                     <td>
-                        <label for="mail_username_text">QBT_TR(Username:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                        <label for="mail_username_text" class="qbt-translatable" data-i18n="Username:">Username:</label>
                     </td>
                     <td>
                         <input type="text" id="mail_username_text" />
@@ -255,7 +255,7 @@
                 </tr>
                 <tr>
                     <td>
-                        <label for="mail_password_text">QBT_TR(Password:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                        <label for="mail_password_text" class="qbt-translatable" data-i18n="Password:">Password:</label>
                     </td>
                     <td>
                         <input type="password" id="mail_password_text" />
@@ -274,28 +274,28 @@
         </legend>
         <div class="formRow">
             <input type="checkbox" id="autorunOnTorrentAddedCheckbox" onclick="qBittorrent.Preferences.updateAutoRunOnTorrentAdded();" />
-            <label for="autorunOnTorrentAddedCheckbox">QBT_TR(Run external program on torrent added)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="autorunOnTorrentAddedCheckbox" class="qbt-translatable" data-i18n="Run external program on torrent added">Run external program on torrent added</label>
             <input type="text" id="autorunOnTorrentAddedProgram" style="width: 400px;" />
         </div>
         <div class="formRow">
             <input type="checkbox" id="autorun_checkbox" onclick="qBittorrent.Preferences.updateAutoRun();" />
-            <label for="autorun_checkbox">QBT_TR(Run external program on torrent finished)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="autorun_checkbox" class="qbt-translatable" data-i18n="Run external program on torrent finished">Run external program on torrent finished</label>
             <input type="text" id="autorunProg_txt" style="width: 400px;" />
         </div>
-        <div style="font-style: italic;">QBT_TR(Supported parameters (case sensitive):)QBT_TR[CONTEXT=OptionsDialog]
+        <div style="font-style: italic;" class="qbt-translatable" data-i18n="Supported parameters (case sensitive):">Supported parameters (case sensitive):
             <ul>
-                <li>QBT_TR(%N: Torrent name)QBT_TR[CONTEXT=OptionsDialog]</li>
-                <li>QBT_TR(%L: Category)QBT_TR[CONTEXT=OptionsDialog]</li>
-                <li>QBT_TR(%G: Tags (separated by comma))QBT_TR[CONTEXT=OptionsDialog]</li>
-                <li>QBT_TR(%F: Content path (same as root path for multifile torrent))QBT_TR[CONTEXT=OptionsDialog]</li>
-                <li>QBT_TR(%R: Root path (first torrent subdirectory path))QBT_TR[CONTEXT=OptionsDialog]</li>
-                <li>QBT_TR(%D: Save path)QBT_TR[CONTEXT=OptionsDialog]</li>
-                <li>QBT_TR(%C: Number of files)QBT_TR[CONTEXT=OptionsDialog]</li>
-                <li>QBT_TR(%Z: Torrent size (bytes))QBT_TR[CONTEXT=OptionsDialog]</li>
-                <li>QBT_TR(%T: Current tracker)QBT_TR[CONTEXT=OptionsDialog]</li>
-                <li>QBT_TR(%I: Info hash v1)QBT_TR[CONTEXT=OptionsDialog]</li>
-                <li>QBT_TR(%J: Info hash v2)QBT_TR[CONTEXT=OptionsDialog]</li>
-                <li>QBT_TR(%K: Torrent ID)QBT_TR[CONTEXT=OptionsDialog]</li>
+                <li class="qbt-translatable" data-i18n="%N: Torrent name">%N: Torrent name</li>
+                <li class="qbt-translatable" data-i18n="%L: Category">%L: Category</li>
+                <li class="qbt-translatable" data-i18n="%G: Tags (separated by comma)">%G: Tags (separated by comma)</li>
+                <li class="qbt-translatable" data-i18n="%F: Content path (same as root path for multifile torrent)">%F: Content path (same as root path for multifile torrent)</li>
+                <li class="qbt-translatable" data-i18n="%R: Root path (first torrent subdirectory path)">%R: Root path (first torrent subdirectory path)</li>
+                <li class="qbt-translatable" data-i18n="%D: Save path">%D: Save path</li>
+                <li class="qbt-translatable" data-i18n="%C: Number of files">%C: Number of files</li>
+                <li class="qbt-translatable" data-i18n="%Z: Torrent size (bytes)">%Z: Torrent size (bytes)</li>
+                <li class="qbt-translatable" data-i18n="%T: Current tracker">%T: Current tracker</li>
+                <li class="qbt-translatable" data-i18n="%I: Info hash v1">%I: Info hash v1</li>
+                <li class="qbt-translatable" data-i18n="%J: Info hash v2">%J: Info hash v2</li>
+                <li class="qbt-translatable" data-i18n="%K: Torrent ID">%K: Torrent ID</li>
             </ul>
             QBT_TR(Tip: Encapsulate parameter with quotation marks to avoid text being cut off at whitespace (e.g., "%N"))QBT_TR[CONTEXT=OptionsDialog]
         </div>
@@ -304,54 +304,54 @@
 
 <div id="ConnectionTab" class="PrefTab invisible">
     <div class="formRow">
-        <label>QBT_TR(Peer connection protocol:)QBT_TR[CONTEXT=OptionsDialog]</label>
+        <label class="qbt-translatable" data-i18n="Peer connection protocol:">Peer connection protocol:</label>
         <select id="enable_protocol_combobox">
-            <option value="0" selected>QBT_TR(TCP and μTP)QBT_TR[CONTEXT=OptionsDialog]</option>
+            <option value="0" selected class="qbt-translatable" data-i18n="TCP and μTP">TCP and μTP</option>
             <option value="1">TCP</option>
             <option value="2">μTP</option>
         </select>
     </div>
     <fieldset class="settings">
-        <legend>QBT_TR(Listening Port)QBT_TR[CONTEXT=OptionsDialog]</legend>
+        <legend class="qbt-translatable" data-i18n="Listening Port">Listening Port</legend>
         <div class="formRow">
-            <label for="port_value">QBT_TR(Port used for incoming connections:)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="port_value" class="qbt-translatable" data-i18n="Port used for incoming connections:">Port used for incoming connections:</label>
             <input type="text" id="port_value" style="width: 4em;" title="QBT_TR(Set to 0 to let your system pick an unused port)QBT_TR[CONTEXT=OptionsDialog]" />
-            <button type="button" style="margin-left: 1em;" onclick="qBittorrent.Preferences.generateRandomPort();">QBT_TR(Random)QBT_TR[CONTEXT=OptionsDialog]</button>
+            <button type="button" style="margin-left: 1em;" onclick="qBittorrent.Preferences.generateRandomPort();" class="qbt-translatable" data-i18n="Random">Random</button>
         </div>
         <div class="formRow">
             <input type="checkbox" id="upnp_checkbox" />
-            <label for="upnp_checkbox">QBT_TR(Use UPnP / NAT-PMP port forwarding from my router)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="upnp_checkbox" class="qbt-translatable" data-i18n="Use UPnP / NAT-PMP port forwarding from my router">Use UPnP / NAT-PMP port forwarding from my router</label>
         </div>
     </fieldset>
 
     <fieldset class="settings">
-        <legend>QBT_TR(Connections Limits)QBT_TR[CONTEXT=OptionsDialog]</legend>
+        <legend class="qbt-translatable" data-i18n="Connections Limits">Connections Limits</legend>
         <table>
             <tr>
                 <td>
                     <input type="checkbox" id="max_connec_checkbox" onclick="qBittorrent.Preferences.updateMaxConnecEnabled();" />
-                    <label for="max_connec_checkbox">QBT_TR(Global maximum number of connections:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="max_connec_checkbox" class="qbt-translatable" data-i18n="Global maximum number of connections:">Global maximum number of connections:</label>
                 </td>
                 <td><input type="text" id="max_connec_value" style="width: 4em;" /></td>
             </tr>
             <tr>
                 <td>
                     <input type="checkbox" id="max_connec_per_torrent_checkbox" onclick="qBittorrent.Preferences.updateMaxConnecPerTorrentEnabled();" />
-                    <label for="max_connec_per_torrent_checkbox">QBT_TR(Maximum number of connections per torrent:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="max_connec_per_torrent_checkbox" class="qbt-translatable" data-i18n="Maximum number of connections per torrent:">Maximum number of connections per torrent:</label>
                 </td>
                 <td><input type="text" id="max_connec_per_torrent_value" style="width: 4em;" /></td>
             </tr>
             <tr>
                 <td>
                     <input type="checkbox" id="max_uploads_checkbox" onclick="qBittorrent.Preferences.updateMaxUploadsEnabled();" />
-                    <label for="max_uploads_checkbox">QBT_TR(Global maximum number of upload slots:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="max_uploads_checkbox" class="qbt-translatable" data-i18n="Global maximum number of upload slots:">Global maximum number of upload slots:</label>
                 </td>
                 <td><input type="text" id="max_uploads_value" style="width: 4em;" /></td>
             </tr>
             <tr>
                 <td>
                     <input type="checkbox" id="max_uploads_per_torrent_checkbox" onclick="qBittorrent.Preferences.updateMaxUploadsPerTorrentEnabled();" />
-                    <label for="max_uploads_per_torrent_checkbox">QBT_TR(Maximum number of upload slots per torrent:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="max_uploads_per_torrent_checkbox" class="qbt-translatable" data-i18n="Maximum number of upload slots per torrent:">Maximum number of upload slots per torrent:</label>
                 </td>
                 <td><input type="text" id="max_uploads_per_torrent_value" style="width: 4em;" /></td>
             </tr>
@@ -361,18 +361,18 @@
     <fieldset class="settings" id="fieldsetI2p">
         <legend>
             <input type="checkbox" id="i2pEnabledCheckbox" onclick="qBittorrent.Preferences.updateI2PSettingsEnabled();" />
-            <label for="i2pEnabledCheckbox">QBT_TR(I2P (Experimental))QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="i2pEnabledCheckbox" class="qbt-translatable" data-i18n="I2P (Experimental)">I2P (Experimental)</label>
         </legend>
         <table>
             <tr>
                 <td>
-                    <label for="i2pAddress">QBT_TR(Host:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="i2pAddress" class="qbt-translatable" data-i18n="Host:">Host:</label>
                 </td>
                 <td>
                     <input type="text" id="i2pAddress" />
                 </td>
                 <td>
-                    <label for="i2pPort">QBT_TR(Port:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="i2pPort" class="qbt-translatable" data-i18n="Port:">Port:</label>
                 </td>
                 <td>
                     <input type="number" id="i2pPort" min="0" max="65535" onchange="qBittorrent.Preferences.numberInputLimiter(this);" style="width: 5em;" />
@@ -381,33 +381,33 @@
         </table>
         <div class="formRow">
             <input type="checkbox" id="i2pMixedMode" title="QBT_TR(If &quot;mixed mode&quot; is enabled, I2P torrents are allowed to also get peers from other sources than the tracker, and connect to regular IPs, not providing any anonymization. This may be useful if the user is not interested in the anonymization of I2P, but still wants to be able to connect to I2P peers.)QBT_TR[CONTEXT=OptionsDialog]" />
-            <label for="i2pMixedMode">QBT_TR(Mixed mode)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="i2pMixedMode" class="qbt-translatable" data-i18n="Mixed mode">Mixed mode</label>
         </div>
     </fieldset>
 
     <fieldset class="settings">
-        <legend>QBT_TR(Proxy Server)QBT_TR[CONTEXT=OptionsDialog]</legend>
+        <legend class="qbt-translatable" data-i18n="Proxy Server">Proxy Server</legend>
         <table>
             <tr>
                 <td>
-                    <label for="peer_proxy_type_select">QBT_TR(Type:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="peer_proxy_type_select" class="qbt-translatable" data-i18n="Type:">Type:</label>
                 </td>
                 <td>
                     <select id="peer_proxy_type_select" onchange="qBittorrent.Preferences.updatePeerProxySettings();">
-                        <option value="None">QBT_TR((None))QBT_TR[CONTEXT=OptionsDialog]</option>
-                        <option value="SOCKS4">QBT_TR(SOCKS4)QBT_TR[CONTEXT=OptionsDialog]</option>
-                        <option value="SOCKS5">QBT_TR(SOCKS5)QBT_TR[CONTEXT=OptionsDialog]</option>
-                        <option value="HTTP">QBT_TR(HTTP)QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="None" class="qbt-translatable" data-i18n="(None)">(None)</option>
+                        <option value="SOCKS4" class="qbt-translatable" data-i18n="SOCKS4">SOCKS4</option>
+                        <option value="SOCKS5" class="qbt-translatable" data-i18n="SOCKS5">SOCKS5</option>
+                        <option value="HTTP" class="qbt-translatable" data-i18n="HTTP">HTTP</option>
                     </select>
                 </td>
                 <td>
-                    <label for="peer_proxy_host_text">QBT_TR(Host:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="peer_proxy_host_text" class="qbt-translatable" data-i18n="Host:">Host:</label>
                 </td>
                 <td>
                     <input type="text" id="peer_proxy_host_text" />
                 </td>
                 <td>
-                    <label for="peer_proxy_port_value">QBT_TR(Port:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="peer_proxy_port_value" class="qbt-translatable" data-i18n="Port:">Port:</label>
                 </td>
                 <td>
                     <input type="text" id="peer_proxy_port_value" style="width: 4em;" />
@@ -417,18 +417,18 @@
 
         <div class="formRow">
             <input type="checkbox" id="proxyHostnameLookupCheckbox" title="QBT_TR(If checked, hostname lookups are done via the proxy.)QBT_TR[CONTEXT=OptionsDialog]" />
-            <label for="proxyHostnameLookupCheckbox">QBT_TR(Perform hostname lookup via proxy)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="proxyHostnameLookupCheckbox" class="qbt-translatable" data-i18n="Perform hostname lookup via proxy">Perform hostname lookup via proxy</label>
         </div>
 
         <fieldset class="settings">
             <legend>
                 <input type="checkbox" id="peer_proxy_auth_checkbox" onclick="qBittorrent.Preferences.updatePeerProxyAuthSettings();" />
-                <label for="peer_proxy_auth_checkbox">QBT_TR(Authentication)QBT_TR[CONTEXT=OptionsDialog]</label>
+                <label for="peer_proxy_auth_checkbox" class="qbt-translatable" data-i18n="Authentication">Authentication</label>
             </legend>
             <table>
                 <tr>
                     <td>
-                        <label for="peer_proxy_username_text">QBT_TR(Username:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                        <label for="peer_proxy_username_text" class="qbt-translatable" data-i18n="Username:">Username:</label>
                     </td>
                     <td>
                         <input type="text" id="peer_proxy_username_text" />
@@ -436,7 +436,7 @@
                 </tr>
                 <tr>
                     <td>
-                        <label for="peer_proxy_password_text">QBT_TR(Password:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                        <label for="peer_proxy_password_text" class="qbt-translatable" data-i18n="Password:">Password:</label>
                     </td>
                     <td>
                         <input type="password" id="peer_proxy_password_text" />
@@ -444,46 +444,46 @@
                 </tr>
             </table>
             <div class="formRow">
-                <span>QBT_TR(Info: The password is saved unencrypted)QBT_TR[CONTEXT=OptionsDialog]</span>
+                <span class="qbt-translatable" data-i18n="Info: The password is saved unencrypted">Info: The password is saved unencrypted</span>
             </div>
         </fieldset>
 
         <fieldset class="settings">
             <legend>
                 <input type="checkbox" id="proxy_bittorrent_checkbox" onclick="qBittorrent.Preferences.updatePeerProxySettings();" />
-                <label for="proxy_bittorrent_checkbox">QBT_TR(Use proxy for BitTorrent purposes)QBT_TR[CONTEXT=OptionsDialog]</label>
+                <label for="proxy_bittorrent_checkbox" class="qbt-translatable" data-i18n="Use proxy for BitTorrent purposes">Use proxy for BitTorrent purposes</label>
             </legend>
             <div class="formRow">
                 <input type="checkbox" id="use_peer_proxy_checkbox" />
-                <label for="use_peer_proxy_checkbox">QBT_TR(Use proxy for peer connections)QBT_TR[CONTEXT=OptionsDialog]</label>
+                <label for="use_peer_proxy_checkbox" class="qbt-translatable" data-i18n="Use proxy for peer connections">Use proxy for peer connections</label>
             </div>
         </fieldset>
         <div class="formRow">
             <input type="checkbox" id="proxy_rss_checkbox" />
-            <label for="proxy_rss_checkbox">QBT_TR(Use proxy for RSS purposes)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="proxy_rss_checkbox" class="qbt-translatable" data-i18n="Use proxy for RSS purposes">Use proxy for RSS purposes</label>
         </div>
         <div class="formRow">
             <input type="checkbox" id="proxy_misc_checkbox" />
-            <label for="proxy_misc_checkbox">QBT_TR(Use proxy for general purposes)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="proxy_misc_checkbox" class="qbt-translatable" data-i18n="Use proxy for general purposes">Use proxy for general purposes</label>
         </div>
     </fieldset>
 
     <fieldset class="settings">
         <legend>
-            <label>QBT_TR(IP Filtering)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label class="qbt-translatable" data-i18n="IP Filtering">IP Filtering</label>
         </legend>
         <div class="formRow">
             <input type="checkbox" id="ipfilter_text_checkbox" onclick="qBittorrent.Preferences.updateFilterSettings();" />
-            <label for="ipfilter_text_checkbox">QBT_TR(Filter path (.dat, .p2p, .p2b):)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="ipfilter_text_checkbox" class="qbt-translatable" data-i18n="Filter path (.dat, .p2p, .p2b):">Filter path (.dat, .p2p, .p2b):</label>
             <input type="text" id="ipfilter_text" />
         </div>
         <div class="formRow">
             <input type="checkbox" id="ipfilter_trackers_checkbox" />
-            <label for="ipfilter_trackers_checkbox">QBT_TR(Apply to trackers)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="ipfilter_trackers_checkbox" class="qbt-translatable" data-i18n="Apply to trackers">Apply to trackers</label>
         </div>
         <div class="formRow">
             <fieldset class="settings">
-                <legend>QBT_TR(Manually banned IP addresses...)QBT_TR[CONTEXT=OptionsDialog]</legend>
+                <legend class="qbt-translatable" data-i18n="Manually banned IP addresses...">Manually banned IP addresses...</legend>
                 <textarea id="banned_IPs_textarea" rows="5" cols="70"></textarea>
             </fieldset>
         </div>
@@ -492,44 +492,44 @@
 
 <div id="SpeedTab" class="PrefTab invisible">
     <fieldset class="settings">
-        <legend>QBT_TR(Global Rate Limits)QBT_TR[CONTEXT=OptionsDialog]</legend>
+        <legend class="qbt-translatable" data-i18n="Global Rate Limits">Global Rate Limits</legend>
         <table>
             <tr>
                 <td rowspan="2">
                     <img src="images/slow_off.svg" style="height: 1.5em;" alt="QBT_TR(Alternative speed limits)QBT_TR[CONTEXT=MainWindow]">
                 </td>
-                <td><label for="up_limit_value">QBT_TR(Upload:)QBT_TR[CONTEXT=OptionsDialog]</label></td>
+                <td><label for="up_limit_value" class="qbt-translatable" data-i18n="Upload:">Upload:</label></td>
                 <td><input type="number" id="up_limit_value" style="width: 4em;" min="0" />&nbsp;&nbsp;QBT_TR(KiB/s)QBT_TR[CONTEXT=OptionsDialog]</td>
             </tr>
             <tr>
-                <td><label for="dl_limit_value">QBT_TR(Download:)QBT_TR[CONTEXT=OptionsDialog]</label></td>
+                <td><label for="dl_limit_value" class="qbt-translatable" data-i18n="Download:">Download:</label></td>
                 <td><input type="number" id="dl_limit_value" style="width: 4em;" min="0" />&nbsp;&nbsp;QBT_TR(KiB/s)QBT_TR[CONTEXT=OptionsDialog]</td>
             </tr>
         </table>
-        <i>QBT_TR(0 means unlimited)QBT_TR[CONTEXT=OptionsDialog]</i>
+        <i class="qbt-translatable" data-i18n="0 means unlimited">0 means unlimited</i>
     </fieldset>
 
     <fieldset class="settings">
-        <legend>QBT_TR(Alternative Rate Limits)QBT_TR[CONTEXT=OptionsDialog]</legend>
+        <legend class="qbt-translatable" data-i18n="Alternative Rate Limits">Alternative Rate Limits</legend>
         <table>
             <tr>
                 <td rowspan="2">
                     <img src="images/slow.svg" style="height: 1.5em;" alt="QBT_TR(Alternative speed limits)QBT_TR[CONTEXT=MainWindow]">
                 </td>
-                <td><label for="alt_up_limit_value">QBT_TR(Upload:)QBT_TR[CONTEXT=OptionsDialog]</label></td>
+                <td><label for="alt_up_limit_value" class="qbt-translatable" data-i18n="Upload:">Upload:</label></td>
                 <td><input type="number" id="alt_up_limit_value" style="width: 4em;" min="0" />&nbsp;&nbsp;QBT_TR(KiB/s)QBT_TR[CONTEXT=OptionsDialog]</td>
             </tr>
             <tr>
-                <td><label for="alt_dl_limit_value">QBT_TR(Download:)QBT_TR[CONTEXT=OptionsDialog]</label></td>
+                <td><label for="alt_dl_limit_value" class="qbt-translatable" data-i18n="Download:">Download:</label></td>
                 <td><input type="number" id="alt_dl_limit_value" style="width: 4em;" min="0" />&nbsp;&nbsp;QBT_TR(KiB/s)QBT_TR[CONTEXT=OptionsDialog]</td>
             </tr>
         </table>
-        <i>QBT_TR(0 means unlimited)QBT_TR[CONTEXT=OptionsDialog]</i>
+        <i class="qbt-translatable" data-i18n="0 means unlimited">0 means unlimited</i>
 
         <fieldset class="settings">
             <legend>
                 <input type="checkbox" id="limitSchedulingCheckbox" onclick="qBittorrent.Preferences.updateSchedulingEnabled();" />
-                <label for="limitSchedulingCheckbox">QBT_TR(Schedule the use of alternative rate limits)QBT_TR[CONTEXT=OptionsDialog]</label>
+                <label for="limitSchedulingCheckbox" class="qbt-translatable" data-i18n="Schedule the use of alternative rate limits">Schedule the use of alternative rate limits</label>
             </legend>
             <div class="formRow">
                 QBT_TR(From:)QBT_TR[CONTEXT=OptionsDialog]
@@ -540,81 +540,81 @@
             <div class="formRow">
                 QBT_TR(When:)QBT_TR[CONTEXT=OptionsDialog]
                 <select id="schedule_freq_select">
-                    <option value="0">QBT_TR(Every day)QBT_TR[CONTEXT=OptionsDialog]</option>
-                    <option value="1">QBT_TR(Weekdays)QBT_TR[CONTEXT=OptionsDialog]</option>
-                    <option value="2">QBT_TR(Weekends)QBT_TR[CONTEXT=OptionsDialog]</option>
-                    <option value="3">QBT_TR(Monday)QBT_TR[CONTEXT=HttpServer]</option>
-                    <option value="4">QBT_TR(Tuesday)QBT_TR[CONTEXT=HttpServer]</option>
-                    <option value="5">QBT_TR(Wednesday)QBT_TR[CONTEXT=HttpServer]</option>
-                    <option value="6">QBT_TR(Thursday)QBT_TR[CONTEXT=HttpServer]</option>
-                    <option value="7">QBT_TR(Friday)QBT_TR[CONTEXT=HttpServer]</option>
-                    <option value="8">QBT_TR(Saturday)QBT_TR[CONTEXT=HttpServer]</option>
-                    <option value="9">QBT_TR(Sunday)QBT_TR[CONTEXT=HttpServer]</option>
+                    <option value="0" class="qbt-translatable" data-i18n="Every day">Every day</option>
+                    <option value="1" class="qbt-translatable" data-i18n="Weekdays">Weekdays</option>
+                    <option value="2" class="qbt-translatable" data-i18n="Weekends">Weekends</option>
+                    <option value="3" class="qbt-translatable" data-i18n="Monday">Monday</option>
+                    <option value="4" class="qbt-translatable" data-i18n="Tuesday">Tuesday</option>
+                    <option value="5" class="qbt-translatable" data-i18n="Wednesday">Wednesday</option>
+                    <option value="6" class="qbt-translatable" data-i18n="Thursday">Thursday</option>
+                    <option value="7" class="qbt-translatable" data-i18n="Friday">Friday</option>
+                    <option value="8" class="qbt-translatable" data-i18n="Saturday">Saturday</option>
+                    <option value="9" class="qbt-translatable" data-i18n="Sunday">Sunday</option>
                 </select>
             </div>
         </fieldset>
     </fieldset>
 
     <fieldset class="settings">
-        <legend>QBT_TR(Rate Limits Settings)QBT_TR[CONTEXT=OptionsDialog]</legend>
+        <legend class="qbt-translatable" data-i18n="Rate Limits Settings">Rate Limits Settings</legend>
         <div class="formRow">
             <input type="checkbox" id="limit_utp_rate_checkbox" />
-            <label for="limit_utp_rate_checkbox">QBT_TR(Apply rate limit to µTP protocol)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="limit_utp_rate_checkbox" class="qbt-translatable" data-i18n="Apply rate limit to µTP protocol">Apply rate limit to µTP protocol</label>
         </div>
         <div class="formRow">
             <input type="checkbox" id="limit_tcp_overhead_checkbox" />
-            <label for="limit_tcp_overhead_checkbox">QBT_TR(Apply rate limit to transport overhead)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="limit_tcp_overhead_checkbox" class="qbt-translatable" data-i18n="Apply rate limit to transport overhead">Apply rate limit to transport overhead</label>
         </div>
         <div class="formRow">
             <input type="checkbox" id="limit_lan_peers_checkbox" />
-            <label for="limit_lan_peers_checkbox">QBT_TR(Apply rate limit to peers on LAN)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="limit_lan_peers_checkbox" class="qbt-translatable" data-i18n="Apply rate limit to peers on LAN">Apply rate limit to peers on LAN</label>
         </div>
     </fieldset>
 </div>
 
 <div id="BittorrentTab" class="PrefTab invisible">
     <fieldset class="settings">
-        <legend>QBT_TR(Privacy)QBT_TR[CONTEXT=OptionsDialog]</legend>
+        <legend class="qbt-translatable" data-i18n="Privacy">Privacy</legend>
         <div class="formRow">
             <input type="checkbox" id="dht_checkbox" />
-            <label for="dht_checkbox">QBT_TR(Enable DHT (decentralized network) to find more peers)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="dht_checkbox" class="qbt-translatable" data-i18n="Enable DHT (decentralized network) to find more peers">Enable DHT (decentralized network) to find more peers</label>
         </div>
         <div class="formRow">
             <input type="checkbox" id="pex_checkbox" />
-            <label for="pex_checkbox">QBT_TR(Enable Peer Exchange (PeX) to find more peers)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="pex_checkbox" class="qbt-translatable" data-i18n="Enable Peer Exchange (PeX) to find more peers">Enable Peer Exchange (PeX) to find more peers</label>
         </div>
         <div class="formRow">
             <input type="checkbox" id="lsd_checkbox" />
-            <label for="lsd_checkbox">QBT_TR(Enable Local Peer Discovery to find more peers)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="lsd_checkbox" class="qbt-translatable" data-i18n="Enable Local Peer Discovery to find more peers">Enable Local Peer Discovery to find more peers</label>
         </div>
         <div class="formRow">
-            <label for="encryption_select">QBT_TR(Encryption mode:)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="encryption_select" class="qbt-translatable" data-i18n="Encryption mode:">Encryption mode:</label>
             <select id="encryption_select">
-                <option value="0">QBT_TR(Allow encryption)QBT_TR[CONTEXT=OptionsDialog]</option>
-                <option value="1">QBT_TR(Require encryption)QBT_TR[CONTEXT=OptionsDialog]</option>
-                <option value="2">QBT_TR(Disable encryption)QBT_TR[CONTEXT=OptionsDialog]</option>
+                <option value="0" class="qbt-translatable" data-i18n="Allow encryption">Allow encryption</option>
+                <option value="1" class="qbt-translatable" data-i18n="Require encryption">Require encryption</option>
+                <option value="2" class="qbt-translatable" data-i18n="Disable encryption">Disable encryption</option>
             </select>
         </div>
         <div class="formRow">
             <input type="checkbox" id="anonymous_mode_checkbox" />
-            <label for="anonymous_mode_checkbox">QBT_TR(Enable anonymous mode)QBT_TR[CONTEXT=OptionsDialog] (<a target="_blank" href="https://github.com/qbittorrent/qBittorrent/wiki/Anonymous-Mode">QBT_TR(More information)QBT_TR[CONTEXT=HttpServer]</a>)</label>
+            <label for="anonymous_mode_checkbox" class="qbt-translatable" data-i18n="Enable anonymous mode">Enable anonymous mode (<a target="_blank" href="https://github.com/qbittorrent/qBittorrent/wiki/Anonymous-Mode" class="qbt-translatable" data-i18n="More information">More information</a>)</label>
         </div>
     </fieldset>
 
     <div class="formRow">
-        <label for="maxActiveCheckingTorrents">QBT_TR(Max active checking torrents:)QBT_TR[CONTEXT=OptionsDialog]</label>
+        <label for="maxActiveCheckingTorrents" class="qbt-translatable" data-i18n="Max active checking torrents:">Max active checking torrents:</label>
         <input type="number" id="maxActiveCheckingTorrents" style="width: 4em;" min="-1" />
     </div>
 
     <fieldset class="settings">
         <legend>
             <input type="checkbox" id="queueing_checkbox" onclick="qBittorrent.Preferences.updateQueueingSystem();" />
-            <label for="queueing_checkbox">QBT_TR(Torrent Queueing)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="queueing_checkbox" class="qbt-translatable" data-i18n="Torrent Queueing">Torrent Queueing</label>
         </legend>
         <table>
             <tr>
                 <td>
-                    <label for="max_active_dl_value">QBT_TR(Maximum active downloads:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="max_active_dl_value" class="qbt-translatable" data-i18n="Maximum active downloads:">Maximum active downloads:</label>
                 </td>
                 <td>
                     <input type="text" id="max_active_dl_value" style="width: 4em;" />
@@ -622,7 +622,7 @@
             </tr>
             <tr>
                 <td>
-                    <label for="max_active_up_value">QBT_TR(Maximum active uploads:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="max_active_up_value" class="qbt-translatable" data-i18n="Maximum active uploads:">Maximum active uploads:</label>
                 </td>
                 <td>
                     <input type="text" id="max_active_up_value" style="width: 4em;" />
@@ -630,7 +630,7 @@
             </tr>
             <tr>
                 <td>
-                    <label for="max_active_to_value">QBT_TR(Maximum active torrents:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="max_active_to_value" class="qbt-translatable" data-i18n="Maximum active torrents:">Maximum active torrents:</label>
                 </td>
                 <td>
                     <input type="text" id="max_active_to_value" style="width: 4em;" />
@@ -640,12 +640,12 @@
         <fieldset class="settings">
             <legend>
                 <input type="checkbox" id="dont_count_slow_torrents_checkbox" onclick="qBittorrent.Preferences.updateSlowTorrentsSettings();" />
-                <label for="dont_count_slow_torrents_checkbox">QBT_TR(Do not count slow torrents in these limits)QBT_TR[CONTEXT=OptionsDialog]</label>
+                <label for="dont_count_slow_torrents_checkbox" class="qbt-translatable" data-i18n="Do not count slow torrents in these limits">Do not count slow torrents in these limits</label>
             </legend>
             <table>
                 <tr>
                     <td>
-                        <label for="dl_rate_threshold">QBT_TR(Download rate threshold:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                        <label for="dl_rate_threshold" class="qbt-translatable" data-i18n="Download rate threshold:">Download rate threshold:</label>
                     </td>
                     <td>
                         <input type="text" id="dl_rate_threshold" style="width: 4em;" />&nbsp;&nbsp;QBT_TR(KiB/s)QBT_TR[CONTEXT=OptionsDialog]
@@ -653,7 +653,7 @@
                 </tr>
                 <tr>
                     <td>
-                        <label for="ul_rate_threshold">QBT_TR(Upload rate threshold:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                        <label for="ul_rate_threshold" class="qbt-translatable" data-i18n="Upload rate threshold:">Upload rate threshold:</label>
                     </td>
                     <td>
                         <input type="text" id="ul_rate_threshold" style="width: 4em;" />&nbsp;&nbsp;QBT_TR(KiB/s)QBT_TR[CONTEXT=OptionsDialog]
@@ -661,7 +661,7 @@
                 </tr>
                 <tr>
                     <td>
-                        <label for="torrent_inactive_timer">QBT_TR(Torrent inactivity timer:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                        <label for="torrent_inactive_timer" class="qbt-translatable" data-i18n="Torrent inactivity timer:">Torrent inactivity timer:</label>
                     </td>
                     <td>
                         <input type="text" id="torrent_inactive_timer" style="width: 4em;" />&nbsp;&nbsp;QBT_TR(seconds)QBT_TR[CONTEXT=OptionsDialog]
@@ -672,12 +672,12 @@
     </fieldset>
 
     <fieldset class="settings">
-        <legend>QBT_TR(Seeding Limits)QBT_TR[CONTEXT=OptionsDialog]</legend>
+        <legend class="qbt-translatable" data-i18n="Seeding Limits">Seeding Limits</legend>
         <table>
             <tr>
                 <td>
                     <input type="checkbox" id="max_ratio_checkbox" onclick="qBittorrent.Preferences.updateMaxRatioTimeEnabled();" />
-                    <label for="max_ratio_checkbox">QBT_TR(When ratio reaches)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="max_ratio_checkbox" class="qbt-translatable" data-i18n="When ratio reaches">When ratio reaches</label>
                 </td>
                 <td>
                     <input type="text" id="max_ratio_value" style="width: 4em;" />
@@ -686,29 +686,29 @@
             <tr>
                 <td>
                     <input type="checkbox" id="max_seeding_time_checkbox" onclick="qBittorrent.Preferences.updateMaxRatioTimeEnabled();" />
-                    <label for="max_seeding_time_checkbox">QBT_TR(When total seeding time reaches)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="max_seeding_time_checkbox" class="qbt-translatable" data-i18n="When total seeding time reaches">When total seeding time reaches</label>
                 </td>
                 <td>
-                    <input type="text" id="max_seeding_time_value" style="width: 4em;" />QBT_TR(minutes)QBT_TR[CONTEXT=OptionsDialog]
+                    <input type="text" id="max_seeding_time_value" style="width: 4em;" / class="qbt-translatable" data-i18n="minutes">minutes
                 </td>
             </tr>
             <tr>
                 <td>
                     <input type="checkbox" id="max_inactive_seeding_time_checkbox" onclick="qBittorrent.Preferences.updateMaxRatioTimeEnabled();" />
-                    <label for="max_inactive_seeding_time_checkbox">QBT_TR(When inactive seeding time reaches)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="max_inactive_seeding_time_checkbox" class="qbt-translatable" data-i18n="When inactive seeding time reaches">When inactive seeding time reaches</label>
                 </td>
                 <td>
-                    <input type="text" id="max_inactive_seeding_time_value" style="width: 4em;" />QBT_TR(minutes)QBT_TR[CONTEXT=OptionsDialog]
+                    <input type="text" id="max_inactive_seeding_time_value" style="width: 4em;" / class="qbt-translatable" data-i18n="minutes">minutes
                 </td>
             </tr>
             <tr>
-                <td style="text-align: right;"><label for="max_ratio_act">QBT_TR(then)QBT_TR[CONTEXT=OptionsDialog]</label></td>
+                <td style="text-align: right;"><label for="max_ratio_act" class="qbt-translatable" data-i18n="then">then</label></td>
                 <td>
                     <select id="max_ratio_act">
-                        <option value="0">QBT_TR(Pause torrent)QBT_TR[CONTEXT=OptionsDialog]</option>
-                        <option value="1">QBT_TR(Remove torrent)QBT_TR[CONTEXT=OptionsDialog]</option>
-                        <option value="3">QBT_TR(Remove torrent and its files)QBT_TR[CONTEXT=OptionsDialog]</option>
-                        <option value="2">QBT_TR(Enable super seeding for torrent)QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="0" class="qbt-translatable" data-i18n="Pause torrent">Pause torrent</option>
+                        <option value="1" class="qbt-translatable" data-i18n="Remove torrent">Remove torrent</option>
+                        <option value="3" class="qbt-translatable" data-i18n="Remove torrent and its files">Remove torrent and its files</option>
+                        <option value="2" class="qbt-translatable" data-i18n="Enable super seeding for torrent">Enable super seeding for torrent</option>
                     </select>
                 </td>
             </tr>
@@ -718,7 +718,7 @@
     <fieldset class="settings">
         <legend>
             <input type="checkbox" id="add_trackers_checkbox" onclick="qBittorrent.Preferences.updateAddTrackersEnabled();" />
-            <label for="add_trackers_checkbox">QBT_TR(Automatically add these trackers to new downloads:)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="add_trackers_checkbox" class="qbt-translatable" data-i18n="Automatically add these trackers to new downloads:">Automatically add these trackers to new downloads:</label>
         </legend>
         <textarea id="add_trackers_textarea" rows="5" cols="70"></textarea>
     </fieldset>
@@ -726,15 +726,15 @@
 
 <div id="RSSTab" class="PrefTab invisible">
     <fieldset class="settings">
-        <legend>QBT_TR(RSS Reader)QBT_TR[CONTEXT=OptionsDialog]</legend>
+        <legend class="qbt-translatable" data-i18n="RSS Reader">RSS Reader</legend>
         <div class="formRow">
             <input type="checkbox" id="enable_fetching_rss_feeds_checkbox" />
-            <label for="enable_fetching_rss_feeds_checkbox">QBT_TR(Enable fetching RSS feeds)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="enable_fetching_rss_feeds_checkbox" class="qbt-translatable" data-i18n="Enable fetching RSS feeds">Enable fetching RSS feeds</label>
         </div>
         <table>
             <tr>
                 <td>
-                    <label for="feed_refresh_interval">QBT_TR(Feeds refresh interval:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="feed_refresh_interval" class="qbt-translatable" data-i18n="Feeds refresh interval:">Feeds refresh interval:</label>
                 </td>
                 <td>
                     <input type="text" id="feed_refresh_interval" style="width: 4em;" />&nbsp;&nbsp;QBT_TR( min)QBT_TR[CONTEXT=OptionsDialog]
@@ -742,7 +742,7 @@
             </tr>
             <tr>
                 <td>
-                    <label for="feedFetchDelay">QBT_TR(Same host request delay:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="feedFetchDelay" class="qbt-translatable" data-i18n="Same host request delay:">Same host request delay:</label>
                 </td>
                 <td>
                     <input type="text" id="feedFetchDelay" style="width: 4em;" />&nbsp;&nbsp;QBT_TR( sec)QBT_TR[CONTEXT=OptionsDialog]
@@ -750,7 +750,7 @@
             </tr>
             <tr>
                 <td>
-                    <label for="maximum_article_number">QBT_TR(Maximum number of articles per feed:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="maximum_article_number" class="qbt-translatable" data-i18n="Maximum number of articles per feed:">Maximum number of articles per feed:</label>
                 </td>
                 <td>
                     <input type="text" id="maximum_article_number" style="width: 4em;" />
@@ -760,54 +760,54 @@
     </fieldset>
 
     <fieldset class="settings">
-        <legend>QBT_TR(RSS Torrent Auto Downloader)QBT_TR[CONTEXT=OptionsDialog]</legend>
+        <legend class="qbt-translatable" data-i18n="RSS Torrent Auto Downloader">RSS Torrent Auto Downloader</legend>
         <div class="formRow">
             <input type="checkbox" id="enable_auto_downloading_rss_torrents_checkbox" />
-            <label for="enable_auto_downloading_rss_torrents_checkbox">QBT_TR(Enable auto downloading of RSS torrents)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="enable_auto_downloading_rss_torrents_checkbox" class="qbt-translatable" data-i18n="Enable auto downloading of RSS torrents">Enable auto downloading of RSS torrents</label>
         </div>
-        <button type="button" style="margin: 0 1em; width: calc(100% - 2.2em)" onclick="window.qBittorrent.Rss.openRssDownloader();">QBT_TR(Edit auto downloading rules...)QBT_TR[CONTEXT=OptionsDialog]</button>
+        <button type="button" style="margin: 0 1em; width: calc(100% - 2.2em)" onclick="window.qBittorrent.Rss.openRssDownloader();" class="qbt-translatable" data-i18n="Edit auto downloading rules...">Edit auto downloading rules...</button>
     </fieldset>
 
     <fieldset class="settings">
-        <legend>QBT_TR(RSS Smart Episode Filter)QBT_TR[CONTEXT=OptionsDialog]</legend>
+        <legend class="qbt-translatable" data-i18n="RSS Smart Episode Filter">RSS Smart Episode Filter</legend>
         <div class="formRow">
             <input type="checkbox" id="downlock_repack_proper_episodes" />
 
-            <label for="downlock_repack_proper_episodes">QBT_TR(Download REPACK/PROPER episodes)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="downlock_repack_proper_episodes" class="qbt-translatable" data-i18n="Download REPACK/PROPER episodes">Download REPACK/PROPER episodes</label>
         </div>
-        <label for="rss_filter_textarea">QBT_TR(Filters:)QBT_TR[CONTEXT=OptionsDialog]</label><br>
+        <label for="rss_filter_textarea" class="qbt-translatable" data-i18n="Filters:">Filters:</label><br>
         <textarea id="rss_filter_textarea" rows="6" cols="70"></textarea>
     </fieldset>
 </div>
 
 <div id="WebUITab" class="PrefTab invisible">
     <fieldset class="settings">
-        <legend>QBT_TR(Web User Interface (Remote control))QBT_TR[CONTEXT=OptionsDialog]</legend>
+        <legend class="qbt-translatable" data-i18n="Web User Interface (Remote control)">Web User Interface (Remote control)</legend>
         <table>
             <tr>
                 <td>
-                    <label for="webui_address_value">QBT_TR(IP address:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="webui_address_value" class="qbt-translatable" data-i18n="IP address:">IP address:</label>
                 </td>
                 <td>
                     <input type="text" id="webui_address_value" />
-                    <label for="webui_port_value" style="margin-left: 10px;">QBT_TR(Port:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="webui_port_value" style="margin-left: 10px;" class="qbt-translatable" data-i18n="Port:">Port:</label>
                     <input type="text" id="webui_port_value" style="width: 4em;" />
                 </td>
             </tr>
         </table>
         <div class="formRow">
             <input type="checkbox" id="webui_upnp_checkbox" />
-            <label for="webui_upnp_checkbox">QBT_TR(Use UPnP / NAT-PMP to forward the port from my router)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="webui_upnp_checkbox" class="qbt-translatable" data-i18n="Use UPnP / NAT-PMP to forward the port from my router">Use UPnP / NAT-PMP to forward the port from my router</label>
         </div>
         <fieldset class="settings">
             <legend>
                 <input type="checkbox" id="use_https_checkbox" onclick="qBittorrent.Preferences.updateHttpsSettings();" />
-                <label for="use_https_checkbox">QBT_TR(Use HTTPS instead of HTTP)QBT_TR[CONTEXT=OptionsDialog]</label>
+                <label for="use_https_checkbox" class="qbt-translatable" data-i18n="Use HTTPS instead of HTTP">Use HTTPS instead of HTTP</label>
             </legend>
             <table>
                 <tr>
                     <td>
-                        <label for="ssl_cert_text">QBT_TR(Certificate:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                        <label for="ssl_cert_text" class="qbt-translatable" data-i18n="Certificate:">Certificate:</label>
                     </td>
                     <td>
                         <input type="text" id="ssl_cert_text" style="width: 30em;" />
@@ -815,22 +815,22 @@
                 </tr>
                 <tr>
                     <td>
-                        <label for="ssl_key_text">QBT_TR(Key:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                        <label for="ssl_key_text" class="qbt-translatable" data-i18n="Key:">Key:</label>
                     </td>
                     <td>
                         <input type="text" id="ssl_key_text" style="width: 30em;" />
                     </td>
                 </tr>
             </table>
-            <div style="padding-left: 10px;"><a target="_blank" href="https://httpd.apache.org/docs/current/ssl/ssl_faq.html#aboutcerts">QBT_TR(Information about certificates)QBT_TR[CONTEXT=HttpServer]</a></div>
+            <div style="padding-left: 10px;"><a target="_blank" href="https://httpd.apache.org/docs/current/ssl/ssl_faq.html#aboutcerts" class="qbt-translatable" data-i18n="Information about certificates">Information about certificates</a></div>
         </fieldset>
 
         <fieldset class="settings">
-            <legend>QBT_TR(Authentication)QBT_TR[CONTEXT=OptionsDialog]</legend>
+            <legend class="qbt-translatable" data-i18n="Authentication">Authentication</legend>
             <table>
                 <tr>
                     <td>
-                        <label for="webui_username_text">QBT_TR(Username:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                        <label for="webui_username_text" class="qbt-translatable" data-i18n="Username:">Username:</label>
                     </td>
                     <td>
                         <input type="text" id="webui_username_text" />
@@ -838,7 +838,7 @@
                 </tr>
                 <tr>
                     <td>
-                        <label for="webui_password_text">QBT_TR(Password:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                        <label for="webui_password_text" class="qbt-translatable" data-i18n="Password:">Password:</label>
                     </td>
                     <td>
                         <input type="password" id="webui_password_text" placeholder="QBT_TR(Change current password)QBT_TR[CONTEXT=OptionsDialog]" autocomplete="new-password" />
@@ -847,28 +847,28 @@
             </table>
             <div class="formRow">
                 <input type="checkbox" id="bypass_local_auth_checkbox" />
-                <label for="bypass_local_auth_checkbox">QBT_TR(Bypass authentication for clients on localhost)QBT_TR[CONTEXT=OptionsDialog]</label>
+                <label for="bypass_local_auth_checkbox" class="qbt-translatable" data-i18n="Bypass authentication for clients on localhost">Bypass authentication for clients on localhost</label>
             </div>
             <div class="formRow">
                 <input type="checkbox" id="bypass_auth_subnet_whitelist_checkbox" onclick="qBittorrent.Preferences.updateBypasssAuthSettings();" />
-                <label for="bypass_auth_subnet_whitelist_checkbox">QBT_TR(Bypass authentication for clients in whitelisted IP subnets)QBT_TR[CONTEXT=OptionsDialog]</label>
+                <label for="bypass_auth_subnet_whitelist_checkbox" class="qbt-translatable" data-i18n="Bypass authentication for clients in whitelisted IP subnets">Bypass authentication for clients in whitelisted IP subnets</label>
             </div>
             <div class="formRow" style="padding-left: 30px; padding-top: 5px;">
                 <textarea id="bypass_auth_subnet_whitelist_textarea" rows="5" cols="48" placeholder="QBT_TR(Example: 172.17.32.0/24, fdff:ffff:c8::/40)QBT_TR[CONTEXT=OptionsDialog]"></textarea>
             </div>
             <table>
                 <tr>
-                    <td><label for="webUIMaxAuthFailCountInput">QBT_TR(Ban client after consecutive failures:)QBT_TR[CONTEXT=OptionsDialog]</label></td>
+                    <td><label for="webUIMaxAuthFailCountInput" class="qbt-translatable" data-i18n="Ban client after consecutive failures:">Ban client after consecutive failures:</label></td>
                     <td><input type="number" id="webUIMaxAuthFailCountInput" style="width: 4em;" min="0" /></td>
                 </tr>
                 <tr>
-                    <td style="text-align: right;"><label for="webUIBanDurationInput">QBT_TR(ban for:)QBT_TR[CONTEXT=OptionsDialog]</label></td>
-                    <td><input type="number" id="webUIBanDurationInput" style="width: 4em;" min="1" />QBT_TR(seconds)QBT_TR[CONTEXT=OptionsDialog]</td>
+                    <td style="text-align: right;"><label for="webUIBanDurationInput" class="qbt-translatable" data-i18n="ban for:">ban for:</label></td>
+                    <td><input type="number" id="webUIBanDurationInput" style="width: 4em;" min="1" / class="qbt-translatable" data-i18n="seconds">seconds</td>
                 </tr>
             </table>
             <table>
                 <tr>
-                    <td><label for="webUISessionTimeoutInput">QBT_TR(Session timeout:)QBT_TR[CONTEXT=OptionsDialog]</label></td>
+                    <td><label for="webUISessionTimeoutInput" class="qbt-translatable" data-i18n="Session timeout:">Session timeout:</label></td>
                     <td><input type="number" id="webUISessionTimeoutInput" style="width: 4em;" min="0" />&nbsp;&nbsp;QBT_TR(seconds)QBT_TR[CONTEXT=OptionsDialog]</td>
                 </tr>
             </table>
@@ -876,38 +876,38 @@
 
         <fieldset class="settings">
             <legend><input type="checkbox" id="use_alt_webui_checkbox" onclick="qBittorrent.Preferences.updateAlternativeWebUISettings();" />
-                <label for="use_alt_webui_checkbox">QBT_TR(Use alternative WebUI)QBT_TR[CONTEXT=OptionsDialog]</label>
+                <label for="use_alt_webui_checkbox" class="qbt-translatable" data-i18n="Use alternative WebUI">Use alternative WebUI</label>
             </legend>
             <div class="formRow">
-                <label for="webui_files_location_textarea">QBT_TR(Files location:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                <label for="webui_files_location_textarea" class="qbt-translatable" data-i18n="Files location:">Files location:</label>
                 <input type="text" id="webui_files_location_textarea" />
             </div>
         </fieldset>
 
         <fieldset class="settings">
-            <legend>QBT_TR(Security)QBT_TR[CONTEXT=OptionsDialog]</legend>
+            <legend class="qbt-translatable" data-i18n="Security">Security</legend>
             <div class="formRow">
                 <input type="checkbox" id="clickjacking_protection_checkbox" />
-                <label for="clickjacking_protection_checkbox">QBT_TR(Enable clickjacking protection)QBT_TR[CONTEXT=OptionsDialog]</label>
+                <label for="clickjacking_protection_checkbox" class="qbt-translatable" data-i18n="Enable clickjacking protection">Enable clickjacking protection</label>
             </div>
             <div class="formRow">
                 <input type="checkbox" id="csrf_protection_checkbox" />
-                <label for="csrf_protection_checkbox">QBT_TR(Enable Cross-Site Request Forgery (CSRF) protection)QBT_TR[CONTEXT=OptionsDialog]</label>
+                <label for="csrf_protection_checkbox" class="qbt-translatable" data-i18n="Enable Cross-Site Request Forgery (CSRF) protection">Enable Cross-Site Request Forgery (CSRF) protection</label>
             </div>
             <div class="formRow">
                 <input type="checkbox" id="secureCookieCheckbox" />
-                <label for="secureCookieCheckbox">QBT_TR(Enable cookie Secure flag (requires HTTPS))QBT_TR[CONTEXT=OptionsDialog]</label>
+                <label for="secureCookieCheckbox" class="qbt-translatable" data-i18n="Enable cookie Secure flag (requires HTTPS)">Enable cookie Secure flag (requires HTTPS)</label>
             </div>
 
             <fieldset class="settings">
                 <legend>
                     <input type="checkbox" id="host_header_validation_checkbox" onclick="qBittorrent.Preferences.updateHostHeaderValidationSettings();" />
-                    <label for="host_header_validation_checkbox">QBT_TR(Enable Host header validation)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="host_header_validation_checkbox" class="qbt-translatable" data-i18n="Enable Host header validation">Enable Host header validation</label>
                 </legend>
                 <table>
                     <tr>
                         <td>
-                            <label for="webui_domain_textarea">QBT_TR(Server domains:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                            <label for="webui_domain_textarea" class="qbt-translatable" data-i18n="Server domains:">Server domains:</label>
                         </td>
                         <td>
                             <textarea id="webui_domain_textarea" rows="1" cols="60" title="QBT_TR(Whitelist for filtering HTTP Host header values.
@@ -924,7 +924,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
         <fieldset class="settings">
             <legend>
                 <input type="checkbox" id="webUIUseCustomHTTPHeadersCheckbox" onclick="qBittorrent.Preferences.updateWebUICustomHTTPHeadersSettings();" />
-                <label for="webUIUseCustomHTTPHeadersCheckbox">QBT_TR(Add custom HTTP headers)QBT_TR[CONTEXT=OptionsDialog]</label>
+                <label for="webUIUseCustomHTTPHeadersCheckbox" class="qbt-translatable" data-i18n="Add custom HTTP headers">Add custom HTTP headers</label>
             </legend>
             <textarea id="webUICustomHTTPHeadersTextarea" placeholder="QBT_TR(Header: value pairs, one per line)QBT_TR[CONTEXT=OptionsDialog]" style="width: 90%;"></textarea>
         </fieldset>
@@ -932,10 +932,10 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
         <fieldset class="settings">
             <legend>
                 <input type="checkbox" id="webUIReverseProxySupportCheckbox" onclick="qBittorrent.Preferences.updateWebUIReverseProxySettings();" />
-                <label for="webUIReverseProxySupportCheckbox">QBT_TR(Enable reverse proxy support)QBT_TR[CONTEXT=OptionsDialog]</label>
+                <label for="webUIReverseProxySupportCheckbox" class="qbt-translatable" data-i18n="Enable reverse proxy support">Enable reverse proxy support</label>
             </legend>
             <div class="formRow">
-                <label for="webUIReverseProxiesListTextarea">QBT_TR(Trusted proxies list:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                <label for="webUIReverseProxiesListTextarea" class="qbt-translatable" data-i18n="Trusted proxies list:">Trusted proxies list:</label>
                 <input type="text" id="webUIReverseProxiesListTextarea" title="QBT_TR(Specify reverse proxy IPs (or subnets, e.g. 0.0.0.0/24) in order to use forwarded client address (X-Forwarded-For header). Use ';' to split multiple entries.)QBT_TR[CONTEXT=OptionsDialog]" />
             </div>
         </fieldset>
@@ -945,7 +945,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
     <fieldset class="settings">
         <legend>
             <input type="checkbox" id="use_dyndns_checkbox" onclick="qBittorrent.Preferences.updateDynDnsSettings();" />
-            <label for="use_dyndns_checkbox">QBT_TR(Update my dynamic domain name)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="use_dyndns_checkbox" class="qbt-translatable" data-i18n="Update my dynamic domain name">Update my dynamic domain name</label>
         </legend>
         <select id="dyndns_select">
             <option value="0">DynDNS</option>
@@ -955,7 +955,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
         <table style="margin-top: 10px;">
             <tr>
                 <td>
-                    <label for="dyndns_domain_text">QBT_TR(Domain name:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="dyndns_domain_text" class="qbt-translatable" data-i18n="Domain name:">Domain name:</label>
                 </td>
                 <td>
                     <input type="text" id="dyndns_domain_text" />
@@ -963,7 +963,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="dyndns_username_text">QBT_TR(Username:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="dyndns_username_text" class="qbt-translatable" data-i18n="Username:">Username:</label>
                 </td>
                 <td>
                     <input type="text" id="dyndns_username_text" />
@@ -971,7 +971,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="dyndns_password_text">QBT_TR(Password:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="dyndns_password_text" class="qbt-translatable" data-i18n="Password:">Password:</label>
                 </td>
                 <td>
                     <input type="password" id="dyndns_password_text" />
@@ -983,22 +983,22 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
 
 <div id="AdvancedTab" class="PrefTab invisible">
     <fieldset class="settings">
-        <legend>QBT_TR(qBittorrent Section)QBT_TR[CONTEXT=OptionsDialog]&nbsp;(<a href="https://github.com/qbittorrent/qBittorrent/wiki/Explanation-of-Options-in-qBittorrent#Advanced" target="_blank">QBT_TR(Open documentation)QBT_TR[CONTEXT=HttpServer]</a>)</legend>
+        <legend class="qbt-translatable" data-i18n="qBittorrent Section">qBittorrent Section&nbsp;(<a href="https://github.com/qbittorrent/qBittorrent/wiki/Explanation-of-Options-in-qBittorrent#Advanced" target="_blank" class="qbt-translatable" data-i18n="Open documentation">Open documentation</a>)</legend>
         <table>
             <tr>
                 <td>
-                    <label for="resumeDataStorageType">QBT_TR(Resume data storage type (requires restart):)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="resumeDataStorageType" class="qbt-translatable" data-i18n="Resume data storage type (requires restart):">Resume data storage type (requires restart):</label>
                 </td>
                 <td>
                     <select id="resumeDataStorageType" style="width: 15em;">
-                        <option value="Legacy">QBT_TR(Fastresume files)QBT_TR[CONTEXT=OptionsDialog]</option>
-                        <option value="SQLite">QBT_TR(SQLite database (experimental))QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="Legacy" class="qbt-translatable" data-i18n="Fastresume files">Fastresume files</option>
+                        <option value="SQLite" class="qbt-translatable" data-i18n="SQLite database (experimental)">SQLite database (experimental)</option>
                     </select>
                 </td>
             </tr>
             <tr id="rowMemoryWorkingSetLimit">
                 <td>
-                    <label for="memoryWorkingSetLimit">QBT_TR(Physical memory (RAM) usage limit:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://wikipedia.org/wiki/Working_set" target="_blank">(?)</a></label>
+                    <label for="memoryWorkingSetLimit" class="qbt-translatable" data-i18n="Physical memory (RAM) usage limit:">Physical memory (RAM) usage limit:&nbsp;<a href="https://wikipedia.org/wiki/Working_set" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="memoryWorkingSetLimit" style="width: 15em;" title="QBT_TR(This option is less effective on Linux)QBT_TR[CONTEXT=OptionsDialog]">&nbsp;&nbsp;QBT_TR(MiB)QBT_TR[CONTEXT=OptionsDialog]
@@ -1006,7 +1006,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="networkInterface">QBT_TR(Network interface:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="networkInterface" class="qbt-translatable" data-i18n="Network interface:">Network interface:</label>
                 </td>
                 <td>
                     <select id="networkInterface" style="width: 15em;">
@@ -1015,7 +1015,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="optionalIPAddressToBind">QBT_TR(Optional IP address to bind to:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="optionalIPAddressToBind" class="qbt-translatable" data-i18n="Optional IP address to bind to:">Optional IP address to bind to:</label>
                 </td>
                 <td>
                     <select id="optionalIPAddressToBind" style="width: 15em;">
@@ -1024,7 +1024,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="saveResumeDataInterval">QBT_TR(Save resume data interval:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="saveResumeDataInterval" class="qbt-translatable" data-i18n="Save resume data interval:">Save resume data interval:</label>
                 </td>
                 <td>
                     <input type="text" id="saveResumeDataInterval" style="width: 15em;">&nbsp;&nbsp;QBT_TR(min)QBT_TR[CONTEXT=OptionsDialog]
@@ -1032,7 +1032,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="torrentFileSizeLimit">QBT_TR(.torrent file size limit:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="torrentFileSizeLimit" class="qbt-translatable" data-i18n=".torrent file size limit:">.torrent file size limit:</label>
                 </td>
                 <td>
                     <input type="text" id="torrentFileSizeLimit" style="width: 15em;">&nbsp;&nbsp;QBT_TR(MiB)QBT_TR[CONTEXT=OptionsDialog]
@@ -1040,7 +1040,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="recheckTorrentsOnCompletion">QBT_TR(Recheck torrents on completion:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="recheckTorrentsOnCompletion" class="qbt-translatable" data-i18n="Recheck torrents on completion:">Recheck torrents on completion:</label>
                 </td>
                 <td>
                     <input type="checkbox" id="recheckTorrentsOnCompletion">
@@ -1048,7 +1048,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="appInstanceName">QBT_TR(Customize application instance name:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="appInstanceName" class="qbt-translatable" data-i18n="Customize application instance name:">Customize application instance name:</label>
                 </td>
                 <td>
                     <input type="text" id="appInstanceName" style="width: 15em;" title="QBT_TR(It appends the text to the window title to help distinguish qBittorent instances)QBT_TR[CONTEXT=OptionsDialog]" />
@@ -1056,7 +1056,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="refreshInterval">QBT_TR(Refresh interval:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="refreshInterval" class="qbt-translatable" data-i18n="Refresh interval:">Refresh interval:</label>
                 </td>
                 <td>
                     <input type="text" id="refreshInterval" style="width: 15em;" title="QBT_TR(It controls the internal state update interval which in turn will affect UI updates)QBT_TR[CONTEXT=OptionsDialog]">&nbsp;&nbsp;QBT_TR(ms)QBT_TR[CONTEXT=OptionsDialog]
@@ -1064,7 +1064,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="resolvePeerCountries">QBT_TR(Resolve peer countries:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="resolvePeerCountries" class="qbt-translatable" data-i18n="Resolve peer countries:">Resolve peer countries:</label>
                 </td>
                 <td>
                     <input type="checkbox" id="resolvePeerCountries">
@@ -1072,7 +1072,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="reannounceWhenAddressChanged">QBT_TR(Reannounce to all trackers when IP or port changed:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="reannounceWhenAddressChanged" class="qbt-translatable" data-i18n="Reannounce to all trackers when IP or port changed:">Reannounce to all trackers when IP or port changed:</label>
                 </td>
                 <td>
                     <input type="checkbox" id="reannounceWhenAddressChanged" />
@@ -1080,7 +1080,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="enableEmbeddedTracker">QBT_TR(Enable embedded tracker:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="enableEmbeddedTracker" class="qbt-translatable" data-i18n="Enable embedded tracker:">Enable embedded tracker:</label>
                 </td>
                 <td>
                     <input type="checkbox" id="enableEmbeddedTracker" />
@@ -1088,7 +1088,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="embeddedTrackerPort">QBT_TR(Embedded tracker port:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="embeddedTrackerPort" class="qbt-translatable" data-i18n="Embedded tracker port:">Embedded tracker port:</label>
                 </td>
                 <td>
                     <input type="text" id="embeddedTrackerPort" style="width: 15em;" />
@@ -1096,7 +1096,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="embeddedTrackerPortForwarding">QBT_TR(Enable port forwarding for embedded tracker:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="embeddedTrackerPortForwarding" class="qbt-translatable" data-i18n="Enable port forwarding for embedded tracker:">Enable port forwarding for embedded tracker:</label>
                 </td>
                 <td>
                     <input type="checkbox" id="embeddedTrackerPortForwarding" />
@@ -1104,7 +1104,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr id="rowMarkOfTheWeb">
                 <td>
-                    <label for="markOfTheWeb">QBT_TR(Enable Mark-of-the-Web (MOTW) for downloaded files (require macOS or Windows):)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="markOfTheWeb" class="qbt-translatable" data-i18n="Enable Mark-of-the-Web (MOTW) for downloaded files (require macOS or Windows):">Enable Mark-of-the-Web (MOTW) for downloaded files (require macOS or Windows):</label>
                 </td>
                 <td>
                     <input type="checkbox" id="markOfTheWeb" />
@@ -1112,7 +1112,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="pythonExecutablePath">QBT_TR(Python executable path (may require restart):)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    <label for="pythonExecutablePath" class="qbt-translatable" data-i18n="Python executable path (may require restart):">Python executable path (may require restart):</label>
                 </td>
                 <td>
                     <input type="text" id="pythonExecutablePath" placeholder="QBT_TR((Auto detect if empty))QBT_TR[CONTEXT=OptionsDialog]" style="width: 15em;" />
@@ -1121,11 +1121,11 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
         </table>
     </fieldset>
     <fieldset class="settings">
-        <legend>QBT_TR(libtorrent Section)QBT_TR[CONTEXT=OptionsDialog]&nbsp;(<a href="https://www.libtorrent.org/reference-Settings.html" target="_blank">QBT_TR(Open documentation)QBT_TR[CONTEXT=HttpServer]</a>)</legend>
+        <legend class="qbt-translatable" data-i18n="libtorrent Section">libtorrent Section&nbsp;(<a href="https://www.libtorrent.org/reference-Settings.html" target="_blank" class="qbt-translatable" data-i18n="Open documentation">Open documentation</a>)</legend>
         <table>
             <tr>
                 <td>
-                    <label for="bdecodeDepthLimit">QBT_TR(Bdecode depth limit:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Bdecoding.html#bdecode()" target="_blank">(?)</a></label>
+                    <label for="bdecodeDepthLimit" class="qbt-translatable" data-i18n="Bdecode depth limit:">Bdecode depth limit:&nbsp;<a href="https://www.libtorrent.org/reference-Bdecoding.html#bdecode()" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="bdecodeDepthLimit" style="width: 15em;" />
@@ -1133,7 +1133,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="bdecodeTokenLimit">QBT_TR(Bdecode token limit:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Bdecoding.html#bdecode()" target="_blank">(?)</a></label>
+                    <label for="bdecodeTokenLimit" class="qbt-translatable" data-i18n="Bdecode token limit:">Bdecode token limit:&nbsp;<a href="https://www.libtorrent.org/reference-Bdecoding.html#bdecode()" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="bdecodeTokenLimit" style="width: 15em;" />
@@ -1141,7 +1141,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="asyncIOThreads">QBT_TR(Asynchronous I/O threads:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#aio_threads" target="_blank">(?)</a></label>
+                    <label for="asyncIOThreads" class="qbt-translatable" data-i18n="Asynchronous I/O threads:">Asynchronous I/O threads:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#aio_threads" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="asyncIOThreads" style="width: 15em;" />
@@ -1149,7 +1149,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr id="rowHashingThreads">
                 <td>
-                    <label for="hashingThreads">QBT_TR(Hashing threads:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#hashing_threads" target="_blank">(?)</a></label>
+                    <label for="hashingThreads" class="qbt-translatable" data-i18n="Hashing threads:">Hashing threads:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#hashing_threads" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="hashingThreads" style="width: 15em;" />
@@ -1157,7 +1157,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="filePoolSize">QBT_TR(File pool size:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#file_pool_size" target="_blank">(?)</a></label>
+                    <label for="filePoolSize" class="qbt-translatable" data-i18n="File pool size:">File pool size:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#file_pool_size" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="filePoolSize" style="width: 15em;" />
@@ -1165,7 +1165,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="outstandMemoryWhenCheckingTorrents">QBT_TR(Outstanding memory when checking torrents:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#checking_mem_usage" target="_blank">(?)</a></label>
+                    <label for="outstandMemoryWhenCheckingTorrents" class="qbt-translatable" data-i18n="Outstanding memory when checking torrents:">Outstanding memory when checking torrents:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#checking_mem_usage" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="outstandMemoryWhenCheckingTorrents" style="width: 15em;" />&nbsp;&nbsp;QBT_TR(MiB)QBT_TR[CONTEXT=OptionsDialog]
@@ -1173,7 +1173,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr id="rowDiskCache">
                 <td>
-                    <label for="diskCache">QBT_TR(Disk cache:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#cache_size" target="_blank">(?)</a></label>
+                    <label for="diskCache" class="qbt-translatable" data-i18n="Disk cache:">Disk cache:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#cache_size" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="diskCache" style="width: 15em;" />&nbsp;&nbsp;QBT_TR(MiB)QBT_TR[CONTEXT=OptionsDialog]
@@ -1181,7 +1181,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr id="rowDiskCacheExpiryInterval">
                 <td>
-                    <label for="diskCacheExpiryInterval">QBT_TR(Disk cache expiry interval:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#cache_expiry" target="_blank">(?)</a></label>
+                    <label for="diskCacheExpiryInterval" class="qbt-translatable" data-i18n="Disk cache expiry interval:">Disk cache expiry interval:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#cache_expiry" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="diskCacheExpiryInterval" style="width: 15em;">&nbsp;&nbsp;QBT_TR(s)QBT_TR[CONTEXT=OptionsDialog]
@@ -1189,7 +1189,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="diskQueueSize">QBT_TR(Disk queue size:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#max_queued_disk_bytes" target="_blank">(?)</a></label>
+                    <label for="diskQueueSize" class="qbt-translatable" data-i18n="Disk queue size:">Disk queue size:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#max_queued_disk_bytes" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="diskQueueSize" style="width: 15em;">&nbsp;&nbsp;QBT_TR(KiB)QBT_TR[CONTEXT=OptionsDialog]
@@ -1197,42 +1197,42 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr id="rowDiskIOType">
                 <td>
-                    <label for="diskIOType">QBT_TR(Disk IO type (requires restart):)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/single-page-ref.html#default-disk-io-constructor" target="_blank">(?)</a></label>
+                    <label for="diskIOType" class="qbt-translatable" data-i18n="Disk IO type (requires restart):">Disk IO type (requires restart):&nbsp;<a href="https://www.libtorrent.org/single-page-ref.html#default-disk-io-constructor" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <select id="diskIOType" style="width: 15em;">
-                        <option value="0">QBT_TR(Default)QBT_TR[CONTEXT=OptionsDialog]</option>
-                        <option value="1">QBT_TR(Memory mapped files)QBT_TR[CONTEXT=OptionsDialog]</option>
-                        <option value="2">QBT_TR(POSIX-compliant)QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="0" class="qbt-translatable" data-i18n="Default">Default</option>
+                        <option value="1" class="qbt-translatable" data-i18n="Memory mapped files">Memory mapped files</option>
+                        <option value="2" class="qbt-translatable" data-i18n="POSIX-compliant">POSIX-compliant</option>
                     </select>
                 </td>
             </tr>
             <tr>
                 <td>
-                    <label for="diskIOReadMode">QBT_TR(Disk IO read mode:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#disk_io_read_mode" target="_blank">(?)</a></label>
+                    <label for="diskIOReadMode" class="qbt-translatable" data-i18n="Disk IO read mode:">Disk IO read mode:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#disk_io_read_mode" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <select id="diskIOReadMode" style="width: 15em;">
-                        <option value="0">QBT_TR(Disable OS cache)QBT_TR[CONTEXT=OptionsDialog]</option>
-                        <option value="1">QBT_TR(Enable OS cache)QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="0" class="qbt-translatable" data-i18n="Disable OS cache">Disable OS cache</option>
+                        <option value="1" class="qbt-translatable" data-i18n="Enable OS cache">Enable OS cache</option>
                     </select>
                 </td>
             </tr>
             <tr>
                 <td>
-                    <label for="diskIOWriteMode">QBT_TR(Disk IO write mode:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#disk_io_write_mode" target="_blank">(?)</a></label>
+                    <label for="diskIOWriteMode" class="qbt-translatable" data-i18n="Disk IO write mode:">Disk IO write mode:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#disk_io_write_mode" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <select id="diskIOWriteMode" style="width: 15em;">
-                        <option value="0">QBT_TR(Disable OS cache)QBT_TR[CONTEXT=OptionsDialog]</option>
-                        <option value="1">QBT_TR(Enable OS cache)QBT_TR[CONTEXT=OptionsDialog]</option>
-                        <option value="2" id="diskIOWriteModeWriteThrough">QBT_TR(Write-through)QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="0" class="qbt-translatable" data-i18n="Disable OS cache">Disable OS cache</option>
+                        <option value="1" class="qbt-translatable" data-i18n="Enable OS cache">Enable OS cache</option>
+                        <option value="2" id="diskIOWriteModeWriteThrough" class="qbt-translatable" data-i18n="Write-through">Write-through</option>
                     </select>
                 </td>
             </tr>
             <tr id="rowCoalesceReadsAndWrites">
                 <td>
-                    <label for="coalesceReadsAndWrites">QBT_TR(Coalesce reads &amp; writes:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#coalesce_reads" target="_blank">(?)</a></label>
+                    <label for="coalesceReadsAndWrites" class="qbt-translatable" data-i18n="Coalesce reads &amp; writes:">Coalesce reads &amp; writes:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#coalesce_reads" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="checkbox" id="coalesceReadsAndWrites" />
@@ -1240,7 +1240,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="pieceExtentAffinity">QBT_TR(Use piece extent affinity:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://libtorrent.org/single-page-ref.html#piece_extent_affinity" target="_blank">(?)</a></label>
+                    <label for="pieceExtentAffinity" class="qbt-translatable" data-i18n="Use piece extent affinity:">Use piece extent affinity:&nbsp;<a href="https://libtorrent.org/single-page-ref.html#piece_extent_affinity" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="checkbox" id="pieceExtentAffinity" />
@@ -1248,7 +1248,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="sendUploadPieceSuggestions">QBT_TR(Send upload piece suggestions:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#suggest_mode" target="_blank">(?)</a></label>
+                    <label for="sendUploadPieceSuggestions" class="qbt-translatable" data-i18n="Send upload piece suggestions:">Send upload piece suggestions:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#suggest_mode" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="checkbox" id="sendUploadPieceSuggestions" />
@@ -1256,7 +1256,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="sendBufferWatermark">QBT_TR(Send buffer watermark:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#send_buffer_watermark" target="_blank">(?)</a></label>
+                    <label for="sendBufferWatermark" class="qbt-translatable" data-i18n="Send buffer watermark:">Send buffer watermark:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#send_buffer_watermark" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="sendBufferWatermark" style="width: 15em;" />&nbsp;&nbsp;QBT_TR(KiB)QBT_TR[CONTEXT=OptionsDialog]
@@ -1264,7 +1264,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="sendBufferLowWatermark">QBT_TR(Send buffer low watermark:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#send_buffer_low_watermark" target="_blank">(?)</a></label>
+                    <label for="sendBufferLowWatermark" class="qbt-translatable" data-i18n="Send buffer low watermark:">Send buffer low watermark:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#send_buffer_low_watermark" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="sendBufferLowWatermark" style="width: 15em;" />&nbsp;&nbsp;QBT_TR(KiB)QBT_TR[CONTEXT=OptionsDialog]
@@ -1272,7 +1272,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="sendBufferWatermarkFactor">QBT_TR(Send buffer watermark factor:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#send_buffer_watermark_factor" target="_blank">(?)</a></label>
+                    <label for="sendBufferWatermarkFactor" class="qbt-translatable" data-i18n="Send buffer watermark factor:">Send buffer watermark factor:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#send_buffer_watermark_factor" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="sendBufferWatermarkFactor" style="width: 15em;" />&nbsp;&nbsp;%
@@ -1280,7 +1280,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="connectionSpeed">QBT_TR(Outgoing connections per second:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#connection_speed" target="_blank">(?)</a></label>
+                    <label for="connectionSpeed" class="qbt-translatable" data-i18n="Outgoing connections per second:">Outgoing connections per second:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#connection_speed" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="connectionSpeed" style="width: 15em;" />
@@ -1288,7 +1288,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="socketSendBufferSize">QBT_TR(Socket send buffer size [0: system default]:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#send_socket_buffer_size" target="_blank">(?)</a></label>
+                    <label for="socketSendBufferSize" class="qbt-translatable" data-i18n="Socket send buffer size [0: system default]:">Socket send buffer size [0: system default]:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#send_socket_buffer_size" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="socketSendBufferSize" style="width: 15em;" />&nbsp;&nbsp;QBT_TR(KiB)QBT_TR[CONTEXT=OptionsDialog]
@@ -1296,7 +1296,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="socketReceiveBufferSize">QBT_TR(Socket receive buffer size [0: system default]:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#recv_socket_buffer_size" target="_blank">(?)</a></label>
+                    <label for="socketReceiveBufferSize" class="qbt-translatable" data-i18n="Socket receive buffer size [0: system default]:">Socket receive buffer size [0: system default]:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#recv_socket_buffer_size" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="socketReceiveBufferSize" style="width: 15em;" />&nbsp;&nbsp;QBT_TR(KiB)QBT_TR[CONTEXT=OptionsDialog]
@@ -1304,7 +1304,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="socketBacklogSize">QBT_TR(Socket backlog size:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#listen_queue_size" target="_blank">(?)</a></label>
+                    <label for="socketBacklogSize" class="qbt-translatable" data-i18n="Socket backlog size:">Socket backlog size:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#listen_queue_size" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="socketBacklogSize" style="width: 15em;" />
@@ -1312,7 +1312,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="outgoingPortsMin">QBT_TR(Outgoing ports (Min) [0: disabled]:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#outgoing_port" target="_blank">(?)</a></label>
+                    <label for="outgoingPortsMin" class="qbt-translatable" data-i18n="Outgoing ports (Min) [0: disabled]:">Outgoing ports (Min) [0: disabled]:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#outgoing_port" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="outgoingPortsMin" style="width: 15em;" />
@@ -1320,7 +1320,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="outgoingPortsMax">QBT_TR(Outgoing ports (Max) [0: disabled]:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#outgoing_port" target="_blank">(?)</a></label>
+                    <label for="outgoingPortsMax" class="qbt-translatable" data-i18n="Outgoing ports (Max) [0: disabled]:">Outgoing ports (Max) [0: disabled]:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#outgoing_port" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="outgoingPortsMax" style="width: 15em;" />
@@ -1328,7 +1328,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="UPnPLeaseDuration">QBT_TR(UPnP lease duration [0: permanent lease]:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#upnp_lease_duration" target="_blank">(?)</a></label>
+                    <label for="UPnPLeaseDuration" class="qbt-translatable" data-i18n="UPnP lease duration [0: permanent lease]:">UPnP lease duration [0: permanent lease]:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#upnp_lease_duration" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="UPnPLeaseDuration" style="width: 15em;" />
@@ -1336,7 +1336,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="peerToS">QBT_TR(Type of service (ToS) for connections to peers)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#peer_tos" target="_blank">(?)</a></label>
+                    <label for="peerToS" class="qbt-translatable" data-i18n="Type of service (ToS) for connections to peers">Type of service (ToS) for connections to peers&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#peer_tos" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="peerToS" style="width: 15em;" />
@@ -1344,18 +1344,18 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="utpTCPMixedModeAlgorithm">QBT_TR(μTP-TCP mixed mode algorithm:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#mixed_mode_algorithm" target="_blank">(?)</a></label>
+                    <label for="utpTCPMixedModeAlgorithm" class="qbt-translatable" data-i18n="μTP-TCP mixed mode algorithm:">μTP-TCP mixed mode algorithm:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#mixed_mode_algorithm" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <select id="utpTCPMixedModeAlgorithm" style="width: 15em;">
-                        <option value="0">QBT_TR(Prefer TCP)QBT_TR[CONTEXT=OptionsDialog]</option>
-                        <option value="1">QBT_TR(Peer proportional (throttles TCP))QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="0" class="qbt-translatable" data-i18n="Prefer TCP">Prefer TCP</option>
+                        <option value="1" class="qbt-translatable" data-i18n="Peer proportional (throttles TCP)">Peer proportional (throttles TCP)</option>
                     </select>
                 </td>
             </tr>
             <tr>
                 <td>
-                    <label for="IDNSupportCheckbox">QBT_TR(Support internationalized domain name (IDN):)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#allow_idna" target="_blank">(?)</a></label>
+                    <label for="IDNSupportCheckbox" class="qbt-translatable" data-i18n="Support internationalized domain name (IDN):">Support internationalized domain name (IDN):&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#allow_idna" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="checkbox" id="IDNSupportCheckbox" />
@@ -1363,7 +1363,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="allowMultipleConnectionsFromTheSameIPAddress">QBT_TR(Allow multiple connections from the same IP address:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#allow_multiple_connections_per_ip" target="_blank">(?)</a></label>
+                    <label for="allowMultipleConnectionsFromTheSameIPAddress" class="qbt-translatable" data-i18n="Allow multiple connections from the same IP address:">Allow multiple connections from the same IP address:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#allow_multiple_connections_per_ip" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="checkbox" id="allowMultipleConnectionsFromTheSameIPAddress" />
@@ -1371,7 +1371,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="validateHTTPSTrackerCertificate">QBT_TR(Validate HTTPS tracker certificate:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#validate_https_trackers" target="_blank">(?)</a></label>
+                    <label for="validateHTTPSTrackerCertificate" class="qbt-translatable" data-i18n="Validate HTTPS tracker certificate:">Validate HTTPS tracker certificate:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#validate_https_trackers" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="checkbox" id="validateHTTPSTrackerCertificate" />
@@ -1379,7 +1379,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="mitigateSSRF">QBT_TR(Server-side request forgery (SSRF) mitigation:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#ssrf_mitigation" target="_blank">(?)</a></label>
+                    <label for="mitigateSSRF" class="qbt-translatable" data-i18n="Server-side request forgery (SSRF) mitigation:">Server-side request forgery (SSRF) mitigation:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#ssrf_mitigation" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="checkbox" id="mitigateSSRF" />
@@ -1387,7 +1387,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="blockPeersOnPrivilegedPorts">QBT_TR(Disallow connection to peers on privileged ports:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://libtorrent.org/single-page-ref.html#no_connect_privileged_ports" target="_blank">(?)</a></label>
+                    <label for="blockPeersOnPrivilegedPorts" class="qbt-translatable" data-i18n="Disallow connection to peers on privileged ports:">Disallow connection to peers on privileged ports:&nbsp;<a href="https://libtorrent.org/single-page-ref.html#no_connect_privileged_ports" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="checkbox" id="blockPeersOnPrivilegedPorts" />
@@ -1395,30 +1395,30 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="uploadSlotsBehavior">QBT_TR(Upload slots behavior:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#choking_algorithm" target="_blank">(?)</a></label>
+                    <label for="uploadSlotsBehavior" class="qbt-translatable" data-i18n="Upload slots behavior:">Upload slots behavior:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#choking_algorithm" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <select id="uploadSlotsBehavior" style="width: 15em;">
-                        <option value="0">QBT_TR(Fixed slots)QBT_TR[CONTEXT=OptionsDialog]</option>
-                        <option value="1">QBT_TR(Upload rate based)QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="0" class="qbt-translatable" data-i18n="Fixed slots">Fixed slots</option>
+                        <option value="1" class="qbt-translatable" data-i18n="Upload rate based">Upload rate based</option>
                     </select>
                 </td>
             </tr>
             <tr>
                 <td>
-                    <label for="uploadChokingAlgorithm">QBT_TR(Upload choking algorithm:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#seed_choking_algorithm" target="_blank">(?)</a></label>
+                    <label for="uploadChokingAlgorithm" class="qbt-translatable" data-i18n="Upload choking algorithm:">Upload choking algorithm:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#seed_choking_algorithm" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <select id="uploadChokingAlgorithm" style="width: 15em;">
-                        <option value="0">QBT_TR(Round-robin)QBT_TR[CONTEXT=OptionsDialog]</option>
-                        <option value="1">QBT_TR(Fastest upload)QBT_TR[CONTEXT=OptionsDialog]</option>
-                        <option value="2">QBT_TR(Anti-leech)QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="0" class="qbt-translatable" data-i18n="Round-robin">Round-robin</option>
+                        <option value="1" class="qbt-translatable" data-i18n="Fastest upload">Fastest upload</option>
+                        <option value="2" class="qbt-translatable" data-i18n="Anti-leech">Anti-leech</option>
                     </select>
                 </td>
             </tr>
             <tr>
                 <td>
-                    <label for="announceAllTrackers">QBT_TR(Always announce to all trackers in a tier:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#announce_to_all_trackers" target="_blank">(?)</a></label>
+                    <label for="announceAllTrackers" class="qbt-translatable" data-i18n="Always announce to all trackers in a tier:">Always announce to all trackers in a tier:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#announce_to_all_trackers" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="checkbox" id="announceAllTrackers" />
@@ -1426,7 +1426,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="announceAllTiers">QBT_TR(Always announce to all tiers:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#announce_to_all_tiers" target="_blank">(?)</a></label>
+                    <label for="announceAllTiers" class="qbt-translatable" data-i18n="Always announce to all tiers:">Always announce to all tiers:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#announce_to_all_tiers" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="checkbox" id="announceAllTiers" />
@@ -1434,7 +1434,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="announceIP">QBT_TR(IP address reported to trackers (requires restart):)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#announce_ip" target="_blank">(?)</a></label>
+                    <label for="announceIP" class="qbt-translatable" data-i18n="IP address reported to trackers (requires restart):">IP address reported to trackers (requires restart):&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#announce_ip" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="announceIP" style="width: 15em;" />
@@ -1442,7 +1442,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="maxConcurrentHTTPAnnounces">QBT_TR(Max concurrent HTTP announces:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#max_concurrent_http_announces" target="_blank">(?)</a></label>
+                    <label for="maxConcurrentHTTPAnnounces" class="qbt-translatable" data-i18n="Max concurrent HTTP announces:">Max concurrent HTTP announces:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#max_concurrent_http_announces" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="maxConcurrentHTTPAnnounces" style="width: 15em;" />
@@ -1450,7 +1450,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="stopTrackerTimeout">QBT_TR(Stop tracker timeout [0: disabled]:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#stop_tracker_timeout" target="_blank">(?)</a></label>
+                    <label for="stopTrackerTimeout" class="qbt-translatable" data-i18n="Stop tracker timeout [0: disabled]:">Stop tracker timeout [0: disabled]:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#stop_tracker_timeout" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="stopTrackerTimeout" style="width: 15em;" />
@@ -1458,7 +1458,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="peerTurnover">QBT_TR(Peer turnover disconnect percentage:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#peer_turnover" target="_blank">(?)</a></label>
+                    <label for="peerTurnover" class="qbt-translatable" data-i18n="Peer turnover disconnect percentage:">Peer turnover disconnect percentage:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#peer_turnover" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="peerTurnover" style="width: 15em;" />&nbsp;&nbsp;%
@@ -1466,7 +1466,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="peerTurnoverCutoff">QBT_TR(Peer turnover threshold percentage:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#peer_turnover" target="_blank">(?)</a></label>
+                    <label for="peerTurnoverCutoff" class="qbt-translatable" data-i18n="Peer turnover threshold percentage:">Peer turnover threshold percentage:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#peer_turnover" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="peerTurnoverCutoff" style="width: 15em;" />&nbsp;&nbsp;%
@@ -1474,7 +1474,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="peerTurnoverInterval">QBT_TR(Peer turnover disconnect interval:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#peer_turnover" target="_blank">(?)</a></label>
+                    <label for="peerTurnoverInterval" class="qbt-translatable" data-i18n="Peer turnover disconnect interval:">Peer turnover disconnect interval:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#peer_turnover" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="peerTurnoverInterval" style="width: 15em;" />&nbsp;&nbsp;s
@@ -1482,7 +1482,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="requestQueueSize">QBT_TR(Maximum outstanding requests to a single peer:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#max_out_request_queue" target="_blank">(?)</a></label>
+                    <label for="requestQueueSize" class="qbt-translatable" data-i18n="Maximum outstanding requests to a single peer:">Maximum outstanding requests to a single peer:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#max_out_request_queue" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="requestQueueSize" style="width: 15em;" />
@@ -1490,7 +1490,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr>
                 <td>
-                    <label for="dhtBootstrapNodes">QBT_TR(DHT bootstrap nodes:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#dht_bootstrap_nodes" target="_blank">(?)</a></label>
+                    <label for="dhtBootstrapNodes" class="qbt-translatable" data-i18n="DHT bootstrap nodes:">DHT bootstrap nodes:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#dht_bootstrap_nodes" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input type="text" id="dhtBootstrapNodes" placeholder="QBT_TR(Resets to default if empty)QBT_TR[CONTEXT=OptionsDialog]" style="width: 15em;" />
@@ -1498,7 +1498,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr id="rowI2pInboundQuantity">
                 <td>
-                    <label for="i2pInboundQuantity">QBT_TR(I2P inbound quantity:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#i2p_inbound_quantity" target="_blank">(?)</a></label>
+                    <label for="i2pInboundQuantity" class="qbt-translatable" data-i18n="I2P inbound quantity:">I2P inbound quantity:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#i2p_inbound_quantity" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input id="i2pInboundQuantity" type="number" min="1" max="16" onchange="qBittorrent.Preferences.numberInputLimiter(this);" style="width: 15em;" />
@@ -1506,7 +1506,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr id="rowI2pOutboundQuantity">
                 <td>
-                    <label for="i2pOutboundQuantity">QBT_TR(I2P outbound quantity:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#i2p_outbound_quantity" target="_blank">(?)</a></label>
+                    <label for="i2pOutboundQuantity" class="qbt-translatable" data-i18n="I2P outbound quantity:">I2P outbound quantity:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#i2p_outbound_quantity" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input id="i2pOutboundQuantity" type="number" min="1" max="16" onchange="qBittorrent.Preferences.numberInputLimiter(this);" style="width: 15em;" />
@@ -1514,7 +1514,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr id="rowI2pInboundLength">
                 <td>
-                    <label for="i2pInboundLength">QBT_TR(I2P inbound length:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#i2p_inbound_length" target="_blank">(?)</a></label>
+                    <label for="i2pInboundLength" class="qbt-translatable" data-i18n="I2P inbound length:">I2P inbound length:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#i2p_inbound_length" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input id="i2pInboundLength" type="number" min="0" max="7" onchange="qBittorrent.Preferences.numberInputLimiter(this);" style="width: 15em;" />
@@ -1522,7 +1522,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             </tr>
             <tr id="rowI2pOutboundLength">
                 <td>
-                    <label for="i2pOutboundLength">QBT_TR(I2P outbound length:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#i2p_outbound_length" target="_blank">(?)</a></label>
+                    <label for="i2pOutboundLength" class="qbt-translatable" data-i18n="I2P outbound length:">I2P outbound length:&nbsp;<a href="https://www.libtorrent.org/reference-Settings.html#i2p_outbound_length" target="_blank">(?)</a></label>
                 </td>
                 <td>
                     <input id="i2pOutboundLength" type="number" min="0" max="7" onchange="qBittorrent.Preferences.numberInputLimiter(this);" style="width: 15em;" />
@@ -1646,9 +1646,9 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             const disableInput = (sel !== "other");
             const mycb = "<div class='select-watched-folder-editable'>"
                 + "<select id ='cb_watch_" + pos + "' onchange='qBittorrent.Preferences.changeWatchFolderSelect(this)'>"
-                + "<option value='watch_folder'>QBT_TR(Monitored folder)QBT_TR[CONTEXT=ScanFoldersModel]</option>"
-                + "<option value='default_folder'>QBT_TR(Default save location)QBT_TR[CONTEXT=ScanFoldersModel]</option>"
-                + "<option value='other'>QBT_TR(Other...)QBT_TR[CONTEXT=ScanFoldersModel]</option>"
+                + "<option value='watch_folder' class="qbt-translatable" data-i18n="Monitored folder">Monitored folder</option>"
+                + "<option value='default_folder' class="qbt-translatable" data-i18n="Default save location">Default save location</option>"
+                + "<option value='other' class="qbt-translatable" data-i18n="Other...">Other...</option>"
                 + "</select>"
                 + "<input id='cb_watch_txt_" + pos + "' type='text' " + (disableInput ? "hidden " : "") + "/>"
                 + "<img src='images/list-add.svg' id='addFolderImg_" + pos + "' alt='Add' style='padding-left:170px;width:16px;cursor:pointer;' onclick='qBittorrent.Preferences.addWatchFolder();' />"

--- a/src/webui/www/private/views/preferencesToolbar.html
+++ b/src/webui/www/private/views/preferencesToolbar.html
@@ -1,14 +1,14 @@
 <!-- preferences -->
 <div class="toolbarTabs">
     <ul id="preferencesTabs" class="tab-menu">
-        <li id="PrefBehaviorLink" class="selected"><a>QBT_TR(Behavior)QBT_TR[CONTEXT=OptionsDialog]</a></li>
-        <li id="PrefDownloadsLink"><a>QBT_TR(Downloads)QBT_TR[CONTEXT=OptionsDialog]</a></li>
-        <li id="PrefConnectionLink"><a>QBT_TR(Connection)QBT_TR[CONTEXT=OptionsDialog]</a></li>
-        <li id="PrefSpeedLink"><a>QBT_TR(Speed)QBT_TR[CONTEXT=OptionsDialog]</a></li>
-        <li id="PrefBittorrentLink"><a>QBT_TR(BitTorrent)QBT_TR[CONTEXT=OptionsDialog]</a></li>
-        <li id="PrefRSSLink"><a>QBT_TR(RSS)QBT_TR[CONTEXT=OptionsDialog]</a></li>
-        <li id="PrefWebUILink"><a>QBT_TR(WebUI)QBT_TR[CONTEXT=OptionsDialog]</a></li>
-        <li id="PrefAdvancedLink"><a>QBT_TR(Advanced)QBT_TR[CONTEXT=OptionsDialog]</a></li>
+        <li id="PrefBehaviorLink" class="selected"><a class="qbt-translatable" data-i18n="Behavior">Behavior</a></li>
+        <li id="PrefDownloadsLink"><a class="qbt-translatable" data-i18n="Downloads">Downloads</a></li>
+        <li id="PrefConnectionLink"><a class="qbt-translatable" data-i18n="Connection">Connection</a></li>
+        <li id="PrefSpeedLink"><a class="qbt-translatable" data-i18n="Speed">Speed</a></li>
+        <li id="PrefBittorrentLink"><a class="qbt-translatable" data-i18n="BitTorrent">BitTorrent</a></li>
+        <li id="PrefRSSLink"><a class="qbt-translatable" data-i18n="RSS">RSS</a></li>
+        <li id="PrefWebUILink"><a class="qbt-translatable" data-i18n="WebUI">WebUI</a></li>
+        <li id="PrefAdvancedLink"><a class="qbt-translatable" data-i18n="Advanced">Advanced</a></li>
     </ul>
     <div class="clear"></div>
 </div>

--- a/src/webui/www/private/views/properties.html
+++ b/src/webui/www/private/views/properties.html
@@ -10,43 +10,43 @@
         <legend><b class="qbt-translatable" data-i18n="Transfer">Transfer</b></legend>
         <table style="width: 100%">
             <tr>
-                <td class="generalLabel">QBT_TR(Time Active:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td class="generalLabel qbt-translatable" data-i18n="Time Active:">Time Active:</td>
                 <td id="time_elapsed"></td>
-                <td class="generalLabel">QBT_TR(ETA:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td class="generalLabel qbt-translatable" data-i18n="ETA:">ETA:</td>
                 <td id="eta"></td>
-                <td class="generalLabel">QBT_TR(Connections:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td class="generalLabel qbt-translatable" data-i18n="Connections:">Connections:</td>
                 <td id="nb_connections"></td>
             </tr>
             <tr>
-                <td class="generalLabel">QBT_TR(Downloaded:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td class="generalLabel qbt-translatable" data-i18n="Downloaded:">Downloaded:</td>
                 <td id="total_downloaded"></td>
-                <td class="generalLabel">QBT_TR(Uploaded:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td class="generalLabel qbt-translatable" data-i18n="Uploaded:">Uploaded:</td>
                 <td id="total_uploaded"></td>
-                <td class="generalLabel">QBT_TR(Seeds:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td class="generalLabel qbt-translatable" data-i18n="Seeds:">Seeds:</td>
                 <td id="seeds"></td>
             </tr>
             <tr>
-                <td class="generalLabel">QBT_TR(Download Speed:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td class="generalLabel qbt-translatable" data-i18n="Download Speed:">Download Speed:</td>
                 <td id="dl_speed"></td>
-                <td class="generalLabel">QBT_TR(Upload Speed:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td class="generalLabel qbt-translatable" data-i18n="Upload Speed:">Upload Speed:</td>
                 <td id="up_speed"></td>
-                <td class="generalLabel">QBT_TR(Peers:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td class="generalLabel qbt-translatable" data-i18n="Peers:">Peers:</td>
                 <td id="peers"></td>
             </tr>
             <tr>
-                <td class="generalLabel">QBT_TR(Download Limit:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td class="generalLabel qbt-translatable" data-i18n="Download Limit:">Download Limit:</td>
                 <td id="dl_limit"></td>
-                <td class="generalLabel">QBT_TR(Upload Limit:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td class="generalLabel qbt-translatable" data-i18n="Upload Limit:">Upload Limit:</td>
                 <td id="up_limit"></td>
-                <td class="generalLabel">QBT_TR(Wasted:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td class="generalLabel qbt-translatable" data-i18n="Wasted:">Wasted:</td>
                 <td id="total_wasted"></td>
             </tr>
             <tr>
-                <td class="generalLabel">QBT_TR(Share Ratio:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td class="generalLabel qbt-translatable" data-i18n="Share Ratio:">Share Ratio:</td>
                 <td id="share_ratio"></td>
-                <td class="generalLabel">QBT_TR(Reannounce In:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td class="generalLabel qbt-translatable" data-i18n="Reannounce In:">Reannounce In:</td>
                 <td id="reannounce"></td>
-                <td class="generalLabel">QBT_TR(Last Seen Complete:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td class="generalLabel qbt-translatable" data-i18n="Last Seen Complete:">Last Seen Complete:</td>
                 <td id="last_seen"></td>
             </tr>
         </table>
@@ -55,35 +55,35 @@
         <legend><b class="qbt-translatable" data-i18n="Information">Information</b></legend>
         <table style="width: 100%">
             <tr>
-                <td class="generalLabel">QBT_TR(Total Size:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td class="generalLabel qbt-translatable" data-i18n="Total Size:">Total Size:</td>
                 <td id="total_size"></td>
-                <td class="generalLabel">QBT_TR(Pieces:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td class="generalLabel qbt-translatable" data-i18n="Pieces:">Pieces:</td>
                 <td id="pieces"></td>
-                <td class="generalLabel">QBT_TR(Created By:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td class="generalLabel qbt-translatable" data-i18n="Created By:">Created By:</td>
                 <td id="created_by"></td>
             </tr>
             <tr>
-                <td class="generalLabel">QBT_TR(Added On:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td class="generalLabel qbt-translatable" data-i18n="Added On:">Added On:</td>
                 <td id="addition_date"></td>
-                <td class="generalLabel">QBT_TR(Completed On:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td class="generalLabel qbt-translatable" data-i18n="Completed On:">Completed On:</td>
                 <td id="completion_date"></td>
-                <td class="generalLabel">QBT_TR(Created On:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td class="generalLabel qbt-translatable" data-i18n="Created On:">Created On:</td>
                 <td id="creation_date"></td>
             </tr>
             <tr>
-                <td class="generalLabel">QBT_TR(Info Hash v1:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td class="generalLabel qbt-translatable" data-i18n="Info Hash v1:">Info Hash v1:</td>
                 <td colspan="5" id="torrent_hash_v1"></td>
             </tr>
             <tr>
-                <td class="generalLabel">QBT_TR(Info Hash v2:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td class="generalLabel qbt-translatable" data-i18n="Info Hash v2:">Info Hash v2:</td>
                 <td colspan="5" id="torrent_hash_v2"></td>
             </tr>
             <tr>
-                <td class="generalLabel">QBT_TR(Save Path:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td class="generalLabel qbt-translatable" data-i18n="Save Path:">Save Path:</td>
                 <td colspan="5" id="save_path"></td>
             </tr>
             <tr>
-                <td class="generalLabel">QBT_TR(Comment:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+                <td class="generalLabel qbt-translatable" data-i18n="Comment:">Comment:</td>
                 <td colspan="5" style="white-space: pre-wrap;" id="comment"></td>
             </tr>
         </table>

--- a/src/webui/www/private/views/properties.html
+++ b/src/webui/www/private/views/properties.html
@@ -1,13 +1,13 @@
 <div id="prop_general" class="propertiesTabContent">
     <table style="width: 100%; padding: 0 3px">
         <tr>
-            <td style="text-align: right; white-space: nowrap">QBT_TR(Progress:)QBT_TR[CONTEXT=PropertiesWidget]</td>
+            <td style="text-align: right; white-space: nowrap" class="qbt-translatable" data-i18n="Progress:">Progress:</td>
             <td id="progress" style="width: 100%"></td>
         </tr>
     </table>
     <hr>
     <fieldset>
-        <legend><b>QBT_TR(Transfer)QBT_TR[CONTEXT=PropertiesWidget]</b></legend>
+        <legend><b class="qbt-translatable" data-i18n="Transfer">Transfer</b></legend>
         <table style="width: 100%">
             <tr>
                 <td class="generalLabel">QBT_TR(Time Active:)QBT_TR[CONTEXT=PropertiesWidget]</td>
@@ -52,7 +52,7 @@
         </table>
     </fieldset>
     <fieldset>
-        <legend><b>QBT_TR(Information)QBT_TR[CONTEXT=PropertiesWidget]</b></legend>
+        <legend><b class="qbt-translatable" data-i18n="Information">Information</b></legend>
         <table style="width: 100%">
             <tr>
                 <td class="generalLabel">QBT_TR(Total Size:)QBT_TR[CONTEXT=PropertiesWidget]</td>
@@ -135,7 +135,7 @@
         <table class="dynamicTable" style="width: 100%">
             <thead>
                 <tr>
-                    <th>QBT_TR(URL)QBT_TR[CONTEXT=TrackerListWidget]</th>
+                    <th class="qbt-translatable" data-i18n="URL">URL</th>
                 </tr>
             </thead>
             <tbody id="webseedsTable"></tbody>

--- a/src/webui/www/private/views/propertiesToolbar.html
+++ b/src/webui/www/private/views/propertiesToolbar.html
@@ -1,6 +1,6 @@
 <div class="toolbarTabs">
     <div id="torrentFilesFilterToolbar" class="invisible">
-        <input type="text" id="torrentFilesFilterInput" placeholder="QBT_TR(Filter files...)QBT_TR[CONTEXT=PropertiesWidget]" autocorrect="off" autocapitalize="none" />
+        <input type="text" id="torrentFilesFilterInput" class="qbt-translatable" data-i18n="[placeholder]Filter files..." placeholder="Filter files..." autocorrect="off" autocapitalize="none" />
     </div>
     <ul id="propertiesTabs" class="tab-menu">
         <li id="PropGeneralLink" class="selected"><a class="qbt-translatable" data-i18n="General">General</a></li>

--- a/src/webui/www/private/views/propertiesToolbar.html
+++ b/src/webui/www/private/views/propertiesToolbar.html
@@ -3,11 +3,11 @@
         <input type="text" id="torrentFilesFilterInput" placeholder="QBT_TR(Filter files...)QBT_TR[CONTEXT=PropertiesWidget]" autocorrect="off" autocapitalize="none" />
     </div>
     <ul id="propertiesTabs" class="tab-menu">
-        <li id="PropGeneralLink" class="selected"><a>QBT_TR(General)QBT_TR[CONTEXT=PropTabBar]</a></li>
-        <li id="PropTrackersLink"><a>QBT_TR(Trackers)QBT_TR[CONTEXT=PropTabBar]</a></li>
-        <li id="PropPeersLink"><a>QBT_TR(Peers)QBT_TR[CONTEXT=PropTabBar]</a></li>
-        <li id="PropWebSeedsLink"><a>QBT_TR(HTTP Sources)QBT_TR[CONTEXT=PropTabBar]</a></li>
-        <li id="PropFilesLink"><a>QBT_TR(Content)QBT_TR[CONTEXT=PropTabBar]</a></li>
+        <li id="PropGeneralLink" class="selected"><a class="qbt-translatable" data-i18n="General">General</a></li>
+        <li id="PropTrackersLink"><a class="qbt-translatable" data-i18n="Trackers">Trackers</a></li>
+        <li id="PropPeersLink"><a class="qbt-translatable" data-i18n="Peers">Peers</a></li>
+        <li id="PropWebSeedsLink"><a class="qbt-translatable" data-i18n="HTTP Sources">HTTP Sources</a></li>
+        <li id="PropFilesLink"><a class="qbt-translatable" data-i18n="Content">Content</a></li>
     </ul>
     <div class="clear"></div>
 </div>

--- a/src/webui/www/private/views/rss.html
+++ b/src/webui/www/private/views/rss.html
@@ -93,7 +93,7 @@
             <button type="button" id="markReadButton" onclick="qBittorrent.Rss.markSelectedAsRead()" class="qbt-translatable" data-i18n="Mark items read">Mark items read</button>
             <button type="button" id="updateAllButton" onclick="qBittorrent.Rss.refreshAllFeeds()" class="qbt-translatable" data-i18n="Update all">Update all</button>
 
-            <button type="button" id="rssDownloaderButton" class="alignRight" onclick="qBittorrent.Rss.openRssDownloader()">QBT_TR(RSS Downloader...)QBT_TR[CONTEXT=RSSWidget]</button>
+            <button type="button" id="rssDownloaderButton" class="alignRight qbt-translatable" onclick="qBittorrent.Rss.openRssDownloader()" data-i18n="RSS Downloader...">RSS Downloader...</button>
         </div>
     </div>
     <div id="rssContentView">

--- a/src/webui/www/private/views/rss.html
+++ b/src/webui/www/private/views/rss.html
@@ -89,9 +89,9 @@
             QBT_TR(Fetching of RSS feeds is disabled now! You can enable it in application settings.)QBT_TR[CONTEXT=RSSWidget]
         </div>
         <div id="rssButtonBar">
-            <button type="button" id="newSubscriptionButton" onclick="qBittorrent.Rss.addRSSFeed()">QBT_TR(New subscription)QBT_TR[CONTEXT=RSSWidget]</button>
-            <button type="button" id="markReadButton" onclick="qBittorrent.Rss.markSelectedAsRead()">QBT_TR(Mark items read)QBT_TR[CONTEXT=RSSWidget]</button>
-            <button type="button" id="updateAllButton" onclick="qBittorrent.Rss.refreshAllFeeds()">QBT_TR(Update all)QBT_TR[CONTEXT=RSSWidget]</button>
+            <button type="button" id="newSubscriptionButton" onclick="qBittorrent.Rss.addRSSFeed()" class="qbt-translatable" data-i18n="New subscription">New subscription</button>
+            <button type="button" id="markReadButton" onclick="qBittorrent.Rss.markSelectedAsRead()" class="qbt-translatable" data-i18n="Mark items read">Mark items read</button>
+            <button type="button" id="updateAllButton" onclick="qBittorrent.Rss.refreshAllFeeds()" class="qbt-translatable" data-i18n="Update all">Update all</button>
 
             <button type="button" id="rssDownloaderButton" class="alignRight" onclick="qBittorrent.Rss.openRssDownloader()">QBT_TR(RSS Downloader...)QBT_TR[CONTEXT=RSSWidget]</button>
         </div>

--- a/src/webui/www/private/views/rss.html
+++ b/src/webui/www/private/views/rss.html
@@ -138,21 +138,21 @@
 </div>
 
 <ul id="rssFeedMenu" class="contextMenu">
-    <li><a href="#update"><img src="images/view-refresh.svg" alt="QBT_TR(Update)QBT_TR[CONTEXT=RSSWidget]" /> QBT_TR(Update)QBT_TR[CONTEXT=RSSWidget]</a></li>
-    <li><a href="#markRead"><img src="images/task-complete.svg" alt="QBT_TR(Mark items read)QBT_TR[CONTEXT=RSSWidget]" /> QBT_TR(Mark items read)QBT_TR[CONTEXT=RSSWidget]</a></li>
-    <li class="separator"><a href="#rename"><img src="images/edit-rename.svg" alt="QBT_TR(Rename...)QBT_TR[CONTEXT=RSSWidget]" /> QBT_TR(Rename...)QBT_TR[CONTEXT=RSSWidget]</a></li>
-    <li><a href="#delete"><img src="images/edit-clear.svg" alt="QBT_TR(Delete)QBT_TR[CONTEXT=RSSWidget]" /> QBT_TR(Delete)QBT_TR[CONTEXT=RSSWidget]</a></li>
+    <li><a href="#update"><img src="images/view-refresh.svg" class="qbt-translatable" data-i18n="[alt]Update" alt="Update" /> QBT_TR(Update)QBT_TR[CONTEXT=RSSWidget]</a></li>
+    <li><a href="#markRead"><img src="images/task-complete.svg" class="qbt-translatable" data-i18n="[alt]Mark items read" alt="Mark items read" /> QBT_TR(Mark items read)QBT_TR[CONTEXT=RSSWidget]</a></li>
+    <li class="separator"><a href="#rename"><img src="images/edit-rename.svg" class="qbt-translatable" data-i18n="[alt]Rename..." alt="Rename..." /> QBT_TR(Rename...)QBT_TR[CONTEXT=RSSWidget]</a></li>
+    <li><a href="#delete"><img src="images/edit-clear.svg" class="qbt-translatable" data-i18n="[alt]Delete" alt="Delete" /> QBT_TR(Delete)QBT_TR[CONTEXT=RSSWidget]</a></li>
 
-    <li class="separator"><a href="#newSubscription"><img src="images/list-add.svg" alt="QBT_TR(New subscription...)QBT_TR[CONTEXT=RSSWidget]" /> QBT_TR(New subscription...)QBT_TR[CONTEXT=RSSWidget]</a></li>
-    <li><a href="#newFolder"><img src="images/folder-new.svg" alt="QBT_TR(New folder...)QBT_TR[CONTEXT=RSSWidget]" /> QBT_TR(New folder...)QBT_TR[CONTEXT=RSSWidget]</a></li>
-    <li class="separator"><a href="#updateAll"><img src="images/view-refresh.svg" alt="QBT_TR(Update all feeds)QBT_TR[CONTEXT=RSSWidget]" /> QBT_TR(Update all feeds)QBT_TR[CONTEXT=RSSWidget]</a></li>
+    <li class="separator"><a href="#newSubscription"><img src="images/list-add.svg" class="qbt-translatable" data-i18n="[alt]New subscription..." alt="New subscription..." /> QBT_TR(New subscription...)QBT_TR[CONTEXT=RSSWidget]</a></li>
+    <li><a href="#newFolder"><img src="images/folder-new.svg" class="qbt-translatable" data-i18n="[alt]New folder..." alt="New folder..." /> QBT_TR(New folder...)QBT_TR[CONTEXT=RSSWidget]</a></li>
+    <li class="separator"><a href="#updateAll"><img src="images/view-refresh.svg" class="qbt-translatable" data-i18n="[alt]Update all feeds" alt="Update all feeds" /> QBT_TR(Update all feeds)QBT_TR[CONTEXT=RSSWidget]</a></li>
 
-    <li class="separator"><a href="#copyFeedURL" id="CopyFeedURL"><img src="images/edit-copy.svg" alt="QBT_TR(Copy feed URL)QBT_TR[CONTEXT=RSSWidget]" /> QBT_TR(Copy feed URL)QBT_TR[CONTEXT=RSSWidget]</a></li>
+    <li class="separator"><a href="#copyFeedURL" id="CopyFeedURL"><img src="images/edit-copy.svg" class="qbt-translatable" data-i18n="[alt]Copy feed URL" alt="Copy feed URL" /> QBT_TR(Copy feed URL)QBT_TR[CONTEXT=RSSWidget]</a></li>
 </ul>
 
 <ul id="rssArticleMenu" class="contextMenu">
-    <li><a href="#Download"><img src="images/downloading.svg" alt="QBT_TR(Download torrent)QBT_TR[CONTEXT=RSSWidget]" /> QBT_TR(Download torrent)QBT_TR[CONTEXT=RSSWidget]</a></li>
-    <li><a href="#OpenNews"><img src="images/application-url.svg" alt="QBT_TR(Open news URL)QBT_TR[CONTEXT=RSSWidget]" /> QBT_TR(Open news URL)QBT_TR[CONTEXT=RSSWidget]</a></li>
+    <li><a href="#Download"><img src="images/downloading.svg" class="qbt-translatable" data-i18n="[alt]Download torrent" alt="Download torrent" /> QBT_TR(Download torrent)QBT_TR[CONTEXT=RSSWidget]</a></li>
+    <li><a href="#OpenNews"><img src="images/application-url.svg" class="qbt-translatable" data-i18n="[alt]Open news URL" alt="Open news URL" /> QBT_TR(Open news URL)QBT_TR[CONTEXT=RSSWidget]</a></li>
 </ul>
 
 <script>

--- a/src/webui/www/private/views/rss.html
+++ b/src/webui/www/private/views/rss.html
@@ -320,7 +320,7 @@
 
             new MochaUI.Window({
                 id: 'newFeed',
-                title: 'QBT_TR(Please type a RSS feed URL)QBT_TR[CONTEXT=RSSWidget]',
+                title: i18next.t('Please type a RSS feed URL'),
                 loadMethod: 'iframe',
                 contentURL: 'newfeed.html?path=' + encodeURIComponent(path),
                 scrollbars: false,
@@ -347,7 +347,7 @@
 
             new MochaUI.Window({
                 id: 'newFolder',
-                title: 'QBT_TR(Please choose a folder name)QBT_TR[CONTEXT=RSSWidget]',
+                title: i18next.t('Please choose a folder name'),
                 loadMethod: 'iframe',
                 contentURL: 'newfolder.html?path=' + encodeURIComponent(path),
                 scrollbars: false,
@@ -413,7 +413,7 @@
                     torrentDate.setAttribute('id', 'rssTorrentDetailsDate');
 
                     let torrentDateDesc = document.createElement('b');
-                    torrentDateDesc.innerText = 'QBT_TR(Date: )QBT_TR[CONTEXT=RSSWidget]';
+                    torrentDateDesc.innerText = i18next.t('Date: ');
                     torrentDate.append(torrentDateDesc);
 
                     let torrentDateData = document.createElement('span');
@@ -590,7 +590,7 @@
                         // Unread entry at top
                         rssFeedTable.updateRowData({
                             rowId: 0,
-                            name: 'QBT_TR(Unread)QBT_TR[CONTEXT=FeedListWidget]',
+                            name: i18next.t('Unread'),
                             unread: 0,
                             status: 'unread',
                             indentation: 0,
@@ -678,7 +678,7 @@
         const moveItem = (oldPath) => {
             new MochaUI.Window({
                 id: 'renamePage',
-                title: 'QBT_TR(Please choose a new name for this RSS feed)QBT_TR[CONTEXT=RSSWidget]',
+                title: i18next.t('Please choose a new name for this RSS feed'),
                 loadMethod: 'iframe',
                 contentURL: 'rename_feed.html?oldPath=' + encodeURIComponent(oldPath),
                 scrollbars: false,
@@ -693,7 +693,7 @@
             const encodedPaths = paths.map((path) => encodeURIComponent(path));
             new MochaUI.Window({
                 id: 'confirmFeedDeletionPage',
-                title: 'QBT_TR(Deletion confirmation)QBT_TR[CONTEXT=RSSWidget]',
+                title: i18next.t('Deletion confirmation'),
                 loadMethod: 'iframe',
                 contentURL: 'confirmfeeddeletion.html?paths=' + encodeURIComponent(encodedPaths.join('|')),
                 scrollbars: false,
@@ -803,7 +803,7 @@
             const id = 'rssdownloaderpage';
             new MochaUI.Window({
                 id: id,
-                title: 'QBT_TR(Rss Downloader)QBT_TR[CONTEXT=AutomatedRssDownloader]',
+                title: i18next.t('Rss Downloader'),
                 loadMethod: 'xhr',
                 contentURL: 'views/rssDownloader.html',
                 maximizable: false,

--- a/src/webui/www/private/views/rssDownloader.html
+++ b/src/webui/www/private/views/rssDownloader.html
@@ -506,7 +506,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
         const addRule = () => {
             new MochaUI.Window({
                 id: 'newRulePage',
-                title: 'QBT_TR(New rule name)QBT_TR[CONTEXT=AutomatedRssDownloader]',
+                title: i18next.t('New rule name'),
                 loadMethod: 'iframe',
                 contentURL: 'newrule.html',
                 scrollbars: false,
@@ -520,7 +520,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
         const renameRule = (rule) => {
             new MochaUI.Window({
                 id: 'renameRulePage',
-                title: 'QBT_TR(Rule renaming)QBT_TR[CONTEXT=AutomatedRssDownloader]',
+                title: i18next.t('Rule renaming'),
                 loadMethod: 'iframe',
                 contentURL: 'rename_rule.html?rule=' + encodeURIComponent(rule),
                 scrollbars: false,
@@ -542,7 +542,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
             const encodedRules = rules.map((rule) => encodeURIComponent(rule));
             new MochaUI.Window({
                 id: 'removeRulePage',
-                title: 'QBT_TR(Rule deletion confirmation)QBT_TR[CONTEXT=AutomatedRssDownloader]',
+                title: i18next.t('Rule deletion confirmation'),
                 loadMethod: 'iframe',
                 contentURL: 'confirmruledeletion.html?rules=' + encodeURIComponent(encodedRules.join('|')),
                 scrollbars: false,
@@ -557,7 +557,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
             const encodedRules = rules.map((rule) => encodeURIComponent(rule));
             new MochaUI.Window({
                 id: 'clearRulesPage',
-                title: 'QBT_TR(New rule name)QBT_TR[CONTEXT=AutomatedRssDownloader]',
+                title: i18next.t('New rule name'),
                 loadMethod: 'iframe',
                 contentURL: 'confirmruleclear.html?rules=' + encodeURIComponent(encodedRules.join('|')),
                 scrollbars: false,
@@ -687,7 +687,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                 $('savetoDifferentDir').checked = false;
                 $('saveToText').value = '';
                 $('ignoreDaysValue').value = 0;
-                $('lastMatchText').textContent = 'QBT_TR(Last Match: Unknown)QBT_TR[CONTEXT=AutomatedRssDownloader]';
+                $('lastMatchText').textContent = i18next.t('Last Match: Unknown');
                 $('addPausedCombobox').value = 'default';
                 $('contentLayoutCombobox').value = 'Default';
                 rssDownloaderFeedSelectionTable.clear();
@@ -733,7 +733,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                     $('lastMatchText').textContent = ' QBT_TR(Last Match: %1 days ago)QBT_TR[CONTEXT=AutomatedRssDownloader]'.replace('%1', daysAgo);
                 }
                 else {
-                    $('lastMatchText').textContent = 'QBT_TR(Last Match: Unknown)QBT_TR[CONTEXT=AutomatedRssDownloader]';
+                    $('lastMatchText').textContent = i18next.t('Last Match: Unknown');
                 }
 
                 if (rulesList[ruleName].torrentParams.stopped === null)
@@ -776,14 +776,14 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                     + ' ● QBT_TR(| is used as OR operator)QBT_TR[CONTEXT=AutomatedRssDownloader]\n\n'
                     + 'QBT_TR(If word order is important use * instead of whitespace.)QBT_TR[CONTEXT=AutomatedRssDownloader]\n\n';
             }
-            let secondPart = 'QBT_TR(An expression with an empty %1 clause (e.g. %2))QBT_TR[CONTEXT=AutomatedRssDownloader]'
+            let secondPart = i18next.t('An expression with an empty %1 clause (e.g. %2)')
                 .replace('%1', '|').replace('%2', 'expr|');
 
-            $('mustContainText').title = mainPart + secondPart + 'QBT_TR( will match all articles.)QBT_TR[CONTEXT=AutomatedRssDownloader]';
-            $('mustNotContainText').title = mainPart + secondPart + 'QBT_TR( will exclude all articles.)QBT_TR[CONTEXT=AutomatedRssDownloader]';
+            $('mustContainText').title = mainPart + secondPart + i18next.t(' will match all articles.');
+            $('mustNotContainText').title = mainPart + secondPart + i18next.t(' will exclude all articles.');
 
             let episodeFilterTitle = 'QBT_TR(Matches articles based on episode filter.)QBT_TR[CONTEXT=AutomatedRssDownloader]\n\n'
-                + 'QBT_TR(Example: )QBT_TR[CONTEXT=AutomatedRssDownloader]'
+                + i18next.t('Example: ')
                 + '1x2;8-15;5;30-;'
                 + 'QBT_TR( will match 2, 5, 8 through 15, 30 and onward episodes of season one)QBT_TR[CONTEXT=AutomatedRssDownloader]\n\n'
                 + 'QBT_TR(Episode filter rules: )QBT_TR[CONTEXT=AutomatedRssDownloader]\n\n'

--- a/src/webui/www/private/views/rssDownloader.html
+++ b/src/webui/www/private/views/rssDownloader.html
@@ -321,10 +321,10 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
 </div>
 
 <ul id="rssDownloaderRuleMenu" class="contextMenu">
-    <li><a href="#addRule"><img src="images/list-add.svg" alt="QBT_TR(Add new rule...)QBT_TR[CONTEXT=AutomatedRssDownloader]" /> QBT_TR(Add new rule...)QBT_TR[CONTEXT=AutomatedRssDownloader]</a></li>
-    <li><a href="#deleteRule"><img src="images/edit-clear.svg" alt="QBT_TR(Delete rule)QBT_TR[CONTEXT=AutomatedRssDownloader]" /> QBT_TR(Delete rule)QBT_TR[CONTEXT=AutomatedRssDownloader]</a></li>
-    <li class="separator"><a href="#renameRule"><img src="images/edit-rename.svg" alt="QBT_TR(Rename rule...)QBT_TR[CONTEXT=AutomatedRssDownloader]" /> QBT_TR(Rename rule...)QBT_TR[CONTEXT=AutomatedRssDownloader]</a></li>
-    <li class="separator"><a href="#clearDownloadedEpisodes"><img src="images/edit-clear.svg" alt="QBT_TR(Clear downloaded episodes...)QBT_TR[CONTEXT=AutomatedRssDownloader]" /> QBT_TR(Clear downloaded episodes...)QBT_TR[CONTEXT=AutomatedRssDownloader]</a></li>
+    <li><a href="#addRule"><img src="images/list-add.svg" class="qbt-translatable" data-i18n="[alt]Add new rule..." alt="Add new rule..." /> QBT_TR(Add new rule...)QBT_TR[CONTEXT=AutomatedRssDownloader]</a></li>
+    <li><a href="#deleteRule"><img src="images/edit-clear.svg" class="qbt-translatable" data-i18n="[alt]Delete rule" alt="Delete rule" /> QBT_TR(Delete rule)QBT_TR[CONTEXT=AutomatedRssDownloader]</a></li>
+    <li class="separator"><a href="#renameRule"><img src="images/edit-rename.svg" class="qbt-translatable" data-i18n="[alt]Rename rule..." alt="Rename rule..." /> QBT_TR(Rename rule...)QBT_TR[CONTEXT=AutomatedRssDownloader]</a></li>
+    <li class="separator"><a href="#clearDownloadedEpisodes"><img src="images/edit-clear.svg" class="qbt-translatable" data-i18n="[alt]Clear downloaded episodes..." alt="Clear downloaded episodes..." /> QBT_TR(Clear downloaded episodes...)QBT_TR[CONTEXT=AutomatedRssDownloader]</a></li>
 </ul>
 
 <script>

--- a/src/webui/www/private/views/rssDownloader.html
+++ b/src/webui/www/private/views/rssDownloader.html
@@ -766,15 +766,15 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
         const setElementTitles = () => {
             let mainPart;
             if ($('useRegEx').checked) {
-                mainPart = 'QBT_TR(Regex mode: use Perl-compatible regular expressions)QBT_TR[CONTEXT=AutomatedRssDownloader]\n\n';
+                mainPart = `${i18next.t('Regex mode: use Perl-compatible regular expressions')}\n\n`;
             }
             else {
-                mainPart = 'QBT_TR(Wildcard mode: you can use)QBT_TR[CONTEXT=AutomatedRssDownloader]\n\n'
-                    + ' ● QBT_TR(? to match any single character)QBT_TR[CONTEXT=AutomatedRssDownloader]\n'
-                    + ' ● QBT_TR(* to match zero or more of any characters)QBT_TR[CONTEXT=AutomatedRssDownloader]\n'
-                    + ' ● QBT_TR(Whitespaces count as AND operators (all words, any order))QBT_TR[CONTEXT=AutomatedRssDownloader]\n'
-                    + ' ● QBT_TR(| is used as OR operator)QBT_TR[CONTEXT=AutomatedRssDownloader]\n\n'
-                    + 'QBT_TR(If word order is important use * instead of whitespace.)QBT_TR[CONTEXT=AutomatedRssDownloader]\n\n';
+                mainPart = `${i18next.t('Wildcard mode: you can use')}\n\n`
+                    + ` ● ${i18next.t('? to match any single character')}\n`
+                    + ` ● ${i18next.t('* to match zero or more of any characters')}\n`
+                    + ` ● ${i18next.t('Whitespaces count as AND operators (all words, any order)')}\n`
+                    + ` ● ${i18next.t('| is used as OR operator')}\n\n`
+                    + `${i18next.t('If word order is important use * instead of whitespace.')}\n\n`;
             }
             let secondPart = i18next.t('An expression with an empty %1 clause (e.g. %2)')
                 .replace('%1', '|').replace('%2', 'expr|');
@@ -782,18 +782,18 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
             $('mustContainText').title = mainPart + secondPart + i18next.t(' will match all articles.');
             $('mustNotContainText').title = mainPart + secondPart + i18next.t(' will exclude all articles.');
 
-            let episodeFilterTitle = 'QBT_TR(Matches articles based on episode filter.)QBT_TR[CONTEXT=AutomatedRssDownloader]\n\n'
+            let episodeFilterTitle = `${i18next.t('Matches articles based on episode filter.')}\n\n`
                 + i18next.t('Example: ')
                 + '1x2;8-15;5;30-;'
-                + 'QBT_TR( will match 2, 5, 8 through 15, 30 and onward episodes of season one)QBT_TR[CONTEXT=AutomatedRssDownloader]\n\n'
-                + 'QBT_TR(Episode filter rules: )QBT_TR[CONTEXT=AutomatedRssDownloader]\n\n'
-                + ' ● QBT_TR(Season number is a mandatory non-zero value)QBT_TR[CONTEXT=AutomatedRssDownloader]\n'
-                + ' ● QBT_TR(Episode number is a mandatory positive value)QBT_TR[CONTEXT=AutomatedRssDownloader]\n'
-                + ' ● QBT_TR(Filter must end with semicolon)QBT_TR[CONTEXT=AutomatedRssDownloader]\n'
-                + ' ● QBT_TR(Three range types for episodes are supported: )QBT_TR[CONTEXT=AutomatedRssDownloader]\n'
-                + '    ● QBT_TR(Single number: <b>1x25;</b> matches episode 25 of season one)QBT_TR[CONTEXT=AutomatedRssDownloader]\n'
-                + '    ● QBT_TR(Normal range: <b>1x25-40;</b> matches episodes 25 through 40 of season one)QBT_TR[CONTEXT=AutomatedRssDownloader]\n'
-                + '    ● QBT_TR(Infinite range: <b>1x25-;</b> matches episodes 25 and upward of season one, and all episodes of later seasons)QBT_TR[CONTEXT=AutomatedRssDownloader]';
+                + `${i18next.t(' will match 2, 5, 8 through 15, 30 and onward episodes of season one')}\n\n`
+                + `${i18next.t('Episode filter rules: ')}\n\n`
+                + ` ● ${i18next.t('Season number is a mandatory non-zero value')}\n`
+                + ` ● ${i18next.t('Episode number is a mandatory positive value')}\n`
+                + ` ● ${i18next.t('Filter must end with semicolon')}\n`
+                + ` ● ${i18next.t('Three range types for episodes are supported: ')}\n`
+                + `    ● ${i18next.t('Single number: <b>1x25;</b> matches episode 25 of season one')}\n`
+                + `    ● ${i18next.t('Normal range: <b>1x25-40;</b> matches episodes 25 through 40 of season one')}\n`
+                + `    ● ${i18next.t('Infinite range: <b>1x25-;</b> matches episodes 25 and upward of season one, and all episodes of later seasons')}`;
 
             episodeFilterTitle = episodeFilterTitle.replace(/<b>/g, '').replace(/<\/b>/g, '');
             $('episodeFilterText').title = episodeFilterTitle;

--- a/src/webui/www/private/views/rssDownloader.html
+++ b/src/webui/www/private/views/rssDownloader.html
@@ -169,7 +169,7 @@
             <table class="fullWidth">
                 <tr>
                     <td>
-                        <label for="mustContainText" class="noWrap">QBT_TR(Must Contain:)QBT_TR[CONTEXT=AutomatedRssDownloader]</label>
+                        <label for="mustContainText" class="noWrap qbt-translatable" data-i18n="Must Contain:">Must Contain:</label>
                     </td>
                     <td class="fullWidth">
                         <input disabled type="text" id="mustContainText" class="fullWidth" autocorrect="off" autocapitalize="none" />
@@ -177,7 +177,7 @@
                 </tr>
                 <tr>
                     <td>
-                        <label for="mustNotContainText" class="noWrap">QBT_TR(Must Not Contain:)QBT_TR[CONTEXT=AutomatedRssDownloader]</label>
+                        <label for="mustNotContainText" class="noWrap qbt-translatable" data-i18n="Must Not Contain:">Must Not Contain:</label>
                     </td>
                     <td class="fullWidth">
                         <input disabled type="text" id="mustNotContainText" class="fullWidth" autocorrect="off" autocapitalize="none" />
@@ -185,7 +185,7 @@
                 </tr>
                 <tr>
                     <td>
-                        <label for="episodeFilterText" class="noWrap">QBT_TR(Episode Filter:)QBT_TR[CONTEXT=AutomatedRssDownloader]</label>
+                        <label for="episodeFilterText" class="noWrap qbt-translatable" data-i18n="Episode Filter:">Episode Filter:</label>
                     </td>
                     <td class="fullWidth">
                         <input disabled type="text" id="episodeFilterText" class="fullWidth" autocorrect="off" autocapitalize="none" />
@@ -203,7 +203,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
             <table class="fullWidth">
                 <tr>
                     <td>
-                        <label class="noWrap">QBT_TR(Assign Category:)QBT_TR[CONTEXT=AutomatedRssDownloader]</label>
+                        <label class="noWrap qbt-translatable" data-i18n="Assign Category:">Assign Category:</label>
                     </td>
                     <td class="fullWidth">
                         <select disabled id="assignCategoryCombobox" class="fullWidth">
@@ -213,7 +213,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                 </tr>
                 <tr>
                     <td>
-                        <label class="noWrap">QBT_TR(Add Tags:)QBT_TR[CONTEXT=AutomatedRssDownloader]</label>
+                        <label class="noWrap qbt-translatable" data-i18n="Add Tags:">Add Tags:</label>
                     </td>
                     <td class="fullWidth">
                         <input type="text" id="ruleAddTags" class="fullWidth" autocapitalize="none" autocorrect="off" />
@@ -228,7 +228,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
             <table class="fullWidth">
                 <tr>
                     <td>
-                        <label class="noWrap" for="saveToText">QBT_TR(Save to:)QBT_TR[CONTEXT=AutomatedRssDownloader]</label>
+                        <label class="noWrap qbt-translatable" for="saveToText" data-i18n="Save to:">Save to:</label>
                     </td>
                     <td class="fullWidth">
                         <input disabled type="text" class="fullWidth" id="saveToText" autocorrect="off" autocapitalize="none" />
@@ -247,7 +247,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
             <table class="fullWidth">
                 <tr>
                     <td>
-                        <label class="noWrap">QBT_TR(Add Paused:)QBT_TR[CONTEXT=AutomatedRssDownloader]</label>
+                        <label class="noWrap qbt-translatable" data-i18n="Add Paused:">Add Paused:</label>
                     </td>
                     <td class="fullWidth">
                         <select disabled id="addPausedCombobox" class="fullWidth">
@@ -261,7 +261,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
             <table class="fullWidth">
                 <tr>
                     <td>
-                        <label class="noWrap">QBT_TR(Torrent content layout:)QBT_TR[CONTEXT=AutomatedRssDownloader]</label>
+                        <label class="noWrap qbt-translatable" data-i18n="Torrent content layout:">Torrent content layout:</label>
                     </td>
                     <td class="fullWidth">
                         <select disabled id="contentLayoutCombobox" class="fullWidth">

--- a/src/webui/www/private/views/rssDownloader.html
+++ b/src/webui/www/private/views/rssDownloader.html
@@ -135,7 +135,7 @@
     </div>
     <div id="leftRssDownloaderColumn">
         <div id="topMenuBar">
-            <b id="rulesTableDesc">QBT_TR(Download Rules)QBT_TR[CONTEXT=AutomatedRssDownloader]</b>
+            <b id="rulesTableDesc" class="qbt-translatable" data-i18n="Download Rules">Download Rules</b>
             <button type="button" id="newRuleButton" class="imageButton" onclick="qBittorrent.RssDownloader.addRule()"></button>
             <button type="button" id="deleteRuleButton" class="imageButton" onclick="qBittorrent.RssDownloader.removeSelectedRule()"></button>
         </div>
@@ -161,10 +161,10 @@
     </div>
     <div id="centerRssDownloaderColumn">
         <fieldset class="settings" id="ruleSettings">
-            <legend>QBT_TR(Rule Definition)QBT_TR[CONTEXT=AutomatedRssDownloader]</legend>
+            <legend class="qbt-translatable" data-i18n="Rule Definition">Rule Definition</legend>
             <div class="formRow">
                 <input disabled type="checkbox" id="useRegEx" onclick="qBittorrent.RssDownloader.setElementTitles()" />
-                <label for="useRegEx">QBT_TR(Use Regular Expressions)QBT_TR[CONTEXT=AutomatedRssDownloader]</label>
+                <label for="useRegEx" class="qbt-translatable" data-i18n="Use Regular Expressions">Use Regular Expressions</label>
             </div>
             <table class="fullWidth">
                 <tr>
@@ -195,7 +195,7 @@
             <div class="formRow" title="QBT_TR(Smart Episode Filter will check the episode number to prevent downloading of duplicates.
 Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also support - as a separator))QBT_TR[CONTEXT=AutomatedRssDownloader]">
                 <input disabled type="checkbox" id="useSmartFilter" />
-                <label for="useSmartFilter">QBT_TR(Use Smart Episode Filter)QBT_TR[CONTEXT=AutomatedRssDownloader]</label>
+                <label for="useSmartFilter" class="qbt-translatable" data-i18n="Use Smart Episode Filter">Use Smart Episode Filter</label>
             </div>
 
             <hr>
@@ -223,7 +223,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
 
             <div class="formRow">
                 <input disabled type="checkbox" id="savetoDifferentDir" />
-                <label for="savetoDifferentDir">QBT_TR(Save to a Different Directory)QBT_TR[CONTEXT=AutomatedRssDownloader]</label>
+                <label for="savetoDifferentDir" class="qbt-translatable" data-i18n="Save to a Different Directory">Save to a Different Directory</label>
             </div>
             <table class="fullWidth">
                 <tr>
@@ -237,12 +237,12 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
             </table>
             <table>
                 <tr>
-                    <td><label for="ignoreDaysValue">QBT_TR(Ignore Subsequent Matches for (0 to Disable))QBT_TR[CONTEXT=AutomatedRssDownloader]</label></td>
-                    <td><input type="number" id="ignoreDaysValue" min="0" />QBT_TR( days)QBT_TR[CONTEXT=AutomatedRssDownloader]</td>
+                    <td><label for="ignoreDaysValue" class="qbt-translatable" data-i18n="Ignore Subsequent Matches for (0 to Disable)">Ignore Subsequent Matches for (0 to Disable)</label></td>
+                    <td><input type="number" id="ignoreDaysValue" min="0" / class="qbt-translatable" data-i18n=" days"> days</td>
                 </tr>
             </table>
             <div id="lastMatchDiv">
-                <span id="lastMatchText">QBT_TR(Last Match: Unknown)QBT_TR[CONTEXT=AutomatedRssDownloader]</span>
+                <span id="lastMatchText" class="qbt-translatable" data-i18n="Last Match: Unknown">Last Match: Unknown</span>
             </div>
             <table class="fullWidth">
                 <tr>
@@ -251,9 +251,9 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                     </td>
                     <td class="fullWidth">
                         <select disabled id="addPausedCombobox" class="fullWidth">
-                            <option value="default">QBT_TR(Use global settings)QBT_TR[CONTEXT=AutomatedRssDownloader]</option>
-                            <option value="always">QBT_TR(Always)QBT_TR[CONTEXT=AutomatedRssDownloader]</option>
-                            <option value="never">QBT_TR(Never)QBT_TR[CONTEXT=AutomatedRssDownloader]</option>
+                            <option value="default" class="qbt-translatable" data-i18n="Use global settings">Use global settings</option>
+                            <option value="always" class="qbt-translatable" data-i18n="Always">Always</option>
+                            <option value="never" class="qbt-translatable" data-i18n="Never">Never</option>
                         </select>
                     </td>
                 </tr>
@@ -265,17 +265,17 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                     </td>
                     <td class="fullWidth">
                         <select disabled id="contentLayoutCombobox" class="fullWidth">
-                            <option value="Default">QBT_TR(Use global settings)QBT_TR[CONTEXT=AutomatedRssDownloader]</option>
-                            <option value="Original">QBT_TR(Original)QBT_TR[CONTEXT=AutomatedRssDownloader]</option>
-                            <option value="Subfolder">QBT_TR(Create subfolder)QBT_TR[CONTEXT=AutomatedRssDownloader]</option>
-                            <option value="NoSubfolder">QBT_TR(Don't create subfolder)QBT_TR[CONTEXT=AutomatedRssDownloader]</option>
+                            <option value="Default" class="qbt-translatable" data-i18n="Use global settings">Use global settings</option>
+                            <option value="Original" class="qbt-translatable" data-i18n="Original">Original</option>
+                            <option value="Subfolder" class="qbt-translatable" data-i18n="Create subfolder">Create subfolder</option>
+                            <option value="NoSubfolder" class="qbt-translatable" data-i18n="Don't create subfolder">Don't create subfolder</option>
                         </select>
                     </td>
                 </tr>
             </table>
         </fieldset>
         <fieldset class="settings" id="rssDownloaderFeeds">
-            <legend>QBT_TR(Apply Rule to Feeds:)QBT_TR[CONTEXT=AutomatedRssDownloader]</legend>
+            <legend class="qbt-translatable" data-i18n="Apply Rule to Feeds:">Apply Rule to Feeds:</legend>
             <div id="rssDownloaderFeedsTable">
                 <div id="rssDownloaderFeedSelectionFixedHeaderDiv" class="dynamicTableFixedHeaderDiv invisible">
                     <table class="dynamicTable unselectable">
@@ -299,7 +299,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
         </button>
     </div>
     <div id="rightRssDownloaderColumn">
-        <b id="articleTableDesc">QBT_TR(Matching RSS Articles)QBT_TR[CONTEXT=AutomatedRssDownloader]</b>
+        <b id="articleTableDesc" class="qbt-translatable" data-i18n="Matching RSS Articles">Matching RSS Articles</b>
         <div id="rssDownloaderArticlesTable">
             <div id="rssDownloaderArticlesFixedHeaderDiv" class="dynamicTableFixedHeaderDiv invisible">
                 <table class="dynamicTable unselectable">

--- a/src/webui/www/private/views/search.html
+++ b/src/webui/www/private/views/search.html
@@ -80,7 +80,7 @@
             <input type="text" id="searchPattern" class="searchInputField" placeholder="QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]" autocorrect="off" autocomplete="off" autocapitalize="none" />
             <select id="categorySelect" class="searchInputField" onchange="qBittorrent.Search.categorySelected()"></select>
             <select id="pluginsSelect" class="searchInputField" onchange="qBittorrent.Search.pluginSelected()"></select>
-            <button type="button" id="startSearchButton" class="searchInputField" onclick="qBittorrent.Search.startStopSearch()">QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]</button>
+            <button type="button" id="startSearchButton" class="searchInputField qbt-translatable" onclick="qBittorrent.Search.startStopSearch()" data-i18n="Search">Search</button>
         </div>
     </div>
 

--- a/src/webui/www/private/views/search.html
+++ b/src/webui/www/private/views/search.html
@@ -77,7 +77,7 @@
 <div id="searchResults">
     <div style="overflow: hidden; height: 70px;">
         <div style="margin: 20px 0; height: 30px;">
-            <input type="text" id="searchPattern" class="searchInputField" placeholder="QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]" autocorrect="off" autocomplete="off" autocapitalize="none" />
+            <input type="text" id="searchPattern" class="searchInputField qbt-translatable" data-i18n="[placeholder]Search" placeholder="Search" autocorrect="off" autocomplete="off" autocapitalize="none" />
             <select id="categorySelect" class="searchInputField" onchange="qBittorrent.Search.categorySelected()"></select>
             <select id="pluginsSelect" class="searchInputField" onchange="qBittorrent.Search.pluginSelected()"></select>
             <button type="button" id="startSearchButton" class="searchInputField qbt-translatable" onclick="qBittorrent.Search.startStopSearch()" data-i18n="Search">Search</button>
@@ -111,7 +111,7 @@
                 <option value="everywhere" class="qbt-translatable" data-i18n="Everywhere">Everywhere</option>
             </select>
 
-            <img id="searchResultsGranularFiltersWarning" src="images/dialog-warning.svg" class="qbt-translatable" data-i18n="[title]Increase window width to display additional filters" title="Increase window width to display additional filters" alt="QBT_TR(Warning)QBT_TR[CONTEXT=SearchEngineWidget]" width="24" height="24">
+            <img id="searchResultsGranularFiltersWarning" src="images/dialog-warning.svg" class="qbt-translatable qbt-translatable" data-i18n="[title]Increase window width to display additional filters" title="Increase window width to display additional filters" data-i18n="[alt]Warning" alt="Warning" width="24" height="24">
 
             <div id="searchResultsGranularFilters">
                 <span style="margin-left: 15px;" class="qbt-translatable" data-i18n="Seeds:">Seeds:</span>

--- a/src/webui/www/private/views/search.html
+++ b/src/webui/www/private/views/search.html
@@ -102,44 +102,44 @@
     <div id="searchResultsFilters">
         <input type="text" id="searchInNameFilter" placeholder="QBT_TR(Filter)QBT_TR[CONTEXT=SearchEngineWidget]" autocorrect="off" autocapitalize="none" />
 
-        <span>QBT_TR(Results)QBT_TR[CONTEXT=SearchEngineWidget] (QBT_TR(showing)QBT_TR[CONTEXT=SearchEngineWidget] <span id="numSearchResultsVisible" class="numSearchResults">0</span> QBT_TR(out of)QBT_TR[CONTEXT=SearchEngineWidget] <span id="numSearchResultsTotal" class="numSearchResults">0</span>):</span>
+        <span class="qbt-translatable" data-i18n="Results">Results (QBT_TR(showing)QBT_TR[CONTEXT=SearchEngineWidget] <span id="numSearchResultsVisible" class="numSearchResults">0</span> QBT_TR(out of)QBT_TR[CONTEXT=SearchEngineWidget] <span id="numSearchResultsTotal" class="numSearchResults">0</span>):</span>
 
         <div style="display: inline-block; float: right;">
-            <label for="searchInTorrentName" style="margin-left: 15px;">QBT_TR(Search in:)QBT_TR[CONTEXT=SearchEngineWidget]</label>
+            <label for="searchInTorrentName" style="margin-left: 15px;" class="qbt-translatable" data-i18n="Search in:">Search in:</label>
             <select id="searchInTorrentName" onchange="qBittorrent.Search.searchInTorrentName()">
-                <option value="names">QBT_TR(Torrent names only)QBT_TR[CONTEXT=SearchEngineWidget]</option>
-                <option value="everywhere">QBT_TR(Everywhere)QBT_TR[CONTEXT=SearchEngineWidget]</option>
+                <option value="names" class="qbt-translatable" data-i18n="Torrent names only">Torrent names only</option>
+                <option value="everywhere" class="qbt-translatable" data-i18n="Everywhere">Everywhere</option>
             </select>
 
             <img id="searchResultsGranularFiltersWarning" src="images/dialog-warning.svg" title="QBT_TR(Increase window width to display additional filters)QBT_TR[CONTEXT=SearchEngineWidget]" alt="QBT_TR(Warning)QBT_TR[CONTEXT=SearchEngineWidget]" width="24" height="24">
 
             <div id="searchResultsGranularFilters">
-                <span style="margin-left: 15px;">QBT_TR(Seeds:)QBT_TR[CONTEXT=SearchEngineWidget]</span>
+                <span style="margin-left: 15px;" class="qbt-translatable" data-i18n="Seeds:">Seeds:</span>
                 <input type="number" min="0" max="1000" id="searchMinSeedsFilter" value="0" onchange="qBittorrent.Search.searchSeedsFilterChanged()">
-                <span>QBT_TR(to)QBT_TR[CONTEXT=SearchEngineWidget]</span>
+                <span class="qbt-translatable" data-i18n="to">to</span>
                 <input type="number" min="0" max="1000" id="searchMaxSeedsFilter" value="0" onchange="qBittorrent.Search.searchSeedsFilterChanged()">
 
-                <span style="margin-left: 15px;">QBT_TR(Size:)QBT_TR[CONTEXT=SearchEngineWidget]</span>
+                <span style="margin-left: 15px;" class="qbt-translatable" data-i18n="Size:">Size:</span>
                 <input type="number" min="0" max="1000" step=".01" value="0.00" id="searchMinSizeFilter" onchange="qBittorrent.Search.searchSizeFilterChanged()">
                 <select id="searchMinSizePrefix" onchange="qBittorrent.Search.searchSizeFilterPrefixChanged()">
-                    <option value="0">QBT_TR(B)QBT_TR[CONTEXT=misc]</option>
-                    <option value="1">QBT_TR(KiB)QBT_TR[CONTEXT=misc]</option>
-                    <option value="2" selected>QBT_TR(MiB)QBT_TR[CONTEXT=misc]</option>
-                    <option value="3">QBT_TR(GiB)QBT_TR[CONTEXT=misc]</option>
-                    <option value="4">QBT_TR(TiB)QBT_TR[CONTEXT=misc]</option>
-                    <option value="5">QBT_TR(PiB)QBT_TR[CONTEXT=misc]</option>
-                    <option value="6">QBT_TR(EiB)QBT_TR[CONTEXT=misc]</option>
+                    <option value="0" class="qbt-translatable" data-i18n="B">B</option>
+                    <option value="1" class="qbt-translatable" data-i18n="KiB">KiB</option>
+                    <option value="2" selected class="qbt-translatable" data-i18n="MiB">MiB</option>
+                    <option value="3" class="qbt-translatable" data-i18n="GiB">GiB</option>
+                    <option value="4" class="qbt-translatable" data-i18n="TiB">TiB</option>
+                    <option value="5" class="qbt-translatable" data-i18n="PiB">PiB</option>
+                    <option value="6" class="qbt-translatable" data-i18n="EiB">EiB</option>
                 </select>
-                <span>QBT_TR(to)QBT_TR[CONTEXT=SearchEngineWidget]</span>
+                <span class="qbt-translatable" data-i18n="to">to</span>
                 <input type="number" min="0" max="1000" step=".01" value="0.00" id="searchMaxSizeFilter" onchange="qBittorrent.Search.searchSizeFilterChanged()">
                 <select id="searchMaxSizePrefix" onchange="qBittorrent.Search.searchSizeFilterPrefixChanged()">
-                    <option value="0">QBT_TR(B)QBT_TR[CONTEXT=misc]</option>
-                    <option value="1">QBT_TR(KiB)QBT_TR[CONTEXT=misc]</option>
-                    <option value="2" selected>QBT_TR(MiB)QBT_TR[CONTEXT=misc]</option>
-                    <option value="3">QBT_TR(GiB)QBT_TR[CONTEXT=misc]</option>
-                    <option value="4">QBT_TR(TiB)QBT_TR[CONTEXT=misc]</option>
-                    <option value="5">QBT_TR(PiB)QBT_TR[CONTEXT=misc]</option>
-                    <option value="6">QBT_TR(EiB)QBT_TR[CONTEXT=misc]</option>
+                    <option value="0" class="qbt-translatable" data-i18n="B">B</option>
+                    <option value="1" class="qbt-translatable" data-i18n="KiB">KiB</option>
+                    <option value="2" selected class="qbt-translatable" data-i18n="MiB">MiB</option>
+                    <option value="3" class="qbt-translatable" data-i18n="GiB">GiB</option>
+                    <option value="4" class="qbt-translatable" data-i18n="TiB">TiB</option>
+                    <option value="5" class="qbt-translatable" data-i18n="PiB">PiB</option>
+                    <option value="6" class="qbt-translatable" data-i18n="EiB">EiB</option>
                 </select>
             </div>
         </div>
@@ -164,7 +164,7 @@
     </div>
 
     <div style="height: 30px; padding-top: 10px;">
-        <button type="button" id="manageSearchPlugins" onclick="qBittorrent.Search.manageSearchPlugins()">QBT_TR(Search plugins...)QBT_TR[CONTEXT=SearchEngineWidget]</button>
+        <button type="button" id="manageSearchPlugins" onclick="qBittorrent.Search.manageSearchPlugins()" class="qbt-translatable" data-i18n="Search plugins...">Search plugins...</button>
     </div>
 </div>
 
@@ -522,8 +522,8 @@
                         });
 
                         const pluginsHtml = [];
-                        pluginsHtml.push('<option value="enabled">QBT_TR(Only enabled)QBT_TR[CONTEXT=SearchEngineWidget]</option>');
-                        pluginsHtml.push('<option value="all">QBT_TR(All plugins)QBT_TR[CONTEXT=SearchEngineWidget]</option>');
+                        pluginsHtml.push('<option value="enabled" class="qbt-translatable" data-i18n="Only enabled">Only enabled</option>');
+                        pluginsHtml.push('<option value="all" class="qbt-translatable" data-i18n="All plugins">All plugins</option>');
 
                         const searchPluginsEmpty = (searchPlugins.length === 0);
                         if (searchPluginsEmpty) {

--- a/src/webui/www/private/views/search.html
+++ b/src/webui/www/private/views/search.html
@@ -230,7 +230,7 @@
             max: 0.00,
             maxUnit: 3
         };
-        let selectedCategory = "QBT_TR(All categories)QBT_TR[CONTEXT=SearchEngineWidget]";
+        let selectedCategory = i18next.t("All categories");
         let selectedPlugin = "all";
         let prevSelectedPlugin;
         let activeSearchId = null;
@@ -308,7 +308,7 @@
                     plugins: plugins
                 },
                 onSuccess: function(response) {
-                    $('startSearchButton').set('text', 'QBT_TR(Stop)QBT_TR[CONTEXT=SearchEngineWidget]');
+                    $('startSearchButton').set('text', i18next.t('Stop'));
                     searchRunning = true;
                     activeSearchId = response.id;
                     updateSearchResultsData();
@@ -397,7 +397,7 @@
             if (!$(id))
                 new MochaUI.Window({
                     id: id,
-                    title: "QBT_TR(Search plugins)QBT_TR[CONTEXT=PluginSelectDlg]",
+                    title: i18next.t("Search plugins"),
                     loadMethod: 'xhr',
                     contentURL: 'views/searchplugins.html',
                     scrollbars: false,
@@ -454,7 +454,7 @@
 
         const resetSearchState = function() {
             clearTimeout(loadSearchResultsTimer);
-            $('startSearchButton').set('text', 'QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]');
+            $('startSearchButton').set('text', i18next.t('Search'));
             searchResultsRowId = 0;
             searchRunning = false;
             activeSearchId = null;

--- a/src/webui/www/private/views/search.html
+++ b/src/webui/www/private/views/search.html
@@ -100,7 +100,7 @@
     </div>
 
     <div id="searchResultsFilters">
-        <input type="text" id="searchInNameFilter" placeholder="QBT_TR(Filter)QBT_TR[CONTEXT=SearchEngineWidget]" autocorrect="off" autocapitalize="none" />
+        <input type="text" id="searchInNameFilter" class="qbt-translatable" data-i18n="[placeholder]Filter" placeholder="Filter" autocorrect="off" autocapitalize="none" />
 
         <span class="qbt-translatable" data-i18n="Results">Results (QBT_TR(showing)QBT_TR[CONTEXT=SearchEngineWidget] <span id="numSearchResultsVisible" class="numSearchResults">0</span> QBT_TR(out of)QBT_TR[CONTEXT=SearchEngineWidget] <span id="numSearchResultsTotal" class="numSearchResults">0</span>):</span>
 
@@ -111,7 +111,7 @@
                 <option value="everywhere" class="qbt-translatable" data-i18n="Everywhere">Everywhere</option>
             </select>
 
-            <img id="searchResultsGranularFiltersWarning" src="images/dialog-warning.svg" title="QBT_TR(Increase window width to display additional filters)QBT_TR[CONTEXT=SearchEngineWidget]" alt="QBT_TR(Warning)QBT_TR[CONTEXT=SearchEngineWidget]" width="24" height="24">
+            <img id="searchResultsGranularFiltersWarning" src="images/dialog-warning.svg" class="qbt-translatable" data-i18n="[title]Increase window width to display additional filters" title="Increase window width to display additional filters" alt="QBT_TR(Warning)QBT_TR[CONTEXT=SearchEngineWidget]" width="24" height="24">
 
             <div id="searchResultsGranularFilters">
                 <span style="margin-left: 15px;" class="qbt-translatable" data-i18n="Seeds:">Seeds:</span>
@@ -169,14 +169,14 @@
 </div>
 
 <ul id="searchResultsTableMenu" class="contextMenu">
-    <li><a href="#Download"><img src="images/downloading.svg" alt="QBT_TR(Download)QBT_TR[CONTEXT=SearchJobWidget]" /> QBT_TR(Download)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
-    <li class="separator"><a href="#OpenDescriptionUrl"><img src="images/application-url.svg" alt="QBT_TR(Open description page)QBT_TR[CONTEXT=SearchJobWidget]" /> QBT_TR(Open description page)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
+    <li><a href="#Download"><img src="images/downloading.svg" class="qbt-translatable" data-i18n="[alt]Download" alt="Download" /> QBT_TR(Download)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
+    <li class="separator"><a href="#OpenDescriptionUrl"><img src="images/application-url.svg" class="qbt-translatable" data-i18n="[alt]Open description page" alt="Open description page" /> QBT_TR(Open description page)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
     <li>
-        <a href="#" class="arrow-right"><img src="images/edit-copy.svg" alt="QBT_TR(Copy)QBT_TR[CONTEXT=SearchJobWidget]" /> QBT_TR(Copy)QBT_TR[CONTEXT=SearchJobWidget]</a>
+        <a href="#" class="arrow-right"><img src="images/edit-copy.svg" class="qbt-translatable" data-i18n="[alt]Copy" alt="Copy" /> QBT_TR(Copy)QBT_TR[CONTEXT=SearchJobWidget]</a>
         <ul>
-            <li><a href="#" id="copySearchTorrentName" class="copySearchDataToClipboard"><img src="images/name.svg" alt="QBT_TR(Name)QBT_TR[CONTEXT=SearchJobWidget]" /> QBT_TR(Name)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
-            <li><a href="#" id="copySearchTorrentDownloadLink" class="copySearchDataToClipboard"><img src="images/insert-link.svg" alt="QBT_TR(Download link)QBT_TR[CONTEXT=SearchJobWidget]" /> QBT_TR(Download link)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
-            <li><a href="#" id="copySearchTorrentDescriptionUrl" class="copySearchDataToClipboard"><img src="images/application-url.svg" alt="QBT_TR(Description page URL)QBT_TR[CONTEXT=SearchJobWidget]" /> QBT_TR(Description page URL)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
+            <li><a href="#" id="copySearchTorrentName" class="copySearchDataToClipboard"><img src="images/name.svg" class="qbt-translatable" data-i18n="[alt]Name" alt="Name" /> QBT_TR(Name)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
+            <li><a href="#" id="copySearchTorrentDownloadLink" class="copySearchDataToClipboard"><img src="images/insert-link.svg" class="qbt-translatable" data-i18n="[alt]Download link" alt="Download link" /> QBT_TR(Download link)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
+            <li><a href="#" id="copySearchTorrentDescriptionUrl" class="copySearchDataToClipboard"><img src="images/application-url.svg" class="qbt-translatable" data-i18n="[alt]Description page URL" alt="Description page URL" /> QBT_TR(Description page URL)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
         </ul>
     </li>
 </ul>

--- a/src/webui/www/private/views/search.html
+++ b/src/webui/www/private/views/search.html
@@ -111,7 +111,7 @@
                 <option value="everywhere" class="qbt-translatable" data-i18n="Everywhere">Everywhere</option>
             </select>
 
-            <img id="searchResultsGranularFiltersWarning" src="images/dialog-warning.svg" class="qbt-translatable qbt-translatable" data-i18n="[title]Increase window width to display additional filters" title="Increase window width to display additional filters" data-i18n="[alt]Warning" alt="Warning" width="24" height="24">
+            <img id="searchResultsGranularFiltersWarning" src="images/dialog-warning.svg" class="qbt-translatable" data-i18n="[title]Increase window width to display additional filters" title="Increase window width to display additional filters" data-i18n="[alt]Warning" alt="Warning" width="24" height="24">
 
             <div id="searchResultsGranularFilters">
                 <span style="margin-left: 15px;" class="qbt-translatable" data-i18n="Seeds:">Seeds:</span>

--- a/src/webui/www/private/views/searchplugins.html
+++ b/src/webui/www/private/views/searchplugins.html
@@ -120,7 +120,7 @@
         const installPlugin = function(path) {
             new MochaUI.Window({
                 id: 'installSearchPlugin',
-                title: "QBT_TR(Install plugin)QBT_TR[CONTEXT=PluginSourceDlg]",
+                title: i18next.t("Install plugin"),
                 loadMethod: 'xhr',
                 contentURL: 'views/installsearchplugin.html',
                 scrollbars: false,

--- a/src/webui/www/private/views/searchplugins.html
+++ b/src/webui/www/private/views/searchplugins.html
@@ -72,8 +72,8 @@
 </div>
 
 <ul id="searchPluginsTableMenu" class="contextMenu">
-    <li><a href="#Enabled"><img src="images/checked-completed.svg" alt="QBT_TR(Enabled)QBT_TR[CONTEXT=PluginSelectDlg]" /> QBT_TR(Enabled)QBT_TR[CONTEXT=PluginSelectDlg]</a></li>
-    <li class="separator"><a href="#Uninstall"><img src="images/list-remove.svg" alt="QBT_TR(Uninstall)QBT_TR[CONTEXT=PluginSelectDlg]" /> QBT_TR(Uninstall)QBT_TR[CONTEXT=PluginSelectDlg]</a></li>
+    <li><a href="#Enabled"><img src="images/checked-completed.svg" class="qbt-translatable" data-i18n="[alt]Enabled" alt="Enabled" /> QBT_TR(Enabled)QBT_TR[CONTEXT=PluginSelectDlg]</a></li>
+    <li class="separator"><a href="#Uninstall"><img src="images/list-remove.svg" class="qbt-translatable" data-i18n="[alt]Uninstall" alt="Uninstall" /> QBT_TR(Uninstall)QBT_TR[CONTEXT=PluginSelectDlg]</a></li>
 </ul>
 
 <script>

--- a/src/webui/www/private/views/searchplugins.html
+++ b/src/webui/www/private/views/searchplugins.html
@@ -42,7 +42,7 @@
 </style>
 
 <div id="searchPluginsContainer">
-    <h2>QBT_TR(Installed search plugins:)QBT_TR[CONTEXT=PluginSelectDlg]</h2>
+    <h2 class="qbt-translatable" data-i18n="Installed search plugins:">Installed search plugins:</h2>
 
     <div id="searchPluginsTable">
         <div id="searchPluginsTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
@@ -62,12 +62,12 @@
         </div>
     </div>
 
-    <span>QBT_TR(Warning: Be sure to comply with your country's copyright laws when downloading torrents from any of these search engines.)QBT_TR[CONTEXT=PluginSelectDlg]</span>
-    <span style="font-style: italic;">QBT_TR(You can get new search engine plugins here:)QBT_TR[CONTEXT=PluginSelectDlg] <a href="https://plugins.qbittorrent.org" target="_blank">https://plugins.qbittorrent.org</a></span>
+    <span class="qbt-translatable" data-i18n="Warning: Be sure to comply with your country's copyright laws when downloading torrents from any of these search engines.">Warning: Be sure to comply with your country's copyright laws when downloading torrents from any of these search engines.</span>
+    <span style="font-style: italic;" class="qbt-translatable" data-i18n="You can get new search engine plugins here:">You can get new search engine plugins here: <a href="https://plugins.qbittorrent.org" target="_blank">https://plugins.qbittorrent.org</a></span>
     <div style="width: 100%; margin-top: 10px;">
-        <button type="button" style="width: 33%; line-height: 1.4em;" onclick="qBittorrent.SearchPlugins.installPlugin();">QBT_TR(Install new plugin)QBT_TR[CONTEXT=PluginSelectDlg]</button>
-        <button type="button" style="width: 33%; line-height: 1.4em;" onclick="qBittorrent.SearchPlugins.checkForUpdates();">QBT_TR(Check for updates)QBT_TR[CONTEXT=PluginSelectDlg]</button>
-        <button type="button" style="width: 32%; line-height: 1.4em;" onclick="qBittorrent.SearchPlugins.closeSearchWindow('searchPlugins');">QBT_TR(Close)QBT_TR[CONTEXT=PluginSelectDlg]</button>
+        <button type="button" style="width: 33%; line-height: 1.4em;" onclick="qBittorrent.SearchPlugins.installPlugin();" class="qbt-translatable" data-i18n="Install new plugin">Install new plugin</button>
+        <button type="button" style="width: 33%; line-height: 1.4em;" onclick="qBittorrent.SearchPlugins.checkForUpdates();" class="qbt-translatable" data-i18n="Check for updates">Check for updates</button>
+        <button type="button" style="width: 32%; line-height: 1.4em;" onclick="qBittorrent.SearchPlugins.closeSearchWindow('searchPlugins');" class="qbt-translatable" data-i18n="Close">Close</button>
     </div>
 </div>
 

--- a/src/webui/www/private/views/statistics.html
+++ b/src/webui/www/private/views/statistics.html
@@ -1,58 +1,58 @@
 <div id="statisticsContent">
-    <h3>QBT_TR(User statistics)QBT_TR[CONTEXT=StatsDialog]</h3>
+    <h3 class="qbt-translatable" data-i18n="User statistics">User statistics</h3>
     <table style="width:100%">
         <tr>
-            <td>QBT_TR(All-time upload:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td class="qbt-translatable" data-i18n="All-time upload:">All-time upload:</td>
             <td id="AlltimeUL" class="statisticsValue"></td>
         </tr>
         <tr>
-            <td>QBT_TR(All-time download:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td class="qbt-translatable" data-i18n="All-time download:">All-time download:</td>
             <td id="AlltimeDL" class="statisticsValue"></td>
         </tr>
         <tr>
-            <td>QBT_TR(All-time share ratio:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td class="qbt-translatable" data-i18n="All-time share ratio:">All-time share ratio:</td>
             <td id="GlobalRatio" class="statisticsValue"></td>
         </tr>
         <tr>
-            <td>QBT_TR(Session waste:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td class="qbt-translatable" data-i18n="Session waste:">Session waste:</td>
             <td id="TotalWastedSession" class="statisticsValue"></td>
         </tr>
         <tr>
-            <td>QBT_TR(Connected peers:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td class="qbt-translatable" data-i18n="Connected peers:">Connected peers:</td>
             <td id="TotalPeerConnections" class="statisticsValue"></td>
         </tr>
     </table>
-    <h3>QBT_TR(Cache statistics)QBT_TR[CONTEXT=StatsDialog]</h3>
+    <h3 class="qbt-translatable" data-i18n="Cache statistics">Cache statistics</h3>
     <table style="width:100%">
         <tr>
-            <td>QBT_TR(Read cache hits:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td class="qbt-translatable" data-i18n="Read cache hits:">Read cache hits:</td>
             <td id="ReadCacheHits" class="statisticsValue"></td>
         </tr>
         <tr>
-            <td>QBT_TR(Total buffer size:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td class="qbt-translatable" data-i18n="Total buffer size:">Total buffer size:</td>
             <td id="TotalBuffersSize" class="statisticsValue"></td>
         </tr>
     </table>
-    <h3>QBT_TR(Performance statistics)QBT_TR[CONTEXT=StatsDialog]</h3>
+    <h3 class="qbt-translatable" data-i18n="Performance statistics">Performance statistics</h3>
     <table style="width:100%">
         <tr>
-            <td>QBT_TR(Write cache overload:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td class="qbt-translatable" data-i18n="Write cache overload:">Write cache overload:</td>
             <td id="WriteCacheOverload" class="statisticsValue"></td>
         </tr>
         <tr>
-            <td>QBT_TR(Read cache overload:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td class="qbt-translatable" data-i18n="Read cache overload:">Read cache overload:</td>
             <td id="ReadCacheOverload" class="statisticsValue"></td>
         </tr>
         <tr>
-            <td>QBT_TR(Queued I/O jobs:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td class="qbt-translatable" data-i18n="Queued I/O jobs:">Queued I/O jobs:</td>
             <td id="QueuedIOJobs" class="statisticsValue"></td>
         </tr>
         <tr>
-            <td>QBT_TR(Average time in queue:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td class="qbt-translatable" data-i18n="Average time in queue:">Average time in queue:</td>
             <td id="AverageTimeInQueue" class="statisticsValue"></td>
         </tr>
         <tr>
-            <td>QBT_TR(Total queued size:)QBT_TR[CONTEXT=StatsDialog]</td>
+            <td class="qbt-translatable" data-i18n="Total queued size:">Total queued size:</td>
             <td id="TotalQueuedSize" class="statisticsValue"></td>
         </tr>
     </table>


### PR DESCRIPTION
This draft PR is meant for collaboration for the i18next transition of the WebUI private part. The public part was done with PR #20520

You can use my commits into your own work without any kind of attribution.
Each commit provides the regex I used for each converstion from `QBT_TR(string)QBT_TR` to the i18next way.

There are .html files with nested elements that the regex hasn't converted. I think they need manucal conversion. About 124 instances.
Almost the same issue with the 3 remaining instances in the .js files.

@Chocobo1 
For translating HTML attributes we need to do some like the following. For example:
```html
<textarea placeholder="Format: IPv4:port / [IPv6]:port"></textarea>
```
```html
<textarea class="qbt-translatable" data-i18n="[placeholder]Format: IPv4:port / [IPv6]:port" placeholder="Format: IPv4:port / [IPv6]:port"></textarea>
```

Aka we set the `data-i18n` attribute's value to `[attribute-name]string`. And if we have multiple attributes to translate for the same HTML element we separate it with `;` eg `[attribute-name1]string1;[attribute-name2]string2`
However, I haven't tested if i18next-parser can correctly break out the different strings.
Source: https://stackoverflow.com/a/22822236/10260481


@ OTHER contributors
If you have time please take look at the diffs and try to verify the conversion.
Example:
This HTML
```html
<p class="random">QBT_TR(Some text)QBT_TR</P>
```

becomes this:
```html
<p class="random qbt-translatable" data-i18n="Some text">Some text</P>
```

and this Javascript:
```js
let a = 'QBT_TR(Some text)QBT_TR';
```

becomes this:
```js
let a = i18next.t('Some text');
```