### PR TITLE
WebUI: Fix wrong log levels

### DIFF
--- a/src/webui/www/private/views/log.html
+++ b/src/webui/www/private/views/log.html
@@ -188,12 +188,8 @@
         let selectedLogLevels = JSON.parse(LocalPreferences.get("qbt_selected_log_levels")) || ["1", "2", "4", "8"];
 
         const init = () => {
-            $("logLevelSelect").getElements("option").each((x) => {
-                if (selectedLogLevels.indexOf(x.value.toString()) !== -1)
-                    x.selected = true;
-                else
-                    x.selected = false;
-            });
+            for (const option of $("logLevelSelect").options)
+                option.setAttribute("selected", selectedLogLevels.includes(option.value));
 
             selectBox = new vanillaSelectBox("#logLevelSelect", {
                 maxHeight: 200,


### PR DESCRIPTION
Fixes bug where the first time visiting _Execution Log_ view all log levels are deselected but log items with all levels are still displayed.
This requires you to select a log level and then deselect it to hide that log level.


https://github.com/user-attachments/assets/d817e28c-9d86-4017-8ee8-4962918e5579

