### PR TITLE
Reduce reliance on the mime database

### DIFF
--- a/src/base/path.cpp
+++ b/src/base/path.cpp
@@ -183,14 +183,16 @@ QString Path::filename() const
 
 QString Path::extension() const
 {
-    const QString suffix = QMimeDatabase().suffixForFileName(m_pathStr);
-    if (!suffix.isEmpty())
-        return (u"." + suffix);
-
     const int slashIndex = m_pathStr.lastIndexOf(u'/');
     const auto filename = QStringView(m_pathStr).mid(slashIndex + 1);
     const int dotIndex = filename.lastIndexOf(u'.', -2);
     return ((dotIndex == -1) ? QString() : filename.mid(dotIndex).toString());
+}
+
+QString Path::mimeExtension() const
+{
+    const QString suffix = QMimeDatabase().suffixForFileName(m_pathStr);
+    return (suffix.isEmpty() ? extension() : (u"." + suffix));
 }
 
 bool Path::hasExtension(const QStringView ext) const

--- a/src/base/path.h
+++ b/src/base/path.h
@@ -59,6 +59,7 @@ public:
     QString filename() const;
 
     QString extension() const;
+    QString mimeExtension() const;
     bool hasExtension(QStringView ext) const;
     void removeExtension();
     Path removedExtension() const;

--- a/src/gui/autoexpandabledialog.cpp
+++ b/src/gui/autoexpandabledialog.cpp
@@ -61,7 +61,7 @@ QString AutoExpandableDialog::getText(QWidget *parent, const QString &title, con
     d.m_ui->textEdit->selectAll();
     if (excludeExtension)
     {
-        const QString extension = Path(text).extension();
+        const QString extension = Path(text).mimeExtension();
         if (!extension.isEmpty())
             d.m_ui->textEdit->setSelection(0, (text.length() - extension.length()));
     }

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -225,6 +225,17 @@ private:
     bool m_isAltUIUsed = false;
     Path m_rootFolder;
 
+    const QHash<QString, QString> m_mimeTypes =
+    {
+        // <extension, mime type>
+        {u".html"_s, u"text/html"_s},
+        {u".css"_s, u"text/css"_s},
+        {u".js"_s, u"text/javascript"_s},
+        {u".svg"_s, u"image/svg+xml"_s},
+        {u".png"_s, u"image/png"_s},
+        {u".gif"_s, u"image/gif"_s},
+    };
+
     struct TranslatedFile
     {
         QByteArray data;


### PR DESCRIPTION
This is a two part PR. See a discussion from https://github.com/qbittorrent/qBittorrent/issues/21363#issuecomment-2368038040.

### Move Path mime extension retrieval into a separate method.

Reasons:
* Most `Path::extension()` callers do not need that.
* Mime database is unreliable and could be manipulated by the system environment.
* Unnecessary overhead.

### WebUI: Store common mime types inside the app.

* Fixes #21363

Related:
* #15218
* #15316