### PR TITLE
Bump WebAPI version

### DIFF
--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -54,7 +54,7 @@
 #include "base/utils/version.h"
 #include "api/isessionmanager.h"
 
-inline const Utils::Version<3, 2> API_VERSION {2, 11, 2};
+inline const Utils::Version<3, 2> API_VERSION {2, 11, 3};
 
 class QTimer;
 


### PR DESCRIPTION
## Changes
- Bumps Web API version to account for https://github.com/qbittorrent/qBittorrent/pull/21043

## Notes
- Currently, I can't tell the difference between v5_0_x and master
- Feel free to close if you want to handle another way; just figured this was easier/better than opening an issue
