### PR TITLE
Display External IP Address in status bar

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -468,6 +468,9 @@ namespace BitTorrent
         virtual void topTorrentsQueuePos(const QList<TorrentID> &ids) = 0;
         virtual void bottomTorrentsQueuePos(const QList<TorrentID> &ids) = 0;
 
+        virtual QString lastExternalIPv4Address() const = 0;
+        virtual QString lastExternalIPv6Address() const = 0;
+
     signals:
         void startupProgressUpdated(int progress);
         void addTorrentFailed(const InfoHash &infoHash, const QString &reason);

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -4951,6 +4951,16 @@ void SessionImpl::setTrackerFilteringEnabled(const bool enabled)
     }
 }
 
+QString SessionImpl::lastExternalIPv4Address() const
+{
+    return m_lastExternalIPv4Address;
+}
+
+QString SessionImpl::lastExternalIPv6Address() const
+{
+    return m_lastExternalIPv6Address;
+}
+
 bool SessionImpl::isListening() const
 {
     return m_nativeSessionExtension->isSessionListening();
@@ -5967,11 +5977,19 @@ void SessionImpl::handleExternalIPAlert(const lt::external_ip_alert *alert)
     LogMsg(tr("Detected external IP. IP: \"%1\"")
         .arg(externalIP), Log::INFO);
 
-    if (m_lastExternalIP != externalIP)
+    const bool isIPv6 = alert->external_address.is_v6();
+    const bool isIPv4 = alert->external_address.is_v4();
+    if (isIPv6 && (externalIP != m_lastExternalIPv6Address))
     {
-        if (isReannounceWhenAddressChangedEnabled() && !m_lastExternalIP.isEmpty())
+        if (isReannounceWhenAddressChangedEnabled() && !m_lastExternalIPv6Address.isEmpty())
             reannounceToAllTrackers();
-        m_lastExternalIP = externalIP;
+        m_lastExternalIPv6Address = externalIP;
+    }
+    else if (isIPv4 && (externalIP != m_lastExternalIPv4Address))
+    {
+        if (isReannounceWhenAddressChangedEnabled() && !m_lastExternalIPv4Address.isEmpty())
+            reannounceToAllTrackers();
+        m_lastExternalIPv4Address = externalIP;
     }
 }
 

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -443,6 +443,9 @@ namespace BitTorrent
         void topTorrentsQueuePos(const QList<TorrentID> &ids) override;
         void bottomTorrentsQueuePos(const QList<TorrentID> &ids) override;
 
+        QString lastExternalIPv4Address() const override;
+        QString lastExternalIPv6Address() const override;
+
         // Torrent interface
         void handleTorrentResumeDataRequested(const TorrentImpl *torrent);
         void handleTorrentShareLimitChanged(TorrentImpl *torrent);
@@ -811,7 +814,8 @@ namespace BitTorrent
 
         QList<MoveStorageJob> m_moveStorageQueue;
 
-        QString m_lastExternalIP;
+        QString m_lastExternalIPv4Address;
+        QString m_lastExternalIPv6Address;
 
         bool m_needUpgradeDownloadPath = false;
 

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -359,6 +359,19 @@ void Preferences::setStatusbarDisplayed(const bool displayed)
     setValue(u"Preferences/General/StatusbarDisplayed"_s, displayed);
 }
 
+bool Preferences::isStatusbarExternalIPDisplayed() const
+{
+    return value(u"Preferences/General/StatusbarExternalIPDisplayed"_s, false);
+}
+
+void Preferences::setStatusbarExternalIPDisplayed(const bool displayed)
+{
+    if (displayed == isStatusbarExternalIPDisplayed())
+        return;
+
+    setValue(u"Preferences/General/StatusbarExternalIPDisplayed"_s, displayed);
+}
+
 bool Preferences::isSplashScreenDisabled() const
 {
     return value(u"Preferences/General/NoSplashScreen"_s, true);

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -119,6 +119,8 @@ public:
     void setHideZeroComboValues(int n);
     bool isStatusbarDisplayed() const;
     void setStatusbarDisplayed(bool displayed);
+    bool isStatusbarExternalIPDisplayed() const;
+    void setStatusbarExternalIPDisplayed(bool displayed);
     bool isToolbarDisplayed() const;
     void setToolbarDisplayed(bool displayed);
     bool isSplashScreenDisabled() const;

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -352,6 +352,7 @@ void OptionsDialog::loadBehaviorTabOptions()
     // Groupbox's check state  must be initialized after some of its children if they are manually enabled/disabled
     m_ui->checkFileLog->setChecked(app()->isFileLoggerEnabled());
 
+    m_ui->checkBoxExternalIPStatusBar->setChecked(pref->isStatusbarExternalIPDisplayed());
     m_ui->checkBoxPerformanceWarning->setChecked(session->isPerformanceWarningEnabled());
 
     connect(m_ui->comboLanguage, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
@@ -439,6 +440,7 @@ void OptionsDialog::loadBehaviorTabOptions()
     connect(m_ui->spinFileLogAge, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->comboFileLogAgeType, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
 
+    connect(m_ui->checkBoxExternalIPStatusBar, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkBoxPerformanceWarning, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
 }
 
@@ -534,6 +536,7 @@ void OptionsDialog::saveBehaviorTabOptions() const
 
     app()->setStartUpWindowState(m_ui->windowStateComboBox->currentData().value<WindowState>());
 
+    pref->setStatusbarExternalIPDisplayed(m_ui->checkBoxExternalIPStatusBar->isChecked());
     session->setPerformanceWarningEnabled(m_ui->checkBoxPerformanceWarning->isChecked());
 }
 

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -815,6 +815,13 @@
              </widget>
             </item>
             <item>
+             <widget class="QCheckBox" name="checkBoxExternalIPStatusBar">
+              <property name="text">
+               <string>Show external IP in status bar</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="QCheckBox" name="checkBoxPerformanceWarning">
               <property name="text">
                <string>Log performance warnings</string>

--- a/src/gui/statusbar.h
+++ b/src/gui/statusbar.h
@@ -58,14 +58,18 @@ private slots:
     void refresh();
     void updateAltSpeedsBtn(bool alternative);
     void capSpeed();
+    void optionsSaved();
 
 private:
     void updateConnectionStatus();
     void updateDHTNodesNumber();
+    void updateExternalAddressesLabel();
+    void updateExternalAddressesVisibility();
     void updateSpeedLabels();
 
     QPushButton *m_dlSpeedLbl = nullptr;
     QPushButton *m_upSpeedLbl = nullptr;
+    QLabel *m_lastExternalIPsLbl = nullptr;
     QLabel *m_DHTLbl = nullptr;
     QPushButton *m_connecStatusLblIcon = nullptr;
     QPushButton *m_altSpeedsBtn = nullptr;

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -136,6 +136,7 @@ void AppController::preferencesAction()
     // Language
     data[u"locale"_s] = pref->getLocale();
     data[u"performance_warning"_s] = session->isPerformanceWarningEnabled();
+    data[u"status_bar_external_ip"_s] = pref->isStatusbarExternalIPDisplayed();
     // Transfer List
     data[u"confirm_torrent_deletion"_s] = pref->confirmTorrentDeletion();
     // Log file
@@ -519,6 +520,8 @@ void AppController::setPreferencesAction()
             pref->setLocale(locale);
         }
     }
+    if (hasKey(u"status_bar_external_ip"_s))
+        pref->setStatusbarExternalIPDisplayed(it.value().toBool());
     if (hasKey(u"performance_warning"_s))
         session->setPerformanceWarningEnabled(it.value().toBool());
     // Transfer List

--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -85,6 +85,8 @@ namespace
     const QString KEY_TRANSFER_DLRATELIMIT = u"dl_rate_limit"_s;
     const QString KEY_TRANSFER_DLSPEED = u"dl_info_speed"_s;
     const QString KEY_TRANSFER_FREESPACEONDISK = u"free_space_on_disk"_s;
+    const QString KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V4 = u"last_external_address_v4"_s;
+    const QString KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V6 = u"last_external_address_v6"_s;
     const QString KEY_TRANSFER_UPDATA = u"up_info_data"_s;
     const QString KEY_TRANSFER_UPRATELIMIT = u"up_rate_limit"_s;
     const QString KEY_TRANSFER_UPSPEED = u"up_info_speed"_s;
@@ -159,6 +161,8 @@ namespace
         map[KEY_TRANSFER_AVERAGE_TIME_QUEUE] = cacheStatus.averageJobTime;
         map[KEY_TRANSFER_TOTAL_QUEUED_SIZE] = cacheStatus.queuedBytes;
 
+        map[KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V4] = session->lastExternalIPv4Address();
+        map[KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V6] = session->lastExternalIPv6Address();
         map[KEY_TRANSFER_DHT_NODES] = sessionStatus.dhtNodes;
         map[KEY_TRANSFER_CONNECTION_STATUS] = session->isListening()
             ? (sessionStatus.hasIncomingConnections ? u"connected"_s : u"firewalled"_s)
@@ -446,6 +450,8 @@ void SyncController::updateFreeDiskSpace(const qint64 freeDiskSpace)
 //  - "dl_info_data": bytes downloaded
 //  - "dl_info_speed": download speed
 //  - "dl_rate_limit: download rate limit
+//  - "last_external_address_v4": last external address v4
+//  - "last_external_address_v6": last external address v6
 //  - "up_info_data: bytes uploaded
 //  - "up_info_speed: upload speed
 //  - "up_rate_limit: upload speed limit

--- a/src/webui/api/transfercontroller.cpp
+++ b/src/webui/api/transfercontroller.cpp
@@ -65,7 +65,8 @@ const QString KEY_TRANSFER_CONNECTION_STATUS = u"connection_status"_s;
 //   - "connection_status": Connection status
 void TransferController::infoAction()
 {
-    const BitTorrent::SessionStatus &sessionStatus = BitTorrent::Session::instance()->status();
+    const auto *btSession = BitTorrent::Session::instance();
+    const BitTorrent::SessionStatus &sessionStatus = btSession->status();
 
     QJsonObject dict;
 
@@ -73,12 +74,12 @@ void TransferController::infoAction()
     dict[KEY_TRANSFER_DLDATA] = static_cast<qint64>(sessionStatus.totalPayloadDownload);
     dict[KEY_TRANSFER_UPSPEED] = static_cast<qint64>(sessionStatus.payloadUploadRate);
     dict[KEY_TRANSFER_UPDATA] = static_cast<qint64>(sessionStatus.totalPayloadUpload);
-    dict[KEY_TRANSFER_DLRATELIMIT] = BitTorrent::Session::instance()->downloadSpeedLimit();
-    dict[KEY_TRANSFER_UPRATELIMIT] = BitTorrent::Session::instance()->uploadSpeedLimit();
-    dict[KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V4] = BitTorrent::Session::instance()->lastExternalIPv4Address();
-    dict[KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V6] = BitTorrent::Session::instance()->lastExternalIPv6Address();
+    dict[KEY_TRANSFER_DLRATELIMIT] = btSession->downloadSpeedLimit();
+    dict[KEY_TRANSFER_UPRATELIMIT] = btSession->uploadSpeedLimit();
+    dict[KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V4] = btSession->lastExternalIPv4Address();
+    dict[KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V6] = btSession->lastExternalIPv6Address();
     dict[KEY_TRANSFER_DHT_NODES] = static_cast<qint64>(sessionStatus.dhtNodes);
-    if (!BitTorrent::Session::instance()->isListening())
+    if (!btSession->isListening())
         dict[KEY_TRANSFER_CONNECTION_STATUS] = u"disconnected"_s;
     else
         dict[KEY_TRANSFER_CONNECTION_STATUS] = sessionStatus.hasIncomingConnections ? u"connected"_s : u"firewalled"_s;

--- a/src/webui/api/transfercontroller.cpp
+++ b/src/webui/api/transfercontroller.cpp
@@ -45,6 +45,8 @@ const QString KEY_TRANSFER_DLRATELIMIT = u"dl_rate_limit"_s;
 const QString KEY_TRANSFER_UPSPEED = u"up_info_speed"_s;
 const QString KEY_TRANSFER_UPDATA = u"up_info_data"_s;
 const QString KEY_TRANSFER_UPRATELIMIT = u"up_rate_limit"_s;
+const QString KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V4 = u"last_external_address_v4"_s;
+const QString KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V6 = u"last_external_address_v6"_s;
 const QString KEY_TRANSFER_DHT_NODES = u"dht_nodes"_s;
 const QString KEY_TRANSFER_CONNECTION_STATUS = u"connection_status"_s;
 
@@ -57,6 +59,8 @@ const QString KEY_TRANSFER_CONNECTION_STATUS = u"connection_status"_s;
 //   - "up_info_data": Data uploaded this session
 //   - "dl_rate_limit": Download rate limit
 //   - "up_rate_limit": Upload rate limit
+//   - "last_external_address_v4": external IPv4 address
+//   - "last_external_address_v6": external IPv6 address
 //   - "dht_nodes": DHT nodes connected to
 //   - "connection_status": Connection status
 void TransferController::infoAction()
@@ -71,6 +75,8 @@ void TransferController::infoAction()
     dict[KEY_TRANSFER_UPDATA] = static_cast<qint64>(sessionStatus.totalPayloadUpload);
     dict[KEY_TRANSFER_DLRATELIMIT] = BitTorrent::Session::instance()->downloadSpeedLimit();
     dict[KEY_TRANSFER_UPRATELIMIT] = BitTorrent::Session::instance()->uploadSpeedLimit();
+    dict[KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V4] = BitTorrent::Session::instance()->lastExternalIPv4Address();
+    dict[KEY_TRANSFER_LAST_EXTERNAL_ADDRESS_V6] = BitTorrent::Session::instance()->lastExternalIPv6Address();
     dict[KEY_TRANSFER_DHT_NODES] = static_cast<qint64>(sessionStatus.dhtNodes);
     if (!BitTorrent::Session::instance()->isListening())
         dict[KEY_TRANSFER_CONNECTION_STATUS] = u"disconnected"_s;

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -280,8 +280,8 @@
                         <td id="freeSpaceOnDisk"></td>
                         <td class="statusBarSeparator invisible"></td>
                         <td id="externalIPs" class="invisible"></td>
-                        <td class="statusBarSeparator"></td>
-                        <td id="DHTNodes"></td>
+                        <td class="statusBarSeparator invisible"></td>
+                        <td id="DHTNodes" class="invisible"></td>
                         <td class="statusBarSeparator"></td>
                         <td><img id="connectionStatus" alt="QBT_TR(Connection status: Firewalled)QBT_TR[CONTEXT=MainWindow]" title="QBT_TR(Connection status: Firewalled)QBT_TR[CONTEXT=MainWindow]" src="images/firewalled.svg" style="height: 1.5em;"></td>
                         <td class="statusBarSeparator"></td>

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -278,6 +278,8 @@
                 <tbody>
                     <tr>
                         <td id="freeSpaceOnDisk"></td>
+                        <td class="statusBarSeparator invisible"></td>
+                        <td id="externalIPs" class="invisible"></td>
                         <td class="statusBarSeparator"></td>
                         <td id="DHTNodes"></td>
                         <td class="statusBarSeparator"></td>

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -956,6 +956,28 @@ window.addEventListener("DOMContentLoaded", () => {
 
         $("freeSpaceOnDisk").textContent = "QBT_TR(Free space: %1)QBT_TR[CONTEXT=HttpServer]".replace("%1", window.qBittorrent.Misc.friendlyUnit(serverState.free_space_on_disk));
 
+        const externalIPsElement = document.getElementById("externalIPs");
+        if (window.qBittorrent.Cache.preferences.get().status_bar_external_ip) {
+            const lastExternalAddressV4 = serverState.last_external_address_v4;
+            const lastExternalAddressV6 = serverState.last_external_address_v6;
+            const hasIPv4Address = lastExternalAddressV4 !== "";
+            const hasIPv6Address = lastExternalAddressV6 !== "";
+            let lastExternalAddressLabel = "QBT_TR(External IP: N/A)QBT_TR[CONTEXT=HttpServer]";
+            if (hasIPv4Address && hasIPv6Address)
+                lastExternalAddressLabel = "QBT_TR(External IPs: %1, %2)QBT_TR[CONTEXT=HttpServer]";
+            else if (hasIPv4Address || hasIPv6Address)
+                lastExternalAddressLabel = "QBT_TR(External IP: %1%2)QBT_TR[CONTEXT=HttpServer]";
+            // replace in reverse order ('%2' before '%1') in case address contains a % character.
+            // for example, see https://en.wikipedia.org/wiki/IPv6_address#Scoped_literal_IPv6_addresses_(with_zone_index)
+            externalIPsElement.textContent = lastExternalAddressLabel.replace("%2", lastExternalAddressV6).replace("%1", lastExternalAddressV4);
+            externalIPsElement.classList.remove("invisible");
+            externalIPsElement.previousElementSibling.classList.remove("invisible");
+        }
+        else {
+            externalIPsElement.classList.add("invisible");
+            externalIPsElement.previousElementSibling.classList.add("invisible");
+        }
+
         const dhtElement = document.getElementById("DHTNodes");
         if (window.qBittorrent.Cache.preferences.get().dht) {
             dhtElement.textContent = "QBT_TR(DHT: %1 nodes)QBT_TR[CONTEXT=StatusBar]".replace("%1", serverState.dht_nodes);

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -90,6 +90,11 @@
         </table>
     </fieldset>
 
+    <div class="formRow" style="margin-bottom: 3px;">
+        <input type="checkbox" id="statusBarExternalIP">
+        <label for="statusBarExternalIP">QBT_TR(Show external IP in status bar)QBT_TR[CONTEXT=OptionsDialog]</label>
+    </div>
+
     <div class="formRow" style="margin-bottom: 5px;">
         <input type="checkbox" id="performanceWarning">
         <label for="performanceWarning">QBT_TR(Log performance warnings)QBT_TR[CONTEXT=OptionsDialog]</label>
@@ -2157,6 +2162,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     // Language
                     updateWebuiLocaleSelect(pref.locale);
                     updateColoSchemeSelect();
+                    $("statusBarExternalIP").checked = pref.status_bar_external_ip;
                     $("performanceWarning").checked = pref.performance_warning;
                     document.getElementById("displayFullURLTrackerColumn").checked = (LocalPreferences.get("full_url_tracker_column", "false") === "true");
                     document.getElementById("hideZeroFiltersCheckbox").checked = (LocalPreferences.get("hide_zero_status_filters", "false") === "true");
@@ -2582,6 +2588,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 LocalPreferences.set("color_scheme", "light");
             else
                 LocalPreferences.set("color_scheme", "dark");
+            settings["status_bar_external_ip"] = $("statusBarExternalIP").checked;
             settings["performance_warning"] = $("performanceWarning").checked;
             LocalPreferences.set("full_url_tracker_column", document.getElementById("displayFullURLTrackerColumn").checked.toString());
             LocalPreferences.set("hide_zero_status_filters", document.getElementById("hideZeroFiltersCheckbox").checked.toString());


### PR DESCRIPTION
This change displays the last detected IPv4 and/or IPv6 address(es) in the GUI and WebUI's status bar. This does not yet handle systems with multiple addresses of the same type (e.g. multiple IPv6 addresses).

This is a continuation of #20118, which has been closed. I've reused most of the code (with minor changes) but removed the ability to directly open the Execution Log by clicking on the address label.


GUI (resolution 1280x800):
![Screenshot 2024-09-24 at 11 35 32](https://github.com/user-attachments/assets/5253f80b-bdd2-490d-bb9d-24213d0312e9)

WebUI:
![Screenshot 2024-09-24 at 11 36 01](https://github.com/user-attachments/assets/0407d6c4-309e-4db1-9574-dc3834554074)
