### PR TITLE
Remove 'loopback address detection' helper function

### DIFF
--- a/src/base/utils/net.cpp
+++ b/src/base/utils/net.cpp
@@ -54,13 +54,6 @@ namespace Utils
             return subnet;
         }
 
-        bool isLoopbackAddress(const QHostAddress &addr)
-        {
-            return (addr == QHostAddress::LocalHost)
-                    || (addr == QHostAddress::LocalHostIPv6)
-                    || (addr == QHostAddress(u"::ffff:127.0.0.1"_s));
-        }
-
         bool isIPInSubnets(const QHostAddress &addr, const QList<Subnet> &subnets)
         {
             QHostAddress protocolEquivalentAddress;

--- a/src/base/utils/net.h
+++ b/src/base/utils/net.h
@@ -45,7 +45,6 @@ namespace Utils::Net
 
     bool isValidIP(const QString &ip);
     std::optional<Subnet> parseSubnet(const QString &subnetStr);
-    bool isLoopbackAddress(const QHostAddress &addr);
     bool isIPInSubnets(const QHostAddress &addr, const QList<Subnet> &subnets);
     QString subnetToString(const Subnet &subnet);
     QHostAddress canonicalIPv6Addr(const QHostAddress &addr);

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -698,7 +698,7 @@ QString WebApplication::generateSid() const
 
 bool WebApplication::isAuthNeeded()
 {
-    if (!m_isLocalAuthEnabled && Utils::Net::isLoopbackAddress(m_clientAddress))
+    if (!m_isLocalAuthEnabled && m_clientAddress.isLoopback())
         return false;
     if (m_isAuthSubnetWhitelistEnabled && Utils::Net::isIPInSubnets(m_clientAddress, m_authSubnetWhitelist))
         return false;


### PR DESCRIPTION
It is not needed since `QHostAddress::isLoopback()` can do the job.
