### PR TITLE
WebUI: fix 'rename files' dialog cannot be opened more than once

### DIFF
--- a/src/webui/www/private/rename_files.html
+++ b/src/webui/www/private/rename_files.html
@@ -19,29 +19,25 @@
                 window.qBittorrent = window.parent.qBittorrent;
             window.qBittorrent = window.parent.qBittorrent;
 
-            const TriState = window.qBittorrent.FileTree.TriState;
             const data = window.MUI.Windows.instances["multiRenamePage"].options.data;
-            let bulkRenameFilesContextMenu;
-            if (!bulkRenameFilesContextMenu) {
-                bulkRenameFilesContextMenu = new window.qBittorrent.ContextMenu.ContextMenu({
-                    targets: "#bulkRenameFilesTableDiv tr",
-                    menu: "multiRenameFilesMenu",
-                    actions: {
-                        ToggleSelection: function(element, ref) {
-                            const rowId = parseInt(element.getAttribute("data-row-id"), 10);
-                            const row = bulkRenameFilesTable.getNode(rowId);
-                            const checkState = (row.checked === 1) ? 0 : 1;
-                            bulkRenameFilesTable.toggleNodeTreeCheckbox(rowId, checkState);
-                            bulkRenameFilesTable.updateGlobalCheckbox();
-                            bulkRenameFilesTable.onRowSelectionChange(bulkRenameFilesTable.getSelectedRows());
-                        }
-                    },
-                    offsets: {
-                        x: 0,
-                        y: 2
+            const bulkRenameFilesContextMenu = new window.qBittorrent.ContextMenu.ContextMenu({
+                targets: "#bulkRenameFilesTableDiv tr",
+                menu: "multiRenameFilesMenu",
+                actions: {
+                    ToggleSelection: function(element, ref) {
+                        const rowId = parseInt(element.getAttribute("data-row-id"), 10);
+                        const row = bulkRenameFilesTable.getNode(rowId);
+                        const checkState = (row.checked === 1) ? 0 : 1;
+                        bulkRenameFilesTable.toggleNodeTreeCheckbox(rowId, checkState);
+                        bulkRenameFilesTable.updateGlobalCheckbox();
+                        bulkRenameFilesTable.onRowSelectionChange(bulkRenameFilesTable.getSelectedRows());
                     }
-                });
-            }
+                },
+                offsets: {
+                    x: 0,
+                    y: 2
+                }
+            });
 
             // Setup the dynamic table for bulk renaming
             const bulkRenameFilesTable = new window.qBittorrent.DynamicTable.BulkRenameTorrentFilesTable();
@@ -49,11 +45,8 @@
 
             // Inject checkbox into the first column of the table header
             const tableHeaders = $$("#bulkRenameFilesTableFixedHeaderDiv .dynamicTableHeader th");
-            let checkboxHeader;
             if (tableHeaders.length > 0) {
-                if (checkboxHeader)
-                    checkboxHeader.remove();
-                checkboxHeader = new Element("input");
+                const checkboxHeader = new Element("input");
                 checkboxHeader.type = "checkbox";
                 checkboxHeader.id = "rootMultiRename_cb";
                 checkboxHeader.addEventListener("click", (e) => {
@@ -68,23 +61,20 @@
 
             // Register keyboard events to modal window
             // https://github.com/qbittorrent/qBittorrent/pull/18687#discussion_r1135045726
-            let keyboard;
-            if (!keyboard) {
-                keyboard = new Keyboard({
-                    defaultEventType: "keydown",
-                    events: {
-                        "Escape": function(event) {
-                            window.parent.qBittorrent.Client.closeWindows();
-                            event.preventDefault();
-                        },
-                        "Esc": function(event) {
-                            window.parent.qBittorrent.Client.closeWindows();
-                            event.preventDefault();
-                        }
+            const keyboard = new Keyboard({
+                defaultEventType: "keydown",
+                events: {
+                    "Escape": function(event) {
+                        window.parent.qBittorrent.Client.closeWindows();
+                        event.preventDefault();
+                    },
+                    "Esc": function(event) {
+                        window.parent.qBittorrent.Client.closeWindows();
+                        event.preventDefault();
                     }
-                });
-                keyboard.activate();
-            }
+                }
+            });
+            keyboard.activate();
 
             const fileRenamer = new window.qBittorrent.MultiRename.RenameFiles();
             fileRenamer.hash = data.hash;

--- a/src/webui/www/private/rename_files.html
+++ b/src/webui/www/private/rename_files.html
@@ -14,394 +14,396 @@
     <script>
         "use strict";
 
-        if (window.parent.qBittorrent !== undefined)
+        (() => {
+            if (window.parent.qBittorrent !== undefined)
+                window.qBittorrent = window.parent.qBittorrent;
             window.qBittorrent = window.parent.qBittorrent;
-        window.qBittorrent = window.parent.qBittorrent;
 
-        const TriState = window.qBittorrent.FileTree.TriState;
-        const data = window.MUI.Windows.instances["multiRenamePage"].options.data;
-        let bulkRenameFilesContextMenu;
-        if (!bulkRenameFilesContextMenu) {
-            bulkRenameFilesContextMenu = new window.qBittorrent.ContextMenu.ContextMenu({
-                targets: "#bulkRenameFilesTableDiv tr",
-                menu: "multiRenameFilesMenu",
-                actions: {
-                    ToggleSelection: function(element, ref) {
-                        const rowId = parseInt(element.getAttribute("data-row-id"), 10);
-                        const row = bulkRenameFilesTable.getNode(rowId);
-                        const checkState = (row.checked === 1) ? 0 : 1;
-                        bulkRenameFilesTable.toggleNodeTreeCheckbox(rowId, checkState);
-                        bulkRenameFilesTable.updateGlobalCheckbox();
-                        bulkRenameFilesTable.onRowSelectionChange(bulkRenameFilesTable.getSelectedRows());
+            const TriState = window.qBittorrent.FileTree.TriState;
+            const data = window.MUI.Windows.instances["multiRenamePage"].options.data;
+            let bulkRenameFilesContextMenu;
+            if (!bulkRenameFilesContextMenu) {
+                bulkRenameFilesContextMenu = new window.qBittorrent.ContextMenu.ContextMenu({
+                    targets: "#bulkRenameFilesTableDiv tr",
+                    menu: "multiRenameFilesMenu",
+                    actions: {
+                        ToggleSelection: function(element, ref) {
+                            const rowId = parseInt(element.getAttribute("data-row-id"), 10);
+                            const row = bulkRenameFilesTable.getNode(rowId);
+                            const checkState = (row.checked === 1) ? 0 : 1;
+                            bulkRenameFilesTable.toggleNodeTreeCheckbox(rowId, checkState);
+                            bulkRenameFilesTable.updateGlobalCheckbox();
+                            bulkRenameFilesTable.onRowSelectionChange(bulkRenameFilesTable.getSelectedRows());
+                        }
+                    },
+                    offsets: {
+                        x: 0,
+                        y: 2
                     }
-                },
-                offsets: {
-                    x: 0,
-                    y: 2
-                }
-            });
-        }
+                });
+            }
 
-        // Setup the dynamic table for bulk renaming
-        const bulkRenameFilesTable = new window.qBittorrent.DynamicTable.BulkRenameTorrentFilesTable();
-        bulkRenameFilesTable.setup("bulkRenameFilesTableDiv", "bulkRenameFilesTableFixedHeaderDiv", bulkRenameFilesContextMenu);
+            // Setup the dynamic table for bulk renaming
+            const bulkRenameFilesTable = new window.qBittorrent.DynamicTable.BulkRenameTorrentFilesTable();
+            bulkRenameFilesTable.setup("bulkRenameFilesTableDiv", "bulkRenameFilesTableFixedHeaderDiv", bulkRenameFilesContextMenu);
 
-        // Inject checkbox into the first column of the table header
-        const tableHeaders = $$("#bulkRenameFilesTableFixedHeaderDiv .dynamicTableHeader th");
-        let checkboxHeader;
-        if (tableHeaders.length > 0) {
-            if (checkboxHeader)
-                checkboxHeader.remove();
-            checkboxHeader = new Element("input");
-            checkboxHeader.type = "checkbox";
-            checkboxHeader.id = "rootMultiRename_cb";
-            checkboxHeader.addEventListener("click", (e) => {
-                bulkRenameFilesTable.toggleGlobalCheckbox();
+            // Inject checkbox into the first column of the table header
+            const tableHeaders = $$("#bulkRenameFilesTableFixedHeaderDiv .dynamicTableHeader th");
+            let checkboxHeader;
+            if (tableHeaders.length > 0) {
+                if (checkboxHeader)
+                    checkboxHeader.remove();
+                checkboxHeader = new Element("input");
+                checkboxHeader.type = "checkbox";
+                checkboxHeader.id = "rootMultiRename_cb";
+                checkboxHeader.addEventListener("click", (e) => {
+                    bulkRenameFilesTable.toggleGlobalCheckbox();
+                    fileRenamer.selectedFiles = bulkRenameFilesTable.getSelectedRows();
+                    fileRenamer.update();
+                });
+
+                const checkboxTH = tableHeaders[0];
+                checkboxHeader.injectInside(checkboxTH);
+            }
+
+            // Register keyboard events to modal window
+            // https://github.com/qbittorrent/qBittorrent/pull/18687#discussion_r1135045726
+            let keyboard;
+            if (!keyboard) {
+                keyboard = new Keyboard({
+                    defaultEventType: "keydown",
+                    events: {
+                        "Escape": function(event) {
+                            window.parent.qBittorrent.Client.closeWindows();
+                            event.preventDefault();
+                        },
+                        "Esc": function(event) {
+                            window.parent.qBittorrent.Client.closeWindows();
+                            event.preventDefault();
+                        }
+                    }
+                });
+                keyboard.activate();
+            }
+
+            const fileRenamer = new window.qBittorrent.MultiRename.RenameFiles();
+            fileRenamer.hash = data.hash;
+
+            // Load Multi Rename Preferences
+            const multiRenamePrefChecked = LocalPreferences.get("multirename_rememberPreferences", "true") === "true";
+            $("multirename_rememberprefs_checkbox").checked = multiRenamePrefChecked;
+
+            if (multiRenamePrefChecked) {
+                const multirename_search = LocalPreferences.get("multirename_search", "");
+                fileRenamer.setSearch(multirename_search);
+                $("multiRenameSearch").value = multirename_search;
+
+                const multirename_useRegex = LocalPreferences.get("multirename_useRegex", false);
+                fileRenamer.useRegex = multirename_useRegex === "true";
+                $("use_regex_search").checked = fileRenamer.useRegex;
+
+                const multirename_matchAllOccurrences = LocalPreferences.get("multirename_matchAllOccurrences", false);
+                fileRenamer.matchAllOccurrences = multirename_matchAllOccurrences === "true";
+                $("match_all_occurrences").checked = fileRenamer.matchAllOccurrences;
+
+                const multirename_caseSensitive = LocalPreferences.get("multirename_caseSensitive", false);
+                fileRenamer.caseSensitive = multirename_caseSensitive === "true";
+                $("case_sensitive").checked = fileRenamer.caseSensitive;
+
+                const multirename_replace = LocalPreferences.get("multirename_replace", "");
+                fileRenamer.setReplacement(multirename_replace);
+                $("multiRenameReplace").value = multirename_replace;
+
+                const multirename_appliesTo = LocalPreferences.get("multirename_appliesTo", window.qBittorrent.MultiRename.AppliesTo.FilenameExtension);
+                fileRenamer.appliesTo = window.qBittorrent.MultiRename.AppliesTo[multirename_appliesTo];
+                $("applies_to_option").value = fileRenamer.appliesTo;
+
+                const multirename_includeFiles = LocalPreferences.get("multirename_includeFiles", true);
+                fileRenamer.includeFiles = multirename_includeFiles === "true";
+                $("include_files").checked = fileRenamer.includeFiles;
+
+                const multirename_includeFolders = LocalPreferences.get("multirename_includeFolders", false);
+                fileRenamer.includeFolders = multirename_includeFolders === "true";
+                $("include_folders").checked = fileRenamer.includeFolders;
+
+                const multirename_fileEnumerationStart = LocalPreferences.get("multirename_fileEnumerationStart", 0);
+                fileRenamer.fileEnumerationStart = parseInt(multirename_fileEnumerationStart, 10);
+                $("file_counter").value = fileRenamer.fileEnumerationStart;
+
+                const multirename_replaceAll = LocalPreferences.get("multirename_replaceAll", false);
+                fileRenamer.replaceAll = multirename_replaceAll === "true";
+                const renameButtonValue = fileRenamer.replaceAll ? "Replace All" : "Replace";
+                $("renameOptions").value = renameButtonValue;
+                $("renameButton").value = renameButtonValue;
+            }
+
+            // Fires every time a row's selection changes
+            bulkRenameFilesTable.onRowSelectionChange = function(row) {
                 fileRenamer.selectedFiles = bulkRenameFilesTable.getSelectedRows();
+                fileRenamer.update();
+            };
+
+            // Setup Search Events that control renaming
+            $("multiRenameSearch").addEventListener("input", (e) => {
+                const sanitized = e.target.value.replace(/\n/g, "");
+                $("multiRenameSearch").value = sanitized;
+
+                // Search input has changed
+                $("multiRenameSearch").style["border-color"] = "";
+                LocalPreferences.set("multirename_search", sanitized);
+                fileRenamer.setSearch(sanitized);
+            });
+            $("use_regex_search").addEventListener("change", (e) => {
+                fileRenamer.useRegex = e.target.checked;
+                LocalPreferences.set("multirename_useRegex", e.target.checked);
+                fileRenamer.update();
+            });
+            $("match_all_occurrences").addEventListener("change", (e) => {
+                fileRenamer.matchAllOccurrences = e.target.checked;
+                LocalPreferences.set("multirename_matchAllOccurrences", e.target.checked);
+                fileRenamer.update();
+            });
+            $("case_sensitive").addEventListener("change", (e) => {
+                fileRenamer.caseSensitive = e.target.checked;
+                LocalPreferences.set("multirename_caseSensitive", e.target.checked);
                 fileRenamer.update();
             });
 
-            const checkboxTH = tableHeaders[0];
-            checkboxHeader.injectInside(checkboxTH);
-        }
+            /**
+             * Fires every time the filerenamer gets changed, it will update all the rows in the table
+             */
+            fileRenamer.onChanged = function(matchedRows) {
+                // Clear renamed column
+                document
+                    .querySelectorAll("span[id^='filesTablefileRenamed']")
+                    .forEach((span) => {
+                        span.textContent = "";
+                    });
 
-        // Register keyboard events to modal window
-        // https://github.com/qbittorrent/qBittorrent/pull/18687#discussion_r1135045726
-        let keyboard;
-        if (!keyboard) {
-            keyboard = new Keyboard({
-                defaultEventType: "keydown",
-                events: {
-                    "Escape": function(event) {
-                        window.parent.qBittorrent.Client.closeWindows();
-                        event.preventDefault();
-                    },
-                    "Esc": function(event) {
-                        window.parent.qBittorrent.Client.closeWindows();
-                        event.preventDefault();
-                    }
+                // Update renamed column for matched rows
+                for (let i = 0; i < matchedRows.length; ++i) {
+                    const row = matchedRows[i];
+                    $("filesTablefileRenamed" + row.rowId).textContent = row.renamed;
                 }
+            };
+            fileRenamer.onInvalidRegex = function(err) {
+                $("multiRenameSearch").style["border-color"] = "#CC0033";
+            };
+
+            // Setup Replace Events that control renaming
+            $("multiRenameReplace").addEventListener("input", (e) => {
+                const sanitized = e.target.value.replace(/\n/g, "");
+                $("multiRenameReplace").value = sanitized;
+
+                // Replace input has changed
+                $("multiRenameReplace").style["border-color"] = "";
+                LocalPreferences.set("multirename_replace", sanitized);
+                fileRenamer.setReplacement(sanitized);
             });
-            keyboard.activate();
-        }
+            $("applies_to_option").addEventListener("change", (e) => {
+                fileRenamer.appliesTo = e.target.value;
+                LocalPreferences.set("multirename_appliesTo", e.target.value);
+                fileRenamer.update();
+            });
+            $("include_files").addEventListener("change", (e) => {
+                fileRenamer.includeFiles = e.target.checked;
+                LocalPreferences.set("multirename_includeFiles", e.target.checked);
+                fileRenamer.update();
+            });
+            $("include_folders").addEventListener("change", (e) => {
+                fileRenamer.includeFolders = e.target.checked;
+                LocalPreferences.set("multirename_includeFolders", e.target.checked);
+                fileRenamer.update();
+            });
+            $("file_counter").addEventListener("input", (e) => {
+                let value = e.target.valueAsNumber;
+                if (!value)
+                    value = 0;
+                if (value < 0)
+                    value = 0;
+                if (value > 99999999)
+                    value = 99999999;
+                fileRenamer.fileEnumerationStart = value;
+                $("file_counter").value = value;
+                LocalPreferences.set("multirename_fileEnumerationStart", value);
+                fileRenamer.update();
+            });
 
-        const fileRenamer = new window.qBittorrent.MultiRename.RenameFiles();
-        fileRenamer.hash = data.hash;
+            // Setup Rename Operation Events
+            $("renameButton").addEventListener("click", (e) => {
+                // Disable Search Options
+                $("multiRenameSearch").disabled = true;
+                $("use_regex_search").disabled = true;
+                $("match_all_occurrences").disabled = true;
+                $("case_sensitive").disabled = true;
+                // Disable Replace Options
+                $("multiRenameReplace").disabled = true;
+                $("applies_to_option").disabled = true;
+                $("include_files").disabled = true;
+                $("include_folders").disabled = true;
+                $("file_counter").disabled = true;
+                // Disable Rename Buttons
+                $("renameButton").disabled = true;
+                $("renameOptions").disabled = true;
+                // Clear error text
+                $("rename_error").textContent = "";
+                fileRenamer.rename();
+            });
+            fileRenamer.onRenamed = function(rows) {
+                // Disable Search Options
+                $("multiRenameSearch").disabled = false;
+                $("use_regex_search").disabled = false;
+                $("match_all_occurrences").disabled = false;
+                $("case_sensitive").disabled = false;
+                // Disable Replace Options
+                $("multiRenameReplace").disabled = false;
+                $("applies_to_option").disabled = false;
+                $("include_files").disabled = false;
+                $("include_folders").disabled = false;
+                $("file_counter").disabled = false;
+                // Disable Rename Buttons
+                $("renameButton").disabled = false;
+                $("renameOptions").disabled = false;
 
-        // Load Multi Rename Preferences
-        const multiRenamePrefChecked = LocalPreferences.get("multirename_rememberPreferences", "true") === "true";
-        $("multirename_rememberprefs_checkbox").checked = multiRenamePrefChecked;
+                // Recreate table
+                let selectedRows = bulkRenameFilesTable.getSelectedRows().map(row => row.rowId.toString());
+                for (const renamedRow of rows)
+                    selectedRows = selectedRows.filter(selectedRow => selectedRow !== renamedRow.rowId.toString());
+                bulkRenameFilesTable.clear();
 
-        if (multiRenamePrefChecked) {
-            const multirename_search = LocalPreferences.get("multirename_search", "");
-            fileRenamer.setSearch(multirename_search);
-            $("multiRenameSearch").value = multirename_search;
+                // Adjust file enumeration count by 1 when replacing single files to prevent naming conflicts
+                if (!fileRenamer.replaceAll) {
+                    fileRenamer.fileEnumerationStart++;
+                    $("file_counter").value = fileRenamer.fileEnumerationStart;
+                }
+                setupTable(selectedRows);
+            };
+            fileRenamer.onRenameError = function(err, row) {
+                if (err.xhr.status === 409)
+                    $("rename_error").textContent = `QBT_TR(Rename failed: file or folder already exists)QBT_TR[CONTEXT=PropertiesWidget] \`${row.renamed}\``;
+            };
+            $("renameOptions").addEventListener("change", (e) => {
+                const combobox = e.target;
+                const replaceOperation = combobox.value;
+                if (replaceOperation === "Replace")
+                    fileRenamer.replaceAll = false;
+                else if (replaceOperation === "Replace All")
+                    fileRenamer.replaceAll = true;
+                else
+                    fileRenamer.replaceAll = false;
+                LocalPreferences.set("multirename_replaceAll", fileRenamer.replaceAll);
+                $("renameButton").value = replaceOperation;
+            });
+            $("closeButton").addEventListener("click", () => {
+                window.parent.qBittorrent.Client.closeWindows();
+                event.preventDefault();
+            });
+            // synchronize header scrolling to table body
+            $("bulkRenameFilesTableDiv").onscroll = function() {
+                const length = $(this).scrollLeft;
+                $("bulkRenameFilesTableFixedHeaderDiv").scrollLeft = length;
+            };
 
-            const multirename_useRegex = LocalPreferences.get("multirename_useRegex", false);
-            fileRenamer.useRegex = multirename_useRegex === "true";
-            $("use_regex_search").checked = fileRenamer.useRegex;
+            const handleTorrentFiles = function(files, selectedRows) {
+                const rows = files.map((file, index) => {
 
-            const multirename_matchAllOccurrences = LocalPreferences.get("multirename_matchAllOccurrences", false);
-            fileRenamer.matchAllOccurrences = multirename_matchAllOccurrences === "true";
-            $("match_all_occurrences").checked = fileRenamer.matchAllOccurrences;
+                    const row = {
+                        fileId: index,
+                        checked: 1, // unchecked
+                        path: file.name,
+                        original: window.qBittorrent.Filesystem.fileName(file.name),
+                        renamed: "",
+                        size: file.size
+                    };
 
-            const multirename_caseSensitive = LocalPreferences.get("multirename_caseSensitive", false);
-            fileRenamer.caseSensitive = multirename_caseSensitive === "true";
-            $("case_sensitive").checked = fileRenamer.caseSensitive;
-
-            const multirename_replace = LocalPreferences.get("multirename_replace", "");
-            fileRenamer.setReplacement(multirename_replace);
-            $("multiRenameReplace").value = multirename_replace;
-
-            const multirename_appliesTo = LocalPreferences.get("multirename_appliesTo", window.qBittorrent.MultiRename.AppliesTo.FilenameExtension);
-            fileRenamer.appliesTo = window.qBittorrent.MultiRename.AppliesTo[multirename_appliesTo];
-            $("applies_to_option").value = fileRenamer.appliesTo;
-
-            const multirename_includeFiles = LocalPreferences.get("multirename_includeFiles", true);
-            fileRenamer.includeFiles = multirename_includeFiles === "true";
-            $("include_files").checked = fileRenamer.includeFiles;
-
-            const multirename_includeFolders = LocalPreferences.get("multirename_includeFolders", false);
-            fileRenamer.includeFolders = multirename_includeFolders === "true";
-            $("include_folders").checked = fileRenamer.includeFolders;
-
-            const multirename_fileEnumerationStart = LocalPreferences.get("multirename_fileEnumerationStart", 0);
-            fileRenamer.fileEnumerationStart = parseInt(multirename_fileEnumerationStart, 10);
-            $("file_counter").value = fileRenamer.fileEnumerationStart;
-
-            const multirename_replaceAll = LocalPreferences.get("multirename_replaceAll", false);
-            fileRenamer.replaceAll = multirename_replaceAll === "true";
-            const renameButtonValue = fileRenamer.replaceAll ? "Replace All" : "Replace";
-            $("renameOptions").value = renameButtonValue;
-            $("renameButton").value = renameButtonValue;
-        }
-
-        // Fires every time a row's selection changes
-        bulkRenameFilesTable.onRowSelectionChange = function(row) {
-            fileRenamer.selectedFiles = bulkRenameFilesTable.getSelectedRows();
-            fileRenamer.update();
-        };
-
-        // Setup Search Events that control renaming
-        $("multiRenameSearch").addEventListener("input", (e) => {
-            const sanitized = e.target.value.replace(/\n/g, "");
-            $("multiRenameSearch").value = sanitized;
-
-            // Search input has changed
-            $("multiRenameSearch").style["border-color"] = "";
-            LocalPreferences.set("multirename_search", sanitized);
-            fileRenamer.setSearch(sanitized);
-        });
-        $("use_regex_search").addEventListener("change", (e) => {
-            fileRenamer.useRegex = e.target.checked;
-            LocalPreferences.set("multirename_useRegex", e.target.checked);
-            fileRenamer.update();
-        });
-        $("match_all_occurrences").addEventListener("change", (e) => {
-            fileRenamer.matchAllOccurrences = e.target.checked;
-            LocalPreferences.set("multirename_matchAllOccurrences", e.target.checked);
-            fileRenamer.update();
-        });
-        $("case_sensitive").addEventListener("change", (e) => {
-            fileRenamer.caseSensitive = e.target.checked;
-            LocalPreferences.set("multirename_caseSensitive", e.target.checked);
-            fileRenamer.update();
-        });
-
-        /**
-         * Fires every time the filerenamer gets changed, it will update all the rows in the table
-         */
-        fileRenamer.onChanged = function(matchedRows) {
-            // Clear renamed column
-            document
-                .querySelectorAll("span[id^='filesTablefileRenamed']")
-                .forEach((span) => {
-                    span.textContent = "";
+                    return row;
                 });
 
-            // Update renamed column for matched rows
-            for (let i = 0; i < matchedRows.length; ++i) {
-                const row = matchedRows[i];
-                $("filesTablefileRenamed" + row.rowId).textContent = row.renamed;
-            }
-        };
-        fileRenamer.onInvalidRegex = function(err) {
-            $("multiRenameSearch").style["border-color"] = "#CC0033";
-        };
+                addRowsToTable(rows, selectedRows);
+            };
 
-        // Setup Replace Events that control renaming
-        $("multiRenameReplace").addEventListener("input", (e) => {
-            const sanitized = e.target.value.replace(/\n/g, "");
-            $("multiRenameReplace").value = sanitized;
+            const addRowsToTable = function(rows, selectedRows) {
+                let rowId = 0;
+                const rootNode = new window.qBittorrent.FileTree.FolderNode();
+                rootNode.autoCheckFolders = false;
 
-            // Replace input has changed
-            $("multiRenameReplace").style["border-color"] = "";
-            LocalPreferences.set("multirename_replace", sanitized);
-            fileRenamer.setReplacement(sanitized);
-        });
-        $("applies_to_option").addEventListener("change", (e) => {
-            fileRenamer.appliesTo = e.target.value;
-            LocalPreferences.set("multirename_appliesTo", e.target.value);
-            fileRenamer.update();
-        });
-        $("include_files").addEventListener("change", (e) => {
-            fileRenamer.includeFiles = e.target.checked;
-            LocalPreferences.set("multirename_includeFiles", e.target.checked);
-            fileRenamer.update();
-        });
-        $("include_folders").addEventListener("change", (e) => {
-            fileRenamer.includeFolders = e.target.checked;
-            LocalPreferences.set("multirename_includeFolders", e.target.checked);
-            fileRenamer.update();
-        });
-        $("file_counter").addEventListener("input", (e) => {
-            let value = e.target.valueAsNumber;
-            if (!value)
-                value = 0;
-            if (value < 0)
-                value = 0;
-            if (value > 99999999)
-                value = 99999999;
-            fileRenamer.fileEnumerationStart = value;
-            $("file_counter").value = value;
-            LocalPreferences.set("multirename_fileEnumerationStart", value);
-            fileRenamer.update();
-        });
+                rows.forEach((row) => {
+                    const pathItems = row.path.split(window.qBittorrent.Filesystem.PathSeparator);
 
-        // Setup Rename Operation Events
-        $("renameButton").addEventListener("click", (e) => {
-            // Disable Search Options
-            $("multiRenameSearch").disabled = true;
-            $("use_regex_search").disabled = true;
-            $("match_all_occurrences").disabled = true;
-            $("case_sensitive").disabled = true;
-            // Disable Replace Options
-            $("multiRenameReplace").disabled = true;
-            $("applies_to_option").disabled = true;
-            $("include_files").disabled = true;
-            $("include_folders").disabled = true;
-            $("file_counter").disabled = true;
-            // Disable Rename Buttons
-            $("renameButton").disabled = true;
-            $("renameOptions").disabled = true;
-            // Clear error text
-            $("rename_error").textContent = "";
-            fileRenamer.rename();
-        });
-        fileRenamer.onRenamed = function(rows) {
-            // Disable Search Options
-            $("multiRenameSearch").disabled = false;
-            $("use_regex_search").disabled = false;
-            $("match_all_occurrences").disabled = false;
-            $("case_sensitive").disabled = false;
-            // Disable Replace Options
-            $("multiRenameReplace").disabled = false;
-            $("applies_to_option").disabled = false;
-            $("include_files").disabled = false;
-            $("include_folders").disabled = false;
-            $("file_counter").disabled = false;
-            // Disable Rename Buttons
-            $("renameButton").disabled = false;
-            $("renameOptions").disabled = false;
+                    pathItems.pop(); // remove last item (i.e. file name)
+                    let parent = rootNode;
+                    pathItems.forEach((folderName) => {
+                        if (folderName === ".unwanted")
+                            return;
 
-            // Recreate table
-            let selectedRows = bulkRenameFilesTable.getSelectedRows().map(row => row.rowId.toString());
-            for (const renamedRow of rows)
-                selectedRows = selectedRows.filter(selectedRow => selectedRow !== renamedRow.rowId.toString());
-            bulkRenameFilesTable.clear();
-
-            // Adjust file enumeration count by 1 when replacing single files to prevent naming conflicts
-            if (!fileRenamer.replaceAll) {
-                fileRenamer.fileEnumerationStart++;
-                $("file_counter").value = fileRenamer.fileEnumerationStart;
-            }
-            setupTable(selectedRows);
-        };
-        fileRenamer.onRenameError = function(err, row) {
-            if (err.xhr.status === 409)
-                $("rename_error").textContent = `QBT_TR(Rename failed: file or folder already exists)QBT_TR[CONTEXT=PropertiesWidget] \`${row.renamed}\``;
-        };
-        $("renameOptions").addEventListener("change", (e) => {
-            const combobox = e.target;
-            const replaceOperation = combobox.value;
-            if (replaceOperation === "Replace")
-                fileRenamer.replaceAll = false;
-            else if (replaceOperation === "Replace All")
-                fileRenamer.replaceAll = true;
-            else
-                fileRenamer.replaceAll = false;
-            LocalPreferences.set("multirename_replaceAll", fileRenamer.replaceAll);
-            $("renameButton").value = replaceOperation;
-        });
-        $("closeButton").addEventListener("click", () => {
-            window.parent.qBittorrent.Client.closeWindows();
-            event.preventDefault();
-        });
-        // synchronize header scrolling to table body
-        $("bulkRenameFilesTableDiv").onscroll = function() {
-            const length = $(this).scrollLeft;
-            $("bulkRenameFilesTableFixedHeaderDiv").scrollLeft = length;
-        };
-
-        const handleTorrentFiles = function(files, selectedRows) {
-            const rows = files.map((file, index) => {
-
-                const row = {
-                    fileId: index,
-                    checked: 1, // unchecked
-                    path: file.name,
-                    original: window.qBittorrent.Filesystem.fileName(file.name),
-                    renamed: "",
-                    size: file.size
-                };
-
-                return row;
-            });
-
-            addRowsToTable(rows, selectedRows);
-        };
-
-        const addRowsToTable = function(rows, selectedRows) {
-            let rowId = 0;
-            const rootNode = new window.qBittorrent.FileTree.FolderNode();
-            rootNode.autoCheckFolders = false;
-
-            rows.forEach((row) => {
-                const pathItems = row.path.split(window.qBittorrent.Filesystem.PathSeparator);
-
-                pathItems.pop(); // remove last item (i.e. file name)
-                let parent = rootNode;
-                pathItems.forEach((folderName) => {
-                    if (folderName === ".unwanted")
-                        return;
-
-                    let folderNode = null;
-                    if (parent.children !== null) {
-                        for (let i = 0; i < parent.children.length; ++i) {
-                            const childFolder = parent.children[i];
-                            if (childFolder.original === folderName) {
-                                folderNode = childFolder;
-                                break;
+                        let folderNode = null;
+                        if (parent.children !== null) {
+                            for (let i = 0; i < parent.children.length; ++i) {
+                                const childFolder = parent.children[i];
+                                if (childFolder.original === folderName) {
+                                    folderNode = childFolder;
+                                    break;
+                                }
                             }
                         }
-                    }
 
-                    if (folderNode === null) {
-                        folderNode = new window.qBittorrent.FileTree.FolderNode();
-                        folderNode.autoCheckFolders = false;
-                        folderNode.rowId = rowId;
-                        folderNode.path = (parent.path === "")
-                            ? folderName
-                            : [parent.path, folderName].join(window.qBittorrent.Filesystem.PathSeparator);
-                        folderNode.checked = selectedRows.includes(rowId.toString()) ? 0 : 1;
-                        folderNode.original = folderName;
-                        folderNode.renamed = "";
-                        folderNode.root = parent;
-                        parent.addChild(folderNode);
+                        if (folderNode === null) {
+                            folderNode = new window.qBittorrent.FileTree.FolderNode();
+                            folderNode.autoCheckFolders = false;
+                            folderNode.rowId = rowId;
+                            folderNode.path = (parent.path === "")
+                                ? folderName
+                                : [parent.path, folderName].join(window.qBittorrent.Filesystem.PathSeparator);
+                            folderNode.checked = selectedRows.includes(rowId.toString()) ? 0 : 1;
+                            folderNode.original = folderName;
+                            folderNode.renamed = "";
+                            folderNode.root = parent;
+                            parent.addChild(folderNode);
 
-                        ++rowId;
-                    }
+                            ++rowId;
+                        }
 
-                    parent = folderNode;
+                        parent = folderNode;
+                    });
+
+                    const childNode = new window.qBittorrent.FileTree.FileNode();
+                    childNode.rowId = rowId;
+                    childNode.path = row.path;
+                    childNode.checked = selectedRows.includes(rowId.toString()) ? 0 : 1;
+                    childNode.original = row.original;
+                    childNode.renamed = "";
+                    childNode.root = parent;
+                    childNode.data = row;
+                    parent.addChild(childNode);
+
+                    ++rowId;
                 });
 
-                const childNode = new window.qBittorrent.FileTree.FileNode();
-                childNode.rowId = rowId;
-                childNode.path = row.path;
-                childNode.checked = selectedRows.includes(rowId.toString()) ? 0 : 1;
-                childNode.original = row.original;
-                childNode.renamed = "";
-                childNode.root = parent;
-                childNode.data = row;
-                parent.addChild(childNode);
+                bulkRenameFilesTable.populateTable(rootNode);
+                bulkRenameFilesTable.updateTable(false);
 
-                ++rowId;
-            });
+                if (selectedRows !== undefined)
+                    bulkRenameFilesTable.reselectRows(selectedRows);
 
-            bulkRenameFilesTable.populateTable(rootNode);
-            bulkRenameFilesTable.updateTable(false);
+                fileRenamer.selectedFiles = bulkRenameFilesTable.getSelectedRows();
+                fileRenamer.update();
+            };
 
-            if (selectedRows !== undefined)
-                bulkRenameFilesTable.reselectRows(selectedRows);
-
-            fileRenamer.selectedFiles = bulkRenameFilesTable.getSelectedRows();
-            fileRenamer.update();
-        };
-
-        const setupTable = function(selectedRows) {
-            new Request.JSON({
-                url: new URI("api/v2/torrents/files?hash=" + data.hash),
-                noCache: true,
-                method: "get",
-                onSuccess: function(files) {
-                    if (files.length === 0)
-                        bulkRenameFilesTable.clear();
-                    else
-                        handleTorrentFiles(files, selectedRows);
-                }
-            }).send();
-        };
-        setupTable(data.selectedRows);
+            const setupTable = function(selectedRows) {
+                new Request.JSON({
+                    url: new URI("api/v2/torrents/files?hash=" + data.hash),
+                    noCache: true,
+                    method: "get",
+                    onSuccess: function(files) {
+                        if (files.length === 0)
+                            bulkRenameFilesTable.clear();
+                        else
+                            handleTorrentFiles(files, selectedRows);
+                    }
+                }).send();
+            };
+            setupTable(data.selectedRows);
+        })();
     </script>
 </head>
 


### PR DESCRIPTION
Added an IIFE around the whole script to suppress variable redeclaration errors.

Closes #21614.

ps. PR #21621 is for v5_0_x since it wasn't able to cleanly cherry-pick this PR to v5_0_x.