### PR TITLE
Allow to select Qt's default style

### DIFF
--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -461,7 +461,10 @@ void OptionsDialog::saveBehaviorTabOptions() const
     pref->setLocale(locale);
 
 #ifdef Q_OS_WIN
-    pref->setStyle(m_ui->comboStyle->currentText());
+    if (const QVariant systemStyle = m_ui->comboStyle->currentData(); systemStyle.isValid())
+        pref->setStyle(systemStyle.toString());
+    else
+        pref->setStyle(m_ui->comboStyle->currentText());
 #endif
 
 #ifdef QBT_HAS_COLORSCHEME_OPTION
@@ -1698,18 +1701,27 @@ bool OptionsDialog::isSplashScreenDisabled() const
 void OptionsDialog::initializeStyleCombo()
 {
 #ifdef Q_OS_WIN
+    m_ui->labelStyleHint->setText(tr("%1 is recommended for best compatibility with Windows dark mode"
+                        , "Fusion is recommended for best compatibility with Windows dark mode").arg(u"Fusion"_s));
+    m_ui->comboStyle->addItem(tr("System", "System default Qt style"), u"system"_s);
+    m_ui->comboStyle->setItemData(0, tr("Let Qt decide the style for this system"), Qt::ToolTipRole);
+    m_ui->comboStyle->insertSeparator(1);
+
     QStringList styleNames = QStyleFactory::keys();
     std::sort(styleNames.begin(), styleNames.end(), Utils::Compare::NaturalLessThan<Qt::CaseInsensitive>());
     m_ui->comboStyle->addItems(styleNames);
     const QString prefStyleName = Preferences::instance()->getStyle();
     const QString selectedStyleName = prefStyleName.isEmpty() ? QApplication::style()->name() : prefStyleName;
-    m_ui->comboStyle->setCurrentText(selectedStyleName);
+
+    if (selectedStyleName.compare(u"system"_s, Qt::CaseInsensitive) != 0)
+        m_ui->comboStyle->setCurrentText(selectedStyleName);
 #else
     m_ui->labelStyle->hide();
     m_ui->comboStyle->hide();
+    m_ui->labelStyleHint->hide();
     m_ui->UISettingsBoxLayout->removeWidget(m_ui->labelStyle);
     m_ui->UISettingsBoxLayout->removeWidget(m_ui->comboStyle);
-    m_ui->UISettingsBoxLayout->removeItem(m_ui->spacerStyle);
+    m_ui->UISettingsBoxLayout->removeWidget(m_ui->labelStyleHint);
 #endif
 }
 

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -179,17 +179,13 @@
                 <widget class="QComboBox" name="comboStyle"/>
                </item>
                <item row="2" column="2">
-                <spacer name="spacerStyle">
-                 <property name="orientation">
-                  <enum>Qt::Orientation::Horizontal</enum>
+                <widget class="QLabel" name="labelStyleHint">
+                 <property name="font">
+                  <font>
+                   <italic>true</italic>
+                  </font>
                  </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
+                </widget>
                </item>
                <item row="3" column="0">
                 <widget class="QLabel" name="labelColorScheme">

--- a/src/gui/uithememanager.cpp
+++ b/src/gui/uithememanager.cpp
@@ -37,10 +37,6 @@
 #include <QStyle>
 #include <QStyleHints>
 
-#ifdef Q_OS_WIN
-#include <QOperatingSystemVersion>
-#endif
-
 #include "base/global.h"
 #include "base/logger.h"
 #include "base/path.h"
@@ -88,9 +84,11 @@ UIThemeManager::UIThemeManager()
 #endif
 {
 #ifdef Q_OS_WIN
-    const QString defaultStyle = (QOperatingSystemVersion::current() >= QOperatingSystemVersion::Windows10) ? u"Fusion"_s : QString();
-    if (const QString styleName = Preferences::instance()->getStyle(); !QApplication::setStyle(styleName.isEmpty() ? defaultStyle : styleName))
-        LogMsg(tr("Set app style failed. Unknown style: \"%1\"").arg(styleName), Log::WARNING);
+    if (const QString styleName = Preferences::instance()->getStyle(); styleName.compare(u"system", Qt::CaseInsensitive) != 0)
+    {
+        if (!QApplication::setStyle(styleName.isEmpty() ? u"Fusion"_s : styleName))
+            LogMsg(tr("Set app style failed. Unknown style: \"%1\"").arg(styleName), Log::WARNING);
+    }
 #endif
 
 #ifdef QBT_HAS_COLORSCHEME_OPTION


### PR DESCRIPTION
Relevant prior PR #21553

Fusion is still the default.
Here is how it looks on a default profile:
![Untitled](https://github.com/user-attachments/assets/c4323e33-ee1d-46e8-a769-76b9059bafa8)
