### PR TITLE
WebUI: Correctly filter torrent list when input regex is invalid

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1502,9 +1502,17 @@ window.qBittorrent.DynamicTable ??= (() => {
             const rows = this.rows.getValues();
             const useRegex = $("torrentsFilterRegexBox").checked;
             const filterText = $("torrentsFilterInput").value.trim().toLowerCase();
-            const filterTerms = (filterText.length > 0)
-                ? (useRegex ? new RegExp(filterText) : filterText.split(" "))
-                : null;
+            let filterTerms;
+            try {
+                filterTerms = (filterText.length > 0)
+                    ? (useRegex ? new RegExp(filterText) : filterText.split(" "))
+                    : null;
+            }
+            catch (e) {
+                // return 0 filtered torrents when regex is invalid
+                console.error(e.message);
+                return [];
+            }
 
             for (let i = 0; i < rows.length; ++i) {
                 if (this.applyFilter(rows[i], selected_filter, selected_category, selectedTag, selectedTracker, filterTerms)) {


### PR DESCRIPTION
In GUI, you get 0 filtered torrents when input regex is invalid, so I changed the WebUI to do the exact same thing.