### PR TITLE
WebUI: Add missing icon to 'Queue' context menu item

### DIFF
--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -188,7 +188,7 @@
         <li class="separator"><a href="#forceRecheck"><img src="images/force-recheck.svg" alt="QBT_TR(Force recheck)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Force recheck)QBT_TR[CONTEXT=TransferListWidget]</a></li>
         <li><a href="#forceReannounce"><img src="images/reannounce.svg" alt="QBT_TR(Force reannounce)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Force reannounce)QBT_TR[CONTEXT=TransferListWidget]</a></li>
         <li id="queueingMenuItems" class="separator">
-            <a href="#queue" class="arrow-right"><span style="display: inline-block; width:16px"></span> QBT_TR(Queue)QBT_TR[CONTEXT=TransferListWidget]</a>
+            <a href="#queue" class="arrow-right"><img src="images/queued.svg" alt="QBT_TR(Queue)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Queue)QBT_TR[CONTEXT=TransferListWidget]</a>
             <ul>
                 <li><a href="#queueTop"><img src="images/go-top.svg" alt="QBT_TR(Move to top)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Move to top)QBT_TR[CONTEXT=TransferListWidget]</a></li>
                 <li><a href="#queueUp"><img src="images/go-up.svg" alt="QBT_TR(Move up)QBT_TR[CONTEXT=TransferListWidget]"> QBT_TR(Move up)QBT_TR[CONTEXT=TransferListWidget]</a></li>


### PR DESCRIPTION
This PR adds missing icon to 'Queue' context menu item:

![image](https://github.com/user-attachments/assets/0e18c9c6-843b-4abb-84d8-f05363a908d8)
