### PR TITLE
WebUI: Clear properties panel when torrent no longer selected

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -229,32 +229,63 @@ window.addEventListener("DOMContentLoaded", () => {
     buildLogTab();
     MochaUI.initializeTabs("mainWindowTabsList");
 
+    const handleFilterSelectionChange = function(prevSelectedTorrent, currSelectedTorrent) {
+        // clear properties panels when filter changes (e.g. selected torrent is no longer visible)
+        if (prevSelectedTorrent !== currSelectedTorrent) {
+            window.qBittorrent.PropGeneral.clear();
+            window.qBittorrent.PropTrackers.clear();
+            window.qBittorrent.PropPeers.clear();
+            window.qBittorrent.PropWebseeds.clear();
+            window.qBittorrent.PropFiles.clear();
+        }
+    };
+
     setStatusFilter = function(name) {
+        const currentHash = torrentsTable.getCurrentTorrentID();
+
         LocalPreferences.set("selected_filter", name);
         selectedStatus = name;
         highlightSelectedStatus();
         updateMainData();
+
+        const newHash = torrentsTable.getCurrentTorrentID();
+        handleFilterSelectionChange(currentHash, newHash);
     };
 
     setCategoryFilter = function(hash) {
+        const currentHash = torrentsTable.getCurrentTorrentID();
+
         LocalPreferences.set("selected_category", hash);
         selectedCategory = Number(hash);
         highlightSelectedCategory();
         updateMainData();
+
+        const newHash = torrentsTable.getCurrentTorrentID();
+        handleFilterSelectionChange(currentHash, newHash);
     };
 
     setTagFilter = function(hash) {
+        const currentHash = torrentsTable.getCurrentTorrentID();
+
         LocalPreferences.set("selected_tag", hash);
         selectedTag = Number(hash);
         highlightSelectedTag();
         updateMainData();
+
+        const newHash = torrentsTable.getCurrentTorrentID();
+        handleFilterSelectionChange(currentHash, newHash);
     };
 
     setTrackerFilter = function(hash) {
+        const currentHash = torrentsTable.getCurrentTorrentID();
+
         LocalPreferences.set("selected_tracker", hash);
         selectedTracker = Number(hash);
         highlightSelectedTracker();
         updateMainData();
+
+        const newHash = torrentsTable.getCurrentTorrentID();
+        handleFilterSelectionChange(currentHash, newHash);
     };
 
     toggleFilterDisplay = function(filterListID) {

--- a/src/webui/www/private/scripts/prop-files.js
+++ b/src/webui/www/private/scripts/prop-files.js
@@ -42,7 +42,8 @@ window.qBittorrent.PropFiles ??= (() => {
             updateData: updateData,
             collapseIconClicked: collapseIconClicked,
             expandFolder: expandFolder,
-            collapseFolder: collapseFolder
+            collapseFolder: collapseFolder,
+            clear: clear
         };
     };
 
@@ -343,7 +344,6 @@ window.qBittorrent.PropFiles ??= (() => {
         if (new_hash === "") {
             torrentFilesTable.clear();
             clearTimeout(loadTorrentFilesDataTimer);
-            loadTorrentFilesDataTimer = loadTorrentFilesData.delay(5000);
             return;
         }
         let loadedNewTorrent = false;
@@ -762,6 +762,10 @@ window.qBittorrent.PropFiles ??= (() => {
 
             _collapseNode(child, shouldCollapse, applyToChildren, true);
         });
+    };
+
+    const clear = function() {
+        torrentFilesTable.clear();
     };
 
     return exports();

--- a/src/webui/www/private/scripts/prop-general.js
+++ b/src/webui/www/private/scripts/prop-general.js
@@ -32,7 +32,8 @@ window.qBittorrent ??= {};
 window.qBittorrent.PropGeneral ??= (() => {
     const exports = () => {
         return {
-            updateData: updateData
+            updateData: updateData,
+            clear: clear
         };
     };
 
@@ -83,7 +84,6 @@ window.qBittorrent.PropGeneral ??= (() => {
         if (current_id === "") {
             clearData();
             clearTimeout(loadTorrentDataTimer);
-            loadTorrentDataTimer = loadTorrentData.delay(5000);
             return;
         }
         const url = new URI("api/v2/torrents/properties?hash=" + current_id);
@@ -252,6 +252,10 @@ window.qBittorrent.PropGeneral ??= (() => {
         clearTimeout(loadTorrentDataTimer);
         loadTorrentDataTimer = -1;
         loadTorrentData();
+    };
+
+    const clear = function() {
+        clearData();
     };
 
     return exports();

--- a/src/webui/www/private/scripts/prop-peers.js
+++ b/src/webui/www/private/scripts/prop-peers.js
@@ -32,7 +32,8 @@ window.qBittorrent ??= {};
 window.qBittorrent.PropPeers ??= (() => {
     const exports = () => {
         return {
-            updateData: updateData
+            updateData: updateData,
+            clear: clear
         };
     };
 
@@ -53,7 +54,6 @@ window.qBittorrent.PropPeers ??= (() => {
             syncTorrentPeersLastResponseId = 0;
             torrentPeersTable.clear();
             clearTimeout(loadTorrentPeersTimer);
-            loadTorrentPeersTimer = loadTorrentPeersData.delay(window.qBittorrent.Client.getSyncMainDataInterval());
             return;
         }
         const url = new URI("api/v2/sync/torrentPeers");
@@ -110,6 +110,10 @@ window.qBittorrent.PropPeers ??= (() => {
         clearTimeout(loadTorrentPeersTimer);
         loadTorrentPeersTimer = -1;
         loadTorrentPeersData();
+    };
+
+    const clear = function() {
+        torrentPeersTable.clear();
     };
 
     const torrentPeersContextMenu = new window.qBittorrent.ContextMenu.ContextMenu({

--- a/src/webui/www/private/scripts/prop-trackers.js
+++ b/src/webui/www/private/scripts/prop-trackers.js
@@ -32,7 +32,8 @@ window.qBittorrent ??= {};
 window.qBittorrent.PropTrackers ??= (() => {
     const exports = () => {
         return {
-            updateData: updateData
+            updateData: updateData,
+            clear: clear
         };
     };
 
@@ -51,7 +52,6 @@ window.qBittorrent.PropTrackers ??= (() => {
         if (new_hash === "") {
             torrentTrackersTable.clear();
             clearTimeout(loadTrackersDataTimer);
-            loadTrackersDataTimer = loadTrackersData.delay(10000);
             return;
         }
         if (new_hash !== current_hash) {
@@ -225,6 +225,10 @@ window.qBittorrent.PropTrackers ??= (() => {
                 updateData();
             }
         }).send();
+    };
+
+    const clear = function() {
+        torrentTrackersTable.clear();
     };
 
     new ClipboardJS("#CopyTrackerUrl", {

--- a/src/webui/www/private/scripts/prop-webseeds.js
+++ b/src/webui/www/private/scripts/prop-webseeds.js
@@ -32,7 +32,8 @@ window.qBittorrent ??= {};
 window.qBittorrent.PropWebseeds ??= (() => {
     const exports = () => {
         return {
-            updateData: updateData
+            updateData: updateData,
+            clear: clear
         };
     };
 
@@ -51,7 +52,6 @@ window.qBittorrent.PropWebseeds ??= (() => {
         if (new_hash === "") {
             torrentWebseedsTable.clear();
             clearTimeout(loadWebSeedsDataTimer);
-            loadWebSeedsDataTimer = loadWebSeedsData.delay(10000);
             return;
         }
         if (new_hash !== current_hash) {
@@ -202,6 +202,10 @@ window.qBittorrent.PropWebseeds ??= (() => {
                 updateData();
             }
         }).send();
+    };
+
+    const clear = function() {
+        torrentWebseedsTable.clear();
     };
 
     new ClipboardJS("#CopyWebseedUrl", {


### PR DESCRIPTION
Currently the properties panels don't immediately clear when unselecting the torrent (e.g. by switching filters)/