### PR TITLE
WebAPI: Provide "isPrivate" flag via "torrents/info" endpoint

### DIFF
--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -163,6 +163,7 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         {KEY_TORRENT_AVAILABILITY, torrent.distributedCopies()},
         {KEY_TORRENT_REANNOUNCE, torrent.nextAnnounce()},
         {KEY_TORRENT_COMMENT, torrent.comment()},
+        {KEY_TORRENT_ISPRIVATE, torrent.isPrivate()},
 
         {KEY_TORRENT_TOTAL_SIZE, torrent.totalSize()}
     };

--- a/src/webui/api/serialize/serialize_torrent.h
+++ b/src/webui/api/serialize/serialize_torrent.h
@@ -93,5 +93,6 @@ inline const QString KEY_TORRENT_SEEDING_TIME = u"seeding_time"_s;
 inline const QString KEY_TORRENT_AVAILABILITY = u"availability"_s;
 inline const QString KEY_TORRENT_REANNOUNCE = u"reannounce"_s;
 inline const QString KEY_TORRENT_COMMENT = u"comment"_s;
+inline const QString KEY_TORRENT_ISPRIVATE = u"is_private"_s;
 
 QVariantMap serialize(const BitTorrent::Torrent &torrent);


### PR DESCRIPTION
Currently, the "isPrivate" flag is only present on the "properties"-API:
/api/v2/torrents/properties

With this PR, I'd like to add it to the "info" -API:
/api/v2/torrents/info

Advantage:  This way it can be retrieved for all torrents in one go (rather than having to query the properties-API for each hash 1 by 1)

Disclaimer: I tried to the best of my abilities to read the code and amend it (which I believe is a super simple change).
I was not able (due to my lack of skill) to build qBit with my change and test it. 

Thank you very much for your review.
