### PR TITLE
WebUI: Hide context menu when clicking on a table row

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -838,7 +838,6 @@ window.qBittorrent.DynamicTable ??= (() => {
                     });
                     tr.addEventListener("click", function(e) {
                         e.preventDefault();
-                        e.stopPropagation();
 
                         if (e.ctrlKey || e.metaKey) {
                             // CTRL/CMD ⌘ key was pressed


### PR DESCRIPTION
This fixes a bug where the torrents table header menu 
could not be closed by clicking on a table row.
This also fixes the same bug for other context menus.

