### PR TITLE
WebUI: Improve sort order in Status column

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -672,6 +672,28 @@ window.addEventListener("DOMContentLoaded", () => {
             tracker.classList.toggle("selectedFilter", (Number(tracker.id) === selectedTracker));
     };
 
+    const statusSortOrder = Object.freeze({
+        "unknown": -1,
+        "forcedDL": 0,
+        "downloading": 1,
+        "forcedMetaDL": 2,
+        "metaDL": 3,
+        "stalledDL": 4,
+        "forcedUP": 5,
+        "uploading": 6,
+        "stalledUP": 7,
+        "checkingResumeData": 8,
+        "queuedDL": 9,
+        "queuedUP": 10,
+        "checkingUP": 11,
+        "checkingDL": 12,
+        "stoppedDL": 13,
+        "stoppedUP": 14,
+        "moving": 15,
+        "missingFiles": 16,
+        "error": 17
+    });
+
     let syncMainDataTimeoutID = -1;
     let syncRequestInProgress = false;
     const syncMainData = function() {
@@ -800,8 +822,11 @@ window.addEventListener("DOMContentLoaded", () => {
 
                             response["torrents"][key]["hash"] = key;
                             response["torrents"][key]["rowId"] = key;
-                            if (response["torrents"][key]["state"])
-                                response["torrents"][key]["status"] = response["torrents"][key]["state"];
+                            if (response["torrents"][key]["state"]) {
+                                const state = response["torrents"][key]["state"];
+                                response["torrents"][key]["status"] = state;
+                                response["torrents"][key]["_statusOrder"] = statusSortOrder[state];
+                            }
                             torrentsTable.updateRowData(response["torrents"][key]);
                             if (addTorrentToCategoryList(response["torrents"][key]))
                                 update_categories = true;

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1102,6 +1102,10 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.title = status;
             };
 
+            this.columns["status"].compareRows = function(row1, row2) {
+                return compareNumbers(row1.full_data._statusOrder, row2.full_data._statusOrder);
+            };
+
             // priority
             this.columns["priority"].updateTd = function(td, row) {
                 const queuePos = this.getRowValue(row);


### PR DESCRIPTION
This PR adds custom compare function to Status column (same sort order as in the GUI but I could use some double check here).

I suppose this could close https://github.com/qbittorrent/qBittorrent/issues/15499
