### PR TITLE
Add eXact Length parameter when creating magnet URI

### DIFF
--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -2863,6 +2863,11 @@ QString TorrentImpl::createMagnetURI() const
         ret += u"&dn=" + QString::fromLatin1(QUrl::toPercentEncoding(displayName));
     }
 
+    if (hasMetadata())
+    {
+        ret += u"&xl=" + QString::number(totalSize());
+    }    
+
     for (const TrackerEntryStatus &tracker : asConst(trackers()))
     {
         ret += u"&tr=" + QString::fromLatin1(QUrl::toPercentEncoding(tracker.url));

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -2866,7 +2866,7 @@ QString TorrentImpl::createMagnetURI() const
     if (hasMetadata())
     {
         ret += u"&xl=" + QString::number(totalSize());
-    }    
+    }
 
     for (const TrackerEntryStatus &tracker : asConst(trackers()))
     {


### PR DESCRIPTION
Include the `xl` (eXact Length) parameter in the magnet URI string inside the function `TorrentImpl::createMagnetURI()`.

Closes #20752.