### PR TITLE
WebUI: Use enabled search plugins by default

### DIFF
--- a/src/webui/www/private/scripts/search.js
+++ b/src/webui/www/private/scripts/search.js
@@ -53,7 +53,7 @@ window.qBittorrent.Search = (function() {
     const searchPlugins = [];
     let prevSearchPluginsResponse;
     let selectedCategory = "QBT_TR(All categories)QBT_TR[CONTEXT=SearchEngineWidget]";
-    let selectedPlugin = "all";
+    let selectedPlugin = "enabled";
     let prevSelectedPlugin;
     // whether the current search pattern differs from the pattern that the active search was performed with
     let searchPatternChanged = false;


### PR DESCRIPTION
This switches the WebUI's default search plugin from "All plugins" to "Only enabled". "All plugins" is a nonsensical default since it completely ignores whether plugins are enabled. This now matches the behavior of the GUI.

Closes #20558