### PR TITLE
Remove non-working DHT bootstrap nodes

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -118,7 +118,7 @@ namespace
 {
     const char PEER_ID[] = "qB";
     const auto USER_AGENT = QStringLiteral("qBittorrent/" QBT_VERSION_2);
-    const QString DEFAULT_DHT_BOOTSTRAP_NODES = u"dht.libtorrent.org:25401, dht.transmissionbt.com:6881, router.bittorrent.com:6881, router.utorrent.com:6881, dht.aelitis.com:6881"_s;
+    const QString DEFAULT_DHT_BOOTSTRAP_NODES = u"dht.libtorrent.org:25401, dht.transmissionbt.com:6881, router.silotis.us:6881"_s;
 
     void torrentQueuePositionUp(const lt::torrent_handle &handle)
     {


### PR DESCRIPTION
router.utorrent.com has been dead for a long time. router.bittorrent.com died about a month or two ago. dht.aelitis.com doesn't work either. It is no longer possible to get DHT nodes from them.
Added router.silotis.us. Only ipv6!