### PR TITLE
WebUI: Fix bug where the 'Tracker editing' dialog displays incorrect data

### DIFF
--- a/src/webui/www/private/scripts/prop-trackers.js
+++ b/src/webui/www/private/scripts/prop-trackers.js
@@ -198,7 +198,7 @@ window.qBittorrent.PropTrackers ??= (() => {
         if (current_hash.length === 0)
             return;
 
-        const trackerUrl = encodeURIComponent(element.childNodes[1].textContent);
+        const trackerUrl = encodeURIComponent(torrentTrackersTable.selectedRowsIds()[0]);
         new MochaUI.Window({
             id: "trackersPage",
             icon: "images/qbittorrent-tray.svg",


### PR DESCRIPTION
In Trackers table, moving the 'URL' column from its default (2) position caused the 'Tracker editing' dialog to display incorrect data.

Steps to reproduce:
1. Move 'URL' column in Trackers table to any position from default
2. Choose tracker URL and click 'Edit tracker URL':

![image](https://github.com/user-attachments/assets/c20afbe0-4503-4430-9db5-e8db937f2a41)
