### PR TITLE
WebUI: Add 'Engine' column to Search table

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1743,7 +1743,8 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.newColumn("fileSize", "", "QBT_TR(Size)QBT_TR[CONTEXT=SearchResultsTable]", 100, true);
             this.newColumn("nbSeeders", "", "QBT_TR(Seeders)QBT_TR[CONTEXT=SearchResultsTable]", 100, true);
             this.newColumn("nbLeechers", "", "QBT_TR(Leechers)QBT_TR[CONTEXT=SearchResultsTable]", 100, true);
-            this.newColumn("siteUrl", "", "QBT_TR(Search engine)QBT_TR[CONTEXT=SearchResultsTable]", 250, true);
+            this.newColumn("engineName", "", "QBT_TR(Engine)QBT_TR[CONTEXT=SearchResultsTable]", 100, true);
+            this.newColumn("siteUrl", "", "QBT_TR(Engine URL)QBT_TR[CONTEXT=SearchResultsTable]", 250, true);
             this.newColumn("pubDate", "", "QBT_TR(Published On)QBT_TR[CONTEXT=SearchResultsTable]", 200, true);
 
             this.initColumnsFunctions();

--- a/src/webui/www/private/scripts/search.js
+++ b/src/webui/www/private/scripts/search.js
@@ -820,6 +820,7 @@ window.qBittorrent.Search ??= (() => {
                                 fileUrl: result.fileUrl,
                                 nbLeechers: result.nbLeechers,
                                 nbSeeders: result.nbSeeders,
+                                engineName: result.engineName,
                                 siteUrl: result.siteUrl,
                                 pubDate: result.pubDate,
                             };


### PR DESCRIPTION
This PR adds 'Engine' column to Search table.

I also fixed inconsistent naming and renamed 'Search engine' column to 'Engine URL'.