### PR TITLE
Use custom storage when reloading torrent

### DIFF
--- a/src/base/bittorrent/customstorage.cpp
+++ b/src/base/bittorrent/customstorage.cpp
@@ -240,11 +240,11 @@ void CustomDiskIOThread::handleCompleteFiles(lt::storage_index_t storage, const 
 
 lt::storage_interface *customStorageConstructor(const lt::storage_params &params, lt::file_pool &pool)
 {
-    return new CustomStorage {params, pool};
+    return new CustomStorage(params, pool);
 }
 
 CustomStorage::CustomStorage(const lt::storage_params &params, lt::file_pool &filePool)
-    : lt::default_storage {params, filePool}
+    : lt::default_storage(params, filePool)
     , m_savePath {params.path}
 {
 }

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -77,6 +77,10 @@
 #include "base/utils/os.h"
 #endif // Q_OS_MACOS || Q_OS_WIN
 
+#ifndef QBT_USES_LIBTORRENT2
+#include "customstorage.h"
+#endif
+
 using namespace BitTorrent;
 
 namespace
@@ -1860,6 +1864,9 @@ void TorrentImpl::reload()
 
         auto *const extensionData = new ExtensionData;
         p.userdata = LTClientData(extensionData);
+#ifndef QBT_USES_LIBTORRENT2
+        p.storage = customStorageConstructor;
+#endif
         m_nativeHandle = m_nativeSession->add_torrent(p);
 
         m_nativeStatus = extensionData->status;


### PR DESCRIPTION
Unlike libtorrent-2.0 disk IO is customizable on per-torrent basis in libtorrent-1.2, so it should be handled when reloading underlying torrent as well.
