### PR TITLE
WebUI: temporarily pin dependency version

### DIFF
--- a/src/webui/www/package.json
+++ b/src/webui/www/package.json
@@ -13,7 +13,7 @@
     "@stylistic/eslint-plugin": "*",
     "eslint": "*",
     "eslint-plugin-html": "*",
-    "eslint-plugin-prefer-arrow-functions": "*",
+    "eslint-plugin-prefer-arrow-functions": "3.4.2",
     "eslint-plugin-regexp": "*",
     "html-validate": "*",
     "js-beautify": "*",


### PR DESCRIPTION
The plugin was causing problems in new versions so pin it with an older version and look into it later.
