### PR TITLE
WebUI: Allow to display only hostname in the Tracker column

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -30,8 +30,6 @@ window.qBittorrent.Client ??= (() => {
     const exports = () => {
         return {
             closeWindows: closeWindows,
-            genHash: genHash,
-            getHost: getHost,
             getSyncMainDataInterval: getSyncMainDataInterval,
             isStopped: isStopped,
             stop: stop,
@@ -47,40 +45,6 @@ window.qBittorrent.Client ??= (() => {
 
     const closeWindows = function() {
         MochaUI.closeAll();
-    };
-
-    const genHash = function(string) {
-        // origins:
-        // https://stackoverflow.com/a/8831937
-        // https://gist.github.com/hyamamoto/fd435505d29ebfa3d9716fd2be8d42f0
-        let hash = 0;
-        for (let i = 0; i < string.length; ++i)
-            hash = ((Math.imul(hash, 31) + string.charCodeAt(i)) | 0);
-        return hash;
-    };
-
-    // getHost emulate the GUI version `QString getHost(const QString &url)`
-    const getHost = function(url) {
-        // We want the hostname.
-        // If failed to parse the domain, original input should be returned
-
-        if (!/^(?:https?|udp):/i.test(url))
-            return url;
-
-        try {
-            // hack: URL can not get hostname from udp protocol
-            const parsedUrl = new URL(url.replace(/^udp:/i, "https:"));
-            // host: "example.com:8443"
-            // hostname: "example.com"
-            const host = parsedUrl.hostname;
-            if (!host)
-                return url;
-
-            return host;
-        }
-        catch (error) {
-            return url;
-        }
     };
 
     const getSyncMainDataInterval = function() {
@@ -397,7 +361,7 @@ window.addEventListener("DOMContentLoaded", () => {
             return true;
         }
 
-        const categoryHash = window.qBittorrent.Client.genHash(category);
+        const categoryHash = window.qBittorrent.Misc.genHash(category);
         if (!category_list.has(categoryHash)) { // This should not happen
             category_list.set(categoryHash, {
                 name: category,
@@ -440,7 +404,7 @@ window.addEventListener("DOMContentLoaded", () => {
         const tags = torrent["tags"].split(",");
         let added = false;
         for (let i = 0; i < tags.length; ++i) {
-            const tagHash = window.qBittorrent.Client.genHash(tags[i].trim());
+            const tagHash = window.qBittorrent.Misc.genHash(tags[i].trim());
             if (!tagList.has(tagHash)) { // This should not happen
                 tagList.set(tagHash, {
                     name: tags,
@@ -791,7 +755,7 @@ window.addEventListener("DOMContentLoaded", () => {
                                 continue;
 
                             const responseCategory = response["categories"][key];
-                            const categoryHash = window.qBittorrent.Client.genHash(key);
+                            const categoryHash = window.qBittorrent.Misc.genHash(key);
                             const category = category_list.get(categoryHash);
                             if (category !== undefined) {
                                 // only the save path can change for existing categories
@@ -809,14 +773,14 @@ window.addEventListener("DOMContentLoaded", () => {
                     }
                     if (response["categories_removed"]) {
                         response["categories_removed"].each((category) => {
-                            const categoryHash = window.qBittorrent.Client.genHash(category);
+                            const categoryHash = window.qBittorrent.Misc.genHash(category);
                             category_list.delete(categoryHash);
                         });
                         update_categories = true;
                     }
                     if (response["tags"]) {
                         for (const tag of response["tags"]) {
-                            const tagHash = window.qBittorrent.Client.genHash(tag);
+                            const tagHash = window.qBittorrent.Misc.genHash(tag);
                             if (!tagList.has(tagHash)) {
                                 tagList.set(tagHash, {
                                     name: tag,
@@ -828,15 +792,15 @@ window.addEventListener("DOMContentLoaded", () => {
                     }
                     if (response["tags_removed"]) {
                         for (let i = 0; i < response["tags_removed"].length; ++i) {
-                            const tagHash = window.qBittorrent.Client.genHash(response["tags_removed"][i]);
+                            const tagHash = window.qBittorrent.Misc.genHash(response["tags_removed"][i]);
                             tagList.delete(tagHash);
                         }
                         updateTags = true;
                     }
                     if (response["trackers"]) {
                         for (const [tracker, torrents] of Object.entries(response["trackers"])) {
-                            const host = window.qBittorrent.Client.getHost(tracker);
-                            const hash = window.qBittorrent.Client.genHash(host);
+                            const host = window.qBittorrent.Misc.getHost(tracker);
+                            const hash = window.qBittorrent.Misc.genHash(host);
 
                             let trackerListItem = trackerList.get(hash);
                             if (trackerListItem === undefined) {
@@ -851,8 +815,8 @@ window.addEventListener("DOMContentLoaded", () => {
                     if (response["trackers_removed"]) {
                         for (let i = 0; i < response["trackers_removed"].length; ++i) {
                             const tracker = response["trackers_removed"][i];
-                            const host = window.qBittorrent.Client.getHost(tracker);
-                            const hash = window.qBittorrent.Client.genHash(host);
+                            const host = window.qBittorrent.Misc.getHost(tracker);
+                            const hash = window.qBittorrent.Misc.genHash(host);
                             const trackerListEntry = trackerList.get(hash);
                             if (trackerListEntry)
                                 trackerListEntry.trackerTorrentMap.delete(tracker);

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1244,6 +1244,14 @@ window.qBittorrent.DynamicTable ??= (() => {
                 }
             };
 
+            // tracker
+            this.columns["tracker"].updateTd = function(td, row) {
+                const value = this.getRowValue(row);
+                const tracker = displayFullURLTrackerColumn ? value : window.qBittorrent.Client.getHost(value);
+                td.textContent = tracker;
+                td.title = value;
+            };
+
             //  dl_limit, up_limit
             this.columns["dl_limit"].updateTd = function(td, row) {
                 const speed = this.getRowValue(row);

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1247,7 +1247,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             // tracker
             this.columns["tracker"].updateTd = function(td, row) {
                 const value = this.getRowValue(row);
-                const tracker = displayFullURLTrackerColumn ? value : window.qBittorrent.Client.getHost(value);
+                const tracker = displayFullURLTrackerColumn ? value : window.qBittorrent.Misc.getHost(value);
                 td.textContent = tracker;
                 td.title = value;
             };
@@ -1428,7 +1428,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                     break; // do nothing
                 default:
                     if (!useSubcategories) {
-                        if (categoryHash !== window.qBittorrent.Client.genHash(row["full_data"].category))
+                        if (categoryHash !== window.qBittorrent.Misc.genHash(row["full_data"].category))
                             return false;
                     }
                     else {
@@ -1453,7 +1453,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                     break; // do nothing
 
                 default: {
-                    const tagHashes = row["full_data"].tags.split(", ").map(tag => window.qBittorrent.Client.genHash(tag));
+                    const tagHashes = row["full_data"].tags.split(", ").map(tag => window.qBittorrent.Misc.genHash(tag));
                     if (!tagHashes.contains(tagHash))
                         return false;
                     break;

--- a/src/webui/www/private/scripts/misc.js
+++ b/src/webui/www/private/scripts/misc.js
@@ -32,6 +32,8 @@ window.qBittorrent ??= {};
 window.qBittorrent.Misc ??= (() => {
     const exports = () => {
         return {
+            genHash: genHash,
+            getHost: getHost,
             createDebounceHandler: createDebounceHandler,
             friendlyUnit: friendlyUnit,
             friendlyDuration: friendlyDuration,
@@ -49,6 +51,40 @@ window.qBittorrent.Misc ??= (() => {
             FILTER_INPUT_DELAY: 400,
             MAX_ETA: 8640000
         };
+    };
+
+    const genHash = function(string) {
+        // origins:
+        // https://stackoverflow.com/a/8831937
+        // https://gist.github.com/hyamamoto/fd435505d29ebfa3d9716fd2be8d42f0
+        let hash = 0;
+        for (let i = 0; i < string.length; ++i)
+            hash = ((Math.imul(hash, 31) + string.charCodeAt(i)) | 0);
+        return hash;
+    };
+
+    // getHost emulate the GUI version `QString getHost(const QString &url)`
+    const getHost = function(url) {
+        // We want the hostname.
+        // If failed to parse the domain, original input should be returned
+
+        if (!/^(?:https?|udp):/i.test(url))
+            return url;
+
+        try {
+            // hack: URL can not get hostname from udp protocol
+            const parsedUrl = new URL(url.replace(/^udp:/i, "https:"));
+            // host: "example.com:8443"
+            // hostname: "example.com"
+            const host = parsedUrl.hostname;
+            if (!host)
+                return url;
+
+            return host;
+        }
+        catch (error) {
+            return url;
+        }
     };
 
     const createDebounceHandler = (delay, func) => {

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -76,10 +76,18 @@
         </table>
     </fieldset>
 
-    <div class="formRow">
+    <div class="formRow" style="margin-bottom: 5px;">
         <input type="checkbox" id="performanceWarning">
         <label for="performanceWarning">QBT_TR(Log performance warnings)QBT_TR[CONTEXT=OptionsDialog]</label>
     </div>
+
+    <fieldset class="settings">
+        <legend title="QBT_TR(Following settings are WebUI only)QBT_TR[CONTEXT=OptionsDialog]">QBT_TR(Custom WebUI settings)QBT_TR[CONTEXT=OptionsDialog]</legend>
+        <div class="formRow" style="margin-bottom: 3px;">
+            <input type="checkbox" id="displayFullURLTrackerColumn">
+            <label for="displayFullURLTrackerColumn">QBT_TR(Display full announce URL in the Tracker column)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </div>
+    </fieldset>
 </div>
 
 <div id="DownloadsTab" class="PrefTab invisible">
@@ -2082,6 +2090,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             window.parent.qBittorrent.Cache.preferences.init({
                 onSuccess: (pref) => {
                     // Behavior tab
+                    document.getElementById("displayFullURLTrackerColumn").checked = (LocalPreferences.get("full_url_tracker_column", "false") === "true");
                     document.getElementById("hideZeroFiltersCheckbox").checked = (LocalPreferences.get("hide_zero_status_filters", "false") === "true");
                     $("dblclickDownloadSelect").value = LocalPreferences.get("dblclick_download", "1");
                     $("dblclickCompleteSelect").value = LocalPreferences.get("dblclick_complete", "1");
@@ -2494,6 +2503,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             // Validate form data
 
             // Behavior tab
+            LocalPreferences.set("full_url_tracker_column", document.getElementById("displayFullURLTrackerColumn").checked.toString());
             LocalPreferences.set("hide_zero_status_filters", document.getElementById("hideZeroFiltersCheckbox").checked.toString());
             LocalPreferences.set("dblclick_download", $("dblclickDownloadSelect").value);
             LocalPreferences.set("dblclick_complete", $("dblclickCompleteSelect").value);


### PR DESCRIPTION
It is now possible to display only hostname in the Tracker column. 

Closes #11357.