### PR TITLE
WebUI: Add "isPrivate" filter for 'info' API

### DIFF
--- a/src/base/torrentfilter.cpp
+++ b/src/base/torrentfilter.cpp
@@ -34,6 +34,7 @@
 const std::optional<QString> TorrentFilter::AnyCategory;
 const std::optional<TorrentIDSet> TorrentFilter::AnyID;
 const std::optional<Tag> TorrentFilter::AnyTag;
+const std::optional<isPrivate> TorrentFilter::None = std::nullopt;
 
 const TorrentFilter TorrentFilter::DownloadingTorrent(TorrentFilter::Downloading);
 const TorrentFilter TorrentFilter::SeedingTorrent(TorrentFilter::Seeding);
@@ -52,19 +53,22 @@ const TorrentFilter TorrentFilter::ErroredTorrent(TorrentFilter::Errored);
 using BitTorrent::Torrent;
 
 TorrentFilter::TorrentFilter(const Type type, const std::optional<TorrentIDSet> &idSet
-        , const std::optional<QString> &category, const std::optional<Tag> &tag)
+        , const std::optional<QString> &category, const std::optional<Tag> &tag, const std::optional<isPrivate> &isPrivate)
     : m_type {type}
     , m_category {category}
     , m_tag {tag}
     , m_idSet {idSet}
+    , m_isPrivate {isPrivate}
 {
 }
 
+
 TorrentFilter::TorrentFilter(const QString &filter, const std::optional<TorrentIDSet> &idSet
-        , const std::optional<QString> &category, const std::optional<Tag> &tag)
+        , const std::optional<QString> &category, const std::optional<Tag> &tag, bool isPrivate)
     : m_category {category}
     , m_tag {tag}
     , m_idSet {idSet}
+    , m_isPrivate {isPrivate}
 {
     setTypeByName(filter);
 }
@@ -130,6 +134,16 @@ bool TorrentFilter::setCategory(const std::optional<QString> &category)
     if (m_category != category)
     {
         m_category = category;
+        return true;
+    }
+
+    return false;
+}
+
+bool TorrentFilter::setIsPrivate(const std::optional<bool> &isPrivate)
+{
+    if (m_isPrivate != isPrivate)
+    {
         return true;
     }
 
@@ -223,4 +237,12 @@ bool TorrentFilter::matchTag(const BitTorrent::Torrent *const torrent) const
         return torrent->tags().isEmpty();
 
     return torrent->hasTag(*m_tag);
+}
+
+bool TorrentFilter::matchIsPrivate(const BitTorrent::Torrent *const torrent) const
+{
+    if (!m_isPrivate)
+        return true;
+
+    return false
 }

--- a/src/base/torrentfilter.h
+++ b/src/base/torrentfilter.h
@@ -70,6 +70,7 @@ public:
     static const std::optional<QString> AnyCategory;
     static const std::optional<TorrentIDSet> AnyID;
     static const std::optional<Tag> AnyTag;
+    static const std::optional<isPrivate> None = std::nullopt;
 
     static const TorrentFilter DownloadingTorrent;
     static const TorrentFilter SeedingTorrent;
@@ -88,16 +89,19 @@ public:
     TorrentFilter() = default;
     // category & tags: pass empty string for uncategorized / untagged torrents.
     TorrentFilter(Type type, const std::optional<TorrentIDSet> &idSet = AnyID
-            , const std::optional<QString> &category = AnyCategory, const std::optional<Tag> &tag = AnyTag);
+            , const std::optional<QString> &category = AnyCategory, const std::optional<Tag> &tag = AnyTag
+            , const std::optional<isPrivate> &isPrivate = std::nullopt); 
     TorrentFilter(const QString &filter, const std::optional<TorrentIDSet> &idSet = AnyID
-            , const std::optional<QString> &category = AnyCategory, const std::optional<Tag> &tags = AnyTag);
+            , const std::optional<QString> &category = AnyCategory, const std::optional<Tag> &tags = AnyTag
+            , const std::optional<isPrivate> &isPrivate = std::nullopt);  
+
 
     bool setType(Type type);
     bool setTypeByName(const QString &filter);
     bool setTorrentIDSet(const std::optional<TorrentIDSet> &idSet);
     bool setCategory(const std::optional<QString> &category);
     bool setTag(const std::optional<Tag> &tag);
-
+    bool setisPrivate(const std::optional<isPrivate> &isPrivate);
     bool match(const BitTorrent::Torrent *torrent) const;
 
 private:
@@ -105,9 +109,11 @@ private:
     bool matchHash(const BitTorrent::Torrent *torrent) const;
     bool matchCategory(const BitTorrent::Torrent *torrent) const;
     bool matchTag(const BitTorrent::Torrent *torrent) const;
+    bool matchIsPrivate(const BitTorrent::Torrent *torrent) const;
 
     Type m_type {All};
     std::optional<QString> m_category;
     std::optional<Tag> m_tag;
     std::optional<TorrentIDSet> m_idSet;
+    std::optional<isPrivate> m_isPrivate;  
 };

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -163,6 +163,7 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         {KEY_TORRENT_AVAILABILITY, torrent.distributedCopies()},
         {KEY_TORRENT_REANNOUNCE, torrent.nextAnnounce()},
         {KEY_TORRENT_COMMENT, torrent.comment()},
+        {KEY_TORRENT_ISPRIVATE, torrent.isPrivate()},
 
         {KEY_TORRENT_TOTAL_SIZE, torrent.totalSize()}
     };

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -163,7 +163,7 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         {KEY_TORRENT_AVAILABILITY, torrent.distributedCopies()},
         {KEY_TORRENT_REANNOUNCE, torrent.nextAnnounce()},
         {KEY_TORRENT_COMMENT, torrent.comment()},
-        {KEY_TORRENT_ISPRIVATE, torrent.isPrivate()},
+        {KEY_TORRENT_IS_PRIVATE, torrent.isPrivate()},
 
         {KEY_TORRENT_TOTAL_SIZE, torrent.totalSize()}
     };

--- a/src/webui/api/serialize/serialize_torrent.h
+++ b/src/webui/api/serialize/serialize_torrent.h
@@ -93,5 +93,6 @@ inline const QString KEY_TORRENT_SEEDING_TIME = u"seeding_time"_s;
 inline const QString KEY_TORRENT_AVAILABILITY = u"availability"_s;
 inline const QString KEY_TORRENT_REANNOUNCE = u"reannounce"_s;
 inline const QString KEY_TORRENT_COMMENT = u"comment"_s;
+inline const QString KEY_TORRENT_ISPRIVATE = u"is_private"_s;
 
 QVariantMap serialize(const BitTorrent::Torrent &torrent);

--- a/src/webui/api/serialize/serialize_torrent.h
+++ b/src/webui/api/serialize/serialize_torrent.h
@@ -93,6 +93,6 @@ inline const QString KEY_TORRENT_SEEDING_TIME = u"seeding_time"_s;
 inline const QString KEY_TORRENT_AVAILABILITY = u"availability"_s;
 inline const QString KEY_TORRENT_REANNOUNCE = u"reannounce"_s;
 inline const QString KEY_TORRENT_COMMENT = u"comment"_s;
-inline const QString KEY_TORRENT_ISPRIVATE = u"is_private"_s;
+inline const QString KEY_TORRENT_IS_PRIVATE = u"is_private"_s;
 
 QVariantMap serialize(const BitTorrent::Torrent &torrent);

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -111,7 +111,7 @@ const QString KEY_PROP_CREATION_DATE = u"creation_date"_s;
 const QString KEY_PROP_SAVE_PATH = u"save_path"_s;
 const QString KEY_PROP_DOWNLOAD_PATH = u"download_path"_s;
 const QString KEY_PROP_COMMENT = u"comment"_s;
-const QString KEY_PROP_ISPRIVATE = u"is_private"_s;
+const QString KEY_PROP_IS_PRIVATE = u"is_private"_s;
 const QString KEY_PROP_SSL_CERTIFICATE = u"ssl_certificate"_s;
 const QString KEY_PROP_SSL_PRIVATEKEY = u"ssl_private_key"_s;
 const QString KEY_PROP_SSL_DHPARAMS = u"ssl_dh_params"_s;
@@ -470,7 +470,7 @@ void TorrentsController::propertiesAction()
         {KEY_PROP_PIECE_SIZE, torrent->pieceLength()},
         {KEY_PROP_PIECES_HAVE, torrent->piecesHave()},
         {KEY_PROP_CREATED_BY, torrent->creator()},
-        {KEY_PROP_ISPRIVATE, torrent->isPrivate()},
+        {KEY_PROP_IS_PRIVATE, torrent->isPrivate()},
         {KEY_PROP_ADDITION_DATE, Utils::DateTime::toSecsSinceEpoch(torrent->addedTime())},
         {KEY_PROP_LAST_SEEN, Utils::DateTime::toSecsSinceEpoch(torrent->lastSeenComplete())},
         {KEY_PROP_COMPLETION_DATE, Utils::DateTime::toSecsSinceEpoch(torrent->completedTime())},

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -282,10 +282,12 @@ void TorrentsController::countAction()
 //   - category (string): torrent category for filtering by it (empty string means "uncategorized"; no "category" param presented means "any category")
 //   - tag (string): torrent tag for filtering by it (empty string means "untagged"; no "tag" param presented means "any tag")
 //   - hashes (string): filter by hashes, can contain multiple hashes separated by |
+//   - isPrivate (bool): filter torrents that are from private trackers (true) or not (false). Empty means any torrent (no filtering)
 //   - sort (string): name of column for sorting by its value
 //   - reverse (bool): enable reverse sorting
 //   - limit (int): set limit number of torrents returned (if greater than 0, otherwise - unlimited)
 //   - offset (int): set offset (if less than 0 - offset from end)
+
 void TorrentsController::infoAction()
 {
     const QString filter {params()[u"filter"_s]};
@@ -296,6 +298,7 @@ void TorrentsController::infoAction()
     int limit {params()[u"limit"_s].toInt()};
     int offset {params()[u"offset"_s].toInt()};
     const QStringList hashes {params()[u"hashes"_s].split(u'|', Qt::SkipEmptyParts)};
+    const bool isPrivate {parseBool(params()[u"isPrivate"_s]).value_or(false)};
 
     std::optional<TorrentIDSet> idSet;
     if (!hashes.isEmpty())
@@ -305,7 +308,7 @@ void TorrentsController::infoAction()
             idSet->insert(BitTorrent::TorrentID::fromString(hash));
     }
 
-    const TorrentFilter torrentFilter {filter, idSet, category, tag};
+    const TorrentFilter torrentFilter {filter, idSet, category, tag, isPrivate};
     QVariantList torrentList;
     for (const BitTorrent::Torrent *torrent : asConst(BitTorrent::Session::instance()->torrents()))
     {


### PR DESCRIPTION
It is already possible to filter the "info" response by hashes, status, tag, category.
Since the "isPrivate" flag has been added in https://github.com/qbittorrent/qBittorrent/pull/20686, it would be nice if it was possible to also pre-filter the response by this attribute.


Unfortunately, this exceeds my technical skills, and I tried to the best of my abilities to identify the necessary changes and start a DRAFT. I would very much appreciate your help in finalizing this proposed change.

