### PR TITLE
Apply "merge trackers" logic regardless of way the torrent is added

### DIFF
--- a/src/base/net/smtp.h
+++ b/src/base/net/smtp.h
@@ -43,7 +43,6 @@ class QSslSocket;
 #else
 class QTcpSocket;
 #endif
-class QTextCodec;
 
 namespace Net
 {


### PR DESCRIPTION
Fixes the problem described in https://github.com/qbittorrent/qBittorrent/issues/20342#issuecomment-2313118433.