### PR TITLE
Avoid memory leak on macOS

### DIFF
--- a/src/base/utils/os.cpp
+++ b/src/base/utils/os.cpp
@@ -316,7 +316,11 @@ bool Utils::OS::applyMarkOfTheWeb(const Path &file, const QString &url)
 
     ::CFDictionarySetValue(properties, kLSQuarantineTypeKey, kLSQuarantineTypeOtherDownload);
     if (!url.isEmpty())
-        ::CFDictionarySetValue(properties, kLSQuarantineDataURLKey, url.toCFString());
+    {
+        const CFStringRef urlCFString = url.toCFString();
+        [[maybe_unused]] const auto urlStringGuard = qScopeGuard([&urlCFString] { ::CFRelease(urlCFString); });
+        ::CFDictionarySetValue(properties, kLSQuarantineDataURLKey, urlCFString);
+    }
 
     const Boolean success = ::CFURLSetResourcePropertyForKey(fileURL, kCFURLQuarantinePropertiesKey
         , properties, NULL);

--- a/src/gui/powermanagement/powermanagement.cpp
+++ b/src/gui/powermanagement/powermanagement.cpp
@@ -32,6 +32,7 @@
 
 #ifdef Q_OS_MACOS
 #include <IOKit/pwr_mgt/IOPMLib.h>
+#include <QScopeGuard>
 #endif
 
 #ifdef Q_OS_WIN
@@ -74,8 +75,10 @@ void PowerManagement::setBusy()
 #elif defined(QBT_USES_DBUS)
     m_inhibitor->requestBusy();
 #elif defined(Q_OS_MACOS)
+    const CFStringRef assertName = tr("qBittorrent is active").toCFString();
+    [[maybe_unused]] const auto assertNameGuard = qScopeGuard([&assertName] { ::CFRelease(assertName); });
     const IOReturn success = ::IOPMAssertionCreateWithName(kIOPMAssertionTypeNoIdleSleep, kIOPMAssertionLevelOn
-        , tr("qBittorrent is active").toCFString(), &m_assertionID);
+        , assertName, &m_assertionID);
     if (success != kIOReturnSuccess)
         m_busy = false;
 #endif


### PR DESCRIPTION
Only Mark-of-the-Web and Power Management are affected.
