### PR TITLE
WebUI: Don't load Tabs & dynamicTable stylesheets in Properties panel

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -1434,7 +1434,6 @@ window.addEventListener("DOMContentLoaded", () => {
         },
         contentURL: "views/properties.html",
         require: {
-            css: ["css/Tabs.css", "css/dynamicTable.css"],
             js: ["scripts/prop-general.js", "scripts/prop-trackers.js", "scripts/prop-peers.js", "scripts/prop-webseeds.js", "scripts/prop-files.js"],
         },
         tabsURL: "views/propertiesToolbar.html",


### PR DESCRIPTION
This removes duplicate stylesheet imports that caused the transfer list to be completely collapsed in Chrome-based browsers.
Closes https://github.com/qbittorrent/qBittorrent/issues/21426.