### PR TITLE
WebUI: Improve table overflow handling in Transfers tab

### DIFF
--- a/src/webui/www/private/css/dynamicTable.css
+++ b/src/webui/www/private/css/dynamicTable.css
@@ -101,3 +101,42 @@ tr.dynamicTableHeader {
     padding-bottom: 0px !important;
     padding-top: 0px !important;
 }
+
+#transferList {
+    overflow: hidden !important; /* override for mocha inline styles */
+
+    & #transferList_pad {
+        display: flex !important;
+        flex-direction: column;
+        height: inherit;
+
+        & #torrentsTableDiv {
+            flex: 1;
+        }
+    }
+}
+
+#propertiesPanel {
+    & #propertiesPanel_pad {
+        height: inherit;
+    }
+
+    & .dynamicTableDiv {
+        flex: 1;
+    }
+
+    & .propertiesTabContent:not(#propGeneral, .invisible) {
+        display: flex;
+        flex-direction: column;
+        height: inherit;
+    }
+}
+
+#torrentFiles {
+    display: flex;
+    flex-direction: column;
+
+    & #bulkRenameFilesTableDiv {
+        flex: 1;
+    }
+}

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -100,33 +100,6 @@ window.qBittorrent.DynamicTable ??= (() => {
             tableDiv.addEventListener("scroll", () => {
                 tableElement.style.left = `${-tableDiv.scrollLeft}px`;
             });
-
-            // if the table exists within a panel
-            const parentPanel = tableDiv.getParent(".panel");
-            if (parentPanel) {
-                const resizeFn = (entries) => {
-                    const panel = entries[0].target;
-                    let h = panel.getBoundingClientRect().height - tableFixedHeaderDiv.getBoundingClientRect().height;
-                    tableDiv.style.height = `${h}px`;
-
-                    // Workaround due to inaccurate calculation of elements heights by browser
-                    let n = 2;
-
-                    // is panel vertical scrollbar visible or does panel content not fit?
-                    while (((panel.clientWidth !== panel.offsetWidth) || (panel.clientHeight !== panel.scrollHeight)) && (n > 0)) {
-                        --n;
-                        h -= 0.5;
-                        tableDiv.style.height = `${h}px`;
-                    }
-                };
-
-                const resizeDebouncer = window.qBittorrent.Misc.createDebounceHandler(100, (entries) => {
-                    resizeFn(entries);
-                });
-
-                const resizeObserver = new ResizeObserver(resizeDebouncer);
-                resizeObserver.observe(parentPanel, { box: "border-box" });
-            }
         },
 
         setupHeaderEvents: function() {

--- a/src/webui/www/private/views/properties.html
+++ b/src/webui/www/private/views/properties.html
@@ -105,81 +105,73 @@
 </div>
 
 <div id="propTrackers" class="propertiesTabContent invisible unselectable">
-    <div id="trackers">
-        <div id="torrentTrackersTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
-            <table class="dynamicTable" style="position:relative;">
-                <thead>
-                    <tr class="dynamicTableHeader"></tr>
-                </thead>
-            </table>
-        </div>
-        <div id="torrentTrackersTableDiv" class="dynamicTableDiv">
-            <table class="dynamicTable">
-                <thead>
-                    <tr class="dynamicTableHeader"></tr>
-                </thead>
-                <tbody></tbody>
-            </table>
-        </div>
+    <div id="torrentTrackersTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
+        <table class="dynamicTable" style="position:relative;">
+            <thead>
+                <tr class="dynamicTableHeader"></tr>
+            </thead>
+        </table>
+    </div>
+    <div id="torrentTrackersTableDiv" class="dynamicTableDiv">
+        <table class="dynamicTable">
+            <thead>
+                <tr class="dynamicTableHeader"></tr>
+            </thead>
+            <tbody></tbody>
+        </table>
     </div>
 </div>
 
 <div id="propPeers" class="propertiesTabContent invisible unselectable">
-    <div>
-        <div id="torrentPeersTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
-            <table class="dynamicTable" style="position:relative;">
-                <thead>
-                    <tr class="dynamicTableHeader"></tr>
-                </thead>
-            </table>
-        </div>
-        <div id="torrentPeersTableDiv" class="dynamicTableDiv">
-            <table class="dynamicTable">
-                <thead>
-                    <tr class="dynamicTableHeader"></tr>
-                </thead>
-                <tbody></tbody>
-            </table>
-        </div>
+    <div id="torrentPeersTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
+        <table class="dynamicTable" style="position:relative;">
+            <thead>
+                <tr class="dynamicTableHeader"></tr>
+            </thead>
+        </table>
+    </div>
+    <div id="torrentPeersTableDiv" class="dynamicTableDiv">
+        <table class="dynamicTable">
+            <thead>
+                <tr class="dynamicTableHeader"></tr>
+            </thead>
+            <tbody></tbody>
+        </table>
     </div>
 </div>
 
 <div id="propWebSeeds" class="propertiesTabContent invisible unselectable">
-    <div id="webseeds">
-        <div id="torrentWebseedsTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
-            <table class="dynamicTable" style="position:relative;">
-                <thead>
-                    <tr class="dynamicTableHeader"></tr>
-                </thead>
-            </table>
-        </div>
-        <div id="torrentWebseedsTableDiv" class="dynamicTableDiv">
-            <table class="dynamicTable">
-                <thead>
-                    <tr class="dynamicTableHeader"></tr>
-                </thead>
-                <tbody></tbody>
-            </table>
-        </div>
+    <div id="torrentWebseedsTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
+        <table class="dynamicTable" style="position:relative;">
+            <thead>
+                <tr class="dynamicTableHeader"></tr>
+            </thead>
+        </table>
+    </div>
+    <div id="torrentWebseedsTableDiv" class="dynamicTableDiv">
+        <table class="dynamicTable">
+            <thead>
+                <tr class="dynamicTableHeader"></tr>
+            </thead>
+            <tbody></tbody>
+        </table>
     </div>
 </div>
 
 <div id="propFiles" class="propertiesTabContent invisible unselectable">
-    <div id="torrentFiles">
-        <div id="torrentFilesTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
-            <table class="dynamicTable" style="position:relative;">
-                <thead>
-                    <tr class="dynamicTableHeader"></tr>
-                </thead>
-            </table>
-        </div>
-        <div id="torrentFilesTableDiv" class="dynamicTableDiv">
-            <table class="dynamicTable">
-                <thead>
-                    <tr class="dynamicTableHeader"></tr>
-                </thead>
-                <tbody></tbody>
-            </table>
-        </div>
+    <div id="torrentFilesTableFixedHeaderDiv" class="dynamicTableFixedHeaderDiv">
+        <table class="dynamicTable" style="position:relative;">
+            <thead>
+                <tr class="dynamicTableHeader"></tr>
+            </thead>
+        </table>
+    </div>
+    <div id="torrentFilesTableDiv" class="dynamicTableDiv">
+        <table class="dynamicTable">
+            <thead>
+                <tr class="dynamicTableHeader"></tr>
+            </thead>
+            <tbody></tbody>
+        </table>
     </div>
 </div>


### PR DESCRIPTION
This PR improves table overflow handling in Transfers tab:
1) Table headers in properties panel are visible in all circumstances.
2) Fixed many other overflow issues, like double scrollbars, blinking/jumping scrollbars, scrollbars appearing even when there is no overflow etc.