### PR TITLE
Bump Python version minimum requirement

### DIFF
--- a/.github/workflows/ci_python.yaml
+++ b/.github/workflows/ci_python.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup python (search engine)
         uses: actions/setup-python@v5
         with:
-          python-version: '3.7'
+          python-version: '3.9'
 
       - name: Install tools (search engine)
         run: pip install bandit mypy pycodestyle pyflakes pyright

--- a/INSTALL
+++ b/INSTALL
@@ -18,7 +18,7 @@ qBittorrent - A BitTorrent client in C++ / Qt
   - CMake >= 3.16
       * Compile-time only
 
-  - Python >= 3.7.0
+  - Python >= 3.9.0
       * Optional, run-time only
       * Used by the bundled search engine
 

--- a/src/base/utils/foreignapps.cpp
+++ b/src/base/utils/foreignapps.cpp
@@ -252,7 +252,7 @@ bool Utils::ForeignApps::PythonInfo::isValid() const
 
 bool Utils::ForeignApps::PythonInfo::isSupportedVersion() const
 {
-    return (version >= Version {3, 7, 0});
+    return (version >= Version {3, 9, 0});
 }
 
 PythonInfo Utils::ForeignApps::pythonInfo()

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1667,14 +1667,14 @@ void MainWindow::on_actionSearchWidget_triggered()
 #ifdef Q_OS_WIN
             const QMessageBox::StandardButton buttonPressed = QMessageBox::question(this, tr("Old Python Runtime")
                 , tr("Your Python version (%1) is outdated. Minimum requirement: %2.\nDo you want to install a newer version now?")
-                    .arg(pyInfo.version.toString(), u"3.7.0")
+                    .arg(pyInfo.version.toString(), u"3.9.0")
                 , (QMessageBox::Yes | QMessageBox::No), QMessageBox::Yes);
             if (buttonPressed == QMessageBox::Yes)
                 installPython();
 #else
             QMessageBox::information(this, tr("Old Python Runtime")
                 , tr("Your Python version (%1) is outdated. Please upgrade to latest version for search engines to work.\nMinimum requirement: %2.")
-                .arg(pyInfo.version.toString(), u"3.7.0"));
+                .arg(pyInfo.version.toString(), u"3.9.0"));
 #endif
             return;
         }
@@ -1953,7 +1953,7 @@ void MainWindow::installPython()
 {
     setCursor(QCursor(Qt::WaitCursor));
     // Download python
-    const auto installerURL = u"https://www.python.org/ftp/python/3.10.11/python-3.10.11-amd64.exe"_s;
+    const auto installerURL = u"https://www.python.org/ftp/python/3.12.4/python-3.12.4-amd64.exe"_s;
     Net::DownloadManager::instance()->download(
             Net::DownloadRequest(installerURL).saveToFile(true)
             , Preferences::instance()->useProxyForGeneralPurposes()


### PR DESCRIPTION
The new minimum version is Python 3.9.

Debian Buster (oldoldstable) support ends at [2024.06.30](https://www.debian.org/releases/buster/).
Ubuntu Focal (20.04LTS) support ends at [2025.04](https://ubuntu.com/about/release-cycle).
By the time qbt v5.1 is released, Buster and Focal would have become EOL.

https://packages.debian.org/search?keywords=python3
https://packages.ubuntu.com/search?keywords=python3

