### PR TITLE
qbittorrent systemd unit file should require mounts

### DIFF
--- a/dist/unix/systemd/qbittorrent-nox@.service.in
+++ b/dist/unix/systemd/qbittorrent-nox@.service.in
@@ -2,7 +2,8 @@
 Description=qBittorrent-nox service for user %I
 Documentation=man:qbittorrent-nox(1)
 Wants=network-online.target
-After=local-fs.target network-online.target nss-lookup.target
+After=network-online.target nss-lookup.target
+Requires=local-fs.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
`After` means start qbittorrent after systemd starting to mount disk.

`Requires` means start qbittorretn after disks are ready.

QB require path exists on startup, so it should be `Requires`, not `After`