### PR TITLE
Don't ignore SSL errors (v4_6_x)

### DIFF
--- a/src/base/net/downloadmanager.cpp
+++ b/src/base/net/downloadmanager.cpp
@@ -124,10 +124,20 @@ Net::DownloadManager::DownloadManager(QObject *parent)
         QStringList errorList;
         for (const QSslError &error : errors)
             errorList += error.errorString();
-        LogMsg(tr("Ignoring SSL error, URL: \"%1\", errors: \"%2\"").arg(reply->url().toString(), errorList.join(u". ")), Log::WARNING);
 
-        // Ignore all SSL errors
-        reply->ignoreSslErrors();
+        QString errorMsg;
+        if (!Preferences::instance()->isIgnoreSSLErrors())
+        {
+            errorMsg = tr("SSL error, URL: \"%1\", errors: \"%2\"");
+        }
+        else
+        {
+            errorMsg = tr("Ignoring SSL error, URL: \"%1\", errors: \"%2\"");
+            // Ignore all SSL errors
+            reply->ignoreSslErrors();
+        }
+
+        LogMsg(errorMsg.arg(reply->url().toString(), errorList.join(u". ")), Log::WARNING);
     });
 
     connect(ProxyConfigurationManager::instance(), &ProxyConfigurationManager::proxyConfigurationChanged

--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -1331,6 +1331,19 @@ void Preferences::setTrackerPortForwardingEnabled(const bool enabled)
     setValue(u"Preferences/Advanced/trackerPortForwarding"_s, enabled);
 }
 
+bool Preferences::isIgnoreSSLErrors() const
+{
+    return value(u"Preferences/Advanced/IgnoreSSLErrors"_s, false);
+}
+
+void Preferences::setIgnoreSSLErrors(const bool enabled)
+{
+    if (enabled == isIgnoreSSLErrors())
+        return;
+
+    setValue(u"Preferences/Advanced/IgnoreSSLErrors"_s, enabled);
+}
+
 #if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
 bool Preferences::isUpdateCheckEnabled() const
 {

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -296,6 +296,8 @@ public:
     void setTrackerPort(int port);
     bool isTrackerPortForwardingEnabled() const;
     void setTrackerPortForwardingEnabled(bool enabled);
+    bool isIgnoreSSLErrors() const;
+    void setIgnoreSSLErrors(bool enabled);
 #if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
     bool isUpdateCheckEnabled() const;
     void setUpdateCheckEnabled(bool enabled);

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -100,6 +100,7 @@ namespace
         TRACKER_STATUS,
         TRACKER_PORT,
         TRACKER_PORT_FORWARDING,
+        IGNORE_SSL_ERRORS,
         // libtorrent section
         LIBTORRENT_HEADER,
         BDECODE_DEPTH_LIMIT,
@@ -319,6 +320,8 @@ void AdvancedSettings::saveAdvancedSettings() const
     pref->setTrackerPortForwardingEnabled(m_checkBoxTrackerPortForwarding.isChecked());
     session->setTrackerEnabled(m_checkBoxTrackerStatus.isChecked());
 
+    // Ignore SSL errors
+    pref->setIgnoreSSLErrors(m_checkBoxIgnoreSSLErrors.isChecked());
     // Choking algorithm
     session->setChokingAlgorithm(m_comboBoxChokingAlgorithm.currentData().value<BitTorrent::ChokingAlgorithm>());
     // Seed choking algorithm
@@ -813,6 +816,10 @@ void AdvancedSettings::loadAdvancedSettings()
     // Tracker port forwarding
     m_checkBoxTrackerPortForwarding.setChecked(pref->isTrackerPortForwardingEnabled());
     addRow(TRACKER_PORT_FORWARDING, tr("Enable port forwarding for embedded tracker"), &m_checkBoxTrackerPortForwarding);
+    // Ignore SSL errors
+    m_checkBoxIgnoreSSLErrors.setChecked(pref->isIgnoreSSLErrors());
+    m_checkBoxIgnoreSSLErrors.setToolTip(tr("Affects certificate validation and non-torrent protocol activities (e.g. RSS feeds, program updates, torrent files, geoip db, etc)"));
+    addRow(IGNORE_SSL_ERRORS, tr("Ignore SSL errors"), &m_checkBoxIgnoreSSLErrors);
     // Choking algorithm
     m_comboBoxChokingAlgorithm.addItem(tr("Fixed slots"), QVariant::fromValue(BitTorrent::ChokingAlgorithm::FixedSlots));
     m_comboBoxChokingAlgorithm.addItem(tr("Upload rate based"), QVariant::fromValue(BitTorrent::ChokingAlgorithm::RateBased));

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -77,9 +77,9 @@ private:
              m_spinBoxSavePathHistoryLength, m_spinBoxPeerTurnover, m_spinBoxPeerTurnoverCutoff, m_spinBoxPeerTurnoverInterval, m_spinBoxRequestQueueSize;
     QCheckBox m_checkBoxOsCache, m_checkBoxRecheckCompleted, m_checkBoxResolveCountries, m_checkBoxResolveHosts,
               m_checkBoxProgramNotifications, m_checkBoxTorrentAddedNotifications, m_checkBoxReannounceWhenAddressChanged, m_checkBoxTrackerFavicon, m_checkBoxTrackerStatus,
-              m_checkBoxTrackerPortForwarding, m_checkBoxConfirmTorrentRecheck, m_checkBoxConfirmRemoveAllTags, m_checkBoxAnnounceAllTrackers, m_checkBoxAnnounceAllTiers,
-              m_checkBoxMultiConnectionsPerIp, m_checkBoxValidateHTTPSTrackerCertificate, m_checkBoxSSRFMitigation, m_checkBoxBlockPeersOnPrivilegedPorts, m_checkBoxPieceExtentAffinity,
-              m_checkBoxSuggestMode, m_checkBoxSpeedWidgetEnabled, m_checkBoxIDNSupport;
+              m_checkBoxTrackerPortForwarding, m_checkBoxIgnoreSSLErrors, m_checkBoxConfirmTorrentRecheck, m_checkBoxConfirmRemoveAllTags, m_checkBoxAnnounceAllTrackers,
+              m_checkBoxAnnounceAllTiers, m_checkBoxMultiConnectionsPerIp, m_checkBoxValidateHTTPSTrackerCertificate, m_checkBoxSSRFMitigation, m_checkBoxBlockPeersOnPrivilegedPorts,
+              m_checkBoxPieceExtentAffinity, m_checkBoxSuggestMode, m_checkBoxSpeedWidgetEnabled, m_checkBoxIDNSupport;
     QComboBox m_comboBoxInterface, m_comboBoxInterfaceAddress, m_comboBoxDiskIOReadMode, m_comboBoxDiskIOWriteMode, m_comboBoxUtpMixedMode, m_comboBoxChokingAlgorithm,
               m_comboBoxSeedChokingAlgorithm, m_comboBoxResumeDataStorage;
     QLineEdit m_lineEditAnnounceIP;

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -348,6 +348,8 @@ void AppController::preferencesAction()
     data[u"resolve_peer_countries"_s] = pref->resolvePeerCountries();
     // Reannounce to all trackers when ip/port changed
     data[u"reannounce_when_address_changed"_s] = session->isReannounceWhenAddressChangedEnabled();
+    // Ignore SSL errors
+    data[u"ignore_ssl_errors"_s] = pref->isIgnoreSSLErrors();
 
     // libtorrent preferences
     // Bdecode depth limit
@@ -915,6 +917,9 @@ void AppController::setPreferencesAction()
     // Reannounce to all trackers when ip/port changed
     if (hasKey(u"reannounce_when_address_changed"_s))
         session->setReannounceWhenAddressChangedEnabled(it.value().toBool());
+    // Ignore SLL errors
+    if (hasKey(u"ignore_ssl_errors"_s))
+        pref->setIgnoreSSLErrors(it.value().toBool());
 
     // libtorrent preferences
     // Bdecode depth limit

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -348,6 +348,10 @@ void AppController::preferencesAction()
     data[u"resolve_peer_countries"_s] = pref->resolvePeerCountries();
     // Reannounce to all trackers when ip/port changed
     data[u"reannounce_when_address_changed"_s] = session->isReannounceWhenAddressChangedEnabled();
+    // Embedded tracker
+    data[u"enable_embedded_tracker"_s] = session->isTrackerEnabled();
+    data[u"embedded_tracker_port"_s] = pref->getTrackerPort();
+    data[u"embedded_tracker_port_forwarding"_s] = pref->isTrackerPortForwardingEnabled();
     // Ignore SSL errors
     data[u"ignore_ssl_errors"_s] = pref->isIgnoreSSLErrors();
 
@@ -412,10 +416,6 @@ void AppController::preferencesAction()
     data[u"ssrf_mitigation"_s] = session->isSSRFMitigationEnabled();
     // Disallow connection to peers on privileged ports
     data[u"block_peers_on_privileged_ports"_s] = session->blockPeersOnPrivilegedPorts();
-    // Embedded tracker
-    data[u"enable_embedded_tracker"_s] = session->isTrackerEnabled();
-    data[u"embedded_tracker_port"_s] = pref->getTrackerPort();
-    data[u"embedded_tracker_port_forwarding"_s] = pref->isTrackerPortForwardingEnabled();
     // Choking algorithm
     data[u"upload_slots_behavior"_s] = static_cast<int>(session->chokingAlgorithm());
     // Seed choking algorithm
@@ -917,6 +917,13 @@ void AppController::setPreferencesAction()
     // Reannounce to all trackers when ip/port changed
     if (hasKey(u"reannounce_when_address_changed"_s))
         session->setReannounceWhenAddressChangedEnabled(it.value().toBool());
+    // Embedded tracker
+    if (hasKey(u"embedded_tracker_port"_s))
+        pref->setTrackerPort(it.value().toInt());
+    if (hasKey(u"embedded_tracker_port_forwarding"_s))
+        pref->setTrackerPortForwardingEnabled(it.value().toBool());
+    if (hasKey(u"enable_embedded_tracker"_s))
+        session->setTrackerEnabled(it.value().toBool());
     // Ignore SLL errors
     if (hasKey(u"ignore_ssl_errors"_s))
         pref->setIgnoreSSLErrors(it.value().toBool());
@@ -1014,13 +1021,6 @@ void AppController::setPreferencesAction()
     // Disallow connection to peers on privileged ports
     if (hasKey(u"block_peers_on_privileged_ports"_s))
         session->setBlockPeersOnPrivilegedPorts(it.value().toBool());
-    // Embedded tracker
-    if (hasKey(u"embedded_tracker_port"_s))
-        pref->setTrackerPort(it.value().toInt());
-    if (hasKey(u"embedded_tracker_port_forwarding"_s))
-        pref->setTrackerPortForwardingEnabled(it.value().toBool());
-    if (hasKey(u"enable_embedded_tracker"_s))
-        session->setTrackerEnabled(it.value().toBool());
     // Choking algorithm
     if (hasKey(u"upload_slots_behavior"_s))
         session->setChokingAlgorithm(static_cast<BitTorrent::ChokingAlgorithm>(it.value().toInt()));

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -2276,6 +2276,9 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                         $('refreshInterval').setProperty('value', pref.refresh_interval);
                         $('resolvePeerCountries').setProperty('checked', pref.resolve_peer_countries);
                         $('reannounceWhenAddressChanged').setProperty('checked', pref.reannounce_when_address_changed);
+                        $('enableEmbeddedTracker').setProperty('checked', pref.enable_embedded_tracker);
+                        $('embeddedTrackerPort').setProperty('value', pref.embedded_tracker_port);
+                        $('embeddedTrackerPortForwarding').setProperty('checked', pref.embedded_tracker_port_forwarding);
                         $('ignoreSSLErrors').setProperty('checked', pref.ignore_ssl_errors);
                         // libtorrent section
                         $('bdecodeDepthLimit').setProperty('value', pref.bdecode_depth_limit);
@@ -2310,9 +2313,6 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                         $('validateHTTPSTrackerCertificate').setProperty('checked', pref.validate_https_tracker_certificate);
                         $('mitigateSSRF').setProperty('checked', pref.ssrf_mitigation);
                         $('blockPeersOnPrivilegedPorts').setProperty('checked', pref.block_peers_on_privileged_ports);
-                        $('enableEmbeddedTracker').setProperty('checked', pref.enable_embedded_tracker);
-                        $('embeddedTrackerPort').setProperty('value', pref.embedded_tracker_port);
-                        $('embeddedTrackerPortForwarding').setProperty('checked', pref.embedded_tracker_port_forwarding);
                         $('uploadSlotsBehavior').setProperty('value', pref.upload_slots_behavior);
                         $('uploadChokingAlgorithm').setProperty('value', pref.upload_choking_algorithm);
                         $('announceAllTrackers').setProperty('checked', pref.announce_to_all_trackers);
@@ -2718,6 +2718,9 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             settings.set('refresh_interval', $('refreshInterval').getProperty('value'));
             settings.set('resolve_peer_countries', $('resolvePeerCountries').getProperty('checked'));
             settings.set('reannounce_when_address_changed', $('reannounceWhenAddressChanged').getProperty('checked'));
+            settings.set('enable_embedded_tracker', $('enableEmbeddedTracker').getProperty('checked'));
+            settings.set('embedded_tracker_port', $('embeddedTrackerPort').getProperty('value'));
+            settings.set('embedded_tracker_port_forwarding', $('embeddedTrackerPortForwarding').getProperty('checked'));
             settings.set('ignore_ssl_errors', $('ignoreSSLErrors').getProperty('checked'));
 
             // libtorrent section
@@ -2753,9 +2756,6 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             settings.set('validate_https_tracker_certificate', $('validateHTTPSTrackerCertificate').getProperty('checked'));
             settings.set('ssrf_mitigation', $('mitigateSSRF').getProperty('checked'));
             settings.set('block_peers_on_privileged_ports', $('blockPeersOnPrivilegedPorts').getProperty('checked'));
-            settings.set('enable_embedded_tracker', $('enableEmbeddedTracker').getProperty('checked'));
-            settings.set('embedded_tracker_port', $('embeddedTrackerPort').getProperty('value'));
-            settings.set('embedded_tracker_port_forwarding', $('embeddedTrackerPortForwarding').getProperty('checked'));
             settings.set('upload_slots_behavior', $('uploadSlotsBehavior').getProperty('value'));
             settings.set('upload_choking_algorithm', $('uploadChokingAlgorithm').getProperty('value'));
             settings.set('announce_to_all_trackers', $('announceAllTrackers').getProperty('checked'));

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -1077,6 +1077,14 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     <input type="checkbox" id="embeddedTrackerPortForwarding" />
                 </td>
             </tr>
+            <tr>
+                <td>
+                    <label for="ignoreSSLErrors">QBT_TR(Ignore SSL errors:)QBT_TR[CONTEXT=OptionsDialog]</label>
+                </td>
+                <td>
+                    <input type="checkbox" id="ignoreSSLErrors">
+                </td>
+            </tr>
         </table>
     </fieldset>
     <fieldset class="settings">
@@ -2268,6 +2276,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                         $('refreshInterval').setProperty('value', pref.refresh_interval);
                         $('resolvePeerCountries').setProperty('checked', pref.resolve_peer_countries);
                         $('reannounceWhenAddressChanged').setProperty('checked', pref.reannounce_when_address_changed);
+                        $('ignoreSSLErrors').setProperty('checked', pref.ignore_ssl_errors);
                         // libtorrent section
                         $('bdecodeDepthLimit').setProperty('value', pref.bdecode_depth_limit);
                         $('bdecodeTokenLimit').setProperty('value', pref.bdecode_token_limit);
@@ -2709,6 +2718,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             settings.set('refresh_interval', $('refreshInterval').getProperty('value'));
             settings.set('resolve_peer_countries', $('resolvePeerCountries').getProperty('checked'));
             settings.set('reannounce_when_address_changed', $('reannounceWhenAddressChanged').getProperty('checked'));
+            settings.set('ignore_ssl_errors', $('ignoreSSLErrors').getProperty('checked'));
 
             // libtorrent section
             settings.set('bdecode_depth_limit', $('bdecodeDepthLimit').getProperty('value'));


### PR DESCRIPTION
Backport of #21364

Closes #21781

The PPA autobuilds the `v4_6_x` branch for the older Ubuntu versions. So this will be available automatically after the PR is merged.

Because it involves a security fix I think we should backport it to v4_6_x.