### PR TITLE
GHA CI: Use Qt 6.9.0 on Windows and macOS

### DIFF
--- a/.github/workflows/ci_macos.yaml
+++ b/.github/workflows/ci_macos.yaml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         libt_version: ["2.0.11", "1.2.20"]
         qbt_gui: ["GUI=ON", "GUI=OFF"]
-        qt_version: ["6.7.0"]
+        qt_version: ["6.9.0"]
 
     env:
       boost_path: "${{ github.workspace }}/../boost"

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -106,7 +106,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: "6.8.0"
+          version: "6.9.0"
           arch: win64_msvc2022_64
           archives: qtbase qtsvg qttools
           cache: true


### PR DESCRIPTION
* Bumped Windows/macOS Qt version to `6.9.0`
[Qt 6.9.0 Released](https://www.qt.io/blog/qt-6.9-released) / [Release Notes](https://code.qt.io/cgit/qt/qtreleasenotes.git/about/qt/6.9.0/release-note.md)

Qt 6.8.3+ has a fix for macOS related issue, ref.: #22303 / [QTBUG-134316](https://bugreports.qt.io/browse/QTBUG-134316).