### PR TITLE
WebAPI: optionally include trackers list in torrent info response

### DIFF
--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -567,11 +567,10 @@ void TorrentsController::trackersAction()
         throw APIError(APIErrorType::NotFound);
 
     QJsonArray trackersList = getStickyTrackers(torrent);
-    QJsonArray trackers = getTrackers(torrent);
 
     // merge QJsonArray
-    for (auto &&tracker : trackers)
-        trackersList.append(std::move(tracker));
+    for (const auto &tracker : asConst(getTrackers(torrent)))
+        trackersList.append(tracker);
 
     setResult(trackersList);
 }

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -117,6 +117,7 @@ const QString KEY_PROP_SSL_PRIVATEKEY = u"ssl_private_key"_s;
 const QString KEY_PROP_SSL_DHPARAMS = u"ssl_dh_params"_s;
 const QString KEY_PROP_HAS_METADATA = u"has_metadata"_s;
 const QString KEY_PROP_PROGRESS = u"progress"_s;
+const QString KEY_PROP_TRACKERS = u"trackers"_s;
 
 
 // File keys
@@ -304,6 +305,7 @@ void TorrentsController::countAction()
 //   - tag (string): torrent tag for filtering by it (empty string means "untagged"; no "tag" param presented means "any tag")
 //   - hashes (string): filter by hashes, can contain multiple hashes separated by |
 //   - private (bool): filter torrents that are from private trackers (true) or not (false). Empty means any torrent (no filtering)
+//   - includeTrackers (bool): include trackers in list outout (true) or not (false). Empty means not included
 //   - sort (string): name of column for sorting by its value
 //   - reverse (bool): enable reverse sorting
 //   - limit (int): set limit number of torrents returned (if greater than 0, otherwise - unlimited)
@@ -319,6 +321,7 @@ void TorrentsController::infoAction()
     int offset {params()[u"offset"_s].toInt()};
     const QStringList hashes {params()[u"hashes"_s].split(u'|', Qt::SkipEmptyParts)};
     const std::optional<bool> isPrivate = parseBool(params()[u"private"_s]);
+    const std::optional<bool> includeTrackers = parseBool(params()[u"includeTrackers"_s]);
 
     std::optional<TorrentIDSet> idSet;
     if (!hashes.isEmpty())
@@ -333,7 +336,36 @@ void TorrentsController::infoAction()
     for (const BitTorrent::Torrent *torrent : asConst(BitTorrent::Session::instance()->torrents()))
     {
         if (torrentFilter.match(torrent))
-            torrentList.append(serialize(*torrent));
+        {
+        	QVariantMap serializedTorrent = serialize(*torrent);
+
+          	if (includeTrackers)
+            {
+                QJsonArray trackerList = getStickyTrackers(torrent);
+
+                for (const BitTorrent::TrackerEntryStatus &tracker : asConst(torrent->trackers()))
+                {
+                    const bool isNotWorking = (tracker.state == BitTorrent::TrackerEndpointState::NotWorking)
+                            || (tracker.state == BitTorrent::TrackerEndpointState::TrackerError)
+                            || (tracker.state == BitTorrent::TrackerEndpointState::Unreachable);
+                    trackerList << QJsonObject
+                    {
+                        {KEY_TRACKER_URL, tracker.url},
+                        {KEY_TRACKER_TIER, tracker.tier},
+                        {KEY_TRACKER_STATUS, static_cast<int>((isNotWorking ? BitTorrent::TrackerEndpointState::NotWorking : tracker.state))},
+                        {KEY_TRACKER_MSG, tracker.message},
+                        {KEY_TRACKER_PEERS_COUNT, tracker.numPeers},
+                        {KEY_TRACKER_SEEDS_COUNT, tracker.numSeeds},
+                        {KEY_TRACKER_LEECHES_COUNT, tracker.numLeeches},
+                        {KEY_TRACKER_DOWNLOADED_COUNT, tracker.numDownloaded}
+                    };
+                }
+
+                serializedTorrent.insert(KEY_PROP_TRACKERS, trackerList);
+            }
+
+            torrentList.append(serializedTorrent);
+        }
     }
 
     if (torrentList.isEmpty())

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -305,7 +305,7 @@ void TorrentsController::countAction()
 //   - tag (string): torrent tag for filtering by it (empty string means "untagged"; no "tag" param presented means "any tag")
 //   - hashes (string): filter by hashes, can contain multiple hashes separated by |
 //   - private (bool): filter torrents that are from private trackers (true) or not (false). Empty means any torrent (no filtering)
-//   - includeTrackers (bool): include trackers in list outout (true) or not (false). Empty means not included
+//   - includeTrackers (bool): include trackers in list output (true) or not (false). Empty means not included
 //   - sort (string): name of column for sorting by its value
 //   - reverse (bool): enable reverse sorting
 //   - limit (int): set limit number of torrents returned (if greater than 0, otherwise - unlimited)
@@ -321,7 +321,7 @@ void TorrentsController::infoAction()
     int offset {params()[u"offset"_s].toInt()};
     const QStringList hashes {params()[u"hashes"_s].split(u'|', Qt::SkipEmptyParts)};
     const std::optional<bool> isPrivate = parseBool(params()[u"private"_s]);
-    const std::optional<bool> includeTrackers = parseBool(params()[u"includeTrackers"_s]);
+    const bool includeTrackers = parseBool(params()[u"includeTrackers"_s]).value_or(false);
 
     std::optional<TorrentIDSet> idSet;
     if (!hashes.isEmpty())
@@ -335,8 +335,9 @@ void TorrentsController::infoAction()
     QVariantList torrentList;
     for (const BitTorrent::Torrent *torrent : asConst(BitTorrent::Session::instance()->torrents()))
     {
-        if (torrentFilter.match(torrent))
-        {
+        if (!torrentFilter.match(torrent))
+            continue;
+        
         	QVariantMap serializedTorrent = serialize(*torrent);
 
           	if (includeTrackers)
@@ -366,7 +367,6 @@ void TorrentsController::infoAction()
 
             torrentList.append(serializedTorrent);
         }
-    }
 
     if (torrentList.isEmpty())
     {

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -251,10 +251,10 @@ namespace
 
     QJsonArray getAllTrackers(const BitTorrent::Torrent *const torrent, const bool includeSticky)
     {
-		QJsonArray trackerList;
+        QJsonArray trackerList;
 
         if (includeSticky)
-        	trackerList << getStickyTrackers(torrent);
+            trackerList << getStickyTrackers(torrent);
 
         for (const BitTorrent::TrackerEntryStatus &tracker : asConst(torrent->trackers()))
         {
@@ -365,14 +365,14 @@ void TorrentsController::infoAction()
     {
         if (!torrentFilter.match(torrent))
             continue;
-        
-        	QVariantMap serializedTorrent = serialize(*torrent);
 
-          	if (includeTrackers)
+        QVariantMap serializedTorrent = serialize(*torrent);
+
+        if (includeTrackers)
             serializedTorrent.insert(KEY_PROP_TRACKERS, getAllTrackers(torrent, false));
 
-            torrentList.append(serializedTorrent);
-        }
+        torrentList.append(serializedTorrent);
+    }
 
     if (torrentList.isEmpty())
     {

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -249,12 +249,9 @@ namespace
         return {dht, pex, lsd};
     }
 
-    QJsonArray getAllTrackers(const BitTorrent::Torrent *const torrent, const bool includeSticky)
+    QJsonArray getTrackers(const BitTorrent::Torrent *const torrent)
     {
-        QJsonArray trackerList;
-
-        if (includeSticky)
-            trackerList << getStickyTrackers(torrent);
+        QJsonArray trackerList = getStickyTrackers(torrent);
 
         for (const BitTorrent::TrackerEntryStatus &tracker : asConst(torrent->trackers()))
         {
@@ -369,7 +366,7 @@ void TorrentsController::infoAction()
         QVariantMap serializedTorrent = serialize(*torrent);
 
         if (includeTrackers)
-            serializedTorrent.insert(KEY_PROP_TRACKERS, getAllTrackers(torrent, false));
+            serializedTorrent.insert(KEY_PROP_TRACKERS, getTrackers(torrent));
 
         torrentList.append(serializedTorrent);
     }
@@ -569,7 +566,7 @@ void TorrentsController::trackersAction()
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 
-    setResult(getAllTrackers(torrent, true));
+    setResult(getTrackers(torrent));
 }
 
 // Returns the web seeds for a torrent in JSON format.

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -251,7 +251,7 @@ namespace
 
     QJsonArray getTrackers(const BitTorrent::Torrent *const torrent)
     {
-        QJsonArray trackerList = getStickyTrackers(torrent);
+        QJsonArray trackerList;
 
         for (const BitTorrent::TrackerEntryStatus &tracker : asConst(torrent->trackers()))
         {
@@ -566,7 +566,14 @@ void TorrentsController::trackersAction()
     if (!torrent)
         throw APIError(APIErrorType::NotFound);
 
-    setResult(getTrackers(torrent));
+    QJsonArray trackersList = getStickyTrackers(torrent);
+    QJsonArray trackers = getTrackers(torrent);
+
+    // merge QJsonArray
+    for (auto &&tracker : trackers)
+        trackersList.append(std::move(tracker));
+
+    setResult(trackersList);
 }
 
 // Returns the web seeds for a torrent in JSON format.


### PR DESCRIPTION
This PR adds an optional parameter `includeTrackers` to the Torrent info endpoint `/torrents/info` to include the trackers list of each torrent in the response under the key `trackers`.

## Why?

Me and a lot of other users runs anything between 1-40k torrents in a single instance and we rely on various tools to do things like tag by different tracker states.

To get the trackers we have to first get the list of torrents and then loop through that to get the trackers per torrent. With 10k torrents that's 10000+1 requests towards qBitorrent. It does handle it fairly well but it feels a bit wrong to spam it like that.

With this change we'll be able to get all that info in a single call (or few calls with pagination). It will most likely reduce the overall load quite a bit.

## About the code

This is my first time touching c++ and making any changes to this codebase but I read the contributing guidelines etc so it should be to spec.

Not sure if `KEY_PROP_TRACKERS` is the correct one to set or if it should be `TORRENT_` something instead.

I just copied the `private` bool param so it behaves the same but it could potentially be changed to `includes=trackers,other` which takes a comma separated string of other things that could be of interest to include.

The trackers logic is just a copy paste from the getTrackers endpoint. Not sure if `getStickyTrackers()` should be included or not.

I tested it locally and it works as expected with and without the new `includeTrackers` query param.