### PR TITLE
Replace QVector with QList

### DIFF
--- a/src/app/qtlocalpeer/qtlockedfile.h
+++ b/src/app/qtlocalpeer/qtlockedfile.h
@@ -71,8 +71,8 @@
 #include <QFile>
 
 #ifdef Q_OS_WIN
+#include <QList>
 #include <QString>
-#include <QVector>
 #endif
 
 namespace QtLP_Private
@@ -105,7 +105,7 @@ namespace QtLP_Private
 
         Qt::HANDLE m_writeMutex = nullptr;
         Qt::HANDLE m_readMutex = nullptr;
-        QVector<Qt::HANDLE> m_readMutexes;
+        QList<Qt::HANDLE> m_readMutexes;
         QString m_mutexName;
 #endif
 

--- a/src/gui/macutilities.mm
+++ b/src/gui/macutilities.mm
@@ -34,7 +34,6 @@
 #include <QPixmap>
 #include <QSize>
 #include <QString>
-#include <QVector>
 
 #include "base/path.h"
 

--- a/test/testbittorrenttrackerentry.cpp
+++ b/test/testbittorrenttrackerentry.cpp
@@ -28,9 +28,9 @@
 
 #include <algorithm>
 
+#include <QList>
 #include <QObject>
 #include <QTest>
-#include <QVector>
 
 #include "base/bittorrent/trackerentry.h"
 #include "base/global.h"
@@ -46,7 +46,7 @@ public:
 private slots:
     void testParseTrackerEntries() const
     {
-        using Entries = QVector<BitTorrent::TrackerEntry>;
+        using Entries = QList<BitTorrent::TrackerEntry>;
 
         const auto isEqual = [](const Entries &left, const Entries &right) -> bool
         {


### PR DESCRIPTION
Migrated last remnants of `QVector` to `Qlist`, reference https://github.com/qbittorrent/qBittorrent/pull/21016#issuecomment-2212403741 onward.