### PR TITLE
WebUI: Fix incorrect row ID

### DIFF
--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1107,7 +1107,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                         </select>
                     </td>
                 </tr>
-                <tr id="rowMemoryWorkingSetLimit">
+                <tr id="rowTorrentContentRemoveOption">
                     <td>
                         <label for="torrentContentRemoveOption">QBT_TR(Torrent content removing mode:)QBT_TR[CONTEXT=OptionsDialog]</label>
                     </td>
@@ -1118,7 +1118,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                         </select>
                     </td>
                 </tr>
-                <tr>
+                <tr id="rowMemoryWorkingSetLimit">
                     <td>
                         <label for="memoryWorkingSetLimit">QBT_TR(Physical memory (RAM) usage limit:)QBT_TR[CONTEXT=OptionsDialog]&nbsp;<a href="https://wikipedia.org/wiki/Working_set" target="_blank">(?)</a></label>
                     </td>


### PR DESCRIPTION
Incorrect row ID prevented the "Torrent content removing mode" option from being displayed on some platforms.
