### PR TITLE
WebUI: Add tooltip to regex filter button

### DIFF
--- a/src/webui/www/private/css/style.css
+++ b/src/webui/www/private/css/style.css
@@ -487,6 +487,7 @@ a.propButton img {
     background-size: 1.5em;
     border: 1px solid var(--color-border-default);
     border-radius: 4px;
+    cursor: pointer;
     display: inline-block;
     height: 26px;
     margin-bottom: -9px;

--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -140,7 +140,7 @@
                 <div id="torrentsFilterToolbar">
                     <input type="text" id="torrentsFilterInput" placeholder="QBT_TR(Filter torrent list...)QBT_TR[CONTEXT=MainWindow]" aria-label="QBT_TR(Filter torrent list...)QBT_TR[CONTEXT=MainWindow]" autocorrect="off" autocapitalize="none">
                     <input type="checkbox" id="torrentsFilterRegexBox">
-                    <label for="torrentsFilterRegexBox" aria-label="QBT_TR(Use regular expressions)QBT_TR[CONTEXT=MainWindow]"></label>
+                    <label for="torrentsFilterRegexBox" aria-label="QBT_TR(Use regular expression)QBT_TR[CONTEXT=MainWindow]" title="QBT_TR(Use regular expression)QBT_TR[CONTEXT=MainWindow]"></label>
                     <label for="torrentsFilterSelect">QBT_TR(Filter by:)QBT_TR[CONTEXT=MainWindow]</label>
                     <select id="torrentsFilterSelect">
                         <option value="name" selected>QBT_TR(Name)QBT_TR[CONTEXT=MainWindow]</option>


### PR DESCRIPTION
Add a tooltip to indicate the button's function. 
And change the cursor to a pointer since label is used as a button.
