### PR TITLE
Avoid heavy weight function object

### DIFF
--- a/src/base/bittorrent/resumedatastorage.cpp
+++ b/src/base/bittorrent/resumedatastorage.cpp
@@ -35,8 +35,6 @@
 #include <QMutexLocker>
 #include <QThread>
 
-#include "base/global.h"
-
 const int TORRENTIDLIST_TYPEID = qRegisterMetaType<QList<BitTorrent::TorrentID>>();
 
 BitTorrent::ResumeDataStorage::ResumeDataStorage(const Path &path, QObject *parent)

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -71,7 +71,6 @@
 #include <QRegularExpression>
 #include <QString>
 #include <QThread>
-#include <QThreadPool>
 #include <QTimer>
 #include <QUuid>
 
@@ -3011,11 +3010,6 @@ void SessionImpl::removeMappedPorts(const QSet<quint16> &ports)
             return true;
         });
     });
-}
-
-void SessionImpl::invokeAsync(std::function<void ()> func)
-{
-    m_asyncWorker->start(std::move(func));
 }
 
 // Add a torrent to libtorrent session in hidden mode

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -44,6 +44,7 @@
 #include <QMap>
 #include <QPointer>
 #include <QSet>
+#include <QThreadPool>
 
 #include "base/path.h"
 #include "base/settingvalue.h"
@@ -57,7 +58,6 @@
 #include "trackerentrystatus.h"
 
 class QString;
-class QThreadPool;
 class QTimer;
 class QUrl;
 
@@ -482,7 +482,11 @@ namespace BitTorrent
             QMetaObject::invokeMethod(this, std::forward<Func>(func), Qt::QueuedConnection);
         }
 
-        void invokeAsync(std::function<void ()> func);
+        template <typename Func>
+        void invokeAsync(Func &&func)
+        {
+            m_asyncWorker->start(std::forward<Func>(func));
+        }
 
     signals:
         void addTorrentAlertsReceived(qsizetype count);

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -28,6 +28,7 @@
 
 #include "torrentscontroller.h"
 
+#include <concepts>
 #include <functional>
 
 #include <QBitArray>
@@ -135,7 +136,9 @@ namespace
 
     const QSet<QString> SUPPORTED_WEB_SEED_SCHEMES {u"http"_s, u"https"_s, u"ftp"_s};
 
-    void applyToTorrents(const QStringList &idList, const std::function<void (BitTorrent::Torrent *torrent)> &func)
+    template <typename Func>
+    void applyToTorrents(const QStringList &idList, Func func)
+        requires std::invocable<Func, BitTorrent::Torrent *>
     {
         if ((idList.size() == 1) && (idList[0] == u"all"))
         {


### PR DESCRIPTION
Also, by switching to template we can avoid the cost of converting to some specific type and perfectly forward the parameter to the final function.
