### PR TITLE
WebUI: Use Map instead of Mootools Hash in Torrents table

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -483,14 +483,10 @@ window.addEventListener("DOMContentLoaded", () => {
             }
         };
 
-        const all = torrentsTable.getRowIds().length;
+        const all = torrentsTable.rows.size;
         let uncategorized = 0;
-        for (const key in torrentsTable.rows) {
-            if (!Object.hasOwn(torrentsTable.rows, key))
-                continue;
-
-            const row = torrentsTable.rows[key];
-            if (row["full_data"].category.length === 0)
+        for (const { full_data: { category } } of torrentsTable.rows.values()) {
+            if (category.length === 0)
                 uncategorized += 1;
         }
 
@@ -585,12 +581,13 @@ window.addEventListener("DOMContentLoaded", () => {
             return tagFilterItem;
         };
 
-        const torrentsCount = torrentsTable.getRowIds().length;
+        const torrentsCount = torrentsTable.rows.size;
         let untagged = 0;
-        for (const key in torrentsTable.rows) {
-            if (Object.hasOwn(torrentsTable.rows, key) && (torrentsTable.rows[key]["full_data"].tags.length === 0))
+        for (const { full_data: { tags } } of torrentsTable.rows.values()) {
+            if (tags.length === 0)
                 untagged += 1;
         }
+
         tagFilterList.appendChild(createLink(TAGS_ALL, "QBT_TR(All)QBT_TR[CONTEXT=TagFilterModel]", torrentsCount));
         tagFilterList.appendChild(createLink(TAGS_UNTAGGED, "QBT_TR(Untagged)QBT_TR[CONTEXT=TagFilterModel]", untagged));
 
@@ -637,13 +634,14 @@ window.addEventListener("DOMContentLoaded", () => {
             return trackerFilterItem;
         };
 
-        const torrentsCount = torrentsTable.getRowIds().length;
-        trackerFilterList.appendChild(createLink(TRACKERS_ALL, "QBT_TR(All (%1))QBT_TR[CONTEXT=TrackerFiltersList]", torrentsCount));
+        const torrentsCount = torrentsTable.rows.size;
         let trackerlessTorrentsCount = 0;
-        for (const key in torrentsTable.rows) {
-            if (Object.hasOwn(torrentsTable.rows, key) && (torrentsTable.rows[key]["full_data"].trackers_count === 0))
+        for (const { full_data: { trackers_count: trackersCount } } of torrentsTable.rows.values()) {
+            if (trackersCount === 0)
                 trackerlessTorrentsCount += 1;
         }
+
+        trackerFilterList.appendChild(createLink(TRACKERS_ALL, "QBT_TR(All (%1))QBT_TR[CONTEXT=TrackerFiltersList]", torrentsCount));
         trackerFilterList.appendChild(createLink(TRACKERS_TRACKERLESS, "QBT_TR(Trackerless (%1))QBT_TR[CONTEXT=TrackerFiltersList]", trackerlessTorrentsCount));
 
         // Sort trackers by hostname

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -295,7 +295,7 @@ const initializeWindows = function() {
             // check if all selected torrents have same share ratio
             for (let i = 0; i < hashes.length; ++i) {
                 const hash = hashes[i];
-                const row = torrentsTable.rows[hash].full_data;
+                const row = torrentsTable.rows.get(hash).full_data;
                 const origValues = row.ratio_limit + "|" + row.seeding_time_limit + "|" + row.inactive_seeding_time_limit + "|"
                     + row.max_ratio + "|" + row.max_seeding_time + "|" + row.max_inactive_seeding_time;
 
@@ -522,7 +522,7 @@ const initializeWindows = function() {
         if (hashes.length) {
             let enable = false;
             hashes.each((hash, index) => {
-                const row = torrentsTable.rows[hash];
+                const row = torrentsTable.rows.get(hash);
                 if (!row.full_data.auto_tmm)
                     enable = true;
             });
@@ -570,7 +570,7 @@ const initializeWindows = function() {
         const hashes = torrentsTable.selectedRowsIds();
         if (hashes.length) {
             const hash = hashes[0];
-            const row = torrentsTable.rows[hash];
+            const row = torrentsTable.rows.get(hash);
 
             new MochaUI.Window({
                 id: "setLocationPage",
@@ -593,7 +593,7 @@ const initializeWindows = function() {
         const hashes = torrentsTable.selectedRowsIds();
         if (hashes.length === 1) {
             const hash = hashes[0];
-            const row = torrentsTable.rows[hash];
+            const row = torrentsTable.rows.get(hash);
             if (row) {
                 new MochaUI.Window({
                     id: "renamePage",
@@ -617,7 +617,7 @@ const initializeWindows = function() {
         const hashes = torrentsTable.selectedRowsIds();
         if (hashes.length === 1) {
             const hash = hashes[0];
-            const row = torrentsTable.rows[hash];
+            const row = torrentsTable.rows.get(hash);
             if (row) {
                 new MochaUI.Window({
                     id: "multiRenamePage",


### PR DESCRIPTION
Mootools is not maintained and [Hash itself was deprecated](https://mootools.net/core/docs/1.5.2/Types/Object#Deprecated-Functions
) over 10 years ago so I wanted to experiment a bit and switched torrents table to use vanilla Map instead. What do you think? Could be done one table at a time.. Or maybe it should be done differently (approach)?

Pretty much all tables could be pretty easily switched to Map with just some minor changes. Only RSS Feed & Article tables would require more work IIRC.