### PR TITLE
GHA CI: Bump libtorrent versions

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libt_version: ["2.0.10", "1.2.19"]
+        libt_version: ["2.0.11", "1.2.20"]
         qbt_gui: ["GUI=ON", "GUI=OFF"]
         qt_version: ["6.7.0"]
 

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libt_version: ["2.0.10", "1.2.19"]
+        libt_version: ["2.0.11", "1.2.20"]
         qbt_gui: ["GUI=ON", "GUI=OFF"]
         qt_version: ["6.5.2"]
 

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libt_version: ["2.0.10", "1.2.19"]
+        libt_version: ["2.0.11", "1.2.20"]
 
     env:
       boost_path: "${{ github.workspace }}/../boost"

--- a/.github/workflows/coverity-scan.yaml
+++ b/.github/workflows/coverity-scan.yaml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        libt_version: ["2.0.10"]
+        libt_version: ["2.0.11"]
         qbt_gui: ["GUI=ON"]
         qt_version: ["6.5.2"]
 


### PR DESCRIPTION
* Bump libtorrent -> `1.2.20`
https://github.com/arvidn/libtorrent/releases/tag/v1.2.20
* Bump libtorrent2 -> `2.0.11`
https://github.com/arvidn/libtorrent/releases/tag/v2.0.11