### PR TITLE
WebUI: Setup copy events only once

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -678,36 +678,6 @@ window.addEventListener("DOMContentLoaded", () => {
             tracker.classList.toggle("selectedFilter", (Number(tracker.id) === selectedTracker));
     };
 
-    const setupCopyEventHandler = (function() {
-        let clipboardEvent;
-
-        return () => {
-            if (clipboardEvent)
-                clipboardEvent.destroy();
-
-            clipboardEvent = new ClipboardJS(".copyToClipboard", {
-                text: function(trigger) {
-                    switch (trigger.id) {
-                        case "copyName":
-                            return copyNameFN();
-                        case "copyInfohash1":
-                            return copyInfohashFN(1);
-                        case "copyInfohash2":
-                            return copyInfohashFN(2);
-                        case "copyMagnetLink":
-                            return copyMagnetLinkFN();
-                        case "copyID":
-                            return copyIdFN();
-                        case "copyComment":
-                            return copyCommentFN();
-                        default:
-                            return "";
-                    }
-                }
-            });
-        };
-    })();
-
     let syncMainDataTimeoutID = -1;
     let syncRequestInProgress = false;
     const syncMainData = function() {
@@ -821,7 +791,6 @@ window.addEventListener("DOMContentLoaded", () => {
                         updateTrackers = true;
                     }
                     if (response["torrents"]) {
-                        let updateTorrentList = false;
                         for (const key in response["torrents"]) {
                             if (!Object.hasOwn(response["torrents"], key))
                                 continue;
@@ -835,12 +804,7 @@ window.addEventListener("DOMContentLoaded", () => {
                                 update_categories = true;
                             if (addTorrentToTagList(response["torrents"][key]))
                                 updateTags = true;
-                            if (response["torrents"][key]["name"])
-                                updateTorrentList = true;
                         }
-
-                        if (updateTorrentList)
-                            setupCopyEventHandler();
                     }
                     if (response["torrents_removed"]) {
                         response["torrents_removed"].each((hash) => {
@@ -1660,6 +1624,27 @@ window.addEventListener("DOMContentLoaded", () => {
             }
         }
     }).activate();
+
+    new ClipboardJS(".copyToClipboard", {
+        text: function(trigger) {
+            switch (trigger.id) {
+                case "copyName":
+                    return copyNameFN();
+                case "copyInfohash1":
+                    return copyInfohashFN(1);
+                case "copyInfohash2":
+                    return copyInfohashFN(2);
+                case "copyMagnetLink":
+                    return copyMagnetLinkFN();
+                case "copyID":
+                    return copyIdFN();
+                case "copyComment":
+                    return copyCommentFN();
+                default:
+                    return "";
+            }
+        }
+    });
 });
 
 window.addEventListener("load", () => {


### PR DESCRIPTION
It is enough to set them up just once during initial load. Number of elements with copyToClipboard class is fixed - they are context menu items.