### PR TITLE
Use compact format for JSON files

### DIFF
--- a/src/base/rss/feed_serializer.cpp
+++ b/src/base/rss/feed_serializer.cpp
@@ -73,7 +73,7 @@ void RSS::Private::FeedSerializer::store(const Path &dataFileName, const QList<Q
         arr << jsonObj;
     }
 
-    const nonstd::expected<void, QString> result = Utils::IO::saveToFile(dataFileName, QJsonDocument(arr).toJson());
+    const nonstd::expected<void, QString> result = Utils::IO::saveToFile(dataFileName, QJsonDocument(arr).toJson(QJsonDocument::Compact));
     if (!result)
     {
        LogMsg(tr("Failed to save RSS feed in '%1', Reason: %2").arg(dataFileName.toString(), result.error())

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -873,7 +873,7 @@ void SearchWidget::DataStorage::storeSession(const SessionData &sessionData)
     };
 
     const Path sessionFilePath = makeDataFilePath(SESSION_FILE_NAME);
-    const auto saveResult = Utils::IO::saveToFile(sessionFilePath, QJsonDocument(sessionObj).toJson());
+    const auto saveResult = Utils::IO::saveToFile(sessionFilePath, QJsonDocument(sessionObj).toJson(QJsonDocument::Compact));
     if (!saveResult)
     {
         LogMsg(tr("Failed to save Search UI state. File: \"%1\". Error: \"%2\"")
@@ -905,7 +905,7 @@ void SearchWidget::DataStorage::storeTab(const QString &tabID, const QList<Searc
     }
 
     const Path filePath = makeDataFilePath(tabID + u".json");
-    const auto saveResult = Utils::IO::saveToFile(filePath, QJsonDocument(searchResultsArray).toJson());
+    const auto saveResult = Utils::IO::saveToFile(filePath, QJsonDocument(searchResultsArray).toJson(QJsonDocument::Compact));
     if (!saveResult)
     {
         LogMsg(tr("Failed to save search results. Tab: \"%1\". File: \"%2\". Error: \"%3\"")


### PR DESCRIPTION
It saves a bit of space on disk and deters novice users from tampering them.
