### PR TITLE
Search helpers: Add POST support to `retrieve_url`

### DIFF
--- a/src/searchengine/nova3/helpers.py
+++ b/src/searchengine/nova3/helpers.py
@@ -89,7 +89,7 @@ def htmlentitydecode(s: str) -> str:
     return re.sub(r'&#x(\w+);', lambda x: chr(int(x.group(1), 16)), t)
 
 
-def retrieve_url(url: str, custom_headers: Mapping[str, Any] = {}, post_data: Optional[bytes] = None) -> str:
+def retrieve_url(url: str, custom_headers: Mapping[str, Any] = {}, request_data: Optional[bytes] = None) -> str:
     """ Return the content of the url page as a string """
 
     request = urllib.request.Request(url, request_data, {**headers, **custom_headers})

--- a/src/searchengine/nova3/helpers.py
+++ b/src/searchengine/nova3/helpers.py
@@ -89,7 +89,7 @@ def htmlentitydecode(s: str) -> str:
     return re.sub(r'&#x(\w+);', lambda x: chr(int(x.group(1), 16)), t)
 
 
-def retrieve_url(url: str, custom_headers: Mapping[str, Any] = {}, request_data: Optional[bytes] = None) -> str:
+def retrieve_url(url: str, custom_headers: Mapping[str, Any] = {}, request_data: Optional[Any] = None) -> str:
     """ Return the content of the url page as a string """
 
     request = urllib.request.Request(url, request_data, {**headers, **custom_headers})

--- a/src/searchengine/nova3/helpers.py
+++ b/src/searchengine/nova3/helpers.py
@@ -1,4 +1,4 @@
-#VERSION: 1.48
+#VERSION: 1.49
 
 # Author:
 #  Christophe DUMEZ (chris@qbittorrent.org)

--- a/src/searchengine/nova3/helpers.py
+++ b/src/searchengine/nova3/helpers.py
@@ -92,7 +92,7 @@ def htmlentitydecode(s: str) -> str:
 def retrieve_url(url: str, custom_headers: Mapping[str, Any] = {}, post_data: Optional[bytes] = None) -> str:
     """ Return the content of the url page as a string """
 
-    request = urllib.request.Request(url, headers={**headers, **custom_headers}, data=post_data)
+    request = urllib.request.Request(url, request_data, {**headers, **custom_headers})
     try:
         response = urllib.request.urlopen(request)
     except urllib.error.URLError as errno:

--- a/src/searchengine/nova3/helpers.py
+++ b/src/searchengine/nova3/helpers.py
@@ -89,10 +89,10 @@ def htmlentitydecode(s: str) -> str:
     return re.sub(r'&#x(\w+);', lambda x: chr(int(x.group(1), 16)), t)
 
 
-def retrieve_url(url: str, custom_headers: Mapping[str, Any] = {}) -> str:
+def retrieve_url(url: str, custom_headers: Mapping[str, Any] = {}, post_data: Optional[bytes] = None) -> str:
     """ Return the content of the url page as a string """
 
-    request = urllib.request.Request(url, headers={**headers, **custom_headers})
+    request = urllib.request.Request(url, headers={**headers, **custom_headers}, data=post_data)
     try:
         response = urllib.request.urlopen(request)
     except urllib.error.URLError as errno:


### PR DESCRIPTION
This allows passing post_data to retrieve_url in order to create a post request.

This is required for me to fix eztv search plugin.

<!--
MANDATORY Before submitting your work, make sure you have:
1. Read https://github.com/qbittorrent/qBittorrent/blob/master/CONTRIBUTING.md#opening-a-pull-request
2. Delete this comment block
-->
