### PR TITLE
Support configuring WebUI URL base path

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -1026,6 +1026,19 @@ void Preferences::setWebUITrustedReverseProxiesList(const QString &addr)
     setValue(u"Preferences/WebUI/TrustedReverseProxiesList"_s, addr);
 }
 
+QString Preferences::getWebUIBasePath() const
+{
+    return value(u"Preferences/WebUI/BasePath"_s, u"/"_s);
+}
+
+void Preferences::setWebUIBasePath(const QString &path)
+{
+    if (path == getWebUIBasePath())
+        return;
+
+    setValue(u"Preferences/WebUI/BasePath"_s, path);
+}
+
 bool Preferences::isDynDNSEnabled() const
 {
     return value(u"Preferences/DynDNS/Enabled"_s, false);

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -237,6 +237,8 @@ public:
     void setWebUIReverseProxySupportEnabled(bool enabled);
     QString getWebUITrustedReverseProxiesList() const;
     void setWebUITrustedReverseProxiesList(const QString &addr);
+    QString getWebUIBasePath() const;
+    void setWebUIBasePath(const QString &path);
 
     // Dynamic DNS
     bool isDynDNSEnabled() const;

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -1313,6 +1313,7 @@ void OptionsDialog::loadWebUITabOptions()
     // Reverse proxy
     m_ui->groupEnableReverseProxySupport->setChecked(pref->isWebUIReverseProxySupportEnabled());
     m_ui->textTrustedReverseProxiesList->setText(pref->getWebUITrustedReverseProxiesList());
+    m_ui->textWebUIBasePath->setText(pref->getWebUIBasePath());
     // DynDNS
     m_ui->checkDynDNS->setChecked(pref->isDynDNSEnabled());
     m_ui->comboDNSService->setCurrentIndex(static_cast<int>(pref->getDynDNSService()));
@@ -1354,6 +1355,7 @@ void OptionsDialog::loadWebUITabOptions()
 
     connect(m_ui->groupEnableReverseProxySupport, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->textTrustedReverseProxiesList, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
+    connect(m_ui->textWebUIBasePath, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
 
     connect(m_ui->checkDynDNS, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->comboDNSService, qComboBoxCurrentIndexChanged, this, &ThisType::enableApplyButton);
@@ -1400,6 +1402,17 @@ void OptionsDialog::saveWebUITabOptions() const
     // Reverse proxy
     pref->setWebUIReverseProxySupportEnabled(m_ui->groupEnableReverseProxySupport->isChecked());
     pref->setWebUITrustedReverseProxiesList(m_ui->textTrustedReverseProxiesList->text());
+
+    QString path = m_ui->textWebUIBasePath->text();
+    if (!path.startsWith(u"/"_s))
+        path.prepend(u"/");
+    if (!path.endsWith(u"/"_s))
+        path.append(u"/");
+    QUrl url;
+    url.setPath(path, QUrl::StrictMode);
+    if (url.isValid())
+        pref->setWebUIBasePath(url.path());
+
     // DynDNS
     pref->setDynDNSEnabled(m_ui->checkDynDNS->isChecked());
     pref->setDynDNSService(static_cast<DNS::Service>(m_ui->comboDNSService->currentIndex()));

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -3815,6 +3815,24 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
                    </layout>
                   </item>
                   <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_132">
+                    <item>
+                     <widget class="QLabel" name="lblWebUIBasePath">
+                      <property name="text">
+                       <string>URL base path:</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QLineEdit" name="textWebUIBasePath">
+                      <property name="toolTip">
+                       <string>Specify the URL path qBittorent will be made accessible at (e.g. '/qbittorrent/').</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
                    <widget class="QLabel" name="labelReverseProxyLink">
                     <property name="text">
                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/qbittorrent/qBittorrent/wiki#reverse-proxy-setup-for-webui-access&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Reverse proxy setup examples&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -342,6 +342,7 @@ void AppController::preferencesAction()
     // Reverse proxy
     data[u"web_ui_reverse_proxy_enabled"_s] = pref->isWebUIReverseProxySupportEnabled();
     data[u"web_ui_reverse_proxies_list"_s] = pref->getWebUITrustedReverseProxiesList();
+    data[u"web_ui_base_path"_s] = pref->getWebUIBasePath();
     // Update my dynamic domain name
     data[u"dyndns_enabled"_s] = pref->isDynDNSEnabled();
     data[u"dyndns_service"_s] = static_cast<int>(pref->getDynDNSService());
@@ -924,6 +925,18 @@ void AppController::setPreferencesAction()
         pref->setWebUIReverseProxySupportEnabled(it.value().toBool());
     if (hasKey(u"web_ui_reverse_proxies_list"_s))
         pref->setWebUITrustedReverseProxiesList(it.value().toString());
+    if (hasKey(u"web_ui_base_path"_s))
+    {
+        QString path = it.value().toString();
+        if (!path.startsWith(u"/"_s))
+            path.prepend(u"/");
+        if (!path.endsWith(u"/"_s))
+            path.append(u"/");
+        QUrl url;
+        url.setPath(path, QUrl::StrictMode);
+        if (url.isValid())
+            pref->setWebUIBasePath(url.path());
+    }
     // Update my dynamic domain name
     if (hasKey(u"dyndns_enabled"_s))
         pref->setDynDNSEnabled(it.value().toBool());

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -412,7 +412,7 @@ void WebApplication::configure()
     {
         m_isAltUIUsed = isAltUIUsed;
         m_rootFolder = rootFolder;
-        m_translatedFiles.clear();
+        m_cachedFiles.clear();
         if (!m_isAltUIUsed)
             LogMsg(tr("Using built-in WebUI."));
         else
@@ -423,7 +423,7 @@ void WebApplication::configure()
     if (m_currentLocale != newLocale)
     {
         m_currentLocale = newLocale;
-        m_translatedFiles.clear();
+        m_cachedFiles.clear();
 
         m_translationFileLoaded = m_translator.load((m_rootFolder / Path(u"translations/webui_"_s) + newLocale).data());
         if (m_translationFileLoaded)
@@ -539,8 +539,8 @@ void WebApplication::sendFile(const Path &path)
     // find translated file in cache
     if (!m_isAltUIUsed)
     {
-        if (const auto it = m_translatedFiles.constFind(path);
-            (it != m_translatedFiles.constEnd()) && (lastModified <= it->lastModified))
+        if (const auto it = m_cachedFiles.constFind(path);
+            (it != m_cachedFiles.constEnd()) && (lastModified <= it->lastModified))
         {
             print(it->data, it->mimeType);
             setHeader({Http::HEADER_CACHE_CONTROL, getCachingInterval(it->mimeType)});
@@ -589,7 +589,7 @@ void WebApplication::sendFile(const Path &path)
             dataStr.replace(u"${LANGUAGE_OPTIONS}"_s, createLanguagesOptionsHtml());
 
         data = dataStr.toUtf8();
-        m_translatedFiles[path] = {data, mimeType.name(), lastModified}; // caching translated file
+        m_cachedFiles[path] = {data, mimeType.name(), lastModified}; // caching translated file
     }
 
     print(data, mimeType.name());

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -226,13 +226,13 @@ private:
     bool m_isAltUIUsed = false;
     Path m_rootFolder;
 
-    struct TranslatedFile
+    struct CachedFile
     {
         QByteArray data;
         QString mimeType;
         QDateTime lastModified;
     };
-    QHash<Path, TranslatedFile> m_translatedFiles;
+    QHash<Path, CachedFile> m_cachedFiles;
     QString m_currentLocale;
     QTranslator m_translator;
     bool m_translationFileLoaded = false;

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -225,6 +225,7 @@ private:
     };
     bool m_isAltUIUsed = false;
     Path m_rootFolder;
+    QString m_basePath;
 
     struct CachedFile
     {

--- a/src/webui/www/private/addpeers.html
+++ b/src/webui/www/private/addpeers.html
@@ -4,11 +4,11 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(Add Peers)QBT_TR[CONTEXT=PeersAdditionDialog]</title>
-    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <link rel="stylesheet" href="${BASE_PATH}css/style.css?v=${CACHEID}" type="text/css">
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 
@@ -42,7 +42,7 @@
                     return;
 
                 new Request({
-                    url: "api/v2/torrents/addPeers",
+                    url: "${BASE_PATH}api/v2/torrents/addPeers",
                     method: "post",
                     data: {
                         hashes: hash,

--- a/src/webui/www/private/addtrackers.html
+++ b/src/webui/www/private/addtrackers.html
@@ -4,11 +4,11 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(Add trackers)QBT_TR[CONTEXT=TrackersAdditionDialog]</title>
-    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <link rel="stylesheet" href="${BASE_PATH}css/style.css?v=${CACHEID}" type="text/css">
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 
@@ -34,7 +34,7 @@
 
                 const hash = new URI().getData("hash");
                 new Request({
-                    url: "api/v2/torrents/addTrackers",
+                    url: "${BASE_PATH}api/v2/torrents/addTrackers",
                     method: "post",
                     data: {
                         hash: hash,

--- a/src/webui/www/private/addwebseeds.html
+++ b/src/webui/www/private/addwebseeds.html
@@ -4,11 +4,11 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(Add web seeds)QBT_TR[CONTEXT=HttpServer]</title>
-    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <link rel="stylesheet" href="${BASE_PATH}css/style.css?v=${CACHEID}" type="text/css">
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 
@@ -32,7 +32,7 @@
                 e.stopPropagation();
                 const hash = new URI().getData("hash");
                 new Request({
-                    url: "api/v2/torrents/addWebSeeds",
+                    url: "${BASE_PATH}api/v2/torrents/addWebSeeds",
                     method: "post",
                     data: {
                         hash: hash,

--- a/src/webui/www/private/confirmfeeddeletion.html
+++ b/src/webui/www/private/confirmfeeddeletion.html
@@ -4,11 +4,11 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(Deletion confirmation)QBT_TR[CONTEXT=RSSWidget]</title>
-    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <link rel="stylesheet" href="${BASE_PATH}css/style.css?v=${CACHEID}" type="text/css">
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 
@@ -27,7 +27,7 @@
                 let completionCount = 0;
                 paths.forEach((path) => {
                     new Request({
-                        url: "api/v2/rss/removeItem",
+                        url: "${BASE_PATH}api/v2/rss/removeItem",
                         method: "post",
                         data: {
                             path: decodeURIComponent(path)

--- a/src/webui/www/private/confirmruleclear.html
+++ b/src/webui/www/private/confirmruleclear.html
@@ -4,11 +4,11 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(Clear downloaded episodes)QBT_TR[CONTEXT=AutomatedRssDownloader]</title>
-    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <link rel="stylesheet" href="${BASE_PATH}css/style.css?v=${CACHEID}" type="text/css">
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 

--- a/src/webui/www/private/confirmruledeletion.html
+++ b/src/webui/www/private/confirmruledeletion.html
@@ -4,11 +4,11 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(Rule deletion confirmation)QBT_TR[CONTEXT=AutomatedRssDownloader]</title>
-    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <link rel="stylesheet" href="${BASE_PATH}css/style.css?v=${CACHEID}" type="text/css">
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 
@@ -28,7 +28,7 @@
                 let completionCount = 0;
                 rules.forEach((rule) => {
                     new Request({
-                        url: "api/v2/rss/removeRule",
+                        url: "${BASE_PATH}api/v2/rss/removeRule",
                         method: "post",
                         data: {
                             ruleName: decodeURIComponent(rule)

--- a/src/webui/www/private/confirmtrackerdeletion.html
+++ b/src/webui/www/private/confirmtrackerdeletion.html
@@ -4,11 +4,11 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(Remove tracker)QBT_TR[CONTEXT=confirmDeletionDlg]</title>
-    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <link rel="stylesheet" href="${BASE_PATH}css/style.css?v=${CACHEID}" type="text/css">
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 
@@ -24,7 +24,7 @@
             });
             $("confirmBtn").addEvent("click", (e) => {
                 e.stopPropagation();
-                const cmd = "api/v2/torrents/removeTrackers";
+                const cmd = "${BASE_PATH}api/v2/torrents/removeTrackers";
                 new Request({
                     url: cmd,
                     method: "post",

--- a/src/webui/www/private/css/Layout.css
+++ b/src/webui/www/private/css/Layout.css
@@ -34,7 +34,7 @@ Required by:
 }
 
 #desktopTitlebar {
-    background: url("../images/logo.gif") no-repeat;
+    background: url("${BASE_PATH}images/logo.gif") no-repeat;
     background-position: left 0;
     height: 32px;
     padding: 7px 8px 6px;
@@ -119,7 +119,7 @@ Required by:
 
 #desktopNavbar ul li a.arrow-right,
 #desktopNavbar ul li a:hover.arrow-right {
-    background-image: url("../images/arrow-right.gif");
+    background-image: url("${BASE_PATH}images/arrow-right.gif");
     background-position: right 7px;
     background-repeat: no-repeat;
 }
@@ -269,11 +269,11 @@ li.divider {
 }
 
 .panel-collapse {
-    background: url("../images/collapse.svg") center/16px no-repeat;
+    background: url("${BASE_PATH}images/collapse.svg") center/16px no-repeat;
 }
 
 .panel-expand {
-    background: url("../images/collapse.svg") center/16px no-repeat;
+    background: url("${BASE_PATH}images/collapse.svg") center/16px no-repeat;
     transform: rotate(180deg);
 }
 
@@ -296,8 +296,8 @@ li.divider {
 }
 
 .horizontalHandle .handleIcon {
-    background: url("../images/handle-icon-horizontal.gif") center center
-        no-repeat;
+    background: url("${BASE_PATH}images/handle-icon-horizontal.gif") center
+        center no-repeat;
     font-size: 1px;
     height: 6px;
     line-height: 1px;
@@ -306,7 +306,8 @@ li.divider {
 }
 
 .columnHandle {
-    background: url("../images/handle-icon.gif") center center no-repeat;
+    background: url("${BASE_PATH}images/handle-icon.gif") center center
+        no-repeat;
     border: 1px solid var(--color-border-default);
     border-bottom: 0;
     border-top: 0;
@@ -329,7 +330,7 @@ li.divider {
 
 /* Have to specify div here for IE6's sake */
 div.toolbox.divider {
-    background: url("../images/toolbox-divider.gif") repeat-y;
+    background: url("${BASE_PATH}images/toolbox-divider.gif") repeat-y;
     padding-left: 8px;
 }
 
@@ -362,14 +363,14 @@ div.toolbox.divider {
 }
 
 #spinnerWrapper {
-    background: url("../images/spinner-placeholder.gif") no-repeat;
+    background: url("${BASE_PATH}images/spinner-placeholder.gif") no-repeat;
     height: 16px;
     margin: 4px 5px 0;
     width: 16px;
 }
 
 #spinner {
-    background: url("../images/spinner.gif") no-repeat;
+    background: url("${BASE_PATH}images/spinner.gif") no-repeat;
     display: none;
     height: 16px;
     width: 16px;

--- a/src/webui/www/private/css/Window.css
+++ b/src/webui/www/private/css/Window.css
@@ -175,7 +175,7 @@ div.mochaToolbarWrapper.bottom {
 }
 
 .mochaSpinner {
-    background: url("../images/spinner.gif") no-repeat;
+    background: url("${BASE_PATH}images/spinner.gif") no-repeat;
     bottom: 7px;
     display: none;
     height: 16px;
@@ -325,7 +325,7 @@ div.mochaToolbarWrapper.bottom {
 /* Example Window Themes */
 
 #about_contentWrapper {
-    background: #e5e5e5 url("../images/logo2.gif") 3px 3px no-repeat;
+    background: #e5e5e5 url("${BASE_PATH}images/logo2.gif") 3px 3px no-repeat;
 }
 
 #builder_contentWrapper {

--- a/src/webui/www/private/css/dynamicTable.css
+++ b/src/webui/www/private/css/dynamicTable.css
@@ -67,14 +67,14 @@
 }
 
 .dynamicTable th.sorted {
-    background-image: url("../images/go-up.svg");
+    background-image: url("${BASE_PATH}images/go-up.svg");
     background-position: right 3px center;
     background-repeat: no-repeat;
     background-size: 12px;
 }
 
 .dynamicTable th.sorted.reverse {
-    background-image: url("../images/go-down.svg");
+    background-image: url("${BASE_PATH}images/go-down.svg");
 }
 
 .dynamicTable span.flags {

--- a/src/webui/www/private/css/style.css
+++ b/src/webui/www/private/css/style.css
@@ -357,7 +357,7 @@ a.propButton img {
 }
 
 .contextMenu li:not(.disabled) .arrow-right {
-    background-image: url("../images/arrow-right.gif");
+    background-image: url("${BASE_PATH}images/arrow-right.gif");
     background-position: right center;
     background-repeat: no-repeat;
 }
@@ -408,7 +408,7 @@ a.propButton img {
 }
 
 .sliderarea {
-    background: #f2f2f2 url("../images/slider-area.gif") repeat-x;
+    background: #f2f2f2 url("${BASE_PATH}images/slider-area.gif") repeat-x;
     border: 1px solid #a3a3a3;
     border-bottom: 1px solid #ccc;
     border-left: 1px solid #ccc;
@@ -424,7 +424,7 @@ a.propButton img {
 }
 
 .sliderknob {
-    background: url("../images/knob.gif") no-repeat;
+    background: url("${BASE_PATH}images/knob.gif") no-repeat;
     cursor: pointer;
     font-size: 1px;
     height: 9px;
@@ -455,7 +455,7 @@ a.propButton img {
 }
 
 #mochaToolbar .divider {
-    background-image: url("../images/toolbox-divider.gif");
+    background-image: url("${BASE_PATH}images/toolbox-divider.gif");
     background-position: left center;
     background-repeat: no-repeat;
     padding-left: 14px;
@@ -478,7 +478,7 @@ a.propButton img {
 
 #torrentsFilterInput {
     background-color: var(--color-background-default);
-    background-image: url("../images/edit-find.svg");
+    background-image: url("${BASE_PATH}images/edit-find.svg");
     background-position: left;
     background-repeat: no-repeat;
     background-size: 1.5em;
@@ -493,7 +493,7 @@ a.propButton img {
 }
 
 #torrentsFilterRegexBox + label {
-    background-image: url("../images/regex.svg");
+    background-image: url("${BASE_PATH}images/regex.svg");
     background-position: center;
     background-repeat: no-repeat;
     background-size: 1.5em;
@@ -508,7 +508,7 @@ a.propButton img {
 
 #torrentsFilterRegexBox:checked + label {
     background-color: var(--color-background-default);
-    background-image: url("../images/regex.svg");
+    background-image: url("${BASE_PATH}images/regex.svg");
     background-position: center;
     background-repeat: no-repeat;
     background-size: 1.5em;
@@ -530,7 +530,7 @@ a.propButton img {
 }
 
 #torrentFilesFilterInput {
-    background-image: url("../images/edit-find.svg");
+    background-image: url("${BASE_PATH}images/edit-find.svg");
     background-position: left;
     background-repeat: no-repeat;
     background-size: 1.5em;
@@ -544,7 +544,7 @@ a.propButton img {
 /* Tri-state checkbox */
 
 label.tristate {
-    background: url("../images/3-state-checkbox.gif") 0 0 no-repeat;
+    background: url("${BASE_PATH}images/3-state-checkbox.gif") 0 0 no-repeat;
     display: block;
     float: left;
     height: 13px;
@@ -667,8 +667,8 @@ span.link :is(img, button) {
 }
 
 .categoryToggle {
-    background: url("../images/go-down.svg") center center / 10px no-repeat
-        transparent;
+    background: url("${BASE_PATH}images/go-down.svg") center center / 10px
+        no-repeat transparent;
     border: none;
     display: none;
     height: 16px;
@@ -796,7 +796,7 @@ td.generalLabel {
 }
 
 td.statusBarSeparator {
-    background-image: url("../images/toolbox-divider.gif");
+    background-image: url("${BASE_PATH}images/toolbox-divider.gif");
     background-position: center 1px;
     background-repeat: no-repeat;
     background-size: 2px 18px;
@@ -882,7 +882,7 @@ td.statusBarSeparator {
 }
 
 #rememberBtn {
-    background: url("../images/object-locked.svg") center center / 24px
+    background: url("${BASE_PATH}images/object-locked.svg") center center / 24px
         no-repeat var(--color-background-popup);
     height: 38px;
     padding: 4px 6px;
@@ -922,11 +922,12 @@ td.statusBarSeparator {
 
 .confirmWarning,
 .confirmDialogWarning {
-    background: url("../images/dialog-warning.svg") center center no-repeat;
+    background: url("${BASE_PATH}images/dialog-warning.svg") center center
+        no-repeat;
     height: 38px;
     width: 38px;
 }
 
 .confirmWarning {
-    background-image: url("../images/help-about.svg");
+    background-image: url("${BASE_PATH}images/help-about.svg");
 }

--- a/src/webui/www/private/download.html
+++ b/src/webui/www/private/download.html
@@ -4,20 +4,20 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(Add Torrent Links)QBT_TR[CONTEXT=downloadFromURL]</title>
-    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <link rel="stylesheet" href="css/Window.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
-    <script src="scripts/download.js?v=${CACHEID}"></script>
-    <script src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
-    <script src="scripts/pathAutofill.js?v=${CACHEID}"></script>
+    <link rel="stylesheet" href="${BASE_PATH}css/style.css?v=${CACHEID}" type="text/css">
+    <link rel="stylesheet" href="${BASE_PATH}css/Window.css?v=${CACHEID}" type="text/css">
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/download.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/pathAutofill.js?v=${CACHEID}"></script>
 </head>
 
 <body>
     <iframe id="download_frame" name="download_frame" class="invisible" title="" src="about:blank"></iframe>
-    <form action="api/v2/torrents/add" enctype="multipart/form-data" method="post" id="downloadForm" style="text-align: center;" target="download_frame" autocorrect="off" autocapitalize="none">
+    <form action="${BASE_PATH}api/v2/torrents/add" enctype="multipart/form-data" method="post" id="downloadForm" style="text-align: center;" target="download_frame" autocorrect="off" autocapitalize="none">
         <div style="text-align: center;">
             <br>
             <h2><label for="urls">QBT_TR(Add torrent links)QBT_TR[CONTEXT=AddNewTorrentDialog]</label></h2>

--- a/src/webui/www/private/downloadlimit.html
+++ b/src/webui/www/private/downloadlimit.html
@@ -4,13 +4,13 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(Torrent Download Speed Limiting)QBT_TR[CONTEXT=TransferListWidget]</title>
-    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/mocha.min.js"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
-    <script src="scripts/speedslider.js?v=${CACHEID}"></script>
+    <link rel="stylesheet" href="${BASE_PATH}css/style.css?v=${CACHEID}" type="text/css">
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/mocha.min.js"></script>
+    <script src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/speedslider.js?v=${CACHEID}"></script>
 </head>
 
 <body>
@@ -38,7 +38,7 @@
             const limit = Number($("dllimitUpdatevalue").value) * 1024;
             if (hashes[0] === "global") {
                 new Request({
-                    url: "api/v2/transfer/setDownloadLimit",
+                    url: "${BASE_PATH}api/v2/transfer/setDownloadLimit",
                     method: "post",
                     data: {
                         "limit": limit
@@ -51,7 +51,7 @@
             }
             else {
                 new Request({
-                    url: "api/v2/torrents/setDownloadLimit",
+                    url: "${BASE_PATH}api/v2/torrents/setDownloadLimit",
                     method: "post",
                     data: {
                         "hashes": hashes.join("|"),

--- a/src/webui/www/private/editfeedurl.html
+++ b/src/webui/www/private/editfeedurl.html
@@ -4,12 +4,12 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(Please type a RSS feed URL)QBT_TR[CONTEXT=RSSWidget]</title>
-    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
-    <script src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
+    <link rel="stylesheet" href="${BASE_PATH}css/style.css?v=${CACHEID}" type="text/css">
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
     <script>
         "use strict";
 
@@ -57,7 +57,7 @@
                 $("submitButton").disabled = true;
 
                 new Request({
-                    url: "api/v2/rss/setFeedURL",
+                    url: "${BASE_PATH}api/v2/rss/setFeedURL",
                     method: "post",
                     data: {
                         path: new URI().getData("path"),

--- a/src/webui/www/private/edittracker.html
+++ b/src/webui/www/private/edittracker.html
@@ -4,11 +4,11 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(Tracker editing)QBT_TR[CONTEXT=TrackerListWidget]</title>
-    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <link rel="stylesheet" href="${BASE_PATH}css/style.css?v=${CACHEID}" type="text/css">
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 
@@ -44,7 +44,7 @@
 
                 const hash = new URI().getData("hash");
                 new Request({
-                    url: "api/v2/torrents/editTracker",
+                    url: "${BASE_PATH}api/v2/torrents/editTracker",
                     method: "post",
                     data: {
                         hash: hash,

--- a/src/webui/www/private/editwebseed.html
+++ b/src/webui/www/private/editwebseed.html
@@ -4,11 +4,11 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(Edit web seed)QBT_TR[CONTEXT=HttpServer]</title>
-    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
+    <link rel="stylesheet" href="${BASE_PATH}css/style.css?v=${CACHEID}" type="text/css">
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 
@@ -39,7 +39,7 @@
                 e.stopPropagation();
                 const hash = new URI().getData("hash");
                 new Request({
-                    url: "api/v2/torrents/editWebSeed",
+                    url: "${BASE_PATH}api/v2/torrents/editWebSeed",
                     method: "post",
                     data: {
                         hash: hash,

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -11,36 +11,36 @@
 
     <title>qBittorrent WebUI</title>
 
-    <link rel="icon" type="image/png" href="images/qbittorrent32.png" sizes="32x32">
-    <link rel="icon" type="image/svg+xml" href="images/qbittorrent-tray.svg" sizes="any">
-    <link rel="stylesheet" type="text/css" href="css/dynamicTable.css?v=${CACHEID}">
-    <link rel="stylesheet" type="text/css" href="css/style.css?v=${CACHEID}">
-    <link rel="stylesheet" type="text/css" href="css/Core.css?v=${CACHEID}">
-    <link rel="stylesheet" type="text/css" href="css/Layout.css?v=${CACHEID}">
-    <link rel="stylesheet" type="text/css" href="css/Window.css?v=${CACHEID}">
-    <link rel="stylesheet" type="text/css" href="css/Tabs.css?v=${CACHEID}">
+    <link rel="icon" type="image/png" href="${BASE_PATH}images/qbittorrent32.png" sizes="32x32">
+    <link rel="icon" type="image/svg+xml" href="${BASE_PATH}images/qbittorrent-tray.svg" sizes="any">
+    <link rel="stylesheet" type="text/css" href="${BASE_PATH}css/dynamicTable.css?v=${CACHEID}">
+    <link rel="stylesheet" type="text/css" href="${BASE_PATH}css/style.css?v=${CACHEID}">
+    <link rel="stylesheet" type="text/css" href="${BASE_PATH}css/Core.css?v=${CACHEID}">
+    <link rel="stylesheet" type="text/css" href="${BASE_PATH}css/Layout.css?v=${CACHEID}">
+    <link rel="stylesheet" type="text/css" href="${BASE_PATH}css/Window.css?v=${CACHEID}">
+    <link rel="stylesheet" type="text/css" href="${BASE_PATH}css/Tabs.css?v=${CACHEID}">
     <noscript>
-        <link rel="stylesheet" type="text/css" href="css/noscript.css?v=${CACHEID}">
+        <link rel="stylesheet" type="text/css" href="${BASE_PATH}css/noscript.css?v=${CACHEID}">
     </noscript>
 
-    <script defer src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script defer src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script defer src="scripts/lib/mocha.min.js"></script>
-    <script defer src="scripts/cache.js?v=${CACHEID}"></script>
-    <script defer src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script defer src="scripts/color-scheme.js?v=${CACHEID}"></script>
-    <script defer src="scripts/mocha-init.js?locale=${LANG}&v=${CACHEID}"></script>
-    <script defer src="scripts/lib/clipboard.min.js"></script>
-    <script defer src="scripts/filesystem.js?v=${CACHEID}"></script>
-    <script defer src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
-    <script defer src="scripts/progressbar.js?v=${CACHEID}"></script>
-    <script defer src="scripts/piecesbar.js?v=${CACHEID}"></script>
-    <script defer src="scripts/file-tree.js?v=${CACHEID}"></script>
-    <script defer src="scripts/dynamicTable.js?locale=${LANG}&v=${CACHEID}"></script>
-    <script defer src="scripts/rename-files.js?v=${CACHEID}"></script>
-    <script defer src="scripts/client.js?locale=${LANG}&v=${CACHEID}"></script>
-    <script defer src="scripts/contextmenu.js?locale=${LANG}&v=${CACHEID}"></script>
-    <script defer src="scripts/pathAutofill.js?v=${CACHEID}"></script>
+    <script defer src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script defer src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script defer src="${BASE_PATH}scripts/lib/mocha.min.js"></script>
+    <script defer src="${BASE_PATH}scripts/cache.js?v=${CACHEID}"></script>
+    <script defer src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script defer src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script defer src="${BASE_PATH}scripts/mocha-init.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script defer src="${BASE_PATH}scripts/lib/clipboard.min.js"></script>
+    <script defer src="${BASE_PATH}scripts/filesystem.js?v=${CACHEID}"></script>
+    <script defer src="${BASE_PATH}scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script defer src="${BASE_PATH}scripts/progressbar.js?v=${CACHEID}"></script>
+    <script defer src="${BASE_PATH}scripts/piecesbar.js?v=${CACHEID}"></script>
+    <script defer src="${BASE_PATH}scripts/file-tree.js?v=${CACHEID}"></script>
+    <script defer src="${BASE_PATH}scripts/dynamicTable.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script defer src="${BASE_PATH}scripts/rename-files.js?v=${CACHEID}"></script>
+    <script defer src="${BASE_PATH}scripts/client.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script defer src="${BASE_PATH}scripts/contextmenu.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script defer src="${BASE_PATH}scripts/pathAutofill.js?v=${CACHEID}"></script>
 </head>
 
 <body>
@@ -57,84 +57,84 @@
                     <li>
                         <a class="returnFalse">QBT_TR(File)QBT_TR[CONTEXT=MainWindow]</a>
                         <ul>
-                            <li><a id="uploadLink"><img class="MyMenuIcon" alt="QBT_TR(Add Torrent File...)QBT_TR[CONTEXT=MainWindow]" src="images/list-add.svg" width="16" height="16">QBT_TR(Add Torrent File...)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li><a id="downloadLink"><img class="MyMenuIcon" alt="QBT_TR(Add Torrent Link...)QBT_TR[CONTEXT=MainWindow]" src="images/insert-link.svg" width="16" height="16">QBT_TR(Add Torrent Link...)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li class="divider"><a id="logoutLink"><img class="MyMenuIcon" alt="QBT_TR(Logout)QBT_TR[CONTEXT=HttpServer]" src="images/system-log-out.svg" width="16" height="16">QBT_TR(Logout)QBT_TR[CONTEXT=HttpServer]</a></li>
-                            <li><a id="shutdownLink"><img class="MyMenuIcon" alt="QBT_TR(Exit qBittorrent)QBT_TR[CONTEXT=HttpServer]" src="images/application-exit.svg" width="16" height="16">QBT_TR(Exit qBittorrent)QBT_TR[CONTEXT=HttpServer]</a></li>
+                            <li><a id="uploadLink"><img class="MyMenuIcon" alt="QBT_TR(Add Torrent File...)QBT_TR[CONTEXT=MainWindow]" src="${BASE_PATH}images/list-add.svg" width="16" height="16">QBT_TR(Add Torrent File...)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li><a id="downloadLink"><img class="MyMenuIcon" alt="QBT_TR(Add Torrent Link...)QBT_TR[CONTEXT=MainWindow]" src="${BASE_PATH}images/insert-link.svg" width="16" height="16">QBT_TR(Add Torrent Link...)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li class="divider"><a id="logoutLink"><img class="MyMenuIcon" alt="QBT_TR(Logout)QBT_TR[CONTEXT=HttpServer]" src="${BASE_PATH}images/system-log-out.svg" width="16" height="16">QBT_TR(Logout)QBT_TR[CONTEXT=HttpServer]</a></li>
+                            <li><a id="shutdownLink"><img class="MyMenuIcon" alt="QBT_TR(Exit qBittorrent)QBT_TR[CONTEXT=HttpServer]" src="${BASE_PATH}images/application-exit.svg" width="16" height="16">QBT_TR(Exit qBittorrent)QBT_TR[CONTEXT=HttpServer]</a></li>
                         </ul>
                     </li>
                     <li>
                         <a class="returnFalse">QBT_TR(Edit)QBT_TR[CONTEXT=MainWindow]</a>
                         <ul>
-                            <li><a id="startLink"><img class="MyMenuIcon" alt="QBT_TR(Start)QBT_TR[CONTEXT=MainWindow]" src="images/torrent-start.svg" width="16" height="16">QBT_TR(Start)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li><a id="stopLink"><img class="MyMenuIcon" src="images/torrent-stop.svg" alt="QBT_TR(Stop)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Stop)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li><a id="startAllLink"><img class="MyMenuIcon" alt="QBT_TR(Start All)QBT_TR[CONTEXT=MainWindow]" src="images/torrent-start.svg" width="16" height="16">QBT_TR(Start All)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li><a id="stopAllLink"><img class="MyMenuIcon" alt="QBT_TR(Stop All)QBT_TR[CONTEXT=MainWindow]" src="images/torrent-stop.svg" width="16" height="16">QBT_TR(Stop All)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li class="divider"><a id="deleteLink"><img class="MyMenuIcon" src="images/list-remove.svg" alt="QBT_TR(Remove)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Remove)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li id="topQueuePosItem" class="divider"><a id="topPrioLink"><img class="MyMenuIcon" src="images/go-top.svg" alt="QBT_TR(Top of Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Top of Queue)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li id="increaseQueuePosItem"><a id="increasePrioLink"><img class="MyMenuIcon" src="images/go-up.svg" alt="QBT_TR(Move Up Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Move Up Queue)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li id="decreaseQueuePosItem"><a id="decreasePrioLink"><img class="MyMenuIcon" src="images/go-down.svg" alt="QBT_TR(Move Down Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Move Down Queue)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li id="bottomQueuePosItem"><a id="bottomPrioLink"><img class="MyMenuIcon" src="images/go-bottom.svg" alt="QBT_TR(Bottom of Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Bottom of Queue)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li><a id="startLink"><img class="MyMenuIcon" alt="QBT_TR(Start)QBT_TR[CONTEXT=MainWindow]" src="${BASE_PATH}images/torrent-start.svg" width="16" height="16">QBT_TR(Start)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li><a id="stopLink"><img class="MyMenuIcon" src="${BASE_PATH}images/torrent-stop.svg" alt="QBT_TR(Stop)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Stop)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li><a id="startAllLink"><img class="MyMenuIcon" alt="QBT_TR(Start All)QBT_TR[CONTEXT=MainWindow]" src="${BASE_PATH}images/torrent-start.svg" width="16" height="16">QBT_TR(Start All)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li><a id="stopAllLink"><img class="MyMenuIcon" alt="QBT_TR(Stop All)QBT_TR[CONTEXT=MainWindow]" src="${BASE_PATH}images/torrent-stop.svg" width="16" height="16">QBT_TR(Stop All)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li class="divider"><a id="deleteLink"><img class="MyMenuIcon" src="${BASE_PATH}images/list-remove.svg" alt="QBT_TR(Remove)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Remove)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li id="topQueuePosItem" class="divider"><a id="topPrioLink"><img class="MyMenuIcon" src="${BASE_PATH}images/go-top.svg" alt="QBT_TR(Top of Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Top of Queue)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li id="increaseQueuePosItem"><a id="increasePrioLink"><img class="MyMenuIcon" src="${BASE_PATH}images/go-up.svg" alt="QBT_TR(Move Up Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Move Up Queue)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li id="decreaseQueuePosItem"><a id="decreasePrioLink"><img class="MyMenuIcon" src="${BASE_PATH}images/go-down.svg" alt="QBT_TR(Move Down Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Move Down Queue)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li id="bottomQueuePosItem"><a id="bottomPrioLink"><img class="MyMenuIcon" src="${BASE_PATH}images/go-bottom.svg" alt="QBT_TR(Bottom of Queue)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Bottom of Queue)QBT_TR[CONTEXT=MainWindow]</a></li>
                         </ul>
                     </li>
                     <li>
                         <a class="returnFalse">QBT_TR(View)QBT_TR[CONTEXT=MainWindow]</a>
                         <ul>
-                            <li><a id="showTopToolbarLink"><img class="MyMenuIcon" src="images/checked-completed.svg" alt="QBT_TR(Top Toolbar)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Top Toolbar)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li><a id="showStatusBarLink"><img class="MyMenuIcon" src="images/checked-completed.svg" alt="QBT_TR(Status Bar)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Status Bar)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li><a id="showFiltersSidebarLink"><img class="MyMenuIcon" src="images/checked-completed.svg" alt="QBT_TR(Filters Sidebar)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Filters Sidebar)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li><a id="speedInBrowserTitleBarLink"><img class="MyMenuIcon" src="images/checked-completed.svg" alt="QBT_TR(Speed in Title Bar)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Speed in Title Bar)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li class="divider"><a id="showSearchEngineLink"><img class="MyMenuIcon" src="images/checked-completed.svg" alt="QBT_TR(Search Engine)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Search Engine)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li><a id="showRssReaderLink"><img class="MyMenuIcon" src="images/checked-completed.svg" alt="QBT_TR(RSS)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(RSS Reader)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li><a id="showLogViewerLink"><img class="MyMenuIcon" src="images/checked-completed.svg" alt="QBT_TR(Log)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Log)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li class="divider"><a id="StatisticsLink"><img class="MyMenuIcon" src="images/view-statistics.svg" alt="QBT_TR(Statistics)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Statistics)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li><a id="showTopToolbarLink"><img class="MyMenuIcon" src="${BASE_PATH}images/checked-completed.svg" alt="QBT_TR(Top Toolbar)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Top Toolbar)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li><a id="showStatusBarLink"><img class="MyMenuIcon" src="${BASE_PATH}images/checked-completed.svg" alt="QBT_TR(Status Bar)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Status Bar)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li><a id="showFiltersSidebarLink"><img class="MyMenuIcon" src="${BASE_PATH}images/checked-completed.svg" alt="QBT_TR(Filters Sidebar)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Filters Sidebar)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li><a id="speedInBrowserTitleBarLink"><img class="MyMenuIcon" src="${BASE_PATH}images/checked-completed.svg" alt="QBT_TR(Speed in Title Bar)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Speed in Title Bar)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li class="divider"><a id="showSearchEngineLink"><img class="MyMenuIcon" src="${BASE_PATH}images/checked-completed.svg" alt="QBT_TR(Search Engine)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Search Engine)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li><a id="showRssReaderLink"><img class="MyMenuIcon" src="${BASE_PATH}images/checked-completed.svg" alt="QBT_TR(RSS)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(RSS Reader)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li><a id="showLogViewerLink"><img class="MyMenuIcon" src="${BASE_PATH}images/checked-completed.svg" alt="QBT_TR(Log)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Log)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li class="divider"><a id="StatisticsLink"><img class="MyMenuIcon" src="${BASE_PATH}images/view-statistics.svg" alt="QBT_TR(Statistics)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Statistics)QBT_TR[CONTEXT=MainWindow]</a></li>
                         </ul>
                     </li>
                     <li>
                         <a class="returnFalse">QBT_TR(Tools)QBT_TR[CONTEXT=MainWindow]</a>
                         <ul>
-                            <li><a id="preferencesLink"><img class="MyMenuIcon" src="images/configure.svg" alt="QBT_TR(Options...)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Options...)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li><a id="registerMagnetHandlerLink"><img class="MyMenuIcon" src="images/torrent-magnet.svg" alt="QBT_TR(Register to handle magnet links...)QBT_TR[CONTEXT=HttpServer]" width="16" height="16">QBT_TR(Register to handle magnet links...)QBT_TR[CONTEXT=HttpServer]</a></li>
-                            <li><a id="manageCookiesLink"><img class="MyMenuIcon" src="images/browser-cookies.svg" alt="QBT_TR(Manage Cookies...)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Manage Cookies...)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li><a id="preferencesLink"><img class="MyMenuIcon" src="${BASE_PATH}images/configure.svg" alt="QBT_TR(Options...)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Options...)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li><a id="registerMagnetHandlerLink"><img class="MyMenuIcon" src="${BASE_PATH}images/torrent-magnet.svg" alt="QBT_TR(Register to handle magnet links...)QBT_TR[CONTEXT=HttpServer]" width="16" height="16">QBT_TR(Register to handle magnet links...)QBT_TR[CONTEXT=HttpServer]</a></li>
+                            <li><a id="manageCookiesLink"><img class="MyMenuIcon" src="${BASE_PATH}images/browser-cookies.svg" alt="QBT_TR(Manage Cookies...)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Manage Cookies...)QBT_TR[CONTEXT=MainWindow]</a></li>
                         </ul>
                     </li>
                     <li>
                         <a class="returnFalse">QBT_TR(Help)QBT_TR[CONTEXT=MainWindow]</a>
                         <ul>
-                            <li><a id="docsLink" target="_blank" href="https://wiki.qbittorrent.org/"><img class="MyMenuIcon" src="images/help-contents.svg" alt="QBT_TR(Documentation)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Documentation)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li class="divider"><a id="bugLink" target="_blank" href="https://www.qbittorrent.org/donate"><img class="MyMenuIcon" src="images/wallet-open.svg" alt="QBT_TR(Donate!)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Donate!)QBT_TR[CONTEXT=MainWindow]</a></li>
-                            <li><a id="aboutLink"><img class="MyMenuIcon" src="images/help-about.svg" alt="QBT_TR(About)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(About)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li><a id="docsLink" target="_blank" href="https://wiki.qbittorrent.org/"><img class="MyMenuIcon" src="${BASE_PATH}images/help-contents.svg" alt="QBT_TR(Documentation)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Documentation)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li class="divider"><a id="bugLink" target="_blank" href="https://www.qbittorrent.org/donate"><img class="MyMenuIcon" src="${BASE_PATH}images/wallet-open.svg" alt="QBT_TR(Donate!)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(Donate!)QBT_TR[CONTEXT=MainWindow]</a></li>
+                            <li><a id="aboutLink"><img class="MyMenuIcon" src="${BASE_PATH}images/help-about.svg" alt="QBT_TR(About)QBT_TR[CONTEXT=MainWindow]" width="16" height="16">QBT_TR(About)QBT_TR[CONTEXT=MainWindow]</a></li>
                         </ul>
                     </li>
                 </ul>
             </div>
             <div id="mochaToolbar">
                 &nbsp;&nbsp;
-                <a id="downloadButton"><img class="mochaToolButton" title="QBT_TR(Add Torrent Link...)QBT_TR[CONTEXT=MainWindow]" src="images/insert-link.svg" alt="QBT_TR(Add Torrent Link...)QBT_TR[CONTEXT=MainWindow]" width="24" height="24"></a>
-                <a id="uploadButton"><img class="mochaToolButton" title="QBT_TR(Add Torrent File...)QBT_TR[CONTEXT=MainWindow]" src="images/list-add.svg" alt="QBT_TR(Add Torrent File...)QBT_TR[CONTEXT=MainWindow]" width="24" height="24"></a>
-                <a id="deleteButton"><img class="mochaToolButton" title="QBT_TR(Remove)QBT_TR[CONTEXT=TransferListWidget]" src="images/list-remove.svg" alt="QBT_TR(Remove)QBT_TR[CONTEXT=TransferListWidget]" width="24" height="24"></a>
-                <a id="startButton" class="divider"><img class="mochaToolButton" title="QBT_TR(Start)QBT_TR[CONTEXT=TransferListWidget]" src="images/torrent-start.svg" alt="QBT_TR(Start)QBT_TR[CONTEXT=TransferListWidget]" width="24" height="24"></a>
-                <a id="stopButton"><img class="mochaToolButton" title="QBT_TR(Stop)QBT_TR[CONTEXT=TransferListWidget]" src="images/torrent-stop.svg" alt="QBT_TR(Stop)QBT_TR[CONTEXT=TransferListWidget]" width="24" height="24"></a>
+                <a id="downloadButton"><img class="mochaToolButton" title="QBT_TR(Add Torrent Link...)QBT_TR[CONTEXT=MainWindow]" src="${BASE_PATH}images/insert-link.svg" alt="QBT_TR(Add Torrent Link...)QBT_TR[CONTEXT=MainWindow]" width="24" height="24"></a>
+                <a id="uploadButton"><img class="mochaToolButton" title="QBT_TR(Add Torrent File...)QBT_TR[CONTEXT=MainWindow]" src="${BASE_PATH}images/list-add.svg" alt="QBT_TR(Add Torrent File...)QBT_TR[CONTEXT=MainWindow]" width="24" height="24"></a>
+                <a id="deleteButton"><img class="mochaToolButton" title="QBT_TR(Remove)QBT_TR[CONTEXT=TransferListWidget]" src="${BASE_PATH}images/list-remove.svg" alt="QBT_TR(Remove)QBT_TR[CONTEXT=TransferListWidget]" width="24" height="24"></a>
+                <a id="startButton" class="divider"><img class="mochaToolButton" title="QBT_TR(Start)QBT_TR[CONTEXT=TransferListWidget]" src="${BASE_PATH}images/torrent-start.svg" alt="QBT_TR(Start)QBT_TR[CONTEXT=TransferListWidget]" width="24" height="24"></a>
+                <a id="stopButton"><img class="mochaToolButton" title="QBT_TR(Stop)QBT_TR[CONTEXT=TransferListWidget]" src="${BASE_PATH}images/torrent-stop.svg" alt="QBT_TR(Stop)QBT_TR[CONTEXT=TransferListWidget]" width="24" height="24"></a>
                 <span id="queueingButtons">
-                    <a id="topPrioButton" class="divider"><img class="mochaToolButton" title="QBT_TR(Move to the top of the queue)QBT_TR[CONTEXT=MainWindow]" src="images/go-top.svg" alt="QBT_TR(Top of Queue)QBT_TR[CONTEXT=MainWindow]" width="24" height="24"></a>
-                    <a id="increasePrioButton"><img class="mochaToolButton" title="QBT_TR(Move up in the queue)QBT_TR[CONTEXT=MainWindow]" src="images/go-up.svg" alt="QBT_TR(Move Up Queue)QBT_TR[CONTEXT=MainWindow]" width="24" height="24"></a>
-                    <a id="decreasePrioButton"><img class="mochaToolButton" title="QBT_TR(Move down in the queue)QBT_TR[CONTEXT=MainWindow]" src="images/go-down.svg" alt="QBT_TR(Move Down Queue)QBT_TR[CONTEXT=MainWindow]" width="24" height="24"></a>
-                    <a id="bottomPrioButton"><img class="mochaToolButton" title="QBT_TR(Move to the bottom of the queue)QBT_TR[CONTEXT=MainWindow]" src="images/go-bottom.svg" alt="QBT_TR(Bottom of Queue)QBT_TR[CONTEXT=MainWindow]" width="24" height="24"></a>
+                    <a id="topPrioButton" class="divider"><img class="mochaToolButton" title="QBT_TR(Move to the top of the queue)QBT_TR[CONTEXT=MainWindow]" src="${BASE_PATH}images/go-top.svg" alt="QBT_TR(Top of Queue)QBT_TR[CONTEXT=MainWindow]" width="24" height="24"></a>
+                    <a id="increasePrioButton"><img class="mochaToolButton" title="QBT_TR(Move up in the queue)QBT_TR[CONTEXT=MainWindow]" src="${BASE_PATH}images/go-up.svg" alt="QBT_TR(Move Up Queue)QBT_TR[CONTEXT=MainWindow]" width="24" height="24"></a>
+                    <a id="decreasePrioButton"><img class="mochaToolButton" title="QBT_TR(Move down in the queue)QBT_TR[CONTEXT=MainWindow]" src="${BASE_PATH}images/go-down.svg" alt="QBT_TR(Move Down Queue)QBT_TR[CONTEXT=MainWindow]" width="24" height="24"></a>
+                    <a id="bottomPrioButton"><img class="mochaToolButton" title="QBT_TR(Move to the bottom of the queue)QBT_TR[CONTEXT=MainWindow]" src="${BASE_PATH}images/go-bottom.svg" alt="QBT_TR(Bottom of Queue)QBT_TR[CONTEXT=MainWindow]" width="24" height="24"></a>
                 </span>
-                <a id="preferencesButton" class="divider"><img class="mochaToolButton" title="QBT_TR(Options)QBT_TR[CONTEXT=OptionsDialog]" src="images/configure.svg" alt="QBT_TR(Options)QBT_TR[CONTEXT=OptionsDialog]" width="24" height="24"></a>
+                <a id="preferencesButton" class="divider"><img class="mochaToolButton" title="QBT_TR(Options)QBT_TR[CONTEXT=OptionsDialog]" src="${BASE_PATH}images/configure.svg" alt="QBT_TR(Options)QBT_TR[CONTEXT=OptionsDialog]" width="24" height="24"></a>
                 <div id="mainWindowTabs" class="toolbarTabs">
                     <menu id="mainWindowTabsList" class="tab-menu">
                         <li id="transfersTabLink" class="selected">
-                            <a><img alt="QBT_TR(Transfers)QBT_TR[CONTEXT=MainWindow]" src="images/filter-all.svg" width="16" height="16">QBT_TR(Transfers)QBT_TR[CONTEXT=MainWindow]</a>
+                            <a><img alt="QBT_TR(Transfers)QBT_TR[CONTEXT=MainWindow]" src="${BASE_PATH}images/filter-all.svg" width="16" height="16">QBT_TR(Transfers)QBT_TR[CONTEXT=MainWindow]</a>
                         </li>
                         <li id="searchTabLink">
-                            <a><img alt="QBT_TR(Search)QBT_TR[CONTEXT=MainWindow]" src="images/edit-find.svg" width="16" height="16">QBT_TR(Search)QBT_TR[CONTEXT=MainWindow]</a>
+                            <a><img alt="QBT_TR(Search)QBT_TR[CONTEXT=MainWindow]" src="${BASE_PATH}images/edit-find.svg" width="16" height="16">QBT_TR(Search)QBT_TR[CONTEXT=MainWindow]</a>
                         </li>
                         <li id="rssTabLink">
-                            <a><img alt="QBT_TR(RSS)QBT_TR[CONTEXT=MainWindow]" src="images/application-rss.svg" width="16" height="16">QBT_TR(RSS)QBT_TR[CONTEXT=MainWindow]</a>
+                            <a><img alt="QBT_TR(RSS)QBT_TR[CONTEXT=MainWindow]" src="${BASE_PATH}images/application-rss.svg" width="16" height="16">QBT_TR(RSS)QBT_TR[CONTEXT=MainWindow]</a>
                         </li>
                         <li id="logTabLink">
-                            <a><img alt="QBT_TR(Execution Log)QBT_TR[CONTEXT=MainWindow]" src="images/help-contents.svg" width="16" height="16">QBT_TR(Execution Log)QBT_TR[CONTEXT=MainWindow]</a>
+                            <a><img alt="QBT_TR(Execution Log)QBT_TR[CONTEXT=MainWindow]" src="${BASE_PATH}images/help-contents.svg" width="16" height="16">QBT_TR(Execution Log)QBT_TR[CONTEXT=MainWindow]</a>
                         </li>
                     </menu>
                     <div class="clear"></div>
@@ -155,110 +155,110 @@
         </div>
     </div>
     <ul id="torrentsTableMenu" class="contextMenu">
-        <li><a href="#start"><img src="images/torrent-start.svg" alt="QBT_TR(Start)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Start)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-        <li><a href="#stop"><img src="images/torrent-stop.svg" alt="QBT_TR(Stop)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Stop)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-        <li><a href="#forceStart"><img src="images/torrent-start-forced.svg" alt="QBT_TR(Force Start)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Force Start)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-        <li class="separator"><a href="#delete"><img src="images/list-remove.svg" alt="QBT_TR(Remove)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Remove)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li><a href="#start"><img src="${BASE_PATH}images/torrent-start.svg" alt="QBT_TR(Start)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Start)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li><a href="#stop"><img src="${BASE_PATH}images/torrent-stop.svg" alt="QBT_TR(Stop)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Stop)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li><a href="#forceStart"><img src="${BASE_PATH}images/torrent-start-forced.svg" alt="QBT_TR(Force Start)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Force Start)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li class="separator"><a href="#delete"><img src="${BASE_PATH}images/list-remove.svg" alt="QBT_TR(Remove)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Remove)QBT_TR[CONTEXT=TransferListWidget]</a></li>
         <li class="separator">
-            <a href="#setLocation"><img src="images/set-location.svg" alt="QBT_TR(Set location...)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Set location...)QBT_TR[CONTEXT=TransferListWidget]</a>
+            <a href="#setLocation"><img src="${BASE_PATH}images/set-location.svg" alt="QBT_TR(Set location...)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Set location...)QBT_TR[CONTEXT=TransferListWidget]</a>
         </li>
         <li>
-            <a href="#rename"><img src="images/edit-rename.svg" alt="QBT_TR(Rename...)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Rename...)QBT_TR[CONTEXT=TransferListWidget]</a>
+            <a href="#rename"><img src="${BASE_PATH}images/edit-rename.svg" alt="QBT_TR(Rename...)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Rename...)QBT_TR[CONTEXT=TransferListWidget]</a>
         </li>
         <li>
-            <a href="#renameFiles"><img src="images/edit-rename.svg" alt="QBT_TR(Rename Files...)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Rename Files...)QBT_TR[CONTEXT=TransferListWidget]</a>
+            <a href="#renameFiles"><img src="${BASE_PATH}images/edit-rename.svg" alt="QBT_TR(Rename Files...)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Rename Files...)QBT_TR[CONTEXT=TransferListWidget]</a>
         </li>
         <li>
-            <a href="#Category" class="arrow-right"><img src="images/view-categories.svg" alt="QBT_TR(Category)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Category)QBT_TR[CONTEXT=TransferListWidget]</a>
+            <a href="#Category" class="arrow-right"><img src="${BASE_PATH}images/view-categories.svg" alt="QBT_TR(Category)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Category)QBT_TR[CONTEXT=TransferListWidget]</a>
             <ul id="contextCategoryList" class="scrollableMenu"></ul>
         </li>
         <li>
-            <a href="#Tags" class="arrow-right"><img src="images/tags.svg" alt="QBT_TR(Tags)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Tags)QBT_TR[CONTEXT=TransferListWidget]</a>
+            <a href="#Tags" class="arrow-right"><img src="${BASE_PATH}images/tags.svg" alt="QBT_TR(Tags)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Tags)QBT_TR[CONTEXT=TransferListWidget]</a>
             <ul id="contextTagList" class="scrollableMenu"></ul>
         </li>
         <li title="QBT_TR(Automatic mode means that various torrent properties(eg save path) will be decided by the associated category)QBT_TR[CONTEXT=TransferListWidget]">
-            <a href="#autoTorrentManagement"><img src="images/checked-completed.svg" alt="QBT_TR(Automatic Torrent Management)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Automatic Torrent Management)QBT_TR[CONTEXT=TransferListWidget]</a>
+            <a href="#autoTorrentManagement"><img src="${BASE_PATH}images/checked-completed.svg" alt="QBT_TR(Automatic Torrent Management)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Automatic Torrent Management)QBT_TR[CONTEXT=TransferListWidget]</a>
         </li>
-        <li class="separator"><a href="#downloadLimit"><img src="images/download.svg" alt="QBT_TR(Limit download rate...)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Limit download rate...)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-        <li><a href="#uploadLimit"><img src="images/upload.svg" alt="QBT_TR(Limit upload rate...)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Limit upload rate...)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-        <li><a href="#shareRatio"><img src="images/ratio.svg" alt="QBT_TR(Limit share ratio...)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Limit share ratio...)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-        <li><a href="#superSeeding"><img src="images/checked-completed.svg" alt="QBT_TR(Super seeding mode)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Super seeding mode)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-        <li class="separator"><a href="#sequentialDownload"><img src="images/checked-completed.svg" alt="QBT_TR(Download in sequential order)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Download in sequential order)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-        <li><a href="#firstLastPiecePrio"><img src="images/checked-completed.svg" alt="QBT_TR(Download first and last pieces first)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Download first and last pieces first)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-        <li class="separator"><a href="#forceRecheck"><img src="images/force-recheck.svg" alt="QBT_TR(Force recheck)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Force recheck)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-        <li><a href="#forceReannounce"><img src="images/reannounce.svg" alt="QBT_TR(Force reannounce)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Force reannounce)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li class="separator"><a href="#downloadLimit"><img src="${BASE_PATH}images/download.svg" alt="QBT_TR(Limit download rate...)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Limit download rate...)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li><a href="#uploadLimit"><img src="${BASE_PATH}images/upload.svg" alt="QBT_TR(Limit upload rate...)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Limit upload rate...)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li><a href="#shareRatio"><img src="${BASE_PATH}images/ratio.svg" alt="QBT_TR(Limit share ratio...)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Limit share ratio...)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li><a href="#superSeeding"><img src="${BASE_PATH}images/checked-completed.svg" alt="QBT_TR(Super seeding mode)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Super seeding mode)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li class="separator"><a href="#sequentialDownload"><img src="${BASE_PATH}images/checked-completed.svg" alt="QBT_TR(Download in sequential order)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Download in sequential order)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li><a href="#firstLastPiecePrio"><img src="${BASE_PATH}images/checked-completed.svg" alt="QBT_TR(Download first and last pieces first)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Download first and last pieces first)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li class="separator"><a href="#forceRecheck"><img src="${BASE_PATH}images/force-recheck.svg" alt="QBT_TR(Force recheck)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Force recheck)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+        <li><a href="#forceReannounce"><img src="${BASE_PATH}images/reannounce.svg" alt="QBT_TR(Force reannounce)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Force reannounce)QBT_TR[CONTEXT=TransferListWidget]</a></li>
         <li id="queueingMenuItems" class="separator">
             <a href="#queue" class="arrow-right"><span style="display: inline-block; width:16px"></span> QBT_TR(Queue)QBT_TR[CONTEXT=TransferListWidget]</a>
             <ul>
-                <li><a href="#queueTop"><img src="images/go-top.svg" alt="QBT_TR(Move to top)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Move to top)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-                <li><a href="#queueUp"><img src="images/go-up.svg" alt="QBT_TR(Move up)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Move up)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-                <li><a href="#queueDown"><img src="images/go-down.svg" alt="QBT_TR(Move down)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Move down)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-                <li><a href="#queueBottom"><img src="images/go-bottom.svg" alt="QBT_TR(Move to bottom)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Move to bottom)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+                <li><a href="#queueTop"><img src="${BASE_PATH}images/go-top.svg" alt="QBT_TR(Move to top)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Move to top)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+                <li><a href="#queueUp"><img src="${BASE_PATH}images/go-up.svg" alt="QBT_TR(Move up)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Move up)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+                <li><a href="#queueDown"><img src="${BASE_PATH}images/go-down.svg" alt="QBT_TR(Move down)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Move down)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+                <li><a href="#queueBottom"><img src="${BASE_PATH}images/go-bottom.svg" alt="QBT_TR(Move to bottom)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Move to bottom)QBT_TR[CONTEXT=TransferListWidget]</a></li>
             </ul>
         </li>
         <li>
-            <a href="#" class="arrow-right"><img src="images/edit-copy.svg" alt="QBT_TR(Copy)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Copy)QBT_TR[CONTEXT=TransferListWidget]</a>
+            <a href="#" class="arrow-right"><img src="${BASE_PATH}images/edit-copy.svg" alt="QBT_TR(Copy)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Copy)QBT_TR[CONTEXT=TransferListWidget]</a>
             <ul>
-                <li><a href="#" id="copyName" class="copyToClipboard"><img src="images/name.svg" alt="QBT_TR(Name)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Name)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-                <li><a href="#copyInfohash1" id="copyInfohash1" class="copyToClipboard"><img src="images/hash.svg" alt="QBT_TR(Info hash v1)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Info hash v1)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-                <li><a href="#copyInfohash2" id="copyInfohash2" class="copyToClipboard"><img src="images/hash.svg" alt="QBT_TR(Info hash v2)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Info hash v2)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-                <li><a href="#" id="copyMagnetLink" class="copyToClipboard"><img src="images/torrent-magnet.svg" alt="QBT_TR(Magnet link)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Magnet link)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-                <li><a href="#" id="copyID" class="copyToClipboard"><img src="images/help-about.svg" alt="QBT_TR(Torrent ID)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Torrent ID)QBT_TR[CONTEXT=TransferListWidget]</a></li>
-                <li><a href="#" id="copyComment" class="copyToClipboard"><img src="images/edit-copy.svg" alt="QBT_TR(Comment)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Comment)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+                <li><a href="#" id="copyName" class="copyToClipboard"><img src="${BASE_PATH}images/name.svg" alt="QBT_TR(Name)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Name)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+                <li><a href="#copyInfohash1" id="copyInfohash1" class="copyToClipboard"><img src="${BASE_PATH}images/hash.svg" alt="QBT_TR(Info hash v1)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Info hash v1)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+                <li><a href="#copyInfohash2" id="copyInfohash2" class="copyToClipboard"><img src="${BASE_PATH}images/hash.svg" alt="QBT_TR(Info hash v2)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Info hash v2)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+                <li><a href="#" id="copyMagnetLink" class="copyToClipboard"><img src="${BASE_PATH}images/torrent-magnet.svg" alt="QBT_TR(Magnet link)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Magnet link)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+                <li><a href="#" id="copyID" class="copyToClipboard"><img src="${BASE_PATH}images/help-about.svg" alt="QBT_TR(Torrent ID)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Torrent ID)QBT_TR[CONTEXT=TransferListWidget]</a></li>
+                <li><a href="#" id="copyComment" class="copyToClipboard"><img src="${BASE_PATH}images/edit-copy.svg" alt="QBT_TR(Comment)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Comment)QBT_TR[CONTEXT=TransferListWidget]</a></li>
             </ul>
         </li>
         <li>
-            <a href="#exportTorrent"><img src="images/edit-copy.svg" alt="QBT_TR(Export .torrent)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Export .torrent)QBT_TR[CONTEXT=TransferListWidget]</a>
+            <a href="#exportTorrent"><img src="${BASE_PATH}images/edit-copy.svg" alt="QBT_TR(Export .torrent)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Export .torrent)QBT_TR[CONTEXT=TransferListWidget]</a>
         </li>
     </ul>
     <ul id="statusesFilterMenu" class="contextMenu">
-        <li><a href="#startTorrents"><img src="images/torrent-start.svg" alt="QBT_TR(Start torrents)QBT_TR[CONTEXT=StatusFilterWidget]">QBT_TR(Start torrents)QBT_TR[CONTEXT=StatusFilterWidget]</a></li>
-        <li><a href="#stopTorrents"><img src="images/torrent-stop.svg" alt="QBT_TR(Stop torrents)QBT_TR[CONTEXT=StatusFilterWidget]">QBT_TR(Stop torrents)QBT_TR[CONTEXT=StatusFilterWidget]</a></li>
-        <li><a href="#deleteTorrents"><img src="images/list-remove.svg" alt="QBT_TR(Remove torrents)QBT_TR[CONTEXT=StatusFilterWidget]">QBT_TR(Remove torrents)QBT_TR[CONTEXT=StatusFilterWidget]</a></li>
+        <li><a href="#startTorrents"><img src="${BASE_PATH}images/torrent-start.svg" alt="QBT_TR(Start torrents)QBT_TR[CONTEXT=StatusFilterWidget]">QBT_TR(Start torrents)QBT_TR[CONTEXT=StatusFilterWidget]</a></li>
+        <li><a href="#stopTorrents"><img src="${BASE_PATH}images/torrent-stop.svg" alt="QBT_TR(Stop torrents)QBT_TR[CONTEXT=StatusFilterWidget]">QBT_TR(Stop torrents)QBT_TR[CONTEXT=StatusFilterWidget]</a></li>
+        <li><a href="#deleteTorrents"><img src="${BASE_PATH}images/list-remove.svg" alt="QBT_TR(Remove torrents)QBT_TR[CONTEXT=StatusFilterWidget]">QBT_TR(Remove torrents)QBT_TR[CONTEXT=StatusFilterWidget]</a></li>
     </ul>
     <ul id="categoriesFilterMenu" class="contextMenu">
-        <li><a href="#createCategory"><img src="images/list-add.svg" alt="QBT_TR(Add category...)QBT_TR[CONTEXT=CategoryFilterWidget]"> QBT_TR(Add category...)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
-        <li><a href="#createSubcategory"><img src="images/list-add.svg" alt="QBT_TR(Add subcategory...)QBT_TR[CONTEXT=CategoryFilterWidget]"> QBT_TR(Add subcategory...)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
-        <li><a href="#editCategory"><img src="images/edit-rename.svg" alt="QBT_TR(Edit category...)QBT_TR[CONTEXT=CategoryFilterWidget]"> QBT_TR(Edit category...)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
-        <li><a href="#deleteCategory"><img src="images/list-remove.svg" alt="QBT_TR(Remove category)QBT_TR[CONTEXT=CategoryFilterWidget]"> QBT_TR(Remove category)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
-        <li><a href="#deleteUnusedCategories" class="separatorBottom"><img src="images/list-remove.svg" alt="QBT_TR(Remove unused categories)QBT_TR[CONTEXT=CategoryFilterWidget]"> QBT_TR(Remove unused categories)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
-        <li><a href="#startTorrents"><img src="images/torrent-start.svg" alt="QBT_TR(Start torrents)QBT_TR[CONTEXT=CategoryFilterWidget]"> QBT_TR(Start torrents)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
-        <li><a href="#stopTorrents"><img src="images/torrent-stop.svg" alt="QBT_TR(Stop torrents)QBT_TR[CONTEXT=CategoryFilterWidget]"> QBT_TR(Stop torrents)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
-        <li><a href="#deleteTorrents"><img src="images/list-remove.svg" alt="QBT_TR(Remove torrents)QBT_TR[CONTEXT=CategoryFilterWidget]"> QBT_TR(Remove torrents)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
+        <li><a href="#createCategory"><img src="${BASE_PATH}images/list-add.svg" alt="QBT_TR(Add category...)QBT_TR[CONTEXT=CategoryFilterWidget]"> QBT_TR(Add category...)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
+        <li><a href="#createSubcategory"><img src="${BASE_PATH}images/list-add.svg" alt="QBT_TR(Add subcategory...)QBT_TR[CONTEXT=CategoryFilterWidget]"> QBT_TR(Add subcategory...)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
+        <li><a href="#editCategory"><img src="${BASE_PATH}images/edit-rename.svg" alt="QBT_TR(Edit category...)QBT_TR[CONTEXT=CategoryFilterWidget]"> QBT_TR(Edit category...)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
+        <li><a href="#deleteCategory"><img src="${BASE_PATH}images/list-remove.svg" alt="QBT_TR(Remove category)QBT_TR[CONTEXT=CategoryFilterWidget]"> QBT_TR(Remove category)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
+        <li><a href="#deleteUnusedCategories" class="separatorBottom"><img src="${BASE_PATH}images/list-remove.svg" alt="QBT_TR(Remove unused categories)QBT_TR[CONTEXT=CategoryFilterWidget]"> QBT_TR(Remove unused categories)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
+        <li><a href="#startTorrents"><img src="${BASE_PATH}images/torrent-start.svg" alt="QBT_TR(Start torrents)QBT_TR[CONTEXT=CategoryFilterWidget]"> QBT_TR(Start torrents)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
+        <li><a href="#stopTorrents"><img src="${BASE_PATH}images/torrent-stop.svg" alt="QBT_TR(Stop torrents)QBT_TR[CONTEXT=CategoryFilterWidget]"> QBT_TR(Stop torrents)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
+        <li><a href="#deleteTorrents"><img src="${BASE_PATH}images/list-remove.svg" alt="QBT_TR(Remove torrents)QBT_TR[CONTEXT=CategoryFilterWidget]"> QBT_TR(Remove torrents)QBT_TR[CONTEXT=CategoryFilterWidget]</a></li>
     </ul>
     <ul id="tagsFilterMenu" class="contextMenu">
-        <li><a href="#createTag"><img src="images/list-add.svg" alt="QBT_TR(Add tag...)QBT_TR[CONTEXT=TagFilterWidget]"> QBT_TR(Add tag...)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
-        <li><a href="#deleteTag"><img src="images/list-remove.svg" alt="QBT_TR(Remove tag)QBT_TR[CONTEXT=TagFilterWidget]"> QBT_TR(Remove tag)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
-        <li><a href="#deleteUnusedTags" class="separatorBottom"><img src="images/list-remove.svg" alt="QBT_TR(Remove unused tags)QBT_TR[CONTEXT=TagFilterWidget]"> QBT_TR(Remove unused tags)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
-        <li><a href="#startTorrents"><img src="images/torrent-start.svg" alt="QBT_TR(Start torrents)QBT_TR[CONTEXT=TagFilterWidget]"> QBT_TR(Start torrents)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
-        <li><a href="#stopTorrents"><img src="images/torrent-stop.svg" alt="QBT_TR(Stop torrents)QBT_TR[CONTEXT=TagFilterWidget]"> QBT_TR(Stop torrents)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
-        <li><a href="#deleteTorrents"><img src="images/list-remove.svg" alt="QBT_TR(Remove torrents)QBT_TR[CONTEXT=TagFilterWidget]"> QBT_TR(Remove torrents)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
+        <li><a href="#createTag"><img src="${BASE_PATH}images/list-add.svg" alt="QBT_TR(Add tag...)QBT_TR[CONTEXT=TagFilterWidget]"> QBT_TR(Add tag...)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
+        <li><a href="#deleteTag"><img src="${BASE_PATH}images/list-remove.svg" alt="QBT_TR(Remove tag)QBT_TR[CONTEXT=TagFilterWidget]"> QBT_TR(Remove tag)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
+        <li><a href="#deleteUnusedTags" class="separatorBottom"><img src="${BASE_PATH}images/list-remove.svg" alt="QBT_TR(Remove unused tags)QBT_TR[CONTEXT=TagFilterWidget]"> QBT_TR(Remove unused tags)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
+        <li><a href="#startTorrents"><img src="${BASE_PATH}images/torrent-start.svg" alt="QBT_TR(Start torrents)QBT_TR[CONTEXT=TagFilterWidget]"> QBT_TR(Start torrents)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
+        <li><a href="#stopTorrents"><img src="${BASE_PATH}images/torrent-stop.svg" alt="QBT_TR(Stop torrents)QBT_TR[CONTEXT=TagFilterWidget]"> QBT_TR(Stop torrents)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
+        <li><a href="#deleteTorrents"><img src="${BASE_PATH}images/list-remove.svg" alt="QBT_TR(Remove torrents)QBT_TR[CONTEXT=TagFilterWidget]"> QBT_TR(Remove torrents)QBT_TR[CONTEXT=TagFilterWidget]</a></li>
     </ul>
     <ul id="trackersFilterMenu" class="contextMenu">
-        <li><a href="#deleteTracker" class="separatorBottom"><img src="images/edit-clear.svg" alt="QBT_TR(Remove tracker)QBT_TR[CONTEXT=TrackerFiltersList]"> QBT_TR(Remove tracker)QBT_TR[CONTEXT=TrackerFiltersList]</a></li>
-        <li><a href="#startTorrents"><img src="images/torrent-start.svg" alt="QBT_TR(Start torrents)QBT_TR[CONTEXT=TrackerFiltersList]"> QBT_TR(Start torrents)QBT_TR[CONTEXT=TrackerFiltersList]</a></li>
-        <li><a href="#stopTorrents"><img src="images/torrent-stop.svg" alt="QBT_TR(Stop torrents)QBT_TR[CONTEXT=TrackerFiltersList]"> QBT_TR(Stop torrents)QBT_TR[CONTEXT=TrackerFiltersList]</a></li>
-        <li><a href="#deleteTorrents"><img src="images/list-remove.svg" alt="QBT_TR(Remove torrents)QBT_TR[CONTEXT=TrackerFiltersList]"> QBT_TR(Remove torrents)QBT_TR[CONTEXT=TrackerFiltersList]</a></li>
+        <li><a href="#deleteTracker" class="separatorBottom"><img src="${BASE_PATH}images/edit-clear.svg" alt="QBT_TR(Remove tracker)QBT_TR[CONTEXT=TrackerFiltersList]"> QBT_TR(Remove tracker)QBT_TR[CONTEXT=TrackerFiltersList]</a></li>
+        <li><a href="#startTorrents"><img src="${BASE_PATH}images/torrent-start.svg" alt="QBT_TR(Start torrents)QBT_TR[CONTEXT=TrackerFiltersList]"> QBT_TR(Start torrents)QBT_TR[CONTEXT=TrackerFiltersList]</a></li>
+        <li><a href="#stopTorrents"><img src="${BASE_PATH}images/torrent-stop.svg" alt="QBT_TR(Stop torrents)QBT_TR[CONTEXT=TrackerFiltersList]"> QBT_TR(Stop torrents)QBT_TR[CONTEXT=TrackerFiltersList]</a></li>
+        <li><a href="#deleteTorrents"><img src="${BASE_PATH}images/list-remove.svg" alt="QBT_TR(Remove torrents)QBT_TR[CONTEXT=TrackerFiltersList]"> QBT_TR(Remove torrents)QBT_TR[CONTEXT=TrackerFiltersList]</a></li>
     </ul>
     <ul id="torrentTrackersMenu" class="contextMenu">
-        <li><a href="#AddTracker"><img src="images/list-add.svg" alt="QBT_TR(Add trackers...)QBT_TR[CONTEXT=TrackerListWidget]"> QBT_TR(Add trackers...)QBT_TR[CONTEXT=TrackerListWidget]</a></li>
-        <li class="separator"><a href="#EditTracker"><img src="images/edit-rename.svg" alt="QBT_TR(Edit tracker URL...)QBT_TR[CONTEXT=TrackerListWidget]"> QBT_TR(Edit tracker URL...)QBT_TR[CONTEXT=TrackerListWidget]</a></li>
-        <li><a href="#RemoveTracker"><img src="images/list-remove.svg" alt="QBT_TR(Remove tracker)QBT_TR[CONTEXT=TrackerListWidget]"> QBT_TR(Remove tracker)QBT_TR[CONTEXT=TrackerListWidget]</a></li>
-        <li><a href="#CopyTrackerUrl" id="CopyTrackerUrl"><img src="images/edit-copy.svg" alt="QBT_TR(Copy tracker URL)QBT_TR[CONTEXT=TrackerListWidget]"> QBT_TR(Copy tracker URL)QBT_TR[CONTEXT=TrackerListWidget]</a></li>
+        <li><a href="#AddTracker"><img src="${BASE_PATH}images/list-add.svg" alt="QBT_TR(Add trackers...)QBT_TR[CONTEXT=TrackerListWidget]"> QBT_TR(Add trackers...)QBT_TR[CONTEXT=TrackerListWidget]</a></li>
+        <li class="separator"><a href="#EditTracker"><img src="${BASE_PATH}images/edit-rename.svg" alt="QBT_TR(Edit tracker URL...)QBT_TR[CONTEXT=TrackerListWidget]"> QBT_TR(Edit tracker URL...)QBT_TR[CONTEXT=TrackerListWidget]</a></li>
+        <li><a href="#RemoveTracker"><img src="${BASE_PATH}images/list-remove.svg" alt="QBT_TR(Remove tracker)QBT_TR[CONTEXT=TrackerListWidget]"> QBT_TR(Remove tracker)QBT_TR[CONTEXT=TrackerListWidget]</a></li>
+        <li><a href="#CopyTrackerUrl" id="CopyTrackerUrl"><img src="${BASE_PATH}images/edit-copy.svg" alt="QBT_TR(Copy tracker URL)QBT_TR[CONTEXT=TrackerListWidget]"> QBT_TR(Copy tracker URL)QBT_TR[CONTEXT=TrackerListWidget]</a></li>
     </ul>
     <ul id="torrentPeersMenu" class="contextMenu">
-        <li><a href="#addPeer"><img src="images/peers-add.svg" alt="QBT_TR(Add peers...)QBT_TR[CONTEXT=PeerListWidget]"> QBT_TR(Add peers...)QBT_TR[CONTEXT=PeerListWidget]</a></li>
-        <li><a href="#copyPeer" id="CopyPeerInfo"><img src="images/edit-copy.svg" alt="QBT_TR(Copy IP:port)QBT_TR[CONTEXT=PeerListWidget]"> QBT_TR(Copy IP:port)QBT_TR[CONTEXT=PeerListWidget]</a></li>
-        <li class="separator"><a href="#banPeer"><img src="images/peers-remove.svg" alt="QBT_TR(Ban peer permanently)QBT_TR[CONTEXT=PeerListWidget]"> QBT_TR(Ban peer permanently)QBT_TR[CONTEXT=PeerListWidget]</a></li>
+        <li><a href="#addPeer"><img src="${BASE_PATH}images/peers-add.svg" alt="QBT_TR(Add peers...)QBT_TR[CONTEXT=PeerListWidget]"> QBT_TR(Add peers...)QBT_TR[CONTEXT=PeerListWidget]</a></li>
+        <li><a href="#copyPeer" id="CopyPeerInfo"><img src="${BASE_PATH}images/edit-copy.svg" alt="QBT_TR(Copy IP:port)QBT_TR[CONTEXT=PeerListWidget]"> QBT_TR(Copy IP:port)QBT_TR[CONTEXT=PeerListWidget]</a></li>
+        <li class="separator"><a href="#banPeer"><img src="${BASE_PATH}images/peers-remove.svg" alt="QBT_TR(Ban peer permanently)QBT_TR[CONTEXT=PeerListWidget]"> QBT_TR(Ban peer permanently)QBT_TR[CONTEXT=PeerListWidget]</a></li>
     </ul>
     <ul id="torrentWebseedsMenu" class="contextMenu">
-        <li><a href="#AddWebSeeds"><img src="images/list-add.svg" alt="QBT_TR(Add web seeds...)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Add web seeds...)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
-        <li><a href="#RemoveWebSeed"><img src="images/list-remove.svg" alt="QBT_TR(Remove web seed)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Remove web seed)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
-        <li class="separator"><a href="#CopyWebseedUrl" id="CopyWebseedUrl"><img src="images/edit-copy.svg" alt="QBT_TR(Copy web seed URL)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Copy web seed URL)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
-        <li><a href="#EditWebSeed"><img src="images/edit-rename.svg" alt="QBT_TR(Edit web seed URL...)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Edit web seed URL...)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
+        <li><a href="#AddWebSeeds"><img src="${BASE_PATH}images/list-add.svg" alt="QBT_TR(Add web seeds...)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Add web seeds...)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
+        <li><a href="#RemoveWebSeed"><img src="${BASE_PATH}images/list-remove.svg" alt="QBT_TR(Remove web seed)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Remove web seed)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
+        <li class="separator"><a href="#CopyWebseedUrl" id="CopyWebseedUrl"><img src="${BASE_PATH}images/edit-copy.svg" alt="QBT_TR(Copy web seed URL)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Copy web seed URL)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
+        <li><a href="#EditWebSeed"><img src="${BASE_PATH}images/edit-rename.svg" alt="QBT_TR(Edit web seed URL...)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Edit web seed URL...)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
     </ul>
     <ul id="torrentFilesMenu" class="contextMenu">
-        <li><a href="#Rename"><img src="images/edit-rename.svg" alt="QBT_TR(Rename...)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Rename...)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
+        <li><a href="#Rename"><img src="${BASE_PATH}images/edit-rename.svg" alt="QBT_TR(Rename...)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Rename...)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
         <li class="separator">
             <a href="#FilePrio" class="arrow-right"><span style="display: inline-block; width: 16px;"></span> QBT_TR(Priority)QBT_TR[CONTEXT=PropertiesWidget]</a>
             <ul>
@@ -270,7 +270,7 @@
         </li>
     </ul>
     <ul id="multiRenameFilesMenu" class="contextMenu">
-        <li><a href="#ToggleSelection"><img src="images/edit-rename.svg" alt="QBT_TR(Toggle Selection)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Toggle Selection)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
+        <li><a href="#ToggleSelection"><img src="${BASE_PATH}images/edit-rename.svg" alt="QBT_TR(Toggle Selection)QBT_TR[CONTEXT=PropertiesWidget]"> QBT_TR(Toggle Selection)QBT_TR[CONTEXT=PropertiesWidget]</a></li>
     </ul>
     <div id="desktopFooterWrapper">
         <div id="desktopFooter">
@@ -284,13 +284,13 @@
                         <td class="statusBarSeparator invisible"></td>
                         <td id="DHTNodes" class="invisible"></td>
                         <td class="statusBarSeparator"></td>
-                        <td><img id="connectionStatus" alt="QBT_TR(Connection status: Firewalled)QBT_TR[CONTEXT=MainWindow]" title="QBT_TR(Connection status: Firewalled)QBT_TR[CONTEXT=MainWindow]" src="images/firewalled.svg" style="height: 1.5em;"></td>
+                        <td><img id="connectionStatus" alt="QBT_TR(Connection status: Firewalled)QBT_TR[CONTEXT=MainWindow]" title="QBT_TR(Connection status: Firewalled)QBT_TR[CONTEXT=MainWindow]" src="${BASE_PATH}images/firewalled.svg" style="height: 1.5em;"></td>
                         <td class="statusBarSeparator"></td>
-                        <td style="cursor:pointer;"><img id="alternativeSpeedLimits" alt="QBT_TR(Alternative speed limits: Off)QBT_TR[CONTEXT=MainWindow]" title="QBT_TR(Alternative speed limits: Off)QBT_TR[CONTEXT=MainWindow]" src="images/slow_off.svg" style="height: 1.5em;"></td>
+                        <td style="cursor:pointer;"><img id="alternativeSpeedLimits" alt="QBT_TR(Alternative speed limits: Off)QBT_TR[CONTEXT=MainWindow]" title="QBT_TR(Alternative speed limits: Off)QBT_TR[CONTEXT=MainWindow]" src="${BASE_PATH}images/slow_off.svg" style="height: 1.5em;"></td>
                         <td class="statusBarSeparator"></td>
-                        <td class="speedLabel"><img src="images/downloading.svg" alt="QBT_TR(Download speed icon)QBT_TR[CONTEXT=MainWindow]" style="height: 1.5em; margin: 0 5px -4px 0;"><span id="DlInfos"></span></td>
+                        <td class="speedLabel"><img src="${BASE_PATH}images/downloading.svg" alt="QBT_TR(Download speed icon)QBT_TR[CONTEXT=MainWindow]" style="height: 1.5em; margin: 0 5px -4px 0;"><span id="DlInfos"></span></td>
                         <td class="statusBarSeparator"></td>
-                        <td class="speedLabel"><img src="images/upload.svg" alt="QBT_TR(Upload speed icon)QBT_TR[CONTEXT=MainWindow]" style="height: 1.5em; margin: 0 5px -4px 0;"><span id="UpInfos"></span></td>
+                        <td class="speedLabel"><img src="${BASE_PATH}images/upload.svg" alt="QBT_TR(Upload speed icon)QBT_TR[CONTEXT=MainWindow]" style="height: 1.5em; margin: 0 5px -4px 0;"><span id="UpInfos"></span></td>
                     </tr>
                 </tbody>
             </table>

--- a/src/webui/www/private/newcategory.html
+++ b/src/webui/www/private/newcategory.html
@@ -4,13 +4,13 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(New Category)QBT_TR[CONTEXT=TransferListWidget]</title>
-    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
-    <script src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
-    <script src="scripts/pathAutofill.js?v=${CACHEID}"></script>
+    <link rel="stylesheet" href="${BASE_PATH}css/style.css?v=${CACHEID}" type="text/css">
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/pathAutofill.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 
@@ -78,7 +78,7 @@
                             return;
 
                         new Request({
-                            url: "api/v2/torrents/createCategory",
+                            url: "${BASE_PATH}api/v2/torrents/createCategory",
                             method: "post",
                             data: {
                                 category: categoryName,
@@ -86,7 +86,7 @@
                             },
                             onSuccess: () => {
                                 new Request({
-                                    url: "api/v2/torrents/setCategory",
+                                    url: "${BASE_PATH}api/v2/torrents/setCategory",
                                     method: "post",
                                     data: {
                                         hashes: uriHashes,
@@ -112,7 +112,7 @@
                             return;
 
                         new Request({
-                            url: "api/v2/torrents/createCategory",
+                            url: "${BASE_PATH}api/v2/torrents/createCategory",
                             method: "post",
                             data: {
                                 category: categoryName,
@@ -129,7 +129,7 @@
                         break;
                     case "edit":
                         new Request({
-                            url: "api/v2/torrents/editCategory",
+                            url: "${BASE_PATH}api/v2/torrents/editCategory",
                             method: "post",
                             data: {
                                 category: uriCategoryName, // category name can't be changed

--- a/src/webui/www/private/newfeed.html
+++ b/src/webui/www/private/newfeed.html
@@ -4,12 +4,12 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(Please type a RSS feed URL)QBT_TR[CONTEXT=RSSWidget]</title>
-    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
-    <script src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
+    <link rel="stylesheet" href="${BASE_PATH}css/style.css?v=${CACHEID}" type="text/css">
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
     <script>
         "use strict";
 
@@ -47,7 +47,7 @@
                 $("submitButton").disabled = true;
 
                 new Request({
-                    url: "api/v2/rss/addFeed",
+                    url: "${BASE_PATH}api/v2/rss/addFeed",
                     method: "post",
                     data: {
                         url: feedURL,

--- a/src/webui/www/private/newfolder.html
+++ b/src/webui/www/private/newfolder.html
@@ -4,13 +4,13 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(Please choose a folder name)QBT_TR[CONTEXT=RSSWidget]</title>
-    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
-    <script src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
-    <script src="scripts/pathAutofill.js?v=${CACHEID}"></script>
+    <link rel="stylesheet" href="${BASE_PATH}css/style.css?v=${CACHEID}" type="text/css">
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/pathAutofill.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 
@@ -48,7 +48,7 @@
                 $("submitButton").disabled = true;
 
                 new Request({
-                    url: "api/v2/rss/addFolder",
+                    url: "${BASE_PATH}api/v2/rss/addFolder",
                     method: "post",
                     data: {
                         path: path ? (path + "\\" + folderName) : folderName

--- a/src/webui/www/private/newrule.html
+++ b/src/webui/www/private/newrule.html
@@ -4,12 +4,12 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(New rule name)QBT_TR[CONTEXT=AutomatedRssDownloader]</title>
-    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
-    <script src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
+    <link rel="stylesheet" href="${BASE_PATH}css/style.css?v=${CACHEID}" type="text/css">
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
     <script>
         "use strict";
 
@@ -44,7 +44,7 @@
                 }
                 $("submitButton").disabled = true;
                 new Request({
-                    url: "api/v2/rss/setRule",
+                    url: "${BASE_PATH}api/v2/rss/setRule",
                     method: "post",
                     data: {
                         ruleName: name,

--- a/src/webui/www/private/newtag.html
+++ b/src/webui/www/private/newtag.html
@@ -4,12 +4,12 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(Add tags)QBT_TR[CONTEXT=TransferListWidget]</title>
-    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
-    <script src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
+    <link rel="stylesheet" href="${BASE_PATH}css/style.css?v=${CACHEID}" type="text/css">
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
     <script>
         "use strict";
 
@@ -62,7 +62,7 @@
                             return;
 
                         new Request({
-                            url: "api/v2/torrents/addTags",
+                            url: "${BASE_PATH}api/v2/torrents/addTags",
                             method: "post",
                             data: {
                                 hashes: uriHashes,
@@ -79,7 +79,7 @@
                             return;
 
                         new Request({
-                            url: "api/v2/torrents/createTags",
+                            url: "${BASE_PATH}api/v2/torrents/createTags",
                             method: "post",
                             data: {
                                 tags: tagName,

--- a/src/webui/www/private/rename.html
+++ b/src/webui/www/private/rename.html
@@ -4,12 +4,12 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(Rename)QBT_TR[CONTEXT=TransferListWidget]</title>
-    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
-    <script src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
+    <link rel="stylesheet" href="${BASE_PATH}css/style.css?v=${CACHEID}" type="text/css">
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
     <script>
         "use strict";
 
@@ -50,7 +50,7 @@
                 const hash = new URI().getData("hash");
                 if (hash) {
                     new Request({
-                        url: "api/v2/torrents/rename",
+                        url: "${BASE_PATH}api/v2/torrents/rename",
                         method: "post",
                         data: {
                             hash: hash,

--- a/src/webui/www/private/rename_feed.html
+++ b/src/webui/www/private/rename_feed.html
@@ -4,12 +4,12 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(Please choose a new name for this RSS feed)QBT_TR[CONTEXT=RSSWidget]</title>
-    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
-    <script src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
+    <link rel="stylesheet" href="${BASE_PATH}css/style.css?v=${CACHEID}" type="text/css">
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
     <script>
         "use strict";
 
@@ -56,7 +56,7 @@
                 $("renameButton").disabled = true;
 
                 new Request({
-                    url: "api/v2/rss/moveItem",
+                    url: "${BASE_PATH}api/v2/rss/moveItem",
                     method: "post",
                     data: {
                         itemPath: oldPath,

--- a/src/webui/www/private/rename_file.html
+++ b/src/webui/www/private/rename_file.html
@@ -4,13 +4,13 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(Renaming)QBT_TR[CONTEXT=TorrentContentTreeView]</title>
-    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
-    <script src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
-    <script src="scripts/filesystem.js?v=${CACHEID}"></script>
+    <link rel="stylesheet" href="${BASE_PATH}css/style.css?v=${CACHEID}" type="text/css">
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/filesystem.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 
@@ -66,7 +66,7 @@
                     ? parentPath + window.qBittorrent.Filesystem.PathSeparator + newName
                     : newName;
                 new Request({
-                    url: isFolder ? "api/v2/torrents/renameFolder" : "api/v2/torrents/renameFile",
+                    url: isFolder ? "${BASE_PATH}api/v2/torrents/renameFolder" : "${BASE_PATH}api/v2/torrents/renameFile",
                     method: "post",
                     data: {
                         hash: hash,

--- a/src/webui/www/private/rename_files.html
+++ b/src/webui/www/private/rename_files.html
@@ -4,13 +4,13 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(Renaming)QBT_TR[CONTEXT=TorrentContentTreeView]</title>
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/filesystem.js?v=${CACHEID}"></script>
-    <script src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
-    <script src="scripts/file-tree.js?v=${CACHEID}"></script>
-    <script src="scripts/dynamicTable.js?locale=${LANG}&v=${CACHEID}"></script>
-    <script src="scripts/rename-files.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/filesystem.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/file-tree.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/dynamicTable.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/rename-files.js?v=${CACHEID}"></script>
     <script>
         "use strict";
 
@@ -381,7 +381,7 @@
 
             const setupTable = (selectedRows) => {
                 new Request.JSON({
-                    url: new URI("api/v2/torrents/files?hash=" + data.hash),
+                    url: new URI("${BASE_PATH}api/v2/torrents/files?hash=" + data.hash),
                     noCache: true,
                     method: "get",
                     onSuccess: (files) => {

--- a/src/webui/www/private/rename_rule.html
+++ b/src/webui/www/private/rename_rule.html
@@ -4,12 +4,12 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(Rule renaming)QBT_TR[CONTEXT=AutomatedRssDownloader]</title>
-    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
-    <script src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
+    <link rel="stylesheet" href="${BASE_PATH}css/style.css?v=${CACHEID}" type="text/css">
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
     <script>
         "use strict";
 
@@ -55,7 +55,7 @@
 
                 $("renameButton").disabled = true;
                 new Request({
-                    url: "api/v2/rss/renameRule",
+                    url: "${BASE_PATH}api/v2/rss/renameRule",
                     method: "post",
                     data: {
                         ruleName: oldName,

--- a/src/webui/www/private/scripts/cache.js
+++ b/src/webui/www/private/scripts/cache.js
@@ -54,7 +54,7 @@ window.qBittorrent.Cache ??= (() => {
         #m_store = {};
 
         async init() {
-            return fetch("api/v2/app/buildInfo", {
+            return fetch("${BASE_PATH}api/v2/app/buildInfo", {
                     method: "GET",
                     cache: "no-store"
                 })
@@ -82,7 +82,7 @@ window.qBittorrent.Cache ??= (() => {
         //   onSuccess: () => {}
         // }
         async init(obj = {}) {
-            return fetch("api/v2/app/preferences", {
+            return fetch("${BASE_PATH}api/v2/app/preferences", {
                     method: "GET",
                     cache: "no-store"
                 })
@@ -119,7 +119,7 @@ window.qBittorrent.Cache ??= (() => {
             if (typeof obj.data !== "object")
                 throw new Error("`data` is not an object.");
 
-            fetch("api/v2/app/setPreferences", {
+            fetch("${BASE_PATH}api/v2/app/setPreferences", {
                     method: "POST",
                     body: new URLSearchParams({
                         "json": JSON.stringify(obj.data)
@@ -155,7 +155,7 @@ window.qBittorrent.Cache ??= (() => {
         #m_store = "";
 
         async init() {
-            return fetch("api/v2/app/version", {
+            return fetch("${BASE_PATH}api/v2/app/version", {
                     method: "GET",
                     cache: "no-store"
                 })

--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -748,7 +748,7 @@ window.addEventListener("DOMContentLoaded", () => {
     let syncMainDataTimeoutID = -1;
     let syncRequestInProgress = false;
     const syncMainData = () => {
-        const url = new URI("api/v2/sync/maindata");
+        const url = new URI("${BASE_PATH}api/v2/sync/maindata");
         url.setData("rid", syncMainDataLastResponseId);
         const request = new Request.JSON({
             url: url,
@@ -1033,17 +1033,17 @@ window.addEventListener("DOMContentLoaded", () => {
 
         switch (serverState.connection_status) {
             case "connected":
-                $("connectionStatus").src = "images/connected.svg";
+                $("connectionStatus").src = "${BASE_PATH}images/connected.svg";
                 $("connectionStatus").alt = "QBT_TR(Connection status: Connected)QBT_TR[CONTEXT=MainWindow]";
                 $("connectionStatus").title = "QBT_TR(Connection status: Connected)QBT_TR[CONTEXT=MainWindow]";
                 break;
             case "firewalled":
-                $("connectionStatus").src = "images/firewalled.svg";
+                $("connectionStatus").src = "${BASE_PATH}images/firewalled.svg";
                 $("connectionStatus").alt = "QBT_TR(Connection status: Firewalled)QBT_TR[CONTEXT=MainWindow]";
                 $("connectionStatus").title = "QBT_TR(Connection status: Firewalled)QBT_TR[CONTEXT=MainWindow]";
                 break;
             default:
-                $("connectionStatus").src = "images/disconnected.svg";
+                $("connectionStatus").src = "${BASE_PATH}images/disconnected.svg";
                 $("connectionStatus").alt = "QBT_TR(Connection status: Disconnected)QBT_TR[CONTEXT=MainWindow]";
                 $("connectionStatus").title = "QBT_TR(Connection status: Disconnected)QBT_TR[CONTEXT=MainWindow]";
                 break;
@@ -1086,12 +1086,12 @@ window.addEventListener("DOMContentLoaded", () => {
 
     const updateAltSpeedIcon = (enabled) => {
         if (enabled) {
-            $("alternativeSpeedLimits").src = "images/slow.svg";
+            $("alternativeSpeedLimits").src = "${BASE_PATH}images/slow.svg";
             $("alternativeSpeedLimits").alt = "QBT_TR(Alternative speed limits: On)QBT_TR[CONTEXT=MainWindow]";
             $("alternativeSpeedLimits").title = "QBT_TR(Alternative speed limits: On)QBT_TR[CONTEXT=MainWindow]";
         }
         else {
-            $("alternativeSpeedLimits").src = "images/slow_off.svg";
+            $("alternativeSpeedLimits").src = "${BASE_PATH}images/slow_off.svg";
             $("alternativeSpeedLimits").alt = "QBT_TR(Alternative speed limits: Off)QBT_TR[CONTEXT=MainWindow]";
             $("alternativeSpeedLimits").title = "QBT_TR(Alternative speed limits: Off)QBT_TR[CONTEXT=MainWindow]";
         }
@@ -1102,7 +1102,7 @@ window.addEventListener("DOMContentLoaded", () => {
         updateAltSpeedIcon(!alternativeSpeedLimits);
 
         new Request({
-            url: "api/v2/transfer/toggleSpeedLimitsMode",
+            url: "${BASE_PATH}api/v2/transfer/toggleSpeedLimitsMode",
             method: "post",
             onComplete: () => {
                 alternativeSpeedLimits = !alternativeSpeedLimits;
@@ -1417,7 +1417,7 @@ window.addEventListener("DOMContentLoaded", () => {
             loadMethod: "xhr",
             contentURL: "views/search.html",
             require: {
-                js: ["scripts/search.js"],
+                js: ["${BASE_PATH}scripts/search.js"],
                 onload: () => {
                     isSearchPanelLoaded = true;
                 },
@@ -1464,8 +1464,8 @@ window.addEventListener("DOMContentLoaded", () => {
             loadMethod: "xhr",
             contentURL: "views/log.html",
             require: {
-                css: ["css/vanillaSelectBox.css"],
-                js: ["scripts/lib/vanillaSelectBox.js"],
+                css: ["${BASE_PATH}css/vanillaSelectBox.css"],
+                js: ["${BASE_PATH}scripts/lib/vanillaSelectBox.js"],
                 onload: () => {
                     isLogPanelLoaded = true;
                 },
@@ -1539,7 +1539,7 @@ window.addEventListener("DOMContentLoaded", () => {
         },
         contentURL: "views/properties.html",
         require: {
-            js: ["scripts/prop-general.js", "scripts/prop-trackers.js", "scripts/prop-peers.js", "scripts/prop-webseeds.js", "scripts/prop-files.js"],
+            js: ["${BASE_PATH}scripts/prop-general.js", "${BASE_PATH}scripts/prop-trackers.js", "${BASE_PATH}scripts/prop-peers.js", "${BASE_PATH}scripts/prop-webseeds.js", "${BASE_PATH}scripts/prop-files.js"],
             onload: () => {
                 updatePropertiesPanel = () => {
                     switch (LocalPreferences.get("selected_properties_tab")) {
@@ -1664,7 +1664,7 @@ window.addEventListener("DOMContentLoaded", () => {
                 const id = "uploadPage";
                 new MochaUI.Window({
                     id: id,
-                    icon: "images/qbittorrent-tray.svg",
+                    icon: "${BASE_PATH}images/qbittorrent-tray.svg",
                     title: "QBT_TR(Upload local torrent)QBT_TR[CONTEXT=HttpServer]",
                     loadMethod: "iframe",
                     contentURL: new URI("upload.html").toString(),
@@ -1707,7 +1707,7 @@ window.addEventListener("DOMContentLoaded", () => {
                 const contentURI = new URI("download.html").setData("urls", urls.map(encodeURIComponent).join("|"));
                 new MochaUI.Window({
                     id: id,
-                    icon: "images/qbittorrent-tray.svg",
+                    icon: "${BASE_PATH}images/qbittorrent-tray.svg",
                     title: "QBT_TR(Download from URLs)QBT_TR[CONTEXT=downloadFromURL]",
                     loadMethod: "iframe",
                     contentURL: contentURI.toString(),

--- a/src/webui/www/private/scripts/contextmenu.js
+++ b/src/webui/www/private/scripts/contextmenu.js
@@ -497,8 +497,8 @@ window.qBittorrent.ContextMenu ??= (() => {
 
                 return item;
             };
-            contextCategoryList.appendChild(createMenuItem("QBT_TR(New...)QBT_TR[CONTEXT=TransferListWidget]", "images/list-add.svg", torrentNewCategoryFN));
-            contextCategoryList.appendChild(createMenuItem("QBT_TR(Reset)QBT_TR[CONTEXT=TransferListWidget]", "images/edit-clear.svg", () => { torrentSetCategoryFN(0); }));
+            contextCategoryList.appendChild(createMenuItem("QBT_TR(New...)QBT_TR[CONTEXT=TransferListWidget]", "${BASE_PATH}images/list-add.svg", torrentNewCategoryFN));
+            contextCategoryList.appendChild(createMenuItem("QBT_TR(Reset)QBT_TR[CONTEXT=TransferListWidget]", "${BASE_PATH}images/edit-clear.svg", () => { torrentSetCategoryFN(0); }));
 
             const sortedCategories = [];
             categoryList.forEach((category, hash) => sortedCategories.push({
@@ -519,7 +519,7 @@ window.qBittorrent.ContextMenu ??= (() => {
                 });
 
                 const img = document.createElement("img");
-                img.src = "images/view-categories.svg";
+                img.src = "${BASE_PATH}images/view-categories.svg";
                 anchor.prepend(img);
 
                 const setCategoryItem = document.createElement("li");
@@ -553,8 +553,8 @@ window.qBittorrent.ContextMenu ??= (() => {
 
                 return item;
             };
-            contextTagList.appendChild(createMenuItem("QBT_TR(Add...)QBT_TR[CONTEXT=TransferListWidget]", "images/list-add.svg", torrentAddTagsFN));
-            contextTagList.appendChild(createMenuItem("QBT_TR(Remove All)QBT_TR[CONTEXT=TransferListWidget]", "images/edit-clear.svg", torrentRemoveAllTagsFN));
+            contextTagList.appendChild(createMenuItem("QBT_TR(Add...)QBT_TR[CONTEXT=TransferListWidget]", "${BASE_PATH}images/list-add.svg", torrentAddTagsFN));
+            contextTagList.appendChild(createMenuItem("QBT_TR(Remove All)QBT_TR[CONTEXT=TransferListWidget]", "${BASE_PATH}images/edit-clear.svg", torrentRemoveAllTagsFN));
 
             const sortedTags = [];
             tagList.forEach((tag, hash) => sortedTags.push({

--- a/src/webui/www/private/scripts/download.js
+++ b/src/webui/www/private/scripts/download.js
@@ -37,7 +37,7 @@ window.qBittorrent.Download ??= (() => {
 
     const getCategories = () => {
         new Request.JSON({
-            url: "api/v2/torrents/categories",
+            url: "${BASE_PATH}api/v2/torrents/categories",
             method: "get",
             noCache: true,
             onSuccess: (data) => {

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -441,7 +441,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                 anchor.textContent = text;
 
                 const img = document.createElement("img");
-                img.src = "images/checked-completed.svg";
+                img.src = "${BASE_PATH}images/checked-completed.svg";
                 anchor.prepend(img);
 
                 const listItem = document.createElement("li");
@@ -1059,50 +1059,50 @@ window.qBittorrent.DynamicTable ??= (() => {
                     case "forcedMetaDL":
                     case "downloading":
                         state = "downloading";
-                        img_path = "images/downloading.svg";
+                        img_path = "${BASE_PATH}images/downloading.svg";
                         break;
                     case "forcedUP":
                     case "uploading":
                         state = "uploading";
-                        img_path = "images/upload.svg";
+                        img_path = "${BASE_PATH}images/upload.svg";
                         break;
                     case "stalledUP":
                         state = "stalledUP";
-                        img_path = "images/stalledUP.svg";
+                        img_path = "${BASE_PATH}images/stalledUP.svg";
                         break;
                     case "stalledDL":
                         state = "stalledDL";
-                        img_path = "images/stalledDL.svg";
+                        img_path = "${BASE_PATH}images/stalledDL.svg";
                         break;
                     case "stoppedDL":
                         state = "torrent-stop";
-                        img_path = "images/stopped.svg";
+                        img_path = "${BASE_PATH}images/stopped.svg";
                         break;
                     case "stoppedUP":
                         state = "checked-completed";
-                        img_path = "images/checked-completed.svg";
+                        img_path = "${BASE_PATH}images/checked-completed.svg";
                         break;
                     case "queuedDL":
                     case "queuedUP":
                         state = "queued";
-                        img_path = "images/queued.svg";
+                        img_path = "${BASE_PATH}images/queued.svg";
                         break;
                     case "checkingDL":
                     case "checkingUP":
                     case "queuedForChecking":
                     case "checkingResumeData":
                         state = "force-recheck";
-                        img_path = "images/force-recheck.svg";
+                        img_path = "${BASE_PATH}images/force-recheck.svg";
                         break;
                     case "moving":
                         state = "moving";
-                        img_path = "images/set-location.svg";
+                        img_path = "${BASE_PATH}images/set-location.svg";
                         break;
                     case "error":
                     case "unknown":
                     case "missingFiles":
                         state = "error";
-                        img_path = "images/error.svg";
+                        img_path = "${BASE_PATH}images/error.svg";
                         break;
                     default:
                         break; // do nothing
@@ -1750,7 +1750,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                     td.append(span);
                 }
 
-                span.style.backgroundImage = `url('images/flags/${country_code ?? "xx"}.svg')`;
+                span.style.backgroundImage = `url('${BASE_PATH}images/flags/${country_code ?? "xx"}.svg')`;
                 span.textContent = country;
                 td.title = country;
             };
@@ -2200,7 +2200,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                 const value = this.getRowValue(row);
 
                 const treeImg = new Element("img", {
-                    src: "images/L.gif",
+                    src: "${BASE_PATH}images/L.gif",
                     styles: {
                         "margin-bottom": -2
                     }
@@ -2244,7 +2244,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                             id: fileNameId
                         });
                         const dirImg = new Element("img", {
-                            src: "images/directory.svg",
+                            src: "${BASE_PATH}images/directory.svg",
                             styles: {
                                 "width": 20,
                                 "padding-right": 5,
@@ -2527,7 +2527,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                 }
                 else {
                     const treeImg = new Element("img", {
-                        src: "images/L.gif",
+                        src: "${BASE_PATH}images/L.gif",
                         styles: {
                             "margin-bottom": -2
                         }
@@ -2553,7 +2553,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                     }
                     else {
                         const collapseIcon = new Element("img", {
-                            src: "images/go-down.svg",
+                            src: "${BASE_PATH}images/go-down.svg",
                             styles: {
                                 "margin-left": (node.depth * 20)
                             },
@@ -2567,7 +2567,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                             id: fileNameId
                         });
                         const dirImg = new Element("img", {
-                            src: "images/directory.svg",
+                            src: "${BASE_PATH}images/directory.svg",
                             styles: {
                                 "width": 20,
                                 "padding-right": 5,
@@ -2843,19 +2843,19 @@ window.qBittorrent.DynamicTable ??= (() => {
                 let img_path;
                 switch (row.full_data.status) {
                     case "default":
-                        img_path = "images/application-rss.svg";
+                        img_path = "${BASE_PATH}images/application-rss.svg";
                         break;
                     case "hasError":
-                        img_path = "images/task-reject.svg";
+                        img_path = "${BASE_PATH}images/task-reject.svg";
                         break;
                     case "isLoading":
-                        img_path = "images/spinner.gif";
+                        img_path = "${BASE_PATH}images/spinner.gif";
                         break;
                     case "unread":
-                        img_path = "images/mail-inbox.svg";
+                        img_path = "${BASE_PATH}images/mail-inbox.svg";
                         break;
                     case "isFolder":
-                        img_path = "images/folder-documents.svg";
+                        img_path = "${BASE_PATH}images/folder-documents.svg";
                         break;
                 }
                 let td;

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -74,7 +74,7 @@ window.qBittorrent.Dialog ??= (() => {
         cornerRadius: 5,
         draggable: true,
         footerHeight: 20,
-        icon: "images/qbittorrent-tray.svg",
+        icon: "${BASE_PATH}images/qbittorrent-tray.svg",
         loadMethod: "xhr",
         maximizable: false,
         method: "post",
@@ -186,7 +186,7 @@ const initializeWindows = () => {
 
         new MochaUI.Window({
             id: id,
-            icon: "images/qbittorrent-tray.svg",
+            icon: "${BASE_PATH}images/qbittorrent-tray.svg",
             title: "QBT_TR(Download from URLs)QBT_TR[CONTEXT=downloadFromURL]",
             loadMethod: "iframe",
             contentURL: contentUri.toString(),
@@ -212,13 +212,13 @@ const initializeWindows = () => {
         const id = "preferencesPage";
         new MochaUI.Window({
             id: id,
-            icon: "images/qbittorrent-tray.svg",
+            icon: "${BASE_PATH}images/qbittorrent-tray.svg",
             title: "QBT_TR(Options)QBT_TR[CONTEXT=OptionsDialog]",
             loadMethod: "xhr",
             toolbar: true,
             contentURL: new URI("views/preferences.html").toString(),
             require: {
-                css: ["css/Tabs.css"]
+                css: ["${BASE_PATH}css/Tabs.css"]
             },
             toolbarURL: "views/preferencesToolbar.html",
             maximizable: false,
@@ -261,7 +261,7 @@ const initializeWindows = () => {
         const id = "uploadPage";
         new MochaUI.Window({
             id: id,
-            icon: "images/qbittorrent-tray.svg",
+            icon: "${BASE_PATH}images/qbittorrent-tray.svg",
             title: "QBT_TR(Upload local torrent)QBT_TR[CONTEXT=HttpServer]",
             loadMethod: "iframe",
             contentURL: new URI("upload.html").toString(),
@@ -282,7 +282,7 @@ const initializeWindows = () => {
     globalUploadLimitFN = () => {
         new MochaUI.Window({
             id: "uploadLimitPage",
-            icon: "images/qbittorrent-tray.svg",
+            icon: "${BASE_PATH}images/qbittorrent-tray.svg",
             title: "QBT_TR(Global Upload Speed Limit)QBT_TR[CONTEXT=MainWindow]",
             loadMethod: "iframe",
             contentURL: new URI("uploadlimit.html").setData("hashes", "global").toString(),
@@ -301,7 +301,7 @@ const initializeWindows = () => {
         if (hashes.length) {
             new MochaUI.Window({
                 id: "uploadLimitPage",
-                icon: "images/qbittorrent-tray.svg",
+                icon: "${BASE_PATH}images/qbittorrent-tray.svg",
                 title: "QBT_TR(Torrent Upload Speed Limiting)QBT_TR[CONTEXT=TransferListWidget]",
                 loadMethod: "iframe",
                 contentURL: new URI("uploadlimit.html").setData("hashes", hashes.join("|")).toString(),
@@ -343,7 +343,7 @@ const initializeWindows = () => {
             const orig = torrentsHaveSameShareRatio ? shareRatio : "";
             new MochaUI.Window({
                 id: "shareRatioPage",
-                icon: "images/qbittorrent-tray.svg",
+                icon: "${BASE_PATH}images/qbittorrent-tray.svg",
                 title: "QBT_TR(Torrent Upload/Download Ratio Limiting)QBT_TR[CONTEXT=UpDownRatioDialog]",
                 loadMethod: "iframe",
                 contentURL: new URI("shareratio.html").setData("hashes", hashes.join("|")).setData("orig", orig).toString(),
@@ -361,7 +361,7 @@ const initializeWindows = () => {
         const hashes = torrentsTable.selectedRowsIds();
         if (hashes.length) {
             new Request({
-                url: "api/v2/torrents/toggleSequentialDownload",
+                url: "${BASE_PATH}api/v2/torrents/toggleSequentialDownload",
                 method: "post",
                 data: {
                     hashes: hashes.join("|")
@@ -375,7 +375,7 @@ const initializeWindows = () => {
         const hashes = torrentsTable.selectedRowsIds();
         if (hashes.length) {
             new Request({
-                url: "api/v2/torrents/toggleFirstLastPiecePrio",
+                url: "${BASE_PATH}api/v2/torrents/toggleFirstLastPiecePrio",
                 method: "post",
                 data: {
                     hashes: hashes.join("|")
@@ -389,7 +389,7 @@ const initializeWindows = () => {
         const hashes = torrentsTable.selectedRowsIds();
         if (hashes.length) {
             new Request({
-                url: "api/v2/torrents/setSuperSeeding",
+                url: "${BASE_PATH}api/v2/torrents/setSuperSeeding",
                 method: "post",
                 data: {
                     value: val,
@@ -404,7 +404,7 @@ const initializeWindows = () => {
         const hashes = torrentsTable.selectedRowsIds();
         if (hashes.length) {
             new Request({
-                url: "api/v2/torrents/setForceStart",
+                url: "${BASE_PATH}api/v2/torrents/setForceStart",
                 method: "post",
                 data: {
                     value: "true",
@@ -418,7 +418,7 @@ const initializeWindows = () => {
     globalDownloadLimitFN = () => {
         new MochaUI.Window({
             id: "downloadLimitPage",
-            icon: "images/qbittorrent-tray.svg",
+            icon: "${BASE_PATH}images/qbittorrent-tray.svg",
             title: "QBT_TR(Global Download Speed Limit)QBT_TR[CONTEXT=MainWindow]",
             loadMethod: "iframe",
             contentURL: new URI("downloadlimit.html").setData("hashes", "global").toString(),
@@ -436,7 +436,7 @@ const initializeWindows = () => {
         const id = "statisticspage";
         new MochaUI.Window({
             id: id,
-            icon: "images/qbittorrent-tray.svg",
+            icon: "${BASE_PATH}images/qbittorrent-tray.svg",
             title: "QBT_TR(Statistics)QBT_TR[CONTEXT=StatsDialog]",
             loadMethod: "xhr",
             contentURL: new URI("views/statistics.html").toString(),
@@ -455,7 +455,7 @@ const initializeWindows = () => {
         if (hashes.length) {
             new MochaUI.Window({
                 id: "downloadLimitPage",
-                icon: "images/qbittorrent-tray.svg",
+                icon: "${BASE_PATH}images/qbittorrent-tray.svg",
                 title: "QBT_TR(Torrent Download Speed Limiting)QBT_TR[CONTEXT=TransferListWidget]",
                 loadMethod: "iframe",
                 contentURL: new URI("downloadlimit.html").setData("hashes", hashes.join("|")).toString(),
@@ -495,7 +495,7 @@ const initializeWindows = () => {
             }
             else {
                 new Request({
-                    url: "api/v2/torrents/delete",
+                    url: "${BASE_PATH}api/v2/torrents/delete",
                     method: "post",
                     data: {
                         hashes: hashes.join("|"),
@@ -524,7 +524,7 @@ const initializeWindows = () => {
         const hashes = torrentsTable.selectedRowsIds();
         if (hashes.length) {
             new Request({
-                url: "api/v2/torrents/stop",
+                url: "${BASE_PATH}api/v2/torrents/stop",
                 method: "post",
                 data: {
                     hashes: hashes.join("|")
@@ -538,7 +538,7 @@ const initializeWindows = () => {
         const hashes = torrentsTable.selectedRowsIds();
         if (hashes.length) {
             new Request({
-                url: "api/v2/torrents/start",
+                url: "${BASE_PATH}api/v2/torrents/start",
                 method: "post",
                 data: {
                     hashes: hashes.join("|")
@@ -566,7 +566,7 @@ const initializeWindows = () => {
             }
             else {
                 new Request({
-                    url: "api/v2/torrents/setAutoManagement",
+                    url: "${BASE_PATH}api/v2/torrents/setAutoManagement",
                     method: "post",
                     data: {
                         hashes: hashes.join("|"),
@@ -597,7 +597,7 @@ const initializeWindows = () => {
             }
             else {
                 new Request({
-                    url: "api/v2/torrents/recheck",
+                    url: "${BASE_PATH}api/v2/torrents/recheck",
                     method: "post",
                     data: {
                         "hashes": hashes.join("|"),
@@ -617,7 +617,7 @@ const initializeWindows = () => {
         const hashes = torrentsTable.selectedRowsIds();
         if (hashes.length) {
             new Request({
-                url: "api/v2/torrents/reannounce",
+                url: "${BASE_PATH}api/v2/torrents/reannounce",
                 method: "post",
                 data: {
                     hashes: hashes.join("|"),
@@ -635,7 +635,7 @@ const initializeWindows = () => {
 
             new MochaUI.Window({
                 id: "setLocationPage",
-                icon: "images/qbittorrent-tray.svg",
+                icon: "${BASE_PATH}images/qbittorrent-tray.svg",
                 title: "QBT_TR(Set location)QBT_TR[CONTEXT=TransferListWidget]",
                 loadMethod: "iframe",
                 contentURL: new URI("setlocation.html").setData("hashes", hashes.join("|")).setData("path", encodeURIComponent(row.full_data.save_path)).toString(),
@@ -658,7 +658,7 @@ const initializeWindows = () => {
             if (row) {
                 new MochaUI.Window({
                     id: "renamePage",
-                    icon: "images/qbittorrent-tray.svg",
+                    icon: "${BASE_PATH}images/qbittorrent-tray.svg",
                     title: "QBT_TR(Rename)QBT_TR[CONTEXT=TransferListWidget]",
                     loadMethod: "iframe",
                     contentURL: new URI("rename.html").setData("hash", hash).setData("name", row.full_data.name).toString(),
@@ -682,7 +682,7 @@ const initializeWindows = () => {
             if (row) {
                 new MochaUI.Window({
                     id: "multiRenamePage",
-                    icon: "images/qbittorrent-tray.svg",
+                    icon: "${BASE_PATH}images/qbittorrent-tray.svg",
                     title: "QBT_TR(Renaming)QBT_TR[CONTEXT=TransferListWidget]",
                     data: { hash: hash, selectedRows: [] },
                     loadMethod: "xhr",
@@ -704,7 +704,7 @@ const initializeWindows = () => {
         const hashes = torrentsTable.getFilteredTorrentsHashes(selectedStatus, selectedCategory, selectedTag, selectedTracker);
         if (hashes.length > 0) {
             new Request({
-                url: "api/v2/torrents/start",
+                url: "${BASE_PATH}api/v2/torrents/start",
                 method: "post",
                 data: {
                     hashes: hashes.join("|")
@@ -724,7 +724,7 @@ const initializeWindows = () => {
         const hashes = torrentsTable.getFilteredTorrentsHashes(selectedStatus, selectedCategory, selectedTag, selectedTracker);
         if (hashes.length > 0) {
             new Request({
-                url: "api/v2/torrents/stop",
+                url: "${BASE_PATH}api/v2/torrents/stop",
                 method: "post",
                 data: {
                     hashes: hashes.join("|")
@@ -761,7 +761,7 @@ const initializeWindows = () => {
             }
             else {
                 new Request({
-                    url: "api/v2/torrents/delete",
+                    url: "${BASE_PATH}api/v2/torrents/delete",
                     method: "post",
                     data: {
                         hashes: hashes.join("|"),
@@ -786,7 +786,7 @@ const initializeWindows = () => {
         if (hashes.length) {
             new MochaUI.Window({
                 id: "newCategoryPage",
-                icon: "images/qbittorrent-tray.svg",
+                icon: "${BASE_PATH}images/qbittorrent-tray.svg",
                 title: "QBT_TR(New Category)QBT_TR[CONTEXT=TransferListWidget]",
                 loadMethod: "iframe",
                 contentURL: new URI("newcategory.html").setData("action", action).setData("hashes", hashes.join("|")).toString(),
@@ -810,7 +810,7 @@ const initializeWindows = () => {
             ? category_list.get(categoryHash).name
             : "";
         new Request({
-            url: "api/v2/torrents/setCategory",
+            url: "${BASE_PATH}api/v2/torrents/setCategory",
             method: "post",
             data: {
                 hashes: hashes.join("|"),
@@ -826,7 +826,7 @@ const initializeWindows = () => {
         const action = "create";
         new MochaUI.Window({
             id: "newCategoryPage",
-            icon: "images/qbittorrent-tray.svg",
+            icon: "${BASE_PATH}images/qbittorrent-tray.svg",
             title: "QBT_TR(New Category)QBT_TR[CONTEXT=CategoryFilterWidget]",
             loadMethod: "iframe",
             contentURL: new URI("newcategory.html").setData("action", action).toString(),
@@ -845,7 +845,7 @@ const initializeWindows = () => {
         const categoryName = category_list.get(categoryHash).name + "/";
         new MochaUI.Window({
             id: "newSubcategoryPage",
-            icon: "images/qbittorrent-tray.svg",
+            icon: "${BASE_PATH}images/qbittorrent-tray.svg",
             title: "QBT_TR(New Category)QBT_TR[CONTEXT=CategoryFilterWidget]",
             loadMethod: "iframe",
             contentURL: new URI("newcategory.html").setData("action", action).setData("categoryName", categoryName).toString(),
@@ -864,7 +864,7 @@ const initializeWindows = () => {
         const category = category_list.get(categoryHash);
         new MochaUI.Window({
             id: "editCategoryPage",
-            icon: "images/qbittorrent-tray.svg",
+            icon: "${BASE_PATH}images/qbittorrent-tray.svg",
             title: "QBT_TR(Edit Category)QBT_TR[CONTEXT=TransferListWidget]",
             loadMethod: "iframe",
             contentURL: new URI("newcategory.html").setData("action", action).setData("categoryName", category.name).setData("savePath", category.savePath).toString(),
@@ -881,7 +881,7 @@ const initializeWindows = () => {
     removeCategoryFN = (categoryHash) => {
         const categoryName = category_list.get(categoryHash).name;
         new Request({
-            url: "api/v2/torrents/removeCategories",
+            url: "${BASE_PATH}api/v2/torrents/removeCategories",
             method: "post",
             data: {
                 categories: categoryName
@@ -901,7 +901,7 @@ const initializeWindows = () => {
         });
 
         new Request({
-            url: "api/v2/torrents/removeCategories",
+            url: "${BASE_PATH}api/v2/torrents/removeCategories",
             method: "post",
             data: {
                 categories: categories.join("\n")
@@ -919,7 +919,7 @@ const initializeWindows = () => {
         if (hashes.length) {
             new MochaUI.Window({
                 id: "newTagPage",
-                icon: "images/qbittorrent-tray.svg",
+                icon: "${BASE_PATH}images/qbittorrent-tray.svg",
                 title: "QBT_TR(Add tags)QBT_TR[CONTEXT=TransferListWidget]",
                 loadMethod: "iframe",
                 contentURL: new URI("newtag.html").setData("action", action).setData("hashes", hashes.join("|")).toString(),
@@ -941,7 +941,7 @@ const initializeWindows = () => {
 
         const tagName = tagList.has(tagHash) ? tagList.get(tagHash).name : "";
         new Request({
-            url: (isSet ? "api/v2/torrents/addTags" : "api/v2/torrents/removeTags"),
+            url: (isSet ? "${BASE_PATH}api/v2/torrents/addTags" : "${BASE_PATH}api/v2/torrents/removeTags"),
             method: "post",
             data: {
                 hashes: hashes.join("|"),
@@ -954,7 +954,7 @@ const initializeWindows = () => {
         const hashes = torrentsTable.selectedRowsIds();
         if (hashes.length) {
             new Request({
-                url: ("api/v2/torrents/removeTags"),
+                url: ("${BASE_PATH}api/v2/torrents/removeTags"),
                 method: "post",
                 data: {
                     hashes: hashes.join("|"),
@@ -967,7 +967,7 @@ const initializeWindows = () => {
         const action = "create";
         new MochaUI.Window({
             id: "newTagPage",
-            icon: "images/qbittorrent-tray.svg",
+            icon: "${BASE_PATH}images/qbittorrent-tray.svg",
             title: "QBT_TR(New Tag)QBT_TR[CONTEXT=TagFilterWidget]",
             loadMethod: "iframe",
             contentURL: new URI("newtag.html").setData("action", action).toString(),
@@ -985,7 +985,7 @@ const initializeWindows = () => {
     removeTagFN = (tagHash) => {
         const tagName = tagList.get(tagHash).name;
         new Request({
-            url: "api/v2/torrents/deleteTags",
+            url: "${BASE_PATH}api/v2/torrents/deleteTags",
             method: "post",
             data: {
                 tags: tagName
@@ -1001,7 +1001,7 @@ const initializeWindows = () => {
                 tags.push(tag.name);
         });
         new Request({
-            url: "api/v2/torrents/deleteTags",
+            url: "${BASE_PATH}api/v2/torrents/deleteTags",
             method: "post",
             data: {
                 tags: tags.join(",")
@@ -1115,7 +1115,7 @@ const initializeWindows = () => {
                 continue;
 
             const name = row.full_data.name;
-            const url = new URI("api/v2/torrents/export").setData("hash", hash).toString();
+            const url = new URI("${BASE_PATH}api/v2/torrents/export").setData("hash", hash).toString();
 
             // download response to file
             await window.qBittorrent.Misc.downloadFile(url, `${name}.torrent`, "QBT_TR(Unable to export torrent file)QBT_TR[CONTEXT=MainWindow]");
@@ -1131,7 +1131,7 @@ const initializeWindows = () => {
 
         if (confirm("QBT_TR(Would you like to stop all torrents?)QBT_TR[CONTEXT=MainWindow]")) {
             new Request({
-                url: "api/v2/torrents/stop",
+                url: "${BASE_PATH}api/v2/torrents/stop",
                 method: "post",
                 data: {
                     hashes: "all"
@@ -1147,7 +1147,7 @@ const initializeWindows = () => {
 
         if (confirm("QBT_TR(Would you like to start all torrents?)QBT_TR[CONTEXT=MainWindow]")) {
             new Request({
-                url: "api/v2/torrents/start",
+                url: "${BASE_PATH}api/v2/torrents/start",
                 method: "post",
                 data: {
                     hashes: "all"
@@ -1166,7 +1166,7 @@ const initializeWindows = () => {
             if (hashes.length) {
                 hashes.each((hash, index) => {
                     new Request({
-                        url: "api/v2/torrents/" + item,
+                        url: "${BASE_PATH}api/v2/torrents/" + item,
                         method: "post",
                         data: {
                             hashes: hash
@@ -1190,7 +1190,7 @@ const initializeWindows = () => {
         const hashes = torrentsTable.selectedRowsIds();
         if (hashes.length) {
             new Request({
-                url: "api/v2/torrents/" + cmd,
+                url: "${BASE_PATH}api/v2/torrents/" + cmd,
                 method: "post",
                 data: {
                     hashes: hashes.join("|")
@@ -1207,12 +1207,12 @@ const initializeWindows = () => {
         const id = "aboutpage";
         new MochaUI.Window({
             id: id,
-            icon: "images/qbittorrent-tray.svg",
+            icon: "${BASE_PATH}images/qbittorrent-tray.svg",
             title: "QBT_TR(About qBittorrent)QBT_TR[CONTEXT=AboutDialog]",
             loadMethod: "xhr",
             contentURL: new URI("views/about.html").toString(),
             require: {
-                css: ["css/Tabs.css"]
+                css: ["${BASE_PATH}css/Tabs.css"]
             },
             toolbar: true,
             toolbarURL: "views/aboutToolbar.html",
@@ -1230,7 +1230,7 @@ const initializeWindows = () => {
         e.stopPropagation();
 
         new Request({
-            url: "api/v2/auth/logout",
+            url: "${BASE_PATH}api/v2/auth/logout",
             method: "post",
             onSuccess: () => {
                 window.location.reload(true);
@@ -1244,7 +1244,7 @@ const initializeWindows = () => {
 
         if (confirm("QBT_TR(Are you sure you want to quit qBittorrent?)QBT_TR[CONTEXT=MainWindow]")) {
             new Request({
-                url: "api/v2/app/shutdown",
+                url: "${BASE_PATH}api/v2/app/shutdown",
                 method: "post",
                 onSuccess: () => {
                     const shutdownMessage = "QBT_TR(%1 has been shutdown)QBT_TR[CONTEXT=HttpServer]".replace("%1", window.qBittorrent.Client.mainTitle());

--- a/src/webui/www/private/scripts/pathAutofill.js
+++ b/src/webui/www/private/scripts/pathAutofill.js
@@ -64,7 +64,7 @@ window.qBittorrent.pathAutofill ??= (() => {
         if (partialPath === "")
             return;
 
-        fetch(`api/v2/app/getDirectoryContent?dirPath=${partialPath}&mode=${mode}`, {
+        fetch(`${BASE_PATH}api/v2/app/getDirectoryContent?dirPath=${partialPath}&mode=${mode}`, {
                 method: "GET",
                 cache: "no-store"
             })

--- a/src/webui/www/private/scripts/prop-files.js
+++ b/src/webui/www/private/scripts/prop-files.js
@@ -309,7 +309,7 @@ window.qBittorrent.PropFiles ??= (() => {
         loadTorrentFilesDataTimer = -1;
 
         new Request({
-            url: "api/v2/torrents/filePrio",
+            url: "${BASE_PATH}api/v2/torrents/filePrio",
             method: "post",
             data: {
                 "hash": current_hash,
@@ -352,7 +352,7 @@ window.qBittorrent.PropFiles ??= (() => {
             current_hash = new_hash;
             loadedNewTorrent = true;
         }
-        const url = new URI("api/v2/torrents/files?hash=" + current_hash);
+        const url = new URI("${BASE_PATH}api/v2/torrents/files?hash=" + current_hash);
         new Request.JSON({
             url: url,
             method: "get",
@@ -545,7 +545,7 @@ window.qBittorrent.PropFiles ??= (() => {
 
         new MochaUI.Window({
             id: "renamePage",
-            icon: "images/qbittorrent-tray.svg",
+            icon: "${BASE_PATH}images/qbittorrent-tray.svg",
             title: "QBT_TR(Renaming)QBT_TR[CONTEXT=TorrentContentTreeView]",
             loadMethod: "iframe",
             contentURL: "rename_file.html?hash=" + hash + "&isFolder=" + node.isFolder
@@ -563,7 +563,7 @@ window.qBittorrent.PropFiles ??= (() => {
     const multiFileRename = (hash) => {
         new MochaUI.Window({
             id: "multiRenamePage",
-            icon: "images/qbittorrent-tray.svg",
+            icon: "${BASE_PATH}images/qbittorrent-tray.svg",
             title: "QBT_TR(Renaming)QBT_TR[CONTEXT=TorrentContentTreeView]",
             data: { hash: hash, selectedRows: torrentFilesTable.selectedRows },
             loadMethod: "xhr",

--- a/src/webui/www/private/scripts/prop-general.js
+++ b/src/webui/www/private/scripts/prop-general.js
@@ -87,7 +87,7 @@ window.qBittorrent.PropGeneral ??= (() => {
             clearTimeout(loadTorrentDataTimer);
             return;
         }
-        const url = new URI("api/v2/torrents/properties?hash=" + current_id);
+        const url = new URI("${BASE_PATH}api/v2/torrents/properties?hash=" + current_id);
         new Request.JSON({
             url: url,
             method: "get",
@@ -227,7 +227,7 @@ window.qBittorrent.PropGeneral ??= (() => {
             }
         }).send();
 
-        const piecesUrl = new URI("api/v2/torrents/pieceStates?hash=" + current_id);
+        const piecesUrl = new URI("${BASE_PATH}api/v2/torrents/pieceStates?hash=" + current_id);
         new Request.JSON({
             url: piecesUrl,
             method: "get",

--- a/src/webui/www/private/scripts/prop-peers.js
+++ b/src/webui/www/private/scripts/prop-peers.js
@@ -56,7 +56,7 @@ window.qBittorrent.PropPeers ??= (() => {
             clearTimeout(loadTorrentPeersTimer);
             return;
         }
-        const url = new URI("api/v2/sync/torrentPeers");
+        const url = new URI("${BASE_PATH}api/v2/sync/torrentPeers");
         url.setData("rid", syncTorrentPeersLastResponseId);
         url.setData("hash", current_hash);
         new Request.JSON({
@@ -127,7 +127,7 @@ window.qBittorrent.PropPeers ??= (() => {
 
                 new MochaUI.Window({
                     id: "addPeersPage",
-                    icon: "images/qbittorrent-tray.svg",
+                    icon: "${BASE_PATH}images/qbittorrent-tray.svg",
                     title: "QBT_TR(Add Peers)QBT_TR[CONTEXT=PeersAdditionDialog]",
                     loadMethod: "iframe",
                     contentURL: "addpeers.html?hash=" + hash,
@@ -147,7 +147,7 @@ window.qBittorrent.PropPeers ??= (() => {
 
                 if (confirm("QBT_TR(Are you sure you want to permanently ban the selected peers?)QBT_TR[CONTEXT=PeerListWidget]")) {
                     new Request({
-                        url: "api/v2/transfer/banPeers",
+                        url: "${BASE_PATH}api/v2/transfer/banPeers",
                         method: "post",
                         data: {
                             hash: torrentsTable.getCurrentTorrentID(),

--- a/src/webui/www/private/scripts/prop-trackers.js
+++ b/src/webui/www/private/scripts/prop-trackers.js
@@ -58,7 +58,7 @@ window.qBittorrent.PropTrackers ??= (() => {
             torrentTrackersTable.clear();
             current_hash = new_hash;
         }
-        const url = new URI("api/v2/torrents/trackers?hash=" + current_hash);
+        const url = new URI("${BASE_PATH}api/v2/torrents/trackers?hash=" + current_hash);
         new Request.JSON({
             url: url,
             method: "get",
@@ -167,7 +167,7 @@ window.qBittorrent.PropTrackers ??= (() => {
             return;
         new MochaUI.Window({
             id: "trackersPage",
-            icon: "images/qbittorrent-tray.svg",
+            icon: "${BASE_PATH}images/qbittorrent-tray.svg",
             title: "QBT_TR(Add trackers)QBT_TR[CONTEXT=TrackersAdditionDialog]",
             loadMethod: "iframe",
             contentURL: "addtrackers.html?hash=" + current_hash,
@@ -192,7 +192,7 @@ window.qBittorrent.PropTrackers ??= (() => {
         const trackerUrl = encodeURIComponent(element.childNodes[1].textContent);
         new MochaUI.Window({
             id: "trackersPage",
-            icon: "images/qbittorrent-tray.svg",
+            icon: "${BASE_PATH}images/qbittorrent-tray.svg",
             title: "QBT_TR(Tracker editing)QBT_TR[CONTEXT=TrackerListWidget]",
             loadMethod: "iframe",
             contentURL: "edittracker.html?hash=" + current_hash + "&url=" + trackerUrl,
@@ -216,7 +216,7 @@ window.qBittorrent.PropTrackers ??= (() => {
 
         const selectedTrackers = torrentTrackersTable.selectedRowsIds();
         new Request({
-            url: "api/v2/torrents/removeTrackers",
+            url: "${BASE_PATH}api/v2/torrents/removeTrackers",
             method: "post",
             data: {
                 hash: current_hash,

--- a/src/webui/www/private/scripts/prop-webseeds.js
+++ b/src/webui/www/private/scripts/prop-webseeds.js
@@ -59,7 +59,7 @@ window.qBittorrent.PropWebseeds ??= (() => {
             current_hash = new_hash;
         }
         new Request.JSON({
-            url: new URI("api/v2/torrents/webseeds").setData("hash", current_hash),
+            url: new URI("${BASE_PATH}api/v2/torrents/webseeds").setData("hash", current_hash),
             method: "get",
             noCache: true,
             onComplete: () => {
@@ -192,7 +192,7 @@ window.qBittorrent.PropWebseeds ??= (() => {
 
         const selectedWebseeds = torrentWebseedsTable.selectedRowsIds();
         new Request({
-            url: "api/v2/torrents/removeWebSeeds",
+            url: "${BASE_PATH}api/v2/torrents/removeWebSeeds",
             method: "post",
             data: {
                 hash: current_hash,

--- a/src/webui/www/private/scripts/rename-files.js
+++ b/src/webui/www/private/scripts/rename-files.js
@@ -241,7 +241,7 @@ window.qBittorrent.MultiRename ??= (() => {
                     ? parentPath + window.qBittorrent.Filesystem.PathSeparator + newName
                     : newName;
                 const renameRequest = new Request({
-                    url: isFolder ? "api/v2/torrents/renameFolder" : "api/v2/torrents/renameFile",
+                    url: isFolder ? "${BASE_PATH}api/v2/torrents/renameFolder" : "${BASE_PATH}api/v2/torrents/renameFile",
                     method: "post",
                     data: {
                         hash: this.hash,

--- a/src/webui/www/private/scripts/search.js
+++ b/src/webui/www/private/scripts/search.js
@@ -185,14 +185,14 @@ window.qBittorrent.Search ??= (() => {
         const closeTabElem = new Element("img", {
             alt: "QBT_TR(Close tab)QBT_TR[CONTEXT=SearchWidget]",
             title: "QBT_TR(Close tab)QBT_TR[CONTEXT=SearchWidget]",
-            src: "images/application-exit.svg",
+            src: "${BASE_PATH}images/application-exit.svg",
             width: "10",
             height: "10",
             onclick: "qBittorrent.Search.closeSearchTab(this);",
         });
         closeTabElem.inject(tabElem, "top");
 
-        tabElem.appendChild(getStatusIconElement("QBT_TR(Searching...)QBT_TR[CONTEXT=SearchJobWidget]", "images/queued.svg"));
+        tabElem.appendChild(getStatusIconElement("QBT_TR(Searching...)QBT_TR[CONTEXT=SearchJobWidget]", "${BASE_PATH}images/queued.svg"));
 
         const listItem = document.createElement("li");
         listItem.id = newTabId;
@@ -253,7 +253,7 @@ window.qBittorrent.Search ??= (() => {
         tab.destroy();
 
         new Request({
-            url: new URI("api/v2/search/delete"),
+            url: new URI("${BASE_PATH}api/v2/search/delete"),
             method: "post",
             data: {
                 id: searchId
@@ -401,7 +401,7 @@ window.qBittorrent.Search ??= (() => {
     const startSearch = (pattern, category, plugins) => {
         searchPatternChanged = false;
 
-        const url = new URI("api/v2/search/start");
+        const url = new URI("${BASE_PATH}api/v2/search/start");
         new Request.JSON({
             url: url,
             method: "post",
@@ -423,7 +423,7 @@ window.qBittorrent.Search ??= (() => {
     };
 
     const stopSearch = (searchId) => {
-        const url = new URI("api/v2/search/stop");
+        const url = new URI("${BASE_PATH}api/v2/search/stop");
         new Request({
             url: url,
             method: "post",
@@ -433,7 +433,7 @@ window.qBittorrent.Search ??= (() => {
             onSuccess: (response) => {
                 resetSearchState(searchId);
                 // not strictly necessary to do this when the tab is being closed, but there's no harm in it
-                updateStatusIconElement(searchId, "QBT_TR(Search aborted)QBT_TR[CONTEXT=SearchJobWidget]", "images/task-reject.svg");
+                updateStatusIconElement(searchId, "QBT_TR(Search aborted)QBT_TR[CONTEXT=SearchJobWidget]", "${BASE_PATH}images/task-reject.svg");
             }
         }).send();
     };
@@ -510,7 +510,7 @@ window.qBittorrent.Search ??= (() => {
             new MochaUI.Window({
                 id: id,
                 title: "QBT_TR(Search plugins)QBT_TR[CONTEXT=PluginSelectDlg]",
-                icon: "images/qbittorrent-tray.svg",
+                icon: "${BASE_PATH}images/qbittorrent-tray.svg",
                 loadMethod: "xhr",
                 contentURL: "views/searchplugins.html",
                 scrollbars: false,
@@ -644,7 +644,7 @@ window.qBittorrent.Search ??= (() => {
 
     const getPlugins = () => {
         new Request.JSON({
-            url: new URI("api/v2/search/plugins"),
+            url: new URI("${BASE_PATH}api/v2/search/plugins"),
             method: "get",
             noCache: true,
             onSuccess: (response) => {
@@ -773,7 +773,7 @@ window.qBittorrent.Search ??= (() => {
         const state = searchState.get(searchId);
 
         const maxResults = 500;
-        const url = new URI("api/v2/search/results");
+        const url = new URI("${BASE_PATH}api/v2/search/results");
         new Request.JSON({
             url: url,
             method: "get",
@@ -787,7 +787,7 @@ window.qBittorrent.Search ??= (() => {
                 if ((response.status === 400) || (response.status === 404)) {
                     // bad params. search id is invalid
                     resetSearchState(searchId);
-                    updateStatusIconElement(searchId, "QBT_TR(An error occurred during search...)QBT_TR[CONTEXT=SearchJobWidget]", "images/error.svg");
+                    updateStatusIconElement(searchId, "QBT_TR(An error occurred during search...)QBT_TR[CONTEXT=SearchJobWidget]", "${BASE_PATH}images/error.svg");
                 }
                 else {
                     clearTimeout(state.loadResultsTimer);
@@ -801,7 +801,7 @@ window.qBittorrent.Search ??= (() => {
                 // check if user stopped the search prior to receiving the response
                 if (!state.running) {
                     clearTimeout(state.loadResultsTimer);
-                    updateStatusIconElement(searchId, "QBT_TR(Search aborted)QBT_TR[CONTEXT=SearchJobWidget]", "images/task-reject.svg");
+                    updateStatusIconElement(searchId, "QBT_TR(Search aborted)QBT_TR[CONTEXT=SearchJobWidget]", "${BASE_PATH}images/task-reject.svg");
                     return;
                 }
 
@@ -845,7 +845,7 @@ window.qBittorrent.Search ??= (() => {
 
                     if ((response.status === "Stopped") && (state.rowId >= response.total)) {
                         resetSearchState(searchId);
-                        updateStatusIconElement(searchId, "QBT_TR(Search has finished)QBT_TR[CONTEXT=SearchJobWidget]", "images/task-complete.svg");
+                        updateStatusIconElement(searchId, "QBT_TR(Search has finished)QBT_TR[CONTEXT=SearchJobWidget]", "${BASE_PATH}images/task-complete.svg");
                         return;
                     }
                 }

--- a/src/webui/www/private/scripts/speedslider.js
+++ b/src/webui/www/private/scripts/speedslider.js
@@ -34,7 +34,7 @@ MochaUI.extend({
             // Get global upload limit
             let maximum = 500;
             new Request({
-                url: "api/v2/transfer/uploadLimit",
+                url: "${BASE_PATH}api/v2/transfer/uploadLimit",
                 method: "get",
                 data: {},
                 onSuccess: (data) => {
@@ -84,7 +84,7 @@ MochaUI.extend({
                     }
                     else {
                         new Request.JSON({
-                            url: "api/v2/torrents/uploadLimit",
+                            url: "${BASE_PATH}api/v2/torrents/uploadLimit",
                             method: "post",
                             data: {
                                 hashes: hashes.join("|")
@@ -138,7 +138,7 @@ MochaUI.extend({
             // Get global upload limit
             let maximum = 500;
             new Request({
-                url: "api/v2/transfer/downloadLimit",
+                url: "${BASE_PATH}api/v2/transfer/downloadLimit",
                 method: "get",
                 data: {},
                 onSuccess: (data) => {
@@ -188,7 +188,7 @@ MochaUI.extend({
                     }
                     else {
                         new Request.JSON({
-                            url: "api/v2/torrents/downloadLimit",
+                            url: "${BASE_PATH}api/v2/torrents/downloadLimit",
                             method: "post",
                             data: {
                                 hashes: hashes.join("|")

--- a/src/webui/www/private/setlocation.html
+++ b/src/webui/www/private/setlocation.html
@@ -4,12 +4,12 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(Set location)QBT_TR[CONTEXT=HttpServer]</title>
-    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
-    <script src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
+    <link rel="stylesheet" href="${BASE_PATH}css/style.css?v=${CACHEID}" type="text/css">
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
     <script>
         "use strict";
 
@@ -52,7 +52,7 @@
 
                 const hashesList = new URI().getData("hashes");
                 new Request({
-                    url: "api/v2/torrents/setLocation",
+                    url: "${BASE_PATH}api/v2/torrents/setLocation",
                     method: "post",
                     data: {
                         hashes: hashesList,

--- a/src/webui/www/private/shareratio.html
+++ b/src/webui/www/private/shareratio.html
@@ -4,12 +4,12 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(Torrent Upload/Download Ratio Limiting)QBT_TR[CONTEXT=UpDownRatioDialog]</title>
-    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
-    <script src="scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
+    <link rel="stylesheet" href="${BASE_PATH}css/style.css?v=${CACHEID}" type="text/css">
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/misc.js?locale=${LANG}&v=${CACHEID}"></script>
     <script>
         "use strict";
 
@@ -106,7 +106,7 @@
                 }
 
                 new Request({
-                    url: "api/v2/torrents/setShareLimits",
+                    url: "${BASE_PATH}api/v2/torrents/setShareLimits",
                     method: "post",
                     data: {
                         hashes: hashesList.join("|"),

--- a/src/webui/www/private/upload.html
+++ b/src/webui/www/private/upload.html
@@ -4,18 +4,18 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(Upload local torrent)QBT_TR[CONTEXT=HttpServer]</title>
-    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <link rel="stylesheet" href="css/Window.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
-    <script src="scripts/download.js?v=${CACHEID}"></script>
-    <script src="scripts/pathAutofill.js?v=${CACHEID}"></script>
+    <link rel="stylesheet" href="${BASE_PATH}css/style.css?v=${CACHEID}" type="text/css">
+    <link rel="stylesheet" href="${BASE_PATH}css/Window.css?v=${CACHEID}" type="text/css">
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/download.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/pathAutofill.js?v=${CACHEID}"></script>
 </head>
 
 <body>
     <iframe id="upload_frame" name="upload_frame" class="invisible" title="" src="about:blank"></iframe>
-    <form action="api/v2/torrents/add" enctype="multipart/form-data" method="post" id="uploadForm" style="text-align: center;" target="upload_frame" autocorrect="off" autocapitalize="none">
+    <form action="${BASE_PATH}api/v2/torrents/add" enctype="multipart/form-data" method="post" id="uploadForm" style="text-align: center;" target="upload_frame" autocorrect="off" autocapitalize="none">
         <div style="margin-top: 25px; display: inline-block; border: 1px solid lightgrey; border-radius: 4px;">
             <input type="file" id="fileselect" accept=".torrent, application/x-bittorrent" name="fileselect[]" multiple aria-label="QBT_TR(Select .torrent files)QBT_TR[CONTEXT=AddNewTorrentDialog]">
         </div>

--- a/src/webui/www/private/uploadlimit.html
+++ b/src/webui/www/private/uploadlimit.html
@@ -4,13 +4,13 @@
 <head>
     <meta charset="UTF-8">
     <title>QBT_TR(Torrent Upload Speed Limiting)QBT_TR[CONTEXT=TransferListWidget]</title>
-    <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css">
-    <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
-    <script src="scripts/lib/mocha.min.js"></script>
-    <script src="scripts/localpreferences.js?v=${CACHEID}"></script>
-    <script src="scripts/color-scheme.js?v=${CACHEID}"></script>
-    <script src="scripts/speedslider.js?v=${CACHEID}"></script>
+    <link rel="stylesheet" href="${BASE_PATH}css/style.css?v=${CACHEID}" type="text/css">
+    <script src="${BASE_PATH}scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>
+    <script src="${BASE_PATH}scripts/lib/mocha.min.js"></script>
+    <script src="${BASE_PATH}scripts/localpreferences.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/color-scheme.js?v=${CACHEID}"></script>
+    <script src="${BASE_PATH}scripts/speedslider.js?v=${CACHEID}"></script>
 </head>
 
 <body>
@@ -38,7 +38,7 @@
             const limit = Number($("uplimitUpdatevalue").value) * 1024;
             if (hashes[0] === "global") {
                 new Request({
-                    url: "api/v2/transfer/setUploadLimit",
+                    url: "${BASE_PATH}api/v2/transfer/setUploadLimit",
                     method: "post",
                     data: {
                         "limit": limit
@@ -51,7 +51,7 @@
             }
             else {
                 new Request({
-                    url: "api/v2/torrents/setUploadLimit",
+                    url: "${BASE_PATH}api/v2/torrents/setUploadLimit",
                     method: "post",
                     data: {
                         "hashes": hashes.join("|"),

--- a/src/webui/www/private/views/about.html
+++ b/src/webui/www/private/views/about.html
@@ -1,7 +1,7 @@
 <div id="aboutAboutContent" class="aboutTabContent">
-    <img src="images/mascot.png" style="float: left;" alt="QBT_TR(qBittorrent Mascot)QBT_TR[CONTEXT=AboutDialog]">
+    <img src="${BASE_PATH}images/mascot.png" style="float: left;" alt="QBT_TR(qBittorrent Mascot)QBT_TR[CONTEXT=AboutDialog]">
     <div>
-        <img src="images/qbittorrent-tray.svg" style="float: left; height: 1.5em;" alt="QBT_TR(qBittorrent icon)QBT_TR[CONTEXT=AboutDialog]">
+        <img src="${BASE_PATH}images/qbittorrent-tray.svg" style="float: left; height: 1.5em;" alt="QBT_TR(qBittorrent icon)QBT_TR[CONTEXT=AboutDialog]">
         <h3 id="qbittorrentVersion">qBittorrent</h3>
     </div>
     <p>QBT_TR(An advanced BitTorrent client programmed in C++, based on Qt toolkit and libtorrent-rasterbar.)QBT_TR[CONTEXT=AboutDialog]</p>

--- a/src/webui/www/private/views/confirmAutoTMM.html
+++ b/src/webui/www/private/views/confirmAutoTMM.html
@@ -27,7 +27,7 @@
         cancelButton.addEventListener("click", (e) => { window.qBittorrent.Client.closeWindow(id); });
         confirmButton.addEventListener("click", (e) => {
             new Request({
-                url: "api/v2/torrents/setAutoManagement",
+                url: "${BASE_PATH}api/v2/torrents/setAutoManagement",
                 method: "post",
                 data: {
                     hashes: hashes.join("|"),

--- a/src/webui/www/private/views/confirmRecheck.html
+++ b/src/webui/www/private/views/confirmRecheck.html
@@ -29,7 +29,7 @@
         });
         confirmButton.addEventListener("click", (e) => {
             new Request({
-                url: "api/v2/torrents/recheck",
+                url: "${BASE_PATH}api/v2/torrents/recheck",
                 method: "post",
                 data: {
                     hashes: hashes.join("|"),

--- a/src/webui/www/private/views/confirmdeletion.html
+++ b/src/webui/www/private/views/confirmdeletion.html
@@ -78,7 +78,7 @@
                 : torrentsTable.selectedRowsIds();
 
             new Request({
-                url: "api/v2/torrents/delete",
+                url: "${BASE_PATH}api/v2/torrents/delete",
                 method: "post",
                 data: {
                     "hashes": hashes.join("|"),

--- a/src/webui/www/private/views/cookies.html
+++ b/src/webui/www/private/views/cookies.html
@@ -62,7 +62,7 @@
                 <td class="name"><input type="text" aria-label="QBT_TR(Name)QBT_TR[CONTEXT=CookiesDialog]" autocomplete="off" autocorrect="off" autocapitalize="none"></td>
                 <td class="value"><input type="text" aria-label="QBT_TR(Value)QBT_TR[CONTEXT=CookiesDialog]" autocomplete="off" autocorrect="off" autocapitalize="none"></td>
                 <td class="expDate"><input type="datetime-local" aria-label="QBT_TR(Expiration Date)QBT_TR[CONTEXT=CookiesDialog]"></td>
-                <td><img class="removeCookie" src="images/list-remove.svg" alt="QBT_TR(Remove)QBT_TR[CONTEXT=CookiesDialog]"></td>
+                <td><img class="removeCookie" src="${BASE_PATH}images/list-remove.svg" alt="QBT_TR(Remove)QBT_TR[CONTEXT=CookiesDialog]"></td>
             </tr>
         </tbody>
         <tfoot>
@@ -72,7 +72,7 @@
                 <td></td>
                 <td></td>
                 <td></td>
-                <td><img class="addCookie" src="images/list-add.svg" alt="QBT_TR(Add Cookie)QBT_TR[CONTEXT=CookiesDialog]"></td>
+                <td><img class="addCookie" src="${BASE_PATH}images/list-add.svg" alt="QBT_TR(Add Cookie)QBT_TR[CONTEXT=CookiesDialog]"></td>
             </tr>
         </tfoot>
     </table>
@@ -124,7 +124,7 @@
             });
 
             new Request({
-                url: "api/v2/app/setCookies",
+                url: "${BASE_PATH}api/v2/app/setCookies",
                 method: "post",
                 noCache: true,
                 data: {
@@ -144,7 +144,7 @@
 
         const loadCookies = () => {
             new Request.JSON({
-                url: "api/v2/app/cookies",
+                url: "${BASE_PATH}api/v2/app/cookies",
                 method: "get",
                 onFailure: (response) => {
                     let error = "Unable to load cookies";

--- a/src/webui/www/private/views/filters.html
+++ b/src/webui/www/private/views/filters.html
@@ -1,41 +1,41 @@
 <div class="filterWrapper">
     <span class="filterTitle">
-        <img src="images/go-down.svg" alt="QBT_TR(Collapse/expand)QBT_TR[CONTEXT=TransferListFiltersWidget]">QBT_TR(Status)QBT_TR[CONTEXT=TransferListFiltersWidget]
+        <img src="${BASE_PATH}images/go-down.svg" alt="QBT_TR(Collapse/expand)QBT_TR[CONTEXT=TransferListFiltersWidget]">QBT_TR(Status)QBT_TR[CONTEXT=TransferListFiltersWidget]
     </span>
     <ul class="filterList" id="statusFilterList">
-        <li class="statusesFilterContextMenuTarget" id="all_filter"><span class="link"><img src="images/filter-all.svg" alt="All">QBT_TR(All (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
-        <li class="statusesFilterContextMenuTarget" id="downloading_filter"><span class="link"><img src="images/downloading.svg" alt="Downloading">QBT_TR(Downloading (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
-        <li class="statusesFilterContextMenuTarget" id="seeding_filter"><span class="link"><img src="images/upload.svg" alt="Seeding">QBT_TR(Seeding (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
-        <li class="statusesFilterContextMenuTarget" id="completed_filter"><span class="link"><img src="images/checked-completed.svg" alt="Completed">QBT_TR(Completed (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
-        <li class="statusesFilterContextMenuTarget" id="running_filter"><span class="link"><img src="images/torrent-start.svg" alt="Running">QBT_TR(Running (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
-        <li class="statusesFilterContextMenuTarget" id="stopped_filter"><span class="link"><img src="images/stopped.svg" alt="Stopped">QBT_TR(Stopped (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
-        <li class="statusesFilterContextMenuTarget" id="active_filter"><span class="link"><img src="images/filter-active.svg" alt="Active">QBT_TR(Active (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
-        <li class="statusesFilterContextMenuTarget" id="inactive_filter"><span class="link"><img src="images/filter-inactive.svg" alt="Inactive">QBT_TR(Inactive (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
-        <li class="statusesFilterContextMenuTarget" id="stalled_filter"><span class="link"><img src="images/filter-stalled.svg" alt="Stalled">QBT_TR(Stalled (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
-        <li class="statusesFilterContextMenuTarget" id="stalled_uploading_filter"><span class="link"><img src="images/stalledUP.svg" alt="Stalled Uploading">QBT_TR(Stalled Uploading (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
-        <li class="statusesFilterContextMenuTarget" id="stalled_downloading_filter"><span class="link"><img src="images/stalledDL.svg" alt="Stalled Downloading">QBT_TR(Stalled Downloading (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
-        <li class="statusesFilterContextMenuTarget" id="checking_filter"><span class="link"><img src="images/force-recheck.svg" alt="Checking">QBT_TR(Checking (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
-        <li class="statusesFilterContextMenuTarget" id="moving_filter"><span class="link"><img src="images/set-location.svg" alt="Moving">QBT_TR(Moving (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
-        <li class="statusesFilterContextMenuTarget" id="errored_filter"><span class="link"><img src="images/error.svg" alt="Errored">QBT_TR(Errored (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
+        <li class="statusesFilterContextMenuTarget" id="all_filter"><span class="link"><img src="${BASE_PATH}images/filter-all.svg" alt="All">QBT_TR(All (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
+        <li class="statusesFilterContextMenuTarget" id="downloading_filter"><span class="link"><img src="${BASE_PATH}images/downloading.svg" alt="Downloading">QBT_TR(Downloading (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
+        <li class="statusesFilterContextMenuTarget" id="seeding_filter"><span class="link"><img src="${BASE_PATH}images/upload.svg" alt="Seeding">QBT_TR(Seeding (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
+        <li class="statusesFilterContextMenuTarget" id="completed_filter"><span class="link"><img src="${BASE_PATH}images/checked-completed.svg" alt="Completed">QBT_TR(Completed (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
+        <li class="statusesFilterContextMenuTarget" id="running_filter"><span class="link"><img src="${BASE_PATH}images/torrent-start.svg" alt="Running">QBT_TR(Running (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
+        <li class="statusesFilterContextMenuTarget" id="stopped_filter"><span class="link"><img src="${BASE_PATH}images/stopped.svg" alt="Stopped">QBT_TR(Stopped (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
+        <li class="statusesFilterContextMenuTarget" id="active_filter"><span class="link"><img src="${BASE_PATH}images/filter-active.svg" alt="Active">QBT_TR(Active (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
+        <li class="statusesFilterContextMenuTarget" id="inactive_filter"><span class="link"><img src="${BASE_PATH}images/filter-inactive.svg" alt="Inactive">QBT_TR(Inactive (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
+        <li class="statusesFilterContextMenuTarget" id="stalled_filter"><span class="link"><img src="${BASE_PATH}images/filter-stalled.svg" alt="Stalled">QBT_TR(Stalled (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
+        <li class="statusesFilterContextMenuTarget" id="stalled_uploading_filter"><span class="link"><img src="${BASE_PATH}images/stalledUP.svg" alt="Stalled Uploading">QBT_TR(Stalled Uploading (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
+        <li class="statusesFilterContextMenuTarget" id="stalled_downloading_filter"><span class="link"><img src="${BASE_PATH}images/stalledDL.svg" alt="Stalled Downloading">QBT_TR(Stalled Downloading (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
+        <li class="statusesFilterContextMenuTarget" id="checking_filter"><span class="link"><img src="${BASE_PATH}images/force-recheck.svg" alt="Checking">QBT_TR(Checking (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
+        <li class="statusesFilterContextMenuTarget" id="moving_filter"><span class="link"><img src="${BASE_PATH}images/set-location.svg" alt="Moving">QBT_TR(Moving (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
+        <li class="statusesFilterContextMenuTarget" id="errored_filter"><span class="link"><img src="${BASE_PATH}images/error.svg" alt="Errored">QBT_TR(Errored (0))QBT_TR[CONTEXT=StatusFilterWidget]</span></li>
     </ul>
 </div>
 <div class="filterWrapper">
     <span class="filterTitle">
-        <img src="images/go-down.svg" alt="QBT_TR(Collapse/expand)QBT_TR[CONTEXT=TransferListFiltersWidget]">QBT_TR(Categories)QBT_TR[CONTEXT=TransferListFiltersWidget]
+        <img src="${BASE_PATH}images/go-down.svg" alt="QBT_TR(Collapse/expand)QBT_TR[CONTEXT=TransferListFiltersWidget]">QBT_TR(Categories)QBT_TR[CONTEXT=TransferListFiltersWidget]
     </span>
     <ul class="filterList" id="categoryFilterList">
     </ul>
 </div>
 <div class="filterWrapper">
     <span class="filterTitle">
-        <img src="images/go-down.svg" alt="QBT_TR(Collapse/expand)QBT_TR[CONTEXT=TransferListFiltersWidget]">QBT_TR(Tags)QBT_TR[CONTEXT=TransferListFiltersWidget]
+        <img src="${BASE_PATH}images/go-down.svg" alt="QBT_TR(Collapse/expand)QBT_TR[CONTEXT=TransferListFiltersWidget]">QBT_TR(Tags)QBT_TR[CONTEXT=TransferListFiltersWidget]
     </span>
     <ul class="filterList" id="tagFilterList">
     </ul>
 </div>
 <div class="filterWrapper">
     <span class="filterTitle">
-        <img src="images/go-down.svg" alt="QBT_TR(Collapse/expand)QBT_TR[CONTEXT=TransferListFiltersWidget]">QBT_TR(Trackers)QBT_TR[CONTEXT=TransferListFiltersWidget]
+        <img src="${BASE_PATH}images/go-down.svg" alt="QBT_TR(Collapse/expand)QBT_TR[CONTEXT=TransferListFiltersWidget]">QBT_TR(Trackers)QBT_TR[CONTEXT=TransferListFiltersWidget]
     </span>
     <ul class="filterList" id="trackerFilterList">
     </ul>
@@ -45,7 +45,7 @@
     <li class="categoriesFilterContextMenuTarget">
         <span class="link">
             <button class="categoryToggle" type="button" aria-label="QBT_TR(Collapse/expand category)QBT_TR[CONTEXT=TransferListFiltersWidget]"></button>
-            <img src="images/view-categories.svg" width="16" height="16" alt="">
+            <img src="${BASE_PATH}images/view-categories.svg" width="16" height="16" alt="">
             <span></span>
         </span>
     </li>
@@ -53,14 +53,14 @@
 <template id="tagFilterItem">
     <li class="tagsFilterContextMenuTarget">
         <span class="link">
-            <img src="images/tags.svg" alt="">
+            <img src="${BASE_PATH}images/tags.svg" alt="">
         </span>
     </li>
 </template>
 <template id="trackerFilterItem">
     <li class="trackersFilterContextMenuTarget">
         <span class="link">
-            <img src="images/trackers.svg" alt="">
+            <img src="${BASE_PATH}images/trackers.svg" alt="">
         </span>
     </li>
 </template>

--- a/src/webui/www/private/views/installsearchplugin.html
+++ b/src/webui/www/private/views/installsearchplugin.html
@@ -62,7 +62,7 @@
             const path = $("newPluginPath").value.trim();
             if (path) {
                 new Request({
-                    url: "api/v2/search/installPlugin",
+                    url: "${BASE_PATH}api/v2/search/installPlugin",
                     method: "post",
                     data: {
                         sources: path,

--- a/src/webui/www/private/views/log.html
+++ b/src/webui/www/private/views/log.html
@@ -41,7 +41,7 @@
     }
 
     #filterTextInput {
-        background-image: url("../images/edit-find.svg");
+        background-image: url("${BASE_PATH}images/edit-find.svg");
         background-repeat: no-repeat;
         background-position: left;
         background-size: 1.5em;
@@ -144,8 +144,8 @@
 </div>
 
 <ul id="logTableMenu" class="contextMenu">
-    <li><a href="#" class="copyLogDataToClipboard"><img src="images/edit-copy.svg" alt="QBT_TR(Copy)QBT_TR[CONTEXT=ExecutionLogWidget]">QBT_TR(Copy)QBT_TR[CONTEXT=ExecutionLogWidget]</a></li>
-    <li><a href="#Clear"><img src="images/list-remove.svg" alt="QBT_TR(Clear)QBT_TR[CONTEXT=ExecutionLogWidget]">QBT_TR(Clear)QBT_TR[CONTEXT=ExecutionLogWidget]</a></li>
+    <li><a href="#" class="copyLogDataToClipboard"><img src="${BASE_PATH}images/edit-copy.svg" alt="QBT_TR(Copy)QBT_TR[CONTEXT=ExecutionLogWidget]">QBT_TR(Copy)QBT_TR[CONTEXT=ExecutionLogWidget]</a></li>
+    <li><a href="#Clear"><img src="${BASE_PATH}images/list-remove.svg" alt="QBT_TR(Clear)QBT_TR[CONTEXT=ExecutionLogWidget]">QBT_TR(Clear)QBT_TR[CONTEXT=ExecutionLogWidget]</a></li>
 </ul>
 
 <script>
@@ -341,7 +341,7 @@
 
             let url;
             if (curTab === "main") {
-                url = new URI("api/v2/log/main");
+                url = new URI("${BASE_PATH}api/v2/log/main");
                 url.setData({
                     normal: selectedLogLevels.indexOf("1") !== -1,
                     info: selectedLogLevels.indexOf("2") !== -1,
@@ -350,7 +350,7 @@
                 });
             }
             else {
-                url = new URI("api/v2/log/peers");
+                url = new URI("${BASE_PATH}api/v2/log/peers");
             }
 
             url.setData("last_known_id", tableInfo[curTab].last_id);

--- a/src/webui/www/private/views/logTabs.html
+++ b/src/webui/www/private/views/logTabs.html
@@ -1,10 +1,10 @@
 <div class="toolbarTabs">
     <menu id="panelTabs" class="tab-menu">
         <li id="logMessageLink" class="selected">
-            <a><img alt="QBT_TR(General)QBT_TR[CONTEXT=ExecutionLogWidget]" src="images/help-contents.svg" width="16" height="16">QBT_TR(General)QBT_TR[CONTEXT=ExecutionLogWidget]</a>
+            <a><img alt="QBT_TR(General)QBT_TR[CONTEXT=ExecutionLogWidget]" src="${BASE_PATH}images/help-contents.svg" width="16" height="16">QBT_TR(General)QBT_TR[CONTEXT=ExecutionLogWidget]</a>
         </li>
         <li id="logPeerLink">
-            <a><img alt="QBT_TR(Blocked IPs)QBT_TR[CONTEXT=ExecutionLogWidget]" src="images/ip-blocked.svg" width="16" height="16">QBT_TR(Blocked IPs)QBT_TR[CONTEXT=ExecutionLogWidget]</a>
+            <a><img alt="QBT_TR(Blocked IPs)QBT_TR[CONTEXT=ExecutionLogWidget]" src="${BASE_PATH}images/ip-blocked.svg" width="16" height="16">QBT_TR(Blocked IPs)QBT_TR[CONTEXT=ExecutionLogWidget]</a>
         </li>
     </menu>
     <div class="clear"></div>

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -590,7 +590,7 @@
             <tbody>
                 <tr>
                     <td rowspan="2">
-                        <img src="images/slow_off.svg" style="height: 2.5em;" alt="QBT_TR(Alternative speed limits)QBT_TR[CONTEXT=MainWindow]">
+                        <img src="${BASE_PATH}images/slow_off.svg" style="height: 2.5em;" alt="QBT_TR(Alternative speed limits)QBT_TR[CONTEXT=MainWindow]">
                     </td>
                     <td><label for="up_limit_value">QBT_TR(Upload:)QBT_TR[CONTEXT=OptionsDialog]</label></td>
                     <td><input type="number" id="up_limit_value" style="width: 6em;" min="0">&nbsp;&nbsp;QBT_TR(KiB/s)QBT_TR[CONTEXT=OptionsDialog]</td>
@@ -610,7 +610,7 @@
             <tbody>
                 <tr>
                     <td rowspan="2">
-                        <img src="images/slow.svg" style="height: 2.5em;" alt="QBT_TR(Alternative speed limits)QBT_TR[CONTEXT=MainWindow]">
+                        <img src="${BASE_PATH}images/slow.svg" style="height: 2.5em;" alt="QBT_TR(Alternative speed limits)QBT_TR[CONTEXT=MainWindow]">
                     </td>
                     <td><label for="alt_up_limit_value">QBT_TR(Upload:)QBT_TR[CONTEXT=OptionsDialog]</label></td>
                     <td><input type="number" id="alt_up_limit_value" style="width: 6em;" min="0">&nbsp;&nbsp;QBT_TR(KiB/s)QBT_TR[CONTEXT=OptionsDialog]</td>
@@ -1819,7 +1819,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 + "<option value='other'>QBT_TR(Other...)QBT_TR[CONTEXT=ScanFoldersModel]</option>"
                 + "</select>"
                 + "<input id='cb_watch_txt_" + pos + "' type='text' " + (disableInput ? "hidden " : "") + "/>"
-                + "<img src='images/list-add.svg' id='addFolderImg_" + pos + "' alt='Add' style='padding-left:170px;width:16px;cursor:pointer;' onclick='qBittorrent.Preferences.addWatchFolder();'>"
+                + "<img src='${BASE_PATH}images/list-add.svg' id='addFolderImg_" + pos + "' alt='Add' style='padding-left:170px;width:16px;cursor:pointer;' onclick='qBittorrent.Preferences.addWatchFolder();'>"
                 + "</div>";
 
             watchedFoldersTable.push([myinput, mycb]);
@@ -1893,7 +1893,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
 
         const sendTestEmail = () => {
             new Request({
-                url: "api/v2/app/sendTestEmail",
+                url: "${BASE_PATH}api/v2/app/sendTestEmail",
                 method: "post",
                 onFailure: () => {
                     alert("QBT_TR(Could not contact qBittorrent)QBT_TR[CONTEXT=HttpServer]");
@@ -2083,7 +2083,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
 
         // Advanced Tab
         const updateNetworkInterfaces = (default_iface, default_iface_name) => {
-            const url = "api/v2/app/networkInterfaceList";
+            const url = "${BASE_PATH}api/v2/app/networkInterfaceList";
             $("networkInterface").getChildren().each(c => c.destroy());
             new Request.JSON({
                 url: url,
@@ -2110,7 +2110,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
         };
 
         const updateInterfaceAddresses = (iface, default_addr) => {
-            const url = "api/v2/app/networkInterfaceAddressList";
+            const url = "${BASE_PATH}api/v2/app/networkInterfaceAddressList";
             $("optionalIPAddressToBind").getChildren().each(c => c.destroy());
             new Request.JSON({
                 url: url,

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1059,6 +1059,10 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 <input type="text" id="webUIReverseProxiesListTextarea" title="QBT_TR(Specify reverse proxy IPs (or subnets, e.g. 0.0.0.0/24) in order to use forwarded client address (X-Forwarded-For header). Use ';' to split multiple entries.)QBT_TR[CONTEXT=OptionsDialog]">
             </div>
             <div class="formRow">
+                <label for="webUIBasePathTextarea">QBT_TR(URL base path:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                <input type="text" id="webUIBasePathTextarea" title="QBT_TR(Specify the URL path qBittorent will be made accessible at (e.g. '/qbittorrent/').)QBT_TR[CONTEXT=OptionsDialog]">
+            </div>
+            <div class="formRow">
                 <a href="https://github.com/qbittorrent/qBittorrent/wiki#reverse-proxy-setup-for-webui-access" target="_blank">QBT_TR(Reverse proxy setup examples)QBT_TR[CONTEXT=HttpServer]</a>
             </div>
         </fieldset>
@@ -2045,6 +2049,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
         const updateWebUIReverseProxySettings = () => {
             const isEnabled = $("webUIReverseProxySupportCheckbox").checked;
             $("webUIReverseProxiesListTextarea").disabled = !isEnabled;
+            $("webUIBasePathTextarea").disabled = !isEnabled;
         };
 
         const updateDynDnsSettings = () => {
@@ -2490,6 +2495,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     // Reverse Proxy
                     $("webUIReverseProxySupportCheckbox").checked = pref.web_ui_reverse_proxy_enabled;
                     $("webUIReverseProxiesListTextarea").value = pref.web_ui_reverse_proxies_list;
+                    $("webUIBasePathTextarea").value = pref.web_ui_base_path;
                     updateWebUIReverseProxySettings();
 
                     // Update my dynamic domain name
@@ -2957,6 +2963,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             // Reverse Proxy
             settings["web_ui_reverse_proxy_enabled"] = $("webUIReverseProxySupportCheckbox").checked;
             settings["web_ui_reverse_proxies_list"] = $("webUIReverseProxiesListTextarea").value;
+            settings["web_ui_base_path"] = $("webUIBasePathTextarea").value;
 
             // Update my dynamic domain name
             settings["dyndns_enabled"] = $("use_dyndns_checkbox").checked;

--- a/src/webui/www/private/views/preferencesToolbar.html
+++ b/src/webui/www/private/views/preferencesToolbar.html
@@ -2,28 +2,28 @@
 <div class="toolbarTabs">
     <menu id="preferencesTabs" class="tab-menu">
         <li id="PrefBehaviorLink" class="selected">
-            <a><img alt="QBT_TR(Behavior)QBT_TR[CONTEXT=OptionsDialog]" src="images/preferences-desktop.svg" width="16" height="16">QBT_TR(Behavior)QBT_TR[CONTEXT=OptionsDialog]</a>
+            <a><img alt="QBT_TR(Behavior)QBT_TR[CONTEXT=OptionsDialog]" src="${BASE_PATH}images/preferences-desktop.svg" width="16" height="16">QBT_TR(Behavior)QBT_TR[CONTEXT=OptionsDialog]</a>
         </li>
         <li id="PrefDownloadsLink">
-            <a><img alt="QBT_TR(Downloads)QBT_TR[CONTEXT=OptionsDialog]" src="images/download.svg" width="16" height="16">QBT_TR(Downloads)QBT_TR[CONTEXT=OptionsDialog]</a>
+            <a><img alt="QBT_TR(Downloads)QBT_TR[CONTEXT=OptionsDialog]" src="${BASE_PATH}images/download.svg" width="16" height="16">QBT_TR(Downloads)QBT_TR[CONTEXT=OptionsDialog]</a>
         </li>
         <li id="PrefConnectionLink">
-            <a><img alt="QBT_TR(Connection)QBT_TR[CONTEXT=OptionsDialog]" src="images/network-connect.svg" width="16" height="16">QBT_TR(Connection)QBT_TR[CONTEXT=OptionsDialog]</a>
+            <a><img alt="QBT_TR(Connection)QBT_TR[CONTEXT=OptionsDialog]" src="${BASE_PATH}images/network-connect.svg" width="16" height="16">QBT_TR(Connection)QBT_TR[CONTEXT=OptionsDialog]</a>
         </li>
         <li id="PrefSpeedLink">
-            <a><img alt="QBT_TR(Speed)QBT_TR[CONTEXT=OptionsDialog]" src="images/slow_off.svg" width="16" height="16">QBT_TR(Speed)QBT_TR[CONTEXT=OptionsDialog]</a>
+            <a><img alt="QBT_TR(Speed)QBT_TR[CONTEXT=OptionsDialog]" src="${BASE_PATH}images/slow_off.svg" width="16" height="16">QBT_TR(Speed)QBT_TR[CONTEXT=OptionsDialog]</a>
         </li>
         <li id="PrefBittorrentLink">
-            <a><img alt="QBT_TR(BitTorrent)QBT_TR[CONTEXT=OptionsDialog]" src="images/preferences-bittorrent.svg" width="16" height="16">QBT_TR(BitTorrent)QBT_TR[CONTEXT=OptionsDialog]</a>
+            <a><img alt="QBT_TR(BitTorrent)QBT_TR[CONTEXT=OptionsDialog]" src="${BASE_PATH}images/preferences-bittorrent.svg" width="16" height="16">QBT_TR(BitTorrent)QBT_TR[CONTEXT=OptionsDialog]</a>
         </li>
         <li id="PrefRSSLink">
-            <a><img alt="QBT_TR(RSS)QBT_TR[CONTEXT=OptionsDialog]" src="images/application-rss.svg" width="16" height="16">QBT_TR(RSS)QBT_TR[CONTEXT=OptionsDialog]</a>
+            <a><img alt="QBT_TR(RSS)QBT_TR[CONTEXT=OptionsDialog]" src="${BASE_PATH}images/application-rss.svg" width="16" height="16">QBT_TR(RSS)QBT_TR[CONTEXT=OptionsDialog]</a>
         </li>
         <li id="PrefWebUILink">
-            <a><img alt="QBT_TR(WebUI)QBT_TR[CONTEXT=OptionsDialog]" src="images/preferences-webui.svg" width="16" height="16">QBT_TR(WebUI)QBT_TR[CONTEXT=OptionsDialog]</a>
+            <a><img alt="QBT_TR(WebUI)QBT_TR[CONTEXT=OptionsDialog]" src="${BASE_PATH}images/preferences-webui.svg" width="16" height="16">QBT_TR(WebUI)QBT_TR[CONTEXT=OptionsDialog]</a>
         </li>
         <li id="PrefAdvancedLink">
-            <a><img alt="QBT_TR(Advanced)QBT_TR[CONTEXT=OptionsDialog]" src="images/preferences-advanced.svg" width="16" height="16">QBT_TR(Advanced)QBT_TR[CONTEXT=OptionsDialog]</a>
+            <a><img alt="QBT_TR(Advanced)QBT_TR[CONTEXT=OptionsDialog]" src="${BASE_PATH}images/preferences-advanced.svg" width="16" height="16">QBT_TR(Advanced)QBT_TR[CONTEXT=OptionsDialog]</a>
         </li>
     </menu>
     <div class="clear"></div>

--- a/src/webui/www/private/views/propertiesToolbar.html
+++ b/src/webui/www/private/views/propertiesToolbar.html
@@ -4,19 +4,19 @@
     </div>
     <menu id="propertiesTabs" class="tab-menu">
         <li id="propGeneralLink">
-            <a><img alt="QBT_TR(General)QBT_TR[CONTEXT=PropTabBar]" src="images/help-about.svg" width="16" height="16">QBT_TR(General)QBT_TR[CONTEXT=PropTabBar]</a>
+            <a><img alt="QBT_TR(General)QBT_TR[CONTEXT=PropTabBar]" src="${BASE_PATH}images/help-about.svg" width="16" height="16">QBT_TR(General)QBT_TR[CONTEXT=PropTabBar]</a>
         </li>
         <li id="propTrackersLink">
-            <a><img alt="QBT_TR(Trackers)QBT_TR[CONTEXT=PropTabBar]" src="images/trackers.svg" width="16" height="16">QBT_TR(Trackers)QBT_TR[CONTEXT=PropTabBar]</a>
+            <a><img alt="QBT_TR(Trackers)QBT_TR[CONTEXT=PropTabBar]" src="${BASE_PATH}images/trackers.svg" width="16" height="16">QBT_TR(Trackers)QBT_TR[CONTEXT=PropTabBar]</a>
         </li>
         <li id="propPeersLink">
-            <a><img alt="QBT_TR(Peers)QBT_TR[CONTEXT=PropTabBar]" src="images/peers.svg" width="16" height="16">QBT_TR(Peers)QBT_TR[CONTEXT=PropTabBar]</a>
+            <a><img alt="QBT_TR(Peers)QBT_TR[CONTEXT=PropTabBar]" src="${BASE_PATH}images/peers.svg" width="16" height="16">QBT_TR(Peers)QBT_TR[CONTEXT=PropTabBar]</a>
         </li>
         <li id="propWebSeedsLink">
-            <a><img alt="QBT_TR(HTTP Sources)QBT_TR[CONTEXT=PropTabBar]" src="images/network-server.svg" width="16" height="16">QBT_TR(HTTP Sources)QBT_TR[CONTEXT=PropTabBar]</a>
+            <a><img alt="QBT_TR(HTTP Sources)QBT_TR[CONTEXT=PropTabBar]" src="${BASE_PATH}images/network-server.svg" width="16" height="16">QBT_TR(HTTP Sources)QBT_TR[CONTEXT=PropTabBar]</a>
         </li>
         <li id="propFilesLink">
-            <a><img alt="QBT_TR(Content)QBT_TR[CONTEXT=PropTabBar]" src="images/directory.svg" width="16" height="16">QBT_TR(Content)QBT_TR[CONTEXT=PropTabBar]</a>
+            <a><img alt="QBT_TR(Content)QBT_TR[CONTEXT=PropTabBar]" src="${BASE_PATH}images/directory.svg" width="16" height="16">QBT_TR(Content)QBT_TR[CONTEXT=PropTabBar]</a>
         </li>
     </menu>
     <div class="clear"></div>

--- a/src/webui/www/private/views/rss.html
+++ b/src/webui/www/private/views/rss.html
@@ -109,16 +109,16 @@
         </div>
         <div id="rssButtonBar">
             <button type="button" id="newSubscriptionButton" onclick="qBittorrent.Rss.addRSSFeed()">
-                <img alt="QBT_TR(New subscription)QBT_TR[CONTEXT=RSSWidget]" src="images/list-add.svg" width="16" height="16">QBT_TR(New subscription)QBT_TR[CONTEXT=RSSWidget]
+                <img alt="QBT_TR(New subscription)QBT_TR[CONTEXT=RSSWidget]" src="${BASE_PATH}images/list-add.svg" width="16" height="16">QBT_TR(New subscription)QBT_TR[CONTEXT=RSSWidget]
             </button>
             <button type="button" id="markReadButton" onclick="qBittorrent.Rss.markSelectedAsRead()">
-                <img alt="QBT_TR(Mark items read)QBT_TR[CONTEXT=RSSWidget]" src="images/task-complete.svg" width="16" height="16">QBT_TR(Mark items read)QBT_TR[CONTEXT=RSSWidget]
+                <img alt="QBT_TR(Mark items read)QBT_TR[CONTEXT=RSSWidget]" src="${BASE_PATH}images/task-complete.svg" width="16" height="16">QBT_TR(Mark items read)QBT_TR[CONTEXT=RSSWidget]
             </button>
             <button type="button" id="updateAllButton" onclick="qBittorrent.Rss.refreshAllFeeds()">
-                <img alt="QBT_TR(Update all)QBT_TR[CONTEXT=RSSWidget]" src="images/view-refresh.svg" width="16" height="16">QBT_TR(Update all)QBT_TR[CONTEXT=RSSWidget]
+                <img alt="QBT_TR(Update all)QBT_TR[CONTEXT=RSSWidget]" src="${BASE_PATH}images/view-refresh.svg" width="16" height="16">QBT_TR(Update all)QBT_TR[CONTEXT=RSSWidget]
             </button>
             <button type="button" id="rssDownloaderButton" class="alignRight" onclick="qBittorrent.Rss.openRssDownloader()">
-                <img alt="QBT_TR(RSS Downloader...)QBT_TR[CONTEXT=RSSWidget]" src="images/downloading.svg" width="16" height="16">QBT_TR(RSS Downloader...)QBT_TR[CONTEXT=RSSWidget]
+                <img alt="QBT_TR(RSS Downloader...)QBT_TR[CONTEXT=RSSWidget]" src="${BASE_PATH}images/downloading.svg" width="16" height="16">QBT_TR(RSS Downloader...)QBT_TR[CONTEXT=RSSWidget]
             </button>
         </div>
     </div>
@@ -164,22 +164,22 @@
 </div>
 
 <ul id="rssFeedMenu" class="contextMenu">
-    <li><a href="#update"><img src="images/view-refresh.svg" alt="QBT_TR(Update)QBT_TR[CONTEXT=RSSWidget]"> QBT_TR(Update)QBT_TR[CONTEXT=RSSWidget]</a></li>
-    <li><a href="#markRead"><img src="images/task-complete.svg" alt="QBT_TR(Mark items read)QBT_TR[CONTEXT=RSSWidget]"> QBT_TR(Mark items read)QBT_TR[CONTEXT=RSSWidget]</a></li>
-    <li class="separator"><a href="#rename"><img src="images/edit-rename.svg" alt="QBT_TR(Rename...)QBT_TR[CONTEXT=RSSWidget]"> QBT_TR(Rename...)QBT_TR[CONTEXT=RSSWidget]</a></li>
-    <li><a href="#edit"><img src="images/edit-rename.svg" alt="QBT_TR(Edit feed URL...)QBT_TR[CONTEXT=RSSWidget]"> QBT_TR(Edit feed URL...)QBT_TR[CONTEXT=RSSWidget]</a></li>
-    <li><a href="#delete"><img src="images/edit-clear.svg" alt="QBT_TR(Delete)QBT_TR[CONTEXT=RSSWidget]"> QBT_TR(Delete)QBT_TR[CONTEXT=RSSWidget]</a></li>
+    <li><a href="#update"><img src="${BASE_PATH}images/view-refresh.svg" alt="QBT_TR(Update)QBT_TR[CONTEXT=RSSWidget]"> QBT_TR(Update)QBT_TR[CONTEXT=RSSWidget]</a></li>
+    <li><a href="#markRead"><img src="${BASE_PATH}images/task-complete.svg" alt="QBT_TR(Mark items read)QBT_TR[CONTEXT=RSSWidget]"> QBT_TR(Mark items read)QBT_TR[CONTEXT=RSSWidget]</a></li>
+    <li class="separator"><a href="#rename"><img src="${BASE_PATH}images/edit-rename.svg" alt="QBT_TR(Rename...)QBT_TR[CONTEXT=RSSWidget]"> QBT_TR(Rename...)QBT_TR[CONTEXT=RSSWidget]</a></li>
+    <li><a href="#edit"><img src="${BASE_PATH}images/edit-rename.svg" alt="QBT_TR(Edit feed URL...)QBT_TR[CONTEXT=RSSWidget]"> QBT_TR(Edit feed URL...)QBT_TR[CONTEXT=RSSWidget]</a></li>
+    <li><a href="#delete"><img src="${BASE_PATH}images/edit-clear.svg" alt="QBT_TR(Delete)QBT_TR[CONTEXT=RSSWidget]"> QBT_TR(Delete)QBT_TR[CONTEXT=RSSWidget]</a></li>
 
-    <li class="separator"><a href="#newSubscription"><img src="images/list-add.svg" alt="QBT_TR(New subscription...)QBT_TR[CONTEXT=RSSWidget]"> QBT_TR(New subscription...)QBT_TR[CONTEXT=RSSWidget]</a></li>
-    <li><a href="#newFolder"><img src="images/folder-new.svg" alt="QBT_TR(New folder...)QBT_TR[CONTEXT=RSSWidget]"> QBT_TR(New folder...)QBT_TR[CONTEXT=RSSWidget]</a></li>
-    <li class="separator"><a href="#updateAll"><img src="images/view-refresh.svg" alt="QBT_TR(Update all feeds)QBT_TR[CONTEXT=RSSWidget]"> QBT_TR(Update all feeds)QBT_TR[CONTEXT=RSSWidget]</a></li>
+    <li class="separator"><a href="#newSubscription"><img src="${BASE_PATH}images/list-add.svg" alt="QBT_TR(New subscription...)QBT_TR[CONTEXT=RSSWidget]"> QBT_TR(New subscription...)QBT_TR[CONTEXT=RSSWidget]</a></li>
+    <li><a href="#newFolder"><img src="${BASE_PATH}images/folder-new.svg" alt="QBT_TR(New folder...)QBT_TR[CONTEXT=RSSWidget]"> QBT_TR(New folder...)QBT_TR[CONTEXT=RSSWidget]</a></li>
+    <li class="separator"><a href="#updateAll"><img src="${BASE_PATH}images/view-refresh.svg" alt="QBT_TR(Update all feeds)QBT_TR[CONTEXT=RSSWidget]"> QBT_TR(Update all feeds)QBT_TR[CONTEXT=RSSWidget]</a></li>
 
-    <li class="separator"><a href="#copyFeedURL" id="CopyFeedURL"><img src="images/edit-copy.svg" alt="QBT_TR(Copy feed URL)QBT_TR[CONTEXT=RSSWidget]"> QBT_TR(Copy feed URL)QBT_TR[CONTEXT=RSSWidget]</a></li>
+    <li class="separator"><a href="#copyFeedURL" id="CopyFeedURL"><img src="${BASE_PATH}images/edit-copy.svg" alt="QBT_TR(Copy feed URL)QBT_TR[CONTEXT=RSSWidget]"> QBT_TR(Copy feed URL)QBT_TR[CONTEXT=RSSWidget]</a></li>
 </ul>
 
 <ul id="rssArticleMenu" class="contextMenu">
-    <li><a href="#Download"><img src="images/downloading.svg" alt="QBT_TR(Download torrent)QBT_TR[CONTEXT=RSSWidget]"> QBT_TR(Download torrent)QBT_TR[CONTEXT=RSSWidget]</a></li>
-    <li><a href="#OpenNews"><img src="images/application-url.svg" alt="QBT_TR(Open news URL)QBT_TR[CONTEXT=RSSWidget]"> QBT_TR(Open news URL)QBT_TR[CONTEXT=RSSWidget]</a></li>
+    <li><a href="#Download"><img src="${BASE_PATH}images/downloading.svg" alt="QBT_TR(Download torrent)QBT_TR[CONTEXT=RSSWidget]"> QBT_TR(Download torrent)QBT_TR[CONTEXT=RSSWidget]</a></li>
+    <li><a href="#OpenNews"><img src="${BASE_PATH}images/application-url.svg" alt="QBT_TR(Open news URL)QBT_TR[CONTEXT=RSSWidget]"> QBT_TR(Open news URL)QBT_TR[CONTEXT=RSSWidget]</a></li>
 </ul>
 
 <script>
@@ -340,7 +340,7 @@
 
             new MochaUI.Window({
                 id: "newFeed",
-                icon: "images/qbittorrent-tray.svg",
+                icon: "${BASE_PATH}images/qbittorrent-tray.svg",
                 title: "QBT_TR(Please type a RSS feed URL)QBT_TR[CONTEXT=RSSWidget]",
                 loadMethod: "iframe",
                 contentURL: "newfeed.html?path=" + encodeURIComponent(path),
@@ -368,7 +368,7 @@
 
             new MochaUI.Window({
                 id: "newFolder",
-                icon: "images/qbittorrent-tray.svg",
+                icon: "${BASE_PATH}images/qbittorrent-tray.svg",
                 title: "QBT_TR(Please choose a folder name)QBT_TR[CONTEXT=RSSWidget]",
                 loadMethod: "iframe",
                 contentURL: "newfolder.html?path=" + encodeURIComponent(path),
@@ -449,13 +449,13 @@
                 // Place in iframe with sandbox attribute to prevent js execution
                 const torrentDescription = document.createRange().createContextualFragment('<iframe sandbox id="rssDescription"></iframe>');
                 $("rssDetailsView").append(torrentDescription);
-                document.getElementById("rssDescription").srcdoc = '<html><head><link rel="stylesheet" type="text/css" href="css/style.css"></head><body>' + article.description + "</body></html>";
+                document.getElementById("rssDescription").srcdoc = '<html><head><link rel="stylesheet" type="text/css" href="${BASE_PATH}css/style.css"></head><body>' + article.description + "</body></html>";
             }
         };
 
         const updateRssFeedList = () => {
             new Request.JSON({
-                url: "api/v2/rss/items",
+                url: "${BASE_PATH}api/v2/rss/items",
                 method: "get",
                 noCache: true,
                 data: {
@@ -700,7 +700,7 @@
             rssFeedTable.updateIcons();
 
             new Request({
-                url: "api/v2/rss/refreshItem",
+                url: "${BASE_PATH}api/v2/rss/refreshItem",
                 method: "post",
                 data: {
                     itemPath: pathByFeedId.get(feedUid)
@@ -723,7 +723,7 @@
         const moveItem = (oldPath) => {
             new MochaUI.Window({
                 id: "renamePage",
-                icon: "images/qbittorrent-tray.svg",
+                icon: "${BASE_PATH}images/qbittorrent-tray.svg",
                 title: "QBT_TR(Please choose a new name for this RSS feed)QBT_TR[CONTEXT=RSSWidget]",
                 loadMethod: "iframe",
                 contentURL: "rename_feed.html?oldPath=" + encodeURIComponent(oldPath),
@@ -738,7 +738,7 @@
         const editUrl = (path, url) => {
             new MochaUI.Window({
                 id: "editFeedURL",
-                icon: "images/qbittorrent-tray.svg",
+                icon: "${BASE_PATH}images/qbittorrent-tray.svg",
                 title: "QBT_TR(Please type a RSS feed URL)QBT_TR[CONTEXT=RSSWidget]",
                 loadMethod: "iframe",
                 contentURL: new URI("editfeedurl.html").setData("path", path).setData("url", url).toString(),
@@ -754,7 +754,7 @@
             const encodedPaths = paths.map((path) => encodeURIComponent(path));
             new MochaUI.Window({
                 id: "confirmFeedDeletionPage",
-                icon: "images/qbittorrent-tray.svg",
+                icon: "${BASE_PATH}images/qbittorrent-tray.svg",
                 title: "QBT_TR(Deletion confirmation)QBT_TR[CONTEXT=RSSWidget]",
                 loadMethod: "iframe",
                 contentURL: "confirmfeeddeletion.html?paths=" + encodeURIComponent(encodedPaths.join("|")),
@@ -803,7 +803,7 @@
 
             // send request
             new Request({
-                url: "api/v2/rss/markAsRead",
+                url: "${BASE_PATH}api/v2/rss/markAsRead",
                 method: "post",
                 data: {
                     itemPath: path
@@ -844,7 +844,7 @@
                 rssFeedTable.updateTable(true);
 
                 new Request({
-                    url: "api/v2/rss/markAsRead",
+                    url: "${BASE_PATH}api/v2/rss/markAsRead",
                     method: "post",
                     data: {
                         itemPath: path,
@@ -872,7 +872,7 @@
             const id = "rssdownloaderpage";
             new MochaUI.Window({
                 id: id,
-                icon: "images/qbittorrent-tray.svg",
+                icon: "${BASE_PATH}images/qbittorrent-tray.svg",
                 title: "QBT_TR(Rss Downloader)QBT_TR[CONTEXT=AutomatedRssDownloader]",
                 loadMethod: "xhr",
                 contentURL: "views/rssDownloader.html",

--- a/src/webui/www/private/views/rssDownloader.html
+++ b/src/webui/www/private/views/rssDownloader.html
@@ -118,12 +118,12 @@
 
     #newRuleButton {
         float: right;
-        background-image: url('images/list-add.svg');
+        background-image: url('${BASE_PATH}images/list-add.svg');
     }
 
     #deleteRuleButton {
         float: right;
-        background-image: url('images/edit-clear.svg');
+        background-image: url('${BASE_PATH}images/edit-clear.svg');
     }
 
 </style>
@@ -332,10 +332,10 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
 </div>
 
 <ul id="rssDownloaderRuleMenu" class="contextMenu">
-    <li><a href="#addRule"><img src="images/list-add.svg" alt="QBT_TR(Add new rule...)QBT_TR[CONTEXT=AutomatedRssDownloader]"> QBT_TR(Add new rule...)QBT_TR[CONTEXT=AutomatedRssDownloader]</a></li>
-    <li><a href="#deleteRule"><img src="images/edit-clear.svg" alt="QBT_TR(Delete rule)QBT_TR[CONTEXT=AutomatedRssDownloader]"> QBT_TR(Delete rule)QBT_TR[CONTEXT=AutomatedRssDownloader]</a></li>
-    <li class="separator"><a href="#renameRule"><img src="images/edit-rename.svg" alt="QBT_TR(Rename rule...)QBT_TR[CONTEXT=AutomatedRssDownloader]"> QBT_TR(Rename rule...)QBT_TR[CONTEXT=AutomatedRssDownloader]</a></li>
-    <li class="separator"><a href="#clearDownloadedEpisodes"><img src="images/edit-clear.svg" alt="QBT_TR(Clear downloaded episodes...)QBT_TR[CONTEXT=AutomatedRssDownloader]"> QBT_TR(Clear downloaded episodes...)QBT_TR[CONTEXT=AutomatedRssDownloader]</a></li>
+    <li><a href="#addRule"><img src="${BASE_PATH}images/list-add.svg" alt="QBT_TR(Add new rule...)QBT_TR[CONTEXT=AutomatedRssDownloader]"> QBT_TR(Add new rule...)QBT_TR[CONTEXT=AutomatedRssDownloader]</a></li>
+    <li><a href="#deleteRule"><img src="${BASE_PATH}images/edit-clear.svg" alt="QBT_TR(Delete rule)QBT_TR[CONTEXT=AutomatedRssDownloader]"> QBT_TR(Delete rule)QBT_TR[CONTEXT=AutomatedRssDownloader]</a></li>
+    <li class="separator"><a href="#renameRule"><img src="${BASE_PATH}images/edit-rename.svg" alt="QBT_TR(Rename rule...)QBT_TR[CONTEXT=AutomatedRssDownloader]"> QBT_TR(Rename rule...)QBT_TR[CONTEXT=AutomatedRssDownloader]</a></li>
+    <li class="separator"><a href="#clearDownloadedEpisodes"><img src="${BASE_PATH}images/edit-clear.svg" alt="QBT_TR(Clear downloaded episodes...)QBT_TR[CONTEXT=AutomatedRssDownloader]"> QBT_TR(Clear downloaded episodes...)QBT_TR[CONTEXT=AutomatedRssDownloader]</a></li>
 </ul>
 
 <script>
@@ -438,7 +438,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
             });
             // get all categories and add to combobox
             new Request.JSON({
-                url: "api/v2/torrents/categories",
+                url: "${BASE_PATH}api/v2/torrents/categories",
                 method: "get",
                 noCache: true,
                 onSuccess: (response) => {
@@ -455,7 +455,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
             }).send();
             // get all rss feed
             new Request.JSON({
-                url: "api/v2/rss/items",
+                url: "${BASE_PATH}api/v2/rss/items",
                 method: "get",
                 noCache: true,
                 data: {
@@ -483,7 +483,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
         const updateRulesList = () => {
             // get all rules
             new Request.JSON({
-                url: "api/v2/rss/rules",
+                url: "${BASE_PATH}api/v2/rss/rules",
                 method: "get",
                 noCache: true,
                 onSuccess: (response) => {
@@ -507,7 +507,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
         const modifyRuleState = (rule, setting, newState, callback = () => {}) => {
             rulesList[rule][setting] = newState;
             new Request({
-                url: "api/v2/rss/setRule",
+                url: "${BASE_PATH}api/v2/rss/setRule",
                 method: "post",
                 data: {
                     ruleName: rule,
@@ -522,7 +522,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
         const addRule = () => {
             new MochaUI.Window({
                 id: "newRulePage",
-                icon: "images/qbittorrent-tray.svg",
+                icon: "${BASE_PATH}images/qbittorrent-tray.svg",
                 title: "QBT_TR(New rule name)QBT_TR[CONTEXT=AutomatedRssDownloader]",
                 loadMethod: "iframe",
                 contentURL: "newrule.html",
@@ -537,7 +537,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
         const renameRule = (rule) => {
             new MochaUI.Window({
                 id: "renameRulePage",
-                icon: "images/qbittorrent-tray.svg",
+                icon: "${BASE_PATH}images/qbittorrent-tray.svg",
                 title: "QBT_TR(Rule renaming)QBT_TR[CONTEXT=AutomatedRssDownloader]",
                 loadMethod: "iframe",
                 contentURL: "rename_rule.html?rule=" + encodeURIComponent(rule),
@@ -560,7 +560,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
             const encodedRules = rules.map((rule) => encodeURIComponent(rule));
             new MochaUI.Window({
                 id: "removeRulePage",
-                icon: "images/qbittorrent-tray.svg",
+                icon: "${BASE_PATH}images/qbittorrent-tray.svg",
                 title: "QBT_TR(Rule deletion confirmation)QBT_TR[CONTEXT=AutomatedRssDownloader]",
                 loadMethod: "iframe",
                 contentURL: "confirmruledeletion.html?rules=" + encodeURIComponent(encodedRules.join("|")),
@@ -576,7 +576,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
             const encodedRules = rules.map((rule) => encodeURIComponent(rule));
             new MochaUI.Window({
                 id: "clearRulesPage",
-                icon: "images/qbittorrent-tray.svg",
+                icon: "${BASE_PATH}images/qbittorrent-tray.svg",
                 title: "QBT_TR(New rule name)QBT_TR[CONTEXT=AutomatedRssDownloader]",
                 loadMethod: "iframe",
                 contentURL: "confirmruleclear.html?rules=" + encodeURIComponent(encodedRules.join("|")),
@@ -640,7 +640,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
             }
 
             new Request({
-                url: "api/v2/rss/setRule",
+                url: "${BASE_PATH}api/v2/rss/setRule",
                 method: "post",
                 data: {
                     ruleName: rule,
@@ -654,7 +654,7 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
 
         const updateMatchingArticles = (ruleName) => {
             new Request.JSON({
-                url: "api/v2/rss/matchingArticles",
+                url: "${BASE_PATH}api/v2/rss/matchingArticles",
                 method: "get",
                 noCache: true,
                 data: {

--- a/src/webui/www/private/views/search.html
+++ b/src/webui/www/private/views/search.html
@@ -1,7 +1,7 @@
 <style>
     #searchPattern {
         width: 300px;
-        background-image: url("images/edit-find.svg");
+        background-image: url("${BASE_PATH}images/edit-find.svg");
         background-repeat: no-repeat;
         background-size: 1.5em;
         background-position: left;
@@ -93,7 +93,7 @@
             <select id="categorySelect" class="searchInputField" aria-label="QBT_TR(Select category)QBT_TR[CONTEXT=SearchEngineWidget]" onchange="qBittorrent.Search.categorySelected()"></select>
             <select id="pluginsSelect" class="searchInputField" aria-label="QBT_TR(Select plugins)QBT_TR[CONTEXT=SearchEngineWidget]" onchange="qBittorrent.Search.pluginSelected()"></select>
             <button type="button" id="startSearchButton" class="searchInputField" onclick="qBittorrent.Search.startStopSearch()">
-                <img src="images/edit-find.svg" alt="QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]" width="16" height="16">QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]
+                <img src="${BASE_PATH}images/edit-find.svg" alt="QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]" width="16" height="16">QBT_TR(Search)QBT_TR[CONTEXT=SearchEngineWidget]
             </button>
         </div>
     </div>
@@ -143,7 +143,7 @@
                 <option value="everywhere">QBT_TR(Everywhere)QBT_TR[CONTEXT=SearchEngineWidget]</option>
             </select>
 
-            <img id="searchResultsGranularFiltersWarning" src="images/dialog-warning.svg" title="QBT_TR(Increase window width to display additional filters)QBT_TR[CONTEXT=SearchEngineWidget]" alt="QBT_TR(Warning)QBT_TR[CONTEXT=SearchEngineWidget]" width="24" height="24">
+            <img id="searchResultsGranularFiltersWarning" src="${BASE_PATH}images/dialog-warning.svg" title="QBT_TR(Increase window width to display additional filters)QBT_TR[CONTEXT=SearchEngineWidget]" alt="QBT_TR(Warning)QBT_TR[CONTEXT=SearchEngineWidget]" width="24" height="24">
 
             <div id="searchResultsGranularFilters">
                 <label for="searchMinSeedsFilter" style="margin-left: 15px;">QBT_TR(Seeds:)QBT_TR[CONTEXT=SearchEngineWidget]</label>
@@ -197,20 +197,20 @@
 
     <div style="height: 30px; padding-top: 10px;">
         <button type="button" id="manageSearchPlugins" onclick="qBittorrent.Search.manageSearchPlugins()">
-            <img alt="QBT_TR(Search plugins...)QBT_TR[CONTEXT=SearchEngineWidget]" src="images/plugins.svg" width="16" height="16">QBT_TR(Search plugins...)QBT_TR[CONTEXT=SearchEngineWidget]
+            <img alt="QBT_TR(Search plugins...)QBT_TR[CONTEXT=SearchEngineWidget]" src="${BASE_PATH}images/plugins.svg" width="16" height="16">QBT_TR(Search plugins...)QBT_TR[CONTEXT=SearchEngineWidget]
         </button>
     </div>
 </div>
 
 <ul id="searchResultsTableMenu" class="contextMenu">
-    <li><a href="#Download"><img src="images/downloading.svg" alt="QBT_TR(Download)QBT_TR[CONTEXT=SearchJobWidget]"> QBT_TR(Download)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
-    <li class="separator"><a href="#OpenDescriptionUrl"><img src="images/application-url.svg" alt="QBT_TR(Open description page)QBT_TR[CONTEXT=SearchJobWidget]"> QBT_TR(Open description page)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
+    <li><a href="#Download"><img src="${BASE_PATH}images/downloading.svg" alt="QBT_TR(Download)QBT_TR[CONTEXT=SearchJobWidget]"> QBT_TR(Download)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
+    <li class="separator"><a href="#OpenDescriptionUrl"><img src="${BASE_PATH}images/application-url.svg" alt="QBT_TR(Open description page)QBT_TR[CONTEXT=SearchJobWidget]"> QBT_TR(Open description page)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
     <li>
-        <a href="#" class="arrow-right"><img src="images/edit-copy.svg" alt="QBT_TR(Copy)QBT_TR[CONTEXT=SearchJobWidget]"> QBT_TR(Copy)QBT_TR[CONTEXT=SearchJobWidget]</a>
+        <a href="#" class="arrow-right"><img src="${BASE_PATH}images/edit-copy.svg" alt="QBT_TR(Copy)QBT_TR[CONTEXT=SearchJobWidget]"> QBT_TR(Copy)QBT_TR[CONTEXT=SearchJobWidget]</a>
         <ul>
-            <li><a href="#" id="copySearchTorrentName" class="copySearchDataToClipboard"><img src="images/name.svg" alt="QBT_TR(Name)QBT_TR[CONTEXT=SearchJobWidget]"> QBT_TR(Name)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
-            <li><a href="#" id="copySearchTorrentDownloadLink" class="copySearchDataToClipboard"><img src="images/insert-link.svg" alt="QBT_TR(Download link)QBT_TR[CONTEXT=SearchJobWidget]"> QBT_TR(Download link)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
-            <li><a href="#" id="copySearchTorrentDescriptionUrl" class="copySearchDataToClipboard"><img src="images/application-url.svg" alt="QBT_TR(Description page URL)QBT_TR[CONTEXT=SearchJobWidget]"> QBT_TR(Description page URL)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
+            <li><a href="#" id="copySearchTorrentName" class="copySearchDataToClipboard"><img src="${BASE_PATH}images/name.svg" alt="QBT_TR(Name)QBT_TR[CONTEXT=SearchJobWidget]"> QBT_TR(Name)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
+            <li><a href="#" id="copySearchTorrentDownloadLink" class="copySearchDataToClipboard"><img src="${BASE_PATH}images/insert-link.svg" alt="QBT_TR(Download link)QBT_TR[CONTEXT=SearchJobWidget]"> QBT_TR(Download link)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
+            <li><a href="#" id="copySearchTorrentDescriptionUrl" class="copySearchDataToClipboard"><img src="${BASE_PATH}images/application-url.svg" alt="QBT_TR(Description page URL)QBT_TR[CONTEXT=SearchJobWidget]"> QBT_TR(Description page URL)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
         </ul>
     </li>
 </ul>

--- a/src/webui/www/private/views/searchplugins.html
+++ b/src/webui/www/private/views/searchplugins.html
@@ -68,8 +68,8 @@
 </div>
 
 <ul id="searchPluginsTableMenu" class="contextMenu">
-    <li><a href="#Enabled"><img src="images/checked-completed.svg" alt="QBT_TR(Enabled)QBT_TR[CONTEXT=PluginSelectDlg]"> QBT_TR(Enabled)QBT_TR[CONTEXT=PluginSelectDlg]</a></li>
-    <li class="separator"><a href="#Uninstall"><img src="images/list-remove.svg" alt="QBT_TR(Uninstall)QBT_TR[CONTEXT=PluginSelectDlg]"> QBT_TR(Uninstall)QBT_TR[CONTEXT=PluginSelectDlg]</a></li>
+    <li><a href="#Enabled"><img src="${BASE_PATH}images/checked-completed.svg" alt="QBT_TR(Enabled)QBT_TR[CONTEXT=PluginSelectDlg]"> QBT_TR(Enabled)QBT_TR[CONTEXT=PluginSelectDlg]</a></li>
+    <li class="separator"><a href="#Uninstall"><img src="${BASE_PATH}images/list-remove.svg" alt="QBT_TR(Uninstall)QBT_TR[CONTEXT=PluginSelectDlg]"> QBT_TR(Uninstall)QBT_TR[CONTEXT=PluginSelectDlg]</a></li>
 </ul>
 
 <script>
@@ -120,7 +120,7 @@
         const installPlugin = (path) => {
             new MochaUI.Window({
                 id: "installSearchPlugin",
-                icon: "images/qbittorrent-tray.svg",
+                icon: "${BASE_PATH}images/qbittorrent-tray.svg",
                 title: "QBT_TR(Install plugin)QBT_TR[CONTEXT=PluginSourceDlg]",
                 loadMethod: "xhr",
                 contentURL: "views/installsearchplugin.html",
@@ -136,7 +136,7 @@
 
         const uninstallPlugin = () => {
             const plugins = searchPluginsTable.selectedRowsIds().join("|");
-            const url = new URI("api/v2/search/uninstallPlugin");
+            const url = new URI("${BASE_PATH}api/v2/search/uninstallPlugin");
             new Request({
                 url: url,
                 method: "post",
@@ -152,7 +152,7 @@
             if (plugins && plugins.length)
                 enable = !window.qBittorrent.Search.getPlugin(plugins[0]).enabled;
 
-            const url = new URI("api/v2/search/enablePlugin");
+            const url = new URI("${BASE_PATH}api/v2/search/enablePlugin");
             new Request({
                 url: url,
                 method: "post",
@@ -164,7 +164,7 @@
         };
 
         const checkForUpdates = () => {
-            const url = new URI("api/v2/search/updatePlugins");
+            const url = new URI("${BASE_PATH}api/v2/search/updatePlugins");
             new Request({
                 url: url,
                 method: "post"

--- a/src/webui/www/public/index.html
+++ b/src/webui/www/public/index.html
@@ -9,14 +9,14 @@
 
     <title>QBT_TR(qBittorrent WebUI)QBT_TR[CONTEXT=Login]</title>
 
-    <link rel="icon" type="image/png" href="images/qbittorrent32.png">
-    <link rel="icon" type="image/svg+xml" href="images/qbittorrent-tray.svg">
-    <link rel="stylesheet" type="text/css" href="css/login.css?v=${CACHEID}">
+    <link rel="icon" type="image/png" href="${BASE_PATH}images/qbittorrent32.png">
+    <link rel="icon" type="image/svg+xml" href="${BASE_PATH}images/qbittorrent-tray.svg">
+    <link rel="stylesheet" type="text/css" href="${BASE_PATH}css/login.css?v=${CACHEID}">
     <noscript>
-        <link rel="stylesheet" type="text/css" href="css/noscript.css?v=${CACHEID}">
+        <link rel="stylesheet" type="text/css" href="${BASE_PATH}css/noscript.css?v=${CACHEID}">
     </noscript>
 
-    <script defer src="scripts/login.js?locale=${LANG}&v=${CACHEID}"></script>
+    <script defer src="${BASE_PATH}scripts/login.js?locale=${LANG}&v=${CACHEID}"></script>
 </head>
 
 <body>
@@ -26,7 +26,7 @@
     <div id="main">
         <h1>QBT_TR(qBittorrent WebUI)QBT_TR[CONTEXT=Login]</h1>
         <div id="logo" class="col">
-            <img src="images/qbittorrent-tray.svg" alt="qBittorrent logo">
+            <img src="${BASE_PATH}images/qbittorrent-tray.svg" alt="qBittorrent logo">
         </div>
         <div id="formplace" class="col">
             <form id="loginform">

--- a/src/webui/www/public/scripts/login.js
+++ b/src/webui/www/public/scripts/login.js
@@ -37,7 +37,7 @@ const submitLoginForm = (event) => {
     const usernameElement = document.getElementById("username");
     const passwordElement = document.getElementById("password");
 
-    fetch("api/v2/auth/login", {
+    fetch("${BASE_PATH}api/v2/auth/login", {
             method: "POST",
             body: new URLSearchParams({
                 "username": usernameElement.value,


### PR DESCRIPTION
This PR adds support for configuring the URL base path used to access the WebUI. This makes it easier to use qBittorrent behind a reverse proxy with a custom path (e.g. `https://example.com/qbit/`).

The WebUI previously relied heavily on relative paths. For example, api requests were made to `api/v2/...` and scripts were loaded from `scripts/lib/...` (note the lack of a leading `/`). Now, the WebUI exclusively makes use of absolute paths, defaulting to a base path of `/`. These means that, by default, these resources will be loaded from `/api/v2/...` and `/scripts/lib...`, respectively. An empty base path can no longer be set - if attempting to do so, it will use `/`.

Closes #5693.

![Screenshot 2024-10-02 at 11 16 00](https://github.com/user-attachments/assets/935edf89-dca4-421e-af3a-f7789eccb764)
