### PR TITLE
Add buttons to select/check files based on filter

### DIFF
--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -79,7 +79,7 @@ PropertiesWidget::PropertiesWidget(QWidget *parent)
     m_contentFilterLine->setPlaceholderText(tr("Filter files..."));
     m_contentFilterLine->setFixedWidth(300);
     connect(m_contentFilterLine, &LineEdit::textChanged, m_ui->filesList, &TorrentContentWidget::setFilterPattern);
-    m_ui->contentFilterLayout->insertWidget(3, m_contentFilterLine);
+    m_ui->contentFilterLayout->insertWidget(6, m_contentFilterLine);
 
     m_ui->filesList->setDoubleClickAction(TorrentContentWidget::DoubleClickAction::Open);
     m_ui->filesList->setOpenByEnterKey(true);
@@ -87,6 +87,9 @@ PropertiesWidget::PropertiesWidget(QWidget *parent)
     // SIGNAL/SLOTS
     connect(m_ui->selectAllButton, &QPushButton::clicked, m_ui->filesList, &TorrentContentWidget::checkAll);
     connect(m_ui->selectNoneButton, &QPushButton::clicked, m_ui->filesList, &TorrentContentWidget::checkNone);
+    connect(m_ui->selectMatchButton, &QPushButton::clicked, m_ui->filesList, &TorrentContentWidget::selectMatches);
+    connect(m_ui->checkSelectionButton, &QPushButton::clicked, m_ui->filesList, &TorrentContentWidget::checkSelection);
+    connect(m_ui->uncheckSelectionButton, &QPushButton::clicked, m_ui->filesList, &TorrentContentWidget::uncheckSelection);
     connect(m_ui->listWebSeeds, &QWidget::customContextMenuRequested, this, &PropertiesWidget::displayWebSeedListMenu);
     connect(m_ui->stackedProperties, &QStackedWidget::currentChanged, this, &PropertiesWidget::loadDynamicData);
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::torrentSavePathChanged, this, &PropertiesWidget::updateSavePath);

--- a/src/gui/properties/propertieswidget.ui
+++ b/src/gui/properties/propertieswidget.ui
@@ -1102,6 +1102,27 @@
           </widget>
          </item>
          <item>
+          <widget class="QPushButton" name="checkSelectionButton">
+           <property name="text">
+            <string>Select Selected</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="uncheckSelectionButton">
+           <property name="text">
+            <string>Deselect Selected</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="selectMatchButton">
+           <property name="text">
+            <string>Select Matches</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <spacer name="horizontalSpacer">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>

--- a/src/gui/torrentcontentwidget.h
+++ b/src/gui/torrentcontentwidget.h
@@ -96,6 +96,9 @@ public:
 
     void checkAll();
     void checkNone();
+    void checkSelection();
+    void uncheckSelection();
+    void selectMatches();
 
 signals:
     void stateChanged();


### PR DESCRIPTION
This makes it easy to mark a subset of a deep directory structure of files for download.

If I want to download all the qBittorrent source code apart from the header files:

| Filter by `*.h` and select all that match | Mark them to not be downloaded |
|-|-|
| ![Screenshot from 2024-04-14 00-44-43](https://github.com/qbittorrent/qBittorrent/assets/334272/1dbacf85-4e5d-468d-9408-1330037a98ac) | ![Screenshot from 2024-04-14 00-44-57](https://github.com/qbittorrent/qBittorrent/assets/334272/5ab84b19-7102-467c-a614-12490212a97d) |

This needs some UX work to avoid confusion:
Select All/None mark files for download.
"Select Selected" does the same for the selected items.
"Check all" would imply verifying (rechecking) the downloads.
Maybe "Highlight Matched" and "Select Highlighted" would be better.
Maybe "Select All" should become "Mark All".