### PR TITLE
Revise Protocol column

### DIFF
--- a/src/gui/trackerlist/trackerlistmodel.cpp
+++ b/src/gui/trackerlist/trackerlistmodel.cpp
@@ -492,7 +492,7 @@ QVariant TrackerListModel::headerData(const int section, const Qt::Orientation o
         case COL_TIER:
             return tr("Tier");
         case COL_PROTOCOL:
-            return tr("Protocol");
+            return tr("BT Protocol");
         case COL_STATUS:
             return tr("Status");
         case COL_PEERS:
@@ -585,7 +585,7 @@ QVariant TrackerListModel::data(const QModelIndex &index, const int role) const
         case COL_TIER:
             return (isEndpoint || (index.row() < STICKY_ROW_COUNT)) ? QString() : QString::number(itemPtr->tier);
         case COL_PROTOCOL:
-            return isEndpoint ? tr("v%1").arg(itemPtr->btVersion) : QString();
+            return isEndpoint ? (u'v' + QString::number(itemPtr->btVersion)) : QString();
         case COL_STATUS:
             if (isEndpoint)
                 return toString(itemPtr->status);

--- a/src/gui/trackerlist/trackerlistmodel.cpp
+++ b/src/gui/trackerlist/trackerlistmodel.cpp
@@ -488,7 +488,7 @@ QVariant TrackerListModel::headerData(const int section, const Qt::Orientation o
         switch (section)
         {
         case COL_URL:
-            return tr("URL/Announce endpoint");
+            return tr("URL/Announce Endpoint");
         case COL_TIER:
             return tr("Tier");
         case COL_PROTOCOL:
@@ -506,9 +506,9 @@ QVariant TrackerListModel::headerData(const int section, const Qt::Orientation o
         case COL_MSG:
             return tr("Message");
         case COL_NEXT_ANNOUNCE:
-            return tr("Next announce");
+            return tr("Next Announce");
         case COL_MIN_ANNOUNCE:
-            return tr("Min announce");
+            return tr("Min Announce");
         default:
             return {};
         }


### PR DESCRIPTION
* Capitalize header text
* Revise Protocol column
  Add "BT" (BitTorrent) to avoid confusion about which protocol it is referring to.
  Also its value doesn't need to be translated since it is used as-is in the spec (BEP52).

screenshot:
![screenshot](https://github.com/qbittorrent/qBittorrent/assets/9395168/76164a47-f116-4057-a978-d17016dd09f0)