### PR TITLE
WebUI: Improve properties panel

### DIFF
--- a/src/webui/www/private/css/style.css
+++ b/src/webui/www/private/css/style.css
@@ -455,7 +455,7 @@ a.propButton img {
 
 #torrentFilesFilterToolbar {
     float: right;
-    margin-right: 30px;
+    margin-right: 5px;
 }
 
 #torrentFilesFilterInput {
@@ -464,7 +464,7 @@ a.propButton img {
     background-repeat: no-repeat;
     background-size: 1.5em;
     padding-left: 2em;
-    width: 160px;
+    width: 250px;
 }
 
 /* Tri-state checkbox */
@@ -591,7 +591,7 @@ td.generalLabel {
     user-select: none;
 }
 
-#prop_general {
+#propGeneral {
     padding: 2px;
 }
 

--- a/src/webui/www/private/scripts/prop-files.js
+++ b/src/webui/www/private/scripts/prop-files.js
@@ -334,7 +334,7 @@ window.qBittorrent.PropFiles ??= (() => {
 
     let loadTorrentFilesDataTimer = -1;
     const loadTorrentFilesData = function() {
-        if ($("prop_files").hasClass("invisible")
+        if ($("propFiles").hasClass("invisible")
             || $("propertiesPanel_collapseToggle").hasClass("panel-expand")) {
             // Tab changed, don't do anything
             return;

--- a/src/webui/www/private/scripts/prop-general.js
+++ b/src/webui/www/private/scripts/prop-general.js
@@ -74,7 +74,7 @@ window.qBittorrent.PropGeneral ??= (() => {
 
     let loadTorrentDataTimer = -1;
     const loadTorrentData = function() {
-        if ($("prop_general").hasClass("invisible")
+        if ($("propGeneral").hasClass("invisible")
             || $("propertiesPanel_collapseToggle").hasClass("panel-expand")) {
             // Tab changed, don't do anything
             return;

--- a/src/webui/www/private/scripts/prop-peers.js
+++ b/src/webui/www/private/scripts/prop-peers.js
@@ -42,7 +42,7 @@ window.qBittorrent.PropPeers ??= (() => {
     let show_flags = true;
 
     const loadTorrentPeersData = function() {
-        if ($("prop_peers").hasClass("invisible")
+        if ($("propPeers").hasClass("invisible")
             || $("propertiesPanel_collapseToggle").hasClass("panel-expand")) {
             syncTorrentPeersLastResponseId = 0;
             torrentPeersTable.clear();

--- a/src/webui/www/private/scripts/prop-trackers.js
+++ b/src/webui/www/private/scripts/prop-trackers.js
@@ -42,7 +42,7 @@ window.qBittorrent.PropTrackers ??= (() => {
     let loadTrackersDataTimer = -1;
 
     const loadTrackersData = function() {
-        if ($("prop_trackers").hasClass("invisible")
+        if ($("propTrackers").hasClass("invisible")
             || $("propertiesPanel_collapseToggle").hasClass("panel-expand")) {
             // Tab changed, don't do anything
             return;

--- a/src/webui/www/private/scripts/prop-webseeds.js
+++ b/src/webui/www/private/scripts/prop-webseeds.js
@@ -90,7 +90,7 @@ window.qBittorrent.PropWebseeds ??= (() => {
 
     let loadWebSeedsDataTimer = -1;
     const loadWebSeedsData = function() {
-        if ($("prop_webseeds").hasClass("invisible")
+        if ($("propWebSeeds").hasClass("invisible")
             || $("propertiesPanel_collapseToggle").hasClass("panel-expand")) {
             // Tab changed, don't do anything
             return;

--- a/src/webui/www/private/views/properties.html
+++ b/src/webui/www/private/views/properties.html
@@ -1,4 +1,4 @@
-<div id="prop_general" class="propertiesTabContent">
+<div id="propGeneral" class="propertiesTabContent invisible unselectable">
     <table style="width: 100%; padding: 0 3px">
         <tbody>
             <tr>
@@ -104,7 +104,7 @@
     </fieldset>
 </div>
 
-<div id="prop_trackers" class="propertiesTabContent invisible unselectable">
+<div id="propTrackers" class="propertiesTabContent invisible unselectable">
     <div id="trackers">
         <div id="torrentTrackersTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
             <table class="dynamicTable" style="position:relative;">
@@ -124,7 +124,7 @@
     </div>
 </div>
 
-<div id="prop_peers" class="propertiesTabContent invisible unselectable">
+<div id="propPeers" class="propertiesTabContent invisible unselectable">
     <div>
         <div id="torrentPeersTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
             <table class="dynamicTable" style="position:relative;">
@@ -144,7 +144,7 @@
     </div>
 </div>
 
-<div id="prop_webseeds" class="propertiesTabContent invisible unselectable">
+<div id="propWebSeeds" class="propertiesTabContent invisible unselectable">
     <div id="webseeds">
         <table class="dynamicTable" style="width: 100%">
             <thead>
@@ -157,7 +157,7 @@
     </div>
 </div>
 
-<div id="prop_files" class="propertiesTabContent invisible unselectable">
+<div id="propFiles" class="propertiesTabContent invisible unselectable">
     <div id="torrentFiles">
         <div id="torrentFilesTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
             <table class="dynamicTable" style="position:relative;">
@@ -176,13 +176,3 @@
         </div>
     </div>
 </div>
-
-<script>
-    "use strict";
-
-    (function() {
-        const selectedTab = $(LocalPreferences.get("selected_tab", "PropGeneralLink"));
-        if (selectedTab)
-            selectedTab.click();
-    })();
-</script>

--- a/src/webui/www/private/views/propertiesToolbar.html
+++ b/src/webui/www/private/views/propertiesToolbar.html
@@ -3,19 +3,19 @@
         <input type="text" id="torrentFilesFilterInput" placeholder="QBT_TR(Filter files...)QBT_TR[CONTEXT=PropertiesWidget]" aria-label="QBT_TR(Filter files...)QBT_TR[CONTEXT=PropertiesWidget]" autocorrect="off" autocapitalize="none">
     </div>
     <menu id="propertiesTabs" class="tab-menu">
-        <li id="PropGeneralLink" class="selected">
+        <li id="propGeneralLink">
             <a><img alt="QBT_TR(General)QBT_TR[CONTEXT=PropTabBar]" src="images/help-about.svg" width="16" height="16">QBT_TR(General)QBT_TR[CONTEXT=PropTabBar]</a>
         </li>
-        <li id="PropTrackersLink">
+        <li id="propTrackersLink">
             <a><img alt="QBT_TR(Trackers)QBT_TR[CONTEXT=PropTabBar]" src="images/trackers.svg" width="16" height="16">QBT_TR(Trackers)QBT_TR[CONTEXT=PropTabBar]</a>
         </li>
-        <li id="PropPeersLink">
+        <li id="propPeersLink">
             <a><img alt="QBT_TR(Peers)QBT_TR[CONTEXT=PropTabBar]" src="images/peers.svg" width="16" height="16">QBT_TR(Peers)QBT_TR[CONTEXT=PropTabBar]</a>
         </li>
-        <li id="PropWebSeedsLink">
+        <li id="propWebSeedsLink">
             <a><img alt="QBT_TR(HTTP Sources)QBT_TR[CONTEXT=PropTabBar]" src="images/network-server.svg" width="16" height="16">QBT_TR(HTTP Sources)QBT_TR[CONTEXT=PropTabBar]</a>
         </li>
-        <li id="PropFilesLink">
+        <li id="propFilesLink">
             <a><img alt="QBT_TR(Content)QBT_TR[CONTEXT=PropTabBar]" src="images/directory.svg" width="16" height="16">QBT_TR(Content)QBT_TR[CONTEXT=PropTabBar]</a>
         </li>
     </menu>


### PR DESCRIPTION
This PR improves properties panel.

---

It is now possible to expand & collapse it by clicking directly on tabs, just like in GUI.
In addition, collapse state is saved and applied on page load.
Fixed one minor bug and now files search input is properly hidden even when panel is collapsed, before it was like this:

![image](https://github.com/user-attachments/assets/699b7f47-ed27-4e3b-97f5-4dd2194299e0)
