### PR TITLE
Improve connection handling

### DIFF
--- a/src/base/bittorrent/bencoderesumedatastorage.cpp
+++ b/src/base/bittorrent/bencoderesumedatastorage.cpp
@@ -40,7 +40,6 @@
 #include <QRegularExpression>
 #include <QThread>
 
-#include "base/algorithm.h"
 #include "base/exceptions.h"
 #include "base/global.h"
 #include "base/logger.h"

--- a/src/base/http/connection.cpp
+++ b/src/base/http/connection.cpp
@@ -44,6 +44,7 @@ Connection::Connection(QTcpSocket *socket, IRequestHandler *requestHandler, QObj
     , m_requestHandler(requestHandler)
 {
     m_socket->setParent(this);
+    connect(m_socket, &QAbstractSocket::disconnected, this, &Connection::closed);
 
     // reserve common size for requests, don't use the max allowed size which is too big for
     // memory constrained platforms
@@ -60,11 +61,6 @@ Connection::Connection(QTcpSocket *socket, IRequestHandler *requestHandler, QObj
     {
         m_idleTimer.start();
     });
-}
-
-Connection::~Connection()
-{
-    m_socket->close();
 }
 
 void Connection::read()
@@ -180,11 +176,6 @@ bool Connection::hasExpired(const qint64 timeout) const
     return (m_socket->bytesAvailable() == 0)
         && (m_socket->bytesToWrite() == 0)
         && m_idleTimer.hasExpired(timeout);
-}
-
-bool Connection::isClosed() const
-{
-    return (m_socket->state() == QAbstractSocket::UnconnectedState);
 }
 
 bool Connection::acceptsGzipEncoding(QString codings)

--- a/src/base/http/connection.h
+++ b/src/base/http/connection.h
@@ -47,10 +47,11 @@ namespace Http
 
     public:
         Connection(QTcpSocket *socket, IRequestHandler *requestHandler, QObject *parent = nullptr);
-        ~Connection();
 
         bool hasExpired(qint64 timeout) const;
-        bool isClosed() const;
+
+    signals:
+        void closed();
 
     private:
         static bool acceptsGzipEncoding(QString codings);

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -39,7 +39,6 @@
 #include <QUrl>
 #include <QVBoxLayout>
 
-#include "base/algorithm.h"
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/torrent.h"
 #include "base/bittorrent/trackerentrystatus.h"


### PR DESCRIPTION
1. Previously unhandled connections will stay in pending state. It won't be closed until timeout happened. This may lead to wasting system resources. Now the (over-limit) connection is actively rejected.
2. When out-of-memory occurs here, reject the new connection instead of throwing exception and crash.
3. Also clean up some unused bits.
