### PR TITLE
`QBT_USES_LIBTORRENT2` usage + dependency on `libtorrent`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ build/
 # Web UI tools
 node_modules
 package-lock.json
+.cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,9 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
 include(FeatureSummary)
 include(FeatureOptionsSetup)
 
+# add dependencies
+include(cmake/CPM.cmake)
+
 # features, list is loosely sorted by user's interests
 feature_option(GUI "Build GUI application" ON)
 feature_option(WEBUI "Enable built-in HTTP server for remote control" ON)

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MIT
+#
+# SPDX-FileCopyrightText: Copyright (c) 2019-2023 Lars Melchior and contributors
+
+set(CPM_DOWNLOAD_VERSION 0.40.2)
+set(CPM_HASH_SUM "c8cdc32c03816538ce22781ed72964dc864b2a34a310d3b7104812a5ca2d835d")
+
+if(CPM_SOURCE_CACHE)
+  set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+  set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+else()
+  set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+endif()
+
+# Expand relative path. This is important if the provided path contains a tilde (~)
+get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
+
+file(DOWNLOAD
+     https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+     ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM}
+)
+
+include(${CPM_DOWNLOAD_LOCATION})

--- a/cmake/Modules/CheckPackages.cmake
+++ b/cmake/Modules/CheckPackages.cmake
@@ -1,48 +1,9 @@
 # use CONFIG mode first in find_package
 set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 
-macro(find_libtorrent version)
-    if (UNIX AND (NOT APPLE) AND (NOT CYGWIN))
-        find_package(LibtorrentRasterbar QUIET ${version} COMPONENTS torrent-rasterbar)
-        if (NOT LibtorrentRasterbar_FOUND)
-            include(FindPkgConfig)
-            pkg_check_modules(LibtorrentRasterbar IMPORTED_TARGET GLOBAL "libtorrent-rasterbar>=${version}")
-            if (NOT LibtorrentRasterbar_FOUND)
-                message(
-                    FATAL_ERROR
-                    "Package LibtorrentRasterbar >= ${version} not found"
-                    " with CMake or pkg-config.\n- Set LibtorrentRasterbar_DIR to a directory containing"
-                    " a LibtorrentRasterbarConfig.cmake file or add the installation prefix of LibtorrentRasterbar"
-                    " to CMAKE_PREFIX_PATH.\n- Alternatively, make sure there is a valid libtorrent-rasterbar.pc"
-                    " file in your system's pkg-config search paths (use the system environment variable PKG_CONFIG_PATH"
-                    " to specify additional search paths if needed)."
-                )
-            endif()
-            add_library(LibtorrentRasterbar::torrent-rasterbar ALIAS PkgConfig::LibtorrentRasterbar)
-            # force a fake package to show up in the feature summary
-            set_property(GLOBAL APPEND PROPERTY
-                PACKAGES_FOUND
-                "LibtorrentRasterbar via pkg-config (version >= ${version})"
-            )
-            set_package_properties("LibtorrentRasterbar via pkg-config (version >= ${version})"
-                PROPERTIES
-                TYPE REQUIRED
-            )
-        else()
-            set_package_properties(LibtorrentRasterbar PROPERTIES TYPE REQUIRED)
-        endif()
-    else()
-        find_package(LibtorrentRasterbar ${version} REQUIRED COMPONENTS torrent-rasterbar)
-    endif()
-endmacro()
-
-find_libtorrent(${minLibtorrent1Version})
-if (LibtorrentRasterbar_FOUND AND (LibtorrentRasterbar_VERSION VERSION_GREATER_EQUAL 2.0))
-    find_libtorrent(${minLibtorrentVersion})
-endif()
+CPMAddPackage("gh:arvidn/libtorrent@2.0.10")
 
 # force variable type so that it always shows up in ccmake/cmake-gui frontends
-set_property(CACHE LibtorrentRasterbar_DIR PROPERTY TYPE PATH)
 find_package(Boost ${minBoostVersion} REQUIRED)
 find_package(OpenSSL ${minOpenSSLVersion} REQUIRED)
 find_package(ZLIB ${minZlibVersion} REQUIRED)

--- a/cmake/Modules/CommonConfig.cmake
+++ b/cmake/Modules/CommonConfig.cmake
@@ -99,7 +99,3 @@ endif()
 if (DBUS)
     target_compile_definitions(qbt_common_cfg INTERFACE QBT_USES_DBUS)
 endif()
-
-if (LibtorrentRasterbar_VERSION VERSION_GREATER_EQUAL ${minLibtorrentVersion})
-    target_compile_definitions(qbt_common_cfg INTERFACE QBT_USES_LIBTORRENT2)
-endif()

--- a/cmake/Modules/CommonConfig.cmake
+++ b/cmake/Modules/CommonConfig.cmake
@@ -5,19 +5,13 @@
 # treat value specified by the CXX_STANDARD target property as a requirement by default
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD 20)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTORCC_OPTIONS --compress-algo best --threshold 5)
 
 add_library(qbt_common_cfg INTERFACE)
-
-# C++ 20 support is required
-# See also https://cmake.org/cmake/help/latest/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html
-# for a breakdown of the features that CMake recognizes for each C++ standard
-target_compile_features(qbt_common_cfg INTERFACE
-    cxx_std_20
-)
 
 target_compile_definitions(qbt_common_cfg INTERFACE
     QT_DISABLE_DEPRECATED_UP_TO=0x060500

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -387,7 +387,7 @@ void Application::setMemoryWorkingSetLimit(const int size)
         return;
 
     m_storeMemoryWorkingSetLimit = size;
-#if defined(QBT_USES_LIBTORRENT2) && !defined(Q_OS_MACOS)
+#if !defined(Q_OS_MACOS)
     applyMemoryWorkingSetLimit();
 #endif
 }
@@ -814,7 +814,7 @@ int Application::exec()
     printf("%s\n", qUtf8Printable(loadingStr));
 #endif
 
-#if defined(QBT_USES_LIBTORRENT2) && !defined(Q_OS_MACOS)
+#if !defined(Q_OS_MACOS)
     applyMemoryWorkingSetLimit();
 #endif
 
@@ -1172,7 +1172,7 @@ void Application::shutdownCleanup([[maybe_unused]] QSessionManager &manager)
 }
 #endif
 
-#if defined(QBT_USES_LIBTORRENT2) && !defined(Q_OS_MACOS)
+#if !defined(Q_OS_MACOS)
 void Application::applyMemoryWorkingSetLimit() const
 {
     const size_t MiB = 1024 * 1024;

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -167,7 +167,7 @@ private:
     void runExternalProgram(const QString &programTemplate, const BitTorrent::Torrent *torrent) const;
     void sendNotificationEmail(const BitTorrent::Torrent *torrent);
 
-#if defined(QBT_USES_LIBTORRENT2) && !defined(Q_OS_MACOS)
+#if !defined(Q_OS_MACOS)
     void applyMemoryWorkingSetLimit() const;
 #endif
 

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -215,13 +215,15 @@ add_library(qbt_base STATIC
     utils/version.cpp
 )
 
+find_package(libtorrent REQUIRED)
+
 target_link_libraries(qbt_base
     PRIVATE
         OpenSSL::Crypto
         OpenSSL::SSL
         ZLIB::ZLIB
     PUBLIC
-        LibtorrentRasterbar::torrent-rasterbar
+        libtorrent
         Qt::Core
         Qt::CorePrivate
         Qt::Network

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -223,7 +223,7 @@ target_link_libraries(qbt_base
         OpenSSL::SSL
         ZLIB::ZLIB
     PUBLIC
-        libtorrent
+        torrent-rasterbar
         Qt::Core
         Qt::CorePrivate
         Qt::Network

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -215,8 +215,6 @@ add_library(qbt_base STATIC
     utils/version.cpp
 )
 
-find_package(libtorrent REQUIRED)
-
 target_link_libraries(qbt_base
     PRIVATE
         OpenSSL::Crypto

--- a/src/base/bittorrent/bencoderesumedatastorage.cpp
+++ b/src/base/bittorrent/bencoderesumedatastorage.cpp
@@ -308,12 +308,8 @@ BitTorrent::LoadResumeDataResult BitTorrent::BencodeResumeDataStorage::loadTorre
 
         p.ti = torrentInfo;
 
-#ifdef QBT_USES_LIBTORRENT2
         if (((p.info_hashes.has_v1() && (p.info_hashes.v1 != p.ti->info_hashes().v1))
                 || (p.info_hashes.has_v2() && (p.info_hashes.v2 != p.ti->info_hashes().v2))))
-#else
-        if (!p.info_hash.is_all_zeros() && (p.info_hash != p.ti->info_hash()))
-#endif
         {
             return nonstd::make_unexpected(tr("Mismatching info-hash detected in resume data"));
         }

--- a/src/base/bittorrent/customstorage.h
+++ b/src/base/bittorrent/customstorage.h
@@ -35,17 +35,12 @@
 
 #include "base/path.h"
 
-#ifdef QBT_USES_LIBTORRENT2
 #include <libtorrent/disk_interface.hpp>
 #include <libtorrent/file_storage.hpp>
 #include <libtorrent/io_context.hpp>
 
 #include <QHash>
-#else
-#include <libtorrent/storage.hpp>
-#endif
 
-#ifdef QBT_USES_LIBTORRENT2
 std::unique_ptr<lt::disk_interface> customDiskIOConstructor(
         lt::io_context &ioContext, lt::settings_interface const &settings, lt::counters &counters);
 std::unique_ptr<lt::disk_interface> customPosixDiskIOConstructor(
@@ -102,24 +97,3 @@ private:
     };
     QHash<lt::storage_index_t, StorageData> m_storageData;
 };
-
-#else
-
-lt::storage_interface *customStorageConstructor(const lt::storage_params &params, lt::file_pool &pool);
-
-class CustomStorage final : public lt::default_storage
-{
-public:
-    explicit CustomStorage(const lt::storage_params &params, lt::file_pool &filePool);
-
-    bool verify_resume_data(const lt::add_torrent_params &rd, const lt::aux::vector<std::string, lt::file_index_t> &links, lt::storage_error &ec) override;
-    void set_file_priority(lt::aux::vector<lt::download_priority_t, lt::file_index_t> &priorities, lt::storage_error &ec) override;
-    lt::status_t move_storage(const std::string &savePath, lt::move_flags_t flags, lt::storage_error &ec) override;
-
-private:
-    void handleCompleteFiles(const Path &savePath);
-
-    lt::aux::vector<lt::download_priority_t, lt::file_index_t> m_filePriorities;
-    Path m_savePath;
-};
-#endif

--- a/src/base/bittorrent/extensiondata.h
+++ b/src/base/bittorrent/extensiondata.h
@@ -35,12 +35,8 @@
 #include <libtorrent/announce_entry.hpp>
 #include <libtorrent/torrent_status.hpp>
 
-#ifdef QBT_USES_LIBTORRENT2
 #include <libtorrent/client_data.hpp>
 using LTClientData = lt::client_data_t;
-#else
-using LTClientData = void *;
-#endif
 
 struct ExtensionData
 {

--- a/src/base/bittorrent/infohash.cpp
+++ b/src/base/bittorrent/infohash.cpp
@@ -38,12 +38,10 @@ BitTorrent::InfoHash::InfoHash(const WrappedType &nativeHash)
 {
 }
 
-#ifdef QBT_USES_LIBTORRENT2
 BitTorrent::InfoHash::InfoHash(const SHA1Hash &v1, const SHA256Hash &v2)
     : InfoHash {WrappedType(v1, v2)}
 {
 }
-#endif
 
 bool BitTorrent::InfoHash::isValid() const
 {
@@ -52,38 +50,22 @@ bool BitTorrent::InfoHash::isValid() const
 
 bool BitTorrent::InfoHash::isHybrid() const
 {
-#ifdef QBT_USES_LIBTORRENT2
-    return (m_nativeHash.has_v1() && m_nativeHash.has_v2());
-#else
-    return false;
-#endif
+return (m_nativeHash.has_v1() && m_nativeHash.has_v2());
 }
 
 SHA1Hash BitTorrent::InfoHash::v1() const
 {
-#ifdef QBT_USES_LIBTORRENT2
-    return (m_nativeHash.has_v1() ? SHA1Hash(m_nativeHash.v1) : SHA1Hash());
-#else
-    return {m_nativeHash};
-#endif
+return (m_nativeHash.has_v1() ? SHA1Hash(m_nativeHash.v1) : SHA1Hash());
 }
 
 SHA256Hash BitTorrent::InfoHash::v2() const
 {
-#ifdef QBT_USES_LIBTORRENT2
-    return (m_nativeHash.has_v2() ? SHA256Hash(m_nativeHash.v2) : SHA256Hash());
-#else
-    return {};
-#endif
+return (m_nativeHash.has_v2() ? SHA256Hash(m_nativeHash.v2) : SHA256Hash());
 }
 
 BitTorrent::TorrentID BitTorrent::InfoHash::toTorrentID() const
 {
-#ifdef QBT_USES_LIBTORRENT2
-    return m_nativeHash.get_best();
-#else
-    return {m_nativeHash};
-#endif
+return m_nativeHash.get_best();
 }
 
 BitTorrent::InfoHash::operator WrappedType() const

--- a/src/base/bittorrent/infohash.h
+++ b/src/base/bittorrent/infohash.h
@@ -28,9 +28,7 @@
 
 #pragma once
 
-#ifdef QBT_USES_LIBTORRENT2
 #include <libtorrent/info_hash.hpp>
-#endif
 
 #include <QMetaType>
 
@@ -61,17 +59,11 @@ namespace BitTorrent
     class InfoHash
     {
     public:
-#ifdef QBT_USES_LIBTORRENT2
         using WrappedType = lt::info_hash_t;
-#else
-        using WrappedType = lt::sha1_hash;
-#endif
 
         InfoHash() = default;
         InfoHash(const WrappedType &nativeHash);
-#ifdef QBT_USES_LIBTORRENT2
         InfoHash(const SHA1Hash &v1, const SHA256Hash &v2);
-#endif
 
         bool isValid() const;
         bool isHybrid() const;

--- a/src/base/bittorrent/peerinfo.cpp
+++ b/src/base/bittorrent/peerinfo.cpp
@@ -184,7 +184,7 @@ QString PeerInfo::I2PAddress() const
     if (!useI2PSocket())
         return {};
 
-#if defined(QBT_USES_LIBTORRENT2) && TORRENT_USE_I2P
+#if TORRENT_USE_I2P
     if (m_I2PAddress.isEmpty())
     {
         const lt::sha256_hash destHash = m_nativeInfo.i2p_destination();

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -101,9 +101,7 @@ namespace BitTorrent
         {
             DisableOSCache = 0,
             EnableOSCache = 1,
-#ifdef QBT_USES_LIBTORRENT2
             WriteThrough = 2
-#endif
         };
         Q_ENUM_NS(DiskIOWriteMode)
 

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -117,9 +117,7 @@ namespace BitTorrent
         {
             int diskBlocksInUse = -1;
             int numBlocksRead = -1;
-#ifndef QBT_USES_LIBTORRENT2
             int numBlocksCacheHits = -1;
-#endif
             int writeJobs = -1;
             int readJobs = -1;
             int hashJobs = -1;
@@ -580,9 +578,7 @@ namespace BitTorrent
         void handleSocks5Alert(const lt::socks5_alert *alert) const;
         void handleI2PAlert(const lt::i2p_alert *alert) const;
         void handleTrackerAlert(const lt::tracker_alert *alert);
-#ifdef QBT_USES_LIBTORRENT2
         void handleTorrentConflictAlert(const lt::torrent_conflict_alert *alert);
-#endif
 
         TorrentImpl *createTorrent(const lt::torrent_handle &nativeHandle, const LoadTorrentParams &params);
 

--- a/src/base/bittorrent/torrentcreator.h
+++ b/src/base/bittorrent/torrentcreator.h
@@ -40,24 +40,17 @@
 
 namespace BitTorrent
 {
-#ifdef QBT_USES_LIBTORRENT2
     enum class TorrentFormat
     {
         V1,
         V2,
         Hybrid
     };
-#endif
 
     struct TorrentCreatorParams
     {
         bool isPrivate = false;
-#ifdef QBT_USES_LIBTORRENT2
         TorrentFormat torrentFormat = TorrentFormat::Hybrid;
-#else
-        bool isAlignmentOptimized = false;
-        int paddedFileSizeLimit = 0;
-#endif
         int pieceSize = 0;
         Path sourcePath;
         Path torrentFilePath;
@@ -87,12 +80,7 @@ namespace BitTorrent
 
         void run() override;
 
-#ifdef QBT_USES_LIBTORRENT2
         static int calculateTotalPieces(const Path &inputPath, int pieceSize, TorrentFormat torrentFormat);
-#else
-        static int calculateTotalPieces(const Path &inputPath, const int pieceSize
-                , const bool isAlignmentOptimized, int paddedFileSizeLimit);
-#endif
 
     public slots:
         void requestInterruption();

--- a/src/base/bittorrent/torrentdescriptor.cpp
+++ b/src/base/bittorrent/torrentdescriptor.cpp
@@ -152,11 +152,7 @@ BitTorrent::TorrentDescriptor::TorrentDescriptor(lt::add_torrent_params ltAddTor
 
 BitTorrent::InfoHash BitTorrent::TorrentDescriptor::infoHash() const
 {
-#ifdef QBT_USES_LIBTORRENT2
     return m_ltAddTorrentParams.info_hashes;
-#else
-    return m_ltAddTorrentParams.info_hash;
-#endif
 }
 
 QString BitTorrent::TorrentDescriptor::name() const
@@ -196,11 +192,7 @@ void BitTorrent::TorrentDescriptor::setTorrentInfo(TorrentInfo torrentInfo)
     {
         m_info = std::move(torrentInfo);
         m_ltAddTorrentParams.ti = m_info->nativeInfo();
-#ifdef QBT_USES_LIBTORRENT2
         m_ltAddTorrentParams.info_hashes = m_ltAddTorrentParams.ti->info_hashes();
-#else
-        m_ltAddTorrentParams.info_hash = m_ltAddTorrentParams.ti->info_hash();
-#endif
     }
 }
 

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -293,9 +293,7 @@ namespace BitTorrent
         void handleFastResumeRejectedAlert(const lt::fastresume_rejected_alert *p);
         void handleFileCompletedAlert(const lt::file_completed_alert *p);
         void handleFileErrorAlert(const lt::file_error_alert *p);
-#ifdef QBT_USES_LIBTORRENT2
         void handleFilePrioAlert(const lt::file_prio_alert *p);
-#endif
         void handleFileRenamedAlert(const lt::file_renamed_alert *p);
         void handleFileRenameFailedAlert(const lt::file_rename_failed_alert *p);
         void handleMetadataReceivedAlert(const lt::metadata_received_alert *p);

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -35,10 +35,8 @@
 #include <QString>
 #include <QUrl>
 
-#include "base/global.h"
 #include "base/path.h"
 #include "infohash.h"
-#include "trackerentry.h"
 
 using namespace BitTorrent;
 
@@ -77,11 +75,7 @@ InfoHash TorrentInfo::infoHash() const
 {
     if (!isValid()) return {};
 
-#ifdef QBT_USES_LIBTORRENT2
     return m_nativeInfo->info_hashes();
-#else
-    return m_nativeInfo->info_hash();
-#endif
 }
 
 QString TorrentInfo::name() const
@@ -182,12 +176,8 @@ qlonglong TorrentInfo::fileOffset(const int index) const
 QByteArray TorrentInfo::rawData() const
 {
     if (!isValid()) return {};
-#ifdef QBT_USES_LIBTORRENT2
     const lt::span<const char> infoSection {m_nativeInfo->info_section()};
     return {infoSection.data(), static_cast<int>(infoSection.size())};
-#else
-    return {m_nativeInfo->metadata().get(), m_nativeInfo->metadata_size()};
-#endif
 }
 
 PathList TorrentInfo::filesForPiece(const int pieceIndex) const

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -65,7 +65,7 @@ namespace
         QBITTORRENT_HEADER,
         RESUME_DATA_STORAGE,
         TORRENT_CONTENT_REMOVE_OPTION,
-#if defined(QBT_USES_LIBTORRENT2) && !defined(Q_OS_MACOS)
+#if !defined(Q_OS_MACOS)
         MEMORY_WORKING_SET_LIMIT,
 #endif
 #if defined(Q_OS_WIN)
@@ -116,25 +116,13 @@ namespace
         BDECODE_DEPTH_LIMIT,
         BDECODE_TOKEN_LIMIT,
         ASYNC_IO_THREADS,
-#ifdef QBT_USES_LIBTORRENT2
         HASHING_THREADS,
-#endif
         FILE_POOL_SIZE,
         CHECKING_MEM_USAGE,
-#ifndef QBT_USES_LIBTORRENT2
-        // cache
-        DISK_CACHE,
-        DISK_CACHE_TTL,
-#endif
         DISK_QUEUE_SIZE,
-#ifdef QBT_USES_LIBTORRENT2
         DISK_IO_TYPE,
-#endif
         DISK_IO_READ_MODE,
         DISK_IO_WRITE_MODE,
-#ifndef QBT_USES_LIBTORRENT2
-        COALESCE_RW,
-#endif
         PIECE_EXTENT_AFFINITY,
         SUGGEST_MODE,
         SEND_BUF_WATERMARK,
@@ -169,7 +157,7 @@ namespace
         PEER_TURNOVER_INTERVAL,
         REQUEST_QUEUE_SIZE,
         DHT_BOOTSTRAP_NODES,
-#if defined(QBT_USES_LIBTORRENT2) && TORRENT_USE_I2P
+#if TORRENT_USE_I2P
         I2P_INBOUND_QUANTITY,
         I2P_OUTBOUND_QUANTITY,
         I2P_INBOUND_LENGTH,
@@ -206,7 +194,7 @@ void AdvancedSettings::saveAdvancedSettings() const
     BitTorrent::Session *const session = BitTorrent::Session::instance();
 
     session->setResumeDataStorageType(m_comboBoxResumeDataStorage.currentData().value<BitTorrent::ResumeDataStorageType>());
-#if defined(QBT_USES_LIBTORRENT2) && !defined(Q_OS_MACOS)
+#if !defined(Q_OS_MACOS)
     // Physical memory (RAM) usage limit
     app()->setMemoryWorkingSetLimit(m_spinBoxMemoryWorkingSetLimit.value());
 #endif
@@ -219,32 +207,19 @@ void AdvancedSettings::saveAdvancedSettings() const
     pref->setBdecodeTokenLimit(m_spinBoxBdecodeTokenLimit.value());
     // Async IO threads
     session->setAsyncIOThreads(m_spinBoxAsyncIOThreads.value());
-#ifdef QBT_USES_LIBTORRENT2
     // Hashing threads
     session->setHashingThreads(m_spinBoxHashingThreads.value());
-#endif
     // File pool size
     session->setFilePoolSize(m_spinBoxFilePoolSize.value());
     // Checking Memory Usage
     session->setCheckingMemUsage(m_spinBoxCheckingMemUsage.value());
-#ifndef QBT_USES_LIBTORRENT2
-    // Disk write cache
-    session->setDiskCacheSize(m_spinBoxCache.value());
-    session->setDiskCacheTTL(m_spinBoxCacheTTL.value());
-#endif
     // Disk queue size
     session->setDiskQueueSize(m_spinBoxDiskQueueSize.value() * 1024);
-#ifdef QBT_USES_LIBTORRENT2
     session->setDiskIOType(m_comboBoxDiskIOType.currentData().value<BitTorrent::DiskIOType>());
-#endif
     // Disk IO read mode
     session->setDiskIOReadMode(m_comboBoxDiskIOReadMode.currentData().value<BitTorrent::DiskIOReadMode>());
     // Disk IO write mode
     session->setDiskIOWriteMode(m_comboBoxDiskIOWriteMode.currentData().value<BitTorrent::DiskIOWriteMode>());
-#ifndef QBT_USES_LIBTORRENT2
-    // Coalesce reads & writes
-    session->setCoalesceReadWriteEnabled(m_checkBoxCoalesceRW.isChecked());
-#endif
     // Piece extent affinity
     session->setPieceExtentAffinity(m_checkBoxPieceExtentAffinity.isChecked());
     // Suggest mode
@@ -362,7 +337,7 @@ void AdvancedSettings::saveAdvancedSettings() const
     session->setRequestQueueSize(m_spinBoxRequestQueueSize.value());
     // DHT bootstrap nodes
     session->setDHTBootstrapNodes(m_lineEditDHTBootstrapNodes.text());
-#if defined(QBT_USES_LIBTORRENT2) && TORRENT_USE_I2P
+#if TORRENT_USE_I2P
     // I2P session options
     session->setI2PInboundQuantity(m_spinBoxI2PInboundQuantity.value());
     session->setI2POutboundQuantity(m_spinBoxI2POutboundQuantity.value());
@@ -372,18 +347,6 @@ void AdvancedSettings::saveAdvancedSettings() const
 
     session->setTorrentContentRemoveOption(m_comboBoxTorrentContentRemoveOption.currentData().value<BitTorrent::TorrentContentRemoveOption>());
 }
-
-#ifndef QBT_USES_LIBTORRENT2
-void AdvancedSettings::updateCacheSpinSuffix(const int value)
-{
-    if (value == 0)
-        m_spinBoxCache.setSuffix(tr(" (disabled)"));
-    else if (value < 0)
-        m_spinBoxCache.setSuffix(tr(" (auto)"));
-    else
-        m_spinBoxCache.setSuffix(tr(" MiB"));
-}
-#endif
 
 #ifdef QBT_USES_DBUS
 void AdvancedSettings::updateNotificationTimeoutSuffix(const int value)
@@ -484,7 +447,7 @@ void AdvancedSettings::loadAdvancedSettings()
     m_comboBoxTorrentContentRemoveOption.setCurrentIndex(m_comboBoxTorrentContentRemoveOption.findData(QVariant::fromValue(session->torrentContentRemoveOption())));
     addRow(TORRENT_CONTENT_REMOVE_OPTION, tr("Torrent content removing mode"), &m_comboBoxTorrentContentRemoveOption);
 
-#if defined(QBT_USES_LIBTORRENT2) && !defined(Q_OS_MACOS)
+#if !defined(Q_OS_MACOS)
     // Physical memory (RAM) usage limit
     m_spinBoxMemoryWorkingSetLimit.setMinimum(1);
     m_spinBoxMemoryWorkingSetLimit.setMaximum(std::numeric_limits<int>::max());
@@ -524,14 +487,12 @@ void AdvancedSettings::loadAdvancedSettings()
     addRow(ASYNC_IO_THREADS, (tr("Asynchronous I/O threads") + u' ' + makeLink(u"https://www.libtorrent.org/reference-Settings.html#aio_threads", u"(?)"))
             , &m_spinBoxAsyncIOThreads);
 
-#ifdef QBT_USES_LIBTORRENT2
     // Hashing threads
     m_spinBoxHashingThreads.setMinimum(1);
     m_spinBoxHashingThreads.setMaximum(1024);
     m_spinBoxHashingThreads.setValue(session->hashingThreads());
     addRow(HASHING_THREADS, (tr("Hashing threads") + u' ' + makeLink(u"https://www.libtorrent.org/reference-Settings.html#hashing_threads", u"(?)"))
             , &m_spinBoxHashingThreads);
-#endif
 
     // File pool size
     m_spinBoxFilePoolSize.setMinimum(1);
@@ -553,30 +514,6 @@ void AdvancedSettings::loadAdvancedSettings()
     m_spinBoxCheckingMemUsage.setSuffix(tr(" MiB"));
     addRow(CHECKING_MEM_USAGE, (tr("Outstanding memory when checking torrents") + u' ' + makeLink(u"https://www.libtorrent.org/reference-Settings.html#checking_mem_usage", u"(?)"))
             , &m_spinBoxCheckingMemUsage);
-#ifndef QBT_USES_LIBTORRENT2
-    // Disk write cache
-    m_spinBoxCache.setMinimum(-1);
-    // When build as 32bit binary, set the maximum at less than 2GB to prevent crashes.
-#ifdef QBT_APP_64BIT
-    m_spinBoxCache.setMaximum(33554431);  // 32768GiB
-#else
-    // allocate 1536MiB and leave 512MiB to the rest of program data in RAM
-    m_spinBoxCache.setMaximum(1536);
-#endif
-    m_spinBoxCache.setValue(session->diskCacheSize());
-    updateCacheSpinSuffix(m_spinBoxCache.value());
-    connect(&m_spinBoxCache, qOverload<int>(&QSpinBox::valueChanged)
-            , this, &AdvancedSettings::updateCacheSpinSuffix);
-    addRow(DISK_CACHE, (tr("Disk cache") + u' ' + makeLink(u"https://www.libtorrent.org/reference-Settings.html#cache_size", u"(?)"))
-            , &m_spinBoxCache);
-    // Disk cache expiry
-    m_spinBoxCacheTTL.setMinimum(1);
-    m_spinBoxCacheTTL.setMaximum(std::numeric_limits<int>::max());
-    m_spinBoxCacheTTL.setValue(session->diskCacheTTL());
-    m_spinBoxCacheTTL.setSuffix(tr(" s", " seconds"));
-    addRow(DISK_CACHE_TTL, (tr("Disk cache expiry interval") + u' ' + makeLink(u"https://www.libtorrent.org/reference-Settings.html#cache_expiry", u"(?)"))
-            , &m_spinBoxCacheTTL);
-#endif
     // Disk queue size
     m_spinBoxDiskQueueSize.setMinimum(1);
     m_spinBoxDiskQueueSize.setMaximum(std::numeric_limits<int>::max() / 1024);
@@ -584,7 +521,6 @@ void AdvancedSettings::loadAdvancedSettings()
     m_spinBoxDiskQueueSize.setSuffix(tr(" KiB"));
     addRow(DISK_QUEUE_SIZE, (tr("Disk queue size") + u' ' + makeLink(u"https://www.libtorrent.org/reference-Settings.html#max_queued_disk_bytes", u"(?)"))
             , &m_spinBoxDiskQueueSize);
-#ifdef QBT_USES_LIBTORRENT2
     // Disk IO type
     m_comboBoxDiskIOType.addItem(tr("Default"), QVariant::fromValue(BitTorrent::DiskIOType::Default));
     m_comboBoxDiskIOType.addItem(tr("Memory mapped files"), QVariant::fromValue(BitTorrent::DiskIOType::MMap));
@@ -593,7 +529,6 @@ void AdvancedSettings::loadAdvancedSettings()
     m_comboBoxDiskIOType.setCurrentIndex(m_comboBoxDiskIOType.findData(QVariant::fromValue(session->diskIOType())));
     addRow(DISK_IO_TYPE, tr("Disk IO type (requires restart)") + u' ' + makeLink(u"https://www.libtorrent.org/single-page-ref.html#default-disk-io-constructor", u"(?)")
            , &m_comboBoxDiskIOType);
-#endif
     // Disk IO read mode
     m_comboBoxDiskIOReadMode.addItem(tr("Disable OS cache"), QVariant::fromValue(BitTorrent::DiskIOReadMode::DisableOSCache));
     m_comboBoxDiskIOReadMode.addItem(tr("Enable OS cache"), QVariant::fromValue(BitTorrent::DiskIOReadMode::EnableOSCache));
@@ -603,18 +538,10 @@ void AdvancedSettings::loadAdvancedSettings()
     // Disk IO write mode
     m_comboBoxDiskIOWriteMode.addItem(tr("Disable OS cache"), QVariant::fromValue(BitTorrent::DiskIOWriteMode::DisableOSCache));
     m_comboBoxDiskIOWriteMode.addItem(tr("Enable OS cache"), QVariant::fromValue(BitTorrent::DiskIOWriteMode::EnableOSCache));
-#ifdef QBT_USES_LIBTORRENT2
     m_comboBoxDiskIOWriteMode.addItem(tr("Write-through"), QVariant::fromValue(BitTorrent::DiskIOWriteMode::WriteThrough));
-#endif
     m_comboBoxDiskIOWriteMode.setCurrentIndex(m_comboBoxDiskIOWriteMode.findData(QVariant::fromValue(session->diskIOWriteMode())));
     addRow(DISK_IO_WRITE_MODE, (tr("Disk IO write mode") + u' ' + makeLink(u"https://www.libtorrent.org/reference-Settings.html#disk_io_write_mode", u"(?)"))
             , &m_comboBoxDiskIOWriteMode);
-#ifndef QBT_USES_LIBTORRENT2
-    // Coalesce reads & writes
-    m_checkBoxCoalesceRW.setChecked(session->isCoalesceReadWriteEnabled());
-    addRow(COALESCE_RW, (tr("Coalesce reads & writes") + u' ' + makeLink(u"https://www.libtorrent.org/reference-Settings.html#coalesce_reads", u"(?)"))
-            , &m_checkBoxCoalesceRW);
-#endif
     // Piece extent affinity
     m_checkBoxPieceExtentAffinity.setChecked(session->usePieceExtentAffinity());
     addRow(PIECE_EXTENT_AFFINITY, (tr("Use piece extent affinity") + u' ' + makeLink(u"https://libtorrent.org/single-page-ref.html#piece_extent_affinity", u"(?)")), &m_checkBoxPieceExtentAffinity);
@@ -947,7 +874,7 @@ void AdvancedSettings::loadAdvancedSettings()
     m_lineEditDHTBootstrapNodes.setText(session->getDHTBootstrapNodes());
     addRow(DHT_BOOTSTRAP_NODES, (tr("DHT bootstrap nodes") + u' ' + makeLink(u"https://www.libtorrent.org/reference-Settings.html#dht_bootstrap_nodes", u"(?)"))
         , &m_lineEditDHTBootstrapNodes);
-#if defined(QBT_USES_LIBTORRENT2) && TORRENT_USE_I2P
+#if TORRENT_USE_I2P
     // I2P session options
     m_spinBoxI2PInboundQuantity.setMinimum(1);
     m_spinBoxI2PInboundQuantity.setMaximum(16);

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -56,10 +56,6 @@ signals:
 private slots:
     void updateInterfaceAddressCombo();
 
-#ifndef QBT_USES_LIBTORRENT2
-    void updateCacheSpinSuffix(int value);
-#endif
-
 #ifdef QBT_USES_DBUS
     void updateNotificationTimeoutSuffix(int value);
 #endif
@@ -84,19 +80,14 @@ private:
               m_comboBoxSeedChokingAlgorithm, m_comboBoxResumeDataStorage, m_comboBoxTorrentContentRemoveOption;
     QLineEdit m_lineEditAppInstanceName, m_pythonExecutablePath, m_lineEditAnnounceIP, m_lineEditDHTBootstrapNodes;
 
-#ifndef QBT_USES_LIBTORRENT2
-    QSpinBox m_spinBoxCache, m_spinBoxCacheTTL;
-    QCheckBox m_checkBoxCoalesceRW;
-#else
     QComboBox m_comboBoxDiskIOType;
     QSpinBox m_spinBoxHashingThreads;
-#endif
 
-#if defined(QBT_USES_LIBTORRENT2) && !defined(Q_OS_MACOS)
+#if !defined(Q_OS_MACOS)
     QSpinBox m_spinBoxMemoryWorkingSetLimit;
 #endif
 
-#if defined(QBT_USES_LIBTORRENT2) && TORRENT_USE_I2P
+#if TORRENT_USE_I2P
     QSpinBox m_spinBoxI2PInboundQuantity, m_spinBoxI2POutboundQuantity, m_spinBoxI2PInboundLength, m_spinBoxI2POutboundLength;
 #endif
 

--- a/src/gui/downloadfromurldialog.cpp
+++ b/src/gui/downloadfromurldialog.cpp
@@ -50,9 +50,7 @@ namespace
     {
         return (Net::DownloadManager::hasSupportedScheme(str)
             || str.startsWith(u"magnet:", Qt::CaseInsensitive)
-#ifdef QBT_USES_LIBTORRENT2
             || ((str.size() == 64) && !str.contains(QRegularExpression(u"[^0-9A-Fa-f]"_s))) // v2 hex-encoded SHA-256 info-hash
-#endif
             || ((str.size() == 40) && !str.contains(QRegularExpression(u"[^0-9A-Fa-f]"_s))) // v1 hex-encoded SHA-1 info-hash
             || ((str.size() == 32) && !str.contains(QRegularExpression(u"[^2-7A-Za-z]"_s)))); // v1 Base32 encoded SHA-1 info-hash
     }

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -846,7 +846,7 @@ void OptionsDialog::loadConnectionTabOptions()
         m_ui->spinMaxUploadsPerTorrent->setEnabled(false);
     }
 
-#if defined(QBT_USES_LIBTORRENT2) && TORRENT_USE_I2P
+#if TORRENT_USE_I2P
     m_ui->textI2PHost->setText(session->I2PAddress());
     m_ui->spinI2PPort->setValue(session->I2PPort());
     m_ui->checkI2PMixed->setChecked(session->I2PMixedMode());
@@ -909,7 +909,7 @@ void OptionsDialog::loadConnectionTabOptions()
     connect(m_ui->textProxyIP, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->spinProxyPort, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
 
-#if defined(QBT_USES_LIBTORRENT2) && TORRENT_USE_I2P
+#if TORRENT_USE_I2P
     connect(m_ui->textI2PHost, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->spinI2PPort, qSpinBoxValueChanged, this, &ThisType::enableApplyButton);
     connect(m_ui->checkI2PMixed, &QCheckBox::toggled, this, &ThisType::enableApplyButton);
@@ -947,7 +947,7 @@ void OptionsDialog::saveConnectionTabOptions() const
     session->setMaxUploads(getMaxUploads());
     session->setMaxUploadsPerTorrent(getMaxUploadsPerTorrent());
 
-#if defined(QBT_USES_LIBTORRENT2) && TORRENT_USE_I2P
+#if TORRENT_USE_I2P
     session->setI2PEnabled(m_ui->groupI2P->isChecked());
     session->setI2PAddress(m_ui->textI2PHost->text().trimmed());
     session->setI2PPort(m_ui->spinI2PPort->value());

--- a/src/gui/statsdialog.cpp
+++ b/src/gui/statsdialog.cpp
@@ -55,10 +55,8 @@ StatsDialog::StatsDialog(QWidget *parent)
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::statsUpdated
             , this, &StatsDialog::update);
 
-#ifdef QBT_USES_LIBTORRENT2
     m_ui->labelCacheHitsText->hide();
     m_ui->labelCacheHits->hide();
-#endif
 
     if (const QSize dialogSize = m_storeDialogSize; dialogSize.isValid())
         resize(dialogSize);
@@ -87,13 +85,6 @@ void StatsDialog::update()
                 ((atd > 0) && (atu > 0))
                 ? Utils::String::fromDouble(static_cast<qreal>(atu) / atd, 2)
                 : u"-"_s);
-#ifndef QBT_USES_LIBTORRENT2
-    // Cache hits
-    const qreal readRatio = cs.readRatio;
-    m_ui->labelCacheHits->setText(u"%1%"_s.arg((readRatio > 0)
-        ? Utils::String::fromDouble((100 * readRatio), 2)
-        : u"0"_s));
-#endif
     // Buffers size
     m_ui->labelTotalBuf->setText(Utils::Misc::friendlyUnit(cs.totalUsedBuffers * 16 * 1024));
     // Disk overload (100%) equivalent

--- a/src/gui/torrentcreatordialog.h
+++ b/src/gui/torrentcreatordialog.h
@@ -70,11 +70,7 @@ private:
     void setInteractionEnabled(bool enabled) const;
 
     int getPieceSize() const;
-#ifdef QBT_USES_LIBTORRENT2
     BitTorrent::TorrentFormat getTorrentFormat() const;
-#else
-    int getPaddedFileSizeLimit() const;
-#endif
 
     Ui::TorrentCreatorDialog *m_ui = nullptr;
     QThreadPool m_threadPool;
@@ -85,12 +81,7 @@ private:
     SettingValue<bool> m_storePrivateTorrent;
     SettingValue<bool> m_storeStartSeeding;
     SettingValue<bool> m_storeIgnoreRatio;
-#ifdef QBT_USES_LIBTORRENT2
     SettingValue<int> m_storeTorrentFormat;
-#else
-    SettingValue<bool> m_storeOptimizeAlignment;
-    SettingValue<int> m_paddedFileSizeLimit;
-#endif
     SettingValue<Path> m_storeLastAddPath;
     SettingValue<QString> m_storeTrackerList;
     SettingValue<QString> m_storeWebSeedList;

--- a/src/gui/trackerlist/trackerlistwidget.cpp
+++ b/src/gui/trackerlist/trackerlistwidget.cpp
@@ -48,7 +48,6 @@
 #include "base/bittorrent/session.h"
 #include "base/bittorrent/torrent.h"
 #include "base/bittorrent/trackerentrystatus.h"
-#include "base/global.h"
 #include "base/preferences.h"
 #include "gui/autoexpandabledialog.h"
 #include "gui/trackersadditiondialog.h"
@@ -60,10 +59,7 @@
 TrackerListWidget::TrackerListWidget(QWidget *parent)
     : QTreeView(parent)
 {
-#ifdef QBT_USES_LIBTORRENT2
     setColumnHidden(TrackerListModel::COL_PROTOCOL, true); // Must be set before calling loadSettings()
-#endif
-
     setExpandsOnDoubleClick(false);
     setAllColumnsShowFocus(true);
     setSelectionMode(QAbstractItemView::ExtendedSelection);

--- a/src/webui/api/torrentcreatorcontroller.cpp
+++ b/src/webui/api/torrentcreatorcontroller.cpp
@@ -64,7 +64,6 @@ namespace
     using Utils::String::parseBool;
     using Utils::String::parseInt;
 
-#ifdef QBT_USES_LIBTORRENT2
     BitTorrent::TorrentFormat parseTorrentFormat(const QString &str)
     {
         if (str == u"v1")
@@ -86,7 +85,6 @@ namespace
             return u"hybrid"_s;
         }
     }
-#endif
 
     QString taskStatusString(const std::shared_ptr<BitTorrent::TorrentCreationTask> task)
     {
@@ -119,12 +117,7 @@ void TorrentCreatorController::addTaskAction()
     const BitTorrent::TorrentCreatorParams createTorrentParams
     {
         .isPrivate = parseBool(params()[KEY_PRIVATE]).value_or(false),
-#ifdef QBT_USES_LIBTORRENT2
         .torrentFormat = parseTorrentFormat(params()[KEY_FORMAT].toLower()),
-#else
-        .isAlignmentOptimized = parseBool(params()[KEY_OPTIMIZE_ALIGNMENT]).value_or(true),
-        .paddedFileSizeLimit = parseInt(params()[KEY_PADDED_FILE_SIZE_LIMIT]).value_or(-1),
-#endif
         .pieceSize = parseInt(params()[KEY_PIECE_SIZE]).value_or(0),
         .sourcePath = Path(params()[KEY_SOURCE_PATH]),
         .torrentFilePath = Path(params()[KEY_TORRENT_FILE_PATH]),
@@ -163,12 +156,7 @@ void TorrentCreatorController::statusAction()
             {KEY_PIECE_SIZE, task->params().pieceSize},
             {KEY_PRIVATE, task->params().isPrivate},
             {KEY_TIME_ADDED, task->timeAdded().toString()},
-#ifdef QBT_USES_LIBTORRENT2
             {KEY_FORMAT, torrentFormatToString(task->params().torrentFormat)},
-#else
-            {KEY_OPTIMIZE_ALIGNMENT, task->params().isAlignmentOptimized},
-            {KEY_PADDED_FILE_SIZE_LIMIT, task->params().paddedFileSizeLimit},
-#endif
             {KEY_STATUS, taskStatusString(task)},
         };
 


### PR DESCRIPTION
Remove usage of the `QBT_USES_LIBTORRENT2` macro since it is no longer required. I dont think any version uses libtorrent 1.x anymore. so if we always use libtorrent 2.x, then we can remove all the dead code. 

also, i think it is better to statically link libtorrent rather than use system dependencies. it can help make deployments simpler as you dont need to make sure libtorrent is installed on the system first. 