### PR TITLE
Improve add torrent error handling

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -926,10 +926,10 @@ int Application::exec()
                 m_desktopIntegration->showNotification(tr("Torrent added"), tr("'%1' was added.", "e.g: xxx.avi was added.").arg(torrent->name()));
         });
         connect(m_addTorrentManager, &AddTorrentManager::addTorrentFailed, this
-                , [this](const QString &source, const QString &reason)
+                , [this](const QString &source, const BitTorrent::AddTorrentError &reason)
         {
             m_desktopIntegration->showNotification(tr("Add torrent failed")
-                    , tr("Couldn't add torrent '%1', reason: %2.").arg(source, reason));
+                    , tr("Couldn't add torrent '%1', reason: %2.").arg(source, reason.message));
         });
 
         disconnect(m_desktopIntegration, &DesktopIntegration::activationRequested, this, &Application::createStartupProgressDialog);

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(qbt_base STATIC
     applicationcomponent.h
     asyncfilestorage.h
     bittorrent/abstractfilestorage.h
+    bittorrent/addtorrenterror.h
     bittorrent/addtorrentparams.h
     bittorrent/announcetimepoint.h
     bittorrent/bandwidthscheduler.h

--- a/src/base/addtorrentmanager.cpp
+++ b/src/base/addtorrentmanager.cpp
@@ -140,7 +140,7 @@ void AddTorrentManager::onSessionTorrentAdded(BitTorrent::Torrent *torrent)
     }
 }
 
-void AddTorrentManager::onSessionAddTorrentFailed(const BitTorrent::InfoHash &infoHash, const QString &reason)
+void AddTorrentManager::onSessionAddTorrentFailed(const BitTorrent::InfoHash &infoHash, const BitTorrent::AddTorrentError &reason)
 {
     if (const QString source = m_sourcesByInfoHash.take(infoHash); !source.isEmpty())
     {
@@ -154,7 +154,7 @@ void AddTorrentManager::onSessionAddTorrentFailed(const BitTorrent::InfoHash &in
 void AddTorrentManager::handleAddTorrentFailed(const QString &source, const QString &reason)
 {
     LogMsg(tr("Failed to add torrent. Source: \"%1\". Reason: \"%2\"").arg(source, reason), Log::WARNING);
-    emit addTorrentFailed(source, reason);
+    emit addTorrentFailed(source, {BitTorrent::AddTorrentError::Other, reason});
 }
 
 void AddTorrentManager::handleDuplicateTorrent(const QString &source
@@ -187,7 +187,7 @@ void AddTorrentManager::handleDuplicateTorrent(const QString &source
 
     LogMsg(tr("Detected an attempt to add a duplicate torrent. Source: %1. Existing torrent: %2. Result: %3")
             .arg(source, existingTorrent->name(), message));
-    emit addTorrentFailed(source, message);
+    emit addTorrentFailed(source, {BitTorrent::AddTorrentError::DuplicateTorrent, message});
 }
 
 void AddTorrentManager::setTorrentFileGuard(const QString &source, std::shared_ptr<TorrentFileGuard> torrentFileGuard)

--- a/src/base/addtorrentmanager.h
+++ b/src/base/addtorrentmanager.h
@@ -35,6 +35,7 @@
 #include <QObject>
 
 #include "base/applicationcomponent.h"
+#include "base/bittorrent/addtorrenterror.h"
 #include "base/bittorrent/addtorrentparams.h"
 #include "base/torrentfileguard.h"
 
@@ -66,7 +67,7 @@ public:
 
 signals:
     void torrentAdded(const QString &source, BitTorrent::Torrent *torrent);
-    void addTorrentFailed(const QString &source, const QString &reason);
+    void addTorrentFailed(const QString &source, const BitTorrent::AddTorrentError &reason);
 
 protected:
     bool addTorrentToSession(const QString &source, const BitTorrent::TorrentDescriptor &torrentDescr
@@ -79,7 +80,7 @@ protected:
 private:
     void onDownloadFinished(const Net::DownloadResult &result);
     void onSessionTorrentAdded(BitTorrent::Torrent *torrent);
-    void onSessionAddTorrentFailed(const BitTorrent::InfoHash &infoHash, const QString &reason);
+    void onSessionAddTorrentFailed(const BitTorrent::InfoHash &infoHash, const BitTorrent::AddTorrentError &reason);
     bool processTorrent(const QString &source, const BitTorrent::TorrentDescriptor &torrentDescr
             , const BitTorrent::AddTorrentParams &addTorrentParams);
 

--- a/src/base/bittorrent/addtorrenterror.h
+++ b/src/base/bittorrent/addtorrenterror.h
@@ -1,0 +1,49 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2025  Vladimir Golovnev <glassez@yandex.ru>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#pragma once
+
+#include <QMetaType>
+#include <QString>
+
+namespace BitTorrent
+{
+    struct AddTorrentError
+    {
+        enum Kind
+        {
+            DuplicateTorrent,
+            Other
+        };
+
+        Kind kind = Other;
+        QString message;
+    };
+}
+
+Q_DECLARE_METATYPE(BitTorrent::AddTorrentError)

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -34,6 +34,7 @@
 
 #include "base/pathfwd.h"
 #include "base/tagset.h"
+#include "addtorrenterror.h"
 #include "addtorrentparams.h"
 #include "categoryoptions.h"
 #include "sharelimitaction.h"
@@ -485,7 +486,7 @@ namespace BitTorrent
 
     signals:
         void startupProgressUpdated(int progress);
-        void addTorrentFailed(const InfoHash &infoHash, const QString &reason);
+        void addTorrentFailed(const InfoHash &infoHash, const AddTorrentError &reason);
         void allTorrentsFinished();
         void categoryAdded(const QString &categoryName);
         void categoryRemoved(const QString &categoryName);

--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -375,7 +375,7 @@ void AutoDownloader::handleTorrentAdded(const QString &source)
     }
 }
 
-void AutoDownloader::handleAddTorrentFailed(const QString &source)
+void AutoDownloader::handleAddTorrentFailed(const QString &source, [[maybe_unused]] const BitTorrent::AddTorrentError &error)
 {
     m_waitingJobs.remove(source);
     // TODO: Re-schedule job here.

--- a/src/base/rss/rss_autodownloader.h
+++ b/src/base/rss/rss_autodownloader.h
@@ -37,6 +37,7 @@
 #include <QSharedPointer>
 
 #include "base/applicationcomponent.h"
+#include "base/bittorrent/addtorrenterror.h"
 #include "base/exceptions.h"
 #include "base/settingvalue.h"
 #include "base/utils/thread.h"
@@ -111,7 +112,7 @@ namespace RSS
     private slots:
         void process();
         void handleTorrentAdded(const QString &source);
-        void handleAddTorrentFailed(const QString &url);
+        void handleAddTorrentFailed(const QString &url, const BitTorrent::AddTorrentError &error);
         void handleNewArticle(const Article *article);
         void handleFeedURLChanged(Feed *feed, const QString &oldURL);
 


### PR DESCRIPTION
Allows the observer to determine that the torrent was not added due to a duplicate torrent.
This is not supposed to have any effect on its own, but it is required for some other improvements.