### PR TITLE
Add option to enable previous Add new torrent dialog behavior

### DIFF
--- a/src/base/preferences.cpp
+++ b/src/base/preferences.cpp
@@ -2067,6 +2067,19 @@ void Preferences::setAddNewTorrentDialogSavePathHistoryLength(const int value)
     setValue(u"AddNewTorrentDialog/SavePathHistoryLength"_s, clampedValue);
 }
 
+bool Preferences::isAddNewTorrentDialogAttached() const
+{
+    return value(u"AddNewTorrentDialog/Attached"_s, false);
+}
+
+void Preferences::setAddNewTorrentDialogAttached(const bool attached)
+{
+    if (attached == isAddNewTorrentDialogAttached())
+        return;
+
+    setValue(u"AddNewTorrentDialog/Attached"_s, attached);
+}
+
 void Preferences::apply()
 {
     if (SettingsStorage::instance()->save())

--- a/src/base/preferences.h
+++ b/src/base/preferences.h
@@ -435,6 +435,8 @@ public:
     void setAddNewTorrentDialogTopLevel(bool value);
     int addNewTorrentDialogSavePathHistoryLength() const;
     void setAddNewTorrentDialogSavePathHistoryLength(int value);
+    bool isAddNewTorrentDialogAttached() const;
+    void setAddNewTorrentDialogAttached(bool attached);
 
 public slots:
     void setStatusFilterState(bool checked);

--- a/src/gui/advancedsettings.cpp
+++ b/src/gui/advancedsettings.cpp
@@ -98,6 +98,7 @@ namespace
         ENABLE_SPEED_WIDGET,
 #ifndef Q_OS_MACOS
         ENABLE_ICONS_IN_MENUS,
+        USE_ATTACHED_ADD_NEW_TORRENT_DIALOG,
 #endif
         // embedded tracker
         TRACKER_STATUS,
@@ -332,6 +333,7 @@ void AdvancedSettings::saveAdvancedSettings() const
     pref->setSpeedWidgetEnabled(m_checkBoxSpeedWidgetEnabled.isChecked());
 #ifndef Q_OS_MACOS
     pref->setIconsInMenusEnabled(m_checkBoxIconsInMenusEnabled.isChecked());
+    pref->setAddNewTorrentDialogAttached(m_checkBoxAttachedAddNewTorrentDialog.isChecked());
 #endif
 
     // Tracker
@@ -866,6 +868,9 @@ void AdvancedSettings::loadAdvancedSettings()
     // Enable icons in menus
     m_checkBoxIconsInMenusEnabled.setChecked(pref->iconsInMenusEnabled());
     addRow(ENABLE_ICONS_IN_MENUS, tr("Enable icons in menus"), &m_checkBoxIconsInMenusEnabled);
+
+    m_checkBoxAttachedAddNewTorrentDialog.setChecked(pref->isAddNewTorrentDialogAttached());
+    addRow(USE_ATTACHED_ADD_NEW_TORRENT_DIALOG, tr("Attach \"Add new torrent\" dialog to main window"), &m_checkBoxAttachedAddNewTorrentDialog);
 #endif
     // Tracker State
     m_checkBoxTrackerStatus.setChecked(session->isTrackerEnabled());

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -108,6 +108,7 @@ private:
 
 #ifndef Q_OS_MACOS
     QCheckBox m_checkBoxIconsInMenusEnabled;
+    QCheckBox m_checkBoxAttachedAddNewTorrentDialog;
 #endif
 
 #if defined(Q_OS_MACOS) || defined(Q_OS_WIN)

--- a/src/gui/guiaddtorrentmanager.cpp
+++ b/src/gui/guiaddtorrentmanager.cpp
@@ -225,12 +225,19 @@ bool GUIAddTorrentManager::processTorrent(const QString &source
     if (!hasMetadata)
         btSession()->downloadMetadata(torrentDescr);
 
+#ifdef Q_OS_MACOS
+    const bool attached = false;
+#else
+    const bool attached = Preferences::instance()->isAddNewTorrentDialogAttached();
+#endif
+
     // By not setting a parent to the "AddNewTorrentDialog", all those dialogs
     // will be displayed on top and will not overlap with the main window.
-    auto *dlg = new AddNewTorrentDialog(torrentDescr, params, nullptr);
+    auto *dlg = new AddNewTorrentDialog(torrentDescr, params, (attached ? app()->mainWindow() : nullptr));
     // Qt::Window is required to avoid showing only two dialog on top (see #12852).
     // Also improves the general convenience of adding multiple torrents.
-    dlg->setWindowFlags(Qt::Window);
+    if (!attached)
+        dlg->setWindowFlags(Qt::Window);
 
     dlg->setAttribute(Qt::WA_DeleteOnClose);
     m_dialogs[infoHash] = dlg;


### PR DESCRIPTION
Based on original PR #19874.

Some people are still unhappy with "standalone window mode" of "Add new torrent dialog" so just provide them with an option to use old "modal dialog mode" in all the current qBittorrent branches.
