### PR TITLE
WebUI: Set status filter to 'All' if selected filter is no longer visible

### DIFF
--- a/src/webui/www/private/scripts/client.js
+++ b/src/webui/www/private/scripts/client.js
@@ -477,6 +477,8 @@ window.addEventListener("DOMContentLoaded", () => {
         updateFilter("checking", "QBT_TR(Checking (%1))QBT_TR[CONTEXT=StatusFilterWidget]");
         updateFilter("moving", "QBT_TR(Moving (%1))QBT_TR[CONTEXT=StatusFilterWidget]");
         updateFilter("errored", "QBT_TR(Errored (%1))QBT_TR[CONTEXT=StatusFilterWidget]");
+        if (useAutoHideZeroStatusFilters && document.getElementById(`${selectedStatus}_filter`).classList.contains("invisible"))
+            setStatusFilter("all");
     };
 
     const highlightSelectedStatus = () => {


### PR DESCRIPTION
Fixup for https://github.com/qbittorrent/qBittorrent/pull/21145

To reproduce:
1) Select status filter with 0 torrents
2) Enable 'Auto hide zero status filters' and save settings. Hidden filter is still selected:

![image](https://github.com/user-attachments/assets/9da5feaf-c029-4365-b4c2-6d531c97fb80)


