### PR TITLE
Using Command + Backspace as the shortcut to delete torrents on macOS

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -851,7 +851,13 @@ void MainWindow::createKeyboardShortcuts()
 {
     m_ui->actionCreateTorrent->setShortcut(QKeySequence::New);
     m_ui->actionOpen->setShortcut(QKeySequence::Open);
-    m_ui->actionDelete->setShortcut(QKeySequence::Delete);
+    m_ui->actionDelete->setShortcut(
+#ifdef Q_OS_MACOS
+        Qt::CTRL | Qt::Key_Backspace
+#else
+        QKeySequence::Delete
+#endif
+        );
     m_ui->actionDelete->setShortcutContext(Qt::WidgetShortcut);  // nullify its effect: delete key event is handled by respective widgets, not here
     m_ui->actionDownloadFromURL->setShortcut(Qt::CTRL | Qt::SHIFT | Qt::Key_O);
     m_ui->actionExit->setShortcut(Qt::CTRL | Qt::Key_Q);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -857,6 +857,7 @@ void MainWindow::createKeyboardShortcuts()
     m_ui->actionExit->setShortcut(Qt::CTRL | Qt::Key_Q);
 #ifdef Q_OS_MACOS
     m_ui->actionCloseWindow->setShortcut(QKeySequence::Close);
+    m_ui->actionDelete->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_Backspace));
 #else
     m_ui->actionCloseWindow->setVisible(false);
 #endif


### PR DESCRIPTION
macOS usually uses the Command key plus another key as shortcuts, similar to qBittorrent's other shortcuts.

Closes #20187.