### PR TITLE
Adjust tracker tier when adding additional trackers

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -107,6 +107,7 @@ add_library(qbt_base STATIC
     utils/io.h
     utils/misc.h
     utils/net.h
+    utils/number.h
     utils/os.h
     utils/password.h
     utils/random.h
@@ -201,6 +202,7 @@ add_library(qbt_base STATIC
     utils/io.cpp
     utils/misc.cpp
     utils/net.cpp
+    utils/number.cpp
     utils/os.cpp
     utils/password.cpp
     utils/random.cpp

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -731,7 +731,7 @@ namespace BitTorrent
         const bool m_wasPexEnabled = m_isPeXEnabled;
 
         int m_numResumeData = 0;
-        QVector<TrackerEntry> m_additionalTrackerList;
+        QVector<TrackerEntry> m_additionalTrackerEntries;
         QVector<QRegularExpression> m_excludedFileNamesRegExpList;
 
         // Statistics

--- a/src/base/utils/number.cpp
+++ b/src/base/utils/number.cpp
@@ -1,0 +1,43 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2024  Mike Tzou (Chocobo1)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include "number.h"
+
+#include <algorithm>
+#include <limits>
+
+int Utils::Number::clampingAdd(const int num1, const int num2)
+{
+    static_assert(sizeof(int64_t) > sizeof(int));
+
+    const int64_t intMin = std::numeric_limits<int>::min();
+    const int64_t intMax = std::numeric_limits<int>::max();
+    const int64_t sumResult = static_cast<int64_t>(num1) + num2;
+    const int64_t clampedValue = std::clamp(sumResult, intMin, intMax);
+    return static_cast<int>(clampedValue);
+}

--- a/src/base/utils/number.h
+++ b/src/base/utils/number.h
@@ -1,0 +1,35 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2024  Mike Tzou (Chocobo1)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+namespace Utils::Number
+{
+    // math addition that the result will never overflow/underflow
+    int clampingAdd(int num1, int num2);
+}

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -3069,7 +3069,7 @@ Disable encryption: Only connect to peers without protocol encryption</string>
             <item>
              <widget class="QGroupBox" name="checkEnableAddTrackers">
               <property name="title">
-               <string>A&amp;utomatically add these trackers to new downloads:</string>
+               <string>A&amp;utomatically append these trackers to new downloads:</string>
               </property>
               <property name="checkable">
                <bool>true</bool>

--- a/src/gui/trackersadditiondialog.cpp
+++ b/src/gui/trackersadditiondialog.cpp
@@ -36,9 +36,11 @@
 
 #include "base/bittorrent/torrent.h"
 #include "base/bittorrent/trackerentry.h"
+#include "base/bittorrent/trackerentrystatus.h"
 #include "base/global.h"
 #include "base/net/downloadmanager.h"
 #include "base/preferences.h"
+#include "base/utils/number.h"
 #include "gui/uithememanager.h"
 #include "ui_trackersadditiondialog.h"
 
@@ -74,7 +76,13 @@ TrackersAdditionDialog::~TrackersAdditionDialog()
 
 void TrackersAdditionDialog::onAccepted() const
 {
-    const QVector<BitTorrent::TrackerEntry> entries = BitTorrent::parseTrackerEntries(m_ui->textEditTrackersList->toPlainText());
+    const QVector<BitTorrent::TrackerEntryStatus> currentTrackers = m_torrent->trackers();
+    const int baseTier = !currentTrackers.isEmpty() ? (currentTrackers.last().tier + 1) : 0;
+
+    QVector<BitTorrent::TrackerEntry> entries = BitTorrent::parseTrackerEntries(m_ui->textEditTrackersList->toPlainText());
+    for (BitTorrent::TrackerEntry &entry : entries)
+        entry.tier = Utils::Number::clampingAdd(entry.tier, baseTier);
+
     m_torrent->addTrackers(entries);
 }
 

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -718,7 +718,7 @@
     <fieldset class="settings">
         <legend>
             <input type="checkbox" id="add_trackers_checkbox" onclick="qBittorrent.Preferences.updateAddTrackersEnabled();" />
-            <label for="add_trackers_checkbox">QBT_TR(Automatically add these trackers to new downloads:)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <label for="add_trackers_checkbox">QBT_TR(Automatically append these trackers to new downloads:)QBT_TR[CONTEXT=OptionsDialog]</label>
         </legend>
         <textarea id="add_trackers_textarea" rows="5" cols="70"></textarea>
     </fieldset>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,7 @@ set(testFiles
     testutilsdatetime.cpp
     testutilsgzip.cpp
     testutilsio.cpp
+    testutilsnumber.cpp
     testutilsstring.cpp
     testutilsversion.cpp
 )

--- a/test/testutilsnumber.cpp
+++ b/test/testutilsnumber.cpp
@@ -1,0 +1,63 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2024  Mike Tzou (Chocobo1)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include <limits>
+
+#include <QTest>
+
+#include "base/utils/number.h"
+
+class TestUtilsNumber final : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(TestUtilsNumber)
+
+public:
+    TestUtilsNumber() = default;
+
+private slots:
+    void testClampingAdd() const
+    {
+        const int intMin = std::numeric_limits<int>::min();
+        const int intMax = std::numeric_limits<int>::max();
+
+        QCOMPARE(Utils::Number::clampingAdd(1, 2), 3);
+        QCOMPARE(Utils::Number::clampingAdd(-1, -2), -3);
+
+        QCOMPARE(Utils::Number::clampingAdd((intMax - 1), 1), intMax);
+        QCOMPARE(Utils::Number::clampingAdd(intMax, 1), intMax);
+        QCOMPARE(Utils::Number::clampingAdd(intMax, intMax), intMax);
+
+        QCOMPARE(Utils::Number::clampingAdd((intMin + 1), -1), intMin);
+        QCOMPARE(Utils::Number::clampingAdd(intMin, -1), intMin);
+        QCOMPARE(Utils::Number::clampingAdd(intMin, intMin), intMin);
+    }
+};
+
+QTEST_APPLESS_MAIN(TestUtilsNumber)
+#include "testutilsnumber.moc"


### PR DESCRIPTION
* On torrent add, tiers of additional trackers will be adjusted after the highest tier of the existing trackers.
* "Add trackers" button will adjust tiers of all newly added trackers after existing trackers.

Closes #20102.
