### PR TITLE
Add ability to pause/resume entire session

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -430,6 +430,8 @@ namespace BitTorrent
         virtual void setResumeDataStorageType(ResumeDataStorageType type) = 0;
         virtual bool isMergeTrackersEnabled() const = 0;
         virtual void setMergeTrackersEnabled(bool enabled) = 0;
+        virtual bool isStartPaused() const = 0;
+        virtual void setStartPaused(bool value) = 0;
 
         virtual bool isRestored() const = 0;
 

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -433,6 +433,10 @@ namespace BitTorrent
 
         virtual bool isRestored() const = 0;
 
+        virtual bool isPaused() const = 0;
+        virtual void pause() = 0;
+        virtual void resume() = 0;
+
         virtual Torrent *getTorrent(const TorrentID &id) const = 0;
         virtual Torrent *findTorrent(const InfoHash &infoHash) const = 0;
         virtual QVector<Torrent *> torrents() const = 0;
@@ -466,6 +470,8 @@ namespace BitTorrent
         void loadTorrentFailed(const QString &error);
         void metadataDownloaded(const TorrentInfo &info);
         void restored();
+        void paused();
+        void resumed();
         void speedLimitModeChanged(bool alternative);
         void statsUpdated();
         void subcategoriesSupportChanged();

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -4412,6 +4412,9 @@ void SessionImpl::setQueueingSystemEnabled(const bool enabled)
             m_torrentsQueueChanged = true;
         else
             removeTorrentsQueue();
+
+        for (TorrentImpl *torrent : asConst(m_torrents))
+            torrent->handleQueueingModeChanged();
     }
 }
 

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -1540,7 +1540,9 @@ void SessionImpl::endStartup(ResumeSessionContext *context)
     context->deleteLater();
     connect(context, &QObject::destroyed, this, [this]
     {
-        m_nativeSession->resume();
+        if (!m_isPaused)
+            m_nativeSession->resume();
+
         if (m_refreshEnqueued)
             m_refreshEnqueued = false;
         else
@@ -3921,6 +3923,35 @@ QStringList SessionImpl::bannedIPs() const
 bool SessionImpl::isRestored() const
 {
     return m_isRestored;
+}
+
+bool SessionImpl::isPaused() const
+{
+    return m_isPaused;
+}
+
+void SessionImpl::pause()
+{
+    if (!m_isPaused)
+    {
+        if (isRestored())
+            m_nativeSession->pause();
+
+        m_isPaused = true;
+        emit paused();
+    }
+}
+
+void SessionImpl::resume()
+{
+    if (m_isPaused)
+    {
+        if (isRestored())
+            m_nativeSession->resume();
+
+        m_isPaused = false;
+        emit resumed();
+    }
 }
 
 int SessionImpl::maxConnectionsPerTorrent() const

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -522,6 +522,7 @@ SessionImpl::SessionImpl(QObject *parent)
     , m_I2POutboundQuantity {BITTORRENT_SESSION_KEY(u"I2P/OutboundQuantity"_s), 3}
     , m_I2PInboundLength {BITTORRENT_SESSION_KEY(u"I2P/InboundLength"_s), 3}
     , m_I2POutboundLength {BITTORRENT_SESSION_KEY(u"I2P/OutboundLength"_s), 3}
+    , m_startPaused {BITTORRENT_SESSION_KEY(u"StartPaused"_s)}
     , m_seedingLimitTimer {new QTimer(this)}
     , m_resumeDataTimer {new QTimer(this)}
     , m_ioThread {new QThread}
@@ -3913,6 +3914,16 @@ bool SessionImpl::isMergeTrackersEnabled() const
 void SessionImpl::setMergeTrackersEnabled(const bool enabled)
 {
     m_isMergeTrackersEnabled = enabled;
+}
+
+bool SessionImpl::isStartPaused() const
+{
+    return m_startPaused.get(false);
+}
+
+void SessionImpl::setStartPaused(const bool value)
+{
+    m_startPaused = value;
 }
 
 QStringList SessionImpl::bannedIPs() const

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -407,6 +407,8 @@ namespace BitTorrent
         void setResumeDataStorageType(ResumeDataStorageType type) override;
         bool isMergeTrackersEnabled() const override;
         void setMergeTrackersEnabled(bool enabled) override;
+        bool isStartPaused() const override;
+        void setStartPaused(bool value) override;
 
         bool isRestored() const override;
 
@@ -726,9 +728,10 @@ namespace BitTorrent
         CachedSettingValue<int> m_I2POutboundQuantity;
         CachedSettingValue<int> m_I2PInboundLength;
         CachedSettingValue<int> m_I2POutboundLength;
+        SettingValue<bool> m_startPaused;
 
         bool m_isRestored = false;
-        bool m_isPaused = false;
+        bool m_isPaused = isStartPaused();
 
         // Order is important. This needs to be declared after its CachedSettingsValue
         // counterpart, because it uses it for initialization in the constructor

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -410,6 +410,10 @@ namespace BitTorrent
 
         bool isRestored() const override;
 
+        bool isPaused() const override;
+        void pause() override;
+        void resume() override;
+
         Torrent *getTorrent(const TorrentID &id) const override;
         Torrent *findTorrent(const InfoHash &infoHash) const override;
         QVector<Torrent *> torrents() const override;
@@ -724,6 +728,7 @@ namespace BitTorrent
         CachedSettingValue<int> m_I2POutboundLength;
 
         bool m_isRestored = false;
+        bool m_isPaused = false;
 
         // Order is important. This needs to be declared after its CachedSettingsValue
         // counterpart, because it uses it for initialization in the constructor

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -999,6 +999,9 @@ bool TorrentImpl::isStopped() const
 
 bool TorrentImpl::isQueued() const
 {
+    if (!m_session->isQueueingSystemEnabled())
+        return false;
+
     // Torrent is Queued if it isn't in Stopped state but paused internally
     return (!isStopped()
             && (m_nativeStatus.flags & lt::torrent_flags::auto_managed)
@@ -1153,7 +1156,7 @@ void TorrentImpl::updateState()
     {
         if (isStopped())
             m_state = TorrentState::StoppedDownloading;
-        else if (m_session->isQueueingSystemEnabled() && isQueued())
+        else if (isQueued())
             m_state = TorrentState::QueuedDownloading;
         else
             m_state = isForced() ? TorrentState::ForcedDownloadingMetadata : TorrentState::DownloadingMetadata;
@@ -1167,7 +1170,7 @@ void TorrentImpl::updateState()
     {
         if (isStopped())
             m_state = TorrentState::StoppedUploading;
-        else if (m_session->isQueueingSystemEnabled() && isQueued())
+        else if (isQueued())
             m_state = TorrentState::QueuedUploading;
         else if (isForced())
             m_state = TorrentState::ForcedUploading;
@@ -1180,7 +1183,7 @@ void TorrentImpl::updateState()
     {
         if (isStopped())
             m_state = TorrentState::StoppedDownloading;
-        else if (m_session->isQueueingSystemEnabled() && isQueued())
+        else if (isQueued())
             m_state = TorrentState::QueuedDownloading;
         else if (isForced())
             m_state = TorrentState::ForcedDownloading;
@@ -1951,6 +1954,11 @@ void TorrentImpl::renameFile(const int index, const Path &path)
 void TorrentImpl::handleStateUpdate(const lt::torrent_status &nativeStatus)
 {
     updateStatus(nativeStatus);
+}
+
+void TorrentImpl::handleQueueingModeChanged()
+{
+    updateState();
 }
 
 void TorrentImpl::handleMoveStorageJobFinished(const Path &path, const MoveStorageContext context, const bool hasOutstandingJob)

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -269,6 +269,7 @@ namespace BitTorrent
 
         void handleAlert(const lt::alert *a);
         void handleStateUpdate(const lt::torrent_status &nativeStatus);
+        void handleQueueingModeChanged();
         void handleCategoryOptionsChanged();
         void handleAppendExtensionToggled();
         void handleUnwantedFolderToggled();

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -1397,19 +1397,6 @@ void Preferences::setConfirmRemoveAllTags(const bool enabled)
     setValue(u"Preferences/Advanced/confirmRemoveAllTags"_s, enabled);
 }
 
-bool Preferences::confirmPauseAndResumeAll() const
-{
-    return value(u"GUI/ConfirmActions/PauseAndResumeAllTorrents"_s, true);
-}
-
-void Preferences::setConfirmPauseAndResumeAll(const bool enabled)
-{
-    if (enabled == confirmPauseAndResumeAll())
-        return;
-
-    setValue(u"GUI/ConfirmActions/PauseAndResumeAllTorrents"_s, enabled);
-}
-
 bool Preferences::confirmMergeTrackers() const
 {
     return value(u"GUI/ConfirmActions/MergeTrackers"_s, true);

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -305,8 +305,6 @@ public:
     void setConfirmTorrentRecheck(bool enabled);
     bool confirmRemoveAllTags() const;
     void setConfirmRemoveAllTags(bool enabled);
-    bool confirmPauseAndResumeAll() const;
-    void setConfirmPauseAndResumeAll(bool enabled);
     bool confirmMergeTrackers() const;
     void setConfirmMergeTrackers(bool enabled);
     bool confirmRemoveTrackerFromAllTorrents() const;

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2016 qBittorrent project
+ * Copyright (C) 2016-2024 qBittorrent project
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -105,6 +105,7 @@ namespace
         ENABLE_MARK_OF_THE_WEB,
 #endif // Q_OS_MACOS || Q_OS_WIN
         PYTHON_EXECUTABLE_PATH,
+        START_SESSION_PAUSED,
 
         // libtorrent section
         LIBTORRENT_HEADER,
@@ -331,6 +332,8 @@ void AdvancedSettings::saveAdvancedSettings() const
 #endif // Q_OS_MACOS || Q_OS_WIN
     // Python executable path
     pref->setPythonExecutablePath(Path(m_pythonExecutablePath.text().trimmed()));
+    // Start session paused
+    session->setStartPaused(m_checkBoxStartSessionPaused.isChecked());
     // Choking algorithm
     session->setChokingAlgorithm(m_comboBoxChokingAlgorithm.currentData().value<BitTorrent::ChokingAlgorithm>());
     // Seed choking algorithm
@@ -843,6 +846,9 @@ void AdvancedSettings::loadAdvancedSettings()
     m_pythonExecutablePath.setPlaceholderText(tr("(Auto detect if empty)"));
     m_pythonExecutablePath.setText(pref->getPythonExecutablePath().toString());
     addRow(PYTHON_EXECUTABLE_PATH, tr("Python executable path (may require restart)"), &m_pythonExecutablePath);
+    // Start session paused
+    m_checkBoxStartSessionPaused.setChecked(session->isStartPaused());
+    addRow(START_SESSION_PAUSED, tr("Start session in paused state"), &m_checkBoxStartSessionPaused);
     // Choking algorithm
     m_comboBoxChokingAlgorithm.addItem(tr("Fixed slots"), QVariant::fromValue(BitTorrent::ChokingAlgorithm::FixedSlots));
     m_comboBoxChokingAlgorithm.addItem(tr("Upload rate based"), QVariant::fromValue(BitTorrent::ChokingAlgorithm::RateBased));

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015 qBittorrent project
+ * Copyright (C) 2015-2024 qBittorrent project
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -79,7 +79,7 @@ private:
               m_checkBoxProgramNotifications, m_checkBoxTorrentAddedNotifications, m_checkBoxReannounceWhenAddressChanged, m_checkBoxTrackerFavicon, m_checkBoxTrackerStatus,
               m_checkBoxTrackerPortForwarding, m_checkBoxConfirmTorrentRecheck, m_checkBoxConfirmRemoveAllTags, m_checkBoxAnnounceAllTrackers, m_checkBoxAnnounceAllTiers,
               m_checkBoxMultiConnectionsPerIp, m_checkBoxValidateHTTPSTrackerCertificate, m_checkBoxSSRFMitigation, m_checkBoxBlockPeersOnPrivilegedPorts, m_checkBoxPieceExtentAffinity,
-              m_checkBoxSuggestMode, m_checkBoxSpeedWidgetEnabled, m_checkBoxIDNSupport, m_checkBoxConfirmRemoveTrackerFromAllTorrents;
+              m_checkBoxSuggestMode, m_checkBoxSpeedWidgetEnabled, m_checkBoxIDNSupport, m_checkBoxConfirmRemoveTrackerFromAllTorrents, m_checkBoxStartSessionPaused;
     QComboBox m_comboBoxInterface, m_comboBoxInterfaceAddress, m_comboBoxDiskIOReadMode, m_comboBoxDiskIOWriteMode, m_comboBoxUtpMixedMode, m_comboBoxChokingAlgorithm,
               m_comboBoxSeedChokingAlgorithm, m_comboBoxResumeDataStorage;
     QLineEdit m_lineEditAppInstanceName, m_pythonExecutablePath, m_lineEditAnnounceIP, m_lineEditDHTBootstrapNodes;

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -185,12 +185,14 @@ MainWindow::MainWindow(IGUIApplication *app, const WindowState initialState, con
         m_ui->actionPauseSession->setVisible(false);
         m_ui->actionResumeSession->setVisible(true);
         refreshWindowTitle();
+        refreshTrayIconTooltip();
     });
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::resumed, this, [this]
     {
         m_ui->actionPauseSession->setVisible(true);
         m_ui->actionResumeSession->setVisible(false);
         refreshWindowTitle();
+        refreshTrayIconTooltip();
     });
 
     auto *lockMenu = new QMenu(m_ui->menuView);
@@ -1515,10 +1517,7 @@ void MainWindow::loadSessionStats()
 #ifdef Q_OS_MACOS
     m_badger->updateSpeed(status.payloadDownloadRate, status.payloadUploadRate);
 #else
-    const auto toolTip = u"%1\n%2"_s.arg(
-        tr("DL speed: %1", "e.g: Download speed: 10 KiB/s").arg(m_downloadRate)
-        , tr("UP speed: %1", "e.g: Upload speed: 10 KiB/s").arg(m_uploadRate));
-    app()->desktopIntegration()->setToolTip(toolTip); // tray icon
+    refreshTrayIconTooltip();
 #endif  // Q_OS_MACOS
 
     refreshWindowTitle();
@@ -1910,6 +1909,22 @@ void MainWindow::refreshWindowTitle()
         {
             setWindowTitle(m_windowTitle);
         }
+    }
+}
+
+void MainWindow::refreshTrayIconTooltip()
+{
+    const auto *btSession = BitTorrent::Session::instance();
+    if (!btSession->isPaused())
+    {
+        const auto toolTip = u"%1\n%2"_s.arg(
+                tr("DL speed: %1", "e.g: Download speed: 10 KiB/s").arg(m_downloadRate)
+                , tr("UP speed: %1", "e.g: Upload speed: 10 KiB/s").arg(m_uploadRate));
+        app()->desktopIntegration()->setToolTip(toolTip);
+    }
+    else
+    {
+        app()->desktopIntegration()->setToolTip(tr("Paused"));
     }
 }
 

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -204,6 +204,7 @@ private:
     void showFiltersSidebar(bool show);
     void applyTransferListFilter();
     void refreshWindowTitle();
+    void refreshTrayIconTooltip();
 
     Ui::MainWindow *m_ui = nullptr;
 

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -127,7 +127,7 @@ private slots:
     void displayRSSTab();
     void displayExecutionLogTab();
     void toggleFocusBetweenLineEdits();
-    void reloadSessionStats();
+    void loadSessionStats();
     void reloadTorrentStats(const QVector<BitTorrent::Torrent *> &torrents);
     void loadPreferences();
     void optionsSaved();
@@ -203,14 +203,18 @@ private:
     void showStatusBar(bool show);
     void showFiltersSidebar(bool show);
     void applyTransferListFilter();
+    void refreshWindowTitle();
 
     Ui::MainWindow *m_ui = nullptr;
 
-    QFileSystemWatcher *m_executableWatcher = nullptr;
-    // GUI related
     QString m_windowTitle;
+    QString m_downloadRate;
+    QString m_uploadRate;
     bool m_posInitialized = false;
     bool m_neverShown = true;
+
+    QFileSystemWatcher *m_executableWatcher = nullptr;
+    // GUI related
     QPointer<QTabWidget> m_tabs;
     QPointer<StatusBar> m_statusBar;
     QPointer<OptionsDialog> m_options;

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -44,14 +44,15 @@
     </property>
     <addaction name="actionStart"/>
     <addaction name="actionStop"/>
-    <addaction name="actionStartAll"/>
-    <addaction name="actionStopAll"/>
     <addaction name="separator"/>
     <addaction name="actionDelete"/>
     <addaction name="actionTopQueuePos"/>
     <addaction name="actionIncreaseQueuePos"/>
     <addaction name="actionDecreaseQueuePos"/>
     <addaction name="actionBottomQueuePos"/>
+    <addaction name="separator"/>
+    <addaction name="actionPauseSession"/>
+    <addaction name="actionResumeSession"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
     <property name="title">
@@ -196,14 +197,14 @@
     <string>Sto&amp;p</string>
    </property>
   </action>
-  <action name="actionStartAll">
+  <action name="actionResumeSession">
    <property name="text">
-    <string>Star&amp;t All</string>
+    <string>&amp;Resume Session</string>
    </property>
   </action>
-  <action name="actionStopAll">
+  <action name="actionPauseSession">
    <property name="text">
-    <string>&amp;Stop All</string>
+    <string>Pau&amp;se Session</string>
    </property>
   </action>
   <action name="actionDelete">

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -281,7 +281,6 @@ void OptionsDialog::loadBehaviorTabOptions()
     m_ui->checkShowSplash->setChecked(!pref->isSplashScreenDisabled());
     m_ui->checkProgramExitConfirm->setChecked(pref->confirmOnExit());
     m_ui->checkProgramAutoExitConfirm->setChecked(!pref->dontConfirmAutoExit());
-    m_ui->checkConfirmStopAndStartAll->setChecked(pref->confirmPauseAndResumeAll());
 
     m_ui->windowStateComboBox->addItem(tr("Normal"), QVariant::fromValue(WindowState::Normal));
     m_ui->windowStateComboBox->addItem(tr("Minimized"), QVariant::fromValue(WindowState::Minimized));
@@ -381,7 +380,6 @@ void OptionsDialog::loadBehaviorTabOptions()
     connect(m_ui->checkShowSplash, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkProgramExitConfirm, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkProgramAutoExitConfirm, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
-    connect(m_ui->checkConfirmStopAndStartAll, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkShowSystray, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkMinimizeToSysTray, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkCloseToSystray, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
@@ -464,7 +462,6 @@ void OptionsDialog::saveBehaviorTabOptions() const
     pref->setSplashScreenDisabled(isSplashScreenDisabled());
     pref->setConfirmOnExit(m_ui->checkProgramExitConfirm->isChecked());
     pref->setDontConfirmAutoExit(!m_ui->checkProgramAutoExitConfirm->isChecked());
-    pref->setConfirmPauseAndResumeAll(m_ui->checkConfirmStopAndStartAll->isChecked());
 
 #ifdef Q_OS_WIN
     pref->setWinStartup(WinStartup());

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -227,19 +227,6 @@
                 </widget>
                </item>
                <item>
-                <widget class="QCheckBox" name="checkConfirmStopAndStartAll">
-                 <property name="toolTip">
-                  <string>Shows a confirmation dialog upon pausing/starting all the torrents</string>
-                 </property>
-                 <property name="text">
-                  <string>Confirm &quot;Stop/Start all&quot; actions</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item>
                 <widget class="QCheckBox" name="checkAltRowColors">
                  <property name="text">
                   <string extracomment="In table elements, every other row will have a grey background.">Use alternating row colors</string>

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -377,36 +377,14 @@ void TransferListWidget::setSelectedTorrentsLocation()
     fileDialog->open();
 }
 
-void TransferListWidget::stopAllTorrents()
+void TransferListWidget::pauseSession()
 {
-    if (Preferences::instance()->confirmPauseAndResumeAll())
-    {
-        // Show confirmation if user would really like to Stop All
-        const QMessageBox::StandardButton ret = QMessageBox::question(this, tr("Confirm stop all torrents")
-                , tr("Would you like to stop all torrents?"), (QMessageBox::Yes | QMessageBox::No));
-
-        if (ret != QMessageBox::Yes)
-            return;
-    }
-
-    for (BitTorrent::Torrent *const torrent : asConst(BitTorrent::Session::instance()->torrents()))
-        torrent->stop();
+    BitTorrent::Session::instance()->pause();
 }
 
-void TransferListWidget::startAllTorrents()
+void TransferListWidget::resumeSession()
 {
-    if (Preferences::instance()->confirmPauseAndResumeAll())
-    {
-        // Show confirmation if user would really like to Start All
-        const QMessageBox::StandardButton ret = QMessageBox::question(this, tr("Confirm start all torrents")
-                , tr("Would you like to start all torrents?"), (QMessageBox::Yes | QMessageBox::No));
-
-        if (ret != QMessageBox::Yes)
-            return;
-    }
-
-    for (BitTorrent::Torrent *const torrent : asConst(BitTorrent::Session::instance()->torrents()))
-        torrent->start();
+    BitTorrent::Session::instance()->resume();
 }
 
 void TransferListWidget::startSelectedTorrents()

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -1120,8 +1120,7 @@ void TransferListWidget::displayListMenu()
             needsStop = true;
         }
 
-        const bool queued = (BitTorrent::Session::instance()->isQueueingSystemEnabled() && torrent->isQueued());
-
+        const bool queued = torrent->isQueued();
         if (!isStopped && !rechecking && !queued)
             oneCanForceReannounce = true;
 

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -68,8 +68,8 @@ public slots:
     void removeSelectionTag(const Tag &tag);
     void clearSelectionTags();
     void setSelectedTorrentsLocation();
-    void stopAllTorrents();
-    void startAllTorrents();
+    void pauseSession();
+    void resumeSession();
     void startSelectedTorrents();
     void forceStartSelectedTorrents();
     void startVisibleTorrents();


### PR DESCRIPTION
* Replaces current unsafe `Start all` and `Stop all` actions with `Pause session` and `Resume session` (paused session preserves started/stopped states of torrents when resumed).
* Adds an option to start session in paused state.

Closes #18993.

![001](https://github.com/qbittorrent/qBittorrent/assets/5063477/80228786-952e-4c26-a08f-953500f81df7)


![003](https://github.com/qbittorrent/qBittorrent/assets/5063477/bd5b2d08-aff6-42f9-b71c-d195720a73a3)


![004](https://github.com/qbittorrent/qBittorrent/assets/5063477/aa8e56c6-8442-4e63-b2a0-df3396a19f69)


![002](https://github.com/qbittorrent/qBittorrent/assets/5063477/3d14e421-3a05-49da-b1ba-6cfa8ea013ef)
