### PR TITLE
WebUI: add percentage sign for hsl components

### DIFF
--- a/src/webui/www/private/css/Window.css
+++ b/src/webui/www/private/css/Window.css
@@ -205,7 +205,7 @@ div.mochaToolbarWrapper.bottom {
 ---------------------------------------------------------------- */
 
 #modalOverlay {
-    background: hsla(0deg 0 0 / 30%);
+    background: hsl(0deg 0% 0% / 30%);
     display: none;
     left: 0;
     opacity: 0;


### PR DESCRIPTION
This is a workaround to avoid confusing the stylelint checker (and probably some other checker internally). They cannot accept the fact that the component can be `<number>` but instead insist it should be `<percentage>`
Reference: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl#formal_syntax

Also, MDN recommended to use `hsl()` instead of `hsla()`.
From https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl :
> Note: The hsla() functional notation is an alias for hsl(). They are exactly equivalent. It is recommended to use hsl().
