### PR TITLE
Support fetching tracker list from URL

### DIFF
--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -237,6 +237,12 @@ namespace BitTorrent
         virtual Path finishedTorrentExportDirectory() const = 0;
         virtual void setFinishedTorrentExportDirectory(const Path &path) = 0;
 
+        virtual bool isAddTrackersFromURLEnabled() const = 0;
+        virtual void setAddTrackersFromURLEnabled(bool enabled) = 0;
+        virtual QString additionalTrackersURL() const = 0;
+        virtual void setAdditionalTrackersURL(const QString &url) = 0;
+        virtual QString additionalTrackersFromURL() const = 0;
+
         virtual int globalDownloadSpeedLimit() const = 0;
         virtual void setGlobalDownloadSpeedLimit(int limit) = 0;
         virtual int globalUploadSpeedLimit() const = 0;

--- a/src/base/bittorrent/sessionimpl.h
+++ b/src/base/bittorrent/sessionimpl.h
@@ -490,6 +490,12 @@ namespace BitTorrent
             m_asyncWorker->start(std::forward<Func>(func));
         }
 
+        bool isAddTrackersFromURLEnabled() const override;
+        void setAddTrackersFromURLEnabled(bool enabled) override;
+        QString additionalTrackersURL() const override;
+        void setAdditionalTrackersURL(const QString &url) override;
+        QString additionalTrackersFromURL() const override;
+
     signals:
         void addTorrentAlertsReceived(qsizetype count);
 
@@ -596,6 +602,8 @@ namespace BitTorrent
         void saveTorrentsQueue();
         void removeTorrentsQueue();
 
+        void populateAdditionalTrackersFromURL();
+
         std::vector<lt::alert *> getPendingAlerts(lt::time_duration time = lt::time_duration::zero()) const;
 
         void moveTorrentStorage(const MoveStorageJob &job) const;
@@ -613,6 +621,9 @@ namespace BitTorrent
         void updateTrackerEntryStatuses(lt::torrent_handle torrentHandle, QHash<std::string, QHash<lt::tcp::endpoint, QMap<int, int>>> updatedTrackers);
 
         void handleRemovedTorrent(const TorrentID &torrentID, const QString &partfileRemoveError = {});
+
+        void setAdditionalTrackersFromURL(const QString &trackers);
+        void updateTrackersFromURL();
 
         CachedSettingValue<QString> m_DHTBootstrapNodes;
         CachedSettingValue<bool> m_isDHTEnabled;
@@ -676,6 +687,8 @@ namespace BitTorrent
         CachedSettingValue<bool> m_blockPeersOnPrivilegedPorts;
         CachedSettingValue<bool> m_isAddTrackersEnabled;
         CachedSettingValue<QString> m_additionalTrackers;
+        CachedSettingValue<bool> m_isAddTrackersFromURLEnabled;
+        CachedSettingValue<QString> m_additionalTrackersURL;
         CachedSettingValue<qreal> m_globalMaxRatio;
         CachedSettingValue<int> m_globalMaxSeedingMinutes;
         CachedSettingValue<int> m_globalMaxInactiveSeedingMinutes;
@@ -749,6 +762,9 @@ namespace BitTorrent
         bool m_IPFilteringConfigured = false;
         mutable bool m_listenInterfaceConfigured = false;
 
+        QString m_additionalTrackersFromURL;
+        QTimer *m_updateTrackersFromURLTimer = nullptr;
+
         bool m_isRestored = false;
         bool m_isPaused = isStartPaused();
 
@@ -759,6 +775,7 @@ namespace BitTorrent
 
         int m_numResumeData = 0;
         QList<TrackerEntry> m_additionalTrackerEntries;
+        QList<TrackerEntry> m_additionalTrackerEntriesFromURL;
         QList<QRegularExpression> m_excludedFileNamesRegExpList;
 
         // Statistics

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -53,6 +53,7 @@
 #include "base/bittorrent/sharelimitaction.h"
 #include "base/exceptions.h"
 #include "base/global.h"
+#include "base/net/downloadmanager.h"
 #include "base/net/portforwarder.h"
 #include "base/net/proxyconfigurationmanager.h"
 #include "base/path.h"
@@ -1148,6 +1149,10 @@ void OptionsDialog::loadBittorrentTabOptions()
     m_ui->checkEnableAddTrackers->setChecked(session->isAddTrackersEnabled());
     m_ui->textTrackers->setPlainText(session->additionalTrackers());
 
+    m_ui->checkAddTrackersFromURL->setChecked(session->isAddTrackersFromURLEnabled());
+    m_ui->textTrackersURL->setText(session->additionalTrackersURL());
+    m_ui->textTrackersFromURL->setPlainText(session->additionalTrackersFromURL());
+
     connect(m_ui->checkDHT, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkPeX, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->checkLSD, &QAbstractButton::toggled, this, &ThisType::enableApplyButton);
@@ -1181,6 +1186,9 @@ void OptionsDialog::loadBittorrentTabOptions()
 
     connect(m_ui->checkEnableAddTrackers, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
     connect(m_ui->textTrackers, &QPlainTextEdit::textChanged, this, &ThisType::enableApplyButton);
+
+    connect(m_ui->checkAddTrackersFromURL, &QGroupBox::toggled, this, &ThisType::enableApplyButton);
+    connect(m_ui->textTrackersURL, &QLineEdit::textChanged, this, &ThisType::enableApplyButton);
 }
 
 void OptionsDialog::saveBittorrentTabOptions() const
@@ -1218,6 +1226,9 @@ void OptionsDialog::saveBittorrentTabOptions() const
 
     session->setAddTrackersEnabled(m_ui->checkEnableAddTrackers->isChecked());
     session->setAdditionalTrackers(m_ui->textTrackers->toPlainText());
+
+    session->setAddTrackersFromURLEnabled(m_ui->checkAddTrackersFromURL->isChecked());
+    session->setAdditionalTrackersURL(m_ui->textTrackersURL->text());
 }
 
 void OptionsDialog::loadRSSTabOptions()

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -3132,6 +3132,49 @@ Disable encryption: Only connect to peers without protocol encryption</string>
              </widget>
             </item>
             <item>
+             <widget class="QGroupBox" name="checkAddTrackersFromURL">
+              <property name="title">
+               <string>Automatically append trackers from URL to new downloads:</string>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
+              </property>
+              <layout class="QVBoxLayout" name="checkAddTrackersFromURLLayout">
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayout_21">
+                 <item>
+                  <widget class="QLabel" name="labelCustomizeTrackersListUrl">
+                   <property name="text">
+                    <string>URL:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLineEdit" name="textTrackersURL"/>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <widget class="QLabel" name="labeltrackersFromURL">
+                 <property name="text">
+                  <string>Fetched trackers</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPlainTextEdit" name="textTrackersFromURL">
+                 <property name="readOnly">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
              <spacer name="verticalSpacer_8">
               <property name="orientation">
                <enum>Qt::Orientation::Vertical</enum>

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -306,6 +306,9 @@ void AppController::preferencesAction()
     // Add trackers
     data[u"add_trackers_enabled"_s] = session->isAddTrackersEnabled();
     data[u"add_trackers"_s] = session->additionalTrackers();
+    data[u"add_trackers_from_url_enabled"_s] = session->isAddTrackersFromURLEnabled();
+    data[u"add_trackers_url"_s] = session->additionalTrackersURL();
+    data[u"add_trackers_url_list"_s] = session->additionalTrackersFromURL();
 
     // WebUI
     // HTTP Server
@@ -860,6 +863,10 @@ void AppController::setPreferencesAction()
         session->setAddTrackersEnabled(it.value().toBool());
     if (hasKey(u"add_trackers"_s))
         session->setAdditionalTrackers(it.value().toString());
+    if (hasKey(u"add_trackers_from_url_enabled"_s))
+        session->setAddTrackersFromURLEnabled(it.value().toBool());
+    if (hasKey(u"add_trackers_url"_s))
+        session->setAdditionalTrackersURL(it.value().toString());
 
     // WebUI
     // HTTP Server

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -820,6 +820,23 @@
         </legend>
         <textarea id="add_trackers_textarea" rows="5" cols="70" aria-labelledby="addTrackersLabel"></textarea>
     </fieldset>
+
+    <fieldset class="settings">
+        <legend>
+            <input type="checkbox" id="addTrackersFromURLCheckbox" onclick="qBittorrent.Preferences.updateAddTrackersFromURLEnabled();">
+            <label for="addTrackersFromURLCheckbox">QBT_TR(Automatically append trackers from URL to new downloads:)QBT_TR[CONTEXT=OptionsDialog]</label>
+        </legend>
+        <div class="formRow">
+            <label for="addTrackersURL">QBT_TR(URL:)QBT_TR[CONTEXT=OptionsDialog]</label>
+            <input type="text" id="addTrackersURL" style="width: 40em;">
+        </div>
+        <div class="formRow">
+            <fieldset class="settings">
+                <legend id="fetchedTrackersFromURLLabel">QBT_TR(Fetched trackers)QBT_TR[CONTEXT=OptionsDialog]</legend>
+                <textarea id="addTrackersURLListTextarea" aria-labelledby="fetchedTrackersFromURLLabel" rows="5" cols="70" readonly></textarea>
+            </fieldset>
+        </div>
+    </fieldset>
 </div>
 
 <div id="RSSTab" class="PrefTab invisible">
@@ -1731,6 +1748,7 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                 updateSlowTorrentsSettings: updateSlowTorrentsSettings,
                 updateMaxRatioTimeEnabled: updateMaxRatioTimeEnabled,
                 updateAddTrackersEnabled: updateAddTrackersEnabled,
+                updateAddTrackersFromURLEnabled: updateAddTrackersFromURLEnabled,
                 updateHttpsSettings: updateHttpsSettings,
                 updateBypasssAuthSettings: updateBypasssAuthSettings,
                 updateAlternativeWebUISettings: updateAlternativeWebUISettings,
@@ -2007,6 +2025,11 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
         const updateAddTrackersEnabled = () => {
             const isAddTrackersEnabled = $("add_trackers_checkbox").checked;
             $("add_trackers_textarea").disabled = !isAddTrackersEnabled;
+        };
+
+        const updateAddTrackersFromURLEnabled = () => {
+            const isAddTrackersFromURLEnabled = $("addTrackersFromURLCheckbox").checked;
+            $("addTrackersURL").disabled = !isAddTrackersFromURLEnabled;
         };
 
         // WebUI tab
@@ -2431,7 +2454,11 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
                     // Add trackers
                     $("add_trackers_checkbox").checked = pref.add_trackers_enabled;
                     $("add_trackers_textarea").value = pref.add_trackers;
+                    $("addTrackersFromURLCheckbox").checked = pref.add_trackers_from_url_enabled;
+                    $("addTrackersURLListTextarea").value = pref.add_trackers_url_list;
+                    $("addTrackersURL").value = pref.add_trackers_url;
                     updateAddTrackersEnabled();
+                    updateAddTrackersFromURLEnabled();
 
                     // RSS Tab
                     $("enable_fetching_rss_feeds_checkbox").checked = pref.rss_processing_enabled;
@@ -2864,6 +2891,8 @@ Use ';' to split multiple entries. Can use wildcard '*'.)QBT_TR[CONTEXT=OptionsD
             // Add trackers
             settings["add_trackers_enabled"] = $("add_trackers_checkbox").checked;
             settings["add_trackers"] = $("add_trackers_textarea").value;
+            settings["add_trackers_from_url_enabled"] = $("addTrackersFromURLCheckbox").checked;
+            settings["add_trackers_url"] = $("addTrackersURL").value;
 
             // RSS Tab
             settings["rss_processing_enabled"] = $("enable_fetching_rss_feeds_checkbox").checked;


### PR DESCRIPTION
This feature is adapted from [qBittorrent-Enhanced-Edition](https://github.com/c0re100/qBittorrent-Enhanced-Edition) to allow for automatically adding trackers retrieved from a URL. @ngosang's [trackerlist repo](https://github.com/ngosang/trackerslist/) is a good example, however I've opted not to include a default URL.

Partially addresses #14535.

