### PR TITLE
WebUI: restore arrow keys table navigation

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -721,7 +721,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                     const tr = new Element("tr");
                     // set tabindex so element receives keydown events
                     // more info: https://developer.mozilla.org/en-US/docs/Web/API/Element/keydown_event
-                    tr.tabindex = "-1";
+                    tr.tabIndex = -1;
 
                     const rowId = rows[rowPos]["rowId"];
                     tr.setAttribute("data-row-id", rowId);
@@ -765,10 +765,10 @@ window.qBittorrent.DynamicTable ??= (() => {
                     }, { passive: true });
                     tr.addEventListener("keydown", function(event) {
                         switch (event.key) {
-                            case "up":
+                            case "ArrowUp":
                                 this._this.selectPreviousRow();
                                 return false;
-                            case "down":
+                            case "ArrowDown":
                                 this._this.selectNextRow();
                                 return false;
                         }
@@ -2294,10 +2294,10 @@ window.qBittorrent.DynamicTable ??= (() => {
         setupTr: function(tr) {
             tr.addEventListener("keydown", function(event) {
                 switch (event.key) {
-                    case "left":
+                    case "ArrowLeft":
                         qBittorrent.PropFiles.collapseFolder(this._this.getSelectedRowId());
                         return false;
-                    case "right":
+                    case "ArrowRight":
                         qBittorrent.PropFiles.expandFolder(this._this.getSelectedRowId());
                         return false;
                 }
@@ -2623,10 +2623,10 @@ window.qBittorrent.DynamicTable ??= (() => {
         setupTr: function(tr) {
             tr.addEventListener("keydown", function(event) {
                 switch (event.key) {
-                    case "left":
+                    case "ArrowLeft":
                         qBittorrent.PropFiles.collapseFolder(this._this.getSelectedRowId());
                         return false;
-                    case "right":
+                    case "ArrowRight":
                         qBittorrent.PropFiles.expandFolder(this._this.getSelectedRowId());
                         return false;
                 }


### PR DESCRIPTION
Fixup for #21007 and #21147. Table navigation with arrows (#15186) has been broken by that changes.
See https://github.com/qbittorrent/qBittorrent/pull/21007#discussion_r1807326166 and https://github.com/qbittorrent/qBittorrent/pull/21147#discussion_r1807361385 for details.
This PR restores the functionaly.