### PR TITLE
Enable customizing the save statistics time interval

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -257,10 +257,10 @@ namespace BitTorrent
         virtual void setPerformanceWarningEnabled(bool enable) = 0;
         virtual int saveResumeDataInterval() const = 0;
         virtual void setSaveResumeDataInterval(int value) = 0;
-        virtual int shutdownTimeout() const = 0;
-        virtual void setShutdownTimeout(int value) = 0;
         virtual int saveStatisticsInterval() const = 0;
         virtual void setSaveStatisticsInterval(int value) = 0;
+        virtual int shutdownTimeout() const = 0;
+        virtual void setShutdownTimeout(int value) = 0;
         virtual int port() const = 0;
         virtual void setPort(int port) = 0;
         virtual bool isSSLEnabled() const = 0;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -259,6 +259,8 @@ namespace BitTorrent
         virtual void setSaveResumeDataInterval(int value) = 0;
         virtual int shutdownTimeout() const = 0;
         virtual void setShutdownTimeout(int value) = 0;
+        virtual int saveStatisticsInterval() const = 0;
+        virtual void setSaveStatisticsInterval(int value) = 0;
         virtual int port() const = 0;
         virtual void setPort(int port) = 0;
         virtual bool isSSLEnabled() const = 0;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -257,8 +257,8 @@ namespace BitTorrent
         virtual void setPerformanceWarningEnabled(bool enable) = 0;
         virtual int saveResumeDataInterval() const = 0;
         virtual void setSaveResumeDataInterval(int value) = 0;
-        virtual int saveStatisticsInterval() const = 0;
-        virtual void setSaveStatisticsInterval(int value) = 0;
+        virtual std::chrono::minutes saveStatisticsInterval() const = 0;
+        virtual void setSaveStatisticsInterval(std::chrono::minutes value) = 0;
         virtual int shutdownTimeout() const = 0;
         virtual void setShutdownTimeout(int value) = 0;
         virtual int port() const = 0;

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -3518,14 +3518,14 @@ void SessionImpl::setSaveResumeDataInterval(const int value)
     }
 }
 
-int SessionImpl::saveStatisticsInterval() const
+std::chrono::minutes SessionImpl::saveStatisticsInterval() const
 {
-    return m_saveStatisticsInterval;
+    return std::chrono::minutes(m_saveStatisticsInterval);
 }
 
-void SessionImpl::setSaveStatisticsInterval(const int timeInMinutes)
+void SessionImpl::setSaveStatisticsInterval(const std::chrono::minutes timeInMinutes)
 {
-    m_saveStatisticsInterval = timeInMinutes;
+    m_saveStatisticsInterval = timeInMinutes.count();
 }
 
 int SessionImpl::shutdownTimeout() const
@@ -5993,7 +5993,7 @@ void SessionImpl::handleSessionStatsAlert(const lt::session_stats_alert *alert)
 
     if (m_saveStatisticsInterval > 0)
     {
-        const auto saveInterval = std::chrono::milliseconds(std::chrono::minutes(m_saveStatisticsInterval));
+        const auto saveInterval = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::minutes(m_saveStatisticsInterval));
         if (m_statisticsLastUpdateTimer.hasExpired(saveInterval.count()))
         {
             saveStatistics();

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -112,7 +112,6 @@ using namespace BitTorrent;
 
 const Path CATEGORIES_FILE_NAME {u"categories.json"_s};
 const int MAX_PROCESSING_RESUMEDATA_COUNT = 50;
-const int DEFAULT_STATISTICS_SAVE_INTERVAL_MIN = 15;
 
 namespace
 {
@@ -482,8 +481,8 @@ SessionImpl::SessionImpl(QObject *parent)
     , m_isBandwidthSchedulerEnabled(BITTORRENT_SESSION_KEY(u"BandwidthSchedulerEnabled"_s), false)
     , m_isPerformanceWarningEnabled(BITTORRENT_SESSION_KEY(u"PerformanceWarning"_s), false)
     , m_saveResumeDataInterval(BITTORRENT_SESSION_KEY(u"SaveResumeDataInterval"_s), 60)
+    , m_saveStatisticsInterval(BITTORRENT_SESSION_KEY(u"SaveStatisticsInterval"_s), 15)
     , m_shutdownTimeout(BITTORRENT_SESSION_KEY(u"ShutdownTimeout"_s), -1)
-    , m_saveStatisticsInterval(BITTORRENT_SESSION_KEY(u"SaveStatisticsInterval"_s), DEFAULT_STATISTICS_SAVE_INTERVAL_MIN)
     , m_port(BITTORRENT_SESSION_KEY(u"Port"_s), -1)
     , m_sslEnabled(BITTORRENT_SESSION_KEY(u"SSL/Enabled"_s), false)
     , m_sslPort(BITTORRENT_SESSION_KEY(u"SSL/Port"_s), -1)
@@ -3519,16 +3518,6 @@ void SessionImpl::setSaveResumeDataInterval(const int value)
     }
 }
 
-int SessionImpl::shutdownTimeout() const
-{
-    return m_shutdownTimeout;
-}
-
-void SessionImpl::setShutdownTimeout(const int value)
-{
-    m_shutdownTimeout = value;
-}
-
 int SessionImpl::saveStatisticsInterval() const
 {
     return m_saveStatisticsInterval;
@@ -3537,6 +3526,16 @@ int SessionImpl::saveStatisticsInterval() const
 void SessionImpl::setSaveStatisticsInterval(const int timeInMinutes)
 {
     m_saveStatisticsInterval = timeInMinutes;
+}
+
+int SessionImpl::shutdownTimeout() const
+{
+    return m_shutdownTimeout;
+}
+
+void SessionImpl::setShutdownTimeout(const int value)
+{
+    m_shutdownTimeout = value;
 }
 
 int SessionImpl::port() const
@@ -5995,7 +5994,7 @@ void SessionImpl::handleSessionStatsAlert(const lt::session_stats_alert *alert)
     if (m_saveStatisticsInterval > 0)
     {
         const auto saveInterval = std::chrono::milliseconds(std::chrono::minutes(m_saveStatisticsInterval));
-        if(m_statisticsLastUpdateTimer.hasExpired(saveInterval.count()))
+        if (m_statisticsLastUpdateTimer.hasExpired(saveInterval.count()))
         {
             saveStatistics();
         }

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -236,6 +236,8 @@ namespace BitTorrent
         void setSaveResumeDataInterval(int value) override;
         int shutdownTimeout() const override;
         void setShutdownTimeout(int value) override;
+        int saveStatisticsInterval() const override;
+        void setSaveStatisticsInterval(int value) override;
         int port() const override;
         void setPort(int port) override;
         bool isSSLEnabled() const override;
@@ -690,6 +692,7 @@ namespace BitTorrent
         CachedSettingValue<bool> m_isPerformanceWarningEnabled;
         CachedSettingValue<int> m_saveResumeDataInterval;
         CachedSettingValue<int> m_shutdownTimeout;
+        CachedSettingValue<int> m_saveStatisticsInterval;
         CachedSettingValue<int> m_port;
         CachedSettingValue<bool> m_sslEnabled;
         CachedSettingValue<int> m_sslPort;

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -234,8 +234,8 @@ namespace BitTorrent
         void setPerformanceWarningEnabled(bool enable) override;
         int saveResumeDataInterval() const override;
         void setSaveResumeDataInterval(int value) override;
-        int saveStatisticsInterval() const override;
-        void setSaveStatisticsInterval(int value) override;
+        std::chrono::minutes saveStatisticsInterval() const override;
+        void setSaveStatisticsInterval(std::chrono::minutes value) override;
         int shutdownTimeout() const override;
         void setShutdownTimeout(int value) override;
         int port() const override;

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -234,10 +234,10 @@ namespace BitTorrent
         void setPerformanceWarningEnabled(bool enable) override;
         int saveResumeDataInterval() const override;
         void setSaveResumeDataInterval(int value) override;
-        int shutdownTimeout() const override;
-        void setShutdownTimeout(int value) override;
         int saveStatisticsInterval() const override;
         void setSaveStatisticsInterval(int value) override;
+        int shutdownTimeout() const override;
+        void setShutdownTimeout(int value) override;
         int port() const override;
         void setPort(int port) override;
         bool isSSLEnabled() const override;
@@ -691,8 +691,8 @@ namespace BitTorrent
         CachedSettingValue<bool> m_isBandwidthSchedulerEnabled;
         CachedSettingValue<bool> m_isPerformanceWarningEnabled;
         CachedSettingValue<int> m_saveResumeDataInterval;
-        CachedSettingValue<int> m_shutdownTimeout;
         CachedSettingValue<int> m_saveStatisticsInterval;
+        CachedSettingValue<int> m_shutdownTimeout;
         CachedSettingValue<int> m_port;
         CachedSettingValue<bool> m_sslEnabled;
         CachedSettingValue<int> m_sslPort;

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -263,7 +263,7 @@ void AdvancedSettings::saveAdvancedSettings() const
     // Save resume data interval
     session->setSaveResumeDataInterval(m_spinBoxSaveResumeDataInterval.value());
     // Save statistics interval
-    session->setSaveStatisticsInterval(m_spinBoxSaveStatisticsInterval.value());
+    session->setSaveStatisticsInterval(std::chrono::minutes(m_spinBoxSaveStatisticsInterval.value()));
     // .torrent file size limit
     pref->setTorrentFileSizeLimit(m_spinBoxTorrentFileSizeLimit.value() * 1024 * 1024);
     // Outgoing ports
@@ -677,7 +677,7 @@ void AdvancedSettings::loadAdvancedSettings()
     // Save statistics interval
     m_spinBoxSaveStatisticsInterval.setMinimum(0);
     m_spinBoxSaveStatisticsInterval.setMaximum(std::numeric_limits<int>::max());
-    m_spinBoxSaveStatisticsInterval.setValue(session->saveStatisticsInterval());
+    m_spinBoxSaveStatisticsInterval.setValue(session->saveStatisticsInterval().count());
     m_spinBoxSaveStatisticsInterval.setSuffix(tr(" min", " minutes"));
     m_spinBoxSaveStatisticsInterval.setSpecialValueText(tr("0 (disabled)"));
     addRow(SAVE_STATISTICS_INTERVAL, tr("Save statistics interval [0: disabled]", "How often the statistics file is saved."), &m_spinBoxSaveStatisticsInterval);

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -76,6 +76,7 @@ namespace
         NETWORK_IFACE_ADDRESS,
         // behavior
         SAVE_RESUME_DATA_INTERVAL,
+        SAVE_STATISTICS_INTERVAL,
         TORRENT_FILE_SIZE_LIMIT,
         CONFIRM_RECHECK_TORRENT,
         RECHECK_COMPLETED,
@@ -106,7 +107,6 @@ namespace
         ENABLE_MARK_OF_THE_WEB,
 #endif // Q_OS_MACOS || Q_OS_WIN
         PYTHON_EXECUTABLE_PATH,
-        SAVE_STATISTICS_INTERVAL,
         START_SESSION_PAUSED,
         SESSION_SHUTDOWN_TIMEOUT,
 
@@ -262,6 +262,8 @@ void AdvancedSettings::saveAdvancedSettings() const
     session->setSocketBacklogSize(m_spinBoxSocketBacklogSize.value());
     // Save resume data interval
     session->setSaveResumeDataInterval(m_spinBoxSaveResumeDataInterval.value());
+    // Save statistics interval
+    session->setSaveStatisticsInterval(m_spinBoxSaveStatisticsInterval.value());
     // .torrent file size limit
     pref->setTorrentFileSizeLimit(m_spinBoxTorrentFileSizeLimit.value() * 1024 * 1024);
     // Outgoing ports
@@ -339,8 +341,6 @@ void AdvancedSettings::saveAdvancedSettings() const
     session->setStartPaused(m_checkBoxStartSessionPaused.isChecked());
     // Session shutdown timeout
     session->setShutdownTimeout(m_spinBoxSessionShutdownTimeout.value());
-    // Save statistics interval
-    session->setSaveStatisticsInterval(m_spinBoxSaveStatisticsInterval.value());
     // Choking algorithm
     session->setChokingAlgorithm(m_comboBoxChokingAlgorithm.currentData().value<BitTorrent::ChokingAlgorithm>());
     // Seed choking algorithm
@@ -674,6 +674,13 @@ void AdvancedSettings::loadAdvancedSettings()
     m_spinBoxSaveResumeDataInterval.setSuffix(tr(" min", " minutes"));
     m_spinBoxSaveResumeDataInterval.setSpecialValueText(tr("0 (disabled)"));
     addRow(SAVE_RESUME_DATA_INTERVAL, tr("Save resume data interval [0: disabled]", "How often the fastresume file is saved."), &m_spinBoxSaveResumeDataInterval);
+    // Save statistics interval
+    m_spinBoxSaveStatisticsInterval.setMinimum(0);
+    m_spinBoxSaveStatisticsInterval.setMaximum(std::numeric_limits<int>::max());
+    m_spinBoxSaveStatisticsInterval.setValue(session->saveStatisticsInterval());
+    m_spinBoxSaveStatisticsInterval.setSuffix(tr(" min", " minutes"));
+    m_spinBoxSaveStatisticsInterval.setSpecialValueText(tr("0 (disabled)"));
+    addRow(SAVE_STATISTICS_INTERVAL, tr("Save statistics interval [0: disabled]", "How often the statistics file is saved."), &m_spinBoxSaveStatisticsInterval);
     // .torrent file size limit
     m_spinBoxTorrentFileSizeLimit.setMinimum(1);
     m_spinBoxTorrentFileSizeLimit.setMaximum(std::numeric_limits<int>::max() / 1024 / 1024);
@@ -860,13 +867,6 @@ void AdvancedSettings::loadAdvancedSettings()
     m_pythonExecutablePath.setPlaceholderText(tr("(Auto detect if empty)"));
     m_pythonExecutablePath.setText(pref->getPythonExecutablePath().toString());
     addRow(PYTHON_EXECUTABLE_PATH, tr("Python executable path (may require restart)"), &m_pythonExecutablePath);
-    // Save statistics interval
-    m_spinBoxSaveStatisticsInterval.setMinimum(0);
-    m_spinBoxSaveStatisticsInterval.setMaximum(std::numeric_limits<int>::max());
-    m_spinBoxSaveStatisticsInterval.setValue(session->saveStatisticsInterval());
-    m_spinBoxSaveStatisticsInterval.setSuffix(tr(" min", " minutes"));
-    m_spinBoxSaveStatisticsInterval.setSpecialValueText(tr("0 (disabled)"));
-    addRow(SAVE_STATISTICS_INTERVAL, tr("Save statistics interval [0: disabled]", "How often the statistics file is saved."), &m_spinBoxSaveStatisticsInterval);
     // Start session paused
     m_checkBoxStartSessionPaused.setChecked(session->isStartPaused());
     addRow(START_SESSION_PAUSED, tr("Start BitTorrent session in paused state"), &m_checkBoxStartSessionPaused);

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -106,6 +106,7 @@ namespace
         ENABLE_MARK_OF_THE_WEB,
 #endif // Q_OS_MACOS || Q_OS_WIN
         PYTHON_EXECUTABLE_PATH,
+        SAVE_STATISTICS_INTERVAL,
         START_SESSION_PAUSED,
         SESSION_SHUTDOWN_TIMEOUT,
 
@@ -338,6 +339,8 @@ void AdvancedSettings::saveAdvancedSettings() const
     session->setStartPaused(m_checkBoxStartSessionPaused.isChecked());
     // Session shutdown timeout
     session->setShutdownTimeout(m_spinBoxSessionShutdownTimeout.value());
+    // Save statistics interval
+    session->setSaveStatisticsInterval(m_spinBoxSaveStatisticsInterval.value());
     // Choking algorithm
     session->setChokingAlgorithm(m_comboBoxChokingAlgorithm.currentData().value<BitTorrent::ChokingAlgorithm>());
     // Seed choking algorithm
@@ -857,6 +860,13 @@ void AdvancedSettings::loadAdvancedSettings()
     m_pythonExecutablePath.setPlaceholderText(tr("(Auto detect if empty)"));
     m_pythonExecutablePath.setText(pref->getPythonExecutablePath().toString());
     addRow(PYTHON_EXECUTABLE_PATH, tr("Python executable path (may require restart)"), &m_pythonExecutablePath);
+    // Save statistics interval
+    m_spinBoxSaveStatisticsInterval.setMinimum(0);
+    m_spinBoxSaveStatisticsInterval.setMaximum(std::numeric_limits<int>::max());
+    m_spinBoxSaveStatisticsInterval.setValue(session->saveStatisticsInterval());
+    m_spinBoxSaveStatisticsInterval.setSuffix(tr(" min", " minutes"));
+    m_spinBoxSaveStatisticsInterval.setSpecialValueText(tr("0 (disabled)"));
+    addRow(SAVE_STATISTICS_INTERVAL, tr("Save statistics interval [0: disabled]", "How often the statistics file is saved."), &m_spinBoxSaveStatisticsInterval);
     // Start session paused
     m_checkBoxStartSessionPaused.setChecked(session->isStartPaused());
     addRow(START_SESSION_PAUSED, tr("Start BitTorrent session in paused state"), &m_checkBoxStartSessionPaused);
@@ -868,7 +878,6 @@ void AdvancedSettings::loadAdvancedSettings()
     m_spinBoxSessionShutdownTimeout.setSpecialValueText(tr("-1 (unlimited)"));
     m_spinBoxSessionShutdownTimeout.setToolTip(u"Sets the timeout for the session to be shut down gracefully, at which point it will be forcibly terminated.<br>Note that this does not apply to the saving resume data time."_s);
     addRow(SESSION_SHUTDOWN_TIMEOUT, tr("BitTorrent session shutdown timeout [-1: unlimited]"), &m_spinBoxSessionShutdownTimeout);
-
     // Choking algorithm
     m_comboBoxChokingAlgorithm.addItem(tr("Fixed slots"), QVariant::fromValue(BitTorrent::ChokingAlgorithm::FixedSlots));
     m_comboBoxChokingAlgorithm.addItem(tr("Upload rate based"), QVariant::fromValue(BitTorrent::ChokingAlgorithm::RateBased));

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -74,7 +74,8 @@ private:
              m_spinBoxListRefresh, m_spinBoxTrackerPort, m_spinBoxSendBufferWatermark, m_spinBoxSendBufferLowWatermark,
              m_spinBoxSendBufferWatermarkFactor, m_spinBoxConnectionSpeed, m_spinBoxSocketSendBufferSize, m_spinBoxSocketReceiveBufferSize, m_spinBoxSocketBacklogSize,
              m_spinBoxMaxConcurrentHTTPAnnounces, m_spinBoxStopTrackerTimeout, m_spinBoxSessionShutdownTimeout,
-             m_spinBoxSavePathHistoryLength, m_spinBoxPeerTurnover, m_spinBoxPeerTurnoverCutoff, m_spinBoxPeerTurnoverInterval, m_spinBoxRequestQueueSize;
+             m_spinBoxSavePathHistoryLength, m_spinBoxPeerTurnover, m_spinBoxPeerTurnoverCutoff, m_spinBoxPeerTurnoverInterval, m_spinBoxRequestQueueSize,
+             m_spinBoxSaveStatisticsInterval;
     QCheckBox m_checkBoxOsCache, m_checkBoxRecheckCompleted, m_checkBoxResolveCountries, m_checkBoxResolveHosts,
               m_checkBoxProgramNotifications, m_checkBoxTorrentAddedNotifications, m_checkBoxReannounceWhenAddressChanged, m_checkBoxTrackerFavicon, m_checkBoxTrackerStatus,
               m_checkBoxTrackerPortForwarding, m_checkBoxConfirmTorrentRecheck, m_checkBoxConfirmRemoveAllTags, m_checkBoxAnnounceAllTrackers, m_checkBoxAnnounceAllTiers,

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -68,14 +68,13 @@ private:
     void loadAdvancedSettings();
     template <typename T> void addRow(int row, const QString &text, T *widget);
 
-    QSpinBox m_spinBoxSaveResumeDataInterval, m_spinBoxTorrentFileSizeLimit, m_spinBoxBdecodeDepthLimit, m_spinBoxBdecodeTokenLimit,
+    QSpinBox m_spinBoxSaveResumeDataInterval, m_spinBoxSaveStatisticsInterval, m_spinBoxTorrentFileSizeLimit, m_spinBoxBdecodeDepthLimit, m_spinBoxBdecodeTokenLimit,
              m_spinBoxAsyncIOThreads, m_spinBoxFilePoolSize, m_spinBoxCheckingMemUsage, m_spinBoxDiskQueueSize,
              m_spinBoxOutgoingPortsMin, m_spinBoxOutgoingPortsMax, m_spinBoxUPnPLeaseDuration, m_spinBoxPeerToS,
              m_spinBoxListRefresh, m_spinBoxTrackerPort, m_spinBoxSendBufferWatermark, m_spinBoxSendBufferLowWatermark,
              m_spinBoxSendBufferWatermarkFactor, m_spinBoxConnectionSpeed, m_spinBoxSocketSendBufferSize, m_spinBoxSocketReceiveBufferSize, m_spinBoxSocketBacklogSize,
              m_spinBoxMaxConcurrentHTTPAnnounces, m_spinBoxStopTrackerTimeout, m_spinBoxSessionShutdownTimeout,
-             m_spinBoxSavePathHistoryLength, m_spinBoxPeerTurnover, m_spinBoxPeerTurnoverCutoff, m_spinBoxPeerTurnoverInterval, m_spinBoxRequestQueueSize,
-             m_spinBoxSaveStatisticsInterval;
+             m_spinBoxSavePathHistoryLength, m_spinBoxPeerTurnover, m_spinBoxPeerTurnoverCutoff, m_spinBoxPeerTurnoverInterval, m_spinBoxRequestQueueSize;
     QCheckBox m_checkBoxOsCache, m_checkBoxRecheckCompleted, m_checkBoxResolveCountries, m_checkBoxResolveHosts,
               m_checkBoxProgramNotifications, m_checkBoxTorrentAddedNotifications, m_checkBoxReannounceWhenAddressChanged, m_checkBoxTrackerFavicon, m_checkBoxTrackerStatus,
               m_checkBoxTrackerPortForwarding, m_checkBoxConfirmTorrentRecheck, m_checkBoxConfirmRemoveAllTags, m_checkBoxAnnounceAllTrackers, m_checkBoxAnnounceAllTiers,

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -362,6 +362,8 @@ void AppController::preferencesAction()
     data[u"current_interface_address"_s] = session->networkInterfaceAddress();
     // Save resume data interval
     data[u"save_resume_data_interval"_s] = session->saveResumeDataInterval();
+    // Save statistics interval
+    data[u"save_statistics_interval"_s] = session->saveStatisticsInterval();
     // .torrent file size limit
     data[u"torrent_file_size_limit"_s] = pref->getTorrentFileSizeLimit();
     // Recheck completed torrents
@@ -374,8 +376,6 @@ void AppController::preferencesAction()
     data[u"resolve_peer_countries"_s] = pref->resolvePeerCountries();
     // Reannounce to all trackers when ip/port changed
     data[u"reannounce_when_address_changed"_s] = session->isReannounceWhenAddressChangedEnabled();
-    // Save statistics interval
-    data[u"save_statistics_interval"_s] = session->saveStatisticsInterval();
 
     // libtorrent preferences
     // Bdecode depth limit
@@ -966,6 +966,9 @@ void AppController::setPreferencesAction()
     // Save resume data interval
     if (hasKey(u"save_resume_data_interval"_s))
         session->setSaveResumeDataInterval(it.value().toInt());
+    // Save statistics interval
+    if (hasKey(u"save_statistics_interval"_s))
+        session->setSaveStatisticsInterval(it.value().toInt());
     // .torrent file size limit
     if (hasKey(u"torrent_file_size_limit"_s))
         pref->setTorrentFileSizeLimit(it.value().toLongLong());
@@ -984,9 +987,6 @@ void AppController::setPreferencesAction()
     // Reannounce to all trackers when ip/port changed
     if (hasKey(u"reannounce_when_address_changed"_s))
         session->setReannounceWhenAddressChangedEnabled(it.value().toBool());
-    // Save statistics interval
-    if (hasKey(u"save_statistics_interval"_s))
-        session->setSaveStatisticsInterval(it.value().toInt());
 
     // libtorrent preferences
     // Bdecode depth limit

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -374,6 +374,8 @@ void AppController::preferencesAction()
     data[u"resolve_peer_countries"_s] = pref->resolvePeerCountries();
     // Reannounce to all trackers when ip/port changed
     data[u"reannounce_when_address_changed"_s] = session->isReannounceWhenAddressChangedEnabled();
+    // Save statistics interval
+    data[u"save_statistics_interval"_s] = session->saveStatisticsInterval();
 
     // libtorrent preferences
     // Bdecode depth limit
@@ -982,6 +984,9 @@ void AppController::setPreferencesAction()
     // Reannounce to all trackers when ip/port changed
     if (hasKey(u"reannounce_when_address_changed"_s))
         session->setReannounceWhenAddressChangedEnabled(it.value().toBool());
+    // Save statistics interval
+    if (hasKey(u"save_statistics_interval"_s))
+        session->setSaveStatisticsInterval(it.value().toInt());
 
     // libtorrent preferences
     // Bdecode depth limit

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -363,7 +363,7 @@ void AppController::preferencesAction()
     // Save resume data interval
     data[u"save_resume_data_interval"_s] = session->saveResumeDataInterval();
     // Save statistics interval
-    data[u"save_statistics_interval"_s] = session->saveStatisticsInterval();
+    data[u"save_statistics_interval"_s] = static_cast<int>(session->saveStatisticsInterval().count());
     // .torrent file size limit
     data[u"torrent_file_size_limit"_s] = pref->getTorrentFileSizeLimit();
     // Recheck completed torrents
@@ -968,7 +968,7 @@ void AppController::setPreferencesAction()
         session->setSaveResumeDataInterval(it.value().toInt());
     // Save statistics interval
     if (hasKey(u"save_statistics_interval"_s))
-        session->setSaveStatisticsInterval(it.value().toInt());
+        session->setSaveStatisticsInterval(std::chrono::minutes(it.value().toInt()));
     // .torrent file size limit
     if (hasKey(u"torrent_file_size_limit"_s))
         pref->setTorrentFileSizeLimit(it.value().toLongLong());

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1226,6 +1226,14 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                         <input type="text" id="pythonExecutablePath" class="pathFile" placeholder="QBT_TR((Auto detect if empty))QBT_TR[CONTEXT=OptionsDialog]" style="width: 15em;">
                     </td>
                 </tr>
+                <tr>
+                    <td>
+                        <label for="saveStatisticsInterval">QBT_TR(Save statistics interval:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    </td>
+                    <td>
+                        <input type="text" id="saveStatisticsInterval" style="width: 15em;">&nbsp;&nbsp;QBT_TR(min)QBT_TR[CONTEXT=OptionsDialog]
+                    </td>
+                </tr>
             </tbody>
         </table>
     </fieldset>
@@ -2445,6 +2453,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     $("refreshInterval").value = pref.refresh_interval;
                     $("resolvePeerCountries").checked = pref.resolve_peer_countries;
                     $("reannounceWhenAddressChanged").checked = pref.reannounce_when_address_changed;
+                    $("saveStatisticsInterval").value = pref.save_statistics_interval;
                     // libtorrent section
                     $("bdecodeDepthLimit").value = pref.bdecode_depth_limit;
                     $("bdecodeTokenLimit").value = pref.bdecode_token_limit;
@@ -2898,6 +2907,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             settings["refresh_interval"] = Number($("refreshInterval").value);
             settings["resolve_peer_countries"] = $("resolvePeerCountries").checked;
             settings["reannounce_when_address_changed"] = $("reannounceWhenAddressChanged").checked;
+            settings["save_statistics_interval"] = Number($("saveStatisticsInterval").value);
 
             // libtorrent section
             settings["bdecode_depth_limit"] = Number($("bdecodeDepthLimit").value);

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1140,6 +1140,14 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 </tr>
                 <tr>
                     <td>
+                        <label for="saveStatisticsInterval">QBT_TR(Save statistics interval:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                    </td>
+                    <td>
+                        <input type="text" id="saveStatisticsInterval" style="width: 15em;">&nbsp;&nbsp;QBT_TR(min)QBT_TR[CONTEXT=OptionsDialog]
+                    </td>
+                </tr>
+                <tr>
+                    <td>
                         <label for="torrentFileSizeLimit">QBT_TR(.torrent file size limit:)QBT_TR[CONTEXT=OptionsDialog]</label>
                     </td>
                     <td>
@@ -1224,14 +1232,6 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     </td>
                     <td>
                         <input type="text" id="pythonExecutablePath" class="pathFile" placeholder="QBT_TR((Auto detect if empty))QBT_TR[CONTEXT=OptionsDialog]" style="width: 15em;">
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <label for="saveStatisticsInterval">QBT_TR(Save statistics interval:)QBT_TR[CONTEXT=OptionsDialog]</label>
-                    </td>
-                    <td>
-                        <input type="text" id="saveStatisticsInterval" style="width: 15em;">&nbsp;&nbsp;QBT_TR(min)QBT_TR[CONTEXT=OptionsDialog]
                     </td>
                 </tr>
             </tbody>
@@ -2447,13 +2447,13 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     updateNetworkInterfaces(pref.current_network_interface, pref.current_interface_name);
                     updateInterfaceAddresses(pref.current_network_interface, pref.current_interface_address);
                     $("saveResumeDataInterval").value = pref.save_resume_data_interval;
+                    $("saveStatisticsInterval").value = pref.save_statistics_interval;
                     $("torrentFileSizeLimit").value = (pref.torrent_file_size_limit / 1024 / 1024);
                     $("recheckTorrentsOnCompletion").checked = pref.recheck_completed_torrents;
                     $("appInstanceName").value = pref.app_instance_name;
                     $("refreshInterval").value = pref.refresh_interval;
                     $("resolvePeerCountries").checked = pref.resolve_peer_countries;
                     $("reannounceWhenAddressChanged").checked = pref.reannounce_when_address_changed;
-                    $("saveStatisticsInterval").value = pref.save_statistics_interval;
                     // libtorrent section
                     $("bdecodeDepthLimit").value = pref.bdecode_depth_limit;
                     $("bdecodeTokenLimit").value = pref.bdecode_token_limit;
@@ -2901,13 +2901,13 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             settings["current_network_interface"] = $("networkInterface").value;
             settings["current_interface_address"] = $("optionalIPAddressToBind").value;
             settings["save_resume_data_interval"] = Number($("saveResumeDataInterval").value);
+            settings["save_statistics_interval"] = Number($("saveStatisticsInterval").value);
             settings["torrent_file_size_limit"] = ($("torrentFileSizeLimit").value * 1024 * 1024);
             settings["recheck_completed_torrents"] = $("recheckTorrentsOnCompletion").checked;
             settings["app_instance_name"] = $("appInstanceName").value;
             settings["refresh_interval"] = Number($("refreshInterval").value);
             settings["resolve_peer_countries"] = $("resolvePeerCountries").checked;
             settings["reannounce_when_address_changed"] = $("reannounceWhenAddressChanged").checked;
-            settings["save_statistics_interval"] = Number($("saveStatisticsInterval").value);
 
             // libtorrent section
             settings["bdecode_depth_limit"] = Number($("bdecodeDepthLimit").value);


### PR DESCRIPTION
This change extends the Advanced section of the Preferences menu with a new field, allowing changing the time statistics save interval. A null value will prevent recurrent saving.

This aims to provide the feature requested in issue #21285 

Tested updating the value from the web UI and reading it from the local client and the other way around. Did **not test** the actual file update time, as I did not touch the mechanism below the `saveStatistics` function.

I did not extend the lang/translation files as I wasn't sure I was supposed to. This is my first contribution to qBittorent, so I'm not familiar with the WoW

![image](https://github.com/user-attachments/assets/547fd995-ba65-4432-9c35-844c966162fa)

![image](https://github.com/user-attachments/assets/ebb51aa5-225d-4070-a5d0-c7188e32f762)

closes #21285