### PR TITLE
Fix shift-click selection on macOS

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -287,10 +287,10 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
         macosdockbadge/badger.mm
         macosdockbadge/badgeview.h
         macosdockbadge/badgeview.mm
-        macutilities.h
-        macutilities.mm
         macosshiftclickhandler.h
         macosshiftclickhandler.cpp
+        macutilities.h
+        macutilities.mm
     )
     target_link_libraries(qbt_gui PRIVATE objc)
 endif()

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -289,6 +289,8 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
         macosdockbadge/badgeview.mm
         macutilities.h
         macutilities.mm
+        macosshiftclickhandler.h
+        macosshiftclickhandler.cpp
     )
     target_link_libraries(qbt_gui PRIVATE objc)
 endif()

--- a/src/gui/macosshiftclickhandler.cpp
+++ b/src/gui/macosshiftclickhandler.cpp
@@ -29,11 +29,10 @@
 #include "macosshiftclickhandler.h"
 
 #include <QMouseEvent>
-#include "transferlistwidget.h"
+#include <QTreeView>
 
-MacOSShiftClickHandler::MacOSShiftClickHandler(TransferListWidget *treeView)
-    : QObject(treeView)
-    , m_treeView {treeView}
+MacOSShiftClickHandler::MacOSShiftClickHandler(QTreeView *treeView)
+    : QObject(treeView), m_treeView{treeView}
 {
     treeView->installEventFilter(this);
 }

--- a/src/gui/macosshiftclickhandler.cpp
+++ b/src/gui/macosshiftclickhandler.cpp
@@ -46,7 +46,7 @@ bool MacOSShiftClickHandler::eventFilter(QObject *watched, QEvent *event)
         if (mouseEvent->button() != Qt::LeftButton)
             return false;
 
-        const QModelIndex clickedIndex = m_treeView->indexAt(mouseEvent->position());
+        const QModelIndex clickedIndex = m_treeView->indexAt(mouseEvent->position().toPoint());
         if (!clickedIndex.isValid())
             return false;
 
@@ -69,5 +69,5 @@ bool MacOSShiftClickHandler::eventFilter(QObject *watched, QEvent *event)
             m_lastClickedIndex = clickedIndex;
     }
 
-    return QObject::eventFilter(obj, event);
+    return QObject::eventFilter(watched, event);
 }

--- a/src/gui/macosshiftclickhandler.cpp
+++ b/src/gui/macosshiftclickhandler.cpp
@@ -32,7 +32,8 @@
 #include <QTreeView>
 
 MacOSShiftClickHandler::MacOSShiftClickHandler(QTreeView *treeView)
-    : QObject(treeView), m_treeView{treeView}, m_lastClickedIndex{}
+    : QObject(treeView)
+    , m_treeView {treeView}
 {
     treeView->installEventFilter(this);
 }

--- a/src/gui/macosshiftclickhandler.cpp
+++ b/src/gui/macosshiftclickhandler.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2025  Your_Name_Or_Nick <your_email@example.com>
+ * Copyright (C) 2025  Luke Memet <lukemmtt@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/src/gui/macosshiftclickhandler.cpp
+++ b/src/gui/macosshiftclickhandler.cpp
@@ -69,5 +69,5 @@ bool MacOSShiftClickHandler::eventFilter(QObject *watched, QEvent *event)
             m_lastClickedIndex = clickedIndex;
     }
 
-    return false;
+    return QObject::eventFilter(obj, event);
 }

--- a/src/gui/macosshiftclickhandler.cpp
+++ b/src/gui/macosshiftclickhandler.cpp
@@ -25,6 +25,7 @@
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
  */
+
 #include "macosshiftclickhandler.h"
 
 #include <QMouseEvent>

--- a/src/gui/macosshiftclickhandler.cpp
+++ b/src/gui/macosshiftclickhandler.cpp
@@ -1,0 +1,45 @@
+#include "macosshiftclickhandler.h"
+
+#include <QMouseEvent>
+#include "transferlistwidget.h"
+
+MacOSShiftClickHandler::MacOSShiftClickHandler(TransferListWidget *parent)
+    : QObject(parent)
+    , m_treeView(parent)
+{
+    parent->installEventFilter(this);
+}
+
+bool MacOSShiftClickHandler::eventFilter(QObject *watched, QEvent *event)
+{
+    if ((watched == m_treeView) && (event->type() == QEvent::MouseButtonPress))
+    {
+        auto *mouseEvent = static_cast<QMouseEvent *>(event);
+        if (mouseEvent->button() != Qt::LeftButton)
+            return false;
+
+        const QModelIndex clickedIndex = m_treeView->indexAt(mouseEvent->pos());
+        if (!clickedIndex.isValid())
+            return false;
+
+        const Qt::KeyboardModifiers modifiers = mouseEvent->modifiers();
+        const bool shiftPressed = modifiers.testFlag(Qt::ShiftModifier);
+        const bool commandPressed = modifiers.testFlag(Qt::ControlModifier);
+
+        if (shiftPressed && m_lastClickedIndex.isValid())
+        {
+            const QItemSelection selection(m_lastClickedIndex, clickedIndex);
+            if (commandPressed)
+                m_treeView->selectionModel()->select(selection, QItemSelectionModel::Select | QItemSelectionModel::Rows);
+            else
+                m_treeView->selectionModel()->select(selection, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+            m_treeView->selectionModel()->setCurrentIndex(clickedIndex, QItemSelectionModel::NoUpdate);
+            return true;
+        }
+
+        if (!(modifiers & (Qt::AltModifier | Qt::MetaModifier)))
+            m_lastClickedIndex = clickedIndex;
+    }
+
+    return false;
+} 

--- a/src/gui/macosshiftclickhandler.cpp
+++ b/src/gui/macosshiftclickhandler.cpp
@@ -42,7 +42,7 @@ bool MacOSShiftClickHandler::eventFilter(QObject *watched, QEvent *event)
 {
     if ((watched == m_treeView) && (event->type() == QEvent::MouseButtonPress))
     {
-        auto *mouseEvent = static_cast<QMouseEvent *>(event);
+        const auto *mouseEvent = static_cast<QMouseEvent *>(event);
         if (mouseEvent->button() != Qt::LeftButton)
             return false;
 
@@ -52,20 +52,20 @@ bool MacOSShiftClickHandler::eventFilter(QObject *watched, QEvent *event)
 
         const Qt::KeyboardModifiers modifiers = mouseEvent->modifiers();
         const bool shiftPressed = modifiers.testFlag(Qt::ShiftModifier);
-        const bool commandPressed = modifiers.testFlag(Qt::ControlModifier);
-
+        
         if (shiftPressed && m_lastClickedIndex.isValid())
         {
             const QItemSelection selection(m_lastClickedIndex, clickedIndex);
+            const bool commandPressed = modifiers.testFlag(Qt::ControlModifier);
             if (commandPressed)
-                m_treeView->selectionModel()->select(selection, QItemSelectionModel::Select | QItemSelectionModel::Rows);
+                m_treeView->selectionModel()->select(selection, (QItemSelectionModel::Select | QItemSelectionModel::Rows));
             else
-                m_treeView->selectionModel()->select(selection, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+                m_treeView->selectionModel()->select(selection, (QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows));
             m_treeView->selectionModel()->setCurrentIndex(clickedIndex, QItemSelectionModel::NoUpdate);
             return true;
         }
 
-        if (!(modifiers & (Qt::AltModifier | Qt::MetaModifier)))
+        if (!modifiers.testFlags(Qt::AltModifier | Qt::MetaModifier))
             m_lastClickedIndex = clickedIndex;
     }
 

--- a/src/gui/macosshiftclickhandler.cpp
+++ b/src/gui/macosshiftclickhandler.cpp
@@ -26,7 +26,7 @@
  * exception statement from your version.
  */
  
- #include "macosshiftclickhandler.h"
+#include "macosshiftclickhandler.h"
 
 #include <QMouseEvent>
 #include "transferlistwidget.h"

--- a/src/gui/macosshiftclickhandler.cpp
+++ b/src/gui/macosshiftclickhandler.cpp
@@ -32,7 +32,7 @@
 #include <QTreeView>
 
 MacOSShiftClickHandler::MacOSShiftClickHandler(QTreeView *treeView)
-    : QObject(treeView), m_treeView{treeView}
+    : QObject(treeView), m_treeView{treeView}, m_lastClickedIndex{}
 {
     treeView->installEventFilter(this);
 }

--- a/src/gui/macosshiftclickhandler.cpp
+++ b/src/gui/macosshiftclickhandler.cpp
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2025  Luke Memet <lukemmtt@users.noreply.github.com>
+ * Copyright (C) 2025  Luke Memet (lukemmtt)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/src/gui/macosshiftclickhandler.cpp
+++ b/src/gui/macosshiftclickhandler.cpp
@@ -25,7 +25,6 @@
  * but you are not obligated to do so. If you do not wish to do so, delete this
  * exception statement from your version.
  */
- 
 #include "macosshiftclickhandler.h"
 
 #include <QMouseEvent>

--- a/src/gui/macosshiftclickhandler.cpp
+++ b/src/gui/macosshiftclickhandler.cpp
@@ -46,7 +46,7 @@ bool MacOSShiftClickHandler::eventFilter(QObject *watched, QEvent *event)
         if (mouseEvent->button() != Qt::LeftButton)
             return false;
 
-        const QModelIndex clickedIndex = m_treeView->indexAt(mouseEvent->pos());
+        const QModelIndex clickedIndex = m_treeView->indexAt(mouseEvent->position());
         if (!clickedIndex.isValid())
             return false;
 

--- a/src/gui/macosshiftclickhandler.cpp
+++ b/src/gui/macosshiftclickhandler.cpp
@@ -52,7 +52,7 @@ bool MacOSShiftClickHandler::eventFilter(QObject *watched, QEvent *event)
 
         const Qt::KeyboardModifiers modifiers = mouseEvent->modifiers();
         const bool shiftPressed = modifiers.testFlag(Qt::ShiftModifier);
-        
+
         if (shiftPressed && m_lastClickedIndex.isValid())
         {
             const QItemSelection selection(m_lastClickedIndex, clickedIndex);

--- a/src/gui/macosshiftclickhandler.cpp
+++ b/src/gui/macosshiftclickhandler.cpp
@@ -1,13 +1,41 @@
-#include "macosshiftclickhandler.h"
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2025  Your_Name_Or_Nick <your_email@example.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+ 
+ #include "macosshiftclickhandler.h"
 
 #include <QMouseEvent>
 #include "transferlistwidget.h"
 
-MacOSShiftClickHandler::MacOSShiftClickHandler(TransferListWidget *parent)
-    : QObject(parent)
-    , m_treeView(parent)
+MacOSShiftClickHandler::MacOSShiftClickHandler(TransferListWidget *treeView)
+    : QObject(treeView)
+    , m_treeView {treeView}
 {
-    parent->installEventFilter(this);
+    treeView->installEventFilter(this);
 }
 
 bool MacOSShiftClickHandler::eventFilter(QObject *watched, QEvent *event)
@@ -42,4 +70,4 @@ bool MacOSShiftClickHandler::eventFilter(QObject *watched, QEvent *event)
     }
 
     return false;
-} 
+}

--- a/src/gui/macosshiftclickhandler.h
+++ b/src/gui/macosshiftclickhandler.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2025  Your_Name_Or_Nick <your_email@example.com>
+ * Copyright (C) 2025  Luke Memet <lukemmtt@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/src/gui/macosshiftclickhandler.h
+++ b/src/gui/macosshiftclickhandler.h
@@ -1,6 +1,6 @@
 /*
  * Bittorrent Client using Qt and libtorrent.
- * Copyright (C) 2025  Luke Memet <lukemmtt@users.noreply.github.com>
+ * Copyright (C) 2025  Luke Memet (lukemmtt)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/src/gui/macosshiftclickhandler.h
+++ b/src/gui/macosshiftclickhandler.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <QObject>
+#include <QPersistentModelIndex>
+
+class TransferListWidget;
+
+// Workaround for QTBUG-115838: Shift-click range selection not working properly on macOS
+class MacOSShiftClickHandler final : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(MacOSShiftClickHandler)
+
+public:
+    explicit MacOSShiftClickHandler(TransferListWidget *parent);
+
+protected:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
+private:
+    TransferListWidget *m_treeView;
+    QPersistentModelIndex m_lastClickedIndex;
+}; 

--- a/src/gui/macosshiftclickhandler.h
+++ b/src/gui/macosshiftclickhandler.h
@@ -31,7 +31,7 @@
 #include <QObject>
 #include <QPersistentModelIndex>
 
-class TransferListWidget;
+class QTreeView;
 
 // Workaround for QTBUG-115838: Shift-click range selection not working properly on macOS
 class MacOSShiftClickHandler final : public QObject
@@ -40,11 +40,11 @@ class MacOSShiftClickHandler final : public QObject
     Q_DISABLE_COPY_MOVE(MacOSShiftClickHandler)
 
 public:
-    explicit MacOSShiftClickHandler(TransferListWidget *treeView);
+    explicit MacOSShiftClickHandler(QTreeView *treeView);
 
 private:
     bool eventFilter(QObject *watched, QEvent *event) override;
 
-    TransferListWidget *m_treeView = nullptr;
+    QTreeView *m_treeView = nullptr;
     QPersistentModelIndex m_lastClickedIndex;
 };

--- a/src/gui/macosshiftclickhandler.h
+++ b/src/gui/macosshiftclickhandler.h
@@ -1,3 +1,31 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2025  Your_Name_Or_Nick <your_email@example.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
 #pragma once
 
 #include <QObject>
@@ -12,12 +40,11 @@ class MacOSShiftClickHandler final : public QObject
     Q_DISABLE_COPY_MOVE(MacOSShiftClickHandler)
 
 public:
-    explicit MacOSShiftClickHandler(TransferListWidget *parent);
-
-protected:
-    bool eventFilter(QObject *watched, QEvent *event) override;
+    explicit MacOSShiftClickHandler(TransferListWidget *treeView);
 
 private:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
     TransferListWidget *m_treeView;
     QPersistentModelIndex m_lastClickedIndex;
-}; 
+};

--- a/src/gui/macosshiftclickhandler.h
+++ b/src/gui/macosshiftclickhandler.h
@@ -45,6 +45,6 @@ public:
 private:
     bool eventFilter(QObject *watched, QEvent *event) override;
 
-    TransferListWidget *m_treeView;
+    TransferListWidget *m_treeView = nullptr;
     QPersistentModelIndex m_lastClickedIndex;
 };

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -74,8 +74,8 @@
 #include "utils.h"
 
 #ifdef Q_OS_MACOS
-#include "macutilities.h"
 #include "macosshiftclickhandler.h"
+#include "macutilities.h"
 #endif
 
 namespace

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -159,7 +159,7 @@ TransferListWidget::TransferListWidget(IGUIApplication *app, QWidget *parent)
     setDropIndicatorShown(true);
 #if defined(Q_OS_MACOS)
     setAttribute(Qt::WA_MacShowFocusRect, false);
-    m_shiftClickHandler = new MacOSShiftClickHandler(this);
+    new MacOSShiftClickHandler(this);
 #endif
     header()->setFirstSectionMovable(true);
     header()->setStretchLastSection(false);

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -1446,38 +1446,3 @@ void TransferListWidget::wheelEvent(QWheelEvent *event)
 
     QTreeView::wheelEvent(event);  // event delegated to base class
 }
-
-#ifdef Q_OS_MACOS
-void TransferListWidget::mousePressEvent(QMouseEvent *event)
-{
-    const QModelIndex clickedIndex = indexAt(event->pos());
-    if (!clickedIndex.isValid())
-    {
-        QTreeView::mousePressEvent(event);
-        return;
-    }
-
-    const Qt::KeyboardModifiers modifiers = event->modifiers();
-    const bool shiftPressed = modifiers.testFlag(Qt::ShiftModifier);
-    const bool cmdPressed = modifiers.testFlag(Qt::ControlModifier);  // Command key on macOS
-
-    if (shiftPressed && m_lastClickedIndex.isValid())
-    {
-        // Handle shift-click range selection
-        const QItemSelection selection(m_lastClickedIndex, clickedIndex);
-        if (cmdPressed)
-            selectionModel()->select(selection, QItemSelectionModel::Select | QItemSelectionModel::Rows);
-        else
-            selectionModel()->select(selection, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
-        selectionModel()->setCurrentIndex(clickedIndex, QItemSelectionModel::NoUpdate);
-        event->accept();
-        return;
-    }
-
-    // For non-shift clicks, update the last clicked index
-    if (!(modifiers & (Qt::AltModifier | Qt::MetaModifier)))  // Ignore if Alt/Meta is pressed
-        m_lastClickedIndex = clickedIndex;
-
-    QTreeView::mousePressEvent(event);
-}
-#endif

--- a/src/gui/transferlistwidget.cpp
+++ b/src/gui/transferlistwidget.cpp
@@ -75,6 +75,7 @@
 
 #ifdef Q_OS_MACOS
 #include "macutilities.h"
+#include "macosshiftclickhandler.h"
 #endif
 
 namespace
@@ -158,6 +159,7 @@ TransferListWidget::TransferListWidget(IGUIApplication *app, QWidget *parent)
     setDropIndicatorShown(true);
 #if defined(Q_OS_MACOS)
     setAttribute(Qt::WA_MacShowFocusRect, false);
+    m_shiftClickHandler = new MacOSShiftClickHandler(this);
 #endif
     header()->setFirstSectionMovable(true);
     header()->setStretchLastSection(false);

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -118,14 +118,11 @@ private slots:
     void askNewCategoryForSelection();
     void saveSettings();
 
-protected:
+private:
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dragMoveEvent(QDragMoveEvent *event) override;
     void dropEvent(QDropEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
-    void mousePressEvent(QMouseEvent *event) override;
-
-private:
     QModelIndex mapToSource(const QModelIndex &index) const;
     QModelIndexList mapToSource(const QModelIndexList &indexes) const;
     QModelIndex mapFromSource(const QModelIndex &index) const;
@@ -142,7 +139,4 @@ private:
 
     TransferListModel *m_listModel = nullptr;
     TransferListSortModel *m_sortFilterModel = nullptr;
-#ifdef Q_OS_MACOS
-    QPersistentModelIndex m_lastClickedIndex;  // For handling shift-click selection on macOS
-#endif
 };

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -118,11 +118,14 @@ private slots:
     void askNewCategoryForSelection();
     void saveSettings();
 
-private:
+protected:
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dragMoveEvent(QDragMoveEvent *event) override;
     void dropEvent(QDropEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
+    void mousePressEvent(QMouseEvent *event) override;
+
+private:
     QModelIndex mapToSource(const QModelIndex &index) const;
     QModelIndexList mapToSource(const QModelIndexList &indexes) const;
     QModelIndex mapFromSource(const QModelIndex &index) const;
@@ -139,4 +142,7 @@ private:
 
     TransferListModel *m_listModel = nullptr;
     TransferListSortModel *m_sortFilterModel = nullptr;
+#ifdef Q_OS_MACOS
+    QPersistentModelIndex m_lastClickedIndex;  // For handling shift-click selection on macOS
+#endif
 };

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -52,10 +52,6 @@ enum class CopyInfohashPolicy
     Version2
 };
 
-#ifdef Q_OS_MACOS
-class MacOSShiftClickHandler;  // Forward declaration
-#endif
-
 class TransferListWidget final : public GUIApplicationComponent<QTreeView>
 {
     Q_OBJECT
@@ -140,10 +136,6 @@ private:
     void applyToSelectedTorrents(const std::function<void (BitTorrent::Torrent *const)> &fn);
     QList<BitTorrent::Torrent *> getVisibleTorrents() const;
     int visibleColumnsCount() const;
-
-#ifdef Q_OS_MACOS
-    MacOSShiftClickHandler *m_shiftClickHandler = nullptr;
-#endif
 
     TransferListModel *m_listModel = nullptr;
     TransferListSortModel *m_sortFilterModel = nullptr;

--- a/src/gui/transferlistwidget.h
+++ b/src/gui/transferlistwidget.h
@@ -52,6 +52,10 @@ enum class CopyInfohashPolicy
     Version2
 };
 
+#ifdef Q_OS_MACOS
+class MacOSShiftClickHandler;  // Forward declaration
+#endif
+
 class TransferListWidget final : public GUIApplicationComponent<QTreeView>
 {
     Q_OBJECT
@@ -136,6 +140,10 @@ private:
     void applyToSelectedTorrents(const std::function<void (BitTorrent::Torrent *const)> &fn);
     QList<BitTorrent::Torrent *> getVisibleTorrents() const;
     int visibleColumnsCount() const;
+
+#ifdef Q_OS_MACOS
+    MacOSShiftClickHandler *m_shiftClickHandler = nullptr;
+#endif
 
     TransferListModel *m_listModel = nullptr;
     TransferListSortModel *m_sortFilterModel = nullptr;


### PR DESCRIPTION
Adds a macOS-specific event filter to handle shift-click range selection in the transfer list. This addresses a long-standing issue where shift-click selection was not working correctly in the transfer list on macOS.

The implementation:
- Creates a dedicated MacOSShiftClickHandler class to manage shift-click behavior
- Tracks the last clicked index using a persistent model index
- Properly handles both shift-click and command+shift-click selection modes
- Only activates on macOS via conditional compilation

This is a workaround for QTBUG-115838, which affects QTreeView shift-click selection behavior on macOS. The issue prevents users from selecting a range of torrents using shift-click, making bulk operations more difficult.

Closes #16818.

### Before & After videos

_Please note that in these videos, I'm holding the "shift" key the entire time, except when clicking in the empty area to clear the selections._

**Before:**

https://github.com/user-attachments/assets/c7050ae2-53b2-4ff6-82f3-ba2848b426d5

**After:**

https://github.com/user-attachments/assets/ae754c33-7ecb-4237-8067-d0b7e5dd31dc


