### PR TITLE
Don't apply Mark-of-the-Web on existing files

### DIFF
--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -2388,7 +2388,8 @@ void TorrentImpl::handleFileCompletedAlert(const lt::file_completed_alert *p)
 
 #if defined(Q_OS_MACOS) || defined(Q_OS_WIN)
     // only apply Mark-of-the-Web to new download files
-    if (Preferences::instance()->isMarkOfTheWebEnabled() && isDownloading())
+    if (Preferences::instance()->isMarkOfTheWebEnabled()
+        && (m_nativeStatus.state == lt::torrent_status::downloading))
     {
         const Path fullpath = actualStorageLocation() / actualPath;
         Utils::OS::applyMarkOfTheWeb(fullpath);


### PR DESCRIPTION
`TorrentImpl::isDownloading()` was excessively broad which included unexpected events for the case here. So check the underlying state directly.

The current PR should be able to handle #21788 use case.

Closes #21788.