### PR TITLE
Revise wordings related to SOCKS4 proxy

### DIFF
--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -1689,7 +1689,7 @@ void OptionsDialog::adjustProxyOptions()
 
     if (currentProxyType == Net::ProxyType::None)
     {
-        m_ui->labelProxyTypeIncompatible->setVisible(false);
+        m_ui->labelProxyTypeUnavailable->setVisible(false);
 
         m_ui->lblProxyIP->setEnabled(false);
         m_ui->textProxyIP->setEnabled(false);
@@ -1714,7 +1714,7 @@ void OptionsDialog::adjustProxyOptions()
 
         if (currentProxyType == Net::ProxyType::SOCKS4)
         {
-            m_ui->labelProxyTypeIncompatible->setVisible(true);
+            m_ui->labelProxyTypeUnavailable->setVisible(true);
 
             m_ui->checkProxyHostnameLookup->setEnabled(false);
             m_ui->checkProxyRSS->setEnabled(false);
@@ -1723,7 +1723,7 @@ void OptionsDialog::adjustProxyOptions()
         else
         {
             // SOCKS5 or HTTP
-            m_ui->labelProxyTypeIncompatible->setVisible(false);
+            m_ui->labelProxyTypeUnavailable->setVisible(false);
 
             m_ui->checkProxyHostnameLookup->setEnabled(true);
             m_ui->checkProxyRSS->setEnabled(true);

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -2077,14 +2077,14 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                 </layout>
                </item>
                <item>
-                <widget class="QLabel" name="labelProxyTypeIncompatible">
+                <widget class="QLabel" name="labelProxyTypeUnavailable">
                  <property name="font">
                   <font>
                    <italic>true</italic>
                   </font>
                  </property>
                  <property name="text">
-                  <string>Some options are incompatible with the chosen proxy type!</string>
+                  <string>Some functions are unavailable with the chosen proxy type!</string>
                  </property>
                 </widget>
                </item>
@@ -2144,7 +2144,7 @@ readme[0-9].txt: filter 'readme1.txt', 'readme2.txt' but not 'readme10.txt'.</st
                   <item>
                    <widget class="QLabel" name="label_23">
                     <property name="text">
-                     <string>Info: The password is saved unencrypted</string>
+                     <string>Note: The password is saved unencrypted</string>
                     </property>
                    </widget>
                   </item>

--- a/src/webui/www/private/views/preferences.html
+++ b/src/webui/www/private/views/preferences.html
@@ -537,7 +537,7 @@
                 </tbody>
             </table>
             <div class="formRow">
-                <span>QBT_TR(Info: The password is saved unencrypted)QBT_TR[CONTEXT=OptionsDialog]</span>
+                <span>QBT_TR(Note: The password is saved unencrypted)QBT_TR[CONTEXT=OptionsDialog]</span>
             </div>
         </fieldset>
 


### PR DESCRIPTION
Most affected options are not really incompatible with SOCKS4 but it is due to Qt missing implementation. Therefore 'unavailable' is more suitable.

screenshot:
![screenshot](https://github.com/user-attachments/assets/af9e60a1-51af-4fff-8087-66327845d788)


