### PR TITLE
WebUI: Query to reset the alternative UI setting

### DIFF
--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -211,6 +211,12 @@ void WebApplication::sendWebUIFile()
         throw BadRequestHTTPError();
     }
 
+    if (m_isAltUIUsed && request().path == u"/" && request().query.contains(QStringLiteral(u"resetui")))
+    {
+        Preferences::instance()->setAltWebUIEnabled(false);
+        configure();
+    }
+
     const QString path = (request().path != u"/")
         ? request().path
         : u"/index.html"_s;


### PR DESCRIPTION
Useful for users in case of alternative WebUI being broken. As apparently people struggle to edit the config manually on headless configurations.

This makes possible to reset the alternative UI setting by making a special query to the index page like:

```
http://localhost:8080/?resetui=
```

Closes #18401.
