### PR TITLE
Don't add duplicate episodes to list of previously matched

### DIFF
--- a/src/base/rss/rss_autodownloadrule.cpp
+++ b/src/base/rss/rss_autodownloadrule.cpp
@@ -396,6 +396,8 @@ bool AutoDownloadRule::matchesSmartEpisodeFilter(const QString &articleTitle) co
             m_dataPtr->lastComputedEpisodes.append(episodeStr + u"-REPACK");
             m_dataPtr->lastComputedEpisodes.append(episodeStr + u"-PROPER");
         }
+
+        return true;
     }
 
     m_dataPtr->lastComputedEpisodes.append(episodeStr);


### PR DESCRIPTION
If you already have episode `2x4` in the previously matched list for an RSS auto-download rule, then a REPACK or PROPER is matched, the original is added to the list again, e.g.:
```
2x4
2x4-REPACK
2x4
```

This change should append an episode to an auto download rule's previously matched list only if it hasn't been previously matched.