### PR TITLE
Represent by TorrentInfo only info-section related metadata

### DIFF
--- a/src/base/bittorrent/torrentdescriptor.h
+++ b/src/base/bittorrent/torrentdescriptor.h
@@ -37,7 +37,6 @@
 
 #include "base/3rdparty/expected.hpp"
 #include "base/path.h"
-#include "torrentdescriptor.h"
 #include "torrentinfo.h"
 
 class QByteArray;

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -403,17 +403,27 @@ QString TorrentImpl::name() const
 
 QDateTime TorrentImpl::creationDate() const
 {
-    return m_torrentInfo.creationDate();
+    if (!hasMetadata())
+        return {};
+
+    const std::time_t date = nativeTorrentInfo()->creation_date();
+    return ((date != 0) ? QDateTime::fromSecsSinceEpoch(date) : QDateTime());
 }
 
 QString TorrentImpl::creator() const
 {
-    return m_torrentInfo.creator();
+    if (!hasMetadata())
+        return {};
+
+    return QString::fromStdString(nativeTorrentInfo()->creator());
 }
 
 QString TorrentImpl::comment() const
 {
-    return m_torrentInfo.comment();
+    if (!hasMetadata())
+        return {};
+
+    return QString::fromStdString(nativeTorrentInfo()->comment());
 }
 
 bool TorrentImpl::isPrivate() const

--- a/src/base/bittorrent/torrentinfo.h
+++ b/src/base/bittorrent/torrentinfo.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2015  Vladimir Golovnev <glassez@yandex.ru>
+ * Copyright (C) 2015-2024  Vladimir Golovnev <glassez@yandex.ru>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -34,7 +34,6 @@
 #include <QCoreApplication>
 #include <QList>
 
-#include "base/3rdparty/expected.hpp"
 #include "base/indexrange.h"
 #include "base/pathfwd.h"
 
@@ -50,26 +49,17 @@ namespace BitTorrent
 
     class TorrentInfo
     {
-        Q_DECLARE_TR_FUNCTIONS(TorrentInfo)
-
     public:
         TorrentInfo() = default;
         TorrentInfo(const TorrentInfo &other) = default;
 
         explicit TorrentInfo(const lt::torrent_info &nativeInfo);
 
-        static nonstd::expected<TorrentInfo, QString> load(const QByteArray &data) noexcept;
-        static nonstd::expected<TorrentInfo, QString> loadFromFile(const Path &path) noexcept;
-        nonstd::expected<void, QString> saveToFile(const Path &path) const;
-
         TorrentInfo &operator=(const TorrentInfo &other);
 
         bool isValid() const;
         InfoHash infoHash() const;
         QString name() const;
-        QDateTime creationDate() const;
-        QString creator() const;
-        QString comment() const;
         bool isPrivate() const;
         qlonglong totalSize() const;
         int filesCount() const;
@@ -80,9 +70,6 @@ namespace BitTorrent
         PathList filePaths() const;
         qlonglong fileSize(int index) const;
         qlonglong fileOffset(int index) const;
-        QList<TrackerEntry> trackers() const;
-        QList<QUrl> urlSeeds() const;
-        QByteArray metadata() const;
         PathList filesForPiece(int pieceIndex) const;
         QList<int> fileIndicesForPiece(int pieceIndex) const;
         QList<QByteArray> pieceHashes() const;
@@ -92,6 +79,8 @@ namespace BitTorrent
         // the given file extends (maybe partially).
         PieceRange filePieces(const Path &filePath) const;
         PieceRange filePieces(int fileIndex) const;
+
+        QByteArray rawData() const;
 
         bool matchesInfoHash(const InfoHash &otherInfoHash) const;
 

--- a/src/gui/addnewtorrentdialog.cpp
+++ b/src/gui/addnewtorrentdialog.cpp
@@ -897,11 +897,11 @@ void AddNewTorrentDialog::setupTreeview()
     // Set dialog title
     setWindowTitle(torrentDescr.name());
 
-    const auto &torrentInfo = *torrentDescr.info();
-
     // Set torrent information
-    m_ui->labelCommentData->setText(Utils::Misc::parseHtmlLinks(torrentInfo.comment().toHtmlEscaped()));
-    m_ui->labelDateData->setText(!torrentInfo.creationDate().isNull() ? QLocale().toString(torrentInfo.creationDate(), QLocale::ShortFormat) : tr("Not available"));
+    m_ui->labelCommentData->setText(Utils::Misc::parseHtmlLinks(torrentDescr.comment().toHtmlEscaped()));
+    m_ui->labelDateData->setText(!torrentDescr.creationDate().isNull() ? QLocale().toString(torrentDescr.creationDate(), QLocale::ShortFormat) : tr("Not available"));
+
+    const auto &torrentInfo = *torrentDescr.info();
 
     BitTorrent::AddTorrentParams &addTorrentParams = m_currentContext->torrentParams;
     if (addTorrentParams.filePaths.isEmpty())


### PR DESCRIPTION
Just following the previously planned course of restructuring the object model.
In fact, it follows the changes supposed to be made to `libtorrent`, but it is slow in such things (for various reasons). However, nothing prevents us from getting ahead of `libtorrent` in such matters in order to avoid the spread of legacy approaches in our code.