### PR TITLE
Add date column to the built-in search engine

### DIFF
--- a/src/base/search/searchhandler.cpp
+++ b/src/base/search/searchhandler.cpp
@@ -55,6 +55,7 @@ namespace
         PL_LEECHS,
         PL_ENGINE_URL,
         PL_DESC_LINK,
+        PL_PUB_DATE,
         NB_PLUGIN_COLUMNS
     };
 }
@@ -176,7 +177,7 @@ bool SearchHandler::parseSearchResult(const QStringView line, SearchResult &sear
     const QList<QStringView> parts = line.split(u'|');
     const int nbFields = parts.size();
 
-    if (nbFields < (NB_PLUGIN_COLUMNS - 1)) return false; // -1 because desc_link is optional
+    if (nbFields <= PL_ENGINE_URL) return false; // Anything after ENGINE_URL is optional
 
     searchResult = SearchResult();
     searchResult.fileUrl = parts.at(PL_DL_LINK).trimmed().toString(); // download URL
@@ -194,8 +195,16 @@ bool SearchHandler::parseSearchResult(const QStringView line, SearchResult &sear
         searchResult.nbLeechers = -1;
 
     searchResult.siteUrl = parts.at(PL_ENGINE_URL).trimmed().toString(); // Search site URL
-    if (nbFields == NB_PLUGIN_COLUMNS)
+
+    if (nbFields > PL_DESC_LINK)
         searchResult.descrLink = parts.at(PL_DESC_LINK).trimmed().toString(); // Description Link
+
+    if (nbFields > PL_PUB_DATE)
+    {
+        const qint64 secs = parts.at(PL_PUB_DATE).trimmed().toLongLong(&ok);
+        if (ok && (secs > 0))
+            searchResult.pubDate = QDateTime::fromSecsSinceEpoch(secs); // Date
+    }
 
     return true;
 }

--- a/src/base/search/searchhandler.h
+++ b/src/base/search/searchhandler.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include <QByteArray>
+#include <QDateTime>
 #include <QList>
 #include <QObject>
 #include <QString>
@@ -47,6 +48,7 @@ struct SearchResult
     qlonglong nbLeechers = 0;
     QString siteUrl;
     QString descrLink;
+    QDateTime pubDate;
 };
 
 class SearchPluginManager;

--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -71,6 +71,7 @@ SearchJobWidget::SearchJobWidget(SearchHandler *searchHandler, IGUIApplication *
     m_searchListModel->setHeaderData(SearchSortModel::SEEDS, Qt::Horizontal, tr("Seeders", "i.e: Number of full sources"));
     m_searchListModel->setHeaderData(SearchSortModel::LEECHES, Qt::Horizontal, tr("Leechers", "i.e: Number of partial sources"));
     m_searchListModel->setHeaderData(SearchSortModel::ENGINE_URL, Qt::Horizontal, tr("Search engine"));
+    m_searchListModel->setHeaderData(SearchSortModel::PUB_DATE, Qt::Horizontal, tr("Published On"));
     // Set columns text alignment
     m_searchListModel->setHeaderData(SearchSortModel::SIZE, Qt::Horizontal, QVariant(Qt::AlignRight | Qt::AlignVCenter), Qt::TextAlignmentRole);
     m_searchListModel->setHeaderData(SearchSortModel::SEEDS, Qt::Horizontal, QVariant(Qt::AlignRight | Qt::AlignVCenter), Qt::TextAlignmentRole);
@@ -533,6 +534,7 @@ void SearchJobWidget::appendSearchResults(const QVector<SearchResult> &results)
         setModelData(SearchSortModel::SIZE, Utils::Misc::friendlyUnit(result.fileSize), result.fileSize, (Qt::AlignRight | Qt::AlignVCenter));
         setModelData(SearchSortModel::SEEDS, QString::number(result.nbSeeders), result.nbSeeders, (Qt::AlignRight | Qt::AlignVCenter));
         setModelData(SearchSortModel::LEECHES, QString::number(result.nbLeechers), result.nbLeechers, (Qt::AlignRight | Qt::AlignVCenter));
+        setModelData(SearchSortModel::PUB_DATE, QLocale().toString(result.pubDate.toLocalTime(), QLocale::ShortFormat), result.pubDate);
     }
 
     updateResultsCount();

--- a/src/gui/search/searchsortmodel.h
+++ b/src/gui/search/searchsortmodel.h
@@ -45,6 +45,7 @@ public:
         SEEDS,
         LEECHES,
         ENGINE_URL,
+        PUB_DATE,
         DL_LINK,
         DESC_LINK,
         NB_SEARCH_COLUMNS

--- a/src/searchengine/nova3/novaprinter.py
+++ b/src/searchengine/nova3/novaprinter.py
@@ -1,4 +1,4 @@
-#VERSION: 1.47
+#VERSION: 1.48
 
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/src/searchengine/nova3/novaprinter.py
+++ b/src/searchengine/nova3/novaprinter.py
@@ -26,12 +26,16 @@
 
 
 def prettyPrinter(dictionary):
-    dictionary['size'] = anySizeToBytes(dictionary['size'])
-    outtext = "|".join((dictionary["link"], dictionary["name"].replace("|", " "),
-                        str(dictionary["size"]), str(dictionary["seeds"]),
-                        str(dictionary["leech"]), dictionary["engine_url"]))
-    if 'desc_link' in dictionary:
-        outtext = "|".join((outtext, dictionary["desc_link"]))
+    outtext = "|".join((
+        dictionary["link"],
+        dictionary["name"].replace("|", " "),
+        str(anySizeToBytes(dictionary['size'])),
+        str(dictionary["seeds"]),
+        str(dictionary["leech"]),
+        dictionary["engine_url"],
+        dictionary.get("desc_link", ""),  # Optional
+        str(dictionary.get("pub_date", -1)),  # Optional
+    ))
 
     # fd 1 is stdout
     with open(1, 'w', encoding='utf-8', closefd=False) as utf8stdout:

--- a/src/webui/api/searchcontroller.cpp
+++ b/src/webui/api/searchcontroller.cpp
@@ -39,6 +39,7 @@
 #include "base/global.h"
 #include "base/logger.h"
 #include "base/search/searchhandler.h"
+#include "base/utils/datetime.h"
 #include "base/utils/foreignapps.h"
 #include "base/utils/random.h"
 #include "base/utils/string.h"
@@ -301,6 +302,7 @@ int SearchController::generateSearchId() const
  *   - "nbLeechers"
  *   - "siteUrl"
  *   - "descrLink"
+ *   - "pubDate"
  */
 QJsonObject SearchController::getResults(const QList<SearchResult> &searchResults, const bool isSearchActive, const int totalResults) const
 {
@@ -315,7 +317,8 @@ QJsonObject SearchController::getResults(const QList<SearchResult> &searchResult
             {u"nbSeeders"_s, searchResult.nbSeeders},
             {u"nbLeechers"_s, searchResult.nbLeechers},
             {u"siteUrl"_s, searchResult.siteUrl},
-            {u"descrLink"_s, searchResult.descrLink}
+            {u"descrLink"_s, searchResult.descrLink},
+            {u"pubDate"_s, Utils::DateTime::toSecsSinceEpoch(searchResult.pubDate)}
         };
     }
 

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1684,6 +1684,7 @@ window.qBittorrent.DynamicTable = (function() {
             this.newColumn('nbSeeders', '', 'QBT_TR(Seeders)QBT_TR[CONTEXT=SearchResultsTable]', 100, true);
             this.newColumn('nbLeechers', '', 'QBT_TR(Leechers)QBT_TR[CONTEXT=SearchResultsTable]', 100, true);
             this.newColumn('siteUrl', '', 'QBT_TR(Search engine)QBT_TR[CONTEXT=SearchResultsTable]', 250, true);
+            this.newColumn('pubDate', '', 'QBT_TR(Published On)QBT_TR[CONTEXT=SearchResultsTable]', 200, true);
 
             this.initColumnsFunctions();
         },
@@ -1700,10 +1701,17 @@ window.qBittorrent.DynamicTable = (function() {
                 td.set('text', formattedValue);
                 td.set('title', formattedValue);
             };
+            const displayDate = function(td, row) {
+                const value = this.getRowValue(row) * 1000;
+                const formattedValue = (isNaN(value) || (value <= 0)) ? "" : (new Date(value).toLocaleString());
+                td.set('text', formattedValue);
+                td.set('title', formattedValue);
+            };
 
             this.columns['fileSize'].updateTd = displaySize;
             this.columns['nbSeeders'].updateTd = displayNum;
             this.columns['nbLeechers'].updateTd = displayNum;
+            this.columns['pubDate'].updateTd = displayDate;
         },
 
         getFilteredAndSortedRows: function() {

--- a/src/webui/www/private/views/search.html
+++ b/src/webui/www/private/views/search.html
@@ -961,6 +961,7 @@
                                     nbLeechers: result.nbLeechers,
                                     nbSeeders: result.nbSeeders,
                                     siteUrl: result.siteUrl,
+                                    pubDate: result.pubDate,
                                 };
 
                                 newRows.push(row);


### PR DESCRIPTION
This PR adds a date column to the built-in search engine to show when a torrent was published/uploaded on the torrent site.

When a plugin wants to show a date, it can now add a `date` entry to its result dict. The value format is a unix timestamp (an integer representing seconds since epoch).

This commit adds the date column to both the Qt UI and the WebUI and updates the nova3 prettyPrinter.

Plugins with no date support will keep working.

If this PR is accepted, I will send a PR to the plugins repo to update as many plugins as I can! Here's the updated thepiratebay for testing the PR: https://github.com/ducalex/qbittorrent-search-plugins/blob/ducalex/add-date-field-tpb/nova3/engines/piratebay.py

Related open issues: #1463


Still to do are translations (a single additional string "Date"), am I expected to update all translations?

The guidelines suggest I include a screenshot (desktop top, webui bottom):
![Untitled](https://github.com/qbittorrent/qBittorrent/assets/13711380/66abf519-fc5b-4969-a304-367aa80d1377)
