### PR TITLE
Disable zoom when focusing input on mobile

### DIFF
--- a/src/webui/www/private/index.html
+++ b/src/webui/www/private/index.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=10">
     <meta name="application-name" content="qBittorrent">
     <meta name="description" content="qBittorrent WebUI">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
 
     <title>qBittorrent WebUI</title>
 

--- a/src/webui/www/public/index.html
+++ b/src/webui/www/public/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="color-scheme" content="light dark">
     <meta name="description" content="qBittorrent WebUI">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
 
     <title>QBT_TR(qBittorrent WebUI)QBT_TR[CONTEXT=Login]</title>
 


### PR DESCRIPTION
This makes the mobile experience slightly better by not automatically zooming in when an input field is focused (e.g. performing a search). This does not prevent manually zooming in, should someone want to do that.