### PR TITLE
WebUI: clean up fetch API usage

### DIFF
--- a/src/webui/www/private/scripts/misc.js
+++ b/src/webui/www/private/scripts/misc.js
@@ -278,7 +278,7 @@ window.qBittorrent.Misc ??= (() => {
 
     const downloadFile = async (url, defaultFileName, errorMessage = "QBT_TR(Unable to download file)QBT_TR[CONTEXT=HttpServer]") => {
         try {
-            const response = await fetch(url);
+            const response = await fetch(url, { method: "GET" });
             if (!response.ok) {
                 alert(errorMessage);
                 return;

--- a/src/webui/www/private/scripts/pathAutofill.js
+++ b/src/webui/www/private/scripts/pathAutofill.js
@@ -64,7 +64,10 @@ window.qBittorrent.pathAutofill ??= (() => {
         if (partialPath === "")
             return;
 
-        fetch(`api/v2/app/getDirectoryContent?dirPath=${partialPath}&mode=${mode}`)
+        fetch(`api/v2/app/getDirectoryContent?dirPath=${partialPath}&mode=${mode}`, {
+                method: "GET",
+                cache: "no-store"
+            })
             .then(response => response.json())
             .then(filesList => { showInputSuggestions(element, filesList); })
             .catch(error => {});

--- a/src/webui/www/public/scripts/login.js
+++ b/src/webui/www/public/scripts/login.js
@@ -37,17 +37,12 @@ const submitLoginForm = (event) => {
     const usernameElement = document.getElementById("username");
     const passwordElement = document.getElementById("password");
 
-    const query = new URLSearchParams();
-    query.set("username", usernameElement.value);
-    query.set("password", passwordElement.value);
-    passwordElement.value = ""; // clear previous value
-
     fetch("api/v2/auth/login", {
             method: "POST",
-            headers: {
-                "Content-type": "application/x-www-form-urlencoded; charset=UTF-8"
-            },
-            body: query.toString()
+            body: new URLSearchParams({
+                "username": usernameElement.value,
+                "password": passwordElement.value
+            })
         })
         .then(async (response) => {
                 const responseText = await response.text();
@@ -62,6 +57,8 @@ const submitLoginForm = (event) => {
             (error) => {
                 errorMsgElement.textContent = `QBT_TR(Unable to log in, server is probably unreachable.)QBT_TR[CONTEXT=Login]\n${error}`;
             });
+
+    passwordElement.value = ""; // clear previous value
 };
 
 document.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
The `Content-type` header isn't required since `URLSearchParams` is present.
The `method` property is preferred to be always specified for clarity.
The `cache: "no-store"` is preferred for most GET requests to avoid caching.
