### PR TITLE
Opt into Windows SegmentHeap

### DIFF
--- a/src/qbittorrent.exe.manifest
+++ b/src/qbittorrent.exe.manifest
@@ -36,10 +36,12 @@
       </application>
   </compatibility>
 
-  <!-- Enable long paths that exceed MAX_PATH in length -->
-  <asmv3:application>
-    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
-      <longPathAware>true</longPathAware>
-    </asmv3:windowsSettings>
-  </asmv3:application>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <!-- Override Windows default heap implementation with more modern "Segment Heap" on supported platforms (requires Windows 10 2004 or newer) -->
+      <heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
+      <!-- Enable long paths that exceed MAX_PATH in length -->
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
 </assembly>


### PR DESCRIPTION
SegmentHeap provides a faster malloc implementation that only available with Dynamic UCRT in Windows 10, version 2004 (build 19041) and later

<!--
MANDATORY Before submitting your work, make sure you have:
1. Read https://github.com/qbittorrent/qBittorrent/blob/master/CONTRIBUTING.md#opening-a-pull-request
2. Delete this comment block
-->
