### PR TITLE
Sort grid items properly

### DIFF
--- a/.github/workflows/ci_python.yaml
+++ b/.github/workflows/ci_python.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Lint code (auxiliary scripts)
         run: |
           pyflakes $PY_FILES
-          bandit --skip B314,B405 $PY_FILES
+          bandit --skip B101,B314,B405 $PY_FILES
 
       - name: Format code (auxiliary scripts)
         run: |
@@ -61,7 +61,7 @@ jobs:
           echo $PY_FILES
           echo "PY_FILES=$PY_FILES" >> "$GITHUB_ENV"
 
-      - name: Check typings  (search engine)
+      - name: Check typings (search engine)
         run: |
           MYPYPATH="src/searchengine/nova3" \
           mypy \

--- a/.github/workflows/helper/pre-commit/check_grid_items_order.py
+++ b/.github/workflows/helper/pre-commit/check_grid_items_order.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+# A pre-commit hook for checking items order in grid layouts
+# Copyright (C) 2024  Mike Tzou (Chocobo1)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# In addition, as a special exception, the copyright holders give permission to
+# link this program with the OpenSSL project's "OpenSSL" library (or with
+# modified versions of it that use the same license as the "OpenSSL" library),
+# and distribute the linked executables. You must obey the GNU General Public
+# License in all respects for all of the code used other than "OpenSSL".  If you
+# modify file(s), you may extend this exception to your version of the file(s),
+# but you are not obligated to do so. If you do not wish to do so, delete this
+# exception statement from your version.
+
+from collections.abc import Callable, Sequence
+from typing import Optional
+import argparse
+import re
+import xml.etree.ElementTree as ElementTree
+import sys
+
+
+def traversePostOrder(root: ElementTree.Element, visitFunc: Callable[[ElementTree.Element], None]) -> None:
+    stack = [(root, False)]
+
+    while len(stack) > 0:
+        (element, visit) = stack.pop()
+        if visit:
+            visitFunc(element)
+        else:
+            stack.append((element, True))
+            stack.extend((child, False) for child in reversed(element))
+
+
+def modifyElement(element: ElementTree.Element) -> None:
+    def getSortKey(e: ElementTree.Element) -> tuple[int, int]:
+        if e.tag == 'item':
+            return (int(e.attrib['row']), int(e.attrib['column']))
+        return (-1, -1)  # don't care
+
+    if element.tag == 'layout' and element.attrib['class'] == 'QGridLayout' and len(element) > 0:
+        element[:] = sorted(element, key=getSortKey)
+
+    # workaround_2a: ElementTree will unescape `&quot;` and we need to escape it back
+    if element.tag == 'string' and element.text is not None:
+        element.text = element.text.replace('"', '&quot;')
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('filenames', nargs='*', help='Filenames to check')
+    args = parser.parse_args(argv)
+
+    for filename in args.filenames:
+        with open(filename, 'r+') as f:
+            orig = f.read()
+            root = ElementTree.fromstring(orig)
+            traversePostOrder(root, modifyElement)
+            ElementTree.indent(root, ' ')
+
+            # workaround_1: cannot use `xml_declaration=True` since it uses single quotes instead of Qt preferred double quotes
+            ret = f'<?xml version="1.0" encoding="UTF-8"?>\n{ElementTree.tostring(root, 'unicode')}\n'
+
+            # workaround_2b: ElementTree will turn `&quot;` into `&amp;quot;`, so revert it back
+            ret = ret.replace('&amp;quot;', '&quot;')
+
+            # workaround_3: Qt prefers no whitespaces in self-closing tags
+            ret = re.sub('<(.+) +/>', r'<\1/>', ret)
+
+            if ret != orig:
+                f.seek(0)
+                f.write(ret)
+                f.truncate()
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/workflows/helper/pre-commit/check_grid_items_order.py
+++ b/.github/workflows/helper/pre-commit/check_grid_items_order.py
@@ -82,6 +82,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             ret = re.sub('<(.+) +/>', r'<\1/>', ret)
 
             if ret != orig:
+                print(f'Tip: run this script to apply the fix: `python {__file__} {filename}`', file=sys.stderr)
+
                 f.seek(0)
                 f.write(ret)
                 f.truncate()

--- a/.github/workflows/helper/pre-commit/check_translation_tag.py
+++ b/.github/workflows/helper/pre-commit/check_translation_tag.py
@@ -26,9 +26,11 @@
 # but you are not obligated to do so. If you do not wish to do so, delete this
 # exception statement from your version.
 
-from typing import Optional, Sequence
+from collections.abc import Sequence
+from typing import Optional
 import argparse
 import re
+import sys
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
@@ -67,4 +69,4 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
 
 if __name__ == '__main__':
-    exit(main())
+    sys.exit(main())

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,12 @@
 repos:
   - repo: local
     hooks:
+      - id: check-grid-order
+        name: Check items order in grid layouts
+        entry: .github/workflows/helper/pre-commit/check_grid_items_order.py
+        language: script
+        files: \.ui$
+
       - id: check-translation-tag
         name: Check newline characters in <translation> tag
         entry: .github/workflows/helper/pre-commit/check_translation_tag.py

--- a/src/gui/aboutdialog.ui
+++ b/src/gui/aboutdialog.ui
@@ -90,10 +90,38 @@
           <string>Current maintainer</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_4">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_14">
+            <property name="text">
+             <string>Name:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="label_17">
+            <property name="text">
+             <string notr="true">Sledgehammer999</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_15">
+            <property name="text">
+             <string>Nationality:</string>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="1">
            <widget class="QLabel" name="label_18">
             <property name="text">
              <string>Greece</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_16">
+            <property name="text">
+             <string>E-mail:</string>
             </property>
            </widget>
           </item>
@@ -107,34 +135,6 @@
             </property>
             <property name="textInteractionFlags">
              <set>Qt::TextInteractionFlag::LinksAccessibleByMouse|Qt::TextInteractionFlag::TextSelectableByMouse</set>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_15">
-            <property name="text">
-             <string>Nationality:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_16">
-            <property name="text">
-             <string>E-mail:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_14">
-            <property name="text">
-             <string>Name:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLabel" name="label_17">
-            <property name="text">
-             <string notr="true">Sledgehammer999</string>
             </property>
            </widget>
           </item>
@@ -160,10 +160,10 @@
           <string>Original author</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_5">
-          <item row="1" column="1">
-           <widget class="QLabel" name="label_7">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_3">
             <property name="text">
-             <string>France</string>
+             <string>Name:</string>
             </property>
            </widget>
           </item>
@@ -171,6 +171,27 @@
            <widget class="QLabel" name="label_2">
             <property name="text">
              <string notr="true">Christophe Dumez</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Nationality:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="label_7">
+            <property name="text">
+             <string>France</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>E-mail:</string>
             </property>
            </widget>
           </item>
@@ -184,27 +205,6 @@
             </property>
             <property name="textInteractionFlags">
              <set>Qt::TextInteractionFlag::LinksAccessibleByMouse|Qt::TextInteractionFlag::TextSelectableByMouse</set>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="text">
-             <string>Name:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string>E-mail:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_4">
-            <property name="text">
-             <string>Nationality:</string>
             </property>
            </widget>
           </item>
@@ -365,8 +365,54 @@
        </item>
        <item>
         <layout class="QGridLayout" name="gridLayout">
-         <item row="2" column="2">
-          <widget class="QLabel" name="labelBoostVer">
+         <item row="0" column="1">
+          <widget class="QLabel" name="labelQt">
+           <property name="text">
+            <string notr="true">Qt:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::TextInteractionFlag::LinksAccessibleByMouse|Qt::TextInteractionFlag::TextSelectableByMouse</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="labelQtVer">
+           <property name="textInteractionFlags">
+            <set>Qt::TextInteractionFlag::LinksAccessibleByMouse|Qt::TextInteractionFlag::TextSelectableByMouse</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <spacer name="horizontalSpacer_4">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLabel" name="labelLibt">
+           <property name="text">
+            <string notr="true">Libtorrent:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::TextInteractionFlag::LinksAccessibleByMouse|Qt::TextInteractionFlag::TextSelectableByMouse</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="labelLibtVer">
            <property name="textInteractionFlags">
             <set>Qt::TextInteractionFlag::LinksAccessibleByMouse|Qt::TextInteractionFlag::TextSelectableByMouse</set>
            </property>
@@ -385,32 +431,6 @@
            </property>
           </spacer>
          </item>
-         <item row="0" column="1">
-          <widget class="QLabel" name="labelQt">
-           <property name="text">
-            <string notr="true">Qt:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-           </property>
-           <property name="textInteractionFlags">
-            <set>Qt::TextInteractionFlag::LinksAccessibleByMouse|Qt::TextInteractionFlag::TextSelectableByMouse</set>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QLabel" name="labelLibt">
-           <property name="text">
-            <string notr="true">Libtorrent:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-           </property>
-           <property name="textInteractionFlags">
-            <set>Qt::TextInteractionFlag::LinksAccessibleByMouse|Qt::TextInteractionFlag::TextSelectableByMouse</set>
-           </property>
-          </widget>
-         </item>
          <item row="2" column="1">
           <widget class="QLabel" name="labelBoost">
            <property name="text">
@@ -424,32 +444,12 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="2">
-          <widget class="QLabel" name="labelQtVer">
+         <item row="2" column="2">
+          <widget class="QLabel" name="labelBoostVer">
            <property name="textInteractionFlags">
             <set>Qt::TextInteractionFlag::LinksAccessibleByMouse|Qt::TextInteractionFlag::TextSelectableByMouse</set>
            </property>
           </widget>
-         </item>
-         <item row="1" column="2">
-          <widget class="QLabel" name="labelLibtVer">
-           <property name="textInteractionFlags">
-            <set>Qt::TextInteractionFlag::LinksAccessibleByMouse|Qt::TextInteractionFlag::TextSelectableByMouse</set>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <spacer name="horizontalSpacer_4">
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
-          </spacer>
          </item>
          <item row="3" column="1">
           <widget class="QLabel" name="labelOpenssl">

--- a/src/gui/aboutdialog.ui
+++ b/src/gui/aboutdialog.ui
@@ -75,6 +75,9 @@
          <property name="openExternalLinks">
           <bool>true</bool>
          </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextInteractionFlag::LinksAccessibleByKeyboard|Qt::TextInteractionFlag::LinksAccessibleByMouse</set>
+         </property>
         </widget>
        </item>
       </layout>

--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -378,6 +378,26 @@
               <string>Torrent information</string>
              </property>
              <layout class="QGridLayout" name="gridLayout_2">
+              <item row="0" column="0">
+               <widget class="QLabel" name="labelSize">
+                <property name="text">
+                 <string>Size:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QLabel" name="labelSizeData"/>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="labelDate">
+                <property name="text">
+                 <string>Date:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QLabel" name="labelDateData"/>
+              </item>
               <item row="2" column="0">
                <widget class="QLabel" name="labelInfohash1">
                 <property name="text">
@@ -385,11 +405,36 @@
                 </property>
                </widget>
               </item>
-              <item row="0" column="1">
-               <widget class="QLabel" name="labelSizeData"/>
+              <item row="2" column="1">
+               <widget class="QLabel" name="labelInfohash1Data">
+                <property name="textInteractionFlags">
+                 <set>Qt::TextInteractionFlag::TextSelectableByMouse</set>
+                </property>
+               </widget>
               </item>
-              <item row="1" column="1">
-               <widget class="QLabel" name="labelDateData"/>
+              <item row="3" column="0">
+               <widget class="QLabel" name="labelInfohash2">
+                <property name="text">
+                 <string>Info hash v2:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="QLabel" name="labelInfohash2Data">
+                <property name="textInteractionFlags">
+                 <set>Qt::TextInteractionFlag::TextSelectableByMouse</set>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="0">
+               <widget class="QLabel" name="labelComment">
+                <property name="text">
+                 <string>Comment:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+                </property>
+               </widget>
               </item>
               <item row="4" column="1">
                <widget class="QScrollArea" name="scrollArea">
@@ -445,51 +490,6 @@
                   </item>
                  </layout>
                 </widget>
-               </widget>
-              </item>
-              <item row="4" column="0">
-               <widget class="QLabel" name="labelComment">
-                <property name="text">
-                 <string>Comment:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="labelSize">
-                <property name="text">
-                 <string>Size:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QLabel" name="labelInfohash1Data">
-                <property name="textInteractionFlags">
-                 <set>Qt::TextInteractionFlag::TextSelectableByMouse</set>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="labelDate">
-                <property name="text">
-                 <string>Date:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="labelInfohash2">
-                <property name="text">
-                 <string>Info hash v2:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1">
-               <widget class="QLabel" name="labelInfohash2Data">
-                <property name="textInteractionFlags">
-                 <set>Qt::TextInteractionFlag::TextSelectableByMouse</set>
-                </property>
                </widget>
               </item>
              </layout>

--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -484,7 +484,7 @@
                      <bool>true</bool>
                     </property>
                     <property name="textInteractionFlags">
-                     <set>Qt::TextInteractionFlag::TextBrowserInteraction</set>
+                     <set>Qt::TextInteractionFlag::TextSelectableByKeyboard|Qt::TextInteractionFlag::TextSelectableByMouse</set>
                     </property>
                    </widget>
                   </item>

--- a/src/gui/banlistoptionsdialog.ui
+++ b/src/gui/banlistoptionsdialog.ui
@@ -102,12 +102,6 @@
    </item>
   </layout>
  </widget>
- <tabstops>
-  <tabstop>bannedIPList</tabstop>
-  <tabstop>txtIP</tabstop>
-  <tabstop>buttonBanIP</tabstop>
-  <tabstop>buttonDeleteIP</tabstop>
- </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/gui/ipsubnetwhitelistoptionsdialog.ui
+++ b/src/gui/ipsubnetwhitelistoptionsdialog.ui
@@ -86,12 +86,6 @@
    </item>
   </layout>
  </widget>
- <tabstops>
-  <tabstop>whitelistedIPSubnetList</tabstop>
-  <tabstop>txtIPSubnet</tabstop>
-  <tabstop>buttonWhitelistIPSubnet</tabstop>
-  <tabstop>buttonDeleteIPSubnet</tabstop>
- </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -1496,6 +1496,9 @@ readme.txt: filter exact file name.
 ?.txt: filter 'a.txt', 'b.txt' but not 'aa.txt'.
 readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</string>
                  </property>
+                 <property name="tabChangesFocus">
+                  <bool>true</bool>
+                 </property>
                  <property name="lineWrapMode">
                   <enum>QPlainTextEdit::LineWrapMode::NoWrap</enum>
                  </property>
@@ -3136,7 +3139,11 @@ Disable encryption: Only connect to peers without protocol encryption</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_16">
                <item row="0" column="0">
-                <widget class="QPlainTextEdit" name="textTrackers"/>
+                <widget class="QPlainTextEdit" name="textTrackers">
+                 <property name="tabChangesFocus">
+                  <bool>true</bool>
+                 </property>
+                </widget>
                </item>
               </layout>
              </widget>
@@ -3326,7 +3333,11 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                 </widget>
                </item>
                <item>
-                <widget class="QPlainTextEdit" name="textSmartEpisodeFilters"/>
+                <widget class="QPlainTextEdit" name="textSmartEpisodeFilters">
+                 <property name="tabChangesFocus">
+                  <bool>true</bool>
+                 </property>
+                </widget>
                </item>
               </layout>
              </widget>
@@ -3785,6 +3796,9 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
                  <layout class="QVBoxLayout" name="verticalLayout_8">
                   <item>
                    <widget class="QPlainTextEdit" name="textWebUICustomHTTPHeaders">
+                    <property name="tabChangesFocus">
+                     <bool>true</bool>
+                    </property>
                     <property name="lineWrapMode">
                      <enum>QPlainTextEdit::LineWrapMode::NoWrap</enum>
                     </property>

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -361,6 +361,19 @@
                     </item>
                    </widget>
                   </item>
+                  <item row="0" column="2">
+                   <spacer name="horizontalSpacer_12">
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
                   <item row="1" column="0">
                    <widget class="QLabel" name="lblUploadList">
                     <property name="text">
@@ -396,19 +409,6 @@
                      </property>
                     </item>
                    </widget>
-                  </item>
-                  <item row="0" column="2">
-                   <spacer name="horizontalSpacer_12">
-                    <property name="orientation">
-                     <enum>Qt::Orientation::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
                   </item>
                  </layout>
                 </widget>
@@ -1518,8 +1518,18 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
               <layout class="QVBoxLayout" name="verticalLayout_171">
                <item>
                 <layout class="QGridLayout" name="gridLayout_9">
-                 <item row="1" column="1">
-                  <widget class="QLineEdit" name="lineEditDestEmail"/>
+                 <item row="0" column="0">
+                  <widget class="QLabel" name="label_25">
+                   <property name="toolTip">
+                    <string>Sender</string>
+                   </property>
+                   <property name="text">
+                    <string comment="From sender">From:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="1">
+                  <widget class="QLineEdit" name="senderEmailTxt"/>
                  </item>
                  <item row="1" column="0">
                   <widget class="QLabel" name="label_2">
@@ -1531,6 +1541,9 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                    </property>
                   </widget>
                  </item>
+                 <item row="1" column="1">
+                  <widget class="QLineEdit" name="lineEditDestEmail"/>
+                 </item>
                  <item row="2" column="0">
                   <widget class="QLabel" name="label_3">
                    <property name="text">
@@ -1540,19 +1553,6 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                  </item>
                  <item row="2" column="1">
                   <widget class="QLineEdit" name="lineEditSmtpServer"/>
-                 </item>
-                 <item row="0" column="1">
-                  <widget class="QLineEdit" name="senderEmailTxt"/>
-                 </item>
-                 <item row="0" column="0">
-                  <widget class="QLabel" name="label_25">
-                   <property name="toolTip">
-                    <string>Sender</string>
-                   </property>
-                   <property name="text">
-                    <string comment="From sender">From:</string>
-                   </property>
-                  </widget>
                  </item>
                 </layout>
                </item>
@@ -1824,26 +1824,6 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                <string>Connections Limits</string>
               </property>
               <layout class="QGridLayout" name="gridLayout">
-               <item row="3" column="1">
-                <widget class="QSpinBox" name="spinMaxUploadsPerTorrent">
-                 <property name="maximum">
-                  <number>500</number>
-                 </property>
-                 <property name="value">
-                  <number>4</number>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="0">
-                <widget class="QCheckBox" name="checkMaxConnectionsPerTorrent">
-                 <property name="text">
-                  <string>Maximum number of connections per torrent:</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
                <item row="0" column="0">
                 <widget class="QCheckBox" name="checkMaxConnections">
                  <property name="text">
@@ -1870,6 +1850,29 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                  </property>
                 </widget>
                </item>
+               <item row="0" column="2">
+                <spacer name="horizontalSpacer_3">
+                 <property name="orientation">
+                  <enum>Qt::Orientation::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="1" column="0">
+                <widget class="QCheckBox" name="checkMaxConnectionsPerTorrent">
+                 <property name="text">
+                  <string>Maximum number of connections per torrent:</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
                <item row="1" column="1">
                 <widget class="QSpinBox" name="spinMaxConnecPerTorrent">
                  <property name="minimum">
@@ -1880,13 +1883,6 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                  </property>
                  <property name="value">
                   <number>100</number>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="0">
-                <widget class="QCheckBox" name="checkMaxUploadsPerTorrent">
-                 <property name="text">
-                  <string>Maximum number of upload slots per torrent:</string>
                  </property>
                 </widget>
                </item>
@@ -1907,18 +1903,22 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                  </property>
                 </widget>
                </item>
-               <item row="0" column="2">
-                <spacer name="horizontalSpacer_3">
-                 <property name="orientation">
-                  <enum>Qt::Orientation::Horizontal</enum>
+               <item row="3" column="0">
+                <widget class="QCheckBox" name="checkMaxUploadsPerTorrent">
+                 <property name="text">
+                  <string>Maximum number of upload slots per torrent:</string>
                  </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QSpinBox" name="spinMaxUploadsPerTorrent">
+                 <property name="maximum">
+                  <number>500</number>
                  </property>
-                </spacer>
+                 <property name="value">
+                  <number>4</number>
+                 </property>
+                </widget>
                </item>
               </layout>
              </widget>
@@ -1985,7 +1985,7 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                <item>
                 <widget class="QCheckBox" name="checkI2PMixed">
                  <property name="toolTip">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If &amp;quot;mixed mode&amp;quot; is enabled I2P torrents are allowed to also get peers from other sources than the tracker, and connect to regular IPs, not providing any anonymization. This may be useful if the user is not interested in the anonymization of I2P, but still wants to be able to connect to I2P peers.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If &quot;mixed mode&quot; is enabled I2P torrents are allowed to also get peers from other sources than the tracker, and connect to regular IPs, not providing any anonymization. This may be useful if the user is not interested in the anonymization of I2P, but still wants to be able to connect to I2P peers.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
                  <property name="text">
                   <string>Mixed mode</string>
@@ -2294,6 +2294,16 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                <string>Global Rate Limits</string>
               </property>
               <layout class="QGridLayout" name="rateLimitBoxLayout">
+               <item row="0" column="0" rowspan="2">
+                <widget class="QLabel" name="labelGlobalRate"/>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLabel" name="label_10">
+                 <property name="text">
+                  <string>Upload:</string>
+                 </property>
+                </widget>
+               </item>
                <item row="0" column="2">
                 <widget class="QSpinBox" name="spinUploadLimit">
                  <property name="specialValueText">
@@ -2310,6 +2320,26 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                  </property>
                  <property name="value">
                   <number>100</number>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="3">
+                <spacer name="horizontalSpacer">
+                 <property name="orientation">
+                  <enum>Qt::Orientation::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="label_11">
+                 <property name="text">
+                  <string>Download:</string>
                  </property>
                 </widget>
                </item>
@@ -2332,36 +2362,6 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                  </property>
                 </widget>
                </item>
-               <item row="0" column="0" rowspan="2">
-                <widget class="QLabel" name="labelGlobalRate"/>
-               </item>
-               <item row="0" column="3">
-                <spacer name="horizontalSpacer">
-                 <property name="orientation">
-                  <enum>Qt::Orientation::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item row="0" column="1">
-                <widget class="QLabel" name="label_10">
-                 <property name="text">
-                  <string>Upload:</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="1">
-                <widget class="QLabel" name="label_11">
-                 <property name="text">
-                  <string>Download:</string>
-                 </property>
-                </widget>
-               </item>
               </layout>
              </widget>
             </item>
@@ -2371,143 +2371,14 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                <string>Alternative Rate Limits</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_6">
-               <item row="1" column="2">
-                <widget class="QSpinBox" name="spinDownloadLimitAlt">
-                 <property name="specialValueText">
-                  <string>∞</string>
-                 </property>
-                 <property name="suffix">
-                  <string> KiB/s</string>
-                 </property>
-                 <property name="maximum">
-                  <number>2000000</number>
-                 </property>
-                 <property name="stepType">
-                  <enum>QAbstractSpinBox::StepType::AdaptiveDecimalStepType</enum>
-                 </property>
-                 <property name="value">
-                  <number>10</number>
-                 </property>
-                </widget>
-               </item>
                <item row="0" column="0" rowspan="2">
                 <widget class="QLabel" name="labelAltRate"/>
                </item>
-               <item row="2" column="0" colspan="4">
-                <widget class="QGroupBox" name="groupBoxSchedule">
-                 <property name="title">
-                  <string>Schedule &amp;the use of alternative rate limits</string>
+               <item row="0" column="1">
+                <widget class="QLabel" name="label_13">
+                 <property name="text">
+                  <string>Upload:</string>
                  </property>
-                 <property name="checkable">
-                  <bool>true</bool>
-                 </property>
-                 <property name="checked">
-                  <bool>false</bool>
-                 </property>
-                 <layout class="QGridLayout" name="gridLayout_7">
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="label_6">
-                    <property name="toolTip">
-                     <string>Start time</string>
-                    </property>
-                    <property name="text">
-                     <string comment="From start time">From:</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="3">
-                   <widget class="QTimeEdit" name="timeEditScheduleTo">
-                    <property name="wrapping">
-                     <bool>true</bool>
-                    </property>
-                    <property name="displayFormat">
-                     <string notr="true">hh:mm</string>
-                    </property>
-                    <property name="time">
-                     <time>
-                      <hour>20</hour>
-                      <minute>0</minute>
-                      <second>0</second>
-                     </time>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="2">
-                   <widget class="QLabel" name="label_17">
-                    <property name="toolTip">
-                     <string>End time</string>
-                    </property>
-                    <property name="text">
-                     <string comment="To end time">To:</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="1">
-                   <widget class="QTimeEdit" name="timeEditScheduleFrom">
-                    <property name="wrapping">
-                     <bool>true</bool>
-                    </property>
-                    <property name="displayFormat">
-                     <string notr="true">hh:mm</string>
-                    </property>
-                    <property name="calendarPopup">
-                     <bool>false</bool>
-                    </property>
-                    <property name="time">
-                     <time>
-                      <hour>8</hour>
-                      <minute>0</minute>
-                      <second>0</second>
-                     </time>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="0">
-                   <widget class="QLabel" name="label_18">
-                    <property name="text">
-                     <string>When:</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="1" colspan="3">
-                   <widget class="QComboBox" name="comboBoxScheduleDays">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <item>
-                     <property name="text">
-                      <string>Every day</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Weekdays</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Weekends</string>
-                     </property>
-                    </item>
-                   </widget>
-                  </item>
-                  <item row="0" column="4">
-                   <spacer name="horizontalSpacer_8">
-                    <property name="orientation">
-                     <enum>Qt::Orientation::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                 </layout>
                 </widget>
                </item>
                <item row="0" column="2">
@@ -2542,18 +2413,147 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                  </property>
                 </spacer>
                </item>
-               <item row="0" column="1">
-                <widget class="QLabel" name="label_13">
-                 <property name="text">
-                  <string>Upload:</string>
-                 </property>
-                </widget>
-               </item>
                <item row="1" column="1">
                 <widget class="QLabel" name="label_14">
                  <property name="text">
                   <string>Download:</string>
                  </property>
+                </widget>
+               </item>
+               <item row="1" column="2">
+                <widget class="QSpinBox" name="spinDownloadLimitAlt">
+                 <property name="specialValueText">
+                  <string>∞</string>
+                 </property>
+                 <property name="suffix">
+                  <string> KiB/s</string>
+                 </property>
+                 <property name="maximum">
+                  <number>2000000</number>
+                 </property>
+                 <property name="stepType">
+                  <enum>QAbstractSpinBox::StepType::AdaptiveDecimalStepType</enum>
+                 </property>
+                 <property name="value">
+                  <number>10</number>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0" colspan="4">
+                <widget class="QGroupBox" name="groupBoxSchedule">
+                 <property name="title">
+                  <string>Schedule &amp;the use of alternative rate limits</string>
+                 </property>
+                 <property name="checkable">
+                  <bool>true</bool>
+                 </property>
+                 <property name="checked">
+                  <bool>false</bool>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_7">
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="label_6">
+                    <property name="toolTip">
+                     <string>Start time</string>
+                    </property>
+                    <property name="text">
+                     <string comment="From start time">From:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QTimeEdit" name="timeEditScheduleFrom">
+                    <property name="wrapping">
+                     <bool>true</bool>
+                    </property>
+                    <property name="displayFormat">
+                     <string notr="true">hh:mm</string>
+                    </property>
+                    <property name="calendarPopup">
+                     <bool>false</bool>
+                    </property>
+                    <property name="time">
+                     <time>
+                      <hour>8</hour>
+                      <minute>0</minute>
+                      <second>0</second>
+                     </time>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="2">
+                   <widget class="QLabel" name="label_17">
+                    <property name="toolTip">
+                     <string>End time</string>
+                    </property>
+                    <property name="text">
+                     <string comment="To end time">To:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="3">
+                   <widget class="QTimeEdit" name="timeEditScheduleTo">
+                    <property name="wrapping">
+                     <bool>true</bool>
+                    </property>
+                    <property name="displayFormat">
+                     <string notr="true">hh:mm</string>
+                    </property>
+                    <property name="time">
+                     <time>
+                      <hour>20</hour>
+                      <minute>0</minute>
+                      <second>0</second>
+                     </time>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="4">
+                   <spacer name="horizontalSpacer_8">
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_18">
+                    <property name="text">
+                     <string>When:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1" colspan="3">
+                   <widget class="QComboBox" name="comboBoxScheduleDays">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <item>
+                     <property name="text">
+                      <string>Every day</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Weekdays</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Weekends</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                 </layout>
                 </widget>
                </item>
               </layout>
@@ -2839,6 +2839,19 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                  </property>
                 </widget>
                </item>
+               <item row="0" column="2">
+                <spacer name="horizontalSpacer_7">
+                 <property name="orientation">
+                  <enum>Qt::Orientation::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
                <item row="1" column="0">
                 <widget class="QLabel" name="label_max_active_up">
                  <property name="text">
@@ -2879,19 +2892,6 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                  </property>
                 </widget>
                </item>
-               <item row="0" column="2">
-                <spacer name="horizontalSpacer_7">
-                 <property name="orientation">
-                  <enum>Qt::Orientation::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
                <item row="3" column="0" colspan="3">
                 <widget class="QGroupBox" name="checkIgnoreSlowTorrentsForQueueing">
                  <property name="title">
@@ -2904,6 +2904,13 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                   <bool>false</bool>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_13">
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="labelDownloadRateForSlowTorrents">
+                    <property name="text">
+                     <string>Download rate threshold:</string>
+                    </property>
+                   </widget>
+                  </item>
                   <item row="0" column="1">
                    <widget class="QSpinBox" name="spinDownloadRateForSlowTorrents">
                     <property name="suffix">
@@ -2917,6 +2924,26 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                     </property>
                     <property name="value">
                      <number>2</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="2">
+                   <spacer name="horizontalSpacer_9">
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="labelUploadRateForSlowTorrents">
+                    <property name="text">
+                     <string>Upload rate threshold:</string>
                     </property>
                    </widget>
                   </item>
@@ -2936,32 +2963,12 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="1" column="0">
-                   <widget class="QLabel" name="labelUploadRateForSlowTorrents">
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="labelSlowTorrentInactivityTimer">
                     <property name="text">
-                     <string>Upload rate threshold:</string>
+                     <string>Torrent inactivity timer:</string>
                     </property>
                    </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="labelDownloadRateForSlowTorrents">
-                    <property name="text">
-                     <string>Download rate threshold:</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="2">
-                   <spacer name="horizontalSpacer_9">
-                    <property name="orientation">
-                     <enum>Qt::Orientation::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
                   </item>
                   <item row="2" column="1">
                    <widget class="QSpinBox" name="spinSlowTorrentsInactivityTimer">
@@ -2976,13 +2983,6 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                     </property>
                     <property name="value">
                      <number>60</number>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="labelSlowTorrentInactivityTimer">
-                    <property name="text">
-                     <string>Torrent inactivity timer:</string>
                     </property>
                    </widget>
                   </item>
@@ -3208,26 +3208,6 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                    </property>
                   </widget>
                  </item>
-                 <item row="1" column="1">
-                  <widget class="QSpinBox" name="spinRSSFetchDelay">
-                   <property name="suffix">
-                    <string> sec</string>
-                   </property>
-                   <property name="maximum">
-                    <number>2147483646</number>
-                   </property>
-                   <property name="value">
-                    <number>2</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="0">
-                  <widget class="QLabel" name="labelRSSFetchDelay">
-                   <property name="text">
-                    <string>Same host request delay:</string>
-                   </property>
-                  </widget>
-                 </item>
                  <item row="0" column="1">
                   <widget class="QSpinBox" name="spinRSSRefreshInterval">
                    <property name="suffix">
@@ -3257,13 +3237,23 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                    </property>
                   </spacer>
                  </item>
-                 <item row="2" column="1">
-                  <widget class="QSpinBox" name="spinRSSMaxArticlesPerFeed">
+                 <item row="1" column="0">
+                  <widget class="QLabel" name="labelRSSFetchDelay">
+                   <property name="text">
+                    <string>Same host request delay:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="1">
+                  <widget class="QSpinBox" name="spinRSSFetchDelay">
+                   <property name="suffix">
+                    <string> sec</string>
+                   </property>
                    <property name="maximum">
                     <number>2147483646</number>
                    </property>
                    <property name="value">
-                    <number>100</number>
+                    <number>2</number>
                    </property>
                   </widget>
                  </item>
@@ -3271,6 +3261,16 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                   <widget class="QLabel" name="label_12">
                    <property name="text">
                     <string>Maximum number of articles per feed:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="1">
+                  <widget class="QSpinBox" name="spinRSSMaxArticlesPerFeed">
+                   <property name="maximum">
+                    <number>2147483646</number>
+                   </property>
+                   <property name="value">
+                    <number>100</number>
                    </property>
                   </widget>
                  </item>
@@ -3462,12 +3462,8 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                   <bool>false</bool>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_11">
-                  <item row="1" column="1">
-                   <widget class="QLabel" name="lblWebUIKey">
-                    <property name="text">
-                     <string>Key:</string>
-                    </property>
-                   </widget>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="lblSslCertStatus"/>
                   </item>
                   <item row="0" column="1">
                    <widget class="QLabel" name="lblWebUICrt">
@@ -3476,11 +3472,21 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                     </property>
                    </widget>
                   </item>
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="lblSslCertStatus"/>
+                  <item row="0" column="2">
+                   <widget class="FileSystemPathLineEdit" name="textWebUIHttpsCert" native="true"/>
                   </item>
                   <item row="1" column="0">
                    <widget class="QLabel" name="lblSslKeyStatus"/>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QLabel" name="lblWebUIKey">
+                    <property name="text">
+                     <string>Key:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="2">
+                   <widget class="FileSystemPathLineEdit" name="textWebUIHttpsKey" native="true"/>
                   </item>
                   <item row="2" column="0" colspan="3">
                    <widget class="QLabel" name="lblWebUICertInfo">
@@ -3491,12 +3497,6 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                      <bool>true</bool>
                     </property>
                    </widget>
-                  </item>
-                  <item row="0" column="2">
-                   <widget class="FileSystemPathLineEdit" name="textWebUIHttpsCert" native="true"/>
-                  </item>
-                  <item row="1" column="2">
-                   <widget class="FileSystemPathLineEdit" name="textWebUIHttpsKey" native="true"/>
                   </item>
                  </layout>
                 </widget>
@@ -3574,6 +3574,16 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                       </property>
                      </widget>
                     </item>
+                    <item row="0" column="1">
+                     <widget class="QSpinBox" name="spinBanCounter">
+                      <property name="specialValueText">
+                       <string>Never</string>
+                      </property>
+                      <property name="maximum">
+                       <number>2147483647</number>
+                      </property>
+                     </widget>
+                    </item>
                     <item row="0" column="2">
                      <spacer name="horizontalSpacer_15">
                       <property name="orientation">
@@ -3586,16 +3596,6 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                        </size>
                       </property>
                      </spacer>
-                    </item>
-                    <item row="0" column="1">
-                     <widget class="QSpinBox" name="spinBanCounter">
-                      <property name="specialValueText">
-                       <string>Never</string>
-                      </property>
-                      <property name="maximum">
-                       <number>2147483647</number>
-                      </property>
-                     </widget>
                     </item>
                     <item row="1" column="0">
                      <widget class="QLabel" name="lblBanDuration">
@@ -3967,206 +3967,6 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
    <container>1</container>
   </customwidget>
  </customwidgets>
- <tabstops>
-  <tabstop>tabOption</tabstop>
-  <tabstop>tabSelection</tabstop>
-  <tabstop>comboLanguage</tabstop>
-  <tabstop>comboStyle</tabstop>
-  <tabstop>comboColorScheme</tabstop>
-  <tabstop>checkUseCustomTheme</tabstop>
-  <tabstop>customThemeFilePath</tabstop>
-  <tabstop>checkUseSystemIcon</tabstop>
-  <tabstop>buttonCustomizeUITheme</tabstop>
-  <tabstop>confirmDeletion</tabstop>
-  <tabstop>checkAltRowColors</tabstop>
-  <tabstop>checkHideZero</tabstop>
-  <tabstop>comboHideZero</tabstop>
-  <tabstop>actionTorrentDlOnDblClBox</tabstop>
-  <tabstop>actionTorrentFnOnDblClBox</tabstop>
-  <tabstop>checkBoxHideZeroStatusFilters</tabstop>
-  <tabstop>checkStartup</tabstop>
-  <tabstop>checkShowSplash</tabstop>
-  <tabstop>windowStateComboBox</tabstop>
-  <tabstop>checkProgramExitConfirm</tabstop>
-  <tabstop>checkProgramAutoExitConfirm</tabstop>
-  <tabstop>checkShowSystray</tabstop>
-  <tabstop>checkMinimizeToSysTray</tabstop>
-  <tabstop>checkCloseToSystray</tabstop>
-  <tabstop>comboTrayIcon</tabstop>
-  <tabstop>checkAssociateTorrents</tabstop>
-  <tabstop>checkAssociateMagnetLinks</tabstop>
-  <tabstop>checkProgramUpdates</tabstop>
-  <tabstop>checkPreventFromSuspendWhenDownloading</tabstop>
-  <tabstop>checkPreventFromSuspendWhenSeeding</tabstop>
-  <tabstop>checkFileLog</tabstop>
-  <tabstop>textFileLogPath</tabstop>
-  <tabstop>checkFileLogBackup</tabstop>
-  <tabstop>spinFileLogSize</tabstop>
-  <tabstop>checkFileLogDelete</tabstop>
-  <tabstop>spinFileLogAge</tabstop>
-  <tabstop>comboFileLogAgeType</tabstop>
-  <tabstop>checkBoxPerformanceWarning</tabstop>
-  <tabstop>scrollArea</tabstop>
-  <tabstop>checkAdditionDialog</tabstop>
-  <tabstop>checkAdditionDialogFront</tabstop>
-  <tabstop>contentLayoutComboBox</tabstop>
-  <tabstop>checkAddToQueueTop</tabstop>
-  <tabstop>checkAddStopped</tabstop>
-  <tabstop>stopConditionComboBox</tabstop>
-  <tabstop>checkMergeTrackers</tabstop>
-  <tabstop>checkConfirmMergeTrackers</tabstop>
-  <tabstop>deleteTorrentBox</tabstop>
-  <tabstop>deleteCancelledTorrentBox</tabstop>
-  <tabstop>checkPreallocateAll</tabstop>
-  <tabstop>checkAppendqB</tabstop>
-  <tabstop>checkUnwantedFolder</tabstop>
-  <tabstop>checkRecursiveDownload</tabstop>
-  <tabstop>comboSavingMode</tabstop>
-  <tabstop>comboTorrentCategoryChanged</tabstop>
-  <tabstop>comboCategoryDefaultPathChanged</tabstop>
-  <tabstop>comboCategoryChanged</tabstop>
-  <tabstop>checkUseSubcategories</tabstop>
-  <tabstop>checkUseCategoryPaths</tabstop>
-  <tabstop>textSavePath</tabstop>
-  <tabstop>checkUseDownloadPath</tabstop>
-  <tabstop>textDownloadPath</tabstop>
-  <tabstop>checkExportDir</tabstop>
-  <tabstop>textExportDir</tabstop>
-  <tabstop>checkExportDirFin</tabstop>
-  <tabstop>textExportDirFin</tabstop>
-  <tabstop>scanFoldersView</tabstop>
-  <tabstop>addWatchedFolderButton</tabstop>
-  <tabstop>editWatchedFolderButton</tabstop>
-  <tabstop>removeWatchedFolderButton</tabstop>
-  <tabstop>groupExcludedFileNames</tabstop>
-  <tabstop>textExcludedFileNames</tabstop>
-  <tabstop>groupMailNotification</tabstop>
-  <tabstop>senderEmailTxt</tabstop>
-  <tabstop>lineEditDestEmail</tabstop>
-  <tabstop>lineEditSmtpServer</tabstop>
-  <tabstop>checkSmtpSSL</tabstop>
-  <tabstop>groupMailNotifAuth</tabstop>
-  <tabstop>mailNotifUsername</tabstop>
-  <tabstop>mailNotifPassword</tabstop>
-  <tabstop>sendTestEmail</tabstop>
-  <tabstop>groupBoxRunOnAdded</tabstop>
-  <tabstop>lineEditRunOnAdded</tabstop>
-  <tabstop>groupBoxRunOnFinished</tabstop>
-  <tabstop>lineEditRunOnFinished</tabstop>
-  <tabstop>autoRunConsole</tabstop>
-  <tabstop>scrollArea_2</tabstop>
-  <tabstop>comboProtocol</tabstop>
-  <tabstop>spinPort</tabstop>
-  <tabstop>randomButton</tabstop>
-  <tabstop>checkUPnP</tabstop>
-  <tabstop>checkMaxConnections</tabstop>
-  <tabstop>spinMaxConnec</tabstop>
-  <tabstop>checkMaxConnectionsPerTorrent</tabstop>
-  <tabstop>spinMaxConnecPerTorrent</tabstop>
-  <tabstop>checkMaxUploads</tabstop>
-  <tabstop>spinMaxUploads</tabstop>
-  <tabstop>checkMaxUploadsPerTorrent</tabstop>
-  <tabstop>spinMaxUploadsPerTorrent</tabstop>
-  <tabstop>groupI2P</tabstop>
-  <tabstop>textI2PHost</tabstop>
-  <tabstop>spinI2PPort</tabstop>
-  <tabstop>checkI2PMixed</tabstop>
-  <tabstop>comboProxyType</tabstop>
-  <tabstop>textProxyIP</tabstop>
-  <tabstop>spinProxyPort</tabstop>
-  <tabstop>checkProxyHostnameLookup</tabstop>
-  <tabstop>checkProxyAuth</tabstop>
-  <tabstop>textProxyUsername</tabstop>
-  <tabstop>textProxyPassword</tabstop>
-  <tabstop>checkProxyBitTorrent</tabstop>
-  <tabstop>checkProxyPeerConnections</tabstop>
-  <tabstop>checkProxyRSS</tabstop>
-  <tabstop>checkProxyMisc</tabstop>
-  <tabstop>checkIPFilter</tabstop>
-  <tabstop>textFilterPath</tabstop>
-  <tabstop>IpFilterRefreshBtn</tabstop>
-  <tabstop>banListButton</tabstop>
-  <tabstop>checkIpFilterTrackers</tabstop>
-  <tabstop>scrollArea_3</tabstop>
-  <tabstop>spinUploadLimit</tabstop>
-  <tabstop>spinDownloadLimit</tabstop>
-  <tabstop>spinUploadLimitAlt</tabstop>
-  <tabstop>spinDownloadLimitAlt</tabstop>
-  <tabstop>groupBoxSchedule</tabstop>
-  <tabstop>timeEditScheduleFrom</tabstop>
-  <tabstop>timeEditScheduleTo</tabstop>
-  <tabstop>comboBoxScheduleDays</tabstop>
-  <tabstop>checkLimituTPConnections</tabstop>
-  <tabstop>checkLimitTransportOverhead</tabstop>
-  <tabstop>checkLimitLocalPeerRate</tabstop>
-  <tabstop>scrollArea_9</tabstop>
-  <tabstop>checkDHT</tabstop>
-  <tabstop>checkPeX</tabstop>
-  <tabstop>checkLSD</tabstop>
-  <tabstop>comboEncryption</tabstop>
-  <tabstop>checkAnonymousMode</tabstop>
-  <tabstop>spinBoxMaxActiveCheckingTorrents</tabstop>
-  <tabstop>checkEnableQueueing</tabstop>
-  <tabstop>spinMaxActiveDownloads</tabstop>
-  <tabstop>spinMaxActiveUploads</tabstop>
-  <tabstop>spinMaxActiveTorrents</tabstop>
-  <tabstop>checkIgnoreSlowTorrentsForQueueing</tabstop>
-  <tabstop>spinDownloadRateForSlowTorrents</tabstop>
-  <tabstop>spinUploadRateForSlowTorrents</tabstop>
-  <tabstop>spinSlowTorrentsInactivityTimer</tabstop>
-  <tabstop>checkMaxRatio</tabstop>
-  <tabstop>spinMaxRatio</tabstop>
-  <tabstop>checkMaxSeedingMinutes</tabstop>
-  <tabstop>spinMaxSeedingMinutes</tabstop>
-  <tabstop>checkMaxInactiveSeedingMinutes</tabstop>
-  <tabstop>spinMaxInactiveSeedingMinutes</tabstop>
-  <tabstop>comboRatioLimitAct</tabstop>
-  <tabstop>checkEnableAddTrackers</tabstop>
-  <tabstop>textTrackers</tabstop>
-  <tabstop>scrollArea_4</tabstop>
-  <tabstop>checkRSSEnable</tabstop>
-  <tabstop>spinRSSRefreshInterval</tabstop>
-  <tabstop>spinRSSFetchDelay</tabstop>
-  <tabstop>spinRSSMaxArticlesPerFeed</tabstop>
-  <tabstop>checkRSSAutoDownloaderEnable</tabstop>
-  <tabstop>btnEditRules</tabstop>
-  <tabstop>checkSmartFilterDownloadRepacks</tabstop>
-  <tabstop>textSmartEpisodeFilters</tabstop>
-  <tabstop>scrollArea_5</tabstop>
-  <tabstop>checkWebUI</tabstop>
-  <tabstop>textWebUIAddress</tabstop>
-  <tabstop>spinWebUIPort</tabstop>
-  <tabstop>checkWebUIUPnP</tabstop>
-  <tabstop>checkWebUIHttps</tabstop>
-  <tabstop>textWebUIHttpsCert</tabstop>
-  <tabstop>textWebUIHttpsKey</tabstop>
-  <tabstop>textWebUIUsername</tabstop>
-  <tabstop>textWebUIPassword</tabstop>
-  <tabstop>checkBypassLocalAuth</tabstop>
-  <tabstop>checkBypassAuthSubnetWhitelist</tabstop>
-  <tabstop>IPSubnetWhitelistButton</tabstop>
-  <tabstop>spinBanCounter</tabstop>
-  <tabstop>spinBanDuration</tabstop>
-  <tabstop>spinSessionTimeout</tabstop>
-  <tabstop>groupAltWebUI</tabstop>
-  <tabstop>textWebUIRootFolder</tabstop>
-  <tabstop>checkClickjacking</tabstop>
-  <tabstop>checkCSRFProtection</tabstop>
-  <tabstop>checkSecureCookie</tabstop>
-  <tabstop>groupHostHeaderValidation</tabstop>
-  <tabstop>textServerDomains</tabstop>
-  <tabstop>groupWebUIAddCustomHTTPHeaders</tabstop>
-  <tabstop>textWebUICustomHTTPHeaders</tabstop>
-  <tabstop>groupEnableReverseProxySupport</tabstop>
-  <tabstop>textTrustedReverseProxiesList</tabstop>
-  <tabstop>checkDynDNS</tabstop>
-  <tabstop>comboDNSService</tabstop>
-  <tabstop>registerDNSBtn</tabstop>
-  <tabstop>domainNameTxt</tabstop>
-  <tabstop>DNSUsernameTxt</tabstop>
-  <tabstop>DNSPasswordTxt</tabstop>
-  <tabstop>scrollArea_7</tabstop>
- </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -2750,6 +2750,9 @@ Disable encryption: Only connect to peers without protocol encryption</string>
                    <property name="openExternalLinks">
                     <bool>true</bool>
                    </property>
+                   <property name="textInteractionFlags">
+                    <set>Qt::TextInteractionFlag::LinksAccessibleByKeyboard|Qt::TextInteractionFlag::LinksAccessibleByMouse</set>
+                   </property>
                   </widget>
                  </item>
                  <item>
@@ -3496,6 +3499,9 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                     <property name="openExternalLinks">
                      <bool>true</bool>
                     </property>
+                    <property name="textInteractionFlags">
+                     <set>Qt::TextInteractionFlag::LinksAccessibleByKeyboard|Qt::TextInteractionFlag::LinksAccessibleByMouse</set>
+                    </property>
                    </widget>
                   </item>
                  </layout>
@@ -3696,6 +3702,9 @@ Specify an IPv4 or IPv6 address. You can specify &quot;0.0.0.0&quot; for any IPv
                     <property name="openExternalLinks">
                      <bool>true</bool>
                     </property>
+                    <property name="textInteractionFlags">
+                     <set>Qt::TextInteractionFlag::LinksAccessibleByKeyboard|Qt::TextInteractionFlag::LinksAccessibleByMouse</set>
+                    </property>
                    </widget>
                   </item>
                  </layout>
@@ -3817,7 +3826,13 @@ Use ';' to split multiple entries. Can use wildcard '*'.</string>
                   <item>
                    <widget class="QLabel" name="labelReverseProxyLink">
                     <property name="text">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/qbittorrent/qBittorrent/wiki#reverse-proxy-setup-for-webui-access&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Reverse proxy setup examples&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     <string>&lt;a href=https://github.com/qbittorrent/qBittorrent/wiki#reverse-proxy-setup-for-webui-access&gt;Reverse proxy setup examples&lt;/a&gt;</string>
+                    </property>
+                    <property name="openExternalLinks">
+                     <bool>true</bool>
+                    </property>
+                    <property name="textInteractionFlags">
+                     <set>Qt::TextInteractionFlag::LinksAccessibleByKeyboard|Qt::TextInteractionFlag::LinksAccessibleByMouse</set>
                     </property>
                    </widget>
                   </item>

--- a/src/gui/properties/peersadditiondialog.ui
+++ b/src/gui/properties/peersadditiondialog.ui
@@ -23,6 +23,9 @@
    </item>
    <item>
     <widget class="QTextEdit" name="textEditPeers">
+     <property name="tabChangesFocus">
+      <bool>true</bool>
+     </property>
      <property name="lineWrapMode">
       <enum>QTextEdit::LineWrapMode::NoWrap</enum>
      </property>

--- a/src/gui/properties/propertieswidget.ui
+++ b/src/gui/properties/propertieswidget.ui
@@ -85,6 +85,13 @@
                 </property>
                </widget>
               </item>
+              <item row="0" column="1">
+               <widget class="QLabel" name="tempProgressBarArea">
+                <property name="textFormat">
+                 <enum>Qt::TextFormat::PlainText</enum>
+                </property>
+               </widget>
+              </item>
               <item row="0" column="2">
                <widget class="QLabel" name="labelProgressVal">
                 <property name="sizePolicy">
@@ -114,6 +121,13 @@
                 </property>
                </widget>
               </item>
+              <item row="1" column="1">
+               <widget class="QLabel" name="tempAvailabilityBarArea">
+                <property name="textFormat">
+                 <enum>Qt::TextFormat::PlainText</enum>
+                </property>
+               </widget>
+              </item>
               <item row="1" column="2">
                <widget class="QLabel" name="labelAverageAvailabilityVal">
                 <property name="sizePolicy">
@@ -122,20 +136,6 @@
                   <verstretch>0</verstretch>
                  </sizepolicy>
                 </property>
-                <property name="textFormat">
-                 <enum>Qt::TextFormat::PlainText</enum>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QLabel" name="tempAvailabilityBarArea">
-                <property name="textFormat">
-                 <enum>Qt::TextFormat::PlainText</enum>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QLabel" name="tempProgressBarArea">
                 <property name="textFormat">
                  <enum>Qt::TextFormat::PlainText</enum>
                 </property>
@@ -163,6 +163,196 @@
               <property name="bottomMargin">
                <number>4</number>
               </property>
+              <item row="0" column="0">
+               <widget class="QLabel" name="labelTimeActive">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string extracomment="Time (duration) the torrent is active (not stopped)">Time Active:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QLabel" name="labelElapsedVal">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::TextFormat::PlainText</enum>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="2">
+               <widget class="QLabel" name="labelETA">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>ETA:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="3">
+               <widget class="QLabel" name="labelETAVal">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::TextFormat::PlainText</enum>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="4">
+               <widget class="QLabel" name="labelConnections">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Connections:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="5">
+               <widget class="QLabel" name="labelConnectionsVal">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::TextFormat::PlainText</enum>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="labelDownloaded">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Downloaded:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QLabel" name="labelDlTotalVal">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::TextFormat::PlainText</enum>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="2">
+               <widget class="QLabel" name="labelUploaded">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Uploaded:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="3">
+               <widget class="QLabel" name="labelUpTotalVal">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::TextFormat::PlainText</enum>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="4">
+               <widget class="QLabel" name="labelSeeds">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Seeds:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="5">
+               <widget class="QLabel" name="labelSeedsVal">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::TextFormat::PlainText</enum>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="labelDlSpeed">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Download Speed:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
               <item row="2" column="1">
                <widget class="QLabel" name="labelDlSpeedVal">
                 <property name="sizePolicy">
@@ -221,37 +411,8 @@
                 </property>
                </widget>
               </item>
-              <item row="0" column="4">
-               <widget class="QLabel" name="labelConnections">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Connections:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="3">
-               <widget class="QLabel" name="labelReannounceInVal">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="textFormat">
-                 <enum>Qt::TextFormat::PlainText</enum>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="3">
-               <widget class="QLabel" name="labelETAVal">
+              <item row="2" column="5">
+               <widget class="QLabel" name="labelPeersVal">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
                   <horstretch>0</horstretch>
@@ -279,43 +440,8 @@
                 </property>
                </widget>
               </item>
-              <item row="4" column="0">
-               <widget class="QLabel" name="labelRatio">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Share Ratio:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="0">
-               <widget class="QLabel" name="labelPopularity">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="toolTip">
-                 <string>Ratio / Time Active (in months), indicates how popular the torrent is</string>
-                </property>
-                <property name="text">
-                 <string>Popularity:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="5">
-               <widget class="QLabel" name="labelConnectionsVal">
+              <item row="3" column="1">
+               <widget class="QLabel" name="labelDlLimitVal">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
                   <horstretch>0</horstretch>
@@ -324,35 +450,6 @@
                 </property>
                 <property name="textFormat">
                  <enum>Qt::TextFormat::PlainText</enum>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="5">
-               <widget class="QLabel" name="labelPeersVal">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="textFormat">
-                 <enum>Qt::TextFormat::PlainText</enum>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="labelDownloaded">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Downloaded:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                 </property>
                </widget>
               </item>
@@ -372,24 +469,8 @@
                 </property>
                </widget>
               </item>
-              <item row="4" column="4">
-               <widget class="QLabel" name="labelLastSeenComplete">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Last Seen Complete:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1">
-               <widget class="QLabel" name="labelDlLimitVal">
+              <item row="3" column="3">
+               <widget class="QLabel" name="labelUpLimitVal">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
                   <horstretch>0</horstretch>
@@ -401,8 +482,53 @@
                 </property>
                </widget>
               </item>
-              <item row="1" column="3">
-               <widget class="QLabel" name="labelUpTotalVal">
+              <item row="3" column="4">
+               <widget class="QLabel" name="labelWasted">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Wasted:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="5">
+               <widget class="QLabel" name="labelWastedVal">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::TextFormat::PlainText</enum>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="0">
+               <widget class="QLabel" name="labelRatio">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Share Ratio:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="1">
+               <widget class="QLabel" name="labelShareRatioVal">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
                   <horstretch>0</horstretch>
@@ -430,6 +556,35 @@
                 </property>
                </widget>
               </item>
+              <item row="4" column="3">
+               <widget class="QLabel" name="labelReannounceInVal">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::TextFormat::PlainText</enum>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="4">
+               <widget class="QLabel" name="labelLastSeenComplete">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Last Seen Complete:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
               <item row="4" column="5">
                <widget class="QLabel" name="labelLastSeenCompleteVal">
                 <property name="sizePolicy">
@@ -443,74 +598,22 @@
                 </property>
                </widget>
               </item>
-              <item row="1" column="4">
-               <widget class="QLabel" name="labelSeeds">
+              <item row="5" column="0">
+               <widget class="QLabel" name="labelPopularity">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
                   <horstretch>0</horstretch>
                   <verstretch>0</verstretch>
                  </sizepolicy>
                 </property>
+                <property name="toolTip">
+                 <string>Ratio / Time Active (in months), indicates how popular the torrent is</string>
+                </property>
                 <property name="text">
-                 <string>Seeds:</string>
+                 <string>Popularity:</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="labelDlSpeed">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Download Speed:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QLabel" name="labelDlTotalVal">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="textFormat">
-                 <enum>Qt::TextFormat::PlainText</enum>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="5">
-               <widget class="QLabel" name="labelWastedVal">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="textFormat">
-                 <enum>Qt::TextFormat::PlainText</enum>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="1">
-               <widget class="QLabel" name="labelShareRatioVal">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="textFormat">
-                 <enum>Qt::TextFormat::PlainText</enum>
                 </property>
                </widget>
               </item>
@@ -527,109 +630,6 @@
                 </property>
                 <property name="textFormat">
                  <enum>Qt::TextFormat::PlainText</enum>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="2">
-               <widget class="QLabel" name="labelUploaded">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Uploaded:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="5">
-               <widget class="QLabel" name="labelSeedsVal">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="textFormat">
-                 <enum>Qt::TextFormat::PlainText</enum>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QLabel" name="labelElapsedVal">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="textFormat">
-                 <enum>Qt::TextFormat::PlainText</enum>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="labelTimeActive">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string extracomment="Time (duration) the torrent is active (not stopped)">Time Active:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="3">
-               <widget class="QLabel" name="labelUpLimitVal">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="textFormat">
-                 <enum>Qt::TextFormat::PlainText</enum>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="2">
-               <widget class="QLabel" name="labelETA">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>ETA:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="4">
-               <widget class="QLabel" name="labelWasted">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Wasted:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                 </property>
                </widget>
               </item>

--- a/src/gui/rss/automatedrssdownloader.ui
+++ b/src/gui/rss/automatedrssdownloader.ui
@@ -182,22 +182,11 @@
              </property>
             </widget>
            </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="labelMustNotContain">
-             <property name="text">
-              <string>Must Not Contain:</string>
-             </property>
-            </widget>
+           <item row="0" column="1">
+            <widget class="QLineEdit" name="lineContains"/>
            </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="lblEFilter">
-             <property name="text">
-              <string>Episode Filter:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="2">
-            <widget class="QLabel" name="lblEFilterStat">
+           <item row="0" column="2">
+            <widget class="QLabel" name="labelMustStat">
              <property name="maximumSize">
               <size>
                <width>18</width>
@@ -205,6 +194,16 @@
               </size>
              </property>
             </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="labelMustNotContain">
+             <property name="text">
+              <string>Must Not Contain:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLineEdit" name="lineNotContains"/>
            </item>
            <item row="1" column="2">
             <widget class="QLabel" name="labelMustNotStat">
@@ -216,11 +215,18 @@
              </property>
             </widget>
            </item>
-           <item row="0" column="1">
-            <widget class="QLineEdit" name="lineContains"/>
+           <item row="2" column="0">
+            <widget class="QLabel" name="lblEFilter">
+             <property name="text">
+              <string>Episode Filter:</string>
+             </property>
+            </widget>
            </item>
-           <item row="0" column="2">
-            <widget class="QLabel" name="labelMustStat">
+           <item row="2" column="1">
+            <widget class="QLineEdit" name="lineEFilter"/>
+           </item>
+           <item row="2" column="2">
+            <widget class="QLabel" name="lblEFilterStat">
              <property name="maximumSize">
               <size>
                <width>18</width>
@@ -238,12 +244,6 @@
               </size>
              </property>
             </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QLineEdit" name="lineNotContains"/>
-           </item>
-           <item row="2" column="1">
-            <widget class="QLineEdit" name="lineEFilter"/>
            </item>
           </layout>
          </item>
@@ -427,20 +427,6 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
    </item>
   </layout>
  </widget>
- <tabstops>
-  <tabstop>renameRuleBtn</tabstop>
-  <tabstop>removeRuleBtn</tabstop>
-  <tabstop>addRuleBtn</tabstop>
-  <tabstop>ruleList</tabstop>
-  <tabstop>lineContains</tabstop>
-  <tabstop>lineNotContains</tabstop>
-  <tabstop>lineEFilter</tabstop>
-  <tabstop>spinIgnorePeriod</tabstop>
-  <tabstop>listFeeds</tabstop>
-  <tabstop>matchingArticlesTree</tabstop>
-  <tabstop>importBtn</tabstop>
-  <tabstop>exportBtn</tabstop>
- </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/gui/statsdialog.ui
+++ b/src/gui/statsdialog.ui
@@ -20,29 +20,15 @@
       <string>User statistics</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="3" column="1" alignment="Qt::AlignmentFlag::AlignRight">
-       <widget class="QLabel" name="labelWaste">
+      <item row="0" column="0">
+       <widget class="QLabel" name="labelAlltimeULText">
         <property name="text">
-         <string notr="true">TextLabel</string>
+         <string>All-time upload:</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="labelPeersText">
-        <property name="text">
-         <string>Connected peers:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="labelGlobalRatioText">
-        <property name="text">
-         <string>All-time share ratio:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1" alignment="Qt::AlignmentFlag::AlignRight">
-       <widget class="QLabel" name="labelPeers">
+      <item row="0" column="1" alignment="Qt::AlignmentFlag::AlignRight">
+       <widget class="QLabel" name="labelAlltimeUL">
         <property name="text">
          <string notr="true">TextLabel</string>
         </property>
@@ -62,6 +48,13 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="labelGlobalRatioText">
+        <property name="text">
+         <string>All-time share ratio:</string>
+        </property>
+       </widget>
+      </item>
       <item row="2" column="1" alignment="Qt::AlignmentFlag::AlignRight">
        <widget class="QLabel" name="labelGlobalRatio">
         <property name="text">
@@ -76,15 +69,22 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="labelAlltimeULText">
+      <item row="3" column="1" alignment="Qt::AlignmentFlag::AlignRight">
+       <widget class="QLabel" name="labelWaste">
         <property name="text">
-         <string>All-time upload:</string>
+         <string notr="true">TextLabel</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="1" alignment="Qt::AlignmentFlag::AlignRight">
-       <widget class="QLabel" name="labelAlltimeUL">
+      <item row="4" column="0">
+       <widget class="QLabel" name="labelPeersText">
+        <property name="text">
+         <string>Connected peers:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1" alignment="Qt::AlignmentFlag::AlignRight">
+       <widget class="QLabel" name="labelPeers">
         <property name="text">
          <string notr="true">TextLabel</string>
         </property>
@@ -113,17 +113,17 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1" alignment="Qt::AlignmentFlag::AlignRight">
-       <widget class="QLabel" name="labelTotalBuf">
-        <property name="text">
-         <string notr="true">TextLabel</string>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="labelTotalBufText">
         <property name="text">
          <string>Total buffer size:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1" alignment="Qt::AlignmentFlag::AlignRight">
+       <widget class="QLabel" name="labelTotalBuf">
+        <property name="text">
+         <string notr="true">TextLabel</string>
         </property>
        </widget>
       </item>
@@ -136,17 +136,10 @@
       <string>Performance statistics</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
-      <item row="3" column="1" alignment="Qt::AlignmentFlag::AlignRight">
-       <widget class="QLabel" name="labelJobsTime">
+      <item row="0" column="0">
+       <widget class="QLabel" name="labelWriteStarveText">
         <property name="text">
-         <string notr="true">TextLabel</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1" alignment="Qt::AlignmentFlag::AlignRight">
-       <widget class="QLabel" name="labelQueuedJobs">
-        <property name="text">
-         <string notr="true">TextLabel</string>
+         <string>Write cache overload:</string>
         </property>
        </widget>
       </item>
@@ -154,6 +147,13 @@
        <widget class="QLabel" name="labelWriteStarve">
         <property name="text">
          <string notr="true">TextLabel</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="labelReadStarveText">
+        <property name="text">
+         <string>Read cache overload:</string>
         </property>
        </widget>
       </item>
@@ -171,10 +171,10 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="labelWriteStarveText">
+      <item row="2" column="1" alignment="Qt::AlignmentFlag::AlignRight">
+       <widget class="QLabel" name="labelQueuedJobs">
         <property name="text">
-         <string>Write cache overload:</string>
+         <string notr="true">TextLabel</string>
         </property>
        </widget>
       </item>
@@ -185,10 +185,10 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="labelReadStarveText">
+      <item row="3" column="1" alignment="Qt::AlignmentFlag::AlignRight">
+       <widget class="QLabel" name="labelJobsTime">
         <property name="text">
-         <string>Read cache overload:</string>
+         <string notr="true">TextLabel</string>
         </property>
        </widget>
       </item>

--- a/src/gui/torrentcategorydialog.ui
+++ b/src/gui/torrentcategorydialog.ui
@@ -173,12 +173,6 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
- <tabstops>
-  <tabstop>textCategoryName</tabstop>
-  <tabstop>comboSavePath</tabstop>
-  <tabstop>comboUseDownloadPath</tabstop>
-  <tabstop>comboDownloadPath</tabstop>
- </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/gui/torrentcreatordialog.ui
+++ b/src/gui/torrentcreatordialog.ui
@@ -313,6 +313,13 @@
           <string>Fields</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
+          <item row="0" column="0">
+           <widget class="QLabel" name="lbl_announce_url">
+            <property name="text">
+             <string>Tracker URLs:</string>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="1">
            <widget class="QTextEdit" name="trackersList">
             <property name="toolTip">
@@ -337,24 +344,17 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QTextEdit" name="txtComment">
-            <property name="acceptRichText">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="lbl_announce_url">
-            <property name="text">
-             <string>Tracker URLs:</string>
-            </property>
-           </widget>
-          </item>
           <item row="2" column="0">
            <widget class="QLabel" name="lbl_comment">
             <property name="text">
              <string>Comments:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QTextEdit" name="txtComment">
+            <property name="acceptRichText">
+             <bool>false</bool>
             </property>
            </widget>
           </item>
@@ -413,23 +413,6 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
- <tabstops>
-  <tabstop>textInputPath</tabstop>
-  <tabstop>addFileButton</tabstop>
-  <tabstop>addFolderButton</tabstop>
-  <tabstop>comboTorrentFormat</tabstop>
-  <tabstop>comboPieceSize</tabstop>
-  <tabstop>buttonCalcTotalPieces</tabstop>
-  <tabstop>checkPrivate</tabstop>
-  <tabstop>checkStartSeeding</tabstop>
-  <tabstop>checkIgnoreShareLimits</tabstop>
-  <tabstop>checkOptimizeAlignment</tabstop>
-  <tabstop>spinPaddedFileSizeLimit</tabstop>
-  <tabstop>trackersList</tabstop>
-  <tabstop>URLSeedsList</tabstop>
-  <tabstop>txtComment</tabstop>
-  <tabstop>lineEditSource</tabstop>
- </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/gui/torrentcreatordialog.ui
+++ b/src/gui/torrentcreatordialog.ui
@@ -325,6 +325,9 @@
             <property name="toolTip">
              <string>You can separate tracker tiers / groups with an empty line.</string>
             </property>
+            <property name="tabChangesFocus">
+             <bool>true</bool>
+            </property>
             <property name="acceptRichText">
              <bool>false</bool>
             </property>
@@ -339,6 +342,9 @@
           </item>
           <item row="1" column="1">
            <widget class="QTextEdit" name="URLSeedsList">
+            <property name="tabChangesFocus">
+             <bool>true</bool>
+            </property>
             <property name="acceptRichText">
              <bool>false</bool>
             </property>
@@ -353,6 +359,9 @@
           </item>
           <item row="2" column="1">
            <widget class="QTextEdit" name="txtComment">
+            <property name="tabChangesFocus">
+             <bool>true</bool>
+            </property>
             <property name="acceptRichText">
              <bool>false</bool>
             </property>

--- a/src/gui/torrentoptionsdialog.ui
+++ b/src/gui/torrentoptionsdialog.ui
@@ -52,6 +52,13 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout_4">
+     <item row="0" column="0">
+      <widget class="QLabel" name="labelCategory">
+       <property name="text">
+        <string>Category:</string>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="1">
       <widget class="QComboBox" name="comboCategory">
        <property name="sizePolicy">
@@ -71,13 +78,6 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="labelCategory">
-       <property name="text">
-        <string>Category:</string>
-       </property>
-      </widget>
-     </item>
     </layout>
    </item>
    <item>
@@ -86,26 +86,17 @@
       <string>Torrent Speed Limits</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
         <property name="text">
-         <string>Download:</string>
+         <string>Upload:</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
-       <widget class="QSpinBox" name="spinDownloadLimit">
-        <property name="specialValueText">
-         <string>∞</string>
-        </property>
-        <property name="suffix">
-         <string> KiB/s</string>
-        </property>
-        <property name="maximum">
-         <number>2000000</number>
-        </property>
-        <property name="stepType">
-         <enum>QAbstractSpinBox::StepType::AdaptiveDecimalStepType</enum>
+      <item row="0" column="1">
+       <widget class="QSlider" name="sliderUploadLimit">
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
        </widget>
       </item>
@@ -125,24 +116,10 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1" colspan="2">
-       <widget class="QLabel" name="labelWarning">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>These will not exceed the global limits</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Upload:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QSlider" name="sliderUploadLimit">
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
+         <string>Download:</string>
         </property>
        </widget>
       </item>
@@ -150,6 +127,29 @@
        <widget class="QSlider" name="sliderDownloadLimit">
         <property name="orientation">
          <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QSpinBox" name="spinDownloadLimit">
+        <property name="specialValueText">
+         <string>∞</string>
+        </property>
+        <property name="suffix">
+         <string> KiB/s</string>
+        </property>
+        <property name="maximum">
+         <number>2000000</number>
+        </property>
+        <property name="stepType">
+         <enum>QAbstractSpinBox::StepType::AdaptiveDecimalStepType</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1" colspan="2">
+       <widget class="QLabel" name="labelWarning">
+        <property name="text">
+         <string>These will not exceed the global limits</string>
         </property>
        </widget>
       </item>
@@ -256,23 +256,6 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
- <tabstops>
-  <tabstop>checkAutoTMM</tabstop>
-  <tabstop>savePath</tabstop>
-  <tabstop>checkUseDownloadPath</tabstop>
-  <tabstop>downloadPath</tabstop>
-  <tabstop>comboCategory</tabstop>
-  <tabstop>sliderUploadLimit</tabstop>
-  <tabstop>spinUploadLimit</tabstop>
-  <tabstop>sliderDownloadLimit</tabstop>
-  <tabstop>spinDownloadLimit</tabstop>
-  <tabstop>torrentShareLimitsBox</tabstop>
-  <tabstop>checkDisableDHT</tabstop>
-  <tabstop>checkSequential</tabstop>
-  <tabstop>checkDisablePEX</tabstop>
-  <tabstop>checkFirstLastPieces</tabstop>
-  <tabstop>checkDisableLSD</tabstop>
- </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/gui/torrentsharelimitswidget.ui
+++ b/src/gui/torrentsharelimitswidget.ui
@@ -13,8 +13,60 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="limitsLayout">
-     <item row="2" column="1">
-      <widget class="QComboBox" name="comboBoxInactiveSeedingTimeMode">
+     <item row="0" column="0">
+      <widget class="QLabel" name="labelRatio">
+       <property name="text">
+        <string>Ratio:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="comboBoxRatioMode">
+       <property name="currentIndex">
+        <number>-1</number>
+       </property>
+       <item>
+        <property name="text">
+         <string>Default</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Unlimited</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Set to</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QDoubleSpinBox" name="spinBoxRatioValue">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="maximum">
+        <double>9998.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.050000000000000</double>
+       </property>
+       <property name="value">
+        <double>1.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelSeedingTime">
+       <property name="text">
+        <string>Seeding time:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QComboBox" name="comboBoxSeedingTimeMode">
        <property name="currentIndex">
         <number>-1</number>
        </property>
@@ -51,18 +103,33 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="labelRatio">
-       <property name="text">
-        <string>Ratio:</string>
-       </property>
-      </widget>
-     </item>
      <item row="2" column="0">
       <widget class="QLabel" name="labelInactiveSeedingTime">
        <property name="text">
         <string>Inactive seeding time:</string>
        </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QComboBox" name="comboBoxInactiveSeedingTimeMode">
+       <property name="currentIndex">
+        <number>-1</number>
+       </property>
+       <item>
+        <property name="text">
+         <string>Default</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Unlimited</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Set to</string>
+        </property>
+       </item>
       </widget>
      </item>
      <item row="2" column="2">
@@ -78,73 +145,6 @@
        </property>
        <property name="value">
         <number>1440</number>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="2">
-      <widget class="QDoubleSpinBox" name="spinBoxRatioValue">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="maximum">
-        <double>9998.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.050000000000000</double>
-       </property>
-       <property name="value">
-        <double>1.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QComboBox" name="comboBoxSeedingTimeMode">
-       <property name="currentIndex">
-        <number>-1</number>
-       </property>
-       <item>
-        <property name="text">
-         <string>Default</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Unlimited</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Set to</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QComboBox" name="comboBoxRatioMode">
-       <property name="currentIndex">
-        <number>-1</number>
-       </property>
-       <item>
-        <property name="text">
-         <string>Default</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Unlimited</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Set to</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="labelSeedingTime">
-       <property name="text">
-        <string>Seeding time:</string>
        </property>
       </widget>
      </item>
@@ -208,15 +208,6 @@
    </item>
   </layout>
  </widget>
- <tabstops>
-  <tabstop>comboBoxRatioMode</tabstop>
-  <tabstop>spinBoxRatioValue</tabstop>
-  <tabstop>comboBoxSeedingTimeMode</tabstop>
-  <tabstop>spinBoxSeedingTimeValue</tabstop>
-  <tabstop>comboBoxInactiveSeedingTimeMode</tabstop>
-  <tabstop>spinBoxInactiveSeedingTimeValue</tabstop>
-  <tabstop>comboBoxAction</tabstop>
- </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/gui/trackersadditiondialog.ui
+++ b/src/gui/trackersadditiondialog.ui
@@ -23,6 +23,9 @@
    </item>
    <item>
     <widget class="QTextEdit" name="textEditTrackersList">
+     <property name="tabChangesFocus">
+      <bool>true</bool>
+     </property>
      <property name="lineWrapMode">
       <enum>QTextEdit::LineWrapMode::NoWrap</enum>
      </property>


### PR DESCRIPTION
* GHA CI: add checks for grid items order
  Now all items under `QGridLayout` are required to be sorted. This allow
us to omit tabstop order. The tabstop order will follow the layout order.
  The script can be invoked to fix wrong grid items order in .ui files:
  ```console  
  python check_grid_items_order.py file.ui
  ```
* Sort grid items properly
  Supersedes #21856.
* Make links accessible by keyboard
* Make tab key switch focus
  These fields do not expect tab characters.
