### PR TITLE
GHA CI: Bump numerous hook revs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,7 @@ repos:
         - ts
 
   - repo: https://github.com/codespell-project/codespell.git
-    rev: v2.3.0
+    rev: v2.4.0
     hooks:
     - id: codespell
       name: Check spelling (codespell)
@@ -88,7 +88,7 @@ repos:
         - ts
 
   - repo: https://github.com/crate-ci/typos.git
-    rev: v1.28.4
+    rev: v1.29.4
     hooks:
     - id: typos
       name: Check spelling (typos)

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -579,7 +579,7 @@ void Application::runExternalProgram(const QString &programTemplate, const BitTo
     const QString logMsg = tr("Running external program. Torrent: \"%1\". Command: `%2`");
     const QString logMsgError = tr("Failed to run external program. Torrent: \"%1\". Command: `%2`");
 
-    // The processing sequenece is different for Windows and other OS, this is intentional
+    // The processing sequence is different for Windows and other OS, this is intentional
 #if defined(Q_OS_WIN)
     const QString program = replaceVariables(programTemplate);
     const std::wstring programWStr = program.toStdWString();


### PR DESCRIPTION
* Bumped `codespell` -> `2.4.0`
* Bumped `typos` -> `1.29.4`
(Applied typo fix from dry-run)