### PR TITLE
WebUI: Add Web App manifest to allow standalone usage

### DIFF
--- a/src/webui/www/package.json
+++ b/src/webui/www/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/qbittorrent/qBittorrent.git"
   },
   "scripts": {
-    "format": "js-beautify -r *.mjs private/*.html private/scripts/*.js private/views/*.html public/*.html public/scripts/*.js public/*.json && prettier --write **.css",
+    "format": "js-beautify -r *.mjs private/*.html private/scripts/*.js private/views/*.html public/*.html public/*.json public/scripts/*.js && prettier --write **.css",
     "lint": "eslint *.mjs private/*.html private/scripts/*.js private/views/*.html public/*.html public/scripts/*.js && stylelint **/*.css && html-validate private public"
   },
   "devDependencies": {

--- a/src/webui/www/package.json
+++ b/src/webui/www/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/qbittorrent/qBittorrent.git"
   },
   "scripts": {
-    "format": "js-beautify -r *.mjs private/*.html private/scripts/*.js private/views/*.html public/*.html public/scripts/*.js && prettier --write **.css",
+    "format": "js-beautify -r *.mjs private/*.html private/scripts/*.js private/views/*.html public/*.html public/scripts/*.js public/*.json && prettier --write **.css",
     "lint": "eslint *.mjs private/*.html private/scripts/*.js private/views/*.html public/*.html public/scripts/*.js && stylelint **/*.css && html-validate private public"
   },
   "devDependencies": {

--- a/src/webui/www/public/index.html
+++ b/src/webui/www/public/index.html
@@ -15,6 +15,7 @@
     <noscript>
         <link rel="stylesheet" type="text/css" href="css/noscript.css?v=${CACHEID}">
     </noscript>
+    <link rel="manifest" href="manifest.json?v=${CACHEID}">
 
     <script defer src="scripts/login.js?locale=${LANG}&v=${CACHEID}"></script>
 </head>

--- a/src/webui/www/public/manifest.json
+++ b/src/webui/www/public/manifest.json
@@ -1,0 +1,13 @@
+{
+    "name": "QBT_TR(qBittorrent WebUI)QBT_TR[CONTEXT=Login]",
+    "icons": [{
+        "src": "images/qbittorrent32.png",
+        "sizes": "32x32",
+        "type": "image/png"
+    }, {
+        "src": "images/qbittorrent-tray.svg",
+        "sizes": "any",
+        "type": "image/svg+xml"
+    }],
+    "display": "standalone"
+}

--- a/src/webui/www/tstool.py
+++ b/src/webui/www/tstool.py
@@ -35,7 +35,7 @@ import re
 import sys
 import xml.etree.ElementTree as ET
 
-accepted_exts = [".js", ".html", ".css"]
+accepted_exts = [".js", ".html", ".css", ".json"]
 
 no_obsolete = False
 www_folder = "."

--- a/src/webui/www/webui.qrc
+++ b/src/webui/www/webui.qrc
@@ -447,6 +447,7 @@
         <file>public/images/qbittorrent-tray.svg</file>
         <file>public/images/qbittorrent32.png</file>
         <file>public/index.html</file>
+        <file>public/manifest.json</file>
         <file>public/scripts/login.js</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
### Why

I love the WebUI and use it regularly on multiple devices. I've installed it on my homepage of my iPhone so it looks like an app of its own - but it just opens in the browser when I click on it. I would like it to function less like another webpage that opens in a browser tab, and more like a app of its own with its own window.

### What

To get an app-like feel, all that is needed in a little `manifest.json` file. So I add that file in this PR. I've tried my best to match the existing logic - adding it to the auto formatter and (hopefully) getting translation working correctly. I don't expect this PR to be approved and merged without some discussion of its merits  - but hopefully this gets the ball rolling and we can see where it ends up.

### Testing

I'm using a mac... I was able to get a successful run of the build commands, but when I try to actually open the app, it just crashes. I think I might not have everything setup correctly with Qt. So... unfortunately that means this PR is fully untested. If there are any docs I can read, please let me know. Otherwise, maybe this PR will still be useful for a discussion if this feature is even wanted by the project or not. I tried searching in advanced, and I couldn't find any similar requests.