### PR TITLE
Remove deferral of loading external JS scripts

### DIFF
--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -23,23 +23,23 @@
         <link rel="stylesheet" type="text/css" href="css/noscript.css?v=${CACHEID}">
     </noscript>
 
-    <script defer src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script defer src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script defer src="scripts/lib/mocha.min.js"></script>
-    <script defer src="scripts/cache.js?v=${CACHEID}"></script>
-    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script defer src="scripts/mocha-init.js?locale=${LANG}&v=${CACHEID}"></script>
-    <script defer src="scripts/lib/clipboard.min.js"></script>
-    <script defer src="scripts/filesystem.js?v=${CACHEID}"></script>
-    <script defer src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
-    <script defer src="scripts/progressbar.js?v=${CACHEID}"></script>
-    <script defer src="scripts/piecesbar.js?v=${CACHEID}"></script>
-    <script defer src="scripts/file-tree.js?v=${CACHEID}"></script>
-    <script defer src="scripts/dynamicTable.js?locale=${LANG}&v=${CACHEID}"></script>
-    <script defer src="scripts/rename-files.js?v=${CACHEID}"></script>
-    <script defer src="scripts/client.js?locale=${LANG}&v=${CACHEID}"></script>
-    <script defer src="scripts/contextmenu.js?locale=${LANG}&v=${CACHEID}"></script>
-    <script defer src="scripts/pathAutofill.js?v=${CACHEID}"></script>
+    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="scripts/lib/mocha.min.js"></script>
+    <script src="scripts/cache.js?v=${CACHEID}"></script>
+    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="scripts/mocha-init.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script src="scripts/lib/clipboard.min.js"></script>
+    <script src="scripts/filesystem.js?v=${CACHEID}"></script>
+    <script src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script src="scripts/progressbar.js?v=${CACHEID}"></script>
+    <script src="scripts/piecesbar.js?v=${CACHEID}"></script>
+    <script src="scripts/file-tree.js?v=${CACHEID}"></script>
+    <script src="scripts/dynamicTable.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script src="scripts/rename-files.js?v=${CACHEID}"></script>
+    <script src="scripts/client.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script src="scripts/contextmenu.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script src="scripts/pathAutofill.js?v=${CACHEID}"></script>
 </head>
 
 <body>


### PR DESCRIPTION
This reverses commit 9976f283d85e53e183c581f41425c33a8d133c14. As can be seen in the video below, deferring these scripts results in a broken page when the asset cache is bypassed. I've briefly investigated and have not been able to determine why this is the case, given that our scripts seem to appropriately use the `DOMContentLoaded` event. After removing the `defer` attribute, the WebUI correctly loads in all situations.

https://github.com/user-attachments/assets/010ae2ba-453a-40c3-9f3a-09cae45b83c8

