### PR TITLE
WebUI: Add context menu to search tabs

### DIFF
--- a/src/webui/www/private/views/search.html
+++ b/src/webui/www/private/views/search.html
@@ -213,3 +213,7 @@
         </ul>
     </li>
 </ul>
+<ul id="searchResultsTabsMenu" class="contextMenu">
+    <li><a href="#closeTab">QBT_TR(Close tab)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
+    <li><a href="#closeAllTabs">QBT_TR(Close all tabs)QBT_TR[CONTEXT=SearchJobWidget]</a></li>
+</ul>


### PR DESCRIPTION
This PR adds context menu to Search tabs (same options as in GUI):
![image](https://github.com/user-attachments/assets/9ccb1085-153f-4b4a-8821-7a580cd1162f)
