### PR TITLE
Disable the ability to create torrents with a piece size of 256MiB

### DIFF
--- a/src/gui/torrentcreatordialog.cpp
+++ b/src/gui/torrentcreatordialog.cpp
@@ -84,11 +84,7 @@ TorrentCreatorDialog::TorrentCreatorDialog(QWidget *parent, const Path &defaultP
     m_ui->setupUi(this);
 
     m_ui->comboPieceSize->addItem(tr("Auto"), 0);
-#ifdef QBT_USES_LIBTORRENT2
-    for (int i = 4; i <= 18; ++i)
-#else
     for (int i = 4; i <= 17; ++i)
-#endif
     {
         const int size = 1024 << i;
         const QString displaySize = Utils::Misc::friendlyUnit(size, false, 0);


### PR DESCRIPTION
Disabling will reduce the number of users experiencing this issue.

- https://github.com/qbittorrent/qBittorrent/issues/21011