### PR TITLE
WebUI: Set base background color

### DIFF
--- a/src/webui/www/private/css/style.css
+++ b/src/webui/www/private/css/style.css
@@ -10,6 +10,7 @@
     --color-text-white: hsl(0deg 0% 100%);
     --color-text-disabled: hsl(0deg 0% 60%);
     --color-text-default: hsl(0deg 0% 33%);
+    --color-background-primary: hsl(0deg 0% 100%);
     --color-background-blue: hsl(210deg 65% 55%);
     --color-background-popup: hsl(0deg 0% 100%);
     --color-background-default: hsl(0deg 0% 94%);
@@ -28,6 +29,7 @@
         --color-text-blue: hsl(210deg 88.1% 73.5%);
         --color-text-orange: hsl(26deg 65% 70%);
         --color-text-default: hsl(0deg 0% 90%);
+        --color-background-primary: hsl(0deg 0% 7%);
         --color-background-blue: hsl(210deg 42% 48%);
         --color-background-popup: hsl(0deg 0% 20%);
         --color-background-default: hsl(0deg 0% 25%);
@@ -130,11 +132,17 @@ button:disabled {
 /* Structure */
 
 body {
+    background-color: var(--color-background-primary);
     color: var(--color-text-default);
     font-family: Arial, Helvetica, sans-serif;
     font-size: 12px;
     line-height: 1.5;
     text-align: left;
+}
+
+/* targets dialog windows loaded via iframes */
+body:not(:has(#desktop)) {
+    background-color: var(--color-background-popup);
 }
 
 .aside {


### PR DESCRIPTION
This PR ensures that the same base background color is used across different browsers (more consistent styling).

Context https://github.com/qbittorrent/qBittorrent/pull/21498#issuecomment-2399929576
Used default Chrome colors https://github.com/qbittorrent/qBittorrent/issues/21894#issuecomment-2494253459

Before/after (Firefox):

![before](https://github.com/user-attachments/assets/2b1e4f38-d96f-494f-a4b6-301d0da509aa)
![after](https://github.com/user-attachments/assets/c4109d90-b9f9-4848-b202-7dd2d8a0ac8b)

PR https://github.com/qbittorrent/qBittorrent/pull/21498 can go forward after this is merged.