### PR TITLE
Remove wrong dependency on Main Window

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -728,6 +728,16 @@ void MainWindow::displaySearchTab(bool enable)
         if (!m_searchWidget)
         {
             m_searchWidget = new SearchWidget(app(), this);
+            connect(m_searchWidget, &SearchWidget::activeSearchFinished, this, [this](const bool failed)
+            {
+                if (app()->desktopIntegration()->isNotificationsEnabled() && (currentTabWidget() != m_searchWidget))
+                {
+                    if (failed)
+                        app()->desktopIntegration()->showNotification(tr("Search Engine"), tr("Search has failed"));
+                    else
+                        app()->desktopIntegration()->showNotification(tr("Search Engine"), tr("Search has finished"));
+                }
+            });
             m_tabs->insertTab(1, m_searchWidget,
 #ifndef Q_OS_MACOS
                 UIThemeManager::instance()->getIcon(u"edit-find"_s),

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -54,7 +54,6 @@
 #include "base/utils/foreignapps.h"
 #include "gui/desktopintegration.h"
 #include "gui/interfaces/iguiapplication.h"
-#include "gui/mainwindow.h"
 #include "gui/uithememanager.h"
 #include "pluginselectdialog.h"
 #include "searchjobwidget.h"
@@ -373,13 +372,7 @@ void SearchWidget::tabStatusChanged(QWidget *tab)
     {
         Q_ASSERT(m_activeSearchTab->status() != SearchJobWidget::Status::Ongoing);
 
-        if (app()->desktopIntegration()->isNotificationsEnabled() && (app()->mainWindow()->currentTabWidget() != this))
-        {
-            if (m_activeSearchTab->status() == SearchJobWidget::Status::Error)
-                app()->desktopIntegration()->showNotification(tr("Search Engine"), tr("Search has failed"));
-            else
-                app()->desktopIntegration()->showNotification(tr("Search Engine"), tr("Search has finished"));
-        }
+        emit activeSearchFinished(m_activeSearchTab->status() == SearchJobWidget::Status::Error);
 
         m_activeSearchTab = nullptr;
         m_ui->searchButton->setText(tr("Search"));

--- a/src/gui/search/searchwidget.h
+++ b/src/gui/search/searchwidget.h
@@ -56,6 +56,9 @@ public:
 
     void giveFocusToSearchInput();
 
+signals:
+    void activeSearchFinished(bool failed);
+
 private slots:
     void on_searchButton_clicked();
     void on_pluginsButton_clicked();


### PR DESCRIPTION
Don't depend on upper level widget (Main Window) state.