### PR TITLE
Optimize conversion of time points from libtorrent to Qt clocks

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -5488,6 +5488,11 @@ void SessionImpl::setTorrentContentLayout(const TorrentContentLayout value)
 // Read alerts sent by libtorrent session
 void SessionImpl::readAlerts()
 {
+    // cache current datetime of Qt and libtorrent clocks in order
+    // to optimize conversion of time points from lt to Qt clocks
+    m_ltNow = lt::clock_type::now();
+    m_qNow = QDateTime::currentDateTime();
+
     const std::vector<lt::alert *> alerts = getPendingAlerts();
 
     Q_ASSERT(m_loadedTorrents.isEmpty());
@@ -6356,4 +6361,10 @@ void SessionImpl::handleRemovedTorrent(const TorrentID &torrentID, const QString
     }
 
     m_removingTorrents.erase(removingTorrentDataIter);
+}
+
+QDateTime SessionImpl::fromLTTimePoint32(const libtorrent::time_point32 &timePoint) const
+{
+    const auto secsSinceNow = lt::duration_cast<lt::seconds>(timePoint - m_ltNow + lt::milliseconds(500)).count();
+    return m_qNow.addSecs(secsSinceNow);
 }

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -476,6 +476,8 @@ namespace BitTorrent
         void addMappedPorts(const QSet<quint16> &ports);
         void removeMappedPorts(const QSet<quint16> &ports);
 
+        QDateTime fromLTTimePoint32(const lt::time_point32 &timePoint) const;
+
         template <typename Func>
         void invoke(Func &&func)
         {
@@ -825,6 +827,9 @@ namespace BitTorrent
         QDateTime m_wakeupCheckTimestamp;
 
         QList<TorrentImpl *> m_pendingFinishedTorrents;
+
+        QDateTime m_qNow;
+        lt::clock_type::time_point m_ltNow;
 
         friend void Session::initInstance();
         friend void Session::freeInstance();

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -92,22 +92,15 @@ namespace
         return entry;
     }
 
-    QDateTime fromLTTimePoint32(const lt::time_point32 &timePoint)
-    {
-        const auto ltNow = lt::clock_type::now();
-        const auto qNow = QDateTime::currentDateTime();
-        const auto secsSinceNow = lt::duration_cast<lt::seconds>(timePoint - ltNow + lt::milliseconds(500)).count();
-
-        return qNow.addSecs(secsSinceNow);
-    }
-
     QString toString(const lt::tcp::endpoint &ltTCPEndpoint)
     {
         return QString::fromStdString((std::stringstream() << ltTCPEndpoint).str());
     }
 
+    template <typename FromLTTimePoint32Func>
     void updateTrackerEntryStatus(TrackerEntryStatus &trackerEntryStatus, const lt::announce_entry &nativeEntry
-            , const QSet<int> &btProtocols, const QHash<lt::tcp::endpoint, QMap<int, int>> &updateInfo)
+            , const QSet<int> &btProtocols, const QHash<lt::tcp::endpoint, QMap<int, int>> &updateInfo
+            , FromLTTimePoint32Func fromLTTimePoint32)
     {
         Q_ASSERT(trackerEntryStatus.url == QString::fromStdString(nativeEntry.url));
 
@@ -1769,7 +1762,13 @@ TrackerEntryStatus TorrentImpl::updateTrackerEntryStatus(const lt::announce_entr
 #else
     const QSet<int> btProtocols {1};
 #endif
-    ::updateTrackerEntryStatus(*it, announceEntry, btProtocols, updateInfo);
+
+    const auto fromLTTimePoint32 = [this](const lt::time_point32 &timePoint)
+    {
+        return m_session->fromLTTimePoint32(timePoint);
+    };
+    ::updateTrackerEntryStatus(*it, announceEntry, btProtocols, updateInfo, fromLTTimePoint32);
+
     return *it;
 }
 

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -100,7 +100,7 @@ namespace
     template <typename FromLTTimePoint32Func>
     void updateTrackerEntryStatus(TrackerEntryStatus &trackerEntryStatus, const lt::announce_entry &nativeEntry
             , const QSet<int> &btProtocols, const QHash<lt::tcp::endpoint, QMap<int, int>> &updateInfo
-            , FromLTTimePoint32Func fromLTTimePoint32)
+            , const FromLTTimePoint32Func &fromLTTimePoint32)
     {
         Q_ASSERT(trackerEntryStatus.url == QString::fromStdString(nativeEntry.url));
 


### PR DESCRIPTION
Obtain current date time of Qt and libtorrent clocks only once for processing entire current libtorrent alerts bunch.
