### PR TITLE
Do not escape quote characters

### DIFF
--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -265,10 +265,6 @@ void WebApplication::translateDocument(QString &data) const
             // it should fallback to `sourceText`
             QString translation = loadedText.isEmpty() ? sourceText : loadedText;
 
-            // Use HTML code for quotes to prevent issues with JS
-            translation.replace(u'\'', u"&#39;"_s);
-            translation.replace(u'\"', u"&#34;"_s);
-
             data.replace(i, regexMatch.capturedLength(), translation);
             i += translation.length();
         }


### PR DESCRIPTION
At the site of `QBT_TR` usage will now try to handle them properly.
In addition, this workaround actually force JS to use the dangerous `innerHTML` to set the text instead of the safer `textContent`. See: https://github.com/qbittorrent/qBittorrent/pull/21056#discussion_r1693279666
