### PR TITLE
WebUI: Implement 'Auto hide zero status filters'

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -119,6 +119,7 @@ let queueing_enabled = true;
 let serverSyncMainDataInterval = 1500;
 let customSyncMainDataInterval = null;
 let useSubcategories = true;
+const useAutoHideZeroStatusFilters = LocalPreferences.get("hide_zero_status_filters", "false") === "true";
 
 /* Categories filter */
 const CATEGORIES_ALL = 1;
@@ -431,7 +432,14 @@ window.addEventListener("DOMContentLoaded", () => {
     };
 
     const updateFilter = function(filter, filterTitle) {
-        $(filter + "_filter").firstChild.childNodes[1].nodeValue = filterTitle.replace("%1", torrentsTable.getFilteredTorrentsNumber(filter, CATEGORIES_ALL, TAGS_ALL, TRACKERS_ALL));
+        const filterEl = document.getElementById(`${filter}_filter`);
+        const filterTorrentCount = torrentsTable.getFilteredTorrentsNumber(filter, CATEGORIES_ALL, TAGS_ALL, TRACKERS_ALL);
+        if (useAutoHideZeroStatusFilters) {
+            const hideFilter = (filterTorrentCount === 0) && (filter !== "all");
+            if (filterEl.classList.toggle("invisible", hideFilter))
+                return;
+        }
+        filterEl.firstElementChild.lastChild.nodeValue = filterTitle.replace("%1", filterTorrentCount);
     };
 
     const updateFiltersList = function() {

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -38,6 +38,10 @@
                 </tbody>
             </table>
         </fieldset>
+        <div class="formRow" style="margin-bottom: 3px;">
+            <input type="checkbox" id="hideZeroFiltersCheckbox">
+            <label for="hideZeroFiltersCheckbox">QBT_TR(Auto hide zero status filters)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </div>
     </fieldset>
 
     <fieldset class="settings">
@@ -2075,6 +2079,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             window.parent.qBittorrent.Cache.preferences.init({
                 onSuccess: (pref) => {
                     // Behavior tab
+                    document.getElementById("hideZeroFiltersCheckbox").checked = (LocalPreferences.get("hide_zero_status_filters", "false") === "true");
                     $("dblclickDownloadSelect").value = LocalPreferences.get("dblclick_download", "1");
                     $("dblclickCompleteSelect").value = LocalPreferences.get("dblclick_complete", "1");
                     document.getElementById("useAltRowColorsInput").checked = (LocalPreferences.get("use_alt_row_colors", "true") === "true");
@@ -2486,6 +2491,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             // Validate form data
 
             // Behavior tab
+            LocalPreferences.set("hide_zero_status_filters", document.getElementById("hideZeroFiltersCheckbox").checked.toString());
             LocalPreferences.set("dblclick_download", $("dblclickDownloadSelect").value);
             LocalPreferences.set("dblclick_complete", $("dblclickCompleteSelect").value);
             LocalPreferences.set("use_alt_row_colors", document.getElementById("useAltRowColorsInput").checked.toString());


### PR DESCRIPTION
This PR implements 'Auto hide zero status filters' option in WebUI.

---
In GUI, filters are not cleaned up after deleting all torrents:
![image](https://github.com/user-attachments/assets/adfbccdf-a544-48ad-87ca-afc77b57e029)

Just add a couple of torrents in paused state then delete them all to reproduce.
When you reopen the client only 'All' remains, so it looks like a bug (checked both 4.6.5 and master).

In WebUI, 'All' is the only filter shown in all cases.


