### PR TITLE
Add "% Selected" column to transfer list

### DIFF
--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -196,7 +196,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_INFOHASH_V2: return tr("Info Hash v2", "i.e: torrent info hash v2");
             case TR_REANNOUNCE: return tr("Reannounce In", "Indicates the time until next trackers reannounce");
             case TR_PRIVATE: return tr("Private", "Flags private torrents");
-            case TR_PERCENT_SELECTED: return tr("% Selected", "Percentage of torrent selected");
+            case TR_PERCENT_SELECTED: return tr("% Selected Data", "Percentage of selected data to download.");
             default: return {};
             }
         }
@@ -449,6 +449,8 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
     case TR_PRIVATE:
         return privateString(torrent->isPrivate(), torrent->hasMetadata());
     case TR_PERCENT_SELECTED:
+        if (!torrent->hasMetadata())
+            return tr("N/A");
         return QString::number((torrent->wantedSize() * 100) / torrent->totalSize()) + u'%';
     }
 
@@ -536,6 +538,8 @@ QVariant TransferListModel::internalValue(const BitTorrent::Torrent *torrent, co
     case TR_PRIVATE:
         return (torrent->hasMetadata() ? torrent->isPrivate() : QVariant());
     case TR_PERCENT_SELECTED:
+        if (!torrent->hasMetadata())
+            return 0;
         return (torrent->wantedSize() * 100) / torrent->totalSize();
     }
 

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -196,7 +196,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_INFOHASH_V2: return tr("Info Hash v2", "i.e: torrent info hash v2");
             case TR_REANNOUNCE: return tr("Reannounce In", "Indicates the time until next trackers reannounce");
             case TR_PRIVATE: return tr("Private", "Flags private torrents");
-            case TR_PERCENT_SELECTED: return tr("% Selected Data", "Percentage of selected data to download.");
+            case TR_PERCENT_SELECTED: return tr("%", "Percentage of selected data to download.");
             default: return {};
             }
         }

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -196,7 +196,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_INFOHASH_V2: return tr("Info Hash v2", "i.e: torrent info hash v2");
             case TR_REANNOUNCE: return tr("Reannounce In", "Indicates the time until next trackers reannounce");
             case TR_PRIVATE: return tr("Private", "Flags private torrents");
-            case TR_PERCENT_SELECTED: return tr("%", "Percentage of selected data to download.");
+            case TR_PERCENT_SELECTED: return tr("%", "Percentage of selected data to download");
             default: return {};
             }
         }
@@ -205,7 +205,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             switch (section)
             {
             case TR_POPULARITY: return tr("Ratio / Time Active (in months), indicates how popular the torrent is");
-            case TR_PERCENT_SELECTED: return tr("Wanted / Total size, indicates percentage of selected data to download.");
+            case TR_PERCENT_SELECTED: return tr("Wanted / Total size, indicates percentage of selected data to download");
             default: return {};
             }
         }
@@ -450,9 +450,7 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
     case TR_PRIVATE:
         return privateString(torrent->isPrivate(), torrent->hasMetadata());
     case TR_PERCENT_SELECTED:
-        if (!torrent->hasMetadata())
-            return tr("N/A");
-        return QString::number((torrent->wantedSize() * 100) / torrent->totalSize()) + u'%';
+        return torrent->hasMetadata() ? QString::number((static_cast<qreal>(torrent->wantedSize()) * 100) / torrent->totalSize(), 'f', 2) + u'%' : tr("N/A");
     }
 
     return {};
@@ -539,9 +537,7 @@ QVariant TransferListModel::internalValue(const BitTorrent::Torrent *torrent, co
     case TR_PRIVATE:
         return (torrent->hasMetadata() ? torrent->isPrivate() : QVariant());
     case TR_PERCENT_SELECTED:
-        if (!torrent->hasMetadata())
-            return 0;
-        return (torrent->wantedSize() * 100) / torrent->totalSize();
+        return torrent->hasMetadata() ? (static_cast<qreal>(torrent->wantedSize()) * 100) / torrent->totalSize() : 0;
     }
 
     return {};

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -196,6 +196,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_INFOHASH_V2: return tr("Info Hash v2", "i.e: torrent info hash v2");
             case TR_REANNOUNCE: return tr("Reannounce In", "Indicates the time until next trackers reannounce");
             case TR_PRIVATE: return tr("Private", "Flags private torrents");
+            case TR_PERCENT_SELECTED: return tr("% Selected", "Percentage of torrent selected");
             default: return {};
             }
         }
@@ -447,8 +448,9 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
         return reannounceString(torrent->nextAnnounce());
     case TR_PRIVATE:
         return privateString(torrent->isPrivate(), torrent->hasMetadata());
+    case TR_PERCENT_SELECTED:
+        return QString::number((torrent->wantedSize() * 100) / torrent->totalSize()) + u'%';
     }
-
     return {};
 }
 
@@ -532,6 +534,8 @@ QVariant TransferListModel::internalValue(const BitTorrent::Torrent *torrent, co
         return torrent->nextAnnounce();
     case TR_PRIVATE:
         return (torrent->hasMetadata() ? torrent->isPrivate() : QVariant());
+    case TR_PERCENT_SELECTED:
+        return (torrent->wantedSize() * 100) / torrent->totalSize();
     }
 
     return {};

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -195,8 +195,8 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_INFOHASH_V1: return tr("Info Hash v1", "i.e: torrent info hash v1");
             case TR_INFOHASH_V2: return tr("Info Hash v2", "i.e: torrent info hash v2");
             case TR_REANNOUNCE: return tr("Reannounce In", "Indicates the time until next trackers reannounce");
-            case TR_PRIVATE: return tr("Private", "Flags private torrents");
             case TR_PERCENT_SELECTED: return tr("%", "Percentage of selected data to download");
+            case TR_PRIVATE: return tr("Private", "Flags private torrents");
             default: return {};
             }
         }
@@ -447,10 +447,10 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
         return hashString(torrent->infoHash().v2());
     case TR_REANNOUNCE:
         return reannounceString(torrent->nextAnnounce());
+    case TR_PERCENT_SELECTED:
+        return torrent->hasMetadata() ? (QString::number((static_cast<qreal>(torrent->wantedSize()) * 100) / torrent->totalSize(), 'f', 2) + u'%') : tr("N/A");
     case TR_PRIVATE:
         return privateString(torrent->isPrivate(), torrent->hasMetadata());
-    case TR_PERCENT_SELECTED:
-        return torrent->hasMetadata() ? QString::number((static_cast<qreal>(torrent->wantedSize()) * 100) / torrent->totalSize(), 'f', 2) + u'%' : tr("N/A");
     }
 
     return {};
@@ -537,7 +537,7 @@ QVariant TransferListModel::internalValue(const BitTorrent::Torrent *torrent, co
     case TR_PRIVATE:
         return (torrent->hasMetadata() ? torrent->isPrivate() : QVariant());
     case TR_PERCENT_SELECTED:
-        return torrent->hasMetadata() ? (static_cast<qreal>(torrent->wantedSize()) * 100) / torrent->totalSize() : 0;
+        return torrent->hasMetadata() ? ((static_cast<qreal>(torrent->wantedSize()) * 100) / torrent->totalSize()) : 0;
     }
 
     return {};

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -204,8 +204,8 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
         {
             switch (section)
             {
-            case TR_POPULARITY: return tr("Ratio / Time Active (in months), indicates how popular the torrent is");
             case TR_PERCENT_SELECTED: return tr("Wanted / Total size, indicates percentage of selected data to download");
+            case TR_POPULARITY: return tr("Ratio / Time Active (in months), indicates how popular the torrent is");
             default: return {};
             }
         }

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -205,6 +205,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             switch (section)
             {
             case TR_POPULARITY: return tr("Ratio / Time Active (in months), indicates how popular the torrent is");
+            case TR_PERCENT_SELECTED: return tr("Wanted / Total size, indicates percentage of selected data to download.");
             default: return {};
             }
         }

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -195,7 +195,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_INFOHASH_V1: return tr("Info Hash v1", "i.e: torrent info hash v1");
             case TR_INFOHASH_V2: return tr("Info Hash v2", "i.e: torrent info hash v2");
             case TR_REANNOUNCE: return tr("Reannounce In", "Indicates the time until next trackers reannounce");
-            case TR_PERCENT_SELECTED: return tr("Size %", "Percentage of selected data to download");
+            case TR_PERCENT_SELECTED: return tr("Selected", "Percentage of selected data to download");
             case TR_PRIVATE: return tr("Private", "Flags private torrents");
             default: return {};
             }

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -195,7 +195,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_INFOHASH_V1: return tr("Info Hash v1", "i.e: torrent info hash v1");
             case TR_INFOHASH_V2: return tr("Info Hash v2", "i.e: torrent info hash v2");
             case TR_REANNOUNCE: return tr("Reannounce In", "Indicates the time until next trackers reannounce");
-            case TR_PERCENT_SELECTED: return tr("%", "Percentage of selected data to download");
+            case TR_PERCENT_SELECTED: return tr("Size %", "Percentage of selected data to download");
             case TR_PRIVATE: return tr("Private", "Flags private torrents");
             default: return {};
             }

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -451,6 +451,7 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
     case TR_PERCENT_SELECTED:
         return QString::number((torrent->wantedSize() * 100) / torrent->totalSize()) + u'%';
     }
+
     return {};
 }
 

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -197,7 +197,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_INFOHASH_V2: return tr("Info Hash v2", "i.e: torrent info hash v2");
             case TR_REANNOUNCE: return tr("Reannounce In", "Indicates the time until next trackers reannounce");
             case TR_PRIVATE: return tr("Private", "Flags private torrents");
-            case TR_PERCENT_SELECTED: return tr("% Selected", "Percentage of torrent selected");
+            case TR_PERCENT_SELECTED: return tr("% Selected Data", "Percentage of selected data to download.");
             default: return {};
             }
         }
@@ -450,6 +450,8 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
     case TR_PRIVATE:
         return privateString(torrent->isPrivate(), torrent->hasMetadata());
     case TR_PERCENT_SELECTED:
+        if (!torrent->hasMetadata())
+            return tr("N/A");
         return QString::number((torrent->wantedSize() * 100) / torrent->totalSize()) + u'%';
     }
 
@@ -537,6 +539,8 @@ QVariant TransferListModel::internalValue(const BitTorrent::Torrent *torrent, co
     case TR_PRIVATE:
         return (torrent->hasMetadata() ? torrent->isPrivate() : QVariant());
     case TR_PERCENT_SELECTED:
+        if (!torrent->hasMetadata())
+            return 0;
         return (torrent->wantedSize() * 100) / torrent->totalSize();
     }
 

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -452,6 +452,7 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
     case TR_PERCENT_SELECTED:
         return QString::number((torrent->wantedSize() * 100) / torrent->totalSize()) + u'%';
     }
+
     return {};
 }
 

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -449,7 +449,12 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
     case TR_REANNOUNCE:
         return reannounceString(torrent->nextAnnounce());
     case TR_PERCENT_SELECTED:
-        return torrent->hasMetadata() ? (QString::number((static_cast<qreal>(torrent->wantedSize()) * 100) / torrent->totalSize(), 'f', 2) + u'%') : tr("N/A");
+        {
+            const qint64 totalSize = torrent->totalSize();
+            if (!torrent->hasMetadata() || (totalSize <= 0))
+                return tr("N/A");
+            return QString::number((static_cast<qreal>(torrent->wantedSize()) * 100) / totalSize, 'f', 2) + u'%';
+        }
     case TR_PRIVATE:
         return privateString(torrent->isPrivate(), torrent->hasMetadata());
     }
@@ -538,7 +543,12 @@ QVariant TransferListModel::internalValue(const BitTorrent::Torrent *torrent, co
     case TR_PRIVATE:
         return (torrent->hasMetadata() ? torrent->isPrivate() : QVariant());
     case TR_PERCENT_SELECTED:
-        return torrent->hasMetadata() ? ((static_cast<qreal>(torrent->wantedSize()) * 100) / torrent->totalSize()) : 0;
+        {
+            const qint64 totalSize = torrent->totalSize();
+            if (!torrent->hasMetadata() || (totalSize <= 0))
+                return 0;
+            return (static_cast<qreal>(torrent->wantedSize()) * 100) / totalSize;
+        }
     }
 
     return {};

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -196,7 +196,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_INFOHASH_V1: return tr("Info Hash v1", "i.e: torrent info hash v1");
             case TR_INFOHASH_V2: return tr("Info Hash v2", "i.e: torrent info hash v2");
             case TR_REANNOUNCE: return tr("Reannounce In", "Indicates the time until next trackers reannounce");
-            case TR_PERCENT_SELECTED: return tr("Size %", "Percentage of selected data to download");
+            case TR_PERCENT_SELECTED: return tr("Selected", "Percentage of selected data to download");
             case TR_PRIVATE: return tr("Private", "Flags private torrents");
             default: return {};
             }

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -197,7 +197,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_INFOHASH_V2: return tr("Info Hash v2", "i.e: torrent info hash v2");
             case TR_REANNOUNCE: return tr("Reannounce In", "Indicates the time until next trackers reannounce");
             case TR_PRIVATE: return tr("Private", "Flags private torrents");
-            case TR_PERCENT_SELECTED: return tr("%", "Percentage of selected data to download.");
+            case TR_PERCENT_SELECTED: return tr("%", "Percentage of selected data to download");
             default: return {};
             }
         }
@@ -206,7 +206,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             switch (section)
             {
             case TR_POPULARITY: return tr("Ratio / Time Active (in months), indicates how popular the torrent is");
-            case TR_PERCENT_SELECTED: return tr("Wanted / Total size, indicates percentage of selected data to download.");
+            case TR_PERCENT_SELECTED: return tr("Wanted / Total size, indicates percentage of selected data to download");
             default: return {};
             }
         }
@@ -451,9 +451,7 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
     case TR_PRIVATE:
         return privateString(torrent->isPrivate(), torrent->hasMetadata());
     case TR_PERCENT_SELECTED:
-        if (!torrent->hasMetadata())
-            return tr("N/A");
-        return QString::number((torrent->wantedSize() * 100) / torrent->totalSize()) + u'%';
+        return torrent->hasMetadata() ? QString::number((static_cast<qreal>(torrent->wantedSize()) * 100) / torrent->totalSize(), 'f', 2) + u'%' : tr("N/A");
     }
 
     return {};
@@ -540,9 +538,7 @@ QVariant TransferListModel::internalValue(const BitTorrent::Torrent *torrent, co
     case TR_PRIVATE:
         return (torrent->hasMetadata() ? torrent->isPrivate() : QVariant());
     case TR_PERCENT_SELECTED:
-        if (!torrent->hasMetadata())
-            return 0;
-        return (torrent->wantedSize() * 100) / torrent->totalSize();
+        return torrent->hasMetadata() ? (static_cast<qreal>(torrent->wantedSize()) * 100) / torrent->totalSize() : 0;
     }
 
     return {};

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -197,6 +197,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_INFOHASH_V2: return tr("Info Hash v2", "i.e: torrent info hash v2");
             case TR_REANNOUNCE: return tr("Reannounce In", "Indicates the time until next trackers reannounce");
             case TR_PRIVATE: return tr("Private", "Flags private torrents");
+            case TR_PERCENT_SELECTED: return tr("% Selected", "Percentage of torrent selected");
             default: return {};
             }
         }
@@ -448,8 +449,9 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
         return reannounceString(torrent->nextAnnounce());
     case TR_PRIVATE:
         return privateString(torrent->isPrivate(), torrent->hasMetadata());
+    case TR_PERCENT_SELECTED:
+        return QString::number((torrent->wantedSize() * 100) / torrent->totalSize()) + u'%';
     }
-
     return {};
 }
 
@@ -533,6 +535,8 @@ QVariant TransferListModel::internalValue(const BitTorrent::Torrent *torrent, co
         return torrent->nextAnnounce();
     case TR_PRIVATE:
         return (torrent->hasMetadata() ? torrent->isPrivate() : QVariant());
+    case TR_PERCENT_SELECTED:
+        return (torrent->wantedSize() * 100) / torrent->totalSize();
     }
 
     return {};

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -205,8 +205,8 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
         {
             switch (section)
             {
-            case TR_POPULARITY: return tr("Ratio / Time Active (in months), indicates how popular the torrent is");
             case TR_PERCENT_SELECTED: return tr("Wanted / Total size, indicates percentage of selected data to download");
+            case TR_POPULARITY: return tr("Ratio / Time Active (in months), indicates how popular the torrent is");
             default: return {};
             }
         }

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -196,7 +196,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_INFOHASH_V1: return tr("Info Hash v1", "i.e: torrent info hash v1");
             case TR_INFOHASH_V2: return tr("Info Hash v2", "i.e: torrent info hash v2");
             case TR_REANNOUNCE: return tr("Reannounce In", "Indicates the time until next trackers reannounce");
-            case TR_PERCENT_SELECTED: return tr("%", "Percentage of selected data to download");
+            case TR_PERCENT_SELECTED: return tr("Size %", "Percentage of selected data to download");
             case TR_PRIVATE: return tr("Private", "Flags private torrents");
             default: return {};
             }

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -206,6 +206,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             switch (section)
             {
             case TR_POPULARITY: return tr("Ratio / Time Active (in months), indicates how popular the torrent is");
+            case TR_PERCENT_SELECTED: return tr("Wanted / Total size, indicates percentage of selected data to download.");
             default: return {};
             }
         }

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -197,7 +197,7 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_INFOHASH_V2: return tr("Info Hash v2", "i.e: torrent info hash v2");
             case TR_REANNOUNCE: return tr("Reannounce In", "Indicates the time until next trackers reannounce");
             case TR_PRIVATE: return tr("Private", "Flags private torrents");
-            case TR_PERCENT_SELECTED: return tr("% Selected Data", "Percentage of selected data to download.");
+            case TR_PERCENT_SELECTED: return tr("%", "Percentage of selected data to download.");
             default: return {};
             }
         }

--- a/src/gui/transferlistmodel.cpp
+++ b/src/gui/transferlistmodel.cpp
@@ -196,8 +196,8 @@ QVariant TransferListModel::headerData(const int section, const Qt::Orientation 
             case TR_INFOHASH_V1: return tr("Info Hash v1", "i.e: torrent info hash v1");
             case TR_INFOHASH_V2: return tr("Info Hash v2", "i.e: torrent info hash v2");
             case TR_REANNOUNCE: return tr("Reannounce In", "Indicates the time until next trackers reannounce");
-            case TR_PRIVATE: return tr("Private", "Flags private torrents");
             case TR_PERCENT_SELECTED: return tr("%", "Percentage of selected data to download");
+            case TR_PRIVATE: return tr("Private", "Flags private torrents");
             default: return {};
             }
         }
@@ -448,10 +448,10 @@ QString TransferListModel::displayValue(const BitTorrent::Torrent *torrent, cons
         return hashString(torrent->infoHash().v2());
     case TR_REANNOUNCE:
         return reannounceString(torrent->nextAnnounce());
+    case TR_PERCENT_SELECTED:
+        return torrent->hasMetadata() ? (QString::number((static_cast<qreal>(torrent->wantedSize()) * 100) / torrent->totalSize(), 'f', 2) + u'%') : tr("N/A");
     case TR_PRIVATE:
         return privateString(torrent->isPrivate(), torrent->hasMetadata());
-    case TR_PERCENT_SELECTED:
-        return torrent->hasMetadata() ? QString::number((static_cast<qreal>(torrent->wantedSize()) * 100) / torrent->totalSize(), 'f', 2) + u'%' : tr("N/A");
     }
 
     return {};
@@ -538,7 +538,7 @@ QVariant TransferListModel::internalValue(const BitTorrent::Torrent *torrent, co
     case TR_PRIVATE:
         return (torrent->hasMetadata() ? torrent->isPrivate() : QVariant());
     case TR_PERCENT_SELECTED:
-        return torrent->hasMetadata() ? (static_cast<qreal>(torrent->wantedSize()) * 100) / torrent->totalSize() : 0;
+        return torrent->hasMetadata() ? ((static_cast<qreal>(torrent->wantedSize()) * 100) / torrent->totalSize()) : 0;
     }
 
     return {};

--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -88,6 +88,7 @@ public:
         TR_REANNOUNCE,
         TR_PRIVATE,
         TR_CREATE_DATE,
+        TR_PERCENT_SELECTED,
 
         NB_COLUMNS
     };

--- a/src/gui/transferlistmodel.h
+++ b/src/gui/transferlistmodel.h
@@ -93,6 +93,7 @@ public:
         TR_REANNOUNCE,
         TR_PRIVATE,
         TR_CREATE_DATE,
+        TR_PERCENT_SELECTED,
 
         NB_COLUMNS
     };

--- a/src/gui/transferlistsortmodel.cpp
+++ b/src/gui/transferlistsortmodel.cpp
@@ -251,7 +251,6 @@ int TransferListSortModel::compare(const QModelIndex &left, const QModelIndex &r
     case TransferListModel::TR_RATIO:
     case TransferListModel::TR_RATIO_LIMIT:
     case TransferListModel::TR_POPULARITY:
-    case TransferListModel::TR_PERCENT_SELECTED:
         return customCompare(leftValue.toReal(), rightValue.toReal());
 
     case TransferListModel::TR_STATUS:
@@ -286,6 +285,9 @@ int TransferListSortModel::compare(const QModelIndex &left, const QModelIndex &r
             const auto totalR = right.data(TransferListModel::AdditionalUnderlyingDataRole).toInt();
             return threeWayCompare(totalL, totalR);
         }
+
+    case TransferListModel::TR_PERCENT_SELECTED:
+        return customCompare(leftValue.toFloat(), rightValue.toFloat());
 
     default:
         Q_ASSERT_X(false, Q_FUNC_INFO, "Missing comparison case");

--- a/src/gui/transferlistsortmodel.cpp
+++ b/src/gui/transferlistsortmodel.cpp
@@ -286,6 +286,7 @@ int TransferListSortModel::compare(const QModelIndex &left, const QModelIndex &r
             const auto totalR = right.data(TransferListModel::AdditionalUnderlyingDataRole).toInt();
             return threeWayCompare(totalL, totalR);
         }
+
     default:
         Q_ASSERT_X(false, Q_FUNC_INFO, "Missing comparison case");
         break;

--- a/src/gui/transferlistsortmodel.cpp
+++ b/src/gui/transferlistsortmodel.cpp
@@ -251,6 +251,7 @@ int TransferListSortModel::compare(const QModelIndex &left, const QModelIndex &r
     case TransferListModel::TR_RATIO:
     case TransferListModel::TR_RATIO_LIMIT:
     case TransferListModel::TR_POPULARITY:
+    case TransferListModel::TR_PERCENT_SELECTED:
         return customCompare(leftValue.toReal(), rightValue.toReal());
 
     case TransferListModel::TR_STATUS:
@@ -285,7 +286,6 @@ int TransferListSortModel::compare(const QModelIndex &left, const QModelIndex &r
             const auto totalR = right.data(TransferListModel::AdditionalUnderlyingDataRole).toInt();
             return threeWayCompare(totalL, totalR);
         }
-
     default:
         Q_ASSERT_X(false, Q_FUNC_INFO, "Missing comparison case");
         break;

--- a/src/gui/transferlistsortmodel.cpp
+++ b/src/gui/transferlistsortmodel.cpp
@@ -250,6 +250,7 @@ int TransferListSortModel::compare(const QModelIndex &left, const QModelIndex &r
     case TransferListModel::TR_PROGRESS:
     case TransferListModel::TR_RATIO:
     case TransferListModel::TR_RATIO_LIMIT:
+    case TransferListModel::TR_PERCENT_SELECTED:
     case TransferListModel::TR_POPULARITY:
         return customCompare(leftValue.toReal(), rightValue.toReal());
 
@@ -285,9 +286,6 @@ int TransferListSortModel::compare(const QModelIndex &left, const QModelIndex &r
             const auto totalR = right.data(TransferListModel::AdditionalUnderlyingDataRole).toInt();
             return threeWayCompare(totalL, totalR);
         }
-
-    case TransferListModel::TR_PERCENT_SELECTED:
-        return customCompare(leftValue.toFloat(), rightValue.toFloat());
 
     default:
         Q_ASSERT_X(false, Q_FUNC_INFO, "Missing comparison case");

--- a/src/gui/transferlistsortmodel.cpp
+++ b/src/gui/transferlistsortmodel.cpp
@@ -247,11 +247,11 @@ int TransferListSortModel::compare(const QModelIndex &left, const QModelIndex &r
         return customCompare(leftValue.toLongLong(), rightValue.toLongLong());
 
     case TransferListModel::TR_AVAILABILITY:
+    case TransferListModel::TR_PERCENT_SELECTED:
+    case TransferListModel::TR_POPULARITY:
     case TransferListModel::TR_PROGRESS:
     case TransferListModel::TR_RATIO:
     case TransferListModel::TR_RATIO_LIMIT:
-    case TransferListModel::TR_PERCENT_SELECTED:
-    case TransferListModel::TR_POPULARITY:
         return customCompare(leftValue.toReal(), rightValue.toReal());
 
     case TransferListModel::TR_STATUS:

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -180,6 +180,7 @@ TransferListWidget::TransferListWidget(IGUIApplication *app, QWidget *parent)
         setColumnHidden(TransferListModel::TR_TOTAL_SIZE, true);
         setColumnHidden(TransferListModel::TR_REANNOUNCE, true);
         setColumnHidden(TransferListModel::TR_PRIVATE, true);
+        setColumnHidden(TransferListModel::TR_PERCENT_SELECTED, true);
     }
 
     //Ensure that at least one column is visible at all times

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -182,14 +182,6 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         {KEY_TORRENT_LAST_ACTIVITY_TIME, getLastActivityTime()},
         {KEY_TORRENT_AVAILABILITY, torrent.distributedCopies()},
         {KEY_TORRENT_REANNOUNCE, torrent.nextAnnounce()},
-<<<<<<< HEAD
         {KEY_TORRENT_COMMENT, torrent.comment()}
-=======
-        {KEY_TORRENT_COMMENT, torrent.comment()},
-        {KEY_TORRENT_PRIVATE, (torrent.hasMetadata() ? torrent.isPrivate() : QVariant())},
-        {KEY_TORRENT_TOTAL_SIZE, torrent.totalSize()},
-        {KEY_TORRENT_HAS_METADATA, torrent.hasMetadata()},
-        {KEY_TORRENT_PERCENT_SELECTED, torrent.hasMetadata() ? (torrent.wantedSize() * 100) / torrent.totalSize() : -1},
->>>>>>> ba7b726ce (Pass number to WebUI instead of text and use float when comparing.)
     };
 }

--- a/src/webui/api/serialize/serialize_torrent.cpp
+++ b/src/webui/api/serialize/serialize_torrent.cpp
@@ -182,6 +182,14 @@ QVariantMap serialize(const BitTorrent::Torrent &torrent)
         {KEY_TORRENT_LAST_ACTIVITY_TIME, getLastActivityTime()},
         {KEY_TORRENT_AVAILABILITY, torrent.distributedCopies()},
         {KEY_TORRENT_REANNOUNCE, torrent.nextAnnounce()},
+<<<<<<< HEAD
         {KEY_TORRENT_COMMENT, torrent.comment()}
+=======
+        {KEY_TORRENT_COMMENT, torrent.comment()},
+        {KEY_TORRENT_PRIVATE, (torrent.hasMetadata() ? torrent.isPrivate() : QVariant())},
+        {KEY_TORRENT_TOTAL_SIZE, torrent.totalSize()},
+        {KEY_TORRENT_HAS_METADATA, torrent.hasMetadata()},
+        {KEY_TORRENT_PERCENT_SELECTED, torrent.hasMetadata() ? (torrent.wantedSize() * 100) / torrent.totalSize() : -1},
+>>>>>>> ba7b726ce (Pass number to WebUI instead of text and use float when comparing.)
     };
 }

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1181,14 +1181,14 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.newColumn("infohash_v2", "", "QBT_TR(Info Hash v2)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("reannounce", "", "QBT_TR(Reannounce In)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("private", "", "QBT_TR(Private)QBT_TR[CONTEXT=TransferListModel]", 100, false);
-            this.newColumn("percent_selected", "", "QBT_TR(%)QBT_TR[CONTEXT=TransferListModel]", 100, false);
+            this.newColumn("percent_selected", "", "QBT_TR(Size %)QBT_TR[CONTEXT=TransferListModel]", 100, false);
 
             this.columns["state_icon"].dataProperties[0] = "state";
             this.columns["name"].dataProperties.push("state");
             this.columns["num_seeds"].dataProperties.push("num_complete");
             this.columns["num_leechs"].dataProperties.push("num_incomplete");
             this.columns["time_active"].dataProperties.push("seeding_time");
-            this.columns["percent_selected"].dataProperties = ["size", "total_size", "has_metadata"];
+            this.columns["percent_selected"].dataProperties = ["has_metadata", "size", "total_size"];
 
             this.initColumnsFunctions();
         }
@@ -1584,14 +1584,14 @@ window.qBittorrent.DynamicTable ??= (() => {
 
             // percent_selected
             this.columns["percent_selected"].updateTd = function(td, row) {
-                const size = this.getRowValue(row, 0);
-                const totalSize = this.getRowValue(row, 1);
-                const hasMetadata = this.getRowValue(row, 2);
+                const hasMetadata = this.getRowValue(row, 0);
                 if (hasMetadata === false) {
                     td.textContent = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     return;
                 }
+                const size = this.getRowValue(row, 1);
+                const totalSize = this.getRowValue(row, 2);
                 const percent = (size / totalSize) * 100;
                 if (percent === -1) {
                     td.textContent = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
@@ -1601,6 +1601,24 @@ window.qBittorrent.DynamicTable ??= (() => {
                 const value = `${window.qBittorrent.Misc.toFixedPointString(percent, 2)}%`;
                 td.textContent = value;
                 td.title = value;
+            };
+            this.columns["percent_selected"].compareRows = function(row1, row2) {
+                let percent1 = 0;
+                let percent2 = 0;
+                const hasMetadata1 = this.getRowValue(row1, 0);
+                if (hasMetadata1 !== false) {
+                    const size1 = this.getRowValue(row1, 1);
+                    const totalSize1 = this.getRowValue(row1, 2);
+                    percent1 = (size1 / totalSize1) * 100;
+                }
+                const hasMetadata2 = this.getRowValue(row2, 0);
+                if (hasMetadata2 !== false) {
+                    const size2 = this.getRowValue(row2, 1);
+                    const totalSize2 = this.getRowValue(row2, 2);
+                    percent2 = (size2 / totalSize2) * 100;
+                }
+
+                return compareNumbers(percent1, percent2);
             };
         }
 

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1181,7 +1181,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.newColumn("infohash_v2", "", "QBT_TR(Info Hash v2)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("reannounce", "", "QBT_TR(Reannounce In)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("private", "", "QBT_TR(Private)QBT_TR[CONTEXT=TransferListModel]", 100, false);
-            this.newColumn("percent_selected", "", "QBT_TR(Percent Selected)QBT_TR[CONTEXT=TransferListModel]", 100, false);
+            this.newColumn("percent_selected", "", "QBT_TR(%)QBT_TR[CONTEXT=TransferListModel]", 100, false);
 
             this.columns["state_icon"].dataProperties[0] = "state";
             this.columns["name"].dataProperties.push("state");

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1607,9 +1607,9 @@ window.qBittorrent.DynamicTable ??= (() => {
                 const hasMetadata1 = this.getRowValue(row1, 0);
                 const hasMetadata2 = this.getRowValue(row2, 0);
 
-                if (hasMetadata1 === true && hasMetadata2 === false)
+                if ((hasMetadata1 === true) && (hasMetadata2 === false))
                     return -1;
-                if (hasMetadata1 === false && hasMetadata2 === true)
+                if ((hasMetadata1 === false) && (hasMetadata2 === true))
                     return 1;
 
                 const size1 = this.getRowValue(row1, 1);

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1592,33 +1592,39 @@ window.qBittorrent.DynamicTable ??= (() => {
                 }
                 const size = this.getRowValue(row, 1);
                 const totalSize = this.getRowValue(row, 2);
-                const percent = (size / totalSize) * 100;
-                if (percent === -1) {
+                if (totalSize <= 0) {
                     td.textContent = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     return;
                 }
+                const percent = (size / totalSize) * 100;
                 const value = `${window.qBittorrent.Misc.toFixedPointString(percent, 2)}%`;
                 td.textContent = value;
                 td.title = value;
             };
-            this.columns["percent_selected"].compareRows = function(row1, row2) {
-                let percent1 = 0;
-                let percent2 = 0;
-                const hasMetadata1 = this.getRowValue(row1, 0);
-                if (hasMetadata1 !== false) {
-                    const size1 = this.getRowValue(row1, 1);
-                    const totalSize1 = this.getRowValue(row1, 2);
-                    percent1 = (size1 / totalSize1) * 100;
-                }
-                const hasMetadata2 = this.getRowValue(row2, 0);
-                if (hasMetadata2 !== false) {
-                    const size2 = this.getRowValue(row2, 1);
-                    const totalSize2 = this.getRowValue(row2, 2);
-                    percent2 = (size2 / totalSize2) * 100;
-                }
 
-                return compareNumbers(percent1, percent2);
+            this.columns["percent_selected"].compareRows = function(row1, row2) {
+                const hasMetadata1 = this.getRowValue(row1, 0);
+                const hasMetadata2 = this.getRowValue(row2, 0);
+
+                if (hasMetadata1 === true && hasMetadata2 === false)
+                    return -1;
+                if (hasMetadata1 === false && hasMetadata2 === true)
+                    return 1;
+
+                const size1 = this.getRowValue(row1, 1);
+                const totalSize1 = this.getRowValue(row1, 2);
+                if (totalSize1 <= 0)
+                    return 1;
+                const ratio1 = (size1 / totalSize1) * 100;
+
+                const size2 = this.getRowValue(row2, 1);
+                const totalSize2 = this.getRowValue(row2, 2);
+                if (totalSize2 <= 0)
+                    return -1;
+                const ratio2 = (size2 / totalSize2) * 100;
+
+                return compareNumbers(ratio1, ratio2);
             };
         }
 

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1181,7 +1181,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.newColumn("infohash_v2", "", "QBT_TR(Info Hash v2)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("reannounce", "", "QBT_TR(Reannounce In)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("private", "", "QBT_TR(Private)QBT_TR[CONTEXT=TransferListModel]", 100, false);
-            this.newColumn("percent_selected", "", "QBT_TR(Size %)QBT_TR[CONTEXT=TransferListModel]", 100, false);
+            this.newColumn("percent_selected", "", "QBT_TR(Selected)QBT_TR[CONTEXT=TransferListModel]", 100, false);
 
             this.columns["state_icon"].dataProperties[0] = "state";
             this.columns["name"].dataProperties.push("state");

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1181,6 +1181,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.newColumn("infohash_v2", "", "QBT_TR(Info Hash v2)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("reannounce", "", "QBT_TR(Reannounce In)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("private", "", "QBT_TR(Private)QBT_TR[CONTEXT=TransferListModel]", 100, false);
+            this.newColumn("percent_selected", "", "QBT_TR(Percent Selected)QBT_TR[CONTEXT=TransferListModel]", 100, false);
 
             this.columns["state_icon"].dataProperties[0] = "state";
             this.columns["name"].dataProperties.push("state");

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1054,7 +1054,8 @@ window.qBittorrent.DynamicTable ??= (() => {
                     tds[i].style.width = `${this.columns[i].width}px`;
                     tds[i].style.maxWidth = `${this.columns[i].width}px`;
                 }
-                this.columns[i].updateTd(tds[i], row);
+                if (this.columns[i].dataProperties.some(prop => Object.hasOwn(data, prop)))
+                    this.columns[i].updateTd(tds[i], row);
             }
             row.data = {};
         }
@@ -1187,6 +1188,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.columns["num_seeds"].dataProperties.push("num_complete");
             this.columns["num_leechs"].dataProperties.push("num_incomplete");
             this.columns["time_active"].dataProperties.push("seeding_time");
+            this.columns["percent_selected"].dataProperties = ["size", "total_size", "has_metadata"];
 
             this.initColumnsFunctions();
         }
@@ -1582,13 +1584,15 @@ window.qBittorrent.DynamicTable ??= (() => {
 
             // percent_selected
             this.columns["percent_selected"].updateTd = function(td, row) {
-                const fullData = row["full_data"];
-                if (fullData["has_metadata"] === false) {
+                const size = this.getRowValue(row, 0);
+                const totalSize = this.getRowValue(row, 1);
+                const hasMetadata = this.getRowValue(row, 2);
+                if (hasMetadata === false) {
                     td.textContent = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     return;
                 }
-                const percent = (fullData["size"] / fullData["total_size"]) * 100;
+                const percent = (size / totalSize) * 100;
                 if (percent === -1) {
                     td.textContent = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1580,6 +1580,18 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.textContent = string;
                 td.title = string;
             };
+
+            // percent_selected
+            this.columns["percent_selected"].updateTd = function(td, row) {
+                if (this.getRowValue(row) === -1) {
+                    td.textContent = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
+                    td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
+                    return;
+                }
+                const value = window.qBittorrent.Misc.toFixedPointString(this.getRowValue(row), 2) + "%";
+                td.textContent = value;
+                td.title = value;
+            };
         }
 
         applyFilter(row, filterName, category, tag, trackerHost, filterTerms) {

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1585,7 +1585,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             // percent_selected
             this.columns["percent_selected"].updateTd = function(td, row) {
                 const hasMetadata = this.getRowValue(row, 0);
-                if (hasMetadata === false) {
+                if (!hasMetadata) {
                     td.textContent = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     return;
@@ -1607,9 +1607,9 @@ window.qBittorrent.DynamicTable ??= (() => {
                 const hasMetadata1 = this.getRowValue(row1, 0);
                 const hasMetadata2 = this.getRowValue(row2, 0);
 
-                if ((hasMetadata1 === true) && (hasMetadata2 === false))
+                if (hasMetadata1 && !hasMetadata2)
                     return -1;
-                if ((hasMetadata1 === false) && (hasMetadata2 === true))
+                if (!hasMetadata1 && hasMetadata2)
                     return 1;
 
                 const size1 = this.getRowValue(row1, 1);

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1588,7 +1588,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                     td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     return;
                 }
-                const value = window.qBittorrent.Misc.toFixedPointString(this.getRowValue(row), 2) + "%";
+                const value = `${window.qBittorrent.Misc.toFixedPointString(this.getRowValue(row), 2)  }%`;
                 td.textContent = value;
                 td.title = value;
             };

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1054,8 +1054,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                     tds[i].style.width = `${this.columns[i].width}px`;
                     tds[i].style.maxWidth = `${this.columns[i].width}px`;
                 }
-                if (this.columns[i].dataProperties.some(prop => Object.hasOwn(data, prop)))
-                    this.columns[i].updateTd(tds[i], row);
+                this.columns[i].updateTd(tds[i], row);
             }
             row.data = {};
         }
@@ -1583,7 +1582,13 @@ window.qBittorrent.DynamicTable ??= (() => {
 
             // percent_selected
             this.columns["percent_selected"].updateTd = function(td, row) {
-                const percent = this.getRowValue(row);
+                const fullData = row["full_data"];
+                if (fullData["has_metadata"] === false) {
+                    td.textContent = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
+                    td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
+                    return;
+                }
+                const percent = (fullData["size"] / fullData["total_size"]) * 100;
                 if (percent === -1) {
                     td.textContent = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1589,7 +1589,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                     td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     return;
                 }
-                const value = `${window.qBittorrent.Misc.toFixedPointString(percent, 2)  }%`;
+                const value = `${window.qBittorrent.Misc.toFixedPointString(percent, 2)}%`;
                 td.textContent = value;
                 td.title = value;
             };

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1583,12 +1583,13 @@ window.qBittorrent.DynamicTable ??= (() => {
 
             // percent_selected
             this.columns["percent_selected"].updateTd = function(td, row) {
-                if (this.getRowValue(row) === -1) {
+                const percent = this.getRowValue(row);
+                if (percent === -1) {
                     td.textContent = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     return;
                 }
-                const value = `${window.qBittorrent.Misc.toFixedPointString(this.getRowValue(row), 2)  }%`;
+                const value = `${window.qBittorrent.Misc.toFixedPointString(percent, 2)  }%`;
                 td.textContent = value;
                 td.title = value;
             };

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1650,9 +1650,9 @@ window.qBittorrent.DynamicTable ??= (() => {
                 const hasMetadata1 = this.getRowValue(row1, 0);
                 const hasMetadata2 = this.getRowValue(row2, 0);
 
-                if (hasMetadata1 === true && hasMetadata2 === false)
+                if ((hasMetadata1 === true) && (hasMetadata2 === false))
                     return -1;
-                if (hasMetadata1 === false && hasMetadata2 === true)
+                if ((hasMetadata1 === false) && (hasMetadata2 === true))
                     return 1;
 
                 const size1 = this.getRowValue(row1, 1);

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1224,6 +1224,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.newColumn("infohash_v2", "", "QBT_TR(Info Hash v2)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("reannounce", "", "QBT_TR(Reannounce In)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("private", "", "QBT_TR(Private)QBT_TR[CONTEXT=TransferListModel]", 100, false);
+            this.newColumn("percent_selected", "", "QBT_TR(Percent Selected)QBT_TR[CONTEXT=TransferListModel]", 100, false);
 
             this.columns["state_icon"].dataProperties[0] = "state";
             this.columns["name"].dataProperties.push("state");

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1632,7 +1632,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                     td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     return;
                 }
-                const value = `${window.qBittorrent.Misc.toFixedPointString(percent, 2)  }%`;
+                const value = `${window.qBittorrent.Misc.toFixedPointString(percent, 2)}%`;
                 td.textContent = value;
                 td.title = value;
             };

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1626,12 +1626,13 @@ window.qBittorrent.DynamicTable ??= (() => {
 
             // percent_selected
             this.columns["percent_selected"].updateTd = function(td, row) {
-                if (this.getRowValue(row) === -1) {
+                const percent = this.getRowValue(row);
+                if (percent === -1) {
                     td.textContent = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     return;
                 }
-                const value = `${window.qBittorrent.Misc.toFixedPointString(this.getRowValue(row), 2)  }%`;
+                const value = `${window.qBittorrent.Misc.toFixedPointString(percent, 2)  }%`;
                 td.textContent = value;
                 td.title = value;
             };

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1628,16 +1628,16 @@ window.qBittorrent.DynamicTable ??= (() => {
             // percent_selected
             this.columns["percent_selected"].updateTd = function(td, row) {
                 const hasMetadata = this.getRowValue(row, 0);
-                if (hasMetadata === false) {
-                    td.textContent = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
-                    td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
+                if (!hasMetadata) {
+                    td.textContent = "QBT_TR(N/A)QBT_TR[CONTEXT=TransferListDelegate]";
+                    td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TransferListDelegate]";
                     return;
                 }
                 const size = this.getRowValue(row, 1);
                 const totalSize = this.getRowValue(row, 2);
                 if (totalSize <= 0) {
-                    td.textContent = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
-                    td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
+                    td.textContent = "QBT_TR(N/A)QBT_TR[CONTEXT=TransferListDelegate]";
+                    td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TransferListDelegate]";
                     return;
                 }
                 const percent = (size / totalSize) * 100;
@@ -1650,9 +1650,9 @@ window.qBittorrent.DynamicTable ??= (() => {
                 const hasMetadata1 = this.getRowValue(row1, 0);
                 const hasMetadata2 = this.getRowValue(row2, 0);
 
-                if ((hasMetadata1 === true) && (hasMetadata2 === false))
+                if (hasMetadata1 && !hasMetadata2)
                     return -1;
-                if ((hasMetadata1 === false) && (hasMetadata2 === true))
+                if (!hasMetadata1 && hasMetadata2)
                     return 1;
 
                 const size1 = this.getRowValue(row1, 1);

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1097,8 +1097,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                     tds[i].style.width = `${this.columns[i].width}px`;
                     tds[i].style.maxWidth = `${this.columns[i].width}px`;
                 }
-                if (this.columns[i].dataProperties.some(prop => Object.hasOwn(data, prop)))
-                    this.columns[i].updateTd(tds[i], row);
+                this.columns[i].updateTd(tds[i], row);
             }
             row.data = {};
         }
@@ -1626,7 +1625,13 @@ window.qBittorrent.DynamicTable ??= (() => {
 
             // percent_selected
             this.columns["percent_selected"].updateTd = function(td, row) {
-                const percent = this.getRowValue(row);
+                const fullData = row["full_data"];
+                if (fullData["has_metadata"] === false) {
+                    td.textContent = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
+                    td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
+                    return;
+                }
+                const percent = (fullData["size"] / fullData["total_size"]) * 100;
                 if (percent === -1) {
                     td.textContent = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1224,7 +1224,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.newColumn("infohash_v2", "", "QBT_TR(Info Hash v2)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("reannounce", "", "QBT_TR(Reannounce In)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("private", "", "QBT_TR(Private)QBT_TR[CONTEXT=TransferListModel]", 100, false);
-            this.newColumn("percent_selected", "", "QBT_TR(Percent Selected)QBT_TR[CONTEXT=TransferListModel]", 100, false);
+            this.newColumn("percent_selected", "", "QBT_TR(%)QBT_TR[CONTEXT=TransferListModel]", 100, false);
 
             this.columns["state_icon"].dataProperties[0] = "state";
             this.columns["name"].dataProperties.push("state");

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1635,33 +1635,39 @@ window.qBittorrent.DynamicTable ??= (() => {
                 }
                 const size = this.getRowValue(row, 1);
                 const totalSize = this.getRowValue(row, 2);
-                const percent = (size / totalSize) * 100;
-                if (percent === -1) {
+                if (totalSize <= 0) {
                     td.textContent = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     return;
                 }
+                const percent = (size / totalSize) * 100;
                 const value = `${window.qBittorrent.Misc.toFixedPointString(percent, 2)}%`;
                 td.textContent = value;
                 td.title = value;
             };
-            this.columns["percent_selected"].compareRows = function(row1, row2) {
-                let percent1 = 0;
-                let percent2 = 0;
-                const hasMetadata1 = this.getRowValue(row1, 0);
-                if (hasMetadata1 !== false) {
-                    const size1 = this.getRowValue(row1, 1);
-                    const totalSize1 = this.getRowValue(row1, 2);
-                    percent1 = (size1 / totalSize1) * 100;
-                }
-                const hasMetadata2 = this.getRowValue(row2, 0);
-                if (hasMetadata2 !== false) {
-                    const size2 = this.getRowValue(row2, 1);
-                    const totalSize2 = this.getRowValue(row2, 2);
-                    percent2 = (size2 / totalSize2) * 100;
-                }
 
-                return compareNumbers(percent1, percent2);
+            this.columns["percent_selected"].compareRows = function(row1, row2) {
+                const hasMetadata1 = this.getRowValue(row1, 0);
+                const hasMetadata2 = this.getRowValue(row2, 0);
+
+                if (hasMetadata1 === true && hasMetadata2 === false)
+                    return -1;
+                if (hasMetadata1 === false && hasMetadata2 === true)
+                    return 1;
+
+                const size1 = this.getRowValue(row1, 1);
+                const totalSize1 = this.getRowValue(row1, 2);
+                if (totalSize1 <= 0)
+                    return 1;
+                const ratio1 = (size1 / totalSize1) * 100;
+
+                const size2 = this.getRowValue(row2, 1);
+                const totalSize2 = this.getRowValue(row2, 2);
+                if (totalSize2 <= 0)
+                    return -1;
+                const ratio2 = (size2 / totalSize2) * 100;
+
+                return compareNumbers(ratio1, ratio2);
             };
         }
 

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1623,6 +1623,18 @@ window.qBittorrent.DynamicTable ??= (() => {
                 td.textContent = string;
                 td.title = string;
             };
+
+            // percent_selected
+            this.columns["percent_selected"].updateTd = function(td, row) {
+                if (this.getRowValue(row) === -1) {
+                    td.textContent = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
+                    td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
+                    return;
+                }
+                const value = window.qBittorrent.Misc.toFixedPointString(this.getRowValue(row), 2) + "%";
+                td.textContent = value;
+                td.title = value;
+            };
         }
 
         applyFilter(row, filterName, category, tag, trackerHost, filterTerms) {

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1224,14 +1224,14 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.newColumn("infohash_v2", "", "QBT_TR(Info Hash v2)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("reannounce", "", "QBT_TR(Reannounce In)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("private", "", "QBT_TR(Private)QBT_TR[CONTEXT=TransferListModel]", 100, false);
-            this.newColumn("percent_selected", "", "QBT_TR(%)QBT_TR[CONTEXT=TransferListModel]", 100, false);
+            this.newColumn("percent_selected", "", "QBT_TR(Size %)QBT_TR[CONTEXT=TransferListModel]", 100, false);
 
             this.columns["state_icon"].dataProperties[0] = "state";
             this.columns["name"].dataProperties.push("state");
             this.columns["num_seeds"].dataProperties.push("num_complete");
             this.columns["num_leechs"].dataProperties.push("num_incomplete");
             this.columns["time_active"].dataProperties.push("seeding_time");
-            this.columns["percent_selected"].dataProperties = ["size", "total_size", "has_metadata"];
+            this.columns["percent_selected"].dataProperties = ["has_metadata", "size", "total_size"];
 
             this.initColumnsFunctions();
         }
@@ -1627,14 +1627,14 @@ window.qBittorrent.DynamicTable ??= (() => {
 
             // percent_selected
             this.columns["percent_selected"].updateTd = function(td, row) {
-                const size = this.getRowValue(row, 0);
-                const totalSize = this.getRowValue(row, 1);
-                const hasMetadata = this.getRowValue(row, 2);
+                const hasMetadata = this.getRowValue(row, 0);
                 if (hasMetadata === false) {
                     td.textContent = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     return;
                 }
+                const size = this.getRowValue(row, 1);
+                const totalSize = this.getRowValue(row, 2);
                 const percent = (size / totalSize) * 100;
                 if (percent === -1) {
                     td.textContent = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
@@ -1644,6 +1644,24 @@ window.qBittorrent.DynamicTable ??= (() => {
                 const value = `${window.qBittorrent.Misc.toFixedPointString(percent, 2)}%`;
                 td.textContent = value;
                 td.title = value;
+            };
+            this.columns["percent_selected"].compareRows = function(row1, row2) {
+                let percent1 = 0;
+                let percent2 = 0;
+                const hasMetadata1 = this.getRowValue(row1, 0);
+                if (hasMetadata1 !== false) {
+                    const size1 = this.getRowValue(row1, 1);
+                    const totalSize1 = this.getRowValue(row1, 2);
+                    percent1 = (size1 / totalSize1) * 100;
+                }
+                const hasMetadata2 = this.getRowValue(row2, 0);
+                if (hasMetadata2 !== false) {
+                    const size2 = this.getRowValue(row2, 1);
+                    const totalSize2 = this.getRowValue(row2, 2);
+                    percent2 = (size2 / totalSize2) * 100;
+                }
+
+                return compareNumbers(percent1, percent2);
             };
         }
 

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1631,7 +1631,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                     td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     return;
                 }
-                const value = window.qBittorrent.Misc.toFixedPointString(this.getRowValue(row), 2) + "%";
+                const value = `${window.qBittorrent.Misc.toFixedPointString(this.getRowValue(row), 2)  }%`;
                 td.textContent = value;
                 td.title = value;
             };

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1097,7 +1097,8 @@ window.qBittorrent.DynamicTable ??= (() => {
                     tds[i].style.width = `${this.columns[i].width}px`;
                     tds[i].style.maxWidth = `${this.columns[i].width}px`;
                 }
-                this.columns[i].updateTd(tds[i], row);
+                if (this.columns[i].dataProperties.some(prop => Object.hasOwn(data, prop)))
+                    this.columns[i].updateTd(tds[i], row);
             }
             row.data = {};
         }
@@ -1230,6 +1231,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.columns["num_seeds"].dataProperties.push("num_complete");
             this.columns["num_leechs"].dataProperties.push("num_incomplete");
             this.columns["time_active"].dataProperties.push("seeding_time");
+            this.columns["percent_selected"].dataProperties = ["size", "total_size", "has_metadata"];
 
             this.initColumnsFunctions();
         }
@@ -1625,13 +1627,15 @@ window.qBittorrent.DynamicTable ??= (() => {
 
             // percent_selected
             this.columns["percent_selected"].updateTd = function(td, row) {
-                const fullData = row["full_data"];
-                if (fullData["has_metadata"] === false) {
+                const size = this.getRowValue(row, 0);
+                const totalSize = this.getRowValue(row, 1);
+                const hasMetadata = this.getRowValue(row, 2);
+                if (hasMetadata === false) {
                     td.textContent = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     return;
                 }
-                const percent = (fullData["size"] / fullData["total_size"]) * 100;
+                const percent = (size / totalSize) * 100;
                 if (percent === -1) {
                     td.textContent = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";
                     td.title = "QBT_TR(N/A)QBT_TR[CONTEXT=TrackerListWidget]";

--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -1224,7 +1224,7 @@ window.qBittorrent.DynamicTable ??= (() => {
             this.newColumn("infohash_v2", "", "QBT_TR(Info Hash v2)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("reannounce", "", "QBT_TR(Reannounce In)QBT_TR[CONTEXT=TransferListModel]", 100, false);
             this.newColumn("private", "", "QBT_TR(Private)QBT_TR[CONTEXT=TransferListModel]", 100, false);
-            this.newColumn("percent_selected", "", "QBT_TR(Size %)QBT_TR[CONTEXT=TransferListModel]", 100, false);
+            this.newColumn("percent_selected", "", "QBT_TR(Selected)QBT_TR[CONTEXT=TransferListModel]", 100, false);
 
             this.columns["state_icon"].dataProperties[0] = "state";
             this.columns["name"].dataProperties.push("state");


### PR DESCRIPTION
Closes #22087.

# Description

A new column that displays the % of selected data from a torrent.
Its meant to make it easier to distinguish and manage partial torrents as described in the issue.

# UI images

Two partial picture of the UI follow, first is from Desktop app (Linux) second is from WebUI (Linux, Mozilla)
![image](https://github.com/user-attachments/assets/acb26269-6e5c-49b6-bd9a-d74b76a0748c)
![image](https://github.com/user-attachments/assets/af2e3e61-4d6c-4a52-82e8-ffed193bf755)

# Example use case
You download a few episodes of series or files and want to determine by the first files if its worth downloading the whole torrent. In the presence of multiple torrents it might become bothersome to seek out those partial ones.
With this column you could go in `Completed` and order by `% Selected` ascending, which would put the partial torrents on top. From there on its up to the user.