### PR TITLE
WebUI: Always create generic filter items

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -771,6 +771,9 @@ window.addEventListener("DOMContentLoaded", () => {
                     const full_update = (response["full_update"] === true);
                     if (full_update) {
                         torrentsTableSelectedRows = torrentsTable.selectedRowsIds();
+                        update_categories = true;
+                        updateTags = true;
+                        updateTrackers = true;
                         torrentsTable.clear();
                         category_list.clear();
                         tagList.clear();


### PR DESCRIPTION
This PR ensures that generic filter items are created in all circumstances.

---

There is at least a couple of ways to reproduce it, here's one:
1) Delete all torrents and custom categories / tags (if any present) from the desktop client
2) Turn on "Use subcategories" option
3) Open fresh WebUI:

![image](https://github.com/user-attachments/assets/97f08348-ece4-468b-afe9-8cad679c40bf)

4) Here's how tracker filter list looks after adding one trackerless torrent:

![image](https://github.com/user-attachments/assets/d4135d52-1af8-4aca-afb2-8243a2dda009)
