### PR TITLE
Add SOCKS4/SOCKS4a proxy support to search engine

### DIFF
--- a/src/searchengine/nova3/helpers.py
+++ b/src/searchengine/nova3/helpers.py
@@ -1,4 +1,4 @@
-#VERSION: 1.51
+#VERSION: 1.52
 
 # Author:
 #  Christophe DUMEZ (chris@qbittorrent.org)
@@ -32,19 +32,19 @@ import gzip
 import html
 import io
 import os
-import re
 import socket
 import socks
 import ssl
 import sys
 import tempfile
 import urllib.error
+import urllib.parse
 import urllib.request
 from collections.abc import Mapping
 from typing import Any, Optional
 
 
-def getBrowserUserAgent() -> str:
+def _getBrowserUserAgent() -> str:
     """ Disguise as browser to circumvent website blocking """
 
     # Firefox release calendar
@@ -60,17 +60,33 @@ def getBrowserUserAgent() -> str:
     return f"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:{nowVersion}.0) Gecko/20100101 Firefox/{nowVersion}.0"
 
 
-headers: dict[str, Any] = {'User-Agent': getBrowserUserAgent()}
+_headers: dict[str, Any] = {'User-Agent': _getBrowserUserAgent()}
 
-# SOCKS5 Proxy support
-if "sock_proxy" in os.environ and len(os.environ["sock_proxy"].strip()) > 0:
-    proxy_str = os.environ["sock_proxy"].strip()
-    m = re.match(r"^(?:(?P<username>[^:]+):(?P<password>[^@]+)@)?(?P<host>[^:]+):(?P<port>\w+)$",
-                 proxy_str)
-    if m is not None:
-        socks.setdefaultproxy(socks.PROXY_TYPE_SOCKS5, m.group('host'),
-                              int(m.group('port')), True, m.group('username'), m.group('password'))
-        socket.socket = socks.socksocket  # type: ignore[misc]
+
+def injectSOCKSProxySocket() -> None:
+    socksURL = os.environ.get("qbt_socks_proxy")
+    if socksURL is not None:
+        parts = urllib.parse.urlsplit(socksURL)
+        resolveHostname = (parts.scheme == "socks4a") or (parts.scheme == "socks5h")
+        if (parts.scheme == "socks4") or (parts.scheme == "socks4a"):
+            socks.setdefaultproxy(socks.PROXY_TYPE_SOCKS4, parts.hostname, parts.port, resolveHostname)
+            socket.socket = socks.socksocket  # type: ignore[misc]
+        elif (parts.scheme == "socks5") or (parts.scheme == "socks5h"):
+            socks.setdefaultproxy(socks.PROXY_TYPE_SOCKS5, parts.hostname, parts.port, resolveHostname, parts.username, parts.password)
+            socket.socket = socks.socksocket  # type: ignore[misc]
+    else:
+        # the following code provide backward compatibility for older qbt versions
+        # TODO: scheduled be removed with qbt >= 5.3
+        legacySocksURL = os.environ.get("sock_proxy")
+        if legacySocksURL is not None:
+            legacySocksURL = f"socks5h://{legacySocksURL.strip()}"
+            parts = urllib.parse.urlsplit(legacySocksURL)
+            socks.setdefaultproxy(socks.PROXY_TYPE_SOCKS5, parts.hostname, parts.port, True, parts.username, parts.password)
+            socket.socket = socks.socksocket  # type: ignore[misc]
+
+
+# monkey patching, run it now
+injectSOCKSProxySocket()
 
 
 # This is only provided for backward compatibility, new code should not use it
@@ -80,7 +96,7 @@ htmlentitydecode = html.unescape
 def retrieve_url(url: str, custom_headers: Mapping[str, Any] = {}, request_data: Optional[Any] = None, ssl_context: Optional[ssl.SSLContext] = None, unescape_html_entities: bool = True) -> str:
     """ Return the content of the url page as a string """
 
-    request = urllib.request.Request(url, request_data, {**headers, **custom_headers})
+    request = urllib.request.Request(url, request_data, {**_headers, **custom_headers})
     try:
         response = urllib.request.urlopen(request, context=ssl_context)
     except urllib.error.URLError as errno:
@@ -112,7 +128,7 @@ def download_file(url: str, referer: Optional[str] = None, ssl_context: Optional
     """ Download file at url and write it to a file, return the path to the file and the url """
 
     # Download url
-    request = urllib.request.Request(url, headers=headers)
+    request = urllib.request.Request(url, headers=_headers)
     if referer is not None:
         request.add_header('referer', referer)
     response = urllib.request.urlopen(request, context=ssl_context)


### PR DESCRIPTION
Pass 'Perform hostname lookup via proxy' setting along the way.
Also add underline to variables and functions that are private to the python module.

ps. based on user reports, the search engine SOCKS lib seems to be broken. I'll look into it after this PR.