### PR TITLE
Add drag support to torrent content widget

### DIFF
--- a/src/gui/torrentcontentmodel.h
+++ b/src/gui/torrentcontentmodel.h
@@ -37,6 +37,7 @@
 #include "torrentcontentmodelitem.h"
 
 class QFileIconProvider;
+class QMimeData;
 class QModelIndex;
 class QVariant;
 
@@ -86,6 +87,8 @@ signals:
 private:
     using ColumnInterval = IndexInterval<int>;
 
+    QMimeData *mimeData(const QModelIndexList &indexes) const override;
+    QStringList mimeTypes() const override;
     void populate();
     void updateFilesProgress();
     void updateFilesPriorities();

--- a/src/gui/torrentcontentwidget.cpp
+++ b/src/gui/torrentcontentwidget.cpp
@@ -71,6 +71,8 @@ namespace
 TorrentContentWidget::TorrentContentWidget(QWidget *parent)
     : QTreeView(parent)
 {
+    setDragEnabled(true);
+    setDragDropMode(QAbstractItemView::DragOnly);
     setExpandsOnDoubleClick(false);
     setSortingEnabled(true);
     setUniformRowHeights(true);


### PR DESCRIPTION
Now qbt supports dragging items from torrent content widget to another app.

Closes #5860.