### PR TITLE
WebUI: Maintain row highlight after rearranging table columns

### DIFF
--- a/src/webui/www/private/scripts/dynamicTable.js
+++ b/src/webui/www/private/scripts/dynamicTable.js
@@ -293,6 +293,7 @@ window.qBittorrent.DynamicTable ??= (() => {
                     this.updateTableHeaders();
                     this.tableBody.replaceChildren();
                     this.updateTable(true);
+                    this.reselectRows(this.selectedRowsIds());
                 }
                 if (this.currentHeaderAction === "drag") {
                     resetElementBorderStyle(el);
@@ -751,10 +752,7 @@ window.qBittorrent.DynamicTable ??= (() => {
         reselectRows: function(rowIds) {
             this.deselectAll();
             this.selectedRows = rowIds.slice();
-            for (const tr of this.getTrs()) {
-                if (rowIds.includes(tr.rowId))
-                    tr.classList.add("selected");
-            }
+            this.setRowClass();
         },
 
         setRowClass: function() {


### PR DESCRIPTION
This PR fixes a bug where row highlight effect would be lost after reordering columns.