### PR TITLE
Fix highlighted piece color

### DIFF
--- a/src/gui/properties/piecesbar.cpp
+++ b/src/gui/properties/piecesbar.cpp
@@ -195,10 +195,8 @@ void PiecesBar::paintEvent(QPaintEvent *)
 
     if (!m_highlightedRegion.isNull())
     {
-        QColor highlightColor {this->palette().color(QPalette::Active, QPalette::Highlight)};
-        highlightColor.setAlphaF(0.35f);
         QRect targetHighlightRect {m_highlightedRegion.adjusted(borderWidth, borderWidth, borderWidth, height() - 2 * borderWidth)};
-        painter.fillRect(targetHighlightRect, highlightColor);
+        painter.fillRect(targetHighlightRect, highlightedPieceColor());
     }
 
     QPainterPath border;
@@ -229,6 +227,13 @@ QColor PiecesBar::borderColor() const
 QColor PiecesBar::pieceColor() const
 {
     return palette().color(QPalette::Active, QPalette::Highlight);
+}
+
+QColor PiecesBar::highlightedPieceColor() const
+{
+    QColor col = palette().color(QPalette::Highlight).darker();
+    col.setAlphaF(0.35);
+    return col;
 }
 
 QColor PiecesBar::colorBoxBorderColor() const

--- a/src/gui/properties/piecesbar.h
+++ b/src/gui/properties/piecesbar.h
@@ -68,7 +68,9 @@ protected:
     QColor backgroundColor() const;
     QColor borderColor() const;
     QColor pieceColor() const;
+    QColor highlightedPieceColor() const;
     QColor colorBoxBorderColor() const;
+
     const QList<QRgb> &pieceColors() const;
 
     // mix two colors by light model, ratio <0, 1>


### PR DESCRIPTION
Much better contrast with download piece and selected pieces. Previously same color was used for both

New Behaviour


https://github.com/qbittorrent/qBittorrent/assets/34717789/b3d80dbb-47aa-4e03-b1e6-22f31b2e7982


https://github.com/qbittorrent/qBittorrent/assets/34717789/58f08ea1-eb86-4487-9f5d-d21363547d7f

