### PR TITLE
Clean up 'reverse proxy' related code

### DIFF
--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -872,16 +872,14 @@ QHostAddress WebApplication::resolveClientAddress() const
 
         if (!remoteIpList.isEmpty())
         {
-            QHostAddress clientAddress;
-
             for (const QString &remoteIp : remoteIpList)
             {
-                if (clientAddress.setAddress(remoteIp) && clientAddress.isGlobal())
+                const QHostAddress clientAddress {remoteIp};
+                if (clientAddress.isGlobal())
                     return clientAddress;
             }
 
-            if (clientAddress.setAddress(remoteIpList[0]))
-                return clientAddress;
+            return QHostAddress(remoteIpList[0]);
         }
     }
 


### PR DESCRIPTION
`QHostAddress::setAddress()` returns `void` and should not be used as predicate.
