### PR TITLE
GHA CI: Bump some pre-commit hook revs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
           - ts
 
   - repo: https://github.com/pre-commit/pre-commit-hooks.git
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
     - id: check-json
       name: Check JSON files
@@ -82,7 +82,7 @@ repos:
         - ts
 
   - repo: https://github.com/crate-ci/typos.git
-    rev: v1.25.0
+    rev: v1.28.4
     hooks:
     - id: typos
       name: Check spelling (typos)


### PR DESCRIPTION
* Bumped `pre-commit-hooks` -> v5.0.0
* Bumped `typos` -> v1.28.4