### PR TITLE
GHA CI: fix AppImage building

### DIFF
--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -138,16 +138,15 @@ jobs:
 
       - name: Install AppImage
         run: |
-          sudo apt install libfuse2
           curl \
             -L \
             -Z \
-            -O https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-static-x86_64.AppImage \
-            -O https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-static-x86_64.AppImage \
+            -O https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage \
+            -O https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage \
             -O https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-x86_64.AppImage
           chmod +x \
-            linuxdeploy-static-x86_64.AppImage \
-            linuxdeploy-plugin-qt-static-x86_64.AppImage \
+            linuxdeploy-x86_64.AppImage \
+            linuxdeploy-plugin-qt-x86_64.AppImage \
             linuxdeploy-plugin-appimage-x86_64.AppImage
 
       - name: Prepare files for AppImage
@@ -160,12 +159,12 @@ jobs:
 
       - name: Package AppImage
         run: |
-          ./linuxdeploy-static-x86_64.AppImage --appdir qbittorrent --plugin qt
+          ./linuxdeploy-x86_64.AppImage --appdir qbittorrent --plugin qt
           rm qbittorrent/apprun-hooks/*
           cp .github/workflows/helper/appimage/export_vars.sh qbittorrent/apprun-hooks/export_vars.sh
           NO_APPSTREAM=1 \
             OUTPUT=upload/qbittorrent-CI_Ubuntu_x86_64.AppImage \
-            ./linuxdeploy-static-x86_64.AppImage --appdir qbittorrent --output appimage
+            ./linuxdeploy-x86_64.AppImage --appdir qbittorrent --output appimage
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Upstream now defaults to static runtime and the previous URL is invalid now.
Upstream commits:
* https://github.com/linuxdeploy/linuxdeploy/commit/c28054bab6623e72e0e27ffec88c41df5ce46667
* https://github.com/linuxdeploy/linuxdeploy-plugin-qt/commit/ce5291e25979d7d6417551d787f308b88c1b8d76

Also fuse2 is not needed now as stated on:
https://github.com/AppImage/type2-runtime?tab=readme-ov-file#type2-runtime-
