### PR TITLE
Bump search engine components version

### DIFF
--- a/src/searchengine/nova3/nova2.py
+++ b/src/searchengine/nova3/nova2.py
@@ -1,4 +1,4 @@
-#VERSION: 1.47
+#VERSION: 1.48
 
 # Author:
 #  Fabien Devaux <fab AT gnux DOT info>

--- a/src/searchengine/nova3/novaprinter.py
+++ b/src/searchengine/nova3/novaprinter.py
@@ -1,4 +1,4 @@
-#VERSION: 1.51
+#VERSION: 1.52
 
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
The master branch should have version larger than stable branch.
https://github.com/qbittorrent/qBittorrent/pull/21539/files#r1790078486

Master branch `helpers.py` already has version `1.49` so no need to bump it.