### PR TITLE
Resolve relative URLs within RSS article description

### DIFF
--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -55,7 +55,7 @@
 #include "ui_rsswidget.h"
 namespace
 {
-void convertRelativeUrlToAbsolute(QString &html, const QString &baseUrl);
+    void convertRelativeUrlToAbsolute(QString &html, const QString &baseUrl);
 }
 RSSWidget::RSSWidget(IGUIApplication *app, QWidget *parent)
     : GUIApplicationComponent(app, parent)

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -56,8 +56,6 @@
 
 namespace
 {
-    void convertRelativeUrlToAbsolute(QString &html, const QString &baseUrl);
-    
     void convertRelativeUrlToAbsolute(QString &html, const QString &baseUrl)
     {
         const QRegularExpression rx {uR"(((<a\s+[^>]*?href|<img\s+[^>]*?src)\s*=\s*["'])((https?|ftp):)?(\/\/[^\/]*)?(\/?[^\/"].*?)(["']))"_s

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -53,10 +53,12 @@
 #include "automatedrssdownloader.h"
 #include "feedlistwidget.h"
 #include "ui_rsswidget.h"
+
 namespace
 {
     void convertRelativeUrlToAbsolute(QString &html, const QString &baseUrl);
 }
+
 RSSWidget::RSSWidget(IGUIApplication *app, QWidget *parent)
     : GUIApplicationComponent(app, parent)
     , m_ui {new Ui::RSSWidget}

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -53,9 +53,10 @@
 #include "automatedrssdownloader.h"
 #include "feedlistwidget.h"
 #include "ui_rsswidget.h"
-
+namespace
+{
 void convertRelativeUrlToAbsolute(QString &html, const QString &baseUrl);
-
+}
 RSSWidget::RSSWidget(IGUIApplication *app, QWidget *parent)
     : GUIApplicationComponent(app, parent)
     , m_ui {new Ui::RSSWidget}
@@ -613,48 +614,53 @@ void RSSWidget::renderArticle(const RSS::Article *article) const
         html += u"<pre>" + description + u"</pre>";
     }
 
-    // Supplement relative path to absolute path
+    // Supplement relative URLs to absolute ones
     const QUrl url {article->link()};
     const QString baseUrl = url.toString(QUrl::RemovePath | QUrl::RemoveQuery);
     convertRelativeUrlToAbsolute(html, baseUrl);
     html += u"</div>";
     m_ui->textBrowser->setHtml(html);
 }
-
-void convertRelativeUrlToAbsolute(QString &html, const QString &baseUrl)
+namespace
 {
-    const QRegularExpression rx {uR"(((<a\s+[^>]*?href|<img\s+[^>]*?src)\s*=\s*["'])((https?|ftp):)?(\/\/[^\/]*)?(\/?[^\/"].*?)(["']))"_s
-        , QRegularExpression::CaseInsensitiveOption};
-
-    QString normalizedBaseUrl = baseUrl.endsWith(u'/') ? baseUrl : baseUrl + u'/';
-    QRegularExpressionMatchIterator iter = rx.globalMatch(html);
-
-    while (iter.hasNext())
+    void convertRelativeUrlToAbsolute(QString &html, const QString &baseUrl)
     {
-        const QRegularExpressionMatch match = iter.next();
-        const QString scheme = match.captured(4);
-        const QString host = match.captured(5);
-        if (!scheme.isEmpty())
+        const QRegularExpression rx {uR"(((<a\s+[^>]*?href|<img\s+[^>]*?src)\s*=\s*["'])((https?|ftp):)?(\/\/[^\/]*)?(\/?[^\/"].*?)(["']))"_s
+            , QRegularExpression::CaseInsensitiveOption};
+
+        QString normalizedBaseUrl = baseUrl.endsWith(u'/') ? baseUrl : baseUrl + u'/';
+        const QUrl url {normalizedBaseUrl};
+        const QString defaultScheme = url.scheme();
+        QRegularExpressionMatchIterator iter = rx.globalMatch(html);
+
+        while (iter.hasNext())
         {
-            if (host.isEmpty())
-                break; // invalid URL, should never happen
-                
-            // already absolute path
-            continue;
+            const QRegularExpressionMatch match = iter.next();
+            const QString scheme = match.captured(4);
+            const QString host = match.captured(5);
+            if (!scheme.isEmpty())
+            {
+                if (host.isEmpty())
+                    break; // invalid URL, should never happen
+
+                // already absolute URL
+                continue;
+            }
+
+            QString relativePath = match.captured(6);
+            if (relativePath.startsWith(u'/'))
+                relativePath = relativePath.mid(1);
+
+            if (!host.isEmpty())
+            {
+                normalizedBaseUrl = defaultScheme + u":" + host;
+            }
+            const QString fullMatch = match.captured(0);
+            const QString prefix = match.captured(1);
+            const QString suffix = match.captured(7);
+            const QString absoluteUrl = normalizedBaseUrl + relativePath;
+
+            html.replace(fullMatch, (prefix + absoluteUrl + suffix));
         }
-
-        QString relativePath = match.captured(6);
-        if (relativePath.startsWith(u'/'))
-            relativePath = relativePath.mid(1);
-
-        if (!host.isEmpty())
-            normalizedBaseUrl = u"http:" + host;
-
-        const QString fullMatch = match.captured(0);
-        const QString prefix = match.captured(1);
-        const QString suffix = match.captured(7);
-        const QString absolutePath = normalizedBaseUrl + relativePath;
-
-        html.replace(fullMatch, (prefix + absolutePath + suffix));
     }
 }

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -653,11 +653,8 @@ namespace
             if (relativePath.startsWith(u'/'))
                 relativePath = relativePath.mid(1);
 
-            QString absoluteUrl;
-            if (!host.isEmpty())
-                absoluteUrl = defaultScheme + u":" + host;
-            else
-                absoluteUrl = normalizedBaseUrl + relativePath;
+            const QString absoluteUrl = !host.isEmpty()
+                    ? (defaultScheme + u":" + host) : (normalizedBaseUrl + relativePath);
             const QString fullMatch = match.captured(0);
             const QString prefix = match.captured(1);
             const QString suffix = match.captured(7);

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -54,7 +54,7 @@
 #include "feedlistwidget.h"
 #include "ui_rsswidget.h"
 
-void convertRelativePathToAbsolute(QString &html, const QString &basePath);
+void convertRelativeUrlToAbsolute(QString &html, const QString &baseUrl);
 
 RSSWidget::RSSWidget(IGUIApplication *app, QWidget *parent)
     : GUIApplicationComponent(app, parent)
@@ -615,18 +615,18 @@ void RSSWidget::renderArticle(const RSS::Article *article) const
 
     // Supplement relative path to absolute path
     const QUrl url {article->link()};
-    const QString basePath = url.toString(QUrl::RemovePath | QUrl::RemoveQuery);
-    convertRelativePathToAbsolute(html, basePath);
+    const QString baseUrl = url.toString(QUrl::RemovePath | QUrl::RemoveQuery);
+    convertRelativeUrlToAbsolute(html, baseUrl);
     html += u"</div>";
     m_ui->textBrowser->setHtml(html);
 }
 
-void convertRelativePathToAbsolute(QString &html, const QString &basePath)
+void convertRelativeUrlToAbsolute(QString &html, const QString &baseUrl)
 {
     const QRegularExpression rx {uR"(((<a\s+[^>]*?href|<img\s+[^>]*?src)\s*=\s*["'])((https?|ftp):)?(\/\/[^\/]*)?(\/?[^\/"].*?)(["']))"_s
         , QRegularExpression::CaseInsensitiveOption};
 
-    QString normalizedBasePath = basePath.endsWith(u'/') ? basePath : basePath + u'/';
+    QString normalizedBaseUrl = baseUrl.endsWith(u'/') ? baseUrl : baseUrl + u'/';
     QRegularExpressionMatchIterator iter = rx.globalMatch(html);
 
     while (iter.hasNext())
@@ -648,12 +648,12 @@ void convertRelativePathToAbsolute(QString &html, const QString &basePath)
             relativePath = relativePath.mid(1);
 
         if (!host.isEmpty())
-            normalizedBasePath = u"http:" + host;
+            normalizedBaseUrl = u"http:" + host;
 
         const QString fullMatch = match.captured(0);
         const QString prefix = match.captured(1);
         const QString suffix = match.captured(7);
-        const QString absolutePath = normalizedBasePath + relativePath;
+        const QString absolutePath = normalizedBaseUrl + relativePath;
 
         html.replace(fullMatch, (prefix + absolutePath + suffix));
     }

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -589,8 +589,7 @@ void RSSWidget::convertRelativePathToAbsolute(QString &html, const QString &base
             break; // invalid url, should never happen
         QString absolutePath = normalizedBasePath + relativePath;
 
-        html.replace(fullMatch,
-                     prefix + absolutePath + suffix);
+        html.replace(fullMatch, prefix + absolutePath + suffix);
     }
 }
 

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -630,7 +630,7 @@ namespace
         const QRegularExpression rx {uR"(((<a\s+[^>]*?href|<img\s+[^>]*?src)\s*=\s*["'])((https?|ftp):)?(\/\/[^\/]*)?(\/?[^\/"].*?)(["']))"_s
             , QRegularExpression::CaseInsensitiveOption};
 
-        QString normalizedBaseUrl = baseUrl.endsWith(u'/') ? baseUrl : baseUrl + u'/';
+        const QString normalizedBaseUrl = baseUrl.endsWith(u'/') ? baseUrl : baseUrl + u'/';
         const QUrl url {normalizedBaseUrl};
         const QString defaultScheme = url.scheme();
         QRegularExpressionMatchIterator iter = rx.globalMatch(html);
@@ -653,14 +653,14 @@ namespace
             if (relativePath.startsWith(u'/'))
                 relativePath = relativePath.mid(1);
 
+            QString absoluteUrl;
             if (!host.isEmpty())
-            {
-                normalizedBaseUrl = defaultScheme + u":" + host;
-            }
+                absoluteUrl = defaultScheme + u":" + host;
+            else
+                absoluteUrl = normalizedBaseUrl + relativePath;
             const QString fullMatch = match.captured(0);
             const QString prefix = match.captured(1);
             const QString suffix = match.captured(7);
-            const QString absoluteUrl = normalizedBaseUrl + relativePath;
 
             html.replace(fullMatch, (prefix + absoluteUrl + suffix));
         }

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -612,10 +612,10 @@ void RSSWidget::renderArticle(const RSS::Article *article) const
 
         html += u"<pre>" + description + u"</pre>";
     }
-    // Supplement relative path to absolute path
 
+    // Supplement relative path to absolute path
     const QUrl url {article->link()};
-    const QString basePath = url.scheme() + u"://" + url.host();
+    const QString basePath = url.toString(QUrl::RemovePath | QUrl::RemoveQuery);
     convertRelativePathToAbsolute(html, basePath);
     html += u"</div>";
     m_ui->textBrowser->setHtml(html);
@@ -623,11 +623,8 @@ void RSSWidget::renderArticle(const RSS::Article *article) const
 
 void convertRelativePathToAbsolute(QString &html, const QString &basePath)
 {
-    QRegularExpression rx;
-    rx.setPatternOptions(QRegularExpression::CaseInsensitiveOption);
-    // href regex
-    rx.setPattern(
-        uR"(((<a\s+[^>]*?href|<img\s+[^>]*?src)\s*=\s*["'])((https?|ftp):)?(\/\/[^\/]*)?(\/?[^\/"].*?)(["']))"_s);
+    const QRegularExpression rx {uR"(((<a\s+[^>]*?href|<img\s+[^>]*?src)\s*=\s*["'])((https?|ftp):)?(\/\/[^\/]*)?(\/?[^\/"].*?)(["']))"_s
+        , QRegularExpression::CaseInsensitiveOption};
 
     QString normalizedBasePath = basePath.endsWith(u'/') ? basePath : basePath + u'/';
     QRegularExpressionMatchIterator iter = rx.globalMatch(html);
@@ -635,8 +632,8 @@ void convertRelativePathToAbsolute(QString &html, const QString &basePath)
     while (iter.hasNext())
     {
         const QRegularExpressionMatch match = iter.next();
-        const QString &scheme = match.captured(4);
-        const QString &host = match.captured(5);
+        const QString scheme = match.captured(4);
+        const QString host = match.captured(5);
         if (!scheme.isEmpty())
         {
             if (host.isEmpty())
@@ -653,11 +650,11 @@ void convertRelativePathToAbsolute(QString &html, const QString &basePath)
         if (!host.isEmpty())
             normalizedBasePath = u"http:" + host;
 
-        const QString &fullMatch = match.captured(0);
-        const QString &prefix = match.captured(1);
-        const QString &suffix = match.captured(7);
+        const QString fullMatch = match.captured(0);
+        const QString prefix = match.captured(1);
+        const QString suffix = match.captured(7);
         const QString absolutePath = normalizedBasePath + relativePath;
 
-        html.replace(fullMatch, prefix + absolutePath + suffix);
+        html.replace(fullMatch, (prefix + absolutePath + suffix));
     }
 }

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -63,7 +63,7 @@ namespace
         const QRegularExpression rx {uR"(((<a\s+[^>]*?href|<img\s+[^>]*?src)\s*=\s*["'])((https?|ftp):)?(\/\/[^\/]*)?(\/?[^\/"].*?)(["']))"_s
             , QRegularExpression::CaseInsensitiveOption};
 
-        const QString normalizedBaseUrl = baseUrl.endsWith(u'/') ? baseUrl : baseUrl + u'/';
+        const QString normalizedBaseUrl = baseUrl.endsWith(u'/') ? baseUrl : (baseUrl + u'/');
         const QUrl url {normalizedBaseUrl};
         const QString defaultScheme = url.scheme();
         QRegularExpressionMatchIterator iter = rx.globalMatch(html);
@@ -87,7 +87,7 @@ namespace
                 relativePath = relativePath.mid(1);
 
             const QString absoluteUrl = !host.isEmpty()
-                    ? QString(defaultScheme + u":" + host) : QString(normalizedBaseUrl + relativePath);
+                    ? QString(defaultScheme + u':' + host) : (normalizedBaseUrl + relativePath);
             const QString fullMatch = match.captured(0);
             const QString prefix = match.captured(1);
             const QString suffix = match.captured(7);

--- a/src/gui/rss/rsswidget.cpp
+++ b/src/gui/rss/rsswidget.cpp
@@ -654,7 +654,7 @@ namespace
                 relativePath = relativePath.mid(1);
 
             const QString absoluteUrl = !host.isEmpty()
-                    ? (defaultScheme + u":" + host) : (normalizedBaseUrl + relativePath);
+                    ? QString(defaultScheme + u":" + host) : QString(normalizedBaseUrl + relativePath);
             const QString fullMatch = match.captured(0);
             const QString prefix = match.captured(1);
             const QString suffix = match.captured(7);

--- a/src/gui/rss/rsswidget.h
+++ b/src/gui/rss/rsswidget.h
@@ -91,7 +91,6 @@ private slots:
 
 private:
     bool eventFilter(QObject *obj, QEvent *event) override;
-    void convertRelativePathToAbsolute(QString &html, const QString &basePath) const;
     void renderArticle(const RSS::Article *article) const;
 
     Ui::RSSWidget *m_ui = nullptr;

--- a/src/gui/rss/rsswidget.h
+++ b/src/gui/rss/rsswidget.h
@@ -91,6 +91,7 @@ private slots:
 
 private:
     bool eventFilter(QObject *obj, QEvent *event) override;
+    void convertRelativePathToAbsolute(QString &html, const QString &basePath) const;
     void renderArticle(const RSS::Article *article) const;
 
     Ui::RSSWidget *m_ui = nullptr;


### PR DESCRIPTION
In RSS widget, a relative url will cause an infinite loop loading for resource, which won't break until unselect the article explicitly, thus caused the memory leak described in #20117 .

The code provides a conversion over the first 3 forms of relative path as described in [MDN web docs](https://developer.mozilla.org/en-US/docs/Learn/Common_questions/Web_mechanics/What_is_a_URL#absolute_urls_vs._relative_urls) using regex, and only function on `<a href>` and `<img src>` html tags. With the code, RSS widget now should follow the correct absolute urls.

However, the #20117 could not be fully closed with the code, as now log shows the RSS widget still send around 5 reqs/sec in the condition which was causing a rapid flow of qDebug log which indicates it stuck on a infinite loop sending requests, failing fast and immediately retries. The former situation is eating up a single CPU core at 100% and 3 MiB/s RAM increase, while the latter at below 10% CPU usage and 1 MiB/s RAM.
![image](https://github.com/user-attachments/assets/c6763171-35ed-47ad-ae94-f3fbd58ce7de)
From the snapshot you could know the url is correct, but with no valid response (QNetworkReply::RemoteHostClosedError) and I don't know why. The fact is that the site `byr.pt` is an IPv6 only site and the url will provide an 30x jump to another path.

Happy with any assistance or suggestions on further improvements. 😃 🚀  