### PR TITLE
WebUI: remove deleted torrents even if they are currently filtered out

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -838,13 +838,11 @@ window.qBittorrent.DynamicTable ??= (() => {
 
         removeRow: function(rowId) {
             this.selectedRows.erase(rowId);
-            const tr = this.getTrByRowId(rowId);
-            if (tr !== null) {
-                tr.destroy();
+            if (this.rows.has(rowId))
                 this.rows.erase(rowId);
-                return true;
-            }
-            return false;
+            const tr = this.getTrByRowId(rowId);
+            if (tr !== null)
+                tr.destroy();
         },
 
         clear: function() {


### PR DESCRIPTION
Remove the torrent row regardless of it being visible.

I've also removed the return value because:
- it doesn't appear to be used by any caller;
- other functions (e.g. `updateRowData`) do not return any value;
- it's not clear whether `true` refers to the torrent being removed from the list of all torrents or just the visible ones.

Closes #21070.