### PR TITLE
Fix cannot remove trackers via WebAPI

### DIFF
--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -880,7 +880,13 @@ void TorrentsController::removeTrackersAction()
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 
-    const QStringList urls = params()[u"urls"_s].split(u'|');
+    const QStringList urlsParam = params()[u"urls"_s].split(u'|', Qt::SkipEmptyParts);
+
+    QStringList urls;
+    urls.reserve(urlsParam.size());
+    for (const QString &urlStr : urlsParam)
+        urls << QUrl::fromPercentEncoding(urlStr.toLatin1());
+
     torrent->removeTrackers(urls);
 
     if (!torrent->isStopped())


### PR DESCRIPTION
The backport commit c3c7f28bad0a3e874e6883d98e422c6716f8e77a was insufficient.

Closes #22039.
