### PR TITLE
Add CLI option to force default WebUI

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -331,6 +331,9 @@ Application::Application(int &argc, char **argv)
     if (m_commandLineArgs.webUIPort > 0) // it will be -1 when user did not set any value
         Preferences::instance()->setWebUIPort(m_commandLineArgs.webUIPort);
 
+    if (m_commandLineArgs.forceDefaultWebUI)
+        Preferences::instance()->setAltWebUIEnabled(false);
+
     if (m_commandLineArgs.torrentingPort > 0) // it will be -1 when user did not set any value
     {
         SettingValue<int> port {u"BitTorrent/Session/Port"_s};

--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -315,6 +315,7 @@ namespace
     constexpr const BoolOption NO_SPLASH_OPTION {u"no-splash"};
 #endif
     constexpr const IntOption WEBUI_PORT_OPTION {u"webui-port"};
+    constexpr const BoolOption FORCE_DEFAULT_WEBUI_OPTION {u"force-default-webui"};
     constexpr const IntOption TORRENTING_PORT_OPTION {u"torrenting-port"};
     constexpr const StringOption PROFILE_OPTION {u"profile"};
     constexpr const StringOption CONFIGURATION_OPTION {u"configuration"};
@@ -382,6 +383,10 @@ QBtCommandLineParameters parseCommandLine(const QStringList &args)
                 if ((result.webUIPort < 1) || (result.webUIPort > 65535))
                     throw CommandLineParameterError(QCoreApplication::translate("CMD Options", "%1 must specify a valid port (1 to 65535).")
                                                     .arg(u"--webui-port"_s));
+            }
+            else if (arg == FORCE_DEFAULT_WEBUI_OPTION)
+            {
+                result.forceDefaultWebUI = true;
             }
             else if (arg == TORRENTING_PORT_OPTION)
             {
@@ -503,6 +508,7 @@ QString makeUsage(const QString &prgName)
         + WEBUI_PORT_OPTION.usage(QCoreApplication::translate("CMD Options", "port"))
         + wrapText(QCoreApplication::translate("CMD Options", "Change the WebUI port"))
         + u'\n'
+        + FORCE_DEFAULT_WEBUI_OPTION.usage() + wrapText(QCoreApplication::translate("CMD Options", "Disable alternative WebUI and use the default")) + u'\n'
         + TORRENTING_PORT_OPTION.usage(QCoreApplication::translate("CMD Options", "port"))
         + wrapText(QCoreApplication::translate("CMD Options", "Change the torrenting port"))
         + u'\n'

--- a/src/app/cmdoptions.h
+++ b/src/app/cmdoptions.h
@@ -55,6 +55,7 @@ struct QBtCommandLineParameters
     bool shouldDaemonize = false;
 #endif
     int webUIPort = -1;
+    bool forceDefaultWebUI = false;
     int torrentingPort = -1;
     std::optional<bool> skipDialog;
     Path profileDir;


### PR DESCRIPTION
Useful for users in case of alternative WebUI being broken.
As apparently people struggle to edit the config manually on headless configurations. This reduces the task to simply running

```
$ qbittorrent-nox --force-default-webui
```

Closes #18401.
