### PR TITLE
WebUI: Show file filter when Content tab selected on load

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -1506,6 +1506,10 @@ window.addEventListener("DOMContentLoaded", () => {
                 const showFilesFilter = (selectedTab.id === "propFilesLink") && !this.isCollapsed;
                 document.getElementById("torrentFilesFilterToolbar").classList.toggle("invisible", !showFilesFilter);
             });
+
+            const showFilesFilter = (lastUsedTab === "propFilesLink") && !this.isCollapsed;
+            if (showFilesFilter)
+                document.getElementById("torrentFilesFilterToolbar").classList.remove("invisible");
         },
         column: "mainColumn",
         height: prop_h


### PR DESCRIPTION
This fixes a bug where the file filter is only shown when the Content tab is switched to. The filter is not being shown if the Content tab is already selected on page load (due to being previously selected).