### PR TITLE
Migrate away from deprecated functions in Qt 6.9

### DIFF
--- a/src/base/net/smtp.cpp
+++ b/src/base/net/smtp.cpp
@@ -565,29 +565,11 @@ void Smtp::logError(const QString &msg)
 
 QString Smtp::getCurrentDateTime() const
 {
-    // return date & time in the format specified in RFC 2822, section 3.3
-    const QDateTime nowDateTime = QDateTime::currentDateTime();
-    const QDate nowDate = nowDateTime.date();
-    const QLocale eng(QLocale::English);
-
-    const QString timeStr = nowDateTime.time().toString(u"HH:mm:ss");
-    const QString weekDayStr = eng.dayName(nowDate.dayOfWeek(), QLocale::ShortFormat);
-    const QString dayStr = QString::number(nowDate.day());
-    const QString monthStr = eng.monthName(nowDate.month(), QLocale::ShortFormat);
-    const QString yearStr = QString::number(nowDate.year());
-
-    QDateTime tmp = nowDateTime;
-    tmp.setTimeSpec(Qt::UTC);
-    const int timeOffsetHour = nowDateTime.secsTo(tmp) / 3600;
-    const int timeOffsetMin = nowDateTime.secsTo(tmp) / 60 - (60 * timeOffsetHour);
-    const int timeOffset = timeOffsetHour * 100 + timeOffsetMin;
-    // buf size = 11 to avoid format truncation warnings from snprintf
-    char buf[11] = {0};
-    std::snprintf(buf, sizeof(buf), "%+05d", timeOffset);
-    const auto timeOffsetStr = QString::fromUtf8(buf);
-
-    const QString ret = weekDayStr + u", " + dayStr + u' ' + monthStr + u' ' + yearStr + u' ' + timeStr + u' ' + timeOffsetStr;
-    return ret;
+    // [rfc2822] 3.3. Date and Time Specification
+    const auto now = QDateTime::currentDateTime();
+    const QLocale eng {QLocale::English};
+    const QString weekday = eng.dayName(now.date().dayOfWeek(), QLocale::ShortFormat);
+    return (weekday + u", " + now.toString(Qt::RFC2822Date));
 }
 
 void Smtp::error(QAbstractSocket::SocketError socketError)

--- a/src/base/rss/rss_parser.cpp
+++ b/src/base/rss/rss_parser.cpp
@@ -36,6 +36,7 @@
 #include <QMetaObject>
 #include <QRegularExpression>
 #include <QStringList>
+#include <QTimeZone>
 #include <QVariant>
 #include <QXmlStreamEntityResolver>
 #include <QXmlStreamReader>
@@ -521,7 +522,7 @@ namespace
             return QDateTime::currentDateTime();
 
         const QTime qTime(hour, minute, second);
-        QDateTime result(qDate, qTime, Qt::UTC);
+        QDateTime result(qDate, qTime, QTimeZone::UTC);
         if (offset)
             result = result.addSecs(-offset);
         if (!result.isValid())

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -30,6 +30,7 @@
 
 #include <limits>
 
+#include <QtVersionChecks>
 #include <QHeaderView>
 #include <QHostAddress>
 #include <QLabel>
@@ -981,7 +982,13 @@ void AdvancedSettings::addRow(const int row, const QString &text, T *widget)
     setCellWidget(row, VALUE, widget);
 
     if constexpr (std::is_same_v<T, QCheckBox>)
+    {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+        connect(widget, &QCheckBox::checkStateChanged, this, &AdvancedSettings::settingsChanged);
+#else
         connect(widget, &QCheckBox::stateChanged, this, &AdvancedSettings::settingsChanged);
+#endif
+    }
     else if constexpr (std::is_same_v<T, QSpinBox>)
         connect(widget, qOverload<int>(&QSpinBox::valueChanged), this, &AdvancedSettings::settingsChanged);
     else if constexpr (std::is_same_v<T, QComboBox>)

--- a/src/gui/rss/automatedrssdownloader.cpp
+++ b/src/gui/rss/automatedrssdownloader.cpp
@@ -29,6 +29,7 @@
 
 #include "automatedrssdownloader.h"
 
+#include <QtVersionChecks>
 #include <QCursor>
 #include <QFileDialog>
 #include <QMenu>
@@ -129,10 +130,17 @@ AutomatedRssDownloader::AutomatedRssDownloader(QWidget *parent)
     connect(m_ui->lineNotContains, &QLineEdit::textEdited, this, &AutomatedRssDownloader::updateMustNotLineValidity);
     connect(m_ui->lineEFilter, &QLineEdit::textEdited, this, &AutomatedRssDownloader::handleRuleDefinitionChanged);
     connect(m_ui->lineEFilter, &QLineEdit::textEdited, this, &AutomatedRssDownloader::updateEpisodeFilterValidity);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+    connect(m_ui->checkRegex, &QCheckBox::checkStateChanged, this, &AutomatedRssDownloader::handleRuleDefinitionChanged);
+    connect(m_ui->checkRegex, &QCheckBox::checkStateChanged, this, &AutomatedRssDownloader::updateMustLineValidity);
+    connect(m_ui->checkRegex, &QCheckBox::checkStateChanged, this, &AutomatedRssDownloader::updateMustNotLineValidity);
+    connect(m_ui->checkSmart, &QCheckBox::checkStateChanged, this, &AutomatedRssDownloader::handleRuleDefinitionChanged);
+#else
     connect(m_ui->checkRegex, &QCheckBox::stateChanged, this, &AutomatedRssDownloader::handleRuleDefinitionChanged);
     connect(m_ui->checkRegex, &QCheckBox::stateChanged, this, &AutomatedRssDownloader::updateMustLineValidity);
     connect(m_ui->checkRegex, &QCheckBox::stateChanged, this, &AutomatedRssDownloader::updateMustNotLineValidity);
     connect(m_ui->checkSmart, &QCheckBox::stateChanged, this, &AutomatedRssDownloader::handleRuleDefinitionChanged);
+#endif
     connect(m_ui->spinIgnorePeriod, qOverload<int>(&QSpinBox::valueChanged)
             , this, &AutomatedRssDownloader::handleRuleDefinitionChanged);
 


### PR DESCRIPTION
Closes #21412.
