### PR TITLE
WebUI: Allow to filter torrent list by save path

### DIFF
--- a/src/webui/www/private/css/style.css
+++ b/src/webui/www/private/css/style.css
@@ -449,6 +449,10 @@ a.propButton img {
     width: 26px;
 }
 
+#torrentsFilterSelect {
+    padding: 2px 4px;
+}
+
 #torrentFilesFilterToolbar {
     float: right;
     margin-right: 30px;

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -133,6 +133,11 @@
                     <input type="text" id="torrentsFilterInput" placeholder="QBT_TR(Filter torrent list...)QBT_TR[CONTEXT=MainWindow]" aria-label="QBT_TR(Filter torrent list...)QBT_TR[CONTEXT=MainWindow]" autocorrect="off" autocapitalize="none">
                     <input type="checkbox" id="torrentsFilterRegexBox">
                     <label for="torrentsFilterRegexBox" aria-label="QBT_TR(Use regular expressions)QBT_TR[CONTEXT=MainWindow]"></label>
+                    <label for="torrentsFilterSelect">QBT_TR(Filter by:)QBT_TR[CONTEXT=MainWindow]</label>
+                    <select id="torrentsFilterSelect">
+                        <option value="name" selected>QBT_TR(Name)QBT_TR[CONTEXT=MainWindow]</option>
+                        <option value="save_path">QBT_TR(Save Path)QBT_TR[CONTEXT=MainWindow]</option>
+                    </select>
                 </div>
             </div>
         </div>

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -1523,9 +1523,8 @@ window.addEventListener("DOMContentLoaded", () => {
             torrentsTable.updateTable();
         }, window.qBittorrent.Misc.FILTER_INPUT_DELAY);
     });
-    $("torrentsFilterRegexBox").addEventListener("change", () => {
-        torrentsTable.updateTable();
-    });
+
+    document.getElementById("torrentsFilterToolbar").addEventListener("change", (e) => { torrentsTable.updateTable(); });
 
     $("transfersTabLink").addEventListener("click", showTransfersTab);
     $("searchTabLink").addEventListener("click", showSearchTab);

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1330,7 +1330,6 @@ window.qBittorrent.DynamicTable ??= (() => {
 
         applyFilter: function(row, filterName, categoryHash, tagHash, trackerHash, filterTerms) {
             const state = row["full_data"].state;
-            const name = row["full_data"].name.toLowerCase();
             let inactive = false;
 
             switch (filterName) {
@@ -1460,12 +1459,14 @@ window.qBittorrent.DynamicTable ??= (() => {
             }
 
             if ((filterTerms !== undefined) && (filterTerms !== null)) {
+                const filterBy = document.getElementById("torrentsFilterSelect").value;
+                const textToSearch = row["full_data"][filterBy].toLowerCase();
                 if (filterTerms instanceof RegExp) {
-                    if (!filterTerms.test(name))
+                    if (!filterTerms.test(textToSearch))
                         return false;
                 }
                 else {
-                    if ((filterTerms.length > 0) && !window.qBittorrent.Misc.containsAllTerms(name, filterTerms))
+                    if ((filterTerms.length > 0) && !window.qBittorrent.Misc.containsAllTerms(textToSearch, filterTerms))
                         return false;
                 }
             }


### PR DESCRIPTION
This PR adds ability to filter torrent list by save path. Everything should work exactly like in GUI.

![image](https://github.com/user-attachments/assets/a998231c-5803-4ccf-96c4-6ec0d1732b6c)

Closes #19393.

