### PR TITLE
Revise cookie 'secure flag' enable condition

### DIFF
--- a/src/base/http/types.h
+++ b/src/base/http/types.h
@@ -57,6 +57,7 @@ namespace Http
     inline const QString HEADER_X_CONTENT_TYPE_OPTIONS = u"x-content-type-options"_s;
     inline const QString HEADER_X_FORWARDED_FOR = u"x-forwarded-for"_s;
     inline const QString HEADER_X_FORWARDED_HOST = u"x-forwarded-host"_s;
+    inline const QString HEADER_X_FORWARDED_PROTO = u"X-forwarded-proto"_s;
     inline const QString HEADER_X_FRAME_OPTIONS = u"x-frame-options"_s;
     inline const QString HEADER_X_XSS_PROTECTION = u"x-xss-protection"_s;
 

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -1273,7 +1273,6 @@ void OptionsDialog::loadWebUITabOptions()
     // Security
     m_ui->checkClickjacking->setChecked(pref->isWebUIClickjackingProtectionEnabled());
     m_ui->checkCSRFProtection->setChecked(pref->isWebUICSRFProtectionEnabled());
-    m_ui->checkSecureCookie->setEnabled(pref->isWebUIHttpsEnabled());
     m_ui->checkSecureCookie->setChecked(pref->isWebUISecureCookieEnabled());
     m_ui->groupHostHeaderValidation->setChecked(pref->isWebUIHostHeaderValidationEnabled());
     m_ui->textServerDomains->setText(pref->getServerDomains());
@@ -1315,7 +1314,6 @@ void OptionsDialog::loadWebUITabOptions()
 
     connect(m_ui->checkClickjacking, &QCheckBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkCSRFProtection, &QCheckBox::toggled, this, &ThisType::enableApplyButton);
-    connect(m_ui->checkWebUIHttps, &QGroupBox::toggled, m_ui->checkSecureCookie, &QWidget::setEnabled);
     connect(m_ui->checkSecureCookie, &QCheckBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->groupHostHeaderValidation, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->textServerDomains, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -3675,7 +3675,7 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                   <item>
                    <widget class="QCheckBox" name="checkSecureCookie">
                     <property name="text">
-                     <string>Enable cookie Secure flag (requires HTTPS)</string>
+                     <string>Enable cookie Secure flag (requires HTTPS or localhost connection)</string>
                     </property>
                    </widget>
                   </item>

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -128,9 +128,11 @@ private:
     bool isAuthNeeded();
     bool isPublicAPI(const QString &scope, const QString &action) const;
 
+    bool isOriginTrustworthy() const;
     bool isCrossSiteRequest(const Http::Request &request) const;
     bool validateHostHeader(const QStringList &domains) const;
 
+    // reverse proxy
     QHostAddress resolveClientAddress() const;
 
     // Persistent data

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -980,7 +980,7 @@
             </div>
             <div class="formRow">
                 <input type="checkbox" id="secureCookieCheckbox">
-                <label for="secureCookieCheckbox">QBT_TR(Enable cookie Secure flag (requires HTTPS))QBT_TR[CONTEXT=OptionsDialog]</label>
+                <label for="secureCookieCheckbox">QBT_TR(Enable cookie Secure flag (requires HTTPS or localhost connection))QBT_TR[CONTEXT=OptionsDialog]</label>
             </div>
 
             <fieldset class="settings">
@@ -1957,7 +1957,6 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             const isUseHttpsEnabled = $("use_https_checkbox").checked;
             $("ssl_cert_text").disabled = !isUseHttpsEnabled;
             $("ssl_key_text").disabled = !isUseHttpsEnabled;
-            $("secureCookieCheckbox").disabled = !isUseHttpsEnabled;
         };
 
         const updateBypasssAuthSettings = function() {


### PR DESCRIPTION
The localhost is 'potentially trustworthy' and RFC 6265 allows setting secure flag in this case.
Also check `X-Forwarded-Proto` header value to support reverse proxy usage.

Note: for reverse proxy users, now the `X-Forwarded-Proto` header is expected to be sent to qbt
otherwise the `secure` flag might be set erroneously.

https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.2.5
https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy