### PR TITLE
Change URL seed error message

### DIFF
--- a/src/base/bittorrent/sessionimpl.cpp
+++ b/src/base/bittorrent/sessionimpl.cpp
@@ -5965,7 +5965,7 @@ void SessionImpl::handleUrlSeedAlert(const lt::url_seed_alert *alert)
 
     if (alert->error)
     {
-        LogMsg(tr("URL seed DNS lookup failed. Torrent: \"%1\". URL: \"%2\". Error: \"%3\"")
+        LogMsg(tr("URL seed connection failed. Torrent: \"%1\". URL: \"%2\". Error: \"%3\"")
             .arg(torrent->name(), QString::fromUtf8(alert->server_url()), QString::fromStdString(alert->message()))
             , Log::WARNING);
     }


### PR DESCRIPTION
Current URL seed error message assumes that only possible error is DNS lookup failure, which is not true.
So replace it with a more generic message. Real reason is provided by the `Error:` part.

See discussion in https://github.com/qbittorrent/qBittorrent/issues/22076#issuecomment-2569058681.