### PR TITLE
RSS: Mark matched article as "read" if refers to duplicate torrent

### DIFF
--- a/src/base/rss/rss_autodownloader.cpp
+++ b/src/base/rss/rss_autodownloader.cpp
@@ -375,10 +375,24 @@ void AutoDownloader::handleTorrentAdded(const QString &source)
     }
 }
 
-void AutoDownloader::handleAddTorrentFailed(const QString &source, [[maybe_unused]] const BitTorrent::AddTorrentError &error)
+void AutoDownloader::handleAddTorrentFailed(const QString &source, const BitTorrent::AddTorrentError &error)
 {
-    m_waitingJobs.remove(source);
-    // TODO: Re-schedule job here.
+    const auto job = m_waitingJobs.take(source);
+    if (!job)
+        return;
+
+    if (error.kind == BitTorrent::AddTorrentError::DuplicateTorrent)
+    {
+        if (Feed *feed = Session::instance()->feedByURL(job->feedURL))
+        {
+            if (Article *article = feed->articleByGUID(job->articleData.value(Article::KeyId).toString()))
+                article->markAsRead();
+        }
+    }
+    else
+    {
+        // TODO: Re-schedule job here.
+    }
 }
 
 void AutoDownloader::handleNewArticle(const Article *article)


### PR DESCRIPTION
Partialy solves the problem described in #18436.