### PR TITLE
WebUI: Show 'Rename...' context menu item only when one torrent is selected

### DIFF
--- a/src/webui/www/private/scripts/contextmenu.js
+++ b/src/webui/www/private/scripts/contextmenu.js
@@ -392,6 +392,7 @@ window.qBittorrent.ContextMenu ??= (() => {
                 const data = torrentsTable.getRow(selectedRows[0]).full_data;
                 const metadata_downloaded = !((data["state"] === "metaDL") || (data["state"] === "forcedMetaDL") || (data["total_size"] === -1));
 
+                this.showItem("rename");
                 // hide renameFiles when metadata hasn't been downloaded yet
                 metadata_downloaded
                     ? this.showItem("renameFiles")
@@ -399,6 +400,7 @@ window.qBittorrent.ContextMenu ??= (() => {
             }
             else {
                 this.hideItem("renameFiles");
+                this.hideItem("rename");
             }
 
             if (all_are_downloaded) {


### PR DESCRIPTION
'Rename...' item in torrents table menu is displayed only when exactly one torrent is selected