### PR TITLE
Check real palette darkness to detect "dark theme"

### DIFF
--- a/src/gui/uithememanager.cpp
+++ b/src/gui/uithememanager.cpp
@@ -47,16 +47,9 @@ namespace
 {
     bool isDarkTheme()
     {
-        switch (qApp->styleHints()->colorScheme())
-        {
-        case Qt::ColorScheme::Dark:
-            return true;
-        case Qt::ColorScheme::Light:
-            return false;
-        default:
-            // fallback to custom method
-            return (qApp->palette().color(QPalette::Active, QPalette::Base).lightness() < 127);
-        }
+        const QPalette palette = qApp->palette();
+        const QColor &color = palette.color(QPalette::Active, QPalette::Base);
+        return (color.lightness() < 127);
     }
 }
 


### PR DESCRIPTION
`QStyleHints::colorScheme()` returns chosen color scheme even if current style doesn't support it and uses different palette.

Ref.: https://github.com/qbittorrent/qBittorrent/issues/21421#issuecomment-2453437663.
