### PR TITLE
WebUI: Use proper text color to highlight items in all filter lists

### DIFF
--- a/src/webui/www/private/css/style.css
+++ b/src/webui/www/private/css/style.css
@@ -529,7 +529,7 @@ ul.filterList {
 
 ul.filterList a,
 ul.filterList span.link {
-    color: var(--color-text-default);
+    color: inherit;
     cursor: pointer;
     display: block;
     overflow: hidden;


### PR DESCRIPTION
Previously, text color of selected filter items was not applied correctly in all situations, making them difficult to read. This improves existing styles so that text is always correctly distinguished from the background.

This fixes issue from second post in https://github.com/qbittorrent/qBittorrent/issues/21426