### PR TITLE
Fix new-line in "Invalid category name" translation for Bulgarian

### DIFF
--- a/src/webui/www/translations/webui_bg.ts
+++ b/src/webui/www/translations/webui_bg.ts
@@ -317,8 +317,7 @@
     </message>
     <message>
         <source>Invalid category name:\nPlease do not use any special characters in the category name.</source>
-        <translation>Невалидно име на категория:
-Моля не използвайте никакви специални символи в името на категорията.</translation>
+        <translation>Невалидно име на категория:\nМоля не използвайте никакви специални символи в името на категорията.</translation>
     </message>
     <message>
         <source>Unable to create category</source>


### PR DESCRIPTION
The translated text contained a new-line instead of the `\n` literal.

This resulted in `/newcategory.html?action=create` rendering:

```js
if (name.match("^([^\\\\\\/]|[^\\\\\\/]([^\\\\\\/]|\\/(?=[^\\/]))*[^\\\\\\/])$") === null) {
  alert("Невалидно име на категория:
Моля не използвайте никакви специални символи в името на категорията.");
  return false;
}
```

.. which resulted in the following error:

> Uncaught SyntaxError: "" string literal contains an unescaped line break

This made creating new categories via the web UI not possible when the Bulgarian translation was used.

<!--
MANDATORY Before submitting your work, make sure you have:
1. Read https://github.com/qbittorrent/qBittorrent/blob/master/CONTRIBUTING.md#opening-a-pull-request
2. Delete this comment block
-->
