### PR TITLE
Allow to reuse existing search term

### DIFF
--- a/src/gui/search/searchjobwidget.cpp
+++ b/src/gui/search/searchjobwidget.cpp
@@ -286,6 +286,7 @@ void SearchJobWidget::cancelSearch()
         return;
 
     m_searchHandler->cancelSearch();
+    setStatus(Status::Aborted);
 }
 
 void SearchJobWidget::downloadTorrents(const AddTorrentOption option)

--- a/src/gui/search/searchwidget.h
+++ b/src/gui/search/searchwidget.h
@@ -65,8 +65,9 @@ private:
     void pluginsButtonClicked();
     void searchButtonClicked();
     void stopButtonClicked();
+    void searchTextEdited(const QString &text);
+    void currentTabChanged(int index);
 
-    void tabChanged(int index);
     void tabStatusChanged(SearchJobWidget *tab);
 
     void closeTab(int index);
@@ -76,11 +77,11 @@ private:
 
     void selectMultipleBox(int index);
     void toggleFocusBetweenLineEdits();
+    void adjustSearchButton();
 
     void fillCatCombobox();
     void fillPluginComboBox();
     void selectActivePage();
-    void searchTextEdited(const QString &);
 
     QString selectedCategory() const;
     QStringList selectedPlugins() const;


### PR DESCRIPTION
The search pattern text reflects that of the current search tab, unless it is manually edited.
The edited search pattern can be reset by double-clicking on one of the tabs.

The alternative option @bartonnen [suggested](https://github.com/qbittorrent/qBittorrent/issues/17184#issuecomment-2573591004) is to simply follow the current tab regardless of whether the pattern has been edited or not. This behavior seems undesirable to me.