### PR TITLE
Don't leak parent file descriptors to child processes

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -674,6 +674,9 @@ void Application::runExternalProgram(const QString &programTemplate, const BitTo
     QProcess proc;
     proc.setProgram(command);
     proc.setArguments(args);
+#if defined(Q_OS_UNIX) && (QT_VERSION >= QT_VERSION_CHECK(6, 6, 0))
+    proc.setUnixProcessParameters(QProcess::UnixProcessFlag::CloseFileDescriptors);
+#endif
 
     if (proc.startDetached())
     {

--- a/src/base/search/searchdownloadhandler.cpp
+++ b/src/base/search/searchdownloadhandler.cpp
@@ -42,6 +42,9 @@ SearchDownloadHandler::SearchDownloadHandler(const QString &pluginName, const QS
     , m_downloadProcess {new QProcess(this)}
 {
     m_downloadProcess->setEnvironment(QProcess::systemEnvironment());
+#if defined(Q_OS_UNIX) && (QT_VERSION >= QT_VERSION_CHECK(6, 6, 0))
+    m_downloadProcess->setUnixProcessParameters(QProcess::UnixProcessFlag::CloseFileDescriptors);
+#endif
     connect(m_downloadProcess, qOverload<int, QProcess::ExitStatus>(&QProcess::finished)
             , this, &SearchDownloadHandler::downloadProcessFinished);
     const QStringList params

--- a/src/base/search/searchpluginmanager.cpp
+++ b/src/base/search/searchpluginmanager.cpp
@@ -520,6 +520,9 @@ void SearchPluginManager::update()
 {
     QProcess nova;
     nova.setProcessEnvironment(QProcessEnvironment::systemEnvironment());
+#if defined(Q_OS_UNIX) && (QT_VERSION >= QT_VERSION_CHECK(6, 6, 0))
+    nova.setUnixProcessParameters(QProcess::UnixProcessFlag::CloseFileDescriptors);
+#endif
 
     const QStringList params
     {

--- a/src/base/utils/foreignapps.cpp
+++ b/src/base/utils/foreignapps.cpp
@@ -57,6 +57,9 @@ namespace
         info = {};
 
         QProcess proc;
+#if defined(Q_OS_UNIX) && (QT_VERSION >= QT_VERSION_CHECK(6, 6, 0))
+        proc.setUnixProcessParameters(QProcess::UnixProcessFlag::CloseFileDescriptors);
+#endif
         proc.start(exeName, {u"--version"_s}, QIODevice::ReadOnly);
         if (proc.waitForFinished() && (proc.exitCode() == QProcess::NormalExit))
         {

--- a/src/gui/utils.cpp
+++ b/src/gui/utils.cpp
@@ -176,6 +176,9 @@ void Utils::Gui::openFolderSelect(const Path &path)
     const int lineMaxLength = 64;
 
     QProcess proc;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+    proc.setUnixProcessParameters(QProcess::UnixProcessFlag::CloseFileDescriptors);
+#endif
     proc.start(u"xdg-mime"_s, {u"query"_s, u"default"_s, u"inode/directory"_s});
     proc.waitForFinished();
     const auto output = QString::fromLocal8Bit(proc.readLine(lineMaxLength).simplified());


### PR DESCRIPTION
It is unexpected for the child process to inherit parent file descriptors.
Requires Qt >= 6.6 and only affects Linux.

Closes #10312.

