### PR TITLE
Add WebAPI for fetching torrent metadata

### DIFF
--- a/WebAPI_Changelog.md
+++ b/WebAPI_Changelog.md
@@ -1,5 +1,14 @@
 # WebAPI Changelog
 
+## 2.11.9
+
+* [#21015](https://github.com/qbittorrent/qBittorrent/pull/21015)
+  * Add `torrents/fetchMetadata` endpoint for retrieving torrent metadata associated with a URL
+  * Add `torrents/parseMetadata` endpoint for retrieving torrent metadata associated with a .torrent file
+  * Add `torrents/saveMetadata` endpoint for saving retrieved torrent metadata to a .torrent file
+  * `torrents/add` allows adding a torrent with metadata previously retrieved via `torrents/fetchMetadata` or `torrents/parseMetadata`
+  * `torrents/add` allows specifying a torrent's file priorities
+
 ## 2.11.8
 
 * [#21349](https://github.com/qbittorrent/qBittorrent/pull/21349)

--- a/src/base/bittorrent/torrentdescriptor.cpp
+++ b/src/base/bittorrent/torrentdescriptor.cpp
@@ -141,6 +141,22 @@ catch (const lt::system_error &err)
     return nonstd::make_unexpected(QString::fromLocal8Bit(err.what()));
 }
 
+nonstd::expected<QByteArray, QString> BitTorrent::TorrentDescriptor::saveToBuffer() const
+try
+{
+    const lt::entry torrentEntry = lt::write_torrent_file(m_ltAddTorrentParams);
+    // usually torrent size should be smaller than 1 MB,
+    // however there are >100 MB v2/hybrid torrent files out in the wild
+    QByteArray buffer;
+    buffer.reserve(1024 * 1024);
+    lt::bencode(std::back_inserter(buffer), torrentEntry);
+    return buffer;
+}
+catch (const lt::system_error &err)
+{
+    return nonstd::make_unexpected(QString::fromLocal8Bit(err.what()));
+}
+
 BitTorrent::TorrentDescriptor::TorrentDescriptor(lt::add_torrent_params ltAddTorrentParams)
     : m_ltAddTorrentParams {std::move(ltAddTorrentParams)}
 {

--- a/src/base/bittorrent/torrentdescriptor.h
+++ b/src/base/bittorrent/torrentdescriptor.h
@@ -69,6 +69,7 @@ namespace BitTorrent
         static nonstd::expected<TorrentDescriptor, QString> loadFromFile(const Path &path) noexcept;
         static nonstd::expected<TorrentDescriptor, QString> parse(const QString &str) noexcept;
         nonstd::expected<void, QString> saveToFile(const Path &path) const;
+        nonstd::expected<QByteArray, QString> saveToBuffer() const;
 
         const lt::add_torrent_params &ltAddTorrentParams() const;
 

--- a/src/webui/api/torrentscontroller.h
+++ b/src/webui/api/torrentscontroller.h
@@ -112,6 +112,7 @@ private slots:
     void setSSLParametersAction();
     void fetchMetadataAction();
     void parseMetadataAction();
+    void saveMetadataAction();
 
 private:
     void onDownloadFinished(const Net::DownloadResult &result);

--- a/src/webui/api/torrentscontroller.h
+++ b/src/webui/api/torrentscontroller.h
@@ -28,7 +28,22 @@
 
 #pragma once
 
+#include <QHash>
+#include <QSet>
+
+#include "base/bittorrent/torrentdescriptor.h"
 #include "apicontroller.h"
+
+namespace BitTorrent
+{
+    class InfoHash;
+    class TorrentInfo;
+}
+
+namespace Net
+{
+    struct DownloadResult;
+}
 
 class TorrentsController : public APIController
 {
@@ -36,7 +51,7 @@ class TorrentsController : public APIController
     Q_DISABLE_COPY_MOVE(TorrentsController)
 
 public:
-    using APIController::APIController;
+    explicit TorrentsController(IApplication *app, QObject *parent = nullptr);
 
 private slots:
     void countAction();
@@ -95,4 +110,14 @@ private slots:
     void exportAction();
     void SSLParametersAction();
     void setSSLParametersAction();
+    void fetchMetadataAction();
+    void parseMetadataAction();
+
+private:
+    void onDownloadFinished(const Net::DownloadResult &result);
+    void onMetadataDownloaded(const BitTorrent::TorrentInfo &info);
+
+    QHash<QString, BitTorrent::InfoHash> m_torrentSourceCache;
+    QHash<BitTorrent::InfoHash, BitTorrent::TorrentDescriptor> m_torrentMetadataCache;
+    QSet<QString> m_requestedTorrentSource;
 };

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -53,7 +53,7 @@
 #include "base/utils/version.h"
 #include "api/isessionmanager.h"
 
-inline const Utils::Version<3, 2> API_VERSION {2, 11, 8};
+inline const Utils::Version<3, 2> API_VERSION {2, 11, 9};
 
 class APIController;
 class AuthController;


### PR DESCRIPTION
This PR implements two new APIs for fetching a torrent's metadata. The APIs accept a magnet URI, torrent hash, .torrent URL, or uploaded .torrent file, and return the torrent's associated metadata. This PR also modifies the `/torrents/add` API to support downloading a torrent whose metadata has been previously fetched. The ultimate goal is for the WebUI to provide an Add Torrent experience equivalent to that of the GUI, where content can be reprioritized/unchecked before the torrent is added.

## `/fetchMetadata` API

### HTTP request

To request metadata for a torrent, specify the torrent in the `source` query parameter of a GET request to `/api/v2/torrents/fetchMetadata`. Torrents are supported  in the following formats:

- magnet URI (e.g. `magnet:?xt=urn:btih:a8eeefc8a0dc402b24686ddfd775a409fe4b00e0&dn=example`)
- hash (e.g. `a8eeefc8a0dc402b24686ddfd775a409fe4b00e0`)
- .torrent URL (e.g. `https://example.com/example.torrent`)

### HTTP response
Given the asynchronous nature of retrieving metadata, there are two successful HTTP status codes used.

When metadata is requested for a torrent that requires asynchronous background work (i.e. connecting to DHT/peers), the client will receive a 202. A 202 indicates that the request was successful, but additional background work must be completed before a meaningful response can be provided. The response will contain the info hashes, if available, or an empty object.
```
GET /api/v2/torrents/fetchMetadata?source=abc
HTTP/1.1 202 OK
{
  "hash": string,
  "infohash_v1": string,
  "infohash_v2": string
} | {}
```

When metadata is available for the torrent, either because the torrent exists in the transfer list or because the metadata has been retrieved from a prior request, the client will receive a 200.
```
GET /api/v2/torrents/fetchMetadata?source=abc
HTTP/1.1 200 OK
{
  "comment": string,
  "created_by": string,
  "creation_date": int,
  "hash": string,
  "infohash_v1": string,
  "infohash_v2": string,
  "info": {
    "files": [],
    "length": int,
    "name": string,
    "piece_length": int,
    "pieces_num": int,
    "private": bool
  },
  "trackers": [],
  "webseeds": []
}
```

Retrieved metadata will be cached in the current web session. Subsequent requests performed within the same web session will return the metadata immediately, while other web sessions will be required to reretrieve the torrent's metadata from peers. Once a torrent is added using the cached metadata, the metadata is removed from the cache.


## `/parseMetadata` API

### HTTP request

To request metadata for one to several .torrent file(s), you may upload the files to the `/parseMetadata` API. To do so, submit the file(s) as multipart MIME data. You may use any key for the uploaded value.

To test file upload using curl, specify the `-F` flag (e.g. `curl https://127.0.0.1:8080/api/v2/torrents/parseMetadata --get -F file=@"/root/example.torrent"`).

### HTTP response
This API always responds to successful requests (i.e. valid torrent file(s)) with a 200. The response will contain the full metadata for the uploaded torrent(s). The response object is keyed off of the uploaded file's name.

```
GET /api/v2/torrents/parseMetadata
HTTP/1.1 200 OK
{
  "example.torrent": {
    "comment": string,
    "created_by": string,
    "creation_date": int,
    "hash": string,
    "infohash_v1": string,
    "infohash_v2": string,
    "info": {
      "files": [],
      "length": int,
      "name": string,
      "piece_length": int,
      "pieces_num": int,
      "private": bool
    },
    "trackers": [],
    "webseeds": []
  }
}
```

## `/add` API

The existing `/add` API now supports using the metadata cache that's populated by the new metadata APIs. When specifying a url and/or torrent file to download, the metadata cache is first checked for the torrent. If found, the metadata is used directly from the cache, rather than needing to re-retrieve it. Note that when specifying the name of a .torrent file uploaded via the `parseMetadata` API, you must prepend `file:` to the file name. For example, if you uploaded `example.torrent` to the `parseMetadata` API, you can add this torrent via the `/add` API by specifying a url of `file:example.torrent`.

When metadata is retrieved directly from the cache, you may also specify a new `filePriorities` parameter. This parameter allows for specifying the file priority of each file in the torrent. This parameter may only be specified when adding a single torrent.

## Alternatives:
I explored having the metadata API leave the request open until the metadata was available. Once the metadata was fetched, it would be returned directly in the response of the original request. One downside of this approach is that metadata retrieval can take an arbitrary long amount of time. This could result in torrents whose metadata could never be retrieved via this API (e.g. due to the retrieval taking longer than the client's/reverse proxy's request timeout). This approach would also require some further modification of qBittorrent's web application layer to suppress the default behavior of returning a blank response.

## Future work:
- Modify the WebUI to make use of the new `/fetchMetadata` API (#21645)

Closes #20966.
