### PR TITLE
Avoid shadowing function parameter

### DIFF
--- a/src/base/bittorrent/bencoderesumedatastorage.cpp
+++ b/src/base/bittorrent/bencoderesumedatastorage.cpp
@@ -293,7 +293,6 @@ BitTorrent::LoadResumeDataResult BitTorrent::BencodeResumeDataStorage::loadTorre
 
     if (!metadata.isEmpty())
     {
-        const auto *pref = Preferences::instance();
         const lt::bdecode_node torentInfoRoot = lt::bdecode(metadata, ec
                 , nullptr, pref->getBdecodeDepthLimit(), pref->getBdecodeTokenLimit());
         if (ec)

--- a/src/base/net/geoipmanager.cpp
+++ b/src/base/net/geoipmanager.cpp
@@ -456,15 +456,15 @@ void GeoIPManager::downloadFinished(const DownloadResult &result)
                 Utils::Fs::mkpath(targetPath);
 
             const auto path = targetPath / Path(GEODB_FILENAME);
-            const nonstd::expected<void, QString> result = Utils::IO::saveToFile(path, data);
-            if (result)
+            const nonstd::expected<void, QString> saveResult = Utils::IO::saveToFile(path, data);
+            if (saveResult)
             {
                 LogMsg(tr("Successfully updated IP geolocation database."), Log::INFO);
             }
             else
             {
                 LogMsg(tr("Couldn't save downloaded IP geolocation database file. Reason: %1")
-                    .arg(result.error()), Log::WARNING);
+                    .arg(saveResult.error()), Log::WARNING);
             }
         }
         else


### PR DESCRIPTION
The function already has a parameter named `result`.

Also remove a duplicate variable since it already has a pref pointer at the start of the function.
