### PR TITLE
Search: Lax separator matching when filtering results

### DIFF
--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -395,8 +395,12 @@ void SearchJobWidget::fillFilterComboBoxes()
 
 void SearchJobWidget::filterSearchResults(const QString &name)
 {
-    const QString pattern = (Preferences::instance()->getRegexAsFilteringPatternForSearchJob()
-                    ? name : Utils::String::wildcardToRegexPattern(name));
+    QString pattern = name;
+    if (!Preferences::instance()->getRegexAsFilteringPatternForSearchJob())
+    {
+        pattern.replace(QRegularExpression(u"[-.\\s_]+"_s), u"[-. _]"_s);
+        pattern = Utils::String::wildcardToRegexPattern(pattern);
+    }
     m_proxyModel->setFilterRegularExpression(QRegularExpression(pattern, QRegularExpression::CaseInsensitiveOption));
     updateResultsCount();
 }


### PR DESCRIPTION
This PR updates search result filtering behavior to be more intuitive.

Any separator (` ` `_` `-` `.`) will now match any other separator when filtering search results.

Example: Type "live server" in filter. Currently it would only match "live server". Similarly, if you type "live.server" it will only match "live.server" and not "live server" even though the user likely wants to see both.

With this update any separator now matches any other separator; a space now matches `.` `-` `_`, an underscore also matches a space or a dash, etc.

This means that a filter of "live server" will now show "live.server" in the results and vice-versa.

Note that this does not affect regex search, only regular wildcard search.

This is a lot more intuitive in my opinion!

![image](https://github.com/user-attachments/assets/69b55708-9176-44e4-b868-4157ef418594)
