### PR TITLE
Improve "split to byte array views" function

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,7 @@ repos:
     hooks:
     - id: codespell
       name: Check spelling (codespell)
-      args: ["--ignore-words-list", "additionals,categor,curren,fo,ist,ket,notin,searchin,sectionin,superseeding,te,ths"]
+      args: ["--ignore-words-list", "additionals,categor,curren,fo,indexIn,ist,ket,notin,searchin,sectionin,superseeding,te,ths"]
       exclude: |
         (?x)^(
           .*\.desktop |

--- a/src/base/http/requestparser.cpp
+++ b/src/base/http/requestparser.cpp
@@ -279,7 +279,7 @@ bool RequestParser::parsePostMessage(const QByteArrayView data)
 
         // split data by "dash-boundary"
         const QByteArray dashDelimiter = QByteArray("--") + delimiter + CRLF;
-        QList<QByteArrayView> multipart = splitToViews(data, dashDelimiter, Qt::SkipEmptyParts);
+        QList<QByteArrayView> multipart = splitToViews(data, dashDelimiter);
         if (multipart.isEmpty())
         {
             qWarning() << Q_FUNC_INFO << "multipart empty";

--- a/src/base/search/searchpluginmanager.cpp
+++ b/src/base/search/searchpluginmanager.cpp
@@ -592,14 +592,14 @@ void SearchPluginManager::parseVersionInfo(const QByteArray &info)
     QHash<QString, PluginVersion> updateInfo;
     int numCorrectData = 0;
 
-    const QList<QByteArrayView> lines = Utils::ByteArray::splitToViews(info, "\n", Qt::SkipEmptyParts);
+    const QList<QByteArrayView> lines = Utils::ByteArray::splitToViews(info, "\n");
     for (QByteArrayView line : lines)
     {
         line = line.trimmed();
         if (line.isEmpty()) continue;
         if (line.startsWith('#')) continue;
 
-        const QList<QByteArrayView> list = Utils::ByteArray::splitToViews(line, ":", Qt::SkipEmptyParts);
+        const QList<QByteArrayView> list = Utils::ByteArray::splitToViews(line, ":");
         if (list.size() != 2) continue;
 
         const auto pluginName = QString::fromUtf8(list.first().trimmed());

--- a/src/base/utils/bytearray.cpp
+++ b/src/base/utils/bytearray.cpp
@@ -30,28 +30,30 @@
 #include "bytearray.h"
 
 #include <QByteArray>
+#include <QByteArrayMatcher>
 #include <QByteArrayView>
 #include <QList>
 
-QList<QByteArrayView> Utils::ByteArray::splitToViews(const QByteArrayView in, const QByteArrayView sep, const Qt::SplitBehavior behavior)
+QList<QByteArrayView> Utils::ByteArray::splitToViews(const QByteArrayView in, const QByteArrayView sep)
 {
+    if (in.isEmpty())
+        return {};
     if (sep.isEmpty())
         return {in};
 
+    const QByteArrayMatcher matcher {sep};
     QList<QByteArrayView> ret;
-    ret.reserve((behavior == Qt::KeepEmptyParts)
-                ? (1 + (in.size() / sep.size()))
-                : (1 + (in.size() / (sep.size() + 1))));
-    int head = 0;
+    ret.reserve(1 + (in.size() / (sep.size() + 1)));
+    qsizetype head = 0;
     while (head < in.size())
     {
-        int end = in.indexOf(sep, head);
+        qsizetype end = matcher.indexIn(in, head);
         if (end < 0)
             end = in.size();
 
         // omit empty parts
-        const QByteArrayView part = in.mid(head, (end - head));
-        if (!part.isEmpty() || (behavior == Qt::KeepEmptyParts))
+        const QByteArrayView part = in.sliced(head, (end - head));
+        if (!part.isEmpty())
             ret += part;
 
         head = end + sep.size();

--- a/src/base/utils/bytearray.h
+++ b/src/base/utils/bytearray.h
@@ -37,8 +37,8 @@ class QByteArrayView;
 
 namespace Utils::ByteArray
 {
-    // Mimic QStringView(in).split(sep, behavior)
-    QList<QByteArrayView> splitToViews(QByteArrayView in, QByteArrayView sep, Qt::SplitBehavior behavior = Qt::KeepEmptyParts);
+    // Inspired by QStringView(in).split(sep, Qt::SkipEmptyParts)
+    QList<QByteArrayView> splitToViews(QByteArrayView in, QByteArrayView sep);
     QByteArray asQByteArray(QByteArrayView view);
 
     QByteArray toBase32(const QByteArray &in);

--- a/src/base/utils/foreignapps.cpp
+++ b/src/base/utils/foreignapps.cpp
@@ -68,7 +68,7 @@ namespace
             // Software 'Anaconda' installs its own python interpreter
             // and `python --version` returns a string like this:
             // "Python 3.4.3 :: Anaconda 2.3.0 (64-bit)"
-            const QList<QByteArrayView> outputSplit = Utils::ByteArray::splitToViews(procOutput, " ", Qt::SkipEmptyParts);
+            const QList<QByteArrayView> outputSplit = Utils::ByteArray::splitToViews(procOutput, " ");
             if (outputSplit.size() <= 1)
                 return false;
 

--- a/src/base/utils/password.cpp
+++ b/src/base/utils/password.cpp
@@ -115,7 +115,7 @@ bool Utils::Password::PBKDF2::verify(const QByteArray &secret, const QString &pa
 
 bool Utils::Password::PBKDF2::verify(const QByteArray &secret, const QByteArray &password)
 {
-    const QList<QByteArrayView> list = ByteArray::splitToViews(secret, ":", Qt::SkipEmptyParts);
+    const QList<QByteArrayView> list = ByteArray::splitToViews(secret, ":");
     if (list.size() != 2)
         return false;
 

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -172,8 +172,10 @@ namespace
             return nonstd::make_unexpected(readResult.error().message);
         }
 
+        const QList<QByteArrayView> lines = Utils::ByteArray::splitToViews(readResult.value(), "\n");
         QStringList history;
-        for (const QByteArrayView line : asConst(Utils::ByteArray::splitToViews(readResult.value(), "\n")))
+        history.reserve(lines.size());
+        for (const QByteArrayView line : lines)
             history.append(QString::fromUtf8(line));
 
         return history;


### PR DESCRIPTION
1. Utilize string matcher
2. Remove split behavior parameter Previously `KeepEmptyParts` behavior doesn't match Qt's implementation and since our codebase doesn't really make use of it, we can just remove the parameter.
3. Add tests.

