### PR TITLE
Use QList explicitly

### DIFF
--- a/src/app/filelogger.cpp
+++ b/src/app/filelogger.cpp
@@ -32,8 +32,8 @@
 
 #include <QDateTime>
 #include <QDir>
+#include <QList>
 #include <QTextStream>
-#include <QVector>
 
 #include "base/global.h"
 #include "base/logger.h"

--- a/src/base/bittorrent/abstractfilestorage.cpp
+++ b/src/base/bittorrent/abstractfilestorage.cpp
@@ -30,7 +30,7 @@
 
 #include <QDir>
 #include <QHash>
-#include <QVector>
+#include <QList>
 
 #include "base/exceptions.h"
 #include "base/path.h"
@@ -71,7 +71,7 @@ void BitTorrent::AbstractFileStorage::renameFolder(const Path &oldFolderPath, co
     if (newFolderPath.isAbsolute())
         throw RuntimeError(tr("Absolute path isn't allowed: '%1'.").arg(newFolderPath.toString()));
 
-    QVector<int> renamingFileIndexes;
+    QList<int> renamingFileIndexes;
     renamingFileIndexes.reserve(filesCount());
 
     for (int i = 0; i < filesCount(); ++i)

--- a/src/base/bittorrent/addtorrentparams.h
+++ b/src/base/bittorrent/addtorrentparams.h
@@ -30,9 +30,9 @@
 
 #include <optional>
 
+#include <QList>
 #include <QMetaType>
 #include <QString>
-#include <QVector>
 
 #include "base/path.h"
 #include "base/tagset.h"
@@ -62,7 +62,7 @@ namespace BitTorrent
         std::optional<bool> addStopped;
         std::optional<Torrent::StopCondition> stopCondition;
         PathList filePaths; // used if TorrentInfo is set
-        QVector<DownloadPriority> filePriorities; // used if TorrentInfo is set
+        QList<DownloadPriority> filePriorities; // used if TorrentInfo is set
         bool skipChecking = false;
         std::optional<BitTorrent::TorrentContentLayout> contentLayout;
         std::optional<bool> useAutoTMM;

--- a/src/base/bittorrent/bencoderesumedatastorage.cpp
+++ b/src/base/bittorrent/bencoderesumedatastorage.cpp
@@ -64,7 +64,7 @@ namespace BitTorrent
 
         void store(const TorrentID &id, const LoadTorrentParams &resumeData) const;
         void remove(const TorrentID &id) const;
-        void storeQueue(const QVector<TorrentID> &queue) const;
+        void storeQueue(const QList<TorrentID> &queue) const;
 
     private:
         const Path m_resumeDataDir;
@@ -134,7 +134,7 @@ BitTorrent::BencodeResumeDataStorage::BencodeResumeDataStorage(const Path &path,
     m_ioThread->start();
 }
 
-QVector<BitTorrent::TorrentID> BitTorrent::BencodeResumeDataStorage::registeredTorrents() const
+QList<BitTorrent::TorrentID> BitTorrent::BencodeResumeDataStorage::registeredTorrents() const
 {
     return m_registeredTorrents;
 }
@@ -354,7 +354,7 @@ void BitTorrent::BencodeResumeDataStorage::remove(const TorrentID &id) const
     });
 }
 
-void BitTorrent::BencodeResumeDataStorage::storeQueue(const QVector<TorrentID> &queue) const
+void BitTorrent::BencodeResumeDataStorage::storeQueue(const QList<TorrentID> &queue) const
 {
     QMetaObject::invokeMethod(m_asyncWorker, [this, queue]()
     {
@@ -460,7 +460,7 @@ void BitTorrent::BencodeResumeDataStorage::Worker::remove(const TorrentID &id) c
     Utils::Fs::removeFile(m_resumeDataDir / torrentFilename);
 }
 
-void BitTorrent::BencodeResumeDataStorage::Worker::storeQueue(const QVector<TorrentID> &queue) const
+void BitTorrent::BencodeResumeDataStorage::Worker::storeQueue(const QList<TorrentID> &queue) const
 {
     QByteArray data;
     data.reserve(((BitTorrent::TorrentID::length() * 2) + 1) * queue.size());

--- a/src/base/bittorrent/bencoderesumedatastorage.h
+++ b/src/base/bittorrent/bencoderesumedatastorage.h
@@ -29,7 +29,7 @@
 #pragma once
 
 #include <QDir>
-#include <QVector>
+#include <QList>
 
 #include "base/pathfwd.h"
 #include "base/utils/thread.h"
@@ -49,18 +49,18 @@ namespace BitTorrent
     public:
         explicit BencodeResumeDataStorage(const Path &path, QObject *parent = nullptr);
 
-        QVector<TorrentID> registeredTorrents() const override;
+        QList<TorrentID> registeredTorrents() const override;
         LoadResumeDataResult load(const TorrentID &id) const override;
         void store(const TorrentID &id, const LoadTorrentParams &resumeData) const override;
         void remove(const TorrentID &id) const override;
-        void storeQueue(const QVector<TorrentID> &queue) const override;
+        void storeQueue(const QList<TorrentID> &queue) const override;
 
     private:
         void doLoadAll() const override;
         void loadQueue(const Path &queueFilename);
         LoadResumeDataResult loadTorrentResumeData(const QByteArray &data, const QByteArray &metadata) const;
 
-        QVector<TorrentID> m_registeredTorrents;
+        QList<TorrentID> m_registeredTorrents;
         Utils::Thread::UniquePtr m_ioThread;
 
         class Worker;

--- a/src/base/bittorrent/filterparserthread.cpp
+++ b/src/base/bittorrent/filterparserthread.cpp
@@ -133,7 +133,7 @@ int FilterParserThread::parseDATFilterFile()
         return ruleCount;
     }
 
-    std::vector<char> buffer(BUFFER_SIZE, 0); // seems a bit faster than QVector
+    std::vector<char> buffer(BUFFER_SIZE, 0); // seems a bit faster than QList
     qint64 bytesRead = 0;
     int offset = 0;
     int start = 0;
@@ -297,7 +297,7 @@ int FilterParserThread::parseP2PFilterFile()
         return ruleCount;
     }
 
-    std::vector<char> buffer(BUFFER_SIZE, 0); // seems a bit faster than QVector
+    std::vector<char> buffer(BUFFER_SIZE, 0); // seems a bit faster than QList
     qint64 bytesRead = 0;
     int offset = 0;
     int start = 0;

--- a/src/base/bittorrent/resumedatastorage.cpp
+++ b/src/base/bittorrent/resumedatastorage.cpp
@@ -30,12 +30,12 @@
 
 #include <utility>
 
+#include <QList>
 #include <QMetaObject>
 #include <QMutexLocker>
 #include <QThread>
-#include <QVector>
 
-const int TORRENTIDLIST_TYPEID = qRegisterMetaType<QVector<BitTorrent::TorrentID>>();
+const int TORRENTIDLIST_TYPEID = qRegisterMetaType<QList<BitTorrent::TorrentID>>();
 
 BitTorrent::ResumeDataStorage::ResumeDataStorage(const Path &path, QObject *parent)
     : QObject(parent)

--- a/src/base/bittorrent/resumedatastorage.h
+++ b/src/base/bittorrent/resumedatastorage.h
@@ -58,17 +58,17 @@ namespace BitTorrent
 
         Path path() const;
 
-        virtual QVector<TorrentID> registeredTorrents() const = 0;
+        virtual QList<TorrentID> registeredTorrents() const = 0;
         virtual LoadResumeDataResult load(const TorrentID &id) const = 0;
         virtual void store(const TorrentID &id, const LoadTorrentParams &resumeData) const = 0;
         virtual void remove(const TorrentID &id) const = 0;
-        virtual void storeQueue(const QVector<TorrentID> &queue) const = 0;
+        virtual void storeQueue(const QList<TorrentID> &queue) const = 0;
 
         void loadAll() const;
         QList<LoadedResumeData> fetchLoadedResumeData() const;
 
     signals:
-        void loadStarted(const QVector<BitTorrent::TorrentID> &torrents);
+        void loadStarted(const QList<BitTorrent::TorrentID> &torrents);
         void loadFinished();
 
     protected:

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -446,7 +446,7 @@ namespace BitTorrent
 
         virtual Torrent *getTorrent(const TorrentID &id) const = 0;
         virtual Torrent *findTorrent(const InfoHash &infoHash) const = 0;
-        virtual QVector<Torrent *> torrents() const = 0;
+        virtual QList<Torrent *> torrents() const = 0;
         virtual qsizetype torrentsCount() const = 0;
         virtual const SessionStatus &status() const = 0;
         virtual const CacheStatus &cacheStatus() const = 0;
@@ -460,10 +460,10 @@ namespace BitTorrent
         virtual bool downloadMetadata(const TorrentDescriptor &torrentDescr) = 0;
         virtual bool cancelDownloadMetadata(const TorrentID &id) = 0;
 
-        virtual void increaseTorrentsQueuePos(const QVector<TorrentID> &ids) = 0;
-        virtual void decreaseTorrentsQueuePos(const QVector<TorrentID> &ids) = 0;
-        virtual void topTorrentsQueuePos(const QVector<TorrentID> &ids) = 0;
-        virtual void bottomTorrentsQueuePos(const QVector<TorrentID> &ids) = 0;
+        virtual void increaseTorrentsQueuePos(const QList<TorrentID> &ids) = 0;
+        virtual void decreaseTorrentsQueuePos(const QList<TorrentID> &ids) = 0;
+        virtual void topTorrentsQueuePos(const QList<TorrentID> &ids) = 0;
+        virtual void bottomTorrentsQueuePos(const QList<TorrentID> &ids) = 0;
 
     signals:
         void startupProgressUpdated(int progress);
@@ -494,12 +494,12 @@ namespace BitTorrent
         void torrentStarted(Torrent *torrent);
         void torrentSavePathChanged(Torrent *torrent);
         void torrentSavingModeChanged(Torrent *torrent);
-        void torrentsLoaded(const QVector<Torrent *> &torrents);
-        void torrentsUpdated(const QVector<Torrent *> &torrents);
+        void torrentsLoaded(const QList<Torrent *> &torrents);
+        void torrentsUpdated(const QList<Torrent *> &torrents);
         void torrentTagAdded(Torrent *torrent, const Tag &tag);
         void torrentTagRemoved(Torrent *torrent, const Tag &tag);
         void trackerError(Torrent *torrent, const QString &tracker);
-        void trackersAdded(Torrent *torrent, const QVector<TrackerEntry> &trackers);
+        void trackersAdded(Torrent *torrent, const QList<TrackerEntry> &trackers);
         void trackersChanged(Torrent *torrent);
         void trackersRemoved(Torrent *torrent, const QStringList &trackers);
         void trackerSuccess(Torrent *torrent, const QString &tracker);

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -1306,7 +1306,7 @@ void SessionImpl::prepareStartup()
         context->startupStorage = m_resumeDataStorage;
 
     connect(context->startupStorage, &ResumeDataStorage::loadStarted, context
-            , [this, context](const QVector<TorrentID> &torrents)
+            , [this, context](const QList<TorrentID> &torrents)
     {
         context->totalResumeDataCount = torrents.size();
 #ifdef QBT_USES_LIBTORRENT2
@@ -2491,7 +2491,7 @@ bool SessionImpl::cancelDownloadMetadata(const TorrentID &id)
     return true;
 }
 
-void SessionImpl::increaseTorrentsQueuePos(const QVector<TorrentID> &ids)
+void SessionImpl::increaseTorrentsQueuePos(const QList<TorrentID> &ids)
 {
     using ElementType = std::pair<int, const TorrentImpl *>;
     std::priority_queue<ElementType
@@ -2518,7 +2518,7 @@ void SessionImpl::increaseTorrentsQueuePos(const QVector<TorrentID> &ids)
     m_torrentsQueueChanged = true;
 }
 
-void SessionImpl::decreaseTorrentsQueuePos(const QVector<TorrentID> &ids)
+void SessionImpl::decreaseTorrentsQueuePos(const QList<TorrentID> &ids)
 {
     using ElementType = std::pair<int, const TorrentImpl *>;
     std::priority_queue<ElementType> torrentQueue;
@@ -2546,7 +2546,7 @@ void SessionImpl::decreaseTorrentsQueuePos(const QVector<TorrentID> &ids)
     m_torrentsQueueChanged = true;
 }
 
-void SessionImpl::topTorrentsQueuePos(const QVector<TorrentID> &ids)
+void SessionImpl::topTorrentsQueuePos(const QList<TorrentID> &ids)
 {
     using ElementType = std::pair<int, const TorrentImpl *>;
     std::priority_queue<ElementType> torrentQueue;
@@ -2571,7 +2571,7 @@ void SessionImpl::topTorrentsQueuePos(const QVector<TorrentID> &ids)
     m_torrentsQueueChanged = true;
 }
 
-void SessionImpl::bottomTorrentsQueuePos(const QVector<TorrentID> &ids)
+void SessionImpl::bottomTorrentsQueuePos(const QList<TorrentID> &ids)
 {
     using ElementType = std::pair<int, const TorrentImpl *>;
     std::priority_queue<ElementType
@@ -2607,9 +2607,9 @@ void SessionImpl::handleTorrentResumeDataRequested(const TorrentImpl *torrent)
     ++m_numResumeData;
 }
 
-QVector<Torrent *> SessionImpl::torrents() const
+QList<Torrent *> SessionImpl::torrents() const
 {
-    QVector<Torrent *> result;
+    QList<Torrent *> result;
     result.reserve(m_torrents.size());
     for (TorrentImpl *torrent : asConst(m_torrents))
         result << torrent;
@@ -3133,7 +3133,7 @@ void SessionImpl::saveResumeData()
 
 void SessionImpl::saveTorrentsQueue()
 {
-    QVector<TorrentID> queue;
+    QList<TorrentID> queue;
     for (const TorrentImpl *torrent : asConst(m_torrents))
     {
         if (const int queuePos = torrent->queuePosition(); queuePos >= 0)
@@ -4985,7 +4985,7 @@ void SessionImpl::handleTorrentSavingModeChanged(TorrentImpl *const torrent)
     emit torrentSavingModeChanged(torrent);
 }
 
-void SessionImpl::handleTorrentTrackersAdded(TorrentImpl *const torrent, const QVector<TrackerEntry> &newTrackers)
+void SessionImpl::handleTorrentTrackersAdded(TorrentImpl *const torrent, const QList<TrackerEntry> &newTrackers)
 {
     for (const TrackerEntry &newTracker : newTrackers)
         LogMsg(tr("Added tracker to torrent. Torrent: \"%1\". Tracker: \"%2\"").arg(torrent->name(), newTracker.url));
@@ -5004,13 +5004,13 @@ void SessionImpl::handleTorrentTrackersChanged(TorrentImpl *const torrent)
     emit trackersChanged(torrent);
 }
 
-void SessionImpl::handleTorrentUrlSeedsAdded(TorrentImpl *const torrent, const QVector<QUrl> &newUrlSeeds)
+void SessionImpl::handleTorrentUrlSeedsAdded(TorrentImpl *const torrent, const QList<QUrl> &newUrlSeeds)
 {
     for (const QUrl &newUrlSeed : newUrlSeeds)
         LogMsg(tr("Added URL seed to torrent. Torrent: \"%1\". URL: \"%2\"").arg(torrent->name(), newUrlSeed.toString()));
 }
 
-void SessionImpl::handleTorrentUrlSeedsRemoved(TorrentImpl *const torrent, const QVector<QUrl> &urlSeeds)
+void SessionImpl::handleTorrentUrlSeedsRemoved(TorrentImpl *const torrent, const QList<QUrl> &urlSeeds)
 {
     for (const QUrl &urlSeed : urlSeeds)
         LogMsg(tr("Removed URL seed from torrent. Torrent: \"%1\". URL: \"%2\"").arg(torrent->name(), urlSeed.toString()));
@@ -5028,7 +5028,7 @@ void SessionImpl::handleTorrentStopped(TorrentImpl *const torrent)
 {
     torrent->resetTrackerEntryStatuses();
 
-    const QVector<TrackerEntryStatus> trackers = torrent->trackers();
+    const QList<TrackerEntryStatus> trackers = torrent->trackers();
     QHash<QString, TrackerEntryStatus> updatedTrackers;
     updatedTrackers.reserve(trackers.size());
 
@@ -6056,7 +6056,7 @@ void SessionImpl::handleStorageMovedFailedAlert(const lt::storage_moved_failed_a
 
 void SessionImpl::handleStateUpdateAlert(const lt::state_update_alert *alert)
 {
-    QVector<Torrent *> updatedTorrents;
+    QList<Torrent *> updatedTorrents;
     updatedTorrents.reserve(static_cast<decltype(updatedTorrents)::size_type>(alert->status.size()));
 
     for (const lt::torrent_status &status : alert->status)

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -40,10 +40,10 @@
 #include <QDateTime>
 #include <QElapsedTimer>
 #include <QHash>
+#include <QList>
 #include <QMap>
 #include <QPointer>
 #include <QSet>
-#include <QVector>
 
 #include "base/path.h"
 #include "base/settingvalue.h"
@@ -423,7 +423,7 @@ namespace BitTorrent
 
         Torrent *getTorrent(const TorrentID &id) const override;
         Torrent *findTorrent(const InfoHash &infoHash) const override;
-        QVector<Torrent *> torrents() const override;
+        QList<Torrent *> torrents() const override;
         qsizetype torrentsCount() const override;
         const SessionStatus &status() const override;
         const CacheStatus &cacheStatus() const override;
@@ -437,10 +437,10 @@ namespace BitTorrent
         bool downloadMetadata(const TorrentDescriptor &torrentDescr) override;
         bool cancelDownloadMetadata(const TorrentID &id) override;
 
-        void increaseTorrentsQueuePos(const QVector<TorrentID> &ids) override;
-        void decreaseTorrentsQueuePos(const QVector<TorrentID> &ids) override;
-        void topTorrentsQueuePos(const QVector<TorrentID> &ids) override;
-        void bottomTorrentsQueuePos(const QVector<TorrentID> &ids) override;
+        void increaseTorrentsQueuePos(const QList<TorrentID> &ids) override;
+        void decreaseTorrentsQueuePos(const QList<TorrentID> &ids) override;
+        void topTorrentsQueuePos(const QList<TorrentID> &ids) override;
+        void bottomTorrentsQueuePos(const QList<TorrentID> &ids) override;
 
         // Torrent interface
         void handleTorrentResumeDataRequested(const TorrentImpl *torrent);
@@ -456,11 +456,11 @@ namespace BitTorrent
         void handleTorrentStarted(TorrentImpl *torrent);
         void handleTorrentChecked(TorrentImpl *torrent);
         void handleTorrentFinished(TorrentImpl *torrent);
-        void handleTorrentTrackersAdded(TorrentImpl *torrent, const QVector<TrackerEntry> &newTrackers);
+        void handleTorrentTrackersAdded(TorrentImpl *torrent, const QList<TrackerEntry> &newTrackers);
         void handleTorrentTrackersRemoved(TorrentImpl *torrent, const QStringList &deletedTrackers);
         void handleTorrentTrackersChanged(TorrentImpl *torrent);
-        void handleTorrentUrlSeedsAdded(TorrentImpl *torrent, const QVector<QUrl> &newUrlSeeds);
-        void handleTorrentUrlSeedsRemoved(TorrentImpl *torrent, const QVector<QUrl> &urlSeeds);
+        void handleTorrentUrlSeedsAdded(TorrentImpl *torrent, const QList<QUrl> &newUrlSeeds);
+        void handleTorrentUrlSeedsRemoved(TorrentImpl *torrent, const QList<QUrl> &urlSeeds);
         void handleTorrentResumeDataReady(TorrentImpl *torrent, const LoadTorrentParams &data);
         void handleTorrentInfoHashChanged(TorrentImpl *torrent, const InfoHash &prevInfoHash);
         void handleTorrentStorageMovingStateChanged(TorrentImpl *torrent);
@@ -749,8 +749,8 @@ namespace BitTorrent
         const bool m_wasPexEnabled = m_isPeXEnabled;
 
         int m_numResumeData = 0;
-        QVector<TrackerEntry> m_additionalTrackerEntries;
-        QVector<QRegularExpression> m_excludedFileNamesRegExpList;
+        QList<TrackerEntry> m_additionalTrackerEntries;
+        QList<QRegularExpression> m_excludedFileNamesRegExpList;
 
         // Statistics
         mutable QElapsedTimer m_statisticsLastUpdateTimer;

--- a/src/base/bittorrent/torrent.h
+++ b/src/base/bittorrent/torrent.h
@@ -249,8 +249,8 @@ namespace BitTorrent
         virtual bool hasMissingFiles() const = 0;
         virtual bool hasError() const = 0;
         virtual int queuePosition() const = 0;
-        virtual QVector<TrackerEntryStatus> trackers() const = 0;
-        virtual QVector<QUrl> urlSeeds() const = 0;
+        virtual QList<TrackerEntryStatus> trackers() const = 0;
+        virtual QList<QUrl> urlSeeds() const = 0;
         virtual QString error() const = 0;
         virtual qlonglong totalDownload() const = 0;
         virtual qlonglong totalUpload() const = 0;
@@ -274,10 +274,10 @@ namespace BitTorrent
         virtual bool isDHTDisabled() const = 0;
         virtual bool isPEXDisabled() const = 0;
         virtual bool isLSDDisabled() const = 0;
-        virtual QVector<PeerInfo> peers() const = 0;
+        virtual QList<PeerInfo> peers() const = 0;
         virtual QBitArray pieces() const = 0;
         virtual QBitArray downloadingPieces() const = 0;
-        virtual QVector<int> pieceAvailability() const = 0;
+        virtual QList<int> pieceAvailability() const = 0;
         virtual qreal distributedCopies() const = 0;
         virtual qreal maxRatio() const = 0;
         virtual int maxSeedingTime() const = 0;
@@ -306,11 +306,11 @@ namespace BitTorrent
         virtual void setDHTDisabled(bool disable) = 0;
         virtual void setPEXDisabled(bool disable) = 0;
         virtual void setLSDDisabled(bool disable) = 0;
-        virtual void addTrackers(QVector<TrackerEntry> trackers) = 0;
+        virtual void addTrackers(QList<TrackerEntry> trackers) = 0;
         virtual void removeTrackers(const QStringList &trackers) = 0;
-        virtual void replaceTrackers(QVector<TrackerEntry> trackers) = 0;
-        virtual void addUrlSeeds(const QVector<QUrl> &urlSeeds) = 0;
-        virtual void removeUrlSeeds(const QVector<QUrl> &urlSeeds) = 0;
+        virtual void replaceTrackers(QList<TrackerEntry> trackers) = 0;
+        virtual void addUrlSeeds(const QList<QUrl> &urlSeeds) = 0;
+        virtual void removeUrlSeeds(const QList<QUrl> &urlSeeds) = 0;
         virtual bool connectPeer(const PeerAddress &peerAddress) = 0;
         virtual void clearPeers() = 0;
         virtual void setMetadata(const TorrentInfo &torrentInfo) = 0;
@@ -324,9 +324,9 @@ namespace BitTorrent
         virtual nonstd::expected<QByteArray, QString> exportToBuffer() const = 0;
         virtual nonstd::expected<void, QString> exportToFile(const Path &path) const = 0;
 
-        virtual void fetchPeerInfo(std::function<void (QVector<PeerInfo>)> resultHandler) const = 0;
-        virtual void fetchURLSeeds(std::function<void (QVector<QUrl>)> resultHandler) const = 0;
-        virtual void fetchPieceAvailability(std::function<void (QVector<int>)> resultHandler) const = 0;
+        virtual void fetchPeerInfo(std::function<void (QList<PeerInfo>)> resultHandler) const = 0;
+        virtual void fetchURLSeeds(std::function<void (QList<QUrl>)> resultHandler) const = 0;
+        virtual void fetchPieceAvailability(std::function<void (QList<int>)> resultHandler) const = 0;
         virtual void fetchDownloadingPieces(std::function<void (QBitArray)> resultHandler) const = 0;
 
         TorrentID id() const;

--- a/src/base/bittorrent/torrentcontenthandler.h
+++ b/src/base/bittorrent/torrentcontenthandler.h
@@ -44,18 +44,18 @@ namespace BitTorrent
         virtual bool hasMetadata() const = 0;
         virtual Path actualStorageLocation() const = 0;
         virtual Path actualFilePath(int fileIndex) const = 0;
-        virtual QVector<DownloadPriority> filePriorities() const = 0;
-        virtual QVector<qreal> filesProgress() const = 0;
+        virtual QList<DownloadPriority> filePriorities() const = 0;
+        virtual QList<qreal> filesProgress() const = 0;
         /**
          * @brief fraction of file pieces that are available at least from one peer
          *
          * This is not the same as torrrent availability, it is just a fraction of pieces
          * that can be downloaded right now. It varies between 0 to 1.
          */
-        virtual QVector<qreal> availableFileFractions() const = 0;
-        virtual void fetchAvailableFileFractions(std::function<void (QVector<qreal>)> resultHandler) const = 0;
+        virtual QList<qreal> availableFileFractions() const = 0;
+        virtual void fetchAvailableFileFractions(std::function<void (QList<qreal>)> resultHandler) const = 0;
 
-        virtual void prioritizeFiles(const QVector<DownloadPriority> &priorities) = 0;
+        virtual void prioritizeFiles(const QList<DownloadPriority> &priorities) = 0;
         virtual void flushCache() const = 0;
     };
 }

--- a/src/base/bittorrent/torrentdescriptor.cpp
+++ b/src/base/bittorrent/torrentdescriptor.cpp
@@ -204,9 +204,9 @@ void BitTorrent::TorrentDescriptor::setTorrentInfo(TorrentInfo torrentInfo)
     }
 }
 
-QVector<BitTorrent::TrackerEntry> BitTorrent::TorrentDescriptor::trackers() const
+QList<BitTorrent::TrackerEntry> BitTorrent::TorrentDescriptor::trackers() const
 {
-    QVector<TrackerEntry> ret;
+    QList<TrackerEntry> ret;
     ret.reserve(static_cast<decltype(ret)::size_type>(m_ltAddTorrentParams.trackers.size()));
     std::size_t i = 0;
     for (const std::string &tracker : m_ltAddTorrentParams.trackers)
@@ -215,9 +215,9 @@ QVector<BitTorrent::TrackerEntry> BitTorrent::TorrentDescriptor::trackers() cons
     return ret;
 }
 
-QVector<QUrl> BitTorrent::TorrentDescriptor::urlSeeds() const
+QList<QUrl> BitTorrent::TorrentDescriptor::urlSeeds() const
 {
-    QVector<QUrl> urlSeeds;
+    QList<QUrl> urlSeeds;
     urlSeeds.reserve(static_cast<decltype(urlSeeds)::size_type>(m_ltAddTorrentParams.url_seeds.size()));
 
     for (const std::string &nativeURLSeed : m_ltAddTorrentParams.url_seeds)

--- a/src/base/bittorrent/torrentdescriptor.h
+++ b/src/base/bittorrent/torrentdescriptor.h
@@ -60,8 +60,8 @@ namespace BitTorrent
         QDateTime creationDate() const;
         QString creator() const;
         QString comment() const;
-        QVector<TrackerEntry> trackers() const;
-        QVector<QUrl> urlSeeds() const;
+        QList<TrackerEntry> trackers() const;
+        QList<QUrl> urlSeeds() const;
         const std::optional<TorrentInfo> &info() const;
 
         void setTorrentInfo(TorrentInfo torrentInfo);

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -606,12 +606,12 @@ Path TorrentImpl::makeUserPath(const Path &path) const
     return userPath;
 }
 
-QVector<TrackerEntryStatus> TorrentImpl::trackers() const
+QList<TrackerEntryStatus> TorrentImpl::trackers() const
 {
     return m_trackerEntryStatuses;
 }
 
-void TorrentImpl::addTrackers(QVector<TrackerEntry> trackers)
+void TorrentImpl::addTrackers(QList<TrackerEntry> trackers)
 {
     trackers.removeIf([](const TrackerEntry &trackerEntry) { return trackerEntry.url.isEmpty(); });
 
@@ -624,7 +624,7 @@ void TorrentImpl::addTrackers(QVector<TrackerEntry> trackers)
     if (newTrackerSet.isEmpty())
         return;
 
-    trackers = QVector<TrackerEntry>(newTrackerSet.cbegin(), newTrackerSet.cend());
+    trackers = QList<TrackerEntry>(newTrackerSet.cbegin(), newTrackerSet.cend());
     for (const TrackerEntry &tracker : asConst(trackers))
     {
         m_nativeHandle.add_tracker(makeNativeAnnounceEntry(tracker.url, tracker.tier));
@@ -660,13 +660,13 @@ void TorrentImpl::removeTrackers(const QStringList &trackers)
     }
 }
 
-void TorrentImpl::replaceTrackers(QVector<TrackerEntry> trackers)
+void TorrentImpl::replaceTrackers(QList<TrackerEntry> trackers)
 {
     trackers.removeIf([](const TrackerEntry &trackerEntry) { return trackerEntry.url.isEmpty(); });
 
     // Filter out duplicate trackers
     const auto uniqueTrackers = QSet<TrackerEntry>(trackers.cbegin(), trackers.cend());
-    trackers = QVector<TrackerEntry>(uniqueTrackers.cbegin(), uniqueTrackers.cend());
+    trackers = QList<TrackerEntry>(uniqueTrackers.cbegin(), uniqueTrackers.cend());
     std::sort(trackers.begin(), trackers.end()
         , [](const TrackerEntry &left, const TrackerEntry &right) { return left.tier < right.tier; });
 
@@ -691,12 +691,12 @@ void TorrentImpl::replaceTrackers(QVector<TrackerEntry> trackers)
     m_session->handleTorrentTrackersChanged(this);
 }
 
-QVector<QUrl> TorrentImpl::urlSeeds() const
+QList<QUrl> TorrentImpl::urlSeeds() const
 {
     return m_urlSeeds;
 }
 
-void TorrentImpl::addUrlSeeds(const QVector<QUrl> &urlSeeds)
+void TorrentImpl::addUrlSeeds(const QList<QUrl> &urlSeeds)
 {
     m_session->invokeAsync([urlSeeds, session = m_session
                            , nativeHandle = m_nativeHandle
@@ -705,12 +705,12 @@ void TorrentImpl::addUrlSeeds(const QVector<QUrl> &urlSeeds)
         try
         {
             const std::set<std::string> nativeSeeds = nativeHandle.url_seeds();
-            QVector<QUrl> currentSeeds;
+            QList<QUrl> currentSeeds;
             currentSeeds.reserve(static_cast<decltype(currentSeeds)::size_type>(nativeSeeds.size()));
             for (const std::string &urlSeed : nativeSeeds)
                 currentSeeds.append(QString::fromStdString(urlSeed));
 
-            QVector<QUrl> addedUrlSeeds;
+            QList<QUrl> addedUrlSeeds;
             addedUrlSeeds.reserve(urlSeeds.size());
 
             for (const QUrl &url : urlSeeds)
@@ -740,7 +740,7 @@ void TorrentImpl::addUrlSeeds(const QVector<QUrl> &urlSeeds)
     });
 }
 
-void TorrentImpl::removeUrlSeeds(const QVector<QUrl> &urlSeeds)
+void TorrentImpl::removeUrlSeeds(const QList<QUrl> &urlSeeds)
 {
     m_session->invokeAsync([urlSeeds, session = m_session
                            , nativeHandle = m_nativeHandle
@@ -749,12 +749,12 @@ void TorrentImpl::removeUrlSeeds(const QVector<QUrl> &urlSeeds)
         try
         {
             const std::set<std::string> nativeSeeds = nativeHandle.url_seeds();
-            QVector<QUrl> currentSeeds;
+            QList<QUrl> currentSeeds;
             currentSeeds.reserve(static_cast<decltype(currentSeeds)::size_type>(nativeSeeds.size()));
             for (const std::string &urlSeed : nativeSeeds)
                 currentSeeds.append(QString::fromStdString(urlSeed));
 
-            QVector<QUrl> removedUrlSeeds;
+            QList<QUrl> removedUrlSeeds;
             removedUrlSeeds.reserve(urlSeeds.size());
 
             for (const QUrl &url : urlSeeds)
@@ -966,7 +966,7 @@ Path TorrentImpl::filePath(const int index) const
 
 Path TorrentImpl::actualFilePath(const int index) const
 {
-    const QVector<lt::file_index_t> nativeIndexes = m_torrentInfo.nativeIndexes();
+    const QList<lt::file_index_t> nativeIndexes = m_torrentInfo.nativeIndexes();
 
     Q_ASSERT(index >= 0);
     Q_ASSERT(index < nativeIndexes.size());
@@ -1001,7 +1001,7 @@ PathList TorrentImpl::actualFilePaths() const
     return paths;
 }
 
-QVector<DownloadPriority> TorrentImpl::filePriorities() const
+QList<DownloadPriority> TorrentImpl::filePriorities() const
 {
     return m_filePriorities;
 }
@@ -1317,7 +1317,7 @@ qlonglong TorrentImpl::eta() const
     return (wantedSize() - completedSize()) / speedAverage.download;
 }
 
-QVector<qreal> TorrentImpl::filesProgress() const
+QList<qreal> TorrentImpl::filesProgress() const
 {
     if (!hasMetadata())
         return {};
@@ -1328,9 +1328,9 @@ QVector<qreal> TorrentImpl::filesProgress() const
         return {};
 
     if (m_completedFiles.count(true) == count)
-        return QVector<qreal>(count, 1);
+        return QList<qreal>(count, 1);
 
-    QVector<qreal> result;
+    QList<qreal> result;
     result.reserve(count);
     for (int i = 0; i < count; ++i)
     {
@@ -1445,12 +1445,12 @@ bool TorrentImpl::isLSDDisabled() const
     return static_cast<bool>(m_nativeStatus.flags & lt::torrent_flags::disable_lsd);
 }
 
-QVector<PeerInfo> TorrentImpl::peers() const
+QList<PeerInfo> TorrentImpl::peers() const
 {
     std::vector<lt::peer_info> nativePeers;
     m_nativeHandle.get_peer_info(nativePeers);
 
-    QVector<PeerInfo> peers;
+    QList<PeerInfo> peers;
     peers.reserve(static_cast<decltype(peers)::size_type>(nativePeers.size()));
 
     for (const lt::peer_info &peer : nativePeers)
@@ -1477,7 +1477,7 @@ QBitArray TorrentImpl::downloadingPieces() const
     return result;
 }
 
-QVector<int> TorrentImpl::pieceAvailability() const
+QList<int> TorrentImpl::pieceAvailability() const
 {
     std::vector<int> avail;
     m_nativeHandle.piece_availability(avail);
@@ -2113,7 +2113,7 @@ void TorrentImpl::handleSaveResumeDataAlert(const lt::save_resume_data_alert *p)
         // URL seed list have been changed by libtorrent for some reason, so we need to update cached one.
         // Unfortunately, URL seed list containing in "resume data" is generated according to different rules
         // than the list we usually cache, so we have to request it from the appropriate source.
-        fetchURLSeeds([this](const QVector<QUrl> &urlSeeds) { m_urlSeeds = urlSeeds; });
+        fetchURLSeeds([this](const QList<QUrl> &urlSeeds) { m_urlSeeds = urlSeeds; });
     }
 
     if ((m_maintenanceJob == MaintenanceJob::HandleMetadata) && p->params.ti)
@@ -2490,7 +2490,7 @@ void TorrentImpl::adjustStorageLocation()
 
 void TorrentImpl::doRenameFile(const int index, const Path &path)
 {
-    const QVector<lt::file_index_t> nativeIndexes = m_torrentInfo.nativeIndexes();
+    const QList<lt::file_index_t> nativeIndexes = m_torrentInfo.nativeIndexes();
 
     Q_ASSERT(index >= 0);
     Q_ASSERT(index < nativeIndexes.size());
@@ -2872,15 +2872,15 @@ nonstd::expected<void, QString> TorrentImpl::exportToFile(const Path &path) cons
     return {};
 }
 
-void TorrentImpl::fetchPeerInfo(std::function<void (QVector<PeerInfo>)> resultHandler) const
+void TorrentImpl::fetchPeerInfo(std::function<void (QList<PeerInfo>)> resultHandler) const
 {
-    invokeAsync([nativeHandle = m_nativeHandle, allPieces = pieces()]() -> QVector<PeerInfo>
+    invokeAsync([nativeHandle = m_nativeHandle, allPieces = pieces()]() -> QList<PeerInfo>
     {
         try
         {
             std::vector<lt::peer_info> nativePeers;
             nativeHandle.get_peer_info(nativePeers);
-            QVector<PeerInfo> peers;
+            QList<PeerInfo> peers;
             peers.reserve(static_cast<decltype(peers)::size_type>(nativePeers.size()));
             for (const lt::peer_info &peer : nativePeers)
                 peers.append(PeerInfo(peer, allPieces));
@@ -2893,14 +2893,14 @@ void TorrentImpl::fetchPeerInfo(std::function<void (QVector<PeerInfo>)> resultHa
     , std::move(resultHandler));
 }
 
-void TorrentImpl::fetchURLSeeds(std::function<void (QVector<QUrl>)> resultHandler) const
+void TorrentImpl::fetchURLSeeds(std::function<void (QList<QUrl>)> resultHandler) const
 {
-    invokeAsync([nativeHandle = m_nativeHandle]() -> QVector<QUrl>
+    invokeAsync([nativeHandle = m_nativeHandle]() -> QList<QUrl>
     {
         try
         {
             const std::set<std::string> currentSeeds = nativeHandle.url_seeds();
-            QVector<QUrl> urlSeeds;
+            QList<QUrl> urlSeeds;
             urlSeeds.reserve(static_cast<decltype(urlSeeds)::size_type>(currentSeeds.size()));
             for (const std::string &urlSeed : currentSeeds)
                 urlSeeds.append(QString::fromStdString(urlSeed));
@@ -2913,15 +2913,15 @@ void TorrentImpl::fetchURLSeeds(std::function<void (QVector<QUrl>)> resultHandle
     , std::move(resultHandler));
 }
 
-void TorrentImpl::fetchPieceAvailability(std::function<void (QVector<int>)> resultHandler) const
+void TorrentImpl::fetchPieceAvailability(std::function<void (QList<int>)> resultHandler) const
 {
-    invokeAsync([nativeHandle = m_nativeHandle]() -> QVector<int>
+    invokeAsync([nativeHandle = m_nativeHandle]() -> QList<int>
     {
         try
         {
             std::vector<int> piecesAvailability;
             nativeHandle.piece_availability(piecesAvailability);
-            return QVector<int>(piecesAvailability.cbegin(), piecesAvailability.cend());
+            return QList<int>(piecesAvailability.cbegin(), piecesAvailability.cend());
         }
         catch (const std::exception &) {}
 
@@ -2955,9 +2955,9 @@ void TorrentImpl::fetchDownloadingPieces(std::function<void (QBitArray)> resultH
     , std::move(resultHandler));
 }
 
-void TorrentImpl::fetchAvailableFileFractions(std::function<void (QVector<qreal>)> resultHandler) const
+void TorrentImpl::fetchAvailableFileFractions(std::function<void (QList<qreal>)> resultHandler) const
 {
-    invokeAsync([nativeHandle = m_nativeHandle, torrentInfo = m_torrentInfo]() -> QVector<qreal>
+    invokeAsync([nativeHandle = m_nativeHandle, torrentInfo = m_torrentInfo]() -> QList<qreal>
     {
         if (!torrentInfo.isValid() || (torrentInfo.filesCount() <= 0))
             return {};
@@ -2969,9 +2969,9 @@ void TorrentImpl::fetchAvailableFileFractions(std::function<void (QVector<qreal>
             const int filesCount = torrentInfo.filesCount();
             // libtorrent returns empty array for seeding only torrents
             if (piecesAvailability.empty())
-                return QVector<qreal>(filesCount, -1);
+                return QList<qreal>(filesCount, -1);
 
-            QVector<qreal> result;
+            QList<qreal> result;
             result.reserve(filesCount);
             for (int i = 0; i < filesCount; ++i)
             {
@@ -2995,7 +2995,7 @@ void TorrentImpl::fetchAvailableFileFractions(std::function<void (QVector<qreal>
     , std::move(resultHandler));
 }
 
-void TorrentImpl::prioritizeFiles(const QVector<DownloadPriority> &priorities)
+void TorrentImpl::prioritizeFiles(const QList<DownloadPriority> &priorities)
 {
     if (!hasMetadata())
         return;
@@ -3004,7 +3004,7 @@ void TorrentImpl::prioritizeFiles(const QVector<DownloadPriority> &priorities)
 
     // Reset 'm_hasSeedStatus' if needed in order to react again to
     // 'torrent_finished_alert' and eg show tray notifications
-    const QVector<DownloadPriority> oldPriorities = filePriorities();
+    const QList<DownloadPriority> oldPriorities = filePriorities();
     for (int i = 0; i < oldPriorities.size(); ++i)
     {
         if ((oldPriorities[i] == DownloadPriority::Ignored)
@@ -3032,18 +3032,18 @@ void TorrentImpl::prioritizeFiles(const QVector<DownloadPriority> &priorities)
     manageActualFilePaths();
 }
 
-QVector<qreal> TorrentImpl::availableFileFractions() const
+QList<qreal> TorrentImpl::availableFileFractions() const
 {
     Q_ASSERT(hasMetadata());
 
     const int filesCount = this->filesCount();
     if (filesCount <= 0) return {};
 
-    const QVector<int> piecesAvailability = pieceAvailability();
+    const QList<int> piecesAvailability = pieceAvailability();
     // libtorrent returns empty array for seeding only torrents
-    if (piecesAvailability.empty()) return QVector<qreal>(filesCount, -1);
+    if (piecesAvailability.empty()) return QList<qreal>(filesCount, -1);
 
-    QVector<qreal> res;
+    QList<qreal> res;
     res.reserve(filesCount);
     for (int i = 0; i < filesCount; ++i)
     {

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -41,11 +41,11 @@
 #include <QBitArray>
 #include <QDateTime>
 #include <QHash>
+#include <QList>
 #include <QMap>
 #include <QObject>
 #include <QQueue>
 #include <QString>
-#include <QVector>
 
 #include "base/path.h"
 #include "base/tagset.h"
@@ -154,7 +154,7 @@ namespace BitTorrent
         qlonglong fileSize(int index) const override;
         PathList filePaths() const override;
         PathList actualFilePaths() const override;
-        QVector<DownloadPriority> filePriorities() const override;
+        QList<DownloadPriority> filePriorities() const override;
 
         TorrentInfo info() const override;
         bool isFinished() const override;
@@ -176,15 +176,15 @@ namespace BitTorrent
         bool hasMissingFiles() const override;
         bool hasError() const override;
         int queuePosition() const override;
-        QVector<TrackerEntryStatus> trackers() const override;
-        QVector<QUrl> urlSeeds() const override;
+        QList<TrackerEntryStatus> trackers() const override;
+        QList<QUrl> urlSeeds() const override;
         QString error() const override;
         qlonglong totalDownload() const override;
         qlonglong totalUpload() const override;
         qlonglong activeTime() const override;
         qlonglong finishedTime() const override;
         qlonglong eta() const override;
-        QVector<qreal> filesProgress() const override;
+        QList<qreal> filesProgress() const override;
         int seedsCount() const override;
         int peersCount() const override;
         int leechsCount() const override;
@@ -202,10 +202,10 @@ namespace BitTorrent
         bool isDHTDisabled() const override;
         bool isPEXDisabled() const override;
         bool isLSDDisabled() const override;
-        QVector<PeerInfo> peers() const override;
+        QList<PeerInfo> peers() const override;
         QBitArray pieces() const override;
         QBitArray downloadingPieces() const override;
-        QVector<int> pieceAvailability() const override;
+        QList<int> pieceAvailability() const override;
         qreal distributedCopies() const override;
         qreal maxRatio() const override;
         int maxSeedingTime() const override;
@@ -219,7 +219,7 @@ namespace BitTorrent
         int connectionsCount() const override;
         int connectionsLimit() const override;
         qlonglong nextAnnounce() const override;
-        QVector<qreal> availableFileFractions() const override;
+        QList<qreal> availableFileFractions() const override;
 
         void setName(const QString &name) override;
         void setSequentialDownload(bool enable) override;
@@ -230,7 +230,7 @@ namespace BitTorrent
         void forceDHTAnnounce() override;
         void forceRecheck() override;
         void renameFile(int index, const Path &path) override;
-        void prioritizeFiles(const QVector<DownloadPriority> &priorities) override;
+        void prioritizeFiles(const QList<DownloadPriority> &priorities) override;
         void setUploadLimit(int limit) override;
         void setDownloadLimit(int limit) override;
         void setSuperSeeding(bool enable) override;
@@ -238,11 +238,11 @@ namespace BitTorrent
         void setPEXDisabled(bool disable) override;
         void setLSDDisabled(bool disable) override;
         void flushCache() const override;
-        void addTrackers(QVector<TrackerEntry> trackers) override;
+        void addTrackers(QList<TrackerEntry> trackers) override;
         void removeTrackers(const QStringList &trackers) override;
-        void replaceTrackers(QVector<TrackerEntry> trackers) override;
-        void addUrlSeeds(const QVector<QUrl> &urlSeeds) override;
-        void removeUrlSeeds(const QVector<QUrl> &urlSeeds) override;
+        void replaceTrackers(QList<TrackerEntry> trackers) override;
+        void addUrlSeeds(const QList<QUrl> &urlSeeds) override;
+        void removeUrlSeeds(const QList<QUrl> &urlSeeds) override;
         bool connectPeer(const PeerAddress &peerAddress) override;
         void clearPeers() override;
         void setMetadata(const TorrentInfo &torrentInfo) override;
@@ -257,11 +257,11 @@ namespace BitTorrent
         nonstd::expected<QByteArray, QString> exportToBuffer() const override;
         nonstd::expected<void, QString> exportToFile(const Path &path) const override;
 
-        void fetchPeerInfo(std::function<void (QVector<PeerInfo>)> resultHandler) const override;
-        void fetchURLSeeds(std::function<void (QVector<QUrl>)> resultHandler) const override;
-        void fetchPieceAvailability(std::function<void (QVector<int>)> resultHandler) const override;
+        void fetchPeerInfo(std::function<void (QList<PeerInfo>)> resultHandler) const override;
+        void fetchURLSeeds(std::function<void (QList<QUrl>)> resultHandler) const override;
+        void fetchPieceAvailability(std::function<void (QList<int>)> resultHandler) const override;
         void fetchDownloadingPieces(std::function<void (QBitArray)> resultHandler) const override;
-        void fetchAvailableFileFractions(std::function<void (QVector<qreal>)> resultHandler) const override;
+        void fetchAvailableFileFractions(std::function<void (QList<qreal>)> resultHandler) const override;
 
         bool needSaveResumeData() const;
 
@@ -336,7 +336,7 @@ namespace BitTorrent
         TorrentInfo m_torrentInfo;
         PathList m_filePaths;
         QHash<lt::file_index_t, int> m_indexMap;
-        QVector<DownloadPriority> m_filePriorities;
+        QList<DownloadPriority> m_filePriorities;
         QBitArray m_completedFiles;
         SpeedMonitor m_payloadRateMonitor;
 
@@ -352,8 +352,8 @@ namespace BitTorrent
 
         MaintenanceJob m_maintenanceJob = MaintenanceJob::None;
 
-        QVector<TrackerEntryStatus> m_trackerEntryStatuses;
-        QVector<QUrl> m_urlSeeds;
+        QList<TrackerEntryStatus> m_trackerEntryStatuses;
+        QList<QUrl> m_urlSeeds;
         FileErrorInfo m_lastFileError;
 
         // Persistent data
@@ -384,7 +384,7 @@ namespace BitTorrent
         int m_uploadLimit = 0;
 
         QBitArray m_pieces;
-        QVector<std::int64_t> m_filesProgress;
+        QList<std::int64_t> m_filesProgress;
 
         bool m_deferredRequestResumeDataInvoked = false;
     };

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -270,13 +270,13 @@ qlonglong TorrentInfo::fileOffset(const int index) const
     return m_nativeInfo->orig_files().file_offset(m_nativeIndexes[index]);
 }
 
-QVector<TrackerEntry> TorrentInfo::trackers() const
+QList<TrackerEntry> TorrentInfo::trackers() const
 {
     if (!isValid()) return {};
 
     const std::vector<lt::announce_entry> trackers = m_nativeInfo->trackers();
 
-    QVector<TrackerEntry> ret;
+    QList<TrackerEntry> ret;
     ret.reserve(static_cast<decltype(ret)::size_type>(trackers.size()));
     for (const lt::announce_entry &tracker : trackers)
         ret.append({.url = QString::fromStdString(tracker.url), .tier = tracker.tier});
@@ -284,13 +284,13 @@ QVector<TrackerEntry> TorrentInfo::trackers() const
     return ret;
 }
 
-QVector<QUrl> TorrentInfo::urlSeeds() const
+QList<QUrl> TorrentInfo::urlSeeds() const
 {
     if (!isValid()) return {};
 
     const std::vector<lt::web_seed_entry> &nativeWebSeeds = m_nativeInfo->web_seeds();
 
-    QVector<QUrl> urlSeeds;
+    QList<QUrl> urlSeeds;
     urlSeeds.reserve(static_cast<decltype(urlSeeds)::size_type>(nativeWebSeeds.size()));
 
     for (const lt::web_seed_entry &webSeed : nativeWebSeeds)
@@ -320,7 +320,7 @@ QByteArray TorrentInfo::metadata() const
 PathList TorrentInfo::filesForPiece(const int pieceIndex) const
 {
     // no checks here because fileIndicesForPiece() will return an empty list
-    const QVector<int> fileIndices = fileIndicesForPiece(pieceIndex);
+    const QList<int> fileIndices = fileIndicesForPiece(pieceIndex);
 
     PathList res;
     res.reserve(fileIndices.size());
@@ -330,14 +330,14 @@ PathList TorrentInfo::filesForPiece(const int pieceIndex) const
     return res;
 }
 
-QVector<int> TorrentInfo::fileIndicesForPiece(const int pieceIndex) const
+QList<int> TorrentInfo::fileIndicesForPiece(const int pieceIndex) const
 {
     if (!isValid() || (pieceIndex < 0) || (pieceIndex >= piecesCount()))
         return {};
 
     const std::vector<lt::file_slice> files = m_nativeInfo->map_block(
                 lt::piece_index_t {pieceIndex}, 0, m_nativeInfo->piece_size(lt::piece_index_t {pieceIndex}));
-    QVector<int> res;
+    QList<int> res;
     res.reserve(static_cast<decltype(res)::size_type>(files.size()));
     for (const lt::file_slice &fileSlice : files)
     {
@@ -349,13 +349,13 @@ QVector<int> TorrentInfo::fileIndicesForPiece(const int pieceIndex) const
     return res;
 }
 
-QVector<QByteArray> TorrentInfo::pieceHashes() const
+QList<QByteArray> TorrentInfo::pieceHashes() const
 {
     if (!isValid())
         return {};
 
     const int count = piecesCount();
-    QVector<QByteArray> hashes;
+    QList<QByteArray> hashes;
     hashes.reserve(count);
 
     for (int i = 0; i < count; ++i)
@@ -450,7 +450,7 @@ std::shared_ptr<lt::torrent_info> TorrentInfo::nativeInfo() const
     return std::make_shared<lt::torrent_info>(*m_nativeInfo);
 }
 
-QVector<lt::file_index_t> TorrentInfo::nativeIndexes() const
+QList<lt::file_index_t> TorrentInfo::nativeIndexes() const
 {
     return m_nativeIndexes;
 }

--- a/src/base/bittorrent/torrentinfo.h
+++ b/src/base/bittorrent/torrentinfo.h
@@ -32,7 +32,7 @@
 
 #include <QtContainerFwd>
 #include <QCoreApplication>
-#include <QVector>
+#include <QList>
 
 #include "base/3rdparty/expected.hpp"
 #include "base/indexrange.h"
@@ -80,12 +80,12 @@ namespace BitTorrent
         PathList filePaths() const;
         qlonglong fileSize(int index) const;
         qlonglong fileOffset(int index) const;
-        QVector<TrackerEntry> trackers() const;
-        QVector<QUrl> urlSeeds() const;
+        QList<TrackerEntry> trackers() const;
+        QList<QUrl> urlSeeds() const;
         QByteArray metadata() const;
         PathList filesForPiece(int pieceIndex) const;
-        QVector<int> fileIndicesForPiece(int pieceIndex) const;
-        QVector<QByteArray> pieceHashes() const;
+        QList<int> fileIndicesForPiece(int pieceIndex) const;
+        QList<QByteArray> pieceHashes() const;
 
         using PieceRange = IndexRange<int>;
         // returns pair of the first and the last pieces into which
@@ -96,7 +96,7 @@ namespace BitTorrent
         bool matchesInfoHash(const InfoHash &otherInfoHash) const;
 
         std::shared_ptr<lt::torrent_info> nativeInfo() const;
-        QVector<lt::file_index_t> nativeIndexes() const;
+        QList<lt::file_index_t> nativeIndexes() const;
 
     private:
         // returns file index or -1 if fileName is not found
@@ -106,7 +106,7 @@ namespace BitTorrent
 
         // internal indexes of files (payload only, excluding any .pad files)
         // by which they are addressed in libtorrent
-        QVector<lt::file_index_t> m_nativeIndexes;
+        QList<lt::file_index_t> m_nativeIndexes;
     };
 }
 

--- a/src/base/http/types.h
+++ b/src/base/http/types.h
@@ -30,8 +30,8 @@
 #pragma once
 
 #include <QHostAddress>
+#include <QList>
 #include <QString>
-#include <QVector>
 
 #include "base/global.h"
 
@@ -109,7 +109,7 @@ namespace Http
         HeaderMap headers;
         QHash<QString, QByteArray> query;
         QHash<QString, QString> posts;
-        QVector<UploadedFile> files;
+        QList<UploadedFile> files;
     };
 
     struct ResponseStatus

--- a/src/base/logger.cpp
+++ b/src/base/logger.cpp
@@ -31,14 +31,14 @@
 #include <algorithm>
 
 #include <QDateTime>
-#include <QVector>
+#include <QList>
 
 namespace
 {
     template <typename T>
-    QVector<T> loadFromBuffer(const boost::circular_buffer_space_optimized<T> &src, const int offset = 0)
+    QList<T> loadFromBuffer(const boost::circular_buffer_space_optimized<T> &src, const int offset = 0)
     {
-        QVector<T> ret;
+        QList<T> ret;
         ret.reserve(static_cast<typename decltype(ret)::size_type>(src.size()) - offset);
         std::copy((src.begin() + offset), src.end(), std::back_inserter(ret));
         return ret;
@@ -90,7 +90,7 @@ void Logger::addPeer(const QString &ip, const bool blocked, const QString &reaso
     emit newLogPeer(msg);
 }
 
-QVector<Log::Msg> Logger::getMessages(const int lastKnownId) const
+QList<Log::Msg> Logger::getMessages(const int lastKnownId) const
 {
     const QReadLocker locker(&m_lock);
 
@@ -106,7 +106,7 @@ QVector<Log::Msg> Logger::getMessages(const int lastKnownId) const
     return loadFromBuffer(m_messages, (size - diff));
 }
 
-QVector<Log::Peer> Logger::getPeers(const int lastKnownId) const
+QList<Log::Peer> Logger::getPeers(const int lastKnownId) const
 {
     const QReadLocker locker(&m_lock);
 

--- a/src/base/logger.h
+++ b/src/base/logger.h
@@ -81,8 +81,8 @@ public:
 
     void addMessage(const QString &message, const Log::MsgType &type = Log::NORMAL);
     void addPeer(const QString &ip, bool blocked, const QString &reason = {});
-    QVector<Log::Msg> getMessages(int lastKnownId = -1) const;
-    QVector<Log::Peer> getPeers(int lastKnownId = -1) const;
+    QList<Log::Msg> getMessages(int lastKnownId = -1) const;
+    QList<Log::Peer> getPeers(int lastKnownId = -1) const;
 
 signals:
     void newLogMessage(const Log::Msg &message);

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -673,11 +673,11 @@ void Preferences::setWebUIAuthSubnetWhitelistEnabled(const bool enabled)
     setValue(u"Preferences/WebUI/AuthSubnetWhitelistEnabled"_s, enabled);
 }
 
-QVector<Utils::Net::Subnet> Preferences::getWebUIAuthSubnetWhitelist() const
+QList<Utils::Net::Subnet> Preferences::getWebUIAuthSubnetWhitelist() const
 {
     const auto subnets = value<QStringList>(u"Preferences/WebUI/AuthSubnetWhitelist"_s);
 
-    QVector<Utils::Net::Subnet> ret;
+    QList<Utils::Net::Subnet> ret;
     ret.reserve(subnets.size());
 
     for (const QString &rawSubnet : subnets)

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -185,7 +185,7 @@ public:
     void setWebUILocalAuthEnabled(bool enabled);
     bool isWebUIAuthSubnetWhitelistEnabled() const;
     void setWebUIAuthSubnetWhitelistEnabled(bool enabled);
-    QVector<Utils::Net::Subnet> getWebUIAuthSubnetWhitelist() const;
+    QList<Utils::Net::Subnet> getWebUIAuthSubnetWhitelist() const;
     void setWebUIAuthSubnetWhitelist(QStringList subnets);
     QString getWebUIUsername() const;
     void setWebUIUsername(const QString &username);

--- a/src/base/rss/feed_serializer.cpp
+++ b/src/base/rss/feed_serializer.cpp
@@ -34,14 +34,14 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QVector>
+#include <QList>
 
 #include "base/logger.h"
 #include "base/path.h"
 #include "base/utils/io.h"
 #include "rss_article.h"
 
-const int ARTICLEDATALIST_TYPEID = qRegisterMetaType<QVector<QVariantHash>>();
+const int ARTICLEDATALIST_TYPEID = qRegisterMetaType<QList<QVariantHash>>();
 
 void RSS::Private::FeedSerializer::load(const Path &dataFileName, const QString &url)
 {
@@ -61,7 +61,7 @@ void RSS::Private::FeedSerializer::load(const Path &dataFileName, const QString 
     emit loadingFinished(loadArticles(readResult.value(), url));
 }
 
-void RSS::Private::FeedSerializer::store(const Path &dataFileName, const QVector<QVariantHash> &articlesData)
+void RSS::Private::FeedSerializer::store(const Path &dataFileName, const QList<QVariantHash> &articlesData)
 {
     QJsonArray arr;
     for (const QVariantHash &data : articlesData)
@@ -81,7 +81,7 @@ void RSS::Private::FeedSerializer::store(const Path &dataFileName, const QVector
     }
 }
 
-QVector<QVariantHash> RSS::Private::FeedSerializer::loadArticles(const QByteArray &data, const QString &url)
+QList<QVariantHash> RSS::Private::FeedSerializer::loadArticles(const QByteArray &data, const QString &url)
 {
     QJsonParseError jsonError;
     const QJsonDocument jsonDoc = QJsonDocument::fromJson(data, &jsonError);
@@ -98,7 +98,7 @@ QVector<QVariantHash> RSS::Private::FeedSerializer::loadArticles(const QByteArra
         return {};
     }
 
-    QVector<QVariantHash> result;
+    QList<QVariantHash> result;
     const QJsonArray jsonArr = jsonDoc.array();
     result.reserve(jsonArr.size());
     for (int i = 0; i < jsonArr.size(); ++i)

--- a/src/base/rss/feed_serializer.h
+++ b/src/base/rss/feed_serializer.h
@@ -49,12 +49,12 @@ namespace RSS::Private
         using QObject::QObject;
 
         void load(const Path &dataFileName, const QString &url);
-        void store(const Path &dataFileName, const QVector<QVariantHash> &articlesData);
+        void store(const Path &dataFileName, const QList<QVariantHash> &articlesData);
 
     signals:
-        void loadingFinished(const QVector<QVariantHash> &articles);
+        void loadingFinished(const QList<QVariantHash> &articles);
 
     private:
-        QVector<QVariantHash> loadArticles(const QByteArray &data, const QString &url);
+        QList<QVariantHash> loadArticles(const QByteArray &data, const QString &url);
     };
 }

--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -35,11 +35,11 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
+#include <QList>
 #include <QThread>
 #include <QTimer>
 #include <QUrl>
 #include <QVariant>
-#include <QVector>
 
 #include "base/addtorrentmanager.h"
 #include "base/asyncfilestorage.h"
@@ -68,7 +68,7 @@ const QString RULES_FILE_NAME = u"download_rules.json"_s;
 
 namespace
 {
-    QVector<RSS::AutoDownloadRule> rulesFromJSON(const QByteArray &jsonData)
+    QList<RSS::AutoDownloadRule> rulesFromJSON(const QByteArray &jsonData)
     {
         QJsonParseError jsonError;
         const QJsonDocument jsonDoc = QJsonDocument::fromJson(jsonData, &jsonError);
@@ -79,7 +79,7 @@ namespace
             throw RSS::ParsingError(RSS::AutoDownloader::tr("Invalid data format."));
 
         const QJsonObject jsonObj {jsonDoc.object()};
-        QVector<RSS::AutoDownloadRule> rules;
+        QList<RSS::AutoDownloadRule> rules;
         for (auto it = jsonObj.begin(); it != jsonObj.end(); ++it)
         {
             const QJsonValue jsonVal {it.value()};

--- a/src/base/rss/rss_feed.cpp
+++ b/src/base/rss/rss_feed.cpp
@@ -39,8 +39,8 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
+#include <QList>
 #include <QUrl>
-#include <QVector>
 
 #include "base/asyncfilestorage.h"
 #include "base/global.h"
@@ -301,7 +301,7 @@ void Feed::store()
     m_dirty = false;
     m_savingTimer.stop();
 
-    QVector<QVariantHash> articlesData;
+    QList<QVariantHash> articlesData;
     articlesData.reserve(m_articles.size());
 
     for (Article *article :asConst(m_articles))
@@ -395,7 +395,7 @@ int Feed::updateArticles(const QList<QVariantHash> &loadedArticles)
         return 0;
 
     QDateTime dummyPubDate {QDateTime::currentDateTime()};
-    QVector<QVariantHash> newArticles;
+    QList<QVariantHash> newArticles;
     newArticles.reserve(loadedArticles.size());
     for (QVariantHash article : loadedArticles)
     {
@@ -516,7 +516,7 @@ void Feed::handleArticleRead(Article *article)
     storeDeferred();
 }
 
-void Feed::handleArticleLoadFinished(QVector<QVariantHash> articles)
+void Feed::handleArticleLoadFinished(QList<QVariantHash> articles)
 {
     Q_ASSERT(m_articles.isEmpty());
     Q_ASSERT(m_unreadCount == 0);

--- a/src/base/rss/rss_feed.h
+++ b/src/base/rss/rss_feed.h
@@ -102,7 +102,7 @@ namespace RSS
         void handleDownloadFinished(const Net::DownloadResult &result);
         void handleParsingFinished(const Private::ParsingResult &result);
         void handleArticleRead(Article *article);
-        void handleArticleLoadFinished(QVector<QVariantHash> articles);
+        void handleArticleLoadFinished(QList<QVariantHash> articles);
 
     private:
         void timerEvent(QTimerEvent *event) override;

--- a/src/base/search/searchhandler.cpp
+++ b/src/base/search/searchhandler.cpp
@@ -31,10 +31,10 @@
 
 #include <chrono>
 
+#include <QList>
 #include <QMetaObject>
 #include <QProcess>
 #include <QTimer>
-#include <QVector>
 
 #include "base/global.h"
 #include "base/path.h"
@@ -145,7 +145,7 @@ void SearchHandler::readSearchOutput()
         lines.prepend(m_searchResultLineTruncated + lines.takeFirst());
     m_searchResultLineTruncated = lines.takeLast().trimmed();
 
-    QVector<SearchResult> searchResultList;
+    QList<SearchResult> searchResultList;
     searchResultList.reserve(lines.size());
 
     for (const QByteArray &line : asConst(lines))

--- a/src/base/search/searchhandler.h
+++ b/src/base/search/searchhandler.h
@@ -75,7 +75,7 @@ public:
 signals:
     void searchFinished(bool cancelled = false);
     void searchFailed();
-    void newSearchResults(const QVector<SearchResult> &results);
+    void newSearchResults(const QList<SearchResult> &results);
 
 private:
     void readSearchOutput();

--- a/src/base/utils/net.cpp
+++ b/src/base/utils/net.cpp
@@ -33,7 +33,6 @@
 #include <QSslCertificate>
 #include <QSslKey>
 #include <QString>
-#include <QVector>
 
 #include "base/global.h"
 
@@ -62,7 +61,7 @@ namespace Utils
                     || (addr == QHostAddress(u"::ffff:127.0.0.1"_s));
         }
 
-        bool isIPInSubnets(const QHostAddress &addr, const QVector<Subnet> &subnets)
+        bool isIPInSubnets(const QHostAddress &addr, const QList<Subnet> &subnets)
         {
             QHostAddress protocolEquivalentAddress;
             bool addrConversionOk = false;

--- a/src/base/utils/net.h
+++ b/src/base/utils/net.h
@@ -46,7 +46,7 @@ namespace Utils::Net
     bool isValidIP(const QString &ip);
     std::optional<Subnet> parseSubnet(const QString &subnetStr);
     bool isLoopbackAddress(const QHostAddress &addr);
-    bool isIPInSubnets(const QHostAddress &addr, const QVector<Subnet> &subnets);
+    bool isIPInSubnets(const QHostAddress &addr, const QList<Subnet> &subnets);
     QString subnetToString(const Subnet &subnet);
     QHostAddress canonicalIPv6Addr(const QHostAddress &addr);
 

--- a/src/base/utils/password.cpp
+++ b/src/base/utils/password.cpp
@@ -34,8 +34,8 @@
 #include <openssl/evp.h>
 
 #include <QByteArray>
+#include <QList>
 #include <QString>
-#include <QVector>
 
 #include "base/global.h"
 #include "bytearray.h"

--- a/src/base/utils/string.cpp
+++ b/src/base/utils/string.cpp
@@ -31,10 +31,10 @@
 
 #include <cmath>
 
+#include <QList>
 #include <QLocale>
 #include <QRegularExpression>
 #include <QStringList>
-#include <QVector>
 
 // to send numbers instead of strings with suffixes
 QString Utils::String::fromDouble(const double n, const int precision)

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -38,6 +38,7 @@
 #include <QDebug>
 #include <QDir>
 #include <QFileDialog>
+#include <QList>
 #include <QMenu>
 #include <QMessageBox>
 #include <QPushButton>
@@ -46,7 +47,6 @@
 #include <QSize>
 #include <QString>
 #include <QUrl>
-#include <QVector>
 
 #include "base/bittorrent/addtorrentparams.h"
 #include "base/bittorrent/downloadpriority.h"
@@ -143,7 +143,7 @@ class AddNewTorrentDialog::TorrentContentAdaptor final
 {
 public:
     TorrentContentAdaptor(const BitTorrent::TorrentInfo &torrentInfo, PathList &filePaths
-            , QVector<BitTorrent::DownloadPriority> &filePriorities, std::function<void ()> onFilePrioritiesChanged)
+            , QList<BitTorrent::DownloadPriority> &filePriorities, std::function<void ()> onFilePrioritiesChanged)
         : m_torrentInfo {torrentInfo}
         , m_filePaths {filePaths}
         , m_filePriorities {filePriorities}
@@ -227,29 +227,29 @@ public:
         }
     }
 
-    QVector<BitTorrent::DownloadPriority> filePriorities() const override
+    QList<BitTorrent::DownloadPriority> filePriorities() const override
     {
         return m_filePriorities.isEmpty()
-                ? QVector<BitTorrent::DownloadPriority>(filesCount(), BitTorrent::DownloadPriority::Normal)
+                ? QList<BitTorrent::DownloadPriority>(filesCount(), BitTorrent::DownloadPriority::Normal)
                 : m_filePriorities;
     }
 
-    QVector<qreal> filesProgress() const override
+    QList<qreal> filesProgress() const override
     {
-        return QVector<qreal>(filesCount(), 0);
+        return QList<qreal>(filesCount(), 0);
     }
 
-    QVector<qreal> availableFileFractions() const override
+    QList<qreal> availableFileFractions() const override
     {
-        return QVector<qreal>(filesCount(), 0);
+        return QList<qreal>(filesCount(), 0);
     }
 
-    void fetchAvailableFileFractions(std::function<void (QVector<qreal>)> resultHandler) const override
+    void fetchAvailableFileFractions(std::function<void (QList<qreal>)> resultHandler) const override
     {
         resultHandler(availableFileFractions());
     }
 
-    void prioritizeFiles(const QVector<BitTorrent::DownloadPriority> &priorities) override
+    void prioritizeFiles(const QList<BitTorrent::DownloadPriority> &priorities) override
     {
         Q_ASSERT(priorities.size() == filesCount());
         m_filePriorities = priorities;
@@ -274,7 +274,7 @@ public:
 private:
     const BitTorrent::TorrentInfo &m_torrentInfo;
     PathList &m_filePaths;
-    QVector<BitTorrent::DownloadPriority> &m_filePriorities;
+    QList<BitTorrent::DownloadPriority> &m_filePriorities;
     std::function<void ()> m_onFilePrioritiesChanged;
     Path m_originalRootFolder;
     BitTorrent::TorrentContentLayout m_currentContentLayout;
@@ -594,7 +594,7 @@ void AddNewTorrentDialog::updateDiskSpaceLabel()
     if (hasMetadata)
     {
         const auto torrentInfo = *torrentDescr.info();
-        const QVector<BitTorrent::DownloadPriority> &priorities = m_contentAdaptor->filePriorities();
+        const QList<BitTorrent::DownloadPriority> &priorities = m_contentAdaptor->filePriorities();
         Q_ASSERT(priorities.size() == torrentInfo.filesCount());
         for (int i = 0; i < priorities.size(); ++i)
         {
@@ -916,7 +916,7 @@ void AddNewTorrentDialog::setupTreeview()
     if (BitTorrent::Session::instance()->isExcludedFileNamesEnabled())
     {
         // Check file name blacklist for torrents that are manually added
-        QVector<BitTorrent::DownloadPriority> priorities = m_contentAdaptor->filePriorities();
+        QList<BitTorrent::DownloadPriority> priorities = m_contentAdaptor->filePriorities();
         BitTorrent::Session::instance()->applyFilenameFilter(m_contentAdaptor->filePaths(), priorities);
         m_contentAdaptor->prioritizeFiles(priorities);
     }

--- a/src/gui/filtermode.h
+++ b/src/gui/filtermode.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2021-2022  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2024  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -28,44 +28,9 @@
 
 #pragma once
 
-#include <QReadWriteLock>
-
-#include "base/pathfwd.h"
-#include "base/utils/thread.h"
-#include "resumedatastorage.h"
-
-class QThread;
-
-namespace BitTorrent
+enum class FilterMode
 {
-    class DBResumeDataStorage final : public ResumeDataStorage
-    {
-        Q_OBJECT
-        Q_DISABLE_COPY_MOVE(DBResumeDataStorage)
-
-    public:
-        explicit DBResumeDataStorage(const Path &dbPath, QObject *parent = nullptr);
-        ~DBResumeDataStorage() override;
-
-        QList<TorrentID> registeredTorrents() const override;
-        LoadResumeDataResult load(const TorrentID &id) const override;
-
-        void store(const TorrentID &id, const LoadTorrentParams &resumeData) const override;
-        void remove(const TorrentID &id) const override;
-        void storeQueue(const QList<TorrentID> &queue) const override;
-
-    private:
-        void doLoadAll() const override;
-        int currentDBVersion() const;
-        void createDB() const;
-        void updateDB(int fromVersion) const;
-        void enableWALMode() const;
-
-        Utils::Thread::UniquePtr m_ioThread;
-
-        class Worker;
-        Worker *m_asyncWorker = nullptr;
-
-        mutable QReadWriteLock m_dbLock;
-    };
-}
+    PlainText = 0,
+    Wildcard = 1,
+    Regex = 2
+};

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -254,7 +254,7 @@ MainWindow::MainWindow(IGUIApplication *app, const WindowState initialState, con
 #endif
         tr("Transfers"));
     // Filter types
-    const QVector<TransferListModel::Column> filterTypes = {TransferListModel::Column::TR_NAME, TransferListModel::Column::TR_SAVE_PATH};
+    const QList<TransferListModel::Column> filterTypes = {TransferListModel::Column::TR_NAME, TransferListModel::Column::TR_SAVE_PATH};
     for (const TransferListModel::Column type : filterTypes)
     {
         const QString typeName = m_transferListWidget->getSourceModel()->headerData(type, Qt::Horizontal, Qt::DisplayRole).value<QString>();
@@ -1172,7 +1172,7 @@ void MainWindow::closeEvent(QCloseEvent *e)
     }
 #endif // Q_OS_MACOS
 
-    const QVector<BitTorrent::Torrent *> allTorrents = BitTorrent::Session::instance()->torrents();
+    const QList<BitTorrent::Torrent *> allTorrents = BitTorrent::Session::instance()->torrents();
     const bool hasActiveTorrents = std::any_of(allTorrents.cbegin(), allTorrents.cend(), [](BitTorrent::Torrent *torrent)
     {
         return torrent->isActive();
@@ -1523,7 +1523,7 @@ void MainWindow::loadSessionStats()
     refreshWindowTitle();
 }
 
-void MainWindow::reloadTorrentStats(const QVector<BitTorrent::Torrent *> &torrents)
+void MainWindow::reloadTorrentStats(const QList<BitTorrent::Torrent *> &torrents)
 {
     if (currentTabWidget() == m_transferListWidget)
     {
@@ -1868,7 +1868,7 @@ void MainWindow::updatePowerManagementState() const
     const bool preventFromSuspendWhenDownloading = pref->preventFromSuspendWhenDownloading();
     const bool preventFromSuspendWhenSeeding = pref->preventFromSuspendWhenSeeding();
 
-    const QVector<BitTorrent::Torrent *> allTorrents = BitTorrent::Session::instance()->torrents();
+    const QList<BitTorrent::Torrent *> allTorrents = BitTorrent::Session::instance()->torrents();
     const bool inhibitSuspend = std::any_of(allTorrents.cbegin(), allTorrents.cend(), [&](const BitTorrent::Torrent *torrent)
     {
         if (preventFromSuspendWhenDownloading && (!torrent->isFinished() && !torrent->isStopped() && !torrent->isErrored() && torrent->hasMetadata()))

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -128,7 +128,7 @@ private slots:
     void displayExecutionLogTab();
     void toggleFocusBetweenLineEdits();
     void loadSessionStats();
-    void reloadTorrentStats(const QVector<BitTorrent::Torrent *> &torrents);
+    void reloadTorrentStats(const QList<BitTorrent::Torrent *> &torrents);
     void loadPreferences();
     void optionsSaved();
     void toggleAlternativeSpeeds();

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -1179,7 +1179,7 @@ void OptionsDialog::saveBittorrentTabOptions() const
     session->setGlobalMaxRatio(getMaxRatio());
     session->setGlobalMaxSeedingMinutes(getMaxSeedingMinutes());
     session->setGlobalMaxInactiveSeedingMinutes(getMaxInactiveSeedingMinutes());
-    const QVector<BitTorrent::ShareLimitAction> actIndex =
+    const QList<BitTorrent::ShareLimitAction> actIndex =
     {
         BitTorrent::ShareLimitAction::Stop,
         BitTorrent::ShareLimitAction::Remove,

--- a/src/gui/previewselectdialog.cpp
+++ b/src/gui/previewselectdialog.cpp
@@ -81,7 +81,7 @@ PreviewSelectDialog::PreviewSelectDialog(QWidget *parent, const BitTorrent::Torr
     m_ui->previewList->setItemDelegate(listDelegate);
 
     // Fill list in
-    const QVector<qreal> fp = torrent->filesProgress();
+    const QList<qreal> fp = torrent->filesProgress();
     for (int i = 0; i < torrent->filesCount(); ++i)
     {
         const Path filePath = torrent->filePath(i);

--- a/src/gui/properties/downloadedpiecesbar.cpp
+++ b/src/gui/properties/downloadedpiecesbar.cpp
@@ -32,7 +32,7 @@
 #include <cmath>
 
 #include <QDebug>
-#include <QVector>
+#include <QList>
 
 #include "base/global.h"
 
@@ -51,9 +51,9 @@ DownloadedPiecesBar::DownloadedPiecesBar(QWidget *parent)
 {
 }
 
-QVector<float> DownloadedPiecesBar::bitfieldToFloatVector(const QBitArray &vecin, int reqSize)
+QList<float> DownloadedPiecesBar::bitfieldToFloatVector(const QBitArray &vecin, int reqSize)
 {
-    QVector<float> result(reqSize, 0.0);
+    QList<float> result(reqSize, 0.0);
     if (vecin.isEmpty()) return result;
 
     const float ratio = vecin.size() / static_cast<float>(reqSize);
@@ -145,8 +145,8 @@ bool DownloadedPiecesBar::updateImage(QImage &image)
         return true;
     }
 
-    QVector<float> scaledPieces = bitfieldToFloatVector(m_pieces, image2.width());
-    QVector<float> scaledPiecesDl = bitfieldToFloatVector(m_downloadedPieces, image2.width());
+    QList<float> scaledPieces = bitfieldToFloatVector(m_pieces, image2.width());
+    QList<float> scaledPiecesDl = bitfieldToFloatVector(m_downloadedPieces, image2.width());
 
     // filling image
     for (int x = 0; x < scaledPieces.size(); ++x)

--- a/src/gui/properties/downloadedpiecesbar.h
+++ b/src/gui/properties/downloadedpiecesbar.h
@@ -51,7 +51,7 @@ public:
 
 private:
     // scale bitfield vector to float vector
-    QVector<float> bitfieldToFloatVector(const QBitArray &vecin, int reqSize);
+    QList<float> bitfieldToFloatVector(const QBitArray &vecin, int reqSize);
     bool updateImage(QImage &image) override;
     QString simpleToolTipText() const override;
 

--- a/src/gui/properties/peerlistwidget.cpp
+++ b/src/gui/properties/peerlistwidget.cpp
@@ -35,6 +35,7 @@
 #include <QClipboard>
 #include <QHeaderView>
 #include <QHostAddress>
+#include <QList>
 #include <QMenu>
 #include <QMessageBox>
 #include <QPointer>
@@ -42,7 +43,6 @@
 #include <QShortcut>
 #include <QSortFilterProxyModel>
 #include <QStandardItemModel>
-#include <QVector>
 #include <QWheelEvent>
 
 #include "base/bittorrent/peeraddress.h"
@@ -290,7 +290,7 @@ void PeerListWidget::showPeerListMenu()
     QAction *addNewPeer = menu->addAction(UIThemeManager::instance()->getIcon(u"peers-add"_s), tr("Add peers...")
         , this, [this, torrent]()
     {
-        const QVector<BitTorrent::PeerAddress> peersList = PeersAdditionDialog::askForPeers(this);
+        const QList<BitTorrent::PeerAddress> peersList = PeersAdditionDialog::askForPeers(this);
         const int peerCount = std::count_if(peersList.cbegin(), peersList.cend(), [torrent](const BitTorrent::PeerAddress &peer)
         {
             return torrent->connectPeer(peer);
@@ -335,7 +335,7 @@ void PeerListWidget::banSelectedPeers()
     // Store selected rows first as selected peers may disconnect
     const QModelIndexList selectedIndexes = selectionModel()->selectedRows();
 
-    QVector<QString> selectedIPs;
+    QList<QString> selectedIPs;
     selectedIPs.reserve(selectedIndexes.size());
 
     for (const QModelIndex &index : selectedIndexes)
@@ -405,7 +405,7 @@ void PeerListWidget::loadPeers(const BitTorrent::Torrent *torrent)
         return;
 
     using TorrentPtr = QPointer<const BitTorrent::Torrent>;
-    torrent->fetchPeerInfo([this, torrent = TorrentPtr(torrent)](const QVector<BitTorrent::PeerInfo> &peers)
+    torrent->fetchPeerInfo([this, torrent = TorrentPtr(torrent)](const QList<BitTorrent::PeerInfo> &peers)
     {
         if (torrent != m_properties->getCurrentTorrent())
             return;

--- a/src/gui/properties/peersadditiondialog.cpp
+++ b/src/gui/properties/peersadditiondialog.cpp
@@ -50,7 +50,7 @@ PeersAdditionDialog::~PeersAdditionDialog()
     delete m_ui;
 }
 
-QVector<BitTorrent::PeerAddress> PeersAdditionDialog::askForPeers(QWidget *parent)
+QList<BitTorrent::PeerAddress> PeersAdditionDialog::askForPeers(QWidget *parent)
 {
     PeersAdditionDialog dlg(parent);
     dlg.exec();

--- a/src/gui/properties/peersadditiondialog.h
+++ b/src/gui/properties/peersadditiondialog.h
@@ -29,7 +29,7 @@
 #pragma once
 
 #include <QDialog>
-#include <QVector>
+#include <QList>
 
 #include "base/bittorrent/peerinfo.h"
 
@@ -47,12 +47,12 @@ public:
     PeersAdditionDialog(QWidget *parent);
     ~PeersAdditionDialog();
 
-    static QVector<BitTorrent::PeerAddress> askForPeers(QWidget *parent);
+    static QList<BitTorrent::PeerAddress> askForPeers(QWidget *parent);
 
 protected slots:
     void validateInput();
 
 private:
     Ui::PeersAdditionDialog *m_ui = nullptr;
-    QVector<BitTorrent::PeerAddress> m_peersList;
+    QList<BitTorrent::PeerAddress> m_peersList;
 };

--- a/src/gui/properties/pieceavailabilitybar.cpp
+++ b/src/gui/properties/pieceavailabilitybar.cpp
@@ -40,9 +40,9 @@ PieceAvailabilityBar::PieceAvailabilityBar(QWidget *parent)
 {
 }
 
-QVector<float> PieceAvailabilityBar::intToFloatVector(const QVector<int> &vecin, int reqSize)
+QList<float> PieceAvailabilityBar::intToFloatVector(const QList<int> &vecin, int reqSize)
 {
-    QVector<float> result(reqSize, 0.0);
+    QList<float> result(reqSize, 0.0);
     if (vecin.isEmpty()) return result;
 
     const float ratio = static_cast<float>(vecin.size()) / reqSize;
@@ -142,7 +142,7 @@ bool PieceAvailabilityBar::updateImage(QImage &image)
         return true;
     }
 
-    QVector<float> scaledPieces = intToFloatVector(m_pieces, image2.width());
+    QList<float> scaledPieces = intToFloatVector(m_pieces, image2.width());
 
     // filling image
     for (int x = 0; x < scaledPieces.size(); ++x)
@@ -154,7 +154,7 @@ bool PieceAvailabilityBar::updateImage(QImage &image)
     return true;
 }
 
-void PieceAvailabilityBar::setAvailability(const QVector<int> &avail)
+void PieceAvailabilityBar::setAvailability(const QList<int> &avail)
 {
     m_pieces = avail;
 

--- a/src/gui/properties/pieceavailabilitybar.h
+++ b/src/gui/properties/pieceavailabilitybar.h
@@ -40,7 +40,7 @@ class PieceAvailabilityBar final : public PiecesBar
 public:
     PieceAvailabilityBar(QWidget *parent);
 
-    void setAvailability(const QVector<int> &avail);
+    void setAvailability(const QList<int> &avail);
 
     // PiecesBar interface
     void clear() override;
@@ -51,8 +51,8 @@ private:
 
     // last used int vector, uses to better resize redraw
     // TODO: make a diff pieces to new pieces and update only changed pixels, speedup when update > 20x faster
-    QVector<int> m_pieces;
+    QList<int> m_pieces;
 
     // scale int vector to float vector
-    QVector<float> intToFloatVector(const QVector<int> &vecin, int reqSize);
+    QList<float> intToFloatVector(const QList<int> &vecin, int reqSize);
 };

--- a/src/gui/properties/piecesbar.cpp
+++ b/src/gui/properties/piecesbar.cpp
@@ -222,7 +222,7 @@ QColor PiecesBar::colorBoxBorderColor() const
     return palette().color(QPalette::ToolTipText);
 }
 
-const QVector<QRgb> &PiecesBar::pieceColors() const
+const QList<QRgb> &PiecesBar::pieceColors() const
 {
     return m_pieceColors;
 }
@@ -261,7 +261,7 @@ void PiecesBar::showToolTip(const QHelpEvent *e)
         {
             const PieceIndexToImagePos transform {torrentInfo, m_image};
             const int pieceIndex = transform.pieceIndex(imagePos);
-            const QVector<int> fileIndexes = torrentInfo.fileIndicesForPiece(pieceIndex);
+            const QList<int> fileIndexes = torrentInfo.fileIndicesForPiece(pieceIndex);
 
             QString tooltipTitle;
             if (fileIndexes.count() > 1)
@@ -305,7 +305,7 @@ void PiecesBar::highlightFile(int imagePos)
     PieceIndexToImagePos transform {torrentInfo, m_image};
 
     int pieceIndex = transform.pieceIndex(imagePos);
-    QVector<int> fileIndices {torrentInfo.fileIndicesForPiece(pieceIndex)};
+    QList<int> fileIndices {torrentInfo.fileIndicesForPiece(pieceIndex)};
     if (fileIndices.count() == 1)
     {
         BitTorrent::TorrentInfo::PieceRange filePieces = torrentInfo.filePieces(fileIndices.first());
@@ -327,7 +327,7 @@ void PiecesBar::highlightFile(int imagePos)
 
 void PiecesBar::updatePieceColors()
 {
-    m_pieceColors = QVector<QRgb>(256);
+    m_pieceColors = QList<QRgb>(256);
     for (int i = 0; i < 256; ++i)
     {
         float ratio = (i / 255.0);

--- a/src/gui/properties/piecesbar.h
+++ b/src/gui/properties/piecesbar.h
@@ -70,7 +70,7 @@ protected:
     QColor borderColor() const;
     QColor pieceColor() const;
     QColor colorBoxBorderColor() const;
-    const QVector<QRgb> &pieceColors() const;
+    const QList<QRgb> &pieceColors() const;
 
     // mix two colors by light model, ratio <0, 1>
     static QRgb mixTwoColors(QRgb rgb1, QRgb rgb2, float ratio);
@@ -91,7 +91,7 @@ private:
     const BitTorrent::Torrent *m_torrent = nullptr;
     QImage m_image;
     // buffered 256 levels gradient from bg_color to piece_color
-    QVector<QRgb> m_pieceColors;
+    QList<QRgb> m_pieceColors;
     bool m_hovered = false;
     QRect m_highlightedRegion; // part of the bar can be highlighted; this rectangle is in the same frame as m_image
 };

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -471,7 +471,7 @@ void PropertiesWidget::loadDynamicData()
                 {
                     // Pieces availability
                     showPiecesAvailability(true);
-                    m_torrent->fetchPieceAvailability([this, torrent = TorrentPtr(m_torrent)](const QVector<int> &pieceAvailability)
+                    m_torrent->fetchPieceAvailability([this, torrent = TorrentPtr(m_torrent)](const QList<int> &pieceAvailability)
                     {
                         if (torrent == m_torrent)
                             m_piecesAvailability->setAvailability(pieceAvailability);
@@ -517,7 +517,7 @@ void PropertiesWidget::loadUrlSeeds()
         return;
 
     using TorrentPtr = QPointer<BitTorrent::Torrent>;
-    m_torrent->fetchURLSeeds([this, torrent = TorrentPtr(m_torrent)](const QVector<QUrl> &urlSeeds)
+    m_torrent->fetchURLSeeds([this, torrent = TorrentPtr(m_torrent)](const QList<QUrl> &urlSeeds)
     {
         if (torrent != m_torrent)
             return;
@@ -620,7 +620,7 @@ void PropertiesWidget::deleteSelectedUrlSeeds()
     const QList<QListWidgetItem *> selectedItems = m_ui->listWebSeeds->selectedItems();
     if (selectedItems.isEmpty()) return;
 
-    QVector<QUrl> urlSeeds;
+    QList<QUrl> urlSeeds;
     urlSeeds.reserve(selectedItems.size());
 
     for (const QListWidgetItem *item : selectedItems)

--- a/src/gui/properties/speedplotview.cpp
+++ b/src/gui/properties/speedplotview.cpp
@@ -292,7 +292,7 @@ void SpeedPlotView::paintEvent(QPaintEvent *)
     rect.adjust(0, fontMetrics.height(), 0, 0); // Add top padding for top speed text
 
     // draw Y axis speed labels
-    const QVector<QString> speedLabels =
+    const QList<QString> speedLabels =
     {
         formatLabel(niceScale.arg, niceScale.unit),
         formatLabel((0.75 * niceScale.arg), niceScale.unit),
@@ -358,7 +358,7 @@ void SpeedPlotView::paintEvent(QPaintEvent *)
         if (!m_properties[static_cast<GraphID>(id)].enable)
             continue;
 
-        QVector<QPoint> points;
+        QList<QPoint> points;
         milliseconds duration {0};
 
         for (int i = static_cast<int>(queue.size()) - 1; i >= 0; --i)

--- a/src/gui/search/pluginselectdialog.cpp
+++ b/src/gui/search/pluginselectdialog.cpp
@@ -249,9 +249,9 @@ void PluginSelectDialog::setRowColor(const int row, const QString &color)
     }
 }
 
-QVector<QTreeWidgetItem*> PluginSelectDialog::findItemsWithUrl(const QString &url)
+QList<QTreeWidgetItem*> PluginSelectDialog::findItemsWithUrl(const QString &url)
 {
-    QVector<QTreeWidgetItem*> res;
+    QList<QTreeWidgetItem*> res;
     res.reserve(m_ui->pluginsTree->topLevelItemCount());
 
     for (int i = 0; i < m_ui->pluginsTree->topLevelItemCount(); ++i)

--- a/src/gui/search/pluginselectdialog.h
+++ b/src/gui/search/pluginselectdialog.h
@@ -57,7 +57,7 @@ public:
     explicit PluginSelectDialog(SearchPluginManager *pluginManager, QWidget *parent = nullptr);
     ~PluginSelectDialog() override;
 
-    QVector<QTreeWidgetItem*> findItemsWithUrl(const QString &url);
+    QList<QTreeWidgetItem*> findItemsWithUrl(const QString &url);
     QTreeWidgetItem *findItemWithID(const QString &id);
 
 protected:

--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -508,7 +508,7 @@ void SearchJobWidget::searchFailed()
     setStatus(Status::Error);
 }
 
-void SearchJobWidget::appendSearchResults(const QVector<SearchResult> &results)
+void SearchJobWidget::appendSearchResults(const QList<SearchResult> &results)
 {
     for (const SearchResult &result : results)
     {

--- a/src/gui/search/searchjobwidget.h
+++ b/src/gui/search/searchjobwidget.h
@@ -105,7 +105,7 @@ private:
     void onItemDoubleClicked(const QModelIndex &index);
     void searchFinished(bool cancelled);
     void searchFailed();
-    void appendSearchResults(const QVector<SearchResult> &results);
+    void appendSearchResults(const QList<SearchResult> &results);
     void updateResultsCount();
     void setStatus(Status value);
     void downloadTorrent(const QModelIndex &rowIndex, AddTorrentOption option = AddTorrentOption::Default);

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -40,13 +40,13 @@
 
 #include <QDebug>
 #include <QEvent>
+#include <QList>
 #include <QMessageBox>
 #include <QMenu>
 #include <QMouseEvent>
 #include <QObject>
 #include <QRegularExpression>
 #include <QShortcut>
-#include <QVector>
 
 #include "base/global.h"
 #include "base/search/searchhandler.h"
@@ -184,7 +184,7 @@ void SearchWidget::fillCatCombobox()
     m_ui->comboCategory->addItem(SearchPluginManager::categoryFullName(u"all"_s), u"all"_s);
 
     using QStrPair = std::pair<QString, QString>;
-    QVector<QStrPair> tmpList;
+    QList<QStrPair> tmpList;
     for (const QString &cat : asConst(SearchPluginManager::instance()->getPluginCategories(selectedPlugin())))
         tmpList << std::make_pair(SearchPluginManager::categoryFullName(cat), cat);
     std::sort(tmpList.begin(), tmpList.end(), [](const QStrPair &l, const QStrPair &r) { return (QString::localeAwareCompare(l.first, r.first) < 0); });
@@ -207,7 +207,7 @@ void SearchWidget::fillPluginComboBox()
     m_ui->selectPlugin->addItem(tr("Select..."), u"multi"_s);
 
     using QStrPair = std::pair<QString, QString>;
-    QVector<QStrPair> tmpList;
+    QList<QStrPair> tmpList;
     for (const QString &name : asConst(SearchPluginManager::instance()->enabledPlugins()))
         tmpList << std::make_pair(SearchPluginManager::instance()->pluginFullName(name), name);
     std::sort(tmpList.begin(), tmpList.end(), [](const QStrPair &l, const QStrPair &r) { return (l.first < r.first); } );

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -163,7 +163,7 @@ namespace
 
 TorrentContentModel::TorrentContentModel(QObject *parent)
     : QAbstractItemModel(parent)
-    , m_rootItem(new TorrentContentModelFolder(QVector<QString>({ tr("Name"), tr("Total Size"), tr("Progress"), tr("Download Priority"), tr("Remaining"), tr("Availability") })))
+    , m_rootItem(new TorrentContentModelFolder(QList<QString>({ tr("Name"), tr("Total Size"), tr("Progress"), tr("Download Priority"), tr("Remaining"), tr("Availability") })))
 #if defined(Q_OS_WIN)
     , m_fileIconProvider {new QFileIconProvider}
 #elif defined(Q_OS_MACOS)
@@ -185,7 +185,7 @@ void TorrentContentModel::updateFilesProgress()
 {
     Q_ASSERT(m_contentHandler && m_contentHandler->hasMetadata());
 
-    const QVector<qreal> &filesProgress = m_contentHandler->filesProgress();
+    const QList<qreal> &filesProgress = m_contentHandler->filesProgress();
     Q_ASSERT(m_filesIndex.size() == filesProgress.size());
     // XXX: Why is this necessary?
     if (m_filesIndex.size() != filesProgress.size()) [[unlikely]]
@@ -202,7 +202,7 @@ void TorrentContentModel::updateFilesPriorities()
 {
     Q_ASSERT(m_contentHandler && m_contentHandler->hasMetadata());
 
-    const QVector<BitTorrent::DownloadPriority> fprio = m_contentHandler->filePriorities();
+    const QList<BitTorrent::DownloadPriority> fprio = m_contentHandler->filePriorities();
     Q_ASSERT(m_filesIndex.size() == fprio.size());
     // XXX: Why is this necessary?
     if (m_filesIndex.size() != fprio.size())
@@ -217,7 +217,7 @@ void TorrentContentModel::updateFilesAvailability()
     Q_ASSERT(m_contentHandler && m_contentHandler->hasMetadata());
 
     using HandlerPtr = QPointer<BitTorrent::TorrentContentHandler>;
-    m_contentHandler->fetchAvailableFileFractions([this, handler = HandlerPtr(m_contentHandler)](const QVector<qreal> &availableFileFractions)
+    m_contentHandler->fetchAvailableFileFractions([this, handler = HandlerPtr(m_contentHandler)](const QList<qreal> &availableFileFractions)
     {
         if (handler != m_contentHandler)
             return;
@@ -250,7 +250,7 @@ bool TorrentContentModel::setItemPriority(const QModelIndex &index, BitTorrent::
     m_rootItem->recalculateProgress();
     m_rootItem->recalculateAvailability();
 
-    const QVector<ColumnInterval> columns =
+    const QList<ColumnInterval> columns =
     {
         {TorrentContentModelItem::COL_NAME, TorrentContentModelItem::COL_NAME},
         {TorrentContentModelItem::COL_PRIO, TorrentContentModelItem::COL_PRIO}
@@ -260,9 +260,9 @@ bool TorrentContentModel::setItemPriority(const QModelIndex &index, BitTorrent::
     return true;
 }
 
-QVector<BitTorrent::DownloadPriority> TorrentContentModel::getFilePriorities() const
+QList<BitTorrent::DownloadPriority> TorrentContentModel::getFilePriorities() const
 {
-    QVector<BitTorrent::DownloadPriority> prio;
+    QList<BitTorrent::DownloadPriority> prio;
     prio.reserve(m_filesIndex.size());
     for (const TorrentContentModelFile *file : asConst(m_filesIndex))
         prio.push_back(file->priority());
@@ -523,7 +523,7 @@ void TorrentContentModel::populate()
     m_filesIndex.reserve(filesCount);
 
     QHash<TorrentContentModelFolder *, QHash<QString, TorrentContentModelFolder *>> folderMap;
-    QVector<QString> lastParentPath;
+    QList<QString> lastParentPath;
     TorrentContentModelFolder *lastParent = m_rootItem;
     // Iterate over files
     for (int i = 0; i < filesCount; ++i)
@@ -602,7 +602,7 @@ void TorrentContentModel::refresh()
         updateFilesPriorities();
         updateFilesAvailability();
 
-        const QVector<ColumnInterval> columns =
+        const QList<ColumnInterval> columns =
         {
             {TorrentContentModelItem::COL_NAME, TorrentContentModelItem::COL_NAME},
             {TorrentContentModelItem::COL_PROGRESS, TorrentContentModelItem::COL_PROGRESS},
@@ -619,7 +619,7 @@ void TorrentContentModel::refresh()
     }
 }
 
-void TorrentContentModel::notifySubtreeUpdated(const QModelIndex &index, const QVector<ColumnInterval> &columns)
+void TorrentContentModel::notifySubtreeUpdated(const QModelIndex &index, const QList<ColumnInterval> &columns)
 {
     // For best performance, `columns` entries should be arranged from left to right
 
@@ -639,7 +639,7 @@ void TorrentContentModel::notifySubtreeUpdated(const QModelIndex &index, const Q
     }
 
     // propagate down the model
-    QVector<QModelIndex> parentIndexes;
+    QList<QModelIndex> parentIndexes;
 
     if (hasChildren(index))
         parentIndexes.push_back(index);

--- a/src/gui/torrentcontentmodel.h
+++ b/src/gui/torrentcontentmodel.h
@@ -30,7 +30,7 @@
 #pragma once
 
 #include <QAbstractItemModel>
-#include <QVector>
+#include <QList>
 
 #include "base/indexrange.h"
 #include "base/pathfwd.h"
@@ -66,7 +66,7 @@ public:
 
     void refresh();
 
-    QVector<BitTorrent::DownloadPriority> getFilePriorities() const;
+    QList<BitTorrent::DownloadPriority> getFilePriorities() const;
     TorrentContentModelItem::ItemType itemType(const QModelIndex &index) const;
     int getFileIndex(const QModelIndex &index) const;
     Path getItemPath(const QModelIndex &index) const;
@@ -91,10 +91,10 @@ private:
     void updateFilesPriorities();
     void updateFilesAvailability();
     bool setItemPriority(const QModelIndex &index, BitTorrent::DownloadPriority priority);
-    void notifySubtreeUpdated(const QModelIndex &index, const QVector<ColumnInterval> &columns);
+    void notifySubtreeUpdated(const QModelIndex &index, const QList<ColumnInterval> &columns);
 
     BitTorrent::TorrentContentHandler *m_contentHandler = nullptr;
     TorrentContentModelFolder *m_rootItem = nullptr;
-    QVector<TorrentContentModelFile *> m_filesIndex;
+    QList<TorrentContentModelFile *> m_filesIndex;
     QFileIconProvider *m_fileIconProvider = nullptr;
 };

--- a/src/gui/torrentcontentmodelfolder.cpp
+++ b/src/gui/torrentcontentmodelfolder.cpp
@@ -39,7 +39,7 @@ TorrentContentModelFolder::TorrentContentModelFolder(const QString &name, Torren
     m_name = name;
 }
 
-TorrentContentModelFolder::TorrentContentModelFolder(const QVector<QString> &data)
+TorrentContentModelFolder::TorrentContentModelFolder(const QList<QString> &data)
     : TorrentContentModelItem(nullptr)
 {
     Q_ASSERT(data.size() == NB_COL);
@@ -63,7 +63,7 @@ void TorrentContentModelFolder::deleteAllChildren()
     m_childItems.clear();
 }
 
-const QVector<TorrentContentModelItem *> &TorrentContentModelFolder::children() const
+const QList<TorrentContentModelItem *> &TorrentContentModelFolder::children() const
 {
     return m_childItems;
 }

--- a/src/gui/torrentcontentmodelfolder.h
+++ b/src/gui/torrentcontentmodelfolder.h
@@ -42,7 +42,7 @@ public:
     TorrentContentModelFolder(const QString &name, TorrentContentModelFolder *parent);
 
     // Invisible root item constructor
-    explicit TorrentContentModelFolder(const QVector<QString> &data);
+    explicit TorrentContentModelFolder(const QList<QString> &data);
 
     ~TorrentContentModelFolder() override;
 
@@ -56,11 +56,11 @@ public:
     void setPriority(BitTorrent::DownloadPriority newPriority, bool updateParent = true) override;
 
     void deleteAllChildren();
-    const QVector<TorrentContentModelItem*> &children() const;
+    const QList<TorrentContentModelItem*> &children() const;
     void appendChild(TorrentContentModelItem *item);
     TorrentContentModelItem *child(int row) const;
     int childCount() const;
 
 private:
-    QVector<TorrentContentModelItem *> m_childItems;
+    QList<TorrentContentModelItem *> m_childItems;
 };

--- a/src/gui/torrentcontentmodelitem.h
+++ b/src/gui/torrentcontentmodelitem.h
@@ -29,7 +29,7 @@
 #pragma once
 
 #include <QCoreApplication>
-#include <QVector>
+#include <QList>
 
 #include "base/bittorrent/downloadpriority.h"
 
@@ -86,7 +86,7 @@ public:
 protected:
     TorrentContentModelFolder *m_parentItem = nullptr;
     // Root item members
-    QVector<QString> m_itemData;
+    QList<QString> m_itemData;
     // Non-root item members
     QString m_name;
     qulonglong m_size = 0;

--- a/src/gui/torrentoptionsdialog.cpp
+++ b/src/gui/torrentoptionsdialog.cpp
@@ -58,7 +58,7 @@ namespace
     }
 }
 
-TorrentOptionsDialog::TorrentOptionsDialog(QWidget *parent, const QVector<BitTorrent::Torrent *> &torrents)
+TorrentOptionsDialog::TorrentOptionsDialog(QWidget *parent, const QList<BitTorrent::Torrent *> &torrents)
     : QDialog {parent}
     , m_ui {new Ui::TorrentOptionsDialog}
     , m_storeDialogSize {SETTINGS_KEY(u"Size"_s)}

--- a/src/gui/torrentoptionsdialog.h
+++ b/src/gui/torrentoptionsdialog.h
@@ -58,7 +58,7 @@ class TorrentOptionsDialog final : public QDialog
     Q_DISABLE_COPY_MOVE(TorrentOptionsDialog)
 
 public:
-    explicit TorrentOptionsDialog(QWidget *parent, const QVector<BitTorrent::Torrent *> &torrents);
+    explicit TorrentOptionsDialog(QWidget *parent, const QList<BitTorrent::Torrent *> &torrents);
     ~TorrentOptionsDialog() override;
 
 public slots:
@@ -73,7 +73,7 @@ private slots:
     void handleDownSpeedLimitChanged();
 
 private:
-    QVector<BitTorrent::TorrentID> m_torrentIDs;
+    QList<BitTorrent::TorrentID> m_torrentIDs;
     Ui::TorrentOptionsDialog *m_ui = nullptr;
     SettingValue<QSize> m_storeDialogSize;
     QStringList m_categories;

--- a/src/gui/trackerentriesdialog.cpp
+++ b/src/gui/trackerentriesdialog.cpp
@@ -31,7 +31,7 @@
 #include <algorithm>
 
 #include <QHash>
-#include <QVector>
+#include <QList>
 
 #include "base/bittorrent/trackerentry.h"
 #include "ui_trackerentriesdialog.h"
@@ -59,7 +59,7 @@ TrackerEntriesDialog::~TrackerEntriesDialog()
     delete m_ui;
 }
 
-void TrackerEntriesDialog::setTrackers(const QVector<BitTorrent::TrackerEntry> &trackers)
+void TrackerEntriesDialog::setTrackers(const QList<BitTorrent::TrackerEntry> &trackers)
 {
     int maxTier = -1;
     QHash<int, QString> tiers;  // <tier, tracker URLs>
@@ -78,7 +78,7 @@ void TrackerEntriesDialog::setTrackers(const QVector<BitTorrent::TrackerEntry> &
     m_ui->plainTextEdit->setPlainText(text);
 }
 
-QVector<BitTorrent::TrackerEntry> TrackerEntriesDialog::trackers() const
+QList<BitTorrent::TrackerEntry> TrackerEntriesDialog::trackers() const
 {
     return BitTorrent::parseTrackerEntries(m_ui->plainTextEdit->toPlainText());
 }

--- a/src/gui/trackerentriesdialog.h
+++ b/src/gui/trackerentriesdialog.h
@@ -52,8 +52,8 @@ public:
     explicit TrackerEntriesDialog(QWidget *parent);
     ~TrackerEntriesDialog() override;
 
-    void setTrackers(const QVector<BitTorrent::TrackerEntry> &trackers);
-    QVector<BitTorrent::TrackerEntry> trackers() const;
+    void setTrackers(const QList<BitTorrent::TrackerEntry> &trackers);
+    QList<BitTorrent::TrackerEntry> trackers() const;
 
 private:
     void saveSettings();

--- a/src/gui/trackerlist/trackerlistwidget.cpp
+++ b/src/gui/trackerlist/trackerlistwidget.cpp
@@ -35,6 +35,7 @@
 #include <QColor>
 #include <QDebug>
 #include <QHeaderView>
+#include <QList>
 #include <QLocale>
 #include <QMenu>
 #include <QMessageBox>
@@ -42,7 +43,6 @@
 #include <QStringList>
 #include <QTreeWidgetItem>
 #include <QUrl>
-#include <QVector>
 #include <QWheelEvent>
 
 #include "base/bittorrent/session.h"

--- a/src/gui/trackersadditiondialog.cpp
+++ b/src/gui/trackersadditiondialog.cpp
@@ -29,10 +29,10 @@
 
 #include "trackersadditiondialog.h"
 
+#include <QList>
 #include <QMessageBox>
 #include <QSize>
 #include <QStringView>
-#include <QVector>
 
 #include "base/bittorrent/torrent.h"
 #include "base/bittorrent/trackerentry.h"
@@ -76,10 +76,10 @@ TrackersAdditionDialog::~TrackersAdditionDialog()
 
 void TrackersAdditionDialog::onAccepted() const
 {
-    const QVector<BitTorrent::TrackerEntryStatus> currentTrackers = m_torrent->trackers();
+    const QList<BitTorrent::TrackerEntryStatus> currentTrackers = m_torrent->trackers();
     const int baseTier = !currentTrackers.isEmpty() ? (currentTrackers.last().tier + 1) : 0;
 
-    QVector<BitTorrent::TrackerEntry> entries = BitTorrent::parseTrackerEntries(m_ui->textEditTrackersList->toPlainText());
+    QList<BitTorrent::TrackerEntry> entries = BitTorrent::parseTrackerEntries(m_ui->textEditTrackersList->toPlainText());
     for (BitTorrent::TrackerEntry &entry : entries)
         entry.tier = Utils::Number::clampingAdd(entry.tier, baseTier);
 

--- a/src/gui/transferlistfilters/basefilterwidget.h
+++ b/src/gui/transferlistfilters/basefilterwidget.h
@@ -55,7 +55,7 @@ public slots:
 private slots:
     virtual void showMenu() = 0;
     virtual void applyFilter(int row) = 0;
-    virtual void handleTorrentsLoaded(const QVector<BitTorrent::Torrent *> &torrents) = 0;
+    virtual void handleTorrentsLoaded(const QList<BitTorrent::Torrent *> &torrents) = 0;
     virtual void torrentAboutToBeDeleted(BitTorrent::Torrent *) = 0;
 
 private:

--- a/src/gui/transferlistfilters/categoryfiltermodel.cpp
+++ b/src/gui/transferlistfilters/categoryfiltermodel.cpp
@@ -350,7 +350,7 @@ void CategoryFilterModel::categoryRemoved(const QString &categoryName)
     }
 }
 
-void CategoryFilterModel::torrentsLoaded(const QVector<BitTorrent::Torrent *> &torrents)
+void CategoryFilterModel::torrentsLoaded(const QList<BitTorrent::Torrent *> &torrents)
 {
     for (const BitTorrent::Torrent *torrent : torrents)
     {

--- a/src/gui/transferlistfilters/categoryfiltermodel.h
+++ b/src/gui/transferlistfilters/categoryfiltermodel.h
@@ -62,7 +62,7 @@ public:
 private slots:
     void categoryAdded(const QString &categoryName);
     void categoryRemoved(const QString &categoryName);
-    void torrentsLoaded(const QVector<BitTorrent::Torrent *> &torrents);
+    void torrentsLoaded(const QList<BitTorrent::Torrent *> &torrents);
     void torrentAboutToBeRemoved(BitTorrent::Torrent *torrent);
     void torrentCategoryChanged(BitTorrent::Torrent *torrent, const QString &oldCategory);
     void subcategoriesSupportChanged();

--- a/src/gui/transferlistfilters/statusfilterwidget.cpp
+++ b/src/gui/transferlistfilters/statusfilterwidget.cpp
@@ -86,7 +86,7 @@ StatusFilterWidget::StatusFilterWidget(QWidget *parent, TransferListWidget *tran
     errored->setData(Qt::DisplayRole, tr("Errored (0)"));
     errored->setData(Qt::DecorationRole, UIThemeManager::instance()->getIcon(u"error"_s));
 
-    const QVector<BitTorrent::Torrent *> torrents = BitTorrent::Session::instance()->torrents();
+    const QList<BitTorrent::Torrent *> torrents = BitTorrent::Session::instance()->torrents();
     update(torrents);
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::torrentsUpdated
             , this, &StatusFilterWidget::update);
@@ -199,7 +199,7 @@ void StatusFilterWidget::hideZeroItems()
         setCurrentRow(TorrentFilter::All, QItemSelectionModel::SelectCurrent);
 }
 
-void StatusFilterWidget::update(const QVector<BitTorrent::Torrent *> &torrents)
+void StatusFilterWidget::update(const QList<BitTorrent::Torrent *> &torrents)
 {
     for (const BitTorrent::Torrent *torrent : torrents)
         updateTorrentStatus(torrent);
@@ -233,7 +233,7 @@ void StatusFilterWidget::applyFilter(int row)
     transferList()->applyStatusFilter(row);
 }
 
-void StatusFilterWidget::handleTorrentsLoaded(const QVector<BitTorrent::Torrent *> &torrents)
+void StatusFilterWidget::handleTorrentsLoaded(const QList<BitTorrent::Torrent *> &torrents)
 {
     for (const BitTorrent::Torrent *torrent : torrents)
         updateTorrentStatus(torrent);

--- a/src/gui/transferlistfilters/statusfilterwidget.h
+++ b/src/gui/transferlistfilters/statusfilterwidget.h
@@ -53,12 +53,12 @@ private:
     // No need to redeclare them here as slots.
     void showMenu() override;
     void applyFilter(int row) override;
-    void handleTorrentsLoaded(const QVector<BitTorrent::Torrent *> &torrents) override;
+    void handleTorrentsLoaded(const QList<BitTorrent::Torrent *> &torrents) override;
     void torrentAboutToBeDeleted(BitTorrent::Torrent *) override;
 
     void configure();
 
-    void update(const QVector<BitTorrent::Torrent *> &torrents);
+    void update(const QList<BitTorrent::Torrent *> &torrents);
     void updateTorrentStatus(const BitTorrent::Torrent *torrent);
     void updateTexts();
     void hideZeroItems();

--- a/src/gui/transferlistfilters/tagfiltermodel.cpp
+++ b/src/gui/transferlistfilters/tagfiltermodel.cpp
@@ -30,7 +30,7 @@
 #include "tagfiltermodel.h"
 
 #include <QIcon>
-#include <QVector>
+#include <QList>
 
 #include "base/bittorrent/session.h"
 #include "base/global.h"
@@ -236,13 +236,13 @@ void TagFilterModel::torrentTagRemoved(BitTorrent::Torrent *const torrent, const
     emit dataChanged(i, i);
 }
 
-void TagFilterModel::torrentsLoaded(const QVector<BitTorrent::Torrent *> &torrents)
+void TagFilterModel::torrentsLoaded(const QList<BitTorrent::Torrent *> &torrents)
 {
     for (const BitTorrent::Torrent *torrent : torrents)
     {
         allTagsItem()->increaseTorrentsCount();
 
-        const QVector<TagModelItem *> items = findItems(torrent->tags());
+        const QList<TagModelItem *> items = findItems(torrent->tags());
         if (items.isEmpty())
             untaggedItem()->increaseTorrentsCount();
 
@@ -339,9 +339,9 @@ TagModelItem *TagFilterModel::findItem(const Tag &tag)
     return &m_tagItems[row];
 }
 
-QVector<TagModelItem *> TagFilterModel::findItems(const TagSet &tags)
+QList<TagModelItem *> TagFilterModel::findItems(const TagSet &tags)
 {
-    QVector<TagModelItem *> items;
+    QList<TagModelItem *> items;
     items.reserve(tags.count());
     for (const Tag &tag : tags)
     {

--- a/src/gui/transferlistfilters/tagfiltermodel.h
+++ b/src/gui/transferlistfilters/tagfiltermodel.h
@@ -64,7 +64,7 @@ private slots:
     void tagRemoved(const Tag &tag);
     void torrentTagAdded(BitTorrent::Torrent *torrent, const Tag &tag);
     void torrentTagRemoved(BitTorrent::Torrent *, const Tag &tag);
-    void torrentsLoaded(const QVector<BitTorrent::Torrent *> &torrents);
+    void torrentsLoaded(const QList<BitTorrent::Torrent *> &torrents);
     void torrentAboutToBeRemoved(BitTorrent::Torrent *torrent);
 
 private:
@@ -74,7 +74,7 @@ private:
     bool isValidRow(int row) const;
     int findRow(const Tag &tag) const;
     TagModelItem *findItem(const Tag &tag);
-    QVector<TagModelItem *> findItems(const TagSet &tags);
+    QList<TagModelItem *> findItems(const TagSet &tags);
     TagModelItem *allTagsItem();
     TagModelItem *untaggedItem();
 

--- a/src/gui/transferlistfilters/trackersfilterwidget.cpp
+++ b/src/gui/transferlistfilters/trackersfilterwidget.cpp
@@ -155,7 +155,7 @@ TrackersFilterWidget::~TrackersFilterWidget()
         Utils::Fs::removeFile(iconPath);
 }
 
-void TrackersFilterWidget::addTrackers(const BitTorrent::Torrent *torrent, const QVector<BitTorrent::TrackerEntry> &trackers)
+void TrackersFilterWidget::addTrackers(const BitTorrent::Torrent *torrent, const QList<BitTorrent::TrackerEntry> &trackers)
 {
     const BitTorrent::TorrentID torrentID = torrent->id();
 
@@ -204,7 +204,7 @@ void TrackersFilterWidget::refreshTrackers(const BitTorrent::Torrent *torrent)
         return false;
     });
 
-    const QVector<BitTorrent::TrackerEntryStatus> trackers = torrent->trackers();
+    const QList<BitTorrent::TrackerEntryStatus> trackers = torrent->trackers();
     if (trackers.isEmpty())
     {
         addItems(NULL_HOST, {torrentID});
@@ -228,7 +228,7 @@ void TrackersFilterWidget::refreshTrackers(const BitTorrent::Torrent *torrent)
     updateGeometry();
 }
 
-void TrackersFilterWidget::addItems(const QString &trackerURL, const QVector<BitTorrent::TorrentID> &torrents)
+void TrackersFilterWidget::addItems(const QString &trackerURL, const QList<BitTorrent::TorrentID> &torrents)
 {
     const QString host = getHost(trackerURL);
     auto trackersIt = m_trackers.find(host);
@@ -587,13 +587,13 @@ void TrackersFilterWidget::applyFilter(const int row)
         transferList()->applyTrackerFilter(getTorrentIDs(row));
 }
 
-void TrackersFilterWidget::handleTorrentsLoaded(const QVector<BitTorrent::Torrent *> &torrents)
+void TrackersFilterWidget::handleTorrentsLoaded(const QList<BitTorrent::Torrent *> &torrents)
 {
-    QHash<QString, QVector<BitTorrent::TorrentID>> torrentsPerTracker;
+    QHash<QString, QList<BitTorrent::TorrentID>> torrentsPerTracker;
     for (const BitTorrent::Torrent *torrent : torrents)
     {
         const BitTorrent::TorrentID torrentID = torrent->id();
-        const QVector<BitTorrent::TrackerEntryStatus> trackers = torrent->trackers();
+        const QList<BitTorrent::TrackerEntryStatus> trackers = torrent->trackers();
         for (const BitTorrent::TrackerEntryStatus &tracker : trackers)
             torrentsPerTracker[tracker.url].append(torrentID);
 
@@ -614,7 +614,7 @@ void TrackersFilterWidget::handleTorrentsLoaded(const QVector<BitTorrent::Torren
 void TrackersFilterWidget::torrentAboutToBeDeleted(BitTorrent::Torrent *const torrent)
 {
     const BitTorrent::TorrentID torrentID = torrent->id();
-    const QVector<BitTorrent::TrackerEntryStatus> trackers = torrent->trackers();
+    const QList<BitTorrent::TrackerEntryStatus> trackers = torrent->trackers();
     for (const BitTorrent::TrackerEntryStatus &tracker : trackers)
         removeItem(tracker.url, torrentID);
 

--- a/src/gui/transferlistfilters/trackersfilterwidget.h
+++ b/src/gui/transferlistfilters/trackersfilterwidget.h
@@ -57,7 +57,7 @@ public:
     TrackersFilterWidget(QWidget *parent, TransferListWidget *transferList, bool downloadFavicon);
     ~TrackersFilterWidget() override;
 
-    void addTrackers(const BitTorrent::Torrent *torrent, const QVector<BitTorrent::TrackerEntry> &trackers);
+    void addTrackers(const BitTorrent::Torrent *torrent, const QList<BitTorrent::TrackerEntry> &trackers);
     void removeTrackers(const BitTorrent::Torrent *torrent, const QStringList &trackers);
     void refreshTrackers(const BitTorrent::Torrent *torrent);
     void handleTrackerStatusesUpdated(const BitTorrent::Torrent *torrent
@@ -72,12 +72,12 @@ private:
     // No need to redeclare them here as slots.
     void showMenu() override;
     void applyFilter(int row) override;
-    void handleTorrentsLoaded(const QVector<BitTorrent::Torrent *> &torrents) override;
+    void handleTorrentsLoaded(const QList<BitTorrent::Torrent *> &torrents) override;
     void torrentAboutToBeDeleted(BitTorrent::Torrent *torrent) override;
 
     void onRemoveTrackerTriggered();
 
-    void addItems(const QString &trackerURL, const QVector<BitTorrent::TorrentID> &torrents);
+    void addItems(const QString &trackerURL, const QList<BitTorrent::TorrentID> &torrents);
     void removeItem(const QString &trackerURL, const BitTorrent::TorrentID &id);
     QString trackerFromRow(int row) const;
     int rowFromTracker(const QString &tracker) const;

--- a/src/gui/transferlistfilterswidget.cpp
+++ b/src/gui/transferlistfilterswidget.cpp
@@ -176,7 +176,7 @@ void TransferListFiltersWidget::setDownloadTrackerFavicon(bool value)
     m_trackersFilterWidget->setDownloadTrackerFavicon(value);
 }
 
-void TransferListFiltersWidget::addTrackers(const BitTorrent::Torrent *torrent, const QVector<BitTorrent::TrackerEntry> &trackers)
+void TransferListFiltersWidget::addTrackers(const BitTorrent::Torrent *torrent, const QList<BitTorrent::TrackerEntry> &trackers)
 {
     m_trackersFilterWidget->addTrackers(torrent, trackers);
 }

--- a/src/gui/transferlistfilterswidget.h
+++ b/src/gui/transferlistfilterswidget.h
@@ -56,7 +56,7 @@ public:
     void setDownloadTrackerFavicon(bool value);
 
 public slots:
-    void addTrackers(const BitTorrent::Torrent *torrent, const QVector<BitTorrent::TrackerEntry> &trackers);
+    void addTrackers(const BitTorrent::Torrent *torrent, const QList<BitTorrent::TrackerEntry> &trackers);
     void removeTrackers(const BitTorrent::Torrent *torrent, const QStringList &trackers);
     void refreshTrackers(const BitTorrent::Torrent *torrent);
     void trackerEntryStatusesUpdated(const BitTorrent::Torrent *torrent

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -611,7 +611,7 @@ bool TransferListModel::setData(const QModelIndex &index, const QVariant &value,
     return true;
 }
 
-void TransferListModel::addTorrents(const QVector<BitTorrent::Torrent *> &torrents)
+void TransferListModel::addTorrents(const QList<BitTorrent::Torrent *> &torrents)
 {
     qsizetype row = m_torrentList.size();
     const qsizetype total = row + torrents.size();
@@ -669,7 +669,7 @@ void TransferListModel::handleTorrentStatusUpdated(BitTorrent::Torrent *const to
     emit dataChanged(index(row, 0), index(row, columnCount() - 1));
 }
 
-void TransferListModel::handleTorrentsUpdated(const QVector<BitTorrent::Torrent *> &torrents)
+void TransferListModel::handleTorrentsUpdated(const QList<BitTorrent::Torrent *> &torrents)
 {
     const int columns = (columnCount() - 1);
 

--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -108,10 +108,10 @@ public:
     BitTorrent::Torrent *torrentHandle(const QModelIndex &index) const;
 
 private slots:
-    void addTorrents(const QVector<BitTorrent::Torrent *> &torrents);
+    void addTorrents(const QList<BitTorrent::Torrent *> &torrents);
     void handleTorrentAboutToBeRemoved(BitTorrent::Torrent *torrent);
     void handleTorrentStatusUpdated(BitTorrent::Torrent *torrent);
-    void handleTorrentsUpdated(const QVector<BitTorrent::Torrent *> &torrents);
+    void handleTorrentsUpdated(const QList<BitTorrent::Torrent *> &torrents);
 
 private:
     void configure();

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -35,12 +35,12 @@
 #include <QDebug>
 #include <QFileDialog>
 #include <QHeaderView>
+#include <QList>
 #include <QMenu>
 #include <QMessageBox>
 #include <QRegularExpression>
 #include <QSet>
 #include <QShortcut>
-#include <QVector>
 #include <QWheelEvent>
 
 #include "base/bittorrent/session.h"
@@ -76,9 +76,9 @@
 
 namespace
 {
-    QVector<BitTorrent::TorrentID> extractIDs(const QVector<BitTorrent::Torrent *> &torrents)
+    QList<BitTorrent::TorrentID> extractIDs(const QList<BitTorrent::Torrent *> &torrents)
     {
-        QVector<BitTorrent::TorrentID> torrentIDs;
+        QList<BitTorrent::TorrentID> torrentIDs;
         torrentIDs.reserve(torrents.size());
         for (const BitTorrent::Torrent *torrent : torrents)
             torrentIDs << torrent->id();
@@ -113,7 +113,7 @@ namespace
 #endif
     }
 
-    void removeTorrents(const QVector<BitTorrent::Torrent *> &torrents, const bool isDeleteFileSelected)
+    void removeTorrents(const QList<BitTorrent::Torrent *> &torrents, const bool isDeleteFileSelected)
     {
         auto *session = BitTorrent::Session::instance();
         const BitTorrent::TorrentRemoveOption removeOption = isDeleteFileSelected
@@ -323,22 +323,22 @@ void TransferListWidget::torrentDoubleClicked()
     }
 }
 
-QVector<BitTorrent::Torrent *> TransferListWidget::getSelectedTorrents() const
+QList<BitTorrent::Torrent *> TransferListWidget::getSelectedTorrents() const
 {
     const QModelIndexList selectedRows = selectionModel()->selectedRows();
 
-    QVector<BitTorrent::Torrent *> torrents;
+    QList<BitTorrent::Torrent *> torrents;
     torrents.reserve(selectedRows.size());
     for (const QModelIndex &index : selectedRows)
         torrents << m_listModel->torrentHandle(mapToSource(index));
     return torrents;
 }
 
-QVector<BitTorrent::Torrent *> TransferListWidget::getVisibleTorrents() const
+QList<BitTorrent::Torrent *> TransferListWidget::getVisibleTorrents() const
 {
     const int visibleTorrentsCount = m_sortFilterModel->rowCount();
 
-    QVector<BitTorrent::Torrent *> torrents;
+    QList<BitTorrent::Torrent *> torrents;
     torrents.reserve(visibleTorrentsCount);
     for (int i = 0; i < visibleTorrentsCount; ++i)
         torrents << m_listModel->torrentHandle(mapToSource(m_sortFilterModel->index(i, 0)));
@@ -347,7 +347,7 @@ QVector<BitTorrent::Torrent *> TransferListWidget::getVisibleTorrents() const
 
 void TransferListWidget::setSelectedTorrentsLocation()
 {
-    const QVector<BitTorrent::Torrent *> torrents = getSelectedTorrents();
+    const QList<BitTorrent::Torrent *> torrents = getSelectedTorrents();
     if (torrents.isEmpty())
         return;
 
@@ -359,7 +359,7 @@ void TransferListWidget::setSelectedTorrentsLocation()
     fileDialog->setOptions(QFileDialog::DontConfirmOverwrite | QFileDialog::ShowDirsOnly | QFileDialog::HideNameFilterDetails);
     connect(fileDialog, &QDialog::accepted, this, [this, fileDialog]()
     {
-        const QVector<BitTorrent::Torrent *> torrents = getSelectedTorrents();
+        const QList<BitTorrent::Torrent *> torrents = getSelectedTorrents();
         if (torrents.isEmpty())
             return;
 
@@ -432,7 +432,7 @@ void TransferListWidget::deleteSelectedTorrents(const bool deleteLocalFiles)
 {
     if (m_mainWindow->currentTabWidget() != this) return;
 
-    const QVector<BitTorrent::Torrent *> torrents = getSelectedTorrents();
+    const QList<BitTorrent::Torrent *> torrents = getSelectedTorrents();
     if (torrents.empty()) return;
 
     if (Preferences::instance()->confirmTorrentDeletion())
@@ -455,7 +455,7 @@ void TransferListWidget::deleteSelectedTorrents(const bool deleteLocalFiles)
 
 void TransferListWidget::deleteVisibleTorrents()
 {
-    const QVector<BitTorrent::Torrent *> torrents = getVisibleTorrents();
+    const QList<BitTorrent::Torrent *> torrents = getVisibleTorrents();
     if (torrents.empty()) return;
 
     if (Preferences::instance()->confirmTorrentDeletion())
@@ -624,7 +624,7 @@ void TransferListWidget::previewSelectedTorrents()
 
 void TransferListWidget::setTorrentOptions()
 {
-    const QVector<BitTorrent::Torrent *> selectedTorrents = getSelectedTorrents();
+    const QList<BitTorrent::Torrent *> selectedTorrents = getSelectedTorrents();
     if (selectedTorrents.empty()) return;
 
     auto *dialog = new TorrentOptionsDialog {this, selectedTorrents};
@@ -761,8 +761,8 @@ void TransferListWidget::askAddTagsForSelection()
 
 void TransferListWidget::editTorrentTrackers()
 {
-    const QVector<BitTorrent::Torrent *> torrents = getSelectedTorrents();
-    QVector<BitTorrent::TrackerEntry> commonTrackers;
+    const QList<BitTorrent::Torrent *> torrents = getSelectedTorrents();
+    QList<BitTorrent::TrackerEntry> commonTrackers;
 
     if (!torrents.empty())
     {
@@ -805,7 +805,7 @@ void TransferListWidget::exportTorrent()
     fileDialog->setOptions(QFileDialog::ShowDirsOnly);
     connect(fileDialog, &QFileDialog::fileSelected, this, [this](const QString &dir)
     {
-        const QVector<BitTorrent::Torrent *> torrents = getSelectedTorrents();
+        const QList<BitTorrent::Torrent *> torrents = getSelectedTorrents();
         if (torrents.isEmpty())
             return;
 

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -124,14 +124,14 @@ private:
     QModelIndexList mapToSource(const QModelIndexList &indexes) const;
     QModelIndex mapFromSource(const QModelIndex &index) const;
     bool loadSettings();
-    QVector<BitTorrent::Torrent *> getSelectedTorrents() const;
+    QList<BitTorrent::Torrent *> getSelectedTorrents() const;
     void askAddTagsForSelection();
     void editTorrentTrackers();
     void exportTorrent();
     void confirmRemoveAllTagsForSelection();
     TagSet askTagsForSelection(const QString &dialogTitle);
     void applyToSelectedTorrents(const std::function<void (BitTorrent::Torrent *const)> &fn);
-    QVector<BitTorrent::Torrent *> getVisibleTorrents() const;
+    QList<BitTorrent::Torrent *> getVisibleTorrents() const;
     int visibleColumnsCount() const;
 
     TransferListModel *m_listModel = nullptr;

--- a/src/webui/api/apicontroller.cpp
+++ b/src/webui/api/apicontroller.cpp
@@ -32,8 +32,8 @@
 
 #include <QHash>
 #include <QJsonDocument>
+#include <QList>
 #include <QMetaObject>
-#include <QVector>
 
 #include "apierror.h"
 
@@ -72,7 +72,7 @@ const DataMap &APIController::data() const
     return m_data;
 }
 
-void APIController::requireParams(const QVector<QString> &requiredParams) const
+void APIController::requireParams(const QList<QString> &requiredParams) const
 {
     const bool hasAllRequiredParams = std::all_of(requiredParams.cbegin(), requiredParams.cend()
         , [this](const QString &requiredParam)

--- a/src/webui/api/apicontroller.h
+++ b/src/webui/api/apicontroller.h
@@ -60,7 +60,7 @@ public:
 protected:
     const StringMap &params() const;
     const DataMap &data() const;
-    void requireParams(const QVector<QString> &requiredParams) const;
+    void requireParams(const QList<QString> &requiredParams) const;
 
     void setResult(const QString &result);
     void setResult(const QJsonArray &result);

--- a/src/webui/api/logcontroller.cpp
+++ b/src/webui/api/logcontroller.cpp
@@ -30,7 +30,7 @@
 
 #include <QJsonArray>
 #include <QJsonObject>
-#include <QVector>
+#include <QList>
 
 #include "base/global.h"
 #include "base/logger.h"

--- a/src/webui/api/rsscontroller.cpp
+++ b/src/webui/api/rsscontroller.cpp
@@ -32,7 +32,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
-#include <QVector>
+#include <QList>
 
 #include "base/rss/rss_article.h"
 #include "base/rss/rss_autodownloader.h"

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -29,7 +29,7 @@
 #include "serialize_torrent.h"
 
 #include <QDateTime>
-#include <QVector>
+#include <QList>
 
 #include "base/bittorrent/infohash.h"
 #include "base/bittorrent/torrent.h"

--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -732,7 +732,7 @@ void SyncController::torrentPeersAction()
     QVariantMap data;
     QVariantHash peers;
 
-    const QVector<BitTorrent::PeerInfo> peersList = torrent->peers();
+    const QList<BitTorrent::PeerInfo> peersList = torrent->peers();
 
     bool resolvePeerCountries = Preferences::instance()->resolvePeerCountries();
 
@@ -912,7 +912,7 @@ void SyncController::onTorrentTagRemoved(BitTorrent::Torrent *torrent, [[maybe_u
     m_updatedTorrents.insert(torrent->id());
 }
 
-void SyncController::onTorrentsUpdated(const QVector<BitTorrent::Torrent *> &torrents)
+void SyncController::onTorrentsUpdated(const QList<BitTorrent::Torrent *> &torrents)
 {
     for (const BitTorrent::Torrent *torrent : torrents)
         m_updatedTorrents.insert(torrent->id());
@@ -922,7 +922,7 @@ void SyncController::onTorrentTrackersChanged(BitTorrent::Torrent *torrent)
 {
     using namespace BitTorrent;
 
-    const QVector<TrackerEntryStatus> trackers = torrent->trackers();
+    const QList<TrackerEntryStatus> trackers = torrent->trackers();
 
     QSet<QString> currentTrackers;
     currentTrackers.reserve(trackers.size());

--- a/src/webui/api/synccontroller.h
+++ b/src/webui/api/synccontroller.h
@@ -77,7 +77,7 @@ private:
     void onTorrentSavingModeChanged(BitTorrent::Torrent *torrent);
     void onTorrentTagAdded(BitTorrent::Torrent *torrent, const Tag &tag);
     void onTorrentTagRemoved(BitTorrent::Torrent *torrent, const Tag &tag);
-    void onTorrentsUpdated(const QVector<BitTorrent::Torrent *> &torrents);
+    void onTorrentsUpdated(const QList<BitTorrent::Torrent *> &torrents);
     void onTorrentTrackersChanged(BitTorrent::Torrent *torrent);
 
     qint64 m_freeDiskSpace = 0;

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -242,9 +242,9 @@ namespace
         return {dht, pex, lsd};
     }
 
-    QVector<BitTorrent::TorrentID> toTorrentIDs(const QStringList &idStrings)
+    QList<BitTorrent::TorrentID> toTorrentIDs(const QStringList &idStrings)
     {
-        QVector<BitTorrent::TorrentID> idList;
+        QList<BitTorrent::TorrentID> idList;
         idList.reserve(idStrings.size());
         for (const QString &hash : idStrings)
             idList << BitTorrent::TorrentID::fromString(hash);
@@ -576,7 +576,7 @@ void TorrentsController::filesAction()
         throw APIError(APIErrorType::NotFound);
 
     const int filesCount = torrent->filesCount();
-    QVector<int> fileIndexes;
+    QList<int> fileIndexes;
     const auto idxIt = params().constFind(u"indexes"_s);
     if (idxIt != params().cend())
     {
@@ -604,9 +604,9 @@ void TorrentsController::filesAction()
     QJsonArray fileList;
     if (torrent->hasMetadata())
     {
-        const QVector<BitTorrent::DownloadPriority> priorities = torrent->filePriorities();
-        const QVector<qreal> fp = torrent->filesProgress();
-        const QVector<qreal> fileAvailability = torrent->availableFileFractions();
+        const QList<BitTorrent::DownloadPriority> priorities = torrent->filePriorities();
+        const QList<qreal> fp = torrent->filesProgress();
+        const QList<qreal> fileAvailability = torrent->availableFileFractions();
         const BitTorrent::TorrentInfo info = torrent->info();
         for (const int index : asConst(fileIndexes))
         {
@@ -648,7 +648,7 @@ void TorrentsController::pieceHashesAction()
     QJsonArray pieceHashes;
     if (torrent->hasMetadata())
     {
-        const QVector<QByteArray> hashes = torrent->info().pieceHashes();
+        const QList<QByteArray> hashes = torrent->info().pieceHashes();
         for (const QByteArray &hash : hashes)
             pieceHashes.append(QString::fromLatin1(hash.toHex()));
     }
@@ -889,7 +889,7 @@ void TorrentsController::addPeersAction()
     const QStringList hashes = params()[u"hashes"_s].split(u'|');
     const QStringList peers = params()[u"peers"_s].split(u'|');
 
-    QVector<BitTorrent::PeerAddress> peerList;
+    QList<BitTorrent::PeerAddress> peerList;
     peerList.reserve(peers.size());
     for (const QString &peer : peers)
     {
@@ -956,7 +956,7 @@ void TorrentsController::filePrioAction()
         throw APIError(APIErrorType::Conflict, tr("Torrent's metadata has not yet downloaded"));
 
     const int filesCount = torrent->filesCount();
-    QVector<BitTorrent::DownloadPriority> priorities = torrent->filePriorities();
+    QList<BitTorrent::DownloadPriority> priorities = torrent->filePriorities();
     bool priorityChanged = false;
     for (const QString &fileID : params()[u"id"_s].split(u'|'))
     {

--- a/src/webui/api/transfercontroller.cpp
+++ b/src/webui/api/transfercontroller.cpp
@@ -29,7 +29,7 @@
 #include "transfercontroller.h"
 
 #include <QJsonObject>
-#include <QVector>
+#include <QList>
 
 #include "base/bittorrent/peeraddress.h"
 #include "base/bittorrent/peerinfo.h"

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -36,12 +36,12 @@
 #include <QElapsedTimer>
 #include <QHash>
 #include <QHostAddress>
+#include <QList>
 #include <QMap>
 #include <QObject>
 #include <QRegularExpression>
 #include <QSet>
 #include <QTranslator>
-#include <QVector>
 
 #include "base/applicationcomponent.h"
 #include "base/global.h"
@@ -234,7 +234,7 @@ private:
     AuthController *m_authController = nullptr;
     bool m_isLocalAuthEnabled = false;
     bool m_isAuthSubnetWhitelistEnabled = false;
-    QVector<Utils::Net::Subnet> m_authSubnetWhitelist;
+    QList<Utils::Net::Subnet> m_authSubnetWhitelist;
     int m_sessionTimeout = 0;
     QString m_sessionCookieName;
 
@@ -247,10 +247,10 @@ private:
 
     // Reverse proxy
     bool m_isReverseProxySupportEnabled = false;
-    QVector<Utils::Net::Subnet> m_trustedReverseProxyList;
+    QList<Utils::Net::Subnet> m_trustedReverseProxyList;
     QHostAddress m_clientAddress;
 
-    QVector<Http::Header> m_prebuiltHeaders;
+    QList<Http::Header> m_prebuiltHeaders;
 
     Utils::Thread::UniquePtr m_workerThread;
     FreeDiskSpaceChecker *m_freeDiskSpaceChecker = nullptr;


### PR DESCRIPTION
In Qt6, `QVector` is just an alias for `QList` (left to provide compatibility with existing code), so just use `QList` explicitly to keep the code clean.