### PR TITLE
Fix Enter key behavior in Add new torrent dialog

### DIFF
--- a/src/gui/fspathedit_p.cpp
+++ b/src/gui/fspathedit_p.cpp
@@ -163,6 +163,7 @@ QValidator::State Private::FileSystemPathValidator::validate(QString &input, [[m
 Private::FileLineEdit::FileLineEdit(QWidget *parent)
     : QLineEdit(parent)
 {
+    setCompleter(new QCompleter(this));
     connect(this, &QLineEdit::textChanged, this, &FileLineEdit::validateText);
 }
 
@@ -221,7 +222,7 @@ void Private::FileLineEdit::keyPressEvent(QKeyEvent *e)
 
     if ((e->key() == Qt::Key_Space) && (e->modifiers() == Qt::CTRL))
     {
-        if (!m_completer)
+        if (!m_completerModel)
         {
             m_iconProvider = new QFileIconProvider;
             m_iconProvider->setOptions(QFileIconProvider::DontUseCustomDirectoryIcons);
@@ -234,9 +235,7 @@ void Private::FileLineEdit::keyPressEvent(QKeyEvent *e)
                     | (m_completeDirectoriesOnly ? QDir::Dirs : QDir::AllEntries);
             m_completerModel->setFilter(filters);
 
-            m_completer = new QCompleter(this);
-            m_completer->setModel(m_completerModel);
-            setCompleter(m_completer);
+            completer()->setModel(m_completerModel);
         }
 
         m_completerModel->setRootPath(Path(text()).data());
@@ -260,8 +259,8 @@ void Private::FileLineEdit::contextMenuEvent(QContextMenuEvent *event)
 
 void Private::FileLineEdit::showCompletionPopup()
 {
-    m_completer->setCompletionPrefix(text());
-    m_completer->complete();
+    completer()->setCompletionPrefix(text());
+    completer()->complete();
 }
 
 void Private::FileLineEdit::validateText()

--- a/src/gui/fspathedit_p.h
+++ b/src/gui/fspathedit_p.h
@@ -37,7 +37,6 @@
 #include "base/pathfwd.h"
 
 class QAction;
-class QCompleter;
 class QContextMenuEvent;
 class QFileIconProvider;
 class QFileSystemModel;
@@ -141,7 +140,6 @@ namespace Private
         static QString warningText(FileSystemPathValidator::TestResult result);
 
         QFileSystemModel *m_completerModel = nullptr;
-        QCompleter *m_completer = nullptr;
         QAction *m_browseAction = nullptr;
         QAction *m_warningAction = nullptr;
         QFileIconProvider *m_iconProvider = nullptr;


### PR DESCRIPTION
Prevent inappropriate default completer from being used by path edit.

Closes #20663.
