### PR TITLE
Add URL link for reverse proxy setup examples

### DIFF
--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -3765,6 +3765,13 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
                     </item>
                    </layout>
                   </item>
+                  <item>
+                   <widget class="QLabel" name="labelReverseProxyLink">
+                    <property name="text">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/qbittorrent/qBittorrent/wiki#reverse-proxy-setup-for-webui-access&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Reverse proxy setup examples&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                   </widget>
+                  </item>
                  </layout>
                 </widget>
                </item>

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1032,6 +1032,9 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 <label for="webUIReverseProxiesListTextarea">QBT_TR(Trusted proxies list:)QBT_TR[CONTEXT=OptionsDialog]</label>
                 <input type="text" id="webUIReverseProxiesListTextarea" title="QBT_TR(Specify reverse proxy IPs (or subnets, e.g. 0.0.0.0/24) in order to use forwarded client address (X-Forwarded-For header). Use ';' to split multiple entries.)QBT_TR[CONTEXT=OptionsDialog]">
             </div>
+            <div class="formRow">
+                <a href="https://github.com/qbittorrent/qBittorrent/wiki#reverse-proxy-setup-for-webui-access" target="_blank">QBT_TR(Reverse proxy setup examples)QBT_TR[CONTEXT=HttpServer]</a>
+            </div>
         </fieldset>
 
     </fieldset>


### PR DESCRIPTION
The link is helpful for users whom needs to setup reverse proxy.
![screenshot](https://github.com/user-attachments/assets/5f106933-6c47-45bd-9bb8-baf3e218103e)
