### PR TITLE
Improve CI scripts

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -52,7 +52,7 @@ jobs:
           store_cache: ${{ github.ref == 'refs/heads/master' }}
           update_packager_index: false
           ccache_options: |
-            max_size=2G
+            max_size=1G
 
       - name: Install boost
         env:

--- a/.github/workflows/ci_ubuntu.yaml
+++ b/.github/workflows/ci_ubuntu.yaml
@@ -47,7 +47,7 @@ jobs:
           store_cache: ${{ github.ref == 'refs/heads/master' }}
           update_packager_index: false
           ccache_options: |
-            max_size=2G
+            max_size=1G
 
       - name: Install boost
         env:

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -67,6 +67,7 @@ jobs:
               "set(VCPKG_BUILD_TYPE release)")
           # clear buildtrees after each package installation to reduce disk space requirements
           $packages = `
+            "boost-build:x64-windows-static-md-release",
             "openssl:x64-windows-static-md-release",
             "zlib:x64-windows-static-md-release"
           ${{ env.vcpkg_path }}/vcpkg.exe upgrade `
@@ -95,8 +96,12 @@ jobs:
           }
           move "${{ github.workspace }}/../boost_*" "${{ env.boost_path }}"
           cd "${{ env.boost_path }}"
-          .\bootstrap.bat
-          .\b2.exe stage --stagedir=.\ --with-headers
+          #.\bootstrap.bat
+          ${{ env.vcpkg_path }}/installed/x64-windows-static-md-release/tools/boost-build/b2.exe `
+            stage `
+            toolset=msvc `
+            --stagedir=.\ `
+            --with-headers
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v4


### PR DESCRIPTION
* GHA CI: tweak cache size
  It seems ~500MB is enough to cache all the build artifacts but we still make it a bit larger to avoid thrashing.
* GHA CI: shorten Windows CI build time
  Now vcpkg caches b2 tool. Boost doesn't need the exact b2 version to generate the cmake files.