### PR TITLE
Implement double-click behavior controls for the WebUI

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1536,6 +1536,20 @@ window.qBittorrent.DynamicTable = (function() {
                 this._this.selectRow(this.rowId);
                 const row = this._this.rows.get(this.rowId);
                 const state = row["full_data"].state;
+
+                const prefKey =
+                    (state !== "uploading")
+                    && (state !== "stoppedUP")
+                    && (state !== "forcedUP")
+                    && (state !== "stalledUP")
+                    && (state !== "queuedUP")
+                    && (state !== "checkingUP")
+                    ? "dblclick_download"
+                    : "dblclick_complete";
+
+                if (LocalPreferences.get(prefKey, "1") !== "1")
+                    return true;
+
                 if (state.includes("stopped"))
                     startFN();
                 else

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -8,6 +8,30 @@
     </fieldset>
 
     <fieldset class="settings">
+        <legend>QBT_TR(Action on double-click)QBT_TR[CONTEXT=OptionsDialog]</legend>
+        <table>
+            <tr>
+                <td><label for="dblclickDownloadSelect">QBT_TR(Downloading torrents:)QBT_TR[CONTEXT=OptionsDialog]</label></td>
+                <td>
+                    <select id="dblclickDownloadSelect">
+                        <option value="1" selected>QBT_TR(Start / Stop Torrent)QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="0">QBT_TR(No action)QBT_TR[CONTEXT=OptionsDialog]</option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <td><label for="dblclickCompleteSelect">QBT_TR(Completed torrents:)QBT_TR[CONTEXT=OptionsDialog]</label></td>
+                <td>
+                    <select id="dblclickCompleteSelect">
+                        <option value="1" selected>QBT_TR(Start / Stop Torrent)QBT_TR[CONTEXT=OptionsDialog]</option>
+                        <option value="0">QBT_TR(No action)QBT_TR[CONTEXT=OptionsDialog]</option>
+                    </select>
+                </td>
+            </tr>
+        </table>
+    </fieldset>
+
+    <fieldset class="settings">
         <legend>
             <input type="checkbox" id="filelog_checkbox" onclick="qBittorrent.Preferences.updateFileLogEnabled();" />
             <label for="filelog_checkbox">QBT_TR(Log file)QBT_TR[CONTEXT=OptionsDialog]</label>
@@ -1984,6 +2008,8 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             window.parent.qBittorrent.Cache.preferences.init({
                 onSuccess: (pref) => {
                     // Behavior tab
+                    $("dblclickDownloadSelect").value = LocalPreferences.get("dblclick_download", "1");
+                    $("dblclickCompleteSelect").value = LocalPreferences.get("dblclick_complete", "1");
                     $("filelog_checkbox").setProperty("checked", pref.file_log_enabled);
                     $("filelog_save_path_input").setProperty("value", pref.file_log_path);
                     $("filelog_backup_checkbox").setProperty("checked", pref.file_log_backup_enabled);
@@ -2391,6 +2417,8 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             // Validate form data
 
             // Behavior tab
+            LocalPreferences.set("dblclick_download", $("dblclickDownloadSelect").value);
+            LocalPreferences.set("dblclick_complete", $("dblclickCompleteSelect").value);
             settings["file_log_enabled"] = $("filelog_checkbox").getProperty("checked");
             settings["file_log_path"] = $("filelog_save_path_input").getProperty("value");
             settings["file_log_backup_enabled"] = $("filelog_backup_checkbox").getProperty("checked");


### PR DESCRIPTION
This PR implements double-click behavior controls for the WebUI, similar to the desktop GUI.
Closes #20436.

But as I discussed in https://github.com/qbittorrent/qBittorrent/issues/20436#issuecomment-2192285880, despite the same names, this is not the same settings. Because existing options of the GUI are not applicable for the WebUI, they are implemented as independent standalone settings.

Also the settings implemented as selectors, despite having only 2 options. They actually could be implemented as check boxes instead, but:

1. I think it is better to be kinda consistent with the GUI.
2. Allows for more options to be easily added in the future.

<details>
<summary>Screenshot</summary>

![screenshot](https://github.com/qbittorrent/qBittorrent/assets/13597663/94ae2493-92e4-457f-9042-0994541b7e64)

</details>
