### PR TITLE
WebAPI: Do not wrap result if offset is invalid

### DIFF
--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -386,8 +386,10 @@ void TorrentsController::infoAction()
     // normalize offset
     if (offset < 0)
         offset = size + offset;
-    if ((offset >= size) || (offset < 0))
-        throw APIError(APIErrorType::Conflict, tr("Offset is out of range"));
+    if ((offset >= size) || (offset < 0)) {
+        setResult(QJsonArray {});
+        return;
+    }
     // normalize limit
     if (limit <= 0)
         limit = -1; // unlimited

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -387,7 +387,7 @@ void TorrentsController::infoAction()
     if (offset < 0)
         offset = size + offset;
     if ((offset >= size) || (offset < 0))
-        offset = 0;
+        throw APIError(APIErrorType::Conflict, tr("Offset is out of range"));
     // normalize limit
     if (limit <= 0)
         limit = -1; // unlimited

--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -386,10 +386,6 @@ void TorrentsController::infoAction()
     // normalize offset
     if (offset < 0)
         offset = size + offset;
-    if ((offset >= size) || (offset < 0)) {
-        setResult(QJsonArray {});
-        return;
-    }
     // normalize limit
     if (limit <= 0)
         limit = -1; // unlimited


### PR DESCRIPTION
Closes #22158.