### PR TITLE
Avoid redundant string length function calls

### DIFF
--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -36,6 +36,7 @@
 #include <QDebug>
 #include <QFileInfo>
 #include <QProcessEnvironment>
+#include <QStringView>
 
 #if defined(Q_OS_WIN) && !defined(DISABLE_GUI)
 #include <QMessageBox>
@@ -60,7 +61,7 @@ namespace
     class Option
     {
     protected:
-        explicit constexpr Option(const char *name, char shortcut = 0)
+        explicit constexpr Option(const QStringView name, const QChar shortcut = QChar::Null)
             : m_name {name}
             , m_shortcut {shortcut}
         {
@@ -68,23 +69,23 @@ namespace
 
         QString fullParameter() const
         {
-            return u"--" + QString::fromLatin1(m_name);
+            return u"--" + m_name.toString();
         }
 
         QString shortcutParameter() const
         {
-            return u"-" + QChar::fromLatin1(m_shortcut);
+            return u"-" + m_shortcut;
         }
 
         bool hasShortcut() const
         {
-            return m_shortcut != 0;
+            return !m_shortcut.isNull();
         }
 
         QString envVarName() const
         {
             return u"QBT_"
-                   + QString::fromLatin1(m_name).toUpper().replace(u'-', u'_');
+                   + m_name.toString().toUpper().replace(u'-', u'_');
         }
 
     public:
@@ -99,15 +100,15 @@ namespace
         }
 
     private:
-        const char *m_name = nullptr;
-        const char m_shortcut;
+        const QStringView m_name;
+        const QChar m_shortcut;
     };
 
     // Boolean option.
     class BoolOption : protected Option
     {
     public:
-        explicit constexpr BoolOption(const char *name, char shortcut = 0)
+        explicit constexpr BoolOption(const QStringView name, const QChar shortcut = QChar::Null)
             : Option {name, shortcut}
         {
         }
@@ -139,8 +140,8 @@ namespace
     struct StringOption : protected Option
     {
     public:
-        explicit constexpr StringOption(const char *name)
-            : Option {name, 0}
+        explicit constexpr StringOption(const QStringView name)
+            : Option {name, QChar::Null}
         {
         }
 
@@ -181,7 +182,7 @@ namespace
     class IntOption : protected StringOption
     {
     public:
-        explicit constexpr IntOption(const char *name)
+        explicit constexpr IntOption(const QStringView name)
             : StringOption {name}
         {
         }
@@ -229,8 +230,8 @@ namespace
     class TriStateBoolOption : protected Option
     {
     public:
-        constexpr TriStateBoolOption(const char *name, bool defaultValue)
-            : Option {name, 0}
+        constexpr TriStateBoolOption(const QStringView name, const bool defaultValue)
+            : Option {name, QChar::Null}
             , m_defaultValue(defaultValue)
         {
         }
@@ -299,31 +300,32 @@ namespace
             return arg.section(u'=', 0, 0) == option.fullParameter();
         }
 
-        bool m_defaultValue;
+    private:
+        bool m_defaultValue = false;
     };
 
-    constexpr const BoolOption SHOW_HELP_OPTION {"help", 'h'};
+    constexpr const BoolOption SHOW_HELP_OPTION {u"help", u'h'};
 #if !defined(Q_OS_WIN) || defined(DISABLE_GUI)
-    constexpr const BoolOption SHOW_VERSION_OPTION {"version", 'v'};
+    constexpr const BoolOption SHOW_VERSION_OPTION {u"version", u'v'};
 #endif
-    constexpr const BoolOption CONFIRM_LEGAL_NOTICE {"confirm-legal-notice"};
+    constexpr const BoolOption CONFIRM_LEGAL_NOTICE {u"confirm-legal-notice"};
 #if defined(DISABLE_GUI) && !defined(Q_OS_WIN)
-    constexpr const BoolOption DAEMON_OPTION {"daemon", 'd'};
+    constexpr const BoolOption DAEMON_OPTION {u"daemon", u'd'};
 #else
-    constexpr const BoolOption NO_SPLASH_OPTION {"no-splash"};
+    constexpr const BoolOption NO_SPLASH_OPTION {u"no-splash"};
 #endif
-    constexpr const IntOption WEBUI_PORT_OPTION {"webui-port"};
-    constexpr const IntOption TORRENTING_PORT_OPTION {"torrenting-port"};
-    constexpr const StringOption PROFILE_OPTION {"profile"};
-    constexpr const StringOption CONFIGURATION_OPTION {"configuration"};
-    constexpr const BoolOption RELATIVE_FASTRESUME {"relative-fastresume"};
-    constexpr const StringOption SAVE_PATH_OPTION {"save-path"};
-    constexpr const TriStateBoolOption STOPPED_OPTION {"add-stopped", true};
-    constexpr const BoolOption SKIP_HASH_CHECK_OPTION {"skip-hash-check"};
-    constexpr const StringOption CATEGORY_OPTION {"category"};
-    constexpr const BoolOption SEQUENTIAL_OPTION {"sequential"};
-    constexpr const BoolOption FIRST_AND_LAST_OPTION {"first-and-last"};
-    constexpr const TriStateBoolOption SKIP_DIALOG_OPTION {"skip-dialog", true};
+    constexpr const IntOption WEBUI_PORT_OPTION {u"webui-port"};
+    constexpr const IntOption TORRENTING_PORT_OPTION {u"torrenting-port"};
+    constexpr const StringOption PROFILE_OPTION {u"profile"};
+    constexpr const StringOption CONFIGURATION_OPTION {u"configuration"};
+    constexpr const BoolOption RELATIVE_FASTRESUME {u"relative-fastresume"};
+    constexpr const StringOption SAVE_PATH_OPTION {u"save-path"};
+    constexpr const TriStateBoolOption STOPPED_OPTION {u"add-stopped", true};
+    constexpr const BoolOption SKIP_HASH_CHECK_OPTION {u"skip-hash-check"};
+    constexpr const StringOption CATEGORY_OPTION {u"category"};
+    constexpr const BoolOption SEQUENTIAL_OPTION {u"sequential"};
+    constexpr const BoolOption FIRST_AND_LAST_OPTION {u"first-and-last"};
+    constexpr const TriStateBoolOption SKIP_DIALOG_OPTION {u"skip-dialog", true};
 }
 
 QBtCommandLineParameters::QBtCommandLineParameters(const QProcessEnvironment &env)

--- a/src/app/qtlocalpeer/qtlocalpeer.cpp
+++ b/src/app/qtlocalpeer/qtlocalpeer.cpp
@@ -74,6 +74,7 @@
 #include <windows.h>
 #endif
 
+#include <QByteArray>
 #include <QDataStream>
 #include <QFileInfo>
 #include <QLocalServer>
@@ -90,7 +91,7 @@ namespace QtLP_Private
 #endif
 }
 
-const char ACK[] = "ack";
+const QByteArray ACK = QByteArrayLiteral("ack");
 
 QtLocalPeer::QtLocalPeer(const QString &path, QObject *parent)
     : QObject(parent)
@@ -169,7 +170,7 @@ bool QtLocalPeer::sendMessage(const QString &message, const int timeout)
     {
         res &= socket.waitForReadyRead(timeout);   // wait for ack
         if (res)
-            res &= (socket.read(qstrlen(ACK)) == ACK);
+            res &= (socket.read(ACK.size()) == ACK);
     }
     return res;
 }
@@ -220,7 +221,7 @@ void QtLocalPeer::receiveConnection()
         return;
     }
     QString message(QString::fromUtf8(uMsg));
-    socket->write(ACK, qstrlen(ACK));
+    socket->write(ACK);
     socket->waitForBytesWritten(1000);
     socket->waitForDisconnected(1000); // make sure client reads ack
     delete socket;

--- a/src/base/bittorrent/dbresumedatastorage.cpp
+++ b/src/base/bittorrent/dbresumedatastorage.cpp
@@ -120,36 +120,35 @@ namespace
         QString placeholder;
     };
 
-    Column makeColumn(const char *columnName)
+    Column makeColumn(const QString &columnName)
     {
-        const QString name = QString::fromLatin1(columnName);
-        return {.name = name, .placeholder = (u':' + name)};
+        return {.name = columnName, .placeholder = (u':' + columnName)};
     }
 
-    const Column DB_COLUMN_ID = makeColumn("id");
-    const Column DB_COLUMN_TORRENT_ID = makeColumn("torrent_id");
-    const Column DB_COLUMN_QUEUE_POSITION = makeColumn("queue_position");
-    const Column DB_COLUMN_NAME = makeColumn("name");
-    const Column DB_COLUMN_CATEGORY = makeColumn("category");
-    const Column DB_COLUMN_TAGS = makeColumn("tags");
-    const Column DB_COLUMN_TARGET_SAVE_PATH = makeColumn("target_save_path");
-    const Column DB_COLUMN_DOWNLOAD_PATH = makeColumn("download_path");
-    const Column DB_COLUMN_CONTENT_LAYOUT = makeColumn("content_layout");
-    const Column DB_COLUMN_RATIO_LIMIT = makeColumn("ratio_limit");
-    const Column DB_COLUMN_SEEDING_TIME_LIMIT = makeColumn("seeding_time_limit");
-    const Column DB_COLUMN_INACTIVE_SEEDING_TIME_LIMIT = makeColumn("inactive_seeding_time_limit");
-    const Column DB_COLUMN_SHARE_LIMIT_ACTION = makeColumn("share_limit_action");
-    const Column DB_COLUMN_HAS_OUTER_PIECES_PRIORITY = makeColumn("has_outer_pieces_priority");
-    const Column DB_COLUMN_HAS_SEED_STATUS = makeColumn("has_seed_status");
-    const Column DB_COLUMN_OPERATING_MODE = makeColumn("operating_mode");
-    const Column DB_COLUMN_STOPPED = makeColumn("stopped");
-    const Column DB_COLUMN_STOP_CONDITION = makeColumn("stop_condition");
-    const Column DB_COLUMN_SSL_CERTIFICATE = makeColumn("ssl_certificate");
-    const Column DB_COLUMN_SSL_PRIVATE_KEY = makeColumn("ssl_private_key");
-    const Column DB_COLUMN_SSL_DH_PARAMS = makeColumn("ssl_dh_params");
-    const Column DB_COLUMN_RESUMEDATA = makeColumn("libtorrent_resume_data");
-    const Column DB_COLUMN_METADATA = makeColumn("metadata");
-    const Column DB_COLUMN_VALUE = makeColumn("value");
+    const Column DB_COLUMN_ID = makeColumn(u"id"_s);
+    const Column DB_COLUMN_TORRENT_ID = makeColumn(u"torrent_id"_s);
+    const Column DB_COLUMN_QUEUE_POSITION = makeColumn(u"queue_position"_s);
+    const Column DB_COLUMN_NAME = makeColumn(u"name"_s);
+    const Column DB_COLUMN_CATEGORY = makeColumn(u"category"_s);
+    const Column DB_COLUMN_TAGS = makeColumn(u"tags"_s);
+    const Column DB_COLUMN_TARGET_SAVE_PATH = makeColumn(u"target_save_path"_s);
+    const Column DB_COLUMN_DOWNLOAD_PATH = makeColumn(u"download_path"_s);
+    const Column DB_COLUMN_CONTENT_LAYOUT = makeColumn(u"content_layout"_s);
+    const Column DB_COLUMN_RATIO_LIMIT = makeColumn(u"ratio_limit"_s);
+    const Column DB_COLUMN_SEEDING_TIME_LIMIT = makeColumn(u"seeding_time_limit"_s);
+    const Column DB_COLUMN_INACTIVE_SEEDING_TIME_LIMIT = makeColumn(u"inactive_seeding_time_limit"_s);
+    const Column DB_COLUMN_SHARE_LIMIT_ACTION = makeColumn(u"share_limit_action"_s);
+    const Column DB_COLUMN_HAS_OUTER_PIECES_PRIORITY = makeColumn(u"has_outer_pieces_priority"_s);
+    const Column DB_COLUMN_HAS_SEED_STATUS = makeColumn(u"has_seed_status"_s);
+    const Column DB_COLUMN_OPERATING_MODE = makeColumn(u"operating_mode"_s);
+    const Column DB_COLUMN_STOPPED = makeColumn(u"stopped"_s);
+    const Column DB_COLUMN_STOP_CONDITION = makeColumn(u"stop_condition"_s);
+    const Column DB_COLUMN_SSL_CERTIFICATE = makeColumn(u"ssl_certificate"_s);
+    const Column DB_COLUMN_SSL_PRIVATE_KEY = makeColumn(u"ssl_private_key"_s);
+    const Column DB_COLUMN_SSL_DH_PARAMS = makeColumn(u"ssl_dh_params"_s);
+    const Column DB_COLUMN_RESUMEDATA = makeColumn(u"libtorrent_resume_data"_s);
+    const Column DB_COLUMN_METADATA = makeColumn(u"metadata"_s);
+    const Column DB_COLUMN_VALUE = makeColumn(u"value"_s);
 
     template <typename LTStr>
     QString fromLTString(const LTStr &str)
@@ -214,9 +213,9 @@ namespace
                 .arg(quoted(constraint.name), names, values);
     }
 
-    QString makeColumnDefinition(const Column &column, const char *definition)
+    QString makeColumnDefinition(const Column &column, const QString &definition)
     {
-        return u"%1 %2"_s.arg(quoted(column.name), QString::fromLatin1(definition));
+        return u"%1 %2"_s.arg(quoted(column.name), definition);
     }
 
     LoadTorrentParams parseQueryResultRow(const QSqlQuery &query)
@@ -511,9 +510,9 @@ void BitTorrent::DBResumeDataStorage::createDB() const
     try
     {
         const QStringList tableMetaItems = {
-            makeColumnDefinition(DB_COLUMN_ID, "INTEGER PRIMARY KEY"),
-            makeColumnDefinition(DB_COLUMN_NAME, "TEXT NOT NULL UNIQUE"),
-            makeColumnDefinition(DB_COLUMN_VALUE, "BLOB")
+            makeColumnDefinition(DB_COLUMN_ID, u"INTEGER PRIMARY KEY"_s),
+            makeColumnDefinition(DB_COLUMN_NAME, u"TEXT NOT NULL UNIQUE"_s),
+            makeColumnDefinition(DB_COLUMN_VALUE, u"BLOB"_s)
         };
         const QString createTableMetaQuery = makeCreateTableStatement(DB_TABLE_META, tableMetaItems);
         if (!query.exec(createTableMetaQuery))
@@ -530,29 +529,29 @@ void BitTorrent::DBResumeDataStorage::createDB() const
             throw RuntimeError(query.lastError().text());
 
         const QStringList tableTorrentsItems = {
-            makeColumnDefinition(DB_COLUMN_ID, "INTEGER PRIMARY KEY"),
-            makeColumnDefinition(DB_COLUMN_TORRENT_ID, "BLOB NOT NULL UNIQUE"),
-            makeColumnDefinition(DB_COLUMN_QUEUE_POSITION, "INTEGER NOT NULL DEFAULT -1"),
-            makeColumnDefinition(DB_COLUMN_NAME, "TEXT"),
-            makeColumnDefinition(DB_COLUMN_CATEGORY, "TEXT"),
-            makeColumnDefinition(DB_COLUMN_TAGS, "TEXT"),
-            makeColumnDefinition(DB_COLUMN_TARGET_SAVE_PATH, "TEXT"),
-            makeColumnDefinition(DB_COLUMN_DOWNLOAD_PATH, "TEXT"),
-            makeColumnDefinition(DB_COLUMN_CONTENT_LAYOUT, "TEXT NOT NULL"),
-            makeColumnDefinition(DB_COLUMN_RATIO_LIMIT, "INTEGER NOT NULL"),
-            makeColumnDefinition(DB_COLUMN_SEEDING_TIME_LIMIT, "INTEGER NOT NULL"),
-            makeColumnDefinition(DB_COLUMN_INACTIVE_SEEDING_TIME_LIMIT, "INTEGER NOT NULL"),
-            makeColumnDefinition(DB_COLUMN_SHARE_LIMIT_ACTION, "TEXT NOT NULL DEFAULT `Default`"),
-            makeColumnDefinition(DB_COLUMN_HAS_OUTER_PIECES_PRIORITY, "INTEGER NOT NULL"),
-            makeColumnDefinition(DB_COLUMN_HAS_SEED_STATUS, "INTEGER NOT NULL"),
-            makeColumnDefinition(DB_COLUMN_OPERATING_MODE, "TEXT NOT NULL"),
-            makeColumnDefinition(DB_COLUMN_STOPPED, "INTEGER NOT NULL"),
-            makeColumnDefinition(DB_COLUMN_STOP_CONDITION, "TEXT NOT NULL DEFAULT `None`"),
-            makeColumnDefinition(DB_COLUMN_SSL_CERTIFICATE, "TEXT"),
-            makeColumnDefinition(DB_COLUMN_SSL_PRIVATE_KEY, "TEXT"),
-            makeColumnDefinition(DB_COLUMN_SSL_DH_PARAMS, "TEXT"),
-            makeColumnDefinition(DB_COLUMN_RESUMEDATA, "BLOB NOT NULL"),
-            makeColumnDefinition(DB_COLUMN_METADATA, "BLOB")
+            makeColumnDefinition(DB_COLUMN_ID, u"INTEGER PRIMARY KEY"_s),
+            makeColumnDefinition(DB_COLUMN_TORRENT_ID, u"BLOB NOT NULL UNIQUE"_s),
+            makeColumnDefinition(DB_COLUMN_QUEUE_POSITION, u"INTEGER NOT NULL DEFAULT -1"_s),
+            makeColumnDefinition(DB_COLUMN_NAME, u"TEXT"_s),
+            makeColumnDefinition(DB_COLUMN_CATEGORY, u"TEXT"_s),
+            makeColumnDefinition(DB_COLUMN_TAGS, u"TEXT"_s),
+            makeColumnDefinition(DB_COLUMN_TARGET_SAVE_PATH, u"TEXT"_s),
+            makeColumnDefinition(DB_COLUMN_DOWNLOAD_PATH, u"TEXT"_s),
+            makeColumnDefinition(DB_COLUMN_CONTENT_LAYOUT, u"TEXT NOT NULL"_s),
+            makeColumnDefinition(DB_COLUMN_RATIO_LIMIT, u"INTEGER NOT NULL"_s),
+            makeColumnDefinition(DB_COLUMN_SEEDING_TIME_LIMIT, u"INTEGER NOT NULL"_s),
+            makeColumnDefinition(DB_COLUMN_INACTIVE_SEEDING_TIME_LIMIT, u"INTEGER NOT NULL"_s),
+            makeColumnDefinition(DB_COLUMN_SHARE_LIMIT_ACTION, u"TEXT NOT NULL DEFAULT `Default`"_s),
+            makeColumnDefinition(DB_COLUMN_HAS_OUTER_PIECES_PRIORITY, u"INTEGER NOT NULL"_s),
+            makeColumnDefinition(DB_COLUMN_HAS_SEED_STATUS, u"INTEGER NOT NULL"_s),
+            makeColumnDefinition(DB_COLUMN_OPERATING_MODE, u"TEXT NOT NULL"_s),
+            makeColumnDefinition(DB_COLUMN_STOPPED, u"INTEGER NOT NULL"_s),
+            makeColumnDefinition(DB_COLUMN_STOP_CONDITION, u"TEXT NOT NULL DEFAULT `None`"_s),
+            makeColumnDefinition(DB_COLUMN_SSL_CERTIFICATE, u"TEXT"_s),
+            makeColumnDefinition(DB_COLUMN_SSL_PRIVATE_KEY, u"TEXT"_s),
+            makeColumnDefinition(DB_COLUMN_SSL_DH_PARAMS, u"TEXT"_s),
+            makeColumnDefinition(DB_COLUMN_RESUMEDATA, u"BLOB NOT NULL"_s),
+            makeColumnDefinition(DB_COLUMN_METADATA, u"BLOB"_s)
         };
         const QString createTableTorrentsQuery = makeCreateTableStatement(DB_TABLE_TORRENTS, tableTorrentsItems);
         if (!query.exec(createTableTorrentsQuery))
@@ -590,7 +589,7 @@ void BitTorrent::DBResumeDataStorage::updateDB(const int fromVersion) const
 
     try
     {
-        const auto addColumn = [&query](const QString &table, const Column &column, const char *definition)
+        const auto addColumn = [&query](const QString &table, const Column &column, const QString &definition)
         {
             const auto testQuery = u"SELECT COUNT(%1) FROM %2;"_s.arg(quoted(column.name), quoted(table));
             if (query.exec(testQuery))
@@ -602,10 +601,10 @@ void BitTorrent::DBResumeDataStorage::updateDB(const int fromVersion) const
         };
 
         if (fromVersion <= 1)
-            addColumn(DB_TABLE_TORRENTS, DB_COLUMN_DOWNLOAD_PATH, "TEXT");
+            addColumn(DB_TABLE_TORRENTS, DB_COLUMN_DOWNLOAD_PATH, u"TEXT"_s);
 
         if (fromVersion <= 2)
-            addColumn(DB_TABLE_TORRENTS, DB_COLUMN_STOP_CONDITION, "TEXT NOT NULL DEFAULT `None`");
+            addColumn(DB_TABLE_TORRENTS, DB_COLUMN_STOP_CONDITION, u"TEXT NOT NULL DEFAULT `None`"_s);
 
         if (fromVersion <= 3)
         {
@@ -617,17 +616,17 @@ void BitTorrent::DBResumeDataStorage::updateDB(const int fromVersion) const
         }
 
         if (fromVersion <= 4)
-            addColumn(DB_TABLE_TORRENTS, DB_COLUMN_INACTIVE_SEEDING_TIME_LIMIT, "INTEGER NOT NULL DEFAULT -2");
+            addColumn(DB_TABLE_TORRENTS, DB_COLUMN_INACTIVE_SEEDING_TIME_LIMIT, u"INTEGER NOT NULL DEFAULT -2"_s);
 
         if (fromVersion <= 5)
         {
-            addColumn(DB_TABLE_TORRENTS, DB_COLUMN_SSL_CERTIFICATE, "TEXT");
-            addColumn(DB_TABLE_TORRENTS, DB_COLUMN_SSL_PRIVATE_KEY, "TEXT");
-            addColumn(DB_TABLE_TORRENTS, DB_COLUMN_SSL_DH_PARAMS, "TEXT");
+            addColumn(DB_TABLE_TORRENTS, DB_COLUMN_SSL_CERTIFICATE, u"TEXT"_s);
+            addColumn(DB_TABLE_TORRENTS, DB_COLUMN_SSL_PRIVATE_KEY, u"TEXT"_s);
+            addColumn(DB_TABLE_TORRENTS, DB_COLUMN_SSL_DH_PARAMS, u"TEXT"_s);
         }
 
         if (fromVersion <= 6)
-            addColumn(DB_TABLE_TORRENTS, DB_COLUMN_SHARE_LIMIT_ACTION, "TEXTNOT NULL DEFAULT `Default`");
+            addColumn(DB_TABLE_TORRENTS, DB_COLUMN_SHARE_LIMIT_ACTION, u"TEXTNOT NULL DEFAULT `Default`"_s);
 
         const QString updateMetaVersionQuery = makeUpdateStatement(DB_TABLE_META, {DB_COLUMN_NAME, DB_COLUMN_VALUE});
         if (!query.prepare(updateMetaVersionQuery))

--- a/src/base/http/requestparser.cpp
+++ b/src/base/http/requestparser.cpp
@@ -50,7 +50,7 @@ using QStringPair = std::pair<QString, QString>;
 
 namespace
 {
-    const QByteArray EOH = QByteArray(CRLF).repeated(2);
+    const QByteArray EOH = CRLF.repeated(2);
 
     const QByteArrayView viewWithoutEndingWith(const QByteArrayView in, const QByteArrayView str)
     {

--- a/src/base/http/types.h
+++ b/src/base/http/types.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include <QByteArray>
 #include <QHostAddress>
 #include <QList>
 #include <QString>
@@ -76,7 +77,7 @@ namespace Http
     inline const QString CONTENT_TYPE_FORM_DATA = u"multipart/form-data"_s;
 
     // portability: "\r\n" doesn't guarantee mapping to the correct symbol
-    inline const char CRLF[] = {0x0D, 0x0A, '\0'};
+    inline const QByteArray CRLF = QByteArrayLiteral("\x0D\x0A");
 
     struct Environment
     {

--- a/src/base/net/geoipdatabase.cpp
+++ b/src/base/net/geoipdatabase.cpp
@@ -28,6 +28,7 @@
 
 #include "geoipdatabase.h"
 
+#include <QByteArray>
 #include <QDateTime>
 #include <QDebug>
 #include <QFile>
@@ -41,7 +42,7 @@ namespace
 {
     const qint32 MAX_FILE_SIZE = 67108864; // 64MB
     const quint32 MAX_METADATA_SIZE = 131072; // 128KB
-    const char METADATA_BEGIN_MARK[] = "\xab\xcd\xefMaxMind.com";
+    const QByteArray METADATA_BEGIN_MARK = QByteArrayLiteral("\xab\xcd\xefMaxMind.com");
     const char DATA_SECTION_SEPARATOR[16] = {0};
 
     enum class DataType
@@ -309,7 +310,7 @@ QVariantHash GeoIPDatabase::readMetadata() const
     {
         if (m_size > MAX_METADATA_SIZE)
             index += (m_size - MAX_METADATA_SIZE); // from begin of all data
-        auto offset = static_cast<quint32>(index + strlen(METADATA_BEGIN_MARK));
+        auto offset = static_cast<quint32>(index + METADATA_BEGIN_MARK.size());
         const QVariant metadata = readDataField(offset);
         if (metadata.userType() == QMetaType::QVariantHash)
             return metadata.toHash();

--- a/src/base/utils/fs.cpp
+++ b/src/base/utils/fs.cpp
@@ -60,7 +60,6 @@
 #include <QRegularExpression>
 #include <QStorageInfo>
 
-#include "base/global.h"
 #include "base/path.h"
 
 /**

--- a/src/base/utils/string.cpp
+++ b/src/base/utils/string.cpp
@@ -49,14 +49,14 @@ QString Utils::String::fromDouble(const double n, const int precision)
     return QLocale::system().toString(std::floor(n * prec) / prec, 'f', precision);
 }
 
-QString Utils::String::fromLatin1(const std::string &string)
+QString Utils::String::fromLatin1(const std::string_view string)
 {
-    return QString::fromLatin1(string.c_str(), string.size());
+    return QString::fromLatin1(string.data(), string.size());
 }
 
-QString Utils::String::fromLocal8Bit(const std::string &string)
+QString Utils::String::fromLocal8Bit(const std::string_view string)
 {
-    return QString::fromLocal8Bit(string.c_str(), string.size());
+    return QString::fromLocal8Bit(string.data(), string.size());
 }
 
 QString Utils::String::wildcardToRegexPattern(const QString &pattern)

--- a/src/base/utils/string.h
+++ b/src/base/utils/string.h
@@ -32,6 +32,7 @@
 
 #include <numeric>
 #include <optional>
+#include <string_view>
 
 #include <QChar>
 #include <QMetaEnum>
@@ -66,8 +67,8 @@ namespace Utils::String
     QStringList splitCommand(const QString &command);
 
     QString fromDouble(double n, int precision);
-    QString fromLatin1(const std::string &string);
-    QString fromLocal8Bit(const std::string &string);
+    QString fromLatin1(std::string_view string);
+    QString fromLocal8Bit(std::string_view string);
 
     template <typename Container>
     QString joinIntoString(const Container &container, const QString &separator)


### PR DESCRIPTION
Also change helper function parameter to `std::string_view` as it is more generic and can handle more types (including view types).
