### PR TITLE
WebUI: fix failed conversion to number

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -184,7 +184,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             const onStart = function(el, event) {
                 if (this.canResize) {
                     this.currentHeaderAction = "resize";
-                    this.startWidth = Number(this.resizeTh.style.width);
+                    this.startWidth = parseInt(this.resizeTh.style.width, 10);
                 }
                 else {
                     this.currentHeaderAction = "drag";


### PR DESCRIPTION
The value has unit suffix (`px`) and require using `parseInt()` for conversion.

Related: https://github.com/qbittorrent/qBittorrent/pull/21831#discussion_r1844954795.
Fix up f73f31619ddebafcc82dfd65b9be7eeb347d467a.
