### PR TITLE
Reduce sensitive data instances

### DIFF
--- a/src/webui/webui.h
+++ b/src/webui/webui.h
@@ -77,5 +77,5 @@ private:
     QPointer<Net::DNSUpdater> m_dnsUpdater;
     QPointer<WebApplication> m_webapp;
 
-    QByteArray m_passwordHash;
+    QByteArray m_tempPasswordHash;
 };


### PR DESCRIPTION
There is no reason for `WebUI` class to retain this information.
