### PR TITLE
Allow drop action only on transfer list

### DIFF
--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -47,6 +47,7 @@
 #include <QStringView>
 #include <QSysInfo>
 
+#include "base/net/downloadmanager.h"
 #include "base/path.h"
 #include "base/unicodestrings.h"
 #include "base/utils/string.h"
@@ -210,6 +211,14 @@ bool Utils::Misc::isPreviewable(const Path &filePath)
         u".WMV"_s
     };
     return multimediaExtensions.contains(filePath.extension().toUpper());
+}
+
+bool Utils::Misc::isTorrentLink(const QString &str)
+{
+    return str.startsWith(u"magnet:", Qt::CaseInsensitive)
+        || str.endsWith(TORRENT_FILE_EXTENSION, Qt::CaseInsensitive)
+        || (!str.startsWith(u"file:", Qt::CaseInsensitive)
+            && Net::DownloadManager::hasSupportedScheme(str));
 }
 
 QString Utils::Misc::userFriendlyDuration(const qlonglong seconds, const qlonglong maxCap, const TimeResolution resolution)

--- a/src/base/utils/misc.h
+++ b/src/base/utils/misc.h
@@ -78,6 +78,7 @@ namespace Utils::Misc
     qint64 sizeInBytes(qreal size, SizeUnit unit);
 
     bool isPreviewable(const Path &filePath);
+    bool isTorrentLink(const QString &str);
 
     // Take a number of seconds and return a user-friendly
     // time duration like "1d 2h 10m".

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -191,8 +191,6 @@ private:
     void installPython();
 #endif
 
-    void dropEvent(QDropEvent *event) override;
-    void dragEnterEvent(QDragEnterEvent *event) override;
     void closeEvent(QCloseEvent *) override;
     void showEvent(QShowEvent *) override;
     void keyPressEvent(QKeyEvent *event) override;

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -35,9 +35,9 @@
 #include <QTreeView>
 
 #include "base/bittorrent/infohash.h"
+#include "guiapplicationcomponent.h"
 #include "transferlistmodel.h"
 
-class MainWindow;
 class Path;
 class TransferListSortModel;
 
@@ -52,13 +52,13 @@ enum class CopyInfohashPolicy
     Version2
 };
 
-class TransferListWidget final : public QTreeView
+class TransferListWidget final : public GUIApplicationComponent<QTreeView>
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(TransferListWidget)
 
 public:
-    TransferListWidget(QWidget *parent, MainWindow *mainWindow);
+    TransferListWidget(IGUIApplication *app, QWidget *parent);
     ~TransferListWidget() override;
     TransferListModel *getSourceModel() const;
 
@@ -119,6 +119,9 @@ private slots:
     void saveSettings();
 
 private:
+    void dragEnterEvent(QDragEnterEvent *event) override;
+    void dragMoveEvent(QDragMoveEvent *event) override;
+    void dropEvent(QDropEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
     QModelIndex mapToSource(const QModelIndex &index) const;
     QModelIndexList mapToSource(const QModelIndexList &indexes) const;
@@ -136,5 +139,4 @@ private:
 
     TransferListModel *m_listModel = nullptr;
     TransferListSortModel *m_sortFilterModel = nullptr;
-    MainWindow *m_mainWindow = nullptr;
 };


### PR DESCRIPTION
Now drop action is only allowed on transfer list, previously it was on main window.
Having drop action on the whole main window is not preferred because it could allow drop action on other unrelated widgets, such as execution log or RSS widget which is unexpected behavior.
