### PR TITLE
Fix search engine API response handling

### DIFF
--- a/src/searchengine/nova3/helpers.py
+++ b/src/searchengine/nova3/helpers.py
@@ -113,6 +113,10 @@ def retrieve_url(url: str, custom_headers: Mapping[str, Any] = {}, request_data:
         pass
 
     dataStr = data.decode(charset, 'replace')
+
+    # better do it here than in htmlentitydecode which shouldn't make specific exceptions in its task
+    dataStr = dataStr.replace('&quot;', '\\"')
+
     dataStr = htmlentitydecode(dataStr)
     return dataStr
 


### PR DESCRIPTION
Added manual escaping of HTML entities before automatic replacement.
Now, `"Ubuntu 22.04.5 LTS (&quot;Jammy Jellyfish&quot;)"` becomes `"Ubuntu 22.04.5 LTS (\"Jammy Jellyfish\")"` instead of `"Ubuntu 22.04.5 LTS ("Jammy Jellyfish")"`.
Closes #22074.