### PR TITLE
WebUI: Use thin scrollbars

### DIFF
--- a/src/webui/www/private/css/style.css
+++ b/src/webui/www/private/css/style.css
@@ -75,6 +75,18 @@ ol {
     list-style: none;
 }
 
+/* Scrollbars */
+
+@supports (scrollbar-width: auto) {
+    :root[slick-uniqueid], /* targets iframe mocha dialogs */
+    .panel,
+    .mochaContentWrapper,
+    .dynamicTableDiv,
+    #rssDetailsView {
+        scrollbar-width: thin;
+    }
+}
+
 /* Forms */
 
 input[type="text"],

--- a/src/webui/www/private/css/style.css
+++ b/src/webui/www/private/css/style.css
@@ -79,9 +79,9 @@ ol {
 
 @supports (scrollbar-width: auto) {
     :root[slick-uniqueid], /* targets iframe mocha dialogs */
-    .panel,
-    .mochaContentWrapper,
     .dynamicTableDiv,
+    .mochaContentWrapper,
+    .panel,
     #rssDetailsView {
         scrollbar-width: thin;
     }

--- a/src/webui/www/private/css/style.css
+++ b/src/webui/www/private/css/style.css
@@ -77,7 +77,7 @@ ol {
 
 /* Scrollbars */
 
-@supports (scrollbar-width: auto) {
+@supports (scrollbar-width: auto) and (selector(::-webkit-scrollbar)) {
     :root[slick-uniqueid], /* targets iframe mocha dialogs */
     .dynamicTableDiv,
     .mochaContentWrapper,


### PR DESCRIPTION
Thin scrollbars are now used if they are supported by user's browser. The main goal was to make them less intrusive in Chrome-likes on some platforms.

a) Before:

![before](https://github.com/user-attachments/assets/89077e6f-669c-4d44-82da-20e979b568af)

b) After:

![after](https://github.com/user-attachments/assets/01a82952-c387-4623-a04c-c821de19c35c)
