### PR TITLE
Use proper macro for unreachable switch cases

### DIFF
--- a/src/base/bittorrent/bandwidthscheduler.cpp
+++ b/src/base/bittorrent/bandwidthscheduler.cpp
@@ -102,7 +102,7 @@ bool BandwidthScheduler::isTimeForAlternative() const
                 alternative = !alternative;
             break;
         default:
-            Q_ASSERT(false);
+            Q_UNREACHABLE();
             break;
         }
     }

--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -296,14 +296,15 @@ namespace
     {
         switch (mode)
         {
-        default:
-            Q_ASSERT(false);
         case MoveStorageMode::FailIfExist:
             return lt::move_flags_t::fail_if_exist;
         case MoveStorageMode::KeepExistingFiles:
             return lt::move_flags_t::dont_replace;
         case MoveStorageMode::Overwrite:
             return lt::move_flags_t::always_replace_files;
+        default:
+            Q_UNREACHABLE();
+            break;
         }
     }
 }

--- a/src/base/http/connection.cpp
+++ b/src/base/http/connection.cpp
@@ -160,7 +160,7 @@ void Connection::read()
             break;
 
         default:
-            Q_ASSERT(false);
+            Q_UNREACHABLE();
             return;
         }
     }

--- a/src/base/net/dnsupdater.cpp
+++ b/src/base/net/dnsupdater.cpp
@@ -153,7 +153,7 @@ QString DNSUpdater::getUpdateUrl() const
         break;
     default:
         qWarning() << "Unrecognized Dynamic DNS service!";
-        Q_ASSERT(false);
+        Q_UNREACHABLE();
         break;
     }
     url.setPath(u"/nic/update"_s);
@@ -305,7 +305,7 @@ QUrl DNSUpdater::getRegistrationUrl(const DNS::Service service)
     case DNS::Service::NoIP:
         return {u"https://www.noip.com/remote-access"_s};
     default:
-        Q_ASSERT(false);
+        Q_UNREACHABLE();
         break;
     }
     return {};

--- a/src/base/torrentfilter.cpp
+++ b/src/base/torrentfilter.cpp
@@ -205,9 +205,11 @@ bool TorrentFilter::matchState(const BitTorrent::Torrent *const torrent) const
     case Errored:
         return torrent->isErrored();
     default:
-        Q_ASSERT(false);
-        return false;
+        Q_UNREACHABLE();
+        break;
     }
+
+    return false;
 }
 
 bool TorrentFilter::matchHash(const BitTorrent::Torrent *const torrent) const

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -410,7 +410,7 @@ void AdvancedSettings::updateInterfaceAddressCombo()
         case QAbstractSocket::IPv6Protocol:
             return Utils::Net::canonicalIPv6Addr(address).toString();
         default:
-            Q_ASSERT(false);
+            Q_UNREACHABLE();
             break;
         }
         return {};

--- a/src/gui/torrentcontentmodelitem.cpp
+++ b/src/gui/torrentcontentmodelitem.cpp
@@ -140,9 +140,11 @@ QString TorrentContentModelItem::displayData(const int column) const
             return (value + u'%');
         }
     default:
-        Q_ASSERT(false);
-        return {};
+        Q_UNREACHABLE();
+        break;
     }
+
+    return {};
 }
 
 QVariant TorrentContentModelItem::underlyingData(const int column) const
@@ -165,9 +167,11 @@ QVariant TorrentContentModelItem::underlyingData(const int column) const
     case COL_AVAILABILITY:
         return availability();
     default:
-        Q_ASSERT(false);
-        return {};
+        Q_UNREACHABLE();
+        break;
     }
+
+    return {};
 }
 
 int TorrentContentModelItem::row() const

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -775,7 +775,9 @@ QIcon TransferListModel::getIconByState(const BitTorrent::TorrentState state) co
     case BitTorrent::TorrentState::Error:
         return m_errorIcon;
     default:
-        Q_ASSERT(false);
-        return m_errorIcon;
+        Q_UNREACHABLE();
+        break;
     }
+
+    return {};
 }

--- a/src/webui/api/synccontroller.cpp
+++ b/src/webui/api/synccontroller.cpp
@@ -288,7 +288,7 @@ namespace
                     }
                     break;
                 default:
-                    Q_ASSERT(false);
+                    Q_UNREACHABLE();
                     break;
                 }
             }

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -396,7 +396,8 @@ void WebApplication::doProcessRequest()
         case APIErrorType::NotFound:
             throw NotFoundHTTPError(error.message());
         default:
-            Q_ASSERT(false);
+            Q_UNREACHABLE();
+            break;
         }
     }
 }


### PR DESCRIPTION
Those are the `default` cases which are not expected to hit (nor reachable) normally.

When the code is compiled with release mode and it reaches `Q_UNREACHABLE()`, it becomes undefined behavior. So it rely on the developers to catch the errors in debug mode. The upside of this is that the `switch` statement will be more optimized than not using it. This also means the statements after `Q_UNREACHABLE()` isn't important. It allow anything to preserve the intention of the code.

This marco is preferred over C++23 `std::unreachable` because it will automatically insert a `Q_ASSERT(false)` with it.

<!--
MANDATORY Before submitting your work, make sure you have:
1. Read https://github.com/qbittorrent/qBittorrent/blob/master/CONTRIBUTING.md#opening-a-pull-request
2. Delete this comment block
-->
