### PR TITLE
WebUI: Use modern class syntax to create LocalPreferences class

### DIFF
--- a/src/webui/www/private/scripts/localpreferences.js
+++ b/src/webui/www/private/scripts/localpreferences.js
@@ -32,11 +32,11 @@ window.qBittorrent ??= {};
 window.qBittorrent.LocalPreferences ??= (() => {
     const exports = () => {
         return {
-            LocalPreferencesClass: LocalPreferencesClass
+            LocalPreferences: LocalPreferences
         };
     };
 
-    class LocalPreferencesClass {
+    class LocalPreferences {
         get(key, defaultValue) {
             const value = localStorage.getItem(key);
             return ((value === null) && (defaultValue !== undefined))

--- a/src/webui/www/private/scripts/localpreferences.js
+++ b/src/webui/www/private/scripts/localpreferences.js
@@ -36,24 +36,24 @@ window.qBittorrent.LocalPreferences ??= (() => {
         };
     };
 
-    const LocalPreferencesClass = new Class({
-        get: (key, defaultValue) => {
+    class LocalPreferencesClass {
+        get(key, defaultValue) {
             const value = localStorage.getItem(key);
             return ((value === null) && (defaultValue !== undefined))
                 ? defaultValue
                 : value;
-        },
+        }
 
-        set: (key, value) => {
+        set(key, value) {
             try {
                 localStorage.setItem(key, value);
             }
             catch (err) {
                 console.error(err);
             }
-        },
+        }
 
-        remove: (key) => {
+        remove(key) {
             try {
                 localStorage.removeItem(key);
             }
@@ -61,7 +61,7 @@ window.qBittorrent.LocalPreferences ??= (() => {
                 console.error(err);
             }
         }
-    });
+    };
 
     return exports();
 })();

--- a/src/webui/www/private/scripts/mocha-init.js
+++ b/src/webui/www/private/scripts/mocha-init.js
@@ -99,7 +99,7 @@ window.qBittorrent.Dialog ??= (() => {
 })();
 Object.freeze(window.qBittorrent.Dialog);
 
-const LocalPreferences = new window.qBittorrent.LocalPreferences.LocalPreferencesClass();
+const LocalPreferences = new window.qBittorrent.LocalPreferences.LocalPreferences();
 
 let saveWindowSize = () => {};
 let loadWindowWidth = () => {};


### PR DESCRIPTION
LocalPreferences class is now created using modern class syntax (minimal changes to remove Mootools bits). In addition, I removed redundant suffix from class name.