### PR TITLE
Fix wrong translation to Spanish

### DIFF
--- a/src/lang/qbittorrent_es.ts
+++ b/src/lang/qbittorrent_es.ts
@@ -6628,12 +6628,12 @@ readme[0-9].txt: filtra &apos;readme1.txt&apos;, &apos;readme2.txt&apos; pero no
     <message>
         <location filename="../gui/optionsdialog.ui" line="1581"/>
         <source>Run on torrent added</source>
-        <translation>Seguir ejecutando torrent añadido</translation>
+        <translation>Ejecutar al añadir torrent</translation>
     </message>
     <message>
         <location filename="../gui/optionsdialog.ui" line="1599"/>
         <source>Run on torrent finished</source>
-        <translation>Seguir ejecutando torrent finalizado</translation>
+        <translation>Ejecutar al finalizar torrent</translation>
     </message>
     <message>
         <location filename="../gui/optionsdialog.ui" line="1617"/>


### PR DESCRIPTION
A very small correction for what it seems to be a very wrong automated translation. 

I am aware of transfiex, but I don't have an account nor I plan to actively work on translations and for this trivial change I hope it won't be necessary. 
