### PR TITLE
Clean up search engine

### DIFF
--- a/src/base/search/searchpluginmanager.cpp
+++ b/src/base/search/searchpluginmanager.cpp
@@ -367,14 +367,14 @@ QString SearchPluginManager::categoryFullName(const QString &categoryName)
     const QHash<QString, QString> categoryTable
     {
         {u"all"_s, tr("All categories")},
-        {u"movies"_s, tr("Movies")},
-        {u"tv"_s, tr("TV shows")},
-        {u"music"_s, tr("Music")},
-        {u"games"_s, tr("Games")},
         {u"anime"_s, tr("Anime")},
-        {u"software"_s, tr("Software")},
+        {u"books"_s, tr("Books")},
+        {u"games"_s, tr("Games")},
+        {u"movies"_s, tr("Movies")},
+        {u"music"_s, tr("Music")},
         {u"pictures"_s, tr("Pictures")},
-        {u"books"_s, tr("Books")}
+        {u"software"_s, tr("Software")},
+        {u"tv"_s, tr("TV shows")}
     };
     return categoryTable.value(categoryName);
 }

--- a/src/searchengine/nova3/novaprinter.py
+++ b/src/searchengine/nova3/novaprinter.py
@@ -1,4 +1,4 @@
-#VERSION: 1.50
+#VERSION: 1.51
 
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -25,21 +25,18 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import re
-from collections.abc import Mapping
-from typing import Any, Union
+from typing import TypedDict, Union
 
-# TODO: enable the following when using Python >= 3.8
-#SearchResults = TypedDict('SearchResults', {
-#    'link': str,
-#    'name': str,
-#    'size': Union[float, int, str],
-#    'seeds': int,
-#    'leech': int,
-#    'engine_url': str,
-#    'desc_link': str,  # Optional  # TODO: use `NotRequired[str]` when using Python >= 3.11
-#    'pub_date': int  # Optional  # TODO: use `NotRequired[int]` when using Python >= 3.11
-#})
-SearchResults = Mapping[str, Any]
+SearchResults = TypedDict('SearchResults', {
+    'link': str,
+    'name': str,
+    'size': Union[float, int, str],  # TODO: use `float | int | str` when using Python >= 3.10
+    'seeds': int,
+    'leech': int,
+    'engine_url': str,
+    'desc_link': str,  # Optional  # TODO: use `NotRequired[str]` when using Python >= 3.11
+    'pub_date': int  # Optional  # TODO: use `NotRequired[int]` when using Python >= 3.11
+})
 
 
 def prettyPrinter(dictionary: SearchResults) -> None:
@@ -62,6 +59,7 @@ def prettyPrinter(dictionary: SearchResults) -> None:
 sizeUnitRegex: re.Pattern[str] = re.compile(r"^(?P<size>\d*\.?\d+) *(?P<unit>[a-z]+)?", re.IGNORECASE)
 
 
+# TODO: use `float | int | str` when using Python >= 3.10
 def anySizeToBytes(size_string: Union[float, int, str]) -> int:
     """
     Convert a string like '1 KB' to '1024' (bytes)


### PR DESCRIPTION
Notable changes:
1. Prevent excessive engine module imports.
2. Replace trivial usage of `join()`.
3. Keep the output text sorted whenever possible.
4. Close handles properly.
5. Print error to stderr, not stdout.
6. Report search job exit code.
7. Print exception message to stderr if exception was thrown when running a search job.
8. Utilize XML library to build XML data And use 2 spaces as indentation.
