### PR TITLE
Don't try to apply Mark-of-the-Web to nonexistent files

### DIFF
--- a/src/base/utils/os.cpp
+++ b/src/base/utils/os.cpp
@@ -271,6 +271,11 @@ Path Utils::OS::windowsSystemPath()
 #if defined(Q_OS_MACOS) || defined(Q_OS_WIN)
 bool Utils::OS::applyMarkOfTheWeb(const Path &file, const QString &url)
 {
+    // Trying to apply this to a non-existent file is unacceptable,
+    // as it may unexpectedly create such a file.
+    if (!file.exists())
+        return false;
+
     Q_ASSERT(url.isEmpty() || url.startsWith(u"http:") || url.startsWith(u"https:"));
 
 #ifdef Q_OS_MACOS


### PR DESCRIPTION
Trying to apply it to a nonexistent file is unacceptable, as it may unexpectedly create such a file.

Closes #21081.
Closes #21239.
Closes #21434.
Closes #21440.
