### PR TITLE
Add optional headers to search request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .vscode/
-.idea/
 src/gui/geoip/GeoIP.dat
 src/gui/geoip/GeoIP.dat.gz
 src/qbittorrent

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode/
+.idea/
 src/gui/geoip/GeoIP.dat
 src/gui/geoip/GeoIP.dat.gz
 src/qbittorrent

--- a/src/searchengine/nova3/helpers.py
+++ b/src/searchengine/nova3/helpers.py
@@ -87,11 +87,9 @@ def htmlentitydecode(s):
     return re.sub(r'&#x(\w+);', lambda x: chr(int(x.group(1), 16)), t)
 
 
-def retrieve_url(url, custom_headers=None):
+def retrieve_url(url, custom_headers={}):
     """ Return the content of the url page as a string """
-    if custom_headers is None:
-        custom_headers = headers
-    req = urllib.request.Request(url, headers=custom_headers)
+    req = urllib.request.Request(url, headers={**headers, **custom_headers})
     try:
         response = urllib.request.urlopen(req)
     except urllib.error.URLError as errno:

--- a/src/searchengine/nova3/helpers.py
+++ b/src/searchengine/nova3/helpers.py
@@ -87,9 +87,11 @@ def htmlentitydecode(s):
     return re.sub(r'&#x(\w+);', lambda x: chr(int(x.group(1), 16)), t)
 
 
-def retrieve_url(url):
+def retrieve_url(url, custom_headers=None):
     """ Return the content of the url page as a string """
-    req = urllib.request.Request(url, headers=headers)
+    if custom_headers is None:
+        custom_headers = headers
+    req = urllib.request.Request(url, headers=custom_headers)
     try:
         response = urllib.request.urlopen(req)
     except urllib.error.URLError as errno:

--- a/src/searchengine/nova3/helpers.py
+++ b/src/searchengine/nova3/helpers.py
@@ -1,4 +1,4 @@
-#VERSION: 1.45
+#VERSION: 1.46
 
 # Author:
 #  Christophe DUMEZ (chris@qbittorrent.org)


### PR DESCRIPTION
Some sites use headers to determine if it's a bot performing the search or it's an actual user, by adding it to the `retrieve_url` function, plugin developers can now pass any custom headers