### PR TITLE
Add systemd user service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     feature_option_dependent(SYSTEMD
-        "Install systemd service file. Target directory is overridable with `SYSTEMD_SERVICES_INSTALL_DIR` variable"
+        "Install systemd unit files. Target directory is overridable with `SYSTEMD_SERVICES_INSTALL_DIR` and `SYSTEMD_USER_SERVICES_INSTALL_DIR` variable"
         OFF "NOT GUI" OFF
     )
 endif()

--- a/cmake/Modules/FindSystemd.cmake
+++ b/cmake/Modules/FindSystemd.cmake
@@ -21,6 +21,17 @@ elseif (NOT SYSTEMD_FOUND AND SYSTEMD_SERVICES_INSTALL_DIR)
         defined, but we can't find systemd using pkg-config")
 endif()
 
+if (SYSTEMD_FOUND AND "${SYSTEMD_USER_SERVICES_INSTALL_DIR}" STREQUAL "")
+    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE}
+        --variable=systemduserunitdir systemd
+	OUTPUT_VARIABLE SYSTEMD_USER_SERVICES_INSTALL_DIR)
+    string(REGEX REPLACE "[ \t\n]+" "" SYSTEMD_USER_SERVICES_INSTALL_DIR
+        "${SYSTEMD_USER_SERVICES_INSTALL_DIR}")
+elseif (NOT SYSTEMD_FOUND AND SYSTEMD_USER_SERVICES_INSTALL_DIR)
+    message (FATAL_ERROR "Variable SYSTEMD_USER_SERVICES_INSTALL_DIR is\
+        defined, but we can't find systemd using pkg-config")
+endif()
+
 if (SYSTEMD_FOUND)
-    message(STATUS "systemd services install dir: ${SYSTEMD_SERVICES_INSTALL_DIR}")
+    message(STATUS "systemd system units install dir: ${SYSTEMD_SERVICES_INSTALL_DIR}; systemd user units install dir: ${SYSTEMD_USER_SERVICES_INSTALL_DIR}")
 endif()

--- a/dist/unix/CMakeLists.txt
+++ b/dist/unix/CMakeLists.txt
@@ -4,8 +4,19 @@ if (SYSTEMD)
         if (NOT SYSTEMD_FOUND)
             message(
                 FATAL_ERROR
-                "Could not locate systemd services install dir."
+                "Could not locate systemd system units install dir."
                 " Either pass the -DSYSTEMD_SERVICES_INSTALL_DIR=/path/to/systemd/services option"
+                " or install systemd pkg-config"
+            )
+        endif()
+    endif()
+    if (NOT SYSTEMD_USER_SERVICES_INSTALL_DIR)
+        find_package(Systemd)
+        if (NOT SYSTEMD_FOUND)
+            message(
+                FATAL_ERROR
+                "Could not locate systemd user units install dir."
+		" Either pass the -DSYSTEMD_USER_SERVICES_INSTALL_DIR=/path/to/systemd/user option"
                 " or install systemd pkg-config"
             )
         endif()
@@ -14,6 +25,11 @@ if (SYSTEMD)
     configure_file(systemd/qbittorrent-nox@.service.in ${CMAKE_CURRENT_BINARY_DIR}/qbittorrent-nox@.service @ONLY)
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/qbittorrent-nox@.service"
         DESTINATION ${SYSTEMD_SERVICES_INSTALL_DIR}
+        COMPONENT data
+    )
+    configure_file(systemd/qbittorrent-nox.service.in ${CMAKE_CURRENT_BINARY_DIR}/qbittorrent-nox.service @ONLY)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/qbittorrent-nox.service"
+        DESTINATION ${SYSTEMD_USER_SERVICES_INSTALL_DIR}
         COMPONENT data
     )
 endif()

--- a/dist/unix/systemd/qbittorrent-nox.service.in
+++ b/dist/unix/systemd/qbittorrent-nox.service.in
@@ -1,0 +1,14 @@
+[Unit]
+Description=qBittorrent-nox service
+Documentation=man:qbittorrent-nox(1)
+Wants=network-online.target
+After=local-fs.target network-online.target nss-lookup.target
+
+[Service]
+Type=simple
+PrivateTmp=false
+ExecStart=/usr/bin/qbittorrent-nox
+TimeoutStopSec=1800
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
The qbittorrent-nox@.service was introduced by
e00c96df9942723ff867f12c4db3ae4ffbe51ccf. This system-level unit uses User= to change into a specific user, and qbittorrent will access cache and database files in that user's home.

This is a very bad design, because systemd offers a better solution called systemd-user. It makes units specific to the current user run completely under the user service manager, so there is no need to do User= in the system unit anymore.

The current approach breaks service dependencies because my home directory is dynamically mounted by systemd-homed upon logon, which is unavailable when qbittorrent-nox@.service was started, rendering the service to dump its core. By moving the unit to systemd-user, systemd handles all dependencies perfectly since the user unit is only going to be started when the home directory is mounted.

This patch preserves compatibility with existing setups as it does not delete the previous qbittorrent-nox@.service.

