### PR TITLE
WebUI: Fallback alternative UI to the default in case of problems

### DIFF
--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -75,6 +75,7 @@ const QString DEFAULT_SESSION_COOKIE_NAME = u"SID"_s;
 const QString WWW_FOLDER = u":/www"_s;
 const QString PUBLIC_FOLDER = u"/public"_s;
 const QString PRIVATE_FOLDER = u"/private"_s;
+const QString INDEX_HTML = u"/index.html"_s;
 
 using namespace std::chrono_literals;
 
@@ -200,6 +201,13 @@ WebApplication::~WebApplication()
     qDeleteAll(m_sessions);
 }
 
+void WebApplication::fallbackAltUI(const QString &path)
+{
+    if (path != INDEX_HTML) return;
+    Preferences::instance()->setAltWebUIEnabled(false);
+    configure();
+}
+
 void WebApplication::sendWebUIFile()
 {
     if (request().path.contains(u'\\'))
@@ -213,7 +221,7 @@ void WebApplication::sendWebUIFile()
 
     const QString path = (request().path != u"/")
         ? request().path
-        : u"/index.html"_s;
+        : INDEX_HTML;
 
     Path localPath = m_rootFolder
                 / Path(session() ? PRIVATE_FOLDER : PUBLIC_FOLDER)
@@ -227,7 +235,10 @@ void WebApplication::sendWebUIFile()
     if (m_isAltUIUsed)
     {
         if (!Utils::Fs::isRegularFile(localPath))
+        {
+            fallbackAltUI(path);
             throw InternalServerErrorHTTPError(tr("Unacceptable file type, only regular file is allowed."));
+        }
 
         const QString rootFolder = m_rootFolder.data();
 
@@ -235,7 +246,10 @@ void WebApplication::sendWebUIFile()
         while (fileInfo.path() != rootFolder)
         {
             if (fileInfo.isSymLink())
+            {
+                fallbackAltUI(path);
                 throw InternalServerErrorHTTPError(tr("Symlinks inside alternative UI folder are forbidden."));
+            }
 
             fileInfo.setFile(fileInfo.path());
         }

--- a/src/webui/webapplication.h
+++ b/src/webui/webapplication.h
@@ -119,6 +119,7 @@ private:
 
     void sendFile(const Path &path);
     void sendWebUIFile();
+    void fallbackAltUI(const QString &path);
 
     void translateDocument(QString &data) const;
 


### PR DESCRIPTION
To avoid manual intervention in case of broken alternative WebUIs.
Initial failed access shows an error as before, but on the next reload it falls back to the default WebUI.