### PR TITLE
Enable adaptive step size for upload and download limits

### DIFF
--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -2259,6 +2259,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                  <property name="value">
                   <number>100</number>
                  </property>
+                 <property name="stepType">
+                  <enum>QAbstractSpinBox::AdaptiveDecimalStepType</enum>
+                 </property>
                 </widget>
                </item>
                <item row="1" column="2">
@@ -2274,6 +2277,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                  </property>
                  <property name="value">
                   <number>100</number>
+                 </property>
+                 <property name="stepType">
+                  <enum>QAbstractSpinBox::AdaptiveDecimalStepType</enum>
                  </property>
                 </widget>
                </item>
@@ -2329,6 +2335,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                  </property>
                  <property name="value">
                   <number>10</number>
+                 </property>
+                 <property name="stepType">
+                  <enum>QAbstractSpinBox::AdaptiveDecimalStepType</enum>
                  </property>
                 </widget>
                </item>
@@ -2465,6 +2474,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                  </property>
                  <property name="value">
                   <number>10</number>
+                 </property>
+                 <property name="stepType">
+                  <enum>QAbstractSpinBox::AdaptiveDecimalStepType</enum>
                  </property>
                 </widget>
                </item>
@@ -2854,6 +2866,9 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                     <property name="value">
                      <number>2</number>
                     </property>
+                    <property name="stepType">
+                     <enum>QAbstractSpinBox::AdaptiveDecimalStepType</enum>
+                    </property>
                    </widget>
                   </item>
                   <item row="1" column="1">
@@ -2866,6 +2881,9 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                     </property>
                     <property name="value">
                      <number>2</number>
+                    </property>
+                    <property name="stepType">
+                     <enum>QAbstractSpinBox::AdaptiveDecimalStepType</enum>
                     </property>
                    </widget>
                   </item>

--- a/src/gui/speedlimitdialog.ui
+++ b/src/gui/speedlimitdialog.ui
@@ -52,6 +52,9 @@
         <property name="maximum">
          <number>2000000</number>
         </property>
+        <property name="stepType">
+         <enum>QAbstractSpinBox::AdaptiveDecimalStepType</enum>
+        </property>
        </widget>
       </item>
       <item row="1" column="1">
@@ -78,6 +81,9 @@
         </property>
         <property name="maximum">
          <number>2000000</number>
+        </property>
+        <property name="stepType">
+         <enum>QAbstractSpinBox::AdaptiveDecimalStepType</enum>
         </property>
        </widget>
       </item>
@@ -122,6 +128,9 @@
         <property name="maximum">
          <number>2000000</number>
         </property>
+        <property name="stepType">
+         <enum>QAbstractSpinBox::AdaptiveDecimalStepType</enum>
+        </property>
        </widget>
       </item>
       <item row="1" column="1">
@@ -148,6 +157,9 @@
         </property>
         <property name="maximum">
          <number>2000000</number>
+        </property>
+        <property name="stepType">
+         <enum>QAbstractSpinBox::AdaptiveDecimalStepType</enum>
         </property>
        </widget>
       </item>

--- a/src/gui/torrentoptionsdialog.ui
+++ b/src/gui/torrentoptionsdialog.ui
@@ -104,6 +104,9 @@
         <property name="maximum">
          <number>2000000</number>
         </property>
+        <property name="stepType">
+         <enum>QAbstractSpinBox::AdaptiveDecimalStepType</enum>
+        </property>
        </widget>
       </item>
       <item row="0" column="2">
@@ -116,6 +119,9 @@
         </property>
         <property name="maximum">
          <number>2000000</number>
+        </property>
+        <property name="stepType">
+         <enum>QAbstractSpinBox::AdaptiveDecimalStepType</enum>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
I created the same functionality here many years ago, it received some positive feedback but was ultimately closed: https://github.com/qbittorrent/qBittorrent/pull/4943

Since then, I went ahead and created this feature within Qt itself, see documentation here: https://doc.qt.io/qt-6/qspinbox.html#setStepType

Now that this functionality exists in a more straightforward way, maybe it can be useful for us here?