### PR TITLE
Fix typo in WebApplication::isAuthNeeded()

### DIFF
--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -700,7 +700,7 @@ QString WebApplication::generateSid() const
 
 bool WebApplication::isAuthNeeded()
 {
-    if (!m_isLocalAuthEnabled && m_clientAddress.isLoopback())
+    if (m_isLocalAuthEnabled && m_clientAddress.isLoopback())
         return false;
     if (m_isAuthSubnetWhitelistEnabled && Utils::Net::isIPInSubnets(m_clientAddress, m_authSubnetWhitelist))
         return false;


### PR DESCRIPTION
If we want local auth without username/password
(m_isLocalAuthEnabled is set) and client address is loopback,
we should return false from WebApplication::isAuthNeeded().
