### PR TITLE
Use SystemCallFilter in systemd unit

### DIFF
--- a/dist/unix/systemd/qbittorrent-nox@.service.in
+++ b/dist/unix/systemd/qbittorrent-nox@.service.in
@@ -10,6 +10,8 @@ PrivateTmp=false
 User=%i
 ExecStart=@EXPAND_BINDIR@/qbittorrent-nox
 TimeoutStopSec=1800
+SystemCallArchitectures=native
+SystemCallFilter=@basic-io @file-system @io-event @network-io @process @signal @sync @system-service @timer
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This makes use of systemd's system-call filtering facility to add (Linux) seccomp support to `qbittorrent-nox` in a non-invasive way. This implicitly also enables NoNewPrivileges. (See `SystemCallFilter=` in `systemd.exec(5)` for details.)

The syscall filter marks wide swaths of the Linux kernel API as off-limits, significantly reducing the attack surface of the system available to a baddie who manages to compromise the application. If a prohibited syscall is used, the process is immediately killed with SIGSYS.

The specific filter I've put together here is fairly broad, making use of systemd's syscall sets. It could probably be narrowed down a bit, but should be good as a starting point. I've tested it by running through a torrent download, but as I'm not yet familiar with the application's more advanced features, I've not checked that those can be used without issue. Some testing by a "power user" would be beneficial.

Some notes on testing the filter:

* If/when the process uses a prohibited syscall, in addition to the SIGSYS, a message like the following will appear in syslog:
  ```
  May 21 00:17:10 darkstar kernel: [ 4789.893316] audit: type=1326 audit(1684642630.723:258): auid=4294967295 uid=124 gid=130 ses=4294967295 subj=unconfined pid=28046 comm="qbittorrent-nox" exe="/usr/bin/qbittorrent-nox" sig=31 arch=c000003e syscall=99 compat=0 ip=0x7fb9ee316f9b code=0x80000000
  ```
* The `syscall=99` bit is salient. The syscall number can be looked up using the `scmp_sys_resolver(1)` utility:
  ```
  $ scmp_sys_resolver 99
  sysinfo
  ```
* The syscall name can either be added to the filter directly, or if you'd rather use systemd's syscall sets, the sets can be listed with `systemd-analyze syscall-filter`.
* Alternately, you can test without the threat of SIGSYS by using `SystemCallLog=`. Comment out `SystemCallFilter=`, and append its arguments to `SystemCallLog=~@default`. Then watch syslog for messages like the one above (only they will show `sig=0`).
