### PR TITLE
GHA CI: use static versions of AppImage builder

### DIFF
--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -138,12 +138,12 @@ jobs:
           curl \
             -L \
             -Z \
-            -O https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage \
-            -O https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage \
+            -O https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-static-x86_64.AppImage \
+            -O https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-static-x86_64.AppImage \
             -O https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-x86_64.AppImage
           chmod +x \
-            linuxdeploy-x86_64.AppImage \
-            linuxdeploy-plugin-qt-x86_64.AppImage \
+            linuxdeploy-static-x86_64.AppImage \
+            linuxdeploy-plugin-qt-static-x86_64.AppImage \
             linuxdeploy-plugin-appimage-x86_64.AppImage
 
       - name: Prepare files for AppImage
@@ -156,12 +156,12 @@ jobs:
 
       - name: Package AppImage
         run: |
-          ./linuxdeploy-x86_64.AppImage --appdir qbittorrent --plugin qt
+          ./linuxdeploy-static-x86_64.AppImage --appdir qbittorrent --plugin qt
           rm qbittorrent/apprun-hooks/*
           cp .github/workflows/helper/appimage/export_vars.sh qbittorrent/apprun-hooks/export_vars.sh
           NO_APPSTREAM=1 \
             OUTPUT=upload/qbittorrent-CI_Ubuntu_x86_64.AppImage \
-            ./linuxdeploy-x86_64.AppImage --appdir qbittorrent --output appimage
+            ./linuxdeploy-static-x86_64.AppImage --appdir qbittorrent --output appimage
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
It does not affect the produced artifacts. The only difference is the tool itself won't depend on some specific OS image or library version.
