### PR TITLE
Import correct libraries

### DIFF
--- a/src/searchengine/nova3/helpers.py
+++ b/src/searchengine/nova3/helpers.py
@@ -1,4 +1,4 @@
-#VERSION: 1.47
+#VERSION: 1.48
 
 # Author:
 #  Christophe DUMEZ (chris@qbittorrent.org)
@@ -39,8 +39,7 @@ import tempfile
 import urllib.error
 import urllib.parse
 import urllib.request
-from collections.abc import Mapping
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Mapping, Match, Optional
 
 
 def getBrowserUserAgent() -> str:
@@ -75,7 +74,7 @@ if "sock_proxy" in os.environ and len(os.environ["sock_proxy"].strip()) > 0:
 def htmlentitydecode(s: str) -> str:
     # First convert alpha entities (such as &eacute;)
     # (Inspired from http://mail.python.org/pipermail/python-list/2007-June/443813.html)
-    def entity2char(m: re.Match[str]) -> str:
+    def entity2char(m: Match[str]) -> str:
         entity = m.group(1)
         if entity in html.entities.name2codepoint:
             return chr(html.entities.name2codepoint[entity])

--- a/src/searchengine/nova3/nova2.py
+++ b/src/searchengine/nova3/nova2.py
@@ -1,4 +1,4 @@
-#VERSION: 1.46
+#VERSION: 1.47
 
 # Author:
 #  Fabien Devaux <fab AT gnux DOT info>
@@ -37,12 +37,11 @@ import importlib
 import pathlib
 import sys
 import urllib.parse
-from collections.abc import Iterable, Iterator, Sequence
 from enum import Enum
 from glob import glob
 from multiprocessing import Pool, cpu_count
 from os import path
-from typing import Dict, List, Optional, Set, Tuple, Type
+from typing import Dict, Iterable, Iterator, List, Optional, Sequence, Set, Tuple, Type
 
 THREADED: bool = True
 try:

--- a/src/searchengine/nova3/novaprinter.py
+++ b/src/searchengine/nova3/novaprinter.py
@@ -1,4 +1,4 @@
-#VERSION: 1.50
+#VERSION: 1.51
 
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -25,8 +25,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import re
-from collections.abc import Mapping
-from typing import Any, Union
+from typing import Any, Mapping, Pattern, Union
 
 # TODO: enable the following when using Python >= 3.8
 #SearchResults = TypedDict('SearchResults', {
@@ -59,7 +58,7 @@ def prettyPrinter(dictionary: SearchResults) -> None:
         print(outtext, file=utf8stdout)
 
 
-sizeUnitRegex: re.Pattern[str] = re.compile(r"^(?P<size>\d*\.?\d+) *(?P<unit>[a-z]+)?", re.IGNORECASE)
+sizeUnitRegex: Pattern[str] = re.compile(r"^(?P<size>\d*\.?\d+) *(?P<unit>[a-z]+)?", re.IGNORECASE)
 
 
 def anySizeToBytes(size_string: Union[float, int, str]) -> int:


### PR DESCRIPTION
Fixes "plugin not supported" errors with python 3.8.

ps. Tested with python 3.7.9 & 3.8.10 on windows. Also tested master branch with python 3.9.13 & 3.12.4, no problem.