### PR TITLE
Revise lambda specifiers

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -6328,7 +6328,7 @@ void SessionImpl::loadStatistics()
 
 void SessionImpl::updateTrackerEntryStatuses(lt::torrent_handle torrentHandle)
 {
-    invokeAsync([this, torrentHandle = std::move(torrentHandle)]() mutable
+    invokeAsync([this, torrentHandle = std::move(torrentHandle)]()
     {
         try
         {

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -3117,7 +3117,7 @@ void TorrentImpl::invokeAsync(Func func, Callback resultHandler) const
     m_session->invokeAsync([session = m_session
                            , func = std::move(func)
                            , resultHandler = std::move(resultHandler)
-                           , thisTorrent = QPointer<const TorrentImpl>(this)]() mutable
+                           , thisTorrent = QPointer<const TorrentImpl>(this)]()
     {
         session->invoke([result = func(), thisTorrent, resultHandler = std::move(resultHandler)]
         {


### PR DESCRIPTION
The `mutable` is redundant as nothing in the lambda body need to modify captured variables.
