### PR TITLE
Sanitize peer client names

### DIFF
--- a/src/base/bittorrent/peerinfo.cpp
+++ b/src/base/bittorrent/peerinfo.cpp
@@ -198,7 +198,12 @@ QString PeerInfo::I2PAddress() const
 
 QString PeerInfo::client() const
 {
-    return QString::fromStdString(m_nativeInfo.client);
+    auto client = QString::fromStdString(m_nativeInfo.client).simplified();
+
+    // remove non-printable characters
+    erase_if(client, [](const QChar &c) { return !c.isPrint(); });
+
+    return client;
 }
 
 QString PeerInfo::peerIdClient() const


### PR DESCRIPTION
Clients can send arbitrary UTF-8 strings as their client identificators. qBittorrent displays that strings as is, which could lead to unexpected results and affect GUI layout in case of junk or intentionally malicious strings.

This PR introduces basic sanitization for client strings.

* Source string is [simplified](https://doc.qt.io/qt-6/qstring.html#simplified).
* Rest non-printable characters are removed.

Fixes #20010