### PR TITLE
Add support for Thunar file manager

### DIFF
--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -203,6 +203,9 @@ void Utils::Gui::openFolderSelect(const Path &path)
     {
         proc.startDetached(u"konqueror"_s, {u"--select"_s, path.toString()});
     }
+    else if (output == u"thunar.desktop"){
+        proc.startDetached(u"thunar"_s, {path.toString()});
+    }
     else
     {
         // "caja" manager can't pinpoint the file, see: https://github.com/qbittorrent/qBittorrent/issues/5003

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -203,7 +203,8 @@ void Utils::Gui::openFolderSelect(const Path &path)
     {
         proc.startDetached(u"konqueror"_s, {u"--select"_s, path.toString()});
     }
-    else if (output == u"thunar.desktop"){
+    else if (output == u"thunar.desktop")
+    {
         proc.startDetached(u"thunar"_s, {path.toString()});
     }
     else


### PR DESCRIPTION
currently, on linux desktop, when we have Thunar installed as the default file manager, qbittorrent does not support open file manager and select the downloaded file when we double click that item.
thus, I added the Thunar support.