### PR TITLE
Add "Simple pread/pwrite" disk IO type

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -92,7 +92,8 @@ namespace BitTorrent
         {
             Default = 0,
             MMap = 1,
-            Posix = 2
+            Posix = 2,
+            SimplePreadPwrite = 3
         };
         Q_ENUM_NS(DiskIOType)
 

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -585,6 +585,7 @@ void AdvancedSettings::loadAdvancedSettings()
     m_comboBoxDiskIOType.addItem(tr("Default"), QVariant::fromValue(BitTorrent::DiskIOType::Default));
     m_comboBoxDiskIOType.addItem(tr("Memory mapped files"), QVariant::fromValue(BitTorrent::DiskIOType::MMap));
     m_comboBoxDiskIOType.addItem(tr("POSIX-compliant"), QVariant::fromValue(BitTorrent::DiskIOType::Posix));
+    m_comboBoxDiskIOType.addItem(tr("Simple pread/pwrite"), QVariant::fromValue(BitTorrent::DiskIOType::SimplePreadPwrite));
     m_comboBoxDiskIOType.setCurrentIndex(m_comboBoxDiskIOType.findData(QVariant::fromValue(session->diskIOType())));
     addRow(DISK_IO_TYPE, tr("Disk IO type (requires restart)") + u' ' + makeLink(u"https://www.libtorrent.org/single-page-ref.html#default-disk-io-constructor", u"(?)")
            , &m_comboBoxDiskIOType);

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1314,6 +1314,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                             <option value="0">QBT_TR(Default)QBT_TR[CONTEXT=OptionsDialog]</option>
                             <option value="1">QBT_TR(Memory mapped files)QBT_TR[CONTEXT=OptionsDialog]</option>
                             <option value="2">QBT_TR(POSIX-compliant)QBT_TR[CONTEXT=OptionsDialog]</option>
+                            <option value="3">QBT_TR(Simple pread/pwrite)QBT_TR[CONTEXT=OptionsDialog]</option>
                         </select>
                     </td>
                 </tr>


### PR DESCRIPTION
I think everyone is aware of infamous LT20 memory-mapped files problems at this point. In case someone not up to the topic: arvidn/libtorrent#6667.
Despite it being on its way to a pread-disk-io implementation (arvidn/libtorrent#7013), I am sick of waiting and fighting with mmap problems.

Here is a simple way to fix it completely by cutting the problem roots:
LT20 currently falls back to pread io for small files (<640K). But that's actually a tunable [`mmap_file_size_cutoff`](https://www.libtorrent.org/reference-Settings.html#mmap_file_size_cutoff), never used by qBittorrent. So the fix is very straightforward, we simply increase that value.

This patch implements a new disk IO type, which forces all files to use the pread/pwrite fallback.
Well, technically files <32 TiB in size, as this is the max int value we can put there. But that should be enough for everyone. ©

It mitigates all mmap related problems, such as:

1. Memory hog and OOM crashes. Such as
#17650
#19914
#20893
#20925
and the rest countless duplicates.

3. Generally subpar performance in comparison with LT12. Especially on network drives. Such as
#16043
#19902
#19407
and many more.

I run with this change for a month and have not seen any negative effects. Only pure relief.
It is still a bit subpar to LT12, as it doesn't have the client cache. But OS cache still works and I don't see any decremental in that regard in comparison with mmap.
