### PR TITLE
WebAPI: Add root_path to torrent/info result

### DIFF
--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -135,6 +135,7 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         {KEY_TORRENT_SAVE_PATH, torrent.savePath().toString()},
         {KEY_TORRENT_DOWNLOAD_PATH, torrent.downloadPath().toString()},
         {KEY_TORRENT_CONTENT_PATH, torrent.contentPath().toString()},
+        {KEY_TORRENT_ROOT_PATH, torrent.rootPath().toString()},
         {KEY_TORRENT_ADDED_ON, Utils::DateTime::toSecsSinceEpoch(torrent.addedTime())},
         {KEY_TORRENT_COMPLETION_ON, Utils::DateTime::toSecsSinceEpoch(torrent.completedTime())},
         {KEY_TORRENT_TRACKER, torrent.currentTracker()},

--- a/src/webui/api/serialize/serialize_torrent.h
+++ b/src/webui/api/serialize/serialize_torrent.h
@@ -66,6 +66,7 @@ inline const QString KEY_TORRENT_FORCE_START = u"force_start"_s;
 inline const QString KEY_TORRENT_SAVE_PATH = u"save_path"_s;
 inline const QString KEY_TORRENT_DOWNLOAD_PATH = u"download_path"_s;
 inline const QString KEY_TORRENT_CONTENT_PATH = u"content_path"_s;
+inline const QString KEY_TORRENT_ROOT_PATH = u"root_path"_s;
 inline const QString KEY_TORRENT_ADDED_ON = u"added_on"_s;
 inline const QString KEY_TORRENT_COMPLETION_ON = u"completion_on"_s;
 inline const QString KEY_TORRENT_TRACKER = u"tracker"_s;


### PR DESCRIPTION
Adds `root_path` to the `torrent/info` API endpoint for each transfer.

Closes #21057.
