### PR TITLE
Optimize converting TCP endpoints to strings

### DIFF
--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -49,6 +49,7 @@
 
 #include <QtSystemDetection>
 #include <QByteArray>
+#include <QCache>
 #include <QDebug>
 #include <QPointer>
 #include <QSet>
@@ -103,7 +104,15 @@ namespace
 
     QString toString(const lt::tcp::endpoint &ltTCPEndpoint)
     {
-        return QString::fromStdString((std::stringstream() << ltTCPEndpoint).str());
+        static QCache<lt::tcp::endpoint, QString> cache;
+
+        if (const QString *endpointName = cache.object(ltTCPEndpoint))
+            return *endpointName;
+
+        const std::string tmp = (std::ostringstream() << ltTCPEndpoint).str();
+        const auto endpointName = QString::fromLatin1(tmp.c_str(), tmp.size());
+        cache.insert(ltTCPEndpoint, new QString(endpointName));
+        return endpointName;
     }
 
     void updateTrackerEntryStatus(TrackerEntryStatus &trackerEntryStatus, const lt::announce_entry &nativeEntry


### PR DESCRIPTION
There may be quite a few endpoint names (one for each available network card), and they usually remain unchanged throughout the session, while previously producing such names was performed every time they were accessed. Now they are retrieved from the cache.