### PR TITLE
Add "remove File" to UI & API

### DIFF
--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -2009,6 +2009,17 @@ void TorrentImpl::renameFile(const int index, const Path &path)
     doRenameFile(index, targetActualPath);
 }
 
+// void TorrentImpl::removeFile(const int index)
+// {
+//     Q_ASSERT((index >= 0) && (index < filesCount()));
+//     if ((index < 0) || (index >= filesCount())) [[unlikely]]
+//         return;
+
+//     const Path filePath = filePath(index);
+//     const Path targetActualPath = makeActualPath(index, filePath);
+//     doRemoveFile(index, targetActualPath);
+// }
+
 void TorrentImpl::handleStateUpdate(const lt::torrent_status &nativeStatus)
 {
     updateStatus(nativeStatus);
@@ -2525,6 +2536,19 @@ void TorrentImpl::doRenameFile(const int index, const Path &path)
     ++m_renameCount;
     m_nativeHandle.rename_file(nativeIndexes[index], path.toString().toStdString());
 }
+
+// void TorrentImpl::doRemoveFile(const int index, const Path &path)
+// {
+//     const QList<lt::file_index_t> nativeIndexes = m_torrentInfo.nativeIndexes();
+
+//     Q_ASSERT(index >= 0);
+//     Q_ASSERT(index < nativeIndexes.size());
+//     if ((index < 0) || (index >= nativeIndexes.size())) [[unlikely]]
+//         return;
+
+//     ++m_renameCount;
+//     m_nativeHandle.rename_file(nativeIndexes[index], path.toString().toStdString());
+// }
 
 lt::torrent_handle TorrentImpl::nativeHandle() const
 {

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -230,6 +230,7 @@ namespace BitTorrent
         void forceDHTAnnounce() override;
         void forceRecheck() override;
         void renameFile(int index, const Path &path) override;
+        // void removeFile(int index) override;
         void prioritizeFiles(const QList<DownloadPriority> &priorities) override;
         void setUploadLimit(int limit) override;
         void setDownloadLimit(int limit) override;
@@ -315,6 +316,7 @@ namespace BitTorrent
         Path makeUserPath(const Path &path) const;
         void adjustStorageLocation();
         void doRenameFile(int index, const Path &path);
+        // void doRemoveFile(int index, const Path &path);
         void moveStorage(const Path &newPath, MoveStorageContext context);
         void manageActualFilePaths();
         void applyFirstLastPiecePriority(bool enabled);

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -1073,6 +1073,41 @@ void TorrentsController::filePrioAction()
         torrent->prioritizeFiles(priorities);
 }
 
+void TorrentsController::removeFileAction()
+{
+    requireParams({u"hash"_s, u"id"_s});
+
+    const auto torrentId = BitTorrent::TorrentID::fromString(params()[u"hash"_s]);
+    bool ok = false;
+
+    BitTorrent::Torrent *const torrent = BitTorrent::Session::instance()->getTorrent(torrentId);
+    if (!torrent)
+        throw APIError(APIErrorType::NotFound);
+    if (!torrent->hasMetadata())
+        throw APIError(APIErrorType::Conflict, tr("Torrent's metadata has not yet downloaded"));
+
+    const int filesCount = torrent->filesCount();
+    for (const QString &fileID : params()[u"id"_s].split(u'|'))
+    {
+        const int fileId = fileID.toInt(&ok);
+        if (!ok)
+            throw APIError(APIErrorType::BadParams, tr("File IDs must be integers"));
+        if ((fileId < 0) || (fileId >= filesCount))
+            throw APIError(APIErrorType::Conflict, tr("File ID is not valid"));
+
+        try 
+        {
+            throw APIError(APIErrorType::Conflict, tr("Debugging: The below command is not working"));
+            // torrent->removeFile(fileId); 
+        }
+        catch (const RuntimeError &error)
+        {
+            throw APIError(APIErrorType::Conflict, error.message());
+        }
+
+    }
+}
+
 void TorrentsController::uploadLimitAction()
 {
     requireParams({u"hashes"_s});

--- a/src/webui/api/torrentscontroller.h
+++ b/src/webui/api/torrentscontroller.h
@@ -72,6 +72,7 @@ private slots:
     void removeTrackersAction();
     void addPeersAction();
     void filePrioAction();
+    void removeFileAction();
     void uploadLimitAction();
     void downloadLimitAction();
     void setUploadLimitAction();

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -54,7 +54,7 @@
 #include "base/utils/version.h"
 #include "api/isessionmanager.h"
 
-inline const Utils::Version<3, 2> API_VERSION {2, 11, 3};
+inline const Utils::Version<3, 2> API_VERSION {2, 11, 4};
 
 class QTimer;
 
@@ -198,6 +198,7 @@ private:
         {{u"torrents"_s, u"removeWebSeeds"_s}, Http::METHOD_POST},
         {{u"torrents"_s, u"rename"_s}, Http::METHOD_POST},
         {{u"torrents"_s, u"renameFile"_s}, Http::METHOD_POST},
+        {{u"torrents"_s, u"removeFile"_s}, Http::METHOD_POST},
         {{u"torrents"_s, u"renameFolder"_s}, Http::METHOD_POST},
         {{u"torrents"_s, u"setAutoManagement"_s}, Http::METHOD_POST},
         {{u"torrents"_s, u"setCategory"_s}, Http::METHOD_POST},

--- a/src/webui/www/private/scripts/prop-files.js
+++ b/src/webui/www/private/scripts/prop-files.js
@@ -567,7 +567,7 @@ window.qBittorrent.PropFiles ??= (() => {
 
         new MochaUI.Window({
             id: "renamePage",
-            icon: "images/qbittorrent-  y.svg",
+            icon: "images/qbittorrent-tray.svg",
             title: "QBT_TR(Renaming)QBT_TR[CONTEXT=TorrentContentTreeView]",
             loadMethod: "iframe",
             contentURL: "rename_file.html?hash=" + hash + "&isFolder=" + node.isFolder

--- a/src/webui/www/private/scripts/prop-files.js
+++ b/src/webui/www/private/scripts/prop-files.js
@@ -300,6 +300,28 @@ window.qBittorrent.PropFiles ??= (() => {
         return true;
     };
 
+    const removeFile = function(ids, fileIds) {
+        if (current_hash === "")
+            return;
+
+        clearTimeout(loadTorrentFilesDataTimer);
+        loadTorrentFilesDataTimer = -1;
+
+        new Request({
+            url: "api/v2/torrents/removeFile",
+            method: "post",
+            data: {
+                "hash": current_hash,
+                "id": fileIds.join("|")
+            },
+            onComplete: function() {
+                loadTorrentFilesDataTimer = loadTorrentFilesData.delay(1000);
+            }
+        }).send();
+        torrentFilesTable.updateTable(false);
+    };
+
+
     const setFilePriority = function(ids, fileIds, priority) {
         if (current_hash === "")
             return;
@@ -545,7 +567,7 @@ window.qBittorrent.PropFiles ??= (() => {
 
         new MochaUI.Window({
             id: "renamePage",
-            icon: "images/qbittorrent-tray.svg",
+            icon: "images/qbittorrent-  y.svg",
             title: "QBT_TR(Renaming)QBT_TR[CONTEXT=TorrentContentTreeView]",
             loadMethod: "iframe",
             contentURL: "rename_file.html?hash=" + hash + "&isFolder=" + node.isFolder


### PR DESCRIPTION
By design, qBit does not remove data when setting files to "Do not download".
If users do not want these files, they need to remove them manually from the operating system.

The idea of this PR is to add an additional menu entry, whereby files can explicitly be removed.
This helps in two regards:
1) It is less painful than user having to go to the operating system and removing the files from there (as requested [here](https://github.com/qbittorrent/qBittorrent/issues/20926), for example)
2) Downstream applications like sonarr may actually think the partial files are full downloads, since eventually the entire torrent will change to "Complete" and sonarr will then try to process the files. By allowing users to remove the files easily, sonarr would not stumple over the remains..

The proposal I'd have is that we add a menu entry, maybe like in the picture below.
This would hit a new API end point /fileRemove.

I have started having a go, and would appreciate 
1) Your thoughts as to whether this even makes sense and fits the strategy of qbit
2) Help in coding it - my skills are quite basic. I have seen that certain methods like "remove File" are already available, but I struggle piecing it together.. Maybe with a few pointers on the starts in this PR, I can bring it further

<img width="559" alt="image" src="https://github.com/user-attachments/assets/417b618d-defd-451e-a33a-937c2b9157b7">
