### PR TITLE
WebUI: Fix error when category doesn't exist

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1400,10 +1400,13 @@ window.qBittorrent.DynamicTable = (function() {
                             return false;
                     }
                     else {
-                        const selectedCategoryName = category_list.get(categoryHash).name + "/";
-                        const torrentCategoryName = row['full_data'].category + "/";
-                        if (!torrentCategoryName.startsWith(selectedCategoryName))
-                            return false;
+                        const selectedCategory = category_list.get(categoryHash);
+                        if (selectedCategory !== undefined) {
+                            const selectedCategoryName = selectedCategory.name + "/";
+                            const torrentCategoryName = row['full_data'].category + "/";
+                            if (!torrentCategoryName.startsWith(selectedCategoryName))
+                                return false;
+                        }
                     }
                     break;
             }


### PR DESCRIPTION
This prevents hitting a TypeError when the category stored in localstorage does not exist. The behavior for a nonexistent category now mirrors that of a nonexistent tag or filter - no option is selected and no torrents are shown.

Closes #20623.