### PR TITLE
WebUI: fix preferences class name

### DIFF
--- a/src/webui/www/private/scripts/color-scheme.js
+++ b/src/webui/www/private/scripts/color-scheme.js
@@ -36,7 +36,7 @@ window.qBittorrent.ColorScheme ??= (() => {
         };
     };
 
-    const LocalPreferences = new window.qBittorrent.LocalPreferences.LocalPreferencesClass();
+    const LocalPreferences = new window.qBittorrent.LocalPreferences.LocalPreferences();
     const colorSchemeQuery = window.matchMedia("(prefers-color-scheme: dark)");
 
     const update = () => {


### PR DESCRIPTION
Fixup for #21780. Account for changed preferences class name in the color scheme logic.