### PR TITLE
GHA CI: only store cache for master branch

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -47,8 +47,10 @@ jobs:
       - name: Setup ccache
         uses: Chocobo1/setup-ccache-action@v1
         with:
-          store_cache: ${{ startsWith(github.ref, 'refs/heads/') }}
+          store_cache: ${{ github.ref == 'refs/heads/master' }}
           update_packager_index: false
+          ccache_options: |
+            max_size=2G
 
       - name: Install boost
         env:

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup ccache
         uses: Chocobo1/setup-ccache-action@v1
         with:
-          store_cache: ${{ startsWith(github.ref, 'refs/heads/') }}
+          store_cache: ${{ github.ref == 'refs/heads/master' }}
           update_packager_index: false
           ccache_options: |
             max_size=2G


### PR DESCRIPTION
Also set a lower cache limit for macOS to prevent cache thrashing. Previously the default was 5G.

Will backport to v4.6.x.