### PR TITLE
GHA CI: lock to ESLint v8

### DIFF
--- a/src/webui/www/package.json
+++ b/src/webui/www/package.json
@@ -11,8 +11,8 @@
     "lint": "eslint private/*.html private/scripts/*.js private/views/*.html public/*.html public/scripts/*.js && stylelint **/*.css && html-validate private public"
   },
   "devDependencies": {
-    "eslint": "*",
-    "eslint-plugin-html": "*",
+    "eslint": "^8",
+    "eslint-plugin-html": "^8",
     "html-validate": "*",
     "i18next-parser": "*",
     "js-beautify": "*",


### PR DESCRIPTION
For unknown reasons, ESLint v9 doesn't work correctly. Migration to ESLint v9 will be done later when it is stable enough.

Will backport to v4.6.x.