### PR TITLE
Add name to threads

### DIFF
--- a/src/base/bittorrent/bencoderesumedatastorage.cpp
+++ b/src/base/bittorrent/bencoderesumedatastorage.cpp
@@ -131,6 +131,7 @@ BitTorrent::BencodeResumeDataStorage::BencodeResumeDataStorage(const Path &path,
 
     m_asyncWorker->moveToThread(m_ioThread.get());
     connect(m_ioThread.get(), &QThread::finished, m_asyncWorker, &QObject::deleteLater);
+    m_ioThread->setObjectName("BencodeResumeDataStorage m_ioThread");
     m_ioThread->start();
 }
 

--- a/src/base/bittorrent/bencoderesumedatastorage.h
+++ b/src/base/bittorrent/bencoderesumedatastorage.h
@@ -37,7 +37,6 @@
 #include "resumedatastorage.h"
 
 class QByteArray;
-class QThread;
 
 namespace BitTorrent
 {

--- a/src/base/bittorrent/dbresumedatastorage.cpp
+++ b/src/base/bittorrent/dbresumedatastorage.cpp
@@ -325,7 +325,6 @@ namespace BitTorrent
 
 BitTorrent::DBResumeDataStorage::DBResumeDataStorage(const Path &dbPath, QObject *parent)
     : ResumeDataStorage(dbPath, parent)
-    , m_ioThread {new QThread}
 {
     const bool needCreateDB = !dbPath.exists();
 

--- a/src/base/bittorrent/dbresumedatastorage.h
+++ b/src/base/bittorrent/dbresumedatastorage.h
@@ -34,8 +34,6 @@
 #include "base/utils/thread.h"
 #include "resumedatastorage.h"
 
-class QThread;
-
 namespace BitTorrent
 {
     class DBResumeDataStorage final : public ResumeDataStorage
@@ -60,8 +58,6 @@ namespace BitTorrent
         void createDB() const;
         void updateDB(int fromVersion) const;
         void enableWALMode() const;
-
-        Utils::Thread::UniquePtr m_ioThread;
 
         class Worker;
         Worker *m_asyncWorker = nullptr;

--- a/src/base/bittorrent/resumedatastorage.cpp
+++ b/src/base/bittorrent/resumedatastorage.cpp
@@ -35,6 +35,8 @@
 #include <QMutexLocker>
 #include <QThread>
 
+#include "base/global.h"
+
 const int TORRENTIDLIST_TYPEID = qRegisterMetaType<QList<BitTorrent::TorrentID>>();
 
 BitTorrent::ResumeDataStorage::ResumeDataStorage(const Path &path, QObject *parent)
@@ -56,6 +58,7 @@ void BitTorrent::ResumeDataStorage::loadAll() const
     {
         doLoadAll();
     });
+    loadingThread->setObjectName("ResumeDataStorage::loadAll loadingThread");
     connect(loadingThread, &QThread::finished, loadingThread, &QObject::deleteLater);
     loadingThread->start();
 }

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -536,6 +536,7 @@ SessionImpl::SessionImpl(QObject *parent)
 {
     // It is required to perform async access to libtorrent sequentially
     m_asyncWorker->setMaxThreadCount(1);
+    m_asyncWorker->setObjectName("SessionImpl m_asyncWorker");
 
     if (port() < 0)
         m_port = Utils::Random::rand(1024, 65535);
@@ -600,6 +601,7 @@ SessionImpl::SessionImpl(QObject *parent)
     connect(m_ioThread.get(), &QThread::finished, m_torrentContentRemover, &QObject::deleteLater);
     connect(m_torrentContentRemover, &TorrentContentRemover::jobFinished, this, &SessionImpl::torrentContentRemovingFinished);
 
+    m_ioThread->setObjectName("SessionImpl m_ioThread");
     m_ioThread->start();
 
     initMetrics();
@@ -659,6 +661,7 @@ SessionImpl::~SessionImpl()
         qDebug("Deleting libtorrent session...");
         delete nativeSessionProxy;
     });
+    sessionTerminateThread->setObjectName("~SessionImpl sessionTerminateThread");
     connect(sessionTerminateThread, &QThread::finished, sessionTerminateThread, &QObject::deleteLater);
     sessionTerminateThread->start();
     if (sessionTerminateThread->wait(shutdownDeadlineTimer))

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -57,7 +57,6 @@
 #include "trackerentrystatus.h"
 
 class QString;
-class QThread;
 class QThreadPool;
 class QTimer;
 class QUrl;

--- a/src/base/bittorrent/torrentcreationmanager.cpp
+++ b/src/base/bittorrent/torrentcreationmanager.cpp
@@ -62,7 +62,10 @@ BitTorrent::TorrentCreationManager::TorrentCreationManager(IApplication *app, QO
     , m_maxTasks {SETTINGS_KEY(u"MaxTasks"_s), 256}
     , m_numThreads {SETTINGS_KEY(u"NumThreads"_s), 1}
     , m_tasks {std::make_unique<TaskSet>()}
+    , m_threadPool(this)
 {
+    m_threadPool.setObjectName("TorrentCreationManager m_threadPool");
+
     if (m_numThreads > 0)
         m_threadPool.setMaxThreadCount(m_numThreads);
 }

--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -123,6 +123,7 @@ AutoDownloader::AutoDownloader(IApplication *app)
                .arg(fileName.toString(), errorString), Log::CRITICAL);
     });
 
+    m_ioThread->setObjectName("RSS::AutoDownloader m_ioThread");
     m_ioThread->start();
 
     connect(app->addTorrentManager(), &AddTorrentManager::torrentAdded

--- a/src/base/rss/rss_autodownloader.h
+++ b/src/base/rss/rss_autodownloader.h
@@ -41,7 +41,6 @@
 #include "base/settingvalue.h"
 #include "base/utils/thread.h"
 
-class QThread;
 class QTimer;
 
 class Application;

--- a/src/base/rss/rss_session.cpp
+++ b/src/base/rss/rss_session.cpp
@@ -90,6 +90,7 @@ Session::Session()
 
     m_itemsByPath.insert(u""_s, new Folder); // root folder
 
+    m_workingThread->setObjectName("RSS::Session m_workingThread");
     m_workingThread->start();
     load();
 

--- a/src/base/torrentfileswatcher.cpp
+++ b/src/base/torrentfileswatcher.cpp
@@ -146,6 +146,7 @@ TorrentFilesWatcher::TorrentFilesWatcher(QObject *parent)
 
     m_asyncWorker->moveToThread(m_ioThread.get());
     connect(m_ioThread.get(), &QThread::finished, m_asyncWorker, &QObject::deleteLater);
+    m_ioThread->setObjectName("TorrentFilesWatcher m_ioThread");
     m_ioThread->start();
 
     load();

--- a/src/base/torrentfileswatcher.h
+++ b/src/base/torrentfileswatcher.h
@@ -36,8 +36,6 @@
 #include "base/path.h"
 #include "base/utils/thread.h"
 
-class QThread;
-
 /*
  * Watches the configured directories for new .torrent files in order
  * to add torrents to BitTorrent session. Supports Network File System

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -39,7 +39,6 @@
 #include <QSplitter>
 #include <QShortcut>
 #include <QStackedWidget>
-#include <QThread>
 #include <QUrl>
 
 #include "base/bittorrent/infohash.h"

--- a/src/gui/torrentcontentwidget.cpp
+++ b/src/gui/torrentcontentwidget.cpp
@@ -37,7 +37,6 @@
 #include <QMessageBox>
 #include <QModelIndexList>
 #include <QShortcut>
-#include <QThread>
 #include <QWheelEvent>
 
 #include "base/bittorrent/torrentcontenthandler.h"

--- a/src/gui/torrentcreatordialog.cpp
+++ b/src/gui/torrentcreatordialog.cpp
@@ -109,6 +109,7 @@ TorrentCreatorDialog::TorrentCreatorDialog(QWidget *parent, const Path &defaultP
     updateInputPath(defaultPath);
 
     m_threadPool.setMaxThreadCount(1);
+    m_threadPool.setObjectName("TorrentCreatorDialog m_threadPool");
 
 #ifdef QBT_USES_LIBTORRENT2
     m_ui->checkOptimizeAlignment->hide();

--- a/src/gui/uithemedialog.cpp
+++ b/src/gui/uithemedialog.cpp
@@ -75,7 +75,7 @@ public:
         , m_defaultColor {defaultColor}
         , m_currentColor {currentColor}
     {
-        setObjectName(u"colorWidget"_s);
+        setObjectName("colorWidget");
         setFrameShape(QFrame::Box);
         setFrameShadow(QFrame::Plain);
         setAlignment(Qt::AlignCenter);
@@ -159,7 +159,7 @@ public:
         : QLabel(parent)
         , m_defaultPath {defaultPath}
     {
-        setObjectName(u"iconWidget"_s);
+        setObjectName("iconWidget");
         setAlignment(Qt::AlignCenter);
 
         setCurrentPath(currentPath);

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -134,6 +134,7 @@ void Utils::Gui::openPath(const Path &path)
             ::CoUninitialize();
         }
     });
+    thread->setObjectName("Utils::Gui::openPath thread");
     QObject::connect(thread, &QThread::finished, thread, &QObject::deleteLater);
     thread->start();
 #else
@@ -168,6 +169,7 @@ void Utils::Gui::openFolderSelect(const Path &path)
             ::CoUninitialize();
         }
     });
+    thread->setObjectName("Utils::Gui::openFolderSelect thread");
     QObject::connect(thread, &QThread::finished, thread, &QObject::deleteLater);
     thread->start();
 #elif defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -184,6 +184,7 @@ WebApplication::WebApplication(IApplication *app, QObject *parent)
 
     m_freeDiskSpaceChecker->moveToThread(m_workerThread.get());
     connect(m_workerThread.get(), &QThread::finished, m_freeDiskSpaceChecker, &QObject::deleteLater);
+    m_workerThread->setObjectName("WebApplication m_workerThread");
     m_workerThread->start();
 
     m_freeDiskSpaceCheckingTimer->setInterval(FREEDISKSPACE_CHECK_TIMEOUT);


### PR DESCRIPTION
This help identifying threads when debugging.
The name is using 'variable name + class/function name' due to the thread name field is limited to 16 chars on linux. Note that on Windows, the limit is 32767 chars.

